### PR TITLE
Fix tooltip position in main embedded window

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1580,7 +1580,7 @@ void Viewport::_gui_show_tooltip() {
 	Point2 tooltip_offset = ProjectSettings::get_singleton()->get("display/mouse_cursor/tooltip_position_offset");
 	Rect2 r(gui.tooltip_pos + tooltip_offset, gui.tooltip_popup->get_contents_minimum_size());
 
-	Rect2i vr = gui.tooltip_popup->get_parent_visible_window()->get_usable_parent_rect();
+	Rect2i vr = gui.tooltip_popup->get_usable_parent_rect();
 
 	if (r.size.x + r.position.x > vr.size.x + vr.position.x) {
 		r.position.x = vr.position.x + vr.size.x - r.size.x;


### PR DESCRIPTION
If the project is to use embedded windows, tooltips will not try to remain inside the main one (at least while in the editor), appearing cutoff:
![Screenshot_20201210_174532](https://user-images.githubusercontent.com/30739239/101827816-aa7d4880-3b28-11eb-994e-3e9d0ace3562.png)

This PR fixes that:
![Screenshot_20201210_173619](https://user-images.githubusercontent.com/30739239/101826825-6f2e4a00-3b27-11eb-9a02-267b2f11cd42.png)