### PR TITLE
GDScript member inferred type enhanced

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1499,7 +1499,7 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 		switch (identifier->source) {
 			case GDScriptParser::IdentifierNode::MEMBER_VARIABLE: {
 				GDScriptParser::DataType id_type = identifier->variable_source->get_datatype();
-				if (!id_type.is_hard_type()) {
+				if (!id_type.is_hard_type() && !id_type.is_kind_same(p_assignment->assigned_value->get_datatype())) {
 					id_type.kind = GDScriptParser::DataType::VARIANT;
 					id_type.type_source = GDScriptParser::DataType::UNDETECTED;
 					identifier->variable_source->set_datatype(id_type);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -137,15 +137,7 @@ public:
 		_FORCE_INLINE_ bool is_hard_type() const { return type_source > INFERRED; }
 		String to_string() const;
 
-		bool operator==(const DataType &p_other) const {
-			if (type_source == UNDETECTED || p_other.type_source == UNDETECTED) {
-				return true; // Can be consireded equal for parsing purposes.
-			}
-
-			if (type_source == INFERRED || p_other.type_source == INFERRED) {
-				return true; // Can be consireded equal for parsing purposes.
-			}
-
+		bool is_kind_same(const DataType &p_other) const {
 			if (kind != p_other.kind) {
 				return false;
 			}
@@ -169,6 +161,18 @@ public:
 			}
 
 			return false;
+		}
+
+		bool operator==(const DataType &p_other) const {
+			if (type_source == UNDETECTED || p_other.type_source == UNDETECTED) {
+				return true; // Can be consireded equal for parsing purposes.
+			}
+
+			if (type_source == INFERRED || p_other.type_source == INFERRED) {
+				return true; // Can be consireded equal for parsing purposes.
+			}
+
+			return is_kind_same(p_other);
 		}
 
 		bool operator!=(const DataType &p_other) const {


### PR DESCRIPTION
Partial Fix: #43586

GDScript inferred (not hard type) member kind will remain the same (and source as inferred) if it's assigned to the same kind, instead of marking it as unresolved variant.