### PR TITLE
Fix invalid invocation of `get_class_loader`.

### DIFF
--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -103,7 +103,7 @@ jobject GodotJavaWrapper::get_member_object(const char *p_name, const char *p_cl
 jobject GodotJavaWrapper::get_class_loader() {
 	if (_get_class_loader) {
 		JNIEnv *env = ThreadAndroid::get_env();
-		return env->CallObjectMethod(godot_instance, _get_class_loader);
+		return env->CallObjectMethod(activity, _get_class_loader);
 	} else {
 		return nullptr;
 	}


### PR DESCRIPTION
The call was made on a `Godot` instance instead of an `Activity` instance.

This addresses the issue brought up in comment https://github.com/godotengine/godot/issues/44587#issuecomment-750027459
