### PR TITLE
Remove useless check in GDScript

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -475,11 +475,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 
 		if (p_instance) {
-			if (p_instance->base_ref && static_cast<Reference *>(p_instance->owner)->is_referenced()) {
-				self = REF(static_cast<Reference *>(p_instance->owner));
-			} else {
-				self = p_instance->owner;
-			}
+			self = p_instance->owner;
 			script = p_instance->script.ptr();
 		} else {
 			script = _script;


### PR DESCRIPTION
The removed check was adding a protection for the case where a `Reference` has not yet got its reference count initialized and a script is called on it. That would cause the object to be released after the call. The removed code was constructing the `Variant` via the `Object` constructor so it didn't deal with the reference count and so the release was prevented.

However, `Variant` no longer works that way so that check was useless. Now it's just illegal to run GDScript on a Reference whose reference count has not been initialized.

**NOTE:** Separate version is going to be submitted for 3.2.

---
**This code is generously donated by IMVU.**