### PR TITLE
Refactored Mesh internals and formats.

### DIFF
--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -102,6 +102,7 @@ public:
 	virtual String get_resource_type() const = 0;
 	virtual float get_priority() const { return 1.0; }
 	virtual int get_import_order() const { return 0; }
+	virtual int get_format_version() const { return 0; }
 
 	struct ImportOption {
 		PropertyInfo option;

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -615,6 +615,7 @@ int RenderingDeviceVulkan::get_format_vertex_size(DataFormat p_format) {
 		case DATA_FORMAT_B8G8R8A8_SNORM:
 		case DATA_FORMAT_B8G8R8A8_UINT:
 		case DATA_FORMAT_B8G8R8A8_SINT:
+		case DATA_FORMAT_A2B10G10R10_UNORM_PACK32:
 			return 4;
 		case DATA_FORMAT_R16_UNORM:
 		case DATA_FORMAT_R16_SNORM:
@@ -3528,7 +3529,7 @@ RenderingDevice::VertexFormatID RenderingDeviceVulkan::vertex_format_create(cons
 		ERR_FAIL_COND_V(used_locations.has(p_vertex_formats[i].location), INVALID_ID);
 
 		ERR_FAIL_COND_V_MSG(get_format_vertex_size(p_vertex_formats[i].format) == 0, INVALID_ID,
-				"Data format for attachment (" + itos(i) + ") is not valid for a vertex array.");
+				"Data format for attachment (" + itos(i) + "), '" + named_formats[p_vertex_formats[i].format] + "', is not valid for a vertex array.");
 
 		vdcache.bindings[i].binding = i;
 		vdcache.bindings[i].stride = p_vertex_formats[i].stride;

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -844,19 +844,19 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 
 			for (int k = 0; k < vertex_array.size(); k++) {
 				if (normal_src) {
-					surftool->add_normal(vertex_array[k].normal);
+					surftool->set_normal(vertex_array[k].normal);
 					if (binormal_src && tangent_src) {
-						surftool->add_tangent(vertex_array[k].tangent);
+						surftool->set_tangent(vertex_array[k].tangent);
 					}
 				}
 				if (uv_src) {
-					surftool->add_uv(Vector2(vertex_array[k].uv.x, vertex_array[k].uv.y));
+					surftool->set_uv(Vector2(vertex_array[k].uv.x, vertex_array[k].uv.y));
 				}
 				if (uv2_src) {
-					surftool->add_uv2(Vector2(vertex_array[k].uv2.x, vertex_array[k].uv2.y));
+					surftool->set_uv2(Vector2(vertex_array[k].uv2.x, vertex_array[k].uv2.y));
 				}
 				if (color_src) {
-					surftool->add_color(vertex_array[k].color);
+					surftool->set_color(vertex_array[k].color);
 				}
 
 				if (has_weights) {
@@ -876,8 +876,8 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 						}
 					}
 
-					surftool->add_bones(bones);
-					surftool->add_weights(weights);
+					surftool->set_bones(bones);
+					surftool->set_weights(weights);
 				}
 
 				surftool->add_vertex(vertex_array[k].vertex);
@@ -923,7 +923,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 				mr.push_back(a);
 			}
 
-			p_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, d, mr, Dictionary(), p_use_compression ? Mesh::ARRAY_COMPRESS_DEFAULT : 0);
+			p_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, d, mr, Dictionary(), 0);
 
 			if (material.is_valid()) {
 				if (p_use_mesh_material) {

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -970,8 +970,7 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 		return OK;
 	}
 
-	bool compress_vert_data = state.import_flags & IMPORT_USE_COMPRESSION;
-	uint32_t mesh_flags = compress_vert_data ? Mesh::ARRAY_COMPRESS_DEFAULT : 0;
+	uint32_t mesh_flags = 0;
 
 	Array meshes = state.json["meshes"];
 	for (GLTFMeshIndex i = 0; i < meshes.size(); i++) {

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -210,7 +210,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 	bool generate_tangents = p_generate_tangents;
 	Vector3 scale_mesh = p_scale_mesh;
 	Vector3 offset_mesh = p_offset_mesh;
-	int mesh_flags = p_optimize ? Mesh::ARRAY_COMPRESS_DEFAULT : 0;
+	int mesh_flags = 0;
 
 	Vector<Vector3> vertices;
 	Vector<Vector3> normals;
@@ -294,7 +294,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 							norm += normals.size() + 1;
 						}
 						ERR_FAIL_INDEX_V(norm, normals.size(), ERR_FILE_CORRUPT);
-						surf_tool->add_normal(normals[norm]);
+						surf_tool->set_normal(normals[norm]);
 					}
 
 					if (face[idx].size() >= 2 && face[idx][1] != String()) {
@@ -303,7 +303,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 							uv += uvs.size() + 1;
 						}
 						ERR_FAIL_INDEX_V(uv, uvs.size(), ERR_FILE_CORRUPT);
-						surf_tool->add_uv(uvs[uv]);
+						surf_tool->set_uv(uvs[uv]);
 					}
 
 					int vtx = face[idx][0].to_int() - 1;
