### PR TITLE
Delete the CharProxy<T> copy constructor

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -57,11 +57,9 @@ class CharProxy {
 			_index(p_index),
 			_cowdata(p_cowdata) {}
 
-public:
-	_FORCE_INLINE_ CharProxy(const CharProxy<T> &p_other) :
-			_index(p_other._index),
-			_cowdata(p_other._cowdata) {}
+	CharProxy(const CharProxy<T> &) = delete;
 
+public:
 	_FORCE_INLINE_ operator T() const {
 		if (unlikely(_index == _cowdata.size())) {
 			return _null;


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/?mode=tree&ruleFocus=2165180572&id=cpp%2Frule-of-two), `CharProxy` has an assignment operator, but no copy constructor. To avoid differences in behaviour, which would be unexpected, they should either both be created or deleted.

However, `CharProxy` is just a helper class to manipulate underlying data. The assignment operator is used to specifically change an element in the underlying data, but not the reference to the underlying data. There is no default constructor, and neither would a copy constructor make sense. So this PR explicitly deletes the copy constructor to ensure a compiler created one can never be used.
