### PR TITLE
Implement Signed Distance Fields for 2D shaders

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -511,6 +511,11 @@ void EditorNode::_notification(int p_what) {
 				scene_root->set_snap_2d_transforms_to_pixel(snap_2d_transforms);
 				bool snap_2d_vertices = GLOBAL_GET("rendering/quality/2d/snap_2d_vertices_to_pixel");
 				scene_root->set_snap_2d_vertices_to_pixel(snap_2d_vertices);
+
+				Viewport::SDFOversize sdf_oversize = Viewport::SDFOversize(int(GLOBAL_GET("rendering/quality/2d_sdf/oversize")));
+				scene_root->set_sdf_oversize(sdf_oversize);
+				Viewport::SDFScale sdf_scale = Viewport::SDFScale(int(GLOBAL_GET("rendering/quality/2d_sdf/scale")));
+				scene_root->set_sdf_scale(sdf_scale);
 			}
 
 			ResourceImporterTexture::get_singleton()->update_imports();

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -265,6 +265,14 @@ String LightOccluder2D::get_configuration_warning() const {
 	return warning;
 }
 
+void LightOccluder2D::set_as_sdf_collision(bool p_enable) {
+	sdf_collision = p_enable;
+	RS::get_singleton()->canvas_light_occluder_set_as_sdf_collision(occluder, sdf_collision);
+}
+bool LightOccluder2D::is_set_as_sdf_collision() const {
+	return sdf_collision;
+}
+
 void LightOccluder2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_occluder_polygon", "polygon"), &LightOccluder2D::set_occluder_polygon);
 	ClassDB::bind_method(D_METHOD("get_occluder_polygon"), &LightOccluder2D::get_occluder_polygon);
@@ -272,14 +280,20 @@ void LightOccluder2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_occluder_light_mask", "mask"), &LightOccluder2D::set_occluder_light_mask);
 	ClassDB::bind_method(D_METHOD("get_occluder_light_mask"), &LightOccluder2D::get_occluder_light_mask);
 
