### PR TITLE
Allow to override drop data in LineEdit

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -709,7 +709,7 @@ bool Control::can_drop_data(const Point2 &p_point, const Variant &p_data) const 
 		}
 	}
 
-	return Variant();
+	return false;
 }
 
 void Control::drop_data(const Point2 &p_point, const Variant &p_data) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -635,10 +635,17 @@ Variant LineEdit::get_drag_data(const Point2 &p_point) {
 }
 
 bool LineEdit::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
+	bool drop_override = Control::can_drop_data(p_point, p_data); // In case user wants to drop custom data.
+	if (drop_override) {
+		return drop_override;
+	}
+
 	return p_data.get_type() == Variant::STRING;
 }
 
 void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
+	Control::drop_data(p_point, p_data);
+
 	if (p_data.get_type() == Variant::STRING) {
 		set_cursor_at_pixel_pos(p_point.x);
 		int selected = selection.end - selection.begin;


### PR DESCRIPTION
Addresses #30480 (the change in Control is unrelated, I can remove it if requested)

Not sure what should we do about SpinBox. It's impossible pass drop data to parent without explicitly checking its type. But with LineEdit fixed, this can be done on user side (although in a bit convoluted way, see my comment in the issue). If it's fine this way, #30480 can be closed after this PR is merged.