### PR TITLE
Use zero-indexing for physics and render layer names

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -619,245 +619,245 @@
 		<member name="input_devices/pointing/ios/touch_delay" type="float" setter="" getter="" default="0.15">
 			Default delay for touch events. This only affects iOS devices.
 		</member>
+		<member name="layer_names/2d_physics/layer_0" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 0. If left empty, the layer will display as "Layer 0".
+		</member>
 		<member name="layer_names/2d_physics/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 1.
+			Optional name for the 2D physics layer 1. If left empty, the layer will display as "Layer 1".
 		</member>
 		<member name="layer_names/2d_physics/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 10.
+			Optional name for the 2D physics layer 10. If left empty, the layer will display as "Layer 10".
 		</member>
 		<member name="layer_names/2d_physics/layer_11" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 11.
+			Optional name for the 2D physics layer 11. If left empty, the layer will display as "Layer 11".
 		</member>
 		<member name="layer_names/2d_physics/layer_12" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 12.
+			Optional name for the 2D physics layer 12. If left empty, the layer will display as "Layer 12".
 		</member>
 		<member name="layer_names/2d_physics/layer_13" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 13.
+			Optional name for the 2D physics layer 13. If left empty, the layer will display as "Layer 13".
 		</member>
 		<member name="layer_names/2d_physics/layer_14" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 14.
+			Optional name for the 2D physics layer 14. If left empty, the layer will display as "Layer 14".
 		</member>
 		<member name="layer_names/2d_physics/layer_15" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 15.
+			Optional name for the 2D physics layer 15. If left empty, the layer will display as "Layer 15".
 		</member>
 		<member name="layer_names/2d_physics/layer_16" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 16.
+			Optional name for the 2D physics layer 16. If left empty, the layer will display as "Layer 16".
 		</member>
 		<member name="layer_names/2d_physics/layer_17" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 17.
+			Optional name for the 2D physics layer 17. If left empty, the layer will display as "Layer 17".
 		</member>
 		<member name="layer_names/2d_physics/layer_18" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 18.
+			Optional name for the 2D physics layer 18. If left empty, the layer will display as "Layer 18".
 		</member>
 		<member name="layer_names/2d_physics/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 19.
+			Optional name for the 2D physics layer 19. If left empty, the layer will display as "Layer 19".
 		</member>
 		<member name="layer_names/2d_physics/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 2.
-		</member>
-		<member name="layer_names/2d_physics/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 20.
+			Optional name for the 2D physics layer 2. If left empty, the layer will display as "Layer 2".
 		</member>
 		<member name="layer_names/2d_physics/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 3.
+			Optional name for the 2D physics layer 3. If left empty, the layer will display as "Layer 3".
 		</member>
 		<member name="layer_names/2d_physics/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 4.
+			Optional name for the 2D physics layer 4. If left empty, the layer will display as "Layer 4".
 		</member>
 		<member name="layer_names/2d_physics/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 5.
+			Optional name for the 2D physics layer 5. If left empty, the layer will display as "Layer 5".
 		</member>
 		<member name="layer_names/2d_physics/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 6.
+			Optional name for the 2D physics layer 6. If left empty, the layer will display as "Layer 6".
 		</member>
 		<member name="layer_names/2d_physics/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 7.
+			Optional name for the 2D physics layer 7. If left empty, the layer will display as "Layer 7".
 		</member>
 		<member name="layer_names/2d_physics/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 8.
+			Optional name for the 2D physics layer 8. If left empty, the layer will display as "Layer 8".
 		</member>
 		<member name="layer_names/2d_physics/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 9.
+			Optional name for the 2D physics layer 9. If left empty, the layer will display as "Layer 9".
+		</member>
+		<member name="layer_names/2d_render/layer_0" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 0. If left empty, the layer will display as "Layer 0".
 		</member>
 		<member name="layer_names/2d_render/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 1.
+			Optional name for the 2D render layer 1. If left empty, the layer will display as "Layer 1".
 		</member>
 		<member name="layer_names/2d_render/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 10.
