### PR TITLE
Fix dummy rasterizer so that javascript can build again

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -383,7 +383,7 @@ public:
 	bool material_is_animated(RID p_material) override { return false; }
 	bool material_casts_shadows(RID p_material) override { return false; }
 	void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override {}
-	void material_update_dependency(RID p_material, RendererSceneRender::InstanceBase *p_instance) override {}
+	void material_update_dependency(RID p_material, InstanceBaseDependency *p_instance) override {}
 
 	/* MESH API */
 
@@ -642,8 +642,8 @@ public:
 	float reflection_probe_get_origin_max_distance(RID p_probe) const override { return 0.0; }
 	bool reflection_probe_renders_shadows(RID p_probe) const override { return false; }
 
-	void base_update_dependency(RID p_base, RendererSceneRender::InstanceBase *p_instance) override {}
-	void skeleton_update_dependency(RID p_base, RendererSceneRender::InstanceBase *p_instance) override {}
+	void base_update_dependency(RID p_base, InstanceBaseDependency *p_instance) override {}
+	void skeleton_update_dependency(RID p_base, InstanceBaseDependency *p_instance) override {}
 
 	/* DECAL API */
 
@@ -826,8 +826,8 @@ public:
 	int particles_get_draw_passes(RID p_particles) const override { return 0; }
 	RID particles_get_draw_pass_mesh(RID p_particles, int p_pass) const override { return RID(); }
 
-	void particles_add_collision(RID p_particles, RendererSceneRender::InstanceBase *p_instance) override {}
-	void particles_remove_collision(RID p_particles, RendererSceneRender::InstanceBase *p_instance) override {}
+	void particles_add_collision(RID p_particles, InstanceBaseDependency *p_instance) override {}
+	void particles_remove_collision(RID p_particles, InstanceBaseDependency *p_instance) override {}
 
 	void update_particles() override {}
 


### PR DESCRIPTION
When trying to build the HTML5 export templates via this command:

```
scons -j10 platform=javascript tools=no target=release use_closure_compiler=true
```

I'm getting these errors on the 'master' branch currently:

