### PR TITLE
Fix VariantInternal initialization and setting of object

### DIFF
--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -777,18 +777,23 @@ String Variant::get_constructor_argument_name(Variant::Type p_type, int p_constr
 	return construct_data[p_type][p_constructor].arg_names[p_argument];
 }
 
-void VariantInternal::object_assign(Variant *v, const Variant *o) {
-	if (o->_get_obj().obj && o->_get_obj().id.is_reference()) {
-		Reference *reference = static_cast<Reference *>(o->_get_obj().obj);
-		if (!reference->reference()) {
-			v->_get_obj().obj = nullptr;
-			v->_get_obj().id = ObjectID();
-			return;
+void VariantInternal::object_assign(Variant *v, const Object *o) {
+	if (o) {
+		if (o->is_reference()) {
+			Reference *reference = const_cast<Reference *>(static_cast<const Reference *>(o));
+			if (!reference->init_ref()) {
+				v->_get_obj().obj = nullptr;
+				v->_get_obj().id = ObjectID();
+				return;
+			}
 		}
-	}
 
-	v->_get_obj().obj = const_cast<Object *>(o->_get_obj().obj);
-	v->_get_obj().id = o->_get_obj().id;
+		v->_get_obj().obj = const_cast<Object *>(o);
+		v->_get_obj().id = o->get_instance_id();
+	} else {
+		v->_get_obj().obj = nullptr;
+		v->_get_obj().id = ObjectID();
+	}
 }
 
 void Variant::get_constructor_list(Type p_type, List<MethodInfo> *r_list) {

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -100,18 +100,11 @@ public:
 			case Variant::PACKED_COLOR_ARRAY:
 				init_color_array(v);
 				break;
+			case Variant::OBJECT:
+				object_assign_null(v);
+				break;
 			default:
 				break;
-		}
-	}
-
-	_FORCE_INLINE_ static void set_object(Variant *v, Object *obj) {
-		if (obj) {
-			v->_get_obj().obj = obj;
-			v->_get_obj().id = obj->get_instance_id();
-		} else {
-			v->_get_obj().obj = nullptr;
-			v->_get_obj().id = ObjectID();
 		}
 	}
 
@@ -285,7 +278,11 @@ public:
 		v->clear();
 	}
 
-	static void object_assign(Variant *v, const Variant *o); //needs to use reference, do away
+	static void object_assign(Variant *v, const Object *o); // Needs Reference, so it's implemented elsewhere.
+
+	_FORCE_INLINE_ static void object_assign(Variant *v, const Variant *o) {
+		object_assign(v, o->_get_obj().obj);
+	}
 
 	_FORCE_INLINE_ static void object_assign_null(Variant *v) {
 		v->_get_obj().obj = nullptr;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1653,7 +1653,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				VariantInternal::initialize(ret, Variant::OBJECT);
 				Object **ret_opaque = VariantInternal::get_object(ret);
 				method->ptrcall(base_obj, argptrs, ret_opaque);
-				VariantInternal::set_object(ret, *ret_opaque);
+				VariantInternal::object_assign(ret, *ret_opaque); // Set so ID is correct too.
 
 #ifdef DEBUG_ENABLED
 				if (GDScriptLanguage::get_singleton()->profiling) {


### PR DESCRIPTION
- Initialize Object pointer to nullptr so it's not used by mistake.
- When setting an Object check if it's a reference so refcounting works as intended.

Fix #43941
Fix #43851