### PR TITLE
Add `OS.get_hostname()` method to get the machine's hostname

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -315,6 +315,10 @@ String OS::get_model_name() const {
 	return ::OS::get_singleton()->get_model_name();
 }
 
+String OS::get_hostname() const {
+	return ::OS::get_singleton()->get_hostname();
+}
+
 Error OS::set_thread_name(const String &p_name) {
 	return ::Thread::set_name(p_name);
 }
@@ -590,6 +594,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_locale"), &OS::get_locale);
 	ClassDB::bind_method(D_METHOD("get_locale_language"), &OS::get_locale_language);
 	ClassDB::bind_method(D_METHOD("get_model_name"), &OS::get_model_name);
+	ClassDB::bind_method(D_METHOD("get_hostname"), &OS::get_hostname);
 
 	ClassDB::bind_method(D_METHOD("is_userfs_persistent"), &OS::is_userfs_persistent);
 	ClassDB::bind_method(D_METHOD("is_stdout_verbose"), &OS::is_stdout_verbose);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -187,6 +187,7 @@ public:
 	String get_locale_language() const;
 
 	String get_model_name() const;
+	String get_hostname() const;
 
 	void dump_memory_to_file(const String &p_file);
 	void dump_resources_to_file(const String &p_file);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -37,7 +37,13 @@
 #include "core/os/midi_driver.h"
 #include "core/version_generated.gen.h"
 
+#include <limits.h>
 #include <stdarg.h>
+#ifdef WINDOWS_ENABLED
+#include <winsock.h>
+#else
+#include <unistd.h>
+#endif
 
 OS *OS::singleton = nullptr;
 uint64_t OS::target_ticks = 0;
@@ -345,6 +351,20 @@ void OS::ensure_user_data_dir() {
 
 String OS::get_model_name() const {
 	return "GenericDevice";
+}
+
+String OS::get_hostname() const {
+#if defined(OSX_ENABLED) || defined(IPHONE_ENABLED)
+#define HOST_NAME_MAX sysconf(_SC_HOST_NAME_MAX)
+#else if defined(WINDOWS_ENABLED)
+#define HOST_NAME_MAX 256
+#endif
+	char hostname[HOST_NAME_MAX + 1];
+	// Handle maximum-length hostname correctly.
+	hostname[HOST_NAME_MAX] = 0;
+	gethostname(hostname, HOST_NAME_MAX);
+
+	return String(hostname);
 }
 
 void OS::set_cmdline(const char *p_execpath, const List<String> &p_args) {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -159,6 +159,7 @@ public:
 	virtual String get_name() const = 0;
 	virtual List<String> get_cmdline_args() const { return _cmdline; }
 	virtual String get_model_name() const;
+	virtual String get_hostname() const;
 
 	bool is_layered_allowed() const { return _allow_layered; }
 	bool is_hidpi_allowed() const { return _allow_hidpi; }


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-proposals/issues/2027.

## TODO

- [x] Test on Linux.
- [ ] Test on Windows.
- [ ] Test on macOS.

Testing is welcome :slightly_smiling_face:
You can use the builds on the [Checks](https://github.com/godotengine/godot/pull/44783/checks) tab for testing.

## Test script

```gdscript
func _ready():
	print(OS.get_hostname())
````