### PR TITLE
Remove Unnecessary Double List

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -587,10 +587,7 @@ void _OS::print_resources_by_type(const Vector<String> &p_types) {
 	List<Ref<Resource>> resources;
 	ResourceCache::get_cached_resources(&resources);
 
-	List<Ref<Resource>> rsrc;
-	ResourceCache::get_cached_resources(&rsrc);
-
-	for (List<Ref<Resource>>::Element *E = rsrc.front(); E; E = E->next()) {
+	for (List<Ref<Resource>>::Element *E = resources.front(); E; E = E->next()) {
 		Ref<Resource> r = E->get();
 
 		bool found = false;


### PR DESCRIPTION
`_OS::print_resources_by_type` had two of the exact same list, both created in the exact same way, one of which was never used.
