### PR TITLE
ProximityGroup: Fix access modifiers, rename private methods for clarity

### DIFF
--- a/doc/classes/ProximityGroup3D.xml
+++ b/doc/classes/ProximityGroup3D.xml
@@ -12,7 +12,7 @@
 		<method name="broadcast">
 			<return type="void">
 			</return>
-			<argument index="0" name="name" type="String">
+			<argument index="0" name="method" type="String">
 			</argument>
 			<argument index="1" name="parameters" type="Variant">
 			</argument>
@@ -30,7 +30,7 @@
 	</members>
 	<signals>
 		<signal name="broadcast">
-			<argument index="0" name="group_name" type="String">
+			<argument index="0" name="method" type="String">
 			</argument>
 			<argument index="1" name="parameters" type="Array">
 			</argument>

--- a/scene/3d/proximity_group_3d.cpp
+++ b/scene/3d/proximity_group_3d.cpp
@@ -32,7 +32,7 @@
 
 #include "core/math/math_funcs.h"
 
-void ProximityGroup3D::clear_groups() {
+void ProximityGroup3D::_clear_groups() {
 	Map<StringName, uint32_t>::Element *E;
 
 	{
@@ -43,21 +43,21 @@ void ProximityGroup3D::clear_groups() {
 		while (E && num < size) {
 			if (E->get() != group_version) {
 				remove_list[num++] = E->key();
-			};
+			}
 
 			E = E->next();
-		};
+		}
 		for (int i = 0; i < num; i++) {
 			groups.erase(remove_list[i]);
-		};
-	};
+		}
+	}
 
 	if (E) {
-		clear_groups(); // call until we go through the whole list
-	};
-};
+		_clear_groups(); // call until we go through the whole list
+	}
+}
 
-void ProximityGroup3D::update_groups() {
+void ProximityGroup3D::_update_groups() {
 	if (grid_radius == Vector3(0, 0, 0)) {
 		return;
 	}
@@ -68,20 +68,20 @@ void ProximityGroup3D::update_groups() {
 	Vector3 vcell = pos / cell_size;
 	int cell[3] = { Math::fast_ftoi(vcell.x), Math::fast_ftoi(vcell.y), Math::fast_ftoi(vcell.z) };
 
-	add_groups(cell, group_name, 0);
+	_add_groups(cell, group_name, 0);
 
-	clear_groups();
-};
+	_clear_groups();
+}
 
-void ProximityGroup3D::add_groups(int *p_cell, String p_base, int p_depth) {
+void ProximityGroup3D::_add_groups(int *p_cell, String p_base, int p_depth) {
 	p_base = p_base + "|";
 	if (grid_radius[p_depth] == 0) {
 		if (p_depth == 2) {
 			_new_group(p_base);
 		} else {
-			add_groups(p_cell, p_base, p_depth + 1);
-		};
-	};
+			_add_groups(p_cell, p_base, p_depth + 1);
+		}
+	}
 
 	int start = p_cell[p_depth] - grid_radius[p_depth];
 	int end = p_cell[p_depth] + grid_radius[p_depth];
@@ -91,72 +91,72 @@ void ProximityGroup3D::add_groups(int *p_cell, String p_base, int p_depth) {
 		if (p_depth == 2) {
 			_new_group(gname);
 		} else {
-			add_groups(p_cell, gname, p_depth + 1);
-		};
-	};
-};
+			_add_groups(p_cell, gname, p_depth + 1);
+		}
+	}
+}
 
 void ProximityGroup3D::_new_group(StringName p_name) {
 	const Map<StringName, uint32_t>::Element *E = groups.find(p_name);
 	if (!E) {
 		add_to_group(p_name);
-	};
+	}
 
 	groups[p_name] = group_version;
-};
+}
 
 void ProximityGroup3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_EXIT_TREE:
 			++group_version;
-			clear_groups();
+			_clear_groups();
 			break;
 		case NOTIFICATION_TRANSFORM_CHANGED:
-			update_groups();
+			_update_groups();
 			break;
-	};
-};
+	}
+}
 
-void ProximityGroup3D::broadcast(String p_name, Variant p_params) {
+void ProximityGroup3D::broadcast(String p_method, Variant p_parameters) {
 	Map<StringName, uint32_t>::Element *E;
 	E = groups.front();
 	while (E) {
-		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFAULT, E->key(), "_proximity_group_broadcast", p_name, p_params);
+		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFAULT, E->key(), "_proximity_group_broadcast", p_method, p_parameters);
 		E = E->next();
-	};
-};
+	}
+}
 
