### PR TITLE
Fix trying to set grid visibility on an invalid instance

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4999,9 +4999,6 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			for (int i = 0; i < 3; ++i) {
 				if (grid_enable[i]) {
 					grid_visible[i] = grid_enabled;
-					if (grid_instance[i].is_valid()) {
-						RenderingServer::get_singleton()->instance_set_visible(grid_instance[i], grid_enabled);
-					}
 				}
 			}
 			_finish_grid();
@@ -6160,7 +6157,6 @@ void Node3DEditor::clear() {
 	view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(MENU_VIEW_ORIGIN), true);
 	for (int i = 0; i < 3; ++i) {
 		if (grid_enable[i]) {
-			RenderingServer::get_singleton()->instance_set_visible(grid_instance[i], true);
 			grid_visible[i] = true;
 		}
 	}


### PR DESCRIPTION
Fixes #43764 in master. 3.2 version: https://github.com/aaronfranke/godot/tree/3.2-grid-inst-err

In a nutshell, the infinite grid is deleted and recreated any time the camera moves or the grid visibility checkboxes are checked. As such, trying to set visibility on the existing instance doesn't work anymore, so this code is a bogus holdover from <= 3.2.3.