### PR TITLE
Type generic interface

### DIFF
--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -160,7 +160,249 @@ typedef struct {
 
 #include <gdnative/gdnative.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if __STDC_VERSION__ >= 201112L
+
+#define godot_packed_array_new(r_dest)                                  \
+    _Generic((r_dest),                                                  \
+        godot_packed_byte_array*:    godot_packed_byte_array_new,       \
+        godot_packed_int_array*:     godot_packed_int_array_new,        \
+        godot_packed_real_array*:    godot_packed_real_array_new,       \
+        godot_packed_string_array*:  godot_packed_string_array_new,     \
+        godot_packed_vector2_array*: godot_packed_vector2_array_new,    \
+        godot_packed_vector3_array*: godot_packed_vector3_array_new,    \
+        godot_packed_color_array*:   godot_packed_color_array_new)      \
+    ((r_dest))
+
+
+#define godot_packed_array_new_copy(r_dest, p_src)                       \
+    _Generic((r_dest),                                                   \
+        godot_packed_byte_array*:    godot_packed_byte_array_new_copy,   \
+        godot_packed_int_array*:     godot_packed_int_array_new_copy,    \
+        godot_packed_real_array*:    godot_packed_real_array_new_copy,   \
+        godot_packed_string_array*:  godot_packed_string_array_new_copy, \
+        godot_packed_vector2_array*: godot_packed_vector2_array_new_copy,\
+        godot_packed_vector3_array*: godot_packed_vector3_array_new_copy,\
+        godot_packed_color_array*:   godot_packed_color_array_new_copy)  \
+    ((r_dest), (p_src))
+
+
+#define godot_packed_array_new_with_array(r_dest, p_a)                          \
+    _Generic((r_dest),                                                          \
+        godot_packed_byte_array*:    godot_packed_byte_array_new_with_array,    \
+        godot_packed_int_array*:     godot_packed_int_array_new_with_array,     \
+        godot_packed_real_array*:    godot_packed_real_array_new_with_array,    \
+        godot_packed_string_array*:  godot_packed_string_array_new_with_array,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_new_with_array, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_new_with_array, \
+        godot_packed_color_array*:   godot_packed_color_array_new_with_array)   \
+    ((r_dest), (p_a))
+
+
+#define godot_packed_array_append(p_self, p_data)                      \
+    _Generic((p_self),                                                 \
+        godot_packed_byte_array*:    godot_packed_byte_array_append,   \
+        godot_packed_int_array*:     godot_packed_int_array_append,    \
+        godot_packed_real_array*:    godot_packed_real_array_append,   \
+        godot_packed_string_array*:  godot_packed_string_array_append, \
+        godot_packed_vector2_array*: godot_packed_vector2_array_append,\
+        godot_packed_vector3_array*: godot_packed_vector3_array_append,\
+        godot_packed_color_array*:   godot_packed_color_array_append)  \
+    ((p_self), (p_data))
+
+
+#define godot_packed_array_append_array(p_self, p_array)                      \
+    _Generic((p_self),                                                        \
+        godot_packed_byte_array*:    godot_packed_byte_array_append_array,    \
+        godot_packed_int_array*:     godot_packed_int_array_append_array,     \
+        godot_packed_real_array*:    godot_packed_real_array_append_array,    \
+        godot_packed_string_array*:  godot_packed_string_array_append_array,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_append_array, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_append_array, \
+        godot_packed_color_array*:   godot_packed_color_array_append_array)   \
+    ((p_self), (p_array))
+
+
+#define godot_packed_array_insert(p_self, p_idx, p_data)                \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array*:    godot_packed_byte_array_insert,    \
+        godot_packed_int_array*:     godot_packed_int_array_insert,     \
+        godot_packed_real_array*:    godot_packed_real_array_insert,    \
+        godot_packed_string_array*:  godot_packed_string_array_insert,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_insert, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_insert, \
+        godot_packed_color_array*:   godot_packed_color_array_insert)   \
+    ((p_self), (p_idx), (p_data))
+
+
+#define godot_packed_array_invert(p_self)                               \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array*:    godot_packed_byte_array_invert,    \
+        godot_packed_int_array*:     godot_packed_int_array_invert,     \
+        godot_packed_real_array*:    godot_packed_real_array_invert,    \
+        godot_packed_string_array*:  godot_packed_string_array_invert,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_invert, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_invert, \
+        godot_packed_color_array*:   godot_packed_color_array_invert)   \
+    ((p_self))
+
+
+#define godot_packed_array_push_back(p_self, p_data)                        \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array*:    godot_packed_byte_array_push_back,     \
+        godot_packed_int_array*:     godot_packed_int_array_push_back,      \
+        godot_packed_real_array*:    godot_packed_real_array_push_back,     \
+        godot_packed_string_array*:  godot_packed_string_array_push_back,   \
+        godot_packed_vector2_array*: godot_packed_vector2_array_push_back,  \
+        godot_packed_vector3_array*: godot_packed_vector3_array_push_back,  \
+        godot_packed_color_array*:   godot_packed_color_array_push_back)    \
+    ((p_self), (p_data))
+
+
+#define godot_packed_array_remove(p_self, p_idx)                        \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array*:    godot_packed_byte_array_remove,    \
+        godot_packed_int_array*:     godot_packed_int_array_remove,     \
+        godot_packed_real_array*:    godot_packed_real_array_remove,    \
+        godot_packed_string_array*:  godot_packed_string_array_remove,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_remove, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_remove, \
+        godot_packed_color_array*:   godot_packed_color_array_remove)   \
+    ((p_self), (p_idx))
+
+
+#define godot_packed_array_resize(p_self, p_size)                           \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array*:    godot_packed_byte_array_resize,        \
+        godot_packed_int_array*:     godot_packed_int_array_resize,         \
+        godot_packed_real_array*:    godot_packed_real_array_resize,        \
+        godot_packed_string_array*:  godot_packed_string_array_resize,      \
+        godot_packed_vector2_array*: godot_packed_vector2_array_resize,     \
+        godot_packed_vector3_array*: godot_packed_vector3_array_resize,     \
+        godot_packed_color_array*:   godot_packed_color_array_resize)       \
+    ((p_self), (p_size))
+
+
+#define godot_packed_array_read(p_self)                                 \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array*:    godot_packed_byte_array_read,      \
+        godot_packed_int_array*:     godot_packed_int_array_read,       \
+        godot_packed_real_array*:    godot_packed_real_array_read,      \
+        godot_packed_string_array*:  godot_packed_string_array_read,    \
+        godot_packed_vector2_array*: godot_packed_vector2_array_read,   \
+        godot_packed_vector3_array*: godot_packed_vector3_array_read,   \
+        godot_packed_color_array*:   godot_packed_color_array_read)     \
+    ((p_self))
+
+
+#define godot_packed_array_write(p_self)                                \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array*:    godot_packed_byte_array_write,     \
+        godot_packed_int_array*:     godot_packed_int_array_write,      \
+        godot_packed_real_array*:    godot_packed_real_array_write,     \
+        godot_packed_string_array*:  godot_packed_string_array_write,   \
+        godot_packed_vector2_array*: godot_packed_vector2_array_write,  \
+        godot_packed_vector3_array*: godot_packed_vector3_array_write,  \
+        godot_packed_color_array*:   godot_packed_color_array_write)    \
+    ((p_self))
+
+
+#define godot_packed_array_set(p_self, p_idx, p_data)                \
+    _Generic((p_self),                                               \
+        godot_packed_byte_array*:    godot_packed_byte_array_set,    \
+        godot_packed_int_array*:     godot_packed_int_array_set,     \
+        godot_packed_real_array*:    godot_packed_real_array_set,    \
+        godot_packed_string_array*:  godot_packed_string_array_set,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_set, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_set, \
+        godot_packed_color_array*:   godot_packed_color_array_set)   \
+    ((p_self), (p_idx), (p_data))
+
+
+#define godot_packed_array_get(p_self, p_idx)                        \
+    _Generic((p_self),                                               \
+        godot_packed_byte_array*:    godot_packed_byte_array_get,    \
+        godot_packed_int_array*:     godot_packed_int_array_get,     \
+        godot_packed_real_array*:    godot_packed_real_array_get,    \
+        godot_packed_string_array*:  godot_packed_string_array_get,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_get, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_get, \
+        godot_packed_color_array*:   godot_packed_color_array_get)   \
+    ((p_self), (p_idx))
+
+
+#define godot_packed_array_size(p_self)                               \
+    _Generic((p_self),                                                \
+        godot_packed_byte_array*:    godot_packed_byte_array_size,    \
+        godot_packed_int_array*:     godot_packed_int_array_size,     \
+        godot_packed_real_array*:    godot_packed_real_array_size,    \
+        godot_packed_string_array*:  godot_packed_string_array_size,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_size, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_size, \
+        godot_packed_color_array*:   godot_packed_color_array_size)   \
+    ((p_self))
+
+
+#define godot_packed_array_empty(p_self)                               \
+    _Generic((p_self),                                                 \
+        godot_packed_byte_array*:    godot_packed_byte_array_empty,    \
+        godot_packed_int_array*:     godot_packed_int_array_empty,     \
+        godot_packed_real_array*:    godot_packed_real_array_empty,    \
+        godot_packed_string_array*:  godot_packed_string_array_empty,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_empty, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_empty, \
+        godot_packed_color_array*:   godot_packed_color_array_empty)   \
+    ((p_self))
+
+
+#define godot_packed_array_destroy(p_self)                               \
+    _Generic((p_self),                                                   \
+        godot_packed_byte_array*:    godot_packed_byte_array_destroy,    \
+        godot_packed_int_array*:     godot_packed_int_array_destroy,     \
+        godot_packed_real_array*:    godot_packed_real_array_destroy,    \
+        godot_packed_string_array*:  godot_packed_string_array_destroy,  \
+        godot_packed_vector2_array*: godot_packed_vector2_array_destroy, \
+        godot_packed_vector3_array*: godot_packed_vector3_array_destroy, \
+        godot_packed_color_array*:   godot_packed_color_array_destroy)   \
+    ((p_self))
+
+#endif
+
 // Byte.
+void GDAPI godot_packed_byte_array_new(godot_packed_byte_array *r_dest);
+void GDAPI godot_packed_byte_array_new_copy(godot_packed_byte_array *r_dest, const godot_packed_byte_array *p_src);
+void GDAPI godot_packed_byte_array_new_with_array(godot_packed_byte_array *r_dest, const godot_array *p_a);
+
+const uint8_t GDAPI *godot_packed_byte_array_ptr(const godot_packed_byte_array *p_self);
+uint8_t GDAPI *godot_packed_byte_array_ptrw(godot_packed_byte_array *p_self);
+
+void GDAPI godot_packed_byte_array_append(godot_packed_byte_array *p_self, const uint8_t p_data);
+
+void GDAPI godot_packed_byte_array_append_array(godot_packed_byte_array *p_self, const godot_packed_byte_array *p_array);
+
+godot_error GDAPI godot_packed_byte_array_insert(godot_packed_byte_array *p_self, const godot_int p_idx, const uint8_t p_data);
+
+godot_bool GDAPI godot_packed_byte_array_has(godot_packed_byte_array *p_self, const uint8_t p_value);
+
+void GDAPI godot_packed_byte_array_sort(godot_packed_byte_array *p_self);
+
+void GDAPI godot_packed_byte_array_invert(godot_packed_byte_array *p_self);
+
+void GDAPI godot_packed_byte_array_push_back(godot_packed_byte_array *p_self, const uint8_t p_data);
+
+void GDAPI godot_packed_byte_array_remove(godot_packed_byte_array *p_self, const godot_int p_idx);
+
+void GDAPI godot_packed_byte_array_resize(godot_packed_byte_array *p_self, const godot_int p_size);
+
+void GDAPI godot_packed_byte_array_set(godot_packed_byte_array *p_self, const godot_int p_idx, const uint8_t p_data);
+uint8_t GDAPI godot_packed_byte_array_get(const godot_packed_byte_array *p_self, const godot_int p_idx);
+
+godot_int GDAPI godot_packed_byte_array_size(const godot_packed_byte_array *p_self);
+
+godot_bool GDAPI godot_packed_byte_array_is_empty(const godot_packed_byte_array *p_self);
 
 void GDAPI godot_packed_byte_array_new(godot_packed_byte_array *p_self);
 void GDAPI godot_packed_byte_array_destroy(godot_packed_byte_array *p_self);

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -332,7 +332,7 @@ extern "C" {
         godot_packed_vector2i_array *:godot_packed_vector2i_array_push_back,\
         godot_packed_vector3_array *:godot_packed_vector3_array_push_back,\
         godot_packed_color_array *:godot_packed_color_array_push_back)\
