### PR TITLE
COPYRIGHT: Update with recent additions, cleanup

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -55,12 +55,19 @@ Comment: Godot Engine logo
 Copyright: 2017, Andrea Calabró
 License: CC-BY-4.0
 
-Files: ./platform/android/java/aidl/com/android/vending/billing/IInAppBillingService.aidl
- ./platform/android/java/res/layout/status_bar_ongoing_event_progress_bar.xml
- ./platform/android/java/src/com/google/android/vending/expansion/downloader/*
- ./platform/android/java/src/com/google/android/vending/licensing/*
- ./platform/android/java/src/org/godotengine/godot/input/InputManagerCompat.java
- ./platform/android/java/src/org/godotengine/godot/input/InputManagerV16.java
+Files: ./modules/fbx/fbx_parser/
+Comment: Open Asset Import Library (FBX parser)
+Copyright: 2006-2020, assimp team
+ 2007-2021, Juan Linietsky, Ariel Manzur.
+ 2014-2021, Godot Engine contributors.
+License: BSD-3-clause
+
+Files: ./platform/android/java/lib/aidl/com/android/vending/licensing/
+ ./platform/android/java/lib/res/layout/status_bar_ongoing_event_progress_bar.xml
+ ./platform/android/java/lib/src/com/google/android/vending/expansion/downloader/
+ ./platform/android/java/lib/src/com/google/android/vending/licensing/
+ ./platform/android/java/lib/src/org/godotengine/godot/input/InputManagerCompat.java
+ ./platform/android/java/lib/src/org/godotengine/godot/input/InputManagerV16.java
 Comment: The Android Open Source Project
 Copyright: 2008-2013, The Android Open Source Project
 License: Apache-2.0
@@ -70,11 +77,6 @@ Files: ./platform/android/java/src/com/android/vending/licensing/util/Base64.jav
 Comment: The Android Open Source Project
 Copyright: 2002, Google Inc.
 License: Apache-2.0
-
-Files: ./scene/animation/tween_interpolaters.cpp
-Comment: Penner Easing
-Copyright: 2001, Robert Penner
-License: BSD-3-clause
 
 Files: ./servers/physics/gjk_epa.cpp
  ./servers/physics/joints/generic_6dof_joint_sw.cpp
@@ -99,11 +101,6 @@ Copyright: 2007, Starbreeze Studios
  2007-2021, Juan Linietsky, Ariel Manzur.
  2014-2021, Godot Engine contributors.
 License: Expat and Zlib
-
-Files: ./thirdparty/assimp/
-Comment: Open Asset Import Library (assimp)
-Copyright: 2006-2016, assimp team
-License: BSD-3-clause
 
 Files: ./thirdparty/basis_universal/
 Comment: Basis Universal
@@ -169,7 +166,7 @@ License: FTL
 
 Files: ./thirdparty/glslang/
 Comment: glslang
-Copyright: 2015-2020 Google, Inc.
+Copyright: 2015-2020, Google, Inc.
   2014-2020, The Khronos Group Inc
   2002, NVIDIA Corporation.
 License: glslang
@@ -181,19 +178,19 @@ License: MPL-2.0
 
 Files: ./thirdparty/harfbuzz/
 Comment: HarfBuzz text shaping library
-Copyright: 2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020 Google, Inc.
- 2018,2019,2020 Ebrahim Byagowi
- 2019,2020 Facebook, Inc.
- 2012 Mozilla Foundation
- 2011 Codethink Limited
- 2008,2010 Nokia Corporation and/or its subsidiary(-ies)
- 2009 Keith Stribley
- 2009 Martin Hosken and SIL International
- 2007 Chris Wilson
- 2006 Behdad Esfahbod
- 2005 David Turner
- 2004,2007,2008,2009,2010 Red Hat, Inc.
- 1998-2004 David Turner and Werner Lemberg
+Copyright: 2010-2020, Google, Inc.
+ 2018-2020, Ebrahim Byagowi
+ 2019-2020, Facebook, Inc.
+ 2012, Mozilla Foundation
+ 2011, Codethink Limited
+ 2008, 2010 Nokia Corporation and/or its subsidiary(-ies)
+ 2009, Keith Stribley
+ 2009, Martin Hosken and SIL International
+ 2007, Chris Wilson
+ 2006, Behdad Esfahbod
+ 2005, David Turner
+ 2004, 2007-2010, Red Hat, Inc.
+ 1998-2004, David Turner and Werner Lemberg
 License: HarfBuzz
 
 Files: ./thirdparty/icu4c/
@@ -201,10 +198,10 @@ Comment: International Components for Unicode
 Copyright: 1991-2020, Unicode
 License: Unicode
 
-Files: ./thirdparty/jpeg_compressor/
+Files: ./thirdparty/jpeg-compressor/
 Comment: jpeg-compressor
 Copyright: 2012, Rich Geldreich
-License: public-domain
+License: public-domain or Apache-2.0
 
 Files: ./thirdparty/libogg/
 Comment: OggVorbis
@@ -258,12 +255,22 @@ License: BSD-3-clause
 
 Files: ./thirdparty/mbedtls/
 Comment: Mbed TLS
-Copyright: 2006-2018, Arm Limited (or its affiliates)
+Copyright: The Mbed TLS Contributors
 License: Apache-2.0
+
+Files: ./thirdparty/meshoptimizer/
+Comment: meshoptimizer
+Copyright: 2016-2020, Arseny Kapoulkine
+License: Expat
+
+Files: ./thirdparty/minimp3/
+Comment: MiniMP3
+Copyright: lieff
+License: CC0-1.0
 
 Files: ./thirdparty/miniupnpc/
 Comment: MiniUPnPc
-Copyright: 2005-2018, Thomas Bernard
+Copyright: 2005-2019, Thomas Bernard
 License: BSD-3-clause
 
 Files: ./thirdparty/minizip/
@@ -278,6 +285,11 @@ Files: ./thirdparty/misc/clipper.cpp
 Comment: Clipper
 Copyright: 2010-2017, Angus Johnson
 License: BSL-1.0
+
+Files: ./thirdparty/misc/cubemap_coeffs.h
+Comment: Fast Filtering of Reflection Probes
+Copyright: 2016, Activision Publishing, Inc.
+License: Expat
 
 Files: ./thirdparty/misc/easing_equations.cpp
 Comment: Robert Penner's Easing Functions
@@ -302,17 +314,35 @@ Comment: Tangent Space Normal Maps implementation
 Copyright: 2011, Morten S. Mikkelsen
 License: Zlib
 
+Files: ./thirdparty/misc/open-simplex-noise.c
+ ./thirdparty/misc/open-simplex-noise.h
+Comment: OpenSimplex Noise
+Copyright: 2014, Stephen M. Cameron
+License: public-domain or Unlicense
+
 Files: ./thirdparty/misc/pcg.cpp
  ./thirdparty/misc/pcg.h
 Comment: Minimal PCG32 implementation
 Copyright: 2014, M.E. O'Neill
 License: Apache-2.0
 
+Files: ./thirdparty/misc/r128.c
+ ./thirdparty/misc/r128.h
+Comment: r128 library
+Copyright: Alan Hickman
+License: public-domain or Unlicense
+
 Files: ./thirdparty/misc/smaz.c
  ./thirdparty/misc/smaz.h
 Comment: SMAZ
 Copyright: 2006-2009, Salvatore Sanfilippo
 License: BSD-3-clause
+
+Files: ./thirdparty/misc/stb_rect_pack.h
+ ./thirdparty/misc/stb_vorbis.c
+Comment: stb libraries
+Copyright: Sean Barrett
+License: public-domain or Unlicense or Expat
 
 Files: ./thirdparty/misc/triangulator.cpp
  ./thirdparty/misc/triangulator.h
@@ -362,7 +392,12 @@ License: Zlib
 Files: ./thirdparty/rvo2/
 Comment: RVO2
 Copyright: 2016, University of North Carolina at Chapel Hill
-License: Apache 2.0
+License: Apache-2.0
+
+Files: ./thirdparty/spirv-reflect/
+Comment: SPIRV-Reflect
+Copyright: 2017-2018, Google Inc.
+License: Apache-2.0
 
 Files: ./thirdparty/squish/
 Comment: libSquish
@@ -396,7 +431,7 @@ License: Expat
 
 Files: ./thirdparty/wslay/
 Comment: Wslay
-Copyright: 2011-2015, Tatsuhiro Tsujikawa
+Copyright: 2011, 2012, 2015, Tatsuhiro Tsujikawa
 License: Expat
 
 Files: ./thirdparty/xatlas/
@@ -547,6 +582,121 @@ License: BSL-1.0
  FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  DEALINGS IN THE SOFTWARE.
+
+License: CC0-1.0
+ CC0 1.0 Universal
+ .
+ Statement of Purpose
+ .
+ The laws of most jurisdictions throughout the world automatically confer
+ exclusive Copyright and Related Rights (defined below) upon the creator and
+ subsequent owner(s) (each and all, an "owner") of an original work of
+ authorship and/or a database (each, a "Work").
+ .
+ Certain owners wish to permanently relinquish those rights to a Work for the
+ purpose of contributing to a commons of creative, cultural and scientific
+ works ("Commons") that the public can reliably and without fear of later
+ claims of infringement build upon, modify, incorporate in other works, reuse
+ and redistribute as freely as possible in any form whatsoever and for any
+ purposes, including without limitation commercial purposes. These owners may
+ contribute to the Commons to promote the ideal of a free culture and the
+ further production of creative, cultural and scientific works, or to gain
+ reputation or greater distribution for their Work in part through the use and
+ efforts of others.
+ .
+ For these and/or other purposes and motivations, and without any expectation
+ of additional consideration or compensation, the person associating CC0 with a
+ Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+ and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+ and publicly distribute the Work under its terms, with knowledge of his or her
+ Copyright and Related Rights in the Work and the meaning and intended legal
+ effect of CC0 on those rights.
+ .
+ 1. Copyright and Related Rights. A Work made available under CC0 may be
+ protected by copyright and related or neighboring rights ("Copyright and
+ Related Rights"). Copyright and Related Rights include, but are not limited
+ to, the following:
+ .
+ i. the right to reproduce, adapt, distribute, perform, display, communicate,
+ and translate a Work;
+ .
+ ii. moral rights retained by the original author(s) and/or performer(s);
+ .
+ iii. publicity and privacy rights pertaining to a person's image or likeness
+ depicted in a Work;
+ .
+ iv. rights protecting against unfair competition in regards to a Work,
+ subject to the limitations in paragraph 4(a), below;
+ .
+ v. rights protecting the extraction, dissemination, use and reuse of data in
+ a Work;
+ .
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+ European Parliament and of the Council of 11 March 1996 on the legal
+ protection of databases, and under any national implementation thereof,
+ including any amended or successor version of such directive); and
+ .
+ vii. other similar, equivalent or corresponding rights throughout the world
+ based on applicable law or treaty, and any national implementations thereof.
+ .
+ 2. Waiver. To the greatest extent permitted by, but not in contravention of,
+ applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+ unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+ and Related Rights and associated claims and causes of action, whether now
+ known or unknown (including existing as well as future claims and causes of
+ action), in the Work (i) in all territories worldwide, (ii) for the maximum
+ duration provided by applicable law or treaty (including future time
+ extensions), (iii) in any current or future medium and for any number of
+ copies, and (iv) for any purpose whatsoever, including without limitation
+ commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+ the Waiver for the benefit of each member of the public at large and to the
+ detriment of Affirmer's heirs and successors, fully intending that such Waiver
+ shall not be subject to revocation, rescission, cancellation, termination, or
+ any other legal or equitable action to disrupt the quiet enjoyment of the Work
+ by the public as contemplated by Affirmer's express Statement of Purpose.
+ .
+ 3. Public License Fallback. Should any part of the Waiver for any reason be
+ judged legally invalid or ineffective under applicable law, then the Waiver
+ shall be preserved to the maximum extent permitted taking into account
+ Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+ is so judged Affirmer hereby grants to each affected person a royalty-free,
+ non transferable, non sublicensable, non exclusive, irrevocable and
+ unconditional license to exercise Affirmer's Copyright and Related Rights in
+ the Work (i) in all territories worldwide, (ii) for the maximum duration
+ provided by applicable law or treaty (including future time extensions), (iii)
+ in any current or future medium and for any number of copies, and (iv) for any
+ purpose whatsoever, including without limitation commercial, advertising or
+ promotional purposes (the "License"). The License shall be deemed effective as
+ of the date CC0 was applied by Affirmer to the Work. Should any part of the
+ License for any reason be judged legally invalid or ineffective under
+ applicable law, such partial invalidity or ineffectiveness shall not
+ invalidate the remainder of the License, and in such case Affirmer hereby
+ affirms that he or she will not (i) exercise any of his or her remaining
+ Copyright and Related Rights in the Work or (ii) assert any associated claims
+ and causes of action with respect to the Work, in either case contrary to
+ Affirmer's express Statement of Purpose.
+ .
+ 4. Limitations and Disclaimers.
+ .
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+ surrendered, licensed or otherwise affected by this document.
+ .
+ b. Affirmer offers the Work as-is and makes no representations or warranties
+ of any kind concerning the Work, express, implied, statutory or otherwise,
+ including without limitation warranties of title, merchantability, fitness
+ for a particular purpose, non infringement, or the absence of latent or
+ other defects, accuracy, or the present or absence of errors, whether or not
+ discoverable, all to the greatest extent permissible under applicable law.
+ .
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+ that may apply to the Work or any use thereof, including without limitation
+ any person's Copyright and Related Rights in the Work. Further, Affirmer
+ disclaims responsibility for obtaining any necessary consents, permissions
+ or other rights required for any use of the Work.
+ .
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+ party to this document and has no duty or obligation with respect to this
+ CC0 or use of the Work.
 
 License: CC-BY-4.0
  Creative Commons Attribution 4.0 International Public License
@@ -1728,6 +1878,32 @@ License: Unicode
  shall not be used in advertising or otherwise to promote the sale,
  use or other dealings in these Data Files or Software without prior
  written authorization of the copyright holder.
+
+License: Unlicense
+ This is free and unencumbered software released into the public domain.
+ .
+ Anyone is free to copy, modify, publish, use, compile, sell, or
+ distribute this software, either in source code form or as a compiled
+ binary, for any purpose, commercial or non-commercial, and by any
+ means.
+ .
+ In jurisdictions that recognize copyright laws, the author or authors
+ of this software dedicate any and all copyright interest in the
+ software to the public domain. We make this dedication for the benefit
+ of the public at large and to the detriment of our heirs and
+ successors. We intend this dedication to be an overt act of
+ relinquishment in perpetuity of all present and future rights to this
+ software under copyright law.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+ .
+ For more information, please refer to <https://unlicense.org/>
 
 License: Zlib
  This software is provided 'as-is', without any express or implied

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -3,7 +3,6 @@
 Please keep categories (`##` level) listed alphabetically and matching their
 respective folder names. Use two empty lines to separate categories for
 readability.
-Subcategories (`###` level) where needed are separated by a single empty line.
 
 
 ## basis_universal
@@ -46,7 +45,7 @@ as it's generated on the user's system.)
 ## cvtt
 
 - Upstream: https://github.com/elasota/cvtt
-- Version: 1.0.0-beta4 (2018)
+- Version: 1.0.0-beta4 (cc8472a04ba110fe999c686d07af40f7839051fd, 2018)
 - License: MIT
 
 Files extracted from upstream source:
@@ -105,37 +104,31 @@ comments.
 
 ## fonts
 
-### Noto Sans
+- `NotoSans*.ttf`, `NotoNaskhArabicUI_Regular.ttf`:
+  * Upstream: https://github.com/googlei18n/noto-fonts
+  * Version: 1.06 (2017)
+  * License: OFL-1.1
+  * Comment: Use UI font variant if available, because it has tight vertical metrics and
+    good for UI.
+- `Hack_Regular.ttf`:
+  * Upstream: https://github.com/source-foundry/Hack
+  * Version: 3.003 (2018)
+  * License: MIT + Bitstream Vera License
+- `DroidSans*.ttf`:
+  * Upstream: https://android.googlesource.com/platform/frameworks/base/+/master/data/fonts/
+  * Version: ? (pre-2014 commit when DroidSansJapanese.ttf was obsoleted)
+  * License: Apache 2.0
+- `Tamsyn*.png`:
+  * Upstream: http://www.fial.com/~scott/tamsyn-font/
+  * Version: 1.11 (2015)
+  * License: Tamsyn
+  * Comment: Extracted "0..9,A..F" characters for hex code printing.
 
-- Upstream: https://github.com/googlei18n/noto-fonts
-- Version: 1.06 (2017)
-- License: OFL-1.1
-
-Use UI font variant if available, because it has tight vertical metrics and good for UI.
-
-### Hack Regular
-
-- Upstream: https://github.com/source-foundry/Hack
-- Version: 3.003 (2018)
-- License: MIT + Bitstream Vera License
-
-### DroidSans*.ttf
-
-- Upstream: https://android.googlesource.com/platform/frameworks/base/+/master/data/fonts/
-- Version: ? (pre-2014 commit when DroidSansJapanese.ttf was obsoleted)
-- License: Apache 2.0
-
-### Tamsyn
-- Upstream: http://www.fial.com/~scott/tamsyn-font/
-- Version: 1.11
-- License: Tamsyn
-
-Extracted "0..9,A..F" characters for hex code printing.
 
 ## freetype
 
 - Upstream: https://www.freetype.org
-- Version: 2.10.4 (2020)
+- Version: 2.10.4 (6a2b3e4007e794bfc6c91030d0ed987f925164a8, 2020)
 - License: FreeType License (BSD-like)
 
 Files extracted from upstream source:
@@ -164,45 +157,55 @@ Files extracted from upstream source:
 - `LICENSE.txt`
 - Unnecessary files like `CMakeLists.txt` and `updateGrammar` removed.
 
-## Graphite engine
+
+## graphite
 
 - Upstream: https://github.com/silnrsi/graphite
-- Version: 1.3.14
+- Version: 1.3.14 (92f59dcc52f73ce747f1cdc831579ed2546884aa, 2020)
 - License: MPL-2.0
 
 Files extracted from upstream source:
+
 - the `include` folder
 - the `src` folder
 - `COPYING`, `ChangeLog`
 
-## HarfBuzz
+
+## harfbuzz
 
 - Upstream: https://github.com/harfbuzz/harfbuzz
-- Version: 2.7.4
-- License: HarfBuzz
+- Version: 2.7.4 (7236c7e29cef1c2d76c7a284c5081ff4d3aa1127, 2020)
+- License: MIT
 
 Files extracted from upstream source:
+
 - the `src` folder
 - `AUTHORS`, `COPYING`, `NEWS`, `THANKS`
 
-## International Components for Unicode
+
+## icu4c
 
 - Upstream: https://github.com/unicode-org/icu
-- Version: 68.2
+- Version: 68.2 (84e1f26ea77152936e70d53178a816dbfbf69989, 2020)
 - License: Unicode
 
 Files extracted from upstream source:
+
 - the `common` folder
 - `APIChangeReport.md`, `LICENSE`
 
 Files generated from upstream source:
-- the `icudt68l.dat` built with the provided `godot_data.json` config file (see https://github.com/unicode-org/icu/blob/master/docs/userguide/icu_data/buildtool.md for instructions)
+
+- the `icudt68l.dat` built with the provided `godot_data.json` config file (see
+  https://github.com/unicode-org/icu/blob/master/docs/userguide/icu_data/buildtool.md
+  for instructions)
+
 
 ## jpeg-compressor
 
 - Upstream: https://github.com/richgel999/jpeg-compressor
 - Version: 2.00 (aeb7d3b463aa8228b87a28013c15ee50a7e6fcf3, 2020)
-- License: Public domain
+- License: Public domain or MIT
 
 Files extracted from upstream source:
 
@@ -225,7 +228,7 @@ Files extracted from upstream source:
 ## libpng
 
 - Upstream: http://libpng.org/pub/png/libpng.html
-- Version: 1.6.37 (2019)
+- Version: 1.6.37 (a40189cf881e9f0db80511c382292a5604c3c3d1, 2019)
 - License: libpng/zlib
 
 Files extracted from upstream source:
@@ -305,7 +308,7 @@ from the Android NDK r18.
 ## libwebp
 
 - Upstream: https://chromium.googlesource.com/webm/libwebp/
-- Version: 1.1.0 (2020)
+- Version: 1.1.0 (d7844e9762b61c9638c263657bd49e1690184832, 2020)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:
@@ -321,7 +324,7 @@ changes are marked with `// -- GODOT --` comments.
 ## mbedtls
 
 - Upstream: https://tls.mbed.org/
-- Version: 2.16.9 (2020)
+- Version: 2.16.9 (3fac0bae4a50113989b3d015cd2d948f51a6d9ac, 2020)
 - License: Apache 2.0
 
 File extracted from upstream release tarball:
@@ -344,8 +347,11 @@ File extracted from upstream release tarball:
 - Version: git (e4e43fe36e7a8705e602e7ca2f9fb795ded1d0b9, 2020)
 - License: MIT
 
-- File extracted from upstream tarball:
+Files extracted from upstream repository:
+
 - All files in `src/`.
+- `LICENSE.md`.
+
 
 ## miniupnpc
 
@@ -382,8 +388,6 @@ comments and a patch is provided in the minizip/ folder.
 
 Collection of single-file libraries used in Godot components.
 
-### core
-
 - `clipper.{cpp,hpp}`
   * Upstream: https://sourceforge.net/projects/polyclipping
   * Version: 6.4.2 (2017) + Godot changes (added optional exceptions handling)
@@ -392,6 +396,10 @@ Collection of single-file libraries used in Godot components.
   * Upstream: https://research.activision.com/publications/archives/fast-filtering-of-reflection-probes
     File coeffs_const_8.txt (retrieved April 2020)
   * License: MIT
+- `easing_equations.cpp`
+  * Upstream: http://robertpenner.com/easing/ via https://github.com/jesusgollonet/ofpennereasing (modified to fit Godot types)
+  * Version: git (af72c147c3a74e7e872aa28c7e2abfcced04fdce, 2008) + Godot types and style changes
+  * License: BSD-3-Clause
 - `fastlz.{c,h}`
   * Upstream: https://github.com/ariya/FastLZ
   * Version: 0.5.0 (4f20f54d46f5a6dd4fae4def134933369b7602d2, 2020)
@@ -400,10 +408,18 @@ Collection of single-file libraries used in Godot components.
   * Upstream: https://github.com/brunexgeek/hqx
   * Version: TBD, file structure differs
   * License: Apache 2.0
+- `ifaddrs-android.{cc,h}`
+  * Upstream: https://chromium.googlesource.com/external/webrtc/stable/talk/+/master/base/ifaddrs-android.h
+  * Version: git (5976650443d68ccfadf1dea24999ee459dd2819d, 2013)
+  * License: BSD-3-Clause
+- `mikktspace.{c,h}`
+  * Upstream: https://archive.blender.org/wiki/index.php/Dev:Shading/Tangent_Space_Normal_Maps/
+  * Version: 1.0 (2011)
+  * License: zlib
 - `open-simplex-noise.{c,h}`
   * Upstream: https://github.com/smcameron/open-simplex-noise-in-c
   * Version: git (826f1dd1724e6fb3ff45f58e48c0fbae864c3403, 2020) + custom changes
-  * License: Unlicense
+  * License: Public Domain or Unlicense
 - `pcg.{cpp,h}`
   * Upstream: http://www.pcg-random.org
   * Version: minimal C implementation, http://www.pcg-random.org/download.html
@@ -411,49 +427,28 @@ Collection of single-file libraries used in Godot components.
 - `r128.h`
   * Upstream: https://github.com/fahickman/r128
   * Version: git (423f693617faafd01de21e92818add4208eb8bd1, 2020)
-  * License: Public Domain
+  * License: Public Domain or Unlicense
 - `smaz.{c,h}`
   * Upstream: https://github.com/antirez/smaz
-  * Version: git (150e125cbae2e8fd20dd332432776ce13395d4d4, 2009)
+  * Version: git (2f625846a775501fb69456567409a8b12f10ea25, 2012)
   * License: BSD-3-Clause
   * Modifications: use `const char*` instead of `char*` for input string
 - `stb_rect_pack.h`
   * Upstream: https://github.com/nothings/stb
-  * Version: 1.00 (2019)
-  * License: Public Domain (Unlicense) or MIT
+  * Version: 1.00 (2bb4a0accd4003c1db4c24533981e01b1adfd656, 2019)
+  * License: Public Domain or Unlicense or MIT
+- `stb_vorbis.c`
+  * Upstream: https://github.com/nothings/stb
+  * Version: 1.20 (314d0a6f9af5af27e585336eecea333e95c5a2d8, 2020)
+  * License: Public Domain or Unlicense or MIT
 - `triangulator.{cpp,h}`
   * Upstream: https://github.com/ivanfratric/polypartition (`src/polypartition.cpp`)
   * Version: TBD, class was renamed
   * License: MIT
-
-### modules
-
 - `yuv2rgb.h`
   * Upstream: http://wss.co.uk/pinknoise/yuv2rgb/ (to check)
   * Version: ?
   * License: BSD
-
-### platform
-
-- `ifaddrs-android.{cc,h}`
-  * Upstream: https://chromium.googlesource.com/external/webrtc/stable/talk/+/master/base/ifaddrs-android.h
-  * Version: git (5976650443d68ccfadf1dea24999ee459dd2819d, 2013)
-  * License: BSD-3-Clause
-
-### scene
-
-- `easing_equations.cpp`
-  * Upstream: http://robertpenner.com/easing/ via https://github.com/jesusgollonet/ofpennereasing (modified to fit Godot types)
-  * Version: git (af72c147c3a74e7e872aa28c7e2abfcced04fdce, 2008) + Godot types and style changes
-  * License: BSD-3-Clause
-- `mikktspace.{c,h}`
-  * Upstream: https://archive.blender.org/wiki/index.php/Dev:Shading/Tangent_Space_Normal_Maps/
-  * Version: 1.0 (2011)
-  * License: zlib
-- `stb_vorbis.c`
-  * Upstream: https://github.com/nothings/stb
-  * Version: 1.20
-  * License: Public Domain (Unlicense) or MIT
 
 
 ## nanosvg
@@ -476,27 +471,27 @@ Files extracted from the upstream source:
 
 Files extracted from upstream source:
 
-common/* (except tasking.* and CMakeLists.txt)
-core/*
-include/OpenImageDenoise/* (except version.h.in)
-LICENSE.txt
-mkl-dnn/include/*
-mkl-dnn/src/* (except CMakeLists.txt)
-weights/rtlightmap_hdr.tza
-scripts/resource_to_cpp.py
+- common/* (except tasking.* and CMakeLists.txt)
+- core/*
+- include/OpenImageDenoise/* (except version.h.in)
+- LICENSE.txt
+- mkl-dnn/include/*
+- mkl-dnn/src/* (except CMakeLists.txt)
+- weights/rtlightmap_hdr.tza
+- scripts/resource_to_cpp.py
 
 Modified files:
 Modifications are marked with `// -- GODOT start --` and `// -- GODOT end --`.
 Patch files are provided in `oidn/patches/`.
 
-core/autoencoder.cpp
-core/autoencoder.h
-core/common.h
-core/device.cpp
-core/device.h
-core/transfer_function.cpp
+- core/autoencoder.cpp
+- core/autoencoder.h
+- core/common.h
+- core/device.cpp
+- core/device.h
+- core/transfer_function.cpp
 
-scripts/resource_to_cpp.py (used in modules/denoise/resource_to_cpp.py)
+- scripts/resource_to_cpp.py (used in modules/denoise/resource_to_cpp.py)
 
 
 ## opus
@@ -519,7 +514,7 @@ Files extracted from upstream source:
 ## pcre2
 
 - Upstream: http://www.pcre.org
-- Version: 10.34 (2019)
+- Version: 10.34 (r1189, 2019)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:
@@ -534,7 +529,8 @@ Files extracted from upstream source:
 
 ## pvrtccompressor
 
-- Upstream: https://bitbucket.org/jthlim/pvrtccompressor
+- Upstream: https://bitbucket.org/jthlim/pvrtccompressor (dead link)
+  Unofficial backup fork: https://github.com/LibreGamesArchive/PVRTCCompressor
 - Version: hg (cf7177748ee0dcdccfe89716dc11a47d2dc81af5, 2015)
 - License: BSD-3-Clause
 
@@ -558,8 +554,8 @@ Files extracted from upstream source:
 
 ## rvo2
 
-- Upstream: http://gamma.cs.unc.edu/RVO2/
-- Version: 3D - 1.0.1 (2016)
+- Upstream: https://github.com/snape/RVO2-3D
+- Version: 1.0.1 (e3883f288a9e55ecfed3633a01af3e12778c6acf, 2016)
 - License: Apache 2.0
 
 Files extracted from upstream source:
@@ -572,10 +568,22 @@ originally proposed by this library and better integrate this library with
 Godot. Please check the file to know what's new.
 
 
+## spirv-reflect
+
+- Upstream: https://github.com/KhronosGroup/SPIRV-Reflect
+- Version: git (bc3c0d63b6dadcde3f08bcd6fdc5ab98a31354da, 2019)
+- License: Apache 2.0
+
+Files extracted from upstream source:
+
+- `spirv_reflect.{c,h}`
+- `include` folder
+
+
 ## squish
 
 - Upstream: https://sourceforge.net/projects/libsquish
-- Version: 1.15 (2017)
+- Version: 1.15 (r104, 2017)
 - License: MIT
 
 Files extracted from upstream source:
@@ -618,7 +626,7 @@ folder.
 ## vulkan
 
 - Upstream: https://github.com/KhronosGroup/Vulkan-Loader
-- Version: sdk-1.2.162.0 (2020)
+- Version: sdk-1.2.162.0 (7a313093b5c4af964d50a5a64e73d7df6152ea3f, 2020)
 - License: Apache 2.0
 
 Unless there is a specific reason to package a more recent version, please stick
@@ -647,7 +655,7 @@ Patches in the `patches` directory should be re-applied after updates.
 ## wslay
 
 - Upstream: https://github.com/tatsuhiro-t/wslay
-- Version: 1.1.1 (2020)
+- Version: 1.1.1 (c9a84aa6df8512584c77c8cd15be9536b89c35aa, 2020)
 - License: MIT
 
 File extracted from upstream release tarball:
@@ -683,7 +691,7 @@ Files extracted from upstream source:
 ## zstd
 
 - Upstream: https://github.com/facebook/zstd
-- Version: 1.4.8 (2020)
+- Version: 1.4.8 (97a3da1df009d4dc67251de0c4b1c9d7fe286fc1, 2020)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:


### PR DESCRIPTION
Also include public domain assets in `COPYRIGHT.txt` with Unlicence text or
dual-licensing scheme.

And document commit hashes for most thirdparty code in `thirdparty/README.md`
for clarity, and in case there's no tag matching the included version numbers.

---

Some of it can be cherry-picked, not all though. Will likely need redoing for `3.2` specifically.