### PR TITLE
Add PluginScript support for global class naming/icon path

### DIFF
--- a/modules/gdnative/include/pluginscript/godot_pluginscript.h
+++ b/modules/gdnative/include/pluginscript/godot_pluginscript.h
@@ -72,6 +72,7 @@ typedef struct {
 	godot_string_name name;
 	godot_bool is_tool;
 	godot_string_name base;
+	godot_string icon_path;
 
 	// Member lines format: {<string>: <int>}
 	godot_dictionary member_lines;

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -398,6 +398,32 @@ void PluginScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool 
 #endif
 }
 
+bool PluginScriptLanguage::handles_global_class_type(const String &p_type) const {
+	return p_type == "PluginScript";
+}
+
+String PluginScriptLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const {
+	if (!p_path.empty()) {
+		Ref<PluginScript> script = ResourceLoader::load(p_path, "PluginScript");
+		if (script.is_valid()) {
+			if (r_base_type) {
+				*r_base_type = script->get_instance_base_type();
+			}
+			if (r_icon_path) {
+				*r_icon_path = script->get_script_class_icon_path();
+			}
+			return script->get_script_class_name();
+		}
+		if (r_base_type) {
+			*r_base_type = String();
+		}
+		if (r_icon_path) {
+			*r_icon_path = String();
+		}
+	}
+	return String();
+}
+
 void PluginScriptLanguage::lock() {
 	_lock.lock();
 }

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -122,6 +122,11 @@ public:
 
 	virtual void frame();
 
+	/* GLOBAL CLASSES */
+
+	virtual bool handles_global_class_type(const String &p_type) const;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr) const;
+
 	void lock();
 	void unlock();
 

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -302,6 +302,7 @@ Error PluginScript::reload(bool p_keep_state) {
 	_data = manifest.data;
 	_name = *(StringName *)&manifest.name;
 	_tool = manifest.is_tool;
+	_icon_path = *(String *)&manifest.icon_path;
 
 	Dictionary *members = (Dictionary *)&manifest.member_lines;
 	for (const Variant *key = members->next(); key != nullptr; key = members->next(key)) {

--- a/modules/gdnative/pluginscript/pluginscript_script.h
+++ b/modules/gdnative/pluginscript/pluginscript_script.h
@@ -69,6 +69,7 @@ private:
 	String _source;
 	String _path;
 	StringName _name;
+	String _icon_path;
 
 protected:
 	static void _bind_methods();
@@ -84,6 +85,14 @@ protected:
 	virtual void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder) override;
 #endif
 public:
+	String get_script_class_name() const {
+		return _name;
+	}
+
+	String get_script_class_icon_path() const {
+		return _icon_path;
+	}
+
 	virtual bool can_instance() const override;
 
 	virtual Ref<Script> get_base_script() const override; //for script inheritance


### PR DESCRIPTION
This PR can easily be cherry-picked for 3.2 branch, however I don't think we should do this given it modifies the Pluginscript's `godot_pluginscript_script_manifest` structure (and hence break API compatibility)