### PR TITLE
Mention that NetworkedMultiplayerENet uses UDP only

### DIFF
--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -5,6 +5,8 @@
 	</brief_description>
 	<description>
 		A PacketPeer implementation that should be passed to [member SceneTree.network_peer] after being initialized as either a client or server. Events can then be handled by connecting to [SceneTree] signals.
+		ENet's purpose is to provide a relatively thin, simple and robust network communication layer on top of UDP (User Datagram Protocol).
+		[b]Note:[/b] ENet only uses UDP, not TCP. When forwarding the server port to make your server accessible on the public Internet, you only need to forward the server port in UDP. You can use the [UPNP] class to try to forward the server port automatically when starting the server.
 	</description>
 	<tutorials>
 		<link title="High-level multiplayer">https://docs.godotengine.org/en/latest/tutorials/networking/high_level_multiplayer.html</link>


### PR DESCRIPTION
This is important to clarify for those doing port forwarding.

See https://godotengine.org/qa/92039/what-protocol-tcp-or-udp-does-networkedmultiplayerenet-use.