### PR TITLE
Fix crash when assigning same A and B to Joint3D

### DIFF
--- a/scene/3d/physics_joint_3d.cpp
+++ b/scene/3d/physics_joint_3d.cpp
@@ -81,6 +81,11 @@ void Joint3D::set_node_a(const NodePath &p_node_a) {
 		return;
 	}
 
+	if (b == p_node_a) {
+		b = NodePath();
+		_change_notify("nodes/node_b");
+	}
+
 	a = p_node_a;
 	_update_joint();
 }
@@ -93,6 +98,12 @@ void Joint3D::set_node_b(const NodePath &p_node_b) {
 	if (b == p_node_b) {
 		return;
 	}
+
+	if (a == p_node_b) {
+		a = NodePath();
+		_change_notify("nodes/node_a");
+	}
+
 	b = p_node_b;
 	_update_joint();
 }


### PR DESCRIPTION
Previsously, when `node_a` and `node_b` of a `Joint3D` were set to the same node path, the engine would just crash. This is now prevented by unsetting the other node path, respectively (see the GIF below).

![joint3d](https://user-images.githubusercontent.com/31868812/100293139-053c6f00-2f83-11eb-8865-f0673738e563.gif)

This fixes #43860