### PR TITLE
Fix unintended SpinBox mouse capture

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -280,7 +280,6 @@ SpinBox::SpinBox() {
 	line_edit->connect("text_entered", callable_mp(this, &SpinBox::_text_entered), Vector<Variant>(), CONNECT_DEFERRED);
 	line_edit->connect("focus_exited", callable_mp(this, &SpinBox::_line_edit_focus_exit), Vector<Variant>(), CONNECT_DEFERRED);
 	line_edit->connect("gui_input", callable_mp(this, &SpinBox::_line_edit_input));
-	drag.enabled = false;
 
 	range_click_timer = memnew(Timer);
 	range_click_timer->connect("timeout", callable_mp(this, &SpinBox::_range_click_timeout));

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -52,11 +52,11 @@ class SpinBox : public Range {
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 
 	struct Drag {
-		float base_val;
-		bool allowed;
-		bool enabled;
+		float base_val = 0;
+		bool allowed = false;
+		bool enabled = false;
 		Vector2 capture_pos;
-		float diff_y;
+		float diff_y = 0;
 	} drag;
 
 	void _line_edit_focus_exit();


### PR DESCRIPTION
Initializes SpinBox drag variables to prevent the mouse from being captured if pressed outside the SpinBox and dragged inside.

Fixes #43608