+	ClassDB::bind_method(D_METHOD("set_as_sdf_collision", "enable"), &LightOccluder2D::set_as_sdf_collision);
+	ClassDB::bind_method(D_METHOD("is_set_as_sdf_collision"), &LightOccluder2D::is_set_as_sdf_collision);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "occluder", PROPERTY_HINT_RESOURCE_TYPE, "OccluderPolygon2D"), "set_occluder_polygon", "get_occluder_polygon");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sdf_collision"), "set_as_sdf_collision", "is_set_as_sdf_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_occluder_light_mask", "get_occluder_light_mask");
 }
 
 LightOccluder2D::LightOccluder2D() {
 	occluder = RS::get_singleton()->canvas_light_occluder_create();
 	mask = 1;
+
 	set_notify_transform(true);
+	set_as_sdf_collision(true);
 }
 
 LightOccluder2D::~LightOccluder2D() {

--- a/scene/2d/light_occluder_2d.h
+++ b/scene/2d/light_occluder_2d.h
@@ -84,7 +84,7 @@ class LightOccluder2D : public Node2D {
 	bool enabled;
 	int mask;
 	Ref<OccluderPolygon2D> occluder_polygon;
-
+	bool sdf_collision;
 	void _poly_changed();
 
 protected:
@@ -102,6 +102,9 @@ public:
 
 	void set_occluder_light_mask(int p_mask);
 	int get_occluder_light_mask() const;
+
+	void set_as_sdf_collision(bool p_enable);
+	bool is_set_as_sdf_collision() const;
 
 	String get_configuration_warning() const override;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1397,6 +1397,14 @@ SceneTree::SceneTree() {
 	bool snap_2d_vertices = GLOBAL_DEF("rendering/quality/2d/snap_2d_vertices_to_pixel", false);
 	root->set_snap_2d_vertices_to_pixel(snap_2d_vertices);
 
+	Viewport::SDFOversize sdf_oversize = Viewport::SDFOversize(int(GLOBAL_DEF("rendering/quality/2d_sdf/oversize", 1)));
+	root->set_sdf_oversize(sdf_oversize);
+	Viewport::SDFScale sdf_scale = Viewport::SDFScale(int(GLOBAL_DEF("rendering/quality/2d_sdf/scale", 1)));
+	root->set_sdf_scale(sdf_scale);
+
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/2d_sdf/oversize", PropertyInfo(Variant::INT, "rendering/quality/2d_sdf/oversize", PROPERTY_HINT_ENUM, "100%,120%,150%,200%"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/2d_sdf/scale", PropertyInfo(Variant::INT, "rendering/quality/2d_sdf/scale", PROPERTY_HINT_ENUM, "100%,50%,25%"));
+
 	{ //load default fallback environment
 		//get possible extensions
 		List<String> exts;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3383,6 +3383,24 @@ void Viewport::pass_mouse_focus_to(Viewport *p_viewport, Control *p_control) {
 	}
 }
 
+void Viewport::set_sdf_oversize(SDFOversize p_sdf_oversize) {
+	ERR_FAIL_INDEX(p_sdf_oversize, SDF_OVERSIZE_MAX);
+	sdf_oversize = p_sdf_oversize;
+	RS::get_singleton()->viewport_set_sdf_oversize_and_scale(viewport, RS::ViewportSDFOversize(sdf_oversize), RS::ViewportSDFScale(sdf_scale));
+}
+Viewport::SDFOversize Viewport::get_sdf_oversize() const {
+	return sdf_oversize;
+}
+
+void Viewport::set_sdf_scale(SDFScale p_sdf_scale) {
+	ERR_FAIL_INDEX(p_sdf_scale, SDF_SCALE_MAX);
+	sdf_scale = p_sdf_scale;
+	RS::get_singleton()->viewport_set_sdf_oversize_and_scale(viewport, RS::ViewportSDFOversize(sdf_oversize), RS::ViewportSDFScale(sdf_scale));
+}
+Viewport::SDFScale Viewport::get_sdf_scale() const {
+	return sdf_scale;
+}
+
 void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_world_2d", "world_2d"), &Viewport::set_world_2d);
 	ClassDB::bind_method(D_METHOD("get_world_2d"), &Viewport::get_world_2d);
@@ -3482,6 +3500,12 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_default_canvas_item_texture_repeat", "mode"), &Viewport::set_default_canvas_item_texture_repeat);
 	ClassDB::bind_method(D_METHOD("get_default_canvas_item_texture_repeat"), &Viewport::get_default_canvas_item_texture_repeat);
 
+	ClassDB::bind_method(D_METHOD("set_sdf_oversize", "oversize"), &Viewport::set_sdf_oversize);
+	ClassDB::bind_method(D_METHOD("get_sdf_oversize"), &Viewport::get_sdf_oversize);
+
+	ClassDB::bind_method(D_METHOD("set_sdf_scale", "scale"), &Viewport::set_sdf_scale);
+	ClassDB::bind_method(D_METHOD("get_sdf_scale"), &Viewport::get_sdf_scale);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "own_world_3d"), "set_use_own_world_3d", "is_using_own_world_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_3d", PROPERTY_HINT_RESOURCE_TYPE, "World3D"), "set_world_3d", "get_world_3d");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_2d", PROPERTY_HINT_RESOURCE_TYPE, "World2D", 0), "set_world_2d", "get_world_2d");
@@ -3506,6 +3530,9 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_disable_input"), "set_disable_input", "is_input_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_snap_controls_to_pixels"), "set_snap_controls_to_pixels", "is_snap_controls_to_pixels_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_embed_subwindows"), "set_embed_subwindows_hint", "get_embed_subwindows_hint");
+	ADD_GROUP("SDF", "sdf_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdf_oversize", PROPERTY_HINT_ENUM, "100%,120%,150%,200%"), "set_sdf_oversize", "get_sdf_oversize");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdf_scale", PROPERTY_HINT_ENUM, "100%,50%,25%"), "set_sdf_scale", "get_sdf_scale");
 	ADD_GROUP("Shadow Atlas", "shadow_atlas_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_atlas_size"), "set_shadow_atlas_size", "get_shadow_atlas_size");
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_0", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 0);
@@ -3575,6 +3602,17 @@ void Viewport::_bind_methods() {
 	BIND_ENUM_CONSTANT(DEFAULT_CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
 	BIND_ENUM_CONSTANT(DEFAULT_CANVAS_ITEM_TEXTURE_REPEAT_MIRROR);
 	BIND_ENUM_CONSTANT(DEFAULT_CANVAS_ITEM_TEXTURE_REPEAT_MAX);
+
+	BIND_ENUM_CONSTANT(SDF_OVERSIZE_100_PERCENT);
+	BIND_ENUM_CONSTANT(SDF_OVERSIZE_120_PERCENT);
+	BIND_ENUM_CONSTANT(SDF_OVERSIZE_150_PERCENT);
+	BIND_ENUM_CONSTANT(SDF_OVERSIZE_200_PERCENT);
+	BIND_ENUM_CONSTANT(SDF_OVERSIZE_MAX);
+
+	BIND_ENUM_CONSTANT(SDF_SCALE_100_PERCENT);
+	BIND_ENUM_CONSTANT(SDF_SCALE_50_PERCENT);
+	BIND_ENUM_CONSTANT(SDF_SCALE_25_PERCENT);
+	BIND_ENUM_CONSTANT(SDF_SCALE_MAX);
 }
 
 Viewport::Viewport() {
@@ -3661,6 +3699,10 @@ Viewport::Viewport() {
 
 	default_canvas_item_texture_filter = DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
 	default_canvas_item_texture_repeat = DEFAULT_CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
+
+	sdf_oversize = SDF_OVERSIZE_120_PERCENT;
+	sdf_scale = SDF_SCALE_50_PERCENT;
+	set_sdf_oversize(SDF_OVERSIZE_120_PERCENT); //set to server
 }
 
 Viewport::~Viewport() {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -159,6 +159,21 @@ public:
 		DEFAULT_CANVAS_ITEM_TEXTURE_REPEAT_MAX,
 	};
 
+	enum SDFOversize {
+		SDF_OVERSIZE_100_PERCENT,
+		SDF_OVERSIZE_120_PERCENT,
+		SDF_OVERSIZE_150_PERCENT,
+		SDF_OVERSIZE_200_PERCENT,
+		SDF_OVERSIZE_MAX
+	};
+
+	enum SDFScale {
+		SDF_SCALE_100_PERCENT,
+		SDF_SCALE_50_PERCENT,
+		SDF_SCALE_25_PERCENT,
+		SDF_SCALE_MAX
+	};
+
 	enum {
 		SUBWINDOW_CANVAS_LAYER = 1024
 	};
@@ -284,6 +299,9 @@ private:
 	bool use_debanding = false;
 	Ref<ViewportTexture> default_texture;
 	Set<ViewportTexture *> viewport_textures;
+
+	SDFOversize sdf_oversize;
+	SDFScale sdf_scale;
 
 	enum SubWindowDrag {
 		SUB_WINDOW_DRAG_DISABLED,
@@ -572,6 +590,12 @@ public:
 
 	bool gui_is_dragging() const;
 
+	void set_sdf_oversize(SDFOversize p_sdf_oversize);
+	SDFOversize get_sdf_oversize() const;
+
+	void set_sdf_scale(SDFScale p_sdf_scale);
+	SDFScale get_sdf_scale() const;
+
 	void set_default_canvas_item_texture_filter(DefaultCanvasItemTextureFilter p_filter);
 	DefaultCanvasItemTextureFilter get_default_canvas_item_texture_filter() const;
 
@@ -650,6 +674,8 @@ VARIANT_ENUM_CAST(Viewport::ShadowAtlasQuadrantSubdiv);
 VARIANT_ENUM_CAST(Viewport::MSAA);
 VARIANT_ENUM_CAST(Viewport::ScreenSpaceAA);
 VARIANT_ENUM_CAST(Viewport::DebugDraw);
+VARIANT_ENUM_CAST(Viewport::SDFScale);
+VARIANT_ENUM_CAST(Viewport::SDFOversize);
 VARIANT_ENUM_CAST(SubViewport::ClearMode);
 VARIANT_ENUM_CAST(Viewport::RenderInfo);
 VARIANT_ENUM_CAST(Viewport::DefaultCanvasItemTextureFilter);

--- a/servers/rendering/rasterizer.h
+++ b/servers/rendering/rasterizer.h
@@ -752,6 +752,9 @@ public:
 	virtual void render_target_disable_clear_request(RID p_render_target) = 0;
 	virtual void render_target_do_clear_request(RID p_render_target) = 0;
 
+	virtual void render_target_set_sdf_size_and_scale(RID p_render_target, RS::ViewportSDFOversize p_size, RS::ViewportSDFScale p_scale) = 0;
+	virtual Rect2i render_target_get_sdf_rect(RID p_render_target) const = 0;
+
 	virtual RS::InstanceType get_base_type(RID p_rid) const = 0;
 	virtual bool free(RID p_rid) = 0;
 
@@ -1324,7 +1327,7 @@ public:
 		}
 	};
 
-	virtual void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel) = 0;
+	virtual void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) = 0;
 	virtual void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) = 0;
 
 	struct LightOccluderInstance {
@@ -1336,12 +1339,14 @@ public:
 		Transform2D xform;
 		Transform2D xform_cache;
 		int light_mask;
+		bool sdf_collision;
 		RS::CanvasOccluderPolygonCullMode cull_cache;
 
 		LightOccluderInstance *next;
 
 		LightOccluderInstance() {
 			enabled = true;
+			sdf_collision = false;
 			next = nullptr;
 			light_mask = 1;
 			cull_cache = RS::CANVAS_OCCLUDER_POLYGON_CULL_DISABLED;
@@ -1354,8 +1359,10 @@ public:
 	virtual void light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders) = 0;
 	virtual void light_update_directional_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_cull_distance, const Rect2 &p_clip_rect, LightOccluderInstance *p_occluders) = 0;
 
