### PR TITLE
Expose a `File.flush()` method to scripting

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1254,6 +1254,11 @@ Error _File::open(const String &p_path, ModeFlags p_mode_flags) {
 	return err;
 }
 
+void _File::flush() {
+	ERR_FAIL_COND_MSG(!f, "File must be opened before flushing.");
+	f->flush();
+}
+
 void _File::close() {
 	if (f) {
 		memdelete(f);
@@ -1547,6 +1552,7 @@ void _File::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open_compressed", "path", "mode_flags", "compression_mode"), &_File::open_compressed, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("open", "path", "flags"), &_File::open);
+	ClassDB::bind_method(D_METHOD("flush"), &_File::flush);
 	ClassDB::bind_method(D_METHOD("close"), &_File::close);
 	ClassDB::bind_method(D_METHOD("get_path"), &_File::get_path);
 	ClassDB::bind_method(D_METHOD("get_path_absolute"), &_File::get_path_absolute);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -386,6 +386,7 @@ public:
 	Error open_compressed(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode = COMPRESSION_FASTLZ);
 
 	Error open(const String &p_path, ModeFlags p_mode_flags); // open a file.
+	void flush(); // Flush a file (write its buffer to disk).
 	void close(); // Close a file.
 	bool is_open() const; // True when file is open.
 

--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -42,6 +42,7 @@
 		[/codeblocks]
 		In the example above, the file will be saved in the user data folder as specified in the [url=https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html]Data paths[/url] documentation.
 		[b]Note:[/b] To access project resources once exported, it is recommended to use [ResourceLoader] instead of the [File] API, as some files are converted to engine-specific formats and their original source files might not be present in the exported PCK package.
+		[b]Note:[/b] Files are automatically closed only if the process exits "normally" (such as by clicking the window manager's close button or pressing [b]Alt + F4[/b]). If you stop the project execution by pressing [b]F8[/b] while the project is running, the file won't be closed as the game process will be killed. You can work around this by calling [method flush] at regular intervals.
 	</description>
 	<tutorials>
 		<link title="File system">https://docs.godotengine.org/en/latest/getting_started/step_by_step/filesystem.html</link>
@@ -52,7 +53,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Closes the currently opened file.
+				Closes the currently opened file and prevents subsequent read/write operations. Use [method flush] to persist the data to disk without closing the file.
 			</description>
 		</method>
 		<method name="eof_reached" qualifiers="const">
@@ -71,6 +72,14 @@
 			<description>
 				Returns [code]true[/code] if the file exists in the given path.
 				[b]Note:[/b] Many resources types are imported (e.g. textures or sound files), and their source asset will not be included in the exported game, as only the imported version is used. See [method ResourceLoader.exists] for an alternative approach that takes resource remapping into account.
+			</description>
+		</method>
+		<method name="flush">
+			<return type="void">
+			</return>
+			<description>
+				Writes the file's buffer to disk. Flushing is automatically performed when the file is closed. This means you don't need to call [method flush] manually before closing a file using [method close]. Still, calling [method flush] can be used to ensure the data is safe even if the project crashes instead of being closed gracefully.
+				[b]Note:[/b] Only call [method flush] when you actually need it. Otherwise, it will decrease performance due to constant disk writes.
 			</description>
 		</method>
 		<method name="get_16" qualifiers="const">


### PR DESCRIPTION
Follow-up to #44393.

This can be used to ensure a file has its contents saved even if the project crashes or is killed by the user (among other use cases).

~~**Note:** I couldn't test this as I get "File must be opened before use." when trying to create a new file following the File code sample in the class reference, even with a vanilla `master` build.~~

**Edit:** Using `File.WRITE` instead of `File.READ_WRITE` works for testing.

See discussion in #29075.