### PR TITLE
Allow to circle back in 'PopupMenu' even if the first/last item is non-selectable

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -238,6 +238,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 			search_from = 0;
 		}
 
+		bool match_found = false;
 		for (int i = search_from; i < items.size(); i++) {
 			if (!items[i].separator && !items[i].disabled) {
 				mouse_over = i;
@@ -245,7 +246,22 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 				_scroll_to_item(i);
 				control->update();
 				set_input_as_handled();
+				match_found = true;
 				break;
+			}
+		}
+
+		if (!match_found) {
+			// If the last item is not selectable, try re-searching from the start.
+			for (int i = 0; i < search_from; i++) {
+				if (!items[i].separator && !items[i].disabled) {
+					mouse_over = i;
+					emit_signal("id_focused", i);
+					_scroll_to_item(i);
+					control->update();
+					set_input_as_handled();
+					break;
+				}
 			}
 		}
 	} else if (p_event->is_action("ui_up") && p_event->is_pressed()) {
@@ -254,6 +270,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 			search_from = items.size() - 1;
 		}
 
+		bool match_found = false;
 		for (int i = search_from; i >= 0; i--) {
 			if (!items[i].separator && !items[i].disabled) {
 				mouse_over = i;
@@ -261,7 +278,22 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 				_scroll_to_item(i);
 				control->update();
 				set_input_as_handled();
+				match_found = true;
 				break;
+			}
+		}
+
+		if (!match_found) {
+			// If the first item is not selectable, try re-searching from the end.
+			for (int i = items.size() - 1; i >= search_from; i--) {
+				if (!items[i].separator && !items[i].disabled) {
+					mouse_over = i;
+					emit_signal("id_focused", i);
+					_scroll_to_item(i);
+					control->update();
+					set_input_as_handled();
+					break;
+				}
 			}
 		}
 	} else if (p_event->is_action("ui_left") && p_event->is_pressed()) {


### PR DESCRIPTION
Before, if the first/last item in a `PopupMenu` was non-selectable (disabled or a separator), circling back from its direction would not work. This fixes that.