### PR TITLE
Use a size Vector for adjusting the size of Rectangles and Boxes

### DIFF
--- a/doc/classes/BoxMesh.xml
+++ b/doc/classes/BoxMesh.xml
@@ -13,7 +13,7 @@
 	</methods>
 	<members>
 		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3( 2, 2, 2 )">
-			Size of the box mesh.
+			The box's width, height and depth.
 		</member>
 		<member name="subdivide_depth" type="int" setter="set_subdivide_depth" getter="get_subdivide_depth" default="0">
 			Number of extra edge loops inserted along the Z axis.

--- a/doc/classes/BoxShape3D.xml
+++ b/doc/classes/BoxShape3D.xml
@@ -14,8 +14,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3( 1, 1, 1 )">
-			The box's half extents. The width, height and depth of this shape is twice the half extents.
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3( 2, 2, 2 )">
+			The box's width, height and depth.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/RectangleShape2D.xml
+++ b/doc/classes/RectangleShape2D.xml
@@ -13,8 +13,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="extents" type="Vector2" setter="set_extents" getter="get_extents" default="Vector2( 10, 10 )">
-			The rectangle's half extents. The width and height of this shape is twice the half extents.
+		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2( 20, 20 )">
+			The rectangle's width and height.
 		</member>
 	</members>
 	<constants>

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -429,7 +429,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 			CollisionShape3D *colshape = memnew(CollisionShape3D);
 			if (empty_draw_type == "CUBE") {
 				BoxShape3D *boxShape = memnew(BoxShape3D);
-				boxShape->set_extents(Vector3(1, 1, 1));
+				boxShape->set_size(Vector3(2, 2, 2));
 				colshape->set_shape(boxShape);
 				colshape->set_name("BoxShape3D");
 			} else if (empty_draw_type == "SINGLE_ARROW") {

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -3541,7 +3541,7 @@ String CollisionShape3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_g
 	}
 
 	if (Object::cast_to<BoxShape3D>(*s)) {
-		return "Extents";
+		return "Size";
 	}
 
 	if (Object::cast_to<CapsuleShape3D>(*s)) {
@@ -3574,7 +3574,7 @@ Variant CollisionShape3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo
 
 	if (Object::cast_to<BoxShape3D>(*s)) {
 		Ref<BoxShape3D> bs = s;
-		return bs->get_extents();
+		return bs->get_size();
 	}
 
 	if (Object::cast_to<CapsuleShape3D>(*s)) {
@@ -3658,9 +3658,9 @@ void CollisionShape3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_i
 			d = 0.001;
 		}
 
-		Vector3 he = bs->get_extents();
-		he[p_idx] = d;
-		bs->set_extents(he);
+		Vector3 he = bs->get_size();
+		he[p_idx] = d * 2;
+		bs->set_size(he);
 	}
 
 	if (Object::cast_to<CapsuleShape3D>(*s)) {
@@ -3737,14 +3737,14 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 	if (Object::cast_to<BoxShape3D>(*s)) {
 		Ref<BoxShape3D> ss = s;
 		if (p_cancel) {
-			ss->set_extents(p_restore);
+			ss->set_size(p_restore);
 			return;
 		}
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Box Shape Extents"));
-		ur->add_do_method(ss.ptr(), "set_extents", ss->get_extents());
-		ur->add_undo_method(ss.ptr(), "set_extents", p_restore);
+		ur->create_action(TTR("Change Box Shape Size"));
+		ur->add_do_method(ss.ptr(), "set_size", ss->get_size());
+		ur->add_undo_method(ss.ptr(), "set_size", p_restore);
 		ur->commit_action();
 	}
 
@@ -3878,8 +3878,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Ref<BoxShape3D> bs = s;
 		Vector<Vector3> lines;
 		AABB aabb;
-		aabb.position = -bs->get_extents();
-		aabb.size = aabb.position * -2;
+		aabb.position = -bs->get_size() / 2;
+		aabb.size = bs->get_size();
 
 		for (int i = 0; i < 12; i++) {
 			Vector3 a, b;
@@ -3892,7 +3892,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 		for (int i = 0; i < 3; i++) {
 			Vector3 ax;
-			ax[i] = bs->get_extents()[i];
+			ax[i] = bs->get_size()[i] / 2;
 			handles.push_back(ax);
 		}
 

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -98,7 +98,7 @@ Variant CollisionShape2DEditor::get_handle_value(int idx) const {
 			Ref<RectangleShape2D> rect = node->get_shape();
 
 			if (idx < 3) {
-				return rect->get_extents().abs();
+				return rect->get_size().abs();
 			}
 
 		} break;
@@ -179,13 +179,13 @@ void CollisionShape2DEditor::set_handle(int idx, Point2 &p_point) {
 			if (idx < 3) {
 				Ref<RectangleShape2D> rect = node->get_shape();
 
-				Vector2 extents = rect->get_extents();
+				Vector2 size = rect->get_size();
 				if (idx == 2) {
-					extents = p_point;
+					size = p_point * 2;
 				} else {
-					extents[idx] = p_point[idx];
+					size[idx] = p_point[idx] * 2;
 				}
-				rect->set_extents(extents.abs());
+				rect->set_size(size.abs());
 
 				canvas_item_editor->update_viewport();
 			}
@@ -279,9 +279,9 @@ void CollisionShape2DEditor::commit_handle(int idx, Variant &p_org) {
 		case RECTANGLE_SHAPE: {
 			Ref<RectangleShape2D> rect = node->get_shape();
 
-			undo_redo->add_do_method(rect.ptr(), "set_extents", rect->get_extents());
+			undo_redo->add_do_method(rect.ptr(), "set_size", rect->get_size());
 			undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-			undo_redo->add_undo_method(rect.ptr(), "set_extents", p_org);
+			undo_redo->add_undo_method(rect.ptr(), "set_size", p_org);
 			undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
 
 		} break;
@@ -493,7 +493,7 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			Ref<RectangleShape2D> shape = node->get_shape();
 
 			handles.resize(3);
-			Vector2 ext = shape->get_extents();
+			Vector2 ext = shape->get_size() / 2;
 			handles.write[0] = Point2(ext.x, 0);
 			handles.write[1] = Point2(0, ext.y);
 			handles.write[2] = Point2(ext.x, ext.y);

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1125,7 +1125,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 
 		int face = 0;
 
-		Vector3 vertex_mul(width * 0.5, height * 0.5, depth * 0.5);
+		Vector3 vertex_mul = size / 2;
 
 		{
 			for (int i = 0; i < 6; i++) {
@@ -1194,55 +1194,25 @@ CSGBrush *CSGBox3D::_build_brush() {
 }
 
 void CSGBox3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_width", "width"), &CSGBox3D::set_width);
-	ClassDB::bind_method(D_METHOD("get_width"), &CSGBox3D::get_width);
-
-	ClassDB::bind_method(D_METHOD("set_height", "height"), &CSGBox3D::set_height);
-	ClassDB::bind_method(D_METHOD("get_height"), &CSGBox3D::get_height);
-
-	ClassDB::bind_method(D_METHOD("set_depth", "depth"), &CSGBox3D::set_depth);
-	ClassDB::bind_method(D_METHOD("get_depth"), &CSGBox3D::get_depth);
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &CSGBox3D::set_size);
+	ClassDB::bind_method(D_METHOD("get_size"), &CSGBox3D::get_size);
 
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &CSGBox3D::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &CSGBox3D::get_material);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width", PROPERTY_HINT_EXP_RANGE, "0.001,1000.0,0.001,or_greater"), "set_width", "get_width");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_EXP_RANGE, "0.001,1000.0,0.001,or_greater"), "set_height", "get_height");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "depth", PROPERTY_HINT_EXP_RANGE, "0.001,1000.0,0.001,or_greater"), "set_depth", "get_depth");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "StandardMaterial3D,ShaderMaterial"), "set_material", "get_material");
 }
 
-void CSGBox3D::set_width(const float p_width) {
-	width = p_width;
+void CSGBox3D::set_size(const Vector3 &p_size) {
+	size = p_size;
 	_make_dirty();
 	update_gizmo();
-	_change_notify("width");
+	_change_notify("size");
 }
 
-float CSGBox3D::get_width() const {
-	return width;
-}
-
-void CSGBox3D::set_height(const float p_height) {
-	height = p_height;
-	_make_dirty();
-	update_gizmo();
-	_change_notify("height");
-}
-
-float CSGBox3D::get_height() const {
-	return height;
-}
-
-void CSGBox3D::set_depth(const float p_depth) {
-	depth = p_depth;
-	_make_dirty();
-	update_gizmo();
-	_change_notify("depth");
-}
-
-float CSGBox3D::get_depth() const {
-	return depth;
+Vector3 CSGBox3D::get_size() const {
+	return size;
 }
 
 void CSGBox3D::set_material(const Ref<Material> &p_material) {
@@ -1253,13 +1223,6 @@ void CSGBox3D::set_material(const Ref<Material> &p_material) {
 
 Ref<Material> CSGBox3D::get_material() const {
 	return material;
-}
-
-CSGBox3D::CSGBox3D() {
-	// defaults
-	width = 2.0;
-	height = 2.0;
-	depth = 2.0;
 }
 
 ///////////////

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -240,27 +240,19 @@ class CSGBox3D : public CSGPrimitive3D {
 	virtual CSGBrush *_build_brush() override;
 
 	Ref<Material> material;
-	float width;
-	float height;
-	float depth;
+	Vector3 size = Vector3(2, 2, 2);
 
 protected:
 	static void _bind_methods();
 
 public:
-	void set_width(const float p_width);
-	float get_width() const;
-
-	void set_height(const float p_height);
-	float get_height() const;
-
-	void set_depth(const float p_depth);
-	float get_depth() const;
+	void set_size(const Vector3 &p_size);
+	Vector3 get_size() const;
 
 	void set_material(const Ref<Material> &p_material);
 	Ref<Material> get_material() const;
 
-	CSGBox3D();
+	CSGBox3D() {}
 };
 
 class CSGCylinder3D : public CSGPrimitive3D {

--- a/modules/csg/doc_classes/CSGBox3D.xml
+++ b/modules/csg/doc_classes/CSGBox3D.xml
@@ -11,17 +11,11 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="depth" type="float" setter="set_depth" getter="get_depth" default="2.0">
-			Depth of the box measured from the center of the box.
-		</member>
-		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
-			Height of the box measured from the center of the box.
-		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The material used to render the box.
 		</member>
-		<member name="width" type="float" setter="set_width" getter="get_width" default="2.0">
-			Width of the box measured from the center of the box.
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3( 2, 2, 2 )">
+			The box's width, height and depth.
 		</member>
 	</members>
 	<constants>

--- a/modules/gdnavigation/navigation_mesh_generator.cpp
+++ b/modules/gdnavigation/navigation_mesh_generator.cpp
@@ -178,7 +178,7 @@ void NavigationMeshGenerator::_parse_geometry(Transform p_accumulated_transform,
 					if (box) {
 						Ref<BoxMesh> box_mesh;
 						box_mesh.instance();
-						box_mesh->set_size(box->get_extents() * 2.0);
+						box_mesh->set_size(box->get_size());
 						mesh = box_mesh;
 					}
 

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -405,5 +405,5 @@ TouchScreenButton::TouchScreenButton() {
 	shape_centered = true;
 	shape_visible = true;
 	unit_rect = Ref<RectangleShape2D>(memnew(RectangleShape2D));
-	unit_rect->set_extents(Vector2(0.5, 0.5));
+	unit_rect->set_size(Vector2(1, 1));
 }

--- a/scene/resources/box_shape_3d.cpp
+++ b/scene/resources/box_shape_3d.cpp
@@ -34,8 +34,8 @@
 Vector<Vector3> BoxShape3D::get_debug_mesh_lines() const {
 	Vector<Vector3> lines;
 	AABB aabb;
-	aabb.position = -get_extents();
-	aabb.size = aabb.position * -2;
+	aabb.position = -size / 2;
+	aabb.size = size;
 
 	for (int i = 0; i < 12; i++) {
 		Vector3 a, b;
@@ -48,33 +48,33 @@ Vector<Vector3> BoxShape3D::get_debug_mesh_lines() const {
 }
 
 real_t BoxShape3D::get_enclosing_radius() const {
-	return extents.length();
+	return size.length() / 2;
 }
 
 void BoxShape3D::_update_shape() {
-	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), extents);
+	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), size / 2);
 	Shape3D::_update_shape();
 }
 
-void BoxShape3D::set_extents(const Vector3 &p_extents) {
-	extents = p_extents;
+void BoxShape3D::set_size(const Vector3 &p_size) {
+	size = p_size;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("extents");
+	_change_notify("size");
 }
 
-Vector3 BoxShape3D::get_extents() const {
-	return extents;
+Vector3 BoxShape3D::get_size() const {
+	return size;
 }
 
 void BoxShape3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_extents", "extents"), &BoxShape3D::set_extents);
-	ClassDB::bind_method(D_METHOD("get_extents"), &BoxShape3D::get_extents);
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &BoxShape3D::set_size);
+	ClassDB::bind_method(D_METHOD("get_size"), &BoxShape3D::get_size);
 
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "extents"), "set_extents", "get_extents");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size"), "set_size", "get_size");
 }
 
 BoxShape3D::BoxShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_BOX)) {
-	set_extents(Vector3(1, 1, 1));
+	set_size(Vector3(2, 2, 2));
 }

--- a/scene/resources/box_shape_3d.h
+++ b/scene/resources/box_shape_3d.h
@@ -35,7 +35,7 @@
 
 class BoxShape3D : public Shape3D {
 	GDCLASS(BoxShape3D, Shape3D);
-	Vector3 extents;
+	Vector3 size;
 
 protected:
 	static void _bind_methods();
@@ -43,8 +43,8 @@ protected:
 	virtual void _update_shape() override;
 
 public:
-	void set_extents(const Vector3 &p_extents);
-	Vector3 get_extents() const;
+	void set_size(const Vector3 &p_size);
+	Vector3 get_size() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;

--- a/scene/resources/rectangle_shape_2d.cpp
+++ b/scene/resources/rectangle_shape_2d.cpp
@@ -33,40 +33,40 @@
 #include "servers/physics_server_2d.h"
 #include "servers/rendering_server.h"
 void RectangleShape2D::_update_shape() {
-	PhysicsServer2D::get_singleton()->shape_set_data(get_rid(), extents);
+	PhysicsServer2D::get_singleton()->shape_set_data(get_rid(), size / 2);
 	emit_changed();
 }
 
-void RectangleShape2D::set_extents(const Vector2 &p_extents) {
-	extents = p_extents;
+void RectangleShape2D::set_size(const Vector2 &p_size) {
+	size = p_size;
 	_update_shape();
 }
 
-Vector2 RectangleShape2D::get_extents() const {
-	return extents;
+Vector2 RectangleShape2D::get_size() const {
+	return size;
 }
 
 void RectangleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
-	RenderingServer::get_singleton()->canvas_item_add_rect(p_to_rid, Rect2(-extents, extents * 2.0), p_color);
+	RenderingServer::get_singleton()->canvas_item_add_rect(p_to_rid, Rect2(-size / 2, size), p_color);
 }
 
 Rect2 RectangleShape2D::get_rect() const {
-	return Rect2(-extents, extents * 2.0);
+	return Rect2(-size / 2, size);
 }
 
 real_t RectangleShape2D::get_enclosing_radius() const {
-	return extents.length();
+	return size.length() / 2;
 }
 
 void RectangleShape2D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_extents", "extents"), &RectangleShape2D::set_extents);
-	ClassDB::bind_method(D_METHOD("get_extents"), &RectangleShape2D::get_extents);
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &RectangleShape2D::set_size);
+	ClassDB::bind_method(D_METHOD("get_size"), &RectangleShape2D::get_size);
 
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "extents"), "set_extents", "get_extents");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), "set_size", "get_size");
 }
 
 RectangleShape2D::RectangleShape2D() :
 		Shape2D(PhysicsServer2D::get_singleton()->rectangle_shape_create()) {
-	extents = Vector2(10, 10);
+	size = Vector2(20, 20);
 	_update_shape();
 }

--- a/scene/resources/rectangle_shape_2d.h
+++ b/scene/resources/rectangle_shape_2d.h
@@ -36,15 +36,15 @@
 class RectangleShape2D : public Shape2D {
 	GDCLASS(RectangleShape2D, Shape2D);
 
-	Vector2 extents;
+	Vector2 size;
 	void _update_shape();
 
 protected:
 	static void _bind_methods();
 
 public:
-	void set_extents(const Vector2 &p_extents);
-	Vector2 get_extents() const;
+	void set_size(const Vector2 &p_size);
+	Vector2 get_size() const;
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;


### PR DESCRIPTION
Currently, to adjust the size of a `RectangleShape2D` or a `BoxShape3D` you modify the `extents`, which are half the size of the rectangle or box. This is confusing for the user. Furthermore, although a `BoxMesh3D` (a `CubeMesh` in 3.2) uses a `Vector3` for size, a `CSGBox3D` uses three `float`s: `width`, `height` and `depth`.

This PR allows a users to adjust the size of a `RectangleShape`, a `BoxShape`, a `BoxMesh` and a `CSGBox` consistently using a `Vector` property called `size`.

Part of #16863.
