### PR TITLE
Fix inspector update while editing string properties

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -121,6 +121,8 @@ public:
 	virtual void update_property();
 	void update_reload_status();
 
+	virtual void restore_state(EditorProperty *p_property) {}
+
 	virtual bool use_keying_next() const;
 
 	void set_checkable(bool p_checkable);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -77,9 +77,19 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 void EditorPropertyText::update_property() {
 	String s = get_edited_object()->get(get_edited_property());
 	updating = true;
-	text->set_text(s);
+	if (text->get_text() != s) {
+		text->set_text(s);
+	}
 	text->set_editable(!is_read_only());
 	updating = false;
+}
+
+void EditorPropertyText::restore_state(EditorProperty *p_property) {
+	EditorPropertyText *text_property = Object::cast_to<EditorPropertyText>(p_property);
+	ERR_FAIL_NULL(text_property);
+
+	text->set_text(text_property->text->get_text());
+	text->set_cursor_position(text_property->text->get_cursor_position());
 }
 
 void EditorPropertyText::set_string_name(bool p_enabled) {
@@ -108,11 +118,11 @@ EditorPropertyText::EditorPropertyText() {
 
 void EditorPropertyMultilineText::_big_text_changed() {
 	text->set_text(big_text->get_text());
-	emit_changed(get_edited_property(), big_text->get_text(), "", true);
+	emit_changed(get_edited_property(), big_text->get_text(), "", false);
 }
 
 void EditorPropertyMultilineText::_text_changed() {
-	emit_changed(get_edited_property(), text->get_text(), "", true);
+	emit_changed(get_edited_property(), text->get_text(), "", false);
 }
 
 void EditorPropertyMultilineText::_open_big_text() {
@@ -133,9 +143,26 @@ void EditorPropertyMultilineText::_open_big_text() {
 
 void EditorPropertyMultilineText::update_property() {
 	String t = get_edited_object()->get(get_edited_property());
-	text->set_text(t);
-	if (big_text && big_text->is_visible_in_tree()) {
-		big_text->set_text(t);
+	if (text->get_text() != t) {
+		text->set_text(t);
+		if (big_text && big_text->is_visible_in_tree()) {
+			big_text->set_text(t);
+		}
+	}
+}
+
+void EditorPropertyMultilineText::restore_state(EditorProperty *p_property) {
+	EditorPropertyMultilineText *text_property = Object::cast_to<EditorPropertyMultilineText>(p_property);
+	ERR_FAIL_NULL(text_property);
+
+	text->set_text(text_property->text->get_text());
+	text->cursor_set_line(text_property->text->cursor_get_line());
+	text->cursor_set_column(text_property->text->cursor_get_column());
+
+	if (text_property->big_text && text_property->big_text->is_visible_in_tree()) {
+		_open_big_text();
+		big_text->cursor_set_line(text_property->big_text->cursor_get_line());
+		big_text->cursor_set_column(text_property->big_text->cursor_get_column());
 	}
 }
 

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -61,8 +61,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_string_name(bool p_enabled);
 	virtual void update_property() override;
+	virtual void restore_state(EditorProperty *p_property) override;
+	void set_string_name(bool p_enabled);
 	void set_placeholder(const String &p_string);
 	EditorPropertyText();
 };
@@ -85,6 +86,7 @@ protected:
 
 public:
 	virtual void update_property() override;
+	virtual void restore_state(EditorProperty *p_property) override;
 	EditorPropertyMultilineText();
 };
 


### PR DESCRIPTION
Restores cursor position from the previously focused property when the inspector is updated, in a way that can be extended to other property types if needed.

Also fixes change signal emission for multiline string properties (same as #44326 but for multiline strings).

I've tested all different cases on 3.2 branch, but it's more difficult to test on master, because single line string properties are not working right now in the inspector (multiline is ok).

Fixes #44854 (regression from #44326)
Fixes #42488

In case it's cherry-picked for 3.2, #44326 can be cherry-picked as well to fix single line string properties again.