@@ -471,6 +471,10 @@ String ResourceImporterOBJ::get_save_extension() const {
 
 String ResourceImporterOBJ::get_resource_type() const {
 	return "Mesh";
+}
+
+int ResourceImporterOBJ::get_format_version() const {
+	return 1;
 }
 
 int ResourceImporterOBJ::get_preset_count() const {

--- a/editor/import/resource_importer_obj.h
+++ b/editor/import/resource_importer_obj.h
@@ -54,6 +54,7 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
+	virtual int get_format_version() const override;
 
 	virtual int get_preset_count() const override;
 	virtual String get_preset_name(int p_idx) const override;

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -172,6 +172,10 @@ String ResourceImporterScene::get_resource_type() const {
 	return "PackedScene";
 }
 
+int ResourceImporterScene::get_format_version() const {
+	return 1;
+}
+
 bool ResourceImporterScene::get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const {
 	if (p_option.begins_with("animation/")) {
 		if (p_option != "animation/import" && !bool(p_options["animation/import"])) {

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -133,6 +133,7 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
+	virtual int get_format_version() const override;
 
 	virtual int get_preset_count() const override;
 	virtual String get_preset_name(int p_idx) const override;

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -1625,13 +1625,13 @@ void Skeleton3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			int pointidx = 0;
 			for (int j = 0; j < 3; j++) {
 				bones.write[0] = parent;
-				surface_tool->add_bones(bones);
-				surface_tool->add_weights(weights);
-				surface_tool->add_color(rootcolor);
+				surface_tool->set_bones(bones);
+				surface_tool->set_weights(weights);
+				surface_tool->set_color(rootcolor);
 				surface_tool->add_vertex(v0 - grests[parent].basis[j].normalized() * dist * 0.05);
-				surface_tool->add_bones(bones);
-				surface_tool->add_weights(weights);
-				surface_tool->add_color(rootcolor);
+				surface_tool->set_bones(bones);
+				surface_tool->set_weights(weights);
+				surface_tool->set_color(rootcolor);
 				surface_tool->add_vertex(v0 + grests[parent].basis[j].normalized() * dist * 0.05);
 
 				if (j == closest) {
@@ -1654,24 +1654,24 @@ void Skeleton3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 					point += axis * dist * 0.1;
 
 					bones.write[0] = parent;
-					surface_tool->add_bones(bones);
-					surface_tool->add_weights(weights);
-					surface_tool->add_color(bonecolor);
+					surface_tool->set_bones(bones);
+					surface_tool->set_weights(weights);
+					surface_tool->set_color(bonecolor);
 					surface_tool->add_vertex(v0);
-					surface_tool->add_bones(bones);
-					surface_tool->add_weights(weights);
-					surface_tool->add_color(bonecolor);
+					surface_tool->set_bones(bones);
+					surface_tool->set_weights(weights);
+					surface_tool->set_color(bonecolor);
 					surface_tool->add_vertex(point);
 
 					bones.write[0] = parent;
-					surface_tool->add_bones(bones);
-					surface_tool->add_weights(weights);
-					surface_tool->add_color(bonecolor);
+					surface_tool->set_bones(bones);
+					surface_tool->set_weights(weights);
+					surface_tool->set_color(bonecolor);
 					surface_tool->add_vertex(point);
 					bones.write[0] = i;
-					surface_tool->add_bones(bones);
-					surface_tool->add_weights(weights);
-					surface_tool->add_color(bonecolor);
+					surface_tool->set_bones(bones);
+					surface_tool->set_weights(weights);
+					surface_tool->set_color(bonecolor);
 					surface_tool->add_vertex(v1);
 					points[pointidx++] = point;
 				}
@@ -1680,13 +1680,13 @@ void Skeleton3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			SWAP(points[1], points[2]);
 			for (int j = 0; j < 4; j++) {
 				bones.write[0] = parent;
-				surface_tool->add_bones(bones);
-				surface_tool->add_weights(weights);
-				surface_tool->add_color(bonecolor);
+				surface_tool->set_bones(bones);
+				surface_tool->set_weights(weights);
+				surface_tool->set_color(bonecolor);
 				surface_tool->add_vertex(points[j]);
-				surface_tool->add_bones(bones);
-				surface_tool->add_weights(weights);
-				surface_tool->add_color(bonecolor);
+				surface_tool->set_bones(bones);
+				surface_tool->set_weights(weights);
+				surface_tool->set_color(bonecolor);
 				surface_tool->add_vertex(points[(j + 1) % 4]);
 			}
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5345,7 +5345,7 @@ void Node3DEditor::_init_indicators() {
 						Vector2 ofs = Vector2(Math::cos((Math_PI * 2.0 * k) / m), Math::sin((Math_PI * 2.0 * k) / m));
 						Vector3 normal = ivec * ofs.x + ivec2 * ofs.y;
 
-						surftool->add_normal(basis.xform(normal));
+						surftool->set_normal(basis.xform(normal));
 						surftool->add_vertex(vertex);
 					}
 				}

--- a/modules/arkit/arkit_interface.mm
+++ b/modules/arkit/arkit_interface.mm
@@ -712,8 +712,8 @@ void ARKitInterface::_add_or_update_anchor(GodotARAnchor *p_anchor) {
 						int16_t index = planeAnchor.geometry.triangleIndices[j];
 						simd_float3 vrtx = planeAnchor.geometry.vertices[index];
 						simd_float2 textcoord = planeAnchor.geometry.textureCoordinates[index];
-						surftool->add_uv(Vector2(textcoord[0], textcoord[1]));
-						surftool->add_color(Color(0.8, 0.8, 0.8));
+						surftool->set_uv(Vector2(textcoord[0], textcoord[1]));
+						surftool->set_color(Color(0.8, 0.8, 0.8));
 						surftool->add_vertex(Vector3(vrtx[0], vrtx[1], vrtx[2]));
 					}
 

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -827,8 +827,7 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 	Ref<ArrayMesh> mesh;
 	mesh.instance();
 	bool has_uvs = false;
-	bool compress_vert_data = state.import_flags & IMPORT_USE_COMPRESSION;
-	uint32_t mesh_flags = compress_vert_data ? Mesh::ARRAY_COMPRESS_DEFAULT : 0;
+	uint32_t mesh_flags = 0;
 
 	Map<String, uint32_t> morph_mesh_string_lookup;
 
@@ -904,33 +903,33 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 			// Get the texture coordinates if they exist
 			if (ai_mesh->HasTextureCoords(0)) {
 				has_uvs = true;
-				st->add_uv(Vector2(ai_mesh->mTextureCoords[0][j].x, 1.0f - ai_mesh->mTextureCoords[0][j].y));
+				st->set_uv(Vector2(ai_mesh->mTextureCoords[0][j].x, 1.0f - ai_mesh->mTextureCoords[0][j].y));
 			}
 
 			if (ai_mesh->HasTextureCoords(1)) {
 				has_uvs = true;
-				st->add_uv2(Vector2(ai_mesh->mTextureCoords[1][j].x, 1.0f - ai_mesh->mTextureCoords[1][j].y));
+				st->set_uv2(Vector2(ai_mesh->mTextureCoords[1][j].x, 1.0f - ai_mesh->mTextureCoords[1][j].y));
 			}
 
 			// Assign vertex colors
 			if (ai_mesh->HasVertexColors(0)) {
 				Color color = Color(ai_mesh->mColors[0]->r, ai_mesh->mColors[0]->g, ai_mesh->mColors[0]->b,
 						ai_mesh->mColors[0]->a);
-				st->add_color(color);
+				st->set_color(color);
 			}
 
 			// Work out normal calculations? - this needs work it doesn't work properly on huestos
 			if (ai_mesh->mNormals != nullptr) {
 				const aiVector3D normals = ai_mesh->mNormals[j];
 				const Vector3 godot_normal = Vector3(normals.x, normals.y, normals.z);
-				st->add_normal(godot_normal);
+				st->set_normal(godot_normal);
 				if (ai_mesh->HasTangentsAndBitangents()) {
 					const aiVector3D tangents = ai_mesh->mTangents[j];
 					const Vector3 godot_tangent = Vector3(tangents.x, tangents.y, tangents.z);
 					const aiVector3D bitangent = ai_mesh->mBitangents[j];
 					const Vector3 godot_bitangent = Vector3(bitangent.x, bitangent.y, bitangent.z);
 					float d = godot_normal.cross(godot_tangent).dot(godot_bitangent) > 0.0f ? 1.0f : -1.0f;
-					st->add_tangent(Plane(tangents.x, tangents.y, tangents.z, d));
+					st->set_tangent(Plane(tangents.x, tangents.y, tangents.z, d));
 				}
 			}
 
@@ -948,8 +947,8 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 					weights.write[k] = bone_info[k].weight;
 				}
 
-				st->add_bones(bones);
-				st->add_weights(weights);
+				st->set_bones(bones);
+				st->set_weights(weights);
 			}
 
 			// Assign vertex

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -480,7 +480,6 @@ void SoftBody3D::become_mesh_owner() {
 		Dictionary surface_lods = mesh->surface_get_lods(0);
 		uint32_t surface_format = mesh->surface_get_format(0);
 
-		surface_format &= ~(Mesh::ARRAY_COMPRESS_NORMAL);
 		surface_format |= Mesh::ARRAY_FLAG_USE_DYNAMIC_UPDATE;
 
 		Ref<ArrayMesh> soft_mesh;

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -157,7 +157,7 @@ void Mesh::generate_debug_mesh_indices(Vector<Vector3> &r_points) {
 
 bool Mesh::surface_is_softbody_friendly(int p_idx) const {
 	const uint32_t surface_format = surface_get_format(p_idx);
-	return (surface_format & Mesh::ARRAY_FLAG_USE_DYNAMIC_UPDATE && (!(surface_format & Mesh::ARRAY_COMPRESS_NORMAL)));
+	return (surface_format & Mesh::ARRAY_FLAG_USE_DYNAMIC_UPDATE);
 }
 
 Vector<Face3> Mesh::get_faces() const {
@@ -483,37 +483,59 @@ void Mesh::_bind_methods() {
 	BIND_ENUM_CONSTANT(BLEND_SHAPE_MODE_NORMALIZED);
 	BIND_ENUM_CONSTANT(BLEND_SHAPE_MODE_RELATIVE);
 
-	BIND_ENUM_CONSTANT(ARRAY_FORMAT_VERTEX);
-	BIND_ENUM_CONSTANT(ARRAY_FORMAT_NORMAL);
-	BIND_ENUM_CONSTANT(ARRAY_FORMAT_TANGENT);
-	BIND_ENUM_CONSTANT(ARRAY_FORMAT_COLOR);
-	BIND_ENUM_CONSTANT(ARRAY_FORMAT_TEX_UV);
-	BIND_ENUM_CONSTANT(ARRAY_FORMAT_TEX_UV2);
-	BIND_ENUM_CONSTANT(ARRAY_FORMAT_BONES);
-	BIND_ENUM_CONSTANT(ARRAY_FORMAT_WEIGHTS);
-	BIND_ENUM_CONSTANT(ARRAY_FORMAT_INDEX);
-
-	BIND_ENUM_CONSTANT(ARRAY_COMPRESS_NORMAL);
-	BIND_ENUM_CONSTANT(ARRAY_COMPRESS_TANGENT);
-	BIND_ENUM_CONSTANT(ARRAY_COMPRESS_COLOR);
-	BIND_ENUM_CONSTANT(ARRAY_COMPRESS_TEX_UV);
-	BIND_ENUM_CONSTANT(ARRAY_COMPRESS_TEX_UV2);
-	BIND_ENUM_CONSTANT(ARRAY_COMPRESS_INDEX);
-
-	BIND_ENUM_CONSTANT(ARRAY_FLAG_USE_2D_VERTICES);
-
-	BIND_ENUM_CONSTANT(ARRAY_COMPRESS_DEFAULT);
-
 	BIND_ENUM_CONSTANT(ARRAY_VERTEX);
 	BIND_ENUM_CONSTANT(ARRAY_NORMAL);
 	BIND_ENUM_CONSTANT(ARRAY_TANGENT);
 	BIND_ENUM_CONSTANT(ARRAY_COLOR);
 	BIND_ENUM_CONSTANT(ARRAY_TEX_UV);
 	BIND_ENUM_CONSTANT(ARRAY_TEX_UV2);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM0);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM1);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM2);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM3);
 	BIND_ENUM_CONSTANT(ARRAY_BONES);
 	BIND_ENUM_CONSTANT(ARRAY_WEIGHTS);
 	BIND_ENUM_CONSTANT(ARRAY_INDEX);
 	BIND_ENUM_CONSTANT(ARRAY_MAX);
+
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGBA8_UNORM);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGBA8_SNORM);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RG_HALF);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGBA_HALF);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_R_FLOAT);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RG_FLOAT);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGB_FLOAT);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGBA_FLOAT);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_MAX);
+
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_VERTEX);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_NORMAL);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_TANGENT);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_COLOR);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_TEX_UV);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_TEX_UV2);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM0);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM1);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM2);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM3);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_BONES);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_WEIGHTS);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_INDEX);
+
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_BLEND_SHAPE_MASK);
+
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM_BASE);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM0_SHIFT);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM1_SHIFT);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM2_SHIFT);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM3_SHIFT);
+
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM_MASK);
+	BIND_ENUM_CONSTANT(ARRAY_COMPRESS_FLAGS_BASE);
+
+	BIND_ENUM_CONSTANT(ARRAY_FLAG_USE_2D_VERTICES);
+	BIND_ENUM_CONSTANT(ARRAY_FLAG_USE_DYNAMIC_UPDATE);
+	BIND_ENUM_CONSTANT(ARRAY_FLAG_USE_8_BONE_WEIGHTS);
 }
 
 void Mesh::clear_cache() const {
@@ -559,12 +581,50 @@ Vector<Ref<Shape3D>> Mesh::convex_decompose() const {
 
 Mesh::Mesh() {
 }
-
+#if 0
 static Vector<uint8_t> _fix_array_compatibility(const Vector<uint8_t> &p_src, uint32_t p_format, uint32_t p_elements) {
-	bool vertex_16bit = p_format & ((1 << (Mesh::ARRAY_VERTEX + Mesh::ARRAY_COMPRESS_BASE)));
-	bool has_bones = (p_format & Mesh::ARRAY_FORMAT_BONES);
-	bool bone_8 = has_bones && !(p_format & (Mesh::ARRAY_COMPRESS_INDEX << 2));
-	bool weight_32 = has_bones && !(p_format & (Mesh::ARRAY_COMPRESS_TEX_UV2 << 2));
+	enum ArrayType {
+		OLD_ARRAY_VERTEX = 0,
+		OLD_ARRAY_NORMAL = 1,
+		OLD_ARRAY_TANGENT = 2,
+		OLD_ARRAY_COLOR = 3,
+		OLD_ARRAY_TEX_UV = 4,
+		OLD_ARRAY_TEX_UV2 = 5,
+		OLD_ARRAY_BONES = 6,
+		OLD_ARRAY_WEIGHTS = 7,
+		OLD_ARRAY_INDEX = 8,
+		OLD_ARRAY_MAX = 9
+	};
+
+	enum ArrayFormat {
+		/* OLD_ARRAY FORMAT FLAGS */
+		OLD_ARRAY_FORMAT_VERTEX = 1 << OLD_ARRAY_VERTEX, // mandatory
+		OLD_ARRAY_FORMAT_NORMAL = 1 << OLD_ARRAY_NORMAL,
+		OLD_ARRAY_FORMAT_TANGENT = 1 << OLD_ARRAY_TANGENT,
+		OLD_ARRAY_FORMAT_COLOR = 1 << OLD_ARRAY_COLOR,
+		OLD_ARRAY_FORMAT_TEX_UV = 1 << OLD_ARRAY_TEX_UV,
+		OLD_ARRAY_FORMAT_TEX_UV2 = 1 << OLD_ARRAY_TEX_UV2,
+		OLD_ARRAY_FORMAT_BONES = 1 << OLD_ARRAY_BONES,
+		OLD_ARRAY_FORMAT_WEIGHTS = 1 << OLD_ARRAY_WEIGHTS,
+		OLD_ARRAY_FORMAT_INDEX = 1 << OLD_ARRAY_INDEX,
+
+		OLD_ARRAY_COMPRESS_BASE = (OLD_ARRAY_INDEX + 1),
+		OLD_ARRAY_COMPRESS_NORMAL = 1 << (OLD_ARRAY_NORMAL + OLD_ARRAY_COMPRESS_BASE),
+		OLD_ARRAY_COMPRESS_TANGENT = 1 << (OLD_ARRAY_TANGENT + OLD_ARRAY_COMPRESS_BASE),
+		OLD_ARRAY_COMPRESS_COLOR = 1 << (OLD_ARRAY_COLOR + OLD_ARRAY_COMPRESS_BASE),
+		OLD_ARRAY_COMPRESS_TEX_UV = 1 << (OLD_ARRAY_TEX_UV + OLD_ARRAY_COMPRESS_BASE),
+		OLD_ARRAY_COMPRESS_TEX_UV2 = 1 << (OLD_ARRAY_TEX_UV2 + OLD_ARRAY_COMPRESS_BASE),
+		OLD_ARRAY_COMPRESS_INDEX = 1 << (OLD_ARRAY_INDEX + OLD_ARRAY_COMPRESS_BASE),
+		OLD_ARRAY_COMPRESS_DEFAULT = OLD_ARRAY_COMPRESS_NORMAL | OLD_ARRAY_COMPRESS_TANGENT | OLD_ARRAY_COMPRESS_COLOR | OLD_ARRAY_COMPRESS_TEX_UV | OLD_ARRAY_COMPRESS_TEX_UV2,
+
+		OLD_ARRAY_FLAG_USE_2D_VERTICES = OLD_ARRAY_COMPRESS_INDEX << 1,
+		OLD_ARRAY_FLAG_USE_DYNAMIC_UPDATE = OLD_ARRAY_COMPRESS_INDEX << 3,
+	};
+
+	bool vertex_16bit = p_format & ((1 << (OLD_ARRAY_VERTEX + OLD_ARRAY_COMPRESS_BASE)));
+	bool has_bones = (p_format & OLD_ARRAY_FORMAT_BONES);
+	bool bone_8 = has_bones && !(p_format & (OLD_ARRAY_COMPRESS_INDEX << 2));
+	bool weight_32 = has_bones && !(p_format & (OLD_ARRAY_COMPRESS_TEX_UV2 << 2));
 
 	print_line("convert vertex16: " + itos(vertex_16bit) + " convert bone 8 " + itos(bone_8) + " convert weight 32 " + itos(weight_32));
 
@@ -572,7 +632,7 @@ static Vector<uint8_t> _fix_array_compatibility(const Vector<uint8_t> &p_src, ui
 		return p_src;
 	}
 
-	bool vertex_2d = (p_format & (Mesh::ARRAY_COMPRESS_INDEX << 1));
+	bool vertex_2d = (p_format & (OLD_ARRAY_COMPRESS_INDEX << 1));
 
 	uint32_t src_stride = p_src.size() / p_elements;
 	uint32_t dst_stride = src_stride + (vertex_16bit ? 4 : 0) + (bone_8 ? 4 : 0) - (weight_32 ? 8 : 0);
@@ -671,7 +731,7 @@ static Vector<uint8_t> _fix_array_compatibility(const Vector<uint8_t> &p_src, ui
 
 	return ret;
 }
-
+#endif
 bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 	String sname = p_name;
 
@@ -727,6 +787,7 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 			add_surface_from_arrays(PrimitiveType(int(d["primitive"])), d["arrays"], d["morph_arrays"]);
 
 		} else if (d.has("array_data")) {
+#if 0
 			//print_line("array data (old style");
 			//older format (3.x)
 			Vector<uint8_t> array_data = d["array_data"];
@@ -793,6 +854,7 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 			}
 
 			add_surface(format, PrimitiveType(primitive), array_data, vertex_count, array_index_data, index_count, aabb, blend_shapes, bone_aabb);
+#endif
 		} else {
 			ERR_FAIL_V(false);
 		}
@@ -824,6 +886,12 @@ Array ArrayMesh::_get_surfaces() const {
 		data["primitive"] = surface.primitive;
 		data["vertex_data"] = surface.vertex_data;
 		data["vertex_count"] = surface.vertex_count;
+		if (surface.skin_data.size()) {
+			data["skin_data"] = surface.skin_data;
+		}
+		if (surface.attribute_data.size()) {
+			data["attribute_data"] = surface.attribute_data;
+		}
 		data["aabb"] = surface.aabb;
 		if (surface.index_count) {
 			data["index_data"] = surface.index_data;
@@ -848,9 +916,9 @@ Array ArrayMesh::_get_surfaces() const {
 			data["bone_aabbs"] = bone_aabbs;
 		}
 
-		Array blend_shapes;
-		for (int j = 0; j < surface.blend_shapes.size(); j++) {
-			blend_shapes.push_back(surface.blend_shapes[j]);
+		if (surface.blend_shape_data.size()) {
+			data["blend_shapes"] = surface.blend_shape_data;
+			data["blend_shapes_count"] = surface.blend_shape_count;
 		}
 
 		if (surfaces[i].material.is_valid()) {
@@ -896,6 +964,12 @@ void ArrayMesh::_set_surfaces(const Array &p_surfaces) {
 		surface.primitive = RS::PrimitiveType(int(d["primitive"]));
 		surface.vertex_data = d["vertex_data"];
 		surface.vertex_count = d["vertex_count"];
+		if (d.has("attribute_data")) {
+			surface.attribute_data = d["attribute_data"];
+		}
+		if (d.has("skin_data")) {
+			surface.skin_data = d["skin_data"];
+		}
 		surface.aabb = d["aabb"];
 
 		if (d.has("index_data")) {
@@ -922,11 +996,9 @@ void ArrayMesh::_set_surfaces(const Array &p_surfaces) {
 			}
 		}
 
-		if (d.has("blend_shapes")) {
-			Array blend_shapes;
-			for (int j = 0; j < blend_shapes.size(); j++) {
-				surface.blend_shapes.push_back(blend_shapes[j]);
-			}
+		if (d.has("blend_shapes") && d.has("blend_shape_count")) {
+			surface.blend_shape_data = d["blend_shapes"];
+			surface.blend_shape_count = d["blend_shape_count"];
 		}
 
 		Ref<Material> material;
@@ -982,7 +1054,7 @@ void ArrayMesh::_set_surfaces(const Array &p_surfaces) {
 		s.aabb = surface_data[i].aabb;
 		if (i == 0) {
 			aabb = s.aabb;
-			blend_shapes.resize(surface_data[i].blend_shapes.size());
+			blend_shapes.resize(surface_data[i].blend_shape_count);
 		} else {
 			aabb.merge_with(s.aabb);
 		}
@@ -1070,7 +1142,7 @@ void ArrayMesh::_recompute_aabb() {
 #ifndef _MSC_VER
 #warning need to add binding to add_surface using future MeshSurfaceData object
 #endif
-void ArrayMesh::add_surface(uint32_t p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t>> &p_blend_shapes, const Vector<AABB> &p_bone_aabb, const Vector<RS::SurfaceData::LOD> &p_lods) {
+void ArrayMesh::add_surface(uint32_t p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, const Vector<uint8_t> &p_attribute_array, const Vector<uint8_t> &p_skin_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<uint8_t> &p_blend_shape_data, uint32_t p_blend_shape_count, const Vector<AABB> &p_bone_aabbs, const Vector<RS::SurfaceData::LOD> &p_lods) {
 	_create_if_empty();
 
 	Surface s;
@@ -1090,10 +1162,13 @@ void ArrayMesh::add_surface(uint32_t p_format, PrimitiveType p_primitive, const 
 	sd.aabb = p_aabb;
 	sd.vertex_count = p_vertex_count;
 	sd.vertex_data = p_array;
+	sd.attribute_data = p_attribute_array;
+	sd.skin_data = p_skin_array;
 	sd.index_count = p_index_count;
 	sd.index_data = p_index_array;
-	sd.blend_shapes = p_blend_shapes;
-	sd.bone_aabbs = p_bone_aabb;
+	sd.blend_shape_data = p_blend_shape_data;
+	sd.blend_shape_count = p_blend_shape_count;
+	sd.bone_aabbs = p_bone_aabbs;
 	sd.lods = p_lods;
 
 	RenderingServer::get_singleton()->mesh_add_surface(mesh, sd);
@@ -1119,7 +1194,7 @@ void ArrayMesh::add_surface_from_arrays(PrimitiveType p_primitive, const Array &
 	print_line("index count: " + itos(surface.index_count));
 	print_line("primitive: " + itos(surface.primitive));
 */
-	add_surface(surface.format, PrimitiveType(surface.primitive), surface.vertex_data, surface.vertex_count, surface.index_data, surface.index_count, surface.aabb, surface.blend_shapes, surface.bone_aabbs, surface.lods);
+	add_surface(surface.format, PrimitiveType(surface.primitive), surface.vertex_data, surface.attribute_data, surface.skin_data, surface.vertex_count, surface.index_data, surface.index_count, surface.aabb, surface.blend_shape_data, surface.blend_shape_count, surface.bone_aabbs, surface.lods);
 }
 
 Array ArrayMesh::surface_get_arrays(int p_surface) const {
@@ -1452,29 +1527,29 @@ Error ArrayMesh::lightmap_unwrap_cached(int *&r_cache_data, unsigned int &r_cach
 			SurfaceTool::Vertex v = lightmap_surfaces[surface].vertices[uv_indices[gen_vertices[gen_indices[i + j]]].second];
 
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_COLOR) {
-				surfaces_tools.write[surface]->add_color(v.color);
+				surfaces_tools.write[surface]->set_color(v.color);
 			}
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_TEX_UV) {
-				surfaces_tools.write[surface]->add_uv(v.uv);
+				surfaces_tools.write[surface]->set_uv(v.uv);
 			}
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_NORMAL) {
-				surfaces_tools.write[surface]->add_normal(v.normal);
+				surfaces_tools.write[surface]->set_normal(v.normal);
 			}
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_TANGENT) {
 				Plane t;
 				t.normal = v.tangent;
 				t.d = v.binormal.dot(v.normal.cross(v.tangent)) < 0 ? -1 : 1;
-				surfaces_tools.write[surface]->add_tangent(t);
+				surfaces_tools.write[surface]->set_tangent(t);
 			}
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_BONES) {
-				surfaces_tools.write[surface]->add_bones(v.bones);
+				surfaces_tools.write[surface]->set_bones(v.bones);
 			}
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_WEIGHTS) {
-				surfaces_tools.write[surface]->add_weights(v.weights);
+				surfaces_tools.write[surface]->set_weights(v.weights);
 			}
 
 			Vector2 uv2(gen_uvs[gen_indices[i + j] * 2 + 0], gen_uvs[gen_indices[i + j] * 2 + 1]);
-			surfaces_tools.write[surface]->add_uv2(uv2);
+			surfaces_tools.write[surface]->set_uv2(uv2);
 
 			surfaces_tools.write[surface]->add_vertex(v.vertex);
 		}
@@ -1507,7 +1582,7 @@ void ArrayMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_blend_shape_mode", "mode"), &ArrayMesh::set_blend_shape_mode);
 	ClassDB::bind_method(D_METHOD("get_blend_shape_mode"), &ArrayMesh::get_blend_shape_mode);
 
-	ClassDB::bind_method(D_METHOD("add_surface_from_arrays", "primitive", "arrays", "blend_shapes", "lods", "compress_flags"), &ArrayMesh::add_surface_from_arrays, DEFVAL(Array()), DEFVAL(Dictionary()), DEFVAL(ARRAY_COMPRESS_DEFAULT));
+	ClassDB::bind_method(D_METHOD("add_surface_from_arrays", "primitive", "arrays", "blend_shapes", "lods", "compress_flags"), &ArrayMesh::add_surface_from_arrays, DEFVAL(Array()), DEFVAL(Dictionary()), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("clear_surfaces"), &ArrayMesh::clear_surfaces);
 	ClassDB::bind_method(D_METHOD("surface_update_region", "surf_idx", "offset", "data"), &ArrayMesh::surface_update_region);
 	ClassDB::bind_method(D_METHOD("surface_get_array_len", "surf_idx"), &ArrayMesh::surface_get_array_len);
@@ -1546,10 +1621,24 @@ void ArrayMesh::_bind_methods() {
 	BIND_ENUM_CONSTANT(ARRAY_COLOR);
 	BIND_ENUM_CONSTANT(ARRAY_TEX_UV);
 	BIND_ENUM_CONSTANT(ARRAY_TEX_UV2);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM0);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM1);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM2);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM3);
 	BIND_ENUM_CONSTANT(ARRAY_BONES);
 	BIND_ENUM_CONSTANT(ARRAY_WEIGHTS);
 	BIND_ENUM_CONSTANT(ARRAY_INDEX);
 	BIND_ENUM_CONSTANT(ARRAY_MAX);
+
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGBA8_UNORM);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGBA8_SNORM);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RG_HALF);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGBA_HALF);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_R_FLOAT);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RG_FLOAT);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGB_FLOAT);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_RGBA_FLOAT);
+	BIND_ENUM_CONSTANT(ARRAY_CUSTOM_MAX);
 
 	BIND_ENUM_CONSTANT(ARRAY_FORMAT_VERTEX);
 	BIND_ENUM_CONSTANT(ARRAY_FORMAT_NORMAL);
