### PR TITLE
Editor: Fix invalid use of Node::get_viewport() after rename of EditorNode::get_viewport()

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1492,7 +1492,7 @@ AssetLibraryEditorPlugin::AssetLibraryEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	addon_library = memnew(EditorAssetLibrary);
 	addon_library->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_viewport()->add_child(addon_library);
+	editor->get_main_control()->add_child(addon_library);
 	addon_library->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	addon_library->hide();
 }

--- a/editor/plugins/camera_3d_editor_plugin.cpp
+++ b/editor/plugins/camera_3d_editor_plugin.cpp
@@ -98,7 +98,7 @@ void Camera3DEditorPlugin::make_visible(bool p_visible) {
 Camera3DEditorPlugin::Camera3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	/*	camera_editor = memnew( CameraEditor );
-	editor->get_viewport()->add_child(camera_editor);
+	editor->get_main_control()->add_child(camera_editor);
 
 	camera_editor->set_anchor(SIDE_LEFT,Control::ANCHOR_END);
 	camera_editor->set_anchor(SIDE_RIGHT,Control::ANCHOR_END);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6139,7 +6139,7 @@ CanvasItemEditorPlugin::CanvasItemEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	canvas_item_editor = memnew(CanvasItemEditor(editor));
 	canvas_item_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_viewport()->add_child(canvas_item_editor);
+	editor->get_main_control()->add_child(canvas_item_editor);
 	canvas_item_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	canvas_item_editor->hide();
 }

--- a/editor/plugins/cpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.cpp
@@ -122,7 +122,7 @@ void CPUParticles3DEditorPlugin::make_visible(bool p_visible) {
 CPUParticles3DEditorPlugin::CPUParticles3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	particles_editor = memnew(CPUParticles3DEditor);
-	editor->get_viewport()->add_child(particles_editor);
+	editor->get_main_control()->add_child(particles_editor);
 
 	particles_editor->hide();
 }

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -454,7 +454,7 @@ void GPUParticles3DEditorPlugin::make_visible(bool p_visible) {
 GPUParticles3DEditorPlugin::GPUParticles3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	particles_editor = memnew(GPUParticles3DEditor);
-	editor->get_viewport()->add_child(particles_editor);
+	editor->get_main_control()->add_child(particles_editor);
 
 	particles_editor->hide();
 }

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -505,7 +505,7 @@ void MeshInstance3DEditorPlugin::make_visible(bool p_visible) {
 MeshInstance3DEditorPlugin::MeshInstance3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	mesh_editor = memnew(MeshInstance3DEditor);
-	editor->get_viewport()->add_child(mesh_editor);
+	editor->get_main_control()->add_child(mesh_editor);
 
 	mesh_editor->options->hide();
 }

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -297,7 +297,7 @@ MeshLibraryEditorPlugin::MeshLibraryEditorPlugin(EditorNode *p_node) {
 	EDITOR_DEF("editors/grid_map/preview_size", 64);
 	mesh_library_editor = memnew(MeshLibraryEditor(p_node));
 
-	p_node->get_viewport()->add_child(mesh_library_editor);
+	p_node->get_main_control()->add_child(mesh_library_editor);
 	mesh_library_editor->set_anchors_and_offsets_preset(Control::PRESET_TOP_WIDE);
 	mesh_library_editor->set_end(Point2(0, 22));
 	mesh_library_editor->hide();

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -378,7 +378,7 @@ void MultiMeshEditorPlugin::make_visible(bool p_visible) {
 MultiMeshEditorPlugin::MultiMeshEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	multimesh_editor = memnew(MultiMeshEditor);
-	editor->get_viewport()->add_child(multimesh_editor);
+	editor->get_main_control()->add_child(multimesh_editor);
 
 	multimesh_editor->options->hide();
 }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6699,7 +6699,7 @@ Node3DEditorPlugin::Node3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	spatial_editor = memnew(Node3DEditor(p_node));
 	spatial_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_viewport()->add_child(spatial_editor);
+	editor->get_main_control()->add_child(spatial_editor);
 
 	spatial_editor->hide();
 	spatial_editor->connect("transform_key_request", Callable(editor->get_inspector_dock(), "_transform_keyed"));

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -609,7 +609,7 @@ Path3DEditorPlugin::Path3DEditorPlugin(EditorNode *p_node) {
 	curve_edit->set_pressed(true);
 	/*
     collision_polygon_editor = memnew( PathEditor(p_node) );
-    editor->get_viewport()->add_child(collision_polygon_editor);
+    editor->get_main_control()->add_child(collision_polygon_editor);
     collision_polygon_editor->set_margin(MARGIN_LEFT,200);
     collision_polygon_editor->set_margin(MARGIN_RIGHT,230);
     collision_polygon_editor->set_margin(MARGIN_TOP,0);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3646,7 +3646,7 @@ void ScriptEditorPlugin::edited_scene_changed() {
 ScriptEditorPlugin::ScriptEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	script_editor = memnew(ScriptEditor(p_node));
-	editor->get_viewport()->add_child(script_editor);
+	editor->get_main_control()->add_child(script_editor);
 	script_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	script_editor->hide();

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -129,7 +129,7 @@ void Skeleton2DEditorPlugin::make_visible(bool p_visible) {
 Skeleton2DEditorPlugin::Skeleton2DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	sprite_editor = memnew(Skeleton2DEditor);
-	editor->get_viewport()->add_child(sprite_editor);
+	editor->get_main_control()->add_child(sprite_editor);
 	make_visible(false);
 
 	//sprite_editor->options->hide();

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -583,7 +583,7 @@ void Sprite2DEditorPlugin::make_visible(bool p_visible) {
 Sprite2DEditorPlugin::Sprite2DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	sprite_editor = memnew(Sprite2DEditor);
-	editor->get_viewport()->add_child(sprite_editor);
+	editor->get_main_control()->add_child(sprite_editor);
 	make_visible(false);
 
 	//sprite_editor->options->hide();

--- a/modules/gdnavigation/navigation_mesh_editor_plugin.cpp
+++ b/modules/gdnavigation/navigation_mesh_editor_plugin.cpp
@@ -142,7 +142,7 @@ void NavigationMeshEditorPlugin::make_visible(bool p_visible) {
 NavigationMeshEditorPlugin::NavigationMeshEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	navigation_mesh_editor = memnew(NavigationMeshEditor);
-	editor->get_viewport()->add_child(navigation_mesh_editor);
+	editor->get_main_control()->add_child(navigation_mesh_editor);
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, navigation_mesh_editor->bake_hbox);
 	navigation_mesh_editor->hide();
 	navigation_mesh_editor->bake_hbox->hide();


### PR DESCRIPTION
Fixes #44761, was a regression from #44524.

The PR passed CI because EditorNode::get_viewport() used to shadow Node::get_viewport()
(which was a bug in itself, fixed by #44524), so once it was renamed the existing code
relying on it fell back to the now available Node::get_viewport().

:warning: This might bite some thirdparty modules too.