### PR TITLE
[CTL] Fix RTL scrolling and tabs selection.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2935,7 +2935,7 @@ void CanvasItemEditor::_draw_rulers() {
 	// Draw top ruler
 	viewport->draw_rect(Rect2(Point2(RULER_WIDTH, 0), Size2(viewport->get_size().x, RULER_WIDTH)), bg_color);
 	for (int i = Math::ceil(first.x); i < last.x; i++) {
-		Point2 position = (transform * ruler_transform * major_subdivide * minor_subdivide).xform(Point2(i, 0));
+		Point2 position = (transform * ruler_transform * major_subdivide * minor_subdivide).xform(Point2(i, 0)).round();
 		if (i % (major_subdivision * minor_subdivision) == 0) {
 			viewport->draw_line(Point2(position.x, 0), Point2(position.x, RULER_WIDTH), graduation_color, Math::round(EDSCALE));
 			float val = (ruler_transform * major_subdivide * minor_subdivide).xform(Point2(i, 0)).x;
@@ -2952,7 +2952,7 @@ void CanvasItemEditor::_draw_rulers() {
 	// Draw left ruler
 	viewport->draw_rect(Rect2(Point2(0, RULER_WIDTH), Size2(RULER_WIDTH, viewport->get_size().y)), bg_color);
 	for (int i = Math::ceil(first.y); i < last.y; i++) {
-		Point2 position = (transform * ruler_transform * major_subdivide * minor_subdivide).xform(Point2(0, i));
+		Point2 position = (transform * ruler_transform * major_subdivide * minor_subdivide).xform(Point2(0, i)).round();
 		if (i % (major_subdivision * minor_subdivision) == 0) {
 			viewport->draw_line(Point2(0, position.y), Point2(RULER_WIDTH, position.y), graduation_color, Math::round(EDSCALE));
 			float val = (ruler_transform * major_subdivide * minor_subdivide).xform(Point2(0, i)).y;

--- a/modules/text_server_adv/dynamic_font_adv.cpp
+++ b/modules/text_server_adv/dynamic_font_adv.cpp
@@ -432,8 +432,8 @@ DynamicFontDataAdvanced::Character DynamicFontDataAdvanced::bitmap_to_character(
 	}
 
 	Character chr;
-	chr.align = Vector2(xofs, -yofs) * p_data->scale_color_font / oversampling;
-	chr.advance = advance * p_data->scale_color_font / oversampling;
+	chr.align = (Vector2(xofs, -yofs) * p_data->scale_color_font / oversampling).round();
+	chr.advance = (advance * p_data->scale_color_font / oversampling).round();
 	chr.texture_idx = tex_pos.index;
 	chr.found = true;
 

--- a/modules/text_server_fb/dynamic_font_fb.cpp
+++ b/modules/text_server_fb/dynamic_font_fb.cpp
@@ -317,8 +317,8 @@ DynamicFontDataFallback::Character DynamicFontDataFallback::bitmap_to_character(
 	}
 
 	Character chr;
-	chr.align = Vector2(xofs, -yofs) * p_data->scale_color_font / oversampling;
-	chr.advance = advance * p_data->scale_color_font / oversampling;
+	chr.align = (Vector2(xofs, -yofs) * p_data->scale_color_font / oversampling).round();
+	chr.advance = (advance * p_data->scale_color_font / oversampling).round();
 	chr.texture_idx = tex_pos.index;
 	chr.found = true;
 

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -74,7 +74,7 @@ void ProgressBar::_notification(int p_what) {
 		if (percent_visible) {
 			String txt = TS->format_number(itos(int(get_as_ratio() * 100))) + TS->percent_sign();
 			TextLine tl = TextLine(txt, font, font_size);
-			tl.draw(get_canvas_item(), Point2(get_size().width - tl.get_size().x, get_size().height - tl.get_size().y) / 2, font_color);
+			tl.draw(get_canvas_item(), (Point2(get_size().width - tl.get_size().x, get_size().height - tl.get_size().y) / 2).round(), font_color);
 		}
 	}
 }

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -378,7 +378,7 @@ private:
 
 	void _shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width, int *r_char_offset);
 	void _resize_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width);
-	float _draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_color_shadow, bool p_shadow_as_outline, const Point2 &shadow_ofs);
+	void _draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_color_shadow, bool p_shadow_as_outline, const Point2 &shadow_ofs);
 	float _find_click_in_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr);
 
 	String _roman(int p_num, bool p_capitalize) const;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -328,6 +328,7 @@ void ScrollContainer::_notification(int p_what) {
 			if (rtl && v_scroll->is_visible_in_tree() && v_scroll->get_parent() == this) {
 				r.position.x += v_scroll->get_minimum_size().x;
 			}
+			r.position = r.position.floor();
 			fit_child_in_rect(c, r);
 		}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1245,7 +1245,7 @@ void TextEdit::_notification(int p_what) {
 					int gl_size = visual.size();
 
 					ofs_y += ldata->get_line_ascent(line_wrap_index);
-					float char_ofs = 0.f;
+					int char_ofs = 0;
 					for (int j = 0; j < gl_size; j++) {
 						if (color_map.has(glyphs[j].start)) {
 							current_color = color_map[glyphs[j].start].get("color");

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -1038,31 +1038,36 @@ int TextServer::shaped_text_hit_test_position(RID p_shaped, float p_coords) cons
 
 	float off = 0.0f;
 	for (int i = 0; i < v_size; i++) {
-		for (int k = 0; k < glyphs[i].repeat; k++) {
-			if (glyphs[i].count > 0) {
-				float advance = 0.f;
-				for (int j = 0; j < glyphs[i].count; j++) {
-					advance += glyphs[i + j].advance;
-				}
-				// Place caret to the left of clicked grapheme.
-				if (p_coords >= off && p_coords < off + advance / 2) {
-					if ((glyphs[i].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
-						return glyphs[i].end;
-					} else {
-						return glyphs[i].start;
-					}
-				}
-				// Place caret to the right of clicked grapheme.
-				if (p_coords >= off + advance / 2 && p_coords < off + advance) {
-					if ((glyphs[i].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
-						return glyphs[i].start;
-					} else {
-						return glyphs[i].end;
-					}
+		if (glyphs[i].count > 0) {
+			float advance = 0.f;
+			for (int j = 0; j < glyphs[i].count; j++) {
+				advance += glyphs[i + j].advance * glyphs[i + j].repeat;
+			}
+			if (((glyphs[i].flags & GRAPHEME_IS_VIRTUAL) == GRAPHEME_IS_VIRTUAL) && (p_coords >= off && p_coords < off + advance)) {
+				if ((glyphs[i].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
+					return glyphs[i].end;
+				} else {
+					return glyphs[i].start;
 				}
 			}
-			off += glyphs[i].advance;
+			// Place caret to the left of clicked grapheme.
+			if (p_coords >= off && p_coords < off + advance / 2) {
+				if ((glyphs[i].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
+					return glyphs[i].end;
+				} else {
+					return glyphs[i].start;
+				}
+			}
+			// Place caret to the right of clicked grapheme.
+			if (p_coords >= off + advance / 2 && p_coords < off + advance) {
+				if ((glyphs[i].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
+					return glyphs[i].start;
+				} else {
+					return glyphs[i].end;
+				}
+			}
 		}
+		off += glyphs[i].advance * glyphs[i].repeat;
 	}
 	return 0;
 }

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -905,7 +905,7 @@ Vector<Vector2> TextServer::shaped_text_get_selection(RID p_shaped, int p_start,
 	float off = 0.0f;
 	for (int i = 0; i < v_size; i++) {
 		for (int k = 0; k < glyphs[i].repeat; k++) {
-			if (glyphs[i].count > 0 && glyphs[i].index != 0) {
+			if ((glyphs[i].count > 0) && ((glyphs[i].index != 0) || ((glyphs[i].flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE))) {
 				if (glyphs[i].start < end && glyphs[i].end > start) {
 					// Grapheme fully in selection range.
 					if (glyphs[i].start >= start && glyphs[i].end <= end) {
@@ -962,6 +962,10 @@ Vector<Vector2> TextServer::shaped_text_get_selection(RID p_shaped, int p_start,
 
 	// Merge intersecting ranges.
 	int i = 0;
+	while (i < ranges.size()) {
+		i++;
+	}
+	i = 0;
 	while (i < ranges.size()) {
 		int j = i + 1;
 		while (j < ranges.size()) {


### PR DESCRIPTION
- Fixes RTL scrolling / content height calculation. Fixes #44484
- Fixes selection of tabs (and other space characters) with fonts that do not have glyphs for these characters. Fixes #44450
- Fixes non-integer text position with some scrollable controls.