@@ -1557,9 +1646,28 @@ void ArrayMesh::_bind_methods() {
 	BIND_ENUM_CONSTANT(ARRAY_FORMAT_COLOR);
 	BIND_ENUM_CONSTANT(ARRAY_FORMAT_TEX_UV);
 	BIND_ENUM_CONSTANT(ARRAY_FORMAT_TEX_UV2);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM0);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM1);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM2);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM3);
 	BIND_ENUM_CONSTANT(ARRAY_FORMAT_BONES);
 	BIND_ENUM_CONSTANT(ARRAY_FORMAT_WEIGHTS);
 	BIND_ENUM_CONSTANT(ARRAY_FORMAT_INDEX);
+
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_BLEND_SHAPE_MASK);
+
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM_BASE);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM0_SHIFT);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM1_SHIFT);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM2_SHIFT);
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM3_SHIFT);
+
+	BIND_ENUM_CONSTANT(ARRAY_FORMAT_CUSTOM_MASK);
+	BIND_ENUM_CONSTANT(ARRAY_COMPRESS_FLAGS_BASE);
+
+	BIND_ENUM_CONSTANT(ARRAY_FLAG_USE_2D_VERTICES);
+	BIND_ENUM_CONSTANT(ARRAY_FLAG_USE_DYNAMIC_UPDATE);
+	BIND_ENUM_CONSTANT(ARRAY_FLAG_USE_8_BONE_WEIGHTS);
 }
 
 void ArrayMesh::reload_from_file() {

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -61,6 +61,10 @@ public:
 		ARRAY_COLOR = RenderingServer::ARRAY_COLOR,
 		ARRAY_TEX_UV = RenderingServer::ARRAY_TEX_UV,
 		ARRAY_TEX_UV2 = RenderingServer::ARRAY_TEX_UV2,
+		ARRAY_CUSTOM0 = RenderingServer::ARRAY_CUSTOM0,
+		ARRAY_CUSTOM1 = RenderingServer::ARRAY_CUSTOM1,
+		ARRAY_CUSTOM2 = RenderingServer::ARRAY_CUSTOM2,
+		ARRAY_CUSTOM3 = RenderingServer::ARRAY_CUSTOM3,
 		ARRAY_BONES = RenderingServer::ARRAY_BONES,
 		ARRAY_WEIGHTS = RenderingServer::ARRAY_WEIGHTS,
 		ARRAY_INDEX = RenderingServer::ARRAY_INDEX,
@@ -68,30 +72,47 @@ public:
 
 	};
 
