### PR TITLE
Add missing override keywords to core/os.h derived classes

### DIFF
--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -45,7 +45,7 @@ protected:
 	virtual int unix_initialize_audio(int p_audio_driver);
 	//virtual Error initialize(int p_video_driver,int p_audio_driver);
 
-	virtual void finalize_core();
+	virtual void finalize_core() override;
 
 	String stdin_buf;
 
@@ -53,7 +53,7 @@ public:
 	OS_Unix();
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
-	virtual String get_stdin_string(bool p_block);
+	virtual String get_stdin_string(bool p_block) override;
 
 	//virtual void set_mouse_show(bool p_show);
 	//virtual void set_mouse_grab(bool p_grab);
@@ -65,39 +65,39 @@ public:
 	//virtual VideoMode get_video_mode() const;
 	//virtual void get_fullscreen_mode_list(List<VideoMode> *p_list) const;
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
-	virtual Error close_dynamic_library(void *p_library_handle);
-	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false);
+	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false) override;
+	virtual Error close_dynamic_library(void *p_library_handle) override;
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false) override;
 
-	virtual Error set_cwd(const String &p_cwd);
+	virtual Error set_cwd(const String &p_cwd) override;
 
-	virtual String get_name() const;
+	virtual String get_name() const override;
 
-	virtual Date get_date(bool utc) const;
-	virtual Time get_time(bool utc) const;
-	virtual TimeZoneInfo get_time_zone_info() const;
+	virtual Date get_date(bool utc) const override;
+	virtual Time get_time(bool utc) const override;
+	virtual TimeZoneInfo get_time_zone_info() const override;
 
-	virtual double get_unix_time() const;
+	virtual double get_unix_time() const override;
 
-	virtual void delay_usec(uint32_t p_usec) const;
-	virtual uint64_t get_ticks_usec() const;
+	virtual void delay_usec(uint32_t p_usec) const override;
+	virtual uint64_t get_ticks_usec() const override;
 
-	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr);
-	virtual Error kill(const ProcessID &p_pid);
-	virtual int get_process_id() const;
+	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr) override;
+	virtual Error kill(const ProcessID &p_pid) override;
+	virtual int get_process_id() const override;
 
-	virtual bool has_environment(const String &p_var) const;
-	virtual String get_environment(const String &p_var) const;
-	virtual bool set_environment(const String &p_var, const String &p_value) const;
-	virtual String get_locale() const;
+	virtual bool has_environment(const String &p_var) const override;
+	virtual String get_environment(const String &p_var) const override;
+	virtual bool set_environment(const String &p_var, const String &p_value) const override;
+	virtual String get_locale() const override;
 
-	virtual int get_processor_count() const;
+	virtual int get_processor_count() const override;
 
-	virtual void debug_break();
-	virtual void initialize_debugging();
+	virtual void debug_break() override;
+	virtual void initialize_debugging() override;
 
-	virtual String get_executable_path() const;
-	virtual String get_user_data_dir() const;
+	virtual String get_executable_path() const override;
+	virtual String get_user_data_dir() const override;
 };
 
 class UnixTerminalLogger : public StdLogger {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -68,15 +68,15 @@ private:
 	GodotIOJavaWrapper *godot_io_java;
 
 public:
-	virtual void initialize_core();
-	virtual void initialize();
+	virtual void initialize_core() override;
+	virtual void initialize() override;
 
-	virtual void initialize_joypads();
+	virtual void initialize_joypads() override;
 
-	virtual void set_main_loop(MainLoop *p_main_loop);
-	virtual void delete_main_loop();
+	virtual void set_main_loop(MainLoop *p_main_loop) override;
+	virtual void delete_main_loop() override;
 
-	virtual void finalize();
+	virtual void finalize() override;
 
 	typedef int64_t ProcessID;
 
@@ -84,14 +84,14 @@ public:
 	GodotJavaWrapper *get_godot_java();
 	GodotIOJavaWrapper *get_godot_io_java();
 
-	virtual bool request_permission(const String &p_name);
-	virtual bool request_permissions();
-	virtual Vector<String> get_granted_permissions() const;
+	virtual bool request_permission(const String &p_name) override;
+	virtual bool request_permissions() override;
+	virtual Vector<String> get_granted_permissions() const override;
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
+	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false) override;
 
-	virtual String get_name() const;
-	virtual MainLoop *get_main_loop() const;
+	virtual String get_name() const override;
+	virtual MainLoop *get_main_loop() const override;
 
 	void main_loop_begin();
 	bool main_loop_iterate();
@@ -109,19 +109,19 @@ public:
 	void set_native_window(ANativeWindow *p_native_window);
 	ANativeWindow *get_native_window() const;
 
-	virtual Error shell_open(String p_uri);
-	virtual String get_user_data_dir() const;
-	virtual String get_resource_dir() const;
-	virtual String get_locale() const;
-	virtual String get_model_name() const;
+	virtual Error shell_open(String p_uri) override;
+	virtual String get_user_data_dir() const override;
+	virtual String get_resource_dir() const override;
+	virtual String get_locale() const override;
+	virtual String get_model_name() const override;
 
