### PR TITLE
Prevent editor crash due to modify the order of non-instance shader uniforms by instance uniforms

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -6305,7 +6305,9 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 						}
 
 						uniform2.texture_order = -1;
-						uniform2.order = uniforms++;
+						if (uniform_scope != ShaderNode::Uniform::SCOPE_INSTANCE) {
+							uniform2.order = uniforms++;
+						}
 					}
 					uniform2.type = type;
 					uniform2.scope = uniform_scope;


### PR DESCRIPTION
Order is ignored for them but the code is modifying the order for other uniforms which lead to a crash. Fix #40812