### PR TITLE
Rename Node3D's property translation to position

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -291,6 +291,9 @@
 		<member name="global_transform" type="Transform3D" setter="set_global_transform" getter="get_global_transform">
 			World3D space (global) [Transform3D] of this node.
 		</member>
+		<member name="position" type="Vector3" setter="set_position" getter="get_position" default="Vector3( 0, 0, 0 )">
+			Local position or translation of this node relative to the parent. This is equivalent to [code]transform.origin[/code].
+		</member>
 		<member name="rotation" type="Vector3" setter="set_rotation" getter="get_rotation">
 			Rotation part of the local transformation in radians, specified in terms of YXZ-Euler angles in the format (X angle, Y angle, Z angle).
 			[b]Note:[/b] In the mathematical sense, rotation is a matrix and not a vector. The three Euler angles, which are the three independent parameters of the Euler-angle parametrization of the rotation matrix, are stored in a [Vector3] data structure not because the rotation is a vector, but only because [Vector3] exists as a convenient data-structure to store 3 floating-point numbers. Therefore, applying affine operations on the rotation "vector" is not meaningful.
@@ -306,9 +309,6 @@
 		</member>
 		<member name="transform" type="Transform3D" setter="set_transform" getter="get_transform" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 			Local space [Transform3D] of this node, with respect to the parent node.
-		</member>
-		<member name="translation" type="Vector3" setter="set_translation" getter="get_translation" default="Vector3( 0, 0, 0 )">
-			Local translation of this node.
 		</member>
 		<member name="visible" type="bool" setter="set_visible" getter="is_visible" default="true">
 			If [code]true[/code], this node is drawn. The node is only visible if all of its antecedents are visible as well (in other words, [method is_visible_in_tree] must return [code]true[/code]).

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2500,9 +2500,9 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		if (show_info) {
 			String text;
-			text += "X: " + rtos(current_camera->get_translation().x).pad_decimals(1) + "\n";
-			text += "Y: " + rtos(current_camera->get_translation().y).pad_decimals(1) + "\n";
-			text += "Z: " + rtos(current_camera->get_translation().z).pad_decimals(1) + "\n";
+			text += "X: " + rtos(current_camera->get_position().x).pad_decimals(1) + "\n";
+			text += "Y: " + rtos(current_camera->get_position().y).pad_decimals(1) + "\n";
+			text += "Z: " + rtos(current_camera->get_position().z).pad_decimals(1) + "\n";
 			text += TTR("Pitch") + ": " + itos(Math::round(current_camera->get_rotation_degrees().x)) + "\n";
 			text += TTR("Yaw") + ": " + itos(Math::round(current_camera->get_rotation_degrees().y)) + "\n\n";
 
@@ -5834,7 +5834,7 @@ void Node3DEditor::_init_grid() {
 		return;
 	}
 	Camera3D *camera = get_editor_viewport(0)->camera;
-	Vector3 camera_position = camera->get_translation();
+	Vector3 camera_position = camera->get_position();
 	if (camera_position == Vector3()) {
 		return; // Camera3D is invalid, don't draw the grid.
 	}

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -299,8 +299,8 @@ Transform3D Node3D::get_relative_transform(const Node *p_parent) const {
 	}
 }
 
-void Node3D::set_translation(const Vector3 &p_translation) {
-	data.local_transform.origin = p_translation;
+void Node3D::set_position(const Vector3 &p_position) {
+	data.local_transform.origin = p_position;
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
 		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
@@ -339,7 +339,7 @@ void Node3D::set_scale(const Vector3 &p_scale) {
 	}
 }
 
-Vector3 Node3D::get_translation() const {
+Vector3 Node3D::get_position() const {
 	return data.local_transform.origin;
 }
 
@@ -693,8 +693,8 @@ void Node3D::force_update_transform() {
 void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_transform", "local"), &Node3D::set_transform);
 	ClassDB::bind_method(D_METHOD("get_transform"), &Node3D::get_transform);
-	ClassDB::bind_method(D_METHOD("set_translation", "translation"), &Node3D::set_translation);
-	ClassDB::bind_method(D_METHOD("get_translation"), &Node3D::get_translation);
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &Node3D::set_position);
+	ClassDB::bind_method(D_METHOD("get_position"), &Node3D::get_position);
 	ClassDB::bind_method(D_METHOD("set_rotation", "euler"), &Node3D::set_rotation);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &Node3D::get_rotation);
 	ClassDB::bind_method(D_METHOD("set_rotation_degrees", "euler_degrees"), &Node3D::set_rotation_degrees);
@@ -759,7 +759,7 @@ void Node3D::_bind_methods() {
 	//ADD_PROPERTY( PropertyInfo(Variant::TRANSFORM3D,"transform/global",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR ), "set_global_transform", "get_global_transform") ;
 	ADD_GROUP("Transform", "");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "global_transform", PROPERTY_HINT_NONE, "", 0), "set_global_transform", "get_global_transform");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "translation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_translation", "get_translation");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation_degrees", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_rotation_degrees", "get_rotation_degrees");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation", PROPERTY_HINT_NONE, "", 0), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_scale", "get_scale");

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -122,12 +122,12 @@ public:
 
 	Ref<World3D> get_world_3d() const;
 
-	void set_translation(const Vector3 &p_translation);
+	void set_position(const Vector3 &p_position);
 	void set_rotation(const Vector3 &p_euler_rad);
 	void set_rotation_degrees(const Vector3 &p_euler_deg);
 	void set_scale(const Vector3 &p_scale);
 
-	Vector3 get_translation() const;
+	Vector3 get_position() const;
 	Vector3 get_rotation() const;
 	Vector3 get_rotation_degrees() const;
 	Vector3 get_scale() const;

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -493,7 +493,7 @@ TypedArray<String> XRAnchor3D::get_configuration_warnings() const {
 };
 
 Plane XRAnchor3D::get_plane() const {
-	Vector3 location = get_translation();
+	Vector3 location = get_position();
 	Basis orientation = get_transform().basis;
 
 	Plane plane(location, orientation.get_axis(1).normalized());


### PR DESCRIPTION
Currently, `Node3D` has a helper property called `translation`, which would be better called `position` as exists in `Node2D`. This PR renames `Node3D`'s `translation` property, `position`.
Part of #16863.

*Bugsquad edit:* Fixes https://github.com/godotengine/godot-proposals/issues/1557
