### PR TITLE
Fix KinematicBody3D having a duplicate locked_axis variable

### DIFF
--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -48,8 +48,7 @@ protected:
 
 	Ref<KinematicCollision3D> motion_cache;
 
-	uint16_t locked_axis = 0;
-
+	void _apply_axis_lock(Vector3 &p_motion) const;
 	Ref<KinematicCollision3D> _move(const Vector3 &p_motion, bool p_test_only = false, real_t p_margin = 0.001);
 
 public:


### PR DESCRIPTION
Simply put, KinematicBody3D had two different `locked_axis` variables, which caused incorrect behavior any time they were out of sync. It's a much better idea to only have one variable to track this (like RigidBody3D does), so I deleted the duplicate one.

This fixes #25798 in master, and is the master version of #45176.