### PR TITLE
Implemented undo and redo functionality for ItemListEditor

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -36,6 +36,25 @@
 				If selectable is [code]true[/code], the list item will be selectable.
 			</description>
 		</method>
+		</method>
+		<method name="re_add_item">
+			<return type="void">
+			</return>
+			<argument index="0" name="text" type="String">
+			</argument>
+			<argument index="1" name="position" type="unsigned int">
+			</argument>
+			<argument index="2" name="enabled" type="bool">
+			</argument>
+			<argument index="3" name="icon" type="Texture2D" default="null">
+			</argument>
+			<argument index="4" name="selectable" type="bool" default="true">
+			</argument>
+			<description>
+				Adds an item to the item list with specified text, [code]position[/code], and [code]enabled[/code] status. Set the [code]position[/code] to the desired index in the item list. Specify an [code]icon[/code], or use [code]null[/code] as the [code]icon[/code] for a list item with no icon.
+				If selectable is [code]true[/code], the list item will be selectable. If [code]enabled[/code] is [code]true[/code], the list item will be initialized as being enabled.
+			</description>
+		</method>		
 		<method name="clear">
 			<return type="void">
 			</return>

--- a/editor/plugins/item_list_editor_plugin.h
+++ b/editor/plugins/item_list_editor_plugin.h
@@ -46,6 +46,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	static void _bind_methods();
 
 public:
 	enum Flags {
@@ -55,6 +56,7 @@ public:
 		FLAG_ENABLE = 8,
 		FLAG_SEPARATOR = 16
 	};
+	UndoRedo *undo_redo;
 
 	virtual void set_object(Object *p_object) = 0;
 	virtual bool handles(Object *p_object) const = 0;
@@ -87,6 +89,9 @@ public:
 	virtual void add_item() = 0;
 	virtual int get_item_count() const = 0;
 	virtual void erase(int p_idx) = 0;
+	virtual void undoRedo_add_new_item(int idx)= 0;
+	virtual void undoRedo_re_add_item(unsigned int position, String name, Ref<Texture2D> icon, bool enabled) = 0;
+	virtual void undoRedo_erase(int p_pdx) = 0;
 
 	ItemListPlugin() {}
 };
@@ -118,6 +123,9 @@ public:
 	virtual void add_item() override;
 	virtual int get_item_count() const override;
 	virtual void erase(int p_idx) override;
+	virtual void undoRedo_add_new_item(int idx) override;
+	virtual void undoRedo_re_add_item(unsigned int position, String name, Ref<Texture2D> icon, bool enabled) override;
+	virtual void undoRedo_erase(int p_idx) override;
 
 	ItemListOptionButtonPlugin();
 };
@@ -158,6 +166,9 @@ public:
 	virtual void add_item() override;
 	virtual int get_item_count() const override;
 	virtual void erase(int p_idx) override;
+	virtual void undoRedo_add_new_item(int idx) override;
+	virtual void undoRedo_re_add_item(unsigned int position, String name, Ref<Texture2D> icon, bool enabled) override;
+	virtual void undoRedo_erase(int p_idx) override;
 
 	ItemListPopupMenuPlugin();
 };
@@ -186,6 +197,9 @@ public:
 	virtual void add_item() override;
 	virtual int get_item_count() const override;
 	virtual void erase(int p_idx) override;
+	virtual void undoRedo_add_new_item(int idx) override;
+	virtual void undoRedo_re_add_item(unsigned int position, String name, Ref<Texture2D> icon, bool enabled) override;
+	virtual void undoRedo_erase(int p_idx) override;
 
 	ItemListItemListPlugin();
 };
@@ -240,7 +254,7 @@ public:
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
-
+	
 	ItemListEditorPlugin(EditorNode *p_node);
 	~ItemListEditorPlugin();
 };

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -71,6 +71,27 @@ void ItemList::add_item(const String &p_item, const Ref<Texture2D> &p_texture, b
 	shape_changed = true;
 }
 
+void ItemList::re_add_item(const String &text, const unsigned int &position, const bool &is_enabled, const Ref<Texture2D> &texture, bool p_selectable) {
+	Item item;
+	item.icon = texture;
+	item.icon_transposed = false;
+	item.icon_region = Rect2i();
+	item.icon_modulate = Color(1, 1, 1, 1);
+	item.text = text;
+	item.text_buf.instance();
+	item.selectable = p_selectable;
+	item.selected = false;
+	item.disabled = !is_enabled;
+	item.tooltip_enabled = true;
+	item.custom_bg = Color(0, 0, 0, 0);
+	items.insert(position, item);
+
+	_shape(position);
+
+	update();
+	shape_changed = true;
+}
+
 void ItemList::add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable) {
 	Item item;
 	item.icon = p_item;

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -131,6 +131,7 @@ protected:
 
 public:
 	void add_item(const String &p_item, const Ref<Texture2D> &p_texture = Ref<Texture2D>(), bool p_selectable = true);
+	void re_add_item(const String &text, const unsigned int &position, const bool &is_enabled, const Ref<Texture2D> &texture, bool p_selectable = true);
 	void add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable = true);
 
 	void set_item_text(int p_idx, const String &p_text);


### PR DESCRIPTION
Fix for issue "Can't undo actions of ItemList editor" #33300

Updated add_item and erase methods, moved functionalities to helper functions which are
registered with UndoRedo on action.

Edited the erase method to save the state of an item in the undo action. This includes the text, the icon, and the enabled status. Added a re-add method in the itemlist class that adds an item into the list at a given position in the list, with text, icon, and embedded status passed as arguments.

After adding an item in the editor and closing the editor, pressing ctrl+z removes the item. After adding more items, giving them new text and new icons, while arbitrarily changing the enabled status, and then deleting any element, close the editor window and pressing ctrl+z brings the item back into its position, with the changes intact. Pressing ctrl+shift+z removes the item again.

Updated docs for re_add_item in ItemList

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
