### PR TITLE
[3.2] Lightness of dynamic objects from Energy BakedLightmapData

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1306,10 +1306,15 @@ void VisualServerScene::_update_instance_lightmap_captures(Instance *p_instance)
 
 		Vector3 pos = to_cell_xform.xform(p_instance->transform.origin);
 
+		const float capture_energy = VSG::storage->lightmap_capture_get_energy(E->get()->base);
+
 		for (int i = 0; i < 12; i++) {
 
 			Vector3 dir = to_cell_xform.basis.xform(cone_traces[i]).normalized();
 			Color capture = _light_capture_voxel_cone_trace(octree_r.ptr(), pos, dir, cone_aperture, cell_subdiv);
+			capture.r *= capture_energy;
+			capture.g *= capture_energy;
+			capture.b *= capture_energy;
 			p_instance->lightmap_capture_data.write[i] += capture;
 		}
 	}


### PR DESCRIPTION
Added the effect of Energy BakedLightmapData on dynamic objects.

![image](https://user-images.githubusercontent.com/75580200/102509135-c3ea3b80-40b8-11eb-91b6-45276d099bf9.png)
![image](https://user-images.githubusercontent.com/75580200/102509456-26dbd280-40b9-11eb-84c6-5c5d9c81368d.png)

On the GIF: cubes are dynamic objects.

![gd_capture_energy](https://user-images.githubusercontent.com/75580200/102509710-6efaf500-40b9-11eb-81ad-c78dd23eeed5.gif)

Works well in a running game.
In the editor, for the changes to the Energy parameter to take effect, you need to turn off and on the visibility of BakedLightmap.

![image](https://user-images.githubusercontent.com/75580200/102509556-4246dd80-40b9-11eb-9825-bb8732eef2f3.png)

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/1952.
