### PR TITLE
Remove memory leak in Canvas Group

### DIFF
--- a/scene/2d/canvas_group.cpp
+++ b/scene/2d/canvas_group.cpp
@@ -84,4 +84,5 @@ CanvasGroup::CanvasGroup() {
 	set_fit_margin(10.0); //sets things
 }
 CanvasGroup::~CanvasGroup() {
+	RS::get_singleton()->canvas_item_set_canvas_group_mode(get_canvas_item(), RS::CANVAS_GROUP_MODE_DISABLED);
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/44045

Actually this only fixes second leak, because first leak is already fixed
