### PR TITLE
Set editor drag cursor texture to pan icon on Windows

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5756,6 +5756,11 @@ EditorNode::EditorNode() {
 	// Exporters might need the theme
 	theme = create_custom_theme();
 
+#ifdef WINDOWS_ENABLED
+	// Windows has no built-in DRAG cursor, so the editor pan icon is using to emulating it.
+	DisplayServer::get_singleton()->cursor_set_custom_image(theme->get_icon("ToolPan", "EditorIcons"), DisplayServer::CURSOR_DRAG);
+#endif
+
 	register_exporters();
 
 	GLOBAL_DEF("editor/main_run_args", "");


### PR DESCRIPTION
The WIN32 platform lacks a DRAG cursor, and ARROW used by default so I think it's not a bad idea to set it up to pan mode icon instead. 

![pan_icon2](https://user-images.githubusercontent.com/3036176/103474430-ca64fc80-4db4-11eb-91f8-764430261be0.gif)

Note: I've added this for the editor only, I guess on the apps users may implement it custom themself.