### PR TITLE
Move script icon cache to ScriptServer & Remove cache from project.godot

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -67,13 +67,17 @@ class ScriptServer {
 	static bool reload_scripts_on_save;
 	static bool languages_finished;
 
+public:
 	struct GlobalScriptClass {
 		StringName language;
 		String path;
 		String base;
+		String icon;
 	};
 
+private:
 	static HashMap<StringName, GlobalScriptClass> global_classes;
+	static HashMap<String, StringName> path_to_class;
 
 public:
 	static ScriptEditRequestFunction edit_request_func;
@@ -91,16 +95,20 @@ public:
 	static void thread_enter();
 	static void thread_exit();
 
-	static void global_classes_clear();
-	static void add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path);
+	static void clear_global_classes();
+	static void add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, const String &p_icon);
 	static void remove_global_class(const StringName &p_class);
 	static bool is_global_class(const StringName &p_class);
 	static StringName get_global_class_language(const StringName &p_class);
 	static String get_global_class_path(const String &p_class);
 	static StringName get_global_class_base(const String &p_class);
 	static StringName get_global_class_native_base(const String &p_class);
+	static String get_global_class_icon(const String &p_class);
 	static void get_global_class_list(List<StringName> *r_global_classes);
-	static void save_global_classes();
+	static StringName get_path_script_class(const String &p_path);
+
+	static String _get_global_script_class(const String &p_type, const String &p_path, StringName *r_lang, String *r_extends, String *r_icon_path);
+	static void _scan_script_classes(const String &p_path = "res://");
 
 	static void init_languages();
 	static void finish_languages();

--- a/doc/classes/EditorFileSystemDirectory.xml
+++ b/doc/classes/EditorFileSystemDirectory.xml
@@ -61,24 +61,6 @@
 				Returns the path to the file at index [code]idx[/code].
 			</description>
 		</method>
-		<method name="get_file_script_class_extends" qualifiers="const">
-			<return type="String">
-			</return>
-			<argument index="0" name="idx" type="int">
-			</argument>
-			<description>
-				Returns the base class of the script class defined in the file at index [code]idx[/code]. If the file doesn't define a script class using the [code]class_name[/code] syntax, this will return an empty string.
-			</description>
-		</method>
-		<method name="get_file_script_class_name" qualifiers="const">
-			<return type="String">
-			</return>
-			<argument index="0" name="idx" type="int">
-			</argument>
-			<description>
-				Returns the name of the script class defined in the file at index [code]idx[/code]. If the file doesn't define a script class using the [code]class_name[/code] syntax, this will return an empty string.
-			</description>
-		</method>
 		<method name="get_file_type" qualifiers="const">
 			<return type="StringName">
 			</return>

--- a/doc/classes/Variant.xml
+++ b/doc/classes/Variant.xml
@@ -30,8 +30,6 @@
 		        # To get the name of the underlying Object type, you need the `get_class()` method.
 		        print("foo is a(n) %s" % foo.get_class()) # inject the class name into a formatted string.
 		        # Note also that there is not yet any way to get a script's `class_name` string easily.
-		        # To fetch that value, you need to dig deeply into a hidden ProjectSettings setting: an Array of Dictionaries called "_global_script_classes".
-		        # Open your project.godot file to see it up close.
 		[/codeblock]
 		A Variant takes up only 20 bytes and can store almost any engine datatype inside of it. Variants are rarely used to hold information for long periods of time. Instead, they are used mainly for communication, editing, serialization and moving data around.
 		Godot has specifically invested in making its Variant class as flexible as possible; so much so that it is used for a multitude of operations to facilitate communication between all of Godot's systems.

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -891,80 +891,10 @@ Ref<Script> EditorData::script_class_load_script(const String &p_class) const {
 	return ResourceLoader::load(path, "Script");
 }
 
