### PR TITLE
Fix few bugs in visual shader expressions

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1454,6 +1454,17 @@ void VisualShaderEditor::_remove_output_port(int p_node, int p_port) {
 		}
 	}
 
+	int preview_port = node->get_output_port_for_preview();
+	if (preview_port != -1) {
+		if (preview_port == p_port) {
+			undo_redo->add_do_method(node.ptr(), "set_output_port_for_preview", -1);
+			undo_redo->add_undo_method(node.ptr(), "set_output_port_for_preview", preview_port);
+		} else if (preview_port > p_port) {
+			undo_redo->add_do_method(node.ptr(), "set_output_port_for_preview", preview_port - 1);
+			undo_redo->add_undo_method(node.ptr(), "set_output_port_for_preview", preview_port);
+		}
+	}
+
 	undo_redo->add_do_method(node.ptr(), "remove_output_port", p_port);
 	undo_redo->add_undo_method(node.ptr(), "add_output_port", p_port, (int)node->get_output_port_type(p_port), node->get_output_port_name(p_port));
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2767,8 +2767,10 @@ void VisualShaderNodeGroupBase::remove_input_port(int p_id) {
 	inputs.erase(index, count);
 
 	inputs_strings = inputs.split(";", false);
+	inputs = inputs.substr(0, index);
+
 	for (int i = p_id; i < inputs_strings.size(); i++) {
-		inputs = inputs.replace_first(inputs_strings[i].split(",")[0], itos(i));
+		inputs += inputs_strings[i].replace_first(inputs_strings[i].split(",")[0], itos(i)) + ";";
 	}
 
 	_apply_port_changes();
@@ -2837,8 +2839,10 @@ void VisualShaderNodeGroupBase::remove_output_port(int p_id) {
 	outputs.erase(index, count);
 
 	outputs_strings = outputs.split(";", false);
+	outputs = outputs.substr(0, index);
+
 	for (int i = p_id; i < outputs_strings.size(); i++) {
-		outputs = outputs.replace_first(outputs_strings[i].split(",")[0], itos(i));
+		outputs += outputs_strings[i].replace_first(outputs_strings[i].split(",")[0], itos(i)) + ";";
 	}
 
 	_apply_port_changes();


### PR DESCRIPTION
1) Fixed a type bug when Remove input/output port called:

![bug](https://user-images.githubusercontent.com/3036176/100746608-ff66e380-33f1-11eb-8562-df80c999868b.gif)

2) Fixed a bug when the output port is removed but preview is always switched to next port:

![bug2](https://user-images.githubusercontent.com/3036176/100747070-9e8bdb00-33f2-11eb-9903-1eddec654a79.gif)
 
Now they are correctly switched:

![fix](https://user-images.githubusercontent.com/3036176/100747181-c54a1180-33f2-11eb-83fe-15d1a194acce.gif)
