### PR TITLE
Fix ETC quality setting

### DIFF
--- a/modules/etc/image_compress_etc.cpp
+++ b/modules/etc/image_compress_etc.cpp
@@ -166,12 +166,12 @@ static void _compress_etc(Image *p_img, float p_lossy_quality, bool force_etc1_f
 	int encoding_time = 0;
 	float effort = 0.0; //default, reasonable time
 
-	if (p_lossy_quality > 0.75) {
-		effort = 0.4;
+	if (p_lossy_quality > 0.95) {
+		effort = 80;
 	} else if (p_lossy_quality > 0.85) {
-		effort = 0.6;
-	} else if (p_lossy_quality > 0.95) {
-		effort = 0.8;
+		effort = 60;
+	} else if (p_lossy_quality > 0.75) {
+		effort = 40;
 	}
 
 	Etc::ErrorMetric error_metric = Etc::ErrorMetric::RGBX; // NOTE: we can experiment with other error metrics


### PR DESCRIPTION
To compress VRAM textures takes time. b19225bfce3dab39f8ce ensured that ETC compression was as fast as possible. However, there were three issues with this change:
https://github.com/godotengine/godot/blob/545c89461464ee14b2b806dd2dd2c0eef110e181/modules/etc/image_compress_etc.cpp#L167-L175
1. The `else if` statements will never be true so the higher settings will never be applied.
2. ETC `effort` is a value between 0 and 100, not 0 and 1; so even with 0.4 the effort value is effectively 0 (although there is still a difference, as ETC checks if the value is > 0).
3. There is an artificial shift between the `lossy_quality` setting and the `effort` applied.

This PR addresses the first two issues. I haven't addressed the third issue, because I suspect there was a reason for introducing this shift: most of the benefit from ETC compression is obtained between 40 and 65 ([reference](https://richg42.blogspot.com/2016/10/etc2comps-effort-parameters-impact-on.html)) and setting it to 100 has little benefit.

Note: This PR leaves the default effort at 0, because the default `lossy_quality` is 0.7. Therefore there will be no impact to most users. However, anyone using a higher value for the `lossy_quality` will notice a significant increase in the time it takes to create the VRAM compressed files. As an indication, here are the times in ms I get for importing a 1024x1024 texture to ETC and ETC2 format with this PR:

<table>
<tr><th>Lossy Quality </th><th> ETC </th><th> ETC2 </th></tr>
<tr><td> 0.7 </td><td> 797 </td><td> 1,452 </td></tr>
<tr><td> > 0.75 </td><td> 4,104 </td><td> 9,284 </td></tr>
<tr><td> > 0.85 </td><td> 11,419 </td><td> 36,787 </td></tr>
<tr><td> > 0.95 </td><td> 44,267 </td><td> 73,894 </td></tr>
</table>

The benefit of course is that the textures will have the expected higher quality; even if the artificial adjustment to the effort remains.
