### PR TITLE
Fix visual issues with GraphEdit minimap

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -178,7 +178,7 @@
 		<member name="minimap_enabled" type="bool" setter="set_minimap_enabled" getter="is_minimap_enabled" default="true">
 			If [code]true[/code], the minimap is visible.
 		</member>
-		<member name="minimap_opacity" type="float" setter="set_minimap_opacity" getter="get_minimap_opacity" default="0.45">
+		<member name="minimap_opacity" type="float" setter="set_minimap_opacity" getter="get_minimap_opacity" default="0.65">
 			The opacity of the minimap rectangle.
 		</member>
 		<member name="minimap_size" type="Vector2" setter="set_minimap_size" getter="get_minimap_size" default="Vector2(240, 160)">

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -160,7 +160,7 @@ private:
 
 	void _bake_segment2d(Vector<Vector2> &points, Vector<Color> &colors, float p_begin, float p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_min_depth, int p_max_depth, float p_tol, const Color &p_color, const Color &p_to_color, int &lines) const;
 
-	void _draw_cos_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color, float p_bezier_ratio);
+	void _draw_cos_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color, float p_width, float p_bezier_ratio);
 
 	void _graph_node_raised(Node *p_gn);
 	void _graph_node_moved(Node *p_gn);


### PR DESCRIPTION
Follow-up to #43416. 
This fixes the issue with zoom, makes lines a bit thinner on the minimap, and also fixes an issue with `GraphNode` size changes not being reflected on the minimap.

[Here's how it looks now](https://user-images.githubusercontent.com/11782833/102537809-825b8f80-40bc-11eb-9977-bdb5eb3a29e3.png)

I've also adjusted the default value for the minimap's opacity after testing it with the 3.2 branch.
/cc @Chaosus @akien-mga 