### PR TITLE
Rename Camera2D offset_h and offset_v properties

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -55,7 +55,7 @@
 			<argument index="0" name="side" type="int" enum="Side">
 			</argument>
 			<description>
-				Returns the drag margin for the specified [enum Side]. See also [member drag_margin_bottom], [member drag_margin_top], [member drag_margin_left], and [member drag_margin_right].
+				Returns the specified [enum Side]'s margin. See also [member drag_bottom_margin], [member drag_top_margin], [member drag_left_margin], and [member drag_right_margin].
 			</description>
 		</method>
 		<method name="get_limit" qualifiers="const">
@@ -90,7 +90,7 @@
 			<argument index="1" name="drag_margin" type="float">
 			</argument>
 			<description>
-				Sets the drag margin for the specified [enum Side]. See also [member drag_margin_bottom], [member drag_margin_top], [member drag_margin_left], and [member drag_margin_right].
+				Sets the specified [enum Side]'s margin. See also [member drag_bottom_margin], [member drag_top_margin], [member drag_left_margin], and [member drag_right_margin].
 			</description>
 		</method>
 		<method name="set_limit">
@@ -115,23 +115,31 @@
 		<member name="custom_viewport" type="Node" setter="set_custom_viewport" getter="get_custom_viewport">
 			The custom [Viewport] node attached to the [Camera2D]. If [code]null[/code] or not a [Viewport], uses the default viewport instead.
 		</member>
-		<member name="drag_margin_bottom" type="float" setter="set_drag_margin" getter="get_drag_margin" default="0.2">
-			Bottom margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the edge of the screen.
+		<member name="drag_bottom_margin" type="float" setter="set_drag_margin" getter="get_drag_margin" default="0.2">
+			Bottom margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the bottom edge of the screen.
 		</member>
-		<member name="drag_margin_h_enabled" type="bool" setter="set_h_drag_enabled" getter="is_h_drag_enabled" default="false">
-			If [code]true[/code], the camera only moves when reaching the horizontal drag margins. If [code]false[/code], the camera moves horizontally regardless of margins.
+		<member name="drag_horizontal_enabled" type="bool" setter="set_h_drag_enabled" getter="is_h_drag_enabled" default="false">
+			If [code]true[/code], the camera only moves when reaching the horizontal (left and right) drag margins. If [code]false[/code], the camera moves horizontally regardless of margins.
 		</member>
-		<member name="drag_margin_left" type="float" setter="set_drag_margin" getter="get_drag_margin" default="0.2">
-			Left margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the edge of the screen.
+		<member name="drag_horizontal_offset" type="float" setter="set_h_offset" getter="get_h_offset" default="0.0">
+			The relative horizontal drag offset of the camera between the right ([code]-1[/code]) and left ([code]1[/code]) drag margins.
+			[b]Note:[/b] Used to set the initial horizontal drag offset; determine the current offset; or force the current offset. It's not automatically updated when the horizontal drag margin is enabled or the drag margins are changed.
 		</member>
-		<member name="drag_margin_right" type="float" setter="set_drag_margin" getter="get_drag_margin" default="0.2">
-			Right margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the edge of the screen.
+		<member name="drag_left_margin" type="float" setter="set_drag_margin" getter="get_drag_margin" default="0.2">
+			Left margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the left edge of the screen.
 		</member>
-		<member name="drag_margin_top" type="float" setter="set_drag_margin" getter="get_drag_margin" default="0.2">
-			Top margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the edge of the screen.
+		<member name="drag_right_margin" type="float" setter="set_drag_margin" getter="get_drag_margin" default="0.2">
+			Right margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the right edge of the screen.
 		</member>
