### PR TITLE
Fix bug in normal map decompression

### DIFF
--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -455,7 +455,7 @@ void main() {
 
 	if (use_default_normal) {
 		normal.xy = texture2D(normal_texture, uv).xy * 2.0 - 1.0;
-		normal.z = sqrt(1.0 - dot(normal.xy, normal.xy));
+		normal.z = sqrt(max(0.0, 1.0 - dot(normal.xy, normal.xy)));
 		normal_used = true;
 	} else {
 		normal = vec3(0.0, 0.0, 1.0);

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -549,7 +549,7 @@ void main() {
 
 	if (use_default_normal) {
 		normal.xy = textureLod(normal_texture, uv, 0.0).xy * 2.0 - 1.0;
-		normal.z = sqrt(1.0 - dot(normal.xy, normal.xy));
+		normal.z = sqrt(max(0.0, 1.0 - dot(normal.xy, normal.xy)));
 		normal_used = true;
 	} else {
 		normal = vec3(0.0, 0.0, 1.0);


### PR DESCRIPTION
Not clamping the range here leads to dithering artifacts.

Fixes #43309

This seemed obviously wrong in the canvas shader which was leading to artifacts, see the full discussion in #44285. Although the latter issue shows a problem in the sprite 3d, my very quick look suggested the scene shaders were not suffering from the same flaw.

There may be another fix that can be applied for the scene shaders. I'm just doing this as a separate PR as I have to rush off.

## Notes
* The current version in the canvas shader is incorrect and this fixes that bug
* There is still some dither, I'm not clear as to whether this is a cost of compression, or there is something else we could do to improve this
* If the dither is a cost of compression, we should investigate having uncompressed normals option. Especially as this may be cheaper on mobile anyway.

## Example before / after
![Screenshot from 2020-12-11 09-34-56](https://user-images.githubusercontent.com/21999379/101893100-2c5a8980-3b9c-11eb-9ee7-7085d7d50867.png)
![Screenshot from 2020-12-11 09-51-36](https://user-images.githubusercontent.com/21999379/101893108-2f557a00-3b9c-11eb-9318-0703d0bddd49.png)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
