### PR TITLE
SSAO renames and move push constant binding

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -2134,7 +2134,16 @@ RID RenderingDeviceVulkan::texture_create_shared_from_slice(const TextureView &p
 		VK_IMAGE_VIEW_TYPE_2D,
 	};
 
-	image_view_create_info.viewType = p_slice_type == TEXTURE_SLICE_CUBEMAP ? VK_IMAGE_VIEW_TYPE_CUBE : (p_slice_type == TEXTURE_SLICE_3D ? VK_IMAGE_VIEW_TYPE_3D : view_types[texture.type]);
+	image_view_create_info.viewType = view_types[texture.type];
+
+	if (p_slice_type == TEXTURE_SLICE_CUBEMAP) {
+		image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
+	} else if (p_slice_type == TEXTURE_SLICE_3D) {
+		image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_3D;
+	} else if (p_slice_type == TEXTURE_SLICE_2D_ARRAY) {
+		image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+	}
+
 	if (p_view.format_override == DATA_FORMAT_MAX || p_view.format_override == texture.format) {
 		image_view_create_info.format = vulkan_formats[texture.format];
 	} else {

--- a/servers/rendering/renderer_rd/effects_rd.h
+++ b/servers/rendering/renderer_rd/effects_rd.h
@@ -745,9 +745,9 @@ public:
 		float fadeout_from = 50.0;
 		float fadeout_to = 300.0;
 
-		Size2i screen_size = Size2i();
+		Size2i full_screen_size = Size2i();
 		Size2i half_screen_size = Size2i();
-		Size2i quarter_size = Size2i();
+		Size2i quarter_screen_size = Size2i();
 	};
 
 	void tonemapper(RID p_source_color, RID p_dst_framebuffer, const TonemapSettings &p_settings);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -5329,9 +5329,9 @@ void RendererSceneRenderRD::_process_ssao(RID p_render_buffers, RID p_environmen
 	settings.blur_passes = ssao_blur_passes;
 	settings.fadeout_from = ssao_fadeout_from;
 	settings.fadeout_to = ssao_fadeout_to;
-	settings.screen_size = Size2i(rb->width, rb->height);
+	settings.full_screen_size = Size2i(rb->width, rb->height);
 	settings.half_screen_size = Size2i(buffer_width, buffer_height);
-	settings.quarter_size = Size2i(half_width, half_height);
+	settings.quarter_screen_size = Size2i(half_width, half_height);
 
 	storage->get_effects()->generate_ssao(rb->depth_texture, p_normal_buffer, rb->ssao.depth, rb->ssao.depth_slices, rb->ssao.ao_deinterleaved, rb->ssao.ao_deinterleaved_slices, rb->ssao.ao_pong, rb->ssao.ao_pong_slices, rb->ssao.ao_final, rb->ssao.importance_map[0], rb->ssao.importance_map[1], p_projection, settings, uniform_sets_are_invalid);
 }

--- a/servers/rendering/renderer_rd/shaders/ssao.glsl
+++ b/servers/rendering/renderer_rd/shaders/ssao.glsl
@@ -88,7 +88,7 @@ counter;
 layout(rg8, set = 2, binding = 0) uniform restrict writeonly image2D dest_image;
 
 // This push_constant is full - 128 bytes - if you need to add more data, consider adding to the uniform buffer instead
-layout(push_constant, binding = 1, std430) uniform Params {
+layout(push_constant, binding = 3, std430) uniform Params {
 	ivec2 screen_size;
 	int pass;
 	int quality;


### PR DESCRIPTION
Fixes: #44666

1)
Turns out some changes I made to the texture_from_slice function were accidentally creating IMAGE_2D views instead of IMAGE_2D_ARRAY views. On Intel and AMD the drivers forgave my unfortunate mistake. However, on NVidia, the driver forced me to own up to my mistakes. 

The result of that mistake was that only 1 of the 4 deinterleaved buffers was written to. The others contained uninitialized memory. When all 4 buffers were combined we get the glitchy errors in #44666

Tested this fix on GTX 740m (turns out I still had an NVidia device laying around).

2)
Some renames to keep the code consistent and high quality. 

3)
Change the binding for the push constant in the gather pass so it doesn't conflict with the normal buffer. I thought this might have been the cause of #44666 but it wasnt. Either way, the change makes it more correct.