### PR TITLE
Use pointer parameters in Variant function pointers

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -511,7 +511,7 @@ public:
 
 	/* Constructors */
 
-	typedef void (*ValidatedConstructor)(Variant &r_base, const Variant **p_args);
+	typedef void (*ValidatedConstructor)(Variant *r_base, const Variant **p_args);
 	typedef void (*PTRConstructor)(void *base, const void **p_args);
 
 	static int get_constructor_count(Variant::Type p_type);
@@ -550,8 +550,8 @@ public:
 	static bool has_indexing(Variant::Type p_type);
 	static Variant::Type get_indexed_element_type(Variant::Type p_type);
 
-	typedef void (*ValidatedIndexedSetter)(Variant *base, int64_t index, const Variant *value, bool &oob);
-	typedef void (*ValidatedIndexedGetter)(const Variant *base, int64_t index, Variant *value, bool &oob);
+	typedef void (*ValidatedIndexedSetter)(Variant *base, int64_t index, const Variant *value, bool *oob);
+	typedef void (*ValidatedIndexedGetter)(const Variant *base, int64_t index, Variant *value, bool *oob);
 
 	static ValidatedIndexedSetter get_member_validated_indexed_setter(Variant::Type p_type);
 	static ValidatedIndexedGetter get_member_validated_indexed_getter(Variant::Type p_type);
@@ -571,9 +571,9 @@ public:
 
 	static bool is_keyed(Variant::Type p_type);
 
-	typedef void (*ValidatedKeyedSetter)(Variant *base, const Variant *key, const Variant *value, bool &valid);
-	typedef void (*ValidatedKeyedGetter)(const Variant *base, const Variant *key, Variant *value, bool &valid);
-	typedef bool (*ValidatedKeyedChecker)(const Variant *base, const Variant *key, bool &valid);
+	typedef void (*ValidatedKeyedSetter)(Variant *base, const Variant *key, const Variant *value, bool *valid);
+	typedef void (*ValidatedKeyedGetter)(const Variant *base, const Variant *key, Variant *value, bool *valid);
+	typedef bool (*ValidatedKeyedChecker)(const Variant *base, const Variant *key, bool *valid);
 
 	static ValidatedKeyedSetter get_member_validated_keyed_setter(Variant::Type p_type);
 	static ValidatedKeyedGetter get_member_validated_keyed_getter(Variant::Type p_type);

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -69,9 +69,9 @@ public:
 		construct_helper(*VariantGetInternalPtr<T>::get_ptr(&r_ret), p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantTypeChanger<T>::change(&r_ret);
-		validated_construct_helper(*VariantGetInternalPtr<T>::get_ptr(&r_ret), p_args, BuildIndexSequence<sizeof...(P)>{});
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantTypeChanger<T>::change(r_ret);
+		validated_construct_helper(*VariantGetInternalPtr<T>::get_ptr(r_ret), p_args, BuildIndexSequence<sizeof...(P)>{});
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		ptr_construct_helper(base, p_args, BuildIndexSequence<sizeof...(P)>{});
@@ -107,9 +107,9 @@ public:
 		}
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantInternal::clear(&r_ret);
-		VariantInternal::object_assign(&r_ret, p_args[0]);
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantInternal::clear(r_ret);
+		VariantInternal::object_assign(r_ret, p_args[0]);
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrToArg<Object *>::encode(PtrToArg<Object *>::convert(p_args[0]), base);
@@ -141,9 +141,9 @@ public:
 		VariantInternal::object_assign_null(&r_ret);
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantInternal::clear(&r_ret);
-		VariantInternal::object_assign_null(&r_ret);
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantInternal::clear(r_ret);
+		VariantInternal::object_assign_null(r_ret);
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrToArg<Object *>::encode(nullptr, base);
@@ -194,9 +194,9 @@ public:
 		*VariantGetInternalPtr<Callable>::get_ptr(&r_ret) = Callable(object_id, method);
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantTypeChanger<Callable>::change(&r_ret);
-		*VariantGetInternalPtr<Callable>::get_ptr(&r_ret) = Callable(VariantInternal::get_object_id(p_args[0]), *VariantGetInternalPtr<StringName>::get_ptr(p_args[1]));
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantTypeChanger<Callable>::change(r_ret);
+		*VariantGetInternalPtr<Callable>::get_ptr(r_ret) = Callable(VariantInternal::get_object_id(p_args[0]), *VariantGetInternalPtr<StringName>::get_ptr(p_args[1]));
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrToArg<Callable>::encode(Callable(PtrToArg<Object *>::convert(p_args[0]), PtrToArg<StringName>::convert(p_args[1])), base);
@@ -251,9 +251,9 @@ public:
 		*VariantGetInternalPtr<Signal>::get_ptr(&r_ret) = Signal(object_id, method);
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantTypeChanger<Signal>::change(&r_ret);
-		*VariantGetInternalPtr<Signal>::get_ptr(&r_ret) = Signal(VariantInternal::get_object_id(p_args[0]), *VariantGetInternalPtr<StringName>::get_ptr(p_args[1]));
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantTypeChanger<Signal>::change(r_ret);
+		*VariantGetInternalPtr<Signal>::get_ptr(r_ret) = Signal(VariantInternal::get_object_id(p_args[0]), *VariantGetInternalPtr<StringName>::get_ptr(p_args[1]));
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrToArg<Signal>::encode(Signal(PtrToArg<Object *>::convert(p_args[0]), PtrToArg<StringName>::convert(p_args[1])), base);
@@ -298,9 +298,9 @@ public:
 		}
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantTypeChanger<Array>::change(&r_ret);
-		Array &dst_arr = *VariantGetInternalPtr<Array>::get_ptr(&r_ret);
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantTypeChanger<Array>::change(r_ret);
+		Array &dst_arr = *VariantGetInternalPtr<Array>::get_ptr(r_ret);
 		const T &src_arr = *VariantGetInternalPtr<T>::get_ptr(p_args[0]);
 
 		int size = src_arr.size();
