### PR TITLE
[3.2] Remove ChainTip copy constructor

### DIFF
--- a/scene/animation/skeleton_ik.h
+++ b/scene/animation/skeleton_ik.h
@@ -84,10 +84,6 @@ class FabrikInverseKinematic {
 		ChainTip(ChainItem *p_chain_item, const EndEffector *p_end_effector) :
 				chain_item(p_chain_item),
 				end_effector(p_end_effector) {}
-
-		ChainTip(const ChainTip &p_other_ct) :
-				chain_item(p_other_ct.chain_item),
-				end_effector(p_other_ct.end_effector) {}
 	};
 
 	struct Chain {


### PR DESCRIPTION
3.2 version of #44166.
