### PR TITLE
Remove connect *_compat methods

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1266,10 +1266,6 @@ void Object::get_signals_connected_to_this(List<Connection> *p_connections) cons
 	}
 }
 
-Error Object::connect_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method, const Vector<Variant> &p_binds, uint32_t p_flags) {
-	return connect(p_signal, Callable(p_to_object, p_to_method), p_binds, p_flags);
-}
-
 Error Object::connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds, uint32_t p_flags) {
 	ERR_FAIL_COND_V(p_callable.is_null(), ERR_INVALID_PARAMETER);
 
@@ -1331,10 +1327,6 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, co
 	return OK;
 }
 
-bool Object::is_connected_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method) const {
-	return is_connected(p_signal, Callable(p_to_object, p_to_method));
-}
-
 bool Object::is_connected(const StringName &p_signal, const Callable &p_callable) const {
 	ERR_FAIL_COND_V(p_callable.is_null(), false);
 	const SignalData *s = signal_map.getptr(p_signal);
@@ -1356,10 +1348,6 @@ bool Object::is_connected(const StringName &p_signal, const Callable &p_callable
 	return s->slot_map.has(*target.get_base_comparator());
 	//const Map<Signal::Target,Signal::Slot>::Element *E = s->slot_map.find(target);
 	//return (E!=nullptr );
-}
-
-void Object::disconnect_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method) {
-	_disconnect(p_signal, Callable(p_to_object, p_to_method));
 }
 
 void Object::disconnect(const StringName &p_signal, const Callable &p_callable) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -697,10 +697,6 @@ public:
 	int get_persistent_signal_connection_count() const;
 	void get_signals_connected_to_this(List<Connection> *p_connections) const;
 
