### PR TITLE
Added methods to drawing thin poly-lines

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -750,10 +750,24 @@ void CanvasItem::draw_polyline(const Vector<Point2> &p_points, const Color &p_co
 	RenderingServer::get_singleton()->canvas_item_add_polyline(canvas_item, p_points, colors, p_width, p_antialiased);
 }
 
+void CanvasItem::draw_thin_polyline(const Vector<Point2> &p_points, const Color &p_color) {
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
+
+	Vector<Color> colors;
+	colors.push_back(p_color);
+	RenderingServer::get_singleton()->canvas_item_add_thin_polyline(canvas_item, p_points, colors);
+}
+
 void CanvasItem::draw_polyline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width, bool p_antialiased) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	RenderingServer::get_singleton()->canvas_item_add_polyline(canvas_item, p_points, p_colors, p_width, p_antialiased);
+}
+
+void CanvasItem::draw_thin_polyline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors) {
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
+
+	RenderingServer::get_singleton()->canvas_item_add_thin_polyline(canvas_item, p_points, p_colors);
 }
 
 void CanvasItem::draw_arc(const Vector2 &p_center, float p_radius, float p_start_angle, float p_end_angle, int p_point_count, const Color &p_color, float p_width, bool p_antialiased) {
@@ -766,6 +780,18 @@ void CanvasItem::draw_arc(const Vector2 &p_center, float p_radius, float p_start
 	}
 
 	draw_polyline(points, p_color, p_width, p_antialiased);
+}
+
+void CanvasItem::draw_thin_arc(const Vector2 &p_center, float p_radius, float p_start_angle, float p_end_angle, int p_point_count, const Color &p_color) {
+	Vector<Point2> points;
+	points.resize(p_point_count);
+	const float delta_angle = p_end_angle - p_start_angle;
+	for (int i = 0; i < p_point_count; i++) {
+		float theta = (i / (p_point_count - 1.0f)) * delta_angle + p_start_angle;
+		points.set(i, p_center + Vector2(Math::cos(theta), Math::sin(theta)) * p_radius);
+	}
+
+	draw_thin_polyline(points, p_color);
 }
 
 void CanvasItem::draw_multiline(const Vector<Point2> &p_points, const Color &p_color, float p_width) {
@@ -1146,8 +1172,11 @@ void CanvasItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("draw_line", "from", "to", "color", "width"), &CanvasItem::draw_line, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("draw_polyline", "points", "color", "width", "antialiased"), &CanvasItem::draw_polyline, DEFVAL(1.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("draw_thin_polyline", "points", "color"), &CanvasItem::draw_thin_polyline);
 	ClassDB::bind_method(D_METHOD("draw_polyline_colors", "points", "colors", "width", "antialiased"), &CanvasItem::draw_polyline_colors, DEFVAL(1.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("draw_thin_polyline_colors", "points", "colors"), &CanvasItem::draw_thin_polyline_colors);
 	ClassDB::bind_method(D_METHOD("draw_arc", "center", "radius", "start_angle", "end_angle", "point_count", "color", "width", "antialiased"), &CanvasItem::draw_arc, DEFVAL(1.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("draw_thin_arc", "center", "radius", "start_angle", "end_angle", "point_count", "color"), &CanvasItem::draw_thin_arc);
 	ClassDB::bind_method(D_METHOD("draw_multiline", "points", "color", "width"), &CanvasItem::draw_multiline, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("draw_multiline_colors", "points", "colors", "width"), &CanvasItem::draw_multiline_colors, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("draw_rect", "rect", "color", "filled", "width"), &CanvasItem::draw_rect, DEFVAL(true), DEFVAL(1.0));

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -333,8 +333,11 @@ public:
 
 	void draw_line(const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width = 1.0);
 	void draw_polyline(const Vector<Point2> &p_points, const Color &p_color, float p_width = 1.0, bool p_antialiased = false);
+	void draw_thin_polyline(const Vector<Point2> &p_points, const Color &p_color);
 	void draw_polyline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width = 1.0, bool p_antialiased = false);
+	void draw_thin_polyline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors);
 	void draw_arc(const Vector2 &p_center, float p_radius, float p_start_angle, float p_end_angle, int p_point_count, const Color &p_color, float p_width = 1.0, bool p_antialiased = false);
+	void draw_thin_arc(const Vector2 &p_center, float p_radius, float p_start_angle, float p_end_angle, int p_point_count, const Color &p_color);
 	void draw_multiline(const Vector<Point2> &p_points, const Color &p_color, float p_width = 1.0);
 	void draw_multiline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width = 1.0);
 	void draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_filled = true, float p_width = 1.0);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -193,6 +193,7 @@ public:
 
 	void canvas_item_add_line(RID p_item, const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width = 1.0);
 	void canvas_item_add_polyline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width = 1.0, bool p_antialiased = false);