```
./drivers/dummy/rasterizer_dummy.h:386:97: error: non-virtual member function marked 'override' hides virtual member function
        void material_update_dependency(RID p_material, RendererSceneRender::InstanceBase *p_instance) override {}
                                                                                                       ^
./servers/rendering/renderer_storage.h:184:15: note: hidden overloaded virtual function 'RendererStorage::material_update_dependency' declared here: type mismatch at 2nd parameter ('RendererStorage::InstanceBaseDependency *' vs 'RendererSceneRender::InstanceBase *')
        virtual void material_update_dependency(RID p_material, InstanceBaseDependency *p_instance) = 0;
                     ^
In file included from platform/javascript/display_server_javascript.cpp:33:
./drivers/dummy/rasterizer_dummy.h:645:89: error: non-virtual member function marked 'override' hides virtual member function
        void base_update_dependency(RID p_base, RendererSceneRender::InstanceBase *p_instance) override {}
                                                                                               ^
./servers/rendering/renderer_storage.h:338:15: note: hidden overloaded virtual function 'RendererStorage::base_update_dependency' declared here: type mismatch at 2nd parameter ('RendererStorage::InstanceBaseDependency *' vs 'RendererSceneRender::InstanceBase *')
        virtual void base_update_dependency(RID p_base, InstanceBaseDependency *p_instance) = 0;
                     ^
[ 22%] In file included from platform/javascript/display_server_javascript.cpp:33:
./drivers/dummy/rasterizer_dummy.h:646:93: error: non-virtual member function marked 'override' hides virtual member function
        void skeleton_update_dependency(RID p_base, RendererSceneRender::InstanceBase *p_instance) override {}
                                                                                                   ^
./servers/rendering/renderer_storage.h:339:15: note: hidden overloaded virtual function 'RendererStorage::skeleton_update_dependency' declared here: type mismatch at 2nd parameter ('RendererStorage::InstanceBaseDependency *' vs 'RendererSceneRender::InstanceBase *')
        virtual void skeleton_update_dependency(RID p_base, InstanceBaseDependency *p_instance) = 0;
                     ^
[ 22%] In file included from platform/javascript/display_server_javascript.cpp:33:
./drivers/dummy/rasterizer_dummy.h:829:95: error: non-virtual member function marked 'override' hides virtual member function
        void particles_add_collision(RID p_particles, RendererSceneRender::InstanceBase *p_instance) override {}
                                                                                                     ^
./servers/rendering/renderer_storage.h:463:15: note: hidden overloaded virtual function 'RendererStorage::particles_add_collision' declared here: type mismatch at 2nd parameter ('RendererStorage::InstanceBaseDependency *' vs 'RendererSceneRender::InstanceBase *')
        virtual void particles_add_collision(RID p_particles, InstanceBaseDependency *p_instance) = 0;
                     ^
In file included from platform/javascript/display_server_javascript.cpp:33:
./drivers/dummy/rasterizer_dummy.h:830:98: error: non-virtual member function marked 'override' hides virtual member function
        void particles_remove_collision(RID p_particles, RendererSceneRender::InstanceBase *p_instance) override {}
                                                                                                        ^
./servers/rendering/renderer_storage.h:464:15: note: hidden overloaded virtual function 'RendererStorage::particles_remove_collision' declared here: type mismatch at 2nd parameter ('RendererStorage::InstanceBaseDependency *' vs 'RendererSceneRender::InstanceBase *')
        virtual void particles_remove_collision(RID p_particles, InstanceBaseDependency *p_instance) = 0;
                     ^
[ 22%] In file included from platform/javascript/display_server_javascript.cpp:33:
./drivers/dummy/rasterizer_dummy.h:980:25: error: field type 'RasterizerStorageDummy' is an abstract class
        RasterizerStorageDummy storage;
                               ^
./servers/rendering/renderer_storage.h:184:15: note: unimplemented pure virtual method 'material_update_dependency' in 'RasterizerStorageDummy'
        virtual void material_update_dependency(RID p_material, InstanceBaseDependency *p_instance) = 0;
                     ^
./servers/rendering/renderer_storage.h:338:15: note: unimplemented pure virtual method 'base_update_dependency' in 'RasterizerStorageDummy'
        virtual void base_update_dependency(RID p_base, InstanceBaseDependency *p_instance) = 0;
                     ^
./servers/rendering/renderer_storage.h:339:15: note: unimplemented pure virtual method 'skeleton_update_dependency' in 'RasterizerStorageDummy'
        virtual void skeleton_update_dependency(RID p_base, InstanceBaseDependency *p_instance) = 0;
                     ^
./servers/rendering/renderer_storage.h:463:15: note: unimplemented pure virtual method 'particles_add_collision' in 'RasterizerStorageDummy'
        virtual void particles_add_collision(RID p_particles, InstanceBaseDependency *p_instance) = 0;
                     ^
./servers/rendering/renderer_storage.h:464:15: note: unimplemented pure virtual method 'particles_remove_collision' in 'RasterizerStorageDummy'
        virtual void particles_remove_collision(RID p_particles, InstanceBaseDependency *p_instance) = 0;
                     ^
In file included from platform/javascript/display_server_javascript.cpp:33:
./drivers/dummy/rasterizer_dummy.h:1008:10: error: cannot initialize return object of type 'RendererCompositor *' with an rvalue of type 'RasterizerDummy *'
                return memnew(RasterizerDummy);
                       ^~~~~~~~~~~~~~~~~~~~~~~
./core/os/memory.h:93:25: note: expanded from macro 'memnew'
#define memnew(m_class) _post_initialize(new ("") m_class)
```

This PR fixes that!