### PR TITLE
[3.x] Allow exporting custom resources from/to any scripting language (GDScript, VisualScript, C#, NativeScript, PluginScript)

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -40,6 +40,7 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
+#include "core/script_language.h"
 
 /**
  *  Time constants borrowed from loc_time.h
@@ -3003,6 +3004,89 @@ _ClassDB::_ClassDB() {
 }
 _ClassDB::~_ClassDB() {
 }
+///////////////////////////////
+
+bool _ScriptServer::_set(const StringName &p_name, const Variant &p_value) {
+	return false;
+}
+
+bool _ScriptServer::_get(const StringName &p_name, Variant &r_ret) const {
+	if (ScriptServer::is_global_class(p_name)) {
+		r_ret = ResourceLoader::load(ScriptServer::get_global_class_path(p_name), "Script");
+		return true;
+	}
+	return false;
+}
+
+void _ScriptServer::_get_property_list(List<PropertyInfo> *p_list) const {
+	ERR_FAIL_COND(!p_list);
+	List<StringName> names;
+	ScriptServer::get_global_class_list(&names);
+	for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
+		StringName n = E->get();
+		String class_name = String(n).get_file().get_extension();
+		p_list->push_back(PropertyInfo(Variant::OBJECT, class_name, PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_NETWORK, ResourceLoader::get_resource_type(ScriptServer::get_global_class_path(n))));
+	}
+}
+
+bool _ScriptServer::is_global_class(const StringName &p_class) const {
+	return ScriptServer::is_global_class(p_class);
+}
+
+String _ScriptServer::get_global_class_path(const String &p_class) const {
+	return ScriptServer::get_global_class_path(p_class);
+}
+
+StringName _ScriptServer::get_global_class_base(const String &p_class) const {
+	return ScriptServer::get_global_class_base(p_class);
+}
+
+StringName _ScriptServer::get_global_class_native_base(const String &p_class) const {
+	return ScriptServer::get_global_class_native_base(p_class);
+}
+
+StringName _ScriptServer::get_global_class_name(const String &p_path) const {
+	return ScriptServer::get_global_class_name(p_path);
+}
+
+Ref<Script> _ScriptServer::get_global_class_script(const StringName &p_class) const {
+	return ScriptServer::get_global_class_script(p_class);
+}
+
+Variant _ScriptServer::instantiate_global_class(const StringName &p_class) const {
+	return ScriptServer::instantiate_global_class(p_class);
+}
+
+Array _ScriptServer::get_global_class_list() const {
+	Array ret;
+	List<StringName> lst;
+	ScriptServer::get_global_class_list(&lst);
+	for (List<StringName>::Element *E = lst.front(); E; E = E->next()) {
+		ret.push_back(E->get());
+	}
+	return ret;
+}
+
+void _ScriptServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_global_class", "class"), &_ScriptServer::is_global_class);
+	ClassDB::bind_method(D_METHOD("get_global_class_path", "class"), &_ScriptServer::get_global_class_path);
+	ClassDB::bind_method(D_METHOD("get_global_class_base", "class"), &_ScriptServer::get_global_class_base);
+	ClassDB::bind_method(D_METHOD("get_global_class_native_base", "class"), &_ScriptServer::get_global_class_native_base);
+	ClassDB::bind_method(D_METHOD("get_global_class_name", "path"), &_ScriptServer::get_global_class_name);
+	ClassDB::bind_method(D_METHOD("get_global_class_script", "class"), &_ScriptServer::get_global_class_script);
+	ClassDB::bind_method(D_METHOD("instantiate_global_class", "class"), &_ScriptServer::instantiate_global_class);
+	ClassDB::bind_method(D_METHOD("get_global_class_list"), &_ScriptServer::get_global_class_list);
+}
+
+_ScriptServer::_ScriptServer() {
+	singleton = this;
+}
+
+_ScriptServer::~_ScriptServer() {
+}
+
+_ScriptServer *_ScriptServer::singleton = nullptr;
+
 ///////////////////////////////
 
 void _Engine::set_iterations_per_second(int p_ips) {

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -757,6 +757,33 @@ public:
 	~_ClassDB();
 };
 
+class _ScriptServer : public Object {
+	GDCLASS(_ScriptServer, Object);
+
+protected:
+	static void _bind_methods();
+	static _ScriptServer *singleton;
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+public:
+	static _ScriptServer *get_singleton() { return singleton; }
+
+	bool is_global_class(const StringName &p_class) const;
+	String get_global_class_path(const String &p_class) const;
+	StringName get_global_class_base(const String &p_class) const;
+	StringName get_global_class_native_base(const String &p_class) const;
+	StringName get_global_class_name(const String &p_path) const;
+	Ref<Script> get_global_class_script(const StringName &p_class) const;
+	Variant instantiate_global_class(const StringName &p_class) const;
+	Array get_global_class_list() const;
+
+	_ScriptServer();
+	~_ScriptServer();
+};
+
 class _Engine : public Object {
 	GDCLASS(_Engine, Object);
 

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -101,8 +101,14 @@ void ResourceFormatLoader::get_recognized_extensions_for_type(const String &p_ty
 }
 
 void ResourceLoader::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) {
+	StringName native = ScriptServer::is_global_class(p_type) ? ScriptServer::get_global_class_native_base(p_type) : StringName(p_type);
 	for (int i = 0; i < loader_count; i++) {
-		loader[i]->get_recognized_extensions_for_type(p_type, p_extensions);
+		Ref<ResourceFormatLoader> current = loader[i];
+		if (!current->get_script().is_null()) {
+			current->get_recognized_extensions_for_type(p_type, p_extensions);
+		} else {
+			current->get_recognized_extensions_for_type(native, p_extensions);
+		}
 	}
 }
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -69,6 +69,7 @@
 #include "core/packed_data_container.h"
 #include "core/path_remap.h"
 #include "core/project_settings.h"
+#include "core/script_language.h"
 #include "core/translation.h"
 #include "core/undo_redo.h"
 
@@ -87,6 +88,7 @@ static _Engine *_engine = nullptr;
 static _ClassDB *_classdb = nullptr;
 static _Marshalls *_marshalls = nullptr;
 static _JSON *_json = nullptr;
+static _ScriptServer *_script_server = nullptr;
 
 static IP *ip = nullptr;
 
@@ -223,6 +225,7 @@ void register_core_types() {
 	_classdb = memnew(_ClassDB);
 	_marshalls = memnew(_Marshalls);
 	_json = memnew(_JSON);
+	_script_server = memnew(_ScriptServer);
 }
 
 void register_core_settings() {
@@ -252,6 +255,7 @@ void register_core_singletons() {
 	ClassDB::register_class<_JSON>();
 	ClassDB::register_class<Expression>();
 	ClassDB::register_class<Time>();
+	ClassDB::register_class<_ScriptServer>();
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("IP", IP::get_singleton()));
@@ -267,6 +271,7 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("JSON", _JSON::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Time", Time::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ScriptServer", _ScriptServer::get_singleton()));
 }
 
 void unregister_core_types() {
@@ -277,6 +282,7 @@ void unregister_core_types() {
 	memdelete(_classdb);
 	memdelete(_marshalls);
 	memdelete(_json);
+	memdelete(_script_server);
 
 	memdelete(_geometry);
 

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -31,6 +31,7 @@
 #include "script_language.h"
 
 #include "core/core_string_names.h"
+#include "core/io/resource_loader.h"
 #include "core/project_settings.h"
 
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
@@ -200,20 +201,28 @@ void ScriptServer::thread_exit() {
 }
 
 HashMap<StringName, ScriptServer::GlobalScriptClass> ScriptServer::global_classes;
+HashMap<String, StringName> ScriptServer::global_class_paths;
 
 void ScriptServer::global_classes_clear() {
 	global_classes.clear();
+	global_class_paths.clear();
 }
 
 void ScriptServer::add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path) {
 	ERR_FAIL_COND_MSG(p_class == p_base || (global_classes.has(p_base) && get_global_class_native_base(p_base) == p_class), "Cyclic inheritance in script class.");
+	ERR_FAIL_COND_MSG(p_class == StringName(), vformat("Attempted to register global script class at path '%s' without a class name.", p_path));
+	ERR_FAIL_COND_MSG(p_base == StringName(), vformat("Attempted to register global script class at path '%s' without a base name.", p_path));
+	ERR_FAIL_COND_MSG(p_language == StringName(), vformat("Attempted to register global script class at path '%s' without a language name.", p_path));
+	ERR_FAIL_COND_MSG(p_path.empty(), vformat("Attempted to register global script class named '%s' with an empty path.", p_class));
 	GlobalScriptClass g;
 	g.language = p_language;
 	g.path = p_path;
 	g.base = p_base;
 	global_classes[p_class] = g;
+	global_class_paths[p_path] = p_class;
 }
 void ScriptServer::remove_global_class(const StringName &p_class) {
+	global_class_paths.erase(global_classes[p_class].path);
 	global_classes.erase(p_class);
 }
 bool ScriptServer::is_global_class(const StringName &p_class) {
@@ -223,23 +232,71 @@ StringName ScriptServer::get_global_class_language(const StringName &p_class) {
 	ERR_FAIL_COND_V(!global_classes.has(p_class), StringName());
 	return global_classes[p_class].language;
 }
-String ScriptServer::get_global_class_path(const String &p_class) {
+String ScriptServer::get_global_class_path(const StringName &p_class) {
 	ERR_FAIL_COND_V(!global_classes.has(p_class), String());
 	return global_classes[p_class].path;
 }
+StringName ScriptServer::get_global_class_name(const String &p_path) {
+	if (global_class_paths.has(p_path)) {
+		return global_class_paths[p_path];
+	}
+	return StringName();
+}
 
-StringName ScriptServer::get_global_class_base(const String &p_class) {
-	ERR_FAIL_COND_V(!global_classes.has(p_class), String());
+StringName ScriptServer::get_global_class_base(const StringName &p_class) {
+	ERR_FAIL_COND_V(!global_classes.has(p_class), StringName());
 	return global_classes[p_class].base;
 }
-StringName ScriptServer::get_global_class_native_base(const String &p_class) {
-	ERR_FAIL_COND_V(!global_classes.has(p_class), String());
+
+StringName ScriptServer::get_global_class_native_base(const StringName &p_class) {
+	ERR_FAIL_COND_V(!global_classes.has(p_class), StringName());
 	String base = global_classes[p_class].base;
 	while (global_classes.has(base)) {
 		base = global_classes[base].base;
 	}
 	return base;
 }
+
+Ref<Script> ScriptServer::get_global_class_script(const StringName &p_class) {
+	ERR_FAIL_COND_V_MSG(!ScriptServer::is_global_class(p_class), Ref<Script>(), vformat("Class to load '%s' is not a script class.", p_class));
+	if (!ScriptServer::is_global_class(p_class)) {
+		return Ref<Script>();
+	}
+
+	String path = ScriptServer::get_global_class_path(p_class);
+	return ResourceLoader::load(path, "Script");
+}
+
+Variant ScriptServer::instantiate_global_class(const StringName &p_class) {
+	ERR_FAIL_COND_V_MSG(!global_classes.has(p_class), Variant(), vformat("Class to instantiate '%s' is not a script class.", p_class));
+	String native = get_global_class_native_base(p_class);
+	Object *o = ClassDB::instance(native);
+	ERR_FAIL_COND_V_MSG(!o, Variant(), vformat("Could not instantiate global script class '%s'. It extends native class '%s' which is not instantiable.", p_class, native));
+
+	REF ref;
+	Reference *r = Object::cast_to<Reference>(o);
+	if (r) {
+		ref = REF(r);
+	}
+
+	Variant ret;
+	if (ref.is_valid()) {
+		ret = ref;
+	} else {
+		ret = o;
+	}
+
+	Ref<Script> s = get_global_class_script(p_class);
+	ERR_FAIL_COND_V_MSG(s.is_null(), Variant(), vformat("Failed to load global script class '%s'.", p_class));
+
+	o->set_script(s.get_ref_ptr());
+
+	ScriptInstance *si = o->get_script_instance();
+	ERR_FAIL_COND_V_MSG(!si, Variant(), vformat("Failed to create script instance for global script class '%s'.", p_class));
+
+	return ret;
+}
+
 void ScriptServer::get_global_class_list(List<StringName> *r_global_classes) {
 	const StringName *K = nullptr;
 	List<StringName> classes;

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -37,6 +37,7 @@
 #include "core/resource.h"
 
 class ScriptLanguage;
+class Script;
 
 typedef void (*ScriptEditRequestFunction)(const String &p_path);
 
@@ -59,6 +60,7 @@ class ScriptServer {
 	};
 
 	static HashMap<StringName, GlobalScriptClass> global_classes;
+	static HashMap<String, StringName> global_class_paths;
 
 public:
 	static ScriptEditRequestFunction edit_request_func;
@@ -81,9 +83,12 @@ public:
 	static void remove_global_class(const StringName &p_class);
 	static bool is_global_class(const StringName &p_class);
 	static StringName get_global_class_language(const StringName &p_class);
-	static String get_global_class_path(const String &p_class);
-	static StringName get_global_class_base(const String &p_class);
-	static StringName get_global_class_native_base(const String &p_class);
+	static String get_global_class_path(const StringName &p_class);
+	static StringName get_global_class_name(const String &p_path);
+	static StringName get_global_class_base(const StringName &p_class);
+	static StringName get_global_class_native_base(const StringName &p_class);
+	static Ref<Script> get_global_class_script(const StringName &p_class);
+	static Variant instantiate_global_class(const StringName &p_class);
 	static void get_global_class_list(List<StringName> *r_global_classes);
 	static void save_global_classes();
 
@@ -283,6 +288,7 @@ public:
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const = 0;
 	virtual Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) { return ERR_UNAVAILABLE; }
 	virtual bool overrides_external_editor() { return false; }
+	virtual bool has_delayed_script_class_metadata() const { return false; }
 
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptCodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) { return ERR_UNAVAILABLE; }
 

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -86,6 +86,9 @@
 		<member name="Time" type="Time" setter="" getter="">
 			The [Time] singleton.
 		</member>
+		<member name="ScriptServer" type="ScriptServer" setter="" getter="">
+			The [ScriptServer] singleton.
+		</member>
 		<member name="TranslationServer" type="TranslationServer" setter="" getter="">
 			The [TranslationServer] singleton.
 		</member>

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -41,6 +41,15 @@
 				[b]Warning:[/b] Removing and freeing this node will render the editor useless and may cause a crash.
 			</description>
 		</method>
+		<method name="get_class_icon">
+			<return type="Texture" />
+			<argument index="0" name="class" type="String" />
+			<argument index="1" name="fallback" type="String" />
+			<description>
+				Returns the editor icon bound to a class name or the [code]fallback[/code] class's icon if not found. The [code]fallback[/code] defaults to "Object". If still not found, returns [code]null[/code].
+				[b]Node:[/b] This includes icons from custom types (see [method EditorPlugin.add_custom_type]) and global script classes from [ScriptServer].
+			</description>
+		</method>
 		<method name="get_current_path" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -86,6 +95,15 @@
 			<description>
 				Returns the editor's [EditorInspector] instance.
 				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
+			</description>
+		</method>
+		<method name="get_object_icon">
+			<return type="Texture" />
+			<argument index="0" name="object" type="Object" />
+			<argument index="1" name="fallback" type="String" />
+			<description>
+				Returns the editor icon bound to [Object] [code]object[/code] or the class [code]fallback[/code] if a type cannot be determined. If [code]object[/code] extends [Script], then return the editor icon bound to the scripted class, not the actual script. If still not found, return [code]null[/code].
+				[b]Note:[/b] if you need the editor icon for a script such as [GDScript], use [method get_class_icon].
 			</description>
 		</method>
 		<method name="get_open_scenes" qualifiers="const">

--- a/doc/classes/ScriptServer.xml
+++ b/doc/classes/ScriptServer.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ScriptServer" inherits="Object" version="3.5">
+	<brief_description>
+		Global script class management singleton.
+	</brief_description>
+	<description>
+		ScriptServer manages all information related to global script classes in Godot projects, similar to [ClassDB] for engine classes. Scripts independently opt-in to become global classes. With it, you can check if a script has a global name or icon, what its base classes are, or even instantiate them directly.
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton through a global variable.
+	</description>
+	<tutorials>
+		<link>https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_basics.html#classes</link>
+	</tutorials>
+	<methods>
+		<method name="get_global_class_base" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="class" type="String" />
+			<description>
+				Returns the class name that the script named [code]class[/code] directly extends. This may be an engine class or another global script class.
+			</description>
+		</method>
+		<method name="get_global_class_list" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns the names of all global script class names known by the ScriptServer.
+			</description>
+		</method>
+		<method name="get_global_class_name" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="path" type="String" />
+			<description>
+				Returns the global class name bound to the [Script] at [code]path[/code].
+			</description>
+		</method>
+		<method name="get_global_class_native_base" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="class" type="String" />
+			<description>
+				Returns the native engine class that the script named [code]class[/code] eventually extends.
+			</description>
+		</method>
+		<method name="get_global_class_path" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="class" type="String" />
+			<description>
+				Returns the file path to the script resource named [code]class[/code].
+			</description>
+		</method>
+		<method name="get_global_class_script" qualifiers="const">
+			<return type="Script" />
+			<argument index="0" name="class" type="String" />
+			<description>
+				Returns the loaded [Script] named [code]class[/code].
+			</description>
+		</method>
+		<method name="instantiate_global_class" qualifiers="const">
+			<return type="Variant" />
+			<argument index="0" name="class" type="String" />
+			<description>
+				Returns a new instance of the scripted type defined by the script named [code]class[/code].
+			</description>
+		</method>
+		<method name="is_global_class" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="class" type="String" />
+			<description>
+				Returns [code]true[/code] if the name [code]class[/code] is a global script class.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -140,7 +140,6 @@ private:
 	bool _find_updated_instances(Node *p_root, Node *p_node, Set<String> &checked_paths);
 
 	HashMap<StringName, String> _script_class_icon_paths;
-	HashMap<String, StringName> _script_class_file_to_path;
 
 public:
 	EditorPlugin *get_editor(Object *p_object);
@@ -209,17 +208,15 @@ public:
 	void notify_edited_scene_changed();
 	void notify_resource_saved(const Ref<Resource> &p_resource);
 
-	bool script_class_is_parent(const String &p_class, const String &p_inherits);
-	StringName script_class_get_base(const String &p_class) const;
-	Variant script_class_instance(const String &p_class);
+	bool class_equals_or_inherits(const StringName &p_class, const StringName &p_inherits) const;
+	bool script_class_is_parent(const StringName &p_class, const StringName &p_inherits) const;
+	StringName script_class_get_base(const StringName &p_class) const;
+	Variant script_class_instance(const StringName &p_class) const;
 
-	Ref<Script> script_class_load_script(const String &p_class) const;
+	Ref<Script> script_class_get_base_from_anonymous_path(const String &p_path) const;
 
-	StringName script_class_get_name(const String &p_path) const;
-	void script_class_set_name(const String &p_path, const StringName &p_class);
-
-	String script_class_get_icon_path(const String &p_class) const;
-	void script_class_set_icon_path(const String &p_class, const String &p_icon_path);
+	String script_class_get_icon_path(const StringName &p_class) const;
+	void script_class_set_icon_path(const StringName &p_class, const String &p_icon_path);
 	void script_class_clear_icon_paths() { _script_class_icon_paths.clear(); }
 	void script_class_save_icon_paths();
 	void script_class_load_icon_paths();

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -325,6 +325,7 @@ void EditorFileSystem::_save_filesystem_cache() {
 
 void EditorFileSystem::_thread_func(void *_userdata) {
 	EditorFileSystem *sd = (EditorFileSystem *)_userdata;
+	sd->init_compiled_lang_script_class_file_cache();
 	sd->_scan_filesystem();
 }
 
@@ -1356,20 +1357,29 @@ Vector<String> EditorFileSystem::_get_dependencies(const String &p_path) {
 
 String EditorFileSystem::_get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const {
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-		if (ScriptServer::get_language(i)->handles_global_class_type(p_type)) {
-			String global_name;
-			String extends;
-			String icon_path;
-
-			global_name = ScriptServer::get_language(i)->get_global_class_name(p_path, &extends, &icon_path);
-			*r_extends = extends;
-			*r_icon_path = icon_path;
-			return global_name;
+		ScriptLanguage *lang = ScriptServer::get_language(i);
+		if (lang->handles_global_class_type(p_type)) {
+			if (lang->has_delayed_script_class_metadata() && compiled_lang_script_class_file_cache.has(p_path)) {
+				Dictionary d = compiled_lang_script_class_file_cache[p_path];
+				if (r_extends) {
+					*r_extends = d["base"].operator String();
+				}
+				if (r_icon_path) {
+					*r_icon_path = d.has("icon_path") ? d["icon_path"] : "";
+				}
+				return d["class"].operator String();
+			} else {
+				return lang->get_global_class_name(p_path, r_extends, r_icon_path);
+			}
 		}
 	}
-	*r_extends = String();
-	*r_icon_path = String();
-	return String();
+	if (r_extends) {
+		*r_extends = "";
+	}
+	if (r_icon_path) {
+		*r_icon_path = "";
+	}
+	return "";
 }
 
 void EditorFileSystem::_scan_script_classes(EditorFileSystemDirectory *p_dir) {
@@ -1388,7 +1398,6 @@ void EditorFileSystem::_scan_script_classes(EditorFileSystemDirectory *p_dir) {
 		}
 		ScriptServer::add_global_class(files[i]->script_class_name, files[i]->script_class_extends, lang, p_dir->get_file_path(i));
 		EditorNode::get_editor_data().script_class_set_icon_path(files[i]->script_class_name, files[i]->script_class_icon_path);
-		EditorNode::get_editor_data().script_class_set_name(files[i]->file, files[i]->script_class_name);
 	}
 	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
 		_scan_script_classes(p_dir->get_subdir(i));
@@ -1416,6 +1425,56 @@ void EditorFileSystem::update_script_classes() {
 	ResourceLoader::add_custom_loaders();
 	ResourceSaver::remove_custom_savers();
 	ResourceSaver::add_custom_savers();
+}
+
+void EditorFileSystem::update_file_script_class_metadata(const String &p_path, const StringName &p_name, const StringName &p_base, const StringName &p_language, const String &p_icon_path) {
+	EditorFileSystemDirectory *fs = NULL;
+	int cpos = -1;
+
+	if (!_find_file(p_path, &fs, cpos)) {
+		if (!fs)
+			return;
+	}
+	EditorFileSystemDirectory::FileInfo *fi = fs->files[cpos];
+	fi->script_class_name = p_name;
+	fi->script_class_extends = p_base;
+	fi->script_class_icon_path = p_icon_path;
+	if (p_name != StringName() && !ScriptServer::is_global_class(p_name)) {
+		ScriptServer::add_global_class(p_name, p_base, p_language, p_path);
+		EditorNode::get_editor_data().script_class_set_icon_path(p_name, p_icon_path);
+	}
+}
+
+void EditorFileSystem::init_compiled_lang_script_class_file_cache() {
+	if (compiled_lang_script_class_file_cache.empty() && ProjectSettings::get_singleton()->has_setting("_global_script_classes")) {
+		Array script_classes = ProjectSettings::get_singleton()->get_setting("_global_script_classes");
+		Dictionary script_class_icons = ProjectSettings::get_singleton()->get_setting("_global_script_class_icons");
+		Set<StringName> compiled_language_names;
+		for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+			ScriptLanguage *lang = ScriptServer::get_language(i);
+			if (lang->has_delayed_script_class_metadata()) {
+				String n = lang->get_name();
+				compiled_language_names.insert(n);
+			}
+		}
+		for (int i = 0; i < script_classes.size(); i++) {
+			Dictionary d = script_classes[i];
+			StringName c = d["class"];
+			String p = d["path"];
+			StringName lg = d["language"];
+			if (compiled_language_names.has(lg)) {
+				String ip = script_class_icons[c];
+				d["icon_path"] = ip;
+				compiled_lang_script_class_file_cache[p] = d;
+			}
+		}
+	}
+}
+
+void EditorFileSystem::remove_compiled_lang_script_class_file_cache(const String &p_file) {
+	if (compiled_lang_script_class_file_cache.has(p_file)) {
+		compiled_lang_script_class_file_cache.erase(p_file);
+	}
 }
 
 void EditorFileSystem::_queue_update_script_classes() {

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -159,6 +159,8 @@ class EditorFileSystem : public Node {
 
 	void _save_late_updated_files();
 
+	HashMap<String, Dictionary> compiled_lang_script_class_file_cache; // keep track of script classes from compiled languages
+
 	EditorFileSystemDirectory *filesystem;
 
 	static EditorFileSystem *singleton;
@@ -234,8 +236,8 @@ class EditorFileSystem : public Node {
 	void _scan_script_classes(EditorFileSystemDirectory *p_dir);
 	SafeFlag update_script_classes_queued;
 	void _queue_update_script_classes();
-
-	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const;
+	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends = nullptr, String *r_icon_path = nullptr) const;
+	//String _get_global_class_name(String p_path, String *p_base = nullptr, String *p_icon_path = nullptr);
 
 	static Error _resource_import(const String &p_path);
 
@@ -270,6 +272,9 @@ public:
 	void reimport_files(const Vector<String> &p_files);
 
 	void update_script_classes();
+	void update_file_script_class_metadata(const String &p_path, const StringName &p_name, const StringName &p_base, const StringName &p_language, const String &p_icon_path);
+	void remove_compiled_lang_script_class_file_cache(const String &p_file);
+	void init_compiled_lang_script_class_file_cache();
 
 	bool is_group_file(const String &p_path) const;
 	void move_group_file(const String &p_path, const String &p_new_path);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3876,9 +3876,9 @@ Ref<Script> EditorNode::get_object_custom_type_base(const Object *p_object) cons
 		// 	return name;
 
 		// should probably be deprecated in 4.x
-		StringName base = script->get_instance_base_type();
-		if (base != StringName() && EditorNode::get_editor_data().get_custom_types().has(base)) {
-			const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[base];
+		StringName native = script->get_instance_base_type();
+		if (native != StringName() && EditorNode::get_editor_data().get_custom_types().has(native)) {
+			const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[native];
 
 			Ref<Script> base_script = script;
 			while (base_script.is_valid()) {
@@ -3906,7 +3906,7 @@ StringName EditorNode::get_object_custom_type_name(const Object *p_object) const
 	if (script.is_valid()) {
 		Ref<Script> base_script = script;
 		while (base_script.is_valid()) {
-			StringName name = EditorNode::get_editor_data().script_class_get_name(base_script->get_path());
+			StringName name = ScriptServer::get_global_class_name(base_script->get_path());
 			if (name != StringName()) {
 				return name;
 			}
@@ -3972,7 +3972,7 @@ Ref<Texture> EditorNode::get_object_icon(const Object *p_object, const String &p
 	if (script.is_valid()) {
 		Ref<Script> base_script = script;
 		while (base_script.is_valid()) {
-			StringName name = EditorNode::get_editor_data().script_class_get_name(base_script->get_path());
+			StringName name = ScriptServer::get_global_class_name(base_script->get_path());
 			String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
 			Ref<ImageTexture> icon = _load_custom_class_icon(icon_path);
 			if (icon.is_valid()) {
@@ -4012,14 +4012,15 @@ Ref<Texture> EditorNode::get_object_icon(const Object *p_object, const String &p
 Ref<Texture> EditorNode::get_class_icon(const String &p_class, const String &p_fallback) const {
 	ERR_FAIL_COND_V_MSG(p_class.empty(), nullptr, "Class name cannot be empty.");
 
+	EditorData &ed = get_editor_data();
 	if (ScriptServer::is_global_class(p_class)) {
 		Ref<ImageTexture> icon;
-		Ref<Script> script = EditorNode::get_editor_data().script_class_load_script(p_class);
+		Ref<Script> script = ScriptServer::get_global_class_script(p_class);
 		StringName name = p_class;
 
 		while (script.is_valid()) {
-			name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
-			String current_icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
+			name = ScriptServer::get_global_class_name(script->get_path());
+			String current_icon_path = ed.script_class_get_icon_path(name);
 			icon = _load_custom_class_icon(current_icon_path);
 			if (icon.is_valid()) {
 				return icon;
@@ -4034,7 +4035,7 @@ Ref<Texture> EditorNode::get_class_icon(const String &p_class, const String &p_f
 		return icon;
 	}
 
-	const Map<String, Vector<EditorData::CustomType>> &p_map = EditorNode::get_editor_data().get_custom_types();
+	const Map<String, Vector<EditorData::CustomType>> &p_map = ed.get_custom_types();
 	for (const Map<String, Vector<EditorData::CustomType>>::Element *E = p_map.front(); E; E = E->next()) {
 		const Vector<EditorData::CustomType> &ct = E->value();
 		for (int i = 0; i < ct.size(); ++i) {

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -313,6 +313,14 @@ bool EditorInterface::is_distraction_free_mode_enabled() const {
 	return EditorNode::get_singleton()->is_distraction_free_mode_enabled();
 }
 
+Ref<Texture> EditorInterface::get_class_icon(const String &p_class, const String &p_fallback) {
+	return EditorNode::get_singleton()->get_class_icon(p_class, p_fallback);
+}
+
+Ref<Texture> EditorInterface::get_object_icon(const Object *p_object, const String &p_fallback) {
+	return EditorNode::get_singleton()->get_object_icon(p_object, p_fallback);
+}
+
 void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("inspect_object", "object", "for_property", "inspector_only"), &EditorInterface::inspect_object, DEFVAL(String()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
@@ -353,6 +361,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
 	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);
 	ClassDB::bind_method(D_METHOD("is_distraction_free_mode_enabled"), &EditorInterface::is_distraction_free_mode_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_class_icon", "class", "fallback"), &EditorInterface::get_class_icon);
+	ClassDB::bind_method(D_METHOD("get_object_icon", "object", "fallback"), &EditorInterface::get_object_icon);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
 }

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -117,6 +117,9 @@ public:
 	void set_distraction_free_mode(bool p_enter);
 	bool is_distraction_free_mode_enabled() const;
 
+	Ref<Texture> get_class_icon(const String &p_name, const String &p_fallback);
+	Ref<Texture> get_object_icon(const Object *p_object, const String &p_fallback);
+
 	EditorInterface();
 };
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2979,13 +2979,14 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			EditorPropertyResource *editor = memnew(EditorPropertyResource);
 			editor->setup(p_object, p_path, p_hint == PROPERTY_HINT_RESOURCE_TYPE ? p_hint_text : "Resource");
 
+			EditorData &ed = EditorNode::get_editor_data();
 			if (p_hint == PROPERTY_HINT_RESOURCE_TYPE) {
 				String open_in_new = EDITOR_GET("interface/inspector/resources_to_open_in_new_inspector");
 				for (int i = 0; i < open_in_new.get_slice_count(","); i++) {
 					String type = open_in_new.get_slicec(',', i).strip_edges();
 					for (int j = 0; j < p_hint_text.get_slice_count(","); j++) {
 						String inherits = p_hint_text.get_slicec(',', j);
-						if (ClassDB::is_parent_class(inherits, type)) {
+						if (ed.class_equals_or_inherits(inherits, type)) {
 							editor->set_use_sub_inspector(false);
 						}
 					}

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -569,6 +569,7 @@ class EditorPropertyResource : public EditorProperty {
 	bool _can_use_sub_inspector(const RES &p_resource);
 	void _open_editor_pressed();
 	void _fold_other_editors(Object *p_self);
+
 	void _update_property_bg();
 
 protected:

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -60,7 +60,15 @@ void EditorResourcePicker::_update_resource() {
 			assign_button->set_text(edited_resource->get_path().get_file());
 			assign_button->set_tooltip(edited_resource->get_path());
 		} else {
-			assign_button->set_text(edited_resource->get_class());
+			String class_name = edited_resource->get_class();
+			Ref<Script> res_script = edited_resource->get_script();
+			if (res_script.is_valid()) {
+				String script_name = ScriptServer::get_global_class_name(res_script->get_path());
+				if (!script_name.empty()) {
+					class_name = script_name;
+				}
+			}
+			assign_button->set_text(class_name);
 		}
 
 		if (edited_resource->get_path().is_resource_file()) {
@@ -118,9 +126,19 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 	if (base_type != "") {
 		bool any_type_matches = false;
 
+		StringName res_type = loaded_resource->get_class();
+		Ref<Script> res_script = loaded_resource->get_script();
+		if (res_script.is_valid()) {
+			StringName script_type = ScriptServer::get_global_class_name(res_script->get_path());
+			if (script_type != StringName()) {
+				res_type = script_type;
+			}
+		}
+
 		for (int i = 0; i < base_type.get_slice_count(","); i++) {
 			String base = base_type.get_slice(",", i);
-			if (loaded_resource->is_class(base)) {
+
+			if (EditorNode::get_editor_data().class_equals_or_inherits(res_type, base)) {
 				any_type_matches = true;
 				break;
 			}
@@ -185,7 +203,9 @@ void EditorResourcePicker::_update_menu_items() {
 			paste_valid = true;
 		} else {
 			for (int i = 0; i < base_type.get_slice_count(","); i++) {
-				if (ClassDB::class_exists(cb->get_class()) && ClassDB::is_parent_class(cb->get_class(), base_type.get_slice(",", i))) {
+				StringName script_name = ScriptServer::get_global_class_name(cb->get_path());
+				StringName class_name = script_name != StringName() ? script_name : StringName(cb->get_class());
+				if (EditorNode::get_editor_data().class_equals_or_inherits(class_name, base_type.get_slice(",", i))) {
 					paste_valid = true;
 					break;
 				}
@@ -213,12 +233,7 @@ void EditorResourcePicker::_update_menu_items() {
 		}
 		for (int i = 0; i < conversions.size(); i++) {
 			String what = conversions[i]->converts_to();
-			Ref<Texture> icon;
-			if (has_icon(what, "EditorIcons")) {
-				icon = get_icon(what, "EditorIcons");
-			} else {
-				icon = get_icon(what, "Resource");
-			}
+			Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(what, Resource::get_class_static());
 
 			edit_menu->add_icon_item(icon, vformat(TTR("Convert to %s"), what), CONVERT_BASE_ID + i);
 		}
@@ -296,10 +311,20 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 				propvalues.push_back(p);
 			}
 
-			String orig_type = edited_resource->get_class();
-			Object *inst = ClassDB::instance(orig_type);
-			Ref<Resource> unique_resource = Ref<Resource>(Object::cast_to<Resource>(inst));
-			ERR_FAIL_COND(unique_resource.is_null());
+			Ref<Resource> inst;
+			Ref<Script> res_script = edited_resource->get_script();
+			if (res_script.is_valid()) {
+				StringName script_name = ScriptServer::get_global_class_name(res_script->get_path());
+				if (ScriptServer::is_global_class(script_name)) {
+					inst = ScriptServer::instantiate_global_class(script_name);
+				}
+			}
+			if (inst.is_null()) {
+				inst = ClassDB::instance(edited_resource->get_class());
+			}
+			ERR_FAIL_COND_MSG(inst.is_null(), "Failed to instantiate resource during Make Unique.");
+			Ref<Resource> unique_resource = Ref<Resource>(inst);
+			ERR_FAIL_COND_MSG(unique_resource.is_null(), "Failed to copy resource reference during Make Unique.");
 
 			for (List<Pair<String, Variant>>::Element *E = propvalues.front(); E; E = E->next()) {
 				Pair<String, Variant> &p = E->get();
@@ -360,13 +385,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			Variant obj;
 
 			if (ScriptServer::is_global_class(intype)) {
-				obj = ClassDB::instance(ScriptServer::get_global_class_native_base(intype));
-				if (obj) {
-					Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(intype));
-					if (script.is_valid()) {
-						((Object *)obj)->set_script(script.get_ref_ptr());
-					}
-				}
+				obj = ScriptServer::instantiate_global_class(intype);
 			} else {
 				obj = ClassDB::instance(intype);
 			}
@@ -637,14 +656,18 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 			for (Set<String>::Element *E = allowed_types.front(); E; E = E->next()) {
 				String at = E->get().strip_edges();
 
-				if (at == "SpatialMaterial" && ClassDB::is_parent_class(dropped_resource->get_class(), "Texture")) {
+				EditorData &ed = EditorNode::get_editor_data();
+				StringName script_name = ScriptServer::get_global_class_name(dropped_resource->get_path());
+				String class_name = script_name != StringName() ? script_name : StringName(dropped_resource->get_class());
+
+				if (at == "SpatialMaterial" && ed.class_equals_or_inherits(class_name, "Texture")) {
 					Ref<SpatialMaterial> mat = memnew(SpatialMaterial);
 					mat->set_texture(SpatialMaterial::TextureParam::TEXTURE_ALBEDO, dropped_resource);
 					dropped_resource = mat;
 					break;
 				}
 
-				if (at == "ShaderMaterial" && ClassDB::is_parent_class(dropped_resource->get_class(), "Shader")) {
+				if (at == "ShaderMaterial" && ed.class_equals_or_inherits(class_name, "Shader")) {
 					Ref<ShaderMaterial> mat = memnew(ShaderMaterial);
 					mat->set_shader(dropped_resource);
 					dropped_resource = mat;

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1257,7 +1257,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 
 	Ref<Script> root_script = nullptr;
 	if (ScriptServer::is_global_class(root_type)) {
-		root_script = ResourceLoader::load(ScriptServer::get_global_class_path(root_type));
+		root_script = ScriptServer::get_global_class_script(root_type);
 		root_type = ScriptServer::get_global_class_base(root_type);
 	}
 

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -117,6 +117,7 @@ class SceneTreeDock : public VBoxContainer {
 	ToolButton *button_add;
 	ToolButton *button_instance;
 	ToolButton *button_create_script;
+	ToolButton *button_extend_script;
 	ToolButton *button_detach_script;
 
 	Button *button_2d;

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -208,15 +208,17 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		Color accent = get_color("accent_color", "Editor");
 
 		Ref<Script> script = p_node->get_script();
-		if (!script.is_null() && EditorNode::get_singleton()->get_object_custom_type_base(p_node) != script) {
+		if (script.is_valid() &&
+				ScriptServer::get_global_class_name(script->get_path()) == StringName() &&
+				EditorNode::get_singleton()->get_object_custom_type_base(p_node) != script) {
 			//has script
 			item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT);
 		} else {
-			//has no script (or script is a custom type)
+			//has no script (or script is a custom type / script class)
 			item->set_custom_color(0, get_color("disabled_font_color", "Editor"));
 			item->set_selectable(0, false);
 
-			if (!script.is_null()) { // make sure to mark the script if a custom type
+			if (script.is_valid()) { // make sure to mark the script if a custom type or script class
 				item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT);
 				item->set_button_disabled(0, item->get_button_count(0) - 1, true);
 			}
@@ -333,7 +335,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		Ref<Script> script = p_node->get_script();
 		if (!script.is_null()) {
 			item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT, false, TTR("Open Script:") + " " + script->get_path());
-			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == script) {
+			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == script ||
+					ScriptServer::get_global_class_name(script->get_path()) != StringName()) {
 				item->set_button_color(0, item->get_button_count(0) - 1, Color(1, 1, 1, 0.5));
 			}
 		}

--- a/modules/gdnative/include/pluginscript/godot_pluginscript.h
+++ b/modules/gdnative/include/pluginscript/godot_pluginscript.h
@@ -131,6 +131,7 @@ typedef struct {
 	const char **string_delimiters; // NULL terminated array
 	godot_bool has_named_classes;
 	godot_bool supports_builtin_mode;
+	godot_bool has_delayed_script_class_metadata;
 
 	godot_string (*get_template_source_code)(godot_pluginscript_language_data *p_data, const godot_string *p_class_name, const godot_string *p_base_class_name);
 	godot_bool (*validate)(godot_pluginscript_language_data *p_data, const godot_string *p_script, int *r_line_error, int *r_col_error, godot_string *r_test_error, const godot_string *p_path, godot_pool_string_array *r_functions);

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -146,6 +146,10 @@ bool PluginScriptLanguage::supports_builtin_mode() const {
 	return _desc.supports_builtin_mode;
 }
 
+bool PluginScriptLanguage::has_delayed_script_class_metadata() const {
+	return _desc.has_delayed_script_class_metadata;
+}
+
 int PluginScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 	if (_desc.find_function) {
 		return _desc.find_function(_data, (godot_string *)&p_function, (godot_string *)&p_code);

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -80,6 +80,7 @@ public:
 	virtual bool has_named_classes() const;
 	virtual bool supports_builtin_mode() const;
 	virtual bool can_inherit_from_file() { return true; }
+	virtual bool has_delayed_script_class_metadata() const;
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptCodeCompletionOption> *r_options, bool &r_force, String &r_call_hint);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4630,19 +4630,41 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 						Variant constant = static_cast<ConstantNode *>(subexpr)->value;
 
 						if (constant.get_type() == Variant::OBJECT) {
+							StringName class_name;
 							GDScriptNativeClass *native_class = Object::cast_to<GDScriptNativeClass>(constant);
 
-							if (native_class && ClassDB::is_parent_class(native_class->get_name(), "Resource")) {
+							if (native_class) {
+								if (ClassDB::is_parent_class(native_class->get_name(), "Resource")) {
+									class_name = native_class->get_name();
+								} else {
+									current_export = PropertyInfo();
+									_set_error("The export hint isn't a resource type.");
+								}
+							} else {
+								Ref<Script> res_script = constant;
+								StringName script_class;
+								if (res_script.is_valid()) {
+									script_class = res_script->get_language()->get_global_class_name(res_script->get_path());
+
+									if (ClassDB::is_parent_class(ScriptServer::get_global_class_native_base(script_class), "Resource")) {
+										class_name = script_class;
+									} else {
+										current_export = PropertyInfo();
+										_set_error("The exported script does not extend Resource.");
+									}
+								} else {
+									current_export = PropertyInfo();
+									_set_error("The exported script isn't a script class.");
+								}
+							}
+
+							if (class_name != StringName()) {
 								current_export.type = Variant::OBJECT;
 								current_export.hint = PROPERTY_HINT_RESOURCE_TYPE;
 								current_export.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
 
-								current_export.hint_string = native_class->get_name();
-								current_export.class_name = native_class->get_name();
-
-							} else {
-								current_export = PropertyInfo();
-								_set_error("The export hint isn't a resource type.");
+								current_export.hint_string = class_name;
+								current_export.class_name = class_name;
 							}
 						} else if (constant.get_type() == Variant::DICTIONARY) {
 							// Enumeration
@@ -4926,12 +4948,42 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 							member._export.hint_string = member.data_type.native_type;
 							member._export.class_name = member.data_type.native_type;
 						} else {
-							_set_error("Invalid export type. Only built-in and native resource types can be exported.", member.line);
+							_set_error(vformat("Invalid native export type. \"%s\" is not a Resource type.", member.data_type.native_type), member.line);
 							return;
 						}
+					} else if (member.data_type.kind == DataType::SCRIPT || member.data_type.kind == DataType::GDSCRIPT) {
+						if (member.data_type.script_type.is_null()) {
+							_set_error("Invalid script export type. Could not load member script value.", member.line);
+							return;
+						}
+						Ref<Script> s = member.data_type.script_type;
+						StringName class_name = s->get_language()->get_global_class_name(s->get_path());
+						if (class_name == StringName()) {
+							_set_error("Invalid script export type. The member is a script that has no global script class name.", member.line);
+							return;
+						}
+						if (!ClassDB::is_parent_class(ScriptServer::get_global_class_native_base(class_name), "Resource")) {
+							_set_error("Invalid script export type. The member is a script class that does not extend a Resource type.", member.line);
+							return;
+						}
+						member._export.type = Variant::OBJECT;
+						member._export.hint = PROPERTY_HINT_RESOURCE_TYPE;
+						member._export.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
+						member._export.hint_string = class_name;
+						member._export.class_name = class_name;
 
+					} else if (member.data_type.kind == DataType::UNRESOLVED && ScriptServer::is_global_class(member.data_type.native_type)) {
+						StringName class_name = member.data_type.native_type;
+						if (ClassDB::is_parent_class(ScriptServer::get_global_class_native_base(class_name), "Resource")) {
+							member._export.type = Variant::OBJECT;
+							member._export.hint = PROPERTY_HINT_RESOURCE_TYPE;
+							member._export.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
+							member._export.hint_string = class_name;
+							member._export.class_name = class_name;
+						}
+#undef SETUP_SCRIPT_EXPORT
 					} else {
-						_set_error("Invalid export type. Only built-in and native resource types can be exported.", member.line);
+						_set_error("Invalid export type. Only built-in types and native or script class Resource types can be exported.", member.line);
 						return;
 					}
 				}
@@ -6013,7 +6065,22 @@ GDScriptParser::DataType GDScriptParser::_type_from_property(const PropertyInfo 
 	ret.builtin_type = p_property.type;
 	if (p_property.type == Variant::OBJECT) {
 		ret.kind = DataType::NATIVE;
-		ret.native_type = p_property.class_name == StringName() ? "Object" : p_property.class_name;
+		ret.native_type = "Object";
+		if (p_property.class_name != StringName()) {
+			if (ScriptServer::is_global_class(p_property.class_name)) {
+				String p = ScriptServer::get_global_class_path(p_property.class_name);
+				ret.native_type = ScriptServer::get_global_class_native_base(p_property.class_name);
+				if (GDScriptLanguage::get_singleton()->get_extension() == p.get_extension()) {
+					ret.kind = DataType::GDSCRIPT;
+					ret.script_type = ResourceLoader::load(p, "GDScript");
+				} else {
+					ret.kind = DataType::SCRIPT;
+					ret.script_type = ResourceLoader::load(p, "Script");
+				}
+			} else {
+				ret.native_type = p_property.class_name;
+			}
+		}
 	} else {
 		ret.kind = DataType::BUILTIN;
 	}
@@ -7916,13 +7983,25 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 		}
 
 		// Check export hint
-		if (v.data_type.has_type && v._export.type != Variant::NIL) {
+		if (v._export.type != Variant::NIL) {
 			DataType export_type = _type_from_property(v._export);
-			if (!_is_type_compatible(v.data_type, export_type, true)) {
-				_set_error("The export hint's type (" + export_type.to_string() + ") doesn't match the variable's type (" +
-								v.data_type.to_string() + ").",
-						v.line);
-				return;
+
+			if (export_type.kind == DataType::GDSCRIPT || export_type.kind == DataType::SCRIPT) {
+				String class_name = v._export.class_name;
+				if (ScriptServer::is_global_class(class_name)) {
+					class_name = ScriptServer::get_global_class_native_base(class_name);
+				}
+				if (!ClassDB::is_parent_class(class_name, "Resource")) {
+					_set_error(vformat("Exported script-defined type (%s) must inherit from Resource.", export_type.to_string()), v.line);
+					return;
+				}
+			}
+
+			if (v.data_type.has_type) {
+				if (!_is_type_compatible(v.data_type, export_type, true)) {
+					_set_error(vformat("The export hint's type (%s) doesn't match the variable's type (%s).", export_type.to_string(), v.data_type.to_string()), v.line);
+					return;
+				}
 			}
 		}
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -103,6 +103,11 @@ class CSharpScript : public Script {
 	String source;
 	StringName name;
 
+	// For engine "Script Class" support, not affiliated with `GDMonoClass *script_class` property.
+	String script_class_name;
+	String script_class_base;
+	String script_class_icon_path;
+
 	SelfList<CSharpScript> script_list;
 
 	struct Argument {
@@ -140,7 +145,7 @@ class CSharpScript : public Script {
 
 	bool _get_member_export(IMonoClassMember *p_member, bool p_inspect_export, PropertyInfo &r_prop_info, bool &r_exported);
 #ifdef TOOLS_ENABLED
-	static int _try_get_member_export_hint(IMonoClassMember *p_member, ManagedType p_type, Variant::Type p_variant_type, bool p_allow_generics, PropertyHint &r_hint, String &r_hint_string);
+	static int _try_get_member_export_hint(IMonoClassMember *p_member, ManagedType p_type, Variant::Type p_variant_type, PropertyHint p_given_hint, String p_given_hint_string, bool p_allow_generics, PropertyHint &r_hint, String &r_hint_string);
 #endif
 
 	CSharpInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_isref, Variant::CallError &r_error);
@@ -201,6 +206,11 @@ public:
 #endif
 
 	Error load_source_code(const String &p_path);
+
+	String get_script_class_name() const { return script_class_name; }
+	String get_script_class_base() const { return script_class_base; }
+	String get_script_class_icon_path() const { return script_class_icon_path; }
+	void _update_global_script_class_settings();
 
 	StringName get_script_name() const;
 
@@ -419,6 +429,11 @@ public:
 	virtual String _get_indentation() const;
 	/* TODO? */ virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const {}
 	/* TODO */ virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) {}
