### PR TITLE
Change themes font_color_selected to font_selected_color

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -118,17 +118,17 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [Button].
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			Text [Color] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
-			Text [Color] used when the [Button] is being pressed.
+		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Text outline [Color] of the [Button].
 		</theme_item>
-		<theme_item name="font_outline_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
-			Text oubline [Color] of the [Button].
+		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Text [Color] used when the [Button] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the [Button]'s text.

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -36,16 +36,16 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			The [CheckBox] text's font color.
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			The [CheckBox] text's font color when it's disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			The [CheckBox] text's font color when it's hovered.
 		</theme_item>
-		<theme_item name="font_color_hover_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_hover_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckBox] text's font color when it's hovered and pressed.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckBox] text's font color when it's pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -33,16 +33,16 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			The [CheckButton] text's font color.
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			The [CheckButton] text's font color when it's disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			The [CheckButton] text's font color when it's hovered.
 		</theme_item>
-		<theme_item name="font_color_hover_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_hover_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckButton] text's font color when it's hovered and pressed.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckButton] text's font color when it's pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -179,9 +179,9 @@
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 		</theme_item>
-		<theme_item name="font_color_readonly" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
+		<theme_item name="font_readonly_color" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color( 0, 0, 0, 1 )">
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the [CodeEdit]'s text.

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -73,13 +73,13 @@
 		<theme_item name="font_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Default text [Color] of the [ColorPickerButton].
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.3 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.3 )">
 			Text [Color] used when the [ColorPickerButton] is disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 0.8, 0.8, 0.8, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color( 0.8, 0.8, 0.8, 1 )">
 			Text [Color] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -615,7 +615,7 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.63, 0.63, 0.63, 1 )">
 			Default text [Color] of the item.
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the item is selected.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -150,11 +150,11 @@
 		<theme_item name="font_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Default text [Color] of the [Label].
 		</theme_item>
-		<theme_item name="font_color_shadow" type="Color" default="Color( 0, 0, 0, 0 )">
-			[Color] of the text's shadow effect.
-		</theme_item>
-		<theme_item name="font_outline_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The tint of [Font]'s outline.
+		</theme_item>
+		<theme_item name="font_shadow_color" type="Color" default="Color( 0, 0, 0, 0 )">
+			[Color] of the text's shadow effect.
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the [Label]'s text.

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -380,10 +380,10 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default font color.
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color( 0, 0, 0, 1 )">
 			Font color for selected text (inside the selection rectangle).
 		</theme_item>
-		<theme_item name="font_color_uneditable" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
+		<theme_item name="font_uneditable_color" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
 			Font color when editing is disabled.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -81,10 +81,10 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [LinkButton].
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [LinkButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [LinkButton] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -59,13 +59,13 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [MenuButton].
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 1, 1, 1, 0.3 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color( 1, 1, 1, 0.3 )">
 			Text [Color] used when the [MenuButton] is disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [MenuButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -253,13 +253,13 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [OptionButton].
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			Text [Color] used when the [OptionButton] is disabled.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [OptionButton] is being hovered.
 		</theme_item>
-		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [OptionButton] is being pressed.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -720,16 +720,16 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			The default text [Color] for menu items' names.
 		</theme_item>
-		<theme_item name="font_color_accel" type="Color" default="Color( 0.7, 0.7, 0.7, 0.8 )">
+		<theme_item name="font_accelerator_color" type="Color" default="Color( 0.7, 0.7, 0.7, 0.8 )">
 			The text [Color] used for shortcuts and accelerators that show next to the menu item name when defined. See [method get_item_accelerator] for more info on accelerators.
 		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.4, 0.4, 0.4, 0.8 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color( 0.4, 0.4, 0.4, 0.8 )">
 			[Color] used for disabled menu items' text.
 		</theme_item>
-		<theme_item name="font_color_hover" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_hover_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			[Color] used for the hovered text.
 		</theme_item>
-		<theme_item name="font_color_separator" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+		<theme_item name="font_separator_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			[Color] used for labeled separators' text. See [method add_separator].
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -32,7 +32,7 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			The color of the text.
 		</theme_item>
-		<theme_item name="font_color_shadow" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_shadow_color" type="Color" default="Color( 0, 0, 0, 1 )">
 			The color of the text's shadow.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -597,11 +597,11 @@
 		<theme_item name="focus" type="StyleBox">
 			The background The background used when the [RichTextLabel] is focused.
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
-			The color of selected text, used when [member selection_enabled] is [code]true[/code].
-		</theme_item>
-		<theme_item name="font_color_shadow" type="Color" default="Color( 0, 0, 0, 0 )">
+		<theme_item name="font_shadow_color" type="Color" default="Color( 0, 0, 0, 0 )">
 			The color of the font's shadow.
+		</theme_item>
+		<theme_item name="font_selected_color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
+			The color of selected text, used when [member selection_enabled] is [code]true[/code].
 		</theme_item>
 		<theme_item name="italics_font" type="Font">
 			The font used for italics text.

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -198,14 +198,14 @@
 		<theme_item name="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>
-		<theme_item name="font_color_bg" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
-			Font color of inactive tabs.
-		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			Font color of disabled tabs.
 		</theme_item>
-		<theme_item name="font_color_fg" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Font color of the currently selected tab.
+		</theme_item>
+		<theme_item name="font_unselected_color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
+			Font color of the other, unselected tabs.
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the tab names.
@@ -231,14 +231,14 @@
 		<theme_item name="side_margin" type="int" default="8">
 			The space at the left and right edges of the tab bar.
 		</theme_item>
-		<theme_item name="tab_bg" type="StyleBox">
-			The style of inactive tabs.
-		</theme_item>
 		<theme_item name="tab_disabled" type="StyleBox">
 			The style of disabled tabs.
 		</theme_item>
-		<theme_item name="tab_fg" type="StyleBox">
+		<theme_item name="tab_selected" type="StyleBox">
 			The style of the currently selected tab.
+		</theme_item>
+		<theme_item name="tab_unselected" type="StyleBox">
+			The style of the other, unselected tabs.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -359,14 +359,14 @@
 		<theme_item name="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>
-		<theme_item name="font_color_bg" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
-			Font color of inactive tabs.
-		</theme_item>
-		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+		<theme_item name="font_disabled_color" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
 			Font color of disabled tabs.
 		</theme_item>
-		<theme_item name="font_color_fg" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Font color of the currently selected tab.
+		</theme_item>
+		<theme_item name="font_unselected_color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
+			Font color of the other, unselected tabs.
 		</theme_item>
 		<theme_item name="font_size" type="int">
 			Font size of the tab names.
@@ -382,14 +382,14 @@
 		</theme_item>
 		<theme_item name="panel" type="StyleBox">
 		</theme_item>
-		<theme_item name="tab_bg" type="StyleBox">
-			The style of an inactive tab.
-		</theme_item>
 		<theme_item name="tab_disabled" type="StyleBox">
-			The style of a disabled tab
+			The style of disabled tabs.
 		</theme_item>
-		<theme_item name="tab_fg" type="StyleBox">
+		<theme_item name="tab_selected" type="StyleBox">
 			The style of the currently selected tab.
+		</theme_item>
+		<theme_item name="tab_unselected" type="StyleBox">
+			The style of the other, unselected tabs.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -697,7 +697,7 @@
 		</member>
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
 		<member name="override_selected_font_color" type="bool" setter="set_override_selected_font_color" getter="is_overriding_selected_font_color" default="false">
-			If [code]true[/code], custom [code]font_color_selected[/code] will be used for selected text.
+			If [code]true[/code], custom [code]font_selected_color[/code] will be used for selected text.
 		</member>
 		<member name="readonly" type="bool" setter="set_readonly" getter="is_readonly" default="false">
 			If [code]true[/code], read-only mode is enabled. Existing text cannot be modified and new text cannot be added.
@@ -953,9 +953,9 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Sets the font [Color].
 		</theme_item>
-		<theme_item name="font_color_readonly" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
+		<theme_item name="font_readonly_color" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 0, 0, 0, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color( 0, 0, 0, 1 )">
 			Sets the [Color] of the selected text. [member override_selected_font_color] has to be enabled.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -524,7 +524,7 @@
 		<theme_item name="font_color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
 			Default text [Color] of the item.
 		</theme_item>
-		<theme_item name="font_color_selected" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="font_selected_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the item is selected.
 		</theme_item>
 		<theme_item name="font_size" type="int">

--- a/editor/debugger/editor_network_profiler.cpp
+++ b/editor/debugger/editor_network_profiler.cpp
@@ -46,8 +46,8 @@ void EditorNetworkProfiler::_notification(int p_what) {
 		outgoing_bandwidth_text->set_right_icon(get_theme_icon("ArrowUp", "EditorIcons"));
 
 		// This needs to be done here to set the faded color when the profiler is first opened
-		incoming_bandwidth_text->add_theme_color_override("font_color_uneditable", get_theme_color("font_color", "Editor") * Color(1, 1, 1, 0.5));
-		outgoing_bandwidth_text->add_theme_color_override("font_color_uneditable", get_theme_color("font_color", "Editor") * Color(1, 1, 1, 0.5));
+		incoming_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color("font_color", "Editor") * Color(1, 1, 1, 0.5));
+		outgoing_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color("font_color", "Editor") * Color(1, 1, 1, 0.5));
 	}
 }
 
@@ -113,10 +113,10 @@ void EditorNetworkProfiler::set_bandwidth(int p_incoming, int p_outgoing) {
 
 	// Make labels more prominent when the bandwidth is greater than 0 to attract user attention
 	incoming_bandwidth_text->add_theme_color_override(
-			"font_color_uneditable",
+			"font_uneditable_color",
 			get_theme_color("font_color", "Editor") * Color(1, 1, 1, p_incoming > 0 ? 1 : 0.5));
 	outgoing_bandwidth_text->add_theme_color_override(
-			"font_color_uneditable",
+			"font_uneditable_color",
 			get_theme_color("font_color", "Editor") * Color(1, 1, 1, p_outgoing > 0 ? 1 : 0.5));
 }
 

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -78,11 +78,11 @@ void EditorAudioBus::_notification(int p_what) {
 			Color bypass_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(0.13, 0.8, 1.0) : Color(0.44, 0.87, 1.0);
 
 			solo->set_icon(get_theme_icon("AudioBusSolo", "EditorIcons"));
-			solo->add_theme_color_override("icon_color_pressed", solo_color);
+			solo->add_theme_color_override("icon_pressed_color", solo_color);
 			mute->set_icon(get_theme_icon("AudioBusMute", "EditorIcons"));
-			mute->add_theme_color_override("icon_color_pressed", mute_color);
+			mute->add_theme_color_override("icon_pressed_color", mute_color);
 			bypass->set_icon(get_theme_icon("AudioBusBypass", "EditorIcons"));
-			bypass->add_theme_color_override("icon_color_pressed", bypass_color);
+			bypass->add_theme_color_override("icon_pressed_color", bypass_color);
 
 			bus_options->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
 

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1331,11 +1331,11 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 	Ref<Font> doc_code_font = p_rt->get_theme_font("doc_source", "EditorFonts");
 	Ref<Font> doc_kbd_font = p_rt->get_theme_font("doc_keyboard", "EditorFonts");
 
-	Color font_color_hl = p_rt->get_theme_color("headline_color", "EditorHelp");
+	Color headline_color = p_rt->get_theme_color("headline_color", "EditorHelp");
 	Color accent_color = p_rt->get_theme_color("accent_color", "Editor");
 	Color property_color = p_rt->get_theme_color("property_color", "Editor");
-	Color link_color = accent_color.lerp(font_color_hl, 0.8);
-	Color code_color = accent_color.lerp(font_color_hl, 0.6);
+	Color link_color = accent_color.lerp(headline_color, 0.8);
+	Color code_color = accent_color.lerp(headline_color, 0.6);
 	Color kbd_color = accent_color.lerp(property_color, 0.6);
 
 	String bbcode = p_bbcode.dedent().replace("\t", "").replace("\r", "").strip_edges();
@@ -1481,7 +1481,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			tag_stack.push_front(tag);
 		} else if (tag == "i") {
 			//use italics font
-			p_rt->push_color(font_color_hl);
+			p_rt->push_color(headline_color);
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "code" || tag == "codeblock") {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -613,8 +613,8 @@ void EditorNode::_notification(int p_what) {
 			gui_base->add_theme_style_override("panel", gui_base->get_theme_stylebox("Background", "EditorStyles"));
 			scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox("Content", "EditorStyles"));
 			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox("panel", "TabContainer"));
