### PR TITLE
Add important note about OS.get_unixtime.

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -356,6 +356,7 @@
 			</return>
 			<description>
 				Returns the current UNIX epoch timestamp.
+				[b]Important:[/b] This is the system clock that the user can manully set. [b]Never use[/b] this method for precise time calculation since its results are also subject to automatic adjustments by the operating system. [b]Always use[/b] [method get_ticks_usec] or [method get_ticks_msec] for precise time calculation instead, since they are guaranteed to be monotonic (i.e. never decrease).
 			</description>
 		</method>
 		<method name="get_unix_time_from_datetime" qualifiers="const">


### PR DESCRIPTION
Should NEVER be used for precise time computations since its return values are not guaranteed to be monotonic.

In `3.2` it would also need to be mentioned in the now removed `get_system_time_*secs()` function.