### PR TITLE
Intersect at start point if segment inside polygon

### DIFF
--- a/servers/physics_2d/shape_2d_sw.cpp
+++ b/servers/physics_2d/shape_2d_sw.cpp
@@ -547,6 +547,11 @@ bool ConvexPolygonShape2DSW::intersect_segment(const Vector2 &p_begin, const Vec
 	real_t d = 1e10;
 	bool inters = false;
 
+	if (contains_point(p_begin)) {
+		r_point = p_begin;
+		return true;
+	}
+
 	for (int i = 0; i < point_count; i++) {
 		//hmm.. no can do..
 		/*


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
A raycast from within a polygon should result in a line of length zero located at the starting point, consistent with how the collision in this case is handled with Rects. 

Fixes #44003