### PR TITLE
Move initialization of some classes to headers

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -475,12 +475,3 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "z_index", PROPERTY_HINT_RANGE, itos(RS::CANVAS_ITEM_Z_MIN) + "," + itos(RS::CANVAS_ITEM_Z_MAX) + ",1"), "set_z_index", "get_z_index");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "z_as_relative"), "set_z_as_relative", "is_z_relative");
 }
-
-Node2D::Node2D() {
-	angle = 0;
-	_scale = Vector2(1, 1);
-	skew = 0;
-	_xform_dirty = false;
-	z_index = 0;
-	z_relative = true;
-}

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -37,15 +37,15 @@ class Node2D : public CanvasItem {
 	GDCLASS(Node2D, CanvasItem);
 
 	Point2 pos;
-	float angle;
-	Size2 _scale;
-	float skew;
-	int z_index;
-	bool z_relative;
+	float angle = 0;
+	Size2 _scale = Vector2(1, 1);
+	float skew = 0;
+	int z_index = 0;
+	bool z_relative = true;
 
 	Transform2D _mat;
 
-	bool _xform_dirty;
+	bool _xform_dirty = false;
 
 	void _update_transform();
 
@@ -121,7 +121,7 @@ public:
 
 	Transform2D get_transform() const override;
 
-	Node2D();
+	Node2D() {}
 };
 
 #endif // NODE2D_H

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -387,14 +387,3 @@ void PathFollow2D::set_loop(bool p_loop) {
 bool PathFollow2D::has_loop() const {
 	return loop;
 }
-
-PathFollow2D::PathFollow2D() {
-	offset = 0;
-	h_offset = 0;
-	v_offset = 0;
-	path = nullptr;
-	rotates = true;
-	cubic = true;
-	loop = true;
-	lookahead = 4;
-}

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -63,14 +63,14 @@ class PathFollow2D : public Node2D {
 
 public:
 private:
-	Path2D *path;
-	real_t offset;
-	real_t h_offset;
-	real_t v_offset;
-	real_t lookahead;
-	bool cubic;
-	bool loop;
-	bool rotates;
+	Path2D *path = nullptr;
+	real_t offset = 0;
+	real_t h_offset = 0;
+	real_t v_offset = 0;
+	real_t lookahead = 4;
+	bool cubic = true;
+	bool loop = true;
+	bool rotates = true;
 
 	void _update_transform();
 
@@ -107,7 +107,7 @@ public:
 
 	String get_configuration_warning() const override;
 
-	PathFollow2D();
+	PathFollow2D() {}
 };
 
 #endif // PATH_2D_H

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -784,28 +784,4 @@ void Node3D::_bind_methods() {
 }
 
 Node3D::Node3D() :
-		xform_change(this) {
-	data.dirty = DIRTY_NONE;
-	data.children_lock = 0;
-
-	data.ignore_notification = false;
-	data.top_level = false;
-	data.top_level_active = false;
-	data.scale = Vector3(1, 1, 1);
-	data.viewport = nullptr;
-	data.inside_world = false;
-	data.visible = true;
-	data.disable_scale = false;
-
-#ifdef TOOLS_ENABLED
-	data.gizmo_disabled = false;
-	data.gizmo_dirty = false;
-#endif
-	data.notify_local_transform = false;
-	data.notify_transform = false;
-	data.parent = nullptr;
-	data.C = nullptr;
-}
-
-Node3D::~Node3D() {
-}
+		xform_change(this) {}

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -65,32 +65,32 @@ class Node3D : public Node {
 		mutable Transform global_transform;
 		mutable Transform local_transform;
 		mutable Vector3 rotation;
-		mutable Vector3 scale;
+		mutable Vector3 scale = Vector3(1, 1, 1);
 
-		mutable int dirty;
+		mutable int dirty = DIRTY_NONE;
 
-		Viewport *viewport;
+		Viewport *viewport = nullptr;
 
-		bool top_level_active;
-		bool top_level;
-		bool inside_world;
+		bool top_level_active = false;
+		bool top_level = false;
+		bool inside_world = false;
 
-		int children_lock;
-		Node3D *parent;
+		int children_lock = 0;
+		Node3D *parent = nullptr;
 		List<Node3D *> children;
-		List<Node3D *>::Element *C;
+		List<Node3D *>::Element *C = nullptr;
 
-		bool ignore_notification;
-		bool notify_local_transform;
-		bool notify_transform;
+		bool ignore_notification = false;
+		bool notify_local_transform = false;
+		bool notify_transform = false;
 
-		bool visible;
-		bool disable_scale;
+		bool visible = true;
+		bool disable_scale = false;
 
 #ifdef TOOLS_ENABLED
 		Ref<Node3DGizmo> gizmo;
-		bool gizmo_disabled;
-		bool gizmo_dirty;
+		bool gizmo_disabled = false;
+		bool gizmo_dirty = false;
 #endif
 
 	} data;
@@ -197,7 +197,6 @@ public:
 	void force_update_transform();
 
 	Node3D();
-	~Node3D();
 };
 
 #endif // NODE_3D_H

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -385,14 +385,3 @@ void PathFollow3D::set_loop(bool p_loop) {
 bool PathFollow3D::has_loop() const {
 	return loop;
 }
-
-PathFollow3D::PathFollow3D() {
-	offset = 0;
-	delta_offset = 0;
-	h_offset = 0;
-	v_offset = 0;
-	path = nullptr;
-	rotation_mode = ROTATION_XYZ;
-	cubic = true;
-	loop = true;
-}

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -65,14 +65,14 @@ public:
 	};
 
 private:
