### PR TITLE
Fix Scrollbar range calculation error

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1052,8 +1052,6 @@ void Polygon2DEditor::_uv_draw() {
 		if (i < uv_draw_max /*&& polygons.size() == 0 &&  polygon_create.size() == 0*/) { //if using or creating polygons, do not show outline (will show polygons instead)
 			uv_edit_draw->draw_line(mtx.xform(uvs[i]), mtx.xform(next_point), poly_line_color, Math::round(EDSCALE));
 		}
-
-		rect.expand_to(mtx.basis_xform(uvs[i]));
 	}
 
 	for (int i = 0; i < polygons.size(); i++) {
@@ -1160,8 +1158,8 @@ void Polygon2DEditor::_uv_draw() {
 		uv_edit_draw->draw_circle(bone_paint_pos, bone_paint_radius->get_value() * EDSCALE, Color(1, 1, 1, 0.1));
 	}
 
-	rect.position -= uv_edit_draw->get_size();
-	rect.size += uv_edit_draw->get_size() * 2.0;
+	rect.position = -uv_edit_draw->get_size();
+	rect.size = uv_edit_draw->get_size() * 2.0 + base_tex->get_size() * uv_draw_zoom;
 
 	updating_uv_scroll = true;
 


### PR DESCRIPTION
When zoomed in, the right and bottom edges of the resource image will be outside the viewing area.

This is the original look, but the scrollbar has reached the end.
<img width="580" alt="normal" src="https://user-images.githubusercontent.com/47357234/103214439-61602d80-494b-11eb-82a5-c933169fd8ac.png">

When I zoomed in, the lower edge of the picture was out of view.
<img width="615" alt="old" src="https://user-images.githubusercontent.com/47357234/103214663-024ee880-494c-11eb-9e7d-51208ff9508c.png">

After fixing the problem.
<img width="614" alt="new" src="https://user-images.githubusercontent.com/47357234/103214658-ffec8e80-494b-11eb-8a2a-cf8538ecbbc7.png">

Fixes #44592

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
