### PR TITLE
Add an `OS.get_thread_caller_id()` method

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -290,6 +290,10 @@ Error _OS::set_thread_name(const String &p_name) {
 	return Thread::set_name(p_name);
 }
 
+Thread::ID _OS::get_thread_caller_id() const {
+	return Thread::get_caller_id();
+};
+
 bool _OS::has_feature(const String &p_feature) const {
 	return OS::get_singleton()->has_feature(p_feature);
 }
@@ -758,6 +762,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_file_access_save_and_swap", "enabled"), &_OS::set_use_file_access_save_and_swap);
 
 	ClassDB::bind_method(D_METHOD("set_thread_name", "name"), &_OS::set_thread_name);
+	ClassDB::bind_method(D_METHOD("get_thread_caller_id"), &_OS::get_thread_caller_id);
 
 	ClassDB::bind_method(D_METHOD("has_feature", "tag_name"), &_OS::has_feature);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -232,6 +232,7 @@ public:
 	String get_user_data_dir() const;
 
 	Error set_thread_name(const String &p_name);
+	Thread::ID get_thread_caller_id() const;
 
 	bool has_feature(const String &p_feature) const;
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -127,6 +127,14 @@
 				Returns the keycode of the given string (e.g. "Escape").
 			</description>
 		</method>
+		<method name="get_thread_caller_id" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the ID of the current thread. This can be used in logs to ease debugging of multi-threaded applications.
+				[b]Note:[/b] Thread IDs are not deterministic and may be reused across application restarts.
+			</description>
+		</method>
 		<method name="get_cmdline_args">
 			<return type="PackedStringArray">
 			</return>


### PR DESCRIPTION
This can be used to print thread IDs in logs. This can make it easier to debug multi-threaded applications.

This closes https://github.com/godotengine/godot-proposals/issues/2026.

Thanks @Khaos66 for providing an implementation :slightly_smiling_face:
I renamed `OS.get_caller_id()` from their implementation to `OS.get_thread_caller_id()` to make it more explicit.