### PR TITLE
Make tool menu plugins use Callables for callback

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -130,14 +130,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="handler" type="Object">
-			</argument>
-			<argument index="2" name="callback" type="String">
-			</argument>
-			<argument index="3" name="ud" type="Variant" default="null">
+			<argument index="1" name="callable" type="Callable">
 			</argument>
 			<description>
-				Adds a custom menu item to [b]Project &gt; Tools[/b] as [code]name[/code] that calls [code]callback[/code] on an instance of [code]handler[/code] with a parameter [code]ud[/code] when user activates it.
+				Adds a custom menu item to [b]Project &gt; Tools[/b] named [code]name[/code]. When clicked, the provided [code]callable[/code] will be called.
 			</description>
 		</method>
 		<method name="add_tool_submenu_item">
@@ -148,7 +144,7 @@
 			<argument index="1" name="submenu" type="Object">
 			</argument>
 			<description>
-				Adds a custom submenu under [b]Project &gt; Tools &gt;[/b] [code]name[/code]. [code]submenu[/code] should be an object of class [PopupMenu]. This submenu should be cleaned up using [code]remove_tool_menu_item(name)[/code].
+				Adds a custom submenu under [b]Project &gt; Tools &gt;[/b] [code]name[/code]. [code]submenu[/code] should be an object of class [PopupMenu]. Use [code]remove_tool_menu_item(name)[/code] on plugin clean up to remove the menu.
 			</description>
 		</method>
 		<method name="add_translation_parser_plugin">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2743,16 +2743,13 @@ void EditorNode::_tool_menu_option(int p_idx) {
 		} break;
 		case TOOLS_CUSTOM: {
 			if (tool_menu->get_item_submenu(p_idx) == "") {
-				Array params = tool_menu->get_item_metadata(p_idx);
-
-				Object *handler = ObjectDB::get_instance(params[0]);
-				String callback = params[1];
-				Variant *ud = &params[2];
+				Callable callback = tool_menu->get_item_metadata(p_idx);
 				Callable::CallError ce;
+				Variant result;
+				callback.call(nullptr, 0, result, ce);
 
-				handler->call(callback, (const Variant **)&ud, 1, ce);
 				if (ce.error != Callable::CallError::CALL_OK) {
-					String err = Variant::get_call_error_text(handler, callback, (const Variant **)&ud, 1, ce);
+					String err = Variant::get_callable_error_text(callback, nullptr, 0, ce);
 					ERR_PRINT("Error calling function from tool menu: " + err);
 				}
 			} // else it's a submenu so don't do anything.
@@ -5086,17 +5083,10 @@ Variant EditorNode::drag_files_and_dirs(const Vector<String> &p_paths, Control *
 	return drag_data;
 }
 
-void EditorNode::add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud) {
-	ERR_FAIL_NULL(p_handler);
+void EditorNode::add_tool_menu_item(const String &p_name, const Callable &p_callback) {
 	int idx = tool_menu->get_item_count();
 	tool_menu->add_item(p_name, TOOLS_CUSTOM);
-
-	Array parameters;
-	parameters.push_back(p_handler->get_instance_id());
-	parameters.push_back(p_callback);
-	parameters.push_back(p_ud);
-
-	tool_menu->set_item_metadata(idx, parameters);
+	tool_menu->set_item_metadata(idx, p_callback);
 }
 
 void EditorNode::add_tool_submenu_item(const String &p_name, PopupMenu *p_submenu) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -830,7 +830,7 @@ public:
 	Variant drag_resource(const Ref<Resource> &p_res, Control *p_from);
 	Variant drag_files_and_dirs(const Vector<String> &p_paths, Control *p_from);
 
-	void add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud = Variant());
+	void add_tool_menu_item(const String &p_name, const Callable &p_callback);
 	void add_tool_submenu_item(const String &p_name, PopupMenu *p_submenu);
 	void remove_tool_menu_item(const String &p_name);
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -489,8 +489,8 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 	}
 }
 
