### PR TITLE
Add support for duplicate() for Packed*Array, and they are pass by ref in godot 4.0

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -112,6 +112,10 @@ public:
 		sort_custom<_DefaultComparator<T>>();
 	}
 
+	Vector<T> duplicate() {
+		return *this;
+	}
+
 	void ordered_insert(const T &p_val) {
 		int i;
 		for (i = 0; i < _cowdata.size(); i++) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1316,6 +1316,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedByteArray, invert, sarray(), varray());
 	bind_method(PackedByteArray, subarray, sarray("from", "to"), varray());
 	bind_method(PackedByteArray, sort, sarray(), varray());
+	bind_method(PackedByteArray, duplicate, sarray(), varray());
 
 	bind_function(PackedByteArray, get_string_from_ascii, _VariantCall::func_PackedByteArray_get_string_from_ascii, sarray(), varray());
 	bind_function(PackedByteArray, get_string_from_utf8, _VariantCall::func_PackedByteArray_get_string_from_utf8, sarray(), varray());
@@ -1342,6 +1343,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt32Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedInt32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt32Array, sort, sarray(), varray());
+	bind_method(PackedInt32Array, duplicate, sarray(), varray());
 
 	/* Int64 Array */
 
@@ -1359,6 +1361,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt64Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedInt64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt64Array, sort, sarray(), varray());
+	bind_method(PackedInt64Array, duplicate, sarray(), varray());
 
 	/* Float32 Array */
 
@@ -1376,6 +1379,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat32Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedFloat32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat32Array, sort, sarray(), varray());
+	bind_method(PackedFloat32Array, duplicate, sarray(), varray());
 
 	/* Float64 Array */
 
@@ -1393,6 +1397,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat64Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedFloat64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat64Array, sort, sarray(), varray());
+	bind_method(PackedFloat64Array, duplicate, sarray(), varray());
 
 	/* String Array */
 
@@ -1410,6 +1415,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedStringArray, subarray, sarray("from", "to"), varray());
 	bind_method(PackedStringArray, to_byte_array, sarray(), varray());
 	bind_method(PackedStringArray, sort, sarray(), varray());
+	bind_method(PackedStringArray, duplicate, sarray(), varray());
 
 	/* Vector2 Array */
 
@@ -1427,6 +1433,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector2Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedVector2Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector2Array, sort, sarray(), varray());
+	bind_method(PackedVector2Array, duplicate, sarray(), varray());
 
 	/* Vector3 Array */
 
@@ -1444,6 +1451,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector3Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedVector3Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector3Array, sort, sarray(), varray());
+	bind_method(PackedVector3Array, duplicate, sarray(), varray());
 
 	/* Color Array */
 
@@ -1461,6 +1469,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedColorArray, subarray, sarray("from", "to"), varray());
 	bind_method(PackedColorArray, to_byte_array, sarray(), varray());
 	bind_method(PackedColorArray, sort, sarray(), varray());
+	bind_method(PackedColorArray, duplicate, sarray(), varray());
 
 	/* Register constants */
 

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -2023,6 +2023,24 @@ Variant Variant::duplicate(bool deep) const {
 			return operator Dictionary().duplicate(deep);
 		case ARRAY:
 			return operator Array().duplicate(deep);
+		case PACKED_BYTE_ARRAY:
+			return operator Vector<uint8_t>().duplicate();
+		case PACKED_INT32_ARRAY:
+			return operator Vector<int32_t>().duplicate();
+		case PACKED_INT64_ARRAY:
+			return operator Vector<int64_t>().duplicate();
+		case PACKED_FLOAT32_ARRAY:
+			return operator Vector<float>().duplicate();
+		case PACKED_FLOAT64_ARRAY:
+			return operator Vector<double>().duplicate();
+		case PACKED_STRING_ARRAY:
+			return operator Vector<String>().duplicate();
+		case PACKED_VECTOR2_ARRAY:
+			return operator Vector<Vector2>().duplicate();
+		case PACKED_VECTOR3_ARRAY:
+			return operator Vector<Vector3>().duplicate();
+		case PACKED_COLOR_ARRAY:
+			return operator Vector<Color>().duplicate();
 		default:
 			return *this;
 	}

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold bytes. Packs data tightly, so it saves memory for large array sizes.
-		[b]Note:[/b] This type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -84,6 +83,13 @@
 				Returns a new [PackedByteArray] with the data decompressed. Set the compression mode using one of [enum File.CompressionMode]'s constants. [b]This method only accepts gzip and deflate compression modes.[/b]
 				This method is potentially slower than [code]decompress[/code], as it may have to re-allocate it's output buffer multiple times while decompressing, where as [code]decompress[/code] knows it's output buffer size from the beginning.
 				GZIP has a maximal compression ratio of 1032:1, meaning it's very possible for a small compressed payload to decompress to a potentially very large output. To guard against this, you may provide a maximum size this function is allowed to allocate in bytes via [code]max_output_size[/code]. Passing -1 will allow for unbounded output. If any positive value is passed, and the decompression exceeds that amount in bytes, then an error will be returned.