-    (p_self)
+    ((p_self), (p_data))
 
 #define godot_packed_array_remove(p_self, p_idx)                            \
     _Generic((p_self),                                                      \
@@ -360,7 +360,7 @@ extern "C" {
         godot_packed_vector2i_array *:godot_packed_vector2i_array_resize,   \
         godot_packed_vector3_array *:godot_packed_vector3_array_resize,     \
         godot_packed_color_array *:godot_packed_color_array_resize)         \
-    ((p_self))
+    ((p_self), (p_size))
 
 #define godot_packed_array_set(p_self, p_idx, p_data)                   \
     _Generic((p_self),                                                  \

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -168,205 +168,268 @@ extern "C" {
 
 #define godot_packed_array_new(r_dest)                                  \
     _Generic((r_dest),                                                  \
-        godot_packed_byte_array*:    godot_packed_byte_array_new,       \
-        godot_packed_int_array*:     godot_packed_int_array_new,        \
-        godot_packed_real_array*:    godot_packed_real_array_new,       \
-        godot_packed_string_array*:  godot_packed_string_array_new,     \
-        godot_packed_vector2_array*: godot_packed_vector2_array_new,    \
-        godot_packed_vector3_array*: godot_packed_vector3_array_new,    \
-        godot_packed_color_array*:   godot_packed_color_array_new)      \
+        godot_packed_byte_array *:godot_packed_byte_byte_array_new,             \
+        godot_packed_int32_array *:godot_packed_int32_int32_array_new,          \
+        godot_packed_int64_array *:godot_packed_int64_int64_array_new,          \
+        godot_packed_float32_array *:godot_packed_float32_float32_array_new,    \
+        godot_packed_float64_array *:godot_packed_float64_float64_array_new,    \
+        godot_packed_string_array *:godot_packed_string_string_array_new,       \
+        godot_packed_vector2_array *:godot_packed_vector2_vector2_array_new,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_vector2i_array_new, \
+        godot_packed_vector3_array *:godot_packed_vector3_vector3_array_new,    \
+        godot_packed_color_array *:godot_packed_color_color_array_new)          \
     ((r_dest))
 
-
-#define godot_packed_array_new_copy(r_dest, p_src)                       \
-    _Generic((r_dest),                                                   \
-        godot_packed_byte_array*:    godot_packed_byte_array_new_copy,   \
-        godot_packed_int_array*:     godot_packed_int_array_new_copy,    \
-        godot_packed_real_array*:    godot_packed_real_array_new_copy,   \
-        godot_packed_string_array*:  godot_packed_string_array_new_copy, \
-        godot_packed_vector2_array*: godot_packed_vector2_array_new_copy,\
-        godot_packed_vector3_array*: godot_packed_vector3_array_new_copy,\
-        godot_packed_color_array*:   godot_packed_color_array_new_copy)  \
+#define godot_packed_array_new_copy(r_dest, p_src)                                  \
+    _Generic((p_src),                                                               \
+        godot_packed_byte_array *:godot_packed_byte_byte_array_new_copy,            \
+        godot_packed_int32_array *:godot_packed_int32_int32_array_new_copy,         \
+        godot_packed_int64_array *:godot_packed_int64_int64_array_new_copy,         \
+        godot_packed_float32_array *:godot_packed_float32_float32_array_new_copy,   \
+        godot_packed_float64_array *:godot_packed_float64_float64_array_new_copy,   \
+        godot_packed_string_array *:godot_packed_string_string_array_new_copy,      \
+        godot_packed_vector2_array *:godot_packed_vector2_vector2_array_new_copy,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_vector2i_array_new_copy,\
+        godot_packed_vector3_array *:godot_packed_vector3_vector3_array_new_copy,   \
+        godot_packed_color_array *:godot_packed_color_color_array_new_copy)         \
     ((r_dest), (p_src))
 
-
-#define godot_packed_array_new_with_array(r_dest, p_a)                          \
-    _Generic((r_dest),                                                          \
-        godot_packed_byte_array*:    godot_packed_byte_array_new_with_array,    \
-        godot_packed_int_array*:     godot_packed_int_array_new_with_array,     \
-        godot_packed_real_array*:    godot_packed_real_array_new_with_array,    \
-        godot_packed_string_array*:  godot_packed_string_array_new_with_array,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_new_with_array, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_new_with_array, \
-        godot_packed_color_array*:   godot_packed_color_array_new_with_array)   \
+#define godot_packed_array_new_with_array(r_dest, p_a)                                      \
+    _Generic((r_dest),                                                                      \
+        godot_packed_byte_array *:godot_packed_byte_byte_array_new_with_array,              \
+        godot_packed_int32_array *:godot_packed_int32_int32_array_new_with_array,           \
+        godot_packed_int64_array *:godot_packed_int64_int64_array_new_with_array,           \
+        godot_packed_float32_array *:godot_packed_float32_float32_array_new_with_array,     \
+        godot_packed_float64_array *:godot_packed_float64_float64_array_new_with_array,     \
+        godot_packed_string_array *:godot_packed_string_string_array_new_with_array,        \
+        godot_packed_vector2_array *:godot_packed_vector2_vector2_array_new_with_array,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_vector2i_array_new_with_array,  \
+        godot_packed_vector3_array *:godot_packed_vector3_vector3_array_new_with_array,     \
+        godot_packed_color_array *:godot_packed_color_color_array_new_with_array)           \
     ((r_dest), (p_a))
 
-
-#define godot_packed_array_append(p_self, p_data)                      \
-    _Generic((p_self),                                                 \
-        godot_packed_byte_array*:    godot_packed_byte_array_append,   \
-        godot_packed_int_array*:     godot_packed_int_array_append,    \
-        godot_packed_real_array*:    godot_packed_real_array_append,   \
-        godot_packed_string_array*:  godot_packed_string_array_append, \
-        godot_packed_vector2_array*: godot_packed_vector2_array_append,\
-        godot_packed_vector3_array*: godot_packed_vector3_array_append,\
-        godot_packed_color_array*:   godot_packed_color_array_append)  \
-    ((p_self), (p_data))
-
-
-#define godot_packed_array_append_array(p_self, p_array)                      \
-    _Generic((p_self),                                                        \
-        godot_packed_byte_array*:    godot_packed_byte_array_append_array,    \
-        godot_packed_int_array*:     godot_packed_int_array_append_array,     \
-        godot_packed_real_array*:    godot_packed_real_array_append_array,    \
-        godot_packed_string_array*:  godot_packed_string_array_append_array,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_append_array, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_append_array, \
-        godot_packed_color_array*:   godot_packed_color_array_append_array)   \
-    ((p_self), (p_array))
-
-
-#define godot_packed_array_insert(p_self, p_idx, p_data)                \
-    _Generic((p_self),                                                  \
-        godot_packed_byte_array*:    godot_packed_byte_array_insert,    \
-        godot_packed_int_array*:     godot_packed_int_array_insert,     \
-        godot_packed_real_array*:    godot_packed_real_array_insert,    \
-        godot_packed_string_array*:  godot_packed_string_array_insert,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_insert, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_insert, \
-        godot_packed_color_array*:   godot_packed_color_array_insert)   \
-    ((p_self), (p_idx), (p_data))
-
-
-#define godot_packed_array_invert(p_self)                               \
-    _Generic((p_self),                                                  \
-        godot_packed_byte_array*:    godot_packed_byte_array_invert,    \
-        godot_packed_int_array*:     godot_packed_int_array_invert,     \
-        godot_packed_real_array*:    godot_packed_real_array_invert,    \
-        godot_packed_string_array*:  godot_packed_string_array_invert,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_invert, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_invert, \
-        godot_packed_color_array*:   godot_packed_color_array_invert)   \
+#define godot_packed_array_ptr(p_self)                          \
+    _Generic((p_self),                                          \
+godot_packed_byte_array *:godot_packed_byte_array_ptr,          \
+godot_packed_int32_array *:godot_packed_int32_array_ptr,        \
+godot_packed_int64_array *:godot_packed_int64_array_ptr,        \
+godot_packed_float32_array *:godot_packed_float32_array_ptr,    \
+godot_packed_float64_array *:godot_packed_float64_array_ptr,    \
+godot_packed_string_array *:godot_packed_string_array_ptr,      \
+godot_packed_vector2_array *:godot_packed_vector2_array_ptr,    \
+godot_packed_vector2i_array *:godot_packed_vector2i_array_ptr,  \
+godot_packed_vector3_array *:godot_packed_vector3_array_ptr,    \
+godot_packed_color_array *:godot_packed_color_array_ptr)        \
     ((p_self))
 
+#define godot_packed_array_ptrw(p_self)                         \
+    _Generic((),                                                \
+godot_packed_byte_array *:godot_packed_byte_array_ptrw,         \
+godot_packed_int32_array *:godot_packed_int32_array_ptrw,       \
+godot_packed_int64_array *:godot_packed_int64_array_ptrw,       \
+godot_packed_float32_array *:godot_packed_float32_array_ptrw,   \
+godot_packed_float64_array *:godot_packed_float64_array_ptrw,   \
+godot_packed_string_array *:godot_packed_string_array_ptrw,     \
+godot_packed_vector2_array *:godot_packed_vector2_array_ptrw,   \
+godot_packed_vector2i_array *:godot_packed_vector2i_array_ptrw, \
+godot_packed_vector3_array *:godot_packed_vector3_array_ptrw,   \
+godot_packed_color_array *:godot_packed_color_array_ptrw)       \
+    ((p_self))
 
-#define godot_packed_array_push_back(p_self, p_data)                        \
-    _Generic((p_self),                                                      \
-        godot_packed_byte_array*:    godot_packed_byte_array_push_back,     \
-        godot_packed_int_array*:     godot_packed_int_array_push_back,      \
-        godot_packed_real_array*:    godot_packed_real_array_push_back,     \
-        godot_packed_string_array*:  godot_packed_string_array_push_back,   \
-        godot_packed_vector2_array*: godot_packed_vector2_array_push_back,  \
-        godot_packed_vector3_array*: godot_packed_vector3_array_push_back,  \
-        godot_packed_color_array*:   godot_packed_color_array_push_back)    \
+#define godot_packed_array_append(p_self, p_data)                   \
+    _Generic((p_self),                                              \
+godot_packed_byte_array *:godot_packed_byte_array_append,           \
+godot_packed_int32_array *:godot_packed_int32_array_append,         \
+godot_packed_int64_array *:godot_packed_int64_array_append,         \
+godot_packed_float32_array *:godot_packed_float32_array_append,     \
+godot_packed_float64_array *:godot_packed_float64_array_append,     \
+godot_packed_string_array *:godot_packed_string_array_append,       \
+godot_packed_vector2_array *:godot_packed_vector2_array_append,     \
+godot_packed_vector2i_array *:godot_packed_vector2i_array_append,   \
+godot_packed_vector3_array *:godot_packed_vector3_array_append,     \
+godot_packed_color_array *:godot_packed_color_array_append)         \
     ((p_self), (p_data))
 
-
-#define godot_packed_array_remove(p_self, p_idx)                        \
+#define godot_packed_array_append_array(p_self, p_array)                \
     _Generic((p_self),                                                  \
-        godot_packed_byte_array*:    godot_packed_byte_array_remove,    \
-        godot_packed_int_array*:     godot_packed_int_array_remove,     \
-        godot_packed_real_array*:    godot_packed_real_array_remove,    \
-        godot_packed_string_array*:  godot_packed_string_array_remove,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_remove, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_remove, \
-        godot_packed_color_array*:   godot_packed_color_array_remove)   \
-    ((p_self), (p_idx))
+godot_packed_byte_array *:godot_packed_byte_array_append_array,         \
+godot_packed_int32_array *:godot_packed_int32_array_append_array,       \
+godot_packed_int64_array *:godot_packed_int64_array_append_array,       \
+godot_packed_float32_array *:godot_packed_float32_array_append_array,   \
+godot_packed_float64_array *:godot_packed_float64_array_append_array,   \
+godot_packed_string_array *:godot_packed_string_array_append_array,     \
+godot_packed_vector2_array *:godot_packed_vector2_array_append_array,   \
+godot_packed_vector2i_array *:godot_packed_vector2i_array_append_array, \
+godot_packed_vector3_array *:godot_packed_vector3_array_append_array,   \
+godot_packed_color_array *:godot_packed_color_array_append_array)       \
+    ((p_self), (p_array))
 
+#define godot_packed_array_insert(p_self, p_data)                           \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_insert,           \
+        godot_packed_int32_array *:godot_packed_int32_array_insert,         \
+        godot_packed_int64_array *:godot_packed_int64_array_insert,         \
+        godot_packed_float32_array *:godot_packed_float32_array_insert,     \
+        godot_packed_float64_array *:godot_packed_float64_array_insert,     \
+        godot_packed_string_array *:godot_packed_string_array_insert,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_insert,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_insert,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_insert,     \
+        godot_packed_color_array *:godot_packed_color_array_insert)         \
+    ((p_self), (p_data))
+
+#define godot_packed_array_has(p_self, p_value)                         \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_has,          \
+        godot_packed_int32_array *:godot_packed_int32_array_has,        \
+        godot_packed_int64_array *:godot_packed_int64_array_has,        \
+        godot_packed_float32_array *:godot_packed_float32_array_has,    \
+        godot_packed_float64_array *:godot_packed_float64_array_has,    \
+        godot_packed_string_array *:godot_packed_string_array_has,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_has,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_has,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_has,    \
+        godot_packed_color_array *:godot_packed_color_array_has)        \
+    ((p_self), (p_value))
+
+#define godot_packed_array_sort(p_self)                                 \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_sort,         \
+        godot_packed_int32_array *:godot_packed_int32_array_sort,       \
+        godot_packed_int64_array *:godot_packed_int64_array_sort,       \
+        godot_packed_float32_array *:godot_packed_float32_array_sort,   \
+        godot_packed_float64_array *:godot_packed_float64_array_sort,   \
+        godot_packed_string_array *:godot_packed_string_array_sort,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_sort,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_sort, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_sort,   \
+        godot_packed_color_array *:godot_packed_color_array_sort)       \
+    ((p_self))
+
+#define godot_packed_array_invert(p_self)                                   \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_invert,           \
+        godot_packed_int32_array *:godot_packed_int32_array_invert,         \
+        godot_packed_int64_array *:godot_packed_int64_array_invert,         \
+        godot_packed_float32_array *:godot_packed_float32_array_invert,     \
+        godot_packed_float64_array *:godot_packed_float64_array_invert,     \
+        godot_packed_string_array *:godot_packed_string_array_invert,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_invert,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_invert,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_invert,     \
+        godot_packed_color_array *:godot_packed_color_array_invert)         \
+    ((p_self))
+
+#define godot_packed_array_push_back(p_self, p_data) \
+    _Generic((p_self),\
+        godot_packed_byte_array *:godot_packed_byte_array_push_back,\
+        godot_packed_int32_array *:godot_packed_int32_array_push_back,\
+        godot_packed_int64_array *:godot_packed_int64_array_push_back,\
+        godot_packed_float32_array *:godot_packed_float32_array_push_back,\
+        godot_packed_float64_array *:godot_packed_float64_array_push_back,\
+        godot_packed_string_array *:godot_packed_string_array_push_back,\
+        godot_packed_vector2_array *:godot_packed_vector2_array_push_back,\
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_push_back,\
+        godot_packed_vector3_array *:godot_packed_vector3_array_push_back,\
+        godot_packed_color_array *:godot_packed_color_array_push_back)\
+    (p_self)
+
+#define godot_packed_array_remove(p_self, p_idx)                            \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_remove,           \
+        godot_packed_int32_array *:godot_packed_int32_array_remove,         \
+        godot_packed_int64_array *:godot_packed_int64_array_remove,         \
+        godot_packed_float32_array *:godot_packed_float32_array_remove,     \
+        godot_packed_float64_array *:godot_packed_float64_array_remove,     \
+        godot_packed_string_array *:godot_packed_string_array_remove,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_remove,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_remove,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_remove,     \
+        godot_packed_color_array *:godot_packed_color_array_remove)         \
+    ((p_self))
 
 #define godot_packed_array_resize(p_self, p_size)                           \
     _Generic((p_self),                                                      \
-        godot_packed_byte_array*:    godot_packed_byte_array_resize,        \
-        godot_packed_int_array*:     godot_packed_int_array_resize,         \
-        godot_packed_real_array*:    godot_packed_real_array_resize,        \
-        godot_packed_string_array*:  godot_packed_string_array_resize,      \
-        godot_packed_vector2_array*: godot_packed_vector2_array_resize,     \
-        godot_packed_vector3_array*: godot_packed_vector3_array_resize,     \
-        godot_packed_color_array*:   godot_packed_color_array_resize)       \
-    ((p_self), (p_size))
-
-
-#define godot_packed_array_read(p_self)                                 \
-    _Generic((p_self),                                                  \
-        godot_packed_byte_array*:    godot_packed_byte_array_read,      \
-        godot_packed_int_array*:     godot_packed_int_array_read,       \
-        godot_packed_real_array*:    godot_packed_real_array_read,      \
-        godot_packed_string_array*:  godot_packed_string_array_read,    \
-        godot_packed_vector2_array*: godot_packed_vector2_array_read,   \
-        godot_packed_vector3_array*: godot_packed_vector3_array_read,   \
-        godot_packed_color_array*:   godot_packed_color_array_read)     \
+        godot_packed_byte_array *:godot_packed_byte_array_resize,           \
+        godot_packed_int32_array *:godot_packed_int32_array_resize,         \
+        godot_packed_int64_array *:godot_packed_int64_array_resize,         \
+        godot_packed_float32_array *:godot_packed_float32_array_resize,     \
+        godot_packed_float64_array *:godot_packed_float64_array_resize,     \
+        godot_packed_string_array *:godot_packed_string_array_resize,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_resize,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_resize,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_resize,     \
+        godot_packed_color_array *:godot_packed_color_array_resize)         \
     ((p_self))
 
-
-#define godot_packed_array_write(p_self)                                \
+#define godot_packed_array_set(p_self, p_idx, p_data)                   \
     _Generic((p_self),                                                  \
-        godot_packed_byte_array*:    godot_packed_byte_array_write,     \
-        godot_packed_int_array*:     godot_packed_int_array_write,      \
-        godot_packed_real_array*:    godot_packed_real_array_write,     \
-        godot_packed_string_array*:  godot_packed_string_array_write,   \
-        godot_packed_vector2_array*: godot_packed_vector2_array_write,  \
-        godot_packed_vector3_array*: godot_packed_vector3_array_write,  \
-        godot_packed_color_array*:   godot_packed_color_array_write)    \
-    ((p_self))
-
-
-#define godot_packed_array_set(p_self, p_idx, p_data)                \
-    _Generic((p_self),                                               \
-        godot_packed_byte_array*:    godot_packed_byte_array_set,    \
-        godot_packed_int_array*:     godot_packed_int_array_set,     \
-        godot_packed_real_array*:    godot_packed_real_array_set,    \
-        godot_packed_string_array*:  godot_packed_string_array_set,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_set, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_set, \
-        godot_packed_color_array*:   godot_packed_color_array_set)   \
+        godot_packed_byte_array *:godot_packed_byte_array_set,          \
+        godot_packed_int32_array *:godot_packed_int32_array_set,        \
+        godot_packed_int64_array *:godot_packed_int64_array_set,        \
+        godot_packed_float32_array *:godot_packed_float32_array_set,    \
+        godot_packed_float64_array *:godot_packed_float64_array_set,    \
+        godot_packed_string_array *:godot_packed_string_array_set,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_set,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_set,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_set,    \
+        godot_packed_color_array *:godot_packed_color_array_set)        \
     ((p_self), (p_idx), (p_data))
 
-
-#define godot_packed_array_get(p_self, p_idx)                        \
-    _Generic((p_self),                                               \
-        godot_packed_byte_array*:    godot_packed_byte_array_get,    \
-        godot_packed_int_array*:     godot_packed_int_array_get,     \
-        godot_packed_real_array*:    godot_packed_real_array_get,    \
-        godot_packed_string_array*:  godot_packed_string_array_get,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_get, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_get, \
-        godot_packed_color_array*:   godot_packed_color_array_get)   \
+#define godot_packed_array_get(p_self, p_idx)                           \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_get,          \
+        godot_packed_int32_array *:godot_packed_int32_array_get,        \
+        godot_packed_int64_array *:godot_packed_int64_array_get,        \
+        godot_packed_float32_array *:godot_packed_float32_array_get,    \
+        godot_packed_float64_array *:godot_packed_float64_array_get,    \
+        godot_packed_string_array *:godot_packed_string_array_get,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_get,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_get,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_get,    \
+        godot_packed_color_array *:godot_packed_color_array_get)        \
     ((p_self), (p_idx))
 
