### PR TITLE
Rect2: Fix has_point on bottom and right borders

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -158,6 +158,7 @@ struct Rect2 {
 
 		return new_rect;
 	}
+
 	inline bool has_point(const Point2 &p_point) const {
 		if (p_point.x < position.x) {
 			return false;
@@ -166,15 +167,16 @@ struct Rect2 {
 			return false;
 		}
 
-		if (p_point.x >= (position.x + size.x)) {
+		if (p_point.x > (position.x + size.x)) {
 			return false;
 		}
-		if (p_point.y >= (position.y + size.y)) {
+		if (p_point.y > (position.y + size.y)) {
 			return false;
 		}
 
 		return true;
 	}
+
 	bool is_equal_approx(const Rect2 &p_rect) const;
 
 	bool operator==(const Rect2 &p_rect) const { return position == p_rect.position && size == p_rect.size; }
@@ -401,6 +403,7 @@ struct Rect2i {
 
 		return new_rect;
 	}
+
 	bool has_point(const Point2i &p_point) const {
 		if (p_point.x < position.x) {
 			return false;
@@ -409,10 +412,10 @@ struct Rect2i {
 			return false;
 		}
 
-		if (p_point.x >= (position.x + size.x)) {
+		if (p_point.x > (position.x + size.x)) {
 			return false;
 		}
-		if (p_point.y >= (position.y + size.y)) {
+		if (p_point.y > (position.y + size.y)) {
 			return false;
 		}
 

--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -64,6 +64,21 @@
 			</argument>
 			<description>
 				Returns this [AABB] expanded to include a given point.
+				[b]Example:[/b]
+				[codeblocks]
+				[gdscript]
+				# position (-3, 2, 0), size (1, 1, 1)
+				var box = AABB(Vector3(-3, 2, 0), Vector3(1, 1, 1))
+				# position (-3, -1, 0), size (3, 4, 2), so we fit both rect and Vector3(0, -1, 2)
+				var box2 = box.expand(Vector3(0, -1, 2))
+				[/gdscript]
+				[csharp]
+				// position (-3, 2, 0), size (1, 1, 1)
+				var box = new AABB(new Vector3(-3, 2, 0), new Vector3(1, 1, 1));
+				// position (-3, -1, 0), size (3, 4, 2), so we fit both rect and Vector3(0, -1, 2)
+				var box2 = box.Expand(new Vector3(0, -1, 2));
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_area">
@@ -162,7 +177,8 @@
 			<argument index="0" name="point" type="Vector3">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [AABB] contains a point.
+				Returns [code]true[/code] if the [AABB] contains a point. Points on the border of the [AABB] are considered included.
+				[b]Note:[/b] This method is not reliable for [AABB] with a [i]negative size[/i]. Use [method abs] to get a positive sized equivalent [AABB] to check for contained points.
 			</description>
 		</method>
 		<method name="intersection">

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -97,6 +97,21 @@
 			</argument>
 			<description>
 				Returns this [Rect2] expanded to include a given point.
+				[b]Example:[/b]
+				[codeblocks]
+				[gdscript]
+				# position (-3, 2), size (1, 1)
+				var rect = Rect2(Vector2(-3, 2), Vector2(1, 1))
+				# position (-3, -1), size (3, 4), so we fit both rect and Vector2(0, -1)
+				var rect2 = rect.expand(Vector2(0, -1))
+				[/gdscript]
+				[csharp]
+				# position (-3, 2), size (1, 1)
+				var rect = new Rect2(new Vector2(-3, 2), new Vector2(1, 1));
+				# position (-3, -1), size (3, 4), so we fit both rect and Vector2(0, -1)
+				var rect2 = rect.Expand(new Vector2(0, -1));
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_area">
@@ -154,7 +169,8 @@
 			<argument index="0" name="point" type="Vector2">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [Rect2] contains a point.
+				Returns [code]true[/code] if the [Rect2] contains a point. Points on the border of the [Rect2] are considered included.
+				[b]Note:[/b] This method is not reliable for [Rect2] with a [i]negative size[/i]. Use [method abs] to get a positive sized equivalent rectangle to check for contained points.
 			</description>
 		</method>
 		<method name="intersects">

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -95,6 +95,20 @@
 			</argument>
 			<description>
 				Returns this [Rect2i] expanded to include a given point.
+				[codeblocks]
+				[gdscript]
+				# position (-3, 2), size (1, 1)
+				var rect = Rect2i(Vector2i(-3, 2), Vector2i(1, 1))
+				# position (-3, -1), size (3, 4), so we fit both rect and Vector2i(0, -1)
+				var rect2 = rect.expand(Vector2i(0, -1))
+				[/gdscript]
+				[csharp]
+				# position (-3, 2), size (1, 1)
+				var rect = new Rect2i(new Vector2i(-3, 2), new Vector2i(1, 1));
+				# position (-3, -1), size (3, 4), so we fit both rect and Vector2i(0, -1)
+				var rect2 = rect.Expand(new Vector2i(0, -1));
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_area">
@@ -152,7 +166,8 @@
 			<argument index="0" name="point" type="Vector2i">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [Rect2i] contains a point.
+				Returns [code]true[/code] if the [Rect2i] contains a point. Points on the border of the [Rect2i] are considered included.
+				[b]Note:[/b] This method is not reliable for [Rect2i] with a [i]negative size[/i]. Use [method abs] to get a positive sized equivalent rectangle to check for contained points.
 			</description>
 		</method>
 		<method name="intersects">

--- a/tests/test_rect2.h
+++ b/tests/test_rect2.h
@@ -205,25 +205,61 @@ TEST_CASE("[Rect2] Growing") {
 }
 
 TEST_CASE("[Rect2] Has point") {
+	Rect2 rect = Rect2(0, 100, 1280, 720);
 	CHECK_MESSAGE(
-			Rect2(0, 100, 1280, 720).has_point(Vector2(500, 600)),
+			rect.has_point(Vector2(500, 600)),
 			"has_point() with contained Vector2 should return the expected result.");
 	CHECK_MESSAGE(
-			!Rect2(0, 100, 1280, 720).has_point(Vector2(0, 0)),
+			!rect.has_point(Vector2(0, 0)),
 			"has_point() with non-contained Vector2 should return the expected result.");
 
 	CHECK_MESSAGE(
-			Rect2(0, 100, 1280, 720).has_point(Vector2(0, 110)),
-			"has_point() with positive Vector2 on left edge should return the expected result.");
+			rect.has_point(rect.position),
+			"has_point() with positive size should include `position`.");
 	CHECK_MESSAGE(
-			!Rect2(0, 100, 1280, 720).has_point(Vector2(1280, 110)),
-			"has_point() with positive Vector2 on right edge should return the expected result.");
+			rect.has_point(rect.position + Vector2(1, 1)),
+			"has_point() with positive size should include `position + (1, 1)`.");
+	CHECK_MESSAGE(
+			!rect.has_point(rect.position + Vector2(1, -1)),
+			"has_point() with positive size should not include `position + (1, -1)`.");
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + rect.size),
+			"has_point() with positive size should include `position + size`.");
+	CHECK_MESSAGE(
+			!rect.has_point(rect.position + rect.size + Vector2(1, 1)),
+			"has_point() with positive size should include `position + size + (1, 1)`.");
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + rect.size + Vector2(-1, -1)),
+			"has_point() with positive size should include `position + size + (-1, -1)`.");
+	CHECK_MESSAGE(
+			!rect.has_point(rect.position + rect.size + Vector2(-1, 1)),
+			"has_point() with positive size should not include `position + size + (-1, 1)`.");
 
 	CHECK_MESSAGE(
-			Rect2(-4000, 100, 1280, 720).has_point(Vector2(-4000, 110)),
+			rect.has_point(rect.position + Vector2(0, 10)),
+			"has_point() with positive Vector2 on left edge should return the expected result.");
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + Vector2(rect.size.x, 10)),
+			"has_point() with positive Vector2 on right edge should return the expected result.");
+
+	/*
+	// FIXME: Disabled for now until GH-37617 is fixed one way or another.
+	// More tests should then be written like for the positive size case.
+	rect = Rect2(0, 100, -1280, -720);
+	CHECK_MESSAGE(
+			rect.has_point(rect.position),
+			"has_point() with negative size should include `position`.");
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + rect.size),
+			"has_point() with negative size should include `position + size`.");
+	*/
+
+	rect = Rect2(-4000, 100, 1280, 720);
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + Vector2(0, 10)),
 			"has_point() with negative Vector2 on left edge should return the expected result.");
 	CHECK_MESSAGE(
-			!Rect2(-4000, 100, 1280, 720).has_point(Vector2(-2720, 110)),
+			rect.has_point(rect.position + Vector2(rect.size.x, 10)),
 			"has_point() with negative Vector2 on right edge should return the expected result.");
 }
 
