### PR TITLE
Add X509CertificateMbedTLS string save and string load.

### DIFF
--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -63,6 +63,9 @@ X509Certificate *X509Certificate::create() {
 void X509Certificate::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save", "path"), &X509Certificate::save);
 	ClassDB::bind_method(D_METHOD("load", "path"), &X509Certificate::load);
+	ClassDB::bind_method(D_METHOD("set_certificate", "string"), &X509Certificate::set_certificate);
+	ClassDB::bind_method(D_METHOD("get_certificate"), &X509Certificate::get_certificate);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "certificate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_certificate", "get_certificate");
 }
 
 /// HMACContext

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -65,6 +65,8 @@ public:
 	virtual Error load(String p_path) = 0;
 	virtual Error load_from_memory(const uint8_t *p_buffer, int p_len) = 0;
 	virtual Error save(String p_path) = 0;
+	virtual Error set_certificate(String p_key) = 0;
+	virtual String get_certificate() = 0;
 };
 
 class HMACContext : public RefCounted {

--- a/doc/classes/X509Certificate.xml
+++ b/doc/classes/X509Certificate.xml
@@ -11,6 +11,11 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_certificate">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="load">
 			<return type="int" enum="Error" />
 			<argument index="0" name="path" type="String" />
@@ -23,6 +28,12 @@
 			<argument index="0" name="path" type="String" />
 			<description>
 				Saves a certificate to the given [code]path[/code] (should be a "*.crt" file).
+			</description>
+		</method>
+		<method name="set_certificate">
+			<return type="int" enum="Error" />
+			<argument index="0" name="string" type="String" />
+			<description>
 			</description>
 		</method>
 	</methods>

--- a/modules/mbedtls/crypto_mbedtls.h
+++ b/modules/mbedtls/crypto_mbedtls.h
@@ -82,9 +82,11 @@ public:
 	static void make_default() { X509Certificate::_create = create; }
 	static void finalize() { X509Certificate::_create = nullptr; }
 
-	virtual Error load(String p_path);
-	virtual Error load_from_memory(const uint8_t *p_buffer, int p_len);
-	virtual Error save(String p_path);
+	virtual Error load(String p_path) override;
+	virtual Error load_from_memory(const uint8_t *p_buffer, int p_len) override;
+	virtual Error save(String p_path) override;
+	virtual Error set_certificate(String p_key) override;
+	virtual String get_certificate() override;
 
 	X509CertificateMbedTLS() {
 		mbedtls_x509_crt_init(&cert);


### PR DESCRIPTION
The fingerprint RFCs for WebRTC are non-standard and make my head hurt. Read 4 sections and stopped.

Use case:

1. generate a rsa key cert 
2. send to signaling server the cert as a string
3. start dltsl server
4. have clients load from signaling server the cert from a string

Loading from the file system makes no sense.

Test project.

[Crypto Key Project.zip](https://github.com/godotengine/godot/files/5793275/Crypto.Key.Project.zip)