-void EditorData::script_class_set_icon_path(const String &p_class, const String &p_icon_path) {
-	_script_class_icon_paths[p_class] = p_icon_path;
-}
-
-String EditorData::script_class_get_icon_path(const String &p_class) const {
-	if (!ScriptServer::is_global_class(p_class)) {
-		return String();
-	}
-
-	String current = p_class;
-	String ret = _script_class_icon_paths[current];
-	while (ret.is_empty()) {
-		current = script_class_get_base(current);
-		if (!ScriptServer::is_global_class(current)) {
-			return String();
-		}
-		ret = _script_class_icon_paths.has(current) ? _script_class_icon_paths[current] : String();
-	}
-
-	return ret;
-}
-
-StringName EditorData::script_class_get_name(const String &p_path) const {
-	return _script_class_file_to_path.has(p_path) ? _script_class_file_to_path[p_path] : StringName();
-}
-
-void EditorData::script_class_set_name(const String &p_path, const StringName &p_class) {
-	_script_class_file_to_path[p_path] = p_class;
-}
-
-void EditorData::script_class_save_icon_paths() {
-	List<StringName> keys;
-	_script_class_icon_paths.get_key_list(&keys);
-
-	Dictionary d;
-	for (List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-		if (ScriptServer::is_global_class(E->get())) {
-			d[E->get()] = _script_class_icon_paths[E->get()];
-		}
-	}
-
-	if (d.is_empty()) {
-		if (ProjectSettings::get_singleton()->has_setting("_global_script_class_icons")) {
-			ProjectSettings::get_singleton()->clear("_global_script_class_icons");
-		}
-	} else {
-		ProjectSettings::get_singleton()->set("_global_script_class_icons", d);
-	}
-	ProjectSettings::get_singleton()->save();
-}
-
-void EditorData::script_class_load_icon_paths() {
-	script_class_clear_icon_paths();
-
-	if (ProjectSettings::get_singleton()->has_setting("_global_script_class_icons")) {
-		Dictionary d = ProjectSettings::get_singleton()->get("_global_script_class_icons");
-		List<Variant> keys;
-		d.get_key_list(&keys);
-
-		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-			String name = E->get().operator String();
-			_script_class_icon_paths[name] = d[name];
-
-			String path = ScriptServer::get_global_class_path(name);
-			script_class_set_name(path, name);
-		}
-	}
-}
-
 EditorData::EditorData() {
 	current_edited_scene = -1;
 
 	//load_imported_scenes_from_globals();
-	script_class_load_icon_paths();
 }
 
 ///////////

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -139,9 +139,6 @@ private:
 
 	bool _find_updated_instances(Node *p_root, Node *p_node, Set<String> &checked_paths);
 
-	HashMap<StringName, String> _script_class_icon_paths;
-	HashMap<String, StringName> _script_class_file_to_path;
-
 public:
 	EditorPlugin *get_editor(Object *p_object);
 	EditorPlugin *get_subeditor(Object *p_object);
@@ -211,15 +208,6 @@ public:
 	Variant script_class_instance(const String &p_class);
 
 	Ref<Script> script_class_load_script(const String &p_class) const;
-
-	StringName script_class_get_name(const String &p_path) const;
-	void script_class_set_name(const String &p_path, const StringName &p_class);
-
-	String script_class_get_icon_path(const String &p_class) const;
-	void script_class_set_icon_path(const String &p_class, const String &p_icon_path);
-	void script_class_clear_icon_paths() { _script_class_icon_paths.clear(); }
-	void script_class_save_icon_paths();
-	void script_class_load_icon_paths();
 
 	EditorData();
 };

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -57,7 +57,7 @@ class EditorFileSystemDirectory : public Object {
 		bool import_valid = false;
 		String import_group_file;
 		Vector<String> deps;
-		bool verified = false; //used for checking changes
+		bool verified; //used for checking changes
 		String script_class_name;
 		String script_class_extends;
 		String script_class_icon_path;
@@ -90,9 +90,6 @@ public:
 	Vector<String> get_file_deps(int p_idx) const;
 	bool get_file_import_is_valid(int p_idx) const;
 	uint64_t get_file_modified_time(int p_idx) const;
-	String get_file_script_class_name(int p_idx) const; //used for scripts
-	String get_file_script_class_extends(int p_idx) const; //used for scripts
-	String get_file_script_class_icon_path(int p_idx) const; //used for scripts
 
 	EditorFileSystemDirectory *get_parent();
 
@@ -160,9 +157,6 @@ class EditorFileSystem : public Node {
 		Vector<String> deps;
 		bool import_valid = false;
 		String import_group_file;
-		String script_class_name;
-		String script_class_extends;
-		String script_class_icon_path;
 	};
 
 	HashMap<String, FileCache> file_cache;
@@ -219,11 +213,8 @@ class EditorFileSystem : public Node {
 		}
 	};
 
