### PR TITLE
Fix editor locked by generating preview of dynamic font

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -834,7 +834,9 @@ bool EditorFontPreviewPlugin::handles(const String &p_type) const {
 
 Ref<Texture> EditorFontPreviewPlugin::generate_from_path(const String &p_path, const Size2 &p_size) const {
 
-	RES res = ResourceLoader::load(p_path);
+	Ref<ResourceInteractiveLoader> ril = ResourceLoader::load_interactive(p_path);
+	ril.ptr()->wait();
+	RES res = ril.ptr()->get_resource();
 	Ref<DynamicFont> sampled_font;
 	if (res->is_class("DynamicFont")) {
 		sampled_font = res->duplicate();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fix #42785