### PR TITLE
Add test CI stage to find crashes and memory leaks automatically

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -94,7 +94,8 @@ jobs:
       - name: Configure dependencies
         run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm \
+            xvfb wget2 unzip
 
       # Upload cache on completion and check it out now
       - name: Load .scons_cache directory
@@ -137,6 +138,22 @@ jobs:
       - name: Unit Tests
         run: |
           ./bin/godot.linuxbsd.tools.64s --test
+
+      # Download and test project to check leaks and invalid memory usage.
+      # CI has no audio device, so use the Dummy audio driver to avoid spurious error messages.
+      - name: Importing and running project
+        run: |
+          wget2 https://github.com/qarmin/RegressionTestProject/archive/4.0.zip
+          unzip 4.0.zip
+          mv "RegressionTestProject-4.0" "test_project"
+
+          echo "----- Just open and close editor to see if there are any crashes or memory leaks -----"
+          DRI_PRIME=0 xvfb-run bin/godot.linuxbsd.tools.64s --rendering-driver GLES2 --audio-driver Dummy -e -q --path test_project 2>&1 | tee sanitizers_log.txt || true
+          misc/scripts/check_ci_log.py sanitizers_log.txt
+
+          echo "----- Run and test project -----"
+          DRI_PRIME=0 xvfb-run bin/godot.linuxbsd.tools.64s 30 --rendering-driver GLES2 --audio-driver Dummy --path test_project 2>&1 | tee sanitizers_log.txt || true
+          misc/scripts/check_ci_log.py sanitizers_log.txt
 
   linux-template-mono:
     runs-on: "ubuntu-20.04"

--- a/misc/scripts/check_ci_log.py
+++ b/misc/scripts/check_ci_log.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+
+if len(sys.argv) < 2:
+    print("ERROR: You must run program with file name as argument.")
+    sys.exit(1)
+
+fname = sys.argv[1]
+
+fileread = open(fname.strip(), "r")
+file_contents = fileread.read()
+
+# If find "ERROR: AddressSanitizer:", then happens invalid read or write
+# This is critical bug, so we need to fix this as fast as possible
+
+if file_contents.find("ERROR: AddressSanitizer:") != -1:
+    print("FATAL ERROR: An incorrectly used memory was found.")
+    sys.exit(1)
+
+# There is also possible, that program crashed with or without backtrace.
+
+if (
+    file_contents.find("Program crashed with signal") != -1
+    or file_contents.find("Dumping the backtrace") != -1
+    or file_contents.find("Segmentation fault (core dumped)") != -1
+):
+    print("FATAL ERROR: Godot has been crashed.")
+    sys.exit(1)
+
+# Undefined behaviour in C/C++ should be eliminated, but because of the
+# low harm in Godot, it is not worth interrupting the CI.
+
+if file_contents.find("runtime error:") != -1:
+    print("WARNING: Undefined behaviour was found, check CI log for more info")
+
+sys.exit(0)  # TODO - Leak check can be enabled when memory leaks will be fixed
+
+# Finding memory leaks in Godot is quite difficult, because we need to take into
+# account leaks also in external libraries. They are usually provided without
+# debugging symbols, so the leak report from it usually has only 2/3 lines,
+# so searching for 5 element - "#4 0x" - should correctly detect the vast
+# majority of memory leaks
+
+if file_contents.find("ERROR: LeakSanitizer:") != -1:
+    if file_contents.find("#4 0x") != -1:
+        print("ERROR: Memory leak was found")
+        sys.exit(1)
+
+# It may happen that Godot detects leaking nodes/resources and removes them, so
+# this possibility should also be handled as a potential error, even if
+# LeakSanitizer doesn't report anything
+
+if file_contents.find("ObjectDB instances leaked at exit") != -1 or file_contents.find("were leaked."):
+    print("ERROR: Memory leak was found")
+    sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
This PR adds simple opening and checking of editor and project as CI stage.
This will allow to find PR which will cause crashes or memory leaks, before merging them to main repository. 

This fixes https://github.com/godotengine/godot-proposals/issues/1358

It depends on https://github.com/godotengine/godot/pull/44399 because uses GLES 2. 

Test project is https://github.com/qarmin/RegressionTestProject which contains its own CI to be sure that project update will not introduce unexpected errors.

There are a few changes when comparing this PR with  https://github.com/godotengine/godot/pull/40994(for 3.2 branch)
- There is only 1 step with opening editor - Git repository of test project now contains `./godot` folder with imported earlier resources
- Project running time is 30s instead 25s because editor opens a lot slower due compiling shaders
- For now checking for memory leaks is disabled, because for now there is a lot of memory leaks in GLES 2 backed

Example CI log - https://github.com/qarmin/RegressionTestProject/runs/1620701731