### PR TITLE
Expose ScriptServer & add all script class support.

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -39,6 +39,7 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
+#include "core/script_language.h"
 
 /**
  *  Time constants borrowed from loc_time.h
@@ -3074,6 +3075,112 @@ _ClassDB::_ClassDB() {
 }
 _ClassDB::~_ClassDB() {
 }
+///////////////////////////////
+
+bool _ScriptServer::_set(const StringName &p_name, const Variant &p_value) {
+	return false;
+}
+
+bool _ScriptServer::_get(const StringName &p_name, Variant &r_ret) const {
+	if (ScriptServer::is_global_class(p_name)) {
+		r_ret = ResourceLoader::load(ScriptServer::get_global_class_path(p_name), "Script");
+		return true;
+	}
+	return false;
+}
+
+void _ScriptServer::_get_property_list(List<PropertyInfo> *p_list) const {
+	ERR_FAIL_COND(!p_list);
+	List<StringName> names;
+	ScriptServer::get_global_class_list(&names);
+	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		StringName n = E->get();
+		String class_name = String(n).get_file().get_extension();
+		p_list->push_back(PropertyInfo(Variant::OBJECT, class_name, PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_NETWORK, ResourceLoader::get_resource_type(ScriptServer::get_global_class_path(n))));
+	}
+}
+
+bool _ScriptServer::is_global_class(const StringName &p_class) const {
+	return ScriptServer::is_global_class(p_class);
+}
+
+String _ScriptServer::get_global_class_path(const String &p_class) const {
+	return ScriptServer::get_global_class_path(p_class);
+}
+
+StringName _ScriptServer::get_global_class_base(const String &p_class) const {
+	return ScriptServer::get_global_class_base(p_class);
+}
+
+StringName _ScriptServer::get_global_class_native_base(const String &p_class) const {
+	return ScriptServer::get_global_class_native_base(p_class);
+}
+
+StringName _ScriptServer::get_global_class_name(const String &p_path) const {
+	List<StringName> names;
+	ScriptServer::get_global_class_list(&names);
+	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		if (ScriptServer::get_global_class_path(E->get()) == p_path) {
+			return E->get();
+		}
+	}
+	return StringName();
+}
+
+Ref<Script> _ScriptServer::get_global_class_script(const StringName &p_class) const {
+	return ResourceLoader::load(ScriptServer::get_global_class_path(p_class), "Script");
+}
+
+Variant _ScriptServer::instantiate_global_class(const StringName &p_class) const {
+	return ScriptServer::instantiate_global_class(p_class);
+}
+
+Array _ScriptServer::get_global_class_list() const {
+	Array ret;
+	List<StringName> lst;
+	ScriptServer::get_global_class_list(&lst);
+	for (List<StringName>::Element *E = lst.front(); E; E = E->next()) {
+		ret.push_back(E->get());
+	}
+	return ret;
+}
+
+Dictionary _ScriptServer::get_global_class_map() const {
+	Dictionary ret;
+	List<StringName> lst;
+	ScriptServer::get_global_class_list(&lst);
+	for (List<StringName>::Element *E = lst.front(); E; E = E->next()) {
+		StringName n = E->get();
+		Dictionary d;
+		d["language"] = ScriptServer::get_global_class_language(n);
+		d["path"] = ScriptServer::get_global_class_path(n);
+		d["base"] = ScriptServer::get_global_class_base(n);
+		ret[n] = d;
+	}
+	return ret;
+}
+
+void _ScriptServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_global_class", "class"), &_ScriptServer::is_global_class);
+	ClassDB::bind_method(D_METHOD("get_global_class_path", "class"), &_ScriptServer::get_global_class_path);
+	ClassDB::bind_method(D_METHOD("get_global_class_base", "class"), &_ScriptServer::get_global_class_base);
+	ClassDB::bind_method(D_METHOD("get_global_class_native_base", "class"), &_ScriptServer::get_global_class_native_base);
+	ClassDB::bind_method(D_METHOD("get_global_class_name", "path"), &_ScriptServer::get_global_class_name);
+	ClassDB::bind_method(D_METHOD("get_global_class_script", "class"), &_ScriptServer::get_global_class_script);
+	ClassDB::bind_method(D_METHOD("instantiate_global_class", "class"), &_ScriptServer::instantiate_global_class);
+	ClassDB::bind_method(D_METHOD("get_global_class_list"), &_ScriptServer::get_global_class_list);
+	ClassDB::bind_method(D_METHOD("get_global_class_map"), &_ScriptServer::get_global_class_map);
+}
+
+_ScriptServer::_ScriptServer() {
+	singleton = this;
+}
+
+_ScriptServer::~_ScriptServer() {
+}
+
+_ScriptServer *_ScriptServer::singleton = NULL;
+
 ///////////////////////////////
 
 void _Engine::set_iterations_per_second(int p_ips) {

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -751,6 +751,34 @@ public:
 	~_ClassDB();
 };
 
+class _ScriptServer : public Object {
+	GDCLASS(_ScriptServer, Object);
+
+protected:
+	static void _bind_methods();
+	static _ScriptServer *singleton;
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+public:
+	static _ScriptServer *get_singleton() { return singleton; }
+
+	bool is_global_class(const StringName &p_class) const;
+	String get_global_class_path(const String &p_class) const;
+	StringName get_global_class_base(const String &p_class) const;
+	StringName get_global_class_native_base(const String &p_class) const;
+	StringName get_global_class_name(const String &p_path) const;
+	Ref<Script> get_global_class_script(const StringName &p_class) const;
+	Variant instantiate_global_class(const StringName &p_class) const;
+	Array get_global_class_list() const;
+	Dictionary get_global_class_map() const;
+
+	_ScriptServer();
+	~_ScriptServer();
+};
+
 class _Engine : public Object {
 	GDCLASS(_Engine, Object);
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -67,6 +67,7 @@
 #include "core/packed_data_container.h"
 #include "core/path_remap.h"
 #include "core/project_settings.h"
+#include "core/script_language.h"
 #include "core/translation.h"
 #include "core/undo_redo.h"
 
@@ -85,6 +86,7 @@ static _Engine *_engine = NULL;
 static _ClassDB *_classdb = NULL;
 static _Marshalls *_marshalls = NULL;
 static _JSON *_json = NULL;
+static _ScriptServer *_script_server = NULL;
 
 static IP *ip = NULL;
 
@@ -225,6 +227,7 @@ void register_core_types() {
 	_classdb = memnew(_ClassDB);
 	_marshalls = memnew(_Marshalls);
 	_json = memnew(_JSON);
+	_script_server = memnew(_ScriptServer);
 }
 
 void register_core_settings() {
@@ -254,6 +257,7 @@ void register_core_singletons() {
 	ClassDB::register_class<InputMap>();
 	ClassDB::register_class<_JSON>();
 	ClassDB::register_class<Expression>();
+	ClassDB::register_class<_ScriptServer>();
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("IP", IP::get_singleton()));
@@ -268,6 +272,7 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", Input::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("JSON", _JSON::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ScriptServer", _ScriptServer::get_singleton()));
 }
 
 void unregister_core_types() {
@@ -279,6 +284,7 @@ void unregister_core_types() {
 	memdelete(_classdb);
 	memdelete(_marshalls);
 	memdelete(_json);
+	memdelete(_script_server);
 
 	memdelete(_geometry);
 

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -31,6 +31,7 @@
 #include "script_language.h"
 
 #include "core/core_string_names.h"
+#include "core/io/resource_loader.h"
 #include "core/project_settings.h"
 
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
@@ -251,6 +252,27 @@ StringName ScriptServer::get_global_class_native_base(const String &p_class) {
 		base = global_classes[base].base;
 	}
 	return base;
+}
+Variant ScriptServer::instantiate_global_class(const StringName &p_class) {
+	ERR_FAIL_COND_V_MSG(!global_classes.has(p_class), Variant(), "Class to instantiate '" + String(p_class) + "' is not a script class.");
+	String native = get_global_class_native_base(p_class);
+	Object *o = ClassDB::instance(native);
+	ERR_FAIL_COND_V_MSG(!o, Variant(), "Class type: '" + String(native) + "' is not instantiable.");
+
+	REF ref;
+	Reference *r = Object::cast_to<Reference>(o);
+	if (r) {
+		ref = REF(r);
+	}
+
+	Ref<Script> s = ResourceLoader::load(get_global_class_path(p_class), "Script");
+	o->set_script(s.get_ref_ptr());
+
+	if (ref.is_valid()) {
+		return ref;
+	} else {
+		return o;
+	}
 }
 void ScriptServer::get_global_class_list(List<StringName> *r_global_classes) {
 	const StringName *K = NULL;

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -84,6 +84,7 @@ public:
 	static String get_global_class_path(const String &p_class);
 	static StringName get_global_class_base(const String &p_class);
 	static StringName get_global_class_native_base(const String &p_class);
+	static Variant instantiate_global_class(const StringName &p_class);
 	static void get_global_class_list(List<StringName> *r_global_classes);
 	static void save_global_classes();
 
@@ -281,6 +282,7 @@ public:
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const = 0;
 	virtual Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) { return ERR_UNAVAILABLE; }
 	virtual bool overrides_external_editor() { return false; }
+	virtual bool has_delayed_script_class_metadata() const { return false; }
 
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptCodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) { return ERR_UNAVAILABLE; }
 

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -192,7 +192,11 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 		item->set_text(0, p_type);
 	} else {
 		item->set_metadata(0, p_type);
-		item->set_text(0, p_type + " (" + ScriptServer::get_global_class_path(p_type).get_file() + ")");
+		String text = p_type;
+		if (!EDITOR_GET("interface/editors/create_dialog_hide_script_class_filepath")) {
+			text += " (" + ScriptServer::get_global_class_path(p_type).get_file() + ")";
+		}
+		item->set_text(0, text);
 	}
 	if (!can_instance) {
 		item->set_custom_color(0, get_color("disabled_font_color", "Editor"));

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -899,10 +899,10 @@ StringName EditorData::script_class_get_base(const String &p_class) const {
 
 	Ref<Script> base_script = script->get_base_script();
 	if (base_script.is_null()) {
-		return ScriptServer::get_global_class_base(p_class);
+		return ScriptServer::get_global_class_native_base(p_class);
 	}
 
-	return script->get_language()->get_global_class_name(base_script->get_path());
+	return script_class_get_name(base_script->get_path());
 }
 
 Object *EditorData::script_class_instance(const String &p_class) {
@@ -927,15 +927,15 @@ Ref<Script> EditorData::script_class_load_script(const String &p_class) const {
 	return ResourceLoader::load(path, "Script");
 }
 
-void EditorData::script_class_set_icon_path(const String &p_class, const String &p_icon_path) {
+void EditorData::script_class_set_icon_path(const StringName &p_class, const String &p_icon_path) {
 	_script_class_icon_paths[p_class] = p_icon_path;
 }
 
-String EditorData::script_class_get_icon_path(const String &p_class) const {
+String EditorData::script_class_get_icon_path(const StringName &p_class) const {
 	if (!ScriptServer::is_global_class(p_class))
 		return String();
 
-	String current = p_class;
+	StringName current = p_class;
 	String ret = _script_class_icon_paths[current];
 	while (ret.empty()) {
 		current = script_class_get_base(current);
@@ -945,6 +945,24 @@ String EditorData::script_class_get_icon_path(const String &p_class) const {
 	}
 
 	return ret;
+}
+
+Ref<Script> EditorData::script_class_get_base_from_anonymous_path(const String &p_path) const {
+	StringName name = script_class_get_name(p_path);
+	if (name != StringName()) {
+		return NULL;
+	}
+	Ref<Script> script = ResourceLoader::load(p_path, "Script");
+	if (script.is_null()) {
+		return NULL;
+	}
+	do {
+		if (script_class_get_name(script->get_path()) != StringName()) {
+			return script;
+		}
+		script = script->get_base_script();
+	} while (script.is_valid());
+	return NULL;
 }
 
 StringName EditorData::script_class_get_name(const String &p_path) const {
@@ -961,8 +979,11 @@ void EditorData::script_class_save_icon_paths() {
 
 	Dictionary d;
 	for (List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-		if (ScriptServer::is_global_class(E->get()))
-			d[E->get()] = _script_class_icon_paths[E->get()];
+		StringName name = E->get();
+		String icon_path = _script_class_icon_paths[name];
+		if (ScriptServer::is_global_class(name)) {
+			d[name] = icon_path;
+		}
 	}
 
 	if (d.empty()) {
@@ -984,7 +1005,7 @@ void EditorData::script_class_load_icon_paths() {
 		d.get_key_list(&keys);
 
 		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-			String name = E->get().operator String();
+			StringName name = E->get().operator StringName();
 			_script_class_icon_paths[name] = d[name];
 
 			String path = ScriptServer::get_global_class_path(name);

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -221,11 +221,12 @@ public:
 
 	Ref<Script> script_class_load_script(const String &p_class) const;
 
+	Ref<Script> script_class_get_base_from_anonymous_path(const String &p_path) const;
 	StringName script_class_get_name(const String &p_path) const;
 	void script_class_set_name(const String &p_path, const StringName &p_class);
 
-	String script_class_get_icon_path(const String &p_class) const;
-	void script_class_set_icon_path(const String &p_class, const String &p_icon_path);
+	String script_class_get_icon_path(const StringName &p_class) const;
+	void script_class_set_icon_path(const StringName &p_class, const String &p_icon_path);
 	void script_class_clear_icon_paths() { _script_class_icon_paths.clear(); }
 	void script_class_save_icon_paths();
 	void script_class_load_icon_paths();

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -336,6 +336,7 @@ void EditorFileSystem::_save_filesystem_cache() {
 void EditorFileSystem::_thread_func(void *_userdata) {
 
 	EditorFileSystem *sd = (EditorFileSystem *)_userdata;
+	sd->init_compiled_lang_script_class_file_cache();
 	sd->_scan_filesystem();
 }
 
@@ -799,7 +800,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, DirAccess
 
 				fi->type = ResourceFormatImporter::get_singleton()->get_resource_type(path);
 				fi->import_group_file = ResourceFormatImporter::get_singleton()->get_import_group_file(path);
-				fi->script_class_name = _get_global_script_class(fi->type, path, &fi->script_class_extends, &fi->script_class_icon_path);
+				fi->script_class_name = _get_global_class_name(path, &fi->script_class_extends, &fi->script_class_icon_path);
 				fi->modified_time = 0;
 				fi->import_modified_time = 0;
 				fi->import_valid = ResourceLoader::is_import_valid(path);
@@ -825,7 +826,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, DirAccess
 			} else {
 				//new or modified time
 				fi->type = ResourceLoader::get_resource_type(path);
-				fi->script_class_name = _get_global_script_class(fi->type, path, &fi->script_class_extends, &fi->script_class_icon_path);
+				fi->script_class_name = _get_global_class_name(path, &fi->script_class_extends, &fi->script_class_icon_path);
 				fi->deps = _get_dependencies(path);
 				fi->modified_time = mt;
 				fi->import_modified_time = 0;
@@ -926,7 +927,7 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, const 
 					fi->modified_time = FileAccess::get_modified_time(path);
 					fi->import_modified_time = 0;
 					fi->type = ResourceLoader::get_resource_type(path);
-					fi->script_class_name = _get_global_script_class(fi->type, path, &fi->script_class_extends, &fi->script_class_icon_path);
+					fi->script_class_name = _get_global_class_name(path, &fi->script_class_extends, &fi->script_class_icon_path);
 					fi->import_valid = ResourceLoader::is_import_valid(path);
 					fi->import_group_file = ResourceLoader::get_import_group_file(path);
 
@@ -1408,25 +1409,6 @@ Vector<String> EditorFileSystem::_get_dependencies(const String &p_path) {
 	return ret;
 }
 
-String EditorFileSystem::_get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const {
-
-	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-		if (ScriptServer::get_language(i)->handles_global_class_type(p_type)) {
-			String global_name;
-			String extends;
-			String icon_path;
-
-			global_name = ScriptServer::get_language(i)->get_global_class_name(p_path, &extends, &icon_path);
-			*r_extends = extends;
-			*r_icon_path = icon_path;
-			return global_name;
-		}
-	}
-	*r_extends = String();
-	*r_icon_path = String();
-	return String();
-}
-
 void EditorFileSystem::_scan_script_classes(EditorFileSystemDirectory *p_dir) {
 	int filecount = p_dir->files.size();
 	const EditorFileSystemDirectory::FileInfo *const *files = p_dir->files.ptr();
@@ -1443,7 +1425,7 @@ void EditorFileSystem::_scan_script_classes(EditorFileSystemDirectory *p_dir) {
 		}
 		ScriptServer::add_global_class(files[i]->script_class_name, files[i]->script_class_extends, lang, p_dir->get_file_path(i));
 		EditorNode::get_editor_data().script_class_set_icon_path(files[i]->script_class_name, files[i]->script_class_icon_path);
-		EditorNode::get_editor_data().script_class_set_name(files[i]->file, files[i]->script_class_name);
+		EditorNode::get_editor_data().script_class_set_name(p_dir->get_file_path(i), files[i]->script_class_name);
 	}
 	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
 		_scan_script_classes(p_dir->get_subdir(i));
@@ -1473,6 +1455,58 @@ void EditorFileSystem::update_script_classes() {
 	ResourceSaver::add_custom_savers();
 }
 
+void EditorFileSystem::update_file_script_class_metadata(const String &p_path, const StringName &p_name, const StringName &p_base, const StringName &p_language, const String &p_icon_path) {
+	EditorFileSystemDirectory *fs = NULL;
+	int cpos = -1;
+
+	if (!_find_file(p_path, &fs, cpos)) {
+		if (!fs)
+			return;
+	}
+	EditorFileSystemDirectory::FileInfo *fi = fs->files[cpos];
+	fi->script_class_name = p_name;
+	fi->script_class_extends = p_base;
+	fi->script_class_icon_path = p_icon_path;
+	if (p_name != StringName() && !ScriptServer::is_global_class(p_name)) {
+		ScriptServer::add_global_class(p_name, p_base, p_language, p_path);
+		EditorData &ed = EditorNode::get_editor_data();
+		ed.script_class_set_name(p_path, p_name);
+		ed.script_class_set_icon_path(p_name, p_icon_path);
+	}
+}
+
+void EditorFileSystem::init_compiled_lang_script_class_file_cache() {
+	if (compiled_lang_script_class_file_cache.empty() && ProjectSettings::get_singleton()->has_setting("_global_script_classes")) {
+		Array script_classes = ProjectSettings::get_singleton()->get_setting("_global_script_classes");
+		Dictionary script_class_icons = ProjectSettings::get_singleton()->get_setting("_global_script_class_icons");
+		Set<StringName> compiled_language_names;
+		for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+			ScriptLanguage *lang = ScriptServer::get_language(i);
+			if (lang->has_delayed_script_class_metadata()) {
+				String n = lang->get_name();
+				compiled_language_names.insert(n);
+			}
+		}
+		for (int i = 0; i < script_classes.size(); i++) {
+			Dictionary d = script_classes[i];
+			StringName c = d["class"];
+			String p = d["path"];
+			StringName lg = d["language"];
+			if (compiled_language_names.has(lg)) {
+				String ip = script_class_icons[c];
+				d["icon_path"] = ip;
+				compiled_lang_script_class_file_cache[p] = d;
+			}
+		}
+	}
+}
+
+void EditorFileSystem::remove_compiled_lang_script_class_file_cache(const String &p_file) {
+	if (compiled_lang_script_class_file_cache.has(p_file)) {
+		compiled_lang_script_class_file_cache.erase(p_file);
+	}
+}
+
 void EditorFileSystem::_queue_update_script_classes() {
 	if (update_script_classes_queued) {
 		return;
@@ -1480,6 +1514,31 @@ void EditorFileSystem::_queue_update_script_classes() {
 
 	update_script_classes_queued = true;
 	call_deferred("update_script_classes");
+}
+
+String EditorFileSystem::_get_global_class_name(String p_path, String *p_base, String *p_icon_path) {
+	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+		ScriptLanguage *lang = ScriptServer::get_language(i);
+		if (lang->handles_global_class_type(ResourceLoader::get_resource_type(p_path))) {
+			if (lang->has_delayed_script_class_metadata()) {
+				if (compiled_lang_script_class_file_cache.has(p_path)) {
+					Dictionary d = compiled_lang_script_class_file_cache[p_path];
+					if (p_base) {
+						*p_base = d["base"].operator String();
+					}
+					if (p_icon_path) {
+						*p_icon_path = d.has("icon_path") ? d["icon_path"] : "";
+					}
+					return d["class"].operator String();
+				} else {
+					return lang->get_global_class_name(p_path, p_base, p_icon_path);
+				}
+			} else {
+				return lang->get_global_class_name(p_path, p_base, p_icon_path);
+			}
+		}
+	}
+	return String();
 }
 
 void EditorFileSystem::update_file(const String &p_file) {
@@ -1542,7 +1601,7 @@ void EditorFileSystem::update_file(const String &p_file) {
 	}
 
 	fs->files[cpos]->type = type;
-	fs->files[cpos]->script_class_name = _get_global_script_class(type, p_file, &fs->files[cpos]->script_class_extends, &fs->files[cpos]->script_class_icon_path);
+	fs->files[cpos]->script_class_name = _get_global_class_name(p_file, &fs->files[cpos]->script_class_extends, &fs->files[cpos]->script_class_icon_path);
 	fs->files[cpos]->import_group_file = ResourceLoader::get_import_group_file(p_file);
 	fs->files[cpos]->modified_time = FileAccess::get_modified_time(p_file);
 	fs->files[cpos]->deps = _get_dependencies(p_file);

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -157,6 +157,8 @@ class EditorFileSystem : public Node {
 
 	void _save_late_updated_files();
 
+	HashMap<String, Dictionary> compiled_lang_script_class_file_cache; // keep track of script classes from compiled languages
+
 	EditorFileSystemDirectory *filesystem;
 
 	static EditorFileSystem *singleton;
@@ -233,8 +235,7 @@ class EditorFileSystem : public Node {
 	void _scan_script_classes(EditorFileSystemDirectory *p_dir);
 	volatile bool update_script_classes_queued;
 	void _queue_update_script_classes();
-
-	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const;
+	String _get_global_class_name(String p_path, String *p_base = NULL, String *p_icon_path = NULL);
 
 	static Error _resource_import(const String &p_path);
 
@@ -269,6 +270,9 @@ public:
 	void reimport_files(const Vector<String> &p_files);
 
 	void update_script_classes();
+	void update_file_script_class_metadata(const String &p_path, const StringName &p_name, const StringName &p_base, const StringName &p_language, const String &p_icon_path);
+	void remove_compiled_lang_script_class_file_cache(const String &p_file);
+	void init_compiled_lang_script_class_file_cache();
 
 	bool is_group_file(const String &p_path) const;
 	void move_group_file(const String &p_path, const String &p_new_path);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3823,9 +3823,9 @@ Ref<Script> EditorNode::get_object_custom_type_base(const Object *p_object) cons
 		// 	return name;
 
 		// should probably be deprecated in 4.x
-		StringName base = script->get_instance_base_type();
-		if (base != StringName() && EditorNode::get_editor_data().get_custom_types().has(base)) {
-			const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[base];
+		StringName native = script->get_instance_base_type();
+		if (native != StringName() && EditorNode::get_editor_data().get_custom_types().has(native)) {
+			const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[native];
 
 			Ref<Script> base_script = script;
 			while (base_script.is_valid()) {
@@ -3936,14 +3936,16 @@ Ref<Texture> EditorNode::get_object_icon(const Object *p_object, const String &p
 Ref<Texture> EditorNode::get_class_icon(const String &p_class, const String &p_fallback) const {
 	ERR_FAIL_COND_V_MSG(p_class.empty(), NULL, "Class name cannot be empty.");
 
+	EditorData &ed = EditorNode::get_editor_data();
 	if (ScriptServer::is_global_class(p_class)) {
 		Ref<ImageTexture> icon;
 		Ref<Script> script = EditorNode::get_editor_data().script_class_load_script(p_class);
 		StringName name = p_class;
 
 		while (script.is_valid()) {
-			name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
-			String current_icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
+			String path = script->get_path();
+			name = ed.script_class_get_name(path);
+			String current_icon_path = ed.script_class_get_icon_path(name);
 			icon = _load_custom_class_icon(current_icon_path);
 			if (icon.is_valid()) {
 				return icon;
@@ -3958,7 +3960,7 @@ Ref<Texture> EditorNode::get_class_icon(const String &p_class, const String &p_f
 		return icon;
 	}
 
-	const Map<String, Vector<EditorData::CustomType> > &p_map = EditorNode::get_editor_data().get_custom_types();
+	const Map<String, Vector<EditorData::CustomType> > &p_map = ed.get_custom_types();
 	for (const Map<String, Vector<EditorData::CustomType> >::Element *E = p_map.front(); E; E = E->next()) {
 		const Vector<EditorData::CustomType> &ct = E->value();
 		for (int i = 0; i < ct.size(); ++i) {

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -303,11 +303,19 @@ void EditorInterface::set_distraction_free_mode(bool p_enter) {
 	EditorNode::get_singleton()->set_distraction_free_mode(p_enter);
 }
 
-EditorInterface *EditorInterface::singleton = NULL;
-
 bool EditorInterface::is_distraction_free_mode_enabled() const {
 	return EditorNode::get_singleton()->is_distraction_free_mode_enabled();
 }
+
+Ref<Texture> EditorInterface::get_class_icon(const String &p_class, const String &p_fallback) {
+	return EditorNode::get_singleton()->get_class_icon(p_class, p_fallback);
+}
+
+Ref<Texture> EditorInterface::get_object_icon(const Object *p_object, const String &p_fallback) {
+	return EditorNode::get_singleton()->get_object_icon(p_object, p_fallback);
+}
+
+EditorInterface *EditorInterface::singleton = NULL;
 
 void EditorInterface::_bind_methods() {
 
@@ -347,6 +355,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
 	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);
 	ClassDB::bind_method(D_METHOD("is_distraction_free_mode_enabled"), &EditorInterface::is_distraction_free_mode_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_class_icon", "class", "fallback"), &EditorInterface::get_class_icon);
+	ClassDB::bind_method(D_METHOD("get_object_icon", "object", "fallback"), &EditorInterface::get_object_icon);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
 }

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -114,6 +114,9 @@ public:
 	void set_distraction_free_mode(bool p_enter);
 	bool is_distraction_free_mode_enabled() const;
 
+	Ref<Texture> get_class_icon(const String &p_name, const String &p_fallback);
+	Ref<Texture> get_object_icon(const Object *p_object, const String &p_fallback);
+
 	EditorInterface();
 };
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -448,24 +448,64 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (selection.empty())
 				return;
 
-			editor_data->get_undo_redo().create_action(TTR("Detach Script"));
-			editor_data->get_undo_redo().add_do_method(editor, "push_item", (Script *)NULL);
+			Array update_array;
+			EditorData &ed = EditorNode::get_editor_data();
 
 			for (int i = 0; i < selection.size(); i++) {
-
 				Node *n = Object::cast_to<Node>(selection[i]);
 				Ref<Script> existing = n->get_script();
-				Ref<Script> empty = EditorNode::get_singleton()->get_object_custom_type_base(n);
-				if (existing != empty) {
-					editor_data->get_undo_redo().add_do_method(n, "set_script", empty);
-					editor_data->get_undo_redo().add_undo_method(n, "set_script", existing);
+				Ref<Script> base = NULL;
+				if (existing.is_valid()) {
+					StringName script_class_name = ed.script_class_get_name(existing->get_path());
+					if (script_class_name != StringName()) {
+						update_array.clear();
+						print_error("Unable to remove script class '" + script_class_name + "'. Can only remove anonymous scripts.");
+						break;
+					}
+					base = ed.script_class_get_base_from_anonymous_path(existing->get_path());
+					if (base.is_null()) {
+						const Map<String, Vector<EditorData::CustomType> > &ct = EditorNode::get_editor_data().get_custom_types();
+						if (ct.has(n->get_class())) {
+							const Vector<EditorData::CustomType> &v = ct[n->get_class()];
+							String ct_name;
+							for (int j = 0; j < v.size() && !ct_name.empty(); j++) {
+								if (v[j].script == existing) {
+									ct_name = v[j].name;
+								}
+							}
+							if (!ct_name.empty()) {
+								update_array.clear();
+								print_error("Unable to remove custom type '" + ct_name + "'. Can only remove anonymous scripts.");
+								break;
+							}
+						}
+						base = EditorNode::get_singleton()->get_object_custom_type_base(n);
+					}
+				}
+				if (existing != base) {
+					Array an_update;
+					an_update.push_back(n);
+					an_update.push_back(base);
+					an_update.push_back(existing);
+					update_array.push_back(an_update);
 				}
 			}
+			if (update_array.size()) {
+				editor_data->get_undo_redo().create_action(TTR("Detach Script"));
+				editor_data->get_undo_redo().add_do_method(editor, "push_item", (Script *)NULL);
+				for (int i = 0; i < update_array.size(); i++) {
+					Array an_update = update_array[i];
+					Node *n = an_update[0];
+					Ref<Script> do_script = an_update[1];
+					Ref<Script> undo_script = an_update[2];
+					editor_data->get_undo_redo().add_do_method(n, "set_script", do_script);
+					editor_data->get_undo_redo().add_undo_method(n, "set_script", undo_script);
+				}
+				editor_data->get_undo_redo().add_do_method(this, "_update_script_button");
+				editor_data->get_undo_redo().add_undo_method(this, "_update_script_button");
 
-			editor_data->get_undo_redo().add_do_method(this, "_update_script_button");
-			editor_data->get_undo_redo().add_undo_method(this, "_update_script_button");
-
-			editor_data->get_undo_redo().commit_action();
+				editor_data->get_undo_redo().commit_action();
+			}
 		} break;
 		case TOOL_MOVE_UP:
 		case TOOL_MOVE_DOWN: {
@@ -1085,6 +1125,7 @@ void SceneTreeDock::_notification(int p_what) {
 			button_add->set_icon(get_icon("Add", "EditorIcons"));
 			button_instance->set_icon(get_icon("Instance", "EditorIcons"));
 			button_create_script->set_icon(get_icon("ScriptCreate", "EditorIcons"));
+			button_extend_script->set_icon(get_icon("ScriptExtend", "EditorIcons"));
 			button_detach_script->set_icon(get_icon("ScriptRemove", "EditorIcons"));
 
 			filter->set_right_icon(get_icon("Search", "EditorIcons"));
@@ -1161,6 +1202,7 @@ void SceneTreeDock::_notification(int p_what) {
 			button_add->set_icon(get_icon("Add", "EditorIcons"));
 			button_instance->set_icon(get_icon("Instance", "EditorIcons"));
 			button_create_script->set_icon(get_icon("ScriptCreate", "EditorIcons"));
+			button_extend_script->set_icon(get_icon("ScriptExtend", "EditorIcons"));
 			button_detach_script->set_icon(get_icon("ScriptRemove", "EditorIcons"));
 			button_2d->set_icon(get_icon("Node2D", "EditorIcons"));
 			button_3d->set_icon(get_icon("Spatial", "EditorIcons"));
@@ -1909,29 +1951,49 @@ void SceneTreeDock::_update_script_button() {
 	if (!profile_allow_script_editing) {
 
 		button_create_script->hide();
+		button_extend_script->hide();
 		button_detach_script->hide();
 	} else if (EditorNode::get_singleton()->get_editor_selection()->get_selection().size() == 0) {
 		button_create_script->hide();
+		button_extend_script->hide();
 		button_detach_script->hide();
 	} else if (EditorNode::get_singleton()->get_editor_selection()->get_selection().size() == 1) {
 		Node *n = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list()[0];
-		if (n->get_script().is_null()) {
-			button_create_script->show();
-			button_detach_script->hide();
+		Ref<Script> s = n->get_script();
+		if (s.is_valid()) {
+			if (EditorNode::get_editor_data().script_class_get_name(s->get_path()) != StringName()) {
+				button_create_script->hide();
+				button_extend_script->show();
+				button_detach_script->hide();
+			} else {
+				button_create_script->hide();
+				button_extend_script->hide();
+				button_detach_script->show();
+			}
 		} else {
-			button_create_script->hide();
-			button_detach_script->show();
+			button_create_script->show();
+			button_extend_script->hide();
+			button_detach_script->hide();
 		}
 	} else {
 		button_create_script->hide();
 		Array selection = editor_selection->get_selected_nodes();
 		for (int i = 0; i < selection.size(); i++) {
 			Node *n = Object::cast_to<Node>(selection[i]);
-			if (!n->get_script().is_null()) {
-				button_detach_script->show();
-				return;
+			Ref<Script> s = n->get_script();
+			if (s.is_valid()) {
+				if (EditorNode::get_editor_data().script_class_get_name(s->get_path()) != StringName()) {
+					button_extend_script->show();
+					button_detach_script->hide();
+					return;
+				} else {
+					button_extend_script->hide();
+					button_detach_script->show();
+					return;
+				}
 			}
 		}
+		button_extend_script->hide();
 		button_detach_script->hide();
 	}
 }
@@ -2483,7 +2545,8 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 		existing_script = selected->get_script();
 
-		if (EditorNode::get_singleton()->get_object_custom_type_base(selected) == existing_script) {
+		if (EditorNode::get_singleton()->get_object_custom_type_base(selected) == existing_script ||
+				(existing_script.is_valid() && EditorNode::get_editor_data().script_class_get_name(existing_script->get_path()) != StringName())) {
 			exisiting_script_removable = false;
 		}
 	}
@@ -2662,7 +2725,7 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 		for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 			ScriptLanguage *l = ScriptServer::get_language(i);
 			if (l->get_type() == existing->get_class()) {
-				String name = l->get_global_class_name(existing->get_path());
+				String name = EditorNode::get_editor_data().script_class_get_name(existing->get_path());
 				if (ScriptServer::is_global_class(name) && EDITOR_GET("interface/editors/derive_script_globals_by_name").operator bool()) {
 					inherits = name;
 				} else if (l->can_inherit_from_file()) {
@@ -2935,6 +2998,13 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	filter_hbc->add_child(button_create_script);
 	button_create_script->hide();
 
+	button_extend_script = memnew(ToolButton);
+	button_extend_script->connect("pressed", this, "_tool_selected", make_binds(TOOL_EXTEND_SCRIPT, false));
+	button_extend_script->set_tooltip(TTR("Attach a new script extending the selected node's script."));
+	button_extend_script->set_shortcut(ED_GET_SHORTCUT("scene_tree/extend_script"));
+	filter_hbc->add_child(button_extend_script);
+	button_extend_script->hide();
+
 	button_detach_script = memnew(ToolButton);
 	button_detach_script->connect("pressed", this, "_tool_selected", make_binds(TOOL_DETACH_SCRIPT, false));
 	button_detach_script->set_tooltip(TTR("Detach the script from the selected node."));
@@ -3057,5 +3127,6 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	EDITOR_DEF("interface/editors/show_scene_tree_root_selection", true);
 	EDITOR_DEF("interface/editors/derive_script_globals_by_name", true);
+	EDITOR_DEF("interface/editors/create_dialog_hide_script_class_filepath", false);
 	EDITOR_DEF("_use_favorites_root_selection", false);
 }

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -110,6 +110,7 @@ class SceneTreeDock : public VBoxContainer {
 	ToolButton *button_add;
 	ToolButton *button_instance;
 	ToolButton *button_create_script;
+	ToolButton *button_extend_script;
 	ToolButton *button_detach_script;
 
 	Button *button_2d;

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -213,15 +213,18 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		Color accent = get_color("accent_color", "Editor");
 
 		Ref<Script> script = p_node->get_script();
-		if (!script.is_null() && EditorNode::get_singleton()->get_object_custom_type_base(p_node) != script) {
+		EditorData &ed = EditorNode::get_editor_data();
+		if (script.is_valid() &&
+				ed.script_class_get_name(script->get_path()) == StringName() &&
+				EditorNode::get_singleton()->get_object_custom_type_base(p_node) != script) {
 			//has script
 			item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT);
 		} else {
-			//has no script (or script is a custom type)
+			//has no script (or script is a custom type / script class)
 			item->set_custom_color(0, get_color("disabled_font_color", "Editor"));
 			item->set_selectable(0, false);
 
-			if (!script.is_null()) { // make sure to mark the script if a custom type
+			if (script.is_valid()) { // make sure to mark the script if a custom type or script class
 				item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT);
 				item->set_button_disabled(0, item->get_button_count(0) - 1, true);
 			}
@@ -338,7 +341,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		Ref<Script> script = p_node->get_script();
 		if (!script.is_null()) {
 			item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT, false, TTR("Open Script:") + " " + script->get_path());
-			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == script) {
+			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == script ||
+					EditorNode::get_editor_data().script_class_get_name(script->get_path()) != String()) {
 				item->set_button_color(0, item->get_button_count(0) - 1, Color(1, 1, 1, 0.5));
 			}
 		}

--- a/modules/gdnative/include/pluginscript/godot_pluginscript.h
+++ b/modules/gdnative/include/pluginscript/godot_pluginscript.h
@@ -131,6 +131,7 @@ typedef struct {
 	const char **string_delimiters; // NULL terminated array
 	godot_bool has_named_classes;
 	godot_bool supports_builtin_mode;
+	godot_bool has_delayed_script_class_metadata;
 
 	godot_string (*get_template_source_code)(godot_pluginscript_language_data *p_data, const godot_string *p_class_name, const godot_string *p_base_class_name);
 	godot_bool (*validate)(godot_pluginscript_language_data *p_data, const godot_string *p_script, int *r_line_error, int *r_col_error, godot_string *r_test_error, const godot_string *p_path, godot_pool_string_array *r_functions);

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -142,6 +142,10 @@ bool PluginScriptLanguage::supports_builtin_mode() const {
 	return _desc.supports_builtin_mode;
 }
 
+bool PluginScriptLanguage::has_delayed_script_class_metadata() const {
+	return _desc.has_delayed_script_class_metadata;
+}
+
 int PluginScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 	if (_desc.find_function) {
 		return _desc.find_function(_data, (godot_string *)&p_function, (godot_string *)&p_code);

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -79,6 +79,7 @@ public:
 	virtual bool has_named_classes() const;
 	virtual bool supports_builtin_mode() const;
 	virtual bool can_inherit_from_file() { return true; }
+	virtual bool has_delayed_script_class_metadata() const;
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptCodeCompletionOption> *r_options, bool &r_force, String &r_call_hint);

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -103,6 +103,11 @@ class CSharpScript : public Script {
 	String source;
 	StringName name;
 
+	// For engine "Script Class" support, not affiliated with `GDMonoClass *script_class` property.
+	String script_class_name;
+	String script_class_base;
+	String script_class_icon_path;
+
 	SelfList<CSharpScript> script_list;
 
 	struct Argument {
@@ -198,6 +203,11 @@ public:
 #endif
 
 	Error load_source_code(const String &p_path);
+
+	String get_script_class_name() const { return script_class_name; }
+	String get_script_class_base() const { return script_class_base; }
+	String get_script_class_icon_path() const { return script_class_icon_path; }
+	void _update_global_script_class_settings();
 
 	StringName get_script_name() const;
 
@@ -418,6 +428,11 @@ public:
 	virtual String _get_indentation() const;
 	/* TODO? */ virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const {}
 	/* TODO */ virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) {}
