### PR TITLE
Fix properties still using a slash delimiter

### DIFF
--- a/doc/classes/AudioEffectChorus.xml
+++ b/doc/classes/AudioEffectChorus.xml
@@ -15,6 +15,7 @@
 			<argument index="0" name="voice_idx" type="int">
 			</argument>
 			<description>
+				Returns the specified voice's cutoff frequency in Hz.
 			</description>
 		</method>
 		<method name="get_voice_delay_ms" qualifiers="const">
@@ -23,6 +24,7 @@
 			<argument index="0" name="voice_idx" type="int">
 			</argument>
 			<description>
+				Returns the specified voice's signal delay in milliseconds.
 			</description>
 		</method>
 		<method name="get_voice_depth_ms" qualifiers="const">
@@ -31,6 +33,7 @@
 			<argument index="0" name="voice_idx" type="int">
 			</argument>
 			<description>
+				Returns the specified voice's depth in milliseconds.
 			</description>
 		</method>
 		<method name="get_voice_level_db" qualifiers="const">
@@ -39,6 +42,7 @@
 			<argument index="0" name="voice_idx" type="int">
 			</argument>
 			<description>
+				Returns the specified voice's decibel level.
 			</description>
 		</method>
 		<method name="get_voice_pan" qualifiers="const">
@@ -47,6 +51,7 @@
 			<argument index="0" name="voice_idx" type="int">
 			</argument>
 			<description>
+				Returns the specified voice's pan position. A pan of [code]-1[/code] is fully to the left. A pan of [code]1[/code] is fully to the right.
 			</description>
 		</method>
 		<method name="get_voice_rate_hz" qualifiers="const">
@@ -55,6 +60,7 @@
 			<argument index="0" name="voice_idx" type="int">
 			</argument>
 			<description>
+				Returns the specified voice's rate in Hz.
 			</description>
 		</method>
 		<method name="set_voice_cutoff_hz">
@@ -65,6 +71,7 @@
 			<argument index="1" name="cutoff_hz" type="float">
 			</argument>
 			<description>
+				Sets the specified voice's cutoff frequency in Hz.
 			</description>
 		</method>
 		<method name="set_voice_delay_ms">
@@ -75,6 +82,7 @@
 			<argument index="1" name="delay_ms" type="float">
 			</argument>
 			<description>
+				Sets the specified voice's signal delay in milliseconds.
 			</description>
 		</method>
 		<method name="set_voice_depth_ms">
@@ -85,6 +93,7 @@
 			<argument index="1" name="depth_ms" type="float">
 			</argument>
 			<description>
+				Sets the specified voice's depth in milliseconds.
 			</description>
 		</method>
 		<method name="set_voice_level_db">
@@ -95,6 +104,7 @@
 			<argument index="1" name="level_db" type="float">
 			</argument>
 			<description>
+				Sets the specified voice's decibel level.
 			</description>
 		</method>
 		<method name="set_voice_pan">
@@ -105,6 +115,7 @@
 			<argument index="1" name="pan" type="float">
 			</argument>
 			<description>
+				Sets the specified voice's pan position. A pan of [code]-1[/code] is fully to the left. A pan of [code]1[/code] is fully to the right.
 			</description>
 		</method>
 		<method name="set_voice_rate_hz">
@@ -115,90 +126,91 @@
 			<argument index="1" name="rate_hz" type="float">
 			</argument>
 			<description>
+				Sets the specified voice's rate in Hz.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="dry" type="float" setter="set_dry" getter="get_dry" default="1.0">
-			The effect's raw signal.
+			The proportion of the original sound to include. At [code]0[/code], only the chorus sounds are output. The value can range from [code]0[/code] to [code]1[/code].
 		</member>
-		<member name="voice/1/cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz" default="8000.0">
-			The voice's cutoff frequency.
+		<member name="voice_1_cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz" default="8000.0">
+			Voice 1's cutoff frequency in Hz.
 		</member>
-		<member name="voice/1/delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms" default="15.0">
-			The voice's signal delay.
+		<member name="voice_1_delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms" default="15.0">
+			Voice 1's signal delay in milliseconds.
 		</member>
-		<member name="voice/1/depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms" default="2.0">
-			The voice filter's depth.
+		<member name="voice_1_depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms" default="2.0">
+			Voice 1's depth in milliseconds.
 		</member>
-		<member name="voice/1/level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db" default="0.0">
-			The voice's volume.
+		<member name="voice_1_level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db" default="0.0">
+			Voice 1's decibel level.
 		</member>
-		<member name="voice/1/pan" type="float" setter="set_voice_pan" getter="get_voice_pan" default="-0.5">
-			The voice's pan level.
+		<member name="voice_1_pan" type="float" setter="set_voice_pan" getter="get_voice_pan" default="-0.5">
+			Voice 1's pan position. A pan of [code]-1[/code] is fully to the left. A pan of [code]1[/code] is fully to the right.
 		</member>
-		<member name="voice/1/rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz" default="0.8">
-			The voice's filter rate.
+		<member name="voice_1_rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz" default="0.8">
+			Voice 1's rate in Hz.
 		</member>
-		<member name="voice/2/cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz" default="8000.0">
-			The voice's cutoff frequency.
+		<member name="voice_2_cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz" default="8000.0">
+			Voice 2's cutoff frequency in Hz.
 		</member>
-		<member name="voice/2/delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms" default="20.0">
-			The voice's signal delay.
+		<member name="voice_2_delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms" default="20.0">
+			Voice 2's signal delay in milliseconds.
 		</member>
-		<member name="voice/2/depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms" default="3.0">
-			The voice filter's depth.
+		<member name="voice_2_depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms" default="3.0">
+			Voice 2's depth in milliseconds.
 		</member>
-		<member name="voice/2/level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db" default="0.0">
-			The voice's volume.
+		<member name="voice_2_level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db" default="0.0">
+			Voice 2's decibel level.
 		</member>
-		<member name="voice/2/pan" type="float" setter="set_voice_pan" getter="get_voice_pan" default="0.5">
-			The voice's pan level.
+		<member name="voice_2_pan" type="float" setter="set_voice_pan" getter="get_voice_pan" default="0.5">
+			Voice 2's pan position. A pan of [code]-1[/code] is fully to the left. A pan of [code]1[/code] is fully to the right.
 		</member>
-		<member name="voice/2/rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz" default="1.2">
-			The voice's filter rate.
+		<member name="voice_2_rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz" default="1.2">
+			Voice 2's rate in Hz.
 		</member>
-		<member name="voice/3/cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz">
-			The voice's cutoff frequency.
+		<member name="voice_3_cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz">
+			Voice 3's cutoff frequency in Hz.
 		</member>
-		<member name="voice/3/delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms">
-			The voice's signal delay.
+		<member name="voice_3_delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms">
+			Voice 3's signal delay in milliseconds.
 		</member>
-		<member name="voice/3/depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms">
-			The voice filter's depth.
+		<member name="voice_3_depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms">
+			Voice 3's depth in milliseconds.
 		</member>
-		<member name="voice/3/level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db">
-			The voice's volume.
+		<member name="voice_3_level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db">
+			Voice 3's decibel level.
 		</member>
-		<member name="voice/3/pan" type="float" setter="set_voice_pan" getter="get_voice_pan">
-			The voice's pan level.
+		<member name="voice_3_pan" type="float" setter="set_voice_pan" getter="get_voice_pan">
+			Voice 3's pan position. A pan of [code]-1[/code] is fully to the left. A pan of [code]1[/code] is fully to the right.
 		</member>
-		<member name="voice/3/rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz">
-			The voice's filter rate.
+		<member name="voice_3_rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz">
+			Voice 3's rate in Hz.
 		</member>
-		<member name="voice/4/cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz">
-			The voice's cutoff frequency.
+		<member name="voice_4_cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz">
+			Voice 4's cutoff frequency in Hz.
 		</member>
-		<member name="voice/4/delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms">
-			The voice's signal delay.
+		<member name="voice_4_delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms">
+			Voice 4's signal delay in milliseconds.
 		</member>
-		<member name="voice/4/depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms">
-			The voice filter's depth.
+		<member name="voice_4_depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms">
+			Voice 4's depth in milliseconds.
 		</member>
-		<member name="voice/4/level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db">
-			The voice's volume.
+		<member name="voice_4_level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db">
+			Voice 4's decibel level.
 		</member>
-		<member name="voice/4/pan" type="float" setter="set_voice_pan" getter="get_voice_pan">
-			The voice's pan level.
+		<member name="voice_4_pan" type="float" setter="set_voice_pan" getter="get_voice_pan">
+			Voice 4's pan position. A pan of [code]-1[/code] is fully to the left. A pan of [code]1[/code] is fully to the right.
 		</member>
-		<member name="voice/4/rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz">
-			The voice's filter rate.
+		<member name="voice_4_rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz">
+			Voice 4's rate in Hz.
 		</member>
 		<member name="voice_count" type="int" setter="set_voice_count" getter="get_voice_count" default="2">
-			The amount of voices in the effect.
+			The number of voices in the chorus.
 		</member>
 		<member name="wet" type="float" setter="set_wet" getter="get_wet" default="0.5">
-			The effect's processed signal.
+			The proportion of the processed sound to include. At [code]0[/code], only the original sound is output. Value can range from [code]0[/code] to [code]1[/code].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AudioEffectDelay.xml
+++ b/doc/classes/AudioEffectDelay.xml
@@ -13,43 +13,43 @@
 	</methods>
 	<members>
 		<member name="dry" type="float" setter="set_dry" getter="get_dry" default="1.0">
-			Output percent of original sound. At 0, only delayed sounds are output. Value can range from 0 to 1.
+			The proportion of the original sound to include. At [code]0[/code], only delayed sounds are output. The value can range from [code]0[/code] to [code]1[/code].
 		</member>
-		<member name="feedback/active" type="bool" setter="set_feedback_active" getter="is_feedback_active" default="false">
+		<member name="feedback_active" type="bool" setter="set_feedback_active" getter="is_feedback_active" default="false">
 			If [code]true[/code], feedback is enabled.
 		</member>
-		<member name="feedback/delay_ms" type="float" setter="set_feedback_delay_ms" getter="get_feedback_delay_ms" default="340.0">
+		<member name="feedback_delay_ms" type="float" setter="set_feedback_delay_ms" getter="get_feedback_delay_ms" default="340.0">
 			Feedback delay time in milliseconds.
 		</member>
-		<member name="feedback/level_db" type="float" setter="set_feedback_level_db" getter="get_feedback_level_db" default="-6.0">
-			Sound level for [code]tap1[/code].
+		<member name="feedback_level_db" type="float" setter="set_feedback_level_db" getter="get_feedback_level_db" default="-6.0">
+			Feedback decibel level.
 		</member>
-		<member name="feedback/lowpass" type="float" setter="set_feedback_lowpass" getter="get_feedback_lowpass" default="16000.0">
-			Low-pass filter for feedback, in Hz. Frequencies below this value are filtered out of the source signal.
+		<member name="feedback_low_pass" type="float" setter="set_feedback_low_pass" getter="get_feedback_low_pass" default="16000.0">
+			The feedback low-pass cutoff frequency in Hz. Frequencies below this value are filtered out of the source signal.
 		</member>
-		<member name="tap1/active" type="bool" setter="set_tap1_active" getter="is_tap1_active" default="true">
-			If [code]true[/code], [code]tap1[/code] will be enabled.
+		<member name="tap_1_active" type="bool" setter="set_tap_1_active" getter="is_tap_1_active" default="true">
+			If [code]true[/code], tap 1 will be enabled.
 		</member>
-		<member name="tap1/delay_ms" type="float" setter="set_tap1_delay_ms" getter="get_tap1_delay_ms" default="250.0">
-			[code]tap1[/code] delay time in milliseconds.
+		<member name="tap_1_delay_ms" type="float" setter="set_tap_1_delay_ms" getter="get_tap_1_delay_ms" default="250.0">
+			Tap 1's delay time in milliseconds.
 		</member>
-		<member name="tap1/level_db" type="float" setter="set_tap1_level_db" getter="get_tap1_level_db" default="-6.0">
-			Sound level for [code]tap1[/code].
+		<member name="tap_1_level_db" type="float" setter="set_tap_1_level_db" getter="get_tap_1_level_db" default="-6.0">
+			Tap 1's decibel level.
 		</member>
-		<member name="tap1/pan" type="float" setter="set_tap1_pan" getter="get_tap1_pan" default="0.2">
-			Pan position for [code]tap1[/code]. Value can range from -1 (fully left) to 1 (fully right).
+		<member name="tap_1_pan" type="float" setter="set_tap_1_pan" getter="get_tap_1_pan" default="0.2">
+			Tap 1's pan position. A pan of [code]-1[/code] is fully to the left. A pan of [code]1[/code] is fully to the right.
 		</member>
-		<member name="tap2/active" type="bool" setter="set_tap2_active" getter="is_tap2_active" default="true">
-			If [code]true[/code], [code]tap2[/code] will be enabled.
+		<member name="tap_2_active" type="bool" setter="set_tap_2_active" getter="is_tap_2_active" default="true">
+			If [code]true[/code], tap 2 will be enabled.
 		</member>
-		<member name="tap2/delay_ms" type="float" setter="set_tap2_delay_ms" getter="get_tap2_delay_ms" default="500.0">
-			[b]Tap2[/b] delay time in milliseconds.
+		<member name="tap_2_delay_ms" type="float" setter="set_tap_2_delay_ms" getter="get_tap_2_delay_ms" default="500.0">
+			Tap 2's delay time in milliseconds.
 		</member>
-		<member name="tap2/level_db" type="float" setter="set_tap2_level_db" getter="get_tap2_level_db" default="-12.0">
-			Sound level for [code]tap2[/code].
+		<member name="tap_2_level_db" type="float" setter="set_tap_2_level_db" getter="get_tap_2_level_db" default="-12.0">
+			Tap 2's decibel level.
 		</member>
-		<member name="tap2/pan" type="float" setter="set_tap2_pan" getter="get_tap2_pan" default="-0.4">
-			Pan position for [code]tap2[/code]. Value can range from -1 (fully left) to 1 (fully right).
+		<member name="tap_2_pan" type="float" setter="set_tap_2_pan" getter="get_tap_2_pan" default="-0.4">
+			Tap 2's pan position. A pan of [code]-1[/code] is fully to the left. A pan of [code]1[/code] is fully to the right.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ConeTwistJoint3D.xml
+++ b/doc/classes/ConeTwistJoint3D.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ConeTwistJoint3D" inherits="Joint3D" version="4.0">
 	<brief_description>
-		A twist joint between two 3D PhysicsBodies.
+		A cone-limited 3D twist joint.
 	</brief_description>
 	<description>
-		The joint can rotate the bodies across an axis defined by the local x-axes of the [Joint3D].
-		The twist axis is initiated as the X axis of the [Joint3D].
-		Once the Bodies swing, the twist axis is calculated as the middle of the x-axes of the Joint3D in the local space of the two Bodies. See also [Generic6DOFJoint3D].
+		Allows the attached bodies to rotate around the X axis of the joint, and hinge to specified limits around the other axes. The twist axis is calculated as the middle of the X axis of the joint in the local space of the two bodies.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -17,6 +15,7 @@
 			<argument index="0" name="param" type="int" enum="ConeTwistJoint3D.Param">
 			</argument>
 			<description>
+				Returns the current value of the specified [enum Param].
 			</description>
 		</method>
 		<method name="set_param">
@@ -27,6 +26,7 @@
 			<argument index="1" name="value" type="float">
 			</argument>
 			<description>
+				Sets the specified [enum Param] to [code]value[/code].
 			</description>
 		</method>
 	</methods>
@@ -41,13 +41,13 @@
 		<member name="softness" type="float" setter="set_param" getter="get_param" default="0.8">
 			The ease with which the joint starts to twist. If it's too low, it takes more force to start twisting the joint.
 		</member>
-		<member name="swing_span" type="float" setter="_set_swing_span" getter="_get_swing_span" default="45.0">
+		<member name="swing_span" type="float" setter="set_swing_span" getter="get_swing_span" default="45.0">
 			Swing is rotation from side to side, around the axis perpendicular to the twist axis.
 			The swing span defines, how much rotation will not get corrected along the swing axis.
 			Could be defined as looseness in the [ConeTwistJoint3D].
 			If below 0.05, this behavior is locked.
 		</member>
-		<member name="twist_span" type="float" setter="_set_twist_span" getter="_get_twist_span" default="180.0">
+		<member name="twist_span" type="float" setter="set_twist_span" getter="get_twist_span" default="180.0">
 			Twist is the rotation around the twist axis, this value defined how far the joint can twist.
 			Twist is locked if below 0.05.
 		</member>
@@ -74,7 +74,7 @@
 			Defines, how fast the swing- and twist-speed-difference on both sides gets synced.
 		</constant>
 		<constant name="PARAM_MAX" value="5" enum="Param">
-			Represents the size of the [enum Param] enum.
+			The number of [ConeTwistJoint3D] parameters.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -138,25 +138,25 @@
 		<member name="glow_intensity" type="float" setter="set_glow_intensity" getter="get_glow_intensity" default="0.8">
 			The overall brightness multiplier of the glow effect. When using the GLES2 renderer, this should be increased to 1.5 to compensate for the lack of HDR rendering.
 		</member>
-		<member name="glow_levels/1" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
+		<member name="glow_level_1" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
 			The intensity of the 1st level of glow. This is the most "local" level (least blurry).
 		</member>
-		<member name="glow_levels/2" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
+		<member name="glow_level_2" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
 			The intensity of the 2nd level of glow.
 		</member>
-		<member name="glow_levels/3" type="float" setter="set_glow_level" getter="get_glow_level" default="1.0">
+		<member name="glow_level_3" type="float" setter="set_glow_level" getter="get_glow_level" default="1.0">
 			The intensity of the 3rd level of glow.
 		</member>
-		<member name="glow_levels/4" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
+		<member name="glow_level_4" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
 			The intensity of the 4th level of glow.
 		</member>
-		<member name="glow_levels/5" type="float" setter="set_glow_level" getter="get_glow_level" default="1.0">
+		<member name="glow_level_5" type="float" setter="set_glow_level" getter="get_glow_level" default="1.0">
 			The intensity of the 5th level of glow.
 		</member>
-		<member name="glow_levels/6" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
+		<member name="glow_level_6" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
 			The intensity of the 6th level of glow.
 		</member>
-		<member name="glow_levels/7" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
+		<member name="glow_level_7" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
 			The intensity of the 7th level of glow. This is the most "global" level (blurriest).
 		</member>
 		<member name="glow_mix" type="float" setter="set_glow_mix" getter="get_glow_mix" default="0.05">

--- a/doc/classes/Generic6DOFJoint3D.xml
+++ b/doc/classes/Generic6DOFJoint3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Generic6DOFJoint3D" inherits="Joint3D" version="4.0">
 	<brief_description>
-		The generic 6-degrees-of-freedom joint can implement a variety of joint types by locking certain axes' rotation or translation.
+		A generic 6-degrees-of-freedom 3D joint that can implement a wide variety of joints by locking and limiting axes' movement and rotation.
 	</brief_description>
 	<description>
-		The first 3 DOF axes are linear axes, which represent translation of Bodies, and the latter 3 DOF axes represent the angular motion. Each axis can be either locked, or limited.
+		The first 3 degrees of freedom are linear axes, which represent translation or distance between the bodies. T second 3 degrees of freedom are rotational axes. Each axis can be locked or limited independently.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -15,6 +15,7 @@
 			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag">
 			</argument>
 			<description>
+				Returns whether or not the specified X [enum Flag] is enabled.
 			</description>
 		</method>
 		<method name="get_flag_y" qualifiers="const">
@@ -23,6 +24,7 @@
 			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag">
 			</argument>
 			<description>
+				Returns whether or not the specified Y [enum Flag] is enabled.
 			</description>
 		</method>
 		<method name="get_flag_z" qualifiers="const">
@@ -31,6 +33,7 @@
 			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag">
 			</argument>
 			<description>
+				Returns whether or not the specified Z [enum Flag] is enabled.
 			</description>
 		</method>
 		<method name="get_param_x" qualifiers="const">
@@ -39,6 +42,7 @@
 			<argument index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param">
 			</argument>
 			<description>
+				Returns the current value of the specified X [enum Param].
 			</description>
 		</method>
 		<method name="get_param_y" qualifiers="const">
@@ -47,6 +51,7 @@
 			<argument index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param">
 			</argument>
 			<description>
+				Returns the current value of the specified Y [enum Param].
 			</description>
 		</method>
 		<method name="get_param_z" qualifiers="const">
@@ -55,6 +60,7 @@
 			<argument index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param">
 			</argument>
 			<description>
+				Returns the current value of the specified Z [enum Param].
 			</description>
 		</method>
 		<method name="set_flag_x">
@@ -65,6 +71,7 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
+				Sets or clears the specified X [enum Flag].
 			</description>
 		</method>
 		<method name="set_flag_y">
@@ -75,6 +82,7 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
+				Sets or clears the specified Y [enum Flag].
 			</description>
 		</method>
 		<method name="set_flag_z">
@@ -85,6 +93,7 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
+				Sets or clears the specified Z [enum Flag].
 			</description>
 		</method>
 		<method name="set_param_x">
@@ -95,6 +104,7 @@
 			<argument index="1" name="value" type="float">
 			</argument>
 			<description>
+				Sets the specified X [enum Param] to [code]value[/code].
 			</description>
 		</method>
 		<method name="set_param_y">
@@ -105,6 +115,7 @@
 			<argument index="1" name="value" type="float">
 			</argument>
 			<description>
+				Sets the specified Y [enum Param] to [code]value[/code].
 			</description>
 		</method>
 		<method name="set_param_z">
@@ -115,238 +126,239 @@
 			<argument index="1" name="value" type="float">
 			</argument>
 			<description>
+				Sets the specified Z [enum Param] to [code]value[/code].
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="angular_limit_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="1.0">
+		<member name="angular_limit_x_damping" type="float" setter="set_param_x" getter="get_param_x" default="1.0">
 			The amount of rotational damping across the X axis.
 			The lower, the longer an impulse from one side takes to travel to the other side.
 		</member>
-		<member name="angular_limit_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="true">
+		<member name="angular_limit_x_enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="true">
 			If [code]true[/code], rotation across the X axis is limited.
 		</member>
-		<member name="angular_limit_x/erp" type="float" setter="set_param_x" getter="get_param_x" default="0.5">
+		<member name="angular_limit_x_erp" type="float" setter="set_param_x" getter="get_param_x" default="0.5">
 			When rotating across the X axis, this error tolerance factor defines how much the correction gets slowed down. The lower, the slower.
 		</member>
-		<member name="angular_limit_x/force_limit" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="angular_limit_x_force_limit" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 			The maximum amount of force that can occur, when rotating around the X axis.
 		</member>
-		<member name="angular_limit_x/lower_angle" type="float" setter="_set_angular_lo_limit_x" getter="_get_angular_lo_limit_x" default="0.0">
+		<member name="angular_limit_x_lower_angle" type="float" setter="set_angular_lo_limit_x" getter="get_angular_lo_limit_x" default="0.0">
 			The minimum rotation in negative direction to break loose and rotate around the X axis.
 		</member>
-		<member name="angular_limit_x/restitution" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="angular_limit_x_restitution" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 			The amount of rotational restitution across the X axis. The lower, the more restitution occurs.
 		</member>
-		<member name="angular_limit_x/softness" type="float" setter="set_param_x" getter="get_param_x" default="0.5">
+		<member name="angular_limit_x_softness" type="float" setter="set_param_x" getter="get_param_x" default="0.5">
 			The speed of all rotations across the X axis.
 		</member>
-		<member name="angular_limit_x/upper_angle" type="float" setter="_set_angular_hi_limit_x" getter="_get_angular_hi_limit_x" default="0.0">
+		<member name="angular_limit_x_upper_angle" type="float" setter="set_angular_hi_limit_x" getter="get_angular_hi_limit_x" default="0.0">
 			The minimum rotation in positive direction to break loose and rotate around the X axis.
 		</member>
-		<member name="angular_limit_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="1.0">
+		<member name="angular_limit_y_damping" type="float" setter="set_param_y" getter="get_param_y" default="1.0">
 			The amount of rotational damping across the Y axis. The lower, the more dampening occurs.
 		</member>
-		<member name="angular_limit_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="true">
+		<member name="angular_limit_y_enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="true">
 			If [code]true[/code], rotation across the Y axis is limited.
 		</member>
-		<member name="angular_limit_y/erp" type="float" setter="set_param_y" getter="get_param_y" default="0.5">
+		<member name="angular_limit_y_erp" type="float" setter="set_param_y" getter="get_param_y" default="0.5">
 			When rotating across the Y axis, this error tolerance factor defines how much the correction gets slowed down. The lower, the slower.
 		</member>
-		<member name="angular_limit_y/force_limit" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="angular_limit_y_force_limit" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 			The maximum amount of force that can occur, when rotating around the Y axis.
 		</member>
-		<member name="angular_limit_y/lower_angle" type="float" setter="_set_angular_lo_limit_y" getter="_get_angular_lo_limit_y" default="0.0">
+		<member name="angular_limit_y_lower_angle" type="float" setter="set_angular_lo_limit_y" getter="get_angular_lo_limit_y" default="0.0">
 			The minimum rotation in negative direction to break loose and rotate around the Y axis.
 		</member>
-		<member name="angular_limit_y/restitution" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="angular_limit_y_restitution" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 			The amount of rotational restitution across the Y axis. The lower, the more restitution occurs.
 		</member>
-		<member name="angular_limit_y/softness" type="float" setter="set_param_y" getter="get_param_y" default="0.5">
+		<member name="angular_limit_y_softness" type="float" setter="set_param_y" getter="get_param_y" default="0.5">
 			The speed of all rotations across the Y axis.
 		</member>
-		<member name="angular_limit_y/upper_angle" type="float" setter="_set_angular_hi_limit_y" getter="_get_angular_hi_limit_y" default="0.0">
+		<member name="angular_limit_y_upper_angle" type="float" setter="set_angular_hi_limit_y" getter="get_angular_hi_limit_y" default="0.0">
 			The minimum rotation in positive direction to break loose and rotate around the Y axis.
 		</member>
-		<member name="angular_limit_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="1.0">
+		<member name="angular_limit_z_damping" type="float" setter="set_param_z" getter="get_param_z" default="1.0">
 			The amount of rotational damping across the Z axis. The lower, the more dampening occurs.
 		</member>
-		<member name="angular_limit_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="true">
+		<member name="angular_limit_z_enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="true">
 			If [code]true[/code], rotation across the Z axis is limited.
 		</member>
-		<member name="angular_limit_z/erp" type="float" setter="set_param_z" getter="get_param_z" default="0.5">
+		<member name="angular_limit_z_erp" type="float" setter="set_param_z" getter="get_param_z" default="0.5">
 			When rotating across the Z axis, this error tolerance factor defines how much the correction gets slowed down. The lower, the slower.
 		</member>
-		<member name="angular_limit_z/force_limit" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="angular_limit_z_force_limit" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 			The maximum amount of force that can occur, when rotating around the Z axis.
 		</member>
-		<member name="angular_limit_z/lower_angle" type="float" setter="_set_angular_lo_limit_z" getter="_get_angular_lo_limit_z" default="0.0">
+		<member name="angular_limit_z_lower_angle" type="float" setter="set_angular_lo_limit_z" getter="get_angular_lo_limit_z" default="0.0">
 			The minimum rotation in negative direction to break loose and rotate around the Z axis.
 		</member>
-		<member name="angular_limit_z/restitution" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="angular_limit_z_restitution" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 			The amount of rotational restitution across the Z axis. The lower, the more restitution occurs.
 		</member>
-		<member name="angular_limit_z/softness" type="float" setter="set_param_z" getter="get_param_z" default="0.5">
+		<member name="angular_limit_z_softness" type="float" setter="set_param_z" getter="get_param_z" default="0.5">
 			The speed of all rotations across the Z axis.
 		</member>
-		<member name="angular_limit_z/upper_angle" type="float" setter="_set_angular_hi_limit_z" getter="_get_angular_hi_limit_z" default="0.0">
+		<member name="angular_limit_z_upper_angle" type="float" setter="set_angular_hi_limit_z" getter="get_angular_hi_limit_z" default="0.0">
 			The minimum rotation in positive direction to break loose and rotate around the Z axis.
 		</member>
-		<member name="angular_motor_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
+		<member name="angular_motor_x_enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
 			If [code]true[/code], a rotating motor at the X axis is enabled.
 		</member>
-		<member name="angular_motor_x/force_limit" type="float" setter="set_param_x" getter="get_param_x" default="300.0">
+		<member name="angular_motor_x_force_limit" type="float" setter="set_param_x" getter="get_param_x" default="300.0">
 			Maximum acceleration for the motor at the X axis.
 		</member>
-		<member name="angular_motor_x/target_velocity" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="angular_motor_x_target_velocity" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 			Target speed for the motor at the X axis.
 		</member>
-		<member name="angular_motor_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
+		<member name="angular_motor_y_enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
 			If [code]true[/code], a rotating motor at the Y axis is enabled.
 		</member>
-		<member name="angular_motor_y/force_limit" type="float" setter="set_param_y" getter="get_param_y" default="300.0">
+		<member name="angular_motor_y_force_limit" type="float" setter="set_param_y" getter="get_param_y" default="300.0">
 			Maximum acceleration for the motor at the Y axis.
 		</member>
-		<member name="angular_motor_y/target_velocity" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="angular_motor_y_target_velocity" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 			Target speed for the motor at the Y axis.
 		</member>
-		<member name="angular_motor_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
+		<member name="angular_motor_z_enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
 			If [code]true[/code], a rotating motor at the Z axis is enabled.
 		</member>
-		<member name="angular_motor_z/force_limit" type="float" setter="set_param_z" getter="get_param_z" default="300.0">
+		<member name="angular_motor_z_force_limit" type="float" setter="set_param_z" getter="get_param_z" default="300.0">
 			Maximum acceleration for the motor at the Z axis.
 		</member>
-		<member name="angular_motor_z/target_velocity" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="angular_motor_z_target_velocity" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 			Target speed for the motor at the Z axis.
 		</member>
-		<member name="angular_spring_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="angular_spring_x_damping" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 		</member>
-		<member name="angular_spring_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
+		<member name="angular_spring_x_enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
 		</member>
-		<member name="angular_spring_x/equilibrium_point" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="angular_spring_x_equilibrium_point" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 		</member>
-		<member name="angular_spring_x/stiffness" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="angular_spring_x_stiffness" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 		</member>
-		<member name="angular_spring_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="angular_spring_y_damping" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 		</member>
-		<member name="angular_spring_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
+		<member name="angular_spring_y_enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
 		</member>
-		<member name="angular_spring_y/equilibrium_point" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="angular_spring_y_equilibrium_point" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 		</member>
-		<member name="angular_spring_y/stiffness" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="angular_spring_y_stiffness" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 		</member>
-		<member name="angular_spring_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="angular_spring_z_damping" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 		</member>
-		<member name="angular_spring_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
+		<member name="angular_spring_z_enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
 		</member>
-		<member name="angular_spring_z/equilibrium_point" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="angular_spring_z_equilibrium_point" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 		</member>
-		<member name="angular_spring_z/stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="angular_spring_z_stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 		</member>
-		<member name="linear_limit_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="1.0">
+		<member name="linear_limit_x_damping" type="float" setter="set_param_x" getter="get_param_x" default="1.0">
 			The amount of damping that happens at the X motion.
 		</member>
-		<member name="linear_limit_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="true">
+		<member name="linear_limit_x_enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="true">
 			If [code]true[/code], the linear motion across the X axis is limited.
 		</member>
-		<member name="linear_limit_x/lower_distance" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="linear_limit_x_lower_distance" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 			The minimum difference between the pivot points' X axis.
 		</member>
-		<member name="linear_limit_x/restitution" type="float" setter="set_param_x" getter="get_param_x" default="0.5">
+		<member name="linear_limit_x_restitution" type="float" setter="set_param_x" getter="get_param_x" default="0.5">
 			The amount of restitution on the X axis movement. The lower, the more momentum gets lost.
 		</member>
-		<member name="linear_limit_x/softness" type="float" setter="set_param_x" getter="get_param_x" default="0.7">
+		<member name="linear_limit_x_softness" type="float" setter="set_param_x" getter="get_param_x" default="0.7">
 			A factor applied to the movement across the X axis. The lower, the slower the movement.
 		</member>
-		<member name="linear_limit_x/upper_distance" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="linear_limit_x_upper_distance" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 			The maximum difference between the pivot points' X axis.
 		</member>
-		<member name="linear_limit_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="1.0">
+		<member name="linear_limit_y_damping" type="float" setter="set_param_y" getter="get_param_y" default="1.0">
 			The amount of damping that happens at the Y motion.
 		</member>
-		<member name="linear_limit_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="true">
+		<member name="linear_limit_y_enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="true">
 			If [code]true[/code], the linear motion across the Y axis is limited.
 		</member>
-		<member name="linear_limit_y/lower_distance" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="linear_limit_y_lower_distance" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 			The minimum difference between the pivot points' Y axis.
 		</member>
-		<member name="linear_limit_y/restitution" type="float" setter="set_param_y" getter="get_param_y" default="0.5">
+		<member name="linear_limit_y_restitution" type="float" setter="set_param_y" getter="get_param_y" default="0.5">
 			The amount of restitution on the Y axis movement. The lower, the more momentum gets lost.
 		</member>
-		<member name="linear_limit_y/softness" type="float" setter="set_param_y" getter="get_param_y" default="0.7">
+		<member name="linear_limit_y_softness" type="float" setter="set_param_y" getter="get_param_y" default="0.7">
 			A factor applied to the movement across the Y axis. The lower, the slower the movement.
 		</member>
-		<member name="linear_limit_y/upper_distance" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="linear_limit_y_upper_distance" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 			The maximum difference between the pivot points' Y axis.
 		</member>
-		<member name="linear_limit_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="1.0">
+		<member name="linear_limit_z_damping" type="float" setter="set_param_z" getter="get_param_z" default="1.0">
 			The amount of damping that happens at the Z motion.
 		</member>
-		<member name="linear_limit_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="true">
+		<member name="linear_limit_z_enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="true">
 			If [code]true[/code], the linear motion across the Z axis is limited.
 		</member>
-		<member name="linear_limit_z/lower_distance" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="linear_limit_z_lower_distance" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 			The minimum difference between the pivot points' Z axis.
 		</member>
-		<member name="linear_limit_z/restitution" type="float" setter="set_param_z" getter="get_param_z" default="0.5">
+		<member name="linear_limit_z_restitution" type="float" setter="set_param_z" getter="get_param_z" default="0.5">
 			The amount of restitution on the Z axis movement. The lower, the more momentum gets lost.
 		</member>
