### PR TITLE
Changed the shortcut to close an open scene in the editor from CTRL+SHIFT+W to CTRL+W

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6132,7 +6132,7 @@ EditorNode::EditorNode() {
 
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("editor/reload_saved_scene", TTR("Reload Saved Scene")), EDIT_RELOAD_SAVED_SCENE);
-	p->add_shortcut(ED_SHORTCUT("editor/close_scene", TTR("Close Scene"), KEY_MASK_CMD + KEY_MASK_SHIFT + KEY_W), FILE_CLOSE);
+	p->add_shortcut(ED_SHORTCUT("editor/close_scene", TTR("Close Scene"), KEY_MASK_CMD + KEY_W), FILE_CLOSE);
 
 	recent_scenes = memnew(PopupMenu);
 	recent_scenes->set_name("RecentScenes");


### PR DESCRIPTION
This is common shortcut and it's also used in Godot's script editor. 
I'm not sure why the current shortcut is CTRL+SHIFT+W. Maybe there was a shortcut conflict in the past? If there are issues with this that i'm not aware of and it can't be worked around, i can close this again.