### PR TITLE
Use GLES2 by default in the project manager

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1022,7 +1022,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF("rendering/quality/driver/driver_name", "GLES3");
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/driver/driver_name", PropertyInfo(Variant::STRING, "rendering/quality/driver/driver_name", PROPERTY_HINT_ENUM, "GLES2,GLES3"));
 	if (video_driver == "") {
-		video_driver = GLOBAL_GET("rendering/quality/driver/driver_name");
+		if (project_manager) {
+			video_driver = "GLES2"; // Force GLES2 for maximum compatibility, unless specified from command line.
+		} else {
+			video_driver = GLOBAL_GET("rendering/quality/driver/driver_name");
+		}
 	}
 
 	GLOBAL_DEF("rendering/quality/driver/fallback_to_gles2", false);


### PR DESCRIPTION
This only applies to the project manager instance, what driver is used is otherwise
still defined by the project settings for a running game/editor.

Should help users who have issues with buggy GLES3 drivers to still use the project
manager to create and edit GLES2 projects.