### PR TITLE
Prevent crash upon clicking on member panel button (VisualScript Editor)

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1397,6 +1397,9 @@ void VisualScriptEditor::_deselect_input_names() {
 
 void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_button) {
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
+	if (!ti) {
+		return;
+	}
 
 	TreeItem *root = members->get_root();
 


### PR DESCRIPTION
I detected this crash while using recording software (ScreenToGif) on overlay upon Godot - if its window has focus and you click any of these buttons:
![image](https://user-images.githubusercontent.com/3036176/103567025-18245680-4ed4-11eb-81f2-1664f51224ee.png) the editor will crash. After this fix, it will not crash but the user still needs to focus Godot editor window (and press again).