-		<member name="linear_limit_z/softness" type="float" setter="set_param_z" getter="get_param_z" default="0.7">
+		<member name="linear_limit_z_softness" type="float" setter="set_param_z" getter="get_param_z" default="0.7">
 			A factor applied to the movement across the Z axis. The lower, the slower the movement.
 		</member>
-		<member name="linear_limit_z/upper_distance" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="linear_limit_z_upper_distance" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 			The maximum difference between the pivot points' Z axis.
 		</member>
-		<member name="linear_motor_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
+		<member name="linear_motor_x_enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
 			If [code]true[/code], then there is a linear motor on the X axis. It will attempt to reach the target velocity while staying within the force limits.
 		</member>
-		<member name="linear_motor_x/force_limit" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="linear_motor_x_force_limit" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 			The maximum force the linear motor can apply on the X axis while trying to reach the target velocity.
 		</member>
-		<member name="linear_motor_x/target_velocity" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="linear_motor_x_target_velocity" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 			The speed that the linear motor will attempt to reach on the X axis.
 		</member>
-		<member name="linear_motor_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
+		<member name="linear_motor_y_enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
 			If [code]true[/code], then there is a linear motor on the Y axis. It will attempt to reach the target velocity while staying within the force limits.
 		</member>
-		<member name="linear_motor_y/force_limit" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="linear_motor_y_force_limit" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 			The maximum force the linear motor can apply on the Y axis while trying to reach the target velocity.
 		</member>
-		<member name="linear_motor_y/target_velocity" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="linear_motor_y_target_velocity" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 			The speed that the linear motor will attempt to reach on the Y axis.
 		</member>
-		<member name="linear_motor_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
+		<member name="linear_motor_z_enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
 			If [code]true[/code], then there is a linear motor on the Z axis. It will attempt to reach the target velocity while staying within the force limits.
 		</member>
-		<member name="linear_motor_z/force_limit" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="linear_motor_z_force_limit" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 			The maximum force the linear motor can apply on the Z axis while trying to reach the target velocity.
 		</member>
-		<member name="linear_motor_z/target_velocity" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="linear_motor_z_target_velocity" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 			The speed that the linear motor will attempt to reach on the Z axis.
 		</member>
-		<member name="linear_spring_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="0.01">
+		<member name="linear_spring_x_damping" type="float" setter="set_param_x" getter="get_param_x" default="0.01">
 		</member>
-		<member name="linear_spring_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
+		<member name="linear_spring_x_enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
 		</member>
-		<member name="linear_spring_x/equilibrium_point" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+		<member name="linear_spring_x_equilibrium_point" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
 		</member>
-		<member name="linear_spring_x/stiffness" type="float" setter="set_param_x" getter="get_param_x" default="0.01">
+		<member name="linear_spring_x_stiffness" type="float" setter="set_param_x" getter="get_param_x" default="0.01">
 		</member>
-		<member name="linear_spring_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="0.01">
+		<member name="linear_spring_y_damping" type="float" setter="set_param_y" getter="get_param_y" default="0.01">
 		</member>
-		<member name="linear_spring_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
+		<member name="linear_spring_y_enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
 		</member>
-		<member name="linear_spring_y/equilibrium_point" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+		<member name="linear_spring_y_equilibrium_point" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
 		</member>
-		<member name="linear_spring_y/stiffness" type="float" setter="set_param_y" getter="get_param_y" default="0.01">
+		<member name="linear_spring_y_stiffness" type="float" setter="set_param_y" getter="get_param_y" default="0.01">
 		</member>
-		<member name="linear_spring_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
+		<member name="linear_spring_z_damping" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
 		</member>
-		<member name="linear_spring_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
+		<member name="linear_spring_z_enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
 		</member>
-		<member name="linear_spring_z/equilibrium_point" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+		<member name="linear_spring_z_equilibrium_point" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 		</member>
-		<member name="linear_spring_z/stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
+		<member name="linear_spring_z_stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
 		</member>
 	</members>
 	<constants>
@@ -411,7 +423,7 @@
 		<constant name="PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT" value="21" enum="Param">
 		</constant>
 		<constant name="PARAM_MAX" value="22" enum="Param">
-			Represents the size of the [enum Param] enum.
+			The number of [Generic6DOFJoint3D] parameters.
 		</constant>
 		<constant name="FLAG_ENABLE_LINEAR_LIMIT" value="0" enum="Flag">
 			If enabled, linear motion is possible within the given limits.
@@ -430,7 +442,7 @@
 			If enabled, there is a linear motor across these axes.
 		</constant>
 		<constant name="FLAG_MAX" value="6" enum="Flag">
-			Represents the size of the [enum Flag] enum.
+			The number of [Generic6DOFJoint3D] flags.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/HingeJoint3D.xml
+++ b/doc/classes/HingeJoint3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="HingeJoint3D" inherits="Joint3D" version="4.0">
 	<brief_description>
-		A hinge between two 3D PhysicsBodies.
+		A 3D hinge joint.
 	</brief_description>
 	<description>
-		A HingeJoint3D normally uses the Z axis of body A as the hinge axis, another axis can be specified when adding it manually though. See also [Generic6DOFJoint3D].
+		Allows the attached bodies to hinge around the Z axis of the joint.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -15,7 +15,7 @@
 			<argument index="0" name="flag" type="int" enum="HingeJoint3D.Flag">
 			</argument>
 			<description>
-				Returns the value of the specified flag.
+				Returns whether or not the specified [enum Flag] is enabled.
 			</description>
 		</method>
 		<method name="get_param" qualifiers="const">
@@ -24,7 +24,7 @@
 			<argument index="0" name="param" type="int" enum="HingeJoint3D.Param">
 			</argument>
 			<description>
-				Returns the value of the specified parameter.
+				Returns the current value of the specified [enum Param].
 			</description>
 		</method>
 		<method name="set_flag">
@@ -35,7 +35,7 @@
 			<argument index="1" name="enabled" type="bool">
 			</argument>
 			<description>
-				If [code]true[/code], enables the specified flag.
+				Sets or clears the specified [enum Flag].
 			</description>
 		</method>
 		<method name="set_param">
@@ -46,39 +46,39 @@
 			<argument index="1" name="value" type="float">
 			</argument>
 			<description>
-				Sets the value of the specified parameter.
+				Sets the specified [enum Param] to [code]value[/code].
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="angular_limit/bias" type="float" setter="set_param" getter="get_param" default="0.3">
+		<member name="angular_limit_bias" type="float" setter="set_param" getter="get_param" default="0.3">
 			The speed with which the rotation across the axis perpendicular to the hinge gets corrected.
 		</member>
-		<member name="angular_limit/enable" type="bool" setter="set_flag" getter="get_flag" default="false">
-			If [code]true[/code], the hinges maximum and minimum rotation, defined by [member angular_limit/lower] and [member angular_limit/upper] has effects.
+		<member name="angular_limit_enable" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], the hinges maximum and minimum rotation, defined by [member angular_limit_lower] and [member angular_limit_upper] has effects.
 		</member>
-		<member name="angular_limit/lower" type="float" setter="_set_lower_limit" getter="_get_lower_limit" default="-90.0">
-			The minimum rotation. Only active if [member angular_limit/enable] is [code]true[/code].
+		<member name="angular_limit_lower" type="float" setter="set_lower_limit" getter="get_lower_limit" default="-90.0">
+			The minimum rotation. Only active if [member angular_limit_enable] is [code]true[/code].
 		</member>
-		<member name="angular_limit/relaxation" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="angular_limit_relaxation" type="float" setter="set_param" getter="get_param" default="1.0">
 			The lower this value, the more the rotation gets slowed down.
 		</member>
-		<member name="angular_limit/softness" type="float" setter="set_param" getter="get_param" default="0.9">
+		<member name="angular_limit_softness" type="float" setter="set_param" getter="get_param" default="0.9">
 		</member>
-		<member name="angular_limit/upper" type="float" setter="_set_upper_limit" getter="_get_upper_limit" default="90.0">
-			The maximum rotation. Only active if [member angular_limit/enable] is [code]true[/code].
+		<member name="angular_limit_upper" type="float" setter="set_upper_limit" getter="get_upper_limit" default="90.0">
+			The maximum rotation. Only active if [member angular_limit_enable] is [code]true[/code].
 		</member>
-		<member name="motor/enable" type="bool" setter="set_flag" getter="get_flag" default="false">
+		<member name="bias" type="float" setter="set_param" getter="get_param" default="0.3">
+			The speed with which the two bodies get pulled together when they move in different directions.
+		</member>
+		<member name="motor_enable" type="bool" setter="set_flag" getter="get_flag" default="false">
 			When activated, a motor turns the hinge.
 		</member>
-		<member name="motor/max_impulse" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="motor_max_impulse" type="float" setter="set_param" getter="get_param" default="1.0">
 			Maximum acceleration for the motor.
 		</member>
-		<member name="motor/target_velocity" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="motor_target_velocity" type="float" setter="set_param" getter="get_param" default="1.0">
 			Target speed for the motor.
-		</member>
-		<member name="params/bias" type="float" setter="set_param" getter="get_param" default="0.3">
-			The speed with which the two bodies get pulled together when they move in different directions.
 		</member>
 	</members>
 	<constants>
@@ -86,10 +86,10 @@
 			The speed with which the two bodies get pulled together when they move in different directions.
 		</constant>
 		<constant name="PARAM_LIMIT_UPPER" value="1" enum="Param">
-			The maximum rotation. Only active if [member angular_limit/enable] is [code]true[/code].
+			The maximum rotation. Only active if [member angular_limit_enable] is [code]true[/code].
 		</constant>
 		<constant name="PARAM_LIMIT_LOWER" value="2" enum="Param">
-			The minimum rotation. Only active if [member angular_limit/enable] is [code]true[/code].
+			The minimum rotation. Only active if [member angular_limit_enable] is [code]true[/code].
 		</constant>
 		<constant name="PARAM_LIMIT_BIAS" value="3" enum="Param">
 			The speed with which the rotation across the axis perpendicular to the hinge gets corrected.
@@ -106,16 +106,16 @@
 			Maximum acceleration for the motor.
 		</constant>
 		<constant name="PARAM_MAX" value="8" enum="Param">
-			Represents the size of the [enum Param] enum.
+			The number of [HingeJoint3D] parameters.
 		</constant>
 		<constant name="FLAG_USE_LIMIT" value="0" enum="Flag">
-			If [code]true[/code], the hinges maximum and minimum rotation, defined by [member angular_limit/lower] and [member angular_limit/upper] has effects.
+			If [code]true[/code], the hinges maximum and minimum rotation, defined by [member angular_limit_lower] and [member angular_limit_upper] has effects.
 		</constant>
 		<constant name="FLAG_ENABLE_MOTOR" value="1" enum="Flag">
 			When activated, a motor turns the hinge.
 		</constant>
 		<constant name="FLAG_MAX" value="2" enum="Flag">
-			Represents the size of the [enum Flag] enum.
+			The number of [HingeJoint3D] flags.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Joint2D.xml
+++ b/doc/classes/Joint2D.xml
@@ -14,7 +14,7 @@
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="0.0">
 			When [member node_a] and [member node_b] move in different directions the [code]bias[/code] controls how fast the joint pulls them back to their original position. The lower the [code]bias[/code] the more the two bodies can pull on the joint.
 		</member>
-		<member name="disable_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
+		<member name="exclude_nodes_from_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
 			If [code]true[/code], [member node_a] and [member node_b] can not collide.
 		</member>
 		<member name="node_a" type="NodePath" setter="set_node_a" getter="get_node_a" default="NodePath(&quot;&quot;)">

--- a/doc/classes/Joint3D.xml
+++ b/doc/classes/Joint3D.xml
@@ -4,7 +4,7 @@
 		Base class for all 3D joints.
 	</brief_description>
 	<description>
-		Joints are used to bind together two physics bodies. They have a solver priority and can define if the bodies of the two attached nodes should be able to collide with each other. See also [Generic6DOFJoint3D].
+		Joints are used to constrain the permissible movement allowed between two attached physics bodies. They have a solver priority and can define if the bodies of the two attached nodes should be able to collide with each other.
 	</description>
 	<tutorials>
 		<link title="3D Truck Town Demo">https://godotengine.org/asset-library/asset/524</link>
@@ -12,16 +12,16 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="collision/exclude_nodes" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
+		<member name="exclude_nodes_from_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
 			If [code]true[/code], the two bodies of the nodes are not able to collide with each other.
 		</member>
-		<member name="nodes/node_a" type="NodePath" setter="set_node_a" getter="get_node_a" default="NodePath(&quot;&quot;)">
+		<member name="node_a" type="NodePath" setter="set_node_a" getter="get_node_a" default="NodePath(&quot;&quot;)">
 			The node attached to the first side (A) of the joint.
 		</member>
-		<member name="nodes/node_b" type="NodePath" setter="set_node_b" getter="get_node_b" default="NodePath(&quot;&quot;)">
+		<member name="node_b" type="NodePath" setter="set_node_b" getter="get_node_b" default="NodePath(&quot;&quot;)">
 			The node attached to the second side (B) of the joint.
 		</member>
-		<member name="solver/priority" type="int" setter="set_solver_priority" getter="get_solver_priority" default="1">
+		<member name="solver_priority" type="int" setter="set_solver_priority" getter="get_solver_priority" default="1">
 			The priority used to define which solver is executed first for multiple joints. The lower the value, the higher the priority.
 		</member>
 	</members>

--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -161,13 +161,13 @@
 		</method>
 	</methods>
 	<members>
-		<member name="collision/safe_margin" type="float" setter="set_safe_margin" getter="get_safe_margin" default="0.08">
+		<member name="safe_margin" type="float" setter="set_safe_margin" getter="get_safe_margin" default="0.08">
 			Extra margin used for collision recovery in motion functions (see [method move_and_collide], [method move_and_slide], [method move_and_slide_with_snap]).
 			If the body is at least this close to another body, it will consider them to be colliding and will be pushed away before performing the actual motion.
 			A higher value means it's more flexible for detecting collision, which helps with consistently detecting walls and floors.
 			A lower value forces the collision algorithm to use more exact detection, so it can be used in cases that specifically require precision, e.g at very low scale to avoid visible jittering, or for stability with a stack of kinematic bodies.
 		</member>
-		<member name="motion/sync_to_physics" type="bool" setter="set_sync_to_physics" getter="is_sync_to_physics_enabled" default="false">
+		<member name="sync_to_physics" type="bool" setter="set_sync_to_physics" getter="is_sync_to_physics_enabled" default="false">
 			If [code]true[/code], the body's movement will be synchronized to the physics frame. This is useful when animating movement via [AnimationPlayer], for example on moving platforms. Do [b]not[/b] use together with [method move_and_slide] or [method move_and_collide] functions.
 		</member>
 	</members>

--- a/doc/classes/KinematicBody3D.xml
+++ b/doc/classes/KinematicBody3D.xml
@@ -176,7 +176,7 @@
 		<member name="axis_lock_motion_z" type="bool" setter="set_axis_lock" getter="get_axis_lock" default="false">
 			Lock the body's Z axis movement.
 		</member>
-		<member name="collision/safe_margin" type="float" setter="set_safe_margin" getter="get_safe_margin" default="0.001">
+		<member name="safe_margin" type="float" setter="set_safe_margin" getter="get_safe_margin" default="0.001">
 			Extra margin used for collision recovery in motion functions (see [method move_and_collide], [method move_and_slide], [method move_and_slide_with_snap]).
 			If the body is at least this close to another body, it will consider them to be colliding and will be pushed away before performing the actual motion.
 			A higher value means it's more flexible for detecting collision, which helps with consistently detecting walls and floors.

--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -14,12 +14,14 @@
 			<argument index="0" name="polygon" type="PackedInt32Array">
 			</argument>
 			<description>
+				Adds the provided polygon.
 			</description>
 		</method>
 		<method name="clear_polygons">
 			<return type="void">
 			</return>
 			<description>
+				Clears the current polygons.
 			</description>
 		</method>
 		<method name="create_from_mesh">
@@ -28,14 +30,16 @@
 			<argument index="0" name="mesh" type="Mesh">
 			</argument>
 			<description>
+				Creates a [NavigationMesh] from the provided [Mesh].
 			</description>
 		</method>
-		<method name="get_collision_mask_bit" qualifiers="const">
+		<method name="get_physics_mask_bit" qualifiers="const">
 			<return type="bool">
 			</return>
 			<argument index="0" name="bit" type="int">
 			</argument>
 			<description>
+				Returns whether or not the specified [member physics_mask] [code]bit[/code] is set.
 			</description>
 		</method>
 		<method name="get_polygon">
@@ -44,21 +48,17 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
+				Returns the specified polgon.
 			</description>
 		</method>
 		<method name="get_polygon_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
+				Returns the current number of polygons.
 			</description>
 		</method>
-		<method name="get_vertices" qualifiers="const">
-			<return type="PackedVector3Array">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="set_collision_mask_bit">
+		<method name="set_physics_mask_bit">
 			<return type="void">
 			</return>
 			<argument index="0" name="bit" type="int">
@@ -66,72 +66,65 @@
 			<argument index="1" name="value" type="bool">
 			</argument>
 			<description>
-			</description>
-		</method>
-		<method name="set_vertices">
-			<return type="void">
-			</return>
-			<argument index="0" name="vertices" type="PackedVector3Array">
-			</argument>
-			<description>
+				Sets or clears the specified [member physics_mask] [code]bit[/code].
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="agent/height" type="float" setter="set_agent_height" getter="get_agent_height" default="2.0">
+		<member name="agent_height" type="float" setter="set_agent_height" getter="get_agent_height" default="2.0">
 			The minimum Y space needed for navigation to be generated.
 		</member>
-		<member name="agent/max_climb" type="float" setter="set_agent_max_climb" getter="get_agent_max_climb" default="0.9">
+		<member name="agent_max_climb" type="float" setter="set_agent_max_climb" getter="get_agent_max_climb" default="0.9">
 			The maximum height difference between two areas for navigation to be generated between them.
 		</member>
-		<member name="agent/max_slope" type="float" setter="set_agent_max_slope" getter="get_agent_max_slope" default="45.0">
+		<member name="agent_max_slope" type="float" setter="set_agent_max_slope" getter="get_agent_max_slope" default="45.0">
 			The maximum angle a slope can be at for navigation to be generated on it.
 		</member>
-		<member name="agent/radius" type="float" setter="set_agent_radius" getter="get_agent_radius" default="0.6">
+		<member name="agent_radius" type="float" setter="set_agent_radius" getter="get_agent_radius" default="0.6">
 			Determines where the edge of a navigation mesh is. This way an agent will not overlap with another mesh or stand over nothing.
 		</member>
-		<member name="cell/height" type="float" setter="set_cell_height" getter="get_cell_height" default="0.2">
+		<member name="cell_height" type="float" setter="set_cell_height" getter="get_cell_height" default="0.2">
 			The height of a cell.
 		</member>
-		<member name="cell/size" type="float" setter="set_cell_size" getter="get_cell_size" default="0.3">
+		<member name="cell_size" type="float" setter="set_cell_size" getter="get_cell_size" default="0.3">
 			The size of cells in the [NavigationMesh].
 		</member>
-		<member name="detail/sample_distance" type="float" setter="set_detail_sample_distance" getter="get_detail_sample_distance" default="6.0">
+		<member name="detail_sample_distance" type="float" setter="set_detail_sample_distance" getter="get_detail_sample_distance" default="6.0">
 		</member>
-		<member name="detail/sample_max_error" type="float" setter="set_detail_sample_max_error" getter="get_detail_sample_max_error" default="1.0">
+		<member name="detail_sample_max_error" type="float" setter="set_detail_sample_max_error" getter="get_detail_sample_max_error" default="1.0">
 		</member>
-		<member name="edge/max_error" type="float" setter="set_edge_max_error" getter="get_edge_max_error" default="1.3">
+		<member name="edge_max_error" type="float" setter="set_edge_max_error" getter="get_edge_max_error" default="1.3">
 		</member>
-		<member name="edge/max_length" type="float" setter="set_edge_max_length" getter="get_edge_max_length" default="12.0">
+		<member name="edge_max_length" type="float" setter="set_edge_max_length" getter="get_edge_max_length" default="12.0">
 		</member>
-		<member name="filter/filter_walkable_low_height_spans" type="bool" setter="set_filter_walkable_low_height_spans" getter="get_filter_walkable_low_height_spans" default="false">
+		<member name="filter_ledge_spans" type="bool" setter="set_filter_ledge_spans" getter="get_filter_ledge_spans" default="false">
 		</member>
-		<member name="filter/ledge_spans" type="bool" setter="set_filter_ledge_spans" getter="get_filter_ledge_spans" default="false">
+		<member name="filter_low_hanging_obstacles" type="bool" setter="set_filter_low_hanging_obstacles" getter="get_filter_low_hanging_obstacles" default="false">
 		</member>
-		<member name="filter/low_hanging_obstacles" type="bool" setter="set_filter_low_hanging_obstacles" getter="get_filter_low_hanging_obstacles" default="false">
+		<member name="filter_walkable_low_height_spans" type="bool" setter="set_filter_walkable_low_height_spans" getter="get_filter_walkable_low_height_spans" default="false">
 		</member>
-		<member name="geometry/collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask">
-			The physics layers used to generate the [NavigationMesh].
-		</member>
-		<member name="geometry/parsed_geometry_type" type="int" setter="set_parsed_geometry_type" getter="get_parsed_geometry_type" default="0">
+		<member name="parsed_geometry_type" type="int" setter="set_parsed_geometry_type" getter="get_parsed_geometry_type" default="0">
 			What kind of geometry is used to generate the [NavigationMesh].
 		</member>
-		<member name="geometry/source_geometry_mode" type="int" setter="set_source_geometry_mode" getter="get_source_geometry_mode" default="0">
-			Which geometry is used to generate the [NavigationMesh].
+		<member name="physics_mask" type="int" setter="set_physics_mask" getter="get_physics_mask">
+			The physics layers used to generate the [NavigationMesh].
 		</member>
-		<member name="geometry/source_group_name" type="StringName" setter="set_source_group_name" getter="get_source_group_name">
-			The name of the group that is used to generate the [NavigationMesh].
-		</member>
-		<member name="polygon/verts_per_poly" type="float" setter="set_verts_per_poly" getter="get_verts_per_poly" default="6.0">
-			The number of vertices to use per polygon. Higher values will improve performance at the cost of lower precision.
-		</member>
-		<member name="region/merge_size" type="float" setter="set_region_merge_size" getter="get_region_merge_size" default="20.0">
+		<member name="region_merge_size" type="float" setter="set_region_merge_size" getter="get_region_merge_size" default="20.0">
 			If two adjacent regions' edges are separated by a distance lower than this value, the regions will be merged together.
 		</member>
-		<member name="region/min_size" type="float" setter="set_region_min_size" getter="get_region_min_size" default="8.0">
+		<member name="region_min_size" type="float" setter="set_region_min_size" getter="get_region_min_size" default="8.0">
 			The minimum size of a region for it to be created.
 		</member>
-		<member name="sample_partition_type/sample_partition_type" type="int" setter="set_sample_partition_type" getter="get_sample_partition_type" default="0">
+		<member name="sample_partition_type" type="int" setter="set_sample_partition_type" getter="get_sample_partition_type" default="0">
+		</member>
+		<member name="source_geometry_mode" type="int" setter="set_source_geometry_mode" getter="get_source_geometry_mode" default="0">
+			Which geometry is used to generate the [NavigationMesh].
+		</member>
+		<member name="source_group_name" type="StringName" setter="set_source_group_name" getter="get_source_group_name">
+			The name of the group that is used to generate the [NavigationMesh].
+		</member>
+		<member name="vertices_per_polygon" type="float" setter="set_vertices_per_polygon" getter="get_vertices_per_polygon" default="6.0">
+			The number of vertices to use per polygon. Higher values will improve performance at the cost of lower precision.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/PinJoint3D.xml
+++ b/doc/classes/PinJoint3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PinJoint3D" inherits="Joint3D" version="4.0">
 	<brief_description>
-		Pin joint for 3D PhysicsBodies.
+		A 3D pin joint.
 	</brief_description>
 	<description>
-		Pin joint for 3D rigid bodies. It pins 2 bodies (rigid or static) together. See also [Generic6DOFJoint3D].
+		Pins the attached bodies together.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -15,7 +15,7 @@
 			<argument index="0" name="param" type="int" enum="PinJoint3D.Param">
 			</argument>
 			<description>
-				Returns the value of the specified parameter.
+				Returns the current value of the specified [enum Param].
 			</description>
 		</method>
 		<method name="set_param">
@@ -26,18 +26,18 @@
 			<argument index="1" name="value" type="float">
 			</argument>
 			<description>
-				Sets the value of the specified parameter.
+				Sets the specified [enum Param] to [code]value[/code].
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="params/bias" type="float" setter="set_param" getter="get_param" default="0.3">
+		<member name="bias" type="float" setter="set_param" getter="get_param" default="0.3">
 			The force with which the pinned objects stay in positional relation to each other. The higher, the stronger.
 		</member>
-		<member name="params/damping" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="damping" type="float" setter="set_param" getter="get_param" default="1.0">
 			The force with which the pinned objects stay in velocity relation to each other. The higher, the stronger.
 		</member>
-		<member name="params/impulse_clamp" type="float" setter="set_param" getter="get_param" default="0.0">
+		<member name="impulse_clamp" type="float" setter="set_param" getter="get_param" default="0.0">
 			If above 0, this value is the maximum value for an impulse that this Joint3D produces.
 		</member>
 	</members>

--- a/doc/classes/SliderJoint3D.xml
+++ b/doc/classes/SliderJoint3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="SliderJoint3D" inherits="Joint3D" version="4.0">
 	<brief_description>
-		Slider between two PhysicsBodies in 3D.
+		A 3D slider joint.
 	</brief_description>
 	<description>
-		Slides across the X axis of the pivot object. See also [Generic6DOFJoint3D].
+		Allows the attached bodies to slide along and rotate around the X axis of the joint.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -15,6 +15,7 @@
 			<argument index="0" name="param" type="int" enum="SliderJoint3D.Param">
 			</argument>
 			<description>
+				Returns the current value of the specified [enum Param].
 			</description>
 		</method>
 		<method name="set_param">
@@ -25,77 +26,78 @@
 			<argument index="1" name="value" type="float">
 			</argument>
 			<description>
+				Sets the specified [enum Param] to [code]value[/code].
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="angular_limit/damping" type="float" setter="set_param" getter="get_param" default="0.0">
+		<member name="angular_limit_damping" type="float" setter="set_param" getter="get_param" default="0.0">
 			The amount of damping of the rotation when the limit is surpassed.
 			A lower damping value allows a rotation initiated by body A to travel to body B slower.
 		</member>
-		<member name="angular_limit/lower_angle" type="float" setter="_set_lower_limit_angular" getter="_get_lower_limit_angular" default="0.0">
+		<member name="angular_limit_lower_angle" type="float" setter="set_lower_limit_angular" getter="get_lower_limit_angular" default="0.0">
 			The lower limit of rotation in the slider.
 		</member>
-		<member name="angular_limit/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
+		<member name="angular_limit_restitution" type="float" setter="set_param" getter="get_param" default="0.7">
 			The amount of restitution of the rotation when the limit is surpassed.
 			Does not affect damping.
 		</member>
-		<member name="angular_limit/softness" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="angular_limit_softness" type="float" setter="set_param" getter="get_param" default="1.0">
 			A factor applied to the all rotation once the limit is surpassed.
 			Makes all rotation slower when between 0 and 1.
 		</member>
-		<member name="angular_limit/upper_angle" type="float" setter="_set_upper_limit_angular" getter="_get_upper_limit_angular" default="0.0">
+		<member name="angular_limit_upper_angle" type="float" setter="set_upper_limit_angular" getter="get_upper_limit_angular" default="0.0">
 			The upper limit of rotation in the slider.
 		</member>
-		<member name="angular_motion/damping" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="angular_motion_damping" type="float" setter="set_param" getter="get_param" default="1.0">
 			The amount of damping of the rotation in the limits.
 		</member>
-		<member name="angular_motion/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
+		<member name="angular_motion_restitution" type="float" setter="set_param" getter="get_param" default="0.7">
 			The amount of restitution of the rotation in the limits.
 		</member>
-		<member name="angular_motion/softness" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="angular_motion_softness" type="float" setter="set_param" getter="get_param" default="1.0">
 			A factor applied to the all rotation in the limits.
 		</member>
-		<member name="angular_ortho/damping" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="angular_ortho_damping" type="float" setter="set_param" getter="get_param" default="1.0">
 			The amount of damping of the rotation across axes orthogonal to the slider.
 		</member>
-		<member name="angular_ortho/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
+		<member name="angular_ortho_restitution" type="float" setter="set_param" getter="get_param" default="0.7">
 			The amount of restitution of the rotation across axes orthogonal to the slider.
 		</member>
-		<member name="angular_ortho/softness" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="angular_ortho_softness" type="float" setter="set_param" getter="get_param" default="1.0">
 			A factor applied to the all rotation across axes orthogonal to the slider.
 		</member>
-		<member name="linear_limit/damping" type="float" setter="set_param" getter="get_param" default="1.0">
-			The amount of damping that happens once the limit defined by [member linear_limit/lower_distance] and [member linear_limit/upper_distance] is surpassed.
+		<member name="linear_limit_damping" type="float" setter="set_param" getter="get_param" default="1.0">
+			The amount of damping that happens once the limit defined by [member linear_limit_lower_distance] and [member linear_limit_upper_distance] is surpassed.
 		</member>
-		<member name="linear_limit/lower_distance" type="float" setter="set_param" getter="get_param" default="-1.0">
+		<member name="linear_limit_lower_distance" type="float" setter="set_param" getter="get_param" default="-1.0">
 			The minimum difference between the pivot points on their X axis before damping happens.
 		</member>
-		<member name="linear_limit/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
+		<member name="linear_limit_restitution" type="float" setter="set_param" getter="get_param" default="0.7">
 			The amount of restitution once the limits are surpassed. The lower, the more velocity-energy gets lost.
 		</member>
-		<member name="linear_limit/softness" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="linear_limit_softness" type="float" setter="set_param" getter="get_param" default="1.0">
 			A factor applied to the movement across the slider axis once the limits get surpassed. The lower, the slower the movement.
 		</member>
-		<member name="linear_limit/upper_distance" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="linear_limit_upper_distance" type="float" setter="set_param" getter="get_param" default="1.0">
 			The maximum difference between the pivot points on their X axis before damping happens.
 		</member>
-		<member name="linear_motion/damping" type="float" setter="set_param" getter="get_param" default="0.0">
+		<member name="linear_motion_damping" type="float" setter="set_param" getter="get_param" default="0.0">
 			The amount of damping inside the slider limits.
 		</member>
-		<member name="linear_motion/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
+		<member name="linear_motion_restitution" type="float" setter="set_param" getter="get_param" default="0.7">
 			The amount of restitution inside the slider limits.
 		</member>
-		<member name="linear_motion/softness" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="linear_motion_softness" type="float" setter="set_param" getter="get_param" default="1.0">
 			A factor applied to the movement across the slider axis as long as the slider is in the limits. The lower, the slower the movement.
 		</member>
-		<member name="linear_ortho/damping" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="linear_ortho_damping" type="float" setter="set_param" getter="get_param" default="1.0">
 			The amount of damping when movement is across axes orthogonal to the slider.
 		</member>
-		<member name="linear_ortho/restitution" type="float" setter="set_param" getter="get_param" default="0.7">
+		<member name="linear_ortho_restitution" type="float" setter="set_param" getter="get_param" default="0.7">
 			The amount of restitution when movement is across axes orthogonal to the slider.
 		</member>
-		<member name="linear_ortho/softness" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="linear_ortho_softness" type="float" setter="set_param" getter="get_param" default="1.0">
 			A factor applied to the movement across axes orthogonal to the slider.
 		</member>
 	</members>
@@ -167,7 +169,7 @@
 			The amount of damping of the rotation across axes orthogonal to the slider.
 		</constant>
 		<constant name="PARAM_MAX" value="22" enum="Param">
-			Represents the size of the [enum Param] enum.
+			The number of [SliderJoint3D] parameters.
 		</constant>
 	</constants>
 </class>

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -215,12 +215,12 @@ public:
 					args.resize(p_value);
 					d_new["args"] = args;
 					change_notify_deserved = true;
