### PR TITLE
PulseAudio: Remove `get_latency()` caching

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -132,7 +132,7 @@
 		<method name="get_output_latency" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the audio driver's output latency.
+				Returns the audio driver's output latency. This can be expensive, it is not recommended to call this every frame.
 			</description>
 		</method>
 		<method name="get_speaker_mode" qualifiers="const">

--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -192,7 +192,7 @@
 			Number of islands in the 3D physics engine. [i]Lower is better.[/i]
 		</constant>
 		<constant name="AUDIO_OUTPUT_LATENCY" value="23" enum="Monitor">
-			Output latency of the [AudioServer]. [i]Lower is better.[/i]
+			Output latency of the [AudioServer]. Equivalent to calling [method AudioServer.get_output_latency], it is not recommended to call this every frame.
 		</constant>
 		<constant name="NAVIGATION_ACTIVE_MAPS" value="24" enum="Monitor">
 			Number of active navigation maps in the [NavigationServer3D]. This also includes the two empty default navigation maps created by World2D and World3D.

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -370,27 +370,24 @@ Error AudioDriverPulseAudio::init() {
 }
 
 float AudioDriverPulseAudio::get_latency() {
-	if (latency == 0) { //only do this once since it's approximate anyway
-		lock();
+	lock();
 
-		pa_usec_t palat = 0;
-		if (pa_stream_get_state(pa_str) == PA_STREAM_READY) {
-			int negative = 0;
+	pa_usec_t pa_lat = 0;
+	if (pa_stream_get_state(pa_str) == PA_STREAM_READY) {
+		int negative = 0;
 
-			if (pa_stream_get_latency(pa_str, &palat, &negative) >= 0) {
-				if (negative) {
-					palat = 0;
-				}
+		if (pa_stream_get_latency(pa_str, &pa_lat, &negative) >= 0) {
+			if (negative) {
+				pa_lat = 0;
 			}
 		}
-
-		if (palat > 0) {
-			latency = double(palat) / 1000000.0;
-		}
-
-		unlock();
 	}
 
+	if (pa_lat > 0) {
+		latency = double(pa_lat) / 1000000.0;
+	}
+
+	unlock();
 	return latency;
 }
 


### PR DESCRIPTION
Removes the caching on `AudioDriverPulseAudio::get_latency()` and slightly renames variable name `palat` to `pa_lat` to slightly improve readability.

# Rationale #
As mentioned over at https://github.com/godotengine/godot/issues/38215#issuecomment-753456581 the API call `pa_stream_get_latency` returns different values at different times. Being able to sample it only once per program execution is a severe handicap when doing any profiling or using it for things such as latency compensation in rhythm games, as it can be wildly out if sampled under some load conditions.

As a somewhat hyperbolic analogy - what if you could only measure frame time once per program execution? What impact would that have on debugging and optimising your game?
Personally, I was about ready to tear apart my initialization routines when I noticed that my output latency number went from ~50ms to ~30ms on runs where I had breakpoints in initialization. Had I not investigated the engine source code I would have wasted considerable time chasing a dead end because of this cached value under the impression that Pulse was giving me conservative settings under certain start conditions!

# Knock-on effects #
Most of my testing has been on the 3.2 branch (Birdulon/godot/PAlatency) and all I've done on master is verify that it compiles and prints sensible values in a minimal project as I can't port my actual game to master due to unimplemented mesh rendering etc. (made this branch entirely because the default PR text told me to!)
In 3.2 I've observed no degraded performance with the Debugger's Monitors showing Audio Output Latency continuously during gameplay, however I noticed small bits of lag when I also had a label calling it 60 times a second in addition to the monitor. The documentation might need a small note to reflect that `AudioServer.get_output_latency()` and by extension `Performance.get_monitor(Performance.AUDIO_OUTPUT_LATENCY)` are potentially costly calls that should be used sparingly.
In master none of the performance monitors seem to draw for me, but I confirmed behavior with a label changing in `_process`.
I stress again that it should be preferable for this function to return what it says it does, even at cost, even if approximate, rather than lie to the programmer for the sake of saving cycles.

