### PR TITLE
server platform builds with github compilation workflow

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -262,3 +262,4 @@ jobs:
           name: ${{ github.job }}
           path: bin/*
           retention-days: 14
+          

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -199,3 +199,66 @@ jobs:
           name: ${{ github.job }}
           path: bin/*
           retention-days: 14
+
+  linux-server:
+    runs-on: "ubuntu-20.04"
+    name: Server (platform=server target=release_debug, tools=no)
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Azure repositories are not reliable, we need to prevent azure giving us packages.
+      - name: Make apt sources.list use the default Ubuntu repositories
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo apt-get update
+
+      # Install all packages (except scons)
+      - name: Configure dependencies
+        run: |
+          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+
+      # Upload cache on completion and check it out now
+      - name: Load .scons_cache directory
+        id: linux-editor-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
+
+      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.x'
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: 'x64'
+
+      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
+      - name: Configuring Python packages
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons
+          python --version
+          scons --version
+
+      # We should always be explicit with our flags usage here since it's gonna be sure to always set those flags
+      - name: Compilation
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+        run: |
+          scons platform=server tools=no target=release_debug
+          ls -l bin/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: bin/*
+          retention-days: 14

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -527,6 +527,14 @@ public:
 	AABB mesh_get_aabb(RID p_mesh, RID p_skeleton = RID()) override { return AABB(); }
 	void mesh_clear(RID p_mesh) override {}
 
+	void mesh_set_blend_shape_count(RID p_mesh, int p_blend_shape_count) override{};
+	bool mesh_needs_instance(RID p_mesh, bool p_has_skeleton) override { return false; };
+	RID mesh_instance_create(RID p_base) override { return RID(); };
+	void mesh_instance_set_skeleton(RID p_mesh_instance, RID p_skeleton) override{};
+	void mesh_instance_set_blend_shape_weight(RID p_mesh_instance, int p_shape, float p_weight) override{};
+	void mesh_instance_check_for_update(RID p_mesh_instance) override{};
+	void update_mesh_instances() override{};
+
 	/* MULTIMESH API */
 
 	RID multimesh_create() override { return RID(); }

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -130,6 +130,7 @@ public:
 
 	RID reflection_atlas_create() override { return RID(); }
 	void reflection_atlas_set_size(RID p_ref_atlas, int p_reflection_size, int p_reflection_count) override {}
+	int reflection_atlas_get_size(RID p_ref_atlas) const override { return 0; }
 
 	RID reflection_probe_instance_create(RID p_probe) override { return RID(); }
 	void reflection_probe_instance_set_transform(RID p_instance, const Transform &p_transform) override {}
@@ -149,8 +150,8 @@ public:
 
 	void gi_probe_set_quality(RS::GIProbeQuality) override {}
 
-	void render_scene(RID p_render_buffers, const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID *p_light_cull_result, int p_light_cull_count, RID *p_reflection_probe_cull_result, int p_reflection_probe_cull_count, RID *p_gi_probe_cull_result, int p_gi_probe_cull_count, RID *p_decal_cull_result, int p_decal_cull_count, InstanceBase **p_lightmap_cull_result, int p_lightmap_cull_count, RID p_environment, RID p_camera_effects, RID p_shadow_atlas, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass) override {}
-	void render_shadow(RID p_light, RID p_shadow_atlas, int p_pass, InstanceBase **p_cull_result, int p_cull_count) override {}
+	void render_scene(RID p_render_buffers, const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID *p_light_cull_result, int p_light_cull_count, RID *p_reflection_probe_cull_result, int p_reflection_probe_cull_count, RID *p_gi_probe_cull_result, int p_gi_probe_cull_count, RID *p_decal_cull_result, int p_decal_cull_count, InstanceBase **p_lightmap_cull_result, int p_lightmap_cull_count, RID p_environment, RID p_camera_effects, RID p_shadow_atlas, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_lod_threshold) override {}
+	void render_shadow(RID p_light, RID p_shadow_atlas, int p_pass, InstanceBase **p_cull_result, int p_cull_count, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0, float p_screen_lod_threshold = 0.0) override {}
 	void render_material(const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID p_framebuffer, const Rect2i &p_region) override {}
 	void render_sdfgi(RID p_render_buffers, int p_region, InstanceBase **p_cull_result, int p_cull_count) override {}
 	void render_sdfgi_static_lights(RID p_render_buffers, uint32_t p_cascade_count, const uint32_t *p_cascade_indices, const RID **p_positional_light_cull_result, const uint32_t *p_positional_light_cull_count) override {}