+			Optional name for the 2D render layer 10. If left empty, the layer will display as "Layer 10".
 		</member>
 		<member name="layer_names/2d_render/layer_11" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 11.
+			Optional name for the 2D render layer 11. If left empty, the layer will display as "Layer 11".
 		</member>
 		<member name="layer_names/2d_render/layer_12" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 12.
+			Optional name for the 2D render layer 12. If left empty, the layer will display as "Layer 12".
 		</member>
 		<member name="layer_names/2d_render/layer_13" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 13.
+			Optional name for the 2D render layer 13. If left empty, the layer will display as "Layer 13".
 		</member>
 		<member name="layer_names/2d_render/layer_14" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 14.
+			Optional name for the 2D render layer 14. If left empty, the layer will display as "Layer 14".
 		</member>
 		<member name="layer_names/2d_render/layer_15" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 15.
+			Optional name for the 2D render layer 15. If left empty, the layer will display as "Layer 15".
 		</member>
 		<member name="layer_names/2d_render/layer_16" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 16.
+			Optional name for the 2D render layer 16. If left empty, the layer will display as "Layer 16".
 		</member>
 		<member name="layer_names/2d_render/layer_17" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 17.
+			Optional name for the 2D render layer 17. If left empty, the layer will display as "Layer 17".
 		</member>
 		<member name="layer_names/2d_render/layer_18" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 18.
+			Optional name for the 2D render layer 18. If left empty, the layer will display as "Layer 18".
 		</member>
 		<member name="layer_names/2d_render/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 19.
+			Optional name for the 2D render layer 19. If left empty, the layer will display as "Layer 19".
 		</member>
 		<member name="layer_names/2d_render/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 2.
-		</member>
-		<member name="layer_names/2d_render/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 20.
+			Optional name for the 2D render layer 2. If left empty, the layer will display as "Layer 2".
 		</member>
 		<member name="layer_names/2d_render/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 3.
+			Optional name for the 2D render layer 3. If left empty, the layer will display as "Layer 3".
 		</member>
 		<member name="layer_names/2d_render/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 4.
+			Optional name for the 2D render layer 4. If left empty, the layer will display as "Layer 4".
 		</member>
 		<member name="layer_names/2d_render/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 5.
+			Optional name for the 2D render layer 5. If left empty, the layer will display as "Layer 5".
 		</member>
 		<member name="layer_names/2d_render/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 6.
+			Optional name for the 2D render layer 6. If left empty, the layer will display as "Layer 6".
 		</member>
 		<member name="layer_names/2d_render/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 7.
+			Optional name for the 2D render layer 7. If left empty, the layer will display as "Layer 7".
 		</member>
 		<member name="layer_names/2d_render/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 8.
+			Optional name for the 2D render layer 8. If left empty, the layer will display as "Layer 8".
 		</member>
 		<member name="layer_names/2d_render/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 9.
+			Optional name for the 2D render layer 9. If left empty, the layer will display as "Layer 9".
+		</member>
+		<member name="layer_names/3d_physics/layer_0" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 0. If left empty, the layer will display as "Layer 0".
 		</member>
 		<member name="layer_names/3d_physics/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 1.
+			Optional name for the 3D physics layer 1. If left empty, the layer will display as "Layer 1".
 		</member>
 		<member name="layer_names/3d_physics/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 10.
+			Optional name for the 3D physics layer 10. If left empty, the layer will display as "Layer 10".
 		</member>
 		<member name="layer_names/3d_physics/layer_11" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 11.
+			Optional name for the 3D physics layer 11. If left empty, the layer will display as "Layer 11".
 		</member>
 		<member name="layer_names/3d_physics/layer_12" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 12.
+			Optional name for the 3D physics layer 12. If left empty, the layer will display as "Layer 12".
 		</member>
 		<member name="layer_names/3d_physics/layer_13" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 13.
+			Optional name for the 3D physics layer 13. If left empty, the layer will display as "Layer 13".
 		</member>
 		<member name="layer_names/3d_physics/layer_14" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 14.
