### PR TITLE
Expose PopupMenu ScrollContainer to scripting

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -338,6 +338,13 @@
 				Returns the tooltip associated with the specified index index [code]idx[/code].
 			</description>
 		</method>
+		<method name="get_scroll_container" qualifiers="const">
+			<return type="ScrollContainer">
+			</return>
+			<description>
+			Returns the [ScrollContainer] of the [PopupMenu].
+			</description>
+		</method>
 		<method name="is_item_checkable" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1352,6 +1352,10 @@ void PopupMenu::get_translatable_strings(List<String> *p_strings) const {
 	}
 }
 
+ScrollContainer *PopupMenu::get_scroll_container() const {
+	return scroll_container;
+}
+
 void PopupMenu::add_autohide_area(const Rect2 &p_area) {
 	autohide_areas.push_back(p_area);
 }
@@ -1449,6 +1453,8 @@ void PopupMenu::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_allow_search", "allow"), &PopupMenu::set_allow_search);
 	ClassDB::bind_method(D_METHOD("get_allow_search"), &PopupMenu::get_allow_search);
+
+	ClassDB::bind_method(D_METHOD("get_scroll_container"), &PopupMenu::get_scroll_container);
 
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "items", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_items", "_get_items");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_item_selection"), "set_hide_on_item_selection", "is_hide_on_item_selection");

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -216,6 +216,8 @@ public:
 
 	virtual void get_translatable_strings(List<String> *p_strings) const override;
 
+	ScrollContainer *get_scroll_container() const;
+
 	void add_autohide_area(const Rect2 &p_area);
 	void clear_autohide_areas();
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/1859

```
var popup = PopupMenu.new()
var sc = popup.get_scroll_container()
sc.get_v_scrollbar() # or whetever else...
```
