### PR TITLE
Add test suite for `FileAccess`

### DIFF
--- a/tests/data/translations.csv
+++ b/tests/data/translations.csv
@@ -1,0 +1,3 @@
+keys,en,de
+GOOD_MORNING,"Good Morning","Guten Morgen"
+GOOD_EVENING,"Good Evening",""

--- a/tests/test_file_access.h
+++ b/tests/test_file_access.h
@@ -1,0 +1,64 @@
+/*************************************************************************/
+/*  test_file_access.h                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_FILE_ACCESS_H
+#define TEST_FILE_ACCESS_H
+
+#include "core/os/file_access.h"
+
+namespace TestFileAccess {
+
+TEST_CASE("[FileAccess] CSV read") {
+	FileAccess *f = FileAccess::open("tests/data/translations.csv", FileAccess::READ);
+
+	Vector<String> header = f->get_csv_line(); // Default delimiter: ","
+	REQUIRE(header.size() == 3);
+
+	Vector<String> row1 = f->get_csv_line(",");
+	REQUIRE(row1.size() == 3);
+	CHECK(row1[0] == "GOOD_MORNING");
+	CHECK(row1[1] == "Good Morning");
+	CHECK(row1[2] == "Guten Morgen");
+
+	Vector<String> row2 = f->get_csv_line();
+	REQUIRE(row2.size() == 3);
+	CHECK(row2[0] == "GOOD_EVENING");
+	CHECK(row2[1] == "Good Evening");
+	CHECK(row2[2] == ""); // Use case: not yet translated!
+
+	// https://github.com/godotengine/godot/issues/44269
+	CHECK_MESSAGE(row2[2] != "\"", "Should not parse empty string as a single double quote.");
+
+	f->close();
+	memdelete(f);
+}
+} // namespace TestFileAccess
+
+#endif // TEST_FILE_ACCESS_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -42,6 +42,7 @@
 #include "test_crypto.h"
 #include "test_curve.h"
 #include "test_expression.h"
+#include "test_file_access.h"
 #include "test_gradient.h"
 #include "test_gui.h"
 #include "test_json.h"


### PR DESCRIPTION
Currently covers #44269.

Adds CSV data file for testing purposes. `FileAccessMemory` could be used instead, but I don't see a reason for introducing additional complexity to the test case.