-	Error connect_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);
-	void disconnect_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method);
-	bool is_connected_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method) const;
-
 	Error connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);
 	void disconnect(const StringName &p_signal, const Callable &p_callable);
 	bool is_connected(const StringName &p_signal, const Callable &p_callable) const;

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -507,14 +507,14 @@ Ref<Animation> AnimationBezierTrackEdit::get_animation() const {
 void AnimationBezierTrackEdit::set_animation_and_track(const Ref<Animation> &p_animation, int p_track) {
 	animation = p_animation;
 	track = p_track;
-	if (is_connected_compat("select_key", editor, "_key_selected")) {
-		disconnect_compat("select_key", editor, "_key_selected");
+	if (is_connected("select_key", Callable(editor, "_key_selected"))) {
+		disconnect("select_key", Callable(editor, "_key_selected"));
 	}
-	if (is_connected_compat("deselect_key", editor, "_key_deselected")) {
-		disconnect_compat("deselect_key", editor, "_key_deselected");
+	if (is_connected("deselect_key", Callable(editor, "_key_deselected"))) {
+		disconnect("deselect_key", Callable(editor, "_key_deselected"));
 	}
-	connect_compat("select_key", editor, "_key_selected", varray(p_track), CONNECT_DEFERRED);
-	connect_compat("deselect_key", editor, "_key_deselected", varray(p_track), CONNECT_DEFERRED);
+	connect("select_key", Callable(editor, "_key_selected"), varray(p_track), CONNECT_DEFERRED);
+	connect("deselect_key", Callable(editor, "_key_deselected"), varray(p_track), CONNECT_DEFERRED);
 	update();
 }
 
@@ -533,7 +533,7 @@ void AnimationBezierTrackEdit::set_timeline(AnimationTimelineEdit *p_timeline) {
 
 void AnimationBezierTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 	editor = p_editor;
-	connect_compat("clear_selection", editor, "_clear_selection", varray(false));
+	connect("clear_selection", Callable(editor, "_clear_selection"), varray(false));
 }
 
 void AnimationBezierTrackEdit::_play_position_draw() {

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -42,7 +42,7 @@ void EditorPluginSettings::_notification(int p_what) {
 	if (p_what == NOTIFICATION_WM_WINDOW_FOCUS_IN) {
 		update_plugins();
 	} else if (p_what == Node::NOTIFICATION_READY) {
-		plugin_config_dialog->connect_compat("plugin_ready", EditorNode::get_singleton(), "_on_plugin_ready");
+		plugin_config_dialog->connect("plugin_ready", Callable(EditorNode::get_singleton(), "_on_plugin_ready"));
 		plugin_list->connect("button_pressed", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
 	}
 }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6667,7 +6667,7 @@ Node3DEditorPlugin::Node3DEditorPlugin(EditorNode *p_node) {
 	editor->get_viewport()->add_child(spatial_editor);
 
 	spatial_editor->hide();
-	spatial_editor->connect_compat("transform_key_request", editor->get_inspector_dock(), "_transform_keyed");
+	spatial_editor->connect("transform_key_request", Callable(editor->get_inspector_dock(), "_transform_keyed"));
 }
 
 Node3DEditorPlugin::~Node3DEditorPlugin() {

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -3620,11 +3620,11 @@ void TileSetEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		tileset_editor_button->show();
 		editor->make_bottom_panel_item_visible(tileset_editor);
-		get_tree()->connect_compat("idle_frame", tileset_editor, "_on_workspace_process");
+		get_tree()->connect("idle_frame", Callable(tileset_editor, "_on_workspace_process"));
 	} else {
 		editor->hide_bottom_panel();
 		tileset_editor_button->hide();
-		get_tree()->disconnect_compat("idle_frame", tileset_editor, "_on_workspace_process");
+		get_tree()->disconnect("idle_frame", Callable(tileset_editor, "_on_workspace_process"));
 	}
 }
 

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -865,10 +865,10 @@ void ProjectExportDialog::_validate_export_path(const String &p_path) {
 
 	if (invalid_path) {
 		export_project->get_ok()->set_disabled(true);
-		export_project->get_line_edit()->disconnect_compat("text_entered", export_project, "_file_entered");
+		export_project->get_line_edit()->disconnect("text_entered", Callable(export_project, "_file_entered"));
 	} else {
 		export_project->get_ok()->set_disabled(false);
-		export_project->get_line_edit()->connect_compat("text_entered", export_project, "_file_entered");
+		export_project->get_line_edit()->connect("text_entered", Callable(export_project, "_file_entered"));
 	}
 }
 
@@ -900,9 +900,9 @@ void ProjectExportDialog::_export_project() {
 	// with _validate_export_path.
 	// FIXME: This is a hack, we should instead change EditorFileDialog to allow
 	// disabling validation by the "text_entered" signal.
-	if (!export_project->get_line_edit()->is_connected_compat("text_entered", export_project, "_file_entered")) {
+	if (!export_project->get_line_edit()->is_connected("text_entered", Callable(export_project, "_file_entered"))) {
 		export_project->get_ok()->set_disabled(false);
-		export_project->get_line_edit()->connect_compat("text_entered", export_project, "_file_entered");
+		export_project->get_line_edit()->connect("text_entered", Callable(export_project, "_file_entered"));
 	}
 
 	export_project->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1073,14 +1073,14 @@ void SceneTreeDock::_notification(int p_what) {
 
 			CanvasItemEditorPlugin *canvas_item_plugin = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor("2D"));
 			if (canvas_item_plugin) {
-				canvas_item_plugin->get_canvas_item_editor()->connect_compat("item_lock_status_changed", scene_tree, "_update_tree");
-				canvas_item_plugin->get_canvas_item_editor()->connect_compat("item_group_status_changed", scene_tree, "_update_tree");
+				canvas_item_plugin->get_canvas_item_editor()->connect("item_lock_status_changed", Callable(scene_tree, "_update_tree"));
+				canvas_item_plugin->get_canvas_item_editor()->connect("item_group_status_changed", Callable(scene_tree, "_update_tree"));
 				scene_tree->connect("node_changed", callable_mp((CanvasItem *)canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), &CanvasItem::update));
 			}
 
 			Node3DEditorPlugin *spatial_editor_plugin = Object::cast_to<Node3DEditorPlugin>(editor_data->get_editor("3D"));
-			spatial_editor_plugin->get_spatial_editor()->connect_compat("item_lock_status_changed", scene_tree, "_update_tree");
-			spatial_editor_plugin->get_spatial_editor()->connect_compat("item_group_status_changed", scene_tree, "_update_tree");
+			spatial_editor_plugin->get_spatial_editor()->connect("item_lock_status_changed", Callable(scene_tree, "_update_tree"));
+			spatial_editor_plugin->get_spatial_editor()->connect("item_group_status_changed", Callable(scene_tree, "_update_tree"));
 
 			button_add->set_icon(get_theme_icon("Add", "EditorIcons"));
 			button_instance->set_icon(get_theme_icon("Instance", "EditorIcons"));

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2367,7 +2367,7 @@ void VisualScriptFunctionState::connect_to_signal(Object *p_obj, const String &p
 		binds.push_back(p_binds[i]);
 	}
 	binds.push_back(Ref<VisualScriptFunctionState>(this)); //add myself on the back to avoid dying from unreferencing
-	p_obj->connect_compat(p_signal, this, "_signal_callback", binds, CONNECT_ONESHOT);
+	p_obj->connect(p_signal, Callable(this, "_signal_callback"), binds, CONNECT_ONESHOT);
 }
 
 bool VisualScriptFunctionState::is_valid() const {

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -848,7 +848,7 @@ Ref<SkinReference> Skeleton3D::register_skin(const Ref<Skin> &p_skin) {
 
 	skin_bindings.insert(skin_ref.operator->());
 
-	skin->connect_compat("changed", skin_ref.operator->(), "_skin_changed");
+	skin->connect("changed", Callable(skin_ref.operator->(), "_skin_changed"));
 
 	_make_dirty(); //skin needs to be updated, so update skeleton
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -565,7 +565,7 @@ void AnimationNodeStateMachine::replace_node(const StringName &p_name, Ref<Anima
 	{
 		Ref<AnimationNode> node = states[p_name].node;
 		if (node.is_valid()) {
-			node->disconnect_compat("tree_changed", this, "_tree_changed");
+			node->disconnect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed));
 		}
 	}
 
@@ -574,7 +574,7 @@ void AnimationNodeStateMachine::replace_node(const StringName &p_name, Ref<Anima
 	emit_changed();
 	emit_signal("tree_changed");
 
-	p_node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	p_node->connect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed), varray(), CONNECT_REFERENCE_COUNTED);
 }
 
 Ref<AnimationNode> AnimationNodeStateMachine::get_node(const StringName &p_name) const {


### PR DESCRIPTION
See this discussion: https://github.com/godotengine/godot/pull/44110#issuecomment-739391328

This doesn't *necessarily* make #44110 obsolete, we could still do something with that PR. We could add it for compat but with `[Obsolete]` to warn against using it, for example. If we don't keep the method at all, the additional documentation is still useful, it could be added to the normal `Connect` method in the generated file (not sure how that could be done, cc @neikeq).