### PR TITLE
Change physics disabled booleans to enabled

### DIFF
--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -19,7 +19,8 @@
 			<argument index="2" name="shape_idx" type="int">
 			</argument>
 			<description>
-				Accepts unhandled [InputEvent]s. Requires [member input_pickable] to be [code]true[/code]. [code]shape_idx[/code] is the child index of the clicked [Shape2D]. Connect to the [code]input_event[/code] signal to easily pick up these events.
+				Accepts unhandled [InputEvent]s. Connect to the [signal input_event] signal to easily pick up these events. [code]shape_idx[/code] is the index of the [Shape2D].
+				[b]Note:[/b] Requires [member input_pickable] to be [code]true[/code].
 			</description>
 		</method>
 		<method name="create_shape_owner">
@@ -29,6 +30,17 @@
 			</argument>
 			<description>
 				Creates a new shape owner for the given object. Returns [code]owner_id[/code] of the new owner for future reference.
+			</description>
+		</method>
+		<method name="enable_shape_owner">
+			<return type="void">
+			</return>
+			<argument index="0" name="owner_id" type="int">
+			</argument>
+			<argument index="1" name="enable" type="bool" default="true">
+			</argument>
+			<description>
+				Enables the shape owner with the specified [code]owner_id[/code] and all its shapes.
 			</description>
 		</method>
 		<method name="get_collision_layer_bit" qualifiers="const">
@@ -56,15 +68,6 @@
 				Returns the object's [RID].
 			</description>
 		</method>
-		<method name="get_shape_owner_one_way_collision_margin" qualifiers="const">
-			<return type="float">
-			</return>
-			<argument index="0" name="owner_id" type="int">
-			</argument>
-			<description>
-				Returns the [code]one_way_collision_margin[/code] of the shape owner identified by given [code]owner_id[/code].
-			</description>
-		</method>
 		<method name="get_shape_owners">
 			<return type="Array">
 			</return>
@@ -72,22 +75,13 @@
 				Returns an [Array] of [code]owner_id[/code] identifiers. You can use these ids in other methods that take [code]owner_id[/code] as an argument.
 			</description>
 		</method>
-		<method name="is_shape_owner_disabled" qualifiers="const">
+		<method name="is_shape_owner_enabled" qualifiers="const">
 			<return type="bool">
 			</return>
 			<argument index="0" name="owner_id" type="int">
 			</argument>
 			<description>
-				If [code]true[/code], the shape owner and its shapes are disabled.
-			</description>
-		</method>
-		<method name="is_shape_owner_one_way_collision_enabled" qualifiers="const">
-			<return type="bool">
-			</return>
-			<argument index="0" name="owner_id" type="int">
-			</argument>
-			<description>
-				Returns [code]true[/code] if collisions for the shape owner originating from this [CollisionObject2D] will not be reported to collided with [CollisionObject2D]s.
+				Returns whether or not the shape owner with the specified [code]owner_id[/code] and all its shapes are enabled.
 			</description>
 		</method>
 		<method name="remove_shape_owner">
@@ -152,6 +146,26 @@
 				Removes all shapes from the shape owner.
 			</description>
 		</method>
+		<method name="shape_owner_enable_one_way_collision">
+			<return type="void">
+			</return>
+			<argument index="0" name="owner_id" type="int">
+			</argument>
+			<argument index="1" name="enable" type="bool" default="true">
+			</argument>
+			<description>
+				Enables the one-way collision property of the specified shape owner and all its shapes.
+			</description>
+		</method>
+		<method name="shape_owner_get_one_way_collision_margin" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="owner_id" type="int">
+			</argument>
+			<description>
+				Returns the [code]one_way_collision_margin[/code] of the shape owner with the specified [code]owner_id[/code].
+			</description>
+		</method>
 		<method name="shape_owner_get_owner" qualifiers="const">
 			<return type="Object">
 			</return>
@@ -201,6 +215,15 @@
 				Returns the shape owner's [Transform2D].
 			</description>
 		</method>
+		<method name="shape_owner_is_one_way_collision_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="owner_id" type="int">
+			</argument>
+			<description>
+				Returns wether or not one-way collision property of the shape owner with the specified [code]owner_id[/code] is enabled.
+			</description>
+		</method>
 		<method name="shape_owner_remove_shape">
 			<return type="void">
 			</return>
@@ -210,28 +233,6 @@
 			</argument>
 			<description>
 				Removes a shape from the given shape owner.
-			</description>
-		</method>
-		<method name="shape_owner_set_disabled">
-			<return type="void">
-			</return>
-			<argument index="0" name="owner_id" type="int">
-			</argument>
-			<argument index="1" name="disabled" type="bool">
-			</argument>
-			<description>
-				If [code]true[/code], disables the given shape owner.
-			</description>
-		</method>
-		<method name="shape_owner_set_one_way_collision">
-			<return type="void">
-			</return>
-			<argument index="0" name="owner_id" type="int">
-			</argument>
-			<argument index="1" name="enable" type="bool">
-			</argument>
-			<description>
-				If [code]enable[/code] is [code]true[/code], collisions for the shape owner originating from this [CollisionObject2D] will not be reported to collided with [CollisionObject2D]s.
 			</description>
 		</method>
 		<method name="shape_owner_set_one_way_collision_margin">
