### PR TITLE
Remove ChainTip copy constructor

### DIFF
--- a/scene/3d/skeleton_ik_3d.h
+++ b/scene/3d/skeleton_ik_3d.h
@@ -76,10 +76,6 @@ class FabrikInverseKinematic {
 		ChainTip(ChainItem *p_chain_item, const EndEffector *p_end_effector) :
 				chain_item(p_chain_item),
 				end_effector(p_end_effector) {}
-
-		ChainTip(const ChainTip &p_other_ct) :
-				chain_item(p_other_ct.chain_item),
-				end_effector(p_other_ct.end_effector) {}
 	};
 
 	struct Chain {


### PR DESCRIPTION
As identified by [LGTM](https://lgtm.com/projects/g/godotengine/godot/?mode=tree&lang=cpp&ruleFocus=2165180572), the `SkeletonIK` `ChanTip` `struct` has a non-default copy constructor, but no matching copy assignment operator. Since the non-default copy constructor does nothing a compiler created default copy constructor would do, this PR deletes the non-default copy constructor.