### PR TITLE
SCons: Add only selected platform's opts to env

### DIFF
--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -12,7 +12,6 @@ def get_name():
 
 
 def can_build():
-
     if sys.platform == "darwin" or ("OSXCROSS_IOS" in os.environ):
         return True
 
@@ -41,14 +40,12 @@ def get_opts():
 
 
 def get_flags():
-
     return [
         ("tools", False),
     ]
 
 
 def configure(env):
-
     ## Build type
 
     if env["target"].startswith("release"):

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -12,7 +12,6 @@ def get_name():
 
 
 def can_build():
-
     if os.name != "posix" or sys.platform == "darwin":
         return False
 
@@ -81,12 +80,10 @@ def get_opts():
 
 
 def get_flags():
-
     return []
 
 
 def configure(env):
-
     ## Build type
 
     if env["target"] == "release":

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -12,7 +12,6 @@ def get_name():
 
 
 def can_build():
-
     if sys.platform == "darwin" or ("OSXCROSS_ROOT" in os.environ):
         return True
 
@@ -31,6 +30,7 @@ def get_opts():
             " validation layers)",
             False,
         ),
+        EnumVariable("macports_clang", "Build using Clang from MacPorts", "no", ("no", "5.0", "devel")),
         EnumVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", "yes", ("yes", "no")),
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
@@ -40,12 +40,10 @@ def get_opts():
 
 
 def get_flags():
-
     return []
 
 
 def configure(env):
-
     ## Build type
 
     if env["target"] == "release":

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -21,7 +21,6 @@ def get_program_suffix():
 
 
 def can_build():
-
     if os.name != "posix":
         return False
 
@@ -46,7 +45,6 @@ def get_opts():
 
 
 def get_flags():
-
     return []
 
 

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -30,7 +30,6 @@ def get_opts():
 
 
 def get_flags():
-
     return [
         ("tools", False),
         ("xaudio2", True),
@@ -39,7 +38,6 @@ def get_flags():
 
 
 def configure(env):
-
     env.msvc = True
 
     if env["bits"] != "default":

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -68,7 +68,7 @@ def get_opts():
         EnumVariable("windows_subsystem", "Windows subsystem", "default", ("default", "console", "gui")),
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         ("msvc_version", "MSVC version to use. Ignored if VCINSTALLDIR is set in shell env.", None),
-        BoolVariable("use_mingw", "Use the Mingw compiler, even if MSVC is installed. Only used on Windows.", False),
+        BoolVariable("use_mingw", "Use the Mingw compiler, even if MSVC is installed.", False),
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
         BoolVariable("use_thinlto", "Use ThinLTO", False),
         BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True),
@@ -76,12 +76,10 @@ def get_opts():
 
 
 def get_flags():
-
     return []
 
 
 def build_res_file(target, source, env):
-
     if env["bits"] == "32":
         cmdbase = env["mingw_prefix_32"]
     else:


### PR DESCRIPTION
Otherwise we can get situations where platform-specific opts with the same name
can override each other depending on the order at which platforms are parsed,
as was the case with `use_static_cpp` in Linux/Windows.

Fixes #44304.

This also has the added benefit that the `scons --help` output will now only
include the options which are relevant for the selected (or detected) platform.