### PR TITLE
Fixed PopupMenu not matching parent MenuButton/OptionButton width

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1636,7 +1636,6 @@ void PopupMenu::_bind_methods() {
 void PopupMenu::popup(const Rect2 &p_bounds) {
 	moved = Vector2();
 	popup_time_msec = OS::get_singleton()->get_ticks_msec();
-	set_as_minsize();
 	Popup::popup(p_bounds);
 }
 


### PR DESCRIPTION
Fixes item 3 from #44894.

PopupMenu width matches parent button width (e.g. MenuButton).