### PR TITLE
Added driving joystick type to windows joystick handling

### DIFF
--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -151,7 +151,7 @@ bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE *instance) {
 
 	const DWORD devtype = (instance->dwDevType & 0xFF);
 
-	if ((devtype != DI8DEVTYPE_JOYSTICK) && (devtype != DI8DEVTYPE_GAMEPAD) && (devtype != DI8DEVTYPE_1STPERSON)) {
+	if ((devtype != DI8DEVTYPE_JOYSTICK) && (devtype != DI8DEVTYPE_GAMEPAD) && (devtype != DI8DEVTYPE_1STPERSON) && (devtype != DI8DEVTYPE_DRIVING)) {
 		return false;
 	}
 


### PR DESCRIPTION
Was playing around with my new G29 steeringwheel, found out that Godot stopped recognising it as a joystick after installing drivers. Turns out that when proper drivers are installed, steering wheel is recognised in Windows as DI8DEVTYPE_DRIVING
 and we're ignoring that one.

So simply added that to the list of things we no longer ignore and it works like a charm.

If cherry picked for 3.2 our 16 button limit is not enough for our G29 shifter buttons but we have 36 buttons in Godot 4 so :).