### PR TITLE
Rename Rect2 and Rect2i grow_margin() to grow_side()

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -180,16 +180,16 @@ struct Rect2 {
 	bool operator==(const Rect2 &p_rect) const { return position == p_rect.position && size == p_rect.size; }
 	bool operator!=(const Rect2 &p_rect) const { return position != p_rect.position || size != p_rect.size; }
 
-	inline Rect2 grow(real_t p_by) const {
+	inline Rect2 grow(real_t p_amount) const {
 		Rect2 g = *this;
-		g.position.x -= p_by;
-		g.position.y -= p_by;
-		g.size.width += p_by * 2;
-		g.size.height += p_by * 2;
+		g.position.x -= p_amount;
+		g.position.y -= p_amount;
+		g.size.width += p_amount * 2;
+		g.size.height += p_amount * 2;
 		return g;
 	}
 
-	inline Rect2 grow_margin(Side p_side, real_t p_amount) const {
+	inline Rect2 grow_side(Side p_side, real_t p_amount) const {
 		Rect2 g = *this;
 		g = g.grow_individual((SIDE_LEFT == p_side) ? p_amount : 0,
 				(SIDE_TOP == p_side) ? p_amount : 0,
@@ -198,8 +198,8 @@ struct Rect2 {
 		return g;
 	}
 
-	inline Rect2 grow_margin_bind(uint32_t p_side, real_t p_amount) const {
-		return grow_margin(Side(p_side), p_amount);
+	inline Rect2 grow_side_bind(uint32_t p_side, real_t p_amount) const {
+		return grow_side(Side(p_side), p_amount);
 	}
 
 	inline Rect2 grow_individual(real_t p_left, real_t p_top, real_t p_right, real_t p_bottom) const {
@@ -422,16 +422,16 @@ struct Rect2i {
 	bool operator==(const Rect2i &p_rect) const { return position == p_rect.position && size == p_rect.size; }
 	bool operator!=(const Rect2i &p_rect) const { return position != p_rect.position || size != p_rect.size; }
 
-	Rect2i grow(int p_by) const {
+	Rect2i grow(int p_amount) const {
 		Rect2i g = *this;
-		g.position.x -= p_by;
-		g.position.y -= p_by;
-		g.size.width += p_by * 2;
-		g.size.height += p_by * 2;
+		g.position.x -= p_amount;
+		g.position.y -= p_amount;
+		g.size.width += p_amount * 2;
+		g.size.height += p_amount * 2;
 		return g;
 	}
 
-	inline Rect2i grow_margin(Side p_side, int p_amount) const {
+	inline Rect2i grow_side(Side p_side, int p_amount) const {
 		Rect2i g = *this;
 		g = g.grow_individual((SIDE_LEFT == p_side) ? p_amount : 0,
 				(SIDE_TOP == p_side) ? p_amount : 0,
@@ -440,8 +440,8 @@ struct Rect2i {
 		return g;
 	}
 
-	inline Rect2i grow_margin_bind(uint32_t p_side, int p_amount) const {
-		return grow_margin(Side(p_side), p_amount);
+	inline Rect2i grow_side_bind(uint32_t p_side, int p_amount) const {
+		return grow_side(Side(p_side), p_amount);
 	}
 
 	inline Rect2i grow_individual(int p_left, int p_top, int p_right, int p_bottom) const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1036,8 +1036,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(Rect2, intersection, sarray("b"), varray());
 	bind_method(Rect2, merge, sarray("b"), varray());
 	bind_method(Rect2, expand, sarray("to"), varray());
-	bind_method(Rect2, grow, sarray("by"), varray());
-	bind_methodv(Rect2, grow_margin, &Rect2::grow_margin_bind, sarray("margin", "by"), varray());
+	bind_method(Rect2, grow, sarray("amount"), varray());
+	bind_methodv(Rect2, grow_side, &Rect2::grow_side_bind, sarray("side", "amount"), varray());
 	bind_method(Rect2, grow_individual, sarray("left", "top", "right", "bottom"), varray());
 	bind_method(Rect2, abs, sarray(), varray());
 
@@ -1051,8 +1051,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(Rect2i, intersection, sarray("b"), varray());
 	bind_method(Rect2i, merge, sarray("b"), varray());
 	bind_method(Rect2i, expand, sarray("to"), varray());
-	bind_method(Rect2i, grow, sarray("by"), varray());
-	bind_methodv(Rect2i, grow_margin, &Rect2i::grow_margin_bind, sarray("margin", "by"), varray());
+	bind_method(Rect2i, grow, sarray("amount"), varray());
+	bind_methodv(Rect2i, grow_side, &Rect2i::grow_side_bind, sarray("side", "amount"), varray());
 	bind_method(Rect2i, grow_individual, sarray("left", "top", "right", "bottom"), varray());
 	bind_method(Rect2i, abs, sarray(), varray());
 

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1081,19 +1081,19 @@
 		</member>
 		<member name="offset_bottom" type="float" setter="set_offset" getter="get_offset" default="0.0">
 			Distance between the node's bottom edge and its parent control, based on [member anchor_bottom].
-			Margins are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Margins update automatically when you move or resize the node.
+			Offsets are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Offsets update automatically when you move or resize the node.
 		</member>
 		<member name="offset_left" type="float" setter="set_offset" getter="get_offset" default="0.0">
 			Distance between the node's left edge and its parent control, based on [member anchor_left].
-			Margins are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Margins update automatically when you move or resize the node.
+			Offsets are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Offsets update automatically when you move or resize the node.
 		</member>
 		<member name="offset_right" type="float" setter="set_offset" getter="get_offset" default="0.0">
 			Distance between the node's right edge and its parent control, based on [member anchor_right].
-			Margins are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Margins update automatically when you move or resize the node.
+			Offsets are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Offsets update automatically when you move or resize the node.
 		</member>
 		<member name="offset_top" type="float" setter="set_offset" getter="get_offset" default="0.0">
 			Distance between the node's top edge and its parent control, based on [member anchor_top].
-			Margins are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Margins update automatically when you move or resize the node.
+			Offsets are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Offsets update automatically when you move or resize the node.
 		</member>
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" enum="Control.CursorShape" default="0">
 			The default cursor shape for this control. Useful for Godot plugins and applications or games that use the system's mouse cursors.

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -110,10 +110,10 @@
 		<method name="grow">
 			<return type="Rect2">
 			</return>
-			<argument index="0" name="by" type="float">
+			<argument index="0" name="amount" type="float">
 			</argument>
 			<description>
-				Returns a copy of the [Rect2] grown a given amount of units towards all the sides.
+				Returns a copy of the [Rect2] grown by the specified [code]amount[/code] on all sides.
 			</description>
 		</method>
 		<method name="grow_individual">
@@ -128,18 +128,18 @@
 			<argument index="3" name="bottom" type="float">
 			</argument>
 			<description>
-				Returns a copy of the [Rect2] grown a given amount of units towards each direction individually.
+				Returns a copy of the [Rect2] grown by the specified amount on each side individually.
 			</description>
 		</method>
-		<method name="grow_margin">
+		<method name="grow_side">
 			<return type="Rect2">
 			</return>
 			<argument index="0" name="side" type="int" enum="Side">
 			</argument>
-			<argument index="1" name="by" type="float">
+			<argument index="1" name="amount" type="float">
 			</argument>
 			<description>
-				Returns a copy of the [Rect2] grown a given amount of units on the specified [enum Side].
+				Returns a copy of the [Rect2] grown by the specified [code]amount[/code] on the specified [enum Side].
 			</description>
 		</method>
 		<method name="has_no_area">

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -108,10 +108,10 @@
 		<method name="grow">
 			<return type="Rect2i">
 			</return>
-			<argument index="0" name="by" type="int">
+			<argument index="0" name="amount" type="int">
 			</argument>
 			<description>
-				Returns a copy of the [Rect2i] grown a given amount of units towards all the sides.
+				Returns a copy of the [Rect2i] grown by the specified [code]amount[/code] on all sides.
 			</description>
 		</method>
 		<method name="grow_individual">
@@ -126,18 +126,18 @@
 			<argument index="3" name="bottom" type="int">
 			</argument>
 			<description>
-				Returns a copy of the [Rect2i] grown a given amount of units towards each direction individually.
+				Returns a copy of the [Rect2i] grown by the specified amount on each side individually.
 			</description>
 		</method>
-		<method name="grow_margin">
+		<method name="grow_side">
 			<return type="Rect2i">
 			</return>
 			<argument index="0" name="side" type="int" enum="Side">
 			</argument>
-			<argument index="1" name="by" type="int">
+			<argument index="1" name="amount" type="int">
 			</argument>
 			<description>
-				Returns a copy of the [Rect2i] grown a given amount of units on the specified [enum Side].
+				Returns a copy of the [Rect2i] grown by the specified [code]amount[/code] on the specified [enum Side].
 			</description>
 		</method>
 		<method name="has_no_area">

--- a/modules/gdnative/gdnative/rect2.cpp
+++ b/modules/gdnative/gdnative/rect2.cpp
@@ -127,10 +127,10 @@ godot_rect2 GDAPI godot_rect2_grow_individual(const godot_rect2 *p_self, const g
 	return dest;
 }
 
-godot_rect2 GDAPI godot_rect2_grow_margin(const godot_rect2 *p_self, const godot_int p_side, const godot_real p_by) {
+godot_rect2 GDAPI godot_rect2_grow_side(const godot_rect2 *p_self, const godot_int p_side, const godot_real p_by) {
 	godot_rect2 dest;
 	const Rect2 *self = (const Rect2 *)p_self;
-	*((Rect2 *)&dest) = self->grow_margin((Side)p_side, p_by);
+	*((Rect2 *)&dest) = self->grow_side((Side)p_side, p_by);
 	return dest;
 }
 
@@ -270,10 +270,10 @@ godot_rect2i GDAPI godot_rect2i_grow_individual(const godot_rect2i *p_self, cons
 	return dest;
 }
 
-godot_rect2i GDAPI godot_rect2i_grow_margin(const godot_rect2i *p_self, const godot_int p_side, const godot_int p_by) {
+godot_rect2i GDAPI godot_rect2i_grow_side(const godot_rect2i *p_self, const godot_int p_side, const godot_int p_by) {
 	godot_rect2i dest;
 	const Rect2i *self = (const Rect2i *)p_self;
-	*((Rect2i *)&dest) = self->grow_margin((Side)p_side, p_by);
+	*((Rect2i *)&dest) = self->grow_side((Side)p_side, p_by);
 	return dest;
 }
 

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -3534,11 +3534,11 @@
         ]
       },
       {
-        "name": "godot_rect2_grow_margin",
+        "name": "godot_rect2_grow_side",
         "return_type": "godot_rect2",
         "arguments": [
           ["const godot_rect2 *", "p_self"],
-          ["const godot_int", "p_margin"],
+          ["const godot_int", "p_side"],
           ["const godot_real", "p_by"]
         ]
       },
@@ -3758,11 +3758,11 @@
         ]
       },
       {
-        "name": "godot_rect2i_grow_margin",
+        "name": "godot_rect2i_grow_side",
         "return_type": "godot_rect2i",
         "arguments": [
           ["const godot_rect2i *", "p_self"],
-          ["const godot_int", "p_margin"],
+          ["const godot_int", "p_side"],
           ["const godot_int", "p_by"]
         ]
       },

--- a/modules/gdnative/include/gdnative/rect2.h
+++ b/modules/gdnative/include/gdnative/rect2.h
@@ -90,7 +90,7 @@ godot_rect2 GDAPI godot_rect2_grow(const godot_rect2 *p_self, const godot_real p
 
 godot_rect2 GDAPI godot_rect2_grow_individual(const godot_rect2 *p_self, const godot_real p_left, const godot_real p_top, const godot_real p_right, const godot_real p_bottom);
 
-godot_rect2 GDAPI godot_rect2_grow_margin(const godot_rect2 *p_self, const godot_int p_margin, const godot_real p_by);
+godot_rect2 GDAPI godot_rect2_grow_side(const godot_rect2 *p_self, const godot_int p_margin, const godot_real p_by);
 
 godot_rect2 GDAPI godot_rect2_abs(const godot_rect2 *p_self);
 
@@ -133,7 +133,7 @@ godot_rect2i GDAPI godot_rect2i_grow(const godot_rect2i *p_self, const godot_int
 
 godot_rect2i GDAPI godot_rect2i_grow_individual(const godot_rect2i *p_self, const godot_int p_left, const godot_int p_top, const godot_int p_right, const godot_int p_bottom);
 
-godot_rect2i GDAPI godot_rect2i_grow_margin(const godot_rect2i *p_self, const godot_int p_margin, const godot_int p_by);
+godot_rect2i GDAPI godot_rect2i_grow_side(const godot_rect2i *p_self, const godot_int p_margin, const godot_int p_by);
 
 godot_rect2i GDAPI godot_rect2i_abs(const godot_rect2i *p_self);
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -52,7 +52,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// The area of this rect.
+        /// The area of this Rect2.
         /// </summary>
         /// <value>Equivalent to <see cref="GetArea()"/>.</value>
         public real_t Area
@@ -64,7 +64,7 @@ namespace Godot
         /// Returns a Rect2 with equivalent position and size, modified so that
         /// the top-left corner is the origin and width and height are positive.
         /// </summary>
-        /// <returns>The modified rect.</returns>
+        /// <returns>The modified Rect2.</returns>
         public Rect2 Abs()
         {
             Vector2 end = End;
@@ -76,8 +76,8 @@ namespace Godot
         /// Returns the intersection of this Rect2 and `b`.
         /// If the rectangles do not intersect, an empty Rect2 is returned.
         /// </summary>
-        /// <param name="b">The other rect.</param>
-        /// <returns>The intersection of this Rect2 and `b`, or an empty rect if they do not intersect.</returns>
+        /// <param name="b">The other Rect2.</param>
+        /// <returns>The intersection of this Rect2 and `b`, or an empty Rect2 if they do not intersect.</returns>
         public Rect2 Intersection(Rect2 b)
         {
             var newRect = b;
@@ -102,8 +102,8 @@ namespace Godot
         /// <summary>
         /// Returns true if this Rect2 completely encloses another one.
         /// </summary>
-        /// <param name="b">The other rect that may be enclosed.</param>
-        /// <returns>A bool for whether or not this rect encloses `b`.</returns>
+        /// <param name="b">The other Rect2 that may be enclosed.</param>
+        /// <returns>A bool for whether or not this Rect2 encloses `b`.</returns>
         public bool Encloses(Rect2 b)
         {
             return b._position.x >= _position.x && b._position.y >= _position.y &&
@@ -115,7 +115,7 @@ namespace Godot
         /// Returns this Rect2 expanded to include a given point.
         /// </summary>
         /// <param name="to">The point to include.</param>
-        /// <returns>The expanded rect.</returns>
+        /// <returns>The expanded Rect2.</returns>
         public Rect2 Expand(Vector2 to)
         {
             var expanded = this;
@@ -157,10 +157,10 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns a copy of the Rect2 grown a given amount of units towards all the sides.
+        /// Returns a copy of the Rect2 grown by the specified amount on all sides.
         /// </summary>
         /// <param name="by">The amount to grow by.</param>
-        /// <returns>The grown rect.</returns>
+        /// <returns>The grown Rect2.</returns>
         public Rect2 Grow(real_t by)
         {
             var g = this;
@@ -174,13 +174,13 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns a copy of the Rect2 grown a given amount of units towards each direction individually.
+        /// Returns a copy of the Rect2 grown by the specified amount on each side individually.
         /// </summary>
-        /// <param name="left">The amount to grow by on the left.</param>
-        /// <param name="top">The amount to grow by on the top.</param>
-        /// <param name="right">The amount to grow by on the right.</param>
-        /// <param name="bottom">The amount to grow by on the bottom.</param>
-        /// <returns>The grown rect.</returns>
+        /// <param name="left">The amount to grow by on the left side.</param>
+        /// <param name="top">The amount to grow by on the top side.</param>
+        /// <param name="right">The amount to grow by on the right side.</param>
+        /// <param name="bottom">The amount to grow by on the bottom side.</param>
+        /// <returns>The grown Rect2.</returns>
         public Rect2 GrowIndividual(real_t left, real_t top, real_t right, real_t bottom)
         {
             var g = this;
@@ -194,19 +194,19 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns a copy of the Rect2 grown a given amount of units towards the <see cref="Margin"/> direction.
+        /// Returns a copy of the Rect2 grown by the specified amount on the specified Side.
         /// </summary>
-        /// <param name="margin">The direction to grow in.</param>
+        /// <param name="side">The side to grow.</param>
         /// <param name="by">The amount to grow by.</param>
-        /// <returns>The grown rect.</returns>
-        public Rect2 GrowMargin(Margin margin, real_t by)
+        /// <returns>The grown Rect2.</returns>
+        public Rect2 GrowSide(Side side, real_t by)
         {
             var g = this;
 
-            g = g.GrowIndividual(Margin.Left == margin ? by : 0,
-                    Margin.Top == margin ? by : 0,
-                    Margin.Right == margin ? by : 0,
-                    Margin.Bottom == margin ? by : 0);
+            g = g.GrowIndividual(Side.Left == side ? by : 0,
+                    Side.Top == side ? by : 0,
+                    Side.Right == side ? by : 0,
+                    Side.Bottom == side ? by : 0);
 
             return g;
         }
@@ -214,7 +214,7 @@ namespace Godot
         /// <summary>
         /// Returns true if the Rect2 is flat or empty, or false otherwise.
         /// </summary>
-        /// <returns>A bool for whether or not the rect has area.</returns>
+        /// <returns>A bool for whether or not the Rect2 has area.</returns>
         public bool HasNoArea()
         {
             return _size.x <= 0 || _size.y <= 0;
@@ -224,7 +224,7 @@ namespace Godot
         /// Returns true if the Rect2 contains a point, or false otherwise.
         /// </summary>
         /// <param name="point">The point to check.</param>
-        /// <returns>A bool for whether or not the rect contains `point`.</returns>
+        /// <returns>A bool for whether or not the Rect2 contains `point`.</returns>
         public bool HasPoint(Vector2 point)
         {
             if (point.x < _position.x)
@@ -247,7 +247,7 @@ namespace Godot
         /// If `includeBorders` is true, they will also be considered overlapping
         /// if their borders touch, even without intersection.
         /// </summary>
-        /// <param name="b">The other rect to check for intersections with.</param>
+        /// <param name="b">The other Rect2 to check for intersections with.</param>
         /// <param name="includeBorders">Whether or not to consider borders.</param>
         /// <returns>A bool for whether or not they are intersecting.</returns>
         public bool Intersects(Rect2 b, bool includeBorders = false)
@@ -297,8 +297,8 @@ namespace Godot
         /// <summary>
         /// Returns a larger Rect2 that contains this Rect2 and `b`.
         /// </summary>
-        /// <param name="b">The other rect.</param>
-        /// <returns>The merged rect.</returns>
+        /// <param name="b">The other Rect2.</param>
+        /// <returns>The merged Rect2.</returns>
         public Rect2 Merge(Rect2 b)
         {
             Rect2 newRect;
@@ -388,11 +388,11 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns true if this rect and `other` are approximately equal, by running
+        /// Returns true if this Rect2 and `other` are approximately equal, by running
         /// <see cref="Vector2.IsEqualApprox(Vector2)"/> on each component.
         /// </summary>
-        /// <param name="other">The other rect to compare.</param>
-        /// <returns>Whether or not the rects are approximately equal.</returns>
+        /// <param name="other">The other Rect2 to compare.</param>
+        /// <returns>Whether or not the Rect2s are approximately equal.</returns>
         public bool IsEqualApprox(Rect2 other)
         {
             return _position.IsEqualApprox(other._position) && _size.IsEqualApprox(other.Size);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -47,7 +47,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// The area of this rect.
+        /// The area of this Rect2i.
         /// </summary>
         /// <value>Equivalent to <see cref="GetArea()"/>.</value>
         public int Area
@@ -59,7 +59,7 @@ namespace Godot
         /// Returns a Rect2i with equivalent position and size, modified so that
         /// the top-left corner is the origin and width and height are positive.
         /// </summary>
-        /// <returns>The modified rect.</returns>
+        /// <returns>The modified Rect2i.</returns>
         public Rect2i Abs()
         {
             Vector2i end = End;
@@ -71,8 +71,8 @@ namespace Godot
         /// Returns the intersection of this Rect2i and `b`.
         /// If the rectangles do not intersect, an empty Rect2i is returned.
         /// </summary>
-        /// <param name="b">The other rect.</param>
-        /// <returns>The intersection of this Rect2i and `b`, or an empty rect if they do not intersect.</returns>
+        /// <param name="b">The other Rect2i.</param>
+        /// <returns>The intersection of this Rect2i and `b`, or an empty Rect2i if they do not intersect.</returns>
         public Rect2i Intersection(Rect2i b)
         {
             var newRect = b;
@@ -97,8 +97,8 @@ namespace Godot
         /// <summary>
         /// Returns true if this Rect2i completely encloses another one.
         /// </summary>
-        /// <param name="b">The other rect that may be enclosed.</param>
-        /// <returns>A bool for whether or not this rect encloses `b`.</returns>
+        /// <param name="b">The other Rect2i that may be enclosed.</param>
+        /// <returns>A bool for whether or not this Rect2i encloses `b`.</returns>
         public bool Encloses(Rect2i b)
         {
             return b._position.x >= _position.x && b._position.y >= _position.y &&
@@ -110,7 +110,7 @@ namespace Godot
         /// Returns this Rect2i expanded to include a given point.
         /// </summary>
         /// <param name="to">The point to include.</param>
-        /// <returns>The expanded rect.</returns>
+        /// <returns>The expanded Rect2i.</returns>
         public Rect2i Expand(Vector2i to)
         {
             var expanded = this;
@@ -152,10 +152,10 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns a copy of the Rect2i grown a given amount of units towards all the sides.
+        /// Returns a copy of the Rect2i grown by the specified amount on all sides.
         /// </summary>
         /// <param name="by">The amount to grow by.</param>
-        /// <returns>The grown rect.</returns>
+        /// <returns>The grown Rect2i.</returns>
         public Rect2i Grow(int by)
         {
             var g = this;
@@ -169,13 +169,13 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns a copy of the Rect2i grown a given amount of units towards each direction individually.
+        /// Returns a copy of the Rect2i grown by the specified amount on each side individually.
         /// </summary>
-        /// <param name="left">The amount to grow by on the left.</param>
-        /// <param name="top">The amount to grow by on the top.</param>
-        /// <param name="right">The amount to grow by on the right.</param>
-        /// <param name="bottom">The amount to grow by on the bottom.</param>
-        /// <returns>The grown rect.</returns>
+        /// <param name="left">The amount to grow by on the left side.</param>
+        /// <param name="top">The amount to grow by on the top side.</param>
+        /// <param name="right">The amount to grow by on the right side.</param>
+        /// <param name="bottom">The amount to grow by on the bottom side.</param>
+        /// <returns>The grown Rect2i.</returns>
         public Rect2i GrowIndividual(int left, int top, int right, int bottom)
         {
             var g = this;
@@ -189,37 +189,37 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns a copy of the Rect2i grown a given amount of units towards the <see cref="Margin"/> direction.
+        /// Returns a copy of the Rect2i grown by the specified amount on the specified Side.
         /// </summary>
-        /// <param name="margin">The direction to grow in.</param>
+        /// <param name="side">The side to grow.</param>
         /// <param name="by">The amount to grow by.</param>
-        /// <returns>The grown rect.</returns>
-        public Rect2i GrowMargin(Margin margin, int by)
+        /// <returns>The grown Rect2i.</returns>
+        public Rect2i GrowSide(Side side, int by)
         {
             var g = this;
 
-            g = g.GrowIndividual(Margin.Left == margin ? by : 0,
-                    Margin.Top == margin ? by : 0,
-                    Margin.Right == margin ? by : 0,
-                    Margin.Bottom == margin ? by : 0);
+            g = g.GrowIndividual(Side.Left == side ? by : 0,
+                    Side.Top == side ? by : 0,
+                    Side.Right == side ? by : 0,
+                    Side.Bottom == side ? by : 0);
 
             return g;
         }
 
         /// <summary>
-        /// Returns true if the Rect2 is flat or empty, or false otherwise.
+        /// Returns true if the Rect2i is flat or empty, or false otherwise.
         /// </summary>
-        /// <returns>A bool for whether or not the rect has area.</returns>
+        /// <returns>A bool for whether or not the Rect2i has area.</returns>
         public bool HasNoArea()
         {
             return _size.x <= 0 || _size.y <= 0;
         }
 
         /// <summary>
-        /// Returns true if the Rect2 contains a point, or false otherwise.
+        /// Returns true if the Rect2i contains a point, or false otherwise.
         /// </summary>
         /// <param name="point">The point to check.</param>
-        /// <returns>A bool for whether or not the rect contains `point`.</returns>
+        /// <returns>A bool for whether or not the Rect2i contains `point`.</returns>
         public bool HasPoint(Vector2i point)
         {
             if (point.x < _position.x)
@@ -242,7 +242,7 @@ namespace Godot
         /// If `includeBorders` is true, they will also be considered overlapping
         /// if their borders touch, even without intersection.
         /// </summary>
-        /// <param name="b">The other rect to check for intersections with.</param>
+        /// <param name="b">The other Rect2i to check for intersections with.</param>
         /// <param name="includeBorders">Whether or not to consider borders.</param>
         /// <returns>A bool for whether or not they are intersecting.</returns>
         public bool Intersects(Rect2i b, bool includeBorders = false)
@@ -274,10 +274,10 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns a larger Rect2i that contains this Rect2 and `b`.
+        /// Returns a larger Rect2i that contains this Rect2i and `b`.
         /// </summary>
-        /// <param name="b">The other rect.</param>
-        /// <returns>The merged rect.</returns>
+        /// <param name="b">The other Rect2i.</param>
+        /// <returns>The merged Rect2i.</returns>
         public Rect2i Merge(Rect2i b)
         {
             Rect2i newRect;

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -687,7 +687,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	if (aa_on) {
 		for (int i = 0; i < 4; i++) {
 			if (border_width[i] > 0) {
-				border_style_rect = border_style_rect.grow_margin((Side)i, -aa_size_grow);
+				border_style_rect = border_style_rect.grow_side((Side)i, -aa_size_grow);
 			}
 		}
 	}

--- a/tests/test_rect2.h
+++ b/tests/test_rect2.h
@@ -197,11 +197,11 @@ TEST_CASE("[Rect2] Growing") {
 			"grow_individual() with positive and negative values should return the expected Rect2.");
 
 	CHECK_MESSAGE(
-			Rect2(0, 100, 1280, 720).grow_margin(SIDE_TOP, 500).is_equal_approx(Rect2(0, -400, 1280, 1220)),
-			"grow_margin() with positive value should return the expected Rect2.");
+			Rect2(0, 100, 1280, 720).grow_side(SIDE_TOP, 500).is_equal_approx(Rect2(0, -400, 1280, 1220)),
+			"grow_side() with positive value should return the expected Rect2.");
 	CHECK_MESSAGE(
-			Rect2(0, 100, 1280, 720).grow_margin(SIDE_TOP, -500).is_equal_approx(Rect2(0, 600, 1280, 220)),
-			"grow_margin() with negative value should return the expected Rect2.");
+			Rect2(0, 100, 1280, 720).grow_side(SIDE_TOP, -500).is_equal_approx(Rect2(0, 600, 1280, 220)),
+			"grow_side() with negative value should return the expected Rect2.");
 }
 
 TEST_CASE("[Rect2] Has point") {
@@ -409,11 +409,11 @@ TEST_CASE("[Rect2i] Growing") {
 			"grow_individual() with positive and negative values should return the expected Rect2i.");
 
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 1280, 720).grow_margin(SIDE_TOP, 500) == Rect2i(0, -400, 1280, 1220),
-			"grow_margin() with positive value should return the expected Rect2i.");
+			Rect2i(0, 100, 1280, 720).grow_side(SIDE_TOP, 500) == Rect2i(0, -400, 1280, 1220),
+			"grow_side() with positive value should return the expected Rect2i.");
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 1280, 720).grow_margin(SIDE_TOP, -500) == Rect2i(0, 600, 1280, 220),
-			"grow_margin() with negative value should return the expected Rect2i.");
+			Rect2i(0, 100, 1280, 720).grow_side(SIDE_TOP, -500) == Rect2i(0, 600, 1280, 220),
+			"grow_side() with negative value should return the expected Rect2i.");
 }
 
 TEST_CASE("[Rect2i] Has point") {


### PR DESCRIPTION
As suggested [here](https://github.com/godotengine/godot/pull/44605#issuecomment-751610149), renames `Rect2` and `Rect2i` `grow_margin()` to `grow_side()`.

Note: Includes updates to the documentation and the Mono module following #44605. Let me know if you want me to split it into separate commits.

*Bugsquad edit:* Supersedes #44743