### PR TITLE
Implement Bresenham line algorithm in Geometry2D

### DIFF
--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -384,6 +384,50 @@ public:
 		H.resize(k);
 		return H;
 	}
+
+	static Vector<Point2i> bresenham_line(const Point2i &p_start, const Point2i &p_end) {
+		Vector<Point2i> points;
+
+		float dx = ABS(p_end.x - p_start.x);
+		float dy = ABS(p_end.y - p_start.y);
+
+		int x = p_start.x;
+		int y = p_start.y;
+
+		int sx = p_start.x > p_end.x ? -1 : 1;
+		int sy = p_start.y > p_end.y ? -1 : 1;
+
+		if (dx > dy) {
+			float err = dx / 2;
+
+			for (; x != p_end.x; x += sx) {
+				points.push_back(Point2i(x, y));
+
+				err -= dy;
+				if (err < 0) {
+					y += sy;
+					err += dx;
+				}
+			}
+		} else {
+			float err = dy / 2;
+
+			for (; y != p_end.y; y += sy) {
+				points.push_back(Point2i(x, y));
+
+				err -= dx;
+				if (err < 0) {
+					x += sx;
+					err += dy;
+				}
+			}
+		}
+
+		points.push_back(Vector2(x, y));
+
+		return points;
+	}
+
 	static Vector<Vector<Vector2>> decompose_polygon_in_convex(Vector<Point2> polygon);
 
 	static void make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_result, Size2i &r_size);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

I need it to paint on TileSet, Tilemaps, and it should also be useful for the Gridmap editor.

Note: This implementation is taken from the one in TileMap : https://github.com/godotengine/godot/blob/master/editor/plugins/tile_map_editor_plugin.cpp#L970
