### PR TITLE
Increase number of sections in object files for tests with MSVC

### DIFF
--- a/tests/SCsub
+++ b/tests/SCsub
@@ -17,6 +17,11 @@ if env["module_gdnative_enabled"]:
 if env_tests["platform"] == "windows":
     env_tests.Append(CPPDEFINES=[("DOCTEST_THREAD_LOCAL", "")])
 
+# Increase number of addressable sections in object files
+# due to doctest's heavy use of templates and macros.
+if env_tests.msvc:
+    env_tests.Append(CCFLAGS=["/bigobj"])
+
 env_tests.add_source_files(env.tests_sources, "*.cpp")
 
 lib = env_tests.add_library("tests", env.tests_sources)


### PR DESCRIPTION
Enables [`/bigobj`](https://docs.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=msvc-160) on MSVC for tests.

Needed by #44594 and #44274.

It was reported that this issue starts to occur with `target=release_debug tests=yes`.

doctest uses a lot of templates and macros which are expanded when compiled, using subcases and parameterized tests (fixtures?) can likely increase the object size a lot, and we start to have more tests now...

Quote from MSVC docs:

> Most modules never generate an .obj file that contains more than 65,279 sections. However, machine-generated code, or code that makes heavy use of template libraries, may require .obj files that can hold more sections.
