### PR TITLE
Mono: Add extra WASM framework assemblies on game export

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -173,6 +173,8 @@ namespace GodotTools.Export
 
             assemblies[projectDllName] = projectDllSrcPath;
 
+            string bclDir = DeterminePlatformBclDir(platform);
+
             if (platform == OS.Platforms.Android)
             {
                 string godotAndroidExtProfileDir = GetBclProfileDir("godot_android_ext");
@@ -183,8 +185,49 @@ namespace GodotTools.Export
 
                 assemblies["Mono.Android"] = monoAndroidAssemblyPath;
             }
+            else if (platform == OS.Platforms.HTML5)
+            {
+                // Ideally these would be added automatically since they're referenced by the wasm BCL assemblies.
+                // However, at least in the case of 'WebAssembly.Net.Http' for some reason the BCL assemblies
+                // reference a different version even though the assembly is the same, for some weird reason.
 
-            string bclDir = DeterminePlatformBclDir(platform);
+                var wasmFrameworkAssemblies = new[] {"WebAssembly.Bindings", "WebAssembly.Net.WebSockets"};
+
+                foreach (string thisWasmFrameworkAssemblyName in wasmFrameworkAssemblies)
+                {
+                    string thisWasmFrameworkAssemblyPath = Path.Combine(bclDir, thisWasmFrameworkAssemblyName + ".dll");
+                    if (!File.Exists(thisWasmFrameworkAssemblyPath))
+                        throw new FileNotFoundException($"Assembly not found: '{thisWasmFrameworkAssemblyName}'", thisWasmFrameworkAssemblyPath);
+                    assemblies[thisWasmFrameworkAssemblyName] = thisWasmFrameworkAssemblyPath;
+                }
+
+                // Assemblies that can have a different name in a newer version. Newer version must come first and it has priority.
+                (string newName, string oldName)[] wasmFrameworkAssembliesOneOf = new[]
+                {
+                    ("System.Net.Http.WebAssemblyHttpHandler", "WebAssembly.Net.Http")
+                };
+
+                foreach (var thisWasmFrameworkAssemblyName in wasmFrameworkAssembliesOneOf)
+                {
+                    string thisWasmFrameworkAssemblyPath = Path.Combine(bclDir, thisWasmFrameworkAssemblyName.newName + ".dll");
+                    if (File.Exists(thisWasmFrameworkAssemblyPath))
+                    {
+                        assemblies[thisWasmFrameworkAssemblyName.newName] = thisWasmFrameworkAssemblyPath;
+                    }
+                    else
+                    {
+                        thisWasmFrameworkAssemblyPath = Path.Combine(bclDir, thisWasmFrameworkAssemblyName.oldName + ".dll");
+                        if (!File.Exists(thisWasmFrameworkAssemblyPath))
+                        {
+                            throw new FileNotFoundException("Expected one of the following assemblies but none were found: " +
+                                                            $"'{thisWasmFrameworkAssemblyName.newName}' / '{thisWasmFrameworkAssemblyName.oldName}'",
+                                thisWasmFrameworkAssemblyPath);
+                        }
+
+                        assemblies[thisWasmFrameworkAssemblyName.oldName] = thisWasmFrameworkAssemblyPath;
+                    }
+                }
+            }
 
             var initialAssemblies = assemblies.Duplicate();
             internal_GetExportedAssemblyDependencies(initialAssemblies, buildConfig, bclDir, assemblies);


### PR DESCRIPTION
This is needed with newer Mono versions, at least with Mono 6.12+

Depends on the following commit from our build scripts:
godotengine/godot-mono-builds@9d75cff
