### PR TITLE
Update page value properly of ScrollContainer

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -431,6 +431,7 @@ void ScrollContainer::update_scrollbars() {
 
 	v_scroll->set_max(min.height);
 	if (hide_scroll_v) {
+		v_scroll->set_page(size.height);
 		v_scroll->hide();
 		scroll.y = 0;
 	} else {
@@ -446,6 +447,7 @@ void ScrollContainer::update_scrollbars() {
 
 	h_scroll->set_max(min.width);
 	if (hide_scroll_h) {
+		h_scroll->set_page(size.width);
 		h_scroll->hide();
 		scroll.x = 0;
 	} else {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
with my further test,
when child node size changed but still it's smaller than ScrollContainer,
it scrolls 1 page by dragging with touch (or Emulate touch from mouse).

_follow up #43833_