### PR TITLE
Document how focus and mouse events affect signals in `Control`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -11,13 +11,14 @@
 		[b]FIXME:[/b] No longer valid after DisplayServer split and Input refactoring.
 		Call [method accept_event] so no other node receives the event. Once you accepted an input, it becomes handled so [method Node._unhandled_input] will not process it.
 		Only one [Control] node can be in keyboard focus. Only the node in focus will receive keyboard events. To get the focus, call [method grab_focus]. [Control] nodes lose focus when another node grabs it, or if you hide the node in focus.
-		Sets [member mouse_filter] to [constant MOUSE_FILTER_IGNORE] to tell a [Control] node to ignore mouse or touch events. You'll need it if you place an icon on top of a button.
+		Set [member mouse_filter] to [constant MOUSE_FILTER_IGNORE] to tell a [Control] node to ignore mouse or touch events. You'll need it if you place an icon on top of a button.
 		[Theme] resources change the Control's appearance. If you change the [Theme] on a [Control] node, it affects all of its children. To override some of the theme's parameters, call one of the [code]add_theme_*_override[/code] methods, like [method add_theme_font_override]. You can override the theme with the inspector.
 		[b]Note:[/b] Theme items are [i]not[/i] [Object] properties. This means you can't access their values using [method Object.get] and [method Object.set]. Instead, use the [code]get_theme_*[/code] and [code]add_theme_*_override[/code] methods provided by this class.
 	</description>
 	<tutorials>
 		<link title="GUI tutorial index">https://docs.godotengine.org/en/latest/tutorials/gui/index.html</link>
 		<link title="Custom drawing in 2D">https://docs.godotengine.org/en/latest/tutorials/2d/custom_drawing_in_2d.html</link>
+		<link title="InputEvent tutorial">https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
 		<link title="All GUI Demos">https://github.com/godotengine/godot-demo-projects/tree/master/gui</link>
 	</tutorials>
 	<methods>
@@ -43,7 +44,7 @@
 			<argument index="0" name="event" type="InputEvent">
 			</argument>
 			<description>
-				Virtual method to be implemented by the user. Use this method to process and accept inputs on UI elements. See [method accept_event].
+				Virtual method to be implemented by the user. Use this method to process and accept inputs on UI elements. See [method accept_event] and the InputEvent tutorial (link above in Tutorials section).
 				Example: clicking a control.
 				[codeblocks]
 				[gdscript]
@@ -68,10 +69,14 @@
 				[/codeblocks]
 				The event won't trigger if:
 				* clicking outside the control (see [method has_point]);
