### PR TITLE
Add RID reservation infrastructure

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1570,9 +1570,10 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	/* Initialize Visual Server */
 
-	rendering_server = memnew(RenderingServerDefault);
-	if (OS::get_singleton()->get_render_thread_mode() != OS::RENDER_THREAD_UNSAFE) {
-		rendering_server = memnew(RenderingServerWrapMT(rendering_server,
+	if (OS::get_singleton()->get_render_thread_mode() == OS::RENDER_THREAD_UNSAFE) {
+		rendering_server = memnew(RenderingServerDefault);
+	} else {
+		rendering_server = memnew(RenderingServerWrapMT(memnew(RenderingServerDefault),
 				OS::get_singleton()->get_render_thread_mode() ==
 						OS::RENDER_SEPARATE_THREAD));
 	}

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -231,10 +231,11 @@ Error OS_UWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	set_video_mode(vm);
 
-	rendering_server = memnew(RenderingServerDefault);
 	// FIXME: Reimplement threaded rendering
-	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
-		rendering_server = memnew(RenderingServerWrapMT(rendering_server, false));
+	if (get_render_thread_mode() == RENDER_THREAD_UNSAFE) {
+		rendering_server = memnew(RenderingServerDefault);
+	} else {
+		rendering_server = memnew(RenderingServerWrapMT(memnew(RenderingServerDefault), false);
 	}
 
 	rendering_server->init();

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -40,7 +40,7 @@
 #define FLUSH_QUERY_CHECK(m_object) \
 	ERR_FAIL_COND_MSG(m_object->get_space() && flushing_queries, "Can't change this state while flushing queries. Use call_deferred() or set_deferred() to change monitoring state instead.");
 
-RID PhysicsServer2DSW::_shape_create(ShapeType p_shape) {
+RID PhysicsServer2DSW::_shape_create(ShapeType p_shape, RID p_reserved_rid) {
 	Shape2DSW *shape = nullptr;
 	switch (p_shape) {
 		case SHAPE_LINE: {
@@ -73,42 +73,42 @@ RID PhysicsServer2DSW::_shape_create(ShapeType p_shape) {
 		} break;
 	}
 
-	RID id = shape_owner.make_rid(shape);
+	RID id = shape_owner.make_rid(shape, p_reserved_rid);
 	shape->set_self(id);
 
 	return id;
 }
 
-RID PhysicsServer2DSW::line_shape_create() {
-	return _shape_create(SHAPE_LINE);
+RID PhysicsServer2DSW::line_shape_create_reserved(RID p_reserved_rid) {
+	return _shape_create(SHAPE_LINE, p_reserved_rid);
 }
 
-RID PhysicsServer2DSW::ray_shape_create() {
-	return _shape_create(SHAPE_RAY);
+RID PhysicsServer2DSW::ray_shape_create_reserved(RID p_reserved_rid) {
+	return _shape_create(SHAPE_RAY, p_reserved_rid);
 }
 
-RID PhysicsServer2DSW::segment_shape_create() {
-	return _shape_create(SHAPE_SEGMENT);
+RID PhysicsServer2DSW::segment_shape_create_reserved(RID p_reserved_rid) {
+	return _shape_create(SHAPE_SEGMENT, p_reserved_rid);
 }
 
-RID PhysicsServer2DSW::circle_shape_create() {
-	return _shape_create(SHAPE_CIRCLE);
+RID PhysicsServer2DSW::circle_shape_create_reserved(RID p_reserved_rid) {
+	return _shape_create(SHAPE_CIRCLE, p_reserved_rid);
 }
 
-RID PhysicsServer2DSW::rectangle_shape_create() {
-	return _shape_create(SHAPE_RECTANGLE);
+RID PhysicsServer2DSW::rectangle_shape_create_reserved(RID p_reserved_rid) {
+	return _shape_create(SHAPE_RECTANGLE, p_reserved_rid);
 }
 
-RID PhysicsServer2DSW::capsule_shape_create() {
-	return _shape_create(SHAPE_CAPSULE);
+RID PhysicsServer2DSW::capsule_shape_create_reserved(RID p_reserved_rid) {
+	return _shape_create(SHAPE_CAPSULE, p_reserved_rid);
 }
 
-RID PhysicsServer2DSW::convex_polygon_shape_create() {
-	return _shape_create(SHAPE_CONVEX_POLYGON);
+RID PhysicsServer2DSW::convex_polygon_shape_create_reserved(RID p_reserved_rid) {
+	return _shape_create(SHAPE_CONVEX_POLYGON, p_reserved_rid);
 }
 
-RID PhysicsServer2DSW::concave_polygon_shape_create() {
-	return _shape_create(SHAPE_CONCAVE_POLYGON);
+RID PhysicsServer2DSW::concave_polygon_shape_create_reserved(RID p_reserved_rid) {
+	return _shape_create(SHAPE_CONCAVE_POLYGON, p_reserved_rid);
 }
 
 void PhysicsServer2DSW::shape_set_data(RID p_shape, const Variant &p_data) {
@@ -213,9 +213,9 @@ bool PhysicsServer2DSW::shape_collide(RID p_shape_A, const Transform2D &p_xform_
 	return res;
 }
 
-RID PhysicsServer2DSW::space_create() {
+RID PhysicsServer2DSW::space_create_reserved(RID p_reserved_rid) {
 	Space2DSW *space = memnew(Space2DSW);
-	RID id = space_owner.make_rid(space);
+	RID id = space_owner.make_rid(space, p_reserved_rid);
 	space->set_self(id);
 	RID area_id = area_create();
 	Area2DSW *area = area_owner.getornull(area_id);
@@ -283,9 +283,9 @@ PhysicsDirectSpaceState2D *PhysicsServer2DSW::space_get_direct_state(RID p_space
 	return space->get_direct_state();
 }
 
-RID PhysicsServer2DSW::area_create() {
+RID PhysicsServer2DSW::area_create_reserved(RID p_reserved_rid) {
 	Area2DSW *area = memnew(Area2DSW);
-	RID rid = area_owner.make_rid(area);
+	RID rid = area_owner.make_rid(area, p_reserved_rid);
 	area->set_self(rid);
 	return rid;
 };
@@ -528,9 +528,9 @@ void PhysicsServer2DSW::area_set_area_monitor_callback(RID p_area, Object *p_rec
 
 /* BODY API */
 
-RID PhysicsServer2DSW::body_create() {
+RID PhysicsServer2DSW::body_create_reserved(RID p_reserved_rid) {
 	Body2DSW *body = memnew(Body2DSW);
-	RID rid = body_owner.make_rid(body);
+	RID rid = body_owner.make_rid(body, p_reserved_rid);
 	body->set_self(rid);
 	return rid;
 }

--- a/servers/physics_2d/physics_server_2d_wrap_mt.cpp
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.cpp
@@ -115,7 +115,7 @@ void PhysicsServer2DWrapMT::finish() {
 	}
 }
 
-PhysicsServer2DWrapMT::PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool p_create_thread) :
+PhysicsServer2DWrapMT::PhysicsServer2DWrapMT(PhysicsServer2DReserving *p_contained, bool p_create_thread) :
 		command_queue(p_create_thread) {
 	physics_2d_server = p_contained;
 	create_thread = p_create_thread;

--- a/servers/physics_2d/physics_server_2d_wrap_mt.cpp
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.cpp
@@ -113,19 +113,6 @@ void PhysicsServer2DWrapMT::finish() {
 	} else {
 		physics_2d_server->finish();
 	}
-
-	line_shape_free_cached_ids();
-	ray_shape_free_cached_ids();
-	segment_shape_free_cached_ids();
-	circle_shape_free_cached_ids();
-	rectangle_shape_free_cached_ids();
-	capsule_shape_free_cached_ids();
-	convex_polygon_shape_free_cached_ids();
-	concave_polygon_shape_free_cached_ids();
-
-	space_free_cached_ids();
-	area_free_cached_ids();
-	body_free_cached_ids();
 }
 
 PhysicsServer2DWrapMT::PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool p_create_thread) :
@@ -134,8 +121,6 @@ PhysicsServer2DWrapMT::PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool 
 	create_thread = p_create_thread;
 	step_pending = 0;
 	step_thread_up = false;
-
-	pool_max_size = GLOBAL_GET("memory/limits/multithreaded_server/rid_pool_prealloc");
 
 	if (!p_create_thread) {
 		server_thread = Thread::get_caller_id();

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -34,7 +34,7 @@
 #include "core/config/project_settings.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
-#include "servers/physics_server_2d.h"
+#include "servers/physics_server_2d_reserving.h"
 
 #ifdef DEBUG_SYNC
 #define SYNC_DEBUG print_line("sync on: " + String(__FUNCTION__));
@@ -43,7 +43,7 @@
 #endif
 
 class PhysicsServer2DWrapMT : public PhysicsServer2D {
-	mutable PhysicsServer2D *physics_2d_server;
+	mutable PhysicsServer2DReserving *physics_2d_server;
 
 	mutable CommandQueueMT command_queue;
 
@@ -67,7 +67,7 @@ class PhysicsServer2DWrapMT : public PhysicsServer2D {
 	bool first_frame;
 
 public:
-#define ServerName PhysicsServer2D
+#define ServerName PhysicsServer2DReserving
 #define ServerNameWrapMT PhysicsServer2DWrapMT
 #define server_name physics_2d_server
 #include "servers/server_wrap_mt_common.h"
@@ -309,7 +309,7 @@ public:
 		return physics_2d_server->get_process_info(p_info);
 	}
 
-	PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool p_create_thread);
+	PhysicsServer2DWrapMT(PhysicsServer2DReserving *p_contained, bool p_create_thread);
 	~PhysicsServer2DWrapMT();
 
 	template <class T>

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -66,9 +66,6 @@ class PhysicsServer2DWrapMT : public PhysicsServer2D {
 
 	bool first_frame;
 
-	Mutex alloc_mutex;
-	int pool_max_size;
-
 public:
 #define ServerName PhysicsServer2D
 #define ServerNameWrapMT PhysicsServer2DWrapMT

--- a/servers/physics_server_2d_reserving.h
+++ b/servers/physics_server_2d_reserving.h
@@ -1,0 +1,58 @@
+/*************************************************************************/
+/*  physics_server_2d_reserving.h                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PHYSICS_2D_SERVER_RESERVING_H
+#define PHYSICS_2D_SERVER_RESERVING_H
+
+#include "servers/physics_server_2d.h"
+
+#define DECLARE_RESERVING_API(m_type)                             \
+	virtual RID m_type##_create() = 0;                            \
+	virtual RID m_type##_create_reserved(RID p_reserved_rid) = 0; \
+	virtual RID m_type##_reserve_rid() = 0;
+
+class PhysicsServer2DReserving : public PhysicsServer2D {
+public:
+	DECLARE_RESERVING_API(line_shape)
+	DECLARE_RESERVING_API(ray_shape)
+	DECLARE_RESERVING_API(segment_shape)
+	DECLARE_RESERVING_API(circle_shape)
+	DECLARE_RESERVING_API(rectangle_shape)
+	DECLARE_RESERVING_API(capsule_shape)
+	DECLARE_RESERVING_API(convex_polygon_shape)
+	DECLARE_RESERVING_API(concave_polygon_shape)
+	DECLARE_RESERVING_API(space)
+	DECLARE_RESERVING_API(area)
+	DECLARE_RESERVING_API(body)
+};
+
+#undef DECLARE_RESERVING_API
+
+#endif // PHYSICS_2D_SERVER_RESERVING_H

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -97,7 +97,7 @@ void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, Transform2
 	}
 }
 
-void _mark_ysort_dirty(RendererCanvasCull::Item *ysort_owner, RID_PtrOwner<RendererCanvasCull::Item> &canvas_item_owner) {
+void _mark_ysort_dirty(RendererCanvasCull::Item *ysort_owner, RID_PtrOwner<RendererCanvasCull::Item, true> &canvas_item_owner) {
 	do {
 		ysort_owner->ysort_children_count = -1;
 		ysort_owner = canvas_item_owner.owns(ysort_owner->parent) ? canvas_item_owner.getornull(ysort_owner->parent) : nullptr;
@@ -356,10 +356,10 @@ bool RendererCanvasCull::was_sdf_used() {
 	return sdf_used;
 }
 
-RID RendererCanvasCull::canvas_create() {
+RID RendererCanvasCull::canvas_create(RID p_reserved_rid) {
 	Canvas *canvas = memnew(Canvas);
 	ERR_FAIL_COND_V(!canvas, RID());
-	RID rid = canvas_owner.make_rid(canvas);
+	RID rid = canvas_owner.make_rid(canvas, p_reserved_rid);
 
 	return rid;
 }
@@ -393,11 +393,11 @@ void RendererCanvasCull::canvas_set_parent(RID p_canvas, RID p_parent, float p_s
 	canvas->parent_scale = p_scale;
 }
 
-RID RendererCanvasCull::canvas_item_create() {
+RID RendererCanvasCull::canvas_item_create(RID p_reserved_rid) {
 	Item *canvas_item = memnew(Item);
 	ERR_FAIL_COND_V(!canvas_item, RID());
 
-	return canvas_item_owner.make_rid(canvas_item);
+	return canvas_item_owner.make_rid(canvas_item, p_reserved_rid);
 }
 
 void RendererCanvasCull::canvas_item_set_parent(RID p_item, RID p_parent) {
@@ -1075,10 +1075,10 @@ void RendererCanvasCull::canvas_item_set_canvas_group_mode(RID p_item, RS::Canva
 	}
 }
 
-RID RendererCanvasCull::canvas_light_create() {
+RID RendererCanvasCull::canvas_light_create(RID p_reserved_rid) {
 	RendererCanvasRender::Light *clight = memnew(RendererCanvasRender::Light);
 	clight->light_internal = RSG::canvas_render->light_create();
-	return canvas_light_owner.make_rid(clight);
+	return canvas_light_owner.make_rid(clight, p_reserved_rid);
 }
 
 void RendererCanvasCull::canvas_light_set_mode(RID p_light, RS::CanvasLightMode p_mode) {
@@ -1268,10 +1268,10 @@ void RendererCanvasCull::canvas_light_set_shadow_smooth(RID p_light, float p_smo
 	clight->shadow_smooth = p_smooth;
 }
 
-RID RendererCanvasCull::canvas_light_occluder_create() {
+RID RendererCanvasCull::canvas_light_occluder_create(RID p_reserved_rid) {
 	RendererCanvasRender::LightOccluderInstance *occluder = memnew(RendererCanvasRender::LightOccluderInstance);
 
-	return canvas_light_occluder_owner.make_rid(occluder);
+	return canvas_light_occluder_owner.make_rid(occluder, p_reserved_rid);
 }
 
 void RendererCanvasCull::canvas_light_occluder_attach_to_canvas(RID p_occluder, RID p_canvas) {
@@ -1349,10 +1349,10 @@ void RendererCanvasCull::canvas_light_occluder_set_light_mask(RID p_occluder, in
 	occluder->light_mask = p_mask;
 }
 
-RID RendererCanvasCull::canvas_occluder_polygon_create() {
+RID RendererCanvasCull::canvas_occluder_polygon_create(RID p_reserved_rid) {
 	LightOccluderPolygon *occluder_poly = memnew(LightOccluderPolygon);
 	occluder_poly->occluder = RSG::canvas_render->occluder_polygon_create();
-	return canvas_light_occluder_polygon_owner.make_rid(occluder_poly);
+	return canvas_light_occluder_polygon_owner.make_rid(occluder_poly, p_reserved_rid);
 }
 
 void RendererCanvasCull::canvas_occluder_polygon_set_shape(RID p_occluder_polygon, const Vector<Vector2> &p_shape, bool p_closed) {
@@ -1393,8 +1393,12 @@ void RendererCanvasCull::canvas_set_shadow_texture_size(int p_size) {
 	RSG::canvas_render->set_shadow_texture_size(p_size);
 }
 
-RID RendererCanvasCull::canvas_texture_create() {
-	return RSG::storage->canvas_texture_create();
+RID RendererCanvasCull::canvas_texture_create(RID p_reserved_rid) {
+	return RSG::storage->canvas_texture_create(p_reserved_rid);
+}
+
+RID RendererCanvasCull::canvas_texture_reserve_rid() {
+	return RSG::storage->canvas_texture_reserve_rid();
 }
 
 void RendererCanvasCull::canvas_texture_set_channel(RID p_canvas_texture, RS::CanvasTextureChannel p_channel, RID p_texture) {

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -101,9 +101,9 @@ public:
 		}
 	};
 
-	RID_PtrOwner<LightOccluderPolygon> canvas_light_occluder_polygon_owner;
+	RID_PtrOwner<LightOccluderPolygon, true> canvas_light_occluder_polygon_owner;
 
-	RID_PtrOwner<RendererCanvasRender::LightOccluderInstance> canvas_light_occluder_owner;
+	RID_PtrOwner<RendererCanvasRender::LightOccluderInstance, true> canvas_light_occluder_owner;
 
 	struct Canvas : public RendererViewport::CanvasBase {
 		Set<RID> viewports;
@@ -148,9 +148,9 @@ public:
 		}
 	};
 
-	mutable RID_PtrOwner<Canvas> canvas_owner;
-	RID_PtrOwner<Item> canvas_item_owner;
-	RID_PtrOwner<RendererCanvasRender::Light> canvas_light_owner;
+	mutable RID_PtrOwner<Canvas, true> canvas_owner;
+	RID_PtrOwner<Item, true> canvas_item_owner;
+	RID_PtrOwner<RendererCanvasRender::Light, true> canvas_light_owner;
 
 	bool disable_scale;
 	bool sdf_used = false;
@@ -168,13 +168,15 @@ public:
 
 	bool was_sdf_used();
 
-	RID canvas_create();
+	RID canvas_create(RID p_reserved_rid = RID());
+	RID canvas_reserve_rid() { return canvas_owner.reserve_rid(); }
 	void canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring);
 	void canvas_set_modulate(RID p_canvas, const Color &p_color);
 	void canvas_set_parent(RID p_canvas, RID p_parent, float p_scale);
 	void canvas_set_disable_scale(bool p_disable);
 
-	RID canvas_item_create();
+	RID canvas_item_create(RID p_reserved_rid = RID());
+	RID canvas_item_reserve_rid() { return canvas_item_owner.reserve_rid(); }
 	void canvas_item_set_parent(RID p_item, RID p_parent);
 
 	void canvas_item_set_visible(RID p_item, bool p_visible);
@@ -222,7 +224,8 @@ public:
 
 	void canvas_item_set_canvas_group_mode(RID p_item, RS::CanvasGroupMode p_mode, float p_clear_margin = 5.0, bool p_fit_empty = false, float p_fit_margin = 0.0, bool p_blur_mipmaps = false);
 
-	RID canvas_light_create();
+	RID canvas_light_create(RID p_reserved_rid = RID());
+	RID canvas_light_reserve_rid() { return canvas_light_owner.reserve_rid(); }
 	void canvas_light_set_mode(RID p_light, RS::CanvasLightMode p_mode);
 	void canvas_light_attach_to_canvas(RID p_light, RID p_canvas);
 	void canvas_light_set_enabled(RID p_light, bool p_enabled);
@@ -246,7 +249,8 @@ public:
 	void canvas_light_set_shadow_color(RID p_light, const Color &p_color);
 	void canvas_light_set_shadow_smooth(RID p_light, float p_smooth);
 
-	RID canvas_light_occluder_create();
+	RID canvas_light_occluder_create(RID p_reserved_rid = RID());
+	RID canvas_light_occluder_reserve_rid() { return canvas_light_occluder_owner.reserve_rid(); }
 	void canvas_light_occluder_attach_to_canvas(RID p_occluder, RID p_canvas);
 	void canvas_light_occluder_set_enabled(RID p_occluder, bool p_enabled);
 	void canvas_light_occluder_set_polygon(RID p_occluder, RID p_polygon);
@@ -254,14 +258,16 @@ public:
 	void canvas_light_occluder_set_transform(RID p_occluder, const Transform2D &p_xform);
 	void canvas_light_occluder_set_light_mask(RID p_occluder, int p_mask);
 
-	RID canvas_occluder_polygon_create();
+	RID canvas_occluder_polygon_create(RID p_reserved_rid = RID());
+	RID canvas_occluder_polygon_reserve_rid() { return canvas_light_occluder_polygon_owner.reserve_rid(); }
 	void canvas_occluder_polygon_set_shape(RID p_occluder_polygon, const Vector<Vector2> &p_shape, bool p_closed);
 
 	void canvas_occluder_polygon_set_cull_mode(RID p_occluder_polygon, RS::CanvasOccluderPolygonCullMode p_mode);
 
 	void canvas_set_shadow_texture_size(int p_size);
 
-	RID canvas_texture_create();
+	RID canvas_texture_create(RID p_reserved_rid = RID());
+	RID canvas_texture_reserve_rid();
 	void canvas_texture_set_channel(RID p_canvas_texture, RS::CanvasTextureChannel p_channel, RID p_texture);
 	void canvas_texture_set_shading_parameters(RID p_canvas_texture, const Color &p_base_color, float p_shininess);
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -270,7 +270,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		} shadow;
 	};
 
-	RID_Owner<CanvasLight> canvas_light_owner;
+	RID_Owner<CanvasLight, true> canvas_light_owner;
 
 	struct ShadowRenderPushConstant {
 		float projection[16];
@@ -314,7 +314,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		float atlas_rect[4];
 	};
 
-	RID_Owner<OccluderPolygon> occluder_polygon_owner;
+	RID_Owner<OccluderPolygon, true> occluder_polygon_owner;
 
 	enum ShadowRenderMode {
 		SHADOW_RENDER_MODE_SHADOW,

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1873,8 +1873,8 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 	RD::get_singleton()->draw_command_end_label();
 }
 
-RID RendererSceneRenderRD::sky_create() {
-	return sky_owner.make_rid(Sky());
+RID RendererSceneRenderRD::sky_create(RID p_reserved_rid) {
+	return sky_owner.make_rid(Sky(), p_reserved_rid);
 }
 
 void RendererSceneRenderRD::_sky_invalidate(Sky *p_sky) {
@@ -2898,8 +2898,8 @@ RendererStorageRD::MaterialData *RendererSceneRenderRD::_create_sky_material_fun
 	return material_data;
 }
 
-RID RendererSceneRenderRD::environment_create() {
-	return environment_owner.make_rid(Environment());
+RID RendererSceneRenderRD::environment_create(RID p_reserved_rid) {
+	return environment_owner.make_rid(Environment(), p_reserved_rid);
 }
 
 void RendererSceneRenderRD::environment_set_background(RID p_env, RS::EnvironmentBG p_bg) {
@@ -3333,7 +3333,7 @@ Ref<Image> RendererSceneRenderRD::environment_bake_panorama(RID p_env, bool p_ba
 
 ////////////////////////////////////////////////////////////
 
-RID RendererSceneRenderRD::reflection_atlas_create() {
+RID RendererSceneRenderRD::reflection_atlas_create(RID p_reserved_rid) {
 	ReflectionAtlas ra;
 	ra.count = GLOBAL_GET("rendering/quality/reflection_atlas/reflection_count");
 	ra.size = GLOBAL_GET("rendering/quality/reflection_atlas/reflection_size");
@@ -3342,7 +3342,7 @@ RID RendererSceneRenderRD::reflection_atlas_create() {
 	ra.cluster_builder->set_shared(&cluster_builder_shared);
 	ra.cluster_builder->setup(Size2i(ra.size, ra.size), max_cluster_elements, RID(), RID(), RID());
 
-	return reflection_atlas_owner.make_rid(ra);
+	return reflection_atlas_owner.make_rid(ra, p_reserved_rid);
 }
 
 void RendererSceneRenderRD::reflection_atlas_set_size(RID p_ref_atlas, int p_reflection_size, int p_reflection_count) {
@@ -3616,8 +3616,8 @@ RID RendererSceneRenderRD::reflection_probe_instance_get_depth_framebuffer(RID p
 
 ///////////////////////////////////////////////////////////
 
-RID RendererSceneRenderRD::shadow_atlas_create() {
-	return shadow_atlas_owner.make_rid(ShadowAtlas());
+RID RendererSceneRenderRD::shadow_atlas_create(RID p_reserved_rid) {
+	return shadow_atlas_owner.make_rid(ShadowAtlas(), p_reserved_rid);
 }
 
 void RendererSceneRenderRD::_update_shadow_atlas(ShadowAtlas *shadow_atlas) {
@@ -4005,8 +4005,8 @@ int RendererSceneRenderRD::get_directional_light_shadow_size(RID p_light_intance
 
 //////////////////////////////////////////////////
 
-RID RendererSceneRenderRD::camera_effects_create() {
-	return camera_effects_owner.make_rid(CameraEffects());
+RID RendererSceneRenderRD::camera_effects_create(RID p_reserved_rid) {
+	return camera_effects_owner.make_rid(CameraEffects(), p_reserved_rid);
 }
 
 void RendererSceneRenderRD::camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) {
@@ -5097,10 +5097,10 @@ void RendererSceneRenderRD::_debug_sdfgi_probes(RID p_render_buffers, RD::DrawLi
 }
 
 ////////////////////////////////
-RID RendererSceneRenderRD::render_buffers_create() {
+RID RendererSceneRenderRD::render_buffers_create(RID p_reserved_rid) {
 	RenderBuffers rb;
 	rb.data = _create_render_buffer_data();
-	return render_buffers_owner.make_rid(rb);
+	return render_buffers_owner.make_rid(rb, p_reserved_rid);
 }
 
 void RendererSceneRenderRD::_allocate_blur_textures(RenderBuffers *rb) {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -333,7 +333,7 @@ private:
 	uint32_t sky_ggx_samples_quality;
 	bool sky_use_cubemap_array;
 
-	mutable RID_Owner<Sky> sky_owner;
+	mutable RID_Owner<Sky, true> sky_owner;
 
 	/* REFLECTION ATLAS */
 
@@ -356,7 +356,7 @@ private:
 		ClusterBuilderRD *cluster_builder = nullptr;
 	};
 
-	mutable RID_Owner<ReflectionAtlas> reflection_atlas_owner;
+	mutable RID_Owner<ReflectionAtlas, true> reflection_atlas_owner;
 
 	/* REFLECTION PROBE INSTANCE */
 
@@ -595,7 +595,7 @@ private:
 		Vector<ShadowShrinkStage> shrink_stages;
 	};
 
-	RID_Owner<ShadowAtlas> shadow_atlas_owner;
+	RID_Owner<ShadowAtlas, true> shadow_atlas_owner;
 
 	void _update_shadow_atlas(ShadowAtlas *shadow_atlas);
 
@@ -817,7 +817,7 @@ private:
 
 	static uint64_t auto_exposure_counter;
 
-	mutable RID_Owner<Environment> environment_owner;
+	mutable RID_Owner<Environment, true> environment_owner;
 
 	/* CAMERA EFFECTS */
 
@@ -843,7 +843,7 @@ private:
 	float sss_scale = 0.05;
 	float sss_depth_scale = 0.01;
 
-	mutable RID_Owner<CameraEffects> camera_effects_owner;
+	mutable RID_Owner<CameraEffects, true> camera_effects_owner;
 
 	/* RENDER BUFFERS */
 
@@ -1326,7 +1326,7 @@ private:
 	float screen_space_roughness_limiter_amount = 0.25;
 	float screen_space_roughness_limiter_limit = 0.18;
 
-	mutable RID_Owner<RenderBuffers> render_buffers_owner;
+	mutable RID_Owner<RenderBuffers, true> render_buffers_owner;
 
 	void _free_render_buffer_data(RenderBuffers *rb);
 	void _allocate_blur_textures(RenderBuffers *rb);
@@ -1624,7 +1624,9 @@ public:
 
 	/* SHADOW ATLAS API */
 
-	RID shadow_atlas_create();
+	RID shadow_atlas_create(RID p_reserved_rid = RID());
+	RID shadow_atlas_reserve_rid() { return shadow_atlas_owner.reserve_rid(); }
+
 	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false);
 	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision);
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version);
@@ -1668,7 +1670,9 @@ public:
 	RID sdfgi_get_ubo() const { return gi.sdfgi_ubo; }
 	/* SKY API */
 
-	RID sky_create();
+	RID sky_create(RID p_reserved_rid = RID());
+	RID sky_reserve_rid() { return sky_owner.reserve_rid(); }
+
 	void sky_set_radiance_size(RID p_sky, int p_radiance_size);
 	void sky_set_mode(RID p_sky, RS::SkyMode p_mode);
 	void sky_set_material(RID p_sky, RID p_material);
@@ -1680,7 +1684,8 @@ public:
 
 	/* ENVIRONMENT API */
 
-	RID environment_create();
+	RID environment_create(RID p_reserved_rid = RID());
+	RID environment_reserve_rid() { return environment_owner.reserve_rid(); }
 
 	void environment_set_background(RID p_env, RS::EnvironmentBG p_bg);
 	void environment_set_sky(RID p_env, RID p_sky);
@@ -1750,7 +1755,8 @@ public:
 
 	virtual Ref<Image> environment_bake_panorama(RID p_env, bool p_bake_irradiance, const Size2i &p_size);
 
-	virtual RID camera_effects_create();
+	virtual RID camera_effects_create(RID p_reserved_rid = RID());
+	virtual RID camera_effects_reserve_rid() { return camera_effects_owner.reserve_rid(); }
 
 	virtual void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter);
 	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape);
@@ -1889,7 +1895,8 @@ public:
 		return li->light_type;
 	}
 
-	virtual RID reflection_atlas_create();
+	virtual RID reflection_atlas_create(RID p_reserved_rid = RID());
+	virtual RID reflection_atlas_reserve_rid() { return reflection_atlas_owner.reserve_rid(); }
 	virtual void reflection_atlas_set_size(RID p_ref_atlas, int p_reflection_size, int p_reflection_count);
 	virtual int reflection_atlas_get_size(RID p_ref_atlas) const;
 
@@ -2037,7 +2044,9 @@ public:
 		return g_probe->last_pass;
 	}
 */
-	RID render_buffers_create();
+	RID render_buffers_create(RID p_reserved_rid = RID());
+	RID render_buffers_reserve_rid() { return render_buffers_owner.reserve_rid(); }
+
 	void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding);
 	void gi_set_use_half_resolution(bool p_enable);
 

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -1223,8 +1223,8 @@ RendererStorageRD::CanvasTexture::~CanvasTexture() {
 	clear_sets();
 }
 
-RID RendererStorageRD::canvas_texture_create() {
-	return canvas_texture_owner.make_rid(memnew(CanvasTexture));
+RID RendererStorageRD::canvas_texture_create(RID p_reserved_rid) {
+	return canvas_texture_owner.make_rid(memnew(CanvasTexture), p_reserved_rid);
 }
 
 void RendererStorageRD::canvas_texture_set_channel(RID p_canvas_texture, RS::CanvasTextureChannel p_channel, RID p_texture) {
@@ -1365,12 +1365,12 @@ bool RendererStorageRD::canvas_texture_get_uniform_set(RID p_texture, RS::Canvas
 
 /* SHADER API */
 
-RID RendererStorageRD::shader_create() {
+RID RendererStorageRD::shader_create(RID p_reserved_rid) {
 	Shader shader;
 	shader.data = nullptr;
 	shader.type = SHADER_TYPE_MAX;
 
-	return shader_owner.make_rid(shader);
+	return shader_owner.make_rid(shader, p_reserved_rid);
 }
 
 void RendererStorageRD::shader_set_code(RID p_shader, const String &p_code) {
@@ -1510,7 +1510,7 @@ RS::ShaderNativeSourceCode RendererStorageRD::shader_get_native_source_code(RID 
 
 /* COMMON MATERIAL API */
 
-RID RendererStorageRD::material_create() {
+RID RendererStorageRD::material_create(RID p_reserved_rid) {
 	Material material;
 	material.data = nullptr;
 	material.shader = nullptr;
@@ -1520,7 +1520,7 @@ RID RendererStorageRD::material_create() {
 	material.uniform_dirty = false;
 	material.texture_dirty = false;
 	material.priority = 0;
-	RID id = material_owner.make_rid(material);
+	RID id = material_owner.make_rid(material, p_reserved_rid);
 	{
 		Material *material_ptr = material_owner.getornull(id);
 		material_ptr->self = id;
@@ -2399,8 +2399,8 @@ void RendererStorageRD::_update_queued_materials() {
 
 /* MESH API */
 
-RID RendererStorageRD::mesh_create() {
-	return mesh_owner.make_rid(Mesh());
+RID RendererStorageRD::mesh_create(RID p_reserved_rid) {
+	return mesh_owner.make_rid(Mesh(), p_reserved_rid);
 }
 
 void RendererStorageRD::mesh_set_blend_shape_count(RID p_mesh, int p_blend_shape_count) {
@@ -3298,8 +3298,8 @@ void RendererStorageRD::_mesh_surface_generate_version_for_input_mask(Mesh::Surf
 
 ////////////////// MULTIMESH
 
-RID RendererStorageRD::multimesh_create() {
-	return multimesh_owner.make_rid(MultiMesh());
+RID RendererStorageRD::multimesh_create(RID p_reserved_rid) {
+	return multimesh_owner.make_rid(MultiMesh(), p_reserved_rid);
 }
 
 void RendererStorageRD::multimesh_allocate(RID p_multimesh, int p_instances, RS::MultimeshTransformFormat p_transform_format, bool p_use_colors, bool p_use_custom_data) {
@@ -3849,8 +3849,8 @@ void RendererStorageRD::_update_dirty_multimeshes() {
 
 /* PARTICLES */
 
-RID RendererStorageRD::particles_create() {
-	return particles_owner.make_rid(Particles());
+RID RendererStorageRD::particles_create(RID p_reserved_rid) {
+	return particles_owner.make_rid(Particles(), p_reserved_rid);
 }
 
 void RendererStorageRD::particles_set_emitting(RID p_particles, bool p_emitting) {
@@ -4984,8 +4984,8 @@ RendererStorageRD::MaterialData *RendererStorageRD::_create_particles_material_f
 
 /* PARTICLES COLLISION API */
 
-RID RendererStorageRD::particles_collision_create() {
-	return particles_collision_owner.make_rid(ParticlesCollision());
+RID RendererStorageRD::particles_collision_create(RID p_reserved_rid) {
+	return particles_collision_owner.make_rid(ParticlesCollision(), p_reserved_rid);
 }
 
 RID RendererStorageRD::particles_collision_get_heightfield_framebuffer(RID p_particles_collision) const {
@@ -5164,8 +5164,8 @@ void RendererStorageRD::particles_collision_instance_set_active(RID p_collision_
 
 /* SKELETON API */
 
-RID RendererStorageRD::skeleton_create() {
-	return skeleton_owner.make_rid(Skeleton());
+RID RendererStorageRD::skeleton_create(RID p_reserved_rid) {
+	return skeleton_owner.make_rid(Skeleton(), p_reserved_rid);
 }
 
 void RendererStorageRD::_skeleton_make_dirty(Skeleton *skeleton) {
@@ -5350,7 +5350,7 @@ void RendererStorageRD::_update_dirty_skeletons() {
 
 /* LIGHT */
 
-RID RendererStorageRD::light_create(RS::LightType p_type) {
+RID RendererStorageRD::light_create(RS::LightType p_type, RID p_reserved_rid) {
 	Light light;
 	light.type = p_type;
 
@@ -5374,7 +5374,7 @@ RID RendererStorageRD::light_create(RS::LightType p_type) {
 	light.param[RS::LIGHT_PARAM_SHADOW_VOLUMETRIC_FOG_FADE] = 1.0;
 	light.param[RS::LIGHT_PARAM_TRANSMITTANCE_BIAS] = 0.05;
 
-	return light_owner.make_rid(light);
+	return light_owner.make_rid(light, p_reserved_rid);
 }
 
 void RendererStorageRD::light_set_color(RID p_light, const Color &p_color) {
@@ -5612,8 +5612,8 @@ AABB RendererStorageRD::light_get_aabb(RID p_light) const {
 
 /* REFLECTION PROBE */
 
-RID RendererStorageRD::reflection_probe_create() {
-	return reflection_probe_owner.make_rid(ReflectionProbe());
+RID RendererStorageRD::reflection_probe_create(RID p_reserved_rid) {
+	return reflection_probe_owner.make_rid(ReflectionProbe(), p_reserved_rid);
 }
 
 void RendererStorageRD::reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode) {
@@ -5835,8 +5835,8 @@ float RendererStorageRD::reflection_probe_get_ambient_color_energy(RID p_probe) 
 	return reflection_probe->ambient_color_energy;
 }
 
-RID RendererStorageRD::decal_create() {
-	return decal_owner.make_rid(Decal());
+RID RendererStorageRD::decal_create(RID p_reserved_rid) {
+	return decal_owner.make_rid(Decal(), p_reserved_rid);
 }
 
 void RendererStorageRD::decal_set_extents(RID p_decal, const Vector3 &p_extents) {
@@ -5923,8 +5923,8 @@ AABB RendererStorageRD::decal_get_aabb(RID p_decal) const {
 	return AABB(-decal->extents, decal->extents * 2.0);
 }
 
-RID RendererStorageRD::gi_probe_create() {
-	return gi_probe_owner.make_rid(GIProbe());
+RID RendererStorageRD::gi_probe_create(RID p_reserved_rid) {
+	return gi_probe_owner.make_rid(GIProbe(), p_reserved_rid);
 }
 
 void RendererStorageRD::gi_probe_allocate(RID p_gi_probe, const Transform &p_to_cell_xform, const AABB &p_aabb, const Vector3i &p_octree_size, const Vector<uint8_t> &p_octree_cells, const Vector<uint8_t> &p_data_cells, const Vector<uint8_t> &p_distance_field, const Vector<int> &p_level_counts) {
@@ -6276,8 +6276,8 @@ RID RendererStorageRD::gi_probe_get_sdf_texture(RID p_gi_probe) {
 
 /* LIGHTMAP API */
 
-RID RendererStorageRD::lightmap_create() {
-	return lightmap_owner.make_rid(Lightmap());
+RID RendererStorageRD::lightmap_create(RID p_reserved_rid) {
+	return lightmap_owner.make_rid(Lightmap(), p_reserved_rid);
 }
 
 void RendererStorageRD::lightmap_set_textures(RID p_lightmap, RID p_light, bool p_uses_spherical_haromics) {
@@ -6613,7 +6613,7 @@ void RendererStorageRD::_create_render_target_backbuffer(RenderTarget *rt) {
 	}
 }
 
-RID RendererStorageRD::render_target_create() {
+RID RendererStorageRD::render_target_create(RID p_reserved_rid) {
 	RenderTarget render_target;
 
 	render_target.was_used = false;
@@ -6623,7 +6623,7 @@ RID RendererStorageRD::render_target_create() {
 		render_target.flags[i] = false;
 	}
 	_update_render_target(&render_target);
-	return render_target_owner.make_rid(render_target);
+	return render_target_owner.make_rid(render_target, p_reserved_rid);
 }
 
 void RendererStorageRD::render_target_set_position(RID p_render_target, int p_x, int p_y) {

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -221,7 +221,7 @@ private:
 		~CanvasTexture();
 	};
 
-	RID_PtrOwner<CanvasTexture> canvas_texture_owner;
+	RID_PtrOwner<CanvasTexture, true> canvas_texture_owner;
 
 	/* TEXTURE API */
 	struct Texture {
@@ -367,7 +367,7 @@ private:
 	};
 
 	ShaderDataRequestFunction shader_data_request_func[SHADER_TYPE_MAX];
-	mutable RID_Owner<Shader> shader_owner;
+	mutable RID_Owner<Shader, true> shader_owner;
 
 	/* Material */
 
@@ -389,7 +389,7 @@ private:
 	};
 
 	MaterialDataRequestFunction material_data_request_func[SHADER_TYPE_MAX];
-	mutable RID_Owner<Material> material_owner;
+	mutable RID_Owner<Material, true> material_owner;
 
 	Material *material_update_list;
 	void _material_queue_update(Material *material, bool p_uniform, bool p_texture);
@@ -484,7 +484,7 @@ private:
 		Dependency dependency;
 	};
 
-	mutable RID_Owner<Mesh> mesh_owner;
+	mutable RID_Owner<Mesh, true> mesh_owner;
 
 	struct MeshInstance {
 		Mesh *mesh;
@@ -587,7 +587,7 @@ private:
 		Dependency dependency;
 	};
 
-	mutable RID_Owner<MultiMesh> multimesh_owner;
+	mutable RID_Owner<MultiMesh, true> multimesh_owner;
 
 	MultiMesh *multimesh_dirty_list = nullptr;
 
@@ -893,7 +893,7 @@ private:
 
 	void update_particles();
 
-	mutable RID_Owner<Particles> particles_owner;
+	mutable RID_Owner<Particles, true> particles_owner;
 
 	/* Particles Collision */
 
@@ -915,7 +915,7 @@ private:
 		Dependency dependency;
 	};
 
-	mutable RID_Owner<ParticlesCollision> particles_collision_owner;
+	mutable RID_Owner<ParticlesCollision, true> particles_collision_owner;
 
 	struct ParticlesCollisionInstance {
 		RID collision;
@@ -945,7 +945,7 @@ private:
 		Dependency dependency;
 	};
 
-	mutable RID_Owner<Skeleton> skeleton_owner;
+	mutable RID_Owner<Skeleton, true> skeleton_owner;
 
 	_FORCE_INLINE_ void _skeleton_make_dirty(Skeleton *skeleton);
 
@@ -977,7 +977,7 @@ private:
 		Dependency dependency;
 	};
 
-	mutable RID_Owner<Light> light_owner;
+	mutable RID_Owner<Light, true> light_owner;
 
 	/* REFLECTION PROBE */
 
@@ -1000,7 +1000,7 @@ private:
 		Dependency dependency;
 	};
 
-	mutable RID_Owner<ReflectionProbe> reflection_probe_owner;
+	mutable RID_Owner<ReflectionProbe, true> reflection_probe_owner;
 
 	/* DECAL */
 
@@ -1021,7 +1021,7 @@ private:
 		Dependency dependency;
 	};
 
-	mutable RID_Owner<Decal> decal_owner;
+	mutable RID_Owner<Decal, true> decal_owner;
 
 	/* GI PROBE */
 
@@ -1064,7 +1064,7 @@ private:
 	RID giprobe_sdf_shader_version_shader;
 	RID giprobe_sdf_shader_pipeline;
 
-	mutable RID_Owner<GIProbe> gi_probe_owner;
+	mutable RID_Owner<GIProbe, true> gi_probe_owner;
 
 	/* REFLECTION PROBE */
 
@@ -1095,7 +1095,7 @@ private:
 
 	uint64_t lightmap_array_version = 0;
 
-	mutable RID_Owner<Lightmap> lightmap_owner;
+	mutable RID_Owner<Lightmap, true> lightmap_owner;
 
 	float lightmap_probe_capture_update_speed = 4;
 
@@ -1145,7 +1145,7 @@ private:
 		Color clear_color;
 	};
 
-	mutable RID_Owner<RenderTarget> render_target_owner;
+	mutable RID_Owner<RenderTarget, true> render_target_owner;
 
 	void _clear_render_target(RenderTarget *rt);
 	void _update_render_target(RenderTarget *rt);
@@ -1338,7 +1338,8 @@ public:
 
 	/* CANVAS TEXTURE API */
 
-	virtual RID canvas_texture_create();
+	virtual RID canvas_texture_create(RID p_reserved_rid = RID());
+	virtual RID canvas_texture_reserve_rid() { return canvas_texture_owner.reserve_rid(); }
 
 	virtual void canvas_texture_set_channel(RID p_canvas_texture, RS::CanvasTextureChannel p_channel, RID p_texture);
 	virtual void canvas_texture_set_shading_parameters(RID p_canvas_texture, const Color &p_specular_color, float p_shininess);
@@ -1350,7 +1351,8 @@ public:
 
 	/* SHADER API */
 
-	RID shader_create();
+	RID shader_create(RID p_reserved_rid = RID());
+	RID shader_reserve_rid() { return shader_owner.reserve_rid(); }
 
 	void shader_set_code(RID p_shader, const String &p_code);
 	String shader_get_code(RID p_shader) const;
@@ -1365,7 +1367,8 @@ public:
 
 	/* COMMON MATERIAL API */
 
-	RID material_create();
+	RID material_create(RID p_reserved_rid = RID());
+	RID material_reserve_rid() { return material_owner.reserve_rid(); }
 
 	void material_set_shader(RID p_material, RID p_shader);
 
@@ -1401,7 +1404,8 @@ public:
 
 	/* MESH API */
 
-	virtual RID mesh_create();
+	virtual RID mesh_create(RID p_reserved_rid = RID());
+	virtual RID mesh_reserve_rid() { return mesh_owner.reserve_rid(); }
 
 	virtual void mesh_set_blend_shape_count(RID p_mesh, int p_blend_shape_count);
 
@@ -1622,7 +1626,8 @@ public:
 
 	/* MULTIMESH API */
 
-	RID multimesh_create();
+	RID multimesh_create(RID p_reserved_rid = RID());
+	RID multimesh_reserve_rid() { return multimesh_owner.reserve_rid(); }
 
 	void multimesh_allocate(RID p_multimesh, int p_instances, RS::MultimeshTransformFormat p_transform_format, bool p_use_colors = false, bool p_use_custom_data = false);
 	int multimesh_get_instance_count(RID p_multimesh) const;
@@ -1688,7 +1693,8 @@ public:
 
 	/* IMMEDIATE API */
 
-	RID immediate_create() { return RID(); }
+	RID immediate_create(RID p_reserved_rid = RID()) { return RID(); }
+	RID immediate_reserve_rid() { return RID(); }
 	void immediate_begin(RID p_immediate, RS::PrimitiveType p_rimitive, RID p_texture = RID()) {}
 	void immediate_vertex(RID p_immediate, const Vector3 &p_vertex) {}
 	void immediate_normal(RID p_immediate, const Vector3 &p_normal) {}
@@ -1704,7 +1710,9 @@ public:
 
 	/* SKELETON API */
 
-	RID skeleton_create();
+	RID skeleton_create(RID p_reserved_rid = RID());
+	RID skeleton_reserve_rid() { return skeleton_owner.reserve_rid(); }
+
 	void skeleton_allocate(RID p_skeleton, int p_bones, bool p_2d_skeleton = false);
 	void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform);
 	void skeleton_set_world_transform(RID p_skeleton, bool p_enable, const Transform &p_world_transform);
@@ -1739,11 +1747,11 @@ public:
 	}
 	/* Light API */
 
-	RID light_create(RS::LightType p_type);
+	RID light_create(RS::LightType p_type, RID p_reserved_rid);
 
-	RID directional_light_create() { return light_create(RS::LIGHT_DIRECTIONAL); }
-	RID omni_light_create() { return light_create(RS::LIGHT_OMNI); }
-	RID spot_light_create() { return light_create(RS::LIGHT_SPOT); }
+	RID directional_light_reserve_rid() { return light_owner.reserve_rid(); }
+	RID omni_light_reserve_rid() { return light_owner.reserve_rid(); }
+	RID spot_light_reserve_rid() { return light_owner.reserve_rid(); }
 
 	void light_set_color(RID p_light, const Color &p_color);
 	void light_set_param(RID p_light, RS::LightParam p_param, float p_value);
@@ -1846,7 +1854,10 @@ public:
 
 	/* PROBE API */
 
-	RID reflection_probe_create();
+	RID reflection_probe_create(RID p_reserved_rid = RID());
+	RID reflection_probe_reserve_rid() {
+		return reflection_probe_owner.reserve_rid();
+	}
 
 	void reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode);
 	void reflection_probe_set_intensity(RID p_probe, float p_intensity);
@@ -1886,7 +1897,10 @@ public:
 
 	/* DECAL API */
 
-	virtual RID decal_create();
+	virtual RID decal_create(RID p_reserved_rid = RID());
+	virtual RID decal_reserve_rid() {
+		return decal_owner.reserve_rid();
+	}
 	virtual void decal_set_extents(RID p_decal, const Vector3 &p_extents);
 	virtual void decal_set_texture(RID p_decal, RS::DecalTexture p_type, RID p_texture);
 	virtual void decal_set_emission_energy(RID p_decal, float p_energy);
@@ -1961,7 +1975,10 @@ public:
 
 	/* GI PROBE API */
 
-	RID gi_probe_create();
+	RID gi_probe_create(RID p_reserved_rid = RID());
+	RID gi_probe_reserve_rid() {
+		return gi_probe_owner.reserve_rid();
+	}
 
 	void gi_probe_allocate(RID p_gi_probe, const Transform &p_to_cell_xform, const AABB &p_aabb, const Vector3i &p_octree_size, const Vector<uint8_t> &p_octree_cells, const Vector<uint8_t> &p_data_cells, const Vector<uint8_t> &p_distance_field, const Vector<int> &p_level_counts);
 
@@ -2014,7 +2031,10 @@ public:
 
 	/* LIGHTMAP CAPTURE */
 
-	virtual RID lightmap_create();
+	virtual RID lightmap_create(RID p_reserved_rid = RID());
+	virtual RID lightmap_reserve_rid() {
+		return lightmap_owner.reserve_rid();
+	}
 
 	virtual void lightmap_set_textures(RID p_lightmap, RID p_light, bool p_uses_spherical_haromics);
 	virtual void lightmap_set_probe_bounds(RID p_lightmap, const AABB &p_bounds);
@@ -2063,7 +2083,10 @@ public:
 
 	/* PARTICLES */
 
-	RID particles_create();
+	RID particles_create(RID p_reserved_rid = RID());
+	RID particles_reserve_rid() {
+		return particles_owner.reserve_rid();
+	}
 
 	void particles_set_emitting(RID p_particles, bool p_emitting);
 	void particles_set_amount(RID p_particles, int p_amount);
@@ -2141,7 +2164,10 @@ public:
 
 	/* PARTICLES COLLISION */
 
-	virtual RID particles_collision_create();
+	virtual RID particles_collision_create(RID p_reserved_rid = RID());
+	virtual RID particles_collision_reserve_rid() {
+		return particles_collision_owner.reserve_rid();
+	}
 	virtual void particles_collision_set_collision_type(RID p_particles_collision, RS::ParticlesCollisionType p_type);
 	virtual void particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask);
 	virtual void particles_collision_set_sphere_radius(RID p_particles_collision, float p_radius); //for spheres
@@ -2185,7 +2211,9 @@ public:
 
 	/* RENDER TARGET API */
 
-	RID render_target_create();
+	RID render_target_create(RID p_reserved_rid = RID());
+	RID render_target_reserve_rid() { return render_target_owner.reserve_rid(); }
+
 	void render_target_set_position(RID p_render_target, int p_x, int p_y);
 	void render_target_set_size(RID p_render_target, int p_width, int p_height);
 	RID render_target_get_texture(RID p_render_target);
@@ -2235,11 +2263,19 @@ public:
 
 	void render_info_begin_capture() {}
 	void render_info_end_capture() {}
-	int get_captured_render_info(RS::RenderInfo p_info) { return 0; }
+	int get_captured_render_info(RS::RenderInfo p_info) {
+		return 0;
+	}
 
-	int get_render_info(RS::RenderInfo p_info) { return 0; }
-	String get_video_adapter_name() const { return String(); }
-	String get_video_adapter_vendor() const { return String(); }
+	int get_render_info(RS::RenderInfo p_info) {
+		return 0;
+	}
+	String get_video_adapter_name() const {
+		return String();
+	}
+	String get_video_adapter_vendor() const {
+		return String();
+	}
 
 	virtual void capture_timestamps_begin();
 	virtual void capture_timestamp(const String &p_name);
@@ -2249,7 +2285,9 @@ public:
 	virtual uint64_t get_captured_timestamp_cpu_time(uint32_t p_index) const;
 	virtual String get_captured_timestamp_name(uint32_t p_index) const;
 
-	RID get_default_rd_storage_buffer() { return default_rd_storage_buffer; }
+	RID get_default_rd_storage_buffer() {
+		return default_rd_storage_buffer;
+	}
 
 	static RendererStorageRD *base_singleton;
 

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -36,7 +36,8 @@
 
 class RendererScene {
 public:
-	virtual RID camera_create() = 0;
+	virtual RID camera_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID camera_reserve_rid() = 0;
 
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
@@ -48,7 +49,8 @@ public:
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable) = 0;
 	virtual bool is_camera(RID p_camera) const = 0;
 
-	virtual RID scenario_create() = 0;
+	virtual RID scenario_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID scenario_reserve_rid() = 0;
 
 	virtual void scenario_set_debug(RID p_scenario, RS::ScenarioDebugMode p_debug_mode) = 0;
 	virtual void scenario_set_environment(RID p_scenario, RID p_environment) = 0;
@@ -58,7 +60,8 @@ public:
 	virtual bool is_scenario(RID p_scenario) const = 0;
 	virtual RID scenario_get_environment(RID p_scenario) = 0;
 
-	virtual RID instance_create() = 0;
+	virtual RID instance_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID instance_reserve_rid() = 0;
 
 	virtual void instance_set_base(RID p_instance, RID p_base) = 0;
 	virtual void instance_set_scenario(RID p_instance, RID p_scenario) = 0;
@@ -99,7 +102,8 @@ public:
 
 	/* SKY API */
 
-	virtual RID sky_create() = 0;
+	virtual RID sky_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID sky_reserve_rid() = 0;
 	virtual void sky_set_radiance_size(RID p_sky, int p_radiance_size) = 0;
 	virtual void sky_set_mode(RID p_sky, RS::SkyMode p_samples) = 0;
 	virtual void sky_set_material(RID p_sky, RID p_material) = 0;
@@ -107,7 +111,8 @@ public:
 
 	/* ENVIRONMENT API */
 
-	virtual RID environment_create() = 0;
+	virtual RID environment_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID environment_reserve_rid() = 0;
 
 	virtual void environment_set_background(RID p_env, RS::EnvironmentBG p_bg) = 0;
 	virtual void environment_set_sky(RID p_env, RID p_sky) = 0;
@@ -161,7 +166,8 @@ public:
 
 	/* Camera Effects */
 
-	virtual RID camera_effects_create() = 0;
+	virtual RID camera_effects_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID camera_effects_reserve_rid() = 0;
 
 	virtual void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) = 0;
 	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) = 0;
@@ -172,13 +178,15 @@ public:
 	virtual void shadows_quality_set(RS::ShadowQuality p_quality) = 0;
 	virtual void directional_shadow_quality_set(RS::ShadowQuality p_quality) = 0;
 
-	virtual RID shadow_atlas_create() = 0;
+	virtual RID shadow_atlas_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID shadow_atlas_reserve_rid() = 0;
 	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_use_16_bits = false) = 0;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) = 0;
 
 	/* Render Buffers */
 
-	virtual RID render_buffers_create() = 0;
+	virtual RID render_buffers_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID render_buffers_reserve_rid() = 0;
 	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding) = 0;
 
 	virtual void gi_set_use_half_resolution(bool p_enable) = 0;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -39,9 +39,9 @@
 
 /* CAMERA API */
 
-RID RendererSceneCull::camera_create() {
+RID RendererSceneCull::camera_create(RID p_reserved_rid) {
 	Camera *camera = memnew(Camera);
-	return camera_owner.make_rid(camera);
+	return camera_owner.make_rid(camera, p_reserved_rid);
 }
 
 void RendererSceneCull::camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) {
@@ -290,10 +290,10 @@ void RendererSceneCull::_instance_unpair(Instance *p_A, Instance *p_B) {
 	}
 }
 
-RID RendererSceneCull::scenario_create() {
+RID RendererSceneCull::scenario_create(RID p_reserved_rid) {
 	Scenario *scenario = memnew(Scenario);
 	ERR_FAIL_COND_V(!scenario, RID());
-	RID scenario_rid = scenario_owner.make_rid(scenario);
+	RID scenario_rid = scenario_owner.make_rid(scenario, p_reserved_rid);
 	scenario->self = scenario_rid;
 
 	scenario->reflection_probe_shadow_atlas = scene_render->shadow_atlas_create();
@@ -367,11 +367,11 @@ void RendererSceneCull::_instance_queue_update(Instance *p_instance, bool p_upda
 	_instance_update_list.add(&p_instance->update_item);
 }
 
-RID RendererSceneCull::instance_create() {
+RID RendererSceneCull::instance_create(RID p_reserved_rid) {
 	Instance *instance = memnew(Instance);
 	ERR_FAIL_COND_V(!instance, RID());
 
-	RID instance_rid = instance_owner.make_rid(instance);
+	RID instance_rid = instance_owner.make_rid(instance, p_reserved_rid);
 	instance->self = instance_rid;
 
 	return instance_rid;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -94,9 +94,10 @@ public:
 		}
 	};
 
-	mutable RID_PtrOwner<Camera> camera_owner;
+	mutable RID_PtrOwner<Camera, true> camera_owner;
 
-	virtual RID camera_create();
+	virtual RID camera_create(RID p_reserved_rid = RID());
+	virtual RID camera_reserve_rid() { return camera_owner.reserve_rid(); }
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
@@ -296,14 +297,15 @@ public:
 
 	int indexer_update_iterations = 0;
 
-	mutable RID_PtrOwner<Scenario> scenario_owner;
+	mutable RID_PtrOwner<Scenario, true> scenario_owner;
 
 	static void _instance_pair(Instance *p_A, Instance *p_B);
 	static void _instance_unpair(Instance *p_A, Instance *p_B);
 
 	void _instance_update_mesh_instance(Instance *p_instance);
 
-	virtual RID scenario_create();
+	virtual RID scenario_create(RID p_reserved_rid = RID());
+	virtual RID scenario_reserve_rid() { return scenario_owner.reserve_rid(); }
 
 	virtual void scenario_set_debug(RID p_scenario, RS::ScenarioDebugMode p_debug_mode);
 	virtual void scenario_set_environment(RID p_scenario, RID p_environment);
@@ -824,11 +826,12 @@ public:
 
 	uint32_t thread_cull_threshold = 200;
 
-	RID_PtrOwner<Instance> instance_owner;
+	RID_PtrOwner<Instance, true> instance_owner;
 
 	uint32_t geometry_instance_pair_mask; // used in traditional forward, unnecesary on clustered
 
-	virtual RID instance_create();
+	virtual RID instance_create(RID p_reserved_rid = RID());
+	virtual RID instance_reserve_rid() { return instance_owner.reserve_rid(); }
 
 	virtual void instance_set_base(RID p_instance, RID p_base);
 	virtual void instance_set_scenario(RID p_instance, RID p_scenario);
@@ -957,13 +960,15 @@ public:
 
 	/* SKY API */
 
-	PASS0R(RID, sky_create)
+	PASS1R(RID, sky_create, RID)
+	PASS0R(RID, sky_reserve_rid)
 	PASS2(sky_set_radiance_size, RID, int)
 	PASS2(sky_set_mode, RID, RS::SkyMode)
 	PASS2(sky_set_material, RID, RID)
 	PASS4R(Ref<Image>, sky_bake_panorama, RID, float, bool, const Size2i &)
 
-	PASS0R(RID, environment_create)
+	PASS1R(RID, environment_create, RID)
+	PASS0R(RID, environment_reserve_rid)
 
 	PASS1RC(bool, is_environment, RID)
 
@@ -1014,7 +1019,8 @@ public:
 
 	/* CAMERA EFFECTS */
 
-	PASS0R(RID, camera_effects_create)
+	PASS1R(RID, camera_effects_create, RID)
+	PASS0R(RID, camera_effects_reserve_rid)
 
 	PASS2(camera_effects_set_dof_blur_quality, RS::DOFBlurQuality, bool)
 	PASS1(camera_effects_set_dof_blur_bokeh_shape, RS::DOFBokehShape)
@@ -1029,12 +1035,14 @@ public:
 
 	/* Render Buffers */
 
-	PASS0R(RID, render_buffers_create)
+	PASS1R(RID, render_buffers_create, RID)
+	PASS0R(RID, render_buffers_reserve_rid)
 	PASS7(render_buffers_configure, RID, RID, int, int, RS::ViewportMSAA, RS::ViewportScreenSpaceAA, bool)
 	PASS1(gi_set_use_half_resolution, bool)
 
 	/* Shadow Atlas */
-	PASS0R(RID, shadow_atlas_create)
+	PASS1R(RID, shadow_atlas_create, RID)
+	PASS0R(RID, shadow_atlas_reserve_rid)
 	PASS3(shadow_atlas_set_size, RID, int, bool)
 	PASS3(shadow_atlas_set_quadrant_subdivision, RID, int, int)
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -71,9 +71,9 @@ public:
 
 	/* SHADOW ATLAS API */
 
-	virtual RID
-	shadow_atlas_create() = 0;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) = 0;
+	virtual RID shadow_atlas_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID shadow_atlas_reserve_rid() = 0;
+	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_use_16_bits = false) = 0;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) = 0;
 	virtual bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) = 0;
 
@@ -90,7 +90,8 @@ public:
 
 	/* SKY API */
 
-	virtual RID sky_create() = 0;
+	virtual RID sky_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID sky_reserve_rid() = 0;
 	virtual void sky_set_radiance_size(RID p_sky, int p_radiance_size) = 0;
 	virtual void sky_set_mode(RID p_sky, RS::SkyMode p_samples) = 0;
 	virtual void sky_set_material(RID p_sky, RID p_material) = 0;
@@ -98,7 +99,8 @@ public:
 
 	/* ENVIRONMENT API */
 
-	virtual RID environment_create() = 0;
+	virtual RID environment_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID environment_reserve_rid() = 0;
 
 	virtual void environment_set_background(RID p_env, RS::EnvironmentBG p_bg) = 0;
 	virtual void environment_set_sky(RID p_env, RID p_sky) = 0;
@@ -149,7 +151,8 @@ public:
 	virtual RS::EnvironmentBG environment_get_background(RID p_env) const = 0;
 	virtual int environment_get_canvas_max_layer(RID p_env) const = 0;
 
-	virtual RID camera_effects_create() = 0;
+	virtual RID camera_effects_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID camera_effects_reserve_rid() = 0;
 
 	virtual void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) = 0;
 	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) = 0;
@@ -169,7 +172,8 @@ public:
 		return true;
 	}
 
-	virtual RID reflection_atlas_create() = 0;
+	virtual RID reflection_atlas_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID reflection_atlas_reserve_rid() = 0;
 	virtual void reflection_atlas_set_size(RID p_ref_atlas, int p_reflection_size, int p_reflection_count) = 0;
 	virtual int reflection_atlas_get_size(RID p_ref_atlas) const = 0;
 
@@ -225,7 +229,8 @@ public:
 	virtual void set_time(double p_time, double p_step) = 0;
 	virtual void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) = 0;
 
-	virtual RID render_buffers_create() = 0;
+	virtual RID render_buffers_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID render_buffers_reserve_rid() = 0;
 	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding) = 0;
 	virtual void gi_set_use_half_resolution(bool p_enable) = 0;
 

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -161,7 +161,9 @@ public:
 
 	/* CANVAS TEXTURE API */
 
-	virtual RID canvas_texture_create() = 0;
+	virtual RID canvas_texture_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID canvas_texture_reserve_rid() = 0;
+
 	virtual void canvas_texture_set_channel(RID p_canvas_texture, RS::CanvasTextureChannel p_channel, RID p_texture) = 0;
 	virtual void canvas_texture_set_shading_parameters(RID p_canvas_texture, const Color &p_base_color, float p_shininess) = 0;
 
@@ -170,7 +172,8 @@ public:
 
 	/* SHADER API */
 
-	virtual RID shader_create() = 0;
+	virtual RID shader_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID shader_reserve_rid() = 0;
 
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;
@@ -184,7 +187,8 @@ public:
 
 	/* COMMON MATERIAL API */
 
-	virtual RID material_create() = 0;
+	virtual RID material_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID material_reserve_rid() = 0;
 
 	virtual void material_set_render_priority(RID p_material, int priority) = 0;
 	virtual void material_set_shader(RID p_shader_material, RID p_shader) = 0;
@@ -209,7 +213,8 @@ public:
 
 	/* MESH API */
 
-	virtual RID mesh_create() = 0;
+	virtual RID mesh_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID mesh_reserve_rid() = 0;
 
 	virtual void mesh_set_blend_shape_count(RID p_mesh, int p_blend_shape_count) = 0;
 
@@ -251,7 +256,8 @@ public:
 
 	/* MULTIMESH API */
 
-	virtual RID multimesh_create() = 0;
+	virtual RID multimesh_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID multimesh_reserve_rid() = 0;
 
 	virtual void multimesh_allocate(RID p_multimesh, int p_instances, RS::MultimeshTransformFormat p_transform_format, bool p_use_colors = false, bool p_use_custom_data = false) = 0;
 
@@ -280,7 +286,9 @@ public:
 
 	/* IMMEDIATE API */
 
-	virtual RID immediate_create() = 0;
+	virtual RID immediate_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID immediate_reserve_rid() = 0;
+
 	virtual void immediate_begin(RID p_immediate, RS::PrimitiveType p_rimitive, RID p_texture = RID()) = 0;
 	virtual void immediate_vertex(RID p_immediate, const Vector3 &p_vertex) = 0;
 	virtual void immediate_normal(RID p_immediate, const Vector3 &p_normal) = 0;
@@ -296,7 +304,9 @@ public:
 
 	/* SKELETON API */
 
-	virtual RID skeleton_create() = 0;
+	virtual RID skeleton_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID skeleton_reserve_rid() = 0;
+
 	virtual void skeleton_allocate(RID p_skeleton, int p_bones, bool p_2d_skeleton = false) = 0;
 	virtual int skeleton_get_bone_count(RID p_skeleton) const = 0;
 	virtual void skeleton_bone_set_transform(RID p_skeleton, int p_bone, const Transform &p_transform) = 0;
@@ -307,11 +317,14 @@ public:
 
 	/* Light API */
 
-	virtual RID light_create(RS::LightType p_type) = 0;
+	virtual RID light_create(RS::LightType p_type, RID p_reserved_rid) = 0;
 
-	RID directional_light_create() { return light_create(RS::LIGHT_DIRECTIONAL); }
-	RID omni_light_create() { return light_create(RS::LIGHT_OMNI); }
-	RID spot_light_create() { return light_create(RS::LIGHT_SPOT); }
+	RID directional_light_create(RID p_reserved_rid = RID()) { return light_create(RS::LIGHT_DIRECTIONAL, p_reserved_rid); }
+	virtual RID directional_light_reserve_rid() = 0;
+	RID omni_light_create(RID p_reserved_rid = RID()) { return light_create(RS::LIGHT_OMNI, p_reserved_rid); }
+	virtual RID omni_light_reserve_rid() = 0;
+	RID spot_light_create(RID p_reserved_rid = RID()) { return light_create(RS::LIGHT_SPOT, p_reserved_rid); }
+	virtual RID spot_light_reserve_rid() = 0;
 
 	virtual void light_set_color(RID p_light, const Color &p_color) = 0;
 	virtual void light_set_param(RID p_light, RS::LightParam p_param, float p_value) = 0;
@@ -349,7 +362,8 @@ public:
 
 	/* PROBE API */
 
-	virtual RID reflection_probe_create() = 0;
+	virtual RID reflection_probe_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID reflection_probe_reserve_rid() = 0;
 
 	virtual void reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode) = 0;
 	virtual void reflection_probe_set_resolution(RID p_probe, int p_resolution) = 0;
@@ -380,7 +394,9 @@ public:
 
 	/* DECAL API */
 
-	virtual RID decal_create() = 0;
+	virtual RID decal_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID decal_reserve_rid() = 0;
+
 	virtual void decal_set_extents(RID p_decal, const Vector3 &p_extents) = 0;
 	virtual void decal_set_texture(RID p_decal, RS::DecalTexture p_type, RID p_texture) = 0;
 	virtual void decal_set_emission_energy(RID p_decal, float p_energy) = 0;
@@ -395,7 +411,8 @@ public:
 
 	/* GI PROBE API */
 
-	virtual RID gi_probe_create() = 0;
+	virtual RID gi_probe_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID gi_probe_reserve_rid() = 0;
 
 	virtual void gi_probe_allocate(RID p_gi_probe, const Transform &p_to_cell_xform, const AABB &p_aabb, const Vector3i &p_octree_size, const Vector<uint8_t> &p_octree_cells, const Vector<uint8_t> &p_data_cells, const Vector<uint8_t> &p_distance_field, const Vector<int> &p_level_counts) = 0;
 
@@ -442,7 +459,8 @@ public:
 
 	/* LIGHTMAP CAPTURE */
 
-	virtual RID lightmap_create() = 0;
+	virtual RID lightmap_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID lightmap_reserve_rid() = 0;
 
 	virtual void lightmap_set_textures(RID p_lightmap, RID p_light, bool p_uses_spherical_haromics) = 0;
 	virtual void lightmap_set_probe_bounds(RID p_lightmap, const AABB &p_bounds) = 0;
@@ -460,7 +478,8 @@ public:
 
 	/* PARTICLES */
 
-	virtual RID particles_create() = 0;
+	virtual RID particles_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID particles_reserve_rid() = 0;
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) = 0;
 	virtual bool particles_get_emitting(RID p_particles) = 0;
@@ -507,7 +526,9 @@ public:
 
 	/* PARTICLES COLLISION */
 
-	virtual RID particles_collision_create() = 0;
+	virtual RID particles_collision_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID particles_collision_reserve_rid() = 0;
+
 	virtual void particles_collision_set_collision_type(RID p_particles_collision, RS::ParticlesCollisionType p_type) = 0;
 	virtual void particles_collision_set_cull_mask(RID p_particles_collision, uint32_t p_cull_mask) = 0;
 	virtual void particles_collision_set_sphere_radius(RID p_particles_collision, float p_radius) = 0; //for spheres
@@ -553,7 +574,9 @@ public:
 		RENDER_TARGET_FLAG_MAX
 	};
 
-	virtual RID render_target_create() = 0;
+	virtual RID render_target_create(RID p_reserved_rid = RID()) = 0;
+	virtual RID render_target_reserve_rid() = 0;
+
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y) = 0;
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height) = 0;
 	virtual RID render_target_get_texture(RID p_render_target) = 0;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -608,10 +608,10 @@ void RendererViewport::draw_viewports() {
 	}
 }
 
-RID RendererViewport::viewport_create() {
+RID RendererViewport::viewport_create(RID p_reserved_rid) {
 	Viewport *viewport = memnew(Viewport);
 
-	RID rid = viewport_owner.make_rid(viewport);
+	RID rid = viewport_owner.make_rid(viewport, p_reserved_rid);
 
 	viewport->self = rid;
 	viewport->hide_scenario = false;

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -165,7 +165,7 @@ public:
 
 	uint64_t draw_viewports_pass = 0;
 
-	mutable RID_PtrOwner<Viewport> viewport_owner;
+	mutable RID_PtrOwner<Viewport, true> viewport_owner;
 
 	struct ViewportSort {
 		_FORCE_INLINE_ bool operator()(const Viewport *p_left, const Viewport *p_right) const {
@@ -186,7 +186,8 @@ private:
 	void _draw_viewport(Viewport *p_viewport, XRInterface::Eyes p_eye = XRInterface::EYE_MONO);
 
 public:
-	RID viewport_create();
+	RID viewport_create(RID p_reserved_rid = RID());
+	RID viewport_reserve_rid() { return viewport_owner.reserve_rid(); }
 
 	void viewport_set_use_xr(RID p_viewport, bool p_use_xr);
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -38,9 +38,9 @@
 #include "renderer_viewport.h"
 #include "rendering_server_globals.h"
 #include "servers/rendering/renderer_compositor.h"
-#include "servers/rendering_server.h"
+#include "servers/rendering_server_reserving.h"
 
-class RenderingServerDefault : public RenderingServer {
+class RenderingServerDefault : public RenderingServerReserving {
 	enum {
 		MAX_INSTANCE_CULL = 8192,
 		MAX_INSTANCE_LIGHTS = 4,
@@ -101,6 +101,11 @@ public:
 #define DISPLAY_CHANGED \
 	changes++;
 #endif
+
+#define BINDRID(m_name)                                                                                            \
+	virtual RID m_name##_create() { return BINDBASE->m_name##_create(); }                                          \
+	virtual RID m_name##_create_reserved(RID p_reserved_rid) { return BINDBASE->m_name##_create(p_reserved_rid); } \
+	virtual RID m_name##_reserve_rid() { return BINDBASE->m_name##_reserve_rid(); }
 
 #define BIND0R(m_r, m_name) \
 	m_r m_name() { return BINDBASE->m_name(); }
@@ -215,7 +220,7 @@ public:
 
 	/* SHADER API */
 
-	BIND0R(RID, shader_create)
+	BINDRID(shader)
 
 	BIND2(shader_set_code, RID, const String &)
 	BIND1RC(String, shader_get_code, RID)
@@ -230,7 +235,7 @@ public:
 
 	/* COMMON MATERIAL API */
 
-	BIND0R(RID, material_create)
+	BINDRID(material)
 
 	BIND2(material_set_shader, RID, RID)
 
@@ -253,7 +258,7 @@ public:
 
 	BIND2(mesh_set_blend_shape_count, RID, int)
 
-	BIND0R(RID, mesh_create)
+	BINDRID(mesh)
 
 	BIND2(mesh_add_surface, RID, const SurfaceData &)
 
@@ -280,7 +285,7 @@ public:
 
 	/* MULTIMESH API */
 
-	BIND0R(RID, multimesh_create)
+	BINDRID(multimesh)
 
 	BIND5(multimesh_allocate, RID, int, MultimeshTransformFormat, bool, bool)
 	BIND1RC(int, multimesh_get_instance_count, RID)
@@ -307,7 +312,7 @@ public:
 
 	/* IMMEDIATE API */
 
-	BIND0R(RID, immediate_create)
+	BINDRID(immediate)
 	BIND3(immediate_begin, RID, PrimitiveType, RID)
 	BIND2(immediate_vertex, RID, const Vector3 &)
 	BIND2(immediate_normal, RID, const Vector3 &)
@@ -322,7 +327,7 @@ public:
 
 	/* SKELETON API */
 
-	BIND0R(RID, skeleton_create)
+	BINDRID(skeleton)
 	BIND3(skeleton_allocate, RID, int, bool)
 	BIND1RC(int, skeleton_get_bone_count, RID)
 	BIND3(skeleton_bone_set_transform, RID, int, const Transform &)
@@ -333,9 +338,9 @@ public:
 
 	/* Light API */
 
-	BIND0R(RID, directional_light_create)
-	BIND0R(RID, omni_light_create)
-	BIND0R(RID, spot_light_create)
+	BINDRID(directional_light)
+	BINDRID(omni_light)
+	BINDRID(spot_light)
 
 	BIND2(light_set_color, RID, const Color &)
 	BIND3(light_set_param, RID, LightParam, float)
@@ -357,7 +362,7 @@ public:
 
 	/* PROBE API */
 
-	BIND0R(RID, reflection_probe_create)
+	BINDRID(reflection_probe)
 
 	BIND2(reflection_probe_set_update_mode, RID, ReflectionProbeUpdateMode)
 	BIND2(reflection_probe_set_intensity, RID, float)
@@ -376,7 +381,7 @@ public:
 
 	/* DECAL API */
 
-	BIND0R(RID, decal_create)
+	BINDRID(decal)
 
 	BIND2(decal_set_extents, RID, const Vector3 &)
 	BIND3(decal_set_texture, RID, DecalTexture, RID)
@@ -390,7 +395,7 @@ public:
 
 	/* BAKED LIGHT API */
 
-	BIND0R(RID, gi_probe_create)
+	BINDRID(gi_probe)
 
 	BIND8(gi_probe_allocate, RID, const Transform &, const AABB &, const Vector3i &, const Vector<uint8_t> &, const Vector<uint8_t> &, const Vector<uint8_t> &, const Vector<int> &)
 
@@ -434,7 +439,7 @@ public:
 
 	/* LIGHTMAP */
 
-	BIND0R(RID, lightmap_create)
+	BINDRID(lightmap)
 
 	BIND3(lightmap_set_textures, RID, RID, bool)
 	BIND2(lightmap_set_probe_bounds, RID, const AABB &)
@@ -448,7 +453,7 @@ public:
 
 	/* PARTICLES */
 
-	BIND0R(RID, particles_create)
+	BINDRID(particles)
 
 	BIND2(particles_set_emitting, RID, bool)
 	BIND1R(bool, particles_get_emitting, RID)
@@ -481,7 +486,7 @@ public:
 
 	/* PARTICLES COLLISION */
 
-	BIND0R(RID, particles_collision_create)
+	BINDRID(particles_collision)
 
 	BIND2(particles_collision_set_collision_type, RID, ParticlesCollisionType)
 	BIND2(particles_collision_set_cull_mask, RID, uint32_t)
@@ -500,7 +505,7 @@ public:
 
 	/* CAMERA API */
 
-	BIND0R(RID, camera_create)
+	BINDRID(camera)
 	BIND4(camera_set_perspective, RID, float, float, float)
 	BIND4(camera_set_orthogonal, RID, float, float, float)
 	BIND5(camera_set_frustum, RID, float, Vector2, float, float)
@@ -516,7 +521,7 @@ public:
 
 	/* VIEWPORT TARGET API */
 
-	BIND0R(RID, viewport_create)
+	BINDRID(viewport)
 
 	BIND2(viewport_set_use_xr, RID, bool)
 	BIND3(viewport_set_size, RID, int, int)
@@ -579,13 +584,13 @@ public:
 
 	/* SKY API */
 
-	BIND0R(RID, sky_create)
+	BINDRID(sky)
 	BIND2(sky_set_radiance_size, RID, int)
 	BIND2(sky_set_mode, RID, SkyMode)
 	BIND2(sky_set_material, RID, RID)
 	BIND4R(Ref<Image>, sky_bake_panorama, RID, float, bool, const Size2i &)
 
-	BIND0R(RID, environment_create)
+	BINDRID(environment)
 
 	BIND2(environment_set_background, RID, EnvironmentBG)
 	BIND2(environment_set_sky, RID, RID)
@@ -635,7 +640,7 @@ public:
 
 	/* CAMERA EFFECTS */
 
-	BIND0R(RID, camera_effects_create)
+	BINDRID(camera_effects)
 
 	BIND2(camera_effects_set_dof_blur_quality, DOFBlurQuality, bool)
 	BIND1(camera_effects_set_dof_blur_bokeh_shape, DOFBokehShape)
@@ -651,7 +656,7 @@ public:
 #undef BINDBASE
 #define BINDBASE RSG::scene
 
-	BIND0R(RID, scenario_create)
+	BINDRID(scenario)
 
 	BIND2(scenario_set_debug, RID, ScenarioDebugMode)
 	BIND2(scenario_set_environment, RID, RID)
@@ -659,7 +664,7 @@ public:
 	BIND2(scenario_set_fallback_environment, RID, RID)
 
 	/* INSTANCING API */
-	BIND0R(RID, instance_create)
+	BINDRID(instance)
 
 	BIND2(instance_set_base, RID, RID)
 	BIND2(instance_set_scenario, RID, RID)
@@ -706,20 +711,20 @@ public:
 
 	/* CANVAS (2D) */
 
-	BIND0R(RID, canvas_create)
+	BINDRID(canvas)
 	BIND3(canvas_set_item_mirroring, RID, RID, const Point2 &)
 	BIND2(canvas_set_modulate, RID, const Color &)
 	BIND3(canvas_set_parent, RID, RID, float)
 	BIND1(canvas_set_disable_scale, bool)
 
-	BIND0R(RID, canvas_texture_create)
+	BINDRID(canvas_texture)
 	BIND3(canvas_texture_set_channel, RID, CanvasTextureChannel, RID)
 	BIND3(canvas_texture_set_shading_parameters, RID, const Color &, float)
 
 	BIND2(canvas_texture_set_texture_filter, RID, CanvasItemTextureFilter)
 	BIND2(canvas_texture_set_texture_repeat, RID, CanvasItemTextureRepeat)
 
-	BIND0R(RID, canvas_item_create)
+	BINDRID(canvas_item)
 	BIND2(canvas_item_set_parent, RID, RID)
 
 	BIND2(canvas_item_set_default_texture_filter, RID, CanvasItemTextureFilter)
@@ -770,7 +775,7 @@ public:
 
 	BIND6(canvas_item_set_canvas_group_mode, RID, CanvasGroupMode, float, bool, float, bool)
 
-	BIND0R(RID, canvas_light_create)
+	BINDRID(canvas_light)
 
 	BIND2(canvas_light_set_mode, RID, CanvasLightMode)
 
@@ -796,7 +801,7 @@ public:
 	BIND2(canvas_light_set_shadow_color, RID, const Color &)
 	BIND2(canvas_light_set_shadow_smooth, RID, float)
 
-	BIND0R(RID, canvas_light_occluder_create)
+	BINDRID(canvas_light_occluder)
 	BIND2(canvas_light_occluder_attach_to_canvas, RID, RID)
 	BIND2(canvas_light_occluder_set_enabled, RID, bool)
 	BIND2(canvas_light_occluder_set_polygon, RID, RID)
@@ -804,7 +809,7 @@ public:
 	BIND2(canvas_light_occluder_set_transform, RID, const Transform2D &)
 	BIND2(canvas_light_occluder_set_light_mask, RID, int)
 
-	BIND0R(RID, canvas_occluder_polygon_create)
+	BINDRID(canvas_occluder_polygon)
 	BIND3(canvas_occluder_polygon_set_shape, RID, const Vector<Vector2> &, bool)
 
 	BIND2(canvas_occluder_polygon_set_cull_mode, RID, CanvasOccluderPolygonCullMode)

--- a/servers/rendering/rendering_server_wrap_mt.cpp
+++ b/servers/rendering/rendering_server_wrap_mt.cpp
@@ -124,7 +124,7 @@ void RenderingServerWrapMT::set_use_vsync_callback(bool p_enable) {
 
 RenderingServerWrapMT *RenderingServerWrapMT::singleton_mt = nullptr;
 
-RenderingServerWrapMT::RenderingServerWrapMT(RenderingServer *p_contained, bool p_create_thread) :
+RenderingServerWrapMT::RenderingServerWrapMT(RenderingServerReserving *p_contained, bool p_create_thread) :
 		command_queue(p_create_thread) {
 	singleton_mt = this;
 	DisplayServer::switch_vsync_function = set_use_vsync_callback; //as this goes to another thread, make sure it goes properly

--- a/servers/rendering/rendering_server_wrap_mt.cpp
+++ b/servers/rendering/rendering_server_wrap_mt.cpp
@@ -110,32 +110,6 @@ void RenderingServerWrapMT::init() {
 }
 
 void RenderingServerWrapMT::finish() {
-	sky_free_cached_ids();
-	shader_free_cached_ids();
-	material_free_cached_ids();
-	mesh_free_cached_ids();
-	multimesh_free_cached_ids();
-	immediate_free_cached_ids();
-	skeleton_free_cached_ids();
-	directional_light_free_cached_ids();
-	omni_light_free_cached_ids();
-	spot_light_free_cached_ids();
-	reflection_probe_free_cached_ids();
-	gi_probe_free_cached_ids();
-	lightmap_free_cached_ids();
-	particles_free_cached_ids();
-	particles_collision_free_cached_ids();
-	camera_free_cached_ids();
-	viewport_free_cached_ids();
-	environment_free_cached_ids();
-	camera_effects_free_cached_ids();
-	scenario_free_cached_ids();
-	instance_free_cached_ids();
-	canvas_free_cached_ids();
-	canvas_item_free_cached_ids();
-	canvas_light_occluder_free_cached_ids();
-	canvas_occluder_polygon_free_cached_ids();
-
 	if (create_thread) {
 		command_queue.push(this, &RenderingServerWrapMT::thread_exit);
 		thread.wait_to_finish();
@@ -159,7 +133,6 @@ RenderingServerWrapMT::RenderingServerWrapMT(RenderingServer *p_contained, bool 
 	create_thread = p_create_thread;
 	draw_pending = 0;
 	draw_thread_up = false;
-	pool_max_size = GLOBAL_GET("memory/limits/multithreaded_server/rid_pool_prealloc");
 
 	if (!p_create_thread) {
 		server_thread = Thread::get_caller_id();

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -655,7 +655,7 @@ public:
 
 	FUNC6(canvas_item_set_canvas_group_mode, RID, CanvasGroupMode, float, bool, float, bool)
 
-	FUNC0R(RID, canvas_light_create)
+	FUNCRID(canvas_light)
 
 	FUNC2(canvas_light_set_mode, RID, CanvasLightMode)
 

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -33,11 +33,11 @@
 
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
-#include "servers/rendering_server.h"
+#include "servers/rendering_server_reserving.h"
 
 class RenderingServerWrapMT : public RenderingServer {
 	// the real visual server
-	mutable RenderingServer *rendering_server;
+	mutable RenderingServerReserving *rendering_server;
 
 	mutable CommandQueueMT command_queue;
 
@@ -67,7 +67,7 @@ class RenderingServerWrapMT : public RenderingServer {
 #endif
 
 public:
-#define ServerName RenderingServer
+#define ServerName RenderingServerReserving
 #define ServerNameWrapMT RenderingServerWrapMT
 #define server_name rendering_server
 #include "servers/server_wrap_mt_common.h"
@@ -790,7 +790,7 @@ public:
 		rendering_server->set_print_gpu_profile(p_enable);
 	}
 
-	RenderingServerWrapMT(RenderingServer *p_contained, bool p_create_thread);
+	RenderingServerWrapMT(RenderingServerReserving *p_contained, bool p_create_thread);
 	~RenderingServerWrapMT();
 
 #undef ServerName

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -56,10 +56,6 @@ class RenderingServerWrapMT : public RenderingServer {
 
 	void thread_exit();
 
-	Mutex alloc_mutex;
-
-	int pool_max_size;
-
 	//#define DEBUG_SYNC
 
 	static RenderingServerWrapMT *singleton_mt;

--- a/servers/rendering_server_reserving.h
+++ b/servers/rendering_server_reserving.h
@@ -1,0 +1,75 @@
+/*************************************************************************/
+/*  rendering_server_reserving.h                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RENDERING_SERVER_RESERVING_H
+#define RENDERING_SERVER_RESERVING_H
+
+#include "servers/rendering_server.h"
+
+#define DECLARE_RESERVING_API(m_type)                             \
+	virtual RID m_type##_create() = 0;                            \
+	virtual RID m_type##_create_reserved(RID p_reserved_rid) = 0; \
+	virtual RID m_type##_reserve_rid() = 0;
+
+class RenderingServerReserving : public RenderingServer {
+public:
+	DECLARE_RESERVING_API(shader)
+	DECLARE_RESERVING_API(material)
+	DECLARE_RESERVING_API(mesh)
+	DECLARE_RESERVING_API(multimesh)
+	DECLARE_RESERVING_API(immediate)
+	DECLARE_RESERVING_API(skeleton)
+	DECLARE_RESERVING_API(directional_light)
+	DECLARE_RESERVING_API(omni_light)
+	DECLARE_RESERVING_API(spot_light)
+	DECLARE_RESERVING_API(reflection_probe)
+	DECLARE_RESERVING_API(decal)
+	DECLARE_RESERVING_API(gi_probe)
+	DECLARE_RESERVING_API(lightmap)
+	DECLARE_RESERVING_API(particles)
+	DECLARE_RESERVING_API(particles_collision)
+	DECLARE_RESERVING_API(camera)
+	DECLARE_RESERVING_API(viewport)
+	DECLARE_RESERVING_API(sky)
+	DECLARE_RESERVING_API(environment)
+	DECLARE_RESERVING_API(camera_effects)
+	DECLARE_RESERVING_API(scenario)
+	DECLARE_RESERVING_API(instance)
+	DECLARE_RESERVING_API(canvas)
+	DECLARE_RESERVING_API(canvas_texture)
+	DECLARE_RESERVING_API(canvas_item)
+	DECLARE_RESERVING_API(canvas_light)
+	DECLARE_RESERVING_API(canvas_light_occluder)
+	DECLARE_RESERVING_API(canvas_occluder_polygon)
+};
+
+#undef DECLARE_RESERVING_API
+
+#endif // RENDERING_SERVER_RESERVING_H


### PR DESCRIPTION
The goal is avoiding syncs in the multi-threaded servers when an item is created.

- Before this PR, a create command sent to a server via the MT queue needs to be executed so the call can return the created RID to the caller, which involves running every command in the queue (sync).
- After this PR, the caller gets an RID immediately (because it's just "reserved"), but the actual creation, which needs everything in the queue up to that point to have been processed, is put in the queue so it can be run when it's time, without having to sync.

This also removes the need of RID pooling, which was the former mechanism used to prevent syncs, less efficient than the current one.

The idea about separating allocation from initialization is @reduz's. This is the implementation I've been able to come up with.