+	virtual bool has_delayed_script_class_metadata() const override { return true; }
+
+	/* SCRIPT CLASS FUNCTIONS */
+	virtual bool handles_global_class_type(const String &p_type) const;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL, String *r_icon_path = NULL) const;
 
 	/* DEBUGGER FUNCTIONS */
 	virtual String debug_get_error() const;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
@@ -13,5 +13,20 @@ namespace Godot
             this.hint = hint;
             this.hintString = hintString;
         }
+
+        public ExportAttribute(string className)
+        {
+            if (ClassDB.ClassExists(className) || ScriptServer.IsGlobalClass(className))
+            {
+                this.hint = PropertyHint.ResourceType;
+                this.hintString = className;
+            }
+            else
+            {
+                this.hint = PropertyHint.None;
+                this.hintString = "";
+            }
+        }
+
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Godot
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class GlobalAttribute : Attribute
+    {
+        private string name;
+        private string iconPath;
+
+        public GlobalAttribute(string name = "", string iconPath = "")
+        {
+            this.name = name;
+            this.iconPath = iconPath;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -15,6 +15,7 @@
     <Compile Include="Core\AABB.cs" />
     <Compile Include="Core\Array.cs" />
     <Compile Include="Core\Attributes\ExportAttribute.cs" />
+    <Compile Include="Core\Attributes\GlobalAttribute.cs" />
     <Compile Include="Core\Attributes\GodotMethodAttribute.cs" />
     <Compile Include="Core\Attributes\RPCAttributes.cs" />
     <Compile Include="Core\Attributes\SignalAttribute.cs" />

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -132,6 +132,9 @@ void CachedData::clear_godot_api_cache() {
 	class_ExportAttribute = NULL;
 	field_ExportAttribute_hint = NULL;
 	field_ExportAttribute_hintString = NULL;
+	class_GlobalAttribute = NULL;
+	field_GlobalAttribute_name = NULL;
+	field_GlobalAttribute_iconPath = NULL;
 	class_SignalAttribute = NULL;
 	class_ToolAttribute = NULL;
 	class_RemoteAttribute = NULL;
@@ -247,6 +250,9 @@ void update_godot_api_cache() {
 	CACHE_CLASS_AND_CHECK(ExportAttribute, GODOT_API_CLASS(ExportAttribute));
 	CACHE_FIELD_AND_CHECK(ExportAttribute, hint, CACHED_CLASS(ExportAttribute)->get_field("hint"));
 	CACHE_FIELD_AND_CHECK(ExportAttribute, hintString, CACHED_CLASS(ExportAttribute)->get_field("hintString"));
+	CACHE_CLASS_AND_CHECK(GlobalAttribute, GODOT_API_CLASS(GlobalAttribute));
+	CACHE_FIELD_AND_CHECK(GlobalAttribute, name, CACHED_CLASS(GlobalAttribute)->get_field("name"));
+	CACHE_FIELD_AND_CHECK(GlobalAttribute, iconPath, CACHED_CLASS(GlobalAttribute)->get_field("iconPath"));
 	CACHE_CLASS_AND_CHECK(SignalAttribute, GODOT_API_CLASS(SignalAttribute));
 	CACHE_CLASS_AND_CHECK(ToolAttribute, GODOT_API_CLASS(ToolAttribute));
 	CACHE_CLASS_AND_CHECK(RemoteAttribute, GODOT_API_CLASS(RemoteAttribute));

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -103,6 +103,9 @@ struct CachedData {
 	GDMonoClass *class_ExportAttribute;
 	GDMonoField *field_ExportAttribute_hint;
 	GDMonoField *field_ExportAttribute_hintString;
+	GDMonoClass *class_GlobalAttribute;
+	GDMonoField *field_GlobalAttribute_name;
+	GDMonoField *field_GlobalAttribute_iconPath;
 	GDMonoClass *class_SignalAttribute;
 	GDMonoClass *class_ToolAttribute;
 	GDMonoClass *class_RemoteAttribute;

--- a/modules/visual_script/doc_classes/VisualScript.xml
+++ b/modules/visual_script/doc_classes/VisualScript.xml
@@ -165,6 +165,18 @@
 				Returns a node's position in pixels.
 			</description>
 		</method>
+		<method name="get_script_class_icon_path">
+			<return type="String" />
+			<description>
+				Returns this [VisualScript]'s global class icon path provided to the [ScriptServer].
+			</description>
+		</method>
+		<method name="get_script_class_name">
+			<return type="String" />
+			<description>
+				Returns this [VisualScript]'s global class name provided to the [ScriptServer].
+			</description>
+		</method>
 		<method name="get_variable_default_value" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="name" type="String" />
@@ -332,6 +344,20 @@
 			<argument index="2" name="position" type="Vector2" />
 			<description>
 				Position a node on the screen.
+			</description>
+		</method>
+		<method name="set_script_class_icon_path">
+			<return type="void" />
+			<argument index="0" name="script_class_icon_path" type="String" />
+			<description>
+				Assigns the global class icon path that this [VisualScript] provides to the [ScriptServer].
+			</description>
+		</method>
+		<method name="set_script_class_name">
+			<return type="void" />
+			<argument index="0" name="script_class_name" type="String" />
+			<description>
+				Assigns the global class name that this [VisualScript] provides to the [ScriptServer].
 			</description>
 		</method>
 		<method name="set_variable_default_value">

--- a/modules/visual_script/doc_classes/VisualScriptScriptClass.xml
+++ b/modules/visual_script/doc_classes/VisualScriptScriptClass.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisualScriptScriptClass" inherits="VisualScriptNode" version="3.5">
+	<brief_description>
+		Gets a global script class resource.
+	</brief_description>
+	<description>
+		This node returns a global script class with a given name. See the [ScriptServer] class for more information.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="script_class" type="Script" setter="set_script_class" getter="get_script_class">
+			The global script class resource.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -67,6 +67,7 @@ void register_visual_script_types() {
 	ClassDB::register_class<VisualScriptClassConstant>();
 	ClassDB::register_class<VisualScriptMathConstant>();
 	ClassDB::register_class<VisualScriptBasicTypeConstant>();
+	ClassDB::register_class<VisualScriptScriptClass>();
 	ClassDB::register_class<VisualScriptEngineSingleton>();
 	ClassDB::register_class<VisualScriptSceneNode>();
 	ClassDB::register_class<VisualScriptSceneTree>();

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1112,6 +1112,13 @@ void VisualScript::_set_data(const Dictionary &p_data) {
 		}
 	}
 
+	if (d.has("script_class_name")) {
+		script_class_name = d["script_class_name"];
+	}
+	if (d.has("script_class_icon_path")) {
+		script_class_icon_path = d["script_class_icon_path"];
+	}
+
 	if (d.has("is_tool_script")) {
 		is_tool_script = d["is_tool_script"];
 	} else {
@@ -1194,7 +1201,33 @@ Dictionary VisualScript::_get_data() const {
 	d["is_tool_script"] = is_tool_script;
 	d["vs_unify"] = true;
 
+	if (ScriptServer::is_global_class(script_class_name)) {
+		d["script_class_name"] = script_class_name;
+		d["script_class_icon_path"] = script_class_icon_path;
+	} else {
+		d["script_class_name"] = "";
+		d["script_class_icon_path"] = "";
+	}
+
 	return d;
+}
+
+String VisualScript::get_script_class_name() {
+	return script_class_name;
+}
+
+String VisualScript::get_script_class_icon_path() {
+	return script_class_icon_path;
+}
+
+void VisualScript::set_script_class_name(const String &p_name) {
+	if (p_name.is_valid_identifier()) {
+		script_class_name = p_name;
+	}
+}
+
+void VisualScript::set_script_class_icon_path(const String &p_path) {
+	script_class_icon_path = p_path;
 }
 
 void VisualScript::_bind_methods() {
@@ -1255,6 +1288,11 @@ void VisualScript::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &VisualScript::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &VisualScript::_get_data);
+
+	ClassDB::bind_method(D_METHOD("set_script_class_name", "script_class_name"), &VisualScript::set_script_class_name);
+	ClassDB::bind_method(D_METHOD("get_script_class_name"), &VisualScript::get_script_class_name);
+	ClassDB::bind_method(D_METHOD("set_script_class_icon_path", "script_class_icon_path"), &VisualScript::set_script_class_icon_path);
+	ClassDB::bind_method(D_METHOD("get_script_class_icon_path"), &VisualScript::get_script_class_icon_path);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 
@@ -2304,6 +2342,27 @@ Error VisualScriptLanguage::execute_file(const String &p_path) {
 	return OK;
 }
 void VisualScriptLanguage::finish() {
+}
+
+bool VisualScriptLanguage::handles_global_class_type(const String &p_type) const {
+	return p_type == "VisualScript";
+}
+
+String VisualScriptLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const {
+	Ref<VisualScript> script = ResourceLoader::load(p_path, "VisualScript");
+	if (script.is_null()) {
+		if (r_base_type)
+			*r_base_type = String();
+		if (r_icon_path)
+			*r_icon_path = String();
+		return String();
+	}
+
+	if (r_base_type)
+		*r_base_type = script->get_instance_base_type();
+	if (r_icon_path)
+		*r_icon_path = script->get_script_class_icon_path();
+	return script->get_script_class_name().is_valid_identifier() ? script->get_script_class_name() : "";
 }
 
 /* EDITOR FUNCTIONS */

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -241,6 +241,8 @@ private:
 	Map<Object *, VisualScriptInstance *> instances;
 
 	bool is_tool_script;
+	String script_class_name;
+	String script_class_icon_path;
 
 #ifdef TOOLS_ENABLED
 	Set<PlaceHolderScriptInstance *> placeholders;
@@ -359,6 +361,11 @@ public:
 #ifdef TOOLS_ENABLED
 	virtual bool are_subnodes_edited() const;
 #endif
+
+	String get_script_class_name();
+	String get_script_class_icon_path();
+	void set_script_class_name(const String &p_name);
+	void set_script_class_icon_path(const String &p_path);
 
 	VisualScript();
 	~VisualScript();
@@ -555,6 +562,9 @@ public:
 	virtual String get_extension() const;
 	virtual Error execute_file(const String &p_path);
 	virtual void finish();
+
+	virtual bool handles_global_class_type(const String &p_type) const;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL, String *r_icon_path = NULL) const;
 
 	/* EDITOR FUNCTIONS */
 	virtual void get_reserved_words(List<String> *p_words) const;

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -34,6 +34,7 @@
 #include "editor/create_dialog.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/property_editor.h"
+#include "scene/gui/file_dialog.h"
 #include "scene/gui/graph_edit.h"
 #include "visual_script.h"
 #include "visual_script_property_selector.h"
@@ -172,6 +173,10 @@ class VisualScriptEditor : public ScriptEditorBase {
 	Vector2 port_action_pos;
 	int port_action_new_node;
 
+	LineEdit *_script_class_name_edit;
+	Button *_script_class_icon_btn;
+	FileDialog *_script_class_icon_path_dialog;
+
 	bool saved_pos_dirty;
 	Vector2 saved_position;
 
@@ -202,6 +207,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 	void _toggle_tool_script();
 	void _member_selected();
 	void _member_edited();
+	void _script_class_icon_btn_gui_input(Ref<InputEvent> p_event);
 
 	void _begin_node_move();
 	void _end_node_move();
@@ -287,6 +293,12 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	void _member_rmb_selected(const Vector2 &p_pos);
 	void _member_option(int p_option);
+
+	void _script_class_icon_path_dialog_confirmed();
+	void _script_class_icon_path_dialog_file_selected(const String &p_path);
+	void _script_class_icon_btn_set_icon(const String &p_path);
+	void _script_class_name_text_changed(const String &p_text);
+	void _script_class_icon_path_text_changed(const String &p_text);
 
 protected:
 	void _notification(int p_what);

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2153,6 +2153,118 @@ VisualScriptMathConstant::VisualScriptMathConstant() {
 }
 
 //////////////////////////////////////////
+////////////////SCRIPTCLASS///////////////
+//////////////////////////////////////////
+
+int VisualScriptScriptClass::get_output_sequence_port_count() const {
+	return 0;
+}
+
+bool VisualScriptScriptClass::has_input_sequence_port() const {
+	return false;
+}
+
+int VisualScriptScriptClass::get_input_value_port_count() const {
+	return 0;
+}
+int VisualScriptScriptClass::get_output_value_port_count() const {
+	return 1;
+}
+
+String VisualScriptScriptClass::get_output_sequence_port_text(int p_port) const {
+	return String();
+}
+
+PropertyInfo VisualScriptScriptClass::get_input_value_port_info(int p_idx) const {
+	return PropertyInfo();
+}
+
+PropertyInfo VisualScriptScriptClass::get_output_value_port_info(int p_idx) const {
+	if (ScriptServer::is_global_class(script_class)) {
+		Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(script_class), "Script");
+		return PropertyInfo(Variant::OBJECT, script_class, PROPERTY_HINT_RESOURCE_TYPE, script->get_class(), PROPERTY_USAGE_DEFAULT, script->get_class());
+	}
+	return PropertyInfo(Variant::OBJECT, script_class, PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT, "Script");
+}
+
+String VisualScriptScriptClass::get_caption() const {
+	return "Script Class";
+}
+
+void VisualScriptScriptClass::set_script_class(const String &p_name) {
+	ERR_FAIL_COND(!ScriptServer::is_global_class(p_name));
+	script_class = p_name;
+	_change_notify();
+	ports_changed_notify();
+}
+
+const String &VisualScriptScriptClass::get_script_class() const {
+	return script_class;
+}
+
+class VisualScriptNodeInstanceScriptClass : public VisualScriptNodeInstance {
+public:
+	Ref<Script> script;
+
+	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Variant::CallError &r_error, String &r_error_str) {
+		*p_outputs[0] = script;
+		return OK;
+	}
+};
+
+VisualScriptNodeInstance *VisualScriptScriptClass::instance(VisualScriptInstance *p_instance) {
+	VisualScriptNodeInstanceScriptClass *instance = memnew(VisualScriptNodeInstanceScriptClass);
+	instance->script = script_class != StringName() ? ResourceLoader::load(ScriptServer::get_global_class_path(script_class), "Script") : RES();
+	return instance;
+}
+
+bool VisualScriptScriptClass::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "script_class") {
+		set_script_class(p_value);
+		return true;
+	}
+	return false;
+}
+
+bool VisualScriptScriptClass::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "script_class") {
+		r_ret = get_script_class();
+		return true;
+	}
+	return false;
+}
+
+void VisualScriptScriptClass::_get_property_list(List<PropertyInfo> *p_list) const {
+	String cc;
+
+	List<StringName> lst;
+	ScriptServer::get_global_class_list(&lst);
+	int i = 0;
+	for (List<StringName>::Element *E = lst.front(); E; E = E->next()) {
+		if (i > 0)
+			cc += ",";
+		i++;
+		cc += E->get();
+	}
+	p_list->push_back(PropertyInfo(Variant::STRING, "script_class", PROPERTY_HINT_ENUM, cc));
+}
+
+void VisualScriptScriptClass::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_script_class", "name"), &VisualScriptScriptClass::set_script_class);
+	ClassDB::bind_method(D_METHOD("get_script_class"), &VisualScriptScriptClass::get_script_class);
+}
+
+VisualScriptScriptClass::VisualScriptScriptClass() {
+	List<StringName> lst;
+	ScriptServer::get_global_class_list(&lst);
+	script_class = "";
+	if (lst.size()) {
+		StringName name = lst.front()->get();
+		script_class = name;
+	}
+}
+
+//////////////////////////////////////////
 ////////////////ENGINESINGLETON///////////
 //////////////////////////////////////////
 
