### PR TITLE
Fix oversized folding icon in CodeEdit's

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -265,14 +265,13 @@ void CodeEdit::_fold_gutter_draw_callback(int p_line, int p_gutter, Rect2 p_regi
 	int horizontal_padding = p_region.size.x / 10;
 	int vertical_padding = p_region.size.y / 6;
 
-	p_region.position += Point2(horizontal_padding, vertical_padding);
-	p_region.size -= Point2(horizontal_padding, vertical_padding) * 2;
+	Point2 position = p_region.position + Point2(horizontal_padding, vertical_padding) * 2;
 
 	if (can_fold(p_line)) {
-		can_fold_icon->draw_rect(get_canvas_item(), p_region, false, folding_color);
+		can_fold_icon->draw(get_canvas_item(), position, folding_color);
 		return;
 	}
-	folded_icon->draw_rect(get_canvas_item(), p_region, false, folding_color);
+	folded_icon->draw(get_canvas_item(), position, folding_color);
 }
 
 void CodeEdit::_bind_methods() {


### PR DESCRIPTION
I think these sub-buttons are currently looking oversized and ugly (and inconsistent with the tabulation icon rendering):

![image](https://user-images.githubusercontent.com/3036176/103139512-05e53400-46ee-11eb-9899-2705c13338e5.png)

So I changed their drawing method so the result is to be like:

![image](https://user-images.githubusercontent.com/3036176/103139501-e8b06580-46ed-11eb-9d3c-3ff3c8372bef.png)