+	virtual bool has_delayed_script_class_metadata() const override { return true; }
+
+	/* SCRIPT CLASS FUNCTIONS */
+	virtual bool handles_global_class_type(const String &p_type) const;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL, String *r_icon_path = NULL) const;
 
 	/* DEBUGGER FUNCTIONS */
 	virtual String debug_get_error() const;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Godot
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class GlobalAttribute : Attribute
+    {
+        private string name;
+        private string iconPath;
+
+        public GlobalAttribute(string name = "", string iconPath = "")
+        {
+            this.name = name;
+            this.iconPath = iconPath;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -15,6 +15,7 @@
     <Compile Include="Core\AABB.cs" />
     <Compile Include="Core\Array.cs" />
     <Compile Include="Core\Attributes\ExportAttribute.cs" />
+    <Compile Include="Core\Attributes\GlobalAttribute.cs" />
     <Compile Include="Core\Attributes\GodotMethodAttribute.cs" />
     <Compile Include="Core\Attributes\RPCAttributes.cs" />
     <Compile Include="Core\Attributes\SignalAttribute.cs" />

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -134,6 +134,9 @@ void CachedData::clear_godot_api_cache() {
 	class_ExportAttribute = NULL;
 	field_ExportAttribute_hint = NULL;
 	field_ExportAttribute_hintString = NULL;
+	class_GlobalAttribute = NULL;
+	field_GlobalAttribute_name = NULL;
+	field_GlobalAttribute_iconPath = NULL;
 	class_SignalAttribute = NULL;
 	class_ToolAttribute = NULL;
 	class_RemoteAttribute = NULL;
@@ -249,6 +252,9 @@ void update_godot_api_cache() {
 	CACHE_CLASS_AND_CHECK(ExportAttribute, GODOT_API_CLASS(ExportAttribute));
 	CACHE_FIELD_AND_CHECK(ExportAttribute, hint, CACHED_CLASS(ExportAttribute)->get_field("hint"));
 	CACHE_FIELD_AND_CHECK(ExportAttribute, hintString, CACHED_CLASS(ExportAttribute)->get_field("hintString"));
+	CACHE_CLASS_AND_CHECK(GlobalAttribute, GODOT_API_CLASS(GlobalAttribute));
+	CACHE_FIELD_AND_CHECK(GlobalAttribute, name, CACHED_CLASS(GlobalAttribute)->get_field("name"));
+	CACHE_FIELD_AND_CHECK(GlobalAttribute, iconPath, CACHED_CLASS(GlobalAttribute)->get_field("iconPath"));
 	CACHE_CLASS_AND_CHECK(SignalAttribute, GODOT_API_CLASS(SignalAttribute));
 	CACHE_CLASS_AND_CHECK(ToolAttribute, GODOT_API_CLASS(ToolAttribute));
 	CACHE_CLASS_AND_CHECK(RemoteAttribute, GODOT_API_CLASS(RemoteAttribute));

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -104,6 +104,9 @@ struct CachedData {
 	GDMonoClass *class_ExportAttribute;
 	GDMonoField *field_ExportAttribute_hint;
 	GDMonoField *field_ExportAttribute_hintString;
+	GDMonoClass *class_GlobalAttribute;
+	GDMonoField *field_GlobalAttribute_name;
+	GDMonoField *field_GlobalAttribute_iconPath;
 	GDMonoClass *class_SignalAttribute;
 	GDMonoClass *class_ToolAttribute;
 	GDMonoClass *class_RemoteAttribute;

--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -68,6 +68,7 @@ void register_visual_script_types() {
 	ClassDB::register_class<VisualScriptClassConstant>();
 	ClassDB::register_class<VisualScriptMathConstant>();
 	ClassDB::register_class<VisualScriptBasicTypeConstant>();
+	ClassDB::register_class<VisualScriptScriptClass>();
 	ClassDB::register_class<VisualScriptEngineSingleton>();
 	ClassDB::register_class<VisualScriptSceneNode>();
 	ClassDB::register_class<VisualScriptSceneTree>();

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1202,6 +1202,11 @@ void VisualScript::_set_data(const Dictionary &p_data) {
 		}
 	}
 
+	if (d.has("script_class_name"))
+		script_class_name = d["script_class_name"];
+	if (d.has("script_class_icon_path"))
+		script_class_icon_path = d["script_class_icon_path"];
+
 	if (d.has("is_tool_script"))
 		is_tool_script = d["is_tool_script"];
 	else
@@ -1290,7 +1295,33 @@ Dictionary VisualScript::_get_data() const {
 	d["is_tool_script"] = is_tool_script;
 	d["vs_unify"] = true;
 
+	if (ScriptServer::is_global_class(script_class_name)) {
+		d["script_class_name"] = script_class_name;
+		d["script_class_icon_path"] = script_class_icon_path;
+	} else {
+		d["script_class_name"] = "";
+		d["script_class_icon_path"] = "";
+	}
+
 	return d;
+}
+
+String VisualScript::get_script_class_name() {
+	return script_class_name;
+}
+
+String VisualScript::get_script_class_icon_path() {
+	return script_class_icon_path;
+}
+
+void VisualScript::set_script_class_name(const String &p_name) {
+	if (p_name.is_valid_identifier()) {
+		script_class_name = p_name;
+	}
+}
+
+void VisualScript::set_script_class_icon_path(const String &p_path) {
+	script_class_icon_path = p_path;
 }
 
 void VisualScript::_bind_methods() {
@@ -1352,6 +1383,11 @@ void VisualScript::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &VisualScript::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &VisualScript::_get_data);
+
+	ClassDB::bind_method(D_METHOD("set_script_class_name", "script_class_name"), &VisualScript::set_script_class_name);
+	ClassDB::bind_method(D_METHOD("get_script_class_name"), &VisualScript::get_script_class_name);
+	ClassDB::bind_method(D_METHOD("set_script_class_icon_path", "script_class_icon_path"), &VisualScript::set_script_class_icon_path);
+	ClassDB::bind_method(D_METHOD("get_script_class_icon_path"), &VisualScript::get_script_class_icon_path);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 
@@ -2444,6 +2480,27 @@ Error VisualScriptLanguage::execute_file(const String &p_path) {
 	return OK;
 }
 void VisualScriptLanguage::finish() {
+}
+
+bool VisualScriptLanguage::handles_global_class_type(const String &p_type) const {
+	return p_type == "VisualScript";
+}
+
+String VisualScriptLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const {
+	Ref<VisualScript> script = ResourceLoader::load(p_path, "VisualScript");
+	if (script.is_null()) {
+		if (r_base_type)
+			*r_base_type = String();
+		if (r_icon_path)
+			*r_icon_path = String();
+		return String();
+	}
+
+	if (r_base_type)
+		*r_base_type = script->get_instance_base_type();
+	if (r_icon_path)
+		*r_icon_path = script->get_script_class_icon_path();
+	return script->get_script_class_name().is_valid_identifier() ? script->get_script_class_name() : "";
 }
 
 /* EDITOR FUNCTIONS */

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -249,6 +249,8 @@ private:
 	Map<Object *, VisualScriptInstance *> instances;
 
 	bool is_tool_script;
+	String script_class_name;
+	String script_class_icon_path;
 
 #ifdef TOOLS_ENABLED
 	Set<PlaceHolderScriptInstance *> placeholders;
@@ -365,6 +367,11 @@ public:
 #ifdef TOOLS_ENABLED
 	virtual bool are_subnodes_edited() const;
 #endif
+
+	String get_script_class_name();
+	String get_script_class_icon_path();
+	void set_script_class_name(const String &p_name);
+	void set_script_class_icon_path(const String &p_path);
 
 	VisualScript();
 	~VisualScript();
@@ -563,6 +570,9 @@ public:
 	virtual String get_extension() const;
 	virtual Error execute_file(const String &p_path);
 	virtual void finish();
+
+	virtual bool handles_global_class_type(const String &p_type) const;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL, String *r_icon_path = NULL) const;
 
 	/* EDITOR FUNCTIONS */
 	virtual void get_reserved_words(List<String> *p_words) const;

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1178,6 +1178,18 @@ void VisualScriptEditor::_member_edited() {
 	}
 }
 
+void VisualScriptEditor::_script_class_icon_btn_gui_input(Ref<InputEvent> p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && !mb->is_pressed()) {
+		int index = mb->get_button_index();
+		if (index == BUTTON_LEFT) {
+			_script_class_icon_path_dialog->popup_centered_ratio();
+		} else if (index == BUTTON_RIGHT) {
+			_script_class_icon_btn_set_icon("");
+		}
+	}
+}
+
 void VisualScriptEditor::_create_function_dialog() {
 	function_create_dialog->popup_centered();
 	func_name_box->set_text("");
@@ -2430,6 +2442,12 @@ void VisualScriptEditor::set_edited_resource(const RES &p_res) {
 		script->add_function(default_func);
 		script->set_edited(true); //so that if a function was added it's saved
 	}
+
+	_script_class_name_edit->set_text(script->get_script_class_name());
+	String icon_path = script->get_script_class_icon_path();
+	Control *gui_base = EditorNode::get_singleton()->get_gui_base();
+	RES icon = FileAccess::exists(icon_path) ? ResourceLoader::load(icon_path, "Texture") : (RES)gui_base->get_icon("Nil", "EditorIcons");
+	_script_class_icon_btn->set_icon(icon);
 
 	_update_graph();
 	call_deferred("_update_members");
@@ -4621,6 +4639,42 @@ void VisualScriptEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter
 void VisualScriptEditor::set_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
 }
 
+void VisualScriptEditor::_script_class_icon_path_dialog_confirmed() {
+	const String &path = _script_class_icon_path_dialog->get_current_path();
+	_script_class_icon_btn_set_icon(path);
+}
+
+void VisualScriptEditor::_script_class_icon_path_dialog_file_selected(const String &p_path) {
+	_script_class_icon_btn_set_icon(p_path);
+}
+
+void VisualScriptEditor::_script_class_icon_btn_set_icon(const String &p_path) {
+	ERR_FAIL_COND(!_script_class_icon_btn);
+	ERR_FAIL_COND_MSG(p_path.length() && !FileAccess::exists(p_path), "The given script class icon path does not exist.");
+	RES icon = FileAccess::exists(p_path) ? ResourceLoader::load(p_path, "Texture") : (RES)EditorNode::get_singleton()->get_gui_base()->get_icon("Nil", "EditorIcons");
+	undo_redo->create_action("Set script class icon");
+	undo_redo->add_do_method(_script_class_icon_btn, "set_button_icon", icon);
+	undo_redo->add_undo_method(_script_class_icon_btn, "set_button_icon", _script_class_icon_btn->get_icon());
+	if (script.is_valid()) {
+		undo_redo->add_do_method(script.operator->(), "set_script_class_icon_path", p_path);
+		undo_redo->add_undo_method(script.operator->(), "set_script_class_icon_path", script->get_script_class_icon_path());
+	}
+	undo_redo->commit_action();
+	set_edited(true);
+}
+
+void VisualScriptEditor::_script_class_name_text_changed(const String &p_text) {
+	if (script.is_valid())
+		script->set_script_class_name(p_text);
+	set_edited(true);
+}
+
+void VisualScriptEditor::_script_class_icon_path_text_changed(const String &p_text) {
+	if (script.is_valid())
+		script->set_script_class_icon_path(p_text);
+	set_edited(true);
+}
+
 void VisualScriptEditor::_bind_methods() {
 
 	ClassDB::bind_method("_member_button", &VisualScriptEditor::_member_button);
@@ -4695,6 +4749,12 @@ void VisualScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_draw_color_over_button", &VisualScriptEditor::_draw_color_over_button);
 
 	ClassDB::bind_method("_generic_search", &VisualScriptEditor::_generic_search);
+
+	ClassDB::bind_method("_script_class_icon_path_dialog_confirmed", &VisualScriptEditor::_script_class_icon_path_dialog_confirmed);
+	ClassDB::bind_method("_script_class_icon_path_dialog_file_selected", &VisualScriptEditor::_script_class_icon_path_dialog_file_selected);
+	ClassDB::bind_method("_script_class_name_text_changed", &VisualScriptEditor::_script_class_name_text_changed);
+	ClassDB::bind_method("_script_class_icon_path_text_changed", &VisualScriptEditor::_script_class_icon_path_text_changed);
+	ClassDB::bind_method("_script_class_icon_btn_gui_input", &VisualScriptEditor::_script_class_icon_btn_gui_input);
 }
 
 VisualScriptEditor::VisualScriptEditor() {
@@ -4730,6 +4790,37 @@ VisualScriptEditor::VisualScriptEditor() {
 	tool_script_check->set_text(TTR("Make Tool:"));
 	members_section->add_child(tool_script_check);
 	tool_script_check->connect("pressed", this, "_toggle_tool_script");
+
+	HBoxContainer *hb = memnew(HBoxContainer);
+	hb->set_h_size_flags(SIZE_EXPAND_FILL);
+	Label *lbl = memnew(Label);
+	lbl->set_text(TTR("Class Name:"));
+	hb->add_child(lbl);
+	LineEdit *le = memnew(LineEdit);
+	le->set_tooltip(TTR("Script Class names must be valid identifiers. Alphanumeric characters and underscores not starting with a number."));
+	le->connect("text_changed", this, "_script_class_name_text_changed");
+	le->set_h_size_flags(SIZE_EXPAND_FILL);
+	hb->add_child(le);
+	_script_class_name_edit = le;
+	_script_class_icon_btn = memnew(Button);
+	_script_class_icon_btn->set_tooltip(TTR("Choose a 16x16 icon for the class. Right-click to clear."));
+	FileDialog *fd = memnew(FileDialog);
+	fd->set_mode(FileDialog::MODE_OPEN_FILE);
+	List<String> texture_type_exts;
+	ResourceLoader::get_recognized_extensions_for_type("Texture", &texture_type_exts);
+	for (List<String>::Element *E = texture_type_exts.front(); E; E = E->next()) {
+		fd->add_filter(vformat("*.%s", E->get()));
+	}
+	fd->set_enable_multiple_selection(false);
+	fd->set_show_hidden_files(false);
+	fd->set_title("Choose an image.");
+	fd->connect("confirmed", this, "_script_class_icon_path_dialog_confirmed");
+	fd->connect("file_selected", this, "_script_class_icon_path_dialog_file_selected");
+	_script_class_icon_btn->add_child(fd);
+	_script_class_icon_path_dialog = fd;
+	_script_class_icon_btn->connect("gui_input", this, "_script_class_icon_btn_gui_input");
+	hb->add_child(_script_class_icon_btn);
+	members_section->add_child(hb);
 
 	///       Members        ///
 

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -34,6 +34,7 @@
 #include "editor/create_dialog.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/property_editor.h"
+#include "scene/gui/file_dialog.h"
 #include "scene/gui/graph_edit.h"
 #include "visual_script.h"
 #include "visual_script_property_selector.h"
@@ -173,6 +174,10 @@ class VisualScriptEditor : public ScriptEditorBase {
 	Vector2 port_action_pos;
 	int port_action_new_node;
 
+	LineEdit *_script_class_name_edit;
+	Button *_script_class_icon_btn;
+	FileDialog *_script_class_icon_path_dialog;
+
 	bool saved_pos_dirty;
 	Vector2 saved_position;
 
@@ -200,6 +205,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 	void _toggle_tool_script();
 	void _member_selected();
 	void _member_edited();
+	void _script_class_icon_btn_gui_input(Ref<InputEvent> p_event);
 
 	void _begin_node_move();
 	void _end_node_move();
@@ -284,6 +290,12 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	void _member_rmb_selected(const Vector2 &p_pos);
 	void _member_option(int p_option);
+
+	void _script_class_icon_path_dialog_confirmed();
+	void _script_class_icon_path_dialog_file_selected(const String &p_path);
+	void _script_class_icon_btn_set_icon(const String &p_path);
+	void _script_class_name_text_changed(const String &p_text);
+	void _script_class_icon_path_text_changed(const String &p_text);
 
 protected:
 	void _notification(int p_what);

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2331,6 +2331,118 @@ VisualScriptMathConstant::VisualScriptMathConstant() {
 }
 
 //////////////////////////////////////////
+////////////////SCRIPTCLASS///////////////
+//////////////////////////////////////////
+
+int VisualScriptScriptClass::get_output_sequence_port_count() const {
+	return 0;
+}
+
+bool VisualScriptScriptClass::has_input_sequence_port() const {
+	return false;
+}
+
+int VisualScriptScriptClass::get_input_value_port_count() const {
+	return 0;
+}
+int VisualScriptScriptClass::get_output_value_port_count() const {
+	return 1;
+}
+
+String VisualScriptScriptClass::get_output_sequence_port_text(int p_port) const {
+	return String();
+}
+
+PropertyInfo VisualScriptScriptClass::get_input_value_port_info(int p_idx) const {
+	return PropertyInfo();
+}
+
+PropertyInfo VisualScriptScriptClass::get_output_value_port_info(int p_idx) const {
+	if (ScriptServer::is_global_class(script_class)) {
+		Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(script_class), "Script");
+		return PropertyInfo(Variant::OBJECT, script_class, PROPERTY_HINT_RESOURCE_TYPE, script->get_class(), PROPERTY_USAGE_DEFAULT, script->get_class());
+	}
+	return PropertyInfo(Variant::OBJECT, script_class, PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT, "Script");
+}
+
+String VisualScriptScriptClass::get_caption() const {
+	return "Script Class";
+}
+
+void VisualScriptScriptClass::set_script_class(const String &p_name) {
+	ERR_FAIL_COND(!ScriptServer::is_global_class(p_name));
+	script_class = p_name;
+	_change_notify();
+	ports_changed_notify();
+}
+
+const String &VisualScriptScriptClass::get_script_class() const {
+	return script_class;
+}
+
+class VisualScriptNodeInstanceScriptClass : public VisualScriptNodeInstance {
+public:
+	Ref<Script> script;
+
+	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Variant::CallError &r_error, String &r_error_str) {
+		*p_outputs[0] = script;
+		return OK;
+	}
+};
+
+VisualScriptNodeInstance *VisualScriptScriptClass::instance(VisualScriptInstance *p_instance) {
+	VisualScriptNodeInstanceScriptClass *instance = memnew(VisualScriptNodeInstanceScriptClass);
+	instance->script = script_class != StringName() ? ResourceLoader::load(ScriptServer::get_global_class_path(script_class), "Script") : RES();
+	return instance;
+}
+
+bool VisualScriptScriptClass::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "script_class") {
+		set_script_class(p_value);
+		return true;
+	}
+	return false;
+}
+
+bool VisualScriptScriptClass::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "script_class") {
+		r_ret = get_script_class();
+		return true;
+	}
+	return false;
+}
+
+void VisualScriptScriptClass::_get_property_list(List<PropertyInfo> *p_list) const {
+	String cc;
+
+	List<StringName> lst;
+	ScriptServer::get_global_class_list(&lst);
+	int i = 0;
+	for (List<StringName>::Element *E = lst.front(); E; E = E->next()) {
+		if (i > 0)
+			cc += ",";
+		i++;
+		cc += E->get();
+	}
+	p_list->push_back(PropertyInfo(Variant::STRING, "script_class", PROPERTY_HINT_ENUM, cc));
+}
+
+void VisualScriptScriptClass::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_script_class", "name"), &VisualScriptScriptClass::set_script_class);
+	ClassDB::bind_method(D_METHOD("get_script_class"), &VisualScriptScriptClass::get_script_class);
+}
+
+VisualScriptScriptClass::VisualScriptScriptClass() {
+	List<StringName> lst;
+	ScriptServer::get_global_class_list(&lst);
+	script_class = "";
+	if (lst.size()) {
+		StringName name = lst.front()->get();
+		script_class = name;
+	}
+}
+
+//////////////////////////////////////////
 ////////////////ENGINESINGLETON///////////
 //////////////////////////////////////////
 
