### PR TITLE
Reference the control gallery image in the Control class documentation

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -16,8 +16,9 @@
 		[b]Note:[/b] Theme items are [i]not[/i] [Object] properties. This means you can't access their values using [method Object.get] and [method Object.set]. Instead, use the [code]get_theme_*[/code] and [code]add_theme_*_override[/code] methods provided by this class.
 	</description>
 	<tutorials>
-		<link title="GUI tutorial index">https://docs.godotengine.org/en/latest/tutorials/gui/index.html</link>
+		<link title="GUI tutorial index">https://docs.godotengine.org/en/latest/tutorials/ui/index.html</link>
 		<link title="Custom drawing in 2D">https://docs.godotengine.org/en/latest/tutorials/2d/custom_drawing_in_2d.html</link>
+		<link title="Control node gallery">https://docs.godotengine.org/en/latest/tutorials/ui/control_node_gallery.html</link>
 		<link title="All GUI Demos">https://github.com/godotengine/godot-demo-projects/tree/master/gui</link>
 	</tutorials>
 	<methods>


### PR DESCRIPTION
**Depends on https://github.com/godotengine/godot-docs/pull/4535.**

Like the Tween cheatsheet or Color constants cheatsheet, this references a "cheatsheet" image from the documentation repository.