### PR TITLE
Remove Array `append()` alias for `push_back()` to improve consistency

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -64,7 +64,7 @@ Array Script::_get_script_property_list() {
 	List<PropertyInfo> list;
 	get_script_property_list(&list);
 	for (List<PropertyInfo>::Element *E = list.front(); E; E = E->next()) {
-		ret.append(E->get().operator Dictionary());
+		ret.push_back(E->get().operator Dictionary());
 	}
 	return ret;
 }
@@ -74,7 +74,7 @@ Array Script::_get_script_method_list() {
 	List<MethodInfo> list;
 	get_script_method_list(&list);
 	for (List<MethodInfo>::Element *E = list.front(); E; E = E->next()) {
-		ret.append(E->get().operator Dictionary());
+		ret.push_back(E->get().operator Dictionary());
 	}
 	return ret;
 }
@@ -84,7 +84,7 @@ Array Script::_get_script_signal_list() {
 	List<MethodInfo> list;
 	get_script_signal_list(&list);
 	for (List<MethodInfo>::Element *E = list.front(); E; E = E->next()) {
-		ret.append(E->get().operator Dictionary());
+		ret.push_back(E->get().operator Dictionary());
 	}
 	return ret;
 }

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -65,7 +65,6 @@ private:
 
 public:
 	bool push_back(T p_elem);
-	_FORCE_INLINE_ bool append(const T &p_elem) { return push_back(p_elem); } //alias
 
 	void remove(int p_index) { _cowdata.remove(p_index); }
 	void erase(const T &p_val) {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -67,7 +67,6 @@ public:
 	void operator=(const Array &p_array);
 
 	void push_back(const Variant &p_value);
-	_FORCE_INLINE_ void append(const Variant &p_value) { push_back(p_value); } //for python compatibility
 	void append_array(const Array &p_array);
 	Error resize(int p_new_size);
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1276,7 +1276,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, hash, sarray(), varray());
 	bind_method(Array, push_back, sarray("value"), varray());
 	bind_method(Array, push_front, sarray("value"), varray());
-	bind_method(Array, append, sarray("value"), varray());
 	bind_method(Array, append_array, sarray("array"), varray());
 	bind_method(Array, resize, sarray("size"), varray());
 	bind_method(Array, insert, sarray("position", "value"), varray());
@@ -1307,7 +1306,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedByteArray, empty, sarray(), varray());
 	bind_method(PackedByteArray, set, sarray("index", "value"), varray());
 	bind_method(PackedByteArray, push_back, sarray("value"), varray());
-	bind_method(PackedByteArray, append, sarray("value"), varray());
 	bind_method(PackedByteArray, append_array, sarray("array"), varray());
 	bind_method(PackedByteArray, remove, sarray("index"), varray());
 	bind_method(PackedByteArray, insert, sarray("at_index", "value"), varray());
@@ -1332,7 +1330,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt32Array, empty, sarray(), varray());
 	bind_method(PackedInt32Array, set, sarray("index", "value"), varray());
 	bind_method(PackedInt32Array, push_back, sarray("value"), varray());
-	bind_method(PackedInt32Array, append, sarray("value"), varray());
 	bind_method(PackedInt32Array, append_array, sarray("array"), varray());
 	bind_method(PackedInt32Array, remove, sarray("index"), varray());
 	bind_method(PackedInt32Array, insert, sarray("at_index", "value"), varray());
@@ -1349,7 +1346,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt64Array, empty, sarray(), varray());
 	bind_method(PackedInt64Array, set, sarray("index", "value"), varray());
 	bind_method(PackedInt64Array, push_back, sarray("value"), varray());
-	bind_method(PackedInt64Array, append, sarray("value"), varray());
 	bind_method(PackedInt64Array, append_array, sarray("array"), varray());
 	bind_method(PackedInt64Array, remove, sarray("index"), varray());
 	bind_method(PackedInt64Array, insert, sarray("at_index", "value"), varray());
@@ -1366,7 +1362,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat32Array, empty, sarray(), varray());
 	bind_method(PackedFloat32Array, set, sarray("index", "value"), varray());
 	bind_method(PackedFloat32Array, push_back, sarray("value"), varray());
-	bind_method(PackedFloat32Array, append, sarray("value"), varray());
 	bind_method(PackedFloat32Array, append_array, sarray("array"), varray());
 	bind_method(PackedFloat32Array, remove, sarray("index"), varray());
 	bind_method(PackedFloat32Array, insert, sarray("at_index", "value"), varray());
@@ -1383,7 +1378,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat64Array, empty, sarray(), varray());
 	bind_method(PackedFloat64Array, set, sarray("index", "value"), varray());
 	bind_method(PackedFloat64Array, push_back, sarray("value"), varray());
-	bind_method(PackedFloat64Array, append, sarray("value"), varray());
 	bind_method(PackedFloat64Array, append_array, sarray("array"), varray());
 	bind_method(PackedFloat64Array, remove, sarray("index"), varray());
 	bind_method(PackedFloat64Array, insert, sarray("at_index", "value"), varray());
@@ -1400,7 +1394,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedStringArray, empty, sarray(), varray());
 	bind_method(PackedStringArray, set, sarray("index", "value"), varray());
 	bind_method(PackedStringArray, push_back, sarray("value"), varray());
-	bind_method(PackedStringArray, append, sarray("value"), varray());
 	bind_method(PackedStringArray, append_array, sarray("array"), varray());
 	bind_method(PackedStringArray, remove, sarray("index"), varray());
 	bind_method(PackedStringArray, insert, sarray("at_index", "value"), varray());
