### PR TITLE
PVS-Studio static analyzer fixes

### DIFF
--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -257,13 +257,13 @@ int Compression::decompress_dynamic(Vector<uint8_t> *p_dst_vect, int p_max_dst_s
 	} while (ret != Z_STREAM_END);
 
 	// If all done successfully, resize the output if it's larger than the actual output
-	if (ret == Z_STREAM_END && (unsigned long)p_dst_vect->size() > strm.total_out) {
+	if ((unsigned long)p_dst_vect->size() > strm.total_out) {
 		p_dst_vect->resize(strm.total_out);
 	}
 
 	// clean up and return
 	(void)inflateEnd(&strm);
-	return ret == Z_STREAM_END ? Z_OK : Z_DATA_ERROR;
+	return Z_OK;
 }
 
 int Compression::zlib_level = Z_DEFAULT_COMPRESSION;

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -59,8 +59,6 @@ private:
 
 	static ZipArchive *instance;
 
-	FileAccess::CreateFunc fa_create_func;
-
 public:
 	void close_handle(unzFile p_file) const;
 	unzFile get_file_handle(String p_file) const;

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1003,10 +1003,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			}
 
 		} break;
-		case Variant::STRING: {
-			_encode_string(p_variant, buf, r_len);
-
-		} break;
+		case Variant::STRING:
 		case Variant::STRING_NAME: {
 			_encode_string(p_variant, buf, r_len);
 

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1003,31 +1003,19 @@ Expression::ENode *Expression::_parse_expression() {
 					priority = 1;
 					unary = true;
 					break;
-
 				case Variant::OP_MULTIPLY:
-					priority = 2;
-					break;
 				case Variant::OP_DIVIDE:
-					priority = 2;
-					break;
 				case Variant::OP_MODULE:
 					priority = 2;
 					break;
-
 				case Variant::OP_ADD:
-					priority = 3;
-					break;
 				case Variant::OP_SUBTRACT:
 					priority = 3;
 					break;
-
 				case Variant::OP_SHIFT_LEFT:
-					priority = 4;
-					break;
 				case Variant::OP_SHIFT_RIGHT:
 					priority = 4;
 					break;
-
 				case Variant::OP_BIT_AND:
 					priority = 5;
 					break;
@@ -1037,31 +1025,17 @@ Expression::ENode *Expression::_parse_expression() {
 				case Variant::OP_BIT_OR:
 					priority = 7;
 					break;
-
 				case Variant::OP_LESS:
-					priority = 8;
-					break;
 				case Variant::OP_LESS_EQUAL:
-					priority = 8;
-					break;
 				case Variant::OP_GREATER:
-					priority = 8;
-					break;
 				case Variant::OP_GREATER_EQUAL:
-					priority = 8;
-					break;
-
 				case Variant::OP_EQUAL:
-					priority = 8;
-					break;
 				case Variant::OP_NOT_EQUAL:
 					priority = 8;
 					break;
-
 				case Variant::OP_IN:
 					priority = 10;
 					break;
-
 				case Variant::OP_NOT:
 					priority = 11;
 					unary = true;
@@ -1072,7 +1046,6 @@ Expression::ENode *Expression::_parse_expression() {
 				case Variant::OP_OR:
 					priority = 13;
 					break;
-
 				default: {
 					_set_error("Parser bug, invalid operator in expression: " + itos(expression[i].op));
 					return nullptr;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -505,11 +505,7 @@ void OS::add_frame_delay(bool p_can_draw) {
 }
 
 OS::OS() {
-	void *volatile stack_bottom;
-
 	singleton = this;
-
-	_stack_bottom = (void *)(&stack_bottom);
 
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(StdLogger));

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -62,8 +62,6 @@ class OS {
 
 	char *last_error;
 
-	void *_stack_bottom;
-
 	CompositeLogger *_logger = nullptr;
 
 	bool restart_on_exit = false;

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -288,7 +288,7 @@ void NodePath::simplify() {
 		if (data->path[i].operator String() == ".") {
 			data->path.remove(i);
 			i--;
-		} else if (data->path[i].operator String() == ".." && i > 0 && data->path[i - 1].operator String() != "." && data->path[i - 1].operator String() != "..") {
+		} else if (i > 0 && data->path[i].operator String() == ".." && data->path[i - 1].operator String() != "." && data->path[i - 1].operator String() != "..") {
 			//remove both
 			data->path.remove(i - 1);
 			data->path.remove(i - 1);

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -6130,7 +6130,7 @@ void RenderingDeviceVulkan::draw_list_bind_render_pipeline(DrawListID p_list, RI
 
 void RenderingDeviceVulkan::draw_list_bind_uniform_set(DrawListID p_list, RID p_uniform_set, uint32_t p_index) {
 #ifdef DEBUG_ENABLED
-	ERR_FAIL_COND_MSG(p_index >= limits.maxBoundDescriptorSets || p_index > MAX_UNIFORM_SETS,
+	ERR_FAIL_COND_MSG(p_index >= limits.maxBoundDescriptorSets || p_index >= MAX_UNIFORM_SETS,
 			"Attempting to bind a descriptor set (" + itos(p_index) + ") greater than what the hardware supports (" + itos(limits.maxBoundDescriptorSets) + ").");
 #endif
 	DrawList *dl = _get_draw_list_ptr(p_list);
@@ -6552,7 +6552,7 @@ void RenderingDeviceVulkan::compute_list_bind_uniform_set(ComputeListID p_list, 
 	ComputeList *cl = compute_list;
 
 #ifdef DEBUG_ENABLED
-	ERR_FAIL_COND_MSG(p_index >= limits.maxBoundDescriptorSets || p_index > MAX_UNIFORM_SETS,
+	ERR_FAIL_COND_MSG(p_index >= limits.maxBoundDescriptorSets || p_index >= MAX_UNIFORM_SETS,
 			"Attempting to bind a descriptor set (" + itos(p_index) + ") greater than what the hardware supports (" + itos(limits.maxBoundDescriptorSets) + ").");
 #endif
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2512,7 +2512,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 				gpu_time_history[i] = 0;
 			}
 			cpu_time_history_index = 0;
-			cpu_time_history_index = 0;
+			gpu_time_history_index = 0;
 		}
 		if (show_fps) {
 			cpu_time_history[cpu_time_history_index] = RS::get_singleton()->viewport_get_measured_render_time_cpu(viewport->get_viewport_rid());

--- a/modules/gdnavigation/nav_map.cpp
+++ b/modules/gdnavigation/nav_map.cpp
@@ -707,7 +707,7 @@ void NavMap::sync() {
 	}
 
 	if (regenerate_links) {
-		map_update_id = map_update_id + 1 % 9999999;
+		map_update_id = (map_update_id + 1) % 9999999;
 	}
 
 	if (agents_dirty) {

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -723,7 +723,7 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 			} break;
 			case ClassNode::Member::ENUM: {
 				Dictionary enum_dict;
-				for (int j = 0; j < m.m_enum->values.size(); i++) {
+				for (int j = 0; j < m.m_enum->values.size(); j++) {
 					enum_dict[m.m_enum->values[i].identifier->name] = m.m_enum->values[i].value;
 				}
 

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -447,7 +447,6 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 			if (cell != last_cell) {
 				//cell changed, update pointer to indices
 				giw[cell * 2 + 1] = i;
-				last_cell = cell;
 				solidw[cell] = true;
 			}
 			tiw[i] = triangle_sort[i].triangle_index;

--- a/modules/text_server_adv/bitmap_font_adv.cpp
+++ b/modules/text_server_adv/bitmap_font_adv.cpp
@@ -390,7 +390,6 @@ Error BitmapFontDataAdvanced::load_from_memory(const uint8_t *p_data, size_t p_s
 		chr.rect.position.y = c[2];
 		chr.rect.size.x = c[3];
 		chr.rect.size.y = c[4];
-		chr.texture_idx = 0;
 		if (c[7] < 0) {
 			chr.advance.x = c[3];
 		} else {

--- a/modules/text_server_adv/dynamic_font_adv.cpp
+++ b/modules/text_server_adv/dynamic_font_adv.cpp
@@ -178,8 +178,6 @@ Dictionary DynamicFontDataAdvanced::get_feature_list() const {
 DynamicFontDataAdvanced::TexturePosition DynamicFontDataAdvanced::find_texture_pos_for_glyph(DynamicFontDataAdvanced::DataAtSize *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height) {
 	TexturePosition ret;
 	ret.index = -1;
-	ret.x = 0;
-	ret.y = 0;
 
 	int mw = p_width;
 	int mh = p_height;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1636,7 +1636,6 @@ bool TextServerAdvanced::shaped_text_update_breaks(RID p_shaped) {
 						gl.start = sd_glyphs[i].start;
 						gl.end = sd_glyphs[i].end;
 						gl.count = 1;
-						gl.repeat = 1;
 						gl.font_rid = sd_glyphs[i].font_rid;
 						gl.font_size = sd_glyphs[i].font_size;
 						gl.flags = GRAPHEME_IS_BREAK_SOFT | GRAPHEME_IS_VIRTUAL;
@@ -1825,7 +1824,6 @@ bool TextServerAdvanced::shaped_text_update_justification_ops(RID p_shaped) {
 						gl.start = sd->glyphs[i].start;
 						gl.end = sd->glyphs[i].end;
 						gl.count = 1;
-						gl.repeat = 1;
 						gl.font_rid = sd->glyphs[i].font_rid;
 						gl.font_size = sd->glyphs[i].font_size;
 						gl.flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_VIRTUAL;
@@ -1860,8 +1858,6 @@ TextServer::Glyph TextServerAdvanced::_shape_single_glyph(ShapedTextDataAdvanced
 
 	// Process glyphs.
 	TextServer::Glyph gl;
-	gl.start = -1;
-	gl.end = -1;
 
 	if (p_direction == HB_DIRECTION_RTL || p_direction == HB_DIRECTION_BTT) {
 		gl.flags |= TextServer::GRAPHEME_IS_RTL;
@@ -1907,7 +1903,6 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 				gl.index = p_sd->text[i];
 				gl.font_size = fs;
 				gl.font_rid = RID();
-				gl.flags = 0;
 				if (p_direction == HB_DIRECTION_RTL || p_direction == HB_DIRECTION_BTT) {
 					gl.flags |= TextServer::GRAPHEME_IS_RTL;
 				}
@@ -2232,7 +2227,6 @@ bool TextServerAdvanced::shaped_text_shape(RID p_shaped) {
 							gl.start = span.start;
 							gl.end = span.end;
 							gl.count = 1;
-							gl.index = 0;
 							gl.flags = GRAPHEME_IS_VALID | GRAPHEME_IS_VIRTUAL;
 							if (sd->orientation == ORIENTATION_HORIZONTAL) {
 								gl.advance = sd->objects[span.embedded_key].rect.size.x;

--- a/modules/text_server_fb/bitmap_font_fb.cpp
+++ b/modules/text_server_fb/bitmap_font_fb.cpp
@@ -198,7 +198,6 @@ Error BitmapFontDataFallback::load_from_memory(const uint8_t *p_data, size_t p_s
 		chr.rect.position.y = c[2];
 		chr.rect.size.x = c[3];
 		chr.rect.size.y = c[4];
-		chr.texture_idx = 0;
 		if (c[7] < 0) {
 			chr.advance.x = c[3];
 		} else {

--- a/modules/text_server_fb/dynamic_font_fb.cpp
+++ b/modules/text_server_fb/dynamic_font_fb.cpp
@@ -139,8 +139,6 @@ DynamicFontDataFallback::DataAtSize *DynamicFontDataFallback::get_data_for_size(
 DynamicFontDataFallback::TexturePosition DynamicFontDataFallback::find_texture_pos_for_glyph(DynamicFontDataFallback::DataAtSize *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height) {
 	TexturePosition ret;
 	ret.index = -1;
-	ret.x = 0;
-	ret.y = 0;
 
 	int mw = p_width;
 	int mh = p_height;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -486,7 +486,7 @@ void Sprite3D::_draw() {
 		RS::get_singleton()->immediate_normal(immediate, normal);
 		RS::get_singleton()->immediate_tangent(immediate, tangent);
 		RS::get_singleton()->immediate_color(immediate, color);
-		RS::get_singleton()->immediate_uv(immediate, uvs[i]);
+		RS::get_singleton()->immediate_uv(immediate, uvs[index[i]]);
 
 		Vector3 vtx;
 		vtx[x_axis] = vertices[index[i]][0];
@@ -815,7 +815,7 @@ void AnimatedSprite3D::_draw() {
 		RS::get_singleton()->immediate_normal(immediate, normal);
 		RS::get_singleton()->immediate_tangent(immediate, tangent);
 		RS::get_singleton()->immediate_color(immediate, color);
-		RS::get_singleton()->immediate_uv(immediate, uvs[i]);
+		RS::get_singleton()->immediate_uv(immediate, uvs[indices[i]]);
 
 		Vector3 vtx;
 		vtx[x_axis] = vertices[indices[i]][0];

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -228,6 +228,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 				} break;
 
+				case (KEY_Y): // PASTE (Yank for unix users).
 				case (KEY_V): { // PASTE.
 
 					if (editable) {
@@ -258,13 +259,6 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 				} break;
 
-				case (KEY_Y): { // PASTE (Yank for unix users).
-
-					if (editable) {
-						paste_text();
-					}
-
-				} break;
 				case (KEY_K): { // Delete from cursor_pos to end.
 
 					if (editable) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6619,8 +6619,8 @@ void TextEdit::set_line_length_guideline_hard_column(int p_column) {
 }
 
 void TextEdit::set_draw_minimap(bool p_draw) {
-	draw_minimap = p_draw;
 	if (draw_minimap != p_draw) {
+		draw_minimap = p_draw;
 		_update_wrap_at();
 	}
 	update();
@@ -6631,8 +6631,8 @@ bool TextEdit::is_drawing_minimap() const {
 }
 
 void TextEdit::set_minimap_width(int p_minimap_width) {
-	minimap_width = p_minimap_width;
 	if (minimap_width != p_minimap_width) {
+		minimap_width = p_minimap_width;
 		_update_wrap_at();
 	}
 	update();

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -74,9 +74,8 @@ public:
 
 private:
 	struct GroupData {
-		bool persistent;
-		SceneTree::Group *group;
-		GroupData() { persistent = false; }
+		bool persistent = false;
+		SceneTree::Group *group = nullptr;
 	};
 
 	struct NetData {

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -591,7 +591,7 @@ void Environment::set_glow_level(int p_level, float p_intensity) {
 }
 
 float Environment::get_glow_level(int p_level) const {
-	ERR_FAIL_INDEX_V(p_level, RS::MAX_GLOW_LEVELS, false);
+	ERR_FAIL_INDEX_V(p_level, RS::MAX_GLOW_LEVELS, 0.0);
 
 	return glow_levels[p_level];
 }

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -704,7 +704,6 @@ ResourceLoaderText::ResourceLoaderText() {
 
 	resources_total = 0;
 	resource_current = 0;
-	use_sub_threads = false;
 
 	progress = nullptr;
 	lines = false;

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -74,7 +74,7 @@ bool SurfaceTool::Vertex::operator==(const Vertex &p_vertex) const {
 		}
 	}
 
-	for (int i = 0; i < RS::ARRAY_CUSTOM_MAX; i++) {
+	for (int i = 0; i < RS::ARRAY_CUSTOM_COUNT; i++) {
 		if (custom[i] != p_vertex.custom[i]) {
 			return false;
 		}

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3152,13 +3152,13 @@ bool RendererSceneRenderRD::environment_is_ssao_enabled(RID p_env) const {
 
 float RendererSceneRenderRD::environment_get_ssao_ao_affect(RID p_env) const {
 	Environment *env = environment_owner.getornull(p_env);
-	ERR_FAIL_COND_V(!env, false);
+	ERR_FAIL_COND_V(!env, 0.0);
 	return env->ssao_ao_channel_affect;
 }
 
 float RendererSceneRenderRD::environment_get_ssao_light_affect(RID p_env) const {
 	Environment *env = environment_owner.getornull(p_env);
-	ERR_FAIL_COND_V(!env, false);
+	ERR_FAIL_COND_V(!env, 0.0);
 	return env->ssao_direct_light_affect;
 }
 
@@ -5711,8 +5711,8 @@ bool RendererSceneRenderRD::render_buffers_is_sdfgi_using_occlusion(RID p_render
 
 float RendererSceneRenderRD::render_buffers_get_sdfgi_energy(RID p_render_buffers) const {
 	const RenderBuffers *rb = render_buffers_owner.getornull(p_render_buffers);
-	ERR_FAIL_COND_V(!rb, 0);
-	ERR_FAIL_COND_V(!rb->sdfgi, false);
+	ERR_FAIL_COND_V(!rb, 0.0);
+	ERR_FAIL_COND_V(!rb->sdfgi, 0.0);
 
 	return rb->sdfgi->energy;
 }
@@ -7360,7 +7360,6 @@ void RendererSceneRenderRD::render_sdfgi(RID p_render_buffers, int p_region, Ins
 				ipush_constant.store_ambient_texture = false;
 
 				ipush_constant.image_size[0] = rb->sdfgi->probe_axis_count * rb->sdfgi->probe_axis_count;
-				ipush_constant.image_size[1] = rb->sdfgi->probe_axis_count;
 				ipush_constant.image_size[1] = rb->sdfgi->probe_axis_count;
 
 				int32_t probe_divisor = rb->sdfgi->cascade_size / SDFGI::PROBE_DIVISOR;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3174,7 +3174,7 @@ bool ShaderLanguage::_validate_assign(Node *p_node, const FunctionInfo &p_functi
 }
 
 bool ShaderLanguage::_propagate_function_call_sampler_uniform_settings(StringName p_name, int p_argument, TextureFilter p_filter, TextureRepeat p_repeat) {
-	for (int i = 0; shader->functions.size(); i++) {
+	for (int i = 0; i < shader->functions.size(); i++) {
 		if (shader->functions[i].name == p_name) {
 			ERR_FAIL_INDEX_V(p_argument, shader->functions[i].function->arguments.size(), false);
 			FunctionNode::Argument *arg = &shader->functions[i].function->arguments.write[p_argument];
@@ -3208,7 +3208,7 @@ bool ShaderLanguage::_propagate_function_call_sampler_uniform_settings(StringNam
 }
 
 bool ShaderLanguage::_propagate_function_call_sampler_builtin_reference(StringName p_name, int p_argument, const StringName &p_builtin) {
-	for (int i = 0; shader->functions.size(); i++) {
+	for (int i = 0; i < shader->functions.size(); i++) {
 		if (shader->functions[i].name == p_name) {
 			ERR_FAIL_INDEX_V(p_argument, shader->functions[i].function->arguments.size(), false);
 			FunctionNode::Argument *arg = &shader->functions[i].function->arguments.write[p_argument];

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -519,7 +519,7 @@ public:
 		DataType basetype = TYPE_VOID;
 		bool basetype_const = false;
 		StringName base_struct_name;
-		DataPrecision precision;
+		DataPrecision precision = PRECISION_DEFAULT;
 		DataType datatype = TYPE_VOID;
 		int array_size = 0;
 		StringName struct_name;


### PR DESCRIPTION
Removes unused code in OS (added in #9720, partially removed #14726).
Fixes return type in some ERR_FAIL_COND_V.
Fixes line width update on minimap changes in TextEdit.
Fixes few typos.
Merged some identical enum cases.

Addressed some of the errors reported in #44172