-	virtual String get_unique_id() const;
+	virtual String get_unique_id() const override;
 
-	virtual String get_system_dir(SystemDir p_dir) const;
+	virtual String get_system_dir(SystemDir p_dir) const override;
 
-	void vibrate_handheld(int p_duration_ms);
+	void vibrate_handheld(int p_duration_ms) override;
 
-	virtual bool _check_internal_feature_support(const String &p_feature);
+	virtual bool _check_internal_feature_support(const String &p_feature) override;
 	OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion);
 	~OS_Android();
 };

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -43,7 +43,7 @@
 #include "servers/rendering_server.h"
 
 class OS_LinuxBSD : public OS_Unix {
-	virtual void delete_main_loop();
+	virtual void delete_main_loop() override;
 
 	bool force_quit;
 
@@ -68,36 +68,36 @@ class OS_LinuxBSD : public OS_Unix {
 	MainLoop *main_loop;
 
 protected:
-	virtual void initialize();
-	virtual void finalize();
+	virtual void initialize() override;
+	virtual void finalize() override;
 
-	virtual void initialize_joypads();
+	virtual void initialize_joypads() override;
 
-	virtual void set_main_loop(MainLoop *p_main_loop);
+	virtual void set_main_loop(MainLoop *p_main_loop) override;
 
 public:
-	virtual String get_name() const;
+	virtual String get_name() const override;
 
-	virtual MainLoop *get_main_loop() const;
+	virtual MainLoop *get_main_loop() const override;
 
-	virtual String get_config_path() const;
-	virtual String get_data_path() const;
-	virtual String get_cache_path() const;
+	virtual String get_config_path() const override;
+	virtual String get_data_path() const override;
+	virtual String get_cache_path() const override;
 
-	virtual String get_system_dir(SystemDir p_dir) const;
+	virtual String get_system_dir(SystemDir p_dir) const override;
 
-	virtual Error shell_open(String p_uri);
+	virtual Error shell_open(String p_uri) override;
 
-	virtual String get_unique_id() const;
+	virtual String get_unique_id() const override;
 
-	virtual bool _check_internal_feature_support(const String &p_feature);
+	virtual bool _check_internal_feature_support(const String &p_feature) override;
 
 	void run();
 
-	void disable_crash_handler();
-	bool is_disable_crash_handler() const;
+	virtual void disable_crash_handler() override;
+	virtual bool is_disable_crash_handler() const override;
 
-	virtual Error move_to_trash(const String &p_path);
+	virtual Error move_to_trash(const String &p_path) override;
 
 	OS_LinuxBSD();
 };

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -40,7 +40,7 @@
 #include "servers/audio_server.h"
 
 class OS_OSX : public OS_Unix {
-	virtual void delete_main_loop();
+	virtual void delete_main_loop() override;
 
 	bool force_quit;
 
@@ -61,45 +61,45 @@ public:
 	String open_with_filename;
 
 protected:
-	virtual void initialize_core();
-	virtual void initialize();
-	virtual void finalize();
+	virtual void initialize_core() override;
+	virtual void initialize() override;
+	virtual void finalize() override;
 
-	virtual void initialize_joypads();
+	virtual void initialize_joypads() override;
 
-	virtual void set_main_loop(MainLoop *p_main_loop);
+	virtual void set_main_loop(MainLoop *p_main_loop) override;
 
 public:
-	virtual String get_name() const;
+	virtual String get_name() const override;
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
+	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false) override;
 
-	virtual MainLoop *get_main_loop() const;
+	virtual MainLoop *get_main_loop() const override;
 
-	virtual String get_config_path() const;
-	virtual String get_data_path() const;
-	virtual String get_cache_path() const;
-	virtual String get_bundle_resource_dir() const;
-	virtual String get_godot_dir_name() const;
+	virtual String get_config_path() const override;
+	virtual String get_data_path() const override;
+	virtual String get_cache_path() const override;
+	virtual String get_bundle_resource_dir() const override;
+	virtual String get_godot_dir_name() const override;
 
-	virtual String get_system_dir(SystemDir p_dir) const;
+	virtual String get_system_dir(SystemDir p_dir) const override;
 
-	Error shell_open(String p_uri);
+	Error shell_open(String p_uri) override;
 
-	String get_locale() const;
+	String get_locale() const override;
 
-	virtual String get_executable_path() const;
+	virtual String get_executable_path() const override;
 
-	virtual String get_unique_id() const; //++
+	virtual String get_unique_id() const override; //++
 
-	virtual bool _check_internal_feature_support(const String &p_feature);
+	virtual bool _check_internal_feature_support(const String &p_feature) override;
 
 	void run();
 
-	void disable_crash_handler();
-	bool is_disable_crash_handler() const;
+	virtual void disable_crash_handler() override;
+	virtual bool is_disable_crash_handler() const override;
 
-	virtual Error move_to_trash(const String &p_path);
+	virtual Error move_to_trash(const String &p_path) override;
 
 	OS_OSX();
 };

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -93,14 +93,14 @@ class OS_Windows : public OS {
 
 	// functions used by main to initialize/deinitialize the OS
 protected:
-	virtual void initialize();
+	virtual void initialize() override;
 
-	virtual void set_main_loop(MainLoop *p_main_loop);
-	virtual void delete_main_loop();
+	virtual void set_main_loop(MainLoop *p_main_loop) override;
+	virtual void delete_main_loop() override;
 
-	virtual void finalize();
-	virtual void finalize_core();
-	virtual String get_stdin_string(bool p_block);
+	virtual void finalize() override;
+	virtual void finalize_core() override;
+	virtual String get_stdin_string(bool p_block) override;
 
 	String _quote_command_line_argument(const String &p_text) const;
 
@@ -111,66 +111,66 @@ protected:
 	Map<ProcessID, ProcessInfo> *process_map;
 
 public:
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
-	virtual Error close_dynamic_library(void *p_library_handle);
-	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false);
+	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false) override;
+	virtual Error close_dynamic_library(void *p_library_handle) override;
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false) override;
 