@@ -643,6 +644,7 @@ public:
 	void reflection_probe_set_enable_shadows(RID p_probe, bool p_enable) override {}
 	void reflection_probe_set_cull_mask(RID p_probe, uint32_t p_layers) override {}
 	void reflection_probe_set_resolution(RID p_probe, int p_resolution) override {}
+	void reflection_probe_set_lod_threshold(RID p_probe, float p_ratio) override {}
 
 	AABB reflection_probe_get_aabb(RID p_probe) const override { return AABB(); }
 	RS::ReflectionProbeUpdateMode reflection_probe_get_update_mode(RID p_probe) const override { return RenderingServer::REFLECTION_PROBE_UPDATE_ONCE; }
@@ -651,6 +653,7 @@ public:
 	Vector3 reflection_probe_get_origin_offset(RID p_probe) const override { return Vector3(); }
 	float reflection_probe_get_origin_max_distance(RID p_probe) const override { return 0.0; }
 	bool reflection_probe_renders_shadows(RID p_probe) const override { return false; }
+	float reflection_probe_get_lod_threshold(RID p_probe) const override { return 0.0; }
 
 	void base_update_dependency(RID p_base, InstanceBaseDependency *p_instance) override {}
 	void skeleton_update_dependency(RID p_base, InstanceBaseDependency *p_instance) override {}

--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -4,9 +4,10 @@ Import("env")
 Import("env_modules")
 
 env_lightmapper_rd = env_modules.Clone()
-env_lightmapper_rd.GLSL_HEADER("lm_raster.glsl")
-env_lightmapper_rd.GLSL_HEADER("lm_compute.glsl")
-env_lightmapper_rd.GLSL_HEADER("lm_blendseams.glsl")
+if "GLSL_HEADER" in env["BUILDERS"]:
+    env_lightmapper_rd.GLSL_HEADER("lm_raster.glsl")
+    env_lightmapper_rd.GLSL_HEADER("lm_compute.glsl")
+    env_lightmapper_rd.GLSL_HEADER("lm_blendseams.glsl")
 
 # Godot source files
 env_lightmapper_rd.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -31,9 +31,11 @@
 #include "lightmapper_rd.h"
 #include "core/config/project_settings.h"
 #include "core/math/geometry_2d.h"
+#ifndef SERVER_ENABLED
 #include "lm_blendseams.glsl.gen.h"
 #include "lm_compute.glsl.gen.h"
 #include "lm_raster.glsl.gen.h"
+#endif
 #include "servers/rendering/rendering_device_binds.h"
 
 //uncomment this if you want to see textures from all the process saved
@@ -796,7 +798,11 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	//shaders
 	Ref<RDShaderFile> raster_shader;
 	raster_shader.instance();
+#ifdef SERVER_ENABLED
+	Error err = ERR_UNAVAILABLE;
+#else
 	Error err = raster_shader->parse_versions_from_text(lm_raster_shader_glsl);
