### PR TITLE
Do not clear materials when setting mesh

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -112,7 +112,6 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 
 	if (mesh.is_valid()) {
 		mesh->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance3D::_mesh_changed));
-		materials.clear();
 	}
 
 	mesh = p_mesh;


### PR DESCRIPTION
Fixes #44714.
Please note that, in the event of a reduction in the number of material slots, excess materials will still be cleared.