+			</description>
+		</method>
+		<method name="duplicate">
+			<return type="PackedByteArray">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="empty">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold [Color]. Packs data tightly, so it saves memory for large array sizes.
-		[b]Note:[/b] This type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -51,6 +50,13 @@
 			</argument>
 			<description>
 				Appends a [PackedColorArray] at the end of this array.
+			</description>
+		</method>
+		<method name="duplicate">
+			<return type="PackedColorArray">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="empty">

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold 32-bit floating-point values. Packs data tightly, so it saves memory for large array sizes.
-		[b]Note:[/b] This type is passed by value and not by reference.
 		If you need to pack 64-bit floats tightly, see [PackedFloat64Array].
 	</description>
 	<tutorials>
@@ -52,6 +51,13 @@
 			</argument>
 			<description>
 				Appends a [PackedFloat32Array] at the end of this array.
+			</description>
+		</method>
+		<method name="duplicate">
+			<return type="PackedFloat32Array">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="empty">

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold 64-bit floating-point values. Packs data tightly, so it saves memory for large array sizes.
-		[b]Note:[/b] This type is passed by value and not by reference.
 		If you only need to pack 32-bit floats tightly, see [PackedFloat32Array] for a more memory-friendly alternative.
 	</description>
 	<tutorials>
@@ -52,6 +51,13 @@
 			</argument>
 			<description>
 				Appends a [PackedFloat64Array] at the end of this array.
+			</description>
+		</method>
+		<method name="duplicate">
+			<return type="PackedFloat64Array">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="empty">

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold 32-bit integer values. Packs data tightly, so it saves memory for large array sizes.
-		[b]Note:[/b] This type is passed by value and not by reference.
 		[b]Note:[/b] This type stores signed 32-bit integers, which means it can take values in the interval [code][-2^31, 2^31 - 1][/code], i.e. [code][-2147483648, 2147483647][/code]. Exceeding those bounds will wrap around. In comparison, [int] uses signed 64-bit integers which can hold much larger values. If you need to pack 64-bit integers tightly, see [PackedInt64Array].
 	</description>
 	<tutorials>
@@ -52,6 +51,13 @@
 			</argument>
 			<description>
 				Appends a [PackedInt32Array] at the end of this array.
+			</description>
+		</method>
+		<method name="duplicate">
+			<return type="PackedInt32Array">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="empty">

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold 64-bit integer values. Packs data tightly, so it saves memory for large array sizes.
-		[b]Note:[/b] This type is passed by value and not by reference.
 		[b]Note:[/b] This type stores signed 64-bit integers, which means it can take values in the interval [code][-2^63, 2^63 - 1][/code], i.e. [code][-9223372036854775808, 9223372036854775807][/code]. Exceeding those bounds will wrap around. If you only need to pack 32-bit integers tightly, see [PackedInt32Array] for a more memory-friendly alternative.
 	</description>
 	<tutorials>
@@ -52,6 +51,13 @@
 			</argument>
 			<description>
 				Appends a [PackedInt64Array] at the end of this array.
+			</description>
+		</method>
+		<method name="duplicate">
+			<return type="PackedInt64Array">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="empty">

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold [String]s. Packs data tightly, so it saves memory for large array sizes.
-		[b]Note:[/b] This type is passed by value and not by reference.
 	</description>
 	<tutorials>
 		<link title="OS Test Demo">https://godotengine.org/asset-library/asset/677</link>
@@ -52,6 +51,13 @@
 			</argument>
 			<description>
 				Appends a [PackedStringArray] at the end of this array.
+			</description>
+		</method>
+		<method name="duplicate">
+			<return type="PackedStringArray">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="empty">

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold [Vector2]. Packs data tightly, so it saves memory for large array sizes.
-		[b]Note:[/b] This type is passed by value and not by reference.
 	</description>
 	<tutorials>
 		<link title="2D Navigation Astar Demo">https://godotengine.org/asset-library/asset/519</link>
@@ -52,6 +51,13 @@
 			</argument>
 			<description>
 				Appends a [PackedVector2Array] at the end of this array.
+			</description>
+		</method>
+		<method name="duplicate">
+			<return type="PackedVector2Array">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="empty">

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold [Vector3]. Packs data tightly, so it saves memory for large array sizes.
-		[b]Note:[/b] This type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -51,6 +50,13 @@
 			</argument>
 			<description>
 				Appends a [PackedVector3Array] at the end of this array.
+			</description>
+		</method>
+		<method name="duplicate">
+			<return type="PackedVector3Array">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="empty">


### PR DESCRIPTION
As discussed with @reduz on IRC.

I encountered a few more gdscript bugs in my project I'm developing on 4.0, with Packed*Arrays.  (They are now pass by ref in godot 4.0, instead of pass by value).  

This PR adds to Variant::duplicate() method to correctly copy Packed_Arrays on `duplicate()`.  As well exposes a `duplicate()` function on each Packed*Array to do an explicit copy if desired.  Note there is no argument '(deep)' boolean these arrays as that doesn't make sense.

This PR also updates the documentation for these classes accordingly.