-				} else if (name.begins_with("args/")) {
+				} else if (name.begins_with("args_")) {
 					Vector<Variant> args = d_old["args"];
-					int idx = name.get_slice("/", 1).to_int();
+					int idx = name.get_slicec('_', 1).to_int();
 					ERR_FAIL_INDEX_V(idx, args.size(), false);
 
-					String what = name.get_slice("/", 2);
+					String what = name.get_slicec('_', 2);
 					if (what == "type") {
 						Variant::Type t = Variant::Type(int(p_value));
 
@@ -444,11 +444,11 @@ public:
 					return true;
 				}
 
-				if (name.begins_with("args/")) {
-					int idx = name.get_slice("/", 1).to_int();
+				if (name.begins_with("args_")) {
+					int idx = name.get_slicec('_', 1).to_int();
 					ERR_FAIL_INDEX_V(idx, args.size(), false);
 
-					String what = name.get_slice("/", 2);
+					String what = name.get_slicec('_', 2);
 					if (what == "type") {
 						r_ret = args[idx].get_type();
 						return true;
@@ -570,10 +570,12 @@ public:
 					vtypes += Variant::get_type_name(Variant::Type(i));
 				}
 
+				p_list->push_back(PropertyInfo(Variant::NIL, "Args", PROPERTY_HINT_NONE, "args_", PROPERTY_USAGE_GROUP));
 				for (int i = 0; i < args.size(); i++) {
-					p_list->push_back(PropertyInfo(Variant::INT, "args/" + itos(i) + "/type", PROPERTY_HINT_ENUM, vtypes));
+					p_list->push_back(PropertyInfo(Variant::NIL, itos(i), PROPERTY_HINT_NONE, "args_" + itos(i) + "_", PROPERTY_USAGE_SUBGROUP));
+					p_list->push_back(PropertyInfo(Variant::INT, "args_" + itos(i) + "_type", PROPERTY_HINT_ENUM, vtypes));
 					if (args[i].get_type() != Variant::NIL) {
-						p_list->push_back(PropertyInfo(args[i].get_type(), "args/" + itos(i) + "/value"));
+						p_list->push_back(PropertyInfo(args[i].get_type(), "args_" + itos(i) + "_value"));
 					}
 				}
 
@@ -825,12 +827,12 @@ public:
 							args.resize(p_value);
 							d_new["args"] = args;
 							change_notify_deserved = true;
-						} else if (name.begins_with("args/")) {
+						} else if (name.begins_with("args_")) {
 							Vector<Variant> args = d_old["args"];
-							int idx = name.get_slice("/", 1).to_int();
+							int idx = name.get_slicec('_', 1).to_int();
 							ERR_FAIL_INDEX_V(idx, args.size(), false);
 
-							String what = name.get_slice("/", 2);
+							String what = name.get_slicec('_', 2);
 							if (what == "type") {
 								Variant::Type t = Variant::Type(int(p_value));
 
@@ -1044,11 +1046,11 @@ public:
 							return true;
 						}
 
-						if (name.begins_with("args/")) {
-							int idx = name.get_slice("/", 1).to_int();
+						if (name.begins_with("args_")) {
+							int idx = name.get_slicec('_', 1).to_int();
 							ERR_FAIL_INDEX_V(idx, args.size(), false);
 
-							String what = name.get_slice("/", 2);
+							String what = name.get_slicec('_', 2);
 							if (what == "type") {
 								r_ret = args[idx].get_type();
 								return true;
@@ -1213,10 +1215,12 @@ public:
 						vtypes += Variant::get_type_name(Variant::Type(i));
 					}
 
+					p_list->push_back(PropertyInfo(Variant::NIL, "Args", PROPERTY_HINT_NONE, "args_", PROPERTY_USAGE_GROUP));
 					for (int i = 0; i < args.size(); i++) {
-						p_list->push_back(PropertyInfo(Variant::INT, "args/" + itos(i) + "/type", PROPERTY_HINT_ENUM, vtypes));
+						p_list->push_back(PropertyInfo(Variant::NIL, itos(i), PROPERTY_HINT_NONE, "args_" + itos(i) + "_", PROPERTY_USAGE_SUBGROUP));
+						p_list->push_back(PropertyInfo(Variant::INT, "args_" + itos(i) + "_type", PROPERTY_HINT_ENUM, vtypes));
 						if (args[i].get_type() != Variant::NIL) {
-							p_list->push_back(PropertyInfo(args[i].get_type(), "args/" + itos(i) + "/value"));
+							p_list->push_back(PropertyInfo(args[i].get_type(), "args_" + itos(i) + "_value"));
 						}
 					}
 				} break;

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -66,8 +66,8 @@ public:
 	bool _set(const StringName &p_name, const Variant &p_value) {
 		String name = p_name;
 
-		if (name.begins_with("bind/")) {
-			int which = name.get_slice("/", 1).to_int() - 1;
+		if (name.begins_with("bind_")) {
+			int which = name.get_slicec('_', 1).to_int() - 1;
 			ERR_FAIL_INDEX_V(which, params.size(), false);
 			params.write[which] = p_value;
 		} else {
@@ -80,8 +80,8 @@ public:
 	bool _get(const StringName &p_name, Variant &r_ret) const {
 		String name = p_name;
 
-		if (name.begins_with("bind/")) {
-			int which = name.get_slice("/", 1).to_int() - 1;
+		if (name.begins_with("bind_")) {
+			int which = name.get_slicec('_', 1).to_int() - 1;
 			ERR_FAIL_INDEX_V(which, params.size(), false);
 			r_ret = params[which];
 		} else {
@@ -92,8 +92,9 @@ public:
 	}
 
 	void _get_property_list(List<PropertyInfo> *p_list) const {
+		p_list->push_back(PropertyInfo(Variant::NIL, "Bind", PROPERTY_HINT_NONE, "bind_", PROPERTY_USAGE_GROUP));
 		for (int i = 0; i < params.size(); i++) {
-			p_list->push_back(PropertyInfo(params[i].get_type(), "bind/" + itos(i + 1)));
+			p_list->push_back(PropertyInfo(params[i].get_type(), "bind_" + itos(i + 1)));
 		}
 	}
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -38,7 +38,7 @@ bool EditorPropertyArrayObject::_set(const StringName &p_name, const Variant &p_
 	String pn = p_name;
 
 	if (pn.begins_with("indices")) {
-		int idx = pn.get_slicec('/', 1).to_int();
+		int idx = pn.get_slicec('_', 1).to_int();
 		array.set(idx, p_value);
 		return true;
 	}
@@ -50,7 +50,7 @@ bool EditorPropertyArrayObject::_get(const StringName &p_name, Variant &r_ret) c
 	String pn = p_name;
 
 	if (pn.begins_with("indices")) {
-		int idx = pn.get_slicec('/', 1).to_int();
+		int idx = pn.get_slicec('_', 1).to_int();
 		bool valid;
 		r_ret = array.get(idx, &valid);
 		if (r_ret.get_type() == Variant::OBJECT && Object::cast_to<EncodedObjectAsID>(r_ret)) {
@@ -90,7 +90,7 @@ bool EditorPropertyDictionaryObject::_set(const StringName &p_name, const Varian
 	}
 
 	if (pn.begins_with("indices")) {
-		int idx = pn.get_slicec('/', 1).to_int();
+		int idx = pn.get_slicec('_', 1).to_int();
 		Variant key = dict.get_key_at_index(idx);
 		dict[key] = p_value;
 		return true;
@@ -113,7 +113,7 @@ bool EditorPropertyDictionaryObject::_get(const StringName &p_name, Variant &r_r
 	}
 
 	if (pn.begins_with("indices")) {
-		int idx = pn.get_slicec('/', 1).to_int();
+		int idx = pn.get_slicec('_', 1).to_int();
 		Variant key = dict.get_key_at_index(idx);
 		r_ret = dict[key];
 		if (r_ret.get_type() == Variant::OBJECT && Object::cast_to<EncodedObjectAsID>(r_ret)) {
@@ -157,7 +157,7 @@ EditorPropertyDictionaryObject::EditorPropertyDictionaryObject() {
 
 void EditorPropertyArray::_property_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("indices")) {
-		int idx = p_property.get_slice("/", 1).to_int();
+		int idx = p_property.get_slicec('_', 1).to_int();
 		Variant array = object->get_array();
 		array.set(idx, p_value);
 		emit_changed(get_edited_property(), array, "", true);
@@ -322,7 +322,7 @@ void EditorPropertyArray::update_property() {
 		object->set_array(array);
 
 		for (int i = 0; i < amount; i++) {
-			String prop_name = "indices/" + itos(i + offset);
+			String prop_name = "indices_" + itos(i + offset);
 
 			EditorProperty *prop = nullptr;
 			Variant value = array.get(i + offset);
@@ -554,7 +554,7 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 		int hint_subtype_separator = p_hint_string.find(":");
 		if (hint_subtype_separator >= 0) {
 			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);
-			int slash_pos = subtype_string.find("/");
+			int slash_pos = subtype_string.find("_");
 			if (slash_pos >= 0) {
 				subtype_hint = PropertyHint(subtype_string.substr(slash_pos + 1, subtype_string.size() - slash_pos - 1).to_int());
 				subtype_string = subtype_string.substr(0, slash_pos);
@@ -615,7 +615,7 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 	} else if (p_property == "new_item_value") {
 		object->set_new_item_value(p_value);
 	} else if (p_property.begins_with("indices")) {
-		int idx = p_property.get_slice("/", 1).to_int();
+		int idx = p_property.get_slicec('_', 1).to_int();
 		Dictionary dict = object->get_dict();
 		Variant key = dict.get_key_at_index(idx);
 		dict[key] = p_value;
@@ -762,7 +762,7 @@ void EditorPropertyDictionary::update_property() {
 			Variant value;
 
 			if (i < amount) {
-				prop_name = "indices/" + itos(i + offset);
+				prop_name = "indices_" + itos(i + offset);
 				key = dict.get_key_at_index(i + offset);
 				value = dict.get_value_at_index(i + offset);
 			} else if (i == amount) {

--- a/editor/import/scene_importer_mesh.cpp
+++ b/editor/import/scene_importer_mesh.cpp
@@ -569,7 +569,7 @@ Ref<NavigationMesh> EditorSceneImporterMesh::create_navigation_mesh() {
 
 	Ref<NavigationMesh> nm;
 	nm.instance();
-	nm->set_vertices(vertices);
+	nm->_set_vertices(vertices);
 
 	Vector<int> v3;
 	v3.resize(3);

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -4287,7 +4287,7 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		return;
 	}
 
-	Vector<Vector3> vertices = navmeshie->get_vertices();
+	Vector<Vector3> vertices = navmeshie->_get_vertices();
 	const Vector3 *vr = vertices.ptr();
 	List<Face3> faces;
 	for (int i = 0; i < navmeshie->get_polygon_count(); i++) {

--- a/editor/plugins/font_editor_plugin.cpp
+++ b/editor/plugins/font_editor_plugin.cpp
@@ -291,8 +291,8 @@ void EditorInspectorPluginFont::parse_begin(Object *p_object) {
 }
 
 bool EditorInspectorPluginFont::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide) {
-	if (p_path.begins_with("language_support_override/") && p_object->is_class("FontData")) {
-		String lang = p_path.replace("language_support_override/", "");
+	if (p_path.begins_with("language_support_override_") && p_object->is_class("FontData")) {
+		String lang = p_path.replace("language_support_override_", "");
 
 		FontDataEditor *editor = memnew(FontDataEditor);
 		if (lang != "_new") {
@@ -305,8 +305,8 @@ bool EditorInspectorPluginFont::parse_property(Object *p_object, Variant::Type p
 		return true;
 	}
 
-	if (p_path.begins_with("script_support_override/") && p_object->is_class("FontData")) {
-		String script = p_path.replace("script_support_override/", "");
+	if (p_path.begins_with("script_support_override_") && p_object->is_class("FontData")) {
+		String script = p_path.replace("script_support_override_", "");
 
 		FontDataEditor *editor = memnew(FontDataEditor);
 		if (script != "_new") {

--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -35,8 +35,8 @@
 
 bool ItemListPlugin::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
-	int idx = name.get_slice("/", 0).to_int();
-	String what = name.get_slice("/", 1);
+	int idx = name.get_slicec('_', 0).to_int();
+	String what = name.get_slicec('_', 1);
 
 	if (what == "text") {
 		set_item_text(idx, p_value);
@@ -70,8 +70,8 @@ bool ItemListPlugin::_set(const StringName &p_name, const Variant &p_value) {
 
 bool ItemListPlugin::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
-	int idx = name.get_slice("/", 0).to_int();
-	String what = name.get_slice("/", 1);
+	int idx = name.get_slicec('_', 0).to_int();
+	String what = name.get_slicec('_', 1);
 
 	if (what == "text") {
 		r_ret = get_item_text(idx);
@@ -101,7 +101,8 @@ bool ItemListPlugin::_get(const StringName &p_name, Variant &r_ret) const {
 
 void ItemListPlugin::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (int i = 0; i < get_item_count(); i++) {
-		String base = itos(i) + "/";
+		String base = itos(i) + "_";
+		p_list->push_back(PropertyInfo(Variant::NIL, itos(i), PROPERTY_HINT_NONE, base, PROPERTY_USAGE_GROUP));
 
 		p_list->push_back(PropertyInfo(Variant::STRING, base + "text"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, base + "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"));

--- a/editor/plugins/ot_features_plugin.cpp
+++ b/editor/plugins/ot_features_plugin.cpp
@@ -95,7 +95,7 @@ OpenTypeFeaturesEditor::OpenTypeFeaturesEditor() {
 /*************************************************************************/
 
 void OpenTypeFeaturesAdd::_add_feature(int p_option) {
-	get_edited_object()->set("opentype_features/" + TS->tag_to_name(p_option), 1);
+	get_edited_object()->set("opentype_features_" + TS->tag_to_name(p_option), 1);
 }
 
 void OpenTypeFeaturesAdd::update_property() {
@@ -192,7 +192,7 @@ void EditorInspectorPluginOpenTypeFeatures::parse_category(Object *p_object, con
 }
 
 bool EditorInspectorPluginOpenTypeFeatures::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide) {
-	if (p_path == "opentype_features/_new") {
+	if (p_path == "opentype_features__new") {
 		OpenTypeFeaturesAdd *editor = memnew(OpenTypeFeaturesAdd);
 		add_property_editor(p_path, editor);
 		return true;

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -203,12 +203,12 @@ void BoneTransformEditor::_value_changed_transform(const String p_property_name,
 }
 
 void BoneTransformEditor::_change_transform(Transform p_new_transform) {
-	if (property.get_slicec('/', 0) == "bones" && property.get_slicec('/', 2) == "custom_pose") {
+	if (property.get_slicec('_', 0) == "bones" && property.get_slicec('_', 2) == "custom_pose") {
 		undo_redo->create_action(TTR("Set Custom Bone Pose Transform"), UndoRedo::MERGE_ENDS);
-		undo_redo->add_undo_method(skeleton, "set_bone_custom_pose", property.get_slicec('/', 1).to_int(), skeleton->get_bone_custom_pose(property.get_slicec('/', 1).to_int()));
-		undo_redo->add_do_method(skeleton, "set_bone_custom_pose", property.get_slicec('/', 1).to_int(), p_new_transform);
+		undo_redo->add_undo_method(skeleton, "set_bone_custom_pose", property.get_slicec('_', 1).to_int(), skeleton->get_bone_custom_pose(property.get_slicec('_', 1).to_int()));
+		undo_redo->add_do_method(skeleton, "set_bone_custom_pose", property.get_slicec('_', 1).to_int(), p_new_transform);
 		undo_redo->commit_action();
-	} else if (property.get_slicec('/', 0) == "bones") {
+	} else if (property.get_slicec('_', 0) == "bones") {
 		undo_redo->create_action(TTR("Set Bone Transform"), UndoRedo::MERGE_ENDS);
 		undo_redo->add_undo_property(skeleton, property, skeleton->get(property));
 		undo_redo->add_do_property(skeleton, property, p_new_transform);
@@ -218,7 +218,7 @@ void BoneTransformEditor::_change_transform(Transform p_new_transform) {
 
 void BoneTransformEditor::update_enabled_checkbox() {
 	if (enabled_checkbox) {
-		const String path = "bones/" + property.get_slicec('/', 1) + "/enabled";
+		const String path = "bones_" + property.get_slicec('_', 1) + "_enabled";
 		const bool is_enabled = skeleton->get(path);
 		enabled_checkbox->set_pressed(is_enabled);
 	}
@@ -298,7 +298,7 @@ void BoneTransformEditor::_key_button_pressed() {
 		return;
 	}
 
-	const BoneId bone_id = property.get_slicec('/', 1).to_int();
+	const BoneId bone_id = property.get_slicec('_', 1).to_int();
 	const String name = skeleton->get_bone_name(bone_id);
 
 	if (name.is_empty()) {
@@ -313,7 +313,7 @@ void BoneTransformEditor::_key_button_pressed() {
 
 void BoneTransformEditor::_checkbox_toggled(const bool p_toggled) {
 	if (enabled_checkbox) {
-		const String path = "bones/" + property.get_slicec('/', 1) + "/enabled";
+		const String path = "bones_" + property.get_slicec('_', 1) + "_enabled";
 		skeleton->set(path, p_toggled);
 	}
 }
@@ -446,7 +446,7 @@ bool Skeleton3DEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_
 	}
 
 	const String path = target->get_metadata(0);
-	if (!path.begins_with("bones/")) {
+	if (!path.begins_with("bones_")) {
 		return false;
 	}
 
@@ -456,7 +456,7 @@ bool Skeleton3DEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_
 	}
 
 	const String path2 = target->get_metadata(0);
-	if (!path2.begins_with("bones/")) {
+	if (!path2.begins_with("bones_")) {
 		return false;
 	}
 
@@ -471,8 +471,8 @@ void Skeleton3DEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	TreeItem *target = joint_tree->get_item_at_position(p_point);
 	TreeItem *selected = Object::cast_to<TreeItem>(Dictionary(p_data)["node"]);
 
-	const BoneId target_boneidx = String(target->get_metadata(0)).get_slicec('/', 1).to_int();
-	const BoneId selected_boneidx = String(selected->get_metadata(0)).get_slicec('/', 1).to_int();
+	const BoneId target_boneidx = String(target->get_metadata(0)).get_slicec('_', 1).to_int();
+	const BoneId selected_boneidx = String(selected->get_metadata(0)).get_slicec('_', 1).to_int();
 
 	move_skeleton_bone(skeleton->get_path(), selected_boneidx, target_boneidx);
 }
@@ -507,9 +507,9 @@ void Skeleton3DEditor::_joint_tree_selection_changed() {
 	TreeItem *selected = joint_tree->get_selected();
 	const String path = selected->get_metadata(0);
 
-	if (path.begins_with("bones/")) {
-		const int b_idx = path.get_slicec('/', 1).to_int();
-		const String bone_path = "bones/" + itos(b_idx) + "/";
+	if (path.begins_with("bones_")) {
+		const int b_idx = path.get_slicec('_', 1).to_int();
+		const String bone_path = "bones_" + itos(b_idx) + "_";
 
 		pose_editor->set_target(bone_path + "pose");
 		rest_editor->set_target(bone_path + "rest");
@@ -566,7 +566,7 @@ void Skeleton3DEditor::update_joint_tree() {
 		joint_item->set_text(0, skeleton->get_bone_name(b_idx));
 		joint_item->set_icon(0, bone_icon);
 		joint_item->set_selectable(0, true);
-		joint_item->set_metadata(0, "bones/" + itos(b_idx));
+		joint_item->set_metadata(0, "bones_" + itos(b_idx));
 	}
 }
 

--- a/modules/gdnavigation/nav_region.cpp
+++ b/modules/gdnavigation/nav_region.cpp
@@ -104,7 +104,7 @@ void NavRegion::update_polygons() {
 		return;
 	}
 
-	Vector<Vector3> vertices = mesh->get_vertices();
+	Vector<Vector3> vertices = mesh->_get_vertices();
 	int len = vertices.size();
 	if (len == 0) {
 		return;

--- a/modules/gdnavigation/navigation_mesh_generator.h
+++ b/modules/gdnavigation/navigation_mesh_generator.h
@@ -52,7 +52,7 @@ protected:
 	static void _add_vertex(const Vector3 &p_vec3, Vector<float> &p_verticies);
 	static void _add_mesh(const Ref<Mesh> &p_mesh, const Transform &p_xform, Vector<float> &p_verticies, Vector<int> &p_indices);
 	static void _add_faces(const PackedVector3Array &p_faces, const Transform &p_xform, Vector<float> &p_verticies, Vector<int> &p_indices);
-	static void _parse_geometry(Transform p_accumulated_transform, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices, int p_generate_from, uint32_t p_collision_mask, bool p_recurse_children);
+	static void _parse_geometry(Transform p_accumulated_transform, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices, int p_generate_from, uint32_t p_physics_mask, bool p_recurse_children);
 
 	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_nav_mesh);
 	static void _build_recast_navigation_mesh(

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1019,7 +1019,7 @@ bool GDScript::_set(const StringName &p_name, const Variant &p_value) {
 }
 
 void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
-	p_properties->push_back(PropertyInfo(Variant::STRING, "script/source", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+	p_properties->push_back(PropertyInfo(Variant::STRING, "script_source", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 }
 
 void GDScript::_bind_methods() {
@@ -2244,7 +2244,7 @@ GDScriptLanguage::GDScriptLanguage() {
 	strings._set = StaticCString::create("_set");
 	strings._get = StaticCString::create("_get");
 	strings._get_property_list = StaticCString::create("_get_property_list");
-	strings._script_source = StaticCString::create("script/source");
+	strings._script_source = StaticCString::create("script_source");
 	_debug_parse_err_line = -1;
 	_debug_parse_err_file = "";
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -98,10 +98,10 @@ protected:
 
 			return true;
 		}
-		if (String(p_name).begins_with("argument/")) {
-			int idx = String(p_name).get_slice("/", 1).to_int() - 1;
+		if (String(p_name).begins_with("argument_")) {
+			int idx = String(p_name).get_slicec('_', 1).to_int() - 1;
 			ERR_FAIL_INDEX_V(idx, script->custom_signal_get_argument_count(sig), false);
-			String what = String(p_name).get_slice("/", 2);
+			String what = String(p_name).get_slicec('_', 2);
 			if (what == "type") {
 				int old_type = script->custom_signal_get_argument_type(sig, idx);
 				int new_type = p_value;
@@ -136,10 +136,10 @@ protected:
 			r_ret = script->custom_signal_get_argument_count(sig);
 			return true;
 		}
-		if (String(p_name).begins_with("argument/")) {
-			int idx = String(p_name).get_slice("/", 1).to_int() - 1;
+		if (String(p_name).begins_with("argument_")) {
+			int idx = String(p_name).get_slicec('_', 1).to_int() - 1;
 			ERR_FAIL_INDEX_V(idx, script->custom_signal_get_argument_count(sig), false);
-			String what = String(p_name).get_slice("/", 2);
+			String what = String(p_name).get_slicec('_', 2);
 			if (what == "type") {
 				r_ret = script->custom_signal_get_argument_type(sig, idx);
 				return true;
@@ -163,9 +163,11 @@ protected:
 			argt += "," + Variant::get_type_name(Variant::Type(i));
 		}
 
+		p_list->push_back(PropertyInfo(Variant::NIL, "Arguments", PROPERTY_HINT_NONE, "argument_", PROPERTY_USAGE_GROUP));
 		for (int i = 0; i < script->custom_signal_get_argument_count(sig); i++) {
-			p_list->push_back(PropertyInfo(Variant::INT, "argument/" + itos(i + 1) + "/type", PROPERTY_HINT_ENUM, argt));
-			p_list->push_back(PropertyInfo(Variant::STRING, "argument/" + itos(i + 1) + "/name"));
+			p_list->push_back(PropertyInfo(Variant::NIL, itos(i + 1), PROPERTY_HINT_NONE, "argument_" + itos(i + 1) + "_", PROPERTY_USAGE_SUBGROUP));
+			p_list->push_back(PropertyInfo(Variant::INT, "argument_" + itos(i + 1) + "_type", PROPERTY_HINT_ENUM, argt));
+			p_list->push_back(PropertyInfo(Variant::STRING, "argument_" + itos(i + 1) + "_name"));
 		}
 	}
 

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -68,10 +68,10 @@ bool VisualScriptExpression::_set(const StringName &p_name, const Variant &p_val
 	}
 
 	if (String(p_name).begins_with("input_")) {
-		int idx = String(p_name).get_slicec('_', 1).get_slicec('/', 0).to_int();
+		int idx = String(p_name).get_slicec('_', 1).to_int();
 		ERR_FAIL_INDEX_V(idx, inputs.size(), false);
 
-		String what = String(p_name).get_slice("/", 1);
+		String what = String(p_name).get_slicec('_', 2);
 
 		if (what == "type") {
 			inputs.write[idx].type = Variant::Type(int(p_value));
@@ -111,10 +111,10 @@ bool VisualScriptExpression::_get(const StringName &p_name, Variant &r_ret) cons
 	}
 
 	if (String(p_name).begins_with("input_")) {
-		int idx = String(p_name).get_slicec('_', 1).get_slicec('/', 0).to_int();
+		int idx = String(p_name).get_slicec('_', 1).to_int();
 		ERR_FAIL_INDEX_V(idx, inputs.size(), false);
 
-		String what = String(p_name).get_slice("/", 1);
+		String what = String(p_name).get_slicec('_', 2);
 
 		if (what == "type") {
 			r_ret = inputs[idx].type;
@@ -141,9 +141,11 @@ void VisualScriptExpression::_get_property_list(List<PropertyInfo> *p_list) cons
 	p_list->push_back(PropertyInfo(Variant::INT, "input_count", PROPERTY_HINT_RANGE, "0,64,1"));
 	p_list->push_back(PropertyInfo(Variant::BOOL, "sequenced"));
 
+	p_list->push_back(PropertyInfo(Variant::NIL, "Inputs", PROPERTY_HINT_NONE, "input_", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < inputs.size(); i++) {
-		p_list->push_back(PropertyInfo(Variant::INT, "input_" + itos(i) + "/type", PROPERTY_HINT_ENUM, argt));
-		p_list->push_back(PropertyInfo(Variant::STRING, "input_" + itos(i) + "/name"));
+		p_list->push_back(PropertyInfo(Variant::NIL, itos(i), PROPERTY_HINT_NONE, "input_" + itos(i) + "_", PROPERTY_USAGE_SUBGROUP));
+		p_list->push_back(PropertyInfo(Variant::INT, "input_" + itos(i) + "_type", PROPERTY_HINT_ENUM, argt));
+		p_list->push_back(PropertyInfo(Variant::STRING, "input_" + itos(i) + "_name"));
 	}
 }
 

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -633,8 +633,8 @@ bool VisualScriptSwitch::_set(const StringName &p_name, const Variant &p_value) 
 		return true;
 	}
 
-	if (String(p_name).begins_with("case/")) {
-		int idx = String(p_name).get_slice("/", 1).to_int();
+	if (String(p_name).begins_with("case_")) {
+		int idx = String(p_name).get_slicec('_', 1).to_int();
 		ERR_FAIL_INDEX_V(idx, case_values.size(), false);
 
 		case_values.write[idx].type = Variant::Type(int(p_value));
@@ -653,8 +653,8 @@ bool VisualScriptSwitch::_get(const StringName &p_name, Variant &r_ret) const {
 		return true;
 	}
 
-	if (String(p_name).begins_with("case/")) {
-		int idx = String(p_name).get_slice("/", 1).to_int();
+	if (String(p_name).begins_with("case_")) {
+		int idx = String(p_name).get_slicec('_', 1).to_int();
 		ERR_FAIL_INDEX_V(idx, case_values.size(), false);
 
 		r_ret = case_values[idx].type;
@@ -672,8 +672,9 @@ void VisualScriptSwitch::_get_property_list(List<PropertyInfo> *p_list) const {
 		argt += "," + Variant::get_type_name(Variant::Type(i));
 	}
 
+	p_list->push_back(PropertyInfo(Variant::NIL, "Cases", PROPERTY_HINT_NONE, "case_", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < case_values.size(); i++) {
-		p_list->push_back(PropertyInfo(Variant::INT, "case/" + itos(i), PROPERTY_HINT_ENUM, argt));
+		p_list->push_back(PropertyInfo(Variant::INT, "case_" + itos(i), PROPERTY_HINT_ENUM, argt));
 	}
 }
 

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -61,9 +61,9 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 		return true;
 	}
 	if (String(p_name).begins_with("argument_")) {
-		int idx = String(p_name).get_slicec('_', 1).get_slicec('/', 0).to_int() - 1;
+		int idx = String(p_name).get_slicec('_', 1).to_int() - 1;
 		ERR_FAIL_INDEX_V(idx, arguments.size(), false);
-		String what = String(p_name).get_slice("/", 1);
+		String what = String(p_name).get_slicec('_', 2);
 		if (what == "type") {
 			Variant::Type new_type = Variant::Type(int(p_value));
 			arguments.write[idx].type = new_type;
@@ -79,22 +79,22 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 		}
 	}
 
-	if (p_name == "stack/stackless") {
+	if (p_name == "stack_stackless") {
 		set_stack_less(p_value);
 		return true;
 	}
 
-	if (p_name == "stack/size") {
+	if (p_name == "stack_size") {
 		stack_size = p_value;
 		return true;
 	}
 
-	if (p_name == "rpc/mode") {
+	if (p_name == "rpc_mode") {
 		rpc_mode = MultiplayerAPI::RPCMode(int(p_value));
 		return true;
 	}
 
-	if (p_name == "sequenced/sequenced") {
+	if (p_name == "sequenced") {
 		sequenced = p_value;
 		ports_changed_notify();
 		return true;
@@ -109,9 +109,9 @@ bool VisualScriptFunction::_get(const StringName &p_name, Variant &r_ret) const 
 		return true;
 	}
 	if (String(p_name).begins_with("argument_")) {
-		int idx = String(p_name).get_slicec('_', 1).get_slicec('/', 0).to_int() - 1;
+		int idx = String(p_name).get_slicec('_', 1).to_int() - 1;
 		ERR_FAIL_INDEX_V(idx, arguments.size(), false);
-		String what = String(p_name).get_slice("/", 1);
+		String what = String(p_name).get_slicec('_', 2);
 		if (what == "type") {
 			r_ret = arguments[idx].type;
 			return true;
@@ -122,22 +122,22 @@ bool VisualScriptFunction::_get(const StringName &p_name, Variant &r_ret) const 
 		}
 	}
 
-	if (p_name == "stack/stackless") {
+	if (p_name == "stack_stackless") {
 		r_ret = stack_less;
 		return true;
 	}
 
-	if (p_name == "stack/size") {
+	if (p_name == "stack_size") {
 		r_ret = stack_size;
 		return true;
 	}
 
-	if (p_name == "rpc/mode") {
+	if (p_name == "rpc_mode") {
 		r_ret = rpc_mode;
 		return true;
 	}
 
-	if (p_name == "sequenced/sequenced") {
+	if (p_name == "sequenced") {
 		r_ret = sequenced;
 		return true;
 	}
@@ -153,17 +153,17 @@ void VisualScriptFunction::_get_property_list(List<PropertyInfo> *p_list) const 
 	}
 
 	for (int i = 0; i < arguments.size(); i++) {
-		p_list->push_back(PropertyInfo(Variant::INT, "argument_" + itos(i + 1) + "/type", PROPERTY_HINT_ENUM, argt));
-		p_list->push_back(PropertyInfo(Variant::STRING, "argument_" + itos(i + 1) + "/name"));
+		p_list->push_back(PropertyInfo(Variant::INT, "argument_" + itos(i + 1) + "_type", PROPERTY_HINT_ENUM, argt));
+		p_list->push_back(PropertyInfo(Variant::STRING, "argument_" + itos(i + 1) + "_name"));
 	}
 
-	p_list->push_back(PropertyInfo(Variant::BOOL, "sequenced/sequenced"));
+	p_list->push_back(PropertyInfo(Variant::BOOL, "sequenced"));
 
 	if (!stack_less) {
-		p_list->push_back(PropertyInfo(Variant::INT, "stack/size", PROPERTY_HINT_RANGE, "1,100000"));
+		p_list->push_back(PropertyInfo(Variant::INT, "stack_size", PROPERTY_HINT_RANGE, "1,100000"));
 	}
-	p_list->push_back(PropertyInfo(Variant::BOOL, "stack/stackless"));
-	p_list->push_back(PropertyInfo(Variant::INT, "rpc/mode", PROPERTY_HINT_ENUM, "Disabled,Remote,Master,Puppet,Remote Sync,Master Sync,Puppet Sync"));
+	p_list->push_back(PropertyInfo(Variant::BOOL, "stack_stackless"));
+	p_list->push_back(PropertyInfo(Variant::INT, "rpc_mode", PROPERTY_HINT_ENUM, "Disabled,Remote,Master,Puppet,Remote Sync,Master Sync,Puppet Sync"));
 }
 
 int VisualScriptFunction::get_output_sequence_port_count() const {
@@ -433,9 +433,9 @@ bool VisualScriptLists::_set(const StringName &p_name, const Variant &p_value) {
 		return true;
 	}
 	if (String(p_name).begins_with("input_") && is_input_port_editable()) {
-		int idx = String(p_name).get_slicec('_', 1).get_slicec('/', 0).to_int() - 1;
+		int idx = String(p_name).get_slicec('_', 1).to_int() - 1;
 		ERR_FAIL_INDEX_V(idx, inputports.size(), false);
-		String what = String(p_name).get_slice("/", 1);
+		String what = String(p_name).get_slicec('_', 2);
 		if (what == "type") {
 			Variant::Type new_type = Variant::Type(int(p_value));
 			inputports.write[idx].type = new_type;
@@ -469,9 +469,9 @@ bool VisualScriptLists::_set(const StringName &p_name, const Variant &p_value) {
 		return true;
 	}
 	if (String(p_name).begins_with("output_") && is_output_port_editable()) {
-		int idx = String(p_name).get_slicec('_', 1).get_slicec('/', 0).to_int() - 1;
+		int idx = String(p_name).get_slicec('_', 1).to_int() - 1;
 		ERR_FAIL_INDEX_V(idx, outputports.size(), false);
-		String what = String(p_name).get_slice("/", 1);
+		String what = String(p_name).get_slicec('_', 1);
 		if (what == "type") {
 			Variant::Type new_type = Variant::Type(int(p_value));
 			outputports.write[idx].type = new_type;
@@ -502,9 +502,9 @@ bool VisualScriptLists::_get(const StringName &p_name, Variant &r_ret) const {
 		return true;
 	}
 	if (String(p_name).begins_with("input_") && is_input_port_editable()) {
-		int idx = String(p_name).get_slicec('_', 1).get_slicec('/', 0).to_int() - 1;
+		int idx = String(p_name).get_slicec('_', 1).to_int() - 1;
 		ERR_FAIL_INDEX_V(idx, inputports.size(), false);
-		String what = String(p_name).get_slice("/", 1);
+		String what = String(p_name).get_slicec('_', 1);
 		if (what == "type") {
 			r_ret = inputports[idx].type;
 			return true;
@@ -520,9 +520,9 @@ bool VisualScriptLists::_get(const StringName &p_name, Variant &r_ret) const {
 		return true;
 	}
 	if (String(p_name).begins_with("output_") && is_output_port_editable()) {
-		int idx = String(p_name).get_slicec('_', 1).get_slicec('/', 0).to_int() - 1;
+		int idx = String(p_name).get_slicec('_', 1).to_int() - 1;
 		ERR_FAIL_INDEX_V(idx, outputports.size(), false);
-		String what = String(p_name).get_slice("/", 1);
+		String what = String(p_name).get_slicec('_', 1);
 		if (what == "type") {
 			r_ret = outputports[idx].type;
 			return true;
@@ -550,8 +550,8 @@ void VisualScriptLists::_get_property_list(List<PropertyInfo> *p_list) const {
 		}
 
 		for (int i = 0; i < inputports.size(); i++) {
-			p_list->push_back(PropertyInfo(Variant::INT, "input_" + itos(i + 1) + "/type", PROPERTY_HINT_ENUM, argt));
-			p_list->push_back(PropertyInfo(Variant::STRING, "input_" + itos(i + 1) + "/name"));
+			p_list->push_back(PropertyInfo(Variant::INT, "input_" + itos(i + 1) + "_type", PROPERTY_HINT_ENUM, argt));
+			p_list->push_back(PropertyInfo(Variant::STRING, "input_" + itos(i + 1) + "_name"));
 		}
 	}
 
@@ -563,11 +563,11 @@ void VisualScriptLists::_get_property_list(List<PropertyInfo> *p_list) const {
 		}
 
 		for (int i = 0; i < outputports.size(); i++) {
-			p_list->push_back(PropertyInfo(Variant::INT, "output_" + itos(i + 1) + "/type", PROPERTY_HINT_ENUM, argt));
-			p_list->push_back(PropertyInfo(Variant::STRING, "output_" + itos(i + 1) + "/name"));
+			p_list->push_back(PropertyInfo(Variant::INT, "output_" + itos(i + 1) + "_type", PROPERTY_HINT_ENUM, argt));
+			p_list->push_back(PropertyInfo(Variant::STRING, "output_" + itos(i + 1) + "_name"));
 		}
 	}
-	p_list->push_back(PropertyInfo(Variant::BOOL, "sequenced/sequenced"));
+	p_list->push_back(PropertyInfo(Variant::BOOL, "sequenced"));
 }
 
 // input data port interaction

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -221,7 +221,7 @@ void Joint2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody2D"), "set_node_a", "get_node_a");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_b", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody2D"), "set_node_b", "get_node_b");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0,0.9,0.001"), "set_bias", "get_bias");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_collision"), "set_exclude_nodes_from_collision", "get_exclude_nodes_from_collision");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclude_nodes_from_collision"), "set_exclude_nodes_from_collision", "get_exclude_nodes_from_collision");
 }
 
 Joint2D::Joint2D() {

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -181,7 +181,7 @@ Ref<NavigationMesh> NavigationPolygon::get_mesh() {
 				w[i] = Vector3(r[i].x, 0.0, r[i].y);
 			}
 		}
-		navmesh->set_vertices(verts);
+		navmesh->_set_vertices(verts);
 
 		for (int i(0); i < get_polygon_count(); i++) {
 			navmesh->add_polygon(get_polygon(i));

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1153,8 +1153,8 @@ void KinematicBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sync_to_physics", "enable"), &KinematicBody2D::set_sync_to_physics);
 	ClassDB::bind_method(D_METHOD("is_sync_to_physics_enabled"), &KinematicBody2D::is_sync_to_physics_enabled);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision/safe_margin", PROPERTY_HINT_RANGE, "0.001,256,0.001"), "set_safe_margin", "get_safe_margin");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "motion/sync_to_physics"), "set_sync_to_physics", "is_sync_to_physics_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "safe_margin", PROPERTY_HINT_RANGE, "0.001,256,0.001"), "set_safe_margin", "get_safe_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync_to_physics"), "set_sync_to_physics", "is_sync_to_physics_enabled");
 }
 
 KinematicBody2D::KinematicBody2D() :

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -51,8 +51,8 @@ bool MeshInstance3D::_set(const StringName &p_name, const Variant &p_value) {
 		return true;
 	}
 
-	if (p_name.operator String().begins_with("surface_material_override/")) {
-		int idx = p_name.operator String().get_slicec('/', 1).to_int();
+	if (p_name.operator String().begins_with("surface_material_override_")) {
+		int idx = p_name.operator String().get_slicec('_', 3).to_int();
 		if (idx >= surface_override_materials.size() || idx < 0) {
 			return false;
 		}
@@ -75,8 +75,8 @@ bool MeshInstance3D::_get(const StringName &p_name, Variant &r_ret) const {
 		return true;
 	}
 
-	if (p_name.operator String().begins_with("surface_material_override/")) {
-		int idx = p_name.operator String().get_slicec('/', 1).to_int();
+	if (p_name.operator String().begins_with("surface_material_override_")) {
+		int idx = p_name.operator String().get_slicec('_', 3).to_int();
 		if (idx >= surface_override_materials.size() || idx < 0) {
 			return false;
 		}
@@ -99,8 +99,9 @@ void MeshInstance3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 
 	if (mesh.is_valid()) {
+		p_list->push_back(PropertyInfo(Variant::NIL, "Materials", PROPERTY_HINT_NONE, "mateiral_", PROPERTY_USAGE_GROUP));
 		for (int i = 0; i < mesh->get_surface_count(); i++) {
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "surface_material_override/" + itos(i), PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,StandardMaterial3D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_DEFERRED_SET_RESOURCE));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "surface_material_override_" + itos(i), PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,StandardMaterial3D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_DEFERRED_SET_RESOURCE));
 		}
 	}
 }

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -758,7 +758,6 @@ void Node3D::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_EXIT_WORLD);
 	BIND_CONSTANT(NOTIFICATION_VISIBILITY_CHANGED);
 
-	//ADD_PROPERTY( PropertyInfo(Variant::TRANSFORM,"transform/global",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR ), "set_global_transform", "get_global_transform") ;
 	ADD_GROUP("Transform", "");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM, "global_transform", PROPERTY_HINT_NONE, "", 0), "set_global_transform", "get_global_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "translation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_translation", "get_translation");

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1290,19 +1290,19 @@ bool PhysicalBone3D::PinJointData::_set(const StringName &p_name, const Variant 
 		return true;
 	}
 
-	if ("joint_constraints/bias" == p_name) {
+	if ("joint_constraints_bias" == p_name) {
 		bias = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->pin_joint_set_param(j, PhysicsServer3D::PIN_JOINT_BIAS, bias);
 		}
 
-	} else if ("joint_constraints/damping" == p_name) {
+	} else if ("joint_constraints_damping" == p_name) {
 		damping = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->pin_joint_set_param(j, PhysicsServer3D::PIN_JOINT_DAMPING, damping);
 		}
 
-	} else if ("joint_constraints/impulse_clamp" == p_name) {
+	} else if ("joint_constraints_impulse_clamp" == p_name) {
 		impulse_clamp = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->pin_joint_set_param(j, PhysicsServer3D::PIN_JOINT_IMPULSE_CLAMP, impulse_clamp);
@@ -1320,11 +1320,11 @@ bool PhysicalBone3D::PinJointData::_get(const StringName &p_name, Variant &r_ret
 		return true;
 	}
 
-	if ("joint_constraints/bias" == p_name) {
+	if ("joint_constraints_bias" == p_name) {
 		r_ret = bias;
-	} else if ("joint_constraints/damping" == p_name) {
+	} else if ("joint_constraints_damping" == p_name) {
 		r_ret = damping;
-	} else if ("joint_constraints/impulse_clamp" == p_name) {
+	} else if ("joint_constraints_impulse_clamp" == p_name) {
 		r_ret = impulse_clamp;
 	} else {
 		return false;
@@ -1336,9 +1336,10 @@ bool PhysicalBone3D::PinJointData::_get(const StringName &p_name, Variant &r_ret
 void PhysicalBone3D::PinJointData::_get_property_list(List<PropertyInfo> *p_list) const {
 	JointData::_get_property_list(p_list);
 
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/damping", PROPERTY_HINT_RANGE, "0.01,8.0,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/impulse_clamp", PROPERTY_HINT_RANGE, "0.0,64.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::NIL, "Joint Constraints", PROPERTY_HINT_NONE, "joint_constraints_", PROPERTY_USAGE_GROUP));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_damping", PROPERTY_HINT_RANGE, "0.01,8.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_impulse_clamp", PROPERTY_HINT_RANGE, "0.0,64.0,0.01"));
 }
 
 bool PhysicalBone3D::ConeJointData::_set(const StringName &p_name, const Variant &p_value, RID j) {
@@ -1346,31 +1347,31 @@ bool PhysicalBone3D::ConeJointData::_set(const StringName &p_name, const Variant
 		return true;
 	}
 
-	if ("joint_constraints/swing_span" == p_name) {
+	if ("joint_constraints_swing_span" == p_name) {
 		swing_span = Math::deg2rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->cone_twist_joint_set_param(j, PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN, swing_span);
 		}
 
-	} else if ("joint_constraints/twist_span" == p_name) {
+	} else if ("joint_constraints_twist_span" == p_name) {
 		twist_span = Math::deg2rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->cone_twist_joint_set_param(j, PhysicsServer3D::CONE_TWIST_JOINT_TWIST_SPAN, twist_span);
 		}
 
-	} else if ("joint_constraints/bias" == p_name) {
+	} else if ("joint_constraints_bias" == p_name) {
 		bias = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->cone_twist_joint_set_param(j, PhysicsServer3D::CONE_TWIST_JOINT_BIAS, bias);
 		}
 
-	} else if ("joint_constraints/softness" == p_name) {
+	} else if ("joint_constraints_softness" == p_name) {
 		softness = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->cone_twist_joint_set_param(j, PhysicsServer3D::CONE_TWIST_JOINT_SOFTNESS, softness);
 		}
 
-	} else if ("joint_constraints/relaxation" == p_name) {
+	} else if ("joint_constraints_relaxation" == p_name) {
 		relaxation = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->cone_twist_joint_set_param(j, PhysicsServer3D::CONE_TWIST_JOINT_RELAXATION, relaxation);
@@ -1388,15 +1389,15 @@ bool PhysicalBone3D::ConeJointData::_get(const StringName &p_name, Variant &r_re
 		return true;
 	}
 
-	if ("joint_constraints/swing_span" == p_name) {
+	if ("joint_constraints_swing_span" == p_name) {
 		r_ret = Math::rad2deg(swing_span);
-	} else if ("joint_constraints/twist_span" == p_name) {
+	} else if ("joint_constraints_twist_span" == p_name) {
 		r_ret = Math::rad2deg(twist_span);
-	} else if ("joint_constraints/bias" == p_name) {
+	} else if ("joint_constraints_bias" == p_name) {
 		r_ret = bias;
-	} else if ("joint_constraints/softness" == p_name) {
+	} else if ("joint_constraints_softness" == p_name) {
 		r_ret = softness;
-	} else if ("joint_constraints/relaxation" == p_name) {
+	} else if ("joint_constraints_relaxation" == p_name) {
 		r_ret = relaxation;
 	} else {
 		return false;
@@ -1408,11 +1409,12 @@ bool PhysicalBone3D::ConeJointData::_get(const StringName &p_name, Variant &r_re
 void PhysicalBone3D::ConeJointData::_get_property_list(List<PropertyInfo> *p_list) const {
 	JointData::_get_property_list(p_list);
 
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/swing_span", PROPERTY_HINT_RANGE, "-180,180,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/twist_span", PROPERTY_HINT_RANGE, "-40000,40000,0.1,or_lesser,or_greater"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/bias", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/relaxation", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::NIL, "Joint Constraints", PROPERTY_HINT_NONE, "joint_constraints_", PROPERTY_USAGE_GROUP));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_swing_span", PROPERTY_HINT_RANGE, "-180,180,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_twist_span", PROPERTY_HINT_RANGE, "-40000,40000,0.1,or_lesser,or_greater"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_bias", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_relaxation", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
 }
 
 bool PhysicalBone3D::HingeJointData::_set(const StringName &p_name, const Variant &p_value, RID j) {
@@ -1420,37 +1422,37 @@ bool PhysicalBone3D::HingeJointData::_set(const StringName &p_name, const Varian
 		return true;
 	}
 
-	if ("joint_constraints/angular_limit_enabled" == p_name) {
+	if ("joint_constraints_angular_limit_enabled" == p_name) {
 		angular_limit_enabled = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->hinge_joint_set_flag(j, PhysicsServer3D::HINGE_JOINT_FLAG_USE_LIMIT, angular_limit_enabled);
 		}
 
-	} else if ("joint_constraints/angular_limit_upper" == p_name) {
+	} else if ("joint_constraints_angular_limit_upper" == p_name) {
 		angular_limit_upper = Math::deg2rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->hinge_joint_set_param(j, PhysicsServer3D::HINGE_JOINT_LIMIT_UPPER, angular_limit_upper);
 		}
 
-	} else if ("joint_constraints/angular_limit_lower" == p_name) {
+	} else if ("joint_constraints_angular_limit_lower" == p_name) {
 		angular_limit_lower = Math::deg2rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->hinge_joint_set_param(j, PhysicsServer3D::HINGE_JOINT_LIMIT_LOWER, angular_limit_lower);
 		}
 
-	} else if ("joint_constraints/angular_limit_bias" == p_name) {
+	} else if ("joint_constraints_angular_limit_bias" == p_name) {
 		angular_limit_bias = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->hinge_joint_set_param(j, PhysicsServer3D::HINGE_JOINT_LIMIT_BIAS, angular_limit_bias);
 		}
 
-	} else if ("joint_constraints/angular_limit_softness" == p_name) {
+	} else if ("joint_constraints_angular_limit_softness" == p_name) {
 		angular_limit_softness = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->hinge_joint_set_param(j, PhysicsServer3D::HINGE_JOINT_LIMIT_SOFTNESS, angular_limit_softness);
 		}
 
-	} else if ("joint_constraints/angular_limit_relaxation" == p_name) {
+	} else if ("joint_constraints_angular_limit_relaxation" == p_name) {
 		angular_limit_relaxation = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->hinge_joint_set_param(j, PhysicsServer3D::HINGE_JOINT_LIMIT_RELAXATION, angular_limit_relaxation);
@@ -1468,17 +1470,17 @@ bool PhysicalBone3D::HingeJointData::_get(const StringName &p_name, Variant &r_r
 		return true;
 	}
 
-	if ("joint_constraints/angular_limit_enabled" == p_name) {
+	if ("joint_constraints_angular_limit_enabled" == p_name) {
 		r_ret = angular_limit_enabled;
-	} else if ("joint_constraints/angular_limit_upper" == p_name) {
+	} else if ("joint_constraints_angular_limit_upper" == p_name) {
 		r_ret = Math::rad2deg(angular_limit_upper);
-	} else if ("joint_constraints/angular_limit_lower" == p_name) {
+	} else if ("joint_constraints_angular_limit_lower" == p_name) {
 		r_ret = Math::rad2deg(angular_limit_lower);
-	} else if ("joint_constraints/angular_limit_bias" == p_name) {
+	} else if ("joint_constraints_angular_limit_bias" == p_name) {
 		r_ret = angular_limit_bias;
-	} else if ("joint_constraints/angular_limit_softness" == p_name) {
+	} else if ("joint_constraints_angular_limit_softness" == p_name) {
 		r_ret = angular_limit_softness;
-	} else if ("joint_constraints/angular_limit_relaxation" == p_name) {
+	} else if ("joint_constraints_angular_limit_relaxation" == p_name) {
 		r_ret = angular_limit_relaxation;
 	} else {
 		return false;
@@ -1490,12 +1492,12 @@ bool PhysicalBone3D::HingeJointData::_get(const StringName &p_name, Variant &r_r
 void PhysicalBone3D::HingeJointData::_get_property_list(List<PropertyInfo> *p_list) const {
 	JointData::_get_property_list(p_list);
 
-	p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints/angular_limit_enabled"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_upper", PROPERTY_HINT_RANGE, "-180,180,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_lower", PROPERTY_HINT_RANGE, "-180,180,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_relaxation", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
+	p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints_angular_limit_enabled"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_upper", PROPERTY_HINT_RANGE, "-180,180,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_lower", PROPERTY_HINT_RANGE, "-180,180,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_relaxation", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
 }
 
 bool PhysicalBone3D::SliderJointData::_set(const StringName &p_name, const Variant &p_value, RID j) {
@@ -1503,61 +1505,61 @@ bool PhysicalBone3D::SliderJointData::_set(const StringName &p_name, const Varia
 		return true;
 	}
 
-	if ("joint_constraints/linear_limit_upper" == p_name) {
+	if ("joint_constraints_linear_limit_upper" == p_name) {
 		linear_limit_upper = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_UPPER, linear_limit_upper);
 		}
 
-	} else if ("joint_constraints/linear_limit_lower" == p_name) {
+	} else if ("joint_constraints_linear_limit_lower" == p_name) {
 		linear_limit_lower = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_LOWER, linear_limit_lower);
 		}
 
-	} else if ("joint_constraints/linear_limit_softness" == p_name) {
+	} else if ("joint_constraints_linear_limit_softness" == p_name) {
 		linear_limit_softness = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS, linear_limit_softness);
 		}
 
-	} else if ("joint_constraints/linear_limit_restitution" == p_name) {
+	} else if ("joint_constraints_linear_limit_restitution" == p_name) {
 		linear_limit_restitution = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION, linear_limit_restitution);
 		}
 
-	} else if ("joint_constraints/linear_limit_damping" == p_name) {
+	} else if ("joint_constraints_linear_limit_damping" == p_name) {
 		linear_limit_damping = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_DAMPING, linear_limit_restitution);
 		}
 
-	} else if ("joint_constraints/angular_limit_upper" == p_name) {
+	} else if ("joint_constraints_angular_limit_upper" == p_name) {
 		angular_limit_upper = Math::deg2rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_UPPER, angular_limit_upper);
 		}
 
-	} else if ("joint_constraints/angular_limit_lower" == p_name) {
+	} else if ("joint_constraints_angular_limit_lower" == p_name) {
 		angular_limit_lower = Math::deg2rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_LOWER, angular_limit_lower);
 		}
 
-	} else if ("joint_constraints/angular_limit_softness" == p_name) {
+	} else if ("joint_constraints_angular_limit_softness" == p_name) {
 		angular_limit_softness = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS, angular_limit_softness);
 		}
 
-	} else if ("joint_constraints/angular_limit_restitution" == p_name) {
+	} else if ("joint_constraints_angular_limit_restitution" == p_name) {
 		angular_limit_restitution = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS, angular_limit_softness);
 		}
 
-	} else if ("joint_constraints/angular_limit_damping" == p_name) {
+	} else if ("joint_constraints_angular_limit_damping" == p_name) {
 		angular_limit_damping = p_value;
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING, angular_limit_damping);
@@ -1575,25 +1577,25 @@ bool PhysicalBone3D::SliderJointData::_get(const StringName &p_name, Variant &r_
 		return true;
 	}
 
-	if ("joint_constraints/linear_limit_upper" == p_name) {
+	if ("joint_constraints_linear_limit_upper" == p_name) {
 		r_ret = linear_limit_upper;
-	} else if ("joint_constraints/linear_limit_lower" == p_name) {
+	} else if ("joint_constraints_linear_limit_lower" == p_name) {
 		r_ret = linear_limit_lower;
-	} else if ("joint_constraints/linear_limit_softness" == p_name) {
+	} else if ("joint_constraints_linear_limit_softness" == p_name) {
 		r_ret = linear_limit_softness;
-	} else if ("joint_constraints/linear_limit_restitution" == p_name) {
+	} else if ("joint_constraints_linear_limit_restitution" == p_name) {
 		r_ret = linear_limit_restitution;
-	} else if ("joint_constraints/linear_limit_damping" == p_name) {
+	} else if ("joint_constraints_linear_limit_damping" == p_name) {
 		r_ret = linear_limit_damping;
-	} else if ("joint_constraints/angular_limit_upper" == p_name) {
+	} else if ("joint_constraints_angular_limit_upper" == p_name) {
 		r_ret = Math::rad2deg(angular_limit_upper);
-	} else if ("joint_constraints/angular_limit_lower" == p_name) {
+	} else if ("joint_constraints_angular_limit_lower" == p_name) {
 		r_ret = Math::rad2deg(angular_limit_lower);
-	} else if ("joint_constraints/angular_limit_softness" == p_name) {
+	} else if ("joint_constraints_angular_limit_softness" == p_name) {
 		r_ret = angular_limit_softness;
-	} else if ("joint_constraints/angular_limit_restitution" == p_name) {
+	} else if ("joint_constraints_angular_limit_restitution" == p_name) {
 		r_ret = angular_limit_restitution;
-	} else if ("joint_constraints/angular_limit_damping" == p_name) {
+	} else if ("joint_constraints_angular_limit_damping" == p_name) {
 		r_ret = angular_limit_damping;
 	} else {
 		return false;
@@ -1605,17 +1607,18 @@ bool PhysicalBone3D::SliderJointData::_get(const StringName &p_name, Variant &r_
 void PhysicalBone3D::SliderJointData::_get_property_list(List<PropertyInfo> *p_list) const {
 	JointData::_get_property_list(p_list);
 
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/linear_limit_upper"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/linear_limit_lower"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/linear_limit_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/linear_limit_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/linear_limit_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::NIL, "Joint Constraints", PROPERTY_HINT_NONE, "joint_constraints_", PROPERTY_USAGE_GROUP));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_linear_limit_upper"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_linear_limit_lower"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_linear_limit_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_linear_limit_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_linear_limit_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"));
 
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_upper", PROPERTY_HINT_RANGE, "-180,180,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_lower", PROPERTY_HINT_RANGE, "-180,180,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/angular_limit_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_upper", PROPERTY_HINT_RANGE, "-180,180,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_lower", PROPERTY_HINT_RANGE, "-180,180,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"));
+	p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_angular_limit_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"));
 }
 
 bool PhysicalBone3D::SixDOFJointData::_set(const StringName &p_name, const Variant &p_value, RID j) {
@@ -1631,7 +1634,7 @@ bool PhysicalBone3D::SixDOFJointData::_set(const StringName &p_name, const Varia
 
 	Vector3::Axis axis;
 	{
-		const String axis_s = path.get_slicec('/', 1);
+		const String axis_s = path.get_slicec('_', 1);
 		if ("x" == axis_s) {
 			axis = Vector3::AXIS_X;
 		} else if ("y" == axis_s) {
@@ -1643,7 +1646,7 @@ bool PhysicalBone3D::SixDOFJointData::_set(const StringName &p_name, const Varia
 		}
 	}
 
-	String var_name = path.get_slicec('/', 2);
+	String var_name = path.get_slicec('_', 2);
 
 	if ("linear_limit_enabled" == var_name) {
 		axis_data[axis].linear_limit_enabled = p_value;
@@ -1791,7 +1794,7 @@ bool PhysicalBone3D::SixDOFJointData::_get(const StringName &p_name, Variant &r_
 
 	int axis;
 	{
-		const String axis_s = path.get_slicec('/', 1);
+		const String axis_s = path.get_slicec('_', 1);
 		if ("x" == axis_s) {
 			axis = 0;
 		} else if ("y" == axis_s) {
@@ -1803,7 +1806,7 @@ bool PhysicalBone3D::SixDOFJointData::_get(const StringName &p_name, Variant &r_
 		}
 	}
 
-	String var_name = path.get_slicec('/', 2);
+	String var_name = path.get_slicec('_', 2);
 
 	if ("linear_limit_enabled" == var_name) {
 		r_ret = axis_data[axis].linear_limit_enabled;
@@ -1856,28 +1859,30 @@ bool PhysicalBone3D::SixDOFJointData::_get(const StringName &p_name, Variant &r_
 
 void PhysicalBone3D::SixDOFJointData::_get_property_list(List<PropertyInfo> *p_list) const {
 	const StringName axis_names[] = { "x", "y", "z" };
+	p_list->push_back(PropertyInfo(Variant::NIL, "Joint Constraints", PROPERTY_HINT_NONE, "joint_constraints_", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < 3; ++i) {
-		p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints/" + axis_names[i] + "/linear_limit_enabled"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/linear_limit_upper"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/linear_limit_lower"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/linear_limit_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
-		p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints/" + axis_names[i] + "/linear_spring_enabled"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/linear_spring_stiffness"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/linear_spring_damping"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/linear_equilibrium_point"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/linear_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/linear_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
-		p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints/" + axis_names[i] + "/angular_limit_enabled"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/angular_limit_upper", PROPERTY_HINT_RANGE, "-180,180,0.01"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/angular_limit_lower", PROPERTY_HINT_RANGE, "-180,180,0.01"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/angular_limit_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/angular_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/angular_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/erp"));
-		p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints/" + axis_names[i] + "/angular_spring_enabled"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/angular_spring_stiffness"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/angular_spring_damping"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints/" + axis_names[i] + "/angular_equilibrium_point"));
+		p_list->push_back(PropertyInfo(Variant::NIL, axis_names[i], PROPERTY_HINT_NONE, "joint_constraints_" + axis_names[i] + "_", PROPERTY_USAGE_SUBGROUP));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints_" + axis_names[i] + "_linear_limit_enabled"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_linear_limit_upper"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_linear_limit_lower"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_linear_limit_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints_" + axis_names[i] + "_linear_spring_enabled"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_linear_spring_stiffness"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_linear_spring_damping"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_linear_equilibrium_point"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_linear_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_linear_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints_" + axis_names[i] + "_angular_limit_enabled"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_angular_limit_upper", PROPERTY_HINT_RANGE, "-180,180,0.01"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_angular_limit_lower", PROPERTY_HINT_RANGE, "-180,180,0.01"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_angular_limit_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_angular_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_angular_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_erp"));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "joint_constraints_" + axis_names[i] + "_angular_spring_enabled"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_angular_spring_stiffness"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_angular_spring_damping"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "joint_constraints_" + axis_names[i] + "_angular_equilibrium_point"));
 	}
 }
 

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1118,7 +1118,7 @@ void KinematicBody3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "axis_lock_motion_y"), "set_axis_lock", "get_axis_lock", PhysicsServer3D::BODY_AXIS_LINEAR_Y);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "axis_lock_motion_z"), "set_axis_lock", "get_axis_lock", PhysicsServer3D::BODY_AXIS_LINEAR_Z);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision/safe_margin", PROPERTY_HINT_RANGE, "0.001,256,0.001"), "set_safe_margin", "get_safe_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "safe_margin", PROPERTY_HINT_RANGE, "0.001,256,0.001"), "set_safe_margin", "get_safe_margin");
 }
 
 void KinematicBody3D::_direct_state_changed(Object *p_state) {

--- a/scene/3d/physics_joint_3d.cpp
+++ b/scene/3d/physics_joint_3d.cpp
@@ -213,11 +213,11 @@ void Joint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude_nodes_from_collision", "enable"), &Joint3D::set_exclude_nodes_from_collision);
 	ClassDB::bind_method(D_METHOD("get_exclude_nodes_from_collision"), &Joint3D::get_exclude_nodes_from_collision);
 
-	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "nodes/node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody3D"), "set_node_a", "get_node_a");
-	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "nodes/node_b", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody3D"), "set_node_b", "get_node_b");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "solver/priority", PROPERTY_HINT_RANGE, "1,8,1"), "set_solver_priority", "get_solver_priority");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody3D"), "set_node_a", "get_node_a");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_b", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody3D"), "set_node_b", "get_node_b");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "solver_priority", PROPERTY_HINT_RANGE, "1,8,1"), "set_solver_priority", "get_solver_priority");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collision/exclude_nodes"), "set_exclude_nodes_from_collision", "get_exclude_nodes_from_collision");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclude_nodes_from_collision"), "set_exclude_nodes_from_collision", "get_exclude_nodes_from_collision");
 }
 
 Joint3D::Joint3D() {
@@ -235,9 +235,9 @@ void PinJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &PinJoint3D::set_param);
 	ClassDB::bind_method(D_METHOD("get_param", "param"), &PinJoint3D::get_param);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"), "set_param", "get_param", PARAM_BIAS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/damping", PROPERTY_HINT_RANGE, "0.01,8.0,0.01"), "set_param", "get_param", PARAM_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/impulse_clamp", PROPERTY_HINT_RANGE, "0.0,64.0,0.01"), "set_param", "get_param", PARAM_IMPULSE_CLAMP);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"), "set_param", "get_param", PARAM_BIAS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping", PROPERTY_HINT_RANGE, "0.01,8.0,0.01"), "set_param", "get_param", PARAM_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "impulse_clamp", PROPERTY_HINT_RANGE, "0.0,64.0,0.01"), "set_param", "get_param", PARAM_IMPULSE_CLAMP);
 
 	BIND_ENUM_CONSTANT(PARAM_BIAS);
 	BIND_ENUM_CONSTANT(PARAM_DAMPING);
@@ -284,19 +284,19 @@ PinJoint3D::PinJoint3D() {
 
 ///////////////////////////////////
 
-void HingeJoint3D::_set_upper_limit(real_t p_limit) {
+void HingeJoint3D::set_upper_limit(real_t p_limit) {
 	set_param(PARAM_LIMIT_UPPER, Math::deg2rad(p_limit));
 }
 
-real_t HingeJoint3D::_get_upper_limit() const {
+real_t HingeJoint3D::get_upper_limit() const {
 	return Math::rad2deg(get_param(PARAM_LIMIT_UPPER));
 }
 
-void HingeJoint3D::_set_lower_limit(real_t p_limit) {
+void HingeJoint3D::set_lower_limit(real_t p_limit) {
 	set_param(PARAM_LIMIT_LOWER, Math::deg2rad(p_limit));
 }
 
-real_t HingeJoint3D::_get_lower_limit() const {
+real_t HingeJoint3D::get_lower_limit() const {
 	return Math::rad2deg(get_param(PARAM_LIMIT_LOWER));
 }
 
@@ -307,24 +307,26 @@ void HingeJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flag", "flag", "enabled"), &HingeJoint3D::set_flag);
 	ClassDB::bind_method(D_METHOD("get_flag", "flag"), &HingeJoint3D::get_flag);
 
-	ClassDB::bind_method(D_METHOD("_set_upper_limit", "upper_limit"), &HingeJoint3D::_set_upper_limit);
-	ClassDB::bind_method(D_METHOD("_get_upper_limit"), &HingeJoint3D::_get_upper_limit);
+	ClassDB::bind_method(D_METHOD("set_upper_limit", "upper_limit"), &HingeJoint3D::set_upper_limit);
+	ClassDB::bind_method(D_METHOD("get_upper_limit"), &HingeJoint3D::get_upper_limit);
 
-	ClassDB::bind_method(D_METHOD("_set_lower_limit", "lower_limit"), &HingeJoint3D::_set_lower_limit);
-	ClassDB::bind_method(D_METHOD("_get_lower_limit"), &HingeJoint3D::_get_lower_limit);
+	ClassDB::bind_method(D_METHOD("set_lower_limit", "lower_limit"), &HingeJoint3D::set_lower_limit);
+	ClassDB::bind_method(D_METHOD("get_lower_limit"), &HingeJoint3D::get_lower_limit);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/bias", PROPERTY_HINT_RANGE, "0.00,0.99,0.01"), "set_param", "get_param", PARAM_BIAS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0.00,0.99,0.01"), "set_param", "get_param", PARAM_BIAS);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit/enable"), "set_flag", "get_flag", FLAG_USE_LIMIT);
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit/upper", PROPERTY_HINT_RANGE, "-180,180,0.1"), "_set_upper_limit", "_get_upper_limit");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit/lower", PROPERTY_HINT_RANGE, "-180,180,0.1"), "_set_lower_limit", "_get_lower_limit");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"), "set_param", "get_param", PARAM_LIMIT_BIAS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param", "get_param", PARAM_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/relaxation", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param", "get_param", PARAM_LIMIT_RELAXATION);
+	ADD_GROUP("Angular Limit", "angular_limit_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_enable"), "set_flag", "get_flag", FLAG_USE_LIMIT);
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_upper", PROPERTY_HINT_RANGE, "-180,180,0.1"), "set_upper_limit", "get_upper_limit");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_lower", PROPERTY_HINT_RANGE, "-180,180,0.1"), "set_lower_limit", "get_lower_limit");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"), "set_param", "get_param", PARAM_LIMIT_BIAS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param", "get_param", PARAM_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_relaxation", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param", "get_param", PARAM_LIMIT_RELAXATION);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "motor/enable"), "set_flag", "get_flag", FLAG_ENABLE_MOTOR);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "motor/target_velocity", PROPERTY_HINT_RANGE, "-200,200,0.01,or_greater,or_lesser"), "set_param", "get_param", PARAM_MOTOR_TARGET_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "motor/max_impulse", PROPERTY_HINT_RANGE, "0.01,1024,0.01"), "set_param", "get_param", PARAM_MOTOR_MAX_IMPULSE);
+	ADD_GROUP("Motor", "motor_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "motor_enable"), "set_flag", "get_flag", FLAG_ENABLE_MOTOR);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "motor_target_velocity", PROPERTY_HINT_RANGE, "-200,200,0.01,or_greater,or_lesser"), "set_param", "get_param", PARAM_MOTOR_TARGET_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "motor_max_impulse", PROPERTY_HINT_RANGE, "0.01,1024,0.01"), "set_param", "get_param", PARAM_MOTOR_MAX_IMPULSE);
 
 	BIND_ENUM_CONSTANT(PARAM_BIAS);
 	BIND_ENUM_CONSTANT(PARAM_LIMIT_UPPER);
@@ -414,19 +416,19 @@ HingeJoint3D::HingeJoint3D() {
 
 //////////////////////////////////
 
-void SliderJoint3D::_set_upper_limit_angular(real_t p_limit_angular) {
+void SliderJoint3D::set_upper_limit_angular(real_t p_limit_angular) {
 	set_param(PARAM_ANGULAR_LIMIT_UPPER, Math::deg2rad(p_limit_angular));
 }
 
-real_t SliderJoint3D::_get_upper_limit_angular() const {
+real_t SliderJoint3D::get_upper_limit_angular() const {
 	return Math::rad2deg(get_param(PARAM_ANGULAR_LIMIT_UPPER));
 }
 
-void SliderJoint3D::_set_lower_limit_angular(real_t p_limit_angular) {
+void SliderJoint3D::set_lower_limit_angular(real_t p_limit_angular) {
 	set_param(PARAM_ANGULAR_LIMIT_LOWER, Math::deg2rad(p_limit_angular));
 }
 
-real_t SliderJoint3D::_get_lower_limit_angular() const {
+real_t SliderJoint3D::get_lower_limit_angular() const {
 	return Math::rad2deg(get_param(PARAM_ANGULAR_LIMIT_LOWER));
 }
 
@@ -434,35 +436,41 @@ void SliderJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &SliderJoint3D::set_param);
 	ClassDB::bind_method(D_METHOD("get_param", "param"), &SliderJoint3D::get_param);
 
-	ClassDB::bind_method(D_METHOD("_set_upper_limit_angular", "upper_limit_angular"), &SliderJoint3D::_set_upper_limit_angular);
-	ClassDB::bind_method(D_METHOD("_get_upper_limit_angular"), &SliderJoint3D::_get_upper_limit_angular);
+	ClassDB::bind_method(D_METHOD("set_upper_limit_angular", "upper_limit_angular"), &SliderJoint3D::set_upper_limit_angular);
+	ClassDB::bind_method(D_METHOD("get_upper_limit_angular"), &SliderJoint3D::get_upper_limit_angular);
 
-	ClassDB::bind_method(D_METHOD("_set_lower_limit_angular", "lower_limit_angular"), &SliderJoint3D::_set_lower_limit_angular);
-	ClassDB::bind_method(D_METHOD("_get_lower_limit_angular"), &SliderJoint3D::_get_lower_limit_angular);
+	ClassDB::bind_method(D_METHOD("set_lower_limit_angular", "lower_limit_angular"), &SliderJoint3D::set_lower_limit_angular);
+	ClassDB::bind_method(D_METHOD("get_lower_limit_angular"), &SliderJoint3D::get_lower_limit_angular);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/upper_distance", PROPERTY_HINT_RANGE, "-1024,1024,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_UPPER);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/lower_distance", PROPERTY_HINT_RANGE, "-1024,1024,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_LOWER);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_MOTION_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_MOTION_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_MOTION_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_DAMPING);
+	ADD_GROUP("Linear Limit", "linear_limit_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_upper_distance", PROPERTY_HINT_RANGE, "-1024,1024,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_UPPER);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_lower_distance", PROPERTY_HINT_RANGE, "-1024,1024,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_LOWER);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_DAMPING);
+	ADD_GROUP("Linear Motion", "linear_motion_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_MOTION_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_MOTION_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motion_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_MOTION_DAMPING);
+	ADD_GROUP("Linear Orthogonal Motion", "linear_ortho_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_ortho_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_ORTHOGONAL_DAMPING);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit/upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.1"), "_set_upper_limit_angular", "_get_upper_limit_angular");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit/lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.1"), "_set_lower_limit_angular", "_get_lower_limit_angular");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_MOTION_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_MOTION_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_MOTION_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho/restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho/damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_DAMPING);
+	ADD_GROUP("Angular Limit", "angular_limit_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.1"), "set_upper_limit_angular", "get_upper_limit_angular");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.1"), "set_lower_limit_angular", "get_lower_limit_angular");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_LIMIT_DAMPING);
+	ADD_GROUP("Angular Motion", "angular_motion_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_MOTION_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_MOTION_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motion_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_MOTION_DAMPING);
+	ADD_GROUP("Angular Orthogonal Motion", "angular_ortho_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho_softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho_restitution", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_ortho_damping", PROPERTY_HINT_RANGE, "0,16.0,0.01"), "set_param", "get_param", PARAM_ANGULAR_ORTHOGONAL_DAMPING);
 
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_UPPER);
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_LOWER);
@@ -554,19 +562,19 @@ SliderJoint3D::SliderJoint3D() {
 
 //////////////////////////////////
 
-void ConeTwistJoint3D::_set_swing_span(real_t p_limit_angular) {
+void ConeTwistJoint3D::set_swing_span(real_t p_limit_angular) {
 	set_param(PARAM_SWING_SPAN, Math::deg2rad(p_limit_angular));
 }
 
-real_t ConeTwistJoint3D::_get_swing_span() const {
+real_t ConeTwistJoint3D::get_swing_span() const {
 	return Math::rad2deg(get_param(PARAM_SWING_SPAN));
 }
 
-void ConeTwistJoint3D::_set_twist_span(real_t p_limit_angular) {
+void ConeTwistJoint3D::set_twist_span(real_t p_limit_angular) {
 	set_param(PARAM_TWIST_SPAN, Math::deg2rad(p_limit_angular));
 }
 
-real_t ConeTwistJoint3D::_get_twist_span() const {
+real_t ConeTwistJoint3D::get_twist_span() const {
 	return Math::rad2deg(get_param(PARAM_TWIST_SPAN));
 }
 
@@ -574,14 +582,14 @@ void ConeTwistJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &ConeTwistJoint3D::set_param);
 	ClassDB::bind_method(D_METHOD("get_param", "param"), &ConeTwistJoint3D::get_param);
 
-	ClassDB::bind_method(D_METHOD("_set_swing_span", "swing_span"), &ConeTwistJoint3D::_set_swing_span);
-	ClassDB::bind_method(D_METHOD("_get_swing_span"), &ConeTwistJoint3D::_get_swing_span);
+	ClassDB::bind_method(D_METHOD("set_swing_span", "swing_span"), &ConeTwistJoint3D::set_swing_span);
+	ClassDB::bind_method(D_METHOD("get_swing_span"), &ConeTwistJoint3D::get_swing_span);
 
-	ClassDB::bind_method(D_METHOD("_set_twist_span", "twist_span"), &ConeTwistJoint3D::_set_twist_span);
-	ClassDB::bind_method(D_METHOD("_get_twist_span"), &ConeTwistJoint3D::_get_twist_span);
+	ClassDB::bind_method(D_METHOD("set_twist_span", "twist_span"), &ConeTwistJoint3D::set_twist_span);
+	ClassDB::bind_method(D_METHOD("get_twist_span"), &ConeTwistJoint3D::get_twist_span);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "swing_span", PROPERTY_HINT_RANGE, "-180,180,0.1"), "_set_swing_span", "_get_swing_span");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "twist_span", PROPERTY_HINT_RANGE, "-40000,40000,0.1"), "_set_twist_span", "_get_twist_span");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "swing_span", PROPERTY_HINT_RANGE, "-180,180,0.1"), "set_swing_span", "get_swing_span");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "twist_span", PROPERTY_HINT_RANGE, "-40000,40000,0.1"), "set_twist_span", "get_twist_span");
 
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_BIAS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_SOFTNESS);
@@ -644,72 +652,72 @@ ConeTwistJoint3D::ConeTwistJoint3D() {
 
 /////////////////////////////////////////////////////////////////////
 
-void Generic6DOFJoint3D::_set_angular_hi_limit_x(real_t p_limit_angular) {
+void Generic6DOFJoint3D::set_angular_hi_limit_x(real_t p_limit_angular) {
 	set_param_x(PARAM_ANGULAR_UPPER_LIMIT, Math::deg2rad(p_limit_angular));
 }
 
-real_t Generic6DOFJoint3D::_get_angular_hi_limit_x() const {
+real_t Generic6DOFJoint3D::get_angular_hi_limit_x() const {
 	return Math::rad2deg(get_param_x(PARAM_ANGULAR_UPPER_LIMIT));
 }
 
-void Generic6DOFJoint3D::_set_angular_lo_limit_x(real_t p_limit_angular) {
+void Generic6DOFJoint3D::set_angular_lo_limit_x(real_t p_limit_angular) {
 	set_param_x(PARAM_ANGULAR_LOWER_LIMIT, Math::deg2rad(p_limit_angular));
 }
 
-real_t Generic6DOFJoint3D::_get_angular_lo_limit_x() const {
+real_t Generic6DOFJoint3D::get_angular_lo_limit_x() const {
 	return Math::rad2deg(get_param_x(PARAM_ANGULAR_LOWER_LIMIT));
 }
 
-void Generic6DOFJoint3D::_set_angular_hi_limit_y(real_t p_limit_angular) {
+void Generic6DOFJoint3D::set_angular_hi_limit_y(real_t p_limit_angular) {
 	set_param_y(PARAM_ANGULAR_UPPER_LIMIT, Math::deg2rad(p_limit_angular));
 }
 
-real_t Generic6DOFJoint3D::_get_angular_hi_limit_y() const {
+real_t Generic6DOFJoint3D::get_angular_hi_limit_y() const {
 	return Math::rad2deg(get_param_y(PARAM_ANGULAR_UPPER_LIMIT));
 }
 
-void Generic6DOFJoint3D::_set_angular_lo_limit_y(real_t p_limit_angular) {
+void Generic6DOFJoint3D::set_angular_lo_limit_y(real_t p_limit_angular) {
 	set_param_y(PARAM_ANGULAR_LOWER_LIMIT, Math::deg2rad(p_limit_angular));
 }
 
-real_t Generic6DOFJoint3D::_get_angular_lo_limit_y() const {
+real_t Generic6DOFJoint3D::get_angular_lo_limit_y() const {
 	return Math::rad2deg(get_param_y(PARAM_ANGULAR_LOWER_LIMIT));
 }
 
-void Generic6DOFJoint3D::_set_angular_hi_limit_z(real_t p_limit_angular) {
+void Generic6DOFJoint3D::set_angular_hi_limit_z(real_t p_limit_angular) {
 	set_param_z(PARAM_ANGULAR_UPPER_LIMIT, Math::deg2rad(p_limit_angular));
 }
 
-real_t Generic6DOFJoint3D::_get_angular_hi_limit_z() const {
+real_t Generic6DOFJoint3D::get_angular_hi_limit_z() const {
 	return Math::rad2deg(get_param_z(PARAM_ANGULAR_UPPER_LIMIT));
 }
 
-void Generic6DOFJoint3D::_set_angular_lo_limit_z(real_t p_limit_angular) {
+void Generic6DOFJoint3D::set_angular_lo_limit_z(real_t p_limit_angular) {
 	set_param_z(PARAM_ANGULAR_LOWER_LIMIT, Math::deg2rad(p_limit_angular));
 }
 
-real_t Generic6DOFJoint3D::_get_angular_lo_limit_z() const {
+real_t Generic6DOFJoint3D::get_angular_lo_limit_z() const {
 	return Math::rad2deg(get_param_z(PARAM_ANGULAR_LOWER_LIMIT));
 }
 
 void Generic6DOFJoint3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_set_angular_hi_limit_x", "angle"), &Generic6DOFJoint3D::_set_angular_hi_limit_x);
-	ClassDB::bind_method(D_METHOD("_get_angular_hi_limit_x"), &Generic6DOFJoint3D::_get_angular_hi_limit_x);
+	ClassDB::bind_method(D_METHOD("set_angular_hi_limit_x", "angle"), &Generic6DOFJoint3D::set_angular_hi_limit_x);
+	ClassDB::bind_method(D_METHOD("get_angular_hi_limit_x"), &Generic6DOFJoint3D::get_angular_hi_limit_x);
 
-	ClassDB::bind_method(D_METHOD("_set_angular_lo_limit_x", "angle"), &Generic6DOFJoint3D::_set_angular_lo_limit_x);
-	ClassDB::bind_method(D_METHOD("_get_angular_lo_limit_x"), &Generic6DOFJoint3D::_get_angular_lo_limit_x);
+	ClassDB::bind_method(D_METHOD("set_angular_lo_limit_x", "angle"), &Generic6DOFJoint3D::set_angular_lo_limit_x);
+	ClassDB::bind_method(D_METHOD("get_angular_lo_limit_x"), &Generic6DOFJoint3D::get_angular_lo_limit_x);
 
-	ClassDB::bind_method(D_METHOD("_set_angular_hi_limit_y", "angle"), &Generic6DOFJoint3D::_set_angular_hi_limit_y);
-	ClassDB::bind_method(D_METHOD("_get_angular_hi_limit_y"), &Generic6DOFJoint3D::_get_angular_hi_limit_y);
+	ClassDB::bind_method(D_METHOD("set_angular_hi_limit_y", "angle"), &Generic6DOFJoint3D::set_angular_hi_limit_y);
+	ClassDB::bind_method(D_METHOD("get_angular_hi_limit_y"), &Generic6DOFJoint3D::get_angular_hi_limit_y);
 
-	ClassDB::bind_method(D_METHOD("_set_angular_lo_limit_y", "angle"), &Generic6DOFJoint3D::_set_angular_lo_limit_y);
-	ClassDB::bind_method(D_METHOD("_get_angular_lo_limit_y"), &Generic6DOFJoint3D::_get_angular_lo_limit_y);
+	ClassDB::bind_method(D_METHOD("set_angular_lo_limit_y", "angle"), &Generic6DOFJoint3D::set_angular_lo_limit_y);
+	ClassDB::bind_method(D_METHOD("get_angular_lo_limit_y"), &Generic6DOFJoint3D::get_angular_lo_limit_y);
 
-	ClassDB::bind_method(D_METHOD("_set_angular_hi_limit_z", "angle"), &Generic6DOFJoint3D::_set_angular_hi_limit_z);
-	ClassDB::bind_method(D_METHOD("_get_angular_hi_limit_z"), &Generic6DOFJoint3D::_get_angular_hi_limit_z);
+	ClassDB::bind_method(D_METHOD("set_angular_hi_limit_z", "angle"), &Generic6DOFJoint3D::set_angular_hi_limit_z);
+	ClassDB::bind_method(D_METHOD("get_angular_hi_limit_z"), &Generic6DOFJoint3D::get_angular_hi_limit_z);
 
-	ClassDB::bind_method(D_METHOD("_set_angular_lo_limit_z", "angle"), &Generic6DOFJoint3D::_set_angular_lo_limit_z);
-	ClassDB::bind_method(D_METHOD("_get_angular_lo_limit_z"), &Generic6DOFJoint3D::_get_angular_lo_limit_z);
+	ClassDB::bind_method(D_METHOD("set_angular_lo_limit_z", "angle"), &Generic6DOFJoint3D::set_angular_lo_limit_z);
+	ClassDB::bind_method(D_METHOD("get_angular_lo_limit_z"), &Generic6DOFJoint3D::get_angular_lo_limit_z);
 
 	ClassDB::bind_method(D_METHOD("set_param_x", "param", "value"), &Generic6DOFJoint3D::set_param_x);
 	ClassDB::bind_method(D_METHOD("get_param_x", "param"), &Generic6DOFJoint3D::get_param_x);
@@ -729,93 +737,113 @@ void Generic6DOFJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flag_z", "flag", "value"), &Generic6DOFJoint3D::set_flag_z);
 	ClassDB::bind_method(D_METHOD("get_flag_z", "flag"), &Generic6DOFJoint3D::get_flag_z);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/upper_distance"), "set_param_x", "get_param_x", PARAM_LINEAR_UPPER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/lower_distance"), "set_param_x", "get_param_x", PARAM_LINEAR_LOWER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_LINEAR_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_LINEAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_LINEAR_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_motor_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_MOTOR);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_x/target_velocity"), "set_param_x", "get_param_x", PARAM_LINEAR_MOTOR_TARGET_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_x/force_limit"), "set_param_x", "get_param_x", PARAM_LINEAR_MOTOR_FORCE_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_spring_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x/stiffness"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x/damping"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x/equilibrium_point"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
+	ADD_GROUP("Linear Limit X", "linear_limit_x_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_x_enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x_upper_distance"), "set_param_x", "get_param_x", PARAM_LINEAR_UPPER_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x_lower_distance"), "set_param_x", "get_param_x", PARAM_LINEAR_LOWER_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_LINEAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_LINEAR_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_x_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_LINEAR_DAMPING);
+	ADD_GROUP("Linear Motor X", "linear_motor_x_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_motor_x_enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_MOTOR);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_x_target_velocity"), "set_param_x", "get_param_x", PARAM_LINEAR_MOTOR_TARGET_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_x_force_limit"), "set_param_x", "get_param_x", PARAM_LINEAR_MOTOR_FORCE_LIMIT);
+	ADD_GROUP("Linear Spring X", "linear_spring_x_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_spring_x_enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_SPRING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x_stiffness"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x_damping"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_x_equilibrium_point"), "set_param_x", "get_param_x", PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_ANGULAR_LIMIT);
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_x/upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "_set_angular_hi_limit_x", "_get_angular_hi_limit_x");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_x/lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "_set_angular_lo_limit_x", "_get_angular_lo_limit_x");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_ANGULAR_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_ANGULAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_ANGULAR_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/force_limit"), "set_param_x", "get_param_x", PARAM_ANGULAR_FORCE_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x/erp"), "set_param_x", "get_param_x", PARAM_ANGULAR_ERP);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_motor_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_MOTOR);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_x/target_velocity"), "set_param_x", "get_param_x", PARAM_ANGULAR_MOTOR_TARGET_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_x/force_limit"), "set_param_x", "get_param_x", PARAM_ANGULAR_MOTOR_FORCE_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_spring_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_ANGULAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x/stiffness"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x/damping"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x/equilibrium_point"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
+	ADD_GROUP("Angular Limit X", "angular_limit_x_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_x_enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_ANGULAR_LIMIT);
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_x_upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "set_angular_hi_limit_x", "get_angular_hi_limit_x");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_x_lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "set_angular_lo_limit_x", "get_angular_lo_limit_x");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_ANGULAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_ANGULAR_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_x", "get_param_x", PARAM_ANGULAR_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x_force_limit"), "set_param_x", "get_param_x", PARAM_ANGULAR_FORCE_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_x_erp"), "set_param_x", "get_param_x", PARAM_ANGULAR_ERP);
+	ADD_GROUP("Angular Motor X", "angular_motor_x_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_motor_x_enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_MOTOR);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_x_target_velocity"), "set_param_x", "get_param_x", PARAM_ANGULAR_MOTOR_TARGET_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_x_force_limit"), "set_param_x", "get_param_x", PARAM_ANGULAR_MOTOR_FORCE_LIMIT);
+	ADD_GROUP("Angular Spring X", "angular_spring_x_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_spring_x_enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_ANGULAR_SPRING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x_stiffness"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x_damping"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_x_equilibrium_point"), "set_param_x", "get_param_x", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_LINEAR_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/upper_distance"), "set_param_y", "get_param_y", PARAM_LINEAR_UPPER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/lower_distance"), "set_param_y", "get_param_y", PARAM_LINEAR_LOWER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_LINEAR_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_LINEAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_LINEAR_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_motor_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_LINEAR_MOTOR);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_y/target_velocity"), "set_param_y", "get_param_y", PARAM_LINEAR_MOTOR_TARGET_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_y/force_limit"), "set_param_y", "get_param_y", PARAM_LINEAR_MOTOR_FORCE_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_spring_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_LINEAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y/stiffness"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y/damping"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y/equilibrium_point"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_ANGULAR_LIMIT);
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_y/upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "_set_angular_hi_limit_y", "_get_angular_hi_limit_y");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_y/lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "_set_angular_lo_limit_y", "_get_angular_lo_limit_y");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_ANGULAR_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_ANGULAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_ANGULAR_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/force_limit"), "set_param_y", "get_param_y", PARAM_ANGULAR_FORCE_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y/erp"), "set_param_y", "get_param_y", PARAM_ANGULAR_ERP);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_motor_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_MOTOR);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_y/target_velocity"), "set_param_y", "get_param_y", PARAM_ANGULAR_MOTOR_TARGET_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_y/force_limit"), "set_param_y", "get_param_y", PARAM_ANGULAR_MOTOR_FORCE_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_spring_y/enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_ANGULAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y/stiffness"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y/damping"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y/equilibrium_point"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
+	ADD_GROUP("Linear Limit Y", "linear_limit_y_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_y_enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_LINEAR_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y_upper_distance"), "set_param_y", "get_param_y", PARAM_LINEAR_UPPER_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y_lower_distance"), "set_param_y", "get_param_y", PARAM_LINEAR_LOWER_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_LINEAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_LINEAR_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_y_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_LINEAR_DAMPING);
+	ADD_GROUP("Linear Motor Y", "linear_motor_y_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_motor_y_enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_LINEAR_MOTOR);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_y_target_velocity"), "set_param_y", "get_param_y", PARAM_LINEAR_MOTOR_TARGET_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_y_force_limit"), "set_param_y", "get_param_y", PARAM_LINEAR_MOTOR_FORCE_LIMIT);
+	ADD_GROUP("Linear Spring Y", "linear_spring_y_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_spring_y_enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_LINEAR_SPRING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y_stiffness"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y_damping"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_y_equilibrium_point"), "set_param_y", "get_param_y", PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_LINEAR_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/upper_distance"), "set_param_z", "get_param_z", PARAM_LINEAR_UPPER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/lower_distance"), "set_param_z", "get_param_z", PARAM_LINEAR_LOWER_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_LINEAR_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_LINEAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_LINEAR_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_motor_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_LINEAR_MOTOR);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_z/target_velocity"), "set_param_z", "get_param_z", PARAM_LINEAR_MOTOR_TARGET_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_z/force_limit"), "set_param_z", "get_param_z", PARAM_LINEAR_MOTOR_FORCE_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_spring_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_LINEAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z/stiffness"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z/damping"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z/equilibrium_point"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_ANGULAR_LIMIT);
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_z/upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "_set_angular_hi_limit_z", "_get_angular_hi_limit_z");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_z/lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "_set_angular_lo_limit_z", "_get_angular_lo_limit_z");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_ANGULAR_LIMIT_SOFTNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_ANGULAR_RESTITUTION);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_ANGULAR_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/force_limit"), "set_param_z", "get_param_z", PARAM_ANGULAR_FORCE_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z/erp"), "set_param_z", "get_param_z", PARAM_ANGULAR_ERP);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_motor_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_MOTOR);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_z/target_velocity"), "set_param_z", "get_param_z", PARAM_ANGULAR_MOTOR_TARGET_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_z/force_limit"), "set_param_z", "get_param_z", PARAM_ANGULAR_MOTOR_FORCE_LIMIT);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_spring_z/enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_ANGULAR_SPRING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/stiffness"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_STIFFNESS);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/damping"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z/equilibrium_point"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
+	ADD_GROUP("Angular Limit Y", "angular_limit_y_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_y_enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_ANGULAR_LIMIT);
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_y_upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "set_angular_hi_limit_y", "get_angular_hi_limit_y");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_y_lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "set_angular_lo_limit_y", "get_angular_lo_limit_y");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_ANGULAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_ANGULAR_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_y", "get_param_y", PARAM_ANGULAR_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y_force_limit"), "set_param_y", "get_param_y", PARAM_ANGULAR_FORCE_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_y_erp"), "set_param_y", "get_param_y", PARAM_ANGULAR_ERP);
+	ADD_GROUP("Angular Motor Y", "angular_motor_y_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_motor_y_enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_MOTOR);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_y_target_velocity"), "set_param_y", "get_param_y", PARAM_ANGULAR_MOTOR_TARGET_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_y_force_limit"), "set_param_y", "get_param_y", PARAM_ANGULAR_MOTOR_FORCE_LIMIT);
+	ADD_GROUP("Angular Spring Y", "angular_spring_y_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_spring_y_enabled"), "set_flag_y", "get_flag_y", FLAG_ENABLE_ANGULAR_SPRING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y_stiffness"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y_damping"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_y_equilibrium_point"), "set_param_y", "get_param_y", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
+
+	ADD_GROUP("Linear Limit Z", "linear_limit_z_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_z_enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_LINEAR_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z_upper_distance"), "set_param_z", "get_param_z", PARAM_LINEAR_UPPER_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z_lower_distance"), "set_param_z", "get_param_z", PARAM_LINEAR_LOWER_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_LINEAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_LINEAR_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit_z_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_LINEAR_DAMPING);
+	ADD_GROUP("Linear Motor Z", "linear_motor_z_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_motor_z_enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_LINEAR_MOTOR);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_z_target_velocity"), "set_param_z", "get_param_z", PARAM_LINEAR_MOTOR_TARGET_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_motor_z_force_limit"), "set_param_z", "get_param_z", PARAM_LINEAR_MOTOR_FORCE_LIMIT);
+	ADD_GROUP("Linear Spring Z", "linear_spring_z_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_spring_z_enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_LINEAR_SPRING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z_stiffness"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z_damping"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_spring_z_equilibrium_point"), "set_param_z", "get_param_z", PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
+
+	ADD_GROUP("Angular Limit Z", "angular_limit_z_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit_z_enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_ANGULAR_LIMIT);
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_z_upper_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "set_angular_hi_limit_z", "get_angular_hi_limit_z");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_limit_z_lower_angle", PROPERTY_HINT_RANGE, "-180,180,0.01"), "set_angular_lo_limit_z", "get_angular_lo_limit_z");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z_softness", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_ANGULAR_LIMIT_SOFTNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z_restitution", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_ANGULAR_RESTITUTION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z_damping", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_param_z", "get_param_z", PARAM_ANGULAR_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z_force_limit"), "set_param_z", "get_param_z", PARAM_ANGULAR_FORCE_LIMIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_limit_z_erp"), "set_param_z", "get_param_z", PARAM_ANGULAR_ERP);
+	ADD_GROUP("Angular Motor Z", "angular_motor_z_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_motor_z_enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_MOTOR);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_z_target_velocity"), "set_param_z", "get_param_z", PARAM_ANGULAR_MOTOR_TARGET_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_motor_z_force_limit"), "set_param_z", "get_param_z", PARAM_ANGULAR_MOTOR_FORCE_LIMIT);
+	ADD_GROUP("Angular Spring Z", "angular_spring_z_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_spring_z_enabled"), "set_flag_z", "get_flag_z", FLAG_ENABLE_ANGULAR_SPRING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z_stiffness"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_STIFFNESS);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z_damping"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_spring_z_equilibrium_point"), "set_param_z", "get_param_z", PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
 
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_LOWER_LIMIT);
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_UPPER_LIMIT);