@@ -357,10 +357,10 @@ public:
 		}
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantTypeChanger<T>::change(&r_ret);
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantTypeChanger<T>::change(r_ret);
 		const Array &src_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
-		T &dst_arr = *VariantGetInternalPtr<T>::get_ptr(&r_ret);
+		T &dst_arr = *VariantGetInternalPtr<T>::get_ptr(r_ret);
 
 		int size = src_arr.size();
 		dst_arr.resize(size);
@@ -408,8 +408,8 @@ public:
 		VariantInternal::clear(&r_ret);
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantInternal::clear(&r_ret);
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantInternal::clear(r_ret);
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrToArg<Variant>::encode(Variant(), base);
@@ -436,8 +436,8 @@ public:
 		r_error.error = Callable::CallError::CALL_OK;
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantTypeChanger<T>::change_and_reset(&r_ret);
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantTypeChanger<T>::change_and_reset(r_ret);
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrToArg<T>::encode(T(), base);
@@ -463,8 +463,8 @@ public:
 		r_error.error = Callable::CallError::CALL_OK;
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantInternal::clear(&r_ret);
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantInternal::clear(r_ret);
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		ERR_FAIL_MSG("can't ptrcall nil constructor");
@@ -491,9 +491,9 @@ public:
 		r_error.error = Callable::CallError::CALL_OK;
 	}
 
-	static void validated_construct(Variant &r_ret, const Variant **p_args) {
-		VariantInternal::clear(&r_ret);
-		VariantInternal::object_assign_null(&r_ret);
+	static void validated_construct(Variant *r_ret, const Variant **p_args) {
+		VariantInternal::clear(r_ret);
+		VariantInternal::object_assign_null(r_ret);
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrToArg<Object *>::encode(nullptr, base);

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1181,7 +1181,7 @@ struct VariantKeyedSetGetObject {
 
 	static bool has(const Variant *base, const Variant *key, bool *r_valid) {
 		Object *obj = base->get_validated_object();
-		if (obj != nullptr) {
+		if (!obj) {
 			*r_valid = false;
 			return false;
 		}

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -582,18 +582,18 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 
 #define INDEXED_SETGET_STRUCT_TYPED(m_base_type, m_elem_type)                                                                        \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                      \
-		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                             \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                             \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                \
 			if (index < 0) {                                                                                                         \
 				index += size;                                                                                                       \
 			}                                                                                                                        \
 			if (index < 0 || index >= size) {                                                                                        \
-				oob = true;                                                                                                          \
+				*oob = true;                                                                                                         \
 				return;                                                                                                              \
 			}                                                                                                                        \
 			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                           \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];       \
-			oob = false;                                                                                                             \
+			*oob = false;                                                                                                            \
 		}                                                                                                                            \
 		static void ptr_get(const void *base, int64_t index, void *member) {                                                         \
 			/* avoid ptrconvert for performance*/                                                                                    \
@@ -603,10 +603,10 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, v.size());                                                                                               \
 			PtrToArg<m_elem_type>::encode(v[index], member);                                                                         \
 		}                                                                                                                            \
-		static void set(Variant *base, int64_t index, const Variant *value, bool &valid, bool &oob) {                                \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                                \
 			if (value->get_type() != GetTypeInfo<m_elem_type>::VARIANT_TYPE) {                                                       \
-				oob = false;                                                                                                         \
-				valid = false;                                                                                                       \
+				*oob = false;                                                                                                        \
+				*valid = false;                                                                                                      \
 				return;                                                                                                              \
 			}                                                                                                                        \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                \
@@ -614,25 +614,25 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 				index += size;                                                                                                       \
 			}                                                                                                                        \
 			if (index < 0 || index >= size) {                                                                                        \
-				oob = true;                                                                                                          \
-				valid = false;                                                                                                       \
+				*oob = true;                                                                                                         \
+				*valid = false;                                                                                                      \
 				return;                                                                                                              \
 			}                                                                                                                        \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base)).write[index] = *VariantGetInternalPtr<m_elem_type>::get_ptr(value); \
