### PR TITLE
Use correct normal for ReflectionProbe in GLES2

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1600,7 +1600,7 @@ FRAGMENT_SHADER_CODE
 #endif
 			refprobe1_reflection_normal_blend.a,
 #else
-			normal_interp, vertex_interp, refprobe1_local_matrix,
+			normal, vertex_interp, refprobe1_local_matrix,
 			refprobe1_use_box_project, refprobe1_box_extents, refprobe1_box_offset,
 #endif
 			refprobe1_exterior, refprobe1_intensity, refprobe1_ambient, roughness,
@@ -1618,7 +1618,7 @@ FRAGMENT_SHADER_CODE
 #endif
 			refprobe2_reflection_normal_blend.a,
 #else
-			normal_interp, vertex_interp, refprobe2_local_matrix,
+			normal, vertex_interp, refprobe2_local_matrix,
 			refprobe2_use_box_project, refprobe2_box_extents, refprobe2_box_offset,
 #endif
 			refprobe2_exterior, refprobe2_intensity, refprobe2_ambient, roughness,


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
The GLES2 SpatialMaterial used unchanged normals from the vertex shader for ReflectionProbe reflections, and thus ignored the normal map. This commit makes ReflectionProbe reflections use the normals which can be perturbed by an input normal map.

Before:
![reflections are not perturbed by normal map](https://user-images.githubusercontent.com/29317321/100292845-f30e0100-2f81-11eb-9842-9b4ba3b41a7d.png)

After:
![reflections are perturbed by normal map](https://user-images.githubusercontent.com/29317321/100350429-2ab09380-2fea-11eb-82b1-05c3b96087ef.png)


This fixes #43873