### PR TITLE
Add support for low-end 3D rendering.

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -1456,6 +1456,8 @@ private:
 		float weight;
 	};
 
+	bool low_end = false;
+
 public:
 	/* SHADOW ATLAS API */
 
@@ -1951,6 +1953,8 @@ public:
 	int get_max_directional_lights() const;
 
 	void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir);
+
+	bool is_low_end() const;
 
 	RendererSceneRenderRD(RendererStorageRD *p_storage);
 	~RendererSceneRenderRD();

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -46,6 +46,7 @@ class ShaderRD {
 	//versions
 	CharString general_defines;
 	Vector<CharString> variant_defines;
+	Vector<bool> variants_enabled;
 
 	struct Version {
 		CharString uniforms;
@@ -109,6 +110,7 @@ public:
 
 	_FORCE_INLINE_ RID version_get_shader(RID p_version, int p_variant) {
 		ERR_FAIL_INDEX_V(p_variant, variant_defines.size(), RID());
+		ERR_FAIL_COND_V(!variants_enabled[p_variant], RID());
 
 		Version *version = version_owner.getornull(p_version);
 		ERR_FAIL_COND_V(!version, RID());
@@ -127,6 +129,9 @@ public:
 	bool version_is_valid(RID p_version);
 
 	bool version_free(RID p_version);
+
+	void set_variant_enabled(int p_variant, bool p_enabled);
+	bool is_variant_enabled(int p_variant) const;
 
 	void initialize(const Vector<String> &p_variant_defines, const String &p_general_defines = "");
 	virtual ~ShaderRD();

--- a/servers/rendering/renderer_rd/shaders/SCsub
+++ b/servers/rendering/renderer_rd/shaders/SCsub
@@ -11,7 +11,7 @@ if "RD_GLSL" in env["BUILDERS"]:
     env.RD_GLSL("cubemap_roughness.glsl")
     env.RD_GLSL("cubemap_downsampler.glsl")
     env.RD_GLSL("cubemap_filter.glsl")
-    env.RD_GLSL("scene_high_end.glsl")
+    env.RD_GLSL("scene_forward.glsl")
     env.RD_GLSL("sky.glsl")
     env.RD_GLSL("tonemap.glsl")
     env.RD_GLSL("cube_to_dp.glsl")

--- a/servers/rendering/renderer_rd/shaders/scene_forward_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_inc.glsl
@@ -204,6 +204,8 @@ layout(set = 0, binding = 19, std430) restrict readonly buffer GlobalVariableDat
 }
 global_variables;
 
+#ifndef LOW_END_MODE
+
 struct SDFGIProbeCascadeData {
 	vec3 position;
 	float to_probe;
@@ -239,6 +241,8 @@ layout(set = 0, binding = 20, std140) uniform SDFGI {
 }
 sdfgi;
 
+#endif //LOW_END_MODE
+
 // decal atlas
 
 /* Set 1, Radiance */
@@ -255,20 +259,22 @@ layout(set = 1, binding = 0) uniform textureCube radiance_cubemap;
 
 /* Set 2, Reflection and Shadow Atlases (view dependent) */
 
-layout(set = 2, binding = 0) uniform textureCubeArray reflection_atlas;
+layout(set = 1, binding = 1) uniform textureCubeArray reflection_atlas;
 
-layout(set = 2, binding = 1) uniform texture2D shadow_atlas;
+layout(set = 1, binding = 2) uniform texture2D shadow_atlas;
 
-layout(set = 2, binding = 2) uniform texture3D gi_probe_textures[MAX_GI_PROBES];
+#ifndef LOW_END_MODE
+layout(set = 1, binding = 3) uniform texture3D gi_probe_textures[MAX_GI_PROBES];
+#endif
 
 /* Set 3, Render Buffers */
 
 #ifdef MODE_RENDER_SDF
 
-layout(r16ui, set = 3, binding = 0) uniform restrict writeonly uimage3D albedo_volume_grid;
-layout(r32ui, set = 3, binding = 1) uniform restrict writeonly uimage3D emission_grid;
-layout(r32ui, set = 3, binding = 2) uniform restrict writeonly uimage3D emission_aniso_grid;
-layout(r32ui, set = 3, binding = 3) uniform restrict uimage3D geom_facing_grid;
+layout(r16ui, set = 1, binding = 4) uniform restrict writeonly uimage3D albedo_volume_grid;
+layout(r32ui, set = 1, binding = 5) uniform restrict writeonly uimage3D emission_grid;
+layout(r32ui, set = 1, binding = 6) uniform restrict writeonly uimage3D emission_aniso_grid;
+layout(r32ui, set = 1, binding = 7) uniform restrict uimage3D geom_facing_grid;
 
 //still need to be present for shaders that use it, so remap them to something
 #define depth_buffer shadow_atlas
@@ -277,14 +283,17 @@ layout(r32ui, set = 3, binding = 3) uniform restrict uimage3D geom_facing_grid;
 
 #else
 
-layout(set = 3, binding = 0) uniform texture2D depth_buffer;
-layout(set = 3, binding = 1) uniform texture2D color_buffer;
-layout(set = 3, binding = 2) uniform texture2D normal_roughness_buffer;
-layout(set = 3, binding = 4) uniform texture2D ao_buffer;
-layout(set = 3, binding = 5) uniform texture2D ambient_buffer;
-layout(set = 3, binding = 6) uniform texture2D reflection_buffer;
-layout(set = 3, binding = 7) uniform texture2DArray sdfgi_lightprobe_texture;
-layout(set = 3, binding = 8) uniform texture3D sdfgi_occlusion_cascades;
+layout(set = 1, binding = 4) uniform texture2D depth_buffer;
+layout(set = 1, binding = 5) uniform texture2D color_buffer;
+
+#ifndef LOW_END_MODE
+
+layout(set = 1, binding = 6) uniform texture2D normal_roughness_buffer;
+layout(set = 1, binding = 7) uniform texture2D ao_buffer;
+layout(set = 1, binding = 8) uniform texture2D ambient_buffer;
+layout(set = 1, binding = 9) uniform texture2D reflection_buffer;
+layout(set = 1, binding = 10) uniform texture2DArray sdfgi_lightprobe_texture;
+layout(set = 1, binding = 11) uniform texture3D sdfgi_occlusion_cascades;
 
 struct GIProbeData {
 	mat4 xform;
@@ -302,18 +311,20 @@ struct GIProbeData {
 	uint mipmaps;
 };
 
-layout(set = 3, binding = 9, std140) uniform GIProbes {
+layout(set = 1, binding = 12, std140) uniform GIProbes {
 	GIProbeData data[MAX_GI_PROBES];
 }
 gi_probes;
 
-layout(set = 3, binding = 10) uniform texture3D volumetric_fog_texture;
+layout(set = 1, binding = 13) uniform texture3D volumetric_fog_texture;
+
+#endif // LOW_END_MODE
 
 #endif
 
 /* Set 4 Skeleton & Instancing (Multimesh) */
 
-layout(set = 4, binding = 0, std430) restrict readonly buffer Transforms {
+layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {
 	vec4 data[];
 }
 transforms;

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -260,6 +260,8 @@ public:
 
 	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) = 0;
 
+	virtual bool is_low_end() const = 0;
+
 	virtual void update() = 0;
 	virtual ~RendererSceneRender() {}
 };

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2268,6 +2268,9 @@ RenderingServer::RenderingServer() {
 
 	GLOBAL_DEF("rendering/quality/2d_shadow_atlas/size", 2048);
 
+	GLOBAL_DEF("rendering/quality/rd_renderer/use_low_end_renderer", false);
+	GLOBAL_DEF("rendering/quality/rd_renderer/use_low_end_renderer.mobile", true);
+
 	GLOBAL_DEF("rendering/quality/shadow_atlas/size", 4096);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384"));


### PR DESCRIPTION
-Reduce number of uniform sets from 6 to 4.
-Add a low end mode (default false, but true if running in mobile).
-Remove features in low end mode, in order to reduce the number of texture units fit to 16.

