### PR TITLE
Remove any constraints connected to a Bullet body when removing it

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -323,9 +323,6 @@ void RigidBodyBullet::set_space(SpaceBullet *p_space) {
 		can_integrate_forces = false;
 		isScratchedSpaceOverrideModificator = false;
 
-		// Remove all eventual constraints
-		assert_no_constraints();
-
 		// Remove this object form the physics world
 		space->remove_rigid_body(this);
 	}
@@ -441,12 +438,6 @@ bool RigidBodyBullet::was_colliding(RigidBodyBullet *p_other_object) {
 		}
 	}
 	return false;
-}
-
-void RigidBodyBullet::assert_no_constraints() {
-	if (btBody->getNumConstraintRefs()) {
-		WARN_PRINT("A body with a joints is destroyed. Please check the implementation in order to destroy the joint before the body.");
-	}
 }
 
 void RigidBodyBullet::set_activation_state(bool p_active) {

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -267,8 +267,6 @@ public:
 	bool add_collision_object(RigidBodyBullet *p_otherObject, const Vector3 &p_hitWorldLocation, const Vector3 &p_hitLocalLocation, const Vector3 &p_hitNormal, const float &p_appliedImpulse, int p_other_shape_index, int p_local_shape_index);
 	bool was_colliding(RigidBodyBullet *p_other_object);
 
-	void assert_no_constraints();
-
 	void set_activation_state(bool p_active);
 	bool is_active() const;
 

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -478,10 +478,20 @@ void SpaceBullet::add_rigid_body(RigidBodyBullet *p_body) {
 }
 
 void SpaceBullet::remove_rigid_body(RigidBodyBullet *p_body) {
+	btRigidBody *btBody = p_body->get_bt_rigid_body();
+
+	int constraints = btBody->getNumConstraintRefs();
+	if (constraints > 0) {
+		WARN_PRINT("A body connected to joints was removed. Ensure bodies are disconnected from joints before removing them.");
+		for (int i = 0; i < constraints; i++) {
+			dynamicsWorld->removeConstraint(btBody->getConstraintRef(i));
+		}
+	}
+
 	if (p_body->is_static()) {
-		dynamicsWorld->removeCollisionObject(p_body->get_bt_rigid_body());
+		dynamicsWorld->removeCollisionObject(btBody);
 	} else {
-		dynamicsWorld->removeRigidBody(p_body->get_bt_rigid_body());
+		dynamicsWorld->removeRigidBody(btBody);
 	}
 }
 


### PR DESCRIPTION
Currently, in Bullet physics, if a `PhysicsBody` connected to a `Joint` is deleted, it only raises a warning:
`WARNING: A body with a joints is destroyed. Please check the implementation in order to destroy the joint before the body.`
However, Bullet physics insists (asserts) that a`PhysicsBody` is disconnected from all `Joints` before it is deleted.

This PR ensures that all the `Joint`s that a `PhysicsBody` is connected to are destroyed within the Bullet physics engine before the `PhysicsBody` is destroyed.

Fixes #31348
Fixes #43852

**Note:**
This only destroys the `Joint` in the Bullet physics engine, it is still available and can be deleted or connected to another `PhysicsBody` within Godot. In fact, whenever a `Joint` is reconfigured, the previous `Joint` is destroyed, and a new one created:
https://github.com/godotengine/godot/blob/e5ff2d0ffd2edd61f51f95054880c5b943c3c855/scene/3d/physics_joint_3d.cpp#L39

The only difference is that the Joint in Godot won't be aware that the `PhysicsBody` connected to the `Joint` was deleted; so, when the `Joint` is reconfigured (or deleted), it will raise an error when trying to remove the deleted `PhysicsBody` from the other `PhysicsBody`'s collision exception list: `ERROR: Condition "!body" is true`. However, I think, together with the updated previous Warning message: `WARNING: A body connected to joints was removed. Ensure bodies are disconnected from joints before removing them.` it should be clear to the user that the problem lies with the way (or order) the users is trying to reconfigure the `Joint` i.e. the `PhysicsBody` needs to be removed from the `Joint` first. So I don't think we need to address this error message.