+	enum ArrayCustomFormat {
+		ARRAY_CUSTOM_RGBA8_UNORM,
+		ARRAY_CUSTOM_RGBA8_SNORM,
+		ARRAY_CUSTOM_RG_HALF,
+		ARRAY_CUSTOM_RGBA_HALF,
+		ARRAY_CUSTOM_R_FLOAT,
+		ARRAY_CUSTOM_RG_FLOAT,
+		ARRAY_CUSTOM_RGB_FLOAT,
+		ARRAY_CUSTOM_RGBA_FLOAT,
+		ARRAY_CUSTOM_MAX
+	};
+
 	enum ArrayFormat {
-		/* ARRAY FORMAT FLAGS */
-		ARRAY_FORMAT_VERTEX = 1 << ARRAY_VERTEX, // mandatory
-		ARRAY_FORMAT_NORMAL = 1 << ARRAY_NORMAL,
-		ARRAY_FORMAT_TANGENT = 1 << ARRAY_TANGENT,
-		ARRAY_FORMAT_COLOR = 1 << ARRAY_COLOR,
-		ARRAY_FORMAT_TEX_UV = 1 << ARRAY_TEX_UV,
-		ARRAY_FORMAT_TEX_UV2 = 1 << ARRAY_TEX_UV2,
-		ARRAY_FORMAT_BONES = 1 << ARRAY_BONES,
-		ARRAY_FORMAT_WEIGHTS = 1 << ARRAY_WEIGHTS,
-		ARRAY_FORMAT_INDEX = 1 << ARRAY_INDEX,
+		ARRAY_FORMAT_VERTEX = RS::ARRAY_FORMAT_VERTEX,
+		ARRAY_FORMAT_NORMAL = RS::ARRAY_FORMAT_NORMAL,
+		ARRAY_FORMAT_TANGENT = RS::ARRAY_FORMAT_TANGENT,
+		ARRAY_FORMAT_COLOR = RS::ARRAY_FORMAT_COLOR,
+		ARRAY_FORMAT_TEX_UV = RS::ARRAY_FORMAT_TEX_UV,
+		ARRAY_FORMAT_TEX_UV2 = RS::ARRAY_FORMAT_TEX_UV2,
+		ARRAY_FORMAT_CUSTOM0 = RS::ARRAY_FORMAT_CUSTOM0,
+		ARRAY_FORMAT_CUSTOM1 = RS::ARRAY_FORMAT_CUSTOM1,
+		ARRAY_FORMAT_CUSTOM2 = RS::ARRAY_FORMAT_CUSTOM2,
+		ARRAY_FORMAT_CUSTOM3 = RS::ARRAY_FORMAT_CUSTOM3,
+		ARRAY_FORMAT_BONES = RS::ARRAY_FORMAT_BONES,
+		ARRAY_FORMAT_WEIGHTS = RS::ARRAY_FORMAT_WEIGHTS,
+		ARRAY_FORMAT_INDEX = RS::ARRAY_FORMAT_INDEX,
 
-		ARRAY_COMPRESS_BASE = (ARRAY_INDEX + 1),
-		ARRAY_COMPRESS_NORMAL = 1 << (ARRAY_NORMAL + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_TANGENT = 1 << (ARRAY_TANGENT + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_COLOR = 1 << (ARRAY_COLOR + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_TEX_UV = 1 << (ARRAY_TEX_UV + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_TEX_UV2 = 1 << (ARRAY_TEX_UV2 + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_INDEX = 1 << (ARRAY_INDEX + ARRAY_COMPRESS_BASE),
+		ARRAY_FORMAT_BLEND_SHAPE_MASK = RS::ARRAY_FORMAT_BLEND_SHAPE_MASK,
 
-		ARRAY_FLAG_USE_2D_VERTICES = ARRAY_COMPRESS_INDEX << 1,
-		ARRAY_FLAG_USE_DYNAMIC_UPDATE = ARRAY_COMPRESS_INDEX << 3,
+		ARRAY_FORMAT_CUSTOM_BASE = RS::ARRAY_FORMAT_CUSTOM_BASE,
+		ARRAY_FORMAT_CUSTOM0_SHIFT = RS::ARRAY_FORMAT_CUSTOM0_SHIFT,
+		ARRAY_FORMAT_CUSTOM1_SHIFT = RS::ARRAY_FORMAT_CUSTOM1_SHIFT,
+		ARRAY_FORMAT_CUSTOM2_SHIFT = RS::ARRAY_FORMAT_CUSTOM2_SHIFT,
+		ARRAY_FORMAT_CUSTOM3_SHIFT = RS::ARRAY_FORMAT_CUSTOM3_SHIFT,
 
-		ARRAY_COMPRESS_DEFAULT = ARRAY_COMPRESS_NORMAL | ARRAY_COMPRESS_TANGENT | ARRAY_COMPRESS_COLOR | ARRAY_COMPRESS_TEX_UV | ARRAY_COMPRESS_TEX_UV2
+		ARRAY_FORMAT_CUSTOM_MASK = RS::ARRAY_FORMAT_CUSTOM_MASK,
+		ARRAY_COMPRESS_FLAGS_BASE = RS::ARRAY_COMPRESS_FLAGS_BASE,
+
+		ARRAY_FLAG_USE_2D_VERTICES = RS::ARRAY_FLAG_USE_2D_VERTICES,
+		ARRAY_FLAG_USE_DYNAMIC_UPDATE = RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE,
+		ARRAY_FLAG_USE_8_BONE_WEIGHTS = RS::ARRAY_FLAG_USE_8_BONE_WEIGHTS,
 
 	};
 
@@ -187,9 +208,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_surface_from_arrays(PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), uint32_t p_flags = ARRAY_COMPRESS_DEFAULT);
+	void add_surface_from_arrays(PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), uint32_t p_flags = 0);
 
-	void add_surface(uint32_t p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t>> &p_blend_shapes = Vector<Vector<uint8_t>>(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>(), const Vector<RS::SurfaceData::LOD> &p_lods = Vector<RS::SurfaceData::LOD>());
+	void add_surface(uint32_t p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, const Vector<uint8_t> &p_attribute_array, const Vector<uint8_t> &p_skin_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<uint8_t> &p_blend_shape_data = Vector<uint8_t>(), uint32_t p_blend_shape_count = 0, const Vector<AABB> &p_bone_aabbs = Vector<AABB>(), const Vector<RS::SurfaceData::LOD> &p_lods = Vector<RS::SurfaceData::LOD>());
 
 	Array surface_get_arrays(int p_surface) const override;
 	Array surface_get_blend_shape_arrays(int p_surface) const override;
@@ -244,6 +265,7 @@ public:
 
 VARIANT_ENUM_CAST(Mesh::ArrayType);
 VARIANT_ENUM_CAST(Mesh::ArrayFormat);
+VARIANT_ENUM_CAST(Mesh::ArrayCustomFormat);
 VARIANT_ENUM_CAST(Mesh::PrimitiveType);
 VARIANT_ENUM_CAST(Mesh::BlendShapeMode);
 

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -148,7 +148,7 @@ Array PrimitiveMesh::surface_get_blend_shape_arrays(int p_surface) const {
 uint32_t PrimitiveMesh::surface_get_format(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, 1, 0);
 
-	return RS::ARRAY_FORMAT_VERTEX | RS::ARRAY_FORMAT_NORMAL | RS::ARRAY_FORMAT_TANGENT | RS::ARRAY_FORMAT_TEX_UV | RS::ARRAY_FORMAT_INDEX | RS::ARRAY_COMPRESS_DEFAULT;
+	return RS::ARRAY_FORMAT_VERTEX | RS::ARRAY_FORMAT_NORMAL | RS::ARRAY_FORMAT_TANGENT | RS::ARRAY_FORMAT_TEX_UV | RS::ARRAY_FORMAT_INDEX;
 }
 
 Mesh::PrimitiveType PrimitiveMesh::surface_get_primitive_type(int p_idx) const {

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -49,10 +49,28 @@ public:
 		Vector2 uv2;
 		Vector<int> bones;
 		Vector<float> weights;
+		Color custom[RS::ARRAY_CUSTOM_COUNT];
 
 		bool operator==(const Vertex &p_vertex) const;
 
 		Vertex() {}
+	};
+
+	enum CustomFormat {
+		CUSTOM_RGBA8_UNORM = RS::ARRAY_CUSTOM_RGBA8_UNORM,
+		CUSTOM_RGBA8_SNORM = RS::ARRAY_CUSTOM_RGBA8_SNORM,
+		CUSTOM_RG_HALF = RS::ARRAY_CUSTOM_RG_HALF,
+		CUSTOM_RGBA_HALF = RS::ARRAY_CUSTOM_RGBA_HALF,
+		CUSTOM_R_FLOAT = RS::ARRAY_CUSTOM_R_FLOAT,
+		CUSTOM_RG_FLOAT = RS::ARRAY_CUSTOM_RG_FLOAT,
+		CUSTOM_RGB_FLOAT = RS::ARRAY_CUSTOM_RGB_FLOAT,
+		CUSTOM_RGBA_FLOAT = RS::ARRAY_CUSTOM_RGBA_FLOAT,
+		CUSTOM_MAX = RS::ARRAY_CUSTOM_MAX
+	};
+
+	enum SkinWeightCount {
+		SKIN_4_WEIGHTS,
+		SKIN_8_WEIGHTS
 	};
 
 private:
@@ -71,7 +89,7 @@ private:
 	bool begun;
 	bool first;
 	Mesh::PrimitiveType primitive;
-	int format;
+	uint32_t format;
 	Ref<Material> material;
 	//arrays
 	List<Vertex> vertex_array;
@@ -87,8 +105,14 @@ private:
 	Vector<float> last_weights;
 	Plane last_tangent;
 
-	void _create_list_from_arrays(Array arr, List<Vertex> *r_vertex, List<int> *r_index, int &lformat);
-	void _create_list(const Ref<Mesh> &p_existing, int p_surface, List<Vertex> *r_vertex, List<int> *r_index, int &lformat);
+	SkinWeightCount skin_weights;
+
+	Color last_custom[RS::ARRAY_CUSTOM_COUNT];
+
+	CustomFormat last_custom_format[RS::ARRAY_CUSTOM_COUNT];
+
+	void _create_list_from_arrays(Array arr, List<Vertex> *r_vertex, List<int> *r_index, uint32_t &lformat);
+	void _create_list(const Ref<Mesh> &p_existing, int p_surface, List<Vertex> *r_vertex, List<int> *r_index, uint32_t &lformat);
 
 	//mikktspace callbacks
 	static int mikktGetNumFaces(const SMikkTSpaceContext *pContext);
@@ -103,18 +127,26 @@ protected:
 	static void _bind_methods();
 
 public:
+	void set_skin_weight_count(SkinWeightCount p_weights);
+	SkinWeightCount get_skin_weight_count() const;
+
+	void set_custom_format(int p_index, CustomFormat p_format);
+	CustomFormat get_custom_format(int p_index) const;
+
 	void begin(Mesh::PrimitiveType p_primitive);
 
-	void add_vertex(const Vector3 &p_vertex);
-	void add_color(Color p_color);
-	void add_normal(const Vector3 &p_normal);
-	void add_tangent(const Plane &p_tangent);
-	void add_uv(const Vector2 &p_uv);
-	void add_uv2(const Vector2 &p_uv2);
-	void add_bones(const Vector<int> &p_bones);
-	void add_weights(const Vector<float> &p_weights);
-	void add_smooth_group(bool p_smooth);
+	void set_color(Color p_color);
+	void set_normal(const Vector3 &p_normal);
+	void set_tangent(const Plane &p_tangent);
+	void set_uv(const Vector2 &p_uv);
+	void set_uv2(const Vector2 &p_uv2);
+	void set_custom(int p_index, const Color &p_custom);
+	void set_bones(const Vector<int> &p_bones);
+	void set_weights(const Vector<float> &p_weights);
 
+	void add_vertex(const Vector3 &p_vertex);
+
+	void add_smooth_group(bool p_smooth);
 	void add_triangle_fan(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs = Vector<Vector2>(), const Vector<Color> &p_colors = Vector<Color>(), const Vector<Vector2> &p_uv2s = Vector<Vector2>(), const Vector<Vector3> &p_normals = Vector<Vector3>(), const Vector<Plane> &p_tangents = Vector<Plane>());
 
 	void add_index(int p_index);
@@ -131,14 +163,17 @@ public:
 	List<Vertex> &get_vertex_array() { return vertex_array; }
 
 	void create_from_triangle_arrays(const Array &p_arrays);
-	static Vector<Vertex> create_vertex_array_from_triangle_arrays(const Array &p_arrays);
+	static Vector<Vertex> create_vertex_array_from_triangle_arrays(const Array &p_arrays, uint32_t *r_format = nullptr);
 	Array commit_to_arrays();
 	void create_from(const Ref<Mesh> &p_existing, int p_surface);
 	void create_from_blend_shape(const Ref<Mesh> &p_existing, int p_surface, const String &p_blend_shape_name);
 	void append_from(const Ref<Mesh> &p_existing, int p_surface, const Transform &p_xform);
-	Ref<ArrayMesh> commit(const Ref<ArrayMesh> &p_existing = Ref<ArrayMesh>(), uint32_t p_flags = Mesh::ARRAY_COMPRESS_DEFAULT);
+	Ref<ArrayMesh> commit(const Ref<ArrayMesh> &p_existing = Ref<ArrayMesh>(), uint32_t p_flags = 0);
 
 	SurfaceTool();
 };
+
+VARIANT_ENUM_CAST(SurfaceTool::CustomFormat)
+VARIANT_ENUM_CAST(SurfaceTool::SkinWeightCount)
 
 #endif

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -2795,6 +2795,12 @@ RasterizerSceneHighEndRD::RasterizerSceneHighEndRD(RasterizerStorageRD *p_storag
 		actions.renames["FOG"] = "custom_fog";
 		actions.renames["RADIANCE"] = "custom_radiance";
 		actions.renames["IRRADIANCE"] = "custom_irradiance";
+		actions.renames["BONE_INDICES"] = "bone_attrib";
+		actions.renames["BONE_WEIGHTS"] = "weight_attrib";
+		actions.renames["CUSTOM0"] = "custom0_attrib";
+		actions.renames["CUSTOM1"] = "custom1_attrib";
+		actions.renames["CUSTOM2"] = "custom2_attrib";
+		actions.renames["CUSTOM3"] = "custom3_attrib";
 
 		//for light
 		actions.renames["VIEW"] = "view";
@@ -2817,6 +2823,12 @@ RasterizerSceneHighEndRD::RasterizerSceneHighEndRD(RasterizerStorageRD *p_storag
 		actions.usage_defines["AO_LIGHT_AFFECT"] = "#define AO_USED\n";
 		actions.usage_defines["UV"] = "#define UV_USED\n";
 		actions.usage_defines["UV2"] = "#define UV2_USED\n";
+		actions.usage_defines["BONE_INDICES"] = "#define BONES_USED\n";
+		actions.usage_defines["BONE_WEIGHTS"] = "#define WEIGHTS_USED\n";
+		actions.usage_defines["CUSTOM0"] = "#define CUSTOM0\n";
+		actions.usage_defines["CUSTOM1"] = "#define CUSTOM1\n";
+		actions.usage_defines["CUSTOM2"] = "#define CUSTOM2\n";
+		actions.usage_defines["CUSTOM3"] = "#define CUSTOM3\n";
 		actions.usage_defines["NORMALMAP"] = "#define NORMALMAP_USED\n";
 		actions.usage_defines["NORMALMAP_DEPTH"] = "@NORMALMAP";
 		actions.usage_defines["COLOR"] = "#define COLOR_USED\n";

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -5336,18 +5336,19 @@ void RasterizerSceneRD::_render_buffers_post_process_and_tonemap(RID p_render_bu
 			tonemap.exposure = env->exposure;
 		}
 
+		tonemap.use_color_correction = false;
+		tonemap.use_1d_color_correction = false;
+		tonemap.color_correction_texture = storage->texture_rd_get_default(RasterizerStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+
 		if (can_use_effects && env) {
 			tonemap.use_bcs = env->adjustments_enabled;
 			tonemap.brightness = env->adjustments_brightness;
 			tonemap.contrast = env->adjustments_contrast;
 			tonemap.saturation = env->adjustments_saturation;
-			tonemap.use_1d_color_correction = env->use_1d_color_correction;
 			if (env->adjustments_enabled && env->color_correction.is_valid()) {
 				tonemap.use_color_correction = true;
+				tonemap.use_1d_color_correction = env->use_1d_color_correction;
 				tonemap.color_correction_texture = storage->texture_get_rd_texture(env->color_correction);
-			} else {
-				tonemap.use_color_correction = false;
-				tonemap.color_correction_texture = storage->texture_rd_get_default(RasterizerStorageRD::DEFAULT_RD_TEXTURE_WHITE);
 			}
 		}
 

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
@@ -170,6 +170,10 @@ public:
 		DEFAULT_RD_BUFFER_COLOR,
 		DEFAULT_RD_BUFFER_TEX_UV,
 		DEFAULT_RD_BUFFER_TEX_UV2,
+		DEFAULT_RD_BUFFER_CUSTOM0,
+		DEFAULT_RD_BUFFER_CUSTOM1,
+		DEFAULT_RD_BUFFER_CUSTOM2,
+		DEFAULT_RD_BUFFER_CUSTOM3,
 		DEFAULT_RD_BUFFER_BONES,
 		DEFAULT_RD_BUFFER_WEIGHTS,
 		DEFAULT_RD_BUFFER_MAX,
@@ -378,6 +382,8 @@ private:
 			uint32_t format = 0;
 
 			RID vertex_buffer;
+			RID attribute_buffer;
+			RID skin_buffer;
 			uint32_t vertex_count = 0;
 
 			// A different pipeline needs to be allocated
@@ -414,8 +420,7 @@ private:
 
 			Vector<AABB> bone_aabbs;
 
-			Vector<RID> blend_shapes;
-			RID blend_shape_base_buffer; //source buffer goes here when using blend shapes, and main one is uncompressed
+			RID blend_shape_buffer;
 
 			RID material;
 

--- a/servers/rendering/rasterizer_rd/shaders/canvas.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/canvas.glsl
@@ -9,7 +9,8 @@ layout(location = 0) in vec2 vertex_attrib;
 layout(location = 3) in vec4 color_attrib;
 layout(location = 4) in vec2 uv_attrib;
 
-layout(location = 6) in uvec4 bones_attrib;
+layout(location = 10) in uvec4 bone_attrib;
+layout(location = 11) in vec4 weight_attrib;
 
 #endif
 
@@ -61,6 +62,7 @@ void main() {
 		color = vec4(unpackHalf2x16(draw_data.colors[4]), unpackHalf2x16(draw_data.colors[5]));
 	}
 	uvec4 bones = uvec4(0, 0, 0, 0);
+	vec4 bone_weights = vec4(0.0);
 
 #elif defined(USE_ATTRIBUTES)
 
@@ -68,7 +70,8 @@ void main() {
 	vec4 color = color_attrib;
 	vec2 uv = uv_attrib;
 
-	uvec4 bones = bones_attrib;
+	uvec4 bones = bone_attrib;
+	vec4 bone_weights = weight_attrib;
 #else
 
 	vec2 vertex_base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));

--- a/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
@@ -24,7 +24,29 @@ layout(location = 4) in vec2 uv_attrib;
 layout(location = 5) in vec2 uv2_attrib;
 #endif
 
-layout(location = 6) in uvec4 bone_attrib; // always bound, even if unused
+#if defined(CUSTOM0_USED)
+layout(location = 6) in vec4 custom0_attrib;
+#endif
+
+#if defined(CUSTOM1_USED)
+layout(location = 7) in vec4 custom1_attrib;
+#endif
+
+#if defined(CUSTOM2_USED)
+layout(location = 8) in vec4 custom2_attrib;
+#endif
+
+#if defined(CUSTOM3_USED)
+layout(location = 9) in vec4 custom3_attrib;
+#endif
+
+#if defined(BONES_USED)
+layout(location = 10) in uvec4 bone_attrib;
+#endif
+
+#if defined(WEIGHTS_USED)
+layout(location = 11) in vec4 weight_attrib;
+#endif
 
 /* Varyings */
 
@@ -116,14 +138,15 @@ void main() {
 	}
 
 	vec3 vertex = vertex_attrib;
-	vec3 normal = normal_attrib;
+	vec3 normal = normal_attrib * 2.0 - 1.0;
 
 #if defined(TANGENT_USED) || defined(NORMALMAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-	vec3 tangent = tangent_attrib.xyz;
-	float binormalf = tangent_attrib.a;
+	vec3 tangent = tangent_attrib.xyz * 2.0 - 1.0;
+	float binormalf = tangent_attrib.a * 2.0 - 1.0;
 	vec3 binormal = normalize(cross(normal, tangent) * binormalf);
 #endif
 
+#if 0
 	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_SKELETON)) {
 		//multimesh, instances are for it
 
@@ -147,7 +170,7 @@ void main() {
 		binormal = (vec4(binormal, 0.0) * m).xyz;
 #endif
 	}
-
+#endif
 	uv_interp = uv_attrib;
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -67,6 +67,12 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["INSTANCE_ID"] = constt(ShaderLanguage::TYPE_INT);
 	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["INSTANCE_CUSTOM"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["ROUGHNESS"] = ShaderLanguage::TYPE_FLOAT;
+	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["BONE_INDICES"] = ShaderLanguage::TYPE_UVEC4;
+	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["BONE_WEIGHTS"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["CUSTOM0"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["CUSTOM1"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["CUSTOM2"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["CUSTOM3"] = ShaderLanguage::TYPE_VEC4;
 	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].can_discard = false;
 
 	//builtins

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -52,7 +52,7 @@ class RenderingServer : public Object {
 
 	void _camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	void _canvas_item_add_style_box(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector<float> &p_margins, const Color &p_modulate = Color(1, 1, 1));
-	Array _get_array_from_surface(uint32_t p_format, Vector<uint8_t> p_vertex_data, int p_vertex_len, Vector<uint8_t> p_index_data, int p_index_len) const;
+	Array _get_array_from_surface(uint32_t p_format, Vector<uint8_t> p_vertex_data, Vector<uint8_t> p_attrib_data, Vector<uint8_t> p_skin_data, int p_vertex_len, Vector<uint8_t> p_index_data, int p_index_len) const;
 
 protected:
 	RID _make_test_cube();
@@ -61,7 +61,7 @@ protected:
 	RID white_texture;
 	RID test_material;
 
-	Error _surface_set_data(Array p_arrays, uint32_t p_format, uint32_t *p_offsets, uint32_t p_stride, Vector<uint8_t> &r_vertex_array, int p_vertex_array_len, Vector<uint8_t> &r_index_array, int p_index_array_len, AABB &r_aabb, Vector<AABB> &r_bone_aabb);
+	Error _surface_set_data(Array p_arrays, uint32_t p_format, uint32_t *p_offsets, uint32_t p_vertex_stride, uint32_t p_attrib_stride, uint32_t p_skin_stride, Vector<uint8_t> &r_vertex_array, Vector<uint8_t> &r_attrib_array, Vector<uint8_t> &r_skin_array, int p_vertex_array_len, Vector<uint8_t> &r_index_array, int p_index_array_len, AABB &r_aabb, Vector<AABB> &r_bone_aabb);
 
 	static RenderingServer *(*create_func)();
 	static void _bind_methods();
@@ -199,16 +199,36 @@ public:
 	/* MESH API */
 
 	enum ArrayType {
-		ARRAY_VERTEX = 0,
-		ARRAY_NORMAL = 1,
-		ARRAY_TANGENT = 2,
-		ARRAY_COLOR = 3,
-		ARRAY_TEX_UV = 4,
-		ARRAY_TEX_UV2 = 5,
-		ARRAY_BONES = 6,
-		ARRAY_WEIGHTS = 7,
-		ARRAY_INDEX = 8,
-		ARRAY_MAX = 9
+		ARRAY_VERTEX = 0, // RG32F or RGB32F (depending on 2D bit)
+		ARRAY_NORMAL = 1, // A2B10G10R10
+		ARRAY_TANGENT = 2, // A2B10G10R10, A flips sign of binormal
+		ARRAY_COLOR = 3, // RGBA16F
+		ARRAY_TEX_UV = 4, // RG32F
+		ARRAY_TEX_UV2 = 5, // RG32F
+		ARRAY_CUSTOM0 = 6, // depends on ArrayCustomFormat
+		ARRAY_CUSTOM1 = 7,
+		ARRAY_CUSTOM2 = 8,
+		ARRAY_CUSTOM3 = 9,
+		ARRAY_BONES = 10, // RGBA16UI (x2 if 8 weights)
+		ARRAY_WEIGHTS = 11, // RGBA16UNORM (x2 if 8 weights)
+		ARRAY_INDEX = 12, // 16 or 32 bits depending on length > 0xFFFF
+		ARRAY_MAX = 13
+	};
+
+	enum {
+		ARRAY_CUSTOM_COUNT = ARRAY_BONES - ARRAY_CUSTOM0
+	};
+
+	enum ArrayCustomFormat {
+		ARRAY_CUSTOM_RGBA8_UNORM,
+		ARRAY_CUSTOM_RGBA8_SNORM,
+		ARRAY_CUSTOM_RG_HALF,
+		ARRAY_CUSTOM_RGBA_HALF,
+		ARRAY_CUSTOM_R_FLOAT,
+		ARRAY_CUSTOM_RG_FLOAT,
+		ARRAY_CUSTOM_RGB_FLOAT,
+		ARRAY_CUSTOM_RGBA_FLOAT,
+		ARRAY_CUSTOM_MAX
 	};
 
 	enum ArrayFormat {
@@ -219,21 +239,29 @@ public:
 		ARRAY_FORMAT_COLOR = 1 << ARRAY_COLOR,
 		ARRAY_FORMAT_TEX_UV = 1 << ARRAY_TEX_UV,
 		ARRAY_FORMAT_TEX_UV2 = 1 << ARRAY_TEX_UV2,
+		ARRAY_FORMAT_CUSTOM0 = 1 << ARRAY_CUSTOM0,
+		ARRAY_FORMAT_CUSTOM1 = 1 << ARRAY_CUSTOM1,
+		ARRAY_FORMAT_CUSTOM2 = 1 << ARRAY_CUSTOM2,
+		ARRAY_FORMAT_CUSTOM3 = 1 << ARRAY_CUSTOM3,
 		ARRAY_FORMAT_BONES = 1 << ARRAY_BONES,
 		ARRAY_FORMAT_WEIGHTS = 1 << ARRAY_WEIGHTS,
 		ARRAY_FORMAT_INDEX = 1 << ARRAY_INDEX,
 
-		ARRAY_COMPRESS_BASE = (ARRAY_INDEX + 1),
-		ARRAY_COMPRESS_NORMAL = 1 << (ARRAY_NORMAL + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_TANGENT = 1 << (ARRAY_TANGENT + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_COLOR = 1 << (ARRAY_COLOR + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_TEX_UV = 1 << (ARRAY_TEX_UV + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_TEX_UV2 = 1 << (ARRAY_TEX_UV2 + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_INDEX = 1 << (ARRAY_INDEX + ARRAY_COMPRESS_BASE),
-		ARRAY_COMPRESS_DEFAULT = ARRAY_COMPRESS_NORMAL | ARRAY_COMPRESS_TANGENT | ARRAY_COMPRESS_COLOR | ARRAY_COMPRESS_TEX_UV | ARRAY_COMPRESS_TEX_UV2,
+		ARRAY_FORMAT_BLEND_SHAPE_MASK = ~(ARRAY_FORMAT_COLOR | ARRAY_FORMAT_TEX_UV | ARRAY_FORMAT_TEX_UV2 | ARRAY_FORMAT_BONES | ARRAY_FORMAT_WEIGHTS | ARRAY_FORMAT_CUSTOM0 | ARRAY_FORMAT_CUSTOM1 | ARRAY_FORMAT_CUSTOM2 | ARRAY_FORMAT_CUSTOM3 | ARRAY_FORMAT_INDEX),
 
-		ARRAY_FLAG_USE_2D_VERTICES = ARRAY_COMPRESS_INDEX << 1,
-		ARRAY_FLAG_USE_DYNAMIC_UPDATE = ARRAY_COMPRESS_INDEX << 3,
+		ARRAY_FORMAT_CUSTOM_BASE = (ARRAY_INDEX + 1),
+		ARRAY_FORMAT_CUSTOM_BITS = 3,
+		ARRAY_FORMAT_CUSTOM0_SHIFT = (ARRAY_FORMAT_CUSTOM_BASE + 0),
+		ARRAY_FORMAT_CUSTOM1_SHIFT = (ARRAY_FORMAT_CUSTOM_BASE + ARRAY_FORMAT_CUSTOM_BITS),
+		ARRAY_FORMAT_CUSTOM2_SHIFT = (ARRAY_FORMAT_CUSTOM_BASE + ARRAY_FORMAT_CUSTOM_BITS * 2),
+		ARRAY_FORMAT_CUSTOM3_SHIFT = (ARRAY_FORMAT_CUSTOM_BASE + ARRAY_FORMAT_CUSTOM_BITS * 3),
+
+		ARRAY_FORMAT_CUSTOM_MASK = 0x7,
+		ARRAY_COMPRESS_FLAGS_BASE = (ARRAY_INDEX + 1 + 12),
+
+		ARRAY_FLAG_USE_2D_VERTICES = 1 << (ARRAY_COMPRESS_FLAGS_BASE + 0),
+		ARRAY_FLAG_USE_DYNAMIC_UPDATE = 1 << (ARRAY_COMPRESS_FLAGS_BASE + 1),
+		ARRAY_FLAG_USE_8_BONE_WEIGHTS = 1 << (ARRAY_COMPRESS_FLAGS_BASE + 2),
 	};
 
 	enum PrimitiveType {
@@ -249,10 +277,14 @@ public:
 		PrimitiveType primitive = PRIMITIVE_MAX;
 
 		uint32_t format = 0;
-		Vector<uint8_t> vertex_data;
+		Vector<uint8_t> vertex_data; // vertex, normal, tangent (change with skinning, blendshape)
+		Vector<uint8_t> attribute_data; // color,uv, uv2, custom0-3
+		Vector<uint8_t> skin_data; // bone index, bone weight
 		uint32_t vertex_count = 0;
 		Vector<uint8_t> index_data;
 		uint32_t index_count = 0;
+
+		uint32_t blend_shape_count = 0;
 
 		AABB aabb;
 		struct LOD {
@@ -262,7 +294,7 @@ public:
 		Vector<LOD> lods;
 		Vector<AABB> bone_aabbs;
 
-		Vector<Vector<uint8_t>> blend_shapes;
+		Vector<uint8_t> blend_shape_data;
 
 		RID material;
 	};
@@ -270,17 +302,20 @@ public:
 	virtual RID mesh_create_from_surfaces(const Vector<SurfaceData> &p_surfaces) = 0;
 	virtual RID mesh_create() = 0;
 
-	virtual uint32_t mesh_surface_get_format_offset(uint32_t p_format, int p_vertex_len, int p_index_len, int p_array_index) const;
-	virtual uint32_t mesh_surface_get_format_stride(uint32_t p_format, int p_vertex_len, int p_index_len) const;
+	virtual uint32_t mesh_surface_get_format_offset(uint32_t p_format, int p_vertex_len, int p_array_index) const;
+	virtual uint32_t mesh_surface_get_format_vertex_stride(uint32_t p_format, int p_vertex_len) const;
+	virtual uint32_t mesh_surface_get_format_attribute_stride(uint32_t p_format, int p_vertex_len) const;
+	virtual uint32_t mesh_surface_get_format_skin_stride(uint32_t p_format, int p_vertex_len) const;
+
 	/// Returns stride
-	virtual uint32_t mesh_surface_make_offsets_from_format(uint32_t p_format, int p_vertex_len, int p_index_len, uint32_t *r_offsets) const;
-	virtual Error mesh_create_surface_data_from_arrays(SurfaceData *r_surface_data, PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), uint32_t p_compress_format = ARRAY_COMPRESS_DEFAULT);
+	virtual void mesh_surface_make_offsets_from_format(uint32_t p_format, int p_vertex_len, int p_index_len, uint32_t *r_offsets, uint32_t &r_vertex_element_size, uint32_t &r_attrib_element_size, uint32_t &r_skin_element_size) const;
+	virtual Error mesh_create_surface_data_from_arrays(SurfaceData *r_surface_data, PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), uint32_t p_compress_format = 0);
 	Array mesh_create_arrays_from_surface_data(const SurfaceData &p_data) const;
 	Array mesh_surface_get_arrays(RID p_mesh, int p_surface) const;
 	Array mesh_surface_get_blend_shape_arrays(RID p_mesh, int p_surface) const;
 	Dictionary mesh_surface_get_lods(RID p_mesh, int p_surface) const;
 
-	virtual void mesh_add_surface_from_arrays(RID p_mesh, PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), uint32_t p_compress_format = ARRAY_COMPRESS_DEFAULT);
+	virtual void mesh_add_surface_from_arrays(RID p_mesh, PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), uint32_t p_compress_format = 0);
 	virtual void mesh_add_surface(RID p_mesh, const SurfaceData &p_surface) = 0;
 
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const = 0;


### PR DESCRIPTION
-Changed how mesh data is organized, hoping to make it more efficient on Vulkan and GLES.
-Removed compression, it now always uses the most efficient format.
-Added support for custom arrays (up to 8 custom formats)
-Added support for 8 weights in skeleton data.
-Added a simple optional versioning system for imported assets, to reimport if binary is newer
-Fixes #43979 (I needed to test)

WARNING:

-NOT backwards compatible with previous 4.x-devel, will most likely never be, but it will force reimport scenes due to version change.
-NOT backwards compatible with 3.x scenes, this will be eventually re-added.
-Skeletons not working any longer, will fix in next PR.
