### PR TITLE
Rename Rect2 and Rect2i clip() to intersection()

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2480,7 +2480,7 @@ void Image::blit_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Po
 	ERR_FAIL_COND(format != p_src->format);
 	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot blit_rect in compressed or custom image formats.");
 
-	Rect2i clipped_src_rect = Rect2i(0, 0, p_src->width, p_src->height).clip(p_src_rect);
+	Rect2i clipped_src_rect = Rect2i(0, 0, p_src->width, p_src->height).intersection(p_src_rect);
 
 	if (p_dest.x < 0) {
 		clipped_src_rect.position.x = ABS(p_dest.x);
@@ -2494,7 +2494,7 @@ void Image::blit_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Po
 	}
 
 	Point2 src_underscan = Point2(MIN(0, p_src_rect.position.x), MIN(0, p_src_rect.position.y));
-	Rect2i dest_rect = Rect2i(0, 0, width, height).clip(Rect2i(p_dest - src_underscan, clipped_src_rect.size));
+	Rect2i dest_rect = Rect2i(0, 0, width, height).intersection(Rect2i(p_dest - src_underscan, clipped_src_rect.size));
 
 	uint8_t *wp = data.ptrw();
 	uint8_t *dst_data_ptr = wp;
@@ -2535,7 +2535,7 @@ void Image::blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, co
 	ERR_FAIL_COND_MSG(p_src->height != p_mask->height, "Source image height is different from mask height.");
 	ERR_FAIL_COND(format != p_src->format);
 
-	Rect2i clipped_src_rect = Rect2i(0, 0, p_src->width, p_src->height).clip(p_src_rect);
+	Rect2i clipped_src_rect = Rect2i(0, 0, p_src->width, p_src->height).intersection(p_src_rect);
 
 	if (p_dest.x < 0) {
 		clipped_src_rect.position.x = ABS(p_dest.x);
@@ -2549,7 +2549,7 @@ void Image::blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, co
 	}
 
 	Point2 src_underscan = Point2(MIN(0, p_src_rect.position.x), MIN(0, p_src_rect.position.y));
-	Rect2i dest_rect = Rect2i(0, 0, width, height).clip(Rect2i(p_dest - src_underscan, clipped_src_rect.size));
+	Rect2i dest_rect = Rect2i(0, 0, width, height).intersection(Rect2i(p_dest - src_underscan, clipped_src_rect.size));
 
 	uint8_t *wp = data.ptrw();
 	uint8_t *dst_data_ptr = wp;
@@ -2589,7 +2589,7 @@ void Image::blend_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const P
 	ERR_FAIL_COND(srcdsize == 0);
 	ERR_FAIL_COND(format != p_src->format);
 
-	Rect2i clipped_src_rect = Rect2i(0, 0, p_src->width, p_src->height).clip(p_src_rect);
+	Rect2i clipped_src_rect = Rect2i(0, 0, p_src->width, p_src->height).intersection(p_src_rect);
 
 	if (p_dest.x < 0) {
 		clipped_src_rect.position.x = ABS(p_dest.x);
@@ -2603,7 +2603,7 @@ void Image::blend_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const P
 	}
 
 	Point2 src_underscan = Point2(MIN(0, p_src_rect.position.x), MIN(0, p_src_rect.position.y));
-	Rect2i dest_rect = Rect2i(0, 0, width, height).clip(Rect2i(p_dest - src_underscan, clipped_src_rect.size));
+	Rect2i dest_rect = Rect2i(0, 0, width, height).intersection(Rect2i(p_dest - src_underscan, clipped_src_rect.size));
 
 	Ref<Image> img = p_src;
 
@@ -2638,7 +2638,7 @@ void Image::blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, c
 	ERR_FAIL_COND_MSG(p_src->height != p_mask->height, "Source image height is different from mask height.");
 	ERR_FAIL_COND(format != p_src->format);
 
