### PR TITLE
[3.x] Initialize class variables with default values

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2564,6 +2564,8 @@ void _Directory::_bind_methods() {
 _Directory::_Directory() {
 
 	d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	_list_skip_hidden = false;
+	_list_skip_navigational = false;
 }
 
 _Directory::~_Directory() {

--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -265,6 +265,7 @@ ClassDB::ClassInfo::ClassInfo() {
 	inherits_ptr = NULL;
 	disabled = false;
 	exposed = false;
+	class_ptr = NULL;
 }
 
 ClassDB::ClassInfo::~ClassInfo() {

--- a/core/crypto/hashing_context.cpp
+++ b/core/crypto/hashing_context.cpp
@@ -129,6 +129,7 @@ void HashingContext::_bind_methods() {
 }
 
 HashingContext::HashingContext() {
+	type = HASH_MD5;
 	ctx = NULL;
 }
 

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -234,6 +234,7 @@ Engine::Engine() {
 	_in_physics = false;
 	_frame_ticks = 0;
 	_frame_step = 0;
+	_snap_2d_viewports = false;
 	editor_hint = false;
 }
 

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -392,6 +392,7 @@ Error FileAccessCompressed::_set_unix_permissions(const String &p_file, uint32_t
 FileAccessCompressed::FileAccessCompressed() :
 		cmode(Compression::MODE_ZSTD),
 		writing(false),
+		write_pos(0),
 		write_ptr(0),
 		write_buffer_size(0),
 		write_max(0),

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -324,6 +324,8 @@ FileAccessEncrypted::FileAccessEncrypted() {
 	eofed = false;
 	mode = MODE_MAX;
 	writing = false;
+	base = 0;
+	length = 0;
 }
 
 FileAccessEncrypted::~FileAccessEncrypted() {

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -197,4 +197,6 @@ void FileAccessMemory::store_buffer(const uint8_t *p_src, int p_length) {
 FileAccessMemory::FileAccessMemory() {
 
 	data = NULL;
+	length = 0;
+	pos = 0;
 }

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -781,6 +781,7 @@ HTTPClient::HTTPClient() {
 	handshaking = false;
 	// 64 KiB by default (favors fast download speeds at the cost of memory usage).
 	read_chunk_size = 65536;
+	ssl_verify_host = false;
 }
 
 HTTPClient::~HTTPClient() {

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -181,7 +181,7 @@ Error PCKPacker::flush(bool p_verbose) {
 };
 
 PCKPacker::PCKPacker() {
-
+	alignment = 0;
 	file = NULL;
 };
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -980,6 +980,8 @@ ResourceInteractiveLoaderBinary::ResourceInteractiveLoaderBinary() :
 		f(NULL),
 		error(OK),
 		stage(0) {
+	ver_format = 0;
+	importmd_ofs = 0;
 }
 
 ResourceInteractiveLoaderBinary::~ResourceInteractiveLoaderBinary() {

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -48,8 +48,13 @@ class AStar : public Reference {
 	struct Point {
 
 		Point() :
+				id(0),
+				enabled(false),
 				neighbours(4u),
-				unlinked_neighbours(4u) {}
+				unlinked_neighbours(4u),
+				prev_point(NULL),
+				open_pass(0),
+				closed_pass(0) {}
 
 		int id;
 		Vector3 pos;

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -2230,6 +2230,8 @@ Expression::Expression() :
 		root(NULL),
 		nodes(NULL),
 		execution_error(false) {
+	str_ofs = 0;
+	expression_dirty = false;
 }
 
 Expression::~Expression() {

--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -220,7 +220,10 @@ private:
 
 		Type type;
 
-		ENode() { next = NULL; }
+		ENode() {
+			type = TYPE_INPUT;
+			next = NULL;
+		}
 		virtual ~ENode() {
 			if (next) {
 				memdelete(next);
@@ -243,6 +246,7 @@ private:
 
 		int index;
 		InputNode() {
+			index = 0;
 			type = TYPE_INPUT;
 		}
 	};
@@ -262,6 +266,8 @@ private:
 		ENode *nodes[2];
 
 		OperatorNode() {
+			nodes[0] = nullptr;
+			nodes[1] = nullptr;
 			type = TYPE_OPERATOR;
 		}
 	};
@@ -278,6 +284,8 @@ private:
 		ENode *index;
 
 		IndexNode() {
+			base = nullptr;
+			index = nullptr;
 			type = TYPE_INDEX;
 		}
 	};
@@ -287,6 +295,7 @@ private:
 		StringName name;
 
 		NamedIndexNode() {
+			base = nullptr;
 			type = TYPE_NAMED_INDEX;
 		}
 	};
@@ -306,6 +315,7 @@ private:
 		Vector<ENode *> arguments;
 
 		CallNode() {
+			base = nullptr;
 			type = TYPE_CALL;
 		}
 	};
@@ -328,6 +338,7 @@ private:
 		BuiltinFunc func;
 		Vector<ENode *> arguments;
 		BuiltinFuncNode() {
+			func = BuiltinFunc::BYTES_TO_VAR;
 			type = TYPE_BUILTIN_FUNC;
 		}
 	};

--- a/core/object.h
+++ b/core/object.h
@@ -465,7 +465,10 @@ private:
 			int reference_count;
 			Connection conn;
 			List<Connection>::Element *cE;
-			Slot() { reference_count = 0; }
+			Slot() {
+				cE = nullptr;
+				reference_count = 0;
+			}
 		};
 
 		MethodInfo user;

--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -446,7 +446,7 @@ bool DirAccess::exists(String p_dir) {
 }
 
 DirAccess::DirAccess() {
-
+	next_is_dir = false;
 	_access_type = ACCESS_FILESYSTEM;
 }
 

--- a/core/packed_data_container.cpp
+++ b/core/packed_data_container.cpp
@@ -428,4 +428,5 @@ int PackedDataContainerRef::size() const {
 };
 
 PackedDataContainerRef::PackedDataContainerRef() {
+	offset = 0;
 }

--- a/core/script_debugger_local.cpp
+++ b/core/script_debugger_local.cpp
@@ -418,6 +418,10 @@ void ScriptDebuggerLocal::send_error(const String &p_func, const String &p_file,
 
 ScriptDebuggerLocal::ScriptDebuggerLocal() {
 
+	frame_time = 0;
+	idle_time = 0;
+	physics_time = 0;
+	physics_frame_time = 0;
 	profiling = false;
 	idle_accum = OS::get_singleton()->get_ticks_usec();
 	options["variable_prefix"] = "";

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -343,6 +343,11 @@ AudioDriverALSA::AudioDriverALSA() :
 		pcm_handle(NULL),
 		device_name("Default"),
 		new_device("Default") {
+	mix_rate = 0;
+	channels = 0;
+	active = 0;
+	thread_exited = false;
+	exit_thread = false;
 }
 
 AudioDriverALSA::~AudioDriverALSA() {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -172,6 +172,7 @@ public:
 				vertex_mem(0) {
 			render.reset();
 			render_final.reset();
+			snap.reset();
 		}
 
 	} info;
@@ -229,6 +230,7 @@ public:
 		virtual void material_changed_notify() {}
 
 		Geometry() {
+			type = GEOMETRY_INVALID;
 			last_pass = 0;
 			index = 0;
 		}
@@ -296,6 +298,7 @@ public:
 				flags(0),
 				width(0),
 				height(0),
+				depth(0),
 				alloc_width(0),
 				alloc_height(0),
 				format(Image::FORMAT_L8),
@@ -305,6 +308,7 @@ public:
 				total_data_size(0),
 				ignore_mipmaps(false),
 				compressed(false),
+				srgb(false),
 				mipmaps(0),
 				resize_to_po2(false),
 				active(false),
@@ -532,6 +536,10 @@ public:
 			custom_code_id = 0;
 			version = 1;
 			last_pass = 0;
+			texture_count = 0;
+			index = 0;
+			uses_vertex_time = false;
+			uses_fragment_time = false;
 		}
 	};
 
@@ -588,6 +596,7 @@ public:
 			line_width = 1.0;
 			last_pass = 0;
 			render_priority = 0;
+			index = 0;
 		}
 	};
 
@@ -688,6 +697,8 @@ public:
 				primitive(VS::PRIMITIVE_POINTS),
 				active(false),
 				total_data_size(0) {
+			format = 0;
+			max_bone = 0;
 		}
 	};
 
@@ -720,6 +731,8 @@ public:
 		Mesh() :
 				blend_shape_count(0),
 				blend_shape_mode(VS::BLEND_SHAPE_MODE_NORMALIZED) {
+			active = false;
+			last_pass = 0;
 		}
 	};
 
@@ -859,6 +872,7 @@ public:
 		Immediate() {
 			type = GEOMETRY_IMMEDIATE;
 			building = false;
+			mask = 0;
 		}
 	};
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -182,6 +182,7 @@ public:
 			vertex_mem = 0;
 			render.reset();
 			render_final.reset();
+			snap.reset();
 		}
 
 	} info;
