### PR TITLE
Fixed EditorPropertyText change signal emission.

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -68,9 +68,9 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 	}
 
 	if (string_name) {
-		emit_changed(get_edited_property(), StringName(p_string), "", true);
+		emit_changed(get_edited_property(), StringName(p_string), "", false);
 	} else {
-		emit_changed(get_edited_property(), p_string, "", true);
+		emit_changed(get_edited_property(), p_string, "", false);
 	}
 }
 


### PR DESCRIPTION
The [EditorPropertyText](https://github.com/godotengine/godot/blob/master/editor/editor_properties.cpp#L65) is not properly emitting the `emit_change` signal.

The signal is emitted with the variable `changing = true`. You can see that the `if (updating) {` statement is already preventing such signal to be executed at all while the user is writing; so the correct variable value for `changing` is `false`.

*Bugsquad edit:* Fixes #43238.