### PR TITLE
Fix window restoring after fullscreen again

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -417,7 +417,7 @@ private:
 	void _drag_event(WindowID p_window, float p_x, float p_y, int idx);
 	void _touch_event(WindowID p_window, bool p_pressed, float p_x, float p_y, int idx);
 
-	void _update_window_style(WindowID p_window, bool p_repaint = true, bool p_maximized = false);
+	void _update_window_style(WindowID p_window, bool p_repaint = true);
 	void _update_window_mouse_passthrough(WindowID p_window);
 
 	void _update_real_mouse_position(WindowID p_window);


### PR DESCRIPTION
Fix restoring window after fullscreen (originally introduced by #33112) which currently broken on the master, 

Also fixes the editor window that becomes invisible when ALT+TAB is used while fullscreen mode (by adding `WS_VISIBLE` flag for non-borderless windows).
