### PR TITLE
Refuse to use a dictionary as a key for itself

### DIFF
--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1128,8 +1128,12 @@ struct VariantKeyedSetGetDictionary {
 		PtrToArg<Variant>::encode(*ptr, value);
 	}
 	static void set(Variant *base, const Variant *key, const Variant *value, bool &r_valid) {
-		(*VariantGetInternalPtr<Dictionary>::get_ptr(base))[*key] = *value;
-		r_valid = true;
+		if (*key != *base) {
+			(*VariantGetInternalPtr<Dictionary>::get_ptr(base))[*key] = *value;
+			r_valid = true;
+		} else {
+			r_valid = false;
+		}
 	}
 	static void ptr_set(void *base, const void *key, const void *value) {
 		Dictionary &v = *reinterpret_cast<Dictionary *>(base);


### PR DESCRIPTION
The cause of the null pointer dereference from #44195 lies here:

https://github.com/godotengine/godot/blob/31d0f8ad8d5cf50a310ee7e8ada4dcdb4510690b/core/ordered_hash_map.h#L216-L218

Note that the key in the Pair is set to null first, then updated when the pair has been added to the map. However, to hash the map itself the key needs to be derefenced too but since it's null the engine crashes.

https://github.com/godotengine/godot/blob/31d0f8ad8d5cf50a310ee7e8ada4dcdb4510690b/core/dictionary.cpp#L196

https://github.com/godotengine/godot/blob/31d0f8ad8d5cf50a310ee7e8ada4dcdb4510690b/core/variant.cpp#L2739

I tried a (naive) fix by replacing `NULL` with `&p_key` but this results in a stack overflow because the dictionary keeps hashing the key (which is itself too) ad infinitum, so instead I believe it is best to prevent using a dictionary as a key for itself (since the hash can't be calculated anyways)

This patch doesn't catch all possible causes for cyclic references though, such as the one below, but I'm not sure what the best way is to fix that.

```gdscript
extends MainLoop


func _init():
	var a = {}
	var b = {}
	b[a] = 0
	a[b] = 0
```

I've also considered preventing `OrderedHashMap` from being accessed while an insertion is in progress but I don't know how to do that without (potentially) breaking a lot of things.

Closes #44195