### PR TITLE
 Removed unused code from EditorSelection and added documentation.

### DIFF
--- a/doc/classes/EditorSelection.xml
+++ b/doc/classes/EditorSelection.xml
@@ -30,12 +30,6 @@
 				Gets the list of selected nodes.
 			</description>
 		</method>
-		<method name="get_transformable_selected_nodes">
-			<return type="Array" />
-			<description>
-				Gets the list of selected nodes, optimized for transform operations (i.e. moving them, rotating, etc). This list avoids situations where a node is selected and also child/grandchild.
-			</description>
-		</method>
 		<method name="remove_node">
 			<return type="void" />
 			<argument index="0" name="node" type="Node" />

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1032,7 +1032,6 @@ EditorData::EditorData() {
 	script_class_load_icon_paths();
 }
 
-///////////
 void EditorSelection::_node_removed(Node *p_node) {
 	if (!selection.has(p_node)) {
 		return;
@@ -1066,8 +1065,6 @@ void EditorSelection::add_node(Node *p_node) {
 	selection[p_node] = meta;
 
 	p_node->connect("tree_exiting", callable_mp(this, &EditorSelection::_node_removed), varray(p_node), CONNECT_ONESHOT);
-
-	//emit_signal(SNAME("selection_changed"));
 }
 
 void EditorSelection::remove_node(Node *p_node) {
@@ -1085,31 +1082,10 @@ void EditorSelection::remove_node(Node *p_node) {
 	}
 	selection.erase(p_node);
 	p_node->disconnect("tree_exiting", callable_mp(this, &EditorSelection::_node_removed));
-	//emit_signal(SNAME("selection_changed"));
 }
 
 bool EditorSelection::is_selected(Node *p_node) const {
 	return selection.has(p_node);
-}
-
-Array EditorSelection::_get_transformable_selected_nodes() {
-	Array ret;
-
-	for (const Node *E : selected_node_list) {
-		ret.push_back(E);
-	}
-
-	return ret;
-}
-
-TypedArray<Node> EditorSelection::get_selected_nodes() {
-	TypedArray<Node> ret;
-
-	for (const KeyValue<Node *, Object *> &E : selection) {
-		ret.push_back(E.key);
-	}
-
-	return ret;
 }
 
 void EditorSelection::_bind_methods() {
@@ -1117,7 +1093,6 @@ void EditorSelection::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node", "node"), &EditorSelection::add_node);
 	ClassDB::bind_method(D_METHOD("remove_node", "node"), &EditorSelection::remove_node);
 	ClassDB::bind_method(D_METHOD("get_selected_nodes"), &EditorSelection::get_selected_nodes);
-	ClassDB::bind_method(D_METHOD("get_transformable_selected_nodes"), &EditorSelection::_get_transformable_selected_nodes);
 	ClassDB::bind_method(D_METHOD("_emit_change"), &EditorSelection::_emit_change);
 	ADD_SIGNAL(MethodInfo("selection_changed"));
 }
@@ -1133,6 +1108,9 @@ void EditorSelection::_update_nl() {
 
 	selected_node_list.clear();
 
+	// If the selection does not have the parent of the selected node, then add the node to the node list.
+	// However, if the parent is already selected, then adding this node is redundant as
+	// it is included with the parent, so skip it.
 	for (const KeyValue<Node *, Object *> &E : selection) {
 		Node *parent = E.key;
 		parent = parent->get_parent();
@@ -1170,6 +1148,15 @@ void EditorSelection::update() {
 void EditorSelection::_emit_change() {
 	emit_signal(SNAME("selection_changed"));
 	emitted = false;
+}
+
+TypedArray<Node> EditorSelection::get_selected_nodes() {
+	TypedArray<Node> ret;
+	for (const KeyValue<Node *, Object *> &E : selection) {
+		ret.push_back(E.key);
+	}
+
+	return ret;
 }
 
 List<Node *> &EditorSelection::get_selected_node_list() {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -235,33 +235,43 @@ public:
 	EditorData();
 };
 
+/**
+ * Stores and provides access to the nodes currently selected in the editor.
+ *
+ * This provides a central location for storing "selected" nodes, as a selection can be triggered from multiple places,
+ * such as the SceneTreeDock or a main screen editor plugin (e.g. CanvasItemEditor).
+ */
 class EditorSelection : public Object {
 	GDCLASS(EditorSelection, Object);
 
 private:
+	// Contains the selected nodes and corresponding metadata.
+	// Metadata objects come from calling _get_editor_data on the editor_plugins, passing the selected node.
 	Map<Node *, Object *> selection;
 
+	// Tracks whether the selection change signal has been emitted. Prevents multiple signals being called in one frame.
 	bool emitted;
+
+	// Stores state of whether selection or node list have been changed.
 	bool changed;
 	bool nl_changed;
 
 	void _node_removed(Node *p_node);
 
+	// Editor plugins which are related to selection.
 	List<Object *> editor_plugins;
 	List<Node *> selected_node_list;
 
 	void _update_nl();
-	Array _get_transformable_selected_nodes();
 	void _emit_change();
 
 protected:
 	static void _bind_methods();
 
 public:
-	TypedArray<Node> get_selected_nodes();
 	void add_node(Node *p_node);
 	void remove_node(Node *p_node);
-	bool is_selected(Node *) const;
+	bool is_selected(Node *p_node) const;
 
 	template <class T>
 	T *get_node_editor_data(Node *p_node) {
@@ -271,13 +281,19 @@ public:
 		return Object::cast_to<T>(selection[p_node]);
 	}
 
+	// Add an editor plugin which can provide metadata for selected nodes.
 	void add_editor_plugin(Object *p_object);
 
 	void update();
 	void clear();
 
+	// Returns all the selected nodes.
+	TypedArray<Node> get_selected_nodes();
+	// Returns only the top level selected nodes. That is, if the selection includes some node and a child of that node, only the parent is returned.
 	List<Node *> &get_selected_node_list();
+	// Returns all the selected nodes (list version of "get_selected_nodes").
 	List<Node *> get_full_selected_node_list();
+	// Returns the map of selected objects and their metadata.
 	Map<Node *, Object *> &get_selection() { return selection; }
 
 	EditorSelection();


### PR DESCRIPTION
A continuation of #44222

* `_get_transformable_selected_nodes` must have been a remnant of a previous implementation. It was not used anymore.
* `get_selected_nodes` moved lower to be with other `get_selected` methods
* Added documentation in the header to make it clear that in the `Map<Node *, Object *>`, the Object* is metadata provided by an editor plugin, which can then be accessed later by `get_node_editor_data()`.