+	virtual void render_sdf(RID p_render_target, LightOccluderInstance *p_occluders) = 0;
+
 	virtual RID occluder_polygon_create() = 0;
-	virtual void occluder_polygon_set_shape_as_lines(RID p_occluder, const Vector<Vector2> &p_lines) = 0;
+	virtual void occluder_polygon_set_shape(RID p_occluder, const Vector<Vector2> &p_points, bool p_closed) = 0;
 	virtual void occluder_polygon_set_cull_mode(RID p_occluder, RS::CanvasOccluderPolygonCullMode p_mode) = 0;
 	virtual void set_shadow_texture_size(int p_size) = 0;
 

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
@@ -35,6 +35,7 @@
 #include "servers/rendering/rasterizer.h"
 #include "servers/rendering/rasterizer_rd/rasterizer_effects_rd.h"
 #include "servers/rendering/rasterizer_rd/shader_compiler_rd.h"
+#include "servers/rendering/rasterizer_rd/shaders/canvas_sdf.glsl.gen.h"
 #include "servers/rendering/rasterizer_rd/shaders/giprobe_sdf.glsl.gen.h"
 #include "servers/rendering/rasterizer_rd/shaders/particles.glsl.gen.h"
 #include "servers/rendering/rasterizer_rd/shaders/particles_copy.glsl.gen.h"
@@ -1003,6 +1004,15 @@ private:
 		RID framebuffer_uniform_set;
 		RID backbuffer_uniform_set;
 
