### PR TITLE
Invert the Y-axis on thumbsticks and trackpads in WebXR

### DIFF
--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -601,7 +601,13 @@ const GodotWebXR = {
 		const buf = GodotRuntime.malloc((axes_count + 1) * 4);
 		GodotRuntime.setHeapValue(buf, axes_count, 'i32');
 		for (let i = 0; i < axes_count; i++) {
-			GodotRuntime.setHeapValue(buf + 4 + (i * 4), controller.gamepad.axes[i], 'float');
+			let value = controller.gamepad.axes[i];
+			if (i === 1 || i === 3) {
+				// Invert the Y-axis on thumbsticks and trackpads, in order to
+				// match OpenXR and other XR platform SDKs.
+				value *= -1.0;
+			}
+			GodotRuntime.setHeapValue(buf + 4 + (i * 4), value, 'float');
 		}
 		return buf;
 	},


### PR DESCRIPTION
WebXR is reporting the Y-axis of thumbsticks and trackpads inverted (-Y is UP) when compared to the OpenVR, Oculus Quest and OpenXR APIs (where +Y is UP). This PR inverts the reported values, so that WebXR will match those other APIs.

This issue was originally reported by @NeoSpark314, but I wanted to confirm that OpenXR (which is the future!) also used +Y for UP, so that we weren't going to make WebXR less compatible with the future. Yesterday, @BastiaanOlij verified on stream that this was the case for OpenXR.

This should be cherry-picked to 3.2 (which is, of course, where I tested this :-))