### PR TITLE
Emit changed signal from Color Picker when changed

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2148,6 +2148,12 @@ void EditorPropertyColor::_color_changed(const Color &p_color) {
 	emit_changed(get_edited_property(), p_color, "", true);
 }
 
+void EditorPropertyColor::_popup_closed() {
+	if (picker->get_pick_color() != last_color) {
+		emit_changed(get_edited_property(), picker->get_pick_color(), "", false);
+	}
+}
+
 void EditorPropertyColor::_picker_created() {
 	// get default color picker mode from editor settings
 	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
@@ -2156,6 +2162,10 @@ void EditorPropertyColor::_picker_created() {
 	} else if (default_color_mode == 2) {
 		picker->get_picker()->set_raw_mode(true);
 	}
+}
+
+void EditorPropertyColor::_picker_opening() {
+	last_color = picker->get_pick_color();
 }
 
 void EditorPropertyColor::_bind_methods() {
@@ -2191,7 +2201,9 @@ EditorPropertyColor::EditorPropertyColor() {
 	add_child(picker);
 	picker->set_flat(true);
 	picker->connect("color_changed", callable_mp(this, &EditorPropertyColor::_color_changed));
+	picker->connect("popup_closed", callable_mp(this, &EditorPropertyColor::_popup_closed));
 	picker->connect("picker_created", callable_mp(this, &EditorPropertyColor::_picker_created));
+	picker->get_popup()->connect("about_to_popup", callable_mp(this, &EditorPropertyColor::_picker_opening));
 }
 
 ////////////// NODE PATH //////////////////////

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -547,7 +547,11 @@ class EditorPropertyColor : public EditorProperty {
 	GDCLASS(EditorPropertyColor, EditorProperty);
 	ColorPickerButton *picker;
 	void _color_changed(const Color &p_color);
+	void _popup_closed();
 	void _picker_created();
+	void _picker_opening();
+
+	Color last_color;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
This reverts #44895 and applies a different fix. Instead of not emitting signal it's now emitted only when color was changed.

Fixes https://github.com/godotengine/godot/pull/44895#issuecomment-757148892