### PR TITLE
Mono: Rename margin to side

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -196,17 +196,17 @@ namespace Godot
         /// <summary>
         /// Returns a copy of the Rect2 grown a given amount of units towards the <see cref="Margin"/> direction.
         /// </summary>
-        /// <param name="margin">The direction to grow in.</param>
+        /// <param name="side">The direction to grow in.</param>
         /// <param name="by">The amount to grow by.</param>
         /// <returns>The grown rect.</returns>
-        public Rect2 GrowMargin(Margin margin, real_t by)
+        public Rect2 GrowMargin(Side side, real_t by)
         {
             var g = this;
 
-            g = g.GrowIndividual(Margin.Left == margin ? by : 0,
-                    Margin.Top == margin ? by : 0,
-                    Margin.Right == margin ? by : 0,
-                    Margin.Bottom == margin ? by : 0);
+            g = g.GrowIndividual(Side.Left == side ? by : 0,
+                    Side.Top == side ? by : 0,
+                    Side.Right == side ? by : 0,
+                    Side.Bottom == side ? by : 0);
 
             return g;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -191,17 +191,17 @@ namespace Godot
         /// <summary>
         /// Returns a copy of the Rect2i grown a given amount of units towards the <see cref="Margin"/> direction.
         /// </summary>
-        /// <param name="margin">The direction to grow in.</param>
+        /// <param name="side">The direction to grow in.</param>
         /// <param name="by">The amount to grow by.</param>
         /// <returns>The grown rect.</returns>
-        public Rect2i GrowMargin(Margin margin, int by)
+        public Rect2i GrowMargin(Side side, int by)
         {
             var g = this;
 
-            g = g.GrowIndividual(Margin.Left == margin ? by : 0,
-                    Margin.Top == margin ? by : 0,
-                    Margin.Right == margin ? by : 0,
-                    Margin.Bottom == margin ? by : 0);
+            g = g.GrowIndividual(Side.Left == side ? by : 0,
+                    Side.Top == side ? by : 0,
+                    Side.Right == side ? by : 0,
+                    Side.Bottom == side ? by : 0);
 
             return g;
         }


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Rename `margin` to `side` that was missed in #44605