### PR TITLE
Rename XRPositionalTracker methods

### DIFF
--- a/doc/classes/XRController3D.xml
+++ b/doc/classes/XRController3D.xml
@@ -19,7 +19,7 @@
 				If active, returns the name of the associated controller if provided by the AR/VR SDK used.
 			</description>
 		</method>
-		<method name="get_hand" qualifiers="const">
+		<method name="get_tracker_hand" qualifiers="const">
 			<return type="int" enum="XRPositionalTracker.TrackerHand">
 			</return>
 			<description>

--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -12,7 +12,7 @@
 		<link title="VR tutorial index">https://docs.godotengine.org/en/latest/tutorials/vr/index.html</link>
 	</tutorials>
 	<methods>
-		<method name="get_hand" qualifiers="const">
+		<method name="get_tracker_hand" qualifiers="const">
 			<return type="int" enum="XRPositionalTracker.TrackerHand">
 			</return>
 			<description>
@@ -68,18 +68,18 @@
 				Returns the tracker's type, which will be one of the values from the [enum XRServer.TrackerType] enum.
 			</description>
 		</method>
-		<method name="get_tracks_orientation" qualifiers="const">
+		<method name="is_tracking_orientation" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if this device tracks orientation.
+				Returns [code]true[/code] if this device is tracking orientation.
 			</description>
 		</method>
-		<method name="get_tracks_position" qualifiers="const">
+		<method name="is_tracking_position" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if this device tracks position.
+				Returns [code]true[/code] if this device is tracking position.
 			</description>
 		</method>
 		<method name="get_transform" qualifiers="const">

--- a/modules/arkit/arkit_interface.mm
+++ b/modules/arkit/arkit_interface.mm
@@ -398,14 +398,14 @@ XRPositionalTracker *ARKitInterface::get_anchor_for_uuid(const unsigned char *p_
 	}
 
 	XRPositionalTracker *new_tracker = memnew(XRPositionalTracker);
-	new_tracker->set_type(XRServer::TRACKER_ANCHOR);
+	new_tracker->set_tracker_type(XRServer::TRACKER_ANCHOR);
 
 	char tracker_name[256];
 	sprintf(tracker_name, "Anchor %02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x", p_uuid[0], p_uuid[1], p_uuid[2], p_uuid[3], p_uuid[4], p_uuid[5], p_uuid[6], p_uuid[7], p_uuid[8], p_uuid[9], p_uuid[10], p_uuid[11], p_uuid[12], p_uuid[13], p_uuid[14], p_uuid[15]);
 
 	String name = tracker_name;
 	print_line("Adding tracker " + name);
-	new_tracker->set_name(name);
+	new_tracker->set_tracker_name(name);
 
 	// add our tracker
 	XRServer::get_singleton()->add_tracker(new_tracker);

