### PR TITLE
Rename tree item double-click signal to match the actual behaviour

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -381,7 +381,7 @@
 		</signal>
 		<signal name="item_activated">
 			<description>
-				Emitted when an item's label is double-clicked.
+				Emitted when an item is activated either by double-clicking the item, or by pressing a [code]ui_accept[/code] action when it is selected.
 			</description>
 		</signal>
 		<signal name="item_collapsed">
@@ -396,9 +396,10 @@
 				Emitted when a custom button is pressed (i.e. in a [constant TreeItem.CELL_MODE_CUSTOM] mode cell).
 			</description>
 		</signal>
-		<signal name="item_double_clicked">
+		<signal name="item_editable_icon_clicked">
 			<description>
-				Emitted when an item's icon is double-clicked.
+				Emitted when an editable item's icon is clicked. See [method TreeItem.set_editable].
+				[b]Note:[/b] Requires the item to be editable. Will be emitted when any non-editable portion of an editable item is clicked; not just the icon. If [member select_mode] is [code]SELECT_MULTI[/code] ([code]2[/code]), requires an editable item to first be selected and then clicked.
 			</description>
 		</signal>
 		<signal name="item_edited">

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2917,7 +2917,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	scene_tree->connect("script_dropped", callable_mp(this, &SceneTreeDock::_script_dropped));
 	scene_tree->connect("nodes_dragged", callable_mp(this, &SceneTreeDock::_nodes_drag_begin));
 
-	scene_tree->get_scene_tree()->connect("item_double_clicked", callable_mp(this, &SceneTreeDock::_focus_node));
+	scene_tree->get_scene_tree()->connect("item_editable_icon_clicked", callable_mp(this, &SceneTreeDock::_focus_node));
 
 	scene_tree->set_undo_redo(&editor_data->get_undo_redo());
 	scene_tree->set_editor_selection(editor_selection);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2732,10 +2732,10 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 						}
 						if (rect.has_point(mpos)) {
 							if (!edit_selected()) {
-								emit_signal("item_double_clicked");
+								emit_signal("item_editable_icon_clicked");
 							}
 						} else {
-							emit_signal("item_double_clicked");
+							emit_signal("item_editable_icon_clicked");
 						}
 					}
 					pressing_for_editor = false;
@@ -4204,9 +4204,8 @@ void Tree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("item_edited"));
 	ADD_SIGNAL(MethodInfo("item_rmb_edited"));
 	ADD_SIGNAL(MethodInfo("item_custom_button_pressed"));
-	ADD_SIGNAL(MethodInfo("item_double_clicked"));
+	ADD_SIGNAL(MethodInfo("item_editable_icon_clicked"));
 	ADD_SIGNAL(MethodInfo("item_collapsed", PropertyInfo(Variant::OBJECT, "item", PROPERTY_HINT_RESOURCE_TYPE, "TreeItem")));
-	//ADD_SIGNAL( MethodInfo("item_doubleclicked" ) );
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::OBJECT, "item", PROPERTY_HINT_RESOURCE_TYPE, "TreeItem"), PropertyInfo(Variant::INT, "column"), PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("custom_popup_edited", PropertyInfo(Variant::BOOL, "arrow_clicked")));
 	ADD_SIGNAL(MethodInfo("item_activated"));


### PR DESCRIPTION
As identified [here](https://github.com/godotengine/godot/issues/16839#issuecomment-366896486), currently a `Tree` emits an `item_activated` signal when the item's label is double-clicked, and an `item_double_clicked` signal when the item's icon is double-clicked.

This PR renames the `Tree`'s item double-click signals to match the events and improves docs:
- `item_double_clicked` -> `item_icon_double-clicked`

Part of #16863.

_Bugsquad: updated to reflect current state_