### PR TITLE
Fix and decrease Godot logo size in the HTML5 editor loader

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -169,7 +169,7 @@
 					<option value="GLES3">WebGL 2</option>
 				</select>
 				<br />
-				<img src="logo.svg">
+				<img src="logo.svg" width="1024" height="414" style="width: auto; height: auto; max-width: 85%; max-height: 250px" />
 				<br />
 				<label for="zip-file" style="margin-right: 1rem">Preload project ZIP:</label> <input id="zip-file" type="file" id="files" name="files" style="margin-bottom: 1rem"/>
 				<br />


### PR DESCRIPTION
The logo can no longer overflow the viewport. The logo size (or rather, its aspect ratio) is also specified in advance to avoid reflows while the page is loading.

This closes #44692.

## Preview

https://user-images.githubusercontent.com/180032/103155850-7d28cf80-47a3-11eb-861b-a9bfdd768655.mp4