-				* control has [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
+				* it is a keypress or joypad event and the control does not have keyboard focus (see [method has_focus] and [method grab_focus], only one control has keyboard focus at any time);
+				* it is a mouse or touch event and control has [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
 				* control is obstructed by another [Control] on top of it, which doesn't have [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
-				* control's parent has [member mouse_filter] set to [constant MOUSE_FILTER_STOP] or has accepted the event;
-				* it happens outside parent's rectangle and the parent has either [member rect_clip_content] or [method _clips_input] enabled.
+				* one of control's children has [member mouse_filter] set to [constant MOUSE_FILTER_STOP] or has accepted the event;
+				* it happens outside parent's [code]Rect[/code] (see [method get_rect]) and the parent has [method _clips_input] enabled ([member rect_clip_content] clips visibility but does not affect input);
+				* a mouse button was pressed over another control and the mouse button has not been released yet (other control must be able to receive mouse events);
+				* any [Node] has called [method Viewport.set_input_as_handled] during [method Node._input] calls (this prevents the [Viewport] from passing the event to any control's [code]_gui_input()[/code] or related signals).
+				The event will be passed up to the parent control if children do not mark the event as handled and have [member mouse_filter] set to [constant MOUSE_FILTER_PASS] (does not apply to key or joypad events). Children with [constant MOUSE_FILTER_PASS] will pass mouse and touch events to the parent even when the event is outside the parent's [code]Rect[/code].
 			</description>
 		</method>
 		<method name="_make_custom_tooltip" qualifiers="virtual">
@@ -1048,7 +1053,7 @@
 			[b]Note:[/b] On Linux, shapes may vary depending on the cursor theme of the system.
 		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" enum="Control.MouseFilter" default="0">
-			Controls whether the control will be able to receive mouse button input events through [method _gui_input] and how these events should be handled. Also controls whether the control can receive the [signal mouse_entered], and [signal mouse_exited] signals. See the constants to learn what each does.
+			Controls whether the control will be able to receive mouse button input events through [method _gui_input] and how these events should be handled. Also controls whether the control can receive the [signal mouse_entered], and [signal mouse_exited] signals. See the [enum MouseFilter] constants to learn what each does.
 		</member>
 		<member name="offset_bottom" type="float" setter="set_offset" getter="get_offset" default="0.0">
 			Distance between the node's bottom edge and its parent control, based on [member anchor_bottom].
@@ -1133,12 +1138,16 @@
 		</signal>
 		<signal name="mouse_entered">
 			<description>
-				Emitted when the mouse enters the control's [code]Rect[/code] area, provided its [member mouse_filter] lets the event reach it.
+				Emitted when the mouse enters the control's [code]Rect[/code] area (see [method has_point] and [method get_rect]), provided it is not obstructed and its [member mouse_filter] lets the event reach it.
+				If the control contains children with [member mouse_filter] set to [constant MOUSE_FILTER_PASS] and the mouse enters a child's [code]Rect[/code] area, this signal will also be emitted in the parent (even if the mouse is not within the parent's [code]Rect[/code]) unless the parent has its [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE].
+				When a mouse button is clicked over a control which can process mouse events, that control will retain mouse focus until the mouse button is released. That control will not emit [signal mouse_exited] and other control nodes will not emit [code]mouse_entered[/code] until the moment the mouse button is released. See [method _gui_input] for more information.
 			</description>
 		</signal>
 		<signal name="mouse_exited">
 			<description>
-				Emitted when the mouse leaves the control's [code]Rect[/code] area, provided its [member mouse_filter] lets the event reach it.
+				Emitted when the mouse leaves the control's [code]Rect[/code] area (see [method has_point] and [method get_rect]), provided its [member mouse_filter] lets the event reach it and it has not been removed from the [SceneTree].
+				If the control has its [member mouse_filter] set to [constant MOUSE_FILTER_PASS] and its parent control's [member mouse_filter] is not set to [constant MOUSE_FILTER_IGNORE], this signal will be emitted in the parent after the child.
+				When a mouse button is clicked over a control which can process mouse events, that control will retain mouse focus until the mouse button is released. That control will not emit [code]mouse_exited[/code] and other control nodes will not emit [signal mouse_entered] until the moment the mouse button is released. See [method _gui_input] for more information.
 			</description>
 		</signal>
 		<signal name="resized">
@@ -1170,10 +1179,10 @@
 			Sent when the node changes size. Use [member rect_size] to get the new size.
 		</constant>
 		<constant name="NOTIFICATION_MOUSE_ENTER" value="41">
-			Sent when the mouse pointer enters the node.
+			Sent when the mouse pointer enters the node. See [signal mouse_entered] for more information.
 		</constant>
 		<constant name="NOTIFICATION_MOUSE_EXIT" value="42">
-			Sent when the mouse pointer exits the node.
+			Sent when the mouse pointer exits the node. See [signal mouse_exited] for more information.
 		</constant>
 		<constant name="NOTIFICATION_FOCUS_ENTER" value="43">
 			Sent when the node grabs focus.
@@ -1320,13 +1329,13 @@
 			Tells the parent [Container] to align the node with its end, either the bottom or the right edge. It doesn't work with the fill or expand size flags. Use with [member size_flags_horizontal] and [member size_flags_vertical].
 		</constant>
 		<constant name="MOUSE_FILTER_STOP" value="0" enum="MouseFilter">
-			The control will receive mouse button input events through [method _gui_input] if clicked on. And the control will receive the [signal mouse_entered] and [signal mouse_exited] signals. These events are automatically marked as handled, and they will not propagate further to other controls. This also results in blocking signals in other controls.
+			The control will receive mouse button input events through [method _gui_input] if clicked on. And the control will receive the [signal mouse_entered] and [signal mouse_exited] signals (unless the mouse clicked another control and the mouse button has not been released yet). These events are automatically marked as handled, and they will not propagate further up to other controls. This also results in blocking signals in other controls.
 		</constant>
 		<constant name="MOUSE_FILTER_PASS" value="1" enum="MouseFilter">
-			The control will receive mouse button input events through [method _gui_input] if clicked on. And the control will receive the [signal mouse_entered] and [signal mouse_exited] signals. If this control does not handle the event, the parent control (if any) will be considered, and so on until there is no more parent control to potentially handle it. This also allows signals to fire in other controls. Even if no control handled it at all, the event will still be handled automatically, so unhandled input will not be fired.
+			The control will receive mouse button input events through [method _gui_input] if clicked on. And the control will receive the [signal mouse_entered] and [signal mouse_exited] signals (unless the mouse clicked another control and the mouse button has not been released yet). If this control does not handle the event, the parent control (if any) will be considered, and so on until there are no more parent controls to potentially handle it. This also allows signals to fire in other controls. Even if no control handled it at all, the event will still be handled automatically, so unhandled input will not be fired.
 		</constant>
 		<constant name="MOUSE_FILTER_IGNORE" value="2" enum="MouseFilter">
-			The control will not receive mouse button input events through [method _gui_input]. The control will also not receive the [signal mouse_entered] nor [signal mouse_exited] signals. This will not block other controls from receiving these events or firing the signals. Ignored events will not be handled automatically.
+			The control will not receive mouse button input events through [method _gui_input]. The control will also not receive the [signal mouse_entered] nor [signal mouse_exited] signals. This will not block other controls from receiving these events or firing the signals. Unlike [constant MOUSE_FILTER_PASS], Godot will look for the next control node under the mouse, even if it is not a parent of this control. Ignored events will not be handled automatically.
 		</constant>
 		<constant name="GROW_DIRECTION_BEGIN" value="0" enum="GrowDirection">
 			The control will grow to the left or top to make up if its minimum size is changed to be greater than its current size on the respective axis.


### PR DESCRIPTION
API clarification, doc-bug fixes, & added undocumented features.
------
Closes https://github.com/godotengine/godot-docs/issues/4266

**Changes :**
Specified how holding mouse button down blocks other controls until release.
Corrected 2 false statements in `_gui_input()`.
Added more precise details to
- `_gui_input()`,
- signal `mouse_entered`,
- signal `mouse_exited`,
- `enum MouseFilter`.

Added InputEvent tutorial to Tutorial section.

**Why is this Pull Request so detailed? :**

The commit itself is not very long, but this is my first contribution. So I thought it would be nice to detail my thought processes and to show my research to justify these additions. Perhaps this is unnecessary, but I figure revealing too much of the backstory here is better than explaining too little. 

Feel free to skip any detailed meta-descriptions, unless you plan to revise or add to these sections. I mainly wish to show that these changes are needed, and that the additions are correct. (Also, being a new contributor, I wanted to prove that I am not recklessly altering the API docs =). 

**Conversely, about the changes I'm submitting :**
I've tried very hard to keep the actual changes brief, comprehensive, and correct. I've gone through several revisions to condense it into something that should make sense in as few words as possible. I have verified each added line of text by experimenting with projects in Godot, and I've traced the C++ code for all the changes to make sure (1) what I describe is correct (2) there is nothing vital (within scope) which I've omitted.

Thematically most of the changes in this Pull Request are related to mouse events and mouse filters. However there are a few things out of scope I fixed and corrected while I was in the area (particularly, this Pull Request fixes 2 inaccurate descriptions in `Control._gui_input`, and there were 2 minor typos elsewhere). 

<hr>

What API will look like after this commit : 
-----
![no commentary](https://user-images.githubusercontent.com/65138515/101724354-02a64300-3a74-11eb-847d-c716a9500e0b.png)

<br><br><br>

<hr>

Explanation & points changed : 
-----
**enum MouseFilter**

![3-enum MouseFilter](https://user-images.githubusercontent.com/65138515/101724443-341f0e80-3a74-11eb-86ad-d550e9a3a1b6.png)

- Now describes why signals sometimes fail to emit and why events fail to fire (when another control is hogging mouse input by design) even though the `MouseFilter` is set up to recognize mouse entry.
It is intuitive based on the current API that `MOUSE_FILTER_IGNORE` will result in no signals being emitted, however it is not apparent that `MOUSE_FILTER_PASS` and `MOUSE_FILTER_STOP` do not guarantee that mouse motion events will always be routed to the Control.<br>
For the following, assume a setup where a Control has `mouse_filter` set to `MOUSE_FILTER_STOP` or `MOUSE_FILTER_PASS` and assume that it normally receives events and signals and _gui_input() when the mouse clicks, enters, or exits it.<br>
These signals will not emit and `func _gui_input()` will not fire if the mouse was clicked on another Control (which can receive mouse input) and has not been released yet. This applies to signals `mouse_entered` and `mouse_exited`, signal `gui_event(e)`, and virtual `_gui_input()`, all will be blocked and all events are routed up through the clicked Control instead.<br>
See ~line 1809 in `viewport.cpp` function `Viewport::_gui_input_event(..)` which is called when regular `Node._input()` calls do not handle an event. All gui input signals and scripted `func _gui_input(event)` events originate here.<br> 
Now look at ~lines 1821, 1872, 1897 in `viewport.cpp` function `Viewport::_gui_input_event(..)` <br>
`1821 -- if (gui.mouse_focus_mask) {`
`1872 -- if (mb->get_button_index() == BUTTON_LEFT) { //assign focus`
`1897 -- if (gui.mouse_focus && gui.mouse_focus->can_process()) {`<br>
When a Control which can receive mouse input is clicked, it remains in mouse focus until release. Even when the mouse hovers over other Controls, the event will be passed to the Control which the mouse initially clicked via (Control *control) `gui.mouse_focus`. <br>See `viewport.cpp`'s same `_gui_input_event(..)` in the branch for InputEventMouseMotion around lines 2009, 2057, and 2063 to see why events are called on the Control which was clicked (and not released) instead of the Control which is now under the mouse:<br>
`2009 -- if (!gui.drag_attempted && gui.mouse_focus && mm->get_button_mask() & ..`
`2057 -- if (gui.mouse_focus) {`
`2063 -- if (over != gui.mouse_over) {`<br><br><br>
- Also added detail emphasizing that `MOUSE_FILTER_PASS` passes the event straight up, whereas `MOUSE_FILTER_IGNORE` will look for nodes outside of ancestor branches.<br>
When looking for the Control under the mouse, Godot will find any node in the Viewport which is visually below (aka higher in the tree than) the one with `MOUSE_FILTER_IGNORE`, it doesn't have to be a parent or a parent of a parent; Godot searches whole tree in reverse order. <br>
See  `viewport.cpp` the functions `Viewport::_gui_find_control(..)` and `Viewport::_gui_find_control_at_pos(..)` around ~line 1703 to see it in the code.<br><br>

<br><br><br>

<hr>

Explanation & points changed : 
-----
**signal mouse_entered**
**signal mouse_exited**

![4-signals mouse_entered mouse_exited](https://user-images.githubusercontent.com/65138515/101725910-27e88080-3a77-11eb-9679-c32a1ff2f43d.png)

These signals were minimally documented. 

I spent a lot of time debugging a personal project until I discovered that the unexpected behavior of my GDScripts was due to the mouse-hogging behavior of clicked Controls, and not due to a bug in my code. Then I discovered that this mouse-hogging behavior was undocumented (see my previous section of this Pull Request for more details, also see doc bug report @ https://github.com/godotengine/godot-docs/issues/4266).

_Note: this is desired functionality. When you click and drag on a scroll bar's handle, it's standard that other Controls will not display a hover animation, and will similarly be blocked until mouse button release._

This was my entry point in researching everything that led to this Pull Request.

Fun fact.

Changes to `mouse_entered` and `mouse_exited` :
- Added links to `Control.has_point()` and `Control.get_rect()`, as `Rect` has its own section in the Inspector Dock, but it does not have a dedicated section in the API. Referring the reader to `Control.get_rect()` will make it apparent what this line is referencing with the word `Rect` (and exactly where to read more).<br><br>
- Added undocumented detail : if you parent a `Button` control under another `Button` control, then set the child's `mouse_filter` to `MOUSE_FILTER_PASS`:<br>hovering on the child will hover the parent (and emit `mouse_entered` for the child then the parent) and clicking the child `Button` will click the child and the parent `Button`. <br>
You can do this with any Control type and `MOUSE_FILTER_PASS`, but this is the simplest example to visualize.<br>
This is not intuitive (unless you look at the code for `viewport.cpp`) and I thought it aught to be documented. Look in `viewport.cpp` around line 1604 for the method `Viewport._gui_call_input(..)`. This is called for all gui events (mouse button, mouse motion, touch, drag, gesture) which are not keypress and joypad events from `Viewport::_gui_input_event(..)`'s c++ code. All gui mouse events flow through here. <br><br>
- Added details about how a control will hog mouse focus and hog signals/events/_gui_input until mouse release. Upon mouse button release, if the mouse is now under a `Control` different than the one that was clicked, the clicked control will emit `mouse_exited` and the `Control` actually under the mouse will emit `mouse_entered` and propagate the signal upwards if appropriate (these will both happen during the same `InputEventMouseButton` or `InputEventMouseMotion` event in `Viewport::_gui_input_event()`<br>
`1983 -- _gui_call_notification(gui.mouse_over, Control::NOTIFICATION_MOUSE_EXIT);`
`2065 -- _gui_call_notification(gui.mouse_over, Control::NOTIFICATION_MOUSE_EXIT);`<br><br>
- For this Pull Request's additions to these signals,<br> `mouse_entered` uses `[code]mouse_entered[/code]` and `[signal mouse_exited]` and<br>`mouse_exited` uses `[code]mouse_exited[/code]` and `[signal mouse_entered]`<br>so they do not link to themselves. (Also this gives a visual cue which one you are currently reading; Not the main reason, but a fun side-effect).

<br><br><br>

Explanation & points changed : 
-----
**func _gui_input(e)**

- Added reference to the InputEvent tutorial : https://docs.godotengine.org/en/3.2/tutorials/inputs/inputevent.html<br> I added this to the tutorials section at the top of the Control API page (see the first picture in this post). But I also wanted to refer the reader to it here specifically. It's vitally important to understand that tutorial in conjunction with the following description of `_gui_input()` in Control's API. <br>
I am unaware of a way to directly link to this tutorial's webpage in the online docs from the XML file. Further, I am unaware if this addition this breaches any conventions. This is the one non-strictly-technical point I've added which I'm unsure about, feel free to accept it or not, but I think it would be very beneficial to many.<br><br>
- The existing documentation for `_gui_input()` made it seem possible that keypress events were dependent on `mouse_filter`. I added a bullet point that keypress events and joypad events will only fire for the Control with key focus. This is briefly mentioned in the Intro section of Control's current API, but this section is not comprehensive without mentioning it.<br><br>
- Likewise, I added a phrase specifying that Control gui events are dependent on `mouse_filter` if they are mouse or touch events. <br><br>
- **[DOC-BUG FIX]** The current API for Godot 3 and Godot 4 both incorrectly state that parents pass events down to children unless they have `MOUSE_FILTER_STOP`. The current implementation passes all events (which are not joypad nor keypress events) up through the tree (see the while loop where this happens in the picture below). I corrected this phrase. See the first red outline in the picture below.<br><br>
- **[DOC-BUG FIX]** `rect_clip_content` does not clip input. Specified this, but largely left this line untouched. <br><br>Demonstration :
- - Add a `Button` to a `Panel`, 
- - clip input in the panel (you can do this from the Inspector Dock), 
- - don't override `_clips_input()` in a script, 
- - offset the `Button` to where part of it is invisible
- - run the scene and observe that you can still click <br>the invisible parts of the `Button`
- - add a script, add `func _clips_input(){ return true }`
- - run scene, observe that you can no longer click<br>the invisible parts of the `Button`.<br><br>
- Added details about mouse-hogging behavior (see the previous section of this Pull Request)<br><br>
- Added an important nuance : `_gui_input()` is not called if a node marks an event as handled in `func _input()`. This is outlined in the InputEvent tutorial, but will not be apparent without a lot of cross-referencing for beginners. This is an effort to make this method's documentation complete. Perhaps out of scope, but it's brief + more important than my main scope.

![5-_gui_input](https://user-images.githubusercontent.com/65138515/101727601-629fe800-3a7a-11eb-90a4-0404ef04cfa7.png)

<br><br><br>

<hr>

**Concluding remarks :**
Again, the changes are much smaller than these explanations.

If in the future anyone wants to reword or expand on this contribution, I wanted to lay out all the details in one place. Hopefully someday this will help someone who is exploring this area of the API + engine code for the first time. 

I plan on contributing fairly regularly to the Documentation. But since I haven't issued a Pull Request before, I wanted to back up my work with reasons.

I took notes on several other changes which were out of scope, and will submit bug reports to the godot-docs project and issue Pull Requests for those separately in the future.

If I need to issue multiple Pull Requests for the changes in this one, feel free to let me know and I will break it up into chunks. 

I'll rebase my fork every 12 hours or so to keep it up to date. 

Thanks to all who contribute their time and efforts to Godot.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