@@ -1417,7 +1410,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector2Array, empty, sarray(), varray());
 	bind_method(PackedVector2Array, set, sarray("index", "value"), varray());
 	bind_method(PackedVector2Array, push_back, sarray("value"), varray());
-	bind_method(PackedVector2Array, append, sarray("value"), varray());
 	bind_method(PackedVector2Array, append_array, sarray("array"), varray());
 	bind_method(PackedVector2Array, remove, sarray("index"), varray());
 	bind_method(PackedVector2Array, insert, sarray("at_index", "value"), varray());
@@ -1434,7 +1426,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector3Array, empty, sarray(), varray());
 	bind_method(PackedVector3Array, set, sarray("index", "value"), varray());
 	bind_method(PackedVector3Array, push_back, sarray("value"), varray());
-	bind_method(PackedVector3Array, append, sarray("value"), varray());
 	bind_method(PackedVector3Array, append_array, sarray("array"), varray());
 	bind_method(PackedVector3Array, remove, sarray("index"), varray());
 	bind_method(PackedVector3Array, insert, sarray("at_index", "value"), varray());
@@ -1451,7 +1442,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedColorArray, empty, sarray(), varray());
 	bind_method(PackedColorArray, set, sarray("index", "value"), varray());
 	bind_method(PackedColorArray, push_back, sarray("value"), varray());
