### PR TITLE
Rename empty() to is_empty()

### DIFF
--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -135,7 +135,7 @@ void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_idle_ticks, ui
 
 void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Vector<String> p_breakpoints) {
 	register_uri_handler("tcp://", RemoteDebuggerPeerTCP::create); // TCP is the default protocol. Platforms/modules can add more.
-	if (p_uri.empty()) {
+	if (p_uri.is_empty()) {
 		return;
 	}
 	if (p_uri == "local://") {

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -117,7 +117,7 @@ struct LocalDebugger::ScriptsProfiler {
 void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	ScriptLanguage *script_lang = script_debugger->get_break_language();
 
-	if (!target_function.empty()) {
+	if (!target_function.is_empty()) {
 		String current_function = script_lang->debug_get_stack_level_function(0);
 		if (current_function != target_function) {
 			script_debugger->set_depth(0);
@@ -259,7 +259,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				String source = breakpoint.first;
 				int linenr = breakpoint.second;
 
-				if (source.empty()) {
+				if (source.is_empty()) {
 					continue;
 				}
 
@@ -285,7 +285,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				String source = breakpoint.first;
 				int linenr = breakpoint.second;
 
-				if (source.empty()) {
+				if (source.is_empty()) {
 					continue;
 				}
 
@@ -323,7 +323,7 @@ void LocalDebugger::print_variables(const List<String> &names, const List<Varian
 	for (const List<String>::Element *E = names.front(); E; E = E->next()) {
 		value = String(V->get());
 
-		if (variable_prefix.empty()) {
+		if (variable_prefix.is_empty()) {
 			print_line(E->get() + ": " + String(V->get()));
 		} else {
 			print_line(E->get() + ":");
@@ -359,7 +359,7 @@ void LocalDebugger::send_message(const String &p_message, const Array &p_args) {
 }
 
 void LocalDebugger::send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, ErrorHandlerType p_type) {
-	print_line("ERROR: '" + (p_descr.empty() ? p_err : p_descr) + "'");
+	print_line("ERROR: '" + (p_descr.is_empty() ? p_err : p_descr) + "'");
 }
 
 LocalDebugger::LocalDebugger() {

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -553,7 +553,7 @@ void RemoteDebugger::flush_output() {
 		for (int i = 0; i < output_strings.size(); i++) {
 			const OutputString &output_string = output_strings[i];
 			if (output_string.type == MESSAGE_TYPE_ERROR) {
-				if (!joined_log_strings.empty()) {
+				if (!joined_log_strings.is_empty()) {
 					strings.push_back(String("\n").join(joined_log_strings));
 					types.push_back(MESSAGE_TYPE_LOG);
 					joined_log_strings.clear();
@@ -565,7 +565,7 @@ void RemoteDebugger::flush_output() {
 			}
 		}
 
-		if (!joined_log_strings.empty()) {
+		if (!joined_log_strings.is_empty()) {
 			strings.push_back(String("\n").join(joined_log_strings));
 			types.push_back(MESSAGE_TYPE_LOG);
 		}

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -806,7 +806,7 @@ void Input::accumulate_input_event(const Ref<InputEvent> &p_event) {
 		parse_input_event(p_event);
 		return;
 	}
-	if (!accumulated_events.empty() && accumulated_events.back()->get()->accumulate(p_event)) {
+	if (!accumulated_events.is_empty() && accumulated_events.back()->get()->accumulate(p_event)) {
 		return; //event was accumulated, exit
 	}
 

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -210,7 +210,7 @@ String InputEventWithModifiers::as_text() const {
 		mod_names.push_back(find_keycode_name(KEY_META));
 	}
 
-	if (!mod_names.empty()) {
+	if (!mod_names.is_empty()) {
 		return String("+").join(mod_names);
 	} else {
 		return "";

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -71,7 +71,7 @@ void InputMap::erase_action(const StringName &p_action) {
 Array InputMap::_get_actions() {
 	Array ret;
 	List<StringName> actions = get_actions();
-	if (actions.empty()) {
+	if (actions.is_empty()) {
 		return ret;
 	}
 
@@ -84,7 +84,7 @@ Array InputMap::_get_actions() {
 
 List<StringName> InputMap::get_actions() const {
 	List<StringName> actions = List<StringName>();
-	if (input_map.empty()) {
+	if (input_map.is_empty()) {
 		return actions;
 	}
 

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -67,7 +67,7 @@ void ConfigFile::set_value(const String &p_section, const String &p_key, const V
 			return; // ?
 		}
 		values[p_section].erase(p_key);
-		if (values[p_section].empty()) {
+		if (values[p_section].is_empty()) {
 			values.erase(p_section);
 		}
 

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -350,7 +350,7 @@ void FileAccessNetwork::_queue_page(int p_page) const {
 	if (p_page >= pages.size()) {
 		return;
 	}
-	if (pages[p_page].buffer.empty() && !pages[p_page].queued) {
+	if (pages[p_page].buffer.is_empty() && !pages[p_page].queued) {
 		FileAccessNetworkClient *nc = FileAccessNetworkClient::singleton;
 		{
 			MutexLock lock(nc->blockrequest_mutex);
@@ -386,7 +386,7 @@ int FileAccessNetwork::get_buffer(uint8_t *p_dst, int p_length) const {
 
 		if (page != last_page) {
 			buffer_mutex.lock();
-			if (pages[page].buffer.empty()) {
+			if (pages[page].buffer.is_empty()) {
 				waiting_on_page = page;
 				for (int j = 0; j < read_ahead; j++) {
 					_queue_page(page + j);

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -89,7 +89,7 @@ void PackedData::add_path(const String &pkg_path, const String &path, uint64_t o
 		}
 		String filename = path.get_file();
 		// Don't add as a file if the path points to a directory
-		if (!filename.empty()) {
+		if (!filename.is_empty()) {
 			cd->files.insert(filename);
 		}
 	}

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -375,7 +375,7 @@ Image::Image3DValidateError Image::validate_3d_image(Image::Format p_format, int
 			if (idx >= p_images.size()) {
 				return VALIDATE_3D_ERR_MISSING_IMAGES;
 			}
-			if (p_images[idx].is_null() || p_images[idx]->empty()) {
+			if (p_images[idx].is_null() || p_images[idx]->is_empty()) {
 				return VALIDATE_3D_ERR_IMAGE_EMPTY;
 			}
 			if (p_images[idx]->get_format() != p_format) {
@@ -1756,7 +1756,7 @@ Error Image::generate_mipmap_roughness(RoughnessChannel p_roughness_channel, con
 	double *normal_sat = nullptr; //summed area table for normalmap
 	int normal_w = 0, normal_h = 0;
 
-	ERR_FAIL_COND_V_MSG(p_normal_map.is_null() || p_normal_map->empty(), ERR_INVALID_PARAMETER, "Must provide a valid normalmap for roughness mipmaps");
+	ERR_FAIL_COND_V_MSG(p_normal_map.is_null() || p_normal_map->is_empty(), ERR_INVALID_PARAMETER, "Must provide a valid normalmap for roughness mipmaps");
 
 	Ref<Image> nm = p_normal_map->duplicate();
 	if (nm->is_compressed()) {
@@ -1950,7 +1950,7 @@ void Image::clear_mipmaps() {
 		return;
 	}
 
-	if (empty()) {
+	if (is_empty()) {
 		return;
 	}
 
@@ -1961,7 +1961,7 @@ void Image::clear_mipmaps() {
 	mipmaps = false;
 }
 
-bool Image::empty() const {
+bool Image::is_empty() const {
 	return (data.size() == 0);
 }
 
@@ -3090,7 +3090,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create", "width", "height", "use_mipmaps", "format"), &Image::_create_empty);
 	ClassDB::bind_method(D_METHOD("create_from_data", "width", "height", "use_mipmaps", "format", "data"), &Image::_create_from_data);
 
-	ClassDB::bind_method(D_METHOD("is_empty"), &Image::empty);
+	ClassDB::bind_method(D_METHOD("is_empty"), &Image::is_empty);
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &Image::load);
 	ClassDB::bind_method(D_METHOD("save_png", "path"), &Image::save_png);
@@ -3585,7 +3585,7 @@ Image::Image(const uint8_t *p_mem_png_jpg, int p_len) {
 		copy_internals_from(_png_mem_loader_func(p_mem_png_jpg, p_len));
 	}
 
-	if (empty() && _jpg_mem_loader_func) {
+	if (is_empty() && _jpg_mem_loader_func) {
 		copy_internals_from(_jpg_mem_loader_func(p_mem_png_jpg, p_len));
 	}
 }

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -285,7 +285,7 @@ public:
 	/**
 	 * returns true when the image is empty (0,0) in size
 	 */
-	bool empty() const;
+	bool is_empty() const;
 
 	Vector<uint8_t> get_data() const;
 

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -189,7 +189,7 @@ void IP::erase_resolve_item(ResolverID p_id) {
 void IP::clear_cache(const String &p_hostname) {
 	MutexLock lock(resolver->mutex);
 
-	if (p_hostname.empty()) {
+	if (p_hostname.is_empty()) {
 		resolver->cache.clear();
 	} else {
 		resolver->cache.erase(_IP_ResolverPrivate::get_cache_key(p_hostname, IP::TYPE_NONE));

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -47,7 +47,7 @@ const char *JSON::tk_name[TK_MAX] = {
 
 static String _make_indent(const String &p_indent, int p_size) {
 	String indent_text = "";
-	if (!p_indent.empty()) {
+	if (!p_indent.is_empty()) {
 		for (int i = 0; i < p_size; i++) {
 			indent_text += p_indent;
 		}
@@ -59,7 +59,7 @@ String JSON::_print_var(const Variant &p_var, const String &p_indent, int p_cur_
 	String colon = ":";
 	String end_statement = "";
 
-	if (!p_indent.empty()) {
+	if (!p_indent.is_empty()) {
 		colon += " ";
 		end_statement += "\n";
 	}

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -53,7 +53,7 @@ void PCKPacker::_bind_methods() {
 }
 
 Error PCKPacker::pck_start(const String &p_file, int p_alignment, const String &p_key, bool p_encrypt_directory) {
-	ERR_FAIL_COND_V_MSG((p_key.empty() || !p_key.is_valid_hex_number(false) || p_key.length() != 64), ERR_CANT_CREATE, "Invalid Encryption Key (must be 64 characters long).");
+	ERR_FAIL_COND_V_MSG((p_key.is_empty() || !p_key.is_valid_hex_number(false) || p_key.length() != 64), ERR_CANT_CREATE, "Invalid Encryption Key (must be 64 characters long).");
 
 	String _key = p_key.to_lower();
 	key.resize(32);

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -70,7 +70,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 		is_eof = f->eof_reached();
 
 		// If we reached last line and it's not a content line, break, otherwise let processing that last loop
-		if (is_eof && l.empty()) {
+		if (is_eof && l.is_empty()) {
 			if (status == STATUS_READING_ID || status == STATUS_READING_CONTEXT || (status == STATUS_READING_PLURAL && plural_index != plural_forms - 1)) {
 				memdelete(f);
 				ERR_FAIL_V_MSG(RES(), "Unexpected EOF while reading PO file at: " + path + ":" + itos(line));

--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -35,7 +35,7 @@
 #include "scene/scene_string_names.h"
 
 int AStar::get_available_point_id() const {
-	if (points.empty()) {
+	if (points.is_empty()) {
 		return 1;
 	}
 
@@ -341,7 +341,7 @@ bool AStar::_solve(Point *begin_point, Point *end_point) {
 	begin_point->f_score = _estimate_cost(begin_point->id, end_point->id);
 	open_list.push_back(begin_point);
 
-	while (!open_list.empty()) {
+	while (!open_list.is_empty()) {
 		Point *p = open_list[0]; // The currently processed point
 
 		if (p == end_point) {
@@ -805,7 +805,7 @@ bool AStar2D::_solve(AStar::Point *begin_point, AStar::Point *end_point) {
 	begin_point->f_score = _estimate_cost(begin_point->id, end_point->id);
 	open_list.push_back(begin_point);
 
-	while (!open_list.empty()) {
+	while (!open_list.is_empty()) {
 		AStar::Point *p = open_list[0]; // The currently processed point
 
 		if (p == end_point) {

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -278,7 +278,7 @@ private:
 public:
 	// Methods
 	void clear();
-	bool empty() const { return (0 == bvh_root); }
+	bool is_empty() const { return (0 == bvh_root); }
 	void optimize_bottom_up();
 	void optimize_top_down(int bu_threshold = 128);
 	void optimize_incremental(int passes);
@@ -332,7 +332,7 @@ void DynamicBVH::aabb_query(const AABB &p_box, QueryResult &r_result) {
 		if (n->volume.intersects(volume)) {
 			if (n->is_internal()) {
 				if (depth > threshold) {
-					if (aux_stack.empty()) {
+					if (aux_stack.is_empty()) {
 						aux_stack.resize(ALLOCA_STACK_SIZE * 2);
 						copymem(aux_stack.ptr(), stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
 					} else {
@@ -388,7 +388,7 @@ void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Ve
 		if (n->volume.intersects(volume) && n->volume.intersects_convex(p_planes, p_plane_count, p_points, p_point_count)) {
 			if (n->is_internal()) {
 				if (depth > threshold) {
-					if (aux_stack.empty()) {
+					if (aux_stack.is_empty()) {
 						aux_stack.resize(ALLOCA_STACK_SIZE * 2);
 						copymem(aux_stack.ptr(), stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
 					} else {
@@ -445,7 +445,7 @@ void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResu
 		if (result1) {
 			if (node->is_internal()) {
 				if (depth > threshold) {
-					if (aux_stack.empty()) {
+					if (aux_stack.is_empty()) {
 						aux_stack.resize(ALLOCA_STACK_SIZE * 2);
 						copymem(aux_stack.ptr(), stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
 					} else {

--- a/core/math/octree.h
+++ b/core/math/octree.h
@@ -572,7 +572,7 @@ bool Octree<T, use_pairs, AL>::_remove_element_from_octant(Element *p_element, O
 
 		Octant *parent = p_octant->parent;
 
-		if (p_octant->children_count == 0 && p_octant->elements.empty() && p_octant->pairable_elements.empty()) {
+		if (p_octant->children_count == 0 && p_octant->elements.is_empty() && p_octant->pairable_elements.is_empty()) {
 			// erase octant
 
 			if (p_octant == root) { // won't have a parent, just erase
@@ -942,7 +942,7 @@ void Octree<T, use_pairs, AL>::_cull_convex(Octant *p_octant, _CullConvexData *p
 		return; //pointless
 	}
 
-	if (!p_octant->elements.empty()) {
+	if (!p_octant->elements.is_empty()) {
 		typename List<Element *, AL>::Element *I;
 		I = p_octant->elements.front();
 
@@ -965,7 +965,7 @@ void Octree<T, use_pairs, AL>::_cull_convex(Octant *p_octant, _CullConvexData *p
 		}
 	}
 
-	if (use_pairs && !p_octant->pairable_elements.empty()) {
+	if (use_pairs && !p_octant->pairable_elements.is_empty()) {
 		typename List<Element *, AL>::Element *I;
 		I = p_octant->pairable_elements.front();
 
@@ -1001,7 +1001,7 @@ void Octree<T, use_pairs, AL>::_cull_aabb(Octant *p_octant, const AABB &p_aabb, 
 		return; //pointless
 	}
 
-	if (!p_octant->elements.empty()) {
+	if (!p_octant->elements.is_empty()) {
 		typename List<Element *, AL>::Element *I;
 		I = p_octant->elements.front();
 		for (; I; I = I->next()) {
@@ -1027,7 +1027,7 @@ void Octree<T, use_pairs, AL>::_cull_aabb(Octant *p_octant, const AABB &p_aabb, 
 		}
 	}
 
-	if (use_pairs && !p_octant->pairable_elements.empty()) {
+	if (use_pairs && !p_octant->pairable_elements.is_empty()) {
 		typename List<Element *, AL>::Element *I;
 		I = p_octant->pairable_elements.front();
 		for (; I; I = I->next()) {
@@ -1065,7 +1065,7 @@ void Octree<T, use_pairs, AL>::_cull_segment(Octant *p_octant, const Vector3 &p_
 		return; //pointless
 	}
 
-	if (!p_octant->elements.empty()) {
+	if (!p_octant->elements.is_empty()) {
 		typename List<Element *, AL>::Element *I;
 		I = p_octant->elements.front();
 		for (; I; I = I->next()) {
@@ -1091,7 +1091,7 @@ void Octree<T, use_pairs, AL>::_cull_segment(Octant *p_octant, const Vector3 &p_
 		}
 	}
 
-	if (use_pairs && !p_octant->pairable_elements.empty()) {
+	if (use_pairs && !p_octant->pairable_elements.is_empty()) {
 		typename List<Element *, AL>::Element *I;
 		I = p_octant->pairable_elements.front();
 		for (; I; I = I->next()) {
@@ -1132,7 +1132,7 @@ void Octree<T, use_pairs, AL>::_cull_point(Octant *p_octant, const Vector3 &p_po
 		return; //pointless
 	}
 
-	if (!p_octant->elements.empty()) {
+	if (!p_octant->elements.is_empty()) {
 		typename List<Element *, AL>::Element *I;
 		I = p_octant->elements.front();
 		for (; I; I = I->next()) {
@@ -1158,7 +1158,7 @@ void Octree<T, use_pairs, AL>::_cull_point(Octant *p_octant, const Vector3 &p_po
 		}
 	}
 
-	if (use_pairs && !p_octant->pairable_elements.empty()) {
+	if (use_pairs && !p_octant->pairable_elements.is_empty()) {
 		typename List<Element *, AL>::Element *I;
 		I = p_octant->pairable_elements.front();
 		for (; I; I = I->next()) {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -377,7 +377,7 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 			while ((k = t->method_map.next(k))) {
 				String name = k->operator String();
 
-				ERR_CONTINUE(name.empty());
+				ERR_CONTINUE(name.is_empty());
 
 				if (name[0] == '_') {
 					continue; // Ignore non-virtual methods that start with an underscore

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -506,7 +506,7 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 }
 
 void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid) {
-	if (p_names.empty()) {
+	if (p_names.is_empty()) {
 		if (r_valid) {
 			*r_valid = false;
 		}
@@ -561,11 +561,11 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 	set(p_names[0], value_stack.back()->get(), r_valid);
 	value_stack.pop_back();
 
-	ERR_FAIL_COND(!value_stack.empty());
+	ERR_FAIL_COND(!value_stack.is_empty());
 }
 
 Variant Object::get_indexed(const Vector<StringName> &p_names, bool *r_valid) const {
-	if (p_names.empty()) {
+	if (p_names.is_empty()) {
 		if (r_valid) {
 			*r_valid = false;
 		}
@@ -599,7 +599,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 	if (!is_class("Script")) { // can still be set, but this is for userfriendlyness
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));
 	}
-	if (!metadata.empty()) {
+	if (!metadata.is_empty()) {
 		p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 	}
 	if (script_instance && !p_reversed) {
@@ -1089,7 +1089,7 @@ Error Object::emit_signal(const StringName &p_name, const Variant **p_args, int 
 		}
 	}
 
-	while (!disconnect_data.empty()) {
+	while (!disconnect_data.is_empty()) {
 		const _ObjectSignalDisconnectData &dd = disconnect_data.front()->get();
 
 		_disconnect(dd.signal, dd.callable);
@@ -1373,7 +1373,7 @@ void Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 	target_object->connections.erase(slot->cE);
 	s->slot_map.erase(*p_callable.get_base_comparator());
 
-	if (s->slot_map.empty() && ClassDB::has_signal(get_class_name(), p_signal)) {
+	if (s->slot_map.is_empty() && ClassDB::has_signal(get_class_name(), p_signal)) {
 		//not user signal, delete
 		signal_map.erase(p_signal);
 	}

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -275,7 +275,7 @@ void ScriptServer::save_global_classes() {
 		gcarr.push_back(d);
 	}
 
-	if (gcarr.empty()) {
+	if (gcarr.is_empty()) {
 		if (ProjectSettings::get_singleton()->has_setting("_global_script_classes")) {
 			ProjectSettings::get_singleton()->clear("_global_script_classes");
 		}

--- a/core/string/string_buffer.h
+++ b/core/string/string_buffer.h
@@ -40,7 +40,7 @@ class StringBuffer {
 	int string_length = 0;
 
 	_FORCE_INLINE_ char32_t *current_buffer_ptr() {
-		return static_cast<String &>(buffer).empty() ? short_buffer : buffer.ptrw();
+		return static_cast<String &>(buffer).is_empty() ? short_buffer : buffer.ptrw();
 	}
 
 public:
@@ -122,7 +122,7 @@ StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::reserve(int p_
 		return *this;
 	}
 
-	bool need_copy = string_length > 0 && buffer.empty();
+	bool need_copy = string_length > 0 && buffer.is_empty();
 	buffer.resize(next_power_of_2(p_size));
 	if (need_copy) {
 		memcpy(buffer.ptrw(), short_buffer, string_length * sizeof(char32_t));
@@ -139,7 +139,7 @@ int StringBuffer<SHORT_BUFFER_SIZE>::length() const {
 template <int SHORT_BUFFER_SIZE>
 String StringBuffer<SHORT_BUFFER_SIZE>::as_string() {
 	current_buffer_ptr()[string_length] = '\0';
-	if (buffer.empty()) {
+	if (buffer.is_empty()) {
 		return String(short_buffer);
 	} else {
 		buffer.resize(string_length + 1);

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -83,7 +83,7 @@ class StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
-	operator const void *() const { return (_data && (_data->cname || !_data->name.empty())) ? (void *)1 : nullptr; }
+	operator const void *() const { return (_data && (_data->cname || !_data->name.is_empty())) ? (void *)1 : nullptr; }
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -851,7 +851,7 @@ void Translation::add_message(const StringName &p_src_text, const StringName &p_
 
 void Translation::add_plural_message(const StringName &p_src_text, const Vector<String> &p_plural_xlated_texts, const StringName &p_context) {
 	WARN_PRINT("Translation class doesn't handle plural messages. Calling add_plural_message() on a Translation instance is probably a mistake. \nUse a derived Translation class that handles plurals, such as TranslationPO class");
-	ERR_FAIL_COND_MSG(p_plural_xlated_texts.empty(), "Parameter vector p_plural_xlated_texts passed in is empty.");
+	ERR_FAIL_COND_MSG(p_plural_xlated_texts.is_empty(), "Parameter vector p_plural_xlated_texts passed in is empty.");
 	translation_map[p_src_text] = p_plural_xlated_texts[0];
 }
 

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -230,7 +230,7 @@ StringName TranslationPO::get_message(const StringName &p_src_text, const String
 	if (!translation_map.has(p_context) || !translation_map[p_context].has(p_src_text)) {
 		return StringName();
 	}
-	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].empty(), StringName(), "Source text \"" + String(p_src_text) + "\" is registered but doesn't have a translation. Please report this bug.");
+	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].is_empty(), StringName(), "Source text \"" + String(p_src_text) + "\" is registered but doesn't have a translation. Please report this bug.");
 
 	return translation_map[p_context][p_src_text][0];
 }
@@ -246,7 +246,7 @@ StringName TranslationPO::get_plural_message(const StringName &p_src_text, const
 	if (!translation_map.has(p_context) || !translation_map[p_context].has(p_src_text)) {
 		return StringName();
 	}
-	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].empty(), StringName(), "Source text \"" + String(p_src_text) + "\" is registered but doesn't have a translation. Please report this bug.");
+	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].is_empty(), StringName(), "Source text \"" + String(p_src_text) + "\" is registered but doesn't have a translation. Please report this bug.");
 
 	if (translation_map[p_context][p_src_text].size() == 1) {
 		WARN_PRINT("Source string \"" + String(p_src_text) + "\" doesn't have plural translations. Use singular translation API for such as tr(), TTR() to translate \"" + String(p_src_text) + "\"");

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -427,12 +427,12 @@ String operator+(char32_t p_chr, const String &p_str) {
 }
 
 String &String::operator+=(const String &p_str) {
-	if (empty()) {
+	if (is_empty()) {
 		*this = p_str;
 		return *this;
 	}
 
-	if (p_str.empty()) {
+	if (p_str.is_empty()) {
 		return *this;
 	}
 
@@ -519,7 +519,7 @@ bool String::operator==(const char *p_str) const {
 	if (length() != len) {
 		return false;
 	}
-	if (empty()) {
+	if (is_empty()) {
 		return true;
 	}
 
@@ -558,7 +558,7 @@ bool String::operator==(const char32_t *p_str) const {
 	if (length() != len) {
 		return false;
 	}
-	if (empty()) {
+	if (is_empty()) {
 		return true;
 	}
 
@@ -580,7 +580,7 @@ bool String::operator==(const String &p_str) const {
 	if (length() != p_str.length()) {
 		return false;
 	}
-	if (empty()) {
+	if (is_empty()) {
 		return true;
 	}
 
@@ -605,7 +605,7 @@ bool String::operator==(const StrRange &p_str_range) const {
 	if (length() != len) {
 		return false;
 	}
-	if (empty()) {
+	if (is_empty()) {
 		return true;
 	}
 
@@ -678,20 +678,20 @@ bool String::operator>=(const String &p_str) const {
 }
 
 bool String::operator<(const char *p_str) const {
-	if (empty() && p_str[0] == 0) {
+	if (is_empty() && p_str[0] == 0) {
 		return false;
 	}
-	if (empty()) {
+	if (is_empty()) {
 		return true;
 	}
 	return is_str_less(get_data(), p_str);
 }
 
 bool String::operator<(const wchar_t *p_str) const {
-	if (empty() && p_str[0] == 0) {
+	if (is_empty() && p_str[0] == 0) {
 		return false;
 	}
-	if (empty()) {
+	if (is_empty()) {
 		return true;
 	}
 
@@ -705,10 +705,10 @@ bool String::operator<(const wchar_t *p_str) const {
 }
 
 bool String::operator<(const char32_t *p_str) const {
-	if (empty() && p_str[0] == 0) {
+	if (is_empty() && p_str[0] == 0) {
 		return false;
 	}
-	if (empty()) {
+	if (is_empty()) {
 		return true;
 	}
 
@@ -720,13 +720,13 @@ bool String::operator<(const String &p_str) const {
 }
 
 signed char String::nocasecmp_to(const String &p_str) const {
-	if (empty() && p_str.empty()) {
+	if (is_empty() && p_str.is_empty()) {
 		return 0;
 	}
-	if (empty()) {
+	if (is_empty()) {
 		return -1;
 	}
-	if (p_str.empty()) {
+	if (p_str.is_empty()) {
 		return 1;
 	}
 
@@ -752,13 +752,13 @@ signed char String::nocasecmp_to(const String &p_str) const {
 }
 
 signed char String::casecmp_to(const String &p_str) const {
-	if (empty() && p_str.empty()) {
+	if (is_empty() && p_str.is_empty()) {
 		return 0;
 	}
-	if (empty()) {
+	if (is_empty()) {
 		return -1;
 	}
-	if (p_str.empty()) {
+	if (p_str.is_empty()) {
 		return 1;
 	}
 
@@ -949,10 +949,10 @@ String String::get_with_code_lines() const {
 }
 
 int String::get_slice_count(String p_splitter) const {
-	if (empty()) {
+	if (is_empty()) {
 		return 0;
 	}
-	if (p_splitter.empty()) {
+	if (p_splitter.is_empty()) {
 		return 0;
 	}
 
@@ -968,7 +968,7 @@ int String::get_slice_count(String p_splitter) const {
 }
 
 String String::get_slice(String p_splitter, int p_slice) const {
-	if (empty() || p_splitter.empty()) {
+	if (is_empty() || p_splitter.is_empty()) {
 		return "";
 	}
 
@@ -1008,7 +1008,7 @@ String String::get_slice(String p_splitter, int p_slice) const {
 }
 
 String String::get_slicec(char32_t p_splitter, int p_slice) const {
-	if (empty()) {
+	if (is_empty()) {
 		return String();
 	}
 
@@ -2585,7 +2585,7 @@ int64_t String::to_int(const char32_t *p_str, int p_len, bool p_clamp) {
 }
 
 double String::to_float() const {
-	if (empty()) {
+	if (is_empty()) {
 		return 0;
 	}
 	return built_in_strtod<char32_t>(get_data());
@@ -2767,7 +2767,7 @@ String String::substr(int p_from, int p_chars) const {
 		p_chars = length() - p_from;
 	}
 
-	if (empty() || p_from < 0 || p_from >= length() || p_chars <= 0) {
+	if (is_empty() || p_from < 0 || p_from >= length() || p_chars <= 0) {
 		return "";
 	}
 
@@ -3142,7 +3142,7 @@ bool String::is_quoted() const {
 }
 
 int String::_count(const String &p_string, int p_from, int p_to, bool p_case_insensitive) const {
-	if (p_string.empty()) {
+	if (p_string.is_empty()) {
 		return 0;
 	}
 	int len = length();
@@ -4241,7 +4241,7 @@ bool String::is_valid_ip_address() const {
 		Vector<String> ip = split(":");
 		for (int i = 0; i < ip.size(); i++) {
 			String n = ip[i];
-			if (n.empty()) {
+			if (n.is_empty()) {
 				continue;
 			}
 			if (n.is_valid_hex_number(false)) {
@@ -4331,7 +4331,7 @@ String String::get_extension() const {
 }
 
 String String::plus_file(const String &p_file) const {
-	if (empty()) {
+	if (is_empty()) {
 		return p_file;
 	}
 	if (operator[](length() - 1) == '/' || (p_file.size() > 0 && p_file.operator[](0) == '/')) {
@@ -4760,7 +4760,7 @@ String String::unquote() const {
 
 Vector<uint8_t> String::to_ascii_buffer() const {
 	const String *s = this;
-	if (s->empty()) {
+	if (s->is_empty()) {
 		return Vector<uint8_t>();
 	}
 	CharString charstr = s->ascii();
@@ -4776,7 +4776,7 @@ Vector<uint8_t> String::to_ascii_buffer() const {
 
 Vector<uint8_t> String::to_utf8_buffer() const {
 	const String *s = this;
-	if (s->empty()) {
+	if (s->is_empty()) {
 		return Vector<uint8_t>();
 	}
 	CharString charstr = s->utf8();
@@ -4792,7 +4792,7 @@ Vector<uint8_t> String::to_utf8_buffer() const {
 
 Vector<uint8_t> String::to_utf16_buffer() const {
 	const String *s = this;
-	if (s->empty()) {
+	if (s->is_empty()) {
 		return Vector<uint8_t>();
 	}
 	Char16String charstr = s->utf16();
@@ -4808,7 +4808,7 @@ Vector<uint8_t> String::to_utf16_buffer() const {
 
 Vector<uint8_t> String::to_utf32_buffer() const {
 	const String *s = this;
-	if (s->empty()) {
+	if (s->is_empty()) {
 		return Vector<uint8_t>();
 	}
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -394,7 +394,7 @@ public:
 	Vector<uint8_t> sha1_buffer() const;
 	Vector<uint8_t> sha256_buffer() const;
 
-	_FORCE_INLINE_ bool empty() const { return length() == 0; }
+	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 
 	// path functions
 	bool is_abs_path() const;

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -135,7 +135,7 @@ public:
 	}
 
 	_FORCE_INLINE_ void clear() { resize(0); }
-	_FORCE_INLINE_ bool empty() const { return _ptr == nullptr; }
+	_FORCE_INLINE_ bool is_empty() const { return _ptr == nullptr; }
 
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) {
 		CRASH_BAD_INDEX(p_index, size());

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -497,7 +497,7 @@ public:
 		return elements;
 	}
 
-	inline bool empty() const {
+	inline bool is_empty() const {
 		return elements == 0;
 	}
 

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -373,7 +373,7 @@ public:
 	/**
 	 * return whether the list is empty
 	 */
-	_FORCE_INLINE_ bool empty() const {
+	_FORCE_INLINE_ bool is_empty() const {
 		return (!_data || !_data->size_cache);
 	}
 

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -104,7 +104,7 @@ public:
 			capacity = 0;
 		}
 	}
-	_FORCE_INLINE_ bool empty() const { return count == 0; }
+	_FORCE_INLINE_ bool is_empty() const { return count == 0; }
 	_FORCE_INLINE_ void reserve(U p_size) {
 		p_size = nearest_power_of_2_templated(p_size);
 		if (p_size > capacity) {

--- a/core/templates/map.h
+++ b/core/templates/map.h
@@ -625,7 +625,7 @@ public:
 		return e;
 	}
 
-	inline bool empty() const { return _data.size_cache == 0; }
+	inline bool is_empty() const { return _data.size_cache == 0; }
 	inline int size() const { return _data.size_cache; }
 
 	int calculate_depth() const {

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -190,7 +190,7 @@ public:
 	_FORCE_INLINE_ uint32_t get_capacity() const { return capacity; }
 	_FORCE_INLINE_ uint32_t get_num_elements() const { return num_elements; }
 
-	bool empty() const {
+	bool is_empty() const {
 		return num_elements == 0;
 	}
 

--- a/core/templates/ordered_hash_map.h
+++ b/core/templates/ordered_hash_map.h
@@ -265,7 +265,7 @@ public:
 		return ConstElement(list.back());
 	}
 
-	inline bool empty() const { return list.empty(); }
+	inline bool is_empty() const { return list.is_empty(); }
 	inline int size() const { return list.size(); }
 
 	const void *id() const {

--- a/core/templates/set.h
+++ b/core/templates/set.h
@@ -576,7 +576,7 @@ public:
 		return e;
 	}
 
-	inline bool empty() const { return _data.size_cache == 0; }
+	inline bool is_empty() const { return _data.size_cache == 0; }
 	inline int size() const { return _data.size_cache; }
 
 	int calculate_depth() const {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -79,7 +79,7 @@ public:
 	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ void clear() { resize(0); }
-	_FORCE_INLINE_ bool empty() const { return _cowdata.empty(); }
+	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
 
 	_FORCE_INLINE_ T get(int p_index) { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ const T &get(int p_index) const { return _cowdata.get(p_index); }

--- a/core/templates/vmap.h
+++ b/core/templates/vmap.h
@@ -54,7 +54,7 @@ private:
 
 	_FORCE_INLINE_ int _find(const T &p_val, bool &r_exact) const {
 		r_exact = false;
-		if (_cowdata.empty()) {
+		if (_cowdata.is_empty()) {
 			return 0;
 		}
 
@@ -89,7 +89,7 @@ private:
 	}
 
 	_FORCE_INLINE_ int _find_exact(const T &p_val) const {
-		if (_cowdata.empty()) {
+		if (_cowdata.is_empty()) {
 			return -1;
 		}
 
@@ -147,7 +147,7 @@ public:
 	}
 
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
-	_FORCE_INLINE_ bool empty() const { return _cowdata.empty(); }
+	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
 
 	const Pair *get_array() const {
 		return _cowdata.ptr();

--- a/core/templates/vset.h
+++ b/core/templates/vset.h
@@ -40,7 +40,7 @@ class VSet {
 
 	_FORCE_INLINE_ int _find(const T &p_val, bool &r_exact) const {
 		r_exact = false;
-		if (_data.empty()) {
+		if (_data.is_empty()) {
 			return 0;
 		}
 
@@ -76,7 +76,7 @@ class VSet {
 	}
 
 	_FORCE_INLINE_ int _find_exact(const T &p_val) const {
-		if (_data.empty()) {
+		if (_data.is_empty()) {
 			return -1;
 		}
 
@@ -126,7 +126,7 @@ public:
 		return _find_exact(p_val);
 	}
 
-	_FORCE_INLINE_ bool empty() const { return _data.empty(); }
+	_FORCE_INLINE_ bool is_empty() const { return _data.is_empty(); }
 
 	_FORCE_INLINE_ int size() const { return _data.size(); }
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -86,8 +86,8 @@ int Array::size() const {
 	return _p->array.size();
 }
 
-bool Array::empty() const {
-	return _p->array.empty();
+bool Array::is_empty() const {
+	return _p->array.is_empty();
 }
 
 void Array::clear() {
@@ -318,7 +318,7 @@ Array Array::slice(int p_begin, int p_end, int p_step, bool p_deep) const { // l
 
 	ERR_FAIL_COND_V_MSG(p_step == 0, new_arr, "Array slice step size cannot be zero.");
 
-	if (empty()) { // Don't try to slice empty arrays.
+	if (is_empty()) { // Don't try to slice empty arrays.
 		return new_arr;
 	}
 	if (p_step > 0) {
@@ -459,7 +459,7 @@ void Array::push_front(const Variant &p_value) {
 }
 
 Variant Array::pop_back() {
-	if (!_p->array.empty()) {
+	if (!_p->array.is_empty()) {
 		int n = _p->array.size() - 1;
 		Variant ret = _p->array.get(n);
 		_p->array.resize(n);
@@ -469,7 +469,7 @@ Variant Array::pop_back() {
 }
 
 Variant Array::pop_front() {
-	if (!_p->array.empty()) {
+	if (!_p->array.is_empty()) {
 		Variant ret = _p->array.get(0);
 		_p->array.remove(0);
 		return ret;

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -57,7 +57,7 @@ public:
 	const Variant &get(int p_idx) const;
 
 	int size() const;
-	bool empty() const;
+	bool is_empty() const;
 	void clear();
 
 	bool operator==(const Array &p_array) const;

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -40,7 +40,7 @@ struct DictionaryPrivate {
 };
 
 void Dictionary::get_key_list(List<Variant> *p_keys) const {
-	if (_p->variant_map.empty()) {
+	if (_p->variant_map.is_empty()) {
 		return;
 	}
 
@@ -121,7 +121,7 @@ int Dictionary::size() const {
 	return _p->variant_map.size();
 }
 
-bool Dictionary::empty() const {
+bool Dictionary::is_empty() const {
 	return !_p->variant_map.size();
 }
 
@@ -192,7 +192,7 @@ uint32_t Dictionary::hash() const {
 
 Array Dictionary::keys() const {
 	Array varr;
-	if (_p->variant_map.empty()) {
+	if (_p->variant_map.is_empty()) {
 		return varr;
 	}
 
@@ -209,7 +209,7 @@ Array Dictionary::keys() const {
 
 Array Dictionary::values() const {
 	Array varr;
-	if (_p->variant_map.empty()) {
+	if (_p->variant_map.is_empty()) {
 		return varr;
 	}
 

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -60,7 +60,7 @@ public:
 	Variant get(const Variant &p_key, const Variant &p_default) const;
 
 	int size() const;
-	bool empty() const;
+	bool is_empty() const;
 	void clear();
 
 	bool has(const Variant &p_key) const;

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -912,11 +912,11 @@ bool Variant::is_zero() const {
 
 		} break;
 		case DICTIONARY: {
-			return reinterpret_cast<const Dictionary *>(_data._mem)->empty();
+			return reinterpret_cast<const Dictionary *>(_data._mem)->is_empty();
 
 		} break;
 		case ARRAY: {
-			return reinterpret_cast<const Array *>(_data._mem)->empty();
+			return reinterpret_cast<const Array *>(_data._mem)->is_empty();
 
 		} break;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -940,7 +940,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, md5_buffer, sarray(), varray());
 	bind_method(String, sha1_buffer, sarray(), varray());
 	bind_method(String, sha256_buffer, sarray(), varray());
-	bind_method(String, empty, sarray(), varray());
+	bind_method(String, is_empty, sarray(), varray());
 	// FIXME: Static function, not sure how to bind
 	//bind_method(String, humanize_size, sarray("size"), varray());
 
@@ -1269,7 +1269,7 @@ static void _register_variant_builtin_methods() {
 	/* Dictionary */
 
 	bind_method(Dictionary, size, sarray(), varray());
-	bind_method(Dictionary, empty, sarray(), varray());
+	bind_method(Dictionary, is_empty, sarray(), varray());
 	bind_method(Dictionary, clear, sarray(), varray());
 	bind_method(Dictionary, has, sarray("key"), varray());
 	bind_method(Dictionary, has_all, sarray("keys"), varray());
@@ -1283,7 +1283,7 @@ static void _register_variant_builtin_methods() {
 	/* Array */
 
 	bind_method(Array, size, sarray(), varray());
-	bind_method(Array, empty, sarray(), varray());
+	bind_method(Array, is_empty, sarray(), varray());
 	bind_method(Array, clear, sarray(), varray());
 	bind_method(Array, hash, sarray(), varray());
 	bind_method(Array, push_back, sarray("value"), varray());
@@ -1316,7 +1316,7 @@ static void _register_variant_builtin_methods() {
 
 	/* Byte Array */
 	bind_method(PackedByteArray, size, sarray(), varray());
-	bind_method(PackedByteArray, empty, sarray(), varray());
+	bind_method(PackedByteArray, is_empty, sarray(), varray());
 	bind_method(PackedByteArray, set, sarray("index", "value"), varray());
 	bind_method(PackedByteArray, push_back, sarray("value"), varray());
 	bind_method(PackedByteArray, append, sarray("value"), varray());
@@ -1342,7 +1342,7 @@ static void _register_variant_builtin_methods() {
 	/* Int32 Array */
 
 	bind_method(PackedInt32Array, size, sarray(), varray());
-	bind_method(PackedInt32Array, empty, sarray(), varray());
+	bind_method(PackedInt32Array, is_empty, sarray(), varray());
 	bind_method(PackedInt32Array, set, sarray("index", "value"), varray());
 	bind_method(PackedInt32Array, push_back, sarray("value"), varray());
 	bind_method(PackedInt32Array, append, sarray("value"), varray());
@@ -1360,7 +1360,7 @@ static void _register_variant_builtin_methods() {
 	/* Int64 Array */
 
 	bind_method(PackedInt64Array, size, sarray(), varray());
-	bind_method(PackedInt64Array, empty, sarray(), varray());
+	bind_method(PackedInt64Array, is_empty, sarray(), varray());
 	bind_method(PackedInt64Array, set, sarray("index", "value"), varray());
 	bind_method(PackedInt64Array, push_back, sarray("value"), varray());
 	bind_method(PackedInt64Array, append, sarray("value"), varray());
@@ -1378,7 +1378,7 @@ static void _register_variant_builtin_methods() {
 	/* Float32 Array */
 
 	bind_method(PackedFloat32Array, size, sarray(), varray());
-	bind_method(PackedFloat32Array, empty, sarray(), varray());
+	bind_method(PackedFloat32Array, is_empty, sarray(), varray());
 	bind_method(PackedFloat32Array, set, sarray("index", "value"), varray());
 	bind_method(PackedFloat32Array, push_back, sarray("value"), varray());
 	bind_method(PackedFloat32Array, append, sarray("value"), varray());
@@ -1396,7 +1396,7 @@ static void _register_variant_builtin_methods() {
 	/* Float64 Array */
 
 	bind_method(PackedFloat64Array, size, sarray(), varray());
-	bind_method(PackedFloat64Array, empty, sarray(), varray());
+	bind_method(PackedFloat64Array, is_empty, sarray(), varray());
 	bind_method(PackedFloat64Array, set, sarray("index", "value"), varray());
 	bind_method(PackedFloat64Array, push_back, sarray("value"), varray());
 	bind_method(PackedFloat64Array, append, sarray("value"), varray());
@@ -1414,7 +1414,7 @@ static void _register_variant_builtin_methods() {
 	/* String Array */
 
 	bind_method(PackedStringArray, size, sarray(), varray());
-	bind_method(PackedStringArray, empty, sarray(), varray());
+	bind_method(PackedStringArray, is_empty, sarray(), varray());
 	bind_method(PackedStringArray, set, sarray("index", "value"), varray());
 	bind_method(PackedStringArray, push_back, sarray("value"), varray());
 	bind_method(PackedStringArray, append, sarray("value"), varray());
@@ -1432,7 +1432,7 @@ static void _register_variant_builtin_methods() {
 	/* Vector2 Array */
 
 	bind_method(PackedVector2Array, size, sarray(), varray());
-	bind_method(PackedVector2Array, empty, sarray(), varray());
+	bind_method(PackedVector2Array, is_empty, sarray(), varray());
 	bind_method(PackedVector2Array, set, sarray("index", "value"), varray());
 	bind_method(PackedVector2Array, push_back, sarray("value"), varray());
 	bind_method(PackedVector2Array, append, sarray("value"), varray());
@@ -1450,7 +1450,7 @@ static void _register_variant_builtin_methods() {
 	/* Vector3 Array */
 
 	bind_method(PackedVector3Array, size, sarray(), varray());
-	bind_method(PackedVector3Array, empty, sarray(), varray());
+	bind_method(PackedVector3Array, is_empty, sarray(), varray());
 	bind_method(PackedVector3Array, set, sarray("index", "value"), varray());
 	bind_method(PackedVector3Array, push_back, sarray("value"), varray());
 	bind_method(PackedVector3Array, append, sarray("value"), varray());
@@ -1468,7 +1468,7 @@ static void _register_variant_builtin_methods() {
 	/* Color Array */
 
 	bind_method(PackedColorArray, size, sarray(), varray());
-	bind_method(PackedColorArray, empty, sarray(), varray());
+	bind_method(PackedColorArray, is_empty, sarray(), varray());
 	bind_method(PackedColorArray, set, sarray("index", "value"), varray());
 	bind_method(PackedColorArray, push_back, sarray("value"), varray());
 	bind_method(PackedColorArray, append, sarray("value"), varray());

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1477,7 +1477,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 
 		case STRING: {
 			const String *str = reinterpret_cast<const String *>(_data._mem);
-			if (str->empty()) {
+			if (str->is_empty()) {
 				return false;
 			}
 			r_iter = 0;
@@ -1485,7 +1485,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 		} break;
 		case DICTIONARY: {
 			const Dictionary *dic = reinterpret_cast<const Dictionary *>(_data._mem);
-			if (dic->empty()) {
+			if (dic->is_empty()) {
 				return false;
 			}
 
@@ -1496,7 +1496,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 		} break;
 		case ARRAY: {
 			const Array *arr = reinterpret_cast<const Array *>(_data._mem);
-			if (arr->empty()) {
+			if (arr->is_empty()) {
 				return false;
 			}
 			r_iter = 0;

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -228,7 +228,7 @@
 				If [code]deep[/code] is [code]true[/code], a deep copy is performed: all nested arrays and dictionaries are duplicated and will not be shared with the original array. If [code]false[/code], a shallow copy is made and references to the original nested arrays and dictionaries are kept, so that modifying a sub-array or dictionary in the copy will also impact those referenced in the source array.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -215,7 +215,7 @@
 				Creates a copy of the dictionary, and returns it. The [code]deep[/code] parameter causes inner dictionaries and arrays to be copied recursively, but does not apply to objects.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -92,7 +92,7 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -59,7 +59,7 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -60,7 +60,7 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -60,7 +60,7 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -60,7 +60,7 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -60,7 +60,7 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -60,7 +60,7 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -60,7 +60,7 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -59,7 +59,7 @@
 				Creates a copy of the array, and returns it.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -135,7 +135,7 @@
 				Returns a copy of the string with indentation (leading tabs and spaces) removed.
 			</description>
 		</method>
-		<method name="empty">
+		<method name="is_empty">
 			<return type="bool">
 			</return>
 			<description>

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4577,7 +4577,7 @@ void RenderingDeviceVulkan::_descriptor_pool_free(const DescriptorPoolKey &p_key
 		vkDestroyDescriptorPool(device, p_pool->pool, nullptr);
 		descriptor_pools[p_key].erase(p_pool);
 		memdelete(p_pool);
-		if (descriptor_pools[p_key].empty()) {
+		if (descriptor_pools[p_key].is_empty()) {
 			descriptor_pools.erase(p_key);
 		}
 	}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3779,7 +3779,7 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 		r_base_path = node->get_path();
 	}
 
-	if (leftover_path.empty()) {
+	if (leftover_path.is_empty()) {
 		if (r_current_val) {
 			if (res.is_valid()) {
 				*r_current_val = res;
@@ -4080,8 +4080,8 @@ void AnimationTrackEditor::_update_tracks() {
 					object = res.ptr();
 				}
 
-				if (object && !leftover_path.empty()) {
-					if (pinfo.name.empty()) {
+				if (object && !leftover_path.is_empty()) {
+					if (pinfo.name.is_empty()) {
 						pinfo.name = leftover_path[leftover_path.size() - 1];
 					}
 
@@ -5285,7 +5285,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			scale_dialog->popup_centered(Size2(200, 100) * EDSCALE);
 		} break;
 		case EDIT_SCALE_CONFIRM: {
-			if (selection.empty()) {
+			if (selection.is_empty()) {
 				return;
 			}
 

--- a/editor/array_property_edit.cpp
+++ b/editor/array_property_edit.cpp
@@ -259,7 +259,7 @@ void ArrayPropertyEdit::edit(Object *p_obj, const StringName &p_prop, const Stri
 	obj = p_obj->get_instance_id();
 	default_type = p_deftype;
 
-	if (!p_hint_string.empty()) {
+	if (!p_hint_string.is_empty()) {
 		int hint_subtype_separator = p_hint_string.find(":");
 		if (hint_subtype_separator >= 0) {
 			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -325,7 +325,7 @@ void FindReplaceBar::_update_results_count() {
 	results_count = 0;
 
 	String searched = get_search_text();
-	if (searched.empty()) {
+	if (searched.is_empty()) {
 		return;
 	}
 
@@ -356,7 +356,7 @@ void FindReplaceBar::_update_results_count() {
 }
 
 void FindReplaceBar::_update_matches_label() {
-	if (search_text->get_text().empty() || results_count == -1) {
+	if (search_text->get_text().is_empty() || results_count == -1) {
 		matches_label->hide();
 	} else {
 		matches_label->show();
@@ -483,7 +483,7 @@ void FindReplaceBar::_show_search(bool p_focus_replace, bool p_show_only) {
 		search_text->set_text(text_editor->get_selection_text());
 	}
 
-	if (!get_search_text().empty()) {
+	if (!get_search_text().is_empty()) {
 		if (p_focus_replace) {
 			replace_text->select_all();
 			replace_text->set_cursor_position(replace_text->get_text().length());
@@ -1309,7 +1309,7 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		for (int i = begin; i <= end; i++) {
 			String line_text = text_editor->get_line(i);
 
-			if (line_text.strip_edges().empty()) {
+			if (line_text.strip_edges().is_empty()) {
 				line_text = delimiter;
 			} else {
 				if (is_commented) {

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1008,7 +1008,7 @@ void ConnectionsDock::update_tree() {
 								break;
 							}
 						}
-						if (!F->get().inherits.empty()) {
+						if (!F->get().inherits.is_empty()) {
 							F = dd->class_list.find(F->get().inherits);
 						} else {
 							break;

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -115,7 +115,7 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 		tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("DebuggerPanel", "EditorStyles"));
 	}
 
-	if (!debugger_plugins.empty()) {
+	if (!debugger_plugins.is_empty()) {
 		for (Set<Ref<Script>>::Element *i = debugger_plugins.front(); i; i = i->next()) {
 			node->add_debugger_plugin(i->get());
 		}
@@ -140,7 +140,7 @@ void EditorDebuggerNode::_error_selected(const String &p_file, int p_line, int p
 
 void EditorDebuggerNode::_text_editor_stack_goto(const ScriptEditorDebugger *p_debugger) {
 	const String file = p_debugger->get_stack_script_file();
-	if (file.empty()) {
+	if (file.is_empty()) {
 		return;
 	}
 	stack_script = ResourceLoader::load(file);

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -242,7 +242,7 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 		} break;
 		case ITEM_MENU_COPY_NODE_PATH: {
 			String text = get_selected_path();
-			if (text.empty()) {
+			if (text.is_empty()) {
 				return;
 			} else if (text == "/root") {
 				text = ".";

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -102,7 +102,7 @@ void EditorPerformanceProfiler::_monitor_draw() {
 		}
 	}
 
-	if (active.empty()) {
+	if (active.is_empty()) {
 		info_message->show();
 		return;
 	}
@@ -217,7 +217,7 @@ void EditorPerformanceProfiler::_build_monitor_tree() {
 		TreeItem *item = _create_monitor_item(i.value().name, base);
 		item->set_checked(0, monitor_checked.has(i.key()));
 		i.value().item = item;
-		if (!i.value().history.empty()) {
+		if (!i.value().history.is_empty()) {
 			i.value().update_value(i.value().history.front()->get());
 		}
 	}

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -596,7 +596,7 @@ bool EditorProfiler::is_profiling() {
 Vector<Vector<String>> EditorProfiler::get_data_as_csv() const {
 	Vector<Vector<String>> res;
 
-	if (frame_metrics.empty()) {
+	if (frame_metrics.is_empty()) {
 		return res;
 	}
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -490,17 +490,17 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		if (oe.callstack.size() > 0) {
 			// If available, use the script's stack in the error title.
 			error_title = oe.callstack[oe.callstack.size() - 1].func + ": ";
-		} else if (!oe.source_func.empty()) {
+		} else if (!oe.source_func.is_empty()) {
 			// Otherwise try to use the C++ source function.
 			error_title += oe.source_func + ": ";
 		}
 		// If we have a (custom) error message, use it as title, and add a C++ Error
 		// item with the original error condition.
-		error_title += oe.error_descr.empty() ? oe.error : oe.error_descr;
+		error_title += oe.error_descr.is_empty() ? oe.error : oe.error_descr;
 		error->set_text(1, error_title);
 		tooltip += " " + error_title + "\n";
 
-		if (!oe.error_descr.empty()) {
+		if (!oe.error_descr.is_empty()) {
 			// Add item for C++ error condition.
 			TreeItem *cpp_cond = error_tree->create_item(error);
 			cpp_cond->set_text(0, "<" + TTR("C++ Error") + ">");
@@ -516,7 +516,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 		// Source of the error.
 		String source_txt = (source_is_project_file ? oe.source_file.get_file() : oe.source_file) + ":" + itos(oe.source_line);
-		if (!oe.source_func.empty()) {
+		if (!oe.source_func.is_empty()) {
 			source_txt += " @ " + oe.source_func + "()";
 		}
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -448,7 +448,7 @@ void DependencyRemoveDialog::show(const Vector<String> &p_folders, const Vector<
 	Vector<RemovedDependency> removed_deps;
 	_find_all_removed_dependencies(EditorFileSystem::get_singleton()->get_filesystem(), removed_deps);
 	removed_deps.sort();
-	if (removed_deps.empty()) {
+	if (removed_deps.is_empty()) {
 		owners->hide();
 		text->set_text(TTR("Remove selected files from the project? (no undo)\nYou can find the removed files in the system trash to restore them."));
 		set_size(Size2());
@@ -639,7 +639,7 @@ void OrphanResourcesDialog::ok_pressed() {
 	paths.clear();
 
 	_find_to_delete(files->get_root(), paths);
-	if (paths.empty()) {
+	if (paths.is_empty()) {
 		return;
 	}
 

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -111,8 +111,8 @@ class DependencyRemoveDialog : public ConfirmationDialog {
 		String dependency_folder;
 
 		bool operator<(const RemovedDependency &p_other) const {
-			if (dependency_folder.empty() != p_other.dependency_folder.empty()) {
-				return p_other.dependency_folder.empty();
+			if (dependency_folder.is_empty() != p_other.dependency_folder.is_empty()) {
+				return p_other.dependency_folder.is_empty();
 			} else {
 				return dependency < p_other.dependency;
 			}

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -813,7 +813,7 @@ void DocTools::generate(bool p_basic_types) {
 			}
 
 			// Skip adding the lang if it doesn't expose anything (e.g. C#).
-			if (c.methods.empty() && c.constants.empty()) {
+			if (c.methods.is_empty() && c.constants.is_empty()) {
 				continue;
 			}
 
@@ -1165,7 +1165,7 @@ Error DocTools::save_classes(const String &p_default_path, const Map<String, Str
 		_write_string(f, 1, "<tutorials>");
 		for (int i = 0; i < c.tutorials.size(); i++) {
 			DocData::TutorialDoc tutorial = c.tutorials.get(i);
-			String title_attribute = (!tutorial.title.empty()) ? " title=\"" + tutorial.title.xml_escape() + "\"" : "";
+			String title_attribute = (!tutorial.title.is_empty()) ? " title=\"" + tutorial.title.xml_escape() + "\"" : "";
 			_write_string(f, 2, "<link" + title_attribute + ">" + tutorial.link.xml_escape() + "</link>");
 		}
 		_write_string(f, 1, "</tutorials>");

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -402,7 +402,7 @@ void EditorAutoloadSettings::update_autoload() {
 		String name = pi.name.get_slice("/", 1);
 		String path = ProjectSettings::get_singleton()->get(pi.name);
 
-		if (name.empty()) {
+		if (name.is_empty()) {
 			continue;
 		}
 
@@ -774,7 +774,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 		String name = pi.name.get_slice("/", 1);
 		String path = ProjectSettings::get_singleton()->get(pi.name);
 
-		if (name.empty()) {
+		if (name.is_empty()) {
 			continue;
 		}
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -331,7 +331,7 @@ Dictionary EditorData::get_editor_states() const {
 	Dictionary metadata;
 	for (int i = 0; i < editor_plugins.size(); i++) {
 		Dictionary state = editor_plugins[i]->get_state();
-		if (state.empty()) {
+		if (state.is_empty()) {
 			continue;
 		}
 		metadata[editor_plugins[i]->get_name()] = state;
@@ -493,7 +493,7 @@ void EditorData::remove_custom_type(const String &p_type) {
 		for (int i = 0; i < E->get().size(); i++) {
 			if (E->get()[i].name == p_type) {
 				E->get().remove(i);
-				if (E->get().empty()) {
+				if (E->get().is_empty()) {
 					custom_types.erase(E->key());
 				}
 				return;
@@ -901,7 +901,7 @@ String EditorData::script_class_get_icon_path(const String &p_class) const {
 
 	String current = p_class;
 	String ret = _script_class_icon_paths[current];
-	while (ret.empty()) {
+	while (ret.is_empty()) {
 		current = script_class_get_base(current);
 		if (!ScriptServer::is_global_class(current)) {
 			return String();
@@ -931,7 +931,7 @@ void EditorData::script_class_save_icon_paths() {
 		}
 	}
 
-	if (d.empty()) {
+	if (d.is_empty()) {
 		if (ProjectSettings::get_singleton()->has_setting("_global_script_class_icons")) {
 			ProjectSettings::get_singleton()->clear("_global_script_class_icons");
 		}
@@ -1125,7 +1125,7 @@ List<Node *> EditorSelection::get_full_selected_node_list() {
 }
 
 void EditorSelection::clear() {
-	while (!selection.empty()) {
+	while (!selection.is_empty()) {
 		remove_node(selection.front()->key());
 	}
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -521,7 +521,7 @@ void EditorExportPlatform::_edit_filter_list(Set<String> &r_list, const String &
 	Vector<String> filters;
 	for (int i = 0; i < split.size(); i++) {
 		String f = split[i].strip_edges();
-		if (f.empty()) {
+		if (f.is_empty()) {
 			continue;
 		}
 		filters.push_back(f);
@@ -754,7 +754,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		Vector<String> enc_in_split = p_preset->get_enc_in_filter().split(",");
 		for (int i = 0; i < enc_in_split.size(); i++) {
 			String f = enc_in_split[i].strip_edges();
-			if (f.empty()) {
+			if (f.is_empty()) {
 				continue;
 			}
 			enc_in_filters.push_back(f);
@@ -763,7 +763,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		Vector<String> enc_ex_split = p_preset->get_enc_ex_filter().split(",");
 		for (int i = 0; i < enc_ex_split.size(); i++) {
 			String f = enc_ex_split[i].strip_edges();
-			if (f.empty()) {
+			if (f.is_empty()) {
 				continue;
 			}
 			enc_ex_filters.push_back(f);
@@ -1696,7 +1696,7 @@ bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset,
 	valid = dvalid || rvalid;
 	r_missing_templates = !valid;
 
-	if (!err.empty()) {
+	if (!err.is_empty()) {
 		r_error = err;
 	}
 	return valid;
@@ -1783,7 +1783,7 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 			}
 		}
 
-		if (err == OK && !so_files.empty()) {
+		if (err == OK && !so_files.is_empty()) {
 			//if shared object files, copy them
 			da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			for (int i = 0; i < so_files.size() && err == OK; i++) {

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -96,7 +96,7 @@ void EditorFeatureProfile::set_disable_class_property(const StringName &p_class,
 	} else {
 		ERR_FAIL_COND(!disabled_properties.has(p_class));
 		disabled_properties[p_class].erase(p_property);
-		if (disabled_properties[p_class].empty()) {
+		if (disabled_properties[p_class].is_empty()) {
 			disabled_properties.erase(p_class);
 		}
 	}

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -758,7 +758,7 @@ void EditorFileDialog::update_file_list() {
 	dirs.sort_custom<NaturalNoCaseComparator>();
 	files.sort_custom<NaturalNoCaseComparator>();
 
-	while (!dirs.empty()) {
+	while (!dirs.is_empty()) {
 		const String &dir_name = dirs.front()->get();
 
 		item_list->add_item(dir_name);
@@ -806,8 +806,8 @@ void EditorFileDialog::update_file_list() {
 		}
 	}
 
-	while (!files.empty()) {
-		bool match = patterns.empty();
+	while (!files.is_empty()) {
+		bool match = patterns.is_empty();
 
 		for (List<String>::Element *E = patterns.front(); E; E = E->next()) {
 			if (files.front()->get().matchn(E->get())) {

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -167,12 +167,12 @@ void EditorHelp::_class_desc_resized() {
 
 void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 	String t = p_type;
-	if (t.empty()) {
+	if (t.is_empty()) {
 		t = "void";
 	}
-	bool can_ref = (t != "void") || !p_enum.empty();
+	bool can_ref = (t != "void") || !p_enum.is_empty();
 
-	if (!p_enum.empty()) {
+	if (!p_enum.is_empty()) {
 		if (p_enum.get_slice_count(".") > 1) {
 			t = p_enum.get_slice(".", 1);
 		} else {
@@ -188,7 +188,7 @@ void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 			add_array = true;
 			t = t.replace("[]", "");
 		}
-		if (p_enum.empty()) {
+		if (p_enum.is_empty()) {
 			class_desc->push_meta("#" + t); //class
 		} else {
 			class_desc->push_meta("$" + p_enum); //class
@@ -472,7 +472,7 @@ void EditorHelp::_update_doc() {
 
 		for (int i = 0; i < cd.tutorials.size(); i++) {
 			const String link = DTR(cd.tutorials[i].link);
-			String linktxt = (cd.tutorials[i].title.empty()) ? link : DTR(cd.tutorials[i].title);
+			String linktxt = (cd.tutorials[i].title.is_empty()) ? link : DTR(cd.tutorials[i].title);
 			const int seppos = linktxt.find("//");
 			if (seppos != -1) {
 				linktxt = link.right(seppos + 2);
@@ -498,7 +498,7 @@ void EditorHelp::_update_doc() {
 	if (cd.is_script_doc) {
 		has_properties = false;
 		for (int i = 0; i < cd.properties.size(); i++) {
-			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.empty()) {
+			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.is_empty()) {
 				continue;
 			}
 			has_properties = true;
@@ -522,7 +522,7 @@ void EditorHelp::_update_doc() {
 
 		for (int i = 0; i < cd.properties.size(); i++) {
 			// Ignore undocumented private.
-			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.empty()) {
+			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.is_empty()) {
 				continue;
 			}
 			property_line[cd.properties[i].name] = class_desc->get_line_count() - 2; //gets overridden if description
@@ -633,7 +633,7 @@ void EditorHelp::_update_doc() {
 			}
 		}
 		// Ignore undocumented private.
-		if (cd.methods[i].name.begins_with("_") && cd.methods[i].description.empty()) {
+		if (cd.methods[i].name.begins_with("_") && cd.methods[i].description.is_empty()) {
 			continue;
 		}
 		methods.push_back(cd.methods[i]);
@@ -668,7 +668,7 @@ void EditorHelp::_update_doc() {
 				}
 			}
 
-			if (any_previous && !m.empty()) {
+			if (any_previous && !m.is_empty()) {
 				class_desc->push_cell();
 				class_desc->pop(); //cell
 				class_desc->push_cell();
@@ -702,7 +702,7 @@ void EditorHelp::_update_doc() {
 				_add_method(m[i], true);
 			}
 
-			any_previous = !m.empty();
+			any_previous = !m.is_empty();
 		}
 
 		class_desc->pop(); //table
@@ -848,7 +848,7 @@ void EditorHelp::_update_doc() {
 		Vector<DocData::ConstantDoc> constants;
 
 		for (int i = 0; i < cd.constants.size(); i++) {
-			if (!cd.constants[i].enumeration.empty()) {
+			if (!cd.constants[i].enumeration.is_empty()) {
 				if (!enums.has(cd.constants[i].enumeration)) {
 					enums[cd.constants[i].enumeration] = Vector<DocData::ConstantDoc>();
 				}
@@ -856,7 +856,7 @@ void EditorHelp::_update_doc() {
 				enums[cd.constants[i].enumeration].push_back(cd.constants[i]);
 			} else {
 				// Ignore undocumented private.
-				if (cd.constants[i].name.begins_with("_") && cd.constants[i].description.empty()) {
+				if (cd.constants[i].name.begins_with("_") && cd.constants[i].description.is_empty()) {
 					continue;
 				}
 				constants.push_back(cd.constants[i]);
@@ -1174,7 +1174,7 @@ void EditorHelp::_update_doc() {
 			class_desc->push_color(text_color);
 			class_desc->push_font(doc_font);
 			class_desc->push_indent(1);
-			if (!cd.properties[i].description.strip_edges().empty()) {
+			if (!cd.properties[i].description.strip_edges().is_empty()) {
 				_add_text(DTR(cd.properties[i].description));
 			} else {
 				class_desc->add_image(get_theme_icon("Error", "EditorIcons"));
@@ -1229,7 +1229,7 @@ void EditorHelp::_update_doc() {
 				class_desc->push_color(text_color);
 				class_desc->push_font(doc_font);
 				class_desc->push_indent(1);
-				if (!methods_filtered[i].description.strip_edges().empty()) {
+				if (!methods_filtered[i].description.strip_edges().is_empty()) {
 					_add_text(DTR(methods_filtered[i].description));
 				} else {
 					class_desc->add_image(get_theme_icon("Error", "EditorIcons"));
@@ -1838,7 +1838,7 @@ void FindBar::popup_search() {
 		grabbed_focus = true;
 	}
 
-	if (!search_text->get_text().empty()) {
+	if (!search_text->get_text().is_empty()) {
 		search_text->select_all();
 		search_text->set_cursor_position(search_text->get_text().length());
 		if (grabbed_focus) {
@@ -1908,7 +1908,7 @@ void FindBar::_update_results_count() {
 	results_count = 0;
 
 	String searched = search_text->get_text();
-	if (searched.empty()) {
+	if (searched.is_empty()) {
 		return;
 	}
 
@@ -1928,7 +1928,7 @@ void FindBar::_update_results_count() {
 }
 
 void FindBar::_update_matches_label() {
-	if (search_text->get_text().empty() || results_count == -1) {
+	if (search_text->get_text().is_empty() || results_count == -1) {
 		matches_label->hide();
 	} else {
 		matches_label->show();

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -865,7 +865,7 @@ Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 
 	String text;
 	PackedStringArray slices = p_text.split("::", false);
-	if (!slices.empty()) {
+	if (!slices.is_empty()) {
 		String property_name = slices[0].strip_edges();
 		text = TTR("Property:") + " [u][b]" + property_name + "[/b][/u]";
 
@@ -1098,7 +1098,7 @@ Control *EditorInspectorCategory::make_custom_tooltip(const String &p_text) cons
 	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
 
 	PackedStringArray slices = p_text.split("::", false);
-	if (!slices.empty()) {
+	if (!slices.is_empty()) {
 		String property_name = slices[0].strip_edges();
 		String text = "[u][b]" + property_name + "[/b][/u]";
 
@@ -1901,7 +1901,7 @@ void EditorInspector::update_tree() {
 						}
 					}
 
-					if (!F->get().inherits.empty()) {
+					if (!F->get().inherits.is_empty()) {
 						F = dd->class_list.find(F->get().inherits);
 					} else {
 						break;
@@ -2525,7 +2525,7 @@ void EditorInspector::_update_script_class_properties(const Object &p_object, Li
 		script = script->get_base_script();
 	}
 
-	if (classes.empty()) {
+	if (classes.is_empty()) {
 		return;
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -377,9 +377,9 @@ void EditorNode::_version_control_menu_option(int p_idx) {
 
 void EditorNode::_update_title() {
 	String appname = ProjectSettings::get_singleton()->get("application/config/name");
-	String title = appname.empty() ? String(VERSION_FULL_NAME) : String(VERSION_NAME + String(" - ") + appname);
+	String title = appname.is_empty() ? String(VERSION_FULL_NAME) : String(VERSION_NAME + String(" - ") + appname);
 	String edited = editor_data.get_edited_scene_root() ? editor_data.get_edited_scene_root()->get_filename() : String();
-	if (!edited.empty()) {
+	if (!edited.is_empty()) {
 		title += " - " + String(edited.get_file());
 	}
 	if (unsaved_cache) {
@@ -782,8 +782,8 @@ void EditorNode::_fs_changed() {
 					preset_name);
 		} else {
 			Ref<EditorExportPlatform> platform = preset->get_platform();
-			const String export_path = export_defer.path.empty() ? preset->get_export_path() : export_defer.path;
-			if (export_path.empty()) {
+			const String export_path = export_defer.path.is_empty() ? preset->get_export_path() : export_defer.path;
+			if (export_path.is_empty()) {
 				export_error = vformat("Export preset '%s' doesn't have a default export path, and none was specified.", preset_name);
 			} else if (platform.is_null()) {
 				export_error = vformat("Export preset '%s' doesn't have a matching platform.", preset_name);
@@ -821,7 +821,7 @@ void EditorNode::_fs_changed() {
 			}
 		}
 
-		if (!export_error.empty()) {
+		if (!export_error.is_empty()) {
 			ERR_PRINT(export_error);
 			OS::get_singleton()->set_exit_code(EXIT_FAILURE);
 		}
@@ -1711,7 +1711,7 @@ void EditorNode::_dialog_action(String p_file) {
 			current_obj->_change_notify();
 		} break;
 		case SETTINGS_LAYOUT_SAVE: {
-			if (p_file.empty()) {
+			if (p_file.is_empty()) {
 				return;
 			}
 
@@ -1739,7 +1739,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 		} break;
 		case SETTINGS_LAYOUT_DELETE: {
-			if (p_file.empty()) {
+			if (p_file.is_empty()) {
 				return;
 			}
 
@@ -1822,7 +1822,7 @@ void EditorNode::edit_item(Object *p_object) {
 		sub_plugins = editor_data.get_subeditors(p_object);
 	}
 
-	if (!sub_plugins.empty()) {
+	if (!sub_plugins.is_empty()) {
 		bool same = true;
 		if (sub_plugins.size() == editor_plugins_over->get_plugins_list().size()) {
 			for (int i = 0; i < sub_plugins.size(); i++) {
@@ -1998,7 +1998,7 @@ void EditorNode::_edit_current() {
 							multi_nodes.push_back(node);
 						}
 					}
-					if (!multi_nodes.empty()) {
+					if (!multi_nodes.is_empty()) {
 						// Pick the top-most node
 						multi_nodes.sort_custom<Node::Comparator>();
 						selected_node = multi_nodes.front()->get();
@@ -2080,13 +2080,13 @@ void EditorNode::_edit_current() {
 			sub_plugins = editor_data.get_subeditors(current_obj);
 		}
 
-		if (!sub_plugins.empty()) {
+		if (!sub_plugins.is_empty()) {
 			_display_top_editors(false);
 
 			_set_top_editors(sub_plugins);
 			_set_editing_top_editors(current_obj);
 			_display_top_editors(true);
-		} else if (!editor_plugins_over->get_plugins_list().empty()) {
+		} else if (!editor_plugins_over->get_plugins_list().is_empty()) {
 			hide_top_editors();
 		}
 	}
@@ -2256,7 +2256,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		} break;
 		case FILE_OPEN_PREV: {
-			if (previous_scenes.empty()) {
+			if (previous_scenes.is_empty()) {
 				break;
 			}
 			opening_prev = true;
@@ -2527,7 +2527,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		} break;
 		case RUN_PLAY_CUSTOM_SCENE: {
-			if (run_custom_filename.empty() || editor_run.get_status() == EditorRun::STATUS_STOP) {
+			if (run_custom_filename.is_empty() || editor_run.get_status() == EditorRun::STATUS_STOP) {
 				_menu_option_confirm(RUN_STOP, true);
 				quick_run->popup_dialog("PackedScene", true);
 				quick_run->set_title(TTR("Quick Run Scene..."));
@@ -2876,7 +2876,7 @@ void EditorNode::_update_file_menu_opened() {
 	Ref<Shortcut> reopen_closed_scene_sc = ED_GET_SHORTCUT("editor/reopen_closed_scene");
 	reopen_closed_scene_sc->set_name(TTR("Reopen Closed Scene"));
 	PopupMenu *pop = file_menu->get_popup();
-	pop->set_item_disabled(pop->get_item_index(FILE_OPEN_PREV), previous_scenes.empty());
+	pop->set_item_disabled(pop->get_item_index(FILE_OPEN_PREV), previous_scenes.is_empty());
 }
 
 void EditorNode::_update_file_menu_closed() {
@@ -3823,7 +3823,7 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 }
 
 Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p_fallback) const {
-	ERR_FAIL_COND_V_MSG(p_class.empty(), nullptr, "Class name cannot be empty.");
+	ERR_FAIL_COND_V_MSG(p_class.is_empty(), nullptr, "Class name cannot be empty.");
 
 	if (ScriptServer::is_global_class(p_class)) {
 		Ref<ImageTexture> icon;
@@ -4555,7 +4555,7 @@ bool EditorNode::has_scenes_in_session() {
 		return false;
 	}
 	Array scenes = config->get_value("EditorNode", "open_scenes");
-	return !scenes.empty();
+	return !scenes.is_empty();
 }
 
 bool EditorNode::ensure_main_scene(bool p_from_native) {
@@ -4781,7 +4781,7 @@ void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
 				Ref<Shortcut> undo_close_tab_sc = ED_GET_SHORTCUT("editor/reopen_closed_scene");
 				undo_close_tab_sc->set_name(TTR("Undo Close Tab"));
 				scene_tabs_context_menu->add_shortcut(undo_close_tab_sc, FILE_OPEN_PREV);
-				if (previous_scenes.empty()) {
+				if (previous_scenes.is_empty()) {
 					scene_tabs_context_menu->set_item_disabled(scene_tabs_context_menu->get_item_index(FILE_OPEN_PREV), true);
 				}
 				scene_tabs_context_menu->add_item(TTR("Close Other Tabs"), FILE_CLOSE_OTHERS);
@@ -5185,7 +5185,7 @@ void EditorNode::_add_dropped_files_recursive(const Vector<String> &p_files, Str
 				next_file = sub_dir->get_next();
 			}
 
-			if (!sub_files.empty()) {
+			if (!sub_files.is_empty()) {
 				dir->make_dir(to);
 				_add_dropped_files_recursive(sub_files, to);
 			}
@@ -6950,8 +6950,8 @@ void EditorPluginList::remove_plugin(EditorPlugin *p_plugin) {
 	plugins_list.erase(p_plugin);
 }
 
-bool EditorPluginList::empty() {
-	return plugins_list.empty();
+bool EditorPluginList::is_empty() {
+	return plugins_list.is_empty();
 }
 
 void EditorPluginList::clear() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -903,7 +903,7 @@ public:
 	void add_plugin(EditorPlugin *p_plugin);
 	void remove_plugin(EditorPlugin *p_plugin);
 	void clear();
-	bool empty();
+	bool is_empty();
 
 	EditorPluginList();
 	~EditorPluginList();

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -128,7 +128,7 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 		Main::iteration();
 		Main::iteration();
 		Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
-		ERR_CONTINUE(!img.is_valid() || img->empty());
+		ERR_CONTINUE(!img.is_valid() || img->is_empty());
 		Ref<ImageTexture> it(memnew(ImageTexture));
 		it->create_from_image(img);
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2356,7 +2356,7 @@ void EditorPropertyResource::_file_selected(const String &p_path) {
 			property_types = E->get().hint_string;
 		}
 	}
-	if (!property_types.empty()) {
+	if (!property_types.is_empty()) {
 		bool any_type_matches = false;
 		const Vector<String> split_property_types = property_types.split(",");
 		for (int i = 0; i < split_property_types.size(); ++i) {
@@ -2514,7 +2514,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 				update_property();
 				break;
 			}
-			ERR_FAIL_COND(inheritors_array.empty());
+			ERR_FAIL_COND(inheritors_array.is_empty());
 
 			String intype = inheritors_array[p_which - TYPE_BASE_ID];
 
@@ -2658,7 +2658,7 @@ void EditorPropertyResource::_update_menu_items() {
 
 				bool is_custom_resource = false;
 				Ref<Texture2D> icon;
-				if (!custom_resources.empty()) {
+				if (!custom_resources.is_empty()) {
 					for (int j = 0; j < custom_resources.size(); j++) {
 						if (custom_resources[j].name == t) {
 							is_custom_resource = true;

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -550,7 +550,7 @@ void EditorPropertyArray::_length_changed(double p_page) {
 void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint_string) {
 	array_type = p_array_type;
 
-	if (array_type == Variant::ARRAY && !p_hint_string.empty()) {
+	if (array_type == Variant::ARRAY && !p_hint_string.is_empty()) {
 		int hint_subtype_separator = p_hint_string.find(":");
 		if (hint_subtype_separator >= 0) {
 			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -46,7 +46,7 @@ void EditorRunNative::_notification(int p_what) {
 				Ref<Image> im = icon->get_data();
 				im = im->duplicate();
 				im->clear_mipmaps();
-				if (!im->empty()) {
+				if (!im->is_empty()) {
 					im->resize(16 * EDSCALE, 16 * EDSCALE);
 					Ref<ImageTexture> small_icon;
 					small_icon.instance();

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -234,7 +234,7 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		if (!filter.empty() && pi.name.findn(filter) == -1 && pi.name.replace("/", " ").capitalize().findn(filter) == -1) {
+		if (!filter.is_empty() && pi.name.findn(filter) == -1 && pi.name.replace("/", " ").capitalize().findn(filter) == -1) {
 			continue;
 		}
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -281,7 +281,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 			locales_to_skip.push_back("te"); // Telugu
 		}
 
-		if (!locales_to_skip.empty()) {
+		if (!locales_to_skip.is_empty()) {
 			WARN_PRINT("Some locales are not properly supported by selected Text Server and are disabled.");
 		}
 
@@ -1476,7 +1476,7 @@ bool EditorSettings::is_default_text_editor_theme() {
 Vector<String> EditorSettings::get_script_templates(const String &p_extension, const String &p_custom_path) {
 	Vector<String> templates;
 	String template_dir = get_script_templates_dir();
-	if (!p_custom_path.empty()) {
+	if (!p_custom_path.is_empty()) {
 		template_dir = p_custom_path;
 	}
 	DirAccess *d = DirAccess::open(template_dir);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -531,7 +531,7 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 	}
 
 	String file_name = p_path.get_file();
-	if (!file_name.empty()) {
+	if (!file_name.is_empty()) {
 		for (int i = 0; i < files->get_item_count(); i++) {
 			if (files->get_item_text(i) == file_name) {
 				files->select(i, true);
@@ -1528,7 +1528,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_ove
 	if (!p_overwrite) {
 		to_move_path = p_to_path;
 		Vector<String> conflicting_items = _check_existing();
-		if (!conflicting_items.empty()) {
+		if (!conflicting_items.is_empty()) {
 			// Ask to do something.
 			overwrite_dialog->set_text(vformat(
 					TTR("The following files or folders conflict with items in the target location '%s':\n\n%s\n\nDo you wish to overwrite them?"),
@@ -1721,7 +1721,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 					paths.push_back(fpath);
 				}
 			}
-			if (!paths.empty()) {
+			if (!paths.is_empty()) {
 				emit_signal("instance", paths);
 			}
 		} break;
@@ -1753,7 +1753,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 
 		case FILE_DEPENDENCIES: {
 			// Checkout the file dependencies.
-			if (!p_selected.empty()) {
+			if (!p_selected.is_empty()) {
 				String fpath = p_selected[0];
 				deps_editor->edit(fpath);
 			}
@@ -1761,7 +1761,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 
 		case FILE_OWNERS: {
 			// Checkout the file owners.
-			if (!p_selected.empty()) {
+			if (!p_selected.is_empty()) {
 				String fpath = p_selected[0];
 				owners_editor->show(fpath);
 			}
@@ -1784,7 +1784,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 
 		case FILE_RENAME: {
 			// Rename the active file.
-			if (!p_selected.empty()) {
+			if (!p_selected.is_empty()) {
 				to_rename.path = p_selected[0];
 				if (to_rename.path != "res://") {
 					to_rename.is_file = !to_rename.path.ends_with("/");
@@ -1885,7 +1885,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_COPY_PATH: {
-			if (!p_selected.empty()) {
+			if (!p_selected.is_empty()) {
 				String fpath = p_selected[0];
 				DisplayServer::get_singleton()->clipboard_set(fpath);
 			}
@@ -2013,7 +2013,7 @@ Variant FileSystemDock::get_drag_data_fw(const Point2 &p_point, Control *p_from)
 		all_not_favorites = true;
 	}
 
-	if (paths.empty()) {
+	if (paths.is_empty()) {
 		return Variant();
 	}
 
@@ -2061,7 +2061,7 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
-		return !to_dir.empty();
+		return !to_dir.is_empty();
 	}
 
 	if (drag_data.has("type") && (String(drag_data["type"]) == "files" || String(drag_data["type"]) == "files_and_dirs")) {
@@ -2074,7 +2074,7 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 			return true;
 		}
 
-		if (to_dir.empty()) {
+		if (to_dir.is_empty()) {
 			return false;
 		}
 
@@ -2169,7 +2169,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
-		if (res.is_valid() && !to_dir.empty()) {
+		if (res.is_valid() && !to_dir.is_empty()) {
 			EditorNode::get_singleton()->push_item(res.ptr());
 			EditorNode::get_singleton()->save_resource_as(res, to_dir);
 		}
@@ -2180,7 +2180,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
-		if (!to_dir.empty()) {
+		if (!to_dir.is_empty()) {
 			Vector<String> fnames = drag_data["files"];
 			to_move.clear();
 			for (int i = 0; i < fnames.size(); i++) {
@@ -2188,7 +2188,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 					to_move.push_back(FileOrFolder(fnames[i], !fnames[i].ends_with("/")));
 				}
 			}
-			if (!to_move.empty()) {
+			if (!to_move.is_empty()) {
 				if (Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 					for (int i = 0; i < to_move.size(); i++) {
 						String new_path;
@@ -2291,7 +2291,7 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 
 void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<String> p_paths, bool p_display_path_dependent_options) {
 	// Add options for files and folders.
-	ERR_FAIL_COND_MSG(p_paths.empty(), "Path cannot be empty.");
+	ERR_FAIL_COND_MSG(p_paths.is_empty(), "Path cannot be empty.");
 
 	Vector<String> filenames;
 	Vector<String> foldernames;
@@ -2414,7 +2414,7 @@ void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
 	}
 
 	// Popup.
-	if (!paths.empty()) {
+	if (!paths.is_empty()) {
 		tree_popup->set_size(Size2(1, 1));
 		_file_and_folders_fill_popup(tree_popup, paths);
 		tree_popup->set_position(tree->get_screen_position() + p_pos);
@@ -2454,7 +2454,7 @@ void FileSystemDock::_file_list_rmb_select(int p_item, const Vector2 &p_pos) {
 	}
 
 	// Popup.
-	if (!paths.empty()) {
+	if (!paths.is_empty()) {
 		file_list_popup->clear();
 		file_list_popup->set_size(Size2(1, 1));
 		_file_and_folders_fill_popup(file_list_popup, paths, searched_string.length() == 0);

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -499,8 +499,8 @@ void FindInFilesDialog::_on_search_text_modified(String text) {
 	ERR_FAIL_COND(!_find_button);
 	ERR_FAIL_COND(!_replace_button);
 
-	_find_button->set_disabled(get_search_text().empty());
-	_replace_button->set_disabled(get_search_text().empty());
+	_find_button->set_disabled(get_search_text().is_empty());
+	_replace_button->set_disabled(get_search_text().is_empty());
 }
 
 void FindInFilesDialog::_on_search_text_entered(String text) {

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -198,7 +198,7 @@ void GroupDialog::_add_group(String p_name) {
 	}
 
 	String name = p_name.strip_edges();
-	if (name.empty() || groups->get_item_with_text(name)) {
+	if (name.is_empty() || groups->get_item_with_text(name)) {
 		return;
 	}
 
@@ -551,7 +551,7 @@ void GroupsEditor::_add_group(const String &p_group) {
 	}
 
 	const String name = group_name->get_text().strip_edges();
-	if (name.empty()) {
+	if (name.is_empty()) {
 		return;
 	}
 

--- a/editor/import/collada.cpp
+++ b/editor/import/collada.cpp
@@ -1365,7 +1365,7 @@ Collada::Node *Collada::_parse_visual_instance_geometry(XMLParser &parser) {
 	}
 
 	if (geom->controller) {
-		if (geom->skeletons.empty()) {
+		if (geom->skeletons.is_empty()) {
 			//XSI style
 
 			if (state.skin_controller_data_map.has(geom->source)) {
@@ -2321,7 +2321,7 @@ void Collada::_optimize() {
 				i--;
 			}
 
-			while (!mgeom.empty()) {
+			while (!mgeom.is_empty()) {
 				Node *n = mgeom.front()->get();
 				n->parent->children.push_back(n);
 				mgeom.pop_front();

--- a/editor/import/collada.h
+++ b/editor/import/collada.h
@@ -274,7 +274,7 @@ public:
 					if (normal == p_vert.normal) {
 						if (uv == p_vert.uv) {
 							if (uv2 == p_vert.uv2) {
-								if (!weights.empty() || !p_vert.weights.empty()) {
+								if (!weights.is_empty() || !p_vert.weights.is_empty()) {
 									if (weights.size() == p_vert.weights.size()) {
 										for (int i = 0; i < weights.size(); i++) {
 											if (weights[i].bone_idx != p_vert.weights[i].bone_idx) {

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1027,7 +1027,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 
 					Vector<String> skeletons = ng2->skeletons;
 
-					ERR_FAIL_COND_V(skeletons.empty(), ERR_INVALID_DATA);
+					ERR_FAIL_COND_V(skeletons.is_empty(), ERR_INVALID_DATA);
 
 					String skname = skeletons[0];
 					ERR_FAIL_COND_V(!node_map.has(skname), ERR_INVALID_DATA);
@@ -1471,7 +1471,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 				}
 
 				Vector<float> data = at.get_value_at_time(snapshots[i]);
-				ERR_CONTINUE(data.empty());
+				ERR_CONTINUE(data.is_empty());
 
 				Collada::Node::XForm &xf = cn->xform_list.write[xform_idx];
 

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -373,7 +373,7 @@ Error ResourceImporterLayeredTexture::import(const String &p_source_file, const 
 			int x = slice_w * j;
 			int y = slice_h * i;
 			Ref<Image> slice = image->get_rect(Rect2(x, y, slice_w, slice_h));
-			ERR_CONTINUE(slice.is_null() || slice->empty());
+			ERR_CONTINUE(slice.is_null() || slice->is_empty());
 			if (slice->get_width() != slice_w || slice->get_height() != slice_h) {
 				slice->resize(slice_w, slice_h);
 			}

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1468,7 +1468,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 
 				if (!ret_used_cache) {
 					// Cache was not used, add the generated entry to the current cache
-					if (cache_data.empty()) {
+					if (cache_data.is_empty()) {
 						cache_data.resize(4 + ret_cache_size);
 						int *data = (int *)cache_data.ptrw();
 						data[0] = 1;

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -82,7 +82,7 @@ void ResourceImporterTexture::update_imports() {
 	MutexLock lock(mutex);
 	Vector<String> to_reimport;
 	{
-		if (make_flags.empty()) {
+		if (make_flags.is_empty()) {
 			return;
 		}
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -452,7 +452,7 @@ void InspectorDock::update(Object *p_object) {
 	List<MethodInfo> methods;
 	p_object->get_method_list(&methods);
 
-	if (!methods.empty()) {
+	if (!methods.is_empty()) {
 		bool found = false;
 		List<MethodInfo>::Element *I = methods.front();
 		int i = 0;

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -198,7 +198,7 @@ void EditorNode3DGizmo::add_mesh(const Ref<ArrayMesh> &p_mesh, bool p_billboard,
 }
 
 void EditorNode3DGizmo::add_lines(const Vector<Vector3> &p_lines, const Ref<Material> &p_material, bool p_billboard, const Color &p_modulate) {
-	if (p_lines.empty()) {
+	if (p_lines.is_empty()) {
 		return;
 	}
 
@@ -4205,7 +4205,7 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		}
 	}
 
-	if (faces.empty()) {
+	if (faces.is_empty()) {
 		return;
 	}
 
@@ -4521,7 +4521,7 @@ Joint3DGizmoPlugin::Joint3DGizmoPlugin() {
 }
 
 void Joint3DGizmoPlugin::incremental_update_gizmos() {
-	if (!current_gizmos.empty()) {
+	if (!current_gizmos.is_empty()) {
 		update_idx++;
 		update_idx = update_idx % current_gizmos.size();
 		redraw(current_gizmos[update_idx]);

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -126,7 +126,7 @@ void PluginConfigDialog::_on_cancelled() {
 void PluginConfigDialog::_on_required_text_changed(const String &) {
 	int lang_idx = script_option_edit->get_selected();
 	String ext = ScriptServer::get_language(lang_idx)->get_extension();
-	get_ok_button()->set_disabled(script_edit->get_text().get_basename().empty() || script_edit->get_text().get_extension() != ext || name_edit->get_text().empty());
+	get_ok_button()->set_disabled(script_edit->get_text().get_basename().is_empty() || script_edit->get_text().get_extension() != ext || name_edit->get_text().is_empty());
 }
 
 void PluginConfigDialog::_notification(int p_what) {

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -416,7 +416,7 @@ void AnimationNodeBlendTreeEditor::_delete_nodes_request() {
 		}
 	}
 
-	if (to_erase.empty()) {
+	if (to_erase.is_empty()) {
 		return;
 	}
 
@@ -537,7 +537,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 					default: {
 					} break;
 				}
-				if (!track_type_name.empty()) {
+				if (!track_type_name.is_empty()) {
 					types[track_path].insert(track_type_name);
 				}
 			}

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -680,7 +680,7 @@ void AnimationPlayerEditor::set_state(const Dictionary &p_state) {
 
 			if (p_state.has("animation")) {
 				String anim = p_state["animation"];
-				if (!anim.empty() && player->has_animation(anim)) {
+				if (!anim.is_empty() && player->has_animation(anim)) {
 					_select_anim_by_name(anim);
 					_animation_edit();
 				}

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -702,7 +702,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PackedB
 			}
 		}
 
-		if (!image->empty()) {
+		if (!image->is_empty()) {
 			switch (image_queue[p_queue_id].image_type) {
 				case IMAGE_QUEUE_ICON:
 
@@ -1151,7 +1151,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 			asset_bottom_page = _make_pages(page, pages, page_len, total_items, result.size());
 			library_vb->add_child(asset_bottom_page);
 
-			if (result.empty()) {
+			if (result.is_empty()) {
 				if (filter->get_text() != String()) {
 					library_error->set_text(
 							vformat(TTR("No results for \"%s\"."), filter->get_text()));
@@ -1188,7 +1188,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				}
 			}
 
-			if (!result.empty()) {
+			if (!result.is_empty()) {
 				library_scroll->set_v_scroll(0);
 			}
 		} break;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -518,7 +518,7 @@ void CanvasItemEditor::_keying_changed() {
 }
 
 Rect2 CanvasItemEditor::_get_encompassing_rect_from_list(List<CanvasItem *> p_list) {
-	ERR_FAIL_COND_V(p_list.empty(), Rect2());
+	ERR_FAIL_COND_V(p_list.is_empty(), Rect2());
 
 	// Handles the first element
 	CanvasItem *canvas_item = p_list.front()->get();
@@ -1147,7 +1147,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						if (dragged_guide_index >= 0) {
 							vguides.remove(dragged_guide_index);
 							undo_redo->create_action(TTR("Remove Vertical Guide"));
-							if (vguides.empty()) {
+							if (vguides.is_empty()) {
 								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_vertical_guides_");
 							} else {
 								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
@@ -1180,7 +1180,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						if (dragged_guide_index >= 0) {
 							hguides.remove(dragged_guide_index);
 							undo_redo->create_action(TTR("Remove Horizontal Guide"));
-							if (hguides.empty()) {
+							if (hguides.is_empty()) {
 								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_horizontal_guides_");
 							} else {
 								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
@@ -2400,7 +2400,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 				_select_click_on_item(item, click, b->get_shift());
 
 				return true;
-			} else if (!selection_results.empty()) {
+			} else if (!selection_results.is_empty()) {
 				// Sorts items according the their z-index
 				selection_results.sort();
 
@@ -2463,13 +2463,13 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 			// Retrieve the bones
 			Vector<_SelectResult> selection = Vector<_SelectResult>();
 			_get_bones_at_pos(click, selection);
-			if (!selection.empty()) {
+			if (!selection.is_empty()) {
 				canvas_item = selection[0].item;
 			} else {
 				// Retrieve the canvas items
 				selection = Vector<_SelectResult>();
 				_get_canvas_items_at_pos(click, selection);
-				if (!selection.empty()) {
+				if (!selection.is_empty()) {
 					canvas_item = selection[0].item;
 				}
 			}
@@ -3916,7 +3916,7 @@ void CanvasItemEditor::_draw_viewport() {
 	bool all_locked = true;
 	bool all_group = true;
 	List<Node *> selection = editor_selection->get_selected_node_list();
-	if (selection.empty()) {
+	if (selection.is_empty()) {
 		all_locked = false;
 		all_group = false;
 	} else {
@@ -3935,10 +3935,10 @@ void CanvasItemEditor::_draw_viewport() {
 	}
 
 	lock_button->set_visible(!all_locked);
-	lock_button->set_disabled(selection.empty());
+	lock_button->set_disabled(selection.is_empty());
 	unlock_button->set_visible(all_locked);
 	group_button->set_visible(!all_group);
-	group_button->set_disabled(selection.empty());
+	group_button->set_disabled(selection.is_empty());
 	ungroup_button->set_visible(all_group);
 
 	info_overlay->set_offset(SIDE_LEFT, (show_rulers ? RULER_WIDTH : 0) + 10);
@@ -3956,11 +3956,11 @@ void CanvasItemEditor::_draw_viewport() {
 	RenderingServer::get_singleton()->canvas_item_add_set_transform(ci, Transform2D());
 
 	EditorPluginList *over_plugin_list = editor->get_editor_plugins_over();
-	if (!over_plugin_list->empty()) {
+	if (!over_plugin_list->is_empty()) {
 		over_plugin_list->forward_canvas_draw_over_viewport(viewport);
 	}
 	EditorPluginList *force_over_plugin_list = editor->get_editor_plugins_force_over();
-	if (!force_over_plugin_list->empty()) {
+	if (!force_over_plugin_list->is_empty()) {
 		force_over_plugin_list->forward_canvas_force_draw_over_viewport(viewport);
 	}
 

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -106,7 +106,7 @@ Ref<Texture2D> EditorTexturePreviewPlugin::generate(const RES &p_from, const Siz
 		}
 	}
 
-	if (img.is_null() || img->empty()) {
+	if (img.is_null() || img->is_empty()) {
 		return Ref<Texture2D>();
 	}
 
@@ -150,7 +150,7 @@ bool EditorImagePreviewPlugin::handles(const String &p_type) const {
 Ref<Texture2D> EditorImagePreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
 	Ref<Image> img = p_from;
 
-	if (img.is_null() || img->empty()) {
+	if (img.is_null() || img->is_empty()) {
 		return Ref<Image>();
 	}
 

--- a/editor/plugins/font_editor_plugin.cpp
+++ b/editor/plugins/font_editor_plugin.cpp
@@ -216,7 +216,7 @@ void FontDataEditor::init_script_edit() {
 
 void FontDataEditor::add_lang() {
 	FontData *fd = Object::cast_to<FontData>(get_edited_object());
-	if (fd != nullptr && !le->get_text().empty()) {
+	if (fd != nullptr && !le->get_text().is_empty()) {
 		fd->set_language_support_override(le->get_text(), chk->is_pressed());
 		le->set_text("");
 		chk->set_pressed(false);

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -63,7 +63,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			List<Node *> selection = editor_selection->get_selected_node_list();
 
-			if (selection.empty()) {
+			if (selection.is_empty()) {
 				Ref<Shape3D> shape = mesh->create_trimesh_shape();
 				if (shape.is_null()) {
 					err_dialog->set_text(TTR("Couldn't create a Trimesh collision shape."));

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -612,7 +612,7 @@ void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, bool &r_inclu
 		results.push_back(res);
 	}
 
-	if (results.empty()) {
+	if (results.is_empty()) {
 		return;
 	}
 
@@ -1045,7 +1045,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 			clicked = ObjectID();
 		}
 
-	} else if (!selection_results.empty()) {
+	} else if (!selection_results.is_empty()) {
 		NodePath root_path = get_tree()->get_edited_scene_root()->get_path();
 		StringName root_name = root_path.get_name(root_path.get_name_count() - 1);
 
@@ -1097,7 +1097,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	{
 		EditorNode *en = editor;
 		EditorPluginList *force_input_forwarding_list = en->get_editor_plugins_force_input_forwarding();
-		if (!force_input_forwarding_list->empty()) {
+		if (!force_input_forwarding_list->is_empty()) {
 			bool discard = force_input_forwarding_list->forward_spatial_gui_input(camera, p_event, true);
 			if (discard) {
 				return;
@@ -1107,7 +1107,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	{
 		EditorNode *en = editor;
 		EditorPluginList *over_plugin_list = en->get_editor_plugins_over();
-		if (!over_plugin_list->empty()) {
+		if (!over_plugin_list->is_empty()) {
 			bool discard = over_plugin_list->forward_spatial_gui_input(camera, p_event, false);
 			if (discard) {
 				return;
@@ -2615,12 +2615,12 @@ static void draw_indicator_bar(Control &surface, real_t fill, const Ref<Texture2
 
 void Node3DEditorViewport::_draw() {
 	EditorPluginList *over_plugin_list = EditorNode::get_singleton()->get_editor_plugins_over();
-	if (!over_plugin_list->empty()) {
+	if (!over_plugin_list->is_empty()) {
 		over_plugin_list->forward_spatial_draw_over_viewport(surface);
 	}
 
 	EditorPluginList *force_over_plugin_list = editor->get_editor_plugins_force_over();
-	if (!force_over_plugin_list->empty()) {
+	if (!force_over_plugin_list->is_empty()) {
 		force_over_plugin_list->forward_spatial_force_draw_over_viewport(surface);
 	}
 
@@ -5778,7 +5778,7 @@ void Node3DEditor::_refresh_menu_icons() {
 
 	List<Node *> &selection = editor_selection->get_selected_node_list();
 
-	if (selection.empty()) {
+	if (selection.is_empty()) {
 		all_locked = false;
 		all_grouped = false;
 	} else {
@@ -5797,11 +5797,11 @@ void Node3DEditor::_refresh_menu_icons() {
 	}
 
 	tool_button[TOOL_LOCK_SELECTED]->set_visible(!all_locked);
-	tool_button[TOOL_LOCK_SELECTED]->set_disabled(selection.empty());
+	tool_button[TOOL_LOCK_SELECTED]->set_disabled(selection.is_empty());
 	tool_button[TOOL_UNLOCK_SELECTED]->set_visible(all_locked);
 
 	tool_button[TOOL_GROUP_SELECTED]->set_visible(!all_grouped);
-	tool_button[TOOL_GROUP_SELECTED]->set_disabled(selection.empty());
+	tool_button[TOOL_GROUP_SELECTED]->set_disabled(selection.is_empty());
 	tool_button[TOOL_UNGROUP_SELECTED]->set_visible(all_grouped);
 }
 

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -81,14 +81,14 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 				Vector<String> str_values = property_value;
 				for (int k = 0; k < str_values.size(); k++) {
 					String desc = str_values[k].get_slice(";", 1).strip_edges();
-					if (!desc.empty()) {
+					if (!desc.is_empty()) {
 						parsed_strings.push_back(desc);
 					}
 				}
 			} else if (property_value.get_type() == Variant::STRING) {
 				String str_value = String(property_value);
 				// Prevent reading text containing only spaces.
-				if (!str_value.strip_edges().empty()) {
+				if (!str_value.strip_edges().is_empty()) {
 					parsed_strings.push_back(str_value);
 				}
 			}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -587,7 +587,7 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 }
 
 void ScriptEditor::_add_recent_script(String p_path) {
-	if (p_path.empty()) {
+	if (p_path.is_empty()) {
 		return;
 	}
 
@@ -702,7 +702,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save, bool p_history_back) {
 			}
 		}
 		if (script.is_valid()) {
-			if (!script->get_path().empty()) {
+			if (!script->get_path().is_empty()) {
 				// Only saved scripts can be restored.
 				previous_scripts.push_back(script->get_path());
 			}
@@ -1129,7 +1129,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			return;
 		} break;
 		case FILE_REOPEN_CLOSED: {
-			if (previous_scripts.empty()) {
+			if (previous_scripts.is_empty()) {
 				return;
 			}
 
@@ -1381,7 +1381,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			case SHOW_IN_FILE_SYSTEM: {
 				const RES script = current->get_edited_resource();
 				const String path = script->get_path();
-				if (!path.empty()) {
+				if (!path.is_empty()) {
 					FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
 					file_system_dock->navigate_to_path(path);
 					// Ensure that the FileSystem dock is visible.
@@ -1887,7 +1887,7 @@ void ScriptEditor::_update_script_names() {
 		if (se) {
 			Ref<Texture2D> icon = se->get_theme_icon();
 			String path = se->get_edited_resource()->get_path();
-			bool saved = !path.empty();
+			bool saved = !path.is_empty();
 			if (saved) {
 				// The script might be deleted, moved, or renamed, so make sure
 				// to update original path to previously edited resource.
@@ -1934,7 +1934,7 @@ void ScriptEditor::_update_script_names() {
 					sd.name = name;
 				} break;
 				case DISPLAY_DIR_AND_NAME: {
-					if (!path.get_base_dir().get_file().empty()) {
+					if (!path.get_base_dir().get_file().is_empty()) {
 						sd.name = path.get_base_dir().get_file().plus_file(name);
 					} else {
 						sd.name = name;
@@ -1988,7 +1988,7 @@ void ScriptEditor::_update_script_names() {
 		}
 	}
 
-	if (_sort_list_on_update && !sedata.empty()) {
+	if (_sort_list_on_update && !sedata.is_empty()) {
 		sedata.sort();
 
 		// change actual order of tab_container so that the order can be rearranged by user
@@ -2052,7 +2052,7 @@ void ScriptEditor::_update_script_names() {
 	_update_help_overview_visibility();
 	_update_script_colors();
 
-	file_menu->get_popup()->set_item_disabled(file_menu->get_popup()->get_item_index(FILE_REOPEN_CLOSED), previous_scripts.empty());
+	file_menu->get_popup()->set_item_disabled(file_menu->get_popup()->get_item_index(FILE_REOPEN_CLOSED), previous_scripts.is_empty());
 }
 
 void ScriptEditor::_update_script_connections() {
@@ -2806,7 +2806,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 		String path = scripts[i];
 
 		Dictionary script_info = scripts[i];
-		if (!script_info.empty()) {
+		if (!script_info.is_empty()) {
 			path = script_info["path"];
 		}
 
@@ -2833,7 +2833,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 			}
 		}
 
-		if (!script_info.empty()) {
+		if (!script_info.is_empty()) {
 			ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(tab_container->get_tab_count() - 1));
 			if (se) {
 				se->set_edit_state(script_info["state"]);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -349,7 +349,7 @@ void ScriptTextEditor::update_settings() {
 bool ScriptTextEditor::is_unsaved() {
 	const bool unsaved =
 			code_editor->get_text_editor()->get_version() != code_editor->get_text_editor()->get_saved_version() ||
-			script->get_path().empty(); // In memory.
+			script->get_path().is_empty(); // In memory.
 	return unsaved;
 }
 
@@ -427,7 +427,7 @@ String ScriptTextEditor::get_name() {
 	if (script->get_path().find("local://") == -1 && script->get_path().find("::") == -1) {
 		name = script->get_path().get_file();
 		if (is_unsaved()) {
-			if (script->get_path().empty()) {
+			if (script->get_path().is_empty()) {
 				name = TTR("[unsaved]");
 			}
 			name += "(*)";
@@ -551,7 +551,7 @@ void ScriptTextEditor::_validate_script() {
 			if (safe_lines.has(i + 1)) {
 				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 				last_is_safe = true;
-			} else if (last_is_safe && (te->is_line_comment(i) || te->get_line(i).strip_edges().empty())) {
+			} else if (last_is_safe && (te->is_line_comment(i) || te->get_line(i).strip_edges().is_empty())) {
 				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 			} else {
 				te->set_line_gutter_item_color(i, line_number_gutter, default_line_number_color);

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -59,7 +59,7 @@ void ShaderFileEditor::_version_selected(int p_option) {
 	ERR_FAIL_COND(bytecode.is_null());
 
 	for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
-		if (bytecode->get_stage_bytecode(RD::ShaderStage(i)).empty() && bytecode->get_stage_compile_error(RD::ShaderStage(i)) == String()) {
+		if (bytecode->get_stage_bytecode(RD::ShaderStage(i)).is_empty() && bytecode->get_stage_compile_error(RD::ShaderStage(i)) == String()) {
 			stages[i]->set_icon(Ref<Texture2D>());
 			continue;
 		}
@@ -182,7 +182,7 @@ void ShaderFileEditor::_update_options() {
 	for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
 		Vector<uint8_t> bc = bytecode->get_stage_bytecode(RD::ShaderStage(i));
 		String error = bytecode->get_stage_compile_error(RD::ShaderStage(i));
-		bool disable = error == String() && bc.empty();
+		bool disable = error == String() && bc.is_empty();
 		stages[i]->set_disabled(disable);
 		if (!disable) {
 			if (stages[i]->is_pressed()) {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -293,7 +293,7 @@ void BoneTransformEditor::_key_button_pressed() {
 	const BoneId bone_id = property.get_slicec('/', 1).to_int();
 	const String name = skeleton->get_bone_name(bone_id);
 
-	if (name.empty())
+	if (name.is_empty())
 		return;
 
 	// Need to normalize the basis before you key it

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -340,7 +340,7 @@ void Sprite2DEditor::_convert_to_mesh_2d_node() {
 }
 
 void Sprite2DEditor::_convert_to_polygon_2d_node() {
-	if (computed_outline_lines.empty()) {
+	if (computed_outline_lines.is_empty()) {
 		err_dialog->set_text(TTR("Invalid geometry, can't create polygon."));
 		err_dialog->popup_centered();
 		return;
@@ -398,7 +398,7 @@ void Sprite2DEditor::_convert_to_polygon_2d_node() {
 }
 
 void Sprite2DEditor::_create_collision_polygon_2d_node() {
-	if (computed_outline_lines.empty()) {
+	if (computed_outline_lines.is_empty()) {
 		err_dialog->set_text(TTR("Invalid geometry, can't create collision polygon."));
 		err_dialog->popup_centered();
 		return;
@@ -420,7 +420,7 @@ void Sprite2DEditor::_create_collision_polygon_2d_node() {
 }
 
 void Sprite2DEditor::_create_light_occluder_2d_node() {
-	if (computed_outline_lines.empty()) {
+	if (computed_outline_lines.is_empty()) {
 		err_dialog->set_text(TTR("Invalid geometry, can't create light occluder."));
 		err_dialog->popup_centered();
 		return;

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -318,7 +318,7 @@ void SpriteFramesEditor::_file_load_request(const Vector<String> &p_path, int p_
 		resources.push_back(resource);
 	}
 
-	if (resources.empty()) {
+	if (resources.is_empty()) {
 		return;
 	}
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -119,7 +119,7 @@ String TextEditor::get_name() {
 	if (text_file->get_path().find("local://") == -1 && text_file->get_path().find("::") == -1) {
 		name = text_file->get_path().get_file();
 		if (is_unsaved()) {
-			if (text_file->get_path().empty()) {
+			if (text_file->get_path().is_empty()) {
 				name = TTR("[unsaved]");
 			}
 			name += "(*)";
@@ -242,7 +242,7 @@ void TextEditor::apply_code() {
 bool TextEditor::is_unsaved() {
 	const bool unsaved =
 			code_editor->get_text_editor()->get_version() != code_editor->get_text_editor()->get_saved_version() ||
-			text_file->get_path().empty(); // In memory.
+			text_file->get_path().is_empty(); // In memory.
 	return unsaved;
 }
 

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -449,7 +449,7 @@ void TileMapEditor::_update_palette() {
 
 	List<int> tiles;
 	tileset->get_tile_list(&tiles);
-	if (tiles.empty()) {
+	if (tiles.is_empty()) {
 		return;
 	}
 
@@ -1779,7 +1779,7 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 				return;
 			}
 
-			if (paint_undo.empty()) {
+			if (paint_undo.is_empty()) {
 				return;
 			}
 
@@ -1810,7 +1810,7 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 				}
 			}
 		} else if (tool == TOOL_PASTING) {
-			if (copydata.empty()) {
+			if (copydata.is_empty()) {
 				return;
 			}
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1015,7 +1015,7 @@ void VisualShaderEditor::_update_options_menu() {
 	TreeItem *root = members->create_item();
 
 	String filter = node_filter->get_text().strip_edges();
-	bool use_filter = !filter.empty();
+	bool use_filter = !filter.is_empty();
 
 	bool is_first_item = true;
 
@@ -2108,7 +2108,7 @@ void VisualShaderEditor::_delete_nodes_request() {
 		}
 	}
 
-	if (to_erase.empty()) {
+	if (to_erase.is_empty()) {
 		return;
 	}
 
@@ -2145,13 +2145,13 @@ void VisualShaderEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 		}
-		if (to_change.empty() && copy_nodes_buffer.empty()) {
+		if (to_change.is_empty() && copy_nodes_buffer.is_empty()) {
 			_show_members_dialog(true);
 		} else {
-			popup_menu->set_item_disabled(NodeMenuOptions::COPY, to_change.empty());
-			popup_menu->set_item_disabled(NodeMenuOptions::PASTE, copy_nodes_buffer.empty());
-			popup_menu->set_item_disabled(NodeMenuOptions::DELETE, to_change.empty());
-			popup_menu->set_item_disabled(NodeMenuOptions::DUPLICATE, to_change.empty());
+			popup_menu->set_item_disabled(NodeMenuOptions::COPY, to_change.is_empty());
+			popup_menu->set_item_disabled(NodeMenuOptions::PASTE, copy_nodes_buffer.is_empty());
+			popup_menu->set_item_disabled(NodeMenuOptions::DELETE, to_change.is_empty());
+			popup_menu->set_item_disabled(NodeMenuOptions::DUPLICATE, to_change.is_empty());
 			menu_point = graph->get_local_mouse_position();
 			Point2 gpos = Input::get_singleton()->get_mouse_position();
 			popup_menu->set_position(gpos);
@@ -2445,7 +2445,7 @@ void VisualShaderEditor::_duplicate_nodes() {
 
 	_dup_copy_nodes(type, nodes, excluded);
 
-	if (nodes.empty()) {
+	if (nodes.is_empty()) {
 		return;
 	}
 
@@ -2463,7 +2463,7 @@ void VisualShaderEditor::_copy_nodes() {
 }
 
 void VisualShaderEditor::_paste_nodes(bool p_use_custom_position, const Vector2 &p_custom_position) {
-	if (copy_nodes_buffer.empty()) {
+	if (copy_nodes_buffer.is_empty()) {
 		return;
 	}
 

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -135,7 +135,7 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			}
 
 			// Write context.
-			if (!context.empty()) {
+			if (!context.is_empty()) {
 				file->store_line("msgctxt \"" + context + "\"");
 			}
 
@@ -143,7 +143,7 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			_write_msgid(file, msgid, false);
 
 			// Write msgid_plural
-			if (!plural.empty()) {
+			if (!plural.is_empty()) {
 				_write_msgid(file, plural, true);
 				file->store_line("msgstr[0] \"\"");
 				file->store_line("msgstr[1] \"\"\n");
@@ -185,7 +185,7 @@ void POTGenerator::_add_new_msgid(const String &p_msgid, const String &p_context
 		Vector<MsgidData> &v_mdata = all_translation_strings[p_msgid];
 		for (int i = 0; i < v_mdata.size(); i++) {
 			if (v_mdata[i].ctx == p_context) {
-				if (!v_mdata[i].plural.empty() && !p_plural.empty() && v_mdata[i].plural != p_plural) {
+				if (!v_mdata[i].plural.is_empty() && !p_plural.is_empty() && v_mdata[i].plural != p_plural) {
 					WARN_PRINT("Redefinition of plural message (msgid_plural), under the same message (msgid) and context (msgctxt)");
 				}
 				v_mdata.write[i].locations.insert(p_location);

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -111,7 +111,7 @@ void BackgroundProgress::task_step(const String &p_task, int p_step) {
 	bool no_updates = true;
 	{
 		_THREAD_SAFE_METHOD_
-		no_updates = updates.empty();
+		no_updates = updates.is_empty();
 	}
 
 	if (no_updates) {
@@ -218,7 +218,7 @@ void ProgressDialog::end_task(const String &p_task) {
 	memdelete(t.vb);
 	tasks.erase(p_task);
 
-	if (tasks.empty()) {
+	if (tasks.is_empty()) {
 		hide();
 	} else {
 		_popup();

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -516,7 +516,7 @@ void ProjectExportDialog::_script_encryption_key_changed(const String &p_key) {
 bool ProjectExportDialog::_validate_script_encryption_key(const String &p_key) {
 	bool is_valid = false;
 
-	if (!p_key.empty() && p_key.is_valid_hex_number(false) && p_key.length() == 64) {
+	if (!p_key.is_empty() && p_key.is_valid_hex_number(false) && p_key.length() == 64) {
 		is_valid = true;
 	}
 	return is_valid;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1545,7 +1545,7 @@ bool ProjectList::is_any_project_missing() const {
 }
 
 void ProjectList::erase_missing_projects() {
-	if (_projects.empty()) {
+	if (_projects.is_empty()) {
 		return;
 	}
 
@@ -1875,7 +1875,7 @@ void ProjectManager::_dim_window() {
 
 void ProjectManager::_update_project_buttons() {
 	Vector<ProjectList::Item> selected_projects = _project_list->get_selected_projects();
-	bool empty_selection = selected_projects.empty();
+	bool empty_selection = selected_projects.is_empty();
 
 	bool is_missing_project_selected = false;
 	for (int i = 0; i < selected_projects.size(); ++i) {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -156,7 +156,7 @@ void ProjectSettingsEditor::_update_advanced_bar() {
 	bool disable_add = true;
 	bool disable_del = true;
 
-	if (!property_box->get_text().empty()) {
+	if (!property_box->get_text().is_empty()) {
 		const String setting = _get_setting_name();
 		bool setting_exists = ps->has_setting(setting);
 		if (setting_exists) {
@@ -197,7 +197,7 @@ void ProjectSettingsEditor::_update_advanced_bar() {
 
 String ProjectSettingsEditor::_get_setting_name() const {
 	const String cat = category_box->get_text();
-	const String name = (cat.empty() ? "global" : cat.strip_edges()).plus_file(property_box->get_text().strip_edges());
+	const String name = (cat.is_empty() ? "global" : cat.strip_edges()).plus_file(property_box->get_text().strip_edges());
 	const String feature = feature_override->get_item_text(feature_override->get_selected());
 
 	return (feature == "") ? name : (name + "." + feature);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -251,7 +251,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 						emit_signal("variant_changed");
 						break;
 					}
-					ERR_FAIL_COND(inheritors_array.empty());
+					ERR_FAIL_COND(inheritors_array.is_empty());
 
 					String intype = inheritors_array[p_which - TYPE_BASE_ID];
 
@@ -367,18 +367,18 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				int c = hint_text.get_slice_count(",");
 				float min = 0, max = 100, step = type == Variant::FLOAT ? .01 : 1;
 				if (c >= 1) {
-					if (!hint_text.get_slice(",", 0).empty()) {
+					if (!hint_text.get_slice(",", 0).is_empty()) {
 						min = hint_text.get_slice(",", 0).to_float();
 					}
 				}
 				if (c >= 2) {
-					if (!hint_text.get_slice(",", 1).empty()) {
+					if (!hint_text.get_slice(",", 1).is_empty()) {
 						max = hint_text.get_slice(",", 1).to_float();
 					}
 				}
 
 				if (c >= 3) {
-					if (!hint_text.get_slice(",", 2).empty()) {
+					if (!hint_text.get_slice(",", 2).is_empty()) {
 						step = hint_text.get_slice(",", 2).to_float();
 					}
 				}
@@ -882,7 +882,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 						bool is_custom_resource = false;
 						Ref<Texture2D> icon;
-						if (!custom_resources.empty()) {
+						if (!custom_resources.is_empty()) {
 							for (int k = 0; k < custom_resources.size(); k++) {
 								if (custom_resources[k].name == t) {
 									is_custom_resource = true;
@@ -1246,7 +1246,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 		} break;
 		case Variant::OBJECT: {
 			if (p_which == 0) {
-				ERR_FAIL_COND(inheritors_array.empty());
+				ERR_FAIL_COND(inheritors_array.is_empty());
 
 				String intype = inheritors_array[0];
 

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -572,7 +572,7 @@ void RenameDialog::rename() {
 	// Forward recursive as opposed to the actual renaming.
 	_iterate_scene(root_node, selected_node_list, &global_count);
 
-	if (undo_redo && !to_rename.empty()) {
+	if (undo_redo && !to_rename.is_empty()) {
 		undo_redo->create_action(TTR("Batch Rename"));
 
 		// Make sure to iterate reversed so that child nodes will find parents.

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -361,7 +361,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (current_edited_scene_root) {
 				String root_class = current_edited_scene_root->get_class_name();
 				static Vector<String> preferred_types;
-				if (preferred_types.empty()) {
+				if (preferred_types.is_empty()) {
 					preferred_types.push_back("Control");
 					preferred_types.push_back("Node2D");
 					preferred_types.push_back("Node3D");
@@ -416,7 +416,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			Node *selected = scene_tree->get_selected();
-			if (!selected && !editor_selection->get_selected_node_list().empty()) {
+			if (!selected && !editor_selection->get_selected_node_list().is_empty()) {
 				selected = editor_selection->get_selected_node_list().front()->get();
 			}
 
@@ -438,7 +438,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			Array selection = editor_selection->get_selected_nodes();
 
-			if (selection.empty()) {
+			if (selection.is_empty()) {
 				return;
 			}
 
@@ -737,7 +737,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			List<Node *> remove_list = editor_selection->get_selected_node_list();
 
-			if (remove_list.empty()) {
+			if (remove_list.is_empty()) {
 				return;
 			}
 
@@ -1529,7 +1529,7 @@ void SceneTreeDock::_node_reparent(NodePath p_path, bool p_keep_global_xform) {
 
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
-	if (selection.empty()) {
+	if (selection.is_empty()) {
 		return; // Nothing to reparent.
 	}
 
@@ -1703,7 +1703,7 @@ bool SceneTreeDock::_is_collapsed_recursive(TreeItem *p_item) const {
 	List<TreeItem *> needs_check;
 	needs_check.push_back(p_item);
 
-	while (!needs_check.empty()) {
+	while (!needs_check.is_empty()) {
 		TreeItem *item = needs_check.back()->get();
 		needs_check.pop_back();
 
@@ -1725,7 +1725,7 @@ void SceneTreeDock::_set_collapsed_recursive(TreeItem *p_item, bool p_collapsed)
 	List<TreeItem *> to_collapse;
 	to_collapse.push_back(p_item);
 
-	while (!to_collapse.empty()) {
+	while (!to_collapse.is_empty()) {
 		TreeItem *item = to_collapse.back()->get();
 		to_collapse.pop_back();
 
@@ -1742,7 +1742,7 @@ void SceneTreeDock::_set_collapsed_recursive(TreeItem *p_item, bool p_collapsed)
 void SceneTreeDock::_script_created(Ref<Script> p_script) {
 	List<Node *> selected = editor_selection->get_selected_node_list();
 
-	if (selected.empty()) {
+	if (selected.is_empty()) {
 		return;
 	}
 
@@ -1811,7 +1811,7 @@ void SceneTreeDock::_toggle_editable_children(Node *p_node) {
 void SceneTreeDock::_delete_confirm() {
 	List<Node *> remove_list = editor_selection->get_selected_node_list();
 
-	if (remove_list.empty()) {
+	if (remove_list.is_empty()) {
 		return;
 	}
 
@@ -2349,7 +2349,7 @@ void SceneTreeDock::_script_dropped(String p_file, NodePath p_to) {
 void SceneTreeDock::_nodes_dragged(Array p_nodes, NodePath p_to, int p_type) {
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
-	if (selection.empty()) {
+	if (selection.is_empty()) {
 		return; //nothing to reparent
 	}
 
@@ -2601,7 +2601,7 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 	}
 
 	List<Node *> selection = editor_selection->get_selected_node_list();
-	if (selection.empty()) {
+	if (selection.is_empty()) {
 		return;
 	}
 

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -251,7 +251,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	if (can_rename) { //should be can edit..
 
 		String warning = p_node->get_configuration_warning();
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			item->add_button(0, get_theme_icon("NodeWarning", "EditorIcons"), BUTTON_WARNING, false, TTR("Node configuration warning:") + "\n" + p_node->get_configuration_warning());
 		}
 
@@ -754,7 +754,7 @@ void SceneTreeEditor::_renamed() {
 	ERR_FAIL_COND(!n);
 
 	// Empty node names are not allowed, so resets it to previous text and show warning
-	if (which->get_text(0).strip_edges().empty()) {
+	if (which->get_text(0).strip_edges().is_empty()) {
 		which->set_text(0, n->get_name());
 		EditorNode::get_singleton()->show_warning(TTR("No name provided."));
 		return;
@@ -765,7 +765,7 @@ void SceneTreeEditor::_renamed() {
 		error->set_text(TTR("Invalid node name, the following characters are not allowed:") + "\n" + Node::invalid_character);
 		error->popup_centered();
 
-		if (new_name.empty()) {
+		if (new_name.is_empty()) {
 			which->set_text(0, n->get_name());
 			return;
 		}
@@ -931,7 +931,7 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 		next = tree->get_next_selected(next);
 	}
 
-	if (selected.empty()) {
+	if (selected.is_empty()) {
 		return Variant();
 	}
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -50,7 +50,7 @@ void ScriptCreateDialog::_theme_changed() {
 	}
 
 	String last_lang = EditorSettings::get_singleton()->get_project_metadata("script_setup", "last_selected_language", "");
-	if (!last_lang.empty()) {
+	if (!last_lang.is_empty()) {
 		for (int i = 0; i < language_menu->get_item_count(); i++) {
 			if (language_menu->get_item_text(i) == last_lang) {
 				language_menu->select(i);

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -167,7 +167,7 @@ public:
 	BulletPhysicsDirectSpaceState *get_direct_state();
 
 	void set_debug_contacts(int p_amount) { contactDebug.resize(p_amount); }
-	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contactDebug.empty(); }
+	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contactDebug.is_empty(); }
 	_FORCE_INLINE_ void reset_debug_contact_count() {
 		contactDebugCount = 0;
 	}

--- a/modules/fbx/data/fbx_material.cpp
+++ b/modules/fbx/data/fbx_material.cpp
@@ -42,7 +42,7 @@ void FBXMaterial::set_imported_material(FBXDocParser::Material *p_material) {
 }
 
 void FBXMaterial::add_search_string(String p_filename, String p_current_directory, String search_directory, Vector<String> &texture_search_paths) {
-	if (search_directory.empty()) {
+	if (search_directory.is_empty()) {
 		texture_search_paths.push_back(p_current_directory.get_base_dir().plus_file(p_filename));
 	} else {
 		texture_search_paths.push_back(p_current_directory.get_base_dir().plus_file(search_directory + "/" + p_filename));
@@ -188,7 +188,7 @@ Ref<StandardMaterial3D> FBXMaterial::import_material(ImportState &state) {
 			spatial_material->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
 		}
 
-		ERR_CONTINUE_MSG(file_extension.empty(), "your texture has no file extension so we had to ignore it, let us know if you think this is wrong file an issue on github! " + debug_string);
+		ERR_CONTINUE_MSG(file_extension.is_empty(), "your texture has no file extension so we had to ignore it, let us know if you think this is wrong file an issue on github! " + debug_string);
 		ERR_CONTINUE_MSG(fbx_texture_map.count(fbx_mapping_name) <= 0, "This material has a texture with mapping name: " + String(fbx_mapping_name.c_str()) + " which is not yet supported by this importer. Consider opening an issue so we can support it.");
 		ERR_CONTINUE_MSG(
 				file_extension_uppercase != "PNG" &&
@@ -211,7 +211,7 @@ Ref<StandardMaterial3D> FBXMaterial::import_material(ImportState &state) {
 			texture = state.cached_image_searches[texture_name];
 		} else {
 			String path = find_texture_path_by_filename(texture_name, p_fbx_current_directory);
-			if (!path.empty()) {
+			if (!path.is_empty()) {
 				Ref<Texture2D> image_texture = ResourceLoader::load(path);
 
 				ERR_CONTINUE(image_texture.is_null());

--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -38,7 +38,7 @@
 
 template <class T>
 T collect_first(const Vector<VertexData<T>> *p_data, T p_fall_back) {
-	if (p_data->empty()) {
+	if (p_data->is_empty()) {
 		return p_fall_back;
 	}
 
@@ -47,7 +47,7 @@ T collect_first(const Vector<VertexData<T>> *p_data, T p_fall_back) {
 
 template <class T>
 HashMap<int, T> collect_all(const Vector<VertexData<T>> *p_data, HashMap<int, T> p_fall_back) {
-	if (p_data->empty()) {
+	if (p_data->is_empty()) {
 		return p_fall_back;
 	}
 
@@ -61,7 +61,7 @@ HashMap<int, T> collect_all(const Vector<VertexData<T>> *p_data, HashMap<int, T>
 
 template <class T>
 T collect_average(const Vector<VertexData<T>> *p_data, T p_fall_back) {
-	if (p_data->empty()) {
+	if (p_data->is_empty()) {
 		return p_fall_back;
 	}
 
@@ -76,7 +76,7 @@ T collect_average(const Vector<VertexData<T>> *p_data, T p_fall_back) {
 }
 
 HashMap<int, Vector3> collect_normal(const Vector<VertexData<Vector3>> *p_data, HashMap<int, Vector3> p_fall_back) {
-	if (p_data->empty()) {
+	if (p_data->is_empty()) {
 		return p_fall_back;
 	}
 
@@ -89,7 +89,7 @@ HashMap<int, Vector3> collect_normal(const Vector<VertexData<Vector3>> *p_data, 
 }
 
 HashMap<int, Vector2> collect_uv(const Vector<VertexData<Vector2>> *p_data, HashMap<int, Vector2> p_fall_back) {
-	if (p_data->empty()) {
+	if (p_data->is_empty()) {
 		return p_fall_back;
 	}
 
@@ -231,7 +231,7 @@ EditorSceneImporterMeshNode3D *FBXMeshData::create_fbx_mesh(const ImportState &s
 
 	// Phase 2. For each material create a surface tool (So a different mesh).
 	{
-		if (polygon_surfaces.empty()) {
+		if (polygon_surfaces.is_empty()) {
 			// No material, just use the default one with index -1.
 			// Set -1 to all polygons.
 			const int polygon_count = count_polygons(polygon_indices);
@@ -990,7 +990,7 @@ void FBXMeshData::triangulate_polygon(Ref<SurfaceTool> st, Vector<int> p_polygon
 }
 
 void FBXMeshData::gen_weight_info(Ref<SurfaceTool> st, Vertex vertex_id) const {
-	if (vertex_weights.empty()) {
+	if (vertex_weights.is_empty()) {
 		return;
 	}
 
@@ -1417,7 +1417,7 @@ void FBXMeshData::extract_morphs(const FBXDocParser::MeshGeometry *mesh_geometry
 			const std::vector<const FBXDocParser::ShapeGeometry *> &shape_geometries = blend_shape_channel->GetShapeGeometries();
 			for (const FBXDocParser::ShapeGeometry *shape_geometry : shape_geometries) {
 				String morph_name = ImportUtils::FBXAnimMeshName(shape_geometry->Name()).c_str();
-				if (morph_name.empty()) {
+				if (morph_name.is_empty()) {
 					morph_name = "morph";
 				}
 

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -286,7 +286,7 @@ bool GDNative::initialize() {
 	}
 
 	String lib_path = library->get_current_library_path();
-	if (lib_path.empty()) {
+	if (lib_path.is_empty()) {
 		ERR_PRINT("No library set for this platform");
 		return false;
 	}

--- a/modules/gdnative/gdnative/array.cpp
+++ b/modules/gdnative/gdnative/array.cpp
@@ -215,9 +215,9 @@ godot_int GDAPI godot_array_count(const godot_array *p_self, const godot_variant
 	return self->count(*val);
 }
 
-godot_bool GDAPI godot_array_empty(const godot_array *p_self) {
+godot_bool GDAPI godot_array_is_empty(const godot_array *p_self) {
 	const Array *self = (const Array *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_array_erase(godot_array *p_self, const godot_variant *p_value) {

--- a/modules/gdnative/gdnative/dictionary.cpp
+++ b/modules/gdnative/gdnative/dictionary.cpp
@@ -71,9 +71,9 @@ godot_int GDAPI godot_dictionary_size(const godot_dictionary *p_self) {
 	return self->size();
 }
 
-godot_bool GDAPI godot_dictionary_empty(const godot_dictionary *p_self) {
+godot_bool GDAPI godot_dictionary_is_empty(const godot_dictionary *p_self) {
 	const Dictionary *self = (const Dictionary *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_dictionary_clear(godot_dictionary *p_self) {

--- a/modules/gdnative/gdnative/packed_arrays.cpp
+++ b/modules/gdnative/gdnative/packed_arrays.cpp
@@ -150,9 +150,9 @@ godot_int GDAPI godot_packed_byte_array_size(const godot_packed_byte_array *p_se
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_byte_array_empty(const godot_packed_byte_array *p_self) {
+godot_bool GDAPI godot_packed_byte_array_is_empty(const godot_packed_byte_array *p_self) {
 	const Vector<uint8_t> *self = (const Vector<uint8_t> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_byte_array_destroy(godot_packed_byte_array *p_self) {
@@ -254,9 +254,9 @@ godot_int GDAPI godot_packed_int32_array_size(const godot_packed_int32_array *p_
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_int32_array_empty(const godot_packed_int32_array *p_self) {
+godot_bool GDAPI godot_packed_int32_array_is_empty(const godot_packed_int32_array *p_self) {
 	const Vector<int32_t> *self = (const Vector<int32_t> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_int32_array_destroy(godot_packed_int32_array *p_self) {
@@ -358,9 +358,9 @@ godot_int GDAPI godot_packed_int64_array_size(const godot_packed_int64_array *p_
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_int64_array_empty(const godot_packed_int64_array *p_self) {
+godot_bool GDAPI godot_packed_int64_array_is_empty(const godot_packed_int64_array *p_self) {
 	const Vector<int64_t> *self = (const Vector<int64_t> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_int64_array_destroy(godot_packed_int64_array *p_self) {
@@ -462,9 +462,9 @@ godot_int GDAPI godot_packed_float32_array_size(const godot_packed_float32_array
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_float32_array_empty(const godot_packed_float32_array *p_self) {
+godot_bool GDAPI godot_packed_float32_array_is_empty(const godot_packed_float32_array *p_self) {
 	const Vector<float> *self = (const Vector<float> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_float32_array_destroy(godot_packed_float32_array *p_self) {
@@ -566,9 +566,9 @@ godot_int GDAPI godot_packed_float64_array_size(const godot_packed_float64_array
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_float64_array_empty(const godot_packed_float64_array *p_self) {
+godot_bool GDAPI godot_packed_float64_array_is_empty(const godot_packed_float64_array *p_self) {
 	const Vector<double> *self = (const Vector<double> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_float64_array_destroy(godot_packed_float64_array *p_self) {
@@ -679,9 +679,9 @@ godot_int GDAPI godot_packed_string_array_size(const godot_packed_string_array *
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_string_array_empty(const godot_packed_string_array *p_self) {
+godot_bool GDAPI godot_packed_string_array_is_empty(const godot_packed_string_array *p_self) {
 	const Vector<String> *self = (const Vector<String> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_string_array_destroy(godot_packed_string_array *p_self) {
@@ -791,9 +791,9 @@ godot_int GDAPI godot_packed_vector2_array_size(const godot_packed_vector2_array
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_vector2_array_empty(const godot_packed_vector2_array *p_self) {
+godot_bool GDAPI godot_packed_vector2_array_is_empty(const godot_packed_vector2_array *p_self) {
 	const Vector<Vector2> *self = (const Vector<Vector2> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_vector2_array_destroy(godot_packed_vector2_array *p_self) {
@@ -903,9 +903,9 @@ godot_int GDAPI godot_packed_vector2i_array_size(const godot_packed_vector2i_arr
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_vector2i_array_empty(const godot_packed_vector2i_array *p_self) {
+godot_bool GDAPI godot_packed_vector2i_array_is_empty(const godot_packed_vector2i_array *p_self) {
 	const Vector<Vector2i> *self = (const Vector<Vector2i> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_vector2i_array_destroy(godot_packed_vector2i_array *p_self) {
@@ -1015,9 +1015,9 @@ godot_int GDAPI godot_packed_vector3_array_size(const godot_packed_vector3_array
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_vector3_array_empty(const godot_packed_vector3_array *p_self) {
+godot_bool GDAPI godot_packed_vector3_array_is_empty(const godot_packed_vector3_array *p_self) {
 	const Vector<Vector3> *self = (const Vector<Vector3> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_vector3_array_destroy(godot_packed_vector3_array *p_self) {
@@ -1127,9 +1127,9 @@ godot_int GDAPI godot_packed_color_array_size(const godot_packed_color_array *p_
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_color_array_empty(const godot_packed_color_array *p_self) {
+godot_bool GDAPI godot_packed_color_array_is_empty(const godot_packed_color_array *p_self) {
 	const Vector<Color> *self = (const Vector<Color> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_color_array_destroy(godot_packed_color_array *p_self) {

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -1087,10 +1087,10 @@ godot_string GDAPI godot_string_sha256_text(const godot_string *p_self) {
 	return result;
 }
 
-godot_bool godot_string_empty(const godot_string *p_self) {
+godot_bool godot_string_is_empty(const godot_string *p_self) {
 	const String *self = (const String *)p_self;
 
-	return self->empty();
+	return self->is_empty();
 }
 
 // path functions

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -380,7 +380,7 @@
         ]
       },
       {
-        "name": "godot_array_empty",
+        "name": "godot_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_array *", "p_self"]
@@ -1388,7 +1388,7 @@
         ]
       },
       {
-        "name": "godot_dictionary_empty",
+        "name": "godot_dictionary_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_dictionary *", "p_self"]
@@ -1647,7 +1647,7 @@
         ]
       },
       {
-        "name": "godot_packed_byte_array_empty",
+        "name": "godot_packed_byte_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_byte_array *", "p_self"]
@@ -1793,7 +1793,7 @@
         ]
       },
       {
-        "name": "godot_packed_int32_array_empty",
+        "name": "godot_packed_int32_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_int32_array *", "p_self"]
@@ -1939,7 +1939,7 @@
         ]
       },
       {
-        "name": "godot_packed_int64_array_empty",
+        "name": "godot_packed_int64_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_int64_array *", "p_self"]
@@ -2085,7 +2085,7 @@
         ]
       },
       {
-        "name": "godot_packed_float32_array_empty",
+        "name": "godot_packed_float32_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_float32_array *", "p_self"]
@@ -2231,7 +2231,7 @@
         ]
       },
       {
-        "name": "godot_packed_float64_array_empty",
+        "name": "godot_packed_float64_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_float64_array *", "p_self"]
@@ -2377,7 +2377,7 @@
         ]
       },
       {
-        "name": "godot_packed_string_array_empty",
+        "name": "godot_packed_string_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_string_array *", "p_self"]
@@ -2523,7 +2523,7 @@
         ]
       },
       {
-        "name": "godot_packed_vector2_array_empty",
+        "name": "godot_packed_vector2_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_vector2_array *", "p_self"]
@@ -2669,7 +2669,7 @@
         ]
       },
       {
-        "name": "godot_packed_vector2i_array_empty",
+        "name": "godot_packed_vector2i_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_vector2i_array *", "p_self"]
@@ -2815,7 +2815,7 @@
         ]
       },
       {
-        "name": "godot_packed_vector3_array_empty",
+        "name": "godot_packed_vector3_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_vector3_array *", "p_self"]
@@ -2961,7 +2961,7 @@
         ]
       },
       {
-        "name": "godot_packed_color_array_empty",
+        "name": "godot_packed_color_array_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_packed_color_array *", "p_self"]
@@ -5005,7 +5005,7 @@
         ]
       },
       {
-        "name": "godot_string_empty",
+        "name": "godot_string_is_empty",
         "return_type": "godot_bool",
         "arguments": [
           ["const godot_string *", "p_self"]
@@ -7946,7 +7946,7 @@
           ]
         },
         {
-          "name": "godot_packed_glyph_array_empty",
+          "name": "godot_packed_glyph_array_is_empty",
           "return_type": "godot_bool",
           "arguments": [
             ["const godot_packed_glyph_array *", "p_self"]

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -65,7 +65,7 @@ void GDNativeLibraryEditor::_update_tree() {
 			continue;
 		}
 		Map<String, NativePlatformConfig>::Element *E = platforms.find(filter_list->get_item_metadata(i));
-		if (!text.empty()) {
+		if (!text.is_empty()) {
 			text += ", ";
 		}
 		text += E->get().name;
@@ -91,7 +91,7 @@ void GDNativeLibraryEditor::_update_tree() {
 
 			bit->add_button(1, get_theme_icon("Folder", "EditorIcons"), BUTTON_SELECT_LIBRARY, false, TTR("Select the dynamic library for this entry"));
 			String file = entry_configs[target].library;
-			if (!file.empty()) {
+			if (!file.is_empty()) {
 				bit->add_button(1, get_theme_icon("Clear", "EditorIcons"), BUTTON_CLEAR_LIBRARY, false, TTR("Clear"));
 			}
 			bit->set_text(1, file);
@@ -195,7 +195,7 @@ void GDNativeLibraryEditor::_on_item_activated() {
 void GDNativeLibraryEditor::_on_create_new_entry() {
 	String platform = new_architecture_dialog->get_meta("platform");
 	String entry = new_architecture_input->get_text().strip_edges();
-	if (!entry.empty()) {
+	if (!entry.is_empty()) {
 		platforms[platform].entries.push_back(entry);
 		_update_tree();
 	}
@@ -248,7 +248,7 @@ void GDNativeLibraryEditor::_translate_to_config_file() {
 		for (Map<String, NativePlatformConfig>::Element *E = platforms.front(); E; E = E->next()) {
 			for (List<String>::Element *it = E->value().entries.front(); it; it = it->next()) {
 				String target = E->key() + "." + it->get();
-				if (entry_configs[target].library.empty() && entry_configs[target].dependencies.empty()) {
+				if (entry_configs[target].library.is_empty() && entry_configs[target].dependencies.is_empty()) {
 					continue;
 				}
 

--- a/modules/gdnative/include/gdnative/array.h
+++ b/modules/gdnative/include/gdnative/array.h
@@ -87,7 +87,7 @@ void GDAPI godot_array_clear(godot_array *p_self);
 
 godot_int GDAPI godot_array_count(const godot_array *p_self, const godot_variant *p_value);
 
-godot_bool GDAPI godot_array_empty(const godot_array *p_self);
+godot_bool GDAPI godot_array_is_empty(const godot_array *p_self);
 
 void GDAPI godot_array_erase(godot_array *p_self, const godot_variant *p_value);
 

--- a/modules/gdnative/include/gdnative/dictionary.h
+++ b/modules/gdnative/include/gdnative/dictionary.h
@@ -67,7 +67,7 @@ godot_dictionary GDAPI godot_dictionary_duplicate(const godot_dictionary *p_self
 
 godot_int GDAPI godot_dictionary_size(const godot_dictionary *p_self);
 
-godot_bool GDAPI godot_dictionary_empty(const godot_dictionary *p_self);
+godot_bool GDAPI godot_dictionary_is_empty(const godot_dictionary *p_self);
 
 void GDAPI godot_dictionary_clear(godot_dictionary *p_self);
 

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -195,7 +195,7 @@ uint8_t GDAPI godot_packed_byte_array_get(const godot_packed_byte_array *p_self,
 
 godot_int GDAPI godot_packed_byte_array_size(const godot_packed_byte_array *p_self);
 
-godot_bool GDAPI godot_packed_byte_array_empty(const godot_packed_byte_array *p_self);
+godot_bool GDAPI godot_packed_byte_array_is_empty(const godot_packed_byte_array *p_self);
 
 void GDAPI godot_packed_byte_array_destroy(godot_packed_byte_array *p_self);
 
@@ -231,7 +231,7 @@ int32_t GDAPI godot_packed_int32_array_get(const godot_packed_int32_array *p_sel
 
 godot_int GDAPI godot_packed_int32_array_size(const godot_packed_int32_array *p_self);
 
-godot_bool GDAPI godot_packed_int32_array_empty(const godot_packed_int32_array *p_self);
+godot_bool GDAPI godot_packed_int32_array_is_empty(const godot_packed_int32_array *p_self);
 
 void GDAPI godot_packed_int32_array_destroy(godot_packed_int32_array *p_self);
 
@@ -267,7 +267,7 @@ int64_t GDAPI godot_packed_int64_array_get(const godot_packed_int64_array *p_sel
 
 godot_int GDAPI godot_packed_int64_array_size(const godot_packed_int64_array *p_self);
 
-godot_bool GDAPI godot_packed_int64_array_empty(const godot_packed_int64_array *p_self);
+godot_bool GDAPI godot_packed_int64_array_is_empty(const godot_packed_int64_array *p_self);
 
 void GDAPI godot_packed_int64_array_destroy(godot_packed_int64_array *p_self);
 
@@ -303,7 +303,7 @@ float GDAPI godot_packed_float32_array_get(const godot_packed_float32_array *p_s
 
 godot_int GDAPI godot_packed_float32_array_size(const godot_packed_float32_array *p_self);
 
-godot_bool GDAPI godot_packed_float32_array_empty(const godot_packed_float32_array *p_self);
+godot_bool GDAPI godot_packed_float32_array_is_empty(const godot_packed_float32_array *p_self);
 
 void GDAPI godot_packed_float32_array_destroy(godot_packed_float32_array *p_self);
 
@@ -339,7 +339,7 @@ double GDAPI godot_packed_float64_array_get(const godot_packed_float64_array *p_
 
 godot_int GDAPI godot_packed_float64_array_size(const godot_packed_float64_array *p_self);
 
-godot_bool GDAPI godot_packed_float64_array_empty(const godot_packed_float64_array *p_self);
+godot_bool GDAPI godot_packed_float64_array_is_empty(const godot_packed_float64_array *p_self);
 
 void GDAPI godot_packed_float64_array_destroy(godot_packed_float64_array *p_self);
 
@@ -375,7 +375,7 @@ godot_string GDAPI godot_packed_string_array_get(const godot_packed_string_array
 
 godot_int GDAPI godot_packed_string_array_size(const godot_packed_string_array *p_self);
 
-godot_bool GDAPI godot_packed_string_array_empty(const godot_packed_string_array *p_self);
+godot_bool GDAPI godot_packed_string_array_is_empty(const godot_packed_string_array *p_self);
 
 void GDAPI godot_packed_string_array_destroy(godot_packed_string_array *p_self);
 
@@ -411,7 +411,7 @@ godot_vector2 GDAPI godot_packed_vector2_array_get(const godot_packed_vector2_ar
 
 godot_int GDAPI godot_packed_vector2_array_size(const godot_packed_vector2_array *p_self);
 
-godot_bool GDAPI godot_packed_vector2_array_empty(const godot_packed_vector2_array *p_self);
+godot_bool GDAPI godot_packed_vector2_array_is_empty(const godot_packed_vector2_array *p_self);
 
 void GDAPI godot_packed_vector2_array_destroy(godot_packed_vector2_array *p_self);
 
@@ -447,7 +447,7 @@ godot_vector2i GDAPI godot_packed_vector2i_array_get(const godot_packed_vector2i
 
 godot_int GDAPI godot_packed_vector2i_array_size(const godot_packed_vector2i_array *p_self);
 
-godot_bool GDAPI godot_packed_vector2i_array_empty(const godot_packed_vector2i_array *p_self);
+godot_bool GDAPI godot_packed_vector2i_array_is_empty(const godot_packed_vector2i_array *p_self);
 
 void GDAPI godot_packed_vector2i_array_destroy(godot_packed_vector2i_array *p_self);
 
@@ -483,7 +483,7 @@ godot_vector3 GDAPI godot_packed_vector3_array_get(const godot_packed_vector3_ar
 
 godot_int GDAPI godot_packed_vector3_array_size(const godot_packed_vector3_array *p_self);
 
-godot_bool GDAPI godot_packed_vector3_array_empty(const godot_packed_vector3_array *p_self);
+godot_bool GDAPI godot_packed_vector3_array_is_empty(const godot_packed_vector3_array *p_self);
 
 void GDAPI godot_packed_vector3_array_destroy(godot_packed_vector3_array *p_self);
 
@@ -519,7 +519,7 @@ godot_color GDAPI godot_packed_color_array_get(const godot_packed_color_array *p
 
 godot_int GDAPI godot_packed_color_array_size(const godot_packed_color_array *p_self);
 
-godot_bool GDAPI godot_packed_color_array_empty(const godot_packed_color_array *p_self);
+godot_bool GDAPI godot_packed_color_array_is_empty(const godot_packed_color_array *p_self);
 
 void GDAPI godot_packed_color_array_destroy(godot_packed_color_array *p_self);
 

--- a/modules/gdnative/include/gdnative/string.h
+++ b/modules/gdnative/include/gdnative/string.h
@@ -256,7 +256,7 @@ godot_string GDAPI godot_string_sha1_text(const godot_string *p_self);
 godot_packed_byte_array GDAPI godot_string_sha256_buffer(const godot_string *p_self);
 godot_string GDAPI godot_string_sha256_text(const godot_string *p_self);
 
-godot_bool godot_string_empty(const godot_string *p_self);
+godot_bool godot_string_is_empty(const godot_string *p_self);
 
 // path functions
 godot_string GDAPI godot_string_get_base_dir(const godot_string *p_self);

--- a/modules/gdnative/include/text/godot_text.h
+++ b/modules/gdnative/include/text/godot_text.h
@@ -218,7 +218,7 @@ godot_glyph GDAPI godot_packed_glyph_array_get(const godot_packed_glyph_array *p
 
 godot_int GDAPI godot_packed_glyph_array_size(const godot_packed_glyph_array *p_self);
 
-godot_bool GDAPI godot_packed_glyph_array_empty(const godot_packed_glyph_array *p_self);
+godot_bool GDAPI godot_packed_glyph_array_is_empty(const godot_packed_glyph_array *p_self);
 
 void GDAPI godot_packed_glyph_array_destroy(godot_packed_glyph_array *p_self);
 

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -295,7 +295,7 @@ List<ClassAPI> generate_c_api_classes() {
 
 				property_api.index = ClassDB::get_property_index(class_name, p->get().name);
 
-				if (!property_api.setter.empty() || !property_api.getter.empty()) {
+				if (!property_api.setter.is_empty() || !property_api.getter.is_empty()) {
 					class_api.properties.push_back(property_api);
 				}
 			}

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -717,7 +717,7 @@ String NativeScript::get_property_documentation(const StringName &p_path) const 
 }
 
 Variant NativeScript::_new(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
-	if (lib_path.empty() || class_name.empty() || library.is_null()) {
+	if (lib_path.is_empty() || class_name.is_empty() || library.is_null()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
 		return Variant();
 	}
@@ -1800,7 +1800,7 @@ bool NativeScriptLanguage::handles_global_class_type(const String &p_type) const
 }
 
 String NativeScriptLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const {
-	if (!p_path.empty()) {
+	if (!p_path.is_empty()) {
 		Ref<NativeScript> script = ResourceLoader::load(p_path, "NativeScript");
 		if (script.is_valid()) {
 			if (r_base_type) {

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -407,7 +407,7 @@ bool PluginScriptLanguage::handles_global_class_type(const String &p_type) const
 }
 
 String PluginScriptLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const {
-	if (!p_path.empty()) {
+	if (!p_path.is_empty()) {
 		Ref<PluginScript> script = ResourceLoader::load(p_path, "PluginScript");
 		if (script.is_valid()) {
 			if (r_base_type) {

--- a/modules/gdnative/tests/test_string.h
+++ b/modules/gdnative/tests/test_string.h
@@ -259,11 +259,11 @@ TEST_CASE("[GDNative String] Testing for empty string") {
 	godot_string s;
 
 	godot_string_new_with_latin1_chars(&s, "Mellon");
-	CHECK(!godot_string_empty(&s));
+	CHECK(!godot_string_is_empty(&s));
 	godot_string_destroy(&s);
 
 	godot_string_new_with_latin1_chars(&s, "");
-	CHECK(godot_string_empty(&s));
+	CHECK(godot_string_is_empty(&s));
 	godot_string_destroy(&s);
 }
 

--- a/modules/gdnative/text/text_server_gdnative.cpp
+++ b/modules/gdnative/text/text_server_gdnative.cpp
@@ -839,9 +839,9 @@ godot_int GDAPI godot_packed_glyph_array_size(const godot_packed_glyph_array *p_
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_glyph_array_empty(const godot_packed_glyph_array *p_self) {
+godot_bool GDAPI godot_packed_glyph_array_is_empty(const godot_packed_glyph_array *p_self) {
 	const Vector<TextServer::Glyph> *self = (const Vector<TextServer::Glyph> *)p_self;
-	return self->empty();
+	return self->is_empty();
 }
 
 void GDAPI godot_packed_glyph_array_destroy(godot_packed_glyph_array *p_self) {

--- a/modules/gdnavigation/navigation_mesh_generator.cpp
+++ b/modules/gdnavigation/navigation_mesh_generator.cpp
@@ -151,7 +151,7 @@ void NavigationMeshGenerator::_parse_geometry(Transform p_accumulated_transform,
 	if (Object::cast_to<CSGShape3D>(p_node) && p_generate_from != NavigationMesh::PARSED_GEOMETRY_STATIC_COLLIDERS) {
 		CSGShape3D *csg_shape = Object::cast_to<CSGShape3D>(p_node);
 		Array meshes = csg_shape->get_meshes();
-		if (!meshes.empty()) {
+		if (!meshes.is_empty()) {
 			Ref<Mesh> mesh = meshes[1];
 			if (mesh.is_valid()) {
 				_add_mesh(mesh, p_accumulated_transform * csg_shape->get_transform(), p_verticies, p_indices);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -425,7 +425,7 @@ void GDScript::_update_doc() {
 	_clear_doc();
 
 	doc.script_path = "\"" + get_path().get_slice("://", 1) + "\"";
-	if (!name.empty()) {
+	if (!name.is_empty()) {
 		doc.name = name;
 	} else {
 		doc.name = doc.script_path;
@@ -793,10 +793,10 @@ Error GDScript::reload(bool p_keep_state) {
 
 	{
 		String source_path = path;
-		if (source_path.empty()) {
+		if (source_path.is_empty()) {
 			source_path = get_path();
 		}
-		if (!source_path.empty()) {
+		if (!source_path.is_empty()) {
 			MutexLock lock(GDScriptCache::singleton->lock);
 			if (!GDScriptCache::singleton->shallow_gdscript_cache.has(source_path)) {
 				GDScriptCache::singleton->shallow_gdscript_cache[source_path] = this;
@@ -812,7 +812,7 @@ Error GDScript::reload(bool p_keep_state) {
 			GDScriptLanguage::get_singleton()->debug_break_parse(get_path(), parser.get_errors().front()->get().line, "Parser Error: " + parser.get_errors().front()->get().message);
 		}
 		// TODO: Show all error messages.
-		_err_print_error("GDScript::reload", path.empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), ERR_HANDLER_SCRIPT);
+		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), ERR_HANDLER_SCRIPT);
 		ERR_FAIL_V(ERR_PARSE_ERROR);
 	}
 
@@ -826,7 +826,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 		const List<GDScriptParser::ParserError>::Element *e = parser.get_errors().front();
 		while (e != nullptr) {
-			_err_print_error("GDScript::reload", path.empty() ? "built-in" : (const char *)path.utf8().get_data(), e->get().line, ("Parse Error: " + e->get().message).utf8().get_data(), ERR_HANDLER_SCRIPT);
+			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), e->get().line, ("Parse Error: " + e->get().message).utf8().get_data(), ERR_HANDLER_SCRIPT);
 			e = e->next();
 		}
 		ERR_FAIL_V(ERR_PARSE_ERROR);
@@ -846,7 +846,7 @@ Error GDScript::reload(bool p_keep_state) {
 			if (EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(get_path(), compiler.get_error_line(), "Parser Error: " + compiler.get_error());
 			}
-			_err_print_error("GDScript::reload", path.empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), ERR_HANDLER_SCRIPT);
+			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), ERR_HANDLER_SCRIPT);
 			ERR_FAIL_V(ERR_COMPILATION_FAILED);
 		} else {
 			return err;
@@ -2151,7 +2151,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 	if (err == OK) {
 		const GDScriptParser::ClassNode *c = parser.get_tree();
 		if (r_icon_path) {
-			if (c->icon_path.empty() || c->icon_path.is_abs_path()) {
+			if (c->icon_path.is_empty() || c->icon_path.is_abs_path()) {
 				*r_icon_path = c->icon_path;
 			} else if (c->icon_path.is_rel_path()) {
 				*r_icon_path = p_path.get_base_dir().plus_file(c->icon_path).simplify_path();
@@ -2163,7 +2163,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 			GDScriptParser subparser;
 			while (subclass) {
 				if (subclass->extends_used) {
-					if (!subclass->extends_path.empty()) {
+					if (!subclass->extends_path.is_empty()) {
 						if (subclass->extends.size() == 0) {
 							get_global_class_name(subclass->extends_path, r_base_type);
 							subclass = nullptr;
@@ -2177,7 +2177,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 							}
 							String subsource = subfile->get_as_utf8_string();
 
-							if (subsource.empty()) {
+							if (subsource.is_empty()) {
 								break;
 							}
 							String subpath = subclass->extends_path;
@@ -2374,7 +2374,7 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 	ERR_FAIL_COND_MSG(!file, "Cannot open file '" + p_path + "'.");
 
 	String source = file->get_as_utf8_string();
-	if (source.empty()) {
+	if (source.is_empty()) {
 		return;
 	}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -60,7 +60,7 @@ static const char *underscore_classes[] = {
 	nullptr,
 };
 static StringName get_real_class_name(const StringName &p_source) {
-	if (underscore_map.empty()) {
+	if (underscore_map.is_empty()) {
 		const char **class_name = underscore_classes;
 		while (*class_name != nullptr) {
 			underscore_map[*class_name] = String("_") + *class_name;
@@ -209,7 +209,7 @@ Error GDScriptAnalyzer::resolve_inheritance(GDScriptParser::ClassNode *p_class, 
 
 		int extends_index = 0;
 
-		if (!p_class->extends_path.empty()) {
+		if (!p_class->extends_path.is_empty()) {
 			Ref<GDScriptParserRef> parser = get_parser_for(p_class->extends_path);
 			if (parser.is_null()) {
 				push_error(vformat(R"(Could not resolve super class path "%s".)", p_class->extends_path), p_class);
@@ -224,7 +224,7 @@ Error GDScriptAnalyzer::resolve_inheritance(GDScriptParser::ClassNode *p_class, 
 
 			base = parser->get_parser()->head->get_datatype();
 		} else {
-			if (p_class->extends.empty()) {
+			if (p_class->extends.is_empty()) {
 				return ERR_PARSE_ERROR;
 			}
 			const StringName &name = p_class->extends[extends_index++];
@@ -376,7 +376,7 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 	result.type_source = result.ANNOTATED_EXPLICIT;
 	result.builtin_type = Variant::OBJECT;
 
-	if (p_type->type_chain.empty()) {
+	if (p_type->type_chain.is_empty()) {
 		// void.
 		result.kind = GDScriptParser::DataType::BUILTIN;
 		result.builtin_type = Variant::NIL;
@@ -3402,12 +3402,12 @@ Error GDScriptAnalyzer::resolve_inheritance() {
 
 Error GDScriptAnalyzer::resolve_interface() {
 	resolve_class_interface(parser->head);
-	return parser->errors.empty() ? OK : ERR_PARSE_ERROR;
+	return parser->errors.is_empty() ? OK : ERR_PARSE_ERROR;
 }
 
 Error GDScriptAnalyzer::resolve_body() {
 	resolve_class_body(parser->head);
-	return parser->errors.empty() ? OK : ERR_PARSE_ERROR;
+	return parser->errors.is_empty() ? OK : ERR_PARSE_ERROR;
 }
 
 Error GDScriptAnalyzer::resolve_program() {
@@ -3422,7 +3422,7 @@ Error GDScriptAnalyzer::resolve_program() {
 		}
 		depended_parsers[E->get()]->raise_status(GDScriptParserRef::FULLY_SOLVED);
 	}
-	return parser->errors.empty() ? OK : ERR_PARSE_ERROR;
+	return parser->errors.is_empty() ? OK : ERR_PARSE_ERROR;
 }
 
 Error GDScriptAnalyzer::analyze() {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -107,7 +107,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 			// Locate class by constructing the path to it and following that path
 			GDScriptParser::ClassNode *class_type = p_datatype.class_type;
 			if (class_type) {
-				if (class_type->fqcn.begins_with(main_script->path) || (!main_script->name.empty() && class_type->fqcn.begins_with(main_script->name))) {
+				if (class_type->fqcn.begins_with(main_script->path) || (!main_script->name.is_empty() && class_type->fqcn.begins_with(main_script->name))) {
 					// Local class.
 					List<StringName> names;
 					while (class_type->outer) {
@@ -2231,7 +2231,7 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 				}
 				p_script->_signals[name] = parameters_names;
 #ifdef TOOLS_ENABLED
-				if (!signal->doc_description.empty()) {
+				if (!signal->doc_description.is_empty()) {
 					p_script->doc_signals[name] = signal->doc_description;
 				}
 #endif

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -123,10 +123,10 @@ static void get_function_names_recursively(const GDScriptParser::ClassNode *p_cl
 	for (int i = 0; i < p_class->members.size(); i++) {
 		if (p_class->members[i].type == GDScriptParser::ClassNode::Member::FUNCTION) {
 			const GDScriptParser::FunctionNode *function = p_class->members[i].function;
-			r_funcs[function->start_line] = p_prefix.empty() ? String(function->identifier->name) : p_prefix + "." + String(function->identifier->name);
+			r_funcs[function->start_line] = p_prefix.is_empty() ? String(function->identifier->name) : p_prefix + "." + String(function->identifier->name);
 		} else if (p_class->members[i].type == GDScriptParser::ClassNode::Member::CLASS) {
 			String new_prefix = p_class->members[i].m_class->identifier->name;
-			get_function_names_recursively(p_class->members[i].m_class, p_prefix.empty() ? new_prefix : p_prefix + "." + new_prefix, r_funcs);
+			get_function_names_recursively(p_class->members[i].m_class, p_prefix.is_empty() ? new_prefix : p_prefix + "." + new_prefix, r_funcs);
 		}
 	}
 }
@@ -476,7 +476,7 @@ String GDScriptLanguage::make_function(const String &p_class, const String &p_na
 			s += p_args[i].get_slice(":", 0);
 			if (th) {
 				String type = p_args[i].get_slice(":", 1);
-				if (!type.empty() && type != "var") {
+				if (!type.is_empty() && type != "var") {
 					s += ": " + type;
 				}
 			}
@@ -2511,7 +2511,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 				break;
 			}
 
-			if (!type.enumeration.empty()) {
+			if (!type.enumeration.is_empty()) {
 				_find_enumeration_candidates(completion_context, type.enumeration, options);
 				r_forced = options.size() > 0;
 			} else {

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -114,7 +114,7 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 			ERR_CONTINUE(!sdmap.has(sd.identifier));
 
 			sdmap[sd.identifier].pos.pop_back();
-			if (sdmap[sd.identifier].pos.empty()) {
+			if (sdmap[sd.identifier].pos.is_empty()) {
 				sdmap.erase(sd.identifier);
 			}
 		}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -47,7 +47,7 @@
 
 static HashMap<StringName, Variant::Type> builtin_types;
 Variant::Type GDScriptParser::get_builtin_type(const StringName &p_type) {
-	if (builtin_types.empty()) {
+	if (builtin_types.is_empty()) {
 		builtin_types["bool"] = Variant::BOOL;
 		builtin_types["int"] = Variant::INT;
 		builtin_types["float"] = Variant::FLOAT;
@@ -177,16 +177,16 @@ void GDScriptParser::push_error(const String &p_message, const Node *p_origin) {
 void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_code, const String &p_symbol1, const String &p_symbol2, const String &p_symbol3, const String &p_symbol4) {
 	ERR_FAIL_COND(p_source == nullptr);
 	Vector<String> symbols;
-	if (!p_symbol1.empty()) {
+	if (!p_symbol1.is_empty()) {
 		symbols.push_back(p_symbol1);
 	}
-	if (!p_symbol2.empty()) {
+	if (!p_symbol2.is_empty()) {
 		symbols.push_back(p_symbol2);
 	}
-	if (!p_symbol3.empty()) {
+	if (!p_symbol3.is_empty()) {
 		symbols.push_back(p_symbol3);
 	}
-	if (!p_symbol4.empty()) {
+	if (!p_symbol4.is_empty()) {
 		symbols.push_back(p_symbol4);
 	}
 	push_warning(p_source, p_code, symbols);
@@ -284,7 +284,7 @@ void GDScriptParser::pop_completion_call() {
 	if (!for_completion) {
 		return;
 	}
-	ERR_FAIL_COND_MSG(completion_call_stack.empty(), "Trying to pop empty completion call stack");
+	ERR_FAIL_COND_MSG(completion_call_stack.is_empty(), "Trying to pop empty completion call stack");
 	completion_call_stack.pop_back();
 }
 
@@ -292,7 +292,7 @@ void GDScriptParser::set_last_completion_call_arg(int p_argument) {
 	if (!for_completion || passed_cursor) {
 		return;
 	}
-	ERR_FAIL_COND_MSG(completion_call_stack.empty(), "Trying to set argument on empty completion call stack");
+	ERR_FAIL_COND_MSG(completion_call_stack.is_empty(), "Trying to set argument on empty completion call stack");
 	completion_call_stack.back()->get().argument = p_argument;
 }
 
@@ -358,7 +358,7 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 	}
 #endif
 
-	if (errors.empty()) {
+	if (errors.is_empty()) {
 		return OK;
 	} else {
 		return ERR_PARSE_ERROR;
@@ -369,7 +369,7 @@ GDScriptTokenizer::Token GDScriptParser::advance() {
 	if (current.type == GDScriptTokenizer::Token::TK_EOF) {
 		ERR_FAIL_COND_V_MSG(current.type == GDScriptTokenizer::Token::TK_EOF, current, "GDScript parser bug: Trying to advance past the end of stream.");
 	}
-	if (for_completion && !completion_call_stack.empty()) {
+	if (for_completion && !completion_call_stack.is_empty()) {
 		if (completion_call.call == nullptr && tokenizer.is_past_cursor()) {
 			completion_call = completion_call_stack.back()->get();
 			passed_cursor = true;
@@ -500,7 +500,7 @@ void GDScriptParser::parse_program() {
 		// Order here doesn't matter, but there should be only one of each at most.
 		switch (current.type) {
 			case GDScriptTokenizer::Token::CLASS_NAME:
-				if (!annotation_stack.empty()) {
+				if (!annotation_stack.is_empty()) {
 					push_error(R"("class_name" should be used before annotations.)");
 				}
 				advance();
@@ -511,7 +511,7 @@ void GDScriptParser::parse_program() {
 				}
 				break;
 			case GDScriptTokenizer::Token::EXTENDS:
-				if (!annotation_stack.empty()) {
+				if (!annotation_stack.is_empty()) {
 					push_error(R"("extends" should be used before annotations.)");
 				}
 				advance();
@@ -675,7 +675,7 @@ void GDScriptParser::parse_class_member(T *(GDScriptParser::*p_parse_function)()
 #endif // TOOLS_ENABLED
 
 	// Consume annotations.
-	while (!annotation_stack.empty()) {
+	while (!annotation_stack.is_empty()) {
 		AnnotationNode *last_annotation = annotation_stack.back()->get();
 		if (last_annotation->applies_to(p_target)) {
 			last_annotation->apply(this, member);
@@ -1698,7 +1698,7 @@ GDScriptParser::MatchBranchNode *GDScriptParser::parse_match_branch() {
 		branch->patterns.push_back(pattern);
 	} while (match(GDScriptTokenizer::Token::COMMA));
 
-	if (branch->patterns.empty()) {
+	if (branch->patterns.is_empty()) {
 		push_error(R"(No pattern found for "match" branch.)");
 	}
 
@@ -2751,7 +2751,7 @@ String GDScriptParser::get_doc_comment(int p_line, bool p_single_line) {
 		}
 		String line_join = (in_codeblock) ? "\n" : " ";
 
-		doc = (doc.empty()) ? doc_line : doc + line_join + doc_line;
+		doc = (doc.is_empty()) ? doc_line : doc + line_join + doc_line;
 		line++;
 	}
 
@@ -2845,7 +2845,7 @@ void GDScriptParser::get_class_doc_comment(int p_line, String &p_brief, String &
 
 			mode = TUTORIALS;
 			in_codeblock = false;
-		} else if (striped_line.empty()) {
+		} else if (striped_line.is_empty()) {
 			continue;
 		} else {
 			// Tutorial docs are single line, we need a @tag after it.
@@ -3280,11 +3280,11 @@ String GDScriptParser::DataType::to_string() const {
 				return script_type->get_class_name().operator String();
 			}
 			String name = script_type->get_name();
-			if (!name.empty()) {
+			if (!name.is_empty()) {
 				return name;
 			}
 			name = script_path;
-			if (!name.empty()) {
+			if (!name.is_empty()) {
 				return name;
 			}
 			return native_type.operator String();
@@ -3329,7 +3329,7 @@ void GDScriptParser::TreePrinter::decrease_indent() {
 }
 
 void GDScriptParser::TreePrinter::push_line(const String &p_line) {
-	if (!p_line.empty()) {
+	if (!p_line.is_empty()) {
 		push_text(p_line);
 	}
 	printed += "\n";
@@ -3538,7 +3538,7 @@ void GDScriptParser::TreePrinter::print_class(ClassNode *p_class) {
 	if (p_class->extends_used) {
 		bool first = true;
 		push_text(" Extends ");
-		if (!p_class->extends_path.empty()) {
+		if (!p_class->extends_path.is_empty()) {
 			push_text(vformat(R"("%s")", p_class->extends_path));
 			first = false;
 		}
@@ -4000,7 +4000,7 @@ void GDScriptParser::TreePrinter::print_ternary_op(TernaryOpNode *p_ternary_op) 
 }
 
 void GDScriptParser::TreePrinter::print_type(TypeNode *p_type) {
-	if (p_type->type_chain.empty()) {
+	if (p_type->type_chain.is_empty()) {
 		push_text("Void");
 	} else {
 		for (int i = 0; i < p_type->type_chain.size(); i++) {
@@ -4120,7 +4120,7 @@ void GDScriptParser::TreePrinter::print_tree(const GDScriptParser &p_parser) {
 	if (p_parser.is_tool()) {
 		push_line("@tool");
 	}
-	if (!p_parser.get_tree()->icon_path.empty()) {
+	if (!p_parser.get_tree()->icon_path.is_empty()) {
 		push_text(R"(@icon (")");
 		push_text(p_parser.get_tree()->icon_path);
 		push_line("\")");

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -221,7 +221,7 @@ String GDScriptTokenizer::get_token_name(Token::Type p_token_type) {
 
 void GDScriptTokenizer::set_source_code(const String &p_source_code) {
 	source = p_source_code;
-	if (source.empty()) {
+	if (source.is_empty()) {
 		_source = U"";
 	} else {
 		_source = source.ptr();
@@ -287,7 +287,7 @@ void GDScriptTokenizer::push_paren(char32_t p_char) {
 }
 
 bool GDScriptTokenizer::pop_paren(char32_t p_expected) {
-	if (paren_stack.empty()) {
+	if (paren_stack.is_empty()) {
 		return false;
 	}
 	char32_t actual = paren_stack.back()->get();
@@ -405,7 +405,7 @@ void GDScriptTokenizer::push_error(const Token &p_error) {
 }
 
 GDScriptTokenizer::Token GDScriptTokenizer::make_paren_error(char32_t p_paren) {
-	if (paren_stack.empty()) {
+	if (paren_stack.is_empty()) {
 		return make_error(vformat("Closing \"%c\" doesn't have an opening counterpart.", p_paren));
 	}
 	Token error = make_error(vformat("Closing \"%c\" doesn't match the opening \"%c\".", p_paren, paren_stack.back()->get()));

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -230,7 +230,7 @@ private:
 	_FORCE_INLINE_ bool _is_at_end() { return position >= length; }
 	_FORCE_INLINE_ char32_t _peek(int p_offset = 0) { return position + p_offset >= 0 && position + p_offset < length ? _current[p_offset] : '\0'; }
 	int indent_level() const { return indent_stack.size(); }
-	bool has_error() const { return !error_stack.empty(); }
+	bool has_error() const { return !error_stack.is_empty(); }
 	Token pop_error();
 	char32_t _advance();
 	void _skip_whitespace();

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -2282,7 +2282,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				VariantInternal::initialize(counter, Variant::INT);
 				*VariantInternal::get_int(counter) = 0;
 
-				if (!str->empty()) {
+				if (!str->is_empty()) {
 					GET_INSTRUCTION_ARG(iterator, 2);
 					VariantInternal::initialize(iterator, Variant::STRING);
 					*VariantInternal::get_string(iterator) = str->substr(0, 1);
@@ -2308,7 +2308,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				const Variant *next = dict->next(nullptr);
 				*counter = *next;
 
-				if (!dict->empty()) {
+				if (!dict->is_empty()) {
 					GET_INSTRUCTION_ARG(iterator, 2);
 					*iterator = *next;
 
@@ -2334,7 +2334,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				VariantInternal::initialize(counter, Variant::INT);
 				*VariantInternal::get_int(counter) = 0;
 
-				if (!array->empty()) {
+				if (!array->is_empty()) {
 					GET_INSTRUCTION_ARG(iterator, 2);
 					*iterator = array->get(0);
 
@@ -2357,7 +2357,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		Vector<m_elem_type> *array = VariantInternal::m_get_func(container);                                               \
 		VariantInternal::initialize(counter, Variant::INT);                                                                \
 		*VariantInternal::get_int(counter) = 0;                                                                            \
-		if (!array->empty()) {                                                                                             \
+		if (!array->is_empty()) {                                                                                          \
 			GET_INSTRUCTION_ARG(iterator, 2);                                                                              \
 			VariantInternal::initialize(iterator, Variant::m_var_ret_type);                                                \
 			m_ret_type *it = VariantInternal::m_ret_get_func(iterator);                                                    \
@@ -2781,7 +2781,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						GET_INSTRUCTION_ARG(message, 1);
 						message_str = *message;
 					}
-					if (message_str.empty()) {
+					if (message_str.is_empty()) {
 						err_text = "Assertion failed.";
 					} else {
 						err_text = "Assertion failed: " + message_str;

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -147,7 +147,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 	r_symbol.script_path = path;
 	r_symbol.children.clear();
 	r_symbol.name = p_class->identifier != nullptr ? String(p_class->identifier->name) : String();
-	if (r_symbol.name.empty()) {
+	if (r_symbol.name.is_empty()) {
 		r_symbol.name = path.get_file();
 	}
 	r_symbol.kind = lsp::SymbolKind::Class;
@@ -215,9 +215,9 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				String value_text;
 				if (default_value.get_type() == Variant::OBJECT) {
 					RES res = default_value;
-					if (res.is_valid() && !res->get_path().empty()) {
+					if (res.is_valid() && !res->get_path().is_empty()) {
 						value_text = "preload(\"" + res->get_path() + "\")";
-						if (symbol.documentation.empty()) {
+						if (symbol.documentation.is_empty()) {
 							if (Map<String, ExtendGDScriptParser *>::Element *S = GDScriptLanguageProtocol::get_singleton()->get_workspace()->scripts.find(res->get_path())) {
 								symbol.documentation = S->get()->class_symbol.documentation;
 							}
@@ -228,7 +228,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				} else {
 					value_text = JSON::print(default_value);
 				}
-				if (!value_text.empty()) {
+				if (!value_text.is_empty()) {
 					symbol.detail += " = " + value_text;
 				}
 
@@ -453,7 +453,7 @@ String ExtendGDScriptParser::get_text_for_lookup_symbol(const lsp::Position &p_c
 			String line = lines[i];
 			String first_part = line.substr(0, p_cursor.character);
 			String last_part = line.substr(p_cursor.character + 1, lines[i].length());
-			if (!p_symbol.empty()) {
+			if (!p_symbol.is_empty()) {
 				String left_cursor_text;
 				for (int c = p_cursor.character - 1; c >= 0; c--) {
 					left_cursor_text = line.substr(c, p_cursor.character - c);
@@ -589,7 +589,7 @@ const lsp::DocumentSymbol *ExtendGDScriptParser::get_symbol_defined_at_line(int 
 }
 
 const lsp::DocumentSymbol *ExtendGDScriptParser::get_member_symbol(const String &p_name, const String &p_subclass) const {
-	if (p_subclass.empty()) {
+	if (p_subclass.is_empty()) {
 		const lsp::DocumentSymbol *const *ptr = members.getptr(p_name);
 		if (ptr) {
 			return *ptr;
@@ -611,7 +611,7 @@ const List<lsp::DocumentLink> &ExtendGDScriptParser::get_document_links() const 
 }
 
 const Array &ExtendGDScriptParser::get_member_completions() {
-	if (member_completions.empty()) {
+	if (member_completions.is_empty()) {
 		const String *name = members.next(nullptr);
 		while (name) {
 			const lsp::DocumentSymbol *symbol = members.get(*name);

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -96,7 +96,7 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 
 		// Response
 		String output = GDScriptLanguageProtocol::get_singleton()->process_message(msg);
-		if (!output.empty()) {
+		if (!output.is_empty()) {
 			res_queue.push_back(output.utf8());
 		}
 	}
@@ -105,7 +105,7 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 
 Error GDScriptLanguageProtocol::LSPeer::send_data() {
 	int sent = 0;
-	if (!res_queue.empty()) {
+	if (!res_queue.is_empty()) {
 		CharString c_res = res_queue[0];
 		if (res_sent < c_res.size()) {
 			Error err = connection->put_partial_data((const uint8_t *)c_res.get_data() + res_sent, c_res.size() - res_sent - 1, sent);
@@ -141,7 +141,7 @@ void GDScriptLanguageProtocol::on_client_disconnected(const int &p_client_id) {
 
 String GDScriptLanguageProtocol::process_message(const String &p_text) {
 	String ret = process_string(p_text);
-	if (ret.empty()) {
+	if (ret.is_empty()) {
 		return ret;
 	} else {
 		return format_output(ret);

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -147,7 +147,7 @@ Array GDScriptTextDocument::completion(const Dictionary &p_params) {
 	List<ScriptCodeCompletionOption> options;
 	GDScriptLanguageProtocol::get_singleton()->get_workspace()->completion(params, &options);
 
-	if (!options.empty()) {
+	if (!options.is_empty()) {
 		int i = 0;
 		arr.resize(options.size());
 
@@ -257,7 +257,7 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 
 	if ((item.kind == lsp::CompletionItemKind::Method || item.kind == lsp::CompletionItemKind::Function) && !item.label.ends_with("):")) {
 		item.insertText = item.label + "(";
-		if (symbol && symbol->children.empty()) {
+		if (symbol && symbol->children.is_empty()) {
 			item.insertText += ")";
 		}
 	} else if (item.kind == lsp::CompletionItemKind::Event) {
@@ -341,7 +341,7 @@ Variant GDScriptTextDocument::declaration(const Dictionary &p_params) {
 	params.load(p_params);
 	List<const lsp::DocumentSymbol *> symbols;
 	Array arr = this->find_symbols(params, symbols);
-	if (arr.empty() && !symbols.empty() && !symbols.front()->get()->native_class.empty()) { // Find a native symbol
+	if (arr.is_empty() && !symbols.is_empty() && !symbols.front()->get()->native_class.is_empty()) { // Find a native symbol
 		const lsp::DocumentSymbol *symbol = symbols.front()->get();
 		if (GDScriptLanguageProtocol::get_singleton()->is_goto_native_symbols_enabled()) {
 			String id;
@@ -425,7 +425,7 @@ Array GDScriptTextDocument::find_symbols(const lsp::TextDocumentPositionParams &
 		GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_related_symbols(p_location, list);
 		for (List<const lsp::DocumentSymbol *>::Element *E = list.front(); E; E = E->next()) {
 			if (const lsp::DocumentSymbol *s = E->get()) {
-				if (!s->uri.empty()) {
+				if (!s->uri.is_empty()) {
 					lsp::Location location;
 					location.uri = s->uri;
 					location.range = s->range;

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -80,7 +80,7 @@ const lsp::DocumentSymbol *GDScriptWorkspace::get_native_symbol(const String &p_
 		if (const Map<StringName, lsp::DocumentSymbol>::Element *E = native_symbols.find(class_name)) {
 			const lsp::DocumentSymbol &class_symbol = E->value();
 
-			if (p_member.empty()) {
+			if (p_member.is_empty()) {
 				return &class_symbol;
 			} else {
 				for (int i = 0; i < class_symbol.children.size(); i++) {
@@ -171,7 +171,7 @@ ExtendGDScriptParser *GDScriptWorkspace::get_parse_result(const String &p_path) 
 Array GDScriptWorkspace::symbol(const Dictionary &p_params) {
 	String query = p_params["query"];
 	Array arr;
-	if (!query.empty()) {
+	if (!query.is_empty()) {
 		for (Map<String, ExtendGDScriptParser *>::Element *E = scripts.front(); E; E = E->next()) {
 			Vector<lsp::DocumentedSymbolInformation> script_symbols;
 			E->get()->get_symbols().symbol_tree_as_list(E->key(), script_symbols);
@@ -199,7 +199,7 @@ Error GDScriptWorkspace::initialize() {
 		class_symbol.native_class = class_name;
 		class_symbol.kind = lsp::SymbolKind::Class;
 		class_symbol.detail = String("<Native> class ") + class_name;
-		if (!class_data.inherits.empty()) {
+		if (!class_data.inherits.is_empty()) {
 			class_symbol.detail += " extends " + class_data.inherits;
 		}
 		class_symbol.documentation = class_data.brief_description + "\n" + class_data.description;
@@ -263,7 +263,7 @@ Error GDScriptWorkspace::initialize() {
 				symbol_arg.kind = lsp::SymbolKind::Variable;
 				symbol_arg.detail = arg.type;
 
-				if (!arg_default_value_started && !arg.default_value.empty()) {
+				if (!arg_default_value_started && !arg.default_value.is_empty()) {
 					arg_default_value_started = true;
 				}
 				String arg_str = arg.name + ": " + arg.type;
@@ -278,11 +278,11 @@ Error GDScriptWorkspace::initialize() {
 				symbol.children.push_back(symbol_arg);
 			}
 			if (data.qualifiers.find("vararg") != -1) {
-				params += params.empty() ? "..." : ", ...";
+				params += params.is_empty() ? "..." : ", ...";
 			}
 
 			String return_type = data.return_type;
-			if (return_type.empty()) {
+			if (return_type.is_empty()) {
 				return_type = "void";
 			}
 			symbol.detail = "func " + class_name + "." + data.name + "(" + params + ") -> " + return_type;
@@ -448,13 +448,13 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 		}
 
 		lsp::Position pos = p_doc_pos.position;
-		if (symbol_identifier.empty()) {
+		if (symbol_identifier.is_empty()) {
 			Vector2i offset;
 			symbol_identifier = parser->get_identifier_under_position(p_doc_pos.position, offset);
 			pos.character += offset.y;
 		}
 
-		if (!symbol_identifier.empty()) {
+		if (!symbol_identifier.is_empty()) {
 			if (ScriptServer::is_global_class(symbol_identifier)) {
 				String class_path = ScriptServer::get_global_class_path(symbol_identifier);
 				symbol = get_script_symbol(class_path);
@@ -474,7 +474,7 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 
 					} else {
 						String member = ret.class_member;
-						if (member.empty() && symbol_identifier != ret.class_name) {
+						if (member.is_empty() && symbol_identifier != ret.class_name) {
 							member = symbol_identifier;
 						}
 						symbol = get_native_symbol(ret.class_name, member);
@@ -529,7 +529,7 @@ void GDScriptWorkspace::resolve_related_symbols(const lsp::TextDocumentPositionP
 const lsp::DocumentSymbol *GDScriptWorkspace::resolve_native_symbol(const lsp::NativeSymbolInspectParams &p_params) {
 	if (Map<StringName, lsp::DocumentSymbol>::Element *E = native_symbols.find(p_params.native_class)) {
 		const lsp::DocumentSymbol &symbol = E->get();
-		if (p_params.symbol_name.empty() || p_params.symbol_name == symbol.name) {
+		if (p_params.symbol_name.is_empty() || p_params.symbol_name == symbol.name) {
 			return &symbol;
 		}
 

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -687,7 +687,7 @@ struct Diagnostic {
 		dict["severity"] = severity;
 		dict["message"] = message;
 		dict["source"] = source;
-		if (!relatedInformation.empty()) {
+		if (!relatedInformation.is_empty()) {
 			Array arr;
 			arr.resize(relatedInformation.size());
 			for (int i = 0; i < relatedInformation.size(); i++) {
@@ -1191,7 +1191,7 @@ struct DocumentSymbol {
 
 	void symbol_tree_as_list(const String &p_uri, Vector<DocumentedSymbolInformation> &r_list, const String &p_container = "", bool p_join_name = false) const {
 		DocumentedSymbolInformation si;
-		if (p_join_name && !p_container.empty()) {
+		if (p_join_name && !p_container.is_empty()) {
 			si.name = p_container + ">" + name;
 		} else {
 			si.name = name;

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -239,7 +239,7 @@ void init_autoloads() {
 void test(TestType p_type) {
 	List<String> cmdlargs = OS::get_singleton()->get_cmdline_args();
 
-	if (cmdlargs.empty()) {
+	if (cmdlargs.is_empty()) {
 		return;
 	}
 

--- a/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
@@ -82,7 +82,7 @@ void SceneExporterGLTFPlugin::convert_scene_to_gltf2() {
 		return;
 	}
 	String filename = String(root->get_filename().get_file().get_basename());
-	if (filename.empty()) {
+	if (filename.is_empty()) {
 		filename = root->get_name();
 	}
 	file_export_lib->set_current_file(filename + String(".gltf"));

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -204,7 +204,7 @@ Error GLTFDocument::_serialize_scenes(Ref<GLTFState> state) {
 
 	if (state->nodes.size()) {
 		Dictionary s;
-		if (!state->scene_name.empty()) {
+		if (!state->scene_name.is_empty()) {
 			s["name"] = state->scene_name;
 		}
 
@@ -395,7 +395,7 @@ Error GLTFDocument::_serialize_nodes(Ref<GLTFState> state) {
 		Ref<GLTFNode> n = state->nodes[i];
 		Dictionary extensions;
 		node["extensions"] = extensions;
-		if (!n->get_name().empty()) {
+		if (!n->get_name().is_empty()) {
 			node["name"] = n->get_name();
 		}
 		if (n->camera != -1) {
@@ -493,7 +493,7 @@ String GLTFDocument::_sanitize_bone_name(const String &name) {
 
 String GLTFDocument::_gen_unique_bone_name(Ref<GLTFState> state, const GLTFSkeletonIndex skel_i, const String &p_name) {
 	String s_name = _sanitize_bone_name(p_name);
-	if (s_name.empty()) {
+	if (s_name.is_empty()) {
 		s_name = "bone";
 	}
 	String name;
@@ -2703,7 +2703,7 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> state, const String &p_path
 			d["mimeType"] = "image/png";
 		} else {
 			String name = state->images[i]->get_name();
-			if (name.empty()) {
+			if (name.is_empty()) {
 				name = itos(i);
 			}
 			name = _gen_unique_name(state, name);
@@ -2785,7 +2785,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> state, const String &p_base_pat
 				data_ptr = data.ptr();
 				data_size = data.size();
 				// mimeType is optional, but if we have it defined in the URI, let's use it.
-				if (mimetype.empty()) {
+				if (mimetype.is_empty()) {
 					if (uri.begins_with("data:image/png;base64")) {
 						mimetype = "image/png";
 					} else if (uri.begins_with("data:image/jpeg;base64")) {
@@ -2814,7 +2814,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> state, const String &p_base_pat
 			}
 		} else if (d.has("bufferView")) {
 			// Handles the third bullet point from the spec (bufferView).
-			ERR_FAIL_COND_V_MSG(mimetype.empty(), ERR_FILE_CORRUPT,
+			ERR_FAIL_COND_V_MSG(mimetype.is_empty(), ERR_FILE_CORRUPT,
 					vformat("glTF: Image index '%d' specifies 'bufferView' but no 'mimeType', which is invalid.", i));
 
 			const GLTFBufferViewIndex bvi = d["bufferView"];
@@ -2936,7 +2936,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> state) {
 			materials.push_back(d);
 			continue;
 		}
-		if (!material->get_name().empty()) {
+		if (!material->get_name().is_empty()) {
 			d["name"] = _gen_unique_name(state, material->get_name());
 		}
 		{
@@ -4071,7 +4071,7 @@ Error GLTFDocument::_create_skeletons(Ref<GLTFState> state) {
 		// a sorted order, and DEPTH FIRST
 		bones.sort();
 
-		while (!bones.empty()) {
+		while (!bones.is_empty()) {
 			const GLTFNodeIndex node_i = bones.front()->get();
 			bones.pop_front();
 
@@ -4096,7 +4096,7 @@ Error GLTFDocument::_create_skeletons(Ref<GLTFState> state) {
 
 			const int bone_index = skeleton->get_bone_count();
 
-			if (node->get_name().empty()) {
+			if (node->get_name().is_empty()) {
 				node->set_name("bone");
 			}
 
@@ -4153,7 +4153,7 @@ Error GLTFDocument::_create_skins(Ref<GLTFState> state) {
 		skin.instance();
 
 		// Some skins don't have IBM's! What absolute monsters!
-		const bool has_ibms = !gltf_skin->inverse_binds.empty();
+		const bool has_ibms = !gltf_skin->inverse_binds.is_empty();
 
 		for (int joint_i = 0; joint_i < gltf_skin->joints_original.size(); ++joint_i) {
 			GLTFNodeIndex node = gltf_skin->joints_original[joint_i];
@@ -4181,7 +4181,7 @@ Error GLTFDocument::_create_skins(Ref<GLTFState> state) {
 	// Create unique names now, after removing duplicates
 	for (GLTFSkinIndex skin_i = 0; skin_i < state->skins.size(); ++skin_i) {
 		Ref<Skin> skin = state->skins.write[skin_i]->godot_skin;
-		if (skin->get_name().empty()) {
+		if (skin->get_name().is_empty()) {
 			// Make a unique name, no gltf node represents this skin
 			skin->set_name(_gen_unique_name(state, "Skin"));
 		}
@@ -4447,7 +4447,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 			continue;
 		}
 
-		if (!gltf_animation->get_name().empty()) {
+		if (!gltf_animation->get_name().is_empty()) {
 			d["name"] = gltf_animation->get_name();
 		}
 		Array channels;
@@ -4707,7 +4707,7 @@ void GLTFDocument::_assign_scene_names(Ref<GLTFState> state) {
 		if (n->skeleton >= 0)
 			continue;
 
-		if (n->get_name().empty()) {
+		if (n->get_name().is_empty()) {
 			if (n->mesh >= 0) {
 				n->set_name(_gen_unique_name(state, "Mesh"));
 			} else if (n->camera >= 0) {
@@ -5407,7 +5407,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 	Ref<GLTFAnimation> anim = state->animations[index];
 
 	String name = anim->get_name();
-	if (name.empty()) {
+	if (name.is_empty()) {
 		// No node represent these, and they are not in the hierarchy, so just make a unique name
 		name = _gen_unique_name(state, "Animation");
 	}
@@ -5652,7 +5652,7 @@ void GLTFDocument::_convert_mesh_instances(Ref<GLTFState> state) {
 		Ref<GLTFSkeleton> gltf_skeleton = state->skeletons.write[skeleton_gltf_i];
 		for (int32_t bind_i = 0; bind_i < skin->get_bind_count(); bind_i++) {
 			String godot_bone_name = skin->get_bind_name(bind_i);
-			if (godot_bone_name.empty()) {
+			if (godot_bone_name.is_empty()) {
 				int32_t bone = skin->get_bind_bone(bind_i);
 				godot_bone_name = skeleton->get_bone_name(bone);
 			}

--- a/modules/jsonrpc/jsonrpc.cpp
+++ b/modules/jsonrpc/jsonrpc.cpp
@@ -151,7 +151,7 @@ Variant JSONRPC::process_action(const Variant &p_action, bool p_process_arr_elem
 }
 
 String JSONRPC::process_string(const String &p_input) {
-	if (p_input.empty()) {
+	if (p_input.is_empty()) {
 		return String();
 	}
 

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -40,8 +40,8 @@
 //#define DEBUG_TEXTURES
 
 void LightmapperRD::add_mesh(const MeshData &p_mesh) {
-	ERR_FAIL_COND(p_mesh.albedo_on_uv2.is_null() || p_mesh.albedo_on_uv2->empty());
-	ERR_FAIL_COND(p_mesh.emission_on_uv2.is_null() || p_mesh.emission_on_uv2->empty());
+	ERR_FAIL_COND(p_mesh.albedo_on_uv2.is_null() || p_mesh.albedo_on_uv2->is_empty());
+	ERR_FAIL_COND(p_mesh.emission_on_uv2.is_null() || p_mesh.emission_on_uv2->is_empty());
 	ERR_FAIL_COND(p_mesh.albedo_on_uv2->get_width() != p_mesh.emission_on_uv2->get_width());
 	ERR_FAIL_COND(p_mesh.albedo_on_uv2->get_height() != p_mesh.emission_on_uv2->get_height());
 	ERR_FAIL_COND(p_mesh.points.size() == 0);

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -205,7 +205,7 @@ Error HMACContextMbedTLS::start(HashingContext::HashType p_hash_type, PackedByte
 	ERR_FAIL_COND_V_MSG(ctx != nullptr, ERR_FILE_ALREADY_IN_USE, "HMACContext already started.");
 
 	// HMAC keys can be any size.
-	ERR_FAIL_COND_V_MSG(p_key.empty(), ERR_INVALID_PARAMETER, "Key must not be empty.");
+	ERR_FAIL_COND_V_MSG(p_key.is_empty(), ERR_INVALID_PARAMETER, "Key must not be empty.");
 
 	hash_type = p_hash_type;
 	mbedtls_md_type_t ht = CryptoMbedTLS::md_type_from_hashtype(p_hash_type, hash_len);
@@ -224,7 +224,7 @@ Error HMACContextMbedTLS::start(HashingContext::HashType p_hash_type, PackedByte
 Error HMACContextMbedTLS::update(PackedByteArray p_data) {
 	ERR_FAIL_COND_V_MSG(ctx == nullptr, ERR_INVALID_DATA, "Start must be called before update.");
 
-	ERR_FAIL_COND_V_MSG(p_data.empty(), ERR_INVALID_PARAMETER, "Src must not be empty.");
+	ERR_FAIL_COND_V_MSG(p_data.is_empty(), ERR_INVALID_PARAMETER, "Src must not be empty.");
 
 	int ret = mbedtls_md_hmac_update((mbedtls_md_context_t *)ctx, (const uint8_t *)p_data.ptr(), (size_t)p_data.size());
 	return ret ? FAILED : OK;

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -71,7 +71,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 			while ((k = t->method_map.next(k))) {
 				String name = k->operator String();
 
-				ERR_CONTINUE(name.empty());
+				ERR_CONTINUE(name.is_empty());
 
 				if (name[0] == '_') {
 					continue; // Ignore non-virtual methods that start with an underscore
@@ -122,7 +122,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				method_dict["hint_flags"] = mb->get_hint_flags();
 			}
 
-			if (!methods.empty()) {
+			if (!methods.is_empty()) {
 				class_dict["methods"] = methods;
 			}
 		}
@@ -149,7 +149,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				constant_dict["value"] = t->constant_map[F->get()];
 			}
 
-			if (!constants.empty()) {
+			if (!constants.is_empty()) {
 				class_dict["constants"] = constants;
 			}
 		}
@@ -184,7 +184,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				}
 			}
 
-			if (!signals.empty()) {
+			if (!signals.is_empty()) {
 				class_dict["signals"] = signals;
 			}
 		}
@@ -214,7 +214,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				property_dict["getter"] = psg->getter;
 			}
 
-			if (!properties.empty()) {
+			if (!properties.is_empty()) {
 				class_dict["property_setget"] = properties;
 			}
 		}
@@ -233,7 +233,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 			property_dict["usage"] = F->get().usage;
 		}
 
-		if (!property_list.empty()) {
+		if (!property_list.is_empty()) {
 			class_dict["property_list"] = property_list;
 		}
 	}

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -400,7 +400,7 @@ bool CSharpLanguage::supports_builtin_mode() const {
 
 #ifdef TOOLS_ENABLED
 static String variant_type_to_managed_name(const String &p_var_type_name) {
-	if (p_var_type_name.empty()) {
+	if (p_var_type_name.is_empty()) {
 		return "object";
 	}
 
@@ -762,7 +762,7 @@ bool CSharpLanguage::is_assembly_reloading_needed() {
 
 	String appname = ProjectSettings::get_singleton()->get("application/config/name");
 	String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-	if (appname_safe.empty()) {
+	if (appname_safe.is_empty()) {
 		appname_safe = "UnnamedProject";
 	}
 
@@ -859,7 +859,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 
 		to_reload.push_back(script);
 
-		if (script->get_path().empty()) {
+		if (script->get_path().is_empty()) {
 			script->tied_class_name_for_reload = script->script_class->get_name_for_lookup();
 			script->tied_class_namespace_for_reload = script->script_class->get_namespace();
 		}
@@ -976,7 +976,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 #endif
 		script->signals_invalidated = true;
 
-		if (!script->get_path().empty()) {
+		if (!script->get_path().is_empty()) {
 			script->reload(p_soft_reload);
 
 			if (!script->valid) {
@@ -1446,7 +1446,7 @@ Map<Object *, CSharpScriptBinding>::Element *CSharpLanguage::insert_script_bindi
 void CSharpLanguage::free_instance_binding_data(void *p_data) {
 	if (GDMono::get_singleton() == nullptr) {
 #ifdef DEBUG_ENABLED
-		CRASH_COND(!script_bindings.empty());
+		CRASH_COND(!script_bindings.is_empty());
 #endif
 		// Mono runtime finalized, all the gchandle bindings were already released
 		return;
@@ -3128,7 +3128,7 @@ CSharpInstance *CSharpScript::_create_instance(const Variant **p_args, int p_arg
 		ERR_FAIL_COND_V_MSG(p_argcount == 0, nullptr,
 				"Cannot create script instance. The class '" + script_class->get_full_name() +
 						"' does not define a parameterless constructor." +
-						(get_path().empty() ? String() : " Path: '" + get_path() + "'."));
+						(get_path().is_empty() ? String() : " Path: '" + get_path() + "'."));
 
 		ERR_FAIL_V_MSG(nullptr, "Constructor not found.");
 	}
@@ -3283,7 +3283,7 @@ bool CSharpScript::instance_has(const Object *p_this) const {
 }
 
 bool CSharpScript::has_source_code() const {
-	return !source.empty();
+	return !source.is_empty();
 }
 
 String CSharpScript::get_source_code() const {
@@ -3598,7 +3598,7 @@ Error CSharpScript::load_source_code(const String &p_path) {
 void CSharpScript::_update_name() {
 	String path = get_path();
 
-	if (!path.empty()) {
+	if (!path.is_empty()) {
 		name = get_path().get_file().get_basename();
 	}
 }

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -181,7 +181,7 @@ static String snake_to_camel_case(const String &p_identifier, bool p_input_is_up
 String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterface *p_itype) {
 	// Based on the version in EditorHelp
 
-	if (p_bbcode.empty()) {
+	if (p_bbcode.is_empty()) {
 		return String();
 	}
 
@@ -644,7 +644,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 }
 
 int BindingsGenerator::_determine_enum_prefix(const EnumInterface &p_ienum) {
-	CRASH_COND(p_ienum.constants.empty());
+	CRASH_COND(p_ienum.constants.is_empty());
 
 	const ConstantInterface &front_iconstant = p_ienum.constants.front()->get();
 	Vector<String> front_parts = front_iconstant.name.split("_", /* p_allow_empty: */ true);
@@ -819,7 +819,7 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 		p_output.append(";");
 	}
 
-	if (!global_constants.empty()) {
+	if (!global_constants.is_empty()) {
 		p_output.append("\n");
 	}
 
@@ -830,7 +830,7 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 	for (List<EnumInterface>::Element *E = global_enums.front(); E; E = E->next()) {
 		const EnumInterface &ienum = E->get();
 
-		CRASH_COND(ienum.constants.empty());
+		CRASH_COND(ienum.constants.is_empty());
 
 		String enum_proxy_name = ienum.cname.operator String();
 
@@ -1283,7 +1283,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 	for (const List<EnumInterface>::Element *E = itype.enums.front(); E; E = E->next()) {
 		const EnumInterface &ienum = E->get();
 
-		ERR_FAIL_COND_V(ienum.constants.empty(), ERR_BUG);
+		ERR_FAIL_COND_V(ienum.constants.is_empty(), ERR_BUG);
 
 		output.append(MEMBER_BEGIN "public enum ");
 		output.append(ienum.cname.operator String());
@@ -1661,14 +1661,14 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 			cs_in_statements += def_arg;
 			cs_in_statements += ";\n" INDENT3;
 
-			icall_params += arg_type->cs_in.empty() ? arg_in : sformat(arg_type->cs_in, arg_in);
+			icall_params += arg_type->cs_in.is_empty() ? arg_in : sformat(arg_type->cs_in, arg_in);
 
 			// Apparently the name attribute must not include the @
 			String param_tag_name = iarg.name.begins_with("@") ? iarg.name.substr(1, iarg.name.length()) : iarg.name;
 
 			default_args_doc.append(MEMBER_BEGIN "/// <param name=\"" + param_tag_name + "\">If the parameter is null, then the default value is " + def_arg + "</param>");
 		} else {
-			icall_params += arg_type->cs_in.empty() ? iarg.name : sformat(arg_type->cs_in, iarg.name);
+			icall_params += arg_type->cs_in.is_empty() ? iarg.name : sformat(arg_type->cs_in, iarg.name);
 		}
 	}
 
@@ -1714,7 +1714,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 		}
 
 		if (p_imethod.is_deprecated) {
-			if (p_imethod.deprecation_message.empty()) {
+			if (p_imethod.deprecation_message.is_empty()) {
 				WARN_PRINT("An empty deprecation message is discouraged. Method: '" + p_imethod.proxy_name + "'.");
 			}
 
@@ -1782,7 +1782,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 		if (return_type->cname == name_cache.type_void) {
 			p_output.append(im_call + "(" + icall_params + ");\n");
-		} else if (return_type->cs_out.empty()) {
+		} else if (return_type->cs_out.is_empty()) {
 			p_output.append("return " + im_call + "(" + icall_params + ");\n");
 		} else {
 			p_output.append(sformat(return_type->cs_out, im_call, icall_params, return_type->cs_type, return_type->im_type_out));
@@ -1839,7 +1839,7 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 		}
 
 		if (p_isignal.is_deprecated) {
-			if (p_isignal.deprecation_message.empty()) {
+			if (p_isignal.deprecation_message.is_empty()) {
 				WARN_PRINT("An empty deprecation message is discouraged. Signal: '" + p_isignal.proxy_name + "'.");
 			}
 
@@ -2263,7 +2263,7 @@ Error BindingsGenerator::_generate_glue_method(const BindingsGenerator::TypeInte
 		}
 
 		if (!ret_void) {
-			if (return_type->c_out.empty()) {
+			if (return_type->c_out.is_empty()) {
 				p_output.append("\treturn " C_LOCAL_RET ";\n");
 			} else if (return_type->ret_as_byref_arg) {
 				p_output.append(sformat(return_type->c_out, return_type->c_type_out, C_LOCAL_RET, return_type->name, "arg_ret"));
@@ -2585,7 +2585,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 			int argc = method_info.arguments.size();
 
-			if (method_info.name.empty()) {
+			if (method_info.name.is_empty()) {
 				continue;
 			}
 

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -150,7 +150,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			List<String> directories;
 			directories.push_back(dir_access->get_current_dir());
 
-			while (!directories.empty()) {
+			while (!directories.is_empty()) {
 				dir_access->change_dir(directories.back()->get());
 				directories.pop_back();
 

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -195,7 +195,7 @@ int32_t godot_icall_ScriptClassParser_ParseFile(MonoString *p_filepath, MonoObje
 		}
 	} else {
 		String error_str = scp.get_error();
-		if (!error_str.empty()) {
+		if (!error_str.is_empty()) {
 			*r_error_str = GDMonoMarshal::mono_string_from_godot(error_str);
 		}
 	}

--- a/modules/mono/glue/scene_tree_glue.cpp
+++ b/modules/mono/glue/scene_tree_glue.cpp
@@ -48,7 +48,7 @@ Array *godot_icall_SceneTree_get_nodes_in_group_Generic(SceneTree *ptr, StringNa
 	ptr->get_nodes_in_group(*group, &nodes);
 
 	// No need to bother if the group is empty
-	if (!nodes.empty()) {
+	if (!nodes.is_empty()) {
 		MonoType *elem_type = mono_reflection_type_get_type(refltype);
 		MonoClass *mono_class = mono_class_from_mono_type(elem_type);
 		GDMonoClass *klass = GDMono::get_singleton()->get_class(mono_class);

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -146,7 +146,7 @@ private:
 
 		String appname = ProjectSettings::get_singleton()->get("application/config/name");
 		String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-		if (appname_safe.empty()) {
+		if (appname_safe.is_empty()) {
 			appname_safe = "UnnamedProject";
 		}
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -142,7 +142,7 @@ void gd_mono_debug_init() {
 	int da_timeout = GLOBAL_DEF("mono/debugger_agent/wait_timeout", 3000);
 
 	if (Engine::get_singleton()->is_editor_hint() ||
-			ProjectSettings::get_singleton()->get_resource_path().empty() ||
+			ProjectSettings::get_singleton()->get_resource_path().is_empty() ||
 			Main::is_project_manager()) {
 		if (da_args.size() == 0) {
 			return;
@@ -297,7 +297,7 @@ void GDMono::determine_mono_dirs(String &r_assembly_rootdir, String &r_config_di
 	}
 
 #ifdef WINDOWS_ENABLED
-	if (r_assembly_rootdir.empty() || r_config_dir.empty()) {
+	if (r_assembly_rootdir.is_empty() || r_config_dir.is_empty()) {
 		ERR_PRINT("Cannot find Mono in the registry.");
 		// Assertion: if they are not set, then they weren't found in the registry
 		CRASH_COND(mono_reg_info.assembly_dir.length() > 0 || mono_reg_info.config_dir.length() > 0);
@@ -360,7 +360,7 @@ void GDMono::initialize() {
 #ifndef TOOLS_ENABLED
 	// Exported games that don't use C# must still work. They likely don't ship with mscorlib.
 	// We only initialize the Mono runtime if we can find mscorlib. Otherwise it would crash.
-	if (GDMonoAssembly::find_assembly("mscorlib.dll").empty()) {
+	if (GDMonoAssembly::find_assembly("mscorlib.dll").is_empty()) {
 		print_verbose("Mono: Skipping runtime initialization because 'mscorlib.dll' could not be found");
 		return;
 	}
@@ -944,7 +944,7 @@ void GDMono::_load_api_assemblies() {
 
 		// 2. Update the API assemblies
 		String update_error = update_api_assemblies_from_prebuilt("Debug", &core_api_assembly.out_of_sync, &editor_api_assembly.out_of_sync);
-		CRASH_COND_MSG(!update_error.empty(), update_error);
+		CRASH_COND_MSG(!update_error.is_empty(), update_error);
 
 		// 3. Load the scripts domain again
 		Error domain_load_err = _load_scripts_domain();
@@ -998,7 +998,7 @@ bool GDMono::_load_project_assembly() {
 
 	String appname = ProjectSettings::get_singleton()->get("application/config/name");
 	String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-	if (appname_safe.empty()) {
+	if (appname_safe.is_empty()) {
 		appname_safe = "UnnamedProject";
 	}
 

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -48,20 +48,20 @@ Vector<String> GDMonoAssembly::search_dirs;
 void GDMonoAssembly::fill_search_dirs(Vector<String> &r_search_dirs, const String &p_custom_config, const String &p_custom_bcl_dir) {
 	String framework_dir;
 
-	if (!p_custom_bcl_dir.empty()) {
+	if (!p_custom_bcl_dir.is_empty()) {
 		framework_dir = p_custom_bcl_dir;
 	} else if (mono_assembly_getrootdir()) {
 		framework_dir = String::utf8(mono_assembly_getrootdir()).plus_file("mono").plus_file("4.5");
 	}
 
-	if (!framework_dir.empty()) {
+	if (!framework_dir.is_empty()) {
 		r_search_dirs.push_back(framework_dir);
 		r_search_dirs.push_back(framework_dir.plus_file("Facades"));
 	}
 
 #if !defined(TOOLS_ENABLED)
 	String data_game_assemblies_dir = GodotSharpDirs::get_data_game_assemblies_dir();
-	if (!data_game_assemblies_dir.empty()) {
+	if (!data_game_assemblies_dir.is_empty()) {
 		r_search_dirs.push_back(data_game_assemblies_dir);
 	}
 #endif
@@ -72,7 +72,7 @@ void GDMonoAssembly::fill_search_dirs(Vector<String> &r_search_dirs, const Strin
 		r_search_dirs.push_back(GodotSharpDirs::get_res_temp_assemblies_dir());
 	}
 
-	if (p_custom_config.empty()) {
+	if (p_custom_config.is_empty()) {
 		r_search_dirs.push_back(GodotSharpDirs::get_res_assemblies_dir());
 	} else {
 		String api_config = p_custom_config == "ExportRelease" ? "Release" : "Debug";
@@ -230,7 +230,7 @@ void GDMonoAssembly::initialize() {
 
 MonoAssembly *GDMonoAssembly::_real_load_assembly_from(const String &p_path, bool p_refonly, MonoAssemblyName *p_aname) {
 	Vector<uint8_t> data = FileAccess::get_file_as_array(p_path);
-	ERR_FAIL_COND_V_MSG(data.empty(), nullptr, "Could read the assembly in the specified location");
+	ERR_FAIL_COND_V_MSG(data.is_empty(), nullptr, "Could read the assembly in the specified location");
 
 	String image_filename;
 
@@ -423,7 +423,7 @@ GDMonoClass *GDMonoAssembly::get_object_derived_class(const StringName &p_class)
 				match = current;
 			}
 
-			while (!nested_classes.empty()) {
+			while (!nested_classes.is_empty()) {
 				GDMonoClass *current_nested = nested_classes.front()->get();
 				nested_classes.pop_front();
 

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -136,7 +136,7 @@ String realpath(const String &p_path) {
 }
 
 String join(const String &p_a, const String &p_b) {
-	if (p_a.empty()) {
+	if (p_a.is_empty()) {
 		return p_b;
 	}
 
@@ -165,7 +165,7 @@ String relative_to_impl(const String &p_path, const String &p_relative_to) {
 	} else {
 		String base_dir = p_relative_to.get_base_dir();
 
-		if (base_dir.length() <= 2 && (base_dir.empty() || base_dir.ends_with(":"))) {
+		if (base_dir.length() <= 2 && (base_dir.is_empty() || base_dir.ends_with(":"))) {
 			return p_path;
 		}
 

--- a/modules/pvr/texture_loader_pvr.cpp
+++ b/modules/pvr/texture_loader_pvr.cpp
@@ -153,7 +153,7 @@ RES ResourceFormatPVR::load(const String &p_path, const String &p_original_path,
 	}
 
 	Ref<Image> image = memnew(Image(width, height, mipmaps, format, data));
-	ERR_FAIL_COND_V(image->empty(), RES());
+	ERR_FAIL_COND_V(image->is_empty(), RES());
 
 	Ref<ImageTexture> texture = memnew(ImageTexture);
 	texture->create_from_image(image);

--- a/modules/text_server_adv/dynamic_font_adv.cpp
+++ b/modules/text_server_adv/dynamic_font_adv.cpp
@@ -55,7 +55,7 @@ DynamicFontDataAdvanced::DataAtSize *DynamicFontDataAdvanced::get_data_for_size(
 		fds = E->get();
 	} else {
 		if (font_mem == nullptr && font_path != String()) {
-			if (!font_mem_cache.empty()) {
+			if (!font_mem_cache.is_empty()) {
 				font_mem = font_mem_cache.ptr();
 				font_mem_size = font_mem_cache.size();
 			} else {
@@ -171,7 +171,7 @@ DynamicFontDataAdvanced::DataAtSize *DynamicFontDataAdvanced::get_data_for_size(
 			}
 
 			FT_Set_Var_Design_Coordinates(fds->face, coords.size(), coords.ptrw());
-			hb_font_set_variations(fds->hb_handle, hb_vars.empty() ? nullptr : &hb_vars[0], hb_vars.size());
+			hb_font_set_variations(fds->hb_handle, hb_vars.is_empty() ? nullptr : &hb_vars[0], hb_vars.size());
 
 			FT_Done_MM_Var(library, amaster);
 		}

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -171,7 +171,7 @@ bool TextServerAdvanced::load_support_data(const String &p_filename) {
 	}
 #else
 	if (icu_data == nullptr) {
-		String filename = (p_filename.empty()) ? String("res://") + _MKSTR(ICU_DATA_NAME) : p_filename;
+		String filename = (p_filename.is_empty()) ? String("res://") + _MKSTR(ICU_DATA_NAME) : p_filename;
 
 		FileAccess *f = FileAccess::open(filename, FileAccess::READ);
 		if (!f) {
@@ -1061,7 +1061,7 @@ bool TextServerAdvanced::shaped_text_add_string(RID p_shaped, const String &p_te
 	ERR_FAIL_COND_V(!sd, false);
 	ERR_FAIL_COND_V(p_size <= 0, false);
 
-	if (p_text.empty()) {
+	if (p_text.is_empty()) {
 		return true;
 	}
 
@@ -1984,7 +1984,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 			ftrs.push_back(feature);
 		}
 	}
-	hb_shape(hb_font, p_sd->hb_buffer, ftrs.empty() ? nullptr : &ftrs[0], ftrs.size());
+	hb_shape(hb_font, p_sd->hb_buffer, ftrs.is_empty() ? nullptr : &ftrs[0], ftrs.size());
 
 	unsigned int glyph_count = 0;
 	hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(p_sd->hb_buffer, &glyph_count);
@@ -2131,7 +2131,7 @@ bool TextServerAdvanced::shaped_text_shape(RID p_shaped) {
 		sd->script_iter = memnew(ScriptIterator(sd->text, 0, sd->text.length()));
 	}
 
-	if (sd->bidi_override.empty()) {
+	if (sd->bidi_override.is_empty()) {
 		sd->bidi_override.push_back(Vector2i(0, sd->end));
 	}
 

--- a/modules/upnp/upnp.cpp
+++ b/modules/upnp/upnp.cpp
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 
 bool UPNP::is_common_device(const String &dev) const {
-	return dev.empty() ||
+	return dev.is_empty() ||
 		   dev.find("InternetGatewayDevice") >= 0 ||
 		   dev.find("WANIPConnection") >= 0 ||
 		   dev.find("WANPPPConnection") >= 0 ||
@@ -76,7 +76,7 @@ int UPNP::discover(int timeout, int ttl, const String &device_filter) {
 	struct UPNPDev *dev = devlist;
 
 	while (dev) {
-		if (device_filter.empty() || strstr(dev->st, device_filter.utf8().get_data())) {
+		if (device_filter.is_empty() || strstr(dev->st, device_filter.utf8().get_data())) {
 			add_device_to_list(dev, devlist);
 		}
 

--- a/modules/upnp/upnp_device.cpp
+++ b/modules/upnp/upnp_device.cpp
@@ -65,7 +65,7 @@ int UPNPDevice::add_port_mapping(int port, int port_internal, String desc, Strin
 			itos(port).utf8().get_data(),
 			itos(port_internal).utf8().get_data(),
 			igd_our_addr.utf8().get_data(),
-			desc.empty() ? nullptr : desc.utf8().get_data(),
+			desc.is_empty() ? nullptr : desc.utf8().get_data(),
 			proto.utf8().get_data(),
 			nullptr, // Remote host, always nullptr as IGDs don't support it
 			duration > 0 ? itos(duration).utf8().get_data() : nullptr);

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -810,7 +810,7 @@ void VisualScript::get_custom_signal_list(List<StringName> *r_custom_signals) co
 int VisualScript::get_available_id() const {
 	int max_id = 0;
 	for (Map<StringName, Function>::Element *E = functions.front(); E; E = E->next()) {
-		if (E->get().nodes.empty()) {
+		if (E->get().nodes.is_empty()) {
 			continue;
 		}
 
@@ -1401,7 +1401,7 @@ Set<int> VisualScript::get_output_sequence_ports_connected(const String &edited_
 }
 
 VisualScript::~VisualScript() {
-	while (!functions.empty()) {
+	while (!functions.is_empty()) {
 		remove_function(functions.front()->key());
 	}
 }
@@ -1506,7 +1506,7 @@ void VisualScriptInstance::_dependency_step(VisualScriptNodeInstance *node, int 
 
 	pass_stack[node->pass_idx] = p_pass;
 
-	if (!node->dependencies.empty()) {
+	if (!node->dependencies.is_empty()) {
 		int dc = node->dependencies.size();
 		VisualScriptNodeInstance **deps = node->dependencies.ptrw();
 
@@ -1593,7 +1593,7 @@ Variant VisualScriptInstance::_call_internal(const StringName &p_method, void *p
 		} else {
 			//run dependencies first
 
-			if (!node->dependencies.empty()) {
+			if (!node->dependencies.is_empty()) {
 				int dc = node->dependencies.size();
 				VisualScriptNodeInstance **deps = node->dependencies.ptrw();
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -724,7 +724,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				line_edit->connect("text_changed", callable_mp(this, &VisualScriptEditor::_expression_text_changed), varray(E->get()));
 			} else {
 				String text = node->get_text();
-				if (!text.empty()) {
+				if (!text.is_empty()) {
 					has_gnode_text = true;
 					Label *label = memnew(Label);
 					label->set_text(text);
@@ -1723,7 +1723,7 @@ void VisualScriptEditor::_on_nodes_delete() {
 		}
 	}
 
-	if (to_erase.empty()) {
+	if (to_erase.is_empty()) {
 		return;
 	}
 
@@ -1776,7 +1776,7 @@ void VisualScriptEditor::_on_nodes_duplicate() {
 		}
 	}
 
-	if (to_duplicate.empty()) {
+	if (to_duplicate.is_empty()) {
 		return;
 	}
 
@@ -2566,7 +2566,7 @@ String VisualScriptEditor::get_name() {
 	if (script->get_path().find("local://") == -1 && script->get_path().find("::") == -1) {
 		name = script->get_path().get_file();
 		if (is_unsaved()) {
-			if (script->get_path().empty()) {
+			if (script->get_path().is_empty()) {
 				name = TTR("[unsaved]");
 			}
 			name += "(*)";
@@ -2588,7 +2588,7 @@ bool VisualScriptEditor::is_unsaved() {
 	bool unsaved =
 			script->is_edited() ||
 			script->are_subnodes_edited() ||
-			script->get_path().empty(); // In memory.
+			script->get_path().is_empty(); // In memory.
 	return unsaved;
 }
 
@@ -4183,7 +4183,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 				}
 			}
 
-			if (clipboard->nodes.empty()) {
+			if (clipboard->nodes.is_empty()) {
 				break;
 			}
 
@@ -4218,7 +4218,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 				break;
 			}
 
-			if (clipboard->nodes.empty()) {
+			if (clipboard->nodes.is_empty()) {
 				EditorNode::get_singleton()->show_warning(TTR("Clipboard is empty!"));
 				break;
 			}

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -358,7 +358,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 			continue;
 		}
 
-		bool in_modifier = p_modifiers.empty();
+		bool in_modifier = p_modifiers.is_empty();
 		for (Set<String>::Element *F = p_modifiers.front(); F && in_modifier; F = F->next()) {
 			if (E->get().findn(F->get()) != -1) {
 				in_modifier = true;

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -39,7 +39,7 @@
 #include <webp/encode.h>
 
 static Vector<uint8_t> _webp_lossy_pack(const Ref<Image> &p_image, float p_quality) {
-	ERR_FAIL_COND_V(p_image.is_null() || p_image->empty(), Vector<uint8_t>());
+	ERR_FAIL_COND_V(p_image.is_null() || p_image->is_empty(), Vector<uint8_t>());
 
 	Ref<Image> img = p_image->duplicate();
 	if (img->detect_alpha()) {

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -647,7 +647,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		if (DirAccess::exists(plugins_dir)) {
 			Vector<String> plugins_filenames = list_gdap_files(plugins_dir);
 
-			if (!plugins_filenames.empty()) {
+			if (!plugins_filenames.is_empty()) {
 				Ref<ConfigFile> config_file = memnew(ConfigFile);
 				for (int i = 0; i < plugins_filenames.size(); i++) {
 					PluginConfig config = load_plugin_config(config_file, plugins_dir.plus_file(plugins_filenames[i]));
@@ -750,7 +750,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		PackedStringArray user_perms = p_preset->get("permissions/custom_permissions");
 		for (int i = 0; i < user_perms.size(); i++) {
 			String user_perm = user_perms[i].strip_edges();
-			if (!user_perm.empty()) {
+			if (!user_perm.is_empty()) {
 				r_permissions.push_back(user_perm);
 			}
 		}
@@ -975,7 +975,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 							encode_uint32(xr_mode_index == /* XRMode.OVR */ 1 && focus_awareness ? 0xFFFFFFFF : 0, &p_manifest.write[iofs + 16]);
 						}
 
-						if (tname == "meta-data" && attrname == "value" && value == "plugins_value" && !plugins_names.empty()) {
+						if (tname == "meta-data" && attrname == "value" && value == "plugins_value" && !plugins_names.is_empty()) {
 							// Update the meta-data 'android:value' attribute with the list of enabled plugins.
 							string_table.write[attr_value] = plugins_names;
 						}
@@ -1471,7 +1471,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		// TODO: Figure out how to handle remaining boot splash parameters (e.g: fullsize, filter)
 		String project_splash_path = ProjectSettings::get_singleton()->get("application/boot_splash/image");
 
-		if (!project_splash_path.empty()) {
+		if (!project_splash_path.is_empty()) {
 			splash_image.instance();
 			const Error err = ImageLoader::load_image(project_splash_path, splash_image);
 			if (err) {
@@ -1505,19 +1505,19 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 		// Regular icon: user selection -> project icon -> default.
 		String path = static_cast<String>(p_preset->get(launcher_icon_option)).strip_edges();
-		if (path.empty() || ImageLoader::load_image(path, icon) != OK) {
+		if (path.is_empty() || ImageLoader::load_image(path, icon) != OK) {
 			ImageLoader::load_image(project_icon_path, icon);
 		}
 
 		// Adaptive foreground: user selection -> regular icon (user selection -> project icon -> default).
 		path = static_cast<String>(p_preset->get(launcher_adaptive_icon_foreground_option)).strip_edges();
-		if (path.empty() || ImageLoader::load_image(path, foreground) != OK) {
+		if (path.is_empty() || ImageLoader::load_image(path, foreground) != OK) {
 			foreground = icon;
 		}
 
 		// Adaptive background: user selection -> default.
 		path = static_cast<String>(p_preset->get(launcher_adaptive_icon_background_option)).strip_edges();
-		if (!path.empty()) {
+		if (!path.is_empty()) {
 			ImageLoader::load_image(path, background);
 		}
 	}
@@ -1538,14 +1538,14 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 			const Ref<Image> &foreground,
 			const Ref<Image> &background) {
 		// Store the splash image
-		if (splash_image.is_valid() && !splash_image->empty()) {
+		if (splash_image.is_valid() && !splash_image->is_empty()) {
 			Vector<uint8_t> data;
 			_load_image_data(splash_image, data);
 			store_image(SPLASH_IMAGE_EXPORT_PATH, data);
 		}
 
 		// Store the splash bg color image
-		if (splash_bg_color_image.is_valid() && !splash_bg_color_image->empty()) {
+		if (splash_bg_color_image.is_valid() && !splash_bg_color_image->is_empty()) {
 			Vector<uint8_t> data;
 			_load_image_data(splash_bg_color_image, data);
 			store_image(SPLASH_BG_COLOR_PATH, data);
@@ -1555,20 +1555,20 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		// the default image from the export template will be used.
 
 		for (int i = 0; i < icon_densities_count; ++i) {
-			if (main_image.is_valid() && !main_image->empty()) {
+			if (main_image.is_valid() && !main_image->is_empty()) {
 				Vector<uint8_t> data;
 				_process_launcher_icons(launcher_icons[i].export_path, main_image, launcher_icons[i].dimensions, data);
 				store_image(launcher_icons[i], data);
 			}
 
-			if (foreground.is_valid() && !foreground->empty()) {
+			if (foreground.is_valid() && !foreground->is_empty()) {
 				Vector<uint8_t> data;
 				_process_launcher_icons(launcher_adaptive_icon_foregrounds[i].export_path, foreground,
 						launcher_adaptive_icon_foregrounds[i].dimensions, data);
 				store_image(launcher_adaptive_icon_foregrounds[i], data);
 			}
 
-			if (background.is_valid() && !background->empty()) {
+			if (background.is_valid() && !background->is_empty()) {
 				Vector<uint8_t> data;
 				_process_launcher_icons(launcher_adaptive_icon_backgrounds[i].export_path, background,
 						launcher_adaptive_icon_backgrounds[i].dimensions, data);
@@ -1962,7 +1962,7 @@ public:
 
 		String rk = p_preset->get("keystore/release");
 
-		if (!rk.empty() && !FileAccess::exists(rk)) {
+		if (!rk.is_empty() && !FileAccess::exists(rk)) {
 			valid = false;
 			err += TTR("Release keystore incorrectly configured in the export preset.") + "\n";
 		}
@@ -2019,7 +2019,7 @@ public:
 		// Ensure that `Use Custom Build` is enabled if a plugin is selected.
 		String enabled_plugins_names = get_plugins_names(get_enabled_plugins(p_preset));
 		bool custom_build_enabled = p_preset->get("custom_template/use_custom_build");
-		if (!enabled_plugins_names.empty() && !custom_build_enabled) {
+		if (!enabled_plugins_names.is_empty() && !custom_build_enabled) {
 			valid = false;
 			err += TTR("\"Use Custom Build\" must be enabled to use the plugins.");
 			err += "\n";
@@ -2189,7 +2189,7 @@ public:
 			password = p_preset->get("keystore/debug_password");
 			user = p_preset->get("keystore/debug_user");
 
-			if (keystore.empty()) {
+			if (keystore.is_empty()) {
 				keystore = EditorSettings::get_singleton()->get("export/android/debug_keystore");
 				password = EditorSettings::get_singleton()->get("export/android/debug_keystore_pass");
 				user = EditorSettings::get_singleton()->get("export/android/debug_keystore_user");
@@ -2549,27 +2549,27 @@ public:
 			}
 
 			// Process the splash image
-			if (file == SPLASH_IMAGE_EXPORT_PATH && splash_image.is_valid() && !splash_image->empty()) {
+			if (file == SPLASH_IMAGE_EXPORT_PATH && splash_image.is_valid() && !splash_image->is_empty()) {
 				_load_image_data(splash_image, data);
 			}
 
 			// Process the splash bg color image
-			if (file == SPLASH_BG_COLOR_PATH && splash_bg_color_image.is_valid() && !splash_bg_color_image->empty()) {
+			if (file == SPLASH_BG_COLOR_PATH && splash_bg_color_image.is_valid() && !splash_bg_color_image->is_empty()) {
 				_load_image_data(splash_bg_color_image, data);
 			}
 
 			for (int i = 0; i < icon_densities_count; ++i) {
-				if (main_image.is_valid() && !main_image->empty()) {
+				if (main_image.is_valid() && !main_image->is_empty()) {
 					if (file == launcher_icons[i].export_path) {
 						_process_launcher_icons(file, main_image, launcher_icons[i].dimensions, data);
 					}
 				}
-				if (foreground.is_valid() && !foreground->empty()) {
+				if (foreground.is_valid() && !foreground->is_empty()) {
 					if (file == launcher_adaptive_icon_foregrounds[i].export_path) {
 						_process_launcher_icons(file, foreground, launcher_adaptive_icon_foregrounds[i].dimensions, data);
 					}
 				}
-				if (background.is_valid() && !background->empty()) {
+				if (background.is_valid() && !background->is_empty()) {
 					if (file == launcher_adaptive_icon_backgrounds[i].export_path) {
 						_process_launcher_icons(file, background, launcher_adaptive_icon_backgrounds[i].dimensions, data);
 					}
@@ -2620,7 +2620,7 @@ public:
 			ret = unzGoToNextFile(pkg);
 		}
 
-		if (!invalid_abis.empty()) {
+		if (!invalid_abis.is_empty()) {
 			String unsupported_arch = String(", ").join(invalid_abis);
 			EditorNode::add_io_error("Missing libraries in the export template for the selected architectures: " + unsupported_arch + ".\n" +
 									 "Please build a template with all required libraries, or uncheck the missing architectures in the export preset.");

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -261,7 +261,7 @@ String _get_instrumentation_tag(const Ref<EditorExportPreset> &p_preset) {
 }
 
 String _get_plugins_tag(const String &plugins_names) {
-	if (!plugins_names.empty()) {
+	if (!plugins_names.is_empty()) {
 		return vformat("    <meta-data tools:node=\"replace\" android:name=\"plugins\" android:value=\"%s\" />\n", plugins_names);
 	} else {
 		return "    <meta-data tools:node=\"remove\" android:name=\"plugins\" />\n";

--- a/platform/android/plugin/godot_plugin_config.h
+++ b/platform/android/plugin/godot_plugin_config.h
@@ -101,7 +101,7 @@ struct PluginConfig {
 
 static inline String resolve_local_dependency_path(String plugin_config_dir, String dependency_path) {
 	String absolute_path;
-	if (!dependency_path.empty()) {
+	if (!dependency_path.is_empty()) {
 		if (dependency_path.is_abs_path()) {
 			absolute_path = ProjectSettings::get_singleton()->globalize_path(dependency_path);
 		} else {
@@ -115,7 +115,7 @@ static inline String resolve_local_dependency_path(String plugin_config_dir, Str
 static inline PluginConfig resolve_prebuilt_plugin(PluginConfig prebuilt_plugin, String plugin_config_dir) {
 	PluginConfig resolved = prebuilt_plugin;
 	resolved.binary = resolved.binary_type == BINARY_TYPE_LOCAL ? resolve_local_dependency_path(plugin_config_dir, prebuilt_plugin.binary) : prebuilt_plugin.binary;
-	if (!prebuilt_plugin.local_dependencies.empty()) {
+	if (!prebuilt_plugin.local_dependencies.is_empty()) {
 		resolved.local_dependencies.clear();
 		for (int i = 0; i < prebuilt_plugin.local_dependencies.size(); i++) {
 			resolved.local_dependencies.push_back(resolve_local_dependency_path(plugin_config_dir, prebuilt_plugin.local_dependencies[i]));
@@ -131,19 +131,19 @@ static inline Vector<PluginConfig> get_prebuilt_plugins(String plugins_base_dir)
 }
 
 static inline bool is_plugin_config_valid(PluginConfig plugin_config) {
-	bool valid_name = !plugin_config.name.empty();
+	bool valid_name = !plugin_config.name.is_empty();
 	bool valid_binary_type = plugin_config.binary_type == BINARY_TYPE_LOCAL ||
 							 plugin_config.binary_type == BINARY_TYPE_REMOTE;
 
 	bool valid_binary = false;
 	if (valid_binary_type) {
-		valid_binary = !plugin_config.binary.empty() &&
+		valid_binary = !plugin_config.binary.is_empty() &&
 					   (plugin_config.binary_type == BINARY_TYPE_REMOTE ||
 							   FileAccess::exists(plugin_config.binary));
 	}
 
 	bool valid_local_dependencies = true;
-	if (!plugin_config.local_dependencies.empty()) {
+	if (!plugin_config.local_dependencies.is_empty()) {
 		for (int i = 0; i < plugin_config.local_dependencies.size(); i++) {
 			if (!FileAccess::exists(plugin_config.local_dependencies[i])) {
 				valid_local_dependencies = false;
@@ -182,7 +182,7 @@ static inline PluginConfig load_plugin_config(Ref<ConfigFile> config_file, const
 
 			if (config_file->has_section(DEPENDENCIES_SECTION)) {
 				Vector<String> local_dependencies_paths = config_file->get_value(DEPENDENCIES_SECTION, DEPENDENCIES_LOCAL_KEY, Vector<String>());
-				if (!local_dependencies_paths.empty()) {
+				if (!local_dependencies_paths.is_empty()) {
 					for (int i = 0; i < local_dependencies_paths.size(); i++) {
 						plugin_config.local_dependencies.push_back(resolve_local_dependency_path(config_base_dir, local_dependencies_paths[i]));
 					}
@@ -202,7 +202,7 @@ static inline PluginConfig load_plugin_config(Ref<ConfigFile> config_file, const
 
 static inline String get_plugins_binaries(String binary_type, Vector<PluginConfig> plugins_configs) {
 	String plugins_binaries;
-	if (!plugins_configs.empty()) {
+	if (!plugins_configs.is_empty()) {
 		Vector<String> binaries;
 		for (int i = 0; i < plugins_configs.size(); i++) {
 			PluginConfig config = plugins_configs[i];
@@ -231,7 +231,7 @@ static inline String get_plugins_binaries(String binary_type, Vector<PluginConfi
 
 static inline String get_plugins_custom_maven_repos(Vector<PluginConfig> plugins_configs) {
 	String custom_maven_repos;
-	if (!plugins_configs.empty()) {
+	if (!plugins_configs.is_empty()) {
 		Vector<String> repos_urls;
 		for (int i = 0; i < plugins_configs.size(); i++) {
 			PluginConfig config = plugins_configs[i];
@@ -249,7 +249,7 @@ static inline String get_plugins_custom_maven_repos(Vector<PluginConfig> plugins
 
 static inline String get_plugins_names(Vector<PluginConfig> plugins_configs) {
 	String plugins_names;
-	if (!plugins_configs.empty()) {
+	if (!plugins_configs.is_empty()) {
 		Vector<String> names;
 		for (int i = 0; i < plugins_configs.size(); i++) {
 			PluginConfig config = plugins_configs[i];

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -218,7 +218,7 @@ public:
 			da->list_dir_begin();
 			while (true) {
 				String file = da->get_next();
-				if (file.empty()) {
+				if (file.is_empty()) {
 					break;
 				}
 
@@ -259,7 +259,7 @@ public:
 		if (DirAccess::exists(plugins_dir)) {
 			Vector<String> plugins_filenames = list_plugin_config_files(plugins_dir, true);
 
-			if (!plugins_filenames.empty()) {
+			if (!plugins_filenames.is_empty()) {
 				Ref<ConfigFile> config_file = memnew(ConfigFile);
 				for (int i = 0; i < plugins_filenames.size(); i++) {
 					PluginConfig config = load_plugin_config(config_file, plugins_dir.plus_file(plugins_filenames[i]));
@@ -815,7 +815,7 @@ Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExpor
 
 		const String splash_path = ProjectSettings::get_singleton()->get("application/boot_splash/image");
 
-		if (!splash_path.empty()) {
+		if (!splash_path.is_empty()) {
 			splash.instance();
 			const Error err = splash->load(splash_path);
 			if (err) {
@@ -1430,7 +1430,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 			String key = *K;
 			String value = plugin.plist[key];
 
-			if (key.empty() || value.empty()) {
+			if (key.is_empty() || value.is_empty()) {
 				continue;
 			}
 
@@ -1457,7 +1457,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 			String key = *K;
 			String value = plist_values[key];
 
-			if (key.empty() || value.empty()) {
+			if (key.is_empty() || value.is_empty()) {
 				continue;
 			}
 
@@ -1930,7 +1930,7 @@ bool EditorExportPlatformIOS::can_export(const Ref<EditorExportPreset> &p_preset
 		err += etc_error;
 	}
 
-	if (!err.empty()) {
+	if (!err.is_empty()) {
 		r_error = err;
 	}
 

--- a/platform/iphone/plugin/godot_plugin_config.h
+++ b/platform/iphone/plugin/godot_plugin_config.h
@@ -97,7 +97,7 @@ struct PluginConfig {
 static inline String resolve_local_dependency_path(String plugin_config_dir, String dependency_path) {
 	String absolute_path;
 
-	if (dependency_path.empty()) {
+	if (dependency_path.is_empty()) {
 		return absolute_path;
 	}
 
@@ -114,7 +114,7 @@ static inline String resolve_local_dependency_path(String plugin_config_dir, Str
 static inline String resolve_system_dependency_path(String dependency_path) {
 	String absolute_path;
 
-	if (dependency_path.empty()) {
+	if (dependency_path.is_empty()) {
 		return absolute_path;
 	}
 
@@ -133,7 +133,7 @@ static inline Vector<String> resolve_local_dependencies(String plugin_config_dir
 	for (int i = 0; i < p_paths.size(); i++) {
 		String path = resolve_local_dependency_path(plugin_config_dir, p_paths[i]);
 
-		if (path.empty()) {
+		if (path.is_empty()) {
 			continue;
 		}
 
@@ -149,7 +149,7 @@ static inline Vector<String> resolve_system_dependencies(Vector<String> p_paths)
 	for (int i = 0; i < p_paths.size(); i++) {
 		String path = resolve_system_dependency_path(p_paths[i]);
 
-		if (path.empty()) {
+		if (path.is_empty()) {
 			continue;
 		}
 
@@ -160,10 +160,10 @@ static inline Vector<String> resolve_system_dependencies(Vector<String> p_paths)
 }
 
 static inline bool validate_plugin(PluginConfig &plugin_config) {
-	bool valid_name = !plugin_config.name.empty();
-	bool valid_binary_name = !plugin_config.binary.empty();
-	bool valid_initialize = !plugin_config.initialization_method.empty();
-	bool valid_deinitialize = !plugin_config.deinitialization_method.empty();
+	bool valid_name = !plugin_config.name.is_empty();
+	bool valid_binary_name = !plugin_config.binary.is_empty();
+	bool valid_initialize = !plugin_config.initialization_method.is_empty();
+	bool valid_deinitialize = !plugin_config.deinitialization_method.is_empty();
 
 	bool fields_value = valid_name && valid_binary_name && valid_initialize && valid_deinitialize;
 
@@ -247,7 +247,7 @@ static inline PluginConfig load_plugin_config(Ref<ConfigFile> config_file, const
 		for (int i = 0; i < keys.size(); i++) {
 			String value = config_file->get_value(PLIST_SECTION, keys[i], String());
 
-			if (value.empty()) {
+			if (value.is_empty()) {
 				continue;
 			}
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -119,7 +119,7 @@ public:
 			filepath = cache_path.plus_file(req[1].get_file()); // TODO dangerous?
 			ctype = "application/wasm";
 		}
-		if (filepath.empty() || !FileAccess::exists(filepath)) {
+		if (filepath.is_empty() || !FileAccess::exists(filepath)) {
 			String s = "HTTP/1.1 404 Not Found\r\n";
 			s += "Connection: Close\r\n";
 			s += "\r\n";
@@ -394,7 +394,7 @@ bool EditorExportPlatformJavaScript::can_export(const Ref<EditorExportPreset> &p
 		}
 	}
 
-	if (!err.empty()) {
+	if (!err.is_empty()) {
 		r_error = err;
 	}
 
@@ -485,7 +485,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 		//write
 
 		if (file == "godot.html") {
-			if (!custom_html.empty()) {
+			if (!custom_html.is_empty()) {
 				continue;
 			}
 			_fix_html(data, p_preset, p_path.get_file().get_basename(), p_debug, p_flags, shared_objects);
@@ -520,7 +520,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 	} while (unzGoToNextFile(pkg) == UNZ_OK);
 	unzClose(pkg);
 
-	if (!custom_html.empty()) {
+	if (!custom_html.is_empty()) {
 		FileAccess *f = FileAccess::open(custom_html, FileAccess::READ);
 		if (!f) {
 			EditorNode::get_singleton()->show_warning(TTR("Could not read custom HTML shell:") + "\n" + custom_html);
@@ -543,7 +543,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 
 	Ref<Image> splash;
 	const String splash_path = String(GLOBAL_GET("application/boot_splash/image")).strip_edges();
-	if (!splash_path.empty()) {
+	if (!splash_path.is_empty()) {
 		splash.instance();
 		const Error err = splash->load(splash_path);
 		if (err) {
@@ -564,7 +564,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 	// This way, the favicon can be displayed immediately when loading the page.
 	Ref<Image> favicon;
 	const String favicon_path = String(GLOBAL_GET("application/config/icon")).strip_edges();
-	if (!favicon_path.empty()) {
+	if (!favicon_path.is_empty()) {
 		favicon.instance();
 		const Error err = favicon->load(favicon_path);
 		if (err) {

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -622,7 +622,7 @@ String DisplayServerX11::_clipboard_get(Atom p_source, Window x11_window) const 
 	if (utf8_atom != None) {
 		ret = _clipboard_get_impl(p_source, x11_window, utf8_atom);
 	}
-	if (ret.empty()) {
+	if (ret.is_empty()) {
 		ret = _clipboard_get_impl(p_source, x11_window, XA_STRING);
 	}
 	return ret;
@@ -634,7 +634,7 @@ String DisplayServerX11::clipboard_get() const {
 	String ret;
 	ret = _clipboard_get(XInternAtom(x11_display, "CLIPBOARD", 0), windows[MAIN_WINDOW_ID].x11_window);
 
-	if (ret.empty()) {
+	if (ret.is_empty()) {
 		ret = _clipboard_get(XA_PRIMARY, windows[MAIN_WINDOW_ID].x11_window);
 	}
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -65,9 +65,9 @@ void OS_LinuxBSD::initialize_joypads() {
 
 String OS_LinuxBSD::get_unique_id() const {
 	static String machine_id;
-	if (machine_id.empty()) {
+	if (machine_id.is_empty()) {
 		if (FileAccess *f = FileAccess::open("/etc/machine-id", FileAccess::READ)) {
-			while (machine_id.empty() && !f->eof_reached()) {
+			while (machine_id.is_empty() && !f->eof_reached()) {
 				machine_id = f->get_line().strip_edges();
 			}
 			f->close();

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -457,7 +457,7 @@ Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_prese
 	PackedStringArray user_args = p_preset->get("codesign/custom_options");
 	for (int i = 0; i < user_args.size(); i++) {
 		String user_arg = user_args[i].strip_edges();
-		if (!user_arg.empty()) {
+		if (!user_arg.is_empty()) {
 			args.push_back(user_arg);
 		}
 	}
@@ -665,7 +665,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 					Ref<Image> icon;
 					icon.instance();
 					icon->load(iconpath);
-					if (!icon->empty()) {
+					if (!icon->is_empty()) {
 						_make_icon(icon, data);
 					}
 				}
@@ -927,7 +927,7 @@ bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset
 		}
 	}
 
-	if (!err.empty()) {
+	if (!err.is_empty()) {
 		r_error = err;
 	}
 	return valid;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -99,7 +99,7 @@ public:
 String OS_OSX::get_unique_id() const {
 	static String serial_number;
 
-	if (serial_number.empty()) {
+	if (serial_number.is_empty()) {
 		io_service_t platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
 		CFStringRef serialNumberAsCFString = NULL;
 		if (platformExpert) {

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -641,7 +641,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 	};
 
 	bool _valid_resource_name(const String &p_name) const {
-		if (p_name.empty()) {
+		if (p_name.is_empty()) {
 			return false;
 		}
 		if (p_name.ends_with(".")) {
@@ -687,7 +687,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 	}
 
 	bool _valid_bgcolor(const String &p_color) const {
-		if (p_color.empty()) {
+		if (p_color.is_empty()) {
 			return true;
 		}
 		if (p_color.begins_with("#") && p_color.is_valid_html_color()) {
@@ -763,7 +763,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		String architecture = arch == ARM ? "arm" : arch == X86 ? "x86" : "x64";
 		result = result.replace("$architecture$", architecture);
 
-		result = result.replace("$display_name$", String(p_preset->get("package/display_name")).empty() ? (String)ProjectSettings::get_singleton()->get("application/config/name") : String(p_preset->get("package/display_name")));
+		result = result.replace("$display_name$", String(p_preset->get("package/display_name")).is_empty() ? (String)ProjectSettings::get_singleton()->get("application/config/name") : String(p_preset->get("package/display_name")));
 
 		result = result.replace("$publisher_display_name$", p_preset->get("package/publisher_display_name"));
 		result = result.replace("$app_description$", p_preset->get("package/description"));
@@ -782,7 +782,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		}
 
 		String show_name_on_tiles = "";
-		if (!name_on_tiles.empty()) {
+		if (!name_on_tiles.is_empty()) {
 			show_name_on_tiles = "<uap:ShowNameOnTiles>\n" + name_on_tiles + "        </uap:ShowNameOnTiles>";
 		}
 
@@ -803,7 +803,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		}
 
 		String rotation_preference = "";
-		if (!rotations.empty()) {
+		if (!rotations.is_empty()) {
 			rotation_preference = "<uap:InitialRotationPreference>\n" + rotations + "        </uap:InitialRotationPreference>";
 		}
 
@@ -837,7 +837,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		}
 
 		String capabilities_string = "<Capabilities />";
-		if (!capabilities_elements.empty()) {
+		if (!capabilities_elements.is_empty()) {
 			capabilities_string = "<Capabilities>\n" + capabilities_elements + "  </Capabilities>";
 		}
 

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -299,7 +299,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 	PackedStringArray user_args = p_preset->get("codesign/custom_options");
 	for (int i = 0; i < user_args.size(); i++) {
 		String user_arg = user_args[i].strip_edges();
-		if (!user_arg.empty()) {
+		if (!user_arg.is_empty()) {
 			args.push_back(user_arg);
 		}
 	}

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -654,7 +654,7 @@ String AnimatedSprite2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (frames.is_null()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite to display frames.");

--- a/scene/2d/canvas_modulate.cpp
+++ b/scene/2d/canvas_modulate.cpp
@@ -84,7 +84,7 @@ String CanvasModulate::get_configuration_warning() const {
 	get_tree()->get_nodes_in_group("_canvas_modulate_" + itos(get_canvas().get_id()), &nodes);
 
 	if (nodes.size() > 1) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Only one visible CanvasModulate is allowed per scene (or set of instanced scenes). The first created one will work, while the rest will be ignored.");

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -366,8 +366,8 @@ void CollisionObject2D::_update_pickable() {
 String CollisionObject2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
-	if (shapes.empty()) {
-		if (!warning.empty()) {
+	if (shapes.is_empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape2D or CollisionPolygon2D as a child to define its shape.");

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -233,14 +233,14 @@ String CollisionPolygon2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (!Object::cast_to<CollisionObject2D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("CollisionPolygon2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidBody2D, KinematicBody2D, etc. to give them a shape.");
 	}
 
-	if (polygon.empty()) {
-		if (!warning.empty()) {
+	if (polygon.is_empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("An empty CollisionPolygon2D has no effect on collision.");

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -176,8 +176,8 @@ bool Joint2D::get_exclude_nodes_from_collision() const {
 String Joint2D::get_configuration_warning() const {
 	String node_warning = Node2D::get_configuration_warning();
 
-	if (!warning.empty()) {
-		if (!node_warning.empty()) {
+	if (!warning.is_empty()) {
+		if (!node_warning.is_empty()) {
 			node_warning += "\n\n";
 		}
 		node_warning += warning;

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -404,7 +404,7 @@ String PointLight2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (!texture.is_valid()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("A texture with the shape of the light must be supplied to the \"Texture\" property.");

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -249,14 +249,14 @@ String LightOccluder2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (!occluder_polygon.is_valid()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("An occluder polygon must be set (or drawn) for this occluder to take effect.");
 	}
 
 	if (occluder_polygon.is_valid() && occluder_polygon->get_polygon().size() == 0) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("The occluder polygon for this occluder is empty. Please draw a polygon.");

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -274,7 +274,7 @@ String NavigationAgent2D::get_configuration_warning() const {
 	String warning = Node::get_configuration_warning();
 
 	if (!Object::cast_to<Node2D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("The NavigationAgent2D can be used only under a Node2D node");

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -109,7 +109,7 @@ String NavigationObstacle2D::get_configuration_warning() const {
 	String warning = Node::get_configuration_warning();
 
 	if (!Object::cast_to<Node2D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("The NavigationObstacle2D only serves to provide collision avoidance to a Node2D object.");

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -503,7 +503,7 @@ String NavigationRegion2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (!navpoly.is_valid()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("A NavigationPolygon resource must be set or created for this node to work. Please set a property or draw a polygon.");
@@ -516,7 +516,7 @@ String NavigationRegion2D::get_configuration_warning() const {
 
 		c = Object::cast_to<Node2D>(c->get_parent());
 	}
-	if (!warning.empty()) {
+	if (!warning.is_empty()) {
 		warning += "\n\n";
 	}
 	return warning + TTR("NavigationRegion2D must be a child or grandchild to a Navigation2D node. It only provides navigation data.");

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -139,7 +139,7 @@ String ParallaxLayer::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (!Object::cast_to<ParallaxBackground>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("ParallaxLayer node only works when set as child of a ParallaxBackground node.");

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -257,7 +257,7 @@ String PathFollow2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (!Object::cast_to<Path2D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("PathFollow2D only works when set as a child of a Path2D node.");

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -301,7 +301,7 @@ void RigidBody2D::_body_inout(int p_status, ObjectID p_instance, int p_body_shap
 
 		bool in_scene = E->get().in_scene;
 
-		if (E->get().shapes.empty()) {
+		if (E->get().shapes.is_empty()) {
 			if (node) {
 				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &RigidBody2D::_body_enter_tree));
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &RigidBody2D::_body_exit_tree));
@@ -724,7 +724,7 @@ String RigidBody2D::get_configuration_warning() const {
 	String warning = CollisionObject2D::get_configuration_warning();
 
 	if ((get_mode() == MODE_RIGID || get_mode() == MODE_CHARACTER) && (ABS(t.elements[0].length() - 1.0) > 0.05 || ABS(t.elements[1].length() - 1.0) > 0.05)) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Size changes to RigidBody2D (in character or rigid modes) will be overridden by the physics engine when running.\nChange the size in children collision shapes instead.");

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -189,7 +189,7 @@ String RemoteTransform2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (!has_node(remote_node) || !Object::cast_to<Node2D>(get_node(remote_node))) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Path property must point to a valid Node2D node to work.");

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -136,7 +136,7 @@ int Bone2D::get_index_in_skeleton() const {
 String Bone2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 	if (!skeleton) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		if (parent_bone) {
@@ -147,7 +147,7 @@ String Bone2D::get_configuration_warning() const {
 	}
 
 	if (rest == Transform2D(0, 0, 0, 0, 0, 0)) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("This bone lacks a proper REST pose. Go to the Skeleton2D node and set one.");

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1714,7 +1714,7 @@ String TileMap::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
 	if (use_parent && !collision_parent) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		return TTR("TileMap with Use Parent on needs a parent CollisionObject2D to give shapes to. Please use it as a child of Area2D, StaticBody2D, RigidBody2D, KinematicBody2D, etc. to give them a shape.");

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -317,7 +317,7 @@ String VisibilityEnabler2D::get_configuration_warning() const {
 
 #ifdef TOOLS_ENABLED
 	if (is_inside_tree() && get_parent() && (get_parent()->get_filename() == String() && get_parent() != get_tree()->get_edited_scene_root())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("VisibilityEnabler2D works best when used with the edited scene root directly as parent.");

--- a/scene/3d/baked_lightmap.cpp
+++ b/scene/3d/baked_lightmap.cpp
@@ -678,7 +678,7 @@ BakedLightmap::BakeError BakedLightmap::bake(Node *p_from_node, String p_image_d
 			}
 			TypedArray<Image> images = RS::get_singleton()->bake_render_uv2(mf.mesh->get_rid(), overrides, lightmap_size);
 
-			ERR_FAIL_COND_V(images.empty(), BAKE_ERROR_CANT_CREATE_IMAGE);
+			ERR_FAIL_COND_V(images.is_empty(), BAKE_ERROR_CANT_CREATE_IMAGE);
 
 			Ref<Image> albedo = images[RS::BAKE_CHANNEL_ALBEDO_ALPHA];
 			Ref<Image> orm = images[RS::BAKE_CHANNEL_ORM];

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -349,8 +349,8 @@ bool CollisionObject3D::get_capture_input_on_drag() const {
 String CollisionObject3D::get_configuration_warning() const {
 	String warning = Node3D::get_configuration_warning();
 
-	if (shapes.empty()) {
-		if (!warning.empty()) {
+	if (shapes.is_empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape3D or CollisionPolygon3D as a child to define its shape.");

--- a/scene/3d/collision_polygon_3d.cpp
+++ b/scene/3d/collision_polygon_3d.cpp
@@ -159,14 +159,14 @@ String CollisionPolygon3D::get_configuration_warning() const {
 	String warning = Node3D::get_configuration_warning();
 
 	if (!Object::cast_to<CollisionObject3D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("CollisionPolygon3D only serves to provide a collision shape to a CollisionObject3D derived node. Please only use it as a child of Area3D, StaticBody3D, RigidBody3D, KinematicBody3D, etc. to give them a shape.");
 	}
 
-	if (polygon.empty()) {
-		if (!warning.empty()) {
+	if (polygon.is_empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("An empty CollisionPolygon3D has no effect on collision.");

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -60,7 +60,7 @@ void CollisionShape3D::make_convex_from_siblings() {
 			if (m.is_valid()) {
 				for (int j = 0; j < m->get_surface_count(); j++) {
 					Array a = m->surface_get_arrays(j);
-					if (!a.empty()) {
+					if (!a.is_empty()) {
 						Vector<Vector3> v = a[RenderingServer::ARRAY_VERTEX];
 						for (int k = 0; k < v.size(); k++) {
 							vertices.append(mi->get_transform().xform(v[k]));
@@ -127,14 +127,14 @@ String CollisionShape3D::get_configuration_warning() const {
 	String warning = Node3D::get_configuration_warning();
 
 	if (!Object::cast_to<CollisionObject3D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("CollisionShape3D only serves to provide a collision shape to a CollisionObject3D derived node. Please only use it as a child of Area3D, StaticBody3D, RigidBody3D, KinematicBody3D, etc. to give them a shape.");
 	}
 
 	if (!shape.is_valid()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("A shape must be provided for CollisionShape3D to function. Please create a shape resource for it.");
@@ -144,7 +144,7 @@ String CollisionShape3D::get_configuration_warning() const {
 			Object::cast_to<RigidBody3D>(get_parent()) &&
 			Object::cast_to<ConcavePolygonShape3D>(*shape) &&
 			Object::cast_to<RigidBody3D>(get_parent())->get_mode() != RigidBody3D::MODE_STATIC) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("ConcavePolygonShape3D doesn't support RigidBody3D in another mode than static.");

--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -516,7 +516,7 @@ String GIProbe::get_configuration_warning() const {
 	String warning = VisualInstance3D::get_configuration_warning();
 
 	if (RenderingServer::get_singleton()->is_low_end()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("GIProbes are not supported by the GLES2 video driver.\nUse a BakedLightmap instead.");

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -462,7 +462,7 @@ String OmniLight3D::get_configuration_warning() const {
 	String warning = Light3D::get_configuration_warning();
 
 	if (!has_shadow() && get_projector().is_valid()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Projector texture only works with shadows active.");
@@ -496,14 +496,14 @@ String SpotLight3D::get_configuration_warning() const {
 	String warning = Light3D::get_configuration_warning();
 
 	if (has_shadow() && get_param(PARAM_SPOT_ANGLE) >= 90.0) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("A SpotLight3D with an angle wider than 90 degrees cannot cast shadows.");
 	}
 
 	if (!has_shadow() && get_projector().is_valid()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Projector texture only works with shadows active.");

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -290,7 +290,7 @@ String NavigationAgent3D::get_configuration_warning() const {
 	String warning = Node::get_configuration_warning();
 
 	if (!Object::cast_to<Node3D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("The NavigationAgent3D can be used only under a spatial node.");

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -116,7 +116,7 @@ String NavigationObstacle3D::get_configuration_warning() const {
 	String warning = Node::get_configuration_warning();
 
 	if (!Object::cast_to<Node3D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("The NavigationObstacle3D only serves to provide collision avoidance to a spatial object.");

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -193,7 +193,7 @@ String NavigationRegion3D::get_configuration_warning() const {
 	String warning = Node3D::get_configuration_warning();
 
 	if (!navmesh.is_valid()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("A NavigationMesh resource must be set or created for this node to work.");
@@ -208,7 +208,7 @@ String NavigationRegion3D::get_configuration_warning() const {
 		c = Object::cast_to<Node3D>(c->get_parent());
 	}
 
-	if (!warning.empty()) {
+	if (!warning.is_empty()) {
 		warning += "\n\n";
 	}
 	return warning + TTR("NavigationRegion3D must be a child or grandchild to a Navigation3D node. It only provides navigation data.");

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -249,14 +249,14 @@ String PathFollow3D::get_configuration_warning() const {
 	String warning = Node3D::get_configuration_warning();
 
 	if (!Object::cast_to<Path3D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("PathFollow3D only works when set as a child of a Path3D node.");
 	} else {
 		Path3D *path = Object::cast_to<Path3D>(get_parent());
 		if (path->get_curve().is_valid() && !path->get_curve()->is_up_vector_enabled() && rotation_mode == ROTATION_ORIENTED) {
-			if (!warning.empty()) {
+			if (!warning.is_empty()) {
 				warning += "\n\n";
 			}
 			warning += TTR("PathFollow3D's ROTATION_ORIENTED requires \"Up Vector\" to be enabled in its parent Path3D's Curve resource.");

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -311,7 +311,7 @@ void RigidBody3D::_body_inout(int p_status, ObjectID p_instance, int p_body_shap
 
 		bool in_tree = E->get().in_tree;
 
-		if (E->get().shapes.empty()) {
+		if (E->get().shapes.is_empty()) {
 			if (node) {
 				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &RigidBody3D::_body_enter_tree));
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &RigidBody3D::_body_exit_tree));
@@ -714,7 +714,7 @@ String RigidBody3D::get_configuration_warning() const {
 	String warning = CollisionObject3D::get_configuration_warning();
 
 	if ((get_mode() == MODE_RIGID || get_mode() == MODE_CHARACTER) && (ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(2).length() - 1.0) > 0.05)) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Size changes to RigidBody3D (in character or rigid modes) will be overridden by the physics engine when running.\nChange the size in children collision shapes instead.");

--- a/scene/3d/physics_joint_3d.cpp
+++ b/scene/3d/physics_joint_3d.cpp
@@ -168,8 +168,8 @@ bool Joint3D::get_exclude_nodes_from_collision() const {
 String Joint3D::get_configuration_warning() const {
 	String node_warning = Node3D::get_configuration_warning();
 
-	if (!warning.empty()) {
-		if (!node_warning.empty()) {
+	if (!warning.is_empty()) {
+		if (!node_warning.is_empty()) {
 			node_warning += "\n\n";
 		}
 		node_warning += warning;

--- a/scene/3d/remote_transform_3d.cpp
+++ b/scene/3d/remote_transform_3d.cpp
@@ -183,7 +183,7 @@ String RemoteTransform3D::get_configuration_warning() const {
 	String warning = Node3D::get_configuration_warning();
 
 	if (!has_node(remote_node) || !Object::cast_to<Node3D>(get_node(remote_node))) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("The \"Remote Path\" property must point to a valid Node3D or Node3D-derived node to work.");

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -204,7 +204,7 @@ void FabrikInverseKinematic::solve_simple_forwards(Chain &r_chain, bool p_solve_
 	while (sub_chain_root) { // Reach the tip
 		sub_chain_root->current_pos = origin;
 
-		if (!sub_chain_root->children.empty()) {
+		if (!sub_chain_root->children.is_empty()) {
 			ChainItem &child(sub_chain_root->children.write[0]);
 
 			// Is not tip
@@ -301,7 +301,7 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 		Transform new_bone_pose(ci->initial_transform);
 		new_bone_pose.origin = ci->current_pos;
 
-		if (!ci->children.empty()) {
+		if (!ci->children.is_empty()) {
 			/// Rotate basis
 			const Vector3 initial_ori((ci->children[0].initial_transform.origin - ci->initial_transform.origin).normalized());
 			const Vector3 rot_axis(initial_ori.cross(ci->current_ori).normalized());
@@ -321,7 +321,7 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 
 		p_task->skeleton->set_bone_global_pose_override(ci->bone, new_bone_pose, 1.0, true);
 
-		if (!ci->children.empty()) {
+		if (!ci->children.is_empty()) {
 			ci = &ci->children.write[0];
 		} else {
 			ci = nullptr;

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -380,7 +380,7 @@ String SoftBody3D::get_configuration_warning() const {
 	String warning = MeshInstance3D::get_configuration_warning();
 
 	if (get_mesh().is_null()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 
@@ -389,7 +389,7 @@ String SoftBody3D::get_configuration_warning() const {
 
 	Transform t = get_transform();
 	if ((ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(2).length() - 1.0) > 0.05)) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1074,7 +1074,7 @@ String AnimatedSprite3D::get_configuration_warning() const {
 	String warning = SpriteBase3D::get_configuration_warning();
 
 	if (frames.is_null()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite3D to display frames.");

--- a/scene/3d/vehicle_body_3d.cpp
+++ b/scene/3d/vehicle_body_3d.cpp
@@ -106,7 +106,7 @@ String VehicleWheel3D::get_configuration_warning() const {
 	String warning = Node3D::get_configuration_warning();
 
 	if (!Object::cast_to<VehicleBody3D>(get_parent())) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("VehicleWheel3D serves to provide a wheel system to a VehicleBody3D. Please use it as a child of a VehicleBody3D.");

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -294,7 +294,7 @@ void Voxelizer::_plot_face(int p_idx, int p_level, int p_x, int p_y, int p_z, co
 Vector<Color> Voxelizer::_get_bake_texture(Ref<Image> p_image, const Color &p_color_mul, const Color &p_color_add) {
 	Vector<Color> ret;
 
-	if (p_image.is_null() || p_image->empty()) {
+	if (p_image.is_null() || p_image->is_empty()) {
 		ret.resize(bake_texture_size * bake_texture_size);
 		for (int i = 0; i < bake_texture_size * bake_texture_size; i++) {
 			ret.write[i] = p_color_add;

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -113,7 +113,7 @@ String WorldEnvironment::get_configuration_warning() const {
 	String warning = Node::get_configuration_warning();
 
 	if (!environment.is_valid()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("WorldEnvironment requires its \"Environment\" property to contain an Environment to have a visible effect.");
@@ -127,7 +127,7 @@ String WorldEnvironment::get_configuration_warning() const {
 	get_tree()->get_nodes_in_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()), &nodes);
 
 	if (nodes.size() > 1) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Only one WorldEnvironment is allowed per scene (or set of instanced scenes).");

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -65,7 +65,7 @@ String XRCamera3D::get_configuration_warning() const {
 	// must be child node of XROrigin3D!
 	XROrigin3D *origin = Object::cast_to<XROrigin3D>(get_parent());
 	if (origin == nullptr) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("XRCamera3D must have an XROrigin3D node as its parent.");
@@ -372,14 +372,14 @@ String XRController3D::get_configuration_warning() const {
 	// must be child node of XROrigin!
 	XROrigin3D *origin = Object::cast_to<XROrigin3D>(get_parent());
 	if (origin == nullptr) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("XRController3D must have an XROrigin3D node as its parent.");
 	};
 
 	if (controller_id == 0) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("The controller ID must not be 0 or this controller won't be bound to an actual controller.");
@@ -497,14 +497,14 @@ String XRAnchor3D::get_configuration_warning() const {
 	// must be child node of XROrigin3D!
 	XROrigin3D *origin = Object::cast_to<XROrigin3D>(get_parent());
 	if (origin == nullptr) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("XRAnchor3D must have an XROrigin3D node as its parent.");
 	};
 
 	if (anchor_id == 0) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("The anchor ID must not be 0 or this anchor won't be bound to an actual anchor.");
@@ -536,7 +536,7 @@ String XROrigin3D::get_configuration_warning() const {
 	String warning = Node3D::get_configuration_warning();
 
 	if (tracked_camera == nullptr) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("XROrigin3D requires an XRCamera3D child node.");

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -40,7 +40,7 @@ void AnimationNode::get_parameter_list(List<PropertyInfo> *r_list) const {
 		Array parameters = get_script_instance()->call("get_parameter_list");
 		for (int i = 0; i < parameters.size(); i++) {
 			Dictionary d = parameters[i];
-			ERR_CONTINUE(d.empty());
+			ERR_CONTINUE(d.is_empty());
 			r_list->push_back(PropertyInfo::from_dict(d));
 		}
 	}
@@ -1287,14 +1287,14 @@ String AnimationTree::get_configuration_warning() const {
 	String warning = Node::get_configuration_warning();
 
 	if (!root.is_valid()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("No root AnimationNode for the graph is set.");
 	}
 
 	if (!has_node(animation_player)) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Path to an AnimationPlayer node containing animations is not set.");
@@ -1302,12 +1302,12 @@ String AnimationTree::get_configuration_warning() const {
 		AnimationPlayer *player = Object::cast_to<AnimationPlayer>(get_node(animation_player));
 
 		if (!player) {
-			if (!warning.empty()) {
+			if (!warning.is_empty()) {
 				warning += "\n\n";
 			}
 			warning += TTR("Path set for AnimationPlayer does not lead to an AnimationPlayer node.");
 		} else if (!player->has_node(player->get_root())) {
-			if (!warning.empty()) {
+			if (!warning.is_empty()) {
 				warning += "\n\n";
 			}
 			warning += TTR("The AnimationPlayer root node is not a valid node.");

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -591,7 +591,7 @@ void ColorPicker::_screen_input(const Ref<InputEvent> &p_event) {
 		}
 
 		Ref<Image> img = r->get_texture()->get_data();
-		if (img.is_valid() && !img->empty()) {
+		if (img.is_valid() && !img->is_empty()) {
 			Vector2 ofs = mev->get_global_position() - r->get_visible_rect().get_position();
 			Color c = img->get_pixel(ofs.x, r->get_visible_rect().size.height - ofs.y);
 

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -163,7 +163,7 @@ String Container::get_configuration_warning() const {
 	String warning = Control::get_configuration_warning();
 
 	if (get_class() == "Container" && get_script().is_null()) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Container by itself serves no purpose unless a script configures its children placement behavior.\nIf you don't intend to add a script, use a plain Control node instead.");

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2698,7 +2698,7 @@ String Control::get_configuration_warning() const {
 	String warning = CanvasItem::get_configuration_warning();
 
 	if (data.mouse_filter == MOUSE_FILTER_IGNORE && data.tooltip != "") {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("The Hint Tooltip won't be displayed as the control's Mouse Filter is set to \"Ignore\". To solve this, set the Mouse Filter to \"Stop\" or \"Pass\".");

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -165,7 +165,7 @@ void AcceptDialog::register_text_enter(Node *p_line_edit) {
 
 void AcceptDialog::_update_child_rects() {
 	Size2 label_size = label->get_minimum_size();
-	if (label->get_text().empty()) {
+	if (label->get_text().is_empty()) {
 		label_size.height = 0;
 	}
 	int margin = hbc->get_theme_constant("margin", "Dialogs");

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -434,7 +434,7 @@ void FileDialog::update_file_list() {
 	dirs.sort_custom<NaturalNoCaseComparator>();
 	files.sort_custom<NaturalNoCaseComparator>();
 
-	while (!dirs.empty()) {
+	while (!dirs.is_empty()) {
 		String &dir_name = dirs.front()->get();
 		TreeItem *ti = tree->create_item(root);
 		ti->set_text(0, dir_name);
@@ -478,8 +478,8 @@ void FileDialog::update_file_list() {
 
 	String base_dir = dir_access->get_current_dir();
 
-	while (!files.empty()) {
-		bool match = patterns.empty();
+	while (!files.is_empty()) {
+		bool match = patterns.is_empty();
 		String match_str;
 
 		for (List<String>::Element *E = patterns.front(); E; E = E->next()) {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1314,7 +1314,7 @@ int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 }
 
 bool ItemList::is_pos_at_end_of_items(const Point2 &p_pos) const {
-	if (items.empty()) {
+	if (items.is_empty()) {
 		return true;
 	}
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -69,7 +69,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 		_reset_caret_blink_timer();
 		if (b->is_pressed()) {
 			accept_event(); //don't pass event further when clicked on text field
-			if (!text.empty() && is_editable() && _is_over_clear_button(b->get_position())) {
+			if (!text.is_empty() && is_editable() && _is_over_clear_button(b->get_position())) {
 				clear_button_status.press_attempt = true;
 				clear_button_status.pressing_inside = true;
 				update();
@@ -106,7 +106,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 			update();
 
 		} else {
-			if (!text.empty() && is_editable() && clear_button_enabled) {
+			if (!text.is_empty() && is_editable() && clear_button_enabled) {
 				bool press_attempt = clear_button_status.press_attempt;
 				clear_button_status.press_attempt = false;
 				if (press_attempt && clear_button_status.pressing_inside && _is_over_clear_button(b->get_position())) {
@@ -136,7 +136,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 	Ref<InputEventMouseMotion> m = p_event;
 
 	if (m.is_valid()) {
-		if (!text.empty() && is_editable() && clear_button_enabled) {
+		if (!text.is_empty() && is_editable() && clear_button_enabled) {
 			bool last_press_inside = clear_button_status.pressing_inside;
 			clear_button_status.pressing_inside = clear_button_status.press_attempt && _is_over_clear_button(m->get_position());
 			if (last_press_inside != clear_button_status.pressing_inside) {
@@ -653,7 +653,7 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 }
 
 Control::CursorShape LineEdit::get_cursor_shape(const Point2 &p_pos) const {
-	if (!text.empty() && is_editable() && _is_over_clear_button(p_pos)) {
+	if (!text.is_empty() && is_editable() && _is_over_clear_button(p_pos)) {
 		return CURSOR_ARROW;
 	}
 	return Control::get_cursor_shape(p_pos);
@@ -735,7 +735,7 @@ void LineEdit::_notification(int p_what) {
 			}
 
 			int x_ofs = 0;
-			bool using_placeholder = text.empty() && ime_text.empty();
+			bool using_placeholder = text.is_empty() && ime_text.is_empty();
 			float text_width = TS->shaped_text_get_size(text_rid).x;
 			float text_height = TS->shaped_text_get_size(text_rid).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM);
 
@@ -1109,7 +1109,7 @@ void LineEdit::set_cursor_at_pixel_pos(int p_x) {
 		} break;
 	}
 
-	bool using_placeholder = text.empty() && ime_text.empty();
+	bool using_placeholder = text.is_empty() && ime_text.is_empty();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
@@ -1157,7 +1157,7 @@ Vector2i LineEdit::get_cursor_pixel_pos() {
 		} break;
 	}
 
-	bool using_placeholder = text.empty() && ime_text.empty();
+	bool using_placeholder = text.is_empty() && ime_text.is_empty();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
@@ -1482,7 +1482,7 @@ void LineEdit::set_cursor_position(int p_pos) {
 	}
 
 	int ofs_max = get_size().width - style->get_margin(SIDE_RIGHT);
-	bool using_placeholder = text.empty() && ime_text.empty();
+	bool using_placeholder = text.is_empty() && ime_text.is_empty();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
@@ -1570,7 +1570,7 @@ Size2 LineEdit::get_minimum_size() const {
 	min_size.height = MAX(TS->shaped_text_get_size(text_rid).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM), font->get_height(font_size));
 
 	// Take icons into account.
-	bool using_placeholder = text.empty() && ime_text.empty();
+	bool using_placeholder = text.is_empty() && ime_text.is_empty();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
@@ -1995,7 +1995,7 @@ void LineEdit::_fit_to_width() {
 	if (align == ALIGN_FILL) {
 		Ref<StyleBox> style = get_theme_stylebox("normal");
 		int t_width = get_size().width - style->get_margin(SIDE_RIGHT) - style->get_margin(SIDE_LEFT);
-		bool using_placeholder = text.empty() && ime_text.empty();
+		bool using_placeholder = text.is_empty() && ime_text.is_empty();
 		bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 		if (right_icon.is_valid() || display_clear_icon) {
 			Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -34,7 +34,7 @@ String Range::get_configuration_warning() const {
 	String warning = Control::get_configuration_warning();
 
 	if (shared->exp_ratio && shared->min <= 0) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("If \"Exp Edit\" is enabled, \"Min Value\" must be greater than 0.");

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2723,7 +2723,7 @@ Error RichTextLabel::append_bbcode(const String &p_bbcode) {
 		String bbcode_name;
 		typedef Map<String, String> OptionMap;
 		OptionMap bbcode_options;
-		if (!split_tag_block.empty()) {
+		if (!split_tag_block.is_empty()) {
 			bbcode_name = split_tag_block[0];
 			for (int i = 1; i < split_tag_block.size(); i++) {
 				const String &expr = split_tag_block[i];
@@ -3071,7 +3071,7 @@ Error RichTextLabel::append_bbcode(const String &p_bbcode) {
 
 				int width = 0;
 				int height = 0;
-				if (!bbcode_value.empty()) {
+				if (!bbcode_value.is_empty()) {
 					int sep = bbcode_value.find("x");
 					if (sep == -1) {
 						width = bbcode_value.to_int();

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -558,7 +558,7 @@ String ScrollContainer::get_configuration_warning() const {
 	}
 
 	if (found != 1) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("ScrollContainer is intended to work with a single child control.\nUse a container as child (VBox, HBox, etc.), or a Control and set the custom minimum size manually.");

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -189,12 +189,12 @@ void TextEdit::Text::invalidate_cache(int p_line, int p_column, const String &p_
 	text.write[p_line].data_buf->set_preserve_control(draw_control_chars);
 	if (p_ime_text.length() > 0) {
 		text.write[p_line].data_buf->add_string(p_ime_text, font, font_size, opentype_features, language);
-		if (!p_bidi_override.empty()) {
+		if (!p_bidi_override.is_empty()) {
 			TS->shaped_text_set_bidi_override(text.write[p_line].data_buf->get_rid(), p_bidi_override);
 		}
 	} else {
 		text.write[p_line].data_buf->add_string(text[p_line].data, font, font_size, opentype_features, language);
-		if (!text[p_line].bidi_override.empty()) {
+		if (!text[p_line].bidi_override.is_empty()) {
 			TS->shaped_text_set_bidi_override(text.write[p_line].data_buf->get_rid(), text[p_line].bidi_override);
 		}
 	}
@@ -1167,7 +1167,7 @@ void TextEdit::_notification(int p_what) {
 					}
 
 					int start = TS->shaped_text_get_range(rid).x;
-					if (!search_text.empty()) { // Search highhlight
+					if (!search_text.is_empty()) { // Search highhlight
 						int search_text_col = _get_column_pos_of_word(search_text, str, search_flags, 0);
 						while (search_text_col != -1) {
 							Vector<Vector2> sel = TS->shaped_text_get_selection(rid, search_text_col + start, search_text_col + search_text.length() + start);
@@ -1190,7 +1190,7 @@ void TextEdit::_notification(int p_what) {
 						}
 					}
 
-					if (highlight_all_occurrences && !only_whitespaces_highlighted && !highlighted_text.empty()) { // Highlight
+					if (highlight_all_occurrences && !only_whitespaces_highlighted && !highlighted_text.is_empty()) { // Highlight
 						int highlighted_text_col = _get_column_pos_of_word(highlighted_text, str, SEARCH_MATCH_CASE | SEARCH_WHOLE_WORDS, 0);
 						while (highlighted_text_col != -1) {
 							Vector<Vector2> sel = TS->shaped_text_get_selection(rid, highlighted_text_col + start, highlighted_text_col + highlighted_text.length() + start);
@@ -5197,7 +5197,7 @@ void TextEdit::paste() {
 		cursor_set_line(selection.from_line);
 		cursor_set_column(selection.from_column);
 
-	} else if (!cut_copy_line.empty() && cut_copy_line == clipboard) {
+	} else if (!cut_copy_line.is_empty() && cut_copy_line == clipboard) {
 		cursor_set_column(0);
 		String ins = "\n";
 		clipboard += ins;
@@ -6469,7 +6469,7 @@ void TextEdit::query_code_comple() {
 		c--;
 	}
 
-	bool ignored = completion_active && !completion_options.empty();
+	bool ignored = completion_active && !completion_options.is_empty();
 	if (ignored) {
 		ScriptCodeCompletionOption::Kind kind = ScriptCodeCompletionOption::KIND_PLAIN_TEXT;
 		const ScriptCodeCompletionOption *previous_option = nullptr;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -163,7 +163,7 @@ void TreeItem::set_text(int p_column, String p_text) {
 		cells.write[p_column].max = INT_MIN;
 		for (int i = 0; i < strings.size(); i++) {
 			int value = i;
-			if (!strings[i].get_slicec(':', 1).empty()) {
+			if (!strings[i].get_slicec(':', 1).is_empty()) {
 				value = strings[i].get_slicec(':', 1).to_int();
 			}
 			cells.write[p_column].min = MIN(cells[p_column].min, value);
@@ -1212,7 +1212,7 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 			Vector<String> strings = p_item->cells[p_col].text.split(",");
 			for (int j = 0; j < strings.size(); j++) {
 				int value = j;
-				if (!strings[j].get_slicec(':', 1).empty()) {
+				if (!strings[j].get_slicec(':', 1).is_empty()) {
 					value = strings[j].get_slicec(':', 1).to_int();
 				}
 				if (option == value) {
@@ -2031,7 +2031,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 					popup_menu->clear();
 					for (int i = 0; i < c.text.get_slice_count(","); i++) {
 						String s = c.text.get_slicec(',', i);
-						popup_menu->add_item(s.get_slicec(':', 0), s.get_slicec(':', 1).empty() ? i : s.get_slicec(':', 1).to_int());
+						popup_menu->add_item(s.get_slicec(':', 0), s.get_slicec(':', 1).is_empty() ? i : s.get_slicec(':', 1).to_int());
 					}
 
 					popup_menu->set_size(Size2(col_width, 0));
@@ -2930,7 +2930,7 @@ bool Tree::edit_selected() {
 		popup_menu->clear();
 		for (int i = 0; i < c.text.get_slice_count(","); i++) {
 			String s2 = c.text.get_slicec(',', i);
-			popup_menu->add_item(s2.get_slicec(':', 0), s2.get_slicec(':', 1).empty() ? i : s2.get_slicec(':', 1).to_int());
+			popup_menu->add_item(s2.get_slicec(':', 0), s2.get_slicec(':', 1).is_empty() ? i : s2.get_slicec(':', 1).to_int());
 		}
 
 		popup_menu->set_size(Size2(rect.size.width, 0));

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1887,7 +1887,7 @@ void Node::remove_and_skip() {
 		}
 	}
 
-	while (!children.empty()) {
+	while (!children.is_empty()) {
 		Node *c_node = children.front()->get();
 		data.parent->add_child(c_node);
 		c_node->_propagate_replace_owner(nullptr, new_owner);
@@ -2245,7 +2245,7 @@ void Node::_duplicate_signals(const Node *p_original, Node *p_copy) const {
 
 	List<const Node *> process_list;
 	process_list.push_back(this);
-	while (!process_list.empty()) {
+	while (!process_list.is_empty()) {
 		const Node *n = process_list.front()->get();
 		process_list.pop_front();
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -136,7 +136,7 @@ void SceneTree::remove_from_group(const StringName &p_group, Node *p_node) {
 	ERR_FAIL_COND(!E);
 
 	E->get().nodes.erase(p_node);
-	if (E->get().nodes.empty()) {
+	if (E->get().nodes.is_empty()) {
 		group_map.erase(E);
 	}
 }
@@ -183,7 +183,7 @@ void SceneTree::_update_group_order(Group &g, bool p_use_priority) {
 	if (!g.changed) {
 		return;
 	}
-	if (g.nodes.empty()) {
+	if (g.nodes.is_empty()) {
 		return;
 	}
 
@@ -206,7 +206,7 @@ void SceneTree::call_group_flags(uint32_t p_call_flags, const StringName &p_grou
 		return;
 	}
 	Group &g = E->get();
-	if (g.nodes.empty()) {
+	if (g.nodes.is_empty()) {
 		return;
 	}
 
@@ -282,7 +282,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 		return;
 	}
 	Group &g = E->get();
-	if (g.nodes.empty()) {
+	if (g.nodes.is_empty()) {
 		return;
 	}
 
@@ -333,7 +333,7 @@ void SceneTree::set_group_flags(uint32_t p_call_flags, const StringName &p_group
 		return;
 	}
 	Group &g = E->get();
-	if (g.nodes.empty()) {
+	if (g.nodes.is_empty()) {
 		return;
 	}
 
@@ -787,7 +787,7 @@ void SceneTree::_notify_group_pause(const StringName &p_group, int p_notificatio
 		return;
 	}
 	Group &g = E->get();
-	if (g.nodes.empty()) {
+	if (g.nodes.is_empty()) {
 		return;
 	}
 
@@ -840,7 +840,7 @@ void SceneTree::_call_input_pause(const StringName &p_group, const StringName &p
 		return;
 	}
 	Group &g = E->get();
-	if (g.nodes.empty()) {
+	if (g.nodes.is_empty()) {
 		return;
 	}
 
@@ -1303,7 +1303,7 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 		List<String> directories;
 		directories.push_back(dir_access->get_current_dir());
 
-		while (!directories.empty()) {
+		while (!directories.is_empty()) {
 			dir_access->change_dir(directories.back()->get());
 			directories.pop_back();
 

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -264,7 +264,7 @@ String ShaderGlobalsOverride::get_configuration_warning() const {
 	String warning = Node::get_configuration_warning();
 
 	if (!active) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("ShaderGlobalsOverride is not active because another node of the same type is in the scene.");

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1505,7 +1505,7 @@ String Viewport::_gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Cont
 		}
 
 		// If we found a tooltip, we stop here.
-		if (!tooltip.empty()) {
+		if (!tooltip.is_empty()) {
 			break;
 		}
 
@@ -1539,7 +1539,7 @@ void Viewport::_gui_show_tooltip() {
 			gui.tooltip_control->get_global_transform().xform_inv(gui.last_mouse_pos),
 			&tooltip_owner);
 	tooltip_text.strip_edges();
-	if (tooltip_text.empty()) {
+	if (tooltip_text.is_empty()) {
 		return; // Nothing to show.
 	}
 
@@ -3139,7 +3139,7 @@ String Viewport::get_configuration_warning() const {
 	String warning = Node::get_configuration_warning();
 
 	if (size.x == 0 || size.y == 0) {
-		if (!warning.empty()) {
+		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
 		warning += TTR("Viewport size must be greater than 0 to render anything.");

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -43,7 +43,7 @@ void BitMap::create(const Size2 &p_size) {
 }
 
 void BitMap::create_from_image_alpha(const Ref<Image> &p_image, float p_threshold) {
-	ERR_FAIL_COND(p_image.is_null() || p_image->empty());
+	ERR_FAIL_COND(p_image.is_null() || p_image->is_empty());
 	Ref<Image> img = p_image->duplicate();
 	img->convert(Image::FORMAT_LA8);
 	ERR_FAIL_COND(img->get_format() != Image::FORMAT_LA8);

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -602,7 +602,7 @@ void Curve2D::remove_point(int p_index) {
 }
 
 void Curve2D::clear_points() {
-	if (!points.empty()) {
+	if (!points.is_empty()) {
 		points.clear();
 		baked_cache_dirty = true;
 		emit_signal(CoreStringNames::get_singleton()->changed);
@@ -1087,7 +1087,7 @@ void Curve3D::remove_point(int p_index) {
 }
 
 void Curve3D::clear_points() {
-	if (!points.empty()) {
+	if (!points.is_empty()) {
 		points.clear();
 		baked_cache_dirty = true;
 		emit_signal(CoreStringNames::get_singleton()->changed);

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -724,7 +724,7 @@ void Font::set_spacing(int p_type, int p_value) {
 // Drawing string and string sizes, cached.
 
 Size2 Font::get_string_size(const String &p_text, int p_size) const {
-	ERR_FAIL_COND_V(data.empty(), Size2());
+	ERR_FAIL_COND_V(data.is_empty(), Size2());
 
 	uint64_t hash = p_text.hash64();
 	hash = hash_djb2_one_64(p_size, hash);
@@ -746,7 +746,7 @@ Size2 Font::get_string_size(const String &p_text, int p_size) const {
 }
 
 Size2 Font::get_multiline_string_size(const String &p_text, float p_width, int p_size, uint8_t p_flags) const {
-	ERR_FAIL_COND_V(data.empty(), Size2());
+	ERR_FAIL_COND_V(data.is_empty(), Size2());
 
 	uint64_t hash = p_text.hash64();
 	hash = hash_djb2_one_64(p_size, hash);

--- a/scene/resources/gradient.h
+++ b/scene/resources/gradient.h
@@ -82,7 +82,7 @@ public:
 	Vector<Color> get_colors() const;
 
 	_FORCE_INLINE_ Color get_color_at_offset(float p_offset) {
-		if (points.empty()) {
+		if (points.is_empty()) {
 			return Color(0, 0, 0, 1);
 		}
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -74,7 +74,7 @@ Ref<TriangleMesh> Mesh::generate_triangle_mesh() const {
 		}
 
 		Array a = surface_get_arrays(i);
-		ERR_FAIL_COND_V(a.empty(), Ref<TriangleMesh>());
+		ERR_FAIL_COND_V(a.is_empty(), Ref<TriangleMesh>());
 
 		int vc = surface_get_array_len(i);
 		Vector<Vector3> vertices = a[ARRAY_VERTEX];
@@ -226,7 +226,7 @@ Ref<Shape3D> Mesh::create_convex_shape() const {
 
 	for (int i = 0; i < get_surface_count(); i++) {
 		Array a = surface_get_arrays(i);
-		ERR_FAIL_COND_V(a.empty(), Ref<ConvexPolygonShape3D>());
+		ERR_FAIL_COND_V(a.is_empty(), Ref<ConvexPolygonShape3D>());
 		Vector<Vector3> v = a[ARRAY_VERTEX];
 		vertices.append_array(v);
 	}
@@ -266,7 +266,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 		}
 
 		Array a = surface_get_arrays(i);
-		ERR_FAIL_COND_V(a.empty(), Ref<ArrayMesh>());
+		ERR_FAIL_COND_V(a.is_empty(), Ref<ArrayMesh>());
 
 		if (i == 0) {
 			arrays = a;

--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -43,7 +43,7 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 	ERR_FAIL_COND_V(p_mesh->surface_get_primitive_type(p_surface) != Mesh::PRIMITIVE_TRIANGLES, ERR_INVALID_PARAMETER);
 
 	Array arrays = p_mesh->surface_get_arrays(p_surface);
-	ERR_FAIL_COND_V(arrays.empty(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(arrays.is_empty(), ERR_INVALID_PARAMETER);
 
 	Vector<Vector3> varray = arrays[Mesh::ARRAY_VERTEX];
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -80,7 +80,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 
 	Node **ret_nodes = (Node **)alloca(sizeof(Node *) * nc);
 
-	bool gen_node_path_cache = p_edit_state != GEN_EDIT_STATE_DISABLED && node_path_cache.empty();
+	bool gen_node_path_cache = p_edit_state != GEN_EDIT_STATE_DISABLED && node_path_cache.is_empty();
 
 	Map<Ref<Resource>, Ref<Resource>> resources_local_to_scene;
 
@@ -603,7 +603,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 
 	// Save the right type. If this node was created by an instance
 	// then flag that the node should not be created but reused
-	if (pack_state_stack.empty()) {
+	if (pack_state_stack.is_empty()) {
 		//this node is not part of an instancing process, so save the type
 		nd.type = _nm_get_string(p_node->get_class(), name_map);
 	} else {
@@ -1349,7 +1349,7 @@ NodePath SceneState::get_node_path(int p_idx, bool p_for_parent) const {
 		sub_path.insert(0, base_path.get_name(i));
 	}
 
-	if (sub_path.empty()) {
+	if (sub_path.is_empty()) {
 		return NodePath(".");
 	}
 

--- a/scene/resources/shape_3d.cpp
+++ b/scene/resources/shape_3d.cpp
@@ -66,7 +66,7 @@ Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 
 	debug_mesh_cache = Ref<ArrayMesh>(memnew(ArrayMesh));
 
-	if (!lines.empty()) {
+	if (!lines.is_empty()) {
 		//make mesh
 		Vector<Vector3> array;
 		array.resize(lines.size());

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -552,7 +552,7 @@ Dictionary CodeHighlighter::get_color_regions() const {
 	Dictionary r_color_regions;
 	for (int i = 0; i < color_regions.size(); i++) {
 		ColorRegion region = color_regions[i];
-		r_color_regions[region.start_key + (region.end_key.empty() ? "" : " " + region.end_key)] = region.color;
+		r_color_regions[region.start_key + (region.end_key.is_empty() ? "" : " " + region.end_key)] = region.color;
 	}
 	return r_color_regions;
 }

--- a/scene/resources/text_line.cpp
+++ b/scene/resources/text_line.cpp
@@ -97,7 +97,7 @@ void TextLine::_bind_methods() {
 
 void TextLine::_shape() {
 	if (dirty) {
-		if (!tab_stops.empty()) {
+		if (!tab_stops.is_empty()) {
 			TS->shaped_text_tab_align(rid, tab_stops);
 		}
 		if (align == HALIGN_FILL) {

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -110,14 +110,14 @@ void TextParagraph::_shape_lines() {
 		}
 		lines.clear();
 
-		if (!tab_stops.empty()) {
+		if (!tab_stops.is_empty()) {
 			TS->shaped_text_tab_align(rid, tab_stops);
 		}
 
 		Vector<Vector2i> line_breaks = TS->shaped_text_get_line_breaks(rid, width, 0, flags);
 		for (int i = 0; i < line_breaks.size(); i++) {
 			RID line = TS->shaped_text_substr(rid, line_breaks[i].x, line_breaks[i].y - line_breaks[i].x);
-			if (!tab_stops.empty()) {
+			if (!tab_stops.is_empty()) {
 				TS->shaped_text_tab_align(line, tab_stops);
 			}
 			if (align == HALIGN_FILL && (line_breaks.size() == 1 || i < line_breaks.size() - 1)) {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -371,8 +371,8 @@ Ref<Image> StreamTexture2D::load_image_from_file(FileAccess *f, int p_size_limit
 				img = Image::lossy_unpacker(pv);
 			}
 
-			if (img.is_null() || img->empty()) {
-				ERR_FAIL_COND_V(img.is_null() || img->empty(), Ref<Image>());
+			if (img.is_null() || img->is_empty()) {
+				ERR_FAIL_COND_V(img.is_null() || img->is_empty(), Ref<Image>());
 			}
 
 			if (first) {
@@ -548,7 +548,7 @@ Error StreamTexture2D::_load_data(const String &p_path, int &tw, int &th, int &t
 
 	memdelete(f);
 
-	if (image.is_null() || image->empty()) {
+	if (image.is_null() || image->is_empty()) {
 		return ERR_CANT_OPEN;
 	}
 
@@ -924,7 +924,7 @@ Error StreamTexture3D::_load_data(const String &p_path, Vector<Ref<Image>> &r_da
 
 	for (int i = 0; i < (r_depth + mipmaps); i++) {
 		Ref<Image> image = StreamTexture2D::load_image_from_file(f, 0);
-		ERR_FAIL_COND_V(image.is_null() || image->empty(), ERR_CANT_OPEN);
+		ERR_FAIL_COND_V(image.is_null() || image->is_empty(), ERR_CANT_OPEN);
 		if (i == 0) {
 			r_format = image->get_format();
 			r_width = image->get_width();
@@ -2223,7 +2223,7 @@ Error ImageTextureLayered::create_from_images(Vector<Ref<Image>> p_images) {
 				"Cubemap array layers must be a multiple of 6");
 	}
 
-	ERR_FAIL_COND_V(p_images[0].is_null() || p_images[0]->empty(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_images[0].is_null() || p_images[0]->is_empty(), ERR_INVALID_PARAMETER);
 
 	Image::Format new_format = p_images[0]->get_format();
 	int new_width = p_images[0]->get_width();
@@ -2361,7 +2361,7 @@ Error StreamTextureLayered::_load_data(const String &p_path, Vector<Ref<Image>> 
 
 	for (uint32_t i = 0; i < layer_count; i++) {
 		Ref<Image> image = StreamTexture2D::load_image_from_file(f, p_size_limit);
-		ERR_FAIL_COND_V(image.is_null() || image->empty(), ERR_CANT_OPEN);
+		ERR_FAIL_COND_V(image.is_null() || image->is_empty(), ERR_CANT_OPEN);
 		images.write[i] = image;
 	}
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3124,7 +3124,7 @@ String VisualShaderNodeExpression::generate_code(Shader::Mode p_mode, VisualShad
 	_expression = _expression.replace("\n", "\n\t\t");
 
 	static Vector<String> pre_symbols;
-	if (pre_symbols.empty()) {
+	if (pre_symbols.is_empty()) {
 		pre_symbols.push_back("\t");
 		pre_symbols.push_back(",");
 		pre_symbols.push_back(";");
@@ -3144,7 +3144,7 @@ String VisualShaderNodeExpression::generate_code(Shader::Mode p_mode, VisualShad
 	}
 
 	static Vector<String> post_symbols;
-	if (post_symbols.empty()) {
+	if (post_symbols.is_empty()) {
 		post_symbols.push_back("\t");
 		post_symbols.push_back("\n");
 		post_symbols.push_back(",");

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -111,7 +111,7 @@ struct SpatialIndexer2D {
 					ERR_CONTINUE(!E);
 					if (E->get().notifiers[p_notifier].dec() == 0) {
 						E->get().notifiers.erase(p_notifier);
-						if (E->get().notifiers.empty()) {
+						if (E->get().notifiers.is_empty()) {
 							cells.erase(E);
 						}
 					}
@@ -156,7 +156,7 @@ struct SpatialIndexer2D {
 			}
 		}
 
-		while (!removed.empty()) {
+		while (!removed.is_empty()) {
 			p_notifier->_exit_viewport(removed.front()->get());
 			removed.pop_front();
 		}
@@ -189,7 +189,7 @@ struct SpatialIndexer2D {
 			removed.push_back(E->key());
 		}
 
-		while (!removed.empty()) {
+		while (!removed.is_empty()) {
 			removed.front()->get()->_exit_viewport(p_viewport);
 			removed.pop_front();
 		}
@@ -271,12 +271,12 @@ struct SpatialIndexer2D {
 				}
 			}
 
-			while (!added.empty()) {
+			while (!added.is_empty()) {
 				added.front()->get()->_enter_viewport(E->key());
 				added.pop_front();
 			}
 
-			while (!removed.empty()) {
+			while (!removed.is_empty()) {
 				E->get().notifiers.erase(removed.front()->get());
 				removed.front()->get()->_exit_viewport(E->key());
 				removed.pop_front();

--- a/scene/resources/world_3d.cpp
+++ b/scene/resources/world_3d.cpp
@@ -97,7 +97,7 @@ struct SpatialIndexer {
 			}
 		}
 
-		while (!removed.empty()) {
+		while (!removed.is_empty()) {
 			p_notifier->_exit_camera(removed.front()->get());
 			removed.pop_front();
 		}
@@ -125,7 +125,7 @@ struct SpatialIndexer {
 			removed.push_back(E->key());
 		}
 
-		while (!removed.empty()) {
+		while (!removed.is_empty()) {
 			removed.front()->get()->_exit_camera(p_camera);
 			removed.pop_front();
 		}
@@ -175,12 +175,12 @@ struct SpatialIndexer {
 				}
 			}
 
-			while (!added.empty()) {
+			while (!added.is_empty()) {
 				added.front()->get()->_enter_camera(E->key());
 				added.pop_front();
 			}
 
-			while (!removed.empty()) {
+			while (!removed.is_empty()) {
 				E->get().notifiers.erase(removed.front()->get());
 				removed.front()->get()->_exit_camera(E->key());
 				removed.pop_front();

--- a/servers/physics_2d/area_2d_sw.cpp
+++ b/servers/physics_2d/area_2d_sw.cpp
@@ -199,7 +199,7 @@ void Area2DSW::set_monitorable(bool p_monitorable) {
 }
 
 void Area2DSW::call_queries() {
-	if (monitor_callback_id.is_valid() && !monitored_bodies.empty()) {
+	if (monitor_callback_id.is_valid() && !monitored_bodies.is_empty()) {
 		Variant res[5];
 		Variant *resptr[5];
 		for (int i = 0; i < 5; i++) {
@@ -234,7 +234,7 @@ void Area2DSW::call_queries() {
 		}
 	}
 
-	if (area_monitor_callback_id.is_valid() && !monitored_areas.empty()) {
+	if (area_monitor_callback_id.is_valid() && !monitored_areas.is_empty()) {
 		Variant res[5];
 		Variant *resptr[5];
 		for (int i = 0; i < 5; i++) {

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -164,7 +164,7 @@ public:
 
 	_FORCE_INLINE_ int get_max_contacts_reported() const { return contacts.size(); }
 
-	_FORCE_INLINE_ bool can_report_contacts() const { return !contacts.empty(); }
+	_FORCE_INLINE_ bool can_report_contacts() const { return !contacts.is_empty(); }
 	_FORCE_INLINE_ void add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_normal, real_t p_depth, int p_local_shape, const Vector2 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector2 &p_collider_velocity_at_pos);
 
 	_FORCE_INLINE_ void add_exception(const RID &p_exception) { exceptions.insert(p_exception); }

--- a/servers/physics_2d/broad_phase_2d_hash_grid.cpp
+++ b/servers/physics_2d/broad_phase_2d_hash_grid.cpp
@@ -261,7 +261,7 @@ void BroadPhase2DHashGrid::_exit_grid(Element *p_elem, const Rect2 &p_rect, bool
 				}
 			}
 
-			if (pb->object_set.empty() && pb->static_object_set.empty()) {
+			if (pb->object_set.is_empty() && pb->static_object_set.is_empty()) {
 				if (hash_table[idx] == pb) {
 					hash_table[idx] = pb->next;
 				} else {

--- a/servers/physics_2d/space_2d_sw.h
+++ b/servers/physics_2d/space_2d_sw.h
@@ -187,7 +187,7 @@ public:
 	int test_body_ray_separation(Body2DSW *p_body, const Transform2D &p_transform, bool p_infinite_inertia, Vector2 &r_recover_motion, PhysicsServer2D::SeparationResult *r_results, int p_result_max, real_t p_margin);
 
 	void set_debug_contacts(int p_amount) { contact_debug.resize(p_amount); }
-	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contact_debug.empty(); }
+	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contact_debug.is_empty(); }
 	_FORCE_INLINE_ void add_debug_contact(const Vector2 &p_contact) {
 		if (contact_debug_count < contact_debug.size()) {
 			contact_debug.write[contact_debug_count++] = p_contact;

--- a/servers/physics_3d/area_3d_sw.cpp
+++ b/servers/physics_3d/area_3d_sw.cpp
@@ -199,7 +199,7 @@ void Area3DSW::set_monitorable(bool p_monitorable) {
 }
 
 void Area3DSW::call_queries() {
-	if (monitor_callback_id.is_valid() && !monitored_bodies.empty()) {
+	if (monitor_callback_id.is_valid() && !monitored_bodies.is_empty()) {
 		Variant res[5];
 		Variant *resptr[5];
 		for (int i = 0; i < 5; i++) {
@@ -234,7 +234,7 @@ void Area3DSW::call_queries() {
 		}
 	}
 
-	if (area_monitor_callback_id.is_valid() && !monitored_areas.empty()) {
+	if (area_monitor_callback_id.is_valid() && !monitored_areas.is_empty()) {
 		Variant res[5];
 		Variant *resptr[5];
 		for (int i = 0; i < 5; i++) {

--- a/servers/physics_3d/body_3d_sw.h
+++ b/servers/physics_3d/body_3d_sw.h
@@ -178,7 +178,7 @@ public:
 	}
 	_FORCE_INLINE_ int get_max_contacts_reported() const { return contacts.size(); }
 
-	_FORCE_INLINE_ bool can_report_contacts() const { return !contacts.empty(); }
+	_FORCE_INLINE_ bool can_report_contacts() const { return !contacts.is_empty(); }
 	_FORCE_INLINE_ void add_contact(const Vector3 &p_local_pos, const Vector3 &p_local_normal, real_t p_depth, int p_local_shape, const Vector3 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector3 &p_collider_velocity_at_pos);
 
 	_FORCE_INLINE_ void add_exception(const RID &p_exception) { exceptions.insert(p_exception); }

--- a/servers/physics_3d/space_3d_sw.h
+++ b/servers/physics_3d/space_3d_sw.h
@@ -182,7 +182,7 @@ public:
 	PhysicsDirectSpaceState3DSW *get_direct_state();
 
 	void set_debug_contacts(int p_amount) { contact_debug.resize(p_amount); }
-	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contact_debug.empty(); }
+	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contact_debug.is_empty(); }
 	_FORCE_INLINE_ void add_debug_contact(const Vector3 &p_contact) {
 		if (contact_debug_count < contact_debug.size()) {
 			contact_debug.write[contact_debug_count++] = p_contact;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -874,7 +874,7 @@ void RendererCanvasCull::canvas_item_add_polygon(RID p_item, const Vector<Point2
 	ERR_FAIL_COND(uv_size != 0 && (uv_size != pointcount));
 #endif
 	Vector<int> indices = Geometry2D::triangulate_polygon(p_points);
-	ERR_FAIL_COND_MSG(indices.empty(), "Invalid polygon data, triangulation failed.");
+	ERR_FAIL_COND_MSG(indices.is_empty(), "Invalid polygon data, triangulation failed.");
 
 	Item::CommandPolygon *polygon = canvas_item->alloc_command<Item::CommandPolygon>();
 	ERR_FAIL_COND(!polygon);
@@ -889,10 +889,10 @@ void RendererCanvasCull::canvas_item_add_triangle_array(RID p_item, const Vector
 
 	int vertex_count = p_points.size();
 	ERR_FAIL_COND(vertex_count == 0);
-	ERR_FAIL_COND(!p_colors.empty() && p_colors.size() != vertex_count && p_colors.size() != 1);
-	ERR_FAIL_COND(!p_uvs.empty() && p_uvs.size() != vertex_count);
-	ERR_FAIL_COND(!p_bones.empty() && p_bones.size() != vertex_count * 4);
-	ERR_FAIL_COND(!p_weights.empty() && p_weights.size() != vertex_count * 4);
+	ERR_FAIL_COND(!p_colors.is_empty() && p_colors.size() != vertex_count && p_colors.size() != 1);
+	ERR_FAIL_COND(!p_uvs.is_empty() && p_uvs.size() != vertex_count);
+	ERR_FAIL_COND(!p_bones.is_empty() && p_bones.size() != vertex_count * 4);
+	ERR_FAIL_COND(!p_weights.is_empty() && p_weights.size() != vertex_count * 4);
 
 	Vector<int> indices = p_indices;
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
@@ -894,7 +894,7 @@ void RendererSceneRenderForward::_fill_instances(RenderList::Element **p_element
 			} else {
 				id.gi_offset = 0xFFFFFFFF;
 			}
-		} else if (!e->instance->lightmap_sh.empty()) {
+		} else if (!e->instance->lightmap_sh.is_empty()) {
 			if (lightmap_captures_used < scene_state.max_lightmap_captures) {
 				const Color *src_capture = e->instance->lightmap_sh.ptr();
 				LightmapCaptureData &lcd = scene_state.lightmap_captures[lightmap_captures_used];
@@ -914,7 +914,7 @@ void RendererSceneRenderForward::_fill_instances(RenderList::Element **p_element
 				id.flags |= INSTANCE_DATA_FLAG_USE_GI_BUFFERS;
 			}
 
-			if (!low_end && !e->instance->gi_probe_instances.empty()) {
+			if (!low_end && !e->instance->gi_probe_instances.is_empty()) {
 				uint32_t written = 0;
 				for (int j = 0; j < e->instance->gi_probe_instances.size(); j++) {
 					RID probe = e->instance->gi_probe_instances[j];
@@ -1521,7 +1521,7 @@ void RendererSceneRenderForward::_add_geometry_with_material(InstanceBase *p_ins
 	e->geometry_index = p_geometry_index;
 	e->material_index = e->material->index;
 	e->uses_instancing = e->instance->base_type == RS::INSTANCE_MULTIMESH;
-	e->uses_lightmap = e->instance->lightmap != nullptr || !e->instance->lightmap_sh.empty();
+	e->uses_lightmap = e->instance->lightmap != nullptr || !e->instance->lightmap_sh.is_empty();
 	e->uses_forward_gi = has_alpha && (e->instance->gi_probe_instances.size() || p_using_sdfgi);
 	e->shader_index = e->shader_index;
 	e->depth_layer = e->instance->depth_layer;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -6681,7 +6681,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 	//update directional shadow
 
 	if (p_use_directional_shadows) {
-		if (directional_shadow.shrink_stages.empty()) {
+		if (directional_shadow.shrink_stages.is_empty()) {
 			if (rb->volumetric_fog->uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(rb->volumetric_fog->uniform_set)) {
 				//invalidate uniform set, we will need a new one
 				RD::get_singleton()->free(rb->volumetric_fog->uniform_set);
@@ -6716,7 +6716,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		bool force_shrink_shadows = false;
 
-		if (shadow_atlas->shrink_stages.empty()) {
+		if (shadow_atlas->shrink_stages.is_empty()) {
 			if (rb->volumetric_fog->uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(rb->volumetric_fog->uniform_set)) {
 				//invalidate uniform set, we will need a new one
 				RD::get_singleton()->free(rb->volumetric_fog->uniform_set);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -537,7 +537,7 @@ Ref<Image> RendererStorageRD::_validate_texture_format(const Ref<Image> &p_image
 
 RID RendererStorageRD::texture_2d_create(const Ref<Image> &p_image) {
 	ERR_FAIL_COND_V(p_image.is_null(), RID());
-	ERR_FAIL_COND_V(p_image->empty(), RID());
+	ERR_FAIL_COND_V(p_image->is_empty(), RID());
 
 	TextureToRDFormat ret_format;
 	Ref<Image> image = _validate_texture_format(p_image, ret_format);
@@ -620,7 +620,7 @@ RID RendererStorageRD::texture_2d_layered_create(const Vector<Ref<Image>> &p_lay
 		Image::Format valid_format = Image::FORMAT_MAX;
 
 		for (int i = 0; i < p_layers.size(); i++) {
-			ERR_FAIL_COND_V(p_layers[i]->empty(), RID());
+			ERR_FAIL_COND_V(p_layers[i]->is_empty(), RID());
 
 			if (i == 0) {
 				valid_width = p_layers[i]->get_width();
@@ -855,7 +855,7 @@ RID RendererStorageRD::texture_proxy_create(RID p_base) {
 }
 
 void RendererStorageRD::_texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer, bool p_immediate) {
-	ERR_FAIL_COND(p_image.is_null() || p_image->empty());
+	ERR_FAIL_COND(p_image.is_null() || p_image->is_empty());
 
 	Texture *tex = texture_owner.getornull(p_texture);
 	ERR_FAIL_COND(!tex);
@@ -1039,7 +1039,7 @@ Ref<Image> RendererStorageRD::texture_2d_get(RID p_texture) const {
 	Ref<Image> image;
 	image.instance();
 	image->create(tex->width, tex->height, tex->mipmaps > 1, tex->validated_format, data);
-	ERR_FAIL_COND_V(image->empty(), Ref<Image>());
+	ERR_FAIL_COND_V(image->is_empty(), Ref<Image>());
 	if (tex->format != tex->validated_format) {
 		image->convert(tex->format);
 	}
@@ -1062,7 +1062,7 @@ Ref<Image> RendererStorageRD::texture_2d_layer_get(RID p_texture, int p_layer) c
 	Ref<Image> image;
 	image.instance();
 	image->create(tex->width, tex->height, tex->mipmaps > 1, tex->validated_format, data);
-	ERR_FAIL_COND_V(image->empty(), Ref<Image>());
+	ERR_FAIL_COND_V(image->is_empty(), Ref<Image>());
 	if (tex->format != tex->validated_format) {
 		image->convert(tex->format);
 	}
@@ -1090,7 +1090,7 @@ Vector<Ref<Image>> RendererStorageRD::texture_3d_get(RID p_texture) const {
 		Ref<Image> img;
 		img.instance();
 		img->create(bs.size.width, bs.size.height, false, tex->validated_format, sub_region);
-		ERR_FAIL_COND_V(img->empty(), Vector<Ref<Image>>());
+		ERR_FAIL_COND_V(img->is_empty(), Vector<Ref<Image>>());
 		if (tex->format != tex->validated_format) {
 			img->convert(tex->format);
 		}

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -1408,7 +1408,7 @@ public:
 		if (r_surface_count == 0) {
 			return nullptr;
 		}
-		if (mesh->material_cache.empty()) {
+		if (mesh->material_cache.is_empty()) {
 			mesh->material_cache.resize(mesh->surface_count);
 			for (uint32_t i = 0; i < r_surface_count; i++) {
 				mesh->material_cache.write[i] = mesh->surfaces[i]->material;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -255,7 +255,7 @@ void RendererSceneCull::_instance_unpair(Instance *p_A, Instance *p_B) {
 		if (A->dynamic_gi) {
 			geom->lightmap_captures.erase(B);
 
-			if (geom->lightmap_captures.empty() && A->scenario && A->array_index >= 0) {
+			if (geom->lightmap_captures.is_empty() && A->scenario && A->array_index >= 0) {
 				InstanceData &idata = A->scenario->instance_data[A->array_index];
 				idata.flags &= ~uint32_t(InstanceData::FLAG_LIGHTMAP_CAPTURE);
 			}
@@ -1134,7 +1134,7 @@ void RendererSceneCull::_update_instance(Instance *p_instance) {
 			//affected by lightmap captures, must update capture info!
 			_update_instance_lightmap_captures(p_instance);
 		} else {
-			if (!p_instance->lightmap_sh.empty()) {
+			if (!p_instance->lightmap_sh.is_empty()) {
 				p_instance->lightmap_sh.clear(); //don't need SH
 				p_instance->lightmap_target_sh.clear(); //don't need SH
 			}
@@ -2382,7 +2382,7 @@ void RendererSceneCull::_prepare_scene(const Transform p_cam_transform, const Ca
 						idata.flags &= ~uint32_t(InstanceData::FLAG_GEOM_GI_PROBE_DIRTY);
 					}
 
-					if ((idata.flags & InstanceData::FLAG_LIGHTMAP_CAPTURE) && idata.instance->last_frame_pass != frame_number && !idata.instance->lightmap_target_sh.empty() && !idata.instance->lightmap_sh.empty()) {
+					if ((idata.flags & InstanceData::FLAG_LIGHTMAP_CAPTURE) && idata.instance->last_frame_pass != frame_number && !idata.instance->lightmap_target_sh.is_empty() && !idata.instance->lightmap_sh.is_empty()) {
 						Color *sh = idata.instance->lightmap_sh.ptrw();
 						const Color *target_sh = idata.instance->lightmap_target_sh.ptr();
 						for (uint32_t j = 0; j < 9; j++) {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -68,7 +68,7 @@ RID RenderingDevice::_texture_create(const Ref<RDTextureFormat> &p_format, const
 	Vector<Vector<uint8_t>> data;
 	for (int i = 0; i < p_data.size(); i++) {
 		Vector<uint8_t> byte_slice = p_data[i];
-		ERR_FAIL_COND_V(byte_slice.empty(), RID());
+		ERR_FAIL_COND_V(byte_slice.is_empty(), RID());
 		data.push_back(byte_slice);
 	}
 	return texture_create(p_format->base, p_view->base, data);
@@ -154,7 +154,7 @@ RID RenderingDevice::shader_create_from_bytecode(const Ref<RDShaderBytecode> &p_
 		String error = p_bytecode->get_stage_compile_error(stage);
 		ERR_FAIL_COND_V_MSG(error != String(), RID(), "Can't create a shader from an errored bytecode. Check errors in source bytecode.");
 		sd.spir_v = p_bytecode->get_stage_bytecode(stage);
-		if (sd.spir_v.empty()) {
+		if (sd.spir_v.is_empty()) {
 			continue;
 		}
 		stage_data.push_back(sd);

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -163,7 +163,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 			ERR_FAIL_V_MSG(ERR_PARSE_ERROR, "When writing compute shaders, [compute] mustbe the only stage present.");
 		}
 
-		if (version_texts.empty()) {
+		if (version_texts.is_empty()) {
 			version_texts[""] = ""; //make sure a default version exists
 		}
 

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3818,7 +3818,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						if (index_expression->type == Node::TYPE_CONSTANT) {
 							ConstantNode *cnode = (ConstantNode *)index_expression;
 							if (cnode) {
-								if (!cnode->values.empty()) {
+								if (!cnode->values.is_empty()) {
 									int value = cnode->values[0].sint;
 									if (value < 0 || value >= array_size) {
 										_set_error(vformat("Index [%s] out of range [%s..%s]", value, 0, array_size - 1));
@@ -4210,7 +4210,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						if (index_expression->type == Node::TYPE_CONSTANT) {
 							ConstantNode *cnode = (ConstantNode *)index_expression;
 							if (cnode) {
-								if (!cnode->values.empty()) {
+								if (!cnode->values.is_empty()) {
 									int value = cnode->values[0].sint;
 									if (value < 0 || value >= array_size) {
 										_set_error(vformat("Index [%s] out of range [%s..%s]", value, 0, array_size - 1));
@@ -5504,7 +5504,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 							if (flow->flow_op == FLOW_OP_CASE) {
 								if (flow->expressions[0]->type == Node::TYPE_CONSTANT) {
 									ConstantNode *cn = static_cast<ConstantNode *>(flow->expressions[0]);
-									if (!cn || cn->values.empty()) {
+									if (!cn || cn->values.is_empty()) {
 										return ERR_PARSE_ERROR;
 									}
 									if (constants.has(cn->values[0].sint)) {

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -550,7 +550,7 @@ void TextServer::draw_hex_code_box(RID p_canvas, int p_size, const Vector2 &p_po
 Vector<Vector2i> TextServer::shaped_text_get_line_breaks_adv(RID p_shaped, const Vector<float> &p_width, int p_start, bool p_once, uint8_t /*TextBreakFlag*/ p_break_flags) const {
 	Vector<Vector2i> lines;
 
-	ERR_FAIL_COND_V(p_width.empty(), lines);
+	ERR_FAIL_COND_V(p_width.is_empty(), lines);
 
 	const_cast<TextServer *>(this)->shaped_text_update_breaks(p_shaped);
 	const Vector<Glyph> &logical = const_cast<TextServer *>(this)->shaped_text_sort_logical(p_shaped);

--- a/tests/test_class_db.h
+++ b/tests/test_class_db.h
@@ -397,7 +397,7 @@ void validate_method(const Context &p_context, const ExposedClass &p_class, cons
 			String type_error_msg;
 			bool arg_defval_assignable_to_type = arg_default_value_is_assignable_to_type(p_context, arg.defval, arg.type, &type_error_msg);
 			String err_msg = vformat("Invalid default value for parameter '%s' of method '%s.%s'.", arg.name, p_class.name, p_method.name);
-			if (!type_error_msg.empty()) {
+			if (!type_error_msg.is_empty()) {
 				err_msg += " " + type_error_msg;
 			}
 			TEST_COND(!arg_defval_assignable_to_type, err_msg.utf8().get_data());
@@ -538,7 +538,7 @@ void add_exposed_classes(Context &r_context) {
 
 			int argc = method_info.arguments.size();
 
-			if (method_info.name.empty()) {
+			if (method_info.name.is_empty()) {
 				continue;
 			}
 

--- a/tests/test_list.h
+++ b/tests/test_list.h
@@ -57,7 +57,7 @@ TEST_CASE("[List] Push/pop back") {
 	CHECK(n->get() == "C");
 
 	CHECK(list.size() == 3);
-	CHECK(!list.empty());
+	CHECK(!list.is_empty());
 
 	String v;
 	v = list.back()->get();
@@ -71,7 +71,7 @@ TEST_CASE("[List] Push/pop back") {
 	CHECK(v == "A");
 
 	CHECK(list.size() == 0);
-	CHECK(list.empty());
+	CHECK(list.is_empty());
 
 	CHECK(list.back() == nullptr);
 	CHECK(list.front() == nullptr);
@@ -89,7 +89,7 @@ TEST_CASE("[List] Push/pop front") {
 	CHECK(n->get() == "C");
 
 	CHECK(list.size() == 3);
-	CHECK(!list.empty());
+	CHECK(!list.is_empty());
 
 	String v;
 	v = list.front()->get();
@@ -103,7 +103,7 @@ TEST_CASE("[List] Push/pop front") {
 	CHECK(v == "A");
 
 	CHECK(list.size() == 0);
-	CHECK(list.empty());
+	CHECK(list.is_empty());
 
 	CHECK(list.back() == nullptr);
 	CHECK(list.front() == nullptr);
@@ -252,7 +252,7 @@ TEST_CASE("[List] Clear") {
 	list.clear();
 
 	CHECK(list.size() == 0);
-	CHECK(list.empty());
+	CHECK(list.is_empty());
 }
 
 TEST_CASE("[List] Invert") {

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -513,7 +513,7 @@ MainLoop *test() {
 
 	List<String> cmdlargs = OS::get_singleton()->get_cmdline_args();
 
-	if (cmdlargs.empty()) {
+	if (cmdlargs.is_empty()) {
 		//try editor!
 		return nullptr;
 	}

--- a/tests/test_shader_lang.cpp
+++ b/tests/test_shader_lang.cpp
@@ -308,7 +308,7 @@ static Error recreate_code(void *p_str, SL::ShaderNode *p_program) {
 MainLoop *test() {
 	List<String> cmdlargs = OS::get_singleton()->get_cmdline_args();
 
-	if (cmdlargs.empty()) {
+	if (cmdlargs.is_empty()) {
 		//try editor!
 		print_line("usage: godot -test shader_lang <shader>");
 		return nullptr;

--- a/tests/test_string.h
+++ b/tests/test_string.h
@@ -244,11 +244,11 @@ TEST_CASE("[String] Testing size and length of string") {
 }
 
 TEST_CASE("[String] Testing for empty string") {
-	CHECK(!String("Mellon").empty());
+	CHECK(!String("Mellon").is_empty());
 	// do this more than once, to check for string corruption
-	CHECK(String("").empty());
-	CHECK(String("").empty());
-	CHECK(String("").empty());
+	CHECK(String("").is_empty());
+	CHECK(String("").is_empty());
+	CHECK(String("").is_empty());
 }
 
 TEST_CASE("[String] Test chr") {

--- a/thirdparty/misc/triangulator.cpp
+++ b/thirdparty/misc/triangulator.cpp
@@ -665,7 +665,7 @@ int TriangulatorPartition::Triangulate_OPT(TriangulatorPoly *poly, List<Triangul
 	newdiagonal.index1 = 0;
 	newdiagonal.index2 = n-1;
 	diagonals.push_back(newdiagonal);
-	while(!diagonals.empty()) {
+	while(!diagonals.is_empty()) {
 		diagonal = (diagonals.front()->get());
 		diagonals.pop_front();
 		bestvertex = dpstates[diagonal.index2][diagonal.index1].bestvertex;
@@ -712,8 +712,8 @@ void TriangulatorPartition::UpdateState(long a, long b, long w, long i, long j, 
 		pairs->push_front(newdiagonal);
 		dpstates[a][b].weight = w;
 	} else {
-		if((!pairs->empty())&&(i <= pairs->front()->get().index1)) return;
-		while((!pairs->empty())&&(pairs->front()->get().index2 >= j)) pairs->pop_front();
+		if((!pairs->is_empty())&&(i <= pairs->front()->get().index1)) return;
+		while((!pairs->is_empty())&&(pairs->front()->get().index2 >= j)) pairs->pop_front();
 		pairs->push_front(newdiagonal);
 	}
 }
@@ -771,7 +771,7 @@ void TriangulatorPartition::TypeB(long i, long j, long k, PartitionVertex *verti
 		pairs = &(dpstates[j][k].pairs);
 
 		iter = pairs->front();
-		if((!pairs->empty())&&(!IsReflex(vertices[i].p,vertices[j].p,vertices[iter->get().index1].p))) {
+		if((!pairs->is_empty())&&(!IsReflex(vertices[i].p,vertices[j].p,vertices[iter->get().index1].p))) {
 			lastiter = iter;
 			while(iter!=NULL) {
 				if(!IsReflex(vertices[i].p,vertices[j].p,vertices[iter->get().index1].p)) {
@@ -906,12 +906,12 @@ int TriangulatorPartition::ConvexPartition_OPT(TriangulatorPoly *poly, List<Tria
 	newdiagonal.index1 = 0;
 	newdiagonal.index2 = n-1;
 	diagonals.push_front(newdiagonal);
-	while(!diagonals.empty()) {
+	while(!diagonals.is_empty()) {
 		diagonal = (diagonals.front()->get());
 		diagonals.pop_front();
 		if((diagonal.index2 - diagonal.index1) <=1) continue;
 		pairs = &(dpstates[diagonal.index1][diagonal.index2].pairs);
-		if(pairs->empty()) {
+		if(pairs->is_empty()) {
 			ret = 0;
 			break;
 		}
@@ -926,7 +926,7 @@ int TriangulatorPartition::ConvexPartition_OPT(TriangulatorPoly *poly, List<Tria
 				if(iter->get().index1 != iter->get().index2) {
 					pairs2 = &(dpstates[diagonal.index1][j].pairs);
 					while(1) {
-						if(pairs2->empty()) {
+						if(pairs2->is_empty()) {
 							ret = 0;
 							break;
 						}
@@ -951,7 +951,7 @@ int TriangulatorPartition::ConvexPartition_OPT(TriangulatorPoly *poly, List<Tria
 				if(iter->get().index1 != iter->get().index2) {
 					pairs2 = &(dpstates[j][diagonal.index2].pairs);
 					while(1) {
-						if(pairs2->empty()) {
+						if(pairs2->is_empty()) {
 							ret = 0;
 							break;
 						}
@@ -981,7 +981,7 @@ int TriangulatorPartition::ConvexPartition_OPT(TriangulatorPoly *poly, List<Tria
 	newdiagonal.index1 = 0;
 	newdiagonal.index2 = n-1;
 	diagonals.push_front(newdiagonal);
-	while(!diagonals.empty()) {
+	while(!diagonals.is_empty()) {
 		diagonal = (diagonals.front())->get();
 		diagonals.pop_front();
 		if((diagonal.index2 - diagonal.index1) <= 1) continue;
@@ -992,7 +992,7 @@ int TriangulatorPartition::ConvexPartition_OPT(TriangulatorPoly *poly, List<Tria
 		indices.push_back(diagonal.index2);
 		diagonals2.push_front(diagonal);
 
-		while(!diagonals2.empty()) {
+		while(!diagonals2.is_empty()) {
 			diagonal = (diagonals2.front()->get());
 			diagonals2.pop_front();
 			if((diagonal.index2 - diagonal.index1) <= 1) continue;


### PR DESCRIPTION
Most of Godot's data structures have the method `empty()` which returns a `bool`, and is used to determine whether or not the data structure is empty. This can be confused with the action to empty the data structure (for which most of the data structures use `clear()`). Therefore, to avoid confusion, this method should be renamed `is_empty()`.

This PR renames `empty()` to `is_empty()` in all of Godot's data structures.

Part of #16863 

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/1989.*