### PR TITLE
Fixes #41690 where exported values revert to defaults

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -586,6 +586,9 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 					// TODO: Move this out into a routine specific to validate annotations.
 					if (member.variable->export_info.hint == PROPERTY_HINT_TYPE_STRING) {
 						// @export annotation.
+						if (member.variable->export_info.type == Variant::NIL) {
+							member.variable->export_info.type = datatype.builtin_type;
+						}
 						switch (datatype.kind) {
 							case GDScriptParser::DataType::BUILTIN:
 								member.variable->export_info.hint_string = Variant::get_type_name(datatype.builtin_type);


### PR DESCRIPTION
`E->get().type` (in `PlaceHolderScriptInstance::update()` )was returning nil here when called from `ScriptTextEditor::apply_code()` upon saving

Before this commit
```
@export var test : int = 1
@export var test_scene : PackedScene
```
would revert to 1 and nil upon saving and lose whatever were set on the nodes in editor. This commit fixes the issue. (Though I am not sure if it would be better to figure out why properties (`E->get().type`) has nil type)

Update 1/12/2021:
Found the issue where nil types were from.
In `GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node *p_node)`
```
	if (p_annotation->name == "@export") {
		if (variable->datatype_specifier == nullptr) {
			if (variable->initializer == nullptr) {
				push_error(R"(Cannot use "@export" annotation with variable without type or initializer, since type can't be inferred.)", p_annotation);
				return false;
			}
			if (variable->initializer->type != Node::LITERAL) {
				push_error(R"(To use "@export" annotation with type-less variable, the default value must be a literal.)", p_annotation);
				return false;
			}
			variable->export_info.type = static_cast<LiteralNode *>(variable->initializer)->value.get_type();
		} // else: Actual type will be set by the analyzer, which can infer the proper type.
	}
```
but the type was not actually set in `GDScriptAnalyzer::resolve_class_interface`, which only set hint strings.

Updated the pull request. My cases are still working locally.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
