### PR TITLE
Increase dithering in the PhysicalSkyMaterial shader to combat banding

### DIFF
--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -568,7 +568,7 @@ PhysicalSkyMaterial::PhysicalSkyMaterial() {
 	code += "\tCOLOR = pow(color, vec3(1.0 / (1.2 + (1.2 * sun_fade))));\n";
 	code += "\tCOLOR *= exposure;\n";
 	code += "\t// Make optional, eliminates banding\n";
-	code += "\tCOLOR += (hash(EYEDIR * 1741.9782) * 0.08 - 0.04) * 0.008 * dither_strength;\n";
+	code += "\tCOLOR += (hash(EYEDIR * 1741.9782) * 0.08 - 0.04) * 0.016 * dither_strength;\n";
 	code += "}\n";
 
 	shader = RS::get_singleton()->shader_create();


### PR DESCRIPTION
Banding should now be much less visible when using the default PhysicalSkyMaterial settings. (This option works independently of the screen-space debanding shader.)