+#endif
 	if (err != OK) {
 		raster_shader->print_errors("raster_shader");
 
@@ -956,7 +962,11 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	Ref<RDShaderFile> compute_shader;
 	compute_shader.instance();
+#ifdef SERVER_ENABLED
+	err = ERR_UNAVAILABLE;
+#else
 	err = compute_shader->parse_versions_from_text(lm_compute_shader_glsl, p_bake_sh ? "\n#define USE_SH_LIGHTMAPS\n" : "");
+#endif
 	if (err != OK) {
 		FREE_TEXTURES
 		FREE_BUFFERS
@@ -1511,7 +1521,11 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	//shaders
 	Ref<RDShaderFile> blendseams_shader;
 	blendseams_shader.instance();
+#ifdef SERVER_ENABLED
+	err = ERR_UNAVAILABLE;
+#else
 	err = blendseams_shader->parse_versions_from_text(lm_blendseams_shader_glsl);
+#endif
 	if (err != OK) {
 		FREE_TEXTURES
 		FREE_BUFFERS

--- a/platform/server/SCsub
+++ b/platform/server/SCsub
@@ -11,6 +11,6 @@ common_server = [
 if sys.platform == "darwin":
     common_server.append("#platform/osx/crash_handler_osx.mm")
 else:
-    common_server.append("#platform/x11/crash_handler_x11.cpp")
+    common_server.append("#platform/linuxbsd/crash_handler_linuxbsd.cpp")
 
 prog = env.add_program("#bin/godot_server", ["godot_server.cpp"] + common_server)

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -59,28 +59,29 @@ void OS_Server::initialize_core() {
 	OS_Unix::initialize_core();
 }
 
-Error OS_Server::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {
+void OS_Server::initialize_joypads() {
+	// Do nothing
+}
+
+void OS_Server::initialize() {
 	args = OS::get_singleton()->get_cmdline_args();
-	current_videomode = p_desired;
 	main_loop = nullptr;
 
 	RasterizerDummy::make_current();
 
-	video_driver_index = p_video_driver; // unused in server platform, but should still be initialized
+	video_driver_index = 0; // unused in server platform, but should still be initialized
 
 	rendering_server = memnew(RenderingServerDefault);
 	rendering_server->init();
 
-	AudioDriverManager::initialize(p_audio_driver);
+	AudioDriverManager::initialize(-1);
 
-	input = memnew(InputDefault);
+	input = memnew(Input);
 
-	_ensure_user_data_dir();
+	ensure_user_data_dir();
 
 	resource_loader_dummy.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_dummy);
-
-	return OK;
 }
 
 void OS_Server::finalize() {
@@ -121,20 +122,6 @@ Point2 OS_Server::get_mouse_position() const {
 void OS_Server::set_window_title(const String &p_title) {
 }
 
-void OS_Server::set_video_mode(const VideoMode &p_video_mode, int p_screen) {
-}
-
-OS::VideoMode OS_Server::get_video_mode(int p_screen) const {
-	return current_videomode;
-}
-
-Size2 OS_Server::get_window_size() const {
-	return Vector2(current_videomode.width, current_videomode.height);
-}
-
-void OS_Server::get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen) const {
-}
-
 MainLoop *OS_Server::get_main_loop() const {
 	return main_loop;
 }
@@ -147,7 +134,6 @@ void OS_Server::delete_main_loop() {
 
 void OS_Server::set_main_loop(MainLoop *p_main_loop) {
 	main_loop = p_main_loop;
-	input->set_main_loop(p_main_loop);
 }
 
 String OS_Server::get_name() const {

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -38,7 +38,7 @@
 #include "core/os/semaphore.h"
 #include "platform/osx/crash_handler_osx.h"
 #else
-#include "platform/x11/crash_handler_linuxbsd.h"
+#include "platform/linuxbsd/crash_handler_linuxbsd.h"
 #endif
 #include "servers/audio_server.h"
 #include "servers/rendering/renderer_compositor.h"

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -35,8 +35,8 @@
 #include "drivers/dummy/texture_loader_dummy.h"
 #include "drivers/unix/os_unix.h"
 #ifdef __APPLE__
+#include "core/os/semaphore.h"
 #include "platform/osx/crash_handler_osx.h"
-#include "platform/osx/semaphore_osx.h"
 #else
 #include "platform/x11/crash_handler_linuxbsd.h"
 #endif
@@ -48,7 +48,6 @@
 
 class OS_Server : public OS_Unix {
 	RenderingServer *rendering_server = nullptr;
-	VideoMode current_videomode;
 	List<String> args;
 	MainLoop *main_loop = nullptr;
 
@@ -58,7 +57,7 @@ class OS_Server : public OS_Unix {
 
 	bool force_quit = false;
 
-	InputDefault *input = nullptr;
+	Input *input = nullptr;
 
 	CrashHandler crash_handler;
 
@@ -72,7 +71,8 @@ protected:
 	virtual int get_current_video_driver() const;
 
 	virtual void initialize_core();
-	virtual Error initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
+	virtual void initialize();
+	virtual void initialize_joypads();
 	virtual void finalize();
 
 	virtual void set_main_loop(MainLoop *p_main_loop);
@@ -89,12 +89,6 @@ public:
 
 	virtual MainLoop *get_main_loop() const;
 
-	virtual void set_video_mode(const VideoMode &p_video_mode, int p_screen = 0);
-	virtual VideoMode get_video_mode(int p_screen = 0) const;
-	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen = 0) const;
-
-	virtual Size2 get_window_size() const;
-
 	virtual void move_window_to_foreground();
 
 	void run();
@@ -105,7 +99,7 @@ public:
 	virtual String get_data_path() const;
 	virtual String get_cache_path() const;
 
-	virtual String get_system_dir(SystemDir p_dir) const;
+	virtual String get_system_dir(OS::SystemDir p_dir) const;
 
 	void disable_crash_handler();
 	bool is_disable_crash_handler() const;


### PR DESCRIPTION
This PR gets the server platform building on master again.  This also adds a github workflow for the compilation of this target.  There's still work to done here, but I think it's worth having this target in CI:

* The server platform is the only target right now that actually uses the RasterizerStorageDummy.  I think it's actually important to have something that actually compiles and links this class because most of the fixes to this platform are just making sure these Dummy classes actually compile as per their intention.  

* Because some of the refactoring that is going on right now, it's nice to catch any renaming/rework at the time of commit instead of going back to this platform after the fact and try and remember what was refactored how.

I'm going to maintain this moving forward as we're starting to do gameserver builds for our 4.0 project.  If it's not something ready to keep maintained just feel free to close :)