### PR TITLE
Don't handle BaseException in build scripts

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -530,13 +530,13 @@ if selected_platform in platform_list:
                 doc_path = config.get_doc_path()
                 for c in doc_classes:
                     env.doc_class_path[c] = path + "/" + doc_path
-            except:
+            except Exception:
                 pass
             # Get icon paths (if present)
             try:
                 icons_path = config.get_icons_path()
                 env.module_icons_paths.append(path + "/" + icons_path)
-            except:
+            except Exception:
                 # Default path for module icons
                 env.module_icons_paths.append(path + "/" + "icons")
             modules_enabled[name] = path

--- a/core/SCsub
+++ b/core/SCsub
@@ -25,7 +25,7 @@ if "SCRIPT_AES256_ENCRYPTION_KEY" in os.environ:
             txts = "0x" + e[i * 2 : i * 2 + 2]
             try:
                 int(txts, 16)
-            except:
+            except Exception:
                 ec_valid = False
             txt += txts
     if not ec_valid:

--- a/methods.py
+++ b/methods.py
@@ -843,7 +843,7 @@ def show_progress(env):
     try:
         with open(node_count_fname) as f:
             node_count_max = int(f.readline())
-    except:
+    except Exception:
         pass
 
     cache_directory = os.environ.get("SCONS_CACHE")

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -278,7 +278,7 @@ if webm_cpu_x86:
         try:
             yasm_found = True
             subprocess.Popen([yasm_path, "--version"], stdout=devnull, stderr=devnull).communicate()
-        except:
+        except Exception:
             yasm_found = False
         if yasm_found:
             break

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -334,6 +334,6 @@ def get_ndk_version(path):
                 key_value = list(map(lambda x: x.strip(), line.split("=")))
                 if key_value[0] == "Pkg.Revision":
                     return key_value[1]
-    except:
+    except Exception:
         print("Could not read source prop file '%s'" % prop_file_path)
     return None

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -50,9 +50,7 @@ def get_flags():
 
 
 def configure(env):
-    try:
-        env["initial_memory"] = int(env["initial_memory"])
-    except:
+    if not isinstance(env["initial_memory"], int):
         print("Initial memory must be a valid integer")
         sys.exit(255)
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -95,7 +95,7 @@ def build_res_file(target, source, env):
             out = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
             if len(out[1]):
                 return 1
-        except:
+        except Exception:
             return 1
     return 0
 


### PR DESCRIPTION
As identified by [LGTM](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=&ruleFocus=6780080&id=py%2Fcatch-base-exception), there are a number of places where the build scripts catch all exceptions, including the `BaseException`, which includes `SystemExit` and `KeyboardInterrupt` exceptions. `SystemExit` and `KeyboardInterrupt` exceptions should not be caught unless they're specifically being handled.

This PR changes `exception:` to `exception Exception:` to ensure that the `SystemExit` and `KeyboardInterrupt` exceptions are not unintentionally caught.

Note: In `platform/javascript/detect.py` a throw is being used to check for an integer, which is probably better handled using an `isinstance(variable, int)`, so I've made that change too.