+			Optional name for the 3D physics layer 14. If left empty, the layer will display as "Layer 14".
 		</member>
 		<member name="layer_names/3d_physics/layer_15" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 15.
+			Optional name for the 3D physics layer 15. If left empty, the layer will display as "Layer 15".
 		</member>
 		<member name="layer_names/3d_physics/layer_16" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 16.
+			Optional name for the 3D physics layer 16. If left empty, the layer will display as "Layer 16".
 		</member>
 		<member name="layer_names/3d_physics/layer_17" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 17.
+			Optional name for the 3D physics layer 17. If left empty, the layer will display as "Layer 17".
 		</member>
 		<member name="layer_names/3d_physics/layer_18" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 18.
+			Optional name for the 3D physics layer 18. If left empty, the layer will display as "Layer 18".
 		</member>
 		<member name="layer_names/3d_physics/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 19.
+			Optional name for the 3D physics layer 19. If left empty, the layer will display as "Layer 19".
 		</member>
 		<member name="layer_names/3d_physics/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 2.
-		</member>
-		<member name="layer_names/3d_physics/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 20.
+			Optional name for the 3D physics layer 2. If left empty, the layer will display as "Layer 2".
 		</member>
 		<member name="layer_names/3d_physics/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 3.
+			Optional name for the 3D physics layer 3. If left empty, the layer will display as "Layer 3".
 		</member>
 		<member name="layer_names/3d_physics/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 4.
+			Optional name for the 3D physics layer 4. If left empty, the layer will display as "Layer 4".
 		</member>
 		<member name="layer_names/3d_physics/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 5.
+			Optional name for the 3D physics layer 5. If left empty, the layer will display as "Layer 5".
 		</member>
 		<member name="layer_names/3d_physics/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 6.
+			Optional name for the 3D physics layer 6. If left empty, the layer will display as "Layer 6".
 		</member>
 		<member name="layer_names/3d_physics/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 7.
+			Optional name for the 3D physics layer 7. If left empty, the layer will display as "Layer 7".
 		</member>
 		<member name="layer_names/3d_physics/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 8.
+			Optional name for the 3D physics layer 8. If left empty, the layer will display as "Layer 8".
 		</member>
 		<member name="layer_names/3d_physics/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 9.
+			Optional name for the 3D physics layer 9. If left empty, the layer will display as "Layer 9".
+		</member>
+		<member name="layer_names/3d_render/layer_0" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 0. If left empty, the layer will display as "Layer 0".
 		</member>
 		<member name="layer_names/3d_render/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 1.
+			Optional name for the 3D render layer 1. If left empty, the layer will display as "Layer 1".
 		</member>
 		<member name="layer_names/3d_render/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 10.
+			Optional name for the 3D render layer 10. If left empty, the layer will display as "Layer 10".
 		</member>
 		<member name="layer_names/3d_render/layer_11" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 11.
+			Optional name for the 3D render layer 11. If left empty, the layer will display as "Layer 11".
 		</member>
 		<member name="layer_names/3d_render/layer_12" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 12.
+			Optional name for the 3D render layer 12. If left empty, the layer will display as "Layer 12".
 		</member>
 		<member name="layer_names/3d_render/layer_13" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 13.
+			Optional name for the 3D render layer 13. If left empty, the layer will display as "Layer 13".
 		</member>
 		<member name="layer_names/3d_render/layer_14" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 14
+			Optional name for the 3D render layer 14. If left empty, the layer will display as "Layer 14"
 		</member>
 		<member name="layer_names/3d_render/layer_15" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 15.
+			Optional name for the 3D render layer 15. If left empty, the layer will display as "Layer 15".
 		</member>
 		<member name="layer_names/3d_render/layer_16" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 16.
+			Optional name for the 3D render layer 16. If left empty, the layer will display as "Layer 16".
 		</member>
 		<member name="layer_names/3d_render/layer_17" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 17.
+			Optional name for the 3D render layer 17. If left empty, the layer will display as "Layer 17".
 		</member>
 		<member name="layer_names/3d_render/layer_18" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 18.
