### PR TITLE
[3.2] Improve 2d snapping

### DIFF
--- a/core/engine.h
+++ b/core/engine.h
@@ -60,6 +60,7 @@ private:
 	float _time_scale;
 	bool _pixel_snap;
 	bool _snap_2d_transforms;
+	bool _snap_2d_viewports;
 	uint64_t _physics_frames;
 	float _physics_interpolation_fraction;
 
@@ -109,6 +110,7 @@ public:
 
 	_FORCE_INLINE_ bool get_use_pixel_snap() const { return _pixel_snap; }
 	bool get_snap_2d_transforms() const { return _snap_2d_transforms; }
+	bool get_snap_2d_viewports() const { return _snap_2d_viewports; }
 
 #ifdef TOOLS_ENABLED
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) { editor_hint = p_enabled; }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1114,6 +1114,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	Engine::get_singleton()->_pixel_snap = GLOBAL_DEF("rendering/quality/2d/use_pixel_snap", false);
 	Engine::get_singleton()->_snap_2d_transforms = GLOBAL_DEF("rendering/quality/2d/use_transform_snap", false);
+	Engine::get_singleton()->_snap_2d_viewports = GLOBAL_DEF("rendering/quality/2d/use_camera_snap", false);
 	OS::get_singleton()->_keep_screen_on = GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
 	if (rtm == -1) {
 		rtm = GLOBAL_DEF("rendering/threads/thread_model", OS::RENDER_THREAD_SAFE);

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -99,7 +99,7 @@ void Sprite::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_cli
 	Point2 dest_offset = offset;
 	if (centered)
 		dest_offset -= frame_size / 2;
-	if (Engine::get_singleton()->get_snap_2d_transforms()) {
+	if (Engine::get_singleton()->get_use_pixel_snap()) {
 		dest_offset = dest_offset.floor();
 	}
 
@@ -378,7 +378,7 @@ Rect2 Sprite::get_rect() const {
 	Point2 ofs = offset;
 	if (centered)
 		ofs -= Size2(s) / 2;
-	if (Engine::get_singleton()->get_snap_2d_transforms()) {
+	if (Engine::get_singleton()->get_use_pixel_snap()) {
 		ofs = ofs.floor();
 	}
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -40,12 +40,24 @@ static Transform2D _canvas_get_transform(VisualServerViewport::Viewport *p_viewp
 	Transform2D xf = p_viewport->global_transform;
 
 	float scale = 1.0;
+
+	bool snap = Engine::get_singleton()->get_snap_2d_viewports();
+
 	if (p_viewport->canvas_map.has(p_canvas->parent)) {
-		xf = xf * p_viewport->canvas_map[p_canvas->parent].transform;
+
+		Transform2D c_xform = p_viewport->canvas_map[p_canvas->parent].transform;
+		if (snap) {
+			c_xform.elements[2] = c_xform.elements[2].floor();
+		}
+		xf = xf * c_xform;
 		scale = p_canvas->parent_scale;
 	}
 
-	xf = xf * p_canvas_data->transform;
+	Transform2D c_xform = p_canvas_data->transform;
+	if (snap) {
+		c_xform.elements[2] = c_xform.elements[2].floor();
+	}
+	xf = xf * c_xform;
 
 	if (scale != 1.0 && !VSG::canvas->disable_scale) {
 		Vector2 pivot = p_vp_size * 0.5;


### PR DESCRIPTION
Partially revert change allowing sprite get_rect snapping to be controlled by `pixel_snap` again rather than `transform_snap` (to prevent breaking compatibility). Adds a final `use_camera_snap` project setting to allow snapping viewports as in reduz original PR.

Based on feedback these are some improvements to #43554 (which is a backport of #43194).

## Fixes #44686
This user was unable to reproduce the same behaviour as 3.2.3. This is a valid complaint.

Although moving the get_rect snapping to the `transform_snap` project setting was logical (in #43194), it loses some flexibility. Ultimate flexibility would be to have a setting for each, but in practice I currently believe most people using `transform_snap` will also be using `pixel_snap`, so this will save an extra project setting.

## Viewport (Camera) Snapping
This is a little more controversial in my opinion, and I accidentally / on purpose missed it out of the original PR. But I guess it is ok here with a separate project setting.

There are current two problems with camera snapping:
1) There is currently another bug (likely in the update order) which can cause jittering between camera position and target position (may be the force_update_scroll() bug #28492)
https://github.com/godotengine/godot/issues/43800#issuecomment-732319004
![99997767-8a722900-2db5-11eb-84f3-4e70e0988fe9](https://user-images.githubusercontent.com/21999379/103141246-c3215d00-46e9-11eb-9e8e-62c1d141f85e.gif)

2) Using the `camera_snap` option means you cannot smoothly interpolate the camera in 'sub texel' movement (assuming blocky pixels, which I will refer to as texels here). This means you can't have smoothly interpolating cameras or smooth camera 'shock' effects.

You can achieve (2) by doing camera snapping manually however (see https://github.com/godotengine/godot/pull/43554#issuecomment-732177386), and also bypass the bug of (1). However this is more advanced, and may be beyond beginner users to understand and pull off.

See this example project for an example of manual camera snapping:
[Jittering Camera Bug Workaround.zip](https://github.com/godotengine/godot/files/5742317/Jittering.Camera.Bug.Workaround.zip)

In this same project if you change the active camera to the camera hanging off the player, and switch on camera snapping, you will likely see bug (1) exhibiting. This bug is more apparent when the physics tick rate diverges from the refresh rate.

Also the very act of merging camera_snapping may also expedite fixing bug (1). It is a chicken and egg situation, as few are aware of the bug at the moment and the need to fix it. I haven't fixed it as part of this PR because I'm unsure of the exact cause as yet.

### Extra Demo
This shows (2) nicely. By doing manual camera snapping, it allows the camera to exactly follow a player, but apply a float offset. Note that if you turn on the `camera_snapping` in the project settings of this project, you will see the limitation (you lose the ability to have float offsets). This is a large part of the reasoning to have a separate setting for `camera_snapping` from `transform_snapping`.

[Jittering Camera Bug Workaround2.zip](https://github.com/godotengine/godot/files/5742880/Jittering.Camera.Bug.Workaround2.zip)
![smooth_cameraB](https://user-images.githubusercontent.com/21999379/103148973-4def6f80-475d-11eb-9708-acde0f7961e2.gif)


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
