### PR TITLE
Display the number of results for global search

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -779,7 +779,19 @@ void FindInFilesPanel::_on_item_edited() {
 }
 
 void FindInFilesPanel::_on_finished() {
-	_status_label->set_text(TTR("Search complete"));
+	String results_text;
+	int result_count = _result_items.size();
+	int file_count = _file_items.size();
+
+	if (result_count == 1 && file_count == 1) {
+		results_text = vformat(TTR("%d match in %d file."), result_count, file_count);
+	} else if (result_count != 1 && file_count == 1) {
+		results_text = vformat(TTR("%d matches in %d file."), result_count, file_count);
+	} else {
+		results_text = vformat(TTR("%d matches in %d files."), result_count, file_count);
+	}
+
+	_status_label->set_text(results_text);
 	update_replace_buttons();
 	set_progress_visible(false);
 	_refresh_button->show();


### PR DESCRIPTION
This replaces the ambiguous "Search complete" phrase with the actual number of results found in files.

![godot windows tools 64_2020-12-11_19-09-44](https://user-images.githubusercontent.com/11782833/101927192-3d7bb880-3be5-11eb-8f7a-7ff564d6d432.png)

This especially helps when doing refactoring and clicking "Refresh" to repeat the search.

*Bugsquad edit: This partially addresses https://github.com/godotengine/godot-proposals/issues/600.*