-			oob = false;                                                                                                             \
-			valid = true;                                                                                                            \
+			*oob = false;                                                                                                            \
+			*valid = true;                                                                                                           \
 		}                                                                                                                            \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool &oob) {                                   \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                                   \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                \
 			if (index < 0) {                                                                                                         \
 				index += size;                                                                                                       \
 			}                                                                                                                        \
 			if (index < 0 || index >= size) {                                                                                        \
-				oob = true;                                                                                                          \
+				*oob = true;                                                                                                         \
 				return;                                                                                                              \
 			}                                                                                                                        \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base)).write[index] = *VariantGetInternalPtr<m_elem_type>::get_ptr(value); \
-			oob = false;                                                                                                             \
+			*oob = false;                                                                                                            \
 		}                                                                                                                            \
 		static void ptr_set(void *base, int64_t index, const void *member) {                                                         \
 			/* avoid ptrconvert for performance*/                                                                                    \
@@ -648,18 +648,18 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 
 #define INDEXED_SETGET_STRUCT_TYPED_NUMERIC(m_base_type, m_elem_type, m_assign_type)                                                 \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                      \
-		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                             \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                             \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                \
 			if (index < 0) {                                                                                                         \
 				index += size;                                                                                                       \
 			}                                                                                                                        \
 			if (index < 0 || index >= size) {                                                                                        \
-				oob = true;                                                                                                          \
+				*oob = true;                                                                                                         \
 				return;                                                                                                              \
 			}                                                                                                                        \
 			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                           \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];       \
-			oob = false;                                                                                                             \
+			*oob = false;                                                                                                            \
 		}                                                                                                                            \
 		static void ptr_get(const void *base, int64_t index, void *member) {                                                         \
 			/* avoid ptrconvert for performance*/                                                                                    \
@@ -669,14 +669,14 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, v.size());                                                                                               \
 			PtrToArg<m_elem_type>::encode(v[index], member);                                                                         \
 		}                                                                                                                            \
-		static void set(Variant *base, int64_t index, const Variant *value, bool &valid, bool &oob) {                                \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                                \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                \
 			if (index < 0) {                                                                                                         \
 				index += size;                                                                                                       \
 			}                                                                                                                        \
 			if (index < 0 || index >= size) {                                                                                        \
-				oob = true;                                                                                                          \
-				valid = false;                                                                                                       \
+				*oob = true;                                                                                                         \
+				*valid = false;                                                                                                      \
 				return;                                                                                                              \
 			}                                                                                                                        \
 			m_assign_type num;                                                                                                       \
@@ -685,25 +685,25 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			} else if (value->get_type() == Variant::FLOAT) {                                                                        \
 				num = (m_assign_type)*VariantGetInternalPtr<double>::get_ptr(value);                                                 \
 			} else {                                                                                                                 \
-				oob = false;                                                                                                         \
-				valid = false;                                                                                                       \
+				*oob = false;                                                                                                        \
+				*valid = false;                                                                                                      \
 				return;                                                                                                              \
 			}                                                                                                                        \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base)).write[index] = num;                                                 \
-			oob = false;                                                                                                             \
-			valid = true;                                                                                                            \
+			*oob = false;                                                                                                            \
+			*valid = true;                                                                                                           \
 		}                                                                                                                            \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool &oob) {                                   \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                                   \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                \
 			if (index < 0) {                                                                                                         \
 				index += size;                                                                                                       \
 			}                                                                                                                        \
 			if (index < 0 || index >= size) {                                                                                        \
-				oob = true;                                                                                                          \
+				*oob = true;                                                                                                         \
 				return;                                                                                                              \
 			}                                                                                                                        \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base)).write[index] = *VariantGetInternalPtr<m_elem_type>::get_ptr(value); \
