### PR TITLE
Revert "solved ctrl + alt + special character Issue #6851"

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -584,7 +584,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 			if (handled) {
 				accept_event();
-			} else if (!k->get_command() || (k->get_command() && k->get_alt())) {
+			} else if (!k->get_command()) {
 				if (k->get_unicode() >= 32 && k->get_keycode() != KEY_DELETE) {
 					if (editable) {
 						selection_delete();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3619,7 +3619,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			return;
 		}
 
-		if (!keycode_handled && (!k->get_command() || (k->get_command() && k->get_alt()))) { // For German keyboards.
+		if (!keycode_handled && !k->get_command()) { // For German keyboards.
 
 			if (k->get_unicode() >= 32) {
 				if (readonly) {


### PR DESCRIPTION
Reverts godotengine/godot#37769

This causes regression in the handling of shortcuts using <kbd>Ctrl</kbd>+<kbd>Alt</kbd>:
Fixes #41942.
Fixes #43117.

Supersedes and closes #44875.
Reintroduces #6851.

We can retry a fix for #6851 if we can ensure that it does not trigger the #41942 and #43117 regressions.