@@ -267,7 +268,8 @@
 			[b]Note:[/b] A contact is detected if object A is in any of the layers that object B scans, or object B is in any layers that object A scans. See [url=https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="input_pickable" type="bool" setter="set_pickable" getter="is_pickable" default="true">
-			If [code]true[/code], this object is pickable. A pickable object can detect the mouse pointer entering/leaving, and if the mouse is inside it, report input events. Requires at least one [code]collision_layer[/code] bit to be set.
+			If [code]true[/code], this object can trigger input events. A pickable object will detect the mouse pointer entering and leaving, and, while the mouse is on it, generate [InputEventMouse] events.
+			[b]Note:[/b] Requires at least one [code]collision_layer[/code] bit to be set.
 		</member>
 	</members>
 	<signals>
@@ -279,17 +281,20 @@
 			<argument index="2" name="shape_idx" type="int">
 			</argument>
 			<description>
-				Emitted when an input event occurs. Requires [member input_pickable] to be [code]true[/code] and at least one [code]collision_layer[/code] bit to be set. See [method _input_event] for details.
+				Emitted when the mouse is over any of this object's shapes. See [InputEventMouse] for [code]event[/code] details.
+				[b]Note:[/b] Requires [member input_pickable] to be [code]true[/code].
 			</description>
 		</signal>
 		<signal name="mouse_entered">
 			<description>
-				Emitted when the mouse pointer enters any of this object's shapes. Requires [member input_pickable] to be [code]true[/code] and at least one [code]collision_layer[/code] bit to be set.
+				Emitted when the mouse pointer enters any of this object's shapes.
+				[b]Note:[/b] Requires [member input_pickable] to be [code]true[/code].
 			</description>
 		</signal>
 		<signal name="mouse_exited">
 			<description>
-				Emitted when the mouse pointer exits all this object's shapes. Requires [member input_pickable] to be [code]true[/code] and at least one [code]collision_layer[/code] bit to be set.
+				Emitted when the mouse pointer exits all this object's shapes.
+				[b]Note:[/b] Requires [member input_pickable] to be [code]true[/code].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -16,14 +16,15 @@
 			</argument>
 			<argument index="1" name="event" type="InputEvent">
 			</argument>
-			<argument index="2" name="click_position" type="Vector3">
+			<argument index="2" name="position" type="Vector3">
 			</argument>
-			<argument index="3" name="click_normal" type="Vector3">
+			<argument index="3" name="normal" type="Vector3">
 			</argument>
 			<argument index="4" name="shape_idx" type="int">
 			</argument>
 			<description>
-				Accepts unhandled [InputEvent]s. [code]click_position[/code] is the clicked location in world space and [code]click_normal[/code] is the normal vector extending from the clicked surface of the [Shape3D] at [code]shape_idx[/code]. Connect to the [code]input_event[/code] signal to easily pick up these events.
+				Accepts unhandled [InputEvent]s. Connect to the [signal input_event] signal to easily pick up these events.
+				[b]Note:[/b] Requires [member input_pickable] to be [code]true[/code].
 			</description>
 		</method>
 		<method name="create_shape_owner">
@@ -33,6 +34,17 @@
 			</argument>
 			<description>
 				Creates a new shape owner for the given object. Returns [code]owner_id[/code] of the new owner for future reference.
+			</description>
+		</method>
+		<method name="enable_shape_owner">
+			<return type="void">
+			</return>
+			<argument index="0" name="owner_id" type="int">
+			</argument>
+			<argument index="1" name="enable" type="bool" default="true">
+			</argument>
+			<description>
+				Enables the shape owner with the specified [code]owner_id[/code] and all its shapes.
 			</description>
 		</method>
 		<method name="get_collision_layer_bit" qualifiers="const">
@@ -67,13 +79,13 @@
 				Returns an [Array] of [code]owner_id[/code] identifiers. You can use these ids in other methods that take [code]owner_id[/code] as an argument.
 			</description>
 		</method>
-		<method name="is_shape_owner_disabled" qualifiers="const">
+		<method name="is_shape_owner_enabled" qualifiers="const">
 			<return type="bool">
 			</return>
 			<argument index="0" name="owner_id" type="int">
 			</argument>
 			<description>
-				If [code]true[/code], the shape owner and its shapes are disabled.
+				Returns whether or not the shape owner with the specified [code]owner_id[/code] and all its shapes are enabled.
 			</description>
 		</method>
 		<method name="remove_shape_owner">
@@ -198,17 +210,6 @@
 				Removes a shape from the given shape owner.
 			</description>
 		</method>
-		<method name="shape_owner_set_disabled">
-			<return type="void">
-			</return>
-			<argument index="0" name="owner_id" type="int">
-			</argument>
-			<argument index="1" name="disabled" type="bool">
-			</argument>
-			<description>
-				If [code]true[/code], disables the given shape owner.
-			</description>
-		</method>
 		<method name="shape_owner_set_transform">
 			<return type="void">
 			</return>
@@ -230,11 +231,12 @@
 			The physics layers this CollisionObject3D scans. Collision objects can scan one or more of 32 different layers. See also [member collision_layer].
 			[b]Note:[/b] A contact is detected if object A is in any of the layers that object B scans, or object B is in any layers that object A scans. See [url=https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
-		<member name="input_capture_on_drag" type="bool" setter="set_capture_input_on_drag" getter="get_capture_input_on_drag" default="false">
-			If [code]true[/code], the [CollisionObject3D] will continue to receive input events as the mouse is dragged across its shapes.
+		<member name="input_capture_on_drag" type="bool" setter="enable_capture_on_drag" getter="is_capture_on_drag_enabled" default="false">
+			If [code]true[/code], this object will continue to receive input events as the mouse is dragged across its shapes.
 		</member>
-		<member name="input_ray_pickable" type="bool" setter="set_ray_pickable" getter="is_ray_pickable" default="true">
-			If [code]true[/code], the [CollisionObject3D]'s shapes will respond to [RayCast3D]s.
+		<member name="input_pickable" type="bool" setter="set_pickable" getter="is_pickable" default="true">
+			If [code]true[/code], this object can trigger input events. A pickable object will detect the mouse pointer entering and leaving, and, while the mouse is on it, generate [InputEventMouse] events.
+			[b]Note:[/b] Requires at least one [code]collision_layer[/code] bit to be set.
 		</member>
 	</members>
 	<signals>
@@ -243,24 +245,27 @@
 			</argument>
 			<argument index="1" name="event" type="InputEvent">
 			</argument>
-			<argument index="2" name="click_position" type="Vector3">
+			<argument index="2" name="position" type="Vector3">
 			</argument>
-			<argument index="3" name="click_normal" type="Vector3">
+			<argument index="3" name="normal" type="Vector3">
 			</argument>
 			<argument index="4" name="shape_idx" type="int">
 			</argument>
 			<description>
-				Emitted when [method _input_event] receives an event. See its description for details.
+				Emitted when the mouse is over any of this object's shapes. [code]position[/code] is the location in world space of the event and [code]normal[/code] is the normal of the surface of the [Shape3D] with index [code]shape_idx[/code].
+				[b]Note:[/b] Requires [member input_pickable] to be [code]true[/code].
 			</description>
 		</signal>
 		<signal name="mouse_entered">
 			<description>
 				Emitted when the mouse pointer enters any of this object's shapes.
+				[b]Note:[/b] Requires [member input_pickable] to be [code]true[/code].
 			</description>
 		</signal>
 		<signal name="mouse_exited">
 			<description>
 				Emitted when the mouse pointer exits all this object's shapes.
+				[b]Note:[/b] Requires [member input_pickable] to be [code]true[/code].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/CollisionPolygon2D.xml
+++ b/doc/classes/CollisionPolygon2D.xml
@@ -14,14 +14,14 @@
 		<member name="build_mode" type="int" setter="set_build_mode" getter="get_build_mode" enum="CollisionPolygon2D.BuildMode" default="0">
 			Collision build mode. Use one of the [enum BuildMode] constants.
 		</member>
-		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
-			If [code]true[/code], no collisions will be detected.
+		<member name="enabled" type="bool" setter="enable" getter="is_enabled" default="true">
+			If [code]true[/code], other objects will collide with this [CollisionPolygon2D].
 		</member>
-		<member name="one_way_collision" type="bool" setter="set_one_way_collision" getter="is_one_way_collision_enabled" default="false">
-			If [code]true[/code], only edges that face up, relative to [CollisionPolygon2D]'s rotation, will collide with other objects.
+		<member name="one_way_collision" type="bool" setter="enable_one_way_collision" getter="is_one_way_collision_enabled" default="false">
+			If [code]true[/code], other objects will only collide with edges that face up, relative to this [CollisionPolygon2D]'s rotation.
 		</member>
 		<member name="one_way_collision_margin" type="float" setter="set_one_way_collision_margin" getter="get_one_way_collision_margin" default="1.0">
-			The margin used for one-way collision (in pixels). Higher values will make the shape thicker, and work better for colliders that enter the polygon at a high velocity.
+			The margin used for one-way collisions (in pixels). Higher values will make the shape thicker, and work better for colliders that enter the polygon at a high velocity.
 		</member>
 		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array(  )">
 			The polygon's list of vertices. The final point will be connected to the first. The returned value is a clone of the [PackedVector2Array], not a reference.

--- a/doc/classes/CollisionPolygon3D.xml
+++ b/doc/classes/CollisionPolygon3D.xml
@@ -14,8 +14,8 @@
 		<member name="depth" type="float" setter="set_depth" getter="get_depth" default="1.0">
 			Length that the resulting collision extends in either direction perpendicular to its polygon.
 		</member>
-		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
-			If [code]true[/code], no collision will be produced.
+		<member name="enabled" type="bool" setter="enable" getter="is_enabled" default="true">
+			If [code]true[/code], other objects will collide with this [CollisionPolygon3D].
 		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.04">
 			The collision margin for the generated [Shape3D]. See [member Shape3D.margin] for more details.

--- a/doc/classes/CollisionShape2D.xml
+++ b/doc/classes/CollisionShape2D.xml
@@ -15,14 +15,14 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
-			A disabled collision shape has no effect in the world. This property should be changed with [method Object.set_deferred].
+		<member name="enabled" type="bool" setter="enable" getter="is_enabled" default="true">
+			If [code]true[/code], other objects will collide with this [CollisionShape2D]. This property should be changed with [method Object.set_deferred].
 		</member>
-		<member name="one_way_collision" type="bool" setter="set_one_way_collision" getter="is_one_way_collision_enabled" default="false">
-			Sets whether this collision shape should only detect collision on one side (top or bottom).
+		<member name="one_way_collision" type="bool" setter="enable_one_way_collision" getter="is_one_way_collision_enabled" default="false">
+			If [code]true[/code], other objects will only collide with edges that face up, relative to this [CollisionShape2D]'s rotation.
 		</member>
 		<member name="one_way_collision_margin" type="float" setter="set_one_way_collision_margin" getter="get_one_way_collision_margin" default="1.0">
-			The margin used for one-way collision (in pixels). Higher values will make the shape thicker, and work better for colliders that enter the shape at a high velocity.
+			The margin used for one-way collisions (in pixels). Higher values will make the shape thicker, and work better for colliders that enter the shape at a high velocity.
 		</member>
 		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape">
 			The actual shape owned by this collision shape.

--- a/doc/classes/CollisionShape3D.xml
+++ b/doc/classes/CollisionShape3D.xml
@@ -31,8 +31,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
-			A disabled collision shape has no effect in the world.
+		<member name="enabled" type="bool" setter="enable" getter="is_enabled" default="true">
+			If [code]true[/code], other objects will collide with this [CollisionShape3D].
 		</member>
 		<member name="shape" type="Shape3D" setter="set_shape" getter="get_shape">
 			The actual shape owned by this collision shape.

--- a/doc/classes/Joint2D.xml
+++ b/doc/classes/Joint2D.xml
@@ -14,14 +14,14 @@
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="0.0">
 			When [member node_a] and [member node_b] move in different directions the [code]bias[/code] controls how fast the joint pulls them back to their original position. The lower the [code]bias[/code] the more the two bodies can pull on the joint.
 		</member>
-		<member name="disable_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
-			If [code]true[/code], [member node_a] and [member node_b] can not collide.
+		<member name="collisions_between_bodies" type="bool" setter="enable_collisions_between_bodies" getter="is_collisions_between_bodies_enabled" default="false">
+			If [code]true[/code], the [PhysicsBody2D]s assigned to [member node_a] and [member node_b] will collide with each other.
 		</member>
 		<member name="node_a" type="NodePath" setter="set_node_a" getter="get_node_a" default="NodePath(&quot;&quot;)">
-			The first body attached to the joint. Must derive from [PhysicsBody2D].
+			The first [PhysicsBody2D] attached to the joint.
 		</member>
 		<member name="node_b" type="NodePath" setter="set_node_b" getter="get_node_b" default="NodePath(&quot;&quot;)">
-			The second body attached to the joint. Must derive from [PhysicsBody2D].
+			The second [PhysicsBody2D] attached to the joint.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Joint3D.xml
+++ b/doc/classes/Joint3D.xml
@@ -12,14 +12,14 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="collision/exclude_nodes" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
-			If [code]true[/code], the two bodies of the nodes are not able to collide with each other.
+		<member name="collisions_between_bodies" type="bool" setter="enable_collisions_between_bodies" getter="is_collisions_between_bodies_enabled" default="false">
+			If [code]true[/code], the [PhysicsBody3D]s assigned to [member node_a] and [member node_b] will collide with each other.
 		</member>
-		<member name="nodes/node_a" type="NodePath" setter="set_node_a" getter="get_node_a" default="NodePath(&quot;&quot;)">
-			The node attached to the first side (A) of the joint.
+		<member name="node_a" type="NodePath" setter="set_node_a" getter="get_node_a" default="NodePath(&quot;&quot;)">
+			The first [PhysicsBody3D] attached to the joint.
 		</member>
-		<member name="nodes/node_b" type="NodePath" setter="set_node_b" getter="get_node_b" default="NodePath(&quot;&quot;)">
-			The node attached to the second side (B) of the joint.
+		<member name="node_b" type="NodePath" setter="set_node_b" getter="get_node_b" default="NodePath(&quot;&quot;)">
+			The second [PhysicsBody3D] attached to the joint.
 		</member>
 		<member name="solver/priority" type="int" setter="set_solver_priority" getter="get_solver_priority" default="1">
 			The priority used to define which solver is executed first for multiple joints. The lower the value, the higher the priority.

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -18,7 +18,7 @@
 			</argument>
 			<argument index="2" name="transform" type="Transform2D" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
 			</argument>
-			<argument index="3" name="disabled" type="bool" default="false">
+			<argument index="3" name="enabled" type="bool" default="true">
 			</argument>
 			<description>
 				Adds a shape to the area, along with a transform matrix. Shapes are usually referenced by their index, so you should track which shape has a given index.
@@ -59,6 +59,19 @@
 			</return>
 			<description>
 				Creates an [Area2D]. After creating an [Area2D] with this method, assign it to a space using [method area_set_space] to use the created [Area2D] in the physics world.
+			</description>
+		</method>
+		<method name="area_enable_shape">
+			<return type="void">
+			</return>
+			<argument index="0" name="area" type="RID">
+			</argument>
+			<argument index="1" name="shape_idx" type="int">
+			</argument>
+			<argument index="2" name="enable" type="bool" default="true">
+			</argument>
+			<description>
+				Sets whether or not the area's shape specified by [code]shape_idx[/code] is enabled.
 			</description>
 		</method>
 		<method name="area_get_canvas_instance_id" qualifiers="const">
@@ -246,19 +259,6 @@
 				Substitutes a given area shape by another. The old shape is selected by its index, the new one by its [RID].
 			</description>
 		</method>
-		<method name="area_set_shape_disabled">
-			<return type="void">
-			</return>
-			<argument index="0" name="area" type="RID">
-			</argument>
-			<argument index="1" name="shape_idx" type="int">
-			</argument>
-			<argument index="2" name="disabled" type="bool">
-			</argument>
-			<description>
-				Disables a given shape in an area.
-			</description>
-		</method>
 		<method name="area_set_shape_transform">
 			<return type="void">
 			</return>
@@ -348,7 +348,7 @@
 			</argument>
 			<argument index="2" name="transform" type="Transform2D" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
 			</argument>
-			<argument index="3" name="disabled" type="bool" default="false">
+			<argument index="3" name="enabled" type="bool" default="true">
 			</argument>
 			<description>
 				Adds a shape to the body, along with a transform matrix. Shapes are usually referenced by their index, so you should track which shape has a given index.
@@ -432,6 +432,34 @@
 			</return>
 			<description>
 				Creates a physics body.
+			</description>
+		</method>
+		<method name="body_enable_shape">
+			<return type="void">
+			</return>
+			<argument index="0" name="body" type="RID">
+			</argument>
+			<argument index="1" name="shape_idx" type="int">
+			</argument>
+			<argument index="2" name="enabled" type="bool" default="true">
+			</argument>
+			<description>
+				Sets whether or not the body's shape specified by [code]shape_idx[/code] is enabled.
+			</description>
+		</method>
+		<method name="body_enable_shape_one_way_collision">
+			<return type="void">
+			</return>
+			<argument index="0" name="body" type="RID">
+			</argument>
+			<argument index="1" name="shape_idx" type="int">
+			</argument>
+			<argument index="2" name="enabled" type="bool" default="true">
+			</argument>
+			<argument index="3" name="margin" type="float" default="1">
+			</argument>
+			<description>
+				Sets whether or not the body's shape specified by [code]shape_idx[/code] one-way collision property is enabled.
 			</description>
 		</method>
 		<method name="body_get_canvas_instance_id" qualifiers="const">
@@ -694,7 +722,7 @@
 			</return>
 			<argument index="0" name="body" type="RID">
 			</argument>
-			<argument index="1" name="enable" type="bool">
+			<argument index="1" name="omit" type="bool">
 			</argument>
 			<description>
 				Sets whether a body uses a callback function to calculate its own physics (see [method body_set_force_integration_callback]).
@@ -724,34 +752,6 @@
 			</argument>
 			<description>
 				Substitutes a given body shape by another. The old shape is selected by its index, the new one by its [RID].
-			</description>
-		</method>
-		<method name="body_set_shape_as_one_way_collision">
-			<return type="void">
-			</return>
-			<argument index="0" name="body" type="RID">
-			</argument>
-			<argument index="1" name="shape_idx" type="int">
-			</argument>
-			<argument index="2" name="enable" type="bool">
-			</argument>
-			<argument index="3" name="margin" type="float">
-			</argument>
-			<description>
-				Enables one way collision on body if [code]enable[/code] is [code]true[/code].
-			</description>
-		</method>
-		<method name="body_set_shape_disabled">
-			<return type="void">
-			</return>
-			<argument index="0" name="body" type="RID">
-			</argument>
-			<argument index="1" name="shape_idx" type="int">
-			</argument>
-			<argument index="2" name="disabled" type="bool">
-			</argument>
-			<description>
-				Disables shape in body if [code]disable[/code] is [code]true[/code].
 			</description>
 		</method>
 		<method name="body_set_shape_metadata">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -18,7 +18,7 @@
 			</argument>
 			<argument index="2" name="transform" type="Transform" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 			</argument>
-			<argument index="3" name="disabled" type="bool" default="false">
+			<argument index="3" name="enabled" type="bool" default="true">
 			</argument>
 			<description>
 				Adds a shape to the area, along with a transform matrix. Shapes are usually referenced by their index, so you should track which shape has a given index.
@@ -49,6 +49,19 @@
 			</return>
 			<description>
 				Creates an [Area3D].
+			</description>
+		</method>
+		<method name="area_enable_shape">
+			<return type="void">
+			</return>
+			<argument index="0" name="area" type="RID">
+			</argument>
+			<argument index="1" name="shape_idx" type="int">
+			</argument>
+			<argument index="2" name="enable" type="bool" default="true">
+			</argument>
+			<description>
+				Sets whether or not the area's shape specified by [code]shape_idx[/code] is enabled.
 			</description>
 		</method>
 		<method name="area_get_object_instance_id" qualifiers="const">
@@ -215,15 +228,15 @@
 				Sets the value for an area parameter. A list of available parameters is on the [enum AreaParameter] constants.
 			</description>
 		</method>
-		<method name="area_set_ray_pickable">
+		<method name="area_set_pickable">
 			<return type="void">
 			</return>
 			<argument index="0" name="area" type="RID">
 			</argument>
-			<argument index="1" name="enable" type="bool">
+			<argument index="1" name="pickable" type="bool">
 			</argument>
 			<description>
-				Sets object pickable with rays.
+				Sets whether or not the area can trigger input events.
 			</description>
 		</method>
 		<method name="area_set_shape">
@@ -237,18 +250,6 @@
 			</argument>
 			<description>
 				Substitutes a given area shape by another. The old shape is selected by its index, the new one by its [RID].
-			</description>
-		</method>
-		<method name="area_set_shape_disabled">
-			<return type="void">
-			</return>
-			<argument index="0" name="area" type="RID">
-			</argument>
-			<argument index="1" name="shape_idx" type="int">
-			</argument>
-			<argument index="2" name="disabled" type="bool">
-			</argument>
-			<description>
 			</description>
 		</method>
 		<method name="area_set_shape_transform">
@@ -339,7 +340,7 @@
 			</argument>
 			<argument index="2" name="transform" type="Transform" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 			</argument>
-			<argument index="3" name="disabled" type="bool" default="false">
+			<argument index="3" name="enabled" type="bool" default="true">
 			</argument>
 			<description>
 				Adds a shape to the body, along with a transform matrix. Shapes are usually referenced by their index, so you should track which shape has a given index.
@@ -415,6 +416,30 @@
 			<description>
 			</description>
 		</method>
+		<method name="body_enable_continuous_collision_detection">
+			<return type="void">
+			</return>
+			<argument index="0" name="body" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool" default="true">
+			</argument>
+			<description>
+				Sets whether or not the body's continuous collision detection mode is enabled.
+			</description>
+		</method>
+		<method name="body_enable_shape">
+			<return type="void">
+			</return>
+			<argument index="0" name="body" type="RID">
+			</argument>
+			<argument index="1" name="shape_idx" type="int">
+			</argument>
+			<argument index="2" name="enable" type="bool" default="true">
+			</argument>
+			<description>
+				Sets whether or not the body's shape specified by [code]shape_idx[/code] is enabled.
+			</description>
+		</method>
 		<method name="body_get_collision_layer" qualifiers="const">
 			<return type="int">
 			</return>
@@ -431,7 +456,6 @@
 			</argument>
 			<description>
 				Returns the physics layer or layers a body can collide with.
--
 			</description>
 		</method>
 		<method name="body_get_direct_state">
@@ -556,7 +580,7 @@
 			<argument index="0" name="body" type="RID">
 			</argument>
 			<description>
-				If [code]true[/code], the continuous collision detection mode is enabled.
+				Returns whether or not the body's continuous collision detection mode is enabled.
 			</description>
 		</method>
 		<method name="body_is_omitting_force_integration" qualifiers="const">
@@ -636,18 +660,6 @@
 				Sets the physics layer or layers a body can collide with.
 			</description>
 		</method>
-		<method name="body_set_enable_continuous_collision_detection">
-			<return type="void">
-			</return>
-			<argument index="0" name="body" type="RID">
-			</argument>
-			<argument index="1" name="enable" type="bool">
-			</argument>
-			<description>
-				If [code]true[/code], the continuous collision detection mode is enabled.
-				Continuous collision detection tries to predict where a moving body will collide, instead of moving it and correcting its movement if it collided.
-			</description>
-		</method>
 		<method name="body_set_force_integration_callback">
 			<return type="void">
 			</return>
@@ -698,7 +710,7 @@
 			</return>
 			<argument index="0" name="body" type="RID">
 			</argument>
-			<argument index="1" name="enable" type="bool">
+			<argument index="1" name="omit" type="bool">
 			</argument>
 			<description>
 				Sets whether a body uses a callback function to calculate its own physics (see [method body_set_force_integration_callback]).
@@ -717,15 +729,15 @@
 				Sets a body parameter. A list of available parameters is on the [enum BodyParameter] constants.
 			</description>
 		</method>
-		<method name="body_set_ray_pickable">
+		<method name="body_set_pickable">
 			<return type="void">
 			</return>
 			<argument index="0" name="body" type="RID">
 			</argument>
-			<argument index="1" name="enable" type="bool">
+			<argument index="1" name="pickable" type="bool">
 			</argument>
 			<description>
-				Sets the body pickable with rays if [code]enabled[/code] is set.
+				Sets whether or not the body can trigger input events.
 			</description>
 		</method>
 		<method name="body_set_shape">
@@ -739,18 +751,6 @@
 			</argument>
 			<description>
 				Substitutes a given body shape by another. The old shape is selected by its index, the new one by its [RID].
-			</description>
-		</method>
-		<method name="body_set_shape_disabled">
-			<return type="void">
-			</return>
-			<argument index="0" name="body" type="RID">
-			</argument>
-			<argument index="1" name="shape_idx" type="int">
-			</argument>
-			<argument index="2" name="disabled" type="bool">
-			</argument>
-			<description>
 			</description>
 		</method>
 		<method name="body_set_shape_transform">
@@ -894,7 +894,7 @@
 			</argument>
 			<argument index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag">
 			</argument>
-			<argument index="3" name="enable" type="bool">
+			<argument index="3" name="on" type="bool" default="true">
 			</argument>
 			<description>
 				Sets a generic_6_DOF_joint flag (see [enum G6DOFJointAxisFlag] constants).
@@ -959,7 +959,7 @@
 			</argument>
 			<argument index="1" name="flag" type="int" enum="PhysicsServer3D.HingeJointFlag">
 			</argument>
-			<argument index="2" name="enabled" type="bool">
+			<argument index="2" name="on" type="bool" default="true">
 			</argument>
 			<description>
 				Sets a hinge_joint flag (see [enum HingeJointFlag] constants).

--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -11,10 +11,10 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
+		<member name="collide_with_areas" type="bool" setter="enable_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
 			If [code]true[/code], the query will take [Area2D]s into account.
 		</member>
-		<member name="collide_with_bodies" type="bool" setter="set_collide_with_bodies" getter="is_collide_with_bodies_enabled" default="true">
+		<member name="collide_with_bodies" type="bool" setter="enable_collide_with_bodies" getter="is_collide_with_bodies_enabled" default="true">
 			If [code]true[/code], the query will take [PhysicsBody2D]s into account.
 		</member>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="2147483647">

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -11,10 +11,10 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
+		<member name="collide_with_areas" type="bool" setter="enable_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
 			If [code]true[/code], the query will take [Area3D]s into account.
 		</member>
-		<member name="collide_with_bodies" type="bool" setter="set_collide_with_bodies" getter="is_collide_with_bodies_enabled" default="true">
+		<member name="collide_with_bodies" type="bool" setter="enable_collide_with_bodies" getter="is_collide_with_bodies_enabled" default="true">
 			If [code]true[/code], the query will take [PhysicsBody3D]s into account.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="2147483647">

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -168,7 +168,7 @@
 			The maximum number of contacts that will be recorded. Requires [member contact_monitor] to be set to [code]true[/code].
 			[b]Note:[/b] The number of contacts is different from the number of collisions. Collisions between parallel edges will result in two contacts (one at each end), and collisions between parallel faces will result in four contacts (one at each corner).
 		</member>
-		<member name="continuous_cd" type="bool" setter="set_use_continuous_collision_detection" getter="is_using_continuous_collision_detection" default="false">
+		<member name="continuous_cd" type="bool" setter="enable_continuous_collision_detection" getter="is_continuous_collision_detection_enabled" default="false">
 			If [code]true[/code], continuous collision detection is used.
 			Continuous collision detection tries to predict where a moving body will collide, instead of moving it and correcting its movement if it collided. Continuous collision detection is more precise, and misses fewer impacts by small, fast-moving objects. Not using continuous collision detection is faster to compute, but can miss small, fast-moving objects.
 		</member>

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -100,10 +100,9 @@
 		<member name="parent_collision_ignore" type="NodePath" setter="set_parent_collision_ignore" getter="get_parent_collision_ignore" default="NodePath(&quot;&quot;)">
 			[NodePath] to a [CollisionObject3D] this SoftBody3D should avoid clipping.
 		</member>
-		<member name="pressure_coefficient" type="float" setter="set_pressure_coefficient" getter="get_pressure_coefficient" default="0.0">
+		<member name="pickable" type="bool" setter="set_pickable" getter="is_pickable" default="true">
 		</member>
-		<member name="ray_pickable" type="bool" setter="set_ray_pickable" getter="is_ray_pickable" default="true">
-			If [code]true[/code], the [SoftBody3D] will respond to [RayCast3D]s.
+		<member name="pressure_coefficient" type="float" setter="set_pressure_coefficient" getter="get_pressure_coefficient" default="0.0">
 		</member>
 		<member name="simulation_precision" type="int" setter="set_simulation_precision" getter="get_simulation_precision" default="5">
 			Increasing this value will improve the resulting simulation, but can affect performance. Use with care.

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -3587,7 +3587,7 @@ void CollisionObject3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Object *owner = co->shape_owner_get_owner(owner_id);
 		// Exclude CollisionShape3D and CollisionPolygon3D as they have their gizmo.
 		if (!Object::cast_to<CollisionShape3D>(owner) && !Object::cast_to<CollisionPolygon3D>(owner)) {
-			Ref<Material> material = get_material(!co->is_shape_owner_disabled(owner_id) ? "shape_material" : "shape_material_disabled", p_gizmo);
+			Ref<Material> material = get_material(co->is_shape_owner_enabled(owner_id) ? "shape_material" : "shape_material_disabled", p_gizmo);
 			for (int shape_id = 0; shape_id < co->shape_owner_get_shape_count(owner_id); shape_id++) {
 				Ref<Shape3D> s = co->shape_owner_get_shape(owner_id, shape_id);
 				if (s.is_null()) {
@@ -3926,7 +3926,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	const Ref<Material> material =
-			get_material(!cs->is_disabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
+			get_material(cs->is_enabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
 	Ref<Material> handles_material = get_material("handles");
 
 	if (Object::cast_to<SphereShape3D>(*s)) {
@@ -4246,7 +4246,7 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	const Ref<Material> material =
-			get_material(!polygon->is_disabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
+			get_material(polygon->is_enabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
 
 	p_gizmo->add_lines(lines, material);
 	p_gizmo->add_collision_segments(lines);

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -123,7 +123,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 			sb->get_shape_owners(&shapes);
 
 			for (List<uint32_t>::Element *E = shapes.front(); E; E = E->next()) {
-				if (sb->is_shape_owner_disabled(E->get())) {
+				if (!sb->is_shape_owner_enabled(E->get())) {
 					continue;
 				}
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -122,12 +122,12 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 			sb->get_shape_owners(&shapes);
 
 			for (List<uint32_t>::Element *E = shapes.front(); E; E = E->next()) {
-				if (sb->is_shape_owner_disabled(E->get())) {
+				if (!sb->is_shape_owner_enabled(E->get())) {
 					continue;
 				}
 
 				Transform2D shape_transform = sb->get_transform() * sb->shape_owner_get_transform(E->get());
-				bool one_way = sb->is_shape_owner_one_way_collision_enabled(E->get());
+				bool one_way = sb->shape_owner_is_one_way_collision_enabled(E->get());
 
 				shape_transform[2] -= phys_offset;
 

--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -50,7 +50,7 @@ AreaBullet::AreaBullet() :
 	setupBulletCollisionObject(btGhost);
 	/// Collision objects with a callback still have collision response with dynamic rigid bodies.
 	/// In order to use collision objects as trigger, you have to disable the collision response.
-	set_collision_enabled(false);
+	enable_collisions(false);
 
 	for (int i = 0; i < 5; ++i) {
 		call_event_res_ptr[i] = &call_event_res[i];

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -71,7 +71,7 @@
 	}
 
 #define AddJointToSpace(body, joint) \
-	body->get_space()->add_constraint(joint, joint->is_disabled_collisions_between_bodies());
+	body->get_space()->add_constraint(joint, joint->is_collisions_between_bodies_enabled());
 // <--------------- Joint creation asserts
 
 void BulletPhysicsServer3D::_bind_methods() {
@@ -268,14 +268,14 @@ PhysicsServer3D::AreaSpaceOverrideMode BulletPhysicsServer3D::area_get_space_ove
 	return area->get_spOv_mode();
 }
 
-void BulletPhysicsServer3D::area_add_shape(RID p_area, RID p_shape, const Transform &p_transform, bool p_disabled) {
+void BulletPhysicsServer3D::area_add_shape(RID p_area, RID p_shape, const Transform &p_transform, bool p_enabled) {
 	AreaBullet *area = area_owner.getornull(p_area);
 	ERR_FAIL_COND(!area);
 
 	ShapeBullet *shape = shape_owner.getornull(p_shape);
 	ERR_FAIL_COND(!shape);
 
-	area->add_shape(shape, p_transform, p_disabled);
+	area->add_shape(shape, p_transform, p_enabled);
 }
 
 void BulletPhysicsServer3D::area_set_shape(RID p_area, int p_shape_idx, RID p_shape) {
@@ -331,11 +331,11 @@ void BulletPhysicsServer3D::area_clear_shapes(RID p_area) {
 	}
 }
 
-void BulletPhysicsServer3D::area_set_shape_disabled(RID p_area, int p_shape_idx, bool p_disabled) {
+void BulletPhysicsServer3D::area_enable_shape(RID p_area, int p_shape_idx, bool p_enable) {
 	AreaBullet *area = area_owner.getornull(p_area);
 	ERR_FAIL_COND(!area);
 
-	area->set_shape_disabled(p_shape_idx, p_disabled);
+	area->enable_shape(p_shape_idx, p_enable);
 }
 
 void BulletPhysicsServer3D::area_attach_object_instance_id(RID p_area, ObjectID p_id) {
@@ -427,10 +427,10 @@ void BulletPhysicsServer3D::area_set_area_monitor_callback(RID p_area, Object *p
 	area->set_event_callback(CollisionObjectBullet::TYPE_AREA, p_receiver ? p_receiver->get_instance_id() : ObjectID(), p_method);
 }
 
-void BulletPhysicsServer3D::area_set_ray_pickable(RID p_area, bool p_enable) {
+void BulletPhysicsServer3D::area_set_pickable(RID p_area, bool p_pickable) {
 	AreaBullet *area = area_owner.getornull(p_area);
 	ERR_FAIL_COND(!area);
-	area->set_ray_pickable(p_enable);
+	area->set_pickable(p_pickable);
 }
 
 RID BulletPhysicsServer3D::body_create(BodyMode p_mode, bool p_init_sleeping) {
@@ -484,14 +484,14 @@ PhysicsServer3D::BodyMode BulletPhysicsServer3D::body_get_mode(RID p_body) const
 	return body->get_mode();
 }
 
-void BulletPhysicsServer3D::body_add_shape(RID p_body, RID p_shape, const Transform &p_transform, bool p_disabled) {
+void BulletPhysicsServer3D::body_add_shape(RID p_body, RID p_shape, const Transform &p_transform, bool p_enabled) {
 	RigidBodyBullet *body = rigid_body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
 
 	ShapeBullet *shape = shape_owner.getornull(p_shape);
 	ERR_FAIL_COND(!shape);
 
-	body->add_shape(shape, p_transform, p_disabled);
+	body->add_shape(shape, p_transform, p_enabled);
 }
 
 void BulletPhysicsServer3D::body_set_shape(RID p_body, int p_shape_idx, RID p_shape) {
@@ -533,11 +533,11 @@ Transform BulletPhysicsServer3D::body_get_shape_transform(RID p_body, int p_shap
 	return body->get_shape_transform(p_shape_idx);
 }
 
-void BulletPhysicsServer3D::body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) {
+void BulletPhysicsServer3D::body_enable_shape(RID p_body, int p_shape_idx, bool p_enable) {
 	RigidBodyBullet *body = rigid_body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->set_shape_disabled(p_shape_idx, p_disabled);
+	body->enable_shape(p_shape_idx, p_enable);
 }
 
 void BulletPhysicsServer3D::body_remove_shape(RID p_body, int p_shape_idx) {
@@ -568,11 +568,11 @@ ObjectID BulletPhysicsServer3D::body_get_object_instance_id(RID p_body) const {
 	return body->get_instance_id();
 }
 
-void BulletPhysicsServer3D::body_set_enable_continuous_collision_detection(RID p_body, bool p_enable) {
+void BulletPhysicsServer3D::body_enable_continuous_collision_detection(RID p_body, bool p_enable) {
 	RigidBodyBullet *body = rigid_body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->set_continuous_collision_detection(p_enable);
+	body->enable_continuous_collision_detection(p_enable);
 }
 
 bool BulletPhysicsServer3D::body_is_continuous_collision_detection_enabled(RID p_body) const {
@@ -830,10 +830,10 @@ void BulletPhysicsServer3D::body_set_force_integration_callback(RID p_body, cons
 	body->set_force_integration_callback(p_callable, p_udata);
 }
 
-void BulletPhysicsServer3D::body_set_ray_pickable(RID p_body, bool p_enable) {
+void BulletPhysicsServer3D::body_set_pickable(RID p_body, bool p_pickable) {
 	RigidBodyBullet *body = rigid_body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
-	body->set_ray_pickable(p_enable);
+	body->set_pickable(p_pickable);
 }
 
 PhysicsDirectBodyState3D *BulletPhysicsServer3D::body_get_direct_state(RID p_body) {
@@ -997,10 +997,10 @@ void BulletPhysicsServer3D::soft_body_set_transform(RID p_body, const Transform 
 	body->set_soft_transform(p_transform);
 }
 
-void BulletPhysicsServer3D::soft_body_set_ray_pickable(RID p_body, bool p_enable) {
+void BulletPhysicsServer3D::soft_body_set_pickable(RID p_body, bool p_pickable) {
 	SoftBodyBullet *body = soft_body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
-	body->set_ray_pickable(p_enable);
+	body->set_pickable(p_pickable);
 }
 
 void BulletPhysicsServer3D::soft_body_set_simulation_precision(RID p_body, int p_simulation_precision) {
@@ -1122,18 +1122,18 @@ int BulletPhysicsServer3D::joint_get_solver_priority(RID p_joint) const {
 	return 0;
 }
 
-void BulletPhysicsServer3D::joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) {
+void BulletPhysicsServer3D::joint_enable_collisions_between_bodies(RID p_joint, const bool p_enable) {
 	JointBullet *joint = joint_owner.getornull(p_joint);
 	ERR_FAIL_COND(!joint);
 
-	joint->disable_collisions_between_bodies(p_disable);
+	joint->enable_collisions_between_bodies(p_enable);
 }
 
-bool BulletPhysicsServer3D::joint_is_disabled_collisions_between_bodies(RID p_joint) const {
+bool BulletPhysicsServer3D::joint_is_collisions_between_bodies_enabled(RID p_joint) const {
 	JointBullet *joint(joint_owner.getornull(p_joint));
 	ERR_FAIL_COND_V(!joint, false);
 
-	return joint->is_disabled_collisions_between_bodies();
+	return joint->is_collisions_between_bodies_enabled();
 }
 
 RID BulletPhysicsServer3D::joint_create_pin(RID p_body_A, const Vector3 &p_local_A, RID p_body_B, const Vector3 &p_local_B) {

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -134,7 +134,7 @@ public:
 	virtual void area_set_space_override_mode(RID p_area, AreaSpaceOverrideMode p_mode) override;
 	virtual AreaSpaceOverrideMode area_get_space_override_mode(RID p_area) const override;
 
-	virtual void area_add_shape(RID p_area, RID p_shape, const Transform &p_transform = Transform(), bool p_disabled = false) override;
+	virtual void area_add_shape(RID p_area, RID p_shape, const Transform &p_transform = Transform(), bool p_enabled = true) override;
 	virtual void area_set_shape(RID p_area, int p_shape_idx, RID p_shape) override;
 	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform &p_transform) override;
 	virtual int area_get_shape_count(RID p_area) const override;
@@ -142,7 +142,7 @@ public:
 	virtual Transform area_get_shape_transform(RID p_area, int p_shape_idx) const override;
 	virtual void area_remove_shape(RID p_area, int p_shape_idx) override;
 	virtual void area_clear_shapes(RID p_area) override;
-	virtual void area_set_shape_disabled(RID p_area, int p_shape_idx, bool p_disabled) override;
+	virtual void area_enable_shape(RID p_area, int p_shape_idx, bool p_enable = true) override;
 	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id) override;
 	virtual ObjectID area_get_object_instance_id(RID p_area) const override;
 
@@ -162,7 +162,7 @@ public:
 	virtual void area_set_monitorable(RID p_area, bool p_monitorable) override;
 	virtual void area_set_monitor_callback(RID p_area, Object *p_receiver, const StringName &p_method) override;
 	virtual void area_set_area_monitor_callback(RID p_area, Object *p_receiver, const StringName &p_method) override;
-	virtual void area_set_ray_pickable(RID p_area, bool p_enable) override;
+	virtual void area_set_pickable(RID p_area, bool p_pickable) override;
 
 	/* RIGID BODY API */
 
@@ -174,7 +174,7 @@ public:
 	virtual void body_set_mode(RID p_body, BodyMode p_mode) override;
 	virtual BodyMode body_get_mode(RID p_body) const override;
 
-	virtual void body_add_shape(RID p_body, RID p_shape, const Transform &p_transform = Transform(), bool p_disabled = false) override;
+	virtual void body_add_shape(RID p_body, RID p_shape, const Transform &p_transform = Transform(), bool p_enabled = true) override;
 	// Not supported, Please remove and add new shape
 	virtual void body_set_shape(RID p_body, int p_shape_idx, RID p_shape) override;
 	virtual void body_set_shape_transform(RID p_body, int p_shape_idx, const Transform &p_transform) override;
@@ -183,7 +183,7 @@ public:
 	virtual RID body_get_shape(RID p_body, int p_shape_idx) const override;
 	virtual Transform body_get_shape_transform(RID p_body, int p_shape_idx) const override;
 
-	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override;
+	virtual void body_enable_shape(RID p_body, int p_shape_idx, bool p_enable = true) override;
 
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) override;
 	virtual void body_clear_shapes(RID p_body) override;
@@ -192,7 +192,7 @@ public:
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) override;
 	virtual ObjectID body_get_object_instance_id(RID p_body) const override;
 
-	virtual void body_set_enable_continuous_collision_detection(RID p_body, bool p_enable) override;
+	virtual void body_enable_continuous_collision_detection(RID p_body, bool p_enable = true) override;
 	virtual bool body_is_continuous_collision_detection_enabled(RID p_body) const override;
 
 	virtual void body_set_collision_layer(RID p_body, uint32_t p_layer) override;
@@ -248,7 +248,7 @@ public:
 
 	virtual void body_set_force_integration_callback(RID p_body, const Callable &p_callable, const Variant &p_udata = Variant()) override;
 
-	virtual void body_set_ray_pickable(RID p_body, bool p_enable) override;
+	virtual void body_set_pickable(RID p_body, bool p_pickable) override;
 
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override;
@@ -285,7 +285,7 @@ public:
 	/// Special function. This function has bad performance
 	virtual void soft_body_set_transform(RID p_body, const Transform &p_transform) override;
 
-	virtual void soft_body_set_ray_pickable(RID p_body, bool p_enable) override;
+	virtual void soft_body_set_pickable(RID p_body, bool p_pickable) override;
 
 	virtual void soft_body_set_simulation_precision(RID p_body, int p_simulation_precision) override;
 	virtual int soft_body_get_simulation_precision(RID p_body) const override;
@@ -319,8 +319,8 @@ public:
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) override;
 	virtual int joint_get_solver_priority(RID p_joint) const override;
 
-	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) override;
-	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const override;
+	virtual void joint_enable_collisions_between_bodies(RID p_joint, const bool p_enable = true) override;
+	virtual bool joint_is_collisions_between_bodies_enabled(RID p_joint) const override;
 
 	virtual RID joint_create_pin(RID p_body_A, const Vector3 &p_local_A, RID p_body_B, const Vector3 &p_local_B) override;
 
@@ -339,7 +339,7 @@ public:
 	virtual void hinge_joint_set_param(RID p_joint, HingeJointParam p_param, real_t p_value) override;
 	virtual real_t hinge_joint_get_param(RID p_joint, HingeJointParam p_param) const override;
 
-	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_value) override;
+	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_on = true) override;
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const override;
 
 	/// Reference frame is A
@@ -360,7 +360,7 @@ public:
 	virtual void generic_6dof_joint_set_param(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisParam p_param, real_t p_value) override;
 	virtual real_t generic_6dof_joint_get_param(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisParam p_param) override;
 
-	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag, bool p_enable) override;
+	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag, bool p_on = true) override;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag) override;
 
 	/* MISC */

--- a/modules/bullet/collision_object_bullet.cpp
+++ b/modules/bullet/collision_object_bullet.cpp
@@ -131,7 +131,7 @@ void CollisionObjectBullet::setupBulletCollisionObject(btCollisionObject *p_coll
 	bt_collision_object->setUserPointer(this);
 	bt_collision_object->setUserIndex(type);
 	// Force the enabling of collision and avoid problems
-	set_collision_enabled(collisionsEnabled);
+	enable_collisions(collisions_enabled);
 	p_collisionObject->setCollisionFlags(p_collisionObject->getCollisionFlags() | btCollisionObject::CF_CUSTOM_MATERIAL_CALLBACK);
 }
 
@@ -161,20 +161,20 @@ bool CollisionObjectBullet::has_collision_exception(const CollisionObjectBullet 
 	return exceptions.has(p_otherCollisionObject->get_self());
 }
 
-void CollisionObjectBullet::set_collision_enabled(bool p_enabled) {
-	collisionsEnabled = p_enabled;
+void CollisionObjectBullet::enable_collisions(bool p_enable) {
+	collisions_enabled = p_enable;
 	if (!bt_collision_object) {
 		return;
 	}
-	if (collisionsEnabled) {
+	if (collisions_enabled) {
 		bt_collision_object->setCollisionFlags(bt_collision_object->getCollisionFlags() & (~btCollisionObject::CF_NO_CONTACT_RESPONSE));
 	} else {
 		bt_collision_object->setCollisionFlags(bt_collision_object->getCollisionFlags() | btCollisionObject::CF_NO_CONTACT_RESPONSE);
 	}
 }
 
-bool CollisionObjectBullet::is_collisions_response_enabled() {
-	return collisionsEnabled;
+bool CollisionObjectBullet::is_collisions_enabled() {
+	return collisions_enabled;
 }
 
 void CollisionObjectBullet::notify_new_overlap(AreaBullet *p_area) {
@@ -230,8 +230,8 @@ RigidCollisionObjectBullet::~RigidCollisionObjectBullet() {
 	}
 }
 
-void RigidCollisionObjectBullet::add_shape(ShapeBullet *p_shape, const Transform &p_transform, bool p_disabled) {
-	shapes.push_back(ShapeWrapper(p_shape, p_transform, !p_disabled));
+void RigidCollisionObjectBullet::add_shape(ShapeBullet *p_shape, const Transform &p_transform, bool p_enabled) {
+	shapes.push_back(ShapeWrapper(p_shape, p_transform, p_enabled));
 	p_shape->add_owner(this);
 	reload_shapes();
 }
@@ -313,16 +313,16 @@ Transform RigidCollisionObjectBullet::get_shape_transform(int p_index) const {
 	return trs;
 }
 
-void RigidCollisionObjectBullet::set_shape_disabled(int p_index, bool p_disabled) {
-	if (shapes[p_index].active != p_disabled) {
+void RigidCollisionObjectBullet::enable_shape(int p_index, bool p_enable) {
+	if (shapes[p_index].active == p_enable) {
 		return;
 	}
-	shapes.write[p_index].active = !p_disabled;
+	shapes.write[p_index].active = p_enable;
 	shape_changed(p_index);
 }
 
-bool RigidCollisionObjectBullet::is_shape_disabled(int p_index) {
-	return !shapes[p_index].active;
+bool RigidCollisionObjectBullet::is_shape_enabled(int p_index) {
+	return shapes[p_index].active;
 }
 
 void RigidCollisionObjectBullet::shape_changed(int p_shape_index) {

--- a/modules/bullet/collision_object_bullet.h
+++ b/modules/bullet/collision_object_bullet.h
@@ -114,9 +114,9 @@ protected:
 	ObjectID instance_id;
 	uint32_t collisionLayer = 0;
 	uint32_t collisionMask = 0;
-	bool collisionsEnabled = true;
+	bool collisions_enabled = true;
 	bool m_isStatic = false;
-	bool ray_pickable = false;
+	bool pickable = false;
 	btCollisionObject *bt_collision_object = nullptr;
 	Vector3 body_scale = Vector3(1, 1, 1);
 	bool force_shape_reset = false;
@@ -148,8 +148,8 @@ public:
 
 	_FORCE_INLINE_ bool is_static() const { return m_isStatic; }
 
-	_FORCE_INLINE_ void set_ray_pickable(bool p_enable) { ray_pickable = p_enable; }
-	_FORCE_INLINE_ bool is_ray_pickable() const { return ray_pickable; }
+	_FORCE_INLINE_ void set_pickable(bool p_pickable) { pickable = p_pickable; }
+	_FORCE_INLINE_ bool is_pickable() const { return pickable; }
 
 	void set_body_scale(const Vector3 &p_new_scale);
 	const Vector3 &get_body_scale() const { return body_scale; }
@@ -192,8 +192,8 @@ public:
 
 	virtual void dispatch_callbacks() = 0;
 
-	void set_collision_enabled(bool p_enabled);
-	bool is_collisions_response_enabled();
+	void enable_collisions(bool p_enable = true);
+	bool is_collisions_enabled();
 
 	void notify_new_overlap(AreaBullet *p_area);
 	virtual void on_enter_area(AreaBullet *p_area) = 0;
@@ -225,7 +225,7 @@ public:
 
 	_FORCE_INLINE_ btCollisionShape *get_main_shape() const { return mainShape; }
 
-	void add_shape(ShapeBullet *p_shape, const Transform &p_transform = Transform(), bool p_disabled = false);
+	void add_shape(ShapeBullet *p_shape, const Transform &p_transform = Transform(), bool p_enabled = true);
 	void set_shape(int p_index, ShapeBullet *p_shape);
 
 	int get_shape_count() const;
@@ -243,8 +243,8 @@ public:
 	const btTransform &get_bt_shape_transform(int p_index) const;
 	Transform get_shape_transform(int p_index) const;
 
-	void set_shape_disabled(int p_index, bool p_disabled);
-	bool is_shape_disabled(int p_index);
+	void enable_shape(int p_index, bool p_enable = true);
+	bool is_shape_enabled(int p_index);
 
 	virtual void shape_changed(int p_shape_index);
 	virtual void reload_shapes();

--- a/modules/bullet/constraint_bullet.cpp
+++ b/modules/bullet/constraint_bullet.cpp
@@ -52,11 +52,11 @@ void ConstraintBullet::destroy_internal_constraint() {
 	space->remove_constraint(this);
 }
 
-void ConstraintBullet::disable_collisions_between_bodies(const bool p_disabled) {
-	disabled_collisions_between_bodies = p_disabled;
+void ConstraintBullet::enable_collisions_between_bodies(const bool p_enabled) {
+	collisions_between_bodies_enabled = p_enabled;
 
 	if (space) {
 		space->remove_constraint(this);
-		space->add_constraint(this, disabled_collisions_between_bodies);
+		space->add_constraint(this, collisions_between_bodies_enabled);
 	}
 }

--- a/modules/bullet/constraint_bullet.h
+++ b/modules/bullet/constraint_bullet.h
@@ -48,7 +48,7 @@ class ConstraintBullet : public RIDBullet {
 protected:
 	SpaceBullet *space = nullptr;
 	btTypedConstraint *constraint = nullptr;
-	bool disabled_collisions_between_bodies = true;
+	bool collisions_between_bodies_enabled = false;
 
 public:
 	ConstraintBullet();
@@ -57,8 +57,8 @@ public:
 	virtual void set_space(SpaceBullet *p_space);
 	virtual void destroy_internal_constraint();
 
-	void disable_collisions_between_bodies(const bool p_disabled);
-	_FORCE_INLINE_ bool is_disabled_collisions_between_bodies() const { return disabled_collisions_between_bodies; }
+	void enable_collisions_between_bodies(const bool p_enabled);
+	_FORCE_INLINE_ bool is_collisions_between_bodies_enabled() const { return collisions_between_bodies_enabled; }
 
 public:
 	virtual ~ConstraintBullet() {

--- a/modules/bullet/godot_result_callbacks.cpp
+++ b/modules/bullet/godot_result_callbacks.cpp
@@ -71,7 +71,7 @@ bool GodotClosestRayResultCallback::needsCollision(btBroadphaseProxy *proxy0) co
 			}
 		}
 
-		if (m_pickRay && !gObj->is_ray_pickable()) {
+		if (m_pickRay && !gObj->is_pickable()) {
 			return false;
 		}
 

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -305,7 +305,7 @@ void RigidBodyBullet::destroy_kinematic_utilities() {
 void RigidBodyBullet::main_shape_changed() {
 	CRASH_COND(!get_main_shape());
 	btBody->setCollisionShape(get_main_shape());
-	set_continuous_collision_detection(is_continuous_collision_detection_enabled()); // Reset
+	enable_continuous_collision_detection(is_continuous_collision_detection_enabled()); // Reset
 }
 
 void RigidBodyBullet::reload_body() {
@@ -719,7 +719,7 @@ void RigidBodyBullet::reload_axis_lock() {
 	}
 }
 
-void RigidBodyBullet::set_continuous_collision_detection(bool p_enable) {
+void RigidBodyBullet::enable_continuous_collision_detection(bool p_enable) {
 	if (p_enable) {
 		// This threshold enable CCD if the object moves more than
 		// 1 meter in one simulation frame
@@ -816,7 +816,7 @@ void RigidBodyBullet::reload_shapes() {
 	btBody->updateInertiaTensor();
 
 	reload_kinematic_shapes();
-	set_continuous_collision_detection(is_continuous_collision_detection_enabled());
+	enable_continuous_collision_detection(is_continuous_collision_detection_enabled());
 	reload_body();
 }
 

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -300,7 +300,7 @@ public:
 
 	/// Doc:
 	/// https://web.archive.org/web/20180404091446/http://www.bulletphysics.org/mediawiki-1.5.8/index.php/Anti_tunneling_by_Motion_Clamping
-	void set_continuous_collision_detection(bool p_enable);
+	void enable_continuous_collision_detection(bool p_enable = true);
 	bool is_continuous_collision_detection_enabled() const;
 
 	void set_linear_velocity(const Vector3 &p_velocity);

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -537,9 +537,9 @@ void SpaceBullet::reload_collision_filters(SoftBodyBullet *p_body) {
 	add_soft_body(p_body);
 }
 
-void SpaceBullet::add_constraint(ConstraintBullet *p_constraint, bool disableCollisionsBetweenLinkedBodies) {
+void SpaceBullet::add_constraint(ConstraintBullet *p_constraint, bool collisions_between_bodies_enabled) {
 	p_constraint->set_space(this);
-	dynamicsWorld->addConstraint(p_constraint->get_bt_constraint(), disableCollisionsBetweenLinkedBodies);
+	dynamicsWorld->addConstraint(p_constraint->get_bt_constraint(), !collisions_between_bodies_enabled);
 }
 
 void SpaceBullet::remove_constraint(ConstraintBullet *p_constraint) {
@@ -974,7 +974,7 @@ bool SpaceBullet::test_body_motion(RigidBodyBullet *p_body, const Transform &p_f
 #endif
 
 		for (int shIndex = 0; shIndex < shape_count; ++shIndex) {
-			if (p_body->is_shape_disabled(shIndex)) {
+			if (!p_body->is_shape_enabled(shIndex)) {
 				continue;
 			}
 

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -159,7 +159,7 @@ public:
 	void remove_soft_body(SoftBodyBullet *p_body);
 	void reload_collision_filters(SoftBodyBullet *p_body);
 
-	void add_constraint(ConstraintBullet *p_constraint, bool disableCollisionsBetweenLinkedBodies = false);
+	void add_constraint(ConstraintBullet *p_constraint, bool collisions_between_bodies_enabled);
 	void remove_constraint(ConstraintBullet *p_constraint);
 
 	int get_num_collision_objects() const;

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -53,8 +53,7 @@ class CollisionObject2D : public Node2D {
 		};
 
 		Vector<Shape> shapes;
-
-		bool disabled = false;
+		bool enabled = true;
 		bool one_way_collision = false;
 		real_t one_way_collision_margin = 0.0;
 	};
@@ -76,7 +75,7 @@ protected:
 	void _mouse_enter();
 	void _mouse_exit();
 
-	void set_only_update_transform_changes(bool p_enable);
+	void enable_only_update_transform_changes(bool p_enable = true);
 
 public:
 	void set_collision_layer(uint32_t p_layer);
@@ -100,14 +99,14 @@ public:
 	Transform2D shape_owner_get_transform(uint32_t p_owner) const;
 	Object *shape_owner_get_owner(uint32_t p_owner) const;
 
-	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
-	bool is_shape_owner_disabled(uint32_t p_owner) const;
+	void enable_shape_owner(uint32_t p_owner, bool p_enable = true);
+	bool is_shape_owner_enabled(uint32_t p_owner) const;
 
-	void shape_owner_set_one_way_collision(uint32_t p_owner, bool p_enable);
-	bool is_shape_owner_one_way_collision_enabled(uint32_t p_owner) const;
+	void shape_owner_enable_one_way_collision(uint32_t p_owner, bool p_enable = true);
+	bool shape_owner_is_one_way_collision_enabled(uint32_t p_owner) const;
 
 	void shape_owner_set_one_way_collision_margin(uint32_t p_owner, real_t p_margin);
-	real_t get_shape_owner_one_way_collision_margin(uint32_t p_owner) const;
+	real_t shape_owner_get_one_way_collision_margin(uint32_t p_owner) const;
 
 	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
@@ -119,7 +118,7 @@ public:
 
 	uint32_t shape_find_owner(int p_shape_index) const;
 
-	void set_pickable(bool p_enabled);
+	void set_pickable(bool p_pickable);
 	bool is_pickable() const;
 
 	TypedArray<String> get_configuration_warnings() const override;

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -89,8 +89,8 @@ void CollisionPolygon2D::_update_in_shape_owner(bool p_xform_only) {
 	if (p_xform_only) {
 		return;
 	}
-	parent->shape_owner_set_disabled(owner_id, disabled);
-	parent->shape_owner_set_one_way_collision(owner_id, one_way_collision);
+	parent->enable_shape_owner(owner_id, enabled);
+	parent->shape_owner_enable_one_way_collision(owner_id, one_way_collision);
 	parent->shape_owner_set_one_way_collision_margin(owner_id, one_way_collision_margin);
 }
 
@@ -264,23 +264,23 @@ TypedArray<String> CollisionPolygon2D::get_configuration_warnings() const {
 	return warnings;
 }
 
-void CollisionPolygon2D::set_disabled(bool p_disabled) {
-	disabled = p_disabled;
+void CollisionPolygon2D::enable(bool p_enable) {
+	enabled = p_enable;
 	update();
 	if (parent) {
-		parent->shape_owner_set_disabled(owner_id, p_disabled);
+		parent->enable_shape_owner(owner_id, p_enable);
 	}
 }
 
-bool CollisionPolygon2D::is_disabled() const {
-	return disabled;
+bool CollisionPolygon2D::is_enabled() const {
+	return enabled;
 }
 
-void CollisionPolygon2D::set_one_way_collision(bool p_enable) {
+void CollisionPolygon2D::enable_one_way_collision(bool p_enable) {
 	one_way_collision = p_enable;
 	update();
 	if (parent) {
-		parent->shape_owner_set_one_way_collision(owner_id, p_enable);
+		parent->shape_owner_enable_one_way_collision(owner_id, p_enable);
 	}
 }
 
@@ -305,17 +305,17 @@ void CollisionPolygon2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_build_mode", "build_mode"), &CollisionPolygon2D::set_build_mode);
 	ClassDB::bind_method(D_METHOD("get_build_mode"), &CollisionPolygon2D::get_build_mode);
-	ClassDB::bind_method(D_METHOD("set_disabled", "disabled"), &CollisionPolygon2D::set_disabled);
-	ClassDB::bind_method(D_METHOD("is_disabled"), &CollisionPolygon2D::is_disabled);
-	ClassDB::bind_method(D_METHOD("set_one_way_collision", "enabled"), &CollisionPolygon2D::set_one_way_collision);
+	ClassDB::bind_method(D_METHOD("enable", "enable"), &CollisionPolygon2D::enable, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("is_enabled"), &CollisionPolygon2D::is_enabled);
+	ClassDB::bind_method(D_METHOD("enable_one_way_collision", "enable"), &CollisionPolygon2D::enable_one_way_collision, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_one_way_collision_enabled"), &CollisionPolygon2D::is_one_way_collision_enabled);
 	ClassDB::bind_method(D_METHOD("set_one_way_collision_margin", "margin"), &CollisionPolygon2D::set_one_way_collision_margin);
 	ClassDB::bind_method(D_METHOD("get_one_way_collision_margin"), &CollisionPolygon2D::get_one_way_collision_margin);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "build_mode", PROPERTY_HINT_ENUM, "Solids,Segments"), "set_build_mode", "get_build_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "polygon"), "set_polygon", "get_polygon");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_way_collision"), "set_one_way_collision", "is_one_way_collision_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "enable", "is_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_way_collision"), "enable_one_way_collision", "is_one_way_collision_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "one_way_collision_margin", PROPERTY_HINT_RANGE, "0,128,0.1"), "set_one_way_collision_margin", "get_one_way_collision_margin");
 
 	BIND_ENUM_CONSTANT(BUILD_SOLIDS);

--- a/scene/2d/collision_polygon_2d.h
+++ b/scene/2d/collision_polygon_2d.h
@@ -51,7 +51,7 @@ protected:
 	Vector<Point2> polygon;
 	uint32_t owner_id = 0;
 	CollisionObject2D *parent = nullptr;
-	bool disabled = false;
+	bool enabled = true;
 	bool one_way_collision = false;
 	real_t one_way_collision_margin = 1.0;
 
@@ -80,10 +80,10 @@ public:
 
 	TypedArray<String> get_configuration_warnings() const override;
 
-	void set_disabled(bool p_disabled);
-	bool is_disabled() const;
+	void enable(bool p_enable = true);
+	bool is_enabled() const;
 
-	void set_one_way_collision(bool p_enable);
+	void enable_one_way_collision(bool p_enable = true);
 	bool is_one_way_collision_enabled() const;
 
 	void set_one_way_collision_margin(real_t p_margin);

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -49,8 +49,8 @@ void CollisionShape2D::_update_in_shape_owner(bool p_xform_only) {
 	if (p_xform_only) {
 		return;
 	}
-	parent->shape_owner_set_disabled(owner_id, disabled);
-	parent->shape_owner_set_one_way_collision(owner_id, one_way_collision);
+	parent->enable_shape_owner(owner_id, enabled);
+	parent->shape_owner_enable_one_way_collision(owner_id, one_way_collision);
 	parent->shape_owner_set_one_way_collision_margin(owner_id, one_way_collision_margin);
 }
 
@@ -105,7 +105,7 @@ void CollisionShape2D::_notification(int p_what) {
 			rect = Rect2();
 
 			Color draw_col = get_tree()->get_debug_collisions_color();
-			if (disabled) {
+			if (!enabled) {
 				float g = draw_col.get_v();
 				draw_col.r = g;
 				draw_col.g = g;
@@ -120,7 +120,7 @@ void CollisionShape2D::_notification(int p_what) {
 			if (one_way_collision) {
 				// Draw an arrow indicating the one-way collision direction
 				draw_col = get_tree()->get_debug_collisions_color().inverted();
-				if (disabled) {
+				if (!enabled) {
 					draw_col = draw_col.darkened(0.25);
 				}
 				Vector2 line_to(0, 20);
@@ -196,23 +196,23 @@ TypedArray<String> CollisionShape2D::get_configuration_warnings() const {
 	return warnings;
 }
 
-void CollisionShape2D::set_disabled(bool p_disabled) {
-	disabled = p_disabled;
+void CollisionShape2D::enable(bool p_enable) {
+	enabled = p_enable;
 	update();
 	if (parent) {
-		parent->shape_owner_set_disabled(owner_id, p_disabled);
+		parent->enable_shape_owner(owner_id, p_enable);
 	}
 }
 
-bool CollisionShape2D::is_disabled() const {
-	return disabled;
+bool CollisionShape2D::is_enabled() const {
+	return enabled;
 }
 
-void CollisionShape2D::set_one_way_collision(bool p_enable) {
+void CollisionShape2D::enable_one_way_collision(bool p_enable) {
 	one_way_collision = p_enable;
 	update();
 	if (parent) {
-		parent->shape_owner_set_one_way_collision(owner_id, p_enable);
+		parent->shape_owner_enable_one_way_collision(owner_id, p_enable);
 	}
 }
 
@@ -234,16 +234,16 @@ real_t CollisionShape2D::get_one_way_collision_margin() const {
 void CollisionShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &CollisionShape2D::set_shape);
 	ClassDB::bind_method(D_METHOD("get_shape"), &CollisionShape2D::get_shape);
-	ClassDB::bind_method(D_METHOD("set_disabled", "disabled"), &CollisionShape2D::set_disabled);
-	ClassDB::bind_method(D_METHOD("is_disabled"), &CollisionShape2D::is_disabled);
-	ClassDB::bind_method(D_METHOD("set_one_way_collision", "enabled"), &CollisionShape2D::set_one_way_collision);
+	ClassDB::bind_method(D_METHOD("enable", "enable"), &CollisionShape2D::enable, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("is_enabled"), &CollisionShape2D::is_enabled);
+	ClassDB::bind_method(D_METHOD("enable_one_way_collision", "enable"), &CollisionShape2D::enable_one_way_collision, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_one_way_collision_enabled"), &CollisionShape2D::is_one_way_collision_enabled);
 	ClassDB::bind_method(D_METHOD("set_one_way_collision_margin", "margin"), &CollisionShape2D::set_one_way_collision_margin);
 	ClassDB::bind_method(D_METHOD("get_one_way_collision_margin"), &CollisionShape2D::get_one_way_collision_margin);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_way_collision"), "set_one_way_collision", "is_one_way_collision_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "enable", "is_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_way_collision"), "enable_one_way_collision", "is_one_way_collision_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "one_way_collision_margin", PROPERTY_HINT_RANGE, "0,128,0.1"), "set_one_way_collision_margin", "get_one_way_collision_margin");
 }
 

--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -43,7 +43,7 @@ class CollisionShape2D : public Node2D {
 	uint32_t owner_id = 0;
 	CollisionObject2D *parent = nullptr;
 	void _shape_changed();
-	bool disabled = false;
+	bool enabled = true;
 	bool one_way_collision = false;
 	real_t one_way_collision_margin = 1.0;
 
@@ -63,10 +63,10 @@ public:
 	void set_shape(const Ref<Shape2D> &p_shape);
 	Ref<Shape2D> get_shape() const;
 
-	void set_disabled(bool p_disabled);
-	bool is_disabled() const;
+	void enable(bool p_enable = true);
+	bool is_enabled() const;
 
-	void set_one_way_collision(bool p_enable);
+	void enable_one_way_collision(bool p_enable = true);
 	bool is_one_way_collision_enabled() const;
 
 	void set_one_way_collision_margin(real_t p_margin);

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -55,8 +55,8 @@ void Joint2D::_body_exit_tree() {
 }
 
 void Joint2D::_update_joint(bool p_only_free) {
-	if (ba.is_valid() && bb.is_valid() && exclude_from_collision) {
-		PhysicsServer2D::get_singleton()->joint_disable_collisions_between_bodies(joint, false);
+	if (ba.is_valid() && bb.is_valid() && !collisions_between_bodies_enabled) {
+		PhysicsServer2D::get_singleton()->joint_enable_collisions_between_bodies(joint, true);
 	}
 
 	ba = RID();
@@ -119,7 +119,7 @@ void Joint2D::_update_joint(bool p_only_free) {
 	body_a->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree));
 	body_b->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree));
 
-	PhysicsServer2D::get_singleton()->joint_disable_collisions_between_bodies(joint, exclude_from_collision);
+	PhysicsServer2D::get_singleton()->joint_enable_collisions_between_bodies(joint, collisions_between_bodies_enabled);
 }
 
 void Joint2D::set_node_a(const NodePath &p_node_a) {
@@ -181,18 +181,18 @@ real_t Joint2D::get_bias() const {
 	return bias;
 }
 
-void Joint2D::set_exclude_nodes_from_collision(bool p_enable) {
-	if (exclude_from_collision == p_enable) {
+void Joint2D::enable_collisions_between_bodies(bool p_enable) {
+	if (collisions_between_bodies_enabled == p_enable) {
 		return;
 	}
 
 	_update_joint(true);
-	exclude_from_collision = p_enable;
+	collisions_between_bodies_enabled = p_enable;
 	_update_joint();
 }
 
-bool Joint2D::get_exclude_nodes_from_collision() const {
-	return exclude_from_collision;
+bool Joint2D::is_collisions_between_bodies_enabled() const {
+	return collisions_between_bodies_enabled;
 }
 
 TypedArray<String> Joint2D::get_configuration_warnings() const {
@@ -215,13 +215,13 @@ void Joint2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bias", "bias"), &Joint2D::set_bias);
 	ClassDB::bind_method(D_METHOD("get_bias"), &Joint2D::get_bias);
 
-	ClassDB::bind_method(D_METHOD("set_exclude_nodes_from_collision", "enable"), &Joint2D::set_exclude_nodes_from_collision);
-	ClassDB::bind_method(D_METHOD("get_exclude_nodes_from_collision"), &Joint2D::get_exclude_nodes_from_collision);
+	ClassDB::bind_method(D_METHOD("enable_collisions_between_bodies", "enable"), &Joint2D::enable_collisions_between_bodies, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("is_collisions_between_bodies_enabled"), &Joint2D::is_collisions_between_bodies_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody2D"), "set_node_a", "get_node_a");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_b", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody2D"), "set_node_b", "get_node_b");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0,0.9,0.001"), "set_bias", "get_bias");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_collision"), "set_exclude_nodes_from_collision", "get_exclude_nodes_from_collision");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collisions_between_bodies"), "enable_collisions_between_bodies", "is_collisions_between_bodies_enabled");
 }
 
 Joint2D::Joint2D() {

--- a/scene/2d/joints_2d.h
+++ b/scene/2d/joints_2d.h
@@ -45,7 +45,7 @@ class Joint2D : public Node2D {
 	NodePath b;
 	real_t bias = 0.0;
 
-	bool exclude_from_collision = true;
+	bool collisions_between_bodies_enabled = false;
 	bool configured = false;
 	String warning;
 
@@ -73,8 +73,8 @@ public:
 	void set_bias(real_t p_bias);
 	real_t get_bias() const;
 
-	void set_exclude_nodes_from_collision(bool p_enable);
-	bool get_exclude_nodes_from_collision() const;
+	void enable_collisions_between_bodies(bool p_enable = true);
+	bool is_collisions_between_bodies_enabled() const;
 
 	RID get_joint() const { return joint; }
 	Joint2D();

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1080,11 +1080,11 @@ void KinematicBody2D::set_sync_to_physics(bool p_enable) {
 
 	if (p_enable) {
 		PhysicsServer2D::get_singleton()->body_set_force_integration_callback(get_rid(), callable_mp(this, &KinematicBody2D::_direct_state_changed));
-		set_only_update_transform_changes(true);
+		enable_only_update_transform_changes(true);
 		set_notify_local_transform(true);
 	} else {
 		PhysicsServer2D::get_singleton()->body_set_force_integration_callback(get_rid(), Callable());
-		set_only_update_transform_changes(false);
+		enable_only_update_transform_changes(false);
 		set_notify_local_transform(false);
 	}
 }

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -262,7 +262,7 @@ void TileMap::_add_shape(int &shape_idx, const Quadrant &p_q, const Ref<Shape2D>
 	if (!use_parent) {
 		ps->body_add_shape(p_q.body, p_shape->get_rid(), p_xform);
 		ps->body_set_shape_metadata(p_q.body, shape_idx, p_metadata);
-		ps->body_set_shape_as_one_way_collision(p_q.body, shape_idx, p_shape_data.one_way_collision, p_shape_data.one_way_collision_margin);
+		ps->body_enable_shape_one_way_collision(p_q.body, shape_idx, p_shape_data.one_way_collision, p_shape_data.one_way_collision_margin);
 
 	} else if (collision_parent) {
 		Transform2D xform = p_xform;
@@ -278,7 +278,7 @@ void TileMap::_add_shape(int &shape_idx, const Quadrant &p_q, const Ref<Shape2D>
 		} else {
 			ps->body_set_shape_transform(rid, real_index, get_transform() * xform);
 			ps->body_set_shape_metadata(rid, real_index, p_metadata);
-			ps->body_set_shape_as_one_way_collision(rid, real_index, p_shape_data.one_way_collision, p_shape_data.one_way_collision_margin);
+			ps->body_enable_shape_one_way_collision(rid, real_index, p_shape_data.one_way_collision, p_shape_data.one_way_collision_margin);
 		}
 	}
 	shape_idx++;

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -54,15 +54,15 @@ class CollisionObject3D : public Node3D {
 		};
 
 		Vector<ShapeBase> shapes;
-		bool disabled = false;
+		bool enabled = true;
 	};
 
 	int total_subshapes = 0;
 
 	Map<uint32_t, ShapeData> shapes;
 
-	bool capture_input_on_drag = false;
-	bool ray_pickable = true;
+	bool capture_on_drag = false;
+	bool pickable = true;
 
 	Set<uint32_t> debug_shapes_to_update;
 	int debug_shape_count = 0;
@@ -106,8 +106,8 @@ public:
 	Transform shape_owner_get_transform(uint32_t p_owner) const;
 	Object *shape_owner_get_owner(uint32_t p_owner) const;
 
-	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
-	bool is_shape_owner_disabled(uint32_t p_owner) const;
+	void enable_shape_owner(uint32_t p_owner, bool p_enable = true);
+	bool is_shape_owner_enabled(uint32_t p_owner) const;
 
 	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape3D> &p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
@@ -119,11 +119,11 @@ public:
 
 	uint32_t shape_find_owner(int p_shape_index) const;
 
-	void set_ray_pickable(bool p_ray_pickable);
-	bool is_ray_pickable() const;
+	void set_pickable(bool p_pickable);
+	bool is_pickable() const;
 
-	void set_capture_input_on_drag(bool p_capture);
-	bool get_capture_input_on_drag() const;
+	void enable_capture_on_drag(bool p_enable = true);
+	bool is_capture_on_drag_enabled() const;
 
 	_FORCE_INLINE_ RID get_rid() const { return rid; }
 

--- a/scene/3d/collision_polygon_3d.cpp
+++ b/scene/3d/collision_polygon_3d.cpp
@@ -72,7 +72,7 @@ void CollisionPolygon3D::_build_polygon() {
 		convex->set_points(cp);
 		convex->set_margin(margin);
 		parent->shape_owner_add_shape(owner_id, convex);
-		parent->shape_owner_set_disabled(owner_id, disabled);
+		parent->enable_shape_owner(owner_id, enabled);
 	}
 }
 
@@ -81,7 +81,7 @@ void CollisionPolygon3D::_update_in_shape_owner(bool p_xform_only) {
 	if (p_xform_only) {
 		return;
 	}
-	parent->shape_owner_set_disabled(owner_id, disabled);
+	parent->enable_shape_owner(owner_id, enabled);
 }
 
 void CollisionPolygon3D::_notification(int p_what) {
@@ -143,17 +143,17 @@ real_t CollisionPolygon3D::get_depth() const {
 	return depth;
 }
 
-void CollisionPolygon3D::set_disabled(bool p_disabled) {
-	disabled = p_disabled;
+void CollisionPolygon3D::enable(bool p_enable) {
+	enabled = p_enable;
 	update_gizmo();
 
 	if (parent) {
-		parent->shape_owner_set_disabled(owner_id, p_disabled);
+		parent->enable_shape_owner(owner_id, p_enable);
 	}
 }
 
-bool CollisionPolygon3D::is_disabled() const {
-	return disabled;
+bool CollisionPolygon3D::is_enabled() const {
+	return enabled;
 }
 
 real_t CollisionPolygon3D::get_margin() const {
@@ -192,8 +192,8 @@ void CollisionPolygon3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_polygon", "polygon"), &CollisionPolygon3D::set_polygon);
 	ClassDB::bind_method(D_METHOD("get_polygon"), &CollisionPolygon3D::get_polygon);
 
-	ClassDB::bind_method(D_METHOD("set_disabled", "disabled"), &CollisionPolygon3D::set_disabled);
-	ClassDB::bind_method(D_METHOD("is_disabled"), &CollisionPolygon3D::is_disabled);
+	ClassDB::bind_method(D_METHOD("enable", "enable"), &CollisionPolygon3D::enable, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("is_enabled"), &CollisionPolygon3D::is_enabled);
 
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &CollisionPolygon3D::set_margin);
 	ClassDB::bind_method(D_METHOD("get_margin"), &CollisionPolygon3D::get_margin);
@@ -201,7 +201,7 @@ void CollisionPolygon3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_is_editable_3d_polygon"), &CollisionPolygon3D::_is_editable_3d_polygon);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "depth"), "set_depth", "get_depth");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "enable", "is_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "polygon"), "set_polygon", "get_polygon");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0.001,10,0.001"), "set_margin", "get_margin");
 }

--- a/scene/3d/collision_polygon_3d.h
+++ b/scene/3d/collision_polygon_3d.h
@@ -47,7 +47,7 @@ protected:
 	uint32_t owner_id = 0;
 	CollisionObject3D *parent = nullptr;
 
-	bool disabled = false;
+	bool enabled = true;
 
 	void _build_polygon();
 
@@ -66,8 +66,8 @@ public:
 	void set_polygon(const Vector<Point2> &p_polygon);
 	Vector<Point2> get_polygon() const;
 
-	void set_disabled(bool p_disabled);
-	bool is_disabled() const;
+	void enable(bool p_enable = true);
+	bool is_enabled() const;
 
 	virtual AABB get_item_rect() const;
 

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -81,7 +81,7 @@ void CollisionShape3D::_update_in_shape_owner(bool p_xform_only) {
 	if (p_xform_only) {
 		return;
 	}
-	parent->shape_owner_set_disabled(owner_id, disabled);
+	parent->enable_shape_owner(owner_id, enabled);
 }
 
 void CollisionShape3D::_notification(int p_what) {
@@ -146,13 +146,13 @@ void CollisionShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("resource_changed", "resource"), &CollisionShape3D::resource_changed);
 	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &CollisionShape3D::set_shape);
 	ClassDB::bind_method(D_METHOD("get_shape"), &CollisionShape3D::get_shape);
-	ClassDB::bind_method(D_METHOD("set_disabled", "enable"), &CollisionShape3D::set_disabled);
-	ClassDB::bind_method(D_METHOD("is_disabled"), &CollisionShape3D::is_disabled);
+	ClassDB::bind_method(D_METHOD("enable", "enable"), &CollisionShape3D::enable, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("is_enabled"), &CollisionShape3D::is_enabled);
 	ClassDB::bind_method(D_METHOD("make_convex_from_siblings"), &CollisionShape3D::make_convex_from_siblings);
 	ClassDB::set_method_flags("CollisionShape3D", "make_convex_from_siblings", METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape3D"), "set_shape", "get_shape");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "enable", "is_enabled");
 }
 
 void CollisionShape3D::set_shape(const Ref<Shape3D> &p_shape) {
@@ -186,16 +186,16 @@ Ref<Shape3D> CollisionShape3D::get_shape() const {
 	return shape;
 }
 
-void CollisionShape3D::set_disabled(bool p_disabled) {
-	disabled = p_disabled;
+void CollisionShape3D::enable(bool p_enable) {
+	enabled = p_enable;
 	update_gizmo();
 	if (parent) {
-		parent->shape_owner_set_disabled(owner_id, p_disabled);
+		parent->enable_shape_owner(owner_id, p_enable);
 	}
 }
 
-bool CollisionShape3D::is_disabled() const {
-	return disabled;
+bool CollisionShape3D::is_enabled() const {
+	return enabled;
 }
 
 CollisionShape3D::CollisionShape3D() {

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -44,7 +44,7 @@ class CollisionShape3D : public Node3D {
 	CollisionObject3D *parent = nullptr;
 
 	void resource_changed(RES res);
-	bool disabled = false;
+	bool enabled = true;
 
 protected:
 	void _shape_changed();
@@ -61,8 +61,8 @@ public:
 	void set_shape(const Ref<Shape3D> &p_shape);
 	Ref<Shape3D> get_shape() const;
 
-	void set_disabled(bool p_disabled);
-	bool is_disabled() const;
+	void enable(bool p_enable = true);
+	bool is_enabled() const;
 
 	TypedArray<String> get_configuration_warnings() const override;
 

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -580,12 +580,12 @@ void RigidBody3D::apply_torque_impulse(const Vector3 &p_impulse) {
 	PhysicsServer3D::get_singleton()->body_apply_torque_impulse(get_rid(), p_impulse);
 }
 
-void RigidBody3D::set_use_continuous_collision_detection(bool p_enable) {
+void RigidBody3D::enable_continuous_collision_detection(bool p_enable) {
 	ccd = p_enable;
-	PhysicsServer3D::get_singleton()->body_set_enable_continuous_collision_detection(get_rid(), p_enable);
+	PhysicsServer3D::get_singleton()->body_enable_continuous_collision_detection(get_rid(), p_enable);
 }
 
-bool RigidBody3D::is_using_continuous_collision_detection() const {
+bool RigidBody3D::is_continuous_collision_detection_enabled() const {
 	return ccd;
 }
 
@@ -694,8 +694,8 @@ void RigidBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_contact_monitor", "enabled"), &RigidBody3D::set_contact_monitor);
 	ClassDB::bind_method(D_METHOD("is_contact_monitor_enabled"), &RigidBody3D::is_contact_monitor_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_use_continuous_collision_detection", "enable"), &RigidBody3D::set_use_continuous_collision_detection);
-	ClassDB::bind_method(D_METHOD("is_using_continuous_collision_detection"), &RigidBody3D::is_using_continuous_collision_detection);
+	ClassDB::bind_method(D_METHOD("enable_continuous_collision_detection", "enable"), &RigidBody3D::enable_continuous_collision_detection, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("is_continuous_collision_detection_enabled"), &RigidBody3D::is_continuous_collision_detection_enabled);
 
 	ClassDB::bind_method(D_METHOD("set_axis_velocity", "axis_velocity"), &RigidBody3D::set_axis_velocity);
 
@@ -725,7 +725,7 @@ void RigidBody3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "physics_material_override", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial"), "set_physics_material_override", "get_physics_material_override");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gravity_scale", PROPERTY_HINT_RANGE, "-128,128,0.01"), "set_gravity_scale", "get_gravity_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "custom_integrator"), "set_use_custom_integrator", "is_using_custom_integrator");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "continuous_cd"), "set_use_continuous_collision_detection", "is_using_continuous_collision_detection");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "continuous_cd"), "enable_continuous_collision_detection", "is_continuous_collision_detection_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "contacts_reported", PROPERTY_HINT_RANGE, "0,64,1,or_greater"), "set_max_contacts_reported", "get_max_contacts_reported");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "contact_monitor"), "set_contact_monitor", "is_contact_monitor_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sleeping"), "set_sleeping", "is_sleeping");

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -207,8 +207,8 @@ public:
 	void set_max_contacts_reported(int p_amount);
 	int get_max_contacts_reported() const;
 
-	void set_use_continuous_collision_detection(bool p_enable);
-	bool is_using_continuous_collision_detection() const;
+	void enable_continuous_collision_detection(bool p_enable = true);
+	bool is_continuous_collision_detection_enabled() const;
 
 	void set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock);
 	bool get_axis_lock(PhysicsServer3D::BodyAxis p_axis) const;

--- a/scene/3d/physics_joint_3d.cpp
+++ b/scene/3d/physics_joint_3d.cpp
@@ -116,7 +116,7 @@ void Joint3D::_update_joint(bool p_only_free) {
 		body_b->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint3D::_body_exit_tree));
 	}
 
-	PhysicsServer3D::get_singleton()->joint_disable_collisions_between_bodies(joint, exclude_from_collision);
+	PhysicsServer3D::get_singleton()->joint_enable_collisions_between_bodies(joint, collisions_between_bodies_enabled);
 }
 
 void Joint3D::set_node_a(const NodePath &p_node_a) {
@@ -178,16 +178,16 @@ void Joint3D::_notification(int p_what) {
 	}
 }
 
-void Joint3D::set_exclude_nodes_from_collision(bool p_enable) {
-	if (exclude_from_collision == p_enable) {
+void Joint3D::enable_collisions_between_bodies(bool p_enabled) {
+	if (collisions_between_bodies_enabled == p_enabled) {
 		return;
 	}
-	exclude_from_collision = p_enable;
+	collisions_between_bodies_enabled = p_enabled;
 	_update_joint();
 }
 
-bool Joint3D::get_exclude_nodes_from_collision() const {
-	return exclude_from_collision;
+bool Joint3D::is_collisions_between_bodies_enabled() const {
+	return collisions_between_bodies_enabled;
 }
 
 TypedArray<String> Joint3D::get_configuration_warnings() const {
@@ -210,14 +210,14 @@ void Joint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_solver_priority", "priority"), &Joint3D::set_solver_priority);
 	ClassDB::bind_method(D_METHOD("get_solver_priority"), &Joint3D::get_solver_priority);
 
-	ClassDB::bind_method(D_METHOD("set_exclude_nodes_from_collision", "enable"), &Joint3D::set_exclude_nodes_from_collision);
-	ClassDB::bind_method(D_METHOD("get_exclude_nodes_from_collision"), &Joint3D::get_exclude_nodes_from_collision);
+	ClassDB::bind_method(D_METHOD("enable_collisions_between_bodies", "enabled"), &Joint3D::enable_collisions_between_bodies, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("is_collisions_between_bodies_enabled"), &Joint3D::is_collisions_between_bodies_enabled);
 
-	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "nodes/node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody3D"), "set_node_a", "get_node_a");
-	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "nodes/node_b", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody3D"), "set_node_b", "get_node_b");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody3D"), "set_node_a", "get_node_a");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_b", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody3D"), "set_node_b", "get_node_b");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "solver/priority", PROPERTY_HINT_RANGE, "1,8,1"), "set_solver_priority", "get_solver_priority");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collision/exclude_nodes"), "set_exclude_nodes_from_collision", "get_exclude_nodes_from_collision");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collisions_between_bodies"), "enable_collisions_between_bodies", "is_collisions_between_bodies_enabled");
 }
 
 Joint3D::Joint3D() {

--- a/scene/3d/physics_joint_3d.h
+++ b/scene/3d/physics_joint_3d.h
@@ -45,7 +45,7 @@ class Joint3D : public Node3D {
 	NodePath b;
 
 	int solver_priority = 1;
-	bool exclude_from_collision = true;
+	bool collisions_between_bodies_enabled = false;
 	String warning;
 	bool configured = false;
 
@@ -74,8 +74,8 @@ public:
 	void set_solver_priority(int p_priority);
 	int get_solver_priority() const;
 
-	void set_exclude_nodes_from_collision(bool p_enable);
-	bool get_exclude_nodes_from_collision() const;
+	void enable_collisions_between_bodies(bool p_enabled = true);
+	bool is_collisions_between_bodies_enabled() const;
 
 	RID get_joint() const { return joint; }
 	Joint3D();

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -118,8 +118,8 @@ void SoftBody3D::_update_pickable() {
 	if (!is_inside_tree()) {
 		return;
 	}
-	bool pickable = ray_pickable && is_visible_in_tree();
-	PhysicsServer3D::get_singleton()->soft_body_set_ray_pickable(physics_rid, pickable);
+	bool pickable_and_visible = pickable && is_visible_in_tree();
+	PhysicsServer3D::get_singleton()->soft_body_set_pickable(physics_rid, pickable_and_visible);
 }
 
 bool SoftBody3D::_set(const StringName &p_name, const Variant &p_value) {
@@ -348,8 +348,8 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_drag_coefficient", "drag_coefficient"), &SoftBody3D::set_drag_coefficient);
 	ClassDB::bind_method(D_METHOD("get_drag_coefficient"), &SoftBody3D::get_drag_coefficient);
 
-	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &SoftBody3D::set_ray_pickable);
-	ClassDB::bind_method(D_METHOD("is_ray_pickable"), &SoftBody3D::is_ray_pickable);
+	ClassDB::bind_method(D_METHOD("set_pickable", "pickable"), &SoftBody3D::set_pickable);
+	ClassDB::bind_method(D_METHOD("is_pickable"), &SoftBody3D::is_pickable);
 
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
@@ -363,7 +363,7 @@ void SoftBody3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "damping_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_damping_coefficient", "get_damping_coefficient");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "drag_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_coefficient", "get_drag_coefficient");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ray_pickable"), "set_ray_pickable", "is_ray_pickable");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pickable"), "set_pickable", "is_pickable");
 }
 
 TypedArray<String> SoftBody3D::get_configuration_warnings() const {
@@ -643,13 +643,13 @@ bool SoftBody3D::is_point_pinned(int p_point_index) const {
 	return -1 != _has_pinned_point(p_point_index);
 }
 
-void SoftBody3D::set_ray_pickable(bool p_ray_pickable) {
-	ray_pickable = p_ray_pickable;
+void SoftBody3D::set_pickable(bool p_pickable) {
+	pickable = p_pickable;
 	_update_pickable();
 }
 
-bool SoftBody3D::is_ray_pickable() const {
-	return ray_pickable;
+bool SoftBody3D::is_pickable() const {
+	return pickable;
 }
 
 SoftBody3D::SoftBody3D() :

--- a/scene/3d/soft_body_3d.h
+++ b/scene/3d/soft_body_3d.h
@@ -94,8 +94,8 @@ private:
 	Ref<ArrayMesh> debug_mesh_cache;
 	class MeshInstance3D *debug_mesh = nullptr;
 
-	bool capture_input_on_drag = false;
-	bool ray_pickable = true;
+	bool capture_on_drag = false;
+	bool pickable = true;
 
 	void _update_pickable();
 
@@ -171,8 +171,8 @@ public:
 	void pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path = NodePath());
 	bool is_point_pinned(int p_point_index) const;
 
-	void set_ray_pickable(bool p_ray_pickable);
-	bool is_ray_pickable() const;
+	void set_pickable(bool p_pickable);
+	bool is_pickable() const;
 
 	SoftBody3D();
 	~SoftBody3D();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -792,7 +792,7 @@ void Viewport::_process_picking() {
 				if (ObjectDB::get_instance(last_id) && last_object) {
 					//good, exists
 					_collision_object_input_event(last_object, camera, ev, result.position, result.normal, result.shape);
-					if (last_object->get_capture_input_on_drag() && mb.is_valid() && mb->get_button_index() == 1 && mb->is_pressed()) {
+					if (last_object->is_capture_on_drag_enabled() && mb.is_valid() && mb->get_button_index() == 1 && mb->is_pressed()) {
 						physics_object_capture = last_id;
 					}
 				}
@@ -813,7 +813,7 @@ void Viewport::_process_picking() {
 							last_object = co;
 							last_id = result.collider_id;
 							new_collider = last_id;
-							if (co->get_capture_input_on_drag() && mb.is_valid() && mb->get_button_index() == 1 && mb->is_pressed()) {
+							if (co->is_capture_on_drag_enabled() && mb.is_valid() && mb->get_button_index() == 1 && mb->is_pressed()) {
 								physics_object_capture = last_id;
 							}
 						}

--- a/servers/physics_2d/area_pair_2d_sw.cpp
+++ b/servers/physics_2d/area_pair_2d_sw.cpp
@@ -34,7 +34,7 @@
 bool AreaPair2DSW::setup(real_t p_step) {
 	bool result = false;
 
-	if (area->is_shape_set_as_disabled(area_shape) || body->is_shape_set_as_disabled(body_shape)) {
+	if (!area->is_shape_enabled(area_shape) || !body->is_shape_enabled(body_shape)) {
 		result = false;
 	} else if (area->test_collision_mask(body) && CollisionSolver2DSW::solve(body->get_shape(body_shape), body->get_transform() * body->get_shape_transform(body_shape), Vector2(), area->get_shape(area_shape), area->get_transform() * area->get_shape_transform(area_shape), Vector2(), nullptr, this)) {
 		result = true;
@@ -97,7 +97,7 @@ AreaPair2DSW::~AreaPair2DSW() {
 
 bool Area2Pair2DSW::setup(real_t p_step) {
 	bool result = false;
-	if (area_a->is_shape_set_as_disabled(shape_a) || area_b->is_shape_set_as_disabled(shape_b)) {
+	if (!area_a->is_shape_enabled(shape_a) || !area_b->is_shape_enabled(shape_b)) {
 		result = false;
 	} else if (area_a->test_collision_mask(area_b) && CollisionSolver2DSW::solve(area_a->get_shape(shape_a), area_a->get_transform() * area_a->get_shape_transform(shape_a), Vector2(), area_b->get_shape(shape_b), area_b->get_transform() * area_b->get_shape_transform(shape_b), Vector2(), nullptr, this)) {
 		result = true;

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -58,7 +58,7 @@ void Body2DSW::update_inertias() {
 			inertia = 0;
 
 			for (int i = 0; i < get_shape_count(); i++) {
-				if (is_shape_disabled(i)) {
+				if (!is_shape_enabled(i)) {
 					continue;
 				}
 

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -359,7 +359,7 @@ public:
 	virtual void apply_impulse(const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override { body->apply_impulse(p_impulse, p_position); }
 	virtual void apply_torque_impulse(real_t p_torque) override { body->apply_torque_impulse(p_torque); }
 
-	virtual void set_sleep_state(bool p_enable) override { body->set_active(!p_enable); }
+	virtual void set_sleep_state(bool p_sleeping) override { body->set_active(!p_sleeping); }
 	virtual bool is_sleeping() const override { return !body->is_active(); }
 
 	virtual int get_contact_count() const override { return body->contact_count; }

--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -236,7 +236,7 @@ bool BodyPair2DSW::setup(real_t p_step) {
 		}
 	}
 
-	if (A->is_shape_set_as_disabled(shape_A) || B->is_shape_set_as_disabled(shape_B)) {
+	if (!A->is_shape_enabled(shape_A) || !B->is_shape_enabled(shape_B)) {
 		collided = false;
 		return false;
 	}
@@ -295,7 +295,7 @@ bool BodyPair2DSW::setup(real_t p_step) {
 	}
 
 	if (!prev_collided) {
-		if (A->is_shape_set_as_one_way_collision(shape_A)) {
+		if (A->is_shape_one_way_collision_enabled(shape_A)) {
 			Vector2 direction = xform_A.get_axis(1).normalized();
 			bool valid = false;
 			for (int i = 0; i < contact_count; i++) {
@@ -316,7 +316,7 @@ bool BodyPair2DSW::setup(real_t p_step) {
 			}
 		}
 
-		if (B->is_shape_set_as_one_way_collision(shape_B)) {
+		if (B->is_shape_one_way_collision_enabled(shape_B)) {
 			Vector2 direction = xform_B.get_axis(1).normalized();
 			bool valid = false;
 			for (int i = 0; i < contact_count; i++) {

--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -59,14 +59,9 @@ private:
 		Rect2 aabb_cache; //for rayqueries
 		Shape2DSW *shape;
 		Variant metadata;
-		bool disabled;
-		bool one_way_collision;
-		real_t one_way_collision_margin;
-		Shape() {
-			disabled = false;
-			one_way_collision = false;
-			one_way_collision_margin = 0;
-		}
+		bool enabled = true;
+		bool one_way_collision = false;
+		real_t one_way_collision_margin = 1;
 	};
 
 	Vector<Shape> shapes;
@@ -112,16 +107,13 @@ public:
 	void _shape_changed();
 
 	_FORCE_INLINE_ Type get_type() const { return type; }
-	void add_shape(Shape2DSW *p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false);
+	void add_shape(Shape2DSW *p_shape, const Transform2D &p_transform = Transform2D(), bool p_enabled = true);
 	void set_shape(int p_index, Shape2DSW *p_shape);
 	void set_shape_transform(int p_index, const Transform2D &p_transform);
 	void set_shape_metadata(int p_index, const Variant &p_metadata);
 
 	_FORCE_INLINE_ int get_shape_count() const { return shapes.size(); }
-	_FORCE_INLINE_ bool is_shape_disabled(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
-		return shapes[p_index].disabled;
-	}
+
 	_FORCE_INLINE_ Shape2DSW *get_shape(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].shape;
@@ -147,18 +139,19 @@ public:
 	_FORCE_INLINE_ Transform2D get_inv_transform() const { return inv_transform; }
 	_FORCE_INLINE_ Space2DSW *get_space() const { return space; }
 
-	void set_shape_as_disabled(int p_idx, bool p_disabled);
-	_FORCE_INLINE_ bool is_shape_set_as_disabled(int p_idx) const {
+	void enable_shape(int p_idx, bool p_enable = true);
+	_FORCE_INLINE_ bool is_shape_enabled(int p_idx) const {
 		CRASH_BAD_INDEX(p_idx, shapes.size());
-		return shapes[p_idx].disabled;
+		return shapes[p_idx].enabled;
 	}
 
-	_FORCE_INLINE_ void set_shape_as_one_way_collision(int p_idx, bool p_one_way_collision, real_t p_margin) {
+	_FORCE_INLINE_ void enable_shape_one_way_collision(int p_idx, bool p_one_way_collision = false, real_t p_margin = 1) {
 		CRASH_BAD_INDEX(p_idx, shapes.size());
 		shapes.write[p_idx].one_way_collision = p_one_way_collision;
 		shapes.write[p_idx].one_way_collision_margin = p_margin;
 	}
-	_FORCE_INLINE_ bool is_shape_set_as_one_way_collision(int p_idx) const {
+
+	_FORCE_INLINE_ bool is_shape_one_way_collision_enabled(int p_idx) const {
 		CRASH_BAD_INDEX(p_idx, shapes.size());
 		return shapes[p_idx].one_way_collision;
 	}

--- a/servers/physics_2d/constraint_2d_sw.h
+++ b/servers/physics_2d/constraint_2d_sw.h
@@ -37,7 +37,7 @@ class Constraint2DSW {
 	Body2DSW **_body_ptr;
 	int _body_count;
 	uint64_t island_step;
-	bool disabled_collisions_between_bodies;
+	bool collisions_between_bodies_enabled;
 
 	RID self;
 
@@ -46,7 +46,7 @@ protected:
 		_body_ptr = p_body_ptr;
 		_body_count = p_body_count;
 		island_step = 0;
-		disabled_collisions_between_bodies = true;
+		collisions_between_bodies_enabled = false;
 	}
 
 public:
@@ -59,8 +59,8 @@ public:
 	_FORCE_INLINE_ Body2DSW **get_body_ptr() const { return _body_ptr; }
 	_FORCE_INLINE_ int get_body_count() const { return _body_count; }
 
-	_FORCE_INLINE_ void disable_collisions_between_bodies(const bool p_disabled) { disabled_collisions_between_bodies = p_disabled; }
-	_FORCE_INLINE_ bool is_disabled_collisions_between_bodies() const { return disabled_collisions_between_bodies; }
+	_FORCE_INLINE_ void enable_collisions_between_bodies(const bool p_enable = true) { collisions_between_bodies_enabled = p_enable; }
+	_FORCE_INLINE_ bool is_collisions_between_bodies_enabled() const { return collisions_between_bodies_enabled; }
 
 	virtual bool setup(real_t p_step) = 0;
 	virtual void solve(real_t p_step) = 0;

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -60,7 +60,7 @@ void Joint2DSW::copy_settings_from(Joint2DSW *p_joint) {
 	set_max_force(p_joint->get_max_force());
 	set_bias(p_joint->get_bias());
 	set_max_bias(p_joint->get_max_bias());
-	disable_collisions_between_bodies(p_joint->is_disabled_collisions_between_bodies());
+	enable_collisions_between_bodies(p_joint->is_collisions_between_bodies_enabled());
 }
 
 static inline real_t k_scalar(Body2DSW *a, Body2DSW *b, const Vector2 &rA, const Vector2 &rB, const Vector2 &n) {

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -333,14 +333,14 @@ PhysicsServer2D::AreaSpaceOverrideMode PhysicsServer2DSW::area_get_space_overrid
 	return area->get_space_override_mode();
 }
 
-void PhysicsServer2DSW::area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform, bool p_disabled) {
+void PhysicsServer2DSW::area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform, bool p_enabled) {
 	Area2DSW *area = area_owner.getornull(p_area);
 	ERR_FAIL_COND(!area);
 
 	Shape2DSW *shape = shape_owner.getornull(p_shape);
 	ERR_FAIL_COND(!shape);
 
-	area->add_shape(shape, p_transform, p_disabled);
+	area->add_shape(shape, p_transform, p_enabled);
 }
 
 void PhysicsServer2DSW::area_set_shape(RID p_area, int p_shape_idx, RID p_shape) {
@@ -361,13 +361,13 @@ void PhysicsServer2DSW::area_set_shape_transform(RID p_area, int p_shape_idx, co
 	area->set_shape_transform(p_shape_idx, p_transform);
 }
 
-void PhysicsServer2DSW::area_set_shape_disabled(RID p_area, int p_shape, bool p_disabled) {
+void PhysicsServer2DSW::area_enable_shape(RID p_area, int p_shape, bool p_enable) {
 	Area2DSW *area = area_owner.getornull(p_area);
 	ERR_FAIL_COND(!area);
 	ERR_FAIL_INDEX(p_shape, area->get_shape_count());
 	FLUSH_QUERY_CHECK(area);
 
-	area->set_shape_as_disabled(p_shape, p_disabled);
+	area->enable_shape(p_shape, p_enable);
 }
 
 int PhysicsServer2DSW::area_get_shape_count(RID p_area) const {
@@ -578,14 +578,14 @@ PhysicsServer2D::BodyMode PhysicsServer2DSW::body_get_mode(RID p_body) const {
 	return body->get_mode();
 };
 
-void PhysicsServer2DSW::body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform, bool p_disabled) {
+void PhysicsServer2DSW::body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform, bool p_enabled) {
 	Body2DSW *body = body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
 
 	Shape2DSW *shape = shape_owner.getornull(p_shape);
 	ERR_FAIL_COND(!shape);
 
-	body->add_shape(shape, p_transform, p_disabled);
+	body->add_shape(shape, p_transform, p_enabled);
 }
 
 void PhysicsServer2DSW::body_set_shape(RID p_body, int p_shape_idx, RID p_shape) {
@@ -658,22 +658,22 @@ void PhysicsServer2DSW::body_clear_shapes(RID p_body) {
 	}
 }
 
-void PhysicsServer2DSW::body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) {
+void PhysicsServer2DSW::body_enable_shape(RID p_body, int p_shape_idx, bool p_enabled) {
 	Body2DSW *body = body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
 	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
 	FLUSH_QUERY_CHECK(body);
 
-	body->set_shape_as_disabled(p_shape_idx, p_disabled);
+	body->enable_shape(p_shape_idx, p_enabled);
 }
 
-void PhysicsServer2DSW::body_set_shape_as_one_way_collision(RID p_body, int p_shape_idx, bool p_enable, real_t p_margin) {
+void PhysicsServer2DSW::body_enable_shape_one_way_collision(RID p_body, int p_shape_idx, bool p_enable, real_t p_margin) {
 	Body2DSW *body = body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
 	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
 	FLUSH_QUERY_CHECK(body);
 
-	body->set_shape_as_one_way_collision(p_shape_idx, p_enable, p_margin);
+	body->enable_shape_one_way_collision(p_shape_idx, p_enable, p_margin);
 }
 
 void PhysicsServer2DSW::body_set_continuous_collision_detection_mode(RID p_body, CCDMode p_mode) {
@@ -1039,31 +1039,31 @@ real_t PhysicsServer2DSW::joint_get_param(RID p_joint, JointParam p_param) const
 	return 0;
 }
 
-void PhysicsServer2DSW::joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) {
+void PhysicsServer2DSW::joint_enable_collisions_between_bodies(RID p_joint, const bool p_enable) {
 	Joint2DSW *joint = joint_owner.getornull(p_joint);
 	ERR_FAIL_COND(!joint);
 
-	joint->disable_collisions_between_bodies(p_disable);
+	joint->enable_collisions_between_bodies(p_enable);
 
 	if (2 == joint->get_body_count()) {
 		Body2DSW *body_a = *joint->get_body_ptr();
 		Body2DSW *body_b = *(joint->get_body_ptr() + 1);
 
-		if (p_disable) {
-			body_add_collision_exception(body_a->get_self(), body_b->get_self());
-			body_add_collision_exception(body_b->get_self(), body_a->get_self());
-		} else {
+		if (p_enable) {
 			body_remove_collision_exception(body_a->get_self(), body_b->get_self());
 			body_remove_collision_exception(body_b->get_self(), body_a->get_self());
+		} else {
+			body_add_collision_exception(body_a->get_self(), body_b->get_self());
+			body_add_collision_exception(body_b->get_self(), body_a->get_self());
 		}
 	}
 }
 
-bool PhysicsServer2DSW::joint_is_disabled_collisions_between_bodies(RID p_joint) const {
+bool PhysicsServer2DSW::joint_is_collisions_between_bodies_enabled(RID p_joint) const {
 	const Joint2DSW *joint = joint_owner.getornull(p_joint);
 	ERR_FAIL_COND_V(!joint, true);
 
-	return joint->is_disabled_collisions_between_bodies();
+	return joint->is_collisions_between_bodies_enabled();
 }
 
 void PhysicsServer2DSW::joint_make_pin(RID p_joint, const Vector2 &p_pos, RID p_body_a, RID p_body_b) {

--- a/servers/physics_2d/physics_server_2d_sw.h
+++ b/servers/physics_2d/physics_server_2d_sw.h
@@ -133,7 +133,7 @@ public:
 	virtual void area_set_space(RID p_area, RID p_space) override;
 	virtual RID area_get_space(RID p_area) const override;
 
-	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) override;
+	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_enabled = true) override;
 	virtual void area_set_shape(RID p_area, int p_shape_idx, RID p_shape) override;
 	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform) override;
 
@@ -141,7 +141,7 @@ public:
 	virtual RID area_get_shape(RID p_area, int p_shape_idx) const override;
 	virtual Transform2D area_get_shape_transform(RID p_area, int p_shape_idx) const override;
 
-	virtual void area_set_shape_disabled(RID p_area, int p_shape, bool p_disabled) override;
+	virtual void area_enable_shape(RID p_area, int p_shape, bool p_enabled = true) override;
 
 	virtual void area_remove_shape(RID p_area, int p_shape_idx) override;
 	virtual void area_clear_shapes(RID p_area) override;
@@ -177,7 +177,7 @@ public:
 	virtual void body_set_mode(RID p_body, BodyMode p_mode) override;
 	virtual BodyMode body_get_mode(RID p_body) const override;
 
-	virtual void body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) override;
+	virtual void body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_enabled = true) override;
 	virtual void body_set_shape(RID p_body, int p_shape_idx, RID p_shape) override;
 	virtual void body_set_shape_transform(RID p_body, int p_shape_idx, const Transform2D &p_transform) override;
 	virtual void body_set_shape_metadata(RID p_body, int p_shape_idx, const Variant &p_metadata) override;
@@ -190,8 +190,8 @@ public:
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) override;
 	virtual void body_clear_shapes(RID p_body) override;
 
-	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override;
-	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape_idx, bool p_enable, real_t p_margin) override;
+	virtual void body_enable_shape(RID p_body, int p_shape_idx, bool p_enabled = true) override;
+	virtual void body_enable_shape_one_way_collision(RID p_body, int p_shape_idx, bool p_enable = true, real_t p_margin = 1) override;
 
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) override;
 	virtual ObjectID body_get_object_instance_id(RID p_body) const override;
@@ -262,8 +262,8 @@ public:
 	virtual void joint_set_param(RID p_joint, JointParam p_param, real_t p_value) override;
 	virtual real_t joint_get_param(RID p_joint, JointParam p_param) const override;
 
-	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disabled) override;
-	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const override;
+	virtual void joint_enable_collisions_between_bodies(RID p_joint, const bool p_enable = true) override;
+	virtual bool joint_is_collisions_between_bodies_enabled(RID p_joint) const override;
 
 	virtual void joint_make_pin(RID p_joint, const Vector2 &p_anchor, RID p_body_a, RID p_body_b = RID()) override;
 	virtual void joint_make_groove(RID p_joint, const Vector2 &p_a_groove1, const Vector2 &p_a_groove2, const Vector2 &p_b_anchor, RID p_body_a, RID p_body_b) override;

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -141,7 +141,7 @@ public:
 	FUNC4(area_add_shape, RID, RID, const Transform2D &, bool);
 	FUNC3(area_set_shape, RID, int, RID);
 	FUNC3(area_set_shape_transform, RID, int, const Transform2D &);
-	FUNC3(area_set_shape_disabled, RID, int, bool);
+	FUNC3(area_enable_shape, RID, int, bool);
 
 	FUNC1RC(int, area_get_shape_count, RID);
 	FUNC2RC(RID, area_get_shape, RID, int);
@@ -191,8 +191,8 @@ public:
 	FUNC2RC(Variant, body_get_shape_metadata, RID, int);
 	FUNC2RC(RID, body_get_shape, RID, int);
 
-	FUNC3(body_set_shape_disabled, RID, int, bool);
-	FUNC4(body_set_shape_as_one_way_collision, RID, int, bool, real_t);
+	FUNC3(body_enable_shape, RID, int, bool);
+	FUNC4(body_enable_shape_one_way_collision, RID, int, bool, real_t);
 
 	FUNC2(body_remove_shape, RID, int);
 	FUNC1(body_clear_shapes, RID);
@@ -278,8 +278,8 @@ public:
 	FUNC3(joint_set_param, RID, JointParam, real_t);
 	FUNC2RC(real_t, joint_get_param, RID, JointParam);
 
-	FUNC2(joint_disable_collisions_between_bodies, RID, const bool);
-	FUNC1RC(bool, joint_is_disabled_collisions_between_bodies, RID);
+	FUNC2(joint_enable_collisions_between_bodies, RID, const bool);
+	FUNC1RC(bool, joint_is_collisions_between_bodies_enabled, RID);
 
 	///FUNC3RID(pin_joint,const Vector2&,RID,RID);
 	///FUNC5RID(groove_joint,const Vector2&,const Vector2&,const Vector2&,RID,RID);

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -84,7 +84,7 @@ int PhysicsDirectSpaceState2DSW::_intersect_point_impl(const Vector2 &p_point, S
 
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (col_obj->is_shape_set_as_disabled(shape_idx)) {
+		if (!col_obj->is_shape_enabled(shape_idx)) {
 			continue;
 		}
 
@@ -233,7 +233,7 @@ int PhysicsDirectSpaceState2DSW::intersect_shape(const RID &p_shape, const Trans
 		const CollisionObject2DSW *col_obj = space->intersection_query_results[i];
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (col_obj->is_shape_set_as_disabled(shape_idx)) {
+		if (!col_obj->is_shape_enabled(shape_idx)) {
 			continue;
 		}
 
@@ -280,7 +280,7 @@ bool PhysicsDirectSpaceState2DSW::cast_motion(const RID &p_shape, const Transfor
 		const CollisionObject2DSW *col_obj = space->intersection_query_results[i];
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (col_obj->is_shape_set_as_disabled(shape_idx)) {
+		if (!col_obj->is_shape_enabled(shape_idx)) {
 			continue;
 		}
 
@@ -365,7 +365,7 @@ bool PhysicsDirectSpaceState2DSW::collide_shape(RID p_shape, const Transform2D &
 
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (col_obj->is_shape_set_as_disabled(shape_idx)) {
+		if (!col_obj->is_shape_enabled(shape_idx)) {
 			continue;
 		}
 
@@ -460,7 +460,7 @@ bool PhysicsDirectSpaceState2DSW::rest_info(RID p_shape, const Transform2D &p_sh
 
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (col_obj->is_shape_set_as_disabled(shape_idx)) {
+		if (!col_obj->is_shape_enabled(shape_idx)) {
 			continue;
 		}
 
@@ -516,7 +516,7 @@ int Space2DSW::_cull_aabb_for_body(Body2DSW *p_body, const Rect2 &p_aabb) {
 			keep = false;
 		} else if (static_cast<Body2DSW *>(intersection_query_results[i])->has_exception(p_body->get_self()) || p_body->has_exception(intersection_query_results[i]->get_self())) {
 			keep = false;
-		} else if (static_cast<Body2DSW *>(intersection_query_results[i])->is_shape_set_as_disabled(intersection_query_subindex_results[i])) {
+		} else if (!static_cast<Body2DSW *>(intersection_query_results[i])->is_shape_enabled(intersection_query_subindex_results[i])) {
 			keep = false;
 		}
 
@@ -540,7 +540,7 @@ int Space2DSW::test_body_ray_separation(Body2DSW *p_body, const Transform2D &p_t
 	bool shapes_found = false;
 
 	for (int i = 0; i < p_body->get_shape_count(); i++) {
-		if (p_body->is_shape_set_as_disabled(i)) {
+		if (!p_body->is_shape_enabled(i)) {
 			continue;
 		}
 
@@ -592,7 +592,7 @@ int Space2DSW::test_body_ray_separation(Body2DSW *p_body, const Transform2D &p_t
 			int amount = _cull_aabb_for_body(p_body, body_aabb);
 
 			for (int j = 0; j < p_body->get_shape_count(); j++) {
-				if (p_body->is_shape_set_as_disabled(j)) {
+				if (!p_body->is_shape_enabled(j)) {
 					continue;
 				}
 
@@ -732,7 +732,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 	bool shapes_found = false;
 
 	for (int i = 0; i < p_body->get_shape_count(); i++) {
-		if (p_body->is_shape_set_as_disabled(i)) {
+		if (!p_body->is_shape_enabled(i)) {
 			continue;
 		}
 
@@ -795,7 +795,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 			int amount = _cull_aabb_for_body(p_body, body_aabb);
 
 			for (int j = 0; j < p_body->get_shape_count(); j++) {
-				if (p_body->is_shape_set_as_disabled(j)) {
+				if (!p_body->is_shape_enabled(j)) {
 					continue;
 				}
 
@@ -818,7 +818,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 
 					Transform2D col_obj_shape_xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 
-					if (col_obj->is_shape_set_as_one_way_collision(shape_idx)) {
+					if (col_obj->is_shape_one_way_collision_enabled(shape_idx)) {
 						cbk.valid_dir = col_obj_shape_xform.get_axis(1).normalized();
 
 						real_t owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);
@@ -918,7 +918,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 		int amount = _cull_aabb_for_body(p_body, motion_aabb);
 
 		for (int body_shape_idx = 0; body_shape_idx < p_body->get_shape_count(); body_shape_idx++) {
-			if (p_body->is_shape_set_as_disabled(body_shape_idx)) {
+			if (!p_body->is_shape_enabled(body_shape_idx)) {
 				continue;
 			}
 
@@ -967,7 +967,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 
 				//test initial overlap
 				if (CollisionSolver2DSW::solve(body_shape, body_shape_xform, Vector2(), against_shape, col_obj_shape_xform, Vector2(), nullptr, nullptr, nullptr, 0)) {
-					if (col_obj->is_shape_set_as_one_way_collision(col_shape_idx)) {
+					if (col_obj->is_shape_one_way_collision_enabled(col_shape_idx)) {
 						Vector2 direction = col_obj_shape_xform.get_axis(1).normalized();
 						if (motion_normal.dot(direction) < 0) {
 							continue;
@@ -996,7 +996,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 					}
 				}
 
-				if (col_obj->is_shape_set_as_one_way_collision(col_shape_idx)) {
+				if (col_obj->is_shape_one_way_collision_enabled(col_shape_idx)) {
 					Vector2 cd[2];
 					PhysicsServer2DSW::CollCbkData cbk;
 					cbk.max = 1;
@@ -1060,7 +1060,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 		int to_shape = best_shape != -1 ? best_shape + 1 : p_body->get_shape_count();
 
 		for (int j = from_shape; j < to_shape; j++) {
-			if (p_body->is_shape_set_as_disabled(j)) {
+			if (!p_body->is_shape_enabled(j)) {
 				continue;
 			}
 
@@ -1101,7 +1101,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 
 				Transform2D col_obj_shape_xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 
-				if (col_obj->is_shape_set_as_one_way_collision(shape_idx)) {
+				if (col_obj->is_shape_one_way_collision_enabled(shape_idx)) {
 					rcd.valid_dir = col_obj_shape_xform.get_axis(1).normalized();
 
 					real_t owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);

--- a/servers/physics_3d/area_3d_sw.cpp
+++ b/servers/physics_3d/area_3d_sw.cpp
@@ -288,7 +288,7 @@ Area3DSW::Area3DSW() :
 	angular_damp = 0.1;
 	linear_damp = 0.1;
 	priority = 0;
-	set_ray_pickable(false);
+	set_pickable(false);
 	monitorable = false;
 }
 

--- a/servers/physics_3d/area_pair_3d_sw.cpp
+++ b/servers/physics_3d/area_pair_3d_sw.cpp
@@ -34,7 +34,7 @@
 bool AreaPair3DSW::setup(real_t p_step) {
 	bool result = false;
 
-	if (area->is_shape_set_as_disabled(area_shape) || body->is_shape_set_as_disabled(body_shape)) {
+	if (!area->is_shape_enabled(area_shape) || !body->is_shape_enabled(body_shape)) {
 		result = false;
 	} else if (area->test_collision_mask(body) && CollisionSolver3DSW::solve_static(body->get_shape(body_shape), body->get_transform() * body->get_shape_transform(body_shape), area->get_shape(area_shape), area->get_transform() * area->get_shape_transform(area_shape), nullptr, this)) {
 		result = true;
@@ -97,7 +97,7 @@ AreaPair3DSW::~AreaPair3DSW() {
 
 bool Area2Pair3DSW::setup(real_t p_step) {
 	bool result = false;
-	if (area_a->is_shape_set_as_disabled(shape_a) || area_b->is_shape_set_as_disabled(shape_b)) {
+	if (!area_a->is_shape_enabled(shape_a) || !area_b->is_shape_enabled(shape_b)) {
 		result = false;
 	} else if (area_a->test_collision_mask(area_b) && CollisionSolver3DSW::solve_static(area_a->get_shape(shape_a), area_a->get_transform() * area_a->get_shape_transform(shape_a), area_b->get_shape(shape_b), area_b->get_transform() * area_b->get_shape_transform(shape_b), nullptr, this)) {
 		result = true;

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -82,7 +82,7 @@ void Body3DSW::update_inertias() {
 			bool inertia_set = false;
 
 			for (int i = 0; i < get_shape_count(); i++) {
-				if (is_shape_disabled(i)) {
+				if (!is_shape_enabled(i)) {
 					continue;
 				}
 

--- a/servers/physics_3d/body_3d_sw.h
+++ b/servers/physics_3d/body_3d_sw.h
@@ -273,7 +273,7 @@ public:
 	void set_applied_torque(const Vector3 &p_torque) { applied_torque = p_torque; }
 	Vector3 get_applied_torque() const { return applied_torque; }
 
-	_FORCE_INLINE_ void set_continuous_collision_detection(bool p_enable) { continuous_cd = p_enable; }
+	_FORCE_INLINE_ void enable_continuous_collision_detection(bool p_enable = true) { continuous_cd = p_enable; }
 	_FORCE_INLINE_ bool is_continuous_collision_detection_enabled() const { return continuous_cd; }
 
 	void set_space(Space3DSW *p_space);

--- a/servers/physics_3d/body_pair_3d_sw.cpp
+++ b/servers/physics_3d/body_pair_3d_sw.cpp
@@ -228,7 +228,7 @@ bool BodyPair3DSW::setup(real_t p_step) {
 		}
 	}
 
-	if (A->is_shape_set_as_disabled(shape_A) || B->is_shape_set_as_disabled(shape_B)) {
+	if (!A->is_shape_enabled(shape_A) || !B->is_shape_enabled(shape_B)) {
 		collided = false;
 		return false;
 	}
@@ -569,7 +569,7 @@ bool BodySoftBodyPair3DSW::setup(real_t p_step) {
 		return false;
 	}
 
-	if (body->is_shape_set_as_disabled(body_shape)) {
+	if (!body->is_shape_enabled(body_shape)) {
 		collided = false;
 		return false;
 	}

--- a/servers/physics_3d/collision_object_3d_sw.cpp
+++ b/servers/physics_3d/collision_object_3d_sw.cpp
@@ -32,13 +32,13 @@
 #include "servers/physics_3d/physics_server_3d_sw.h"
 #include "space_3d_sw.h"
 
-void CollisionObject3DSW::add_shape(Shape3DSW *p_shape, const Transform &p_transform, bool p_disabled) {
+void CollisionObject3DSW::add_shape(Shape3DSW *p_shape, const Transform &p_transform, bool p_enabled) {
 	Shape s;
 	s.shape = p_shape;
 	s.xform = p_transform;
 	s.xform_inv = s.xform.affine_inverse();
 	s.bpid = 0; //needs update
-	s.disabled = p_disabled;
+	s.enabled = p_enabled;
 	shapes.push_back(s);
 	p_shape->add_owner(this);
 
@@ -74,8 +74,8 @@ void CollisionObject3DSW::set_shape_transform(int p_index, const Transform &p_tr
 	//_shapes_changed();
 }
 
-void CollisionObject3DSW::set_shape_as_disabled(int p_idx, bool p_enable) {
-	shapes.write[p_idx].disabled = p_enable;
+void CollisionObject3DSW::enable_shape(int p_idx, bool p_enable) {
+	shapes.write[p_idx].enabled = p_enable;
 	if (!pending_shape_update_list.in_list()) {
 		PhysicsServer3DSW::singletonsw->pending_shape_update_list.add(&pending_shape_update_list);
 	}
@@ -222,5 +222,5 @@ CollisionObject3DSW::CollisionObject3DSW(Type p_type) :
 
 	collision_layer = 1;
 	collision_mask = 1;
-	ray_pickable = true;
+	pickable = true;
 }

--- a/servers/physics_3d/collision_object_3d_sw.h
+++ b/servers/physics_3d/collision_object_3d_sw.h
@@ -66,9 +66,7 @@ private:
 		AABB aabb_cache; //for rayqueries
 		real_t area_cache;
 		Shape3DSW *shape;
-		bool disabled;
-
-		Shape() { disabled = false; }
+		bool enabled = true;
 	};
 
 	Vector<Shape> shapes;
@@ -102,7 +100,7 @@ protected:
 	virtual void _shapes_changed() = 0;
 	void _set_space(Space3DSW *p_space);
 
-	bool ray_pickable;
+	bool pickable;
 
 	CollisionObject3DSW(Type p_type);
 
@@ -116,14 +114,11 @@ public:
 	void _shape_changed();
 
 	_FORCE_INLINE_ Type get_type() const { return type; }
-	void add_shape(Shape3DSW *p_shape, const Transform &p_transform = Transform(), bool p_disabled = false);
+	void add_shape(Shape3DSW *p_shape, const Transform &p_transform = Transform(), bool p_enabled = true);
 	void set_shape(int p_index, Shape3DSW *p_shape);
 	void set_shape_transform(int p_index, const Transform &p_transform);
 	_FORCE_INLINE_ int get_shape_count() const { return shapes.size(); }
-	_FORCE_INLINE_ bool is_shape_disabled(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
-		return shapes[p_index].disabled;
-	}
+
 	_FORCE_INLINE_ Shape3DSW *get_shape(int p_index) const { return shapes[p_index].shape; }
 	_FORCE_INLINE_ const Transform &get_shape_transform(int p_index) const { return shapes[p_index].xform; }
 	_FORCE_INLINE_ const Transform &get_shape_inv_transform(int p_index) const { return shapes[p_index].xform_inv; }
@@ -134,13 +129,13 @@ public:
 	_FORCE_INLINE_ const Transform &get_inv_transform() const { return inv_transform; }
 	_FORCE_INLINE_ Space3DSW *get_space() const { return space; }
 
-	_FORCE_INLINE_ void set_ray_pickable(bool p_enable) { ray_pickable = p_enable; }
-	_FORCE_INLINE_ bool is_ray_pickable() const { return ray_pickable; }
+	_FORCE_INLINE_ void set_pickable(bool p_pickable) { pickable = p_pickable; }
+	_FORCE_INLINE_ bool is_pickable() const { return pickable; }
 
-	void set_shape_as_disabled(int p_idx, bool p_enable);
-	_FORCE_INLINE_ bool is_shape_set_as_disabled(int p_idx) const {
+	void enable_shape(int p_idx, bool p_enable = true);
+	_FORCE_INLINE_ bool is_shape_enabled(int p_idx) const {
 		CRASH_BAD_INDEX(p_idx, shapes.size());
-		return shapes[p_idx].disabled;
+		return shapes[p_idx].enabled;
 	}
 
 	_FORCE_INLINE_ void set_collision_layer(uint32_t p_layer) {

--- a/servers/physics_3d/constraint_3d_sw.h
+++ b/servers/physics_3d/constraint_3d_sw.h
@@ -38,7 +38,7 @@ class Constraint3DSW {
 	int _body_count;
 	uint64_t island_step;
 	int priority;
-	bool disabled_collisions_between_bodies;
+	bool collisions_between_bodies_enabled;
 
 	RID self;
 
@@ -48,7 +48,7 @@ protected:
 		_body_count = p_body_count;
 		island_step = 0;
 		priority = 1;
-		disabled_collisions_between_bodies = true;
+		collisions_between_bodies_enabled = false;
 	}
 
 public:
@@ -64,8 +64,8 @@ public:
 	_FORCE_INLINE_ void set_priority(int p_priority) { priority = p_priority; }
 	_FORCE_INLINE_ int get_priority() const { return priority; }
 
-	_FORCE_INLINE_ void disable_collisions_between_bodies(const bool p_disabled) { disabled_collisions_between_bodies = p_disabled; }
-	_FORCE_INLINE_ bool is_disabled_collisions_between_bodies() const { return disabled_collisions_between_bodies; }
+	_FORCE_INLINE_ void enable_collisions_between_bodies(const bool p_enable = true) { collisions_between_bodies_enabled = p_enable; }
+	_FORCE_INLINE_ bool is_collisions_between_bodies_enabled() const { return collisions_between_bodies_enabled; }
 
 	virtual bool setup(real_t p_step) = 0;
 	virtual void solve(real_t p_step) = 0;

--- a/servers/physics_3d/joints_3d_sw.h
+++ b/servers/physics_3d/joints_3d_sw.h
@@ -42,7 +42,7 @@ public:
 	void copy_settings_from(Joint3DSW *p_joint) {
 		set_self(p_joint->get_self());
 		set_priority(p_joint->get_priority());
-		disable_collisions_between_bodies(p_joint->is_disabled_collisions_between_bodies());
+		enable_collisions_between_bodies(p_joint->is_collisions_between_bodies_enabled());
 	}
 
 	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_TYPE_MAX; }

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -263,14 +263,14 @@ PhysicsServer3D::AreaSpaceOverrideMode PhysicsServer3DSW::area_get_space_overrid
 	return area->get_space_override_mode();
 }
 
-void PhysicsServer3DSW::area_add_shape(RID p_area, RID p_shape, const Transform &p_transform, bool p_disabled) {
+void PhysicsServer3DSW::area_add_shape(RID p_area, RID p_shape, const Transform &p_transform, bool p_enabled) {
 	Area3DSW *area = area_owner.getornull(p_area);
 	ERR_FAIL_COND(!area);
 
 	Shape3DSW *shape = shape_owner.getornull(p_shape);
 	ERR_FAIL_COND(!shape);
 
-	area->add_shape(shape, p_transform, p_disabled);
+	area->add_shape(shape, p_transform, p_enabled);
 }
 
 void PhysicsServer3DSW::area_set_shape(RID p_area, int p_shape_idx, RID p_shape) {
@@ -331,12 +331,12 @@ void PhysicsServer3DSW::area_clear_shapes(RID p_area) {
 	}
 }
 
-void PhysicsServer3DSW::area_set_shape_disabled(RID p_area, int p_shape_idx, bool p_disabled) {
+void PhysicsServer3DSW::area_enable_shape(RID p_area, int p_shape_idx, bool p_enable) {
 	Area3DSW *area = area_owner.getornull(p_area);
 	ERR_FAIL_COND(!area);
 	ERR_FAIL_INDEX(p_shape_idx, area->get_shape_count());
 	FLUSH_QUERY_CHECK(area);
-	area->set_shape_as_disabled(p_shape_idx, p_disabled);
+	area->enable_shape(p_shape_idx, p_enable);
 }
 
 void PhysicsServer3DSW::area_attach_object_instance_id(RID p_area, ObjectID p_id) {
@@ -422,11 +422,11 @@ void PhysicsServer3DSW::area_set_monitor_callback(RID p_area, Object *p_receiver
 	area->set_monitor_callback(p_receiver ? p_receiver->get_instance_id() : ObjectID(), p_method);
 }
 
-void PhysicsServer3DSW::area_set_ray_pickable(RID p_area, bool p_enable) {
+void PhysicsServer3DSW::area_set_pickable(RID p_area, bool p_pickable) {
 	Area3DSW *area = area_owner.getornull(p_area);
 	ERR_FAIL_COND(!area);
 
-	area->set_ray_pickable(p_enable);
+	area->set_pickable(p_pickable);
 }
 
 void PhysicsServer3DSW::area_set_area_monitor_callback(RID p_area, Object *p_receiver, const StringName &p_method) {
@@ -488,14 +488,14 @@ PhysicsServer3D::BodyMode PhysicsServer3DSW::body_get_mode(RID p_body) const {
 	return body->get_mode();
 };
 
-void PhysicsServer3DSW::body_add_shape(RID p_body, RID p_shape, const Transform &p_transform, bool p_disabled) {
+void PhysicsServer3DSW::body_add_shape(RID p_body, RID p_shape, const Transform &p_transform, bool p_enabled) {
 	Body3DSW *body = body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
 
 	Shape3DSW *shape = shape_owner.getornull(p_shape);
 	ERR_FAIL_COND(!shape);
 
-	body->add_shape(shape, p_transform, p_disabled);
+	body->add_shape(shape, p_transform, p_enabled);
 }
 
 void PhysicsServer3DSW::body_set_shape(RID p_body, int p_shape_idx, RID p_shape) {
@@ -533,13 +533,13 @@ RID PhysicsServer3DSW::body_get_shape(RID p_body, int p_shape_idx) const {
 	return shape->get_self();
 }
 
-void PhysicsServer3DSW::body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) {
+void PhysicsServer3DSW::body_enable_shape(RID p_body, int p_shape_idx, bool p_enable) {
 	Body3DSW *body = body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
 	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
 	FLUSH_QUERY_CHECK(body);
 
-	body->set_shape_as_disabled(p_shape_idx, p_disabled);
+	body->enable_shape(p_shape_idx, p_enable);
 }
 
 Transform PhysicsServer3DSW::body_get_shape_transform(RID p_body, int p_shape_idx) const {
@@ -565,11 +565,11 @@ void PhysicsServer3DSW::body_clear_shapes(RID p_body) {
 	}
 }
 
-void PhysicsServer3DSW::body_set_enable_continuous_collision_detection(RID p_body, bool p_enable) {
+void PhysicsServer3DSW::body_enable_continuous_collision_detection(RID p_body, bool p_enable) {
 	Body3DSW *body = body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->set_continuous_collision_detection(p_enable);
+	body->enable_continuous_collision_detection(p_enable);
 }
 
 bool PhysicsServer3DSW::body_is_continuous_collision_detection_enabled(RID p_body) const {
@@ -863,10 +863,10 @@ void PhysicsServer3DSW::body_set_force_integration_callback(RID p_body, const Ca
 	body->set_force_integration_callback(p_callable, p_udata);
 }
 
-void PhysicsServer3DSW::body_set_ray_pickable(RID p_body, bool p_enable) {
+void PhysicsServer3DSW::body_set_pickable(RID p_body, bool p_pickable) {
 	Body3DSW *body = body_owner.getornull(p_body);
 	ERR_FAIL_COND(!body);
-	body->set_ray_pickable(p_enable);
+	body->set_pickable(p_pickable);
 }
 
 bool PhysicsServer3DSW::body_test_motion(RID p_body, const Transform &p_from, const Vector3 &p_motion, bool p_infinite_inertia, MotionResult *r_result, bool p_exclude_raycast_shapes) {
@@ -1018,11 +1018,11 @@ void PhysicsServer3DSW::soft_body_set_transform(RID p_body, const Transform &p_t
 	soft_body->set_state(BODY_STATE_TRANSFORM, p_transform);
 }
 
-void PhysicsServer3DSW::soft_body_set_ray_pickable(RID p_body, bool p_enable) {
+void PhysicsServer3DSW::soft_body_set_pickable(RID p_body, bool p_enable) {
 	SoftBody3DSW *soft_body = soft_body_owner.getornull(p_body);
 	ERR_FAIL_COND(!soft_body);
 
-	soft_body->set_ray_pickable(p_enable);
+	soft_body->set_pickable(p_enable);
 }
 
 void PhysicsServer3DSW::soft_body_set_simulation_precision(RID p_body, int p_simulation_precision) {
@@ -1346,31 +1346,31 @@ int PhysicsServer3DSW::joint_get_solver_priority(RID p_joint) const {
 	return joint->get_priority();
 }
 
-void PhysicsServer3DSW::joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) {
+void PhysicsServer3DSW::joint_enable_collisions_between_bodies(RID p_joint, const bool p_enable) {
 	Joint3DSW *joint = joint_owner.getornull(p_joint);
 	ERR_FAIL_COND(!joint);
 
-	joint->disable_collisions_between_bodies(p_disable);
+	joint->enable_collisions_between_bodies(p_enable);
 
 	if (2 == joint->get_body_count()) {
 		Body3DSW *body_a = *joint->get_body_ptr();
 		Body3DSW *body_b = *(joint->get_body_ptr() + 1);
 
-		if (p_disable) {
-			body_add_collision_exception(body_a->get_self(), body_b->get_self());
-			body_add_collision_exception(body_b->get_self(), body_a->get_self());
-		} else {
+		if (p_enable) {
 			body_remove_collision_exception(body_a->get_self(), body_b->get_self());
 			body_remove_collision_exception(body_b->get_self(), body_a->get_self());
+		} else {
+			body_add_collision_exception(body_a->get_self(), body_b->get_self());
+			body_add_collision_exception(body_b->get_self(), body_a->get_self());
 		}
 	}
 }
 
-bool PhysicsServer3DSW::joint_is_disabled_collisions_between_bodies(RID p_joint) const {
+bool PhysicsServer3DSW::joint_is_collisions_between_bodies_enabled(RID p_joint) const {
 	Joint3DSW *joint = joint_owner.getornull(p_joint);
 	ERR_FAIL_COND_V(!joint, true);
 
-	return joint->is_disabled_collisions_between_bodies();
+	return joint->is_collisions_between_bodies_enabled();
 }
 
 PhysicsServer3DSW::JointType PhysicsServer3DSW::joint_get_type(RID p_joint) const {

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -130,7 +130,7 @@ public:
 	virtual void area_set_space(RID p_area, RID p_space) override;
 	virtual RID area_get_space(RID p_area) const override;
 
-	virtual void area_add_shape(RID p_area, RID p_shape, const Transform &p_transform = Transform(), bool p_disabled = false) override;
+	virtual void area_add_shape(RID p_area, RID p_shape, const Transform &p_transform = Transform(), bool p_enabled = true) override;
 	virtual void area_set_shape(RID p_area, int p_shape_idx, RID p_shape) override;
 	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform &p_transform) override;
 
@@ -141,7 +141,7 @@ public:
 	virtual void area_remove_shape(RID p_area, int p_shape_idx) override;
 	virtual void area_clear_shapes(RID p_area) override;
 
-	virtual void area_set_shape_disabled(RID p_area, int p_shape_idx, bool p_disabled) override;
+	virtual void area_enable_shape(RID p_area, int p_shape_idx, bool p_enable = true) override;
 
 	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id) override;
 	virtual ObjectID area_get_object_instance_id(RID p_area) const override;
@@ -152,7 +152,7 @@ public:
 	virtual Variant area_get_param(RID p_area, AreaParameter p_param) const override;
 	virtual Transform area_get_transform(RID p_area) const override;
 
-	virtual void area_set_ray_pickable(RID p_area, bool p_enable) override;
+	virtual void area_set_pickable(RID p_area, bool p_pickable) override;
 
 	virtual void area_set_collision_mask(RID p_area, uint32_t p_mask) override;
 	virtual void area_set_collision_layer(RID p_area, uint32_t p_layer) override;
@@ -173,7 +173,7 @@ public:
 	virtual void body_set_mode(RID p_body, BodyMode p_mode) override;
 	virtual BodyMode body_get_mode(RID p_body) const override;
 
-	virtual void body_add_shape(RID p_body, RID p_shape, const Transform &p_transform = Transform(), bool p_disabled = false) override;
+	virtual void body_add_shape(RID p_body, RID p_shape, const Transform &p_transform = Transform(), bool p_enabled = true) override;
 	virtual void body_set_shape(RID p_body, int p_shape_idx, RID p_shape) override;
 	virtual void body_set_shape_transform(RID p_body, int p_shape_idx, const Transform &p_transform) override;
 
@@ -181,7 +181,7 @@ public:
 	virtual RID body_get_shape(RID p_body, int p_shape_idx) const override;
 	virtual Transform body_get_shape_transform(RID p_body, int p_shape_idx) const override;
 
-	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override;
+	virtual void body_enable_shape(RID p_body, int p_shape_idx, bool p_enable = true) override;
 
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) override;
 	virtual void body_clear_shapes(RID p_body) override;
@@ -189,7 +189,7 @@ public:
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) override;
 	virtual ObjectID body_get_object_instance_id(RID p_body) const override;
 
-	virtual void body_set_enable_continuous_collision_detection(RID p_body, bool p_enable) override;
+	virtual void body_enable_continuous_collision_detection(RID p_body, bool p_enable = true) override;
 	virtual bool body_is_continuous_collision_detection_enabled(RID p_body) const override;
 
 	virtual void body_set_collision_layer(RID p_body, uint32_t p_layer) override;
@@ -243,7 +243,7 @@ public:
 
 	virtual void body_set_force_integration_callback(RID p_body, const Callable &p_callable, const Variant &p_udata = Variant()) override;
 
-	virtual void body_set_ray_pickable(RID p_body, bool p_enable) override;
+	virtual void body_set_pickable(RID p_body, bool p_pickable) override;
 
 	virtual bool body_test_motion(RID p_body, const Transform &p_from, const Vector3 &p_motion, bool p_infinite_inertia, MotionResult *r_result = nullptr, bool p_exclude_raycast_shapes = true) override;
 	virtual int body_test_ray_separation(RID p_body, const Transform &p_transform, bool p_infinite_inertia, Vector3 &r_recover_motion, SeparationResult *r_results, int p_result_max, real_t p_margin = 0.001) override;
@@ -275,7 +275,7 @@ public:
 
 	virtual void soft_body_set_transform(RID p_body, const Transform &p_transform) override;
 
-	virtual void soft_body_set_ray_pickable(RID p_body, bool p_enable) override;
+	virtual void soft_body_set_pickable(RID p_body, bool p_pickable) override;
 
 	virtual void soft_body_set_simulation_precision(RID p_body, int p_simulation_precision) override;
 	virtual int soft_body_get_simulation_precision(RID p_body) const override;
@@ -355,8 +355,8 @@ public:
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) override;
 	virtual int joint_get_solver_priority(RID p_joint) const override;
 
-	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) override;
-	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const override;
+	virtual void joint_enable_collisions_between_bodies(RID p_joint, const bool p_enable = true) override;
+	virtual bool joint_is_collisions_between_bodies_enabled(RID p_joint) const override;
 
 	/* MISC */
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -145,7 +145,7 @@ public:
 	FUNC4(area_add_shape, RID, RID, const Transform &, bool);
 	FUNC3(area_set_shape, RID, int, RID);
 	FUNC3(area_set_shape_transform, RID, int, const Transform &);
-	FUNC3(area_set_shape_disabled, RID, int, bool);
+	FUNC3(area_enable_shape, RID, int, bool);
 
 	FUNC1RC(int, area_get_shape_count, RID);
 	FUNC2RC(RID, area_get_shape, RID, int);
@@ -166,7 +166,7 @@ public:
 	FUNC2(area_set_collision_layer, RID, uint32_t);
 
 	FUNC2(area_set_monitorable, RID, bool);
-	FUNC2(area_set_ray_pickable, RID, bool);
+	FUNC2(area_set_pickable, RID, bool);
 
 	FUNC3(area_set_monitor_callback, RID, Object *, const StringName &);
 	FUNC3(area_set_area_monitor_callback, RID, Object *, const StringName &);
@@ -190,7 +190,7 @@ public:
 	FUNC2RC(Transform, body_get_shape_transform, RID, int);
 	FUNC2RC(RID, body_get_shape, RID, int);
 
-	FUNC3(body_set_shape_disabled, RID, int, bool);
+	FUNC3(body_enable_shape, RID, int, bool);
 
 	FUNC2(body_remove_shape, RID, int);
 	FUNC1(body_clear_shapes, RID);
@@ -198,7 +198,7 @@ public:
 	FUNC2(body_attach_object_instance_id, RID, ObjectID);
 	FUNC1RC(ObjectID, body_get_object_instance_id, RID);
 
-	FUNC2(body_set_enable_continuous_collision_detection, RID, bool);
+	FUNC2(body_enable_continuous_collision_detection, RID, bool);
 	FUNC1RC(bool, body_is_continuous_collision_detection_enabled, RID);
 
 	FUNC2(body_set_collision_layer, RID, uint32_t);
@@ -251,7 +251,7 @@ public:
 
 	FUNC3(body_set_force_integration_callback, RID, const Callable &, const Variant &);
 
-	FUNC2(body_set_ray_pickable, RID, bool);
+	FUNC2(body_set_pickable, RID, bool);
 
 	bool body_test_motion(RID p_body, const Transform &p_from, const Vector3 &p_motion, bool p_infinite_inertia, MotionResult *r_result = nullptr, bool p_exclude_raycast_shapes = true) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
@@ -278,7 +278,7 @@ public:
 	FUNC2(soft_body_set_space, RID, RID)
 	FUNC1RC(RID, soft_body_get_space, RID)
 
-	FUNC2(soft_body_set_ray_pickable, RID, bool);
+	FUNC2(soft_body_set_pickable, RID, bool);
 
 	FUNC2(soft_body_set_collision_layer, RID, uint32_t)
 	FUNC1RC(uint32_t, soft_body_get_collision_layer, RID)
@@ -373,8 +373,8 @@ public:
 	FUNC2(joint_set_solver_priority, RID, int);
 	FUNC1RC(int, joint_get_solver_priority, RID);
 
-	FUNC2(joint_disable_collisions_between_bodies, RID, const bool);
-	FUNC1RC(bool, joint_is_disabled_collisions_between_bodies, RID);
+	FUNC2(joint_enable_collisions_between_bodies, RID, const bool);
+	FUNC1RC(bool, joint_is_collisions_between_bodies_enabled, RID);
 
 	/* MISC */
 

--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -125,7 +125,7 @@ bool PhysicsDirectSpaceState3DSW::intersect_ray(const Vector3 &p_from, const Vec
 			continue;
 		}
 
-		if (p_pick_ray && !(space->intersection_query_results[i]->is_ray_pickable())) {
+		if (p_pick_ray && !(space->intersection_query_results[i]->is_pickable())) {
 			continue;
 		}
 
@@ -214,7 +214,7 @@ int PhysicsDirectSpaceState3DSW::intersect_shape(const RID &p_shape, const Trans
 		const CollisionObject3DSW *col_obj = space->intersection_query_results[i];
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (col_obj->is_shape_set_as_disabled(shape_idx)) {
+		if (!col_obj->is_shape_enabled(shape_idx)) {
 			continue;
 		}
 
@@ -273,7 +273,7 @@ bool PhysicsDirectSpaceState3DSW::cast_motion(const RID &p_shape, const Transfor
 		const CollisionObject3DSW *col_obj = space->intersection_query_results[i];
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (col_obj->is_shape_set_as_disabled(shape_idx)) {
+		if (!col_obj->is_shape_enabled(shape_idx)) {
 			continue;
 		}
 
@@ -385,7 +385,7 @@ bool PhysicsDirectSpaceState3DSW::collide_shape(RID p_shape, const Transform &p_
 
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (col_obj->is_shape_set_as_disabled(shape_idx)) {
+		if (!col_obj->is_shape_enabled(shape_idx)) {
 			continue;
 		}
 
@@ -460,7 +460,7 @@ bool PhysicsDirectSpaceState3DSW::rest_info(RID p_shape, const Transform &p_shap
 
 		int shape_idx = space->intersection_query_subindex_results[i];
 
-		if (col_obj->is_shape_set_as_disabled(shape_idx)) {
+		if (!col_obj->is_shape_enabled(shape_idx)) {
 			continue;
 		}
 
@@ -508,7 +508,7 @@ Vector3 PhysicsDirectSpaceState3DSW::get_closest_point_to_object_volume(RID p_ob
 	bool shapes_found = false;
 
 	for (int i = 0; i < obj->get_shape_count(); i++) {
-		if (obj->is_shape_set_as_disabled(i)) {
+		if (!obj->is_shape_enabled(i)) {
 			continue;
 		}
 
@@ -555,7 +555,7 @@ int Space3DSW::_cull_aabb_for_body(Body3DSW *p_body, const AABB &p_aabb) {
 			keep = false;
 		} else if (static_cast<Body3DSW *>(intersection_query_results[i])->has_exception(p_body->get_self()) || p_body->has_exception(intersection_query_results[i]->get_self())) {
 			keep = false;
-		} else if (static_cast<Body3DSW *>(intersection_query_results[i])->is_shape_set_as_disabled(intersection_query_subindex_results[i])) {
+		} else if (!static_cast<Body3DSW *>(intersection_query_results[i])->is_shape_enabled(intersection_query_subindex_results[i])) {
 			keep = false;
 		}
 
@@ -579,7 +579,7 @@ int Space3DSW::test_body_ray_separation(Body3DSW *p_body, const Transform &p_tra
 	bool shapes_found = false;
 
 	for (int i = 0; i < p_body->get_shape_count(); i++) {
-		if (p_body->is_shape_set_as_disabled(i)) {
+		if (!p_body->is_shape_enabled(i)) {
 			continue;
 		}
 
@@ -626,7 +626,7 @@ int Space3DSW::test_body_ray_separation(Body3DSW *p_body, const Transform &p_tra
 			int amount = _cull_aabb_for_body(p_body, body_aabb);
 
 			for (int j = 0; j < p_body->get_shape_count(); j++) {
-				if (p_body->is_shape_set_as_disabled(j)) {
+				if (!p_body->is_shape_enabled(j)) {
 					continue;
 				}
 
@@ -740,7 +740,7 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform &p_from, cons
 	bool shapes_found = false;
 
 	for (int i = 0; i < p_body->get_shape_count(); i++) {
-		if (p_body->is_shape_set_as_disabled(i)) {
+		if (!p_body->is_shape_enabled(i)) {
 			continue;
 		}
 
@@ -793,7 +793,7 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform &p_from, cons
 			int amount = _cull_aabb_for_body(p_body, body_aabb);
 
 			for (int j = 0; j < p_body->get_shape_count(); j++) {
-				if (p_body->is_shape_set_as_disabled(j)) {
+				if (!p_body->is_shape_enabled(j)) {
 					continue;
 				}
 
@@ -864,7 +864,7 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform &p_from, cons
 		int amount = _cull_aabb_for_body(p_body, motion_aabb);
 
 		for (int j = 0; j < p_body->get_shape_count(); j++) {
-			if (p_body->is_shape_set_as_disabled(j)) {
+			if (!p_body->is_shape_enabled(j)) {
 				continue;
 			}
 
@@ -975,7 +975,7 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform &p_from, cons
 		int to_shape = best_shape != -1 ? best_shape + 1 : p_body->get_shape_count();
 
 		for (int j = from_shape; j < to_shape; j++) {
-			if (p_body->is_shape_set_as_disabled(j)) {
+			if (!p_body->is_shape_enabled(j)) {
 				continue;
 			}
 

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -96,7 +96,7 @@ void PhysicsDirectBodyState2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_torque_impulse", "impulse"), &PhysicsDirectBodyState2D::apply_torque_impulse);
 	ClassDB::bind_method(D_METHOD("apply_impulse", "impulse", "position"), &PhysicsDirectBodyState2D::apply_impulse, Vector2());
 
-	ClassDB::bind_method(D_METHOD("set_sleep_state", "enabled"), &PhysicsDirectBodyState2D::set_sleep_state);
+	ClassDB::bind_method(D_METHOD("set_sleep_state", "sleeping"), &PhysicsDirectBodyState2D::set_sleep_state);
 	ClassDB::bind_method(D_METHOD("is_sleeping"), &PhysicsDirectBodyState2D::is_sleeping);
 
 	ClassDB::bind_method(D_METHOD("get_contact_count"), &PhysicsDirectBodyState2D::get_contact_count);
@@ -201,7 +201,7 @@ Vector<RID> PhysicsShapeQueryParameters2D::get_exclude() const {
 	return ret;
 }
 
-void PhysicsShapeQueryParameters2D::set_collide_with_bodies(bool p_enable) {
+void PhysicsShapeQueryParameters2D::enable_collide_with_bodies(bool p_enable) {
 	collide_with_bodies = p_enable;
 }
 
@@ -209,7 +209,7 @@ bool PhysicsShapeQueryParameters2D::is_collide_with_bodies_enabled() const {
 	return collide_with_bodies;
 }
 
-void PhysicsShapeQueryParameters2D::set_collide_with_areas(bool p_enable) {
+void PhysicsShapeQueryParameters2D::enable_collide_with_areas(bool p_enable) {
 	collide_with_areas = p_enable;
 }
 
@@ -238,10 +238,10 @@ void PhysicsShapeQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude", "exclude"), &PhysicsShapeQueryParameters2D::set_exclude);
 	ClassDB::bind_method(D_METHOD("get_exclude"), &PhysicsShapeQueryParameters2D::get_exclude);
 
-	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &PhysicsShapeQueryParameters2D::set_collide_with_bodies);
+	ClassDB::bind_method(D_METHOD("enable_collide_with_bodies", "enable"), &PhysicsShapeQueryParameters2D::enable_collide_with_bodies, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &PhysicsShapeQueryParameters2D::is_collide_with_bodies_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_collide_with_areas", "enable"), &PhysicsShapeQueryParameters2D::set_collide_with_areas);
+	ClassDB::bind_method(D_METHOD("enable_collide_with_areas", "enable"), &PhysicsShapeQueryParameters2D::enable_collide_with_areas, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_collide_with_areas_enabled"), &PhysicsShapeQueryParameters2D::is_collide_with_areas_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_layer", "get_collision_layer");
@@ -251,8 +251,8 @@ void PhysicsShapeQueryParameters2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "shape_rid"), "set_shape_rid", "get_shape_rid");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform"), "set_transform", "get_transform");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "set_collide_with_areas", "is_collide_with_areas_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "enable_collide_with_bodies", "is_collide_with_bodies_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "enable_collide_with_areas", "is_collide_with_areas_enabled");
 }
 
 PhysicsShapeQueryParameters2D::PhysicsShapeQueryParameters2D() {
@@ -554,10 +554,10 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("area_set_space_override_mode", "area", "mode"), &PhysicsServer2D::area_set_space_override_mode);
 	ClassDB::bind_method(D_METHOD("area_get_space_override_mode", "area"), &PhysicsServer2D::area_get_space_override_mode);
 
-	ClassDB::bind_method(D_METHOD("area_add_shape", "area", "shape", "transform", "disabled"), &PhysicsServer2D::area_add_shape, DEFVAL(Transform2D()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("area_add_shape", "area", "shape", "transform", "enabled"), &PhysicsServer2D::area_add_shape, DEFVAL(Transform2D()), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("area_set_shape", "area", "shape_idx", "shape"), &PhysicsServer2D::area_set_shape);
 	ClassDB::bind_method(D_METHOD("area_set_shape_transform", "area", "shape_idx", "transform"), &PhysicsServer2D::area_set_shape_transform);
-	ClassDB::bind_method(D_METHOD("area_set_shape_disabled", "area", "shape_idx", "disabled"), &PhysicsServer2D::area_set_shape_disabled);
+	ClassDB::bind_method(D_METHOD("area_enable_shape", "area", "shape_idx", "enable"), &PhysicsServer2D::area_enable_shape, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("area_get_shape_count", "area"), &PhysicsServer2D::area_get_shape_count);
 	ClassDB::bind_method(D_METHOD("area_get_shape", "area", "shape_idx"), &PhysicsServer2D::area_get_shape);
@@ -593,7 +593,7 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_mode", "body", "mode"), &PhysicsServer2D::body_set_mode);
 	ClassDB::bind_method(D_METHOD("body_get_mode", "body"), &PhysicsServer2D::body_get_mode);
 
-	ClassDB::bind_method(D_METHOD("body_add_shape", "body", "shape", "transform", "disabled"), &PhysicsServer2D::body_add_shape, DEFVAL(Transform2D()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("body_add_shape", "body", "shape", "transform", "enabled"), &PhysicsServer2D::body_add_shape, DEFVAL(Transform2D()), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("body_set_shape", "body", "shape_idx", "shape"), &PhysicsServer2D::body_set_shape);
 	ClassDB::bind_method(D_METHOD("body_set_shape_transform", "body", "shape_idx", "transform"), &PhysicsServer2D::body_set_shape_transform);
 	ClassDB::bind_method(D_METHOD("body_set_shape_metadata", "body", "shape_idx", "metadata"), &PhysicsServer2D::body_set_shape_metadata);
@@ -606,8 +606,8 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_remove_shape", "body", "shape_idx"), &PhysicsServer2D::body_remove_shape);
 	ClassDB::bind_method(D_METHOD("body_clear_shapes", "body"), &PhysicsServer2D::body_clear_shapes);
 
-	ClassDB::bind_method(D_METHOD("body_set_shape_disabled", "body", "shape_idx", "disabled"), &PhysicsServer2D::body_set_shape_disabled);
-	ClassDB::bind_method(D_METHOD("body_set_shape_as_one_way_collision", "body", "shape_idx", "enable", "margin"), &PhysicsServer2D::body_set_shape_as_one_way_collision);
+	ClassDB::bind_method(D_METHOD("body_enable_shape", "body", "shape_idx", "enabled"), &PhysicsServer2D::body_enable_shape, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("body_enable_shape_one_way_collision", "body", "shape_idx", "enabled", "margin"), &PhysicsServer2D::body_enable_shape_one_way_collision, DEFVAL(true), DEFVAL(1));
 
 	ClassDB::bind_method(D_METHOD("body_attach_object_instance_id", "body", "id"), &PhysicsServer2D::body_attach_object_instance_id);
 	ClassDB::bind_method(D_METHOD("body_get_object_instance_id", "body"), &PhysicsServer2D::body_get_object_instance_id);
@@ -644,7 +644,7 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_max_contacts_reported", "body", "amount"), &PhysicsServer2D::body_set_max_contacts_reported);
 	ClassDB::bind_method(D_METHOD("body_get_max_contacts_reported", "body"), &PhysicsServer2D::body_get_max_contacts_reported);
 
-	ClassDB::bind_method(D_METHOD("body_set_omit_force_integration", "body", "enable"), &PhysicsServer2D::body_set_omit_force_integration);
+	ClassDB::bind_method(D_METHOD("body_set_omit_force_integration", "body", "omit"), &PhysicsServer2D::body_set_omit_force_integration);
 	ClassDB::bind_method(D_METHOD("body_is_omitting_force_integration", "body"), &PhysicsServer2D::body_is_omitting_force_integration);
 
 	ClassDB::bind_method(D_METHOD("body_set_force_integration_callback", "body", "callable", "userdata"), &PhysicsServer2D::body_set_force_integration_callback, DEFVAL(Variant()));

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -67,7 +67,7 @@ public:
 	virtual void apply_torque_impulse(real_t p_torque) = 0;
 	virtual void apply_impulse(const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) = 0;
 
-	virtual void set_sleep_state(bool p_enable) = 0;
+	virtual void set_sleep_state(bool p_enabled) = 0;
 	virtual bool is_sleeping() const = 0;
 
 	virtual int get_contact_count() const = 0;
@@ -131,10 +131,10 @@ public:
 	void set_collision_mask(uint32_t p_mask);
 	uint32_t get_collision_mask() const;
 
-	void set_collide_with_bodies(bool p_enable);
+	void enable_collide_with_bodies(bool p_enable = true);
 	bool is_collide_with_bodies_enabled() const;
 
-	void set_collide_with_areas(bool p_enable);
+	void enable_collide_with_areas(bool p_enable = true);
 	bool is_collide_with_areas_enabled() const;
 
 	void set_exclude(const Vector<RID> &p_exclude);
@@ -329,7 +329,7 @@ public:
 	virtual void area_set_space_override_mode(RID p_area, AreaSpaceOverrideMode p_mode) = 0;
 	virtual AreaSpaceOverrideMode area_get_space_override_mode(RID p_area) const = 0;
 
-	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) = 0;
+	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_enabled = true) = 0;
 	virtual void area_set_shape(RID p_area, int p_shape_idx, RID p_shape) = 0;
 	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform) = 0;
 
@@ -340,7 +340,7 @@ public:
 	virtual void area_remove_shape(RID p_area, int p_shape_idx) = 0;
 	virtual void area_clear_shapes(RID p_area) = 0;
 
-	virtual void area_set_shape_disabled(RID p_area, int p_shape, bool p_disabled) = 0;
+	virtual void area_enable_shape(RID p_area, int p_shape, bool p_enable = true) = 0;
 
 	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id) = 0;
 	virtual ObjectID area_get_object_instance_id(RID p_area) const = 0;
@@ -382,7 +382,7 @@ public:
 	virtual void body_set_mode(RID p_body, BodyMode p_mode) = 0;
 	virtual BodyMode body_get_mode(RID p_body) const = 0;
 
-	virtual void body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) = 0;
+	virtual void body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_enabled = true) = 0;
 	virtual void body_set_shape(RID p_body, int p_shape_idx, RID p_shape) = 0;
 	virtual void body_set_shape_transform(RID p_body, int p_shape_idx, const Transform2D &p_transform) = 0;
 	virtual void body_set_shape_metadata(RID p_body, int p_shape_idx, const Variant &p_metadata) = 0;
@@ -392,8 +392,8 @@ public:
 	virtual Transform2D body_get_shape_transform(RID p_body, int p_shape_idx) const = 0;
 	virtual Variant body_get_shape_metadata(RID p_body, int p_shape_idx) const = 0;
 
-	virtual void body_set_shape_disabled(RID p_body, int p_shape, bool p_disabled) = 0;
-	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) = 0;
+	virtual void body_enable_shape(RID p_body, int p_shape, bool p_enable = true) = 0;
+	virtual void body_enable_shape_one_way_collision(RID p_body, int p_shape, bool p_enable = true, real_t p_margin = 1) = 0;
 
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) = 0;
 	virtual void body_clear_shapes(RID p_body) = 0;
@@ -544,8 +544,8 @@ public:
 	virtual void joint_set_param(RID p_joint, JointParam p_param, real_t p_value) = 0;
 	virtual real_t joint_get_param(RID p_joint, JointParam p_param) const = 0;
 
-	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) = 0;
-	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const = 0;
+	virtual void joint_enable_collisions_between_bodies(RID p_joint, const bool p_enable = true) = 0;
+	virtual bool joint_is_collisions_between_bodies_enabled(RID p_joint) const = 0;
 
 	virtual void joint_make_pin(RID p_joint, const Vector2 &p_anchor, RID p_body_a, RID p_body_b = RID()) = 0;
 	virtual void joint_make_groove(RID p_joint, const Vector2 &p_a_groove1, const Vector2 &p_a_groove2, const Vector2 &p_b_anchor, RID p_body_a, RID p_body_b) = 0;

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -98,7 +98,7 @@ void PhysicsDirectBodyState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_impulse", "impulse", "position"), &PhysicsDirectBodyState3D::apply_impulse, Vector3());
 	ClassDB::bind_method(D_METHOD("apply_torque_impulse", "impulse"), &PhysicsDirectBodyState3D::apply_torque_impulse);
 
-	ClassDB::bind_method(D_METHOD("set_sleep_state", "enabled"), &PhysicsDirectBodyState3D::set_sleep_state);
+	ClassDB::bind_method(D_METHOD("set_sleep_state", "sleeping"), &PhysicsDirectBodyState3D::set_sleep_state);
 	ClassDB::bind_method(D_METHOD("is_sleeping"), &PhysicsDirectBodyState3D::is_sleeping);
 
 	ClassDB::bind_method(D_METHOD("get_contact_count"), &PhysicsDirectBodyState3D::get_contact_count);
@@ -197,7 +197,7 @@ Vector<RID> PhysicsShapeQueryParameters3D::get_exclude() const {
 	return ret;
 }
 
-void PhysicsShapeQueryParameters3D::set_collide_with_bodies(bool p_enable) {
+void PhysicsShapeQueryParameters3D::enable_collide_with_bodies(bool p_enable) {
 	collide_with_bodies = p_enable;
 }
 
@@ -205,7 +205,7 @@ bool PhysicsShapeQueryParameters3D::is_collide_with_bodies_enabled() const {
 	return collide_with_bodies;
 }
 
-void PhysicsShapeQueryParameters3D::set_collide_with_areas(bool p_enable) {
+void PhysicsShapeQueryParameters3D::enable_collide_with_areas(bool p_enable) {
 	collide_with_areas = p_enable;
 }
 
@@ -231,10 +231,10 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude", "exclude"), &PhysicsShapeQueryParameters3D::set_exclude);
 	ClassDB::bind_method(D_METHOD("get_exclude"), &PhysicsShapeQueryParameters3D::get_exclude);
 
-	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &PhysicsShapeQueryParameters3D::set_collide_with_bodies);
+	ClassDB::bind_method(D_METHOD("enable_collide_with_bodies", "enable"), &PhysicsShapeQueryParameters3D::enable_collide_with_bodies, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &PhysicsShapeQueryParameters3D::is_collide_with_bodies_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_collide_with_areas", "enable"), &PhysicsShapeQueryParameters3D::set_collide_with_areas);
+	ClassDB::bind_method(D_METHOD("enable_collide_with_areas", "enable"), &PhysicsShapeQueryParameters3D::enable_collide_with_areas, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_collide_with_areas_enabled"), &PhysicsShapeQueryParameters3D::is_collide_with_areas_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
@@ -243,8 +243,8 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape3D"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "shape_rid"), "set_shape_rid", "get_shape_rid");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM, "transform"), "set_transform", "get_transform");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "set_collide_with_areas", "is_collide_with_areas_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "enable_collide_with_bodies", "is_collide_with_bodies_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "enable_collide_with_areas", "is_collide_with_areas_enabled");
 }
 
 PhysicsShapeQueryParameters3D::PhysicsShapeQueryParameters3D() {
@@ -458,10 +458,10 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("area_set_space_override_mode", "area", "mode"), &PhysicsServer3D::area_set_space_override_mode);
 	ClassDB::bind_method(D_METHOD("area_get_space_override_mode", "area"), &PhysicsServer3D::area_get_space_override_mode);
 
-	ClassDB::bind_method(D_METHOD("area_add_shape", "area", "shape", "transform", "disabled"), &PhysicsServer3D::area_add_shape, DEFVAL(Transform()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("area_add_shape", "area", "shape", "transform", "enabled"), &PhysicsServer3D::area_add_shape, DEFVAL(Transform()), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("area_set_shape", "area", "shape_idx", "shape"), &PhysicsServer3D::area_set_shape);
 	ClassDB::bind_method(D_METHOD("area_set_shape_transform", "area", "shape_idx", "transform"), &PhysicsServer3D::area_set_shape_transform);
-	ClassDB::bind_method(D_METHOD("area_set_shape_disabled", "area", "shape_idx", "disabled"), &PhysicsServer3D::area_set_shape_disabled);
+	ClassDB::bind_method(D_METHOD("area_enable_shape", "area", "shape_idx", "enable"), &PhysicsServer3D::area_enable_shape, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("area_get_shape_count", "area"), &PhysicsServer3D::area_get_shape_count);
 	ClassDB::bind_method(D_METHOD("area_get_shape", "area", "shape_idx"), &PhysicsServer3D::area_get_shape);
@@ -486,7 +486,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("area_set_area_monitor_callback", "area", "receiver", "method"), &PhysicsServer3D::area_set_area_monitor_callback);
 	ClassDB::bind_method(D_METHOD("area_set_monitorable", "area", "monitorable"), &PhysicsServer3D::area_set_monitorable);
 
-	ClassDB::bind_method(D_METHOD("area_set_ray_pickable", "area", "enable"), &PhysicsServer3D::area_set_ray_pickable);
+	ClassDB::bind_method(D_METHOD("area_set_pickable", "area", "pickable"), &PhysicsServer3D::area_set_pickable);
 
 	ClassDB::bind_method(D_METHOD("body_create"), &PhysicsServer3D::body_create);
 
@@ -502,10 +502,10 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_collision_mask", "body", "mask"), &PhysicsServer3D::body_set_collision_mask);
 	ClassDB::bind_method(D_METHOD("body_get_collision_mask", "body"), &PhysicsServer3D::body_get_collision_mask);
 
-	ClassDB::bind_method(D_METHOD("body_add_shape", "body", "shape", "transform", "disabled"), &PhysicsServer3D::body_add_shape, DEFVAL(Transform()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("body_add_shape", "body", "shape", "transform", "enabled"), &PhysicsServer3D::body_add_shape, DEFVAL(Transform()), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("body_set_shape", "body", "shape_idx", "shape"), &PhysicsServer3D::body_set_shape);
 	ClassDB::bind_method(D_METHOD("body_set_shape_transform", "body", "shape_idx", "transform"), &PhysicsServer3D::body_set_shape_transform);
-	ClassDB::bind_method(D_METHOD("body_set_shape_disabled", "body", "shape_idx", "disabled"), &PhysicsServer3D::body_set_shape_disabled);
+	ClassDB::bind_method(D_METHOD("body_enable_shape", "body", "shape_idx", "enable"), &PhysicsServer3D::body_enable_shape, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("body_get_shape_count", "body"), &PhysicsServer3D::body_get_shape_count);
 	ClassDB::bind_method(D_METHOD("body_get_shape", "body", "shape_idx"), &PhysicsServer3D::body_get_shape);
@@ -517,7 +517,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_attach_object_instance_id", "body", "id"), &PhysicsServer3D::body_attach_object_instance_id);
 	ClassDB::bind_method(D_METHOD("body_get_object_instance_id", "body"), &PhysicsServer3D::body_get_object_instance_id);
 
-	ClassDB::bind_method(D_METHOD("body_set_enable_continuous_collision_detection", "body", "enable"), &PhysicsServer3D::body_set_enable_continuous_collision_detection);
+	ClassDB::bind_method(D_METHOD("body_enable_continuous_collision_detection", "body", "enable"), &PhysicsServer3D::body_enable_continuous_collision_detection, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("body_is_continuous_collision_detection_enabled", "body"), &PhysicsServer3D::body_is_continuous_collision_detection_enabled);
 
 	ClassDB::bind_method(D_METHOD("body_set_param", "body", "param", "value"), &PhysicsServer3D::body_set_param);
@@ -547,12 +547,12 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_max_contacts_reported", "body", "amount"), &PhysicsServer3D::body_set_max_contacts_reported);
 	ClassDB::bind_method(D_METHOD("body_get_max_contacts_reported", "body"), &PhysicsServer3D::body_get_max_contacts_reported);
 
-	ClassDB::bind_method(D_METHOD("body_set_omit_force_integration", "body", "enable"), &PhysicsServer3D::body_set_omit_force_integration);
+	ClassDB::bind_method(D_METHOD("body_set_omit_force_integration", "body", "omit"), &PhysicsServer3D::body_set_omit_force_integration);
 	ClassDB::bind_method(D_METHOD("body_is_omitting_force_integration", "body"), &PhysicsServer3D::body_is_omitting_force_integration);
 
 	ClassDB::bind_method(D_METHOD("body_set_force_integration_callback", "body", "callable", "userdata"), &PhysicsServer3D::body_set_force_integration_callback, DEFVAL(Variant()));
 
-	ClassDB::bind_method(D_METHOD("body_set_ray_pickable", "body", "enable"), &PhysicsServer3D::body_set_ray_pickable);
+	ClassDB::bind_method(D_METHOD("body_set_pickable", "body", "pickable"), &PhysicsServer3D::body_set_pickable);
 
 	ClassDB::bind_method(D_METHOD("body_get_direct_state", "body"), &PhysicsServer3D::body_get_direct_state);
 
@@ -603,7 +603,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("hinge_joint_set_param", "joint", "param", "value"), &PhysicsServer3D::hinge_joint_set_param);
 	ClassDB::bind_method(D_METHOD("hinge_joint_get_param", "joint", "param"), &PhysicsServer3D::hinge_joint_get_param);
 
-	ClassDB::bind_method(D_METHOD("hinge_joint_set_flag", "joint", "flag", "enabled"), &PhysicsServer3D::hinge_joint_set_flag);
+	ClassDB::bind_method(D_METHOD("hinge_joint_set_flag", "joint", "flag", "on"), &PhysicsServer3D::hinge_joint_set_flag, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("hinge_joint_get_flag", "joint", "flag"), &PhysicsServer3D::hinge_joint_get_flag);
 
 	ClassDB::bind_method(D_METHOD("joint_make_slider", "joint", "body_A", "local_ref_A", "body_B", "local_ref_B"), &PhysicsServer3D::joint_make_slider);
@@ -679,7 +679,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_set_param", "joint", "axis", "param", "value"), &PhysicsServer3D::generic_6dof_joint_set_param);
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_get_param", "joint", "axis", "param"), &PhysicsServer3D::generic_6dof_joint_get_param);
 
-	ClassDB::bind_method(D_METHOD("generic_6dof_joint_set_flag", "joint", "axis", "flag", "enable"), &PhysicsServer3D::generic_6dof_joint_set_flag);
+	ClassDB::bind_method(D_METHOD("generic_6dof_joint_set_flag", "joint", "axis", "flag", "on"), &PhysicsServer3D::generic_6dof_joint_set_flag, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_get_flag", "joint", "axis", "flag"), &PhysicsServer3D::generic_6dof_joint_get_flag);
 
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer3D::free);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -131,10 +131,10 @@ public:
 	void set_exclude(const Vector<RID> &p_exclude);
 	Vector<RID> get_exclude() const;
 
-	void set_collide_with_bodies(bool p_enable);
+	void enable_collide_with_bodies(bool p_enable = true);
 	bool is_collide_with_bodies_enabled() const;
 
-	void set_collide_with_areas(bool p_enable);
+	void enable_collide_with_areas(bool p_enable = true);
 	bool is_collide_with_areas_enabled() const;
 
 	PhysicsShapeQueryParameters3D();
@@ -335,7 +335,7 @@ public:
 	virtual void area_set_space_override_mode(RID p_area, AreaSpaceOverrideMode p_mode) = 0;
 	virtual AreaSpaceOverrideMode area_get_space_override_mode(RID p_area) const = 0;
 
-	virtual void area_add_shape(RID p_area, RID p_shape, const Transform &p_transform = Transform(), bool p_disabled = false) = 0;
+	virtual void area_add_shape(RID p_area, RID p_shape, const Transform &p_transform = Transform(), bool p_enabled = true) = 0;
 	virtual void area_set_shape(RID p_area, int p_shape_idx, RID p_shape) = 0;
 	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform &p_transform) = 0;
 
@@ -346,7 +346,7 @@ public:
 	virtual void area_remove_shape(RID p_area, int p_shape_idx) = 0;
 	virtual void area_clear_shapes(RID p_area) = 0;
 
-	virtual void area_set_shape_disabled(RID p_area, int p_shape_idx, bool p_disabled) = 0;
+	virtual void area_enable_shape(RID p_area, int p_shape_idx, bool p_enable = true) = 0;
 
 	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id) = 0;
 	virtual ObjectID area_get_object_instance_id(RID p_area) const = 0;
@@ -365,7 +365,7 @@ public:
 	virtual void area_set_monitor_callback(RID p_area, Object *p_receiver, const StringName &p_method) = 0;
 	virtual void area_set_area_monitor_callback(RID p_area, Object *p_receiver, const StringName &p_method) = 0;
 
-	virtual void area_set_ray_pickable(RID p_area, bool p_enable) = 0;
+	virtual void area_set_pickable(RID p_area, bool p_pickable) = 0;
 
 	/* BODY API */
 
@@ -386,7 +386,7 @@ public:
 	virtual void body_set_mode(RID p_body, BodyMode p_mode) = 0;
 	virtual BodyMode body_get_mode(RID p_body) const = 0;
 
-	virtual void body_add_shape(RID p_body, RID p_shape, const Transform &p_transform = Transform(), bool p_disabled = false) = 0;
+	virtual void body_add_shape(RID p_body, RID p_shape, const Transform &p_transform = Transform(), bool p_enabled = true) = 0;
 	virtual void body_set_shape(RID p_body, int p_shape_idx, RID p_shape) = 0;
 	virtual void body_set_shape_transform(RID p_body, int p_shape_idx, const Transform &p_transform) = 0;
 
@@ -397,12 +397,12 @@ public:
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) = 0;
 	virtual void body_clear_shapes(RID p_body) = 0;
 
-	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) = 0;
+	virtual void body_enable_shape(RID p_body, int p_shape_idx, bool p_enable = true) = 0;
 
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) = 0;
 	virtual ObjectID body_get_object_instance_id(RID p_body) const = 0;
 
-	virtual void body_set_enable_continuous_collision_detection(RID p_body, bool p_enable) = 0;
+	virtual void body_enable_continuous_collision_detection(RID p_body, bool p_enable = true) = 0;
 	virtual bool body_is_continuous_collision_detection_enabled(RID p_body) const = 0;
 
 	virtual void body_set_collision_layer(RID p_body, uint32_t p_layer) = 0;
@@ -488,7 +488,7 @@ public:
 
 	virtual void body_set_force_integration_callback(RID p_body, const Callable &p_callable, const Variant &p_udata = Variant()) = 0;
 
-	virtual void body_set_ray_pickable(RID p_body, bool p_enable) = 0;
+	virtual void body_set_pickable(RID p_body, bool p_pickable) = 0;
 
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) = 0;
@@ -556,7 +556,7 @@ public:
 
 	virtual void soft_body_set_transform(RID p_body, const Transform &p_transform) = 0;
 
-	virtual void soft_body_set_ray_pickable(RID p_body, bool p_enable) = 0;
+	virtual void soft_body_set_pickable(RID p_body, bool p_pickable) = 0;
 
 	virtual void soft_body_set_simulation_precision(RID p_body, int p_simulation_precision) = 0;
 	virtual int soft_body_get_simulation_precision(RID p_body) const = 0;
@@ -604,8 +604,8 @@ public:
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) = 0;
 	virtual int joint_get_solver_priority(RID p_joint) const = 0;
 
-	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) = 0;
-	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const = 0;
+	virtual void joint_enable_collisions_between_bodies(RID p_joint, const bool p_enable = true) = 0;
+	virtual bool joint_is_collisions_between_bodies_enabled(RID p_joint) const = 0;
 
 	virtual void joint_make_pin(RID p_joint, RID p_body_A, const Vector3 &p_local_A, RID p_body_B, const Vector3 &p_local_B) = 0;
 
@@ -648,7 +648,7 @@ public:
 	virtual void hinge_joint_set_param(RID p_joint, HingeJointParam p_param, real_t p_value) = 0;
 	virtual real_t hinge_joint_get_param(RID p_joint, HingeJointParam p_param) const = 0;
 
-	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_value) = 0;
+	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_on = true) = 0;
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const = 0;
 
 	enum SliderJointParam {
@@ -739,7 +739,7 @@ public:
 	virtual void generic_6dof_joint_set_param(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param, real_t p_value) = 0;
 	virtual real_t generic_6dof_joint_get_param(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param) const = 0;
 
-	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) = 0;
+	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_on = true) = 0;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const = 0;
 
 	/* QUERY API */


### PR DESCRIPTION
To avoid double negatives, boolean names should be positive. Currently, a `Shape` defaults to not being `disabled`. Similarly, to enable collisions between the bodies attached to a `Joint`'s we need to not `exclude_nodes`.

This PR makes physics boolean names positive, standardises their functions; and updates the documentation.

Part of #16863, specifically this [comment](https://github.com/godotengine/godot/issues/16863#issuecomment-511037393) and the following [two](https://github.com/godotengine/godot/issues/16863#issuecomment-511037764) [comments](https://github.com/godotengine/godot/issues/16863#issuecomment-511042959).

Note: Includes a clarification of `pickable` being associated with `InputEvent`s, specifically `InputEventMouse` events i.e. it has nothing to do with rays (other than a ray being used in 3D to detect objects under the mouse). Also ensures that 2D and 3D are the same (except for 2D being disabled by default and 3D enabled).

