### PR TITLE
[Complex Text Layouts] Add compatibility for legacy Font resources.

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -243,8 +243,11 @@ HashMap<StringName, StringName> ClassDB::resource_base_extensions;
 HashMap<StringName, StringName> ClassDB::compat_classes;
 
 bool ClassDB::_is_parent_class(const StringName &p_class, const StringName &p_inherits) {
-	StringName inherits = p_class;
+	if (!classes.has(p_class)) {
+		return false;
+	}
 
+	StringName inherits = p_class;
 	while (inherits.operator String().length()) {
 		if (inherits == p_inherits) {
 			return true;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -234,6 +234,10 @@ static Ref<ResourceFormatLoaderText> resource_loader_text;
 
 static Ref<ResourceFormatLoaderFont> resource_loader_font;
 
+#ifndef DISABLE_DEPRECATED
+static Ref<ResourceFormatLoaderCompatFont> resource_loader_compat_font;
+#endif /* DISABLE_DEPRECATED */
+
 static Ref<ResourceFormatLoaderStreamTexture2D> resource_loader_stream_texture;
 static Ref<ResourceFormatLoaderStreamTextureLayered> resource_loader_texture_layered;
 static Ref<ResourceFormatLoaderStreamTexture3D> resource_loader_texture_3d;
@@ -250,6 +254,11 @@ void register_scene_types() {
 
 	resource_loader_font.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_font);
+
+#ifndef DISABLE_DEPRECATED
+	resource_loader_compat_font.instance();
+	ResourceLoader::add_resource_format_loader(resource_loader_compat_font);
+#endif /* DISABLE_DEPRECATED */
 
 	resource_loader_stream_texture.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
@@ -799,6 +808,9 @@ void register_scene_types() {
 #ifndef DISABLE_DEPRECATED
 	// Dropped in 4.0, near approximation.
 	ClassDB::add_compatibility_class("AnimationTreePlayer", "AnimationTree");
+	ClassDB::add_compatibility_class("BitmapFont", "Font");
+	ClassDB::add_compatibility_class("DynamicFont", "Font");
+	ClassDB::add_compatibility_class("DynamicFontData", "FontData");
 	ClassDB::add_compatibility_class("ToolButton", "Button");
 
 	// Renamed in 4.0.
@@ -917,7 +929,7 @@ void register_scene_types() {
 	ClassDB::add_compatibility_class("StreamTexture", "StreamTexture2D");
 	ClassDB::add_compatibility_class("Light2D", "PointLight2D");
 
-#endif
+#endif /* DISABLE_DEPRECATED */
 
 	OS::get_singleton()->yield(); //may take time to init
 
@@ -968,6 +980,11 @@ void unregister_scene_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_font);
 	resource_loader_font.unref();
+
+#ifndef DISABLE_DEPRECATED
+	ResourceLoader::remove_resource_format_loader(resource_loader_compat_font);
+	resource_loader_compat_font.unref();
+#endif /* DISABLE_DEPRECATED */
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);
 	resource_loader_texture_layered.unref();

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -198,9 +198,23 @@ VARIANT_ENUM_CAST(Font::SpacingType);
 class ResourceFormatLoaderFont : public ResourceFormatLoader {
 public:
 	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
+	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;
 };
 
-#endif
+#ifndef DISABLE_DEPRECATED
+
+class ResourceFormatLoaderCompatFont : public ResourceFormatLoader {
+public:
+	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
+	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual bool handles_type(const String &p_type) const;
+	virtual String get_resource_type(const String &p_path) const;
+};
+
+#endif /* DISABLE_DEPRECATED */
+
+#endif /* FONT_H */


### PR DESCRIPTION
~Depends on #42595 and #43030~

Add support for loading scenes with `BitmapFont`s and `DynamicFont`s. All relevant code is inside `#ifndef DISABLE_DEPRECATED` blocks.

#### TODO:

- [x] Scene loads successfully.
- [x] `DynamicFont`s are converted to `Font`.
- [x] `BitmapFont` s are converted to `Font`.

Added extra check to `ClassDB::_is_parent_class`, to prevent error spam for other resource loaders.