### PR TITLE
Fix crash parsing a serialized Reference

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -743,6 +743,8 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				return ERR_PARSE_ERROR;
 			}
 
+			REF ref = REF(Object::cast_to<Reference>(obj));
+
 			get_token(p_stream, token, line, r_err_str);
 			if (token.type != TK_COMMA) {
 				r_err_str = "Expected ',' after object type";
@@ -767,12 +769,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 					}
 
 					if (token2.type == TK_PARENTHESIS_CLOSE) {
-						Reference *reference = Object::cast_to<Reference>(obj);
-						if (reference) {
-							value = REF(reference);
-						} else {
-							value = obj;
-						}
+						value = ref.is_valid() ? Variant(ref) : Variant(obj);
 						return OK;
 					}
 


### PR DESCRIPTION
Yet another case of a `Reference` being referenced too late.

Fixes #44447.

**NOTE:** Submitting separare version for 3.2 (since local cherry-picking failed).