### PR TITLE
Rename Animation::track_remove_key_at_position to track_remove_key_at_time

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -514,15 +514,15 @@
 				Removes a key by index in a given track.
 			</description>
 		</method>
-		<method name="track_remove_key_at_position">
+		<method name="track_remove_key_at_time">
 			<return type="void">
 			</return>
 			<argument index="0" name="track_idx" type="int">
 			</argument>
-			<argument index="1" name="position" type="float">
+			<argument index="1" name="time" type="float">
 			</argument>
 			<description>
-				Removes a key by position (seconds) in a given track.
+				Removes a key at [code]time[/code] in a given track.
 			</description>
 		</method>
 		<method name="track_set_enabled">

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -810,8 +810,8 @@ int Animation::transform_track_insert_key(int p_track, float p_time, const Vecto
 	return ret;
 }
 
-void Animation::track_remove_key_at_position(int p_track, float p_pos) {
-	int idx = track_find_key(p_track, p_pos, true);
+void Animation::track_remove_key_at_time(int p_track, float p_time) {
+	int idx = track_find_key(p_track, p_time, true);
 	ERR_FAIL_COND(idx < 0);
 	track_remove_key(p_track, idx);
 }
@@ -2608,7 +2608,7 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("transform_track_insert_key", "track_idx", "time", "location", "rotation", "scale"), &Animation::transform_track_insert_key);
 	ClassDB::bind_method(D_METHOD("track_insert_key", "track_idx", "time", "key", "transition"), &Animation::track_insert_key, DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("track_remove_key", "track_idx", "key_idx"), &Animation::track_remove_key);
-	ClassDB::bind_method(D_METHOD("track_remove_key_at_position", "track_idx", "position"), &Animation::track_remove_key_at_position);
+	ClassDB::bind_method(D_METHOD("track_remove_key_at_time", "track_idx", "time"), &Animation::track_remove_key_at_time);
 	ClassDB::bind_method(D_METHOD("track_set_key_value", "track_idx", "key", "value"), &Animation::track_set_key_value);
 	ClassDB::bind_method(D_METHOD("track_set_key_transition", "track_idx", "key_idx", "transition"), &Animation::track_set_key_transition);
 	ClassDB::bind_method(D_METHOD("track_set_key_time", "track_idx", "key_idx", "time"), &Animation::track_set_key_time);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -293,7 +293,7 @@ public:
 	void track_set_key_time(int p_track, int p_key_idx, float p_time);
 	int track_find_key(int p_track, float p_time, bool p_exact = false) const;
 	void track_remove_key(int p_track, int p_idx);
-	void track_remove_key_at_position(int p_track, float p_pos);
+	void track_remove_key_at_time(int p_track, float p_time);
 	int track_get_key_count(int p_track) const;
 	Variant track_get_key_value(int p_track, int p_key_idx) const;
 	float track_get_key_time(int p_track, int p_key_idx) const;


### PR DESCRIPTION
As originally identified [here](https://github.com/godotengine/godot/issues/16863#issuecomment-394719906), the method `Animation::track_remove_key_at_position(int, float)` actually removes the key at the time specified. This PR renames the method to reflect this.

Part of #16863.
