### PR TITLE
Restored thin polylines if line width <= 0

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -44,7 +44,7 @@
 			<argument index="7" name="antialiased" type="bool" default="false">
 			</argument>
 			<description>
-				Draws an arc between the given angles. The larger the value of [code]point_count[/code], the smoother the curve.
+				Draws an arc between the given angles. The larger the value of [code]point_count[/code], the smoother the curve. If [code]width[/code] is lesser than or equal to [code]0[/code] then arc will be drawed used [constant Mesh.PRIMITIVE_LINES].
 			</description>
 		</method>
 		<method name="draw_char" qualifiers="const">
@@ -221,7 +221,7 @@
 			<argument index="3" name="antialiased" type="bool" default="false">
 			</argument>
 			<description>
-				Draws interconnected line segments with a uniform [code]color[/code] and [code]width[/code].
+				Draws interconnected line segments with a uniform [code]color[/code] and [code]width[/code]. If [code]width[/code] is lesser than or equal to [code]0[/code] then line will be drawed used [constant Mesh.PRIMITIVE_LINES].
 			</description>
 		</method>
 		<method name="draw_polyline_colors">
@@ -236,7 +236,7 @@
 			<argument index="3" name="antialiased" type="bool" default="false">
 			</argument>
 			<description>
-				Draws interconnected line segments with a uniform [code]width[/code] and segment-by-segment coloring. Colors assigned to line segments match by index between [code]points[/code] and [code]colors[/code].
+				Draws interconnected line segments with a uniform [code]width[/code] and segment-by-segment coloring. Colors assigned to line segments match by index between [code]points[/code] and [code]colors[/code]. If [code]width[/code] is lesser than or equal to [code]0[/code] then line will be drawed used [constant Mesh.PRIMITIVE_LINES].
 			</description>
 		</method>
 		<method name="draw_primitive">

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -557,6 +557,39 @@ void RendererCanvasCull::canvas_item_add_polyline(RID p_item, const Vector<Point
 	Item::CommandPolygon *pline = canvas_item->alloc_command<Item::CommandPolygon>();
 	ERR_FAIL_COND(!pline);
 
+	if (p_width <= 0.0) {
+		pline->primitive = RS::PRIMITIVE_LINES;
+
+		indices.resize((pc - 1) * 2);
+		{
+			int *iptr = indices.ptrw();
+			for (int i = 0; i < (pc - 1); i++) {
+				iptr[i * 2 + 0] = i;
+				iptr[i * 2 + 1] = i + 1;
+			}
+		}
+
+		if (p_colors.size() != 1 && p_colors.size() != p_points.size()) {
+			Vector<Color> colors;
+
+			for (int i = 0; i < pc; i++) {
+				if (i < p_colors.size()) {
+					color = p_colors[i];
+				}
+				colors.append(color);
+			}
+
+			pline->polygon.create(indices, p_points, colors);
+		} else {
+			pline->polygon.create(indices, p_points, p_colors);
+		}
+		return;
+	}
+
+	if (p_width < 1.0) {
+		p_width = 1.0;
+	}
+
 	PackedColorArray colors;
 	PackedVector2Array points;
 


### PR DESCRIPTION
The alternative to #44337, #44338 which achieve the same goal by using parameter width <= 0.0
Fix #44332 
