### PR TITLE
GDScript: Fix crash when iterating through empty dictionary.

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -2306,10 +2306,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				Dictionary *dict = VariantInternal::get_dictionary(container);
 				const Variant *next = dict->next(nullptr);
-				*counter = *next;
 
 				if (!dict->empty()) {
 					GET_INSTRUCTION_ARG(iterator, 2);
+					*counter = *next;
 					*iterator = *next;
 
 					// Skip regular iterate.


### PR DESCRIPTION
Fixes #44603

This appears to be a misplaced dereference. From debugging, the crash happens after the pointer dereference, since the next pointer is null for an empty dictionary. It seems reasonable to me to move that dereference into the if statement, and this also matches how arrays are done.