### PR TITLE
Add `create_from_arrays` method to SurfaceTool

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -103,6 +103,18 @@
 				Creates a vertex array from an existing [Mesh].
 			</description>
 		</method>
+		<method name="create_from_arrays">
+			<return type="void" />
+			<argument index="0" name="vertices" type="PackedVector3Array" />
+			<argument index="1" name="indices" type="PackedInt32Array" default="PackedInt32Array()" />
+			<argument index="2" name="colors" type="PackedColorArray" default="PackedColorArray()" />
+			<argument index="3" name="uvs" type="PackedVector2Array" default="PackedVector2Array()" />
+			<argument index="4" name="uv2s" type="PackedVector2Array" default="PackedVector2Array()" />
+			<argument index="5" name="normals" type="PackedVector3Array" default="PackedVector3Array()" />
+			<argument index="6" name="tangents" type="Array" default="[]" />
+			<description>
+			</description>
+		</method>
 		<method name="create_from_blend_shape">
 			<return type="void" />
 			<argument index="0" name="existing" type="Mesh" />

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -269,6 +269,30 @@ void SurfaceTool::set_smooth_group(uint32_t p_group) {
 	last_smooth_group = p_group;
 }
 
+void SurfaceTool::create_from_arrays(const Vector<Vector3> &p_vertices, const Vector<int> &p_indices, const Vector<Color> &p_colors, const Vector<Vector2> &p_uvs, const Vector<Vector2> &p_uv2s, const Vector<Vector3> &p_normals, const Vector<Plane> &p_tangents) {
+	for (int i = 0; i < p_vertices.size(); i++) {
+		if (i < p_colors.size()) {
+			set_color(p_colors[i]);
+		}
+		if (i < p_uvs.size()) {
+			set_uv(p_uvs[i]);
+		}
+		if (i < p_uv2s.size()) {
+			set_uv2(p_uv2s[i]);
+		}
+		if (i < p_normals.size()) {
+			set_normal(p_normals[i]);
+		}
+		if (i < p_tangents.size()) {
+			set_tangent(p_tangents[i]);
+		}
+		add_vertex(p_vertices[i]);
+	}
+	for (int i = 0; i < p_indices.size(); i++) {
+		add_index(p_indices[i]);
+	}
+}
+
 void SurfaceTool::add_triangle_fan(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<Color> &p_colors, const Vector<Vector2> &p_uv2s, const Vector<Vector3> &p_normals, const Vector<Plane> &p_tangents) {
 	ERR_FAIL_COND(!begun);
 	ERR_FAIL_COND(primitive != Mesh::PRIMITIVE_TRIANGLES);
@@ -1216,6 +1240,8 @@ void SurfaceTool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_weights", "weights"), &SurfaceTool::set_weights);
 	ClassDB::bind_method(D_METHOD("set_custom", "index", "custom"), &SurfaceTool::set_custom);
 	ClassDB::bind_method(D_METHOD("set_smooth_group", "index"), &SurfaceTool::set_smooth_group);
+
+	ClassDB::bind_method(D_METHOD("create_from_arrays", "vertices", "indices", "colors", "uvs", "uv2s", "normals", "tangents"), &SurfaceTool::create_from_arrays, DEFVAL(Vector<int>()), DEFVAL(Vector<Color>()), DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Vector3>()), DEFVAL(Vector<Plane>()));
 
 	ClassDB::bind_method(D_METHOD("add_triangle_fan", "vertices", "uvs", "colors", "uv2s", "normals", "tangents"), &SurfaceTool::add_triangle_fan, DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Color>()), DEFVAL(Vector<Vector2>()), DEFVAL(Vector<Vector3>()), DEFVAL(Vector<Plane>()));
 

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -161,6 +161,8 @@ public:
 
 	void add_vertex(const Vector3 &p_vertex);
 
+	void create_from_arrays(const Vector<Vector3> &p_vertices, const Vector<int> &p_indices = Vector<int>(), const Vector<Color> &p_colors = Vector<Color>(), const Vector<Vector2> &p_uvs = Vector<Vector2>(), const Vector<Vector2> &p_uv2s = Vector<Vector2>(), const Vector<Vector3> &p_normals = Vector<Vector3>(), const Vector<Plane> &p_tangents = Vector<Plane>());
+
 	void add_triangle_fan(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs = Vector<Vector2>(), const Vector<Color> &p_colors = Vector<Color>(), const Vector<Vector2> &p_uv2s = Vector<Vector2>(), const Vector<Vector3> &p_normals = Vector<Vector3>(), const Vector<Plane> &p_tangents = Vector<Plane>());
 
 	void add_index(int p_index);


### PR DESCRIPTION
I've decided to fix https://github.com/godotengine/godot/issues/22874#issuecomment-523227239 and added a bunch of methods that accept arrays to SurfaceTool. They are:

```
add_colors
add_normals
add_tangents
add_uvs
add_uvs2
add_vertices
add_indices
```

They all(except `add_tangents` which accept simple Array) accept PackedArray's like:

```
extends Node3D

@onready var mesh_instance = $MeshInstance3D

func _ready():
	var st = SurfaceTool.new()
	
	var colors = PackedColorArray()
	colors.append(Color.red)
	colors.append(Color.blue)
	colors.append(Color.lime)
	
	var vertices = PackedVector3Array()
	vertices.append(Vector3(-0.5, 0, 0))
	vertices.append(Vector3(0, 1, 0))
	vertices.append(Vector3(0.5, 0, 0))
	
	st.begin(Mesh.PRIMITIVE_TRIANGLES)
	
	st.add_colors(colors)
	st.add_vertices(vertices)
	
	mesh_instance.mesh = st.commit()
```

And produces correct results:

![image](https://user-images.githubusercontent.com/3036176/101490560-947a5700-3973-11eb-971e-0ceeba236ef8.png)
