### PR TITLE
Prevent signal disconnection attempts on invalid references

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -401,7 +401,14 @@ void GraphEdit::add_child_notify(Node *p_child) {
 void GraphEdit::remove_child_notify(Node *p_child) {
 	Control::remove_child_notify(p_child);
 
-	if (is_inside_tree()) {
+	if (p_child == top_layer) {
+		top_layer = nullptr;
+		minimap = nullptr;
+	} else if (p_child == connections_layer) {
+		connections_layer = nullptr;
+	}
+
+	if (top_layer != nullptr && is_inside_tree()) {
 		top_layer->call_deferred("raise"); // Top layer always on top!
 	}
 
@@ -409,8 +416,14 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 	if (gn) {
 		gn->disconnect("position_offset_changed", callable_mp(this, &GraphEdit::_graph_node_moved));
 		gn->disconnect("raise_request", callable_mp(this, &GraphEdit::_graph_node_raised));
-		gn->disconnect("item_rect_changed", callable_mp((CanvasItem *)connections_layer, &CanvasItem::update));
-		gn->disconnect("item_rect_changed", callable_mp((CanvasItem *)minimap, &GraphEditMinimap::update));
+
+		// In case of the whole GraphEdit being destroyed these references can already be freed.
+		if (connections_layer != nullptr && connections_layer->is_inside_tree()) {
+			gn->disconnect("item_rect_changed", callable_mp((CanvasItem *)connections_layer, &CanvasItem::update));
+		}
+		if (minimap != nullptr && minimap->is_inside_tree()) {
+			gn->disconnect("item_rect_changed", callable_mp((CanvasItem *)minimap, &GraphEditMinimap::update));
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #45072. At least addresses the error. I would appreciate if someone with a Linux system could validate that there is a crash in beta5 and it is gone with this commit. Alternatively, #45150 can be used for the same testing in 3.2. They should be identical in the end.

From my tests, the error is gone both from the editor and from a running project. I've also tested that for a case described in #41995 the `disconnect` method is still called.