### PR TITLE
Add Quaternion angle_to method

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -33,6 +33,11 @@
 #include "core/math/basis.h"
 #include "core/string/print_string.h"
 
+real_t Quaternion::angle_to(const Quaternion &p_to) const {
+	real_t d = dot(p_to);
+	return Math::acos(CLAMP(d * d * 2 - 1, -1, 1));
+}
+
 // get_euler_xyz returns a vector containing the Euler angles in the format
 // (ax,ay,az), where ax is the angle of rotation around x axis,
 // and similar for other axes.

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef QUAT_H
-#define QUAT_H
+#ifndef QUATERNION_H
+#define QUATERNION_H
 
 #include "core/math/math_defs.h"
 #include "core/math/math_funcs.h"
@@ -62,6 +62,7 @@ public:
 	bool is_normalized() const;
 	Quaternion inverse() const;
 	_FORCE_INLINE_ real_t dot(const Quaternion &p_q) const;
+	real_t angle_to(const Quaternion &p_to) const;
 
 	Vector3 get_euler_xyz() const;
 	Vector3 get_euler_yxz() const;
@@ -235,4 +236,4 @@ _FORCE_INLINE_ Quaternion operator*(const real_t &p_real, const Quaternion &p_qu
 	return p_quaternion * p_real;
 }
 
-#endif // QUAT_H
+#endif // QUATERNION_H

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1552,6 +1552,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Quaternion, is_normalized, sarray(), varray());
 	bind_method(Quaternion, is_equal_approx, sarray("to"), varray());
 	bind_method(Quaternion, inverse, sarray(), varray());
+	bind_method(Quaternion, angle_to, sarray("to"), varray());
 	bind_method(Quaternion, dot, sarray("with"), varray());
 	bind_method(Quaternion, slerp, sarray("to", "weight"), varray());
 	bind_method(Quaternion, slerpni, sarray("to", "weight"), varray());

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -83,6 +83,16 @@
 				Constructs a quaternion defined by the given values.
 			</description>
 		</method>
+		<method name="angle_to" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="to" type="Quaternion">
+			</argument>
+			<description>
+				Returns the angle between this quaternion and [code]to[/code]. This is the magnitude of the angle you would need to rotate by to get from one to the other.
+				[b]Note:[/b] This method has an abnormally high amount of floating-point error, so methods such as [code]is_zero_approx[/code] will not work reliably.
+			</description>
+		</method>
 		<method name="cubic_slerp" qualifiers="const">
 			<return type="Quaternion">
 			</return>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -114,6 +114,23 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the angle between this quaternion and `to`.
+        /// This is the magnitude of the angle you would need to rotate
+        /// by to get from one to the other.
+        ///
+        /// Note: This method has an abnormally high amount
+        /// of floating-point error, so methods such as
+        /// <see cref="Mathf.IsZeroApprox"/> will not work reliably.
+        /// </summary>
+        /// <param name="to">The other quaternion.</param>
+        /// <returns>The angle between the quaternions.</returns>
+        public real_t AngleTo(Quaternion to)
+        {
+            real_t dot = Dot(to);
+            return Mathf.Acos(Mathf.Clamp(dot * dot * 2 - 1, -1, 1));
+        }
+
+        /// <summary>
         /// Performs a cubic spherical interpolation between quaternions `preA`,
         /// this vector, `b`, and `postB`, by the given amount `t`.
         /// </summary>


### PR DESCRIPTION
This PR adds an `angle_to` method to Quaternion for finding the angle between quaternions. This implementation is based on this StackExchange post: https://math.stackexchange.com/questions/90081/quaternion-distance

The lack of this method can be worked around with a one-liner: `var angle_to = acos(clamp(2 * pow(quat1.dot(quat2), 2) - 1, -1, 1))`, however this is not intuitive at all, and this would make the most sense as part of core. I also checked if there was precedent for this method in other engines, Unity and Unreal both have a method for this already.