### PR TITLE
Fix scene being modified when arrows are pressed with no node selected

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2356,12 +2356,12 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 				(!Input::get_singleton()->is_key_pressed(KEY_DOWN)) &&
 				(!Input::get_singleton()->is_key_pressed(KEY_LEFT)) &&
 				(!Input::get_singleton()->is_key_pressed(KEY_RIGHT))) {
-			if (drag_selection.size() != 1) {
+			if (drag_selection.size() > 1) {
 				_commit_canvas_item_state(
 						drag_selection,
 						vformat(TTR("Move %d CanvasItems"), drag_selection.size()),
 						true);
-			} else {
+			} else if (drag_selection.size() == 1) {
 				_commit_canvas_item_state(
 						drag_selection,
 						vformat(TTR("Move CanvasItem \"%s\" to (%d, %d)"),


### PR DESCRIPTION
Currently, pushing arrow keys in the editor causes a drag event, even if nothing was moved. This causes the scene to be considered modified, and pushes unnecessary events onto the undo/redo stack. This commit fixes these problems.

Fixes #44243.