### PR TITLE
Rename MainLoop methods to match Node methods

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -50,7 +50,7 @@ private:
 	uint64_t frames_drawn = 0;
 	uint32_t _frame_delay = 0;
 	uint64_t _frame_ticks = 0;
-	float _frame_step = 0;
+	float _process_step = 0;
 
 	int ips = 60;
 	float physics_jitter_fix = 0.5;
@@ -62,7 +62,7 @@ private:
 	bool abort_on_gpu_errors = false;
 	bool use_validation_layers = false;
 
-	uint64_t _idle_frames = 0;
+	uint64_t _process_frames = 0;
 	bool _in_physics = false;
 
 	List<Singleton> singletons;
@@ -89,10 +89,10 @@ public:
 	uint64_t get_frames_drawn();
 
 	uint64_t get_physics_frames() const { return _physics_frames; }
-	uint64_t get_idle_frames() const { return _idle_frames; }
+	uint64_t get_process_frames() const { return _process_frames; }
 	bool is_in_physics_frame() const { return _in_physics; }
-	uint64_t get_idle_frame_ticks() const { return _frame_ticks; }
-	float get_idle_frame_step() const { return _frame_step; }
+	uint64_t get_frame_ticks() const { return _frame_ticks; }
+	float get_process_step() const { return _process_step; }
 	float get_physics_interpolation_fraction() const { return _physics_interpolation_fraction; }
 
 	void set_time_scale(float p_scale);

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2278,8 +2278,8 @@ uint64_t _Engine::get_physics_frames() const {
 	return Engine::get_singleton()->get_physics_frames();
 }
 
