### PR TITLE
[3.2] Don't handle BaseException in build scripts

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -484,13 +484,13 @@ if selected_platform in platform_list:
                 doc_path = config.get_doc_path()
                 for c in doc_classes:
                     env.doc_class_path[c] = path + "/" + doc_path
-            except:
+            except Exception:
                 pass
             # Get icon paths (if present)
             try:
                 icons_path = config.get_icons_path()
                 env.module_icons_paths.append(path + "/" + icons_path)
-            except:
+            except Exception:
                 # Default path for module icons
                 env.module_icons_paths.append(path + "/" + "icons")
             modules_enabled[name] = path

--- a/core/SCsub
+++ b/core/SCsub
@@ -27,7 +27,7 @@ if "SCRIPT_AES256_ENCRYPTION_KEY" in os.environ:
             txts = "0x" + e[i * 2 : i * 2 + 2]
             try:
                 int(txts, 16)
-            except:
+            except Exception:
                 ec_valid = False
             txt += txts
     if not ec_valid:

--- a/methods.py
+++ b/methods.py
@@ -885,7 +885,7 @@ def show_progress(env):
     try:
         with open(node_count_data["fname"]) as f:
             node_count_data["max"] = int(f.readline())
-    except:
+    except Exception:
         pass
 
     cache_directory = os.environ.get("SCONS_CACHE")

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -270,7 +270,7 @@ if webm_cpu_x86:
         try:
             yasm_found = True
             subprocess.Popen([yasm_path, "--version"], stdout=devnull, stderr=devnull).communicate()
-        except:
+        except Exception:
             yasm_found = False
         if yasm_found:
             break

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -329,6 +329,6 @@ def get_ndk_version(path):
                 key_value = list(map(lambda x: x.strip(), line.split("=")))
                 if key_value[0] == "Pkg.Revision":
                     return key_value[1]
-    except:
+    except Exception:
         print("Could not read source prop file '%s'" % prop_file_path)
     return None

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -94,7 +94,7 @@ def build_res_file(target, source, env):
             out = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
             if len(out[1]):
                 return 1
-        except:
+        except Exception:
             return 1
     return 0
 


### PR DESCRIPTION
3.2 version of #44315.
