### PR TITLE
Add unit tests for `RandomNumberGenerator`

### DIFF
--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -41,6 +41,9 @@
 // The test is skipped with this, run pending tests with `--test --no-skip`.
 #define TEST_CASE_PENDING(name) TEST_CASE(name *doctest::skip())
 
+// The test case is marked as failed, but does not fail the entire test run.
+#define TEST_CASE_MAY_FAIL(name) TEST_CASE(name *doctest::may_fail())
+
 // Temporarily disable error prints to test failure paths.
 // This allows to avoid polluting the test summary with error messages.
 // The `_print_error_enabled` boolean is defined in `core/print_string.cpp` and


### PR DESCRIPTION
Salvages #44350 (I added @vinayakmtiwari as co-author but apparently the account is deleted so I don't know... The author is encouraged to get back!)

This covers RNG functionality completely (added `randf` and `randi` tests as well).

"Integer 32 bit" test is a sanity check to make sure that we do generate 32 unsigned integers given the same test seed.

The problem whether some tests may fail at some point (such as "Normal distribution" case) is handled by doctest's `may_fail` decorator, for which I added `TEST_CASE_MAY_FAIL` test macro in `tests/test_macros.h` to be used by other test suites abstracting away implementation detail behind doctest, so such test cases won't block CI, and if they do fail (I believe this won't happen as long as we don't change RNG implementation often, I hope), it's a matter of updating the seed, because current results are deterministic (but only per platform, not necessarily across platforms).

