### PR TITLE
Rename JSON::print() to to_json()

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2438,12 +2438,12 @@ Variant JSONParseResult::get_result() const {
 }
 
 void _JSON::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("print", "value", "indent", "sort_keys"), &_JSON::print, DEFVAL(String()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("to_json", "value", "indent", "sort_keys"), &_JSON::to_json, DEFVAL(String()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("parse", "json"), &_JSON::parse);
 }
 
-String _JSON::print(const Variant &p_value, const String &p_indent, bool p_sort_keys) {
-	return JSON::print(p_value, p_indent, p_sort_keys);
+String _JSON::to_json(const Variant &p_value, const String &p_indent, bool p_sort_keys) {
+	return JSON::to_json(p_value, p_indent, p_sort_keys);
 }
 
 Ref<JSONParseResult> _JSON::parse(const String &p_json) {

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -704,7 +704,7 @@ protected:
 public:
 	static _JSON *get_singleton() { return singleton; }
 
-	String print(const Variant &p_value, const String &p_indent = "", bool p_sort_keys = false);
+	String to_json(const Variant &p_value, const String &p_indent = "", bool p_sort_keys = false);
 	Ref<JSONParseResult> parse(const String &p_json);
 
 	_JSON() { singleton = this; }

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -55,7 +55,7 @@ static String _make_indent(const String &p_indent, int p_size) {
 	return indent_text;
 }
 
-String JSON::_print_var(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys) {
+String JSON::_variant_to_json(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys) {
 	String colon = ":";
 	String end_statement = "";
 
@@ -87,7 +87,7 @@ String JSON::_print_var(const Variant &p_var, const String &p_indent, int p_cur_
 					s += ",";
 					s += end_statement;
 				}
-				s += _make_indent(p_indent, p_cur_indent + 1) + _print_var(a[i], p_indent, p_cur_indent + 1, p_sort_keys);
+				s += _make_indent(p_indent, p_cur_indent + 1) + _variant_to_json(a[i], p_indent, p_cur_indent + 1, p_sort_keys);
 			}
 			s += end_statement + _make_indent(p_indent, p_cur_indent) + "]";
 			return s;
@@ -108,9 +108,9 @@ String JSON::_print_var(const Variant &p_var, const String &p_indent, int p_cur_
 					s += ",";
 					s += end_statement;
 				}
-				s += _make_indent(p_indent, p_cur_indent + 1) + _print_var(String(E->get()), p_indent, p_cur_indent + 1, p_sort_keys);
+				s += _make_indent(p_indent, p_cur_indent + 1) + _variant_to_json(String(E->get()), p_indent, p_cur_indent + 1, p_sort_keys);
 				s += colon;
-				s += _print_var(d[E->get()], p_indent, p_cur_indent + 1, p_sort_keys);
+				s += _variant_to_json(d[E->get()], p_indent, p_cur_indent + 1, p_sort_keys);
 			}
 
 			s += end_statement + _make_indent(p_indent, p_cur_indent) + "}";
@@ -121,8 +121,8 @@ String JSON::_print_var(const Variant &p_var, const String &p_indent, int p_cur_
 	}
 }
 
-String JSON::print(const Variant &p_var, const String &p_indent, bool p_sort_keys) {
-	return _print_var(p_var, p_indent, 0, p_sort_keys);
+String JSON::to_json(const Variant &p_var, const String &p_indent, bool p_sort_keys) {
+	return _variant_to_json(p_var, p_indent, 0, p_sort_keys);
 }
 
 Error JSON::_get_token(const char32_t *p_str, int &index, int p_len, Token &r_token, int &line, String &r_err_str) {
@@ -470,7 +470,7 @@ Variant JSONParser::get_data() const {
 }
 
 Error JSONParser::decode_data(const Variant &p_data, const String &p_indent, bool p_sort_keys) {
-	string = JSON::print(p_data, p_indent, p_sort_keys);
+	string = JSON::to_json(p_data, p_indent, p_sort_keys);
 	data = p_data;
 	return OK;
 }

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -62,7 +62,7 @@ class JSON {
 
 	static const char *tk_name[TK_MAX];
 
-	static String _print_var(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys);
+	static String _variant_to_json(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys);
 
 	static Error _get_token(const char32_t *p_str, int &index, int p_len, Token &r_token, int &line, String &r_err_str);
 	static Error _parse_value(Variant &value, Token &token, const char32_t *p_str, int &index, int p_len, int &line, String &r_err_str);
@@ -70,7 +70,7 @@ class JSON {
 	static Error _parse_object(Dictionary &object, const char32_t *p_str, int &index, int p_len, int &line, String &r_err_str);
 
 public:
-	static String print(const Variant &p_var, const String &p_indent = "", bool p_sort_keys = true);
+	static String to_json(const Variant &p_var, const String &p_indent = "", bool p_sort_keys = true);
 	static Error parse(const String &p_json, Variant &r_ret, String &r_err_str, int &r_err_line);
 };
 

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -18,7 +18,7 @@
 				Parses a JSON-encoded string and returns a [JSONParseResult] containing the result.
 			</description>
 		</method>
-		<method name="print">
+		<method name="to_json">
 			<return type="String">
 			</return>
 			<argument index="0" name="value" type="Variant">
@@ -28,9 +28,9 @@
 			<argument index="2" name="sort_keys" type="bool" default="false">
 			</argument>
 			<description>
-				Converts a [Variant] var to JSON text and returns the result. Useful for serializing data to store or send over the network.
+				Converts the [Variant] value to JSON text and returns the result as a [String]. Useful for serializing data to store or send over the network.
 				[b]Note:[/b] The JSON specification does not define integer or float types, but only a [i]number[/i] type. Therefore, converting a Variant to JSON text will convert all numerical values to [float] types.
-				Use [code]indent[/code] parameter to pretty print the output.
+				Use the [code]indent[/code] parameter to beautify the output.
 				[b]Example output:[/b]
 				[codeblock]
 				## JSON.print(my_dictionary)

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -172,7 +172,7 @@ Error EditorFeatureProfile::save_to_file(const String &p_path) {
 	FileAccessRef f = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
 
-	String text = JSON::print(json, "\t");
+	String text = JSON::to_json(json, "\t");
 	f->store_string(text);
 	f->close();
 	return OK;

--- a/modules/gdnative/gdnative/dictionary.cpp
+++ b/modules/gdnative/gdnative/dictionary.cpp
@@ -162,7 +162,7 @@ godot_string GDAPI godot_dictionary_to_json(const godot_dictionary *p_self) {
 	godot_string raw_dest;
 	String *dest = (String *)&raw_dest;
 	const Dictionary *self = (const Dictionary *)p_self;
-	memnew_placement(dest, String(JSON::print(Variant(*self))));
+	memnew_placement(dest, String(JSON::to_json(Variant(*self))));
 	return raw_dest;
 }
 

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -182,7 +182,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 					symbol.detail += ": " + m.get_datatype().to_string();
 				}
 				if (m.variable->initializer != nullptr && m.variable->initializer->is_constant) {
-					symbol.detail += " = " + JSON::print(m.variable->initializer->reduced_value);
+					symbol.detail += " = " + JSON::to_json(m.variable->initializer->reduced_value);
 				}
 
 				symbol.documentation = parse_documentation(LINE_NUMBER_TO_INDEX(m.variable->start_line));
@@ -223,10 +223,10 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 							}
 						}
 					} else {
-						value_text = JSON::print(default_value);
+						value_text = JSON::to_json(default_value);
 					}
 				} else {
-					value_text = JSON::print(default_value);
+					value_text = JSON::to_json(default_value);
 				}
 				if (!value_text.empty()) {
 					symbol.detail += " = " + value_text;
@@ -352,7 +352,7 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 			parameters += ": " + parameter->get_datatype().to_string();
 		}
 		if (parameter->default_value != nullptr) {
-			String value = JSON::print(parameter->default_value->reduced_value);
+			String value = JSON::to_json(parameter->default_value->reduced_value);
 			parameters += " = " + value;
 		}
 	}

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -195,7 +195,7 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 				vformat("GDScriptLanguageProtocol: Can't initialize invalid peer '%d'.", latest_client_id));
 		Ref<LSPeer> peer = clients.get(latest_client_id);
 		if (peer != nullptr) {
-			String msg = JSON::print(request);
+			String msg = JSON::to_json(request);
 			msg = format_output(msg);
 			(*peer)->res_queue.push_back(msg.utf8());
 		}
