### PR TITLE
Tweak log file names for consistency between Mono and non-Mono logs

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -152,7 +152,7 @@ void RotatedFileLogger::rotate_file() {
 			char timestamp[21];
 			OS::Date date = OS::get_singleton()->get_date();
 			OS::Time time = OS::get_singleton()->get_time();
-			sprintf(timestamp, "_%04d-%02d-%02d_%02d-%02d-%02d", date.year, date.month, date.day, time.hour, time.min, time.sec);
+			sprintf(timestamp, "_%04d-%02d-%02d_%02d.%02d.%02d", date.year, date.month, date.day, time.hour, time.min, time.sec);
 
 			String backup_name = base_path.get_basename() + timestamp;
 			if (base_path.get_extension() != String()) {

--- a/modules/mono/mono_gd/gd_mono_log.cpp
+++ b/modules/mono/mono_gd/gd_mono_log.cpp
@@ -160,13 +160,13 @@ void GDMonoLog::initialize() {
 		OS::Date date_now = OS::get_singleton()->get_date();
 		OS::Time time_now = OS::get_singleton()->get_time();
 
-		String log_file_name = str_format("%d_%02d_%02d %02d.%02d.%02d",
+		String log_file_name = str_format("%04d-%02d-%02d_%02d.%02d.%02d",
 				date_now.year, date_now.month, date_now.day,
 				time_now.hour, time_now.min, time_now.sec);
 
-		log_file_name += str_format(" (%d)", OS::get_singleton()->get_process_id());
+		log_file_name += str_format("_%d", OS::get_singleton()->get_process_id());
 
-		log_file_name += ".txt";
+		log_file_name += ".log";
 
 		log_file_path = logs_dir.plus_file(log_file_name);
 


### PR DESCRIPTION
- Avoid spaces in Mono log file names.
- Use a `.log` extension for Mono logs, just like non-Mono logs.
- Use periods to separate hours/minutes/seconds for non-Mono logs.

#21895 made me realize there was a dedicated Mono logging system, so I took the time to make this more consistent. :stuck_out_tongue: