### PR TITLE
Increase the page size for array/dictionary editors to 20

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -573,8 +573,7 @@ void EditorPropertyArray::_bind_methods() {
 
 EditorPropertyArray::EditorPropertyArray() {
 	object.instance();
-	page_idx = 0;
-	page_len = 10;
+	page_len = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
 	edit = memnew(Button);
 	edit->set_flat(true);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1069,8 +1068,7 @@ void EditorPropertyDictionary::_bind_methods() {
 
 EditorPropertyDictionary::EditorPropertyDictionary() {
 	object.instance();
-	page_idx = 0;
-	page_len = 10;
+	page_len = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
 	edit = memnew(Button);
 	edit->set_flat(true);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -84,8 +84,8 @@ class EditorPropertyArray : public EditorProperty {
 	bool dropping;
 
 	Ref<EditorPropertyArrayObject> object;
-	int page_len;
-	int page_idx;
+	int page_len = 20;
+	int page_idx = 0;
 	int changing_type_idx;
 	Button *edit;
 	VBoxContainer *vbox;
@@ -129,8 +129,8 @@ class EditorPropertyDictionary : public EditorProperty {
 	bool updating;
 
 	Ref<EditorPropertyDictionaryObject> object;
-	int page_len;
-	int page_idx;
+	int page_len = 20;
+	int page_idx = 0;
 	int changing_type_idx;
 	Button *edit;
 	VBoxContainer *vbox;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -381,6 +381,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/hide_console_window", false);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression
 
+	// Inspector
+	_initial_set("interface/inspector/max_array_dictionary_items_per_page", 20);
+	hints["interface/inspector/max_array_dictionary_items_per_page"] = PropertyInfo(Variant::INT, "interface/inspector/max_array_dictionary_items_per_page", PROPERTY_HINT_RANGE, "10,100,1", PROPERTY_USAGE_DEFAULT);
+
 	// Theme
 	_initial_set("interface/theme/preset", "Default");
 	hints["interface/theme/preset"] = PropertyInfo(Variant::STRING, "interface/theme/preset", PROPERTY_HINT_ENUM, "Default,Alien,Arc,Godot 2,Grey,Light,Solarized (Dark),Solarized (Light),Custom", PROPERTY_USAGE_DEFAULT);


### PR DESCRIPTION
With smaller arrays/dictionaries, this makes it possible to view all of an array/dictionary's items on a single page.

Larger values could be used, but make switching between node selections quite slow, especially on low-end CPUs. They could also be problematic with complex resource inspectors for arrays/dictionaries that contain Resources.

The change is trivially cherry-pickable to `3.2` and has been tested there.

This closes https://github.com/godotengine/godot-proposals/issues/2058.