--- a/modules/gdnative/xr/xr_interface_gdnative.cpp
+++ b/modules/gdnative/xr/xr_interface_gdnative.cpp
@@ -302,12 +302,12 @@ godot_int GDAPI godot_xr_add_controller(char *p_device_name, godot_int p_hand, g
 	ERR_FAIL_NULL_V(input, 0);
 
 	XRPositionalTracker *new_tracker = memnew(XRPositionalTracker);
-	new_tracker->set_name(p_device_name);
-	new_tracker->set_type(XRServer::TRACKER_CONTROLLER);
+	new_tracker->set_tracker_name(p_device_name);
+	new_tracker->set_tracker_type(XRServer::TRACKER_CONTROLLER);
 	if (p_hand == 1) {
-		new_tracker->set_hand(XRPositionalTracker::TRACKER_HAND_LEFT);
+		new_tracker->set_tracker_hand(XRPositionalTracker::TRACKER_HAND_LEFT);
 	} else if (p_hand == 2) {
-		new_tracker->set_hand(XRPositionalTracker::TRACKER_HAND_RIGHT);
+		new_tracker->set_tracker_hand(XRPositionalTracker::TRACKER_HAND_RIGHT);
 	}
 
 	// also register as joystick...

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -247,7 +247,7 @@ void XRController3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_joystick_axis", "axis"), &XRController3D::get_joystick_axis);
 
 	ClassDB::bind_method(D_METHOD("get_is_active"), &XRController3D::get_is_active);
-	ClassDB::bind_method(D_METHOD("get_hand"), &XRController3D::get_hand);
+	ClassDB::bind_method(D_METHOD("get_tracker_hand"), &XRController3D::get_tracker_hand);
 
 	ClassDB::bind_method(D_METHOD("get_rumble"), &XRController3D::get_rumble);
 	ClassDB::bind_method(D_METHOD("set_rumble", "rumble"), &XRController3D::set_rumble);
@@ -349,7 +349,7 @@ bool XRController3D::get_is_active() const {
 	return is_active;
 };
 
-XRPositionalTracker::TrackerHand XRController3D::get_hand() const {
+XRPositionalTracker::TrackerHand XRController3D::get_tracker_hand() const {
 	// get our XRServer
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, XRPositionalTracker::TRACKER_HAND_UNKNOWN);
@@ -359,7 +359,7 @@ XRPositionalTracker::TrackerHand XRController3D::get_hand() const {
 		return XRPositionalTracker::TRACKER_HAND_UNKNOWN;
 	};
 
-	return tracker->get_hand();
+	return tracker->get_tracker_hand();
 };
 
 String XRController3D::get_configuration_warning() const {

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -93,7 +93,7 @@ public:
 	void set_rumble(real_t p_rumble);
 
 	bool get_is_active() const;
-	XRPositionalTracker::TrackerHand get_hand() const;
+	XRPositionalTracker::TrackerHand get_tracker_hand() const;
 
 	Ref<Mesh> get_mesh() const;
 

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -42,17 +42,17 @@ void XRPositionalTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tracker_id"), &XRPositionalTracker::get_tracker_id);
 	ClassDB::bind_method(D_METHOD("get_tracker_name"), &XRPositionalTracker::get_tracker_name);
 	ClassDB::bind_method(D_METHOD("get_joy_id"), &XRPositionalTracker::get_joy_id);
-	ClassDB::bind_method(D_METHOD("get_tracks_orientation"), &XRPositionalTracker::get_tracks_orientation);
+	ClassDB::bind_method(D_METHOD("is_tracking_orientation"), &XRPositionalTracker::is_tracking_orientation);
 	ClassDB::bind_method(D_METHOD("get_orientation"), &XRPositionalTracker::get_orientation);
-	ClassDB::bind_method(D_METHOD("get_tracks_position"), &XRPositionalTracker::get_tracks_position);
+	ClassDB::bind_method(D_METHOD("is_tracking_position"), &XRPositionalTracker::is_tracking_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &XRPositionalTracker::get_position);
-	ClassDB::bind_method(D_METHOD("get_hand"), &XRPositionalTracker::get_hand);
+	ClassDB::bind_method(D_METHOD("get_tracker_hand"), &XRPositionalTracker::get_tracker_hand);
 	ClassDB::bind_method(D_METHOD("get_transform", "adjust_by_reference_frame"), &XRPositionalTracker::get_transform);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &XRPositionalTracker::get_mesh);
 
 	// these functions we don't want to expose to normal users but do need to be callable from GDNative
-	ClassDB::bind_method(D_METHOD("_set_type", "type"), &XRPositionalTracker::set_type);
-	ClassDB::bind_method(D_METHOD("_set_name", "name"), &XRPositionalTracker::set_name);
+	ClassDB::bind_method(D_METHOD("_set_tracker_type", "type"), &XRPositionalTracker::set_tracker_type);
+	ClassDB::bind_method(D_METHOD("_set_tracker_name", "name"), &XRPositionalTracker::set_tracker_name);
 	ClassDB::bind_method(D_METHOD("_set_joy_id", "joy_id"), &XRPositionalTracker::set_joy_id);
 	ClassDB::bind_method(D_METHOD("_set_orientation", "orientation"), &XRPositionalTracker::set_orientation);
 	ClassDB::bind_method(D_METHOD("_set_rw_position", "rw_position"), &XRPositionalTracker::set_rw_position);
@@ -63,7 +63,7 @@ void XRPositionalTracker::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rumble"), "set_rumble", "get_rumble");
 };
 