-	Path3D *path;
-	real_t delta_offset; // change in offset since last _update_transform
-	real_t offset;
-	real_t h_offset;
-	real_t v_offset;
-	bool cubic;
-	bool loop;
-	RotationMode rotation_mode;
+	Path3D *path = nullptr;
+	real_t delta_offset = 0; // Change in offset since last _update_transform.
+	real_t offset = 0;
+	real_t h_offset = 0;
+	real_t v_offset = 0;
+	bool cubic = true;
+	bool loop = true;
+	RotationMode rotation_mode = ROTATION_XYZ;
 
 	void _update_transform(bool p_update_xyz_rot = true);
 
@@ -106,7 +106,7 @@ public:
 
 	String get_configuration_warning() const override;
 
-	PathFollow3D();
+	PathFollow3D() {}
 };
 
 VARIANT_ENUM_CAST(PathFollow3D::RotationMode);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3043,38 +3043,3 @@ void Control::_bind_methods() {
 
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "has_point", PropertyInfo(Variant::VECTOR2, "point")));
 }
-
-Control::Control() {
-	data.parent = nullptr;
-
-	data.mouse_filter = MOUSE_FILTER_STOP;
-
-	data.RI = nullptr;
-	data.theme_owner = nullptr;
-	data.theme_owner_window = nullptr;
-	data.default_cursor = CURSOR_ARROW;
-	data.layout_dir = LAYOUT_DIRECTION_INHERITED;
-	data.h_size_flags = SIZE_FILL;
-	data.v_size_flags = SIZE_FILL;
-	data.expand = 1;
-	data.rotation = 0;
-	data.parent_canvas_item = nullptr;
-	data.scale = Vector2(1, 1);
-
-	data.block_minimum_size_adjust = false;
-	data.disable_visibility_clip = false;
-	data.h_grow = GROW_DIRECTION_END;
-	data.v_grow = GROW_DIRECTION_END;
-	data.minimum_size_valid = false;
-	data.updating_last_minimum_size = false;
-
-	data.clip_contents = false;
-	for (int i = 0; i < 4; i++) {
-		data.anchor[i] = ANCHOR_BEGIN;
-		data.margin[i] = 0;
-	}
-	data.focus_mode = FOCUS_NONE;
-}
-
-Control::~Control() {
-}

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -166,46 +166,46 @@ private:
 		Point2 pos_cache;
 		Size2 size_cache;
 		Size2 minimum_size_cache;
-		bool minimum_size_valid;
+		bool minimum_size_valid = false;
 
 		Size2 last_minimum_size;
-		bool updating_last_minimum_size;
+		bool updating_last_minimum_size = false;
 
-		float margin[4];
-		float anchor[4];
-		FocusMode focus_mode;
-		GrowDirection h_grow;
-		GrowDirection v_grow;
+		float margin[4] = { 0.0, 0.0, 0.0, 0.0 };
+		float anchor[4] = { ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN };
+		FocusMode focus_mode = FOCUS_NONE;
+		GrowDirection h_grow = GROW_DIRECTION_END;
+		GrowDirection v_grow = GROW_DIRECTION_END;
 
-		LayoutDirection layout_dir;
+		LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
 
-		float rotation;
-		Vector2 scale;
+		float rotation = 0;
+		Vector2 scale = Vector2(1, 1);
 		Vector2 pivot_offset;
 