-void EditorPlugin::add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud) {
-	EditorNode::get_singleton()->add_tool_menu_item(p_name, p_handler, p_callback, p_ud);
+void EditorPlugin::add_tool_menu_item(const String &p_name, const Callable &p_callable) {
+	EditorNode::get_singleton()->add_tool_menu_item(p_name, p_callable);
 }
 
 void EditorPlugin::add_tool_submenu_item(const String &p_name, Object *p_submenu) {
@@ -826,7 +826,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_control_from_docks", "control"), &EditorPlugin::remove_control_from_docks);
 	ClassDB::bind_method(D_METHOD("remove_control_from_bottom_panel", "control"), &EditorPlugin::remove_control_from_bottom_panel);
 	ClassDB::bind_method(D_METHOD("remove_control_from_container", "container", "control"), &EditorPlugin::remove_control_from_container);
-	ClassDB::bind_method(D_METHOD("add_tool_menu_item", "name", "handler", "callback", "ud"), &EditorPlugin::add_tool_menu_item, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("add_tool_menu_item", "name", "callable"), &EditorPlugin::add_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("add_tool_submenu_item", "name", "submenu"), &EditorPlugin::add_tool_submenu_item);
 	ClassDB::bind_method(D_METHOD("remove_tool_menu_item", "name"), &EditorPlugin::remove_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("add_custom_type", "type", "base", "script", "icon"), &EditorPlugin::add_custom_type);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -174,7 +174,7 @@ public:
 	void remove_control_from_docks(Control *p_control);
 	void remove_control_from_bottom_panel(Control *p_control);
 
-	void add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud = Variant());
+	void add_tool_menu_item(const String &p_name, const Callable &p_callable);
 	void add_tool_submenu_item(const String &p_name, Object *p_submenu);
 	void remove_tool_menu_item(const String &p_name);
 

--- a/platform/javascript/api/javascript_tools_editor_plugin.cpp
+++ b/platform/javascript/api/javascript_tools_editor_plugin.cpp
@@ -53,8 +53,7 @@ void JavaScriptToolsEditorPlugin::initialize() {
 }
 
 JavaScriptToolsEditorPlugin::JavaScriptToolsEditorPlugin(EditorNode *p_editor) {
-	Variant v;
-	add_tool_menu_item("Download Project Source", this, "_download_zip", v);
+	add_tool_menu_item("Download Project Source", callable_mp(this, &JavaScriptToolsEditorPlugin::_download_zip));
 }
 
 void JavaScriptToolsEditorPlugin::_download_zip(Variant p_v) {
@@ -71,10 +70,6 @@ void JavaScriptToolsEditorPlugin::_download_zip(Variant p_v) {
 	_zip_recursive(resource_path, base_path, zip);
 	zipClose(zip, NULL);
 	godot_js_editor_download_file("/tmp/project.zip", "project.zip", "application/zip");
-}
-
-void JavaScriptToolsEditorPlugin::_bind_methods() {
-	ClassDB::bind_method("_download_zip", &JavaScriptToolsEditorPlugin::_download_zip);
 }
 
 void JavaScriptToolsEditorPlugin::_zip_file(String p_path, String p_base_path, zipFile p_zip) {

--- a/platform/javascript/api/javascript_tools_editor_plugin.h
+++ b/platform/javascript/api/javascript_tools_editor_plugin.h
@@ -41,10 +41,6 @@ class JavaScriptToolsEditorPlugin : public EditorPlugin {
 private:
 	void _zip_file(String p_path, String p_base_path, zipFile p_zip);
 	void _zip_recursive(String p_path, String p_base_path, zipFile p_zip);
-
-protected:
-	static void _bind_methods();
-
 	void _download_zip(Variant p_v);
 
 public:


### PR DESCRIPTION
Supposed to close https://github.com/godotengine/godot-docs/issues/1638 by clarifying the doc a bit, but then I noticed that this method can be changed to Callables, so did that too. It also allowed for minor cleanup in JavaScriptToolsEditorPlugin.