--- a/scene/3d/physics_joint_3d.h
+++ b/scene/3d/physics_joint_3d.h
@@ -136,11 +136,11 @@ protected:
 	virtual void _configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) override;
 	static void _bind_methods();
 
-	void _set_upper_limit(real_t p_limit);
-	real_t _get_upper_limit() const;
+	void set_upper_limit(real_t p_limit);
+	real_t get_upper_limit() const;
 
-	void _set_lower_limit(real_t p_limit);
-	real_t _get_lower_limit() const;
+	void set_lower_limit(real_t p_limit);
+	real_t get_lower_limit() const;
 
 public:
 	void set_param(Param p_param, real_t p_value);
@@ -188,11 +188,11 @@ public:
 	};
 
 protected:
-	void _set_upper_limit_angular(real_t p_limit_angular);
-	real_t _get_upper_limit_angular() const;
+	void set_upper_limit_angular(real_t p_limit_angular);
+	real_t get_upper_limit_angular() const;
 
-	void _set_lower_limit_angular(real_t p_limit_angular);
-	real_t _get_lower_limit_angular() const;
+	void set_lower_limit_angular(real_t p_limit_angular);
+	real_t get_lower_limit_angular() const;
 
 	real_t params[PARAM_MAX];
 	virtual void _configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) override;