-
-#define godot_packed_array_size(p_self)                               \
-    _Generic((p_self),                                                \
-        godot_packed_byte_array*:    godot_packed_byte_array_size,    \
-        godot_packed_int_array*:     godot_packed_int_array_size,     \
-        godot_packed_real_array*:    godot_packed_real_array_size,    \
-        godot_packed_string_array*:  godot_packed_string_array_size,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_size, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_size, \
-        godot_packed_color_array*:   godot_packed_color_array_size)   \
+#define godot_packed_array_size(p_self)                                 \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_size,         \
+        godot_packed_int32_array *:godot_packed_int32_array_size,       \
+        godot_packed_int64_array *:godot_packed_int64_array_size,       \
+        godot_packed_float32_array *:godot_packed_float32_array_size,   \
+        godot_packed_float64_array *:godot_packed_float64_array_size,   \
+        godot_packed_string_array *:godot_packed_string_array_size,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_size,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_size, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_size,   \
+        godot_packed_color_array *:godot_packed_color_array_size)       \
     ((p_self))
 
-
-#define godot_packed_array_empty(p_self)                               \
-    _Generic((p_self),                                                 \
-        godot_packed_byte_array*:    godot_packed_byte_array_empty,    \
-        godot_packed_int_array*:     godot_packed_int_array_empty,     \
-        godot_packed_real_array*:    godot_packed_real_array_empty,    \
-        godot_packed_string_array*:  godot_packed_string_array_empty,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_empty, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_empty, \
-        godot_packed_color_array*:   godot_packed_color_array_empty)   \
+#define godot_packed_array_is_empty(p_self)                                 \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_is_empty,         \
+        godot_packed_int32_array *:godot_packed_int32_array_is_empty,       \
+        godot_packed_int64_array *:godot_packed_int64_array_is_empty,       \
+        godot_packed_float32_array *:godot_packed_float32_array_is_empty,   \
+        godot_packed_float64_array *:godot_packed_float64_array_is_empty,   \
+        godot_packed_string_array *:godot_packed_string_array_is_empty,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_is_empty,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_is_empty, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_is_empty,   \
+        godot_packed_color_array *:godot_packed_color_array_is_empty)       \
     ((p_self))
 
