### PR TITLE
Fix named anonymous struct warning

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -95,6 +95,15 @@
 static const double abs_resolution_mult = 10000.0;
 static const double abs_resolution_range_mult = 10.0;
 
+// Hints for X11 fullscreen
+struct Hints {
+	unsigned long flags = 0;
+	unsigned long functions = 0;
+	unsigned long decorations = 0;
+	long inputMode = 0;
+	unsigned long status = 0;
+};
+
 bool DisplayServerX11::has_feature(Feature p_feature) const {
 	switch (p_feature) {
 		case FEATURE_SUBWINDOWS:

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -61,15 +61,6 @@
 #include <X11/extensions/Xrandr.h>
 #include <X11/keysym.h>
 
-// Hints for X11 fullscreen
-typedef struct {
-	unsigned long flags = 0;
-	unsigned long functions = 0;
-	unsigned long decorations = 0;
-	long inputMode = 0;
-	unsigned long status = 0;
-} Hints;
-
 typedef struct _xrr_monitor_info {
 	Atom name;
 	Bool primary = false;


### PR DESCRIPTION
The clang compiler is complaining:
```
platform/linuxbsd/display_server_x11.h|65|warning: anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Wnon-c-typedef-for-linkage]|
platform/linuxbsd/display_server_x11.h|66|note: type is not C-compatible due to this default member initializer|
platform/linuxbsd/display_server_x11.h|71|note: type is given name 'Hints' for linkage purposes by this typedef declaration|
```
https://github.com/godotengine/godot/blob/92d4deedaa542e9458845fdf2b2a44fedd19fde8/platform/linuxbsd/display_server_x11.h#L65-L71

This is caused by a combination of issues:
1. The `struct` is anonymous
2. The `struct` is `typedef`ed to give it a name, which is a C structure supported by C++
3. The `struct` is initialised in the declaration, which is not supported by C

The `struct` is only used within the X11 display server: Its reference is static cast to an `unsigned char *` to be passed as a pointer to `data` in the Linux [`XChangeProperty()`](https://tronche.com/gui/x/xlib/window-information/XChangeProperty.html) function e.g:
https://github.com/godotengine/godot/blob/92d4deedaa542e9458845fdf2b2a44fedd19fde8/platform/linuxbsd/display_server_x11.cpp#L1410-L1417

It is later extracted via [`XGetWindowProperty()`](https://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html) and cast back:
https://github.com/godotengine/godot/blob/92d4deedaa542e9458845fdf2b2a44fedd19fde8/platform/linuxbsd/display_server_x11.cpp#L1718-L1721

It is never actually used as a C struct. Therefore, this PR does two things:
1. Names the `struct` and removes the `typedef` to make it a C++ `struct`
2. Moves the `struct` into the definition file to keep it local.
