### PR TITLE
Added GraphEdit properties to control lines thickness and antialiasing

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -174,6 +174,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="connection_lines_antialiased" type="bool" setter="set_connection_lines_antialiased" getter="is_connection_lines_antialiased" default="true">
+			If [code]true[/code], the lines between nodes will use antialiasing.
+		</member>
+		<member name="connection_lines_thickness" type="float" setter="set_connection_lines_thickness" getter="get_connection_lines_thickness" default="2.0">
+			The thickness of the lines between the nodes.
+		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="minimap_enabled" type="bool" setter="set_minimap_enabled" getter="is_minimap_enabled" default="true">
 			If [code]true[/code], the minimap is visible.
@@ -181,7 +187,7 @@
 		<member name="minimap_opacity" type="float" setter="set_minimap_opacity" getter="get_minimap_opacity" default="0.65">
 			The opacity of the minimap rectangle.
 		</member>
-		<member name="minimap_size" type="Vector2" setter="set_minimap_size" getter="get_minimap_size" default="Vector2(240, 160)">
+		<member name="minimap_size" type="Vector2" setter="set_minimap_size" getter="get_minimap_size" default="Vector2( 240, 160 )">
 			The size of the minimap rectangle. The map itself is based on the size of the grid area and is scaled to fit this rectangle.
 		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
@@ -325,6 +331,8 @@
 		</theme_item>
 		<theme_item name="grid_minor" type="Color" default="Color( 1, 1, 1, 0.05 )">
 			Color of minor grid lines.
+		</theme_item>
+		<theme_item name="minimap" type="Texture2D">
 		</theme_item>
 		<theme_item name="minus" type="Texture2D">
 			The icon for the zoom out button.

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -784,7 +784,7 @@ void GraphEdit::_bake_segment2d(Vector<Vector2> &points, Vector<Color> &colors, 
 	}
 }
 
-void GraphEdit::_draw_cos_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color, float p_width = 2.0, float p_bezier_ratio = 1.0) {
+void GraphEdit::_draw_cos_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color, float p_width, float p_bezier_ratio = 1.0) {
 	//cubic bezier code
 	float diff = p_to.x - p_from.x;
 	float cp_offset;
@@ -811,9 +811,9 @@ void GraphEdit::_draw_cos_line(CanvasItem *p_where, const Vector2 &p_from, const
 	colors.push_back(p_to_color);
 
 #ifdef TOOLS_ENABLED
-	p_where->draw_polyline_colors(points, colors, Math::floor(p_width * EDSCALE), true);
+	p_where->draw_polyline_colors(points, colors, Math::floor(p_width * EDSCALE), lines_antialiased);
 #else
-	p_where->draw_polyline_colors(points, colors, p_width, true);
+	p_where->draw_polyline_colors(points, colors, p_width, lines_antialiased);
 #endif
 }
 
@@ -860,7 +860,7 @@ void GraphEdit::_connections_layer_draw() {
 			color = color.lerp(activity_color, E->get().activity);
 			tocolor = tocolor.lerp(activity_color, E->get().activity);
 		}
-		_draw_cos_line(connections_layer, frompos, topos, color, tocolor);
+		_draw_cos_line(connections_layer, frompos, topos, color, tocolor, lines_thickness);
 	}
 
 	while (to_erase.size()) {
@@ -899,7 +899,7 @@ void GraphEdit::_top_layer_draw() {
 		if (!connecting_out) {
 			SWAP(pos, topos);
 		}
-		_draw_cos_line(top_layer, pos, topos, col, col);
+		_draw_cos_line(top_layer, pos, topos, col, col, lines_thickness);
 	}
 
 	if (box_selecting) {
@@ -1536,6 +1536,24 @@ void GraphEdit::_minimap_toggled() {
 	minimap->update();
 }
 
+void GraphEdit::set_connection_lines_thickness(float p_thickness) {
+	lines_thickness = p_thickness;
+	update();
+}
+
+float GraphEdit::get_connection_lines_thickness() const {
+	return lines_thickness;
+}
+
+void GraphEdit::set_connection_lines_antialiased(bool p_antialiased) {
+	lines_antialiased = p_antialiased;
+	update();
+}
+
+bool GraphEdit::is_connection_lines_antialiased() const {
+	return lines_antialiased;
+}
+
 HBoxContainer *GraphEdit::get_zoom_hbox() {
 	return zoom_hb;
 }
@@ -1567,6 +1585,12 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_snap", "enable"), &GraphEdit::set_use_snap);
 	ClassDB::bind_method(D_METHOD("is_using_snap"), &GraphEdit::is_using_snap);
 
+	ClassDB::bind_method(D_METHOD("set_connection_lines_thickness", "pixels"), &GraphEdit::set_connection_lines_thickness);
+	ClassDB::bind_method(D_METHOD("get_connection_lines_thickness"), &GraphEdit::get_connection_lines_thickness);
+
+	ClassDB::bind_method(D_METHOD("set_connection_lines_antialiased", "pixels"), &GraphEdit::set_connection_lines_antialiased);
+	ClassDB::bind_method(D_METHOD("is_connection_lines_antialiased"), &GraphEdit::is_connection_lines_antialiased);
+
 	ClassDB::bind_method(D_METHOD("set_minimap_size", "p_size"), &GraphEdit::set_minimap_size);
 	ClassDB::bind_method(D_METHOD("get_minimap_size"), &GraphEdit::get_minimap_size);
 	ClassDB::bind_method(D_METHOD("set_minimap_opacity", "p_opacity"), &GraphEdit::set_minimap_opacity);
@@ -1590,6 +1614,8 @@ void GraphEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "snap_distance"), "set_snap", "get_snap");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_snap"), "set_use_snap", "is_using_snap");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "zoom"), "set_zoom", "get_zoom");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "connection_lines_thickness"), "set_connection_lines_thickness", "get_connection_lines_thickness");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "connection_lines_antialiased"), "set_connection_lines_antialiased", "is_connection_lines_antialiased");
 	ADD_GROUP("Minimap", "minimap");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "minimap_enabled"), "set_minimap_enabled", "is_minimap_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "minimap_size"), "set_minimap_size", "get_minimap_size");

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -158,6 +158,9 @@ private:
 	bool awaiting_scroll_offset_update;
 	List<Connection> connections;
 
+	float lines_thickness = 2.0f;
+	bool lines_antialiased = true;
+
 	void _bake_segment2d(Vector<Vector2> &points, Vector<Color> &colors, float p_begin, float p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_min_depth, int p_max_depth, float p_tol, const Color &p_color, const Color &p_to_color, int &lines) const;
 
 	void _draw_cos_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color, float p_width, float p_bezier_ratio);
@@ -274,6 +277,12 @@ public:
 
 	int get_snap() const;
 	void set_snap(int p_snap);
+
+	void set_connection_lines_thickness(float p_thickness);
+	float get_connection_lines_thickness() const;
+
+	void set_connection_lines_antialiased(bool p_antialiased);
+	bool is_connection_lines_antialiased() const;
 
 	HBoxContainer *get_zoom_hbox();
 


### PR DESCRIPTION
Allows setting lines thickness and lines antialiasing between the nodes in GraphEdit's. This provides extra control for the users who use this class in their projects.