-	Rect2i clipped_src_rect = Rect2i(0, 0, p_src->width, p_src->height).clip(p_src_rect);
+	Rect2i clipped_src_rect = Rect2i(0, 0, p_src->width, p_src->height).intersection(p_src_rect);
 
 	if (p_dest.x < 0) {
 		clipped_src_rect.position.x = ABS(p_dest.x);
@@ -2652,7 +2652,7 @@ void Image::blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, c
 	}
 
 	Point2 src_underscan = Point2(MIN(0, p_src_rect.position.x), MIN(0, p_src_rect.position.y));
-	Rect2i dest_rect = Rect2i(0, 0, width, height).clip(Rect2i(p_dest - src_underscan, clipped_src_rect.size));
+	Rect2i dest_rect = Rect2i(0, 0, width, height).intersection(Rect2i(p_dest - src_underscan, clipped_src_rect.size));
 
 	Ref<Image> img = p_src;
 	Ref<Image> msk = p_mask;

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -123,8 +123,9 @@ struct Rect2 {
 	_FORCE_INLINE_ bool has_no_area() const {
 		return (size.x <= 0 || size.y <= 0);
 	}
-	inline Rect2 clip(const Rect2 &p_rect) const { /// return a clipped rect
 
+	// Returns the instersection between two Rect2s or an empty Rect2 if there is no intersection
+	inline Rect2 intersection(const Rect2 &p_rect) const {
 		Rect2 new_rect = p_rect;
 
 		if (!intersects(new_rect)) {
@@ -365,8 +366,9 @@ struct Rect2i {
 	_FORCE_INLINE_ bool has_no_area() const {
 		return (size.x <= 0 || size.y <= 0);
 	}
-	inline Rect2i clip(const Rect2i &p_rect) const { /// return a clipped rect
 
+	// Returns the instersection between two Rect2is or an empty Rect2i if there is no intersection
+	inline Rect2i intersection(const Rect2i &p_rect) const {
 		Rect2i new_rect = p_rect;
 
 		if (!intersects(new_rect)) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1021,7 +1021,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Rect2, is_equal_approx, sarray("rect"), varray());
 	bind_method(Rect2, intersects, sarray("b", "include_borders"), varray(false));
 	bind_method(Rect2, encloses, sarray("b"), varray());
-	bind_method(Rect2, clip, sarray("b"), varray());
+	bind_method(Rect2, intersection, sarray("b"), varray());
 	bind_method(Rect2, merge, sarray("b"), varray());
 	bind_method(Rect2, expand, sarray("to"), varray());
 	bind_method(Rect2, grow, sarray("by"), varray());
@@ -1036,7 +1036,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Rect2i, has_point, sarray("point"), varray());
 	bind_method(Rect2i, intersects, sarray("b"), varray());
 	bind_method(Rect2i, encloses, sarray("b"), varray());
-	bind_method(Rect2i, clip, sarray("b"), varray());
+	bind_method(Rect2i, intersection, sarray("b"), varray());
 	bind_method(Rect2i, merge, sarray("b"), varray());
 	bind_method(Rect2i, expand, sarray("to"), varray());
 	bind_method(Rect2i, grow, sarray("by"), varray());

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -72,7 +72,7 @@
 				Returns a [Rect2] with equivalent position and area, modified so that the top-left corner is the origin and [code]width[/code] and [code]height[/code] are positive.
 			</description>
 		</method>
-		<method name="clip">
+		<method name="intersection">
 			<return type="Rect2">
 			</return>
 			<argument index="0" name="b" type="Rect2">

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -70,7 +70,7 @@
 				Returns a [Rect2i] with equivalent position and area, modified so that the top-left corner is the origin and [code]width[/code] and [code]height[/code] are positive.
 			</description>
 		</method>
-		<method name="clip">
+		<method name="intersection">
 			<return type="Rect2i">
 			</return>
 			<argument index="0" name="b" type="Rect2i">

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -6378,7 +6378,7 @@ void RenderingDeviceVulkan::draw_list_enable_scissor(DrawListID p_list, const Re
 	Rect2i rect = p_rect;
 	rect.position += dl->viewport.position;
 
-	rect = dl->viewport.clip(rect);
+	rect = dl->viewport.intersection(rect);
 
 	if (rect.get_area() == 0) {
 		return;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2208,7 +2208,7 @@ void AnimationTrackEdit::draw_rect_clipped(const Rect2 &p_rect, const Color &p_c
 		return;
 	}
 	Rect2 clip = Rect2(clip_left, 0, clip_right - clip_left, get_size().height);
-	draw_rect(clip.clip(p_rect), p_color, p_filled);
+	draw_rect(clip.intersection(p_rect), p_color, p_filled);
 }
 
 void AnimationTrackEdit::draw_bg(int p_clip_left, int p_clip_right) {
@@ -2912,7 +2912,7 @@ void AnimationTrackEdit::append_to_selection(const Rect2 &p_box, bool p_deselect
 	// Left Border including space occupied by keyframes on t=0.
 	int limit_start_hitbox = timeline->get_name_limit() - type_icon->get_width();
 	Rect2 select_rect(limit_start_hitbox, 0, get_size().width - timeline->get_name_limit() - timeline->get_buttons_width(), get_size().height);
-	select_rect = select_rect.clip(p_box);
+	select_rect = select_rect.intersection(p_box);
 
 	// Select should happen in the opposite order of drawing for more accurate overlap select.
 	for (int i = animation->track_get_key_count(track) - 1; i >= 0; i--) {
@@ -4947,7 +4947,7 @@ void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 
 		Rect2 rect(from, to - from);
 		Rect2 scroll_rect = Rect2(scroll->get_global_position(), scroll->get_size());
-		rect = scroll_rect.clip(rect);
+		rect = scroll_rect.intersection(rect);
 		box_selection->set_position(rect.position);
 		box_selection->set_size(rect.size);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2705,7 +2705,7 @@ void Node3DEditorViewport::_draw() {
 			} break;
 		}
 
-		draw_rect = Rect2(Vector2(), s).clip(draw_rect);
+		draw_rect = Rect2(Vector2(), s).intersection(draw_rect);
 
 		surface->draw_rect(draw_rect, Color(0.6, 0.6, 0.1, 0.5), false, Math::round(2 * EDSCALE));
 

--- a/modules/gdnative/gdnative/rect2.cpp
+++ b/modules/gdnative/gdnative/rect2.cpp
@@ -90,11 +90,11 @@ godot_bool GDAPI godot_rect2_has_no_area(const godot_rect2 *p_self) {
 	return self->has_no_area();
 }
 
-godot_rect2 GDAPI godot_rect2_clip(const godot_rect2 *p_self, const godot_rect2 *p_b) {
+godot_rect2 GDAPI godot_rect2_intersection(const godot_rect2 *p_self, const godot_rect2 *p_b) {
 	godot_rect2 dest;
 	const Rect2 *self = (const Rect2 *)p_self;
 	const Rect2 *b = (const Rect2 *)p_b;
-	*((Rect2 *)&dest) = self->clip(*b);
+	*((Rect2 *)&dest) = self->intersection(*b);
 	return dest;
 }
 
@@ -233,11 +233,11 @@ godot_bool GDAPI godot_rect2i_has_no_area(const godot_rect2i *p_self) {
 	return self->has_no_area();
 }
 
-godot_rect2i GDAPI godot_rect2i_clip(const godot_rect2i *p_self, const godot_rect2i *p_b) {
+godot_rect2i GDAPI godot_rect2i_intersection(const godot_rect2i *p_self, const godot_rect2i *p_b) {
 	godot_rect2i dest;
 	const Rect2i *self = (const Rect2i *)p_self;
 	const Rect2i *b = (const Rect2i *)p_b;
-	*((Rect2i *)&dest) = self->clip(*b);
+	*((Rect2i *)&dest) = self->intersection(*b);
 	return dest;
 }
 

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -3573,7 +3573,7 @@
         ]
       },
       {
-        "name": "godot_rect2_clip",
+        "name": "godot_rect2_intersection",
         "return_type": "godot_rect2",
         "arguments": [
           ["const godot_rect2 *", "p_self"],
@@ -3715,7 +3715,7 @@
         ]
       },
       {
-        "name": "godot_rect2i_clip",
+        "name": "godot_rect2i_intersection",
         "return_type": "godot_rect2i",
         "arguments": [
           ["const godot_rect2i *", "p_self"],

--- a/modules/gdnative/include/gdnative/rect2.h
+++ b/modules/gdnative/include/gdnative/rect2.h
@@ -80,7 +80,7 @@ godot_bool GDAPI godot_rect2_encloses(const godot_rect2 *p_self, const godot_rec
 
 godot_bool GDAPI godot_rect2_has_no_area(const godot_rect2 *p_self);
 
-godot_rect2 GDAPI godot_rect2_clip(const godot_rect2 *p_self, const godot_rect2 *p_b);
+godot_rect2 GDAPI godot_rect2_intersection(const godot_rect2 *p_self, const godot_rect2 *p_b);
 
 godot_rect2 GDAPI godot_rect2_merge(const godot_rect2 *p_self, const godot_rect2 *p_b);
 
@@ -123,7 +123,7 @@ godot_bool GDAPI godot_rect2i_encloses(const godot_rect2i *p_self, const godot_r
 
 godot_bool GDAPI godot_rect2i_has_no_area(const godot_rect2i *p_self);
 
-godot_rect2i GDAPI godot_rect2i_clip(const godot_rect2i *p_self, const godot_rect2i *p_b);
+godot_rect2i GDAPI godot_rect2i_intersection(const godot_rect2i *p_self, const godot_rect2i *p_b);
 
 godot_rect2i GDAPI godot_rect2i_merge(const godot_rect2i *p_self, const godot_rect2i *p_b);
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2956,7 +2956,7 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			Rect2i r;
 			r.position = screen_get_position(i);
 			r.size = screen_get_size(i);
-			Rect2 inters = r.clip(p_rect);
+			Rect2 inters = r.intersection(p_rect);
 			int area = inters.size.width * inters.size.height;
 			if (area >= nearest_area) {
 				screen_rect = r;

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -63,7 +63,7 @@ void BitMap::create_from_image_alpha(const Ref<Image> &p_image, float p_threshol
 }
 
 void BitMap::set_bit_rect(const Rect2 &p_rect, bool p_value) {
-	Rect2i current = Rect2i(0, 0, width, height).clip(p_rect);
+	Rect2i current = Rect2i(0, 0, width, height).intersection(p_rect);
 	uint8_t *data = bitmask.ptrw();
 
 	for (int i = current.position.x; i < current.position.x + current.size.x; i++) {
@@ -482,7 +482,7 @@ static void fill_bits(const BitMap *p_src, Ref<BitMap> &p_map, const Point2i &p_
 }
 
 Vector<Vector<Vector2>> BitMap::clip_opaque_to_polygons(const Rect2 &p_rect, float p_epsilon) const {
-	Rect2i r = Rect2i(0, 0, width, height).clip(p_rect);
+	Rect2i r = Rect2i(0, 0, width, height).intersection(p_rect);
 	print_verbose("BitMap: Rect: " + r);
 
 	Point2i from;
@@ -522,7 +522,7 @@ void BitMap::grow_mask(int p_pixels, const Rect2 &p_rect) {
 	bool bit_value = p_pixels > 0;
 	p_pixels = Math::abs(p_pixels);
 
-	Rect2i r = Rect2i(0, 0, width, height).clip(p_rect);
+	Rect2i r = Rect2i(0, 0, width, height).intersection(p_rect);
 
 	Ref<BitMap> copy;
 	copy.instance();

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1253,7 +1253,7 @@ bool AtlasTexture::get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect,
 	Vector2 scale = p_rect.size / src.size;
 
 	src.position += (rc.position - margin.position);
-	Rect2 src_c = rc.clip(src);
+	Rect2 src_c = rc.intersection(src);
 	if (src_c.size == Size2()) {
 		return false;
 	}
@@ -1575,7 +1575,7 @@ void LargeTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, cons
 		if (!p_src_rect.intersects(rect)) {
 			continue;
 		}
-		Rect2 local = p_src_rect.clip(rect);
+		Rect2 local = p_src_rect.intersection(rect);
 		Rect2 target = local;
 		target.size *= scale;
 		target.position = p_rect.position + (p_src_rect.position + rect.position) * scale;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -144,7 +144,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 
 	if (ci->clip) {
 		if (p_canvas_clip != nullptr) {
-			ci->final_clip_rect = p_canvas_clip->final_clip_rect.clip(global_rect);
+			ci->final_clip_rect = p_canvas_clip->final_clip_rect.intersection(global_rect);
 		} else {
 			ci->final_clip_rect = global_rect;
 		}
@@ -195,7 +195,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 	}
 
 	if (ci->copy_back_buffer) {
-		ci->copy_back_buffer->screen_rect = xform.xform(ci->copy_back_buffer->rect).clip(p_clip_rect);
+		ci->copy_back_buffer->screen_rect = xform.xform(ci->copy_back_buffer->rect).intersection(p_clip_rect);
 	}
 
 	if (use_canvas_group) {

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -6949,7 +6949,7 @@ void RendererStorageRD::render_target_copy_to_back_buffer(RID p_render_target, c
 	if (p_region == Rect2i()) {
 		region.size = rt->size;
 	} else {
-		region = Rect2i(Size2i(), rt->size).clip(p_region);
+		region = Rect2i(Size2i(), rt->size).intersection(p_region);
 		if (region.size == Size2i()) {
 			return; //nothing to do
 		}
@@ -6989,7 +6989,7 @@ void RendererStorageRD::render_target_clear_back_buffer(RID p_render_target, con
 	if (p_region == Rect2i()) {
 		region.size = rt->size;
 	} else {
-		region = Rect2i(Size2i(), rt->size).clip(p_region);
+		region = Rect2i(Size2i(), rt->size).intersection(p_region);
 		if (region.size == Size2i()) {
 			return; //nothing to do
 		}
@@ -7010,7 +7010,7 @@ void RendererStorageRD::render_target_gen_back_buffer_mipmaps(RID p_render_targe
 	if (p_region == Rect2i()) {
 		region.size = rt->size;
 	} else {
-		region = Rect2i(Size2i(), rt->size).clip(p_region);
+		region = Rect2i(Size2i(), rt->size).intersection(p_region);
 		if (region.size == Size2i()) {
 			return; //nothing to do
 		}

--- a/tests/test_rect2.h
+++ b/tests/test_rect2.h
@@ -144,29 +144,29 @@ TEST_CASE("[Rect2] Absolute coordinates") {
 			"abs() should return the expected Rect2.");
 }
 
-TEST_CASE("[Rect2] Clipping") {
+TEST_CASE("[Rect2] Intersecton") {
 	CHECK_MESSAGE(
-			Rect2(0, 100, 1280, 720).clip(Rect2(0, 300, 100, 100)).is_equal_approx(Rect2(0, 300, 100, 100)),
-			"clip() with fully enclosed Rect2 should return the expected result.");
+			Rect2(0, 100, 1280, 720).intersection(Rect2(0, 300, 100, 100)).is_equal_approx(Rect2(0, 300, 100, 100)),
+			"intersection() with fully enclosed Rect2 should return the expected result.");
 	// The resulting Rect2 is 100 pixels high because the first Rect2 is vertically offset by 100 pixels.
 	CHECK_MESSAGE(
-			Rect2(0, 100, 1280, 720).clip(Rect2(1200, 700, 100, 100)).is_equal_approx(Rect2(1200, 700, 80, 100)),
-			"clip() with partially enclosed Rect2 should return the expected result.");
+			Rect2(0, 100, 1280, 720).intersection(Rect2(1200, 700, 100, 100)).is_equal_approx(Rect2(1200, 700, 80, 100)),
+			"intersection() with partially enclosed Rect2 should return the expected result.");
 	CHECK_MESSAGE(
-			Rect2(0, 100, 1280, 720).clip(Rect2(-4000, -4000, 100, 100)).is_equal_approx(Rect2()),
-			"clip() with non-enclosed Rect2 should return the expected result.");
+			Rect2(0, 100, 1280, 720).intersection(Rect2(-4000, -4000, 100, 100)).is_equal_approx(Rect2()),
+			"intersection() with non-enclosed Rect2 should return the expected result.");
 }
 
 TEST_CASE("[Rect2] Enclosing") {
 	CHECK_MESSAGE(
 			Rect2(0, 100, 1280, 720).encloses(Rect2(0, 300, 100, 100)),
-			"clip() with fully contained Rect2 should return the expected result.");
+			"encloses() with fully contained Rect2 should return the expected result.");
 	CHECK_MESSAGE(
 			!Rect2(0, 100, 1280, 720).encloses(Rect2(1200, 700, 100, 100)),
-			"clip() with partially contained Rect2 should return the expected result.");
+			"encloses() with partially contained Rect2 should return the expected result.");
 	CHECK_MESSAGE(
 			!Rect2(0, 100, 1280, 720).encloses(Rect2(-4000, -4000, 100, 100)),
-			"clip() with non-contained Rect2 should return the expected result.");
+			"encloses() with non-contained Rect2 should return the expected result.");
 }
 
 TEST_CASE("[Rect2] Expanding") {
@@ -356,29 +356,29 @@ TEST_CASE("[Rect2i] Absolute coordinates") {
 			"abs() should return the expected Rect2i.");
 }
 
-TEST_CASE("[Rect2i] Clipping") {
+TEST_CASE("[Rect2i] Intersection") {
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 1280, 720).clip(Rect2i(0, 300, 100, 100)) == Rect2i(0, 300, 100, 100),
-			"clip() with fully enclosed Rect2i should return the expected result.");
+			Rect2i(0, 100, 1280, 720).intersection(Rect2i(0, 300, 100, 100)) == Rect2i(0, 300, 100, 100),
+			"intersection() with fully enclosed Rect2i should return the expected result.");
 	// The resulting Rect2i is 100 pixels high because the first Rect2i is vertically offset by 100 pixels.
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 1280, 720).clip(Rect2i(1200, 700, 100, 100)) == Rect2i(1200, 700, 80, 100),
-			"clip() with partially enclosed Rect2i should return the expected result.");
+			Rect2i(0, 100, 1280, 720).intersection(Rect2i(1200, 700, 100, 100)) == Rect2i(1200, 700, 80, 100),
+			"intersection() with partially enclosed Rect2i should return the expected result.");
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 1280, 720).clip(Rect2i(-4000, -4000, 100, 100)) == Rect2i(),
-			"clip() with non-enclosed Rect2i should return the expected result.");
+			Rect2i(0, 100, 1280, 720).intersection(Rect2i(-4000, -4000, 100, 100)) == Rect2i(),
+			"intersection() with non-enclosed Rect2i should return the expected result.");
 }
 
 TEST_CASE("[Rect2i] Enclosing") {
 	CHECK_MESSAGE(
 			Rect2i(0, 100, 1280, 720).encloses(Rect2i(0, 300, 100, 100)),
-			"clip() with fully contained Rect2i should return the expected result.");
+			"encloses() with fully contained Rect2i should return the expected result.");
 	CHECK_MESSAGE(
 			!Rect2i(0, 100, 1280, 720).encloses(Rect2i(1200, 700, 100, 100)),
-			"clip() with partially contained Rect2i should return the expected result.");
+			"encloses() with partially contained Rect2i should return the expected result.");
 	CHECK_MESSAGE(
 			!Rect2i(0, 100, 1280, 720).encloses(Rect2i(-4000, -4000, 100, 100)),
-			"clip() with non-contained Rect2i should return the expected result.");
+			"encloses() with non-contained Rect2i should return the expected result.");
 }
 
 TEST_CASE("[Rect2i] Expanding") {


### PR DESCRIPTION
As originally identified [here](https://github.com/godotengine/godot/issues/16863#issuecomment-655299536), `Rect2` and `Rect2i`'s method `clip()` is the same as 3D's AABB's method `intersection()`. These methods should have the same name. This PR renames `Rect2` and `Rect2i`'s method `clip()` to `intersection()`, because, although the method can be used to clip a rectangle, it doesn't clip the current rectangle. Instead, it returns the intersection between this rectangle and another rectangle. Even the current [documentation](https://docs.godotengine.org/en/stable/classes/class_rect2.html#class-rect2-method-clip) describes it as such:
> Returns the intersection of this `Rect2` and b.

Part of #16863.
