### PR TITLE
Fix blendshapes and calculation of bone_aabbs

### DIFF
--- a/editor/import/scene_importer_mesh.cpp
+++ b/editor/import/scene_importer_mesh.cpp
@@ -62,9 +62,15 @@ void EditorSceneImporterMesh::add_surface(Mesh::PrimitiveType p_primitive, const
 	s.arrays = p_arrays;
 	s.name = p_name;
 
+	Vector<Vector3> vertex_array = p_arrays[Mesh::ARRAY_VERTEX];
+	int vertex_count = vertex_array.size();
+	ERR_FAIL_COND(vertex_count == 0);
+
 	for (int i = 0; i < blend_shapes.size(); i++) {
 		Array bsdata = p_blend_shapes[i];
 		ERR_FAIL_COND(bsdata.size() != Mesh::ARRAY_MAX);
+		Vector<Vector3> vertex_data = bsdata[Mesh::ARRAY_VERTEX];
+		ERR_FAIL_COND(vertex_data.size() != vertex_count);
 		Surface::BlendShape bs;
 		bs.arrays = bsdata;
 		s.blend_shape_data.push_back(bs);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -2408,9 +2408,6 @@ void RendererStorageRD::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_su
 	Mesh *mesh = mesh_owner.getornull(p_mesh);
 	ERR_FAIL_COND(!mesh);
 
-	//ensure blend shape consistency
-	ERR_FAIL_COND(mesh->blend_shape_count && p_surface.bone_aabbs.size() != mesh->bone_aabbs.size());
-
 #ifdef DEBUG_ENABLED
 	//do a validation, to catch errors first
 	{
@@ -2576,6 +2573,11 @@ void RendererStorageRD::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_su
 		mesh->bone_aabbs = p_surface.bone_aabbs;
 		mesh->aabb = p_surface.aabb;
 	} else {
+		if (mesh->bone_aabbs.size() < p_surface.bone_aabbs.size()) {
+			// ArrayMesh::_surface_set_data only allocates bone_aabbs up to max_bone
+			// Each surface may affect different numbers of bones.
+			mesh->bone_aabbs.resize(p_surface.bone_aabbs.size());
+		}
 		for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
 			mesh->bone_aabbs.write[i].merge_with(p_surface.bone_aabbs[i]);
 		}


### PR DESCRIPTION
We found that meshes with a skeleton do not show any blendshapes.

Blendshapes without a skeleton already worked.
However, due to a faulty ERR_FAIL_COND, it was impossible to create a mesh with both bones and blendshapes.
This also fixes an assumption that all surfaces reference the same number of bones as surface 0.

fixes #44648
