### PR TITLE
Document the expected low performance of VideoPlayer on HTML5

### DIFF
--- a/doc/classes/VideoPlayer.xml
+++ b/doc/classes/VideoPlayer.xml
@@ -7,6 +7,7 @@
 		Control node for playing video streams using [VideoStream] resources.
 		Supported video formats are [url=https://www.webmproject.org/]WebM[/url] ([code].webm[/code], [VideoStreamWebm]), [url=https://www.theora.org/]Ogg Theora[/url] ([code].ogv[/code], [VideoStreamTheora]), and any format exposed via a GDNative plugin using [VideoStreamGDNative].
 		[b]Note:[/b] Due to a bug, VideoPlayer does not support localization remapping yet.
+		[b]Warning:[/b] On HTML5, video playback [i]will[/i] perform poorly due to missing architecture-specific assembly optimizations, especially for VP8/VP9.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
See https://godotengine.org/qa/90673/webgl-export-is-unplayable-in-my-browser and many other questions scattered around the Internet.

We may want to go further and use `WARN_PRINT_ONCE()` in the VideoPlayer constructor in HTML5.