### PR TITLE
fix gdscript code completion crash

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2435,6 +2435,11 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_grouping(ExpressionNode *p
 }
 
 GDScriptParser::ExpressionNode *GDScriptParser::parse_attribute(ExpressionNode *p_previous_operand, bool p_can_assign) {
+	// do nothing / prevent crash
+	if (p_previous_operand == NULL) {
+		return nullptr;
+	}
+
 	SubscriptNode *attribute = alloc_node<SubscriptNode>();
 
 	if (for_completion) {


### PR DESCRIPTION
Fixes GDScript crashing engine when you try to use completion with invalid characters.

reproduction of bug:

put this in one of your GDScript scripts.

```gdscript
@export var something = $./
```

The PR fixes the behaviour.