-			oob = false;                                                                                                             \
+			*oob = false;                                                                                                            \
 		}                                                                                                                            \
 		static void ptr_set(void *base, int64_t index, const void *member) {                                                         \
 			/* avoid ptrconvert for performance*/                                                                                    \
@@ -719,14 +719,14 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 
 #define INDEXED_SETGET_STRUCT_BULTIN_NUMERIC(m_base_type, m_elem_type, m_assign_type, m_max)                                   \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                \
-		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                       \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                       \
 			if (index < 0 || index >= m_max) {                                                                                 \
-				oob = true;                                                                                                    \
+				*oob = true;                                                                                                   \
 				return;                                                                                                        \
 			}                                                                                                                  \
 			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                     \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index]; \
-			oob = false;                                                                                                       \
+			*oob = false;                                                                                                      \
 		}                                                                                                                      \
 		static void ptr_get(const void *base, int64_t index, void *member) {                                                   \
 			/* avoid ptrconvert for performance*/                                                                              \
@@ -734,10 +734,10 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, m_max);                                                                                            \
 			PtrToArg<m_elem_type>::encode(v[index], member);                                                                   \
 		}                                                                                                                      \
-		static void set(Variant *base, int64_t index, const Variant *value, bool &valid, bool &oob) {                          \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                          \
 			if (index < 0 || index >= m_max) {                                                                                 \
-				oob = true;                                                                                                    \
-				valid = false;                                                                                                 \
+				*oob = true;                                                                                                   \
+				*valid = false;                                                                                                \
 				return;                                                                                                        \
 			}                                                                                                                  \
 			m_assign_type num;                                                                                                 \
@@ -746,21 +746,21 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			} else if (value->get_type() == Variant::FLOAT) {                                                                  \
 				num = (m_assign_type)*VariantGetInternalPtr<double>::get_ptr(value);                                           \
 			} else {                                                                                                           \
-				oob = false;                                                                                                   \
-				valid = false;                                                                                                 \
+				*oob = false;                                                                                                  \
+				*valid = false;                                                                                                \
 				return;                                                                                                        \
 			}                                                                                                                  \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index] = num;                                                 \
-			oob = false;                                                                                                       \
-			valid = true;                                                                                                      \
+			*oob = false;                                                                                                      \
+			*valid = true;                                                                                                     \
 		}                                                                                                                      \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool &oob) {                             \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                             \
 			if (index < 0 || index >= m_max) {                                                                                 \
-				oob = true;                                                                                                    \
+				*oob = true;                                                                                                   \
 				return;                                                                                                        \
 			}                                                                                                                  \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index] = *VariantGetInternalPtr<m_elem_type>::get_ptr(value); \
-			oob = false;                                                                                                       \
+			*oob = false;                                                                                                      \
 		}                                                                                                                      \
 		static void ptr_set(void *base, int64_t index, const void *member) {                                                   \
 			/* avoid ptrconvert for performance*/                                                                              \
@@ -774,14 +774,14 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 
 #define INDEXED_SETGET_STRUCT_BULTIN_ACCESSOR(m_base_type, m_elem_type, m_accessor, m_max)                                                \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                           \
-		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                                  \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                                  \
 			if (index < 0 || index >= m_max) {                                                                                            \
-				oob = true;                                                                                                               \
+				*oob = true;                                                                                                              \
 				return;                                                                                                                   \
 			}                                                                                                                             \
 			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                                \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))m_accessor[index];  \
-			oob = false;                                                                                                                  \
+			*oob = false;                                                                                                                 \
 		}                                                                                                                                 \
 		static void ptr_get(const void *base, int64_t index, void *member) {                                                              \
 			/* avoid ptrconvert for performance*/                                                                                         \
@@ -789,27 +789,27 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, m_max);                                                                                                       \
 			PtrToArg<m_elem_type>::encode(v m_accessor[index], member);                                                                   \
 		}                                                                                                                                 \
