### PR TITLE
Restore text_edit shortcuts with Alt on Linux

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -584,7 +584,11 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 			if (handled) {
 				accept_event();
+#ifdef WINDOWS_ENABLED
 			} else if (!k->get_command() || (k->get_command() && k->get_alt())) {
+#else
+			} else if (!k->get_command()) {
+#endif
 				if (k->get_unicode() >= 32 && k->get_keycode() != KEY_DELETE) {
 					if (editable) {
 						selection_delete();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3619,7 +3619,11 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			return;
 		}
 
+#ifdef WINDOWS_ENABLED
 		if (!keycode_handled && (!k->get_command() || (k->get_command() && k->get_alt()))) { // For German keyboards.
+#else
+		if (!keycode_handled && !k->get_command()) { // For German keyboards.
+#endif
 
 			if (k->get_unicode() >= 32) {
 				if (readonly) {


### PR DESCRIPTION
Shortcuts such as Ctrl+Alt+S stopped working following #37769 on Linux.
Fixes #41942, also helps with #43117 on Linux.

I tested this on Linux Mint 20 and Windows 10 with a French keyboard layout on an AZERTY keyboard. On Windows, I am able to use both AltGr and Ctrl+Alt to type special characters such as {}~[], which are located on the number keys in my layout.
On Linux, shortcuts such as Ctrl+Alt+S to save the currently edited script work again; I cannot use Ctrl+Alt to type special characters, but that's apparently not related to Godot itself, as I am unable to do so in other applications as well.

This PR only restores line_edit and text_edit's behavior to what it was before #37769 on Linux.