### PR TITLE
Expose SceneTreeTimer pause mode

### DIFF
--- a/doc/classes/SceneTreeTimer.xml
+++ b/doc/classes/SceneTreeTimer.xml
@@ -18,6 +18,9 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="pause_mode" type="bool" setter="set_pause_mode_process" getter="is_pause_mode_process">
+			Set to [code]true[/code] to process the timer while the [SceneTree] is paused. If set to [code]false[/code], pausing the [SceneTree] will also pause the timer.
+		</member>
 		<member name="time_left" type="float" setter="set_time_left" getter="get_time_left">
 			The time remaining.
 		</member>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -61,6 +61,11 @@ void SceneTreeTimer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_left"), "set_time_left", "get_time_left");
 
+	ClassDB::bind_method(D_METHOD("set_pause_mode_process", "pause_mode"), &SceneTreeTimer::set_pause_mode_process);
+	ClassDB::bind_method(D_METHOD("is_pause_mode_process"), &SceneTreeTimer::is_pause_mode_process);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pause_mode"), "set_pause_mode_process", "is_pause_mode_process");
+
 	ADD_SIGNAL(MethodInfo("timeout"));
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Currently it's possible to tweak `SceneTreeTimer` pause mode value using `SceneTree.create_timer`, however it's impossible to do so afterwards unless a new timer is created.

This PR exposes `SceneTreeTimer.pause_mode` for users who want to keep a reusable timer around and also be able to tweak its pause mode at runtime.