### PR TITLE
Fix instantiation of resource as property value

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2546,10 +2546,12 @@ void EditorPropertyResource::_menu_option(int p_which) {
 			}
 
 			Object *obj = nullptr;
+			RES res_temp;
 
 			if (ScriptServer::is_global_class(intype)) {
 				obj = ClassDB::instance(ScriptServer::get_global_class_native_base(intype));
 				if (obj) {
+					res_temp = obj;
 					Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(intype));
 					if (script.is_valid()) {
 						obj->set_script(Variant(script));
@@ -2557,21 +2559,21 @@ void EditorPropertyResource::_menu_option(int p_which) {
 				}
 			} else {
 				obj = ClassDB::instance(intype);
+				res_temp = obj;
 			}
 
 			if (!obj) {
 				obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+				res_temp = obj;
 			}
 
-			ERR_BREAK(!obj);
-			Resource *resp = Object::cast_to<Resource>(obj);
-			ERR_BREAK(!resp);
+			ERR_BREAK(!res_temp.is_valid());
 			if (get_edited_object() && base_type != String() && base_type == "Script") {
 				//make visual script the right type
-				resp->call("set_instance_base_type", get_edited_object()->get_class());
+				res_temp->call("set_instance_base_type", get_edited_object()->get_class());
 			}
 
-			res = Ref<Resource>(resp);
+			res = res_temp;
 			emit_changed(get_edited_property(), res);
 			update_property();
 


### PR DESCRIPTION
This fixes the case where you instantiate an scripted resource type directly as a property value. (It's another side effect of the new behavior of `Variant` regarding `Reference`, which makes calling script on an unreferenced `Reference` illegal.)