### PR TITLE
Fix script editor's members list not updating in certain occasions

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2059,6 +2059,9 @@ void ScriptEditor::_update_script_names() {
 		_update_members_overview();
 		_update_help_overview();
 	} else {
+		call_deferred("_update_members_overview");
+		call_deferred("_update_help_overview");
+
 		waiting_update_names = false;
 	}
 	_update_members_overview_visibility();
@@ -3247,6 +3250,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_live_auto_reload_running_scripts", &ScriptEditor::_live_auto_reload_running_scripts);
 	ClassDB::bind_method("_unhandled_key_input", &ScriptEditor::_unhandled_key_input);
 	ClassDB::bind_method("_update_members_overview", &ScriptEditor::_update_members_overview);
+	ClassDB::bind_method("_update_help_overview", &ScriptEditor::_update_help_overview);
 	ClassDB::bind_method("_update_recent_scripts", &ScriptEditor::_update_recent_scripts);
 
 	ClassDB::bind_method("get_current_editor", &ScriptEditor::_get_current_editor);


### PR DESCRIPTION
Said occasions being:
- First focus on a doc page that was just opened.
- First focus on a script when the editor was just opened.