### PR TITLE
Cleanup leftover functions from adding SSAO

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -5208,7 +5208,6 @@ void RendererSceneRenderRD::_process_ssao(RID p_render_buffers, RID p_environmen
 
 	RENDER_TIMESTAMP("Process SSAO");
 
-	//TODO clear when settings chenge to or from ultra
 	if (rb->ssao.ao_final.is_valid() && ssao_using_half_size != ssao_half_size) {
 		RD::get_singleton()->free(rb->ssao.depth);
 		RD::get_singleton()->free(rb->ssao.ao_deinterleaved);


### PR DESCRIPTION
Removes comments left over from https://github.com/godotengine/godot/pull/44182 plus a small tweak to a variable to make results more consistent with orthographic cameras