-
-#define godot_packed_array_destroy(p_self)                               \
-    _Generic((p_self),                                                   \
-        godot_packed_byte_array*:    godot_packed_byte_array_destroy,    \
-        godot_packed_int_array*:     godot_packed_int_array_destroy,     \
-        godot_packed_real_array*:    godot_packed_real_array_destroy,    \
-        godot_packed_string_array*:  godot_packed_string_array_destroy,  \
-        godot_packed_vector2_array*: godot_packed_vector2_array_destroy, \
-        godot_packed_vector3_array*: godot_packed_vector3_array_destroy, \
-        godot_packed_color_array*:   godot_packed_color_array_destroy)   \
+#define godot_packed_array_destroy(p_self)                                  \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_destroy,          \
+        godot_packed_int32_array *:godot_packed_int32_array_destroy,        \
+        godot_packed_int64_array *:godot_packed_int64_array_destroy,        \
+        godot_packed_float32_array *:godot_packed_float32_array_destroy,    \
+        godot_packed_float64_array *:godot_packed_float64_array_destroy,    \
+        godot_packed_string_array *:godot_packed_string_array_destroy,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_destroy,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_destroy,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_destroy,    \
+        godot_packed_color_array *:godot_packed_color_array_destroy)        \
     ((p_self))
 
 #endif

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -166,271 +166,442 @@ extern "C" {
 
 #if __STDC_VERSION__ >= 201112L
 
-#define godot_packed_array_new(r_dest)                                  \
-    _Generic((r_dest),                                                  \
-        godot_packed_byte_array *:godot_packed_byte_array_new,          \
-        godot_packed_int32_array *:godot_packed_int32_array_new,        \
-        godot_packed_int64_array *:godot_packed_int64_array_new,        \
-        godot_packed_float32_array *:godot_packed_float32_array_new,    \
-        godot_packed_float64_array *:godot_packed_float64_array_new,    \
-        godot_packed_string_array *:godot_packed_string_array_new,      \
-        godot_packed_vector2_array *:godot_packed_vector2_array_new,    \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_new,  \
-        godot_packed_vector3_array *:godot_packed_vector3_array_new,    \
-        godot_packed_color_array *:godot_packed_color_array_new)        \
-    ((r_dest))
+#define godot_packed_array_new(r_dest)          \
+	_Generic((r_dest),                          \
+			 godot_packed_byte_array *          \
+			 : godot_packed_byte_array_new,     \
+			 godot_packed_int32_array *         \
+			 : godot_packed_int32_array_new,    \
+			 godot_packed_int64_array *         \
+			 : godot_packed_int64_array_new,    \
+			 godot_packed_float32_array *       \
+			 : godot_packed_float32_array_new,  \
+			 godot_packed_float64_array *       \
+			 : godot_packed_float64_array_new,  \
+			 godot_packed_string_array *        \
+			 : godot_packed_string_array_new,   \
+			 godot_packed_vector2_array *       \
+			 : godot_packed_vector2_array_new,  \
+			 godot_packed_vector2i_array *      \
+			 : godot_packed_vector2i_array_new, \
+			 godot_packed_vector3_array *       \
+			 : godot_packed_vector3_array_new,  \
+			 godot_packed_color_array *         \
+			 : godot_packed_color_array_new)((r_dest))
 
-#define godot_packed_array_new_copy(r_dest, p_src)                          \
-    _Generic((p_src),                                                       \
-        godot_packed_byte_array *:godot_packed_byte_array_new_copy,         \
-        godot_packed_int32_array *:godot_packed_int32_array_new_copy,       \
-        godot_packed_int64_array *:godot_packed_int64_array_new_copy,       \
-        godot_packed_float32_array *:godot_packed_float32_array_new_copy,   \
-        godot_packed_float64_array *:godot_packed_float64_array_new_copy,   \
-        godot_packed_string_array *:godot_packed_string_array_new_copy,     \
-        godot_packed_vector2_array *:godot_packed_vector2_array_new_copy,   \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_new_copy, \
-        godot_packed_vector3_array *:godot_packed_vector3_array_new_copy,   \
-        godot_packed_color_array *:godot_packed_color_array_new_copy)       \
-    ((r_dest), (p_src))
+#define godot_packed_array_new_copy(r_dest, p_src)   \
+	_Generic((p_src),                                \
+			 godot_packed_byte_array *               \
+			 : godot_packed_byte_array_new_copy,     \
+			 godot_packed_int32_array *              \
+			 : godot_packed_int32_array_new_copy,    \
+			 godot_packed_int64_array *              \
+			 : godot_packed_int64_array_new_copy,    \
+			 godot_packed_float32_array *            \
+			 : godot_packed_float32_array_new_copy,  \
+			 godot_packed_float64_array *            \
+			 : godot_packed_float64_array_new_copy,  \
+			 godot_packed_string_array *             \
+			 : godot_packed_string_array_new_copy,   \
+			 godot_packed_vector2_array *            \
+			 : godot_packed_vector2_array_new_copy,  \
+			 godot_packed_vector2i_array *           \
+			 : godot_packed_vector2i_array_new_copy, \
+			 godot_packed_vector3_array *            \
+			 : godot_packed_vector3_array_new_copy,  \
+			 godot_packed_color_array *              \
+			 : godot_packed_color_array_new_copy)((r_dest), (p_src))
 
-#define godot_packed_array_new_with_array(r_dest, p_a)                              \
-    _Generic((r_dest),                                                              \
-        godot_packed_byte_array *:godot_packed_byte_array_new_with_array,           \
-        godot_packed_int32_array *:godot_packed_int32_array_new_with_array,         \
-        godot_packed_int64_array *:godot_packed_int64_array_new_with_array,         \
-        godot_packed_float32_array *:godot_packed_float32_array_new_with_array,     \
-        godot_packed_float64_array *:godot_packed_float64_array_new_with_array,     \
-        godot_packed_string_array *:godot_packed_string_array_new_with_array,       \
-        godot_packed_vector2_array *:godot_packed_vector2_array_new_with_array,     \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_new_with_array,   \
-        godot_packed_vector3_array *:godot_packed_vector3_array_new_with_array,     \
-        godot_packed_color_array *:godot_packed_color_array_new_with_array)         \
-    ((r_dest), (p_a))
+#define godot_packed_array_new_with_array(r_dest, p_a)     \
+	_Generic((r_dest),                                     \
+			 godot_packed_byte_array *                     \
+			 : godot_packed_byte_array_new_with_array,     \
+			 godot_packed_int32_array *                    \
+			 : godot_packed_int32_array_new_with_array,    \
+			 godot_packed_int64_array *                    \
+			 : godot_packed_int64_array_new_with_array,    \
+			 godot_packed_float32_array *                  \
+			 : godot_packed_float32_array_new_with_array,  \
+			 godot_packed_float64_array *                  \
+			 : godot_packed_float64_array_new_with_array,  \
+			 godot_packed_string_array *                   \
+			 : godot_packed_string_array_new_with_array,   \
+			 godot_packed_vector2_array *                  \
+			 : godot_packed_vector2_array_new_with_array,  \
+			 godot_packed_vector2i_array *                 \
+			 : godot_packed_vector2i_array_new_with_array, \
+			 godot_packed_vector3_array *                  \
+			 : godot_packed_vector3_array_new_with_array,  \
+			 godot_packed_color_array *                    \
+			 : godot_packed_color_array_new_with_array)((r_dest), (p_a))
 
-#define godot_packed_array_ptr(p_self)                                  \
-    _Generic((p_self),                                                  \
-        godot_packed_byte_array *:godot_packed_byte_array_ptr,          \
-        godot_packed_int32_array *:godot_packed_int32_array_ptr,        \
-        godot_packed_int64_array *:godot_packed_int64_array_ptr,        \
-        godot_packed_float32_array *:godot_packed_float32_array_ptr,    \
-        godot_packed_float64_array *:godot_packed_float64_array_ptr,    \
-        godot_packed_string_array *:godot_packed_string_array_ptr,      \
-        godot_packed_vector2_array *:godot_packed_vector2_array_ptr,    \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_ptr,  \
-        godot_packed_vector3_array *:godot_packed_vector3_array_ptr,    \
-        godot_packed_color_array *:godot_packed_color_array_ptr)        \
-    ((p_self))
+#define godot_packed_array_ptr(p_self)          \
+	_Generic((p_self),                          \
+			 godot_packed_byte_array *          \
+			 : godot_packed_byte_array_ptr,     \
+			 godot_packed_int32_array *         \
+			 : godot_packed_int32_array_ptr,    \
+			 godot_packed_int64_array *         \
+			 : godot_packed_int64_array_ptr,    \
+			 godot_packed_float32_array *       \
+			 : godot_packed_float32_array_ptr,  \
+			 godot_packed_float64_array *       \
+			 : godot_packed_float64_array_ptr,  \
+			 godot_packed_string_array *        \
+			 : godot_packed_string_array_ptr,   \
+			 godot_packed_vector2_array *       \
+			 : godot_packed_vector2_array_ptr,  \
+			 godot_packed_vector2i_array *      \
+			 : godot_packed_vector2i_array_ptr, \
+			 godot_packed_vector3_array *       \
+			 : godot_packed_vector3_array_ptr,  \
+			 godot_packed_color_array *         \
+			 : godot_packed_color_array_ptr)((p_self))
 
-#define godot_packed_array_ptrw(p_self)                                 \
-    _Generic((pself),                                                   \
-        godot_packed_byte_array *:godot_packed_byte_array_ptrw,         \
-        godot_packed_int32_array *:godot_packed_int32_array_ptrw,       \
-        godot_packed_int64_array *:godot_packed_int64_array_ptrw,       \
-        godot_packed_float32_array *:godot_packed_float32_array_ptrw,   \
-        godot_packed_float64_array *:godot_packed_float64_array_ptrw,   \
-        godot_packed_string_array *:godot_packed_string_array_ptrw,     \
-        godot_packed_vector2_array *:godot_packed_vector2_array_ptrw,   \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_ptrw, \
-        godot_packed_vector3_array *:godot_packed_vector3_array_ptrw,   \
-        godot_packed_color_array *:godot_packed_color_array_ptrw)       \
-    ((p_self))
+#define godot_packed_array_ptrw(p_self)          \
+	_Generic((pself),                            \
+			 godot_packed_byte_array *           \
+			 : godot_packed_byte_array_ptrw,     \
+			 godot_packed_int32_array *          \
+			 : godot_packed_int32_array_ptrw,    \
+			 godot_packed_int64_array *          \
+			 : godot_packed_int64_array_ptrw,    \
+			 godot_packed_float32_array *        \
+			 : godot_packed_float32_array_ptrw,  \
+			 godot_packed_float64_array *        \
+			 : godot_packed_float64_array_ptrw,  \
+			 godot_packed_string_array *         \
+			 : godot_packed_string_array_ptrw,   \
+			 godot_packed_vector2_array *        \
+			 : godot_packed_vector2_array_ptrw,  \
+			 godot_packed_vector2i_array *       \
+			 : godot_packed_vector2i_array_ptrw, \
+			 godot_packed_vector3_array *        \
+			 : godot_packed_vector3_array_ptrw,  \
+			 godot_packed_color_array *          \
+			 : godot_packed_color_array_ptrw)((p_self))
 
-#define godot_packed_array_append(p_self, p_data)                           \
-    _Generic((p_self),                                                      \
-        godot_packed_byte_array *:godot_packed_byte_array_append,           \
-        godot_packed_int32_array *:godot_packed_int32_array_append,         \
-        godot_packed_int64_array *:godot_packed_int64_array_append,         \
-        godot_packed_float32_array *:godot_packed_float32_array_append,     \
-        godot_packed_float64_array *:godot_packed_float64_array_append,     \
-        godot_packed_string_array *:godot_packed_string_array_append,       \
-        godot_packed_vector2_array *:godot_packed_vector2_array_append,     \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_append,   \
-        godot_packed_vector3_array *:godot_packed_vector3_array_append,     \
-        godot_packed_color_array *:godot_packed_color_array_append)         \
-    ((p_self), (p_data))
+#define godot_packed_array_append(p_self, p_data)  \
+	_Generic((p_self),                             \
+			 godot_packed_byte_array *             \
+			 : godot_packed_byte_array_append,     \
+			 godot_packed_int32_array *            \
+			 : godot_packed_int32_array_append,    \
+			 godot_packed_int64_array *            \
+			 : godot_packed_int64_array_append,    \
+			 godot_packed_float32_array *          \
+			 : godot_packed_float32_array_append,  \
+			 godot_packed_float64_array *          \
+			 : godot_packed_float64_array_append,  \
+			 godot_packed_string_array *           \
+			 : godot_packed_string_array_append,   \
+			 godot_packed_vector2_array *          \
+			 : godot_packed_vector2_array_append,  \
+			 godot_packed_vector2i_array *         \
+			 : godot_packed_vector2i_array_append, \
+			 godot_packed_vector3_array *          \
+			 : godot_packed_vector3_array_append,  \
+			 godot_packed_color_array *            \
+			 : godot_packed_color_array_append)((p_self), (p_data))
 
-#define godot_packed_array_append_array(p_self, p_array)                        \
-    _Generic((p_self),                                                          \
-        godot_packed_byte_array *:godot_packed_byte_array_append_array,         \
-        godot_packed_int32_array *:godot_packed_int32_array_append_array,       \
-        godot_packed_int64_array *:godot_packed_int64_array_append_array,       \
-        godot_packed_float32_array *:godot_packed_float32_array_append_array,   \
-        godot_packed_float64_array *:godot_packed_float64_array_append_array,   \
-        godot_packed_string_array *:godot_packed_string_array_append_array,     \
-        godot_packed_vector2_array *:godot_packed_vector2_array_append_array,   \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_append_array, \
-        godot_packed_vector3_array *:godot_packed_vector3_array_append_array,   \
-        godot_packed_color_array *:godot_packed_color_array_append_array)       \
-    ((p_self), (p_array))
+#define godot_packed_array_append_array(p_self, p_array) \
+	_Generic((p_self),                                   \
+			 godot_packed_byte_array *                   \
+			 : godot_packed_byte_array_append_array,     \
+			 godot_packed_int32_array *                  \
+			 : godot_packed_int32_array_append_array,    \
+			 godot_packed_int64_array *                  \
+			 : godot_packed_int64_array_append_array,    \
+			 godot_packed_float32_array *                \
+			 : godot_packed_float32_array_append_array,  \
+			 godot_packed_float64_array *                \
+			 : godot_packed_float64_array_append_array,  \
+			 godot_packed_string_array *                 \
+			 : godot_packed_string_array_append_array,   \
+			 godot_packed_vector2_array *                \
+			 : godot_packed_vector2_array_append_array,  \
+			 godot_packed_vector2i_array *               \
+			 : godot_packed_vector2i_array_append_array, \
+			 godot_packed_vector3_array *                \
+			 : godot_packed_vector3_array_append_array,  \
+			 godot_packed_color_array *                  \
+			 : godot_packed_color_array_append_array)((p_self), (p_array))
 
-#define godot_packed_array_insert(p_self, p_data)                           \
-    _Generic((p_self),                                                      \
-        godot_packed_byte_array *:godot_packed_byte_array_insert,           \
-        godot_packed_int32_array *:godot_packed_int32_array_insert,         \
-        godot_packed_int64_array *:godot_packed_int64_array_insert,         \
-        godot_packed_float32_array *:godot_packed_float32_array_insert,     \
-        godot_packed_float64_array *:godot_packed_float64_array_insert,     \
-        godot_packed_string_array *:godot_packed_string_array_insert,       \
-        godot_packed_vector2_array *:godot_packed_vector2_array_insert,     \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_insert,   \
-        godot_packed_vector3_array *:godot_packed_vector3_array_insert,     \
-        godot_packed_color_array *:godot_packed_color_array_insert)         \
-    ((p_self), (p_data))
+#define godot_packed_array_insert(p_self, p_data)  \
+	_Generic((p_self),                             \
+			 godot_packed_byte_array *             \
+			 : godot_packed_byte_array_insert,     \
+			 godot_packed_int32_array *            \
+			 : godot_packed_int32_array_insert,    \
+			 godot_packed_int64_array *            \
+			 : godot_packed_int64_array_insert,    \
+			 godot_packed_float32_array *          \
+			 : godot_packed_float32_array_insert,  \
+			 godot_packed_float64_array *          \
+			 : godot_packed_float64_array_insert,  \
+			 godot_packed_string_array *           \
+			 : godot_packed_string_array_insert,   \
+			 godot_packed_vector2_array *          \
+			 : godot_packed_vector2_array_insert,  \
+			 godot_packed_vector2i_array *         \
+			 : godot_packed_vector2i_array_insert, \
+			 godot_packed_vector3_array *          \
+			 : godot_packed_vector3_array_insert,  \
+			 godot_packed_color_array *            \
+			 : godot_packed_color_array_insert)((p_self), (p_data))
 
-#define godot_packed_array_has(p_self, p_value)                         \
-    _Generic((p_self),                                                  \
-        godot_packed_byte_array *:godot_packed_byte_array_has,          \
-        godot_packed_int32_array *:godot_packed_int32_array_has,        \
-        godot_packed_int64_array *:godot_packed_int64_array_has,        \
-        godot_packed_float32_array *:godot_packed_float32_array_has,    \
-        godot_packed_float64_array *:godot_packed_float64_array_has,    \
-        godot_packed_string_array *:godot_packed_string_array_has,      \
-        godot_packed_vector2_array *:godot_packed_vector2_array_has,    \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_has,  \
-        godot_packed_vector3_array *:godot_packed_vector3_array_has,    \
-        godot_packed_color_array *:godot_packed_color_array_has)        \
-    ((p_self), (p_value))
+#define godot_packed_array_has(p_self, p_value) \
+	_Generic((p_self),                          \
+			 godot_packed_byte_array *          \
+			 : godot_packed_byte_array_has,     \
+			 godot_packed_int32_array *         \
+			 : godot_packed_int32_array_has,    \
+			 godot_packed_int64_array *         \
+			 : godot_packed_int64_array_has,    \
+			 godot_packed_float32_array *       \
+			 : godot_packed_float32_array_has,  \
+			 godot_packed_float64_array *       \
+			 : godot_packed_float64_array_has,  \
+			 godot_packed_string_array *        \
+			 : godot_packed_string_array_has,   \
+			 godot_packed_vector2_array *       \
+			 : godot_packed_vector2_array_has,  \
+			 godot_packed_vector2i_array *      \
+			 : godot_packed_vector2i_array_has, \
+			 godot_packed_vector3_array *       \
+			 : godot_packed_vector3_array_has,  \
+			 godot_packed_color_array *         \
+			 : godot_packed_color_array_has)((p_self), (p_value))
 
-#define godot_packed_array_sort(p_self)                                 \
-    _Generic((p_self),                                                  \
-        godot_packed_byte_array *:godot_packed_byte_array_sort,         \
-        godot_packed_int32_array *:godot_packed_int32_array_sort,       \
-        godot_packed_int64_array *:godot_packed_int64_array_sort,       \
-        godot_packed_float32_array *:godot_packed_float32_array_sort,   \
-        godot_packed_float64_array *:godot_packed_float64_array_sort,   \
-        godot_packed_string_array *:godot_packed_string_array_sort,     \
-        godot_packed_vector2_array *:godot_packed_vector2_array_sort,   \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_sort, \
-        godot_packed_vector3_array *:godot_packed_vector3_array_sort,   \
-        godot_packed_color_array *:godot_packed_color_array_sort)       \
-    ((p_self))
+#define godot_packed_array_sort(p_self)          \
+	_Generic((p_self),                           \
+			 godot_packed_byte_array *           \
+			 : godot_packed_byte_array_sort,     \
+			 godot_packed_int32_array *          \
+			 : godot_packed_int32_array_sort,    \
+			 godot_packed_int64_array *          \
+			 : godot_packed_int64_array_sort,    \
+			 godot_packed_float32_array *        \
+			 : godot_packed_float32_array_sort,  \
+			 godot_packed_float64_array *        \
+			 : godot_packed_float64_array_sort,  \
+			 godot_packed_string_array *         \
+			 : godot_packed_string_array_sort,   \
+			 godot_packed_vector2_array *        \
+			 : godot_packed_vector2_array_sort,  \
+			 godot_packed_vector2i_array *       \
+			 : godot_packed_vector2i_array_sort, \
+			 godot_packed_vector3_array *        \
+			 : godot_packed_vector3_array_sort,  \
+			 godot_packed_color_array *          \
+			 : godot_packed_color_array_sort)((p_self))
 
-#define godot_packed_array_invert(p_self)                                   \
-    _Generic((p_self),                                                      \
-        godot_packed_byte_array *:godot_packed_byte_array_invert,           \
-        godot_packed_int32_array *:godot_packed_int32_array_invert,         \
-        godot_packed_int64_array *:godot_packed_int64_array_invert,         \
-        godot_packed_float32_array *:godot_packed_float32_array_invert,     \
-        godot_packed_float64_array *:godot_packed_float64_array_invert,     \
-        godot_packed_string_array *:godot_packed_string_array_invert,       \
-        godot_packed_vector2_array *:godot_packed_vector2_array_invert,     \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_invert,   \
-        godot_packed_vector3_array *:godot_packed_vector3_array_invert,     \
-        godot_packed_color_array *:godot_packed_color_array_invert)         \
-    ((p_self))
+#define godot_packed_array_invert(p_self)          \
+	_Generic((p_self),                             \
+			 godot_packed_byte_array *             \
+			 : godot_packed_byte_array_invert,     \
+			 godot_packed_int32_array *            \
+			 : godot_packed_int32_array_invert,    \
+			 godot_packed_int64_array *            \
+			 : godot_packed_int64_array_invert,    \
+			 godot_packed_float32_array *          \
+			 : godot_packed_float32_array_invert,  \
+			 godot_packed_float64_array *          \
+			 : godot_packed_float64_array_invert,  \
+			 godot_packed_string_array *           \
+			 : godot_packed_string_array_invert,   \
+			 godot_packed_vector2_array *          \
+			 : godot_packed_vector2_array_invert,  \
+			 godot_packed_vector2i_array *         \
+			 : godot_packed_vector2i_array_invert, \
+			 godot_packed_vector3_array *          \
+			 : godot_packed_vector3_array_invert,  \
+			 godot_packed_color_array *            \
+			 : godot_packed_color_array_invert)((p_self))
 
-#define godot_packed_array_push_back(p_self, p_data) \
-    _Generic((p_self),\
-        godot_packed_byte_array *:godot_packed_byte_array_push_back,\
-        godot_packed_int32_array *:godot_packed_int32_array_push_back,\
-        godot_packed_int64_array *:godot_packed_int64_array_push_back,\
-        godot_packed_float32_array *:godot_packed_float32_array_push_back,\
-        godot_packed_float64_array *:godot_packed_float64_array_push_back,\
-        godot_packed_string_array *:godot_packed_string_array_push_back,\
-        godot_packed_vector2_array *:godot_packed_vector2_array_push_back,\
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_push_back,\
-        godot_packed_vector3_array *:godot_packed_vector3_array_push_back,\
-        godot_packed_color_array *:godot_packed_color_array_push_back)\
-    ((p_self), (p_data))
+#define godot_packed_array_push_back(p_self, p_data)  \
+	_Generic((p_self),                                \
+			 godot_packed_byte_array *                \
+			 : godot_packed_byte_array_push_back,     \
+			 godot_packed_int32_array *               \
+			 : godot_packed_int32_array_push_back,    \
+			 godot_packed_int64_array *               \
+			 : godot_packed_int64_array_push_back,    \
+			 godot_packed_float32_array *             \
+			 : godot_packed_float32_array_push_back,  \
+			 godot_packed_float64_array *             \
+			 : godot_packed_float64_array_push_back,  \
+			 godot_packed_string_array *              \
+			 : godot_packed_string_array_push_back,   \
+			 godot_packed_vector2_array *             \
+			 : godot_packed_vector2_array_push_back,  \
+			 godot_packed_vector2i_array *            \
+			 : godot_packed_vector2i_array_push_back, \
+			 godot_packed_vector3_array *             \
+			 : godot_packed_vector3_array_push_back,  \
+			 godot_packed_color_array *               \
+			 : godot_packed_color_array_push_back)((p_self), (p_data))
 
-#define godot_packed_array_remove(p_self, p_idx)                            \
-    _Generic((p_self),                                                      \
-        godot_packed_byte_array *:godot_packed_byte_array_remove,           \
-        godot_packed_int32_array *:godot_packed_int32_array_remove,         \
-        godot_packed_int64_array *:godot_packed_int64_array_remove,         \
-        godot_packed_float32_array *:godot_packed_float32_array_remove,     \
-        godot_packed_float64_array *:godot_packed_float64_array_remove,     \
-        godot_packed_string_array *:godot_packed_string_array_remove,       \
-        godot_packed_vector2_array *:godot_packed_vector2_array_remove,     \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_remove,   \
-        godot_packed_vector3_array *:godot_packed_vector3_array_remove,     \
-        godot_packed_color_array *:godot_packed_color_array_remove)         \
-    ((p_self))
+#define godot_packed_array_remove(p_self, p_idx)   \
+	_Generic((p_self),                             \
+			 godot_packed_byte_array *             \
+			 : godot_packed_byte_array_remove,     \
+			 godot_packed_int32_array *            \
+			 : godot_packed_int32_array_remove,    \
+			 godot_packed_int64_array *            \
+			 : godot_packed_int64_array_remove,    \
+			 godot_packed_float32_array *          \
+			 : godot_packed_float32_array_remove,  \
+			 godot_packed_float64_array *          \
+			 : godot_packed_float64_array_remove,  \
+			 godot_packed_string_array *           \
+			 : godot_packed_string_array_remove,   \
+			 godot_packed_vector2_array *          \
+			 : godot_packed_vector2_array_remove,  \
+			 godot_packed_vector2i_array *         \
+			 : godot_packed_vector2i_array_remove, \
+			 godot_packed_vector3_array *          \
+			 : godot_packed_vector3_array_remove,  \
+			 godot_packed_color_array *            \
+			 : godot_packed_color_array_remove)((p_self))
 
-#define godot_packed_array_resize(p_self, p_size)                           \
-    _Generic((p_self),                                                      \
-        godot_packed_byte_array *:godot_packed_byte_array_resize,           \
-        godot_packed_int32_array *:godot_packed_int32_array_resize,         \
-        godot_packed_int64_array *:godot_packed_int64_array_resize,         \
-        godot_packed_float32_array *:godot_packed_float32_array_resize,     \
-        godot_packed_float64_array *:godot_packed_float64_array_resize,     \
-        godot_packed_string_array *:godot_packed_string_array_resize,       \
-        godot_packed_vector2_array *:godot_packed_vector2_array_resize,     \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_resize,   \
-        godot_packed_vector3_array *:godot_packed_vector3_array_resize,     \
-        godot_packed_color_array *:godot_packed_color_array_resize)         \
-    ((p_self), (p_size))
+#define godot_packed_array_resize(p_self, p_size)  \
+	_Generic((p_self),                             \
+			 godot_packed_byte_array *             \
+			 : godot_packed_byte_array_resize,     \
+			 godot_packed_int32_array *            \
+			 : godot_packed_int32_array_resize,    \
+			 godot_packed_int64_array *            \
+			 : godot_packed_int64_array_resize,    \
+			 godot_packed_float32_array *          \
+			 : godot_packed_float32_array_resize,  \
+			 godot_packed_float64_array *          \
+			 : godot_packed_float64_array_resize,  \
+			 godot_packed_string_array *           \
+			 : godot_packed_string_array_resize,   \
+			 godot_packed_vector2_array *          \
+			 : godot_packed_vector2_array_resize,  \
+			 godot_packed_vector2i_array *         \
+			 : godot_packed_vector2i_array_resize, \
+			 godot_packed_vector3_array *          \
+			 : godot_packed_vector3_array_resize,  \
+			 godot_packed_color_array *            \
+			 : godot_packed_color_array_resize)((p_self), (p_size))
 
-#define godot_packed_array_set(p_self, p_idx, p_data)                   \
-    _Generic((p_self),                                                  \
-        godot_packed_byte_array *:godot_packed_byte_array_set,          \
-        godot_packed_int32_array *:godot_packed_int32_array_set,        \
-        godot_packed_int64_array *:godot_packed_int64_array_set,        \
-        godot_packed_float32_array *:godot_packed_float32_array_set,    \
-        godot_packed_float64_array *:godot_packed_float64_array_set,    \
-        godot_packed_string_array *:godot_packed_string_array_set,      \
-        godot_packed_vector2_array *:godot_packed_vector2_array_set,    \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_set,  \
-        godot_packed_vector3_array *:godot_packed_vector3_array_set,    \
-        godot_packed_color_array *:godot_packed_color_array_set)        \
-    ((p_self), (p_idx), (p_data))
+#define godot_packed_array_set(p_self, p_idx, p_data) \
+	_Generic((p_self),                                \
+			 godot_packed_byte_array *                \
+			 : godot_packed_byte_array_set,           \
+			 godot_packed_int32_array *               \
+			 : godot_packed_int32_array_set,          \
+			 godot_packed_int64_array *               \
+			 : godot_packed_int64_array_set,          \
+			 godot_packed_float32_array *             \
+			 : godot_packed_float32_array_set,        \
+			 godot_packed_float64_array *             \
+			 : godot_packed_float64_array_set,        \
+			 godot_packed_string_array *              \
+			 : godot_packed_string_array_set,         \
+			 godot_packed_vector2_array *             \
+			 : godot_packed_vector2_array_set,        \
+			 godot_packed_vector2i_array *            \
+			 : godot_packed_vector2i_array_set,       \
+			 godot_packed_vector3_array *             \
+			 : godot_packed_vector3_array_set,        \
+			 godot_packed_color_array *               \
+			 : godot_packed_color_array_set)((p_self), (p_idx), (p_data))
 
-#define godot_packed_array_get(p_self, p_idx)                           \
-    _Generic((p_self),                                                  \
-        godot_packed_byte_array *:godot_packed_byte_array_get,          \
-        godot_packed_int32_array *:godot_packed_int32_array_get,        \
-        godot_packed_int64_array *:godot_packed_int64_array_get,        \
-        godot_packed_float32_array *:godot_packed_float32_array_get,    \
-        godot_packed_float64_array *:godot_packed_float64_array_get,    \
-        godot_packed_string_array *:godot_packed_string_array_get,      \
-        godot_packed_vector2_array *:godot_packed_vector2_array_get,    \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_get,  \
-        godot_packed_vector3_array *:godot_packed_vector3_array_get,    \
-        godot_packed_color_array *:godot_packed_color_array_get)        \
-    ((p_self), (p_idx))
+#define godot_packed_array_get(p_self, p_idx)   \
+	_Generic((p_self),                          \
+			 godot_packed_byte_array *          \
+			 : godot_packed_byte_array_get,     \
+			 godot_packed_int32_array *         \
+			 : godot_packed_int32_array_get,    \
+			 godot_packed_int64_array *         \
+			 : godot_packed_int64_array_get,    \
+			 godot_packed_float32_array *       \
+			 : godot_packed_float32_array_get,  \
+			 godot_packed_float64_array *       \
+			 : godot_packed_float64_array_get,  \
+			 godot_packed_string_array *        \
+			 : godot_packed_string_array_get,   \
+			 godot_packed_vector2_array *       \
+			 : godot_packed_vector2_array_get,  \
+			 godot_packed_vector2i_array *      \
+			 : godot_packed_vector2i_array_get, \
+			 godot_packed_vector3_array *       \
+			 : godot_packed_vector3_array_get,  \
+			 godot_packed_color_array *         \
+			 : godot_packed_color_array_get)((p_self), (p_idx))
 
-#define godot_packed_array_size(p_self)                                 \
-    _Generic((p_self),                                                  \
-        godot_packed_byte_array *:godot_packed_byte_array_size,         \
-        godot_packed_int32_array *:godot_packed_int32_array_size,       \
-        godot_packed_int64_array *:godot_packed_int64_array_size,       \
-        godot_packed_float32_array *:godot_packed_float32_array_size,   \
-        godot_packed_float64_array *:godot_packed_float64_array_size,   \
-        godot_packed_string_array *:godot_packed_string_array_size,     \
-        godot_packed_vector2_array *:godot_packed_vector2_array_size,   \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_size, \
-        godot_packed_vector3_array *:godot_packed_vector3_array_size,   \
-        godot_packed_color_array *:godot_packed_color_array_size)       \
-    ((p_self))
+#define godot_packed_array_size(p_self)          \
+	_Generic((p_self),                           \
+			 godot_packed_byte_array *           \
+			 : godot_packed_byte_array_size,     \
+			 godot_packed_int32_array *          \
+			 : godot_packed_int32_array_size,    \
+			 godot_packed_int64_array *          \
+			 : godot_packed_int64_array_size,    \
+			 godot_packed_float32_array *        \
+			 : godot_packed_float32_array_size,  \
+			 godot_packed_float64_array *        \
+			 : godot_packed_float64_array_size,  \
+			 godot_packed_string_array *         \
+			 : godot_packed_string_array_size,   \
+			 godot_packed_vector2_array *        \
+			 : godot_packed_vector2_array_size,  \
+			 godot_packed_vector2i_array *       \
+			 : godot_packed_vector2i_array_size, \
+			 godot_packed_vector3_array *        \
+			 : godot_packed_vector3_array_size,  \
+			 godot_packed_color_array *          \
+			 : godot_packed_color_array_size)((p_self))
 
-#define godot_packed_array_is_empty(p_self)                                 \
-    _Generic((p_self),                                                      \
-        godot_packed_byte_array *:godot_packed_byte_array_is_empty,         \
-        godot_packed_int32_array *:godot_packed_int32_array_is_empty,       \
-        godot_packed_int64_array *:godot_packed_int64_array_is_empty,       \
-        godot_packed_float32_array *:godot_packed_float32_array_is_empty,   \
-        godot_packed_float64_array *:godot_packed_float64_array_is_empty,   \
-        godot_packed_string_array *:godot_packed_string_array_is_empty,     \
-        godot_packed_vector2_array *:godot_packed_vector2_array_is_empty,   \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_is_empty, \
-        godot_packed_vector3_array *:godot_packed_vector3_array_is_empty,   \
-        godot_packed_color_array *:godot_packed_color_array_is_empty)       \
-    ((p_self))
+#define godot_packed_array_is_empty(p_self)          \
+	_Generic((p_self),                               \
+			 godot_packed_byte_array *               \
+			 : godot_packed_byte_array_is_empty,     \
+			 godot_packed_int32_array *              \
+			 : godot_packed_int32_array_is_empty,    \
+			 godot_packed_int64_array *              \
+			 : godot_packed_int64_array_is_empty,    \
+			 godot_packed_float32_array *            \
+			 : godot_packed_float32_array_is_empty,  \
+			 godot_packed_float64_array *            \
+			 : godot_packed_float64_array_is_empty,  \
+			 godot_packed_string_array *             \
+			 : godot_packed_string_array_is_empty,   \
+			 godot_packed_vector2_array *            \
+			 : godot_packed_vector2_array_is_empty,  \
+			 godot_packed_vector2i_array *           \
+			 : godot_packed_vector2i_array_is_empty, \
+			 godot_packed_vector3_array *            \
+			 : godot_packed_vector3_array_is_empty,  \
+			 godot_packed_color_array *              \
+			 : godot_packed_color_array_is_empty)((p_self))
 
-#define godot_packed_array_destroy(p_self)                                  \
-    _Generic((p_self),                                                      \
-        godot_packed_byte_array *:godot_packed_byte_array_destroy,          \
-        godot_packed_int32_array *:godot_packed_int32_array_destroy,        \
-        godot_packed_int64_array *:godot_packed_int64_array_destroy,        \
-        godot_packed_float32_array *:godot_packed_float32_array_destroy,    \
-        godot_packed_float64_array *:godot_packed_float64_array_destroy,    \
-        godot_packed_string_array *:godot_packed_string_array_destroy,      \
-        godot_packed_vector2_array *:godot_packed_vector2_array_destroy,    \
-        godot_packed_vector2i_array *:godot_packed_vector2i_array_destroy,  \
-        godot_packed_vector3_array *:godot_packed_vector3_array_destroy,    \
-        godot_packed_color_array *:godot_packed_color_array_destroy)        \
-    ((p_self))
+#define godot_packed_array_destroy(p_self)          \
+	_Generic((p_self),                              \
+			 godot_packed_byte_array *              \
+			 : godot_packed_byte_array_destroy,     \
+			 godot_packed_int32_array *             \
+			 : godot_packed_int32_array_destroy,    \
+			 godot_packed_int64_array *             \
+			 : godot_packed_int64_array_destroy,    \
+			 godot_packed_float32_array *           \
+			 : godot_packed_float32_array_destroy,  \
+			 godot_packed_float64_array *           \
+			 : godot_packed_float64_array_destroy,  \
+			 godot_packed_string_array *            \
+			 : godot_packed_string_array_destroy,   \
+			 godot_packed_vector2_array *           \
+			 : godot_packed_vector2_array_destroy,  \
+			 godot_packed_vector2i_array *          \
+			 : godot_packed_vector2i_array_destroy, \
+			 godot_packed_vector3_array *           \
+			 : godot_packed_vector3_array_destroy,  \
+			 godot_packed_color_array *             \
+			 : godot_packed_color_array_destroy)((p_self))
 
 #endif
 

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -168,100 +168,100 @@ extern "C" {
 
 #define godot_packed_array_new(r_dest)                                  \
     _Generic((r_dest),                                                  \
-        godot_packed_byte_array *:godot_packed_byte_byte_array_new,             \
-        godot_packed_int32_array *:godot_packed_int32_int32_array_new,          \
-        godot_packed_int64_array *:godot_packed_int64_int64_array_new,          \
-        godot_packed_float32_array *:godot_packed_float32_float32_array_new,    \
-        godot_packed_float64_array *:godot_packed_float64_float64_array_new,    \
-        godot_packed_string_array *:godot_packed_string_string_array_new,       \
-        godot_packed_vector2_array *:godot_packed_vector2_vector2_array_new,    \
-        godot_packed_vector2i_array *:godot_packed_vector2i_vector2i_array_new, \
-        godot_packed_vector3_array *:godot_packed_vector3_vector3_array_new,    \
-        godot_packed_color_array *:godot_packed_color_color_array_new)          \
+        godot_packed_byte_array *:godot_packed_byte_array_new,          \
+        godot_packed_int32_array *:godot_packed_int32_array_new,        \
+        godot_packed_int64_array *:godot_packed_int64_array_new,        \
+        godot_packed_float32_array *:godot_packed_float32_array_new,    \
+        godot_packed_float64_array *:godot_packed_float64_array_new,    \
+        godot_packed_string_array *:godot_packed_string_array_new,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_new,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_new,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_new,    \
+        godot_packed_color_array *:godot_packed_color_array_new)        \
     ((r_dest))
 
-#define godot_packed_array_new_copy(r_dest, p_src)                                  \
-    _Generic((p_src),                                                               \
-        godot_packed_byte_array *:godot_packed_byte_byte_array_new_copy,            \
-        godot_packed_int32_array *:godot_packed_int32_int32_array_new_copy,         \
-        godot_packed_int64_array *:godot_packed_int64_int64_array_new_copy,         \
-        godot_packed_float32_array *:godot_packed_float32_float32_array_new_copy,   \
-        godot_packed_float64_array *:godot_packed_float64_float64_array_new_copy,   \
-        godot_packed_string_array *:godot_packed_string_string_array_new_copy,      \
-        godot_packed_vector2_array *:godot_packed_vector2_vector2_array_new_copy,   \
-        godot_packed_vector2i_array *:godot_packed_vector2i_vector2i_array_new_copy,\
-        godot_packed_vector3_array *:godot_packed_vector3_vector3_array_new_copy,   \
-        godot_packed_color_array *:godot_packed_color_color_array_new_copy)         \
+#define godot_packed_array_new_copy(r_dest, p_src)                          \
+    _Generic((p_src),                                                       \
+        godot_packed_byte_array *:godot_packed_byte_array_new_copy,         \
+        godot_packed_int32_array *:godot_packed_int32_array_new_copy,       \
+        godot_packed_int64_array *:godot_packed_int64_array_new_copy,       \
+        godot_packed_float32_array *:godot_packed_float32_array_new_copy,   \
+        godot_packed_float64_array *:godot_packed_float64_array_new_copy,   \
+        godot_packed_string_array *:godot_packed_string_array_new_copy,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_new_copy,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_new_copy, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_new_copy,   \
+        godot_packed_color_array *:godot_packed_color_array_new_copy)       \
     ((r_dest), (p_src))
 
-#define godot_packed_array_new_with_array(r_dest, p_a)                                      \
-    _Generic((r_dest),                                                                      \
-        godot_packed_byte_array *:godot_packed_byte_byte_array_new_with_array,              \
-        godot_packed_int32_array *:godot_packed_int32_int32_array_new_with_array,           \
-        godot_packed_int64_array *:godot_packed_int64_int64_array_new_with_array,           \
-        godot_packed_float32_array *:godot_packed_float32_float32_array_new_with_array,     \
-        godot_packed_float64_array *:godot_packed_float64_float64_array_new_with_array,     \
-        godot_packed_string_array *:godot_packed_string_string_array_new_with_array,        \
-        godot_packed_vector2_array *:godot_packed_vector2_vector2_array_new_with_array,     \
-        godot_packed_vector2i_array *:godot_packed_vector2i_vector2i_array_new_with_array,  \
-        godot_packed_vector3_array *:godot_packed_vector3_vector3_array_new_with_array,     \
-        godot_packed_color_array *:godot_packed_color_color_array_new_with_array)           \
+#define godot_packed_array_new_with_array(r_dest, p_a)                              \
+    _Generic((r_dest),                                                              \
+        godot_packed_byte_array *:godot_packed_byte_array_new_with_array,           \
+        godot_packed_int32_array *:godot_packed_int32_array_new_with_array,         \
+        godot_packed_int64_array *:godot_packed_int64_array_new_with_array,         \
+        godot_packed_float32_array *:godot_packed_float32_array_new_with_array,     \
+        godot_packed_float64_array *:godot_packed_float64_array_new_with_array,     \
+        godot_packed_string_array *:godot_packed_string_array_new_with_array,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_new_with_array,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_new_with_array,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_new_with_array,     \
+        godot_packed_color_array *:godot_packed_color_array_new_with_array)         \
     ((r_dest), (p_a))
 
-#define godot_packed_array_ptr(p_self)                          \
-    _Generic((p_self),                                          \
-godot_packed_byte_array *:godot_packed_byte_array_ptr,          \
-godot_packed_int32_array *:godot_packed_int32_array_ptr,        \
-godot_packed_int64_array *:godot_packed_int64_array_ptr,        \
-godot_packed_float32_array *:godot_packed_float32_array_ptr,    \
-godot_packed_float64_array *:godot_packed_float64_array_ptr,    \
-godot_packed_string_array *:godot_packed_string_array_ptr,      \
-godot_packed_vector2_array *:godot_packed_vector2_array_ptr,    \
-godot_packed_vector2i_array *:godot_packed_vector2i_array_ptr,  \
-godot_packed_vector3_array *:godot_packed_vector3_array_ptr,    \
-godot_packed_color_array *:godot_packed_color_array_ptr)        \
+#define godot_packed_array_ptr(p_self)                                  \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_ptr,          \
+        godot_packed_int32_array *:godot_packed_int32_array_ptr,        \
+        godot_packed_int64_array *:godot_packed_int64_array_ptr,        \
+        godot_packed_float32_array *:godot_packed_float32_array_ptr,    \
+        godot_packed_float64_array *:godot_packed_float64_array_ptr,    \
+        godot_packed_string_array *:godot_packed_string_array_ptr,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_ptr,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_ptr,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_ptr,    \
+        godot_packed_color_array *:godot_packed_color_array_ptr)        \
     ((p_self))
 
