### PR TITLE
[3.x] Fix display of programmatically created value in remote inspector

### DIFF
--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -709,7 +709,7 @@ void ScriptDebuggerRemote::_send_object_id(ObjectID p_id) {
 			prop.push_back(pi.hint_string);
 			prop.push_back(pi.usage);
 
-			if (!res.is_null()) {
+			if (!res.is_null() && !res->get_path().empty()) {
 				var = res->get_path();
 			}
 


### PR DESCRIPTION
Programmatically created property value (object) were shown as "Empty" in the remote inspector. (See #28353 and #30033.)

* These objects don't have path, but the empty path check was lost since #22201.
* Programmatically created value is now shown as an editable "Object ID: XXXX" in remote inspector, the same as in 3.0.6.

The debugger code on master had a huge change, so this PR only targets the 3.2 branch.

p.s. I tried the same approach on master in `SceneDebuggerObject::serialize` ([here](https://github.com/godotengine/godot/blob/4d9b95f3a88ab5a225514d503cbf06926840ab02/scene/debugger/scene_debugger.cpp#L370)) and the value is shown as "Object ID: XXXX" correctly. But clicking it does not make the inspector inspect the object. I'm not familiar with the 4.0 code, so I don't know why it happens and whether that's the expected behavior in 4.0.