-		static void set(Variant *base, int64_t index, const Variant *value, bool &valid, bool &oob) {                                     \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                                     \
 			if (value->get_type() != GetTypeInfo<m_elem_type>::VARIANT_TYPE) {                                                            \
-				oob = false;                                                                                                              \
-				valid = false;                                                                                                            \
+				*oob = false;                                                                                                             \
+				*valid = false;                                                                                                           \
 			}                                                                                                                             \
 			if (index < 0 || index >= m_max) {                                                                                            \
-				oob = true;                                                                                                               \
-				valid = false;                                                                                                            \
+				*oob = true;                                                                                                              \
+				*valid = false;                                                                                                           \
 				return;                                                                                                                   \
 			}                                                                                                                             \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base)) m_accessor[index] = *VariantGetInternalPtr<m_elem_type>::get_ptr(value); \
-			oob = false;                                                                                                                  \
-			valid = true;                                                                                                                 \
+			*oob = false;                                                                                                                 \
+			*valid = true;                                                                                                                \
 		}                                                                                                                                 \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool &oob) {                                        \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                                        \
 			if (index < 0 || index >= m_max) {                                                                                            \
-				oob = true;                                                                                                               \
+				*oob = true;                                                                                                              \
 				return;                                                                                                                   \
 			}                                                                                                                             \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base)) m_accessor[index] = *VariantGetInternalPtr<m_elem_type>::get_ptr(value); \
-			oob = false;                                                                                                                  \
+			*oob = false;                                                                                                                 \
 		}                                                                                                                                 \
 		static void ptr_set(void *base, int64_t index, const void *member) {                                                              \
 			/* avoid ptrconvert for performance*/                                                                                         \
@@ -823,14 +823,14 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 
 #define INDEXED_SETGET_STRUCT_BULTIN_FUNC(m_base_type, m_elem_type, m_set, m_get, m_max)                                           \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                    \
-		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                           \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                           \
 			if (index < 0 || index >= m_max) {                                                                                     \
-				oob = true;                                                                                                        \
+				*oob = true;                                                                                                       \
 				return;                                                                                                            \
 			}                                                                                                                      \
 			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                         \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_get(index); \
-			oob = false;                                                                                                           \
+			*oob = false;                                                                                                          \
 		}                                                                                                                          \
 		static void ptr_get(const void *base, int64_t index, void *member) {                                                       \
 			/* avoid ptrconvert for performance*/                                                                                  \
@@ -838,27 +838,27 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, m_max);                                                                                                \
 			PtrToArg<m_elem_type>::encode(v.m_get(index), member);                                                                 \
 		}                                                                                                                          \
-		static void set(Variant *base, int64_t index, const Variant *value, bool &valid, bool &oob) {                              \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                              \
 			if (value->get_type() != GetTypeInfo<m_elem_type>::VARIANT_TYPE) {                                                     \
-				oob = false;                                                                                                       \
-				valid = false;                                                                                                     \
+				*oob = false;                                                                                                      \
+				*valid = false;                                                                                                    \
 			}                                                                                                                      \
 			if (index < 0 || index >= m_max) {                                                                                     \
-				oob = true;                                                                                                        \
-				valid = false;                                                                                                     \
+				*oob = true;                                                                                                       \
+				*valid = false;                                                                                                    \
 				return;                                                                                                            \
 			}                                                                                                                      \
 			VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_set(index, *VariantGetInternalPtr<m_elem_type>::get_ptr(value));  \
-			oob = false;                                                                                                           \
-			valid = true;                                                                                                          \
+			*oob = false;                                                                                                          \
+			*valid = true;                                                                                                         \
 		}                                                                                                                          \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool &oob) {                                 \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                                 \
 			if (index < 0 || index >= m_max) {                                                                                     \
-				oob = true;                                                                                                        \
+				*oob = true;                                                                                                       \
 				return;                                                                                                            \
 			}                                                                                                                      \
 			VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_set(index, *VariantGetInternalPtr<m_elem_type>::get_ptr(value));  \
-			oob = false;                                                                                                           \
+			*oob = false;                                                                                                          \
 		}                                                                                                                          \
 		static void ptr_set(void *base, int64_t index, const void *member) {                                                       \
 			/* avoid ptrconvert for performance*/                                                                                  \
@@ -872,17 +872,17 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 
 #define INDEXED_SETGET_STRUCT_VARIANT(m_base_type)                                                    \
 	struct VariantIndexedSetGet_##m_base_type {                                                       \
-		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {              \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {              \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                 \
 			if (index < 0) {                                                                          \
 				index += size;                                                                        \
 			}                                                                                         \
 			if (index < 0 || index >= size) {                                                         \
-				oob = true;                                                                           \
+				*oob = true;                                                                          \
 				return;                                                                               \
 			}                                                                                         \
 			*value = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];                     \
-			oob = false;                                                                              \
+			*oob = false;                                                                             \
 		}                                                                                             \
 		static void ptr_get(const void *base, int64_t index, void *member) {                          \
 			/* avoid ptrconvert for performance*/                                                     \
@@ -892,31 +892,31 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, v.size());                                                                \
 			PtrToArg<Variant>::encode(v[index], member);                                              \
 		}                                                                                             \
