### PR TITLE
consolidating sanitizers and adding MSAN option on platforms that sup…

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -71,6 +71,7 @@ def get_opts():
         BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
         BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
         BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
+        BoolVariable("use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False),
         BoolVariable("pulseaudio", "Detect and use PulseAudio", True),
         BoolVariable("udev", "Use udev for gamepad connection callbacks", False),
         EnumVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", "yes", ("yes", "no")),
@@ -145,7 +146,7 @@ def configure(env):
         env.Append(CCFLAGS=["-ftest-coverage", "-fprofile-arcs"])
         env.Append(LINKFLAGS=["-ftest-coverage", "-fprofile-arcs"])
 
-    if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"]:
+    if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += "s"
 
         if env["use_ubsan"]:
@@ -163,6 +164,10 @@ def configure(env):
         if env["use_tsan"]:
             env.Append(CCFLAGS=["-fsanitize=thread"])
             env.Append(LINKFLAGS=["-fsanitize=thread"])
+
+        if env["use_msan"]:
+            env.Append(CCFLAGS=["-fsanitize=memory"])
+            env.Append(LINKFLAGS=["-fsanitize=memory"])
 
     if env["use_lto"]:
         if not env["use_llvm"] and env.GetOption("num_jobs") > 1:

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -35,7 +35,9 @@ def get_opts():
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
         BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
+        BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
         BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
+        BoolVariable("use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False),
     ]
 
 
@@ -133,7 +135,7 @@ def configure(env):
         env["AS"] = basecmd + "as"
         env.Append(CPPDEFINES=["__MACPORTS__"])  # hack to fix libvpx MM256_BROADCASTSI128_SI256 define
 
-    if env["use_ubsan"] or env["use_asan"] or env["use_tsan"]:
+    if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += "s"
 
         if env["use_ubsan"]:
@@ -144,9 +146,17 @@ def configure(env):
             env.Append(CCFLAGS=["-fsanitize=address"])
             env.Append(LINKFLAGS=["-fsanitize=address"])
 
+        if env["use_lsan"]:
+            env.Append(CCFLAGS=["-fsanitize=leak"])
+            env.Append(LINKFLAGS=["-fsanitize=leak"])
+
         if env["use_tsan"]:
             env.Append(CCFLAGS=["-fsanitize=thread"])
             env.Append(LINKFLAGS=["-fsanitize=thread"])
+
+        if env["use_msan"]:
+            env.Append(CCFLAGS=["-fsanitize=memory"])
+            env.Append(LINKFLAGS=["-fsanitize=memory"])
 
     ## Dependencies
 

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -39,6 +39,7 @@ def get_opts():
         BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
         BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
         BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
+        BoolVariable("use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False),
         EnumVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", "yes", ("yes", "no")),
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
@@ -100,7 +101,7 @@ def configure(env):
         env.Append(CCFLAGS=["-ftest-coverage", "-fprofile-arcs"])
         env.Append(LINKFLAGS=["-ftest-coverage", "-fprofile-arcs"])
 
-    if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"]:
+    if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += "s"
 
         if env["use_ubsan"]:
@@ -118,6 +119,10 @@ def configure(env):
         if env["use_tsan"]:
             env.Append(CCFLAGS=["-fsanitize=thread"])
             env.Append(LINKFLAGS=["-fsanitize=thread"])
+
+        if env["use_msan"]:
+            env.Append(CCFLAGS=["-fsanitize=memory"])
+            env.Append(LINKFLAGS=["-fsanitize=memory"])
 
     if env["use_lto"]:
         env.Append(CCFLAGS=["-flto"])


### PR DESCRIPTION
This adds an msan build option to platforms that support this sanitizer.  Its off by default like the other sanitizer options, but can be explicitly enabled on builds using clang12 or higher.  

https://clang.llvm.org/docs/MemorySanitizer.html

I'm hoping to integrate this sanitizer eventually in some capacity to catch issues like below:

https://github.com/godotengine/godot/issues/43941

This also just consolidates all sanitizers (ubsan, lsan, asan, tsan, msan) to be available on server, linux, and osx platforms. 

Note, on any llvm platform we could probably eventually expose these options as well (windows, ios).  I typically run memory & address sanitized builds in iOS environments as well, (different architectures, alignment requirements, etc) but I left that out for the time being.  But it could be something that could be added to those platforms as well. 