### PR TITLE
Mono: Add mono_bcl SCons option for a custom BCL location

### DIFF
--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -97,6 +97,7 @@ def configure(env, env_mono):
     copy_mono_root = env["copy_mono_root"]
 
     mono_prefix = env["mono_prefix"]
+    mono_bcl = env["mono_bcl"]
 
     mono_lib_names = ["mono-2.0-sgen", "monosgen-2.0"]
 
@@ -397,7 +398,7 @@ def configure(env, env_mono):
 
         if tools_enabled:
             # Only supported for editor builds.
-            copy_mono_root_files(env, mono_root)
+            copy_mono_root_files(env, mono_root, mono_bcl)
 
 
 def make_template_dir(env, mono_root):
@@ -430,7 +431,7 @@ def make_template_dir(env, mono_root):
     copy_mono_shared_libs(env, mono_root, template_mono_root_dir)
 
 
-def copy_mono_root_files(env, mono_root):
+def copy_mono_root_files(env, mono_root, mono_bcl):
     from glob import glob
     from shutil import copy
     from shutil import rmtree
@@ -455,7 +456,7 @@ def copy_mono_root_files(env, mono_root):
 
     # Copy framework assemblies
 
-    mono_framework_dir = os.path.join(mono_root, "lib", "mono", "4.5")
+    mono_framework_dir = mono_bcl or os.path.join(mono_root, "lib", "mono", "4.5")
     mono_framework_facades_dir = os.path.join(mono_framework_dir, "Facades")
 
     editor_mono_framework_dir = os.path.join(editor_mono_root_dir, "lib", "mono", "4.5")

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -27,6 +27,14 @@ def configure(env):
             PathVariable.PathAccept,
         )
     )
+    envvars.Add(
+        PathVariable(
+            "mono_bcl",
+            "Path to a custom Mono BCL (Base Class Library) directory for the target platform",
+            "",
+            PathVariable.PathAccept,
+        )
+    )
     envvars.Add(BoolVariable("mono_static", "Statically link Mono", default_mono_static))
     envvars.Add(BoolVariable("mono_glue", "Build with the Mono glue sources", True))
     envvars.Add(BoolVariable("build_cil", "Build C# solutions", True))


### PR DESCRIPTION
Makes it less bothersome to work with builds from our [godotengine/godot-mono-builds](https://github.com/godotengine/godot-mono-builds) scripts, as they write the BCL into an output directory separate from the runtime (which is good as two runtimes may share the same BCL).
