### PR TITLE
spatial editor plugin bug fix

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5798,7 +5798,7 @@ void SpatialEditor::snap_selected_nodes_to_floor() {
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 		Spatial *sp = Object::cast_to<Spatial>(E->get());
 		if (sp) {
-			Vector3 from = Vector3();
+			Vector3 from = sp->get_global_transform().origin;
 			Vector3 position_offset = Vector3();
 
 			// Priorities for snapping to floor are CollisionShapes, VisualInstances and then origin
@@ -5806,13 +5806,23 @@ void SpatialEditor::snap_selected_nodes_to_floor() {
 			Set<CollisionShape *> cs = _get_child_nodes<CollisionShape>(sp);
 
 			if (cs.size()) {
-				AABB aabb = sp->get_global_transform().xform(cs.front()->get()->get_shape()->get_debug_mesh()->get_aabb());
-				for (Set<CollisionShape *>::Element *I = cs.front(); I; I = I->next()) {
-					aabb.merge_with(sp->get_global_transform().xform(I->get()->get_shape()->get_debug_mesh()->get_aabb()));
+				AABB aabb;
+				bool found_valid_shape = false;
+				if (cs.front()->get()->get_shape().is_valid()) {
+					aabb = sp->get_global_transform().xform(cs.front()->get()->get_shape()->get_debug_mesh()->get_aabb());
+					found_valid_shape = true;
 				}
-				Vector3 size = aabb.size * Vector3(0.5, 0.0, 0.5);
-				from = aabb.position + size;
-				position_offset.y = from.y - sp->get_global_transform().origin.y;
+				for (Set<CollisionShape *>::Element *I = cs.front(); I; I = I->next()) {
+					if (I->get()->get_shape().is_valid()) {
+						aabb.merge_with(sp->get_global_transform().xform(I->get()->get_shape()->get_debug_mesh()->get_aabb()));
+						found_valid_shape = true;
+					}
+				}
+				if (found_valid_shape) {
+					Vector3 size = aabb.size * Vector3(0.5, 0.0, 0.5);
+					from = aabb.position + size;
+					position_offset.y = from.y - sp->get_global_transform().origin.y;
+				}
 			} else if (vi.size()) {
 				AABB aabb = vi.front()->get()->get_transformed_aabb();
 				for (Set<VisualInstance *>::Element *I = vi.front(); I; I = I->next()) {
@@ -5821,9 +5831,7 @@ void SpatialEditor::snap_selected_nodes_to_floor() {
 				Vector3 size = aabb.size * Vector3(0.5, 0.0, 0.5);
 				from = aabb.position + size;
 				position_offset.y = from.y - sp->get_global_transform().origin.y;
-			} else {
-				from = sp->get_global_transform().origin;
-			}
+			} 
 
 			// We add a bit of margin to the from position to avoid it from snapping
 			// when the spatial is already on a floor and there's another floor under

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5798,7 +5798,7 @@ void SpatialEditor::snap_selected_nodes_to_floor() {
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 		Spatial *sp = Object::cast_to<Spatial>(E->get());
 		if (sp) {
-			Vector3 from = sp->get_global_transform().origin;
+			Vector3 from = Vector3();
 			Vector3 position_offset = Vector3();
 
 			// Priorities for snapping to floor are CollisionShapes, VisualInstances and then origin
@@ -5823,6 +5823,9 @@ void SpatialEditor::snap_selected_nodes_to_floor() {
 					from = aabb.position + size;
 					position_offset.y = from.y - sp->get_global_transform().origin.y;
 				}
+				else {
+					from = sp->get_global_transform().origin;
+				}
 			} else if (vi.size()) {
 				AABB aabb = vi.front()->get()->get_transformed_aabb();
 				for (Set<VisualInstance *>::Element *I = vi.front(); I; I = I->next()) {
@@ -5831,7 +5834,9 @@ void SpatialEditor::snap_selected_nodes_to_floor() {
 				Vector3 size = aabb.size * Vector3(0.5, 0.0, 0.5);
 				from = aabb.position + size;
 				position_offset.y = from.y - sp->get_global_transform().origin.y;
-			} 
+			} else {
+				from = sp->get_global_transform().origin;
+			}
 
 			// We add a bit of margin to the from position to avoid it from snapping
 			// when the spatial is already on a floor and there's another floor under

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5822,8 +5822,7 @@ void SpatialEditor::snap_selected_nodes_to_floor() {
 					Vector3 size = aabb.size * Vector3(0.5, 0.0, 0.5);
 					from = aabb.position + size;
 					position_offset.y = from.y - sp->get_global_transform().origin.y;
-				}
-				else {
+				} else {
 					from = sp->get_global_transform().origin;
 				}
 			} else if (vi.size()) {


### PR DESCRIPTION
fix for crash when snapping a node to ground that has no
collision shape assigned

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
