### PR TITLE
Fix mistake in GLTFMesh.mesh property

### DIFF
--- a/modules/gltf/gltf_mesh.cpp
+++ b/modules/gltf/gltf_mesh.cpp
@@ -37,7 +37,7 @@ void GLTFMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_blend_weights"), &GLTFMesh::get_blend_weights);
 	ClassDB::bind_method(D_METHOD("set_blend_weights", "blend_weights"), &GLTFMesh::set_blend_weights);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "EditorSceneImporterMesh"), "set_mesh", "get_mesh");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh"), "set_mesh", "get_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "blend_weights"), "set_blend_weights", "get_blend_weights"); // Vector<float>
 }
 


### PR DESCRIPTION
This seems like an error introduced when `Mesh` was replaced with `EditorSceneImporterMesh`.

Without this patch, in the documentation, it shows up as:
```
Property Descriptions

● EditorSceneImporterMesh  EditorSceneImporterMesh
 set_mesh(value) setter
 get_mesh() getter
```

Prior to that refactor, the code previously read
```
ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh"), "set_mesh", "get_mesh"); // Ref<Mesh>
```
which matches what it should be.