### PR TITLE
Changed the rotation gizmo handle to use the active axis color

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2657,11 +2657,30 @@ void Node3DEditorViewport::_draw() {
 
 	if (_edit.mode == TRANSFORM_ROTATE) {
 		Point2 center = _point_to_screen(_edit.center);
+
+		Color handle_color;
+		switch (_edit.plane) {
+			case TRANSFORM_X_AXIS:
+				handle_color = get_theme_color("axis_x_color", "Editor");
+				break;
+			case TRANSFORM_Y_AXIS:
+				handle_color = get_theme_color("axis_y_color", "Editor");
+				break;
+			case TRANSFORM_Z_AXIS:
+				handle_color = get_theme_color("axis_z_color", "Editor");
+				break;
+			default:
+				handle_color = get_theme_color("accent_color", "Editor");
+				break;
+		}
+		handle_color.a = 1.0;
+		handle_color *= Color(1.3, 1.3, 1.3, 1.0);
+
 		RenderingServer::get_singleton()->canvas_item_add_line(
 				ci,
 				_edit.mouse_pos,
 				center,
-				get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.6),
+				handle_color,
 				Math::round(2 * EDSCALE));
 	}
 	if (previewing) {


### PR DESCRIPTION
This changes the rotation handle, so that it uses the same color as the currently rotating axis, similar to what Blender does. The colors of the rotation gizmo mesh and the handle line don't match 100% because of a bug outside of the scope of this PR (see #44425).

Before:
![before](https://user-images.githubusercontent.com/8750135/102358470-d2006500-3faf-11eb-826d-b3c0f56e0a10.gif)

After:
![after](https://user-images.githubusercontent.com/8750135/102358479-d462bf00-3faf-11eb-9fdf-bf648322221b.gif)