### PR TITLE
Document that NodePaths sent with RPCs are relative to root node of the MultiPlayerAPI

### DIFF
--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -90,6 +90,7 @@
 		<member name="root_node" type="Node" setter="set_root_node" getter="get_root_node">
 			The root node to use for RPCs. Instead of an absolute path, a relative path will be used to find the node upon which the RPC should be executed.
 			This effectively allows to have different branches of the scene tree to be managed by different MultiplayerAPI, allowing for example to run both client and server in the same scene.
+			Node paths sent with RPCs are relative to this node.
 		</member>
 	</members>
 	<signals>


### PR DESCRIPTION
I didn't know this until Faless mentioned it [here](https://github.com/godotengine/godot/pull/40136#issuecomment-734932473).