### PR TITLE
Added optional id parameter to `PopupMenu::add_separator`

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -205,8 +205,10 @@
 			</return>
 			<argument index="0" name="label" type="String" default="&quot;&quot;">
 			</argument>
+			<argument index="1" name="id" type="int" default="-1">
+			</argument>
 			<description>
-				Adds a separator between items. Separators also occupy an index.
+				Adds a separator between items. Separators also occupy an index, which you can set by using the [code]id[/code] parameter.
 				A [code]label[/code] can optionally be provided, which will appear at the center of the separator.
 			</description>
 		</method>

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1349,10 +1349,10 @@ void PopupMenu::remove_item(int p_idx) {
 	child_controls_changed();
 }
 
-void PopupMenu::add_separator(const String &p_text) {
+void PopupMenu::add_separator(const String &p_text, int p_id) {
 	Item sep;
 	sep.separator = true;
-	sep.id = -1;
+	sep.id = p_id;
 	if (p_text != String()) {
 		sep.text = p_text;
 		sep.xl_text = tr(p_text);
@@ -1600,7 +1600,7 @@ void PopupMenu::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("remove_item", "idx"), &PopupMenu::remove_item);
 
-	ClassDB::bind_method(D_METHOD("add_separator", "label"), &PopupMenu::add_separator, DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("add_separator", "label", "id"), &PopupMenu::add_separator, DEFVAL(String()), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("clear"), &PopupMenu::clear);
 
 	ClassDB::bind_method(D_METHOD("_set_items"), &PopupMenu::_set_items);

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -228,7 +228,7 @@ public:
 
 	void remove_item(int p_idx);
 
-	void add_separator(const String &p_text = String());
+	void add_separator(const String &p_text = String(), int p_id = -1);
 
 	void clear();
 


### PR DESCRIPTION
Currently, it's very easy to add a separator to the PopupMenu using `add_separator` but is hard to remove it using `remove_item` because there is no provided id.
Now it's easy:

```
const SEPARATOR = 1
var popup = PopupMenu.new()
add_child(popup)
popup.add_separator("", SEPARATOR)
popup.remove_item(popup.get_item_index(SEPARATOR))
popup.popup_centered()
```
