### PR TITLE
Document how to solve UV jittering when using large procedural meshes

### DIFF
--- a/doc/classes/BoxMesh.xml
+++ b/doc/classes/BoxMesh.xml
@@ -6,6 +6,7 @@
 	<description>
 		Generate an axis-aligned box [PrimitiveMesh].
 		The box's UV layout is arranged in a 3×2 layout that allows texturing each face individually. To apply the same texture on all faces, change the material's UV property to [code]Vector3(3, 2, 1)[/code].
+		[b]Note:[/b] When using a large textured [BoxMesh] (e.g. as a floor), you may stumble upon UV jittering issues depending on the camera angle. To solve this, increase [member subdivide_depth], [member subdivide_height] and [member subdivide_width] until you no longer notice UV jittering.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PlaneMesh.xml
+++ b/doc/classes/PlaneMesh.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Class representing a planar [PrimitiveMesh]. This flat mesh does not have a thickness. By default, this mesh is aligned on the X and Z axes; this default rotation isn't suited for use with billboarded materials. For billboarded materials, use [QuadMesh] instead.
+		[b]Note:[/b] When using a large textured [PlaneMesh] (e.g. as a floor), you may stumble upon UV jittering issues depending on the camera angle. To solve this, increase [member subdivide_depth] and [member subdivide_width] until you no longer notice UV jittering.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This problem can exhibit itself with any large mesh, although PlaneMesh and BoxMesh (CubeMesh in `3.2`) are more likely to exhibit this problem since they're more likely to be used as large floors.

Video of the issue: https://www.youtube.com/watch?v=0ZMBCytLhBY

In the above video, I'm using 0 subdivisions, then 2 subdivisions, then 3 subdivisions. Notice how the UV jittering decreases as I increase the number of subdivisions.