### PR TITLE
Fix shader uniform instances compilation

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
@@ -3355,7 +3355,7 @@ RendererSceneRenderForward::RendererSceneRenderForward(RendererStorageRD *p_stor
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
 		actions.global_buffer_array_variable = "global_variables.data";
-		actions.instance_uniform_index_variable = "instances.data[instance_index].instance_uniforms_ofs";
+		actions.instance_uniform_index_variable = "draw_call.instance_uniforms_ofs";
 
 		shader.compiler.initialize(actions);
 	}


### PR DESCRIPTION
After @reduz broke it in 5d2a1d78929764b66a0d6ac7d6cc866ea1c91aed
