### PR TITLE
Update body transforms on joint2D setup

### DIFF
--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -90,6 +90,14 @@ void Joint2D::_update_joint(bool p_only_free) {
 	warning = String();
 	update_configuration_warning();
 
+	if (body_a) {
+		body_a->force_update_transform();
+	}
+
+	if (body_b) {
+		body_b->force_update_transform();
+	}
+
 	joint = _configure_joint(body_a, body_b);
 
 	ERR_FAIL_COND_MSG(!joint.is_valid(), "Failed to configure the joint.");


### PR DESCRIPTION
Body transforms from physics are used to setup the joint and they are only updated before the physics step by default.

Without forcing the transform update, joints could use a previous position if the body's position was set after it was added to the scene.

3D physics is not affected by this issue.

Fixes #30191
