### PR TITLE
Disallow integer vector multiplication/division with floats

### DIFF
--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -94,9 +94,7 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorMul<double, double, double>>(Variant::OP_MULTIPLY, Variant::FLOAT, Variant::FLOAT);
 	register_op<OperatorEvaluatorMul<double, double, int64_t>>(Variant::OP_MULTIPLY, Variant::FLOAT, Variant::INT);
 	register_op<OperatorEvaluatorMul<Vector2, double, Vector2>>(Variant::OP_MULTIPLY, Variant::FLOAT, Variant::VECTOR2);
-	register_op<OperatorEvaluatorMul<Vector2i, double, Vector2i>>(Variant::OP_MULTIPLY, Variant::FLOAT, Variant::VECTOR2I);
 	register_op<OperatorEvaluatorMul<Vector3, double, Vector3>>(Variant::OP_MULTIPLY, Variant::FLOAT, Variant::VECTOR3);
-	register_op<OperatorEvaluatorMul<Vector3i, double, Vector3i>>(Variant::OP_MULTIPLY, Variant::FLOAT, Variant::VECTOR3I);
 
 	register_op<OperatorEvaluatorMul<Vector2, Vector2, Vector2>>(Variant::OP_MULTIPLY, Variant::VECTOR2, Variant::VECTOR2);
 	register_op<OperatorEvaluatorMul<Vector2, Vector2, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR2, Variant::INT);
@@ -104,7 +102,6 @@ void Variant::_register_variant_operators() {
 
 	register_op<OperatorEvaluatorMul<Vector2i, Vector2i, Vector2i>>(Variant::OP_MULTIPLY, Variant::VECTOR2I, Variant::VECTOR2I);
 	register_op<OperatorEvaluatorMul<Vector2i, Vector2i, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR2I, Variant::INT);
-	register_op<OperatorEvaluatorMul<Vector2i, Vector2i, double>>(Variant::OP_MULTIPLY, Variant::VECTOR2I, Variant::FLOAT);
 
 	register_op<OperatorEvaluatorMul<Vector3, Vector3, Vector3>>(Variant::OP_MULTIPLY, Variant::VECTOR3, Variant::VECTOR3);
 	register_op<OperatorEvaluatorMul<Vector3, Vector3, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR3, Variant::INT);
@@ -112,7 +109,6 @@ void Variant::_register_variant_operators() {
 
 	register_op<OperatorEvaluatorMul<Vector3i, Vector3i, Vector3i>>(Variant::OP_MULTIPLY, Variant::VECTOR3I, Variant::VECTOR3I);
 	register_op<OperatorEvaluatorMul<Vector3i, Vector3i, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR3I, Variant::INT);
-	register_op<OperatorEvaluatorMul<Vector3i, Vector3i, double>>(Variant::OP_MULTIPLY, Variant::VECTOR3I, Variant::FLOAT);
 
 	register_op<OperatorEvaluatorMul<Quaternion, Quaternion, Quaternion>>(Variant::OP_MULTIPLY, Variant::QUATERNION, Variant::QUATERNION);
 	register_op<OperatorEvaluatorMul<Quaternion, Quaternion, int64_t>>(Variant::OP_MULTIPLY, Variant::QUATERNION, Variant::INT);
@@ -172,19 +168,13 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorDiv<Vector2, Vector2, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR2, Variant::INT);
 
 	register_op<OperatorEvaluatorDivNZ<Vector2i, Vector2i, Vector2i>>(Variant::OP_DIVIDE, Variant::VECTOR2I, Variant::VECTOR2I);
-	register_op<OperatorEvaluatorDivNZ<Vector2i, Vector2i, double>>(Variant::OP_DIVIDE, Variant::VECTOR2I, Variant::FLOAT);
 	register_op<OperatorEvaluatorDivNZ<Vector2i, Vector2i, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR2I, Variant::INT);
-
-	register_op<OperatorEvaluatorDiv<Vector2, Vector2, Vector2>>(Variant::OP_DIVIDE, Variant::VECTOR2, Variant::VECTOR2);
-	register_op<OperatorEvaluatorDiv<Vector2, Vector2, double>>(Variant::OP_DIVIDE, Variant::VECTOR2, Variant::FLOAT);
-	register_op<OperatorEvaluatorDiv<Vector2, Vector2, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR2, Variant::INT);
 
 	register_op<OperatorEvaluatorDiv<Vector3, Vector3, Vector3>>(Variant::OP_DIVIDE, Variant::VECTOR3, Variant::VECTOR3);
 	register_op<OperatorEvaluatorDiv<Vector3, Vector3, double>>(Variant::OP_DIVIDE, Variant::VECTOR3, Variant::FLOAT);
 	register_op<OperatorEvaluatorDiv<Vector3, Vector3, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR3, Variant::INT);
 
 	register_op<OperatorEvaluatorDivNZ<Vector3i, Vector3i, Vector3i>>(Variant::OP_DIVIDE, Variant::VECTOR3I, Variant::VECTOR3I);