+		RID sdf_buffer_write;
+		RID sdf_buffer_write_fb;
+		RID sdf_buffer_process[2];
+		RID sdf_buffer_read;
+		RID sdf_buffer_process_uniform_sets[2];
+		RS::ViewportSDFOversize sdf_oversize = RS::VIEWPORT_SDF_OVERSIZE_120_PERCENT;
+		RS::ViewportSDFScale sdf_scale = RS::VIEWPORT_SDF_SCALE_50_PERCENT;
+		Size2i process_size;
+
 		//texture generated for this owner (nor RD).
 		RID texture;
 		bool was_used;
@@ -1012,11 +1022,38 @@ private:
 		Color clear_color;
 	};
 
-	RID_Owner<RenderTarget> render_target_owner;
+	mutable RID_Owner<RenderTarget> render_target_owner;
 
 	void _clear_render_target(RenderTarget *rt);
 	void _update_render_target(RenderTarget *rt);
 	void _create_render_target_backbuffer(RenderTarget *rt);
+	void _render_target_allocate_sdf(RenderTarget *rt);
+	void _render_target_clear_sdf(RenderTarget *rt);
+	Rect2i _render_target_get_sdf_rect(const RenderTarget *rt) const;
+
+	struct RenderTargetSDF {
+		enum {
+			SHADER_LOAD,
+			SHADER_LOAD_SHRINK,
+			SHADER_PROCESS,
+			SHADER_PROCESS_OPTIMIZED,
+			SHADER_STORE,
+			SHADER_STORE_SHRINK,
+			SHADER_MAX
+		};
+
+		struct PushConstant {
+			int32_t size[2];
+			int32_t stride;
+			int32_t shift;
+			int32_t base_size[2];
+			int32_t pad[2];
+		};
+
+		CanvasSdfShaderRD shader;
+		RID shader_version;
+		RID pipelines[SHADER_MAX];
+	} rt_sdf;
 
 	/* GLOBAL SHADER VARIABLES */
 
@@ -1929,6 +1966,12 @@ public:
 	virtual Color render_target_get_clear_request_color(RID p_render_target);
 	virtual void render_target_disable_clear_request(RID p_render_target);
 	virtual void render_target_do_clear_request(RID p_render_target);
+
+	virtual void render_target_set_sdf_size_and_scale(RID p_render_target, RS::ViewportSDFOversize p_size, RS::ViewportSDFScale p_scale);
+	RID render_target_get_sdf_texture(RID p_render_target);
+	RID render_target_get_sdf_framebuffer(RID p_render_target);
+	void render_target_sdf_process(RID p_render_target);
+	virtual Rect2i render_target_get_sdf_rect(RID p_render_target) const;
 
 	Size2 render_target_get_size(RID p_render_target);
 	RID render_target_get_rd_framebuffer(RID p_render_target);

