### PR TITLE
Fix missing function hints

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2309,7 +2309,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	GDScriptParser::DataType base_type;
 	bool _static = false;
 	const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(p_call);
-	GDScriptParser::Node::Type callee_type = GDScriptParser::Node::NONE;
+	GDScriptParser::Node::Type callee_type = call->get_callee_type();
 
 	GDScriptCompletionIdentifier connect_base;
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes the issue of no hints showing for functions mentioned in https://github.com/godotengine/godot/issues/40933.
The commit https://github.com/godotengine/godot/commit/8a13be50abe929b1905b5e5ef72b199b60de13c3 missed assigning `callee_type` with `call->get_callee_type()` here:
https://github.com/godotengine/godot/blob/78d9aa99cabb47b2f285323e119bbef7972c1822/modules/gdscript/gdscript_editor.cpp#L2312
![image](https://user-images.githubusercontent.com/25207137/100588799-93ea1c80-32f2-11eb-934c-22e9a09ef79d.png)
