### PR TITLE
Remove Generic6DOFJoint precision property

### DIFF
--- a/doc/classes/Generic6DOFJoint3D.xml
+++ b/doc/classes/Generic6DOFJoint3D.xml
@@ -348,8 +348,6 @@
 		</member>
 		<member name="linear_spring_z/stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
 		</member>
-		<member name="precision" type="int" setter="set_precision" getter="get_precision" default="1">
-		</member>
 	</members>
 	<constants>
 		<constant name="PARAM_LINEAR_LOWER_LIMIT" value="0" enum="Param">

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -1463,22 +1463,6 @@ bool BulletPhysicsServer3D::generic_6dof_joint_get_flag(RID p_joint, Vector3::Ax
 	return generic_6dof_joint->get_flag(p_axis, p_flag);
 }
 
-void BulletPhysicsServer3D::generic_6dof_joint_set_precision(RID p_joint, int p_precision) {
-	JointBullet *joint = joint_owner.getornull(p_joint);
-	ERR_FAIL_COND(!joint);
-	ERR_FAIL_COND(joint->get_type() != JOINT_6DOF);
-	Generic6DOFJointBullet *generic_6dof_joint = static_cast<Generic6DOFJointBullet *>(joint);
-	generic_6dof_joint->set_precision(p_precision);
-}
-
-int BulletPhysicsServer3D::generic_6dof_joint_get_precision(RID p_joint) {
-	JointBullet *joint = joint_owner.getornull(p_joint);
-	ERR_FAIL_COND_V(!joint, 0);
-	ERR_FAIL_COND_V(joint->get_type() != JOINT_6DOF, 0);
-	Generic6DOFJointBullet *generic_6dof_joint = static_cast<Generic6DOFJointBullet *>(joint);
-	return generic_6dof_joint->get_precision();
-}
-
 void BulletPhysicsServer3D::free(RID p_rid) {
 	if (shape_owner.owns(p_rid)) {
 		ShapeBullet *shape = shape_owner.getornull(p_rid);

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -376,9 +376,6 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag, bool p_enable) override;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag) override;
 
-	virtual void generic_6dof_joint_set_precision(RID p_joint, int precision) override;
-	virtual int generic_6dof_joint_get_precision(RID p_joint) override;
-
 	/* MISC */
 
 	virtual void free(RID p_rid) override;

--- a/modules/bullet/generic_6dof_joint_bullet.cpp
+++ b/modules/bullet/generic_6dof_joint_bullet.cpp
@@ -273,11 +273,3 @@ bool Generic6DOFJointBullet::get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6D
 	ERR_FAIL_INDEX_V(p_axis, 3, false);
 	return flags[p_axis][p_flag];
 }
-
-void Generic6DOFJointBullet::set_precision(int p_precision) {
-	sixDOFConstraint->setOverrideNumSolverIterations(MAX(1, p_precision));
-}
-
-int Generic6DOFJointBullet::get_precision() const {
-	return sixDOFConstraint->getOverrideNumSolverIterations();
-}

--- a/modules/bullet/generic_6dof_joint_bullet.h
+++ b/modules/bullet/generic_6dof_joint_bullet.h
@@ -68,9 +68,6 @@ public:
 
 	void set_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_value);
 	bool get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const;
-
-	void set_precision(int p_precision);
-	int get_precision() const;
 };
 
 #endif

--- a/scene/3d/physics_joint_3d.cpp
+++ b/scene/3d/physics_joint_3d.cpp
@@ -710,9 +710,6 @@ void Generic6DOFJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flag_z", "flag", "value"), &Generic6DOFJoint3D::set_flag_z);
 	ClassDB::bind_method(D_METHOD("get_flag_z", "flag"), &Generic6DOFJoint3D::get_flag_z);
 
