### PR TITLE
Check if either are STRING/STRING_NAME in hash_compare

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3157,7 +3157,7 @@ uint32_t Variant::hash() const {
 	return true
 
 bool Variant::hash_compare(const Variant &p_variant) const {
-	if (type != p_variant.type) {
+	if (type != p_variant.type && !((type == STRING && p_variant.type == STRING_NAME) || (type == STRING_NAME && p_variant.type == STRING))) {
 		return false;
 	}
 


### PR DESCRIPTION
From my understanding, STRING_NAME is effectively the same as a regular STRING except it is optimized for lookup speed and they produce the same hashes, so no conversion from/to STRING is necessary when comparing hashes.

Closes #44241