### PR TITLE
mesh indexing failing with small scale values

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3321,6 +3321,21 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 
 	xform.basis.scale(scale);
 
+	// if the determinant is zero, we should disable the gizmo from being rendered
+	// this prevents supplying bad values to the renderer and then having to filter it out again
+	if (xform.basis.determinant() == 0) {
+		for (int i = 0; i < 3; i++) {
+			RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(scale_gizmo_instance[i], false);
+			RenderingServer::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], false);
+		}
+		// Rotation white outline
+		RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], false);
+		return;
+	}
+
 	for (int i = 0; i < 3; i++) {
 		RenderingServer::get_singleton()->instance_set_transform(move_gizmo_instance[i], xform);
 		RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], spatial_editor->is_gizmo_visible() && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));

--- a/modules/fbx/data/fbx_material.h
+++ b/modules/fbx/data/fbx_material.h
@@ -217,9 +217,6 @@ struct FBXMaterial : public Reference {
 		{ "TransparencyFactor", PROPERTY_DESC_TRANSPARENT },
 		{ "Maya|opacity", PROPERTY_DESC_TRANSPARENT },
 
-		/* Metallic */
-		{ "Shininess", PROPERTY_DESC_METALLIC },
-		{ "Reflectivity", PROPERTY_DESC_METALLIC },
 		{ "Maya|metalness", PROPERTY_DESC_METALLIC },
 		{ "Maya|metallic", PROPERTY_DESC_METALLIC },
 
@@ -241,6 +238,8 @@ struct FBXMaterial : public Reference {
 		{ "Maya|emissionColor", PROPERTY_DESC_EMISSIVE_COLOR },
 
 		/* Ignore */
+		{ "Shininess", PROPERTY_DESC_IGNORE },
+		{ "Reflectivity", PROPERTY_DESC_IGNORE },
 		{ "Maya|diffuseRoughness", PROPERTY_DESC_IGNORE },
 		{ "Maya", PROPERTY_DESC_IGNORE },
 		{ "Diffuse", PROPERTY_DESC_ALBEDO_COLOR },

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1253,7 +1253,8 @@ void RendererSceneCull::_update_instance(Instance *p_instance) {
 		scene_render->geometry_instance_set_transform(geom->geometry_instance, p_instance->transform, p_instance->aabb, p_instance->transformed_aabb);
 	}
 
-	if (p_instance->scenario == nullptr || !p_instance->visible || Math::is_zero_approx(p_instance->transform.basis.determinant())) {
+	// note: we had to remove is equal approx check here, it meant that det == 0.000004 won't work, which is the case for some of our scenes.
+	if (p_instance->scenario == nullptr || !p_instance->visible || p_instance->transform.basis.determinant() == 0) {
 		p_instance->prev_transformed_aabb = p_instance->transformed_aabb;
 		return;
 	}


### PR DESCRIPTION
Fixes:
- #44655 fbx files not working in latest release
- previous behavior was culling scale values of 0.01 and det == 0.00004. which were valid in FBX land, det was not == 0, but in the cases of actual det==0 scenario which can be reproduced with node_3d_editor_plugin you can see it actually has a det == 0.
- node_3d_editor_plugin was creating gizmos with transforms with det == 0, this is safe to do now due to this change, I have also fixed this for the gizmos but the grid still needs this to be done for it. This relies on absolute zero values to change visibility so I fixed this.
- fixed fbx material mappings going to metallic property

I debugged this by putting checks on det == zero.
I checked bistro fbx and it imports fine, no dropped geometry anymore even with 0.01 scaling and det == 0.00004.

debug build
![image](https://user-images.githubusercontent.com/748770/103316994-1cf39100-4a22-11eb-8e1c-ce5854d430d4.png)

release_debug build (cpu time halves :D)
![image](https://user-images.githubusercontent.com/748770/103317214-c33f9680-4a22-11eb-8a53-f859a86aa6aa.png)

without this PR

![image](https://user-images.githubusercontent.com/748770/103345721-1698ff80-4a8a-11eb-9f84-c2763f6ab246.png)
