### PR TITLE
Add signal to inform joint that body has exited tree

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -482,7 +482,7 @@ void SpaceBullet::remove_rigid_body(RigidBodyBullet *p_body) {
 
 	int constraints = btBody->getNumConstraintRefs();
 	if (constraints > 0) {
-		WARN_PRINT("A body connected to joints was removed. Ensure bodies are disconnected from joints before removing them.");
+		ERR_PRINT("A body connected to joints was removed.");
 		for (int i = 0; i < constraints; i++) {
 			dynamicsWorld->removeConstraint(btBody->getConstraintRef(i));
 		}

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -32,7 +32,37 @@
 
 #include "core/config/engine.h"
 #include "physics_body_2d.h"
+#include "scene/scene_string_names.h"
 #include "servers/physics_server_2d.h"
+
+void Joint2D::_disconnect_signals() {
+	Node *node_a = get_node_or_null(a);
+	PhysicsBody2D *body_a = Object::cast_to<PhysicsBody2D>(node_a);
+	if (body_a) {
+		body_a->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree));
+	}
+
+	Node *node_b = get_node_or_null(b);
+	PhysicsBody2D *body_b = Object::cast_to<PhysicsBody2D>(node_b);
+	if (body_b) {
+		body_b->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree));
+	}
+}
+
+void Joint2D::_body_exit_tree(const ObjectID &p_body_id) {
+	_disconnect_signals();
+	Object *object = ObjectDB::get_instance(p_body_id);
+	PhysicsBody2D *body = Object::cast_to<PhysicsBody2D>(object);
+	ERR_FAIL_NULL(body);
+	RID body_rid = body->get_rid();
+	if (ba == body_rid) {
+		a = NodePath();
+	}
+	if (bb == body_rid) {
+		b = NodePath();
+	}
+	_update_joint();
+}
 
 void Joint2D::_update_joint(bool p_only_free) {
 	if (joint.is_valid()) {
@@ -51,8 +81,8 @@ void Joint2D::_update_joint(bool p_only_free) {
 		return;
 	}
 
-	Node *node_a = has_node(get_node_a()) ? get_node(get_node_a()) : (Node *)nullptr;
-	Node *node_b = has_node(get_node_b()) ? get_node(get_node_b()) : (Node *)nullptr;
+	Node *node_a = get_node_or_null(a);
+	Node *node_b = get_node_or_null(b);
 
 	PhysicsBody2D *body_a = Object::cast_to<PhysicsBody2D>(node_a);
 	PhysicsBody2D *body_b = Object::cast_to<PhysicsBody2D>(node_b);
@@ -107,12 +137,19 @@ void Joint2D::_update_joint(bool p_only_free) {
 	ba = body_a->get_rid();
 	bb = body_b->get_rid();
 
+	body_a->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree), make_binds(body_a->get_instance_id()));
+	body_b->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree), make_binds(body_b->get_instance_id()));
+
 	PhysicsServer2D::get_singleton()->joint_disable_collisions_between_bodies(joint, exclude_from_collision);
 }
 
 void Joint2D::set_node_a(const NodePath &p_node_a) {
 	if (a == p_node_a) {
 		return;
+	}
+
+	if (joint.is_valid()) {
+		_disconnect_signals();
 	}
 
 	a = p_node_a;
@@ -127,6 +164,11 @@ void Joint2D::set_node_b(const NodePath &p_node_b) {
 	if (b == p_node_b) {
 		return;
 	}
+
+	if (joint.is_valid()) {
+		_disconnect_signals();
+	}
+
 	b = p_node_b;
 	_update_joint();
 }
@@ -142,6 +184,7 @@ void Joint2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			if (joint.is_valid()) {
+				_disconnect_signals();
 				_update_joint(true);
 			}
 		} break;

--- a/scene/2d/joints_2d.h
+++ b/scene/2d/joints_2d.h
@@ -49,6 +49,8 @@ class Joint2D : public Node2D {
 	String warning;
 
 protected:
+	void _disconnect_signals();
+	void _body_exit_tree(const ObjectID &p_body_id);
 	void _update_joint(bool p_only_free = false);
 
 	void _notification(int p_what);

--- a/scene/3d/physics_joint_3d.h
+++ b/scene/3d/physics_joint_3d.h
@@ -49,6 +49,8 @@ class Joint3D : public Node3D {
 	String warning;
 
 protected:
+	void _disconnect_signals();
+	void _body_exit_tree(const ObjectID &p_body_id);
 	void _update_joint(bool p_only_free = false);
 
 	void _notification(int p_what);


### PR DESCRIPTION
Currently there is no way to inform a `Joint` that a `PhysicsBody` attached to it has been removed. This PR connects the `tree_exiting` signal from a `PhysicsBody` attached to a configured `Joint` to provide this information and update the `Joint`.

Fixes #44510

Note: This also addresses:
1. The error message(s) raised in Bullet physics when trying to reconfigure a `Joint` that has had a `PhysicsBody` freed without first disconnecting it from the `Joint`; as described [here](https://github.com/godotengine/godot/pull/43898#issue-528237028).
2. The warning message raised in Bullet physics when a scene was closed with a `PhysicsBody` attached to a `Joint` above it in the tree; as identified [here](https://github.com/godotengine/godot/issues/42285#issuecomment-742846838).

This PR includes raising the warning message in Bullet physics to an error; since this should now never occur.
