### PR TITLE
Don't force GLES2 in Project Manager, causes issues on macOS.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -898,13 +898,16 @@ public:
 		rs_button->set_button_group(rasterizer_button_group);
 		rs_button->set_text(TTR("OpenGL ES 3.0"));
 		rs_button->set_meta("driver_name", "GLES3");
-		rs_button->set_pressed(gles3_viable);
-		// If GLES3 can't be used, don't let users shoot themselves in the foot.
-		rs_button->set_disabled(!gles3_viable);
 		rvb->add_child(rs_button);
-		l = memnew(Label);
-		l->set_text(TTR("Not supported by your GPU drivers."));
-		rvb->add_child(l);
+		if (gles3_viable) {
+			rs_button->set_pressed(true);
+		} else {
+			// If GLES3 can't be used, don't let users shoot themselves in the foot.
+			rs_button->set_disabled(true);
+			l = memnew(Label);
+			l->set_text(TTR("Not supported by your GPU drivers."));
+			rvb->add_child(l);
+		}
 		l = memnew(Label);
 		l->set_text(TTR("Higher visual quality\nAll features available\nIncompatible with older hardware\nNot recommended for web games"));
 		rvb->add_child(l);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1030,11 +1030,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF("rendering/quality/driver/driver_name", "GLES3");
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/driver/driver_name", PropertyInfo(Variant::STRING, "rendering/quality/driver/driver_name", PROPERTY_HINT_ENUM, "GLES2,GLES3"));
 	if (video_driver == "") {
-		if (project_manager) {
-			video_driver = "GLES2"; // Force GLES2 for maximum compatibility, unless specified from command line.
-		} else {
-			video_driver = GLOBAL_GET("rendering/quality/driver/driver_name");
-		}
+		video_driver = GLOBAL_GET("rendering/quality/driver/driver_name");
 	}
 
 	GLOBAL_DEF("rendering/quality/driver/fallback_to_gles2", false);


### PR DESCRIPTION
This partially reverts #44041.

Also fix the bogus label about lack of GLES3 support being always shown...
It was meant to be behind a check but I had left it out while testing, and
forgot to put it back.