### PR TITLE
[fbx] Implement ColorIndex for Vertex Colors to ensure they are correct and duplicate vertexes correctly for multiple color attributes.

### DIFF
--- a/modules/fbx/data/fbx_mesh_data.h
+++ b/modules/fbx/data/fbx_mesh_data.h
@@ -108,6 +108,7 @@ private:
 			HashMap<int, Color> &r_color,
 			HashMap<String, MorphVertexData> &r_morphs,
 			HashMap<int, HashMap<int, Vector3> > &r_normals_raw,
+			HashMap<int, HashMap<int, Color> > &r_colors_raw,
 			HashMap<int, HashMap<int, Vector2> > &r_uv_1_raw,
 			HashMap<int, HashMap<int, Vector2> > &r_uv_2_raw);
 

--- a/modules/fbx/fbx_parser/FBXMeshGeometry.cpp
+++ b/modules/fbx/fbx_parser/FBXMeshGeometry.cpp
@@ -211,7 +211,33 @@ MeshGeometry::MeshGeometry(uint64_t id, const ElementPtr element, const std::str
 				} else if (layer_type_name == "LayerElementNormal") {
 					m_normals = resolve_vertex_data_array<Vector3>(layer_scope, MappingInformationType, ReferenceInformationType, "Normals");
 				} else if (layer_type_name == "LayerElementColor") {
-					m_colors = resolve_vertex_data_array<Color>(layer_scope, MappingInformationType, ReferenceInformationType, "Colors");
+					m_colors = resolve_vertex_data_array<Color>(layer_scope, MappingInformationType, ReferenceInformationType, "Colors", "ColorIndex");
+					// NOTE: this is a useful sanity check to ensure you're getting any color data which is not default.
+					//					const Color first_color_check = m_colors.data[0];
+					//					bool colors_are_all_the_same = true;
+					//					size_t i = 1;
+					//					for(i = 1; i < m_colors.data.size(); i++)
+					//					{
+					//						const Color current_color = m_colors.data[i];
+					//						if(current_color.is_equal_approx(first_color_check))
+					//						{
+					//							continue;
+					//						}
+					//						else
+					//						{
+					//							colors_are_all_the_same = false;
+					//							break;
+					//						}
+					//					}
+					//
+					//					if(colors_are_all_the_same)
+					//					{
+					//						print_error("Color serialisation is not working for vertex colors some should be different in the test asset.");
+					//					}
+					//					else
+					//					{
+					//						print_verbose("Color array has unique colors at index: " + itos(i));
+					//					}
 				}
 			}
 		}
@@ -335,12 +361,22 @@ MeshGeometry::MappingData<T> MeshGeometry::resolve_vertex_data_array(
 		const ScopePtr source,
 		const std::string &MappingInformationType,
 		const std::string &ReferenceInformationType,
-		const std::string &dataElementName) {
+		const std::string &dataElementName,
+		const std::string &indexOverride) {
 
 	ERR_FAIL_COND_V_MSG(source == nullptr, MappingData<T>(), "Invalid scope operator preventing memory corruption");
 
 	// UVIndex, MaterialIndex, NormalIndex, etc..
-	std::string indexDataElementName = dataElementName + "Index";
+	std::string indexDataElementName;
+
+	if (indexOverride != "") {
+		// Colors should become ColorIndex
+		indexDataElementName = indexOverride;
+	} else {
+		// Some indexes will exist.
+		indexDataElementName = dataElementName + "Index";
+	}
+
 	// goal: expand everything to be per vertex
 
 	ReferenceType l_ref_type = ReferenceType::direct;

--- a/modules/fbx/fbx_parser/FBXMeshGeometry.h
+++ b/modules/fbx/fbx_parser/FBXMeshGeometry.h
@@ -207,7 +207,8 @@ private:
 			const ScopePtr source,
 			const std::string &MappingInformationType,
 			const std::string &ReferenceInformationType,
-			const std::string &dataElementName);
+			const std::string &dataElementName,
+			const std::string &indexOverride = "");
 };
 
 /*


### PR DESCRIPTION
Fixes vertex color mapping #44297 and also implements ColorIndex with vertex duplication to make sure faces are created correctly.

ColorIndex requires an Override specifier, I have updated any error fields with the same problem to just add their respective override field.