@@ -4150,6 +4262,7 @@ void register_visual_script_nodes() {
 	VisualScriptLanguage::singleton->add_register_func("constants/class_constant", create_node_generic<VisualScriptClassConstant>);
 	VisualScriptLanguage::singleton->add_register_func("constants/global_constant", create_node_generic<VisualScriptGlobalConstant>);
 	VisualScriptLanguage::singleton->add_register_func("constants/basic_type_constant", create_node_generic<VisualScriptBasicTypeConstant>);
+	VisualScriptLanguage::singleton->add_register_func("constants/script_class", create_node_generic<VisualScriptScriptClass>);
 
 	VisualScriptLanguage::singleton->add_register_func("custom/custom_node", create_node_generic<VisualScriptCustomNode>);
 	VisualScriptLanguage::singleton->add_register_func("custom/sub_call", create_node_generic<VisualScriptSubCall>);

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -608,6 +608,41 @@ public:
 
 VARIANT_ENUM_CAST(VisualScriptMathConstant::MathConstant)
 
+class VisualScriptScriptClass : public VisualScriptNode {
+	GDCLASS(VisualScriptScriptClass, VisualScriptNode);
+
+	String script_class;
+
+protected:
+	static void _bind_methods();
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+public:
+	virtual int get_output_sequence_port_count() const;
+	virtual bool has_input_sequence_port() const;
+
+	virtual String get_output_sequence_port_text(int p_port) const;
+
+	virtual int get_input_value_port_count() const;
+	virtual int get_output_value_port_count() const;
+
+	virtual PropertyInfo get_input_value_port_info(int p_idx) const;
+	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
+
+	virtual String get_caption() const;
+	virtual String get_category() const { return "constants"; }
+
+	void set_script_class(const String &p_name);
+	const String &get_script_class() const;
+
+	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
+
+	VisualScriptScriptClass();
+};
+
 class VisualScriptEngineSingleton : public VisualScriptNode {
 
 	GDCLASS(VisualScriptEngineSingleton, VisualScriptNode);


### PR DESCRIPTION
This is is 3.2 port of #40147 since there are presumably going to be core changes that make these features inapplicable to 4.0.

I've created a demo of it:

[Demo_GP22_3_2.zip](https://github.com/godotengine/godot/files/5751270/Demo_GP22_3_2.zip)

Relevant code samples:

    # main.tscn
    - Node (main.gd)
        - Node "MyGDClass" (MyGDClass.gd)
        - Node "MyVSClass" (MyVSClass.vs)
        - Node "MyCSClass" (MyCSClass.cs)

```gdscript        
# MyGDClass.gd
extends Node
class_name MyGDClass, "res://skill.png"
func _ready():
    print("MyGDClass")
```

```csharp
// MyCSClass.cs
using System;
using Godot;

[Global("MyCSClass", "res://skill.png")]
public class MyCSClass : Node
{
    public override void _Ready()
    {
        GD.Print("MyCSClass");
    }
}
```
 
VisualScript sample:

![visual_script_sample](https://user-images.githubusercontent.com/16217563/103297019-0830e200-49bd-11eb-8627-5ec84cda39a5.png)

```gdscript
# main.gd
extends Node

onready var gd = $MyGDClass
onready var vs = $MyVSClass
onready var cs = $MyCSClass

func _ready():
	if gd is ScriptServer.MyGDClass:
		print("gd is MyGDClass")
	if vs.get_script() == ScriptServer.MyVSClass:
		print("vs is MyVSClass")
	if cs.get_script() == ScriptServer.MyCSClass:
		print("cs is MyCSClass")
```

Output:

```
MyGDClass
MyCSClass
MyVSClass
gd is MyGDClass
vs is MyVSClass
cs is MyCSClass
```

It seems as though the `is` keyword doesn't like to cooperate with non-GDScript script types on the right-hand side. Should I try to incorporate that into the feature? Iirc, it worked fine in my 4.0 demo project.

Edit: Also, it looks like the C# glue generation code doesn't implement the `Get()` method for ScriptServer, so you have to use `ScriptServer.GetGlobalClassScript("MyGDClass")`, etc. instead.