### PR TITLE
[FBX] general purpose fixes 🎄 

### DIFF
--- a/modules/fbx/data/fbx_bone.cpp
+++ b/modules/fbx/data/fbx_bone.cpp
@@ -33,8 +33,8 @@
 #include "fbx_node.h"
 #include "import_state.h"
 
-Ref<FBXNode> FBXBone::get_link(const ImportState &state) const {
-	print_verbose("bone name: " + bone_name);
+Ref<FBXNode> FBXSkinDeformer::get_link(const ImportState &state) const {
+	print_verbose("bone name: " + bone->bone_name);
 
 	// safe for when deformers must be polyfilled when skin has different count of binds to bones in the scene ;)
 	if (!cluster) {
@@ -53,54 +53,4 @@ Ref<FBXNode> FBXBone::get_link(const ImportState &state) const {
 
 	// the node in space this is for, like if it's FOR a target.
 	return link_node;
-}
-
-/* right now we just get single skin working and we can patch in the multiple tomorrow - per skin not per bone. */
-// this will work for multiple meshes :) awesomeness.
-// okay so these formula's are complex and need proper understanding of
-// shear, pivots, geometric pivots, pre rotation and post rotation
-// additionally DO NOT EDIT THIS if your blender file isn't working.
-// Contact RevoluPowered Gordon MacPherson if you are contemplating making edits to this.
-Transform FBXBone::get_vertex_skin_xform(const ImportState &state, Transform mesh_global_position, bool &r_valid_pose) {
-	r_valid_pose = false;
-	print_verbose("get_vertex_skin_xform: " + bone_name);
-
-	// safe to do, this means we have 'remove unused deformer' checked.
-	if (!cluster) {
-		print_verbose("bone [" + itos(bone_id) + "] " + bone_name + ": has no skin offset poly-filling the skin to make rasterizer happy with unused deformers not being skinned");
-		r_valid_pose = true;
-		return Transform();
-	}
-
-	ERR_FAIL_COND_V_MSG(cluster == nullptr, Transform(), "[serious] unable to resolve the fbx cluster for this bone " + bone_name);
-	// these methods will ONLY work for Maya.
-	if (cluster->TransformAssociateModelValid()) {
-		//print_error("additive skinning in use");
-		Transform associate_global_init_position = cluster->TransformAssociateModel();
-		Transform associate_global_current_position = Transform();
-		Transform reference_global_init_position = cluster->GetTransform();
-		Transform cluster_global_init_position = cluster->TransformLink();
-		Ref<FBXNode> link_node = get_link(state);
-		ERR_FAIL_COND_V_MSG(link_node.is_null(), Transform(), "invalid link corrupt file detected");
-		r_valid_pose = true;
-		Transform cluster_global_current_position = link_node.is_valid() && link_node->pivot_transform.is_valid() ? link_node->pivot_transform->GlobalTransform : Transform();
-
-		vertex_transform_matrix = reference_global_init_position.affine_inverse() * associate_global_init_position * associate_global_current_position.affine_inverse() *
-								  cluster_global_current_position * cluster_global_init_position.affine_inverse() * reference_global_init_position;
-	} else {
-		//print_error("non additive skinning is in use");
-		Transform reference_global_position = cluster->GetTransform();
-		Transform reference_global_current_position = mesh_global_position;
-		//Transform geometric_pivot = Transform(); // we do not use this - 3ds max only
-		Transform global_init_position = cluster->TransformLink();
-		if (global_init_position.basis.determinant() == 0) {
-			global_init_position = Transform(Basis(), global_init_position.origin);
-		}
-		Transform cluster_relative_init_position = global_init_position.affine_inverse() * reference_global_position;
-		Transform cluster_relative_position_inverse = reference_global_current_position.affine_inverse() * global_init_position;
-		vertex_transform_matrix = cluster_relative_position_inverse * cluster_relative_init_position;
-		r_valid_pose = true;
-	}
-
-	return vertex_transform_matrix;
 }

--- a/modules/fbx/data/fbx_bone.h
+++ b/modules/fbx/data/fbx_bone.h
@@ -49,9 +49,6 @@ struct FBXBone : public Reference {
 		return !valid_parent;
 	}
 
-	uint64_t target_node_id; // the node target id for the skeleton element
-	bool valid_target = false; // only applies to bones with a mesh / in the skin.
-
 	// Godot specific data
 	int godot_bone_id = -2; // godot internal bone id assigned after import
 
@@ -60,36 +57,34 @@ struct FBXBone : public Reference {
 	bool valid_armature_id = false;
 	uint64_t armature_id = 0;
 
-	// Vertex Weight information
-	Transform transform_link; // todo remove
-	Transform transform_matrix; // todo remove
-
-	/* get associate model - the model can be invalid sometimes */
-	Ref<FBXBone> get_associate_model() const {
-		return parent_bone;
-	}
-
 	/* link node is the parent bone */
-	Ref<FBXNode> get_link(const ImportState &state) const;
-	Transform get_vertex_skin_xform(const ImportState &state, Transform mesh_global_position, bool &valid);
-	Transform vertex_transform_matrix;
-	Transform local_cluster_matrix; // set_bone_pose
-
-	mutable const FBXDocParser::Deformer *skin = nullptr;
-	mutable const FBXDocParser::Cluster *cluster = nullptr;
 	mutable const FBXDocParser::Geometry *geometry = nullptr;
 	mutable const FBXDocParser::ModelLimbNode *limb_node = nullptr;
 
-	void set_pivot_xform(Ref<PivotTransform> p_pivot_xform) {
-		pivot_xform = p_pivot_xform;
+	void set_node(Ref<FBXNode> p_node) {
+		node = p_node;
 	}
 
-	// pose node / if assigned
-	Transform pose_node = Transform();
-	bool assigned_pose_node = false;
-	Ref<FBXBone> parent_bone = Ref<FBXBone>();
-	Ref<PivotTransform> pivot_xform = Ref<PivotTransform>();
-	Ref<FBXSkeleton> fbx_skeleton = Ref<FBXSkeleton>();
+	// Stores the pivot xform for this bone
+
+	Ref<FBXNode> node = nullptr;
+	Ref<FBXBone> parent_bone = nullptr;
+	Ref<FBXSkeleton> fbx_skeleton = nullptr;
+};
+
+struct FBXSkinDeformer {
+	FBXSkinDeformer(Ref<FBXBone> p_bone, const FBXDocParser::Cluster *p_cluster) :
+			cluster(p_cluster), bone(p_bone) {}
+	~FBXSkinDeformer() {}
+	const FBXDocParser::Cluster *cluster;
+	Ref<FBXBone> bone;
+
+	/* get associate model - the model can be invalid sometimes */
+	Ref<FBXBone> get_associate_model() const {
+		return bone->parent_bone;
+	}
+
+	Ref<FBXNode> get_link(const ImportState &state) const;
 };
 
 #endif // FBX_BONE_H

--- a/modules/fbx/data/fbx_material.h
+++ b/modules/fbx/data/fbx_material.h
@@ -38,6 +38,7 @@
 
 struct FBXMaterial : public Reference {
 	String material_name = String();
+	bool warning_non_pbr_material = false;
 	FBXDocParser::Material *material = nullptr;
 
 	/* Godot materials
@@ -149,6 +150,8 @@ struct FBXMaterial : public Reference {
 		{ "Maya|SpecularTexture|file", SpatialMaterial::TextureParam::TEXTURE_METALLIC },
 
 		/* Roughness */
+		// Arnold Roughness Map
+		{ "Maya|specularRoughness", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
 
 		{ "3dsMax|Parameters|roughness_map", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
 		{ "Maya|TEX_roughness_map", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
@@ -169,7 +172,6 @@ struct FBXMaterial : public Reference {
 
 		//{ "Maya|diffuseRoughness", SpatialMaterial::TextureParam::UNSUPPORTED },
 		//{ "Maya|diffuseRoughness|file", SpatialMaterial::TextureParam::UNSUPPORTED },
-		//{ "Maya|specularRoughness", SpatialMaterial::TextureParam::UNSUPPORTED },
 		//{ "ShininessExponent", SpatialMaterial::TextureParam::UNSUPPORTED },
 		//{ "ReflectionFactor", SpatialMaterial::TextureParam::UNSUPPORTED },
 		//{ "TransparentColor",SpatialMaterial::TextureParam::TEXTURE_CHANNEL_ALPHA },
@@ -185,7 +187,6 @@ struct FBXMaterial : public Reference {
 		PROPERTY_DESC_ROUGHNESS,
 		PROPERTY_DESC_SPECULAR,
 		PROPERTY_DESC_SPECULAR_COLOR,
-		PROPERTY_DESC_SPECULAR_ROUGHNESS,
 		PROPERTY_DESC_SHINYNESS,
 		PROPERTY_DESC_COAT,
 		PROPERTY_DESC_COAT_ROUGHNESS,
@@ -203,8 +204,8 @@ struct FBXMaterial : public Reference {
 		{ "Maya|specular", PROPERTY_DESC_SPECULAR },
 		{ "Maya|specularColor", PROPERTY_DESC_SPECULAR_COLOR },
 
-		/* Specular roughness */
-		{ "Maya|specularRoughness", PROPERTY_DESC_SPECULAR_ROUGHNESS },
+		/* Specular roughness - arnold roughness map */
+		{ "Maya|specularRoughness", PROPERTY_DESC_ROUGHNESS },
 
 		/* Transparent */
 		{ "Opacity", PROPERTY_DESC_TRANSPARENT },
@@ -221,10 +222,10 @@ struct FBXMaterial : public Reference {
 		{ "Maya|roughness", PROPERTY_DESC_ROUGHNESS },
 
 		/* Coat */
-		{ "Maya|coat", PROPERTY_DESC_COAT },
+		//{ "Maya|coat", PROPERTY_DESC_COAT },
 
 		/* Coat roughness */
-		{ "Maya|coatRoughness", PROPERTY_DESC_COAT_ROUGHNESS },
+		//{ "Maya|coatRoughness", PROPERTY_DESC_COAT_ROUGHNESS },
 
 		/* Emissive */
 		{ "Maya|emission", PROPERTY_DESC_EMISSIVE },

--- a/modules/fbx/data/fbx_skeleton.cpp
+++ b/modules/fbx/data/fbx_skeleton.cpp
@@ -40,7 +40,6 @@ void FBXSkeleton::init_skeleton(const ImportState &state) {
 	if (skeleton == nullptr && skeleton_bone_count > 0) {
 		skeleton = memnew(Skeleton);
 
-		Ref<FBXNode> skeleton_parent_node;
 		if (fbx_node.is_valid()) {
 			// cache skeleton attachment for later during node creation
 			// can't be done until after node hierarchy is built
@@ -100,11 +99,11 @@ void FBXSkeleton::init_skeleton(const ImportState &state) {
 	ERR_FAIL_COND_MSG(skeleton->get_bone_count() != bone_count, "Not all bones got added, is the file corrupted?");
 
 	for (Map<int, Ref<FBXBone> >::Element *bone_element = bone_map.front(); bone_element; bone_element = bone_element->next()) {
-		Ref<FBXBone> bone = bone_element->value();
+		const Ref<FBXBone> bone = bone_element->value();
 		int bone_index = bone_element->key();
 		print_verbose("working on bone: " + itos(bone_index) + " bone name:" + bone->bone_name);
 
-		skeleton->set_bone_rest(bone->godot_bone_id, get_unscaled_transform(bone->pivot_xform->LocalTransform, state.scale));
+		skeleton->set_bone_rest(bone->godot_bone_id, get_unscaled_transform(bone->node->pivot_transform->LocalTransform, state.scale));
 
 		// lookup parent ID
 		if (bone->valid_parent && state.fbx_bone_map.has(bone->parent_bone_id)) {

--- a/modules/fbx/data/import_state.h
+++ b/modules/fbx/data/import_state.h
@@ -32,7 +32,9 @@
 #define IMPORT_STATE_H
 
 #include "fbx_mesh_data.h"
-#include "modules/fbx/tools/import_utils.h"
+#include "tools/import_utils.h"
+#include "tools/validation_tools.h"
+
 #include "pivot_transform.h"
 
 #include "core/bind/core_bind.h"

--- a/modules/fbx/data/pivot_transform.h
+++ b/modules/fbx/data/pivot_transform.h
@@ -31,6 +31,7 @@
 #ifndef PIVOT_TRANSFORM_H
 #define PIVOT_TRANSFORM_H
 
+#include "core/math/transform.h"
 #include "core/reference.h"
 
 #include "model_abstraction.h"
@@ -84,6 +85,9 @@ struct PivotTransform : Reference, ModelAbstraction {
 		print_verbose("raw pre_rotation " + raw_pre_rotation * (180 / Math_PI));
 		print_verbose("raw post_rotation " + raw_post_rotation * (180 / Math_PI));
 	}
+
+	Transform ComputeGlobalTransform(Transform t) const;
+	Transform ComputeLocalTransform(Transform t) const;
 	Transform ComputeGlobalTransform(Vector3 p_translation, Quat p_rotation, Vector3 p_scaling) const;
 	Transform ComputeLocalTransform(Vector3 p_translation, Quat p_rotation, Vector3 p_scaling) const;
 

--- a/modules/fbx/editor_scene_importer_fbx.h
+++ b/modules/fbx/editor_scene_importer_fbx.h
@@ -37,7 +37,10 @@
 #include "tools/import_utils.h"
 
 #include "core/bind/core_bind.h"
+#include "core/dictionary.h"
 #include "core/io/resource_importer.h"
+#include "core/local_vector.h"
+#include "core/ustring.h"
 #include "core/vector.h"
 #include "editor/import/resource_importer_scene.h"
 #include "editor/project_settings_editor.h"

--- a/modules/fbx/fbx_parser/FBXDocument.cpp
+++ b/modules/fbx/fbx_parser/FBXDocument.cpp
@@ -184,7 +184,6 @@ ObjectPtr LazyObject::LoadObject() {
 		if (!strcmp(classtag.c_str(), "Cluster")) {
 			object.reset(new Cluster(id, element, doc, name));
 		} else if (!strcmp(classtag.c_str(), "Skin")) {
-
 			object.reset(new Skin(id, element, doc, name));
 		} else if (!strcmp(classtag.c_str(), "BlendShape")) {
 			object.reset(new BlendShape(id, element, doc, name));
@@ -288,12 +287,15 @@ Document::~Document() {
 		delete v.second;
 	}
 
+	if (metadata_properties != nullptr) {
+		delete metadata_properties;
+	}
 	// clear globals import pointer
 	globals.reset();
 }
 
 // ------------------------------------------------------------------------------------------------
-static const unsigned int LowerSupportedVersion = 7100;
+static const unsigned int LowerSupportedVersion = 7300;
 static const unsigned int UpperSupportedVersion = 7700;
 
 bool Document::ReadHeader() {
@@ -310,17 +312,31 @@ bool Document::ReadHeader() {
 	// While we may have some success with newer files, we don't support
 	// the older 6.n fbx format
 	if (fbxVersion < LowerSupportedVersion) {
-		DOMWarning("unsupported, old format version, supported are only FBX 2011, FBX 2012 and FBX 2013, you can re-export using Maya, 3DS, blender or Autodesk FBX tool");
+		DOMWarning("unsupported, old format version, FBX 2015-2020, you must re-export in a more modern version of your original modelling application");
 		return false;
 	}
 	if (fbxVersion > UpperSupportedVersion) {
-		DOMWarning("unsupported, newer format version, supported are only FBX 2011, up to FBX 2020"
+		DOMWarning("unsupported, newer format version, supported are only FBX 2015, up to FBX 2020"
 				   " trying to read it nevertheless");
 	}
 
 	const ElementPtr ecreator = shead->GetElement("Creator");
 	if (ecreator) {
 		creator = ParseTokenAsString(GetRequiredToken(ecreator, 0));
+	}
+
+	//
+	// Scene Info
+	//
+
+	const ElementPtr scene_info = shead->GetElement("SceneInfo");
+
+	if (scene_info) {
+		PropertyTable *fileExportProps = const_cast<PropertyTable *>(GetPropertyTable(*this, "", scene_info, scene_info->Compound(), true));
+
+		if (fileExportProps) {
+			metadata_properties = fileExportProps;
+		}
 	}
 
 	const ElementPtr etimestamp = shead->GetElement("CreationTimeStamp");

--- a/modules/fbx/fbx_parser/FBXDocument.h
+++ b/modules/fbx/fbx_parser/FBXDocument.h
@@ -1196,6 +1196,10 @@ public:
 		return globals.get();
 	}
 
+	const PropertyTable *GetMetadataProperties() const {
+		return metadata_properties;
+	}
+
 	const PropertyTemplateMap &Templates() const {
 		return templates;
 	}
@@ -1289,6 +1293,7 @@ private:
 	std::vector<uint64_t> materials;
 	std::vector<uint64_t> skins;
 	mutable std::vector<const AnimationStack *> animationStacksResolved;
+	PropertyTable *metadata_properties = nullptr;
 	std::shared_ptr<FileGlobalSettings> globals = nullptr;
 };
 

--- a/modules/fbx/fbx_parser/FBXMeshGeometry.h
+++ b/modules/fbx/fbx_parser/FBXMeshGeometry.h
@@ -106,7 +106,7 @@ public:
 	}
 
 private:
-	const Skin *skin;
+	const Skin *skin = nullptr;
 	std::vector<const BlendShape *> blendShapes;
 };
 

--- a/modules/fbx/fbx_parser/FBXUtil.cpp
+++ b/modules/fbx/fbx_parser/FBXUtil.cpp
@@ -168,10 +168,10 @@ char EncodeBase64(char byte) {
 }
 
 /** Encodes a block of 4 bytes to base64 encoding
-*
 *  @param bytes Bytes to encode.
 *  @param out_string String to write encoded values to.
-*  @param string_pos Position in out_string.*/
+*  @param string_pos Position in out_string.
+*/
 void EncodeByteBlock(const char *bytes, std::string &out_string, size_t string_pos) {
 	char b0 = (bytes[0] & 0xFC) >> 2;
 	char b1 = (bytes[0] & 0x03) << 4 | ((bytes[1] & 0xF0) >> 4);

--- a/modules/fbx/fbx_parser/FBXUtil.h
+++ b/modules/fbx/fbx_parser/FBXUtil.h
@@ -83,14 +83,6 @@ namespace FBXDocParser {
 
 namespace Util {
 
-/** helper for std::for_each to delete all heap-allocated items in a container */
-template <typename T>
-struct delete_fun {
-	void operator()(const volatile T *del) {
-		delete del;
-	}
-};
-
 /** Get a string representation for a #TokenType. */
 const char *TokenTypeString(TokenType t);
 

--- a/modules/fbx/tools/validation_tools.cpp
+++ b/modules/fbx/tools/validation_tools.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  fbx_skeleton.h                                                       */
+/*  validation_tools.cpp                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,26 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef FBX_SKELETON_H
-#define FBX_SKELETON_H
+#include "validation_tools.h"
 
-#include "fbx_bone.h"
-#include "fbx_node.h"
-#include "model_abstraction.h"
+#ifdef TOOLS_ENABLED
 
-#include "core/reference.h"
-#include "scene/3d/skeleton.h"
+#include "core/print_string.h"
+#include "core/ustring.h"
 
-struct FBXNode;
-struct ImportState;
-struct FBXBone;
+ValidationTracker::Entries *ValidationTracker::entries_singleton = memnew(ValidationTracker::Entries);
 
-struct FBXSkeleton : Reference {
-	Ref<FBXNode> fbx_node = Ref<FBXNode>();
-	Vector<Ref<FBXBone> > skeleton_bones = Vector<Ref<FBXBone> >();
-	Skeleton *skeleton = nullptr;
+// for printing our CSV to dump validation problems of files
+// later we can make some agnostic tooling for this but this is fine for the time being.
+void ValidationTracker::Entries::add_validation_error(String asset_path, String message) {
+	print_error(message);
+	// note: implementation is static
+	validation_entries[asset_path].push_back(message);
+}
 
-	void init_skeleton(const ImportState &state);
-};
-
-#endif // FBX_SKELETON_H
+#endif // TOOLS_ENABLED


### PR DESCRIPTION
### Improving FBX support
- Better materials
  - default values will no longer trigger things like emission, clear coat being enabled etc incorrectly, mostly importers misunderstand this value, a value of 1 is not actually enabled emission, it must have a non zero setting other than emission value for the emission flags to actually be enabled correctly in our engine #42386 
  - lambert materials are warned against significantly, do not use Lambert in Godot, use a PBR material like Ai Standard Surface (it's like going from low quality to high definition in terms of output in scenes and on assets, other engines just make you build the material from scratch)
  - roughness values are calculated correctly in this version
- Fixes for normal's array - some normal's from some files were dropped and generated, this is now fixed.
  - FBX indexing for items with (-1) index, for normal data is supported, this is super helpful at increasing our range of compatibility of FBX meshes.
- Fix bone rest data **no longer requiring go to bind pose in Maya and various applications**
  - Partial fix for #43688, animations & skinning needs rebuilt to support this correctly
- Validation tools added for validating large projects
- Provide package name, vendor and FBX vendor in the log.
- Implemented metadata properties so we can read extra document info required for bug reporting
- **FBX 2011 (version 7200)** is unsupported now, you must re-export your file in Maya or Max to upgrade the file format.
- Fixes skin bind poses being generated based on node xforms in the scene, this is fixed.
- Fixes duplicate bones being added to skin and prevents add_bones from registering skeleton bones it now registers skin bind poses, but this should really be documented in the engine correctly right now it doesn't tell you this is the case.

### known bugs:
- euler to quat is failing for some files
- blender is not exporting skins in the correct format.
~~- localise skeleton localises but loses important joint orient information (will write better algorithm at end for this to keep skeleton looking good in the engine)~~
~~- skinning is disabled & animations are broken by the new changes this will be fixed in a following commit.~~

*Bugsquad edit:* Fixes #43846.