### PR TITLE
Allow multiple contextual editors opened at once

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -507,13 +507,13 @@ void EditorPlugin::remove_tool_menu_item(const String &p_name) {
 void EditorPlugin::set_input_event_forwarding_always_enabled() {
 	input_event_forwarding_always_enabled = true;
 	EditorPluginList *always_input_forwarding_list = EditorNode::get_singleton()->get_editor_plugins_force_input_forwarding();
-	always_input_forwarding_list->add_plugin(this);
+	always_input_forwarding_list->add_plugin(this, nullptr);
 }
 
 void EditorPlugin::set_force_draw_over_forwarding_enabled() {
 	force_draw_over_forwarding_enabled = true;
 	EditorPluginList *always_draw_over_forwarding_list = EditorNode::get_singleton()->get_editor_plugins_force_over();
-	always_draw_over_forwarding_list->add_plugin(this);
+	always_draw_over_forwarding_list->add_plugin(this, nullptr);
 }
 
 void EditorPlugin::notify_scene_changed(const Node *scn_root) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -218,7 +218,7 @@ void SceneTreeDock::_perform_instance_scenes(const Vector<String> &p_files, Node
 	}
 
 	editor_data->get_undo_redo().commit_action();
-	editor->push_item(instances[instances.size() - 1]);
+	_push_editor_item(instances[instances.size() - 1]);
 	for (int i = 0; i < instances.size(); i++) {
 		emit_signal("node_created", instances[i]);
 	}
@@ -732,7 +732,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			editor_data->get_undo_redo().commit_action();
 
 			if (dupsingle) {
-				editor->push_item(dupsingle);
+				_push_editor_item(dupsingle);
 			}
 		} break;
 		case TOOL_REPARENT: {
@@ -1147,7 +1147,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				Object *obj = ObjectDB::get_instance(subresources[idx]);
 				ERR_FAIL_COND(!obj);
 
-				editor->push_item(obj);
+				_push_editor_item(obj);
 			}
 		}
 	}
@@ -1337,7 +1337,7 @@ void SceneTreeDock::_node_selected() {
 		restore_script_editor_on_drag = true;
 	}
 
-	editor->push_item(node);
+	_push_editor_item(node);
 }
 
 void SceneTreeDock::_node_renamed() {
@@ -1874,7 +1874,7 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 
 	editor_data->get_undo_redo().commit_action();
 
-	editor->push_item(p_script.operator->());
+	_push_editor_item(p_script.operator->());
 	_update_script_button();
 }
 
@@ -1882,6 +1882,15 @@ void SceneTreeDock::_script_creation_closed() {
 	script_create_dialog->disconnect("script_created", callable_mp(this, &SceneTreeDock::_script_created));
 	script_create_dialog->disconnect("confirmed", callable_mp(this, &SceneTreeDock::_script_creation_closed));
 	script_create_dialog->disconnect("cancelled", callable_mp(this, &SceneTreeDock::_script_creation_closed));
+}
+
+void SceneTreeDock::_push_editor_item(Object *p_node) {
+	last_pushed_item = p_node;
+	editor->push_item(p_node);
+}
+
+Object *SceneTreeDock::get_last_pushed_item() const {
+	return last_pushed_item;
 }
 
 void SceneTreeDock::_toggle_editable_children_from_selection() {
@@ -2005,7 +2014,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 		editor->get_viewport_control()->update();
 	}
 
-	editor->push_item(nullptr);
+	_push_editor_item(nullptr);
 
 	// Fixes the EditorHistory from still offering deleted notes
 	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
@@ -2049,7 +2058,7 @@ void SceneTreeDock::_selection_changed() {
 		//automatically turn on multi-edit
 		_tool_selected(TOOL_MULTI_EDIT);
 	} else if (selection_size == 0) {
-		editor->push_item(nullptr);
+		_push_editor_item(nullptr);
 	}
 
 	_update_script_button();
@@ -2085,7 +2094,7 @@ void SceneTreeDock::_do_create(Node *p_parent) {
 	}
 
 	editor_data->get_undo_redo().commit_action();
-	editor->push_item(c);
+	_push_editor_item(c);
 	editor_selection->clear();
 	editor_selection->add_node(child);
 	if (Object::cast_to<Control>(c)) {
@@ -2244,7 +2253,7 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 		memdelete(default_oldnode);
 	}
 
-	editor->push_item(nullptr);
+	_push_editor_item(nullptr);
 
 	//reconnect signals
 	List<MethodInfo> sl;
@@ -2289,7 +2298,7 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 	}
 	newnode->set_name(newname);
 
-	editor->push_item(newnode);
+	_push_editor_item(newnode);
 
 	if (p_remove_old) {
 		memdelete(n);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -155,6 +155,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _do_create(Node *p_parent);
 	Node *scene_root;
 	Node *edited_scene;
+	Object *last_pushed_item;
 	EditorNode *editor;
 
 	VBoxContainer *create_root_dialog;
@@ -187,6 +188,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _node_renamed();
 	void _script_created(Ref<Script> p_script);
 	void _script_creation_closed();
+	void _push_editor_item(Object *p_node);
 
 	void _delete_confirm(bool p_cut = false);
 
@@ -263,6 +265,7 @@ public:
 	void perform_node_renames(Node *p_base, List<Pair<NodePath, NodePath>> *p_renames, Map<Ref<Animation>, Set<int>> *r_rem_anims = nullptr);
 	SceneTreeEditor *get_tree_editor() { return scene_tree; }
 	EditorData *get_editor_data() { return editor_data; }
+	Object *get_last_pushed_item() const;
 
 	void add_remote_tree_editor(Control *p_remote);
 	void show_remote_tree();


### PR DESCRIPTION
Godot has a known limitation that allows only one editor active at a time, which means you can't e.g. edit TextureRegion and ItemList items at the same time or TileMap and Shader etc. Main reason is that when you select a new node/resource, all previously opened editors are closed, because Godot focuses solely on that single item.

The biggest problem in solving this is ensuring that unused editors are closed. The approach I came up with is besides storing the list of currently used editors, store their owners. So e.g. you edit a Shader then the shader editor is opened, with the property as owner. If the property gets folded or removed from the inspector, shader editor's owner is no longer "valid" and it gets closed. 
Otherwise it remains opened. This way you can have opened any combination of editors at the same time and they properly get closed if not needed anymore.

(That's the theory anyways. Submitting as draft, because closing editors doesn't fully work yet and I even managed to cause crash in `Object::cast_to()`. Hopefully I'll be able to finish this properly)

Fixes #28211
Fixes #32002
Fixes #28341
Fixes #47514
Fixes #29873
*Bugsquad edit: Fixes https://github.com/godotengine/godot/issues/43635*
And other similar issues if there are any.

EDIT:
Also screenshot for hype
![image](https://user-images.githubusercontent.com/2223172/104139886-a43fed80-53ae-11eb-912a-6ee4408fda7e.png)
