### PR TITLE
[Doc] Specify order of drawing of Nodes in raise() description

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -590,7 +590,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Moves this node to the bottom of parent node's children hierarchy. This is often useful in GUIs ([Control] nodes), because their order of drawing depends on their order in the tree, i.e. the further they are on the node list, the higher they are drawn. After using [code]raise[/code], a Control will be drawn on top of their siblings.
+				Moves this node to the bottom of parent node's children hierarchy. This is often useful in GUIs ([Control] nodes), because their order of drawing depends on their order in the tree. The top Node is drawn first, then any siblings below the top Node in the hierarchy are successively drawn on top of it. After using [code]raise[/code], a Control will be drawn on top of its siblings.
 			</description>
 		</method>
 		<method name="remove_and_skip">


### PR DESCRIPTION
Clarifies the order of drawing of sibling nodes in `raise` description.

Closes godotengine/godot-docs#4514

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
