### PR TITLE
[3.3] Use instance and first arg in Basis is_equal_approx

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -145,8 +145,8 @@ public:
 	}
 
 	bool is_equal_approx(const Basis &p_basis) const;
-	// TODO: Break compatibility in 4.0 by getting rid of this so that it's only an instance method. See also TODO in variant_call.cpp
-	bool is_equal_approx(const Basis &a, const Basis &b) const { return a.is_equal_approx(b); }
+	// For complicated reasons, the second argument is always discarded. See #45062.
+	bool is_equal_approx(const Basis &a, const Basis &b) const { return is_equal_approx(a); }
 	bool is_equal_approx_ratio(const Basis &a, const Basis &b, real_t p_epsilon = UNIT_EPSILON) const;
 
 	bool operator==(const Basis &p_matrix) const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -846,7 +846,7 @@ struct _VariantCall {
 	VCALL_PTR0R(Basis, get_orthogonal_index);
 	VCALL_PTR0R(Basis, orthonormalized);
 	VCALL_PTR2R(Basis, slerp);
-	VCALL_PTR2R(Basis, is_equal_approx); // TODO: Break compatibility in 4.0 to change this to an instance method (a.is_equal_approx(b) as VCALL_PTR1R) for consistency.
+	VCALL_PTR2R(Basis, is_equal_approx);
 	VCALL_PTR0R(Basis, get_rotation_quat);
 
 	VCALL_PTR0R(Transform, inverse);
@@ -1966,7 +1966,8 @@ void register_variant_methods() {
 	ADDFUNC1R(BASIS, VECTOR3, Basis, xform_inv, VECTOR3, "v", varray());
 	ADDFUNC0R(BASIS, INT, Basis, get_orthogonal_index, varray());
 	ADDFUNC2R(BASIS, BASIS, Basis, slerp, BASIS, "b", REAL, "t", varray());
-	ADDFUNC2R(BASIS, BOOL, Basis, is_equal_approx, BASIS, "b", REAL, "epsilon", varray(CMP_EPSILON)); // TODO: Replace in 4.0, see other TODO.
+	// For complicated reasons, the epsilon argument is always discarded. See #45062.
+	ADDFUNC2R(BASIS, BOOL, Basis, is_equal_approx, BASIS, "b", REAL, "epsilon", varray(CMP_EPSILON));
 	ADDFUNC0R(BASIS, QUAT, Basis, get_rotation_quat, varray());
 
 	ADDFUNC0R(TRANSFORM, TRANSFORM, Transform, inverse, varray());

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -115,6 +115,7 @@
 			</argument>
 			<description>
 				Returns [code]true[/code] if this basis and [code]b[/code] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
+				[b]Note:[/b] For complicated reasons, the epsilon argument is always discarded. Don't use the epsilon argument, it does nothing.
 			</description>
 		</method>
 		<method name="orthonormalized">


### PR DESCRIPTION
Fixes #45062, mutually exclusive with #45063 (so closes #45063). I'll copy/paste what I wrote in the issue:

Wow, I've been reviewing the history of this for the past hour. [Here is the root of the problem](https://github.com/godotengine/godot/blame/1fed266bf5452b30376db62495f4985f6975f2c1/core/math/basis.cpp#L560) (and [header](https://github.com/godotengine/godot/blame/1fed266bf5452b30376db62495f4985f6975f2c1/core/math/basis.h#L130)), @reduz wrote:

```cpp
bool Basis::is_equal_approx(const Basis &a, const Basis &b, real_t p_epsilon) const {
```

The above is an instance method which doesn't use an instance, which is bogus behavior. It means that you would need to do (in core in the C++ code, since this wasn't ever exposed to GDScript in this form):

```gdscript
b1.is_equal_approx(b2, b3)
```

Which would then discard `b1` and compare `b2` and `b3`.

Then, [this was later bound](https://github.com/godotengine/godot/commit/dee98d3b6d58cbe42fc403d999b278aec9447105#diff-4421d1b614fed4b54265f445a50a3521aeec63ab0efa55a9df639cd00cf987feR1847) by @reduz, a very subtle and innocent mistake caused by the method itself being bogus:

```cpp
ADDFUNC2R(BASIS, BOOL, Basis, is_equal_approx, BASIS, "b", FLOAT, "epsilon", varray(CMP_EPSILON));
```

Since this is actually an instance method, when bound to GDScript and we use `b1.is_equal_approx(b2)`, `b1` is discarded, and then `b2` is passed as `a`. For `b3`, `CMP_EPSILON` is silently auto-converted to `Basis` (which becomes the identity `Basis()`), and then it compares `b2` to the identity.

Now... what should we do about this? What we really want is to compare `b1` and `b2` and discard `b3`. In master we got rid of `b3` by binding the one-arg version, but for 3.2, here is a simple fix that doesn't break ABI compatibility.

```diff
-	bool is_equal_approx(const Basis &a, const Basis &b) const { return a.is_equal_approx(b); }
+	bool is_equal_approx(const Basis &a, const Basis &b) const { return is_equal_approx(a); }
```