@@ -240,6 +241,7 @@ public:
 		virtual void material_changed_notify() {}
 
 		Geometry() {
+			type = GEOMETRY_INVALID;
 			last_pass = 0;
 			index = 0;
 		}
@@ -326,6 +328,11 @@ public:
 				detect_srgb_ud(NULL),
 				detect_normal(NULL),
 				detect_normal_ud(NULL) {
+			depth = 0;
+			alloc_width = 0;
+			alloc_height = 0;
+			alloc_depth = 0;
+			is_npot_repeat_mipmap = false;
 		}
 
 		_ALWAYS_INLINE_ Texture *get_ptr() {
@@ -544,6 +551,9 @@ public:
 			valid = false;
 			custom_code_id = 0;
 			version = 1;
+			texture_count = 0;
+			uses_fragment_time = false;
+			uses_vertex_time = false;
 		}
 	};
 
@@ -606,6 +616,7 @@ public:
 				last_pass(0),
 				can_cast_shadow_cache(false),
 				is_animated_cache(false) {
+			index = 0;
 		}
 	};
 
@@ -724,6 +735,7 @@ public:
 				active(false),
 				total_data_size(0) {
 			type = GEOMETRY_SURFACE;
+			max_bone = 0;
 		}
 
 		~Surface() {
@@ -1129,6 +1141,10 @@ public:
 		GIProbeCompression compression;
 
 		GIProbeData() {
+			width = 0;
+			height = 0;
+			depth = 0;
+			levels = 0;
 		}
 	};
 