+			Optional name for the 3D render layer 18. If left empty, the layer will display as "Layer 18".
 		</member>
 		<member name="layer_names/3d_render/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 19.
+			Optional name for the 3D render layer 19. If left empty, the layer will display as "Layer 19".
 		</member>
 		<member name="layer_names/3d_render/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 2.
-		</member>
-		<member name="layer_names/3d_render/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 20.
+			Optional name for the 3D render layer 2. If left empty, the layer will display as "Layer 2".
 		</member>
 		<member name="layer_names/3d_render/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 3.
+			Optional name for the 3D render layer 3. If left empty, the layer will display as "Layer 3".
 		</member>
 		<member name="layer_names/3d_render/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 4.
+			Optional name for the 3D render layer 4. If left empty, the layer will display as "Layer 4".
 		</member>
 		<member name="layer_names/3d_render/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 5.
+			Optional name for the 3D render layer 5. If left empty, the layer will display as "Layer 5".
 		</member>
 		<member name="layer_names/3d_render/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 6.
+			Optional name for the 3D render layer 6. If left empty, the layer will display as "Layer 6".
 		</member>
 		<member name="layer_names/3d_render/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 7.
+			Optional name for the 3D render layer 7. If left empty, the layer will display as "Layer 7".
 		</member>
 		<member name="layer_names/3d_render/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 8.
+			Optional name for the 3D render layer 8. If left empty, the layer will display as "Layer 8".
 		</member>
 		<member name="layer_names/3d_render/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 9.
+			Optional name for the 3D render layer 9. If left empty, the layer will display as "Layer 9".
 		</member>
 		<member name="locale/fallback" type="String" setter="" getter="" default="&quot;en&quot;">
 			The locale to fall back to if a translation isn't available in a given language. If left empty, [code]en[/code] (English) will be used.

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -725,12 +725,12 @@ void EditorPropertyLayers::setup(LayerType p_layer_type) {
 	for (int i = 0; i < 20; i++) {
 		String name;
 
-		if (ProjectSettings::get_singleton()->has_setting(basename + "/layer_" + itos(i + 1))) {
-			name = ProjectSettings::get_singleton()->get(basename + "/layer_" + itos(i + 1));
+		if (ProjectSettings::get_singleton()->has_setting(basename + vformat("/layer_%d", i))) {
+			name = ProjectSettings::get_singleton()->get(basename + vformat("/layer_%d", i));
 		}
 
 		if (name == "") {
-			name = TTR("Layer") + " " + itos(i + 1);
+			name = vformat(TTR("Layer %d"), i);
 		}
 
 		names.push_back(name);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -936,10 +936,10 @@ void register_scene_types() {
 	OS::get_singleton()->yield(); //may take time to init
 
 	for (int i = 0; i < 20; i++) {
-		GLOBAL_DEF("layer_names/2d_render/layer_" + itos(i + 1), "");
-		GLOBAL_DEF("layer_names/2d_physics/layer_" + itos(i + 1), "");
-		GLOBAL_DEF("layer_names/3d_render/layer_" + itos(i + 1), "");
-		GLOBAL_DEF("layer_names/3d_physics/layer_" + itos(i + 1), "");
+		GLOBAL_DEF(vformat("layer_names/2d_render/layer_%d", i), "");
+		GLOBAL_DEF(vformat("layer_names/2d_physics/layer_%d", i), "");
+		GLOBAL_DEF(vformat("layer_names/3d_render/layer_%d", i), "");
+		GLOBAL_DEF(vformat("layer_names/3d_physics/layer_%d", i), "");
 	}
 
 	bool default_theme_hidpi = GLOBAL_DEF("gui/theme/use_hidpi", false);


### PR DESCRIPTION
The first layer is now Layer 0 instead of Layer 1, and the last layer is now Layer 19 instead of Layer 20.

This helps reference physics and render layers from scripts since layers start from 0 there.

This breaks compatibility in a subtle way since layer name project settings will need to be modified. Also, this might confuse users during an upgrade so I'd suggest merging this only in `master`.

This closes https://github.com/godotengine/godot-proposals/issues/2050.