### PR TITLE
fix #43695 on master by revert part of #41576

### DIFF
--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -295,5 +295,6 @@ void LinkButton::_bind_methods() {
 LinkButton::LinkButton() {
 	text_buf.instance();
 	underline_mode = UNDERLINE_MODE_ALWAYS;
+	set_focus_mode(FOCUS_NONE);
 	set_default_cursor_shape(CURSOR_POINTING_HAND);
 }


### PR DESCRIPTION
This is the same fix as #43974, but for master.

Note that #42109 has already reverted the change to MenuButton,
and actually fixed #43695.
As a result, this commit only reverts the change to LinkButton,
in order to prevent unpredictable consequences.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
