### PR TITLE
Fixed license detection on GitHub

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.
 Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).
 


### PR DESCRIPTION
Just a little cosmetic enhancement:

![](https://user-images.githubusercontent.com/47700418/101560080-8825e680-39d3-11eb-9aae-9c1b958010e4.png)

