### PR TITLE
OpenSimplex data optimization

### DIFF
--- a/modules/opensimplex/doc_classes/OpenSimplexNoise.xml
+++ b/modules/opensimplex/doc_classes/OpenSimplexNoise.xml
@@ -32,7 +32,7 @@
 			<argument index="1" name="height" type="int">
 			</argument>
 			<description>
-				Generate a noise image with the requested [code]width[/code] and [code]height[/code], based on the current noise parameters.
+				Generate a noise image in [constant Image.FORMAT_L8] format with the requested [code]width[/code] and [code]height[/code], based on the current noise parameters.
 			</description>
 		</method>
 		<method name="get_noise_1d" qualifiers="const">
@@ -108,7 +108,7 @@
 			<argument index="0" name="size" type="int">
 			</argument>
 			<description>
-				Generate a tileable noise image, based on the current noise parameters. Generated seamless images are always square ([code]size[/code] × [code]size[/code]).
+				Generate a tileable noise image in [constant Image.FORMAT_L8] format, based on the current noise parameters. Generated seamless images are always square ([code]size[/code] × [code]size[/code]).
 			</description>
 		</method>
 	</methods>

--- a/modules/opensimplex/open_simplex_noise.cpp
+++ b/modules/opensimplex/open_simplex_noise.cpp
@@ -104,7 +104,7 @@ void OpenSimplexNoise::set_lacunarity(float p_lacunarity) {
 
 Ref<Image> OpenSimplexNoise::get_image(int p_width, int p_height) const {
 	Vector<uint8_t> data;
-	data.resize(p_width * p_height * 4);
+	data.resize(p_width * p_height);
 
 	uint8_t *wd8 = data.ptrw();
 
@@ -112,21 +112,17 @@ Ref<Image> OpenSimplexNoise::get_image(int p_width, int p_height) const {
 		for (int j = 0; j < p_width; j++) {
 			float v = get_noise_2d(j, i);
 			v = v * 0.5 + 0.5; // Normalize [0..1]
-			uint8_t value = uint8_t(CLAMP(v * 255.0, 0, 255));
-			wd8[(i * p_width + j) * 4 + 0] = value;
-			wd8[(i * p_width + j) * 4 + 1] = value;
-			wd8[(i * p_width + j) * 4 + 2] = value;
-			wd8[(i * p_width + j) * 4 + 3] = 255;
+			wd8[(i * p_width + j)] = uint8_t(CLAMP(v * 255.0, 0, 255));
 		}
 	}
 
-	Ref<Image> image = memnew(Image(p_width, p_height, false, Image::FORMAT_RGBA8, data));
+	Ref<Image> image = memnew(Image(p_width, p_height, false, Image::FORMAT_L8, data));
 	return image;
 }
 
 Ref<Image> OpenSimplexNoise::get_seamless_image(int p_size) const {
 	Vector<uint8_t> data;
-	data.resize(p_size * p_size * 4);
+	data.resize(p_size * p_size);
 
 	uint8_t *wd8 = data.ptrw();
 
@@ -147,15 +143,11 @@ Ref<Image> OpenSimplexNoise::get_seamless_image(int p_size) const {
 			float v = get_noise_4d(x, y, z, w);
 
 			v = v * 0.5 + 0.5; // Normalize [0..1]
-			uint8_t value = uint8_t(CLAMP(v * 255.0, 0, 255));
-			wd8[(i * p_size + j) * 4 + 0] = value;
-			wd8[(i * p_size + j) * 4 + 1] = value;
-			wd8[(i * p_size + j) * 4 + 2] = value;
-			wd8[(i * p_size + j) * 4 + 3] = 255;
+			wd8[(i * p_size + j)] = uint8_t(CLAMP(v * 255.0, 0, 255));
 		}
 	}
 
-	Ref<Image> image = memnew(Image(p_size, p_size, false, Image::FORMAT_RGBA8, data));
+	Ref<Image> image = memnew(Image(p_size, p_size, false, Image::FORMAT_L8, data));
 	return image;
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

# What Changed?
The images created in `Image::get_texture()` and `Image::get_seamless_image()` were changed from `FORMAT_RGBA8` to `FORMAT_L8`. As a result, the code responsible for allocating and generating values for the redundant memory has been removed.

# Explanation:
For every data point (pixel) in OpenSimplex images:
- Alpha is always 255
- Red == Green == Blue

The Alpha and redundant RGB data can be safely omitted without losing noise data used for the generated image.

---

Discussion source: https://www.reddit.com/r/godot/comments/klawh0/opensimplexnoiseget_image_overhead_intended/
Credit should go to /u/TheHumbleDM for finding/squashing this one!