### PR TITLE
Document the requirement to update GPU particle visibility

### DIFF
--- a/doc/classes/CPUParticles.xml
+++ b/doc/classes/CPUParticles.xml
@@ -6,6 +6,7 @@
 	<description>
 		CPU-based 3D particle node used to create a variety of particle systems and effects.
 		See also [Particles], which provides the same functionality with hardware acceleration, but may not run on older devices.
+		[b]Note:[/b] Unlike [Particles], the visibility rect is generated on-the-fly and doesn't need to be configured by the user.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -6,6 +6,7 @@
 	<description>
 		CPU-based 2D particle node used to create a variety of particle systems and effects.
 		See also [Particles2D], which provides the same functionality with hardware acceleration, but may not run on older devices.
+		[b]Note:[/b] Unlike [Particles2D], the visibility rect is generated on-the-fly and doesn't need to be configured by the user.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/3.2/tutorials/2d/particle_systems_2d.html</link>

--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Particles" inherits="GeometryInstance" version="3.2">
 	<brief_description>
-		3D particle emitter.
+		GPU-based 3D particle emitter.
 	</brief_description>
 	<description>
 		3D particle node used to create a variety of particle systems and effects. [Particles] features an emitter that generates some number of particles at a given rate.
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
+		[b]Note:[/b] [Particles] only work when using the GLES3 renderer. If using the GLES2 renderer, use [CPUParticles] instead. You can convert [Particles] to [CPUParticles] by selecting the node, clicking the [b]Particles[/b] menu at the top of the 3D editor viewport then choosing [b]Convert to CPUParticles[/b].
+		[b]Note:[/b] After working on a Particles node, remember to update its [member visibility_aabb] by selecting it, clicking the [b]Particles[/b] menu at the top of the 3D editor viewport then choose [b]Generate Visibility AABB[/b]. Otherwise, particles may suddenly disappear depending on the camera position and angle.
 	</description>
 	<tutorials>
 		<link title="Controlling thousands of fish with Particles">https://docs.godotengine.org/en/3.2/tutorials/3d/vertex_animation/controlling_thousands_of_fish.html</link>

--- a/doc/classes/Particles2D.xml
+++ b/doc/classes/Particles2D.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Particles2D" inherits="Node2D" version="3.2">
 	<brief_description>
-		2D particle emitter.
+		GPU-based 2D particle emitter.
 	</brief_description>
 	<description>
 		2D particle node used to create a variety of particle systems and effects. [Particles2D] features an emitter that generates some number of particles at a given rate.
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
+		[b]Note:[/b] [Particles2D] only work when using the GLES3 renderer. If using the GLES2 renderer, use [CPUParticles2D] instead. You can convert [Particles2D] to [CPUParticles2D] by selecting the node, clicking the [b]Particles[/b] menu at the top of the 2D editor viewport then choosing [b]Convert to CPUParticles2D[/b].
+		[b]Note:[/b] After working on a Particles node, remember to update its [member visibility_rect] by selecting it, clicking the [b]Particles[/b] menu at the top of the 2D editor viewport then choose [b]Generate Visibility Rect[/b]. Otherwise, particles may suddenly disappear depending on the camera position and angle.
 	</description>
 	<tutorials>
 		<link title="Particle systems (2D)">https://docs.godotengine.org/en/3.2/tutorials/2d/particle_systems_2d.html</link>

--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -381,7 +381,7 @@ Particles2DEditorPlugin::Particles2DEditorPlugin(EditorNode *p_node) {
 	menu->get_popup()->add_item(TTR("Load Emission Mask"), MENU_LOAD_EMISSION_MASK);
 	//	menu->get_popup()->add_item(TTR("Clear Emission Mask"), MENU_CLEAR_EMISSION_MASK);
 	menu->get_popup()->add_separator();
-	menu->get_popup()->add_item(TTR("Convert to CPUParticles"), MENU_OPTION_CONVERT_TO_CPU_PARTICLES);
+	menu->get_popup()->add_item(TTR("Convert to CPUParticles2D"), MENU_OPTION_CONVERT_TO_CPU_PARTICLES);
 	menu->get_popup()->add_separator();
 	menu->get_popup()->add_item(TTR("Restart"), MENU_RESTART);
 	menu->set_text(TTR("Particles"));

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -469,7 +469,7 @@ ParticlesEditor::ParticlesEditor() {
 	particles_editor_hb->hide();
 
 	options->set_text(TTR("Particles"));
-	options->get_popup()->add_item(TTR("Generate AABB"), MENU_OPTION_GENERATE_AABB);
+	options->get_popup()->add_item(TTR("Generate Visibility AABB"), MENU_OPTION_GENERATE_AABB);
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Create Emission Points From Mesh"), MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_MESH);
 	options->get_popup()->add_item(TTR("Create Emission Points From Node"), MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_NODE);


### PR DESCRIPTION
This also updates some option names in the editor for consistency and accuracy.

**Note:** Only applies to `3.2` since 4.0's particle system works differently.

See #44955.