### PR TITLE
free library when no nativescripts reference it

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1724,6 +1724,12 @@ void NativeScriptLanguage::unregister_script(NativeScript *script) {
 		S->get().erase(script);
 		if (S->get().size() == 0) {
 			library_script_users.erase(S);
+
+			Map<String, Ref<GDNative>>::Element *G = library_gdnatives.find(script->lib_path);
+			if (G) {
+				G->get()->terminate();
+				library_gdnatives.erase(G);
+			}
 		}
 	}
 #ifndef NO_THREADS


### PR DESCRIPTION
Removes the gdnative library when no script (gdns) references it any longer. This enables hot reload for gdnative like sync script changes for gdscript.  Proof of concept has been implemented for godot-nim in https://github.com/geekrelief/gdnim.

Without this patch the gdnative library remains in memory when no script references it.  Also on windows, the dll file is locked.

*Bugsquad edit:* Fixes #42449.