-	virtual MainLoop *get_main_loop() const;
+	virtual MainLoop *get_main_loop() const override;
 
-	virtual String get_name() const;
+	virtual String get_name() const override;
 
-	virtual int get_tablet_driver_count() const;
-	virtual String get_tablet_driver_name(int p_driver) const;
-	virtual String get_current_tablet_driver() const;
-	virtual void set_current_tablet_driver(const String &p_driver);
+	virtual int get_tablet_driver_count() const override;
+	virtual String get_tablet_driver_name(int p_driver) const override;
+	virtual String get_current_tablet_driver() const override;
+	virtual void set_current_tablet_driver(const String &p_driver) override;
 
-	virtual void initialize_joypads() {}
+	virtual void initialize_joypads() override {}
 
-	virtual Date get_date(bool utc) const;
-	virtual Time get_time(bool utc) const;
-	virtual TimeZoneInfo get_time_zone_info() const;
-	virtual double get_unix_time() const;
+	virtual Date get_date(bool utc) const override;
+	virtual Time get_time(bool utc) const override;
+	virtual TimeZoneInfo get_time_zone_info() const override;
+	virtual double get_unix_time() const override;
 
-	virtual Error set_cwd(const String &p_cwd);
+	virtual Error set_cwd(const String &p_cwd) override;
 
-	virtual void delay_usec(uint32_t p_usec) const;
-	virtual uint64_t get_ticks_usec() const;
+	virtual void delay_usec(uint32_t p_usec) const override;
+	virtual uint64_t get_ticks_usec() const override;
 
-	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr);
-	virtual Error kill(const ProcessID &p_pid);
-	virtual int get_process_id() const;
+	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr) override;
+	virtual Error kill(const ProcessID &p_pid) override;
+	virtual int get_process_id() const override;
 
-	virtual bool has_environment(const String &p_var) const;
-	virtual String get_environment(const String &p_var) const;
-	virtual bool set_environment(const String &p_var, const String &p_value) const;
+	virtual bool has_environment(const String &p_var) const override;
+	virtual String get_environment(const String &p_var) const override;
+	virtual bool set_environment(const String &p_var, const String &p_value) const override;
 
-	virtual String get_executable_path() const;
+	virtual String get_executable_path() const override;
 
-	virtual String get_locale() const;
+	virtual String get_locale() const override;
 
-	virtual int get_processor_count() const;
+	virtual int get_processor_count() const override;
 
-	virtual String get_config_path() const;
-	virtual String get_data_path() const;
-	virtual String get_cache_path() const;
-	virtual String get_godot_dir_name() const;
+	virtual String get_config_path() const override;
+	virtual String get_data_path() const override;
+	virtual String get_cache_path() const override;
+	virtual String get_godot_dir_name() const override;
 
-	virtual String get_system_dir(SystemDir p_dir) const;
-	virtual String get_user_data_dir() const;
+	virtual String get_system_dir(SystemDir p_dir) const override;
+	virtual String get_user_data_dir() const override;
 
-	virtual String get_unique_id() const;
+	virtual String get_unique_id() const override;
 
-	virtual Error shell_open(String p_uri);
+	virtual Error shell_open(String p_uri) override;
 
 	void run();
 
-	virtual bool _check_internal_feature_support(const String &p_feature);
+	virtual bool _check_internal_feature_support(const String &p_feature) override;
 
 	void disable_crash_handler();
 	bool is_disable_crash_handler() const;
-	virtual void initialize_debugging();
+	virtual void initialize_debugging() override;
 
-	virtual Error move_to_trash(const String &p_path);
+	virtual Error move_to_trash(const String &p_path) override;
 
 	void set_main_window(HWND p_main_window) { main_window = p_main_window; }
 


### PR DESCRIPTION
Adds missing override keywords to:
- `drivers/unix/os_unix.h`
- `platform/android/os_android.h`
- `platform/linuxbsd/os_linuxbsd.h`
- `platform/osx/os_osx.h`
- `platform/windows/os_windows.h`

Note: `platform/iphone/os_iphone.h` and `platform/javascript/os_javascript.h` have already been done, and I've not added them to `platform/server/os_server.h` or `platform/uwp/os_uwp.h`.

