### PR TITLE
Do not iterate over map when removing its values

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1024,7 +1024,9 @@ void TileMap::update_dirty_bitmask() {
 
 void TileMap::fix_invalid_tiles() {
 	ERR_FAIL_COND_MSG(tile_set.is_null(), "Cannot fix invalid tiles if Tileset is not open.");
-	for (Map<PosKey, Cell>::Element *E = tile_map.front(); E; E = E->next()) {
+
+	Map<PosKey, Cell> temp_tile_map = tile_map;
+	for (Map<PosKey, Cell>::Element *E = temp_tile_map.front(); E; E = E->next()) {
 		if (!tile_set->has_tile(get_cell(E->key().x, E->key().y))) {
 			set_cell(E->key().x, E->key().y, INVALID_CELL);
 		}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/44822
Fixes https://github.com/godotengine/godot/issues/42252

Values in for loop may become invalid, because some were removed inside `set_cell` function.

Items shouldn't be added or removed to a collection when it is used