### PR TITLE
Rename Vector2.tangent() to Vector2.orthogonal()

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -272,7 +272,7 @@ struct Rect2 {
 			}
 
 			//check inside
-			Vector2 tg = r.tangent();
+			Vector2 tg = r.orthogonal();
 			float s = tg.dot(center) - tg.dot(a);
 			if (s < 0.0) {
 				side_plus++;

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -134,7 +134,7 @@ struct Vector2 {
 	}
 
 	Vector2 rotated(real_t p_by) const;
-	Vector2 tangent() const {
+	Vector2 orthogonal() const {
 		return Vector2(y, -x);
 	}
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -992,7 +992,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2, cubic_interpolate, sarray("b", "pre_a", "post_b", "t"), varray());
 	bind_method(Vector2, move_toward, sarray("to", "delta"), varray());
 	bind_method(Vector2, rotated, sarray("phi"), varray());
-	bind_method(Vector2, tangent, sarray(), varray());
+	bind_method(Vector2, orthogonal, sarray(), varray());
 	bind_method(Vector2, floor, sarray(), varray());
 	bind_method(Vector2, ceil, sarray(), varray());
 	bind_method(Vector2, round, sarray(), varray());

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -479,7 +479,7 @@
 				Returns this vector with each component snapped to the nearest multiple of [code]step[/code]. This can also be used to round to an arbitrary number of decimals.
 			</description>
 		</method>
-		<method name="tangent">
+		<method name="orthogonal">
 			<return type="Vector2">
 			</return>
 			<description>

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -520,7 +520,7 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 
 	Transform2D xf;
 	xf.elements[0] = (p_to - p_from).normalized();
-	xf.elements[1] = xf.elements[0].tangent();
+	xf.elements[1] = xf.elements[0].orthogonal();
 	xf.elements[2] = (p_from + p_to) * 0.5 - xf.elements[1] * icon->get_height() * 0.5 - xf.elements[0] * icon->get_height() * 0.5;
 
 	state_machine_draw->draw_set_transform_matrix(xf);
@@ -690,7 +690,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		tl.width = tr_bidi_offset;
 
 		if (state_machine->has_transition(tl.to_node, tl.from_node)) { //offset if same exists
-			Vector2 offset = -(tl.from - tl.to).normalized().tangent() * tr_bidi_offset;
+			Vector2 offset = -(tl.from - tl.to).normalized().orthogonal() * tr_bidi_offset;
 			tl.from += offset;
 			tl.to += offset;
 		}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -727,7 +727,7 @@ bool CanvasItemEditor::_get_bone_shape(Vector<Vector2> *shape, Vector<Vector2> *
 	}
 
 	Vector2 rel = to - from;
-	Vector2 relt = rel.tangent().normalized() * bone_width;
+	Vector2 relt = rel.orthogonal().normalized() * bone_width;
 	Vector2 reln = rel.normalized();
 	Vector2 reltn = relt.normalized();
 
@@ -1808,7 +1808,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 						}
 
 						ofs = (endpoints[i] + endpoints[next]) / 2;
-						ofs += (endpoints[next] - endpoints[i]).tangent().normalized() * (select_handle->get_size().width / 2);
+						ofs += (endpoints[next] - endpoints[i]).orthogonal().normalized() * (select_handle->get_size().width / 2);
 						if (ofs.distance_to(b->get_position()) < radius) {
 							resize_drag = dragger[i * 2 + 1];
 						}
@@ -3495,7 +3495,7 @@ void CanvasItemEditor::_draw_selection() {
 					select_handle->draw(ci, (endpoints[i] + ofs - (select_handle->get_size() / 2)).floor());
 
 					ofs = (endpoints[i] + endpoints[next]) / 2;
-					ofs += (endpoints[next] - endpoints[i]).tangent().normalized() * (select_handle->get_size().width / 2);
+					ofs += (endpoints[next] - endpoints[i]).orthogonal().normalized() * (select_handle->get_size().width / 2);
 
 					select_handle->draw(ci, (ofs - (select_handle->get_size() / 2)).floor());
 				}

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -177,7 +177,7 @@ void TextureRegionEditor::_region_draw() {
 		}
 
 		ofs = (endpoints[next] - endpoints[i]) / 2;
