### PR TITLE
[3.2] Fix wrong Basis::is_equal_approx variant being called (2 param vs 1 param version)

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -845,7 +845,7 @@ struct _VariantCall {
 	VCALL_PTR0R(Basis, get_orthogonal_index);
 	VCALL_PTR0R(Basis, orthonormalized);
 	VCALL_PTR2R(Basis, slerp);
-	VCALL_PTR2R(Basis, is_equal_approx); // TODO: Break compatibility in 4.0 to change this to an instance method (a.is_equal_approx(b) as VCALL_PTR1R) for consistency.
+	VCALL_PTR1R(Basis, is_equal_approx);
 	VCALL_PTR0R(Basis, get_rotation_quat);
 
 	VCALL_PTR0R(Transform, inverse);


### PR DESCRIPTION
Related: #37403

Apparently changing this would break compatibility but it's already broken (for GDScript at least) so I guess it should be changed anyways?

Closes #45062