### PR TITLE
Reduced EditorTheme margin on PopupMenu

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -676,7 +676,14 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("panel", "PopupDialog", style_popup);
 
 	// PopupMenu
-	theme->set_stylebox("panel", "PopupMenu", style_popup);
+	const int popup_menu_margin_size = default_margin_size * 1.5 * EDSCALE;
+	Ref<StyleBoxFlat> style_popup_menu = style_popup->duplicate();
+	style_popup_menu->set_default_margin(MARGIN_LEFT, popup_menu_margin_size);
+	style_popup_menu->set_default_margin(MARGIN_TOP, popup_menu_margin_size);
+	style_popup_menu->set_default_margin(MARGIN_RIGHT, popup_menu_margin_size);
+	style_popup_menu->set_default_margin(MARGIN_BOTTOM, popup_menu_margin_size);
+
+	theme->set_stylebox("panel", "PopupMenu", style_popup_menu);
 	theme->set_stylebox("separator", "PopupMenu", style_popup_separator);
 	theme->set_stylebox("labeled_separator_left", "PopupMenu", style_popup_labeled_separator_left);
 	theme->set_stylebox("labeled_separator_right", "PopupMenu", style_popup_labeled_separator_right);


### PR DESCRIPTION
PopupMenu margin size is larger than in 3.2 after my refactor in #41640. At the time I left it at the default `style_popup` but it has margins of 8px by default which is quite big. Here I change it to 6px on all sides which is a bit slimmer but not too slim - I tried 4px and it looked weird so I took the middle ground.

On 3.2.X it is 6px on top, 5px on bottom and 4px on the side.

**Before**
![image](https://user-images.githubusercontent.com/41730826/100557453-0eb43700-32f5-11eb-8412-8ac3b7097851.png)

**After**
![image](https://user-images.githubusercontent.com/41730826/100557476-34414080-32f5-11eb-9d18-38d59fc1ae75.png)
