### PR TITLE
Properly apply auto exposure with FXAA in GLES3

### DIFF
--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -327,16 +327,17 @@ void main() {
 	vec3 color = textureLod(source, uv_interp, 0.0f).rgb;
 
 	// Exposure
+	float full_exposure = exposure;
 
 #ifdef USE_AUTO_EXPOSURE
-	color /= texelFetch(source_auto_exposure, ivec2(0, 0), 0).r / auto_exposure_grey;
+	full_exposure /= texelFetch(source_auto_exposure, ivec2(0, 0), 0).r / auto_exposure_grey;
 #endif
 
-	color *= exposure;
+	color *= full_exposure;
 
 #ifdef USE_FXAA
 	// FXAA must be applied before tonemapping.
-	color = apply_fxaa(color, exposure, uv_interp, pixel_size);
+	color = apply_fxaa(color, full_exposure, uv_interp, pixel_size);
 #endif
 
 #ifdef USE_DEBANDING


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/44576

Auto exposure needs to be applied to the FXAA samples as well. 

This now matches the implementation in master

https://github.com/godotengine/godot/blob/fb16b1e39bb9ff7fe2e551bbf6659e8d502f84a7/servers/rendering/renderer_rd/shaders/tonemap.glsl#L334-L353