-void XRPositionalTracker::set_type(XRServer::TrackerType p_type) {
+void XRPositionalTracker::set_tracker_type(XRServer::TrackerType p_type) {
 	if (type != p_type) {
 		type = p_type;
 		hand = XRPositionalTracker::TRACKER_HAND_UNKNOWN;
@@ -81,7 +81,7 @@ XRServer::TrackerType XRPositionalTracker::get_tracker_type() const {
 	return type;
 };
 
-void XRPositionalTracker::set_name(const String &p_name) {
+void XRPositionalTracker::set_tracker_name(const String &p_name) {
 	name = p_name;
 };
 
@@ -101,14 +101,14 @@ int XRPositionalTracker::get_joy_id() const {
 	return joy_id;
 };
 
-bool XRPositionalTracker::get_tracks_orientation() const {
-	return tracks_orientation;
+bool XRPositionalTracker::is_tracking_orientation() const {
+	return tracking_orientation;
 };
 
 void XRPositionalTracker::set_orientation(const Basis &p_orientation) {
 	_THREAD_SAFE_METHOD_
 
-	tracks_orientation = true; // obviously we have this
+	tracking_orientation = true; // obviously we have this
 	orientation = p_orientation;
 };
 
@@ -118,8 +118,8 @@ Basis XRPositionalTracker::get_orientation() const {
 	return orientation;
 };
 
-bool XRPositionalTracker::get_tracks_position() const {
-	return tracks_position;
+bool XRPositionalTracker::is_tracking_position() const {
+	return tracking_position;
 };
 
 void XRPositionalTracker::set_position(const Vector3 &p_position) {
@@ -130,7 +130,7 @@ void XRPositionalTracker::set_position(const Vector3 &p_position) {
 	real_t world_scale = xr_server->get_world_scale();
 	ERR_FAIL_COND(world_scale == 0);
 
-	tracks_position = true; // obviously we have this
+	tracking_position = true; // obviously we have this
 	rw_position = p_position / world_scale;
 };
 
@@ -147,7 +147,7 @@ Vector3 XRPositionalTracker::get_position() const {
 void XRPositionalTracker::set_rw_position(const Vector3 &p_rw_position) {
 	_THREAD_SAFE_METHOD_
 
-	tracks_position = true; // obviously we have this
+	tracking_position = true; // obviously we have this
 	rw_position = p_rw_position;
 };
 
@@ -169,11 +169,11 @@ Ref<Mesh> XRPositionalTracker::get_mesh() const {
 	return mesh;
 };
 
-XRPositionalTracker::TrackerHand XRPositionalTracker::get_hand() const {
+XRPositionalTracker::TrackerHand XRPositionalTracker::get_tracker_hand() const {
 	return hand;
 };
 
-void XRPositionalTracker::set_hand(const XRPositionalTracker::TrackerHand p_hand) {
+void XRPositionalTracker::set_tracker_hand(const XRPositionalTracker::TrackerHand p_hand) {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);
 
@@ -227,8 +227,8 @@ XRPositionalTracker::XRPositionalTracker() {
 	name = "Unknown";
 	joy_id = -1;
 	tracker_id = 0;
-	tracks_orientation = false;
-	tracks_position = false;
+	tracking_orientation = false;
+	tracking_position = false;
 	hand = TRACKER_HAND_UNKNOWN;
 	rumble = 0.0;
 };

--- a/servers/xr/xr_positional_tracker.h
+++ b/servers/xr/xr_positional_tracker.h
@@ -59,9 +59,9 @@ private:
 	StringName name; // (unique) name of the tracker
 	int tracker_id; // tracker index id that is unique per type
 	int joy_id; // if we also have a related joystick entity, the id of the joystick
-	bool tracks_orientation; // do we track orientation?
+	bool tracking_orientation; // do we track orientation?
 	Basis orientation; // our orientation
-	bool tracks_position; // do we track position?
+	bool tracking_position; // do we track position?
 	Vector3 rw_position; // our position "in the real world, so without world_scale applied"
 	Ref<Mesh> mesh; // when available, a mesh that can be used to render this tracker
 	TrackerHand hand; // if known, the hand this tracker is held in
@@ -71,23 +71,23 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_type(XRServer::TrackerType p_type);
+	void set_tracker_type(XRServer::TrackerType p_type);
 	XRServer::TrackerType get_tracker_type() const;
-	void set_name(const String &p_name);
+	void set_tracker_name(const String &p_name);
 	StringName get_tracker_name() const;
 	int get_tracker_id() const;
 	void set_joy_id(int p_joy_id);
 	int get_joy_id() const;
-	bool get_tracks_orientation() const;
+	bool is_tracking_orientation() const;
 	void set_orientation(const Basis &p_orientation);
 	Basis get_orientation() const;
-	bool get_tracks_position() const;
+	bool is_tracking_position() const;
 	void set_position(const Vector3 &p_position); // set position with world_scale applied
 	Vector3 get_position() const; // get position with world_scale applied
 	void set_rw_position(const Vector3 &p_rw_position);
 	Vector3 get_rw_position() const;
-	XRPositionalTracker::TrackerHand get_hand() const;
-	void set_hand(const XRPositionalTracker::TrackerHand p_hand);
+	XRPositionalTracker::TrackerHand get_tracker_hand() const;
+	void set_tracker_hand(const XRPositionalTracker::TrackerHand p_hand);
 	real_t get_rumble() const;
 	void set_rumble(real_t p_rumble);
 	void set_mesh(const Ref<Mesh> &p_mesh);


### PR DESCRIPTION
#36382 (888deca827) renamed `XRPositionalTracker` `get_type()` and `get_name()` to `get_tracker_type()` and `get_tracker_name()`, but did not rename `set_type()` and `set_name()`.

Furthermore, there are two boolean getters: `get_tracks_orientation()` and `get_tracks_position()` that are confusing because they don't return the track's orientation or position. Instead, they return whether or not the tracker is tracking the orientation or position.

Finally, as originally [suggested](https://github.com/godotengine/godot/issues/16863#issuecomment-494437342), `get_hand()` and `set_hand()`, gets and returns a `TrackerHand` `enum`, so this should be renamed `get_tracker_hand()` and `set_tracker_hand()` for consistency.

This PR renames:
- `set_type()` -> `set_tracker_type()`
- `set_name()` -> `set_tracker_name()`
- `get_tracks_orientation()` - `is_tracking_orientation()`
- `get_tracks_position()` -> `is_tracking_position()`
- `get_hand()` -> `get_tracker_hand()`
- `set_hand()` -> `set_tracker_hand()`

