### PR TITLE
Rename TrackerHand enums

### DIFF
--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -101,10 +101,10 @@
 		<constant name="TRACKER_HAND_UNKNOWN" value="0" enum="TrackerHand">
 			The hand this tracker is held in is unknown or not applicable.
 		</constant>
-		<constant name="TRACKER_LEFT_HAND" value="1" enum="TrackerHand">
+		<constant name="TRACKER_HAND_LEFT" value="1" enum="TrackerHand">
 			This tracker is the left hand controller.
 		</constant>
-		<constant name="TRACKER_RIGHT_HAND" value="2" enum="TrackerHand">
+		<constant name="TRACKER_HAND_RIGHT" value="2" enum="TrackerHand">
 			This tracker is the right hand controller.
 		</constant>
 	</constants>

--- a/modules/gdnative/xr/xr_interface_gdnative.cpp
+++ b/modules/gdnative/xr/xr_interface_gdnative.cpp
@@ -305,9 +305,9 @@ godot_int GDAPI godot_xr_add_controller(char *p_device_name, godot_int p_hand, g
 	new_tracker->set_name(p_device_name);
 	new_tracker->set_type(XRServer::TRACKER_CONTROLLER);
 	if (p_hand == 1) {
-		new_tracker->set_hand(XRPositionalTracker::TRACKER_LEFT_HAND);
+		new_tracker->set_hand(XRPositionalTracker::TRACKER_HAND_LEFT);
 	} else if (p_hand == 2) {
-		new_tracker->set_hand(XRPositionalTracker::TRACKER_RIGHT_HAND);
+		new_tracker->set_hand(XRPositionalTracker::TRACKER_HAND_RIGHT);
 	}
 
 	// also register as joystick...

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -34,8 +34,8 @@
 
 void XRPositionalTracker::_bind_methods() {
 	BIND_ENUM_CONSTANT(TRACKER_HAND_UNKNOWN);
-	BIND_ENUM_CONSTANT(TRACKER_LEFT_HAND);
-	BIND_ENUM_CONSTANT(TRACKER_RIGHT_HAND);
+	BIND_ENUM_CONSTANT(TRACKER_HAND_LEFT);
+	BIND_ENUM_CONSTANT(TRACKER_HAND_RIGHT);
 
 	// this class is read only from GDScript, so we only have access to getters..
 	ClassDB::bind_method(D_METHOD("get_tracker_type"), &XRPositionalTracker::get_tracker_type);
@@ -182,11 +182,11 @@ void XRPositionalTracker::set_hand(const XRPositionalTracker::TrackerHand p_hand
 		ERR_FAIL_COND((type != XRServer::TRACKER_CONTROLLER) && (p_hand != XRPositionalTracker::TRACKER_HAND_UNKNOWN));
 
 		hand = p_hand;
-		if (hand == XRPositionalTracker::TRACKER_LEFT_HAND) {
+		if (hand == XRPositionalTracker::TRACKER_HAND_LEFT) {
 			if (!xr_server->is_tracker_id_in_use_for_type(type, 1)) {
 				tracker_id = 1;
 			};
-		} else if (hand == XRPositionalTracker::TRACKER_RIGHT_HAND) {
+		} else if (hand == XRPositionalTracker::TRACKER_HAND_RIGHT) {
 			if (!xr_server->is_tracker_id_in_use_for_type(type, 2)) {
 				tracker_id = 2;
 			};

--- a/servers/xr/xr_positional_tracker.h
+++ b/servers/xr/xr_positional_tracker.h
@@ -50,8 +50,8 @@ class XRPositionalTracker : public Object {
 public:
 	enum TrackerHand {
 		TRACKER_HAND_UNKNOWN, /* unknown or not applicable */
-		TRACKER_LEFT_HAND, /* controller is the left hand controller */
-		TRACKER_RIGHT_HAND /* controller is the right hand controller */
+		TRACKER_HAND_LEFT, /* controller is the left hand controller */
+		TRACKER_HAND_RIGHT /* controller is the right hand controller */
 	};
 
 private:


### PR DESCRIPTION
As identified [here](https://github.com/godotengine/godot/issues/16863#issuecomment-494437342), the `TrackerHand` `enum`s are named inconsistently:
https://github.com/godotengine/godot/blob/2a325f388825a20b8e87280d967de80411b2e927/servers/xr/xr_positional_tracker.h#L51-L55

This PR renames:
`TRACKER_LEFT_HAND` -> `TRACKER_HAND_LEFT`
`TRACKER_RIGHT_HAND` -> `TRACKER_HAND_RIGHT`

Part of #16863