### PR TITLE
Set Environment's Ao Channel Effect to 1.0 by default

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -215,7 +215,7 @@
 		<member name="ss_reflections_max_steps" type="int" setter="set_ssr_max_steps" getter="get_ssr_max_steps" default="64">
 			The maximum number of steps for screen-space reflections. Higher values are slower.
 		</member>
-		<member name="ssao_ao_channel_affect" type="float" setter="set_ssao_ao_channel_affect" getter="get_ssao_ao_channel_affect" default="0.0">
+		<member name="ssao_ao_channel_affect" type="float" setter="set_ssao_ao_channel_affect" getter="get_ssao_ao_channel_affect" default="1.0">
 			The screen-space ambient occlusion intensity on materials that have an AO texture defined. Values higher than [code]0[/code] will make the SSAO effect visible in areas darkened by AO textures.
 		</member>
 		<member name="ssao_bias" type="float" setter="set_ssao_bias" getter="get_ssao_bias" default="0.01">

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -151,7 +151,7 @@ private:
 	float ssao_intensity = 1.0;
 	float ssao_bias = 0.01;
 	float ssao_direct_light_affect = 0.0;
-	float ssao_ao_channel_affect = 0.0;
+	float ssao_ao_channel_affect = 1.0;
 	SSAOBlur ssao_blur = SSAO_BLUR_3x3;
 	float ssao_edge_sharpness = 4.0;
 	void _update_ssao();

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
@@ -740,7 +740,7 @@ private:
 		float ssao_intensity = 1;
 		float ssao_bias = 0.01;
 		float ssao_direct_light_affect = 0.0;
-		float ssao_ao_channel_affect = 0.0;
+		float ssao_ao_channel_affect = 1.0;
 		float ssao_blur_edge_sharpness = 4.0;
 		RS::EnvironmentSSAOBlur ssao_blur = RS::ENV_SSAO_BLUR_3x3;
 


### PR DESCRIPTION
"Ao Channel Affect" was defaulting to 0, giving unexpected results. This meant that as soon as you set an AO texture on a material, there will no longer be SSAO on that material.

This led many users to think that Godot didn't support using SSAO and AO textures at the same time.

This closes #43957.