### PR TITLE
Fix errors when removing non Control node from TabContainer

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -789,6 +789,10 @@ Control *TabContainer::get_current_tab_control() const {
 void TabContainer::remove_child_notify(Node *p_child) {
 	Container::remove_child_notify(p_child);
 
+	if (!Object::cast_to<Control>(p_child)) {
+		return;
+	}
+
 	call_deferred("_update_current_tab");
 
 	p_child->disconnect("renamed", callable_mp(this, &TabContainer::_child_renamed_callback));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/45105

In `add_child_notify`, only Control based nodes have connected signal `renamed`, but in `remove_child_notify` for all nodes disconnect function is executed