### PR TITLE
Create physical skeleton collider orientation fix

### DIFF
--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -387,6 +387,10 @@ PhysicalBone3D *Skeleton3DEditor::create_physical_bone(int bone_id, int bone_chi
 	CollisionShape3D *bone_shape = memnew(CollisionShape3D);
 	bone_shape->set_shape(bone_shape_capsule);
 
+	Transform capsule_transform;
+	capsule_transform.basis = Basis(Vector3(1, 0, 0), Vector3(0, 0, 1), Vector3(0, -1, 0));
+	bone_shape->set_transform(capsule_transform);
+
 	Transform body_transform;
 	body_transform.set_look_at(Vector3(0, 0, 0), child_rest.origin, Vector3(0, 1, 0));
 	body_transform.origin = body_transform.basis.xform(Vector3(0, 0, -half_height));


### PR DESCRIPTION
Fixes incorrect orientation of collision shapes when creating physical skeleton
Before
![image](https://user-images.githubusercontent.com/38119387/100298731-18354c00-2f4f-11eb-9835-f3e3f58c40bd.png)
After
![image](https://user-images.githubusercontent.com/38119387/100298782-38650b00-2f4f-11eb-838e-d194ff307c6c.png)
Project file
[Physical skeleton fix.zip](https://github.com/godotengine/godot/files/5600368/Physical.skeleton.fix.zip)