### PR TITLE
Added information about omitting extends keyword in a GDScript class

### DIFF
--- a/doc/classes/Reference.xml
+++ b/doc/classes/Reference.xml
@@ -6,6 +6,7 @@
 	<description>
 		Base class for any object that keeps a reference count. [Resource] and many other helper objects inherit this class.
 		Unlike [Object]s, References keep an internal reference counter so that they are automatically released when no longer in use, and only then. References therefore do not need to be freed manually with [method Object.free].
+		If the [code]extends[/code] keyword is omitted from the top of a script in GDScript, the class inherits from [Reference] by default.
 		In the vast majority of use cases, instantiating and using [Reference]-derived types is all you need to do. The methods provided in this class are only for advanced users, and can cause issues if misused.
 		[b]Note:[/b] In C#, references will not be freed instantly after they are no longer in use. Instead, garbage collection will run periodically and will free references that are no longer in use. This means that unused references will linger on for a while before being removed.
 	</description>


### PR DESCRIPTION
There was a discussion in the Discord that has prompted this addition to the reference class. There was an individual who was getting confused that omitting the extends keyword wouldn't default the script to the Object class, but instead the Reference class.