### PR TITLE
[HTML5] HiDPI, emscripten fixes

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -885,6 +885,9 @@ public:
 	void render_target_disable_clear_request(RID p_render_target) override {}
 	void render_target_do_clear_request(RID p_render_target) override {}
 
+	void render_target_set_sdf_size_and_scale(RID p_render_target, RS::ViewportSDFOversize p_size, RS::ViewportSDFScale p_scale) override {}
+	Rect2i render_target_get_sdf_rect(RID p_render_target) const override { return Rect2i(); }
+
 	RS::InstanceType get_base_type(RID p_rid) const override {
 		if (mesh_owner.owns(p_rid)) {
 			return RS::INSTANCE_MESH;
@@ -943,7 +946,7 @@ public:
 	PolygonID request_polygon(const Vector<int> &p_indices, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs = Vector<Point2>(), const Vector<int> &p_bones = Vector<int>(), const Vector<float> &p_weights = Vector<float>()) override { return 0; }
 	void free_polygon(PolygonID p_polygon) override {}
 
-	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel) override {}
+	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) override {}
 	void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) override {}
 
 	RID light_create() override { return RID(); }
@@ -952,8 +955,9 @@ public:
 	void light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders) override {}
 	void light_update_directional_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_cull_distance, const Rect2 &p_clip_rect, LightOccluderInstance *p_occluders) override {}
 
+	void render_sdf(RID p_render_target, LightOccluderInstance *p_occluders) override {}
 	RID occluder_polygon_create() override { return RID(); }
-	void occluder_polygon_set_shape_as_lines(RID p_occluder, const Vector<Vector2> &p_lines) override {}
+	void occluder_polygon_set_shape(RID p_occluder, const Vector<Vector2> &p_points, bool p_closed) override {}
 	void occluder_polygon_set_cull_mode(RID p_occluder, RS::CanvasOccluderPolygonCullMode p_mode) override {}
 	void set_shadow_texture_size(int p_size) override {}
 

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -948,8 +948,8 @@ void DisplayServerJavaScript::window_set_size(const Size2i p_size, WindowID p_wi
 	last_width = p_size.x;
 	last_height = p_size.y;
 	double scale = godot_js_display_pixel_ratio_get();
-	emscripten_set_canvas_element_size(canvas_id, p_size.x * scale, p_size.y * scale);
-	emscripten_set_element_css_size(canvas_id, p_size.x, p_size.y);
+	emscripten_set_canvas_element_size(canvas_id, p_size.x, p_size.y);
+	emscripten_set_element_css_size(canvas_id, p_size.x / scale, p_size.y / scale);
 }
 
 Size2i DisplayServerJavaScript::window_get_size(WindowID p_window) const {

--- a/platform/javascript/js/libs/library_godot_os.js
+++ b/platform/javascript/js/libs/library_godot_os.js
@@ -200,7 +200,7 @@ const GodotFS = {
 				}
 				FS.mkdirTree(dir);
 			}
-			FS.writeFile(path, new Uint8Array(buffer), { 'flags': 'wx+' });
+			FS.writeFile(path, new Uint8Array(buffer));
 		},
 	},
 };


### PR DESCRIPTION
In this PR:

- Usual `DummyRasterizer` sync.
- Remove file flags from writeFile in setup. (removed in emscripten `2.0.9` and broke the generated build, see https://github.com/emscripten-core/emscripten/pull/12671).
- Fix broken layout on load in HiDPI screens.
  This was caused by the devicePixelRatio being applied twice, once by the HTML code, once by the OS code.
  More specifically, OS.get_window_size() would return the canvas element size, while OS.set_window_size() would set the element size to the specified value times the devicePixelRatio.
  Calling OS.set_window_size(OS.get_window_size()) would reapply the devicePixelRatio every time.
  This commit changes the behaviour so that OS.set_window_size() do not apply the devicePixelRatio to the canvas element size, by it divides the CSS size instead.

Fixes #43845 .