### PR TITLE
Implement Vector3.Normalize() as a property?

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -356,6 +356,14 @@ namespace Godot
             v.Normalize();
             return v;
         }
+        
+        public Vector3 normalized {
+            get { 
+                var v = this;
+                v.Normalize();
+                return v;
+            } 
+        }
 
         /// <summary>
         /// Returns the outer product with `b`.


### PR DESCRIPTION
This is more of a question that an actual commit, the code is for example.
There are a quite a few people coming from unity, that are used to being able to get a normalized version of a vector, using: 
`var thing = myVector.normalized;`

Godot uses a function instead of a property, so it might be a good idea to implement the other format as well so new people transitioning are more comfortable with it.
(plus its a nice shorthand, sorta fits with c# code)

again mostly looking for opinions rather that a final change.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
