### PR TITLE
Use `static const int` instead of `#define` for OpenSimplexNoise octaves

### DIFF
--- a/modules/opensimplex/open_simplex_noise.h
+++ b/modules/opensimplex/open_simplex_noise.h
@@ -37,14 +37,14 @@
 
 #include "thirdparty/misc/open-simplex-noise.h"
 
-// The maximum number of octaves allowed. Note that these are statically allocated.
-// Higher values become exponentially slower, so this shouldn't be set too high
-// to avoid freezing the editor for long periods of time.
-#define MAX_OCTAVES 9
-
 class OpenSimplexNoise : public Resource {
 	GDCLASS(OpenSimplexNoise, Resource);
 	OBJ_SAVE_TYPE(OpenSimplexNoise);
+
+	// The maximum number of octaves allowed. Note that these are statically allocated.
+	// Higher values become exponentially slower, so this shouldn't be set too high
+	// to avoid freezing the editor for long periods of time.
+	static const int MAX_OCTAVES = 9;
 
 	osn_context contexts[MAX_OCTAVES];
 


### PR DESCRIPTION
This closes #44860.