### PR TITLE
Fix `AudioServer.get_time_since_last_mix()` returning incorrect value when accessing from another thread

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -71,13 +71,20 @@ void AudioDriver::update_mix_time(int p_frames) {
 	}
 }
 
-double AudioDriver::get_time_since_last_mix() const {
-	return (OS::get_singleton()->get_ticks_usec() - _last_mix_time) / 1000000.0;
+double AudioDriver::get_time_since_last_mix() {
+	lock();
+	uint64_t last_mix_time = _last_mix_time;
+	unlock();
+	return (OS::get_singleton()->get_ticks_usec() - last_mix_time) / 1000000.0;
 }
 
-double AudioDriver::get_time_to_next_mix() const {
-	double total = (OS::get_singleton()->get_ticks_usec() - _last_mix_time) / 1000000.0;
-	double mix_buffer = _last_mix_frames / (double)get_mix_rate();
+double AudioDriver::get_time_to_next_mix() {
+	lock();
+	uint64_t last_mix_time = _last_mix_time;
+	uint64_t last_mix_frames = _last_mix_frames;
+	unlock();
+	double total = (OS::get_singleton()->get_ticks_usec() - last_mix_time) / 1000000.0;
+	double mix_buffer = last_mix_frames / (double)get_mix_rate();
 	return mix_buffer - total;
 }
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -70,8 +70,8 @@ protected:
 #endif
 
 public:
-	double get_time_since_last_mix() const; //useful for video -> audio sync
-	double get_time_to_next_mix() const;
+	double get_time_since_last_mix(); //useful for video -> audio sync
+	double get_time_to_next_mix();
 
 	enum SpeakerMode {
 		SPEAKER_MODE_STEREO,


### PR DESCRIPTION
 - Changes `AudioDriver::_last_mix_time` and `AudioDriver::_last_mix_frames` to be atomic `uint64_t` variables
 - Modifies `get_time_since_last_mix()` and `get_time_to_next_mix()` to make a local copy of each `_last_mix_time` and `_last_mix_frames` prior to `get_ticks_usec` to ensure they are always smaller.

<i>Bugsquad edit</i>: Fix #45025

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