-		<member name="drag_margin_v_enabled" type="bool" setter="set_v_drag_enabled" getter="is_v_drag_enabled" default="false">
-			If [code]true[/code], the camera only moves when reaching the vertical drag margins. If [code]false[/code], the camera moves vertically regardless of margins.
+		<member name="drag_top_margin" type="float" setter="set_drag_margin" getter="get_drag_margin" default="0.2">
+			Top margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the top edge of the screen.
+		</member>
+		<member name="drag_vertical_enabled" type="bool" setter="set_drag_vertical_enabled" getter="is_drag_vertical_enabled" default="false">
+			If [code]true[/code], the camera only moves when reaching the vertical (top and bottom) drag margins. If [code]false[/code], the camera moves vertically regardless of the drag margins.
+		</member>
+		<member name="drag_vertical_offset" type="float" setter="set_drag_verticaloffset" getter="get_drag_vertical_offset" default="0.0">
+			The relative vertical drag offset of the camera between the bottom ([code]-1[/code]) and top ([code]1[/code]) drag margins.
+			[b]Note:[/b] Used to set the initial vertical drag offset; determine the current offset; or force the current offset. It's not automatically updated when the vertical drag margin is enabled or the drag margins are changed.
 		</member>
 		<member name="editor_draw_drag_margin" type="bool" setter="set_margin_drawing_enabled" getter="is_margin_drawing_enabled" default="false">
 			If [code]true[/code], draws the camera's drag margin rectangle in the editor.
@@ -159,14 +167,6 @@
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
 			The camera's offset, useful for looking around or camera shake animations.