@@ -3831,6 +3943,7 @@ void register_visual_script_nodes() {
 	VisualScriptLanguage::singleton->add_register_func("constants/class_constant", create_node_generic<VisualScriptClassConstant>);
 	VisualScriptLanguage::singleton->add_register_func("constants/global_constant", create_node_generic<VisualScriptGlobalConstant>);
 	VisualScriptLanguage::singleton->add_register_func("constants/basic_type_constant", create_node_generic<VisualScriptBasicTypeConstant>);
+	VisualScriptLanguage::singleton->add_register_func("constants/script_class", create_node_generic<VisualScriptScriptClass>);
 
 	VisualScriptLanguage::singleton->add_register_func("custom/custom_node", create_node_generic<VisualScriptCustomNode>);
 	VisualScriptLanguage::singleton->add_register_func("custom/sub_call", create_node_generic<VisualScriptSubCall>);

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -587,6 +587,41 @@ public:
 
 VARIANT_ENUM_CAST(VisualScriptMathConstant::MathConstant)
 
+class VisualScriptScriptClass : public VisualScriptNode {
+	GDCLASS(VisualScriptScriptClass, VisualScriptNode);
+
+	String script_class;
+
+protected:
+	static void _bind_methods();
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+public:
+	virtual int get_output_sequence_port_count() const;
+	virtual bool has_input_sequence_port() const;
+
+	virtual String get_output_sequence_port_text(int p_port) const;
+
+	virtual int get_input_value_port_count() const;
+	virtual int get_output_value_port_count() const;
+
+	virtual PropertyInfo get_input_value_port_info(int p_idx) const;
+	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
+
+	virtual String get_caption() const;
+	virtual String get_category() const { return "constants"; }
+
+	void set_script_class(const String &p_name);
+	const String &get_script_class() const;
+
+	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
+
+	VisualScriptScriptClass();
+};
+
 class VisualScriptEngineSingleton : public VisualScriptNode {
 	GDCLASS(VisualScriptEngineSingleton, VisualScriptNode);
 


### PR DESCRIPTION
This PR adds the ability to export custom resources and arrays of custom resources of any language's type *from* an exported property defined in any language.

Closes godotengine/godot-proposals#18, at least, in Godot 3.2.

~~This builds on top of the commit in #44796, so that would have to be merged first.~~ This now includes the PR content of #44796 as of the 3.x rebase. For a detailed breakdown of the features commit-by-commit, see the 4.0 version at #48201.

This is a continuation of work started by me and @JFonS and would replace his 3.2 PR which deals exclusively with GDScript (#41264).

It includes editor changes to support script classes as valid resource exports.

Because the definition of PropertyInfo objects is manual in VisualScript, NativeScript, and PluginScript, the feature works out-of-the-box for those languages.

GDScript support was already implemented by JFonS's PR, but I've incorporated those changes and more.

C# support is added as well. The `[Export]` attribute now supports the following forms...

```cs
// Infer hint and hint string (no changes)
[Export]

// Manually define hint and hint string. Only applies if valid hint cannot be calculated (no changes).
[Export(PropertyHint.None, "")]

// Applies custom resource name if applicable to the member's data type (new!).
// Only necessary when exporting a Resource or List<Resource> for a non-C# resource type.
[Export("ClassName")]
```

Demo Project:
[Demo_GP22_3_2_Resources.zip](https://github.com/godotengine/godot/files/5760748/Demo_GP22_3_2_Resources.zip)

Screenshots:

GDScript usage, exported properties contracted:
![contracted_resources_gd_usage](https://user-images.githubusercontent.com/16217563/103464545-2159cb80-4cfa-11eb-8c22-e126ab81df31.png)

GDScript usage, exported properties expanded:
![expanded_resources_gd_usage](https://user-images.githubusercontent.com/16217563/103464551-2c146080-4cfa-11eb-8f69-8938eabfc8f7.png)

Note I also have `export var gd_data: GDData` syntax supported as well (so you can infer the export type from the GDScript type hint).

C# usage doing the same thing:
![csharp_export_resources_gdlist](https://user-images.githubusercontent.com/16217563/103464559-3a627c80-4cfa-11eb-96ee-06cda26c2549.png)
