### PR TITLE
[3.x] Fix race condition on `script_binding` in C#

### DIFF
--- a/modules/mono/mono_gd/gd_mono_internals.cpp
+++ b/modules/mono/mono_gd/gd_mono_internals.cpp
@@ -90,7 +90,11 @@ void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 		// The object was just created, no script instance binding should have been attached
 		CRASH_COND(unmanaged->has_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index()));
 
-		void *data = (void *)CSharpLanguage::get_singleton()->insert_script_binding(unmanaged, script_binding);
+		void *data;
+		{
+			MutexLock lock(CSharpLanguage::get_singleton()->get_language_bind_mutex());
+			data = (void *)CSharpLanguage::get_singleton()->insert_script_binding(unmanaged, script_binding);
+		}
 
 		// Should be thread safe because the object was just created and nothing else should be referencing it
 		unmanaged->set_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index(), data);


### PR DESCRIPTION
I believe this simple change fixes #37652 by fixing a race condition on `script_bindings`. I have a version of this change for `master` but I can't reproduce the issue in 4.0 so I think something else was changed that covers the issue up; that's why I'm opening this as 3.2-specific. I'm hoping someone with more knowledge about this can tell if this should also have a lock in v4.0. I suspect it would still be a problem in 4.0 to allocate C# wrapper objects from multiple threads at once without this lock, but I haven't verified that.