### PR TITLE
Re-add circle back scrolling to 'PopupMenu'

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -232,7 +232,7 @@ void PopupMenu::_submenu_timeout() {
 }
 
 void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
-	if (p_event->is_action("ui_down") && p_event->is_pressed() && mouse_over != items.size() - 1) {
+	if (p_event->is_action("ui_down") && p_event->is_pressed()) {
 		int search_from = mouse_over + 1;
 		if (search_from >= items.size()) {
 			search_from = 0;
@@ -248,7 +248,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 				break;
 			}
 		}
-	} else if (p_event->is_action("ui_up") && p_event->is_pressed() && mouse_over != 0) {
+	} else if (p_event->is_action("ui_up") && p_event->is_pressed()) {
 		int search_from = mouse_over - 1;
 		if (search_from < 0) {
 			search_from = items.size() - 1;


### PR DESCRIPTION
This feature was removed with #41640, and to be honest, I don't see why. It's practical for those who use the keyboard, and every other interface allows doing that.

The code for that wasn't even fully removed.