### PR TITLE
Fix collision shape update when changing shape properties

### DIFF
--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -194,6 +194,7 @@ void CollisionPolygon2D::set_polygon(const Vector<Point2> &p_polygon) {
 
 	if (parent) {
 		_build_polygon();
+		_update_in_shape_owner();
 	}
 	update();
 	update_configuration_warning();
@@ -208,6 +209,7 @@ void CollisionPolygon2D::set_build_mode(BuildMode p_mode) {
 	build_mode = p_mode;
 	if (parent) {
 		_build_polygon();
+		_update_in_shape_owner();
 	}
 }
 

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -141,6 +141,9 @@ void CollisionShape2D::_notification(int p_what) {
 }
 
 void CollisionShape2D::set_shape(const Ref<Shape2D> &p_shape) {
+	if (p_shape == shape) {
+		return;
+	}
 	if (shape.is_valid()) {
 		shape->disconnect("changed", callable_mp(this, &CollisionShape2D::_shape_changed));
 	}
@@ -151,6 +154,7 @@ void CollisionShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 		if (shape.is_valid()) {
 			parent->shape_owner_add_shape(owner_id, shape);
 		}
+		_update_in_shape_owner();
 	}
 
 	if (shape.is_valid()) {

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -93,7 +93,6 @@ void CollisionShape3D::_notification(int p_what) {
 				if (shape.is_valid()) {
 					parent->shape_owner_add_shape(owner_id, shape);
 				}
-				_update_in_shape_owner();
 			}
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
@@ -170,6 +169,9 @@ void CollisionShape3D::_bind_methods() {
 }
 
 void CollisionShape3D::set_shape(const Ref<Shape3D> &p_shape) {
+	if (p_shape == shape) {
+		return;
+	}
 	if (!shape.is_null()) {
 		shape->unregister_owner(this);
 		shape->disconnect("changed", callable_mp(this, &CollisionShape3D::_shape_changed));


### PR DESCRIPTION
This change does two things:

1. Properly update the internal shape data using `_update_in_shape_owner` when updating a shape (in 2D it was resetting one way collision because of clearing and re-adding shapes without calling this method)

2. Avoid unnecessary updates when calling `set_shape` with the same shape, which happens each time a shape property is modified (e.g `shape.extents.x = ...`)

Fixes #45090
