### PR TITLE
[Draft] Implemented dedicated shader editor

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -398,7 +398,7 @@
 			</return>
 			<description>
 				Override this method in your plugin to return a [Texture2D] in order to give it an icon.
-				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", and "AssetLib" buttons.
+				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", "Shader", and "AssetLib" buttons.
 				Ideally, the plugin icon should be white with a transparent background and 16x16 pixels in size.
 				[codeblocks]
 				[gdscript]
@@ -425,7 +425,7 @@
 			</return>
 			<description>
 				Override this method in your plugin to provide the name of the plugin when displayed in the Godot editor.
-				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", and "AssetLib" buttons.
+				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", "Shader", and "AssetLib" buttons.
 			</description>
 		</method>
 		<method name="get_script_create_dialog">

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -34,6 +34,7 @@
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"
 #include "editor/editor_scale.h"
+#include "editor/plugins/shader_editor_plugin.h"
 #include "editor_node.h"
 #include "editor_settings.h"
 #include "scene/gui/margin_container.h"
@@ -1563,10 +1564,18 @@ void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
 }
 
 void CodeTextEditor::_toggle_scripts_pressed() {
-	if (is_layout_rtl()) {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon("Forward", "EditorIcons") : get_theme_icon("Back", "EditorIcons"));
+	if (_is_shader_editor()) {
+		if (is_layout_rtl()) {
+			toggle_scripts_button->set_icon(ShaderEditor::get_singleton()->toggle_shaders_panel() ? get_theme_icon("Forward", "EditorIcons") : get_theme_icon("Back", "EditorIcons"));
+		} else {
+			toggle_scripts_button->set_icon(ShaderEditor::get_singleton()->toggle_shaders_panel() ? get_theme_icon("Back", "EditorIcons") : get_theme_icon("Forward", "EditorIcons"));
+		}
 	} else {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon("Back", "EditorIcons") : get_theme_icon("Forward", "EditorIcons"));
+		if (is_layout_rtl()) {
+			toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon("Forward", "EditorIcons") : get_theme_icon("Back", "EditorIcons"));
+		} else {
+			toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->toggle_scripts_panel() ? get_theme_icon("Back", "EditorIcons") : get_theme_icon("Forward", "EditorIcons"));
+		}
 	}
 }
 
@@ -1688,12 +1697,21 @@ void CodeTextEditor::show_toggle_scripts_button() {
 }
 
 void CodeTextEditor::update_toggle_scripts_button() {
-	if (is_layout_rtl()) {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon("Forward", "EditorIcons") : get_theme_icon("Back", "EditorIcons"));
+	if (_is_shader_editor()) {
+		if (is_layout_rtl()) {
+			toggle_scripts_button->set_icon(ShaderEditor::get_singleton()->is_shaders_panel_toggled() ? get_theme_icon("Forward", "EditorIcons") : get_theme_icon("Back", "EditorIcons"));
+		} else {
+			toggle_scripts_button->set_icon(ShaderEditor::get_singleton()->is_shaders_panel_toggled() ? get_theme_icon("Back", "EditorIcons") : get_theme_icon("Forward", "EditorIcons"));
+		}
+		toggle_scripts_button->set_tooltip(TTR("Toggle Shaders Panel") + " (" + ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text() + ")");
 	} else {
-		toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon("Back", "EditorIcons") : get_theme_icon("Forward", "EditorIcons"));
+		if (is_layout_rtl()) {
+			toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon("Forward", "EditorIcons") : get_theme_icon("Back", "EditorIcons"));
+		} else {
+			toggle_scripts_button->set_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? get_theme_icon("Back", "EditorIcons") : get_theme_icon("Forward", "EditorIcons"));
+		}
+		toggle_scripts_button->set_tooltip(TTR("Toggle Scripts Panel") + " (" + ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text() + ")");
 	}
