### PR TITLE
Enable ANSI escape code processing on Windows 10 and later

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1148,6 +1148,21 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 
 	DisplayServerWindows::register_windows_driver();
 
+	// Enable ANSI escape code support on Windows 10 v1607 (Anniversary Update) and later.
+	// This lets the engine and projects use ANSI escape codes to color text just like on macOS and Linux.
+	//
+	// NOTE: The engine does not use ANSI escape codes to color error/warning messages; it uses Windows API calls instead.
+	// Therefore, error/warning messages are still colored on Windows versions older than 10.
+	HANDLE stdoutHandle;
+	stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+	DWORD outMode = 0;
+	outMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+	if (!SetConsoleMode(stdoutHandle, outMode)) {
+		// Windows 8.1 or below, or Windows 10 prior to Anniversary Update.
+		print_verbose("Can't set the ENABLE_VIRTUAL_TERMINAL_PROCESSING Windows console mode. `print_rich()` will not work as expected.");
+	}
+
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(WindowsTerminalLogger));
 	_set_logger(memnew(CompositeLogger(loggers)));


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/66216.

This lets the engine and projects use the same color codes in the terminal on all platforms. This includes support for `print_rich()` (GDScript) and `print_line_rich()` (C++).

This PR will be needed by https://github.com/godotengine/godot/pull/33505 and https://github.com/godotengine/godot/pull/36252.

## TODO

- [x] Test on Windows 7/8.1 and see how the fallback behavior works.
  - Tested on Windows 7; ANSI escape codes are printed as-is. Since Windows versions older than 10 are now EOL, this is probably acceptable, but feel free to improve on this in a future PR (e.g. by stripping ANSI escape codes).