### PR TITLE
Add helper count function to Variant

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -497,6 +497,7 @@ public:
 	static bool is_builtin_method_const(Variant::Type p_type, const StringName &p_method);
 	static bool is_builtin_method_vararg(Variant::Type p_type, const StringName &p_method);
 	static void get_builtin_method_list(Variant::Type p_type, List<StringName> *p_list);
+	static int get_builtin_method_count(Variant::Type p_type);
 
 	void call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error);
 	Variant call(const StringName &p_method, const Variant &p_arg1 = Variant(), const Variant &p_arg2 = Variant(), const Variant &p_arg3 = Variant(), const Variant &p_arg4 = Variant(), const Variant &p_arg5 = Variant());
@@ -535,6 +536,7 @@ public:
 	static bool has_member(Variant::Type p_type, const StringName &p_member);
 	static Variant::Type get_member_type(Variant::Type p_type, const StringName &p_member);
 	static void get_member_list(Type p_type, List<StringName> *r_members);
+	static int get_member_count(Type p_type);
 
 	static ValidatedSetter get_member_validated_setter(Variant::Type p_type, const StringName &p_member);
 	static ValidatedGetter get_member_validated_getter(Variant::Type p_type, const StringName &p_member);
@@ -628,6 +630,7 @@ public:
 	static bool is_utility_function_vararg(const StringName &p_name);
 
 	static void get_utility_function_list(List<StringName> *r_functions);
+	static int get_utility_function_count();
 
 	//argsVariant call()
 
@@ -642,6 +645,7 @@ public:
 
 	void static_assign(const Variant &p_variant);
 	static void get_constants_for_type(Variant::Type p_type, List<StringName> *p_constants);
+	static int get_constants_count_for_type(Variant::Type p_type);
 	static bool has_constant(Variant::Type p_type, const StringName &p_value);
 	static Variant get_constant_value(Variant::Type p_type, const StringName &p_value, bool *r_valid = nullptr);
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -705,6 +705,11 @@ void Variant::get_builtin_method_list(Variant::Type p_type, List<StringName> *p_
 	}
 }
 
+int Variant::get_builtin_method_count(Variant::Type p_type) {
+	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, -1);
+	return builtin_method_names[p_type].size();
+}
+
 Variant::Type Variant::get_builtin_method_return_type(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, Variant::NIL);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
@@ -797,6 +802,13 @@ void Variant::get_constants_for_type(Variant::Type p_type, List<StringName> *p_c
 		p_constants->push_back(E->key());
 #endif
 	}
+}
+
+int Variant::get_constants_count_for_type(Variant::Type p_type) {
+	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, -1);
+	_VariantCall::ConstantData &cd = _VariantCall::constant_data[p_type];
+
+	return cd.value.size() + cd.variant_value.size();
 }
 
 bool Variant::has_constant(Variant::Type p_type, const StringName &p_value) {

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -437,6 +437,11 @@ void Variant::get_member_list(Variant::Type p_type, List<StringName> *r_members)
 	}
 }
 
+int Variant::get_member_count(Type p_type) {
+	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, -1);
+	return variant_setters_getters_names[p_type].size();
+}
+
 Variant::ValidatedSetter Variant::get_member_validated_setter(Variant::Type p_type, const StringName &p_member) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, nullptr);
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1379,3 +1379,7 @@ void Variant::get_utility_function_list(List<StringName> *r_functions) {
 		r_functions->push_back(E->get());
 	}
 }
+
+int Variant::get_utility_function_count() {
+	return utility_function_name_table.size();
+}


### PR DESCRIPTION
To get counts of items before getting the list, which is useful for GDNative so users can pre-allocate the buffer with the correct size without having to get the list twice.


