### PR TITLE
Fix missing empty() to is_empty() renames in #43691.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2359,7 +2359,7 @@ bool RichTextLabel::remove_line(const int p_line) {
 
 void RichTextLabel::push_dropcap(const String &p_string, const Ref<Font> &p_font, int p_size, const Rect2 &p_dropcap_margins, const Color &p_color, int p_ol_size, const Color &p_ol_color) {
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
-	ERR_FAIL_COND(p_string.empty());
+	ERR_FAIL_COND(p_string.is_empty());
 	ERR_FAIL_COND(p_font.is_null());
 	ERR_FAIL_COND(p_size <= 0);
 

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -147,7 +147,7 @@ void TextParagraph::_shape_lines() {
 					TS->free(line);
 					break;
 				}
-				if (!tab_stops.empty()) {
+				if (!tab_stops.is_empty()) {
 					TS->shaped_text_tab_align(line, tab_stops);
 				}
 				if (align == HALIGN_FILL && (line_breaks.size() == 1 || i < line_breaks.size() - 1)) {


### PR DESCRIPTION
Fixes broken CI after merging #43691.
