### PR TITLE
Add option verbose debugging to dynamic BVH.

### DIFF
--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -56,6 +56,8 @@ subject to the following restrictions:
 ///DynamicBVH implementation by Nathanael Presson
 // The DynamicBVH class implements a fast dynamic bounding volume tree based on axis aligned bounding boxes (aabb tree).
 
+// #define DYNAMICBVH_VERBOSE_DEBUG
+
 class DynamicBVH {
 	struct Node;
 
@@ -244,6 +246,9 @@ private:
 	_FORCE_INLINE_ void _update(Node *leaf, int lookahead = -1);
 
 	void _extract_leaves(Node *p_node, List<ID> *r_elements);
+#ifdef DYNAMICBVH_VERBOSE_DEBUG
+	void _debug_print_node(const Node &p_node, int p_depth, String &p_output);
+#endif
 
 	_FORCE_INLINE_ bool _ray_aabb(const Vector3 &rayFrom, const Vector3 &rayInvDirection, const unsigned int raySign[3], const Vector3 bounds[2], real_t &tmin, real_t lambda_min, real_t lambda_max) {
 		real_t tmax, tymin, tymax, tzmin, tzmax;
@@ -287,6 +292,10 @@ public:
 
 	int get_leaf_count() const;
 	int get_max_depth() const;
+
+#ifdef DYNAMICBVH_VERBOSE_DEBUG
+	void debug_print_tree(String p_string);
+#endif
 
 	/* Discouraged, but works as a reference on how it must be used */
 	struct DefaultQueryResult {


### PR DESCRIPTION
In order to test tree balancing, this prints out the tree after certain operations. This is enabled at compile time only, by setting the DYNAMICBVH_VERBOSE_DEBUG define at the top of the header.

## Notes
* This can either be merged as is or used as an example for adding debugging, or we can keep debugging out of the class. However with trees of these sort it is usually useful to have some debugging support.
* This debugging shows the current BVH is not working correctly, see #44623

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
