### PR TITLE
Add C# array features from core PackedArrays

### DIFF
--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -661,6 +661,7 @@ class BindingsGenerator {
 	Error _generate_cs_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, int &p_method_bind_count, StringBuilder &p_output);
 	Error _generate_cs_signal(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::SignalInterface &p_isignal, StringBuilder &p_output);
 
+	void _generate_array_extensions(StringBuilder &p_output);
 	void _generate_global_constants(StringBuilder &p_output);
 
 	Error _generate_glue_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, StringBuilder &p_output);


### PR DESCRIPTION
This PR adds several extension methods to match with core's Packed*Arrays. All of the methods are generated from within the bindings generator to minimize code duplication. Comparing with [core](https://docs.godotengine.org/en/latest/classes/class_packedfloat32array.html):

* ~~`void append ( float value )`: Added as `.PushBack` (note: since C# array length is immutable, this returns a copy).~~
* ~~`void append_array ( array )`: Added as `.AppendArray` (note: since C# array length is immutable, this returns a copy).~~
* `bool empty ( )`: Actually `is_empty` now, added as `.IsEmpty()`.
* ~~`int insert ( int idx, float value )`: Added as `.Insert` (note: since C# array length is immutable, this returns a copy).~~
* `void invert ( )`: Already available via C# `Array.Reverse`.
* ~~`void push_back ( float value )`: Added as `.PushBack` (note: since C# array length is immutable, this returns a copy).~~
* ~~`void remove ( int idx )`: Added as `.Remove(int index)` (note: since C# array length is immutable, this returns a copy).~~
* `void resize ( int idx )`: Already available via C# `Array.Resize`.
* `void set ( int idx, float value )`: Already available via C# array index operator.
* `int size ( )`: Already available via C# `.Length`.
* Added `.Join` because it exists [in 3.2 only for PoolStringArray only](https://docs.godotengine.org/en/stable/classes/class_poolstringarray.html), but I noticed it doesn't exist for others or on master...? Since it's not in core I'm not sure if this API is desired, anyway it's easy to delete from this PR if that's the case.
* Added `.Stringify` for printing out arrays. C# already defines `ToString` for all objects and it's not possible to override it with an extension method or an operator, but we can still provide an alternative method to [C#'s useless implementation](https://i.redd.it/zzknj469um741.png).

