### PR TITLE
[3.x] Remove all elements from monitored_bodies and monitored_areas when processed

### DIFF
--- a/servers/physics/area_sw.cpp
+++ b/servers/physics/area_sw.cpp
@@ -192,7 +192,9 @@ void AreaSW::call_queries() {
 		for (Map<BodyKey, BodyState>::Element *E = monitored_bodies.front(); E;) {
 
 			if (E->get().state == 0) { // Nothing happened
-				E = E->next();
+				Map<BodyKey, BodyState>::Element *next = E->next();
+				monitored_bodies.erase(E);
+				E = next;
 				continue;
 			}
 
@@ -228,7 +230,9 @@ void AreaSW::call_queries() {
 		for (Map<BodyKey, BodyState>::Element *E = monitored_areas.front(); E;) {
 
 			if (E->get().state == 0) { // Nothing happened
-				E = E->next();
+				Map<BodyKey, BodyState>::Element *next = E->next();
+				monitored_areas.erase(E);
+				E = next;
 				continue;
 			}
 

--- a/servers/physics_2d/area_2d_sw.cpp
+++ b/servers/physics_2d/area_2d_sw.cpp
@@ -192,7 +192,9 @@ void Area2DSW::call_queries() {
 		for (Map<BodyKey, BodyState>::Element *E = monitored_bodies.front(); E;) {
 
 			if (E->get().state == 0) { // Nothing happened
-				E = E->next();
+				Map<BodyKey, BodyState>::Element *next = E->next();
+				monitored_bodies.erase(E);
+				E = next;
 				continue;
 			}
 
@@ -228,7 +230,9 @@ void Area2DSW::call_queries() {
 		for (Map<BodyKey, BodyState>::Element *E = monitored_areas.front(); E;) {
 
 			if (E->get().state == 0) { // Nothing happened
-				E = E->next();
+				Map<BodyKey, BodyState>::Element *next = E->next();
+				monitored_areas.erase(E);
+				E = next;
 				continue;
 			}
 


### PR DESCRIPTION
3.2 version of #44695