-		int h_size_flags;
-		int v_size_flags;
-		float expand;
+		int h_size_flags = SIZE_FILL;
+		int v_size_flags = SIZE_FILL;
+		float expand = 1;
 		Point2 custom_minimum_size;
 
-		MouseFilter mouse_filter;
+		MouseFilter mouse_filter = MOUSE_FILTER_STOP;
 
-		bool clip_contents;
+		bool clip_contents = false;
 
-		bool block_minimum_size_adjust;
-		bool disable_visibility_clip;
+		bool block_minimum_size_adjust = false;
+		bool disable_visibility_clip = false;
 
-		Control *parent;
+		Control *parent = nullptr;
 		ObjectID drag_owner;
 		Ref<Theme> theme;
-		Control *theme_owner;
-		Window *theme_owner_window;
+		Control *theme_owner = nullptr;
+		Window *theme_owner_window = nullptr;
 		String tooltip;
-		CursorShape default_cursor;
+		CursorShape default_cursor = CURSOR_ARROW;
 
-		List<Control *>::Element *RI;
+		List<Control *>::Element *RI = nullptr;
 
-		CanvasItem *parent_canvas_item;
+		CanvasItem *parent_canvas_item = nullptr;
 
 		NodePath focus_neighbour[4];
 		NodePath focus_next;
@@ -518,8 +518,7 @@ public:
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 	virtual String get_configuration_warning() const override;
 
-	Control();
-	~Control();
+	Control() {}
 };
 
 VARIANT_ENUM_CAST(Control::FocusMode);

--- a/scene/gui/panel.cpp
+++ b/scene/gui/panel.cpp
@@ -63,6 +63,3 @@ Panel::Panel() {
 	// Has visible stylebox, so stop by default.
 	set_mouse_filter(MOUSE_FILTER_STOP);
 }
-
-Panel::~Panel() {
-}

--- a/scene/gui/panel.h
+++ b/scene/gui/panel.h
@@ -54,7 +54,6 @@ public:
 	Mode get_mode() const;
 
 	Panel();