@@ -417,25 +453,61 @@ TEST_CASE("[Rect2i] Growing") {
 }
 
 TEST_CASE("[Rect2i] Has point") {
+	Rect2i rect = Rect2i(0, 100, 1280, 720);
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 1280, 720).has_point(Vector2i(500, 600)),
+			rect.has_point(Vector2i(500, 600)),
 			"has_point() with contained Vector2i should return the expected result.");
 	CHECK_MESSAGE(
-			!Rect2i(0, 100, 1280, 720).has_point(Vector2i(0, 0)),
+			!rect.has_point(Vector2i(0, 0)),
 			"has_point() with non-contained Vector2i should return the expected result.");
 
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 1280, 720).has_point(Vector2(0, 110)),
-			"has_point() with positive Vector2 on left edge should return the expected result.");
+			rect.has_point(rect.position),
+			"has_point() with positive size should include `position`.");
 	CHECK_MESSAGE(
-			!Rect2i(0, 100, 1280, 720).has_point(Vector2(1280, 110)),
-			"has_point() with positive Vector2 on right edge should return the expected result.");
+			rect.has_point(rect.position + Vector2i(1, 1)),
+			"has_point() with positive size should include `position + (1, 1)`.");
+	CHECK_MESSAGE(
+			!rect.has_point(rect.position + Vector2i(1, -1)),
+			"has_point() with positive size should not include `position + (1, -1)`.");
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + rect.size),
+			"has_point() with positive size should include `position + size`.");
+	CHECK_MESSAGE(
+			!rect.has_point(rect.position + rect.size + Vector2i(1, 1)),
+			"has_point() with positive size should include `position + size + (1, 1)`.");
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + rect.size + Vector2i(-1, -1)),
+			"has_point() with positive size should include `position + size + (-1, -1)`.");
+	CHECK_MESSAGE(
+			!rect.has_point(rect.position + rect.size + Vector2i(-1, 1)),
+			"has_point() with positive size should not include `position + size + (-1, 1)`.");
 
 	CHECK_MESSAGE(
-			Rect2i(-4000, 100, 1280, 720).has_point(Vector2(-4000, 110)),
+			rect.has_point(rect.position + Vector2i(0, 10)),
+			"has_point() with positive Vector2i on left edge should return the expected result.");
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + Vector2i(rect.size.x, 10)),
+			"has_point() with positive Vector2i on right edge should return the expected result.");
+
+	/*
+	// FIXME: Disabled for now until GH-37617 is fixed one way or another.
+	// More tests should then be written like for the positive size case.
+	rect = Rect2i(0, 100, -1280, -720);
+	CHECK_MESSAGE(
+			rect.has_point(rect.position),
+			"has_point() with negative size should include `position`.");
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + rect.size),
+			"has_point() with negative size should include `position + size`.");
+	*/
+
+	rect = Rect2i(-4000, 100, 1280, 720);
+	CHECK_MESSAGE(
+			rect.has_point(rect.position + Vector2i(0, 10)),
 			"has_point() with negative Vector2 on left edge should return the expected result.");
 	CHECK_MESSAGE(
-			!Rect2i(-4000, 100, 1280, 720).has_point(Vector2(-2720, 110)),
+			rect.has_point(rect.position + Vector2i(rect.size.x, 10)),
 			"has_point() with negative Vector2 on right edge should return the expected result.");
 }
 


### PR DESCRIPTION
Improve documentation to clarify things, and improve tests.

`has_point` still breaks with negative sized rectangles (#37617).

Fixes #44723.

-----

So I just spent an hour improving tests and documentation, and then when writing the commit message I realized that this might not have been a bug in the first place, and that this change is possibly wrong (yet the improved tests and docs can still be salvaged).

The main issue with this change is that multiple Rect2's can contain the same points, which might have implications in rendering/batching and tilemaps (CC @groud @lawnjelly). That's the case already with AABB so I thought it's good to make it behave the same, but it might be more problematic in 2D.

So this should be discussed, and if we think it's better to include all borders (and not just top and left), this can be merged. Otherwise this should be clarified further in the documentation.