### PR TITLE
Fixing api for how transforms are accessed through Node2D and CanvasItem

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -457,6 +457,15 @@
 				Returns the mouse position relative to this item's position.
 			</description>
 		</method>
+		<method name="get_relative_transform_to_ancestor" qualifiers="const">
+			<return type="Transform2D">
+			</return>
+			<argument index="0" name="ancestor" type="Node">
+			</argument>
+			<description>
+				Returns the [Transform2D] relative to this node's ancestor.
+			</description>
+		</method>
 		<method name="get_transform" qualifiers="const">
 			<return type="Transform2D">
 			</return>

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -344,15 +344,6 @@ void Node2D::set_transform(const Transform2D &p_transform) {
 	_notify_transform();
 }
 
-void Node2D::set_global_transform(const Transform2D &p_transform) {
-	CanvasItem *pi = get_parent_item();
-	if (pi) {
-		set_transform(pi->get_global_transform().affine_inverse() * p_transform);
-	} else {
-		set_transform(p_transform);
-	}
-}
-
 void Node2D::set_z_index(int p_z) {
 	ERR_FAIL_COND(p_z < RS::CANVAS_ITEM_Z_MIN);
 	ERR_FAIL_COND(p_z > RS::CANVAS_ITEM_Z_MAX);
@@ -375,21 +366,6 @@ bool Node2D::is_z_relative() const {
 
 int Node2D::get_z_index() const {
 	return z_index;
-}
-
-Transform2D Node2D::get_relative_transform_to_parent(const Node *p_parent) const {
-	if (p_parent == this) {
-		return Transform2D();
-	}
-
-	Node2D *parent_2d = Object::cast_to<Node2D>(get_parent());
-
-	ERR_FAIL_COND_V(!parent_2d, Transform2D());
-	if (p_parent == parent_2d) {
-		return get_transform();
-	} else {
-		return parent_2d->get_relative_transform_to_parent(p_parent) * get_transform();
-	}
 }
 
 void Node2D::look_at(const Vector2 &p_pos) {
@@ -441,6 +417,7 @@ void Node2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_transform", "xform"), &Node2D::set_transform);
 	ClassDB::bind_method(D_METHOD("set_global_transform", "xform"), &Node2D::set_global_transform);
+	ClassDB::bind_method(D_METHOD("set_relative_transform_to_ancestor", "xform", "ancestor"), &Node2D::set_relative_transform_to_ancestor);
 
 	ClassDB::bind_method(D_METHOD("look_at", "point"), &Node2D::look_at);
 	ClassDB::bind_method(D_METHOD("get_angle_to", "point"), &Node2D::get_angle_to);
@@ -453,8 +430,6 @@ void Node2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_z_as_relative", "enable"), &Node2D::set_z_as_relative);
 	ClassDB::bind_method(D_METHOD("is_z_relative"), &Node2D::is_z_relative);
-
-	ClassDB::bind_method(D_METHOD("get_relative_transform_to_parent", "parent"), &Node2D::get_relative_transform_to_parent);
 
 	ADD_GROUP("Transform", "");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -98,8 +98,9 @@ public:
 	float get_global_rotation_degrees() const;
 	Size2 get_global_scale() const;
 
-	void set_transform(const Transform2D &p_transform);
-	void set_global_transform(const Transform2D &p_transform);
+	Transform2D get_transform() const override;
+	void set_transform(const Transform2D &p_transform) override;
+
 	void set_global_position(const Point2 &p_pos);
 	void set_global_rotation(float p_radians);
 	void set_global_rotation_degrees(float p_degrees);
@@ -116,10 +117,6 @@ public:
 
 	void set_z_as_relative(bool p_enabled);
 	bool is_z_relative() const;
-
-	Transform2D get_relative_transform_to_parent(const Node *p_parent) const;
-
-	Transform2D get_transform() const override;
 
 	Node2D();
 };

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -137,7 +137,7 @@ void TileMap::_update_quadrant_transform() {
 
 	Transform2D nav_rel;
 	if (navigation) {
-		nav_rel = get_relative_transform_to_parent(navigation);
+		nav_rel = get_relative_transform_to_ancestor(navigation);
 	}
 
 	for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
@@ -319,7 +319,7 @@ void TileMap::update_dirty_quadrants() {
 	Vector2 tofs = get_cell_draw_offset();
 	Transform2D nav_rel;
 	if (navigation) {
-		nav_rel = get_relative_transform_to_parent(navigation);
+		nav_rel = get_relative_transform_to_ancestor(navigation);
 	}
 
 	Vector2 qofs;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2307,6 +2307,11 @@ Transform2D Control::get_transform() const {
 	return xform;
 }
 
+void Control::set_transform(const Transform2D &p_transform) {
+	// control doesn't support setting transform manually yet
+	ERR_FAIL_MSG("Control does not support setting transform directly.  Use set_position(), set_scale(), etc.");
+}
+
 String Control::_get_tooltip() const {
 	return data.tooltip;
 }

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -500,6 +500,7 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const;
 
 	virtual Transform2D get_transform() const override;
+	virtual void set_transform(const Transform2D &p_transform) override;
 
 	bool is_top_level_control() const;
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -486,6 +486,39 @@ Transform2D CanvasItem::get_global_transform() const {
 	return global_transform;
 }
 
+Transform2D CanvasItem::get_relative_transform_to_ancestor(const Node *p_ancestor) const {
+	if (p_ancestor == this) {
+		return Transform2D();
+	}
+
+	CanvasItem *parent_2d = Object::cast_to<CanvasItem>(get_parent());
+
+	ERR_FAIL_COND_V(!parent_2d, Transform2D());
+	if (p_ancestor == parent_2d) {
+		return get_transform();
+	} else {
+		return parent_2d->get_relative_transform_to_ancestor(p_ancestor) * get_transform();
+	}
+}
+
+void CanvasItem::set_global_transform(const Transform2D &p_transform) {
+	CanvasItem *pi = get_parent_item();
+	if (pi) {
+		set_transform(pi->get_global_transform().affine_inverse() * p_transform);
+	} else {
+		set_transform(p_transform);
+	}
+}
+
+void CanvasItem::set_relative_transform_to_ancestor(const Transform2D &p_transform, const Node *p_ancestor) {
+	CanvasItem *pi = get_parent_item();
+	if (pi) {
+		set_transform(pi->get_relative_transform_to_ancestor(p_ancestor).affine_inverse() * p_transform);
+	} else {
+		set_transform(p_transform);
+	}
+}
+
 void CanvasItem::_top_level_raise_self() {
 	if (!is_inside_tree()) {
 		return;
@@ -1168,6 +1201,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_set_transform_matrix", "xform"), &CanvasItem::draw_set_transform_matrix);
 	ClassDB::bind_method(D_METHOD("get_transform"), &CanvasItem::get_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &CanvasItem::get_global_transform);
+	ClassDB::bind_method(D_METHOD("get_relative_transform_to_ancestor", "ancestor"), &CanvasItem::get_relative_transform_to_ancestor);
 	ClassDB::bind_method(D_METHOD("get_global_transform_with_canvas"), &CanvasItem::get_global_transform_with_canvas);
 	ClassDB::bind_method(D_METHOD("get_viewport_transform"), &CanvasItem::get_viewport_transform);
 	ClassDB::bind_method(D_METHOD("get_viewport_rect"), &CanvasItem::get_viewport_rect);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -370,8 +370,13 @@ public:
 	CanvasItem *get_parent_item() const;
 
 	virtual Transform2D get_transform() const = 0;
-
 	virtual Transform2D get_global_transform() const;
+	virtual Transform2D get_relative_transform_to_ancestor(const Node *p_ancestor) const;
+
+	virtual void set_transform(const Transform2D &p_transform) = 0;
+	virtual void set_global_transform(const Transform2D &p_transform);
+	virtual void set_relative_transform_to_ancestor(const Transform2D &p_transform, const Node *p_parent);
+
 	virtual Transform2D get_global_transform_with_canvas() const;
 	virtual Transform2D get_screen_transform() const;
 


### PR DESCRIPTION
This PR fixes some API strangeness that falls under how transforms are addressed in CanvasItem and Node2D classes (with side considerations for the Control class).

The first function is get_relative_transform_to_parent() in Node2D.  This function actually takes one input parameter (a target node), and traverses up the scene tree multiplying transforms until it hits the target node.  This is clearly a relative to ancestor function and I renamed as so.  

Likewise, similar to get_global_transform() (which is in CanvasItem), get_relative_transform_to_ancestor() should be in CanvasItem NOT Node2D.  It only reads get_transform(), which is available in CanvasItem as pure-virtual function.  This function should be accessable to all CanvasItems, not just a Node2D.


All three transform getters and setters are now available at the CanvasItem level, however the set_* functions are not registered at this level.  This is because Control, (which extends CanvasItem), does not support setting a transform using these APIS.  Control can not support this due to not storing an actual transform matrix, (include pivot as well as rts), so there is inrormation loss on a transform setter.  Therefore these functions are only registered in Node2D.  

This correctly sets up CanvasItem to correctly be inherited by new classes (other modules may have a class that extends CanvasItem).

Note** this is an API breaking change, as 'get_relative_transform_to_parent' has been renamed to 'get_relative_transform_to_ancestor'.  The function however is still available in Node2D.  Should be tracked in https://github.com/godotengine/godot/issues/16863

