### PR TITLE
Clarify that duplicate only copies exported members and fails with a constructor

### DIFF
--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -25,7 +25,8 @@
 			<argument index="0" name="subresources" type="bool" default="false">
 			</argument>
 			<description>
-				Duplicates the resource, returning a new resource. By default, sub-resources are shared between resource copies for efficiency. This can be changed by passing [code]true[/code] to the [code]subresources[/code] argument which will copy the subresources.
+				Duplicates the resource, returning a new resource with the exported members copied. [b]Note:[/b] To duplicate the resource the constructor is called without arguments. This method will error when the constructor doesn't have default values.
+				By default, sub-resources are shared between resource copies for efficiency. This can be changed by passing [code]true[/code] to the [code]subresources[/code] argument which will copy the subresources.
 				[b]Note:[/b] If [code]subresources[/code] is [code]true[/code], this method will only perform a shallow copy. Nested resources within subresources will not be duplicated and will still be shared.
 			</description>
 		</method>


### PR DESCRIPTION
These are some quirks about `Resource.duplicate` I wish I knew before I used it. If one or both of these behaviors are a bug, I'll modify the PR and open an issue.

I can't decide what the most helpful and informative sentence is, so here are some I came up with:

More concise, but also vague about if it works with default values:

> Fails if the constructor has parameters without default values.

Probably more helpful, but long (this is what the PR uses):

> Copies correctly if there is no constructor or the constructor has default values, otherwise it fails.
