### PR TITLE
Use `int64_t` instead of `long` for consistency across platforms

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -440,7 +440,7 @@ Dictionary _OS::get_datetime_from_unix_time(int64_t unix_time_val) const {
 	OS::Date date;
 	OS::Time time;
 
-	long dayclock, dayno;
+	int64_t dayclock, dayno;
 	int year = EPOCH_YR;
 
 	if (unix_time_val >= 0) {

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -576,7 +576,7 @@ public:
 			return Vector<Vector3>(); // Empty.
 		}
 
-		long previous = polygon.size() - 1;
+		int64_t previous = polygon.size() - 1;
 		Vector<Vector3> clipped;
 
 		for (int index = 0; index < polygon.size(); index++) {

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -204,7 +204,7 @@ void FileAccessUnix::seek_end(int64_t p_position) {
 size_t FileAccessUnix::get_position() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 
-	long pos = ftell(f);
+	int64_t pos = ftell(f);
 	if (pos < 0) {
 		check_errors();
 		ERR_FAIL_V(0);
@@ -215,10 +215,10 @@ size_t FileAccessUnix::get_position() const {
 size_t FileAccessUnix::get_len() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 
-	long pos = ftell(f);
+	int64_t pos = ftell(f);
 	ERR_FAIL_COND_V(pos < 0, 0);
 	ERR_FAIL_COND_V(fseek(f, 0, SEEK_END), 0);
-	long size = ftell(f);
+	int64_t size = ftell(f);
 	ERR_FAIL_COND_V(size < 0, 0);
 	ERR_FAIL_COND_V(fseek(f, pos, SEEK_SET), 0);
 

--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -47,7 +47,7 @@ godot_int GDAPI godot_videodecoder_file_read(void *ptr, uint8_t *buf, int buf_si
 
 	// if file exists
 	if (file) {
-		long bytes_read = file->get_buffer(buf, buf_size);
+		int64_t bytes_read = file->get_buffer(buf, buf_size);
 		// No bytes to read => EOF
 		if (bytes_read == 0) {
 			return 0;

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -2726,7 +2726,7 @@ public:
 			// read
 			int method, level;
 			unzOpenCurrentFile2(tmp_unaligned, &method, &level, 1); // raw read
-			long file_offset = unzGetCurrentFileZStreamPos64(tmp_unaligned);
+			int64_t file_offset = unzGetCurrentFileZStreamPos64(tmp_unaligned);
 			unzReadCurrentFile(tmp_unaligned, data.ptrw(), data.size());
 			unzCloseCurrentFile(tmp_unaligned);
 
@@ -2734,7 +2734,7 @@ public:
 			int padding = 0;
 			if (!info.compression_method) {
 				// Uncompressed file => Align
-				long new_offset = file_offset + bias;
+				int64_t new_offset = file_offset + bias;
 				padding = (ZIP_ALIGNMENT - (new_offset % ZIP_ALIGNMENT)) % ZIP_ALIGNMENT;
 			}
 

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -100,7 +100,7 @@ struct Hints {
 	unsigned long flags = 0;
 	unsigned long functions = 0;
 	unsigned long decorations = 0;
-	long inputMode = 0;
+	int64_t inputMode = 0;
 	unsigned long status = 0;
 };
 
@@ -1173,7 +1173,7 @@ void DisplayServerX11::window_set_position(const Point2i &p_position, WindowID p
 			unsigned char *data = nullptr;
 			if (XGetWindowProperty(x11_display, wd.x11_window, prop, 0, 4, False, AnyPropertyType, &type, &format, &len, &remaining, &data) == Success) {
 				if (format == 32 && len == 4 && data) {
-					long *extents = (long *)data;
+					int64_t *extents = (int64_t *)data;
 					x = extents[0];
 					y = extents[2];
 				}
@@ -1305,7 +1305,7 @@ Size2i DisplayServerX11::window_get_real_size(WindowID p_window) const {
 		unsigned char *data = nullptr;
 		if (XGetWindowProperty(x11_display, wd.x11_window, prop, 0, 4, False, AnyPropertyType, &type, &format, &len, &remaining, &data) == Success) {
 			if (format == 32 && len == 4 && data) {
-				long *extents = (long *)data;
+				int64_t *extents = (int64_t *)data;
 				w += extents[0] + extents[1]; // left, right
 				h += extents[2] + extents[3]; // top, bottom
 			}
@@ -1628,7 +1628,7 @@ DisplayServer::WindowMode DisplayServerX11::window_get_mode(WindowID p_window) c
 				&data);
 
 		if (result == Success && data) {
-			long *state = (long *)data;
+			int64_t *state = (int64_t *)data;
 			if (state[0] == WM_IconicState) {
 				XFree(data);
 				return WINDOW_MODE_MINIMIZED;
@@ -3590,11 +3590,11 @@ void DisplayServerX11::set_icon(const Ref<Image> &p_icon) {
 
 			const uint8_t *r = img->get_data().ptr();
 
-			long *wr = &pd.write[2];
+			int64_t *wr = &pd.write[2];
 			uint8_t const *pr = r;
 
 			for (int i = 0; i < w * h; i++) {
-				long v = 0;
+				int64_t v = 0;
 				//    A             R             G            B
 				v |= pr[3] << 24 | pr[0] << 16 | pr[1] << 8 | pr[2];
 				*wr++ = v;
@@ -3643,7 +3643,7 @@ DisplayServer *DisplayServerX11::create_func(const String &p_rendering_driver, W
 DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, uint32_t p_flags, const Rect2i &p_rect) {
 	//Create window
 
-	long visualMask = VisualScreenMask;
+	int64_t visualMask = VisualScreenMask;
 	int numberOfVisuals;
 	XVisualInfo vInfoTemplate = {};
 	vInfoTemplate.screen = DefaultScreen(x11_display);
@@ -3701,7 +3701,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, u
 			}
 		}
 
-		long im_event_mask = 0;
+		int64_t im_event_mask = 0;
 
 		{
 			XIEventMask all_event_mask;

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -41,7 +41,7 @@
 #include <libudev.h>
 #endif
 
-#define LONG_BITS (sizeof(long) * 8)
+#define LONG_BITS (sizeof(int64_t) * 8)
 #define test_bit(nr, addr) (((1UL << ((nr) % LONG_BITS)) & ((addr)[(nr) / LONG_BITS])) != 0)
 #define NBITS(x) ((((x)-1) / LONG_BITS) + 1)
 

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -533,7 +533,7 @@ Error AudioStreamSample::save_to_wav(const String &p_path) {
 
 	int n_channels = stereo ? 2 : 1;
 
-	long sample_rate = mix_rate;
+	int64_t sample_rate = mix_rate;
 
 	int byte_pr_sample = 0;
 	switch (format) {

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -86,7 +86,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 
 	double magn, phase, tmp, window, real, imag;
 	double freqPerBin, expct;
-	long i,k, qpd, index, inFifoLatency, stepSize, fftFrameSize2;
+	int64_t i,k, qpd, index, inFifoLatency, stepSize, fftFrameSize2;
 
 	/* set up some handy variables */
 	fftFrameSize2 = fftFrameSize/2;
@@ -240,7 +240,7 @@ void SMBPitchShift::smbFft(float *fftBuffer, long fftFrameSize, long sign)
 {
 	float wr, wi, arg, *p1, *p2, temp;
 	float tr, ti, ur, ui, *p1r, *p1i, *p2r, *p2i;
-	long i, bitm, j, le, le2, k;
+	int64_t i, bitm, j, le, le2, k;
 
 	for (i = 2; i < 2*fftFrameSize-2; i += 2) {
 		for (bitm = 2, j = 0; bitm < 2*fftFrameSize; bitm <<= 1) {
@@ -255,7 +255,7 @@ void SMBPitchShift::smbFft(float *fftBuffer, long fftFrameSize, long sign)
 			*p1 = *p2; *p2 = temp;
 		}
 	}
-	for (k = 0, le = 2; k < (long)(log((double)fftFrameSize)/log(2.)+.5); k++) {
+	for (k = 0, le = 2; k < (int64_t)(log((double)fftFrameSize)/log(2.)+.5); k++) {
 		le <<= 1;
 		le2 = le>>1;
 		ur = 1.0;

--- a/servers/audio/effects/audio_effect_pitch_shift.h
+++ b/servers/audio/effects/audio_effect_pitch_shift.h
@@ -48,7 +48,7 @@ class SMBPitchShift {
 	float gAnaMagn[MAX_FRAME_LENGTH];
 	float gSynFreq[MAX_FRAME_LENGTH];
 	float gSynMagn[MAX_FRAME_LENGTH];
-	long gRover;
+	int64_t gRover;
 
 	void smbFft(float *fftBuffer, long fftFrameSize, long sign);
 

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -46,7 +46,7 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 {
 	float wr, wi, arg, *p1, *p2, temp;
 	float tr, ti, ur, ui, *p1r, *p1i, *p2r, *p2i;
-	long i, bitm, j, le, le2, k;
+	int64_t i, bitm, j, le, le2, k;
 
 	for (i = 2; i < 2 * fftFrameSize - 2; i += 2) {
 		for (bitm = 2, j = 0; bitm < 2 * fftFrameSize; bitm <<= 1) {
@@ -66,7 +66,7 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 			*p2 = temp;
 		}
 	}
-	for (k = 0, le = 2; k < (long)(log((double)fftFrameSize) / log(2.) + .5); k++) {
+	for (k = 0, le = 2; k < (int64_t)(log((double)fftFrameSize) / log(2.) + .5); k++) {
 		le <<= 1;
 		le2 = le >> 1;
 		ur = 1.0;


### PR DESCRIPTION
`long` means different things on Windows and UNIX. It's equal to `int32_t` on Windows and `int64_t` on UNIX.

This closes #25652.