### PR TITLE
Add descriptive error message when trying to access a dir fails

### DIFF
--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -170,7 +170,7 @@ Error DirAccess::make_dir_recursive(String p_dir) {
 		curpath = curpath.plus_file(subdirs[i]);
 		Error err = make_dir(curpath);
 		if (err != OK && err != ERR_ALREADY_EXISTS) {
-			ERR_FAIL_V(err);
+			ERR_FAIL_V_MSG(err, "Could not create directory: " + curpath);
 		}
 	}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Adds a descriptive error message and logs path of dir in question when make_dir() call fails at DirAccess::make_dir_recursive(). Addresses #44815 . 
