### PR TITLE
Expose `Resource.emit_changed()` to script

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -386,6 +386,7 @@ void Resource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_local_to_scene"), &Resource::is_local_to_scene);
 	ClassDB::bind_method(D_METHOD("get_local_scene"), &Resource::get_local_scene);
 	ClassDB::bind_method(D_METHOD("setup_local_to_scene"), &Resource::setup_local_to_scene);
+	ClassDB::bind_method(D_METHOD("emit_changed"), &Resource::emit_changed);
 
 	ClassDB::bind_method(D_METHOD("duplicate", "subresources"), &Resource::duplicate, DEFVAL(false));
 	ADD_SIGNAL(MethodInfo("changed"));

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -29,6 +29,19 @@
 				[b]Note:[/b] If [code]subresources[/code] is [code]true[/code], this method will only perform a shallow copy. Nested resources within subresources will not be duplicated and will still be shared.
 			</description>
 		</method>
+		<method name="emit_changed">
+			<return type="void">
+			</return>
+			<description>
+				Emits the [signal changed] signal.
+				If external objects which depend on this resource should be updated, this method must be called manually whenever the state of this resource has changed (such as modification of properties).
+				The method is equivalent to:
+				[codeblock]
+				emit_signal("changed")
+				[/codeblock]
+				[b]Note:[/b] This method is called automatically for built-in resources.
+			</description>
+		</method>
 		<method name="get_local_scene" qualifiers="const">
 			<return type="Node">
 			</return>


### PR DESCRIPTION
Also known as `emit_signal("changed")`.

## Reasons
1. Makes it consistent with C++ usage, where `emit_changed()` is used to notify other objects about changes.
2. Less typing, more clarity, slightly better performance (in 3.2). See limitation described in [this Q&A question](https://godotengine.org/qa/47386/resource-changed-signal-default-whenever-properties-modified) and #30179.
3. Can copy-paste code more easily between C++ and GDScript etc.
4. Improves documentation.