### PR TITLE
Raise SIGKILL instead of CRASH_NOW in child process when fork fails

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -308,7 +308,8 @@ Error OS_Unix::execute(const String &p_path, const List<String> &p_arguments, St
 
 		execvp(p_path.utf8().get_data(), &args[0]);
 		// The execvp() function only returns if an error occurs.
-		CRASH_NOW_MSG("Could not create child process: " + p_path);
+		ERR_PRINT("Could not create child process: " + p_path);
+		raise(SIGKILL);
 	}
 
 	int status;
@@ -344,7 +345,8 @@ Error OS_Unix::create_process(const String &p_path, const List<String> &p_argume
 
 		execvp(p_path.utf8().get_data(), &args[0]);
 		// The execvp() function only returns if an error occurs.
-		CRASH_NOW_MSG("Could not create child process: " + p_path);
+		ERR_PRINT("Could not create child process: " + p_path);
+		raise(SIGKILL);
 	}
 
 	if (r_child_id) {


### PR DESCRIPTION
As identified by @bruvzg [here](https://github.com/godotengine/godot/pull/44514#discussion_r556396178), `CRASH_NOW` is generating unnecessary stack traces when a fork fails to create a child process.

This PR reverts to using `raise(SIGKILL);`