-		ofs += (endpoints[next] - endpoints[i]).tangent().normalized() * (select_handle->get_size().width / 2);
+		ofs += (endpoints[next] - endpoints[i]).orthogonal().normalized() * (select_handle->get_size().width / 2);
 
 		if (snap_mode != SNAP_AUTOSLICE) {
 			edit_draw->draw_texture(select_handle, (endpoints[i] + ofs - (select_handle->get_size() / 2)).floor() - draw_ofs * draw_zoom);

--- a/modules/gdnative/gdnative/vector2.cpp
+++ b/modules/gdnative/gdnative/vector2.cpp
@@ -154,10 +154,10 @@ godot_vector2 GDAPI godot_vector2_rotated(const godot_vector2 *p_self, const god
 	return dest;
 }
 
-godot_vector2 GDAPI godot_vector2_tangent(const godot_vector2 *p_self) {
+godot_vector2 GDAPI godot_vector2_orthogonal(const godot_vector2 *p_self) {
 	godot_vector2 dest;
 	const Vector2 *self = (const Vector2 *)p_self;
-	*((Vector2 *)&dest) = self->tangent();
+	*((Vector2 *)&dest) = self->orthogonal();
 	return dest;
 }
 

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -6413,7 +6413,7 @@
         ]
       },
       {
-        "name": "godot_vector2_tangent",
+        "name": "godot_vector2_orthogonal",
         "return_type": "godot_vector2",
         "arguments": [
           ["const godot_vector2 *", "p_self"]

--- a/modules/gdnative/include/gdnative/vector2.h
+++ b/modules/gdnative/include/gdnative/vector2.h
@@ -102,7 +102,7 @@ godot_vector2 GDAPI godot_vector2_move_toward(const godot_vector2 *p_self, const
 
 godot_vector2 GDAPI godot_vector2_rotated(const godot_vector2 *p_self, const godot_real p_phi);
 
-godot_vector2 GDAPI godot_vector2_tangent(const godot_vector2 *p_self);
+godot_vector2 GDAPI godot_vector2_orthogonal(const godot_vector2 *p_self);
 
 godot_vector2 GDAPI godot_vector2_floor(const godot_vector2 *p_self);
 

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -743,7 +743,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 						Vector2 normal = emission_normals.get(random_idx);
 						Transform2D m2;
 						m2.set_axis(0, normal);
-						m2.set_axis(1, normal.tangent());
+						m2.set_axis(1, normal.orthogonal());
 						p.velocity = m2.basis_xform(p.velocity);
 					}
 
@@ -908,7 +908,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
 			if (p.velocity.length() > 0.0) {
 				p.transform.elements[1] = p.velocity.normalized();
-				p.transform.elements[0] = p.transform.elements[1].tangent();
+				p.transform.elements[0] = p.transform.elements[1].orthogonal();
 			}
 
 		} else {

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -200,7 +200,7 @@ void PathFollow2D::_update_transform() {
 			tangent_to_curve = (ahead_pos - pos).normalized();
 		}
 
-		Vector2 normal_of_curve = -tangent_to_curve.tangent();
+		Vector2 normal_of_curve = -tangent_to_curve.orthogonal();
 
 		pos += tangent_to_curve * h_offset;
 		pos += normal_of_curve * v_offset;

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -730,7 +730,7 @@ void CPUParticles3D::_particles_process(float p_delta) {
 							Vector2 normal_2d(normal.x, normal.y);
 							Transform2D m2;
 							m2.set_axis(0, normal_2d);
-							m2.set_axis(1, normal_2d.tangent());
+							m2.set_axis(1, normal_2d.orthogonal());
 							Vector2 velocity_2d(p.velocity.x, p.velocity.y);
 							velocity_2d = m2.basis_xform(velocity_2d);
 							p.velocity.x = velocity_2d.x;

--- a/scene/resources/line_shape_2d.cpp
+++ b/scene/resources/line_shape_2d.cpp
@@ -36,7 +36,7 @@
 
 bool LineShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 	Vector2 point = get_distance() * get_normal();
-	Vector2 l[2][2] = { { point - get_normal().tangent() * 100, point + get_normal().tangent() * 100 }, { point, point + get_normal() * 30 } };
+	Vector2 l[2][2] = { { point - get_normal().orthogonal() * 100, point + get_normal().orthogonal() * 100 }, { point, point + get_normal() * 30 } };
 
 	for (int i = 0; i < 2; i++) {
 		Vector2 closest = Geometry2D::get_closest_point_to_segment(p_point, l[i]);
@@ -77,7 +77,7 @@ real_t LineShape2D::get_distance() const {
 void LineShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector2 point = get_distance() * get_normal();
 
-	Vector2 l1[2] = { point - get_normal().tangent() * 100, point + get_normal().tangent() * 100 };
+	Vector2 l1[2] = { point - get_normal().orthogonal() * 100, point + get_normal().orthogonal() * 100 };
 	RS::get_singleton()->canvas_item_add_line(p_to_rid, l1[0], l1[1], p_color, 3);
 	Vector2 l2[2] = { point, point + get_normal() * 30 };
 	RS::get_singleton()->canvas_item_add_line(p_to_rid, l2[0], l2[1], p_color, 3);
@@ -86,7 +86,7 @@ void LineShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 Rect2 LineShape2D::get_rect() const {
 	Vector2 point = get_distance() * get_normal();
 
-	Vector2 l1[2] = { point - get_normal().tangent() * 100, point + get_normal().tangent() * 100 };
+	Vector2 l1[2] = { point - get_normal().orthogonal() * 100, point + get_normal().orthogonal() * 100 };
 	Vector2 l2[2] = { point, point + get_normal() * 30 };
 	Rect2 rect;
 	rect.position = l1[0];

--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -409,7 +409,7 @@ bool BodyPair2DSW::setup(real_t p_step) {
 		kNormal += A->get_inv_inertia() * (c.rA.dot(c.rA) - rnA * rnA) + B->get_inv_inertia() * (c.rB.dot(c.rB) - rnB * rnB);
 		c.mass_normal = 1.0f / kNormal;
 
-		Vector2 tangent = c.normal.tangent();
+		Vector2 tangent = c.normal.orthogonal();
 		real_t rtA = c.rA.dot(tangent);
 		real_t rtB = c.rB.dot(tangent);
 		real_t kTangent = A->get_inv_mass() + B->get_inv_mass();
@@ -469,7 +469,7 @@ void BodyPair2DSW::solve(real_t p_step) {
 
 		real_t vn = dv.dot(c.normal);
 		real_t vbn = dbv.dot(c.normal);
-		Vector2 tangent = c.normal.tangent();
+		Vector2 tangent = c.normal.orthogonal();
 		real_t vt = dv.dot(tangent);
 
 		real_t jbn = (c.bias - vbn) * c.mass_normal;

--- a/servers/physics_2d/collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/collision_solver_2d_sat.cpp
@@ -88,7 +88,7 @@ _FORCE_INLINE_ static void _generate_contacts_edge_edge(const Vector2 *p_points_
 #endif
 
 	Vector2 n = p_collector->normal;
-	Vector2 t = n.tangent();
+	Vector2 t = n.orthogonal();
 	real_t dA = n.dot(p_points_A[0]);
 	real_t dB = n.dot(p_points_B[0]);
 
@@ -209,7 +209,7 @@ public:
 			if (!test_axis(na)) {
 				return false;
 			}
-			if (!test_axis(na.tangent())) {
+			if (!test_axis(na.orthogonal())) {
 				return false;
 			}
 		}
@@ -219,7 +219,7 @@ public:
 			if (!test_axis(nb)) {
 				return false;
 			}
-			if (!test_axis(nb.tangent())) {
+			if (!test_axis(nb.orthogonal())) {
 				return false;
 			}
 		}
@@ -450,7 +450,7 @@ static void _collision_segment_circle(const Shape2DSW *p_a, const Transform2D &p
 
 	//segment normal
 	if (!separator.test_axis(
-				(p_transform_a.xform(segment_A->get_b()) - p_transform_a.xform(segment_A->get_a())).normalized().tangent())) {
+				(p_transform_a.xform(segment_A->get_b()) - p_transform_a.xform(segment_A->get_a())).normalized().orthogonal())) {
 		return;
 	}
 

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -75,9 +75,9 @@ static inline real_t k_scalar(Body2DSW *a, Body2DSW *b, const Vector2 &rA, const
 
 static inline Vector2
 relative_velocity(Body2DSW *a, Body2DSW *b, Vector2 rA, Vector2 rB) {
-	Vector2 sum = a->get_linear_velocity() - rA.tangent() * a->get_angular_velocity();
+	Vector2 sum = a->get_linear_velocity() - rA.orthogonal() * a->get_angular_velocity();
 	if (b) {
-		return (b->get_linear_velocity() - rB.tangent() * b->get_angular_velocity()) - sum;
+		return (b->get_linear_velocity() - rB.orthogonal() * b->get_angular_velocity()) - sum;
 	} else {
 		return -sum;
 	}
@@ -264,7 +264,7 @@ bool GrooveJoint2DSW::setup(real_t p_step) {
 	Space2DSW *space = A->get_space();
 
 	// calculate axis
-	Vector2 n = -(tb - ta).tangent().normalized();
+	Vector2 n = -(tb - ta).orthogonal().normalized();
 	real_t d = ta.dot(n);
 
 	xf_normal = n;
@@ -282,7 +282,7 @@ bool GrooveJoint2DSW::setup(real_t p_step) {
 	} else {
 		clamp = 0.0f;
 		//joint->r1 = cpvsub(cpvadd(cpvmult(cpvperp(n), -td), cpvmult(n, d)), a->p);
-		rA = ((-n.tangent() * -td) + n * d) - A->get_transform().get_origin();
+		rA = ((-n.orthogonal() * -td) + n * d) - A->get_transform().get_origin();
 	}
 
 	// Calculate mass tensor
@@ -332,7 +332,7 @@ GrooveJoint2DSW::GrooveJoint2DSW(const Vector2 &p_a_groove1, const Vector2 &p_a_
 	A_groove_1 = A->get_inv_transform().xform(p_a_groove1);
 	A_groove_2 = A->get_inv_transform().xform(p_a_groove2);
 	B_anchor = B->get_inv_transform().xform(p_b_anchor);
-	A_groove_normal = -(A_groove_2 - A_groove_1).normalized().tangent();
+	A_groove_normal = -(A_groove_2 - A_groove_1).normalized().orthogonal();
 
 	A->add_constraint(this, 0);
 	B->add_constraint(this, 1);

--- a/servers/physics_2d/shape_2d_sw.cpp
+++ b/servers/physics_2d/shape_2d_sw.cpp
@@ -228,7 +228,7 @@ void SegmentShape2DSW::set_data(const Variant &p_data) {
 	Rect2 r = p_data;
 	a = r.position;
 	b = r.size;
-	n = (b - a).tangent();
+	n = (b - a).orthogonal();
 
 	Rect2 aabb;
 	aabb.position = a;
@@ -612,7 +612,7 @@ void ConvexPolygonShape2DSW::set_data(const Variant &p_data) {
 		for (int i = 0; i < point_count; i++) {
 			Vector2 p = points[i].pos;
 			Vector2 pn = points[(i + 1) % point_count].pos;
-			points[i].normal = (pn - p).tangent().normalized();
+			points[i].normal = (pn - p).orthogonal().normalized();
 		}
 	} else {
 		Vector<real_t> dvr = p_data;
@@ -740,7 +740,7 @@ bool ConcavePolygonShape2DSW::intersect_segment(const Vector2 &p_begin, const Ve
 							if (nd < d) {
 								d = nd;
 								r_point = res;
-								r_normal = (b - a).tangent().normalized();
+								r_normal = (b - a).orthogonal().normalized();
 								inters = true;
 							}
 						}
@@ -960,7 +960,7 @@ void ConcavePolygonShape2DSW::cull(const Rect2 &p_local_aabb, Callback p_callbac
 						Vector2 a = pointptr[s.points[0]];
 						Vector2 b = pointptr[s.points[1]];
 
-						SegmentShape2DSW ss(a, b, (b - a).tangent().normalized());
+						SegmentShape2DSW ss(a, b, (b - a).orthogonal().normalized());
 
 						p_callback(p_userdata, &ss);
 						stack[level] = (VISIT_DONE_BIT << VISITED_BIT_SHIFT) | node;

--- a/servers/physics_2d/shape_2d_sw.h
+++ b/servers/physics_2d/shape_2d_sw.h
@@ -237,7 +237,7 @@ public:
 	virtual PhysicsServer2D::ShapeType get_type() const { return PhysicsServer2D::SHAPE_SEGMENT; }
 
 	_FORCE_INLINE_ Vector2 get_xformed_normal(const Transform2D &p_xform) const {
-		return (p_xform.xform(b) - p_xform.xform(a)).normalized().tangent();
+		return (p_xform.xform(b) - p_xform.xform(a)).normalized().orthogonal();
 	}
 	virtual void project_rangev(const Vector2 &p_normal, const Transform2D &p_transform, real_t &r_min, real_t &r_max) const { project_range(p_normal, p_transform, r_min, r_max); }
 	virtual void get_supports(const Vector2 &p_normal, Vector2 *r_supports, int &r_amount) const;
@@ -431,7 +431,7 @@ public:
 		Vector2 a = points[p_idx].pos;
 		p_idx++;
 		Vector2 b = points[p_idx == point_count ? 0 : p_idx].pos;
-		return (p_xform.xform(b) - p_xform.xform(a)).normalized().tangent();
+		return (p_xform.xform(b) - p_xform.xform(a)).normalized().orthogonal();
 	}
 
 	virtual PhysicsServer2D::ShapeType get_type() const { return PhysicsServer2D::SHAPE_CONVEX_POLYGON; }

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -524,7 +524,7 @@ void RendererCanvasCull::canvas_item_add_line(RID p_item, const Point2 &p_from, 
 	Item::CommandPrimitive *line = canvas_item->alloc_command<Item::CommandPrimitive>();
 	ERR_FAIL_COND(!line);
 	if (p_width > 1.001) {
-		Vector2 t = (p_from - p_to).tangent().normalized();
+		Vector2 t = (p_from - p_to).orthogonal().normalized();
 		line->points[0] = p_from + t * p_width;
 		line->points[1] = p_from - t * p_width;
 		line->points[2] = p_to - t * p_width;
@@ -600,7 +600,7 @@ void RendererCanvasCull::canvas_item_add_polyline(RID p_item, const Vector<Point
 			if (i == pc - 1) {
 				t = prev_t;
 			} else {
-				t = (p_points[i + 1] - p_points[i]).normalized().tangent();
+				t = (p_points[i + 1] - p_points[i]).normalized().orthogonal();
 				if (i == 0) {
 					prev_t = t;
 				}
@@ -650,7 +650,7 @@ void RendererCanvasCull::canvas_item_add_polyline(RID p_item, const Vector<Point
 			if (i == pc - 1) {
 				t = prev_t;
 			} else {
-				t = (p_points[i + 1] - p_points[i]).normalized().tangent();
+				t = (p_points[i + 1] - p_points[i]).normalized().orthogonal();
 				if (i == 0) {
 					prev_t = t;
 				}

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1689,7 +1689,7 @@ void RendererCanvasRenderRD::light_update_directional_shadow(RID p_rid, int p_sh
 
 	to_light_xform[2] = from_pos;
 	to_light_xform[1] = light_dir;
-	to_light_xform[0] = -light_dir.tangent();
+	to_light_xform[0] = -light_dir.orthogonal();
 
 	to_light_xform.invert();
 


### PR DESCRIPTION
As [identified](https://github.com/godotengine/godot/issues/16863#issuecomment-618294043) by @razcore-art:
> `Vector2.tangent()` is described in the docs as: `Returns a perpendicular vector.`, that's the definition of `orthogonal` or `orthonormal` if the returned vector is normalized. Since `Vector2.tangent()` returns a non-normalized vector I propose we should rename it to `Vector2.orthogonal()`...

Part of #16863.