-	ClassDB::bind_method(D_METHOD("set_precision", "precision"), &Generic6DOFJoint3D::set_precision);
-	ClassDB::bind_method(D_METHOD("get_precision"), &Generic6DOFJoint3D::get_precision);
-
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/upper_distance"), "set_param_x", "get_param_x", PARAM_LINEAR_UPPER_LIMIT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/lower_distance"), "set_param_x", "get_param_x", PARAM_LINEAR_LOWER_LIMIT);
@@ -800,8 +797,6 @@ void Generic6DOFJoint3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/stiffness"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_STIFFNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/damping"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/equilibrium_point"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
-
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "precision", PROPERTY_HINT_RANGE, "1,99999,1"), "set_precision", "get_precision");
 
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_LOWER_LIMIT);
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_UPPER_LIMIT);
@@ -919,14 +914,6 @@ void Generic6DOFJoint3D::set_flag_z(Flag p_flag, bool p_enabled) {
 bool Generic6DOFJoint3D::get_flag_z(Flag p_flag) const {
 	ERR_FAIL_INDEX_V(p_flag, FLAG_MAX, false);
 	return flags_z[p_flag];
-}
-
-void Generic6DOFJoint3D::set_precision(int p_precision) {
-	precision = p_precision;
-
-	PhysicsServer3D::get_singleton()->generic_6dof_joint_set_precision(
-			get_joint(),
-			precision);
 }
 
 RID Generic6DOFJoint3D::_configure_joint(PhysicsBody3D *body_a, PhysicsBody3D *body_b) {

--- a/scene/3d/physics_joint_3d.h
+++ b/scene/3d/physics_joint_3d.h
@@ -300,8 +300,6 @@ protected:
 	float params_z[PARAM_MAX];
 	bool flags_z[FLAG_MAX];
 
-	int precision = 1;
-
 	virtual RID _configure_joint(PhysicsBody3D *body_a, PhysicsBody3D *body_b) override;
 	static void _bind_methods();
 
@@ -323,11 +321,6 @@ public:
 
 	void set_flag_z(Flag p_flag, bool p_enabled);
 	bool get_flag_z(Flag p_flag) const;
-
-	void set_precision(int p_precision);
-	int get_precision() const {
-		return precision;
-	}
 
 	Generic6DOFJoint3D();
 };

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -346,9 +346,6 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) override;
 
-	virtual void generic_6dof_joint_set_precision(RID p_joint, int precision) override {}
-	virtual int generic_6dof_joint_get_precision(RID p_joint) override { return 0; }
-
 	virtual JointType joint_get_type(RID p_joint) const override;
 
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) override;

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -728,9 +728,6 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) = 0;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) = 0;
 
-	virtual void generic_6dof_joint_set_precision(RID p_joint, int precision) = 0;
-	virtual int generic_6dof_joint_get_precision(RID p_joint) = 0;
-
 	/* QUERY API */
 
 	enum AreaBodyStatus {


### PR DESCRIPTION
Fixes #42285

Currently, in Godot physics, the `Generic6DOFJoint` property is not used:
https://github.com/godotengine/godot/blob/ddbdafbcf1b9ef2b16987b8c89c1a9997b60c755/servers/physics_3d/physics_server_3d_sw.h#L349-L350
In Bullet physics, it is used to override the number of collision solver iterations:
https://github.com/godotengine/godot/blob/ddbdafbcf1b9ef2b16987b8c89c1a9997b60c755/modules/bullet/generic_6dof_joint_bullet.cpp#L277-L283
Controlling the number of solver iterations would be a useful joint property, but it's not specific to the Generic6DOFJoint. Furthermore, the default value in Bullet physics is 10 not 1:
https://github.com/godotengine/godot/blob/ddbdafbcf1b9ef2b16987b8c89c1a9997b60c755/thirdparty/bullet/BulletDynamics/ConstraintSolver/btContactSolverInfo.h#L83
Note: In Godot physics, it is hard-coded to 8:
https://github.com/godotengine/godot/blob/ddbdafbcf1b9ef2b16987b8c89c1a9997b60c755/servers/physics_3d/physics_server_3d_sw.cpp#L1291

Finally, as identified by @addmix in #42285, when using Bullet physics, setting the "precision" property in the Inspector to any value other than the default 1, results in an error, because it tries to set the value before the joint has been created:
```
ERROR: get: Condition "!p_rid.is_valid()" is true. Returned: __null
   At: ./core/rid.h:149.
ERROR: generic_6dof_joint_set_precision: Condition "!joint" is true.
   At: modules/bullet/bullet_physics_server.cpp:1476.
```

Since this property is not used (in Godot physics) unusable (in the Inspector with Bullet physics) would result in reduced "precision" if set to a value less than 10 (when using Bullet physics, and using a script to set the property on an existing Joint) this PR removes the precision property from Generic6DOFJoint.