-	register_op<OperatorEvaluatorDivNZ<Vector3i, Vector3i, double>>(Variant::OP_DIVIDE, Variant::VECTOR3I, Variant::FLOAT);
 	register_op<OperatorEvaluatorDivNZ<Vector3i, Vector3i, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR3I, Variant::INT);
 
 	register_op<OperatorEvaluatorDiv<Quaternion, Quaternion, double>>(Variant::OP_DIVIDE, Variant::QUATERNION, Variant::FLOAT);

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -175,16 +175,6 @@
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2i" />
-			<argument index="0" name="right" type="float" />
-			<description>
-				Multiplies each component of the [Vector2i] by the given [float] truncated to an integer.
-				[codeblock]
-				print(Vector2i(10, 20) * 0.9) # Prints "(0, 0)"
-				[/codeblock]
-			</description>
-		</operator>
-		<operator name="operator *">
-			<return type="Vector2i" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Multiplies each component of the [Vector2i] by the given [int].
@@ -217,16 +207,6 @@
 				Divides each component of the [Vector2i] by the components of the given [Vector2i].
 				[codeblock]
 				print(Vector2i(10, 20) / Vector2i(2, 5)) # Prints "(5, 4)"
-				[/codeblock]
-			</description>
-		</operator>
-		<operator name="operator /">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="float" />
-			<description>
-				Divides each component of the [Vector2i] by the given [float] truncated to an integer.
-				[codeblock]
-				print(Vector2i(10, 20) / 2.9) # Prints "(5, 10)"
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -181,16 +181,6 @@
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3i" />
-			<argument index="0" name="right" type="float" />
-			<description>
-				Multiplies each component of the [Vector3i] by the given [float] truncated to an integer.
-				[codeblock]
-				print(Vector3i(10, 20, 30) * 0.9) # Prints "(0, 0, 0)"
-				[/codeblock]
-			</description>
-		</operator>
-		<operator name="operator *">
-			<return type="Vector3i" />
 			<argument index="0" name="right" type="int" />
 			<description>
 				Multiplies each component of the [Vector3i] by the given [int].
@@ -223,16 +213,6 @@
 				Divides each component of the [Vector3i] by the components of the given [Vector3i].
 				[codeblock]
 				print(Vector3i(10, 20, 30) / Vector3i(2, 5, 3)) # Prints "(5, 4, 10)"
-				[/codeblock]
-			</description>
-		</operator>
-		<operator name="operator /">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="float" />
-			<description>
-				Divides each component of the [Vector3i] by the given [float] truncated to an integer.
-				[codeblock]
-				print(Vector3i(10, 20, 30) / 2.9) # Prints "(5, 10, 15)"
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -89,30 +89,10 @@
 			</description>
 		</operator>
 		<operator name="operator *">
-			<return type="Vector2i" />
-			<argument index="0" name="right" type="Vector2i" />
-			<description>
-				Multiplies each component of the [Vector2i] by the given [float] truncated to an integer.
-				[codeblock]
-				print(0.9 * Vector2i(10, 20)) # Prints "(0, 0)"
-				[/codeblock]
-			</description>
-		</operator>
-		<operator name="operator *">
 			<return type="Vector3" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
 				Multiplies each component of the [Vector3] by the given [float].
-			</description>
-		</operator>
-		<operator name="operator *">
-			<return type="Vector3i" />
-			<argument index="0" name="right" type="Vector3i" />
-			<description>
-				Multiplies each component of the [Vector3i] by the given [float] truncated to an integer.
-				[codeblock]
-				print(0.9 * Vector3i(10, 20, 30)) # Prints "(0, 0, 0)"
-				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">


### PR DESCRIPTION
Fixes-ish #44408 by disallowing the operation and requiring users to be explicit. Instead of this:

```gdscript
print(Vector2i(256, 256) * 0.9) # In master prints (0, 0), which may not be intentional.
```

You can do this:

```gdscript
print(Vector2i(Vector2(256, 256) * 0.9)) # Prints (230, 230)
```

Or this:

```gdscript
print(Vector2(256, 256) * 0.9) # Prints (230.4, 230.4), actually 230.399994 due to imprecision.
```

Or this:

```gdscript
print(Vector2i(256, 256) * int(0.9)) # Prints (0, 0)
```