### PR TITLE
Allow PluginScript to customize language's can_inherit_from_file attribute

### DIFF
--- a/modules/gdnative/include/pluginscript/godot_pluginscript.h
+++ b/modules/gdnative/include/pluginscript/godot_pluginscript.h
@@ -127,6 +127,7 @@ typedef struct {
 	const char **string_delimiters; // nullptr  terminated array
 	godot_bool has_named_classes;
 	godot_bool supports_builtin_mode;
+	godot_bool can_inherit_from_file;
 
 	godot_string (*get_template_source_code)(godot_pluginscript_language_data *p_data, const godot_string *p_class_name, const godot_string *p_base_class_name);
 	godot_bool (*validate)(godot_pluginscript_language_data *p_data, const godot_string *p_script, int *r_line_error, int *r_col_error, godot_string *r_test_error, const godot_string *p_path, godot_packed_string_array *r_functions);

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -142,6 +142,10 @@ bool PluginScriptLanguage::supports_builtin_mode() const {
 	return _desc.supports_builtin_mode;
 }
 
+bool PluginScriptLanguage::can_inherit_from_file() {
+	return _desc.can_inherit_from_file;
+}
+
 int PluginScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 	if (_desc.find_function) {
 		return _desc.find_function(_data, (godot_string *)&p_function, (godot_string *)&p_code);

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -78,7 +78,7 @@ public:
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
 	virtual bool supports_builtin_mode() const;
-	virtual bool can_inherit_from_file() { return true; }
+	virtual bool can_inherit_from_file();
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const;
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptCodeCompletionOption> *r_options, bool &r_force, String &r_call_hint);


### PR DESCRIPTION
`can_inherit_from_file` should be customizable, not sure why it's not already the case ;-)

This change break Pluginscript API so it shouldn't be cherry picked for 3.2