### PR TITLE
RichTextLabel: Add count and scroll functions for wrapped lines and paragraphs.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -70,7 +70,14 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the total number of newlines in the tag stack's text tags. Considers wrapped text as one line.
+				Returns the total number of lines in the text. Wrapped text is counted as multiple lines.
+			</description>
+		</method>
+		<method name="get_paragraph_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the total number of paragraphs (newlines or [code]p[/code] tags in the tag stack's text tags). Considers wrapped text as one paragraph.
 			</description>
 		</method>
 		<method name="get_total_character_count" qualifiers="const">
@@ -92,6 +99,13 @@
 			</return>
 			<description>
 				Returns the number of visible lines.
+			</description>
+		</method>
+		<method name="get_visible_paragraph_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the number of visible paragraphs. A paragraph is considered visible if at least one of its lines is visible.
 			</description>
 		</method>
 		<method name="install_effect">
@@ -340,6 +354,15 @@
 			</argument>
 			<description>
 				Scrolls the window's top line to match [code]line[/code].
+			</description>
+		</method>
+		<method name="scroll_to_paragraph">
+			<return type="void">
+			</return>
+			<argument index="0" name="paragraph" type="int">
+			</argument>
+			<description>
+				Scrolls the window's top line to match first line of the [code]paragraph[/code].
 			</description>
 		</method>
 		<method name="set_cell_border_color">

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -337,6 +337,7 @@ private:
 	bool updating_scroll;
 	int current_idx = 1;
 	int current_char_ofs = 0;
+	int visible_paragraph_count;
 	int visible_line_count;
 
 	int tab_size;
@@ -393,7 +394,7 @@ private:
 
 	void _shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width, int *r_char_offset);
 	void _resize_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width);
-	void _draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_color_shadow, bool p_shadow_as_outline, const Point2 &shadow_ofs);
+	int _draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_color_shadow, bool p_shadow_as_outline, const Point2 &shadow_ofs);
 	float _find_click_in_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr);
 
 	String _roman(int p_num, bool p_capitalize) const;
@@ -506,6 +507,10 @@ public:
 	bool is_fit_content_height_enabled() const;
 
 	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false);
+
+	void scroll_to_paragraph(int p_paragraph);
+	int get_paragraph_count() const;
+	int get_visible_paragraph_count() const;
 
 	void scroll_to_line(int p_line);
 	int get_line_count() const;


### PR DESCRIPTION
Adds separate `get_total_x_count`, `get_visible_x_count` and `scroll_to_x` functions for wrapped lines and paragraphs (newlines).

Old behavior: `get_line_count` and `scroll_to_line functions` were counting newlines/paragraphs, `get_visible_line_count` was counting lines before #40217, and paragraphs after.

New behavior: `x_paragraph_x` functions count paragraphs (newlines or `[p]` tags), and `x_line_x` functions count wrapped lines.

Fixes: #40982