### PR TITLE
Fixed mistakes in InputEvent as_text and to_string implementations.

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -213,7 +213,7 @@ String InputEventWithModifiers::as_text() const {
 	if (!mod_names.empty()) {
 		return String("+").join(mod_names);
 	} else {
-		return "None";
+		return "";
 	}
 }
 
@@ -369,11 +369,19 @@ String InputEventKey::to_string() {
 	String p = is_pressed() ? "true" : "false";
 	String e = is_echo() ? "true" : "false";
 
+	String kc = "";
+	String physical = "false";
 	if (keycode == 0) {
-		return vformat("InputEventKey: keycode=%s mods=%s physical=%s pressed=%s echo=%s", itos(physical_keycode) + " " + keycode_get_string(physical_keycode), InputEventWithModifiers::as_text(), "true", p, e);
+		kc = itos(physical_keycode) + " " + keycode_get_string(physical_keycode);
+		physical = "true";
 	} else {
-		return vformat("InputEventKey: keycode=%s mods=%s physical=%s pressed=%s echo=%s", itos(keycode) + " " + keycode_get_string(keycode), InputEventWithModifiers::as_text(), "false", p, e);
+		kc = itos(keycode) + " " + keycode_get_string(keycode);
 	}
+
+	String mods = InputEventWithModifiers::as_text();
+	mods = mods == "" ? TTR("None") : mods;
+
+	return vformat("InputEventKey: keycode=%s mods=%s physical=%s pressed=%s echo=%s", kc, mods, physical, p, e);
 }
 
 bool InputEventKey::action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const {
@@ -633,7 +641,12 @@ String InputEventMouseButton::to_string() {
 			break;
 	}
 
-	return vformat("InputEventMouseButton: button_index=%s pressed=%s position=(%s) button_mask=%s doubleclick=%s", button_index, p, String(get_position()), itos(get_button_mask()), d);
+	String mods = InputEventWithModifiers::as_text();
+	mods = mods == "" ? TTR("None") : mods;
+
+	// Work around the fact vformat can only take 5 substitutions but 6 need to be passed.
+	String index_and_mods = vformat("button_index=%s mods=%s", button_index, mods);
+	return vformat("InputEventMouseButton: %s pressed=%s position=(%s) button_mask=%s doubleclick=%s", index_and_mods, p, String(get_position()), itos(get_button_mask()), d);
 }
 
 void InputEventMouseButton::_bind_methods() {


### PR DESCRIPTION
I made a couple of mistakes in #43660.

You may have noticed that for the past 10 days in master shortcuts which did not use modifiers said "None+W", for example, or "None+V". Yeah... that was me. Oops!

This PR fixes that and also adds a bit more info to `InputEventMouseButton::to_string` so it also includes what modifiers are being pressed.