### PR TITLE
X11: Include limits.h for LONG_MAX

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -43,6 +43,7 @@
 #include "servers/rendering/rasterizer_rd/rasterizer_rd.h"
 #endif
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fixes #44030.

I can't reproduce it myself on Mageia Cauldron with latest toolchains, but this should fix it.