+	void canvas_item_add_thin_polyline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors);
 	void canvas_item_add_multiline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width = 1.0);
 	void canvas_item_add_rect(RID p_item, const Rect2 &p_rect, const Color &p_color);
 	void canvas_item_add_circle(RID p_item, const Point2 &p_pos, float p_radius, const Color &p_color);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -719,6 +719,7 @@ public:
 
 	BIND5(canvas_item_add_line, RID, const Point2 &, const Point2 &, const Color &, float)
 	BIND5(canvas_item_add_polyline, RID, const Vector<Point2> &, const Vector<Color> &, float, bool)
+	BIND3(canvas_item_add_thin_polyline, RID, const Vector<Point2> &, const Vector<Color> &)
 	BIND4(canvas_item_add_multiline, RID, const Vector<Point2> &, const Vector<Color> &, float)
 	BIND3(canvas_item_add_rect, RID, const Rect2 &, const Color &)
 	BIND4(canvas_item_add_circle, RID, const Point2 &, float, const Color &)

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -620,6 +620,7 @@ public:
 
 	FUNC5(canvas_item_add_line, RID, const Point2 &, const Point2 &, const Color &, float)
 	FUNC5(canvas_item_add_polyline, RID, const Vector<Point2> &, const Vector<Color> &, float, bool)
+	FUNC3(canvas_item_add_thin_polyline, RID, const Vector<Point2> &, const Vector<Color> &)
 	FUNC4(canvas_item_add_multiline, RID, const Vector<Point2> &, const Vector<Color> &, float)
 	FUNC3(canvas_item_add_rect, RID, const Rect2 &, const Color &)
 	FUNC4(canvas_item_add_circle, RID, const Point2 &, float, const Color &)

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1210,6 +1210,7 @@ public:
 
 	virtual void canvas_item_add_line(RID p_item, const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width = 1.0) = 0;
 	virtual void canvas_item_add_polyline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width = 1.0, bool p_antialiased = false) = 0;
+	virtual void canvas_item_add_thin_polyline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors) = 0;
 	virtual void canvas_item_add_multiline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width = 1.0) = 0;
 	virtual void canvas_item_add_rect(RID p_item, const Rect2 &p_rect, const Color &p_color) = 0;
 	virtual void canvas_item_add_circle(RID p_item, const Point2 &p_pos, float p_radius, const Color &p_color) = 0;


### PR DESCRIPTION
This is one of the ways to fix #44332 - I've added `add_thin_polyline` to RenderServer and `draw_thin_polyline`, `draw_thin_polyline_colors`, `draw_thin_arc` to `CanvasItem`. Instead `PRIMITIVE_TRIANGLE_STRIP` it used `PRIMITIVE_LINE` and does not have `thickness` and `antialiasing` parameters.

Also, the line with `width < 1.0` is already draw incorrectly - for example with `width = 0.1`:
![image](https://user-images.githubusercontent.com/3036176/102005518-66f22c80-3d2a-11eb-91c8-889abe4aab69.png)
so I've added a limiter to `canvas_item_add_polyline` to prevent this.
