### PR TITLE
fix renderer storage erroring

### DIFF
--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -71,8 +71,8 @@ public:
 			for (Set<InstanceDependency *>::Element *E = dependencies.front(); E; E = E->next()) {
 				InstanceDependency *dep = E->get();
 				Map<InstanceBaseDependency *, uint32_t>::Element *F = dep->instances.find(this);
-				ERR_CONTINUE(!F);
-				if (F->get() != instance_version) {
+
+				if (F && F->get() != instance_version) {
 					Pair<InstanceDependency *, Map<InstanceBaseDependency *, uint32_t>::Element *> p;
 					p.first = dep;
 					p.second = F;


### PR DESCRIPTION
fixes #44523

seems to happen on re-importing scenes which aren't open in some cases and from other triggers too.

