### PR TITLE
Fix the `String::get_base_dir()` logic to properly check for top level directories on Windows

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4285,7 +4285,10 @@ bool String::is_rel_path() const {
 }
 
 String String::get_base_dir() const {
-	int basepos = find("://");
+	int basepos = find(":/");
+	if (basepos == -1) {
+		basepos = find(":\\");
+	}
 	String rs;
 	String base;
 	if (basepos != -1) {


### PR DESCRIPTION
Given a path like `D:\`, the previous logic would check for `://` and not find it.
This caused it to fall into a case where the returned base directory would be built based on the last `\\` or `/` character, in this case causing `D:` to be returned.

Fixes #44409.

[3.2 backport](https://github.com/godotengine/godot/pull/44610)