### PR TITLE
Buttons: Don't use deprecated set_enabled_focus_mode

### DIFF
--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -140,6 +140,6 @@ void LinkButton::_bind_methods() {
 
 LinkButton::LinkButton() {
 	underline_mode = UNDERLINE_MODE_ALWAYS;
-	set_enabled_focus_mode(FOCUS_NONE);
+	set_focus_mode(FOCUS_NONE);
 	set_default_cursor_shape(CURSOR_POINTING_HAND);
 }

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -129,7 +129,7 @@ MenuButton::MenuButton() {
 	set_flat(true);
 	set_toggle_mode(true);
 	set_disable_shortcuts(false);
-	set_enabled_focus_mode(FOCUS_NONE);
+	set_focus_mode(FOCUS_NONE);
 	set_process_unhandled_key_input(true);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 


### PR DESCRIPTION
It's better to use the equivalent, non-deprecated API.
Follow-up to #43974.

CC @FIF15, I missed that in the review.