### PR TITLE
fixes crash in disassembler for opcode OPCODE_ASSIGN_TYPED_NATIVE

### DIFF
--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -323,11 +323,8 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				incr += 4;
 			} break;
 			case OPCODE_ASSIGN_TYPED_NATIVE: {
-				Variant class_name = _constants_ptr[_code_ptr[ip + 3]];
-				GDScriptNativeClass *nc = Object::cast_to<GDScriptNativeClass>(class_name.operator Object *());
-
 				text += "assign typed native (";
-				text += nc->get_name().operator String();
+				text += DADDR(3);
 				text += ") ";
 				text += DADDR(1);
 				text += " = ";


### PR DESCRIPTION
@vnen This fixes this https://github.com/godotengine/godot/issues/44417 disassembler crash for the OPCODE_ASSIGN_TYPED_NATIVE opcode

*Bugsquad edit:* Fixes #44417.