### PR TITLE
Fix physical bones positions when creating physical skeleton for GLTF

### DIFF
--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -103,7 +103,8 @@ void SkeletonEditor::create_physical_skeleton() {
 
 PhysicalBone *SkeletonEditor::create_physical_bone(int bone_id, int bone_child_id, const Vector<BoneInfo> &bones_infos) {
 
-	real_t half_height(skeleton->get_bone_rest(bone_child_id).origin.length() * 0.5);
+	Vector3 bone_rest_origin = skeleton->get_bone_rest(bone_child_id).origin;
+	real_t half_height(bone_rest_origin.length() * 0.5);
 	real_t radius(half_height * 0.2);
 
 	CapsuleShape *bone_shape_capsule = memnew(CapsuleShape);
@@ -112,9 +113,11 @@ PhysicalBone *SkeletonEditor::create_physical_bone(int bone_id, int bone_child_i
 
 	CollisionShape *bone_shape = memnew(CollisionShape);
 	bone_shape->set_shape(bone_shape_capsule);
+	Transform bone_shape_transform = bone_shape->get_transform().looking_at(bone_rest_origin, Vector3(0, 0, 1));
+	bone_shape->set_transform(bone_shape_transform);
 
 	Transform body_transform;
-	body_transform.origin = Vector3(0, 0, -half_height);
+	body_transform.origin = bone_rest_origin * 0.5;
 
 	Transform joint_transform;
 	joint_transform.origin = Vector3(0, 0, half_height);


### PR DESCRIPTION
Fix physical bones positions when using Create physical bones to generate the bones.
To fix the issue, the physical bone origin is computed using the bone_rest origin vector, and rotation is fixed by changing the collision shape child (this avoid physics engine issue).

Tested on GLTF and DAE models, but not FBX.

Issue linked: https://github.com/godotengine/godot/issues/39757

Test project: [testSkeleton-godot3-2.zip](https://github.com/godotengine/godot/files/5718293/testSkeleton-godot3-2.zip)
Contains GLTF and DAE (and their blender files). 

To test, open some scene Scenery/****DAE.tscn or ****GLB.tscn, erase the physical bones, and recreate them using Create Physical Skeleton
- Before the patch: OK with DAE, FAILED with GLTF
- After the patch: OK for both