-#define godot_packed_array_ptrw(p_self)                         \
-    _Generic((),                                                \
-godot_packed_byte_array *:godot_packed_byte_array_ptrw,         \
-godot_packed_int32_array *:godot_packed_int32_array_ptrw,       \
-godot_packed_int64_array *:godot_packed_int64_array_ptrw,       \
-godot_packed_float32_array *:godot_packed_float32_array_ptrw,   \
-godot_packed_float64_array *:godot_packed_float64_array_ptrw,   \
-godot_packed_string_array *:godot_packed_string_array_ptrw,     \
-godot_packed_vector2_array *:godot_packed_vector2_array_ptrw,   \
-godot_packed_vector2i_array *:godot_packed_vector2i_array_ptrw, \
-godot_packed_vector3_array *:godot_packed_vector3_array_ptrw,   \
-godot_packed_color_array *:godot_packed_color_array_ptrw)       \
+#define godot_packed_array_ptrw(p_self)                                 \
+    _Generic((pself),                                                   \
+        godot_packed_byte_array *:godot_packed_byte_array_ptrw,         \
+        godot_packed_int32_array *:godot_packed_int32_array_ptrw,       \
+        godot_packed_int64_array *:godot_packed_int64_array_ptrw,       \
+        godot_packed_float32_array *:godot_packed_float32_array_ptrw,   \
+        godot_packed_float64_array *:godot_packed_float64_array_ptrw,   \
+        godot_packed_string_array *:godot_packed_string_array_ptrw,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_ptrw,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_ptrw, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_ptrw,   \
+        godot_packed_color_array *:godot_packed_color_array_ptrw)       \
     ((p_self))
 
-#define godot_packed_array_append(p_self, p_data)                   \
-    _Generic((p_self),                                              \
-godot_packed_byte_array *:godot_packed_byte_array_append,           \
-godot_packed_int32_array *:godot_packed_int32_array_append,         \
-godot_packed_int64_array *:godot_packed_int64_array_append,         \
-godot_packed_float32_array *:godot_packed_float32_array_append,     \
-godot_packed_float64_array *:godot_packed_float64_array_append,     \
-godot_packed_string_array *:godot_packed_string_array_append,       \
-godot_packed_vector2_array *:godot_packed_vector2_array_append,     \
-godot_packed_vector2i_array *:godot_packed_vector2i_array_append,   \
-godot_packed_vector3_array *:godot_packed_vector3_array_append,     \
-godot_packed_color_array *:godot_packed_color_array_append)         \
+#define godot_packed_array_append(p_self, p_data)                           \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_append,           \
+        godot_packed_int32_array *:godot_packed_int32_array_append,         \
+        godot_packed_int64_array *:godot_packed_int64_array_append,         \
+        godot_packed_float32_array *:godot_packed_float32_array_append,     \
+        godot_packed_float64_array *:godot_packed_float64_array_append,     \
+        godot_packed_string_array *:godot_packed_string_array_append,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_append,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_append,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_append,     \
+        godot_packed_color_array *:godot_packed_color_array_append)         \
     ((p_self), (p_data))
 
