### PR TITLE
Fixes: GDscript min and max are inverted

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -291,7 +291,7 @@ struct VariantUtilityFunctions {
 		Variant ret;
 		for (int i = 1; i < p_argcount; i++) {
 			bool valid;
-			Variant::evaluate(Variant::OP_GREATER, base, *p_args[i], ret, valid);
+			Variant::evaluate(Variant::OP_LESS, base, *p_args[i], ret, valid);
 			if (!valid) {
 				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.expected = base.get_type();
@@ -324,7 +324,7 @@ struct VariantUtilityFunctions {
 		Variant ret;
 		for (int i = 1; i < p_argcount; i++) {
 			bool valid;
-			Variant::evaluate(Variant::OP_LESS, base, *p_args[i], ret, valid);
+			Variant::evaluate(Variant::OP_GREATER, base, *p_args[i], ret, valid);
 			if (!valid) {
 				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.expected = base.get_type();


### PR DESCRIPTION
The logic was inverted:
- The function `max` has to change the `base` only if the next element is `LESS` than the `base`. 
- Inversely for `min` the `base` has to change only if the next element is `GREATER`.

Fixes https://github.com/godotengine/godot/issues/44659