### PR TITLE
[3.2] Add missing "normalized" accessor property to glTF document

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -506,6 +506,10 @@ Error EditorSceneImporterGLTF::_parse_accessors(GLTFState &state) {
 			accessor.byte_offset = d["byteOffset"];
 		}
 
+		if (d.has("normalized")) {
+			accessor.normalized = d["normalized"];
+		}
+
 		if (d.has("max")) {
 			accessor.max = d["max"];
 		}


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This PR adds missing ["normalized" accessor property](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#accessornormalized) to the scene importer for glTF. It fixes issue #44744 for Godot 3.2.

I say missing, because the code already supports the normalized accessor property, but does not use the glTF files values.

This complements a similar PR for the master branch (#44745), as it has the same issue. I created a separate PR as a simple cherry-pick cannot be done as the glTF module has been refactored in the master branch.