-#define godot_packed_array_append_array(p_self, p_array)                \
-    _Generic((p_self),                                                  \
-godot_packed_byte_array *:godot_packed_byte_array_append_array,         \
-godot_packed_int32_array *:godot_packed_int32_array_append_array,       \
-godot_packed_int64_array *:godot_packed_int64_array_append_array,       \
-godot_packed_float32_array *:godot_packed_float32_array_append_array,   \
-godot_packed_float64_array *:godot_packed_float64_array_append_array,   \
-godot_packed_string_array *:godot_packed_string_array_append_array,     \
-godot_packed_vector2_array *:godot_packed_vector2_array_append_array,   \
-godot_packed_vector2i_array *:godot_packed_vector2i_array_append_array, \
-godot_packed_vector3_array *:godot_packed_vector3_array_append_array,   \
-godot_packed_color_array *:godot_packed_color_array_append_array)       \
+#define godot_packed_array_append_array(p_self, p_array)                        \
+    _Generic((p_self),                                                          \
+        godot_packed_byte_array *:godot_packed_byte_array_append_array,         \
+        godot_packed_int32_array *:godot_packed_int32_array_append_array,       \
+        godot_packed_int64_array *:godot_packed_int64_array_append_array,       \
+        godot_packed_float32_array *:godot_packed_float32_array_append_array,   \
+        godot_packed_float64_array *:godot_packed_float64_array_append_array,   \
+        godot_packed_string_array *:godot_packed_string_array_append_array,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_append_array,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_append_array, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_append_array,   \
+        godot_packed_color_array *:godot_packed_color_array_append_array)       \
     ((p_self), (p_array))
 
 #define godot_packed_array_insert(p_self, p_data)                           \

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -160,10 +160,6 @@ typedef struct {
 
 #include <gdnative/gdnative.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if __STDC_VERSION__ >= 201112L
 
 #define godot_packed_array_new(r_dest)          \

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -166,442 +166,271 @@ extern "C" {
 
 #if __STDC_VERSION__ >= 201112L
 
-#define godot_packed_array_new(r_dest)          \
-	_Generic((r_dest),                          \
-			 godot_packed_byte_array *          \
-			 : godot_packed_byte_array_new,     \
-			 godot_packed_int32_array *         \
-			 : godot_packed_int32_array_new,    \
-			 godot_packed_int64_array *         \
-			 : godot_packed_int64_array_new,    \
-			 godot_packed_float32_array *       \
-			 : godot_packed_float32_array_new,  \
-			 godot_packed_float64_array *       \
-			 : godot_packed_float64_array_new,  \
-			 godot_packed_string_array *        \
-			 : godot_packed_string_array_new,   \
-			 godot_packed_vector2_array *       \
-			 : godot_packed_vector2_array_new,  \
-			 godot_packed_vector2i_array *      \
-			 : godot_packed_vector2i_array_new, \
-			 godot_packed_vector3_array *       \
-			 : godot_packed_vector3_array_new,  \
-			 godot_packed_color_array *         \
-			 : godot_packed_color_array_new)((r_dest))
+#define godot_packed_array_new(r_dest)                                  \
+    _Generic((r_dest),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_new,          \
+        godot_packed_int32_array *:godot_packed_int32_array_new,        \
+        godot_packed_int64_array *:godot_packed_int64_array_new,        \
+        godot_packed_float32_array *:godot_packed_float32_array_new,    \
+        godot_packed_float64_array *:godot_packed_float64_array_new,    \
+        godot_packed_string_array *:godot_packed_string_array_new,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_new,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_new,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_new,    \
+        godot_packed_color_array *:godot_packed_color_array_new)        \
+    ((r_dest))
 
-#define godot_packed_array_new_copy(r_dest, p_src)   \
-	_Generic((p_src),                                \
-			 godot_packed_byte_array *               \
-			 : godot_packed_byte_array_new_copy,     \
-			 godot_packed_int32_array *              \
-			 : godot_packed_int32_array_new_copy,    \
-			 godot_packed_int64_array *              \
-			 : godot_packed_int64_array_new_copy,    \
-			 godot_packed_float32_array *            \
-			 : godot_packed_float32_array_new_copy,  \
-			 godot_packed_float64_array *            \
-			 : godot_packed_float64_array_new_copy,  \
-			 godot_packed_string_array *             \
-			 : godot_packed_string_array_new_copy,   \
-			 godot_packed_vector2_array *            \
-			 : godot_packed_vector2_array_new_copy,  \
-			 godot_packed_vector2i_array *           \
-			 : godot_packed_vector2i_array_new_copy, \
-			 godot_packed_vector3_array *            \
-			 : godot_packed_vector3_array_new_copy,  \
-			 godot_packed_color_array *              \
-			 : godot_packed_color_array_new_copy)((r_dest), (p_src))
+#define godot_packed_array_new_copy(r_dest, p_src)                          \
+    _Generic((p_src),                                                       \
+        godot_packed_byte_array *:godot_packed_byte_array_new_copy,         \
+        godot_packed_int32_array *:godot_packed_int32_array_new_copy,       \
+        godot_packed_int64_array *:godot_packed_int64_array_new_copy,       \
+        godot_packed_float32_array *:godot_packed_float32_array_new_copy,   \
+        godot_packed_float64_array *:godot_packed_float64_array_new_copy,   \
+        godot_packed_string_array *:godot_packed_string_array_new_copy,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_new_copy,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_new_copy, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_new_copy,   \
+        godot_packed_color_array *:godot_packed_color_array_new_copy)       \
+    ((r_dest), (p_src))
 
-#define godot_packed_array_new_with_array(r_dest, p_a)     \
-	_Generic((r_dest),                                     \
-			 godot_packed_byte_array *                     \
-			 : godot_packed_byte_array_new_with_array,     \
-			 godot_packed_int32_array *                    \
-			 : godot_packed_int32_array_new_with_array,    \
-			 godot_packed_int64_array *                    \
-			 : godot_packed_int64_array_new_with_array,    \
-			 godot_packed_float32_array *                  \
-			 : godot_packed_float32_array_new_with_array,  \
-			 godot_packed_float64_array *                  \
-			 : godot_packed_float64_array_new_with_array,  \
-			 godot_packed_string_array *                   \
-			 : godot_packed_string_array_new_with_array,   \
-			 godot_packed_vector2_array *                  \
-			 : godot_packed_vector2_array_new_with_array,  \
-			 godot_packed_vector2i_array *                 \
-			 : godot_packed_vector2i_array_new_with_array, \
-			 godot_packed_vector3_array *                  \
-			 : godot_packed_vector3_array_new_with_array,  \
-			 godot_packed_color_array *                    \
-			 : godot_packed_color_array_new_with_array)((r_dest), (p_a))
+#define godot_packed_array_new_with_array(r_dest, p_a)                              \
+    _Generic((r_dest),                                                              \
+        godot_packed_byte_array *:godot_packed_byte_array_new_with_array,           \
+        godot_packed_int32_array *:godot_packed_int32_array_new_with_array,         \
+        godot_packed_int64_array *:godot_packed_int64_array_new_with_array,         \
+        godot_packed_float32_array *:godot_packed_float32_array_new_with_array,     \
+        godot_packed_float64_array *:godot_packed_float64_array_new_with_array,     \
+        godot_packed_string_array *:godot_packed_string_array_new_with_array,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_new_with_array,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_new_with_array,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_new_with_array,     \
+        godot_packed_color_array *:godot_packed_color_array_new_with_array)         \
+    ((r_dest), (p_a))
 
-#define godot_packed_array_ptr(p_self)          \
-	_Generic((p_self),                          \
-			 godot_packed_byte_array *          \
-			 : godot_packed_byte_array_ptr,     \
-			 godot_packed_int32_array *         \
-			 : godot_packed_int32_array_ptr,    \
-			 godot_packed_int64_array *         \
-			 : godot_packed_int64_array_ptr,    \
-			 godot_packed_float32_array *       \
-			 : godot_packed_float32_array_ptr,  \
-			 godot_packed_float64_array *       \
-			 : godot_packed_float64_array_ptr,  \
-			 godot_packed_string_array *        \
-			 : godot_packed_string_array_ptr,   \
-			 godot_packed_vector2_array *       \
-			 : godot_packed_vector2_array_ptr,  \
-			 godot_packed_vector2i_array *      \
-			 : godot_packed_vector2i_array_ptr, \
-			 godot_packed_vector3_array *       \
-			 : godot_packed_vector3_array_ptr,  \
-			 godot_packed_color_array *         \
-			 : godot_packed_color_array_ptr)((p_self))
+#define godot_packed_array_ptr(p_self)                                  \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_ptr,          \
+        godot_packed_int32_array *:godot_packed_int32_array_ptr,        \
+        godot_packed_int64_array *:godot_packed_int64_array_ptr,        \
+        godot_packed_float32_array *:godot_packed_float32_array_ptr,    \
+        godot_packed_float64_array *:godot_packed_float64_array_ptr,    \
+        godot_packed_string_array *:godot_packed_string_array_ptr,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_ptr,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_ptr,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_ptr,    \
+        godot_packed_color_array *:godot_packed_color_array_ptr)        \
+    ((p_self))
 
-#define godot_packed_array_ptrw(p_self)          \
-	_Generic((pself),                            \
-			 godot_packed_byte_array *           \
-			 : godot_packed_byte_array_ptrw,     \
-			 godot_packed_int32_array *          \
-			 : godot_packed_int32_array_ptrw,    \
-			 godot_packed_int64_array *          \
-			 : godot_packed_int64_array_ptrw,    \
-			 godot_packed_float32_array *        \
-			 : godot_packed_float32_array_ptrw,  \
-			 godot_packed_float64_array *        \
-			 : godot_packed_float64_array_ptrw,  \
-			 godot_packed_string_array *         \
-			 : godot_packed_string_array_ptrw,   \
-			 godot_packed_vector2_array *        \
-			 : godot_packed_vector2_array_ptrw,  \
-			 godot_packed_vector2i_array *       \
-			 : godot_packed_vector2i_array_ptrw, \
-			 godot_packed_vector3_array *        \
-			 : godot_packed_vector3_array_ptrw,  \
-			 godot_packed_color_array *          \
-			 : godot_packed_color_array_ptrw)((p_self))
+#define godot_packed_array_ptrw(p_self)                                 \
+    _Generic((pself),                                                   \
+        godot_packed_byte_array *:godot_packed_byte_array_ptrw,         \
+        godot_packed_int32_array *:godot_packed_int32_array_ptrw,       \
+        godot_packed_int64_array *:godot_packed_int64_array_ptrw,       \
+        godot_packed_float32_array *:godot_packed_float32_array_ptrw,   \
+        godot_packed_float64_array *:godot_packed_float64_array_ptrw,   \
+        godot_packed_string_array *:godot_packed_string_array_ptrw,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_ptrw,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_ptrw, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_ptrw,   \
+        godot_packed_color_array *:godot_packed_color_array_ptrw)       \
+    ((p_self))
 
-#define godot_packed_array_append(p_self, p_data)  \
-	_Generic((p_self),                             \
-			 godot_packed_byte_array *             \
-			 : godot_packed_byte_array_append,     \
-			 godot_packed_int32_array *            \
-			 : godot_packed_int32_array_append,    \
-			 godot_packed_int64_array *            \
-			 : godot_packed_int64_array_append,    \
-			 godot_packed_float32_array *          \
-			 : godot_packed_float32_array_append,  \
-			 godot_packed_float64_array *          \
-			 : godot_packed_float64_array_append,  \
-			 godot_packed_string_array *           \
-			 : godot_packed_string_array_append,   \
-			 godot_packed_vector2_array *          \
-			 : godot_packed_vector2_array_append,  \
-			 godot_packed_vector2i_array *         \
-			 : godot_packed_vector2i_array_append, \
-			 godot_packed_vector3_array *          \
-			 : godot_packed_vector3_array_append,  \
-			 godot_packed_color_array *            \
-			 : godot_packed_color_array_append)((p_self), (p_data))
+#define godot_packed_array_append(p_self, p_data)                           \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_append,           \
+        godot_packed_int32_array *:godot_packed_int32_array_append,         \
+        godot_packed_int64_array *:godot_packed_int64_array_append,         \
+        godot_packed_float32_array *:godot_packed_float32_array_append,     \
+        godot_packed_float64_array *:godot_packed_float64_array_append,     \
+        godot_packed_string_array *:godot_packed_string_array_append,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_append,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_append,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_append,     \
+        godot_packed_color_array *:godot_packed_color_array_append)         \
+    ((p_self), (p_data))
 
-#define godot_packed_array_append_array(p_self, p_array) \
-	_Generic((p_self),                                   \
-			 godot_packed_byte_array *                   \
-			 : godot_packed_byte_array_append_array,     \
-			 godot_packed_int32_array *                  \
-			 : godot_packed_int32_array_append_array,    \
-			 godot_packed_int64_array *                  \
-			 : godot_packed_int64_array_append_array,    \
-			 godot_packed_float32_array *                \
-			 : godot_packed_float32_array_append_array,  \
-			 godot_packed_float64_array *                \
-			 : godot_packed_float64_array_append_array,  \
-			 godot_packed_string_array *                 \
-			 : godot_packed_string_array_append_array,   \
-			 godot_packed_vector2_array *                \
-			 : godot_packed_vector2_array_append_array,  \
-			 godot_packed_vector2i_array *               \
-			 : godot_packed_vector2i_array_append_array, \
-			 godot_packed_vector3_array *                \
-			 : godot_packed_vector3_array_append_array,  \
-			 godot_packed_color_array *                  \
-			 : godot_packed_color_array_append_array)((p_self), (p_array))
+#define godot_packed_array_append_array(p_self, p_array)                        \
+    _Generic((p_self),                                                          \
+        godot_packed_byte_array *:godot_packed_byte_array_append_array,         \
+        godot_packed_int32_array *:godot_packed_int32_array_append_array,       \
+        godot_packed_int64_array *:godot_packed_int64_array_append_array,       \
+        godot_packed_float32_array *:godot_packed_float32_array_append_array,   \
+        godot_packed_float64_array *:godot_packed_float64_array_append_array,   \
+        godot_packed_string_array *:godot_packed_string_array_append_array,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_append_array,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_append_array, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_append_array,   \
+        godot_packed_color_array *:godot_packed_color_array_append_array)       \
+    ((p_self), (p_array))
 
-#define godot_packed_array_insert(p_self, p_data)  \
-	_Generic((p_self),                             \
-			 godot_packed_byte_array *             \
-			 : godot_packed_byte_array_insert,     \
-			 godot_packed_int32_array *            \
-			 : godot_packed_int32_array_insert,    \
-			 godot_packed_int64_array *            \
-			 : godot_packed_int64_array_insert,    \
-			 godot_packed_float32_array *          \
-			 : godot_packed_float32_array_insert,  \
-			 godot_packed_float64_array *          \
-			 : godot_packed_float64_array_insert,  \
-			 godot_packed_string_array *           \
-			 : godot_packed_string_array_insert,   \
-			 godot_packed_vector2_array *          \
-			 : godot_packed_vector2_array_insert,  \
-			 godot_packed_vector2i_array *         \
-			 : godot_packed_vector2i_array_insert, \
-			 godot_packed_vector3_array *          \
-			 : godot_packed_vector3_array_insert,  \
-			 godot_packed_color_array *            \
-			 : godot_packed_color_array_insert)((p_self), (p_data))
+#define godot_packed_array_insert(p_self, p_data)                           \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_insert,           \
+        godot_packed_int32_array *:godot_packed_int32_array_insert,         \
+        godot_packed_int64_array *:godot_packed_int64_array_insert,         \
+        godot_packed_float32_array *:godot_packed_float32_array_insert,     \
+        godot_packed_float64_array *:godot_packed_float64_array_insert,     \
+        godot_packed_string_array *:godot_packed_string_array_insert,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_insert,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_insert,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_insert,     \
+        godot_packed_color_array *:godot_packed_color_array_insert)         \
+    ((p_self), (p_data))
 
-#define godot_packed_array_has(p_self, p_value) \
-	_Generic((p_self),                          \
-			 godot_packed_byte_array *          \
-			 : godot_packed_byte_array_has,     \
-			 godot_packed_int32_array *         \
-			 : godot_packed_int32_array_has,    \
-			 godot_packed_int64_array *         \
-			 : godot_packed_int64_array_has,    \
-			 godot_packed_float32_array *       \
-			 : godot_packed_float32_array_has,  \
-			 godot_packed_float64_array *       \
-			 : godot_packed_float64_array_has,  \
-			 godot_packed_string_array *        \
-			 : godot_packed_string_array_has,   \
-			 godot_packed_vector2_array *       \
-			 : godot_packed_vector2_array_has,  \
-			 godot_packed_vector2i_array *      \
-			 : godot_packed_vector2i_array_has, \
-			 godot_packed_vector3_array *       \
-			 : godot_packed_vector3_array_has,  \
-			 godot_packed_color_array *         \
-			 : godot_packed_color_array_has)((p_self), (p_value))
+#define godot_packed_array_has(p_self, p_value)                         \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_has,          \
+        godot_packed_int32_array *:godot_packed_int32_array_has,        \
+        godot_packed_int64_array *:godot_packed_int64_array_has,        \
+        godot_packed_float32_array *:godot_packed_float32_array_has,    \
+        godot_packed_float64_array *:godot_packed_float64_array_has,    \
+        godot_packed_string_array *:godot_packed_string_array_has,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_has,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_has,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_has,    \
+        godot_packed_color_array *:godot_packed_color_array_has)        \
+    ((p_self), (p_value))
 
-#define godot_packed_array_sort(p_self)          \
-	_Generic((p_self),                           \
-			 godot_packed_byte_array *           \
-			 : godot_packed_byte_array_sort,     \
-			 godot_packed_int32_array *          \
-			 : godot_packed_int32_array_sort,    \
-			 godot_packed_int64_array *          \
-			 : godot_packed_int64_array_sort,    \
-			 godot_packed_float32_array *        \
-			 : godot_packed_float32_array_sort,  \
-			 godot_packed_float64_array *        \
-			 : godot_packed_float64_array_sort,  \
-			 godot_packed_string_array *         \
-			 : godot_packed_string_array_sort,   \
-			 godot_packed_vector2_array *        \
-			 : godot_packed_vector2_array_sort,  \
-			 godot_packed_vector2i_array *       \
-			 : godot_packed_vector2i_array_sort, \
-			 godot_packed_vector3_array *        \
-			 : godot_packed_vector3_array_sort,  \
-			 godot_packed_color_array *          \
-			 : godot_packed_color_array_sort)((p_self))
+#define godot_packed_array_sort(p_self)                                 \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_sort,         \
+        godot_packed_int32_array *:godot_packed_int32_array_sort,       \
+        godot_packed_int64_array *:godot_packed_int64_array_sort,       \
+        godot_packed_float32_array *:godot_packed_float32_array_sort,   \
+        godot_packed_float64_array *:godot_packed_float64_array_sort,   \
+        godot_packed_string_array *:godot_packed_string_array_sort,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_sort,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_sort, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_sort,   \
+        godot_packed_color_array *:godot_packed_color_array_sort)       \
+    ((p_self))
 
