### PR TITLE
Fix gdscript `and` operator

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -428,7 +428,7 @@ void GDScriptByteCodeGenerator::write_end_and(const Address &p_target) {
 	patch_jump(logic_op_jump_pos2.back()->get());
 	logic_op_jump_pos1.pop_back();
 	logic_op_jump_pos2.pop_back();
-	append(GDScriptFunction::OPCODE_ASSIGN_FALSE, 0);
+	append(GDScriptFunction::OPCODE_ASSIGN_FALSE, 1);
 	append(p_target);
 }
 
@@ -453,7 +453,7 @@ void GDScriptByteCodeGenerator::write_end_or(const Address &p_target) {
 	// Jump away from the success condition.
 	append(GDScriptFunction::OPCODE_JUMP, 0);
 	append(opcodes.size() + 3);
-	// Here it means one of operands is false.
+	// Here it means one of operands is true.
 	patch_jump(logic_op_jump_pos1.back()->get());
 	patch_jump(logic_op_jump_pos2.back()->get());
 	logic_op_jump_pos1.pop_back();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
I believe this fixes https://github.com/godotengine/godot/issues/43997
This was tested with the code here: https://github.com/godotengine/godot/issues/43997#issuecomment-745709493