### PR TITLE
Add built-in types to autocompletion list

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -688,7 +688,20 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 	}
 }
 
+static void _find_built_in_variants(Map<String, ScriptCodeCompletionOption> &r_result, bool only_types = false) {
+	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+		if (only_types && Variant::Type(i) == Variant::Type::NIL) {
+			continue;
+		}
+		ScriptCodeCompletionOption option(Variant::get_type_name(Variant::Type(i)), ScriptCodeCompletionOption::KIND_CLASS);
+		r_result.insert(option.display, option);
+	}
+}
+
 static void _list_available_types(bool p_inherit_only, GDScriptParser::CompletionContext &p_context, Map<String, ScriptCodeCompletionOption> &r_result) {
+	// Built-in Variant Types
+	_find_built_in_variants(r_result, true);
+
 	List<StringName> native_types;
 	ClassDB::get_class_list(&native_types);
 	for (const List<StringName>::Element *E = native_types.front(); E != nullptr; E = E->next()) {
@@ -1041,17 +1054,7 @@ static void _find_identifiers(GDScriptParser::CompletionContext &p_context, bool
 		return;
 	}
 
-	static const char *_type_names[Variant::VARIANT_MAX] = {
-		"null", "bool", "int", "float", "String", "StringName", "Vector2", "Vector2i", "Rect2", "Rect2i", "Vector3", "Vector3i", "Transform2D", "Plane", "Quat", "AABB", "Basis", "Transform",
-		"Color", "NodePath", "RID", "Signal", "Callable", "Object", "Dictionary", "Array", "PackedByteArray", "PackedInt32Array", "PackedInt64Array", "PackedFloat32Array", "PackedFloat64Array", "PackedStringArray",
-		"PackedVector2Array", "PackedVector3Array", "PackedColorArray"
-	};
-	static_assert((sizeof(_type_names) / sizeof(*_type_names)) == Variant::VARIANT_MAX, "Completion for builtin types is incomplete");
-
-	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-		ScriptCodeCompletionOption option(_type_names[i], ScriptCodeCompletionOption::KIND_CLASS);
-		r_result.insert(option.display, option);
-	}
+	_find_built_in_variants(r_result);
 
 	static const char *_keywords[] = {
 		"and", "in", "not", "or", "false", "PI", "TAU", "INF", "NAN", "self", "true", "as", "assert",


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Adds built-in types to autocompletion list for variant and function return type hint completion, and cast type completion.
The issue is mentioned in https://github.com/godotengine/godot/issues/40933.
I extracted, replaced and changed code that added variant completion options, in the `gdscript_editor.cpp` file.  
![1](https://user-images.githubusercontent.com/25207137/100671938-861fb000-3361-11eb-985f-0d55416fe4a4.PNG)
![3](https://user-images.githubusercontent.com/25207137/100671945-8750dd00-3361-11eb-96f2-a40750bddab9.PNG)
![2](https://user-images.githubusercontent.com/25207137/100671942-8750dd00-3361-11eb-85e5-d23ec911c18d.PNG)
