### PR TITLE
[4.0] Fix shader editor documentation link

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -339,7 +339,7 @@ void ShaderEditor::_menu_option(int p_option) {
 			shader_editor->remove_all_bookmarks();
 		} break;
 		case HELP_DOCS: {
-			OS::get_singleton()->shell_open("https://docs.godotengine.org/en/stable/tutorials/shading/shading_reference/index.html");
+			OS::get_singleton()->shell_open("https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/index.html");
 		} break;
 	}
 	if (p_option != SEARCH_FIND && p_option != SEARCH_REPLACE && p_option != SEARCH_GOTO_LINE) {


### PR DESCRIPTION
The current latest reference is: https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/index.html while 3.2 version points to https://docs.godotengine.org/en/stable/tutorials/shading/shading_reference/index.html
Currently, the proposed link is invalid because `latest` should be transformed to `current`, but if we do not change the old one prior to release then users will go to an invalid page and this will be considered as a 4.0 release bug.