### PR TITLE
Fix AnimationNodeStateMachinePlayback start() on nonexistent node

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -334,11 +334,17 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 			}
 		} else {
 			// teleport to start
-			path.clear();
-			current = start_request;
-			playing = true;
-			play_start = true;
-			start_request = StringName(); //clear start request
+			if (p_state_machine->states.has(start_request)) {
+				path.clear();
+				current = start_request;
+				playing = true;
+				play_start = true;
+				start_request = StringName(); //clear start request
+			} else {
+				StringName node = start_request;
+				start_request = StringName(); //clear start request
+				ERR_FAIL_V_MSG(0, "No such node: '" + node + "'");
+			}
 		}
 	}
 


### PR DESCRIPTION
It's possible to get the AnimationNodeStateMachine into an invalid state, by calling `start()` with an invalid node name.

This floods the console with errors and I even managed to get crashes in my project, because it accessed invalid parameters (e.g. "parameters/invalid_animation").

I couldn't reproduce the crashes in a minimal example project. Maybe there's a more complicated setup for the crash to appear. I confirmed with gdb that the crash happens when the code accesses invalid parameters.

Test project: 
[anim_tree_bug.zip](https://github.com/godotengine/godot/files/5775673/anim_tree_bug.zip)
