### PR TITLE
Fix filename disambiguation on scripts in certain occasions

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1954,7 +1954,7 @@ void ScriptEditor::_update_script_names() {
 		Vector<String> disambiguated_script_names;
 		Vector<String> full_script_paths;
 		for (int j = 0; j < sedata.size(); j++) {
-			disambiguated_script_names.append(sedata[j].name.replace("(*)", ""));
+			disambiguated_script_names.append(sedata[j].name.replace("(*)", "").get_file());
 			full_script_paths.append(sedata[j].tooltip);
 		}
 


### PR DESCRIPTION
The most common case is opening an odd number of scripts. This happens because script names are parsed with their previous disambiguation, and when an odd number of scripts is parsed, the last one is left out because it ended up not sharing its name with the others.