### PR TITLE
[3.2] Fix ETC quality setting

### DIFF
--- a/modules/etc/image_etc.cpp
+++ b/modules/etc/image_etc.cpp
@@ -199,14 +199,15 @@ static void _compress_etc(Image *p_img, float p_lossy_quality, bool force_etc1_f
 	// prepare parameters to be passed to etc2comp
 	int num_cpus = OS::get_singleton()->get_processor_count();
 	int encoding_time = 0;
+
 	float effort = 0.0; //default, reasonable time
 
-	if (p_lossy_quality > 0.75)
-		effort = 0.4;
+	if (p_lossy_quality > 0.95)
+		effort = 80;
 	else if (p_lossy_quality > 0.85)
-		effort = 0.6;
-	else if (p_lossy_quality > 0.95)
-		effort = 0.8;
+		effort = 60;
+	else if (p_lossy_quality > 0.75)
+		effort = 40;
 
 	Etc::ErrorMetric error_metric = Etc::ErrorMetric::RGBX; // NOTE: we can experiment with other error metrics
 	Etc::Image::Format etc2comp_etc_format = _image_format_to_etc2comp_format(etc_format);


### PR DESCRIPTION
3.2 version of #44682

Note: As stated in #44682, and reproduced here for the benefit of those reading this. This PR leaves the default effort at 0, because the default `lossy_quality` is 0.7. Therefore there will be no impact to most users. However, anyone using a higher value for the `lossy_quality` will notice a significant increase in the time it takes to create the VRAM compressed files. As an indication, here are the times in ms I get for importing a 1024x1024 texture to ETC and ETC2 format with this PR:

<table>
<tr><th>Lossy Quality </th><th> ETC </th><th> ETC2 </th></tr>
<tr><td> 0.7 </td><td> 797 </td><td> 1,452 </td></tr>
<tr><td> > 0.75 </td><td> 4,104 </td><td> 9,284 </td></tr>
<tr><td> > 0.85 </td><td> 11,419 </td><td> 36,787 </td></tr>
<tr><td> > 0.95 </td><td> 44,267 </td><td> 73,894 </td></tr>
</table>

The benefit of course is that the textures will have the expected higher quality; even if the artificial adjustment to the effort remains.
