### PR TITLE
Fix bitwise-and eval not updating return type

### DIFF
--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -318,6 +318,7 @@ public:
 		r_valid = true;
 	}
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) & *VariantGetInternalPtr<B>::get_ptr(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes https://github.com/godotengine/godot/issues/44411.
This was just a missing line of code in `OperatorEvaluatorBitAnd::validated_evaluate`. It's present in all other operator implementations of `validated_evaluate`.

Without this line of code, the bitwise-and operator tries to assign the return value as an int even if the `r_ret` variant isn't an int type. If `r_ret` happens to be an int it just works. But it is possible the variant is sometimes an array or other ref type which may crash the engine by modifying a freed ref.