### PR TITLE
Improve UndoRedo class

### DIFF
--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -84,6 +84,7 @@ private:
 	void _pop_history_tail();
 	void _process_operation_list(List<Operation>::Element *E);
 	void _discard_redo();
+	bool _redo(bool p_execute);
 
 	CommitNotifyCallback callback = nullptr;
 	void *callback_ud = nullptr;
@@ -109,11 +110,15 @@ public:
 	void add_undo_reference(Object *p_object);
 
 	bool is_committing_action() const;
-	void commit_action();
+	void commit_action(bool p_execute = true);
 
 	bool redo();
 	bool undo();
 	String get_current_action_name() const;
+
+	int get_history_count();
+	int get_current_action();
+	String get_action_name(int p_id);
 	void clear_history(bool p_increase_version = true);
 
 	bool has_undo();

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -110,8 +110,10 @@
 		<method name="commit_action">
 			<return type="void">
 			</return>
+			<argument index="0" name="execute" type="bool" default="true">
+			</argument>
 			<description>
-				Commit the action. All "do" methods/properties are called/set when this function is called.
+				Commit the action. If [code]execute[/code] is true (default), all "do" methods/properties are called/set when this function is called.
 			</description>
 		</method>
 		<method name="create_action">
@@ -126,11 +128,34 @@
 				The way actions are merged is dictated by the [code]merge_mode[/code] argument. See [enum MergeMode] for details.
 			</description>
 		</method>
+		<method name="get_action_name">
+			<return type="String">
+			</return>
+			<argument index="0" name="arg0" type="int">
+			</argument>
+			<description>
+				Gets the action name from its index.
+			</description>
+		</method>
+		<method name="get_current_action">
+			<return type="int">
+			</return>
+			<description>
+				Gets the index of the current action.
+			</description>
+		</method>
 		<method name="get_current_action_name" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
-				Gets the name of the current action.
+				Gets the name of the current action, equivalent to [code]get_action_name(get_current_action())[/code].
+			</description>
+		</method>
+		<method name="get_history_count">
+			<return type="int">
+			</return>
+			<description>
+				Return how many element are in the history.
 			</description>
 		</method>
 		<method name="get_version" qualifiers="const">


### PR DESCRIPTION
Add the following features:
- adds an `execute` argument to `commit_action` set by default to `true` (no breaking change). This allows disabling the execution of the `do` methods/properties when committing an action. 
- adds 3 function to retrieve information about the history. They allow iterating over the history and get the name for each action (this should allow creating a dedicated dock in the editor to see the history, and click on actions to go to a previous state):
```
int UndoRedo::get_history_count()
int UndoRedo::get_current_action()
String UndoRedo::get_action_name(int p_id)
```

Regarding the first change, it is useful for my work on the TileMap editor. When I draw a line of tiles in the editor, I only want the action to be created when I am done dragging. But once I am done dragging, I already called all `set_cell()` functions on the TileMap to draw it. Consequently, when I commit the action, they  would be called twice while it's not needed, which can hurt performances for nothing.

Eventually, I could remove the `get_current_action_name()` function, as you can now easily do `get_action_name(get_current_action())` instead.

To test the changes, I used this script (if someone wants a simple test):
[TestUndoRedo.zip](https://github.com/godotengine/godot/files/5801938/TestUndoRedo.zip)
