### PR TITLE
Keep RichTextLabel visible character properties in sync

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -455,6 +455,7 @@
 		</member>
 		<member name="visible_characters" type="int" setter="set_visible_characters" getter="get_visible_characters" default="-1">
 			The restricted number of characters to display in the label. If [code]-1[/code], all characters will be displayed.
+			[b]Note:[/b] Setting this property updates [member percent_visible] based on current [method get_total_character_count].
 		</member>
 	</members>
 	<signals>

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3716,6 +3716,7 @@ void RichTextLabel::set_percent_visible(float p_percent) {
 		}
 		main->first_invalid_line = 0; //invalidate ALL
 		_validate_line_caches(main);
+		_change_notify("visible_characters");
 		update();
 	}
 }
@@ -3929,6 +3930,15 @@ void RichTextLabel::_bind_methods() {
 
 void RichTextLabel::set_visible_characters(int p_visible) {
 	visible_characters = p_visible;
+	if (p_visible == -1) {
+		percent_visible = 1;
+	} else {
+		int total_char_count = get_total_character_count();
+		if (total_char_count > 0) {
+			percent_visible = (float)p_visible / (float)total_char_count;
+		}
+	}
+	_change_notify("percent_visible");
 	update();
 }
 


### PR DESCRIPTION
The RichTextLabel class is inconsistent in how it updates the
visible_characters and percent_visible properties when either is changed.

To keep both properties consistent, update percent_visible when setting the
visible_characters property.
For both properties, when setting one, notify change for the other.

Docs updated for member set_visible_characters on RichTextLabel class.

Fixes https://github.com/godotengine/godot/issues/37778

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
