### PR TITLE
Disable SO_REUSEADDR for UDP.

### DIFF
--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -178,7 +178,6 @@ Error PacketPeerUDP::listen(int p_port, const IP_Address &p_bind_address, int p_
 	}
 
 	_sock->set_blocking_enabled(false);
-	_sock->set_reuse_address_enabled(true);
 	_sock->set_broadcasting_enabled(broadcast);
 	err = _sock->bind(p_bind_address, p_port);
 


### PR DESCRIPTION
It allows binding multiple sockets to the same ADDR:PORT (unlike TCP,
which still requires different ADDR:PORT combinations).

Fixes #43912

Note: I didn't add the platform code because it likely affects all platforms except windows (indeed, all BSD socket implementations).