### PR TITLE
Preliminary Blender FBX support [3.2]

### DIFF
--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -134,26 +134,6 @@ MeshInstance *FBXMeshData::create_fbx_mesh(const ImportState &state, const FBXDo
 			&collect_all,
 			HashMap<int, Vector3>());
 
-	//	List<int> keys;
-	//	normals.get_key_list(&keys);
-	//
-	//	const std::vector<Assimp::FBX::MeshGeometry::Edge>& edges = mesh_geometry->get_edge_map();
-	//	for (int index = 0; index < keys.size(); index++) {
-	//		const int key = keys[index];
-	//		const int v1 = edges[key].vertex_0;
-	//		const int v2 = edges[key].vertex_1;
-	//		const Vector3& n1 = normals.get(v1);
-	//		const Vector3& n2 = normals.get(v2);
-	//		print_verbose("[" + itos(v1) + "] n1: " + n1 + "\n[" + itos(v2) + "] n2: " + n2);
-	//		//print_verbose("[" + itos(key) + "] n1: " + n1 + ", n2: " + n2) ;
-	//		//print_verbose("vindex: " + itos(edges[key].vertex_0) + ", vindex2: " + itos(edges[key].vertex_1));
-	//		//Vector3 ver1 = vertices[edges[key].vertex_0];
-	//		//Vector3 ver2 = vertices[edges[key].vertex_1];
-	//		/*real_t angle1 = Math::rad2deg(n1.angle_to(n2));
-	//		real_t angle2 = Math::rad2deg(n2.angle_to(n1));
-	//		print_verbose("angle of normals: " + rtos(angle1) + " angle 2" + rtos(angle2));*/
-	//	}
-
 	HashMap<int, Vector2> uvs_0;
 	HashMap<int, HashMap<int, Vector2> > uvs_0_raw = extract_per_vertex_data(
 			vertices.size(),
@@ -370,6 +350,9 @@ MeshInstance *FBXMeshData::create_fbx_mesh(const ImportState &state, const FBXDo
 						normals_ptr[vertex]);
 			}
 
+			if (state.is_blender_fbx) {
+				morph_st->generate_normals();
+			}
 			morph_st->generate_tangents();
 			surface->morphs.push_back(morph_st->commit_to_arrays());
 		}
@@ -392,6 +375,9 @@ MeshInstance *FBXMeshData::create_fbx_mesh(const ImportState &state, const FBXDo
 	for (const SurfaceId *surface_id = surfaces.next(nullptr); surface_id != nullptr; surface_id = surfaces.next(surface_id)) {
 		SurfaceData *surface = surfaces.getptr(*surface_id);
 
+		if (state.is_blender_fbx) {
+			surface->surface_tool->generate_normals();
+		}
 		// you can't generate them without a valid uv map.
 		if (uvs_0_raw.size() > 0) {
 			surface->surface_tool->generate_tangents();
@@ -790,7 +776,7 @@ void FBXMeshData::add_vertex(
 
 	ERR_FAIL_INDEX_MSG(p_vertex, (Vertex)p_vertices_position.size(), "FBX file is corrupted, the position of the vertex can't be retrieved.");
 
-	if (p_normals.has(p_vertex)) {
+	if (p_normals.has(p_vertex) && !state.is_blender_fbx) {
 		p_surface_tool->add_normal(p_normals[p_vertex] + p_morph_normal);
 	}
 

--- a/modules/fbx/data/import_state.h
+++ b/modules/fbx/data/import_state.h
@@ -64,6 +64,7 @@ struct FBXSkeleton;
 struct ImportState {
 	bool enable_material_import = true;
 	bool enable_animation_import = true;
+	bool is_blender_fbx = false;
 
 	Map<StringName, Ref<Texture> > cached_image_searches;
 	Map<uint64_t, Ref<SpatialMaterial> > cached_materials;

--- a/modules/fbx/editor_scene_importer_fbx.h
+++ b/modules/fbx/editor_scene_importer_fbx.h
@@ -115,7 +115,9 @@ private:
 
 	Spatial *_generate_scene(const String &p_path, const FBXDocParser::Document *p_document,
 			const uint32_t p_flags,
-			int p_bake_fps, const int32_t p_max_bone_weights);
+			int p_bake_fps,
+			const int32_t p_max_bone_weights,
+			bool p_is_blender_fbx);
 
 	template <class T>
 	T _interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, float p_time, AssetImportAnimation::Interpolation p_interp);


### PR DESCRIPTION
I'm working on blender support and some users have requested this be enabled for 3.2.x.

- always has to use generated normal's 
- some animations won't be compatible (yet)

This is working towards getting this issue tracker fully resolved:
#44402 


4.0 PR is here, made separately so that it's definitely merged into 3.2 as its very important to community: 
- https://github.com/godotengine/godot/pull/44900