### PR TITLE
Blocking updating in SceneTreeEditor when an item was selected

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -531,6 +531,10 @@ void SceneTreeEditor::_update_tree() {
 		return;
 	}
 
+	if (tree->is_editing()) {
+		return;
+	}
+
 	updating_tree = true;
 	tree->clear();
 	if (get_scene_node()) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2981,6 +2981,10 @@ bool Tree::edit_selected() {
 	return false;
 }
 
+bool Tree::is_editing() {
+	return popup_editor->is_visible();
+}
+
 Size2 Tree::get_internal_min_size() const {
 	Size2i size = cache.bg->get_offset();
 	if (root) {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -622,6 +622,7 @@ public:
 	int get_item_offset(TreeItem *p_item) const;
 	Rect2 get_item_rect(TreeItem *p_item, int p_column = -1) const;
 	bool edit_selected();
+	bool is_editing();
 
 	// First item that starts with the text, from the current focused item down and wraps around.
 	TreeItem *search_item_text(const String &p_find, int *r_col = nullptr, bool p_selectable = false);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes #44163

The problem is SceneTreeEditor will update itself when warnings had changed. It also will clean itself. So the editing action gets ignored because the selected TreeItem will get cleaned too.