### PR TITLE
Fix BVH physics project setting

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -170,6 +170,10 @@ static String get_full_version_string() {
 // FIXME: Could maybe be moved to PhysicsServerManager and Physics2DServerManager directly
 // to have less code in main.cpp.
 void initialize_physics() {
+
+	// This must be defined BEFORE the 3d physics server is created
+	GLOBAL_DEF("physics/3d/godot_physics/use_bvh", true);
+
 	/// 3D Physics Server
 	physics_server = PhysicsServerManager::new_server(ProjectSettings::get_singleton()->get(PhysicsServerManager::setting_property_name));
 	if (!physics_server) {

--- a/scene/resources/world.cpp
+++ b/scene/resources/world.cpp
@@ -335,10 +335,6 @@ void World::_bind_methods() {
 
 World::World() {
 
-	// These defaults must be created BEFORE creating the scenario, because the BVH reads
-	// the defaults at that point.
-	GLOBAL_DEF("physics/3d/godot_physics/use_bvh", true);
-
 	space = PhysicsServer::get_singleton()->space_create();
 	scenario = VisualServer::get_singleton()->scenario_create();
 


### PR DESCRIPTION
Move the GLOBAL_DEF for the `godot_physics/use_bvh` to occur before GLOBAL_GET.
This prevents a warning occurring and the selection not being used.

## Notes
* Curious that this did not occur during development, it may be that flipping the default value just before merging made it exhibit.
* It is interesting that the other physics GLOBAL_DEFs are able to be done in World. They must not be required during the server construction, the `use_bvh` being a special case.

Fixes #45142

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
