### PR TITLE
bullet: Sync with upstream 3.08

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -22,7 +22,7 @@ Files extracted from upstream source:
 ## bullet
 
 - Upstream: https://github.com/bulletphysics/bullet3
-- Version: 3.07 (e32fc59c88a3908876949c6f2665e8d091d987fa, 2020)
+- Version: 3.08 (df09fd9ed37e365ceae884ca7f620b61607dae2e, 2020)
 - License: zlib
 
 Files extracted from upstream source:

--- a/thirdparty/bullet/BulletDynamics/Featherstone/btMultiBody.cpp
+++ b/thirdparty/bullet/BulletDynamics/Featherstone/btMultiBody.cpp
@@ -125,7 +125,8 @@ btMultiBody::btMultiBody(int n_links,
 	  m_posVarCnt(0),
 	  m_useRK4(false),
 	  m_useGlobalVelocities(false),
-	  m_internalNeedsJointFeedback(false)
+	  m_internalNeedsJointFeedback(false),
+		m_kinematic_calculate_velocity(false)
 {
 	m_cachedInertiaTopLeft.setValue(0, 0, 0, 0, 0, 0, 0, 0, 0);
 	m_cachedInertiaTopRight.setValue(0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -2381,7 +2382,7 @@ const char *btMultiBody::serialize(void *dataBuffer, class btSerializer *seriali
 void btMultiBody::saveKinematicState(btScalar timeStep)
 {
 	//todo: clamp to some (user definable) safe minimum timestep, to limit maximum angular/linear velocities
-	if (timeStep != btScalar(0.))
+	if (m_kinematic_calculate_velocity && timeStep != btScalar(0.))
 	{
 		btVector3 linearVelocity, angularVelocity;
 		btTransformUtil::calculateVelocity(getInterpolateBaseWorldTransform(), getBaseWorldTransform(), timeStep, linearVelocity, angularVelocity);

--- a/thirdparty/bullet/BulletDynamics/Featherstone/btMultiBody.h
+++ b/thirdparty/bullet/BulletDynamics/Featherstone/btMultiBody.h
@@ -823,6 +823,9 @@ private:
 
 	///the m_needsJointFeedback gets updated/computed during the stepVelocitiesMultiDof and it for internal usage only
 	bool m_internalNeedsJointFeedback;
+
+  //If enabled, calculate the velocity based on kinematic transform changes. Currently only implemented for the base.
+	bool m_kinematic_calculate_velocity;
 };
 
 struct btMultiBodyLinkDoubleData

--- a/thirdparty/bullet/LinearMath/btQuickprof.cpp
+++ b/thirdparty/bullet/LinearMath/btQuickprof.cpp
@@ -720,6 +720,9 @@ void btLeaveProfileZoneDefault()
   #define BT_HAVE_TLS 1
 #elif __linux__
   #define BT_HAVE_TLS 1
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+  // TODO: At the moment disabling purposely OpenBSD, albeit tls support exists but not fully functioning
+  #define BT_HAVE_TLS 1
 #endif
 
 // __thread is broken on Andorid clang until r12b. See

--- a/thirdparty/bullet/LinearMath/btScalar.h
+++ b/thirdparty/bullet/LinearMath/btScalar.h
@@ -25,7 +25,7 @@ subject to the following restrictions:
 #include <float.h>
 
 /* SVN $Revision$ on $Date$ from http://bullet.googlecode.com*/
-#define BT_BULLET_VERSION 307
+#define BT_BULLET_VERSION 308
 
 inline int btGetVersion()
 {

--- a/thirdparty/bullet/LinearMath/btSerializer.h
+++ b/thirdparty/bullet/LinearMath/btSerializer.h
@@ -481,7 +481,7 @@ public:
 
 		buffer[9] = '3';
 		buffer[10] = '0';
-		buffer[11] = '7';
+		buffer[11] = '8';
 	}
 
 	virtual void startSerialization()


### PR DESCRIPTION
Should probably have been 3.07.1, it doesn't change much.