### PR TITLE
Array/Dictionary marked as not safe to const fold

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1719,6 +1719,8 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool is_awa
 				// Those are stored by reference so not suited for compile-time construction.
 				// Because in this case they would be the same reference in all constructed values.
 				case Variant::OBJECT:
+				case Variant::DICTIONARY:
+				case Variant::ARRAY:
 				case Variant::PACKED_BYTE_ARRAY:
 				case Variant::PACKED_INT32_ARRAY:
 				case Variant::PACKED_INT64_ARRAY:


### PR DESCRIPTION
Fix: #44459

(this was only fixed for literal array/dictionary in #41983 before)
