### PR TITLE
Clarify `lstrip()/rstrip()` methods in `String` for removed characters

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -406,7 +406,8 @@
 			<argument index="0" name="chars" type="String">
 			</argument>
 			<description>
-				Returns a copy of the string with characters removed from the left.
+				Returns a copy of the string with characters removed from the left. The [code]chars[/code] argument is a string specifying the set of characters to be removed.
+				[b]Note:[/b] The [code]chars[/code] is not a prefix. See [method trim_prefix] method that will remove a single prefix string rather than a set of characters.
 			</description>
 		</method>
 		<method name="match">
@@ -698,7 +699,8 @@
 			<argument index="0" name="chars" type="String">
 			</argument>
 			<description>
-				Returns a copy of the string with characters removed from the right.
+				Returns a copy of the string with characters removed from the right. The [code]chars[/code] argument is a string specifying the set of characters to be removed.
+				[b]Note:[/b] The [code]chars[/code] is not a suffix. See [method trim_suffix] method that will remove a single suffix string rather than a set of characters.
 			</description>
 		</method>
 		<method name="sha1_buffer">


### PR DESCRIPTION
Closes godotengine/godot-docs#4365.
Closes #45048.