### PR TITLE
Fix broken members panel in visual script editor

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2547,7 +2547,7 @@ void VisualScriptEditor::set_edited_resource(const RES &p_res) {
 	}
 
 	_update_graph();
-	_update_members();
+	call_deferred("_update_members");
 }
 
 void VisualScriptEditor::enable_editor() {


### PR DESCRIPTION
Fix #42984 - I'm not sure I understand why this happens, but attempting to call `_update_members` as a deferred seems to resolve that bug.