-uint64_t _Engine::get_idle_frames() const {
-	return Engine::get_singleton()->get_idle_frames();
+uint64_t _Engine::get_process_frames() const {
+	return Engine::get_singleton()->get_process_frames();
 }
 
 void _Engine::set_time_scale(float p_scale) {
@@ -2358,7 +2358,7 @@ void _Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_frames_drawn"), &_Engine::get_frames_drawn);
 	ClassDB::bind_method(D_METHOD("get_frames_per_second"), &_Engine::get_frames_per_second);
 	ClassDB::bind_method(D_METHOD("get_physics_frames"), &_Engine::get_physics_frames);
-	ClassDB::bind_method(D_METHOD("get_idle_frames"), &_Engine::get_idle_frames);
+	ClassDB::bind_method(D_METHOD("get_process_frames"), &_Engine::get_process_frames);
 
 	ClassDB::bind_method(D_METHOD("get_main_loop"), &_Engine::get_main_loop);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -635,7 +635,7 @@ public:
 
 	float get_frames_per_second() const;
 	uint64_t get_physics_frames() const;
-	uint64_t get_idle_frames() const;
+	uint64_t get_process_frames() const;
 
 	int get_frames_drawn();
 

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -117,9 +117,9 @@ void EngineDebugger::line_poll() {
 	poll_every++;
 }
 
-void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_idle_ticks, uint64_t p_physics_ticks, float p_physics_frame_time) {
+void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, float p_physics_frame_time) {
 	frame_time = USEC_TO_SEC(p_frame_ticks);
-	idle_time = USEC_TO_SEC(p_idle_ticks);
+	process_time = USEC_TO_SEC(p_process_ticks);
 	physics_time = USEC_TO_SEC(p_physics_ticks);
 	physics_frame_time = p_physics_frame_time;
 	// Notify tick to running profilers
@@ -128,7 +128,7 @@ void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_idle_ticks, ui
 		if (!p.active || !p.tick) {
 			continue;
 		}
-		p.tick(p.data, frame_time, idle_time, physics_time, physics_frame_time);
+		p.tick(p.data, frame_time, process_time, physics_time, physics_frame_time);
 	}
 	singleton->poll_events(true);
 }

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -44,7 +44,7 @@ class ScriptDebugger;
 class EngineDebugger {
 public:
 	typedef void (*ProfilingToggle)(void *p_user, bool p_enable, const Array &p_opts);
-	typedef void (*ProfilingTick)(void *p_user, float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time);
+	typedef void (*ProfilingTick)(void *p_user, float p_frame_time, float p_process_time, float p_physics_time, float p_physics_frame_time);
 	typedef void (*ProfilingAdd)(void *p_user, const Array &p_arr);
 
 	typedef Error (*CaptureFunc)(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);
@@ -86,7 +86,7 @@ public:
 
 private:
 	float frame_time = 0.0;
-	float idle_time = 0.0;
+	float process_time = 0.0;
 	float physics_time = 0.0;
 	float physics_frame_time = 0.0;
 
@@ -120,7 +120,7 @@ public:
 
 	static void register_uri_handler(const String &p_protocol, CreatePeerFunc p_func);
 
-	void iteration(uint64_t p_frame_ticks, uint64_t p_idle_ticks, uint64_t p_physics_ticks, float p_physics_frame_time);
+	void iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, float p_physics_frame_time);
 	void profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts = Array());
 	Error capture_parse(const StringName &p_name, const String &p_msg, const Array &p_args, bool &r_captured);
 

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -317,7 +317,7 @@ struct RemoteDebugger::ServersProfiler {
 
 	void _send_frame_data(bool p_final) {
 		DebuggerMarshalls::ServersProfilerFrame frame;
-		frame.frame_number = Engine::get_singleton()->get_idle_frames();
+		frame.frame_number = Engine::get_singleton()->get_process_frames();
 		frame.frame_time = frame_time;
 		frame.idle_time = idle_time;
 		frame.physics_time = physics_time;

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -247,7 +247,7 @@ bool Input::is_action_just_pressed(const StringName &p_action) const {
 	if (Engine::get_singleton()->is_in_physics_frame()) {
 		return E->get().pressed && E->get().physics_frame == Engine::get_singleton()->get_physics_frames();
 	} else {
-		return E->get().pressed && E->get().idle_frame == Engine::get_singleton()->get_idle_frames();
+		return E->get().pressed && E->get().process_frame == Engine::get_singleton()->get_process_frames();
 	}
 }
 
@@ -260,7 +260,7 @@ bool Input::is_action_just_released(const StringName &p_action) const {
 	if (Engine::get_singleton()->is_in_physics_frame()) {
 		return !E->get().pressed && E->get().physics_frame == Engine::get_singleton()->get_physics_frames();
 	} else {
-		return !E->get().pressed && E->get().idle_frame == Engine::get_singleton()->get_idle_frames();
+		return !E->get().pressed && E->get().process_frame == Engine::get_singleton()->get_process_frames();
 	}
 }
 
@@ -588,7 +588,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			if (!p_event->is_echo() && is_action_pressed(E->key()) != p_event->is_action_pressed(E->key())) {
 				Action action;
 				action.physics_frame = Engine::get_singleton()->get_physics_frames();
-				action.idle_frame = Engine::get_singleton()->get_idle_frames();
+				action.process_frame = Engine::get_singleton()->get_process_frames();
 				action.pressed = p_event->is_action_pressed(E->key());
 				action.strength = 0.0f;
 				action.raw_strength = 0.0f;
@@ -714,7 +714,7 @@ void Input::action_press(const StringName &p_action, float p_strength) {
 	Action action;
 
 	action.physics_frame = Engine::get_singleton()->get_physics_frames();
-	action.idle_frame = Engine::get_singleton()->get_idle_frames();
+	action.process_frame = Engine::get_singleton()->get_process_frames();
 	action.pressed = true;
 	action.strength = p_strength;
 
@@ -725,7 +725,7 @@ void Input::action_release(const StringName &p_action) {
 	Action action;
 
 	action.physics_frame = Engine::get_singleton()->get_physics_frames();
-	action.idle_frame = Engine::get_singleton()->get_idle_frames();
+	action.process_frame = Engine::get_singleton()->get_process_frames();
 	action.pressed = false;
 	action.strength = 0.f;
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -114,7 +114,7 @@ private:
 
 	struct Action {
 		uint64_t physics_frame;
-		uint64_t idle_frame;
+		uint64_t process_frame;
 		bool pressed;
 		float strength;
 		float raw_strength;

--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -34,8 +34,8 @@
 
 void MainLoop::_bind_methods() {
 	BIND_VMETHOD(MethodInfo("_initialize"));
-	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_iteration", PropertyInfo(Variant::FLOAT, "delta")));
-	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_idle", PropertyInfo(Variant::FLOAT, "delta")));
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_physics_process", PropertyInfo(Variant::FLOAT, "delta")));
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_process", PropertyInfo(Variant::FLOAT, "delta")));
 	BIND_VMETHOD(MethodInfo("_finalize"));
 
 	BIND_CONSTANT(NOTIFICATION_OS_MEMORY_WARNING);
@@ -52,13 +52,13 @@ void MainLoop::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("on_request_permissions_result", PropertyInfo(Variant::STRING, "permission"), PropertyInfo(Variant::BOOL, "granted")));
 };
 
-void MainLoop::set_init_script(const Ref<Script> &p_init_script) {
-	init_script = p_init_script;
+void MainLoop::set_initialize_script(const Ref<Script> &p_initialize_script) {
+	initialize_script = p_initialize_script;
 }
 
-void MainLoop::init() {
-	if (init_script.is_valid()) {
-		set_script(init_script);
+void MainLoop::initialize() {
+	if (initialize_script.is_valid()) {
+		set_script(initialize_script);
 	}
 
 	if (get_script_instance()) {
@@ -66,23 +66,23 @@ void MainLoop::init() {
 	}
 }
 
-bool MainLoop::iteration(float p_time) {
+bool MainLoop::physics_process(float p_time) {
 	if (get_script_instance()) {
-		return get_script_instance()->call("_iteration", p_time);
+		return get_script_instance()->call("_physics_process", p_time);
 	}
 
 	return false;
 }
 
-bool MainLoop::idle(float p_time) {
+bool MainLoop::process(float p_time) {
 	if (get_script_instance()) {
-		return get_script_instance()->call("_idle", p_time);
+		return get_script_instance()->call("_process", p_time);
 	}
 
 	return false;
 }
 
-void MainLoop::finish() {
+void MainLoop::finalize() {
 	if (get_script_instance()) {
 		get_script_instance()->call("_finalize");
 		set_script(Variant()); //clear script

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -39,7 +39,7 @@ class MainLoop : public Object {
 	GDCLASS(MainLoop, Object);
 	OBJ_CATEGORY("Main Loop");
 
-	Ref<Script> init_script;
+	Ref<Script> initialize_script;
 
 protected:
 	static void _bind_methods();
@@ -59,12 +59,12 @@ public:
 		NOTIFICATION_TEXT_SERVER_CHANGED = 2018,
 	};
 
-	virtual void init();
-	virtual bool iteration(float p_time);
-	virtual bool idle(float p_time);
-	virtual void finish();
+	virtual void initialize();
+	virtual bool physics_process(float p_time);
+	virtual bool process(float p_time);
+	virtual void finalize();
 
-	void set_init_script(const Ref<Script> &p_init_script);
+	void set_initialize_script(const Ref<Script> &p_initialize_script);
 
 	MainLoop() {}
 	virtual ~MainLoop() {}

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -41,7 +41,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the total number of frames drawn. If the render loop is disabled with [code]--disable-render-loop[/code] via command line, this returns [code]0[/code]. See also [method get_idle_frames].
+				Returns the total number of frames drawn. If the render loop is disabled with [code]--disable-render-loop[/code] via command line, this returns [code]0[/code]. See also [method get_process_frames].
 			</description>
 		</method>
 		<method name="get_frames_per_second" qualifiers="const">
@@ -51,11 +51,11 @@
 				Returns the frames per second of the running game.
 			</description>
 		</method>
-		<method name="get_idle_frames" qualifiers="const">
+		<method name="get_process_frames" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the total number of frames passed since engine initialization which is advanced on each [b]idle frame[/b], regardless of whether the render loop is enabled. See also [method get_frames_drawn].
+				Returns the total number of frames passed since engine initialization which is advanced on each [b]process frame[/b], regardless of whether the render loop is enabled. See also [method get_frames_drawn].
 			</description>
 		</method>
 		<method name="get_license_info" qualifiers="const">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2007,7 +2007,7 @@ bool Main::start() {
 								script));
 			}
 
-			script_loop->set_init_script(script_res);
+			script_loop->set_initialize_script(script_res);
 			main_loop = script_loop;
 		} else {
 			return false;
@@ -2026,7 +2026,7 @@ bool Main::start() {
 				DisplayServer::get_singleton()->alert("Error: Invalid MainLoop script base type: " + script_base);
 				ERR_FAIL_V_MSG(false, vformat("The global class %s does not inherit from SceneTree or MainLoop.", main_loop_type));
 			}
-			script_loop->set_init_script(script_res);
+			script_loop->set_initialize_script(script_res);
 			main_loop = script_loop;
 		}
 	}
@@ -2422,7 +2422,7 @@ bool Main::is_iterating() {
 
 // For performance metrics.
 static uint64_t physics_process_max = 0;
-static uint64_t idle_process_max = 0;
+static uint64_t process_max = 0;
 
 bool Main::iteration() {
 	//for now do not error on this
@@ -2438,19 +2438,19 @@ bool Main::iteration() {
 	uint64_t ticks_elapsed = ticks - last_ticks;
 
 	int physics_fps = Engine::get_singleton()->get_iterations_per_second();
-	float frame_slice = 1.0 / physics_fps;
+	float physics_step = 1.0 / physics_fps;
 
 	float time_scale = Engine::get_singleton()->get_time_scale();
 
-	MainFrameTime advance = main_timer_sync.advance(frame_slice, physics_fps);
-	double step = advance.idle_step;
-	double scaled_step = step * time_scale;
+	MainFrameTime advance = main_timer_sync.advance(physics_step, physics_fps);
+	double process_step = advance.process_step;
+	double scaled_step = process_step * time_scale;
 
-	Engine::get_singleton()->_frame_step = step;
+	Engine::get_singleton()->_process_step = process_step;
 	Engine::get_singleton()->_physics_interpolation_fraction = advance.interpolation_fraction;
 
 	uint64_t physics_process_ticks = 0;
-	uint64_t idle_process_ticks = 0;
+	uint64_t process_ticks = 0;
 
 	frame += ticks_elapsed;
 
@@ -2458,7 +2458,7 @@ bool Main::iteration() {
 
 	static const int max_physics_steps = 8;
 	if (fixed_fps == -1 && advance.physics_steps > max_physics_steps) {
-		step -= (advance.physics_steps - max_physics_steps) * frame_slice;
+		process_step -= (advance.physics_steps - max_physics_steps) * physics_step;
 		advance.physics_steps = max_physics_steps;
 	}
 
@@ -2474,33 +2474,32 @@ bool Main::iteration() {
 		PhysicsServer2D::get_singleton()->sync();
 		PhysicsServer2D::get_singleton()->flush_queries();
 
-		if (OS::get_singleton()->get_main_loop()->iteration(frame_slice * time_scale)) {
+		if (OS::get_singleton()->get_main_loop()->physics_process(physics_step * time_scale)) {
 			exit = true;
 			break;
 		}
 
-		NavigationServer3D::get_singleton_mut()->process(frame_slice * time_scale);
+		NavigationServer3D::get_singleton_mut()->process(physics_step * time_scale);
 
 		message_queue->flush();
 
-		PhysicsServer3D::get_singleton()->step(frame_slice * time_scale);
+		PhysicsServer3D::get_singleton()->step(physics_step * time_scale);
 
 		PhysicsServer2D::get_singleton()->end_sync();
-		PhysicsServer2D::get_singleton()->step(frame_slice * time_scale);
+		PhysicsServer2D::get_singleton()->step(physics_step * time_scale);
 
 		message_queue->flush();
 
-		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() -
-																   physics_begin); // keep the largest one for reference
+		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference
 		physics_process_max = MAX(OS::get_singleton()->get_ticks_usec() - physics_begin, physics_process_max);
 		Engine::get_singleton()->_physics_frames++;
 	}
 
 	Engine::get_singleton()->_in_physics = false;
 
-	uint64_t idle_begin = OS::get_singleton()->get_ticks_usec();
+	uint64_t process_begin = OS::get_singleton()->get_ticks_usec();
 
-	if (OS::get_singleton()->get_main_loop()->idle(step * time_scale)) {
+	if (OS::get_singleton()->get_main_loop()->process(process_step * time_scale)) {
 		exit = true;
 	}
 	message_queue->flush();
@@ -2521,8 +2520,8 @@ bool Main::iteration() {
 		}
 	}
 
-	idle_process_ticks = OS::get_singleton()->get_ticks_usec() - idle_begin;
-	idle_process_max = MAX(idle_process_ticks, idle_process_max);
+	process_ticks = OS::get_singleton()->get_ticks_usec() - process_begin;
+	process_max = MAX(process_ticks, process_max);
 	uint64_t frame_time = OS::get_singleton()->get_ticks_usec() - ticks;
 
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
@@ -2532,11 +2531,11 @@ bool Main::iteration() {
 	AudioServer::get_singleton()->update();
 
 	if (EngineDebugger::is_active()) {
-		EngineDebugger::get_singleton()->iteration(frame_time, idle_process_ticks, physics_process_ticks, frame_slice);
+		EngineDebugger::get_singleton()->iteration(frame_time, process_ticks, physics_process_ticks, physics_step);
 	}
 
 	frames++;
-	Engine::get_singleton()->_idle_frames++;
+	Engine::get_singleton()->_process_frames++;
 
 	if (frame > 1000000) {
 		if (editor || project_manager) {
@@ -2548,9 +2547,9 @@ bool Main::iteration() {
 		}
 
 		Engine::get_singleton()->_fps = frames;
-		performance->set_process_time(USEC_TO_SEC(idle_process_max));
+		performance->set_process_time(USEC_TO_SEC(process_max));
 		performance->set_physics_process_time(USEC_TO_SEC(physics_process_max));
-		idle_process_max = 0;
+		process_max = 0;
 		physics_process_max = 0;
 
 		frame %= 1000000;

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -30,17 +30,17 @@
 
 #include "main_timer_sync.h"
 
-void MainFrameTime::clamp_idle(float min_idle_step, float max_idle_step) {
-	if (idle_step < min_idle_step) {
-		idle_step = min_idle_step;
-	} else if (idle_step > max_idle_step) {
-		idle_step = max_idle_step;
+void MainFrameTime::clamp_process_step(float min_process_step, float max_process_step) {
+	if (process_step < min_process_step) {
+		process_step = min_process_step;
+	} else if (process_step > max_process_step) {
+		process_step = max_process_step;
 	}
 }
 
 /////////////////////////////////
 
-// returns the fraction of p_frame_slice required for the timer to overshoot
+// returns the fraction of p_physics_step required for the timer to overshoot
 // before advance_core considers changing the physics_steps return from
 // the typical values as defined by typical_physics_steps
 float MainTimerSync::get_physics_jitter_fix() {
@@ -72,15 +72,15 @@ int MainTimerSync::get_average_physics_steps(float &p_min, float &p_max) {
 	return CONTROL_STEPS;
 }
 
-// advance physics clock by p_idle_step, return appropriate number of steps to simulate
-MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_per_second, float p_idle_step) {
+// advance physics clock by p_process_step, return appropriate number of steps to simulate
+MainFrameTime MainTimerSync::advance_core(float p_physics_step, int p_physics_fps, float p_process_step) {
 	MainFrameTime ret;
 
-	ret.idle_step = p_idle_step;
+	ret.process_step = p_process_step;
 
 	// simple determination of number of physics iteration
-	time_accum += ret.idle_step;
-	ret.physics_steps = floor(time_accum * p_iterations_per_second);
+	time_accum += ret.process_step;
+	ret.physics_steps = floor(time_accum * p_physics_fps);
 
 	int min_typical_steps = typical_physics_steps[0];
 	int max_typical_steps = min_typical_steps + 1;
@@ -107,7 +107,7 @@ MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_
 
 	// try to keep it consistent with previous iterations
 	if (ret.physics_steps < min_typical_steps) {
-		const int max_possible_steps = floor((time_accum)*p_iterations_per_second + get_physics_jitter_fix());
+		const int max_possible_steps = floor((time_accum)*p_physics_fps + get_physics_jitter_fix());
 		if (max_possible_steps < min_typical_steps) {
 			ret.physics_steps = max_possible_steps;
 			update_typical = true;
@@ -115,7 +115,7 @@ MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_
 			ret.physics_steps = min_typical_steps;
 		}
 	} else if (ret.physics_steps > max_typical_steps) {
-		const int min_possible_steps = floor((time_accum)*p_iterations_per_second - get_physics_jitter_fix());
+		const int min_possible_steps = floor((time_accum)*p_physics_fps - get_physics_jitter_fix());
 		if (min_possible_steps > max_typical_steps) {
 			ret.physics_steps = min_possible_steps;
 			update_typical = true;
@@ -124,7 +124,7 @@ MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_
 		}
 	}
 
-	time_accum -= ret.physics_steps * p_frame_slice;
+	time_accum -= ret.physics_steps * p_physics_step;
 
 	// keep track of accumulated step counts
 	for (int i = CONTROL_STEPS - 2; i >= 0; --i) {
@@ -146,52 +146,52 @@ MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_
 }
 
 // calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
-MainFrameTime MainTimerSync::advance_checked(float p_frame_slice, int p_iterations_per_second, float p_idle_step) {
+MainFrameTime MainTimerSync::advance_checked(float p_physics_step, int p_physics_fps, float p_process_step) {
 	if (fixed_fps != -1) {
-		p_idle_step = 1.0 / fixed_fps;
+		p_process_step = 1.0 / fixed_fps;
 	}
 
 	// compensate for last deficit
-	p_idle_step += time_deficit;
+	p_process_step += time_deficit;
 
-	MainFrameTime ret = advance_core(p_frame_slice, p_iterations_per_second, p_idle_step);
+	MainFrameTime ret = advance_core(p_physics_step, p_physics_fps, p_process_step);
 
-	// we will do some clamping on ret.idle_step and need to sync those changes to time_accum,
+	// we will do some clamping on ret.process_step and need to sync those changes to time_accum,
 	// that's easiest if we just remember their fixed difference now
-	const double idle_minus_accum = ret.idle_step - time_accum;
+	const double process_minus_accum = ret.process_step - time_accum;
 
-	// first, least important clamping: keep ret.idle_step consistent with typical_physics_steps.
-	// this smoothes out the idle steps and culls small but quick variations.
+	// first, least important clamping: keep ret.process_step consistent with typical_physics_steps.
+	// this smoothes out the process steps and culls small but quick variations.
 	{
 		float min_average_physics_steps, max_average_physics_steps;
 		int consistent_steps = get_average_physics_steps(min_average_physics_steps, max_average_physics_steps);
 		if (consistent_steps > 3) {
-			ret.clamp_idle(min_average_physics_steps * p_frame_slice, max_average_physics_steps * p_frame_slice);
+			ret.clamp_process_step(min_average_physics_steps * p_physics_step, max_average_physics_steps * p_physics_step);
 		}
 	}
 
 	// second clamping: keep abs(time_deficit) < jitter_fix * frame_slise
-	float max_clock_deviation = get_physics_jitter_fix() * p_frame_slice;
-	ret.clamp_idle(p_idle_step - max_clock_deviation, p_idle_step + max_clock_deviation);
+	float max_clock_deviation = get_physics_jitter_fix() * p_physics_step;
+	ret.clamp_process_step(p_process_step - max_clock_deviation, p_process_step + max_clock_deviation);
 
-	// last clamping: make sure time_accum is between 0 and p_frame_slice for consistency between physics and idle
-	ret.clamp_idle(idle_minus_accum, idle_minus_accum + p_frame_slice);
+	// last clamping: make sure time_accum is between 0 and p_physics_step for consistency between physics and process
+	ret.clamp_process_step(process_minus_accum, process_minus_accum + p_physics_step);
 
 	// restore time_accum
-	time_accum = ret.idle_step - idle_minus_accum;
+	time_accum = ret.process_step - process_minus_accum;
 
 	// track deficit
-	time_deficit = p_idle_step - ret.idle_step;
+	time_deficit = p_process_step - ret.process_step;
 
-	// p_frame_slice is 1.0 / iterations_per_sec
+	// p_physics_step is 1.0 / iterations_per_sec
 	// i.e. the time in seconds taken by a physics tick
-	ret.interpolation_fraction = time_accum / p_frame_slice;
+	ret.interpolation_fraction = time_accum / p_physics_step;
 
 	return ret;
 }
 
 // determine wall clock step since last iteration
-float MainTimerSync::get_cpu_idle_step() {
+float MainTimerSync::get_cpu_process_step() {
 	uint64_t cpu_ticks_elapsed = current_cpu_ticks_usec - last_cpu_ticks_usec;
 	last_cpu_ticks_usec = current_cpu_ticks_usec;
 
@@ -219,9 +219,9 @@ void MainTimerSync::set_fixed_fps(int p_fixed_fps) {
 	fixed_fps = p_fixed_fps;
 }
 
-// advance one frame, return timesteps to take
-MainFrameTime MainTimerSync::advance(float p_frame_slice, int p_iterations_per_second) {
-	float cpu_idle_step = get_cpu_idle_step();
+// advance one physics frame, return timesteps to take
+MainFrameTime MainTimerSync::advance(float p_physics_step, int p_physics_fps) {
+	float cpu_process_step = get_cpu_process_step();
 
-	return advance_checked(p_frame_slice, p_iterations_per_second, cpu_idle_step);
+	return advance_checked(p_physics_step, p_physics_fps, cpu_process_step);
 }

--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -34,11 +34,11 @@
 #include "core/config/engine.h"
 
 struct MainFrameTime {
-	float idle_step; // time to advance idles for (argument to process())
+	float process_step; // delta time to advance during process()
 	int physics_steps; // number of times to iterate the physics engine
 	float interpolation_fraction; // fraction through the current physics tick
 
-	void clamp_idle(float min_idle_step, float max_idle_step);
+	void clamp_process_step(float min_process_step, float max_process_step);
 };
 
 class MainTimerSync {
@@ -49,7 +49,7 @@ class MainTimerSync {
 	// logical game time since last physics timestep
 	float time_accum = 0;
 
-	// current difference between wall clock time and reported sum of idle_steps
+	// current difference between wall clock time and reported sum of process_steps
 	float time_deficit = 0;
 
 	// number of frames back for keeping accumulated physics steps roughly constant.
@@ -67,7 +67,7 @@ class MainTimerSync {
 	int fixed_fps = 0;
 
 protected:
-	// returns the fraction of p_frame_slice required for the timer to overshoot
+	// returns the fraction of p_physics_step required for the timer to overshoot
 	// before advance_core considers changing the physics_steps return from
 	// the typical values as defined by typical_physics_steps
 	float get_physics_jitter_fix();
@@ -76,14 +76,14 @@ protected:
 	// return value: number of frames back this data is consistent
 	int get_average_physics_steps(float &p_min, float &p_max);
 
-	// advance physics clock by p_idle_step, return appropriate number of steps to simulate
-	MainFrameTime advance_core(float p_frame_slice, int p_iterations_per_second, float p_idle_step);
+	// advance physics clock by p_process_step, return appropriate number of steps to simulate
+	MainFrameTime advance_core(float p_physics_step, int p_physics_fps, float p_process_step);
 
 	// calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
-	MainFrameTime advance_checked(float p_frame_slice, int p_iterations_per_second, float p_idle_step);
+	MainFrameTime advance_checked(float p_physics_step, int p_physics_fps, float p_process_step);
 
 	// determine wall clock step since last iteration
-	float get_cpu_idle_step();
+	float get_cpu_process_step();
 
 public:
 	MainTimerSync();
@@ -96,7 +96,7 @@ public:
 	void set_fixed_fps(int p_fixed_fps);
 
 	// advance one frame, return timesteps to take
-	MainFrameTime advance(float p_frame_slice, int p_iterations_per_second);
+	MainFrameTime advance(float p_physics_step, int p_physics_fps);
 };
 
 #endif // MAIN_TIMER_SYNC_H

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -139,7 +139,7 @@ MainLoop *OS_Android::get_main_loop() const {
 
 void OS_Android::main_loop_begin() {
 	if (main_loop)
-		main_loop->init();
+		main_loop->initialize();
 }
 
 bool OS_Android::main_loop_iterate() {
@@ -151,7 +151,7 @@ bool OS_Android::main_loop_iterate() {
 
 void OS_Android::main_loop_end() {
 	if (main_loop)
-		main_loop->finish();
+		main_loop->finalize();
 }
 
 void OS_Android::main_loop_focusout() {

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -149,7 +149,7 @@ void OSIPhone::set_main_loop(MainLoop *p_main_loop) {
 	main_loop = p_main_loop;
 
 	if (main_loop) {
-		main_loop->init();
+		main_loop->initialize();
 	}
 }
 
@@ -159,7 +159,7 @@ MainLoop *OSIPhone::get_main_loop() const {
 
 void OSIPhone::delete_main_loop() {
 	if (main_loop) {
-		main_loop->finish();
+		main_loop->finalize();
 		memdelete(main_loop);
 	};
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -246,7 +246,7 @@ void OS_LinuxBSD::run() {
 		return;
 	}
 
-	main_loop->init();
+	main_loop->initialize();
 
 	//uint64_t last_ticks=get_ticks_usec();
 
@@ -263,7 +263,7 @@ void OS_LinuxBSD::run() {
 		}
 	};
 
-	main_loop->finish();
+	main_loop->finalize();
 }
 
 void OS_LinuxBSD::disable_crash_handler() {

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -312,7 +312,7 @@ void OS_OSX::run() {
 	if (!main_loop)
 		return;
 
-	main_loop->init();
+	main_loop->initialize();
 
 	bool quit = false;
 	while (!force_quit && !quit) {
@@ -329,7 +329,7 @@ void OS_OSX::run() {
 			ERR_PRINT("NSException: " + String([exception reason].UTF8String));
 		}
 	};
-	main_loop->finish();
+	main_loop->finalize();
 }
 
 Error OS_OSX::move_to_trash(const String &p_path) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -614,7 +614,7 @@ void OS_Windows::run() {
 	if (!main_loop)
 		return;
 
-	main_loop->init();
+	main_loop->initialize();
 
 	while (!force_quit) {
 		DisplayServer::get_singleton()->process_events(); // get rid of pending events
@@ -622,7 +622,7 @@ void OS_Windows::run() {
 			break;
 	};
 
-	main_loop->finish();
+	main_loop->finalize();
 }
 
 MainLoop *OS_Windows::get_main_loop() const {

--- a/scene/3d/velocity_tracker_3d.cpp
+++ b/scene/3d/velocity_tracker_3d.cpp
@@ -45,7 +45,7 @@ void VelocityTracker3D::update_position(const Vector3 &p_position) {
 	if (physics_step) {
 		ph.frame = Engine::get_singleton()->get_physics_frames();
 	} else {
-		ph.frame = Engine::get_singleton()->get_idle_frame_ticks();
+		ph.frame = Engine::get_singleton()->get_frame_ticks();
 	}
 
 	if (position_history_len == 0 || position_history[0].frame != ph.frame) { //in same frame, use latest
@@ -72,7 +72,7 @@ Vector3 VelocityTracker3D::get_tracked_linear_velocity() const {
 			uint64_t base = Engine::get_singleton()->get_physics_frames();
 			base_time = float(base - position_history[0].frame) / Engine::get_singleton()->get_iterations_per_second();
 		} else {
-			uint64_t base = Engine::get_singleton()->get_idle_frame_ticks();
+			uint64_t base = Engine::get_singleton()->get_frame_ticks();
 			base_time = double(base - position_history[0].frame) / 1000000.0;
 		}
 	}
@@ -109,7 +109,7 @@ void VelocityTracker3D::reset(const Vector3 &p_new_pos) {
 	if (physics_step) {
 		ph.frame = Engine::get_singleton()->get_physics_frames();
 	} else {
-		ph.frame = Engine::get_singleton()->get_idle_frame_ticks();
+		ph.frame = Engine::get_singleton()->get_frame_ticks();
 	}
 
 	position_history.write[0] = ph;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -797,9 +797,9 @@ bool Node::can_process_notification(int p_what) const {
 		case NOTIFICATION_PHYSICS_PROCESS:
 			return data.physics_process;
 		case NOTIFICATION_PROCESS:
-			return data.idle_process;
+			return data.process;
 		case NOTIFICATION_INTERNAL_PROCESS:
-			return data.idle_process_internal;
+			return data.process_internal;
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS:
 			return data.physics_process_internal;
 	}
@@ -845,50 +845,50 @@ float Node::get_physics_process_delta_time() const {
 
 float Node::get_process_delta_time() const {
 	if (data.tree) {
-		return data.tree->get_idle_process_time();
+		return data.tree->get_process_time();
 	} else {
 		return 0;
 	}
 }
 
-void Node::set_process(bool p_idle_process) {
-	if (data.idle_process == p_idle_process) {
+void Node::set_process(bool p_process) {
+	if (data.process == p_process) {
 		return;
 	}
 
-	data.idle_process = p_idle_process;
+	data.process = p_process;
 
-	if (data.idle_process) {
-		add_to_group("idle_process", false);
+	if (data.process) {
+		add_to_group("process", false);
 	} else {
-		remove_from_group("idle_process");
+		remove_from_group("process");
 	}
 
-	_change_notify("idle_process");
+	_change_notify("process");
 }
 
 bool Node::is_processing() const {
-	return data.idle_process;
+	return data.process;
 }
 
-void Node::set_process_internal(bool p_idle_process_internal) {
-	if (data.idle_process_internal == p_idle_process_internal) {
+void Node::set_process_internal(bool p_process_internal) {
+	if (data.process_internal == p_process_internal) {
 		return;
 	}
 
-	data.idle_process_internal = p_idle_process_internal;
+	data.process_internal = p_process_internal;
 
-	if (data.idle_process_internal) {
-		add_to_group("idle_process_internal", false);
+	if (data.process_internal) {
+		add_to_group("process_internal", false);
 	} else {
-		remove_from_group("idle_process_internal");
+		remove_from_group("process_internal");
 	}
 
-	_change_notify("idle_process_internal");
+	_change_notify("process_internal");
 }
 
 bool Node::is_processing_internal() const {
-	return data.idle_process_internal;
+	return data.process_internal;
 }
 
 void Node::set_process_priority(int p_priority) {
@@ -900,11 +900,11 @@ void Node::set_process_priority(int p_priority) {
 	}
 
 	if (is_processing()) {
-		data.tree->make_group_changed("idle_process");
+		data.tree->make_group_changed("process");
 	}
 
 	if (is_processing_internal()) {
-		data.tree->make_group_changed("idle_process_internal");
+		data.tree->make_group_changed("process_internal");
 	}
 
 	if (is_physics_processing()) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -121,11 +121,11 @@ private:
 		// Variables used to properly sort the node when processing, ignored otherwise.
 		// TODO: Should move all the stuff below to bits.
 		bool physics_process = false;
-		bool idle_process = false;
+		bool process = false;
 		int process_priority = 0;
 
 		bool physics_process_internal = false;
-		bool idle_process_internal = false;
+		bool process_internal = false;
 
 		bool input = false;
 		bool unhandled_input = false;
@@ -339,14 +339,14 @@ public:
 	float get_physics_process_delta_time() const;
 	bool is_physics_processing() const;
 
-	void set_process(bool p_idle_process);
+	void set_process(bool p_process);
 	float get_process_delta_time() const;
 	bool is_processing() const;
 
 	void set_physics_process_internal(bool p_process_internal);
 	bool is_physics_processing_internal() const;
 
-	void set_process_internal(bool p_idle_process_internal);
+	void set_process_internal(bool p_process_internal);
 	bool is_processing_internal() const;
 
 	void set_process_priority(int p_priority);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -88,7 +88,7 @@ private:
 
 	uint64_t tree_version = 1;
 	float physics_process_time = 1.0;
-	float idle_process_time = 1.0;
+	float process_time = 1.0;
 	bool accept_quit = true;
 	bool quit_on_go_back = true;
 
@@ -236,12 +236,12 @@ public:
 
 	void flush_transform_notifications();
 
-	virtual void init() override;
+	virtual void initialize() override;
 
-	virtual bool iteration(float p_time) override;
-	virtual bool idle(float p_time) override;
+	virtual bool physics_process(float p_time) override;
+	virtual bool process(float p_time) override;
 
-	virtual void finish() override;
+	virtual void finalize() override;
 
 	void set_auto_accept_quit(bool p_enable);
 	void set_quit_on_go_back(bool p_enable);
@@ -249,7 +249,7 @@ public:
 	void quit(int p_exit_code = -1);
 
 	_FORCE_INLINE_ float get_physics_process_time() const { return physics_process_time; }
-	_FORCE_INLINE_ float get_idle_process_time() const { return idle_process_time; }
+	_FORCE_INLINE_ float get_process_time() const { return process_time; }
 
 #ifdef TOOLS_ENABLED
 	bool is_node_being_edited(const Node *p_node) const;

--- a/tests/test_gui.cpp
+++ b/tests/test_gui.cpp
@@ -63,8 +63,8 @@ public:
 	virtual void request_quit() {
 		quit();
 	}
-	virtual void init() {
-		SceneTree::init();
+	virtual void initialize() {
+		SceneTree::initialize();
 
 		Panel *frame = memnew(Panel);
 		frame->set_anchor(MARGIN_RIGHT, Control::ANCHOR_END);

--- a/tests/test_physics_2d.cpp
+++ b/tests/test_physics_2d.cpp
@@ -315,7 +315,7 @@ protected:
 	}
 
 public:
-	virtual void init() override {
+	virtual void initialize() override {
 		RenderingServer *vs = RenderingServer::get_singleton();
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
 
@@ -389,10 +389,10 @@ public:
 		//_add_plane(Vector2(-1,0).normalized(),-600);
 	}
 
-	virtual bool idle(float p_time) override {
+	virtual bool process(float p_time) override {
 		return false;
 	}
-	virtual void finish() override {
+	virtual void finalize() override {
 	}
 
 	TestPhysics2DMainLoop() {}

--- a/tests/test_physics_3d.cpp
+++ b/tests/test_physics_3d.cpp
@@ -122,7 +122,7 @@ protected:
 		ps->body_set_param(p_body, PhysicsServer3D::BODY_PARAM_BOUNCE, p_bounce);
 	}
 
-	void init_shapes() {
+	void initialize_shapes() {
 		RenderingServer *vs = RenderingServer::get_singleton();
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
 
@@ -269,9 +269,9 @@ public:
 	virtual void request_quit() {
 		quit = true;
 	}
-	virtual void init() override {
+	virtual void initialize() override {
 		ofs_x = ofs_y = 0;
-		init_shapes();
+		initialize_shapes();
 
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
 		space = ps->space_create();
@@ -310,7 +310,7 @@ public:
 		test_fall();
 		quit = false;
 	}
-	virtual bool iteration(float p_time) override {
+	virtual bool physics_process(float p_time) override {
 		if (mover.is_valid()) {
 			static float joy_speed = 10;
 			PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -328,7 +328,7 @@ public:
 
 		return quit;
 	}
-	virtual void finish() override {
+	virtual void finalize() override {
 	}
 
 	void test_joint() {
@@ -396,7 +396,7 @@ public:
 		create_static_plane(Plane(Vector3(0, 1, 0), -1));
 	}
 
-	virtual bool idle(float p_time) override {
+	virtual bool process(float p_time) override {
 		return false;
 	}
 


### PR DESCRIPTION
Currently, [`MainLoop`](https://docs.godotengine.org/en/stable/classes/class_mainloop.html) has methods [`_iteration()`](https://docs.godotengine.org/en/stable/classes/class_mainloop.html#class-mainloop-method-iteration) and [`_idle()`](https://docs.godotengine.org/en/stable/classes/class_mainloop.html#class-mainloop-method-idle). `_iteration()` is called during `_physics_process()` and `_idle()` is called during `_process()`, in the same way [`Node`](https://docs.godotengine.org/en/stable/classes/class_node.html)'s [`_physics_process()`](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-method-physics-process) and [`_process()`](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-method-process) are called. Similarly, [`Engine`](https://docs.godotengine.org/en/stable/classes/class_engine.html)'s [`get_idle_frames()`](https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-idle-frames) refers to the number of process frames.

To make things consistent and avoid confusion, this PR renames:
- `MainLoop`'s `_iteration()` to `_physics_process()`
- `MainLoop`'s `_idle()` to `_process()`
- `Engine`'s `get_idle_frames()` to `get_process_frames()`

Note: This PR includes renaming the internal methods and variables to match the exposed methods. Since these methods are called by `Main::iteration()`, this PR includes renaming some of the variables used in `Main::iteration()` and `MainTimerSync` to make it clearer what is happening in this method and its helper class. Specifically it should help distinguishing between the physics step, the process step, and the combined frame step. Similarly, it includes renaming the groups `"idle_process"` and  `"idle_process_internal"` to `"process"` and `"process_internal"` to match their notification names.

Part of #16863.