### PR TITLE
Ignore Bullet collision contact points with distance = 0

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -829,7 +829,7 @@ void SpaceBullet::check_body_collision() {
 				btManifoldPoint &pt = contactManifold->getContactPoint(0);
 #endif
 				if (
-						pt.getDistance() <= 0.0 ||
+						pt.getDistance() < 0.0 ||
 						bodyA->was_colliding(bodyB) ||
 						bodyB->was_colliding(bodyA)) {
 					Vector3 collisionWorldPosition;


### PR DESCRIPTION
Currently, Godot processes all Bullet collision manifolds as long as the distance is less than or equal to 0 i.e. a collision has occurred. When CCD is enabled, Bullet creates an additional collision manifold with the CCD results. This manifold sets the collision point distance to 0 if a collision occurs. Therefore, when a CCD collision is detected, this manifold is processed too, when it shouldn't.

This PR ensures that Godot doesn't process Bullet collision manifolds' contact points with a distance of 0; so it won't process the additional collision manifold created by CCD.

Fixes #44644.