-#define godot_packed_array_invert(p_self)          \
-	_Generic((p_self),                             \
-			 godot_packed_byte_array *             \
-			 : godot_packed_byte_array_invert,     \
-			 godot_packed_int32_array *            \
-			 : godot_packed_int32_array_invert,    \
-			 godot_packed_int64_array *            \
-			 : godot_packed_int64_array_invert,    \
-			 godot_packed_float32_array *          \
-			 : godot_packed_float32_array_invert,  \
-			 godot_packed_float64_array *          \
-			 : godot_packed_float64_array_invert,  \
-			 godot_packed_string_array *           \
-			 : godot_packed_string_array_invert,   \
-			 godot_packed_vector2_array *          \
-			 : godot_packed_vector2_array_invert,  \
-			 godot_packed_vector2i_array *         \
-			 : godot_packed_vector2i_array_invert, \
-			 godot_packed_vector3_array *          \
-			 : godot_packed_vector3_array_invert,  \
-			 godot_packed_color_array *            \
-			 : godot_packed_color_array_invert)((p_self))
+#define godot_packed_array_invert(p_self)                                   \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_invert,           \
+        godot_packed_int32_array *:godot_packed_int32_array_invert,         \
+        godot_packed_int64_array *:godot_packed_int64_array_invert,         \
+        godot_packed_float32_array *:godot_packed_float32_array_invert,     \
+        godot_packed_float64_array *:godot_packed_float64_array_invert,     \
+        godot_packed_string_array *:godot_packed_string_array_invert,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_invert,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_invert,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_invert,     \
+        godot_packed_color_array *:godot_packed_color_array_invert)         \
+    ((p_self))
 
-#define godot_packed_array_push_back(p_self, p_data)  \
-	_Generic((p_self),                                \
-			 godot_packed_byte_array *                \
-			 : godot_packed_byte_array_push_back,     \
-			 godot_packed_int32_array *               \
-			 : godot_packed_int32_array_push_back,    \
-			 godot_packed_int64_array *               \
-			 : godot_packed_int64_array_push_back,    \
-			 godot_packed_float32_array *             \
-			 : godot_packed_float32_array_push_back,  \
-			 godot_packed_float64_array *             \
-			 : godot_packed_float64_array_push_back,  \
-			 godot_packed_string_array *              \
-			 : godot_packed_string_array_push_back,   \
-			 godot_packed_vector2_array *             \
-			 : godot_packed_vector2_array_push_back,  \
-			 godot_packed_vector2i_array *            \
-			 : godot_packed_vector2i_array_push_back, \
-			 godot_packed_vector3_array *             \
-			 : godot_packed_vector3_array_push_back,  \
-			 godot_packed_color_array *               \
-			 : godot_packed_color_array_push_back)((p_self), (p_data))
+#define godot_packed_array_push_back(p_self, p_data) \
+    _Generic((p_self),\
+        godot_packed_byte_array *:godot_packed_byte_array_push_back,\
+        godot_packed_int32_array *:godot_packed_int32_array_push_back,\
+        godot_packed_int64_array *:godot_packed_int64_array_push_back,\
+        godot_packed_float32_array *:godot_packed_float32_array_push_back,\
+        godot_packed_float64_array *:godot_packed_float64_array_push_back,\
+        godot_packed_string_array *:godot_packed_string_array_push_back,\
+        godot_packed_vector2_array *:godot_packed_vector2_array_push_back,\
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_push_back,\
+        godot_packed_vector3_array *:godot_packed_vector3_array_push_back,\
+        godot_packed_color_array *:godot_packed_color_array_push_back)\
+    (p_self)
 
-#define godot_packed_array_remove(p_self, p_idx)   \
-	_Generic((p_self),                             \
-			 godot_packed_byte_array *             \
-			 : godot_packed_byte_array_remove,     \
-			 godot_packed_int32_array *            \
-			 : godot_packed_int32_array_remove,    \
-			 godot_packed_int64_array *            \
-			 : godot_packed_int64_array_remove,    \
-			 godot_packed_float32_array *          \
-			 : godot_packed_float32_array_remove,  \
-			 godot_packed_float64_array *          \
-			 : godot_packed_float64_array_remove,  \
-			 godot_packed_string_array *           \
-			 : godot_packed_string_array_remove,   \
-			 godot_packed_vector2_array *          \
-			 : godot_packed_vector2_array_remove,  \
-			 godot_packed_vector2i_array *         \
-			 : godot_packed_vector2i_array_remove, \
-			 godot_packed_vector3_array *          \
-			 : godot_packed_vector3_array_remove,  \
-			 godot_packed_color_array *            \
-			 : godot_packed_color_array_remove)((p_self))
+#define godot_packed_array_remove(p_self, p_idx)                            \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_remove,           \
+        godot_packed_int32_array *:godot_packed_int32_array_remove,         \
+        godot_packed_int64_array *:godot_packed_int64_array_remove,         \
+        godot_packed_float32_array *:godot_packed_float32_array_remove,     \
+        godot_packed_float64_array *:godot_packed_float64_array_remove,     \
+        godot_packed_string_array *:godot_packed_string_array_remove,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_remove,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_remove,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_remove,     \
+        godot_packed_color_array *:godot_packed_color_array_remove)         \
+    ((p_self))
 
-#define godot_packed_array_resize(p_self, p_size)  \
-	_Generic((p_self),                             \
-			 godot_packed_byte_array *             \
-			 : godot_packed_byte_array_resize,     \
-			 godot_packed_int32_array *            \
-			 : godot_packed_int32_array_resize,    \
-			 godot_packed_int64_array *            \
-			 : godot_packed_int64_array_resize,    \
-			 godot_packed_float32_array *          \
-			 : godot_packed_float32_array_resize,  \
-			 godot_packed_float64_array *          \
-			 : godot_packed_float64_array_resize,  \
-			 godot_packed_string_array *           \
-			 : godot_packed_string_array_resize,   \
-			 godot_packed_vector2_array *          \
-			 : godot_packed_vector2_array_resize,  \
-			 godot_packed_vector2i_array *         \
-			 : godot_packed_vector2i_array_resize, \
-			 godot_packed_vector3_array *          \
-			 : godot_packed_vector3_array_resize,  \
-			 godot_packed_color_array *            \
-			 : godot_packed_color_array_resize)((p_self), (p_size))
+#define godot_packed_array_resize(p_self, p_size)                           \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_resize,           \
+        godot_packed_int32_array *:godot_packed_int32_array_resize,         \
+        godot_packed_int64_array *:godot_packed_int64_array_resize,         \
+        godot_packed_float32_array *:godot_packed_float32_array_resize,     \
+        godot_packed_float64_array *:godot_packed_float64_array_resize,     \
+        godot_packed_string_array *:godot_packed_string_array_resize,       \
+        godot_packed_vector2_array *:godot_packed_vector2_array_resize,     \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_resize,   \
+        godot_packed_vector3_array *:godot_packed_vector3_array_resize,     \
+        godot_packed_color_array *:godot_packed_color_array_resize)         \
+    ((p_self))
 
-#define godot_packed_array_set(p_self, p_idx, p_data) \
-	_Generic((p_self),                                \
-			 godot_packed_byte_array *                \
-			 : godot_packed_byte_array_set,           \
-			 godot_packed_int32_array *               \
-			 : godot_packed_int32_array_set,          \
-			 godot_packed_int64_array *               \
-			 : godot_packed_int64_array_set,          \
-			 godot_packed_float32_array *             \
-			 : godot_packed_float32_array_set,        \
-			 godot_packed_float64_array *             \
-			 : godot_packed_float64_array_set,        \
-			 godot_packed_string_array *              \
-			 : godot_packed_string_array_set,         \
-			 godot_packed_vector2_array *             \
-			 : godot_packed_vector2_array_set,        \
-			 godot_packed_vector2i_array *            \
-			 : godot_packed_vector2i_array_set,       \
-			 godot_packed_vector3_array *             \
-			 : godot_packed_vector3_array_set,        \
-			 godot_packed_color_array *               \
-			 : godot_packed_color_array_set)((p_self), (p_idx), (p_data))
+#define godot_packed_array_set(p_self, p_idx, p_data)                   \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_set,          \
+        godot_packed_int32_array *:godot_packed_int32_array_set,        \
+        godot_packed_int64_array *:godot_packed_int64_array_set,        \
+        godot_packed_float32_array *:godot_packed_float32_array_set,    \
+        godot_packed_float64_array *:godot_packed_float64_array_set,    \
+        godot_packed_string_array *:godot_packed_string_array_set,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_set,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_set,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_set,    \
+        godot_packed_color_array *:godot_packed_color_array_set)        \
+    ((p_self), (p_idx), (p_data))
 
-#define godot_packed_array_get(p_self, p_idx)   \
-	_Generic((p_self),                          \
-			 godot_packed_byte_array *          \
-			 : godot_packed_byte_array_get,     \
-			 godot_packed_int32_array *         \
-			 : godot_packed_int32_array_get,    \
-			 godot_packed_int64_array *         \
-			 : godot_packed_int64_array_get,    \
-			 godot_packed_float32_array *       \
-			 : godot_packed_float32_array_get,  \
-			 godot_packed_float64_array *       \
-			 : godot_packed_float64_array_get,  \
-			 godot_packed_string_array *        \
-			 : godot_packed_string_array_get,   \
-			 godot_packed_vector2_array *       \
-			 : godot_packed_vector2_array_get,  \
-			 godot_packed_vector2i_array *      \
-			 : godot_packed_vector2i_array_get, \
-			 godot_packed_vector3_array *       \
-			 : godot_packed_vector3_array_get,  \
-			 godot_packed_color_array *         \
-			 : godot_packed_color_array_get)((p_self), (p_idx))
+#define godot_packed_array_get(p_self, p_idx)                           \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_get,          \
+        godot_packed_int32_array *:godot_packed_int32_array_get,        \
+        godot_packed_int64_array *:godot_packed_int64_array_get,        \
+        godot_packed_float32_array *:godot_packed_float32_array_get,    \
+        godot_packed_float64_array *:godot_packed_float64_array_get,    \
+        godot_packed_string_array *:godot_packed_string_array_get,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_get,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_get,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_get,    \
+        godot_packed_color_array *:godot_packed_color_array_get)        \
+    ((p_self), (p_idx))
 
-#define godot_packed_array_size(p_self)          \
-	_Generic((p_self),                           \
-			 godot_packed_byte_array *           \
-			 : godot_packed_byte_array_size,     \
-			 godot_packed_int32_array *          \
-			 : godot_packed_int32_array_size,    \
-			 godot_packed_int64_array *          \
-			 : godot_packed_int64_array_size,    \
-			 godot_packed_float32_array *        \
-			 : godot_packed_float32_array_size,  \
-			 godot_packed_float64_array *        \
-			 : godot_packed_float64_array_size,  \
-			 godot_packed_string_array *         \
-			 : godot_packed_string_array_size,   \
-			 godot_packed_vector2_array *        \
-			 : godot_packed_vector2_array_size,  \
-			 godot_packed_vector2i_array *       \
-			 : godot_packed_vector2i_array_size, \
-			 godot_packed_vector3_array *        \
-			 : godot_packed_vector3_array_size,  \
-			 godot_packed_color_array *          \
-			 : godot_packed_color_array_size)((p_self))
+#define godot_packed_array_size(p_self)                                 \
+    _Generic((p_self),                                                  \
+        godot_packed_byte_array *:godot_packed_byte_array_size,         \
+        godot_packed_int32_array *:godot_packed_int32_array_size,       \
+        godot_packed_int64_array *:godot_packed_int64_array_size,       \
+        godot_packed_float32_array *:godot_packed_float32_array_size,   \
+        godot_packed_float64_array *:godot_packed_float64_array_size,   \
+        godot_packed_string_array *:godot_packed_string_array_size,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_size,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_size, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_size,   \
+        godot_packed_color_array *:godot_packed_color_array_size)       \
+    ((p_self))
 
-#define godot_packed_array_is_empty(p_self)          \
-	_Generic((p_self),                               \
-			 godot_packed_byte_array *               \
-			 : godot_packed_byte_array_is_empty,     \
-			 godot_packed_int32_array *              \
-			 : godot_packed_int32_array_is_empty,    \
-			 godot_packed_int64_array *              \
-			 : godot_packed_int64_array_is_empty,    \
-			 godot_packed_float32_array *            \
-			 : godot_packed_float32_array_is_empty,  \
-			 godot_packed_float64_array *            \
-			 : godot_packed_float64_array_is_empty,  \
-			 godot_packed_string_array *             \
-			 : godot_packed_string_array_is_empty,   \
-			 godot_packed_vector2_array *            \
-			 : godot_packed_vector2_array_is_empty,  \
-			 godot_packed_vector2i_array *           \
-			 : godot_packed_vector2i_array_is_empty, \
-			 godot_packed_vector3_array *            \
-			 : godot_packed_vector3_array_is_empty,  \
-			 godot_packed_color_array *              \
-			 : godot_packed_color_array_is_empty)((p_self))
+#define godot_packed_array_is_empty(p_self)                                 \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_is_empty,         \
+        godot_packed_int32_array *:godot_packed_int32_array_is_empty,       \
+        godot_packed_int64_array *:godot_packed_int64_array_is_empty,       \
+        godot_packed_float32_array *:godot_packed_float32_array_is_empty,   \
+        godot_packed_float64_array *:godot_packed_float64_array_is_empty,   \
+        godot_packed_string_array *:godot_packed_string_array_is_empty,     \
+        godot_packed_vector2_array *:godot_packed_vector2_array_is_empty,   \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_is_empty, \
+        godot_packed_vector3_array *:godot_packed_vector3_array_is_empty,   \
+        godot_packed_color_array *:godot_packed_color_array_is_empty)       \
+    ((p_self))
 
