### PR TITLE
Implement AnimationPlayer pause() and resume()

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -108,7 +108,7 @@
 			<return type="float">
 			</return>
 			<description>
-				Gets the actual playing speed of current animation or 0 if not playing. This speed is the [member playback_speed] property multiplied by [code]custom_speed[/code] argument specified when calling the [method play] method.
+				Gets the actual playing speed of current animation or 0 if not playing. This speed is the [member playback_speed] property multiplied by [code]custom_speed[/code] argument specified when calling the [method start] method.
 			</description>
 		</method>
 		<method name="get_queue">
@@ -139,34 +139,6 @@
 			</return>
 			<description>
 				Pauses the currently playing animation. To resume the animation again use [method resume]. To stop and reset an animation use [method stop].
-			</description>
-		</method>
-		<method name="play">
-			<return type="void">
-			</return>
-			<argument index="0" name="name" type="StringName" default="&quot;&quot;">
-			</argument>
-			<argument index="1" name="custom_blend" type="float" default="-1">
-			</argument>
-			<argument index="2" name="custom_speed" type="float" default="1.0">
-			</argument>
-			<argument index="3" name="from_end" type="bool" default="false">
-			</argument>
-			<description>
-				Plays the currently assigned animation or the animation with key [code]name[/code] from the beginning. Custom blend times and speed can be set. If [code]custom_speed[/code] is negative and [code]from_end[/code] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
-				[b]Note:[/b] The animation will be updated the next time the [AnimationPlayer] is processed. If other variables are updated at the same time this is called, they may be updated too early. To perform the update immediately, call [code]advance(0)[/code].
-			</description>
-		</method>
-		<method name="play_backwards">
-			<return type="void">
-			</return>
-			<argument index="0" name="name" type="StringName" default="&quot;&quot;">
-			</argument>
-			<argument index="1" name="custom_blend" type="float" default="-1">
-			</argument>
-			<description>
-				Plays the animation with key [code]name[/code] in reverse.
-				This method is a shorthand for [method play] with [code]custom_speed = -1.0[/code] and [code]from_end = true[/code], so see its description for more information.
 			</description>
 		</method>
 		<method name="queue">
@@ -230,6 +202,20 @@
 				Specifies a blend time (in seconds) between two animations, referenced by their names.
 			</description>
 		</method>
+		<method name="start">
+			<return type="void">
+			</return>
+			<argument index="0" name="name" type="StringName" default="&quot;&quot;">
+			</argument>
+			<argument index="1" name="custom_blend_time" type="float" default="-1">
+			</argument>
+			<argument index="2" name="custom_speed" type="float" default="1.0">
+			</argument>
+			<description>
+				Starts playing the currently assigned animation or the animation with key [code]name[/code] from the beginning. A custom blend time and speed can be set. If [code]custom_speed[/code] is negative, the animation will play backwards from the end.
+				[b]Note:[/b] The animation will be updated the next time the [AnimationPlayer] is processed. If other variables are updated at the same time this is called, they may be updated too early. To perform the update immediately, call [code]advance(0)[/code].
+			</description>
+		</method>
 		<method name="stop">
 			<return type="void">
 			</return>
@@ -246,7 +232,7 @@
 			The name of the animation to play when the scene loads.
 		</member>
 		<member name="current_animation" type="String" setter="set_current_animation" getter="get_current_animation" default="&quot;&quot;">
-			The name of the currently playing animation. If no animation is playing, the property's value is an empty string. Changing this value does not restart the animation. See [method play] for more information on playing animations.
+			The name of the currently playing animation. If no animation is playing, the property's value is an empty string. Changing this value does not start the animation. See [method start] for more information on starting the animation.
 			[b]Note[/b]: while this property appears in the inspector, it's not meant to be edited, and it's not saved in the scene. This property is mainly used to get the currently playing animation, and internally for animation playback tracks. For more information, see [Animation].
 		</member>
 		<member name="current_animation_length" type="float" setter="" getter="get_current_animation_length">

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -131,7 +131,14 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if playing an animation.
+				Returns [code]true[/code] if an animation is playing. An animation is playing if it has started, but not finished or been paused.
+			</description>
+		</method>
+		<method name="pause">
+			<return type="void">
+			</return>
+			<description>
+				Pauses the currently playing animation. To resume the animation again use [method resume]. To stop and reset an animation use [method stop].
 			</description>
 		</method>
 		<method name="play">
