### PR TITLE
Improve some argument names for core types

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -1017,15 +1017,15 @@ void Basis::set_diagonal(const Vector3 &p_diag) {
 	elements[2][2] = p_diag.z;
 }
 
-Basis Basis::slerp(const Basis &target, const real_t &t) const {
+Basis Basis::slerp(const Basis &p_to, const real_t &p_weight) const {
 	//consider scale
 	Quat from(*this);
-	Quat to(target);
+	Quat to(p_to);
 
-	Basis b(from.slerp(to, t));
-	b.elements[0] *= Math::lerp(elements[0].length(), target.elements[0].length(), t);
-	b.elements[1] *= Math::lerp(elements[1].length(), target.elements[1].length(), t);
-	b.elements[2] *= Math::lerp(elements[2].length(), target.elements[2].length(), t);
+	Basis b(from.slerp(to, p_weight));
+	b.elements[0] *= Math::lerp(elements[0].length(), p_to.elements[0].length(), p_weight);
+	b.elements[1] *= Math::lerp(elements[1].length(), p_to.elements[1].length(), p_weight);
+	b.elements[2] *= Math::lerp(elements[2].length(), p_to.elements[2].length(), p_weight);
 
 	return b;
 }

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -170,7 +170,7 @@ public:
 	bool is_diagonal() const;
 	bool is_rotation() const;
 
-	Basis slerp(const Basis &target, const real_t &t) const;
+	Basis slerp(const Basis &p_to, const real_t &p_weight) const;
 	void rotate_sh(real_t *p_values);
 
 	operator String() const;

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -92,13 +92,13 @@ struct Color {
 	void invert();
 	Color inverted() const;
 
-	_FORCE_INLINE_ Color lerp(const Color &p_b, float p_t) const {
+	_FORCE_INLINE_ Color lerp(const Color &p_to, float p_weight) const {
 		Color res = *this;
 
-		res.r += (p_t * (p_b.r - r));
-		res.g += (p_t * (p_b.g - g));
-		res.b += (p_t * (p_b.b - b));
-		res.a += (p_t * (p_b.a - a));
+		res.r += (p_weight * (p_to.r - r));
+		res.g += (p_weight * (p_to.g - g));
+		res.b += (p_weight * (p_to.b - b));
+		res.a += (p_weight * (p_to.a - a));
 
 		return res;
 	}

--- a/core/math/quat.h
+++ b/core/math/quat.h
@@ -63,7 +63,7 @@ public:
 	Quat normalized() const;
 	bool is_normalized() const;
 	Quat inverse() const;
-	_FORCE_INLINE_ real_t dot(const Quat &q) const;
+	_FORCE_INLINE_ real_t dot(const Quat &p_q) const;
 
 	void set_euler_xyz(const Vector3 &p_euler);
 	Vector3 get_euler_xyz() const;
@@ -73,9 +73,9 @@ public:
 	void set_euler(const Vector3 &p_euler) { set_euler_yxz(p_euler); };
 	Vector3 get_euler() const { return get_euler_yxz(); };
 
-	Quat slerp(const Quat &q, const real_t &t) const;
-	Quat slerpni(const Quat &q, const real_t &t) const;
-	Quat cubic_slerp(const Quat &q, const Quat &prep, const Quat &postq, const real_t &t) const;
+	Quat slerp(const Quat &p_to, const real_t &p_weight) const;
+	Quat slerpni(const Quat &p_to, const real_t &p_weight) const;
+	Quat cubic_slerp(const Quat &p_b, const Quat &p_pre_a, const Quat &p_post_b, const real_t &p_weight) const;
 
 	void set_axis_angle(const Vector3 &axis, const real_t &angle);
 	_FORCE_INLINE_ void get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
@@ -86,8 +86,8 @@ public:
 		r_axis.z = z * r;
 	}
 
-	void operator*=(const Quat &q);
-	Quat operator*(const Quat &q) const;
+	void operator*=(const Quat &p_q);
+	Quat operator*(const Quat &p_q) const;
 
 	Quat operator*(const Vector3 &v) const {
 		return Quat(w * v.x + y * v.z - z * v.y,
@@ -109,8 +109,8 @@ public:
 		return inverse().xform(v);
 	}
 
-	_FORCE_INLINE_ void operator+=(const Quat &q);
-	_FORCE_INLINE_ void operator-=(const Quat &q);
+	_FORCE_INLINE_ void operator+=(const Quat &p_q);
+	_FORCE_INLINE_ void operator-=(const Quat &p_q);
 	_FORCE_INLINE_ void operator*=(const real_t &s);
 	_FORCE_INLINE_ void operator/=(const real_t &s);
 	_FORCE_INLINE_ Quat operator+(const Quat &q2) const;
@@ -141,18 +141,18 @@ public:
 	Quat(const Vector3 &axis, const real_t &angle) { set_axis_angle(axis, angle); }
 
 	Quat(const Vector3 &euler) { set_euler(euler); }
-	Quat(const Quat &q) :
-			x(q.x),
-			y(q.y),
-			z(q.z),
-			w(q.w) {
+	Quat(const Quat &p_q) :
+			x(p_q.x),
+			y(p_q.y),
+			z(p_q.z),
+			w(p_q.w) {
 	}
 
-	Quat &operator=(const Quat &q) {
-		x = q.x;
-		y = q.y;
-		z = q.z;
-		w = q.w;
+	Quat &operator=(const Quat &p_q) {
+		x = p_q.x;
+		y = p_q.y;
+		z = p_q.z;
+		w = p_q.w;
 		return *this;
 	}
 
@@ -178,26 +178,26 @@ public:
 	}
 };
 
-real_t Quat::dot(const Quat &q) const {
-	return x * q.x + y * q.y + z * q.z + w * q.w;
+real_t Quat::dot(const Quat &p_q) const {
+	return x * p_q.x + y * p_q.y + z * p_q.z + w * p_q.w;
 }
 
 real_t Quat::length_squared() const {
 	return dot(*this);
 }
 
-void Quat::operator+=(const Quat &q) {
-	x += q.x;
-	y += q.y;
-	z += q.z;
-	w += q.w;
+void Quat::operator+=(const Quat &p_q) {
+	x += p_q.x;
+	y += p_q.y;
+	z += p_q.z;
+	w += p_q.w;
 }
 
-void Quat::operator-=(const Quat &q) {
-	x -= q.x;
-	y -= q.y;
-	z -= q.z;
-	w -= q.w;
+void Quat::operator-=(const Quat &p_q) {
+	x -= p_q.x;
+	y -= p_q.y;
+	z -= p_q.z;
+	w -= p_q.w;
 }
 
 void Quat::operator*=(const real_t &s) {

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -118,8 +118,8 @@ Vector2 Vector2::posmodv(const Vector2 &p_modv) const {
 	return Vector2(Math::fposmod(x, p_modv.x), Math::fposmod(y, p_modv.y));
 }
 
-Vector2 Vector2::project(const Vector2 &p_b) const {
-	return p_b * (dot(p_b) / p_b.length_squared());
+Vector2 Vector2::project(const Vector2 &p_to) const {
+	return p_to * (dot(p_to) / p_to.length_squared());
 }
 
 Vector2 Vector2::snapped(const Vector2 &p_by) const {
@@ -139,13 +139,13 @@ Vector2 Vector2::clamped(real_t p_len) const {
 	return v;
 }
 
-Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_t) const {
+Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_weight) const {
 	Vector2 p0 = p_pre_a;
 	Vector2 p1 = *this;
 	Vector2 p2 = p_b;
 	Vector2 p3 = p_post_b;
 
-	real_t t = p_t;
+	real_t t = p_weight;
 	real_t t2 = t * t;
 	real_t t3 = t2 * t;
 

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -77,21 +77,21 @@ struct Vector2 {
 	real_t distance_squared_to(const Vector2 &p_vector2) const;
 	real_t angle_to(const Vector2 &p_vector2) const;
 	real_t angle_to_point(const Vector2 &p_vector2) const;
-	_FORCE_INLINE_ Vector2 direction_to(const Vector2 &p_b) const;
+	_FORCE_INLINE_ Vector2 direction_to(const Vector2 &p_to) const;
 
 	real_t dot(const Vector2 &p_other) const;
 	real_t cross(const Vector2 &p_other) const;
 	Vector2 posmod(const real_t p_mod) const;
 	Vector2 posmodv(const Vector2 &p_modv) const;
-	Vector2 project(const Vector2 &p_b) const;
+	Vector2 project(const Vector2 &p_to) const;
 
 	Vector2 plane_project(real_t p_d, const Vector2 &p_vec) const;
 
 	Vector2 clamped(real_t p_len) const;
 
-	_FORCE_INLINE_ Vector2 lerp(const Vector2 &p_b, real_t p_t) const;
-	_FORCE_INLINE_ Vector2 slerp(const Vector2 &p_b, real_t p_t) const;
-	Vector2 cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_t) const;
+	_FORCE_INLINE_ Vector2 lerp(const Vector2 &p_to, real_t p_weight) const;
+	_FORCE_INLINE_ Vector2 slerp(const Vector2 &p_to, real_t p_weight) const;
+	Vector2 cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_weight) const;
 	Vector2 move_toward(const Vector2 &p_to, const real_t p_delta) const;
 
 	Vector2 slide(const Vector2 &p_normal) const;
@@ -230,25 +230,25 @@ _FORCE_INLINE_ bool Vector2::operator!=(const Vector2 &p_vec2) const {
 	return x != p_vec2.x || y != p_vec2.y;
 }
 
-Vector2 Vector2::lerp(const Vector2 &p_b, real_t p_t) const {
+Vector2 Vector2::lerp(const Vector2 &p_to, real_t p_weight) const {
 	Vector2 res = *this;
 
-	res.x += (p_t * (p_b.x - x));
-	res.y += (p_t * (p_b.y - y));
+	res.x += (p_weight * (p_to.x - x));
+	res.y += (p_weight * (p_to.y - y));
 
 	return res;
 }
 
-Vector2 Vector2::slerp(const Vector2 &p_b, real_t p_t) const {
+Vector2 Vector2::slerp(const Vector2 &p_to, real_t p_weight) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Vector2(), "The start Vector2 must be normalized.");
 #endif
-	real_t theta = angle_to(p_b);
-	return rotated(theta * p_t);
+	real_t theta = angle_to(p_to);
+	return rotated(theta * p_weight);
 }
 
-Vector2 Vector2::direction_to(const Vector2 &p_b) const {
-	Vector2 ret(p_b.x - x, p_b.y - y);
+Vector2 Vector2::direction_to(const Vector2 &p_to) const {
+	Vector2 ret(p_to.x - x, p_to.y - y);
 	ret.normalize();
 	return ret;
 }

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -72,7 +72,7 @@ Vector3 Vector3::snapped(Vector3 p_val) const {
 	return v;
 }
 
-Vector3 Vector3::cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_t) const {
+Vector3 Vector3::cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const {
 	Vector3 p0 = p_pre_a;
 	Vector3 p1 = *this;
 	Vector3 p2 = p_b;
@@ -93,7 +93,7 @@ Vector3 Vector3::cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, 
 		}
 	}
 
-	real_t t = p_t;
+	real_t t = p_weight;
 	real_t t2 = t * t;
 	real_t t3 = t2 * t;
 
@@ -105,13 +105,13 @@ Vector3 Vector3::cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, 
 	return out;
 }
 
-Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_t) const {
+Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const {
 	Vector3 p0 = p_pre_a;
 	Vector3 p1 = *this;
 	Vector3 p2 = p_b;
 	Vector3 p3 = p_post_b;
 
-	real_t t = p_t;
+	real_t t = p_weight;
 	real_t t2 = t * t;
 	real_t t3 = t2 * t;
 

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -86,10 +86,10 @@ struct Vector3 {
 
 	/* Static Methods between 2 vector3s */
 
-	_FORCE_INLINE_ Vector3 lerp(const Vector3 &p_b, real_t p_t) const;
-	_FORCE_INLINE_ Vector3 slerp(const Vector3 &p_b, real_t p_t) const;
-	Vector3 cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_t) const;
-	Vector3 cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_t) const;
+	_FORCE_INLINE_ Vector3 lerp(const Vector3 &p_to, real_t p_weight) const;
+	_FORCE_INLINE_ Vector3 slerp(const Vector3 &p_to, real_t p_weight) const;
+	Vector3 cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const;
+	Vector3 cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const;
 	Vector3 move_toward(const Vector3 &p_to, const real_t p_delta) const;
 
 	_FORCE_INLINE_ Vector3 cross(const Vector3 &p_b) const;
@@ -103,15 +103,15 @@ struct Vector3 {
 	_FORCE_INLINE_ Vector3 ceil() const;
 	_FORCE_INLINE_ Vector3 round() const;
 
-	_FORCE_INLINE_ real_t distance_to(const Vector3 &p_b) const;
-	_FORCE_INLINE_ real_t distance_squared_to(const Vector3 &p_b) const;
+	_FORCE_INLINE_ real_t distance_to(const Vector3 &p_to) const;
+	_FORCE_INLINE_ real_t distance_squared_to(const Vector3 &p_to) const;
 
 	_FORCE_INLINE_ Vector3 posmod(const real_t p_mod) const;
 	_FORCE_INLINE_ Vector3 posmodv(const Vector3 &p_modv) const;
-	_FORCE_INLINE_ Vector3 project(const Vector3 &p_b) const;
+	_FORCE_INLINE_ Vector3 project(const Vector3 &p_to) const;
 
-	_FORCE_INLINE_ real_t angle_to(const Vector3 &p_b) const;
-	_FORCE_INLINE_ Vector3 direction_to(const Vector3 &p_b) const;
+	_FORCE_INLINE_ real_t angle_to(const Vector3 &p_to) const;
+	_FORCE_INLINE_ Vector3 direction_to(const Vector3 &p_to) const;
 
 	_FORCE_INLINE_ Vector3 slide(const Vector3 &p_normal) const;
 	_FORCE_INLINE_ Vector3 bounce(const Vector3 &p_normal) const;
@@ -195,24 +195,24 @@ Vector3 Vector3::round() const {
 	return Vector3(Math::round(x), Math::round(y), Math::round(z));
 }
 
-Vector3 Vector3::lerp(const Vector3 &p_b, real_t p_t) const {
+Vector3 Vector3::lerp(const Vector3 &p_to, real_t p_weight) const {
 	return Vector3(
-			x + (p_t * (p_b.x - x)),
-			y + (p_t * (p_b.y - y)),
-			z + (p_t * (p_b.z - z)));
+			x + (p_weight * (p_to.x - x)),
+			y + (p_weight * (p_to.y - y)),
+			z + (p_weight * (p_to.z - z)));
 }
 
-Vector3 Vector3::slerp(const Vector3 &p_b, real_t p_t) const {
-	real_t theta = angle_to(p_b);
-	return rotated(cross(p_b).normalized(), theta * p_t);
+Vector3 Vector3::slerp(const Vector3 &p_to, real_t p_weight) const {
+	real_t theta = angle_to(p_to);
+	return rotated(cross(p_to).normalized(), theta * p_weight);
 }
 
-real_t Vector3::distance_to(const Vector3 &p_b) const {
-	return (p_b - *this).length();
+real_t Vector3::distance_to(const Vector3 &p_to) const {
+	return (p_to - *this).length();
 }
 
-real_t Vector3::distance_squared_to(const Vector3 &p_b) const {
-	return (p_b - *this).length_squared();
+real_t Vector3::distance_squared_to(const Vector3 &p_to) const {
+	return (p_to - *this).length_squared();
 }
 
 Vector3 Vector3::posmod(const real_t p_mod) const {
@@ -223,16 +223,16 @@ Vector3 Vector3::posmodv(const Vector3 &p_modv) const {
 	return Vector3(Math::fposmod(x, p_modv.x), Math::fposmod(y, p_modv.y), Math::fposmod(z, p_modv.z));
 }
 
-Vector3 Vector3::project(const Vector3 &p_b) const {
-	return p_b * (dot(p_b) / p_b.length_squared());
+Vector3 Vector3::project(const Vector3 &p_to) const {
+	return p_to * (dot(p_to) / p_to.length_squared());
 }
 
-real_t Vector3::angle_to(const Vector3 &p_b) const {
-	return Math::atan2(cross(p_b).length(), dot(p_b));
+real_t Vector3::angle_to(const Vector3 &p_to) const {
+	return Math::atan2(cross(p_to).length(), dot(p_to));
 }
 
-Vector3 Vector3::direction_to(const Vector3 &p_b) const {
-	Vector3 ret(p_b.x - x, p_b.y - y, p_b.z - z);
+Vector3 Vector3::direction_to(const Vector3 &p_to) const {
+	Vector3 ret(p_to.x - x, p_to.y - y, p_to.z - z);
 	ret.normalize();
 	return ret;
 }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -987,9 +987,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2, posmod, sarray("mod"), varray());
 	bind_method(Vector2, posmodv, sarray("modv"), varray());
 	bind_method(Vector2, project, sarray("b"), varray());
-	bind_method(Vector2, lerp, sarray("with", "t"), varray());
-	bind_method(Vector2, slerp, sarray("with", "t"), varray());
-	bind_method(Vector2, cubic_interpolate, sarray("b", "pre_a", "post_b", "t"), varray());
+	bind_method(Vector2, lerp, sarray("to", "weight"), varray());
+	bind_method(Vector2, slerp, sarray("to", "weight"), varray());
+	bind_method(Vector2, cubic_interpolate, sarray("b", "pre_a", "post_b", "weight"), varray());
 	bind_method(Vector2, move_toward, sarray("to", "delta"), varray());
 	bind_method(Vector2, rotated, sarray("phi"), varray());
 	bind_method(Vector2, tangent, sarray(), varray());
@@ -1060,9 +1060,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3, inverse, sarray(), varray());
 	bind_method(Vector3, snapped, sarray("by"), varray());
 	bind_method(Vector3, rotated, sarray("by_axis", "phi"), varray());
-	bind_method(Vector3, lerp, sarray("b", "t"), varray());
-	bind_method(Vector3, slerp, sarray("b", "t"), varray());
-	bind_method(Vector3, cubic_interpolate, sarray("b", "pre_a", "post_b", "t"), varray());
+	bind_method(Vector3, lerp, sarray("to", "weight"), varray());
+	bind_method(Vector3, slerp, sarray("to", "weight"), varray());
+	bind_method(Vector3, cubic_interpolate, sarray("b", "pre_a", "post_b", "weight"), varray());
 	bind_method(Vector3, move_toward, sarray("to", "delta"), varray());
 	bind_method(Vector3, dot, sarray("with"), varray());
 	bind_method(Vector3, cross, sarray("with"), varray());
@@ -1109,9 +1109,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(Quat, is_equal_approx, sarray("to"), varray());
 	bind_method(Quat, inverse, sarray(), varray());
 	bind_method(Quat, dot, sarray("with"), varray());
-	bind_method(Quat, slerp, sarray("b", "t"), varray());
-	bind_method(Quat, slerpni, sarray("b", "t"), varray());
-	bind_method(Quat, cubic_slerp, sarray("b", "pre_a", "post_b", "t"), varray());
+	bind_method(Quat, slerp, sarray("to", "weight"), varray());
+	bind_method(Quat, slerpni, sarray("to", "weight"), varray());
+	bind_method(Quat, cubic_slerp, sarray("b", "pre_a", "post_b", "weight"), varray());
 	bind_method(Quat, get_euler, sarray(), varray());
 
 	// FIXME: Quat is atomic, this should be done via construcror
@@ -1128,7 +1128,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Color, to_rgba64, sarray(), varray());
 
 	bind_method(Color, inverted, sarray(), varray());
-	bind_method(Color, lerp, sarray("b", "t"), varray());
+	bind_method(Color, lerp, sarray("to", "weight"), varray());
 	bind_method(Color, lightened, sarray("amount"), varray());
 	bind_method(Color, darkened, sarray("amount"), varray());
 	bind_method(Color, to_html, sarray("with_alpha"), varray(true));
@@ -1195,7 +1195,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform2D, translated, sarray("offset"), varray());
 	bind_method(Transform2D, basis_xform, sarray("v"), varray());
 	bind_method(Transform2D, basis_xform_inv, sarray("v"), varray());
-	bind_method(Transform2D, interpolate_with, sarray("xform", "t"), varray());
+	bind_method(Transform2D, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform2D, is_equal_approx, sarray("xform"), varray());
 
 	/* Basis */
@@ -1212,7 +1212,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Basis, tdoty, sarray("with"), varray());
 	bind_method(Basis, tdotz, sarray("with"), varray());
 	bind_method(Basis, get_orthogonal_index, sarray(), varray());
-	bind_method(Basis, slerp, sarray("b", "t"), varray());
+	bind_method(Basis, slerp, sarray("to", "weight"), varray());
 	bind_method(Basis, is_equal_approx, sarray("b"), varray());
 	bind_method(Basis, get_rotation_quat, sarray(), varray());
 

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -201,9 +201,9 @@
 		<method name="slerp">
 			<return type="Basis">
 			</return>
-			<argument index="0" name="b" type="Basis">
+			<argument index="0" name="to" type="Basis">
 			</argument>
-			<argument index="1" name="t" type="float">
+			<argument index="1" name="weight" type="float">
 			</argument>
 			<description>
 				Assuming that the matrix is a proper rotation matrix, slerp performs a spherical-linear interpolation with another rotation matrix.

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -164,9 +164,9 @@
 		<method name="lerp">
 			<return type="Color">
 			</return>
-			<argument index="0" name="b" type="Color">
+			<argument index="0" name="to" type="Color">
 			</argument>
-			<argument index="1" name="t" type="float">
+			<argument index="1" name="weight" type="float">
 			</argument>
 			<description>
 				Returns the linear interpolation with another color. The interpolation factor [code]t[/code] is between 0 and 1.

--- a/doc/classes/Quat.xml
+++ b/doc/classes/Quat.xml
@@ -92,10 +92,10 @@
 			</argument>
 			<argument index="2" name="post_b" type="Quat">
 			</argument>
-			<argument index="3" name="t" type="float">
+			<argument index="3" name="weight" type="float">
 			</argument>
 			<description>
-				Performs a cubic spherical interpolation between quaternions [code]preA[/code], this vector, [code]b[/code], and [code]postB[/code], by the given amount [code]t[/code].
+				Performs a cubic spherical interpolation between quaternions [code]pre_a[/code], this vector, [code]b[/code], and [code]post_b[/code], by the given amount [code]weight[/code].
 			</description>
 		</method>
 		<method name="dot">
@@ -261,9 +261,9 @@
 		<method name="slerp">
 			<return type="Quat">
 			</return>
-			<argument index="0" name="b" type="Quat">
+			<argument index="0" name="to" type="Quat">
 			</argument>
-			<argument index="1" name="t" type="float">
+			<argument index="1" name="weight" type="float">
 			</argument>
 			<description>
 				Returns the result of the spherical linear interpolation between this quaternion and [code]to[/code] by amount [code]weight[/code].
@@ -273,9 +273,9 @@
 		<method name="slerpni">
 			<return type="Quat">
 			</return>
-			<argument index="0" name="b" type="Quat">
+			<argument index="0" name="to" type="Quat">
 			</argument>
-			<argument index="1" name="t" type="float">
+			<argument index="1" name="weight" type="float">
 			</argument>
 			<description>
 				Returns the result of the spherical linear interpolation between this quaternion and [code]to[/code] by amount [code]weight[/code], but without checking if the rotation path is not bigger than 90 degrees.

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -107,10 +107,10 @@
 			</return>
 			<argument index="0" name="xform" type="Transform2D">
 			</argument>
-			<argument index="1" name="t" type="float">
+			<argument index="1" name="weight" type="float">
 			</argument>
 			<description>
-				Returns a transform interpolated between this transform and another by a given weight (on the range of 0.0 to 1.0).
+				Returns a transform interpolated between this transform and another by a given [code]weight[/code] (on the range of 0.0 to 1.0).
 			</description>
 		</method>
 		<method name="inverse">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -137,10 +137,10 @@
 			</argument>
 			<argument index="2" name="post_b" type="Vector2">
 			</argument>
-			<argument index="3" name="t" type="float">
+			<argument index="3" name="weight" type="float">
 			</argument>
 			<description>
-				Cubically interpolates between this vector and [code]b[/code] using [code]pre_a[/code] and [code]post_b[/code] as handles, and returns the result at position [code]t[/code]. [code]t[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Cubically interpolates between this vector and [code]b[/code] using [code]pre_a[/code] and [code]post_b[/code] as handles, and returns the result at position [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="direction_to">
@@ -224,9 +224,9 @@
 		<method name="lerp">
 			<return type="Vector2">
 			</return>
-			<argument index="0" name="with" type="Vector2">
+			<argument index="0" name="to" type="Vector2">
 			</argument>
-			<argument index="1" name="t" type="float">
+			<argument index="1" name="weight" type="float">
 			</argument>
 			<description>
 				Returns the result of the linear interpolation between this vector and [code]b[/code] by amount [code]t[/code]. [code]t[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
@@ -452,9 +452,9 @@
 		<method name="slerp">
 			<return type="Vector2">
 			</return>
-			<argument index="0" name="with" type="Vector2">
+			<argument index="0" name="to" type="Vector2">
 			</argument>
-			<argument index="1" name="t" type="float">
+			<argument index="1" name="weight" type="float">
 			</argument>
 			<description>
 				Returns the result of spherical linear interpolation between this vector and [code]b[/code], by amount [code]t[/code]. [code]t[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -105,10 +105,10 @@
 			</argument>
 			<argument index="2" name="post_b" type="Vector3">
 			</argument>
-			<argument index="3" name="t" type="float">
+			<argument index="3" name="weight" type="float">
 			</argument>
 			<description>
-				Performs a cubic interpolation between vectors [code]pre_a[/code], [code]a[/code], [code]b[/code], [code]post_b[/code] ([code]a[/code] is current), by the given amount [code]t[/code]. [code]t[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Performs a cubic interpolation between vectors [code]pre_a[/code], [code]a[/code], [code]b[/code], [code]post_b[/code] ([code]a[/code] is current), by the given amount [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="direction_to">
@@ -199,12 +199,12 @@
 		<method name="lerp">
 			<return type="Vector3">
 			</return>
-			<argument index="0" name="b" type="Vector3">
+			<argument index="0" name="to" type="Vector3">
 			</argument>
-			<argument index="1" name="t" type="float">
+			<argument index="1" name="weight" type="float">
 			</argument>
 			<description>
-				Returns the result of the linear interpolation between this vector and [code]b[/code] by amount [code]t[/code]. [code]t[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Returns the result of the linear interpolation between this vector and [code]b[/code] by amount [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="max_axis">
@@ -468,9 +468,9 @@
 		<method name="slerp">
 			<return type="Vector3">
 			</return>
-			<argument index="0" name="b" type="Vector3">
+			<argument index="0" name="to" type="Vector3">
 			</argument>
-			<argument index="1" name="t" type="float">
+			<argument index="1" name="weight" type="float">
 			</argument>
 			<description>
 				Returns the result of spherical linear interpolation between this vector and [code]b[/code], by amount [code]t[/code]. [code]t[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quat.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quat.cs
@@ -120,13 +120,13 @@ namespace Godot
         /// <param name="b">The destination quaternion.</param>
         /// <param name="preA">A quaternion before this quaternion.</param>
         /// <param name="postB">A quaternion after `b`.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The interpolated quaternion.</returns>
-        public Quat CubicSlerp(Quat b, Quat preA, Quat postB, real_t t)
+        public Quat CubicSlerp(Quat b, Quat preA, Quat postB, real_t weight)
         {
-            real_t t2 = (1.0f - t) * t * 2f;
-            Quat sp = Slerp(b, t);
-            Quat sq = preA.Slerpni(postB, t);
+            real_t t2 = (1.0f - weight) * weight * 2f;
+            Quat sp = Slerp(b, weight);
+            Quat sq = preA.Slerpni(postB, weight);
             return sp.Slerpni(sq, t2);
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -194,15 +194,16 @@ namespace Godot
         /// <param name="b">The destination vector.</param>
         /// <param name="preA">A vector before this vector.</param>
         /// <param name="postB">A vector after `b`.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The interpolated vector.</returns>
-        public Vector2 CubicInterpolate(Vector2 b, Vector2 preA, Vector2 postB, real_t t)
+        public Vector2 CubicInterpolate(Vector2 b, Vector2 preA, Vector2 postB, real_t weight)
         {
             Vector2 p0 = preA;
             Vector2 p1 = this;
             Vector2 p2 = b;
             Vector2 p3 = postB;
 
+            real_t t = weight;
             real_t t2 = t * t;
             real_t t3 = t2 * t;
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -161,15 +161,16 @@ namespace Godot
         /// <param name="b">The destination vector.</param>
         /// <param name="preA">A vector before this vector.</param>
         /// <param name="postB">A vector after `b`.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The interpolated vector.</returns>
-        public Vector3 CubicInterpolate(Vector3 b, Vector3 preA, Vector3 postB, real_t t)
+        public Vector3 CubicInterpolate(Vector3 b, Vector3 preA, Vector3 postB, real_t weight)
         {
             Vector3 p0 = preA;
             Vector3 p1 = this;
             Vector3 p2 = b;
             Vector3 p3 = postB;
 
+            real_t t = weight;
             real_t t2 = t * t;
             real_t t3 = t2 * t;
 


### PR DESCRIPTION
@SubSage noticed an inconsistency in the docs (which is [my fault](https://github.com/godotengine/godot/pull/40501/files#diff-e85a1e2bd4647b80b25410bc48f0f1cf9f0a9324cd8e9c5838a9a8a62d195bc2R162)...)

![Screenshot from 2020-12-07 04-47-33](https://user-images.githubusercontent.com/1646875/101336243-3ac93e00-3848-11eb-843e-e1c674fd7b32.png)

This PR fixes this, and a bit more.

* Change some parameter names to `to` and `weight`, mostly for (s)lerp.

* Add the missing `p_` prefix for many of the internal parameter names.

* Ensure some of the exposed names and internal names match except that the exposed names don't start with `p_`.