-			scene_tabs->add_theme_style_override("tab_fg", gui_base->get_theme_stylebox("SceneTabFG", "EditorStyles"));
-			scene_tabs->add_theme_style_override("tab_bg", gui_base->get_theme_stylebox("SceneTabBG", "EditorStyles"));
+			scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox("SceneTabFG", "EditorStyles"));
+			scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox("SceneTabBG", "EditorStyles"));
 
 			file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
 			project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox("MenuHover", "EditorStyles"));
@@ -5967,8 +5967,8 @@ EditorNode::EditorNode() {
 	tab_preview_panel->add_child(tab_preview);
 
 	scene_tabs = memnew(Tabs);
-	scene_tabs->add_theme_style_override("tab_fg", gui_base->get_theme_stylebox("SceneTabFG", "EditorStyles"));
-	scene_tabs->add_theme_style_override("tab_bg", gui_base->get_theme_stylebox("SceneTabBG", "EditorStyles"));
+	scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox("SceneTabFG", "EditorStyles"));
+	scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox("SceneTabBG", "EditorStyles"));
 	scene_tabs->set_select_with_rmb(true);
 	scene_tabs->add_tab("unsaved");
 	scene_tabs->set_tab_align(Tabs::ALIGN_LEFT);
@@ -6011,7 +6011,7 @@ EditorNode::EditorNode() {
 	tabbar_container->add_child(distraction_free);
 	scene_tab_add->set_tooltip(TTR("Add a new scene."));
 	scene_tab_add->set_icon(gui_base->get_theme_icon("Add", "EditorIcons"));
-	scene_tab_add->add_theme_color_override("icon_color_normal", Color(0.6f, 0.6f, 0.6f, 0.8f));
+	scene_tab_add->add_theme_color_override("icon_normal_color", Color(0.6f, 0.6f, 0.6f, 0.8f));
 	scene_tab_add->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_NEW_SCENE));
 
 	scene_root_parent = memnew(PanelContainer);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -375,18 +375,18 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color contrast_color_2 = base_color.lerp(mono_color, MAX(contrast * 1.5, default_contrast * 1.5));
 
 	const Color font_color = mono_color.lerp(base_color, 0.25);
-	const Color font_color_hl = mono_color.lerp(base_color, 0.15);
-	const Color font_color_disabled = Color(mono_color.r, mono_color.g, mono_color.b, 0.3);
-	const Color font_color_selection = accent_color * Color(1, 1, 1, 0.4);
-	const Color color_disabled = mono_color.inverted().lerp(base_color, 0.7);
-	const Color color_disabled_bg = mono_color.inverted().lerp(base_color, 0.9);
+	const Color font_hover_color = mono_color.lerp(base_color, 0.15);
+	const Color font_disabled_color = Color(mono_color.r, mono_color.g, mono_color.b, 0.3);
+	const Color selection_color = accent_color * Color(1, 1, 1, 0.4);
+	const Color disabled_color = mono_color.inverted().lerp(base_color, 0.7);
+	const Color disabled_bg_color = mono_color.inverted().lerp(base_color, 0.9);
 
-	Color icon_color_hover = Color(1, 1, 1) * (dark_theme ? 1.15 : 1.45);
-	icon_color_hover.a = 1.0;
+	Color icon_hover_color = Color(1, 1, 1) * (dark_theme ? 1.15 : 1.45);
+	icon_hover_color.a = 1.0;
 	// Make the pressed icon color overbright because icons are not completely white on a dark theme.
 	// On a light theme, icons are dark, so we need to modulate them with an even brighter color.
-	Color icon_color_pressed = accent_color * (dark_theme ? 1.15 : 3.5);
-	icon_color_pressed.a = 1.0;
+	Color icon_pressed_color = accent_color * (dark_theme ? 1.15 : 3.5);
+	icon_pressed_color.a = 1.0;
 
 	const Color separator_color = Color(mono_color.r, mono_color.g, mono_color.b, 0.1);
 
@@ -408,8 +408,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("axis_z_color", "Editor", Color(0.16, 0.55, 0.96));
 
 	theme->set_color("font_color", "Editor", font_color);
-	theme->set_color("highlighted_font_color", "Editor", font_color_hl);
-	theme->set_color("disabled_font_color", "Editor", font_color_disabled);
+	theme->set_color("highlighted_font_color", "Editor", font_hover_color);
+	theme->set_color("disabled_font_color", "Editor", font_disabled_color);
 
 	theme->set_color("mono_color", "Editor", mono_color);
 
@@ -485,8 +485,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_widget->set_border_color(dark_color_2);
 
 	Ref<StyleBoxFlat> style_widget_disabled = style_widget->duplicate();
-	style_widget_disabled->set_border_color(color_disabled);
-	style_widget_disabled->set_bg_color(color_disabled_bg);
+	style_widget_disabled->set_border_color(disabled_color);
+	style_widget_disabled->set_bg_color(disabled_bg_color);
 
 	Ref<StyleBoxFlat> style_widget_focus = style_widget->duplicate();
 	style_widget_focus->set_border_color(accent_color);
@@ -550,8 +550,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tab_unselected->set_border_color(dark_color_2);
 
 	Ref<StyleBoxFlat> style_tab_disabled = style_tab_selected->duplicate();
-	style_tab_disabled->set_bg_color(color_disabled_bg);
-	style_tab_disabled->set_border_color(color_disabled);
+	style_tab_disabled->set_bg_color(disabled_bg_color);
+	style_tab_disabled->set_border_color(disabled_color);
 
 	// Editor background
 	theme->set_stylebox("Background", "EditorStyles", make_flat_stylebox(background_color, default_margin_size, default_margin_size, default_margin_size, default_margin_size));
@@ -600,7 +600,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("disabled", "PopupMenu", style_menu);
 
 	theme->set_color("font_color", "MenuButton", font_color);
-	theme->set_color("font_color_hover", "MenuButton", font_color_hl);
+	theme->set_color("font_hover_color", "MenuButton", font_hover_color);
 
 	theme->set_stylebox("MenuHover", "EditorStyles", style_menu_hover_border);
 
@@ -612,11 +612,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("disabled", "Button", style_widget_disabled);
 
 	theme->set_color("font_color", "Button", font_color);
-	theme->set_color("font_color_hover", "Button", font_color_hl);
-	theme->set_color("font_color_pressed", "Button", accent_color);
-	theme->set_color("font_color_disabled", "Button", font_color_disabled);
-	theme->set_color("icon_color_hover", "Button", icon_color_hover);
-	theme->set_color("icon_color_pressed", "Button", icon_color_pressed);
+	theme->set_color("font_hover_color", "Button", font_hover_color);
+	theme->set_color("font_pressed_color", "Button", accent_color);
+	theme->set_color("font_disabled_color", "Button", font_disabled_color);
+	theme->set_color("icon_hover_color", "Button", icon_hover_color);
+	theme->set_color("icon_pressed_color", "Button", icon_pressed_color);
 
 	// OptionButton
 	theme->set_stylebox("focus", "OptionButton", style_widget_focus);
@@ -632,10 +632,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("disabled_mirrored", "OptionButton", style_widget_disabled);
 
 	theme->set_color("font_color", "OptionButton", font_color);
-	theme->set_color("font_color_hover", "OptionButton", font_color_hl);
-	theme->set_color("font_color_pressed", "OptionButton", accent_color);
-	theme->set_color("font_color_disabled", "OptionButton", font_color_disabled);
-	theme->set_color("icon_color_hover", "OptionButton", icon_color_hover);
+	theme->set_color("font_hover_color", "OptionButton", font_hover_color);
+	theme->set_color("font_pressed_color", "OptionButton", accent_color);
+	theme->set_color("font_disabled_color", "OptionButton", font_disabled_color);
+	theme->set_color("icon_hover_color", "OptionButton", icon_hover_color);
 	theme->set_icon("arrow", "OptionButton", theme->get_icon("GuiOptionArrow", "EditorIcons"));
 	theme->set_constant("arrow_margin", "OptionButton", default_margin_size * EDSCALE);
 	theme->set_constant("modulate_arrow", "OptionButton", true);
@@ -658,10 +658,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("off_disabled_mirrored", "CheckButton", theme->get_icon("GuiToggleOffDisabledMirrored", "EditorIcons"));
 
 	theme->set_color("font_color", "CheckButton", font_color);
-	theme->set_color("font_color_hover", "CheckButton", font_color_hl);
-	theme->set_color("font_color_pressed", "CheckButton", accent_color);
-	theme->set_color("font_color_disabled", "CheckButton", font_color_disabled);
-	theme->set_color("icon_color_hover", "CheckButton", icon_color_hover);
+	theme->set_color("font_hover_color", "CheckButton", font_hover_color);
+	theme->set_color("font_pressed_color", "CheckButton", accent_color);
+	theme->set_color("font_disabled_color", "CheckButton", font_disabled_color);
+	theme->set_color("icon_hover_color", "CheckButton", icon_hover_color);
 
 	theme->set_constant("hseparation", "CheckButton", 4 * EDSCALE);
 	theme->set_constant("check_vadjust", "CheckButton", 0 * EDSCALE);
@@ -683,10 +683,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("radio_unchecked", "CheckBox", theme->get_icon("GuiRadioUnchecked", "EditorIcons"));
 
 	theme->set_color("font_color", "CheckBox", font_color);
-	theme->set_color("font_color_hover", "CheckBox", font_color_hl);
-	theme->set_color("font_color_pressed", "CheckBox", accent_color);
-	theme->set_color("font_color_disabled", "CheckBox", font_color_disabled);
-	theme->set_color("icon_color_hover", "CheckBox", icon_color_hover);
+	theme->set_color("font_hover_color", "CheckBox", font_hover_color);
+	theme->set_color("font_pressed_color", "CheckBox", accent_color);
+	theme->set_color("font_disabled_color", "CheckBox", font_disabled_color);
+	theme->set_color("icon_hover_color", "CheckBox", icon_hover_color);
 
 	theme->set_constant("hseparation", "CheckBox", 4 * EDSCALE);
 	theme->set_constant("check_vadjust", "CheckBox", 0 * EDSCALE);
@@ -708,10 +708,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("labeled_separator_right", "PopupMenu", style_popup_labeled_separator_right);
 
 	theme->set_color("font_color", "PopupMenu", font_color);
-	theme->set_color("font_color_hover", "PopupMenu", font_color_hl);
-	theme->set_color("font_color_accel", "PopupMenu", font_color_disabled);
-	theme->set_color("font_color_disabled", "PopupMenu", font_color_disabled);
-	theme->set_color("font_color_separator", "PopupMenu", font_color_disabled);
+	theme->set_color("font_hover_color", "PopupMenu", font_hover_color);
+	theme->set_color("font_accelerator_color", "PopupMenu", font_disabled_color);
+	theme->set_color("font_disabled_color", "PopupMenu", font_disabled_color);
+	theme->set_color("font_separator_color", "PopupMenu", font_disabled_color);
 	theme->set_icon("checked", "PopupMenu", theme->get_icon("GuiChecked", "EditorIcons"));
 	theme->set_icon("unchecked", "PopupMenu", theme->get_icon("GuiUnchecked", "EditorIcons"));
 	theme->set_icon("radio_checked", "PopupMenu", theme->get_icon("GuiRadioChecked", "EditorIcons"));
@@ -753,9 +753,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("custom_button", "Tree", make_empty_stylebox());
 	theme->set_stylebox("custom_button_pressed", "Tree", make_empty_stylebox());
 	theme->set_stylebox("custom_button_hover", "Tree", style_widget);
-	theme->set_color("custom_button_font_highlight", "Tree", font_color_hl);
+	theme->set_color("custom_button_font_highlight", "Tree", font_hover_color);
 	theme->set_color("font_color", "Tree", font_color);
