### PR TITLE
Fix Variant conversion to float instead of double

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1221,7 +1221,7 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 				return (int64_t(*p_args[0]));
 			}
 			case REAL: {
-				return real_t(*p_args[0]);
+				return double(*p_args[0]);
 			}
 			case STRING: {
 				return String(*p_args[0]);


### PR DESCRIPTION
`real_t` is defined as a `float` (or a `double` depending on a flag it seems?) in `core/math/math_defs.h` and `Variant::construct` was thus casting to a float.

Instead of using a double, maybe it is better to fix whatever is causing the flag not to be set?

https://github.com/godotengine/godot/blob/2a4f0bc4d9e81d31777253853850780077672156/core/math/math_defs.h#L109-L113

Closes #44303