### PR TITLE
Don't emit changed signal on Color Picker close

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2144,10 +2144,6 @@ void EditorPropertyColor::_color_changed(const Color &p_color) {
 	emit_changed(get_edited_property(), p_color, "", true);
 }
 
-void EditorPropertyColor::_popup_closed() {
-	emit_changed(get_edited_property(), picker->get_pick_color(), "", false);
-}
-
 void EditorPropertyColor::_picker_created() {
 	// get default color picker mode from editor settings
 	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
@@ -2191,7 +2187,6 @@ EditorPropertyColor::EditorPropertyColor() {
 	add_child(picker);
 	picker->set_flat(true);
 	picker->connect("color_changed", callable_mp(this, &EditorPropertyColor::_color_changed));
-	picker->connect("popup_closed", callable_mp(this, &EditorPropertyColor::_popup_closed));
 	picker->connect("picker_created", callable_mp(this, &EditorPropertyColor::_picker_created));
 }
 

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -547,7 +547,6 @@ class EditorPropertyColor : public EditorProperty {
 	GDCLASS(EditorPropertyColor, EditorProperty);
 	ColorPickerButton *picker;
 	void _color_changed(const Color &p_color);
-	void _popup_closed();
 	void _picker_created();
 
 protected:


### PR DESCRIPTION
I just noticed that #40879 is still not fixed (although I'm pretty sure I tested the PR). The culprit was the `_popup_closed` method in EditorPropertyColor. It emitted the modified signal every time the color picker popup was closed, which is just dumb. Even if it was necessary for something, looks like `_color_changed()` is called anyways when the popup is closed, which resulted in double `set` calls when the color was modified:
![0I71fE10Ih](https://user-images.githubusercontent.com/2223172/103484545-e76af100-4def-11eb-8659-dea707239f81.gif)

btw I inspected the `_color_changed()` call on close and it seems to be called with a slightly different color. Dunno what is it, maybe ColorPicker doesn't set proper RGB value and it's corrected (rounded?) on close.