### PR TITLE
Handle inspector partial tree update on changed properties

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -269,6 +269,9 @@ class EditorInspector : public ScrollContainer {
 
 	//map use to cache the instanced editors
 	Map<StringName, List<EditorProperty *>> editor_property_map;
+	Map<StringName, PropertyInfo> property_info_cache;
+	Map<StringName, List<Control *>> property_control_cache;
+	Map<StringName, List<Pair<StringName, EditorProperty *>>> property_map_cache;
 	List<EditorInspectorSection *> sections;
 	Set<StringName> pending;
 
@@ -354,7 +357,7 @@ public:
 
 	String get_selected_path() const;
 
-	void update_tree();
+	void update_tree(bool p_clear_all = true);
 	void update_property(const String &p_prop);
 
 	void refresh();

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -68,9 +68,9 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 	}
 
 	if (string_name) {
-		emit_changed(get_edited_property(), StringName(p_string), "", true);
+		emit_changed(get_edited_property(), StringName(p_string), "", false);
 	} else {
-		emit_changed(get_edited_property(), p_string, "", true);
+		emit_changed(get_edited_property(), p_string, "", false);
 	}
 }
 
@@ -110,11 +110,11 @@ EditorPropertyText::EditorPropertyText() {
 
 void EditorPropertyMultilineText::_big_text_changed() {
 	text->set_text(big_text->get_text());
-	emit_changed(get_edited_property(), big_text->get_text(), "", true);
+	emit_changed(get_edited_property(), big_text->get_text(), "", false);
 }
 
 void EditorPropertyMultilineText::_text_changed() {
-	emit_changed(get_edited_property(), text->get_text(), "", true);
+	emit_changed(get_edited_property(), text->get_text(), "", false);
 }
 
 void EditorPropertyMultilineText::_open_big_text() {


### PR DESCRIPTION
Adds a cache to the inspector in order to update only modified properties when the property list changes and keep the previous controls whenever possible.

This allows calls to `property_list_changed_notify` to trigger inspector updates without resetting all properties.

~Fixes #44854 (regression from #44326)~
Fixes #43238 (re-applies #44326, reverted because of regression #44854)

Also fixes change signal emission for multiline string properties (same as #44326 but for multiline strings).

Note: The case with multiline string property when editing the string in the big popup window will require further changes. It currently closes and re-opens the popup when the inspector is updated (before this PR it was just closing it).