-void ProximityGroup3D::_proximity_group_broadcast(String p_name, Variant p_params) {
+void ProximityGroup3D::_proximity_group_broadcast(String p_method, Variant p_parameters) {
 	if (dispatch_mode == MODE_PROXY) {
-		get_parent()->call(p_name, p_params);
+		get_parent()->call(p_method, p_parameters);
 	} else {
-		emit_signal("broadcast", p_name, p_params);
-	};
-};
+		emit_signal("broadcast", p_method, p_parameters);
+	}
+}
 
 void ProximityGroup3D::set_group_name(const String &p_group_name) {
 	group_name = p_group_name;
-};
+}
 
 String ProximityGroup3D::get_group_name() const {
 	return group_name;
-};
+}
 
 void ProximityGroup3D::set_dispatch_mode(DispatchMode p_mode) {
 	dispatch_mode = p_mode;
-};
+}
 
 ProximityGroup3D::DispatchMode ProximityGroup3D::get_dispatch_mode() const {
 	return dispatch_mode;
-};
+}
 
 void ProximityGroup3D::set_grid_radius(const Vector3 &p_radius) {
 	grid_radius = p_radius;
-};
+}
 
 Vector3 ProximityGroup3D::get_grid_radius() const {
 	return grid_radius;
-};
+}
 
 void ProximityGroup3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_group_name", "name"), &ProximityGroup3D::set_group_name);
@@ -165,19 +165,21 @@ void ProximityGroup3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_dispatch_mode"), &ProximityGroup3D::get_dispatch_mode);
 	ClassDB::bind_method(D_METHOD("set_grid_radius", "radius"), &ProximityGroup3D::set_grid_radius);
 	ClassDB::bind_method(D_METHOD("get_grid_radius"), &ProximityGroup3D::get_grid_radius);
-	ClassDB::bind_method(D_METHOD("broadcast", "name", "parameters"), &ProximityGroup3D::broadcast);
-	ClassDB::bind_method(D_METHOD("_proximity_group_broadcast", "name", "params"), &ProximityGroup3D::_proximity_group_broadcast);
+
+	ClassDB::bind_method(D_METHOD("broadcast", "method", "parameters"), &ProximityGroup3D::broadcast);
+
+	ClassDB::bind_method(D_METHOD("_proximity_group_broadcast", "method", "parameters"), &ProximityGroup3D::_proximity_group_broadcast);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "group_name"), "set_group_name", "get_group_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "dispatch_mode", PROPERTY_HINT_ENUM, "Proxy,Signal"), "set_dispatch_mode", "get_dispatch_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "grid_radius"), "set_grid_radius", "get_grid_radius");
 
-	ADD_SIGNAL(MethodInfo("broadcast", PropertyInfo(Variant::STRING, "group_name"), PropertyInfo(Variant::ARRAY, "parameters")));
+	ADD_SIGNAL(MethodInfo("broadcast", PropertyInfo(Variant::STRING, "method"), PropertyInfo(Variant::ARRAY, "parameters")));
 
 	BIND_ENUM_CONSTANT(MODE_PROXY);
 	BIND_ENUM_CONSTANT(MODE_SIGNAL);
-};
+}
 
 ProximityGroup3D::ProximityGroup3D() {
 	set_notify_transform(true);
-};
+}

--- a/scene/3d/proximity_group_3d.h
+++ b/scene/3d/proximity_group_3d.h
@@ -35,7 +35,6 @@
 
 class ProximityGroup3D : public Node3D {
 	GDCLASS(ProximityGroup3D, Node3D);
-	OBJ_CATEGORY("3D");
 
 public:
 	enum DispatchMode {
@@ -43,25 +42,25 @@ public:
 		MODE_SIGNAL,
 	};
 
-public:
-	void clear_groups();
-	void update_groups();
-
-	void _notification(int p_what);
-
-	DispatchMode dispatch_mode = MODE_PROXY;
-
+private:
 	Map<StringName, uint32_t> groups;
+
 	String group_name;
+	DispatchMode dispatch_mode = MODE_PROXY;
+	Vector3 grid_radius = Vector3(1, 1, 1);
 
 	float cell_size = 1.0;
-	Vector3 grid_radius = Vector3(1, 1, 1);
 	uint32_t group_version = 0;
 
-	void add_groups(int *p_cell, String p_base, int p_depth);
+	void _clear_groups();
+	void _update_groups();
+	void _add_groups(int *p_cell, String p_base, int p_depth);
 	void _new_group(StringName p_name);
 
-	void _proximity_group_broadcast(String p_name, Variant p_params);
+	void _proximity_group_broadcast(String p_method, Variant p_parameters);
+
+protected:
+	void _notification(int p_what);
 
 	static void _bind_methods();
 
@@ -75,7 +74,7 @@ public:
 	void set_grid_radius(const Vector3 &p_radius);
 	Vector3 get_grid_radius() const;
 
-	void broadcast(String p_name, Variant p_params);
+	void broadcast(String p_method, Variant p_parameters);
 
 	ProximityGroup3D();
 	~ProximityGroup3D() {}
@@ -83,4 +82,4 @@ public:
 
 VARIANT_ENUM_CAST(ProximityGroup3D::DispatchMode);
 
-#endif
+#endif // PROXIMITY_GROUP_H


### PR DESCRIPTION
See #36285 which mistakenly added documentation for the whole C++ API, while
some of it is meant to be and stay private as it's not exposed to scripts.
The access modifiers and method prefix were not used properly.

Cleanup code, and rename wrong `group_name` parameters to `method`, as it's a
method name which is being broadcast.

This is a very old class from pre-open source days, chances are that it was
just forgotten and not meant to be kept as is and undocumented.

---

This is likely a good candidate to be dropped in 4.0 unless someone has an actual use case for this undocumented and far from obvious piece of code. But this should still be cherry-picked for `3.2` and documentation added (#36285, once fixed).