-#define godot_packed_array_destroy(p_self)          \
-	_Generic((p_self),                              \
-			 godot_packed_byte_array *              \
-			 : godot_packed_byte_array_destroy,     \
-			 godot_packed_int32_array *             \
-			 : godot_packed_int32_array_destroy,    \
-			 godot_packed_int64_array *             \
-			 : godot_packed_int64_array_destroy,    \
-			 godot_packed_float32_array *           \
-			 : godot_packed_float32_array_destroy,  \
-			 godot_packed_float64_array *           \
-			 : godot_packed_float64_array_destroy,  \
-			 godot_packed_string_array *            \
-			 : godot_packed_string_array_destroy,   \
-			 godot_packed_vector2_array *           \
-			 : godot_packed_vector2_array_destroy,  \
-			 godot_packed_vector2i_array *          \
-			 : godot_packed_vector2i_array_destroy, \
-			 godot_packed_vector3_array *           \
-			 : godot_packed_vector3_array_destroy,  \
-			 godot_packed_color_array *             \
-			 : godot_packed_color_array_destroy)((p_self))
+#define godot_packed_array_destroy(p_self)                                  \
+    _Generic((p_self),                                                      \
+        godot_packed_byte_array *:godot_packed_byte_array_destroy,          \
+        godot_packed_int32_array *:godot_packed_int32_array_destroy,        \
+        godot_packed_int64_array *:godot_packed_int64_array_destroy,        \
+        godot_packed_float32_array *:godot_packed_float32_array_destroy,    \
+        godot_packed_float64_array *:godot_packed_float64_array_destroy,    \
+        godot_packed_string_array *:godot_packed_string_array_destroy,      \
+        godot_packed_vector2_array *:godot_packed_vector2_array_destroy,    \
+        godot_packed_vector2i_array *:godot_packed_vector2i_array_destroy,  \
+        godot_packed_vector3_array *:godot_packed_vector3_array_destroy,    \
+        godot_packed_color_array *:godot_packed_color_array_destroy)        \
+    ((p_self))
 
 #endif
 

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -191,9 +191,6 @@ typedef void (*godot_ptr_utility_function)(void *r_return, const void **p_argume
 
 #include <gdnative/gdnative.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #if __STDC_VERSION__ >= 201112L
 #define godot_variant_new(r_dest, p_value)             \
 	_Generic((p_value),                                \

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -195,48 +195,84 @@ typedef void (*godot_ptr_utility_function)(void *r_return, const void **p_argume
 extern "C" {
 #endif
 #if __STDC_VERSION__ >= 201112L
-#define godot_variant_new(r_dest, p_value)                                      \
-    _Generic((p_value),                                                         \
-        godot_bool: godot_variant_new_bool,                                     \
-        int:      godot_variant_new_int,                                        \
-        uint64_t: godot_variant_new_uint,                                       \
-        int64_t:  godot_variant_new_int,                                        \
-        double:   godot_variant_new_real,                                       \
-        float:    godot_variant_new_real,                                       \
-        godot_string *: godot_variant_new_string,                               \
-        godot_string_name *: godot_variant_new_string_name,                     \
-        godot_vector2 *: godot_variant_new_vector2,                             \
-        godot_vector2i *: godot_variant_new_vector2i,                           \
-        godot_rect2 *: godot_variant_new_rect2,                                 \
-        godot_rect2i *: godot_variant_new_rect2i,                               \
-        godot_vector3 *: godot_variant_new_vector3,                             \
-        godot_vector3i *: godot_variant_new_vector3i,                           \
-        godot_transform2d *: godot_variant_new_transform2d,                     \
-        godot_plane *: godot_variant_new_plane,                                 \
-        godot_quat *: godot_variant_new_quat,                                   \
-        godot_aabb *: godot_variant_new_aabb,                                   \
-        godot_basis *: godot_variant_new_basis,                                 \
-        godot_transform *: godot_variant_new_transform,                         \
-        godot_color *: godot_variant_new_color,                                 \
-        godot_node_path *: godot_variant_new_node_path,                         \
-        godot_rid *: godot_variant_new_rid,                                     \
-        godot_callable *: godot_variant_new_callable,                           \
-        godot_signal *: godot_variant_new_signal,                               \
-        godot_object *: godot_variant_new_object,                               \
-        godot_dictionary *: godot_variant_new_dictionary,                       \
-        godot_array *: godot_variant_new_array,                                 \
-        godot_packed_byte_array *: godot_variant_new_packed_byte_array,         \
-        godot_packed_int32_array *: godot_variant_new_packed_int32_array,       \
-        godot_packed_int64_array *: godot_variant_new_packed_int64_array,       \
-        godot_packed_float32_array *: godot_variant_new_packed_float32_array,   \
-        godot_packed_float64_array *: godot_variant_new_packed_float64_array,   \
-        godot_packed_string_array *: godot_variant_new_packed_string_array,     \
-        godot_packed_vector2_array *: godot_variant_new_packed_vector2_array,   \
-        godot_packed_vector3_array *: godot_variant_new_packed_vector3_array,   \
-        godot_packed_color_array *: godot_variant_new_packed_color_array)       \
-    ((r_dest), (p_value))
+#define godot_variant_new(r_dest, p_value)             \
+	_Generic((p_value),                                \
+			 godot_bool                                \
+			 : godot_variant_new_bool,                 \
+			 int                                       \
+			 : godot_variant_new_int,                  \
+			 uint64_t                                  \
+			 : godot_variant_new_uint,                 \
+			 int64_t                                   \
+			 : godot_variant_new_int,                  \
+			 double                                    \
+			 : godot_variant_new_real,                 \
+			 float                                     \
+			 : godot_variant_new_real,                 \
+			 godot_string *                            \
+			 : godot_variant_new_string,               \
+			 godot_string_name *                       \
+			 : godot_variant_new_string_name,          \
+			 godot_vector2 *                           \
+			 : godot_variant_new_vector2,              \
+			 godot_vector2i *                          \
+			 : godot_variant_new_vector2i,             \
+			 godot_rect2 *                             \
+			 : godot_variant_new_rect2,                \
+			 godot_rect2i *                            \
+			 : godot_variant_new_rect2i,               \
+			 godot_vector3 *                           \
+			 : godot_variant_new_vector3,              \
+			 godot_vector3i *                          \
+			 : godot_variant_new_vector3i,             \
+			 godot_transform2d *                       \
+			 : godot_variant_new_transform2d,          \
+			 godot_plane *                             \
+			 : godot_variant_new_plane,                \
+			 godot_quat *                              \
+			 : godot_variant_new_quat,                 \
+			 godot_aabb *                              \
+			 : godot_variant_new_aabb,                 \
+			 godot_basis *                             \
+			 : godot_variant_new_basis,                \
+			 godot_transform *                         \
+			 : godot_variant_new_transform,            \
+			 godot_color *                             \
+			 : godot_variant_new_color,                \
+			 godot_node_path *                         \
+			 : godot_variant_new_node_path,            \
+			 godot_rid *                               \
+			 : godot_variant_new_rid,                  \
+			 godot_callable *                          \
+			 : godot_variant_new_callable,             \
+			 godot_signal *                            \
+			 : godot_variant_new_signal,               \
+			 godot_object *                            \
+			 : godot_variant_new_object,               \
+			 godot_dictionary *                        \
+			 : godot_variant_new_dictionary,           \
+			 godot_array *                             \
+			 : godot_variant_new_array,                \
+			 godot_packed_byte_array *                 \
+			 : godot_variant_new_packed_byte_array,    \
+			 godot_packed_int32_array *                \
+			 : godot_variant_new_packed_int32_array,   \
+			 godot_packed_int64_array *                \
+			 : godot_variant_new_packed_int64_array,   \
+			 godot_packed_float32_array *              \
+			 : godot_variant_new_packed_float32_array, \
+			 godot_packed_float64_array *              \
+			 : godot_variant_new_packed_float64_array, \
+			 godot_packed_string_array *               \
+			 : godot_variant_new_packed_string_array,  \
+			 godot_packed_vector2_array *              \
+			 : godot_variant_new_packed_vector2_array, \
+			 godot_packed_vector3_array *              \
+			 : godot_variant_new_packed_vector3_array, \
+			 godot_packed_color_array *                \
+			 : godot_variant_new_packed_color_array)((r_dest), (p_value))
 #endif
-	
+
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 // Memory.
 

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -233,7 +233,7 @@ extern "C" {
         godot_packed_string_array *: godot_variant_new_packed_string_array,     \
         godot_packed_vector2_array *: godot_variant_new_packed_vector2_array,   \
         godot_packed_vector3_array *: godot_variant_new_packed_vector3_array,   \
-        godot_packed_color_array *: godot_variant_new_packed_color_array,       \
+        godot_packed_color_array *: godot_variant_new_packed_color_array)       \
     ((r_dest), (p_value))
 #endif
 	

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -194,7 +194,7 @@ typedef void (*godot_ptr_utility_function)(void *r_return, const void **p_argume
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+#if __STDC_VERSION__ >= 201112L
 #define godot_variant_new(r_dest, p_value)                                      \
     _Generic((p_value),                                                         \
         godot_bool: godot_variant_new_bool,                                     \
@@ -236,7 +236,7 @@ extern "C" {
         godot_packed_color_array *: godot_variant_new_packed_color_array,       \
     ((r_dest), (p_value))
 #endif
-
+	
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 // Memory.
 

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -191,6 +191,53 @@ typedef void (*godot_ptr_utility_function)(void *r_return, const void **p_argume
 
 #include <gdnative/gdnative.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define godot_variant_new(r_dest, p_value)                                      \
+    _Generic((p_value),                                                         \
+        godot_bool: godot_variant_new_bool,                                     \
+        int:      godot_variant_new_int,                                        \
+        uint64_t: godot_variant_new_uint,                                       \
+        int64_t:  godot_variant_new_int,                                        \
+        double:   godot_variant_new_real,                                       \
+        float:    godot_variant_new_real,                                       \
+        godot_string *: godot_variant_new_string,                               \
+        godot_string_name *: godot_variant_new_string_name,                     \
+        godot_vector2 *: godot_variant_new_vector2,                             \
+        godot_vector2i *: godot_variant_new_vector2i,                           \
+        godot_rect2 *: godot_variant_new_rect2,                                 \
+        godot_rect2i *: godot_variant_new_rect2i,                               \
+        godot_vector3 *: godot_variant_new_vector3,                             \
+        godot_vector3i *: godot_variant_new_vector3i,                           \
+        godot_transform2d *: godot_variant_new_transform2d,                     \
+        godot_plane *: godot_variant_new_plane,                                 \
+        godot_quat *: godot_variant_new_quat,                                   \
+        godot_aabb *: godot_variant_new_aabb,                                   \
+        godot_basis *: godot_variant_new_basis,                                 \
+        godot_transform *: godot_variant_new_transform,                         \
+        godot_color *: godot_variant_new_color,                                 \
+        godot_node_path *: godot_variant_new_node_path,                         \
+        godot_rid *: godot_variant_new_rid,                                     \
+        godot_callable *: godot_variant_new_callable,                           \
+        godot_signal *: godot_variant_new_signal,                               \
+        godot_object *: godot_variant_new_object,                               \
+        godot_dictionary *: godot_variant_new_dictionary,                       \
+        godot_array *: godot_variant_new_array,                                 \
+        godot_packed_byte_array *: godot_variant_new_packed_byte_array,         \
+        godot_packed_int32_array *: godot_variant_new_packed_int32_array,       \
+        godot_packed_int64_array *: godot_variant_new_packed_int64_array,       \
+        godot_packed_float32_array *: godot_variant_new_packed_float32_array,   \
+        godot_packed_float64_array *: godot_variant_new_packed_float64_array,   \
+        godot_packed_string_array *: godot_variant_new_packed_string_array,     \
+        godot_packed_vector2_array *: godot_variant_new_packed_vector2_array,   \
+        godot_packed_vector3_array *: godot_variant_new_packed_vector3_array,   \
+        godot_packed_color_array *: godot_variant_new_packed_color_array,       \
+    ((r_dest), (p_value))
+#endif
+
+godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 // Memory.
 
 void GDAPI godot_variant_new_copy(godot_variant *r_dest, const godot_variant *p_src);

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -195,84 +195,6 @@ typedef void (*godot_ptr_utility_function)(void *r_return, const void **p_argume
 extern "C" {
 #endif
 #if __STDC_VERSION__ >= 201112L
-#define godot_variant_new(r_dest, p_value)             \
-	_Generic((p_value),                                \
-			 godot_bool                                \
-			 : godot_variant_new_bool,                 \
-			 int                                       \
-			 : godot_variant_new_int,                  \
-			 uint64_t                                  \
-			 : godot_variant_new_uint,                 \
-			 int64_t                                   \
-			 : godot_variant_new_int,                  \
-			 double                                    \
-			 : godot_variant_new_real,                 \
-			 float                                     \
-			 : godot_variant_new_real,                 \
-			 godot_string *                            \
-			 : godot_variant_new_string,               \
-			 godot_string_name *                       \
-			 : godot_variant_new_string_name,          \
-			 godot_vector2 *                           \
-			 : godot_variant_new_vector2,              \
-			 godot_vector2i *                          \
-			 : godot_variant_new_vector2i,             \
-			 godot_rect2 *                             \
-			 : godot_variant_new_rect2,                \
-			 godot_rect2i *                            \
-			 : godot_variant_new_rect2i,               \
-			 godot_vector3 *                           \
-			 : godot_variant_new_vector3,              \
-			 godot_vector3i *                          \
-			 : godot_variant_new_vector3i,             \
-			 godot_transform2d *                       \
-			 : godot_variant_new_transform2d,          \
-			 godot_plane *                             \
-			 : godot_variant_new_plane,                \
-			 godot_quat *                              \
-			 : godot_variant_new_quat,                 \
-			 godot_aabb *                              \
-			 : godot_variant_new_aabb,                 \
-			 godot_basis *                             \
-			 : godot_variant_new_basis,                \
-			 godot_transform *                         \
-			 : godot_variant_new_transform,            \
-			 godot_color *                             \
-			 : godot_variant_new_color,                \
-			 godot_node_path *                         \
-			 : godot_variant_new_node_path,            \
-			 godot_rid *                               \
-			 : godot_variant_new_rid,                  \
-			 godot_callable *                          \
-			 : godot_variant_new_callable,             \
-			 godot_signal *                            \
-			 : godot_variant_new_signal,               \
-			 godot_object *                            \
-			 : godot_variant_new_object,               \
-			 godot_dictionary *                        \
-			 : godot_variant_new_dictionary,           \
-			 godot_array *                             \
-			 : godot_variant_new_array,                \
-			 godot_packed_byte_array *                 \
-			 : godot_variant_new_packed_byte_array,    \
-			 godot_packed_int32_array *                \
-			 : godot_variant_new_packed_int32_array,   \
-			 godot_packed_int64_array *                \
-			 : godot_variant_new_packed_int64_array,   \
-			 godot_packed_float32_array *              \
-			 : godot_variant_new_packed_float32_array, \
-			 godot_packed_float64_array *              \
-			 : godot_variant_new_packed_float64_array, \
-			 godot_packed_string_array *               \
-			 : godot_variant_new_packed_string_array,  \
-			 godot_packed_vector2_array *              \
-			 : godot_variant_new_packed_vector2_array, \
-			 godot_packed_vector3_array *              \
-			 : godot_variant_new_packed_vector3_array, \
-			 godot_packed_color_array *                \
-			 : godot_variant_new_packed_color_array)((r_dest), (p_value))
-#endif
-
 #define godot_variant_new(r_dest, p_value)                                      \
     _Generic((p_value),                                                         \
         godot_bool: godot_variant_new_bool,                                     \
@@ -314,7 +236,7 @@ extern "C" {
         godot_packed_color_array *: godot_variant_new_packed_color_array,       \
     ((r_dest), (p_value))
 #endif
-
+	
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 // Memory.
 

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -273,6 +273,48 @@ extern "C" {
 			 : godot_variant_new_packed_color_array)((r_dest), (p_value))
 #endif
 
+#define godot_variant_new(r_dest, p_value)                                      \
+    _Generic((p_value),                                                         \
+        godot_bool: godot_variant_new_bool,                                     \
+        int:      godot_variant_new_int,                                        \
+        uint64_t: godot_variant_new_uint,                                       \
+        int64_t:  godot_variant_new_int,                                        \
+        double:   godot_variant_new_real,                                       \
+        float:    godot_variant_new_real,                                       \
+        godot_string *: godot_variant_new_string,                               \
+        godot_string_name *: godot_variant_new_string_name,                     \
+        godot_vector2 *: godot_variant_new_vector2,                             \
+        godot_vector2i *: godot_variant_new_vector2i,                           \
+        godot_rect2 *: godot_variant_new_rect2,                                 \
+        godot_rect2i *: godot_variant_new_rect2i,                               \
+        godot_vector3 *: godot_variant_new_vector3,                             \
+        godot_vector3i *: godot_variant_new_vector3i,                           \
+        godot_transform2d *: godot_variant_new_transform2d,                     \
+        godot_plane *: godot_variant_new_plane,                                 \
+        godot_quat *: godot_variant_new_quat,                                   \
+        godot_aabb *: godot_variant_new_aabb,                                   \
+        godot_basis *: godot_variant_new_basis,                                 \
+        godot_transform *: godot_variant_new_transform,                         \
+        godot_color *: godot_variant_new_color,                                 \
+        godot_node_path *: godot_variant_new_node_path,                         \
+        godot_rid *: godot_variant_new_rid,                                     \
+        godot_callable *: godot_variant_new_callable,                           \
+        godot_signal *: godot_variant_new_signal,                               \
+        godot_object *: godot_variant_new_object,                               \
+        godot_dictionary *: godot_variant_new_dictionary,                       \
+        godot_array *: godot_variant_new_array,                                 \
+        godot_packed_byte_array *: godot_variant_new_packed_byte_array,         \
+        godot_packed_int32_array *: godot_variant_new_packed_int32_array,       \
+        godot_packed_int64_array *: godot_variant_new_packed_int64_array,       \
+        godot_packed_float32_array *: godot_variant_new_packed_float32_array,   \
+        godot_packed_float64_array *: godot_variant_new_packed_float64_array,   \
+        godot_packed_string_array *: godot_variant_new_packed_string_array,     \
+        godot_packed_vector2_array *: godot_variant_new_packed_vector2_array,   \
+        godot_packed_vector3_array *: godot_variant_new_packed_vector3_array,   \
+        godot_packed_color_array *: godot_variant_new_packed_color_array,       \
+    ((r_dest), (p_value))
+#endif
+
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 // Memory.
 


### PR DESCRIPTION
I had originally posted this pull request to the godot_headers repository so now I'm (hopefully) posting this in the right place.

I have added a type generic to both variant and pool arrays.
This is to makes it easier to use when running in c11 or newer standards.

It's a type generic interface so a bit like a template in c++ but it's c11 instead
https://en.cppreference.com/w/c/language/generic
```c 
godot_variant ret;
// instead of this
godot_variant_new_int(&ret, 10);
// you can just say (in c11 and up)
godot_variant_new(&ret, 10);
```
I have only made interfaces where I think it would be most useful but there are a lot of other places where this could also help.
like for instance all the different vector types could have a common interface, but I think this would need further discussion