-	void _scan_script_classes(EditorFileSystemDirectory *p_dir);
 	volatile bool update_script_classes_queued;
 	void _queue_update_script_classes();
-
-	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const;
 
 	static Error _resource_import(const String &p_path);
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1685,12 +1685,15 @@ void EditorInspector::update_tree() {
 				if (s.is_valid()) {
 					base_type = s->get_instance_base_type();
 				}
+				print_line(base_type);
 				while (s.is_valid()) {
-					StringName name = EditorNode::get_editor_data().script_class_get_name(s->get_path());
-					String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
-					if (name != StringName() && icon_path.length()) {
-						category->icon = ResourceLoader::load(icon_path, "Texture");
-						break;
+					StringName name = ScriptServer::get_path_script_class(s->get_path());
+					if (name != StringName()) {
+						String icon_path = ScriptServer::get_global_class_icon(name);
+						if (!icon_path.is_empty()) {
+							category->icon = ResourceLoader::load(icon_path, "Texture");
+							break;
+						}
 					}
 					s = s->get_base_script();
 				}
@@ -2511,7 +2514,7 @@ void EditorInspector::_update_script_class_properties(const Object &p_object, Li
 
 	// NodeC -> NodeB -> NodeA
 	while (script.is_valid()) {
-		String n = EditorNode::get_editor_data().script_class_get_name(script->get_path());
+		String n = ScriptServer::get_path_script_class(script->get_path());
 		if (n.length()) {
 			classes.push_front(n);
 		} else if (script->get_path() != String() && script->get_path().find("::") == -1) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3734,7 +3734,7 @@ StringName EditorNode::get_object_custom_type_name(const Object *p_object) const
 	if (script.is_valid()) {
 		Ref<Script> base_script = script;
 		while (base_script.is_valid()) {
-			StringName name = EditorNode::get_editor_data().script_class_get_name(base_script->get_path());
+			StringName name = ScriptServer::get_path_script_class(base_script->get_path());
 			if (name != StringName()) {
 				return name;
 			}
@@ -3781,11 +3781,15 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 	if (script.is_valid()) {
 		Ref<Script> base_script = script;
 		while (base_script.is_valid()) {
-			StringName name = EditorNode::get_editor_data().script_class_get_name(base_script->get_path());
-			String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
-			Ref<ImageTexture> icon = _load_custom_class_icon(icon_path);
-			if (icon.is_valid()) {
-				return icon;
+			print_line(String("Path ") + base_script->get_path());
+			StringName name = ScriptServer::get_path_script_class(base_script->get_path());
+			if (name != StringName()) {
+				print_line(String("Class name- ") + name);
+				String icon_path = ScriptServer::get_global_class_icon(name);
+				Ref<ImageTexture> icon = _load_custom_class_icon(icon_path);
+				if (icon.is_valid()) {
+					return icon;
+				}
 			}
 
 			// should probably be deprecated in 4.x
@@ -3827,11 +3831,13 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 		StringName name = p_class;
 
 		while (script.is_valid()) {
-			name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
-			String current_icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
-			icon = _load_custom_class_icon(current_icon_path);
-			if (icon.is_valid()) {
-				return icon;
+			name = ScriptServer::get_path_script_class(script->get_path());
+			if (name != StringName()) {
+				String current_icon_path = ScriptServer::get_global_class_icon(name);
+				icon = _load_custom_class_icon(current_icon_path);
+				if (icon.is_valid()) {
+					return icon;
+				}
 			}
 			script = script->get_base_script();
 		}


### PR DESCRIPTION
Edit: Changes in this PR are now in the branch: https://github.com/nathanfranke/godot/tree/archive-script-icon-simplification

---

```
<nathanfranke> Why is there a `_global_script_classes` property in project.godot? Shouldn't this be stored in `.godot`? AutoLoad should be separate
...
<Akien> nathanfranke: no specific reason, it was implemented this way initially because it was easy, but I suggested several times to move it to project metadata. Now that we have .godot instead of .import, that's even better suited.
```

### TODO

- [x] Remove Spaghetti :spaghetti: 
- [ ] Is it necessary to implement a cache system? What if the user edits the script outside of Godot? Lots of issues may arise from a cache system.
  - [x] ~~Create a cache system using `.godot/`~~
- [ ] Make sure this works with all languages (`NativeScript`, `VisualScript(?)`, `CsharpScript`)
- [ ] Resolve all TODOs in changed code.
