### PR TITLE
Rename Area3D audio_bus_name getter and setter

### DIFF
--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -92,7 +92,7 @@
 			The rate at which objects stop spinning in this area. Represents the angular velocity lost per second.
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
-		<member name="audio_bus_name" type="StringName" setter="set_audio_bus" getter="get_audio_bus" default="@&quot;Master&quot;">
+		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="@&quot;Master&quot;">
 			The name of the area's audio bus.
 		</member>
 		<member name="audio_bus_override" type="bool" setter="set_audio_bus_override" getter="is_overriding_audio_bus" default="false">

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -505,11 +505,11 @@ bool Area3D::is_overriding_audio_bus() const {
 	return audio_bus_override;
 }
 
-void Area3D::set_audio_bus(const StringName &p_audio_bus) {
+void Area3D::set_audio_bus_name(const StringName &p_audio_bus) {
 	audio_bus = p_audio_bus;
 }
 
-StringName Area3D::get_audio_bus() const {
+StringName Area3D::get_audio_bus_name() const {
 	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 		if (AudioServer::get_singleton()->get_bus_name(i) == audio_bus) {
 			return audio_bus;
@@ -625,8 +625,8 @@ void Area3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_audio_bus_override", "enable"), &Area3D::set_audio_bus_override);
 	ClassDB::bind_method(D_METHOD("is_overriding_audio_bus"), &Area3D::is_overriding_audio_bus);
 
-	ClassDB::bind_method(D_METHOD("set_audio_bus", "name"), &Area3D::set_audio_bus);
-	ClassDB::bind_method(D_METHOD("get_audio_bus"), &Area3D::get_audio_bus);
+	ClassDB::bind_method(D_METHOD("set_audio_bus_name", "name"), &Area3D::set_audio_bus_name);
+	ClassDB::bind_method(D_METHOD("get_audio_bus_name"), &Area3D::get_audio_bus_name);
 
 	ClassDB::bind_method(D_METHOD("set_use_reverb_bus", "enable"), &Area3D::set_use_reverb_bus);
 	ClassDB::bind_method(D_METHOD("is_using_reverb_bus"), &Area3D::is_using_reverb_bus);
@@ -665,7 +665,7 @@ void Area3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_GROUP("Audio Bus", "audio_bus_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_bus_override"), "set_audio_bus_override", "is_overriding_audio_bus");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "audio_bus_name", PROPERTY_HINT_ENUM, ""), "set_audio_bus", "get_audio_bus");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "audio_bus_name", PROPERTY_HINT_ENUM, ""), "set_audio_bus_name", "get_audio_bus_name");
 	ADD_GROUP("Reverb Bus", "reverb_bus_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reverb_bus_enable"), "set_use_reverb_bus", "is_using_reverb_bus");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "reverb_bus_name", PROPERTY_HINT_ENUM, ""), "set_reverb_bus", "get_reverb_bus");

--- a/scene/3d/area_3d.h
+++ b/scene/3d/area_3d.h
@@ -190,8 +190,8 @@ public:
 	void set_audio_bus_override(bool p_override);
 	bool is_overriding_audio_bus() const;
 
-	void set_audio_bus(const StringName &p_audio_bus);
-	StringName get_audio_bus() const;
+	void set_audio_bus_name(const StringName &p_audio_bus);
+	StringName get_audio_bus_name() const;
 
 	void set_use_reverb_bus(bool p_enable);
 	bool is_using_reverb_bus() const;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -484,7 +484,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 				if (area) {
 					if (area->is_overriding_audio_bus()) {
 						//override audio bus
-						StringName bus_name = area->get_audio_bus();
+						StringName bus_name = area->get_audio_bus_name();
 						output.bus_index = AudioServer::get_singleton()->thread_find_bus_index(bus_name);
 					}
 


### PR DESCRIPTION
As identified in #29670, currently, unlike `Area2D`, `Area3D`'s `audio_bus_name`'s getter and setter are `set_audio_bus` and `get_audio_bus`.

This PR renames Area3D's:
- `set_audio_bus` -> `set_audio_bus_name`
- `get_audio_bus` -> `get_audio_bus_name`

Part of #16863.