-	theme->set_color("font_color_selected", "Tree", mono_color);
+	theme->set_color("font_selected_color", "Tree", mono_color);
 	theme->set_color("title_button_color", "Tree", font_color);
 	theme->set_color("guide_color", "Tree", guide_color);
 	theme->set_color("relationship_line_color", "Tree", relationship_line_color);
@@ -826,7 +826,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("bg_focus", "ItemList", style_focus);
 	theme->set_stylebox("bg", "ItemList", style_itemlist_bg);
 	theme->set_color("font_color", "ItemList", font_color);
-	theme->set_color("font_color_selected", "ItemList", mono_color);
+	theme->set_color("font_selected_color", "ItemList", mono_color);
 	theme->set_color("guide_color", "ItemList", guide_color);
 	theme->set_constant("vseparation", "ItemList", 3 * EDSCALE);
 	theme->set_constant("hseparation", "ItemList", 3 * EDSCALE);
@@ -834,16 +834,16 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("line_separation", "ItemList", 3 * EDSCALE);
 
 	// Tabs & TabContainer
-	theme->set_stylebox("tab_fg", "TabContainer", style_tab_selected);
-	theme->set_stylebox("tab_bg", "TabContainer", style_tab_unselected);
+	theme->set_stylebox("tab_selected", "TabContainer", style_tab_selected);
+	theme->set_stylebox("tab_unselected", "TabContainer", style_tab_unselected);
 	theme->set_stylebox("tab_disabled", "TabContainer", style_tab_disabled);
-	theme->set_stylebox("tab_fg", "Tabs", style_tab_selected);
-	theme->set_stylebox("tab_bg", "Tabs", style_tab_unselected);
+	theme->set_stylebox("tab_selected", "Tabs", style_tab_selected);
+	theme->set_stylebox("tab_unselected", "Tabs", style_tab_unselected);
 	theme->set_stylebox("tab_disabled", "Tabs", style_tab_disabled);
-	theme->set_color("font_color_fg", "TabContainer", font_color);
-	theme->set_color("font_color_bg", "TabContainer", font_color_disabled);
-	theme->set_color("font_color_fg", "Tabs", font_color);
-	theme->set_color("font_color_bg", "Tabs", font_color_disabled);
+	theme->set_color("font_selected_color", "TabContainer", font_color);
+	theme->set_color("font_unselected_color", "TabContainer", font_disabled_color);
+	theme->set_color("font_selected_color", "Tabs", font_color);
+	theme->set_color("font_unselected_color", "Tabs", font_disabled_color);
 	theme->set_icon("menu", "TabContainer", theme->get_icon("GuiTabMenu", "EditorIcons"));
 	theme->set_icon("menu_highlight", "TabContainer", theme->get_icon("GuiTabMenuHl", "EditorIcons"));
 	theme->set_stylebox("SceneTabFG", "EditorStyles", style_tab_selected);
@@ -891,7 +891,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("DebuggerPanel", "EditorStyles", style_panel_debugger);
 
 	Ref<StyleBoxFlat> style_panel_invisible_top = style_content_panel->duplicate();
-	int stylebox_offset = theme->get_font("tab_fg", "TabContainer")->get_height(theme->get_font_size("tab_fg", "TabContainer")) + theme->get_stylebox("tab_fg", "TabContainer")->get_minimum_size().height + theme->get_stylebox("panel", "TabContainer")->get_default_margin(SIDE_TOP);
+	int stylebox_offset = theme->get_font("tab_selected", "TabContainer")->get_height(theme->get_font_size("tab_selected", "TabContainer")) + theme->get_stylebox("tab_selected", "TabContainer")->get_minimum_size().height + theme->get_stylebox("panel", "TabContainer")->get_default_margin(SIDE_TOP);
 	style_panel_invisible_top->set_expand_margin_size(SIDE_TOP, -stylebox_offset);
 	style_panel_invisible_top->set_default_margin(SIDE_TOP, 0);
 	theme->set_stylebox("BottomPanelDebuggerOverride", "EditorStyles", style_panel_invisible_top);
@@ -901,11 +901,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("focus", "LineEdit", style_widget_focus);
 	theme->set_stylebox("read_only", "LineEdit", style_widget_disabled);
 	theme->set_icon("clear", "LineEdit", theme->get_icon("GuiClose", "EditorIcons"));
-	theme->set_color("read_only", "LineEdit", font_color_disabled);
+	theme->set_color("read_only", "LineEdit", font_disabled_color);
 	theme->set_color("font_color", "LineEdit", font_color);
-	theme->set_color("font_color_selected", "LineEdit", mono_color);
+	theme->set_color("font_selected_color", "LineEdit", mono_color);
 	theme->set_color("cursor_color", "LineEdit", font_color);
-	theme->set_color("selection_color", "LineEdit", font_color_selection);
+	theme->set_color("selection_color", "LineEdit", selection_color);
 	theme->set_color("clear_button_color", "LineEdit", font_color);
 	theme->set_color("clear_button_color_pressed", "LineEdit", accent_color);
 
@@ -918,7 +918,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("space", "TextEdit", theme->get_icon("GuiSpace", "EditorIcons"));
 	theme->set_color("font_color", "TextEdit", font_color);
 	theme->set_color("caret_color", "TextEdit", font_color);
-	theme->set_color("selection_color", "TextEdit", font_color_selection);
+	theme->set_color("selection_color", "TextEdit", selection_color);
 
 	// CodeEdit
 	theme->set_stylebox("normal", "CodeEdit", style_widget);
@@ -932,7 +932,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("executing_line", "CodeEdit", theme->get_icon("MainPlay", "EditorIcons"));
 	theme->set_color("font_color", "CodeEdit", font_color);
 	theme->set_color("caret_color", "CodeEdit", font_color);
-	theme->set_color("selection_color", "CodeEdit", font_color_selection);
+	theme->set_color("selection_color", "CodeEdit", selection_color);
 
 	// H/VSplitContainer
 	theme->set_stylebox("bg", "VSplitContainer", make_stylebox(theme->get_icon("GuiVsplitBg", "EditorIcons"), 1, 1, 1, 1));
@@ -1023,7 +1023,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	//RichTextLabel
 	theme->set_color("default_color", "RichTextLabel", font_color);
-	theme->set_color("font_color_shadow", "RichTextLabel", Color(0, 0, 0, 0));
+	theme->set_color("font_shadow_color", "RichTextLabel", Color(0, 0, 0, 0));
 	theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
 	theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
 	theme->set_constant("shadow_as_outline", "RichTextLabel", 0 * EDSCALE);
@@ -1039,7 +1039,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Label
 	theme->set_stylebox("normal", "Label", style_empty);
 	theme->set_color("font_color", "Label", font_color);
-	theme->set_color("font_color_shadow", "Label", Color(0, 0, 0, 0));
+	theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
 	theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
 	theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
 	theme->set_constant("shadow_as_outline", "Label", 0 * EDSCALE);
@@ -1048,9 +1048,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// LinkButton
 	theme->set_stylebox("focus", "LinkButton", style_empty);
 	theme->set_color("font_color", "LinkButton", font_color);
-	theme->set_color("font_color_hover", "LinkButton", font_color_hl);
-	theme->set_color("font_color_pressed", "LinkButton", accent_color);
-	theme->set_color("font_color_disabled", "LinkButton", font_color_disabled);
+	theme->set_color("font_hover_color", "LinkButton", font_hover_color);
+	theme->set_color("font_pressed_color", "LinkButton", accent_color);
+	theme->set_color("font_disabled_color", "LinkButton", font_disabled_color);
 
 	// TooltipPanel
 	Ref<StyleBoxFlat> style_tooltip = style_popup->duplicate();
@@ -1063,7 +1063,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tooltip->set_border_width_all(border_width);
 	style_tooltip->set_border_color(mono_color);
 	theme->set_color("font_color", "TooltipLabel", font_color.inverted());
-	theme->set_color("font_color_shadow", "TooltipLabel", mono_color.inverted() * Color(1, 1, 1, 0.1));
+	theme->set_color("font_shadow_color", "TooltipLabel", mono_color.inverted() * Color(1, 1, 1, 0.1));
 	theme->set_stylebox("panel", "TooltipPanel", style_tooltip);
 
 	// PopupPanel
@@ -1198,7 +1198,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Use a different color for folder icons to make them easier to distinguish from files.
 	// On a light theme, the icon will be dark, so we need to lighten it before blending it with the accent color.
 	theme->set_color("folder_icon_modulate", "FileDialog", (dark_theme ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(accent_color, 0.7));
-	theme->set_color("files_disabled", "FileDialog", font_color_disabled);
+	theme->set_color("files_disabled", "FileDialog", font_disabled_color);
 
 	// color picker
 	theme->set_constant("margin", "ColorPicker", popup_margin_size);
@@ -1251,7 +1251,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color caret_color = mono_color;
 	const Color caret_background_color = mono_color.inverted();
 	const Color text_selected_color = dark_color_3;
-	const Color selection_color = accent_color * Color(1, 1, 1, 0.35);
 	const Color brace_mismatch_color = error_color;
 	const Color current_line_color = alpha1;
 	const Color line_length_guideline_color = dark_theme ? base_color : background_color;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4163,7 +4163,7 @@ void CanvasItemEditor::_notification(int p_what) {
 		// the icon will be dark, so we need to lighten it before blending it
 		// with the red color.
 		const Color key_auto_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25);
-		key_auto_insert_button->add_theme_color_override("icon_color_pressed", key_auto_color.lerp(Color(1, 0, 0), 0.55));
+		key_auto_insert_button->add_theme_color_override("icon_pressed_color", key_auto_color.lerp(Color(1, 0, 0), 0.55));
 		animation_menu->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
 
 		zoom_minus->set_icon(get_theme_icon("ZoomLess", "EditorIcons"));
@@ -5779,7 +5779,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	zoom_reset->set_flat(true);
 	zoom_hb->add_child(zoom_reset);
 	zoom_reset->add_theme_constant_override("outline_size", 1);
-	zoom_reset->add_theme_color_override("font_outline_modulate", Color(0, 0, 0));
+	zoom_reset->add_theme_color_override("font_outline_color", Color(0, 0, 0));
 	zoom_reset->add_theme_color_override("font_color", Color(1, 1, 1));
 	zoom_reset->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_zoom_reset));
 	zoom_reset->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_reset", TTR("Zoom Reset"), KEY_MASK_CMD | KEY_0));
@@ -6613,7 +6613,7 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 	}
 
 	label = memnew(Label);
-	label->add_theme_color_override("font_color_shadow", Color(0, 0, 0, 1));
+	label->add_theme_color_override("font_shadow_color", Color(0, 0, 0, 1));
 	label->add_theme_constant_override("shadow_as_outline", 1 * EDSCALE);
 	label->hide();
 	canvas_item_editor->get_controls_container()->add_child(label);
@@ -6621,7 +6621,7 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 	label_desc = memnew(Label);
 	label_desc->set_text(TTR("Drag & drop + Shift : Add node as sibling\nDrag & drop + Alt : Change node type"));
 	label_desc->add_theme_color_override("font_color", Color(0.6f, 0.6f, 0.6f, 1));
-	label_desc->add_theme_color_override("font_color_shadow", Color(0.2f, 0.2f, 0.2f, 1));
+	label_desc->add_theme_color_override("font_shadow_color", Color(0.2f, 0.2f, 0.2f, 1));
 	label_desc->add_theme_constant_override("shadow_as_outline", 1 * EDSCALE);
 	label_desc->add_theme_constant_override("line_spacing", 0);
 	label_desc->hide();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -214,7 +214,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	text_edit->add_theme_color_override("line_number_color", line_number_color);
 	text_edit->add_theme_color_override("caret_color", caret_color);
 	text_edit->add_theme_color_override("caret_background_color", caret_background_color);
-	text_edit->add_theme_color_override("font_color_selected", text_selected_color);
+	text_edit->add_theme_color_override("font_selected_color", text_selected_color);
 	text_edit->add_theme_color_override("selection_color", selection_color);
 	text_edit->add_theme_color_override("brace_mismatch_color", brace_mismatch_color);
 	text_edit->add_theme_color_override("current_line_color", current_line_color);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -117,7 +117,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	get_text_editor()->add_theme_color_override("line_number_color", line_number_color);
 	get_text_editor()->add_theme_color_override("caret_color", caret_color);
 	get_text_editor()->add_theme_color_override("caret_background_color", caret_background_color);
