### PR TITLE
Fixed Geometry2D::get_closest_points_between_segments docs

### DIFF
--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -91,7 +91,7 @@
 			<argument index="3" name="q2" type="Vector2">
 			</argument>
 			<description>
-				Given the two 2D segments ([code]p1[/code], [code]p2[/code]) and ([code]q1[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PackedVector2Array] that contains this point on ([code]p1[/code], [code]p2[/code]) as well the accompanying point on ([code]q1[/code], [code]q2[/code]).
+				Given the two 2D segments ([code]p1[/code], [code]q1[/code]) and ([code]p2[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PackedVector2Array] that contains this point on ([code]p1[/code], [code]q1[/code]) as well the accompanying point on ([code]p2[/code], [code]q2[/code]).
 			</description>
 		</method>
 		<method name="intersect_polygons">


### PR DESCRIPTION
While writing unit tests for the Geometry2D class i thought i caught a bug in `Geometry2D::get_closest_points_between_segments`, but actually it's just the documentation that's wrong. 
The segments are `(p1, q1)`, `(p2, q2)` not `(p1, p2)`, `(q1, q2)`.