--- a/servers/rendering/rasterizer_rd/shader_compiler_rd.cpp
+++ b/servers/rendering/rasterizer_rd/shader_compiler_rd.cpp
@@ -1072,6 +1072,11 @@ String ShaderCompilerRD::_dump_node_code(const SL::Node *p_node, int p_level, Ge
 					} else if (onode->op == SL::OP_CONSTRUCT) {
 						code += String(vnode->name);
 					} else {
+						if (p_actions.usage_flag_pointers.has(vnode->name) && !used_flag_pointers.has(vnode->name)) {
+							*p_actions.usage_flag_pointers[vnode->name] = true;
+							used_flag_pointers.insert(vnode->name);
+						}
+
 						if (internal_functions.has(vnode->name)) {
 							code += vnode->name;
 							is_texture_func = texture_functions.has(vnode->name);

--- a/servers/rendering/rasterizer_rd/shaders/SCsub
+++ b/servers/rendering/rasterizer_rd/shaders/SCsub
@@ -5,6 +5,7 @@ Import("env")
 if "RD_GLSL" in env["BUILDERS"]:
     env.RD_GLSL("canvas.glsl")
     env.RD_GLSL("canvas_occlusion.glsl")
+    env.RD_GLSL("canvas_sdf.glsl")
     env.RD_GLSL("copy.glsl")
     env.RD_GLSL("copy_to_fb.glsl")
     env.RD_GLSL("cubemap_roughness.glsl")

--- a/servers/rendering/rasterizer_rd/shaders/canvas_occlusion.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/canvas_occlusion.glsl
@@ -2,6 +2,8 @@
 
 #version 450
 
+VERSION_DEFINES
+
 layout(location = 0) in highp vec3 vertex;
 
 layout(push_constant, binding = 0, std430) uniform Constants {
@@ -13,18 +15,24 @@ layout(push_constant, binding = 0, std430) uniform Constants {
 }
 constants;
 
+#ifdef MODE_SHADOW
 layout(location = 0) out highp float depth;
+#endif
 
 void main() {
 	highp vec4 vtx = vec4(vertex, 1.0) * mat4(constants.modelview[0], constants.modelview[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
-	depth = dot(constants.direction, vtx.xy);
 
+#ifdef MODE_SHADOW
+	depth = dot(constants.direction, vtx.xy);
+#endif
 	gl_Position = constants.projection * vtx;
 }
 
 #[fragment]
 
 #version 450
+
+VERSION_DEFINES
 
 layout(push_constant, binding = 0, std430) uniform Constants {
 	mat4 projection;
@@ -35,9 +43,17 @@ layout(push_constant, binding = 0, std430) uniform Constants {
 }
 constants;
 
+#ifdef MODE_SHADOW
 layout(location = 0) in highp float depth;
 layout(location = 0) out highp float distance_buf;
+#else
+layout(location = 0) out highp float sdf_buf;
+#endif
 
 void main() {
+#ifdef MODE_SHADOW
 	distance_buf = depth / constants.z_far;
+#else
+	sdf_buf = 1.0;
+#endif
 }

--- a/servers/rendering/rasterizer_rd/shaders/canvas_sdf.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/canvas_sdf.glsl
@@ -1,0 +1,135 @@
+#[compute]
+
+#version 450
+
+VERSION_DEFINES
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(r8, set = 0, binding = 1) uniform restrict readonly image2D src_pixels;
+layout(r16, set = 0, binding = 2) uniform restrict writeonly image2D dst_sdf;
+
+layout(rg16i, set = 0, binding = 3) uniform restrict readonly iimage2D src_process;
+layout(rg16i, set = 0, binding = 4) uniform restrict writeonly iimage2D dst_process;
+
+layout(push_constant, binding = 0, std430) uniform Params {
+	ivec2 size;
+	int stride;
+	int shift;
+	ivec2 base_size;
+	uvec2 pad;
+}
+params;
+
+#define SDF_MAX_LENGTH 16384.0
+
+void main() {
+	ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+	if (any(greaterThanEqual(pos, params.size))) { //too large, do nothing
+		return;
+	}
+
+#ifdef MODE_LOAD
+
+	bool solid = imageLoad(src_pixels, pos).r > 0.5;
+	imageStore(dst_process, pos, solid ? ivec4(pos, 0, 0) : ivec4(ivec2(32767), 0, 0));
+#endif
+
+#ifdef MODE_LOAD_SHRINK
+
+	int s = 1 << params.shift;
+	ivec2 base = pos << params.shift;
+	ivec2 center = base + ivec2(params.shift);
+
+	ivec2 rel = ivec2(32767);
+	float d = 1e20;
+	for (int i = 0; i < s; i++) {
+		for (int j = 0; j < s; j++) {
+			ivec2 src_pos = base + ivec2(i, j);
+			if (any(greaterThanEqual(src_pos, params.base_size))) {
+				continue;
+			}
+			bool solid = imageLoad(src_pixels, src_pos).r > 0.5;
+			if (solid) {
+				float dist = length(vec2(src_pos - center));
+				if (dist < d) {
+					d = dist;
+					rel = src_pos;
+				}
+			}
+		}
+	}
+
+	imageStore(dst_process, pos, ivec4(rel, 0, 0));
+#endif
+
+#ifdef MODE_PROCESS
+
+	ivec2 base = pos << params.shift;
+	ivec2 center = base + ivec2(params.shift);
+
+	ivec2 rel = imageLoad(src_process, pos).xy;
+
+	if (center != rel) {
+		//only process if it does not point to itself
+		const int ofs_table_size = 8;
+		const ivec2 ofs_table[ofs_table_size] = ivec2[](
+				ivec2(-1, -1),
+				ivec2(0, -1),
+				ivec2(+1, -1),
+
+				ivec2(-1, 0),
+				ivec2(+1, 0),
+
+				ivec2(-1, +1),
+				ivec2(0, +1),
+				ivec2(+1, +1));
+
+		float dist = length(vec2(rel - center));
+		for (int i = 0; i < ofs_table_size; i++) {
+			ivec2 src_pos = pos + ofs_table[i] * params.stride;
+			if (any(lessThan(src_pos, ivec2(0))) || any(greaterThanEqual(src_pos, params.size))) {
+				continue;
+			}
+			ivec2 src_rel = imageLoad(src_process, src_pos).xy;
+			float src_dist = length(vec2(src_rel - center));
+			if (src_dist < dist) {
+				dist = src_dist;
+				rel = src_rel;
+			}
+		}
+	}
+
+	imageStore(dst_process, pos, ivec4(rel, 0, 0));
+#endif
+
+#ifdef MODE_STORE
+
+	ivec2 rel = imageLoad(src_process, pos).xy;
+	float d = length(vec2(rel - pos));
+	if (d > 0.01) {
+		d += 1.0; //make it signed
+	}
+	d /= SDF_MAX_LENGTH;
+	d = clamp(d, 0.0, 1.0);
+	imageStore(dst_sdf, pos, vec4(d));
+
+#endif
+
+#ifdef MODE_STORE_SHRINK
+
+	ivec2 base = pos << params.shift;
+	ivec2 center = base + ivec2(params.shift);
+
+	ivec2 rel = imageLoad(src_process, pos).xy;
+	float d = length(vec2(rel - center));
+
+	if (d > 0.01) {
+		d += 1.0; //make it signed
+	}
+	d /= SDF_MAX_LENGTH;
+	d = clamp(d, 0.0, 1.0);
+	imageStore(dst_sdf, pos, vec4(d));
+
+#endif
+}

--- a/servers/rendering/rasterizer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/canvas_uniforms_inc.glsl
@@ -3,6 +3,8 @@
 
 #define M_PI 3.14159265359
 
+#define SDF_MAX_LENGTH 16384.0
+
 #define FLAGS_INSTANCING_STRIDE_MASK 0xF
 #define FLAGS_INSTANCING_ENABLED (1 << 4)
 #define FLAGS_INSTANCING_HAS_COLORS (1 << 5)
@@ -23,6 +25,19 @@
 
 #define FLAGS_DEFAULT_NORMAL_MAP_USED (1 << 26)
 #define FLAGS_DEFAULT_SPECULAR_MAP_USED (1 << 27)
+
+#define SAMPLER_NEAREST_CLAMP 0
+#define SAMPLER_LINEAR_CLAMP 1
+#define SAMPLER_NEAREST_WITH_MIPMAPS_CLAMP 2
+#define SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP 3
+#define SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_CLAMP 4
+#define SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_CLAMP 5
+#define SAMPLER_NEAREST_REPEAT 6
+#define SAMPLER_LINEAR_REPEAT 7
+#define SAMPLER_NEAREST_WITH_MIPMAPS_REPEAT 8
+#define SAMPLER_LINEAR_WITH_MIPMAPS_REPEAT 9
+#define SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_REPEAT 10
+#define SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_REPEAT 11
 
 // Push Constant
 
@@ -68,8 +83,12 @@ layout(set = 0, binding = 1, std140) uniform CanvasData {
 	float time;
 	bool use_pixel_snap;
 
+	vec4 sdf_to_tex;
+	vec2 screen_to_sdf;
+	vec2 sdf_to_screen;
+
 	uint directional_light_count;
-	uint pad0;
+	float tex_to_sdf;
 	uint pad1;
 	uint pad2;
 }
@@ -115,10 +134,11 @@ layout(set = 0, binding = 4) uniform texture2D shadow_atlas_texture;
 layout(set = 0, binding = 5) uniform sampler shadow_sampler;
 
 layout(set = 0, binding = 6) uniform texture2D screen_texture;
+layout(set = 0, binding = 7) uniform texture2D sdf_texture;
 
-layout(set = 0, binding = 7) uniform sampler material_samplers[12];
+layout(set = 0, binding = 8) uniform sampler material_samplers[12];
 
-layout(set = 0, binding = 8, std430) restrict readonly buffer GlobalVariableData {
+layout(set = 0, binding = 9, std430) restrict readonly buffer GlobalVariableData {
 	vec4 data[];
 }
 global_variables;

--- a/servers/rendering/rendering_server_canvas.h
+++ b/servers/rendering/rendering_server_canvas.h
@@ -153,6 +153,7 @@ public:
 	RID_PtrOwner<RasterizerCanvas::Light> canvas_light_owner;
 
 	bool disable_scale;
+	bool sdf_used = false;
 	bool snapping_2d_transforms_to_pixel = false;
 
 private:
@@ -164,6 +165,8 @@ private:
 
 public:
 	void render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RasterizerCanvas::Light *p_lights, RasterizerCanvas::Light *p_directional_lights, const Rect2 &p_clip_rect, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_vertices_to_pixel);
+
+	bool was_sdf_used();
 
 	RID canvas_create();
 	void canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring);
@@ -247,12 +250,12 @@ public:
 	void canvas_light_occluder_attach_to_canvas(RID p_occluder, RID p_canvas);
 	void canvas_light_occluder_set_enabled(RID p_occluder, bool p_enabled);
 	void canvas_light_occluder_set_polygon(RID p_occluder, RID p_polygon);
+	void canvas_light_occluder_set_as_sdf_collision(RID p_occluder, bool p_enable);
 	void canvas_light_occluder_set_transform(RID p_occluder, const Transform2D &p_xform);
 	void canvas_light_occluder_set_light_mask(RID p_occluder, int p_mask);
 
 	RID canvas_occluder_polygon_create();
 	void canvas_occluder_polygon_set_shape(RID p_occluder_polygon, const Vector<Vector2> &p_shape, bool p_closed);
-	void canvas_occluder_polygon_set_shape_as_lines(RID p_occluder_polygon, const Vector<Vector2> &p_shape);
 
 	void canvas_occluder_polygon_set_cull_mode(RID p_occluder_polygon, RS::CanvasOccluderPolygonCullMode p_mode);
 

--- a/servers/rendering/rendering_server_raster.h
+++ b/servers/rendering/rendering_server_raster.h
@@ -536,6 +536,7 @@ public:
 	BIND2(viewport_set_global_canvas_transform, RID, const Transform2D &)
 	BIND4(viewport_set_canvas_stacking, RID, RID, int, int)
 	BIND2(viewport_set_shadow_atlas_size, RID, int)
+	BIND3(viewport_set_sdf_oversize_and_scale, RID, ViewportSDFOversize, ViewportSDFScale)
 	BIND3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	BIND2(viewport_set_msaa, RID, ViewportMSAA)
 	BIND2(viewport_set_screen_space_aa, RID, ViewportScreenSpaceAA)
@@ -776,12 +777,12 @@ public:
 	BIND2(canvas_light_occluder_attach_to_canvas, RID, RID)
 	BIND2(canvas_light_occluder_set_enabled, RID, bool)
 	BIND2(canvas_light_occluder_set_polygon, RID, RID)
+	BIND2(canvas_light_occluder_set_as_sdf_collision, RID, bool)
 	BIND2(canvas_light_occluder_set_transform, RID, const Transform2D &)
 	BIND2(canvas_light_occluder_set_light_mask, RID, int)
 
 	BIND0R(RID, canvas_occluder_polygon_create)
 	BIND3(canvas_occluder_polygon_set_shape, RID, const Vector<Vector2> &, bool)
-	BIND2(canvas_occluder_polygon_set_shape_as_lines, RID, const Vector<Vector2> &)
 
 	BIND2(canvas_occluder_polygon_set_cull_mode, RID, CanvasOccluderPolygonCullMode)
 

--- a/servers/rendering/rendering_server_viewport.h
+++ b/servers/rendering/rendering_server_viewport.h
@@ -82,6 +82,8 @@ public:
 		RID shadow_atlas;
 		int shadow_atlas_size;
 
+		bool sdf_active;
+
 		uint64_t last_pass = 0;
 
 		int render_info[RS::VIEWPORT_RENDER_INFO_MAX];
@@ -146,6 +148,7 @@ public:
 				render_info[i] = 0;
 			}
 			use_xr = false;
+			sdf_active = false;
 
 			time_cpu_begin = 0;
 			time_cpu_end = 0;
@@ -231,6 +234,8 @@ public:
 
 	void viewport_set_default_canvas_item_texture_filter(RID p_viewport, RS::CanvasItemTextureFilter p_filter);
 	void viewport_set_default_canvas_item_texture_repeat(RID p_viewport, RS::CanvasItemTextureRepeat p_repeat);
+
+	void viewport_set_sdf_oversize_and_scale(RID p_viewport, RS::ViewportSDFOversize p_over_size, RS::ViewportSDFScale p_scale);
 
 	void handle_timestamp(String p_timestamp, uint64_t p_cpu_time, uint64_t p_gpu_time);
 

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -440,6 +440,8 @@ public:
 	FUNC2(viewport_set_global_canvas_transform, RID, const Transform2D &)
 	FUNC4(viewport_set_canvas_stacking, RID, RID, int, int)
 	FUNC2(viewport_set_shadow_atlas_size, RID, int)
+	FUNC3(viewport_set_sdf_oversize_and_scale, RID, ViewportSDFOversize, ViewportSDFScale)
+
 	FUNC3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	FUNC2(viewport_set_msaa, RID, ViewportMSAA)
 	FUNC2(viewport_set_screen_space_aa, RID, ViewportScreenSpaceAA)
@@ -676,12 +678,12 @@ public:
 	FUNC2(canvas_light_occluder_attach_to_canvas, RID, RID)
 	FUNC2(canvas_light_occluder_set_enabled, RID, bool)
 	FUNC2(canvas_light_occluder_set_polygon, RID, RID)
+	FUNC2(canvas_light_occluder_set_as_sdf_collision, RID, bool)
 	FUNC2(canvas_light_occluder_set_transform, RID, const Transform2D &)
 	FUNC2(canvas_light_occluder_set_light_mask, RID, int)
 
 	FUNCRID(canvas_occluder_polygon)
 	FUNC3(canvas_occluder_polygon_set_shape, RID, const Vector<Vector2> &, bool)
-	FUNC2(canvas_occluder_polygon_set_shape_as_lines, RID, const Vector<Vector2> &)
 
 	FUNC2(canvas_occluder_polygon_set_cull_mode, RID, CanvasOccluderPolygonCullMode)
 

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -252,6 +252,27 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["fragment"].built_ins["SCREEN_TEXTURE"] = constt(ShaderLanguage::TYPE_SAMPLER2D);
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["fragment"].can_discard = true;
 
+	{
+		ShaderLanguage::StageFunctionInfo func;
+		func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("sdf_pos", ShaderLanguage::TYPE_VEC2));
+		func.return_type = ShaderLanguage::TYPE_FLOAT; //whether it could emit
+		shader_modes[RS::SHADER_CANVAS_ITEM].functions["fragment"].stage_functions["texture_sdf"] = func;
+		shader_modes[RS::SHADER_CANVAS_ITEM].functions["light"].stage_functions["texture_sdf"] = func;
+		func.return_type = ShaderLanguage::TYPE_VEC2; //whether it could emit
+		shader_modes[RS::SHADER_CANVAS_ITEM].functions["fragment"].stage_functions["sdf_to_screen_uv"] = func;
+		shader_modes[RS::SHADER_CANVAS_ITEM].functions["light"].stage_functions["sdf_to_screen_uv"] = func;
+		shader_modes[RS::SHADER_CANVAS_ITEM].functions["fragment"].stage_functions["texture_sdf_normal"] = func;
+		shader_modes[RS::SHADER_CANVAS_ITEM].functions["light"].stage_functions["texture_sdf_normal"] = func;
+	}
+
+	{
+		ShaderLanguage::StageFunctionInfo func;
+		func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("uv", ShaderLanguage::TYPE_VEC2));
+		func.return_type = ShaderLanguage::TYPE_VEC2; //whether it could emit
+		shader_modes[RS::SHADER_CANVAS_ITEM].functions["fragment"].stage_functions["screen_uv_to_sdf"] = func;
+		shader_modes[RS::SHADER_CANVAS_ITEM].functions["light"].stage_functions["screen_uv_to_sdf"] = func;
+	}
+
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["light"].built_ins["FRAGCOORD"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["light"].built_ins["NORMAL"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["light"].built_ins["COLOR"] = constt(ShaderLanguage::TYPE_VEC4);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1858,7 +1858,6 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("canvas_occluder_polygon_create"), &RenderingServer::canvas_occluder_polygon_create);
 	ClassDB::bind_method(D_METHOD("canvas_occluder_polygon_set_shape", "occluder_polygon", "shape", "closed"), &RenderingServer::canvas_occluder_polygon_set_shape);
-	ClassDB::bind_method(D_METHOD("canvas_occluder_polygon_set_shape_as_lines", "occluder_polygon", "shape"), &RenderingServer::canvas_occluder_polygon_set_shape_as_lines);
 	ClassDB::bind_method(D_METHOD("canvas_occluder_polygon_set_cull_mode", "occluder_polygon", "mode"), &RenderingServer::canvas_occluder_polygon_set_cull_mode);
 
 	ClassDB::bind_method(D_METHOD("global_variable_add", "name", "type", "default_value"), &RenderingServer::global_variable_add);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -730,6 +730,23 @@ public:
 	virtual void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform) = 0;
 	virtual void viewport_set_canvas_stacking(RID p_viewport, RID p_canvas, int p_layer, int p_sublayer) = 0;
 
+	enum ViewportSDFOversize {
+		VIEWPORT_SDF_OVERSIZE_100_PERCENT,
+		VIEWPORT_SDF_OVERSIZE_120_PERCENT,
+		VIEWPORT_SDF_OVERSIZE_150_PERCENT,
+		VIEWPORT_SDF_OVERSIZE_200_PERCENT,
+		VIEWPORT_SDF_OVERSIZE_MAX
+	};
+
+	enum ViewportSDFScale {
+		VIEWPORT_SDF_SCALE_100_PERCENT,
+		VIEWPORT_SDF_SCALE_50_PERCENT,
+		VIEWPORT_SDF_SCALE_25_PERCENT,
+		VIEWPORT_SDF_SCALE_MAX
+	};
+
+	virtual void viewport_set_sdf_oversize_and_scale(RID p_viewport, ViewportSDFOversize p_oversize, ViewportSDFScale p_scale) = 0;
+
 	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size) = 0;
 	virtual void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv) = 0;
 
