### PR TITLE
Translation: Implement override of get_message

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -875,6 +875,11 @@ void Translation::add_plural_message(const StringName &p_src_text, const Vector<
 }
 
 StringName Translation::get_message(const StringName &p_src_text, const StringName &p_context) const {
+	StringName ret;
+	if (GDVIRTUAL_CALL(_get_message, p_src_text, p_context, ret)) {
+		return ret;
+	}
+
 	if (p_context != StringName()) {
 		WARN_PRINT("Translation class doesn't handle context. Using context in get_message() on a Translation instance is probably a mistake. \nUse a derived Translation class that handles context, such as TranslationPO class");
 	}
@@ -888,6 +893,11 @@ StringName Translation::get_message(const StringName &p_src_text, const StringNa
 }
 
 StringName Translation::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
+	StringName ret;
+	if (GDVIRTUAL_CALL(_get_plural_message, p_src_text, p_plural_text, p_n, p_context, ret)) {
+		return ret;
+	}
+
 	WARN_PRINT("Translation class doesn't handle plural messages. Calling get_plural_message() on a Translation instance is probably a mistake. \nUse a derived Translation class that handles plurals, such as TranslationPO class");
 	return get_message(p_src_text);
 }
@@ -922,6 +932,9 @@ void Translation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_message_count"), &Translation::get_message_count);
 	ClassDB::bind_method(D_METHOD("_set_messages"), &Translation::_set_messages);
 	ClassDB::bind_method(D_METHOD("_get_messages"), &Translation::_get_messages);
+
+	GDVIRTUAL_BIND(_get_plural_message, "src_message", "src_plural_message", "n", "context");
+	GDVIRTUAL_BIND(_get_message, "src_message", "context");
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "messages", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_messages", "_get_messages");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "locale"), "set_locale", "get_locale");

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -32,6 +32,8 @@
 #define TRANSLATION_H
 
 #include "core/io/resource.h"
+#include "core/object/gdvirtual.gen.inc"
+#include "core/object/script_language.h"
 
 class Translation : public Resource {
 	GDCLASS(Translation, Resource);
@@ -47,6 +49,9 @@ class Translation : public Resource {
 
 protected:
 	static void _bind_methods();
+
+	GDVIRTUAL2RC(StringName, _get_message, StringName, StringName);
+	GDVIRTUAL4RC(StringName, _get_plural_message, StringName, StringName, int, StringName);
 
 public:
 	void set_locale(const String &p_locale);

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -11,6 +11,24 @@
 		<link title="Locales">https://docs.godotengine.org/en/latest/tutorials/i18n/locales.html</link>
 	</tutorials>
 	<methods>
+		<method name="_get_message" qualifiers="virtual const">
+			<return type="StringName" />
+			<argument index="0" name="src_message" type="StringName" />
+			<argument index="1" name="context" type="StringName" />
+			<description>
+				Virtual method to override [method get_message].
+			</description>
+		</method>
+		<method name="_get_plural_message" qualifiers="virtual const">
+			<return type="StringName" />
+			<argument index="0" name="src_message" type="StringName" />
+			<argument index="1" name="src_plural_message" type="StringName" />
+			<argument index="2" name="n" type="int" />
+			<argument index="3" name="context" type="StringName" />
+			<description>
+				Virtual method to override [method get_plural_message].
+			</description>
+		</method>
 		<method name="add_message">
 			<return type="void" />
 			<argument index="0" name="src_message" type="StringName" />


### PR DESCRIPTION
This PR switches `Translation::get_message` and `Translation::get_plural_message` virtual call to GDScript compatible call. Also it introduces unit test for translations.

Closes https://github.com/godotengine/godot-proposals/issues/1926