### PR TITLE
Fixed hover highlight style rect of items being cut off.

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -72,9 +72,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 		}
 
 		size.width += items[i].text_buf->get_size().x;
-		if (i > 0) {
-			size.height += vseparation;
-		}
+		size.height += vseparation;
 
 		if (items[i].accel || (items[i].shortcut.is_valid() && items[i].shortcut->is_valid())) {
 			int accel_w = hseparation * 2;
@@ -152,9 +150,7 @@ int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
 	}
 
 	for (int i = 0; i < items.size(); i++) {
-		if (i > 0) {
-			ofs.y += vseparation;
-		}
+		ofs.y += i > 0 ? vseparation : (float)vseparation / 2;
 
 		ofs.y += MAX(items[i].get_icon_size().height, items[i].text_buf->get_size().y);
 
@@ -506,10 +502,8 @@ void PopupMenu::_draw_items() {
 
 	// Loop through all items and draw each.
 	for (int i = 0; i < items.size(); i++) {
-		// If not the first item, add the separation space between items.
-		if (i > 0) {
-			ofs.y += vseparation;
-		}
+		// For the first item only add half a separation. For all other items, add a whole separation to the offset.
+		ofs.y += i > 0 ? vseparation : (float)vseparation / 2;
 
 		_shape_item(i);
 
@@ -519,9 +513,9 @@ void PopupMenu::_draw_items() {
 
 		if (i == mouse_over) {
 			if (rtl) {
-				hover->draw(ci, Rect2(item_ofs + Point2(-hseparation + scroll_width, -vseparation / 2), Size2(display_width + hseparation * 2, h + vseparation)));
+				hover->draw(ci, Rect2(item_ofs + Point2(scroll_width, -vseparation / 2), Size2(display_width, h + vseparation)));
 			} else {
-				hover->draw(ci, Rect2(item_ofs + Point2(-hseparation, -vseparation / 2), Size2(display_width + hseparation * 2, h + vseparation)));
+				hover->draw(ci, Rect2(item_ofs + Point2(0, -vseparation / 2), Size2(display_width, h + vseparation)));
 			}
 		}
 


### PR DESCRIPTION
This was caused by an incorrect calculation of the height of each item when determining the minimum size, plus a few things which were leftover after the PopupMenu rework.

Fixes item 2 from #44894.

Not only was the hover rect cut off at the sides, but on the first item the top was cut off, and the last item the bottom was cut off. These are all fixed in this PR.
![image](https://user-images.githubusercontent.com/41730826/103515889-45b0d600-4ebb-11eb-9f89-8133405df977.png)
