### PR TITLE
 Fix shape_centered property in TouchScreenButton

### DIFF
--- a/doc/classes/TouchScreenButton.xml
+++ b/doc/classes/TouchScreenButton.xml
@@ -42,7 +42,7 @@
 			If [code]true[/code], the button's shape is centered in the provided texture. If no texture is used, this property has no effect.
 		</member>
 		<member name="shape_visible" type="bool" setter="set_shape_visible" getter="is_shape_visible" default="true">
-			If [code]true[/code], the button's shape is visible.
+			If [code]true[/code], the button's shape is visible in the editor.
 		</member>
 		<member name="visibility_mode" type="int" setter="set_visibility_mode" getter="get_visibility_mode" enum="TouchScreenButton.VisibilityMode" default="0">
 			The button's visibility mode. See [enum VisibilityMode] for possible values.

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -129,8 +129,11 @@ void TouchScreenButton::_notification(int p_what) {
 			if (shape.is_valid()) {
 				Color draw_col = get_tree()->get_debug_collisions_color();
 
-				Vector2 size = texture.is_null() ? shape->get_rect().size : texture->get_size();
-				Vector2 pos = shape_centered ? size * 0.5f : Vector2();
+				Vector2 pos;
+				if (shape_centered && texture.is_valid()) {
+					pos = texture->get_size() * 0.5;
+				}
+
 				draw_set_transform_matrix(get_canvas_transform().translated(pos));
 				shape->draw(get_canvas_item(), draw_col);
 			}
@@ -251,9 +254,12 @@ bool TouchScreenButton::_is_point_inside(const Point2 &p_point) {
 	if (shape.is_valid()) {
 		check_rect = false;
 
-		Vector2 size = texture.is_null() ? shape->get_rect().size : texture->get_size();
-		Transform2D xform = shape_centered ? Transform2D().translated(size * 0.5f) : Transform2D();
-		touched = shape->collide(xform, unit_rect, Transform2D(0, coord + Vector2(0.5, 0.5)));
+		Vector2 pos;
+		if (shape_centered && texture.is_valid()) {
+			pos = texture->get_size() * 0.5;
+		}
+
+		touched = shape->collide(Transform2D().translated(pos), unit_rect, Transform2D(0, coord + Vector2(0.5, 0.5)));
 	}
 
 	if (bitmask.is_valid()) {


### PR DESCRIPTION
Fixes #35711

Breaks compat, but the previous behavior wasn't really useful, so maybe no one relied on it.
Also the doc change isn't really related (except it's the same class). Could remove if requested.