### PR TITLE
Fixed crash in canvas_item_add_polyline if color arr has incorrect size

### DIFF
--- a/servers/rendering/rendering_server_canvas.cpp
+++ b/servers/rendering/rendering_server_canvas.cpp
@@ -545,6 +545,8 @@ void RenderingServerCanvas::canvas_item_add_polyline(RID p_item, const Vector<Po
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
+	Color color = Color(1, 1, 1, 1);
+
 	Vector<int> indices;
 	int pc = p_points.size();
 	int pc2 = pc * 2;
@@ -565,6 +567,8 @@ void RenderingServerCanvas::canvas_item_add_polyline(RID p_item, const Vector<Po
 	Color *colors_ptr = colors.ptrw();
 
 	if (p_antialiased) {
+		Color color2 = Color(1, 1, 1, 0);
+
 		PackedColorArray colors_top;
 		PackedVector2Array points_top;
 
@@ -616,8 +620,10 @@ void RenderingServerCanvas::canvas_item_add_polyline(RID p_item, const Vector<Po
 			points_bottom_ptr[j] = pos - tangent;
 			points_bottom_ptr[j2] = pos - tangent - tangent;
 
-			Color color = p_colors[i];
-			Color color2 = Color(color.r, color.g, color.b, 0);
+			if (i < p_colors.size()) {
+				color = p_colors[i];
+				color2 = Color(color.r, color.g, color.b, 0);
+			}
 
 			colors_ptr[j] = color;
 			colors_ptr[j2] = color;
@@ -653,12 +659,14 @@ void RenderingServerCanvas::canvas_item_add_polyline(RID p_item, const Vector<Po
 			j2 = j + 1;
 
 			Vector2 tangent = ((t + prev_t).normalized()) * p_width * 0.5;
-
-			Vector2 pos = p_points[j];
-			Color color = p_colors[j2];
+			Vector2 pos = p_points[i];
 
 			points_ptr[j] = pos + tangent;
 			points_ptr[j2] = pos - tangent;
+
+			if (i < p_colors.size()) {
+				color = p_colors[i];
+			}
 
 			colors_ptr[j] = color;
 			colors_ptr[j2] = color;


### PR DESCRIPTION
Fixed crash when Color array is empty or does not equal to point size. Used default white color if color array is empty.
