### PR TITLE
Rename unselect to deselect

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -25,11 +25,11 @@
 				Clear all the added filters in the dialog.
 			</description>
 		</method>
-		<method name="deselect_items">
+		<method name="deselect_all">
 			<return type="void">
 			</return>
 			<description>
-				Clear currently selected items in the dialog.
+				Clear all currently selected items in the dialog.
 			</description>
 		</method>
 		<method name="get_line_edit">

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -288,7 +288,7 @@
 				Emitted when a GraphNode is selected.
 			</description>
 		</signal>
-		<signal name="node_unselected">
+		<signal name="node_deselected">
 			<argument index="0" name="node" type="Node">
 			</argument>
 			<description>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -471,7 +471,7 @@
 				Sorts items in the list by their text.
 			</description>
 		</method>
-		<method name="unselect">
+		<method name="deselect">
 			<return type="void">
 			</return>
 			<argument index="0" name="idx" type="int">
@@ -480,7 +480,7 @@
 				Ensures the item associated with the specified index is not selected.
 			</description>
 		</method>
-		<method name="unselect_all">
+		<method name="deselect_all">
 			<return type="void">
 			</return>
 			<description>

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -492,7 +492,7 @@ void CreateDialog::_favorite_selected() {
 	}
 
 	search_box->set_text(item->get_text(0).get_slicec(' ', 0));