-	~Panel();
 };
 
 VARIANT_ENUM_CAST(Panel::Mode)

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -292,15 +292,10 @@ void CanvasItemMaterial::_bind_methods() {
 
 CanvasItemMaterial::CanvasItemMaterial() :
 		element(this) {
-	blend_mode = BLEND_MODE_MIX;
-	light_mode = LIGHT_MODE_NORMAL;
-	particles_animation = false;
-
 	set_particles_anim_h_frames(1);
 	set_particles_anim_v_frames(1);
 	set_particles_anim_loop(false);
 
-	current_key.key = 0;
 	current_key.invalid_key = 1;
 	_queue_shader_change();
 }
@@ -1411,30 +1406,7 @@ CanvasItem::TextureRepeat CanvasItem::get_texture_repeat() const {
 
 CanvasItem::CanvasItem() :
 		xform_change(this) {
-	window = nullptr;
 	canvas_item = RenderingServer::get_singleton()->canvas_item_create();
-	visible = true;
-	pending_update = false;
-	modulate = Color(1, 1, 1, 1);
-	self_modulate = Color(1, 1, 1, 1);
-	top_level = false;
-	first_draw = false;
-	drawing = false;
-	behind = false;
-	clip_children = false;
-	block_transform_notify = false;
-	canvas_layer = nullptr;
-	use_parent_material = false;
-	global_invalid = true;
-	notify_local_transform = false;
-	notify_transform = false;
-	light_mask = 1;
-	texture_repeat = TEXTURE_REPEAT_PARENT_NODE;
-	texture_filter = TEXTURE_FILTER_PARENT_NODE;
-	texture_filter_cache = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
-	texture_repeat_cache = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
-
-	C = nullptr;
 }
 
 CanvasItem::~CanvasItem() {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -73,7 +73,7 @@ private:
 			uint32_t invalid_key : 1;
 		};
 
-		uint32_t key;
+		uint32_t key = 0;
 
 		bool operator<(const MaterialKey &p_key) const {
 			return key < p_key.key;
@@ -114,10 +114,11 @@ private:
 	_FORCE_INLINE_ void _queue_shader_change();
 	_FORCE_INLINE_ bool _is_shader_dirty() const;
 
-	BlendMode blend_mode;
-	LightMode light_mode;
-	bool particles_animation;
+	BlendMode blend_mode = BLEND_MODE_MIX;
+	LightMode light_mode = LIGHT_MODE_NORMAL;
+	bool particles_animation = false;
 
+	// Initialized in the constructor.
 	int particles_anim_h_frames;
 	int particles_anim_v_frames;
 	bool particles_anim_loop;
@@ -188,39 +189,38 @@ private:
 	RID canvas_item;
 	String group;
 
-	CanvasLayer *canvas_layer;
+	CanvasLayer *canvas_layer = nullptr;
 
-	Color modulate;
-	Color self_modulate;
+	Color modulate = Color(1, 1, 1, 1);
+	Color self_modulate = Color(1, 1, 1, 1);
 
 	List<CanvasItem *> children_items;
-	List<CanvasItem *>::Element *C;
+	List<CanvasItem *>::Element *C = nullptr;
 
-	int light_mask;
+	int light_mask = 1;
 
-	Window *window;
-	bool first_draw;
-	bool visible;
-	bool clip_children;
-	bool pending_update;
-	bool top_level;
-	bool drawing;
-	bool block_transform_notify;
-	bool behind;
-	bool use_parent_material;
-	bool notify_local_transform;
-	bool notify_transform;
+	Window *window = nullptr;
+	bool first_draw = false;
+	bool visible = true;
+	bool clip_children = false;
+	bool pending_update = false;
+	bool top_level = false;
+	bool drawing = false;
+	bool block_transform_notify = false;
+	bool behind = false;
+	bool use_parent_material = false;
+	bool notify_local_transform = false;
+	bool notify_transform = false;
 
-	RS::CanvasItemTextureFilter texture_filter_cache;
-	RS::CanvasItemTextureRepeat texture_repeat_cache;
-
-	TextureFilter texture_filter;
-	TextureRepeat texture_repeat;
+	RS::CanvasItemTextureFilter texture_filter_cache = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
+	RS::CanvasItemTextureRepeat texture_repeat_cache = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
+	TextureFilter texture_filter = TEXTURE_FILTER_PARENT_NODE;
+	TextureRepeat texture_repeat = TEXTURE_REPEAT_PARENT_NODE;
 
 	Ref<Material> material;
 
 	mutable Transform2D global_transform;
-	mutable bool global_invalid;
+	mutable bool global_invalid = true;
 
 	void _top_level_raise_self();
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2925,35 +2925,6 @@ String Node::_get_name_num_separator() {
 }
 
 Node::Node() {
-	data.pos = -1;
-	data.depth = -1;
-	data.blocked = 0;
-	data.parent = nullptr;
-	data.tree = nullptr;
-	data.physics_process = false;
-	data.idle_process = false;
-	data.process_priority = 0;
-	data.physics_process_internal = false;
-	data.idle_process_internal = false;
-	data.inside_tree = false;
-	data.ready_notified = false;
-
-	data.owner = nullptr;
-	data.OW = nullptr;
-	data.input = false;
-	data.unhandled_input = false;
-	data.unhandled_key_input = false;
-	data.pause_mode = PAUSE_MODE_INHERIT;
-	data.pause_owner = nullptr;
-	data.network_master = 1; //server by default
-	data.path_cache = nullptr;
-	data.parent_owned = false;
-	data.in_constructor = true;
-	data.viewport = nullptr;
-	data.use_placeholder = false;
-	data.display_folded = false;
-	data.ready_first = true;
-
 	orphan_node_count++;
 }
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -90,54 +90,54 @@ private:
 
 		HashMap<NodePath, int> editable_instances;
 
-		Node *parent;
-		Node *owner;
-		Vector<Node *> children; // list of children
-		int pos;
-		int depth;
-		int blocked; // safeguard that throws an error when attempting to modify the tree in a harmful way while being traversed.
+		Node *parent = nullptr;
+		Node *owner = nullptr;
+		Vector<Node *> children;
+		int pos = -1;
+		int depth = -1;
+		int blocked = 0; // Safeguard that throws an error when attempting to modify the tree in a harmful way while being traversed.
 		StringName name;
-		SceneTree *tree;
-		bool inside_tree;
-		bool ready_notified; //this is a small hack, so if a node is added during _ready() to the tree, it correctly gets the _ready() notification
-		bool ready_first;
+		SceneTree *tree = nullptr;
+		bool inside_tree = false;
+		bool ready_notified = false; // This is a small hack, so if a node is added during _ready() to the tree, it correctly gets the _ready() notification.
+		bool ready_first = true;
 #ifdef TOOLS_ENABLED
-		NodePath import_path; //path used when imported, used by scene editors to keep tracking
+		NodePath import_path; // Path used when imported, used by scene editors to keep tracking.
 #endif
 
-		Viewport *viewport;
+		Viewport *viewport = nullptr;
 
 		Map<StringName, GroupData> grouped;
-		List<Node *>::Element *OW; // owned element
+		List<Node *>::Element *OW = nullptr; // Owned element.
 		List<Node *> owned;
 
-		PauseMode pause_mode;
-		Node *pause_owner;
+		PauseMode pause_mode = PAUSE_MODE_INHERIT;
+		Node *pause_owner = nullptr;
 
-		int network_master;
+		int network_master = 1; // Server by default.
 		Vector<NetData> rpc_methods;
 		Vector<NetData> rpc_properties;
 
-		// variables used to properly sort the node when processing, ignored otherwise
-		//should move all the stuff below to bits
-		bool physics_process;
-		bool idle_process;
-		int process_priority;
+		// Variables used to properly sort the node when processing, ignored otherwise.
+		// TODO: Should move all the stuff below to bits.
+		bool physics_process = false;
+		bool idle_process = false;
+		int process_priority = 0;
 
-		bool physics_process_internal;
-		bool idle_process_internal;
+		bool physics_process_internal = false;
+		bool idle_process_internal = false;
 
-		bool input;
-		bool unhandled_input;
-		bool unhandled_key_input;
+		bool input = false;
+		bool unhandled_input = false;
+		bool unhandled_key_input = false;
 
-		bool parent_owned;
-		bool in_constructor;
-		bool use_placeholder;
+		bool parent_owned = false;
+		bool in_constructor = true;
+		bool use_placeholder = false;
 
-		bool display_folded;
+		bool display_folded = false;
 
-		mutable NodePath *path_cache;
+		mutable NodePath *path_cache = nullptr;
 
 	} data;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1332,14 +1332,6 @@ SceneTree::SceneTree() {
 	if (singleton == nullptr) {
 		singleton = this;
 	}
-	_quit = false;
-	accept_quit = true;
-	quit_on_go_back = true;
-	initialized = false;
-#ifdef DEBUG_ENABLED
-	debug_collisions_hint = false;
-	debug_navigation_hint = false;
-#endif
 	debug_collisions_color = GLOBAL_DEF("debug/shapes/collision/shape_color", Color(0.0, 0.6, 0.7, 0.5));
 	debug_collision_contact_color = GLOBAL_DEF("debug/shapes/collision/contact_color", Color(1.0, 0.2, 0.1, 0.8));
 	debug_navigation_color = GLOBAL_DEF("debug/shapes/navigation/geometry_color", Color(0.1, 1.0, 0.7, 0.4));
@@ -1347,23 +1339,7 @@ SceneTree::SceneTree() {
 	collision_debug_contacts = GLOBAL_DEF("debug/shapes/collision/max_contacts_displayed", 10000);
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/shapes/collision/max_contacts_displayed", PropertyInfo(Variant::INT, "debug/shapes/collision/max_contacts_displayed", PROPERTY_HINT_RANGE, "0,20000,1")); // No negative
 
-	tree_version = 1;
-	physics_process_time = 1;
-	idle_process_time = 1;
-
-	root = nullptr;
-	pause = false;
-	current_frame = 0;
-	tree_changed_name = "tree_changed";
-	node_added_name = "node_added";
-	node_removed_name = "node_removed";
-	node_renamed_name = "node_renamed";
-	ugc_locked = false;
-	call_lock = 0;
-	root_lock = 0;
-	node_count = 0;
-
-	//create with mainloop
+	// Create with mainloop.
 
 	root = memnew(Window);
 	root->set_name("root");
@@ -1371,8 +1347,7 @@ SceneTree::SceneTree() {
 		root->set_world_3d(Ref<World3D>(memnew(World3D)));
 	}
 
-	// Initialize network state
-	multiplayer_poll = true;
+	// Initialize network state.
 	set_multiplayer(Ref<MultiplayerAPI>(memnew(MultiplayerAPI)));
 
 	//root->set_world_2d( Ref<World2D>( memnew( World2D )));
@@ -1405,8 +1380,8 @@ SceneTree::SceneTree() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/2d_sdf/oversize", PropertyInfo(Variant::INT, "rendering/quality/2d_sdf/oversize", PROPERTY_HINT_ENUM, "100%,120%,150%,200%"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/2d_sdf/scale", PropertyInfo(Variant::INT, "rendering/quality/2d_sdf/scale", PROPERTY_HINT_ENUM, "100%,50%,25%"));
 
-	{ //load default fallback environment
-		//get possible extensions
+	{ // Load default fallback environment.
+		// Get possible extensions.
 		List<String> exts;
 		ResourceLoader::get_recognized_extensions_for_type("Environment", &exts);
 		String ext_hint;
@@ -1416,9 +1391,9 @@ SceneTree::SceneTree() {
 			}
 			ext_hint += "*." + E->get();
 		}
-		//get path
+		// Get path.
 		String env_path = GLOBAL_DEF("rendering/environment/default_environment", "");
-		//setup property
+		// Setup property.
 		ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/default_environment", PropertyInfo(Variant::STRING, "rendering/viewport/default_environment", PROPERTY_HINT_FILE, ext_hint));
 		env_path = env_path.strip_edges();
 		if (env_path != String()) {
@@ -1427,10 +1402,10 @@ SceneTree::SceneTree() {
 				root->get_world_3d()->set_fallback_environment(env);
 			} else {
 				if (Engine::get_singleton()->is_editor_hint()) {
-					//file was erased, clear the field.
+					// File was erased, clear the field.
 					ProjectSettings::get_singleton()->set("rendering/environment/default_environment", "");
 				} else {
-					//file was erased, notify user.
+					// File was erased, notify user.
 					ERR_PRINT(RTR("Default Environment as specified in Project Settings (Rendering -> Environment -> Default Environment) could not be loaded."));
 				}
 			}

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -80,37 +80,36 @@ public:
 private:
 	struct Group {
 		Vector<Node *> nodes;
-		//uint64_t last_tree_version;
 		bool changed;
 		Group() { changed = false; };
 	};
 
-	Window *root;
+	Window *root = nullptr;
 
-	uint64_t tree_version;
-	float physics_process_time;
-	float idle_process_time;
-	bool accept_quit;
-	bool quit_on_go_back;
+	uint64_t tree_version = 1;
+	float physics_process_time = 1.0;
+	float idle_process_time = 1.0;
+	bool accept_quit = true;
+	bool quit_on_go_back = true;
 
 #ifdef DEBUG_ENABLED
-	bool debug_collisions_hint;
-	bool debug_navigation_hint;
+	bool debug_collisions_hint = false;
+	bool debug_navigation_hint = false;
 #endif
-	bool pause;
-	int root_lock;
+	bool pause = false;
+	int root_lock = 0;
 
 	Map<StringName, Group> group_map;
-	bool _quit;
-	bool initialized;
+	bool _quit = false;
+	bool initialized = false;
 
-	StringName tree_changed_name;
-	StringName node_added_name;
-	StringName node_removed_name;
-	StringName node_renamed_name;
+	StringName tree_changed_name = "tree_changed";
+	StringName node_added_name = "node_added";
+	StringName node_removed_name = "node_removed";
+	StringName node_renamed_name = "node_renamed";
 
-	int64_t current_frame;
-	int node_count;
+	int64_t current_frame = 0;
+	int node_count = 0;
 
 #ifdef TOOLS_ENABLED
 	Node *edited_scene_root;
@@ -122,14 +121,14 @@ private:
 		bool operator<(const UGCall &p_with) const { return group == p_with.group ? call < p_with.call : group < p_with.group; }
 	};
 
-	//safety for when a node is deleted while a group is being called
-	int call_lock;
-	Set<Node *> call_skip; //skip erased nodes
+	// Safety for when a node is deleted while a group is being called.
+	int call_lock = 0;
+	Set<Node *> call_skip; // Skip erased nodes.
 
 	List<ObjectID> delete_queue;
 
 	Map<UGCall, Vector<Variant>> unique_group_calls;
-	bool ugc_locked;
+	bool ugc_locked = false;
 	void _flush_ugc();
 
 	_FORCE_INLINE_ void _update_group_order(Group &g, bool p_use_priority = false);
@@ -157,7 +156,7 @@ private:
 	///network///
 
 	Ref<MultiplayerAPI> multiplayer;
-	bool multiplayer_poll;
+	bool multiplayer_poll = true;
 
 	void _network_peer_connected(int p_id);
 	void _network_peer_disconnected(int p_id);
@@ -183,7 +182,7 @@ private:
 	Variant _call_group(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	void _flush_delete_queue();
-	//optimization
+	// Optimization.
 	friend class CanvasItem;
 	friend class Node3D;
 	friend class Viewport;


### PR DESCRIPTION
This PR moves the variable initialization of core classes (plus some random ones) to headers. I also cleaned some comments and removed unused destructors.