### PR TITLE
Fix BVH to world_aabb, and call update

### DIFF
--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -354,10 +354,17 @@ void DynamicBVH::_update(Node *leaf, int lookahead) {
 void DynamicBVH::update(const ID &p_id, const AABB &p_box) {
 	ERR_FAIL_COND(!p_id.is_valid());
 	Node *leaf = p_id.node;
-	Node *base = _remove_leaf(leaf);
+
 	Volume volume;
 	volume.min = p_box.position;
 	volume.max = p_box.position + p_box.size;
+
+	if ((leaf->volume.min == volume.min) && (leaf->volume.max == volume.max)) {
+		// noop
+		return;
+	}
+
+	Node *base = _remove_leaf(leaf);
 	if (base) {
 		if (lkhd >= 0) {
 			for (int i = 0; (i < lkhd) && base->parent; ++i) {

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1070,9 +1070,15 @@ void RendererSceneCull::_update_instance(Instance *p_instance) {
 
 	if (!p_instance->indexer_id.is_valid()) {
 		if ((1 << p_instance->base_type) & RS::INSTANCE_GEOMETRY_MASK) {
-			p_instance->indexer_id = p_instance->scenario->indexers[Scenario::INDEXER_GEOMETRY].insert(p_instance->aabb, p_instance);
+			p_instance->indexer_id = p_instance->scenario->indexers[Scenario::INDEXER_GEOMETRY].insert(p_instance->transformed_aabb, p_instance);
 		} else {
-			p_instance->indexer_id = p_instance->scenario->indexers[Scenario::INDEXER_VOLUMES].insert(p_instance->aabb, p_instance);
+			p_instance->indexer_id = p_instance->scenario->indexers[Scenario::INDEXER_VOLUMES].insert(p_instance->transformed_aabb, p_instance);
+		}
+	} else {
+		if ((1 << p_instance->base_type) & RS::INSTANCE_GEOMETRY_MASK) {
+			p_instance->scenario->indexers[Scenario::INDEXER_GEOMETRY].update(p_instance->indexer_id, p_instance->transformed_aabb);
+		} else {
+			p_instance->scenario->indexers[Scenario::INDEXER_VOLUMES].update(p_instance->indexer_id, p_instance->transformed_aabb);
 		}
 	}
 


### PR DESCRIPTION
The calls to the BVH need to use the world space AABB, rather than local space for it to work. Also, update was not being called which is required to update the AABB as objects move.

Also adds a no-op check to updates in the BVH (if the AABB hasn't changed, no need to update).

## Notes
* See #44623

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
