### PR TITLE
Removed references to 'registering_order', as it was unused.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -524,10 +524,6 @@ bool ProjectSettings::has_setting(String p_var) const {
 	return props.has(p_var);
 }
 
-void ProjectSettings::set_registering_order(bool p_enable) {
-	registering_order = p_enable;
-}
-
 Error ProjectSettings::_load_settings_binary(const String &p_path) {
 	Error err;
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -76,7 +76,6 @@ protected:
 		}
 	};
 
-	bool registering_order = true;
 	int last_order = NO_BUILTIN_ORDER_BASE;
 	int last_builtin_order = 0;
 	Map<StringName, VariantContainer> props;
@@ -159,8 +158,6 @@ public:
 	void set_disable_feature_overrides(bool p_disable);
 
 	bool is_using_datapack() const;
-
-	void set_registering_order(bool p_enable);
 
 	bool has_custom_feature(const String &p_feature) const;
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/16863#issuecomment-704211113