### PR TITLE
Remove OS::can_draw() remnants

### DIFF
--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -150,10 +150,6 @@ void OS_Server::set_main_loop(MainLoop *p_main_loop) {
 	input->set_main_loop(p_main_loop);
 }
 
-bool OS_Server::can_draw() const {
-	return false; //can never draw
-};
-
 String OS_Server::get_name() const {
 	return "Server";
 }

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -89,8 +89,6 @@ public:
 
 	virtual MainLoop *get_main_loop() const;
 
-	virtual bool can_draw() const;
-
 	virtual void set_video_mode(const VideoMode &p_video_mode, int p_screen = 0);
 	virtual VideoMode get_video_mode(int p_screen = 0) const;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen = 0) const;

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -156,10 +156,6 @@ void OS_UWP::initialize_core() {
 	cursor_shape = CURSOR_ARROW;
 }
 
-bool OS_UWP::can_draw() const {
-	return !minimized;
-};
-
 void OS_UWP::set_window(Windows::UI::Core::CoreWindow ^ p_window) {
 	window = p_window;
 }

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -194,7 +194,6 @@ public:
 	virtual TimeZoneInfo get_time_zone_info() const;
 	virtual uint64_t get_unix_time() const;
 
-	virtual bool can_draw() const;
 	virtual Error set_cwd(const String &p_cwd);
 
 	virtual void delay_usec(uint32_t p_usec) const;


### PR DESCRIPTION
Moving `OS::can_draw()` is part of #16863. Most of it was done as part of #37317 and the subsequent implementations of `DisplayServer` for the various platforms, but some remnants remain. This PR removes those remnants.