-	toggle_scripts_button->set_tooltip(TTR("Toggle Scripts Panel") + " (" + ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text() + ")");
 }
 
 CodeTextEditor::CodeTextEditor() {

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -199,6 +199,7 @@ protected:
 	void _line_col_changed();
 	void _notification(int);
 	static void _bind_methods();
+	virtual bool _is_shader_editor() const { return false; }
 
 	bool is_warnings_panel_opened;
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -666,7 +666,8 @@ public:
 		EDITOR_2D = 0,
 		EDITOR_3D,
 		EDITOR_SCRIPT,
-		EDITOR_ASSETLIB
+		EDITOR_SHADER,
+		EDITOR_ASSETLIB,
 	};
 
 	void set_visible_editor(EditorTable p_table) { _editor_select(p_table); }

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3673,7 +3673,7 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 					String type = open_in_new.get_slicec(',', i).strip_edges();
 					for (int j = 0; j < p_hint_text.get_slice_count(","); j++) {
 						String inherits = p_hint_text.get_slicec(',', j);
-						if (ClassDB::is_parent_class(inherits, type)) {
+						if (ClassDB::is_parent_class(inherits, type) || inherits == "Shader") {
 							editor->set_use_sub_inspector(false);
 						}
 					}

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2570,19 +2570,21 @@ void Node3DEditorViewport::_notification(int p_what) {
 		}
 	}
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		surface->connect("draw", callable_mp(this, &Node3DEditorViewport::_draw));
-		surface->connect("gui_input", callable_mp(this, &Node3DEditorViewport::_sinput));
-		surface->connect("mouse_entered", callable_mp(this, &Node3DEditorViewport::_surface_mouse_enter));
-		surface->connect("mouse_exited", callable_mp(this, &Node3DEditorViewport::_surface_mouse_exit));
-		surface->connect("focus_entered", callable_mp(this, &Node3DEditorViewport::_surface_focus_enter));
-		surface->connect("focus_exited", callable_mp(this, &Node3DEditorViewport::_surface_focus_exit));
+	if (!reattaching) {
+		if (p_what == NOTIFICATION_ENTER_TREE) {
+			surface->connect("draw", callable_mp(this, &Node3DEditorViewport::_draw));
+			surface->connect("gui_input", callable_mp(this, &Node3DEditorViewport::_sinput));
+			surface->connect("mouse_entered", callable_mp(this, &Node3DEditorViewport::_surface_mouse_enter));
+			surface->connect("mouse_exited", callable_mp(this, &Node3DEditorViewport::_surface_mouse_exit));
+			surface->connect("focus_entered", callable_mp(this, &Node3DEditorViewport::_surface_focus_enter));
+			surface->connect("focus_exited", callable_mp(this, &Node3DEditorViewport::_surface_focus_exit));
 
-		_init_gizmo_instance(index);
-	}
+			_init_gizmo_instance(index);
+		}
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		_finish_gizmo_instances();
+		if (p_what == NOTIFICATION_EXIT_TREE) {
+			_finish_gizmo_instances();
+		}
 	}
 
 	if (p_what == NOTIFICATION_THEME_CHANGED) {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -255,6 +255,7 @@ private:
 	AABB *preview_bounds;
 	Vector<String> selected_files;
 	AcceptDialog *accept;
+	bool reattaching = false;
 
 	Node *target_node;
 	Point2 drop_pos;
@@ -463,6 +464,13 @@ protected:
 	static void _bind_methods();
 
 public:
+	void set_reattaching(bool p_reattaching) {
+		reattaching = p_reattaching;
+	}
+	bool is_reattaching() const {
+		return reattaching;
+	}
+
 	void update_surface() { surface->update(); }
 	void update_transform_gizmo_view();
 
@@ -581,6 +589,7 @@ private:
 	Node3DEditorViewport *viewports[VIEWPORTS_COUNT];
 	VSplitContainer *shader_split;
 	HSplitContainer *palette_split;
+	bool reattaching = false;
 
 	/////
 
@@ -797,10 +806,22 @@ public:
 	void set_over_gizmo_handle(int idx) { over_gizmo_handle = idx; }
 
 	void set_can_preview(Camera3D *p_preview);
-
+	Node3DEditorViewportContainer *get_editor_viewport_base() const {
+		return viewport_base;
+	}
 	Node3DEditorViewport *get_editor_viewport(int p_idx) {
 		ERR_FAIL_INDEX_V(p_idx, static_cast<int>(VIEWPORTS_COUNT), nullptr);
 		return viewports[p_idx];
+	}
+
+	void set_viewports_reattaching(bool p_reattaching) {
+		for (int i = 0; i < static_cast<int>(VIEWPORTS_COUNT); i++) {
+			viewports[i]->set_reattaching(p_reattaching);
+		}
+		reattaching = p_reattaching;
+	}
+	bool is_viewports_reattaching() const {
+		return reattaching;
 	}
 
 	void add_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin);


### PR DESCRIPTION
I've decided to attempt to implement: https://github.com/godotengine/godot/issues/26229 (gradually) since it is accepted in UI proposals:

![image](https://user-images.githubusercontent.com/3036176/104482108-99b46c80-55d7-11eb-9587-8f736c5fb21e.png)

The result will look almost exactly like in the proposal:

![image](https://user-images.githubusercontent.com/3036176/104554014-a3c48280-564c-11eb-8624-8c849904acae.png)

ToDo List:

- [x] Basic layout
- [x] Spatial preview options
- [ ] Canvas Item preview options
- [ ] Dynamic switch possible previews for each shader type
- [ ] Shaders list (recent list)
- [ ] Vertical dock option
- [ ] File menu
- [ ] Sky preview options
- [ ] Particles preview options
- [ ] Dedicated Visual Shader Editor (?) - maybe later, in other PR

<details>
<summary>Show GIF Presentation</summary>

![shader_demo](https://user-images.githubusercontent.com/3036176/104482626-31b25600-55d8-11eb-9136-6f2c5e443a9d.gif)

</details>