### PR TITLE
GDScript: Don't construct ref values in compiler

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1709,7 +1709,27 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool is_awa
 				call_type.native_type = function_name; // "Object".
 			}
 
-			if (all_is_constant) {
+			bool safe_to_fold = true;
+			switch (builtin_type) {
+				// Those are stored by reference so not suited for compile-time construction.
+				// Because in this case they would be the same reference in all constructed values.
+				case Variant::OBJECT:
+				case Variant::PACKED_BYTE_ARRAY:
+				case Variant::PACKED_INT32_ARRAY:
+				case Variant::PACKED_INT64_ARRAY:
+				case Variant::PACKED_FLOAT32_ARRAY:
+				case Variant::PACKED_FLOAT64_ARRAY:
+				case Variant::PACKED_STRING_ARRAY:
+				case Variant::PACKED_VECTOR2_ARRAY:
+				case Variant::PACKED_VECTOR3_ARRAY:
+				case Variant::PACKED_COLOR_ARRAY:
+					safe_to_fold = false;
+					break;
+				default:
+					break;
+			}
+
+			if (all_is_constant && safe_to_fold) {
 				// Construct here.
 				Vector<const Variant *> args;
 				for (int i = 0; i < p_call->arguments.size(); i++) {


### PR DESCRIPTION
Values that are passed by reference are not suited for being constructed at compile time because in this case they would be shared across all the construction statements.

Fix #43983.
