### PR TITLE
Make UndoRedo use Callables

### DIFF
--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -46,9 +46,6 @@ public:
 	};
 
 	typedef void (*CommitNotifyCallback)(void *p_ud, const String &p_name);
-	Variant _add_do_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-	Variant _add_undo_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-
 	typedef void (*MethodNotifyCallback)(void *p_ud, Object *p_base, const StringName &p_name, VARIANT_ARG_DECLARE);
 	typedef void (*PropertyNotifyCallback)(void *p_ud, Object *p_base, const StringName &p_property, const Variant &p_value);
 
@@ -64,7 +61,7 @@ private:
 		Ref<Reference> ref;
 		ObjectID object;
 		StringName name;
-		Variant args[VARIANT_ARG_MAX];
+		Variant arg;
 	};
 
 	struct Action {
@@ -101,8 +98,11 @@ protected:
 public:
 	void create_action(const String &p_name = "", MergeMode p_mode = MERGE_DISABLE);
 
-	void add_do_method(Object *p_object, const StringName &p_method, VARIANT_ARG_LIST);
-	void add_undo_method(Object *p_object, const StringName &p_method, VARIANT_ARG_LIST);
+	void add_do_method_compat(Object *p_object, const StringName &p_method, VARIANT_ARG_LIST);
+	void add_undo_method_compat(Object *p_object, const StringName &p_method, VARIANT_ARG_LIST);
+
+	void add_do_method(Object *p_object, const Callable &p_callable);
+	void add_undo_method(Object *p_object, const Callable &p_callable);
 	void add_do_property(Object *p_object, const StringName &p_property, const Variant &p_value);
 	void add_undo_property(Object *p_object, const StringName &p_property, const Variant &p_value);
 	void add_do_reference(Object *p_object);

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -51,6 +51,8 @@ public:
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const;
 	virtual const Callable *get_base_comparator() const;
 
+	Vector<Variant> get_binds() { return binds; }
+
 	CallableCustomBind(const Callable &p_callable, const Vector<Variant> &p_binds);
 	virtual ~CallableCustomBind();
 };

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -759,8 +759,8 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			undo_redo->create_action(TTR("Add Bezier Point"));
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", track, time, new_point);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", track, time);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", track, time, new_point);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", track, time);
 			undo_redo->commit_action();
 
 			//then attempt to move
@@ -821,10 +821,10 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (moving_handle != 0 && mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
 		undo_redo->create_action(TTR("Move Bezier Points"));
-		undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_in_handle", track, moving_handle_key, moving_handle_left);
-		undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_out_handle", track, moving_handle_key, moving_handle_right);
-		undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_in_handle", track, moving_handle_key, animation->bezier_track_get_key_in_handle(track, moving_handle_key));
-		undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_out_handle", track, moving_handle_key, animation->bezier_track_get_key_out_handle(track, moving_handle_key));
+		undo_redo->add_do_method_compat(animation.ptr(), "bezier_track_set_key_in_handle", track, moving_handle_key, moving_handle_left);
+		undo_redo->add_do_method_compat(animation.ptr(), "bezier_track_set_key_out_handle", track, moving_handle_key, moving_handle_right);
+		undo_redo->add_undo_method_compat(animation.ptr(), "bezier_track_set_key_in_handle", track, moving_handle_key, animation->bezier_track_get_key_in_handle(track, moving_handle_key));
+		undo_redo->add_undo_method_compat(animation.ptr(), "bezier_track_set_key_out_handle", track, moving_handle_key, animation->bezier_track_get_key_out_handle(track, moving_handle_key));
 		undo_redo->commit_action();
 
 		moving_handle = 0;
@@ -840,7 +840,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			List<AnimMoveRestore> to_restore;
 			// 1-remove the keys
 			for (Set<int>::Element *E = selection.back(); E; E = E->prev()) {
-				undo_redo->add_do_method(animation.ptr(), "track_remove_key", track, E->get());
+				undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key", track, E->get());
 			}
 			// 2- remove overlapped keys
 			for (Set<int>::Element *E = selection.back(); E; E = E->prev()) {
@@ -855,7 +855,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 					continue; //already in selection, don't save
 				}
 
-				undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_position", track, newtime);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key_at_position", track, newtime);
 				AnimMoveRestore amr;
 
 				amr.key = animation->track_get_key_value(track, idx);
@@ -876,7 +876,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				float h = key[0];
 				h += moving_selection_offset.y;
 				key[0] = h;
-				undo_redo->add_do_method(animation.ptr(), "track_insert_key", track, newpos, key, 1);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", track, newpos, key, 1);
 			}
 
 			// 4-(undo) remove inserted keys
@@ -886,23 +886,23 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				if (newpos<0)
 					continue; //no remove what no inserted
 				*/
-				undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", track, newpos);
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", track, newpos);
 			}
 
 			// 5-(undo) reinsert keys
 			for (Set<int>::Element *E = selection.back(); E; E = E->prev()) {
 				float oldpos = animation->track_get_key_time(track, E->get());
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, oldpos, animation->track_get_key_value(track, E->get()), 1);
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", track, oldpos, animation->track_get_key_value(track, E->get()), 1);
 			}
 
 			// 6-(undo) reinsert overlapped keys
 			for (List<AnimMoveRestore>::Element *E = to_restore.front(); E; E = E->next()) {
 				AnimMoveRestore &amr = E->get();
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, 1);
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, 1);
 			}
 
-			undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
-			undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
+			undo_redo->add_do_method_compat(this, "_clear_selection_for_anim", animation);
+			undo_redo->add_undo_method_compat(this, "_clear_selection_for_anim", animation);
 
 			// 7-reselect
 
@@ -910,8 +910,8 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				float oldpos = animation->track_get_key_time(track, E->get());
 				float newpos = editor->snap_time(oldpos + moving_selection_offset.x);
 
-				undo_redo->add_do_method(this, "_select_at_anim", animation, track, newpos);
-				undo_redo->add_undo_method(this, "_select_at_anim", animation, track, oldpos);
+				undo_redo->add_do_method_compat(this, "_select_at_anim", animation, track, newpos);
+				undo_redo->add_undo_method_compat(this, "_select_at_anim", animation, track, oldpos);
 			}
 
 			undo_redo->commit_action();
@@ -1035,8 +1035,8 @@ void AnimationBezierTrackEdit::_menu_selected(int p_index) {
 			}
 
 			undo_redo->create_action(TTR("Add Bezier Point"));
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", track, time, new_point);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", track, time);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", track, time, new_point);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", track, time);
 			undo_redo->commit_action();
 
 		} break;
@@ -1071,8 +1071,8 @@ void AnimationBezierTrackEdit::duplicate_selection() {
 		float dst_time = t + (timeline->get_play_position() - top_time);
 		int existing_idx = animation->track_find_key(track, dst_time, true);
 
-		undo_redo->add_do_method(animation.ptr(), "track_insert_key", track, dst_time, animation->track_get_key_value(track, E->get()), animation->track_get_key_transition(track, E->get()));
-		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", track, dst_time);
+		undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", track, dst_time, animation->track_get_key_value(track, E->get()), animation->track_get_key_transition(track, E->get()));
+		undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", track, dst_time);
 
 		Pair<int, float> p;
 		p.first = track;
@@ -1080,7 +1080,7 @@ void AnimationBezierTrackEdit::duplicate_selection() {
 		new_selection_values.push_back(p);
 
 		if (existing_idx != -1) {
-			undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, dst_time, animation->track_get_key_value(track, existing_idx), animation->track_get_key_transition(track, existing_idx));
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", track, dst_time, animation->track_get_key_value(track, existing_idx), animation->track_get_key_transition(track, existing_idx));
 		}
 	}
 
@@ -1110,11 +1110,11 @@ void AnimationBezierTrackEdit::delete_selection() {
 		undo_redo->create_action(TTR("Anim Delete Keys"));
 
 		for (Set<int>::Element *E = selection.back(); E; E = E->prev()) {
-			undo_redo->add_do_method(animation.ptr(), "track_remove_key", track, E->get());
-			undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, animation->track_get_key_time(track, E->get()), animation->track_get_key_value(track, E->get()), 1);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key", track, E->get());
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", track, animation->track_get_key_time(track, E->get()), animation->track_get_key_value(track, E->get()), 1);
 		}
-		undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
-		undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
+		undo_redo->add_do_method_compat(this, "_clear_selection_for_anim", animation);
+		undo_redo->add_undo_method_compat(this, "_clear_selection_for_anim", animation);
 		undo_redo->commit_action();
 		//selection.clear();
 	}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -131,17 +131,17 @@ public:
 			Variant val = animation->track_get_key_value(track, key);
 			float trans = animation->track_get_key_transition(track, key);
 
-			undo_redo->add_do_method(animation.ptr(), "track_remove_key", track, key);
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", track, new_time, val, trans);
-			undo_redo->add_do_method(this, "_key_ofs_changed", animation, key_ofs, new_time);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", track, new_time);
-			undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, key_ofs, val, trans);
-			undo_redo->add_undo_method(this, "_key_ofs_changed", animation, new_time, key_ofs);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key", track, key);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", track, new_time, val, trans);
+			undo_redo->add_do_method_compat(this, "_key_ofs_changed", animation, key_ofs, new_time);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", track, new_time);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", track, key_ofs, val, trans);
+			undo_redo->add_undo_method_compat(this, "_key_ofs_changed", animation, new_time, key_ofs);
 
 			if (existing != -1) {
 				Variant v = animation->track_get_key_value(track, existing);
 				trans = animation->track_get_key_transition(track, existing);
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, new_time, v, trans);
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", track, new_time, v, trans);
 			}
 			undo_redo->commit_action();
 
@@ -154,10 +154,10 @@ public:
 			float prev_val = animation->track_get_key_transition(track, key);
 			setting = true;
 			undo_redo->create_action(TTR("Anim Change Transition"), UndoRedo::MERGE_ENDS);
-			undo_redo->add_do_method(animation.ptr(), "track_set_key_transition", track, key, val);
-			undo_redo->add_undo_method(animation.ptr(), "track_set_key_transition", track, key, prev_val);
-			undo_redo->add_do_method(this, "_update_obj", animation);
-			undo_redo->add_undo_method(this, "_update_obj", animation);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_set_key_transition", track, key, val);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_set_key_transition", track, key, prev_val);
+			undo_redo->add_do_method_compat(this, "_update_obj", animation);
+			undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 			undo_redo->commit_action();
 
 			setting = false;
@@ -171,10 +171,10 @@ public:
 				d_new[p_name] = p_value;
 				setting = true;
 				undo_redo->create_action(TTR("Anim Change Transform"));
-				undo_redo->add_do_method(animation.ptr(), "track_set_key_value", track, key, d_new);
-				undo_redo->add_undo_method(animation.ptr(), "track_set_key_value", track, key, d_old);
-				undo_redo->add_do_method(this, "_update_obj", animation);
-				undo_redo->add_undo_method(this, "_update_obj", animation);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_set_key_value", track, key, d_new);
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_set_key_value", track, key, d_old);
+				undo_redo->add_do_method_compat(this, "_update_obj", animation);
+				undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 				undo_redo->commit_action();
 
 				setting = false;
@@ -191,10 +191,10 @@ public:
 					setting = true;
 					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 					Variant prev = animation->track_get_key_value(track, key);
-					undo_redo->add_do_method(animation.ptr(), "track_set_key_value", track, key, value);
-					undo_redo->add_undo_method(animation.ptr(), "track_set_key_value", track, key, prev);
-					undo_redo->add_do_method(this, "_update_obj", animation);
-					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->add_do_method_compat(animation.ptr(), "track_set_key_value", track, key, value);
+					undo_redo->add_undo_method_compat(animation.ptr(), "track_set_key_value", track, key, prev);
+					undo_redo->add_do_method_compat(this, "_update_obj", animation);
+					undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 					undo_redo->commit_action();
 
 					setting = false;
@@ -255,10 +255,10 @@ public:
 				}
 
 				setting = true;
-				undo_redo->add_do_method(animation.ptr(), "track_set_key_value", track, key, d_new);
-				undo_redo->add_undo_method(animation.ptr(), "track_set_key_value", track, key, d_old);
-				undo_redo->add_do_method(this, "_update_obj", animation);
-				undo_redo->add_undo_method(this, "_update_obj", animation);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_set_key_value", track, key, d_new);
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_set_key_value", track, key, d_old);
+				undo_redo->add_do_method_compat(this, "_update_obj", animation);
+				undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 				undo_redo->commit_action();
 
 				setting = false;
@@ -274,10 +274,10 @@ public:
 					setting = true;
 					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 					float prev = animation->bezier_track_get_key_value(track, key);
-					undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_value", track, key, value);
-					undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_value", track, key, prev);
-					undo_redo->add_do_method(this, "_update_obj", animation);
-					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->add_do_method_compat(animation.ptr(), "bezier_track_set_key_value", track, key, value);
+					undo_redo->add_undo_method_compat(animation.ptr(), "bezier_track_set_key_value", track, key, prev);
+					undo_redo->add_do_method_compat(this, "_update_obj", animation);
+					undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 					undo_redo->commit_action();
 
 					setting = false;
@@ -290,10 +290,10 @@ public:
 					setting = true;
 					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 					Vector2 prev = animation->bezier_track_get_key_in_handle(track, key);
-					undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_in_handle", track, key, value);
-					undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_in_handle", track, key, prev);
-					undo_redo->add_do_method(this, "_update_obj", animation);
-					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->add_do_method_compat(animation.ptr(), "bezier_track_set_key_in_handle", track, key, value);
+					undo_redo->add_undo_method_compat(animation.ptr(), "bezier_track_set_key_in_handle", track, key, prev);
+					undo_redo->add_do_method_compat(this, "_update_obj", animation);
+					undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 					undo_redo->commit_action();
 
 					setting = false;
@@ -306,10 +306,10 @@ public:
 					setting = true;
 					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 					Vector2 prev = animation->bezier_track_get_key_out_handle(track, key);
-					undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_out_handle", track, key, value);
-					undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_out_handle", track, key, prev);
-					undo_redo->add_do_method(this, "_update_obj", animation);
-					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->add_do_method_compat(animation.ptr(), "bezier_track_set_key_out_handle", track, key, value);
+					undo_redo->add_undo_method_compat(animation.ptr(), "bezier_track_set_key_out_handle", track, key, prev);
+					undo_redo->add_do_method_compat(this, "_update_obj", animation);
+					undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 					undo_redo->commit_action();
 
 					setting = false;
@@ -323,10 +323,10 @@ public:
 					setting = true;
 					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 					RES prev = animation->audio_track_get_key_stream(track, key);
-					undo_redo->add_do_method(animation.ptr(), "audio_track_set_key_stream", track, key, stream);
-					undo_redo->add_undo_method(animation.ptr(), "audio_track_set_key_stream", track, key, prev);
-					undo_redo->add_do_method(this, "_update_obj", animation);
-					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->add_do_method_compat(animation.ptr(), "audio_track_set_key_stream", track, key, stream);
+					undo_redo->add_undo_method_compat(animation.ptr(), "audio_track_set_key_stream", track, key, prev);
+					undo_redo->add_do_method_compat(this, "_update_obj", animation);
+					undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 					undo_redo->commit_action();
 
 					setting = false;
@@ -339,10 +339,10 @@ public:
 					setting = true;
 					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 					float prev = animation->audio_track_get_key_start_offset(track, key);
-					undo_redo->add_do_method(animation.ptr(), "audio_track_set_key_start_offset", track, key, value);
-					undo_redo->add_undo_method(animation.ptr(), "audio_track_set_key_start_offset", track, key, prev);
-					undo_redo->add_do_method(this, "_update_obj", animation);
-					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->add_do_method_compat(animation.ptr(), "audio_track_set_key_start_offset", track, key, value);
+					undo_redo->add_undo_method_compat(animation.ptr(), "audio_track_set_key_start_offset", track, key, prev);
+					undo_redo->add_do_method_compat(this, "_update_obj", animation);
+					undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 					undo_redo->commit_action();
 
 					setting = false;
@@ -355,10 +355,10 @@ public:
 					setting = true;
 					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 					float prev = animation->audio_track_get_key_end_offset(track, key);
-					undo_redo->add_do_method(animation.ptr(), "audio_track_set_key_end_offset", track, key, value);
-					undo_redo->add_undo_method(animation.ptr(), "audio_track_set_key_end_offset", track, key, prev);
-					undo_redo->add_do_method(this, "_update_obj", animation);
-					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->add_do_method_compat(animation.ptr(), "audio_track_set_key_end_offset", track, key, value);
+					undo_redo->add_undo_method_compat(animation.ptr(), "audio_track_set_key_end_offset", track, key, prev);
+					undo_redo->add_do_method_compat(this, "_update_obj", animation);
+					undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 					undo_redo->commit_action();
 
 					setting = false;
@@ -372,10 +372,10 @@ public:
 					setting = true;
 					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 					StringName prev = animation->animation_track_get_key_animation(track, key);
-					undo_redo->add_do_method(animation.ptr(), "animation_track_set_key_animation", track, key, anim_name);
-					undo_redo->add_undo_method(animation.ptr(), "animation_track_set_key_animation", track, key, prev);
-					undo_redo->add_do_method(this, "_update_obj", animation);
-					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->add_do_method_compat(animation.ptr(), "animation_track_set_key_animation", track, key, anim_name);
+					undo_redo->add_undo_method_compat(animation.ptr(), "animation_track_set_key_animation", track, key, prev);
+					undo_redo->add_do_method_compat(this, "_update_obj", animation);
+					undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 					undo_redo->commit_action();
 
 					setting = false;
@@ -755,17 +755,17 @@ public:
 					Variant val = animation->track_get_key_value(track, key);
 					float trans = animation->track_get_key_transition(track, key);
 
-					undo_redo->add_do_method(animation.ptr(), "track_remove_key", track, key);
-					undo_redo->add_do_method(animation.ptr(), "track_insert_key", track, new_time, val, trans);
-					undo_redo->add_do_method(this, "_key_ofs_changed", animation, key_ofs, new_time);
-					undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", track, new_time);
-					undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, key_ofs, val, trans);
-					undo_redo->add_undo_method(this, "_key_ofs_changed", animation, new_time, key_ofs);
+					undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key", track, key);
+					undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", track, new_time, val, trans);
+					undo_redo->add_do_method_compat(this, "_key_ofs_changed", animation, key_ofs, new_time);
+					undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", track, new_time);
+					undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", track, key_ofs, val, trans);
+					undo_redo->add_undo_method_compat(this, "_key_ofs_changed", animation, new_time, key_ofs);
 
 					if (existing != -1) {
 						Variant v = animation->track_get_key_value(track, existing);
 						trans = animation->track_get_key_transition(track, existing);
-						undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, new_time, v, trans);
+						undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", track, new_time, v, trans);
 					}
 				} else if (name == "easing") {
 					float val = p_value;
@@ -775,8 +775,8 @@ public:
 						setting = true;
 						undo_redo->create_action(TTR("Anim Multi Change Transition"), UndoRedo::MERGE_ENDS);
 					}
-					undo_redo->add_do_method(animation.ptr(), "track_set_key_transition", track, key, val);
-					undo_redo->add_undo_method(animation.ptr(), "track_set_key_transition", track, key, prev_val);
+					undo_redo->add_do_method_compat(animation.ptr(), "track_set_key_transition", track, key, val);
+					undo_redo->add_undo_method_compat(animation.ptr(), "track_set_key_transition", track, key, prev_val);
 					update_obj = true;
 				}
 
@@ -790,8 +790,8 @@ public:
 							setting = true;
 							undo_redo->create_action(TTR("Anim Multi Change Transform"));
 						}
-						undo_redo->add_do_method(animation.ptr(), "track_set_key_value", track, key, d_new);
-						undo_redo->add_undo_method(animation.ptr(), "track_set_key_value", track, key, d_old);
+						undo_redo->add_do_method_compat(animation.ptr(), "track_set_key_value", track, key, d_new);
+						undo_redo->add_undo_method_compat(animation.ptr(), "track_set_key_value", track, key, d_old);
 						update_obj = true;
 					} break;
 					case Animation::TYPE_VALUE: {
@@ -807,8 +807,8 @@ public:
 								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 							}
 							Variant prev = animation->track_get_key_value(track, key);
-							undo_redo->add_do_method(animation.ptr(), "track_set_key_value", track, key, value);
-							undo_redo->add_undo_method(animation.ptr(), "track_set_key_value", track, key, prev);
+							undo_redo->add_do_method_compat(animation.ptr(), "track_set_key_value", track, key, value);
+							undo_redo->add_undo_method_compat(animation.ptr(), "track_set_key_value", track, key, prev);
 							update_obj = true;
 						}
 					} break;
@@ -870,8 +870,8 @@ public:
 							setting = true;
 						}
 
-						undo_redo->add_do_method(animation.ptr(), "track_set_key_value", track, key, d_new);
-						undo_redo->add_undo_method(animation.ptr(), "track_set_key_value", track, key, d_old);
+						undo_redo->add_do_method_compat(animation.ptr(), "track_set_key_value", track, key, d_new);
+						undo_redo->add_undo_method_compat(animation.ptr(), "track_set_key_value", track, key, d_old);
 						update_obj = true;
 					} break;
 					case Animation::TYPE_BEZIER: {
@@ -883,8 +883,8 @@ public:
 								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 							}
 							float prev = animation->bezier_track_get_key_value(track, key);
-							undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_value", track, key, value);
-							undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_value", track, key, prev);
+							undo_redo->add_do_method_compat(animation.ptr(), "bezier_track_set_key_value", track, key, value);
+							undo_redo->add_undo_method_compat(animation.ptr(), "bezier_track_set_key_value", track, key, prev);
 							update_obj = true;
 						} else if (name == "in_handle") {
 							const Variant &value = p_value;
@@ -894,8 +894,8 @@ public:
 								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 							}
 							Vector2 prev = animation->bezier_track_get_key_in_handle(track, key);
-							undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_in_handle", track, key, value);
-							undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_in_handle", track, key, prev);
+							undo_redo->add_do_method_compat(animation.ptr(), "bezier_track_set_key_in_handle", track, key, value);
+							undo_redo->add_undo_method_compat(animation.ptr(), "bezier_track_set_key_in_handle", track, key, prev);
 							update_obj = true;
 						} else if (name == "out_handle") {
 							const Variant &value = p_value;
@@ -905,8 +905,8 @@ public:
 								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 							}
 							Vector2 prev = animation->bezier_track_get_key_out_handle(track, key);
-							undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_out_handle", track, key, value);
-							undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_out_handle", track, key, prev);
+							undo_redo->add_do_method_compat(animation.ptr(), "bezier_track_set_key_out_handle", track, key, value);
+							undo_redo->add_undo_method_compat(animation.ptr(), "bezier_track_set_key_out_handle", track, key, prev);
 							update_obj = true;
 						}
 					} break;
@@ -919,8 +919,8 @@ public:
 								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 							}
 							RES prev = animation->audio_track_get_key_stream(track, key);
-							undo_redo->add_do_method(animation.ptr(), "audio_track_set_key_stream", track, key, stream);
-							undo_redo->add_undo_method(animation.ptr(), "audio_track_set_key_stream", track, key, prev);
+							undo_redo->add_do_method_compat(animation.ptr(), "audio_track_set_key_stream", track, key, stream);
+							undo_redo->add_undo_method_compat(animation.ptr(), "audio_track_set_key_stream", track, key, prev);
 							update_obj = true;
 						} else if (name == "start_offset") {
 							float value = p_value;
@@ -930,8 +930,8 @@ public:
 								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 							}
 							float prev = animation->audio_track_get_key_start_offset(track, key);
-							undo_redo->add_do_method(animation.ptr(), "audio_track_set_key_start_offset", track, key, value);
-							undo_redo->add_undo_method(animation.ptr(), "audio_track_set_key_start_offset", track, key, prev);
+							undo_redo->add_do_method_compat(animation.ptr(), "audio_track_set_key_start_offset", track, key, value);
+							undo_redo->add_undo_method_compat(animation.ptr(), "audio_track_set_key_start_offset", track, key, prev);
 							update_obj = true;
 						} else if (name == "end_offset") {
 							float value = p_value;
@@ -941,8 +941,8 @@ public:
 								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 							}
 							float prev = animation->audio_track_get_key_end_offset(track, key);
-							undo_redo->add_do_method(animation.ptr(), "audio_track_set_key_end_offset", track, key, value);
-							undo_redo->add_undo_method(animation.ptr(), "audio_track_set_key_end_offset", track, key, prev);
+							undo_redo->add_do_method_compat(animation.ptr(), "audio_track_set_key_end_offset", track, key, value);
+							undo_redo->add_undo_method_compat(animation.ptr(), "audio_track_set_key_end_offset", track, key, prev);
 							update_obj = true;
 						}
 					} break;
@@ -955,8 +955,8 @@ public:
 								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 							}
 							StringName prev = animation->animation_track_get_key_animation(track, key);
-							undo_redo->add_do_method(animation.ptr(), "animation_track_set_key_animation", track, key, anim_name);
-							undo_redo->add_undo_method(animation.ptr(), "animation_track_set_key_animation", track, key, prev);
+							undo_redo->add_do_method_compat(animation.ptr(), "animation_track_set_key_animation", track, key, anim_name);
+							undo_redo->add_undo_method_compat(animation.ptr(), "animation_track_set_key_animation", track, key, prev);
 							update_obj = true;
 						}
 					} break;
@@ -966,8 +966,8 @@ public:
 
 		if (setting) {
 			if (update_obj) {
-				undo_redo->add_do_method(this, "_update_obj", animation);
-				undo_redo->add_undo_method(this, "_update_obj", animation);
+				undo_redo->add_do_method_compat(this, "_update_obj", animation);
+				undo_redo->add_undo_method_compat(this, "_update_obj", animation);
 			}
 
 			undo_redo->commit_action();
@@ -1317,8 +1317,8 @@ void AnimationTimelineEdit::_anim_length_changed(double p_new_len) {
 
 	editing = true;
 	undo_redo->create_action(TTR("Change Animation Length"));
-	undo_redo->add_do_method(animation.ptr(), "set_length", p_new_len);
-	undo_redo->add_undo_method(animation.ptr(), "set_length", animation->get_length());
+	undo_redo->add_do_method_compat(animation.ptr(), "set_length", p_new_len);
+	undo_redo->add_undo_method_compat(animation.ptr(), "set_length", animation->get_length());
 	undo_redo->commit_action();
 	editing = false;
 	update();
@@ -1328,8 +1328,8 @@ void AnimationTimelineEdit::_anim_length_changed(double p_new_len) {
 
 void AnimationTimelineEdit::_anim_loop_pressed() {
 	undo_redo->create_action(TTR("Change Animation Loop"));
-	undo_redo->add_do_method(animation.ptr(), "set_loop", loop->is_pressed());
-	undo_redo->add_undo_method(animation.ptr(), "set_loop", animation->has_loop());
+	undo_redo->add_do_method_compat(animation.ptr(), "set_loop", loop->is_pressed());
+	undo_redo->add_undo_method_compat(animation.ptr(), "set_loop", animation->has_loop());
 	undo_redo->commit_action();
 }
 
@@ -2350,8 +2350,8 @@ void AnimationTrackEdit::_zoom_changed() {
 
 void AnimationTrackEdit::_path_entered(const String &p_text) {
 	undo_redo->create_action(TTR("Change Track Path"));
-	undo_redo->add_do_method(animation.ptr(), "track_set_path", track, p_text);
-	undo_redo->add_undo_method(animation.ptr(), "track_set_path", track, animation->track_get_path(track));
+	undo_redo->add_do_method_compat(animation.ptr(), "track_set_path", track, p_text);
+	undo_redo->add_undo_method_compat(animation.ptr(), "track_set_path", track, animation->track_get_path(track));
 	undo_redo->commit_action();
 	path_popup->hide();
 }
@@ -2545,8 +2545,8 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 
 		if (check_rect.has_point(pos)) {
 			undo_redo->create_action(TTR("Toggle Track Enabled"));
-			undo_redo->add_do_method(animation.ptr(), "track_set_enabled", track, !animation->track_is_enabled(track));
-			undo_redo->add_undo_method(animation.ptr(), "track_set_enabled", track, animation->track_is_enabled(track));
+			undo_redo->add_do_method_compat(animation.ptr(), "track_set_enabled", track, !animation->track_is_enabled(track));
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_set_enabled", track, animation->track_is_enabled(track));
 			undo_redo->commit_action();
 			update();
 			accept_event();
@@ -2857,8 +2857,8 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 		case MENU_CALL_MODE_CAPTURE: {
 			Animation::UpdateMode update_mode = Animation::UpdateMode(p_index);
 			undo_redo->create_action(TTR("Change Animation Update Mode"));
-			undo_redo->add_do_method(animation.ptr(), "value_track_set_update_mode", track, update_mode);
-			undo_redo->add_undo_method(animation.ptr(), "value_track_set_update_mode", track, animation->value_track_get_update_mode(track));
+			undo_redo->add_do_method_compat(animation.ptr(), "value_track_set_update_mode", track, update_mode);
+			undo_redo->add_undo_method_compat(animation.ptr(), "value_track_set_update_mode", track, animation->value_track_get_update_mode(track));
 			undo_redo->commit_action();
 			update();
 
@@ -2868,8 +2868,8 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 		case MENU_INTERPOLATION_CUBIC: {
 			Animation::InterpolationType interp_mode = Animation::InterpolationType(p_index - MENU_INTERPOLATION_NEAREST);
 			undo_redo->create_action(TTR("Change Animation Interpolation Mode"));
-			undo_redo->add_do_method(animation.ptr(), "track_set_interpolation_type", track, interp_mode);
-			undo_redo->add_undo_method(animation.ptr(), "track_set_interpolation_type", track, animation->track_get_interpolation_type(track));
+			undo_redo->add_do_method_compat(animation.ptr(), "track_set_interpolation_type", track, interp_mode);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_set_interpolation_type", track, animation->track_get_interpolation_type(track));
 			undo_redo->commit_action();
 			update();
 		} break;
@@ -2877,8 +2877,8 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 		case MENU_LOOP_CLAMP: {
 			bool loop_wrap = p_index == MENU_LOOP_WRAP;
 			undo_redo->create_action(TTR("Change Animation Loop Mode"));
-			undo_redo->add_do_method(animation.ptr(), "track_set_interpolation_loop_wrap", track, loop_wrap);
-			undo_redo->add_undo_method(animation.ptr(), "track_set_interpolation_loop_wrap", track, animation->track_get_interpolation_loop_wrap(track));
+			undo_redo->add_do_method_compat(animation.ptr(), "track_set_interpolation_loop_wrap", track, loop_wrap);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_set_interpolation_loop_wrap", track, animation->track_get_interpolation_loop_wrap(track));
 			undo_redo->commit_action();
 			update();
 
@@ -3258,10 +3258,10 @@ void AnimationTrackEditor::_track_remove_request(int p_track) {
 	int idx = p_track;
 	if (idx >= 0 && idx < animation->get_track_count()) {
 		undo_redo->create_action(TTR("Remove Anim Track"));
-		undo_redo->add_do_method(this, "_clear_selection", false);
-		undo_redo->add_do_method(animation.ptr(), "remove_track", idx);
-		undo_redo->add_undo_method(animation.ptr(), "add_track", animation->track_get_type(idx), idx);
-		undo_redo->add_undo_method(animation.ptr(), "track_set_path", idx, animation->track_get_path(idx));
+		undo_redo->add_do_method_compat(this, "_clear_selection", false);
+		undo_redo->add_do_method_compat(animation.ptr(), "remove_track", idx);
+		undo_redo->add_undo_method_compat(animation.ptr(), "add_track", animation->track_get_type(idx), idx);
+		undo_redo->add_undo_method_compat(animation.ptr(), "track_set_path", idx, animation->track_get_path(idx));
 
 		// TODO interpolation.
 		for (int i = 0; i < animation->track_get_key_count(idx); i++) {
@@ -3269,13 +3269,13 @@ void AnimationTrackEditor::_track_remove_request(int p_track) {
 			float time = animation->track_get_key_time(idx, i);
 			float trans = animation->track_get_key_transition(idx, i);
 
-			undo_redo->add_undo_method(animation.ptr(), "track_insert_key", idx, time, v);
-			undo_redo->add_undo_method(animation.ptr(), "track_set_key_transition", idx, i, trans);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", idx, time, v);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_set_key_transition", idx, i, trans);
 		}
 
-		undo_redo->add_undo_method(animation.ptr(), "track_set_interpolation_type", idx, animation->track_get_interpolation_type(idx));
+		undo_redo->add_undo_method_compat(animation.ptr(), "track_set_interpolation_type", idx, animation->track_get_interpolation_type(idx));
 		if (animation->track_get_type(idx) == Animation::TYPE_VALUE) {
-			undo_redo->add_undo_method(animation.ptr(), "value_track_set_update_mode", idx, animation->value_track_get_update_mode(idx));
+			undo_redo->add_undo_method_compat(animation.ptr(), "value_track_set_update_mode", idx, animation->value_track_get_update_mode(idx));
 		}
 
 		undo_redo->commit_action();
@@ -3730,10 +3730,10 @@ Ref<Animation> AnimationTrackEditor::_create_and_get_reset_animation() {
 		Ref<Animation> reset_anim;
 		reset_anim.instance();
 		reset_anim->set_length(ANIM_MIN_LENGTH);
-		undo_redo->add_do_method(player, "add_animation", "RESET", reset_anim);
-		undo_redo->add_do_method(AnimationPlayerEditor::singleton, "_animation_player_changed", player);
-		undo_redo->add_undo_method(player, "remove_animation", "RESET");
-		undo_redo->add_undo_method(AnimationPlayerEditor::singleton, "_animation_player_changed", player);
+		undo_redo->add_do_method_compat(player, "add_animation", "RESET", reset_anim);
+		undo_redo->add_do_method_compat(AnimationPlayerEditor::singleton, "_animation_player_changed", player);
+		undo_redo->add_undo_method_compat(player, "remove_animation", "RESET");
+		undo_redo->add_undo_method_compat(AnimationPlayerEditor::singleton, "_animation_player_changed", player);
 		return reset_anim;
 	}
 }
@@ -3923,10 +3923,10 @@ AnimationTrackEditor::TrackIndices AnimationTrackEditor::_confirm_insert(InsertD
 
 		p_id.track_idx = p_next_tracks.normal;
 
-		undo_redo->add_do_method(animation.ptr(), "add_track", p_id.type);
-		undo_redo->add_do_method(animation.ptr(), "track_set_path", p_id.track_idx, p_id.path);
+		undo_redo->add_do_method_compat(animation.ptr(), "add_track", p_id.type);
+		undo_redo->add_do_method_compat(animation.ptr(), "track_set_path", p_id.track_idx, p_id.path);
 		if (p_id.type == Animation::TYPE_VALUE) {
-			undo_redo->add_do_method(animation.ptr(), "value_track_set_update_mode", p_id.track_idx, update_mode);
+			undo_redo->add_do_method_compat(animation.ptr(), "value_track_set_update_mode", p_id.track_idx, update_mode);
 		}
 
 	} else {
@@ -3967,20 +3967,20 @@ AnimationTrackEditor::TrackIndices AnimationTrackEditor::_confirm_insert(InsertD
 		}
 	}
 
-	undo_redo->add_do_method(animation.ptr(), "track_insert_key", p_id.track_idx, time, value);
+	undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", p_id.track_idx, time, value);
 
 	if (created) {
 		// Just remove the track.
-		undo_redo->add_undo_method(this, "_clear_selection", false);
-		undo_redo->add_undo_method(animation.ptr(), "remove_track", animation->get_track_count());
+		undo_redo->add_undo_method_compat(this, "_clear_selection", false);
+		undo_redo->add_undo_method_compat(animation.ptr(), "remove_track", animation->get_track_count());
 		p_next_tracks.normal++;
 	} else {
-		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", p_id.track_idx, time);
+		undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", p_id.track_idx, time);
 		int existing = animation->track_find_key(p_id.track_idx, time, true);
 		if (existing != -1) {
 			Variant v = animation->track_get_key_value(p_id.track_idx, existing);
 			float trans = animation->track_get_key_transition(p_id.track_idx, existing);
-			undo_redo->add_undo_method(animation.ptr(), "track_insert_key", p_id.track_idx, time, v, trans);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", p_id.track_idx, time, v, trans);
 		}
 	}
 
@@ -3994,10 +3994,10 @@ AnimationTrackEditor::TrackIndices AnimationTrackEditor::_confirm_insert(InsertD
 			}
 		}
 		if (create_reset_track) {
-			undo_redo->add_do_method(reset_anim, "add_track", p_id.type);
-			undo_redo->add_do_method(reset_anim, "track_set_path", p_next_tracks.reset, p_id.path);
-			undo_redo->add_do_method(reset_anim, "track_insert_key", p_next_tracks.reset, 0.0f, value);
-			undo_redo->add_undo_method(reset_anim, "remove_track", reset_anim->get_track_count());
+			undo_redo->add_do_method_compat(reset_anim, "add_track", p_id.type);
+			undo_redo->add_do_method_compat(reset_anim, "track_set_path", p_next_tracks.reset, p_id.path);
+			undo_redo->add_do_method_compat(reset_anim, "track_insert_key", p_next_tracks.reset, 0.0f, value);
+			undo_redo->add_undo_method_compat(reset_anim, "remove_track", reset_anim->get_track_count());
 			p_next_tracks.reset++;
 		}
 	}
@@ -4331,8 +4331,8 @@ void AnimationTrackEditor::_update_step(double p_new_step) {
 			step_value = 1.0 / step_value;
 		}
 	}
-	undo_redo->add_do_method(animation.ptr(), "set_step", step_value);
-	undo_redo->add_undo_method(animation.ptr(), "set_step", animation->get_step());
+	undo_redo->add_do_method_compat(animation.ptr(), "set_step", step_value);
+	undo_redo->add_undo_method_compat(animation.ptr(), "set_step", animation->get_step());
 	step->set_block_signals(true);
 	undo_redo->commit_action();
 	step->set_block_signals(false);
@@ -4350,12 +4350,12 @@ void AnimationTrackEditor::_dropped_track(int p_from_track, int p_to_track) {
 
 	_clear_selection();
 	undo_redo->create_action(TTR("Rearrange Tracks"));
-	undo_redo->add_do_method(animation.ptr(), "track_move_to", p_from_track, p_to_track);
+	undo_redo->add_do_method_compat(animation.ptr(), "track_move_to", p_from_track, p_to_track);
 	// Take into account that the position of the tracks that come after the one removed will change.
 	int to_track_real = p_to_track > p_from_track ? p_to_track - 1 : p_to_track;
-	undo_redo->add_undo_method(animation.ptr(), "track_move_to", to_track_real, p_to_track > p_from_track ? p_from_track : p_from_track + 1);
-	undo_redo->add_do_method(this, "_track_grab_focus", to_track_real);
-	undo_redo->add_undo_method(this, "_track_grab_focus", p_from_track);
+	undo_redo->add_undo_method_compat(animation.ptr(), "track_move_to", to_track_real, p_to_track > p_from_track ? p_from_track : p_from_track + 1);
+	undo_redo->add_do_method_compat(this, "_track_grab_focus", to_track_real);
+	undo_redo->add_undo_method_compat(this, "_track_grab_focus", p_from_track);
 	undo_redo->commit_action();
 }
 
@@ -4379,9 +4379,9 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 		case Animation::TYPE_TRANSFORM:
 		case Animation::TYPE_METHOD: {
 			undo_redo->create_action(TTR("Add Track"));
-			undo_redo->add_do_method(animation.ptr(), "add_track", adding_track_type);
-			undo_redo->add_do_method(animation.ptr(), "track_set_path", animation->get_track_count(), path_to);
-			undo_redo->add_undo_method(animation.ptr(), "remove_track", animation->get_track_count());
+			undo_redo->add_do_method_compat(animation.ptr(), "add_track", adding_track_type);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_set_path", animation->get_track_count(), path_to);
+			undo_redo->add_undo_method_compat(animation.ptr(), "remove_track", animation->get_track_count());
 			undo_redo->commit_action();
 
 		} break;
@@ -4406,9 +4406,9 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 			}
 
 			undo_redo->create_action(TTR("Add Track"));
-			undo_redo->add_do_method(animation.ptr(), "add_track", adding_track_type);
-			undo_redo->add_do_method(animation.ptr(), "track_set_path", animation->get_track_count(), path_to);
-			undo_redo->add_undo_method(animation.ptr(), "remove_track", animation->get_track_count());
+			undo_redo->add_do_method_compat(animation.ptr(), "add_track", adding_track_type);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_set_path", animation->get_track_count(), path_to);
+			undo_redo->add_undo_method_compat(animation.ptr(), "remove_track", animation->get_track_count());
 			undo_redo->commit_action();
 
 		} break;
@@ -4424,9 +4424,9 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 			}
 
 			undo_redo->create_action(TTR("Add Track"));
-			undo_redo->add_do_method(animation.ptr(), "add_track", adding_track_type);
-			undo_redo->add_do_method(animation.ptr(), "track_set_path", animation->get_track_count(), path_to);
-			undo_redo->add_undo_method(animation.ptr(), "remove_track", animation->get_track_count());
+			undo_redo->add_do_method_compat(animation.ptr(), "add_track", adding_track_type);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_set_path", animation->get_track_count(), path_to);
+			undo_redo->add_undo_method_compat(animation.ptr(), "remove_track", animation->get_track_count());
 			undo_redo->commit_action();
 
 		} break;
@@ -4473,10 +4473,10 @@ void AnimationTrackEditor::_new_track_property_selected(String p_name) {
 		}
 
 		undo_redo->create_action(TTR("Add Track"));
-		undo_redo->add_do_method(animation.ptr(), "add_track", adding_track_type);
-		undo_redo->add_do_method(animation.ptr(), "track_set_path", animation->get_track_count(), full_path);
-		undo_redo->add_do_method(animation.ptr(), "value_track_set_update_mode", animation->get_track_count(), update_mode);
-		undo_redo->add_undo_method(animation.ptr(), "remove_track", animation->get_track_count());
+		undo_redo->add_do_method_compat(animation.ptr(), "add_track", adding_track_type);
+		undo_redo->add_do_method_compat(animation.ptr(), "track_set_path", animation->get_track_count(), full_path);
+		undo_redo->add_do_method_compat(animation.ptr(), "value_track_set_update_mode", animation->get_track_count(), update_mode);
+		undo_redo->add_undo_method_compat(animation.ptr(), "remove_track", animation->get_track_count());
 		undo_redo->commit_action();
 	} else {
 		Vector<String> subindices;
@@ -4498,9 +4498,9 @@ void AnimationTrackEditor::_new_track_property_selected(String p_name) {
 		undo_redo->create_action(TTR("Add Bezier Track"));
 		int base_track = animation->get_track_count();
 		for (int i = 0; i < subindices.size(); i++) {
-			undo_redo->add_do_method(animation.ptr(), "add_track", adding_track_type);
-			undo_redo->add_do_method(animation.ptr(), "track_set_path", base_track + i, full_path + subindices[i]);
-			undo_redo->add_undo_method(animation.ptr(), "remove_track", base_track);
+			undo_redo->add_do_method_compat(animation.ptr(), "add_track", adding_track_type);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_set_path", base_track + i, full_path + subindices[i]);
+			undo_redo->add_undo_method_compat(animation.ptr(), "remove_track", base_track);
 		}
 		undo_redo->commit_action();
 	}
@@ -4562,8 +4562,8 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 			Quat rot = xf.basis;
 
 			undo_redo->create_action(TTR("Add Transform Track Key"));
-			undo_redo->add_do_method(animation.ptr(), "transform_track_insert_key", p_track, p_ofs, loc, rot, scale);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
+			undo_redo->add_do_method_compat(animation.ptr(), "transform_track_insert_key", p_track, p_ofs, loc, rot, scale);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
 			undo_redo->commit_action();
 
 		} break;
@@ -4573,9 +4573,9 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 			_find_hint_for_track(p_track, bp, &value);
 
 			undo_redo->create_action(TTR("Add Track Key"));
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", p_track, p_ofs, value);
-			undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", p_track, p_ofs, value);
+			undo_redo->add_undo_method_compat(this, "_clear_selection_for_anim", animation);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
 			undo_redo->commit_action();
 
 		} break;
@@ -4605,8 +4605,8 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 			arr[4] = 0;
 
 			undo_redo->create_action(TTR("Add Track Key"));
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", p_track, p_ofs, arr);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", p_track, p_ofs, arr);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
 			undo_redo->commit_action();
 
 		} break;
@@ -4617,16 +4617,16 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 			ak["end_offset"] = 0;
 
 			undo_redo->create_action(TTR("Add Track Key"));
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", p_track, p_ofs, ak);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", p_track, p_ofs, ak);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
 			undo_redo->commit_action();
 		} break;
 		case Animation::TYPE_ANIMATION: {
 			StringName anim = "[stop]";
 
 			undo_redo->create_action(TTR("Add Track Key"));
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", p_track, p_ofs, anim);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", p_track, p_ofs, anim);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
 			undo_redo->commit_action();
 		} break;
 	}
@@ -4663,8 +4663,8 @@ void AnimationTrackEditor::_add_method_key(const String &p_method) {
 			d["args"] = params;
 
 			undo_redo->create_action(TTR("Add Method Track Key"));
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", insert_key_from_track_call_track, insert_key_from_track_call_ofs, d);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", insert_key_from_track_call_track, insert_key_from_track_call_ofs);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", insert_key_from_track_call_track, insert_key_from_track_call_ofs, d);
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", insert_key_from_track_call_track, insert_key_from_track_call_ofs);
 			undo_redo->commit_action();
 
 			return;
@@ -4858,7 +4858,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 	float motion = moving_selection_offset;
 	// 1 - remove the keys
 	for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-		undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
+		undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
 	}
 	// 2 - remove overlapped keys
 	for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
@@ -4874,7 +4874,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 			continue; //already in selection, don't save
 		}
 
-		undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_position", E->key().track, newtime);
+		undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key_at_position", E->key().track, newtime);
 		_AnimMoveRestore amr;
 
 		amr.key = animation->track_get_key_value(E->key().track, idx);
@@ -4888,36 +4888,36 @@ void AnimationTrackEditor::_move_selection_commit() {
 	// 3 - move the keys (re insert them)
 	for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		float newpos = snap_time(E->get().pos + motion);
-		undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+		undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 	}
 
 	// 4 - (undo) remove inserted keys
 	for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		float newpos = snap_time(E->get().pos + motion);
-		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", E->key().track, newpos);
+		undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", E->key().track, newpos);
 	}
 
 	// 5 - (undo) reinsert keys
 	for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+		undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 	}
 
 	// 6 - (undo) reinsert overlapped keys
 	for (List<_AnimMoveRestore>::Element *E = to_restore.front(); E; E = E->next()) {
 		_AnimMoveRestore &amr = E->get();
-		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
+		undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
 	}
 
-	undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
-	undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
+	undo_redo->add_do_method_compat(this, "_clear_selection_for_anim", animation);
+	undo_redo->add_undo_method_compat(this, "_clear_selection_for_anim", animation);
 
 	// 7 - reselect
 	for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		float oldpos = E->get().pos;
 		float newpos = snap_time(oldpos + motion);
 
-		undo_redo->add_do_method(this, "_select_at_anim", animation, E->key().track, newpos);
-		undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, oldpos);
+		undo_redo->add_do_method_compat(this, "_select_at_anim", animation, E->key().track, newpos);
+		undo_redo->add_undo_method_compat(this, "_select_at_anim", animation, E->key().track, oldpos);
 	}
 
 	undo_redo->commit_action();
@@ -5090,8 +5090,8 @@ void AnimationTrackEditor::_anim_duplicate_keys(bool transpose) {
 
 			int existing_idx = animation->track_find_key(dst_track, dst_time, true);
 
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", dst_track, dst_time, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", dst_track, dst_time);
+			undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", dst_track, dst_time, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+			undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", dst_track, dst_time);
 
 			Pair<int, float> p;
 			p.first = dst_track;
@@ -5099,7 +5099,7 @@ void AnimationTrackEditor::_anim_duplicate_keys(bool transpose) {
 			new_selection_values.push_back(p);
 
 			if (existing_idx != -1) {
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", dst_track, dst_time, animation->track_get_key_value(dst_track, existing_idx), animation->track_get_key_transition(dst_track, existing_idx));
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", dst_track, dst_time, animation->track_get_key_value(dst_track, existing_idx), animation->track_get_key_transition(dst_track, existing_idx));
 			}
 		}
 
@@ -5248,7 +5248,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			int base_track = animation->get_track_count();
 			undo_redo->create_action(TTR("Paste Tracks"));
 			for (int i = 0; i < track_clipboard.size(); i++) {
-				undo_redo->add_do_method(animation.ptr(), "add_track", track_clipboard[i].track_type);
+				undo_redo->add_do_method_compat(animation.ptr(), "add_track", track_clipboard[i].track_type);
 				Node *exists = nullptr;
 				NodePath path = track_clipboard[i].base_path;
 
@@ -5260,19 +5260,19 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 					}
 				}
 
-				undo_redo->add_do_method(animation.ptr(), "track_set_path", base_track, path);
-				undo_redo->add_do_method(animation.ptr(), "track_set_interpolation_type", base_track, track_clipboard[i].interp_type);
-				undo_redo->add_do_method(animation.ptr(), "track_set_interpolation_loop_wrap", base_track, track_clipboard[i].loop_wrap);
-				undo_redo->add_do_method(animation.ptr(), "track_set_enabled", base_track, track_clipboard[i].enabled);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_set_path", base_track, path);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_set_interpolation_type", base_track, track_clipboard[i].interp_type);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_set_interpolation_loop_wrap", base_track, track_clipboard[i].loop_wrap);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_set_enabled", base_track, track_clipboard[i].enabled);
 				if (track_clipboard[i].track_type == Animation::TYPE_VALUE) {
-					undo_redo->add_do_method(animation.ptr(), "value_track_set_update_mode", base_track, track_clipboard[i].update_mode);
+					undo_redo->add_do_method_compat(animation.ptr(), "value_track_set_update_mode", base_track, track_clipboard[i].update_mode);
 				}
 
 				for (int j = 0; j < track_clipboard[i].keys.size(); j++) {
-					undo_redo->add_do_method(animation.ptr(), "track_insert_key", base_track, track_clipboard[i].keys[j].time, track_clipboard[i].keys[j].value, track_clipboard[i].keys[j].transition);
+					undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", base_track, track_clipboard[i].keys[j].time, track_clipboard[i].keys[j].value, track_clipboard[i].keys[j].transition);
 				}
 
-				undo_redo->add_undo_method(animation.ptr(), "remove_track", animation->get_track_count());
+				undo_redo->add_undo_method_compat(animation.ptr(), "remove_track", animation->get_track_count());
 
 				base_track++;
 			}
@@ -5323,7 +5323,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 
 			// 1-remove the keys
 			for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
 			}
 			// 2- remove overlapped keys
 			for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
@@ -5339,7 +5339,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 					continue; //already in selection, don't save
 				}
 
-				undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_position", E->key().track, newtime);
+				undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key_at_position", E->key().track, newtime);
 				_AnimMoveRestore amr;
 
 				amr.key = animation->track_get_key_value(E->key().track, idx);
@@ -5354,37 +5354,37 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			// 3-move the keys (re insert them)
 			for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				float newpos = _NEW_POS(E->get().pos);
-				undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+				undo_redo->add_do_method_compat(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 			}
 
 			// 4-(undo) remove inserted keys
 			for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				float newpos = _NEW_POS(E->get().pos);
-				undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", E->key().track, newpos);
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_remove_key_at_position", E->key().track, newpos);
 			}
 
 			// 5-(undo) reinsert keys
 			for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 			}
 
 			// 6-(undo) reinsert overlapped keys
 			for (List<_AnimMoveRestore>::Element *E = to_restore.front(); E; E = E->next()) {
 				_AnimMoveRestore &amr = E->get();
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
+				undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
 			}
 
-			undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
-			undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
+			undo_redo->add_do_method_compat(this, "_clear_selection_for_anim", animation);
+			undo_redo->add_undo_method_compat(this, "_clear_selection_for_anim", animation);
 
 			// 7-reselect
 			for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				float oldpos = E->get().pos;
 				float newpos = _NEW_POS(oldpos);
 				if (newpos >= 0) {
-					undo_redo->add_do_method(this, "_select_at_anim", animation, E->key().track, newpos);
+					undo_redo->add_do_method_compat(this, "_select_at_anim", animation, E->key().track, newpos);
 				}
-				undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, oldpos);
+				undo_redo->add_undo_method_compat(this, "_select_at_anim", animation, E->key().track, oldpos);
 			}
 #undef _NEW_POS
 			undo_redo->commit_action();
@@ -5413,11 +5413,11 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				undo_redo->create_action(TTR("Anim Delete Keys"));
 
 				for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-					undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
-					undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+					undo_redo->add_do_method_compat(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
+					undo_redo->add_undo_method_compat(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 				}
-				undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
-				undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
+				undo_redo->add_do_method_compat(this, "_clear_selection_for_anim", animation);
+				undo_redo->add_undo_method_compat(this, "_clear_selection_for_anim", animation);
 				undo_redo->commit_action();
 				_update_key_edit();
 			}

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -1003,8 +1003,8 @@ void AnimationTrackEditTypeAudio::drop_data(const Point2 &p_point, const Variant
 			}
 
 			get_undo_redo()->create_action(TTR("Add Audio Track Clip"));
-			get_undo_redo()->add_do_method(get_animation().ptr(), "audio_track_insert_key", get_track(), ofs, stream);
-			get_undo_redo()->add_undo_method(get_animation().ptr(), "track_remove_key_at_position", get_track(), ofs);
+			get_undo_redo()->add_do_method_compat(get_animation().ptr(), "audio_track_insert_key", get_track(), ofs, stream);
+			get_undo_redo()->add_undo_method_compat(get_animation().ptr(), "track_remove_key_at_position", get_track(), ofs);
 			get_undo_redo()->commit_action();
 
 			update();
@@ -1091,15 +1091,15 @@ void AnimationTrackEditTypeAudio::_gui_input(const Ref<InputEvent> &p_event) {
 		if (len_resizing_start) {
 			float prev_ofs = get_animation()->audio_track_get_key_start_offset(get_track(), len_resizing_index);
 			get_undo_redo()->create_action(TTR("Change Audio Track Clip Start Offset"));
-			get_undo_redo()->add_do_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs + ofs_local);
-			get_undo_redo()->add_undo_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
+			get_undo_redo()->add_do_method_compat(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs + ofs_local);
+			get_undo_redo()->add_undo_method_compat(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
 			get_undo_redo()->commit_action();
 
 		} else {
 			float prev_ofs = get_animation()->audio_track_get_key_end_offset(get_track(), len_resizing_index);
 			get_undo_redo()->create_action(TTR("Change Audio Track Clip End Offset"));
-			get_undo_redo()->add_do_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs + ofs_local);
-			get_undo_redo()->add_undo_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
+			get_undo_redo()->add_do_method_compat(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs + ofs_local);
+			get_undo_redo()->add_undo_method_compat(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
 			get_undo_redo()->commit_action();
 		}
 

--- a/editor/array_property_edit.cpp
+++ b/editor/array_property_edit.cpp
@@ -93,11 +93,11 @@ bool ArrayPropertyEdit::_set(const StringName &p_name, const Variant &p_value) {
 
 			UndoRedo *ur = EditorNode::get_undo_redo();
 			ur->create_action(TTR("Resize Array"));
-			ur->add_do_method(this, "_set_size", newsize);
-			ur->add_undo_method(this, "_set_size", size);
+			ur->add_do_method_compat(this, "_set_size", newsize);
+			ur->add_undo_method_compat(this, "_set_size", size);
 			if (newsize < size) {
 				for (int i = newsize; i < size; i++) {
-					ur->add_undo_method(this, "_set_value", i, arr.get(i));
+					ur->add_undo_method_compat(this, "_set_value", i, arr.get(i));
 				}
 			} else if (newsize > size) {
 				Variant init;
@@ -109,12 +109,12 @@ bool ArrayPropertyEdit::_set(const StringName &p_name, const Variant &p_value) {
 				if (new_type != Variant::NIL) {
 					Variant::construct(new_type, init, nullptr, 0, ce);
 					for (int i = size; i < newsize; i++) {
-						ur->add_do_method(this, "_set_value", i, init);
+						ur->add_do_method_compat(this, "_set_value", i, init);
 					}
 				}
 			}
-			ur->add_do_method(this, "_notif_change");
-			ur->add_undo_method(this, "_notif_change");
+			ur->add_do_method_compat(this, "_notif_change");
+			ur->add_undo_method_compat(this, "_notif_change");
 			ur->commit_action();
 			return true;
 		}
@@ -141,10 +141,10 @@ bool ArrayPropertyEdit::_set(const StringName &p_name, const Variant &p_value) {
 				UndoRedo *ur = EditorNode::get_undo_redo();
 
 				ur->create_action(TTR("Change Array Value Type"));
-				ur->add_do_method(this, "_set_value", idx, new_value);
-				ur->add_undo_method(this, "_set_value", idx, value);
-				ur->add_do_method(this, "_notif_change");
-				ur->add_undo_method(this, "_notif_change");
+				ur->add_do_method_compat(this, "_set_value", idx, new_value);
+				ur->add_undo_method_compat(this, "_set_value", idx, value);
+				ur->add_do_method_compat(this, "_notif_change");
+				ur->add_undo_method_compat(this, "_notif_change");
 				ur->commit_action();
 			}
 			return true;
@@ -157,10 +157,10 @@ bool ArrayPropertyEdit::_set(const StringName &p_name, const Variant &p_value) {
 			UndoRedo *ur = EditorNode::get_undo_redo();
 
 			ur->create_action(TTR("Change Array Value"));
-			ur->add_do_method(this, "_set_value", idx, p_value);
-			ur->add_undo_method(this, "_set_value", idx, value);
-			ur->add_do_method(this, "_notif_changev", p_name);
-			ur->add_undo_method(this, "_notif_changev", p_name);
+			ur->add_do_method_compat(this, "_set_value", idx, p_value);
+			ur->add_undo_method_compat(this, "_set_value", idx, value);
+			ur->add_do_method_compat(this, "_notif_changev", p_name);
+			ur->add_undo_method_compat(this, "_notif_changev", p_name);
 			ur->commit_action();
 			return true;
 		}

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -613,12 +613,12 @@ void ConnectionsDock::_connect(ConnectDialog::ConnectionData cToMake) {
 
 	Callable c(target, cToMake.method);
 
-	undo_redo->add_do_method(source, "connect", cToMake.signal, c, cToMake.binds, cToMake.flags);
-	undo_redo->add_undo_method(source, "disconnect", cToMake.signal, c);
-	undo_redo->add_do_method(this, "update_tree");
-	undo_redo->add_undo_method(this, "update_tree");
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); //to force redraw of scene tree
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method_compat(source, "connect", cToMake.signal, c, cToMake.binds, cToMake.flags);
+	undo_redo->add_undo_method_compat(source, "disconnect", cToMake.signal, c);
+	undo_redo->add_do_method_compat(this, "update_tree");
+	undo_redo->add_undo_method_compat(this, "update_tree");
+	undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); //to force redraw of scene tree
+	undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -634,12 +634,12 @@ void ConnectionsDock::_disconnect(TreeItem &item) {
 
 	undo_redo->create_action(vformat(TTR("Disconnect '%s' from '%s'"), c.signal, c.method));
 
-	undo_redo->add_do_method(selectedNode, "disconnect", c.signal, Callable(c.target, c.method));
-	undo_redo->add_undo_method(selectedNode, "connect", c.signal, Callable(c.target, c.method), c.binds, c.flags);
-	undo_redo->add_do_method(this, "update_tree");
-	undo_redo->add_undo_method(this, "update_tree");
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method_compat(selectedNode, "disconnect", c.signal, Callable(c.target, c.method));
+	undo_redo->add_undo_method_compat(selectedNode, "connect", c.signal, Callable(c.target, c.method), c.binds, c.flags);
+	undo_redo->add_do_method_compat(this, "update_tree");
+	undo_redo->add_undo_method_compat(this, "update_tree");
+	undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
+	undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -662,15 +662,15 @@ void ConnectionsDock::_disconnect_all() {
 	while (child) {
 		Connection cd = child->get_metadata(0);
 		ConnectDialog::ConnectionData c = cd;
-		undo_redo->add_do_method(selectedNode, "disconnect", c.signal, Callable(c.target, c.method));
-		undo_redo->add_undo_method(selectedNode, "connect", c.signal, Callable(c.target, c.method), c.binds, c.flags);
+		undo_redo->add_do_method_compat(selectedNode, "disconnect", c.signal, Callable(c.target, c.method));
+		undo_redo->add_undo_method_compat(selectedNode, "connect", c.signal, Callable(c.target, c.method), c.binds, c.flags);
 		child = child->get_next();
 	}
 
-	undo_redo->add_do_method(this, "update_tree");
-	undo_redo->add_undo_method(this, "update_tree");
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method_compat(this, "update_tree");
+	undo_redo->add_undo_method_compat(this, "update_tree");
+	undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }

--- a/editor/dictionary_property_edit.cpp
+++ b/editor/dictionary_property_edit.cpp
@@ -126,10 +126,10 @@ bool DictionaryPropertyEdit::_set(const StringName &p_name, const Variant &p_val
 			UndoRedo *ur = EditorNode::get_undo_redo();
 
 			ur->create_action(TTR("Change Dictionary Key"));
-			ur->add_do_method(this, "_set_key", key, p_value);
-			ur->add_undo_method(this, "_set_key", p_value, key);
-			ur->add_do_method(this, "_notif_changev", p_name);
-			ur->add_undo_method(this, "_notif_changev", p_name);
+			ur->add_do_method_compat(this, "_set_key", key, p_value);
+			ur->add_undo_method_compat(this, "_set_key", p_value, key);
+			ur->add_do_method_compat(this, "_notif_changev", p_name);
+			ur->add_undo_method_compat(this, "_notif_changev", p_name);
 			ur->commit_action();
 
 			return true;
@@ -140,10 +140,10 @@ bool DictionaryPropertyEdit::_set(const StringName &p_name, const Variant &p_val
 				UndoRedo *ur = EditorNode::get_undo_redo();
 
 				ur->create_action(TTR("Change Dictionary Value"));
-				ur->add_do_method(this, "_set_value", key, p_value);
-				ur->add_undo_method(this, "_set_value", key, value);
-				ur->add_do_method(this, "_notif_changev", p_name);
-				ur->add_undo_method(this, "_notif_changev", p_name);
+				ur->add_do_method_compat(this, "_set_value", key, p_value);
+				ur->add_undo_method_compat(this, "_set_value", key, value);
+				ur->add_do_method_compat(this, "_notif_changev", p_name);
+				ur->add_undo_method_compat(this, "_notif_changev", p_name);
 				ur->commit_action();
 
 				return true;

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -281,21 +281,21 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 
 	StringName current = AudioServer::get_singleton()->get_bus_name(get_index());
 	ur->create_action(TTR("Rename Audio Bus"));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_name", get_index(), attempt);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_name", get_index(), current);
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_name", get_index(), attempt);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_name", get_index(), current);
 
 	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 		if (AudioServer::get_singleton()->get_bus_send(i) == current) {
-			ur->add_do_method(AudioServer::get_singleton(), "set_bus_send", i, attempt);
-			ur->add_undo_method(AudioServer::get_singleton(), "set_bus_send", i, current);
+			ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_send", i, attempt);
+			ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_send", i, current);
 		}
 	}
 
-	ur->add_do_method(buses, "_update_bus", get_index());
-	ur->add_undo_method(buses, "_update_bus", get_index());
+	ur->add_do_method_compat(buses, "_update_bus", get_index());
+	ur->add_undo_method_compat(buses, "_update_bus", get_index());
 
-	ur->add_do_method(buses, "_update_sends");
-	ur->add_undo_method(buses, "_update_sends");
+	ur->add_do_method_compat(buses, "_update_sends");
+	ur->add_undo_method_compat(buses, "_update_sends");
 	ur->commit_action();
 
 	updating_bus = false;
@@ -320,10 +320,10 @@ void EditorAudioBus::_volume_changed(float p_normalized) {
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Change Audio Bus Volume"), UndoRedo::MERGE_ENDS);
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", get_index(), p_db);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", get_index(), AudioServer::get_singleton()->get_bus_volume_db(get_index()));
-	ur->add_do_method(buses, "_update_bus", get_index());
-	ur->add_undo_method(buses, "_update_bus", get_index());
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_volume_db", get_index(), p_db);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_volume_db", get_index(), AudioServer::get_singleton()->get_bus_volume_db(get_index()));
+	ur->add_do_method_compat(buses, "_update_bus", get_index());
+	ur->add_undo_method_compat(buses, "_update_bus", get_index());
 	ur->commit_action();
 
 	updating_bus = false;
@@ -405,10 +405,10 @@ void EditorAudioBus::_solo_toggled() {
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Toggle Audio Bus Solo"));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_solo", get_index(), solo->is_pressed());
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_solo", get_index(), AudioServer::get_singleton()->is_bus_solo(get_index()));
-	ur->add_do_method(buses, "_update_bus", get_index());
-	ur->add_undo_method(buses, "_update_bus", get_index());
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_solo", get_index(), solo->is_pressed());
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_solo", get_index(), AudioServer::get_singleton()->is_bus_solo(get_index()));
+	ur->add_do_method_compat(buses, "_update_bus", get_index());
+	ur->add_undo_method_compat(buses, "_update_bus", get_index());
 	ur->commit_action();
 
 	updating_bus = false;
@@ -419,10 +419,10 @@ void EditorAudioBus::_mute_toggled() {
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Toggle Audio Bus Mute"));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_mute", get_index(), mute->is_pressed());
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_mute", get_index(), AudioServer::get_singleton()->is_bus_mute(get_index()));
-	ur->add_do_method(buses, "_update_bus", get_index());
-	ur->add_undo_method(buses, "_update_bus", get_index());
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_mute", get_index(), mute->is_pressed());
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_mute", get_index(), AudioServer::get_singleton()->is_bus_mute(get_index()));
+	ur->add_do_method_compat(buses, "_update_bus", get_index());
+	ur->add_undo_method_compat(buses, "_update_bus", get_index());
 	ur->commit_action();
 
 	updating_bus = false;
@@ -433,10 +433,10 @@ void EditorAudioBus::_bypass_toggled() {
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Toggle Audio Bus Bypass Effects"));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_bypass_effects", get_index(), bypass->is_pressed());
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_bypass_effects", get_index(), AudioServer::get_singleton()->is_bus_bypassing_effects(get_index()));
-	ur->add_do_method(buses, "_update_bus", get_index());
-	ur->add_undo_method(buses, "_update_bus", get_index());
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_bypass_effects", get_index(), bypass->is_pressed());
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_bypass_effects", get_index(), AudioServer::get_singleton()->is_bus_bypassing_effects(get_index()));
+	ur->add_do_method_compat(buses, "_update_bus", get_index());
+	ur->add_undo_method_compat(buses, "_update_bus", get_index());
 	ur->commit_action();
 
 	updating_bus = false;
@@ -447,10 +447,10 @@ void EditorAudioBus::_send_selected(int p_which) {
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Select Audio Bus Send"));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_send", get_index(), send->get_item_text(p_which));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_send", get_index(), AudioServer::get_singleton()->get_bus_send(get_index()));
-	ur->add_do_method(buses, "_update_bus", get_index());
-	ur->add_undo_method(buses, "_update_bus", get_index());
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_send", get_index(), send->get_item_text(p_which));
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_send", get_index(), AudioServer::get_singleton()->get_bus_send(get_index()));
+	ur->add_do_method_compat(buses, "_update_bus", get_index());
+	ur->add_undo_method_compat(buses, "_update_bus", get_index());
 	ur->commit_action();
 
 	updating_bus = false;
@@ -496,10 +496,10 @@ void EditorAudioBus::_effect_edited() {
 
 		UndoRedo *ur = EditorNode::get_undo_redo();
 		ur->create_action(TTR("Select Audio Bus Send"));
-		ur->add_do_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, effect->is_checked(0));
-		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, AudioServer::get_singleton()->is_bus_effect_enabled(get_index(), index));
-		ur->add_do_method(buses, "_update_bus", get_index());
-		ur->add_undo_method(buses, "_update_bus", get_index());
+		ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, effect->is_checked(0));
+		ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, AudioServer::get_singleton()->is_bus_effect_enabled(get_index(), index));
+		ur->add_do_method_compat(buses, "_update_bus", get_index());
+		ur->add_undo_method_compat(buses, "_update_bus", get_index());
 		ur->commit_action();
 
 		updating_bus = false;
@@ -523,10 +523,10 @@ void EditorAudioBus::_effect_add(int p_which) {
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Add Audio Bus Effect"));
-	ur->add_do_method(AudioServer::get_singleton(), "add_bus_effect", get_index(), afxr, -1);
-	ur->add_undo_method(AudioServer::get_singleton(), "remove_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect_count(get_index()));
-	ur->add_do_method(buses, "_update_bus", get_index());
-	ur->add_undo_method(buses, "_update_bus", get_index());
+	ur->add_do_method_compat(AudioServer::get_singleton(), "add_bus_effect", get_index(), afxr, -1);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "remove_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect_count(get_index()));
+	ur->add_do_method_compat(buses, "_update_bus", get_index());
+	ur->add_undo_method_compat(buses, "_update_bus", get_index());
 	ur->commit_action();
 }
 
@@ -675,8 +675,8 @@ void EditorAudioBus::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Move Bus Effect"));
-	ur->add_do_method(AudioServer::get_singleton(), "remove_bus_effect", bus, effect);
-	ur->add_do_method(AudioServer::get_singleton(), "add_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect(bus, effect), paste_at);
+	ur->add_do_method_compat(AudioServer::get_singleton(), "remove_bus_effect", bus, effect);
+	ur->add_do_method_compat(AudioServer::get_singleton(), "add_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect(bus, effect), paste_at);
 
 	if (paste_at == -1) {
 		paste_at = AudioServer::get_singleton()->get_bus_effect_count(get_index());
@@ -685,20 +685,20 @@ void EditorAudioBus::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 		}
 	}
 	if (!enabled) {
-		ur->add_do_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), paste_at, false);
+		ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), paste_at, false);
 	}
 
-	ur->add_undo_method(AudioServer::get_singleton(), "remove_bus_effect", get_index(), paste_at);
-	ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", bus, AudioServer::get_singleton()->get_bus_effect(bus, effect), effect);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "remove_bus_effect", get_index(), paste_at);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "add_bus_effect", bus, AudioServer::get_singleton()->get_bus_effect(bus, effect), effect);
 	if (!enabled) {
-		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", bus, effect, false);
+		ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_effect_enabled", bus, effect, false);
 	}
 
-	ur->add_do_method(buses, "_update_bus", get_index());
-	ur->add_undo_method(buses, "_update_bus", get_index());
+	ur->add_do_method_compat(buses, "_update_bus", get_index());
+	ur->add_undo_method_compat(buses, "_update_bus", get_index());
 	if (get_index() != bus) {
-		ur->add_do_method(buses, "_update_bus", bus);
-		ur->add_undo_method(buses, "_update_bus", bus);
+		ur->add_do_method_compat(buses, "_update_bus", bus);
+		ur->add_undo_method_compat(buses, "_update_bus", bus);
 	}
 	ur->commit_action();
 }
@@ -717,11 +717,11 @@ void EditorAudioBus::_delete_effect_pressed(int p_option) {
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Delete Bus Effect"));
-	ur->add_do_method(AudioServer::get_singleton(), "remove_bus_effect", get_index(), index);
-	ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect(get_index(), index), index);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, AudioServer::get_singleton()->is_bus_effect_enabled(get_index(), index));
-	ur->add_do_method(buses, "_update_bus", get_index());
-	ur->add_undo_method(buses, "_update_bus", get_index());
+	ur->add_do_method_compat(AudioServer::get_singleton(), "remove_bus_effect", get_index(), index);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "add_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect(get_index(), index), index);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, AudioServer::get_singleton()->is_bus_effect_enabled(get_index(), index));
+	ur->add_do_method_compat(buses, "_update_bus", get_index());
+	ur->add_undo_method_compat(buses, "_update_bus", get_index());
 	ur->commit_action();
 }
 
@@ -1050,10 +1050,10 @@ void EditorAudioBuses::_add_bus() {
 	UndoRedo *ur = EditorNode::get_undo_redo();
 
 	ur->create_action(TTR("Add Audio Bus"));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count() + 1);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count());
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count() + 1);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count());
+	ur->add_do_method_compat(this, "_update_buses");
+	ur->add_undo_method_compat(this, "_update_buses");
 	ur->commit_action();
 }
 
@@ -1082,20 +1082,20 @@ void EditorAudioBuses::_delete_bus(Object *p_which) {
 	UndoRedo *ur = EditorNode::get_undo_redo();
 
 	ur->create_action(TTR("Delete Audio Bus"));
-	ur->add_do_method(AudioServer::get_singleton(), "remove_bus", index);
-	ur->add_undo_method(AudioServer::get_singleton(), "add_bus", index);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_name", index, AudioServer::get_singleton()->get_bus_name(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", index, AudioServer::get_singleton()->get_bus_volume_db(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_send", index, AudioServer::get_singleton()->get_bus_send(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_solo", index, AudioServer::get_singleton()->is_bus_solo(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_mute", index, AudioServer::get_singleton()->is_bus_mute(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_bypass_effects", index, AudioServer::get_singleton()->is_bus_bypassing_effects(index));
+	ur->add_do_method_compat(AudioServer::get_singleton(), "remove_bus", index);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "add_bus", index);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_name", index, AudioServer::get_singleton()->get_bus_name(index));
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_volume_db", index, AudioServer::get_singleton()->get_bus_volume_db(index));
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_send", index, AudioServer::get_singleton()->get_bus_send(index));
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_solo", index, AudioServer::get_singleton()->is_bus_solo(index));
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_mute", index, AudioServer::get_singleton()->is_bus_mute(index));
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_bypass_effects", index, AudioServer::get_singleton()->is_bus_bypassing_effects(index));
 	for (int i = 0; i < AudioServer::get_singleton()->get_bus_effect_count(index); i++) {
-		ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", index, AudioServer::get_singleton()->get_bus_effect(index, i));
-		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", index, i, AudioServer::get_singleton()->is_bus_effect_enabled(index, i));
+		ur->add_undo_method_compat(AudioServer::get_singleton(), "add_bus_effect", index, AudioServer::get_singleton()->get_bus_effect(index, i));
+		ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_effect_enabled", index, i, AudioServer::get_singleton()->is_bus_effect_enabled(index, i));
 	}
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method_compat(this, "_update_buses");
+	ur->add_undo_method_compat(this, "_update_buses");
 	ur->commit_action();
 }
 
@@ -1103,20 +1103,20 @@ void EditorAudioBuses::_duplicate_bus(int p_which) {
 	int add_at_pos = p_which + 1;
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Duplicate Audio Bus"));
-	ur->add_do_method(AudioServer::get_singleton(), "add_bus", add_at_pos);
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_name", add_at_pos, AudioServer::get_singleton()->get_bus_name(p_which) + " Copy");
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", add_at_pos, AudioServer::get_singleton()->get_bus_volume_db(p_which));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_send", add_at_pos, AudioServer::get_singleton()->get_bus_send(p_which));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_solo", add_at_pos, AudioServer::get_singleton()->is_bus_solo(p_which));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_mute", add_at_pos, AudioServer::get_singleton()->is_bus_mute(p_which));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_bypass_effects", add_at_pos, AudioServer::get_singleton()->is_bus_bypassing_effects(p_which));
+	ur->add_do_method_compat(AudioServer::get_singleton(), "add_bus", add_at_pos);
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_name", add_at_pos, AudioServer::get_singleton()->get_bus_name(p_which) + " Copy");
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_volume_db", add_at_pos, AudioServer::get_singleton()->get_bus_volume_db(p_which));
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_send", add_at_pos, AudioServer::get_singleton()->get_bus_send(p_which));
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_solo", add_at_pos, AudioServer::get_singleton()->is_bus_solo(p_which));
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_mute", add_at_pos, AudioServer::get_singleton()->is_bus_mute(p_which));
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_bypass_effects", add_at_pos, AudioServer::get_singleton()->is_bus_bypassing_effects(p_which));
 	for (int i = 0; i < AudioServer::get_singleton()->get_bus_effect_count(p_which); i++) {
-		ur->add_do_method(AudioServer::get_singleton(), "add_bus_effect", add_at_pos, AudioServer::get_singleton()->get_bus_effect(p_which, i));
-		ur->add_do_method(AudioServer::get_singleton(), "set_bus_effect_enabled", add_at_pos, i, AudioServer::get_singleton()->is_bus_effect_enabled(p_which, i));
+		ur->add_do_method_compat(AudioServer::get_singleton(), "add_bus_effect", add_at_pos, AudioServer::get_singleton()->get_bus_effect(p_which, i));
+		ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_effect_enabled", add_at_pos, i, AudioServer::get_singleton()->is_bus_effect_enabled(p_which, i));
 	}
-	ur->add_undo_method(AudioServer::get_singleton(), "remove_bus", add_at_pos);
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "remove_bus", add_at_pos);
+	ur->add_do_method_compat(this, "_update_buses");
+	ur->add_undo_method_compat(this, "_update_buses");
 	ur->commit_action();
 }
 
@@ -1126,10 +1126,10 @@ void EditorAudioBuses::_reset_bus_volume(Object *p_which) {
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Reset Bus Volume"));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", index, 0.f);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", index, AudioServer::get_singleton()->get_bus_volume_db(index));
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method_compat(AudioServer::get_singleton(), "set_bus_volume_db", index, 0.f);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "set_bus_volume_db", index, AudioServer::get_singleton()->get_bus_volume_db(index));
+	ur->add_do_method_compat(this, "_update_buses");
+	ur->add_undo_method_compat(this, "_update_buses");
 	ur->commit_action();
 }
 
@@ -1147,13 +1147,13 @@ void EditorAudioBuses::_drop_at_index(int p_bus, int p_index) {
 	UndoRedo *ur = EditorNode::get_undo_redo();
 	ur->create_action(TTR("Move Audio Bus"));
 
-	ur->add_do_method(AudioServer::get_singleton(), "move_bus", p_bus, p_index);
+	ur->add_do_method_compat(AudioServer::get_singleton(), "move_bus", p_bus, p_index);
 	int real_bus = p_index > p_bus ? p_bus : p_bus + 1;
 	int real_index = p_index > p_bus ? p_index - 1 : p_index;
-	ur->add_undo_method(AudioServer::get_singleton(), "move_bus", real_index, real_bus);
+	ur->add_undo_method_compat(AudioServer::get_singleton(), "move_bus", real_index, real_bus);
 
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method_compat(this, "_update_buses");
+	ur->add_undo_method_compat(this, "_update_buses");
 	ur->commit_action();
 }
 

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -176,18 +176,18 @@ void EditorAutoloadSettings::_autoload_edited() {
 		undo_redo->create_action(TTR("Rename Autoload"));
 
 		undo_redo->add_do_property(ProjectSettings::get_singleton(), name, path);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", name, order);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", selected_autoload);
+		undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set_order", name, order);
+		undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "clear", selected_autoload);
 
 		undo_redo->add_undo_property(ProjectSettings::get_singleton(), selected_autoload, path);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", selected_autoload, order);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", name);
+		undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", selected_autoload, order);
+		undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "clear", name);
 
-		undo_redo->add_do_method(this, "call_deferred", "update_autoload");
-		undo_redo->add_undo_method(this, "call_deferred", "update_autoload");
+		undo_redo->add_do_method_compat(this, "call_deferred", "update_autoload");
+		undo_redo->add_undo_method_compat(this, "call_deferred", "update_autoload");
 
-		undo_redo->add_do_method(this, "emit_signal", autoload_changed);
-		undo_redo->add_undo_method(this, "emit_signal", autoload_changed);
+		undo_redo->add_do_method_compat(this, "emit_signal", autoload_changed);
+		undo_redo->add_undo_method_compat(this, "emit_signal", autoload_changed);
 
 		undo_redo->commit_action();
 
@@ -215,14 +215,14 @@ void EditorAutoloadSettings::_autoload_edited() {
 		undo_redo->add_do_property(ProjectSettings::get_singleton(), base, path);
 		undo_redo->add_undo_property(ProjectSettings::get_singleton(), base, ProjectSettings::get_singleton()->get(base));
 
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", base, order);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", base, order);
+		undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set_order", base, order);
+		undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", base, order);
 
-		undo_redo->add_do_method(this, "call_deferred", "update_autoload");
-		undo_redo->add_undo_method(this, "call_deferred", "update_autoload");
+		undo_redo->add_do_method_compat(this, "call_deferred", "update_autoload");
+		undo_redo->add_undo_method_compat(this, "call_deferred", "update_autoload");
 
-		undo_redo->add_do_method(this, "emit_signal", autoload_changed);
-		undo_redo->add_undo_method(this, "emit_signal", autoload_changed);
+		undo_redo->add_do_method_compat(this, "emit_signal", autoload_changed);
+		undo_redo->add_undo_method_compat(this, "emit_signal", autoload_changed);
 
 		undo_redo->commit_action();
 	}
@@ -262,17 +262,17 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 
 			undo_redo->create_action(TTR("Move Autoload"));
 
-			undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", name, swap_order);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", name, order);
+			undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set_order", name, swap_order);
+			undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", name, order);
 
-			undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", swap_name, order);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", swap_name, swap_order);
+			undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set_order", swap_name, order);
+			undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", swap_name, swap_order);
 
-			undo_redo->add_do_method(this, "update_autoload");
-			undo_redo->add_undo_method(this, "update_autoload");
+			undo_redo->add_do_method_compat(this, "update_autoload");
+			undo_redo->add_undo_method_compat(this, "update_autoload");
 
-			undo_redo->add_do_method(this, "emit_signal", autoload_changed);
-			undo_redo->add_undo_method(this, "emit_signal", autoload_changed);
+			undo_redo->add_do_method_compat(this, "emit_signal", autoload_changed);
+			undo_redo->add_undo_method_compat(this, "emit_signal", autoload_changed);
 
 			undo_redo->commit_action();
 		} break;
@@ -284,14 +284,14 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 			undo_redo->add_do_property(ProjectSettings::get_singleton(), name, Variant());
 
 			undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, ProjectSettings::get_singleton()->get(name));
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_persisting", name, true);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", order);
+			undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_persisting", name, true);
+			undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", order);
 
-			undo_redo->add_do_method(this, "update_autoload");
-			undo_redo->add_undo_method(this, "update_autoload");
+			undo_redo->add_do_method_compat(this, "update_autoload");
+			undo_redo->add_undo_method_compat(this, "update_autoload");
 
-			undo_redo->add_do_method(this, "emit_signal", autoload_changed);
-			undo_redo->add_undo_method(this, "emit_signal", autoload_changed);
+			undo_redo->add_do_method_compat(this, "emit_signal", autoload_changed);
+			undo_redo->add_undo_method_compat(this, "emit_signal", autoload_changed);
 
 			undo_redo->commit_action();
 		} break;
@@ -662,17 +662,17 @@ void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &
 	i = 0;
 
 	for (List<AutoLoadInfo>::Element *F = autoload_cache.front(); F; F = F->next()) {
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", "autoload/" + F->get().name, orders[i++]);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", "autoload/" + F->get().name, F->get().order);
+		undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set_order", "autoload/" + F->get().name, orders[i++]);
+		undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", "autoload/" + F->get().name, F->get().order);
 	}
 
 	orders.clear();
 
-	undo_redo->add_do_method(this, "update_autoload");
-	undo_redo->add_undo_method(this, "update_autoload");
+	undo_redo->add_do_method_compat(this, "update_autoload");
+	undo_redo->add_undo_method_compat(this, "update_autoload");
 
-	undo_redo->add_do_method(this, "emit_signal", autoload_changed);
-	undo_redo->add_undo_method(this, "emit_signal", autoload_changed);
+	undo_redo->add_do_method_compat(this, "emit_signal", autoload_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", autoload_changed);
 
 	undo_redo->commit_action();
 }
@@ -711,11 +711,11 @@ bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_
 		undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, Variant());
 	}
 
-	undo_redo->add_do_method(this, "update_autoload");
-	undo_redo->add_undo_method(this, "update_autoload");
+	undo_redo->add_do_method_compat(this, "update_autoload");
+	undo_redo->add_undo_method_compat(this, "update_autoload");
 
-	undo_redo->add_do_method(this, "emit_signal", autoload_changed);
-	undo_redo->add_undo_method(this, "emit_signal", autoload_changed);
+	undo_redo->add_do_method_compat(this, "emit_signal", autoload_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", autoload_changed);
 
 	undo_redo->commit_action();
 
@@ -734,14 +734,14 @@ void EditorAutoloadSettings::autoload_remove(const String &p_name) {
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, Variant());
 
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, ProjectSettings::get_singleton()->get(name));
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_persisting", name, true);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", order);
+	undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_persisting", name, true);
+	undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", order);
 
-	undo_redo->add_do_method(this, "update_autoload");
-	undo_redo->add_undo_method(this, "update_autoload");
+	undo_redo->add_do_method_compat(this, "update_autoload");
+	undo_redo->add_undo_method_compat(this, "update_autoload");
 
-	undo_redo->add_do_method(this, "emit_signal", autoload_changed);
-	undo_redo->add_undo_method(this, "emit_signal", autoload_changed);
+	undo_redo->add_do_method_compat(this, "emit_signal", autoload_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", autoload_changed);
 
 	undo_redo->commit_action();
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2223,11 +2223,11 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		undo_redo->add_undo_property(object, p_name, object->get(p_name));
 
 		if (p_refresh_all) {
-			undo_redo->add_do_method(this, "_edit_request_change", object, "");
-			undo_redo->add_undo_method(this, "_edit_request_change", object, "");
+			undo_redo->add_do_method_compat(this, "_edit_request_change", object, "");
+			undo_redo->add_undo_method_compat(this, "_edit_request_change", object, "");
 		} else {
-			undo_redo->add_do_method(this, "_edit_request_change", object, p_name);
-			undo_redo->add_undo_method(this, "_edit_request_change", object, p_name);
+			undo_redo->add_do_method_compat(this, "_edit_request_change", object, p_name);
+			undo_redo->add_undo_method_compat(this, "_edit_request_change", object, p_name);
 		}
 
 		Resource *r = Object::cast_to<Resource>(object);
@@ -2236,15 +2236,15 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 				bool prev = object->get(p_name);
 				bool next = p_value;
 				if (next) {
-					undo_redo->add_do_method(r, "setup_local_to_scene");
+					undo_redo->add_do_method_compat(r, "setup_local_to_scene");
 				}
 				if (prev) {
-					undo_redo->add_undo_method(r, "setup_local_to_scene");
+					undo_redo->add_undo_method_compat(r, "setup_local_to_scene");
 				}
 			}
 		}
-		undo_redo->add_do_method(this, "emit_signal", _prop_edited, p_name);
-		undo_redo->add_undo_method(this, "emit_signal", _prop_edited, p_name);
+		undo_redo->add_do_method_compat(this, "emit_signal", _prop_edited, p_name);
+		undo_redo->add_undo_method_compat(this, "emit_signal", _prop_edited, p_name);
 		undo_redo->commit_action();
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4814,13 +4814,13 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 	uint64_t next_scene_version = editor_data.get_scene_version(p_tab);
 
 	editor_data.get_undo_redo().create_action(TTR("Switch Scene Tab"));
-	editor_data.get_undo_redo().add_do_method(this, "set_current_version", unsaved ? saved_version : 0);
-	editor_data.get_undo_redo().add_do_method(this, "set_current_scene", p_tab);
-	editor_data.get_undo_redo().add_do_method(this, "set_current_version", next_scene_version == 0 ? editor_data.get_undo_redo().get_version() + 1 : next_scene_version);
+	editor_data.get_undo_redo().add_do_method_compat(this, "set_current_version", unsaved ? saved_version : 0);
+	editor_data.get_undo_redo().add_do_method_compat(this, "set_current_scene", p_tab);
+	editor_data.get_undo_redo().add_do_method_compat(this, "set_current_version", next_scene_version == 0 ? editor_data.get_undo_redo().get_version() + 1 : next_scene_version);
 
-	editor_data.get_undo_redo().add_undo_method(this, "set_current_version", next_scene_version);
-	editor_data.get_undo_redo().add_undo_method(this, "set_current_scene", editor_data.get_edited_scene());
-	editor_data.get_undo_redo().add_undo_method(this, "set_current_version", saved_version);
+	editor_data.get_undo_redo().add_undo_method_compat(this, "set_current_version", next_scene_version);
+	editor_data.get_undo_redo().add_undo_method_compat(this, "set_current_scene", editor_data.get_edited_scene());
+	editor_data.get_undo_redo().add_undo_method_compat(this, "set_current_version", saved_version);
 	editor_data.get_undo_redo().commit_action();
 }
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -132,20 +132,20 @@ void GroupDialog::_add_pressed() {
 
 	while (selected) {
 		Node *node = scene_tree->get_edited_scene_root()->get_node(selected->get_metadata(0));
-		undo_redo->add_do_method(node, "add_to_group", selected_group, true);
-		undo_redo->add_undo_method(node, "remove_from_group", selected_group);
+		undo_redo->add_do_method_compat(node, "add_to_group", selected_group, true);
+		undo_redo->add_undo_method_compat(node, "remove_from_group", selected_group);
 
 		selected = nodes_to_add->get_next_selected(selected);
 	}
 
-	undo_redo->add_do_method(this, "_group_selected");
-	undo_redo->add_undo_method(this, "_group_selected");
-	undo_redo->add_do_method(this, "emit_signal", "group_edited");
-	undo_redo->add_undo_method(this, "emit_signal", "group_edited");
+	undo_redo->add_do_method_compat(this, "_group_selected");
+	undo_redo->add_undo_method_compat(this, "_group_selected");
+	undo_redo->add_do_method_compat(this, "emit_signal", "group_edited");
+	undo_redo->add_undo_method_compat(this, "emit_signal", "group_edited");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -161,20 +161,20 @@ void GroupDialog::_removed_pressed() {
 
 	while (selected) {
 		Node *node = scene_tree->get_edited_scene_root()->get_node(selected->get_metadata(0));
-		undo_redo->add_do_method(node, "remove_from_group", selected_group);
-		undo_redo->add_undo_method(node, "add_to_group", selected_group, true);
+		undo_redo->add_do_method_compat(node, "remove_from_group", selected_group);
+		undo_redo->add_undo_method_compat(node, "add_to_group", selected_group, true);
 
 		selected = nodes_to_add->get_next_selected(selected);
 	}
 
-	undo_redo->add_do_method(this, "_group_selected");
-	undo_redo->add_undo_method(this, "_group_selected");
-	undo_redo->add_do_method(this, "emit_signal", "group_edited");
-	undo_redo->add_undo_method(this, "emit_signal", "group_edited");
+	undo_redo->add_do_method_compat(this, "_group_selected");
+	undo_redo->add_undo_method_compat(this, "_group_selected");
+	undo_redo->add_do_method_compat(this, "emit_signal", "group_edited");
+	undo_redo->add_undo_method_compat(this, "emit_signal", "group_edited");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -243,26 +243,26 @@ void GroupDialog::_group_renamed() {
 	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
 		Node *node = E->get();
 		if (_can_edit(node, selected_group)) {
-			undo_redo->add_do_method(node, "remove_from_group", selected_group);
-			undo_redo->add_undo_method(node, "remove_from_group", name);
-			undo_redo->add_do_method(node, "add_to_group", name, true);
-			undo_redo->add_undo_method(node, "add_to_group", selected_group, true);
+			undo_redo->add_do_method_compat(node, "remove_from_group", selected_group);
+			undo_redo->add_undo_method_compat(node, "remove_from_group", name);
+			undo_redo->add_do_method_compat(node, "add_to_group", name, true);
+			undo_redo->add_undo_method_compat(node, "add_to_group", selected_group, true);
 		} else {
 			removed_all = false;
 		}
 	}
 
 	if (!removed_all) {
-		undo_redo->add_do_method(this, "_add_group", selected_group);
-		undo_redo->add_undo_method(this, "_delete_group_item", selected_group);
+		undo_redo->add_do_method_compat(this, "_add_group", selected_group);
+		undo_redo->add_undo_method_compat(this, "_delete_group_item", selected_group);
 	}
 
-	undo_redo->add_do_method(this, "_rename_group_item", selected_group, name);
-	undo_redo->add_undo_method(this, "_rename_group_item", name, selected_group);
-	undo_redo->add_do_method(this, "_group_selected");
-	undo_redo->add_undo_method(this, "_group_selected");
-	undo_redo->add_do_method(this, "emit_signal", "group_edited");
-	undo_redo->add_undo_method(this, "emit_signal", "group_edited");
+	undo_redo->add_do_method_compat(this, "_rename_group_item", selected_group, name);
+	undo_redo->add_undo_method_compat(this, "_rename_group_item", name, selected_group);
+	undo_redo->add_do_method_compat(this, "_group_selected");
+	undo_redo->add_undo_method_compat(this, "_group_selected");
+	undo_redo->add_do_method_compat(this, "emit_signal", "group_edited");
+	undo_redo->add_undo_method_compat(this, "emit_signal", "group_edited");
 
 	undo_redo->commit_action();
 }
@@ -313,26 +313,26 @@ void GroupDialog::_delete_group_pressed(Object *p_item, int p_column, int p_id) 
 	bool removed_all = true;
 	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
 		if (_can_edit(E->get(), name)) {
-			undo_redo->add_do_method(E->get(), "remove_from_group", name);
-			undo_redo->add_undo_method(E->get(), "add_to_group", name, true);
+			undo_redo->add_do_method_compat(E->get(), "remove_from_group", name);
+			undo_redo->add_undo_method_compat(E->get(), "add_to_group", name, true);
 		} else {
 			removed_all = false;
 		}
 	}
 
 	if (removed_all) {
-		undo_redo->add_do_method(this, "_delete_group_item", name);
-		undo_redo->add_undo_method(this, "_add_group", name);
+		undo_redo->add_do_method_compat(this, "_delete_group_item", name);
+		undo_redo->add_undo_method_compat(this, "_add_group", name);
 	}
 
-	undo_redo->add_do_method(this, "_group_selected");
-	undo_redo->add_undo_method(this, "_group_selected");
-	undo_redo->add_do_method(this, "emit_signal", "group_edited");
-	undo_redo->add_undo_method(this, "emit_signal", "group_edited");
+	undo_redo->add_do_method_compat(this, "_group_selected");
+	undo_redo->add_undo_method_compat(this, "_group_selected");
+	undo_redo->add_do_method_compat(this, "emit_signal", "group_edited");
+	undo_redo->add_undo_method_compat(this, "emit_signal", "group_edited");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -561,14 +561,14 @@ void GroupsEditor::_add_group(const String &p_group) {
 
 	undo_redo->create_action(TTR("Add to Group"));
 
-	undo_redo->add_do_method(node, "add_to_group", name, true);
-	undo_redo->add_undo_method(node, "remove_from_group", name);
-	undo_redo->add_do_method(this, "update_tree");
-	undo_redo->add_undo_method(this, "update_tree");
+	undo_redo->add_do_method_compat(node, "add_to_group", name, true);
+	undo_redo->add_undo_method_compat(node, "remove_from_group", name);
+	undo_redo->add_do_method_compat(this, "update_tree");
+	undo_redo->add_undo_method_compat(this, "update_tree");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 
@@ -589,14 +589,14 @@ void GroupsEditor::_remove_group(Object *p_item, int p_column, int p_id) {
 
 	undo_redo->create_action(TTR("Remove from Group"));
 
-	undo_redo->add_do_method(node, "remove_from_group", name);
-	undo_redo->add_undo_method(node, "add_to_group", name, true);
-	undo_redo->add_do_method(this, "update_tree");
-	undo_redo->add_undo_method(this, "update_tree");
+	undo_redo->add_do_method_compat(node, "remove_from_group", name);
+	undo_redo->add_undo_method_compat(node, "add_to_group", name, true);
+	undo_redo->add_do_method_compat(this, "update_tree");
+	undo_redo->add_undo_method_compat(this, "update_tree");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }

--- a/editor/input_map_editor.cpp
+++ b/editor/input_map_editor.cpp
@@ -118,16 +118,16 @@ void InputMapEditor::_action_edited() {
 
 		setting = true;
 		undo_redo->create_action(TTR("Rename Input Action Event"));
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", add_at);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", action_prop, action);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", action_prop, order);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", action_prop);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", add_at, action);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", add_at, order);
-		undo_redo->add_do_method(this, "_update_actions");
-		undo_redo->add_undo_method(this, "_update_actions");
-		undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
-		undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+		undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "clear", add_at);
+		undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set", action_prop, action);
+		undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set_order", action_prop, order);
+		undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "clear", action_prop);
+		undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set", add_at, action);
+		undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", add_at, order);
+		undo_redo->add_do_method_compat(this, "_update_actions");
+		undo_redo->add_undo_method_compat(this, "_update_actions");
+		undo_redo->add_do_method_compat(this, "emit_signal", inputmap_changed);
+		undo_redo->add_undo_method_compat(this, "emit_signal", inputmap_changed);
 		undo_redo->commit_action();
 		setting = false;
 
@@ -139,10 +139,10 @@ void InputMapEditor::_action_edited() {
 		new_action["deadzone"] = ti->get_range(1);
 
 		undo_redo->create_action(TTR("Change Action deadzone"));
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, new_action);
-		undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_action);
-		undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+		undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set", name, new_action);
+		undo_redo->add_do_method_compat(this, "emit_signal", inputmap_changed);
+		undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set", name, old_action);
+		undo_redo->add_undo_method_compat(this, "emit_signal", inputmap_changed);
 		undo_redo->commit_action();
 	}
 }
@@ -227,12 +227,12 @@ void InputMapEditor::_device_input_add() {
 	action["events"] = events;
 
 	undo_redo->create_action(TTR("Add Input Action Event"));
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
-	undo_redo->add_do_method(this, "_update_actions");
-	undo_redo->add_undo_method(this, "_update_actions");
-	undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
-	undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+	undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set", name, action);
+	undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set", name, old_val);
+	undo_redo->add_do_method_compat(this, "_update_actions");
+	undo_redo->add_undo_method_compat(this, "_update_actions");
+	undo_redo->add_do_method_compat(this, "emit_signal", inputmap_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", inputmap_changed);
 	undo_redo->commit_action();
 
 	_show_last_added(ie, name);
@@ -303,12 +303,12 @@ void InputMapEditor::_press_a_key_confirm() {
 	action["events"] = events;
 
 	undo_redo->create_action(TTR("Add Input Action Event"));
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
-	undo_redo->add_do_method(this, "_update_actions");
-	undo_redo->add_undo_method(this, "_update_actions");
-	undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
-	undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+	undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set", name, action);
+	undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set", name, old_val);
+	undo_redo->add_do_method_compat(this, "_update_actions");
+	undo_redo->add_undo_method_compat(this, "_update_actions");
+	undo_redo->add_do_method_compat(this, "emit_signal", inputmap_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", inputmap_changed);
 	undo_redo->commit_action();
 
 	_show_last_added(ie, name);
@@ -572,13 +572,13 @@ void InputMapEditor::_action_button_pressed(Object *p_obj, int p_column, int p_i
 			int order = ProjectSettings::get_singleton()->get_order(name);
 
 			undo_redo->create_action(TTR("Erase Input Action"));
-			undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", name);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", name, order);
-			undo_redo->add_do_method(this, "_update_actions");
-			undo_redo->add_undo_method(this, "_update_actions");
-			undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
-			undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+			undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "clear", name);
+			undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set", name, old_val);
+			undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", name, order);
+			undo_redo->add_do_method_compat(this, "_update_actions");
+			undo_redo->add_undo_method_compat(this, "_update_actions");
+			undo_redo->add_do_method_compat(this, "emit_signal", inputmap_changed);
+			undo_redo->add_undo_method_compat(this, "emit_signal", inputmap_changed);
 			undo_redo->commit_action();
 
 		} else {
@@ -594,12 +594,12 @@ void InputMapEditor::_action_button_pressed(Object *p_obj, int p_column, int p_i
 			action["events"] = events;
 
 			undo_redo->create_action(TTR("Erase Input Action Event"));
-			undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
-			undo_redo->add_do_method(this, "_update_actions");
-			undo_redo->add_undo_method(this, "_update_actions");
-			undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
-			undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+			undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set", name, action);
+			undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set", name, old_val);
+			undo_redo->add_do_method_compat(this, "_update_actions");
+			undo_redo->add_undo_method_compat(this, "_update_actions");
+			undo_redo->add_do_method_compat(this, "emit_signal", inputmap_changed);
+			undo_redo->add_undo_method_compat(this, "emit_signal", inputmap_changed);
 			undo_redo->commit_action();
 		}
 	} else if (p_id == 3) {
@@ -797,12 +797,12 @@ void InputMapEditor::_action_add() {
 	action["deadzone"] = 0.5f;
 	String name = "input/" + action_name->get_text();
 	undo_redo->create_action(TTR("Add Input Action"));
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", name);
-	undo_redo->add_do_method(this, "_update_actions");
-	undo_redo->add_undo_method(this, "_update_actions");
-	undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
-	undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+	undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set", name, action);
+	undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "clear", name);
+	undo_redo->add_do_method_compat(this, "_update_actions");
+	undo_redo->add_undo_method_compat(this, "_update_actions");
+	undo_redo->add_do_method_compat(this, "emit_signal", inputmap_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", inputmap_changed);
 	undo_redo->commit_action();
 
 	TreeItem *r = input_editor->get_root();
@@ -887,21 +887,21 @@ void InputMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 	while (iterator != target) {
 		String iterator_name = "input/" + iterator->get_text(0);
 		int iterator_order = ProjectSettings::get_singleton()->get_order(iterator_name);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", iterator_name, order);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", iterator_name, iterator_order);
+		undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set_order", iterator_name, order);
+		undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", iterator_name, iterator_order);
 		order = iterator_order;
 		iterator = is_below ? iterator->get_next() : iterator->get_prev();
 	}
 
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", target_name, order);
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", selected_name, target_order);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", target_name, target_order);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", selected_name, old_order);
+	undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set_order", target_name, order);
+	undo_redo->add_do_method_compat(ProjectSettings::get_singleton(), "set_order", selected_name, target_order);
+	undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", target_name, target_order);
+	undo_redo->add_undo_method_compat(ProjectSettings::get_singleton(), "set_order", selected_name, old_order);
 
-	undo_redo->add_do_method(this, "_update_actions");
-	undo_redo->add_undo_method(this, "_update_actions");
-	undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
-	undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+	undo_redo->add_do_method_compat(this, "_update_actions");
+	undo_redo->add_undo_method_compat(this, "_update_actions");
+	undo_redo->add_do_method_compat(this, "emit_signal", inputmap_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", inputmap_changed);
 	undo_redo->commit_action();
 }
 

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -95,10 +95,10 @@ void LocalizationEditor::_translation_add(const PackedStringArray &p_paths) {
 	undo_redo->create_action(vformat(TTR("Add %d Translations"), p_paths.size()));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations", translations);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations", ProjectSettings::get_singleton()->get("locale/translations"));
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 
@@ -121,10 +121,10 @@ void LocalizationEditor::_translation_delete(Object *p_item, int p_column, int p
 	undo_redo->create_action(TTR("Remove Translation"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations", translations);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations", ProjectSettings::get_singleton()->get("locale/translations"));
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 
@@ -151,10 +151,10 @@ void LocalizationEditor::_translation_res_add(const PackedStringArray &p_paths) 
 	undo_redo->create_action(vformat(TTR("Translation Resource Remap: Add %d Path(s)"), p_paths.size()));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", prev);
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 
@@ -182,10 +182,10 @@ void LocalizationEditor::_translation_res_option_add(const PackedStringArray &p_
 	undo_redo->create_action(vformat(TTR("Translation Resource Remap: Add %d Remap(s)"), p_paths.size()));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 
@@ -236,10 +236,10 @@ void LocalizationEditor::_translation_res_option_changed() {
 	undo_redo->create_action(TTR("Change Resource Remap Language"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 	updating_translations = false;
 }
@@ -265,10 +265,10 @@ void LocalizationEditor::_translation_res_delete(Object *p_item, int p_column, i
 	undo_redo->create_action(TTR("Remove Resource Remap"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 
@@ -300,10 +300,10 @@ void LocalizationEditor::_translation_res_option_delete(Object *p_item, int p_co
 	undo_redo->create_action(TTR("Remove Resource Remap Option"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 
@@ -348,10 +348,10 @@ void LocalizationEditor::_translation_filter_option_changed() {
 	undo_redo->create_action(TTR("Changed Locale Filter"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/locale_filter", f_locales_all);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/locale_filter", prev);
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 
@@ -380,10 +380,10 @@ void LocalizationEditor::_translation_filter_mode_changed(int p_mode) {
 	undo_redo->create_action(TTR("Changed Locale Filter Mode"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/locale_filter", f_locales_all);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/locale_filter", prev);
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 
@@ -403,10 +403,10 @@ void LocalizationEditor::_pot_add(const PackedStringArray &p_paths) {
 	undo_redo->create_action(vformat(TTR("Add %d file(s) for POT generation"), p_paths.size()));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", pot_translations);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", ProjectSettings::get_singleton()->get("locale/translations_pot_files"));
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 
@@ -425,10 +425,10 @@ void LocalizationEditor::_pot_delete(Object *p_item, int p_column, int p_button)
 	undo_redo->create_action(TTR("Remove file from POT generation"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", pot_translations);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", ProjectSettings::get_singleton()->get("locale/translations_pot_files"));
-	undo_redo->add_do_method(this, "update_translations");
-	undo_redo->add_undo_method(this, "update_translations");
-	undo_redo->add_do_method(this, "emit_signal", localization_changed);
-	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->add_do_method_compat(this, "update_translations");
+	undo_redo->add_undo_method_compat(this, "update_translations");
+	undo_redo->add_do_method_compat(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method_compat(this, "emit_signal", localization_changed);
 	undo_redo->commit_action();
 }
 

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -80,8 +80,8 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 
 		ur->add_undo_property(n, name, n->get(name));
 	}
-	ur->add_do_method(EditorNode::get_singleton()->get_inspector(), "refresh");
-	ur->add_undo_method(EditorNode::get_singleton()->get_inspector(), "refresh");
+	ur->add_do_method_compat(EditorNode::get_singleton()->get_inspector(), "refresh");
+	ur->add_undo_method_compat(EditorNode::get_singleton()->get_inspector(), "refresh");
 
 	ur->commit_action();
 	return true;

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -899,14 +899,14 @@ void Light3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, co
 	} else if (p_idx == 0) {
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Light Radius"));
-		ur->add_do_method(light, "set_param", Light3D::PARAM_RANGE, light->get_param(Light3D::PARAM_RANGE));
-		ur->add_undo_method(light, "set_param", Light3D::PARAM_RANGE, p_restore);
+		ur->add_do_method_compat(light, "set_param", Light3D::PARAM_RANGE, light->get_param(Light3D::PARAM_RANGE));
+		ur->add_undo_method_compat(light, "set_param", Light3D::PARAM_RANGE, p_restore);
 		ur->commit_action();
 	} else if (p_idx == 1) {
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Light Radius"));
-		ur->add_do_method(light, "set_param", Light3D::PARAM_SPOT_ANGLE, light->get_param(Light3D::PARAM_SPOT_ANGLE));
-		ur->add_undo_method(light, "set_param", Light3D::PARAM_SPOT_ANGLE, p_restore);
+		ur->add_do_method_compat(light, "set_param", Light3D::PARAM_SPOT_ANGLE, light->get_param(Light3D::PARAM_SPOT_ANGLE));
+		ur->add_undo_method_compat(light, "set_param", Light3D::PARAM_SPOT_ANGLE, p_restore);
 		ur->commit_action();
 	}
 }
@@ -1124,8 +1124,8 @@ void AudioStreamPlayer3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, i
 	} else {
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change AudioStreamPlayer3D Emission Angle"));
-		ur->add_do_method(player, "set_emission_angle", player->get_emission_angle());
-		ur->add_undo_method(player, "set_emission_angle", p_restore);
+		ur->add_do_method_compat(player, "set_emission_angle", player->get_emission_angle());
+		ur->add_undo_method_compat(player, "set_emission_angle", p_restore);
 		ur->commit_action();
 	}
 }
@@ -2208,8 +2208,8 @@ void VisibilityNotifier3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, 
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Change Notifier AABB"));
-	ur->add_do_method(notifier, "set_aabb", notifier->get_aabb());
-	ur->add_undo_method(notifier, "set_aabb", p_restore);
+	ur->add_do_method_compat(notifier, "set_aabb", notifier->get_aabb());
+	ur->add_undo_method_compat(notifier, "set_aabb", p_restore);
 	ur->commit_action();
 }
 
@@ -2399,8 +2399,8 @@ void GPUParticles3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Change Particles AABB"));
-	ur->add_do_method(particles, "set_visibility_aabb", particles->get_visibility_aabb());
-	ur->add_undo_method(particles, "set_visibility_aabb", p_restore);
+	ur->add_do_method_compat(particles, "set_visibility_aabb", particles->get_visibility_aabb());
+	ur->add_undo_method_compat(particles, "set_visibility_aabb", p_restore);
 	ur->commit_action();
 }
 
@@ -2562,8 +2562,8 @@ void GPUParticlesCollision3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizm
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Radius"));
-		ur->add_do_method(sn, "set_radius", sn->call("get_radius"));
-		ur->add_undo_method(sn, "set_radius", p_restore);
+		ur->add_do_method_compat(sn, "set_radius", sn->call("get_radius"));
+		ur->add_undo_method_compat(sn, "set_radius", p_restore);
 		ur->commit_action();
 	}
 
@@ -2575,8 +2575,8 @@ void GPUParticlesCollision3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizm
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Box Shape Extents"));
-		ur->add_do_method(sn, "set_extents", sn->call("get_extents"));
-		ur->add_undo_method(sn, "set_extents", p_restore);
+		ur->add_do_method_compat(sn, "set_extents", sn->call("get_extents"));
+		ur->add_undo_method_compat(sn, "set_extents", p_restore);
 		ur->commit_action();
 	}
 }
@@ -2835,10 +2835,10 @@ void ReflectionProbeGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Change Probe Extents"));
-	ur->add_do_method(probe, "set_extents", probe->get_extents());
-	ur->add_do_method(probe, "set_origin_offset", probe->get_origin_offset());
-	ur->add_undo_method(probe, "set_extents", restore.position);
-	ur->add_undo_method(probe, "set_origin_offset", restore.size);
+	ur->add_do_method_compat(probe, "set_extents", probe->get_extents());
+	ur->add_do_method_compat(probe, "set_origin_offset", probe->get_origin_offset());
+	ur->add_undo_method_compat(probe, "set_extents", restore.position);
+	ur->add_undo_method_compat(probe, "set_origin_offset", restore.size);
 	ur->commit_action();
 }
 
@@ -2987,8 +2987,8 @@ void DecalGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, cons
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Change Decal Extents"));
-	ur->add_do_method(decal, "set_extents", decal->get_extents());
-	ur->add_undo_method(decal, "set_extents", restore);
+	ur->add_do_method_compat(decal, "set_extents", decal->get_extents());
+	ur->add_undo_method_compat(decal, "set_extents", restore);
 	ur->commit_action();
 }
 
@@ -3128,8 +3128,8 @@ void GIProbeGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, co
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Change Probe Extents"));
-	ur->add_do_method(probe, "set_extents", probe->get_extents());
-	ur->add_undo_method(probe, "set_extents", restore);
+	ur->add_do_method_compat(probe, "set_extents", probe->get_extents());
+	ur->add_undo_method_compat(probe, "set_extents", restore);
 	ur->commit_action();
 }
 
@@ -3729,8 +3729,8 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Sphere Shape Radius"));
-		ur->add_do_method(ss.ptr(), "set_radius", ss->get_radius());
-		ur->add_undo_method(ss.ptr(), "set_radius", p_restore);
+		ur->add_do_method_compat(ss.ptr(), "set_radius", ss->get_radius());
+		ur->add_undo_method_compat(ss.ptr(), "set_radius", p_restore);
 		ur->commit_action();
 	}
 
@@ -3743,8 +3743,8 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Box Shape Size"));
-		ur->add_do_method(ss.ptr(), "set_size", ss->get_size());
-		ur->add_undo_method(ss.ptr(), "set_size", p_restore);
+		ur->add_do_method_compat(ss.ptr(), "set_size", ss->get_size());
+		ur->add_undo_method_compat(ss.ptr(), "set_size", p_restore);
 		ur->commit_action();
 	}
 
@@ -3762,12 +3762,12 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		if (p_idx == 0) {
 			ur->create_action(TTR("Change Capsule Shape Radius"));
-			ur->add_do_method(ss.ptr(), "set_radius", ss->get_radius());
-			ur->add_undo_method(ss.ptr(), "set_radius", p_restore);
+			ur->add_do_method_compat(ss.ptr(), "set_radius", ss->get_radius());
+			ur->add_undo_method_compat(ss.ptr(), "set_radius", p_restore);
 		} else {
 			ur->create_action(TTR("Change Capsule Shape Height"));
-			ur->add_do_method(ss.ptr(), "set_height", ss->get_height());
-			ur->add_undo_method(ss.ptr(), "set_height", p_restore);
+			ur->add_do_method_compat(ss.ptr(), "set_height", ss->get_height());
+			ur->add_undo_method_compat(ss.ptr(), "set_height", p_restore);
 		}
 
 		ur->commit_action();
@@ -3787,16 +3787,16 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		if (p_idx == 0) {
 			ur->create_action(TTR("Change Cylinder Shape Radius"));
-			ur->add_do_method(ss.ptr(), "set_radius", ss->get_radius());
-			ur->add_undo_method(ss.ptr(), "set_radius", p_restore);
+			ur->add_do_method_compat(ss.ptr(), "set_radius", ss->get_radius());
+			ur->add_undo_method_compat(ss.ptr(), "set_radius", p_restore);
 		} else {
 			ur->create_action(
 					///
 
 					////////
 					TTR("Change Cylinder Shape Height"));
-			ur->add_do_method(ss.ptr(), "set_height", ss->get_height());
-			ur->add_undo_method(ss.ptr(), "set_height", p_restore);
+			ur->add_do_method_compat(ss.ptr(), "set_height", ss->get_height());
+			ur->add_undo_method_compat(ss.ptr(), "set_height", p_restore);
 		}
 
 		ur->commit_action();
@@ -3811,8 +3811,8 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Ray Shape Length"));
-		ur->add_do_method(ss.ptr(), "set_length", ss->get_length());
-		ur->add_undo_method(ss.ptr(), "set_length", p_restore);
+		ur->add_do_method_compat(ss.ptr(), "set_length", ss->get_length());
+		ur->add_undo_method_compat(ss.ptr(), "set_length", p_restore);
 		ur->commit_action();
 	}
 }

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -87,8 +87,8 @@ void AbstractPolygon2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) 
 
 void AbstractPolygon2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
 	Node2D *node = _get_node();
-	undo_redo->add_do_method(node, "set_polygon", p_polygon);
-	undo_redo->add_undo_method(node, "set_polygon", p_previous);
+	undo_redo->add_do_method_compat(node, "set_polygon", p_polygon);
+	undo_redo->add_undo_method_compat(node, "set_polygon", p_previous);
 }
 
 Vector2 AbstractPolygon2DEditor::_get_offset(int p_idx) const {
@@ -96,8 +96,8 @@ Vector2 AbstractPolygon2DEditor::_get_offset(int p_idx) const {
 }
 
 void AbstractPolygon2DEditor::_commit_action() {
-	undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-	undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+	undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+	undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 	undo_redo->commit_action();
 }
 
@@ -198,8 +198,8 @@ void AbstractPolygon2DEditor::_wip_close() {
 		undo_redo->create_action(TTR("Create Polygon"));
 		_action_add_polygon(wip);
 		if (_has_uv()) {
-			undo_redo->add_do_method(_get_node(), "set_uv", Vector<Vector2>());
-			undo_redo->add_undo_method(_get_node(), "set_uv", _get_node()->get("uv"));
+			undo_redo->add_do_method_compat(_get_node(), "set_uv", Vector<Vector2>());
+			undo_redo->add_undo_method_compat(_get_node(), "set_uv", _get_node()->get("uv"));
 		}
 		_commit_action();
 	} else {

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -144,12 +144,12 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 			updating = true;
 			undo_redo->create_action(TTR("Move Node Point"));
-			undo_redo->add_do_method(blend_space.ptr(), "set_blend_point_position", selected_point, point);
-			undo_redo->add_undo_method(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
-			undo_redo->add_do_method(this, "_update_space");
-			undo_redo->add_undo_method(this, "_update_space");
-			undo_redo->add_do_method(this, "_update_edited_point_pos");
-			undo_redo->add_undo_method(this, "_update_edited_point_pos");
+			undo_redo->add_do_method_compat(blend_space.ptr(), "set_blend_point_position", selected_point, point);
+			undo_redo->add_undo_method_compat(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
+			undo_redo->add_do_method_compat(this, "_update_space");
+			undo_redo->add_undo_method_compat(this, "_update_space");
+			undo_redo->add_do_method_compat(this, "_update_edited_point_pos");
+			undo_redo->add_undo_method_compat(this, "_update_edited_point_pos");
 			undo_redo->commit_action();
 			updating = false;
 			_update_edited_point_pos();
@@ -327,14 +327,14 @@ void AnimationNodeBlendSpace1DEditor::_config_changed(double) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Change BlendSpace1D Limits"));
-	undo_redo->add_do_method(blend_space.ptr(), "set_max_space", max_value->get_value());
-	undo_redo->add_undo_method(blend_space.ptr(), "set_max_space", blend_space->get_max_space());
-	undo_redo->add_do_method(blend_space.ptr(), "set_min_space", min_value->get_value());
-	undo_redo->add_undo_method(blend_space.ptr(), "set_min_space", blend_space->get_min_space());
-	undo_redo->add_do_method(blend_space.ptr(), "set_snap", snap_value->get_value());
-	undo_redo->add_undo_method(blend_space.ptr(), "set_snap", blend_space->get_snap());
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_max_space", max_value->get_value());
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_max_space", blend_space->get_max_space());
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_min_space", min_value->get_value());
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_min_space", blend_space->get_min_space());
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_snap", snap_value->get_value());
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_snap", blend_space->get_snap());
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
 	undo_redo->commit_action();
 	updating = false;
 
@@ -348,10 +348,10 @@ void AnimationNodeBlendSpace1DEditor::_labels_changed(String) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Change BlendSpace1D Labels"), UndoRedo::MERGE_ENDS);
-	undo_redo->add_do_method(blend_space.ptr(), "set_value_label", label_value->get_text());
-	undo_redo->add_undo_method(blend_space.ptr(), "set_value_label", blend_space->get_value_label());
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_value_label", label_value->get_text());
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_value_label", blend_space->get_value_label());
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
 	undo_redo->commit_action();
 	updating = false;
 }
@@ -401,10 +401,10 @@ void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Add Node Point"));
-	undo_redo->add_do_method(blend_space.ptr(), "add_blend_point", node, add_point_pos);
-	undo_redo->add_undo_method(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "add_blend_point", node, add_point_pos);
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
 	undo_redo->commit_action();
 	updating = false;
 
@@ -419,10 +419,10 @@ void AnimationNodeBlendSpace1DEditor::_add_animation_type(int p_index) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Add Animation Point"));
-	undo_redo->add_do_method(blend_space.ptr(), "add_blend_point", anim, add_point_pos);
-	undo_redo->add_undo_method(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "add_blend_point", anim, add_point_pos);
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
 	undo_redo->commit_action();
 	updating = false;
 
@@ -488,10 +488,10 @@ void AnimationNodeBlendSpace1DEditor::_erase_selected() {
 		updating = true;
 
 		undo_redo->create_action(TTR("Remove BlendSpace1D Point"));
-		undo_redo->add_do_method(blend_space.ptr(), "remove_blend_point", selected_point);
-		undo_redo->add_undo_method(blend_space.ptr(), "add_blend_point", blend_space->get_blend_point_node(selected_point), blend_space->get_blend_point_position(selected_point), selected_point);
-		undo_redo->add_do_method(this, "_update_space");
-		undo_redo->add_undo_method(this, "_update_space");
+		undo_redo->add_do_method_compat(blend_space.ptr(), "remove_blend_point", selected_point);
+		undo_redo->add_undo_method_compat(blend_space.ptr(), "add_blend_point", blend_space->get_blend_point_node(selected_point), blend_space->get_blend_point_position(selected_point), selected_point);
+		undo_redo->add_do_method_compat(this, "_update_space");
+		undo_redo->add_undo_method_compat(this, "_update_space");
 		undo_redo->commit_action();
 
 		updating = false;
@@ -507,12 +507,12 @@ void AnimationNodeBlendSpace1DEditor::_edit_point_pos(double) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Move BlendSpace1D Node Point"));
-	undo_redo->add_do_method(blend_space.ptr(), "set_blend_point_position", selected_point, edit_value->get_value());
-	undo_redo->add_undo_method(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
-	undo_redo->add_do_method(this, "_update_edited_point_pos");
-	undo_redo->add_undo_method(this, "_update_edited_point_pos");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_blend_point_position", selected_point, edit_value->get_value());
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
+	undo_redo->add_do_method_compat(this, "_update_edited_point_pos");
+	undo_redo->add_undo_method_compat(this, "_update_edited_point_pos");
 	undo_redo->commit_action();
 	updating = false;
 

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -196,10 +196,10 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 					updating = true;
 					undo_redo->create_action(TTR("Add Triangle"));
-					undo_redo->add_do_method(blend_space.ptr(), "add_triangle", making_triangle[0], making_triangle[1], making_triangle[2]);
-					undo_redo->add_undo_method(blend_space.ptr(), "remove_triangle", blend_space->get_triangle_count());
-					undo_redo->add_do_method(this, "_update_space");
-					undo_redo->add_undo_method(this, "_update_space");
+					undo_redo->add_do_method_compat(blend_space.ptr(), "add_triangle", making_triangle[0], making_triangle[1], making_triangle[2]);
+					undo_redo->add_undo_method_compat(blend_space.ptr(), "remove_triangle", blend_space->get_triangle_count());
+					undo_redo->add_do_method_compat(this, "_update_space");
+					undo_redo->add_undo_method_compat(this, "_update_space");
 					undo_redo->commit_action();
 					updating = false;
 					making_triangle.clear();
@@ -221,12 +221,12 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 			updating = true;
 			undo_redo->create_action(TTR("Move Node Point"));
-			undo_redo->add_do_method(blend_space.ptr(), "set_blend_point_position", selected_point, point);
-			undo_redo->add_undo_method(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
-			undo_redo->add_do_method(this, "_update_space");
-			undo_redo->add_undo_method(this, "_update_space");
-			undo_redo->add_do_method(this, "_update_edited_point_pos");
-			undo_redo->add_undo_method(this, "_update_edited_point_pos");
+			undo_redo->add_do_method_compat(blend_space.ptr(), "set_blend_point_position", selected_point, point);
+			undo_redo->add_undo_method_compat(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
+			undo_redo->add_do_method_compat(this, "_update_space");
+			undo_redo->add_undo_method_compat(this, "_update_space");
+			undo_redo->add_do_method_compat(this, "_update_edited_point_pos");
+			undo_redo->add_undo_method_compat(this, "_update_edited_point_pos");
 			undo_redo->commit_action();
 			updating = false;
 			_update_edited_point_pos();
@@ -323,10 +323,10 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Add Node Point"));
-	undo_redo->add_do_method(blend_space.ptr(), "add_blend_point", node, add_point_pos);
-	undo_redo->add_undo_method(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "add_blend_point", node, add_point_pos);
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
 	undo_redo->commit_action();
 	updating = false;
 
@@ -341,10 +341,10 @@ void AnimationNodeBlendSpace2DEditor::_add_animation_type(int p_index) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Add Animation Point"));
-	undo_redo->add_do_method(blend_space.ptr(), "add_blend_point", anim, add_point_pos);
-	undo_redo->add_undo_method(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "add_blend_point", anim, add_point_pos);
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
 	undo_redo->commit_action();
 	updating = false;
 
@@ -621,16 +621,16 @@ void AnimationNodeBlendSpace2DEditor::_config_changed(double) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Change BlendSpace2D Limits"));
-	undo_redo->add_do_method(blend_space.ptr(), "set_max_space", Vector2(max_x_value->get_value(), max_y_value->get_value()));
-	undo_redo->add_undo_method(blend_space.ptr(), "set_max_space", blend_space->get_max_space());
-	undo_redo->add_do_method(blend_space.ptr(), "set_min_space", Vector2(min_x_value->get_value(), min_y_value->get_value()));
-	undo_redo->add_undo_method(blend_space.ptr(), "set_min_space", blend_space->get_min_space());
-	undo_redo->add_do_method(blend_space.ptr(), "set_snap", Vector2(snap_x->get_value(), snap_y->get_value()));
-	undo_redo->add_undo_method(blend_space.ptr(), "set_snap", blend_space->get_snap());
-	undo_redo->add_do_method(blend_space.ptr(), "set_blend_mode", interpolation->get_selected());
-	undo_redo->add_undo_method(blend_space.ptr(), "set_blend_mode", blend_space->get_blend_mode());
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_max_space", Vector2(max_x_value->get_value(), max_y_value->get_value()));
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_max_space", blend_space->get_max_space());
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_min_space", Vector2(min_x_value->get_value(), min_y_value->get_value()));
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_min_space", blend_space->get_min_space());
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_snap", Vector2(snap_x->get_value(), snap_y->get_value()));
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_snap", blend_space->get_snap());
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_blend_mode", interpolation->get_selected());
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_blend_mode", blend_space->get_blend_mode());
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
 	undo_redo->commit_action();
 	updating = false;
 
@@ -644,12 +644,12 @@ void AnimationNodeBlendSpace2DEditor::_labels_changed(String) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Change BlendSpace2D Labels"), UndoRedo::MERGE_ENDS);
-	undo_redo->add_do_method(blend_space.ptr(), "set_x_label", label_x->get_text());
-	undo_redo->add_undo_method(blend_space.ptr(), "set_x_label", blend_space->get_x_label());
-	undo_redo->add_do_method(blend_space.ptr(), "set_y_label", label_y->get_text());
-	undo_redo->add_undo_method(blend_space.ptr(), "set_y_label", blend_space->get_y_label());
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_x_label", label_x->get_text());
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_x_label", blend_space->get_x_label());
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_y_label", label_y->get_text());
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_y_label", blend_space->get_y_label());
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
 	undo_redo->commit_action();
 	updating = false;
 }
@@ -658,21 +658,21 @@ void AnimationNodeBlendSpace2DEditor::_erase_selected() {
 	if (selected_point != -1) {
 		updating = true;
 		undo_redo->create_action(TTR("Remove BlendSpace2D Point"));
-		undo_redo->add_do_method(blend_space.ptr(), "remove_blend_point", selected_point);
-		undo_redo->add_undo_method(blend_space.ptr(), "add_blend_point", blend_space->get_blend_point_node(selected_point), blend_space->get_blend_point_position(selected_point), selected_point);
+		undo_redo->add_do_method_compat(blend_space.ptr(), "remove_blend_point", selected_point);
+		undo_redo->add_undo_method_compat(blend_space.ptr(), "add_blend_point", blend_space->get_blend_point_node(selected_point), blend_space->get_blend_point_position(selected_point), selected_point);
 
 		//restore triangles using this point
 		for (int i = 0; i < blend_space->get_triangle_count(); i++) {
 			for (int j = 0; j < 3; j++) {
 				if (blend_space->get_triangle_point(i, j) == selected_point) {
-					undo_redo->add_undo_method(blend_space.ptr(), "add_triangle", blend_space->get_triangle_point(i, 0), blend_space->get_triangle_point(i, 1), blend_space->get_triangle_point(i, 2), i);
+					undo_redo->add_undo_method_compat(blend_space.ptr(), "add_triangle", blend_space->get_triangle_point(i, 0), blend_space->get_triangle_point(i, 1), blend_space->get_triangle_point(i, 2), i);
 					break;
 				}
 			}
 		}
 
-		undo_redo->add_do_method(this, "_update_space");
-		undo_redo->add_undo_method(this, "_update_space");
+		undo_redo->add_do_method_compat(this, "_update_space");
+		undo_redo->add_undo_method_compat(this, "_update_space");
 		undo_redo->commit_action();
 		updating = false;
 
@@ -680,11 +680,11 @@ void AnimationNodeBlendSpace2DEditor::_erase_selected() {
 	} else if (selected_triangle != -1) {
 		updating = true;
 		undo_redo->create_action(TTR("Remove BlendSpace2D Triangle"));
-		undo_redo->add_do_method(blend_space.ptr(), "remove_triangle", selected_triangle);
-		undo_redo->add_undo_method(blend_space.ptr(), "add_triangle", blend_space->get_triangle_point(selected_triangle, 0), blend_space->get_triangle_point(selected_triangle, 1), blend_space->get_triangle_point(selected_triangle, 2), selected_triangle);
+		undo_redo->add_do_method_compat(blend_space.ptr(), "remove_triangle", selected_triangle);
+		undo_redo->add_undo_method_compat(blend_space.ptr(), "add_triangle", blend_space->get_triangle_point(selected_triangle, 0), blend_space->get_triangle_point(selected_triangle, 1), blend_space->get_triangle_point(selected_triangle, 2), selected_triangle);
 
-		undo_redo->add_do_method(this, "_update_space");
-		undo_redo->add_undo_method(this, "_update_space");
+		undo_redo->add_do_method_compat(this, "_update_space");
+		undo_redo->add_undo_method_compat(this, "_update_space");
 		undo_redo->commit_action();
 		updating = false;
 
@@ -719,12 +719,12 @@ void AnimationNodeBlendSpace2DEditor::_edit_point_pos(double) {
 	}
 	updating = true;
 	undo_redo->create_action(TTR("Move Node Point"));
-	undo_redo->add_do_method(blend_space.ptr(), "set_blend_point_position", selected_point, Vector2(edit_x->get_value(), edit_y->get_value()));
-	undo_redo->add_undo_method(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
-	undo_redo->add_do_method(this, "_update_edited_point_pos");
-	undo_redo->add_undo_method(this, "_update_edited_point_pos");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_blend_point_position", selected_point, Vector2(edit_x->get_value(), edit_y->get_value()));
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
+	undo_redo->add_do_method_compat(this, "_update_edited_point_pos");
+	undo_redo->add_undo_method_compat(this, "_update_edited_point_pos");
 	undo_redo->commit_action();
 	updating = false;
 
@@ -792,10 +792,10 @@ void AnimationNodeBlendSpace2DEditor::_removed_from_graph() {
 
 void AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled() {
 	undo_redo->create_action(TTR("Toggle Auto Triangles"));
-	undo_redo->add_do_method(blend_space.ptr(), "set_auto_triangles", auto_triangles->is_pressed());
-	undo_redo->add_undo_method(blend_space.ptr(), "set_auto_triangles", blend_space->get_auto_triangles());
-	undo_redo->add_do_method(this, "_update_space");
-	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->add_do_method_compat(blend_space.ptr(), "set_auto_triangles", auto_triangles->is_pressed());
+	undo_redo->add_undo_method_compat(blend_space.ptr(), "set_auto_triangles", blend_space->get_auto_triangles());
+	undo_redo->add_do_method_compat(this, "_update_space");
+	undo_redo->add_undo_method_compat(this, "_update_space");
 	undo_redo->commit_action();
 }
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -92,8 +92,8 @@ void AnimationNodeBlendTreeEditor::_property_changed(const StringName &p_propert
 	undo_redo->create_action(TTR("Parameter Changed") + ": " + String(p_property), UndoRedo::MERGE_ENDS);
 	undo_redo->add_do_property(tree, p_property, p_value);
 	undo_redo->add_undo_property(tree, p_property, tree->get(p_property));
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 	updating = false;
 }
@@ -324,20 +324,20 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 	}
 
 	undo_redo->create_action(TTR("Add Node to BlendTree"));
-	undo_redo->add_do_method(blend_tree.ptr(), "add_node", name, anode, instance_pos / EDSCALE);
-	undo_redo->add_undo_method(blend_tree.ptr(), "remove_node", name);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(blend_tree.ptr(), "add_node", name, anode, instance_pos / EDSCALE);
+	undo_redo->add_undo_method_compat(blend_tree.ptr(), "remove_node", name);
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 }
 
 void AnimationNodeBlendTreeEditor::_node_dragged(const Vector2 &p_from, const Vector2 &p_to, const StringName &p_which) {
 	updating = true;
 	undo_redo->create_action(TTR("Node Moved"));
-	undo_redo->add_do_method(blend_tree.ptr(), "set_node_position", p_which, p_to / EDSCALE);
-	undo_redo->add_undo_method(blend_tree.ptr(), "set_node_position", p_which, p_from / EDSCALE);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(blend_tree.ptr(), "set_node_position", p_which, p_to / EDSCALE);
+	undo_redo->add_undo_method_compat(blend_tree.ptr(), "set_node_position", p_which, p_from / EDSCALE);
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 	updating = false;
 }
@@ -351,10 +351,10 @@ void AnimationNodeBlendTreeEditor::_connection_request(const String &p_from, int
 	}
 
 	undo_redo->create_action(TTR("Nodes Connected"));
-	undo_redo->add_do_method(blend_tree.ptr(), "connect_node", p_to, p_to_index, p_from);
-	undo_redo->add_undo_method(blend_tree.ptr(), "disconnect_node", p_to, p_to_index);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(blend_tree.ptr(), "connect_node", p_to, p_to_index, p_from);
+	undo_redo->add_undo_method_compat(blend_tree.ptr(), "disconnect_node", p_to, p_to_index);
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 }
 
@@ -363,10 +363,10 @@ void AnimationNodeBlendTreeEditor::_disconnection_request(const String &p_from, 
 
 	updating = true;
 	undo_redo->create_action(TTR("Nodes Disconnected"));
-	undo_redo->add_do_method(blend_tree.ptr(), "disconnect_node", p_to, p_to_index);
-	undo_redo->add_undo_method(blend_tree.ptr(), "connect_node", p_to, p_to_index, p_from);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(blend_tree.ptr(), "disconnect_node", p_to, p_to_index);
+	undo_redo->add_undo_method_compat(blend_tree.ptr(), "connect_node", p_to, p_to_index, p_from);
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 	updating = false;
 }
@@ -378,29 +378,29 @@ void AnimationNodeBlendTreeEditor::_anim_selected(int p_index, Array p_options, 
 	ERR_FAIL_COND(!anim.is_valid());
 
 	undo_redo->create_action(TTR("Set Animation"));
-	undo_redo->add_do_method(anim.ptr(), "set_animation", option);
-	undo_redo->add_undo_method(anim.ptr(), "set_animation", anim->get_animation());
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(anim.ptr(), "set_animation", option);
+	undo_redo->add_undo_method_compat(anim.ptr(), "set_animation", anim->get_animation());
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 }
 
 void AnimationNodeBlendTreeEditor::_delete_request(const String &p_which) {
 	undo_redo->create_action(TTR("Delete Node"));
-	undo_redo->add_do_method(blend_tree.ptr(), "remove_node", p_which);
-	undo_redo->add_undo_method(blend_tree.ptr(), "add_node", p_which, blend_tree->get_node(p_which), blend_tree.ptr()->get_node_position(p_which));
+	undo_redo->add_do_method_compat(blend_tree.ptr(), "remove_node", p_which);
+	undo_redo->add_undo_method_compat(blend_tree.ptr(), "add_node", p_which, blend_tree->get_node(p_which), blend_tree.ptr()->get_node_position(p_which));
 
 	List<AnimationNodeBlendTree::NodeConnection> conns;
 	blend_tree->get_node_connections(&conns);
 
 	for (List<AnimationNodeBlendTree::NodeConnection>::Element *E = conns.front(); E; E = E->next()) {
 		if (E->get().output_node == p_which || E->get().input_node == p_which) {
-			undo_redo->add_undo_method(blend_tree.ptr(), "connect_node", E->get().input_node, E->get().input_index, E->get().output_node);
+			undo_redo->add_undo_method_compat(blend_tree.ptr(), "connect_node", E->get().input_node, E->get().input_index, E->get().output_node);
 		}
 	}
 
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 }
 
@@ -458,10 +458,10 @@ void AnimationNodeBlendTreeEditor::_open_in_editor(const String &p_which) {
 void AnimationNodeBlendTreeEditor::_filter_toggled() {
 	updating = true;
 	undo_redo->create_action(TTR("Toggle Filter On/Off"));
-	undo_redo->add_do_method(_filter_edit.ptr(), "set_filter_enabled", filter_enabled->is_pressed());
-	undo_redo->add_undo_method(_filter_edit.ptr(), "set_filter_enabled", _filter_edit->is_filter_enabled());
-	undo_redo->add_do_method(this, "_update_filters", _filter_edit);
-	undo_redo->add_undo_method(this, "_update_filters", _filter_edit);
+	undo_redo->add_do_method_compat(_filter_edit.ptr(), "set_filter_enabled", filter_enabled->is_pressed());
+	undo_redo->add_undo_method_compat(_filter_edit.ptr(), "set_filter_enabled", _filter_edit->is_filter_enabled());
+	undo_redo->add_do_method_compat(this, "_update_filters", _filter_edit);
+	undo_redo->add_undo_method_compat(this, "_update_filters", _filter_edit);
 	undo_redo->commit_action();
 	updating = false;
 }
@@ -475,10 +475,10 @@ void AnimationNodeBlendTreeEditor::_filter_edited() {
 
 	updating = true;
 	undo_redo->create_action(TTR("Change Filter"));
-	undo_redo->add_do_method(_filter_edit.ptr(), "set_filter_path", edited_path, filtered);
-	undo_redo->add_undo_method(_filter_edit.ptr(), "set_filter_path", edited_path, _filter_edit->is_path_filtered(edited_path));
-	undo_redo->add_do_method(this, "_update_filters", _filter_edit);
-	undo_redo->add_undo_method(this, "_update_filters", _filter_edit);
+	undo_redo->add_do_method_compat(_filter_edit.ptr(), "set_filter_path", edited_path, filtered);
+	undo_redo->add_undo_method_compat(_filter_edit.ptr(), "set_filter_path", edited_path, _filter_edit->is_path_filtered(edited_path));
+	undo_redo->add_do_method_compat(this, "_update_filters", _filter_edit);
+	undo_redo->add_undo_method_compat(this, "_update_filters", _filter_edit);
 	undo_redo->commit_action();
 	updating = false;
 }
@@ -801,12 +801,12 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 
 	updating = true;
 	undo_redo->create_action(TTR("Node Renamed"));
-	undo_redo->add_do_method(blend_tree.ptr(), "rename_node", prev_name, name);
-	undo_redo->add_undo_method(blend_tree.ptr(), "rename_node", name, prev_name);
-	undo_redo->add_do_method(AnimationTreeEditor::get_singleton()->get_tree(), "rename_parameter", base_path + prev_name, base_path + name);
-	undo_redo->add_undo_method(AnimationTreeEditor::get_singleton()->get_tree(), "rename_parameter", base_path + name, base_path + prev_name);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(blend_tree.ptr(), "rename_node", prev_name, name);
+	undo_redo->add_undo_method_compat(blend_tree.ptr(), "rename_node", name, prev_name);
+	undo_redo->add_do_method_compat(AnimationTreeEditor::get_singleton()->get_tree(), "rename_parameter", base_path + prev_name, base_path + name);
+	undo_redo->add_undo_method_compat(AnimationTreeEditor::get_singleton()->get_tree(), "rename_parameter", base_path + name, base_path + prev_name);
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 	updating = false;
 	gn->set_name(new_name);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -166,19 +166,19 @@ void AnimationPlayerEditor::_autoplay_pressed() {
 	if (player->get_autoplay() == current) {
 		//unset
 		undo_redo->create_action(TTR("Toggle Autoplay"));
-		undo_redo->add_do_method(player, "set_autoplay", "");
-		undo_redo->add_undo_method(player, "set_autoplay", player->get_autoplay());
-		undo_redo->add_do_method(this, "_animation_player_changed", player);
-		undo_redo->add_undo_method(this, "_animation_player_changed", player);
+		undo_redo->add_do_method_compat(player, "set_autoplay", "");
+		undo_redo->add_undo_method_compat(player, "set_autoplay", player->get_autoplay());
+		undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+		undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 		undo_redo->commit_action();
 
 	} else {
 		//set
 		undo_redo->create_action(TTR("Toggle Autoplay"));
-		undo_redo->add_do_method(player, "set_autoplay", current);
-		undo_redo->add_undo_method(player, "set_autoplay", player->get_autoplay());
-		undo_redo->add_do_method(this, "_animation_player_changed", player);
-		undo_redo->add_undo_method(this, "_animation_player_changed", player);
+		undo_redo->add_do_method_compat(player, "set_autoplay", current);
+		undo_redo->add_undo_method_compat(player, "set_autoplay", player->get_autoplay());
+		undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+		undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 		undo_redo->commit_action();
 	}
 }
@@ -436,18 +436,18 @@ void AnimationPlayerEditor::_animation_remove_confirmed() {
 
 	undo_redo->create_action(TTR("Remove Animation"));
 	if (player->get_autoplay() == current) {
-		undo_redo->add_do_method(player, "set_autoplay", "");
-		undo_redo->add_undo_method(player, "set_autoplay", current);
+		undo_redo->add_do_method_compat(player, "set_autoplay", "");
+		undo_redo->add_undo_method_compat(player, "set_autoplay", current);
 		// Avoid having the autoplay icon linger around if there is only one animation in the player.
-		undo_redo->add_do_method(this, "_animation_player_changed", player);
+		undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
 	}
-	undo_redo->add_do_method(player, "remove_animation", current);
-	undo_redo->add_undo_method(player, "add_animation", current, anim);
-	undo_redo->add_do_method(this, "_animation_player_changed", player);
-	undo_redo->add_undo_method(this, "_animation_player_changed", player);
+	undo_redo->add_do_method_compat(player, "remove_animation", current);
+	undo_redo->add_undo_method_compat(player, "add_animation", current, anim);
+	undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+	undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 	if (animation->get_item_count() == 1) {
-		undo_redo->add_do_method(this, "_stop_onion_skinning");
-		undo_redo->add_undo_method(this, "_start_onion_skinning");
+		undo_redo->add_do_method_compat(this, "_stop_onion_skinning");
+		undo_redo->add_undo_method_compat(this, "_start_onion_skinning");
 	}
 	undo_redo->commit_action();
 }
@@ -508,12 +508,12 @@ void AnimationPlayerEditor::_animation_name_edited() {
 		Ref<Animation> anim = player->get_animation(current);
 
 		undo_redo->create_action(TTR("Rename Animation"));
-		undo_redo->add_do_method(player, "rename_animation", current, new_name);
-		undo_redo->add_do_method(anim.ptr(), "set_name", new_name);
-		undo_redo->add_undo_method(player, "rename_animation", new_name, current);
-		undo_redo->add_undo_method(anim.ptr(), "set_name", current);
-		undo_redo->add_do_method(this, "_animation_player_changed", player);
-		undo_redo->add_undo_method(this, "_animation_player_changed", player);
+		undo_redo->add_do_method_compat(player, "rename_animation", current, new_name);
+		undo_redo->add_do_method_compat(anim.ptr(), "set_name", new_name);
+		undo_redo->add_undo_method_compat(player, "rename_animation", new_name, current);
+		undo_redo->add_undo_method_compat(anim.ptr(), "set_name", current);
+		undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+		undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 		undo_redo->commit_action();
 
 		_select_anim_by_name(new_name);
@@ -523,13 +523,13 @@ void AnimationPlayerEditor::_animation_name_edited() {
 		new_anim->set_name(new_name);
 
 		undo_redo->create_action(TTR("Add Animation"));
-		undo_redo->add_do_method(player, "add_animation", new_name, new_anim);
-		undo_redo->add_undo_method(player, "remove_animation", new_name);
-		undo_redo->add_do_method(this, "_animation_player_changed", player);
-		undo_redo->add_undo_method(this, "_animation_player_changed", player);
+		undo_redo->add_do_method_compat(player, "add_animation", new_name, new_anim);
+		undo_redo->add_undo_method_compat(player, "remove_animation", new_name);
+		undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+		undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 		if (animation->get_item_count() == 0) {
-			undo_redo->add_do_method(this, "_start_onion_skinning");
-			undo_redo->add_undo_method(this, "_stop_onion_skinning");
+			undo_redo->add_do_method_compat(this, "_start_onion_skinning");
+			undo_redo->add_undo_method_compat(this, "_stop_onion_skinning");
 		}
 		undo_redo->commit_action();
 
@@ -547,10 +547,10 @@ void AnimationPlayerEditor::_blend_editor_next_changed(const int p_idx) {
 	String current = animation->get_item_text(animation->get_selected());
 
 	undo_redo->create_action(TTR("Blend Next Changed"));
-	undo_redo->add_do_method(player, "animation_set_next", current, blend_editor.next->get_item_text(p_idx));
-	undo_redo->add_undo_method(player, "animation_set_next", current, player->animation_get_next(current));
-	undo_redo->add_do_method(this, "_animation_player_changed", player);
-	undo_redo->add_undo_method(this, "_animation_player_changed", player);
+	undo_redo->add_do_method_compat(player, "animation_set_next", current, blend_editor.next->get_item_text(p_idx));
+	undo_redo->add_undo_method_compat(player, "animation_set_next", current, player->animation_get_next(current));
+	undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+	undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 	undo_redo->commit_action();
 }
 
@@ -632,10 +632,10 @@ void AnimationPlayerEditor::_blend_edited() {
 	float prev_blend_time = player->get_blend_time(current, to);
 
 	undo_redo->create_action(TTR("Change Blend Time"));
-	undo_redo->add_do_method(player, "set_blend_time", current, to, blend_time);
-	undo_redo->add_undo_method(player, "set_blend_time", current, to, prev_blend_time);
-	undo_redo->add_do_method(this, "_animation_player_changed", player);
-	undo_redo->add_undo_method(this, "_animation_player_changed", player);
+	undo_redo->add_do_method_compat(player, "set_blend_time", current, to, blend_time);
+	undo_redo->add_undo_method_compat(player, "set_blend_time", current, to, prev_blend_time);
+	undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+	undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 	undo_redo->commit_action();
 	updating_blends = false;
 }
@@ -733,13 +733,13 @@ void AnimationPlayerEditor::_dialog_action(String p_path) {
 			}
 
 			undo_redo->create_action(TTR("Load Animation"));
-			undo_redo->add_do_method(player, "add_animation", anim_name, res);
-			undo_redo->add_undo_method(player, "remove_animation", anim_name);
+			undo_redo->add_do_method_compat(player, "add_animation", anim_name, res);
+			undo_redo->add_undo_method_compat(player, "remove_animation", anim_name);
 			if (player->has_animation(anim_name)) {
-				undo_redo->add_undo_method(player, "add_animation", anim_name, player->get_animation(anim_name));
+				undo_redo->add_undo_method_compat(player, "add_animation", anim_name, player->get_animation(anim_name));
 			}
-			undo_redo->add_do_method(this, "_animation_player_changed", player);
-			undo_redo->add_undo_method(this, "_animation_player_changed", player);
+			undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+			undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 			undo_redo->commit_action();
 			break;
 		}
@@ -979,11 +979,11 @@ void AnimationPlayerEditor::_animation_duplicate() {
 	new_anim->set_name(new_name);
 
 	undo_redo->create_action(TTR("Duplicate Animation"));
-	undo_redo->add_do_method(player, "add_animation", new_name, new_anim);
-	undo_redo->add_undo_method(player, "remove_animation", new_name);
-	undo_redo->add_do_method(player, "animation_set_next", new_name, player->animation_get_next(current));
-	undo_redo->add_do_method(this, "_animation_player_changed", player);
-	undo_redo->add_undo_method(this, "_animation_player_changed", player);
+	undo_redo->add_do_method_compat(player, "add_animation", new_name, new_anim);
+	undo_redo->add_undo_method_compat(player, "remove_animation", new_name);
+	undo_redo->add_do_method_compat(player, "animation_set_next", new_name, player->animation_get_next(current));
+	undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+	undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 	undo_redo->commit_action();
 
 	for (int i = 0; i < animation->get_item_count(); i++) {
@@ -1150,10 +1150,10 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 			}
 
 			undo_redo->create_action(TTR("Paste Animation"));
-			undo_redo->add_do_method(player, "add_animation", name, anim2);
-			undo_redo->add_undo_method(player, "remove_animation", name);
-			undo_redo->add_do_method(this, "_animation_player_changed", player);
-			undo_redo->add_undo_method(this, "_animation_player_changed", player);
+			undo_redo->add_do_method_compat(player, "add_animation", name, anim2);
+			undo_redo->add_undo_method_compat(player, "remove_animation", name);
+			undo_redo->add_do_method_compat(this, "_animation_player_changed", player);
+			undo_redo->add_undo_method_compat(this, "_animation_player_changed", player);
 			undo_redo->commit_action();
 
 			_select_anim_by_name(name);

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -221,10 +221,10 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			Ref<AnimationNode> an = state_machine->get_node(selected_node);
 			updating = true;
 			undo_redo->create_action(TTR("Move Node"));
-			undo_redo->add_do_method(state_machine.ptr(), "set_node_position", selected_node, state_machine->get_node_position(selected_node) + drag_ofs / EDSCALE);
-			undo_redo->add_undo_method(state_machine.ptr(), "set_node_position", selected_node, state_machine->get_node_position(selected_node));
-			undo_redo->add_do_method(this, "_update_graph");
-			undo_redo->add_undo_method(this, "_update_graph");
+			undo_redo->add_do_method_compat(state_machine.ptr(), "set_node_position", selected_node, state_machine->get_node_position(selected_node) + drag_ofs / EDSCALE);
+			undo_redo->add_undo_method_compat(state_machine.ptr(), "set_node_position", selected_node, state_machine->get_node_position(selected_node));
+			undo_redo->add_do_method_compat(this, "_update_graph");
+			undo_redo->add_undo_method_compat(this, "_update_graph");
 			undo_redo->commit_action();
 			updating = false;
 		}
@@ -262,10 +262,10 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 				updating = true;
 				undo_redo->create_action(TTR("Add Transition"));
-				undo_redo->add_do_method(state_machine.ptr(), "add_transition", connecting_from, connecting_to_node, tr);
-				undo_redo->add_undo_method(state_machine.ptr(), "remove_transition", connecting_from, connecting_to_node);
-				undo_redo->add_do_method(this, "_update_graph");
-				undo_redo->add_undo_method(this, "_update_graph");
+				undo_redo->add_do_method_compat(state_machine.ptr(), "add_transition", connecting_from, connecting_to_node, tr);
+				undo_redo->add_undo_method_compat(state_machine.ptr(), "remove_transition", connecting_from, connecting_to_node);
+				undo_redo->add_do_method_compat(this, "_update_graph");
+				undo_redo->add_undo_method_compat(this, "_update_graph");
 				undo_redo->commit_action();
 				updating = false;
 
@@ -450,10 +450,10 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Add Node"));
-	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, node, add_node_pos);
-	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(state_machine.ptr(), "add_node", name, node, add_node_pos);
+	undo_redo->add_undo_method_compat(state_machine.ptr(), "remove_node", name);
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 	updating = false;
 
@@ -476,10 +476,10 @@ void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Add Node"));
-	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, anim, add_node_pos);
-	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(state_machine.ptr(), "add_node", name, anim, add_node_pos);
+	undo_redo->add_undo_method_compat(state_machine.ptr(), "remove_node", name);
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 	updating = false;
 
@@ -1074,10 +1074,10 @@ void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 
 	updating = true;
 	undo_redo->create_action(TTR("Node Renamed"));
-	undo_redo->add_do_method(state_machine.ptr(), "rename_node", prev_name, name);
-	undo_redo->add_undo_method(state_machine.ptr(), "rename_node", name, prev_name);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(state_machine.ptr(), "rename_node", prev_name, name);
+	undo_redo->add_undo_method_compat(state_machine.ptr(), "rename_node", name, prev_name);
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 	name_edit_popup->hide();
 	updating = false;
@@ -1106,20 +1106,20 @@ void AnimationNodeStateMachineEditor::_erase_selected() {
 	if (selected_node != StringName() && state_machine->has_node(selected_node)) {
 		updating = true;
 		undo_redo->create_action(TTR("Node Removed"));
-		undo_redo->add_do_method(state_machine.ptr(), "remove_node", selected_node);
-		undo_redo->add_undo_method(state_machine.ptr(), "add_node", selected_node, state_machine->get_node(selected_node), state_machine->get_node_position(selected_node));
+		undo_redo->add_do_method_compat(state_machine.ptr(), "remove_node", selected_node);
+		undo_redo->add_undo_method_compat(state_machine.ptr(), "add_node", selected_node, state_machine->get_node(selected_node), state_machine->get_node_position(selected_node));
 		for (int i = 0; i < state_machine->get_transition_count(); i++) {
 			String from = state_machine->get_transition_from(i);
 			String to = state_machine->get_transition_to(i);
 			if (from == selected_node || to == selected_node) {
-				undo_redo->add_undo_method(state_machine.ptr(), "add_transition", from, to, state_machine->get_transition(i));
+				undo_redo->add_undo_method_compat(state_machine.ptr(), "add_transition", from, to, state_machine->get_transition(i));
 			}
 		}
 		if (String(state_machine->get_start_node()) == selected_node) {
-			undo_redo->add_undo_method(state_machine.ptr(), "set_start_node", selected_node);
+			undo_redo->add_undo_method_compat(state_machine.ptr(), "set_start_node", selected_node);
 		}
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 		updating = false;
 		selected_node = StringName();
@@ -1129,10 +1129,10 @@ void AnimationNodeStateMachineEditor::_erase_selected() {
 		Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(state_machine->find_transition(selected_transition_from, selected_transition_to));
 		updating = true;
 		undo_redo->create_action(TTR("Transition Removed"));
-		undo_redo->add_do_method(state_machine.ptr(), "remove_transition", selected_transition_from, selected_transition_to);
-		undo_redo->add_undo_method(state_machine.ptr(), "add_transition", selected_transition_from, selected_transition_to, tr);
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_do_method_compat(state_machine.ptr(), "remove_transition", selected_transition_from, selected_transition_to);
+		undo_redo->add_undo_method_compat(state_machine.ptr(), "add_transition", selected_transition_from, selected_transition_to, tr);
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 		updating = false;
 		selected_transition_from = StringName();
@@ -1153,10 +1153,10 @@ void AnimationNodeStateMachineEditor::_autoplay_selected() {
 
 		updating = true;
 		undo_redo->create_action(TTR("Set Start Node (Autoplay)"));
-		undo_redo->add_do_method(state_machine.ptr(), "set_start_node", new_start_node);
-		undo_redo->add_undo_method(state_machine.ptr(), "set_start_node", state_machine->get_start_node());
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_do_method_compat(state_machine.ptr(), "set_start_node", new_start_node);
+		undo_redo->add_undo_method_compat(state_machine.ptr(), "set_start_node", state_machine->get_start_node());
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 		updating = false;
 		state_machine_draw->update();
@@ -1174,10 +1174,10 @@ void AnimationNodeStateMachineEditor::_end_selected() {
 
 		updating = true;
 		undo_redo->create_action(TTR("Set Start Node (Autoplay)"));
-		undo_redo->add_do_method(state_machine.ptr(), "set_end_node", new_end_node);
-		undo_redo->add_undo_method(state_machine.ptr(), "set_end_node", state_machine->get_end_node());
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_do_method_compat(state_machine.ptr(), "set_end_node", new_end_node);
+		undo_redo->add_undo_method_compat(state_machine.ptr(), "set_end_node", state_machine->get_end_node());
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 		updating = false;
 		state_machine_draw->update();

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -982,18 +982,18 @@ void CanvasItemEditor::_commit_canvas_item_state(List<CanvasItem *> p_canvas_ite
 	for (List<CanvasItem *>::Element *E = modified_canvas_items.front(); E; E = E->next()) {
 		CanvasItem *canvas_item = E->get();
 		CanvasItemEditorSelectedItem *se = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(canvas_item);
-		undo_redo->add_do_method(canvas_item, "_edit_set_state", canvas_item->_edit_get_state());
-		undo_redo->add_undo_method(canvas_item, "_edit_set_state", se->undo_state);
+		undo_redo->add_do_method_compat(canvas_item, "_edit_set_state", canvas_item->_edit_get_state());
+		undo_redo->add_undo_method_compat(canvas_item, "_edit_set_state", se->undo_state);
 		if (commit_bones) {
 			for (List<Dictionary>::Element *F = se->pre_drag_bones_undo_state.front(); F; F = F->next()) {
 				canvas_item = Object::cast_to<CanvasItem>(canvas_item->get_parent());
-				undo_redo->add_do_method(canvas_item, "_edit_set_state", canvas_item->_edit_get_state());
-				undo_redo->add_undo_method(canvas_item, "_edit_set_state", F->get());
+				undo_redo->add_do_method_compat(canvas_item, "_edit_set_state", canvas_item->_edit_get_state());
+				undo_redo->add_undo_method_compat(canvas_item, "_edit_set_state", F->get());
 			}
 		}
 	}
-	undo_redo->add_do_method(viewport, "update");
-	undo_redo->add_undo_method(viewport, "update");
+	undo_redo->add_do_method_compat(viewport, "update");
+	undo_redo->add_undo_method_compat(viewport, "update");
 	undo_redo->commit_action();
 }
 
@@ -1146,16 +1146,16 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						if (dragged_guide_index >= 0) {
 							vguides[dragged_guide_index] = edited.x;
 							undo_redo->create_action(TTR("Move Vertical Guide"));
-							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
+							undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
+							undo_redo->add_undo_method_compat(viewport, "update");
 							undo_redo->commit_action();
 						} else {
 							vguides.push_back(edited.x);
 							undo_redo->create_action(TTR("Create Vertical Guide"));
-							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
+							undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
+							undo_redo->add_undo_method_compat(viewport, "update");
 							undo_redo->commit_action();
 						}
 					} else {
@@ -1163,12 +1163,12 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 							vguides.remove(dragged_guide_index);
 							undo_redo->create_action(TTR("Remove Vertical Guide"));
 							if (vguides.is_empty()) {
-								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_vertical_guides_");
+								undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_vertical_guides_");
 							} else {
-								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
+								undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
 							}
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
+							undo_redo->add_undo_method_compat(viewport, "update");
 							undo_redo->commit_action();
 						}
 					}
@@ -1179,16 +1179,16 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						if (dragged_guide_index >= 0) {
 							hguides[dragged_guide_index] = edited.y;
 							undo_redo->create_action(TTR("Move Horizontal Guide"));
-							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
+							undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
+							undo_redo->add_undo_method_compat(viewport, "update");
 							undo_redo->commit_action();
 						} else {
 							hguides.push_back(edited.y);
 							undo_redo->create_action(TTR("Create Horizontal Guide"));
-							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
+							undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
+							undo_redo->add_undo_method_compat(viewport, "update");
 							undo_redo->commit_action();
 						}
 					} else {
@@ -1196,12 +1196,12 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 							hguides.remove(dragged_guide_index);
 							undo_redo->create_action(TTR("Remove Horizontal Guide"));
 							if (hguides.is_empty()) {
-								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_horizontal_guides_");
+								undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_horizontal_guides_");
 							} else {
-								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
+								undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
 							}
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
+							undo_redo->add_undo_method_compat(viewport, "update");
 							undo_redo->commit_action();
 						}
 					}
@@ -1213,11 +1213,11 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						vguides.push_back(edited.x);
 						hguides.push_back(edited.y);
 						undo_redo->create_action(TTR("Create Horizontal and Vertical Guides"));
-						undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
-						undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
-						undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
-						undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
-						undo_redo->add_undo_method(viewport, "update");
+						undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
+						undo_redo->add_do_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
+						undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
+						undo_redo->add_undo_method_compat(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
+						undo_redo->add_undo_method_compat(viewport, "update");
 						undo_redo->commit_action();
 					}
 				}
@@ -4450,7 +4450,7 @@ void CanvasItemEditor::_set_anchors_and_offsets_preset(Control::LayoutPreset p_p
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 		Control *control = Object::cast_to<Control>(E->get());
 		if (control) {
-			undo_redo->add_do_method(control, "set_anchors_preset", p_preset);
+			undo_redo->add_do_method_compat(control, "set_anchors_preset", p_preset);
 			switch (p_preset) {
 				case PRESET_TOP_LEFT:
 				case PRESET_TOP_RIGHT:
@@ -4461,7 +4461,7 @@ void CanvasItemEditor::_set_anchors_and_offsets_preset(Control::LayoutPreset p_p
 				case PRESET_CENTER_RIGHT:
 				case PRESET_CENTER_BOTTOM:
 				case PRESET_CENTER:
-					undo_redo->add_do_method(control, "set_offsets_preset", p_preset, Control::PRESET_MODE_KEEP_SIZE);
+					undo_redo->add_do_method_compat(control, "set_offsets_preset", p_preset, Control::PRESET_MODE_KEEP_SIZE);
 					break;
 				case PRESET_LEFT_WIDE:
 				case PRESET_TOP_WIDE:
@@ -4470,10 +4470,10 @@ void CanvasItemEditor::_set_anchors_and_offsets_preset(Control::LayoutPreset p_p
 				case PRESET_VCENTER_WIDE:
 				case PRESET_HCENTER_WIDE:
 				case PRESET_WIDE:
-					undo_redo->add_do_method(control, "set_offsets_preset", p_preset, Control::PRESET_MODE_MINSIZE);
+					undo_redo->add_do_method_compat(control, "set_offsets_preset", p_preset, Control::PRESET_MODE_MINSIZE);
 					break;
 			}
-			undo_redo->add_undo_method(control, "_edit_set_state", control->_edit_get_state());
+			undo_redo->add_undo_method_compat(control, "_edit_set_state", control->_edit_get_state());
 		}
 	}
 
@@ -4493,15 +4493,15 @@ void CanvasItemEditor::_set_anchors_and_offsets_to_keep_ratio() {
 		if (control) {
 			Point2 top_left_anchor = _position_to_anchor(control, Point2());
 			Point2 bottom_right_anchor = _position_to_anchor(control, control->get_size());
-			undo_redo->add_do_method(control, "set_anchor", SIDE_LEFT, top_left_anchor.x, false, true);
-			undo_redo->add_do_method(control, "set_anchor", SIDE_RIGHT, bottom_right_anchor.x, false, true);
-			undo_redo->add_do_method(control, "set_anchor", SIDE_TOP, top_left_anchor.y, false, true);
-			undo_redo->add_do_method(control, "set_anchor", SIDE_BOTTOM, bottom_right_anchor.y, false, true);
-			undo_redo->add_do_method(control, "set_meta", "_edit_use_anchors_", true);
+			undo_redo->add_do_method_compat(control, "set_anchor", SIDE_LEFT, top_left_anchor.x, false, true);
+			undo_redo->add_do_method_compat(control, "set_anchor", SIDE_RIGHT, bottom_right_anchor.x, false, true);
+			undo_redo->add_do_method_compat(control, "set_anchor", SIDE_TOP, top_left_anchor.y, false, true);
+			undo_redo->add_do_method_compat(control, "set_anchor", SIDE_BOTTOM, bottom_right_anchor.y, false, true);
+			undo_redo->add_do_method_compat(control, "set_meta", "_edit_use_anchors_", true);
 
 			bool use_anchors = control->has_meta("_edit_use_anchors_") && control->get_meta("_edit_use_anchors_");
-			undo_redo->add_undo_method(control, "_edit_set_state", control->_edit_get_state());
-			undo_redo->add_undo_method(control, "set_meta", "_edit_use_anchors_", use_anchors);
+			undo_redo->add_undo_method_compat(control, "_edit_set_state", control->_edit_get_state());
+			undo_redo->add_undo_method_compat(control, "set_meta", "_edit_use_anchors_", use_anchors);
 
 			anchors_mode = true;
 			anchor_mode_button->set_pressed(anchors_mode);
@@ -4518,8 +4518,8 @@ void CanvasItemEditor::_set_anchors_preset(Control::LayoutPreset p_preset) {
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 		Control *control = Object::cast_to<Control>(E->get());
 		if (control) {
-			undo_redo->add_do_method(control, "set_anchors_preset", p_preset);
-			undo_redo->add_undo_method(control, "_edit_set_state", control->_edit_get_state());
+			undo_redo->add_do_method_compat(control, "set_anchors_preset", p_preset);
+			undo_redo->add_undo_method_compat(control, "_edit_set_state", control->_edit_get_state());
 		}
 	}
 
@@ -4874,13 +4874,13 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 				}
 
-				undo_redo->add_do_method(canvas_item, "set_meta", "_edit_lock_", true);
-				undo_redo->add_undo_method(canvas_item, "remove_meta", "_edit_lock_");
-				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_do_method_compat(canvas_item, "set_meta", "_edit_lock_", true);
+				undo_redo->add_undo_method_compat(canvas_item, "remove_meta", "_edit_lock_");
+				undo_redo->add_do_method_compat(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "item_lock_status_changed");
 			}
-			undo_redo->add_do_method(viewport, "update", Variant());
-			undo_redo->add_undo_method(viewport, "update", Variant());
+			undo_redo->add_do_method_compat(viewport, "update", Variant());
+			undo_redo->add_undo_method_compat(viewport, "update", Variant());
 			undo_redo->commit_action();
 		} break;
 		case UNLOCK_SELECTED: {
@@ -4896,13 +4896,13 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 				}
 
-				undo_redo->add_do_method(canvas_item, "remove_meta", "_edit_lock_");
-				undo_redo->add_undo_method(canvas_item, "set_meta", "_edit_lock_", true);
-				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_do_method_compat(canvas_item, "remove_meta", "_edit_lock_");
+				undo_redo->add_undo_method_compat(canvas_item, "set_meta", "_edit_lock_", true);
+				undo_redo->add_do_method_compat(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "item_lock_status_changed");
 			}
-			undo_redo->add_do_method(viewport, "update", Variant());
-			undo_redo->add_undo_method(viewport, "update", Variant());
+			undo_redo->add_do_method_compat(viewport, "update", Variant());
+			undo_redo->add_undo_method_compat(viewport, "update", Variant());
 			undo_redo->commit_action();
 		} break;
 		case GROUP_SELECTED: {
@@ -4918,13 +4918,13 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 				}
 
-				undo_redo->add_do_method(canvas_item, "set_meta", "_edit_group_", true);
-				undo_redo->add_undo_method(canvas_item, "remove_meta", "_edit_group_");
-				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_do_method_compat(canvas_item, "set_meta", "_edit_group_", true);
+				undo_redo->add_undo_method_compat(canvas_item, "remove_meta", "_edit_group_");
+				undo_redo->add_do_method_compat(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "item_group_status_changed");
 			}
-			undo_redo->add_do_method(viewport, "update", Variant());
-			undo_redo->add_undo_method(viewport, "update", Variant());
+			undo_redo->add_do_method_compat(viewport, "update", Variant());
+			undo_redo->add_undo_method_compat(viewport, "update", Variant());
 			undo_redo->commit_action();
 		} break;
 		case UNGROUP_SELECTED: {
@@ -4940,13 +4940,13 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 				}
 
-				undo_redo->add_do_method(canvas_item, "remove_meta", "_edit_group_");
-				undo_redo->add_undo_method(canvas_item, "set_meta", "_edit_group_", true);
-				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_do_method_compat(canvas_item, "remove_meta", "_edit_group_");
+				undo_redo->add_undo_method_compat(canvas_item, "set_meta", "_edit_group_", true);
+				undo_redo->add_do_method_compat(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "item_group_status_changed");
 			}
-			undo_redo->add_do_method(viewport, "update", Variant());
-			undo_redo->add_undo_method(viewport, "update", Variant());
+			undo_redo->add_do_method_compat(viewport, "update", Variant());
+			undo_redo->add_undo_method_compat(viewport, "update", Variant());
 			undo_redo->commit_action();
 		} break;
 		case ANCHORS_AND_OFFSETS_PRESET_TOP_LEFT: {
@@ -5104,12 +5104,12 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				if (!n2d) {
 					continue;
 				}
-				undo_redo->add_do_method(n2d, "set_position", E->get().pos);
-				undo_redo->add_do_method(n2d, "set_rotation", E->get().rot);
-				undo_redo->add_do_method(n2d, "set_scale", E->get().scale);
-				undo_redo->add_undo_method(n2d, "set_position", n2d->get_position());
-				undo_redo->add_undo_method(n2d, "set_rotation", n2d->get_rotation());
-				undo_redo->add_undo_method(n2d, "set_scale", n2d->get_scale());
+				undo_redo->add_do_method_compat(n2d, "set_position", E->get().pos);
+				undo_redo->add_do_method_compat(n2d, "set_rotation", E->get().rot);
+				undo_redo->add_do_method_compat(n2d, "set_scale", E->get().scale);
+				undo_redo->add_undo_method_compat(n2d, "set_position", n2d->get_position());
+				undo_redo->add_undo_method_compat(n2d, "set_rotation", n2d->get_rotation());
+				undo_redo->add_undo_method_compat(n2d, "set_scale", n2d->get_scale());
 			}
 			undo_redo->commit_action();
 
@@ -5161,16 +5161,16 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				if (root->has_meta("_edit_horizontal_guides_")) {
 					Array hguides = root->get_meta("_edit_horizontal_guides_");
 
-					undo_redo->add_do_method(root, "remove_meta", "_edit_horizontal_guides_");
-					undo_redo->add_undo_method(root, "set_meta", "_edit_horizontal_guides_", hguides);
+					undo_redo->add_do_method_compat(root, "remove_meta", "_edit_horizontal_guides_");
+					undo_redo->add_undo_method_compat(root, "set_meta", "_edit_horizontal_guides_", hguides);
 				}
 				if (root->has_meta("_edit_vertical_guides_")) {
 					Array vguides = root->get_meta("_edit_vertical_guides_");
 
-					undo_redo->add_do_method(root, "remove_meta", "_edit_vertical_guides_");
-					undo_redo->add_undo_method(root, "set_meta", "_edit_vertical_guides_", vguides);
+					undo_redo->add_do_method_compat(root, "remove_meta", "_edit_vertical_guides_");
+					undo_redo->add_undo_method_compat(root, "set_meta", "_edit_vertical_guides_", vguides);
 				}
-				undo_redo->add_undo_method(viewport, "update");
+				undo_redo->add_undo_method_compat(viewport, "update");
 				undo_redo->commit_action();
 			}
 
@@ -5206,13 +5206,13 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 				}
 
-				undo_redo->add_do_method(n2d, "set_meta", "_edit_bone_", true);
-				undo_redo->add_undo_method(n2d, "remove_meta", "_edit_bone_");
+				undo_redo->add_do_method_compat(n2d, "set_meta", "_edit_bone_", true);
+				undo_redo->add_undo_method_compat(n2d, "remove_meta", "_edit_bone_");
 			}
-			undo_redo->add_do_method(this, "_queue_update_bone_list");
-			undo_redo->add_undo_method(this, "_queue_update_bone_list");
-			undo_redo->add_do_method(viewport, "update");
-			undo_redo->add_undo_method(viewport, "update");
+			undo_redo->add_do_method_compat(this, "_queue_update_bone_list");
+			undo_redo->add_undo_method_compat(this, "_queue_update_bone_list");
+			undo_redo->add_do_method_compat(viewport, "update");
+			undo_redo->add_undo_method_compat(viewport, "update");
 			undo_redo->commit_action();
 
 		} break;
@@ -5232,13 +5232,13 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 				}
 
-				undo_redo->add_do_method(n2d, "remove_meta", "_edit_bone_");
-				undo_redo->add_undo_method(n2d, "set_meta", "_edit_bone_", n2d->get_meta("_edit_bone_"));
+				undo_redo->add_do_method_compat(n2d, "remove_meta", "_edit_bone_");
+				undo_redo->add_undo_method_compat(n2d, "set_meta", "_edit_bone_", n2d->get_meta("_edit_bone_"));
 			}
-			undo_redo->add_do_method(this, "_queue_update_bone_list");
-			undo_redo->add_undo_method(this, "_queue_update_bone_list");
-			undo_redo->add_do_method(viewport, "update");
-			undo_redo->add_undo_method(viewport, "update");
+			undo_redo->add_do_method_compat(this, "_queue_update_bone_list");
+			undo_redo->add_undo_method_compat(this, "_queue_update_bone_list");
+			undo_redo->add_do_method_compat(viewport, "update");
+			undo_redo->add_undo_method_compat(viewport, "update");
 			undo_redo->commit_action();
 
 		} break;
@@ -5258,11 +5258,11 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 				}
 
-				undo_redo->add_do_method(canvas_item, "set_meta", "_edit_ik_", true);
-				undo_redo->add_undo_method(canvas_item, "remove_meta", "_edit_ik_");
+				undo_redo->add_do_method_compat(canvas_item, "set_meta", "_edit_ik_", true);
+				undo_redo->add_undo_method_compat(canvas_item, "remove_meta", "_edit_ik_");
 			}
-			undo_redo->add_do_method(viewport, "update");
-			undo_redo->add_undo_method(viewport, "update");
+			undo_redo->add_do_method_compat(viewport, "update");
+			undo_redo->add_undo_method_compat(viewport, "update");
 			undo_redo->commit_action();
 
 		} break;
@@ -5282,11 +5282,11 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 				}
 
-				undo_redo->add_do_method(n2d, "remove_meta", "_edit_ik_");
-				undo_redo->add_undo_method(n2d, "set_meta", "_edit_ik_", n2d->get_meta("_edit_ik_"));
+				undo_redo->add_do_method_compat(n2d, "remove_meta", "_edit_ik_");
+				undo_redo->add_undo_method_compat(n2d, "set_meta", "_edit_ik_", n2d->get_meta("_edit_ik_"));
 			}
-			undo_redo->add_do_method(viewport, "update");
-			undo_redo->add_undo_method(viewport, "update");
+			undo_redo->add_do_method_compat(viewport, "update");
+			undo_redo->add_undo_method_compat(viewport, "update");
 			undo_redo->commit_action();
 
 		} break;
@@ -6258,22 +6258,22 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 	Size2 texture_size = texture->get_size();
 
 	if (parent) {
-		editor_data->get_undo_redo().add_do_method(parent, "add_child", child);
-		editor_data->get_undo_redo().add_do_method(child, "set_owner", editor->get_edited_scene());
+		editor_data->get_undo_redo().add_do_method_compat(parent, "add_child", child);
+		editor_data->get_undo_redo().add_do_method_compat(child, "set_owner", editor->get_edited_scene());
 		editor_data->get_undo_redo().add_do_reference(child);
-		editor_data->get_undo_redo().add_undo_method(parent, "remove_child", child);
+		editor_data->get_undo_redo().add_undo_method_compat(parent, "remove_child", child);
 	} else { // if we haven't parent, lets try to make a child as a parent.
-		editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child);
-		editor_data->get_undo_redo().add_do_method(child, "set_owner", editor->get_edited_scene());
+		editor_data->get_undo_redo().add_do_method_compat(editor, "set_edited_scene", child);
+		editor_data->get_undo_redo().add_do_method_compat(child, "set_owner", editor->get_edited_scene());
 		editor_data->get_undo_redo().add_do_reference(child);
-		editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)nullptr);
+		editor_data->get_undo_redo().add_undo_method_compat(editor, "set_edited_scene", (Object *)nullptr);
 	}
 
 	if (parent) {
 		String new_name = parent->validate_child_name(child);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		editor_data->get_undo_redo().add_do_method(ed, "live_debug_create_node", editor->get_edited_scene()->get_path_to(parent), child->get_class(), new_name);
-		editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
+		editor_data->get_undo_redo().add_do_method_compat(ed, "live_debug_create_node", editor->get_edited_scene()->get_path_to(parent), child->get_class(), new_name);
+		editor_data->get_undo_redo().add_undo_method_compat(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
 	}
 
 	// handle with different property for texture
@@ -6312,7 +6312,7 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 
 	// there's nothing to be used as source position so snapping will work as absolute if enabled
 	target_position = canvas_item_editor->snap_point(target_position);
-	editor_data->get_undo_redo().add_do_method(child, "set_global_position", target_position);
+	editor_data->get_undo_redo().add_do_method_compat(child, "set_global_position", target_position);
 }
 
 bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, const Point2 &p_point) {
@@ -6335,15 +6335,15 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 
 	instanced_scene->set_filename(ProjectSettings::get_singleton()->localize_path(path));
 
-	editor_data->get_undo_redo().add_do_method(parent, "add_child", instanced_scene);
-	editor_data->get_undo_redo().add_do_method(instanced_scene, "set_owner", editor->get_edited_scene());
+	editor_data->get_undo_redo().add_do_method_compat(parent, "add_child", instanced_scene);
+	editor_data->get_undo_redo().add_do_method_compat(instanced_scene, "set_owner", editor->get_edited_scene());
 	editor_data->get_undo_redo().add_do_reference(instanced_scene);
-	editor_data->get_undo_redo().add_undo_method(parent, "remove_child", instanced_scene);
+	editor_data->get_undo_redo().add_undo_method_compat(parent, "remove_child", instanced_scene);
 
 	String new_name = parent->validate_child_name(instanced_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-	editor_data->get_undo_redo().add_do_method(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
-	editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
+	editor_data->get_undo_redo().add_do_method_compat(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
+	editor_data->get_undo_redo().add_undo_method_compat(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
 
 	CanvasItem *parent_ci = Object::cast_to<CanvasItem>(parent);
 	if (parent_ci) {
@@ -6355,7 +6355,7 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 		if (instance_ci) {
 			target_pos += instance_ci->_edit_get_position();
 		}
-		editor_data->get_undo_redo().add_do_method(instanced_scene, "set_position", target_pos);
+		editor_data->get_undo_redo().add_do_method_compat(instanced_scene, "set_position", target_pos);
 	}
 
 	return true;

--- a/editor/plugins/collision_polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_3d_editor_plugin.cpp
@@ -90,10 +90,10 @@ void CollisionPolygon3DEditor::_menu_option(int p_option) {
 
 void CollisionPolygon3DEditor::_wip_close() {
 	undo_redo->create_action(TTR("Create Polygon3D"));
-	undo_redo->add_undo_method(node, "set_polygon", node->call("get_polygon"));
-	undo_redo->add_do_method(node, "set_polygon", wip);
-	undo_redo->add_do_method(this, "_polygon_draw");
-	undo_redo->add_undo_method(this, "_polygon_draw");
+	undo_redo->add_undo_method_compat(node, "set_polygon", node->call("get_polygon"));
+	undo_redo->add_do_method_compat(node, "set_polygon", wip);
+	undo_redo->add_do_method_compat(this, "_polygon_draw");
+	undo_redo->add_undo_method_compat(this, "_polygon_draw");
 	wip.clear();
 	wip_active = false;
 	mode = MODE_EDIT;
@@ -178,11 +178,11 @@ bool CollisionPolygon3DEditor::forward_spatial_gui_input(Camera3D *p_camera, con
 						if (mb->get_control()) {
 							if (poly.size() < 3) {
 								undo_redo->create_action(TTR("Edit Poly"));
-								undo_redo->add_undo_method(node, "set_polygon", poly);
+								undo_redo->add_undo_method_compat(node, "set_polygon", poly);
 								poly.push_back(cpoint);
-								undo_redo->add_do_method(node, "set_polygon", poly);
-								undo_redo->add_do_method(this, "_polygon_draw");
-								undo_redo->add_undo_method(this, "_polygon_draw");
+								undo_redo->add_do_method_compat(node, "set_polygon", poly);
+								undo_redo->add_do_method_compat(this, "_polygon_draw");
+								undo_redo->add_undo_method_compat(this, "_polygon_draw");
 								undo_redo->commit_action();
 								return true;
 							}
@@ -256,10 +256,10 @@ bool CollisionPolygon3DEditor::forward_spatial_gui_input(Camera3D *p_camera, con
 							ERR_FAIL_INDEX_V(edited_point, poly.size(), false);
 							poly.write[edited_point] = edited_point_pos;
 							undo_redo->create_action(TTR("Edit Poly"));
-							undo_redo->add_do_method(node, "set_polygon", poly);
-							undo_redo->add_undo_method(node, "set_polygon", pre_move_edit);
-							undo_redo->add_do_method(this, "_polygon_draw");
-							undo_redo->add_undo_method(this, "_polygon_draw");
+							undo_redo->add_do_method_compat(node, "set_polygon", poly);
+							undo_redo->add_undo_method_compat(node, "set_polygon", pre_move_edit);
+							undo_redo->add_do_method_compat(this, "_polygon_draw");
+							undo_redo->add_undo_method_compat(this, "_polygon_draw");
 							undo_redo->commit_action();
 
 							edited_point = -1;
@@ -284,11 +284,11 @@ bool CollisionPolygon3DEditor::forward_spatial_gui_input(Camera3D *p_camera, con
 
 					if (closest_idx >= 0) {
 						undo_redo->create_action(TTR("Edit Poly (Remove Point)"));
-						undo_redo->add_undo_method(node, "set_polygon", poly);
+						undo_redo->add_undo_method_compat(node, "set_polygon", poly);
 						poly.remove(closest_idx);
-						undo_redo->add_do_method(node, "set_polygon", poly);
-						undo_redo->add_do_method(this, "_polygon_draw");
-						undo_redo->add_undo_method(this, "_polygon_draw");
+						undo_redo->add_do_method_compat(node, "set_polygon", poly);
+						undo_redo->add_do_method_compat(this, "_polygon_draw");
+						undo_redo->add_undo_method_compat(this, "_polygon_draw");
 						undo_redo->commit_action();
 						return true;
 					}

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -218,15 +218,15 @@ void CollisionShape2DEditor::commit_handle(int idx, Variant &p_org) {
 			Ref<CapsuleShape2D> capsule = node->get_shape();
 
 			if (idx == 0) {
-				undo_redo->add_do_method(capsule.ptr(), "set_radius", capsule->get_radius());
-				undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-				undo_redo->add_undo_method(capsule.ptr(), "set_radius", p_org);
-				undo_redo->add_do_method(canvas_item_editor, "update_viewport");
+				undo_redo->add_do_method_compat(capsule.ptr(), "set_radius", capsule->get_radius());
+				undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+				undo_redo->add_undo_method_compat(capsule.ptr(), "set_radius", p_org);
+				undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
 			} else if (idx == 1) {
-				undo_redo->add_do_method(capsule.ptr(), "set_height", capsule->get_height());
-				undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-				undo_redo->add_undo_method(capsule.ptr(), "set_height", p_org);
-				undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+				undo_redo->add_do_method_compat(capsule.ptr(), "set_height", capsule->get_height());
+				undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+				undo_redo->add_undo_method_compat(capsule.ptr(), "set_height", p_org);
+				undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 			}
 
 		} break;
@@ -234,10 +234,10 @@ void CollisionShape2DEditor::commit_handle(int idx, Variant &p_org) {
 		case CIRCLE_SHAPE: {
 			Ref<CircleShape2D> circle = node->get_shape();
 
-			undo_redo->add_do_method(circle.ptr(), "set_radius", circle->get_radius());
-			undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-			undo_redo->add_undo_method(circle.ptr(), "set_radius", p_org);
-			undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+			undo_redo->add_do_method_compat(circle.ptr(), "set_radius", circle->get_radius());
+			undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+			undo_redo->add_undo_method_compat(circle.ptr(), "set_radius", p_org);
+			undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 
 		} break;
 
@@ -253,15 +253,15 @@ void CollisionShape2DEditor::commit_handle(int idx, Variant &p_org) {
 			Ref<LineShape2D> line = node->get_shape();
 
 			if (idx == 0) {
-				undo_redo->add_do_method(line.ptr(), "set_distance", line->get_distance());
-				undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-				undo_redo->add_undo_method(line.ptr(), "set_distance", p_org);
-				undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+				undo_redo->add_do_method_compat(line.ptr(), "set_distance", line->get_distance());
+				undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+				undo_redo->add_undo_method_compat(line.ptr(), "set_distance", p_org);
+				undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 			} else {
-				undo_redo->add_do_method(line.ptr(), "set_normal", line->get_normal());
-				undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-				undo_redo->add_undo_method(line.ptr(), "set_normal", p_org);
-				undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+				undo_redo->add_do_method_compat(line.ptr(), "set_normal", line->get_normal());
+				undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+				undo_redo->add_undo_method_compat(line.ptr(), "set_normal", p_org);
+				undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 			}
 
 		} break;
@@ -269,35 +269,35 @@ void CollisionShape2DEditor::commit_handle(int idx, Variant &p_org) {
 		case RAY_SHAPE: {
 			Ref<RayShape2D> ray = node->get_shape();
 
-			undo_redo->add_do_method(ray.ptr(), "set_length", ray->get_length());
-			undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-			undo_redo->add_undo_method(ray.ptr(), "set_length", p_org);
-			undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+			undo_redo->add_do_method_compat(ray.ptr(), "set_length", ray->get_length());
+			undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+			undo_redo->add_undo_method_compat(ray.ptr(), "set_length", p_org);
+			undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 
 		} break;
 
 		case RECTANGLE_SHAPE: {
 			Ref<RectangleShape2D> rect = node->get_shape();
 
-			undo_redo->add_do_method(rect.ptr(), "set_size", rect->get_size());
-			undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-			undo_redo->add_undo_method(rect.ptr(), "set_size", p_org);
-			undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+			undo_redo->add_do_method_compat(rect.ptr(), "set_size", rect->get_size());
+			undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+			undo_redo->add_undo_method_compat(rect.ptr(), "set_size", p_org);
+			undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 
 		} break;
 
 		case SEGMENT_SHAPE: {
 			Ref<SegmentShape2D> seg = node->get_shape();
 			if (idx == 0) {
-				undo_redo->add_do_method(seg.ptr(), "set_a", seg->get_a());
-				undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-				undo_redo->add_undo_method(seg.ptr(), "set_a", p_org);
-				undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+				undo_redo->add_do_method_compat(seg.ptr(), "set_a", seg->get_a());
+				undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+				undo_redo->add_undo_method_compat(seg.ptr(), "set_a", p_org);
+				undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 			} else if (idx == 1) {
-				undo_redo->add_do_method(seg.ptr(), "set_b", seg->get_b());
-				undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-				undo_redo->add_undo_method(seg.ptr(), "set_b", p_org);
-				undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+				undo_redo->add_do_method_compat(seg.ptr(), "set_b", seg->get_b());
+				undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+				undo_redo->add_undo_method_compat(seg.ptr(), "set_b", p_org);
+				undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 			}
 
 		} break;

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -136,8 +136,8 @@ void CurveEditor::on_gui_input(const Ref<InputEvent> &p_event) {
 				UndoRedo &ur = *EditorNode::get_singleton()->get_undo_redo();
 
 				ur.create_action(_selected_tangent == TANGENT_NONE ? TTR("Modify Curve Point") : TTR("Modify Curve Tangent"));
-				ur.add_do_method(*_curve_ref, "_set_data", _curve_ref->get_data());
-				ur.add_undo_method(*_curve_ref, "_set_data", _undo_data);
+				ur.add_do_method_compat(*_curve_ref, "_set_data", _curve_ref->get_data());
+				ur.add_undo_method_compat(*_curve_ref, "_set_data", _undo_data);
 				// Note: this will trigger one more "changed" signal even if nothing changes,
 				// but it's ok since it would have fired every frame during the drag anyways
 				ur.commit_action();
@@ -298,8 +298,8 @@ void CurveEditor::on_preset_item_selected(int preset_id) {
 	UndoRedo &ur = *EditorNode::get_singleton()->get_undo_redo();
 	ur.create_action(TTR("Load Curve Preset"));
 
-	ur.add_do_method(&curve, "_set_data", curve.get_data());
-	ur.add_undo_method(&curve, "_set_data", previous_data);
+	ur.add_do_method_compat(&curve, "_set_data", curve.get_data());
+	ur.add_undo_method_compat(&curve, "_set_data", previous_data);
 
 	ur.commit_action();
 }
@@ -442,8 +442,8 @@ void CurveEditor::add_point(Vector2 pos) {
 	int i = _curve_ref->add_point(point_pos);
 	_curve_ref->remove_point(i);
 
-	ur.add_do_method(*_curve_ref, "add_point", point_pos);
-	ur.add_undo_method(*_curve_ref, "remove_point", i);
+	ur.add_do_method_compat(*_curve_ref, "add_point", point_pos);
+	ur.add_undo_method_compat(*_curve_ref, "remove_point", i);
 
 	ur.commit_action();
 }
@@ -456,8 +456,8 @@ void CurveEditor::remove_point(int index) {
 
 	Curve::Point p = _curve_ref->get_point(index);
 
-	ur.add_do_method(*_curve_ref, "remove_point", index);
-	ur.add_undo_method(*_curve_ref, "add_point", p.pos, p.left_tangent, p.right_tangent, p.left_mode, p.right_mode);
+	ur.add_do_method_compat(*_curve_ref, "remove_point", index);
+	ur.add_undo_method_compat(*_curve_ref, "add_point", p.pos, p.left_tangent, p.right_tangent, p.left_mode, p.right_mode);
 
 	if (index == _selected_point) {
 		set_selected_point(-1);
@@ -486,8 +486,8 @@ void CurveEditor::toggle_linear(TangentIndex tangent) {
 		Curve::TangentMode prev_mode = _curve_ref->get_point_left_mode(_selected_point);
 		Curve::TangentMode mode = is_linear ? Curve::TANGENT_FREE : Curve::TANGENT_LINEAR;
 
-		ur.add_do_method(*_curve_ref, "set_point_left_mode", _selected_point, mode);
-		ur.add_undo_method(*_curve_ref, "set_point_left_mode", _selected_point, prev_mode);
+		ur.add_do_method_compat(*_curve_ref, "set_point_left_mode", _selected_point, mode);
+		ur.add_undo_method_compat(*_curve_ref, "set_point_left_mode", _selected_point, prev_mode);
 
 	} else {
 		bool is_linear = _curve_ref->get_point_right_mode(_selected_point) == Curve::TANGENT_LINEAR;
@@ -495,8 +495,8 @@ void CurveEditor::toggle_linear(TangentIndex tangent) {
 		Curve::TangentMode prev_mode = _curve_ref->get_point_right_mode(_selected_point);
 		Curve::TangentMode mode = is_linear ? Curve::TANGENT_FREE : Curve::TANGENT_LINEAR;
 
-		ur.add_do_method(*_curve_ref, "set_point_right_mode", _selected_point, mode);
-		ur.add_undo_method(*_curve_ref, "set_point_right_mode", _selected_point, prev_mode);
+		ur.add_do_method_compat(*_curve_ref, "set_point_right_mode", _selected_point, mode);
+		ur.add_undo_method_compat(*_curve_ref, "set_point_right_mode", _selected_point, prev_mode);
 	}
 
 	ur.commit_action();

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -86,9 +86,9 @@ void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles2D"));
-			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", particles, cpu_particles, true, false);
+			ur->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", particles, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
-			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, particles, false, false);
+			ur->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, particles, false, false);
 			ur->add_undo_reference(particles);
 			ur->commit_action();
 
@@ -133,8 +133,8 @@ void GPUParticles2DEditorPlugin::_generate_visibility_rect() {
 	}
 
 	undo_redo->create_action(TTR("Generate Visibility Rect"));
-	undo_redo->add_do_method(particles, "set_visibility_rect", rect);
-	undo_redo->add_undo_method(particles, "set_visibility_rect", particles->get_visibility_rect());
+	undo_redo->add_do_method_compat(particles, "set_visibility_rect", rect);
+	undo_redo->add_undo_method_compat(particles, "set_visibility_rect", particles->get_visibility_rect());
 	undo_redo->commit_action();
 }
 

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -267,9 +267,9 @@ void GPUParticles3DEditor::_menu_option(int p_option) {
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles3D"));
-			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, cpu_particles, true, false);
+			ur->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
-			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, node, false, false);
+			ur->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, node, false, false);
 			ur->add_undo_reference(node);
 			ur->commit_action();
 
@@ -317,8 +317,8 @@ void GPUParticles3DEditor::_generate_aabb() {
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Generate Visibility AABB"));
-	ur->add_do_method(node, "set_visibility_aabb", rect);
-	ur->add_undo_method(node, "set_visibility_aabb", node->get_visibility_aabb());
+	ur->add_do_method_compat(node, "set_visibility_aabb", rect);
+	ur->add_undo_method_compat(node, "set_visibility_aabb", node->get_visibility_aabb());
 	ur->commit_action();
 }
 

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -53,10 +53,10 @@ void GradientEditor::_ramp_changed() {
 	editing = true;
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	undo_redo->create_action(TTR("Gradient Edited"));
-	undo_redo->add_do_method(gradient.ptr(), "set_offsets", get_offsets());
-	undo_redo->add_do_method(gradient.ptr(), "set_colors", get_colors());
-	undo_redo->add_undo_method(gradient.ptr(), "set_offsets", gradient->get_offsets());
-	undo_redo->add_undo_method(gradient.ptr(), "set_colors", gradient->get_colors());
+	undo_redo->add_do_method_compat(gradient.ptr(), "set_offsets", get_offsets());
+	undo_redo->add_do_method_compat(gradient.ptr(), "set_colors", get_colors());
+	undo_redo->add_undo_method_compat(gradient.ptr(), "set_offsets", gradient->get_offsets());
+	undo_redo->add_undo_method_compat(gradient.ptr(), "set_colors", gradient->get_colors());
 	undo_redo->commit_action();
 	editing = false;
 }

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -81,8 +81,8 @@ void LightOccluder2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) co
 
 void LightOccluder2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
 	Ref<OccluderPolygon2D> occluder = _ensure_occluder();
-	undo_redo->add_do_method(occluder.ptr(), "set_polygon", p_polygon);
-	undo_redo->add_undo_method(occluder.ptr(), "set_polygon", p_previous);
+	undo_redo->add_do_method_compat(occluder.ptr(), "set_polygon", p_polygon);
+	undo_redo->add_undo_method_compat(occluder.ptr(), "set_polygon", p_previous);
 }
 
 bool LightOccluder2DEditor::_has_resource() const {
@@ -95,8 +95,8 @@ void LightOccluder2DEditor::_create_resource() {
 	}
 
 	undo_redo->create_action(TTR("Create Occluder Polygon"));
-	undo_redo->add_do_method(node, "set_occluder_polygon", Ref<OccluderPolygon2D>(memnew(OccluderPolygon2D)));
-	undo_redo->add_undo_method(node, "set_occluder_polygon", Variant(REF()));
+	undo_redo->add_do_method_compat(node, "set_occluder_polygon", Ref<OccluderPolygon2D>(memnew(OccluderPolygon2D)));
+	undo_redo->add_undo_method_compat(node, "set_occluder_polygon", Variant(REF()));
 	undo_redo->commit_action();
 
 	_menu_option(MODE_CREATE);

--- a/editor/plugins/line_2d_editor_plugin.cpp
+++ b/editor/plugins/line_2d_editor_plugin.cpp
@@ -52,8 +52,8 @@ void Line2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
 
 void Line2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
 	Node2D *node = _get_node();
-	undo_redo->add_do_method(node, "set_points", p_polygon);
-	undo_redo->add_undo_method(node, "set_points", p_previous);
+	undo_redo->add_do_method_compat(node, "set_points", p_polygon);
+	undo_redo->add_undo_method_compat(node, "set_points", p_previous);
 }
 
 Line2DEditor::Line2DEditor(EditorNode *p_editor) :

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -79,11 +79,11 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				Node *owner = node == get_tree()->get_edited_scene_root() ? node : node->get_owner();
 
 				ur->create_action(TTR("Create Static Trimesh Body"));
-				ur->add_do_method(node, "add_child", body);
-				ur->add_do_method(body, "set_owner", owner);
-				ur->add_do_method(cshape, "set_owner", owner);
+				ur->add_do_method_compat(node, "add_child", body);
+				ur->add_do_method_compat(body, "set_owner", owner);
+				ur->add_do_method_compat(cshape, "set_owner", owner);
 				ur->add_do_reference(body);
-				ur->add_undo_method(node, "remove_child", body);
+				ur->add_undo_method_compat(node, "remove_child", body);
 				ur->commit_action();
 				return;
 			}
@@ -113,11 +113,11 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 				Node *owner = instance == get_tree()->get_edited_scene_root() ? instance : instance->get_owner();
 
-				ur->add_do_method(instance, "add_child", body);
-				ur->add_do_method(body, "set_owner", owner);
-				ur->add_do_method(cshape, "set_owner", owner);
+				ur->add_do_method_compat(instance, "add_child", body);
+				ur->add_do_method_compat(body, "set_owner", owner);
+				ur->add_do_method_compat(cshape, "set_owner", owner);
 				ur->add_do_reference(body);
-				ur->add_undo_method(instance, "remove_child", body);
+				ur->add_undo_method_compat(instance, "remove_child", body);
 			}
 
 			ur->commit_action();
@@ -146,11 +146,11 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			ur->create_action(TTR("Create Trimesh Static Shape"));
 
-			ur->add_do_method(node->get_parent(), "add_child", cshape);
-			ur->add_do_method(node->get_parent(), "move_child", cshape, node->get_index() + 1);
-			ur->add_do_method(cshape, "set_owner", owner);
+			ur->add_do_method_compat(node->get_parent(), "add_child", cshape);
+			ur->add_do_method_compat(node->get_parent(), "move_child", cshape, node->get_index() + 1);
+			ur->add_do_method_compat(cshape, "set_owner", owner);
 			ur->add_do_reference(cshape);
-			ur->add_undo_method(node->get_parent(), "remove_child", cshape);
+			ur->add_undo_method_compat(node->get_parent(), "remove_child", cshape);
 			ur->commit_action();
 		} break;
 		case MENU_OPTION_CREATE_SINGLE_CONVEX_COLLISION_SHAPE: {
@@ -177,11 +177,11 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			Node *owner = node->get_owner();
 
-			ur->add_do_method(node->get_parent(), "add_child", cshape);
-			ur->add_do_method(node->get_parent(), "move_child", cshape, node->get_index() + 1);
-			ur->add_do_method(cshape, "set_owner", owner);
+			ur->add_do_method_compat(node->get_parent(), "add_child", cshape);
+			ur->add_do_method_compat(node->get_parent(), "move_child", cshape, node->get_index() + 1);
+			ur->add_do_method_compat(cshape, "set_owner", owner);
 			ur->add_do_reference(cshape);
-			ur->add_undo_method(node->get_parent(), "remove_child", cshape);
+			ur->add_undo_method_compat(node->get_parent(), "remove_child", cshape);
 
 			ur->commit_action();
 
@@ -211,11 +211,11 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 				Node *owner = node->get_owner();
 
-				ur->add_do_method(node->get_parent(), "add_child", cshape);
-				ur->add_do_method(node->get_parent(), "move_child", cshape, node->get_index() + 1);
-				ur->add_do_method(cshape, "set_owner", owner);
+				ur->add_do_method_compat(node->get_parent(), "add_child", cshape);
+				ur->add_do_method_compat(node->get_parent(), "move_child", cshape, node->get_index() + 1);
+				ur->add_do_method_compat(cshape, "set_owner", owner);
 				ur->add_do_reference(cshape);
-				ur->add_undo_method(node->get_parent(), "remove_child", cshape);
+				ur->add_undo_method_compat(node->get_parent(), "remove_child", cshape);
 			}
 			ur->commit_action();
 
@@ -237,11 +237,11 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Create Navigation Mesh"));
 
-			ur->add_do_method(node, "add_child", nmi);
-			ur->add_do_method(nmi, "set_owner", owner);
+			ur->add_do_method_compat(node, "add_child", nmi);
+			ur->add_do_method_compat(nmi, "set_owner", owner);
 
 			ur->add_do_reference(nmi);
-			ur->add_undo_method(node, "remove_child", nmi);
+			ur->add_undo_method_compat(node, "remove_child", nmi);
 			ur->commit_action();
 		} break;
 
@@ -415,11 +415,11 @@ void MeshInstance3DEditor::_create_outline_mesh() {
 
 	ur->create_action(TTR("Create Outline"));
 
-	ur->add_do_method(node, "add_child", mi);
-	ur->add_do_method(mi, "set_owner", owner);
+	ur->add_do_method_compat(node, "add_child", mi);
+	ur->add_do_method_compat(mi, "set_owner", owner);
 
 	ur->add_do_reference(mi);
-	ur->add_undo_method(node, "remove_child", mi);
+	ur->add_undo_method_compat(node, "remove_child", mi);
 	ur->commit_action();
 }
 

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -73,26 +73,26 @@ void NavigationPolygonEditor::_set_polygon(int p_idx, const Variant &p_polygon) 
 
 void NavigationPolygonEditor::_action_add_polygon(const Variant &p_polygon) {
 	Ref<NavigationPolygon> navpoly = _ensure_navpoly();
-	undo_redo->add_do_method(navpoly.ptr(), "add_outline", p_polygon);
-	undo_redo->add_undo_method(navpoly.ptr(), "remove_outline", navpoly->get_outline_count());
-	undo_redo->add_do_method(navpoly.ptr(), "make_polygons_from_outlines");
-	undo_redo->add_undo_method(navpoly.ptr(), "make_polygons_from_outlines");
+	undo_redo->add_do_method_compat(navpoly.ptr(), "add_outline", p_polygon);
+	undo_redo->add_undo_method_compat(navpoly.ptr(), "remove_outline", navpoly->get_outline_count());
+	undo_redo->add_do_method_compat(navpoly.ptr(), "make_polygons_from_outlines");
+	undo_redo->add_undo_method_compat(navpoly.ptr(), "make_polygons_from_outlines");
 }
 
 void NavigationPolygonEditor::_action_remove_polygon(int p_idx) {
 	Ref<NavigationPolygon> navpoly = _ensure_navpoly();
-	undo_redo->add_do_method(navpoly.ptr(), "remove_outline", p_idx);
-	undo_redo->add_undo_method(navpoly.ptr(), "add_outline_at_index", navpoly->get_outline(p_idx), p_idx);
-	undo_redo->add_do_method(navpoly.ptr(), "make_polygons_from_outlines");
-	undo_redo->add_undo_method(navpoly.ptr(), "make_polygons_from_outlines");
+	undo_redo->add_do_method_compat(navpoly.ptr(), "remove_outline", p_idx);
+	undo_redo->add_undo_method_compat(navpoly.ptr(), "add_outline_at_index", navpoly->get_outline(p_idx), p_idx);
+	undo_redo->add_do_method_compat(navpoly.ptr(), "make_polygons_from_outlines");
+	undo_redo->add_undo_method_compat(navpoly.ptr(), "make_polygons_from_outlines");
 }
 
 void NavigationPolygonEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
 	Ref<NavigationPolygon> navpoly = _ensure_navpoly();
-	undo_redo->add_do_method(navpoly.ptr(), "set_outline", p_idx, p_polygon);
-	undo_redo->add_undo_method(navpoly.ptr(), "set_outline", p_idx, p_previous);
-	undo_redo->add_do_method(navpoly.ptr(), "make_polygons_from_outlines");
-	undo_redo->add_undo_method(navpoly.ptr(), "make_polygons_from_outlines");
+	undo_redo->add_do_method_compat(navpoly.ptr(), "set_outline", p_idx, p_polygon);
+	undo_redo->add_undo_method_compat(navpoly.ptr(), "set_outline", p_idx, p_previous);
+	undo_redo->add_do_method_compat(navpoly.ptr(), "make_polygons_from_outlines");
+	undo_redo->add_undo_method_compat(navpoly.ptr(), "make_polygons_from_outlines");
 }
 
 bool NavigationPolygonEditor::_has_resource() const {
@@ -105,8 +105,8 @@ void NavigationPolygonEditor::_create_resource() {
 	}
 
 	undo_redo->create_action(TTR("Create Navigation Polygon"));
-	undo_redo->add_do_method(node, "set_navigation_polygon", Ref<NavigationPolygon>(memnew(NavigationPolygon)));
-	undo_redo->add_undo_method(node, "set_navigation_polygon", Variant(REF()));
+	undo_redo->add_do_method_compat(node, "set_navigation_polygon", Ref<NavigationPolygon>(memnew(NavigationPolygon)));
+	undo_redo->add_undo_method_compat(node, "set_navigation_polygon", Variant(REF()));
 	undo_redo->commit_action();
 
 	_menu_option(MODE_CREATE);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1383,8 +1383,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 								continue;
 							}
 
-							undo_redo->add_do_method(sp, "set_global_transform", sp->get_global_gizmo_transform());
-							undo_redo->add_undo_method(sp, "set_global_transform", se->original);
+							undo_redo->add_do_method_compat(sp, "set_global_transform", sp->get_global_gizmo_transform());
+							undo_redo->add_undo_method_compat(sp, "set_global_transform", se->original);
 						}
 						undo_redo->commit_action();
 						_edit.mode = TRANSFORM_NONE;
@@ -2877,8 +2877,8 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 					xform.scale_basis(sp->get_scale());
 				}
 
-				undo_redo->add_do_method(sp, "set_global_transform", xform);
-				undo_redo->add_undo_method(sp, "set_global_transform", sp->get_global_gizmo_transform());
+				undo_redo->add_do_method_compat(sp, "set_global_transform", xform);
+				undo_redo->add_undo_method_compat(sp, "set_global_transform", sp->get_global_gizmo_transform());
 			}
 			undo_redo->commit_action();
 
@@ -2904,8 +2904,8 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 					continue;
 				}
 
-				undo_redo->add_do_method(sp, "set_rotation", camera_transform.basis.get_rotation());
-				undo_redo->add_undo_method(sp, "set_rotation", sp->get_rotation());
+				undo_redo->add_do_method_compat(sp, "set_rotation", camera_transform.basis.get_rotation());
+				undo_redo->add_undo_method_compat(sp, "set_rotation", sp->get_rotation());
 			}
 			undo_redo->commit_action();
 
@@ -3727,15 +3727,15 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		instanced_scene->set_filename(ProjectSettings::get_singleton()->localize_path(path));
 	}
 
-	editor_data->get_undo_redo().add_do_method(parent, "add_child", instanced_scene);
-	editor_data->get_undo_redo().add_do_method(instanced_scene, "set_owner", editor->get_edited_scene());
+	editor_data->get_undo_redo().add_do_method_compat(parent, "add_child", instanced_scene);
+	editor_data->get_undo_redo().add_do_method_compat(instanced_scene, "set_owner", editor->get_edited_scene());
 	editor_data->get_undo_redo().add_do_reference(instanced_scene);
-	editor_data->get_undo_redo().add_undo_method(parent, "remove_child", instanced_scene);
+	editor_data->get_undo_redo().add_undo_method_compat(parent, "remove_child", instanced_scene);
 
 	String new_name = parent->validate_child_name(instanced_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-	editor_data->get_undo_redo().add_do_method(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
-	editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
+	editor_data->get_undo_redo().add_do_method_compat(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
+	editor_data->get_undo_redo().add_undo_method_compat(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
 
 	Node3D *node3d = Object::cast_to<Node3D>(instanced_scene);
 	if (node3d) {
@@ -3748,7 +3748,7 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		global_transform.origin = spatial_editor->snap_point(_get_instance_position(p_point));
 		global_transform.basis *= node3d->get_transform().basis;
 
-		editor_data->get_undo_redo().add_do_method(instanced_scene, "set_global_transform", global_transform);
+		editor_data->get_undo_redo().add_do_method_compat(instanced_scene, "set_global_transform", global_transform);
 	}
 
 	return true;
@@ -4856,8 +4856,8 @@ void Node3DEditor::_xform_dialog_action() {
 			tr.origin += t.origin;
 		}
 
-		undo_redo->add_do_method(sp, "set_global_transform", tr);
-		undo_redo->add_undo_method(sp, "set_global_transform", sp->get_global_gizmo_transform());
+		undo_redo->add_do_method_compat(sp, "set_global_transform", tr);
+		undo_redo->add_undo_method_compat(sp, "set_global_transform", sp->get_global_gizmo_transform());
 	}
 	undo_redo->commit_action();
 }
@@ -5082,14 +5082,14 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 					continue;
 				}
 
-				undo_redo->add_do_method(spatial, "set_meta", "_edit_lock_", true);
-				undo_redo->add_undo_method(spatial, "remove_meta", "_edit_lock_");
-				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_do_method_compat(spatial, "set_meta", "_edit_lock_", true);
+				undo_redo->add_undo_method_compat(spatial, "remove_meta", "_edit_lock_");
+				undo_redo->add_do_method_compat(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "item_lock_status_changed");
 			}
 
-			undo_redo->add_do_method(this, "_refresh_menu_icons");
-			undo_redo->add_undo_method(this, "_refresh_menu_icons");
+			undo_redo->add_do_method_compat(this, "_refresh_menu_icons");
+			undo_redo->add_undo_method_compat(this, "_refresh_menu_icons");
 			undo_redo->commit_action();
 		} break;
 		case MENU_UNLOCK_SELECTED: {
@@ -5107,14 +5107,14 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 					continue;
 				}
 
-				undo_redo->add_do_method(spatial, "remove_meta", "_edit_lock_");
-				undo_redo->add_undo_method(spatial, "set_meta", "_edit_lock_", true);
-				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_do_method_compat(spatial, "remove_meta", "_edit_lock_");
+				undo_redo->add_undo_method_compat(spatial, "set_meta", "_edit_lock_", true);
+				undo_redo->add_do_method_compat(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "item_lock_status_changed");
 			}
 
-			undo_redo->add_do_method(this, "_refresh_menu_icons");
-			undo_redo->add_undo_method(this, "_refresh_menu_icons");
+			undo_redo->add_do_method_compat(this, "_refresh_menu_icons");
+			undo_redo->add_undo_method_compat(this, "_refresh_menu_icons");
 			undo_redo->commit_action();
 		} break;
 		case MENU_GROUP_SELECTED: {
@@ -5132,14 +5132,14 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 					continue;
 				}
 
-				undo_redo->add_do_method(spatial, "set_meta", "_edit_group_", true);
-				undo_redo->add_undo_method(spatial, "remove_meta", "_edit_group_");
-				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_do_method_compat(spatial, "set_meta", "_edit_group_", true);
+				undo_redo->add_undo_method_compat(spatial, "remove_meta", "_edit_group_");
+				undo_redo->add_do_method_compat(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "item_group_status_changed");
 			}
 
-			undo_redo->add_do_method(this, "_refresh_menu_icons");
-			undo_redo->add_undo_method(this, "_refresh_menu_icons");
+			undo_redo->add_do_method_compat(this, "_refresh_menu_icons");
+			undo_redo->add_undo_method_compat(this, "_refresh_menu_icons");
 			undo_redo->commit_action();
 		} break;
 		case MENU_UNGROUP_SELECTED: {
@@ -5156,14 +5156,14 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 					continue;
 				}
 
-				undo_redo->add_do_method(spatial, "remove_meta", "_edit_group_");
-				undo_redo->add_undo_method(spatial, "set_meta", "_edit_group_", true);
-				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_do_method_compat(spatial, "remove_meta", "_edit_group_");
+				undo_redo->add_undo_method_compat(spatial, "set_meta", "_edit_group_", true);
+				undo_redo->add_do_method_compat(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "item_group_status_changed");
 			}
 
-			undo_redo->add_do_method(this, "_refresh_menu_icons");
-			undo_redo->add_undo_method(this, "_refresh_menu_icons");
+			undo_redo->add_do_method_compat(this, "_refresh_menu_icons");
+			undo_redo->add_undo_method_compat(this, "_refresh_menu_icons");
 			undo_redo->commit_action();
 		} break;
 	}
@@ -5974,8 +5974,8 @@ void Node3DEditor::snap_selected_nodes_to_floor() {
 					new_transform.origin.y = result.position.y;
 					new_transform.origin = new_transform.origin - position_offset;
 
-					undo_redo->add_do_method(sp, "set_global_transform", new_transform);
-					undo_redo->add_undo_method(sp, "set_global_transform", sp->get_global_transform());
+					undo_redo->add_do_method_compat(sp, "set_global_transform", new_transform);
+					undo_redo->add_undo_method_compat(sp, "set_global_transform", sp->get_global_transform());
 				}
 			}
 

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -121,26 +121,26 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 				if ((mb->get_button_index() == BUTTON_RIGHT && mode == MODE_EDIT) || (mb->get_button_index() == BUTTON_LEFT && mode == MODE_DELETE)) {
 					if (dist_to_p < grab_threshold) {
 						undo_redo->create_action(TTR("Remove Point from Curve"));
-						undo_redo->add_do_method(curve.ptr(), "remove_point", i);
-						undo_redo->add_undo_method(curve.ptr(), "add_point", curve->get_point_position(i), curve->get_point_in(i), curve->get_point_out(i), i);
-						undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-						undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+						undo_redo->add_do_method_compat(curve.ptr(), "remove_point", i);
+						undo_redo->add_undo_method_compat(curve.ptr(), "add_point", curve->get_point_position(i), curve->get_point_in(i), curve->get_point_out(i), i);
+						undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+						undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 						undo_redo->commit_action();
 						return true;
 					} else if (dist_to_p_out < grab_threshold) {
 						undo_redo->create_action(TTR("Remove Out-Control from Curve"));
-						undo_redo->add_do_method(curve.ptr(), "set_point_out", i, Vector2());
-						undo_redo->add_undo_method(curve.ptr(), "set_point_out", i, curve->get_point_out(i));
-						undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-						undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+						undo_redo->add_do_method_compat(curve.ptr(), "set_point_out", i, Vector2());
+						undo_redo->add_undo_method_compat(curve.ptr(), "set_point_out", i, curve->get_point_out(i));
+						undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+						undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 						undo_redo->commit_action();
 						return true;
 					} else if (dist_to_p_in < grab_threshold) {
 						undo_redo->create_action(TTR("Remove In-Control from Curve"));
-						undo_redo->add_do_method(curve.ptr(), "set_point_in", i, Vector2());
-						undo_redo->add_undo_method(curve.ptr(), "set_point_in", i, curve->get_point_in(i));
-						undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-						undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+						undo_redo->add_do_method_compat(curve.ptr(), "set_point_in", i, Vector2());
+						undo_redo->add_undo_method_compat(curve.ptr(), "set_point_in", i, curve->get_point_in(i));
+						undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+						undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 						undo_redo->commit_action();
 						return true;
 					}
@@ -153,10 +153,10 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 			Ref<Curve2D> curve = node->get_curve();
 
 			undo_redo->create_action(TTR("Add Point to Curve"));
-			undo_redo->add_do_method(curve.ptr(), "add_point", cpoint);
-			undo_redo->add_undo_method(curve.ptr(), "remove_point", curve->get_point_count());
-			undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-			undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+			undo_redo->add_do_method_compat(curve.ptr(), "add_point", cpoint);
+			undo_redo->add_undo_method_compat(curve.ptr(), "remove_point", curve->get_point_count());
+			undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+			undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 			undo_redo->commit_action();
 
 			action = ACTION_MOVING_POINT;
@@ -188,10 +188,10 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			undo_redo->create_action(TTR("Split Curve"));
-			undo_redo->add_do_method(curve.ptr(), "add_point", xform.affine_inverse().xform(gpoint2), Vector2(0, 0), Vector2(0, 0), insertion_point + 1);
-			undo_redo->add_undo_method(curve.ptr(), "remove_point", insertion_point + 1);
-			undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-			undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+			undo_redo->add_do_method_compat(curve.ptr(), "add_point", xform.affine_inverse().xform(gpoint2), Vector2(0, 0), Vector2(0, 0), insertion_point + 1);
+			undo_redo->add_undo_method_compat(curve.ptr(), "remove_point", insertion_point + 1);
+			undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+			undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 			undo_redo->commit_action();
 
 			action = ACTION_MOVING_POINT;
@@ -218,40 +218,40 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 				case ACTION_MOVING_POINT: {
 					undo_redo->create_action(TTR("Move Point in Curve"));
-					undo_redo->add_do_method(curve.ptr(), "set_point_position", action_point, cpoint);
-					undo_redo->add_undo_method(curve.ptr(), "set_point_position", action_point, moving_from);
-					undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-					undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+					undo_redo->add_do_method_compat(curve.ptr(), "set_point_position", action_point, cpoint);
+					undo_redo->add_undo_method_compat(curve.ptr(), "set_point_position", action_point, moving_from);
+					undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+					undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 					undo_redo->commit_action();
 
 				} break;
 
 				case ACTION_MOVING_IN: {
 					undo_redo->create_action(TTR("Move In-Control in Curve"));
-					undo_redo->add_do_method(curve.ptr(), "set_point_in", action_point, new_pos);
-					undo_redo->add_undo_method(curve.ptr(), "set_point_in", action_point, moving_from);
+					undo_redo->add_do_method_compat(curve.ptr(), "set_point_in", action_point, new_pos);
+					undo_redo->add_undo_method_compat(curve.ptr(), "set_point_in", action_point, moving_from);
 
 					if (mirror_handle_angle) {
-						undo_redo->add_do_method(curve.ptr(), "set_point_out", action_point, mirror_handle_length ? -new_pos : (-new_pos.normalized() * orig_out_length));
-						undo_redo->add_undo_method(curve.ptr(), "set_point_out", action_point, mirror_handle_length ? -moving_from : (-moving_from.normalized() * orig_out_length));
+						undo_redo->add_do_method_compat(curve.ptr(), "set_point_out", action_point, mirror_handle_length ? -new_pos : (-new_pos.normalized() * orig_out_length));
+						undo_redo->add_undo_method_compat(curve.ptr(), "set_point_out", action_point, mirror_handle_length ? -moving_from : (-moving_from.normalized() * orig_out_length));
 					}
-					undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-					undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+					undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+					undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 					undo_redo->commit_action();
 
 				} break;
 
 				case ACTION_MOVING_OUT: {
 					undo_redo->create_action(TTR("Move Out-Control in Curve"));
-					undo_redo->add_do_method(curve.ptr(), "set_point_out", action_point, new_pos);
-					undo_redo->add_undo_method(curve.ptr(), "set_point_out", action_point, moving_from);
+					undo_redo->add_do_method_compat(curve.ptr(), "set_point_out", action_point, new_pos);
+					undo_redo->add_undo_method_compat(curve.ptr(), "set_point_out", action_point, moving_from);
 
 					if (mirror_handle_angle) {
-						undo_redo->add_do_method(curve.ptr(), "set_point_in", action_point, mirror_handle_length ? -new_pos : (-new_pos.normalized() * orig_in_length));
-						undo_redo->add_undo_method(curve.ptr(), "set_point_in", action_point, mirror_handle_length ? -moving_from : (-moving_from.normalized() * orig_in_length));
+						undo_redo->add_do_method_compat(curve.ptr(), "set_point_in", action_point, mirror_handle_length ? -new_pos : (-new_pos.normalized() * orig_in_length));
+						undo_redo->add_undo_method_compat(curve.ptr(), "set_point_in", action_point, mirror_handle_length ? -moving_from : (-moving_from.normalized() * orig_in_length));
 					}
-					undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-					undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+					undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+					undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 					undo_redo->commit_action();
 
 				} break;
@@ -486,10 +486,10 @@ void Path2DEditor::_mode_selected(int p_mode) {
 		}
 
 		undo_redo->create_action(TTR("Remove Point from Curve"));
-		undo_redo->add_do_method(node->get_curve().ptr(), "add_point", begin);
-		undo_redo->add_undo_method(node->get_curve().ptr(), "remove_point", node->get_curve()->get_point_count());
-		undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-		undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+		undo_redo->add_do_method_compat(node->get_curve().ptr(), "add_point", begin);
+		undo_redo->add_undo_method_compat(node->get_curve().ptr(), "remove_point", node->get_curve()->get_point_count());
+		undo_redo->add_do_method_compat(canvas_item_editor, "update_viewport");
+		undo_redo->add_undo_method_compat(canvas_item_editor, "update_viewport");
 		undo_redo->commit_action();
 		return;
 	}

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -171,8 +171,8 @@ void Path3DGizmo::commit_handle(int p_idx, const Variant &p_restore, bool p_canc
 			return;
 		}
 		ur->create_action(TTR("Set Curve Point Position"));
-		ur->add_do_method(c.ptr(), "set_point_position", p_idx, c->get_point_position(p_idx));
-		ur->add_undo_method(c.ptr(), "set_point_position", p_idx, p_restore);
+		ur->add_do_method_compat(c.ptr(), "set_point_position", p_idx, c->get_point_position(p_idx));
+		ur->add_undo_method_compat(c.ptr(), "set_point_position", p_idx, p_restore);
 		ur->commit_action();
 
 		return;
@@ -190,12 +190,12 @@ void Path3DGizmo::commit_handle(int p_idx, const Variant &p_restore, bool p_canc
 		}
 
 		ur->create_action(TTR("Set Curve In Position"));
-		ur->add_do_method(c.ptr(), "set_point_in", idx, c->get_point_in(idx));
-		ur->add_undo_method(c.ptr(), "set_point_in", idx, p_restore);
+		ur->add_do_method_compat(c.ptr(), "set_point_in", idx, c->get_point_in(idx));
+		ur->add_undo_method_compat(c.ptr(), "set_point_in", idx, p_restore);
 
 		if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
-			ur->add_do_method(c.ptr(), "set_point_out", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -c->get_point_in(idx) : (-c->get_point_in(idx).normalized() * orig_out_length));
-			ur->add_undo_method(c.ptr(), "set_point_out", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -static_cast<Vector3>(p_restore) : (-static_cast<Vector3>(p_restore).normalized() * orig_out_length));
+			ur->add_do_method_compat(c.ptr(), "set_point_out", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -c->get_point_in(idx) : (-c->get_point_in(idx).normalized() * orig_out_length));
+			ur->add_undo_method_compat(c.ptr(), "set_point_out", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -static_cast<Vector3>(p_restore) : (-static_cast<Vector3>(p_restore).normalized() * orig_out_length));
 		}
 		ur->commit_action();
 
@@ -207,12 +207,12 @@ void Path3DGizmo::commit_handle(int p_idx, const Variant &p_restore, bool p_canc
 		}
 
 		ur->create_action(TTR("Set Curve Out Position"));
-		ur->add_do_method(c.ptr(), "set_point_out", idx, c->get_point_out(idx));
-		ur->add_undo_method(c.ptr(), "set_point_out", idx, p_restore);
+		ur->add_do_method_compat(c.ptr(), "set_point_out", idx, c->get_point_out(idx));
+		ur->add_undo_method_compat(c.ptr(), "set_point_out", idx, p_restore);
 
 		if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
-			ur->add_do_method(c.ptr(), "set_point_in", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -c->get_point_out(idx) : (-c->get_point_out(idx).normalized() * orig_in_length));
-			ur->add_undo_method(c.ptr(), "set_point_in", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -static_cast<Vector3>(p_restore) : (-static_cast<Vector3>(p_restore).normalized() * orig_in_length));
+			ur->add_do_method_compat(c.ptr(), "set_point_in", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -c->get_point_out(idx) : (-c->get_point_out(idx).normalized() * orig_in_length));
+			ur->add_undo_method_compat(c.ptr(), "set_point_in", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -static_cast<Vector3>(p_restore) : (-static_cast<Vector3>(p_restore).normalized() * orig_in_length));
 		}
 		ur->commit_action();
 	}
@@ -383,8 +383,8 @@ bool Path3DEditorPlugin::forward_spatial_gui_input(Camera3D *p_camera, const Ref
 				//subdivide
 
 				ur->create_action(TTR("Split Path"));
-				ur->add_do_method(c.ptr(), "add_point", closest_seg_point, Vector3(), Vector3(), closest_seg + 1);
-				ur->add_undo_method(c.ptr(), "remove_point", closest_seg + 1);
+				ur->add_do_method_compat(c.ptr(), "add_point", closest_seg_point, Vector3(), Vector3(), closest_seg + 1);
+				ur->add_undo_method_compat(c.ptr(), "remove_point", closest_seg + 1);
 				ur->commit_action();
 				return true;
 
@@ -402,8 +402,8 @@ bool Path3DEditorPlugin::forward_spatial_gui_input(Camera3D *p_camera, const Ref
 				Vector3 inters;
 				if (p.intersects_ray(ray_from, ray_dir, &inters)) {
 					ur->create_action(TTR("Add Point to Curve"));
-					ur->add_do_method(c.ptr(), "add_point", it.xform(inters), Vector3(), Vector3(), -1);
-					ur->add_undo_method(c.ptr(), "remove_point", c->get_point_count());
+					ur->add_do_method_compat(c.ptr(), "add_point", it.xform(inters), Vector3(), Vector3(), -1);
+					ur->add_undo_method_compat(c.ptr(), "remove_point", c->get_point_count());
 					ur->commit_action();
 					return true;
 				}
@@ -422,22 +422,22 @@ bool Path3DEditorPlugin::forward_spatial_gui_input(Camera3D *p_camera, const Ref
 				if (dist_to_p < click_dist) {
 					UndoRedo *ur = editor->get_undo_redo();
 					ur->create_action(TTR("Remove Path Point"));
-					ur->add_do_method(c.ptr(), "remove_point", i);
-					ur->add_undo_method(c.ptr(), "add_point", c->get_point_position(i), c->get_point_in(i), c->get_point_out(i), i);
+					ur->add_do_method_compat(c.ptr(), "remove_point", i);
+					ur->add_undo_method_compat(c.ptr(), "add_point", c->get_point_position(i), c->get_point_in(i), c->get_point_out(i), i);
 					ur->commit_action();
 					return true;
 				} else if (dist_to_p_out < click_dist) {
 					UndoRedo *ur = editor->get_undo_redo();
 					ur->create_action(TTR("Remove Out-Control Point"));
-					ur->add_do_method(c.ptr(), "set_point_out", i, Vector3());
-					ur->add_undo_method(c.ptr(), "set_point_out", i, c->get_point_out(i));
+					ur->add_do_method_compat(c.ptr(), "set_point_out", i, Vector3());
+					ur->add_undo_method_compat(c.ptr(), "set_point_out", i, c->get_point_out(i));
 					ur->commit_action();
 					return true;
 				} else if (dist_to_p_in < click_dist) {
 					UndoRedo *ur = editor->get_undo_redo();
 					ur->create_action(TTR("Remove In-Control Point"));
-					ur->add_do_method(c.ptr(), "set_point_in", i, Vector3());
-					ur->add_undo_method(c.ptr(), "set_point_in", i, c->get_point_in(i));
+					ur->add_do_method_compat(c.ptr(), "set_point_in", i, Vector3());
+					ur->add_undo_method_compat(c.ptr(), "set_point_in", i, c->get_point_in(i));
 					ur->commit_action();
 					return true;
 				}

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -142,12 +142,12 @@ void Polygon2DEditor::_sync_bones() {
 	Array new_bones = node->call("_get_bones");
 
 	undo_redo->create_action(TTR("Sync Bones"));
-	undo_redo->add_do_method(node, "_set_bones", new_bones);
-	undo_redo->add_undo_method(node, "_set_bones", prev_bones);
-	undo_redo->add_do_method(this, "_update_bone_list");
-	undo_redo->add_undo_method(this, "_update_bone_list");
-	undo_redo->add_do_method(uv_edit_draw, "update");
-	undo_redo->add_undo_method(uv_edit_draw, "update");
+	undo_redo->add_do_method_compat(node, "_set_bones", new_bones);
+	undo_redo->add_undo_method_compat(node, "_set_bones", prev_bones);
+	undo_redo->add_do_method_compat(this, "_update_bone_list");
+	undo_redo->add_undo_method_compat(this, "_update_bone_list");
+	undo_redo->add_do_method_compat(uv_edit_draw, "update");
+	undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 	undo_redo->commit_action();
 }
 
@@ -282,10 +282,10 @@ void Polygon2DEditor::_menu_option(int p_option) {
 			Vector<Vector2> uvs = node->get_uv();
 			if (uvs.size() != points.size()) {
 				undo_redo->create_action(TTR("Create UV Map"));
-				undo_redo->add_do_method(node, "set_uv", points);
-				undo_redo->add_undo_method(node, "set_uv", uvs);
-				undo_redo->add_do_method(uv_edit_draw, "update");
-				undo_redo->add_undo_method(uv_edit_draw, "update");
+				undo_redo->add_do_method_compat(node, "set_uv", points);
+				undo_redo->add_undo_method_compat(node, "set_uv", uvs);
+				undo_redo->add_do_method_compat(uv_edit_draw, "update");
+				undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 				undo_redo->commit_action();
 			}
 
@@ -303,10 +303,10 @@ void Polygon2DEditor::_menu_option(int p_option) {
 			}
 			Vector<Vector2> uvs = node->get_uv();
 			undo_redo->create_action(TTR("Create UV Map"));
-			undo_redo->add_do_method(node, "set_uv", points);
-			undo_redo->add_undo_method(node, "set_uv", uvs);
-			undo_redo->add_do_method(uv_edit_draw, "update");
-			undo_redo->add_undo_method(uv_edit_draw, "update");
+			undo_redo->add_do_method_compat(node, "set_uv", points);
+			undo_redo->add_undo_method_compat(node, "set_uv", uvs);
+			undo_redo->add_do_method_compat(uv_edit_draw, "update");
+			undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 			undo_redo->commit_action();
 		} break;
 		case UVEDIT_UV_TO_POLYGON: {
@@ -317,10 +317,10 @@ void Polygon2DEditor::_menu_option(int p_option) {
 			}
 
 			undo_redo->create_action(TTR("Create Polygon"));
-			undo_redo->add_do_method(node, "set_polygon", uvs);
-			undo_redo->add_undo_method(node, "set_polygon", points);
-			undo_redo->add_do_method(uv_edit_draw, "update");
-			undo_redo->add_undo_method(uv_edit_draw, "update");
+			undo_redo->add_do_method_compat(node, "set_polygon", uvs);
+			undo_redo->add_undo_method_compat(node, "set_polygon", points);
+			undo_redo->add_do_method_compat(uv_edit_draw, "update");
+			undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 			undo_redo->commit_action();
 		} break;
 		case UVEDIT_UV_CLEAR: {
@@ -329,10 +329,10 @@ void Polygon2DEditor::_menu_option(int p_option) {
 				break;
 			}
 			undo_redo->create_action(TTR("Create UV Map"));
-			undo_redo->add_do_method(node, "set_uv", Vector<Vector2>());
-			undo_redo->add_undo_method(node, "set_uv", uvs);
-			undo_redo->add_do_method(uv_edit_draw, "update");
-			undo_redo->add_undo_method(uv_edit_draw, "update");
+			undo_redo->add_do_method_compat(node, "set_uv", Vector<Vector2>());
+			undo_redo->add_undo_method_compat(node, "set_uv", uvs);
+			undo_redo->add_do_method_compat(uv_edit_draw, "update");
+			undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 			undo_redo->commit_action();
 		} break;
 		case UVEDIT_GRID_SETTINGS: {
@@ -382,10 +382,10 @@ void Polygon2DEditor::_update_polygon_editing_state() {
 
 void Polygon2DEditor::_commit_action() {
 	// Makes that undo/redoing actions made outside of the UV editor still affect its polygon.
-	undo_redo->add_do_method(uv_edit_draw, "update");
-	undo_redo->add_undo_method(uv_edit_draw, "update");
-	undo_redo->add_do_method(CanvasItemEditor::get_singleton(), "update_viewport");
-	undo_redo->add_undo_method(CanvasItemEditor::get_singleton(), "update_viewport");
+	undo_redo->add_do_method_compat(uv_edit_draw, "update");
+	undo_redo->add_undo_method_compat(uv_edit_draw, "update");
+	undo_redo->add_do_method_compat(CanvasItemEditor::get_singleton(), "update_viewport");
+	undo_redo->add_undo_method_compat(CanvasItemEditor::get_singleton(), "update_viewport");
 	undo_redo->commit_action();
 }
 
@@ -488,20 +488,20 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 						// Close the polygon if selected point is near start. Threshold for closing scaled by zoom level
 						if (points_prev.size() > 2 && tuv.distance_to(points_prev[0]) < (8 / uv_draw_zoom)) {
 							undo_redo->create_action(TTR("Create Polygon & UV"));
-							undo_redo->add_do_method(node, "set_uv", node->get_uv());
-							undo_redo->add_undo_method(node, "set_uv", uv_create_uv_prev);
-							undo_redo->add_do_method(node, "set_polygon", node->get_polygon());
-							undo_redo->add_undo_method(node, "set_polygon", uv_create_poly_prev);
-							undo_redo->add_do_method(node, "set_internal_vertex_count", 0);
-							undo_redo->add_undo_method(node, "set_internal_vertex_count", uv_create_prev_internal_vertices);
-							undo_redo->add_do_method(node, "set_vertex_colors", Vector<Color>());
-							undo_redo->add_undo_method(node, "set_vertex_colors", uv_create_colors_prev);
-							undo_redo->add_do_method(node, "clear_bones");
-							undo_redo->add_undo_method(node, "_set_bones", uv_create_bones_prev);
-							undo_redo->add_do_method(this, "_update_polygon_editing_state");
-							undo_redo->add_undo_method(this, "_update_polygon_editing_state");
-							undo_redo->add_do_method(uv_edit_draw, "update");
-							undo_redo->add_undo_method(uv_edit_draw, "update");
+							undo_redo->add_do_method_compat(node, "set_uv", node->get_uv());
+							undo_redo->add_undo_method_compat(node, "set_uv", uv_create_uv_prev);
+							undo_redo->add_do_method_compat(node, "set_polygon", node->get_polygon());
+							undo_redo->add_undo_method_compat(node, "set_polygon", uv_create_poly_prev);
+							undo_redo->add_do_method_compat(node, "set_internal_vertex_count", 0);
+							undo_redo->add_undo_method_compat(node, "set_internal_vertex_count", uv_create_prev_internal_vertices);
+							undo_redo->add_do_method_compat(node, "set_vertex_colors", Vector<Color>());
+							undo_redo->add_undo_method_compat(node, "set_vertex_colors", uv_create_colors_prev);
+							undo_redo->add_do_method_compat(node, "clear_bones");
+							undo_redo->add_undo_method_compat(node, "_set_bones", uv_create_bones_prev);
+							undo_redo->add_do_method_compat(this, "_update_polygon_editing_state");
+							undo_redo->add_undo_method_compat(this, "_update_polygon_editing_state");
+							undo_redo->add_do_method_compat(uv_edit_draw, "update");
+							undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 							undo_redo->commit_action();
 							uv_drag = false;
 							uv_create = false;
@@ -536,24 +536,24 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					}
 
 					undo_redo->create_action(TTR("Create Internal Vertex"));
-					undo_redo->add_do_method(node, "set_uv", uv_create_uv_prev);
-					undo_redo->add_undo_method(node, "set_uv", node->get_uv());
-					undo_redo->add_do_method(node, "set_polygon", uv_create_poly_prev);
-					undo_redo->add_undo_method(node, "set_polygon", node->get_polygon());
-					undo_redo->add_do_method(node, "set_vertex_colors", uv_create_colors_prev);
-					undo_redo->add_undo_method(node, "set_vertex_colors", node->get_vertex_colors());
+					undo_redo->add_do_method_compat(node, "set_uv", uv_create_uv_prev);
+					undo_redo->add_undo_method_compat(node, "set_uv", node->get_uv());
+					undo_redo->add_do_method_compat(node, "set_polygon", uv_create_poly_prev);
+					undo_redo->add_undo_method_compat(node, "set_polygon", node->get_polygon());
+					undo_redo->add_do_method_compat(node, "set_vertex_colors", uv_create_colors_prev);
+					undo_redo->add_undo_method_compat(node, "set_vertex_colors", node->get_vertex_colors());
 					for (int i = 0; i < node->get_bone_count(); i++) {
 						Vector<float> bonew = node->get_bone_weights(i);
 						bonew.push_back(0);
-						undo_redo->add_do_method(node, "set_bone_weights", i, bonew);
-						undo_redo->add_undo_method(node, "set_bone_weights", i, node->get_bone_weights(i));
+						undo_redo->add_do_method_compat(node, "set_bone_weights", i, bonew);
+						undo_redo->add_undo_method_compat(node, "set_bone_weights", i, node->get_bone_weights(i));
 					}
-					undo_redo->add_do_method(node, "set_internal_vertex_count", internal_vertices + 1);
-					undo_redo->add_undo_method(node, "set_internal_vertex_count", internal_vertices);
-					undo_redo->add_do_method(this, "_update_polygon_editing_state");
-					undo_redo->add_undo_method(this, "_update_polygon_editing_state");
-					undo_redo->add_do_method(uv_edit_draw, "update");
-					undo_redo->add_undo_method(uv_edit_draw, "update");
+					undo_redo->add_do_method_compat(node, "set_internal_vertex_count", internal_vertices + 1);
+					undo_redo->add_undo_method_compat(node, "set_internal_vertex_count", internal_vertices);
+					undo_redo->add_do_method_compat(this, "_update_polygon_editing_state");
+					undo_redo->add_undo_method_compat(this, "_update_polygon_editing_state");
+					undo_redo->add_do_method_compat(uv_edit_draw, "update");
+					undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 					undo_redo->commit_action();
 				}
 
@@ -591,24 +591,24 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					}
 
 					undo_redo->create_action(TTR("Remove Internal Vertex"));
-					undo_redo->add_do_method(node, "set_uv", uv_create_uv_prev);
-					undo_redo->add_undo_method(node, "set_uv", node->get_uv());
-					undo_redo->add_do_method(node, "set_polygon", uv_create_poly_prev);
-					undo_redo->add_undo_method(node, "set_polygon", node->get_polygon());
-					undo_redo->add_do_method(node, "set_vertex_colors", uv_create_colors_prev);
-					undo_redo->add_undo_method(node, "set_vertex_colors", node->get_vertex_colors());
+					undo_redo->add_do_method_compat(node, "set_uv", uv_create_uv_prev);
+					undo_redo->add_undo_method_compat(node, "set_uv", node->get_uv());
+					undo_redo->add_do_method_compat(node, "set_polygon", uv_create_poly_prev);
+					undo_redo->add_undo_method_compat(node, "set_polygon", node->get_polygon());
+					undo_redo->add_do_method_compat(node, "set_vertex_colors", uv_create_colors_prev);
+					undo_redo->add_undo_method_compat(node, "set_vertex_colors", node->get_vertex_colors());
 					for (int i = 0; i < node->get_bone_count(); i++) {
 						Vector<float> bonew = node->get_bone_weights(i);
 						bonew.remove(closest);
-						undo_redo->add_do_method(node, "set_bone_weights", i, bonew);
-						undo_redo->add_undo_method(node, "set_bone_weights", i, node->get_bone_weights(i));
+						undo_redo->add_do_method_compat(node, "set_bone_weights", i, bonew);
+						undo_redo->add_undo_method_compat(node, "set_bone_weights", i, node->get_bone_weights(i));
 					}
-					undo_redo->add_do_method(node, "set_internal_vertex_count", internal_vertices - 1);
-					undo_redo->add_undo_method(node, "set_internal_vertex_count", internal_vertices);
-					undo_redo->add_do_method(this, "_update_polygon_editing_state");
-					undo_redo->add_undo_method(this, "_update_polygon_editing_state");
-					undo_redo->add_do_method(uv_edit_draw, "update");
-					undo_redo->add_undo_method(uv_edit_draw, "update");
+					undo_redo->add_do_method_compat(node, "set_internal_vertex_count", internal_vertices - 1);
+					undo_redo->add_undo_method_compat(node, "set_internal_vertex_count", internal_vertices);
+					undo_redo->add_do_method_compat(this, "_update_polygon_editing_state");
+					undo_redo->add_undo_method_compat(this, "_update_polygon_editing_state");
+					undo_redo->add_do_method_compat(uv_edit_draw, "update");
+					undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 					undo_redo->commit_action();
 				}
 
@@ -663,10 +663,10 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 								//todo, could check whether it already exists?
 								polygons.push_back(polygon_create);
 								undo_redo->create_action(TTR("Add Custom Polygon"));
-								undo_redo->add_do_method(node, "set_polygons", polygons);
-								undo_redo->add_undo_method(node, "set_polygons", node->get_polygons());
-								undo_redo->add_do_method(uv_edit_draw, "update");
-								undo_redo->add_undo_method(uv_edit_draw, "update");
+								undo_redo->add_do_method_compat(node, "set_polygons", polygons);
+								undo_redo->add_undo_method_compat(node, "set_polygons", node->get_polygons());
+								undo_redo->add_do_method_compat(uv_edit_draw, "update");
+								undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 								undo_redo->commit_action();
 							}
 
@@ -704,10 +704,10 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					if (erase_index != -1) {
 						polygons.remove(erase_index);
 						undo_redo->create_action(TTR("Remove Custom Polygon"));
-						undo_redo->add_do_method(node, "set_polygons", polygons);
-						undo_redo->add_undo_method(node, "set_polygons", node->get_polygons());
-						undo_redo->add_do_method(uv_edit_draw, "update");
-						undo_redo->add_undo_method(uv_edit_draw, "update");
+						undo_redo->add_do_method_compat(node, "set_polygons", polygons);
+						undo_redo->add_undo_method_compat(node, "set_polygons", node->get_polygons());
+						undo_redo->add_do_method_compat(uv_edit_draw, "update");
+						undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 						undo_redo->commit_action();
 					}
 				}
@@ -732,17 +732,17 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 				if (uv_drag && !uv_create) {
 					if (uv_edit_mode[0]->is_pressed()) { // Edit UV.
 						undo_redo->create_action(TTR("Transform UV Map"));
-						undo_redo->add_do_method(node, "set_uv", node->get_uv());
-						undo_redo->add_undo_method(node, "set_uv", points_prev);
-						undo_redo->add_do_method(uv_edit_draw, "update");
-						undo_redo->add_undo_method(uv_edit_draw, "update");
+						undo_redo->add_do_method_compat(node, "set_uv", node->get_uv());
+						undo_redo->add_undo_method_compat(node, "set_uv", points_prev);
+						undo_redo->add_do_method_compat(uv_edit_draw, "update");
+						undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 						undo_redo->commit_action();
 					} else if (uv_edit_mode[1]->is_pressed() && uv_move_current == UV_MODE_EDIT_POINT) { // Edit polygon.
 						undo_redo->create_action(TTR("Transform Polygon"));
-						undo_redo->add_do_method(node, "set_polygon", node->get_polygon());
-						undo_redo->add_undo_method(node, "set_polygon", points_prev);
-						undo_redo->add_do_method(uv_edit_draw, "update");
-						undo_redo->add_undo_method(uv_edit_draw, "update");
+						undo_redo->add_do_method_compat(node, "set_polygon", node->get_polygon());
+						undo_redo->add_undo_method_compat(node, "set_polygon", points_prev);
+						undo_redo->add_do_method_compat(uv_edit_draw, "update");
+						undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 						undo_redo->commit_action();
 					}
 
@@ -751,10 +751,10 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 
 				if (bone_painting) {
 					undo_redo->create_action(TTR("Paint Bone Weights"));
-					undo_redo->add_do_method(node, "set_bone_weights", bone_painting_bone, node->get_bone_weights(bone_painting_bone));
-					undo_redo->add_undo_method(node, "set_bone_weights", bone_painting_bone, prev_weights);
-					undo_redo->add_do_method(uv_edit_draw, "update");
-					undo_redo->add_undo_method(uv_edit_draw, "update");
+					undo_redo->add_do_method_compat(node, "set_bone_weights", bone_painting_bone, node->get_bone_weights(bone_painting_bone));
+					undo_redo->add_undo_method_compat(node, "set_bone_weights", bone_painting_bone, prev_weights);
+					undo_redo->add_do_method_compat(uv_edit_draw, "update");
+					undo_redo->add_undo_method_compat(uv_edit_draw, "update");
 					undo_redo->commit_action();
 					bone_painting = false;
 				}

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -76,10 +76,10 @@ void ResourcePreloaderEditor::_files_load_request(const Vector<String> &p_paths)
 		}
 
 		undo_redo->create_action(TTR("Add Resource"));
-		undo_redo->add_do_method(preloader, "add_resource", name, resource);
-		undo_redo->add_undo_method(preloader, "remove_resource", name);
-		undo_redo->add_do_method(this, "_update_library");
-		undo_redo->add_undo_method(this, "_update_library");
+		undo_redo->add_do_method_compat(preloader, "add_resource", name, resource);
+		undo_redo->add_undo_method_compat(preloader, "remove_resource", name);
+		undo_redo->add_do_method_compat(this, "_update_library");
+		undo_redo->add_undo_method_compat(this, "_update_library");
 		undo_redo->commit_action();
 	}
 }
@@ -120,22 +120,22 @@ void ResourcePreloaderEditor::_item_edited() {
 
 		RES samp = preloader->get_resource(old_name);
 		undo_redo->create_action(TTR("Rename Resource"));
-		undo_redo->add_do_method(preloader, "remove_resource", old_name);
-		undo_redo->add_do_method(preloader, "add_resource", new_name, samp);
-		undo_redo->add_undo_method(preloader, "remove_resource", new_name);
-		undo_redo->add_undo_method(preloader, "add_resource", old_name, samp);
-		undo_redo->add_do_method(this, "_update_library");
-		undo_redo->add_undo_method(this, "_update_library");
+		undo_redo->add_do_method_compat(preloader, "remove_resource", old_name);
+		undo_redo->add_do_method_compat(preloader, "add_resource", new_name, samp);
+		undo_redo->add_undo_method_compat(preloader, "remove_resource", new_name);
+		undo_redo->add_undo_method_compat(preloader, "add_resource", old_name, samp);
+		undo_redo->add_do_method_compat(this, "_update_library");
+		undo_redo->add_undo_method_compat(this, "_update_library");
 		undo_redo->commit_action();
 	}
 }
 
 void ResourcePreloaderEditor::_remove_resource(const String &p_to_remove) {
 	undo_redo->create_action(TTR("Delete Resource"));
-	undo_redo->add_do_method(preloader, "remove_resource", p_to_remove);
-	undo_redo->add_undo_method(preloader, "add_resource", p_to_remove, preloader->get_resource(p_to_remove));
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(preloader, "remove_resource", p_to_remove);
+	undo_redo->add_undo_method_compat(preloader, "add_resource", p_to_remove, preloader->get_resource(p_to_remove));
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 	undo_redo->commit_action();
 }
 
@@ -165,10 +165,10 @@ void ResourcePreloaderEditor::_paste_pressed() {
 	}
 
 	undo_redo->create_action(TTR("Paste Resource"));
-	undo_redo->add_do_method(preloader, "add_resource", name, r);
-	undo_redo->add_undo_method(preloader, "remove_resource", name);
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(preloader, "add_resource", name, r);
+	undo_redo->add_undo_method_compat(preloader, "remove_resource", name);
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 	undo_redo->commit_action();
 }
 
@@ -319,10 +319,10 @@ void ResourcePreloaderEditor::drop_data_fw(const Point2 &p_point, const Variant 
 			}
 
 			undo_redo->create_action(TTR("Add Resource"));
-			undo_redo->add_do_method(preloader, "add_resource", name, r);
-			undo_redo->add_undo_method(preloader, "remove_resource", name);
-			undo_redo->add_do_method(this, "_update_library");
-			undo_redo->add_undo_method(this, "_update_library");
+			undo_redo->add_do_method_compat(preloader, "add_resource", name, r);
+			undo_redo->add_undo_method_compat(preloader, "remove_resource", name);
+			undo_redo->add_do_method_compat(this, "_update_library");
+			undo_redo->add_undo_method_compat(this, "_update_library");
 			undo_redo->commit_action();
 		}
 	}

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -62,8 +62,8 @@ void Skeleton2DEditor::_menu_option(int p_option) {
 			ur->create_action(TTR("Create Rest Pose from Bones"));
 			for (int i = 0; i < node->get_bone_count(); i++) {
 				Bone2D *bone = node->get_bone(i);
-				ur->add_do_method(bone, "set_rest", bone->get_transform());
-				ur->add_undo_method(bone, "set_rest", bone->get_rest());
+				ur->add_do_method_compat(bone, "set_rest", bone->get_transform());
+				ur->add_undo_method_compat(bone, "set_rest", bone->get_rest());
 			}
 			ur->commit_action();
 
@@ -78,8 +78,8 @@ void Skeleton2DEditor::_menu_option(int p_option) {
 			ur->create_action(TTR("Set Rest Pose to Bones"));
 			for (int i = 0; i < node->get_bone_count(); i++) {
 				Bone2D *bone = node->get_bone(i);
-				ur->add_do_method(bone, "set_transform", bone->get_rest());
-				ur->add_undo_method(bone, "set_transform", bone->get_transform());
+				ur->add_do_method_compat(bone, "set_transform", bone->get_rest());
+				ur->add_undo_method_compat(bone, "set_transform", bone->get_transform());
 			}
 			ur->commit_action();
 

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -202,8 +202,8 @@ void BoneTransformEditor::_value_changed_transform(const String p_property_name,
 void BoneTransformEditor::_change_transform(Transform p_new_transform) {
 	if (property.get_slicec('/', 0) == "bones" && property.get_slicec('/', 2) == "custom_pose") {
 		undo_redo->create_action(TTR("Set Custom Bone Pose Transform"), UndoRedo::MERGE_ENDS);
-		undo_redo->add_undo_method(skeleton, "set_bone_custom_pose", property.get_slicec('/', 1).to_int(), skeleton->get_bone_custom_pose(property.get_slicec('/', 1).to_int()));
-		undo_redo->add_do_method(skeleton, "set_bone_custom_pose", property.get_slicec('/', 1).to_int(), p_new_transform);
+		undo_redo->add_undo_method_compat(skeleton, "set_bone_custom_pose", property.get_slicec('/', 1).to_int(), skeleton->get_bone_custom_pose(property.get_slicec('/', 1).to_int()));
+		undo_redo->add_do_method_compat(skeleton, "set_bone_custom_pose", property.get_slicec('/', 1).to_int(), p_new_transform);
 		undo_redo->commit_action();
 	} else if (property.get_slicec('/', 0) == "bones") {
 		undo_redo->create_action(TTR("Set Bone Transform"), UndoRedo::MERGE_ENDS);
@@ -352,9 +352,9 @@ void Skeleton3DEditor::create_physical_skeleton() {
 				bones_infos.write[parent].physical_bone = create_physical_bone(parent, bone_id, bones_infos);
 
 				ur->create_action(TTR("Create physical bones"));
-				ur->add_do_method(skeleton, "add_child", bones_infos[parent].physical_bone);
+				ur->add_do_method_compat(skeleton, "add_child", bones_infos[parent].physical_bone);
 				ur->add_do_reference(bones_infos[parent].physical_bone);
-				ur->add_undo_method(skeleton, "remove_child", bones_infos[parent].physical_bone);
+				ur->add_undo_method_compat(skeleton, "remove_child", bones_infos[parent].physical_bone);
 				ur->commit_action();
 
 				bones_infos[parent].physical_bone->set_bone_name(skeleton->get_bone_name(parent));
@@ -470,14 +470,14 @@ void Skeleton3DEditor::move_skeleton_bone(NodePath p_skeleton_path, int32_t p_se
 		const int bone_count = skeleton->get_bone_count();
 		for (BoneId i = 0; i < bone_count; ++i) {
 			if (skeleton->get_bone_parent(i) == p_selected_boneidx) {
-				ur->add_undo_method(skeleton, "set_bone_parent", i, skeleton->get_bone_parent(i));
-				ur->add_do_method(skeleton, "set_bone_parent", i, parent_idx);
+				ur->add_undo_method_compat(skeleton, "set_bone_parent", i, skeleton->get_bone_parent(i));
+				ur->add_do_method_compat(skeleton, "set_bone_parent", i, parent_idx);
 				skeleton->set_bone_parent(i, parent_idx);
 			}
 		}
 	}
-	ur->add_undo_method(skeleton, "set_bone_parent", p_selected_boneidx, skeleton->get_bone_parent(p_selected_boneidx));
-	ur->add_do_method(skeleton, "set_bone_parent", p_selected_boneidx, p_target_boneidx);
+	ur->add_undo_method_compat(skeleton, "set_bone_parent", p_selected_boneidx, skeleton->get_bone_parent(p_selected_boneidx));
+	ur->add_do_method_compat(skeleton, "set_bone_parent", p_selected_boneidx, p_target_boneidx);
 	skeleton->set_bone_parent(p_selected_boneidx, p_target_boneidx);
 
 	update_joint_tree();

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -332,9 +332,9 @@ void Sprite2DEditor::_convert_to_mesh_2d_node() {
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Convert to Mesh2D"));
-	ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, mesh_instance, true, false);
+	ur->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, mesh_instance, true, false);
 	ur->add_do_reference(mesh_instance);
-	ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", mesh_instance, node, false, false);
+	ur->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", mesh_instance, node, false, false);
 	ur->add_undo_reference(node);
 	ur->commit_action();
 }
@@ -390,9 +390,9 @@ void Sprite2DEditor::_convert_to_polygon_2d_node() {
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Convert to Polygon2D"));
-	ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, polygon_2d_instance, true, false);
+	ur->add_do_method_compat(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, polygon_2d_instance, true, false);
 	ur->add_do_reference(polygon_2d_instance);
-	ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", polygon_2d_instance, node, false, false);
+	ur->add_undo_method_compat(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", polygon_2d_instance, node, false, false);
 	ur->add_undo_reference(node);
 	ur->commit_action();
 }
@@ -412,9 +412,9 @@ void Sprite2DEditor::_create_collision_polygon_2d_node() {
 
 		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Create CollisionPolygon2D Sibling"));
-		ur->add_do_method(this, "_add_as_sibling_or_child", node, collision_polygon_2d_instance);
+		ur->add_do_method_compat(this, "_add_as_sibling_or_child", node, collision_polygon_2d_instance);
 		ur->add_do_reference(collision_polygon_2d_instance);
-		ur->add_undo_method(node != this->get_tree()->get_edited_scene_root() ? node->get_parent() : this->get_tree()->get_edited_scene_root(), "remove_child", collision_polygon_2d_instance);
+		ur->add_undo_method_compat(node != this->get_tree()->get_edited_scene_root() ? node->get_parent() : this->get_tree()->get_edited_scene_root(), "remove_child", collision_polygon_2d_instance);
 		ur->commit_action();
 	}
 }
@@ -445,9 +445,9 @@ void Sprite2DEditor::_create_light_occluder_2d_node() {
 
 		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Create LightOccluder2D Sibling"));
-		ur->add_do_method(this, "_add_as_sibling_or_child", node, light_occluder_2d_instance);
+		ur->add_do_method_compat(this, "_add_as_sibling_or_child", node, light_occluder_2d_instance);
 		ur->add_do_reference(light_occluder_2d_instance);
-		ur->add_undo_method(node != this->get_tree()->get_edited_scene_root() ? node->get_parent() : this->get_tree()->get_edited_scene_root(), "remove_child", light_occluder_2d_instance);
+		ur->add_undo_method_compat(node != this->get_tree()->get_edited_scene_root() ? node->get_parent() : this->get_tree()->get_edited_scene_root(), "remove_child", light_occluder_2d_instance);
 		ur->commit_action();
 	}
 }

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -192,12 +192,12 @@ void SpriteFramesEditor::_sheet_add_frames() {
 		at->set_atlas(split_sheet_preview->get_texture());
 		at->set_region(Rect2(x, y, width, height));
 
-		undo_redo->add_do_method(frames, "add_frame", edited_anim, at, -1);
-		undo_redo->add_undo_method(frames, "remove_frame", edited_anim, fc);
+		undo_redo->add_do_method_compat(frames, "add_frame", edited_anim, at, -1);
+		undo_redo->add_undo_method_compat(frames, "remove_frame", edited_anim, fc);
 	}
 
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 	undo_redo->commit_action();
 }
 
@@ -328,12 +328,12 @@ void SpriteFramesEditor::_file_load_request(const Vector<String> &p_path, int p_
 	int count = 0;
 
 	for (List<Ref<Texture2D>>::Element *E = resources.front(); E; E = E->next()) {
-		undo_redo->add_do_method(frames, "add_frame", edited_anim, E->get(), p_at_pos == -1 ? -1 : p_at_pos + count);
-		undo_redo->add_undo_method(frames, "remove_frame", edited_anim, p_at_pos == -1 ? fc : p_at_pos);
+		undo_redo->add_do_method_compat(frames, "add_frame", edited_anim, E->get(), p_at_pos == -1 ? -1 : p_at_pos + count);
+		undo_redo->add_undo_method_compat(frames, "remove_frame", edited_anim, p_at_pos == -1 ? fc : p_at_pos);
 		count++;
 	}
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 
 	undo_redo->commit_action();
 }
@@ -367,10 +367,10 @@ void SpriteFramesEditor::_paste_pressed() {
 	}
 
 	undo_redo->create_action(TTR("Paste Frame"));
-	undo_redo->add_do_method(frames, "add_frame", edited_anim, r);
-	undo_redo->add_undo_method(frames, "remove_frame", edited_anim, frames->get_frame_count(edited_anim));
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(frames, "add_frame", edited_anim, r);
+	undo_redo->add_undo_method_compat(frames, "remove_frame", edited_anim, frames->get_frame_count(edited_anim));
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 	undo_redo->commit_action();
 }
 
@@ -404,10 +404,10 @@ void SpriteFramesEditor::_empty_pressed() {
 	Ref<Texture2D> r;
 
 	undo_redo->create_action(TTR("Add Empty"));
-	undo_redo->add_do_method(frames, "add_frame", edited_anim, r, from);
-	undo_redo->add_undo_method(frames, "remove_frame", edited_anim, from);
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(frames, "add_frame", edited_anim, r, from);
+	undo_redo->add_undo_method_compat(frames, "remove_frame", edited_anim, from);
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 	undo_redo->commit_action();
 }
 
@@ -427,10 +427,10 @@ void SpriteFramesEditor::_empty2_pressed() {
 	Ref<Texture2D> r;
 
 	undo_redo->create_action(TTR("Add Empty"));
-	undo_redo->add_do_method(frames, "add_frame", edited_anim, r, from + 1);
-	undo_redo->add_undo_method(frames, "remove_frame", edited_anim, from + 1);
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(frames, "add_frame", edited_anim, r, from + 1);
+	undo_redo->add_undo_method_compat(frames, "remove_frame", edited_anim, from + 1);
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 	undo_redo->commit_action();
 }
 
@@ -450,12 +450,12 @@ void SpriteFramesEditor::_up_pressed() {
 	sel -= 1;
 
 	undo_redo->create_action(TTR("Delete Resource"));
-	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move - 1));
-	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move - 1, frames->get_frame(edited_anim, to_move));
-	undo_redo->add_undo_method(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move));
-	undo_redo->add_undo_method(frames, "set_frame", edited_anim, to_move - 1, frames->get_frame(edited_anim, to_move - 1));
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move - 1));
+	undo_redo->add_do_method_compat(frames, "set_frame", edited_anim, to_move - 1, frames->get_frame(edited_anim, to_move));
+	undo_redo->add_undo_method_compat(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move));
+	undo_redo->add_undo_method_compat(frames, "set_frame", edited_anim, to_move - 1, frames->get_frame(edited_anim, to_move - 1));
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 	undo_redo->commit_action();
 }
 
@@ -475,12 +475,12 @@ void SpriteFramesEditor::_down_pressed() {
 	sel += 1;
 
 	undo_redo->create_action(TTR("Delete Resource"));
-	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move + 1));
-	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move + 1, frames->get_frame(edited_anim, to_move));
-	undo_redo->add_undo_method(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move));
-	undo_redo->add_undo_method(frames, "set_frame", edited_anim, to_move + 1, frames->get_frame(edited_anim, to_move + 1));
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move + 1));
+	undo_redo->add_do_method_compat(frames, "set_frame", edited_anim, to_move + 1, frames->get_frame(edited_anim, to_move));
+	undo_redo->add_undo_method_compat(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move));
+	undo_redo->add_undo_method_compat(frames, "set_frame", edited_anim, to_move + 1, frames->get_frame(edited_anim, to_move + 1));
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 	undo_redo->commit_action();
 }
 
@@ -497,10 +497,10 @@ void SpriteFramesEditor::_delete_pressed() {
 	}
 
 	undo_redo->create_action(TTR("Delete Resource"));
-	undo_redo->add_do_method(frames, "remove_frame", edited_anim, to_delete);
-	undo_redo->add_undo_method(frames, "add_frame", edited_anim, frames->get_frame(edited_anim, to_delete), to_delete);
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(frames, "remove_frame", edited_anim, to_delete);
+	undo_redo->add_undo_method_compat(frames, "add_frame", edited_anim, frames->get_frame(edited_anim, to_delete), to_delete);
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 	undo_redo->commit_action();
 }
 
@@ -583,17 +583,17 @@ void SpriteFramesEditor::_animation_name_edited() {
 	_find_anim_sprites(EditorNode::get_singleton()->get_edited_scene(), &nodes, Ref<SpriteFrames>(frames));
 
 	undo_redo->create_action(TTR("Rename Animation"));
-	undo_redo->add_do_method(frames, "rename_animation", edited_anim, name);
-	undo_redo->add_undo_method(frames, "rename_animation", name, edited_anim);
+	undo_redo->add_do_method_compat(frames, "rename_animation", edited_anim, name);
+	undo_redo->add_undo_method_compat(frames, "rename_animation", name, edited_anim);
 
 	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
 		String current = E->get()->call("get_animation");
-		undo_redo->add_do_method(E->get(), "set_animation", name);
-		undo_redo->add_undo_method(E->get(), "set_animation", edited_anim);
+		undo_redo->add_do_method_compat(E->get(), "set_animation", name);
+		undo_redo->add_undo_method_compat(E->get(), "set_animation", edited_anim);
 	}
 
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 
 	edited_anim = new_name;
 
@@ -612,15 +612,15 @@ void SpriteFramesEditor::_animation_add() {
 	_find_anim_sprites(EditorNode::get_singleton()->get_edited_scene(), &nodes, Ref<SpriteFrames>(frames));
 
 	undo_redo->create_action(TTR("Add Animation"));
-	undo_redo->add_do_method(frames, "add_animation", name);
-	undo_redo->add_undo_method(frames, "remove_animation", name);
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(frames, "add_animation", name);
+	undo_redo->add_undo_method_compat(frames, "remove_animation", name);
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 
 	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
 		String current = E->get()->call("get_animation");
-		undo_redo->add_do_method(E->get(), "set_animation", name);
-		undo_redo->add_undo_method(E->get(), "set_animation", current);
+		undo_redo->add_do_method_compat(E->get(), "set_animation", name);
+		undo_redo->add_undo_method_compat(E->get(), "set_animation", current);
 	}
 
 	edited_anim = name;
@@ -644,17 +644,17 @@ void SpriteFramesEditor::_animation_remove() {
 
 void SpriteFramesEditor::_animation_remove_confirmed() {
 	undo_redo->create_action(TTR("Remove Animation"));
-	undo_redo->add_do_method(frames, "remove_animation", edited_anim);
-	undo_redo->add_undo_method(frames, "add_animation", edited_anim);
-	undo_redo->add_undo_method(frames, "set_animation_speed", edited_anim, frames->get_animation_speed(edited_anim));
-	undo_redo->add_undo_method(frames, "set_animation_loop", edited_anim, frames->get_animation_loop(edited_anim));
+	undo_redo->add_do_method_compat(frames, "remove_animation", edited_anim);
+	undo_redo->add_undo_method_compat(frames, "add_animation", edited_anim);
+	undo_redo->add_undo_method_compat(frames, "set_animation_speed", edited_anim, frames->get_animation_speed(edited_anim));
+	undo_redo->add_undo_method_compat(frames, "set_animation_loop", edited_anim, frames->get_animation_loop(edited_anim));
 	int fc = frames->get_frame_count(edited_anim);
 	for (int i = 0; i < fc; i++) {
 		Ref<Texture2D> frame = frames->get_frame(edited_anim, i);
-		undo_redo->add_undo_method(frames, "add_frame", edited_anim, frame);
+		undo_redo->add_undo_method_compat(frames, "add_frame", edited_anim, frame);
 	}
-	undo_redo->add_do_method(this, "_update_library");
-	undo_redo->add_undo_method(this, "_update_library");
+	undo_redo->add_do_method_compat(this, "_update_library");
+	undo_redo->add_undo_method_compat(this, "_update_library");
 
 	edited_anim = StringName();
 
@@ -667,10 +667,10 @@ void SpriteFramesEditor::_animation_loop_changed() {
 	}
 
 	undo_redo->create_action(TTR("Change Animation Loop"));
-	undo_redo->add_do_method(frames, "set_animation_loop", edited_anim, anim_loop->is_pressed());
-	undo_redo->add_undo_method(frames, "set_animation_loop", edited_anim, frames->get_animation_loop(edited_anim));
-	undo_redo->add_do_method(this, "_update_library", true);
-	undo_redo->add_undo_method(this, "_update_library", true);
+	undo_redo->add_do_method_compat(frames, "set_animation_loop", edited_anim, anim_loop->is_pressed());
+	undo_redo->add_undo_method_compat(frames, "set_animation_loop", edited_anim, frames->get_animation_loop(edited_anim));
+	undo_redo->add_do_method_compat(this, "_update_library", true);
+	undo_redo->add_undo_method_compat(this, "_update_library", true);
 	undo_redo->commit_action();
 }
 
@@ -680,10 +680,10 @@ void SpriteFramesEditor::_animation_fps_changed(double p_value) {
 	}
 
 	undo_redo->create_action(TTR("Change Animation FPS"), UndoRedo::MERGE_ENDS);
-	undo_redo->add_do_method(frames, "set_animation_speed", edited_anim, p_value);
-	undo_redo->add_undo_method(frames, "set_animation_speed", edited_anim, frames->get_animation_speed(edited_anim));
-	undo_redo->add_do_method(this, "_update_library", true);
-	undo_redo->add_undo_method(this, "_update_library", true);
+	undo_redo->add_do_method_compat(frames, "set_animation_speed", edited_anim, p_value);
+	undo_redo->add_undo_method_compat(frames, "set_animation_speed", edited_anim, frames->get_animation_speed(edited_anim));
+	undo_redo->add_do_method_compat(this, "_update_library", true);
+	undo_redo->add_undo_method_compat(this, "_update_library", true);
 
 	undo_redo->commit_action();
 }
@@ -931,19 +931,19 @@ void SpriteFramesEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				}
 
 				undo_redo->create_action(TTR("Move Frame"));
-				undo_redo->add_do_method(frames, "remove_frame", edited_anim, from_frame == -1 ? frames->get_frame_count(edited_anim) : from_frame);
-				undo_redo->add_do_method(frames, "add_frame", edited_anim, texture, at_pos == -1 ? -1 : at_pos);
-				undo_redo->add_undo_method(frames, "remove_frame", edited_anim, at_pos == -1 ? frames->get_frame_count(edited_anim) - 1 : at_pos);
-				undo_redo->add_undo_method(frames, "add_frame", edited_anim, texture, from_frame);
-				undo_redo->add_do_method(this, "_update_library");
-				undo_redo->add_undo_method(this, "_update_library");
+				undo_redo->add_do_method_compat(frames, "remove_frame", edited_anim, from_frame == -1 ? frames->get_frame_count(edited_anim) : from_frame);
+				undo_redo->add_do_method_compat(frames, "add_frame", edited_anim, texture, at_pos == -1 ? -1 : at_pos);
+				undo_redo->add_undo_method_compat(frames, "remove_frame", edited_anim, at_pos == -1 ? frames->get_frame_count(edited_anim) - 1 : at_pos);
+				undo_redo->add_undo_method_compat(frames, "add_frame", edited_anim, texture, from_frame);
+				undo_redo->add_do_method_compat(this, "_update_library");
+				undo_redo->add_undo_method_compat(this, "_update_library");
 				undo_redo->commit_action();
 			} else {
 				undo_redo->create_action(TTR("Add Frame"));
-				undo_redo->add_do_method(frames, "add_frame", edited_anim, texture, at_pos == -1 ? -1 : at_pos);
-				undo_redo->add_undo_method(frames, "remove_frame", edited_anim, at_pos == -1 ? frames->get_frame_count(edited_anim) : at_pos);
-				undo_redo->add_do_method(this, "_update_library");
-				undo_redo->add_undo_method(this, "_update_library");
+				undo_redo->add_do_method_compat(frames, "add_frame", edited_anim, texture, at_pos == -1 ? -1 : at_pos);
+				undo_redo->add_undo_method_compat(frames, "remove_frame", edited_anim, at_pos == -1 ? frames->get_frame_count(edited_anim) : at_pos);
+				undo_redo->add_do_method_compat(this, "_update_library");
+				undo_redo->add_undo_method_compat(this, "_update_library");
 				undo_redo->commit_action();
 			}
 		}

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -336,25 +336,25 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 							}
 							undo_redo->create_action(TTR("Set Region Rect"));
 							if (node_sprite) {
-								undo_redo->add_do_method(node_sprite, "set_region_rect", rect);
-								undo_redo->add_undo_method(node_sprite, "set_region_rect", node_sprite->get_region_rect());
+								undo_redo->add_do_method_compat(node_sprite, "set_region_rect", rect);
+								undo_redo->add_undo_method_compat(node_sprite, "set_region_rect", node_sprite->get_region_rect());
 							} else if (node_sprite_3d) {
-								undo_redo->add_do_method(node_sprite_3d, "set_region_rect", rect);
-								undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
+								undo_redo->add_do_method_compat(node_sprite_3d, "set_region_rect", rect);
+								undo_redo->add_undo_method_compat(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
 							} else if (node_ninepatch) {
-								undo_redo->add_do_method(node_ninepatch, "set_region_rect", rect);
-								undo_redo->add_undo_method(node_ninepatch, "set_region_rect", node_ninepatch->get_region_rect());
+								undo_redo->add_do_method_compat(node_ninepatch, "set_region_rect", rect);
+								undo_redo->add_undo_method_compat(node_ninepatch, "set_region_rect", node_ninepatch->get_region_rect());
 							} else if (obj_styleBox.is_valid()) {
-								undo_redo->add_do_method(obj_styleBox.ptr(), "set_region_rect", rect);
-								undo_redo->add_undo_method(obj_styleBox.ptr(), "set_region_rect", obj_styleBox->get_region_rect());
+								undo_redo->add_do_method_compat(obj_styleBox.ptr(), "set_region_rect", rect);
+								undo_redo->add_undo_method_compat(obj_styleBox.ptr(), "set_region_rect", obj_styleBox->get_region_rect());
 							} else if (atlas_tex.is_valid()) {
-								undo_redo->add_do_method(atlas_tex.ptr(), "set_region", rect);
-								undo_redo->add_undo_method(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
+								undo_redo->add_do_method_compat(atlas_tex.ptr(), "set_region", rect);
+								undo_redo->add_undo_method_compat(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
 							}
-							undo_redo->add_do_method(this, "_update_rect");
-							undo_redo->add_undo_method(this, "_update_rect");
-							undo_redo->add_do_method(edit_draw, "update");
-							undo_redo->add_undo_method(edit_draw, "update");
+							undo_redo->add_do_method_compat(this, "_update_rect");
+							undo_redo->add_undo_method_compat(this, "_update_rect");
+							undo_redo->add_do_method_compat(edit_draw, "update");
+							undo_redo->add_undo_method_compat(edit_draw, "update");
 							undo_redo->commit_action();
 							break;
 						}
@@ -397,38 +397,38 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					undo_redo->create_action(TTR("Set Margin"));
 					static Side side[4] = { SIDE_TOP, SIDE_BOTTOM, SIDE_LEFT, SIDE_RIGHT };
 					if (node_ninepatch) {
-						undo_redo->add_do_method(node_ninepatch, "set_patch_margin", side[edited_margin], node_ninepatch->get_patch_margin(side[edited_margin]));
-						undo_redo->add_undo_method(node_ninepatch, "set_patch_margin", side[edited_margin], prev_margin);
+						undo_redo->add_do_method_compat(node_ninepatch, "set_patch_margin", side[edited_margin], node_ninepatch->get_patch_margin(side[edited_margin]));
+						undo_redo->add_undo_method_compat(node_ninepatch, "set_patch_margin", side[edited_margin], prev_margin);
 					} else if (obj_styleBox.is_valid()) {
-						undo_redo->add_do_method(obj_styleBox.ptr(), "set_margin_size", side[edited_margin], obj_styleBox->get_margin_size(side[edited_margin]));
-						undo_redo->add_undo_method(obj_styleBox.ptr(), "set_margin_size", side[edited_margin], prev_margin);
+						undo_redo->add_do_method_compat(obj_styleBox.ptr(), "set_margin_size", side[edited_margin], obj_styleBox->get_margin_size(side[edited_margin]));
+						undo_redo->add_undo_method_compat(obj_styleBox.ptr(), "set_margin_size", side[edited_margin], prev_margin);
 						obj_styleBox->emit_signal(CoreStringNames::get_singleton()->changed);
 					}
 					edited_margin = -1;
 				} else {
 					undo_redo->create_action(TTR("Set Region Rect"));
 					if (node_sprite) {
-						undo_redo->add_do_method(node_sprite, "set_region_rect", node_sprite->get_region_rect());
-						undo_redo->add_undo_method(node_sprite, "set_region_rect", rect_prev);
+						undo_redo->add_do_method_compat(node_sprite, "set_region_rect", node_sprite->get_region_rect());
+						undo_redo->add_undo_method_compat(node_sprite, "set_region_rect", rect_prev);
 					} else if (node_sprite_3d) {
-						undo_redo->add_do_method(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
-						undo_redo->add_undo_method(node_sprite_3d, "set_region_rect", rect_prev);
+						undo_redo->add_do_method_compat(node_sprite_3d, "set_region_rect", node_sprite_3d->get_region_rect());
+						undo_redo->add_undo_method_compat(node_sprite_3d, "set_region_rect", rect_prev);
 					} else if (atlas_tex.is_valid()) {
-						undo_redo->add_do_method(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
-						undo_redo->add_undo_method(atlas_tex.ptr(), "set_region", rect_prev);
+						undo_redo->add_do_method_compat(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
+						undo_redo->add_undo_method_compat(atlas_tex.ptr(), "set_region", rect_prev);
 					} else if (node_ninepatch) {
-						undo_redo->add_do_method(node_ninepatch, "set_region_rect", node_ninepatch->get_region_rect());
-						undo_redo->add_undo_method(node_ninepatch, "set_region_rect", rect_prev);
+						undo_redo->add_do_method_compat(node_ninepatch, "set_region_rect", node_ninepatch->get_region_rect());
+						undo_redo->add_undo_method_compat(node_ninepatch, "set_region_rect", rect_prev);
 					} else if (obj_styleBox.is_valid()) {
-						undo_redo->add_do_method(obj_styleBox.ptr(), "set_region_rect", obj_styleBox->get_region_rect());
-						undo_redo->add_undo_method(obj_styleBox.ptr(), "set_region_rect", rect_prev);
+						undo_redo->add_do_method_compat(obj_styleBox.ptr(), "set_region_rect", obj_styleBox->get_region_rect());
+						undo_redo->add_undo_method_compat(obj_styleBox.ptr(), "set_region_rect", rect_prev);
 					}
 					drag_index = -1;
 				}
-				undo_redo->add_do_method(this, "_update_rect");
-				undo_redo->add_undo_method(this, "_update_rect");
-				undo_redo->add_do_method(edit_draw, "update");
-				undo_redo->add_undo_method(edit_draw, "update");
+				undo_redo->add_do_method_compat(this, "_update_rect");
+				undo_redo->add_undo_method_compat(this, "_update_rect");
+				undo_redo->add_do_method_compat(edit_draw, "update");
+				undo_redo->add_undo_method_compat(edit_draw, "update");
 				undo_redo->commit_action();
 				drag = false;
 				creating = false;

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -192,9 +192,9 @@ void TileMapEditor::_menu_option(int p_option) {
 		} break;
 		case OPTION_FIX_INVALID: {
 			undo_redo->create_action(TTR("Fix Invalid Tiles"));
-			undo_redo->add_undo_method(node, "set", "tile_data", node->get("tile_data"));
+			undo_redo->add_undo_method_compat(node, "set", "tile_data", node->get("tile_data"));
 			node->fix_invalid_tiles();
-			undo_redo->add_do_method(node, "set", "tile_data", node->get("tile_data"));
+			undo_redo->add_do_method_compat(node, "set", "tile_data", node->get("tile_data"));
 			undo_redo->commit_action();
 
 		} break;
@@ -294,8 +294,8 @@ void TileMapEditor::_create_set_cell_undo_redo(const Vector2 &p_vec, const CellO
 	Dictionary cell_old = _create_cell_dictionary(p_cell_old.idx, p_cell_old.xf, p_cell_old.yf, p_cell_old.tr, p_cell_old.ac);
 	Dictionary cell_new = _create_cell_dictionary(p_cell_new.idx, p_cell_new.xf, p_cell_new.yf, p_cell_new.tr, p_cell_new.ac);
 
-	undo_redo->add_undo_method(node, "_set_celld", p_vec, cell_old);
-	undo_redo->add_do_method(node, "_set_celld", p_vec, cell_new);
+	undo_redo->add_undo_method_compat(node, "_set_celld", p_vec, cell_old);
+	undo_redo->add_do_method_compat(node, "_set_celld", p_vec, cell_new);
 }
 
 void TileMapEditor::_start_undo(const String &p_action) {
@@ -1309,8 +1309,8 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 					undo_redo->create_action(TTR("Bucket Fill"));
 
-					undo_redo->add_do_method(this, "_erase_points", points);
-					undo_redo->add_undo_method(this, "_fill_points", points, pop);
+					undo_redo->add_do_method_compat(this, "_erase_points", points);
+					undo_redo->add_undo_method_compat(this, "_fill_points", points, pop);
 
 					undo_redo->commit_action();
 				}

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -716,13 +716,13 @@ void TileSetEditor::_on_tileset_toolbar_confirm() {
 			undo_redo->create_action(TTR("Remove Texture"));
 			for (List<int>::Element *E = ids.front(); E; E = E->next()) {
 				if (tileset->tile_get_texture(E->get())->get_rid() == current_rid) {
-					undo_redo->add_do_method(tileset.ptr(), "remove_tile", E->get());
+					undo_redo->add_do_method_compat(tileset.ptr(), "remove_tile", E->get());
 					_undo_tile_removal(E->get());
 				}
 			}
-			undo_redo->add_do_method(this, "remove_texture", get_current_texture());
-			undo_redo->add_undo_method(this, "add_texture", get_current_texture());
-			undo_redo->add_undo_method(this, "update_texture_list_icon");
+			undo_redo->add_do_method_compat(this, "remove_texture", get_current_texture());
+			undo_redo->add_undo_method_compat(this, "add_texture", get_current_texture());
+			undo_redo->add_undo_method_compat(this, "update_texture_list_icon");
 			undo_redo->commit_action();
 		} break;
 		case TOOL_TILESET_MERGE_SCENE:
@@ -737,13 +737,13 @@ void TileSetEditor::_on_tileset_toolbar_confirm() {
 			tileset->get_tile_list(&ids);
 
 			undo_redo->create_action(option == TOOL_TILESET_MERGE_SCENE ? TTR("Merge Tileset from Scene") : TTR("Create Tileset from Scene"));
-			undo_redo->add_do_method(this, "_undo_redo_import_scene", scene, option == TOOL_TILESET_MERGE_SCENE);
-			undo_redo->add_undo_method(tileset.ptr(), "clear");
+			undo_redo->add_do_method_compat(this, "_undo_redo_import_scene", scene, option == TOOL_TILESET_MERGE_SCENE);
+			undo_redo->add_undo_method_compat(tileset.ptr(), "clear");
 			for (List<int>::Element *E = ids.front(); E; E = E->next()) {
 				_undo_tile_removal(E->get());
 			}
-			undo_redo->add_do_method(this, "edit", tileset);
-			undo_redo->add_undo_method(this, "edit", tileset);
+			undo_redo->add_do_method_compat(this, "edit", tileset);
+			undo_redo->add_undo_method_compat(this, "edit", tileset);
 			undo_redo->commit_action();
 		} break;
 	}
@@ -1336,45 +1336,45 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 				if (!edited_region.has_no_area()) {
 					if (get_current_tile() >= 0 && workspace_mode == WORKSPACE_EDIT) {
 						undo_redo->create_action(TTR("Set Tile Region"));
-						undo_redo->add_do_method(tileset.ptr(), "tile_set_region", get_current_tile(), edited_region);
-						undo_redo->add_undo_method(tileset.ptr(), "tile_set_region", get_current_tile(), tileset->tile_get_region(get_current_tile()));
+						undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_region", get_current_tile(), edited_region);
+						undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_region", get_current_tile(), tileset->tile_get_region(get_current_tile()));
 
 						Size2 tile_workspace_size = edited_region.position + edited_region.size + WORKSPACE_MARGIN * 2;
 						Size2 workspace_minsize = workspace->get_custom_minimum_size();
 						// If the new region is bigger, just directly change the workspace size to avoid checking all other tiles.
 						if (tile_workspace_size.x > workspace_minsize.x || tile_workspace_size.y > workspace_minsize.y) {
 							Size2 max_workspace_size = Size2(MAX(tile_workspace_size.x, workspace_minsize.x), MAX(tile_workspace_size.y, workspace_minsize.y));
-							undo_redo->add_do_method(workspace, "set_custom_minimum_size", max_workspace_size);
-							undo_redo->add_undo_method(workspace, "set_custom_minimum_size", workspace_minsize);
-							undo_redo->add_do_method(workspace_container, "set_custom_minimum_size", max_workspace_size);
-							undo_redo->add_undo_method(workspace_container, "set_custom_minimum_size", workspace_minsize);
-							undo_redo->add_do_method(workspace_overlay, "set_custom_minimum_size", max_workspace_size);
-							undo_redo->add_undo_method(workspace_overlay, "set_custom_minimum_size", workspace_minsize);
+							undo_redo->add_do_method_compat(workspace, "set_custom_minimum_size", max_workspace_size);
+							undo_redo->add_undo_method_compat(workspace, "set_custom_minimum_size", workspace_minsize);
+							undo_redo->add_do_method_compat(workspace_container, "set_custom_minimum_size", max_workspace_size);
+							undo_redo->add_undo_method_compat(workspace_container, "set_custom_minimum_size", workspace_minsize);
+							undo_redo->add_do_method_compat(workspace_overlay, "set_custom_minimum_size", max_workspace_size);
+							undo_redo->add_undo_method_compat(workspace_overlay, "set_custom_minimum_size", workspace_minsize);
 						} else if (workspace_minsize.x > get_current_texture()->get_size().x + WORKSPACE_MARGIN.x * 2 || workspace_minsize.y > get_current_texture()->get_size().y + WORKSPACE_MARGIN.y * 2) {
-							undo_redo->add_do_method(this, "update_workspace_minsize");
-							undo_redo->add_undo_method(this, "update_workspace_minsize");
+							undo_redo->add_do_method_compat(this, "update_workspace_minsize");
+							undo_redo->add_undo_method_compat(this, "update_workspace_minsize");
 						}
 
 						edited_region = Rect2();
 
-						undo_redo->add_do_method(workspace, "update");
-						undo_redo->add_undo_method(workspace, "update");
-						undo_redo->add_do_method(workspace_overlay, "update");
-						undo_redo->add_undo_method(workspace_overlay, "update");
+						undo_redo->add_do_method_compat(workspace, "update");
+						undo_redo->add_undo_method_compat(workspace, "update");
+						undo_redo->add_do_method_compat(workspace_overlay, "update");
+						undo_redo->add_undo_method_compat(workspace_overlay, "update");
 						undo_redo->commit_action();
 					} else {
 						int t_id = tileset->get_last_unused_tile_id();
 						undo_redo->create_action(TTR("Create Tile"));
-						undo_redo->add_do_method(tileset.ptr(), "create_tile", t_id);
-						undo_redo->add_undo_method(tileset.ptr(), "remove_tile", t_id);
-						undo_redo->add_undo_method(this, "_validate_current_tile_id");
-						undo_redo->add_do_method(tileset.ptr(), "tile_set_texture", t_id, get_current_texture());
-						undo_redo->add_do_method(tileset.ptr(), "tile_set_region", t_id, edited_region);
-						undo_redo->add_do_method(tileset.ptr(), "tile_set_name", t_id, get_current_texture()->get_path().get_file() + " " + String::num(t_id, 0));
+						undo_redo->add_do_method_compat(tileset.ptr(), "create_tile", t_id);
+						undo_redo->add_undo_method_compat(tileset.ptr(), "remove_tile", t_id);
+						undo_redo->add_undo_method_compat(this, "_validate_current_tile_id");
+						undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_texture", t_id, get_current_texture());
+						undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_region", t_id, edited_region);
+						undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_name", t_id, get_current_texture()->get_path().get_file() + " " + String::num(t_id, 0));
 						if (workspace_mode != WORKSPACE_CREATE_SINGLE) {
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_size", t_id, snap_step);
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_spacing", t_id, snap_separation.x);
-							undo_redo->add_do_method(tileset.ptr(), "tile_set_tile_mode", t_id, workspace_mode == WORKSPACE_CREATE_AUTOTILE ? TileSet::AUTO_TILE : TileSet::ATLAS_TILE);
+							undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_size", t_id, snap_step);
+							undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_spacing", t_id, snap_separation.x);
+							undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_tile_mode", t_id, workspace_mode == WORKSPACE_CREATE_AUTOTILE ? TileSet::AUTO_TILE : TileSet::ATLAS_TILE);
 						}
 
 						tool_workspacemode[WORKSPACE_EDIT]->set_pressed(true);
@@ -1385,20 +1385,20 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 						Size2 workspace_minsize = workspace->get_custom_minimum_size();
 						if (tile_workspace_size.x > workspace_minsize.x || tile_workspace_size.y > workspace_minsize.y) {
 							Size2 new_workspace_minsize = Size2(MAX(tile_workspace_size.x, workspace_minsize.x), MAX(tile_workspace_size.y, workspace_minsize.y));
-							undo_redo->add_do_method(workspace, "set_custom_minimum_size", new_workspace_minsize);
-							undo_redo->add_undo_method(workspace, "set_custom_minimum_size", workspace_minsize);
-							undo_redo->add_do_method(workspace_container, "set_custom_minimum_size", new_workspace_minsize);
-							undo_redo->add_undo_method(workspace_container, "set_custom_minimum_size", workspace_minsize);
-							undo_redo->add_do_method(workspace_overlay, "set_custom_minimum_size", new_workspace_minsize);
-							undo_redo->add_undo_method(workspace_overlay, "set_custom_minimum_size", workspace_minsize);
+							undo_redo->add_do_method_compat(workspace, "set_custom_minimum_size", new_workspace_minsize);
+							undo_redo->add_undo_method_compat(workspace, "set_custom_minimum_size", workspace_minsize);
+							undo_redo->add_do_method_compat(workspace_container, "set_custom_minimum_size", new_workspace_minsize);
+							undo_redo->add_undo_method_compat(workspace_container, "set_custom_minimum_size", workspace_minsize);
+							undo_redo->add_do_method_compat(workspace_overlay, "set_custom_minimum_size", new_workspace_minsize);
+							undo_redo->add_undo_method_compat(workspace_overlay, "set_custom_minimum_size", workspace_minsize);
 						}
 
 						edited_region = Rect2();
 
-						undo_redo->add_do_method(workspace, "update");
-						undo_redo->add_undo_method(workspace, "update");
-						undo_redo->add_do_method(workspace_overlay, "update");
-						undo_redo->add_undo_method(workspace_overlay, "update");
+						undo_redo->add_do_method_compat(workspace, "update");
+						undo_redo->add_undo_method_compat(workspace, "update");
+						undo_redo->add_do_method_compat(workspace_overlay, "update");
+						undo_redo->add_undo_method_compat(workspace_overlay, "update");
 						undo_redo->commit_action();
 
 						set_current_tile(t_id);
@@ -1432,10 +1432,10 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 						if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT && current_tile_region.has_point(mb->get_position())) {
 							Vector2 coord((int)((mb->get_position().x - current_tile_region.position.x) / (spacing + size.x)), (int)((mb->get_position().y - current_tile_region.position.y) / (spacing + size.y)));
 							undo_redo->create_action(TTR("Set Tile Icon"));
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_icon_coordinate", get_current_tile(), coord);
-							undo_redo->add_undo_method(tileset.ptr(), "autotile_set_icon_coordinate", get_current_tile(), tileset->autotile_get_icon_coordinate(get_current_tile()));
-							undo_redo->add_do_method(workspace, "update");
-							undo_redo->add_undo_method(workspace, "update");
+							undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_icon_coordinate", get_current_tile(), coord);
+							undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_icon_coordinate", get_current_tile(), tileset->autotile_get_icon_coordinate(get_current_tile()));
+							undo_redo->add_do_method_compat(workspace, "update");
+							undo_redo->add_undo_method_compat(workspace, "update");
 							undo_redo->commit_action();
 						}
 					}
@@ -1511,10 +1511,10 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 
 								if (old_mask != new_mask) {
 									undo_redo->create_action(TTR("Edit Tile Bitmask"));
-									undo_redo->add_do_method(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), coord, new_mask);
-									undo_redo->add_undo_method(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), coord, old_mask);
-									undo_redo->add_do_method(workspace, "update");
-									undo_redo->add_undo_method(workspace, "update");
+									undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), coord, new_mask);
+									undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), coord, old_mask);
+									undo_redo->add_do_method_compat(workspace, "update");
+									undo_redo->add_undo_method_compat(workspace, "update");
 									undo_redo->commit_action();
 								}
 							}
@@ -1588,10 +1588,10 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 							}
 							if (old_mask != new_mask) {
 								undo_redo->create_action(TTR("Edit Tile Bitmask"));
-								undo_redo->add_do_method(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), coord, new_mask);
-								undo_redo->add_undo_method(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), coord, old_mask);
-								undo_redo->add_do_method(workspace, "update");
-								undo_redo->add_undo_method(workspace, "update");
+								undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), coord, new_mask);
+								undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), coord, old_mask);
+								undo_redo->add_do_method_compat(workspace, "update");
+								undo_redo->add_undo_method_compat(workspace, "update");
 								undo_redo->commit_action();
 							}
 						}
@@ -1648,8 +1648,8 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 
 										undo_redo->create_action(TTR("Edit Collision Polygon"));
 										_set_edited_shape_points(points);
-										undo_redo->add_do_method(this, "_select_edited_shape_coord");
-										undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+										undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+										undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 										undo_redo->commit_action();
 									}
 								} else if (edit_mode == EDITMODE_OCCLUSION) {
@@ -1665,10 +1665,10 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 										}
 
 										undo_redo->create_action(TTR("Edit Occlusion Polygon"));
-										undo_redo->add_do_method(edited_occlusion_shape.ptr(), "set_polygon", polygon);
-										undo_redo->add_undo_method(edited_occlusion_shape.ptr(), "set_polygon", edited_occlusion_shape->get_polygon());
-										undo_redo->add_do_method(this, "_select_edited_shape_coord");
-										undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+										undo_redo->add_do_method_compat(edited_occlusion_shape.ptr(), "set_polygon", polygon);
+										undo_redo->add_undo_method_compat(edited_occlusion_shape.ptr(), "set_polygon", edited_occlusion_shape->get_polygon());
+										undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+										undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 										undo_redo->commit_action();
 									}
 								} else if (edit_mode == EDITMODE_NAVIGATION) {
@@ -1686,14 +1686,14 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 										}
 
 										undo_redo->create_action(TTR("Edit Navigation Polygon"));
-										undo_redo->add_do_method(edited_navigation_shape.ptr(), "set_vertices", polygon);
-										undo_redo->add_undo_method(edited_navigation_shape.ptr(), "set_vertices", edited_navigation_shape->get_vertices());
-										undo_redo->add_do_method(edited_navigation_shape.ptr(), "clear_polygons");
-										undo_redo->add_undo_method(edited_navigation_shape.ptr(), "clear_polygons");
-										undo_redo->add_do_method(edited_navigation_shape.ptr(), "add_polygon", indices);
-										undo_redo->add_undo_method(edited_navigation_shape.ptr(), "add_polygon", edited_navigation_shape->get_polygon(0));
-										undo_redo->add_do_method(this, "_select_edited_shape_coord");
-										undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+										undo_redo->add_do_method_compat(edited_navigation_shape.ptr(), "set_vertices", polygon);
+										undo_redo->add_undo_method_compat(edited_navigation_shape.ptr(), "set_vertices", edited_navigation_shape->get_vertices());
+										undo_redo->add_do_method_compat(edited_navigation_shape.ptr(), "clear_polygons");
+										undo_redo->add_undo_method_compat(edited_navigation_shape.ptr(), "clear_polygons");
+										undo_redo->add_do_method_compat(edited_navigation_shape.ptr(), "add_polygon", indices);
+										undo_redo->add_undo_method_compat(edited_navigation_shape.ptr(), "add_polygon", edited_navigation_shape->get_polygon(0));
+										undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+										undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 										undo_redo->commit_action();
 									}
 								}
@@ -1798,25 +1798,25 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 		bitmask_map_copy = tileset->autotile_get_bitmask_map(get_current_tile());
 	} else if (p_tool == BITMASK_PASTE) {
 		undo_redo->create_action(TTR("Paste Tile Bitmask"));
-		undo_redo->add_do_method(tileset.ptr(), "autotile_clear_bitmask_map", get_current_tile());
-		undo_redo->add_undo_method(tileset.ptr(), "autotile_clear_bitmask_map", get_current_tile());
+		undo_redo->add_do_method_compat(tileset.ptr(), "autotile_clear_bitmask_map", get_current_tile());
+		undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_clear_bitmask_map", get_current_tile());
 		for (Map<Vector2, uint32_t>::Element *E = bitmask_map_copy.front(); E; E = E->next()) {
-			undo_redo->add_do_method(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), E->key(), E->value());
+			undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), E->key(), E->value());
 		}
 		for (Map<Vector2, uint32_t>::Element *E = tileset->autotile_get_bitmask_map(get_current_tile()).front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), E->key(), E->value());
+			undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), E->key(), E->value());
 		}
-		undo_redo->add_do_method(workspace, "update");
-		undo_redo->add_undo_method(workspace, "update");
+		undo_redo->add_do_method_compat(workspace, "update");
+		undo_redo->add_undo_method_compat(workspace, "update");
 		undo_redo->commit_action();
 	} else if (p_tool == BITMASK_CLEAR) {
 		undo_redo->create_action(TTR("Clear Tile Bitmask"));
-		undo_redo->add_do_method(tileset.ptr(), "autotile_clear_bitmask_map", get_current_tile());
+		undo_redo->add_do_method_compat(tileset.ptr(), "autotile_clear_bitmask_map", get_current_tile());
 		for (Map<Vector2, uint32_t>::Element *E = tileset->autotile_get_bitmask_map(get_current_tile()).front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), E->key(), E->value());
+			undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_bitmask", get_current_tile(), E->key(), E->value());
 		}
-		undo_redo->add_do_method(workspace, "update");
-		undo_redo->add_undo_method(workspace, "update");
+		undo_redo->add_do_method_compat(workspace, "update");
+		undo_redo->add_undo_method_compat(workspace, "update");
 		undo_redo->commit_action();
 	} else if (p_tool == SHAPE_TOGGLE_TYPE) {
 		if (edited_collision_shape.is_valid()) {
@@ -1840,20 +1840,20 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 			}
 			for (int i = 0; i < sd.size(); i++) {
 				if (sd[i].get("shape") == previous_shape) {
-					undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.duplicate());
+					undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.duplicate());
 					sd.remove(i);
 					break;
 				}
 			}
 
-			undo_redo->add_do_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd);
+			undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd);
 			if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
-				undo_redo->add_do_method(tileset.ptr(), "tile_add_shape", get_current_tile(), edited_collision_shape, Transform2D(), false, edited_shape_coord);
+				undo_redo->add_do_method_compat(tileset.ptr(), "tile_add_shape", get_current_tile(), edited_collision_shape, Transform2D(), false, edited_shape_coord);
 			} else {
-				undo_redo->add_do_method(tileset.ptr(), "tile_add_shape", get_current_tile(), edited_collision_shape, Transform2D());
+				undo_redo->add_do_method_compat(tileset.ptr(), "tile_add_shape", get_current_tile(), edited_collision_shape, Transform2D());
 			}
-			undo_redo->add_do_method(this, "_select_edited_shape_coord");
-			undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+			undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+			undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 			undo_redo->commit_action();
 
 			_update_toggle_shape_button();
@@ -1876,21 +1876,21 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 					int t_id = get_current_tile();
 					if (workspace_mode == WORKSPACE_EDIT && t_id >= 0) {
 						undo_redo->create_action(TTR("Remove Tile"));
-						undo_redo->add_do_method(tileset.ptr(), "remove_tile", t_id);
+						undo_redo->add_do_method_compat(tileset.ptr(), "remove_tile", t_id);
 						_undo_tile_removal(t_id);
-						undo_redo->add_do_method(this, "_validate_current_tile_id");
+						undo_redo->add_do_method_compat(this, "_validate_current_tile_id");
 
 						Rect2 tile_region = tileset->tile_get_region(get_current_tile());
 						Size2 tile_workspace_size = tile_region.position + tile_region.size;
 						if (tile_workspace_size.x > get_current_texture()->get_size().x || tile_workspace_size.y > get_current_texture()->get_size().y) {
-							undo_redo->add_do_method(this, "update_workspace_minsize");
-							undo_redo->add_undo_method(this, "update_workspace_minsize");
+							undo_redo->add_do_method_compat(this, "update_workspace_minsize");
+							undo_redo->add_undo_method_compat(this, "update_workspace_minsize");
 						}
 
-						undo_redo->add_do_method(workspace, "update");
-						undo_redo->add_undo_method(workspace, "update");
-						undo_redo->add_do_method(workspace_overlay, "update");
-						undo_redo->add_undo_method(workspace_overlay, "update");
+						undo_redo->add_do_method_compat(workspace, "update");
+						undo_redo->add_undo_method_compat(workspace, "update");
+						undo_redo->add_do_method_compat(workspace_overlay, "update");
+						undo_redo->add_undo_method_compat(workspace_overlay, "update");
 						undo_redo->commit_action();
 					}
 					tool_workspacemode[WORKSPACE_EDIT]->set_pressed(true);
@@ -1904,11 +1904,11 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 						for (int i = 0; i < sd.size(); i++) {
 							if (sd[i].get("shape") == edited_collision_shape) {
 								undo_redo->create_action(TTR("Remove Collision Polygon"));
-								undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.duplicate());
+								undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.duplicate());
 								sd.remove(i);
-								undo_redo->add_do_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd);
-								undo_redo->add_do_method(this, "_select_edited_shape_coord");
-								undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+								undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd);
+								undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+								undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 								undo_redo->commit_action();
 								break;
 							}
@@ -1919,14 +1919,14 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 					if (!edited_occlusion_shape.is_null()) {
 						undo_redo->create_action(TTR("Remove Occlusion Polygon"));
 						if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::SINGLE_TILE) {
-							undo_redo->add_do_method(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), Ref<OccluderPolygon2D>());
-							undo_redo->add_undo_method(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), tileset->tile_get_light_occluder(get_current_tile()));
+							undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), Ref<OccluderPolygon2D>());
+							undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), tileset->tile_get_light_occluder(get_current_tile()));
 						} else {
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), Ref<OccluderPolygon2D>(), edited_shape_coord);
-							undo_redo->add_undo_method(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), tileset->autotile_get_light_occluder(get_current_tile(), edited_shape_coord), edited_shape_coord);
+							undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), Ref<OccluderPolygon2D>(), edited_shape_coord);
+							undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), tileset->autotile_get_light_occluder(get_current_tile(), edited_shape_coord), edited_shape_coord);
 						}
-						undo_redo->add_do_method(this, "_select_edited_shape_coord");
-						undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+						undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+						undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 						undo_redo->commit_action();
 					}
 				} break;
@@ -1934,14 +1934,14 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 					if (!edited_navigation_shape.is_null()) {
 						undo_redo->create_action(TTR("Remove Navigation Polygon"));
 						if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::SINGLE_TILE) {
-							undo_redo->add_do_method(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), Ref<NavigationPolygon>());
-							undo_redo->add_undo_method(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), tileset->tile_get_navigation_polygon(get_current_tile()));
+							undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), Ref<NavigationPolygon>());
+							undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), tileset->tile_get_navigation_polygon(get_current_tile()));
 						} else {
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), Ref<NavigationPolygon>(), edited_shape_coord);
-							undo_redo->add_undo_method(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), tileset->autotile_get_navigation_polygon(get_current_tile(), edited_shape_coord), edited_shape_coord);
+							undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), Ref<NavigationPolygon>(), edited_shape_coord);
+							undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), tileset->autotile_get_navigation_polygon(get_current_tile(), edited_shape_coord), edited_shape_coord);
 						}
-						undo_redo->add_do_method(this, "_select_edited_shape_coord");
-						undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+						undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+						undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 						undo_redo->commit_action();
 					}
 				} break;
@@ -1965,10 +1965,10 @@ void TileSetEditor::_on_priority_changed(float val) {
 	}
 
 	undo_redo->create_action(TTR("Edit Tile Priority"));
-	undo_redo->add_do_method(tileset.ptr(), "autotile_set_subtile_priority", get_current_tile(), edited_shape_coord, (int)val);
-	undo_redo->add_undo_method(tileset.ptr(), "autotile_set_subtile_priority", get_current_tile(), edited_shape_coord, tileset->autotile_get_subtile_priority(get_current_tile(), edited_shape_coord));
-	undo_redo->add_do_method(workspace, "update");
-	undo_redo->add_undo_method(workspace, "update");
+	undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_subtile_priority", get_current_tile(), edited_shape_coord, (int)val);
+	undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_subtile_priority", get_current_tile(), edited_shape_coord, tileset->autotile_get_subtile_priority(get_current_tile(), edited_shape_coord));
+	undo_redo->add_do_method_compat(workspace, "update");
+	undo_redo->add_undo_method_compat(workspace, "update");
 	undo_redo->commit_action();
 }
 
@@ -1978,10 +1978,10 @@ void TileSetEditor::_on_z_index_changed(float val) {
 	}
 
 	undo_redo->create_action(TTR("Edit Tile Z Index"));
-	undo_redo->add_do_method(tileset.ptr(), "autotile_set_z_index", get_current_tile(), edited_shape_coord, (int)val);
-	undo_redo->add_undo_method(tileset.ptr(), "autotile_set_z_index", get_current_tile(), edited_shape_coord, tileset->autotile_get_z_index(get_current_tile(), edited_shape_coord));
-	undo_redo->add_do_method(workspace, "update");
-	undo_redo->add_undo_method(workspace, "update");
+	undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_z_index", get_current_tile(), edited_shape_coord, (int)val);
+	undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_z_index", get_current_tile(), edited_shape_coord, tileset->autotile_get_z_index(get_current_tile(), edited_shape_coord));
+	undo_redo->add_do_method_compat(workspace, "update");
+	undo_redo->add_undo_method_compat(workspace, "update");
 	undo_redo->commit_action();
 }
 
@@ -2014,8 +2014,8 @@ void TileSetEditor::_set_edited_shape_points(const Vector<Vector2> &points) {
 	Ref<ConvexPolygonShape2D> convex = edited_collision_shape;
 	Ref<ConcavePolygonShape2D> concave = edited_collision_shape;
 	if (convex.is_valid()) {
-		undo_redo->add_do_method(convex.ptr(), "set_points", points);
-		undo_redo->add_undo_method(convex.ptr(), "set_points", _get_edited_shape_points());
+		undo_redo->add_do_method_compat(convex.ptr(), "set_points", points);
+		undo_redo->add_undo_method_compat(convex.ptr(), "set_points", _get_edited_shape_points());
 	} else if (concave.is_valid() && points.size() > 1) {
 		PackedVector2Array segments;
 		for (int i = 0; i < points.size() - 1; i++) {
@@ -2024,8 +2024,8 @@ void TileSetEditor::_set_edited_shape_points(const Vector<Vector2> &points) {
 		}
 		segments.push_back(points[points.size() - 1]);
 		segments.push_back(points[0]);
-		undo_redo->add_do_method(concave.ptr(), "set_segments", segments);
-		undo_redo->add_undo_method(concave.ptr(), "set_segments", concave->get_segments());
+		undo_redo->add_do_method_compat(concave.ptr(), "set_segments", segments);
+		undo_redo->add_undo_method_compat(concave.ptr(), "set_segments", concave->get_segments());
 	}
 }
 
@@ -2387,49 +2387,49 @@ void TileSetEditor::_select_edited_shape_coord() {
 }
 
 void TileSetEditor::_undo_tile_removal(int p_id) {
-	undo_redo->add_undo_method(tileset.ptr(), "create_tile", p_id);
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_name", p_id, tileset->tile_get_name(p_id));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_texture_offset", p_id, tileset->tile_get_texture_offset(p_id));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_material", p_id, tileset->tile_get_material(p_id));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_modulate", p_id, tileset->tile_get_modulate(p_id));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_occluder_offset", p_id, tileset->tile_get_occluder_offset(p_id));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_navigation_polygon_offset", p_id, tileset->tile_get_navigation_polygon_offset(p_id));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_shape_offset", p_id, 0, tileset->tile_get_shape_offset(p_id, 0));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_shape_transform", p_id, 0, tileset->tile_get_shape_transform(p_id, 0));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_z_index", p_id, tileset->tile_get_z_index(p_id));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_texture", p_id, tileset->tile_get_texture(p_id));
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_region", p_id, tileset->tile_get_region(p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "create_tile", p_id);
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_name", p_id, tileset->tile_get_name(p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_texture_offset", p_id, tileset->tile_get_texture_offset(p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_material", p_id, tileset->tile_get_material(p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_modulate", p_id, tileset->tile_get_modulate(p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_occluder_offset", p_id, tileset->tile_get_occluder_offset(p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_navigation_polygon_offset", p_id, tileset->tile_get_navigation_polygon_offset(p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_shape_offset", p_id, 0, tileset->tile_get_shape_offset(p_id, 0));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_shape_transform", p_id, 0, tileset->tile_get_shape_transform(p_id, 0));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_z_index", p_id, tileset->tile_get_z_index(p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_texture", p_id, tileset->tile_get_texture(p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_region", p_id, tileset->tile_get_region(p_id));
 	// Necessary to get the version that returns a Array instead of a Vector.
-	undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", p_id, tileset->call("tile_get_shapes", p_id));
+	undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_shapes", p_id, tileset->call("tile_get_shapes", p_id));
 	if (tileset->tile_get_tile_mode(p_id) == TileSet::SINGLE_TILE) {
-		undo_redo->add_undo_method(tileset.ptr(), "tile_set_light_occluder", p_id, tileset->tile_get_light_occluder(p_id));
-		undo_redo->add_undo_method(tileset.ptr(), "tile_set_navigation_polygon", p_id, tileset->tile_get_navigation_polygon(p_id));
+		undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_light_occluder", p_id, tileset->tile_get_light_occluder(p_id));
+		undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_navigation_polygon", p_id, tileset->tile_get_navigation_polygon(p_id));
 	} else {
 		Map<Vector2, Ref<OccluderPolygon2D>> oclusion_map = tileset->autotile_get_light_oclusion_map(p_id);
 		for (Map<Vector2, Ref<OccluderPolygon2D>>::Element *E = oclusion_map.front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_light_occluder", p_id, E->value(), E->key());
+			undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_light_occluder", p_id, E->value(), E->key());
 		}
 		Map<Vector2, Ref<NavigationPolygon>> navigation_map = tileset->autotile_get_navigation_map(p_id);
 		for (Map<Vector2, Ref<NavigationPolygon>>::Element *E = navigation_map.front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_navigation_polygon", p_id, E->value(), E->key());
+			undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_navigation_polygon", p_id, E->value(), E->key());
 		}
 		Map<Vector2, uint32_t> bitmask_map = tileset->autotile_get_bitmask_map(p_id);
 		for (Map<Vector2, uint32_t>::Element *E = bitmask_map.front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_bitmask", p_id, E->key(), E->value());
+			undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_bitmask", p_id, E->key(), E->value());
 		}
 		Map<Vector2, int> priority_map = tileset->autotile_get_priority_map(p_id);
 		for (Map<Vector2, int>::Element *E = priority_map.front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_subtile_priority", p_id, E->key(), E->value());
+			undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_subtile_priority", p_id, E->key(), E->value());
 		}
-		undo_redo->add_undo_method(tileset.ptr(), "autotile_set_icon_coordinate", p_id, tileset->autotile_get_icon_coordinate(p_id));
+		undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_icon_coordinate", p_id, tileset->autotile_get_icon_coordinate(p_id));
 		Map<Vector2, int> z_map = tileset->autotile_get_z_index_map(p_id);
 		for (Map<Vector2, int>::Element *E = z_map.front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_z_index", p_id, E->key(), E->value());
+			undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_z_index", p_id, E->key(), E->value());
 		}
-		undo_redo->add_undo_method(tileset.ptr(), "tile_set_tile_mode", p_id, tileset->tile_get_tile_mode(p_id));
-		undo_redo->add_undo_method(tileset.ptr(), "autotile_set_size", p_id, tileset->autotile_get_size(p_id));
-		undo_redo->add_undo_method(tileset.ptr(), "autotile_set_spacing", p_id, tileset->autotile_get_spacing(p_id));
-		undo_redo->add_undo_method(tileset.ptr(), "autotile_set_bitmask_mode", p_id, tileset->autotile_get_bitmask_mode(p_id));
+		undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_tile_mode", p_id, tileset->tile_get_tile_mode(p_id));
+		undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_size", p_id, tileset->autotile_get_size(p_id));
+		undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_spacing", p_id, tileset->autotile_get_spacing(p_id));
+		undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_bitmask_mode", p_id, tileset->autotile_get_bitmask_mode(p_id));
 	}
 }
 
@@ -2937,22 +2937,22 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 			undo_redo->create_action(TTR("Create Collision Polygon"));
 			// Necessary to get the version that returns a Array instead of a Vector.
 			Array sd = tileset->call("tile_get_shapes", get_current_tile());
-			undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.duplicate());
+			undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.duplicate());
 			for (int i = 0; i < sd.size(); i++) {
 				if (sd[i].get("shape") == edited_collision_shape) {
 					sd.remove(i);
 					break;
 				}
 			}
-			undo_redo->add_do_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd);
+			undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd);
 			if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
-				undo_redo->add_do_method(tileset.ptr(), "tile_add_shape", get_current_tile(), shape, Transform2D(), false, edited_shape_coord);
+				undo_redo->add_do_method_compat(tileset.ptr(), "tile_add_shape", get_current_tile(), shape, Transform2D(), false, edited_shape_coord);
 			} else {
-				undo_redo->add_do_method(tileset.ptr(), "tile_add_shape", get_current_tile(), shape, Transform2D());
+				undo_redo->add_do_method_compat(tileset.ptr(), "tile_add_shape", get_current_tile(), shape, Transform2D());
 			}
 			tools[TOOL_SELECT]->set_pressed(true);
-			undo_redo->add_do_method(this, "_select_edited_shape_coord");
-			undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+			undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+			undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 			undo_redo->commit_action();
 		} else {
 			tools[TOOL_SELECT]->set_pressed(true);
@@ -2973,15 +2973,15 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 
 		undo_redo->create_action(TTR("Create Occlusion Polygon"));
 		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
-			undo_redo->add_do_method(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), shape, edited_shape_coord);
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), tileset->autotile_get_light_occluder(get_current_tile(), edited_shape_coord), edited_shape_coord);
+			undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), shape, edited_shape_coord);
+			undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), tileset->autotile_get_light_occluder(get_current_tile(), edited_shape_coord), edited_shape_coord);
 		} else {
-			undo_redo->add_do_method(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), shape);
-			undo_redo->add_undo_method(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), tileset->tile_get_light_occluder(get_current_tile()));
+			undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), shape);
+			undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), tileset->tile_get_light_occluder(get_current_tile()));
 		}
 		tools[TOOL_SELECT]->set_pressed(true);
-		undo_redo->add_do_method(this, "_select_edited_shape_coord");
-		undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+		undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+		undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 		undo_redo->commit_action();
 	} else if (edit_mode == EDITMODE_NAVIGATION) {
 		Ref<NavigationPolygon> shape = memnew(NavigationPolygon);
@@ -3001,15 +3001,15 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 
 		undo_redo->create_action(TTR("Create Navigation Polygon"));
 		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
-			undo_redo->add_do_method(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), shape, edited_shape_coord);
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), tileset->autotile_get_navigation_polygon(get_current_tile(), edited_shape_coord), edited_shape_coord);
+			undo_redo->add_do_method_compat(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), shape, edited_shape_coord);
+			undo_redo->add_undo_method_compat(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), tileset->autotile_get_navigation_polygon(get_current_tile(), edited_shape_coord), edited_shape_coord);
 		} else {
-			undo_redo->add_do_method(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), shape);
-			undo_redo->add_undo_method(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), tileset->tile_get_navigation_polygon(get_current_tile()));
+			undo_redo->add_do_method_compat(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), shape);
+			undo_redo->add_undo_method_compat(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), tileset->tile_get_navigation_polygon(get_current_tile()));
 		}
 		tools[TOOL_SELECT]->set_pressed(true);
-		undo_redo->add_do_method(this, "_select_edited_shape_coord");
-		undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+		undo_redo->add_do_method_compat(this, "_select_edited_shape_coord");
+		undo_redo->add_undo_method_compat(this, "_select_edited_shape_coord");
 		undo_redo->commit_action();
 	}
 	tileset->_change_notify("");

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1221,10 +1221,10 @@ void VisualShaderEditor::_update_uniform_refs(Set<String> &p_deleted_names) {
 				Ref<VisualShaderNodeUniformRef> ref = visual_shader->get_node(type, nodes[j]);
 				if (ref.is_valid()) {
 					if (p_deleted_names.has(ref->get_uniform_name())) {
-						undo_redo->add_do_method(ref.ptr(), "set_uniform_name", "[None]");
-						undo_redo->add_undo_method(ref.ptr(), "set_uniform_name", ref->get_uniform_name());
-						undo_redo->add_do_method(graph_plugin.ptr(), "update_node", VisualShader::Type(i), nodes[j]);
-						undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", VisualShader::Type(i), nodes[j]);
+						undo_redo->add_do_method_compat(ref.ptr(), "set_uniform_name", "[None]");
+						undo_redo->add_undo_method_compat(ref.ptr(), "set_uniform_name", ref->get_uniform_name());
+						undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", VisualShader::Type(i), nodes[j]);
+						undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", VisualShader::Type(i), nodes[j]);
 					}
 				}
 			}
@@ -1301,10 +1301,10 @@ void VisualShaderEditor::_add_input_port(int p_node, int p_port, int p_port_type
 	}
 
 	undo_redo->create_action(TTR("Add Input Port"));
-	undo_redo->add_do_method(node.ptr(), "add_input_port", p_port, p_port_type, p_name);
-	undo_redo->add_undo_method(node.ptr(), "remove_input_port", p_port);
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type, p_node);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_do_method_compat(node.ptr(), "add_input_port", p_port, p_port_type, p_name);
+	undo_redo->add_undo_method_compat(node.ptr(), "remove_input_port", p_port);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
 	undo_redo->commit_action();
 }
 
@@ -1316,10 +1316,10 @@ void VisualShaderEditor::_add_output_port(int p_node, int p_port, int p_port_typ
 	}
 
 	undo_redo->create_action(TTR("Add Output Port"));
-	undo_redo->add_do_method(node.ptr(), "add_output_port", p_port, p_port_type, p_name);
-	undo_redo->add_undo_method(node.ptr(), "remove_output_port", p_port);
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type, p_node);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_do_method_compat(node.ptr(), "add_output_port", p_port, p_port_type, p_name);
+	undo_redo->add_undo_method_compat(node.ptr(), "remove_output_port", p_port);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
 	undo_redo->commit_action();
 }
 
@@ -1331,10 +1331,10 @@ void VisualShaderEditor::_change_input_port_type(int p_type, int p_node, int p_p
 	}
 
 	undo_redo->create_action(TTR("Change Input Port Type"));
-	undo_redo->add_do_method(node.ptr(), "set_input_port_type", p_port, p_type);
-	undo_redo->add_undo_method(node.ptr(), "set_input_port_type", p_port, node->get_input_port_type(p_port));
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type, p_node);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_do_method_compat(node.ptr(), "set_input_port_type", p_port, p_type);
+	undo_redo->add_undo_method_compat(node.ptr(), "set_input_port_type", p_port, node->get_input_port_type(p_port));
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
 	undo_redo->commit_action();
 }
 
@@ -1346,10 +1346,10 @@ void VisualShaderEditor::_change_output_port_type(int p_type, int p_node, int p_
 	}
 
 	undo_redo->create_action(TTR("Change Output Port Type"));
-	undo_redo->add_do_method(node.ptr(), "set_output_port_type", p_port, p_type);
-	undo_redo->add_undo_method(node.ptr(), "set_output_port_type", p_port, node->get_output_port_type(p_port));
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type, p_node);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_do_method_compat(node.ptr(), "set_output_port_type", p_port, p_type);
+	undo_redo->add_undo_method_compat(node.ptr(), "set_output_port_type", p_port, node->get_output_port_type(p_port));
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
 	undo_redo->commit_action();
 }
 
@@ -1374,10 +1374,10 @@ void VisualShaderEditor::_change_input_port_name(const String &p_text, Object *p
 	}
 
 	undo_redo->create_action(TTR("Change Input Port Name"));
-	undo_redo->add_do_method(node.ptr(), "set_input_port_name", p_port_id, validated_name);
-	undo_redo->add_undo_method(node.ptr(), "set_input_port_name", p_port_id, node->get_input_port_name(p_port_id));
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type, p_node_id);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type, p_node_id);
+	undo_redo->add_do_method_compat(node.ptr(), "set_input_port_name", p_port_id, validated_name);
+	undo_redo->add_undo_method_compat(node.ptr(), "set_input_port_name", p_port_id, node->get_input_port_name(p_port_id));
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type, p_node_id);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type, p_node_id);
 	undo_redo->commit_action();
 }
 
@@ -1402,10 +1402,10 @@ void VisualShaderEditor::_change_output_port_name(const String &p_text, Object *
 	}
 
 	undo_redo->create_action(TTR("Change Output Port Name"));
-	undo_redo->add_do_method(node.ptr(), "set_output_port_name", p_port_id, validated_name);
-	undo_redo->add_undo_method(node.ptr(), "set_output_port_name", p_port_id, prev_name);
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type, p_node_id);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type, p_node_id);
+	undo_redo->add_do_method_compat(node.ptr(), "set_output_port_name", p_port_id, validated_name);
+	undo_redo->add_undo_method_compat(node.ptr(), "set_output_port_name", p_port_id, prev_name);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type, p_node_id);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type, p_node_id);
 	undo_redo->commit_action();
 }
 
@@ -1428,32 +1428,32 @@ void VisualShaderEditor::_remove_input_port(int p_node, int p_port) {
 
 		if (to_node == p_node) {
 			if (to_port == p_port) {
-				undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
-				undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_do_method_compat(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port);
 
-				undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
-				undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_do_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_undo_method_compat(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port);
 			} else if (to_port > p_port) {
-				undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
-				undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_do_method_compat(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port);
 
-				undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
-				undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_do_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_undo_method_compat(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port);
 
-				undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port - 1);
-				undo_redo->add_undo_method(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port - 1);
+				undo_redo->add_do_method_compat(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port - 1);
+				undo_redo->add_undo_method_compat(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port - 1);
 
-				undo_redo->add_do_method(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port - 1);
-				undo_redo->add_undo_method(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port - 1);
+				undo_redo->add_do_method_compat(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port - 1);
+				undo_redo->add_undo_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port - 1);
 			}
 		}
 	}
 
-	undo_redo->add_do_method(node.ptr(), "remove_input_port", p_port);
-	undo_redo->add_undo_method(node.ptr(), "add_input_port", p_port, (int)node->get_input_port_type(p_port), node->get_input_port_name(p_port));
+	undo_redo->add_do_method_compat(node.ptr(), "remove_input_port", p_port);
+	undo_redo->add_undo_method_compat(node.ptr(), "add_input_port", p_port, (int)node->get_input_port_type(p_port), node->get_input_port_name(p_port));
 
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type, p_node);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
 
 	undo_redo->commit_action();
 }
@@ -1477,23 +1477,23 @@ void VisualShaderEditor::_remove_output_port(int p_node, int p_port) {
 
 		if (from_node == p_node) {
 			if (from_port == p_port) {
-				undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
-				undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_do_method_compat(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port);
 
-				undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
-				undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_do_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_undo_method_compat(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port);
 			} else if (from_port > p_port) {
-				undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
-				undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_do_method_compat(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port, to_node, to_port);
 
-				undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
-				undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_do_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port, to_node, to_port);
+				undo_redo->add_undo_method_compat(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port, to_node, to_port);
 
-				undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port - 1, to_node, to_port);
-				undo_redo->add_undo_method(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port - 1, to_node, to_port);
+				undo_redo->add_do_method_compat(visual_shader.ptr(), "connect_nodes_forced", type, from_node, from_port - 1, to_node, to_port);
+				undo_redo->add_undo_method_compat(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_port - 1, to_node, to_port);
 
-				undo_redo->add_do_method(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port - 1, to_node, to_port);
-				undo_redo->add_undo_method(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port - 1, to_node, to_port);
+				undo_redo->add_do_method_compat(graph_plugin.ptr(), "connect_nodes", type, from_node, from_port - 1, to_node, to_port);
+				undo_redo->add_undo_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_port - 1, to_node, to_port);
 			}
 		}
 	}
@@ -1501,19 +1501,19 @@ void VisualShaderEditor::_remove_output_port(int p_node, int p_port) {
 	int preview_port = node->get_output_port_for_preview();
 	if (preview_port != -1) {
 		if (preview_port == p_port) {
-			undo_redo->add_do_method(node.ptr(), "set_output_port_for_preview", -1);
-			undo_redo->add_undo_method(node.ptr(), "set_output_port_for_preview", preview_port);
+			undo_redo->add_do_method_compat(node.ptr(), "set_output_port_for_preview", -1);
+			undo_redo->add_undo_method_compat(node.ptr(), "set_output_port_for_preview", preview_port);
 		} else if (preview_port > p_port) {
-			undo_redo->add_do_method(node.ptr(), "set_output_port_for_preview", preview_port - 1);
-			undo_redo->add_undo_method(node.ptr(), "set_output_port_for_preview", preview_port);
+			undo_redo->add_do_method_compat(node.ptr(), "set_output_port_for_preview", preview_port - 1);
+			undo_redo->add_undo_method_compat(node.ptr(), "set_output_port_for_preview", preview_port);
 		}
 	}
 
-	undo_redo->add_do_method(node.ptr(), "remove_output_port", p_port);
-	undo_redo->add_undo_method(node.ptr(), "add_output_port", p_port, (int)node->get_output_port_type(p_port), node->get_output_port_name(p_port));
+	undo_redo->add_do_method_compat(node.ptr(), "remove_output_port", p_port);
+	undo_redo->add_undo_method_compat(node.ptr(), "add_output_port", p_port, (int)node->get_output_port_type(p_port), node->get_output_port_name(p_port));
 
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type, p_node);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type, p_node);
 
 	undo_redo->commit_action();
 }
@@ -1532,10 +1532,10 @@ void VisualShaderEditor::_expression_focus_out(Object *code_edit, int p_node) {
 	}
 
 	undo_redo->create_action(TTR("Set VisualShader Expression"));
-	undo_redo->add_do_method(node.ptr(), "set_expression", expression_box->get_text());
-	undo_redo->add_undo_method(node.ptr(), "set_expression", node->get_expression());
-	undo_redo->add_do_method(graph_plugin.ptr(), "set_expression", type, p_node, expression_box->get_text());
-	undo_redo->add_undo_method(graph_plugin.ptr(), "set_expression", type, p_node, node->get_expression());
+	undo_redo->add_do_method_compat(node.ptr(), "set_expression", expression_box->get_text());
+	undo_redo->add_undo_method_compat(node.ptr(), "set_expression", node->get_expression());
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "set_expression", type, p_node, expression_box->get_text());
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "set_expression", type, p_node, node->get_expression());
 	undo_redo->commit_action();
 }
 
@@ -1597,8 +1597,8 @@ void VisualShaderEditor::_node_resized(const Vector2 &p_new_size, int p_type, in
 	}
 
 	undo_redo->create_action(TTR("Resize VisualShader Node"), UndoRedo::MERGE_ENDS);
-	undo_redo->add_do_method(this, "_set_node_size", p_type, p_node, p_new_size);
-	undo_redo->add_undo_method(this, "_set_node_size", p_type, p_node, node->get_size());
+	undo_redo->add_do_method_compat(this, "_set_node_size", p_type, p_node, p_new_size);
+	undo_redo->add_undo_method_compat(this, "_set_node_size", p_type, p_node, node->get_size());
 	undo_redo->commit_action();
 }
 
@@ -1613,10 +1613,10 @@ void VisualShaderEditor::_preview_select_port(int p_node, int p_port) {
 		p_port = -1; //toggle it
 	}
 	undo_redo->create_action(p_port == -1 ? TTR("Hide Port Preview") : TTR("Show Port Preview"));
-	undo_redo->add_do_method(node.ptr(), "set_output_port_for_preview", p_port);
-	undo_redo->add_undo_method(node.ptr(), "set_output_port_for_preview", prev_port);
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", (int)type, p_node);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", (int)type, p_node);
+	undo_redo->add_do_method_compat(node.ptr(), "set_output_port_for_preview", p_port);
+	undo_redo->add_undo_method_compat(node.ptr(), "set_output_port_for_preview", prev_port);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", (int)type, p_node);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", (int)type, p_node);
 	undo_redo->commit_action();
 }
 
@@ -1633,13 +1633,13 @@ void VisualShaderEditor::_uniform_line_edit_changed(const String &p_text, int p_
 	}
 
 	undo_redo->create_action(TTR("Set Uniform Name"));
-	undo_redo->add_do_method(node.ptr(), "set_uniform_name", validated_name);
-	undo_redo->add_undo_method(node.ptr(), "set_uniform_name", node->get_uniform_name());
-	undo_redo->add_do_method(graph_plugin.ptr(), "set_uniform_name", type, p_node_id, validated_name);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "set_uniform_name", type, p_node_id, node->get_uniform_name());
+	undo_redo->add_do_method_compat(node.ptr(), "set_uniform_name", validated_name);
+	undo_redo->add_undo_method_compat(node.ptr(), "set_uniform_name", node->get_uniform_name());
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "set_uniform_name", type, p_node_id, validated_name);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "set_uniform_name", type, p_node_id, node->get_uniform_name());
 
-	undo_redo->add_do_method(this, "_update_uniforms", true);
-	undo_redo->add_undo_method(this, "_update_uniforms", true);
+	undo_redo->add_do_method_compat(this, "_update_uniforms", true);
+	undo_redo->add_undo_method_compat(this, "_update_uniforms", true);
 
 	Set<String> changed_names;
 	changed_names.insert(node->get_uniform_name());
@@ -1668,10 +1668,10 @@ void VisualShaderEditor::_port_edited() {
 	ERR_FAIL_COND(!vsn.is_valid());
 
 	undo_redo->create_action(TTR("Set Input Default Port"));
-	undo_redo->add_do_method(vsn.ptr(), "set_input_port_default_value", editing_port, value);
-	undo_redo->add_undo_method(vsn.ptr(), "set_input_port_default_value", editing_port, vsn->get_input_port_default_value(editing_port));
-	undo_redo->add_do_method(graph_plugin.ptr(), "set_input_port_default_value", type, editing_node, editing_port, value);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "set_input_port_default_value", type, editing_node, editing_port, vsn->get_input_port_default_value(editing_port));
+	undo_redo->add_do_method_compat(vsn.ptr(), "set_input_port_default_value", editing_port, value);
+	undo_redo->add_undo_method_compat(vsn.ptr(), "set_input_port_default_value", editing_port, vsn->get_input_port_default_value(editing_port));
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "set_input_port_default_value", type, editing_node, editing_port, value);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "set_input_port_default_value", type, editing_node, editing_port, vsn->get_input_port_default_value(editing_port));
 	undo_redo->commit_action();
 
 	property_editor->hide();
@@ -1869,14 +1869,14 @@ VisualShaderNode *VisualShaderEditor::_add_node(int p_idx, int p_op_idx) {
 	int id_to_use = visual_shader->get_valid_node_id(type);
 
 	undo_redo->create_action(TTR("Add Node to Visual Shader"));
-	undo_redo->add_do_method(visual_shader.ptr(), "add_node", type, vsnode, position, id_to_use);
-	undo_redo->add_undo_method(visual_shader.ptr(), "remove_node", type, id_to_use);
-	undo_redo->add_do_method(graph_plugin.ptr(), "add_node", type, id_to_use);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "remove_node", type, id_to_use);
+	undo_redo->add_do_method_compat(visual_shader.ptr(), "add_node", type, vsnode, position, id_to_use);
+	undo_redo->add_undo_method_compat(visual_shader.ptr(), "remove_node", type, id_to_use);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "add_node", type, id_to_use);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "remove_node", type, id_to_use);
 
 	VisualShaderNodeExpression *expr = Object::cast_to<VisualShaderNodeExpression>(vsnode.ptr());
 	if (expr) {
-		undo_redo->add_do_method(expr, "set_size", Size2(250 * EDSCALE, 150 * EDSCALE));
+		undo_redo->add_do_method_compat(expr, "set_size", Size2(250 * EDSCALE, 150 * EDSCALE));
 	}
 
 	if (to_node != -1 && to_slot != -1) {
@@ -1885,10 +1885,10 @@ VisualShaderNode *VisualShaderEditor::_add_node(int p_idx, int p_op_idx) {
 			int _from_slot = 0;
 
 			if (visual_shader->is_port_types_compatible(vsnode->get_output_port_type(_from_slot), visual_shader->get_node(type, to_node)->get_input_port_type(to_slot))) {
-				undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes", type, _from_node, _from_slot, to_node, to_slot);
-				undo_redo->add_undo_method(visual_shader.ptr(), "disconnect_nodes", type, _from_node, _from_slot, to_node, to_slot);
-				undo_redo->add_do_method(graph_plugin.ptr(), "connect_nodes", type, _from_node, _from_slot, to_node, to_slot);
-				undo_redo->add_undo_method(graph_plugin.ptr(), "disconnect_nodes", type, _from_node, _from_slot, to_node, to_slot);
+				undo_redo->add_do_method_compat(visual_shader.ptr(), "connect_nodes", type, _from_node, _from_slot, to_node, to_slot);
+				undo_redo->add_undo_method_compat(visual_shader.ptr(), "disconnect_nodes", type, _from_node, _from_slot, to_node, to_slot);
+				undo_redo->add_do_method_compat(graph_plugin.ptr(), "connect_nodes", type, _from_node, _from_slot, to_node, to_slot);
+				undo_redo->add_undo_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, _from_node, _from_slot, to_node, to_slot);
 			}
 		}
 	} else if (from_node != -1 && from_slot != -1) {
@@ -1897,18 +1897,18 @@ VisualShaderNode *VisualShaderEditor::_add_node(int p_idx, int p_op_idx) {
 			int _to_slot = 0;
 
 			if (visual_shader->is_port_types_compatible(visual_shader->get_node(type, from_node)->get_output_port_type(from_slot), vsnode->get_input_port_type(_to_slot))) {
-				undo_redo->add_undo_method(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_slot, _to_node, _to_slot);
-				undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes", type, from_node, from_slot, _to_node, _to_slot);
-				undo_redo->add_undo_method(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_slot, _to_node, _to_slot);
-				undo_redo->add_do_method(graph_plugin.ptr(), "connect_nodes", type, from_node, from_slot, _to_node, _to_slot);
+				undo_redo->add_undo_method_compat(visual_shader.ptr(), "disconnect_nodes", type, from_node, from_slot, _to_node, _to_slot);
+				undo_redo->add_do_method_compat(visual_shader.ptr(), "connect_nodes", type, from_node, from_slot, _to_node, _to_slot);
+				undo_redo->add_undo_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, from_node, from_slot, _to_node, _to_slot);
+				undo_redo->add_do_method_compat(graph_plugin.ptr(), "connect_nodes", type, from_node, from_slot, _to_node, _to_slot);
 			}
 		}
 	}
 
 	VisualShaderNodeUniform *uniform = Object::cast_to<VisualShaderNodeUniform>(vsnode.ptr());
 	if (uniform) {
-		undo_redo->add_do_method(this, "_update_uniforms", true);
-		undo_redo->add_undo_method(this, "_update_uniforms", true);
+		undo_redo->add_do_method_compat(this, "_update_uniforms", true);
+		undo_redo->add_undo_method_compat(this, "_update_uniforms", true);
 	}
 
 	VisualShaderNodeCurveTexture *curve = Object::cast_to<VisualShaderNodeCurveTexture>(vsnode.ptr());
@@ -1935,10 +1935,10 @@ void VisualShaderEditor::_nodes_dragged() {
 	undo_redo->create_action(TTR("Node(s) Moved"));
 
 	for (List<DragOp>::Element *E = drag_buffer.front(); E; E = E->next()) {
-		undo_redo->add_do_method(visual_shader.ptr(), "set_node_position", E->get().type, E->get().node, E->get().to);
-		undo_redo->add_undo_method(visual_shader.ptr(), "set_node_position", E->get().type, E->get().node, E->get().from);
-		undo_redo->add_do_method(graph_plugin.ptr(), "set_node_position", E->get().type, E->get().node, E->get().to);
-		undo_redo->add_undo_method(graph_plugin.ptr(), "set_node_position", E->get().type, E->get().node, E->get().from);
+		undo_redo->add_do_method_compat(visual_shader.ptr(), "set_node_position", E->get().type, E->get().node, E->get().to);
+		undo_redo->add_undo_method_compat(visual_shader.ptr(), "set_node_position", E->get().type, E->get().node, E->get().from);
+		undo_redo->add_do_method_compat(graph_plugin.ptr(), "set_node_position", E->get().type, E->get().node, E->get().to);
+		undo_redo->add_undo_method_compat(graph_plugin.ptr(), "set_node_position", E->get().type, E->get().node, E->get().from);
 	}
 
 	drag_buffer.clear();
@@ -1962,19 +1962,19 @@ void VisualShaderEditor::_connection_request(const String &p_from, int p_from_in
 
 	for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
 		if (E->get().to_node == to && E->get().to_port == p_to_index) {
-			undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-			undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-			undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-			undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+			undo_redo->add_do_method_compat(visual_shader.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+			undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+			undo_redo->add_do_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+			undo_redo->add_undo_method_compat(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 		}
 	}
 
-	undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes", type, from, p_from_index, to, p_to_index);
-	undo_redo->add_undo_method(visual_shader.ptr(), "disconnect_nodes", type, from, p_from_index, to, p_to_index);
-	undo_redo->add_do_method(graph_plugin.ptr(), "connect_nodes", type, from, p_from_index, to, p_to_index);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "disconnect_nodes", type, from, p_from_index, to, p_to_index);
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", (int)type, to);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", (int)type, to);
+	undo_redo->add_do_method_compat(visual_shader.ptr(), "connect_nodes", type, from, p_from_index, to, p_to_index);
+	undo_redo->add_undo_method_compat(visual_shader.ptr(), "disconnect_nodes", type, from, p_from_index, to, p_to_index);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "connect_nodes", type, from, p_from_index, to, p_to_index);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, from, p_from_index, to, p_to_index);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", (int)type, to);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", (int)type, to);
 	undo_redo->commit_action();
 }
 
@@ -1987,12 +1987,12 @@ void VisualShaderEditor::_disconnection_request(const String &p_from, int p_from
 	int to = p_to.to_int();
 
 	undo_redo->create_action(TTR("Nodes Disconnected"));
-	undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, from, p_from_index, to, p_to_index);
-	undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, from, p_from_index, to, p_to_index);
-	undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, from, p_from_index, to, p_to_index);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, from, p_from_index, to, p_to_index);
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_node", (int)type, to);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", (int)type, to);
+	undo_redo->add_do_method_compat(visual_shader.ptr(), "disconnect_nodes", type, from, p_from_index, to, p_to_index);
+	undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes", type, from, p_from_index, to, p_to_index);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, from, p_from_index, to, p_to_index);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "connect_nodes", type, from, p_from_index, to, p_to_index);
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", (int)type, to);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", (int)type, to);
 	undo_redo->commit_action();
 }
 
@@ -2016,7 +2016,7 @@ void VisualShaderEditor::_delete_nodes(int p_type, const List<int> &p_nodes) {
 	for (const List<int>::Element *F = p_nodes.front(); F; F = F->next()) {
 		for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
 			if (E->get().from_node == F->get() || E->get().to_node == F->get()) {
-				undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+				undo_redo->add_do_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 			}
 		}
 	}
@@ -2026,25 +2026,25 @@ void VisualShaderEditor::_delete_nodes(int p_type, const List<int> &p_nodes) {
 	for (const List<int>::Element *F = p_nodes.front(); F; F = F->next()) {
 		Ref<VisualShaderNode> node = visual_shader->get_node(type, F->get());
 
-		undo_redo->add_do_method(visual_shader.ptr(), "remove_node", type, F->get());
-		undo_redo->add_undo_method(visual_shader.ptr(), "add_node", type, node, visual_shader->get_node_position(type, F->get()), F->get());
-		undo_redo->add_undo_method(graph_plugin.ptr(), "add_node", type, F->get());
+		undo_redo->add_do_method_compat(visual_shader.ptr(), "remove_node", type, F->get());
+		undo_redo->add_undo_method_compat(visual_shader.ptr(), "add_node", type, node, visual_shader->get_node_position(type, F->get()), F->get());
+		undo_redo->add_undo_method_compat(graph_plugin.ptr(), "add_node", type, F->get());
 
-		undo_redo->add_do_method(this, "_clear_buffer");
-		undo_redo->add_undo_method(this, "_clear_buffer");
+		undo_redo->add_do_method_compat(this, "_clear_buffer");
+		undo_redo->add_undo_method_compat(this, "_clear_buffer");
 
 		// restore size, inputs and outputs if node is group
 		VisualShaderNodeGroupBase *group = Object::cast_to<VisualShaderNodeGroupBase>(node.ptr());
 		if (group) {
-			undo_redo->add_undo_method(group, "set_size", group->get_size());
-			undo_redo->add_undo_method(group, "set_inputs", group->get_inputs());
-			undo_redo->add_undo_method(group, "set_outputs", group->get_outputs());
+			undo_redo->add_undo_method_compat(group, "set_size", group->get_size());
+			undo_redo->add_undo_method_compat(group, "set_inputs", group->get_inputs());
+			undo_redo->add_undo_method_compat(group, "set_outputs", group->get_outputs());
 		}
 
 		// restore expression text if node is expression
 		VisualShaderNodeExpression *expression = Object::cast_to<VisualShaderNodeExpression>(node.ptr());
 		if (expression) {
-			undo_redo->add_undo_method(expression, "set_expression", expression->get_expression());
+			undo_redo->add_undo_method_compat(expression, "set_expression", expression->get_expression());
 		}
 
 		VisualShaderNodeUniform *uniform = Object::cast_to<VisualShaderNodeUniform>(node.ptr());
@@ -2065,8 +2065,8 @@ void VisualShaderEditor::_delete_nodes(int p_type, const List<int> &p_nodes) {
 					}
 				}
 				if (!cancel) {
-					undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-					undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+					undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+					undo_redo->add_undo_method_compat(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 					used_conns.push_back(E->get());
 				}
 			}
@@ -2075,13 +2075,13 @@ void VisualShaderEditor::_delete_nodes(int p_type, const List<int> &p_nodes) {
 
 	// delete nodes from the graph
 	for (const List<int>::Element *F = p_nodes.front(); F; F = F->next()) {
-		undo_redo->add_do_method(graph_plugin.ptr(), "remove_node", type, F->get());
+		undo_redo->add_do_method_compat(graph_plugin.ptr(), "remove_node", type, F->get());
 	}
 
 	// update uniform refs if any uniform has been deleted
 	if (uniform_names.size() > 0) {
-		undo_redo->add_do_method(this, "_update_uniforms", true);
-		undo_redo->add_undo_method(this, "_update_uniforms", true);
+		undo_redo->add_do_method_compat(this, "_update_uniforms", true);
+		undo_redo->add_undo_method_compat(this, "_update_uniforms", true);
 
 		_update_uniform_refs(uniform_names);
 	}
@@ -2373,21 +2373,21 @@ void VisualShaderEditor::_dup_paste_nodes(int p_type, int p_pasted_type, List<in
 
 		Ref<VisualShaderNode> dupli = node->duplicate();
 
-		undo_redo->add_do_method(visual_shader.ptr(), "add_node", type, dupli, visual_shader->get_node_position(pasted_type, E->get()) + p_offset, id_from);
-		undo_redo->add_do_method(graph_plugin.ptr(), "add_node", type, id_from);
+		undo_redo->add_do_method_compat(visual_shader.ptr(), "add_node", type, dupli, visual_shader->get_node_position(pasted_type, E->get()) + p_offset, id_from);
+		undo_redo->add_do_method_compat(graph_plugin.ptr(), "add_node", type, id_from);
 
 		// duplicate size, inputs and outputs if node is group
 		Ref<VisualShaderNodeGroupBase> group = Object::cast_to<VisualShaderNodeGroupBase>(node.ptr());
 		if (!group.is_null()) {
-			undo_redo->add_do_method(dupli.ptr(), "set_size", group->get_size());
-			undo_redo->add_do_method(graph_plugin.ptr(), "set_node_size", type, id_from, group->get_size());
-			undo_redo->add_do_method(dupli.ptr(), "set_inputs", group->get_inputs());
-			undo_redo->add_do_method(dupli.ptr(), "set_outputs", group->get_outputs());
+			undo_redo->add_do_method_compat(dupli.ptr(), "set_size", group->get_size());
+			undo_redo->add_do_method_compat(graph_plugin.ptr(), "set_node_size", type, id_from, group->get_size());
+			undo_redo->add_do_method_compat(dupli.ptr(), "set_inputs", group->get_inputs());
+			undo_redo->add_do_method_compat(dupli.ptr(), "set_outputs", group->get_outputs());
 		}
 		// duplicate expression text if node is expression
 		Ref<VisualShaderNodeExpression> expression = Object::cast_to<VisualShaderNodeExpression>(node.ptr());
 		if (!expression.is_null()) {
-			undo_redo->add_do_method(dupli.ptr(), "set_expression", expression->get_expression());
+			undo_redo->add_do_method_compat(dupli.ptr(), "set_expression", expression->get_expression());
 		}
 
 		id_from++;
@@ -2401,16 +2401,16 @@ void VisualShaderEditor::_dup_paste_nodes(int p_type, int p_pasted_type, List<in
 			continue;
 		}
 		if (connection_remap.has(E->get().from_node) && connection_remap.has(E->get().to_node)) {
-			undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes", type, connection_remap[E->get().from_node], E->get().from_port, connection_remap[E->get().to_node], E->get().to_port);
-			undo_redo->add_do_method(graph_plugin.ptr(), "connect_nodes", type, connection_remap[E->get().from_node], E->get().from_port, connection_remap[E->get().to_node], E->get().to_port);
-			undo_redo->add_undo_method(graph_plugin.ptr(), "disconnect_nodes", type, connection_remap[E->get().from_node], E->get().from_port, connection_remap[E->get().to_node], E->get().to_port);
+			undo_redo->add_do_method_compat(visual_shader.ptr(), "connect_nodes", type, connection_remap[E->get().from_node], E->get().from_port, connection_remap[E->get().to_node], E->get().to_port);
+			undo_redo->add_do_method_compat(graph_plugin.ptr(), "connect_nodes", type, connection_remap[E->get().from_node], E->get().from_port, connection_remap[E->get().to_node], E->get().to_port);
+			undo_redo->add_undo_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, connection_remap[E->get().from_node], E->get().from_port, connection_remap[E->get().to_node], E->get().to_port);
 		}
 	}
 
 	id_from = base_id;
 	for (List<int>::Element *E = r_nodes.front(); E; E = E->next()) {
-		undo_redo->add_undo_method(visual_shader.ptr(), "remove_node", type, id_from);
-		undo_redo->add_undo_method(graph_plugin.ptr(), "remove_node", type, id_from);
+		undo_redo->add_undo_method_compat(visual_shader.ptr(), "remove_node", type, id_from);
+		undo_redo->add_undo_method_compat(graph_plugin.ptr(), "remove_node", type, id_from);
 		id_from++;
 	}
 
@@ -2503,8 +2503,8 @@ void VisualShaderEditor::_input_select_item(Ref<VisualShaderNodeInput> p_input, 
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	undo_redo->create_action(TTR("Visual Shader Input Type Changed"));
 
-	undo_redo->add_do_method(p_input.ptr(), "set_input_name", p_name);
-	undo_redo->add_undo_method(p_input.ptr(), "set_input_name", prev_name);
+	undo_redo->add_do_method_compat(p_input.ptr(), "set_input_name", p_name);
+	undo_redo->add_undo_method_compat(p_input.ptr(), "set_input_name", prev_name);
 
 	// update output port
 	for (int type_id = 0; type_id < VisualShader::TYPE_MAX; type_id++) {
@@ -2517,19 +2517,19 @@ void VisualShaderEditor::_input_select_item(Ref<VisualShaderNodeInput> p_input, 
 				for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
 					if (E->get().from_node == id) {
 						if (visual_shader->is_port_types_compatible(p_input->get_input_type_by_name(p_name), visual_shader->get_node(type, E->get().to_node)->get_input_port_type(E->get().to_port))) {
-							undo_redo->add_do_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-							undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+							undo_redo->add_do_method_compat(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+							undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 							continue;
 						}
-						undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_do_method_compat(visual_shader.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_do_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_undo_method_compat(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 					}
 				}
 			}
-			undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type_id, id);
-			undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type_id, id);
+			undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type_id, id);
+			undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type_id, id);
 			break;
 		}
 	}
@@ -2549,8 +2549,8 @@ void VisualShaderEditor::_uniform_select_item(Ref<VisualShaderNodeUniformRef> p_
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	undo_redo->create_action(TTR("UniformRef Name Changed"));
 
-	undo_redo->add_do_method(p_uniform_ref.ptr(), "set_uniform_name", p_name);
-	undo_redo->add_undo_method(p_uniform_ref.ptr(), "set_uniform_name", prev_name);
+	undo_redo->add_do_method_compat(p_uniform_ref.ptr(), "set_uniform_name", p_name);
+	undo_redo->add_undo_method_compat(p_uniform_ref.ptr(), "set_uniform_name", prev_name);
 
 	// update output port
 	for (int type_id = 0; type_id < VisualShader::TYPE_MAX; type_id++) {
@@ -2565,15 +2565,15 @@ void VisualShaderEditor::_uniform_select_item(Ref<VisualShaderNodeUniformRef> p_
 						if (visual_shader->is_port_types_compatible(p_uniform_ref->get_uniform_type_by_name(p_name), visual_shader->get_node(type, E->get().to_node)->get_input_port_type(E->get().to_port))) {
 							continue;
 						}
-						undo_redo->add_do_method(visual_shader.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_do_method(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-						undo_redo->add_undo_method(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_do_method_compat(visual_shader.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_do_method_compat(graph_plugin.ptr(), "disconnect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_undo_method_compat(graph_plugin.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 					}
 				}
 			}
-			undo_redo->add_do_method(graph_plugin.ptr(), "update_node", type_id, id);
-			undo_redo->add_undo_method(graph_plugin.ptr(), "update_node", type_id, id);
+			undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_node", type_id, id);
+			undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_node", type_id, id);
 			break;
 		}
 	}
@@ -2598,10 +2598,10 @@ void VisualShaderEditor::_float_constant_selected(int p_index, int p_node) {
 	}
 
 	undo_redo->create_action(TTR("Set constant"));
-	undo_redo->add_do_method(node.ptr(), "set_constant", float_constant_defs[p_index].value);
-	undo_redo->add_undo_method(node.ptr(), "set_constant", node->get_constant());
-	undo_redo->add_do_method(graph_plugin.ptr(), "update_constant", type, p_node);
-	undo_redo->add_undo_method(graph_plugin.ptr(), "update_constant", type, p_node);
+	undo_redo->add_do_method_compat(node.ptr(), "set_constant", float_constant_defs[p_index].value);
+	undo_redo->add_undo_method_compat(node.ptr(), "set_constant", node->get_constant());
+	undo_redo->add_do_method_compat(graph_plugin.ptr(), "update_constant", type, p_node);
+	undo_redo->add_undo_method_compat(graph_plugin.ptr(), "update_constant", type, p_node);
 	undo_redo->commit_action();
 }
 
@@ -3734,22 +3734,22 @@ public:
 			RES curr_res = p_value;
 
 			if (curr_res.is_null()) {
-				undo_redo->add_do_method(this, "_open_inspector", (RES)parent_resource.ptr());
+				undo_redo->add_do_method_compat(this, "_open_inspector", (RES)parent_resource.ptr());
 			} else {
-				undo_redo->add_do_method(this, "_open_inspector", (RES)curr_res.ptr());
+				undo_redo->add_do_method_compat(this, "_open_inspector", (RES)curr_res.ptr());
 			}
 			if (!prev_res.is_null()) {
-				undo_redo->add_undo_method(this, "_open_inspector", (RES)prev_res.ptr());
+				undo_redo->add_undo_method_compat(this, "_open_inspector", (RES)prev_res.ptr());
 			} else {
-				undo_redo->add_undo_method(this, "_open_inspector", (RES)parent_resource.ptr());
+				undo_redo->add_undo_method_compat(this, "_open_inspector", (RES)parent_resource.ptr());
 			}
 		}
 		if (p_property != "constant") {
-			undo_redo->add_do_method(VisualShaderEditor::get_singleton()->get_graph_plugin(), "update_node_deferred", shader_type, node_id);
-			undo_redo->add_undo_method(VisualShaderEditor::get_singleton()->get_graph_plugin(), "update_node_deferred", shader_type, node_id);
+			undo_redo->add_do_method_compat(VisualShaderEditor::get_singleton()->get_graph_plugin(), "update_node_deferred", shader_type, node_id);
+			undo_redo->add_undo_method_compat(VisualShaderEditor::get_singleton()->get_graph_plugin(), "update_node_deferred", shader_type, node_id);
 		} else {
-			undo_redo->add_do_method(VisualShaderEditor::get_singleton()->get_graph_plugin(), "update_constant", shader_type, node_id);
-			undo_redo->add_undo_method(VisualShaderEditor::get_singleton()->get_graph_plugin(), "update_constant", shader_type, node_id);
+			undo_redo->add_do_method_compat(VisualShaderEditor::get_singleton()->get_graph_plugin(), "update_constant", shader_type, node_id);
+			undo_redo->add_undo_method_compat(VisualShaderEditor::get_singleton()->get_graph_plugin(), "update_constant", shader_type, node_id);
 		}
 		undo_redo->commit_action();
 
@@ -3909,11 +3909,11 @@ void EditorPropertyShaderMode::_option_selected(int p_which) {
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	undo_redo->create_action(TTR("Visual Shader Mode Changed"));
 	//do is easy
-	undo_redo->add_do_method(visual_shader.ptr(), "set_mode", p_which);
-	undo_redo->add_undo_method(visual_shader.ptr(), "set_mode", visual_shader->get_mode());
+	undo_redo->add_do_method_compat(visual_shader.ptr(), "set_mode", p_which);
+	undo_redo->add_undo_method_compat(visual_shader.ptr(), "set_mode", visual_shader->get_mode());
 
-	undo_redo->add_do_method(VisualShaderEditor::get_singleton(), "_set_mode", p_which);
-	undo_redo->add_undo_method(VisualShaderEditor::get_singleton(), "_set_mode", visual_shader->get_mode());
+	undo_redo->add_do_method_compat(VisualShaderEditor::get_singleton(), "_set_mode", p_which);
+	undo_redo->add_undo_method_compat(VisualShaderEditor::get_singleton(), "_set_mode", visual_shader->get_mode());
 
 	//now undo is hell
 
@@ -3924,7 +3924,7 @@ void EditorPropertyShaderMode::_option_selected(int p_which) {
 		visual_shader->get_node_connections(type, &conns);
 		for (List<VisualShader::Connection>::Element *E = conns.front(); E; E = E->next()) {
 			if (E->get().to_node == VisualShader::NODE_ID_OUTPUT) {
-				undo_redo->add_undo_method(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+				undo_redo->add_undo_method_compat(visual_shader.ptr(), "connect_nodes", type, E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 			}
 		}
 	}
@@ -3938,7 +3938,7 @@ void EditorPropertyShaderMode::_option_selected(int p_which) {
 				continue;
 			}
 
-			undo_redo->add_undo_method(input.ptr(), "set_input_name", input->get_input_name());
+			undo_redo->add_undo_method_compat(input.ptr(), "set_input_name", input->get_input_name());
 		}
 	}
 
@@ -3952,12 +3952,12 @@ void EditorPropertyShaderMode::_option_selected(int p_which) {
 		}
 	}
 
-	undo_redo->add_do_method(VisualShaderEditor::get_singleton(), "_update_options_menu");
-	undo_redo->add_undo_method(VisualShaderEditor::get_singleton(), "_update_options_menu");
+	undo_redo->add_do_method_compat(VisualShaderEditor::get_singleton(), "_update_options_menu");
+	undo_redo->add_undo_method_compat(VisualShaderEditor::get_singleton(), "_update_options_menu");
 
 	//update graph
-	undo_redo->add_do_method(VisualShaderEditor::get_singleton(), "_update_graph");
-	undo_redo->add_undo_method(VisualShaderEditor::get_singleton(), "_update_graph");
+	undo_redo->add_do_method_compat(VisualShaderEditor::get_singleton(), "_update_graph");
+	undo_redo->add_undo_method_compat(VisualShaderEditor::get_singleton(), "_update_graph");
 
 	undo_redo->commit_action();
 }

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -105,10 +105,10 @@ void ProjectSettingsEditor::_add_setting() {
 	undo_redo->add_do_property(ps, setting, value);
 	undo_redo->add_undo_property(ps, setting, ps->has_setting(setting) ? ps->get(setting) : Variant());
 
-	undo_redo->add_do_method(inspector, "update_category_list");
-	undo_redo->add_undo_method(inspector, "update_category_list");
-	undo_redo->add_do_method(this, "queue_save");
-	undo_redo->add_undo_method(this, "queue_save");
+	undo_redo->add_do_method_compat(inspector, "update_category_list");
+	undo_redo->add_undo_method_compat(inspector, "update_category_list");
+	undo_redo->add_do_method_compat(this, "queue_save");
+	undo_redo->add_undo_method_compat(this, "queue_save");
 	undo_redo->commit_action();
 
 	inspector->set_current_section(setting.get_slice("/", 1));
@@ -127,14 +127,14 @@ void ProjectSettingsEditor::_delete_setting(bool p_confirmed) {
 
 	undo_redo->create_action(TTR("Delete Item"));
 
-	undo_redo->add_do_method(ps, "clear", setting);
-	undo_redo->add_undo_method(ps, "set", setting, value);
-	undo_redo->add_undo_method(ps, "set_order", setting, order);
+	undo_redo->add_do_method_compat(ps, "clear", setting);
+	undo_redo->add_undo_method_compat(ps, "set", setting, value);
+	undo_redo->add_undo_method_compat(ps, "set_order", setting, order);
 
-	undo_redo->add_do_method(inspector, "update_category_list");
-	undo_redo->add_undo_method(inspector, "update_category_list");
-	undo_redo->add_do_method(this, "queue_save");
-	undo_redo->add_undo_method(this, "queue_save");
+	undo_redo->add_do_method_compat(inspector, "update_category_list");
+	undo_redo->add_undo_method_compat(inspector, "update_category_list");
+	undo_redo->add_do_method_compat(this, "queue_save");
+	undo_redo->add_undo_method_compat(this, "queue_save");
 
 	undo_redo->commit_action();
 

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -586,8 +586,8 @@ void RenameDialog::rename() {
 			}
 
 			scene_tree_editor->emit_signal("node_prerename", n, new_name);
-			undo_redo->add_do_method(scene_tree_editor, "_rename_node", n->get_instance_id(), new_name);
-			undo_redo->add_undo_method(scene_tree_editor, "_rename_node", n->get_instance_id(), n->get_name());
+			undo_redo->add_do_method_compat(scene_tree_editor, "_rename_node", n->get_instance_id(), new_name);
+			undo_redo->add_undo_method_compat(scene_tree_editor, "_rename_node", n->get_instance_id(), n->get_name());
 		}
 
 		undo_redo->commit_action();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -211,20 +211,20 @@ void SceneTreeDock::_perform_instance_scenes(const Vector<String> &p_files, Node
 	for (int i = 0; i < instances.size(); i++) {
 		Node *instanced_scene = instances[i];
 
-		editor_data->get_undo_redo().add_do_method(parent, "add_child", instanced_scene);
+		editor_data->get_undo_redo().add_do_method_compat(parent, "add_child", instanced_scene);
 		if (p_pos >= 0) {
-			editor_data->get_undo_redo().add_do_method(parent, "move_child", instanced_scene, p_pos + i);
+			editor_data->get_undo_redo().add_do_method_compat(parent, "move_child", instanced_scene, p_pos + i);
 		}
-		editor_data->get_undo_redo().add_do_method(instanced_scene, "set_owner", edited_scene);
-		editor_data->get_undo_redo().add_do_method(editor_selection, "clear");
-		editor_data->get_undo_redo().add_do_method(editor_selection, "add_node", instanced_scene);
+		editor_data->get_undo_redo().add_do_method_compat(instanced_scene, "set_owner", edited_scene);
+		editor_data->get_undo_redo().add_do_method_compat(editor_selection, "clear");
+		editor_data->get_undo_redo().add_do_method_compat(editor_selection, "add_node", instanced_scene);
 		editor_data->get_undo_redo().add_do_reference(instanced_scene);
-		editor_data->get_undo_redo().add_undo_method(parent, "remove_child", instanced_scene);
+		editor_data->get_undo_redo().add_undo_method_compat(parent, "remove_child", instanced_scene);
 
 		String new_name = parent->validate_child_name(instanced_scene);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		editor_data->get_undo_redo().add_do_method(ed, "live_debug_instance_node", edited_scene->get_path_to(parent), p_files[i], new_name);
-		editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(parent)).plus_file(new_name)));
+		editor_data->get_undo_redo().add_do_method_compat(ed, "live_debug_instance_node", edited_scene->get_path_to(parent), p_files[i], new_name);
+		editor_data->get_undo_redo().add_undo_method_compat(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(parent)).plus_file(new_name)));
 	}
 
 	editor_data->get_undo_redo().commit_action();
@@ -251,12 +251,12 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *base)
 
 	Node *parent = base->get_parent();
 	int pos = base->get_index();
-	undo_redo->add_do_method(parent, "remove_child", base);
-	undo_redo->add_undo_method(parent, "remove_child", instanced_scene);
-	undo_redo->add_do_method(parent, "add_child", instanced_scene);
-	undo_redo->add_undo_method(parent, "add_child", base);
-	undo_redo->add_do_method(parent, "move_child", instanced_scene, pos);
-	undo_redo->add_undo_method(parent, "move_child", base, pos);
+	undo_redo->add_do_method_compat(parent, "remove_child", base);
+	undo_redo->add_undo_method_compat(parent, "remove_child", instanced_scene);
+	undo_redo->add_do_method_compat(parent, "add_child", instanced_scene);
+	undo_redo->add_undo_method_compat(parent, "add_child", base);
+	undo_redo->add_do_method_compat(parent, "move_child", instanced_scene, pos);
+	undo_redo->add_undo_method_compat(parent, "move_child", base, pos);
 
 	List<Node *> owned;
 	base->get_owned_by(base->get_owner(), &owned);
@@ -264,13 +264,13 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *base)
 	for (List<Node *>::Element *F = owned.front(); F; F = F->next()) {
 		owners.push_back(F->get());
 	}
-	undo_redo->add_do_method(instanced_scene, "set_owner", edited_scene);
-	undo_redo->add_undo_method(this, "_set_owners", edited_scene, owners);
+	undo_redo->add_do_method_compat(instanced_scene, "set_owner", edited_scene);
+	undo_redo->add_undo_method_compat(this, "_set_owners", edited_scene, owners);
 
-	undo_redo->add_do_method(editor_selection, "clear");
-	undo_redo->add_undo_method(editor_selection, "clear");
-	undo_redo->add_do_method(editor_selection, "add_node", instanced_scene);
-	undo_redo->add_undo_method(editor_selection, "add_node", base);
+	undo_redo->add_do_method_compat(editor_selection, "clear");
+	undo_redo->add_undo_method_compat(editor_selection, "clear");
+	undo_redo->add_do_method_compat(editor_selection, "add_node", instanced_scene);
+	undo_redo->add_undo_method_compat(editor_selection, "add_node", base);
 	undo_redo->add_do_property(scene_tree, "set_selected", instanced_scene);
 	undo_redo->add_undo_property(scene_tree, "set_selected", base);
 
@@ -444,20 +444,20 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			editor_data->get_undo_redo().create_action(TTR("Detach Script"));
-			editor_data->get_undo_redo().add_do_method(editor, "push_item", (Script *)nullptr);
+			editor_data->get_undo_redo().add_do_method_compat(editor, "push_item", (Script *)nullptr);
 
 			for (int i = 0; i < selection.size(); i++) {
 				Node *n = Object::cast_to<Node>(selection[i]);
 				Ref<Script> existing = n->get_script();
 				Ref<Script> empty = EditorNode::get_singleton()->get_object_custom_type_base(n);
 				if (existing != empty) {
-					editor_data->get_undo_redo().add_do_method(n, "set_script", empty);
-					editor_data->get_undo_redo().add_undo_method(n, "set_script", existing);
+					editor_data->get_undo_redo().add_do_method_compat(n, "set_script", empty);
+					editor_data->get_undo_redo().add_undo_method_compat(n, "set_script", existing);
 				}
 			}
 
-			editor_data->get_undo_redo().add_do_method(this, "_update_script_button");
-			editor_data->get_undo_redo().add_undo_method(this, "_update_script_button");
+			editor_data->get_undo_redo().add_do_method_compat(this, "_update_script_button");
+			editor_data->get_undo_redo().add_undo_method_compat(this, "_update_script_button");
 
 			editor_data->get_undo_redo().commit_action();
 		} break;
@@ -530,8 +530,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				int bottom_node_pos = bottom_node->get_index();
 				int top_node_pos_next = top_node->get_index() + (MOVING_DOWN ? 1 : -1);
 
-				editor_data->get_undo_redo().add_do_method(top_node->get_parent(), "move_child", top_node, top_node_pos_next);
-				editor_data->get_undo_redo().add_undo_method(bottom_node->get_parent(), "move_child", bottom_node, bottom_node_pos);
+				editor_data->get_undo_redo().add_do_method_compat(top_node->get_parent(), "move_child", top_node, top_node_pos_next);
+				editor_data->get_undo_redo().add_undo_method_compat(bottom_node->get_parent(), "move_child", bottom_node, bottom_node_pos);
 			}
 
 			editor_data->get_undo_redo().commit_action();
@@ -563,7 +563,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			editor_data->get_undo_redo().create_action(TTR("Duplicate Node(s)"));
-			editor_data->get_undo_redo().add_do_method(editor_selection, "clear");
+			editor_data->get_undo_redo().add_do_method_compat(editor_selection, "clear");
 
 			Node *dupsingle = nullptr;
 			List<Node *> editable_children;
@@ -594,23 +594,23 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				dup->set_name(parent->validate_child_name(dup));
 
-				editor_data->get_undo_redo().add_do_method(add_below_node, "add_sibling", dup);
+				editor_data->get_undo_redo().add_do_method_compat(add_below_node, "add_sibling", dup);
 
 				for (List<Node *>::Element *F = owned.front(); F; F = F->next()) {
 					if (!duplimap.has(F->get())) {
 						continue;
 					}
 					Node *d = duplimap[F->get()];
-					editor_data->get_undo_redo().add_do_method(d, "set_owner", node->get_owner());
+					editor_data->get_undo_redo().add_do_method_compat(d, "set_owner", node->get_owner());
 				}
-				editor_data->get_undo_redo().add_do_method(editor_selection, "add_node", dup);
-				editor_data->get_undo_redo().add_undo_method(parent, "remove_child", dup);
+				editor_data->get_undo_redo().add_do_method_compat(editor_selection, "add_node", dup);
+				editor_data->get_undo_redo().add_undo_method_compat(parent, "remove_child", dup);
 				editor_data->get_undo_redo().add_do_reference(dup);
 
 				EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
 
-				editor_data->get_undo_redo().add_do_method(ed, "live_debug_duplicate_node", edited_scene->get_path_to(node), dup->get_name());
-				editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(parent)).plus_file(dup->get_name())));
+				editor_data->get_undo_redo().add_do_method_compat(ed, "live_debug_duplicate_node", edited_scene->get_path_to(node), dup->get_name());
+				editor_data->get_undo_redo().add_undo_method_compat(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(parent)).plus_file(dup->get_name())));
 
 				add_below_node = dup;
 			}
@@ -690,27 +690,27 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			editor_data->get_undo_redo().create_action(TTR("Make node as Root"));
-			editor_data->get_undo_redo().add_do_method(node->get_parent(), "remove_child", node);
-			editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", node);
-			editor_data->get_undo_redo().add_do_method(node, "add_child", root);
-			editor_data->get_undo_redo().add_do_method(node, "set_filename", root->get_filename());
-			editor_data->get_undo_redo().add_do_method(root, "set_filename", String());
-			editor_data->get_undo_redo().add_do_method(node, "set_owner", (Object *)nullptr);
-			editor_data->get_undo_redo().add_do_method(root, "set_owner", node);
+			editor_data->get_undo_redo().add_do_method_compat(node->get_parent(), "remove_child", node);
+			editor_data->get_undo_redo().add_do_method_compat(editor, "set_edited_scene", node);
+			editor_data->get_undo_redo().add_do_method_compat(node, "add_child", root);
+			editor_data->get_undo_redo().add_do_method_compat(node, "set_filename", root->get_filename());
+			editor_data->get_undo_redo().add_do_method_compat(root, "set_filename", String());
+			editor_data->get_undo_redo().add_do_method_compat(node, "set_owner", (Object *)nullptr);
+			editor_data->get_undo_redo().add_do_method_compat(root, "set_owner", node);
 			_node_replace_owner(root, root, node, MODE_DO);
 
-			editor_data->get_undo_redo().add_undo_method(root, "set_filename", root->get_filename());
-			editor_data->get_undo_redo().add_undo_method(node, "set_filename", String());
-			editor_data->get_undo_redo().add_undo_method(node, "remove_child", root);
-			editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", root);
-			editor_data->get_undo_redo().add_undo_method(node->get_parent(), "add_child", node);
-			editor_data->get_undo_redo().add_undo_method(node->get_parent(), "move_child", node, node->get_index());
-			editor_data->get_undo_redo().add_undo_method(root, "set_owner", (Object *)nullptr);
-			editor_data->get_undo_redo().add_undo_method(node, "set_owner", root);
+			editor_data->get_undo_redo().add_undo_method_compat(root, "set_filename", root->get_filename());
+			editor_data->get_undo_redo().add_undo_method_compat(node, "set_filename", String());
+			editor_data->get_undo_redo().add_undo_method_compat(node, "remove_child", root);
+			editor_data->get_undo_redo().add_undo_method_compat(editor, "set_edited_scene", root);
+			editor_data->get_undo_redo().add_undo_method_compat(node->get_parent(), "add_child", node);
+			editor_data->get_undo_redo().add_undo_method_compat(node->get_parent(), "move_child", node, node->get_index());
+			editor_data->get_undo_redo().add_undo_method_compat(root, "set_owner", (Object *)nullptr);
+			editor_data->get_undo_redo().add_undo_method_compat(node, "set_owner", root);
 			_node_replace_owner(root, root, root, MODE_UNDO);
 
-			editor_data->get_undo_redo().add_do_method(scene_tree, "update_tree");
-			editor_data->get_undo_redo().add_undo_method(scene_tree, "update_tree");
+			editor_data->get_undo_redo().add_do_method_compat(scene_tree, "update_tree");
+			editor_data->get_undo_redo().add_undo_method_compat(scene_tree, "update_tree");
 			editor_data->get_undo_redo().commit_action();
 		} break;
 		case TOOL_MULTI_EDIT: {
@@ -931,11 +931,11 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 					ERR_FAIL_COND(node->get_filename() == String());
 					undo_redo->create_action(TTR("Make Local"));
-					undo_redo->add_do_method(node, "set_filename", "");
-					undo_redo->add_undo_method(node, "set_filename", node->get_filename());
+					undo_redo->add_do_method_compat(node, "set_filename", "");
+					undo_redo->add_undo_method_compat(node, "set_filename", node->get_filename());
 					_node_replace_owner(node, node, root);
-					undo_redo->add_do_method(scene_tree, "update_tree");
-					undo_redo->add_undo_method(scene_tree, "update_tree");
+					undo_redo->add_do_method_compat(scene_tree, "update_tree");
+					undo_redo->add_undo_method_compat(scene_tree, "update_tree");
 					undo_redo->commit_action();
 				}
 			}
@@ -1024,10 +1024,10 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			editor_data->get_undo_redo().create_action(TTR("New Scene Root"));
-			editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", new_node);
-			editor_data->get_undo_redo().add_do_method(scene_tree, "update_tree");
+			editor_data->get_undo_redo().add_do_method_compat(editor, "set_edited_scene", new_node);
+			editor_data->get_undo_redo().add_do_method_compat(scene_tree, "update_tree");
 			editor_data->get_undo_redo().add_do_reference(new_node);
-			editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)nullptr);
+			editor_data->get_undo_redo().add_undo_method_compat(editor, "set_edited_scene", (Object *)nullptr);
 			editor_data->get_undo_redo().commit_action();
 
 			editor->edit_node(new_node);
@@ -1196,16 +1196,16 @@ void SceneTreeDock::_node_replace_owner(Node *p_base, Node *p_node, Node *p_root
 		UndoRedo *undo_redo = &editor_data->get_undo_redo();
 		switch (p_mode) {
 			case MODE_BIDI: {
-				undo_redo->add_do_method(p_node, "set_owner", p_root);
-				undo_redo->add_undo_method(p_node, "set_owner", p_base);
+				undo_redo->add_do_method_compat(p_node, "set_owner", p_root);
+				undo_redo->add_undo_method_compat(p_node, "set_owner", p_base);
 
 			} break;
 			case MODE_DO: {
-				undo_redo->add_do_method(p_node, "set_owner", p_root);
+				undo_redo->add_do_method_compat(p_node, "set_owner", p_root);
 
 			} break;
 			case MODE_UNDO: {
-				undo_redo->add_undo_method(p_node, "set_owner", p_root);
+				undo_redo->add_undo_method_compat(p_node, "set_owner", p_root);
 
 			} break;
 		}
@@ -1435,12 +1435,12 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 										ERR_FAIL_COND(!EI); //another bug
 									}
 
-									editor_data->get_undo_redo().add_do_method(anim.ptr(), "remove_track", idx);
-									editor_data->get_undo_redo().add_undo_method(anim.ptr(), "add_track", anim->track_get_type(i), idx);
-									editor_data->get_undo_redo().add_undo_method(anim.ptr(), "track_set_path", idx, track_np);
-									editor_data->get_undo_redo().add_undo_method(anim.ptr(), "track_set_interpolation_type", idx, anim->track_get_interpolation_type(i));
+									editor_data->get_undo_redo().add_do_method_compat(anim.ptr(), "remove_track", idx);
+									editor_data->get_undo_redo().add_undo_method_compat(anim.ptr(), "add_track", anim->track_get_type(i), idx);
+									editor_data->get_undo_redo().add_undo_method_compat(anim.ptr(), "track_set_path", idx, track_np);
+									editor_data->get_undo_redo().add_undo_method_compat(anim.ptr(), "track_set_interpolation_type", idx, anim->track_get_interpolation_type(i));
 									for (int j = 0; j < anim->track_get_key_count(i); j++) {
-										editor_data->get_undo_redo().add_undo_method(anim.ptr(), "track_insert_key", idx, anim->track_get_key_time(i, j), anim->track_get_key_value(i, j), anim->track_get_key_transition(i, j));
+										editor_data->get_undo_redo().add_undo_method_compat(anim.ptr(), "track_insert_key", idx, anim->track_get_key_time(i, j), anim->track_get_key_value(i, j), anim->track_get_key_transition(i, j));
 									}
 
 									ran.erase(i); //byebye channel
@@ -1453,8 +1453,8 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 									if (new_path == track_np) {
 										continue; //bleh
 									}
-									editor_data->get_undo_redo().add_do_method(anim.ptr(), "track_set_path", i, new_path);
-									editor_data->get_undo_redo().add_undo_method(anim.ptr(), "track_set_path", i, track_np);
+									editor_data->get_undo_redo().add_do_method_compat(anim.ptr(), "track_set_path", i, new_path);
+									editor_data->get_undo_redo().add_undo_method_compat(anim.ptr(), "track_set_path", i, track_np);
 								}
 							}
 						}
@@ -1602,11 +1602,11 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 			inc--; // If the child will generate a gap when moved, adjust.
 		}
 
-		editor_data->get_undo_redo().add_do_method(node->get_parent(), "remove_child", node);
-		editor_data->get_undo_redo().add_do_method(new_parent, "add_child", node);
+		editor_data->get_undo_redo().add_do_method_compat(node->get_parent(), "remove_child", node);
+		editor_data->get_undo_redo().add_do_method_compat(new_parent, "add_child", node);
 
 		if (p_position_in_parent >= 0) {
-			editor_data->get_undo_redo().add_do_method(new_parent, "move_child", node, p_position_in_parent + inc);
+			editor_data->get_undo_redo().add_do_method_compat(new_parent, "move_child", node, p_position_in_parent + inc);
 		}
 
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
@@ -1633,29 +1633,29 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 			path_renames[ni].second = fixed_node_path;
 		}
 
-		editor_data->get_undo_redo().add_do_method(ed, "live_debug_reparent_node", edited_scene->get_path_to(node), edited_scene->get_path_to(new_parent), new_name, p_position_in_parent + inc);
-		editor_data->get_undo_redo().add_undo_method(ed, "live_debug_reparent_node", NodePath(String(edited_scene->get_path_to(new_parent)).plus_file(new_name)), edited_scene->get_path_to(node->get_parent()), node->get_name(), node->get_index());
+		editor_data->get_undo_redo().add_do_method_compat(ed, "live_debug_reparent_node", edited_scene->get_path_to(node), edited_scene->get_path_to(new_parent), new_name, p_position_in_parent + inc);
+		editor_data->get_undo_redo().add_undo_method_compat(ed, "live_debug_reparent_node", NodePath(String(edited_scene->get_path_to(new_parent)).plus_file(new_name)), edited_scene->get_path_to(node->get_parent()), node->get_name(), node->get_index());
 
 		if (p_keep_global_xform) {
 			if (Object::cast_to<Node2D>(node)) {
-				editor_data->get_undo_redo().add_do_method(node, "set_global_transform", Object::cast_to<Node2D>(node)->get_global_transform());
+				editor_data->get_undo_redo().add_do_method_compat(node, "set_global_transform", Object::cast_to<Node2D>(node)->get_global_transform());
 			}
 			if (Object::cast_to<Node3D>(node)) {
-				editor_data->get_undo_redo().add_do_method(node, "set_global_transform", Object::cast_to<Node3D>(node)->get_global_transform());
+				editor_data->get_undo_redo().add_do_method_compat(node, "set_global_transform", Object::cast_to<Node3D>(node)->get_global_transform());
 			}
 			if (Object::cast_to<Control>(node)) {
-				editor_data->get_undo_redo().add_do_method(node, "set_global_position", Object::cast_to<Control>(node)->get_global_position());
+				editor_data->get_undo_redo().add_do_method_compat(node, "set_global_position", Object::cast_to<Control>(node)->get_global_position());
 			}
 		}
 
-		editor_data->get_undo_redo().add_do_method(this, "_set_owners", edited_scene, owners);
+		editor_data->get_undo_redo().add_do_method_compat(this, "_set_owners", edited_scene, owners);
 
 		if (AnimationPlayerEditor::singleton->get_track_editor()->get_root() == node) {
-			editor_data->get_undo_redo().add_do_method(AnimationPlayerEditor::singleton->get_track_editor(), "set_root", node);
+			editor_data->get_undo_redo().add_do_method_compat(AnimationPlayerEditor::singleton->get_track_editor(), "set_root", node);
 		}
 
-		editor_data->get_undo_redo().add_undo_method(new_parent, "remove_child", node);
-		editor_data->get_undo_redo().add_undo_method(node, "set_name", former_names[ni]);
+		editor_data->get_undo_redo().add_undo_method_compat(new_parent, "remove_child", node);
+		editor_data->get_undo_redo().add_undo_method_compat(node, "set_name", former_names[ni]);
 
 		inc++;
 	}
@@ -1673,22 +1673,22 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 
 		int child_pos = node->get_index();
 
-		editor_data->get_undo_redo().add_undo_method(node->get_parent(), "add_child", node);
-		editor_data->get_undo_redo().add_undo_method(node->get_parent(), "move_child", node, child_pos);
-		editor_data->get_undo_redo().add_undo_method(this, "_set_owners", edited_scene, owners);
+		editor_data->get_undo_redo().add_undo_method_compat(node->get_parent(), "add_child", node);
+		editor_data->get_undo_redo().add_undo_method_compat(node->get_parent(), "move_child", node, child_pos);
+		editor_data->get_undo_redo().add_undo_method_compat(this, "_set_owners", edited_scene, owners);
 		if (AnimationPlayerEditor::singleton->get_track_editor()->get_root() == node) {
-			editor_data->get_undo_redo().add_undo_method(AnimationPlayerEditor::singleton->get_track_editor(), "set_root", node);
+			editor_data->get_undo_redo().add_undo_method_compat(AnimationPlayerEditor::singleton->get_track_editor(), "set_root", node);
 		}
 
 		if (p_keep_global_xform) {
 			if (Object::cast_to<Node2D>(node)) {
-				editor_data->get_undo_redo().add_undo_method(node, "set_transform", Object::cast_to<Node2D>(node)->get_transform());
+				editor_data->get_undo_redo().add_undo_method_compat(node, "set_transform", Object::cast_to<Node2D>(node)->get_transform());
 			}
 			if (Object::cast_to<Node3D>(node)) {
-				editor_data->get_undo_redo().add_undo_method(node, "set_transform", Object::cast_to<Node3D>(node)->get_transform());
+				editor_data->get_undo_redo().add_undo_method_compat(node, "set_transform", Object::cast_to<Node3D>(node)->get_transform());
 			}
 			if (Object::cast_to<Control>(node)) {
-				editor_data->get_undo_redo().add_undo_method(node, "set_position", Object::cast_to<Control>(node)->get_position());
+				editor_data->get_undo_redo().add_undo_method_compat(node, "set_position", Object::cast_to<Control>(node)->get_position());
 			}
 		}
 	}
@@ -1750,10 +1750,10 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 	editor_data->get_undo_redo().create_action(TTR("Attach Script"));
 	for (List<Node *>::Element *E = selected.front(); E; E = E->next()) {
 		Ref<Script> existing = E->get()->get_script();
-		editor_data->get_undo_redo().add_do_method(E->get(), "set_script", p_script);
-		editor_data->get_undo_redo().add_undo_method(E->get(), "set_script", existing);
-		editor_data->get_undo_redo().add_do_method(this, "_update_script_button");
-		editor_data->get_undo_redo().add_undo_method(this, "_update_script_button");
+		editor_data->get_undo_redo().add_do_method_compat(E->get(), "set_script", p_script);
+		editor_data->get_undo_redo().add_undo_method_compat(E->get(), "set_script", existing);
+		editor_data->get_undo_redo().add_do_method_compat(this, "_update_script_button");
+		editor_data->get_undo_redo().add_undo_method_compat(this, "_update_script_button");
 	}
 
 	editor_data->get_undo_redo().commit_action();
@@ -1829,10 +1829,10 @@ void SceneTreeDock::_delete_confirm() {
 	}
 
 	if (entire_scene) {
-		editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", (Object *)nullptr);
-		editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", edited_scene);
-		editor_data->get_undo_redo().add_undo_method(edited_scene, "set_owner", edited_scene->get_owner());
-		editor_data->get_undo_redo().add_undo_method(scene_tree, "update_tree");
+		editor_data->get_undo_redo().add_do_method_compat(editor, "set_edited_scene", (Object *)nullptr);
+		editor_data->get_undo_redo().add_undo_method_compat(editor, "set_edited_scene", edited_scene);
+		editor_data->get_undo_redo().add_undo_method_compat(edited_scene, "set_owner", edited_scene->get_owner());
+		editor_data->get_undo_redo().add_undo_method_compat(scene_tree, "update_tree");
 		editor_data->get_undo_redo().add_undo_reference(edited_scene);
 
 	} else {
@@ -1864,18 +1864,18 @@ void SceneTreeDock::_delete_confirm() {
 				owners.push_back(F->get());
 			}
 
-			editor_data->get_undo_redo().add_do_method(n->get_parent(), "remove_child", n);
-			editor_data->get_undo_redo().add_undo_method(n->get_parent(), "add_child", n);
-			editor_data->get_undo_redo().add_undo_method(n->get_parent(), "move_child", n, n->get_index());
+			editor_data->get_undo_redo().add_do_method_compat(n->get_parent(), "remove_child", n);
+			editor_data->get_undo_redo().add_undo_method_compat(n->get_parent(), "add_child", n);
+			editor_data->get_undo_redo().add_undo_method_compat(n->get_parent(), "move_child", n, n->get_index());
 			if (AnimationPlayerEditor::singleton->get_track_editor()->get_root() == n) {
-				editor_data->get_undo_redo().add_undo_method(AnimationPlayerEditor::singleton->get_track_editor(), "set_root", n);
+				editor_data->get_undo_redo().add_undo_method_compat(AnimationPlayerEditor::singleton->get_track_editor(), "set_root", n);
 			}
-			editor_data->get_undo_redo().add_undo_method(this, "_set_owners", edited_scene, owners);
+			editor_data->get_undo_redo().add_undo_method_compat(this, "_set_owners", edited_scene, owners);
 			editor_data->get_undo_redo().add_undo_reference(n);
 
 			EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-			editor_data->get_undo_redo().add_do_method(ed, "live_debug_remove_and_keep_node", edited_scene->get_path_to(n), n->get_instance_id());
-			editor_data->get_undo_redo().add_undo_method(ed, "live_debug_restore_node", n->get_instance_id(), edited_scene->get_path_to(n->get_parent()), n->get_index());
+			editor_data->get_undo_redo().add_do_method_compat(ed, "live_debug_remove_and_keep_node", edited_scene->get_path_to(n), n->get_instance_id());
+			editor_data->get_undo_redo().add_undo_method_compat(ed, "live_debug_restore_node", n->get_instance_id(), edited_scene->get_path_to(n->get_parent()), n->get_index());
 		}
 	}
 	editor_data->get_undo_redo().commit_action();
@@ -1945,23 +1945,23 @@ void SceneTreeDock::_do_create(Node *p_parent) {
 	editor_data->get_undo_redo().create_action(TTR("Create Node"));
 
 	if (edited_scene) {
-		editor_data->get_undo_redo().add_do_method(p_parent, "add_child", child);
-		editor_data->get_undo_redo().add_do_method(child, "set_owner", edited_scene);
-		editor_data->get_undo_redo().add_do_method(editor_selection, "clear");
-		editor_data->get_undo_redo().add_do_method(editor_selection, "add_node", child);
+		editor_data->get_undo_redo().add_do_method_compat(p_parent, "add_child", child);
+		editor_data->get_undo_redo().add_do_method_compat(child, "set_owner", edited_scene);
+		editor_data->get_undo_redo().add_do_method_compat(editor_selection, "clear");
+		editor_data->get_undo_redo().add_do_method_compat(editor_selection, "add_node", child);
 		editor_data->get_undo_redo().add_do_reference(child);
-		editor_data->get_undo_redo().add_undo_method(p_parent, "remove_child", child);
+		editor_data->get_undo_redo().add_undo_method_compat(p_parent, "remove_child", child);
 
 		String new_name = p_parent->validate_child_name(child);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		editor_data->get_undo_redo().add_do_method(ed, "live_debug_create_node", edited_scene->get_path_to(p_parent), child->get_class(), new_name);
-		editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(p_parent)).plus_file(new_name)));
+		editor_data->get_undo_redo().add_do_method_compat(ed, "live_debug_create_node", edited_scene->get_path_to(p_parent), child->get_class(), new_name);
+		editor_data->get_undo_redo().add_undo_method_compat(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(p_parent)).plus_file(new_name)));
 
 	} else {
-		editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child);
-		editor_data->get_undo_redo().add_do_method(scene_tree, "update_tree");
+		editor_data->get_undo_redo().add_do_method_compat(editor, "set_edited_scene", child);
+		editor_data->get_undo_redo().add_do_method_compat(scene_tree, "update_tree");
 		editor_data->get_undo_redo().add_do_reference(child);
-		editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)nullptr);
+		editor_data->get_undo_redo().add_undo_method_compat(editor, "set_edited_scene", (Object *)nullptr);
 	}
 
 	editor_data->get_undo_redo().commit_action();
@@ -2022,9 +2022,9 @@ void SceneTreeDock::_create() {
 			Node *newnode = Object::cast_to<Node>(c);
 			ERR_FAIL_COND(!newnode);
 
-			ur->add_do_method(this, "replace_node", n, newnode, true, false);
+			ur->add_do_method_compat(this, "replace_node", n, newnode, true, false);
 			ur->add_do_reference(newnode);
-			ur->add_undo_method(this, "replace_node", newnode, n, false, false);
+			ur->add_undo_method_compat(this, "replace_node", newnode, n, false, false);
 			ur->add_undo_reference(n);
 		}
 
@@ -2339,10 +2339,10 @@ void SceneTreeDock::_script_dropped(String p_file, NodePath p_to) {
 	Node *n = get_node(p_to);
 	if (n) {
 		editor_data->get_undo_redo().create_action(TTR("Attach Script"));
-		editor_data->get_undo_redo().add_do_method(n, "set_script", scr);
-		editor_data->get_undo_redo().add_undo_method(n, "set_script", n->get_script());
-		editor_data->get_undo_redo().add_do_method(this, "_update_script_button");
-		editor_data->get_undo_redo().add_undo_method(this, "_update_script_button");
+		editor_data->get_undo_redo().add_do_method_compat(n, "set_script", scr);
+		editor_data->get_undo_redo().add_undo_method_compat(n, "set_script", n->get_script());
+		editor_data->get_undo_redo().add_do_method_compat(this, "_update_script_button");
+		editor_data->get_undo_redo().add_undo_method_compat(this, "_update_script_button");
 		editor_data->get_undo_redo().commit_action();
 	}
 }

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -93,12 +93,12 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		undo_redo->create_action(TTR("Unlock Node"));
 
 		if (n->is_class("CanvasItem") || n->is_class("Node3D")) {
-			undo_redo->add_do_method(n, "remove_meta", "_edit_lock_");
-			undo_redo->add_undo_method(n, "set_meta", "_edit_lock_", true);
-			undo_redo->add_do_method(this, "_update_tree", Variant());
-			undo_redo->add_undo_method(this, "_update_tree", Variant());
-			undo_redo->add_do_method(this, "emit_signal", "node_changed");
-			undo_redo->add_undo_method(this, "emit_signal", "node_changed");
+			undo_redo->add_do_method_compat(n, "remove_meta", "_edit_lock_");
+			undo_redo->add_undo_method_compat(n, "set_meta", "_edit_lock_", true);
+			undo_redo->add_do_method_compat(this, "_update_tree", Variant());
+			undo_redo->add_undo_method_compat(this, "_update_tree", Variant());
+			undo_redo->add_do_method_compat(this, "emit_signal", "node_changed");
+			undo_redo->add_undo_method_compat(this, "emit_signal", "node_changed");
 		}
 		undo_redo->commit_action();
 	} else if (p_id == BUTTON_PIN) {
@@ -111,12 +111,12 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		undo_redo->create_action(TTR("Button Group"));
 
 		if (n->is_class("CanvasItem") || n->is_class("Node3D")) {
-			undo_redo->add_do_method(n, "remove_meta", "_edit_group_");
-			undo_redo->add_undo_method(n, "set_meta", "_edit_group_", true);
-			undo_redo->add_do_method(this, "_update_tree", Variant());
-			undo_redo->add_undo_method(this, "_update_tree", Variant());
-			undo_redo->add_do_method(this, "emit_signal", "node_changed");
-			undo_redo->add_undo_method(this, "emit_signal", "node_changed");
+			undo_redo->add_do_method_compat(n, "remove_meta", "_edit_group_");
+			undo_redo->add_undo_method_compat(n, "set_meta", "_edit_group_", true);
+			undo_redo->add_do_method_compat(this, "_update_tree", Variant());
+			undo_redo->add_undo_method_compat(this, "_update_tree", Variant());
+			undo_redo->add_do_method_compat(this, "emit_signal", "node_changed");
+			undo_redo->add_undo_method_compat(this, "emit_signal", "node_changed");
 		}
 		undo_redo->commit_action();
 	} else if (p_id == BUTTON_WARNING) {
@@ -151,8 +151,8 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 void SceneTreeEditor::_toggle_visible(Node *p_node) {
 	if (p_node->has_method("is_visible") && p_node->has_method("set_visible")) {
 		bool v = bool(p_node->call("is_visible"));
-		undo_redo->add_do_method(p_node, "set_visible", !v);
-		undo_redo->add_undo_method(p_node, "set_visible", v);
+		undo_redo->add_do_method_compat(p_node, "set_visible", !v);
+		undo_redo->add_undo_method_compat(p_node, "set_visible", v);
 	}
 }
 
@@ -787,8 +787,8 @@ void SceneTreeEditor::_renamed() {
 	} else {
 		undo_redo->create_action(TTR("Rename Node"));
 		emit_signal("node_prerename", n, new_name);
-		undo_redo->add_do_method(this, "_rename_node", n->get_instance_id(), new_name);
-		undo_redo->add_undo_method(this, "_rename_node", n->get_instance_id(), n->get_name());
+		undo_redo->add_do_method_compat(this, "_rename_node", n->get_instance_id(), new_name);
+		undo_redo->add_undo_method_compat(this, "_rename_node", n->get_instance_id(), n->get_name());
 		undo_redo->commit_action();
 	}
 }

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -285,12 +285,12 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 		}
 
 		undo_redo->create_action(TTR("Erase Shortcut"));
-		undo_redo->add_do_method(sc.ptr(), "set_shortcut", Ref<InputEvent>());
-		undo_redo->add_undo_method(sc.ptr(), "set_shortcut", sc->get_shortcut());
-		undo_redo->add_do_method(this, "_update_shortcuts");
-		undo_redo->add_undo_method(this, "_update_shortcuts");
-		undo_redo->add_do_method(this, "_settings_changed");
-		undo_redo->add_undo_method(this, "_settings_changed");
+		undo_redo->add_do_method_compat(sc.ptr(), "set_shortcut", Ref<InputEvent>());
+		undo_redo->add_undo_method_compat(sc.ptr(), "set_shortcut", sc->get_shortcut());
+		undo_redo->add_do_method_compat(this, "_update_shortcuts");
+		undo_redo->add_undo_method_compat(this, "_update_shortcuts");
+		undo_redo->add_do_method_compat(this, "_settings_changed");
+		undo_redo->add_undo_method_compat(this, "_settings_changed");
 		undo_redo->commit_action();
 	} else if (p_idx == 2) { //revert to original
 		if (!sc.is_valid()) {
@@ -300,12 +300,12 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 		Ref<InputEvent> original = sc->get_meta("original");
 
 		undo_redo->create_action(TTR("Restore Shortcut"));
-		undo_redo->add_do_method(sc.ptr(), "set_shortcut", original);
-		undo_redo->add_undo_method(sc.ptr(), "set_shortcut", sc->get_shortcut());
-		undo_redo->add_do_method(this, "_update_shortcuts");
-		undo_redo->add_undo_method(this, "_update_shortcuts");
-		undo_redo->add_do_method(this, "_settings_changed");
-		undo_redo->add_undo_method(this, "_settings_changed");
+		undo_redo->add_do_method_compat(sc.ptr(), "set_shortcut", original);
+		undo_redo->add_undo_method_compat(sc.ptr(), "set_shortcut", sc->get_shortcut());
+		undo_redo->add_do_method_compat(this, "_update_shortcuts");
+		undo_redo->add_undo_method_compat(this, "_update_shortcuts");
+		undo_redo->add_do_method_compat(this, "_settings_changed");
+		undo_redo->add_undo_method_compat(this, "_settings_changed");
 		undo_redo->commit_action();
 	}
 }
@@ -338,12 +338,12 @@ void EditorSettingsDialog::_press_a_key_confirm() {
 	Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(shortcut_configured);
 
 	undo_redo->create_action(TTR("Change Shortcut") + " '" + shortcut_configured + "'");
-	undo_redo->add_do_method(sc.ptr(), "set_shortcut", ie);
-	undo_redo->add_undo_method(sc.ptr(), "set_shortcut", sc->get_shortcut());
-	undo_redo->add_do_method(this, "_update_shortcuts");
-	undo_redo->add_undo_method(this, "_update_shortcuts");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
+	undo_redo->add_do_method_compat(sc.ptr(), "set_shortcut", ie);
+	undo_redo->add_undo_method_compat(sc.ptr(), "set_shortcut", sc->get_shortcut());
+	undo_redo->add_do_method_compat(this, "_update_shortcuts");
+	undo_redo->add_undo_method_compat(this, "_update_shortcuts");
+	undo_redo->add_do_method_compat(this, "_settings_changed");
+	undo_redo->add_undo_method_compat(this, "_settings_changed");
 	undo_redo->commit_action();
 }
 

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -85,8 +85,8 @@ protected:
 		UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 		undo_redo->create_action("Set Shader Global Variable");
-		undo_redo->add_do_method(RS::get_singleton(), "global_variable_set", p_name, p_value);
-		undo_redo->add_undo_method(RS::get_singleton(), "global_variable_set", p_name, existing);
+		undo_redo->add_do_method_compat(RS::get_singleton(), "global_variable_set", p_name, p_value);
+		undo_redo->add_undo_method_compat(RS::get_singleton(), "global_variable_set", p_name, existing);
 		RS::GlobalVariableType type = RS::get_singleton()->global_variable_get_type(p_name);
 		Dictionary gv;
 		gv["type"] = global_var_type_names[type];
@@ -104,8 +104,8 @@ protected:
 		String path = "shader_globals/" + String(p_name);
 		undo_redo->add_do_property(ProjectSettings::get_singleton(), path, gv);
 		undo_redo->add_undo_property(ProjectSettings::get_singleton(), path, ProjectSettings::get_singleton()->get(path));
-		undo_redo->add_do_method(this, "_var_changed");
-		undo_redo->add_undo_method(this, "_var_changed");
+		undo_redo->add_do_method_compat(this, "_var_changed");
+		undo_redo->add_undo_method_compat(this, "_var_changed");
 		block_update = true;
 		undo_redo->commit_action();
 		block_update = false;
@@ -396,16 +396,16 @@ void ShaderGlobalsEditor::_variable_added() {
 	Variant value = create_var(RS::GlobalVariableType(variable_type->get_selected()));
 
 	undo_redo->create_action("Add Shader Global Variable");
-	undo_redo->add_do_method(RS::get_singleton(), "global_variable_add", var, RS::GlobalVariableType(variable_type->get_selected()), value);
-	undo_redo->add_undo_method(RS::get_singleton(), "global_variable_remove", var);
+	undo_redo->add_do_method_compat(RS::get_singleton(), "global_variable_add", var, RS::GlobalVariableType(variable_type->get_selected()), value);
+	undo_redo->add_undo_method_compat(RS::get_singleton(), "global_variable_remove", var);
 	Dictionary gv;
 	gv["type"] = global_var_type_names[variable_type->get_selected()];
 	gv["value"] = value;
 
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "shader_globals/" + var, gv);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "shader_globals/" + var, Variant());
-	undo_redo->add_do_method(this, "_changed");
-	undo_redo->add_undo_method(this, "_changed");
+	undo_redo->add_do_method_compat(this, "_changed");
+	undo_redo->add_undo_method_compat(this, "_changed");
 	undo_redo->commit_action();
 }
 
@@ -414,13 +414,13 @@ void ShaderGlobalsEditor::_variable_deleted(const String &p_variable) {
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	undo_redo->create_action("Add Shader Global Variable");
-	undo_redo->add_do_method(RS::get_singleton(), "global_variable_remove", p_variable);
-	undo_redo->add_undo_method(RS::get_singleton(), "global_variable_add", p_variable, RS::get_singleton()->global_variable_get_type(p_variable), RS::get_singleton()->global_variable_get(p_variable));
+	undo_redo->add_do_method_compat(RS::get_singleton(), "global_variable_remove", p_variable);
+	undo_redo->add_undo_method_compat(RS::get_singleton(), "global_variable_add", p_variable, RS::get_singleton()->global_variable_get_type(p_variable), RS::get_singleton()->global_variable_get(p_variable));
 
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "shader_globals/" + p_variable, Variant());
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "shader_globals/" + p_variable, ProjectSettings::get_singleton()->get("shader_globals/" + p_variable));
-	undo_redo->add_do_method(this, "_changed");
-	undo_redo->add_undo_method(this, "_changed");
+	undo_redo->add_do_method_compat(this, "_changed");
+	undo_redo->add_undo_method_compat(this, "_changed");
 	undo_redo->commit_action();
 }
 

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -205,8 +205,8 @@ void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx,
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Sphere Shape Radius"));
-		ur->add_do_method(s, "set_radius", s->get_radius());
-		ur->add_undo_method(s, "set_radius", p_restore);
+		ur->add_do_method_compat(s, "set_radius", s->get_radius());
+		ur->add_undo_method_compat(s, "set_radius", p_restore);
 		ur->commit_action();
 	}
 
@@ -219,8 +219,8 @@ void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx,
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change Box Shape Size"));
-		ur->add_do_method(s, "set_size", s->get_size());
-		ur->add_undo_method(s, "set_size", p_restore);
+		ur->add_do_method_compat(s, "set_size", s->get_size());
+		ur->add_undo_method_compat(s, "set_size", p_restore);
 		ur->commit_action();
 	}
 
@@ -238,12 +238,12 @@ void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx,
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		if (p_idx == 0) {
 			ur->create_action(TTR("Change Cylinder Radius"));
-			ur->add_do_method(s, "set_radius", s->get_radius());
-			ur->add_undo_method(s, "set_radius", p_restore);
+			ur->add_do_method_compat(s, "set_radius", s->get_radius());
+			ur->add_undo_method_compat(s, "set_radius", p_restore);
 		} else {
 			ur->create_action(TTR("Change Cylinder Height"));
-			ur->add_do_method(s, "set_height", s->get_height());
-			ur->add_undo_method(s, "set_height", p_restore);
+			ur->add_do_method_compat(s, "set_height", s->get_height());
+			ur->add_undo_method_compat(s, "set_height", p_restore);
 		}
 
 		ur->commit_action();
@@ -263,12 +263,12 @@ void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx,
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		if (p_idx == 0) {
 			ur->create_action(TTR("Change Torus Inner Radius"));
-			ur->add_do_method(s, "set_inner_radius", s->get_inner_radius());
-			ur->add_undo_method(s, "set_inner_radius", p_restore);
+			ur->add_do_method_compat(s, "set_inner_radius", s->get_inner_radius());
+			ur->add_undo_method_compat(s, "set_inner_radius", p_restore);
 		} else {
 			ur->create_action(TTR("Change Torus Outer Radius"));
-			ur->add_do_method(s, "set_outer_radius", s->get_outer_radius());
-			ur->add_undo_method(s, "set_outer_radius", p_restore);
+			ur->add_do_method_compat(s, "set_outer_radius", s->get_outer_radius());
+			ur->add_undo_method_compat(s, "set_outer_radius", p_restore);
 		}
 
 		ur->commit_action();

--- a/modules/gdnative/gdnative_library_singleton_editor.cpp
+++ b/modules/gdnative/gdnative_library_singleton_editor.cpp
@@ -175,9 +175,9 @@ void GDNativeLibrarySingletonEditor::_item_edited() {
 
 	undo_redo->create_action(enabled ? TTR("Enabled GDNative Singleton") : TTR("Disabled GDNative Singleton"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "gdnative/singletons_disabled", disabled_paths);
-	undo_redo->add_do_method(this, "_update_libraries");
+	undo_redo->add_do_method_compat(this, "_update_libraries");
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "gdnative/singletons_disabled", undo_paths);
-	undo_redo->add_undo_method(this, "_update_libraries");
+	undo_redo->add_undo_method_compat(this, "_update_libraries");
 	undo_redo->commit_action();
 }
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -471,13 +471,13 @@ void GridMapEditor::_delete_selection() {
 		for (int j = selection.begin.y; j <= selection.end.y; j++) {
 			for (int k = selection.begin.z; k <= selection.end.z; k++) {
 				Vector3i selected = Vector3i(i, j, k);
-				undo_redo->add_do_method(node, "set_cell_item", selected, GridMap::INVALID_CELL_ITEM);
-				undo_redo->add_undo_method(node, "set_cell_item", selected, node->get_cell_item(selected), node->get_cell_item_orientation(selected));
+				undo_redo->add_do_method_compat(node, "set_cell_item", selected, GridMap::INVALID_CELL_ITEM);
+				undo_redo->add_undo_method_compat(node, "set_cell_item", selected, node->get_cell_item(selected), node->get_cell_item_orientation(selected));
 			}
 		}
 	}
-	undo_redo->add_do_method(this, "_set_selection", !selection.active, selection.begin, selection.end);
-	undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
+	undo_redo->add_do_method_compat(this, "_set_selection", !selection.active, selection.begin, selection.end);
+	undo_redo->add_undo_method_compat(this, "_set_selection", selection.active, selection.begin, selection.end);
 	undo_redo->commit_action();
 }
 
@@ -491,13 +491,13 @@ void GridMapEditor::_fill_selection() {
 		for (int j = selection.begin.y; j <= selection.end.y; j++) {
 			for (int k = selection.begin.z; k <= selection.end.z; k++) {
 				Vector3i selected = Vector3i(i, j, k);
-				undo_redo->add_do_method(node, "set_cell_item", selected, selected_palette, cursor_rot);
-				undo_redo->add_undo_method(node, "set_cell_item", selected, node->get_cell_item(selected), node->get_cell_item_orientation(selected));
+				undo_redo->add_do_method_compat(node, "set_cell_item", selected, selected_palette, cursor_rot);
+				undo_redo->add_undo_method_compat(node, "set_cell_item", selected, node->get_cell_item(selected), node->get_cell_item_orientation(selected));
 			}
 		}
 	}
-	undo_redo->add_do_method(this, "_set_selection", !selection.active, selection.begin, selection.end);
-	undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
+	undo_redo->add_do_method_compat(this, "_set_selection", !selection.active, selection.begin, selection.end);
+	undo_redo->add_undo_method_compat(this, "_set_selection", selection.active, selection.begin, selection.end);
 	undo_redo->commit_action();
 }
 
@@ -592,13 +592,13 @@ void GridMapEditor::_do_paste() {
 		orm.set_orthogonal_index(item.orientation);
 		orm = rot * orm;
 
-		undo_redo->add_do_method(node, "set_cell_item", position, item.cell_item, orm.get_orthogonal_index());
-		undo_redo->add_undo_method(node, "set_cell_item", position, node->get_cell_item(position), node->get_cell_item_orientation(position));
+		undo_redo->add_do_method_compat(node, "set_cell_item", position, item.cell_item, orm.get_orthogonal_index());
+		undo_redo->add_undo_method_compat(node, "set_cell_item", position, node->get_cell_item(position), node->get_cell_item_orientation(position));
 	}
 
 	if (reselect) {
-		undo_redo->add_do_method(this, "_set_selection", true, paste_indicator.begin + ofs, paste_indicator.end + ofs);
-		undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
+		undo_redo->add_do_method_compat(this, "_set_selection", true, paste_indicator.begin + ofs, paste_indicator.end + ofs);
+		undo_redo->add_undo_method_compat(this, "_set_selection", selection.active, selection.begin, selection.end);
 	}
 
 	undo_redo->commit_action();
@@ -670,11 +670,11 @@ bool GridMapEditor::forward_spatial_input_event(Camera3D *p_camera, const Ref<In
 					undo_redo->create_action(TTR("GridMap Paint"));
 					for (List<SetItem>::Element *E = set_items.front(); E; E = E->next()) {
 						const SetItem &si = E->get();
-						undo_redo->add_do_method(node, "set_cell_item", si.position, si.new_value, si.new_orientation);
+						undo_redo->add_do_method_compat(node, "set_cell_item", si.position, si.new_value, si.new_orientation);
 					}
 					for (List<SetItem>::Element *E = set_items.back(); E; E = E->prev()) {
 						const SetItem &si = E->get();
-						undo_redo->add_undo_method(node, "set_cell_item", si.position, si.old_value, si.old_orientation);
+						undo_redo->add_undo_method_compat(node, "set_cell_item", si.position, si.old_value, si.old_orientation);
 					}
 
 					undo_redo->commit_action();
@@ -686,8 +686,8 @@ bool GridMapEditor::forward_spatial_input_event(Camera3D *p_camera, const Ref<In
 
 			if (mb->get_button_index() == BUTTON_LEFT && input_action == INPUT_SELECT) {
 				undo_redo->create_action("GridMap Selection");
-				undo_redo->add_do_method(this, "_set_selection", selection.active, selection.begin, selection.end);
-				undo_redo->add_undo_method(this, "_set_selection", last_selection.active, last_selection.begin, last_selection.end);
+				undo_redo->add_do_method_compat(this, "_set_selection", selection.active, selection.begin, selection.end);
+				undo_redo->add_undo_method_compat(this, "_set_selection", last_selection.active, last_selection.begin, last_selection.end);
 				undo_redo->commit_action();
 			}
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -81,18 +81,18 @@ protected:
 
 			if (new_argc < argc) {
 				for (int i = new_argc; i < argc; i++) {
-					undo_redo->add_do_method(script.ptr(), "custom_signal_remove_argument", sig, new_argc);
-					undo_redo->add_undo_method(script.ptr(), "custom_signal_add_argument", sig, script->custom_signal_get_argument_name(sig, i), script->custom_signal_get_argument_type(sig, i), -1);
+					undo_redo->add_do_method_compat(script.ptr(), "custom_signal_remove_argument", sig, new_argc);
+					undo_redo->add_undo_method_compat(script.ptr(), "custom_signal_add_argument", sig, script->custom_signal_get_argument_name(sig, i), script->custom_signal_get_argument_type(sig, i), -1);
 				}
 			} else if (new_argc > argc) {
 				for (int i = argc; i < new_argc; i++) {
-					undo_redo->add_do_method(script.ptr(), "custom_signal_add_argument", sig, Variant::NIL, "arg" + itos(i + 1), -1);
-					undo_redo->add_undo_method(script.ptr(), "custom_signal_remove_argument", sig, argc);
+					undo_redo->add_do_method_compat(script.ptr(), "custom_signal_add_argument", sig, Variant::NIL, "arg" + itos(i + 1), -1);
+					undo_redo->add_undo_method_compat(script.ptr(), "custom_signal_remove_argument", sig, argc);
 				}
 			}
 
-			undo_redo->add_do_method(this, "_sig_changed");
-			undo_redo->add_undo_method(this, "_sig_changed");
+			undo_redo->add_do_method_compat(this, "_sig_changed");
+			undo_redo->add_undo_method_compat(this, "_sig_changed");
 
 			undo_redo->commit_action();
 
@@ -106,8 +106,8 @@ protected:
 				int old_type = script->custom_signal_get_argument_type(sig, idx);
 				int new_type = p_value;
 				undo_redo->create_action(TTR("Change Argument Type"));
-				undo_redo->add_do_method(script.ptr(), "custom_signal_set_argument_type", sig, idx, new_type);
-				undo_redo->add_undo_method(script.ptr(), "custom_signal_set_argument_type", sig, idx, old_type);
+				undo_redo->add_do_method_compat(script.ptr(), "custom_signal_set_argument_type", sig, idx, new_type);
+				undo_redo->add_undo_method_compat(script.ptr(), "custom_signal_set_argument_type", sig, idx, old_type);
 				undo_redo->commit_action();
 
 				return true;
@@ -117,8 +117,8 @@ protected:
 				String old_name = script->custom_signal_get_argument_name(sig, idx);
 				String new_name = p_value;
 				undo_redo->create_action(TTR("Change Argument name"));
-				undo_redo->add_do_method(script.ptr(), "custom_signal_set_argument_name", sig, idx, new_name);
-				undo_redo->add_undo_method(script.ptr(), "custom_signal_set_argument_name", sig, idx, old_name);
+				undo_redo->add_do_method_compat(script.ptr(), "custom_signal_set_argument_name", sig, idx, new_name);
+				undo_redo->add_undo_method_compat(script.ptr(), "custom_signal_set_argument_name", sig, idx, old_name);
 				undo_redo->commit_action();
 				return true;
 			}
@@ -211,10 +211,10 @@ protected:
 		if (String(p_name) == "value") {
 			undo_redo->create_action(TTR("Set Variable Default Value"));
 			Variant current = script->get_variable_default_value(var);
-			undo_redo->add_do_method(script.ptr(), "set_variable_default_value", var, p_value);
-			undo_redo->add_undo_method(script.ptr(), "set_variable_default_value", var, current);
-			undo_redo->add_do_method(this, "_var_value_changed");
-			undo_redo->add_undo_method(this, "_var_value_changed");
+			undo_redo->add_do_method_compat(script.ptr(), "set_variable_default_value", var, p_value);
+			undo_redo->add_undo_method_compat(script.ptr(), "set_variable_default_value", var, current);
+			undo_redo->add_do_method_compat(this, "_var_value_changed");
+			undo_redo->add_undo_method_compat(this, "_var_value_changed");
 			undo_redo->commit_action();
 			return true;
 		}
@@ -225,8 +225,8 @@ protected:
 			Dictionary dc = d.duplicate();
 			dc["type"] = p_value;
 			undo_redo->create_action(TTR("Set Variable Type"));
-			undo_redo->add_do_method(script.ptr(), "set_variable_info", var, dc);
-			undo_redo->add_undo_method(script.ptr(), "set_variable_info", var, d);
+			undo_redo->add_do_method_compat(script.ptr(), "set_variable_info", var, dc);
+			undo_redo->add_undo_method_compat(script.ptr(), "set_variable_info", var, d);
 
 			// Setting the default value.
 			Variant::Type type = (Variant::Type)(int)p_value;
@@ -235,13 +235,13 @@ protected:
 				Callable::CallError ce;
 				Variant::construct(type, default_value, nullptr, 0, ce);
 				if (ce.error == Callable::CallError::CALL_OK) {
-					undo_redo->add_do_method(script.ptr(), "set_variable_default_value", var, default_value);
-					undo_redo->add_undo_method(script.ptr(), "set_variable_default_value", var, dc["value"]);
+					undo_redo->add_do_method_compat(script.ptr(), "set_variable_default_value", var, default_value);
+					undo_redo->add_undo_method_compat(script.ptr(), "set_variable_default_value", var, dc["value"]);
 				}
 			}
 
-			undo_redo->add_do_method(this, "_var_changed");
-			undo_redo->add_undo_method(this, "_var_changed");
+			undo_redo->add_do_method_compat(this, "_var_changed");
+			undo_redo->add_undo_method_compat(this, "_var_changed");
 			undo_redo->commit_action();
 			return true;
 		}
@@ -250,10 +250,10 @@ protected:
 			Dictionary dc = d.duplicate();
 			dc["hint"] = p_value;
 			undo_redo->create_action(TTR("Set Variable Type"));
-			undo_redo->add_do_method(script.ptr(), "set_variable_info", var, dc);
-			undo_redo->add_undo_method(script.ptr(), "set_variable_info", var, d);
-			undo_redo->add_do_method(this, "_var_changed");
-			undo_redo->add_undo_method(this, "_var_changed");
+			undo_redo->add_do_method_compat(script.ptr(), "set_variable_info", var, dc);
+			undo_redo->add_undo_method_compat(script.ptr(), "set_variable_info", var, d);
+			undo_redo->add_do_method_compat(this, "_var_changed");
+			undo_redo->add_undo_method_compat(this, "_var_changed");
 			undo_redo->commit_action();
 			return true;
 		}
@@ -262,10 +262,10 @@ protected:
 			Dictionary dc = d.duplicate();
 			dc["hint_string"] = p_value;
 			undo_redo->create_action(TTR("Set Variable Type"));
-			undo_redo->add_do_method(script.ptr(), "set_variable_info", var, dc);
-			undo_redo->add_undo_method(script.ptr(), "set_variable_info", var, d);
-			undo_redo->add_do_method(this, "_var_changed");
-			undo_redo->add_undo_method(this, "_var_changed");
+			undo_redo->add_do_method_compat(script.ptr(), "set_variable_info", var, dc);
+			undo_redo->add_undo_method_compat(script.ptr(), "set_variable_info", var, d);
+			undo_redo->add_do_method_compat(this, "_var_changed");
+			undo_redo->add_undo_method_compat(this, "_var_changed");
 			undo_redo->commit_action();
 			return true;
 		}
@@ -994,11 +994,11 @@ void VisualScriptEditor::_change_port_type(int p_select, int p_id, int p_port, b
 
 	undo_redo->create_action("Change Port Type");
 	if (is_input) {
-		undo_redo->add_do_method(vsn.ptr(), "set_input_data_port_type", p_port, Variant::Type(p_select));
-		undo_redo->add_undo_method(vsn.ptr(), "set_input_data_port_type", p_port, vsn->get_input_value_port_info(p_port).type);
+		undo_redo->add_do_method_compat(vsn.ptr(), "set_input_data_port_type", p_port, Variant::Type(p_select));
+		undo_redo->add_undo_method_compat(vsn.ptr(), "set_input_data_port_type", p_port, vsn->get_input_value_port_info(p_port).type);
 	} else {
-		undo_redo->add_do_method(vsn.ptr(), "set_output_data_port_type", p_port, Variant::Type(p_select));
-		undo_redo->add_undo_method(vsn.ptr(), "set_output_data_port_type", p_port, vsn->get_output_value_port_info(p_port).type);
+		undo_redo->add_do_method_compat(vsn.ptr(), "set_output_data_port_type", p_port, Variant::Type(p_select));
+		undo_redo->add_undo_method_compat(vsn.ptr(), "set_output_data_port_type", p_port, vsn->get_output_value_port_info(p_port).type);
 	}
 	undo_redo->commit_action();
 }
@@ -1026,11 +1026,11 @@ void VisualScriptEditor::_port_name_focus_out(const Node *p_name_box, int p_id, 
 
 	undo_redo->create_action("Change Port Name");
 	if (is_input) {
-		undo_redo->add_do_method(vsn.ptr(), "set_input_data_port_name", p_port, text);
-		undo_redo->add_undo_method(vsn.ptr(), "set_input_data_port_name", p_port, vsn->get_input_value_port_info(p_port).name);
+		undo_redo->add_do_method_compat(vsn.ptr(), "set_input_data_port_name", p_port, text);
+		undo_redo->add_undo_method_compat(vsn.ptr(), "set_input_data_port_name", p_port, vsn->get_input_value_port_info(p_port).name);
 	} else {
-		undo_redo->add_do_method(vsn.ptr(), "set_output_data_port_name", p_port, text);
-		undo_redo->add_undo_method(vsn.ptr(), "set_output_data_port_name", p_port, vsn->get_output_value_port_info(p_port).name);
+		undo_redo->add_do_method_compat(vsn.ptr(), "set_output_data_port_name", p_port, text);
+		undo_redo->add_undo_method_compat(vsn.ptr(), "set_output_data_port_name", p_port, vsn->get_output_value_port_info(p_port).name);
 	}
 	undo_redo->commit_action();
 }
@@ -1233,11 +1233,11 @@ void VisualScriptEditor::_member_edited() {
 			func = script->get_node(node_id);
 		}
 		undo_redo->create_action(TTR("Rename Function"));
-		undo_redo->add_do_method(script.ptr(), "rename_function", name, new_name);
-		undo_redo->add_undo_method(script.ptr(), "rename_function", new_name, name);
+		undo_redo->add_do_method_compat(script.ptr(), "rename_function", name, new_name);
+		undo_redo->add_undo_method_compat(script.ptr(), "rename_function", new_name, name);
 		if (func.is_valid()) {
-			undo_redo->add_do_method(func.ptr(), "set_name", new_name);
-			undo_redo->add_undo_method(func.ptr(), "set_name", name);
+			undo_redo->add_do_method_compat(func.ptr(), "set_name", new_name);
+			undo_redo->add_undo_method_compat(func.ptr(), "set_name", name);
 		}
 
 		// Also fix all function calls.
@@ -1249,17 +1249,17 @@ void VisualScriptEditor::_member_edited() {
 				continue;
 			}
 			if (fncall->get_function() == name) {
-				undo_redo->add_do_method(fncall.ptr(), "set_function", new_name);
-				undo_redo->add_undo_method(fncall.ptr(), "set_function", name);
+				undo_redo->add_do_method_compat(fncall.ptr(), "set_function", new_name);
+				undo_redo->add_undo_method_compat(fncall.ptr(), "set_function", name);
 			}
 		}
 
-		undo_redo->add_do_method(this, "_update_members");
-		undo_redo->add_undo_method(this, "_update_members");
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
-		undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
-		undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
+		undo_redo->add_do_method_compat(this, "_update_members");
+		undo_redo->add_undo_method_compat(this, "_update_members");
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
+		undo_redo->add_do_method_compat(this, "emit_signal", "edited_script_changed");
+		undo_redo->add_undo_method_compat(this, "emit_signal", "edited_script_changed");
 		undo_redo->commit_action();
 
 		return; // Or crash because it will become invalid.
@@ -1268,14 +1268,14 @@ void VisualScriptEditor::_member_edited() {
 	if (ti->get_parent() == root->get_children()->get_next()) {
 		selected = new_name;
 		undo_redo->create_action(TTR("Rename Variable"));
-		undo_redo->add_do_method(script.ptr(), "rename_variable", name, new_name);
-		undo_redo->add_undo_method(script.ptr(), "rename_variable", new_name, name);
-		undo_redo->add_do_method(this, "_update_members");
-		undo_redo->add_undo_method(this, "_update_members");
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
-		undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
-		undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
+		undo_redo->add_do_method_compat(script.ptr(), "rename_variable", name, new_name);
+		undo_redo->add_undo_method_compat(script.ptr(), "rename_variable", new_name, name);
+		undo_redo->add_do_method_compat(this, "_update_members");
+		undo_redo->add_undo_method_compat(this, "_update_members");
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
+		undo_redo->add_do_method_compat(this, "emit_signal", "edited_script_changed");
+		undo_redo->add_undo_method_compat(this, "emit_signal", "edited_script_changed");
 		undo_redo->commit_action();
 
 		return; // Or crash because it will become invalid.
@@ -1284,12 +1284,12 @@ void VisualScriptEditor::_member_edited() {
 	if (ti->get_parent() == root->get_children()->get_next()->get_next()) {
 		selected = new_name;
 		undo_redo->create_action(TTR("Rename Signal"));
-		undo_redo->add_do_method(script.ptr(), "rename_custom_signal", name, new_name);
-		undo_redo->add_undo_method(script.ptr(), "rename_custom_signal", new_name, name);
-		undo_redo->add_do_method(this, "_update_members");
-		undo_redo->add_undo_method(this, "_update_members");
-		undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
-		undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
+		undo_redo->add_do_method_compat(script.ptr(), "rename_custom_signal", name, new_name);
+		undo_redo->add_undo_method_compat(script.ptr(), "rename_custom_signal", new_name, name);
+		undo_redo->add_do_method_compat(this, "_update_members");
+		undo_redo->add_undo_method_compat(this, "_update_members");
+		undo_redo->add_do_method_compat(this, "emit_signal", "edited_script_changed");
+		undo_redo->add_undo_method_compat(this, "emit_signal", "edited_script_changed");
 		undo_redo->commit_action();
 
 		return; // Or crash because it will become invalid.
@@ -1329,16 +1329,16 @@ void VisualScriptEditor::_create_function() {
 	int func_node_id = script->get_available_id();
 
 	undo_redo->create_action(TTR("Add Function"));
-	undo_redo->add_do_method(script.ptr(), "add_function", name, func_node_id);
-	undo_redo->add_undo_method(script.ptr(), "remove_function", name);
-	undo_redo->add_do_method(script.ptr(), "add_node", func_node_id, func_node, ofs);
-	undo_redo->add_undo_method(script.ptr(), "remove_node", func_node_id);
-	undo_redo->add_do_method(this, "_update_members");
-	undo_redo->add_undo_method(this, "_update_members");
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
-	undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
-	undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
+	undo_redo->add_do_method_compat(script.ptr(), "add_function", name, func_node_id);
+	undo_redo->add_undo_method_compat(script.ptr(), "remove_function", name);
+	undo_redo->add_do_method_compat(script.ptr(), "add_node", func_node_id, func_node, ofs);
+	undo_redo->add_undo_method_compat(script.ptr(), "remove_node", func_node_id);
+	undo_redo->add_do_method_compat(this, "_update_members");
+	undo_redo->add_undo_method_compat(this, "_update_members");
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
+	undo_redo->add_do_method_compat(this, "emit_signal", "edited_script_changed");
+	undo_redo->add_undo_method_compat(this, "emit_signal", "edited_script_changed");
 	undo_redo->commit_action();
 
 	_update_graph();
@@ -1434,16 +1434,16 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 				int fn_id = script->get_available_id();
 
 				undo_redo->create_action(TTR("Add Function"));
-				undo_redo->add_do_method(script.ptr(), "add_function", name, fn_id);
-				undo_redo->add_do_method(script.ptr(), "add_node", fn_id, func_node, ofs);
-				undo_redo->add_undo_method(script.ptr(), "remove_function", name);
-				undo_redo->add_do_method(script.ptr(), "remove_node", fn_id);
-				undo_redo->add_do_method(this, "_update_members");
-				undo_redo->add_undo_method(this, "_update_members");
-				undo_redo->add_do_method(this, "_update_graph");
-				undo_redo->add_undo_method(this, "_update_graph");
-				undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
+				undo_redo->add_do_method_compat(script.ptr(), "add_function", name, fn_id);
+				undo_redo->add_do_method_compat(script.ptr(), "add_node", fn_id, func_node, ofs);
+				undo_redo->add_undo_method_compat(script.ptr(), "remove_function", name);
+				undo_redo->add_do_method_compat(script.ptr(), "remove_node", fn_id);
+				undo_redo->add_do_method_compat(this, "_update_members");
+				undo_redo->add_undo_method_compat(this, "_update_members");
+				undo_redo->add_do_method_compat(this, "_update_graph");
+				undo_redo->add_undo_method_compat(this, "_update_graph");
+				undo_redo->add_do_method_compat(this, "emit_signal", "edited_script_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "edited_script_changed");
 				undo_redo->commit_action();
 
 				_update_graph();
@@ -1458,12 +1458,12 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 			selected = name;
 
 			undo_redo->create_action(TTR("Add Variable"));
-			undo_redo->add_do_method(script.ptr(), "add_variable", name);
-			undo_redo->add_undo_method(script.ptr(), "remove_variable", name);
-			undo_redo->add_do_method(this, "_update_members");
-			undo_redo->add_undo_method(this, "_update_members");
-			undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
-			undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
+			undo_redo->add_do_method_compat(script.ptr(), "add_variable", name);
+			undo_redo->add_undo_method_compat(script.ptr(), "remove_variable", name);
+			undo_redo->add_do_method_compat(this, "_update_members");
+			undo_redo->add_undo_method_compat(this, "_update_members");
+			undo_redo->add_do_method_compat(this, "emit_signal", "edited_script_changed");
+			undo_redo->add_undo_method_compat(this, "emit_signal", "edited_script_changed");
 			undo_redo->commit_action();
 			return; // Or crash because it will become invalid.
 		}
@@ -1474,12 +1474,12 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 			selected = name;
 
 			undo_redo->create_action(TTR("Add Signal"));
-			undo_redo->add_do_method(script.ptr(), "add_custom_signal", name);
-			undo_redo->add_undo_method(script.ptr(), "remove_custom_signal", name);
-			undo_redo->add_do_method(this, "_update_members");
-			undo_redo->add_undo_method(this, "_update_members");
-			undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
-			undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
+			undo_redo->add_do_method_compat(script.ptr(), "add_custom_signal", name);
+			undo_redo->add_undo_method_compat(script.ptr(), "remove_custom_signal", name);
+			undo_redo->add_do_method_compat(this, "_update_members");
+			undo_redo->add_undo_method_compat(this, "_update_members");
+			undo_redo->add_do_method_compat(this, "emit_signal", "edited_script_changed");
+			undo_redo->add_undo_method_compat(this, "emit_signal", "edited_script_changed");
 			undo_redo->commit_action();
 			return; // Or crash because it will become invalid.
 		}
@@ -1501,11 +1501,11 @@ void VisualScriptEditor::_add_input_port(int p_id) {
 	updating_graph = true;
 
 	undo_redo->create_action(TTR("Add Input Port"), UndoRedo::MERGE_ENDS);
-	undo_redo->add_do_method(vsn.ptr(), "add_input_data_port", Variant::NIL, "arg", -1);
-	undo_redo->add_do_method(this, "_update_graph", p_id);
+	undo_redo->add_do_method_compat(vsn.ptr(), "add_input_data_port", Variant::NIL, "arg", -1);
+	undo_redo->add_do_method_compat(this, "_update_graph", p_id);
 
-	undo_redo->add_undo_method(vsn.ptr(), "remove_input_data_port", vsn->get_input_value_port_count());
-	undo_redo->add_undo_method(this, "_update_graph", p_id);
+	undo_redo->add_undo_method_compat(vsn.ptr(), "remove_input_data_port", vsn->get_input_value_port_count());
+	undo_redo->add_undo_method_compat(this, "_update_graph", p_id);
 
 	updating_graph = false;
 
@@ -1521,11 +1521,11 @@ void VisualScriptEditor::_add_output_port(int p_id) {
 	updating_graph = true;
 
 	undo_redo->create_action(TTR("Add Output Port"), UndoRedo::MERGE_ENDS);
-	undo_redo->add_do_method(vsn.ptr(), "add_output_data_port", Variant::NIL, "arg", -1);
-	undo_redo->add_do_method(this, "_update_graph", p_id);
+	undo_redo->add_do_method_compat(vsn.ptr(), "add_output_data_port", Variant::NIL, "arg", -1);
+	undo_redo->add_do_method_compat(this, "_update_graph", p_id);
 
-	undo_redo->add_undo_method(vsn.ptr(), "remove_output_data_port", vsn->get_output_value_port_count());
-	undo_redo->add_undo_method(this, "_update_graph", p_id);
+	undo_redo->add_undo_method_compat(vsn.ptr(), "remove_output_data_port", vsn->get_output_value_port_count());
+	undo_redo->add_undo_method_compat(this, "_update_graph", p_id);
 
 	updating_graph = false;
 
@@ -1546,18 +1546,18 @@ void VisualScriptEditor::_remove_input_port(int p_id, int p_port) {
 	script->get_input_value_port_connection_source(p_id, p_port, &conn_from, &conn_port);
 
 	if (conn_from != -1) {
-		undo_redo->add_do_method(script.ptr(), "data_disconnect", conn_from, conn_port, p_id, p_port);
+		undo_redo->add_do_method_compat(script.ptr(), "data_disconnect", conn_from, conn_port, p_id, p_port);
 	}
 
-	undo_redo->add_do_method(vsn.ptr(), "remove_input_data_port", p_port);
-	undo_redo->add_do_method(this, "_update_graph", p_id);
+	undo_redo->add_do_method_compat(vsn.ptr(), "remove_input_data_port", p_port);
+	undo_redo->add_do_method_compat(this, "_update_graph", p_id);
 
 	if (conn_from != -1) {
-		undo_redo->add_undo_method(script.ptr(), "data_connect", conn_from, conn_port, p_id, p_port);
+		undo_redo->add_undo_method_compat(script.ptr(), "data_connect", conn_from, conn_port, p_id, p_port);
 	}
 
-	undo_redo->add_undo_method(vsn.ptr(), "add_input_data_port", vsn->get_input_value_port_info(p_port).type, vsn->get_input_value_port_info(p_port).name, p_port);
-	undo_redo->add_undo_method(this, "_update_graph", p_id);
+	undo_redo->add_undo_method_compat(vsn.ptr(), "add_input_data_port", vsn->get_input_value_port_info(p_port).type, vsn->get_input_value_port_info(p_port).name, p_port);
+	undo_redo->add_undo_method_compat(this, "_update_graph", p_id);
 
 	updating_graph = false;
 
@@ -1588,19 +1588,19 @@ void VisualScriptEditor::_remove_output_port(int p_id, int p_port) {
 		}
 	}
 
-	undo_redo->add_do_method(vsn.ptr(), "remove_output_data_port", p_port);
-	undo_redo->add_do_method(this, "_update_graph", p_id);
+	undo_redo->add_do_method_compat(vsn.ptr(), "remove_output_data_port", p_port);
+	undo_redo->add_do_method_compat(this, "_update_graph", p_id);
 
 	List<int> keys;
 	conn_map.get_key_list(&keys);
 	for (const List<int>::Element *E = keys.front(); E; E = E->next()) {
 		for (const Set<int>::Element *F = conn_map[E->get()].front(); F; F = F->next()) {
-			undo_redo->add_undo_method(script.ptr(), "data_connect", p_id, p_port, E->get(), F->get());
+			undo_redo->add_undo_method_compat(script.ptr(), "data_connect", p_id, p_port, E->get(), F->get());
 		}
 	}
 
-	undo_redo->add_undo_method(vsn.ptr(), "add_output_data_port", vsn->get_output_value_port_info(p_port).type, vsn->get_output_value_port_info(p_port).name, p_port);
-	undo_redo->add_undo_method(this, "_update_graph", p_id);
+	undo_redo->add_undo_method_compat(vsn.ptr(), "add_output_data_port", vsn->get_output_value_port_info(p_port).type, vsn->get_output_value_port_info(p_port).name, p_port);
+	undo_redo->add_undo_method_compat(this, "_update_graph", p_id);
 
 	updating_graph = false;
 
@@ -1618,8 +1618,8 @@ void VisualScriptEditor::_expression_text_changed(const String &p_text, int p_id
 	undo_redo->create_action(TTR("Change Expression"), UndoRedo::MERGE_ENDS);
 	undo_redo->add_do_property(vse.ptr(), "expression", p_text);
 	undo_redo->add_undo_property(vse.ptr(), "expression", vse->get("expression"));
-	undo_redo->add_do_method(this, "_update_graph", p_id);
-	undo_redo->add_undo_method(this, "_update_graph", p_id);
+	undo_redo->add_do_method_compat(this, "_update_graph", p_id);
+	undo_redo->add_undo_method_compat(this, "_update_graph", p_id);
 	undo_redo->commit_action();
 
 	Node *node = graph->get_node(itos(p_id));
@@ -1705,15 +1705,15 @@ void VisualScriptEditor::_on_nodes_delete() {
 	for (List<int>::Element *F = to_erase.front(); F; F = F->next()) {
 		int cr_node = F->get();
 
-		undo_redo->add_do_method(script.ptr(), "remove_node", cr_node);
-		undo_redo->add_undo_method(script.ptr(), "add_node", cr_node, script->get_node(cr_node), script->get_node_position(cr_node));
+		undo_redo->add_do_method_compat(script.ptr(), "remove_node", cr_node);
+		undo_redo->add_undo_method_compat(script.ptr(), "add_node", cr_node, script->get_node(cr_node), script->get_node_position(cr_node));
 
 		List<VisualScript::SequenceConnection> sequence_conns;
 		script->get_sequence_connection_list(&sequence_conns);
 
 		for (List<VisualScript::SequenceConnection>::Element *E = sequence_conns.front(); E; E = E->next()) {
 			if (E->get().from_node == cr_node || E->get().to_node == cr_node) {
-				undo_redo->add_undo_method(script.ptr(), "sequence_connect", E->get().from_node, E->get().from_output, E->get().to_node);
+				undo_redo->add_undo_method_compat(script.ptr(), "sequence_connect", E->get().from_node, E->get().from_output, E->get().to_node);
 			}
 		}
 
@@ -1722,12 +1722,12 @@ void VisualScriptEditor::_on_nodes_delete() {
 
 		for (List<VisualScript::DataConnection>::Element *E = data_conns.front(); E; E = E->next()) {
 			if (E->get().from_node == F->get() || E->get().to_node == F->get()) {
-				undo_redo->add_undo_method(script.ptr(), "data_connect", E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+				undo_redo->add_undo_method_compat(script.ptr(), "data_connect", E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 			}
 		}
 	}
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 
 	undo_redo->commit_action();
 }
@@ -1765,15 +1765,15 @@ void VisualScriptEditor::_on_nodes_duplicate() {
 		remap.set(F->get(), new_id);
 
 		to_select.insert(new_id);
-		undo_redo->add_do_method(script.ptr(), "add_node", new_id, dupe, script->get_node_position(F->get()) + Vector2(20, 20));
-		undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
+		undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, dupe, script->get_node_position(F->get()) + Vector2(20, 20));
+		undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
 	}
 
 	List<VisualScript::SequenceConnection> seqs;
 	script->get_sequence_connection_list(&seqs);
 	for (List<VisualScript::SequenceConnection>::Element *E = seqs.front(); E; E = E->next()) {
 		if (to_duplicate.has(E->get().from_node) && to_duplicate.has(E->get().to_node)) {
-			undo_redo->add_do_method(script.ptr(), "sequence_connect", remap[E->get().from_node], E->get().from_output, remap[E->get().to_node]);
+			undo_redo->add_do_method_compat(script.ptr(), "sequence_connect", remap[E->get().from_node], E->get().from_output, remap[E->get().to_node]);
 		}
 	}
 
@@ -1781,12 +1781,12 @@ void VisualScriptEditor::_on_nodes_duplicate() {
 	script->get_data_connection_list(&data);
 	for (List<VisualScript::DataConnection>::Element *E = data.front(); E; E = E->next()) {
 		if (to_duplicate.has(E->get().from_node) && to_duplicate.has(E->get().to_node)) {
-			undo_redo->add_do_method(script.ptr(), "data_connect", remap[E->get().from_node], E->get().from_port, remap[E->get().to_node], E->get().to_port);
+			undo_redo->add_do_method_compat(script.ptr(), "data_connect", remap[E->get().from_node], E->get().from_port, remap[E->get().to_node], E->get().to_port);
 		}
 	}
 
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 
 	undo_redo->commit_action();
 
@@ -1895,11 +1895,11 @@ void VisualScriptEditor::_rename_function(const String &name, const String &new_
 		func = script->get_node(node_id);
 	}
 	undo_redo->create_action(TTR("Rename Function"));
-	undo_redo->add_do_method(script.ptr(), "rename_function", name, new_name);
-	undo_redo->add_undo_method(script.ptr(), "rename_function", new_name, name);
+	undo_redo->add_do_method_compat(script.ptr(), "rename_function", name, new_name);
+	undo_redo->add_undo_method_compat(script.ptr(), "rename_function", new_name, name);
 	if (func.is_valid()) {
-		undo_redo->add_do_method(func.ptr(), "set_name", new_name);
-		undo_redo->add_undo_method(func.ptr(), "set_name", name);
+		undo_redo->add_do_method_compat(func.ptr(), "set_name", new_name);
+		undo_redo->add_undo_method_compat(func.ptr(), "set_name", name);
 	}
 
 	// Also fix all function calls.
@@ -1911,17 +1911,17 @@ void VisualScriptEditor::_rename_function(const String &name, const String &new_
 			continue;
 		}
 		if (fncall->get_function() == name) {
-			undo_redo->add_do_method(fncall.ptr(), "set_function", new_name);
-			undo_redo->add_undo_method(fncall.ptr(), "set_function", name);
+			undo_redo->add_do_method_compat(fncall.ptr(), "set_function", new_name);
+			undo_redo->add_undo_method_compat(fncall.ptr(), "set_function", name);
 		}
 	}
 
-	undo_redo->add_do_method(this, "_update_members");
-	undo_redo->add_undo_method(this, "_update_members");
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
-	undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
-	undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
+	undo_redo->add_do_method_compat(this, "_update_members");
+	undo_redo->add_undo_method_compat(this, "_update_members");
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
+	undo_redo->add_do_method_compat(this, "emit_signal", "edited_script_changed");
+	undo_redo->add_undo_method_compat(this, "emit_signal", "edited_script_changed");
 	undo_redo->commit_action();
 }
 
@@ -2104,10 +2104,10 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 		int new_id = script->get_available_id();
 
 		undo_redo->create_action(TTR("Add Node"));
-		undo_redo->add_do_method(script.ptr(), "add_node", new_id, vnode, ofs);
-		undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, vnode, ofs);
+		undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 
 		Node *node = graph->get_node(itos(new_id));
@@ -2133,13 +2133,13 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 		int new_id = script->get_available_id();
 
 		undo_redo->create_action(TTR("Add Node"));
-		undo_redo->add_do_method(script.ptr(), "add_node", new_id, vnode, ofs);
-		undo_redo->add_do_method(vnode.ptr(), "set_base_type", script->get_instance_base_type());
-		undo_redo->add_do_method(vnode.ptr(), "set_function", d["function"]);
+		undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, vnode, ofs);
+		undo_redo->add_do_method_compat(vnode.ptr(), "set_base_type", script->get_instance_base_type());
+		undo_redo->add_do_method_compat(vnode.ptr(), "set_function", d["function"]);
 
-		undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 
 		Node *node = graph->get_node(itos(new_id));
@@ -2165,10 +2165,10 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 		int new_id = script->get_available_id();
 
 		undo_redo->create_action(TTR("Add Node"));
-		undo_redo->add_do_method(script.ptr(), "add_node", new_id, vnode, ofs);
-		undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, vnode, ofs);
+		undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 
 		Node *node = graph->get_node(itos(new_id));
@@ -2194,10 +2194,10 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 		int new_id = script->get_available_id();
 
 		undo_redo->create_action(TTR("Add Preload Node"));
-		undo_redo->add_do_method(script.ptr(), "add_node", new_id, prnode, ofs);
-		undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, prnode, ofs);
+		undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 
 		Node *node = graph->get_node(itos(new_id));
@@ -2234,15 +2234,15 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				prnode.instance();
 				prnode->set_preload(res);
 
-				undo_redo->add_do_method(script.ptr(), "add_node", new_id, prnode, ofs);
-				undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
+				undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, prnode, ofs);
+				undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
 				new_ids.push_back(new_id);
 				new_id++;
 				ofs += Vector2(20, 20) * EDSCALE;
 			}
 
-			undo_redo->add_do_method(this, "_update_graph");
-			undo_redo->add_undo_method(this, "_update_graph");
+			undo_redo->add_do_method_compat(this, "_update_graph");
+			undo_redo->add_undo_method_compat(this, "_update_graph");
 			undo_redo->commit_action();
 		}
 
@@ -2312,14 +2312,14 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				selecting_method_id = base_id;
 			}
 
-			undo_redo->add_do_method(script.ptr(), "add_node", base_id, n, ofs);
-			undo_redo->add_undo_method(script.ptr(), "remove_node", base_id);
+			undo_redo->add_do_method_compat(script.ptr(), "add_node", base_id, n, ofs);
+			undo_redo->add_undo_method_compat(script.ptr(), "remove_node", base_id);
 
 			base_id++;
 			ofs += Vector2(25, 25);
 		}
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 	}
 
@@ -2382,16 +2382,16 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				vnode = pget;
 			}
 
-			undo_redo->add_do_method(script.ptr(), "add_node", base_id, vnode, ofs);
-			undo_redo->add_do_method(vnode.ptr(), "set_property", d["property"]);
+			undo_redo->add_do_method_compat(script.ptr(), "add_node", base_id, vnode, ofs);
+			undo_redo->add_do_method_compat(vnode.ptr(), "set_property", d["property"]);
 			if (!use_get) {
-				undo_redo->add_do_method(vnode.ptr(), "set_default_input_value", 0, d["value"]);
+				undo_redo->add_do_method_compat(vnode.ptr(), "set_default_input_value", 0, d["value"]);
 			}
 
-			undo_redo->add_undo_method(script.ptr(), "remove_node", base_id);
+			undo_redo->add_undo_method_compat(script.ptr(), "remove_node", base_id);
 
-			undo_redo->add_do_method(this, "_update_graph");
-			undo_redo->add_undo_method(this, "_update_graph");
+			undo_redo->add_do_method_compat(this, "_update_graph");
+			undo_redo->add_undo_method_compat(this, "_update_graph");
 			undo_redo->commit_action();
 
 		} else {
@@ -2427,15 +2427,15 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				}
 				vnode = pget;
 			}
-			undo_redo->add_do_method(script.ptr(), "add_node", base_id, vnode, ofs);
-			undo_redo->add_do_method(vnode.ptr(), "set_property", d["property"]);
+			undo_redo->add_do_method_compat(script.ptr(), "add_node", base_id, vnode, ofs);
+			undo_redo->add_do_method_compat(vnode.ptr(), "set_property", d["property"]);
 			if (!use_get) {
-				undo_redo->add_do_method(vnode.ptr(), "set_default_input_value", 0, d["value"]);
+				undo_redo->add_do_method_compat(vnode.ptr(), "set_default_input_value", 0, d["value"]);
 			}
-			undo_redo->add_undo_method(script.ptr(), "remove_node", base_id);
+			undo_redo->add_undo_method_compat(script.ptr(), "remove_node", base_id);
 
-			undo_redo->add_do_method(this, "_update_graph");
-			undo_redo->add_undo_method(this, "_update_graph");
+			undo_redo->add_do_method_compat(this, "_update_graph");
+			undo_redo->add_undo_method_compat(this, "_update_graph");
 			undo_redo->commit_action();
 		}
 	}
@@ -2743,10 +2743,10 @@ void VisualScriptEditor::_change_base_type_callback() {
 
 	ERR_FAIL_COND(bt == String());
 	undo_redo->create_action(TTR("Change Base Type"));
-	undo_redo->add_do_method(script.ptr(), "set_instance_base_type", bt);
-	undo_redo->add_undo_method(script.ptr(), "set_instance_base_type", script->get_instance_base_type());
-	undo_redo->add_do_method(this, "_update_members");
-	undo_redo->add_undo_method(this, "_update_members");
+	undo_redo->add_do_method_compat(script.ptr(), "set_instance_base_type", bt);
+	undo_redo->add_undo_method_compat(script.ptr(), "set_instance_base_type", script->get_instance_base_type());
+	undo_redo->add_do_method_compat(this, "_update_members");
+	undo_redo->add_undo_method_compat(this, "_update_members");
 	undo_redo->commit_action();
 }
 
@@ -2809,22 +2809,22 @@ void VisualScriptEditor::_move_node(int p_id, const Vector2 &p_to) {
 }
 
 void VisualScriptEditor::_node_moved(Vector2 p_from, Vector2 p_to, int p_id) {
-	undo_redo->add_do_method(this, "_move_node", p_id, p_to);
-	undo_redo->add_undo_method(this, "_move_node", p_id, p_from);
+	undo_redo->add_do_method_compat(this, "_move_node", p_id, p_to);
+	undo_redo->add_undo_method_compat(this, "_move_node", p_id, p_from);
 }
 
 void VisualScriptEditor::_remove_node(int p_id) {
 	undo_redo->create_action(TTR("Remove VisualScript Node"));
 
-	undo_redo->add_do_method(script.ptr(), "remove_node", p_id);
-	undo_redo->add_undo_method(script.ptr(), "add_node", p_id, script->get_node(p_id), script->get_node_position(p_id));
+	undo_redo->add_do_method_compat(script.ptr(), "remove_node", p_id);
+	undo_redo->add_undo_method_compat(script.ptr(), "add_node", p_id, script->get_node(p_id), script->get_node_position(p_id));
 
 	List<VisualScript::SequenceConnection> sequence_conns;
 	script->get_sequence_connection_list(&sequence_conns);
 
 	for (List<VisualScript::SequenceConnection>::Element *E = sequence_conns.front(); E; E = E->next()) {
 		if (E->get().from_node == p_id || E->get().to_node == p_id) {
-			undo_redo->add_undo_method(script.ptr(), "sequence_connect", E->get().from_node, E->get().from_output, E->get().to_node);
+			undo_redo->add_undo_method_compat(script.ptr(), "sequence_connect", E->get().from_node, E->get().from_output, E->get().to_node);
 		}
 	}
 
@@ -2833,12 +2833,12 @@ void VisualScriptEditor::_remove_node(int p_id) {
 
 	for (List<VisualScript::DataConnection>::Element *E = data_conns.front(); E; E = E->next()) {
 		if (E->get().from_node == p_id || E->get().to_node == p_id) {
-			undo_redo->add_undo_method(script.ptr(), "data_connect", E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+			undo_redo->add_undo_method_compat(script.ptr(), "data_connect", E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 		}
 	}
 
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 
 	undo_redo->commit_action();
 }
@@ -2892,11 +2892,11 @@ void VisualScriptEditor::_graph_connected(const String &p_from, int p_from_slot,
 	undo_redo->create_action(TTR("Connect Nodes"));
 
 	if (from_seq) {
-		undo_redo->add_do_method(script.ptr(), "sequence_connect", p_from.to_int(), from_port, p_to.to_int());
+		undo_redo->add_do_method_compat(script.ptr(), "sequence_connect", p_from.to_int(), from_port, p_to.to_int());
 		// This undo error on undo after move can't be removed without painful gymnastics
-		undo_redo->add_undo_method(script.ptr(), "sequence_disconnect", p_from.to_int(), from_port, p_to.to_int());
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_undo_method_compat(script.ptr(), "sequence_disconnect", p_from.to_int(), from_port, p_to.to_int());
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 	} else {
 		bool converted = false;
 
@@ -2922,32 +2922,32 @@ void VisualScriptEditor::_graph_connected(const String &p_from, int p_from_slot,
 				int conn_from;
 				int conn_port;
 				script->get_input_value_port_connection_source(p_to.to_int(), to_port, &conn_from, &conn_port);
-				undo_redo->add_do_method(script.ptr(), "data_disconnect", conn_from, conn_port, p_to.to_int(), to_port);
-				undo_redo->add_do_method(script.ptr(), "data_connect", conn_from, conn_port, data_disconnect_node, data_disconnect_port);
-				undo_redo->add_undo_method(script.ptr(), "data_disconnect", conn_from, conn_port, data_disconnect_node, data_disconnect_port);
-				undo_redo->add_undo_method(script.ptr(), "data_connect", conn_from, conn_port, p_to.to_int(), to_port);
+				undo_redo->add_do_method_compat(script.ptr(), "data_disconnect", conn_from, conn_port, p_to.to_int(), to_port);
+				undo_redo->add_do_method_compat(script.ptr(), "data_connect", conn_from, conn_port, data_disconnect_node, data_disconnect_port);
+				undo_redo->add_undo_method_compat(script.ptr(), "data_disconnect", conn_from, conn_port, data_disconnect_node, data_disconnect_port);
+				undo_redo->add_undo_method_compat(script.ptr(), "data_connect", conn_from, conn_port, p_to.to_int(), to_port);
 				can_swap = false; // swapped
 			} else {
 				int conn_from;
 				int conn_port;
 				script->get_input_value_port_connection_source(p_to.to_int(), to_port, &conn_from, &conn_port);
-				undo_redo->add_do_method(script.ptr(), "data_disconnect", conn_from, conn_port, p_to.to_int(), to_port);
-				undo_redo->add_undo_method(script.ptr(), "data_connect", conn_from, conn_port, p_to.to_int(), to_port);
+				undo_redo->add_do_method_compat(script.ptr(), "data_disconnect", conn_from, conn_port, p_to.to_int(), to_port);
+				undo_redo->add_undo_method_compat(script.ptr(), "data_connect", conn_from, conn_port, p_to.to_int(), to_port);
 			}
 		}
 		if (!converted) {
-			undo_redo->add_do_method(script.ptr(), "data_connect", p_from.to_int(), from_port, p_to.to_int(), to_port);
-			undo_redo->add_undo_method(script.ptr(), "data_disconnect", p_from.to_int(), from_port, p_to.to_int(), to_port);
+			undo_redo->add_do_method_compat(script.ptr(), "data_connect", p_from.to_int(), from_port, p_to.to_int(), to_port);
+			undo_redo->add_undo_method_compat(script.ptr(), "data_disconnect", p_from.to_int(), from_port, p_to.to_int(), to_port);
 		}
 		// Update nodes in graph
 		if (!converted) {
-			undo_redo->add_do_method(this, "_update_graph", p_from.to_int());
-			undo_redo->add_do_method(this, "_update_graph", p_to.to_int());
-			undo_redo->add_undo_method(this, "_update_graph", p_from.to_int());
-			undo_redo->add_undo_method(this, "_update_graph", p_to.to_int());
+			undo_redo->add_do_method_compat(this, "_update_graph", p_from.to_int());
+			undo_redo->add_do_method_compat(this, "_update_graph", p_to.to_int());
+			undo_redo->add_undo_method_compat(this, "_update_graph", p_from.to_int());
+			undo_redo->add_undo_method_compat(this, "_update_graph", p_to.to_int());
 		} else {
-			undo_redo->add_do_method(this, "_update_graph");
-			undo_redo->add_undo_method(this, "_update_graph");
+			undo_redo->add_do_method_compat(this, "_update_graph");
+			undo_redo->add_undo_method_compat(this, "_update_graph");
 		}
 	}
 
@@ -2980,22 +2980,22 @@ void VisualScriptEditor::_graph_disconnected(const String &p_from, int p_from_sl
 	undo_redo->create_action(TTR("Disconnect Nodes"));
 
 	if (from_seq) {
-		undo_redo->add_do_method(script.ptr(), "sequence_disconnect", p_from.to_int(), from_port, p_to.to_int());
-		undo_redo->add_undo_method(script.ptr(), "sequence_connect", p_from.to_int(), from_port, p_to.to_int());
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_do_method_compat(script.ptr(), "sequence_disconnect", p_from.to_int(), from_port, p_to.to_int());
+		undo_redo->add_undo_method_compat(script.ptr(), "sequence_connect", p_from.to_int(), from_port, p_to.to_int());
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 	} else {
 		can_swap = true;
 		data_disconnect_node = p_to.to_int();
 		data_disconnect_port = to_port;
 
-		undo_redo->add_do_method(script.ptr(), "data_disconnect", p_from.to_int(), from_port, p_to.to_int(), to_port);
-		undo_redo->add_undo_method(script.ptr(), "data_connect", p_from.to_int(), from_port, p_to.to_int(), to_port);
+		undo_redo->add_do_method_compat(script.ptr(), "data_disconnect", p_from.to_int(), from_port, p_to.to_int(), to_port);
+		undo_redo->add_undo_method_compat(script.ptr(), "data_connect", p_from.to_int(), from_port, p_to.to_int(), to_port);
 		// Update relevant nodes in the graph.
-		undo_redo->add_do_method(this, "_update_graph", p_from.to_int());
-		undo_redo->add_do_method(this, "_update_graph", p_to.to_int());
-		undo_redo->add_undo_method(this, "_update_graph", p_from.to_int());
-		undo_redo->add_undo_method(this, "_update_graph", p_to.to_int());
+		undo_redo->add_do_method_compat(this, "_update_graph", p_from.to_int());
+		undo_redo->add_do_method_compat(this, "_update_graph", p_to.to_int());
+		undo_redo->add_undo_method_compat(this, "_update_graph", p_from.to_int());
+		undo_redo->add_undo_method_compat(this, "_update_graph", p_to.to_int());
 	}
 
 	undo_redo->commit_action();
@@ -3169,8 +3169,8 @@ void VisualScriptEditor::connect_data(Ref<VisualScriptNode> vnode_old, Ref<Visua
 	if (port >= value_count) {
 		port = 0;
 	}
-	undo_redo->add_do_method(script.ptr(), "data_connect", port_action_node, port, new_id, 0);
-	undo_redo->add_undo_method(script.ptr(), "data_disconnect", port_action_node, port, new_id, 0);
+	undo_redo->add_do_method_compat(script.ptr(), "data_connect", port_action_node, port, new_id, 0);
+	undo_redo->add_undo_method_compat(script.ptr(), "data_disconnect", port_action_node, port, new_id, 0);
 	undo_redo->commit_action();
 }
 
@@ -3219,15 +3219,15 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		}
 
 		undo_redo->create_action(TTR("Add Node"));
-		undo_redo->add_do_method(script.ptr(), "add_node", new_id, vnode_new, ofs);
+		undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, vnode_new, ofs);
 		if (vnode_old.is_valid() && p_connecting) {
 			connect_seq(vnode_old, vnode_new, new_id);
 			connect_data(vnode_old, vnode_new, new_id);
 		}
 
-		undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
+		undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
+		undo_redo->add_do_method_compat(this, "_update_graph");
+		undo_redo->add_undo_method_compat(this, "_update_graph");
 		undo_redo->commit_action();
 		return;
 	}
@@ -3282,10 +3282,10 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 
 	int new_id = script->get_available_id();
 	undo_redo->create_action(TTR("Add Node"));
-	undo_redo->add_do_method(script.ptr(), "add_node", new_id, vnode, ofs);
-	undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
-	undo_redo->add_do_method(this, "_update_graph", new_id);
-	undo_redo->add_undo_method(this, "_update_graph", new_id);
+	undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, vnode, ofs);
+	undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
+	undo_redo->add_do_method_compat(this, "_update_graph", new_id);
+	undo_redo->add_undo_method_compat(this, "_update_graph", new_id);
 	undo_redo->commit_action();
 
 	if (script_prop_set.is_valid()) {
@@ -3423,22 +3423,22 @@ void VisualScriptEditor::connect_seq(Ref<VisualScriptNode> vnode_old, Ref<Visual
 	int return_port = port_action_output - 1;
 	if (vnode_old->get_output_value_port_info(port_action_output).name == String("pass") &&
 			!script->get_output_sequence_ports_connected(port_action_node).has(pass_port)) {
-		undo_redo->add_do_method(script.ptr(), "sequence_connect", port_action_node, pass_port, new_id);
-		undo_redo->add_undo_method(script.ptr(), "sequence_disconnect", port_action_node, pass_port, new_id);
+		undo_redo->add_do_method_compat(script.ptr(), "sequence_connect", port_action_node, pass_port, new_id);
+		undo_redo->add_undo_method_compat(script.ptr(), "sequence_disconnect", port_action_node, pass_port, new_id);
 	} else if (vnode_old->get_output_value_port_info(port_action_output).name == String("return") &&
 			   !script->get_output_sequence_ports_connected(port_action_node).has(return_port)) {
-		undo_redo->add_do_method(script.ptr(), "sequence_connect", port_action_node, return_port, new_id);
-		undo_redo->add_undo_method(script.ptr(), "sequence_disconnect", port_action_node, return_port, new_id);
+		undo_redo->add_do_method_compat(script.ptr(), "sequence_connect", port_action_node, return_port, new_id);
+		undo_redo->add_undo_method_compat(script.ptr(), "sequence_disconnect", port_action_node, return_port, new_id);
 	} else {
 		for (int port = 0; port < vnode_old->get_output_sequence_port_count(); port++) {
 			int count = vnode_old->get_output_sequence_port_count();
 			if (port_action_output < count && !script->get_output_sequence_ports_connected(port_action_node).has(port_action_output)) {
-				undo_redo->add_do_method(script.ptr(), "sequence_connect", port_action_node, port_action_output, new_id);
-				undo_redo->add_undo_method(script.ptr(), "sequence_disconnect", port_action_node, port_action_output, new_id);
+				undo_redo->add_do_method_compat(script.ptr(), "sequence_connect", port_action_node, port_action_output, new_id);
+				undo_redo->add_undo_method_compat(script.ptr(), "sequence_disconnect", port_action_node, port_action_output, new_id);
 				break;
 			} else if (!script->get_output_sequence_ports_connected(port_action_node).has(port)) {
-				undo_redo->add_do_method(script.ptr(), "sequence_connect", port_action_node, port, new_id);
-				undo_redo->add_undo_method(script.ptr(), "sequence_disconnect", port_action_node, port, new_id);
+				undo_redo->add_do_method_compat(script.ptr(), "sequence_connect", port_action_node, port, new_id);
+				undo_redo->add_undo_method_compat(script.ptr(), "sequence_disconnect", port_action_node, port, new_id);
 				break;
 			}
 		}
@@ -3475,7 +3475,7 @@ void VisualScriptEditor::_selected_new_virtual_method(const String &p_text, cons
 	func_node->set_name(name);
 	int fn_id = script->get_available_id();
 	undo_redo->create_action(TTR("Add Function"));
-	undo_redo->add_do_method(script.ptr(), "add_function", name, fn_id);
+	undo_redo->add_do_method_compat(script.ptr(), "add_function", name, fn_id);
 
 	for (int i = 0; i < minfo.arguments.size(); i++) {
 		func_node->add_argument(minfo.arguments[i].type, minfo.arguments[i].name, -1, minfo.arguments[i].hint, minfo.arguments[i].hint_string);
@@ -3483,8 +3483,8 @@ void VisualScriptEditor::_selected_new_virtual_method(const String &p_text, cons
 
 	Vector2 ofs = _get_available_pos();
 
-	undo_redo->add_do_method(script.ptr(), "add_node", fn_id, func_node, ofs);
-	undo_redo->add_undo_method(script.ptr(), "remove_node", fn_id);
+	undo_redo->add_do_method_compat(script.ptr(), "add_node", fn_id, func_node, ofs);
+	undo_redo->add_undo_method_compat(script.ptr(), "remove_node", fn_id);
 	if (minfo.return_val.type != Variant::NIL || minfo.return_val.usage & PROPERTY_USAGE_NIL_IS_VARIANT) {
 		Ref<VisualScriptReturn> ret_node;
 		ret_node.instance();
@@ -3492,15 +3492,15 @@ void VisualScriptEditor::_selected_new_virtual_method(const String &p_text, cons
 		ret_node->set_enable_return_value(true);
 		ret_node->set_name(name);
 		int nid = script->get_available_id() + 1;
-		undo_redo->add_do_method(script.ptr(), "add_node", nid, ret_node, _get_available_pos(false, ofs + Vector2(500, 0)));
-		undo_redo->add_undo_method(script.ptr(), "remove_node", nid);
+		undo_redo->add_do_method_compat(script.ptr(), "add_node", nid, ret_node, _get_available_pos(false, ofs + Vector2(500, 0)));
+		undo_redo->add_undo_method_compat(script.ptr(), "remove_node", nid);
 	}
 
-	undo_redo->add_undo_method(script.ptr(), "remove_function", name);
-	undo_redo->add_do_method(this, "_update_members");
-	undo_redo->add_undo_method(this, "_update_members");
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_undo_method_compat(script.ptr(), "remove_function", name);
+	undo_redo->add_do_method_compat(this, "_update_members");
+	undo_redo->add_undo_method_compat(this, "_update_members");
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 
 	undo_redo->commit_action();
 
@@ -3516,10 +3516,10 @@ int VisualScriptEditor::_create_new_node_from_name(const String &p_text, const V
 	Ref<VisualScriptNode> vnode = VisualScriptLanguage::singleton->create_node_from_name(p_text);
 	int new_id = script->get_available_id();
 	undo_redo->create_action(TTR("Add Node"));
-	undo_redo->add_do_method(script.ptr(), "add_node", new_id, vnode, p_point);
-	undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, vnode, p_point);
+	undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
+	undo_redo->add_do_method_compat(this, "_update_graph");
+	undo_redo->add_undo_method_compat(this, "_update_graph");
 	undo_redo->commit_action();
 	return new_id;
 }
@@ -3531,11 +3531,11 @@ void VisualScriptEditor::_default_value_changed() {
 	}
 
 	undo_redo->create_action(TTR("Change Input Value"));
-	undo_redo->add_do_method(vsn.ptr(), "set_default_input_value", editing_input, default_value_edit->get_variant());
-	undo_redo->add_undo_method(vsn.ptr(), "set_default_input_value", editing_input, vsn->get_default_input_value(editing_input));
+	undo_redo->add_do_method_compat(vsn.ptr(), "set_default_input_value", editing_input, default_value_edit->get_variant());
+	undo_redo->add_undo_method_compat(vsn.ptr(), "set_default_input_value", editing_input, vsn->get_default_input_value(editing_input));
 
-	undo_redo->add_do_method(this, "_update_graph", editing_id);
-	undo_redo->add_undo_method(this, "_update_graph", editing_id);
+	undo_redo->add_do_method_compat(this, "_update_graph", editing_id);
+	undo_redo->add_undo_method_compat(this, "_update_graph", editing_id);
 	undo_redo->commit_action();
 }
 
@@ -3690,8 +3690,8 @@ void VisualScriptEditor::_comment_node_resized(const Vector2 &p_new_size, int p_
 	graph->set_block_minimum_size_adjust(true); //faster resize
 
 	undo_redo->create_action(TTR("Resize Comment"), UndoRedo::MERGE_ENDS);
-	undo_redo->add_do_method(vsc.ptr(), "set_size", p_new_size / EDSCALE);
-	undo_redo->add_undo_method(vsc.ptr(), "set_size", vsc->get_size());
+	undo_redo->add_do_method_compat(vsc.ptr(), "set_size", p_new_size / EDSCALE);
+	undo_redo->add_undo_method_compat(vsc.ptr(), "set_size", vsc->get_size());
 	undo_redo->commit_action();
 
 	gn->set_custom_minimum_size(p_new_size);
@@ -3820,22 +3820,22 @@ void VisualScriptEditor::_menu_option(int p_what) {
 					paste_pos += Vector2(20, 20) * EDSCALE;
 				}
 
-				undo_redo->add_do_method(script.ptr(), "add_node", new_id, node, paste_pos);
-				undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
+				undo_redo->add_do_method_compat(script.ptr(), "add_node", new_id, node, paste_pos);
+				undo_redo->add_undo_method_compat(script.ptr(), "remove_node", new_id);
 			}
 
 			for (Set<VisualScript::SequenceConnection>::Element *E = clipboard->sequence_connections.front(); E; E = E->next()) {
-				undo_redo->add_do_method(script.ptr(), "sequence_connect", remap[E->get().from_node], E->get().from_output, remap[E->get().to_node]);
-				undo_redo->add_undo_method(script.ptr(), "sequence_disconnect", remap[E->get().from_node], E->get().from_output, remap[E->get().to_node]);
+				undo_redo->add_do_method_compat(script.ptr(), "sequence_connect", remap[E->get().from_node], E->get().from_output, remap[E->get().to_node]);
+				undo_redo->add_undo_method_compat(script.ptr(), "sequence_disconnect", remap[E->get().from_node], E->get().from_output, remap[E->get().to_node]);
 			}
 
 			for (Set<VisualScript::DataConnection>::Element *E = clipboard->data_connections.front(); E; E = E->next()) {
-				undo_redo->add_do_method(script.ptr(), "data_connect", remap[E->get().from_node], E->get().from_port, remap[E->get().to_node], E->get().to_port);
-				undo_redo->add_undo_method(script.ptr(), "data_disconnect", remap[E->get().from_node], E->get().from_port, remap[E->get().to_node], E->get().to_port);
+				undo_redo->add_do_method_compat(script.ptr(), "data_connect", remap[E->get().from_node], E->get().from_port, remap[E->get().to_node], E->get().to_port);
+				undo_redo->add_undo_method_compat(script.ptr(), "data_disconnect", remap[E->get().from_node], E->get().from_port, remap[E->get().to_node], E->get().to_port);
 			}
 
-			undo_redo->add_do_method(this, "_update_graph");
-			undo_redo->add_undo_method(this, "_update_graph");
+			undo_redo->add_do_method_compat(this, "_update_graph");
+			undo_redo->add_undo_method_compat(this, "_update_graph");
 
 			undo_redo->commit_action();
 
@@ -3996,20 +3996,20 @@ void VisualScriptEditor::_menu_option(int p_what) {
 
 				undo_redo->create_action(TTR("Create Function"));
 
-				undo_redo->add_do_method(script.ptr(), "add_function", new_fn, fn_id);
-				undo_redo->add_do_method(script.ptr(), "add_node", fn_id, func_node, ofs);
-				undo_redo->add_undo_method(script.ptr(), "remove_function", new_fn);
-				undo_redo->add_undo_method(script.ptr(), "remove_node", fn_id);
-				undo_redo->add_do_method(this, "_update_members");
-				undo_redo->add_undo_method(this, "_update_members");
-				undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
+				undo_redo->add_do_method_compat(script.ptr(), "add_function", new_fn, fn_id);
+				undo_redo->add_do_method_compat(script.ptr(), "add_node", fn_id, func_node, ofs);
+				undo_redo->add_undo_method_compat(script.ptr(), "remove_function", new_fn);
+				undo_redo->add_undo_method_compat(script.ptr(), "remove_node", fn_id);
+				undo_redo->add_do_method_compat(this, "_update_members");
+				undo_redo->add_undo_method_compat(this, "_update_members");
+				undo_redo->add_do_method_compat(this, "emit_signal", "edited_script_changed");
+				undo_redo->add_undo_method_compat(this, "emit_signal", "edited_script_changed");
 				// Might make the system more intelligent by checking port from info.
 				int i = 0;
 				List<Pair<int, int>>::Element *F = input_connections.front();
 				for (List<Variant::Type>::Element *E = inputs.front(); E && F; E = E->next(), F = F->next()) {
 					func_node->add_argument(E->get(), "arg_" + String::num_int64(i), i);
-					undo_redo->add_do_method(script.ptr(), "data_connect", fn_id, i, F->get().first, F->get().second);
+					undo_redo->add_do_method_compat(script.ptr(), "data_connect", fn_id, i, F->get().first, F->get().second);
 					i++; // increment i
 				}
 				// Ensure Preview Selection is of newly created function node.
@@ -4021,16 +4021,16 @@ void VisualScriptEditor::_menu_option(int p_what) {
 
 			// Handles reconnection of sequence connections on undo, start here in case of issues.
 			for (Set<VisualScript::SequenceConnection>::Element *E = seqext.front(); E; E = E->next()) {
-				undo_redo->add_do_method(script.ptr(), "sequence_disconnect", E->get().from_node, E->get().from_output, E->get().to_node);
-				undo_redo->add_undo_method(script.ptr(), "sequence_connect", E->get().from_node, E->get().from_output, E->get().to_node);
+				undo_redo->add_do_method_compat(script.ptr(), "sequence_disconnect", E->get().from_node, E->get().from_output, E->get().to_node);
+				undo_redo->add_undo_method_compat(script.ptr(), "sequence_connect", E->get().from_node, E->get().from_output, E->get().to_node);
 			}
 			for (Set<VisualScript::DataConnection>::Element *E = dataext.front(); E; E = E->next()) {
-				undo_redo->add_do_method(script.ptr(), "data_disconnect", E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
-				undo_redo->add_undo_method(script.ptr(), "data_connect", E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+				undo_redo->add_do_method_compat(script.ptr(), "data_disconnect", E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
+				undo_redo->add_undo_method_compat(script.ptr(), "data_connect", E->get().from_node, E->get().from_port, E->get().to_node, E->get().to_port);
 			}
 
 			// I don't really think we need support for non sequenced functions at this moment.
-			undo_redo->add_do_method(script.ptr(), "sequence_connect", fn_id, 0, start_node);
+			undo_redo->add_do_method_compat(script.ptr(), "sequence_connect", fn_id, 0, start_node);
 
 			// Could fail with the new changes, start here when searching for bugs in create function shortcut.
 			int m = 1;
@@ -4041,22 +4041,22 @@ void VisualScriptEditor::_menu_option(int p_what) {
 				int ret_id = fn_id + (m++);
 				selections.insert(ret_id);
 				Vector2 ofsi = _get_available_pos(false, script->get_node_position(G->get()) + Vector2(80, -100));
-				undo_redo->add_do_method(script.ptr(), "add_node", ret_id, ret_node, ofsi);
-				undo_redo->add_undo_method(script.ptr(), "remove_node", ret_id);
+				undo_redo->add_do_method_compat(script.ptr(), "add_node", ret_id, ret_node, ofsi);
+				undo_redo->add_undo_method_compat(script.ptr(), "remove_node", ret_id);
 
-				undo_redo->add_do_method(script.ptr(), "sequence_connect", G->get(), 0, ret_id);
+				undo_redo->add_do_method_compat(script.ptr(), "sequence_connect", G->get(), 0, ret_id);
 				// Add data outputs from each of the end_nodes.
 				Ref<VisualScriptNode> vsn = script->get_node(G->get());
 				if (vsn.is_valid() && vsn->get_output_value_port_count() > 0) {
 					ret_node->set_enable_return_value(true);
 					// Use the zeroth data port cause that's the likely one that is planned to be used.
 					ret_node->set_return_type(vsn->get_output_value_port_info(0).type);
-					undo_redo->add_do_method(script.ptr(), "data_connect", G->get(), 0, ret_id, 0);
+					undo_redo->add_do_method_compat(script.ptr(), "data_connect", G->get(), 0, ret_id, 0);
 				}
 			}
 
-			undo_redo->add_do_method(this, "_update_graph");
-			undo_redo->add_undo_method(this, "_update_graph");
+			undo_redo->add_do_method_compat(this, "_update_graph");
+			undo_redo->add_undo_method_compat(this, "_update_graph");
 
 			undo_redo->commit_action();
 
@@ -4151,28 +4151,28 @@ void VisualScriptEditor::_member_option(int p_option) {
 				List<String> lst;
 				int fn_node = script->get_function_node_id(name);
 				undo_redo->create_action(TTR("Remove Function"));
-				undo_redo->add_do_method(script.ptr(), "remove_function", name);
-				undo_redo->add_do_method(script.ptr(), "remove_node", fn_node);
-				undo_redo->add_undo_method(script.ptr(), "add_function", name, fn_node);
-				undo_redo->add_undo_method(script.ptr(), "add_node", fn_node, script->get_node(fn_node), script->get_node_position(fn_node));
+				undo_redo->add_do_method_compat(script.ptr(), "remove_function", name);
+				undo_redo->add_do_method_compat(script.ptr(), "remove_node", fn_node);
+				undo_redo->add_undo_method_compat(script.ptr(), "add_function", name, fn_node);
+				undo_redo->add_undo_method_compat(script.ptr(), "add_node", fn_node, script->get_node(fn_node), script->get_node_position(fn_node));
 				List<VisualScript::SequenceConnection> seqcons;
 				script->get_sequence_connection_list(&seqcons);
 				for (const List<VisualScript::SequenceConnection>::Element *E = seqcons.front(); E; E = E->next()) {
 					if (E->get().from_node == fn_node) {
-						undo_redo->add_undo_method(script.ptr(), "sequence_connect", fn_node, E->get().from_output, E->get().to_node);
+						undo_redo->add_undo_method_compat(script.ptr(), "sequence_connect", fn_node, E->get().from_output, E->get().to_node);
 					}
 				}
 				List<VisualScript::DataConnection> datcons;
 				script->get_data_connection_list(&datcons);
 				for (const List<VisualScript::DataConnection>::Element *E = datcons.front(); E; E = E->next()) {
 					if (E->get().from_node == fn_node) {
-						undo_redo->add_undo_method(script.ptr(), "data_connect", fn_node, E->get().from_port, E->get().to_node, E->get().to_port);
+						undo_redo->add_undo_method_compat(script.ptr(), "data_connect", fn_node, E->get().from_port, E->get().to_node, E->get().to_port);
 					}
 				}
-				undo_redo->add_do_method(this, "_update_members");
-				undo_redo->add_undo_method(this, "_update_members");
-				undo_redo->add_do_method(this, "_update_graph");
-				undo_redo->add_undo_method(this, "_update_graph");
+				undo_redo->add_do_method_compat(this, "_update_members");
+				undo_redo->add_undo_method_compat(this, "_update_members");
+				undo_redo->add_do_method_compat(this, "_update_graph");
+				undo_redo->add_undo_method_compat(this, "_update_graph");
 				undo_redo->commit_action();
 			} else if (p_option == MEMBER_EDIT) {
 				selected = members->get_selected()->get_text(0);
@@ -4186,11 +4186,11 @@ void VisualScriptEditor::_member_option(int p_option) {
 
 			if (p_option == MEMBER_REMOVE) {
 				undo_redo->create_action(TTR("Remove Variable"));
-				undo_redo->add_do_method(script.ptr(), "remove_variable", name);
-				undo_redo->add_undo_method(script.ptr(), "add_variable", name, script->get_variable_default_value(name));
-				undo_redo->add_undo_method(script.ptr(), "set_variable_info", name, script->call("get_variable_info", name)); //return as dict
-				undo_redo->add_do_method(this, "_update_members");
-				undo_redo->add_undo_method(this, "_update_members");
+				undo_redo->add_do_method_compat(script.ptr(), "remove_variable", name);
+				undo_redo->add_undo_method_compat(script.ptr(), "add_variable", name, script->get_variable_default_value(name));
+				undo_redo->add_undo_method_compat(script.ptr(), "set_variable_info", name, script->call("get_variable_info", name)); //return as dict
+				undo_redo->add_do_method_compat(this, "_update_members");
+				undo_redo->add_undo_method_compat(this, "_update_members");
 				undo_redo->commit_action();
 			} else if (p_option == MEMBER_EDIT) {
 				variable_editor->edit(name);
@@ -4203,15 +4203,15 @@ void VisualScriptEditor::_member_option(int p_option) {
 
 			if (p_option == MEMBER_REMOVE) {
 				undo_redo->create_action(TTR("Remove Signal"));
-				undo_redo->add_do_method(script.ptr(), "remove_custom_signal", name);
-				undo_redo->add_undo_method(script.ptr(), "add_custom_signal", name);
+				undo_redo->add_do_method_compat(script.ptr(), "remove_custom_signal", name);
+				undo_redo->add_undo_method_compat(script.ptr(), "add_custom_signal", name);
 
 				for (int i = 0; i < script->custom_signal_get_argument_count(name); i++) {
-					undo_redo->add_undo_method(script.ptr(), "custom_signal_add_argument", name, script->custom_signal_get_argument_name(name, i), script->custom_signal_get_argument_type(name, i));
+					undo_redo->add_undo_method_compat(script.ptr(), "custom_signal_add_argument", name, script->custom_signal_get_argument_name(name, i), script->custom_signal_get_argument_type(name, i));
 				}
 
-				undo_redo->add_do_method(this, "_update_members");
-				undo_redo->add_undo_method(this, "_update_members");
+				undo_redo->add_do_method_compat(this, "_update_members");
+				undo_redo->add_undo_method_compat(this, "_update_members");
 				undo_redo->commit_action();
 			} else if (p_option == MEMBER_EDIT) {
 				signal_editor->edit(name);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1573,8 +1573,8 @@ Ref<AnimatedValuesBackup> AnimationPlayer::apply_reset(bool p_user_initiated) {
 
 		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Anim Apply Reset"));
-		ur->add_do_method(new_values.ptr(), "restore");
-		ur->add_undo_method(old_values.ptr(), "restore");
+		ur->add_do_method_compat(new_values.ptr(), "restore");
+		ur->add_undo_method_compat(old_values.ptr(), "restore");
 		ur->commit_action();
 	}
 


### PR DESCRIPTION
This PR makes UndoRedo use Callables instead of method names and hardcoded argument list. I added `add_undo_method_compat` and changed all old calls to this. We need to port them later and cleanup needlessly bound methods.

Likely fixes #26483
And likely fixes #36895

Sumbitting as draft, because I'm not yet sure what to do with
https://github.com/godotengine/godot/blob/7e009a167110e79caa102c5b88363fd32b75293c/core/object/undo_redo.cpp#L301-L303
Either I need to figure out how to change it to Callable or extract arguments from callable and push them here. For now this part is commented out, everything else seems to work.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/5038.*