@@ -1245,12 +1262,12 @@ public:
 	virtual void canvas_light_occluder_attach_to_canvas(RID p_occluder, RID p_canvas) = 0;
 	virtual void canvas_light_occluder_set_enabled(RID p_occluder, bool p_enabled) = 0;
 	virtual void canvas_light_occluder_set_polygon(RID p_occluder, RID p_polygon) = 0;
+	virtual void canvas_light_occluder_set_as_sdf_collision(RID p_occluder, bool p_enable) = 0;
 	virtual void canvas_light_occluder_set_transform(RID p_occluder, const Transform2D &p_xform) = 0;
 	virtual void canvas_light_occluder_set_light_mask(RID p_occluder, int p_mask) = 0;
 
 	virtual RID canvas_occluder_polygon_create() = 0;
 	virtual void canvas_occluder_polygon_set_shape(RID p_occluder_polygon, const Vector<Vector2> &p_shape, bool p_closed) = 0;
-	virtual void canvas_occluder_polygon_set_shape_as_lines(RID p_occluder_polygon, const Vector<Vector2> &p_shape) = 0;
 
 	enum CanvasOccluderPolygonCullMode {
 		CANVAS_OCCLUDER_POLYGON_CULL_DISABLED,


### PR DESCRIPTION
#### SDF Support

* 2D Occluder Polygons now have the option to become geometry to generate the SDF
* New functions added to 2D shaders:

```glsl
vec2 screen_uv_to_sdf(vec2 screen_uv);
vec2 sdf_to_screen_uv(vec2 sdf_pos);
float texture_sdf(vec2 sdf_pos);
vec2 texture_sdf_normal(vec2 sdf_pos);
```

SDF operates in screen-relative global coordinates (pre-canvas transform), so its easy to measure distances in your shaders, as they use the same units as your game.

#### Example:

The following shader allows to make long drop shadows.

![image](https://user-images.githubusercontent.com/6265307/100353927-1199e980-2fce-11eb-8ee2-47fc79efb539.png)

Code:

```glsl
shader_type canvas_item;
render_mode unshaded;

uniform vec4 color : hint_color;
uniform float angle : hint_range(0,360);
uniform float len : hint_range(0,1000) = 300;
uniform float fade_margin : hint_range(0,100) = 5;

void fragment() {
	
	float ang_rad = angle * 3.1416 / 360.0;
	vec2 dir = vec2(sin(ang_rad),cos(ang_rad));
	float max_dist = len;
	vec2 at = screen_uv_to_sdf(SCREEN_UV);
	float accum = 0.0;
	
	while(accum < max_dist) {
	    float d = texture_sdf(at);
	    accum+=d;
	    if (d < 0.01) {
	        break;
	    }
	    at += d * dir;
	}
	float alpha = 1.0-min(1.0,accum/max_dist);
	if (accum < fade_margin) {
		alpha *= max(0.0,accum / fade_margin);
	}
	
	COLOR = vec4(color.rgb,alpha * color.a);
}
```
#### TODO

In the future it may be possible to optionally toggle a canvaslayer for sdf generation, so its not only limited to occluder polygons, but this will most likely have an increased cost, given rendering the screen oversized (like 1.x to 2.x the margins) is required to have useful SDFs (and this also requires more shader variants compiled). Most likely post 4.0 material. 
