### PR TITLE
Revert "Don't open editor window when using --export, --doctool, or --gdnative-generate-json-api"

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -703,8 +703,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			auto_build_solutions = true;
 			editor = true;
-			OS::get_singleton()->set_no_window_mode(true);
-			auto_quit = true;
 #ifdef DEBUG_METHODS_ENABLED
 		} else if (I->get() == "--gdnative-generate-json-api") {
 			// Register as an editor instance to use the GLES2 fallback automatically on hardware that doesn't support the GLES3 backend
@@ -712,17 +710,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			// We still pass it to the main arguments since the argument handling itself is not done in this function
 			main_args.push_back(I->get());
-
-			OS::get_singleton()->set_no_window_mode(true);
-			auto_quit = true;
 #endif
 		} else if (I->get() == "--export" || I->get() == "--export-debug" || I->get() == "--export-pack") { // Export project
 
 			editor = true;
 			main_args.push_back(I->get());
-
-			OS::get_singleton()->set_no_window_mode(true);
-			auto_quit = true;
 #endif
 		} else if (I->get() == "--path") { // set path of project to start or edit
 


### PR DESCRIPTION
This reverts commit 27393de36e2c3c0f1b5e16ca37aa8751e31880ca / PR #43948.

Fixes #44403.