### PR TITLE
Fix not clearing a Joint3D with only a B node when removing the B node

### DIFF
--- a/scene/3d/physics_joint_3d.cpp
+++ b/scene/3d/physics_joint_3d.cpp
@@ -114,21 +114,23 @@ void Joint3D::_update_joint(bool p_only_free) {
 		return;
 	}
 
-	if (!body_a) {
-		SWAP(body_a, body_b);
-	}
-
 	warning = String();
 	update_configuration_warning();
 
-	joint = _configure_joint(body_a, body_b);
+	if (body_a) {
+		joint = _configure_joint(body_a, body_b);
+	} else if (body_b) {
+		joint = _configure_joint(body_b, nullptr);
+	}
 
 	ERR_FAIL_COND_MSG(!joint.is_valid(), "Failed to configure the joint.");
 
 	PhysicsServer3D::get_singleton()->joint_set_solver_priority(joint, solver_priority);
 
-	ba = body_a->get_rid();
-	body_a->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint3D::_body_exit_tree), make_binds(body_a->get_instance_id()));
+	if (body_a) {
+		ba = body_a->get_rid();
+		body_a->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint3D::_body_exit_tree), make_binds(body_a->get_instance_id()));
+	}
 
 	if (body_b) {
 		bb = body_b->get_rid();


### PR DESCRIPTION
#44703 and it's 3.2 version #44704 fail to clear the node attached to a Joint3D when the node is removed, if the node is a B node and it's the only node. Therefore, the `RigidBody` remains connected to the Joint3D and Bullet physics raises the error:
```
ERROR: A body connected to joints was removed.
   at: remove_rigid_body_constraints:  (modules/bullet/space_bullet.cpp:485)
```

This PR addresses the issue, by ensuring that the RID associated with each node is not swapped when there is only a B node.

Fixes #45166.
