### PR TITLE
Split EditorData class into 5 classes for better single responsibility.

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -80,18 +80,16 @@ void CreateDialog::_fill_type_list() {
 	ClassDB::get_class_list(&complete_type_list);
 	ScriptServer::get_global_class_list(&complete_type_list);
 
-	EditorData &ed = EditorNode::get_editor_data();
-
 	for (List<StringName>::Element *I = complete_type_list.front(); I; I = I->next()) {
 		String type = I->get();
 		if (!_should_hide_type(type)) {
 			type_list.push_back(type);
 
-			if (!ed.get_custom_types().has(type)) {
+			if (!EditorNode::get_editor_custom_types()->get_custom_types().has(type)) {
 				continue;
 			}
 
-			const Vector<EditorData::CustomType> &ct = ed.get_custom_types()[type];
+			const Vector<EditorCustomTypes::CustomType> &ct = EditorNode::get_editor_custom_types()->get_custom_types()[type];
 			for (int i = 0; i < ct.size(); i++) {
 				custom_type_parents[ct[i].name] = type;
 				custom_type_indices[ct[i].name] = i;
@@ -107,7 +105,7 @@ bool CreateDialog::_is_type_preferred(const String &p_type) const {
 		return ClassDB::is_parent_class(p_type, preferred_search_result_type);
 	}
 
-	return EditorNode::get_editor_data().script_class_is_parent(p_type, preferred_search_result_type);
+	return EditorNode::get_editor_custom_types()->script_class_is_parent(p_type, preferred_search_result_type);
 }
 
 bool CreateDialog::_is_class_disabled_by_feature_profile(const StringName &p_class) const {
@@ -144,7 +142,7 @@ bool CreateDialog::_should_hide_type(const String &p_type) const {
 			}
 		}
 	} else {
-		if (!EditorNode::get_editor_data().script_class_is_parent(p_type, base_type)) {
+		if (!EditorNode::get_editor_custom_types()->script_class_is_parent(p_type, base_type)) {
 			return true; // Wrong inheritance.
 		}
 		if (!ScriptServer::is_global_class(p_type)) {
@@ -209,7 +207,7 @@ void CreateDialog::_add_type(const String &p_type, bool p_cpp_type) {
 	if (p_cpp_type) {
 		inherits = ClassDB::get_parent_class(p_type);
 	} else if (ScriptServer::is_global_class(p_type)) {
-		inherits = EditorNode::get_editor_data().script_class_get_base(p_type);
+		inherits = EditorNode::get_editor_custom_types()->script_class_get_base(p_type);
 	} else {
 		inherits = custom_type_parents[p_type];
 	}
@@ -256,7 +254,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 	r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
 
 	if (!p_cpp_type && !script_type) {
-		Ref<Texture2D> icon = EditorNode::get_editor_data().get_custom_types()[custom_type_parents[p_type]][custom_type_indices[p_type]].icon;
+		Ref<Texture2D> icon = EditorNode::get_editor_custom_types()->get_custom_types()[custom_type_parents[p_type]][custom_type_indices[p_type]].icon;
 		if (icon.is_valid()) {
 			r_item->set_icon(0, icon);
 		}
@@ -420,13 +418,13 @@ Variant CreateDialog::instance_selected() {
 	if (md.get_type() != Variant::NIL) {
 		String custom = md;
 		if (ScriptServer::is_global_class(custom)) {
-			obj = EditorNode::get_editor_data().script_class_instance(custom);
+			obj = EditorNode::get_editor_custom_types()->script_class_instance(custom);
 			Node *n = Object::cast_to<Node>(obj);
 			if (n) {
 				n->set_name(custom);
 			}
 		} else {
-			obj = EditorNode::get_editor_data().instance_custom_type(selected->get_text(0), custom);
+			obj = EditorNode::get_editor_custom_types()->instance_custom_type(selected->get_text(0), custom);
 		}
 	} else {
 		obj = ClassDB::instance(selected->get_text(0));

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1179,20 +1179,20 @@ void ScriptEditorDebugger::_live_edit_set() {
 
 	NodePath np = path;
 
-	editor->get_editor_data().set_edited_scene_live_edit_root(np);
+	editor->get_editor_scenes_manager()->set_edited_scene_live_edit_root(np);
 
 	update_live_edit_root();
 }
 
 void ScriptEditorDebugger::_live_edit_clear() {
 	NodePath np = NodePath("/root");
-	editor->get_editor_data().set_edited_scene_live_edit_root(np);
+	editor->get_editor_scenes_manager()->set_edited_scene_live_edit_root(np);
 
 	update_live_edit_root();
 }
 
 void ScriptEditorDebugger::update_live_edit_root() {
-	NodePath np = editor->get_editor_data().get_edited_scene_live_edit_root();
+	NodePath np = editor->get_editor_scenes_manager()->get_edited_scene_live_edit_root();
 
 	Array msg;
 	msg.push_back(np);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1404,8 +1404,8 @@ void EditorFileSystem::_scan_script_classes(EditorFileSystemDirectory *p_dir) {
 			}
 		}
 		ScriptServer::add_global_class(files[i]->script_class_name, files[i]->script_class_extends, lang, p_dir->get_file_path(i));
-		EditorNode::get_editor_data().script_class_set_icon_path(files[i]->script_class_name, files[i]->script_class_icon_path);
-		EditorNode::get_editor_data().script_class_set_name(files[i]->file, files[i]->script_class_name);
+		EditorNode::get_editor_custom_types()->script_class_set_icon_path(files[i]->script_class_name, files[i]->script_class_icon_path);
+		EditorNode::get_editor_custom_types()->script_class_set_name(files[i]->file, files[i]->script_class_name);
 	}
 	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
 		_scan_script_classes(p_dir->get_subdir(i));
@@ -1424,7 +1424,7 @@ void EditorFileSystem::update_script_classes() {
 	}
 
 	ScriptServer::save_global_classes();
-	EditorNode::get_editor_data().script_class_save_icon_paths();
+	EditorNode::get_editor_custom_types()->script_class_save_icon_paths();
 
 	// Rescan custom loaders and savers.
 	// Doing the following here because the `filesystem_changed` signal fires multiple times and isn't always followed by script classes update.

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1686,8 +1686,8 @@ void EditorInspector::update_tree() {
 					base_type = s->get_instance_base_type();
 				}
 				while (s.is_valid()) {
-					StringName name = EditorNode::get_editor_data().script_class_get_name(s->get_path());
-					String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
+					StringName name = EditorNode::get_editor_custom_types()->script_class_get_name(s->get_path());
+					String icon_path = EditorNode::get_editor_custom_types()->script_class_get_icon_path(name);
 					if (name != StringName() && icon_path.length()) {
 						category->icon = ResourceLoader::load(icon_path, "Texture");
 						break;
@@ -2537,7 +2537,7 @@ void EditorInspector::_update_script_class_properties(const Object &p_object, Li
 	for (List<Ref<Script>>::Element *E = classes.front(); E; E = E->next()) {
 		Ref<Script> s = E->get();
 		String path = s->get_path();
-		String name = EditorNode::get_editor_data().script_class_get_name(path);
+		String name = EditorNode::get_editor_custom_types()->script_class_get_name(path);
 		if (name.is_empty()) {
 			if (!path.is_empty() && path.find("::") == -1) {
 				name = path.get_file();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6678,8 +6678,8 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(MaterialEditorPlugin(this)));
 	add_editor_plugin(memnew(GPUParticlesCollisionSDFEditorPlugin(this)));
 
-	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
-		add_editor_plugin(EditorPlugins::create(i, this));
+	for (int i = 0; i < CustomEditorPlugins::get_plugin_count(); i++) {
+		add_editor_plugin(CustomEditorPlugins::create(i, this));
 	}
 
 	for (int i = 0; i < plugin_init_callback_count; i++) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -393,14 +393,18 @@ private:
 	uint64_t update_spinner_step_frame;
 	int update_spinner_step;
 
-	Vector<EditorPlugin *> editor_plugins;
 	EditorPlugin *editor_plugin_screen;
 	EditorPluginList *editor_plugins_over;
 	EditorPluginList *editor_plugins_force_over;
 	EditorPluginList *editor_plugins_force_input_forwarding;
 
+	EditorUndoRedo editor_undo_redo;
+	EditorClipboard editor_clipboard;
+	EditorCustomTypes editor_custom_types;
+	EditorScenes editor_scenes;
+	EditorPlugins editor_plugins;
+
 	EditorHistory editor_history;
-	EditorData editor_data;
 	EditorRun editor_run;
 	EditorSelection *editor_selection;
 	ProjectExportDialog *project_export;
@@ -734,7 +738,7 @@ public:
 
 	void set_edited_scene(Node *p_scene);
 
-	Node *get_edited_scene() { return editor_data.get_edited_scene_root(); }
+	Node *get_edited_scene() { return editor_scenes.get_edited_scene_root(); }
 
 	SubViewport *get_scene_root() { return scene_root; } //root of the scene being edited
 
@@ -749,9 +753,14 @@ public:
 	void set_current_version(uint64_t p_version);
 	void set_current_scene(int p_idx);
 
-	static EditorData &get_editor_data() { return singleton->editor_data; }
-	static EditorFolding &get_editor_folding() { return singleton->editor_folding; }
-	EditorHistory *get_editor_history() { return &editor_history; }
+	static UndoRedo *get_undo_redo() { return &singleton->editor_undo_redo.get(); }
+	static EditorClipboard *get_editor_clipboard() { return &singleton->editor_clipboard; }
+	static EditorCustomTypes *get_editor_custom_types() { return &singleton->editor_custom_types; }
+	static EditorScenes *get_editor_scenes_manager() { return &singleton->editor_scenes; }
+	static EditorPlugins *get_editor_plugins() { return &singleton->editor_plugins; }
+
+	static EditorFolding *get_editor_folding() { return &singleton->editor_folding; }
+	static EditorHistory *get_editor_history() { return &singleton->editor_history; }
 
 	static VSplitContainer *get_top_split() { return singleton->top_split; }
 
@@ -761,7 +770,6 @@ public:
 	ImportDock *get_import_dock();
 	SceneTreeDock *get_scene_tree_dock();
 	InspectorDock *get_inspector_dock();
-	static UndoRedo *get_undo_redo() { return &singleton->editor_data.get_undo_redo(); }
 
 	EditorSelection *get_editor_selection() { return editor_selection; }
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -206,7 +206,7 @@ Node *EditorInterface::get_edited_scene_root() {
 
 Array EditorInterface::get_open_scenes() const {
 	Array ret;
-	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
+	Vector<EditorScenes::EditedScene> scenes = EditorNode::get_editor_scenes_manager()->get_edited_scenes();
 
 	int scns_amount = scenes.size();
 	for (int idx_scn = 0; idx_scn < scns_amount; idx_scn++) {
@@ -347,11 +347,11 @@ EditorInterface::EditorInterface() {
 
 ///////////////////////////////////////////
 void EditorPlugin::add_custom_type(const String &p_type, const String &p_base, const Ref<Script> &p_script, const Ref<Texture2D> &p_icon) {
-	EditorNode::get_editor_data().add_custom_type(p_type, p_base, p_script, p_icon);
+	EditorNode::get_editor_custom_types()->add_custom_type(p_type, p_base, p_script, p_icon);
 }
 
 void EditorPlugin::remove_custom_type(const String &p_type) {
-	EditorNode::get_editor_data().remove_custom_type(p_type);
+	EditorNode::get_editor_custom_types()->remove_custom_type(p_type);
 }
 
 void EditorPlugin::add_autoload_singleton(const String &p_name, const String &p_path) {

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -915,6 +915,6 @@ void EditorPlugin::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOCK_SLOT_MAX);
 }
 
-EditorPluginCreateFunc EditorPlugins::creation_funcs[MAX_CREATE_FUNCS];
+EditorPluginCreateFunc CustomEditorPlugins::creation_funcs[MAX_CREATE_FUNCS];
 
-int EditorPlugins::creation_func_count = 0;
+int CustomEditorPlugins::creation_func_count = 0;

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -265,7 +265,7 @@ VARIANT_ENUM_CAST(EditorPlugin::DockSlot);
 
 typedef EditorPlugin *(*EditorPluginCreateFunc)(EditorNode *);
 
-class EditorPlugins {
+class CustomEditorPlugins {
 	enum {
 		MAX_CREATE_FUNCS = 64
 	};

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -120,7 +120,7 @@ public:
 
 class EditorPlugin : public Node {
 	GDCLASS(EditorPlugin, Node);
-	friend class EditorData;
+	friend class EditorPlugins;
 	UndoRedo *undo_redo = nullptr;
 
 	UndoRedo *_get_undo_redo() { return undo_redo; }

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2571,7 +2571,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 			}
 
 			if (!obj) {
-				obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+				obj = EditorNode::get_editor_custom_types()->instance_custom_type(intype, "Resource");
 			}
 
 			Resource *resp = Object::cast_to<Resource>(obj);
@@ -2629,10 +2629,10 @@ void EditorPropertyResource::_update_menu_items() {
 	} else if (base_type != "") {
 		int idx = 0;
 
-		Vector<EditorData::CustomType> custom_resources;
+		Vector<EditorCustomTypes::CustomType> custom_resources;
 
-		if (EditorNode::get_editor_data().get_custom_types().has("Resource")) {
-			custom_resources = EditorNode::get_editor_data().get_custom_types()["Resource"];
+		if (EditorNode::get_editor_custom_types()->get_custom_types().has("Resource")) {
+			custom_resources = EditorNode::get_editor_custom_types()->get_custom_types()["Resource"];
 		}
 
 		for (int i = 0; i < base_type.get_slice_count(","); i++) {
@@ -2657,7 +2657,7 @@ void EditorPropertyResource::_update_menu_items() {
 			ScriptServer::get_global_class_list(&global_classes);
 			E = global_classes.front();
 			while (E) {
-				if (EditorNode::get_editor_data().script_class_is_parent(E->get(), base_type)) {
+				if (EditorNode::get_editor_custom_types()->script_class_is_parent(E->get(), base_type)) {
 					valid_inheritors.insert(E->get());
 				}
 				E = E->next();
@@ -2817,8 +2817,8 @@ void EditorPropertyResource::_fold_other_editors(Object *p_self) {
 		return;
 	}
 	bool use_editor = false;
-	for (int i = 0; i < EditorNode::get_editor_data().get_editor_plugin_count(); i++) {
-		EditorPlugin *ep = EditorNode::get_editor_data().get_editor_plugin(i);
+	for (int i = 0; i < EditorNode::get_editor_plugins()->get_editor_plugin_count(); i++) {
+		EditorPlugin *ep = EditorNode::get_editor_plugins()->get_editor_plugin(i);
 		if (ep->handles(res.ptr())) {
 			use_editor = true;
 		}
@@ -2872,8 +2872,8 @@ void EditorPropertyResource::update_property() {
 				assign->set_pressed(true);
 
 				bool use_editor = false;
-				for (int i = 0; i < EditorNode::get_editor_data().get_editor_plugin_count(); i++) {
-					EditorPlugin *ep = EditorNode::get_editor_data().get_editor_plugin(i);
+				for (int i = 0; i < EditorNode::get_editor_plugins()->get_editor_plugin_count(); i++) {
+					EditorPlugin *ep = EditorNode::get_editor_plugins()->get_editor_plugin(i);
 					if (ep->handles(res.ptr())) {
 						use_editor = true;
 					}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1141,10 +1141,10 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);
 			if (ResourceLoader::get_resource_type(new_item_path) == "PackedScene" && editor->is_scene_open(file_changed_paths[i])) {
-				EditorData *ed = &editor->get_editor_data();
-				for (int j = 0; j < ed->get_edited_scene_count(); j++) {
-					if (ed->get_scene_path(j) == file_changed_paths[i]) {
-						ed->get_edited_scene_root(j)->set_filename(new_item_path);
+				EditorScenes *esm = editor->get_editor_scenes_manager();
+				for (int j = 0; j < esm->get_edited_scene_count(); j++) {
+					if (esm->get_scene_path(j) == file_changed_paths[i]) {
+						esm->get_edited_scene_root(j)->set_filename(new_item_path);
 						editor->save_layout();
 						break;
 					}
@@ -1224,26 +1224,26 @@ void FileSystemDock::_update_resource_paths_after_move(const Map<String, String>
 		r->set_path(base_path + extra_path);
 	}
 
-	for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); i++) {
+	for (int i = 0; i < EditorNode::get_editor_scenes_manager()->get_edited_scene_count(); i++) {
 		String path;
-		if (i == EditorNode::get_editor_data().get_edited_scene()) {
+		if (i == EditorNode::get_editor_scenes_manager()->get_edited_scene()) {
 			if (!get_tree()->get_edited_scene_root()) {
 				continue;
 			}
 
 			path = get_tree()->get_edited_scene_root()->get_filename();
 		} else {
-			path = EditorNode::get_editor_data().get_scene_path(i);
+			path = EditorNode::get_editor_scenes_manager()->get_scene_path(i);
 		}
 
 		if (p_renames.has(path)) {
 			path = p_renames[path];
 		}
 
-		if (i == EditorNode::get_editor_data().get_edited_scene()) {
+		if (i == EditorNode::get_editor_scenes_manager()->get_edited_scene()) {
 			get_tree()->get_edited_scene_root()->set_filename(path);
 		} else {
-			EditorNode::get_editor_data().set_scene_path(i, path);
+			EditorNode::get_editor_scenes_manager()->set_scene_path(i, path);
 		}
 	}
 }
@@ -1405,7 +1405,7 @@ void FileSystemDock::_make_scene_confirm() {
 	memdelete(da);
 
 	int idx = editor->new_scene();
-	editor->get_editor_data().set_scene_path(idx, scene_name);
+	editor->get_editor_scenes_manager()->set_scene_path(idx, scene_name);
 }
 
 void FileSystemDock::_file_removed(String p_file) {

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -67,21 +67,21 @@ void InspectorDock::_menu_option(int p_option) {
 		} break;
 
 		case OBJECT_COPY_PARAMS: {
-			editor_data->apply_changes_in_editors();
+			editor->get_editor_plugins()->apply_changes_in_editors();
 			if (current) {
-				editor_data->copy_object_params(current);
+				editor->get_editor_clipboard()->copy_object_params(current);
 			}
 		} break;
 
 		case OBJECT_PASTE_PARAMS: {
-			editor_data->apply_changes_in_editors();
+			editor->get_editor_plugins()->apply_changes_in_editors();
 			if (current) {
-				editor_data->paste_object_params(current);
+				editor->get_editor_clipboard()->paste_object_params(current);
 			}
 		} break;
 
 		case OBJECT_UNIQUE_RESOURCES: {
-			editor_data->apply_changes_in_editors();
+			editor->get_editor_plugins()->apply_changes_in_editors();
 			if (current) {
 				List<PropertyInfo> props;
 				current->get_property_list(&props);
@@ -110,7 +110,7 @@ void InspectorDock::_menu_option(int p_option) {
 				}
 			}
 
-			editor_data->get_undo_redo().clear_history();
+			editor->get_undo_redo()->clear_history();
 
 			editor->get_editor_plugins_over()->edit(nullptr);
 			editor->get_editor_plugins_over()->edit(current);
@@ -387,7 +387,7 @@ void InspectorDock::clear() {
 }
 
 void InspectorDock::update(Object *p_object) {
-	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+	EditorHistory *editor_history = editor->get_editor_history();
 	backward_button->set_disabled(editor_history->is_at_beginning());
 	forward_button->set_disabled(editor_history->is_at_end());
 
@@ -477,7 +477,7 @@ void InspectorDock::update_keying() {
 	bool valid = false;
 
 	if (AnimationPlayerEditor::singleton->get_track_editor()->has_keying()) {
-		EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+		EditorHistory *editor_history = editor->get_editor_history();
 		if (editor_history->get_path_size() >= 1) {
 			Object *obj = ObjectDB::get_instance(editor_history->get_path_object(0));
 			if (Object::cast_to<Node>(obj)) {
@@ -489,12 +489,11 @@ void InspectorDock::update_keying() {
 	inspector->set_keying(valid);
 }
 
-InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
+InspectorDock::InspectorDock(EditorNode *p_editor) {
 	set_name("Inspector");
 	set_theme(p_editor->get_gui_base()->get_theme());
 
 	editor = p_editor;
-	editor_data = &p_editor_data;
 
 	HBoxContainer *general_options_hb = memnew(HBoxContainer);
 	add_child(general_options_hb);
@@ -613,7 +612,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));
 	inspector->set_use_folding(!bool(EDITOR_GET("interface/inspector/disable_folding")));
 	inspector->register_text_enter(search);
-	inspector->set_undo_redo(&editor_data->get_undo_redo());
+	inspector->set_undo_redo(editor->get_undo_redo());
 
 	inspector->set_use_filter(true); // TODO: check me
 

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -67,7 +67,6 @@ class InspectorDock : public VBoxContainer {
 	};
 
 	EditorNode *editor;
-	EditorData *editor_data;
 
 	EditorInspector *inspector;
 
@@ -129,7 +128,7 @@ public:
 	Container *get_addon_area();
 	EditorInspector *get_inspector() { return inspector; }
 
-	InspectorDock(EditorNode *p_editor, EditorData &p_editor_data);
+	InspectorDock(EditorNode *p_editor);
 	~InspectorDock();
 };
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6258,22 +6258,22 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 	Size2 texture_size = texture->get_size();
 
 	if (parent) {
-		editor_data->get_undo_redo().add_do_method(parent, "add_child", child);
-		editor_data->get_undo_redo().add_do_method(child, "set_owner", editor->get_edited_scene());
-		editor_data->get_undo_redo().add_do_reference(child);
-		editor_data->get_undo_redo().add_undo_method(parent, "remove_child", child);
+		editor->get_undo_redo()->add_do_method(parent, "add_child", child);
+		editor->get_undo_redo()->add_do_method(child, "set_owner", editor->get_edited_scene());
+		editor->get_undo_redo()->add_do_reference(child);
+		editor->get_undo_redo()->add_undo_method(parent, "remove_child", child);
 	} else { // if we haven't parent, lets try to make a child as a parent.
-		editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child);
-		editor_data->get_undo_redo().add_do_method(child, "set_owner", editor->get_edited_scene());
-		editor_data->get_undo_redo().add_do_reference(child);
-		editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)nullptr);
+		editor->get_undo_redo()->add_do_method(editor, "set_edited_scene", child);
+		editor->get_undo_redo()->add_do_method(child, "set_owner", editor->get_edited_scene());
+		editor->get_undo_redo()->add_do_reference(child);
+		editor->get_undo_redo()->add_undo_method(editor, "set_edited_scene", (Object *)nullptr);
 	}
 
 	if (parent) {
 		String new_name = parent->validate_child_name(child);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		editor_data->get_undo_redo().add_do_method(ed, "live_debug_create_node", editor->get_edited_scene()->get_path_to(parent), child->get_class(), new_name);
-		editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
+		editor->get_undo_redo()->add_do_method(ed, "live_debug_create_node", editor->get_edited_scene()->get_path_to(parent), child->get_class(), new_name);
+		editor->get_undo_redo()->add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
 	}
 
 	// handle with different property for texture
@@ -6292,18 +6292,18 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 			break;
 		}
 	}
-	editor_data->get_undo_redo().add_do_property(child, property, texture);
+	editor->get_undo_redo()->add_do_property(child, property, texture);
 
 	// make visible for certain node type
 	if (default_type == "NinePatchRect") {
-		editor_data->get_undo_redo().add_do_property(child, "rect/size", texture_size);
+		editor->get_undo_redo()->add_do_property(child, "rect/size", texture_size);
 	} else if (default_type == "Polygon2D") {
 		Vector<Vector2> list;
 		list.push_back(Vector2(0, 0));
 		list.push_back(Vector2(texture_size.width, 0));
 		list.push_back(Vector2(texture_size.width, texture_size.height));
 		list.push_back(Vector2(0, texture_size.height));
-		editor_data->get_undo_redo().add_do_property(child, "polygon", list);
+		editor->get_undo_redo()->add_do_property(child, "polygon", list);
 	}
 
 	// Compute the global position
@@ -6312,7 +6312,7 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 
 	// there's nothing to be used as source position so snapping will work as absolute if enabled
 	target_position = canvas_item_editor->snap_point(target_position);
-	editor_data->get_undo_redo().add_do_method(child, "set_global_position", target_position);
+	editor->get_undo_redo()->add_do_method(child, "set_global_position", target_position);
 }
 
 bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, const Point2 &p_point) {
@@ -6335,15 +6335,15 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 
 	instanced_scene->set_filename(ProjectSettings::get_singleton()->localize_path(path));
 
-	editor_data->get_undo_redo().add_do_method(parent, "add_child", instanced_scene);
-	editor_data->get_undo_redo().add_do_method(instanced_scene, "set_owner", editor->get_edited_scene());
-	editor_data->get_undo_redo().add_do_reference(instanced_scene);
-	editor_data->get_undo_redo().add_undo_method(parent, "remove_child", instanced_scene);
+	editor->get_undo_redo()->add_do_method(parent, "add_child", instanced_scene);
+	editor->get_undo_redo()->add_do_method(instanced_scene, "set_owner", editor->get_edited_scene());
+	editor->get_undo_redo()->add_do_reference(instanced_scene);
+	editor->get_undo_redo()->add_undo_method(parent, "remove_child", instanced_scene);
 
 	String new_name = parent->validate_child_name(instanced_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-	editor_data->get_undo_redo().add_do_method(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
-	editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
+	editor->get_undo_redo()->add_do_method(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
+	editor->get_undo_redo()->add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
 
 	CanvasItem *parent_ci = Object::cast_to<CanvasItem>(parent);
 	if (parent_ci) {
@@ -6355,7 +6355,7 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 		if (instance_ci) {
 			target_pos += instance_ci->_edit_get_position();
 		}
-		editor_data->get_undo_redo().add_do_method(instanced_scene, "set_position", target_pos);
+		editor->get_undo_redo()->add_do_method(instanced_scene, "set_position", target_pos);
 	}
 
 	return true;
@@ -6373,7 +6373,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 
 	Vector<String> error_files;
 
-	editor_data->get_undo_redo().create_action(TTR("Create Node"));
+	editor->get_undo_redo()->create_action(TTR("Create Node"));
 
 	for (int i = 0; i < selected_files.size(); i++) {
 		String path = selected_files[i];
@@ -6420,7 +6420,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 		}
 	}
 
-	editor_data->get_undo_redo().commit_action();
+	editor->get_undo_redo()->commit_action();
 
 	if (error_files.size() > 0) {
 		String files_str;
@@ -6580,7 +6580,6 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 
 	target_node = nullptr;
 	editor = p_node;
-	editor_data = editor->get_scene_tree_dock()->get_editor_data();
 	canvas_item_editor = p_canvas_item_editor;
 	preview_node = memnew(Node2D);
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -673,7 +673,6 @@ class CanvasItemEditorViewport : public Control {
 	Point2 drop_pos;
 
 	EditorNode *editor;
-	EditorData *editor_data;
 	CanvasItemEditor *canvas_item_editor;
 	Node2D *preview_node;
 	AcceptDialog *accept;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2368,7 +2368,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		_update_freelook(delta);
 
-		Node *scene_root = editor->get_scene_tree_dock()->get_editor_data()->get_edited_scene_root();
+		Node *scene_root = editor->get_editor_scenes_manager()->get_edited_scene_root();
 		if (previewing_cinema && scene_root != nullptr) {
 			Camera3D *cam = scene_root->get_viewport()->get_camera();
 			if (cam != nullptr && cam != previewing) {
@@ -3765,15 +3765,15 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		instanced_scene->set_filename(ProjectSettings::get_singleton()->localize_path(path));
 	}
 
-	editor_data->get_undo_redo().add_do_method(parent, "add_child", instanced_scene);
-	editor_data->get_undo_redo().add_do_method(instanced_scene, "set_owner", editor->get_edited_scene());
-	editor_data->get_undo_redo().add_do_reference(instanced_scene);
-	editor_data->get_undo_redo().add_undo_method(parent, "remove_child", instanced_scene);
+	editor->get_undo_redo()->add_do_method(parent, "add_child", instanced_scene);
+	editor->get_undo_redo()->add_do_method(instanced_scene, "set_owner", editor->get_edited_scene());
+	editor->get_undo_redo()->add_do_reference(instanced_scene);
+	editor->get_undo_redo()->add_undo_method(parent, "remove_child", instanced_scene);
 
 	String new_name = parent->validate_child_name(instanced_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-	editor_data->get_undo_redo().add_do_method(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
-	editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
+	editor->get_undo_redo()->add_do_method(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
+	editor->get_undo_redo()->add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
 
 	Node3D *node3d = Object::cast_to<Node3D>(instanced_scene);
 	if (node3d) {
@@ -3786,7 +3786,7 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		global_transform.origin = spatial_editor->snap_point(_get_instance_position(p_point));
 		global_transform.basis *= node3d->get_transform().basis;
 
-		editor_data->get_undo_redo().add_do_method(instanced_scene, "set_global_transform", global_transform);
+		editor->get_undo_redo()->add_do_method(instanced_scene, "set_global_transform", global_transform);
 	}
 
 	return true;
@@ -3797,7 +3797,7 @@ void Node3DEditorViewport::_perform_drop_data() {
 
 	Vector<String> error_files;
 
-	editor_data->get_undo_redo().create_action(TTR("Create Node"));
+	editor->get_undo_redo()->create_action(TTR("Create Node"));
 
 	for (int i = 0; i < selected_files.size(); i++) {
 		String path = selected_files[i];
@@ -3815,7 +3815,7 @@ void Node3DEditorViewport::_perform_drop_data() {
 		}
 	}
 
-	editor_data->get_undo_redo().commit_action();
+	editor->get_undo_redo()->commit_action();
 
 	if (error_files.size() > 0) {
 		String files_str;
@@ -3937,7 +3937,6 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 
 	index = p_index;
 	editor = p_editor;
-	editor_data = editor->get_scene_tree_dock()->get_editor_data();
 	editor_selection = editor->get_editor_selection();
 	undo_redo = editor->get_undo_redo();
 

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -265,7 +265,6 @@ private:
 	Point2 drop_pos;
 
 	EditorNode *editor;
-	EditorData *editor_data;
 	EditorSelection *editor_selection;
 	UndoRedo *undo_redo;
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3173,7 +3173,7 @@ void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_numb
 		RES res = ResourceLoader::load(fpath);
 
 		if (fpath.get_extension() == "shader") {
-			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));
+			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_editor_plugins()->get_editor("Shader"));
 			shader_editor->edit(res.ptr());
 			shader_editor->make_visible(true);
 			shader_editor->get_shader_editor()->goto_line_selection(line_number - 1, begin, end);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -304,13 +304,12 @@ void ProjectSettingsEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("queue_save"), &ProjectSettingsEditor::queue_save);
 }
 
-ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
+ProjectSettingsEditor::ProjectSettingsEditor() {
 	singleton = this;
 	set_title(TTR("Project Settings (project.godot)"));
 
 	ps = ProjectSettings::get_singleton();
-	undo_redo = &p_data->get_undo_redo();
-	data = p_data;
+	undo_redo = EditorNode::get_undo_redo();
 
 	tab_container = memnew(TabContainer);
 	tab_container->set_tab_align(TabContainer::ALIGN_LEFT);
@@ -413,7 +412,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	}
 
 	inspector = memnew(SectionedInspector);
-	inspector->get_inspector()->set_undo_redo(EditorNode::get_singleton()->get_undo_redo());
+	inspector->get_inspector()->set_undo_redo(EditorNode::get_undo_redo());
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector->register_search_box(search_box);
 	inspector->get_inspector()->connect("property_selected", callable_mp(this, &ProjectSettingsEditor::_setting_selected));

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -84,7 +84,6 @@ class ProjectSettingsEditor : public AcceptDialog {
 	PanelContainer *restart_container;
 	Button *restart_close_button;
 
-	EditorData *data;
 	UndoRedo *undo_redo;
 
 	void _advanced_pressed();
@@ -103,7 +102,6 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _editor_restart_close();
 
 	void _add_feature_overrides();
-	ProjectSettingsEditor();
 
 protected:
 	void _notification(int p_what);
@@ -120,7 +118,7 @@ public:
 
 	void queue_save();
 
-	ProjectSettingsEditor(EditorData *p_data);
+	ProjectSettingsEditor();
 };
 
 #endif // PROJECT_SETTINGS_EDITOR_H

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -266,9 +266,9 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					if (!obj) {
 						if (ScriptServer::is_global_class(intype)) {
-							obj = EditorNode::get_editor_data().script_class_instance(intype);
+							obj = EditorNode::get_editor_custom_types()->script_class_instance(intype);
 						} else {
-							obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+							obj = EditorNode::get_editor_custom_types()->instance_custom_type(intype, "Resource");
 						}
 					}
 
@@ -853,10 +853,10 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			} else if (hint_text != "") {
 				int idx = 0;
 
-				Vector<EditorData::CustomType> custom_resources;
+				Vector<EditorCustomTypes::CustomType> custom_resources;
 
-				if (EditorNode::get_editor_data().get_custom_types().has("Resource")) {
-					custom_resources = EditorNode::get_editor_data().get_custom_types()["Resource"];
+				if (EditorNode::get_editor_custom_types()->get_custom_types().has("Resource")) {
+					custom_resources = EditorNode::get_editor_custom_types()->get_custom_types()["Resource"];
 				}
 
 				for (int i = 0; i < hint_text.get_slice_count(","); i++) {
@@ -1068,9 +1068,9 @@ void CustomPropertyEditor::_type_create_selected(int p_idx) {
 
 		if (!obj) {
 			if (ScriptServer::is_global_class(intype)) {
-				obj = EditorNode::get_editor_data().script_class_instance(intype);
+				obj = EditorNode::get_editor_custom_types()->script_class_instance(intype);
 			} else {
-				obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+				obj = EditorNode::get_editor_custom_types()->instance_custom_type(intype, "Resource");
 			}
 		}
 
@@ -1253,9 +1253,9 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 					if (!obj) {
 						if (ScriptServer::is_global_class(intype)) {
-							obj = EditorNode::get_editor_data().script_class_instance(intype);
+							obj = EditorNode::get_editor_custom_types()->script_class_instance(intype);
 						} else {
-							obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+							obj = EditorNode::get_editor_custom_types()->instance_custom_type(intype, "Resource");
 						}
 					}
 

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -433,8 +433,8 @@ String RenameDialog::_substitute(const String &subject, const Node *node, int co
 		result = result.replace("${TYPE}", node->get_class());
 	}
 
-	int current = EditorNode::get_singleton()->get_editor_data().get_edited_scene();
-	result = result.replace("${SCENE}", EditorNode::get_singleton()->get_editor_data().get_scene_title(current));
+	int current = EditorNode::get_editor_scenes_manager()->get_edited_scene();
+	result = result.replace("${SCENE}", EditorNode::get_editor_scenes_manager()->get_scene_title(current));
 
 	Node *root_node = SceneTree::get_singleton()->get_edited_scene_root();
 	if (root_node) {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -123,7 +123,6 @@ class SceneTreeDock : public VBoxContainer {
 	void _tool_selected(int p_tool, bool p_confirm_override = false);
 	void _node_collapsed(Object *p_obj);
 
-	EditorData *editor_data;
 	EditorSelection *editor_selection;
 
 	ScriptCreateDialog *script_create_dialog;
@@ -251,7 +250,6 @@ public:
 	void fill_path_renames(Node *p_node, Node *p_new_parent, List<Pair<NodePath, NodePath>> *p_renames);
 	void perform_node_renames(Node *p_base, List<Pair<NodePath, NodePath>> *p_renames, Map<Ref<Animation>, Set<int>> *r_rem_anims = nullptr);
 	SceneTreeEditor *get_tree_editor() { return scene_tree; }
-	EditorData *get_editor_data() { return editor_data; }
 
 	void add_remote_tree_editor(Control *p_remote);
 	void show_remote_tree();
@@ -266,7 +264,7 @@ public:
 
 	ScriptCreateDialog *get_script_create_dialog() { return script_create_dialog; }
 
-	SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data);
+	SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSelection *p_editor_selection);
 };
 
 #endif // SCENE_TREE_DOCK_H

--- a/modules/csg/register_types.cpp
+++ b/modules/csg/register_types.cpp
@@ -47,7 +47,7 @@ void register_csg_types() {
 	ClassDB::register_class<CSGCombiner3D>();
 
 #ifdef TOOLS_ENABLED
-	EditorPlugins::add_by_type<EditorPluginCSG>();
+	CustomEditorPlugins::add_by_type<EditorPluginCSG>();
 #endif
 #endif
 }

--- a/modules/gdnavigation/register_types.cpp
+++ b/modules/gdnavigation/register_types.cpp
@@ -64,7 +64,7 @@ void register_gdnavigation_types() {
 #endif
 
 #ifdef TOOLS_ENABLED
-	EditorPlugins::add_by_type<NavigationMeshEditorPlugin>();
+	CustomEditorPlugins::add_by_type<NavigationMeshEditorPlugin>();
 
 	ClassDB::APIType prev_api = ClassDB::get_current_api();
 	ClassDB::set_current_api(ClassDB::API_EDITOR);

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -64,7 +64,7 @@ void register_gltf_types() {
 	ClassDB::set_current_api(ClassDB::API_EDITOR);
 	ClassDB::register_class<EditorSceneImporterGLTF>();
 	ClassDB::register_class<GLTFMesh>();
-	EditorPlugins::add_by_type<SceneExporterGLTFPlugin>();
+	CustomEditorPlugins::add_by_type<SceneExporterGLTFPlugin>();
 	ClassDB::set_current_api(prev_api);
 	EditorNode::add_init_callback(_editor_init);
 #endif

--- a/modules/gridmap/register_types.cpp
+++ b/modules/gridmap/register_types.cpp
@@ -39,7 +39,7 @@ void register_gridmap_types() {
 #ifndef _3D_DISABLED
 	ClassDB::register_class<GridMap>();
 #ifdef TOOLS_ENABLED
-	EditorPlugins::add_by_type<GridMapEditorPlugin>();
+	CustomEditorPlugins::add_by_type<GridMapEditorPlugin>();
 #endif
 #endif
 }


### PR DESCRIPTION
This has no external scripting API changes. This change affects internal usage only. This better encapsulates individual responsibilities for EditorData. Previously EditorData was a big set of, for the most part, unrelated methods and data, making it quite confusing to know exactly what it was for.

Note all changes are in `editor_data.h`, `editor_data.cpp` and `editor_node.h`. All the rest of the changes are just replacing `EditorNode::get_editor_data()` calls with the new equivalent new methods in EditorNode.

This splits up EditorData into 5 different classes.
They are accessed via EditorNode as EditorData previously was (e.g. `EditorNode::get_editor_clipboard()`).

EditorData becomes:
1. EditorClipboard - manages the shared clipboard of the editor (e.g. when copying and pasting object parameters)
2. EditorUndoRedo - the storage location for the one central UndoRedo class for the Editor. This one is optional TBH. The UndoRedo could just be made directly in EditorNode, but I kept it as a separate class for now, as I thought maybe direct storage of state in EditorNode is to be avoided? If that is not the case, EditorUndoRedo could be removed and just instance the UndoRedo in EditorNode.
3. EditorPluginsManager - manages EditorPlugins.
4. EditorScenesManager - manages scenes which are currently open.
5. EditorCustomTypes - manages registration of custom node types from scripts and editor plugins.

** The "manager" names are new to Godot it seems... I am definitely open to alternative names. Just note that "EditorPlugins" is already taken. If anything, I propose changing "EditorPlugins" to "ExternalEditorPlugins" (as that is what that class is used for), and then renaming these "managers" to "EditorPlugins" and "EditorScenes" respectively.