@@ -221,11 +221,11 @@ public:
 	};
 
 protected:
-	void _set_swing_span(real_t p_limit_angular);
-	real_t _get_swing_span() const;
+	void set_swing_span(real_t p_limit_angular);
+	real_t get_swing_span() const;
 
-	void _set_twist_span(real_t p_limit_angular);
-	real_t _get_twist_span() const;
+	void set_twist_span(real_t p_limit_angular);
+	real_t get_twist_span() const;
 
 	real_t params[PARAM_MAX];
 	virtual void _configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) override;
@@ -281,23 +281,23 @@ public:
 	};
 
 protected:
-	void _set_angular_hi_limit_x(real_t p_limit_angular);
-	real_t _get_angular_hi_limit_x() const;
+	void set_angular_hi_limit_x(real_t p_limit_angular);
+	real_t get_angular_hi_limit_x() const;
 
-	void _set_angular_hi_limit_y(real_t p_limit_angular);
-	real_t _get_angular_hi_limit_y() const;
+	void set_angular_hi_limit_y(real_t p_limit_angular);
+	real_t get_angular_hi_limit_y() const;
 
-	void _set_angular_hi_limit_z(real_t p_limit_angular);
-	real_t _get_angular_hi_limit_z() const;
+	void set_angular_hi_limit_z(real_t p_limit_angular);
+	real_t get_angular_hi_limit_z() const;
 
-	void _set_angular_lo_limit_x(real_t p_limit_angular);
-	real_t _get_angular_lo_limit_x() const;
+	void set_angular_lo_limit_x(real_t p_limit_angular);
+	real_t get_angular_lo_limit_x() const;
 
-	void _set_angular_lo_limit_y(real_t p_limit_angular);
-	real_t _get_angular_lo_limit_y() const;
+	void set_angular_lo_limit_y(real_t p_limit_angular);
+	real_t get_angular_lo_limit_y() const;
 
