### PR TITLE
Asset Library: Scroll up the ScrollContainer after page load

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1187,6 +1187,10 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 					_request_image(item->get_instance_id(), r["icon_url"], IMAGE_QUEUE_ICON, 0);
 				}
 			}
+
+			if (!result.empty()) {
+				library_scroll->set_v_scroll(0);
+			}
 		} break;
 		case REQUESTING_ASSET: {
 			Dictionary r = d;


### PR DESCRIPTION
It's a pretty common UI paradigm to scroll up again once a new page loaded. The `master` branch currently only has 1 compatible asset it seems, so here is a little GIF of this working on the `3.2` branch:

![scroll](https://user-images.githubusercontent.com/8750135/101643676-a96aef00-3a34-11eb-868e-12c24c8c458f.gif)