@@ -281,7 +281,7 @@ void GDScriptLanguageProtocol::notify_client(const String &p_method, const Varia
 	ERR_FAIL_COND(peer == nullptr);
 
 	Dictionary message = make_notification(p_method, p_params);
-	String msg = JSON::print(message);
+	String msg = JSON::to_json(message);
 	msg = format_output(msg);
 	peer->res_queue.push_back(msg.utf8());
 }

--- a/modules/jsonrpc/jsonrpc.cpp
+++ b/modules/jsonrpc/jsonrpc.cpp
@@ -168,7 +168,7 @@ String JSONRPC::process_string(const String &p_input) {
 	if (ret.get_type() == Variant::NIL) {
 		return "";
 	}
-	return JSON::print(ret);
+	return JSON::to_json(ret);
 }
 
 void JSONRPC::set_scope(const String &p_scope, Object *p_obj) {

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -240,7 +240,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 	FileAccessRef f = FileAccess::open(p_output_file, FileAccess::WRITE);
 	ERR_FAIL_COND_MSG(!f, "Cannot open file '" + p_output_file + "'.");
-	f->store_string(JSON::print(classes_dict, /*indent: */ "\t"));
+	f->store_string(JSON::to_json(classes_dict, /*indent: */ "\t"));
 	f->close();
 
 	print_line(String() + "ClassDB API JSON written to: " + ProjectSettings::get_singleton()->globalize_path(p_output_file));

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -287,7 +287,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 	Vector<String> flags;
 	String flags_json;
 	gen_export_flags(flags, p_flags);
-	flags_json = JSON::print(flags);
+	flags_json = JSON::to_json(flags);
 	String libs;
 	for (int i = 0; i < p_shared_objects.size(); i++) {
 		libs += "\"" + p_shared_objects[i].path.get_file() + "\",";


### PR DESCRIPTION
As originally identified [here](https://github.com/godotengine/godot/issues/16863#issuecomment-557770496), currently, `JSON::print()` doesn't print anything, it converts the specified `Variant` to a JSON `String`. Since, other references to this method in Godot -- including the @GDScript [version](https://docs.godotengine.org/en/stable/classes/class_@gdscript.html#class-gdscript-method-to-json) of this method (in 3.2) -- that call this method are all `to_json()`, it makes sense to rename this method `to_json()`.

Part of #16863.