@@ -1243,6 +1259,10 @@ public:
 				fractional_delta(false),
 				frame_remainder(0),
 				clear(true) {
+			phase = 0;
+			prev_phase = 0;
+			particle_valid_histories[0] = false;
+			particle_valid_histories[1] = false;
 			particle_buffers[0] = 0;
 			particle_buffers[1] = 0;
 			glGenBuffers(2, particle_buffers);

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -386,6 +386,9 @@ String DirAccessWindows::get_filesystem_type() const {
 
 DirAccessWindows::DirAccessWindows() {
 
+	_cisdir = false;
+	_cishidden = false;
+
 	p = memnew(DirAccessWindowsPrivate);
 	p->h = INVALID_HANDLE_VALUE;
 	current_dir = ".";

--- a/drivers/windows/thread_windows.cpp
+++ b/drivers/windows/thread_windows.cpp
@@ -92,6 +92,7 @@ void ThreadWindows::make_default() {
 
 ThreadWindows::ThreadWindows() :
 		handle(NULL) {
+	user = NULL;
 }
 
 ThreadWindows::~ThreadWindows() {

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -203,6 +203,16 @@ AudioDriverXAudio2::AudioDriverXAudio2() :
 		thread(NULL),
 		mutex(NULL),
 		current_buffer(0) {
+	samples_in = NULL;
+	buffer_size = 0;
+	mix_rate = 0;
+	channels = 0;
+	active = false;
+	thread_exited = false;
+	exit_thread = false;
+	pcm_open = false;
+	mastering_voice = NULL;
+	source_voice = NULL;
 	wave_format = { 0 };
 	for (int i = 0; i < AUDIO_BUFFERS; i++) {
 		xaudio_buffer[i] = { 0 };

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -694,6 +694,7 @@ public:
 		track = -1;
 		setting = false;
 		root_path = NULL;
+		undo_redo = NULL;
 	}
 };
 
@@ -1393,6 +1394,7 @@ public:
 		use_fps = false;
 		setting = false;
 		root_path = NULL;
+		undo_redo = NULL;
 	}
 };
 
@@ -3242,6 +3244,8 @@ void AnimationTrackEditGroup::_bind_methods() {
 
 AnimationTrackEditGroup::AnimationTrackEditGroup() {
 	set_mouse_filter(MOUSE_FILTER_PASS);
+	root = NULL;
+	timeline = NULL;
 }
 
 //////////////////////////////////////

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -66,6 +66,8 @@ void GotoLineDialog::ok_pressed() {
 
 GotoLineDialog::GotoLineDialog() {
 
+	line_label = NULL;
+
 	set_title(TTR("Go to Line"));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);

--- a/editor/collada/collada.h
+++ b/editor/collada/collada.h
@@ -252,6 +252,9 @@ public:
 			Vector<float> sets;
 			Vector<float> indices;
 			int count;
+			Weights() {
+				count = 0;
+			}
 		} weights;
 
 		Map<String, Transform> bone_rest_map;
@@ -440,7 +443,10 @@ public:
 		Map<String, Material> material_map;
 		Vector<String> skeletons;
 
-		NodeGeometry() { type = TYPE_GEOMETRY; }
+		NodeGeometry() {
+			type = TYPE_GEOMETRY;
+			controller = false;
+		}
 	};
 
 	struct NodeCamera : public Node {
@@ -507,7 +513,10 @@ public:
 			Point2 out_tangent;
 			InterpolationType interp_type;
 
-			Key() { interp_type = INTERP_LINEAR; }
+			Key() {
+				interp_type = INTERP_LINEAR;
+				time = 0;
+			}
 		};
 
 		Vector<float> get_value_at_time(float p_time) const;
@@ -580,6 +589,7 @@ public:
 				unit_scale(1.0),
 				up_axis(Vector3::AXIS_Y),
 				animation_length(0) {
+			z_up = false;
 		}
 	} state;
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -638,6 +638,8 @@ void DependencyErrorDialog::custom_action(const String &) {
 
 DependencyErrorDialog::DependencyErrorDialog() {
 
+	mode = Mode::MODE_RESOURCE;
+
 	VBoxContainer *vb = memnew(VBoxContainer);
 	add_child(vb);
 

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -64,6 +64,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 			is_singleton = false;
 			in_editor = false;
 			node = NULL;
+			order = 0;
 		}
 	};
 

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -601,4 +601,8 @@ EditorHelpSearch::Runner::Runner(Control *p_icon_service, Tree *p_results_tree, 
 		search_flags(p_search_flags),
 		empty_icon(ui_service->get_icon("ArrowRight", "EditorIcons")),
 		disabled_color(ui_service->get_color("disabled_font_color", "Editor")) {
+	iterator_doc = NULL;
+	iterator_match = NULL;
+	root_item = NULL;
+	matched_item = NULL;
 }

--- a/editor/editor_profiler.h
+++ b/editor/editor_profiler.h
@@ -83,6 +83,10 @@ public:
 		Metric() {
 			valid = false;
 			frame_number = 0;
+			frame_time = 0;
+			idle_time = 0;
+			physics_time = 0;
+			physics_frame_time = 0;
 		}
 	};
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -46,6 +46,7 @@ EditorPropertyNil::EditorPropertyNil() {
 	Label *label = memnew(Label);
 	label->set_text("[null]");
 	add_child(label);
+	text = NULL;
 }
 
 ///////////////////// TEXT /////////////////////////

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -128,6 +128,7 @@ public:
 
 	SectionedInspectorFilter() {
 		edited = NULL;
+		allow_sub = false;
 	}
 };
 

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -90,6 +90,7 @@ FindInFiles::FindInFiles() {
 	_searching = false;
 	_whole_words = true;
 	_match_case = true;
+	_initial_files_count = 0;
 }
 
 void FindInFiles::set_search_text(String p_pattern) {

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -107,6 +107,8 @@ struct ColladaImport {
 		force_make_tangents = false;
 		apply_mesh_xform_to_vertices = true;
 		bake_fps = 15;
+		scene = NULL;
+		use_mesh_builtin_materials = false;
 	}
 };
 

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -182,6 +182,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 			sparse_indices_component_type = 0;
 			sparse_values_buffer_view = 0;
 			sparse_values_byte_offset = 0;
+			type = GLTFType::TYPE_MAT2;
 		}
 	};
 	struct GLTFTexture {

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -583,6 +583,7 @@ CollisionShape2DEditor::CollisionShape2DEditor(EditorNode *p_editor) {
 
 	edit_handle = -1;
 	pressed = false;
+	shape_type = 0;
 }
 
 void CollisionShape2DEditorPlugin::edit(Object *p_obj) {

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -362,6 +362,8 @@ Ref<Texture> EditorMaterialPreviewPlugin::generate(const RES &p_from, const Size
 
 EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 
+	preview_done = false;
+
 	scenario = VS::get_singleton()->scenario_create();
 
 	viewport = VS::get_singleton()->viewport_create();
@@ -769,6 +771,8 @@ Ref<Texture> EditorMeshPreviewPlugin::generate(const RES &p_from, const Size2 &p
 
 EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
 
+	preview_done = false;
+
 	scenario = VS::get_singleton()->scenario_create();
 
 	viewport = VS::get_singleton()->viewport_create();
@@ -903,6 +907,8 @@ Ref<Texture> EditorFontPreviewPlugin::generate(const RES &p_from, const Size2 &p
 }
 
 EditorFontPreviewPlugin::EditorFontPreviewPlugin() {
+
+	preview_done = false;
 
 	viewport = VS::get_singleton()->viewport_create();
 	VS::get_singleton()->viewport_set_update_mode(viewport, VS::VIEWPORT_UPDATE_DISABLED);

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -317,6 +317,8 @@ void MeshLibraryEditorPlugin::make_visible(bool p_visible) {
 
 MeshLibraryEditorPlugin::MeshLibraryEditorPlugin(EditorNode *p_node) {
 
+	editor = NULL;
+
 	EDITOR_DEF("editors/grid_map/preview_size", 64);
 	mesh_library_editor = memnew(MeshLibraryEditor(p_node));
 

--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -288,6 +288,8 @@ void PathSpatialGizmo::redraw() {
 
 PathSpatialGizmo::PathSpatialGizmo(Path *p_path) {
 
+	orig_in_length = 0;
+	orig_out_length = 0;
 	path = p_path;
 	set_spatial_node(p_path);
 }

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -760,6 +760,7 @@ void ShaderEditorPlugin::apply_changes() {
 
 ShaderEditorPlugin::ShaderEditorPlugin(EditorNode *p_node) {
 
+	_2d = false;
 	editor = p_node;
 	shader_editor = memnew(ShaderEditor(p_node));
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3432,6 +3432,8 @@ void VisualShaderNodePortPreview::_bind_methods() {
 }
 
 VisualShaderNodePortPreview::VisualShaderNodePortPreview() {
+	node = 0;
+	port = 0;
 }
 
 //////////////////////////////////

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2858,7 +2858,8 @@ void ProjectListFilter::set_filter_size(int h_size) {
 }
 
 ProjectListFilter::ProjectListFilter() {
-
+	filter_option = NULL;
+	search_box = NULL;
 	_current_filter = FILTER_NAME;
 	has_search_box = false;
 }

--- a/modules/bullet/generic_6dof_joint_bullet.cpp
+++ b/modules/bullet/generic_6dof_joint_bullet.cpp
@@ -43,6 +43,12 @@
 Generic6DOFJointBullet::Generic6DOFJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Transform &frameInA, const Transform &frameInB) :
 		JointBullet() {
 
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < PhysicsServer::G6DOF_JOINT_FLAG_MAX; j++) {
+			flags[i][j] = false;
+		}
+	}
+
 	Transform scaled_AFrame(frameInA.scaled(rbA->get_body_scale()));
 
 	scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);

--- a/modules/bullet/godot_result_callbacks.h
+++ b/modules/bullet/godot_result_callbacks.h
@@ -204,7 +204,9 @@ public:
 			m_collided(false),
 			m_min_distance(0),
 			collide_with_bodies(p_collide_with_bodies),
-			collide_with_areas(p_collide_with_areas) {}
+			collide_with_areas(p_collide_with_areas) {
+		m_rest_info_collision_object = NULL;
+	}
 
 	virtual bool needsCollision(btBroadphaseProxy *proxy0) const;
 

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -85,7 +85,7 @@ public:
 	real_t deltaTime;
 
 private:
-	BulletPhysicsDirectBodyState() {}
+	BulletPhysicsDirectBodyState() { body = NULL; }
 
 public:
 	virtual Vector3 get_total_gravity() const;

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -445,7 +445,10 @@ btCollisionShape *ConcavePolygonShapeBullet::create_bt_shape(const btVector3 &p_
 /* Height map shape */
 
 HeightMapShapeBullet::HeightMapShapeBullet() :
-		ShapeBullet() {}
+		ShapeBullet() {
+	width = 0;
+	depth = 0;
+}
 
 void HeightMapShapeBullet::set_data(const Variant &p_data) {
 	ERR_FAIL_COND(p_data.get_type() != Variant::DICTIONARY);

--- a/modules/bullet/soft_body_bullet.cpp
+++ b/modules/bullet/soft_body_bullet.cpp
@@ -47,7 +47,9 @@ SoftBodyBullet::SoftBodyBullet() :
 		pressure_coefficient(0.),
 		pose_matching_coefficient(0.),
 		damping_coefficient(0.01),
-		drag_coefficient(0.) {}
+		drag_coefficient(0.) {
+	mat0 = NULL;
+}
 
 SoftBodyBullet::~SoftBodyBullet() {
 }

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -911,6 +911,8 @@ void NetworkedMultiplayerENet::_bind_methods() {
 
 NetworkedMultiplayerENet::NetworkedMultiplayerENet() {
 
+	peer = NULL;
+	host = NULL;
 	active = false;
 	server = false;
 	refuse_connections = false;

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -437,6 +437,7 @@ void GDNativeLibraryEditorPlugin::make_visible(bool p_visible) {
 
 GDNativeLibraryEditorPlugin::GDNativeLibraryEditorPlugin(EditorNode *p_node) {
 
+	editor = NULL;
 	library_editor = memnew(GDNativeLibraryEditor);
 	library_editor->set_custom_minimum_size(Size2(0, 250 * EDSCALE));
 	button = p_node->add_bottom_panel_item(TTR("GDNativeLibrary"), library_editor);

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -93,6 +93,8 @@ struct NativeScriptDesc {
 			base_native_type(),
 			documentation(),
 			type_tag(NULL) {
+		base_data = NULL;
+		is_tool = false;
 		zeromem(&create_func, sizeof(godot_instance_create_func));
 		zeromem(&destroy_func, sizeof(godot_instance_destroy_func));
 	}

--- a/modules/gdnative/pluginscript/pluginscript_instance.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_instance.cpp
@@ -118,6 +118,9 @@ bool PluginScriptInstance::refcount_decremented() {
 }
 
 PluginScriptInstance::PluginScriptInstance() {
+	_owner = NULL;
+	_data = NULL;
+	_desc = NULL;
 }
 
 bool PluginScriptInstance::init(PluginScript *p_script, Object *p_owner) {

--- a/modules/gdnative/videodecoder/video_stream_gdnative.h
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.h
@@ -194,7 +194,9 @@ public:
 	virtual void set_audio_track(int p_track);
 	virtual Ref<VideoStreamPlayback> instance_playback();
 
-	VideoStreamGDNative() {}
+	VideoStreamGDNative() {
+		audio_track = 0;
+	}
 };
 
 class ResourceFormatLoaderVideoStreamGDNative : public ResourceFormatLoader {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2203,4 +2203,8 @@ int GDScriptCompiler::get_error_column() const {
 }
 
 GDScriptCompiler::GDScriptCompiler() {
+	parser = NULL;
+	main_script = NULL;
+	err_line = 0;
+	err_column = 0;
 }

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1769,6 +1769,18 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 GDScriptFunction::GDScriptFunction() :
 		function_list(this) {
 
+	_constants_ptr = NULL;
+	_constant_count = 0;
+	_global_names_ptr = NULL;
+	_global_names_count = 0;
+	_default_arg_ptr = NULL;
+	_default_arg_count = 0;
+	_code_ptr = NULL;
+	_code_size = 0;
+	_argument_count = 0;
+	_initial_line = 0;
+	_static = false;
+	_script = NULL;
 	_stack_size = 0;
 	_call_size = 0;
 	rpc_mode = MultiplayerAPI::RPC_MODE_DISABLED;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8936,6 +8936,9 @@ int GDScriptParser::get_completion_identifier_is_function() {
 
 GDScriptParser::GDScriptParser() {
 
+	completion_line = 0;
+	completion_argument = 0;
+	completion_ident_is_call = false;
 	head = NULL;
 	list = NULL;
 	tokenizer = NULL;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -202,6 +202,8 @@ public:
 			classname_used = false;
 			end_line = -1;
 			owner = NULL;
+			initializer = NULL;
+			ready = NULL;
 		}
 	};
 
@@ -226,6 +228,7 @@ public:
 		int get_required_argument_count() { return arguments.size() - default_values.size(); }
 
 		FunctionNode() {
+			body = NULL;
 			type = TYPE_FUNCTION;
 			_static = false;
 			rpc_mode = MultiplayerAPI::RPC_MODE_DISABLED;
@@ -265,7 +268,10 @@ public:
 	};
 	struct BuiltInFunctionNode : public Node {
 		GDScriptFunctions::Function function;
-		BuiltInFunctionNode() { type = TYPE_BUILT_IN_FUNCTION; }
+		BuiltInFunctionNode() {
+			function = GDScriptFunctions::Function::MATH_SIN;
+			type = TYPE_BUILT_IN_FUNCTION;
+		}
 	};
 
 	struct IdentifierNode : public Node {
@@ -276,6 +282,7 @@ public:
 		virtual DataType get_datatype() const { return datatype; }
 		virtual void set_datatype(const DataType &p_datatype) { datatype = p_datatype; }
 		IdentifierNode() {
+
 			type = TYPE_IDENTIFIER;
 			declared_block = NULL;
 		}
@@ -405,7 +412,10 @@ public:
 		DataType datatype;
 		virtual DataType get_datatype() const { return datatype; }
 		virtual void set_datatype(const DataType &p_datatype) { datatype = p_datatype; }
-		OperatorNode() { type = TYPE_OPERATOR; }
+		OperatorNode() {
+			op = OP_CALL;
+			type = TYPE_OPERATOR;
+		}
 	};
 
 	struct PatternNode : public Node {
@@ -468,6 +478,8 @@ public:
 			cf_type = CF_IF;
 			body = NULL;
 			body_else = NULL;
+			match = NULL;
+			_else = NULL;
 		}
 	};
 
@@ -477,7 +489,10 @@ public:
 		DataType return_type;
 		virtual DataType get_datatype() const { return return_type; }
 		virtual void set_datatype(const DataType &p_datatype) { return_type = p_datatype; }
-		CastNode() { type = TYPE_CAST; }
+		CastNode() {
+			type = TYPE_CAST;
+			source_node = NULL;
+		}
 	};
 
 	struct AssertNode : public Node {

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -93,6 +93,9 @@ class GridMap : public Spatial {
 		struct NavMesh {
 			int id;
 			Transform xform;
+			NavMesh() {
+				id = 0;
+			}
 		};
 
 		struct MultimeshInstance {

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -448,6 +448,9 @@ void MobileVRInterface::notification(int p_what){
 
 MobileVRInterface::MobileVRInterface() {
 	initialized = false;
+	mag_count = 0;
+	has_gyro = false;
+	sensor_first = false;
 
 	// Just set some defaults for these. At some point we need to look at adding a lookup table for common device + headset combos and/or support reading cardboard QR codes
 	eye_height = 1.85;

--- a/modules/mono/mono_gd/gd_mono_log.cpp
+++ b/modules/mono/mono_gd/gd_mono_log.cpp
@@ -193,6 +193,7 @@ GDMonoLog::GDMonoLog() {
 
 	singleton = this;
 
+	log_file = NULL;
 	log_level_id = -1;
 }
 

--- a/modules/mono/signal_awaiter_utils.cpp
+++ b/modules/mono/signal_awaiter_utils.cpp
@@ -117,6 +117,7 @@ void SignalAwaiterHandle::_bind_methods() {
 
 SignalAwaiterHandle::SignalAwaiterHandle(MonoObject *p_managed) :
 		MonoGCHandle(MonoGCHandle::new_strong_handle(p_managed), STRONG_HANDLE) {
+	completed = false;
 
 #ifdef DEBUG_ENABLED
 	conn_target_id = 0;

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.h
@@ -66,7 +66,12 @@ public:
 	virtual float get_playback_position() const;
 	virtual void seek(float p_time);
 
-	AudioStreamPlaybackOGGVorbis() {}
+	AudioStreamPlaybackOGGVorbis() {
+		ogg_stream = NULL;
+		frames_mixed = 0;
+		active = false;
+		loops = 0;
+	}
 	~AudioStreamPlaybackOGGVorbis();
 };
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -672,6 +672,15 @@ void VideoStreamPlaybackTheora::_streaming_thread(void *ud) {
 
 VideoStreamPlaybackTheora::VideoStreamPlaybackTheora() {
 
+	theora_eos = false;
+	vorbis_eos = false;
+	td = NULL;
+	pp_inc = 0;
+	pp_level = 0;
+	pp_level_max = 0;
+	last_update_time = 0;
+	time = 0;
+
 	file = NULL;
 	theora_p = 0;
 	vorbis_p = 0;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -156,6 +156,16 @@ VisualScriptNode::VisualScriptNode() {
 
 VisualScriptNodeInstance::VisualScriptNodeInstance() {
 
+	id = 0;
+	sequence_index = 0;
+	sequence_output_count = 0;
+	input_port_count = 0;
+	output_port_count = 0;
+	output_ports = NULL;
+	working_mem_idx = 0;
+	pass_idx = 0;
+	base = NULL;
+
 	sequence_outputs = NULL;
 	input_ports = NULL;
 }
@@ -2294,6 +2304,9 @@ ScriptLanguage *VisualScriptInstance::get_language() {
 }
 
 VisualScriptInstance::VisualScriptInstance() {
+	owner = NULL;
+	max_input_args = 0;
+	max_output_args = 0;
 }
 
 VisualScriptInstance::~VisualScriptInstance() {
@@ -2409,6 +2422,12 @@ void VisualScriptFunctionState::_bind_methods() {
 }
 
 VisualScriptFunctionState::VisualScriptFunctionState() {
+	instance = NULL;
+	working_mem_index = 0;
+	variant_stack_size = 0;
+	node = NULL;
+	flow_stack_pos = 0;
+	pass = 0;
 }
 
 VisualScriptFunctionState::~VisualScriptFunctionState() {

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -1487,6 +1487,7 @@ VisualScriptExpression::VisualScriptExpression() {
 	root = NULL;
 	nodes = NULL;
 	sequenced = false;
+	str_ofs = 0;
 }
 
 VisualScriptExpression::~VisualScriptExpression() {

--- a/modules/visual_script/visual_script_expression.h
+++ b/modules/visual_script/visual_script_expression.h
@@ -138,7 +138,10 @@ class VisualScriptExpression : public VisualScriptNode {
 
 		Type type;
 
-		ENode() { next = NULL; }
+		ENode() {
+			next = NULL;
+			type = TYPE_INPUT;
+		}
 		virtual ~ENode() {
 			if (next) {
 				memdelete(next);
@@ -161,6 +164,7 @@ class VisualScriptExpression : public VisualScriptNode {
 
 		int index;
 		InputNode() {
+			index = 0;
 			type = TYPE_INPUT;
 		}
 	};
@@ -180,6 +184,8 @@ class VisualScriptExpression : public VisualScriptNode {
 		ENode *nodes[2];
 
 		OperatorNode() {
+			nodes[0] = NULL;
+			nodes[1] = NULL;
 			type = TYPE_OPERATOR;
 		}
 	};
@@ -196,6 +202,8 @@ class VisualScriptExpression : public VisualScriptNode {
 		ENode *index;
 
 		IndexNode() {
+			base = NULL;
+			index = NULL;
 			type = TYPE_INDEX;
 		}
 	};
@@ -205,6 +213,7 @@ class VisualScriptExpression : public VisualScriptNode {
 		StringName name;
 
 		NamedIndexNode() {
+			base = NULL;
 			type = TYPE_NAMED_INDEX;
 		}
 	};
@@ -224,6 +233,7 @@ class VisualScriptExpression : public VisualScriptNode {
 		Vector<ENode *> arguments;
 
 		CallNode() {
+			base = NULL;
 			type = TYPE_CALL;
 		}
 	};
@@ -246,6 +256,7 @@ class VisualScriptExpression : public VisualScriptNode {
 		VisualScriptBuiltinFunc::BuiltinFunc func;
 		Vector<ENode *> arguments;
 		BuiltinFuncNode() {
+			func = VisualScriptBuiltinFunc::BuiltinFunc::BYTES_TO_VAR;
 			type = TYPE_BUILTIN_FUNC;
 		}
 	};

--- a/modules/webrtc/webrtc_multiplayer.cpp
+++ b/modules/webrtc/webrtc_multiplayer.cpp
@@ -369,6 +369,7 @@ void WebRTCMultiplayer::close() {
 
 WebRTCMultiplayer::WebRTCMultiplayer() {
 	unique_id = 0;
+	client_count = 0;
 	next_packet_peer = 0;
 	target_peer = 0;
 	transfer_mode = TRANSFER_MODE_RELIABLE;

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -359,6 +359,9 @@ void AudioDriverOpenSL::set_pause(bool p_pause) {
 
 AudioDriverOpenSL::AudioDriverOpenSL() {
 	s_ad = this;
+	buffer_size = 0;
+	mixdown_buffer = NULL;
+	last_free = 0;
 	mutex = Mutex::create(); //NULL;
 	pause = false;
 	active = false;

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -177,6 +177,8 @@ bool FileAccessAndroid::file_exists(const String &p_path) {
 FileAccessAndroid::FileAccessAndroid() {
 	a = NULL;
 	eof = false;
+	len = 0;
+	pos = 0;
 }
 
 FileAccessAndroid::~FileAccessAndroid() {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -925,6 +925,11 @@ bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 
 OS_Android::OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion) {
 
+	use_16bits_fbo = false;
+	visual_server = NULL;
+	input = NULL;
+	video_driver_index = 0;
+
 	use_apk_expansion = p_use_apk_expansion;
 	default_videomode.width = 800;
 	default_videomode.height = 600;

--- a/platform/android/thread_jandroid.cpp
+++ b/platform/android/thread_jandroid.cpp
@@ -149,6 +149,7 @@ JNIEnv *ThreadAndroid::get_env() {
 
 ThreadAndroid::ThreadAndroid() {
 
+	user = NULL;
 	pthread = 0;
 }
 

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -1832,6 +1832,7 @@ bool EditorExportPlatformIOS::can_export(const Ref<EditorExportPreset> &p_preset
 
 EditorExportPlatformIOS::EditorExportPlatformIOS() {
 
+	version_code = 0;
 	Ref<Image> img = memnew(Image(_iphone_logo));
 	logo.instance();
 	logo->create_from_image(img);

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -1218,6 +1218,9 @@ OS_JavaScript *OS_JavaScript::get_singleton() {
 }
 
 OS_JavaScript::OS_JavaScript() {
+	input = NULL;
+	video_driver_index = 0;
+
 	// Expose method for requesting quit.
 	godot_js_os_request_quit_cb(&request_quit_callback);
 	// Set canvas ID

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -824,6 +824,8 @@ bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset
 
 EditorExportPlatformOSX::EditorExportPlatformOSX() {
 
+	version_code = 0;
+
 	Ref<Image> img = memnew(Image(_osx_logo));
 	logo.instance();
 	logo->create_from_image(img);

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -327,6 +327,13 @@ bool OS_Server::is_disable_crash_handler() const {
 
 OS_Server::OS_Server() {
 
+	visual_server = NULL;
+	main_loop = NULL;
+	force_quit = false;
+	input = NULL;
+	power_manager = NULL;
+	video_driver_index = 0;
+
 	//adriver here
 	grab = false;
 };

--- a/platform/uwp/context_egl_uwp.cpp
+++ b/platform/uwp/context_egl_uwp.cpp
@@ -213,7 +213,9 @@ ContextEGL_UWP::ContextEGL_UWP(CoreWindow ^ p_window, Driver p_driver) :
 		mEglContext(EGL_NO_CONTEXT),
 		mEglSurface(EGL_NO_SURFACE),
 		driver(p_driver),
-		window(p_window) {}
+		window(p_window) {
+	vsync = false;
+}
 
 ContextEGL_UWP::~ContextEGL_UWP() {
 

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -644,7 +644,9 @@ void AppxPackager::finish() {
 	package = NULL;
 }
 
-AppxPackager::AppxPackager() {}
+AppxPackager::AppxPackager() {
+	package = NULL;
+}
 
 AppxPackager::~AppxPackager() {}
 

--- a/platform/windows/context_gl_windows.cpp
+++ b/platform/windows/context_gl_windows.cpp
@@ -230,6 +230,7 @@ ContextGL_Windows::ContextGL_Windows(HWND hwnd, bool p_opengl_3_context) {
 	hWnd = hwnd;
 	use_vsync = false;
 	vsync_via_compositor = false;
+	pixel_format = 0;
 }
 
 ContextGL_Windows::~ContextGL_Windows() {

--- a/platform/windows/joypad_windows.h
+++ b/platform/windows/joypad_windows.h
@@ -108,6 +108,7 @@ private:
 			ff_timestamp = 0;
 			ff_end_timestamp = 0;
 			last_packet = 0;
+			id = 0;
 		}
 	};
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -3737,6 +3737,32 @@ void OS_Windows::set_current_tablet_driver(const String &p_driver) {
 
 OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 
+	min_pressure = 0;
+	max_pressure = 0;
+	tilt_supported = false;
+	last_pressure_update = 0;
+	last_pressure = 0;
+	ticks_per_second = 0;
+	ticks_start = 0;
+	outside = false;
+	old_x = 0;
+	old_y = 0;
+	visual_server = NULL;
+	move_timer_id = 0;
+	main_loop = NULL;
+	window_has_focus = false;
+	last_button_state = 0;
+	use_raw_input = false;
+	input = NULL;
+	joypad = NULL;
+	power_manager = NULL;
+	video_driver_index = 0;
+	process_map = NULL;
+	pre_fs_valid = false;
+	maximized = false;
+	borderless = false;
+	gl_context = NULL;
+
 	drop_events = false;
 	key_event_pos = 0;
 	layered_window = false;

--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -54,6 +54,9 @@ JoypadLinux::Joypad::Joypad() {
 	fd = -1;
 	dpad = 0;
 	devpath = "";
+	force_feedback = false;
+	ff_effect_id = 0;
+	ff_effect_timestamp = 0;
 	for (int i = 0; i < MAX_ABS; i++) {
 		abs_info[i] = NULL;
 	}

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -3966,6 +3966,34 @@ void OS_X11::update_real_mouse_position() {
 
 OS_X11::OS_X11() {
 
+	xdnd_version = 0;
+	visual_server = NULL;
+	main_loop = NULL;
+	x11_display = NULL;
+	xmbstring = NULL;
+	xmblen = 0;
+	last_timestamp = 0;
+	im_active = false;
+	last_mouse_pos_valid = false;
+	last_click_ms = 0;
+	last_click_button_index = 0;
+	last_button_state = 0;
+	events_mutex = NULL;
+	force_quit = false;
+	window_has_focus = false;
+	do_mouse_warp = false;
+	cursor_theme = NULL;
+	cursor_size = 0;
+	input = NULL;
+	power_manager = NULL;
+	video_driver_index = 0;
+	maximized = false;
+	xrr_free_monitors = NULL;
+	xrr_get_monitors = NULL;
+	xrandr_handle = NULL;
+	joypad = NULL;
+	context_gl = NULL;
+
 #ifdef PULSEAUDIO_ENABLED
 	AudioDriverManager::add_driver(&driver_pulseaudio);
 #endif

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -788,6 +788,8 @@ void Camera2D::_bind_methods() {
 
 Camera2D::Camera2D() {
 
+	viewport = NULL;
+
 	anchor_mode = ANCHOR_MODE_DRAG_CENTER;
 	rotating = false;
 	current = false;

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -302,6 +302,7 @@ void LightOccluder2D::_bind_methods() {
 
 LightOccluder2D::LightOccluder2D() {
 
+	enabled = false;
 	occluder = VS::get_singleton()->canvas_light_occluder_create();
 	mask = 1;
 	set_notify_transform(true);

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -93,6 +93,7 @@ static inline Vector2 interpolate(const Rect2 &r, const Vector2 &v) {
 //----------------------------------------------------------------------------
 
 LineBuilder::LineBuilder() {
+	texture_mode = Line2D::LineTextureMode::LINE_TEXTURE_NONE;
 	joint_mode = Line2D::LINE_JOINT_SHARP;
 	width = 10;
 	curve = NULL;

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -161,10 +161,15 @@ private:
 			return body_shape < p_sp.body_shape;
 		}
 
-		ShapePair() {}
+		ShapePair() {
+			body_shape = 0;
+			local_shape = 0;
+			tagged = false;
+		}
 		ShapePair(int p_bs, int p_ls) {
 			body_shape = p_bs;
 			local_shape = p_ls;
+			tagged = false;
 		}
 	};
 	struct RigidBody2D_RemoveAction {

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -173,7 +173,7 @@ private:
 			navpoly_ids = q.navpoly_ids;
 		}
 		Quadrant() :
-				dirty_list(this) {}
+				dirty_list(this) { shape_owner_id = 0; }
 	};
 
 	Map<PosKey, Quadrant> quadrant_map;

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -81,6 +81,7 @@ private:
 		Viewport *viewport; //pointer only used for reference to previous mix
 
 		Output() {
+			pitch_scale = 0;
 			filter_gain = 0;
 			viewport = NULL;
 			reverb_bus_index = -1;

--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -331,6 +331,12 @@ Light::Light(VisualServer::LightType p_type) {
 }
 
 Light::Light() {
+	shadow = false;
+	negative = false;
+	reverse_cull = false;
+	cull_mask = 0;
+	editor_only = false;
+	bake_mode = BakeMode::BAKE_ALL;
 
 	type = VisualServer::LIGHT_DIRECTIONAL;
 	ERR_PRINT("Light should not be instanced directly; use the DirectionalLight, OmniLight or SpotLight subtypes instead.");

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -38,7 +38,12 @@
 #include "scene/3d/skeleton.h"
 #include "servers/physics_server.h"
 
-SoftBodyVisualServerHandler::SoftBodyVisualServerHandler() {}
+SoftBodyVisualServerHandler::SoftBodyVisualServerHandler() {
+	surface = 0;
+	stride = 0;
+	offset_vertices = 0;
+	offset_normal = 0;
+}
 
 void SoftBodyVisualServerHandler::prepare(RID p_mesh, int p_surface) {
 	clear();
@@ -707,6 +712,8 @@ SoftBody::SoftBody() :
 		pinned_points_cache_dirty(true),
 		ray_pickable(true) {
 
+	debug_mesh = NULL;
+	capture_input_on_drag = false;
 	PhysicsServer::get_singleton()->body_attach_object_instance_id(physics_rid, get_instance_id());
 }
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1255,6 +1255,9 @@ void AnimatedSprite3D::_bind_methods() {
 
 AnimatedSprite3D::AnimatedSprite3D() {
 
+	centered = false;
+	hflip = false;
+	vflip = false;
 	frame = 0;
 	playing = false;
 	animation = "default";

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -388,6 +388,9 @@ VehicleWheel::VehicleWheel() {
 
 	m_suspensionRelativeVelocity = 0;
 	m_clippedInvContactDotSuspension = 1.0;
+
+	m_raycastInfo.m_suspensionLength = 0;
+	m_raycastInfo.m_groundObject = NULL;
 	m_raycastInfo.m_isInContact = false;
 	m_raycastInfo.m_suspensionLength = 0.0;
 

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -1610,6 +1610,17 @@ Transform VoxelLightBaker::get_to_cell_space_xform() const {
 	return to_cell_space;
 }
 VoxelLightBaker::VoxelLightBaker() {
+	cell_subdiv = 0;
+	first_leaf = 0;
+	leaf_voxel_count = 0;
+	direct_lights_baked = false;
+	axis_cell_size[0] = 0;
+	axis_cell_size[1] = 0;
+	axis_cell_size[2] = 0;
+	cell_size = 0;
+	bake_quality = BakeQuality::BAKE_QUALITY_HIGH;
+	max_original_cells = 0;
+
 	color_scan_cell_width = 4;
 	bake_texture_size = 128;
 	propagation = 0.85;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -202,6 +202,7 @@ private:
 		Vector3 scale;
 
 		TrackCacheTransform() {
+			rot_blend_accum = 0;
 			type = Animation::TYPE_TRANSFORM;
 			spatial = NULL;
 			bone_idx = -1;

--- a/scene/animation/animation_tree_player.h
+++ b/scene/animation/animation_tree_player.h
@@ -138,7 +138,10 @@ private:
 
 		Vector<Input> inputs;
 
-		NodeBase() { cycletest = false; };
+		NodeBase() {
+			type = NODE_MAX;
+			cycletest = false;
+		};
 		virtual ~NodeBase() { cycletest = false; }
 	};
 
@@ -171,6 +174,8 @@ private:
 		HashMap<NodePath, bool> filter;
 
 		AnimationNode() {
+			time = 0;
+			step = 0;
 			type = NODE_ANIMATION;
 			next = NULL;
 			last_version = 0;
@@ -197,6 +202,9 @@ private:
 		HashMap<NodePath, bool> filter;
 
 		OneShotNode() {
+			autorestart_random_delay = 0;
+			time = 0;
+			remaining = 0;
 			type = NODE_ONESHOT;
 			fade_in = 0;
 			fade_out = 0;
@@ -214,6 +222,7 @@ private:
 
 		float amount;
 		MixNode() {
+			amount = 0;
 			type = NODE_MIX;
 			inputs.resize(2);
 		}
@@ -291,6 +300,7 @@ private:
 		float xfade;
 
 		TransitionNode() {
+			time = 0;
 			type = NODE_TRANSITION;
 			xfade = 0;
 			inputs.resize(1);

--- a/scene/animation/root_motion_view.cpp
+++ b/scene/animation/root_motion_view.cpp
@@ -193,6 +193,8 @@ void RootMotionView::_bind_methods() {
 }
 
 RootMotionView::RootMotionView() {
+	use_in_game = false;
+	first = false;
 	zero_y = true;
 	radius = 10;
 	cell_size = 1;

--- a/scene/animation/skeleton_ik.h
+++ b/scene/animation/skeleton_ik.h
@@ -114,7 +114,8 @@ public:
 				skeleton(NULL),
 				min_distance(0.01),
 				max_iterations(10),
-				root_bone(-1) {}
+				root_bone(-1) {
+		}
 	};
 
 private:

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -102,6 +102,10 @@ private:
 		Variant arg[5];
 		int uid;
 		InterpolateData() {
+			type = InterpolateType::FOLLOW_METHOD;
+			trans_type = TransitionType::TRANS_BACK;
+			ease_type = EaseType::EASE_COUNT;
+			args = 0;
 			active = false;
 			finish = false;
 			call_deferred = false;

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -1270,6 +1270,12 @@ ScriptDebuggerRemote::ScriptDebuggerRemote() :
 		locking(false),
 		poll_every(0),
 		scene_tree(NULL) {
+	frame_time = 0;
+	idle_time = 0;
+	physics_time = 0;
+	physics_frame_time = 0;
+	n_warnings_dropped = 0;
+	skip_breakpoints = false;
 
 	packet_peer_stream->set_stream_peer(tcp_client);
 	packet_peer_stream->set_output_buffer_max_size((1024 * 1024 * 8) - 4); // 8 MiB should be way more than enough, minus 4 bytes for separator.

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -63,6 +63,7 @@ class PopupMenu : public Popup {
 		bool shortcut_is_disabled;
 
 		Item() {
+			id = 0;
 			checked = false;
 			checkable_type = CHECKABLE_TYPE_NONE;
 			separator = false;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -98,6 +98,10 @@ private:
 		int maximum_width;
 
 		Line() {
+			height_cache = 0;
+			height_accum_cache = 0;
+			minimum_width = 0;
+			maximum_width = 0;
 			from = NULL;
 			char_count = 0;
 		}
@@ -119,6 +123,8 @@ private:
 		}
 
 		Item() {
+			index = 0;
+			type = ItemType::ITEM_ALIGN;
 			parent = NULL;
 			E = NULL;
 			line = 0;
@@ -134,6 +140,7 @@ private:
 		ItemFrame *parent_frame;
 
 		ItemFrame() {
+			first_invalid_line = 0;
 			type = ITEM_FRAME;
 			parent_frame = NULL;
 			cell = false;
@@ -177,17 +184,26 @@ private:
 
 	struct ItemAlign : public Item {
 		Align align;
-		ItemAlign() { type = ITEM_ALIGN; }
+		ItemAlign() {
+			type = ITEM_ALIGN;
+			align = Align::ALIGN_CENTER;
+		}
 	};
 
 	struct ItemIndent : public Item {
 		int level;
-		ItemIndent() { type = ITEM_INDENT; }
+		ItemIndent() {
+			type = ITEM_INDENT;
+			level = 0;
+		}
 	};
 
 	struct ItemList : public Item {
 		ListType list_type;
-		ItemList() { type = ITEM_LIST; }
+		ItemList() {
+			type = ITEM_LIST;
+			list_type = ListType::LIST_DOTS;
+		}
 	};
 
 	struct ItemNewline : public Item {
@@ -205,14 +221,21 @@ private:
 
 		Vector<Column> columns;
 		int total_width;
-		ItemTable() { type = ITEM_TABLE; }
+		ItemTable() {
+			total_width = 0;
+			type = ITEM_TABLE;
+		}
 	};
 
 	struct ItemFade : public Item {
 		int starting_index;
 		int length;
 
-		ItemFade() { type = ITEM_FADE; }
+		ItemFade() {
+			type = ITEM_FADE;
+			starting_index = 0;
+			length = 0;
+		}
 	};
 
 	struct ItemFX : public Item {
@@ -230,6 +253,7 @@ private:
 		uint64_t _previous_rng;
 
 		ItemShake() {
+			_previous_rng = 0;
 			strength = 0;
 			rate = 0.0f;
 			_current_rng = 0;

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -668,6 +668,10 @@ void ScrollBar::_bind_methods() {
 
 ScrollBar::ScrollBar(Orientation p_orientation) {
 
+	last_drag_node_time = 0;
+	time_since_motion = 0;
+	click_handled = false;
+
 	orientation = p_orientation;
 	highlight = HIGHLIGHT_NONE;
 	custom_step = -1;

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -360,6 +360,8 @@ void SplitContainer::_bind_methods() {
 
 SplitContainer::SplitContainer(bool p_vertical) {
 
+	drag_from = 0;
+	drag_ofs = 0;
 	mouse_inside = false;
 	split_offset = 0;
 	should_clamp_split_offset = false;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -149,7 +149,10 @@ public:
 		void clear_wrap_cache();
 		void clear_info_icons();
 		_FORCE_INLINE_ const String &operator[](int p_line) const { return text[p_line].data; }
-		Text() { indent_size = 4; }
+		Text() {
+			indent_size = 4;
+			color_regions = NULL;
+		}
 	};
 
 private:

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -112,6 +112,7 @@ private:
 
 		Cell() {
 
+			custom_bg_outline = false;
 			custom_draw_obj = 0;
 			custom_button = false;
 			mode = TreeItem::CELL_MODE_STRING;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -82,7 +82,10 @@ private:
 
 		bool persistent;
 		SceneTree::Group *group;
-		GroupData() { persistent = false; }
+		GroupData() {
+			persistent = false;
+			group = NULL;
+		}
 	};
 
 	struct Data {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -194,6 +194,15 @@ public:
 
 Viewport::GUI::GUI() {
 
+	key_event_accepted = false;
+	last_mouse_focus = NULL;
+	drag_attempted = false;
+	drag_preview = NULL;
+	tooltip_timer = 0;
+	tooltip_delay = 0;
+	roots_order_dirty = false;
+	canvas_sort_index = 0;
+
 	dragging = false;
 	mouse_focus = NULL;
 	mouse_click_grabber = NULL;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -72,6 +72,7 @@ private:
 		bool imported;
 		bool enabled;
 		Track() {
+			type = TrackType::TYPE_ANIMATION;
 			interpolation = INTERPOLATION_LINEAR;
 			imported = false;
 			loop_wrap = true;
@@ -84,7 +85,10 @@ private:
 
 		float transition;
 		float time; // time in secs
-		Key() { transition = 1; }
+		Key() {
+			transition = 1;
+			time = 0;
+		}
 	};
 
 	// transform key holds either Vector3 or Quaternion
@@ -121,6 +125,7 @@ private:
 		ValueTrack() {
 			type = TYPE_VALUE;
 			update_mode = UPDATE_CONTINUOUS;
+			update_on_seek = false;
 		}
 	};
 

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -1042,6 +1042,7 @@ SelfList<DynamicFont>::List *DynamicFont::dynamic_fonts = NULL;
 DynamicFont::DynamicFont() :
 		font_list(this) {
 
+	valid = false;
 	cache_id.size = 16;
 	outline_cache_id.size = 16;
 	spacing_top = 0;

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -151,6 +151,9 @@ class DynamicFontAtSize : public Reference {
 		float advance;
 
 		Character() {
+			found = false;
+			h_align = 0;
+			advance = 0;
 			texture_idx = 0;
 			v_align = 0;
 		}

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -122,6 +122,8 @@ public:
 		Character() {
 			texture_idx = 0;
 			v_align = 0;
+			h_align = 0;
+			advance = 0;
 		}
 	};
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -665,6 +665,12 @@ void ResourceInteractiveLoaderText::set_translation_remapped(bool p_remapped) {
 }
 
 ResourceInteractiveLoaderText::ResourceInteractiveLoaderText() {
+	f = NULL;
+	is_scene = false;
+	ignore_resource_parsing = false;
+	resources_total = 0;
+	resource_current = 0;
+	lines = 0;
 	translation_remapped = false;
 }
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2296,6 +2296,7 @@ String VisualShaderNodeOutput::generate_code(Shader::Mode p_mode, VisualShader::
 }
 
 VisualShaderNodeOutput::VisualShaderNodeOutput() {
+	shader_type = VisualShader::Type::TYPE_MAX;
 }
 
 ///////////////////////////

--- a/servers/arvr_server.cpp
+++ b/servers/arvr_server.cpp
@@ -368,6 +368,9 @@ void ARVRServer::_mark_commit() {
 
 ARVRServer::ARVRServer() {
 	singleton = this;
+	last_process_usec = 0;
+	last_commit_usec = 0;
+	last_frame_usec = 0;
 	world_scale = 1.0;
 };
 

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -127,6 +127,13 @@ void AudioDriverDummy::finish() {
 
 AudioDriverDummy::AudioDriverDummy() {
 
+	samples_in = NULL;
+	buffer_frames = 0;
+	mix_rate = 0;
+	channels = 0;
+	active = false;
+	thread_exited = false;
+	exit_thread = false;
 	mutex = NULL;
 	thread = NULL;
 };

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -234,6 +234,8 @@ AudioStreamPlaybackMicrophone::~AudioStreamPlaybackMicrophone() {
 }
 
 AudioStreamPlaybackMicrophone::AudioStreamPlaybackMicrophone() {
+	active = false;
+	input_ofs = 0;
 }
 
 ////////////////////////////////

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -360,6 +360,9 @@ void AudioEffectPitchShift::_bind_methods() {
 }
 
 AudioEffectPitchShift::AudioEffectPitchShift() {
+	wet = 0;
+	dry = 0;
+	filter = false;
 	pitch_scale = 1.0;
 	oversampling = 4;
 	fft_size = FFT_SIZE_2048;

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -136,6 +136,11 @@ void AudioEffectRecordInstance::finish() {
 
 AudioEffectRecordInstance::~AudioEffectRecordInstance() {
 
+	is_recording = false;
+	io_thread = NULL;
+	ring_buffer_pos = 0;
+	ring_buffer_mask = 0;
+	ring_buffer_read_pos = 0;
 	finish();
 }
 

--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -72,7 +72,13 @@ public:
 	virtual bool process_silence() const;
 
 	AudioEffectRecordInstance() :
-			thread_active(false) {}
+			thread_active(false) {
+		is_recording = false;
+		io_thread = NULL;
+		ring_buffer_pos = 0;
+		ring_buffer_mask = 0;
+		ring_buffer_read_pos = 0;
+	}
 	~AudioEffectRecordInstance();
 };
 

--- a/servers/audio/effects/audio_effect_stereo_enhance.cpp
+++ b/servers/audio/effects/audio_effect_stereo_enhance.cpp
@@ -152,6 +152,7 @@ void AudioEffectStereoEnhance::_bind_methods() {
 }
 
 AudioEffectStereoEnhance::AudioEffectStereoEnhance() {
+	volume_db = 0;
 	pan_pullout = 1;
 	time_pullout = 0;
 	surround = 0;

--- a/servers/audio/effects/reverb.h
+++ b/servers/audio/effects/reverb.h
@@ -67,6 +67,8 @@ private:
 		int extra_spread_frames;
 
 		Comb() {
+			damp = 0;
+			extra_spread_frames = 0;
 			size = 0;
 			buffer = 0;
 			feedback = 0;
@@ -85,6 +87,7 @@ private:
 			size = 0;
 			buffer = 0;
 			pos = 0;
+			extra_spread_frames = 0;
 		}
 	};
 

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -136,6 +136,8 @@ RID CameraFeed::get_texture(CameraServer::FeedImage p_which) {
 CameraFeed::CameraFeed() {
 	// initialize our feed
 	id = CameraServer::get_singleton()->get_free_id();
+	base_height = 0;
+	base_width = 0;
 	name = "???";
 	active = false;
 	datatype = CameraFeed::FEED_RGB;

--- a/servers/physics/collision_object_sw.h
+++ b/servers/physics/collision_object_sw.h
@@ -68,7 +68,11 @@ private:
 		ShapeSW *shape;
 		bool disabled;
 
-		Shape() { disabled = false; }
+		Shape() {
+			disabled = false;
+			bpid = 0;
+			shape = NULL;
+		}
 	};
 
 	Vector<Shape> shapes;

--- a/servers/physics/constraint_sw.h
+++ b/servers/physics/constraint_sw.h
@@ -47,6 +47,8 @@ class ConstraintSW : public RID_Data {
 
 protected:
 	ConstraintSW(BodySW **p_body_ptr = NULL, int p_body_count = 0) {
+		island_next = NULL;
+		island_list_next = NULL;
 		_body_ptr = p_body_ptr;
 		_body_count = p_body_count;
 		island_step = 0;

--- a/servers/physics/gjk_epa.cpp
+++ b/servers/physics/gjk_epa.cpp
@@ -169,6 +169,7 @@ struct	GJK
 		}
 		void				Initialize()
 		{
+			m_simplex   =   nullptr;
 			m_ray		=	Vector3(0,0,0);
 			m_nfree		=	0;
 			m_status	=	eStatus::Failed;

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -1580,6 +1580,10 @@ PhysicsServerSW::PhysicsServerSW() {
 	active_objects = 0;
 	collision_pairs = 0;
 
+	iterations = 0;
+	stepper = NULL;
+	direct_state = NULL;
+
 	active = true;
 	flushing_queries = false;
 };

--- a/servers/physics/shape_sw.h
+++ b/servers/physics/shape_sw.h
@@ -465,7 +465,10 @@ struct MotionShapeSW : public ShapeSW {
 	virtual void set_data(const Variant &p_data) {}
 	virtual Variant get_data() const { return Variant(); }
 
-	MotionShapeSW() { configure(AABB()); }
+	MotionShapeSW() {
+		configure(AABB());
+		shape = NULL;
+	}
 };
 
 struct _ShapeTestConvexBSPSW {

--- a/servers/physics_2d/broad_phase_2d_hash_grid.cpp
+++ b/servers/physics_2d/broad_phase_2d_hash_grid.cpp
@@ -633,6 +633,9 @@ BroadPhase2DSW *BroadPhase2DHashGrid::_create() {
 
 BroadPhase2DHashGrid::BroadPhase2DHashGrid() {
 
+	pair_userdata = NULL;
+	unpair_userdata = NULL;
+
 	hash_table_size = GLOBAL_DEF("physics/2d/bp_hash_table_size", 4096);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/bp_hash_table_size", PropertyInfo(Variant::INT, "physics/2d/bp_hash_table_size", PROPERTY_HINT_RANGE, "0,8192,1,or_greater"));
 	hash_table_size = Math::larger_prime(hash_table_size);

--- a/servers/physics_2d/collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/collision_solver_2d_sat.cpp
@@ -189,8 +189,10 @@ class SeparatorAxisTest2D {
 	const Transform2D *transform_B;
 	real_t best_depth;
 	Vector2 best_axis;
+#ifdef DEBUG_ENABLED
 	int best_axis_count;
 	int best_axis_index;
+#endif
 	Vector2 motion_A;
 	Vector2 motion_B;
 	real_t margin_A;

--- a/servers/physics_2d/constraint_2d_sw.h
+++ b/servers/physics_2d/constraint_2d_sw.h
@@ -46,6 +46,8 @@ class Constraint2DSW : public RID_Data {
 
 protected:
 	Constraint2DSW(Body2DSW **p_body_ptr = NULL, int p_body_count = 0) {
+		island_list_next = NULL;
+		island_next = NULL;
 		_body_ptr = p_body_ptr;
 		_body_count = p_body_count;
 		island_step = 0;

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -1439,6 +1439,11 @@ Physics2DServerSW *Physics2DServerSW::singletonsw = NULL;
 
 Physics2DServerSW::Physics2DServerSW() {
 
+	iterations = 0;
+	doing_sync = false;
+	stepper = NULL;
+	direct_state = NULL;
+
 	singletonsw = this;
 	BroadPhase2DSW::create_func = BroadPhase2DHashGrid::_create;
 	//BroadPhase2DSW::create_func=BroadPhase2DBasic::_create;

--- a/servers/physics_2d/shape_2d_sw.h
+++ b/servers/physics_2d/shape_2d_sw.h
@@ -227,8 +227,14 @@ public:
 
 	DEFAULT_PROJECT_RANGE_CAST
 
-	_FORCE_INLINE_ RayShape2DSW() {}
-	_FORCE_INLINE_ RayShape2DSW(real_t p_length) { length = p_length; }
+	_FORCE_INLINE_ RayShape2DSW() {
+		slips_on_slope = false;
+		length = 0;
+	}
+	_FORCE_INLINE_ RayShape2DSW(real_t p_length) {
+		length = p_length;
+		slips_on_slope = false;
+	}
 };
 
 class SegmentShape2DSW : public Shape2DSW {

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -128,6 +128,8 @@ public:
 		InstanceBase() :
 				dependency_item(this) {
 
+			mirror = false;
+			depth = 0;
 			base_type = VS::INSTANCE_NONE;
 			cast_shadows = VS::SHADOW_CASTING_SETTING_ON;
 			receive_shadows = true;
@@ -664,6 +666,8 @@ public:
 		RID light_internal;
 
 		Light() {
+			radius_cache = 0;
+			shadows_next_ptr = NULL;
 			enabled = true;
 			color = Color(1, 1, 1);
 			shadow_color = Color(0, 0, 0, 0);
@@ -722,7 +726,11 @@ public:
 			Color color;
 			float width;
 			bool antialiased;
-			CommandLine() { type = TYPE_LINE; }
+			CommandLine() {
+				type = TYPE_LINE;
+				width = 0;
+				antialiased = false;
+			}
 		};
 		struct CommandPolyLine : public Command {
 
@@ -768,6 +776,9 @@ public:
 			CommandNinePatch() {
 				draw_center = true;
 				type = TYPE_NINEPATCH;
+				for (int i = 0; i < 4; i++) {
+					margin[i] = 0;
+				}
 			}
 		};
 
@@ -803,6 +814,8 @@ public:
 			CommandPolygon() {
 				type = TYPE_POLYGON;
 				count = 0;
+				antialiased = false;
+				antialiasing_use_indices = false;
 			}
 		};
 
@@ -837,7 +850,10 @@ public:
 			Point2 pos;
 			float radius;
 			Color color;
-			CommandCircle() { type = TYPE_CIRCLE; }
+			CommandCircle() {
+				type = TYPE_CIRCLE;
+				radius = 0;
+			}
 		};
 
 		struct CommandTransform : public Command {

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -5926,6 +5926,16 @@ ShaderLanguage::ShaderNode *ShaderLanguage::get_shader() {
 
 ShaderLanguage::ShaderLanguage() {
 
+	error_set = false;
+	error_line = 0;
+	char_idx = 0;
+	tk_line = 0;
+	shader = NULL;
+	completion_type = CompletionType::COMPLETION_CALL_ARGUMENTS;
+	completion_line = 0;
+	completion_block = NULL;
+	completion_base = DataType::TYPE_BOOL;
+	completion_argument = 0;
 	nodes = NULL;
 	completion_class = TAG_GLOBAL;
 }

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -3672,6 +3672,14 @@ bool VisualServerScene::free(RID p_rid) {
 VisualServerScene *VisualServerScene::singleton = NULL;
 
 VisualServerScene::VisualServerScene() {
+	instance_cull_count = 0;
+	light_cull_count = 0;
+	directional_light_count = 0;
+	reflection_probe_cull_count = 0;
+	probe_bake_mutex = NULL;
+	probe_bake_sem = NULL;
+	probe_bake_thread = NULL;
+	probe_bake_thread_exit = false;
 
 #ifndef NO_THREADS
 	probe_bake_sem = Semaphore::create();

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -346,6 +346,7 @@ public:
 		InstanceReflectionProbeData() :
 				update_list(this) {
 
+			owner = NULL;
 			reflection_dirty = true;
 			render_step = -1;
 		}
@@ -479,6 +480,7 @@ public:
 
 		InstanceGIProbeData() :
 				update_element(this) {
+			owner = NULL;
 			invalid = true;
 			base_version = 0;
 			dynamic.updating_stage = GI_UPDATE_STAGE_CHECK;

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -110,6 +110,9 @@ public:
 		Map<RID, CanvasData> canvas_map;
 
 		Viewport() {
+			viewport_render_direct_to_screen = false;
+			hide_canvas = false;
+			hide_scenario = false;
 			update_mode = VS::VIEWPORT_UPDATE_WHEN_VISIBLE;
 			clear_mode = VS::VIEWPORT_CLEAR_ALWAYS;
 			transparent_bg = false;

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2389,6 +2389,8 @@ void VisualServer::set_render_loop_enabled(bool p_enabled) {
 
 VisualServer::VisualServer() {
 
+	mm_policy = 0;
+
 	//ERR_FAIL_COND(singleton);
 	singleton = this;
 


### PR DESCRIPTION
Part of #43636 for 3.x branch.

It should decrease number of Cppcheck errors from 791 to ~125(except buffers and some rendering things).

It should be really easy to check this commit, because it adds only to constructor values initializations(in opposite to similar commits to master branch when I moved a lot of things across code and also initialized structs members which was not shown in Cppcheck).