-		static void set(Variant *base, int64_t index, const Variant *value, bool &valid, bool &oob) { \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) { \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                 \
 			if (index < 0) {                                                                          \
 				index += size;                                                                        \
 			}                                                                                         \
 			if (index < 0 || index >= size) {                                                         \
-				oob = true;                                                                           \
-				valid = false;                                                                        \
+				*oob = true;                                                                          \
+				*valid = false;                                                                       \
 				return;                                                                               \
 			}                                                                                         \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index] = *value;                     \
-			oob = false;                                                                              \
-			valid = true;                                                                             \
+			*oob = false;                                                                             \
+			*valid = true;                                                                            \
 		}                                                                                             \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool &oob) {    \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {    \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                 \
 			if (index < 0) {                                                                          \
 				index += size;                                                                        \
 			}                                                                                         \
 			if (index < 0 || index >= size) {                                                         \
-				oob = true;                                                                           \
+				*oob = true;                                                                          \
 				return;                                                                               \
 			}                                                                                         \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index] = *value;                     \
-			oob = false;                                                                              \
+			*oob = false;                                                                             \
 		}                                                                                             \
 		static void ptr_set(void *base, int64_t index, const void *member) {                          \
 			/* avoid ptrconvert for performance*/                                                     \
@@ -932,14 +932,14 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 
 #define INDEXED_SETGET_STRUCT_DICT(m_base_type)                                                                                     \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                     \
-		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                            \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                            \
 			const Variant *ptr = VariantGetInternalPtr<m_base_type>::get_ptr(base)->getptr(index);                                  \
 			if (!ptr) {                                                                                                             \
-				oob = true;                                                                                                         \
+				*oob = true;                                                                                                        \
 				return;                                                                                                             \
 			}                                                                                                                       \
 			*value = *ptr;                                                                                                          \
-			oob = false;                                                                                                            \
+			*oob = false;                                                                                                           \
 		}                                                                                                                           \
 		static void ptr_get(const void *base, int64_t index, void *member) {                                                        \
 			/* avoid ptrconvert for performance*/                                                                                   \
@@ -948,14 +948,14 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			NULL_TEST(ptr);                                                                                                         \
 			PtrToArg<Variant>::encode(*ptr, member);                                                                                \
 		}                                                                                                                           \
