### PR TITLE
Add missing "normalized" accessor property to glTF document

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -846,6 +846,7 @@ Error GLTFDocument::_encode_accessors(Ref<GLTFState> state) {
 		d["count"] = accessor->count;
 		d["type"] = _get_accessor_type_name(accessor->type);
 		d["byteOffset"] = accessor->byte_offset;
+		d["normalized"] = accessor->normalized;
 		d["max"] = accessor->max;
 		d["min"] = accessor->min;
 		d["bufferView"] = accessor->buffer_view; //optional because it may be sparse...
@@ -959,6 +960,10 @@ Error GLTFDocument::_parse_accessors(Ref<GLTFState> state) {
 
 		if (d.has("byteOffset")) {
 			accessor->byte_offset = d["byteOffset"];
+		}
+
+		if (d.has("normalized")) {
+			accessor->normalized = d["normalized"];
 		}
 
 		if (d.has("max")) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
This PR adds missing ["normalized" accessor property](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#accessornormalized) to the glTF document of the glTF module, for both import and export. It fixes issue #44744.

I say missing, because the code already supports the normalized accessor property, but does not use the glTF files values.

This complements a similar PR for 3.2 (#44746), as it has the same issue.