### PR TITLE
Rename EditorInterface get_editor_viewport to get_editor_main_control

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -47,7 +47,7 @@
 				Returns the editor's [EditorSettings] instance.
 			</description>
 		</method>
-		<method name="get_editor_viewport">
+		<method name="get_editor_main_control">
 			<return type="Control">
 			</return>
 			<description>

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -398,7 +398,7 @@ Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_pat
 Ref<ImageTexture> EditorExportPlatform::get_option_icon(int p_index) const {
 	Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
 	ERR_FAIL_COND_V(theme.is_null(), Ref<ImageTexture>());
-	if (EditorNode::get_singleton()->get_viewport()->is_layout_rtl()) {
+	if (EditorNode::get_singleton()->get_main_control()->is_layout_rtl()) {
 		return theme->get_icon("PlayBackwards", "EditorIcons");
 	} else {
 		return theme->get_icon("Play", "EditorIcons");

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2727,14 +2727,14 @@ void EditorNode::_screenshot(bool p_use_utc) {
 }
 
 void EditorNode::_save_screenshot(NodePath p_path) {
-	Control *editor_viewport = EditorInterface::get_singleton()->get_editor_viewport();
-	ERR_FAIL_COND_MSG(!editor_viewport, "Cannot get editor viewport.");
-	Viewport *viewport = editor_viewport->get_viewport();
-	ERR_FAIL_COND_MSG(!viewport, "Cannot get editor viewport.");
+	Control *editor_main_control = EditorInterface::get_singleton()->get_editor_main_control();
+	ERR_FAIL_COND_MSG(!editor_main_control, "Cannot get editor main control.");
+	Viewport *viewport = editor_main_control->get_viewport();
+	ERR_FAIL_COND_MSG(!viewport, "Cannot get editor main control viewport.");
 	Ref<ViewportTexture> texture = viewport->get_texture();
-	ERR_FAIL_COND_MSG(texture.is_null(), "Cannot get editor viewport texture.");
+	ERR_FAIL_COND_MSG(texture.is_null(), "Cannot get editor main control viewport texture.");
 	Ref<Image> img = texture->get_data();
-	ERR_FAIL_COND_MSG(img.is_null(), "Cannot get editor viewport texture image.");
+	ERR_FAIL_COND_MSG(img.is_null(), "Cannot get editor main control viewport texture image.");
 	Error error = img->save_png(p_path);
 	ERR_FAIL_COND_MSG(error != OK, "Cannot save screenshot to file '" + p_path + "'.");
 }
@@ -2866,8 +2866,8 @@ void EditorNode::_update_file_menu_closed() {
 	pop->set_item_disabled(pop->get_item_index(FILE_OPEN_PREV), false);
 }
 
-Control *EditorNode::get_viewport() {
-	return viewport;
+Control *EditorNode::get_main_control() {
+	return main_control;
 }
 
 void EditorNode::_editor_select(int p_which) {
@@ -6027,10 +6027,10 @@ EditorNode::EditorNode() {
 	scene_root->set_disable_input(true);
 	scene_root->set_as_audio_listener_2d(true);
 
-	viewport = memnew(VBoxContainer);
-	viewport->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	viewport->add_theme_constant_override("separation", 0);
-	scene_root_parent->add_child(viewport);
+	main_control = memnew(VBoxContainer);
+	main_control->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_control->add_theme_constant_override("separation", 0);
+	scene_root_parent->add_child(main_control);
 
 	HBoxContainer *left_menu_hb = memnew(HBoxContainer);
 	menu_hb->add_child(left_menu_hb);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -255,7 +255,7 @@ private:
 	Control *vp_base;
 
 	HBoxContainer *menu_hb;
-	Control *viewport;
+	Control *main_control;
 	MenuButton *file_menu;
 	MenuButton *project_menu;
 	MenuButton *debug_menu;
@@ -728,7 +728,7 @@ public:
 	bool is_changing_scene() const;
 
 	static EditorLog *get_log() { return singleton->log; }
-	Control *get_viewport();
+	Control *get_main_control();
 
 	void set_edited_scene(Node *p_scene);
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -152,8 +152,8 @@ void EditorInterface::set_main_screen_editor(const String &p_name) {
 	EditorNode::get_singleton()->select_editor_by_name(p_name);
 }
 
-Control *EditorInterface::get_editor_viewport() {
-	return EditorNode::get_singleton()->get_viewport();
+Control *EditorInterface::get_editor_main_control() {
+	return EditorNode::get_singleton()->get_main_control();
 }
 
 void EditorInterface::edit_resource(const Ref<Resource> &p_resource) {
@@ -319,7 +319,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root);
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
 	ClassDB::bind_method(D_METHOD("get_resource_filesystem"), &EditorInterface::get_resource_file_system);
-	ClassDB::bind_method(D_METHOD("get_editor_viewport"), &EditorInterface::get_editor_viewport);
+	ClassDB::bind_method(D_METHOD("get_editor_main_control"), &EditorInterface::get_editor_main_control);
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 	ClassDB::bind_method(D_METHOD("select_file", "file"), &EditorInterface::select_file);
 	ClassDB::bind_method(D_METHOD("get_selected_path"), &EditorInterface::get_selected_path);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -69,7 +69,7 @@ protected:
 public:
 	static EditorInterface *get_singleton() { return singleton; }
 
-	Control *get_editor_viewport();
+	Control *get_editor_main_control();
 	void edit_resource(const Ref<Resource> &p_resource);
 	void open_scene_from_path(const String &scene_path);
 	void reload_scene_from_path(const String &scene_path);


### PR DESCRIPTION
As originally identified [here](https://github.com/godotengine/godot/issues/16863#issuecomment-634258502), `EditorInterface.get_editor_viewport()` doesn't return a `Viewport`, it returns a `Control`. More specifically, as described in the [documentation](https://docs.godotengine.org/en/stable/classes/class_editorinterface.html#class-editorinterface-method-get-editor-viewport), it returns the main editor control. Note: It happens to be a `VBoxContainer`, but this is an implementation detail; so it should not affect the naming of the method.

This PR renames `EditorInterface.get_editor_viewport()` to `EditorInterface.get_editor_main_control()` along with the underlying `EditorNode` method and variable.

Part of #16863. 