-	recent->unselect_all();
+	recent->deselect_all();
 	_update_search();
 }
 

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -499,7 +499,7 @@ void EditorFileDialog::_multi_selected(int p_item, bool p_selected) {
 }
 
 void EditorFileDialog::_items_clear_selection() {
-	item_list->unselect_all();
+	item_list->deselect_all();
 
 	// If nothing is selected, then block Open button.
 	switch (mode) {
@@ -595,7 +595,7 @@ void EditorFileDialog::_item_list_item_rmb_selected(int p_item, const Vector2 &p
 void EditorFileDialog::_item_list_rmb_clicked(const Vector2 &p_pos) {
 	// Right click on folder background. Deselect all files so that actions are applied on the current folder.
 	for (int i = 0; i < item_list->get_item_count(); i++) {
-		item_list->unselect(i);
+		item_list->deselect(i);
 	}
 
 	item_menu->clear();
@@ -849,7 +849,7 @@ void EditorFileDialog::update_file_list() {
 	}
 
 	if (favorites->get_current() >= 0) {
-		favorites->unselect(favorites->get_current());
+		favorites->deselect(favorites->get_current());
 	}
 
 	favorite->set_pressed(false);
@@ -1226,7 +1226,7 @@ void EditorFileDialog::_update_favorites() {
 		if (setthis) {
 			favorite->set_pressed(true);
 			favorites->set_current(favorites->get_item_count() - 1);
-			recent->unselect_all();
+			recent->deselect_all();
 		}
 	}
 }

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -119,7 +119,7 @@ EditorLayoutsDialog::EditorLayoutsDialog() {
 	name->set_anchor_and_margin(MARGIN_LEFT, Control::ANCHOR_BEGIN, 5);
 	name->set_anchor_and_margin(MARGIN_RIGHT, Control::ANCHOR_END, -5);
 	name->connect("gui_input", callable_mp(this, &EditorLayoutsDialog::_line_gui_input));
-	name->connect("focus_entered", callable_mp(layout_names, &ItemList::unselect_all));
+	name->connect("focus_entered", callable_mp(layout_names, &ItemList::deselect_all));
 }
 
 void EditorLayoutsDialog::set_name_line_enabled(bool p_enabled) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2447,7 +2447,7 @@ void FileSystemDock::_file_list_rmb_select(int p_item, const Vector2 &p_pos) {
 			continue;
 		}
 		if (files->get_item_text(p_item) == "..") {
-			files->unselect(i);
+			files->deselect(i);
 			continue;
 		}
 		paths.push_back(files->get_item_metadata(i));

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -262,7 +262,7 @@ Vector<int> TileMapEditor::get_selected_tiles() const {
 }
 
 void TileMapEditor::set_selected_tiles(Vector<int> p_tiles) {
-	palette->unselect_all();
+	palette->deselect_all();
 
 	for (int i = p_tiles.size() - 1; i >= 0; i--) {
 		int idx = palette->find_metadata(p_tiles[i]);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -196,7 +196,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		export_path->hide();
 		runnable->set_disabled(true);
 		parameters->edit(nullptr);
-		presets->unselect_all();
+		presets->deselect_all();
 		duplicate_preset->set_disabled(true);
 		delete_preset->set_disabled(true);
 		sections->hide();

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -724,7 +724,7 @@ bool GridMapEditor::forward_spatial_input_event(Camera3D *p_camera, const Ref<In
 					return true;
 				} else {
 					selected_palette = -1;
-					mesh_library_palette->unselect_all();
+					mesh_library_palette->deselect_all();
 					update_palette();
 					_update_cursor_instance();
 					return true;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -136,7 +136,7 @@ void FileDialog::update_dir() {
 	}
 
 	// Deselect any item, to make "Select Current Folder" button text by default.
-	deselect_items();
+	deselect_all();
 }
 
 void FileDialog::_dir_entered(String p_dir) {
@@ -172,7 +172,7 @@ void FileDialog::_post_popup() {
 
 	// For open dir mode, deselect all items on file dialog open.
 	if (mode == FILE_MODE_OPEN_DIR) {
-		deselect_items();
+		deselect_all();
 		file_box->set_visible(false);
 	} else {
 		file_box->set_visible(true);
@@ -318,7 +318,7 @@ void FileDialog::_go_up() {
 	update_dir();
 }
 
-void FileDialog::deselect_items() {
+void FileDialog::deselect_all() {
 	// Clear currently selected items in file manager.
 	tree->deselect_all();
 
@@ -808,7 +808,7 @@ void FileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_file_name"), &FileDialog::update_file_name);
 	ClassDB::bind_method(D_METHOD("_update_dir"), &FileDialog::update_dir);
 	ClassDB::bind_method(D_METHOD("_update_file_list"), &FileDialog::update_file_list);
-	ClassDB::bind_method(D_METHOD("deselect_items"), &FileDialog::deselect_items);
+	ClassDB::bind_method(D_METHOD("deselect_all"), &FileDialog::deselect_all);
 
 	ClassDB::bind_method(D_METHOD("invalidate"), &FileDialog::invalidate);
 
@@ -932,7 +932,7 @@ FileDialog::FileDialog() {
 	tree->connect("multi_selected", callable_mp(this, &FileDialog::_tree_multi_selected), varray(), CONNECT_DEFERRED);
 	tree->connect("cell_selected", callable_mp(this, &FileDialog::_tree_selected), varray(), CONNECT_DEFERRED);
 	tree->connect("item_activated", callable_mp(this, &FileDialog::_tree_item_activated), varray());
-	tree->connect("nothing_selected", callable_mp(this, &FileDialog::deselect_items));
+	tree->connect("nothing_selected", callable_mp(this, &FileDialog::deselect_all));
 	dir->connect("text_entered", callable_mp(this, &FileDialog::_dir_entered));
 	file->connect("text_entered", callable_mp(this, &FileDialog::_file_entered));
 	filter->connect("item_selected", callable_mp(this, &FileDialog::_filter_selected));

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -170,7 +170,7 @@ public:
 
 	void invalidate();
 
-	void deselect_items();
+	void deselect_all();
 
 	FileDialog();
 	~FileDialog();

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1081,13 +1081,13 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 				if (!gn->is_selected() && box_selection_mode_additive) {
 					emit_signal("node_selected", gn);
 				} else if (gn->is_selected() && !box_selection_mode_additive) {
-					emit_signal("node_unselected", gn);
+					emit_signal("node_deselected", gn);
 				}
 				gn->set_selected(box_selection_mode_additive);
 			} else {
 				bool select = (previus_selected.find(gn) != nullptr);
 				if (gn->is_selected() && !select) {
-					emit_signal("node_unselected", gn);
+					emit_signal("node_deselected", gn);
 				} else if (!gn->is_selected() && select) {
 					emit_signal("node_selected", gn);
 				}
@@ -1112,7 +1112,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 					bool select = (previus_selected.find(gn) != nullptr);
 					if (gn->is_selected() && !select) {
-						emit_signal("node_unselected", gn);
+						emit_signal("node_deselected", gn);
 					} else if (!gn->is_selected() && select) {
 						emit_signal("node_selected", gn);
 					}
@@ -1141,7 +1141,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 						Rect2 r = gn->get_rect();
 						r.size *= zoom;
 						if (r.has_point(b->get_position())) {
-							emit_signal("node_unselected", gn);
+							emit_signal("node_deselected", gn);
 							gn->set_selected(false);
 						}
 					}
@@ -1204,7 +1204,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 								o_gn->set_selected(true);
 							} else {
 								if (o_gn->is_selected()) {
-									emit_signal("node_unselected", o_gn);
+									emit_signal("node_deselected", o_gn);
 								}
 								o_gn->set_selected(false);
 							}
@@ -1264,7 +1264,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 							continue;
 						}
 						if (gn2->is_selected()) {
-							emit_signal("node_unselected", gn2);
+							emit_signal("node_deselected", gn2);
 						}
 						gn2->set_selected(false);
 					}
@@ -1628,7 +1628,7 @@ void GraphEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("copy_nodes_request"));
 	ADD_SIGNAL(MethodInfo("paste_nodes_request"));
 	ADD_SIGNAL(MethodInfo("node_selected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
-	ADD_SIGNAL(MethodInfo("node_unselected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
+	ADD_SIGNAL(MethodInfo("node_deselected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("connection_to_empty", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("connection_from_empty", PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("delete_nodes_request"));

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -333,7 +333,7 @@ void ItemList::select(int p_idx, bool p_single) {
 	update();
 }
 
-void ItemList::unselect(int p_idx) {
+void ItemList::deselect(int p_idx) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 
 	if (select_mode != SELECT_MULTI) {
@@ -345,7 +345,7 @@ void ItemList::unselect(int p_idx) {
 	update();
 }
 
-void ItemList::unselect_all() {
+void ItemList::deselect_all() {
 	if (items.size() < 1) {
 		return;
 	}
@@ -573,7 +573,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 			int i = closest;
 
 			if (select_mode == SELECT_MULTI && items[i].selected && mb->get_command()) {
-				unselect(i);
+				deselect(i);
 				emit_signal("multi_selected", i, false);
 
 			} else if (select_mode == SELECT_MULTI && mb->get_shift() && current >= 0 && current < items.size() && current != i) {
@@ -759,7 +759,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 					select(current, false);
 					emit_signal("multi_selected", current, true);
 				} else if (items[current].selected) {
-					unselect(current);
+					deselect(current);
 					emit_signal("multi_selected", current, false);
 				}
 			}
@@ -1519,8 +1519,8 @@ void ItemList::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_tooltip", "idx"), &ItemList::get_item_tooltip);
 
 	ClassDB::bind_method(D_METHOD("select", "idx", "single"), &ItemList::select, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("unselect", "idx"), &ItemList::unselect);
-	ClassDB::bind_method(D_METHOD("unselect_all"), &ItemList::unselect_all);
+	ClassDB::bind_method(D_METHOD("deselect", "idx"), &ItemList::deselect);
+	ClassDB::bind_method(D_METHOD("deselect_all"), &ItemList::deselect_all);
 
 	ClassDB::bind_method(D_METHOD("is_selected", "idx"), &ItemList::is_selected);
 	ClassDB::bind_method(D_METHOD("get_selected_items"), &ItemList::get_selected_items);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -183,8 +183,8 @@ public:
 	Color get_item_custom_fg_color(int p_idx) const;
 
 	void select(int p_idx, bool p_single = true);
-	void unselect(int p_idx);
-	void unselect_all();
+	void deselect(int p_idx);
+	void deselect_all();
 	bool is_selected(int p_idx) const;
 	Vector<int> get_selected_items();
 	bool is_anything_selected();


### PR DESCRIPTION
As originally identified in #28558, "unselect" should be "deselect".

This PR:
- Renames `ItemList`'s methods `unselect()` and `unselect_all` to `deselect()` and `deselect_all()`
- Renames `GraphEdit`'s signal `node_unselected()` to `node_deselected()`

and for consistency and to make it clear that it deselects all items:
- Renames `FileDialog`'s `deselect_items()` to `deselect_all()`

Part of #16863
