### PR TITLE
C#: Fix multiple awaits to same signal result in connect error

### DIFF
--- a/modules/mono/signal_awaiter_utils.cpp
+++ b/modules/mono/signal_awaiter_utils.cpp
@@ -48,18 +48,10 @@ Error gd_mono_connect_signal_awaiter(Object *p_source, const StringName &p_signa
 }
 
 bool SignalAwaiterCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
+	// Only called if both instances are of type SignalAwaiterCallable. Static cast is safe.
 	const SignalAwaiterCallable *a = static_cast<const SignalAwaiterCallable *>(p_a);
 	const SignalAwaiterCallable *b = static_cast<const SignalAwaiterCallable *>(p_b);
-
-	if (a->target_id != b->target_id) {
-		return false;
-	}
-
-	if (a->signal != b->signal) {
-		return false;
-	}
-
-	return true;
+	return a->awaiter_handle.handle == b->awaiter_handle.handle;
 }
 
 bool SignalAwaiterCallable::compare_less(const CallableCustom *p_a, const CallableCustom *p_b) {


### PR DESCRIPTION
Multiple calls to the same `await ToSignal` were resulting in "signal already connected to slot" error because the custom callable comparer was wrong. Comparing only the signal awaiter handle is the correct way (it's unique for the target).
