### PR TITLE
Don't open editor window when using --export or --doctool

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -703,6 +703,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			auto_build_solutions = true;
 			editor = true;
+		} else if (I->get() == "--doctool") { // Dump the engine API reference
+
+			OS::get_singleton()->set_no_window_mode(true);
+			auto_quit = true;
 #ifdef DEBUG_METHODS_ENABLED
 		} else if (I->get() == "--gdnative-generate-json-api") {
 			// Register as an editor instance to use the GLES2 fallback automatically on hardware that doesn't support the GLES3 backend
@@ -710,11 +714,17 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			// We still pass it to the main arguments since the argument handling itself is not done in this function
 			main_args.push_back(I->get());
+
+			OS::get_singleton()->set_no_window_mode(true);
+			auto_quit = true;
 #endif
 		} else if (I->get() == "--export" || I->get() == "--export-debug" || I->get() == "--export-pack") { // Export project
 
 			editor = true;
 			main_args.push_back(I->get());
+
+			OS::get_singleton()->set_no_window_mode(true);
+			auto_quit = true;
 #endif
 		} else if (I->get() == "--path") { // set path of project to start or edit
 


### PR DESCRIPTION
Fixes #43752

Adds `--no-window` when using `--export`, so the editor window doesn't suddenly pop up and then vanish when exporting from the command line.  ~~Should probably do this for `--doctool` too (and maybe others?), but I couldn't figure out how to make it work consistently.~~  I think it should work for `--doctool` and `--gdnative-generate-json-api` now, too.

This is against `3.2` instead of master because, as mentioned in the discussion on #43752, `--no-window` hasn't been implemented in `master` yet.