-	get_text_editor()->add_theme_color_override("font_color_selected", text_selected_color);
+	get_text_editor()->add_theme_color_override("font_selected_color", text_selected_color);
 	get_text_editor()->add_theme_color_override("selection_color", selection_color);
 	get_text_editor()->add_theme_color_override("brace_mismatch_color", brace_mismatch_color);
 	get_text_editor()->add_theme_color_override("current_line_color", current_line_color);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -96,7 +96,7 @@ void TextEditor::_load_theme_settings() {
 	text_edit->add_theme_color_override("line_number_color", line_number_color);
 	text_edit->add_theme_color_override("caret_color", caret_color);
 	text_edit->add_theme_color_override("caret_background_color", caret_background_color);
-	text_edit->add_theme_color_override("font_color_selected", text_selected_color);
+	text_edit->add_theme_color_override("font_selected_color", text_selected_color);
 	text_edit->add_theme_color_override("selection_color", selection_color);
 	text_edit->add_theme_color_override("brace_mismatch_color", brace_mismatch_color);
 	text_edit->add_theme_color_override("current_line_color", current_line_color);

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -173,8 +173,7 @@ Texture3DEditor::Texture3DEditor() {
 	info->set_h_grow_direction(GROW_DIRECTION_BEGIN);
 	info->set_v_grow_direction(GROW_DIRECTION_BEGIN);
 	info->add_theme_color_override("font_color", Color(1, 1, 1, 1));
-	info->add_theme_color_override("font_color_shadow", Color(0, 0, 0, 0.5));
-	info->add_theme_color_override("font_color_shadow", Color(0, 0, 0, 0.5));
+	info->add_theme_color_override("font_shadow_color", Color(0, 0, 0, 0.5));
 	info->add_theme_constant_override("shadow_as_outline", 1);
 	info->add_theme_constant_override("shadow_offset_x", 2);
 	info->add_theme_constant_override("shadow_offset_y", 2);

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -238,8 +238,7 @@ TextureLayeredEditor::TextureLayeredEditor() {
 	info->set_h_grow_direction(GROW_DIRECTION_BEGIN);
 	info->set_v_grow_direction(GROW_DIRECTION_BEGIN);
 	info->add_theme_color_override("font_color", Color(1, 1, 1, 1));
-	info->add_theme_color_override("font_color_shadow", Color(0, 0, 0, 0.5));
-	info->add_theme_color_override("font_color_shadow", Color(0, 0, 0, 0.5));
+	info->add_theme_color_override("font_shadow_color", Color(0, 0, 0, 0.5));
 	info->add_theme_constant_override("shadow_as_outline", 1);
 	info->add_theme_constant_override("shadow_offset_x", 2);
 	info->add_theme_constant_override("shadow_offset_y", 2);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -619,7 +619,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					if (vsnode->get_input_port_default_hint(i) != "" && !port_left_used) {
 						Label *hint_label = memnew(Label);
 						hint_label->set_text("[" + vsnode->get_input_port_default_hint(i) + "]");
-						hint_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color("font_color_readonly", "TextEdit"));
+						hint_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color("font_readonly_color", "TextEdit"));
 						hint_label->add_theme_style_override("normal", label_style);
 						hb->add_child(hint_label);
 					}

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -102,8 +102,8 @@ void Button::_notification(int p_what) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
 					color = get_theme_color("font_color");
-					if (has_theme_color("icon_color_normal")) {
-						color_icon = get_theme_color("icon_color_normal");
+					if (has_theme_color("icon_normal_color")) {
+						color_icon = get_theme_color("icon_normal_color");
 					}
 				} break;
 				case DRAW_HOVER_PRESSED: {
@@ -117,13 +117,13 @@ void Button::_notification(int p_what) {
 						if (!flat) {
 							style->draw(ci, Rect2(Point2(0, 0), size));
 						}
-						if (has_theme_color("font_color_hover_pressed")) {
-							color = get_theme_color("font_color_hover_pressed");
+						if (has_theme_color("font_hover_pressed_color")) {
+							color = get_theme_color("font_hover_pressed_color");
 						} else {
 							color = get_theme_color("font_color");
 						}
-						if (has_theme_color("icon_color_hover_pressed")) {
-							color_icon = get_theme_color("icon_color_hover_pressed");
+						if (has_theme_color("icon_hover_pressed_color")) {
+							color_icon = get_theme_color("icon_hover_pressed_color");
 						}
 
 						break;
@@ -140,13 +140,13 @@ void Button::_notification(int p_what) {
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
-					if (has_theme_color("font_color_pressed")) {
-						color = get_theme_color("font_color_pressed");
+					if (has_theme_color("font_pressed_color")) {
+						color = get_theme_color("font_pressed_color");
 					} else {
 						color = get_theme_color("font_color");
 					}
-					if (has_theme_color("icon_color_pressed")) {
-						color_icon = get_theme_color("icon_color_pressed");
+					if (has_theme_color("icon_pressed_color")) {
+						color_icon = get_theme_color("icon_pressed_color");
 					}
 
 				} break;
@@ -160,9 +160,9 @@ void Button::_notification(int p_what) {
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
-					color = get_theme_color("font_color_hover");
-					if (has_theme_color("icon_color_hover")) {
-						color_icon = get_theme_color("icon_color_hover");
+					color = get_theme_color("font_hover_color");
+					if (has_theme_color("icon_hover_color")) {
+						color_icon = get_theme_color("icon_hover_color");
 					}
 
 				} break;
@@ -176,9 +176,9 @@ void Button::_notification(int p_what) {
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
-					color = get_theme_color("font_color_disabled");
-					if (has_theme_color("icon_color_disabled")) {
-						color_icon = get_theme_color("icon_color_disabled");
+					color = get_theme_color("font_disabled_color");
+					if (has_theme_color("icon_disabled_color")) {
+						color_icon = get_theme_color("icon_disabled_color");
 					}
 
 				} break;
@@ -303,10 +303,10 @@ void Button::_notification(int p_what) {
 				text_ofs.x -= icon_ofs.x;
 			}
 
-			Color font_outline_modulate = get_theme_color("font_outline_modulate");
+			Color font_outline_color = get_theme_color("font_outline_color");
 			int outline_size = get_theme_constant("outline_size");
-			if (outline_size > 0 && font_outline_modulate.a > 0) {
-				text_buf->draw_outline(ci, text_ofs.floor(), outline_size, font_outline_modulate);
+			if (outline_size > 0 && font_outline_color.a > 0) {
+				text_buf->draw_outline(ci, text_ofs.floor(), outline_size, font_outline_color);
 			}
 
 			text_buf->draw(ci, text_ofs.floor(), color);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -50,20 +50,20 @@ VBoxContainer *FileDialog::get_vbox() {
 
 void FileDialog::_theme_changed() {
 	Color font_color = vbox->get_theme_color("font_color", "Button");
-	Color font_color_hover = vbox->get_theme_color("font_color_hover", "Button");
-	Color font_color_pressed = vbox->get_theme_color("font_color_pressed", "Button");
+	Color font_hover_color = vbox->get_theme_color("font_hover_color", "Button");
+	Color font_pressed_color = vbox->get_theme_color("font_pressed_color", "Button");
 
-	dir_up->add_theme_color_override("icon_color_normal", font_color);
-	dir_up->add_theme_color_override("icon_color_hover", font_color_hover);
-	dir_up->add_theme_color_override("icon_color_pressed", font_color_pressed);
+	dir_up->add_theme_color_override("icon_normal_color", font_color);
+	dir_up->add_theme_color_override("icon_hover_color", font_hover_color);
+	dir_up->add_theme_color_override("icon_pressed_color", font_pressed_color);
 
-	refresh->add_theme_color_override("icon_color_normal", font_color);
-	refresh->add_theme_color_override("icon_color_hover", font_color_hover);
-	refresh->add_theme_color_override("icon_color_pressed", font_color_pressed);
+	refresh->add_theme_color_override("icon_normal_color", font_color);
+	refresh->add_theme_color_override("icon_hover_color", font_hover_color);
+	refresh->add_theme_color_override("icon_pressed_color", font_pressed_color);
 
-	show_hidden->add_theme_color_override("icon_color_normal", font_color);
-	show_hidden->add_theme_color_override("icon_color_hover", font_color_hover);
-	show_hidden->add_theme_color_override("icon_color_pressed", font_color_pressed);
+	show_hidden->add_theme_color_override("icon_normal_color", font_color);
+	show_hidden->add_theme_color_override("icon_hover_color", font_hover_color);
+	show_hidden->add_theme_color_override("icon_pressed_color", font_pressed_color);
 }
 
 void FileDialog::_notification(int p_what) {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -890,7 +890,7 @@ void ItemList::_notification(int p_what) {
 
 		Color guide_color = get_theme_color("guide_color");
 		Color font_color = get_theme_color("font_color");
-		Color font_color_selected = get_theme_color("font_color_selected");
+		Color font_selected_color = get_theme_color("font_selected_color");
 
 		if (has_focus()) {
 			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
@@ -1188,7 +1188,7 @@ void ItemList::_notification(int p_what) {
 					max_len = size2.x;
 				}
 
-				Color modulate = items[i].selected ? font_color_selected : (items[i].custom_fg != Color() ? items[i].custom_fg : font_color);
+				Color modulate = items[i].selected ? font_selected_color : (items[i].custom_fg != Color() ? items[i].custom_fg : font_color);
 				if (items[i].disabled) {
 					modulate.a *= 0.5;
 				}

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -184,10 +184,10 @@ void Label::_notification(int p_what) {
 		Ref<StyleBox> style = get_theme_stylebox("normal");
 		Ref<Font> font = get_theme_font("font");
 		Color font_color = get_theme_color("font_color");
-		Color font_color_shadow = get_theme_color("font_color_shadow");
+		Color font_shadow_color = get_theme_color("font_shadow_color");
 		Point2 shadow_ofs(get_theme_constant("shadow_offset_x"), get_theme_constant("shadow_offset_y"));
 		int line_spacing = get_theme_constant("line_spacing");
-		Color font_outline_modulate = get_theme_color("font_outline_modulate");
+		Color font_outline_color = get_theme_color("font_outline_color");
 		int outline_size = get_theme_constant("outline_size");
 		int shadow_outline_size = get_theme_constant("shadow_outline_size");
 		bool rtl = is_layout_rtl();
@@ -298,17 +298,17 @@ void Label::_notification(int p_what) {
 			for (int j = 0; j < gl_size; j++) {
 				for (int k = 0; k < glyphs[j].repeat; k++) {
 					if (glyphs[j].font_rid != RID()) {
-						if (font_color_shadow.a > 0) {
-							TS->font_draw_glyph(glyphs[j].font_rid, ci, glyphs[j].font_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + shadow_ofs, glyphs[j].index, font_color_shadow);
+						if (font_shadow_color.a > 0) {
+							TS->font_draw_glyph(glyphs[j].font_rid, ci, glyphs[j].font_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + shadow_ofs, glyphs[j].index, font_shadow_color);
 							if (shadow_outline_size > 0) {
 								//draw shadow
-								TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, shadow_outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + Vector2(-shadow_ofs.x, shadow_ofs.y), glyphs[j].index, font_color_shadow);
-								TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, shadow_outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + Vector2(shadow_ofs.x, -shadow_ofs.y), glyphs[j].index, font_color_shadow);
-								TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, shadow_outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + Vector2(-shadow_ofs.x, -shadow_ofs.y), glyphs[j].index, font_color_shadow);
+								TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, shadow_outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + Vector2(-shadow_ofs.x, shadow_ofs.y), glyphs[j].index, font_shadow_color);
+								TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, shadow_outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + Vector2(shadow_ofs.x, -shadow_ofs.y), glyphs[j].index, font_shadow_color);
+								TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, shadow_outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off) + Vector2(-shadow_ofs.x, -shadow_ofs.y), glyphs[j].index, font_shadow_color);
 							}
 						}
-						if (font_outline_modulate.a != 0.0 && outline_size > 0) {
-							TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off), glyphs[j].index, font_outline_modulate);
+						if (font_outline_color.a != 0.0 && outline_size > 0) {
+							TS->font_draw_glyph_outline(glyphs[j].font_rid, ci, glyphs[j].font_size, outline_size, ofs + Vector2(glyphs[j].x_off, glyphs[j].y_off), glyphs[j].index, font_outline_color);
 						}
 					}
 					ofs.x += glyphs[j].advance;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -770,8 +770,8 @@ void LineEdit::_notification(int p_what) {
 			int y_ofs = style->get_offset().y + (y_area - text_height) / 2;
 
 			Color selection_color = get_theme_color("selection_color");
-			Color font_color = is_editable() ? get_theme_color("font_color") : get_theme_color("font_color_uneditable");
-			Color font_color_selected = get_theme_color("font_color_selected");
+			Color font_color = is_editable() ? get_theme_color("font_color") : get_theme_color("font_uneditable_color");
+			Color font_selected_color = get_theme_color("font_selected_color");
 			Color cursor_color = get_theme_color("cursor_color");
 
 			// Draw placeholder color.
@@ -839,9 +839,9 @@ void LineEdit::_notification(int p_what) {
 				for (int j = 0; j < glyphs[i].repeat; j++) {
 					if (ceil(ofs.x) >= x_ofs && (ofs.x + glyphs[i].advance) <= ofs_max) {
 						if (glyphs[i].font_rid != RID()) {
-							TS->font_draw_glyph(glyphs[i].font_rid, ci, glyphs[i].font_size, ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, selected ? font_color_selected : font_color);
+							TS->font_draw_glyph(glyphs[i].font_rid, ci, glyphs[i].font_size, ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, selected ? font_selected_color : font_color);
 						} else if ((glyphs[i].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) {
-							TS->draw_hex_code_box(ci, glyphs[i].font_size, ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, selected ? font_color_selected : font_color);
+							TS->draw_hex_code_box(ci, glyphs[i].font_size, ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, selected ? font_selected_color : font_color);
 						}
 					}
 					ofs.x += glyphs[i].advance;

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -163,8 +163,8 @@ void LinkButton::_notification(int p_what) {
 				} break;
 				case DRAW_HOVER_PRESSED:
 				case DRAW_PRESSED: {
-					if (has_theme_color("font_color_pressed")) {
-						color = get_theme_color("font_color_pressed");
+					if (has_theme_color("font_pressed_color")) {
+						color = get_theme_color("font_pressed_color");
 					} else {
 						color = get_theme_color("font_color");
 					}
@@ -173,12 +173,12 @@ void LinkButton::_notification(int p_what) {
 
 				} break;
 				case DRAW_HOVER: {
-					color = get_theme_color("font_color_hover");
+					color = get_theme_color("font_hover_color");
 					do_underline = underline_mode != UNDERLINE_MODE_NEVER;
 
 				} break;
 				case DRAW_DISABLED: {
-					color = get_theme_color("font_color_disabled");
+					color = get_theme_color("font_disabled_color");
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
 
 				} break;

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -62,13 +62,13 @@ void OptionButton::_notification(int p_what) {
 			if (get_theme_constant("modulate_arrow")) {
 				switch (get_draw_mode()) {
 					case DRAW_PRESSED:
-						clr = get_theme_color("font_color_pressed");
+						clr = get_theme_color("font_pressed_color");
 						break;
 					case DRAW_HOVER:
-						clr = get_theme_color("font_color_hover");
+						clr = get_theme_color("font_hover_color");
 						break;
 					case DRAW_DISABLED:
-						clr = get_theme_color("font_color_disabled");
+						clr = get_theme_color("font_disabled_color");
 						break;
 					default:
 						clr = get_theme_color("font_color");

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -471,10 +471,10 @@ void PopupMenu::_draw_items() {
 	int vseparation = get_theme_constant("vseparation");
 	int hseparation = get_theme_constant("hseparation");
 	Color font_color = get_theme_color("font_color");
-	Color font_color_disabled = get_theme_color("font_color_disabled");
-	Color font_color_accel = get_theme_color("font_color_accel");
-	Color font_color_hover = get_theme_color("font_color_hover");
-	Color font_color_separator = get_theme_color("font_color_separator");
+	Color font_disabled_color = get_theme_color("font_disabled_color");
+	Color font_accelerator_color = get_theme_color("font_accelerator_color");
+	Color font_hover_color = get_theme_color("font_hover_color");
+	Color font_separator_color = get_theme_color("font_separator_color");
 
 	float scroll_width = scroll_container->get_v_scrollbar()->is_visible_in_tree() ? scroll_container->get_v_scrollbar()->get_size().width : 0;
 	float display_width = control->get_size().width - scroll_width;
@@ -575,14 +575,14 @@ void PopupMenu::_draw_items() {
 		if (items[i].separator) {
 			if (text != String()) {
 				int center = (display_width - items[i].text_buf->get_size().width) / 2;
-				items[i].text_buf->draw(ci, Point2(center, item_ofs.y + Math::floor((h - items[i].text_buf->get_size().y) / 2.0)), font_color_separator);
+				items[i].text_buf->draw(ci, Point2(center, item_ofs.y + Math::floor((h - items[i].text_buf->get_size().y) / 2.0)), font_separator_color);
 			}
 		} else {
 			item_ofs.x += icon_ofs + check_ofs;
 			if (rtl) {
-				items[i].text_buf->draw(ci, Size2(control->get_size().width - items[i].text_buf->get_size().width - item_ofs.x, item_ofs.y) + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0)), items[i].disabled ? font_color_disabled : (i == mouse_over ? font_color_hover : font_color));
+				items[i].text_buf->draw(ci, Size2(control->get_size().width - items[i].text_buf->get_size().width - item_ofs.x, item_ofs.y) + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0)), items[i].disabled ? font_disabled_color : (i == mouse_over ? font_hover_color : font_color));
 			} else {
-				items[i].text_buf->draw(ci, item_ofs + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0)), items[i].disabled ? font_color_disabled : (i == mouse_over ? font_color_hover : font_color));
+				items[i].text_buf->draw(ci, item_ofs + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0)), items[i].disabled ? font_disabled_color : (i == mouse_over ? font_hover_color : font_color));
 			}
 		}
 
@@ -593,7 +593,7 @@ void PopupMenu::_draw_items() {
 			} else {
 				item_ofs.x = display_width - style->get_margin(SIDE_RIGHT) - items[i].accel_text_buf->get_size().x;
 			}
-			items[i].accel_text_buf->draw(ci, item_ofs + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0)), i == mouse_over ? font_color_hover : font_color_accel);
+			items[i].accel_text_buf->draw(ci, item_ofs + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0)), i == mouse_over ? font_hover_color : font_accelerator_color);
 		}
 
 		// Cache the item vertical offset from the first item and the height

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -618,7 +618,7 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 	}
 }
 
-int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_color_shadow, bool p_shadow_as_outline, const Point2 &p_shadow_ofs) {
+int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_shadow_color, bool p_shadow_as_outline, const Point2 &p_shadow_ofs) {
 	Vector2 off;
 
 	ERR_FAIL_COND_V(p_frame == nullptr, 0);
@@ -800,7 +800,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 							}
 
 							for (int j = 0; j < frame->lines.size(); j++) {
-								_draw_line(frame, j, p_ofs + rect.position + off + Vector2(0, frame->lines[j].offset.y), rect.size.x, p_base_color, p_outline_size, p_outline_color, p_font_color_shadow, p_shadow_as_outline, p_shadow_ofs);
+								_draw_line(frame, j, p_ofs + rect.position + off + Vector2(0, frame->lines[j].offset.y), rect.size.x, p_base_color, p_outline_size, p_outline_color, p_font_shadow_color, p_shadow_as_outline, p_shadow_ofs);
 							}
 							idx++;
 						}
@@ -920,9 +920,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 				if (visible) {
 					if (frid != RID()) {
 						if (p_shadow_as_outline) {
-							TS->font_draw_glyph_outline(frid, ci, glyphs[i].font_size, size, p_ofs + fx_offset + gloff + Vector2(-shadow_ofs.x, shadow_ofs.y), gl, p_font_color_shadow);
-							TS->font_draw_glyph_outline(frid, ci, glyphs[i].font_size, size, p_ofs + fx_offset + gloff + Vector2(shadow_ofs.x, -shadow_ofs.y), gl, p_font_color_shadow);
-							TS->font_draw_glyph_outline(frid, ci, glyphs[i].font_size, size, p_ofs + fx_offset + gloff + Vector2(-shadow_ofs.x, -shadow_ofs.y), gl, p_font_color_shadow);
+							TS->font_draw_glyph_outline(frid, ci, glyphs[i].font_size, size, p_ofs + fx_offset + gloff + Vector2(-shadow_ofs.x, shadow_ofs.y), gl, p_font_shadow_color);
+							TS->font_draw_glyph_outline(frid, ci, glyphs[i].font_size, size, p_ofs + fx_offset + gloff + Vector2(shadow_ofs.x, -shadow_ofs.y), gl, p_font_shadow_color);
+							TS->font_draw_glyph_outline(frid, ci, glyphs[i].font_size, size, p_ofs + fx_offset + gloff + Vector2(-shadow_ofs.x, -shadow_ofs.y), gl, p_font_shadow_color);
 						}
 						TS->font_draw_glyph_outline(frid, ci, glyphs[i].font_size, size, p_ofs + fx_offset + gloff, gl, font_color);
 					}
@@ -932,7 +932,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 		}
 
 		// Draw main text.
-		Color selection_fg = get_theme_color("font_color_selected");
+		Color selection_fg = get_theme_color("font_selected_color");
 		Color selection_bg = get_theme_color("selection_color");
 
 		int sel_start = -1;
@@ -1400,7 +1400,7 @@ void RichTextLabel::_notification(int p_what) {
 			Color base_color = get_theme_color("default_color");
 			Color outline_color = get_theme_color("outline_color");
 			int outline_size = get_theme_constant("outline_size");
-			Color font_color_shadow = get_theme_color("font_color_shadow");
+			Color font_shadow_color = get_theme_color("font_shadow_color");
 			bool use_outline = get_theme_constant("shadow_as_outline");
 			Point2 shadow_ofs(get_theme_constant("shadow_offset_x"), get_theme_constant("shadow_offset_y"));
 
@@ -1411,7 +1411,7 @@ void RichTextLabel::_notification(int p_what) {
 			Point2 ofs = text_rect.get_position() + Vector2(0, main->lines[from_line].offset.y - vofs);
 			while (ofs.y < size.height && from_line < main->lines.size()) {
 				visible_paragraph_count++;
-				visible_line_count += _draw_line(main, from_line, ofs, text_rect.size.x, base_color, outline_size, outline_color, font_color_shadow, use_outline, shadow_ofs);
+				visible_line_count += _draw_line(main, from_line, ofs, text_rect.size.x, base_color, outline_size, outline_color, font_shadow_color, use_outline, shadow_ofs);
 				ofs.y += main->lines[from_line].text_buf->get_size().y;
 				from_line++;
 			}

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -394,7 +394,7 @@ private:
 
 	void _shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width, int *r_char_offset);
 	void _resize_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width);
-	int _draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_color_shadow, bool p_shadow_as_outline, const Point2 &shadow_ofs);
+	int _draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_shadow_color, bool p_shadow_as_outline, const Point2 &shadow_ofs);
 	float _find_click_in_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr);
 
 	String _roman(int p_num, bool p_capitalize) const;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -43,11 +43,11 @@ int TabContainer::_get_top_margin() const {
 	}
 
 	// Respect the minimum tab height.
-	Ref<StyleBox> tab_bg = get_theme_stylebox("tab_bg");
-	Ref<StyleBox> tab_fg = get_theme_stylebox("tab_fg");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
+	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
 	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
 
-	int tab_height = MAX(MAX(tab_bg->get_minimum_size().height, tab_fg->get_minimum_size().height), tab_disabled->get_minimum_size().height);
+	int tab_height = MAX(MAX(tab_unselected->get_minimum_size().height, tab_selected->get_minimum_size().height), tab_disabled->get_minimum_size().height);
 
 	// Font height or higher icon wins.
 	int content_height = 0;
@@ -337,8 +337,8 @@ void TabContainer::_notification(int p_what) {
 			}
 
 			Vector<Control *> tabs = _get_tabs();
-			Ref<StyleBox> tab_bg = get_theme_stylebox("tab_bg");
-			Ref<StyleBox> tab_fg = get_theme_stylebox("tab_fg");
+			Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
+			Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
 			Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
 			Ref<Texture2D> increment = get_theme_icon("increment");
 			Ref<Texture2D> increment_hl = get_theme_icon("increment_highlight");
@@ -346,9 +346,9 @@ void TabContainer::_notification(int p_what) {
 			Ref<Texture2D> decrement_hl = get_theme_icon("decrement_highlight");
 			Ref<Texture2D> menu = get_theme_icon("menu");
 			Ref<Texture2D> menu_hl = get_theme_icon("menu_highlight");
-			Color font_color_fg = get_theme_color("font_color_fg");
-			Color font_color_bg = get_theme_color("font_color_bg");
-			Color font_color_disabled = get_theme_color("font_color_disabled");
+			Color font_selected_color = get_theme_color("font_selected_color");
+			Color font_unselected_color = get_theme_color("font_unselected_color");
+			Color font_disabled_color = get_theme_color("font_disabled_color");
 			int side_margin = get_theme_constant("side_margin");
 
 			// Find out start and width of the header area.
@@ -433,17 +433,17 @@ void TabContainer::_notification(int p_what) {
 				int tab_width = tab_widths[i];
 				if (get_tab_disabled(index)) {
 					if (rtl) {
-						_draw_tab(tab_disabled, font_color_disabled, index, size.width - (tabs_ofs_cache + x) - tab_width);
+						_draw_tab(tab_disabled, font_disabled_color, index, size.width - (tabs_ofs_cache + x) - tab_width);
 					} else {
-						_draw_tab(tab_disabled, font_color_disabled, index, tabs_ofs_cache + x);
+						_draw_tab(tab_disabled, font_disabled_color, index, tabs_ofs_cache + x);
 					}
 				} else if (index == current) {
 					x_current = x;
 				} else {
 					if (rtl) {
-						_draw_tab(tab_bg, font_color_bg, index, size.width - (tabs_ofs_cache + x) - tab_width);
+						_draw_tab(tab_unselected, font_unselected_color, index, size.width - (tabs_ofs_cache + x) - tab_width);
 					} else {
-						_draw_tab(tab_bg, font_color_bg, index, tabs_ofs_cache + x);
+						_draw_tab(tab_unselected, font_unselected_color, index, tabs_ofs_cache + x);
 					}
 				}
 
@@ -459,9 +459,9 @@ void TabContainer::_notification(int p_what) {
 			// Draw selected tab in front. only draw selected tab when it's in visible range.
 			if (tabs.size() > 0 && current - first_tab_cache < tab_widths.size() && current >= first_tab_cache) {
 				if (rtl) {
-					_draw_tab(tab_fg, font_color_fg, current, size.width - (tabs_ofs_cache + x_current) - tab_widths[current]);
+					_draw_tab(tab_selected, font_selected_color, current, size.width - (tabs_ofs_cache + x_current) - tab_widths[current]);
 				} else {
-					_draw_tab(tab_fg, font_color_fg, current, tabs_ofs_cache + x_current);
+					_draw_tab(tab_selected, font_selected_color, current, tabs_ofs_cache + x_current);
 				}
 			}
 
@@ -655,15 +655,15 @@ int TabContainer::_get_tab_width(int p_index) const {
 	}
 
 	// Respect a minimum size.
-	Ref<StyleBox> tab_bg = get_theme_stylebox("tab_bg");
-	Ref<StyleBox> tab_fg = get_theme_stylebox("tab_fg");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
+	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
 	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
 	if (get_tab_disabled(p_index)) {
 		width += tab_disabled->get_minimum_size().width;
 	} else if (p_index == current) {
-		width += tab_fg->get_minimum_size().width;
+		width += tab_selected->get_minimum_size().width;
 	} else {
-		width += tab_bg->get_minimum_size().width;
+		width += tab_unselected->get_minimum_size().width;
 	}
 
 	return width;
@@ -1131,13 +1131,13 @@ Size2 TabContainer::get_minimum_size() const {
 		ms.y = MAX(ms.y, cms.y);
 	}
 
-	Ref<StyleBox> tab_bg = get_theme_stylebox("tab_bg");
-	Ref<StyleBox> tab_fg = get_theme_stylebox("tab_fg");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
+	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
 	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
 	Ref<Font> font = get_theme_font("font");
 
 	if (tabs_visible) {
-		ms.y += MAX(MAX(tab_bg->get_minimum_size().y, tab_fg->get_minimum_size().y), tab_disabled->get_minimum_size().y);
+		ms.y += MAX(MAX(tab_unselected->get_minimum_size().y, tab_selected->get_minimum_size().y), tab_disabled->get_minimum_size().y);
 		ms.y += _get_top_margin();
 	}
 

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -38,11 +38,11 @@
 #include "scene/gui/texture_rect.h"
 
 Size2 Tabs::get_minimum_size() const {
-	Ref<StyleBox> tab_bg = get_theme_stylebox("tab_bg");
-	Ref<StyleBox> tab_fg = get_theme_stylebox("tab_fg");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
+	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
 	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
 
-	int y_margin = MAX(MAX(tab_bg->get_minimum_size().height, tab_fg->get_minimum_size().height), tab_disabled->get_minimum_size().height);
+	int y_margin = MAX(MAX(tab_unselected->get_minimum_size().height, tab_selected->get_minimum_size().height), tab_disabled->get_minimum_size().height);
 
 	Size2 ms(0, 0);
 
@@ -61,9 +61,9 @@ Size2 Tabs::get_minimum_size() const {
 		if (tabs[i].disabled) {
 			ms.width += tab_disabled->get_minimum_size().width;
 		} else if (current == i) {
-			ms.width += tab_fg->get_minimum_size().width;
+			ms.width += tab_selected->get_minimum_size().width;
 		} else {
-			ms.width += tab_bg->get_minimum_size().width;
+			ms.width += tab_unselected->get_minimum_size().width;
 		}
 
 		if (tabs[i].right_button.is_valid()) {
@@ -71,7 +71,7 @@ Size2 Tabs::get_minimum_size() const {
 			Size2 bms = rb->get_size();
 			bms.width += get_theme_constant("hseparation");
 			ms.width += bms.width;
-			ms.height = MAX(bms.height + tab_bg->get_minimum_size().height, ms.height);
+			ms.height = MAX(bms.height + tab_unselected->get_minimum_size().height, ms.height);
 		}
 
 		if (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current)) {
@@ -79,7 +79,7 @@ Size2 Tabs::get_minimum_size() const {
 			Size2 bms = cb->get_size();
 			bms.width += get_theme_constant("hseparation");
 			ms.width += bms.width;
-			ms.height = MAX(bms.height + tab_bg->get_minimum_size().height, ms.height);
+			ms.height = MAX(bms.height + tab_unselected->get_minimum_size().height, ms.height);
 		}
 	}
 
@@ -268,12 +268,12 @@ void Tabs::_notification(int p_what) {
 			_update_cache();
 			RID ci = get_canvas_item();
 
-			Ref<StyleBox> tab_bg = get_theme_stylebox("tab_bg");
-			Ref<StyleBox> tab_fg = get_theme_stylebox("tab_fg");
+			Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
+			Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
 			Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
-			Color color_fg = get_theme_color("font_color_fg");
-			Color color_bg = get_theme_color("font_color_bg");
-			Color color_disabled = get_theme_color("font_color_disabled");
+			Color font_selected_color = get_theme_color("font_selected_color");
+			Color font_unselected_color = get_theme_color("font_unselected_color");
+			Color font_disabled_color = get_theme_color("font_disabled_color");
 			Ref<Texture2D> close = get_theme_icon("close");
 			Vector2 size = get_size();
 			bool rtl = is_layout_rtl();
@@ -316,13 +316,13 @@ void Tabs::_notification(int p_what) {
 
 				if (tabs[i].disabled) {
 					sb = tab_disabled;
-					col = color_disabled;
+					col = font_disabled_color;
 				} else if (i == current) {
-					sb = tab_fg;
-					col = color_fg;
+					sb = tab_selected;
+					col = font_selected_color;
 				} else {
-					sb = tab_bg;
-					col = color_bg;
+					sb = tab_unselected;
+					col = font_unselected_color;
 				}
 
 				if (w + lsize > limit) {
@@ -652,8 +652,8 @@ void Tabs::_update_hover() {
 
 void Tabs::_update_cache() {
 	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
-	Ref<StyleBox> tab_bg = get_theme_stylebox("tab_bg");
-	Ref<StyleBox> tab_fg = get_theme_stylebox("tab_fg");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
+	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
 	Ref<Texture2D> incr = get_theme_icon("increment");
 	Ref<Texture2D> decr = get_theme_icon("decrement");
 	int limit = get_size().width - incr->get_width() - decr->get_width();
@@ -683,9 +683,9 @@ void Tabs::_update_cache() {
 		if (tabs[i].disabled) {
 			sb = tab_disabled;
 		} else if (i == current) {
-			sb = tab_fg;
+			sb = tab_selected;
 		} else {
-			sb = tab_bg;
+			sb = tab_unselected;
 		}
 		int lsize = tabs[i].size_cache;
 		int slen = tabs[i].size_text;
@@ -918,8 +918,8 @@ void Tabs::move_tab(int from, int to) {
 int Tabs::get_tab_width(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, tabs.size(), 0);
 
-	Ref<StyleBox> tab_bg = get_theme_stylebox("tab_bg");
-	Ref<StyleBox> tab_fg = get_theme_stylebox("tab_fg");
+	Ref<StyleBox> tab_unselected = get_theme_stylebox("tab_unselected");
+	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
 	Ref<StyleBox> tab_disabled = get_theme_stylebox("tab_disabled");
 
 	int x = 0;
@@ -937,9 +937,9 @@ int Tabs::get_tab_width(int p_idx) const {
 	if (tabs[p_idx].disabled) {
 		x += tab_disabled->get_minimum_size().width;
 	} else if (current == p_idx) {
-		x += tab_fg->get_minimum_size().width;
+		x += tab_selected->get_minimum_size().width;
 	} else {
-		x += tab_bg->get_minimum_size().width;
+		x += tab_unselected->get_minimum_size().width;
 	}
 
 	if (tabs[p_idx].right_button.is_valid()) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -637,7 +637,7 @@ void TextEdit::_notification(int p_what) {
 
 			int visible_rows = get_visible_rows() + 1;
 
-			Color color = readonly ? cache.font_color_readonly : cache.font_color;
+			Color color = readonly ? cache.font_readonly_color : cache.font_color;
 
 			if (cache.background_color.a > 0.01) {
 				RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2i(), get_size()), cache.background_color);
@@ -877,7 +877,7 @@ void TextEdit::_notification(int p_what) {
 
 					Color current_color = cache.font_color;
 					if (readonly) {
-						current_color = cache.font_color_readonly;
+						current_color = cache.font_readonly_color;
 					}
 
 					Vector<String> wrap_rows = get_wrap_rows_text(minimap_line);
@@ -918,7 +918,7 @@ void TextEdit::_notification(int p_what) {
 							if (color_map.has(last_wrap_column + j)) {
 								current_color = color_map[last_wrap_column + j].get("color");
 								if (readonly) {
-									current_color.a = cache.font_color_readonly.a;
+									current_color.a = cache.font_readonly_color.a;
 								}
 							}
 							color = current_color;
@@ -1001,7 +1001,7 @@ void TextEdit::_notification(int p_what) {
 				Dictionary color_map = _get_line_syntax_highlighting(line);
 
 				// Ensure we at least use the font color.
-				Color current_color = readonly ? cache.font_color_readonly : cache.font_color;
+				Color current_color = readonly ? cache.font_readonly_color : cache.font_color;
 
 				const Ref<TextParagraph> ldata = text.get_line_data(line);
 
@@ -1230,7 +1230,7 @@ void TextEdit::_notification(int p_what) {
 									}
 									rect.position.y = TS->shaped_text_get_ascent(rid) + cache.font->get_underline_position(cache.font_size);
 									rect.size.y = cache.font->get_underline_thickness(cache.font_size);
-									draw_rect(rect, cache.font_color_selected);
+									draw_rect(rect, cache.font_selected_color);
 								}
 
 								highlighted_word_col = _get_column_pos_of_word(highlighted_word, str, SEARCH_MATCH_CASE | SEARCH_WHOLE_WORDS, highlighted_word_col + 1);
@@ -1249,8 +1249,8 @@ void TextEdit::_notification(int p_what) {
 					for (int j = 0; j < gl_size; j++) {
 						if (color_map.has(glyphs[j].start)) {
 							current_color = color_map[glyphs[j].start].get("color");
-							if (readonly && current_color.a > cache.font_color_readonly.a) {
-								current_color.a = cache.font_color_readonly.a;
+							if (readonly && current_color.a > cache.font_readonly_color.a) {
+								current_color.a = cache.font_readonly_color.a;
 							}
 						}
 
@@ -1259,7 +1259,7 @@ void TextEdit::_notification(int p_what) {
 							int sel_to = (line < selection.to_line) ? TS->shaped_text_get_range(rid).y : selection.to_column;
 
 							if (glyphs[j].start >= sel_from && glyphs[j].end <= sel_to && override_selected_font_color) {
-								current_color = cache.font_color_selected;
+								current_color = cache.font_selected_color;
 							}
 						}
 
@@ -4900,8 +4900,8 @@ void TextEdit::_update_caches() {
 	cache.caret_color = get_theme_color("caret_color");
 	cache.caret_background_color = get_theme_color("caret_background_color");
 	cache.font_color = get_theme_color("font_color");
-	cache.font_color_selected = get_theme_color("font_color_selected");
-	cache.font_color_readonly = get_theme_color("font_color_readonly");
+	cache.font_selected_color = get_theme_color("font_selected_color");
+	cache.font_readonly_color = get_theme_color("font_readonly_color");
 	cache.selection_color = get_theme_color("selection_color");
 	cache.mark_color = get_theme_color("mark_color");
 	cache.current_line_color = get_theme_color("current_line_color");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -485,8 +485,8 @@ protected:
 		Color caret_color;
 		Color caret_background_color;
 		Color font_color;
-		Color font_color_selected;
-		Color font_color_readonly;
+		Color font_selected_color;
+		Color font_readonly_color;
 		Color selection_color;
 		Color mark_color;
 		Color code_folding_color;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1018,7 +1018,7 @@ void Tree::update_cache() {
 	cache.custom_button_font_highlight = get_theme_color("custom_button_font_highlight");
 
 	cache.font_color = get_theme_color("font_color");
-	cache.font_color_selected = get_theme_color("font_color_selected");
+	cache.font_selected_color = get_theme_color("font_selected_color");
 	cache.guide_color = get_theme_color("guide_color");
 	cache.drop_position_color = get_theme_color("drop_position_color");
 	cache.hseparation = get_theme_constant("hseparation");
@@ -1433,7 +1433,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				}
 			}
 
-			Color col = p_item->cells[i].custom_color ? p_item->cells[i].color : get_theme_color(p_item->cells[i].selected ? "font_color_selected" : "font_color");
+			Color col = p_item->cells[i].custom_color ? p_item->cells[i].color : get_theme_color(p_item->cells[i].selected ? "font_selected_color" : "font_color");
 			Color icon_col = p_item->cells[i].icon_color;
 
 			if (p_item->cells[i].dirty) {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -459,7 +459,7 @@ private:
 		Ref<Texture2D> updown;
 
 		Color font_color;
-		Color font_color_selected;
+		Color font_selected_color;
 		Color guide_color;
 		Color drop_position_color;
 		Color relationship_line_color;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -146,12 +146,13 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// Font Colors
 
 	Color control_font_color = Color(0.88, 0.88, 0.88);
-	Color control_font_color_lower = Color(0.63, 0.63, 0.63);
-	Color control_font_color_low = Color(0.69, 0.69, 0.69);
-	Color control_font_color_hover = Color(0.94, 0.94, 0.94);
-	Color control_font_color_disabled = Color(0.9, 0.9, 0.9, 0.2);
-	Color control_font_color_pressed = Color(1, 1, 1);
-	Color font_color_selection = Color(0.49, 0.49, 0.49);
+	Color control_font_lower_color = Color(0.63, 0.63, 0.63);
+	Color control_font_low_color = Color(0.69, 0.69, 0.69);
+	Color control_font_hover_color = Color(0.94, 0.94, 0.94);
+	Color control_font_disabled_color = Color(0.9, 0.9, 0.9, 0.2);
+	Color control_font_pressed_color = Color(1, 1, 1);
+
+	Color control_selection_color = Color(0.49, 0.49, 0.49);
 
 	// Panel
 
@@ -184,10 +185,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("outline_size", "Button", 0 * scale);
 
 	theme->set_color("font_color", "Button", control_font_color);
-	theme->set_color("font_color_pressed", "Button", control_font_color_pressed);
-	theme->set_color("font_color_hover", "Button", control_font_color_hover);
-	theme->set_color("font_color_disabled", "Button", control_font_color_disabled);
-	theme->set_color("font_outline_modulate", "Button", Color(1, 1, 1));
+	theme->set_color("font_pressed_color", "Button", control_font_pressed_color);
+	theme->set_color("font_hover_color", "Button", control_font_hover_color);
+	theme->set_color("font_disabled_color", "Button", control_font_disabled_color);
+	theme->set_color("font_outline_color", "Button", Color(1, 1, 1));
 
 	theme->set_constant("hseparation", "Button", 2 * scale);
 
@@ -199,8 +200,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "LinkButton", -1);
 
 	theme->set_color("font_color", "LinkButton", control_font_color);
-	theme->set_color("font_color_pressed", "LinkButton", control_font_color_pressed);
-	theme->set_color("font_color_hover", "LinkButton", control_font_color_hover);
+	theme->set_color("font_pressed_color", "LinkButton", control_font_pressed_color);
+	theme->set_color("font_hover_color", "LinkButton", control_font_hover_color);
 
 	theme->set_constant("underline_spacing", "LinkButton", 2 * scale);
 
@@ -216,9 +217,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "ColorPickerButton", -1);
 
 	theme->set_color("font_color", "ColorPickerButton", Color(1, 1, 1, 1));
-	theme->set_color("font_color_pressed", "ColorPickerButton", Color(0.8, 0.8, 0.8, 1));
-	theme->set_color("font_color_hover", "ColorPickerButton", Color(1, 1, 1, 1));
-	theme->set_color("font_color_disabled", "ColorPickerButton", Color(0.9, 0.9, 0.9, 0.3));
+	theme->set_color("font_pressed_color", "ColorPickerButton", Color(0.8, 0.8, 0.8, 1));
+	theme->set_color("font_hover_color", "ColorPickerButton", Color(1, 1, 1, 1));
+	theme->set_color("font_disabled_color", "ColorPickerButton", Color(0.9, 0.9, 0.9, 0.3));
 
 	theme->set_constant("hseparation", "ColorPickerButton", 2 * scale);
 
@@ -253,9 +254,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "OptionButton", -1);
 
 	theme->set_color("font_color", "OptionButton", control_font_color);
-	theme->set_color("font_color_pressed", "OptionButton", control_font_color_pressed);
-	theme->set_color("font_color_hover", "OptionButton", control_font_color_hover);
-	theme->set_color("font_color_disabled", "OptionButton", control_font_color_disabled);
+	theme->set_color("font_pressed_color", "OptionButton", control_font_pressed_color);
+	theme->set_color("font_hover_color", "OptionButton", control_font_hover_color);
+	theme->set_color("font_disabled_color", "OptionButton", control_font_disabled_color);
 
 	theme->set_constant("hseparation", "OptionButton", 2 * scale);
 	theme->set_constant("arrow_margin", "OptionButton", 2 * scale);
@@ -272,9 +273,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "MenuButton", -1);
 
 	theme->set_color("font_color", "MenuButton", control_font_color);
-	theme->set_color("font_color_pressed", "MenuButton", control_font_color_pressed);
-	theme->set_color("font_color_hover", "MenuButton", control_font_color_hover);
-	theme->set_color("font_color_disabled", "MenuButton", Color(1, 1, 1, 0.3));
+	theme->set_color("font_pressed_color", "MenuButton", control_font_pressed_color);
+	theme->set_color("font_hover_color", "MenuButton", control_font_hover_color);
+	theme->set_color("font_disabled_color", "MenuButton", Color(1, 1, 1, 0.3));
 
 	theme->set_constant("hseparation", "MenuButton", 3 * scale);
 
@@ -307,10 +308,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "CheckBox", -1);
 
 	theme->set_color("font_color", "CheckBox", control_font_color);
-	theme->set_color("font_color_pressed", "CheckBox", control_font_color_pressed);
-	theme->set_color("font_color_hover", "CheckBox", control_font_color_hover);
-	theme->set_color("font_color_hover_pressed", "CheckBox", control_font_color_pressed);
-	theme->set_color("font_color_disabled", "CheckBox", control_font_color_disabled);
+	theme->set_color("font_pressed_color", "CheckBox", control_font_pressed_color);
+	theme->set_color("font_hover_color", "CheckBox", control_font_hover_color);
+	theme->set_color("font_hover_color_pressed", "CheckBox", control_font_pressed_color);
+	theme->set_color("font_disabled_color", "CheckBox", control_font_disabled_color);
 
 	theme->set_constant("hseparation", "CheckBox", 4 * scale);
 	theme->set_constant("check_vadjust", "CheckBox", 0 * scale);
@@ -344,10 +345,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "CheckButton", -1);
 
 	theme->set_color("font_color", "CheckButton", control_font_color);
-	theme->set_color("font_color_pressed", "CheckButton", control_font_color_pressed);
-	theme->set_color("font_color_hover", "CheckButton", control_font_color_hover);
-	theme->set_color("font_color_hover_pressed", "CheckButton", control_font_color_pressed);
-	theme->set_color("font_color_disabled", "CheckButton", control_font_color_disabled);
+	theme->set_color("font_pressed_color", "CheckButton", control_font_pressed_color);
+	theme->set_color("font_hover_color", "CheckButton", control_font_hover_color);
+	theme->set_color("font_hover_color_pressed", "CheckButton", control_font_pressed_color);
+	theme->set_color("font_disabled_color", "CheckButton", control_font_disabled_color);
 
 	theme->set_constant("hseparation", "CheckButton", 4 * scale);
 	theme->set_constant("check_vadjust", "CheckButton", 0 * scale);
@@ -359,8 +360,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "Label", -1);
 
 	theme->set_color("font_color", "Label", Color(1, 1, 1));
-	theme->set_color("font_color_shadow", "Label", Color(0, 0, 0, 0));
-	theme->set_color("font_outline_modulate", "Label", Color(1, 1, 1));
+	theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
+	theme->set_color("font_outline_color", "Label", Color(1, 1, 1));
 
 	theme->set_constant("shadow_offset_x", "Label", 1 * scale);
 	theme->set_constant("shadow_offset_y", "Label", 1 * scale);
@@ -378,12 +379,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "LineEdit", -1);
 
 	theme->set_color("font_color", "LineEdit", control_font_color);
-	theme->set_color("font_color_selected", "LineEdit", Color(0, 0, 0));
-	theme->set_color("font_color_uneditable", "LineEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
-	theme->set_color("cursor_color", "LineEdit", control_font_color_hover);
-	theme->set_color("selection_color", "LineEdit", font_color_selection);
+	theme->set_color("font_selected_color", "LineEdit", Color(0, 0, 0));
+	theme->set_color("font_uneditable_color", "LineEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
+	theme->set_color("cursor_color", "LineEdit", control_font_hover_color);
+	theme->set_color("selection_color", "LineEdit", control_selection_color);
 	theme->set_color("clear_button_color", "LineEdit", control_font_color);
-	theme->set_color("clear_button_color_pressed", "LineEdit", control_font_color_pressed);
+	theme->set_color("clear_button_color_pressed", "LineEdit", control_font_pressed_color);
 
 	theme->set_constant("minimum_spaces", "LineEdit", 12 * scale);
 
@@ -397,8 +398,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font("font", "ProgressBar", Ref<Font>());
 	theme->set_font_size("font_size", "ProgressBar", -1);
 
-	theme->set_color("font_color", "ProgressBar", control_font_color_hover);
-	theme->set_color("font_color_shadow", "ProgressBar", Color(0, 0, 0));
+	theme->set_color("font_color", "ProgressBar", control_font_hover_color);
+	theme->set_color("font_shadow_color", "ProgressBar", Color(0, 0, 0));
 
 	// TextEdit
 
@@ -417,12 +418,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("completion_background_color", "TextEdit", Color(0.17, 0.16, 0.2));
 	theme->set_color("completion_selected_color", "TextEdit", Color(0.26, 0.26, 0.27));
 	theme->set_color("completion_existing_color", "TextEdit", Color(0.87, 0.87, 0.87, 0.13));
-	theme->set_color("completion_scroll_color", "TextEdit", control_font_color_pressed);
+	theme->set_color("completion_scroll_color", "TextEdit", control_font_pressed_color);
 	theme->set_color("completion_font_color", "TextEdit", Color(0.67, 0.67, 0.67));
 	theme->set_color("font_color", "TextEdit", control_font_color);
-	theme->set_color("font_color_selected", "TextEdit", Color(0, 0, 0));
-	theme->set_color("font_color_readonly", "TextEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
-	theme->set_color("selection_color", "TextEdit", font_color_selection);
+	theme->set_color("font_selected_color", "TextEdit", Color(0, 0, 0));
+	theme->set_color("font_readonly_color", "TextEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
+	theme->set_color("selection_color", "TextEdit", control_selection_color);
 	theme->set_color("mark_color", "TextEdit", Color(1.0, 0.4, 0.4, 0.4));
 	theme->set_color("code_folding_color", "TextEdit", Color(0.8, 0.8, 0.8, 0.8));
 	theme->set_color("current_line_color", "TextEdit", Color(0.25, 0.25, 0.26, 0.8));
@@ -457,12 +458,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("completion_background_color", "CodeEdit", Color(0.17, 0.16, 0.2));
 	theme->set_color("completion_selected_color", "CodeEdit", Color(0.26, 0.26, 0.27));
 	theme->set_color("completion_existing_color", "CodeEdit", Color(0.87, 0.87, 0.87, 0.13));
-	theme->set_color("completion_scroll_color", "CodeEdit", control_font_color_pressed);
+	theme->set_color("completion_scroll_color", "CodeEdit", control_font_pressed_color);
 	theme->set_color("completion_font_color", "CodeEdit", Color(0.67, 0.67, 0.67));
 	theme->set_color("font_color", "CodeEdit", control_font_color);
-	theme->set_color("font_color_selected", "CodeEdit", Color(0, 0, 0));
-	theme->set_color("font_color_readonly", "CodeEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
-	theme->set_color("selection_color", "CodeEdit", font_color_selection);
+	theme->set_color("font_selected_color", "CodeEdit", Color(0, 0, 0));
+	theme->set_color("font_readonly_color", "CodeEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
+	theme->set_color("selection_color", "CodeEdit", control_selection_color);
 	theme->set_color("mark_color", "CodeEdit", Color(1.0, 0.4, 0.4, 0.4));
 	theme->set_color("bookmark_color", "CodeEdit", Color(0.5, 0.64, 1, 0.8));
 	theme->set_color("breakpoint_color", "CodeEdit", Color(0.9, 0.29, 0.3));
@@ -598,10 +599,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "PopupMenu", -1);
 
 	theme->set_color("font_color", "PopupMenu", control_font_color);
-	theme->set_color("font_color_accel", "PopupMenu", Color(0.7, 0.7, 0.7, 0.8));
-	theme->set_color("font_color_disabled", "PopupMenu", Color(0.4, 0.4, 0.4, 0.8));
-	theme->set_color("font_color_hover", "PopupMenu", control_font_color);
-	theme->set_color("font_color_separator", "PopupMenu", control_font_color);
+	theme->set_color("font_accelerator_color", "PopupMenu", Color(0.7, 0.7, 0.7, 0.8));
+	theme->set_color("font_disabled_color", "PopupMenu", Color(0.4, 0.4, 0.4, 0.8));
+	theme->set_color("font_hover_color", "PopupMenu", control_font_color);
+	theme->set_color("font_separator_color", "PopupMenu", control_font_color);
 
 	theme->set_constant("hseparation", "PopupMenu", 4 * scale);
 	theme->set_constant("vseparation", "PopupMenu", 4 * scale);
@@ -671,12 +672,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "Tree", -1);
 
 	theme->set_color("title_button_color", "Tree", control_font_color);
-	theme->set_color("font_color", "Tree", control_font_color_low);
-	theme->set_color("font_color_selected", "Tree", control_font_color_pressed);
+	theme->set_color("font_color", "Tree", control_font_low_color);
+	theme->set_color("font_selected_color", "Tree", control_font_pressed_color);
 	theme->set_color("guide_color", "Tree", Color(0, 0, 0, 0.1));
 	theme->set_color("drop_position_color", "Tree", Color(1, 0.3, 0.2));
 	theme->set_color("relationship_line_color", "Tree", Color(0.27, 0.27, 0.27));
-	theme->set_color("custom_button_font_highlight", "Tree", control_font_color_hover);
+	theme->set_color("custom_button_font_highlight", "Tree", control_font_hover_color);
 
 	theme->set_constant("hseparation", "Tree", 4 * scale);
 	theme->set_constant("vseparation", "Tree", 4 * scale);
@@ -701,8 +702,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font("font", "ItemList", Ref<Font>());
 	theme->set_font_size("font_size", "ItemList", -1);
 
-	theme->set_color("font_color", "ItemList", control_font_color_lower);
-	theme->set_color("font_color_selected", "ItemList", control_font_color_pressed);
+	theme->set_color("font_color", "ItemList", control_font_lower_color);
+	theme->set_color("font_selected_color", "ItemList", control_font_pressed_color);
 	theme->set_color("guide_color", "ItemList", Color(0, 0, 0, 0.1));
 	theme->set_stylebox("selected", "ItemList", item_selected_oof);
 	theme->set_stylebox("selected_focus", "ItemList", item_selected);
@@ -716,8 +717,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	tc_sb->set_expand_margin_size(SIDE_TOP, 2 * scale);
 	tc_sb->set_default_margin(SIDE_TOP, 8 * scale);
 
-	theme->set_stylebox("tab_fg", "TabContainer", sb_expand(make_stylebox(tab_current_png, 4, 4, 4, 1, 16, 4, 16, 4), 2, 2, 2, 2));
-	theme->set_stylebox("tab_bg", "TabContainer", sb_expand(make_stylebox(tab_behind_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
+	theme->set_stylebox("tab_selected", "TabContainer", sb_expand(make_stylebox(tab_current_png, 4, 4, 4, 1, 16, 4, 16, 4), 2, 2, 2, 2));
+	theme->set_stylebox("tab_unselected", "TabContainer", sb_expand(make_stylebox(tab_behind_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
 	theme->set_stylebox("tab_disabled", "TabContainer", sb_expand(make_stylebox(tab_disabled_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
 	theme->set_stylebox("panel", "TabContainer", tc_sb);
 
@@ -731,17 +732,17 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font("font", "TabContainer", Ref<Font>());
 	theme->set_font_size("font_size", "TabContainer", -1);
 
-	theme->set_color("font_color_fg", "TabContainer", control_font_color_hover);
-	theme->set_color("font_color_bg", "TabContainer", control_font_color_low);
-	theme->set_color("font_color_disabled", "TabContainer", control_font_color_disabled);
+	theme->set_color("font_selected_color", "TabContainer", control_font_hover_color);
+	theme->set_color("font_unselected_color", "TabContainer", control_font_low_color);
+	theme->set_color("font_disabled_color", "TabContainer", control_font_disabled_color);
 
 	theme->set_constant("side_margin", "TabContainer", 8 * scale);
 	theme->set_constant("icon_separation", "TabContainer", 4 * scale);
 
 	// Tabs
 
-	theme->set_stylebox("tab_fg", "Tabs", sb_expand(make_stylebox(tab_current_png, 4, 3, 4, 1, 16, 3, 16, 2), 2, 2, 2, 2));
-	theme->set_stylebox("tab_bg", "Tabs", sb_expand(make_stylebox(tab_behind_png, 5, 4, 5, 1, 16, 5, 16, 2), 3, 3, 3, 3));
+	theme->set_stylebox("tab_selected", "Tabs", sb_expand(make_stylebox(tab_current_png, 4, 3, 4, 1, 16, 3, 16, 2), 2, 2, 2, 2));
+	theme->set_stylebox("tab_unselected", "Tabs", sb_expand(make_stylebox(tab_behind_png, 5, 4, 5, 1, 16, 5, 16, 2), 3, 3, 3, 3));
 	theme->set_stylebox("tab_disabled", "Tabs", sb_expand(make_stylebox(tab_disabled_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
 	theme->set_stylebox("panel", "Tabs", tc_sb);
 	theme->set_stylebox("button_pressed", "Tabs", make_stylebox(button_pressed_png, 4, 4, 4, 4));
@@ -756,9 +757,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font("font", "Tabs", Ref<Font>());
 	theme->set_font_size("font_size", "Tabs", -1);
 
-	theme->set_color("font_color_fg", "Tabs", control_font_color_hover);
-	theme->set_color("font_color_bg", "Tabs", control_font_color_low);
-	theme->set_color("font_color_disabled", "Tabs", control_font_color_disabled);
+	theme->set_color("font_selected_color", "Tabs", control_font_hover_color);
+	theme->set_color("font_unselected_color", "Tabs", control_font_low_color);
+	theme->set_color("font_disabled_color", "Tabs", control_font_disabled_color);
 
 	theme->set_constant("hseparation", "Tabs", 4 * scale);
 
@@ -817,7 +818,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "TooltipLabel", -1);
 
 	theme->set_color("font_color", "TooltipLabel", Color(0, 0, 0));
-	theme->set_color("font_color_shadow", "TooltipLabel", Color(0, 0, 0, 0.1));
+	theme->set_color("font_shadow_color", "TooltipLabel", Color(0, 0, 0, 0.1));
 
 	theme->set_constant("shadow_offset_x", "TooltipLabel", 1);
 	theme->set_constant("shadow_offset_y", "TooltipLabel", 1);
@@ -840,10 +841,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("mono_font_size", "RichTextLabel", -1);
 
 	theme->set_color("default_color", "RichTextLabel", Color(1, 1, 1));
-	theme->set_color("font_color_selected", "RichTextLabel", font_color_selection);
+	theme->set_color("font_selected_color", "RichTextLabel", Color(0, 0, 0));
 	theme->set_color("selection_color", "RichTextLabel", Color(0.1, 0.1, 1, 0.8));
 
-	theme->set_color("font_color_shadow", "RichTextLabel", Color(0, 0, 0, 0));
+	theme->set_color("font_shadow_color", "RichTextLabel", Color(0, 0, 0, 0));
 
 	theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * scale);
 	theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * scale);


### PR DESCRIPTION
To make it consistent with all the other `Theme`'s color properties i.e. they end in color, this PR renames `font_color_selected` to `font_selected_color`.
Part of #16863.

**Edit:** Updated to include:
- font_color_accel -> font_accelerator_color
- font_color_bg -> font_unselected_color
- font_color_disabled -> font_disabled_color
- font_color_fg -> font_selected_color
- font_color_hover -> font_hover_color
- font_color_hover_pressed -> font_hover_pressed_color
- font_color_pressed -> font_pressed_color
- font_color_readonly -> font_readonly_color
- font_color_separator -> font_separator_color
- font_color_shadow -> font_shadow_color
- font_color_uneditable -> font_uneditable_color
- font_outline_modulate -> font_outline_color
- icon_color_disabled -> icon_disabled_color
- icon_color_hover -> icon_hover_color
- icon_color_hover_pressed -> icon_hover_pressed_color
- icon_color_normal -> icon_normal_color
- icon_color_pressed -> icon_pressed_color
- tab_fg -> tab_selected
- tab_bg -> tab_unselected

