### PR TITLE
Improve area method descriptions

### DIFF
--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -35,14 +35,16 @@
 			<return type="Area2D[]">
 			</return>
 			<description>
-				Returns a list of intersecting [Area2D]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
+				Returns a list of intersecting [Area2D]s. The overlapping area must have it's collision mask be on the same layer as the collision layer of the node checking, or have its collision layer be on the same layer as the collision mask of the node checking, or else it will not be on the list.
+				For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
 		<method name="get_overlapping_bodies" qualifiers="const">
 			<return type="Node2D[]">
 			</return>
 			<description>
-				Returns a list of intersecting [PhysicsBody2D]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
+				Returns a list of intersecting [PhysicsBody2D]s. The overlapping area must have it's collision mask be on the same layer as the collision layer of the node checking, or have its collision layer be on the same layer as the collision mask of the node checking, or else it will not be on the list.
+				For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
 		<method name="overlaps_area" qualifiers="const">

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -33,14 +33,16 @@
 			<return type="Area3D[]">
 			</return>
 			<description>
-				Returns a list of intersecting [Area3D]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
+				Returns a list of intersecting [Area3D]s. The overlapping area must have it's collision mask be on the same layer as the collision layer of the node checking, or have its collision layer be on the same layer as the collision mask of the node checking, or else it will not be on the list.
+				For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
 		<method name="get_overlapping_bodies" qualifiers="const">
 			<return type="Node3D[]">
 			</return>
 			<description>
-				Returns a list of intersecting [PhysicsBody3D]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
+				Returns a list of intersecting [PhysicsBody3D]s. The overlapping body must have it's collision mask be on the same layer as the collision layer of the node checking, or have its collision layer be on the same layer as the collision mask of the node checking, or else it will not be on the list.
+				For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
 		<method name="overlaps_area" qualifiers="const">


### PR DESCRIPTION
Improves the description of the methods `get_overlapping_areas()` and `get_overlapping_bodies()` for Area2D and Area3D. It now specifies that it only returns nodes in the same collision layer or collision mask. Closes https://github.com/godotengine/godot-docs/issues/4446
