### PR TITLE
Fix overwriting of Node3D's local space transform

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -226,6 +226,7 @@ void Node3D::_notification(int p_what) {
 void Node3D::set_transform(const Transform &p_transform) {
 	data.local_transform = p_transform;
 	data.dirty |= DIRTY_VECTORS;
+	data.dirty &= ~DIRTY_LOCAL;
 	_change_notify("translation");
 	_change_notify("rotation");
 	_change_notify("rotation_degrees");


### PR DESCRIPTION
Currently, when the `DIRTY_LOCAL` flag is set and a new transform is supplied using `set_transform`, the new transform may be overwritten the next time it is read, because the transform is reset using the Node3D's previous rotation and scale, even though the new transform should supersede those.

This PR modifies when the `DIRTY_LOCAL` flag is set to prevent a transform applied using `set_transform` being overwritten by any previous calls that changed the node's rotation, translation or scale.

Closes #43130

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
