### PR TITLE
Basic warning support implementation for the Godot Shading Language.

### DIFF
--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -35,6 +35,7 @@
 #include "editor/editor_plugin.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/rich_text_label.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/text_edit.h"
 #include "scene/main/timer.h"
@@ -46,10 +47,17 @@ class ShaderTextEditor : public CodeTextEditor {
 
 	Color marked_line_color = Color(1, 1, 1);
 
+	struct WarningsComparator {
+		_ALWAYS_INLINE_ bool operator()(const ShaderWarning &p_a, const ShaderWarning &p_b) const { return (p_a.get_line() < p_b.get_line()); }
+	};
+
 	Ref<CodeHighlighter> syntax_highlighter;
+	RichTextLabel *warnings_panel = nullptr;
 	Ref<Shader> shader;
+	List<ShaderWarning> warnings;
 
 	void _check_shader_mode();
+	void _update_warning_panel();
 
 protected:
 	static void _bind_methods();
@@ -61,6 +69,7 @@ public:
 	virtual void _validate_script() override;
 
 	void reload_text();
+	void set_warnings_panel(RichTextLabel *p_warnings_panel);
 
 	Ref<Shader> get_edited_shader() const;
 	void set_edited_shader(const Ref<Shader> &p_shader);
@@ -102,6 +111,7 @@ class ShaderEditor : public PanelContainer {
 	PopupMenu *bookmarks_menu;
 	MenuButton *help_menu;
 	PopupMenu *context_menu;
+	RichTextLabel *warnings_panel = nullptr;
 	uint64_t idle;
 
 	GotoLineDialog *goto_line_dialog;
@@ -111,13 +121,16 @@ class ShaderEditor : public PanelContainer {
 	ShaderTextEditor *shader_editor;
 
 	void _menu_option(int p_option);
-	void _params_changed();
 	mutable Ref<Shader> shader;
 
 	void _editor_settings_changed();
+	void _project_settings_changed();
 
 	void _check_for_external_edit();
 	void _reload_shader_from_disk();
+	void _show_warnings_panel(bool p_show);
+	void _warning_clicked(Variant p_line);
+	void _update_warnings(bool p_validate);
 
 protected:
 	void _notification(int p_what);

--- a/servers/rendering/shader_warnings.cpp
+++ b/servers/rendering/shader_warnings.cpp
@@ -1,0 +1,131 @@
+/*************************************************************************/
+/*  shader_warnings.cpp                                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "shader_warnings.h"
+#include "core/variant/variant.h"
+
+#ifdef DEBUG_ENABLED
+
+ShaderWarning::Code ShaderWarning::get_code() const {
+	return code;
+}
+
+int ShaderWarning::get_line() const {
+	return line;
+}
+
+const StringName &ShaderWarning::get_subject() const {
+	return subject;
+}
+
+String ShaderWarning::get_message() const {
+	switch (code) {
+		case FLOAT_COMPARISON:
+			return vformat("Direct floating-point comparison (this may not evaluate to `true` as you expect). Instead, use `abs(a - b) < 0.0001` for an approximate but predictable comparison.");
+		case UNUSED_CONSTANT:
+			return vformat("The const '%s' is declared but never used.", subject);
+		case UNUSED_FUNCTION:
+			return vformat("The function '%s' is declared but never used.", subject);
+		case UNUSED_STRUCT:
+			return vformat("The struct '%s' is declared but never used.", subject);
+		case UNUSED_UNIFORM:
+			return vformat("The uniform '%s' is declared but never used.", subject);
+		case UNUSED_VARYING:
+			return vformat("The varying '%s' is declared but never used.", subject);
+		default:
+			break;
+	}
+	return String();
+}
+
+String ShaderWarning::get_name() const {
+	return get_name_from_code(code);
+}
+
+String ShaderWarning::get_name_from_code(Code p_code) {
+	ERR_FAIL_INDEX_V(p_code, WARNING_MAX, String());
+
+	static const char *names[] = {
+		"FLOAT_COMPARISON",
+		"UNUSED_CONSTANT",
+		"UNUSED_FUNCTION",
+		"UNUSED_STRUCT",
+		"UNUSED_UNIFORM",
+		"UNUSED_VARYING",
+	};
+
+	static_assert((sizeof(names) / sizeof(*names)) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");
+
+	return names[(int)p_code];
+}
+
+ShaderWarning::Code ShaderWarning::get_code_from_name(const String &p_name) {
+	for (int i = 0; i < WARNING_MAX; i++) {
+		if (get_name_from_code((Code)i) == p_name) {
+			return (Code)i;
+		}
+	}
+
+	ERR_FAIL_V_MSG(WARNING_MAX, "Invalid shader warning name: " + p_name);
+}
+
+static Map<int, uint32_t> *code_to_flags_map = nullptr;
+
+static void init_code_to_flags_map() {
+	code_to_flags_map = memnew((Map<int, uint32_t>));
+	code_to_flags_map->insert(ShaderWarning::FLOAT_COMPARISON, ShaderWarning::FLOAT_COMPARISON_FLAG);
+	code_to_flags_map->insert(ShaderWarning::UNUSED_CONSTANT, ShaderWarning::UNUSED_CONSTANT_FLAG);
+	code_to_flags_map->insert(ShaderWarning::UNUSED_FUNCTION, ShaderWarning::UNUSED_FUNCTION_FLAG);
+	code_to_flags_map->insert(ShaderWarning::UNUSED_STRUCT, ShaderWarning::UNUSED_STRUCT_FLAG);
+	code_to_flags_map->insert(ShaderWarning::UNUSED_UNIFORM, ShaderWarning::UNUSED_UNIFORM_FLAG);
+	code_to_flags_map->insert(ShaderWarning::UNUSED_VARYING, ShaderWarning::UNUSED_VARYING_FLAG);
+}
+
+ShaderWarning::CodeFlags ShaderWarning::get_flags_from_codemap(const Map<Code, bool> &p_map) {
+	uint32_t result = 0U;
+
+	if (code_to_flags_map == nullptr) {
+		init_code_to_flags_map();
+	}
+
+	for (Map<Code, bool>::Element *E = p_map.front(); E; E = E->next()) {
+		if (E->get()) {
+			ERR_FAIL_COND_V(!code_to_flags_map->has((int)E->key()), ShaderWarning::NONE_FLAG);
+			result |= (*code_to_flags_map)[(int)E->key()];
+		}
+	}
+	return (CodeFlags)result;
+}
+
+ShaderWarning::ShaderWarning(Code p_code, int p_line, const StringName &p_subject) :
+		code(p_code), line(p_line), subject(p_subject) {
+}
+
+#endif // DEBUG_ENABLED

--- a/servers/rendering/shader_warnings.h
+++ b/servers/rendering/shader_warnings.h
@@ -1,0 +1,83 @@
+/*************************************************************************/
+/*  shader_warnings.h                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SHADER_WARNINGS
+#define SHADER_WARNINGS
+
+#ifdef DEBUG_ENABLED
+
+#include "core/string/string_name.h"
+#include "core/templates/list.h"
+#include "core/templates/map.h"
+
+class ShaderWarning {
+public:
+	enum Code {
+		FLOAT_COMPARISON,
+		UNUSED_CONSTANT,
+		UNUSED_FUNCTION,
+		UNUSED_STRUCT,
+		UNUSED_UNIFORM,
+		UNUSED_VARYING,
+		WARNING_MAX,
+	};
+
+	enum CodeFlags : uint32_t {
+		NONE_FLAG = 0U,
+		FLOAT_COMPARISON_FLAG = 1U,
+		UNUSED_CONSTANT_FLAG = 2U,
+		UNUSED_FUNCTION_FLAG = 4U,
+		UNUSED_STRUCT_FLAG = 8U,
+		UNUSED_UNIFORM_FLAG = 16U,
+		UNUSED_VARYING_FLAG = 32U,
+	};
+
+private:
+	Code code;
+	int line;
+	StringName subject;
+
+public:
+	Code get_code() const;
+	int get_line() const;
+	const StringName &get_subject() const;
+	String get_message() const;
+	String get_name() const;
+
+	static String get_name_from_code(Code p_code);
+	static Code get_code_from_name(const String &p_name);
+	static CodeFlags get_flags_from_codemap(const Map<Code, bool> &p_map);
+
+	ShaderWarning(Code p_code = WARNING_MAX, int p_line = -1, const StringName &p_subject = "");
+};
+
+#endif // DEBUG_ENABLED
+
+#endif // SHADER_WARNINGS


### PR DESCRIPTION
Basic warning support implementation for the Godot Shading Language.

![warnings](https://user-images.githubusercontent.com/3036176/103462231-d27d5780-4d34-11eb-94bb-e54d230a0ef8.gif)

Currently implemented warnings:

- UNUSED_CONSTANT
- UNUSED_VARYING
- UNUSED_UNIFORM
- UNUSED_FUNCTION
- UNUSED_STRUCT

They are configured inside project settings:

![image](https://user-images.githubusercontent.com/3036176/103462094-fbe9b380-4d33-11eb-8f01-a5713fce062c.png)

