### PR TITLE
[3.2] Main: Create user data dir in `setup()`

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -460,8 +460,7 @@ OS::ScreenOrientation OS::get_screen_orientation() const {
 	return (OS::ScreenOrientation)_orientation;
 }
 
-void OS::_ensure_user_data_dir() {
-
+void OS::ensure_user_data_dir() {
 	String dd = get_user_data_dir();
 	DirAccess *da = DirAccess::open(dd);
 	if (da) {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -140,7 +140,6 @@ protected:
 
 	virtual void set_cmdline(const char *p_execpath, const List<String> &p_args);
 
-	void _ensure_user_data_dir();
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
 
 public:
@@ -304,6 +303,8 @@ public:
 	virtual String get_name() const = 0;
 	virtual List<String> get_cmdline_args() const { return _cmdline; }
 	virtual String get_model_name() const;
+
+	void ensure_user_data_dir();
 
 	virtual MainLoop *get_main_loop() const = 0;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2594,6 +2594,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			}
 		} break;
 		case RUN_PROJECT_DATA_FOLDER: {
+			// ensure_user_data_dir() to prevent the edge case: "Open Project Data Folder" won't work after the project was renamed in ProjectSettingsEditor unless the project is saved
+			OS::get_singleton()->ensure_user_data_dir();
 			OS::get_singleton()->shell_open(String("file://") + OS::get_singleton()->get_user_data_dir());
 		} break;
 		case FILE_EXPLORE_ANDROID_BUILD_TEMPLATES: {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -899,6 +899,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #endif
 	}
 
+	// Initialize user data dir.
+	OS::get_singleton()->ensure_user_data_dir();
+
 	GLOBAL_DEF("memory/limits/multithreaded_server/rid_pool_prealloc", 60);
 	ProjectSettings::get_singleton()->set_custom_property_info("memory/limits/multithreaded_server/rid_pool_prealloc", PropertyInfo(Variant::INT, "memory/limits/multithreaded_server/rid_pool_prealloc", PROPERTY_HINT_RANGE, "0,500,1")); // No negative and limit to 500 due to crashes
 	GLOBAL_DEF("network/limits/debugger_stdout/max_chars_per_second", 2048);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1774,8 +1774,6 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	power_manager = memnew(PowerOSX);
 
-	_ensure_user_data_dir();
-
 	restore_rect = Rect2(get_window_position(), get_window_size());
 
 	if (p_desired.layered) {

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -97,8 +97,6 @@ Error OS_Server::initialize(const VideoMode &p_desired, int p_video_driver, int 
 	power_manager = memnew(PowerX11);
 #endif
 
-	_ensure_user_data_dir();
-
 	resource_loader_dummy.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_dummy);
 

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -340,8 +340,6 @@ Error OS_UWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 				ref new TypedEventHandler<Gyrometer ^, GyrometerReadingChangedEventArgs ^>(managed_object, &ManagedType::on_gyroscope_reading_changed);
 	}
 
-	_ensure_user_data_dir();
-
 	if (is_keep_screen_on())
 		display_request->RequestActive();
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1687,8 +1687,6 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 
 	RegisterTouchWindow(hWnd, 0);
 
-	_ensure_user_data_dir();
-
 	DragAcceptFiles(hWnd, true);
 
 	move_timer_id = 1;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -605,7 +605,6 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 #ifdef JOYDEV_ENABLED
 	joypad = memnew(JoypadLinux(input));
 #endif
-	_ensure_user_data_dir();
 
 	power_manager = memnew(PowerX11);
 


### PR DESCRIPTION
Custom backport of #39563 with preliminary change to make
`OS::ensure_user_data_dir()` public as done in f8a79a9.

Fixes #32488.

---

+ Cherry-pick of #42018.

Fixes #41680.