-		</member>
-		<member name="offset_h" type="float" setter="set_h_offset" getter="get_h_offset" default="0.0">
-			The horizontal offset of the camera, relative to the drag margins.
-			[b]Note:[/b] Offset H is used only to force offset relative to margins. It's not updated in any way if drag margins are enabled and can be used to set initial offset.
-		</member>
-		<member name="offset_v" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
-			The vertical offset of the camera, relative to the drag margins.
-			[b]Note:[/b] Used the same as [member offset_h].
 		</member>
 		<member name="process_mode" type="int" setter="set_process_mode" getter="get_process_mode" enum="Camera2D.Camera2DProcessMode" default="1">
 			The camera's process callback. See [enum Camera2DProcessMode].

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -104,31 +104,31 @@ Transform2D Camera2D::get_camera_transform() {
 
 	if (!first) {
 		if (anchor_mode == ANCHOR_MODE_DRAG_CENTER) {
-			if (h_drag_enabled && !Engine::get_singleton()->is_editor_hint() && !h_offset_changed) {
+			if (drag_horizontal_enabled && !Engine::get_singleton()->is_editor_hint() && !drag_horizontal_offset_changed) {
 				camera_pos.x = MIN(camera_pos.x, (new_camera_pos.x + screen_size.x * 0.5 * zoom.x * drag_margin[SIDE_LEFT]));
 				camera_pos.x = MAX(camera_pos.x, (new_camera_pos.x - screen_size.x * 0.5 * zoom.x * drag_margin[SIDE_RIGHT]));
 			} else {
-				if (h_ofs < 0) {
-					camera_pos.x = new_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_RIGHT] * h_ofs;
+				if (drag_horizontal_offset < 0) {
+					camera_pos.x = new_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_RIGHT] * drag_horizontal_offset;
 				} else {
-					camera_pos.x = new_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_LEFT] * h_ofs;
+					camera_pos.x = new_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_LEFT] * drag_horizontal_offset;
 				}
 
-				h_offset_changed = false;
+				drag_horizontal_offset_changed = false;
 			}
 
-			if (v_drag_enabled && !Engine::get_singleton()->is_editor_hint() && !v_offset_changed) {
+			if (drag_vertical_enabled && !Engine::get_singleton()->is_editor_hint() && !drag_vertical_offset_changed) {
 				camera_pos.y = MIN(camera_pos.y, (new_camera_pos.y + screen_size.y * 0.5 * zoom.y * drag_margin[SIDE_TOP]));
 				camera_pos.y = MAX(camera_pos.y, (new_camera_pos.y - screen_size.y * 0.5 * zoom.y * drag_margin[SIDE_BOTTOM]));
 
 			} else {
-				if (v_ofs < 0) {
-					camera_pos.y = new_camera_pos.y + screen_size.y * 0.5 * drag_margin[SIDE_BOTTOM] * v_ofs;
+				if (drag_vertical_offset < 0) {
+					camera_pos.y = new_camera_pos.y + screen_size.y * 0.5 * drag_margin[SIDE_BOTTOM] * drag_vertical_offset;
 				} else {
-					camera_pos.y = new_camera_pos.y + screen_size.y * 0.5 * drag_margin[SIDE_TOP] * v_ofs;
+					camera_pos.y = new_camera_pos.y + screen_size.y * 0.5 * drag_margin[SIDE_TOP] * drag_vertical_offset;
 				}
 
-				v_offset_changed = false;
+				drag_vertical_offset_changed = false;
 			}
 
 		} else if (anchor_mode == ANCHOR_MODE_FIXED_TOP_LEFT) {
@@ -476,15 +476,15 @@ void Camera2D::align() {
 
 	Point2 current_camera_pos = get_global_transform().get_origin();
 	if (anchor_mode == ANCHOR_MODE_DRAG_CENTER) {
-		if (h_ofs < 0) {
-			camera_pos.x = current_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_RIGHT] * h_ofs;
+		if (drag_horizontal_offset < 0) {
+			camera_pos.x = current_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_RIGHT] * drag_horizontal_offset;
 		} else {
-			camera_pos.x = current_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_LEFT] * h_ofs;
+			camera_pos.x = current_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_LEFT] * drag_horizontal_offset;
 		}
-		if (v_ofs < 0) {
-			camera_pos.y = current_camera_pos.y + screen_size.y * 0.5 * drag_margin[SIDE_TOP] * v_ofs;
+		if (drag_vertical_offset < 0) {
+			camera_pos.y = current_camera_pos.y + screen_size.y * 0.5 * drag_margin[SIDE_TOP] * drag_vertical_offset;
 		} else {
-			camera_pos.y = current_camera_pos.y + screen_size.y * 0.5 * drag_margin[SIDE_BOTTOM] * v_ofs;
+			camera_pos.y = current_camera_pos.y + screen_size.y * 0.5 * drag_margin[SIDE_BOTTOM] * drag_vertical_offset;
 		}
 	} else if (anchor_mode == ANCHOR_MODE_FIXED_TOP_LEFT) {
 		camera_pos = current_camera_pos;
@@ -518,44 +518,44 @@ Size2 Camera2D::_get_camera_screen_size() const {
 	return get_viewport_rect().size;
 }
 
-void Camera2D::set_h_drag_enabled(bool p_enabled) {
-	h_drag_enabled = p_enabled;
+void Camera2D::set_drag_horizontal_enabled(bool p_enabled) {
+	drag_horizontal_enabled = p_enabled;
 }
 
-bool Camera2D::is_h_drag_enabled() const {
-	return h_drag_enabled;
+bool Camera2D::is_drag_horizontal_enabled() const {
+	return drag_horizontal_enabled;
 }
 
-void Camera2D::set_v_drag_enabled(bool p_enabled) {
-	v_drag_enabled = p_enabled;
+void Camera2D::set_drag_vertical_enabled(bool p_enabled) {
+	drag_vertical_enabled = p_enabled;
 }
 
-bool Camera2D::is_v_drag_enabled() const {
-	return v_drag_enabled;
+bool Camera2D::is_drag_vertical_enabled() const {
+	return drag_vertical_enabled;
 }
 
-void Camera2D::set_v_offset(float p_offset) {
-	v_ofs = p_offset;
-	v_offset_changed = true;
+void Camera2D::set_drag_vertical_offset(float p_offset) {
+	drag_vertical_offset = p_offset;
+	drag_vertical_offset_changed = true;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
 	smoothed_camera_pos = old_smoothed_camera_pos;
 }
 
-float Camera2D::get_v_offset() const {
-	return v_ofs;
+float Camera2D::get_drag_vertical_offset() const {
+	return drag_vertical_offset;
 }
 
-void Camera2D::set_h_offset(float p_offset) {
-	h_ofs = p_offset;
-	h_offset_changed = true;
+void Camera2D::set_drag_horizontal_offset(float p_offset) {
+	drag_horizontal_offset = p_offset;
+	drag_horizontal_offset_changed = true;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
 	smoothed_camera_pos = old_smoothed_camera_pos;
 }
 
-float Camera2D::get_h_offset() const {
-	return h_ofs;
+float Camera2D::get_drag_horizontal_offset() const {
+	return drag_horizontal_offset;
 }
 
 void Camera2D::_set_old_smoothing(float p_enable) {
@@ -663,17 +663,17 @@ void Camera2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_limit_smoothing_enabled", "limit_smoothing_enabled"), &Camera2D::set_limit_smoothing_enabled);
 	ClassDB::bind_method(D_METHOD("is_limit_smoothing_enabled"), &Camera2D::is_limit_smoothing_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_v_drag_enabled", "enabled"), &Camera2D::set_v_drag_enabled);
-	ClassDB::bind_method(D_METHOD("is_v_drag_enabled"), &Camera2D::is_v_drag_enabled);
+	ClassDB::bind_method(D_METHOD("set_drag_vertical_enabled", "enabled"), &Camera2D::set_drag_vertical_enabled);
+	ClassDB::bind_method(D_METHOD("is_drag_vertical_enabled"), &Camera2D::is_drag_vertical_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_h_drag_enabled", "enabled"), &Camera2D::set_h_drag_enabled);
-	ClassDB::bind_method(D_METHOD("is_h_drag_enabled"), &Camera2D::is_h_drag_enabled);
+	ClassDB::bind_method(D_METHOD("set_drag_horizontal_enabled", "enabled"), &Camera2D::set_drag_horizontal_enabled);
+	ClassDB::bind_method(D_METHOD("is_drag_horizontal_enabled"), &Camera2D::is_drag_horizontal_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_v_offset", "ofs"), &Camera2D::set_v_offset);
-	ClassDB::bind_method(D_METHOD("get_v_offset"), &Camera2D::get_v_offset);
+	ClassDB::bind_method(D_METHOD("set_drag_vertical_offset", "offset"), &Camera2D::set_drag_vertical_offset);
+	ClassDB::bind_method(D_METHOD("get_drag_vertical_offset"), &Camera2D::get_drag_vertical_offset);
 
-	ClassDB::bind_method(D_METHOD("set_h_offset", "ofs"), &Camera2D::set_h_offset);
-	ClassDB::bind_method(D_METHOD("get_h_offset"), &Camera2D::get_h_offset);
+	ClassDB::bind_method(D_METHOD("set_drag_horizontal_offset", "offset"), &Camera2D::set_drag_horizontal_offset);
+	ClassDB::bind_method(D_METHOD("get_drag_horizontal_offset"), &Camera2D::get_drag_horizontal_offset);
 
 	ClassDB::bind_method(D_METHOD("set_drag_margin", "margin", "drag_margin"), &Camera2D::set_drag_margin);
 	ClassDB::bind_method(D_METHOD("get_drag_margin", "margin"), &Camera2D::get_drag_margin);
@@ -723,23 +723,19 @@ void Camera2D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "limit_bottom"), "set_limit", "get_limit", SIDE_BOTTOM);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "limit_smoothed"), "set_limit_smoothing_enabled", "is_limit_smoothing_enabled");
 
-	ADD_GROUP("Draw Margin", "draw_margin_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_margin_h_enabled"), "set_h_drag_enabled", "is_h_drag_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_margin_v_enabled"), "set_v_drag_enabled", "is_v_drag_enabled");
-
 	ADD_GROUP("Smoothing", "smoothing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "smoothing_enabled"), "set_enable_follow_smoothing", "is_follow_smoothing_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "smoothing_speed"), "set_follow_smoothing", "get_follow_smoothing");
 
-	ADD_GROUP("Offset", "offset_");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "offset_h", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_h_offset", "get_h_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "offset_v", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_v_offset", "get_v_offset");
-
-	ADD_GROUP("Drag Margin", "drag_margin_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "drag_margin_left", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_margin", "get_drag_margin", SIDE_LEFT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "drag_margin_top", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_margin", "get_drag_margin", SIDE_TOP);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "drag_margin_right", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_margin", "get_drag_margin", SIDE_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "drag_margin_bottom", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_margin", "get_drag_margin", SIDE_BOTTOM);
+	ADD_GROUP("Drag", "drag_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_horizontal_enabled"), "set_drag_horizontal_enabled", "is_drag_horizontal_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_vertical_enabled"), "set_drag_vertical_enabled", "is_drag_vertical_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "drag_horizontal_offset", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_drag_horizontal_offset", "get_drag_horizontal_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "drag_vertical_offset", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_drag_vertical_offset", "get_drag_vertical_offset");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "drag_left_margin", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_margin", "get_drag_margin", SIDE_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "drag_top_margin", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_margin", "get_drag_margin", SIDE_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "drag_right_margin", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_margin", "get_drag_margin", SIDE_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "drag_bottom_margin", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_margin", "get_drag_margin", SIDE_BOTTOM);
 
 	ADD_GROUP("Editor", "editor_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editor_draw_screen"), "set_screen_drawing_enabled", "is_screen_drawing_enabled");
@@ -780,12 +776,12 @@ Camera2D::Camera2D() {
 	limit_drawing_enabled = false;
 	margin_drawing_enabled = false;
 
-	h_drag_enabled = false;
-	v_drag_enabled = false;
-	h_ofs = 0;
-	v_ofs = 0;
-	h_offset_changed = false;
-	v_offset_changed = false;
+	drag_horizontal_enabled = false;
+	drag_vertical_enabled = false;
+	drag_horizontal_offset = 0;
+	drag_vertical_offset = 0;
+	drag_horizontal_offset_changed = false;
+	drag_vertical_offset_changed = false;
 
 	set_notify_transform(true);
 }

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -69,15 +69,14 @@ protected:
 	bool smoothing_enabled;
 	int limit[4];
 	bool limit_smoothing_enabled;
+
 	float drag_margin[4];
-
-	bool h_drag_enabled;
-	bool v_drag_enabled;
-	float h_ofs;
-	float v_ofs;
-
-	bool h_offset_changed;
-	bool v_offset_changed;
+	bool drag_horizontal_enabled;
+	bool drag_vertical_enabled;
+	float drag_horizontal_offset;
+	float drag_vertical_offset;
+	bool drag_horizontal_offset_changed;
+	bool drag_vertical_offset_changed;
 
 	Point2 camera_screen_center;
 	void _update_process_mode();
@@ -117,20 +116,20 @@ public:
 	void set_limit_smoothing_enabled(bool enable);
 	bool is_limit_smoothing_enabled() const;
 
-	void set_h_drag_enabled(bool p_enabled);
-	bool is_h_drag_enabled() const;
+	void set_drag_horizontal_enabled(bool p_enabled);
+	bool is_drag_horizontal_enabled() const;
 
-	void set_v_drag_enabled(bool p_enabled);
-	bool is_v_drag_enabled() const;
+	void set_drag_vertical_enabled(bool p_enabled);
+	bool is_drag_vertical_enabled() const;
 
 	void set_drag_margin(Side p_side, float p_drag_margin);
 	float get_drag_margin(Side p_side) const;
 
-	void set_v_offset(float p_offset);
-	float get_v_offset() const;
+	void set_drag_horizontal_offset(float p_offset);
+	float get_drag_horizontal_offset() const;
 
-	void set_h_offset(float p_offset);
-	float get_h_offset() const;
+	void set_drag_vertical_offset(float p_offset);
+	float get_drag_vertical_offset() const;
 
 	void set_enable_follow_smoothing(bool p_enabled);
 	bool is_follow_smoothing_enabled() const;


### PR DESCRIPTION
As identified [here](https://github.com/godotengine/godot/issues/16863#issuecomment-407133383) and [here](https://github.com/godotengine/godot/issues/7489), currently, `Camera2D` has an `offset` property, an `offset_h` property and an `offset_v` property. The `offset` property sets the viewport of the camera relative to its position. The `offset_h` and `offset_v` properties control the relative position of the viewport within the drag margins (when enabled).

This PR groups all the drag properties together in the editor and renames the following and their underlying methods and variables:
- `offset_h` -> `drag_horizontal_offset`
- `offset_v` to `drag_vertical_offset`
- `drag_margin_h_enabled` -> `drag_horizontal_enabled`
- `drag_margin_v_enabled` -> `drag_vertical_enabled`
- `drag_margin_left` -> `drag_left_margin`
- `drag_margin_top` -> `drag_top_margin`
- `drag_margin_right` -> `drag_right_margin`
- `drag_margin_bottom` -> `drag_top_bottom`

Part of #16863.
