### PR TITLE
Fix file name comparison when new file is added to file system

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1477,20 +1477,21 @@ void EditorFileSystem::update_file(const String &p_file) {
 	String type = ResourceLoader::get_resource_type(p_file);
 
 	if (cpos == -1) {
-		//the file did not exist, it was added
+		// The file did not exist, it was added.
 
-		late_added_files.insert(p_file); //remember that it was added. This mean it will be scanned and imported on editor restart
+		late_added_files.insert(p_file); // Remember that it was added. This mean it will be scanned and imported on editor restart.
 		int idx = 0;
+		String file_name = p_file.get_file();
 
 		for (int i = 0; i < fs->files.size(); i++) {
-			if (p_file < fs->files[i]->file) {
+			if (file_name < fs->files[i]->file) {
 				break;
 			}
 			idx++;
 		}
 
 		EditorFileSystemDirectory::FileInfo *fi = memnew(EditorFileSystemDirectory::FileInfo);
-		fi->file = p_file.get_file();
+		fi->file = file_name;
 		fi->import_modified_time = 0;
 		fi->import_valid = ResourceLoader::is_import_valid(p_file);
 


### PR DESCRIPTION
Fixes #45027.

It was caused by improper comparison between full file path vs. file name only.