-		static void set(Variant *base, int64_t index, const Variant *value, bool &valid, bool &oob) {                               \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                               \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index] = *value;                                                   \
-			oob = false;                                                                                                            \
-			valid = true;                                                                                                           \
+			*oob = false;                                                                                                           \
+			*valid = true;                                                                                                          \
 		}                                                                                                                           \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool &oob) {                                  \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                                  \
 			(*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index] = *value;                                                   \
-			oob = false;                                                                                                            \
+			*oob = false;                                                                                                           \
 		}                                                                                                                           \
 		static void ptr_set(void *base, int64_t index, const void *member) {                                                        \
 			m_base_type &v = *reinterpret_cast<m_base_type *>(base);                                                                \
@@ -989,8 +989,8 @@ INDEXED_SETGET_STRUCT_VARIANT(Array)
 INDEXED_SETGET_STRUCT_DICT(Dictionary)
 
 struct VariantIndexedSetterGetterInfo {
-	void (*setter)(Variant *base, int64_t index, const Variant *value, bool &valid, bool &oob);
-	void (*getter)(const Variant *base, int64_t index, Variant *value, bool &oob);
+	void (*setter)(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob);
+	void (*getter)(const Variant *base, int64_t index, Variant *value, bool *oob);
 
 	Variant::ValidatedIndexedSetter validated_setter;
 	Variant::ValidatedIndexedGetter validated_getter;
@@ -1083,7 +1083,7 @@ Variant::PTRIndexedGetter Variant::get_member_ptr_indexed_getter(Variant::Type p
 
 void Variant::set_indexed(int64_t p_index, const Variant &p_value, bool &r_valid, bool &r_oob) {
 	if (likely(variant_indexed_setters_getters[type].valid)) {
-		variant_indexed_setters_getters[type].setter(this, p_index, &p_value, r_valid, r_oob);
+		variant_indexed_setters_getters[type].setter(this, p_index, &p_value, &r_valid, &r_oob);
 	} else {
 		r_valid = false;
 		r_oob = false;
@@ -1092,7 +1092,7 @@ void Variant::set_indexed(int64_t p_index, const Variant &p_value, bool &r_valid
 Variant Variant::get_indexed(int64_t p_index, bool &r_valid, bool &r_oob) const {
 	if (likely(variant_indexed_setters_getters[type].valid)) {
 		Variant ret;
-		variant_indexed_setters_getters[type].getter(this, p_index, &ret, r_oob);
+		variant_indexed_setters_getters[type].getter(this, p_index, &ret, &r_oob);
 		r_valid = !r_oob;
 		return ret;
 	} else {
@@ -1111,14 +1111,14 @@ uint64_t Variant::get_indexed_size() const {
 }
 
 struct VariantKeyedSetGetDictionary {
-	static void get(const Variant *base, const Variant *key, Variant *value, bool &r_valid) {
+	static void get(const Variant *base, const Variant *key, Variant *value, bool *r_valid) {
 		const Variant *ptr = VariantGetInternalPtr<Dictionary>::get_ptr(base)->getptr(*key);
 		if (!ptr) {
-			r_valid = false;
+			*r_valid = false;
 			return;
 		}
 		*value = *ptr;
-		r_valid = true;
+		*r_valid = true;
 	}
 	static void ptr_get(const void *base, const void *key, void *value) {
 		/* avoid ptrconvert for performance*/
@@ -1127,17 +1127,17 @@ struct VariantKeyedSetGetDictionary {
 		NULL_TEST(ptr);
 		PtrToArg<Variant>::encode(*ptr, value);
 	}
-	static void set(Variant *base, const Variant *key, const Variant *value, bool &r_valid) {
+	static void set(Variant *base, const Variant *key, const Variant *value, bool *r_valid) {
 		(*VariantGetInternalPtr<Dictionary>::get_ptr(base))[*key] = *value;
-		r_valid = true;
+		*r_valid = true;
 	}
 	static void ptr_set(void *base, const void *key, const void *value) {
 		Dictionary &v = *reinterpret_cast<Dictionary *>(base);
 		v[PtrToArg<Variant>::convert(key)] = PtrToArg<Variant>::convert(value);
 	}
 
-	static bool has(const Variant *base, const Variant *key, bool &r_valid) {
-		r_valid = true;
+	static bool has(const Variant *base, const Variant *key, bool *r_valid) {
+		*r_valid = true;
 		return VariantGetInternalPtr<Dictionary>::get_ptr(base)->has(*key);
 	}
 	static bool ptr_has(const void *base, const void *key) {
@@ -1148,15 +1148,15 @@ struct VariantKeyedSetGetDictionary {
 };
 
 struct VariantKeyedSetGetObject {
-	static void get(const Variant *base, const Variant *key, Variant *value, bool &r_valid) {
+	static void get(const Variant *base, const Variant *key, Variant *value, bool *r_valid) {
 		Object *obj = base->get_validated_object();
 
 		if (!obj) {
-			r_valid = false;
+			*r_valid = false;
 			*value = Variant();
 			return;
 		}
-		*value = obj->getvar(*key, &r_valid);
+		*value = obj->getvar(*key, r_valid);
 	}
 	static void ptr_get(const void *base, const void *key, void *value) {
 		const Object *obj = PtrToArg<Object *>::convert(base);
@@ -1164,14 +1164,14 @@ struct VariantKeyedSetGetObject {
 		Variant v = obj->getvar(PtrToArg<Variant>::convert(key));
 		PtrToArg<Variant>::encode(v, value);
 	}
-	static void set(Variant *base, const Variant *key, const Variant *value, bool &r_valid) {
+	static void set(Variant *base, const Variant *key, const Variant *value, bool *r_valid) {
 		Object *obj = base->get_validated_object();
 
 		if (!obj) {
-			r_valid = false;
+			*r_valid = false;
 			return;
 		}
-		obj->setvar(*key, *value, &r_valid);
+		obj->setvar(*key, *value, r_valid);
 	}
 	static void ptr_set(void *base, const void *key, const void *value) {
 		Object *obj = PtrToArg<Object *>::convert(base);
@@ -1179,13 +1179,13 @@ struct VariantKeyedSetGetObject {
 		obj->setvar(PtrToArg<Variant>::convert(key), PtrToArg<Variant>::convert(value));
 	}
 
-	static bool has(const Variant *base, const Variant *key, bool &r_valid) {
+	static bool has(const Variant *base, const Variant *key, bool *r_valid) {
 		Object *obj = base->get_validated_object();
 		if (obj != nullptr) {
-			r_valid = false;
+			*r_valid = false;
 			return false;
 		}
-		r_valid = true;
+		*r_valid = true;
 		bool exists;
 		obj->getvar(*key, &exists);
 		return exists;
@@ -1198,14 +1198,6 @@ struct VariantKeyedSetGetObject {
 		return valid;
 	}
 };
-
-/*typedef void (*ValidatedKeyedSetter)(Variant *base, const Variant *key, const Variant *value);
-typedef void (*ValidatedKeyedGetter)(const Variant *base, const Variant *key, Variant *value, bool &valid);
-typedef bool (*ValidatedKeyedChecker)(const Variant *base, const Variant *key);
-
-typedef void (*PTRKeyedSetter)(void *base, const void *key, const void *value);
-typedef void (*PTRKeyedGetter)(const void *base, const void *key, void *value);
-typedef bool (*PTRKeyedChecker)(const void *base, const void *key);*/
 
 struct VariantKeyedSetterGetterInfo {
 	Variant::ValidatedKeyedSetter validated_setter;
@@ -1274,7 +1266,7 @@ Variant::PTRKeyedChecker Variant::get_member_ptr_keyed_checker(Variant::Type p_t
 
 void Variant::set_keyed(const Variant &p_key, const Variant &p_value, bool &r_valid) {
 	if (likely(variant_keyed_setters_getters[type].valid)) {
-		variant_keyed_setters_getters[type].validated_setter(this, &p_key, &p_value, r_valid);
+		variant_keyed_setters_getters[type].validated_setter(this, &p_key, &p_value, &r_valid);
 	} else {
 		r_valid = false;
 	}
@@ -1282,7 +1274,7 @@ void Variant::set_keyed(const Variant &p_key, const Variant &p_value, bool &r_va
 Variant Variant::get_keyed(const Variant &p_key, bool &r_valid) const {
 	if (likely(variant_keyed_setters_getters[type].valid)) {
 		Variant ret;
-		variant_keyed_setters_getters[type].validated_getter(this, &p_key, &ret, r_valid);
+		variant_keyed_setters_getters[type].validated_getter(this, &p_key, &ret, &r_valid);
 		return ret;
 	} else {
 		r_valid = false;
@@ -1291,7 +1283,7 @@ Variant Variant::get_keyed(const Variant &p_key, bool &r_valid) const {
 }
 bool Variant::has_key(const Variant &p_key, bool &r_valid) const {
 	if (likely(variant_keyed_setters_getters[type].valid)) {
-		return variant_keyed_setters_getters[type].validated_checker(this, &p_key, r_valid);
+		return variant_keyed_setters_getters[type].validated_checker(this, &p_key, &r_valid);
 	} else {
 		r_valid = false;
 		return false;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -738,7 +738,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				const Variant::ValidatedKeyedSetter setter = _keyed_setters_ptr[index_setter];
 
 				bool valid;
-				setter(dst, index, value, valid);
+				setter(dst, index, value, &valid);
 
 #ifdef DEBUG_ENABLED
 				if (!valid) {
@@ -770,7 +770,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				int64_t int_index = *VariantInternal::get_int(index);
 
 				bool oob;
-				setter(dst, int_index, value, oob);
+				setter(dst, int_index, value, &oob);
 
 #ifdef DEBUG_ENABLED
 				if (oob) {
@@ -835,9 +835,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				// Allow better error message in cases where src and dst are the same stack position.
 				Variant ret;
-				getter(src, key, &ret, valid);
+				getter(src, key, &ret, &valid);
 #else
-				getter(src, key, dst, valid);
+				getter(src, key, dst, &valid);
 #endif
 #ifdef DEBUG_ENABLED
 				if (!valid) {
@@ -870,7 +870,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				int64_t int_index = *VariantInternal::get_int(index);
 
 				bool oob;
-				getter(src, int_index, dst, oob);
+				getter(src, int_index, dst, &oob);
 
 #ifdef DEBUG_ENABLED
 				if (oob) {
@@ -1292,7 +1292,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				GET_INSTRUCTION_ARG(dst, argc);
 
-				constructor(*dst, (const Variant **)argptrs);
+				constructor(dst, (const Variant **)argptrs);
 
 				ip += 3;
 			}


### PR DESCRIPTION
Instead of references. This is needed because those function pointers are used in GDNative which needs to work with plain C, which doesn't support passing parameters by reference.

Also fix a logic issue in the `has()` function to check available keys in objects.