@@ -146,8 +153,7 @@
 			<argument index="3" name="from_end" type="bool" default="false">
 			</argument>
 			<description>
-				Plays the animation with key [code]name[/code]. Custom blend times and speed can be set. If [code]custom_speed[/code] is negative and [code]from_end[/code] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
-				The [AnimationPlayer] keeps track of its current or last played animation with [member assigned_animation]. If this method is called with that same animation [code]name[/code], or with no [code]name[/code] parameter, the assigned animation will resume playing if it was paused, or restart if it was stopped (see [method stop] for both pause and stop). If the animation was already playing, it will keep playing.
+				Plays the currently assigned animation or the animation with key [code]name[/code] from the beginning. Custom blend times and speed can be set. If [code]custom_speed[/code] is negative and [code]from_end[/code] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
 				[b]Note:[/b] The animation will be updated the next time the [AnimationPlayer] is processed. If other variables are updated at the same time this is called, they may be updated too early. To perform the update immediately, call [code]advance(0)[/code].
 			</description>
 		</method>
@@ -193,6 +199,13 @@
 				Renames an existing animation with key [code]name[/code] to [code]newname[/code].
 			</description>
 		</method>
+		<method name="resume">
+			<return type="void">
+			</return>
+			<description>
+				Resumes an animation that was paused. See [method pause].
+			</description>
+		</method>
 		<method name="seek">
 			<return type="void">
 			</return>
@@ -220,11 +233,8 @@
 		<method name="stop">
 			<return type="void">
 			</return>
-			<argument index="0" name="reset" type="bool" default="true">
-			</argument>
 			<description>
-				Stops or pauses the currently playing animation. If [code]reset[/code] is [code]true[/code], the animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code].
-				If [code]reset[/code] is [code]false[/code], the [member current_animation_position] will be kept and calling [method play] or [method play_backwards] without arguments or with the same animation name as [member assigned_animation] will resume the animation.
+				Stops and resets the currently playing animation. To keep the animation at its current position, use [method pause].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -258,9 +258,6 @@
 		<member name="method_call_mode" type="int" setter="set_method_call_mode" getter="get_method_call_mode" enum="AnimationPlayer.AnimationMethodCallMode" default="0">
 			The call mode to use for Call Method tracks.
 		</member>
-		<member name="playback_active" type="bool" setter="set_active" getter="is_active">
-			If [code]true[/code], updates animations in response to process-related notifications.
-		</member>
 		<member name="playback_default_blend_time" type="float" setter="set_default_blend_time" getter="get_default_blend_time" default="0.0">
 			The default time in which to blend animations. Ranges from 0 to 4096 with 0.01 precision.
 		</member>

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -262,7 +262,7 @@ void AnimationPlayerEditor::_stop_pressed() {
 		return;
 	}
 
-	player->stop(false);
+	player->pause();
 	play->set_pressed(false);
 	stop->set_pressed(true);
 }
@@ -1020,7 +1020,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set) {
 
 		player->seek_delta(pos, pos - cpos);
 	} else {
-		player->stop(true);
+		player->stop();
 		player->seek(pos, true);
 	}
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -192,7 +192,7 @@ void AnimationPlayerEditor::_play_pressed() {
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
 		}
-		player->play(current);
+		player->start(current);
 	}
 
 	//unstop
@@ -212,7 +212,7 @@ void AnimationPlayerEditor::_play_from_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 
-		player->play(current);
+		player->start(current);
 		player->seek(time);
 	}
 
@@ -230,7 +230,7 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
 		}
