### PR TITLE
GDScript crash at incomplete const bug fix

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -976,6 +976,8 @@ GDScriptParser::ConstantNode *GDScriptParser::parse_constant() {
 			push_error(R"(Expected initializer expression for constant.)");
 			return nullptr;
 		}
+	} else {
+		return nullptr;
 	}
 
 	end_statement("constant declaration");


### PR DESCRIPTION
Fix: #44810

Even Minimal reproduction project:
```gdscript
const CONST_VALU ## <-- now add the 'E' here
func f():
    print(CONST_VALUE) ## <-- this line cause the bug
```