### PR TITLE
[Complex Text Layouts] Adds missing Font::SPACING_* to the controls, align glyphs to pixel grid.

### DIFF
--- a/modules/text_server_adv/bitmap_font_adv.cpp
+++ b/modules/text_server_adv/bitmap_font_adv.cpp
@@ -175,8 +175,9 @@ static hb_bool_t hb_bmp_get_font_h_extents(hb_font_t *font, void *font_data, hb_
 	return true;
 }
 
-static hb_font_funcs_t *_hb_bmp_get_font_funcs() {
-	hb_font_funcs_t *funcs = hb_font_funcs_create();
+static hb_font_funcs_t *funcs = nullptr;
+void hb_bmp_create_font_funcs() {
+	funcs = hb_font_funcs_create();
 
 	hb_font_funcs_set_font_h_extents_func(funcs, hb_bmp_get_font_h_extents, nullptr, nullptr);
 	//hb_font_funcs_set_font_v_extents_func (funcs, hb_bmp_get_font_v_extents, nullptr, nullptr);
@@ -194,12 +195,17 @@ static hb_font_funcs_t *_hb_bmp_get_font_funcs() {
 	//hb_font_funcs_set_glyph_from_name_func (funcs, hb_bmp_get_glyph_from_name, nullptr, nullptr);
 
 	hb_font_funcs_make_immutable(funcs);
+}
 
-	return funcs;
+void hb_bmp_free_font_funcs() {
+	if (funcs != nullptr) {
+		hb_font_funcs_destroy(funcs);
+		funcs = nullptr;
+	}
 }
 
 static void _hb_bmp_font_set_funcs(hb_font_t *p_font, BitmapFontDataAdvanced *p_face, int p_size, bool p_unref) {
-	hb_font_set_funcs(p_font, _hb_bmp_get_font_funcs(), _hb_bmp_font_create(p_face, p_size, p_unref), _hb_bmp_font_destroy);
+	hb_font_set_funcs(p_font, funcs, _hb_bmp_font_create(p_face, p_size, p_unref), _hb_bmp_font_destroy);
 }
 
 hb_font_t *hb_bmp_font_create(BitmapFontDataAdvanced *p_face, int p_size, hb_destroy_func_t p_destroy) {

--- a/modules/text_server_adv/bitmap_font_adv.h
+++ b/modules/text_server_adv/bitmap_font_adv.h
@@ -33,6 +33,9 @@
 
 #include "font_adv.h"
 
+void hb_bmp_create_font_funcs();
+void hb_bmp_free_font_funcs();
+
 struct BitmapFontDataAdvanced : public FontDataAdvanced {
 	_THREAD_SAFE_CLASS_
 

--- a/modules/text_server_adv/script_iterator.cpp
+++ b/modules/text_server_adv/script_iterator.cpp
@@ -56,11 +56,12 @@ ScriptIterator::ScriptIterator(const String &p_string, int p_start, int p_length
 	int paren_sp = -1;
 	int start_sp = paren_sp;
 	UErrorCode err = U_ZERO_ERROR;
+	const char32_t *str = p_string.ptr();
 
 	do {
 		script_code = USCRIPT_COMMON;
 		for (script_start = script_end; script_end < p_length; script_end++) {
-			UChar32 ch = p_string[script_end];
+			UChar32 ch = str[script_end];
 			UScriptCode sc = uscript_getScript(ch, &err);
 			if (U_FAILURE(err)) {
 				ERR_FAIL_MSG(u_errorName(err));

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2507,9 +2507,11 @@ void TextServerAdvanced::register_server() {
 }
 
 TextServerAdvanced::TextServerAdvanced() {
+	hb_bmp_create_font_funcs();
 }
 
 TextServerAdvanced::~TextServerAdvanced() {
+	hb_bmp_free_font_funcs();
 	u_cleanup();
 #ifndef ICU_STATIC_DATA
 	if (icu_data != nullptr) {

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1128,8 +1128,8 @@ bool TextServerAdvanced::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 							sd->ascent = MAX(sd->ascent, sd->objects[key].rect.size.y);
 						} break;
 						case VALIGN_CENTER: {
-							sd->ascent = MAX(sd->ascent, sd->objects[key].rect.size.y / 2);
-							sd->descent = MAX(sd->descent, sd->objects[key].rect.size.y / 2);
+							sd->ascent = MAX(sd->ascent, Math::round(sd->objects[key].rect.size.y / 2));
+							sd->descent = MAX(sd->descent, Math::round(sd->objects[key].rect.size.y / 2));
 						} break;
 						case VALIGN_BOTTOM: {
 							sd->descent = MAX(sd->descent, sd->objects[key].rect.size.y);
@@ -1144,8 +1144,8 @@ bool TextServerAdvanced::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 							sd->ascent = MAX(sd->ascent, sd->objects[key].rect.size.x);
 						} break;
 						case VALIGN_CENTER: {
-							sd->ascent = MAX(sd->ascent, sd->objects[key].rect.size.x / 2);
-							sd->descent = MAX(sd->descent, sd->objects[key].rect.size.x / 2);
+							sd->ascent = MAX(sd->ascent, Math::round(sd->objects[key].rect.size.x / 2));
+							sd->descent = MAX(sd->descent, Math::round(sd->objects[key].rect.size.x / 2));
 						} break;
 						case VALIGN_BOTTOM: {
 							sd->descent = MAX(sd->descent, sd->objects[key].rect.size.x);
@@ -1160,19 +1160,19 @@ bool TextServerAdvanced::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 						sd->ascent = MAX(sd->ascent, MAX(fd->get_ascent(gl.font_size), -gl.y_off));
 						sd->descent = MAX(sd->descent, MAX(fd->get_descent(gl.font_size), gl.y_off));
 					} else {
-						sd->ascent = MAX(sd->ascent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
-						sd->descent = MAX(sd->descent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
+						sd->ascent = MAX(sd->ascent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
+						sd->descent = MAX(sd->descent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
 					}
 					sd->upos = MAX(sd->upos, font_get_underline_position(gl.font_rid, gl.font_size));
 					sd->uthk = MAX(sd->uthk, font_get_underline_thickness(gl.font_rid, gl.font_size));
 				} else if (sd->preserve_invalid || (sd->preserve_control && is_control(gl.index))) {
 					// Glyph not found, replace with hex code box.
 					if (sd->orientation == ORIENTATION_HORIZONTAL) {
-						sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f);
-						sd->descent = MAX(sd->descent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f);
+						sd->ascent = MAX(sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f));
+						sd->descent = MAX(sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f));
 					} else {
-						sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
-						sd->descent = MAX(sd->descent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
+						sd->ascent = MAX(sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
+						sd->descent = MAX(sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
 					}
 				}
 				sd->width += gl.advance * gl.repeat;
@@ -1303,8 +1303,8 @@ RID TextServerAdvanced::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 										new_sd->ascent = MAX(new_sd->ascent, new_sd->objects[key].rect.size.y);
 									} break;
 									case VALIGN_CENTER: {
-										new_sd->ascent = MAX(new_sd->ascent, new_sd->objects[key].rect.size.y / 2);
-										new_sd->descent = MAX(new_sd->descent, new_sd->objects[key].rect.size.y / 2);
+										new_sd->ascent = MAX(new_sd->ascent, Math::round(new_sd->objects[key].rect.size.y / 2));
+										new_sd->descent = MAX(new_sd->descent, Math::round(new_sd->objects[key].rect.size.y / 2));
 									} break;
 									case VALIGN_BOTTOM: {
 										new_sd->descent = MAX(new_sd->descent, new_sd->objects[key].rect.size.y);
@@ -1318,8 +1318,8 @@ RID TextServerAdvanced::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 										new_sd->ascent = MAX(new_sd->ascent, new_sd->objects[key].rect.size.x);
 									} break;
 									case VALIGN_CENTER: {
-										new_sd->ascent = MAX(new_sd->ascent, new_sd->objects[key].rect.size.x / 2);
-										new_sd->descent = MAX(new_sd->descent, new_sd->objects[key].rect.size.x / 2);
+										new_sd->ascent = MAX(new_sd->ascent, Math::round(new_sd->objects[key].rect.size.x / 2));
+										new_sd->descent = MAX(new_sd->descent, Math::round(new_sd->objects[key].rect.size.x / 2));
 									} break;
 									case VALIGN_BOTTOM: {
 										new_sd->descent = MAX(new_sd->descent, new_sd->objects[key].rect.size.x);
@@ -1333,17 +1333,17 @@ RID TextServerAdvanced::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 									new_sd->ascent = MAX(new_sd->ascent, MAX(fd->get_ascent(gl.font_size), -gl.y_off));
 									new_sd->descent = MAX(new_sd->descent, MAX(fd->get_descent(gl.font_size), gl.y_off));
 								} else {
-									new_sd->ascent = MAX(new_sd->ascent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
-									new_sd->descent = MAX(new_sd->descent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
+									new_sd->ascent = MAX(new_sd->ascent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
+									new_sd->descent = MAX(new_sd->descent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
 								}
 							} else if (new_sd->preserve_invalid || (new_sd->preserve_control && is_control(gl.index))) {
 								// Glyph not found, replace with hex code box.
 								if (new_sd->orientation == ORIENTATION_HORIZONTAL) {
-									new_sd->ascent = MAX(new_sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f);
-									new_sd->descent = MAX(new_sd->descent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f);
+									new_sd->ascent = MAX(new_sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f));
+									new_sd->descent = MAX(new_sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f));
 								} else {
-									new_sd->ascent = MAX(new_sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
-									new_sd->descent = MAX(new_sd->descent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
+									new_sd->ascent = MAX(new_sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
+									new_sd->descent = MAX(new_sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
 								}
 							}
 							new_sd->width += gl.advance * gl.repeat;
@@ -1491,9 +1491,9 @@ float TextServerAdvanced::shaped_text_fit_to_width(RID p_shaped, float p_width, 
 				if ((gl.flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE) {
 					float old_adv = gl.advance;
 					if ((gl.flags & GRAPHEME_IS_VIRTUAL) == GRAPHEME_IS_VIRTUAL) {
-						gl.advance = MAX(gl.advance + delta_width_per_space, 0.f);
+						gl.advance = Math::round(MAX(gl.advance + delta_width_per_space, 0.f));
 					} else {
-						gl.advance = MAX(gl.advance + delta_width_per_space, 0.05 * gl.font_size);
+						gl.advance = Math::round(MAX(gl.advance + delta_width_per_space, 0.05 * gl.font_size));
 					}
 					sd->width += (gl.advance - old_adv);
 				}
@@ -1540,7 +1540,7 @@ float TextServerAdvanced::shaped_text_tab_align(RID p_shaped, const Vector<float
 				}
 			}
 			float old_adv = sd->glyphs.write[i].advance;
-			sd->glyphs.write[i].advance = (tab_off - off);
+			sd->glyphs.write[i].advance = tab_off - off;
 			sd->width += sd->glyphs.write[i].advance - old_adv;
 			off = 0;
 			continue;
@@ -1850,15 +1850,15 @@ TextServer::Glyph TextServerAdvanced::_shape_single_glyph(ShapedTextDataAdvanced
 
 	if (glyph_count > 0) {
 		if (p_sd->orientation == ORIENTATION_HORIZONTAL) {
-			gl.advance = glyph_pos[0].x_advance / (64.0 / fd->get_font_scale(p_font_size));
+			gl.advance = Math::round(glyph_pos[0].x_advance / (64.0 / fd->get_font_scale(p_font_size)));
 		} else {
-			gl.advance = -glyph_pos[0].y_advance / (64.0 / fd->get_font_scale(p_font_size));
+			gl.advance = -Math::round(glyph_pos[0].y_advance / (64.0 / fd->get_font_scale(p_font_size)));
 		}
 		gl.count = 1;
 
 		gl.index = glyph_info[0].codepoint;
-		gl.x_off = glyph_pos[0].x_offset / (64.0 / fd->get_font_scale(p_font_size));
-		gl.y_off = -glyph_pos[0].y_offset / (64.0 / fd->get_font_scale(p_font_size));
+		gl.x_off = Math::round(glyph_pos[0].x_offset / (64.0 / fd->get_font_scale(p_font_size)));
+		gl.y_off = -Math::round(glyph_pos[0].y_offset / (64.0 / fd->get_font_scale(p_font_size)));
 
 		if ((glyph_info[0].codepoint != 0) || !u_isgraph(p_char)) {
 			gl.flags |= GRAPHEME_IS_VALID;
@@ -1890,12 +1890,12 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 				}
 				if (p_sd->orientation == ORIENTATION_HORIZONTAL) {
 					gl.advance = get_hex_code_box_size(gl.font_size, gl.index).x;
-					p_sd->ascent = MAX(p_sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f);
-					p_sd->descent = MAX(p_sd->descent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f);
+					p_sd->ascent = MAX(p_sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f));
+					p_sd->descent = MAX(p_sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f));
 				} else {
 					gl.advance = get_hex_code_box_size(gl.font_size, gl.index).y;
-					p_sd->ascent = MAX(p_sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
-					p_sd->descent = MAX(p_sd->descent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
+					p_sd->ascent = MAX(p_sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
+					p_sd->descent = MAX(p_sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
 				}
 				p_sd->width += gl.advance;
 
@@ -1986,12 +1986,12 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 			gl.index = glyph_info[i].codepoint;
 			if (gl.index != 0) {
 				if (p_sd->orientation == ORIENTATION_HORIZONTAL) {
-					gl.advance = glyph_pos[i].x_advance / (64.0 / fd->get_font_scale(gl.font_size));
+					gl.advance = Math::round(glyph_pos[i].x_advance / (64.0 / fd->get_font_scale(gl.font_size)));
 				} else {
-					gl.advance = -glyph_pos[i].y_advance / (64.0 / fd->get_font_scale(gl.font_size));
+					gl.advance = -Math::round(glyph_pos[i].y_advance / (64.0 / fd->get_font_scale(gl.font_size)));
 				}
-				gl.x_off = glyph_pos[i].x_offset / (64.0 / fd->get_font_scale(gl.font_size));
-				gl.y_off = -glyph_pos[i].y_offset / (64.0 / fd->get_font_scale(gl.font_size));
+				gl.x_off = Math::round(glyph_pos[i].x_offset / (64.0 / fd->get_font_scale(gl.font_size)));
+				gl.y_off = -Math::round(glyph_pos[i].y_offset / (64.0 / fd->get_font_scale(gl.font_size)));
 			}
 
 			if (p_sd->preserve_control) {
@@ -2029,8 +2029,8 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 						p_sd->ascent = MAX(p_sd->ascent, MAX(fd->get_ascent(w[i + j].font_size), -w[i + j].y_off));
 						p_sd->descent = MAX(p_sd->descent, MAX(fd->get_descent(w[i + j].font_size), w[i + j].y_off));
 					} else {
-						p_sd->ascent = MAX(p_sd->ascent, fd->get_advance(w[i + j].index, w[i + j].font_size).x * 0.5);
-						p_sd->descent = MAX(p_sd->descent, fd->get_advance(w[i + j].index, w[i + j].font_size).x * 0.5);
+						p_sd->ascent = MAX(p_sd->ascent, Math::round(fd->get_advance(w[i + j].index, w[i + j].font_size).x * 0.5));
+						p_sd->descent = MAX(p_sd->descent, Math::round(fd->get_advance(w[i + j].index, w[i + j].font_size).x * 0.5));
 					}
 					p_sd->upos = MAX(p_sd->upos, font_get_underline_position(w[i + j].font_rid, w[i + j].font_size));
 					p_sd->uthk = MAX(p_sd->uthk, font_get_underline_thickness(w[i + j].font_rid, w[i + j].font_size));
@@ -2180,8 +2180,8 @@ bool TextServerAdvanced::shaped_text_shape(RID p_shaped) {
 										sd->ascent = MAX(sd->ascent, sd->objects[span.embedded_key].rect.size.y);
 									} break;
 									case VALIGN_CENTER: {
-										sd->ascent = MAX(sd->ascent, sd->objects[span.embedded_key].rect.size.y / 2);
-										sd->descent = MAX(sd->descent, sd->objects[span.embedded_key].rect.size.y / 2);
+										sd->ascent = MAX(sd->ascent, Math::round(sd->objects[span.embedded_key].rect.size.y / 2));
+										sd->descent = MAX(sd->descent, Math::round(sd->objects[span.embedded_key].rect.size.y / 2));
 									} break;
 									case VALIGN_BOTTOM: {
 										sd->descent = MAX(sd->descent, sd->objects[span.embedded_key].rect.size.y);
@@ -2195,8 +2195,8 @@ bool TextServerAdvanced::shaped_text_shape(RID p_shaped) {
 										sd->ascent = MAX(sd->ascent, sd->objects[span.embedded_key].rect.size.x);
 									} break;
 									case VALIGN_CENTER: {
-										sd->ascent = MAX(sd->ascent, sd->objects[span.embedded_key].rect.size.x / 2);
-										sd->descent = MAX(sd->descent, sd->objects[span.embedded_key].rect.size.x / 2);
+										sd->ascent = MAX(sd->ascent, Math::round(sd->objects[span.embedded_key].rect.size.x / 2));
+										sd->descent = MAX(sd->descent, Math::round(sd->objects[span.embedded_key].rect.size.x / 2));
 									} break;
 									case VALIGN_BOTTOM: {
 										sd->descent = MAX(sd->descent, sd->objects[span.embedded_key].rect.size.x);

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1874,7 +1874,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 	}
 
 	if (fd == nullptr) {
-		// Add fallback glyohs
+		// Add fallback glyphs
 		for (int i = p_start; i < p_end; i++) {
 			if (p_sd->preserve_invalid || (p_sd->preserve_control && is_control(p_sd->text[i]))) {
 				TextServer::Glyph gl;
@@ -2026,7 +2026,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 				}
 				for (int j = 0; j < w[i].count; j++) {
 					if (p_sd->orientation == ORIENTATION_HORIZONTAL) {
-						p_sd->ascent = MAX(p_sd->ascent, MAX(fd->get_ascent(w[i + j].font_size), w[i + j].y_off));
+						p_sd->ascent = MAX(p_sd->ascent, MAX(fd->get_ascent(w[i + j].font_size), -w[i + j].y_off));
 						p_sd->descent = MAX(p_sd->descent, MAX(fd->get_descent(w[i + j].font_size), w[i + j].y_off));
 					} else {
 						p_sd->ascent = MAX(p_sd->ascent, fd->get_advance(w[i + j].index, w[i + j].font_size).x * 0.5);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -645,8 +645,8 @@ bool TextServerFallback::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 							sd->ascent = MAX(sd->ascent, sd->objects[key].rect.size.y);
 						} break;
 						case VALIGN_CENTER: {
-							sd->ascent = MAX(sd->ascent, sd->objects[key].rect.size.y / 2);
-							sd->descent = MAX(sd->descent, sd->objects[key].rect.size.y / 2);
+							sd->ascent = MAX(sd->ascent, Math::round(sd->objects[key].rect.size.y / 2));
+							sd->descent = MAX(sd->descent, Math::round(sd->objects[key].rect.size.y / 2));
 						} break;
 						case VALIGN_BOTTOM: {
 							sd->descent = MAX(sd->descent, sd->objects[key].rect.size.y);
@@ -661,8 +661,8 @@ bool TextServerFallback::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 							sd->ascent = MAX(sd->ascent, sd->objects[key].rect.size.x);
 						} break;
 						case VALIGN_CENTER: {
-							sd->ascent = MAX(sd->ascent, sd->objects[key].rect.size.x / 2);
-							sd->descent = MAX(sd->descent, sd->objects[key].rect.size.x / 2);
+							sd->ascent = MAX(sd->ascent, Math::round(sd->objects[key].rect.size.x / 2));
+							sd->descent = MAX(sd->descent, Math::round(sd->objects[key].rect.size.x / 2));
 						} break;
 						case VALIGN_BOTTOM: {
 							sd->descent = MAX(sd->descent, sd->objects[key].rect.size.x);
@@ -677,19 +677,19 @@ bool TextServerFallback::shaped_text_resize_object(RID p_shaped, Variant p_key, 
 						sd->ascent = MAX(sd->ascent, fd->get_ascent(gl.font_size));
 						sd->descent = MAX(sd->descent, fd->get_descent(gl.font_size));
 					} else {
-						sd->ascent = MAX(sd->ascent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
-						sd->descent = MAX(sd->descent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
+						sd->ascent = MAX(sd->ascent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
+						sd->descent = MAX(sd->descent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
 					}
 					sd->upos = MAX(sd->upos, font_get_underline_position(gl.font_rid, gl.font_size));
 					sd->uthk = MAX(sd->uthk, font_get_underline_thickness(gl.font_rid, gl.font_size));
 				} else if (sd->preserve_invalid || (sd->preserve_control && is_control(gl.index))) {
 					// Glyph not found, replace with hex code box.
 					if (sd->orientation == ORIENTATION_HORIZONTAL) {
-						sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f);
-						sd->descent = MAX(sd->descent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f);
+						sd->ascent = MAX(sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f));
+						sd->descent = MAX(sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f));
 					} else {
-						sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
-						sd->descent = MAX(sd->descent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
+						sd->ascent = MAX(sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
+						sd->descent = MAX(sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
 					}
 				}
 				sd->width += gl.advance * gl.repeat;
@@ -783,8 +783,8 @@ RID TextServerFallback::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 								new_sd->ascent = MAX(new_sd->ascent, new_sd->objects[key].rect.size.y);
 							} break;
 							case VALIGN_CENTER: {
-								new_sd->ascent = MAX(new_sd->ascent, new_sd->objects[key].rect.size.y / 2);
-								new_sd->descent = MAX(new_sd->descent, new_sd->objects[key].rect.size.y / 2);
+								new_sd->ascent = MAX(new_sd->ascent, Math::round(new_sd->objects[key].rect.size.y / 2));
+								new_sd->descent = MAX(new_sd->descent, Math::round(new_sd->objects[key].rect.size.y / 2));
 							} break;
 							case VALIGN_BOTTOM: {
 								new_sd->descent = MAX(new_sd->descent, new_sd->objects[key].rect.size.y);
@@ -798,8 +798,8 @@ RID TextServerFallback::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 								new_sd->ascent = MAX(new_sd->ascent, new_sd->objects[key].rect.size.x);
 							} break;
 							case VALIGN_CENTER: {
-								new_sd->ascent = MAX(new_sd->ascent, new_sd->objects[key].rect.size.x / 2);
-								new_sd->descent = MAX(new_sd->descent, new_sd->objects[key].rect.size.x / 2);
+								new_sd->ascent = MAX(new_sd->ascent, Math::round(new_sd->objects[key].rect.size.x / 2));
+								new_sd->descent = MAX(new_sd->descent, Math::round(new_sd->objects[key].rect.size.x / 2));
 							} break;
 							case VALIGN_BOTTOM: {
 								new_sd->descent = MAX(new_sd->descent, new_sd->objects[key].rect.size.x);
@@ -813,17 +813,17 @@ RID TextServerFallback::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 							new_sd->ascent = MAX(new_sd->ascent, fd->get_ascent(gl.font_size));
 							new_sd->descent = MAX(new_sd->descent, fd->get_descent(gl.font_size));
 						} else {
-							new_sd->ascent = MAX(new_sd->ascent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
-							new_sd->descent = MAX(new_sd->descent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
+							new_sd->ascent = MAX(new_sd->ascent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
+							new_sd->descent = MAX(new_sd->descent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
 						}
 					} else if (new_sd->preserve_invalid || (new_sd->preserve_control && is_control(gl.index))) {
 						// Glyph not found, replace with hex code box.
 						if (new_sd->orientation == ORIENTATION_HORIZONTAL) {
-							new_sd->ascent = MAX(new_sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f);
-							new_sd->descent = MAX(new_sd->descent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f);
+							new_sd->ascent = MAX(new_sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f));
+							new_sd->descent = MAX(new_sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f));
 						} else {
-							new_sd->ascent = MAX(new_sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
-							new_sd->descent = MAX(new_sd->descent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
+							new_sd->ascent = MAX(new_sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
+							new_sd->descent = MAX(new_sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
 						}
 					}
 					new_sd->width += gl.advance * gl.repeat;
@@ -943,7 +943,7 @@ float TextServerFallback::shaped_text_fit_to_width(RID p_shaped, float p_width, 
 			if (gl.count > 0) {
 				if ((gl.flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE) {
 					float old_adv = gl.advance;
-					gl.advance = MAX(gl.advance + delta_width_per_space, 0.05 * gl.font_size);
+					gl.advance = Math::round(MAX(gl.advance + delta_width_per_space, 0.05 * gl.font_size));
 					sd->width += (gl.advance - old_adv);
 				}
 			}
@@ -989,7 +989,7 @@ float TextServerFallback::shaped_text_tab_align(RID p_shaped, const Vector<float
 				}
 			}
 			float old_adv = sd->glyphs.write[i].advance;
-			sd->glyphs.write[i].advance = (tab_off - off);
+			sd->glyphs.write[i].advance = tab_off - off;
 			sd->width += sd->glyphs.write[i].advance - old_adv;
 			off = 0;
 			continue;
@@ -1086,8 +1086,8 @@ bool TextServerFallback::shaped_text_shape(RID p_shaped) {
 						sd->ascent = MAX(sd->ascent, sd->objects[span.embedded_key].rect.size.y);
 					} break;
 					case VALIGN_CENTER: {
-						sd->ascent = MAX(sd->ascent, sd->objects[span.embedded_key].rect.size.y / 2);
-						sd->descent = MAX(sd->descent, sd->objects[span.embedded_key].rect.size.y / 2);
+						sd->ascent = MAX(sd->ascent, Math::round(sd->objects[span.embedded_key].rect.size.y / 2));
+						sd->descent = MAX(sd->descent, Math::round(sd->objects[span.embedded_key].rect.size.y / 2));
 					} break;
 					case VALIGN_BOTTOM: {
 						sd->descent = MAX(sd->descent, sd->objects[span.embedded_key].rect.size.y);
@@ -1101,8 +1101,8 @@ bool TextServerFallback::shaped_text_shape(RID p_shaped) {
 						sd->ascent = MAX(sd->ascent, sd->objects[span.embedded_key].rect.size.x);
 					} break;
 					case VALIGN_CENTER: {
-						sd->ascent = MAX(sd->ascent, sd->objects[span.embedded_key].rect.size.x / 2);
-						sd->descent = MAX(sd->descent, sd->objects[span.embedded_key].rect.size.x / 2);
+						sd->ascent = MAX(sd->ascent, Math::round(sd->objects[span.embedded_key].rect.size.x / 2));
+						sd->descent = MAX(sd->descent, Math::round(sd->objects[span.embedded_key].rect.size.x / 2));
 					} break;
 					case VALIGN_BOTTOM: {
 						sd->descent = MAX(sd->descent, sd->objects[span.embedded_key].rect.size.x);
@@ -1157,10 +1157,10 @@ bool TextServerFallback::shaped_text_shape(RID p_shaped) {
 							sd->descent = MAX(sd->descent, fd->get_descent(gl.font_size));
 						} else {
 							gl.advance = fd->get_advance(gl.index, gl.font_size).y;
-							gl.x_off = -fd->get_advance(gl.index, gl.font_size).x * 0.5;
+							gl.x_off = -Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5);
 							gl.y_off = fd->get_ascent(gl.font_size);
-							sd->ascent = MAX(sd->ascent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
-							sd->descent = MAX(sd->descent, fd->get_advance(gl.index, gl.font_size).x * 0.5);
+							sd->ascent = MAX(sd->ascent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
+							sd->descent = MAX(sd->descent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
 						}
 					}
 					sd->upos = MAX(sd->upos, font_get_underline_position(gl.font_rid, gl.font_size));
@@ -1181,12 +1181,12 @@ bool TextServerFallback::shaped_text_shape(RID p_shaped) {
 					// Glyph not found, replace with hex code box.
 					if (sd->orientation == ORIENTATION_HORIZONTAL) {
 						gl.advance = get_hex_code_box_size(gl.font_size, gl.index).x;
-						sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f);
-						sd->descent = MAX(sd->descent, get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f);
+						sd->ascent = MAX(sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.75f));
+						sd->descent = MAX(sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).y * 0.25f));
 					} else {
 						gl.advance = get_hex_code_box_size(gl.font_size, gl.index).y;
-						sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
-						sd->descent = MAX(sd->descent, get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f);
+						sd->ascent = MAX(sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
+						sd->descent = MAX(sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5f));
 					}
 				}
 				sd->width += gl.advance;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -78,6 +78,7 @@ void ItemList::add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable) {
 	item.icon_region = Rect2i();
 	item.icon_modulate = Color(1, 1, 1, 1);
 	//item.text=p_item;
+	item.text_buf.instance();
 	item.selectable = p_selectable;
 	item.selected = false;
 	item.disabled = false;

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -64,16 +64,17 @@ bool Label::is_uppercase() const {
 }
 
 int Label::get_line_height(int p_line) const {
+	Ref<Font> font = get_theme_font("font");
 	if (p_line >= 0 && p_line < lines_rid.size()) {
-		return TS->shaped_text_get_size(lines_rid[p_line]).y;
+		return TS->shaped_text_get_size(lines_rid[p_line]).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM);
 	} else if (lines_rid.size() > 0) {
 		int h = 0;
 		for (int i = 0; i < lines_rid.size(); i++) {
-			h = MAX(h, TS->shaped_text_get_size(lines_rid[i]).y);
+			h = MAX(h, TS->shaped_text_get_size(lines_rid[i]).y) + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM);
 		}
 		return h;
 	} else {
-		return get_theme_font("font")->get_height(get_theme_font_size("font_size"));
+		return font->get_height(get_theme_font_size("font_size"));
 	}
 }
 
@@ -138,6 +139,7 @@ void Label::_shape() {
 void Label::_update_visible() {
 	int line_spacing = get_theme_constant("line_spacing", "Label");
 	Ref<StyleBox> style = get_theme_stylebox("normal", "Label");
+	Ref<Font> font = get_theme_font("font");
 	int lines_visible = lines_rid.size();
 
 	if (max_lines_visible >= 0 && lines_visible > max_lines_visible) {
@@ -147,7 +149,7 @@ void Label::_update_visible() {
 	minsize.height = 0;
 	int last_line = MIN(lines_rid.size(), lines_visible + lines_skipped);
 	for (int64_t i = lines_skipped; i < last_line; i++) {
-		minsize.height += TS->shaped_text_get_size(lines_rid[i]).y + line_spacing;
+		minsize.height += TS->shaped_text_get_size(lines_rid[i]).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM) + line_spacing;
 		if (minsize.height > (get_size().height - style->get_minimum_size().height + line_spacing)) {
 			break;
 		}
@@ -197,7 +199,7 @@ void Label::_notification(int p_what) {
 
 		// Get number of lines to fit to the height.
 		for (int64_t i = lines_skipped; i < lines_rid.size(); i++) {
-			total_h += TS->shaped_text_get_size(lines_rid[i]).y + line_spacing;
+			total_h += TS->shaped_text_get_size(lines_rid[i]).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM) + line_spacing;
 			if (total_h > (get_size().height - style->get_minimum_size().height + line_spacing)) {
 				break;
 			}
@@ -213,7 +215,7 @@ void Label::_notification(int p_what) {
 		// Get real total height.
 		total_h = 0;
 		for (int64_t i = lines_skipped; i < last_line; i++) {
-			total_h += TS->shaped_text_get_size(lines_rid[i]).y + line_spacing;
+			total_h += TS->shaped_text_get_size(lines_rid[i]).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM) + line_spacing;
 		}
 
 		int vbegin = 0, vsep = 0;
@@ -263,7 +265,7 @@ void Label::_notification(int p_what) {
 		ofs.y = style->get_offset().y + vbegin;
 		for (int i = lines_skipped; i < last_line; i++) {
 			ofs.x = 0;
-			ofs.y += TS->shaped_text_get_ascent(lines_rid[i]);
+			ofs.y += TS->shaped_text_get_ascent(lines_rid[i]) + font->get_spacing(Font::SPACING_TOP);
 			switch (align) {
 				case ALIGN_FILL:
 				case ALIGN_LEFT: {
@@ -337,7 +339,7 @@ void Label::_notification(int p_what) {
 				}
 			}
 
-			ofs.y += TS->shaped_text_get_descent(lines_rid[i]) + vsep + line_spacing;
+			ofs.y += TS->shaped_text_get_descent(lines_rid[i]) + vsep + line_spacing + font->get_spacing(Font::SPACING_BOTTOM);
 		}
 	}
 
@@ -381,12 +383,13 @@ int Label::get_line_count() const {
 }
 
 int Label::get_visible_line_count() const {
+	Ref<Font> font = get_theme_font("font");
 	Ref<StyleBox> style = get_theme_stylebox("normal");
 	int line_spacing = get_theme_constant("line_spacing");
 	int lines_visible = 0;
 	float total_h = 0;
 	for (int64_t i = lines_skipped; i < lines_rid.size(); i++) {
-		total_h += TS->shaped_text_get_size(lines_rid[i]).y + line_spacing;
+		total_h += TS->shaped_text_get_size(lines_rid[i]).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM) + line_spacing;
 		if (total_h > (get_size().height - style->get_minimum_size().height + line_spacing)) {
 			break;
 		}

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -251,8 +251,10 @@ void Label::_notification(int p_what) {
 		if (percent_visible < 1) {
 			int total_glyphs = 0;
 			for (int i = lines_skipped; i < last_line; i++) {
-				const Vector<TextServer::Glyph> glyphs = TS->shaped_text_get_glyphs(lines_rid[i]);
-				for (int j = 0; j < glyphs.size(); j++) {
+				const Vector<TextServer::Glyph> visual = TS->shaped_text_get_glyphs(lines_rid[i]);
+				const TextServer::Glyph *glyphs = visual.ptr();
+				int gl_size = visual.size();
+				for (int j = 0; j < gl_size; j++) {
 					if ((glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
 						total_glyphs++;
 					}
@@ -287,11 +289,13 @@ void Label::_notification(int p_what) {
 				} break;
 			}
 
-			const Vector<TextServer::Glyph> glyphs = TS->shaped_text_get_glyphs(lines_rid[i]);
+			const Vector<TextServer::Glyph> visual = TS->shaped_text_get_glyphs(lines_rid[i]);
+			const TextServer::Glyph *glyphs = visual.ptr();
+			int gl_size = visual.size();
 
 			float x = ofs.x;
 			int outlines_drawn = glyhps_drawn;
-			for (int j = 0; j < glyphs.size(); j++) {
+			for (int j = 0; j < gl_size; j++) {
 				for (int k = 0; k < glyphs[j].repeat; k++) {
 					if (glyphs[j].font_rid != RID()) {
 						if (font_color_shadow.a > 0) {
@@ -320,7 +324,7 @@ void Label::_notification(int p_what) {
 			}
 			ofs.x = x;
 
-			for (int j = 0; j < glyphs.size(); j++) {
+			for (int j = 0; j < gl_size; j++) {
 				for (int k = 0; k < glyphs[j].repeat; k++) {
 					if (glyphs[j].font_rid != RID()) {
 						TS->font_draw_glyph(glyphs[j].font_rid, ci, glyphs[j].font_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off), glyphs[j].index, font_color);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -834,11 +834,13 @@ void LineEdit::_notification(int p_what) {
 					RenderingServer::get_singleton()->canvas_item_add_rect(ci, rect, selection_color);
 				}
 			}
-			const Vector<TextServer::Glyph> glyphs = TS->shaped_text_get_glyphs(text_rid);
+			const Vector<TextServer::Glyph> visual = TS->shaped_text_get_glyphs(text_rid);
+			const TextServer::Glyph *glyphs = visual.ptr();
+			int gl_size = visual.size();
 
 			// Draw text.
 			ofs.y += TS->shaped_text_get_ascent(text_rid);
-			for (int i = 0; i < glyphs.size(); i++) {
+			for (int i = 0; i < gl_size; i++) {
 				bool selected = selection.enabled && glyphs[i].start >= selection.begin && glyphs[i].end <= selection.end;
 				for (int j = 0; j < glyphs[i].repeat; j++) {
 					if (ceil(ofs.x) >= x_ofs && (ofs.x + glyphs[i].advance) <= ofs_max) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -841,7 +841,7 @@ void LineEdit::_notification(int p_what) {
 			for (int i = 0; i < glyphs.size(); i++) {
 				bool selected = selection.enabled && glyphs[i].start >= selection.begin && glyphs[i].end <= selection.end;
 				for (int j = 0; j < glyphs[i].repeat; j++) {
-					if (ceil(ofs.x) >= x_ofs && floor(ofs.x + glyphs[i].advance) <= ofs_max) {
+					if (ceil(ofs.x) >= x_ofs && (ofs.x + glyphs[i].advance) <= ofs_max) {
 						if (glyphs[i].font_rid != RID()) {
 							TS->font_draw_glyph(glyphs[i].font_rid, ci, glyphs[i].font_size, ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, selected ? font_color_selected : font_color);
 						} else if ((glyphs[i].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -732,6 +732,7 @@ void LineEdit::_notification(int p_what) {
 				style = get_theme_stylebox("read_only");
 				draw_caret = false;
 			}
+			Ref<Font> font = get_theme_font("font");
 
 			style->draw(ci, Rect2(Point2(), size));
 
@@ -742,7 +743,7 @@ void LineEdit::_notification(int p_what) {
 			int x_ofs = 0;
 			bool using_placeholder = text.empty() && ime_text.empty();
 			float text_width = TS->shaped_text_get_size(text_rid).x;
-			float text_height = TS->shaped_text_get_size(text_rid).y;
+			float text_height = TS->shaped_text_get_size(text_rid).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM);
 
 			switch (align) {
 				case ALIGN_FILL:
@@ -1570,7 +1571,7 @@ Size2 LineEdit::get_minimum_size() const {
 		min_size.width = MAX(min_size.width, full_width + space_size);
 	}
 
-	min_size.height = MAX(TS->shaped_text_get_size(text_rid).y, font->get_height(font_size));
+	min_size.height = MAX(TS->shaped_text_get_size(text_rid).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM), font->get_height(font_size));
 
 	// Take icons into account.
 	bool using_placeholder = text.empty() && ime_text.empty();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1141,7 +1141,7 @@ void TextEdit::_notification(int p_what) {
 
 					// Draw line.
 					RID rid = ldata->get_line_rid(line_wrap_index);
-					float text_height = TS->shaped_text_get_size(rid).y;
+					float text_height = TS->shaped_text_get_size(rid).y + cache.font->get_spacing(Font::SPACING_TOP) + cache.font->get_spacing(Font::SPACING_BOTTOM);
 
 					if (rtl) {
 						char_margin = size.width - char_margin - TS->shaped_text_get_size(rid).x;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1240,10 +1240,13 @@ void TextEdit::_notification(int p_what) {
 
 					ofs_y += (row_height - text_height) / 2;
 
-					const Vector<TextServer::Glyph> glyphs = TS->shaped_text_get_glyphs(rid);
+					const Vector<TextServer::Glyph> visual = TS->shaped_text_get_glyphs(rid);
+					const TextServer::Glyph *glyphs = visual.ptr();
+					int gl_size = visual.size();
+
 					ofs_y += ldata->get_line_ascent(line_wrap_index);
 					float char_ofs = 0.f;
-					for (int j = 0; j < glyphs.size(); j++) {
+					for (int j = 0; j < gl_size; j++) {
 						if (color_map.has(glyphs[j].start)) {
 							current_color = color_map[glyphs[j].start].get("color");
 							if (readonly && current_color.a > cache.font_color_readonly.a) {

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -595,41 +595,41 @@ Dictionary Font::get_feature_list() const {
 float Font::get_height(int p_size) const {
 	float ret = 0.f;
 	for (int i = 0; i < data.size(); i++) {
-		ret += data[i]->get_height(p_size);
+		ret = MAX(ret, data[i]->get_height(p_size));
 	}
-	return (ret / data.size()) + spacing_top + spacing_bottom;
+	return ret + spacing_top + spacing_bottom;
 }
 
 float Font::get_ascent(int p_size) const {
 	float ret = 0.f;
 	for (int i = 0; i < data.size(); i++) {
-		ret += data[i]->get_ascent(p_size);
+		ret = MAX(ret, data[i]->get_ascent(p_size));
 	}
-	return (ret / data.size()) + spacing_top;
+	return ret + spacing_top;
 }
 
 float Font::get_descent(int p_size) const {
 	float ret = 0.f;
 	for (int i = 0; i < data.size(); i++) {
-		ret += data[i]->get_descent(p_size);
+		ret = MAX(ret, data[i]->get_descent(p_size));
 	}
-	return (ret / data.size()) + spacing_bottom;
+	return ret + spacing_bottom;
 }
 
 float Font::get_underline_position(int p_size) const {
 	float ret = 0.f;
 	for (int i = 0; i < data.size(); i++) {
-		ret += data[i]->get_underline_position(p_size);
+		ret = MAX(ret, data[i]->get_underline_position(p_size));
 	}
-	return (ret / data.size());
+	return ret;
 }
 
 float Font::get_underline_thickness(int p_size) const {
 	float ret = 0.f;
 	for (int i = 0; i < data.size(); i++) {
-		ret += data[i]->get_underline_thickness(p_size);
+		ret = MAX(ret, data[i]->get_underline_thickness(p_size));
 	}
-	return (ret / data.size());
+	return ret;
 }
 
 int Font::get_spacing(int p_type) const {

--- a/scene/resources/text_line.h
+++ b/scene/resources/text_line.h
@@ -40,6 +40,8 @@ class TextLine : public Reference {
 	GDCLASS(TextLine, Reference);
 
 	RID rid;
+	int spacing_top = 0;
+	int spacing_bottom = 0;
 
 	bool dirty = true;
 

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -41,6 +41,8 @@ class TextParagraph : public Reference {
 
 	RID rid;
 	Vector<RID> lines;
+	int spacing_top = 0;
+	int spacing_bottom = 0;
 
 	bool dirty_lines = true;
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -554,14 +554,18 @@ Vector<Vector2i> TextServer::shaped_text_get_line_breaks_adv(RID p_shaped, const
 	int line_start = MAX(p_start, range.x);
 	int last_safe_break = -1;
 	int chunk = 0;
-	for (int i = 0; i < logical.size(); i++) {
-		if (logical[i].start < p_start) {
+
+	int l_size = logical.size();
+	const Glyph *l_gl = logical.ptr();
+
+	for (int i = 0; i < l_size; i++) {
+		if (l_gl[i].start < p_start) {
 			continue;
 		}
-		if (logical[i].count > 0) {
-			if ((p_width[chunk] > 0) && (width + logical[i].advance > p_width[chunk]) && (last_safe_break >= 0)) {
-				lines.push_back(Vector2i(line_start, logical[last_safe_break].end));
-				line_start = logical[last_safe_break].end;
+		if (l_gl[i].count > 0) {
+			if ((p_width[chunk] > 0) && (width + l_gl[i].advance > p_width[chunk]) && (last_safe_break >= 0)) {
+				lines.push_back(Vector2i(line_start, l_gl[last_safe_break].end));
+				line_start = l_gl[last_safe_break].end;
 				i = last_safe_break;
 				last_safe_break = -1;
 				width = 0;
@@ -575,9 +579,9 @@ Vector<Vector2i> TextServer::shaped_text_get_line_breaks_adv(RID p_shaped, const
 				continue;
 			}
 			if ((p_break_flags & BREAK_MANDATORY) == BREAK_MANDATORY) {
-				if ((logical[i].flags & GRAPHEME_IS_BREAK_HARD) == GRAPHEME_IS_BREAK_HARD) {
-					lines.push_back(Vector2i(line_start, logical[i].end));
-					line_start = logical[i].end;
+				if ((l_gl[i].flags & GRAPHEME_IS_BREAK_HARD) == GRAPHEME_IS_BREAK_HARD) {
+					lines.push_back(Vector2i(line_start, l_gl[i].end));
+					line_start = l_gl[i].end;
 					last_safe_break = -1;
 					width = 0;
 					chunk = 0;
@@ -588,7 +592,7 @@ Vector<Vector2i> TextServer::shaped_text_get_line_breaks_adv(RID p_shaped, const
 				}
 			}
 			if ((p_break_flags & BREAK_WORD_BOUND) == BREAK_WORD_BOUND) {
-				if ((logical[i].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT) {
+				if ((l_gl[i].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT) {
 					last_safe_break = i;
 				}
 			}
@@ -596,10 +600,10 @@ Vector<Vector2i> TextServer::shaped_text_get_line_breaks_adv(RID p_shaped, const
 				last_safe_break = i;
 			}
 		}
-		width += logical[i].advance;
+		width += l_gl[i].advance;
 	}
 
-	if (logical.size() > 0) {
+	if (l_size > 0) {
 		lines.push_back(Vector2i(line_start, range.y));
 	} else {
 		lines.push_back(Vector2i(0, 0));
@@ -618,30 +622,34 @@ Vector<Vector2i> TextServer::shaped_text_get_line_breaks(RID p_shaped, float p_w
 	float width = 0.f;
 	int line_start = MAX(p_start, range.x);
 	int last_safe_break = -1;
-	for (int i = 0; i < logical.size(); i++) {
-		if (logical[i].start < p_start) {
+
+	int l_size = logical.size();
+	const Glyph *l_gl = logical.ptr();
+
+	for (int i = 0; i < l_size; i++) {
+		if (l_gl[i].start < p_start) {
 			continue;
 		}
-		if (logical[i].count > 0) {
-			if ((p_width > 0) && (width + logical[i].advance > p_width) && (last_safe_break >= 0)) {
-				lines.push_back(Vector2i(line_start, logical[last_safe_break].end));
-				line_start = logical[last_safe_break].end;
+		if (l_gl[i].count > 0) {
+			if ((p_width > 0) && (width + l_gl[i].advance > p_width) && (last_safe_break >= 0)) {
+				lines.push_back(Vector2i(line_start, l_gl[last_safe_break].end));
+				line_start = l_gl[last_safe_break].end;
 				i = last_safe_break;
 				last_safe_break = -1;
 				width = 0;
 				continue;
 			}
 			if ((p_break_flags & BREAK_MANDATORY) == BREAK_MANDATORY) {
-				if ((logical[i].flags & GRAPHEME_IS_BREAK_HARD) == GRAPHEME_IS_BREAK_HARD) {
-					lines.push_back(Vector2i(line_start, logical[i].end));
-					line_start = logical[i].end;
+				if ((l_gl[i].flags & GRAPHEME_IS_BREAK_HARD) == GRAPHEME_IS_BREAK_HARD) {
+					lines.push_back(Vector2i(line_start, l_gl[i].end));
+					line_start = l_gl[i].end;
 					last_safe_break = -1;
 					width = 0;
 					continue;
 				}
 			}
 			if ((p_break_flags & BREAK_WORD_BOUND) == BREAK_WORD_BOUND) {
-				if ((logical[i].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT) {
+				if ((l_gl[i].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT) {
 					last_safe_break = i;
 				}
 			}
@@ -649,10 +657,10 @@ Vector<Vector2i> TextServer::shaped_text_get_line_breaks(RID p_shaped, float p_w
 				last_safe_break = i;
 			}
 		}
-		width += logical[i].advance;
+		width += l_gl[i].advance;
 	}
 
-	if (logical.size() > 0) {
+	if (l_size > 0) {
 		if (lines.size() == 0 || lines[lines.size() - 1].y < range.y) {
 			lines.push_back(Vector2i(line_start, range.y));
 		}
@@ -671,15 +679,19 @@ Vector<Vector2i> TextServer::shaped_text_get_word_breaks(RID p_shaped) const {
 	const Vector2i &range = shaped_text_get_range(p_shaped);
 
 	int word_start = range.x;
-	for (int i = 0; i < logical.size(); i++) {
-		if (logical[i].count > 0) {
-			if ((logical[i].flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE) {
-				words.push_back(Vector2i(word_start, logical[i].end - 1));
-				word_start = logical[i].end;
+
+	int l_size = logical.size();
+	const Glyph *l_gl = logical.ptr();
+
+	for (int i = 0; i < l_size; i++) {
+		if (l_gl[i].count > 0) {
+			if ((l_gl[i].flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE) {
+				words.push_back(Vector2i(word_start, l_gl[i].end - 1));
+				word_start = l_gl[i].end;
 			}
 		}
 	}
-	if (logical.size() > 0) {
+	if (l_size > 0) {
 		words.push_back(Vector2i(word_start, range.y));
 	}
 
@@ -688,7 +700,7 @@ Vector<Vector2i> TextServer::shaped_text_get_word_breaks(RID p_shaped) const {
 
 void TextServer::shaped_text_get_carets(RID p_shaped, int p_position, Rect2 &p_leading_caret, Direction &p_leading_dir, Rect2 &p_trailing_caret, Direction &p_trailing_dir) const {
 	Vector<Rect2> carets;
-	const Vector<TextServer::Glyph> glyphs = shaped_text_get_glyphs(p_shaped);
+	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
 	TextServer::Orientation orientation = shaped_text_get_orientation(p_shaped);
 	const Vector2 &range = shaped_text_get_range(p_shaped);
 	float ascent = shaped_text_get_ascent(p_shaped);
@@ -698,7 +710,11 @@ void TextServer::shaped_text_get_carets(RID p_shaped, int p_position, Rect2 &p_l
 	float off = 0.0f;
 	p_leading_dir = DIRECTION_AUTO;
 	p_trailing_dir = DIRECTION_AUTO;
-	for (int i = 0; i < glyphs.size(); i++) {
+
+	int v_size = visual.size();
+	const Glyph *glyphs = visual.ptr();
+
+	for (int i = 0; i < v_size; i++) {
 		if (glyphs[i].count > 0) {
 			// Caret before grapheme (top / left).
 			if (p_position == glyphs[i].start && ((glyphs[i].flags & GRAPHEME_IS_VIRTUAL) != GRAPHEME_IS_VIRTUAL)) {
@@ -831,7 +847,7 @@ void TextServer::shaped_text_get_carets(RID p_shaped, int p_position, Rect2 &p_l
 }
 
 TextServer::Direction TextServer::shaped_text_get_dominant_direciton_in_range(RID p_shaped, int p_start, int p_end) const {
-	const Vector<TextServer::Glyph> glyphs = shaped_text_get_glyphs(p_shaped);
+	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
 
 	if (p_start == p_end) {
 		return DIRECTION_AUTO;
@@ -843,7 +859,10 @@ TextServer::Direction TextServer::shaped_text_get_dominant_direciton_in_range(RI
 	int rtl = 0;
 	int ltr = 0;
 
-	for (int i = 0; i < glyphs.size(); i++) {
+	int v_size = visual.size();
+	const Glyph *glyphs = visual.ptr();
+
+	for (int i = 0; i < v_size; i++) {
 		if ((glyphs[i].end > start) && (glyphs[i].start < end)) {
 			if (glyphs[i].count > 0) {
 				if ((glyphs[i].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
@@ -865,7 +884,7 @@ TextServer::Direction TextServer::shaped_text_get_dominant_direciton_in_range(RI
 
 Vector<Vector2> TextServer::shaped_text_get_selection(RID p_shaped, int p_start, int p_end) const {
 	Vector<Vector2> ranges;
-	const Vector<TextServer::Glyph> glyphs = shaped_text_get_glyphs(p_shaped);
+	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
 
 	if (p_start == p_end) {
 		return ranges;
@@ -874,8 +893,11 @@ Vector<Vector2> TextServer::shaped_text_get_selection(RID p_shaped, int p_start,
 	int start = MIN(p_start, p_end);
 	int end = MAX(p_start, p_end);
 
+	int v_size = visual.size();
+	const Glyph *glyphs = visual.ptr();
+
 	float off = 0.0f;
-	for (int i = 0; i < glyphs.size(); i++) {
+	for (int i = 0; i < v_size; i++) {
 		for (int k = 0; k < glyphs[i].repeat; k++) {
 			if (glyphs[i].count > 0 && glyphs[i].index != 0) {
 				if (glyphs[i].start < end && glyphs[i].end > start) {
@@ -951,11 +973,15 @@ Vector<Vector2> TextServer::shaped_text_get_selection(RID p_shaped, int p_start,
 }
 
 int TextServer::shaped_text_hit_test_grapheme(RID p_shaped, float p_coords) const {
-	const Vector<TextServer::Glyph> glyphs = shaped_text_get_glyphs(p_shaped);
+	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
 
 	// Exact grapheme hit test, return -1 if missed.
 	float off = 0.0f;
-	for (int i = 0; i < glyphs.size(); i++) {
+
+	int v_size = visual.size();
+	const Glyph *glyphs = visual.ptr();
+
+	for (int i = 0; i < v_size; i++) {
 		for (int j = 0; j < glyphs[i].repeat; j++) {
 			if (p_coords >= off && p_coords < off + glyphs[i].advance) {
 				return i;
@@ -967,13 +993,16 @@ int TextServer::shaped_text_hit_test_grapheme(RID p_shaped, float p_coords) cons
 }
 
 int TextServer::shaped_text_hit_test_position(RID p_shaped, float p_coords) const {
-	const Vector<TextServer::Glyph> glyphs = shaped_text_get_glyphs(p_shaped);
+	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
+
+	int v_size = visual.size();
+	const Glyph *glyphs = visual.ptr();
 
 	// Cursor placement hit test.
 
 	// Place caret to the left of the leftmost grapheme, or to position 0 if string is empty.
 	if (p_coords <= 0) {
-		if (glyphs.size() > 0) {
+		if (v_size > 0) {
 			if ((glyphs[0].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
 				return glyphs[0].end;
 			} else {
@@ -986,11 +1015,11 @@ int TextServer::shaped_text_hit_test_position(RID p_shaped, float p_coords) cons
 
 	// Place caret to the right of the rightmost grapheme, or to position 0 if string is empty.
 	if (p_coords >= shaped_text_get_width(p_shaped)) {
-		if (glyphs.size() > 0) {
-			if ((glyphs[glyphs.size() - 1].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
-				return glyphs[glyphs.size() - 1].start;
+		if (v_size > 0) {
+			if ((glyphs[v_size - 1].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
+				return glyphs[v_size - 1].start;
 			} else {
-				return glyphs[glyphs.size() - 1].end;
+				return glyphs[v_size - 1].end;
 			}
 		} else {
 			return 0;
@@ -998,7 +1027,7 @@ int TextServer::shaped_text_hit_test_position(RID p_shaped, float p_coords) cons
 	}
 
 	float off = 0.0f;
-	for (int i = 0; i < glyphs.size(); i++) {
+	for (int i = 0; i < v_size; i++) {
 		for (int k = 0; k < glyphs[i].repeat; k++) {
 			if (glyphs[i].count > 0) {
 				float advance = 0.f;
@@ -1029,8 +1058,10 @@ int TextServer::shaped_text_hit_test_position(RID p_shaped, float p_coords) cons
 }
 
 int TextServer::shaped_text_next_grapheme_pos(RID p_shaped, int p_pos) {
-	const Vector<TextServer::Glyph> glyphs = shaped_text_get_glyphs(p_shaped);
-	for (int i = 0; i < glyphs.size(); i++) {
+	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
+	int v_size = visual.size();
+	const Glyph *glyphs = visual.ptr();
+	for (int i = 0; i < v_size; i++) {
 		if (p_pos >= glyphs[i].start && p_pos < glyphs[i].end) {
 			return glyphs[i].end;
 		}
@@ -1039,8 +1070,10 @@ int TextServer::shaped_text_next_grapheme_pos(RID p_shaped, int p_pos) {
 }
 
 int TextServer::shaped_text_prev_grapheme_pos(RID p_shaped, int p_pos) {
-	const Vector<TextServer::Glyph> glyphs = shaped_text_get_glyphs(p_shaped);
-	for (int i = 0; i < glyphs.size(); i++) {
+	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
+	int v_size = visual.size();
+	const Glyph *glyphs = visual.ptr();
+	for (int i = 0; i < v_size; i++) {
 		if (p_pos > glyphs[i].start && p_pos <= glyphs[i].end) {
 			return glyphs[i].start;
 		}
@@ -1050,13 +1083,16 @@ int TextServer::shaped_text_prev_grapheme_pos(RID p_shaped, int p_pos) {
 }
 
 void TextServer::shaped_text_draw(RID p_shaped, RID p_canvas, const Vector2 &p_pos, float p_clip_l, float p_clip_r, const Color &p_color) const {
-	const Vector<TextServer::Glyph> glyphs = shaped_text_get_glyphs(p_shaped);
+	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
 	TextServer::Orientation orientation = shaped_text_get_orientation(p_shaped);
 	bool hex_codes = shaped_text_get_preserve_control(p_shaped) || shaped_text_get_preserve_invalid(p_shaped);
 
+	int v_size = visual.size();
+	const Glyph *glyphs = visual.ptr();
+
 	Vector2 ofs = p_pos;
 	// Draw at the baseline.
-	for (int i = 0; i < glyphs.size(); i++) {
+	for (int i = 0; i < v_size; i++) {
 		for (int j = 0; j < glyphs[i].repeat; j++) {
 			if (p_clip_r > 0) {
 				// Clip right / bottom.
@@ -1099,12 +1135,14 @@ void TextServer::shaped_text_draw(RID p_shaped, RID p_canvas, const Vector2 &p_p
 }
 
 void TextServer::shaped_text_draw_outline(RID p_shaped, RID p_canvas, const Vector2 &p_pos, float p_clip_l, float p_clip_r, int p_outline_size, const Color &p_color) const {
-	const Vector<TextServer::Glyph> glyphs = shaped_text_get_glyphs(p_shaped);
+	const Vector<TextServer::Glyph> visual = shaped_text_get_glyphs(p_shaped);
 	TextServer::Orientation orientation = shaped_text_get_orientation(p_shaped);
 
+	int v_size = visual.size();
+	const Glyph *glyphs = visual.ptr();
 	Vector2 ofs = p_pos;
 	// Draw at the baseline.
-	for (int i = 0; i < glyphs.size(); i++) {
+	for (int i = 0; i < v_size; i++) {
 		for (int j = 0; j < glyphs[i].repeat; j++) {
 			if (p_clip_r > 0) {
 				// Clip right / bottom.


### PR DESCRIPTION
- Fixes oversized editor control height (default editor spacing is negative) and control size changing when text is set.

Fixes #43966

- Round glyph offsets and advances to make small size text sharper.

Fixes #43967

- Fixes bitmap font leak.

Fixes #44002

- Fixes missing text buffer init in `ItemList::add_icon_item`.

Fixes #44049

- Some optimizations.