### PR TITLE
Fix odd newline in `EditorLog::add_message()`

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -101,8 +101,6 @@ void EditorLog::copy() {
 }
 
 void EditorLog::add_message(const String &p_msg, MessageType p_type) {
-	log->add_newline();
-
 	bool restore = p_type != MSG_TYPE_STD;
 	switch (p_type) {
 		case MSG_TYPE_STD: {
@@ -128,6 +126,7 @@ void EditorLog::add_message(const String &p_msg, MessageType p_type) {
 	}
 
 	log->add_text(p_msg);
+	log->add_newline();
 
 	if (restore) {
 		log->pop();


### PR DESCRIPTION
```gdscript
print("line")
print("another line")
```

Before:
```rtf
\n
line\n
another line
```

After:
```rtf
line\n
another line\n
```