### PR TITLE
Add an `OS.get_processor_name()` method

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -362,6 +362,10 @@ int OS::get_processor_count() const {
 	return ::OS::get_singleton()->get_processor_count();
 }
 
+String OS::get_processor_name() const {
+	return ::OS::get_singleton()->get_processor_name();
+}
+
 bool OS::is_stdout_verbose() const {
 	return ::OS::get_singleton()->is_stdout_verbose();
 }
@@ -554,6 +558,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_low_processor_usage_mode_sleep_usec"), &OS::get_low_processor_usage_mode_sleep_usec);
 
 	ClassDB::bind_method(D_METHOD("get_processor_count"), &OS::get_processor_count);
+	ClassDB::bind_method(D_METHOD("get_processor_name"), &OS::get_processor_name);
 
 	ClassDB::bind_method(D_METHOD("get_executable_path"), &OS::get_executable_path);
 	ClassDB::bind_method(D_METHOD("execute", "path", "arguments", "output", "read_stderr", "open_console"), &OS::execute, DEFVAL(Array()), DEFVAL(false), DEFVAL(false));

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -218,6 +218,7 @@ public:
 	bool is_stdout_verbose() const;
 
 	int get_processor_count() const;
+	String get_processor_name() const;
 
 	enum SystemDir {
 		SYSTEM_DIR_DESKTOP,

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -358,6 +358,10 @@ int OS::get_processor_count() const {
 	return 1;
 }
 
+String OS::get_processor_name() const {
+	return "";
+}
+
 bool OS::can_use_threads() const {
 #ifdef NO_THREADS
 	return false;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -302,6 +302,7 @@ public:
 	virtual void set_exit_code(int p_code);
 
 	virtual int get_processor_count() const;
+	virtual String get_processor_name() const;
 	virtual int get_default_thread_pool_size() const { return get_processor_count(); }
 
 	virtual String get_unique_id() const;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -343,7 +343,14 @@
 		<method name="get_processor_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of threads available on the host machine.
+				Returns the number of [i]logical[/i] CPU cores available on the host machine. On CPUs with HyperThreading enabled, this number will be greater than the number of [i]physical[/i] CPU cores.
+			</description>
+		</method>
+		<method name="get_processor_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the name of the CPU model on the host machine (e.g. "Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz").
+				[b]Note:[/b] This method is only implemented on Windows, macOS, Linux and iOS. On Android, HTML5 and UWP, [method get_processor_name] returns an empty string.
 			</description>
 		</method>
 		<method name="get_static_memory_peak_usage" qualifiers="const">

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -109,6 +109,7 @@ public:
 	virtual String get_locale() const override;
 
 	virtual String get_unique_id() const override;
+	virtual String get_processor_name() const override;
 
 	virtual void vibrate_handheld(int p_duration_ms = 500) override;
 

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -45,6 +45,7 @@
 #import <AudioToolbox/AudioServices.h>
 #import <UIKit/UIKit.h>
 #import <dlfcn.h>
+#include <sys/sysctl.h>
 
 #if defined(VULKAN_ENABLED)
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
@@ -285,6 +286,15 @@ String OSIPhone::get_locale() const {
 String OSIPhone::get_unique_id() const {
 	NSString *uuid = [UIDevice currentDevice].identifierForVendor.UUIDString;
 	return String::utf8([uuid UTF8String]);
+}
+
+String OSIPhone::get_processor_name() const {
+	char buffer[256];
+	size_t buffer_len = 256;
+	if (sysctlbyname("machdep.cpu.brand_string", &buffer, &buffer_len, NULL, 0) == 0) {
+		return String::utf8(buffer, buffer_len);
+	}
+	ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name. Returning an empty string."));
 }
 
 void OSIPhone::vibrate_handheld(int p_duration_ms) {

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -141,6 +141,20 @@ String OS_LinuxBSD::get_unique_id() const {
 	return machine_id;
 }
 
+String OS_LinuxBSD::get_processor_name() const {
+	FileAccessRef f = FileAccess::open("/proc/cpuinfo", FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(!f, "", String("Couldn't open `/proc/cpuinfo` to get the CPU model name. Returning an empty string."));
+
+	while (!f->eof_reached()) {
+		const String line = f->get_line();
+		if (line.find("model name") != -1) {
+			return line.split(":")[1].strip_edges();
+		}
+	}
+
+	ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name from `/proc/cpuinfo`. Returning an empty string."));
+}
+
 void OS_LinuxBSD::finalize() {
 	if (main_loop) {
 		memdelete(main_loop);

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -87,6 +87,7 @@ public:
 	virtual Error shell_open(String p_uri) override;
 
 	virtual String get_unique_id() const override;
+	virtual String get_processor_name() const override;
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -102,6 +102,7 @@ public:
 	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) override;
 
 	virtual String get_unique_id() const override;
+	virtual String get_processor_name() const override;
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -42,6 +42,8 @@
 #include <dlfcn.h>
 #include <libproc.h>
 #include <mach-o/dyld.h>
+#include <os/log.h>
+#include <sys/sysctl.h>
 
 _FORCE_INLINE_ String OS_OSX::get_framework_executable(const String &p_path) {
 	// Append framework executable name, or return as is if p_path is not a framework.
@@ -70,6 +72,15 @@ void OS_OSX::initialize() {
 	crash_handler.initialize();
 
 	initialize_core();
+}
+
+String OS_OSX::get_processor_name() const {
+	char buffer[256];
+	size_t buffer_len = 256;
+	if (sysctlbyname("machdep.cpu.brand_string", &buffer, &buffer_len, NULL, 0) == 0) {
+		return String::utf8(buffer, buffer_len);
+	}
+	ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name. Returning an empty string."));
 }
 
 void OS_OSX::initialize_core() {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -625,6 +625,26 @@ int OS_Windows::get_processor_count() const {
 	return sysinfo.dwNumberOfProcessors;
 }
 
+String OS_Windows::get_processor_name() const {
+	const String id = "Hardware\\Description\\System\\CentralProcessor\\0";
+
+	HKEY hkey;
+	if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, (LPCWSTR)(id.utf16().get_data()), 0, KEY_QUERY_VALUE, &hkey) != ERROR_SUCCESS) {
+		ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name. Returning an empty string."));
+	}
+
+	WCHAR buffer[256];
+	DWORD buffer_len = 256;
+	DWORD vtype = REG_SZ;
+	if (RegQueryValueExW(hkey, L"ProcessorNameString", NULL, &vtype, (LPBYTE)buffer, &buffer_len) == ERROR_SUCCESS) {
+		RegCloseKey(hkey);
+		return String::utf16((const char16_t *)buffer, buffer_len).strip_edges();
+	} else {
+		RegCloseKey(hkey);
+		ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name. Returning an empty string."));
+	}
+}
+
 void OS_Windows::run() {
 	if (!main_loop)
 		return;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -142,6 +142,7 @@ public:
 	virtual String get_locale() const override;
 
 	virtual int get_processor_count() const override;
+	virtual String get_processor_name() const override;
 
 	virtual String get_config_path() const override;
 	virtual String get_data_path() const override;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/58157.

*This method can be used to get the CPU model name. It can be used in conjunction with `RenderingServer.get_video_adapter_name()` and `RenderingServer.get_video_adapter_vendor()` for annotating benchmarks and automatic graphics quality configuration.

This closes https://github.com/godotengine/godot-proposals/issues/1660.

**Test project:** [test_processor_name.zip](https://github.com/godotengine/godot/files/6053148/test_processor_name.zip) (`master` branch only)

## Example

```gdscript
func _ready():
    print(OS.get_processor_name())
```

On my Linux machine, this results in:

```
Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
```

## TODO

- [ ] Implement `OS.get_processor_name()` on Android and HTML5 (if possible). This can be done in a future PR.

Volunteers are welcome for those tasks :slightly_smiling_face: 