### PR TITLE
fix #43695 on 3.2 by revert part of  #41577

### DIFF
--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -140,5 +140,6 @@ void LinkButton::_bind_methods() {
 
 LinkButton::LinkButton() {
 	underline_mode = UNDERLINE_MODE_ALWAYS;
+	set_enabled_focus_mode(FOCUS_NONE);
 	set_default_cursor_shape(CURSOR_POINTING_HAND);
 }

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -129,6 +129,7 @@ MenuButton::MenuButton() {
 	set_flat(true);
 	set_toggle_mode(true);
 	set_disable_shortcuts(false);
+	set_enabled_focus_mode(FOCUS_NONE);
 	set_process_unhandled_key_input(true);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 


### PR DESCRIPTION
Restore the default focus mode for MenuButton and LinkButton,
since it is different from the default of BaseButton.

There is a same fix for master, see #43977.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
