### PR TITLE
Properly edit the instanced node in the inspector

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -228,6 +228,7 @@ void SceneTreeDock::_perform_instance_scenes(const Vector<String> &p_files, Node
 	}
 
 	editor_data->get_undo_redo().commit_action();
+	editor->push_item(instances[instances.size() - 1]);
 }
 
 void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *base) {


### PR DESCRIPTION
Fixes #43761

I confirmed that #32908 was the culprit. That PR removed some duplicate calls, which incidentally were the ones that also edited the instanced node. My fix just edits the node explicitly.