### PR TITLE
[3.2] Fix empty RIDs in VisualServer.texture_debug_usage()

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1117,6 +1117,7 @@ void RasterizerStorageGLES2::texture_debug_usage(List<VS::TextureInfo> *r_info) 
 		if (!t)
 			continue;
 		VS::TextureInfo tinfo;
+		tinfo.texture = E->get();
 		tinfo.path = t->path;
 		tinfo.format = t->format;
 		tinfo.width = t->alloc_width;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1564,6 +1564,7 @@ void RasterizerStorageGLES3::texture_debug_usage(List<VS::TextureInfo> *r_info) 
 		if (!t)
 			continue;
 		VS::TextureInfo tinfo;
+		tinfo.texture = E->get();
 		tinfo.path = t->path;
 		tinfo.format = t->format;
 		tinfo.width = t->alloc_width;


### PR DESCRIPTION
The following code will always print `0` without this fix:
```GDScript
for tex in VisualServer.texture_debug_usage():
	print(tex.texture.get_id())
```
#
This PR targets the `3.x` branch since `texture_debug_usage` is currently unimplemented in the `master` branch.