### PR TITLE
Rename XRController signal button_release to button_released

### DIFF
--- a/doc/classes/XRController3D.xml
+++ b/doc/classes/XRController3D.xml
@@ -86,7 +86,7 @@
 				Emitted when a button on this controller is pressed.
 			</description>
 		</signal>
-		<signal name="button_release">
+		<signal name="button_released">
 			<argument index="0" name="button" type="int">
 			</argument>
 			<description>

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -211,7 +211,7 @@ void XRController3D::_notification(int p_what) {
 							emit_signal("button_pressed", i);
 							button_states += mask;
 						} else if (was_pressed && !is_pressed) {
-							emit_signal("button_release", i);
+							emit_signal("button_released", i);
 							button_states -= mask;
 						};
 
@@ -257,7 +257,7 @@ void XRController3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_mesh"), &XRController3D::get_mesh);
 
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::INT, "button")));
-	ADD_SIGNAL(MethodInfo("button_release", PropertyInfo(Variant::INT, "button")));
+	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::INT, "button")));
 	ADD_SIGNAL(MethodInfo("mesh_updated", PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh")));
 };
 


### PR DESCRIPTION
Makes it consistent with `button_pressed`.

Part of #16863.
