### PR TITLE
Ensure flags are applied to CVTT options

### DIFF
--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -171,6 +171,7 @@ void image_compress_cvtt(Image *p_image, float p_lossy_quality, Image::UsedChann
 	if (p_channels == Image::USED_CHANNELS_RG) { //guessing this is a normalmap
 		flags |= cvtt::Flags::Uniform;
 	}
+	options.flags = flags;
 
 	Image::Format target_format = Image::FORMAT_BPTC_RGBA;
 


### PR DESCRIPTION
Currently, the CVTT options are calculated, but never applied. Therefore, CVTT will always use the default quality setting regardless of the "Lossy quality" setting. Furthermore, CVTT will ignore both the `BC7_RespectPunchThrough` and the `Uniform` flag settings.

This PR applies the calculated CVTT flags to the CVTT options.
