### PR TITLE
Zero-initialize new elements when resizing Vector

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -32,6 +32,7 @@
 #define COWDATA_H
 
 #include "core/error/error_macros.h"
+#include "core/os/copymem.h"
 #include "core/os/memory.h"
 #include "core/templates/safe_refcount.h"
 
@@ -297,6 +298,8 @@ Error CowData<T>::resize(int p_size) {
 			for (int i = *_get_size(); i < p_size; i++) {
 				memnew_placement(&elems[i], T);
 			}
+		} else {
+			zeromem((void *)(_get_data() + current_size), (p_size - current_size) * sizeof(T));
 		}
 
 		*_get_size() = p_size;


### PR DESCRIPTION
Related: https://github.com/godotengine/godot-proposals/issues/2023

I decided to zero-initialize elements in `resize()` instead as it requires the least changes. I'm not sure if it has any noticeable impact on performance though.

Test code:

```gdscript
extends MainLoop

func _process(_delta: float) -> bool:
	var arr := PackedByteArray()
	arr.resize(10)
	printt("A", var2str(arr))
	for i in 10:
		arr[i] = i
	printt("B", var2str(arr))
	arr.resize(20)
	printt("C", var2str(arr))
	for i in 10:
		arr[i + 10] = i + 10
	printt("D", var2str(arr))
	return true
```

Output before (may vary):
```
A	PackedByteArray( 218, 164, 1, 94, 15, 84, 92, 10, 136, 52 )
B	PackedByteArray( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 )
C	PackedByteArray( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 239, 16, 248, 205, 155, 46, 0, 0, 0, 0 )
D	PackedByteArray( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 )
```

Output after:
```
A	PackedByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 )
B	PackedByteArray( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 )
C	PackedByteArray( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 )
D	PackedByteArray( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 )
```

Closes: #43033