-	bind_method(PackedColorArray, append, sarray("value"), varray());
 	bind_method(PackedColorArray, append_array, sarray("array"), varray());
 	bind_method(PackedColorArray, remove, sarray("index"), varray());
 	bind_method(PackedColorArray, insert, sarray("at_index", "value"), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -142,15 +142,6 @@
 				Constructs an array from a [PackedVector3Array].
 			</description>
 		</method>
-		<method name="append">
-			<return type="void">
-			</return>
-			<argument index="0" name="value" type="Variant">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -35,15 +35,6 @@
 				Constructs a new [PackedByteArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
-		<method name="append">
-			<return type="bool">
-			</return>
-			<argument index="0" name="value" type="int">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -35,15 +35,6 @@
 				Constructs a new [PackedColorArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
-		<method name="append">
-			<return type="bool">
-			</return>
-			<argument index="0" name="value" type="Color">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -36,15 +36,6 @@
 				Constructs a new [PackedFloat32Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
-		<method name="append">
-			<return type="bool">
-			</return>
-			<argument index="0" name="value" type="float">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -36,15 +36,6 @@
 				Constructs a new [PackedFloat64Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
-		<method name="append">
-			<return type="bool">
-			</return>
-			<argument index="0" name="value" type="float">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -36,15 +36,6 @@
 				Constructs a new [PackedInt32Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
-		<method name="append">
-			<return type="bool">
-			</return>
-			<argument index="0" name="value" type="int">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -36,15 +36,6 @@
 				Constructs a new [PackedInt64Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
-		<method name="append">
-			<return type="bool">
-			</return>
-			<argument index="0" name="value" type="int">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -36,15 +36,6 @@
 				Constructs a new [PackedStringArray]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
-		<method name="append">
-			<return type="bool">
-			</return>
-			<argument index="0" name="value" type="String">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -36,15 +36,6 @@
 				Constructs a new [PackedVector2Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
-		<method name="append">
-			<return type="bool">
-			</return>
-			<argument index="0" name="value" type="Vector2">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -35,15 +35,6 @@
 				Constructs a new [PackedVector3Array]. Optionally, you can pass in a generic [Array] that will be converted.
 			</description>
 		</method>
-		<method name="append">
-			<return type="bool">
-			</return>
-			<argument index="0" name="value" type="Vector3">
-			</argument>
-			<description>
-				Appends an element at the end of the array (alias of [method push_back]).
-			</description>
-		</method>
 		<method name="append_array">
 			<return type="void">
 			</return>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -191,7 +191,7 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 	for (int i = 0; i < r_filenames.size(); i++) {
 		String scene_name = r_filenames[i];
 		if (!scene_name_to_set_index.has(scene_name)) {
-			index_sets.append(Set<int>());
+			index_sets.push_back(Set<int>());
 			scene_name_to_set_index.insert(r_filenames[i], index_sets.size() - 1);
 		}
 		index_sets.write[scene_name_to_set_index[scene_name]].insert(i);
@@ -299,8 +299,8 @@ void EditorNode::_update_scene_tabs() {
 	Vector<String> disambiguated_scene_names;
 	Vector<String> full_path_names;
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
-		disambiguated_scene_names.append(editor_data.get_scene_title(i));
-		full_path_names.append(editor_data.get_scene_path(i));
+		disambiguated_scene_names.push_back(editor_data.get_scene_title(i));
+		full_path_names.push_back(editor_data.get_scene_path(i));
 	}
 
 	disambiguate_filenames(full_path_names, disambiguated_scene_names);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3016,11 +3016,11 @@ bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const
 	for (int i = 0; i < size; i++) {
 		String at = allowed_types[i].strip_edges();
 		if (at == "StandardMaterial3D") {
-			allowed_types.append("Texture2D");
+			allowed_types.push_back("Texture2D");
 		} else if (at == "ShaderMaterial") {
-			allowed_types.append("Shader");
+			allowed_types.push_back("Shader");
 		} else if (at == "Font") {
-			allowed_types.append("FontData");
+			allowed_types.push_back("FontData");
 		}
 	}
 

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -48,7 +48,7 @@ Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<Str
 
 		// Add user's extracted translatable messages.
 		for (int i = 0; i < ids.size(); i++) {
-			r_ids->append(ids[i]);
+			r_ids->push_back(ids[i]);
 		}
 
 		// Add user's collected translatable messages with context or plurals.
@@ -60,7 +60,7 @@ Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<Str
 			id_ctx_plural.push_back(arr[0]);
 			id_ctx_plural.push_back(arr[1]);
 			id_ctx_plural.push_back(arr[2]);
-			r_ids_ctx_plural->append(id_ctx_plural);
+			r_ids_ctx_plural->push_back(id_ctx_plural);
 		}
 		return OK;
 	} else {

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -316,12 +316,12 @@ void LocalizationEditor::_translation_filter_option_changed() {
 
 		if (f_locales_all.size() != 2) {
 			f_locales_all.clear();
-			f_locales_all.append(sel_id);
-			f_locales_all.append(Array());
+			f_locales_all.push_back(sel_id);
+			f_locales_all.push_back(Array());
 		}
 	} else {
-		f_locales_all.append(sel_id);
-		f_locales_all.append(Array());
+		f_locales_all.push_back(sel_id);
+		f_locales_all.push_back(Array());
 	}
 
 	Array f_locales = f_locales_all[1];
@@ -329,7 +329,7 @@ void LocalizationEditor::_translation_filter_option_changed() {
 
 	if (checked) {
 		if (l_idx == -1) {
-			f_locales.append(locale);
+			f_locales.push_back(locale);
 		}
 	} else {
 		if (l_idx != -1) {
@@ -361,14 +361,14 @@ void LocalizationEditor::_translation_filter_mode_changed(int p_mode) {
 
 		if (f_locales_all.size() != 2) {
 			f_locales_all.clear();
-			f_locales_all.append(sel_id);
-			f_locales_all.append(Array());
+			f_locales_all.push_back(sel_id);
+			f_locales_all.push_back(Array());
 		} else {
 			f_locales_all[0] = sel_id;
 		}
 	} else {
-		f_locales_all.append(sel_id);
-		f_locales_all.append(Array());
+		f_locales_all.push_back(sel_id);
+		f_locales_all.push_back(Array());
 	}
 
 	undo_redo->create_action(TTR("Changed Locale Filter Mode"));
@@ -482,8 +482,8 @@ void LocalizationEditor::update_translations() {
 		}
 	}
 	if (is_arr_empty) {
-		l_filter_all.append(0);
-		l_filter_all.append(Array());
+		l_filter_all.push_back(0);
+		l_filter_all.push_back(Array());
 		translation_locale_filter_mode->select(0);
 	}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1954,8 +1954,8 @@ void ScriptEditor::_update_script_names() {
 		Vector<String> disambiguated_script_names;
 		Vector<String> full_script_paths;
 		for (int j = 0; j < sedata.size(); j++) {
-			disambiguated_script_names.append(sedata[j].name.replace("(*)", ""));
-			full_script_paths.append(sedata[j].tooltip);
+			disambiguated_script_names.push_back(sedata[j].name.replace("(*)", ""));
+			full_script_paths.push_back(sedata[j].tooltip);
 		}
 
 		EditorNode::disambiguate_filenames(full_script_paths, disambiguated_script_names);

--- a/modules/gdnative/gdnative/array.cpp
+++ b/modules/gdnative/gdnative/array.cpp
@@ -198,12 +198,6 @@ const godot_variant GDAPI *godot_array_operator_index_const(const godot_array *p
 	return (const godot_variant *)&self->operator[](p_idx);
 }
 
-void GDAPI godot_array_append(godot_array *p_self, const godot_variant *p_value) {
-	Array *self = (Array *)p_self;
-	Variant *val = (Variant *)p_value;
-	self->append(*val);
-}
-
 void GDAPI godot_array_clear(godot_array *p_self) {
 	Array *self = (Array *)p_self;
 	self->clear();

--- a/modules/gdnative/gdnative/packed_arrays.cpp
+++ b/modules/gdnative/gdnative/packed_arrays.cpp
@@ -89,11 +89,6 @@ uint8_t GDAPI *godot_packed_byte_array_ptrw(godot_packed_byte_array *p_self) {
 	return self->ptrw();
 }
 
-void GDAPI godot_packed_byte_array_append(godot_packed_byte_array *p_self, const uint8_t p_data) {
-	Vector<uint8_t> *self = (Vector<uint8_t> *)p_self;
-	self->push_back(p_data);
-}
-
 void GDAPI godot_packed_byte_array_append_array(godot_packed_byte_array *p_self, const godot_packed_byte_array *p_array) {
 	Vector<uint8_t> *self = (Vector<uint8_t> *)p_self;
 	Vector<uint8_t> *array = (Vector<uint8_t> *)p_array;
@@ -191,11 +186,6 @@ const int32_t GDAPI *godot_packed_int32_array_ptr(const godot_packed_int32_array
 int32_t GDAPI *godot_packed_int32_array_ptrw(godot_packed_int32_array *p_self) {
 	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
 	return self->ptrw();
-}
-
-void GDAPI godot_packed_int32_array_append(godot_packed_int32_array *p_self, const int32_t p_data) {
-	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
-	self->push_back(p_data);
 }
 
 void GDAPI godot_packed_int32_array_append_array(godot_packed_int32_array *p_self, const godot_packed_int32_array *p_array) {
@@ -297,11 +287,6 @@ int64_t GDAPI *godot_packed_int64_array_ptrw(godot_packed_int64_array *p_self) {
 	return self->ptrw();
 }
 
-void GDAPI godot_packed_int64_array_append(godot_packed_int64_array *p_self, const int64_t p_data) {
-	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
-	self->push_back(p_data);
-}
-
 void GDAPI godot_packed_int64_array_append_array(godot_packed_int64_array *p_self, const godot_packed_int64_array *p_array) {
 	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
 	Vector<int64_t> *array = (Vector<int64_t> *)p_array;
@@ -399,11 +384,6 @@ const float GDAPI *godot_packed_float32_array_ptr(const godot_packed_float32_arr
 float GDAPI *godot_packed_float32_array_ptrw(godot_packed_float32_array *p_self) {
 	Vector<float> *self = (Vector<float> *)p_self;
 	return self->ptrw();
-}
-
-void GDAPI godot_packed_float32_array_append(godot_packed_float32_array *p_self, const float p_data) {
-	Vector<float> *self = (Vector<float> *)p_self;
-	self->push_back(p_data);
 }
 
 void GDAPI godot_packed_float32_array_append_array(godot_packed_float32_array *p_self, const godot_packed_float32_array *p_array) {
@@ -505,11 +485,6 @@ double GDAPI *godot_packed_float64_array_ptrw(godot_packed_float64_array *p_self
 	return self->ptrw();
 }
 
-void GDAPI godot_packed_float64_array_append(godot_packed_float64_array *p_self, const double p_data) {
-	Vector<double> *self = (Vector<double> *)p_self;
-	self->push_back(p_data);
-}
-
 void GDAPI godot_packed_float64_array_append_array(godot_packed_float64_array *p_self, const godot_packed_float64_array *p_array) {
 	Vector<double> *self = (Vector<double> *)p_self;
 	Vector<double> *array = (Vector<double> *)p_array;
@@ -607,12 +582,6 @@ const godot_string GDAPI *godot_packed_string_array_ptr(const godot_packed_strin
 godot_string GDAPI *godot_packed_string_array_ptrw(godot_packed_string_array *p_self) {
 	Vector<String> *self = (Vector<String> *)p_self;
 	return (godot_string *)self->ptrw();
-}
-
-void GDAPI godot_packed_string_array_append(godot_packed_string_array *p_self, const godot_string *p_data) {
-	Vector<String> *self = (Vector<String> *)p_self;
-	String &s = *(String *)p_data;
-	self->push_back(s);
 }
 
 void GDAPI godot_packed_string_array_append_array(godot_packed_string_array *p_self, const godot_packed_string_array *p_array) {
@@ -722,12 +691,6 @@ godot_vector2 GDAPI *godot_packed_vector2_array_ptrw(godot_packed_vector2_array 
 	return (godot_vector2 *)self->ptrw();
 }
 
-void GDAPI godot_packed_vector2_array_append(godot_packed_vector2_array *p_self, const godot_vector2 *p_data) {
-	Vector<Vector2> *self = (Vector<Vector2> *)p_self;
-	Vector2 &s = *(Vector2 *)p_data;
-	self->push_back(s);
-}
-
 void GDAPI godot_packed_vector2_array_append_array(godot_packed_vector2_array *p_self, const godot_packed_vector2_array *p_array) {
 	Vector<Vector2> *self = (Vector<Vector2> *)p_self;
 	Vector<Vector2> *array = (Vector<Vector2> *)p_array;
@@ -832,12 +795,6 @@ const godot_vector2i GDAPI *godot_packed_vector2i_array_ptr(const godot_packed_v
 godot_vector2i GDAPI *godot_packed_vector2i_array_ptrw(godot_packed_vector2i_array *p_self) {
 	Vector<Vector2i> *self = (Vector<Vector2i> *)p_self;
 	return (godot_vector2i *)self->ptrw();
-}
-
-void GDAPI godot_packed_vector2i_array_append(godot_packed_vector2i_array *p_self, const godot_vector2i *p_data) {
-	Vector<Vector2i> *self = (Vector<Vector2i> *)p_self;
-	Vector2i &s = *(Vector2i *)p_data;
-	self->push_back(s);
 }
 
 void GDAPI godot_packed_vector2i_array_append_array(godot_packed_vector2i_array *p_self, const godot_packed_vector2i_array *p_array) {
@@ -946,12 +903,6 @@ godot_vector3 GDAPI *godot_packed_vector3_array_ptrw(godot_packed_vector3_array 
 	return (godot_vector3 *)self->ptrw();
 }
 
-void GDAPI godot_packed_vector3_array_append(godot_packed_vector3_array *p_self, const godot_vector3 *p_data) {
-	Vector<Vector3> *self = (Vector<Vector3> *)p_self;
-	Vector3 &s = *(Vector3 *)p_data;
-	self->push_back(s);
-}
-
 void GDAPI godot_packed_vector3_array_append_array(godot_packed_vector3_array *p_self, const godot_packed_vector3_array *p_array) {
 	Vector<Vector3> *self = (Vector<Vector3> *)p_self;
 	Vector<Vector3> *array = (Vector<Vector3> *)p_array;
@@ -1056,12 +1007,6 @@ const godot_color GDAPI *godot_packed_color_array_ptr(const godot_packed_color_a
 godot_color GDAPI *godot_packed_color_array_ptrw(godot_packed_color_array *p_self) {
 	Vector<Color> *self = (Vector<Color> *)p_self;
 	return (godot_color *)self->ptrw();
-}
-
-void GDAPI godot_packed_color_array_append(godot_packed_color_array *p_self, const godot_color *p_data) {
-	Vector<Color> *self = (Vector<Color> *)p_self;
-	Color &s = *(Color *)p_data;
-	self->push_back(s);
 }
 
 void GDAPI godot_packed_color_array_append_array(godot_packed_color_array *p_self, const godot_packed_color_array *p_array) {

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -349,14 +349,6 @@
         ]
       },
       {
-        "name": "godot_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_variant *", "p_value"]
-        ]
-      },
-      {
         "name": "godot_array_clear",
         "return_type": "void",
         "arguments": [
@@ -1654,14 +1646,6 @@
         ]
       },
       {
-        "name": "godot_packed_byte_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"],
-          ["const uint8_t", "p_data"]
-        ]
-      },
-      {
         "name": "godot_packed_byte_array_append_array",
         "return_type": "void",
         "arguments": [
@@ -1797,14 +1781,6 @@
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_int32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"],
-          ["const int32_t", "p_data"]
         ]
       },
       {
@@ -1946,14 +1922,6 @@
         ]
       },
       {
-        "name": "godot_packed_int64_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int64_array *", "p_self"],
-          ["const int64_t", "p_data"]
-        ]
-      },
-      {
         "name": "godot_packed_int64_array_append_array",
         "return_type": "void",
         "arguments": [
@@ -2089,14 +2057,6 @@
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_float32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"],
-          ["const float", "p_data"]
         ]
       },
       {
@@ -2238,14 +2198,6 @@
         ]
       },
       {
-        "name": "godot_packed_float64_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float64_array *", "p_self"],
-          ["const double", "p_data"]
-        ]
-      },
-      {
         "name": "godot_packed_float64_array_append_array",
         "return_type": "void",
         "arguments": [
@@ -2381,14 +2333,6 @@
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_string_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"],
-          ["const godot_string *", "p_data"]
         ]
       },
       {
@@ -2530,14 +2474,6 @@
         ]
       },
       {
-        "name": "godot_packed_vector2_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"],
-          ["const godot_vector2 *", "p_data"]
-        ]
-      },
-      {
         "name": "godot_packed_vector2_array_append_array",
         "return_type": "void",
         "arguments": [
@@ -2673,14 +2609,6 @@
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_vector2i_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2i_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2i_array *", "p_self"],
-          ["const godot_vector2i *", "p_data"]
         ]
       },
       {
@@ -2822,14 +2750,6 @@
         ]
       },
       {
-        "name": "godot_packed_vector3_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"],
-          ["const godot_vector3 *", "p_data"]
-        ]
-      },
-      {
         "name": "godot_packed_vector3_array_append_array",
         "return_type": "void",
         "arguments": [
@@ -2965,14 +2885,6 @@
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_color_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "p_self"],
-          ["const godot_color *", "p_data"]
         ]
       },
       {
@@ -7950,14 +7862,6 @@
           "return_type": "godot_bool",
           "arguments": [
             ["const godot_packed_glyph_array *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_packed_glyph_array_append",
-          "return_type": "void",
-          "arguments": [
-            ["godot_packed_glyph_array *", "p_self"],
-            ["const godot_glyph *", "p_data"]
           ]
         },
         {

--- a/modules/gdnative/gdnative_library_singleton_editor.cpp
+++ b/modules/gdnative/gdnative_library_singleton_editor.cpp
@@ -80,7 +80,7 @@ void GDNativeLibrarySingletonEditor::_discover_singletons() {
 		if (!current_files.has(E->get())) {
 			changed = true;
 		}
-		files.append(E->get());
+		files.push_back(E->get());
 	}
 
 	// Check for removed files

--- a/modules/gdnative/include/gdnative/array.h
+++ b/modules/gdnative/include/gdnative/array.h
@@ -81,8 +81,6 @@ godot_variant GDAPI *godot_array_operator_index(godot_array *p_self, const godot
 
 const godot_variant GDAPI *godot_array_operator_index_const(const godot_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_array_append(godot_array *p_self, const godot_variant *p_value);
-
 void GDAPI godot_array_clear(godot_array *p_self);
 
 godot_int GDAPI godot_array_count(const godot_array *p_self, const godot_variant *p_value);

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -172,8 +172,6 @@ void GDAPI godot_packed_byte_array_new_with_array(godot_packed_byte_array *r_des
 const uint8_t GDAPI *godot_packed_byte_array_ptr(const godot_packed_byte_array *p_self);
 uint8_t GDAPI *godot_packed_byte_array_ptrw(godot_packed_byte_array *p_self);
 
-void GDAPI godot_packed_byte_array_append(godot_packed_byte_array *p_self, const uint8_t p_data);
-
 void GDAPI godot_packed_byte_array_append_array(godot_packed_byte_array *p_self, const godot_packed_byte_array *p_array);
 
 godot_error GDAPI godot_packed_byte_array_insert(godot_packed_byte_array *p_self, const godot_int p_idx, const uint8_t p_data);
@@ -207,8 +205,6 @@ void GDAPI godot_packed_int32_array_new_with_array(godot_packed_int32_array *r_d
 
 const int32_t GDAPI *godot_packed_int32_array_ptr(const godot_packed_int32_array *p_self);
 int32_t GDAPI *godot_packed_int32_array_ptrw(godot_packed_int32_array *p_self);
-
-void GDAPI godot_packed_int32_array_append(godot_packed_int32_array *p_self, const int32_t p_data);
 
 void GDAPI godot_packed_int32_array_append_array(godot_packed_int32_array *p_self, const godot_packed_int32_array *p_array);
 
@@ -244,8 +240,6 @@ void GDAPI godot_packed_int64_array_new_with_array(godot_packed_int64_array *r_d
 const int64_t GDAPI *godot_packed_int64_array_ptr(const godot_packed_int64_array *p_self);
 int64_t GDAPI *godot_packed_int64_array_ptrw(godot_packed_int64_array *p_self);
 
-void GDAPI godot_packed_int64_array_append(godot_packed_int64_array *p_self, const int64_t p_data);
-
 void GDAPI godot_packed_int64_array_append_array(godot_packed_int64_array *p_self, const godot_packed_int64_array *p_array);
 
 godot_error GDAPI godot_packed_int64_array_insert(godot_packed_int64_array *p_self, const godot_int p_idx, const int64_t p_data);
@@ -279,8 +273,6 @@ void GDAPI godot_packed_float32_array_new_with_array(godot_packed_float32_array 
 
 const float GDAPI *godot_packed_float32_array_ptr(const godot_packed_float32_array *p_self);
 float GDAPI *godot_packed_float32_array_ptrw(godot_packed_float32_array *p_self);
-
-void GDAPI godot_packed_float32_array_append(godot_packed_float32_array *p_self, const float p_data);
 
 void GDAPI godot_packed_float32_array_append_array(godot_packed_float32_array *p_self, const godot_packed_float32_array *p_array);
 
@@ -316,8 +308,6 @@ void GDAPI godot_packed_float64_array_new_with_array(godot_packed_float64_array 
 const double GDAPI *godot_packed_float64_array_ptr(const godot_packed_float64_array *p_self);
 double GDAPI *godot_packed_float64_array_ptrw(godot_packed_float64_array *p_self);
 
-void GDAPI godot_packed_float64_array_append(godot_packed_float64_array *p_self, const double p_data);
-
 void GDAPI godot_packed_float64_array_append_array(godot_packed_float64_array *p_self, const godot_packed_float64_array *p_array);
 
 godot_error GDAPI godot_packed_float64_array_insert(godot_packed_float64_array *p_self, const godot_int p_idx, const double p_data);
@@ -351,8 +341,6 @@ void GDAPI godot_packed_string_array_new_with_array(godot_packed_string_array *r
 
 const godot_string GDAPI *godot_packed_string_array_ptr(const godot_packed_string_array *p_self);
 godot_string GDAPI *godot_packed_string_array_ptrw(godot_packed_string_array *p_self);
-
-void GDAPI godot_packed_string_array_append(godot_packed_string_array *p_self, const godot_string *p_data);
 
 void GDAPI godot_packed_string_array_append_array(godot_packed_string_array *p_self, const godot_packed_string_array *p_array);
 
@@ -388,8 +376,6 @@ void GDAPI godot_packed_vector2_array_new_with_array(godot_packed_vector2_array 
 const godot_vector2 GDAPI *godot_packed_vector2_array_ptr(const godot_packed_vector2_array *p_self);
 godot_vector2 GDAPI *godot_packed_vector2_array_ptrw(godot_packed_vector2_array *p_self);
 
-void GDAPI godot_packed_vector2_array_append(godot_packed_vector2_array *p_self, const godot_vector2 *p_data);
-
 void GDAPI godot_packed_vector2_array_append_array(godot_packed_vector2_array *p_self, const godot_packed_vector2_array *p_array);
 
 godot_error GDAPI godot_packed_vector2_array_insert(godot_packed_vector2_array *p_self, const godot_int p_idx, const godot_vector2 *p_data);
@@ -423,8 +409,6 @@ void GDAPI godot_packed_vector2i_array_new_with_array(godot_packed_vector2i_arra
 
 const godot_vector2i GDAPI *godot_packed_vector2i_array_ptr(const godot_packed_vector2i_array *p_self);
 godot_vector2i GDAPI *godot_packed_vector2i_array_ptrw(godot_packed_vector2i_array *p_self);
-
-void GDAPI godot_packed_vector2i_array_append(godot_packed_vector2i_array *p_self, const godot_vector2i *p_data);
 
 void GDAPI godot_packed_vector2i_array_append_array(godot_packed_vector2i_array *p_self, const godot_packed_vector2i_array *p_array);
 
@@ -460,8 +444,6 @@ void GDAPI godot_packed_vector3_array_new_with_array(godot_packed_vector3_array 
 const godot_vector3 GDAPI *godot_packed_vector3_array_ptr(const godot_packed_vector3_array *p_self);
 godot_vector3 GDAPI *godot_packed_vector3_array_ptrw(godot_packed_vector3_array *p_self);
 
-void GDAPI godot_packed_vector3_array_append(godot_packed_vector3_array *p_self, const godot_vector3 *p_data);
-
 void GDAPI godot_packed_vector3_array_append_array(godot_packed_vector3_array *p_self, const godot_packed_vector3_array *p_array);
 
 godot_error GDAPI godot_packed_vector3_array_insert(godot_packed_vector3_array *p_self, const godot_int p_idx, const godot_vector3 *p_data);
@@ -495,8 +477,6 @@ void GDAPI godot_packed_color_array_new_with_array(godot_packed_color_array *r_d
 
 const godot_color GDAPI *godot_packed_color_array_ptr(const godot_packed_color_array *p_self);
 godot_color GDAPI *godot_packed_color_array_ptrw(godot_packed_color_array *p_self);
-
-void GDAPI godot_packed_color_array_append(godot_packed_color_array *p_self, const godot_color *p_data);
 
 void GDAPI godot_packed_color_array_append_array(godot_packed_color_array *p_self, const godot_packed_color_array *p_array);
 

--- a/modules/gdnative/include/text/godot_text.h
+++ b/modules/gdnative/include/text/godot_text.h
@@ -195,8 +195,6 @@ void GDAPI godot_packed_glyph_array_new_copy(godot_packed_glyph_array *r_dest, c
 const godot_glyph GDAPI *godot_packed_glyph_array_ptr(const godot_packed_glyph_array *p_self);
 godot_glyph GDAPI *godot_packed_glyph_array_ptrw(godot_packed_glyph_array *p_self);
 
-void GDAPI godot_packed_glyph_array_append(godot_packed_glyph_array *p_self, const godot_glyph *p_data);
-
 void GDAPI godot_packed_glyph_array_append_array(godot_packed_glyph_array *p_self, const godot_packed_glyph_array *p_array);
 
 godot_error GDAPI godot_packed_glyph_array_insert(godot_packed_glyph_array *p_self, const godot_int p_idx, const godot_glyph *p_data);

--- a/modules/gdnative/text/text_server_gdnative.cpp
+++ b/modules/gdnative/text/text_server_gdnative.cpp
@@ -770,12 +770,6 @@ godot_glyph GDAPI *godot_packed_glyph_array_ptrw(godot_packed_glyph_array *p_sel
 	return (godot_glyph *)self->ptrw();
 }
 
-void GDAPI godot_packed_glyph_array_append(godot_packed_glyph_array *p_self, const godot_glyph *p_data) {
-	Vector<TextServer::Glyph> *self = (Vector<TextServer::Glyph> *)p_self;
-	TextServer::Glyph &s = *(TextServer::Glyph *)p_data;
-	self->push_back(s);
-}
-
 void GDAPI godot_packed_glyph_array_append_array(godot_packed_glyph_array *p_self, const godot_packed_glyph_array *p_array) {
 	Vector<TextServer::Glyph> *self = (Vector<TextServer::Glyph> *)p_self;
 	Vector<TextServer::Glyph> *array = (Vector<TextServer::Glyph> *)p_array;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -412,7 +412,7 @@ void GDScript::_add_doc(const DocData::ClassDoc &p_inner_class) {
 				break;
 			}
 		}
-		docs.append(p_inner_class);
+		docs.push_back(p_inner_class);
 	}
 }
 
@@ -587,7 +587,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call) {
 	if (!p_recursive_call) {
 		base_caches.clear();
 	}
-	base_caches.append(this);
+	base_caches.push_back(this);
 
 	bool changed = false;
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2026,7 +2026,7 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 		DocData::TutorialDoc td;
 		td.title = p_class->doc_tutorials[i].first;
 		td.link = p_class->doc_tutorials[i].second;
-		p_script->doc_tutorials.append(td);
+		p_script->doc_tutorials.push_back(td);
 	}
 #endif
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2886,7 +2886,7 @@ void GDScriptParser::get_class_doc_comment(int p_line, String &p_brief, String &
 				p_desc = (p_desc.length() == 0) ? doc_line : p_desc + line_join + doc_line;
 				break;
 			case TUTORIALS:
-				p_tutorials.append(Pair<String, String>(title, link));
+				p_tutorials.push_back(Pair<String, String>(title, link));
 				break;
 			case DONE:
 				return;

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -675,7 +675,7 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 	class_api["path"] = path;
 	Array extends_class;
 	for (int i = 0; i < p_class->extends.size(); i++) {
-		extends_class.append(String(p_class->extends[i]));
+		extends_class.push_back(String(p_class->extends[i]));
 	}
 	class_api["extends_class"] = extends_class;
 	class_api["extends_file"] = String(p_class->extends_path);
@@ -756,7 +756,7 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 				api["name"] = m.signal->identifier->name;
 				Array pars;
 				for (int j = 0; j < m.signal->parameters.size(); j++) {
-					pars.append(String(m.signal->parameters[i]->identifier->name));
+					pars.push_back(String(m.signal->parameters[i]->identifier->name));
 				}
 				api["arguments"] = pars;
 				if (const lsp::DocumentSymbol *symbol = get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(m.signal->start_line))) {
@@ -767,9 +767,9 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 			} break;
 			case ClassNode::Member::FUNCTION: {
 				if (m.function->is_static) {
-					static_functions.append(dump_function_api(m.function));
+					static_functions.push_back(dump_function_api(m.function));
 				} else {
-					methods.append(dump_function_api(m.function));
+					methods.push_back(dump_function_api(m.function));
 				}
 			} break;
 			case ClassNode::Member::UNDEFINED:

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -91,13 +91,13 @@ Array RegExMatch::get_strings() const {
 		int start = data[i].start;
 
 		if (start == -1) {
-			result.append(String());
+			result.push_back(String());
 			continue;
 		}
 
 		int length = data[i].end - start;
 
-		result.append(subject.substr(start, length));
+		result.push_back(subject.substr(start, length));
 	}
 
 	return result;
@@ -356,7 +356,7 @@ Array RegEx::get_names() const {
 	for (uint32_t i = 0; i < count; i++) {
 		String name = &table[i * entry_size + 1];
 		if (result.find(name) < 0) {
-			result.append(name);
+			result.push_back(name);
 		}
 	}
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -125,7 +125,7 @@ TypedArray<PhysicsBody2D> PhysicsBody2D::get_collision_exceptions() {
 		ObjectID instance_id = PhysicsServer2D::get_singleton()->body_get_object_instance_id(body);
 		Object *obj = ObjectDB::get_instance(instance_id);
 		PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(obj);
-		ret.append(physics_body);
+		ret.push_back(physics_body);
 	}
 	return ret;
 }

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -63,7 +63,7 @@ void CollisionShape3D::make_convex_from_siblings() {
 					if (!a.empty()) {
 						Vector<Vector3> v = a[RenderingServer::ARRAY_VERTEX];
 						for (int k = 0; k < v.size(); k++) {
-							vertices.append(mi->get_transform().xform(v[k]));
+							vertices.push_back(mi->get_transform().xform(v[k]));
 						}
 					}
 				}

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -110,7 +110,7 @@ TypedArray<PhysicsBody3D> PhysicsBody3D::get_collision_exceptions() {
 		ObjectID instance_id = PhysicsServer3D::get_singleton()->body_get_object_instance_id(body);
 		Object *obj = ObjectDB::get_instance(instance_id);
 		PhysicsBody3D *physics_body = Object::cast_to<PhysicsBody3D>(obj);
-		ret.append(physics_body);
+		ret.push_back(physics_body);
 	}
 	return ret;
 }

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -569,7 +569,7 @@ Array SoftBody3D::get_collision_exceptions() {
 		ObjectID instance_id = PhysicsServer3D::get_singleton()->body_get_object_instance_id(body);
 		Object *obj = ObjectDB::get_instance(instance_id);
 		PhysicsBody3D *physics_body = Object::cast_to<PhysicsBody3D>(obj);
-		ret.append(physics_body);
+		ret.push_back(physics_body);
 	}
 	return ret;
 }

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -151,7 +151,7 @@ Array CodeEdit::get_breakpointed_lines() const {
 	Array ret;
 	for (int i = 0; i < get_line_count(); i++) {
 		if (is_line_breakpointed(i)) {
-			ret.append(i);
+			ret.push_back(i);
 		}
 	}
 	return ret;
@@ -180,7 +180,7 @@ Array CodeEdit::get_bookmarked_lines() const {
 	Array ret;
 	for (int i = 0; i < get_line_count(); i++) {
 		if (is_line_bookmarked(i)) {
-			ret.append(i);
+			ret.push_back(i);
 		}
 	}
 	return ret;
@@ -209,7 +209,7 @@ Array CodeEdit::get_executing_lines() const {
 	Array ret;
 	for (int i = 0; i < get_line_count(); i++) {
 		if (is_line_executing(i)) {
-			ret.append(i);
+			ret.push_back(i);
 		}
 	}
 	return ret;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3898,24 +3898,24 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 
 		for (int j = 0; j < values.size(); j++) {
 			if (!color.search(values[j]).is_null()) {
-				a.append(Color::html(values[j]));
+				a.push_back(Color::html(values[j]));
 			} else if (!nodepath.search(values[j]).is_null()) {
 				if (values[j].begins_with("$")) {
 					String v = values[j].substr(1, values[j].length());
-					a.append(NodePath(v));
+					a.push_back(NodePath(v));
 				}
 			} else if (!boolean.search(values[j]).is_null()) {
 				if (values[j] == "true") {
-					a.append(true);
+					a.push_back(true);
 				} else if (values[j] == "false") {
-					a.append(false);
+					a.push_back(false);
 				}
 			} else if (!decimal.search(values[j]).is_null()) {
-				a.append(values[j].to_float());
+				a.push_back(values[j].to_float());
 			} else if (!numerical.search(values[j]).is_null()) {
-				a.append(values[j].to_int());
+				a.push_back(values[j].to_int());
 			} else {
-				a.append(values[j]);
+				a.push_back(values[j]);
 			}
 		}
 #endif

--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -366,13 +366,13 @@ void TextureProgress::_notification(int p_what) {
 								}
 
 								float end = start + direction * val;
-								pts.append(start);
-								pts.append(end);
+								pts.push_back(start);
+								pts.push_back(end);
 								float from = MIN(start, end);
 								float to = MAX(start, end);
 								for (int i = 0; i < 12; i++) {
 									if (corners[i] > from && corners[i] < to) {
-										pts.append(corners[i]);
+										pts.push_back(corners[i]);
 									}
 								}
 								pts.sort();

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -1025,7 +1025,7 @@ void TileSet::_decompose_convex_shape(Ref<Shape2D> p_shape) {
 		for (int i = 0; i < decomp.size(); i++) {
 			Ref<ConvexPolygonShape2D> _convex = memnew(ConvexPolygonShape2D);
 			_convex->set_points(decomp[i]);
-			sub_shapes.append(_convex);
+			sub_shapes.push_back(_convex);
 		}
 		convex->set_meta("decomposed", sub_shapes);
 	} else {


### PR DESCRIPTION
This removes the `append()` alias, both internally and in the scripting/GDNative API. Most projects should be convertable easily by searching "append(" and replacing it with "push_back(".

See https://github.com/godotengine/godot/issues/16863#issuecomment-743298531.