-	void _set_angular_lo_limit_z(real_t p_limit_angular);
-	real_t _get_angular_lo_limit_z() const;
+	void set_angular_lo_limit_z(real_t p_limit_angular);
+	real_t get_angular_lo_limit_z() const;
 
 	real_t params_x[PARAM_MAX];
 	bool flags_x[FLAG_MAX];

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -72,12 +72,12 @@ SkinReference::~SkinReference() {
 bool Skeleton3D::_set(const StringName &p_path, const Variant &p_value) {
 	String path = p_path;
 
-	if (!path.begins_with("bones/")) {
+	if (!path.begins_with("bones_")) {
 		return false;
 	}
 
-	int which = path.get_slicec('/', 1).to_int();
-	String what = path.get_slicec('/', 2);
+	int which = path.get_slicec('_', 1).to_int();
+	String what = path.get_slicec('_', 2);
 
 	if (which == bones.size() && what == "name") {
 		add_bone(p_value);
@@ -118,12 +118,12 @@ bool Skeleton3D::_set(const StringName &p_path, const Variant &p_value) {
 bool Skeleton3D::_get(const StringName &p_path, Variant &r_ret) const {
 	String path = p_path;
 
-	if (!path.begins_with("bones/")) {
+	if (!path.begins_with("bones_")) {
 		return false;
 	}
 
-	int which = path.get_slicec('/', 1).to_int();
-	String what = path.get_slicec('/', 2);
+	int which = path.get_slicec('_', 1).to_int();
+	String what = path.get_slicec('_', 2);
 
 	ERR_FAIL_INDEX_V(which, bones.size(), false);
 
@@ -158,8 +158,10 @@ bool Skeleton3D::_get(const StringName &p_path, Variant &r_ret) const {
 }
 
 void Skeleton3D::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::NIL, "Bones", PROPERTY_HINT_NONE, "bones_", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < bones.size(); i++) {
-		String prep = "bones/" + itos(i) + "/";
+		p_list->push_back(PropertyInfo(Variant::NIL, itos(i), PROPERTY_HINT_NONE, "bones_" + itos(i) + "_", PROPERTY_USAGE_SUBGROUP));
+		String prep = "bones_" + itos(i) + "_";
 		p_list->push_back(PropertyInfo(Variant::STRING, prep + "name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::INT, prep + "parent", PROPERTY_HINT_RANGE, "-1," + itos(bones.size() - 1) + ",1", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "rest", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -124,14 +124,14 @@ void SoftBody3D::_update_pickable() {
 
 bool SoftBody3D::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
-	String which = name.get_slicec('/', 0);
+	String which = name.get_slicec('_', 0);
 
 	if ("pinned_points" == which) {
 		return _set_property_pinned_points_indices(p_value);
 
 	} else if ("attachments" == which) {
-		int idx = name.get_slicec('/', 1).to_int();
-		String what = name.get_slicec('/', 2);
+		int idx = name.get_slicec('_', 1).to_int();
+		String what = name.get_slicec('_', 2);
 
 		return _set_property_pinned_points_attachment(idx, what, p_value);
 	}
@@ -141,7 +141,7 @@ bool SoftBody3D::_set(const StringName &p_name, const Variant &p_value) {
 
 bool SoftBody3D::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
-	String which = name.get_slicec('/', 0);
+	String which = name.get_slicec('_', 0);
 
 	if ("pinned_points" == which) {
 		Array arr_ret;
@@ -157,8 +157,8 @@ bool SoftBody3D::_get(const StringName &p_name, Variant &r_ret) const {
 		return true;
 
 	} else if ("attachments" == which) {
-		int idx = name.get_slicec('/', 1).to_int();
-		String what = name.get_slicec('/', 2);
+		int idx = name.get_slicec('_', 1).to_int();
+		String what = name.get_slicec('_', 2);
 
 		return _get_property_pinned_points(idx, what, r_ret);
 	}
@@ -171,10 +171,12 @@ void SoftBody3D::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, "pinned_points"));
 
+	p_list->push_back(PropertyInfo(Variant::NIL, "Attachements", PROPERTY_HINT_NONE, "attachments_", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < pinned_points_indices_size; ++i) {
-		p_list->push_back(PropertyInfo(Variant::INT, "attachments/" + itos(i) + "/point_index"));
-		p_list->push_back(PropertyInfo(Variant::NODE_PATH, "attachments/" + itos(i) + "/spatial_attachment_path"));
-		p_list->push_back(PropertyInfo(Variant::VECTOR3, "attachments/" + itos(i) + "/offset"));
+		p_list->push_back(PropertyInfo(Variant::NIL, itos(i), PROPERTY_HINT_NONE, "attachments_" + itos(i) + "_", PROPERTY_USAGE_SUBGROUP));
+		p_list->push_back(PropertyInfo(Variant::INT, "attachments_" + itos(i) + "_point"));
+		p_list->push_back(PropertyInfo(Variant::NODE_PATH, "attachments_" + itos(i) + "_path"));
+		p_list->push_back(PropertyInfo(Variant::VECTOR3, "attachments_" + itos(i) + "_offset"));
 	}
 }
 
@@ -212,7 +214,7 @@ bool SoftBody3D::_set_property_pinned_points_attachment(int p_item, const String
 		return false;
 	}
 
-	if ("spatial_attachment_path" == p_what) {
+	if ("path" == p_what) {
 		PinnedPoint *w = pinned_points.ptrw();
 		pin_point(w[p_item].point_index, true, p_value);
 		_make_cache_dirty();
@@ -232,9 +234,9 @@ bool SoftBody3D::_get_property_pinned_points(int p_item, const String &p_what, V
 	}
 	const PinnedPoint *r = pinned_points.ptr();
 
-	if ("point_index" == p_what) {
+	if ("point" == p_what) {
 		r_ret = r[p_item].point_index;
-	} else if ("spatial_attachment_path" == p_what) {
+	} else if ("path" == p_what) {
 		r_ret = r[p_item].spatial_attachment_path;
 	} else if ("offset" == p_what) {
 		r_ret = r[p_item].offset;

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -44,8 +44,7 @@ Ref<AnimationNode> AnimationNodeBlendSpace1D::get_child_by_name(const StringName
 
 void AnimationNodeBlendSpace1D::_validate_property(PropertyInfo &property) const {
 	if (property.name.begins_with("blend_point_")) {
-		String left = property.name.get_slicec('/', 0);
-		int idx = left.get_slicec('_', 2).to_int();
+		int idx = property.name.get_slicec('_', 2).to_int();
 		if (idx >= blend_points_used) {
 			property.usage = 0;
 		}
@@ -80,9 +79,10 @@ void AnimationNodeBlendSpace1D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_add_blend_point", "index", "node"), &AnimationNodeBlendSpace1D::_add_blend_point);
 
+	ADD_GROUP("Blend Points", "blend_point_");
 	for (int i = 0; i < MAX_BLEND_POINTS; i++) {
-		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "blend_point_" + itos(i) + "/node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationRootNode", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_add_blend_point", "get_blend_point_node", i);
-		ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "blend_point_" + itos(i) + "/pos", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_blend_point_position", "get_blend_point_position", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "blend_point_" + itos(i) + "_node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationRootNode", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_add_blend_point", "get_blend_point_node", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "blend_point_" + itos(i) + "_pos", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_blend_point_position", "get_blend_point_position", i);
 	}
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "min_space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_min_space", "get_min_space");

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -559,8 +559,7 @@ void AnimationNodeBlendSpace2D::_validate_property(PropertyInfo &property) const
 		property.usage = 0;
 	}
 	if (property.name.begins_with("blend_point_")) {
-		String left = property.name.get_slicec('/', 0);
-		int idx = left.get_slicec('_', 2).to_int();
+		int idx = property.name.get_slicec('_', 2).to_int();
 		if (idx >= blend_points_used) {
 			property.usage = 0;
 		}
@@ -641,9 +640,10 @@ void AnimationNodeBlendSpace2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_triangles", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_auto_triangles", "get_auto_triangles");
 
+	ADD_GROUP("Blend Points", "blend_point_");
 	for (int i = 0; i < MAX_BLEND_POINTS; i++) {
-		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "blend_point_" + itos(i) + "/node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationRootNode", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_add_blend_point", "get_blend_point_node", i);
-		ADD_PROPERTYI(PropertyInfo(Variant::VECTOR2, "blend_point_" + itos(i) + "/pos", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_blend_point_position", "get_blend_point_position", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "blend_point_" + itos(i) + "_node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationRootNode", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_add_blend_point", "get_blend_point_node", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::VECTOR2, "blend_point_" + itos(i) + "_pos", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_blend_point_position", "get_blend_point_position", i);
 	}
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "triangles", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_triangles", "_get_triangles");

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -748,7 +748,7 @@ float AnimationNodeTransition::process(float p_time, bool p_seek) {
 
 void AnimationNodeTransition::_validate_property(PropertyInfo &property) const {
 	if (property.name.begins_with("input_")) {
-		String n = property.name.get_slicec('/', 0).get_slicec('_', 1);
+		String n = property.name.get_slicec('_', 1);
 		if (n != "count") {
 			int idx = n.to_int();
 			if (idx >= enabled_inputs) {
@@ -776,9 +776,10 @@ void AnimationNodeTransition::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "input_count", PROPERTY_HINT_RANGE, "0,64,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_enabled_inputs", "get_enabled_inputs");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "xfade_time", PROPERTY_HINT_RANGE, "0,120,0.01"), "set_cross_fade_time", "get_cross_fade_time");
 
+	ADD_GROUP("Inputs", "input_");
 	for (int i = 0; i < MAX_INPUTS; i++) {
-		ADD_PROPERTYI(PropertyInfo(Variant::STRING, "input_" + itos(i) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_caption", "get_input_caption", i);
-		ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "input_" + itos(i) + "/auto_advance", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_as_auto_advance", "is_input_set_as_auto_advance", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::STRING, "input_" + itos(i) + "_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_caption", "get_input_caption", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "input_" + itos(i) + "_auto_advance", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_as_auto_advance", "is_input_set_as_auto_advance", i);
 	}
 }
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1033,9 +1033,9 @@ Ref<AnimationNode> AnimationNodeBlendTree::get_child_by_name(const StringName &p
 
 bool AnimationNodeBlendTree::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
-	if (name.begins_with("nodes/")) {
-		String node_name = name.get_slicec('/', 1);
-		String what = name.get_slicec('/', 2);
+	if (name.begins_with("nodes_")) {
+		String node_name = name.get_slicec('_', 1);
+		String what = name.get_slicec('_', 2);
 
 		if (what == "node") {
 			Ref<AnimationNode> anode = p_value;
@@ -1066,9 +1066,9 @@ bool AnimationNodeBlendTree::_set(const StringName &p_name, const Variant &p_val
 
 bool AnimationNodeBlendTree::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
-	if (name.begins_with("nodes/")) {
-		String node_name = name.get_slicec('/', 1);
-		String what = name.get_slicec('/', 2);
+	if (name.begins_with("nodes_")) {
+		String node_name = name.get_slicec('_', 1);
+		String what = name.get_slicec('_', 2);
 
 		if (what == "node") {
 			if (nodes.has(node_name)) {
@@ -1114,9 +1114,9 @@ void AnimationNodeBlendTree::_get_property_list(List<PropertyInfo> *p_list) cons
 	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 		String name = E->get();
 		if (name != "output") {
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "nodes/" + name + "/node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationNode", PROPERTY_USAGE_NOEDITOR));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "nodes_" + name + "_node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationNode", PROPERTY_USAGE_NOEDITOR));
 		}
-		p_list->push_back(PropertyInfo(Variant::VECTOR2, "nodes/" + name + "/position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "nodes_" + name + "_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	}
 
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "node_connections", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -810,9 +810,9 @@ Ref<AnimationNode> AnimationNodeStateMachine::get_child_by_name(const StringName
 
 bool AnimationNodeStateMachine::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
-	if (name.begins_with("states/")) {
-		String node_name = name.get_slicec('/', 1);
-		String what = name.get_slicec('/', 2);
+	if (name.begins_with("states_")) {
+		String node_name = name.get_slicec('_', 1);
+		String what = name.get_slicec('_', 2);
 
 		if (what == "node") {
 			Ref<AnimationNode> anode = p_value;
@@ -852,9 +852,9 @@ bool AnimationNodeStateMachine::_set(const StringName &p_name, const Variant &p_
 
 bool AnimationNodeStateMachine::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
-	if (name.begins_with("states/")) {
-		String node_name = name.get_slicec('/', 1);
-		String what = name.get_slicec('/', 2);
+	if (name.begins_with("states_")) {
+		String node_name = name.get_slicec('_', 1);
+		String what = name.get_slicec('_', 2);
 
 		if (what == "node") {
 			if (states.has(node_name)) {
@@ -904,8 +904,8 @@ void AnimationNodeStateMachine::_get_property_list(List<PropertyInfo> *p_list) c
 
 	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 		String name = E->get();
-		p_list->push_back(PropertyInfo(Variant::OBJECT, "states/" + name + "/node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationNode", PROPERTY_USAGE_NOEDITOR));
-		p_list->push_back(PropertyInfo(Variant::VECTOR2, "states/" + name + "/position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "states_" + name + "_node", PROPERTY_HINT_RESOURCE_TYPE, "AnimationNode", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "states_" + name + "_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	}
 
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "transitions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -74,16 +74,12 @@ void AnimatedValuesBackup::_bind_methods() {
 bool AnimationPlayer::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
 
-	if (name.begins_with("playback/play")) { // bw compatibility
-
-		set_current_animation(p_value);
-
-	} else if (name.begins_with("anims/")) {
-		String which = name.get_slicec('/', 1);
+	if (name.begins_with("anims_")) {
+		String which = name.get_slicec('_', 1);
 		add_animation(which, p_value);
 
-	} else if (name.begins_with("next/")) {
-		String which = name.get_slicec('/', 1);
+	} else if (name.begins_with("next_")) {
+		String which = name.get_slicec('_', 1);
 		animation_set_next(which, p_value);
 
 	} else if (p_name == SceneStringNames::get_singleton()->blend_times) {
@@ -109,16 +105,12 @@ bool AnimationPlayer::_set(const StringName &p_name, const Variant &p_value) {
 bool AnimationPlayer::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
 
-	if (name == "playback/play") { // bw compatibility
-
-		r_ret = get_current_animation();
-
-	} else if (name.begins_with("anims/")) {
-		String which = name.get_slicec('/', 1);
+	if (name.begins_with("anims_")) {
+		String which = name.get_slicec('_', 1);
 		r_ret = get_animation(which);
 
-	} else if (name.begins_with("next/")) {
-		String which = name.get_slicec('/', 1);
+	} else if (name.begins_with("next_")) {
+		String which = name.get_slicec('_', 1);
 
 		r_ret = animation_get_next(which);
 
@@ -168,9 +160,9 @@ void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<PropertyInfo> anim_names;
 
 	for (Map<StringName, AnimationData>::Element *E = animation_set.front(); E; E = E->next()) {
-		anim_names.push_back(PropertyInfo(Variant::OBJECT, "anims/" + String(E->key()), PROPERTY_HINT_RESOURCE_TYPE, "Animation", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE));
+		anim_names.push_back(PropertyInfo(Variant::OBJECT, "anims_" + String(E->key()), PROPERTY_HINT_RESOURCE_TYPE, "Animation", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE));
 		if (E->get().next != StringName()) {
-			anim_names.push_back(PropertyInfo(Variant::STRING, "next/" + String(E->key()), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			anim_names.push_back(PropertyInfo(Variant::STRING, "next_" + String(E->key()), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 		}
 	}
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -129,15 +129,15 @@ void Tween::_process_pending_commands() {
 bool Tween::_set(const StringName &p_name, const Variant &p_value) {
 	// Set the correct attribute based on the given name
 	String name = p_name;
-	if (name == "playback/speed" || name == "speed") { // Backwards compatibility
+	if (name == "playback_speed" || name == "speed") { // Backwards compatibility
 		set_speed_scale(p_value);
 		return true;
 
-	} else if (name == "playback/active") {
+	} else if (name == "playback_active") {
 		set_active(p_value);
 		return true;
 
-	} else if (name == "playback/repeat") {
+	} else if (name == "playback_repeat") {
 		set_repeat(p_value);
 		return true;
 	}
@@ -147,26 +147,19 @@ bool Tween::_set(const StringName &p_name, const Variant &p_value) {
 bool Tween::_get(const StringName &p_name, Variant &r_ret) const {
 	// Get the correct attribute based on the given name
 	String name = p_name;
-	if (name == "playback/speed") { // Backwards compatibility
+	if (name == "playback_speed") { // Backwards compatibility
 		r_ret = speed_scale;
 		return true;
 
-	} else if (name == "playback/active") {
+	} else if (name == "playback_active") {
 		r_ret = is_active();
 		return true;
 
-	} else if (name == "playback/repeat") {
+	} else if (name == "playback_repeat") {
 		r_ret = is_repeat();
 		return true;
 	}
 	return false;
-}
-
-void Tween::_get_property_list(List<PropertyInfo> *p_list) const {
-	// Add the property info for the Tween object
-	p_list->push_back(PropertyInfo(Variant::BOOL, "playback/active", PROPERTY_HINT_NONE, ""));
-	p_list->push_back(PropertyInfo(Variant::BOOL, "playback/repeat", PROPERTY_HINT_NONE, ""));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "playback/speed", PROPERTY_HINT_RANGE, "-64,64,0.01"));
 }
 
 void Tween::_notification(int p_what) {

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -140,7 +140,6 @@ private:
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
-	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
 
 	static void _bind_methods();

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -459,8 +459,8 @@ Button::TextAlign Button::get_text_align() const {
 
 bool Button::_set(const StringName &p_name, const Variant &p_value) {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		double value = p_value;
 		if (value == -1) {
@@ -485,8 +485,8 @@ bool Button::_set(const StringName &p_name, const Variant &p_value) {
 
 bool Button::_get(const StringName &p_name, Variant &r_ret) const {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		if (opentype_features.has(tag)) {
 			r_ret = opentype_features[tag];
@@ -500,11 +500,12 @@ bool Button::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void Button::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::NIL, "Opentype Features", PROPERTY_HINT_NONE, "opentype_features_", PROPERTY_USAGE_GROUP));
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features_" + name));
 	}
-	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features__new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }
 
 void Button::_bind_methods() {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -221,37 +221,37 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 	}
 
 	if (p_value.get_type() == Variant::NIL) {
-		if (name.begins_with("custom_icons/")) {
-			String dname = name.get_slicec('/', 1);
+		if (name.begins_with("custom_icons_")) {
+			String dname = name.get_slicec('_', 2);
 			if (data.icon_override.has(dname)) {
 				data.icon_override[dname]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 			}
 			data.icon_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
-		} else if (name.begins_with("custom_styles/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_styles_")) {
+			String dname = name.get_slicec('_', 2);
 			if (data.style_override.has(dname)) {
 				data.style_override[dname]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 			}
 			data.style_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
-		} else if (name.begins_with("custom_fonts/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_fonts_")) {
+			String dname = name.get_slicec('_', 2);
 			if (data.font_override.has(dname)) {
 				data.font_override[dname]->disconnect("changed", callable_mp(this, &Control::_override_changed));
 			}
 			data.font_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
-		} else if (name.begins_with("custom_font_sizes/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_font_sizes_")) {
+			String dname = name.get_slicec('_', 3);
 			data.font_size_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
-		} else if (name.begins_with("custom_colors/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_colors_")) {
+			String dname = name.get_slicec('_', 2);
 			data.color_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
-		} else if (name.begins_with("custom_constants/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_constants_")) {
+			String dname = name.get_slicec('_', 2);
 			data.constant_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
 		} else {
@@ -259,23 +259,23 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 		}
 
 	} else {
-		if (name.begins_with("custom_icons/")) {
-			String dname = name.get_slicec('/', 1);
+		if (name.begins_with("custom_icons_")) {
+			String dname = name.get_slicec('_', 2);
 			add_theme_icon_override(dname, p_value);
-		} else if (name.begins_with("custom_styles/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_styles_")) {
+			String dname = name.get_slicec('_', 2);
 			add_theme_style_override(dname, p_value);
-		} else if (name.begins_with("custom_fonts/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_fonts_")) {
+			String dname = name.get_slicec('_', 2);
 			add_theme_font_override(dname, p_value);
-		} else if (name.begins_with("custom_font_sizes/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_font_sizes_")) {
+			String dname = name.get_slicec('_', 3);
 			add_theme_font_size_override(dname, p_value);
-		} else if (name.begins_with("custom_colors/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_colors_")) {
+			String dname = name.get_slicec('_', 2);
 			add_theme_color_override(dname, p_value);
-		} else if (name.begins_with("custom_constants/")) {
-			String dname = name.get_slicec('/', 1);
+		} else if (name.begins_with("custom_constants_")) {
+			String dname = name.get_slicec('_', 2);
 			add_theme_constant_override(dname, p_value);
 		} else {
 			return false;
@@ -306,23 +306,23 @@ bool Control::_get(const StringName &p_name, Variant &r_ret) const {
 		return false;
 	}
 
-	if (sname.begins_with("custom_icons/")) {
-		String name = sname.get_slicec('/', 1);
+	if (sname.begins_with("custom_icons_")) {
+		String name = sname.get_slicec('_', 2);
 		r_ret = data.icon_override.has(name) ? Variant(data.icon_override[name]) : Variant();
-	} else if (sname.begins_with("custom_styles/")) {
-		String name = sname.get_slicec('/', 1);
+	} else if (sname.begins_with("custom_styles_")) {
+		String name = sname.get_slicec('_', 2);
 		r_ret = data.style_override.has(name) ? Variant(data.style_override[name]) : Variant();
-	} else if (sname.begins_with("custom_fonts/")) {
-		String name = sname.get_slicec('/', 1);
+	} else if (sname.begins_with("custom_fonts_")) {
+		String name = sname.get_slicec('_', 2);
 		r_ret = data.font_override.has(name) ? Variant(data.font_override[name]) : Variant();
-	} else if (sname.begins_with("custom_font_sizes/")) {
-		String name = sname.get_slicec('/', 1);
+	} else if (sname.begins_with("custom_font_sizes_")) {
+		String name = sname.get_slicec('_', 3);
 		r_ret = data.font_size_override.has(name) ? Variant(data.font_size_override[name]) : Variant();
-	} else if (sname.begins_with("custom_colors/")) {
-		String name = sname.get_slicec('/', 1);
+	} else if (sname.begins_with("custom_colors_")) {
+		String name = sname.get_slicec('_', 2);
 		r_ret = data.color_override.has(name) ? Variant(data.color_override[name]) : Variant();
-	} else if (sname.begins_with("custom_constants/")) {
-		String name = sname.get_slicec('/', 1);
+	} else if (sname.begins_with("custom_constants_")) {
+		String name = sname.get_slicec('_', 2);
 		r_ret = data.constant_override.has(name) ? Variant(data.constant_override[name]) : Variant();
 	} else {
 		return false;
@@ -344,73 +344,79 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	{
 		List<StringName> names;
 		theme->get_icon_list(get_class_name(), &names);
+		p_list->push_back(PropertyInfo(Variant::NIL, "Custom Icons", PROPERTY_HINT_NONE, "custom_icons_", PROPERTY_USAGE_GROUP));
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.icon_override.has(E->get())) {
 				hint |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_icons/" + E->get(), PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", hint));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_icons_" + E->get(), PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", hint));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_stylebox_list(get_class_name(), &names);
+		p_list->push_back(PropertyInfo(Variant::NIL, "Custom Styles", PROPERTY_HINT_NONE, "custom_styles_", PROPERTY_USAGE_GROUP));
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.style_override.has(E->get())) {
 				hint |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_styles/" + E->get(), PROPERTY_HINT_RESOURCE_TYPE, "StyleBox", hint));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_styles_" + E->get(), PROPERTY_HINT_RESOURCE_TYPE, "StyleBox", hint));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_font_list(get_class_name(), &names);
+		p_list->push_back(PropertyInfo(Variant::NIL, "Custom Fonts", PROPERTY_HINT_NONE, "custom_fonts_", PROPERTY_USAGE_GROUP));
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.font_override.has(E->get())) {
 				hint |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_fonts/" + E->get(), PROPERTY_HINT_RESOURCE_TYPE, "Font", hint));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "custom_fonts_" + E->get(), PROPERTY_HINT_RESOURCE_TYPE, "Font", hint));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_font_size_list(get_class_name(), &names);
+		p_list->push_back(PropertyInfo(Variant::NIL, "Custom Font Sizes", PROPERTY_HINT_NONE, "custom_font_sizes_", PROPERTY_USAGE_GROUP));
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.font_size_override.has(E->get())) {
 				hint |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::INT, "custom_font_sizes/" + E->get(), PROPERTY_HINT_NONE, "", hint));
+			p_list->push_back(PropertyInfo(Variant::INT, "custom_font_sizes_" + E->get(), PROPERTY_HINT_NONE, "", hint));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_color_list(get_class_name(), &names);
+		p_list->push_back(PropertyInfo(Variant::NIL, "Custom Colors", PROPERTY_HINT_NONE, "custom_colors_", PROPERTY_USAGE_GROUP));
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.color_override.has(E->get())) {
 				hint |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::COLOR, "custom_colors/" + E->get(), PROPERTY_HINT_NONE, "", hint));
+			p_list->push_back(PropertyInfo(Variant::COLOR, "custom_colors_" + E->get(), PROPERTY_HINT_NONE, "", hint));
 		}
 	}
 	{
 		List<StringName> names;
 		theme->get_constant_list(get_class_name(), &names);
+		p_list->push_back(PropertyInfo(Variant::NIL, "Custom Constants", PROPERTY_HINT_NONE, "custom_constants_", PROPERTY_USAGE_GROUP));
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			uint32_t hint = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 			if (data.constant_override.has(E->get())) {
 				hint |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 			}
 
-			p_list->push_back(PropertyInfo(Variant::INT, "custom_constants/" + E->get(), PROPERTY_HINT_RANGE, "-16384,16384", hint));
+			p_list->push_back(PropertyInfo(Variant::INT, "custom_constants_" + E->get(), PROPERTY_HINT_RANGE, "-16384,16384", hint));
 		}
 	}
 }

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -40,8 +40,8 @@ struct _MinSizeCache {
 
 bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		double value = p_value;
 		if (value == -1) {
@@ -61,34 +61,39 @@ bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 		return true;
 	}
 
-	if (!str.begins_with("slot/")) {
+	if (!str.begins_with("slot_")) {
 		return false;
 	}
 
-	int idx = str.get_slice("/", 1).to_int();
-	String what = str.get_slice("/", 2);
+	int idx = str.get_slicec('_', 1).to_int();
+	String side = str.get_slicec('_', 2);
+	String what = str.get_slicec('_', 3);
 
 	Slot si;
 	if (slot_info.has(idx)) {
 		si = slot_info[idx];
 	}
 
-	if (what == "left_enabled") {
-		si.enable_left = p_value;
-	} else if (what == "left_type") {
-		si.type_left = p_value;
-	} else if (what == "left_icon") {
-		si.custom_slot_left = p_value;
-	} else if (what == "left_color") {
-		si.color_left = p_value;
-	} else if (what == "right_enabled") {
-		si.enable_right = p_value;
-	} else if (what == "right_type") {
-		si.type_right = p_value;
-	} else if (what == "right_color") {
-		si.color_right = p_value;
-	} else if (what == "right_icon") {
-		si.custom_slot_right = p_value;
+	if (side == "left") {
+		if (what == "enabled") {
+			si.enable_left = p_value;
+		} else if (what == "type") {
+			si.type_left = p_value;
+		} else if (what == "color") {
+			si.color_left = p_value;
+		} else if (what == "icon") {
+			si.custom_slot_left = p_value;
+		}
+	} else if (side == "right") {
+		if (what == "enabled") {
+			si.enable_right = p_value;
+		} else if (what == "type") {
+			si.type_right = p_value;
+		} else if (what == "color") {
+			si.color_right = p_value;
+		} else if (what == "icon") {
+			si.custom_slot_right = p_value;
+		}
 	} else {
 		return false;
 	}
@@ -100,8 +105,8 @@ bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 
 bool GraphNode::_get(const StringName &p_name, Variant &r_ret) const {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		if (opentype_features.has(tag)) {
 			r_ret = opentype_features[tag];
@@ -112,34 +117,39 @@ bool GraphNode::_get(const StringName &p_name, Variant &r_ret) const {
 		}
 	}
 
-	if (!str.begins_with("slot/")) {
+	if (!str.begins_with("slot_")) {
 		return false;
 	}
 
-	int idx = str.get_slice("/", 1).to_int();
-	String what = str.get_slice("/", 2);
+	int idx = str.get_slicec('_', 1).to_int();
+	String side = str.get_slicec('_', 2);
+	String what = str.get_slicec('_', 3);
 
 	Slot si;
 	if (slot_info.has(idx)) {
 		si = slot_info[idx];
 	}
 
-	if (what == "left_enabled") {
-		r_ret = si.enable_left;
-	} else if (what == "left_type") {
-		r_ret = si.type_left;
-	} else if (what == "left_color") {
-		r_ret = si.color_left;
-	} else if (what == "left_icon") {
-		r_ret = si.custom_slot_left;
-	} else if (what == "right_enabled") {
-		r_ret = si.enable_right;
-	} else if (what == "right_type") {
-		r_ret = si.type_right;
-	} else if (what == "right_color") {
-		r_ret = si.color_right;
-	} else if (what == "right_icon") {
-		r_ret = si.custom_slot_right;
+	if (side == "left") {
+		if (what == "enabled") {
+			r_ret = si.enable_left;
+		} else if (what == "type") {
+			r_ret = si.type_left;
+		} else if (what == "color") {
+			r_ret = si.color_left;
+		} else if (what == "icon") {
+			r_ret = si.custom_slot_left;
+		}
+	} else if (side == "right") {
+		if (what == "enabled") {
+			r_ret = si.enable_right;
+		} else if (what == "type") {
+			r_ret = si.type_right;
+		} else if (what == "color") {
+			r_ret = si.color_right;
+		} else if (what == "icon") {
+			r_ret = si.custom_slot_right;
+		}
 	} else {
 		return false;
 	}
@@ -148,20 +158,23 @@ bool GraphNode::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void GraphNode::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::NIL, "Opentype Features", PROPERTY_HINT_NONE, "opentype_features_", PROPERTY_USAGE_GROUP));
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features_" + name));
 	}
-	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features__new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 
 	int idx = 0;
+	p_list->push_back(PropertyInfo(Variant::NIL, "Slots", PROPERTY_HINT_NONE, "slot_", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c || c->is_set_as_top_level()) {
 			continue;
 		}
 
-		String base = "slot/" + itos(idx) + "/";
+		String base = "slot_" + itos(idx) + "_";
+		p_list->push_back(PropertyInfo(Variant::NIL, itos(idx), PROPERTY_HINT_NONE, base, PROPERTY_USAGE_SUBGROUP));
 
 		p_list->push_back(PropertyInfo(Variant::BOOL, base + "left_enabled"));
 		p_list->push_back(PropertyInfo(Variant::INT, base + "left_type"));

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -599,8 +599,8 @@ int Label::get_total_character_count() const {
 
 bool Label::_set(const StringName &p_name, const Variant &p_value) {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		double value = p_value;
 		if (value == -1) {
@@ -625,8 +625,8 @@ bool Label::_set(const StringName &p_name, const Variant &p_value) {
 
 bool Label::_get(const StringName &p_name, Variant &r_ret) const {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 1);
 		int32_t tag = TS->name_to_tag(name);
 		if (opentype_features.has(tag)) {
 			r_ret = opentype_features[tag];
@@ -640,11 +640,12 @@ bool Label::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void Label::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::NIL, "Opentype Features", PROPERTY_HINT_NONE, "opentype_features_", PROPERTY_USAGE_GROUP));
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features_" + name));
 	}
-	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features__new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }
 
 void Label::_bind_methods() {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2034,8 +2034,8 @@ void LineEdit::_generate_context_menu() {
 
 bool LineEdit::_set(const StringName &p_name, const Variant &p_value) {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		double value = p_value;
 		if (value == -1) {
@@ -2060,8 +2060,8 @@ bool LineEdit::_set(const StringName &p_name, const Variant &p_value) {
 
 bool LineEdit::_get(const StringName &p_name, Variant &r_ret) const {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		if (opentype_features.has(tag)) {
 			r_ret = opentype_features[tag];
@@ -2075,11 +2075,12 @@ bool LineEdit::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void LineEdit::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::NIL, "Opentype Features", PROPERTY_HINT_NONE, "opentype_features_", PROPERTY_USAGE_GROUP));
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features_" + name));
 	}
-	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features__new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }
 
 void LineEdit::_validate_property(PropertyInfo &property) const {

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -222,8 +222,8 @@ void LinkButton::_notification(int p_what) {
 
 bool LinkButton::_set(const StringName &p_name, const Variant &p_value) {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		double value = p_value;
 		if (value == -1) {
@@ -248,8 +248,8 @@ bool LinkButton::_set(const StringName &p_name, const Variant &p_value) {
 
 bool LinkButton::_get(const StringName &p_name, Variant &r_ret) const {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		if (opentype_features.has(tag)) {
 			r_ret = opentype_features[tag];
@@ -263,11 +263,12 @@ bool LinkButton::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void LinkButton::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::NIL, "Opentype Features", PROPERTY_HINT_NONE, "opentype_features_", PROPERTY_USAGE_GROUP));
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features_" + name));
 	}
-	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features__new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }
 
 void LinkButton::_bind_methods() {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6749,8 +6749,8 @@ PopupMenu *TextEdit::get_menu() const {
 
 bool TextEdit::_set(const StringName &p_name, const Variant &p_value) {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		double value = p_value;
 		if (value == -1) {
@@ -6778,8 +6778,8 @@ bool TextEdit::_set(const StringName &p_name, const Variant &p_value) {
 
 bool TextEdit::_get(const StringName &p_name, Variant &r_ret) const {
 	String str = p_name;
-	if (str.begins_with("opentype_features/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("opentype_features_")) {
+		String name = str.get_slicec('_', 2);
 		int32_t tag = TS->name_to_tag(name);
 		if (opentype_features.has(tag)) {
 			r_ret = opentype_features[tag];
@@ -6793,11 +6793,12 @@ bool TextEdit::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void TextEdit::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::NIL, "Opentype Features", PROPERTY_HINT_NONE, "opentype_features_", PROPERTY_USAGE_GROUP));
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features_" + name));
 	}
-	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features__new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }
 
 void TextEdit::_bind_methods() {

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -36,9 +36,9 @@
 bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
 
-	if (name.begins_with("tracks/")) {
-		int track = name.get_slicec('/', 1).to_int();
-		String what = name.get_slicec('/', 2);
+	if (name.begins_with("tracks_")) {
+		int track = name.get_slicec('_', 1).to_int();
+		String what = name.get_slicec('_', 2);
 
 		if (tracks.size() == track && what == "type") {
 			String type = p_value;
@@ -312,9 +312,9 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = loop;
 	} else if (name == "step") {
 		r_ret = step;
-	} else if (name.begins_with("tracks/")) {
-		int track = name.get_slicec('/', 1).to_int();
-		String what = name.get_slicec('/', 2);
+	} else if (name.begins_with("tracks_")) {
+		int track = name.get_slicec('_', 1).to_int();
+		String what = name.get_slicec('_', 2);
 		ERR_FAIL_INDEX_V(track, tracks.size(), false);
 		if (what == "type") {
 			switch (track_get_type(track)) {
@@ -570,13 +570,13 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 
 void Animation::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (int i = 0; i < tracks.size(); i++) {
-		p_list->push_back(PropertyInfo(Variant::STRING, "tracks/" + itos(i) + "/type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::NODE_PATH, "tracks/" + itos(i) + "/path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::INT, "tracks/" + itos(i) + "/interp", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::BOOL, "tracks/" + itos(i) + "/loop_wrap", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::BOOL, "tracks/" + itos(i) + "/imported", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::BOOL, "tracks/" + itos(i) + "/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::ARRAY, "tracks/" + itos(i) + "/keys", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::STRING, "tracks_" + itos(i) + "_type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::NODE_PATH, "tracks_" + itos(i) + "_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::INT, "tracks_" + itos(i) + "_interp", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "tracks_" + itos(i) + "_loop_wrap", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "tracks_" + itos(i) + "_imported", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "tracks_" + itos(i) + "_enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::ARRAY, "tracks_" + itos(i) + "_keys", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 	}
 }
 

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1254,13 +1254,13 @@ void Environment::_bind_methods() {
 
 	ADD_GROUP("Glow", "glow_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "glow_enabled"), "set_glow_enabled", "is_glow_enabled");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_levels/1", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 0);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_levels/2", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 1);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_levels/3", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 2);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_levels/4", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 3);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_levels/5", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 4);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_levels/6", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 5);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_levels/7", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 6);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_level_1", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 0);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_level_2", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 1);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_level_3", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 2);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_level_4", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 3);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_level_5", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 4);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_level_6", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 5);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "glow_level_7", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_glow_level", "get_glow_level", 6);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "glow_normalized"), "set_glow_normalized", "is_glow_normalized");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_intensity", PROPERTY_HINT_RANGE, "0.0,8.0,0.01"), "set_glow_intensity", "get_glow_intensity");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_strength", PROPERTY_HINT_RANGE, "0.0,2.0,0.01"), "set_glow_strength", "get_glow_strength");

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -119,24 +119,24 @@ void FontData::_bind_methods() {
 
 bool FontData::_set(const StringName &p_name, const Variant &p_value) {
 	String str = p_name;
-	if (str.begins_with("language_support_override/")) {
-		String lang = str.get_slicec('/', 1);
-		if (lang == "_new") {
+	if (str.begins_with("language_support_override_")) {
+		String lang = str.get_slicec('_', 3);
+		if (lang == "") {
 			return false;
 		}
 		set_language_support_override(lang, p_value);
 		return true;
 	}
-	if (str.begins_with("script_support_override/")) {
-		String scr = str.get_slicec('/', 1);
-		if (scr == "_new") {
+	if (str.begins_with("script_support_override_")) {
+		String scr = str.get_slicec('_', 3);
+		if (scr == "") {
 			return false;
 		}
 		set_script_support_override(scr, p_value);
 		return true;
 	}
-	if (str.begins_with("variation/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("variation_")) {
+		String name = str.get_slicec('_', 1);
 		set_variation(name, p_value);
 		return true;
 	}
@@ -146,24 +146,24 @@ bool FontData::_set(const StringName &p_name, const Variant &p_value) {
 
 bool FontData::_get(const StringName &p_name, Variant &r_ret) const {
 	String str = p_name;
-	if (str.begins_with("language_support_override/")) {
-		String lang = str.get_slicec('/', 1);
-		if (lang == "_new") {
+	if (str.begins_with("language_support_override_")) {
+		String lang = str.get_slicec('_', 3);
+		if (lang == "") {
 			return true;
 		}
 		r_ret = get_language_support_override(lang);
 		return true;
 	}
-	if (str.begins_with("script_support_override/")) {
-		String scr = str.get_slicec('/', 1);
-		if (scr == "_new") {
+	if (str.begins_with("script_support_override_")) {
+		String scr = str.get_slicec('_', 3);
+		if (scr == "") {
 			return true;
 		}
 		r_ret = get_script_support_override(scr);
 		return true;
 	}
-	if (str.begins_with("variation/")) {
-		String name = str.get_slicec('/', 1);
+	if (str.begins_with("variation_")) {
+		String name = str.get_slicec('_', 1);
 
 		r_ret = get_variation(name);
 		return true;
@@ -175,20 +175,20 @@ bool FontData::_get(const StringName &p_name, Variant &r_ret) const {
 void FontData::_get_property_list(List<PropertyInfo> *p_list) const {
 	Vector<String> lang_over = get_language_support_overrides();
 	for (int i = 0; i < lang_over.size(); i++) {
-		p_list->push_back(PropertyInfo(Variant::BOOL, "language_support_override/" + lang_over[i], PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "language_support_override_" + lang_over[i], PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE));
 	}
-	p_list->push_back(PropertyInfo(Variant::NIL, "language_support_override/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::NIL, "language_support_override__new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 
 	Vector<String> scr_over = get_script_support_overrides();
 	for (int i = 0; i < scr_over.size(); i++) {
-		p_list->push_back(PropertyInfo(Variant::BOOL, "script_support_override/" + scr_over[i], PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "script_support_override_" + scr_over[i], PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE));
 	}
-	p_list->push_back(PropertyInfo(Variant::NIL, "script_support_override/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::NIL, "script_support_override__new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 
 	Dictionary variations = get_variation_list();
 	for (const Variant *ftr = variations.next(nullptr); ftr != nullptr; ftr = variations.next(ftr)) {
 		Vector3i v = variations[*ftr];
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "variation/" + TS->tag_to_name(*ftr), PROPERTY_HINT_RANGE, itos(v.x) + "," + itos(v.y), PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "variation_" + TS->tag_to_name(*ftr), PROPERTY_HINT_RANGE, itos(v.x) + "," + itos(v.y), PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE));
 	}
 }
 
@@ -612,8 +612,8 @@ bool Font::_set(const StringName &p_name, const Variant &p_value) {
 		return false;
 	}
 #endif /* DISABLE_DEPRECATED */
-	if (str.begins_with("data/")) {
-		int idx = str.get_slicec('/', 1).to_int();
+	if (str.begins_with("data_")) {
+		int idx = str.get_slicec('_', 1).to_int();
 		Ref<FontData> fd = p_value;
 
 		if (fd.is_valid()) {
@@ -637,8 +637,8 @@ bool Font::_set(const StringName &p_name, const Variant &p_value) {
 
 bool Font::_get(const StringName &p_name, Variant &r_ret) const {
 	String str = p_name;
-	if (str.begins_with("data/")) {
-		int idx = str.get_slicec('/', 1).to_int();
+	if (str.begins_with("data_")) {
+		int idx = str.get_slicec('_', 1).to_int();
 
 		if (idx == data.size()) {
 			r_ret = Ref<FontData>();
@@ -653,11 +653,12 @@ bool Font::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void Font::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::NIL, "Data", PROPERTY_HINT_NONE, "data_", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < data.size(); i++) {
-		p_list->push_back(PropertyInfo(Variant::OBJECT, "data/" + itos(i), PROPERTY_HINT_RESOURCE_TYPE, "FontData"));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "data_" + itos(i), PROPERTY_HINT_RESOURCE_TYPE, "FontData"));
 	}
 
-	p_list->push_back(PropertyInfo(Variant::OBJECT, "data/" + itos(data.size()), PROPERTY_HINT_RESOURCE_TYPE, "FontData"));
+	p_list->push_back(PropertyInfo(Variant::OBJECT, "data_" + itos(data.size()), PROPERTY_HINT_RESOURCE_TYPE, "FontData"));
 }
 
 void Font::reset_state() {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -745,16 +745,14 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 	String sname = p_name;
 
 	if (sname.begins_with("surface_")) {
-		int sl = sname.find("/");
-		if (sl == -1) {
-			return false;
-		}
-		int idx = sname.substr(8, sl - 8).to_int() - 1;
-		String what = sname.get_slicec('/', 1);
+		int idx = sname.get_slicec('_', 1).to_int() - 1;
+		String what = sname.get_slicec('_', 2);
 		if (what == "material") {
 			surface_set_material(idx, p_value);
 		} else if (what == "name") {
 			surface_set_name(idx, p_value);
+		} else {
+			return false;
 		}
 		return true;
 	}
@@ -1085,18 +1083,15 @@ bool ArrayMesh::_get(const StringName &p_name, Variant &r_ret) const {
 
 	String sname = p_name;
 	if (sname.begins_with("surface_")) {
-		int sl = sname.find("/");
-		if (sl == -1) {
-			return false;
-		}
-		int idx = sname.substr(8, sl - 8).to_int() - 1;
-		String what = sname.get_slicec('/', 1);
+		int idx = sname.get_slicec('_', 1).to_int() - 1;
+		String what = sname.get_slicec('_', 2);
 		if (what == "material") {
 			r_ret = surface_get_material(idx);
 		} else if (what == "name") {
 			r_ret = surface_get_name(idx);
+		} else {
+			return false;
 		}
-		return true;
 	}
 
 	return true;
@@ -1117,11 +1112,11 @@ void ArrayMesh::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 
 	for (int i = 0; i < surfaces.size(); i++) {
-		p_list->push_back(PropertyInfo(Variant::STRING, "surface_" + itos(i + 1) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+		p_list->push_back(PropertyInfo(Variant::STRING, "surface_" + itos(i + 1) + "_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 		if (surfaces[i].is_2d) {
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "surface_" + itos(i + 1) + "/material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,CanvasItemMaterial", PROPERTY_USAGE_EDITOR));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "surface_" + itos(i + 1) + "_material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,CanvasItemMaterial", PROPERTY_USAGE_EDITOR));
 		} else {
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "surface_" + itos(i + 1) + "/material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,StandardMaterial3D", PROPERTY_USAGE_EDITOR));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "surface_" + itos(i + 1) + "_material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,StandardMaterial3D", PROPERTY_USAGE_EDITOR));
 		}
 	}
 }

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -32,9 +32,9 @@
 
 bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
-	if (name.begins_with("item/")) {
-		int idx = name.get_slicec('/', 1).to_int();
-		String what = name.get_slicec('/', 2);
+	if (name.begins_with("item_")) {
+		int idx = name.get_slicec('_', 1).to_int();
+		String what = name.get_slicec('_', 2);
 		if (!item_map.has(idx)) {
 			create_item(idx);
 		}
@@ -54,9 +54,11 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (what == "preview") {
 			set_item_preview(idx, p_value);
 		} else if (what == "navmesh") {
-			set_item_navmesh(idx, p_value);
-		} else if (what == "navmesh_transform") {
-			set_item_navmesh_transform(idx, p_value);
+			if (name.get_slicec('_', 3) == "transform") {
+				set_item_navmesh_transform(idx, p_value);
+			} else {
+				set_item_navmesh(idx, p_value);
+			}
 		} else {
 			return false;
 		}
@@ -69,9 +71,9 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 
 bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
-	int idx = name.get_slicec('/', 1).to_int();
+	int idx = name.get_slicec('_', 1).to_int();
 	ERR_FAIL_COND_V(!item_map.has(idx), false);
-	String what = name.get_slicec('/', 2);
+	String what = name.get_slicec('_', 2);
 
 	if (what == "name") {
 		r_ret = get_item_name(idx);
@@ -80,9 +82,11 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (what == "shapes") {
 		r_ret = _get_item_shapes(idx);
 	} else if (what == "navmesh") {
-		r_ret = get_item_navmesh(idx);
-	} else if (what == "navmesh_transform") {
-		r_ret = get_item_navmesh_transform(idx);
+		if (name.get_slicec('_', 3) == "transform") {
+			r_ret = get_item_navmesh_transform(idx);
+		} else {
+			r_ret = get_item_navmesh(idx);
+		}
 	} else if (what == "preview") {
 		r_ret = get_item_preview(idx);
 	} else {
@@ -93,8 +97,10 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::NIL, "Items", PROPERTY_HINT_NONE, "item_", PROPERTY_USAGE_GROUP));
 	for (Map<int, Item>::Element *E = item_map.front(); E; E = E->next()) {
-		String name = "item/" + itos(E->key()) + "/";
+		String name = "item_" + itos(E->key()) + "_";
+		p_list->push_back(PropertyInfo(Variant::NIL, itos(E->key()), PROPERTY_HINT_NONE, name, PROPERTY_USAGE_SUBGROUP));
 		p_list->push_back(PropertyInfo(Variant::STRING, name + "name"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, name + "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM, name + "mesh_transform"));

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -83,28 +83,28 @@ int NavigationMesh::get_parsed_geometry_type() const {
 	return parsed_geometry_type;
 }
 
-void NavigationMesh::set_collision_mask(uint32_t p_mask) {
-	collision_mask = p_mask;
+void NavigationMesh::set_physics_mask(uint32_t p_mask) {
+	physics_mask = p_mask;
 }
 
-uint32_t NavigationMesh::get_collision_mask() const {
-	return collision_mask;
+uint32_t NavigationMesh::get_physics_mask() const {
+	return physics_mask;
 }
 
-void NavigationMesh::set_collision_mask_bit(int p_bit, bool p_value) {
+void NavigationMesh::set_physics_mask_bit(int p_bit, bool p_value) {
 	ERR_FAIL_INDEX_MSG(p_bit, 32, "Collision mask bit must be between 0 and 31 inclusive.");
-	uint32_t mask = get_collision_mask();
+	uint32_t mask = get_physics_mask();
 	if (p_value) {
 		mask |= 1 << p_bit;
 	} else {
 		mask &= ~(1 << p_bit);
 	}
-	set_collision_mask(mask);
+	set_physics_mask(mask);
 }
 
-bool NavigationMesh::get_collision_mask_bit(int p_bit) const {
+bool NavigationMesh::get_physics_mask_bit(int p_bit) const {
 	ERR_FAIL_INDEX_V_MSG(p_bit, 32, false, "Collision mask bit must be between 0 and 31 inclusive.");
-	return get_collision_mask() & (1 << p_bit);
+	return get_physics_mask() & (1 << p_bit);
 }
 
 void NavigationMesh::set_source_geometry_mode(int p_geometry_mode) {
@@ -205,12 +205,12 @@ float NavigationMesh::get_edge_max_error() const {
 	return edge_max_error;
 }
 
-void NavigationMesh::set_verts_per_poly(float p_value) {
-	verts_per_poly = p_value;
+void NavigationMesh::set_vertices_per_polygon(float p_value) {
+	vertices_per_polygon = p_value;
 }
 
-float NavigationMesh::get_verts_per_poly() const {
-	return verts_per_poly;
+float NavigationMesh::get_vertices_per_polygon() const {
+	return vertices_per_polygon;
 }
 
 void NavigationMesh::set_detail_sample_distance(float p_value) {
@@ -253,12 +253,12 @@ bool NavigationMesh::get_filter_walkable_low_height_spans() const {
 	return filter_walkable_low_height_spans;
 }
 
-void NavigationMesh::set_vertices(const Vector<Vector3> &p_vertices) {
+void NavigationMesh::_set_vertices(const Vector<Vector3> &p_vertices) {
 	vertices = p_vertices;
 	notify_property_list_changed();
 }
 
-Vector<Vector3> NavigationMesh::get_vertices() const {
+Vector<Vector3> NavigationMesh::_get_vertices() const {
 	return vertices;
 }
 
@@ -305,7 +305,7 @@ Ref<Mesh> NavigationMesh::get_debug_mesh() {
 		return debug_mesh;
 	}
 
-	Vector<Vector3> vertices = get_vertices();
+	Vector<Vector3> vertices = _get_vertices();
 	const Vector3 *vr = vertices.ptr();
 	List<Face3> faces;
 	for (int i = 0; i < get_polygon_count(); i++) {
@@ -389,11 +389,11 @@ void NavigationMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_parsed_geometry_type", "geometry_type"), &NavigationMesh::set_parsed_geometry_type);
 	ClassDB::bind_method(D_METHOD("get_parsed_geometry_type"), &NavigationMesh::get_parsed_geometry_type);
 
-	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &NavigationMesh::set_collision_mask);
-	ClassDB::bind_method(D_METHOD("get_collision_mask"), &NavigationMesh::get_collision_mask);
+	ClassDB::bind_method(D_METHOD("set_physics_mask", "mask"), &NavigationMesh::set_physics_mask);
+	ClassDB::bind_method(D_METHOD("get_physics_mask"), &NavigationMesh::get_physics_mask);
 
-	ClassDB::bind_method(D_METHOD("set_collision_mask_bit", "bit", "value"), &NavigationMesh::set_collision_mask_bit);
-	ClassDB::bind_method(D_METHOD("get_collision_mask_bit", "bit"), &NavigationMesh::get_collision_mask_bit);
+	ClassDB::bind_method(D_METHOD("set_physics_mask_bit", "bit", "value"), &NavigationMesh::set_physics_mask_bit);
+	ClassDB::bind_method(D_METHOD("get_physics_mask_bit", "bit"), &NavigationMesh::get_physics_mask_bit);
 
 	ClassDB::bind_method(D_METHOD("set_source_geometry_mode", "mask"), &NavigationMesh::set_source_geometry_mode);
 	ClassDB::bind_method(D_METHOD("get_source_geometry_mode"), &NavigationMesh::get_source_geometry_mode);
@@ -431,8 +431,8 @@ void NavigationMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_edge_max_error", "edge_max_error"), &NavigationMesh::set_edge_max_error);
 	ClassDB::bind_method(D_METHOD("get_edge_max_error"), &NavigationMesh::get_edge_max_error);
 
-	ClassDB::bind_method(D_METHOD("set_verts_per_poly", "verts_per_poly"), &NavigationMesh::set_verts_per_poly);
-	ClassDB::bind_method(D_METHOD("get_verts_per_poly"), &NavigationMesh::get_verts_per_poly);
+	ClassDB::bind_method(D_METHOD("set_vertices_per_polygon", "vertices_per_polygon"), &NavigationMesh::set_vertices_per_polygon);
+	ClassDB::bind_method(D_METHOD("get_vertices_per_polygon"), &NavigationMesh::get_vertices_per_polygon);
 
 	ClassDB::bind_method(D_METHOD("set_detail_sample_distance", "detail_sample_dist"), &NavigationMesh::set_detail_sample_distance);
 	ClassDB::bind_method(D_METHOD("get_detail_sample_distance"), &NavigationMesh::get_detail_sample_distance);
@@ -449,8 +449,8 @@ void NavigationMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_filter_walkable_low_height_spans", "filter_walkable_low_height_spans"), &NavigationMesh::set_filter_walkable_low_height_spans);
 	ClassDB::bind_method(D_METHOD("get_filter_walkable_low_height_spans"), &NavigationMesh::get_filter_walkable_low_height_spans);
 
-	ClassDB::bind_method(D_METHOD("set_vertices", "vertices"), &NavigationMesh::set_vertices);
-	ClassDB::bind_method(D_METHOD("get_vertices"), &NavigationMesh::get_vertices);
+	ClassDB::bind_method(D_METHOD("_set_vertices", "vertices"), &NavigationMesh::_set_vertices);
+	ClassDB::bind_method(D_METHOD("_get_vertices"), &NavigationMesh::_get_vertices);
 
 	ClassDB::bind_method(D_METHOD("add_polygon", "polygon"), &NavigationMesh::add_polygon);
 	ClassDB::bind_method(D_METHOD("get_polygon_count"), &NavigationMesh::get_polygon_count);
@@ -470,43 +470,48 @@ void NavigationMesh::_bind_methods() {
 	BIND_CONSTANT(PARSED_GEOMETRY_STATIC_COLLIDERS);
 	BIND_CONSTANT(PARSED_GEOMETRY_BOTH);
 
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sample_partition_type", PROPERTY_HINT_ENUM, "Watershed,Monotone,Layers"), "set_sample_partition_type", "get_sample_partition_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "parsed_geometry_type", PROPERTY_HINT_ENUM, "Mesh Instances,Static Colliders,Both"), "set_parsed_geometry_type", "get_parsed_geometry_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "physics_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_physics_mask", "get_physics_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "source_geometry_mode", PROPERTY_HINT_ENUM, "Navmesh Children, Group With Children, Group Explicit"), "set_source_geometry_mode", "get_source_geometry_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_group_name"), "set_source_group_name", "get_source_group_name");
+
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_vertices", "_get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "polygons", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_polygons", "_get_polygons");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "vertices_per_polygon", PROPERTY_HINT_RANGE, "3.0,12.0,1.0,or_greater"), "set_vertices_per_polygon", "get_vertices_per_polygon");
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "sample_partition_type/sample_partition_type", PROPERTY_HINT_ENUM, "Watershed,Monotone,Layers"), "set_sample_partition_type", "get_sample_partition_type");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry/parsed_geometry_type", PROPERTY_HINT_ENUM, "Mesh Instances,Static Colliders,Both"), "set_parsed_geometry_type", "get_parsed_geometry_type");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry/collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry/source_geometry_mode", PROPERTY_HINT_ENUM, "Navmesh Children, Group With Children, Group Explicit"), "set_source_geometry_mode", "get_source_geometry_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "geometry/source_group_name"), "set_source_group_name", "get_source_group_name");
-
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell/size", PROPERTY_HINT_RANGE, "0.1,1.0,0.01,or_greater"), "set_cell_size", "get_cell_size");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell/height", PROPERTY_HINT_RANGE, "0.1,1.0,0.01,or_greater"), "set_cell_height", "get_cell_height");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/height", PROPERTY_HINT_RANGE, "0.1,5.0,0.01,or_greater"), "set_agent_height", "get_agent_height");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/radius", PROPERTY_HINT_RANGE, "0.1,5.0,0.01,or_greater"), "set_agent_radius", "get_agent_radius");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/max_climb", PROPERTY_HINT_RANGE, "0.1,5.0,0.01,or_greater"), "set_agent_max_climb", "get_agent_max_climb");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/max_slope", PROPERTY_HINT_RANGE, "0.0,90.0,0.1"), "set_agent_max_slope", "get_agent_max_slope");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "region/min_size", PROPERTY_HINT_RANGE, "0.0,150.0,0.01,or_greater"), "set_region_min_size", "get_region_min_size");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "region/merge_size", PROPERTY_HINT_RANGE, "0.0,150.0,0.01,or_greater"), "set_region_merge_size", "get_region_merge_size");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "edge/max_length", PROPERTY_HINT_RANGE, "0.0,50.0,0.01,or_greater"), "set_edge_max_length", "get_edge_max_length");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "edge/max_error", PROPERTY_HINT_RANGE, "0.1,3.0,0.01,or_greater"), "set_edge_max_error", "get_edge_max_error");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "polygon/verts_per_poly", PROPERTY_HINT_RANGE, "3.0,12.0,1.0,or_greater"), "set_verts_per_poly", "get_verts_per_poly");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail/sample_distance", PROPERTY_HINT_RANGE, "0.0,16.0,0.01,or_greater"), "set_detail_sample_distance", "get_detail_sample_distance");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail/sample_max_error", PROPERTY_HINT_RANGE, "0.0,16.0,0.01,or_greater"), "set_detail_sample_max_error", "get_detail_sample_max_error");
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter/low_hanging_obstacles"), "set_filter_low_hanging_obstacles", "get_filter_low_hanging_obstacles");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter/ledge_spans"), "set_filter_ledge_spans", "get_filter_ledge_spans");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter/filter_walkable_low_height_spans"), "set_filter_walkable_low_height_spans", "get_filter_walkable_low_height_spans");
+	ADD_GROUP("Cell", "cell_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_size", PROPERTY_HINT_RANGE, "0.1,1.0,0.01,or_greater"), "set_cell_size", "get_cell_size");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_height", PROPERTY_HINT_RANGE, "0.1,1.0,0.01,or_greater"), "set_cell_height", "get_cell_height");
+	ADD_GROUP("Agent", "agent_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent_height", PROPERTY_HINT_RANGE, "0.1,5.0,0.01,or_greater"), "set_agent_height", "get_agent_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent_radius", PROPERTY_HINT_RANGE, "0.1,5.0,0.01,or_greater"), "set_agent_radius", "get_agent_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent_max_climb", PROPERTY_HINT_RANGE, "0.1,5.0,0.01,or_greater"), "set_agent_max_climb", "get_agent_max_climb");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent_max_slope", PROPERTY_HINT_RANGE, "0.0,90.0,0.1"), "set_agent_max_slope", "get_agent_max_slope");
+	ADD_GROUP("Region", "region_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "region_min_size", PROPERTY_HINT_RANGE, "0.0,150.0,0.01,or_greater"), "set_region_min_size", "get_region_min_size");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "region_merge_size", PROPERTY_HINT_RANGE, "0.0,150.0,0.01,or_greater"), "set_region_merge_size", "get_region_merge_size");
+	ADD_GROUP("Edge", "edge_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "edge_max_length", PROPERTY_HINT_RANGE, "0.0,50.0,0.01,or_greater"), "set_edge_max_length", "get_edge_max_length");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "edge_max_error", PROPERTY_HINT_RANGE, "0.1,3.0,0.01,or_greater"), "set_edge_max_error", "get_edge_max_error");
+	ADD_GROUP("Detail", "detail_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail_sample_distance", PROPERTY_HINT_RANGE, "0.0,16.0,0.01,or_greater"), "set_detail_sample_distance", "get_detail_sample_distance");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail_sample_max_error", PROPERTY_HINT_RANGE, "0.0,16.0,0.01,or_greater"), "set_detail_sample_max_error", "get_detail_sample_max_error");
+	ADD_GROUP("Filter", "filter_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_low_hanging_obstacles"), "set_filter_low_hanging_obstacles", "get_filter_low_hanging_obstacles");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_ledge_spans"), "set_filter_ledge_spans", "get_filter_ledge_spans");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_walkable_low_height_spans"), "set_filter_walkable_low_height_spans", "get_filter_walkable_low_height_spans");
 }
 
 void NavigationMesh::_validate_property(PropertyInfo &property) const {
-	if (property.name == "geometry/collision_mask") {
+	if (property.name == "physics_mask") {
 		if (parsed_geometry_type == PARSED_GEOMETRY_MESH_INSTANCES) {
 			property.usage = 0;
 			return;
 		}
 	}
 
-	if (property.name == "geometry/source_group_name") {
+	if (property.name == "source_group_name") {
 		if (source_geometry_mode == SOURCE_GEOMETRY_NAVMESH_CHILDREN) {
 			property.usage = 0;
 			return;

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -92,13 +92,13 @@ protected:
 	float region_merge_size = 20.0f;
 	float edge_max_length = 12.0f;
 	float edge_max_error = 1.3f;
-	float verts_per_poly = 6.0f;
+	float vertices_per_polygon = 6.0f;
 	float detail_sample_distance = 6.0f;
 	float detail_sample_max_error = 1.0f;
 
 	SamplePartitionType partition_type = SAMPLE_PARTITION_WATERSHED;
 	ParsedGeometryType parsed_geometry_type = PARSED_GEOMETRY_MESH_INSTANCES;
-	uint32_t collision_mask = 0xFFFFFFFF;
+	uint32_t physics_mask = 0xFFFFFFFF;
 
 	SourceGeometryMode source_geometry_mode = SOURCE_GEOMETRY_NAVMESH_CHILDREN;
 	StringName source_group_name = "navmesh";
@@ -115,11 +115,11 @@ public:
 	void set_parsed_geometry_type(int p_value);
 	int get_parsed_geometry_type() const;
 
-	void set_collision_mask(uint32_t p_mask);
-	uint32_t get_collision_mask() const;
+	void set_physics_mask(uint32_t p_mask);
+	uint32_t get_physics_mask() const;
 
-	void set_collision_mask_bit(int p_bit, bool p_value);
-	bool get_collision_mask_bit(int p_bit) const;
+	void set_physics_mask_bit(int p_bit, bool p_value);
+	bool get_physics_mask_bit(int p_bit) const;
 
 	void set_source_geometry_mode(int p_geometry_mode);
 	int get_source_geometry_mode() const;
@@ -157,8 +157,8 @@ public:
 	void set_edge_max_error(float p_value);
 	float get_edge_max_error() const;
 
-	void set_verts_per_poly(float p_value);
-	float get_verts_per_poly() const;
+	void set_vertices_per_polygon(float p_value);
+	float get_vertices_per_polygon() const;
 
 	void set_detail_sample_distance(float p_value);
 	float get_detail_sample_distance() const;
@@ -177,8 +177,8 @@ public:
 
 	void create_from_mesh(const Ref<Mesh> &p_mesh);
 
-	void set_vertices(const Vector<Vector3> &p_vertices);
-	Vector<Vector3> get_vertices() const;
+	void _set_vertices(const Vector<Vector3> &p_vertices);
+	Vector<Vector3> _get_vertices() const;
 
 	void add_polygon(const Vector<int> &p_polygon);
 	int get_polygon_count() const;

--- a/scene/resources/skin.cpp
+++ b/scene/resources/skin.cpp
@@ -90,9 +90,9 @@ bool Skin::_set(const StringName &p_name, const Variant &p_value) {
 	if (name == "bind_count") {
 		set_bind_count(p_value);
 		return true;
-	} else if (name.begins_with("bind/")) {
-		int index = name.get_slicec('/', 1).to_int();
-		String what = name.get_slicec('/', 2);
+	} else if (name.begins_with("bind_")) {
+		int index = name.get_slicec('_', 1).to_int();
+		String what = name.get_slicec('_', 2);
 		if (what == "bone") {
 			set_bind_bone(index, p_value);
 			return true;
@@ -112,9 +112,9 @@ bool Skin::_get(const StringName &p_name, Variant &r_ret) const {
 	if (name == "bind_count") {
 		r_ret = get_bind_count();
 		return true;
-	} else if (name.begins_with("bind/")) {
-		int index = name.get_slicec('/', 1).to_int();
-		String what = name.get_slicec('/', 2);
+	} else if (name.begins_with("bind_")) {
+		int index = name.get_slicec('_', 1).to_int();
+		String what = name.get_slicec('_', 2);
 		if (what == "bone") {
 			r_ret = get_bind_bone(index);
 			return true;
@@ -131,10 +131,12 @@ bool Skin::_get(const StringName &p_name, Variant &r_ret) const {
 
 void Skin::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::INT, "bind_count", PROPERTY_HINT_RANGE, "0,16384,1,or_greater"));
+	p_list->push_back(PropertyInfo(Variant::NIL, "Binds", PROPERTY_HINT_NONE, "bind_", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < get_bind_count(); i++) {
-		p_list->push_back(PropertyInfo(Variant::STRING_NAME, "bind/" + itos(i) + "/name"));
-		p_list->push_back(PropertyInfo(Variant::INT, "bind/" + itos(i) + "/bone", PROPERTY_HINT_RANGE, "0,16384,1,or_greater", get_bind_name(i) != StringName() ? PROPERTY_USAGE_NOEDITOR : PROPERTY_USAGE_DEFAULT));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM, "bind/" + itos(i) + "/pose"));
+		p_list->push_back(PropertyInfo(Variant::NIL, itos(i), PROPERTY_HINT_NONE, "bind_" + itos(i) + "_", PROPERTY_USAGE_SUBGROUP));
+		p_list->push_back(PropertyInfo(Variant::STRING_NAME, "bind_" + itos(i) + "_name"));
+		p_list->push_back(PropertyInfo(Variant::INT, "bind_" + itos(i) + "_bone", PROPERTY_HINT_RANGE, "0,16384,1,or_greater", get_bind_name(i) != StringName() ? PROPERTY_USAGE_NOEDITOR : PROPERTY_USAGE_DEFAULT));
+		p_list->push_back(PropertyInfo(Variant::TRANSFORM, "bind_" + itos(i) + "_pose"));
 	}
 }
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1909,9 +1909,10 @@ void AnimatedTexture::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "oneshot"), "set_oneshot", "get_oneshot");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fps", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_fps", "get_fps");
 
+	ADD_GROUP("Frames", "frame_");
 	for (int i = 0; i < MAX_FRAMES; i++) {
-		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "frame_" + itos(i) + "/texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_frame_texture", "get_frame_texture", i);
-		ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "frame_" + itos(i) + "/delay_sec", PROPERTY_HINT_RANGE, "0.0,16.0,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_frame_delay", "get_frame_delay", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "frame_" + itos(i) + "_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_frame_texture", "get_frame_texture", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "frame_" + itos(i) + "_delay_sec", PROPERTY_HINT_RANGE, "0.0,16.0,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_frame_delay", "get_frame_delay", i);
 	}
 
 	BIND_CONSTANT(MAX_FRAMES);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1874,7 +1874,7 @@ bool AnimatedTexture::is_pixel_opaque(int p_x, int p_y) const {
 void AnimatedTexture::_validate_property(PropertyInfo &property) const {
 	String prop = property.name;
 	if (prop.begins_with("frame_")) {
-		int frame = prop.get_slicec('/', 0).get_slicec('_', 1).to_int();
+		int frame = prop.get_slicec('_', 0).to_int();
 		if (frame >= frame_count) {
 			property.usage = 0;
 		}

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -36,16 +36,16 @@
 
 bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 	String n = p_name;
-	int slash = n.find("/");
-	if (slash == -1) {
+	int sep = n.find("_");
+	if (sep == -1) {
 		return false;
 	}
-	int id = String::to_int(n.get_data(), slash);
+	int id = String::to_int(n.get_data(), sep);
 
 	if (!tile_map.has(id)) {
 		create_tile(id);
 	}
-	String what = n.substr(slash + 1, n.length());
+	String what = n.substr(sep + 1, n.length());
 
 	if (what == "name") {
 		tile_set_name(id, p_value);
@@ -68,7 +68,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 		if (is_autotile) {
 			tile_set_tile_mode(id, AUTO_TILE);
 		}
-	} else if (what.left(9) == "autotile/") {
+	} else if (what.left(9) == "autotile_") {
 		what = what.right(9);
 		if (what == "bitmask_mode") {
 			autotile_set_bitmask_mode(id, (BitmaskMode)((int)p_value));
@@ -210,15 +210,15 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 
 bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 	String n = p_name;
-	int slash = n.find("/");
-	if (slash == -1) {
+	int sep = n.find("_");
+	if (sep == -1) {
 		return false;
 	}
-	int id = String::to_int(n.get_data(), slash);
+	int id = String::to_int(n.get_data(), sep);
 
 	ERR_FAIL_COND_V(!tile_map.has(id), false);
 
-	String what = n.substr(slash + 1, n.length());
+	String what = n.substr(sep + 1, n.length());
 
 	if (what == "name") {
 		r_ret = tile_get_name(id);
@@ -234,7 +234,7 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = tile_get_region(id);
 	} else if (what == "tile_mode") {
 		r_ret = tile_get_tile_mode(id);
-	} else if (what.left(9) == "autotile/") {
+	} else if (what.left(9) == "autotile_") {
 		what = what.right(9);
 		if (what == "bitmask_mode") {
 			r_ret = autotile_get_bitmask_mode(id);
@@ -324,7 +324,7 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (Map<int, TileData>::Element *E = tile_map.front(); E; E = E->next()) {
 		int id = E->key();
-		String pre = itos(id) + "/";
+		String pre = itos(id) + "_";
 		p_list->push_back(PropertyInfo(Variant::STRING, pre + "name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "tex_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
@@ -333,23 +333,23 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::RECT2, pre + "region", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::INT, pre + "tile_mode", PROPERTY_HINT_ENUM, "SINGLE_TILE,AUTO_TILE,ATLAS_TILE", PROPERTY_USAGE_NOEDITOR));
 		if (tile_get_tile_mode(id) == AUTO_TILE) {
-			p_list->push_back(PropertyInfo(Variant::INT, pre + "autotile/bitmask_mode", PROPERTY_HINT_ENUM, "2X2,3X3 (minimal),3X3", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/bitmask_flags", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile/icon_coordinate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile/tile_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::INT, pre + "autotile/spacing", PROPERTY_HINT_RANGE, "0,256,1", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/occluder_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/navpoly_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/priority_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/z_index_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::INT, pre + "autotile_bitmask_mode", PROPERTY_HINT_ENUM, "2X2,3X3 (minimal),3X3", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile_bitmask_flags", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile_icon_coordinate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile_tile_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::INT, pre + "autotile_spacing", PROPERTY_HINT_RANGE, "0,256,1", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile_occluder_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile_navpoly_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile_priority_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile_z_index_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 		} else if (tile_get_tile_mode(id) == ATLAS_TILE) {
-			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile/icon_coordinate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile/tile_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::INT, pre + "autotile/spacing", PROPERTY_HINT_RANGE, "0,256,1", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/occluder_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/navpoly_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/priority_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/z_index_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile_icon_coordinate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile_tile_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::INT, pre + "autotile_spacing", PROPERTY_HINT_RANGE, "0,256,1", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile_occluder_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile_navpoly_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile_priority_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile_z_index_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 		}
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "occluder_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "occluder", PROPERTY_HINT_RESOURCE_TYPE, "OccluderPolygon2D", PROPERTY_USAGE_NOEDITOR));

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1000,8 +1000,8 @@ bool VisualShader::_set(const StringName &p_name, const Variant &p_value) {
 	if (name == "mode") {
 		set_mode(Shader::Mode(int(p_value)));
 		return true;
-	} else if (name.begins_with("flags/")) {
-		StringName flag = name.get_slicec('/', 1);
+	} else if (name.begins_with("flags_")) {
+		StringName flag = name.get_slicec('_', 1);
 		bool enable = p_value;
 		if (enable) {
 			flags.insert(flag);
@@ -1010,8 +1010,8 @@ bool VisualShader::_set(const StringName &p_name, const Variant &p_value) {
 		}
 		_queue_update();
 		return true;
-	} else if (name.begins_with("modes/")) {
-		String mode = name.get_slicec('/', 1);
+	} else if (name.begins_with("modes_")) {
+		String mode = name.get_slicec('_', 1);
 		int value = p_value;
 		if (value == 0) {
 			modes.erase(mode); //means it's default anyway, so don't store it
@@ -1020,8 +1020,8 @@ bool VisualShader::_set(const StringName &p_name, const Variant &p_value) {
 		}
 		_queue_update();
 		return true;
-	} else if (name.begins_with("nodes/")) {
-		String typestr = name.get_slicec('/', 1);
+	} else if (name.begins_with("nodes_")) {
+		String typestr = name.get_slicec('_', 1);
 		Type type = TYPE_VERTEX;
 		for (int i = 0; i < TYPE_MAX; i++) {
 			if (typestr == type_string[i]) {
@@ -1030,7 +1030,7 @@ bool VisualShader::_set(const StringName &p_name, const Variant &p_value) {
 			}
 		}
 
-		String index = name.get_slicec('/', 2);
+		String index = name.get_slicec('_', 2);
 		if (index == "connections") {
 			Vector<int> conns = p_value;
 			if (conns.size() % 4 == 0) {
@@ -1042,7 +1042,7 @@ bool VisualShader::_set(const StringName &p_name, const Variant &p_value) {
 		}
 
 		int id = index.to_int();
-		String what = name.get_slicec('/', 3);
+		String what = name.get_slicec('_', 3);
 
 		if (what == "node") {
 			add_node(type, p_value, Vector2(), id);
@@ -1072,20 +1072,20 @@ bool VisualShader::_get(const StringName &p_name, Variant &r_ret) const {
 	if (name == "mode") {
 		r_ret = get_mode();
 		return true;
-	} else if (name.begins_with("flags/")) {
-		StringName flag = name.get_slicec('/', 1);
+	} else if (name.begins_with("flags_")) {
+		StringName flag = name.get_slicec('_', 1);
 		r_ret = flags.has(flag);
 		return true;
-	} else if (name.begins_with("modes/")) {
-		String mode = name.get_slicec('/', 1);
+	} else if (name.begins_with("modes_")) {
+		String mode = name.get_slicec('_', 1);
 		if (modes.has(mode)) {
 			r_ret = modes[mode];
 		} else {
 			r_ret = 0;
 		}
 		return true;
-	} else if (name.begins_with("nodes/")) {
-		String typestr = name.get_slicec('/', 1);
+	} else if (name.begins_with("nodes_")) {
+		String typestr = name.get_slicec('_', 1);
 		Type type = TYPE_VERTEX;
 		for (int i = 0; i < TYPE_MAX; i++) {
 			if (typestr == type_string[i]) {
@@ -1094,7 +1094,7 @@ bool VisualShader::_get(const StringName &p_name, Variant &r_ret) const {
 			}
 		}
 
-		String index = name.get_slicec('/', 2);
+		String index = name.get_slicec('_', 2);
 		if (index == "connections") {
 			Vector<int> conns;
 			for (const List<Connection>::Element *E = graph[type].connections.front(); E; E = E->next()) {
@@ -1109,7 +1109,7 @@ bool VisualShader::_get(const StringName &p_name, Variant &r_ret) const {
 		}
 
 		int id = index.to_int();
-		String what = name.get_slicec('/', 3);
+		String what = name.get_slicec('_', 3);
 
 		if (what == "node") {
 			r_ret = get_node(type, id);
@@ -1172,35 +1172,37 @@ void VisualShader::_get_property_list(List<PropertyInfo> *p_list) const {
 		}
 	}
 
+	p_list->push_back(PropertyInfo(Variant::NIL, "Modes", PROPERTY_HINT_NONE, "modes_", PROPERTY_USAGE_GROUP));
 	for (Map<String, String>::Element *E = blend_mode_enums.front(); E; E = E->next()) {
-		p_list->push_back(PropertyInfo(Variant::INT, "modes/" + E->key(), PROPERTY_HINT_ENUM, E->get()));
+		p_list->push_back(PropertyInfo(Variant::INT, "modes_" + E->key(), PROPERTY_HINT_ENUM, E->get()));
 	}
 
+	p_list->push_back(PropertyInfo(Variant::NIL, "Flags", PROPERTY_HINT_NONE, "flags_", PROPERTY_USAGE_GROUP));
 	for (Set<String>::Element *E = toggles.front(); E; E = E->next()) {
-		p_list->push_back(PropertyInfo(Variant::BOOL, "flags/" + E->get()));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "flags_" + E->get()));
 	}
 
 	for (int i = 0; i < TYPE_MAX; i++) {
 		for (Map<int, Node>::Element *E = graph[i].nodes.front(); E; E = E->next()) {
-			String prop_name = "nodes/";
+			String prop_name = "nodes_";
 			prop_name += type_string[i];
-			prop_name += "/" + itos(E->key());
+			prop_name += "_" + itos(E->key());
 
 			if (E->key() != NODE_ID_OUTPUT) {
-				p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + "/node", PROPERTY_HINT_RESOURCE_TYPE, "VisualShaderNode", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE));
+				p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + "_node", PROPERTY_HINT_RESOURCE_TYPE, "VisualShaderNode", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE));
 			}
-			p_list->push_back(PropertyInfo(Variant::VECTOR2, prop_name + "/position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, prop_name + "_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 
 			if (Object::cast_to<VisualShaderNodeGroupBase>(E->get().node.ptr()) != nullptr) {
-				p_list->push_back(PropertyInfo(Variant::VECTOR2, prop_name + "/size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
-				p_list->push_back(PropertyInfo(Variant::STRING, prop_name + "/input_ports", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
-				p_list->push_back(PropertyInfo(Variant::STRING, prop_name + "/output_ports", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+				p_list->push_back(PropertyInfo(Variant::VECTOR2, prop_name + "_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+				p_list->push_back(PropertyInfo(Variant::STRING, prop_name + "_input_ports", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+				p_list->push_back(PropertyInfo(Variant::STRING, prop_name + "_output_ports", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 			}
 			if (Object::cast_to<VisualShaderNodeExpression>(E->get().node.ptr()) != nullptr) {
-				p_list->push_back(PropertyInfo(Variant::STRING, prop_name + "/expression", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+				p_list->push_back(PropertyInfo(Variant::STRING, prop_name + "_expression", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 			}
 		}
-		p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, "nodes/" + String(type_string[i]) + "/connections", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, "nodes_" + String(type_string[i]) + "_connections", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	}
 }
 

--- a/servers/audio/effects/audio_effect_chorus.cpp
+++ b/servers/audio/effects/audio_effect_chorus.cpp
@@ -273,8 +273,8 @@ float AudioEffectChorus::get_dry() const {
 }
 
 void AudioEffectChorus::_validate_property(PropertyInfo &property) const {
-	if (property.name.begins_with("voice/")) {
-		int voice_idx = property.name.get_slice("/", 1).to_int();
+	if (property.name.begins_with("voice_")) {
+		int voice_idx = property.name.get_slice("_", 1).to_int();
 		if (voice_idx > voice_count) {
 			property.usage = 0;
 		}
@@ -313,33 +313,37 @@ void AudioEffectChorus::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dry", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_dry", "get_dry");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "wet", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_wet", "get_wet");
 
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/1/delay_ms", PROPERTY_HINT_RANGE, "0,50,0.01"), "set_voice_delay_ms", "get_voice_delay_ms", 0);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/1/rate_hz", PROPERTY_HINT_RANGE, "0.1,20,0.1"), "set_voice_rate_hz", "get_voice_rate_hz", 0);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/1/depth_ms", PROPERTY_HINT_RANGE, "0,20,0.01"), "set_voice_depth_ms", "get_voice_depth_ms", 0);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/1/level_db", PROPERTY_HINT_RANGE, "-60,24,0.1"), "set_voice_level_db", "get_voice_level_db", 0);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/1/cutoff_hz", PROPERTY_HINT_RANGE, "1,20500,1"), "set_voice_cutoff_hz", "get_voice_cutoff_hz", 0);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/1/pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_voice_pan", "get_voice_pan", 0);
+	ADD_GROUP("Voice 1", "voice_1_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_1_delay_ms", PROPERTY_HINT_RANGE, "0,50,0.01"), "set_voice_delay_ms", "get_voice_delay_ms", 0);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_1_rate_hz", PROPERTY_HINT_RANGE, "0.1,20,0.1"), "set_voice_rate_hz", "get_voice_rate_hz", 0);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_1_depth_ms", PROPERTY_HINT_RANGE, "0,20,0.01"), "set_voice_depth_ms", "get_voice_depth_ms", 0);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_1_level_db", PROPERTY_HINT_RANGE, "-60,24,0.1"), "set_voice_level_db", "get_voice_level_db", 0);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_1_cutoff_hz", PROPERTY_HINT_RANGE, "1,20500,1"), "set_voice_cutoff_hz", "get_voice_cutoff_hz", 0);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_1_pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_voice_pan", "get_voice_pan", 0);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/2/delay_ms", PROPERTY_HINT_RANGE, "0,50,0.01"), "set_voice_delay_ms", "get_voice_delay_ms", 1);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/2/rate_hz", PROPERTY_HINT_RANGE, "0.1,20,0.1"), "set_voice_rate_hz", "get_voice_rate_hz", 1);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/2/depth_ms", PROPERTY_HINT_RANGE, "0,20,0.01"), "set_voice_depth_ms", "get_voice_depth_ms", 1);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/2/level_db", PROPERTY_HINT_RANGE, "-60,24,0.1"), "set_voice_level_db", "get_voice_level_db", 1);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/2/cutoff_hz", PROPERTY_HINT_RANGE, "1,20500,1"), "set_voice_cutoff_hz", "get_voice_cutoff_hz", 1);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/2/pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_voice_pan", "get_voice_pan", 1);
+	ADD_GROUP("Voice 2", "voice_2_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_2_delay_ms", PROPERTY_HINT_RANGE, "0,50,0.01"), "set_voice_delay_ms", "get_voice_delay_ms", 1);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_2_rate_hz", PROPERTY_HINT_RANGE, "0.1,20,0.1"), "set_voice_rate_hz", "get_voice_rate_hz", 1);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_2_depth_ms", PROPERTY_HINT_RANGE, "0,20,0.01"), "set_voice_depth_ms", "get_voice_depth_ms", 1);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_2_level_db", PROPERTY_HINT_RANGE, "-60,24,0.1"), "set_voice_level_db", "get_voice_level_db", 1);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_2_cutoff_hz", PROPERTY_HINT_RANGE, "1,20500,1"), "set_voice_cutoff_hz", "get_voice_cutoff_hz", 1);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_2_pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_voice_pan", "get_voice_pan", 1);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/3/delay_ms", PROPERTY_HINT_RANGE, "0,50,0.01"), "set_voice_delay_ms", "get_voice_delay_ms", 2);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/3/rate_hz", PROPERTY_HINT_RANGE, "0.1,20,0.1"), "set_voice_rate_hz", "get_voice_rate_hz", 2);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/3/depth_ms", PROPERTY_HINT_RANGE, "0,20,0.01"), "set_voice_depth_ms", "get_voice_depth_ms", 2);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/3/level_db", PROPERTY_HINT_RANGE, "-60,24,0.1"), "set_voice_level_db", "get_voice_level_db", 2);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/3/cutoff_hz", PROPERTY_HINT_RANGE, "1,20500,1"), "set_voice_cutoff_hz", "get_voice_cutoff_hz", 2);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/3/pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_voice_pan", "get_voice_pan", 2);
+	ADD_GROUP("Voice 3", "voice_3_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_3_delay_ms", PROPERTY_HINT_RANGE, "0,50,0.01"), "set_voice_delay_ms", "get_voice_delay_ms", 2);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_3_rate_hz", PROPERTY_HINT_RANGE, "0.1,20,0.1"), "set_voice_rate_hz", "get_voice_rate_hz", 2);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_3_depth_ms", PROPERTY_HINT_RANGE, "0,20,0.01"), "set_voice_depth_ms", "get_voice_depth_ms", 2);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_3_level_db", PROPERTY_HINT_RANGE, "-60,24,0.1"), "set_voice_level_db", "get_voice_level_db", 2);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_3_cutoff_hz", PROPERTY_HINT_RANGE, "1,20500,1"), "set_voice_cutoff_hz", "get_voice_cutoff_hz", 2);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_3_pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_voice_pan", "get_voice_pan", 2);
 
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/4/delay_ms", PROPERTY_HINT_RANGE, "0,50,0.01"), "set_voice_delay_ms", "get_voice_delay_ms", 3);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/4/rate_hz", PROPERTY_HINT_RANGE, "0.1,20,0.1"), "set_voice_rate_hz", "get_voice_rate_hz", 3);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/4/depth_ms", PROPERTY_HINT_RANGE, "0,20,0.01"), "set_voice_depth_ms", "get_voice_depth_ms", 3);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/4/level_db", PROPERTY_HINT_RANGE, "-60,24,0.1"), "set_voice_level_db", "get_voice_level_db", 3);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/4/cutoff_hz", PROPERTY_HINT_RANGE, "1,20500,1"), "set_voice_cutoff_hz", "get_voice_cutoff_hz", 3);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice/4/pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_voice_pan", "get_voice_pan", 3);
+	ADD_GROUP("Voice 4", "voice_4_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_4_delay_ms", PROPERTY_HINT_RANGE, "0,50,0.01"), "set_voice_delay_ms", "get_voice_delay_ms", 3);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_4_rate_hz", PROPERTY_HINT_RANGE, "0.1,20,0.1"), "set_voice_rate_hz", "get_voice_rate_hz", 3);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_4_depth_ms", PROPERTY_HINT_RANGE, "0,20,0.01"), "set_voice_depth_ms", "get_voice_depth_ms", 3);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_4_level_db", PROPERTY_HINT_RANGE, "-60,24,0.1"), "set_voice_level_db", "get_voice_level_db", 3);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_4_cutoff_hz", PROPERTY_HINT_RANGE, "1,20500,1"), "set_voice_cutoff_hz", "get_voice_cutoff_hz", 3);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "voice_4_pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_voice_pan", "get_voice_pan", 3);
 }
 
 AudioEffectChorus::AudioEffectChorus() {

--- a/servers/audio/effects/audio_effect_delay.cpp
+++ b/servers/audio/effects/audio_effect_delay.cpp
@@ -54,28 +54,25 @@ void AudioEffectDelayInstance::_process_chunk(const AudioFrame *p_src_frames, Au
 
 	float tap_1_level_f = base->tap_1_active ? Math::db2linear(base->tap_1_level) : 0.0;
 	int tap_1_delay_frames = int((base->tap_1_delay_ms / 1000.0) * mix_rate);
-	;
 
 	float tap_2_level_f = base->tap_2_active ? Math::db2linear(base->tap_2_level) : 0.0;
 	int tap_2_delay_frames = int((base->tap_2_delay_ms / 1000.0) * mix_rate);
-	;
 
 	float feedback_level_f = base->feedback_active ? Math::db2linear(base->feedback_level) : 0.0;
 	unsigned int feedback_delay_frames = int((base->feedback_delay_ms / 1000.0) * mix_rate);
-	;
 
-	AudioFrame tap1_vol = AudioFrame(tap_1_level_f, tap_1_level_f);
+	AudioFrame tap_1_vol = AudioFrame(tap_1_level_f, tap_1_level_f);
 
-	tap1_vol.l *= CLAMP(1.0 - base->tap_1_pan, 0, 1);
-	tap1_vol.r *= CLAMP(1.0 + base->tap_1_pan, 0, 1);
+	tap_1_vol.l *= CLAMP(1.0 - base->tap_1_pan, 0, 1);
+	tap_1_vol.r *= CLAMP(1.0 + base->tap_1_pan, 0, 1);
 
-	AudioFrame tap2_vol = AudioFrame(tap_2_level_f, tap_2_level_f);
+	AudioFrame tap_2_vol = AudioFrame(tap_2_level_f, tap_2_level_f);
 
-	tap2_vol.l *= CLAMP(1.0 - base->tap_2_pan, 0, 1);
-	tap2_vol.r *= CLAMP(1.0 + base->tap_2_pan, 0, 1);
+	tap_2_vol.l *= CLAMP(1.0 - base->tap_2_pan, 0, 1);
+	tap_2_vol.r *= CLAMP(1.0 + base->tap_2_pan, 0, 1);
 
-	// feedback lowpass here
-	float lpf_c = expf(-Math_TAU * base->feedback_lowpass / mix_rate); // 0 .. 10khz
+	// feedback low pass here
+	float lpf_c = expf(-Math_TAU * base->feedback_low_pass / mix_rate); // 0 .. 10khz
 	float lpf_ic = 1.0 - lpf_c;
 
 	const AudioFrame *src = p_src_frames;
@@ -87,14 +84,14 @@ void AudioEffectDelayInstance::_process_chunk(const AudioFrame *p_src_frames, Au
 		rb_buf[ring_buffer_pos & ring_buffer_mask] = src[i];
 
 		AudioFrame main_val = src[i] * main_level_f;
-		AudioFrame tap_1_val = rb_buf[(ring_buffer_pos - tap_1_delay_frames) & ring_buffer_mask] * tap1_vol;
-		AudioFrame tap_2_val = rb_buf[(ring_buffer_pos - tap_2_delay_frames) & ring_buffer_mask] * tap2_vol;
+		AudioFrame tap_1_val = rb_buf[(ring_buffer_pos - tap_1_delay_frames) & ring_buffer_mask] * tap_1_vol;
+		AudioFrame tap_2_val = rb_buf[(ring_buffer_pos - tap_2_delay_frames) & ring_buffer_mask] * tap_2_vol;
 
 		AudioFrame out = main_val + tap_1_val + tap_2_val;
 
 		out += fb_buf[feedback_buffer_pos];
 
-		//apply lowpass and feedback gain
+		//apply low pass and feedback gain
 		AudioFrame fb_in = out * feedback_level_f * lpf_ic + h * lpf_c;
 		fb_in.undenormalise(); //avoid denormals
 
@@ -105,9 +102,8 @@ void AudioEffectDelayInstance::_process_chunk(const AudioFrame *p_src_frames, Au
 
 		ring_buffer_pos++;
 
-		if ((++feedback_buffer_pos) >= feedback_delay_frames) {
+		if ((++feedback_buffer_pos) >= feedback_delay_frames)
 			feedback_buffer_pos = 0;
-		}
 	}
 }
 
@@ -151,67 +147,67 @@ float AudioEffectDelay::get_dry() {
 	return dry;
 }
 
-void AudioEffectDelay::set_tap1_active(bool p_active) {
+void AudioEffectDelay::set_tap_1_active(bool p_active) {
 	tap_1_active = p_active;
 }
 
-bool AudioEffectDelay::is_tap1_active() const {
+bool AudioEffectDelay::is_tap_1_active() const {
 	return tap_1_active;
 }
 
-void AudioEffectDelay::set_tap1_delay_ms(float p_delay_ms) {
+void AudioEffectDelay::set_tap_1_delay_ms(float p_delay_ms) {
 	tap_1_delay_ms = p_delay_ms;
 }
 
-float AudioEffectDelay::get_tap1_delay_ms() const {
+float AudioEffectDelay::get_tap_1_delay_ms() const {
 	return tap_1_delay_ms;
 }
 
-void AudioEffectDelay::set_tap1_level_db(float p_level_db) {
+void AudioEffectDelay::set_tap_1_level_db(float p_level_db) {
 	tap_1_level = p_level_db;
 }
 
-float AudioEffectDelay::get_tap1_level_db() const {
+float AudioEffectDelay::get_tap_1_level_db() const {
 	return tap_1_level;
 }
 
-void AudioEffectDelay::set_tap1_pan(float p_pan) {
+void AudioEffectDelay::set_tap_1_pan(float p_pan) {
 	tap_1_pan = p_pan;
 }
 
-float AudioEffectDelay::get_tap1_pan() const {
+float AudioEffectDelay::get_tap_1_pan() const {
 	return tap_1_pan;
 }
 
-void AudioEffectDelay::set_tap2_active(bool p_active) {
+void AudioEffectDelay::set_tap_2_active(bool p_active) {
 	tap_2_active = p_active;
 }
 
-bool AudioEffectDelay::is_tap2_active() const {
+bool AudioEffectDelay::is_tap_2_active() const {
 	return tap_2_active;
 }
 
-void AudioEffectDelay::set_tap2_delay_ms(float p_delay_ms) {
+void AudioEffectDelay::set_tap_2_delay_ms(float p_delay_ms) {
 	tap_2_delay_ms = p_delay_ms;
 }
 
-float AudioEffectDelay::get_tap2_delay_ms() const {
+float AudioEffectDelay::get_tap_2_delay_ms() const {
 	return tap_2_delay_ms;
 }
 
-void AudioEffectDelay::set_tap2_level_db(float p_level_db) {
+void AudioEffectDelay::set_tap_2_level_db(float p_level_db) {
 	tap_2_level = p_level_db;
 }
 
-float AudioEffectDelay::get_tap2_level_db() const {
+float AudioEffectDelay::get_tap_2_level_db() const {
 	return tap_2_level;
 }
 
-void AudioEffectDelay::set_tap2_pan(float p_pan) {
+void AudioEffectDelay::set_tap_2_pan(float p_pan) {
 	tap_2_pan = p_pan;
 }
 
-float AudioEffectDelay::get_tap2_pan() const {
+float AudioEffectDelay::get_tap_2_pan() const {
 	return tap_2_pan;
 }
 
@@ -239,41 +235,41 @@ float AudioEffectDelay::get_feedback_level_db() const {
 	return feedback_level;
 }
 
-void AudioEffectDelay::set_feedback_lowpass(float p_lowpass) {
-	feedback_lowpass = p_lowpass;
+void AudioEffectDelay::set_feedback_low_pass(float p_low_pass) {
+	feedback_low_pass = p_low_pass;
 }
 
-float AudioEffectDelay::get_feedback_lowpass() const {
-	return feedback_lowpass;
+float AudioEffectDelay::get_feedback_low_pass() const {
+	return feedback_low_pass;
 }
 
 void AudioEffectDelay::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_dry", "amount"), &AudioEffectDelay::set_dry);
 	ClassDB::bind_method(D_METHOD("get_dry"), &AudioEffectDelay::get_dry);
 
-	ClassDB::bind_method(D_METHOD("set_tap1_active", "amount"), &AudioEffectDelay::set_tap1_active);
-	ClassDB::bind_method(D_METHOD("is_tap1_active"), &AudioEffectDelay::is_tap1_active);
+	ClassDB::bind_method(D_METHOD("set_tap_1_active", "amount"), &AudioEffectDelay::set_tap_1_active);
+	ClassDB::bind_method(D_METHOD("is_tap_1_active"), &AudioEffectDelay::is_tap_1_active);
 
-	ClassDB::bind_method(D_METHOD("set_tap1_delay_ms", "amount"), &AudioEffectDelay::set_tap1_delay_ms);
-	ClassDB::bind_method(D_METHOD("get_tap1_delay_ms"), &AudioEffectDelay::get_tap1_delay_ms);
+	ClassDB::bind_method(D_METHOD("set_tap_1_delay_ms", "amount"), &AudioEffectDelay::set_tap_1_delay_ms);
+	ClassDB::bind_method(D_METHOD("get_tap_1_delay_ms"), &AudioEffectDelay::get_tap_1_delay_ms);
 
-	ClassDB::bind_method(D_METHOD("set_tap1_level_db", "amount"), &AudioEffectDelay::set_tap1_level_db);
-	ClassDB::bind_method(D_METHOD("get_tap1_level_db"), &AudioEffectDelay::get_tap1_level_db);
+	ClassDB::bind_method(D_METHOD("set_tap_1_level_db", "amount"), &AudioEffectDelay::set_tap_1_level_db);
+	ClassDB::bind_method(D_METHOD("get_tap_1_level_db"), &AudioEffectDelay::get_tap_1_level_db);
 
-	ClassDB::bind_method(D_METHOD("set_tap1_pan", "amount"), &AudioEffectDelay::set_tap1_pan);
-	ClassDB::bind_method(D_METHOD("get_tap1_pan"), &AudioEffectDelay::get_tap1_pan);
+	ClassDB::bind_method(D_METHOD("set_tap_1_pan", "amount"), &AudioEffectDelay::set_tap_1_pan);
+	ClassDB::bind_method(D_METHOD("get_tap_1_pan"), &AudioEffectDelay::get_tap_1_pan);
 
-	ClassDB::bind_method(D_METHOD("set_tap2_active", "amount"), &AudioEffectDelay::set_tap2_active);
-	ClassDB::bind_method(D_METHOD("is_tap2_active"), &AudioEffectDelay::is_tap2_active);
+	ClassDB::bind_method(D_METHOD("set_tap_2_active", "amount"), &AudioEffectDelay::set_tap_2_active);
+	ClassDB::bind_method(D_METHOD("is_tap_2_active"), &AudioEffectDelay::is_tap_2_active);
 
-	ClassDB::bind_method(D_METHOD("set_tap2_delay_ms", "amount"), &AudioEffectDelay::set_tap2_delay_ms);
-	ClassDB::bind_method(D_METHOD("get_tap2_delay_ms"), &AudioEffectDelay::get_tap2_delay_ms);
+	ClassDB::bind_method(D_METHOD("set_tap_2_delay_ms", "amount"), &AudioEffectDelay::set_tap_2_delay_ms);
+	ClassDB::bind_method(D_METHOD("get_tap_2_delay_ms"), &AudioEffectDelay::get_tap_2_delay_ms);
 
-	ClassDB::bind_method(D_METHOD("set_tap2_level_db", "amount"), &AudioEffectDelay::set_tap2_level_db);
-	ClassDB::bind_method(D_METHOD("get_tap2_level_db"), &AudioEffectDelay::get_tap2_level_db);
+	ClassDB::bind_method(D_METHOD("set_tap_2_level_db", "amount"), &AudioEffectDelay::set_tap_2_level_db);
+	ClassDB::bind_method(D_METHOD("get_tap_2_level_db"), &AudioEffectDelay::get_tap_2_level_db);
 
-	ClassDB::bind_method(D_METHOD("set_tap2_pan", "amount"), &AudioEffectDelay::set_tap2_pan);
-	ClassDB::bind_method(D_METHOD("get_tap2_pan"), &AudioEffectDelay::get_tap2_pan);
+	ClassDB::bind_method(D_METHOD("set_tap_2_pan", "amount"), &AudioEffectDelay::set_tap_2_pan);
+	ClassDB::bind_method(D_METHOD("get_tap_2_pan"), &AudioEffectDelay::get_tap_2_pan);
 
 	ClassDB::bind_method(D_METHOD("set_feedback_active", "amount"), &AudioEffectDelay::set_feedback_active);
 	ClassDB::bind_method(D_METHOD("is_feedback_active"), &AudioEffectDelay::is_feedback_active);
@@ -284,25 +280,26 @@ void AudioEffectDelay::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_feedback_level_db", "amount"), &AudioEffectDelay::set_feedback_level_db);
 	ClassDB::bind_method(D_METHOD("get_feedback_level_db"), &AudioEffectDelay::get_feedback_level_db);
 
-	ClassDB::bind_method(D_METHOD("set_feedback_lowpass", "amount"), &AudioEffectDelay::set_feedback_lowpass);
-	ClassDB::bind_method(D_METHOD("get_feedback_lowpass"), &AudioEffectDelay::get_feedback_lowpass);
+	ClassDB::bind_method(D_METHOD("set_feedback_low_pass", "amount"), &AudioEffectDelay::set_feedback_low_pass);
+	ClassDB::bind_method(D_METHOD("get_feedback_low_pass"), &AudioEffectDelay::get_feedback_low_pass);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dry", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_dry", "get_dry");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tap1/active"), "set_tap1_active", "is_tap1_active");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap1/delay_ms", PROPERTY_HINT_RANGE, "0,1500,1"), "set_tap1_delay_ms", "get_tap1_delay_ms");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap1/level_db", PROPERTY_HINT_RANGE, "-60,0,0.01"), "set_tap1_level_db", "get_tap1_level_db");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap1/pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_tap1_pan", "get_tap1_pan");
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tap2/active"), "set_tap2_active", "is_tap2_active");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap2/delay_ms", PROPERTY_HINT_RANGE, "0,1500,1"), "set_tap2_delay_ms", "get_tap2_delay_ms");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap2/level_db", PROPERTY_HINT_RANGE, "-60,0,0.01"), "set_tap2_level_db", "get_tap2_level_db");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap2/pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_tap2_pan", "get_tap2_pan");
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "feedback/active"), "set_feedback_active", "is_feedback_active");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "feedback/delay_ms", PROPERTY_HINT_RANGE, "0,1500,1"), "set_feedback_delay_ms", "get_feedback_delay_ms");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "feedback/level_db", PROPERTY_HINT_RANGE, "-60,0,0.01"), "set_feedback_level_db", "get_feedback_level_db");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "feedback/lowpass", PROPERTY_HINT_RANGE, "1,16000,1"), "set_feedback_lowpass", "get_feedback_lowpass");
+	ADD_GROUP("Tap 1", "tap_1_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tap_1_active"), "set_tap_1_active", "is_tap_1_active");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap_1_delay_ms", PROPERTY_HINT_RANGE, "0,1500,1"), "set_tap_1_delay_ms", "get_tap_1_delay_ms");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap_1_level_db", PROPERTY_HINT_RANGE, "-60,0,0.01"), "set_tap_1_level_db", "get_tap_1_level_db");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap_1_pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_tap_1_pan", "get_tap_1_pan");
+	ADD_GROUP("Tap 2", "tap_2_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tap_2_active"), "set_tap_2_active", "is_tap_2_active");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap_2_delay_ms", PROPERTY_HINT_RANGE, "0,1500,1"), "set_tap_2_delay_ms", "get_tap_2_delay_ms");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap_2_level_db", PROPERTY_HINT_RANGE, "-60,0,0.01"), "set_tap_2_level_db", "get_tap_2_level_db");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap_2_pan", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_tap_2_pan", "get_tap_2_pan");
+	ADD_GROUP("Feedback", "feedback_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "feedback_active"), "set_feedback_active", "is_feedback_active");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "feedback_delay_ms", PROPERTY_HINT_RANGE, "0,1500,1"), "set_feedback_delay_ms", "get_feedback_delay_ms");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "feedback_level_db", PROPERTY_HINT_RANGE, "-60,0,0.01"), "set_feedback_level_db", "get_feedback_level_db");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "feedback_low_pass", PROPERTY_HINT_RANGE, "1,16000,1"), "set_feedback_low_pass", "get_feedback_low_pass");
 }
 
 AudioEffectDelay::AudioEffectDelay() {
@@ -319,7 +316,7 @@ AudioEffectDelay::AudioEffectDelay() {
 	feedback_active = false;
 	feedback_delay_ms = 340;
 	feedback_level = -6;
-	feedback_lowpass = 16000;
+	feedback_low_pass = 16000;
 
 	dry = 1.0;
 }

--- a/servers/audio/effects/audio_effect_delay.h
+++ b/servers/audio/effects/audio_effect_delay.h
@@ -81,7 +81,7 @@ class AudioEffectDelay : public AudioEffect {
 	bool feedback_active;
 	float feedback_delay_ms;
 	float feedback_level;
-	float feedback_lowpass;
+	float feedback_low_pass;
 
 protected:
 	static void _bind_methods();
@@ -90,29 +90,29 @@ public:
 	void set_dry(float p_dry);
 	float get_dry();
 
-	void set_tap1_active(bool p_active);
-	bool is_tap1_active() const;
+	void set_tap_1_active(bool p_active);
+	bool is_tap_1_active() const;
 
-	void set_tap1_delay_ms(float p_delay_ms);
-	float get_tap1_delay_ms() const;
+	void set_tap_1_delay_ms(float p_delay_ms);
+	float get_tap_1_delay_ms() const;
 
-	void set_tap1_level_db(float p_level_db);
-	float get_tap1_level_db() const;
+	void set_tap_1_level_db(float p_level_db);
+	float get_tap_1_level_db() const;
 
-	void set_tap1_pan(float p_pan);
-	float get_tap1_pan() const;
+	void set_tap_1_pan(float p_pan);
+	float get_tap_1_pan() const;
 
-	void set_tap2_active(bool p_active);
-	bool is_tap2_active() const;
+	void set_tap_2_active(bool p_active);
+	bool is_tap_2_active() const;
 
-	void set_tap2_delay_ms(float p_delay_ms);
-	float get_tap2_delay_ms() const;
+	void set_tap_2_delay_ms(float p_delay_ms);
+	float get_tap_2_delay_ms() const;
 
-	void set_tap2_level_db(float p_level_db);
-	float get_tap2_level_db() const;
+	void set_tap_2_level_db(float p_level_db);
+	float get_tap_2_level_db() const;
 
-	void set_tap2_pan(float p_pan);
-	float get_tap2_pan() const;
+	void set_tap_2_pan(float p_pan);
+	float get_tap_2_pan() const;
 
 	void set_feedback_active(bool p_active);
 	bool is_feedback_active() const;
@@ -123,8 +123,8 @@ public:
 	void set_feedback_level_db(float p_level_db);
 	float get_feedback_level_db() const;
 
-	void set_feedback_lowpass(float p_lowpass);
-	float get_feedback_lowpass() const;
+	void set_feedback_low_pass(float p_low_pass);
+	float get_feedback_low_pass() const;
 
 	Ref<AudioEffectInstance> instance() override;
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1330,15 +1330,15 @@ AudioServer::~AudioServer() {
 
 bool AudioBusLayout::_set(const StringName &p_name, const Variant &p_value) {
 	String s = p_name;
-	if (s.begins_with("bus/")) {
-		int index = s.get_slice("/", 1).to_int();
+	if (s.begins_with("bus_")) {
+		int index = s.get_slicec('_', 1).to_int();
 		if (buses.size() <= index) {
 			buses.resize(index + 1);
 		}
 
 		Bus &bus = buses.write[index];
 
-		String what = s.get_slice("/", 2);
+		String what = s.get_slicec('_', 2);
 
 		if (what == "name") {
 			bus.name = p_value;
@@ -1353,14 +1353,14 @@ bool AudioBusLayout::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (what == "send") {
 			bus.send = p_value;
 		} else if (what == "effect") {
-			int which = s.get_slice("/", 3).to_int();
+			int which = s.get_slicec('_', 3).to_int();
 			if (bus.effects.size() <= which) {
 				bus.effects.resize(which + 1);
 			}
 
 			Bus::Effect &fx = bus.effects.write[which];
 
-			String fxwhat = s.get_slice("/", 4);
+			String fxwhat = s.get_slicec('_', 4);
 			if (fxwhat == "effect") {
 				fx.effect = p_value;
 			} else if (fxwhat == "enabled") {
@@ -1382,15 +1382,15 @@ bool AudioBusLayout::_set(const StringName &p_name, const Variant &p_value) {
 
 bool AudioBusLayout::_get(const StringName &p_name, Variant &r_ret) const {
 	String s = p_name;
-	if (s.begins_with("bus/")) {
-		int index = s.get_slice("/", 1).to_int();
+	if (s.begins_with("bus_")) {
+		int index = s.get_slicec('_', 1).to_int();
 		if (index < 0 || index >= buses.size()) {
 			return false;
 		}
 
 		const Bus &bus = buses[index];
 
-		String what = s.get_slice("/", 2);
+		String what = s.get_slicec('_', 2);
 
 		if (what == "name") {
 			r_ret = bus.name;
@@ -1405,14 +1405,14 @@ bool AudioBusLayout::_get(const StringName &p_name, Variant &r_ret) const {
 		} else if (what == "send") {
 			r_ret = bus.send;
 		} else if (what == "effect") {
-			int which = s.get_slice("/", 3).to_int();
+			int which = s.get_slicec('_', 3).to_int();
 			if (which < 0 || which >= bus.effects.size()) {
 				return false;
 			}
 
 			const Bus::Effect &fx = bus.effects[which];
 
-			String fxwhat = s.get_slice("/", 4);
+			String fxwhat = s.get_slicec('_', 4);
 			if (fxwhat == "effect") {
 				r_ret = fx.effect;
 			} else if (fxwhat == "enabled") {
@@ -1434,16 +1434,16 @@ bool AudioBusLayout::_get(const StringName &p_name, Variant &r_ret) const {
 
 void AudioBusLayout::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (int i = 0; i < buses.size(); i++) {
-		p_list->push_back(PropertyInfo(Variant::STRING, "bus/" + itos(i) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::BOOL, "bus/" + itos(i) + "/solo", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::BOOL, "bus/" + itos(i) + "/mute", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::BOOL, "bus/" + itos(i) + "/bypass_fx", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "bus/" + itos(i) + "/volume_db", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "bus/" + itos(i) + "/send", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::STRING, "bus_" + itos(i) + "_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "bus_" + itos(i) + "_solo", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "bus_" + itos(i) + "_mute", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::BOOL, "bus_" + itos(i) + "_bypass_fx", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "bus_" + itos(i) + "_volume_db", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "bus_" + itos(i) + "_send", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 
 		for (int j = 0; j < buses[i].effects.size(); j++) {
-			p_list->push_back(PropertyInfo(Variant::OBJECT, "bus/" + itos(i) + "/effect/" + itos(j) + "/effect", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::BOOL, "bus/" + itos(i) + "/effect/" + itos(j) + "/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, "bus_" + itos(i) + "_effect_" + itos(j) + "_effect", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::BOOL, "bus_" + itos(i) + "_effect_" + itos(j) + "_enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 		}
 	}
 }


### PR DESCRIPTION
As identified in #17558, there are a number of properties that are still using a slash `/` as a delimiter (Godot 2 style). Many of these properties appear in the inspector, but are difficult to access via scripts, and, in general, are not documented. However, most importantly, it's not even currently possible to create standard getters and setters for them.

This PR converts all(?) of the remaining properties that still use the old slash delimiter to use the underscore delimiter `_`, and includes updating some of the relevant documentation. It has been divided into two commits:
1. Properties that already use the `ADD_PROPERTY` macros: see https://github.com/godotengine/godot/issues/17558#issue-305898418
2. Properties that are built via code: see https://github.com/godotengine/godot/issues/17558#issuecomment-373709536

They are best reviewed separately, because they use different approaches. The first renames properties, but also sometimes renames the getters and setters and includes the necessary documentation updates. The second also involves creating the necessary groupings for the inspector and also updating the old style getters and setters.

Closes #17558.
Prerequisite for https://github.com/godotengine/godot-proposals/issues/2000 and for creating standard getters and setters for the other properties identified in https://github.com/godotengine/godot/issues/17558#issuecomment-373709536.