-		player->play(current, -1, -1, true);
+		player->start(current, -1, -1);
 	}
 
 	//unstop
@@ -249,7 +249,7 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 
-		player->play(current, -1, -1, true);
+		player->start(current, -1, -1);
 		player->seek(time);
 	}
 

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -278,7 +278,11 @@ void VisibilityEnabler2D::_change_node_state(Node *p_node, bool p_enabled) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
 		if (ap) {
-			ap->set_active(p_enabled);
+			if (p_enabled) {
+				ap->resume();
+			} else {
+				ap->pause();
+			}
 		}
 	}
 

--- a/scene/3d/visibility_notifier_3d.cpp
+++ b/scene/3d/visibility_notifier_3d.cpp
@@ -212,7 +212,11 @@ void VisibilityEnabler3D::_change_node_state(Node *p_node, bool p_enabled) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
 		if (ap) {
-			ap->set_active(p_enabled);
+			if (p_enabled) {
+				ap->resume();
+			} else {
+				ap->pause();
+			}
 		}
 	}
 }

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1396,19 +1396,6 @@ void AnimationPlayer::clear_caches() {
 	cache_update_bezier_size = 0;
 }
 
-void AnimationPlayer::set_active(bool p_active) {
-	if (active == p_active) {
-		return;
-	}
-
-	active = p_active;
-	_set_process(processing, true);
-}
-
-bool AnimationPlayer::is_active() const {
-	return active;
-}
-
 StringName AnimationPlayer::find_animation(const Ref<Animation> &p_animation) const {
 	for (Map<StringName, AnimationData>::Element *E = animation_set.front(); E; E = E->next()) {
 		if (E->get().animation == p_animation) {
@@ -1466,17 +1453,17 @@ AnimationPlayer::AnimationMethodCallMode AnimationPlayer::get_method_call_mode()
 	return method_call_mode;
 }
 
-void AnimationPlayer::_set_process(bool p_process, bool p_force) {
-	if (processing == p_process && !p_force) {
+void AnimationPlayer::_set_process(bool p_process) {
+	if (processing == p_process) {
 		return;
 	}
 
 	switch (process_callback) {
 		case ANIMATION_PROCESS_PHYSICS:
-			set_physics_process_internal(p_process && active);
+			set_physics_process_internal(p_process);
 			break;
 		case ANIMATION_PROCESS_IDLE:
-			set_process_internal(p_process && active);
+			set_process_internal(p_process);
 			break;
 		case ANIMATION_PROCESS_MANUAL:
 			break;
@@ -1655,9 +1642,6 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_queue"), &AnimationPlayer::get_queue);
 	ClassDB::bind_method(D_METHOD("clear_queue"), &AnimationPlayer::clear_queue);
 
-	ClassDB::bind_method(D_METHOD("set_active", "active"), &AnimationPlayer::set_active);
-	ClassDB::bind_method(D_METHOD("is_active"), &AnimationPlayer::is_active);
-
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "speed"), &AnimationPlayer::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_speed_scale"), &AnimationPlayer::get_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_playing_speed"), &AnimationPlayer::get_playing_speed);
@@ -1698,7 +1682,6 @@ void AnimationPlayer::_bind_methods() {
 	ADD_GROUP("Playback Options", "playback_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_process_mode", PROPERTY_HINT_ENUM, "Physics,Idle,Manual"), "set_process_callback", "get_process_callback");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_default_blend_time", PROPERTY_HINT_RANGE, "0,4096,0.01"), "set_default_blend_time", "get_default_blend_time");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playback_active", PROPERTY_HINT_NONE, "", 0), "set_active", "is_active");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_speed", PROPERTY_HINT_RANGE, "-64,64,0.01"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "method_call_mode", PROPERTY_HINT_ENUM, "Deferred,Immediate"), "set_method_call_mode", "get_method_call_mode");
 

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -222,6 +222,8 @@ private:
 	void _animation_process(float p_delta);
 
 	void _node_removed(Node *p_node);
+	void _pause_playing_caches();
+	void _resume_playing_caches();
 	void _stop_playing_caches();
 
 	// bind helpers
@@ -243,6 +245,7 @@ private:
 	void _set_process(bool p_process, bool p_force = false);
 
 	bool playing = false;
+	bool paused = false;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -277,7 +280,9 @@ public:
 	void queue(const StringName &p_name);
 	Vector<String> get_queue();
 	void clear_queue();
-	void stop(bool p_reset = true);
+	void pause();
+	void resume();
+	void stop();
 	bool is_playing() const;
 	String get_current_animation() const;
 	void set_current_animation(const String &p_anim);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -209,7 +209,6 @@ private:
 	AnimationProcessCallback process_callback = ANIMATION_PROCESS_IDLE;
 	AnimationMethodCallMode method_call_mode = ANIMATION_METHOD_CALL_DEFERRED;
 	bool processing = false;
-	bool active = true;
 
 	NodePath root;
 
@@ -242,7 +241,7 @@ private:
 	void _ref_anim(const Ref<Animation> &p_anim);
 	void _unref_anim(const Ref<Animation> &p_anim);
 
-	void _set_process(bool p_process, bool p_force = false);
+	void _set_process(bool p_process);
 
 	bool playing = false;
 	bool paused = false;
@@ -289,8 +288,6 @@ public:
 	String get_assigned_animation() const;
 	void set_assigned_animation(const String &p_anim);
 	void stop_all();
-	void set_active(bool p_active);
-	bool is_active() const;
 	bool is_valid() const;
 
 	void set_speed_scale(float p_speed);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -274,8 +274,7 @@ public:
 	void set_default_blend_time(float p_default);
 	float get_default_blend_time() const;
 
-	void play(const StringName &p_name = StringName(), float p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
-	void play_backwards(const StringName &p_name = StringName(), float p_custom_blend = -1);
+	void start(const StringName &p_name = StringName(), float p_custom_blend_time = -1, float p_custom_scale = 1.0);
 	void queue(const StringName &p_name);
 	Vector<String> get_queue();
 	void clear_queue();

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1142,7 +1142,7 @@ void AnimationTree::_process_graph(float p_delta) {
 							}
 
 							if (player2->is_playing() || seeked) {
-								player2->play(anim_name);
+								player2->start(anim_name);
 								player2->seek(at_anim_pos);
 								t->playing = true;
 								playing_caches.insert(t);
@@ -1165,7 +1165,7 @@ void AnimationTree::_process_graph(float p_delta) {
 										t->playing = false;
 									}
 								} else {
-									player2->play(anim_name);
+									player2->start(anim_name);
 									t->playing = true;
 									playing_caches.insert(t);
 								}


### PR DESCRIPTION
As originally identified in #34125 and elaborated on in https://github.com/godotengine/godot-proposals/issues/287, in `AnimationPlayer`:
> Currently play() method doesn't adhere to single responsibility principle. If user calls play() while there is no animation playing it acts as start_animation() where as when user calls it when animation is already playing it acts as resume_animation(). This dual behaviour is not desired by users as it requires a condition statement in order to use start_animation functionality of play(). It is also inconstant across the engine as for example AudioStreamPlayer method play() method has only singular functionality of start_playing(). This is confusing to understand and breaks intuitiveness of the engine.

Similarly, `AnimationPlayer:stop()` has a parameter that defaults to `true` to either stop and reset the animation or just pause the animation. However, as identified in #27499, although `stop(true)` resets the playback position it doesn't reset the animation.

This PR:
- Implements two new functions in `AnimationPlayer`: `pause()` and `resume()`. `pause()` will pause a currently playing animation, and `resume()` will resume a `paused()` animation.
- Ensures that play() always plays the specified (or current animation) from the beginning regardless of whether or not the requested animation is the same as the current animation
- Ensures that stop() also resets the animation
- Updates the relevant documentation

Closes https://github.com/godotengine/godot-proposals/issues/287
Fixes #27499
Fixes #36279
Supersedes #33733
