### PR TITLE
[4.0] Rename 'PluginConfig' struct to fix lto warnings

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -261,7 +261,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		EditorProgress *ep = nullptr;
 	};
 
-	Vector<PluginConfig> plugins;
+	Vector<PluginConfigAndroid> plugins;
 	String last_plugin_names;
 	uint64_t last_custom_build_time = 0;
 	volatile bool plugins_changed;
@@ -280,7 +280,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 			{
 				// Nothing to do if we already know the plugins have changed.
 				if (!ea->plugins_changed) {
-					Vector<PluginConfig> loaded_plugins = get_plugins();
+					Vector<PluginConfigAndroid> loaded_plugins = get_plugins();
 
 					MutexLock lock(ea->plugins_lock);
 
@@ -629,7 +629,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 					continue;
 				}
 
-				if (file.ends_with(PLUGIN_CONFIG_EXT)) {
+				if (file.ends_with(PluginConfigAndroid::PLUGIN_CONFIG_EXT)) {
 					dir_files.push_back(file);
 				}
 			}
@@ -639,8 +639,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		return dir_files;
 	}
 
-	static Vector<PluginConfig> get_plugins() {
-		Vector<PluginConfig> loaded_plugins;
+	static Vector<PluginConfigAndroid> get_plugins() {
+		Vector<PluginConfigAndroid> loaded_plugins;
 
 		String plugins_dir = ProjectSettings::get_singleton()->get_resource_path().plus_file("android/plugins");
 
@@ -653,7 +653,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 			if (!plugins_filenames.is_empty()) {
 				Ref<ConfigFile> config_file = memnew(ConfigFile);
 				for (int i = 0; i < plugins_filenames.size(); i++) {
-					PluginConfig config = load_plugin_config(config_file, plugins_dir.plus_file(plugins_filenames[i]));
+					PluginConfigAndroid config = load_plugin_config(config_file, plugins_dir.plus_file(plugins_filenames[i]));
 					if (config.valid_config) {
 						loaded_plugins.push_back(config);
 					} else {
@@ -666,11 +666,11 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		return loaded_plugins;
 	}
 
-	static Vector<PluginConfig> get_enabled_plugins(const Ref<EditorExportPreset> &p_presets) {
-		Vector<PluginConfig> enabled_plugins;
-		Vector<PluginConfig> all_plugins = get_plugins();
+	static Vector<PluginConfigAndroid> get_enabled_plugins(const Ref<EditorExportPreset> &p_presets) {
+		Vector<PluginConfigAndroid> enabled_plugins;
+		Vector<PluginConfigAndroid> all_plugins = get_plugins();
 		for (int i = 0; i < all_plugins.size(); i++) {
-			PluginConfig plugin = all_plugins[i];
+			PluginConfigAndroid plugin = all_plugins[i];
 			bool enabled = p_presets->get("plugins/" + plugin.name);
 			if (enabled) {
 				enabled_plugins.push_back(plugin);
@@ -1618,7 +1618,7 @@ public:
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "custom_template/use_custom_build"), false));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "custom_template/export_format", PROPERTY_HINT_ENUM, "Export APK,Export AAB"), EXPORT_FORMAT_APK));
 
-		Vector<PluginConfig> plugins_configs = get_plugins();
+		Vector<PluginConfigAndroid> plugins_configs = get_plugins();
 		for (int i = 0; i < plugins_configs.size(); i++) {
 			print_verbose("Found Android plugin " + plugins_configs[i].name);
 			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "plugins/" + plugins_configs[i].name), false));
@@ -2131,7 +2131,7 @@ public:
 		return list;
 	}
 
-	inline bool is_clean_build_required(Vector<PluginConfig> enabled_plugins) {
+	inline bool is_clean_build_required(Vector<PluginConfigAndroid> enabled_plugins) {
 		String plugin_names = get_plugins_names(enabled_plugins);
 		bool first_build = last_custom_build_time == 0;
 		bool have_plugins_changed = false;
@@ -2438,9 +2438,9 @@ public:
 			String sign_flag = should_sign ? "true" : "false";
 			String zipalign_flag = "true";
 
-			Vector<PluginConfig> enabled_plugins = get_enabled_plugins(p_preset);
-			String local_plugins_binaries = get_plugins_binaries(BINARY_TYPE_LOCAL, enabled_plugins);
-			String remote_plugins_binaries = get_plugins_binaries(BINARY_TYPE_REMOTE, enabled_plugins);
+			Vector<PluginConfigAndroid> enabled_plugins = get_enabled_plugins(p_preset);
+			String local_plugins_binaries = get_plugins_binaries(PluginConfigAndroid::BINARY_TYPE_LOCAL, enabled_plugins);
+			String remote_plugins_binaries = get_plugins_binaries(PluginConfigAndroid::BINARY_TYPE_REMOTE, enabled_plugins);
 			String custom_maven_repos = get_plugins_custom_maven_repos(enabled_plugins);
 			bool clean_build_required = is_clean_build_required(enabled_plugins);
 

--- a/platform/android/plugin/godot_plugin_config.h
+++ b/platform/android/plugin/godot_plugin_config.h
@@ -35,23 +35,6 @@
 #include "core/io/config_file.h"
 #include "core/string/ustring.h"
 
-static const char *PLUGIN_CONFIG_EXT = ".gdap";
-
-static const char *CONFIG_SECTION = "config";
-static const char *CONFIG_NAME_KEY = "name";
-static const char *CONFIG_BINARY_TYPE_KEY = "binary_type";
-static const char *CONFIG_BINARY_KEY = "binary";
-
-static const char *DEPENDENCIES_SECTION = "dependencies";
-static const char *DEPENDENCIES_LOCAL_KEY = "local";
-static const char *DEPENDENCIES_REMOTE_KEY = "remote";
-static const char *DEPENDENCIES_CUSTOM_MAVEN_REPOS_KEY = "custom_maven_repos";
-
-static const char *BINARY_TYPE_LOCAL = "local";
-static const char *BINARY_TYPE_REMOTE = "remote";
-
-static const char *PLUGIN_VALUE_SEPARATOR = "|";
-
 /*
  The `config` section and fields are required and defined as follow:
 - **name**: name of the plugin
@@ -67,7 +50,24 @@ The `dependencies` section and fields are optional and defined as follow:
 
  See https://github.com/godotengine/godot/issues/38157#issuecomment-618773871
  */
-struct PluginConfig {
+struct PluginConfigAndroid {
+	inline static const char *PLUGIN_CONFIG_EXT = ".gdap";
+
+	inline static const char *CONFIG_SECTION = "config";
+	inline static const char *CONFIG_NAME_KEY = "name";
+	inline static const char *CONFIG_BINARY_TYPE_KEY = "binary_type";
+	inline static const char *CONFIG_BINARY_KEY = "binary";
+
+	inline static const char *DEPENDENCIES_SECTION = "dependencies";
+	inline static const char *DEPENDENCIES_LOCAL_KEY = "local";
+	inline static const char *DEPENDENCIES_REMOTE_KEY = "remote";
+	inline static const char *DEPENDENCIES_CUSTOM_MAVEN_REPOS_KEY = "custom_maven_repos";
+
+	inline static const char *BINARY_TYPE_LOCAL = "local";
+	inline static const char *BINARY_TYPE_REMOTE = "remote";
+
+	inline static const char *PLUGIN_VALUE_SEPARATOR = "|";
+
 	// Set to true when the config file is properly loaded.
 	bool valid_config = false;
 	// Unix timestamp of last change to this plugin.
@@ -88,7 +88,7 @@ struct PluginConfig {
  * Set of prebuilt plugins.
  * Currently unused, this is just for future reference:
  */
-// static const PluginConfig MY_PREBUILT_PLUGIN = {
+// static const PluginConfigAndroid MY_PREBUILT_PLUGIN = {
 //	/*.valid_config =*/true,
 //	/*.last_updated =*/0,
 //	/*.name =*/"GodotPayment",
@@ -112,9 +112,9 @@ static inline String resolve_local_dependency_path(String plugin_config_dir, Str
 	return absolute_path;
 }
 
-static inline PluginConfig resolve_prebuilt_plugin(PluginConfig prebuilt_plugin, String plugin_config_dir) {
-	PluginConfig resolved = prebuilt_plugin;
-	resolved.binary = resolved.binary_type == BINARY_TYPE_LOCAL ? resolve_local_dependency_path(plugin_config_dir, prebuilt_plugin.binary) : prebuilt_plugin.binary;
+static inline PluginConfigAndroid resolve_prebuilt_plugin(PluginConfigAndroid prebuilt_plugin, String plugin_config_dir) {
+	PluginConfigAndroid resolved = prebuilt_plugin;
+	resolved.binary = resolved.binary_type == PluginConfigAndroid::BINARY_TYPE_LOCAL ? resolve_local_dependency_path(plugin_config_dir, prebuilt_plugin.binary) : prebuilt_plugin.binary;
 	if (!prebuilt_plugin.local_dependencies.is_empty()) {
 		resolved.local_dependencies.clear();
 		for (int i = 0; i < prebuilt_plugin.local_dependencies.size(); i++) {
@@ -124,21 +124,22 @@ static inline PluginConfig resolve_prebuilt_plugin(PluginConfig prebuilt_plugin,
 	return resolved;
 }
 
-static inline Vector<PluginConfig> get_prebuilt_plugins(String plugins_base_dir) {
-	Vector<PluginConfig> prebuilt_plugins;
+static inline Vector<PluginConfigAndroid> get_prebuilt_plugins(String plugins_base_dir) {
+	Vector<PluginConfigAndroid> prebuilt_plugins;
 	// prebuilt_plugins.push_back(resolve_prebuilt_plugin(MY_PREBUILT_PLUGIN, plugins_base_dir));
 	return prebuilt_plugins;
 }
 
-static inline bool is_plugin_config_valid(PluginConfig plugin_config) {
+static inline bool is_plugin_config_valid(PluginConfigAndroid plugin_config) {
 	bool valid_name = !plugin_config.name.is_empty();
-	bool valid_binary_type = plugin_config.binary_type == BINARY_TYPE_LOCAL ||
-							 plugin_config.binary_type == BINARY_TYPE_REMOTE;
+	bool valid_binary_type = plugin_config.binary_type == PluginConfigAndroid::BINARY_TYPE_LOCAL ||
+							 plugin_config.binary_type == PluginConfigAndroid::BINARY_TYPE_REMOTE;
 
 	bool valid_binary = false;
 	if (valid_binary_type) {
 		valid_binary = !plugin_config.binary.is_empty() &&
-					   (plugin_config.binary_type == BINARY_TYPE_REMOTE ||
+					   (plugin_config.binary_type == PluginConfigAndroid::BINARY_TYPE_REMOTE ||
+
 							   FileAccess::exists(plugin_config.binary));
 	}
 
@@ -154,7 +155,7 @@ static inline bool is_plugin_config_valid(PluginConfig plugin_config) {
 	return valid_name && valid_binary && valid_binary_type && valid_local_dependencies;
 }
 
-static inline uint64_t get_plugin_modification_time(const PluginConfig &plugin_config, const String &config_path) {
+static inline uint64_t get_plugin_modification_time(const PluginConfigAndroid &plugin_config, const String &config_path) {
 	uint64_t last_updated = FileAccess::get_modified_time(config_path);
 	last_updated = MAX(last_updated, FileAccess::get_modified_time(plugin_config.binary));
 
@@ -166,30 +167,30 @@ static inline uint64_t get_plugin_modification_time(const PluginConfig &plugin_c
 	return last_updated;
 }
 
-static inline PluginConfig load_plugin_config(Ref<ConfigFile> config_file, const String &path) {
-	PluginConfig plugin_config = {};
+static inline PluginConfigAndroid load_plugin_config(Ref<ConfigFile> config_file, const String &path) {
+	PluginConfigAndroid plugin_config = {};
 
 	if (config_file.is_valid()) {
 		Error err = config_file->load(path);
 		if (err == OK) {
 			String config_base_dir = path.get_base_dir();
 
-			plugin_config.name = config_file->get_value(CONFIG_SECTION, CONFIG_NAME_KEY, String());
-			plugin_config.binary_type = config_file->get_value(CONFIG_SECTION, CONFIG_BINARY_TYPE_KEY, String());
+			plugin_config.name = config_file->get_value(PluginConfigAndroid::CONFIG_SECTION, PluginConfigAndroid::CONFIG_NAME_KEY, String());
+			plugin_config.binary_type = config_file->get_value(PluginConfigAndroid::CONFIG_SECTION, PluginConfigAndroid::CONFIG_BINARY_TYPE_KEY, String());
 
-			String binary_path = config_file->get_value(CONFIG_SECTION, CONFIG_BINARY_KEY, String());
-			plugin_config.binary = plugin_config.binary_type == BINARY_TYPE_LOCAL ? resolve_local_dependency_path(config_base_dir, binary_path) : binary_path;
+			String binary_path = config_file->get_value(PluginConfigAndroid::CONFIG_SECTION, PluginConfigAndroid::CONFIG_BINARY_KEY, String());
+			plugin_config.binary = plugin_config.binary_type == PluginConfigAndroid::BINARY_TYPE_LOCAL ? resolve_local_dependency_path(config_base_dir, binary_path) : binary_path;
 
-			if (config_file->has_section(DEPENDENCIES_SECTION)) {
-				Vector<String> local_dependencies_paths = config_file->get_value(DEPENDENCIES_SECTION, DEPENDENCIES_LOCAL_KEY, Vector<String>());
+			if (config_file->has_section(PluginConfigAndroid::DEPENDENCIES_SECTION)) {
+				Vector<String> local_dependencies_paths = config_file->get_value(PluginConfigAndroid::DEPENDENCIES_SECTION, PluginConfigAndroid::DEPENDENCIES_LOCAL_KEY, Vector<String>());
 				if (!local_dependencies_paths.is_empty()) {
 					for (int i = 0; i < local_dependencies_paths.size(); i++) {
 						plugin_config.local_dependencies.push_back(resolve_local_dependency_path(config_base_dir, local_dependencies_paths[i]));
 					}
 				}
 
-				plugin_config.remote_dependencies = config_file->get_value(DEPENDENCIES_SECTION, DEPENDENCIES_REMOTE_KEY, Vector<String>());
-				plugin_config.custom_maven_repos = config_file->get_value(DEPENDENCIES_SECTION, DEPENDENCIES_CUSTOM_MAVEN_REPOS_KEY, Vector<String>());
+				plugin_config.remote_dependencies = config_file->get_value(PluginConfigAndroid::DEPENDENCIES_SECTION, PluginConfigAndroid::DEPENDENCIES_REMOTE_KEY, Vector<String>());
+				plugin_config.custom_maven_repos = config_file->get_value(PluginConfigAndroid::DEPENDENCIES_SECTION, PluginConfigAndroid::DEPENDENCIES_CUSTOM_MAVEN_REPOS_KEY, Vector<String>());
 			}
 
 			plugin_config.valid_config = is_plugin_config_valid(plugin_config);
@@ -200,12 +201,12 @@ static inline PluginConfig load_plugin_config(Ref<ConfigFile> config_file, const
 	return plugin_config;
 }
 
-static inline String get_plugins_binaries(String binary_type, Vector<PluginConfig> plugins_configs) {
+static inline String get_plugins_binaries(String binary_type, Vector<PluginConfigAndroid> plugins_configs) {
 	String plugins_binaries;
 	if (!plugins_configs.is_empty()) {
 		Vector<String> binaries;
 		for (int i = 0; i < plugins_configs.size(); i++) {
-			PluginConfig config = plugins_configs[i];
+			PluginConfigAndroid config = plugins_configs[i];
 			if (!config.valid_config) {
 				continue;
 			}
@@ -214,27 +215,27 @@ static inline String get_plugins_binaries(String binary_type, Vector<PluginConfi
 				binaries.push_back(config.binary);
 			}
 
-			if (binary_type == BINARY_TYPE_LOCAL) {
+			if (binary_type == PluginConfigAndroid::BINARY_TYPE_LOCAL) {
 				binaries.append_array(config.local_dependencies);
 			}
 
-			if (binary_type == BINARY_TYPE_REMOTE) {
+			if (binary_type == PluginConfigAndroid::BINARY_TYPE_REMOTE) {
 				binaries.append_array(config.remote_dependencies);
 			}
 		}
 
-		plugins_binaries = String(PLUGIN_VALUE_SEPARATOR).join(binaries);
+		plugins_binaries = String(PluginConfigAndroid::PLUGIN_VALUE_SEPARATOR).join(binaries);
 	}
 
 	return plugins_binaries;
 }
 
-static inline String get_plugins_custom_maven_repos(Vector<PluginConfig> plugins_configs) {
+static inline String get_plugins_custom_maven_repos(Vector<PluginConfigAndroid> plugins_configs) {
 	String custom_maven_repos;
 	if (!plugins_configs.is_empty()) {
 		Vector<String> repos_urls;
 		for (int i = 0; i < plugins_configs.size(); i++) {
-			PluginConfig config = plugins_configs[i];
+			PluginConfigAndroid config = plugins_configs[i];
 			if (!config.valid_config) {
 				continue;
 			}
@@ -242,24 +243,24 @@ static inline String get_plugins_custom_maven_repos(Vector<PluginConfig> plugins
 			repos_urls.append_array(config.custom_maven_repos);
 		}
 
-		custom_maven_repos = String(PLUGIN_VALUE_SEPARATOR).join(repos_urls);
+		custom_maven_repos = String(PluginConfigAndroid::PLUGIN_VALUE_SEPARATOR).join(repos_urls);
 	}
 	return custom_maven_repos;
 }
 
-static inline String get_plugins_names(Vector<PluginConfig> plugins_configs) {
+static inline String get_plugins_names(Vector<PluginConfigAndroid> plugins_configs) {
 	String plugins_names;
 	if (!plugins_configs.is_empty()) {
 		Vector<String> names;
 		for (int i = 0; i < plugins_configs.size(); i++) {
-			PluginConfig config = plugins_configs[i];
+			PluginConfigAndroid config = plugins_configs[i];
 			if (!config.valid_config) {
 				continue;
 			}
 
 			names.push_back(config.name);
 		}
-		plugins_names = String(PLUGIN_VALUE_SEPARATOR).join(names);
+		plugins_names = String(PluginConfigAndroid::PLUGIN_VALUE_SEPARATOR).join(names);
 	}
 
 	return plugins_names;

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -60,7 +60,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 	Thread *check_for_changes_thread;
 	volatile bool quit_request;
 	Mutex plugins_lock;
-	Vector<PluginConfig> plugins;
+	Vector<PluginConfigIOS> plugins;
 
 	typedef Error (*FileHandler)(String p_file, void *p_userdata);
 	static Error _walk_dir_recursive(DirAccess *p_da, FileHandler p_handler, void *p_userdata);
@@ -146,7 +146,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 			if (!ea->plugins_changed) {
 				MutexLock lock(ea->plugins_lock);
 
-				Vector<PluginConfig> loaded_plugins = get_plugins();
+				Vector<PluginConfigIOS> loaded_plugins = get_plugins();
 
 				if (ea->plugins.size() != loaded_plugins.size()) {
 					ea->plugins_changed = true;
@@ -241,7 +241,7 @@ public:
 					continue;
 				}
 
-				if (file.ends_with(PLUGIN_CONFIG_EXT)) {
+				if (file.ends_with(PluginConfigIOS::PLUGIN_CONFIG_EXT)) {
 					dir_files.push_back(file);
 				}
 			}
@@ -251,8 +251,8 @@ public:
 		return dir_files;
 	}
 
-	static Vector<PluginConfig> get_plugins() {
-		Vector<PluginConfig> loaded_plugins;
+	static Vector<PluginConfigIOS> get_plugins() {
+		Vector<PluginConfigIOS> loaded_plugins;
 
 		String plugins_dir = ProjectSettings::get_singleton()->get_resource_path().plus_file("ios/plugins");
 
@@ -262,7 +262,7 @@ public:
 			if (!plugins_filenames.is_empty()) {
 				Ref<ConfigFile> config_file = memnew(ConfigFile);
 				for (int i = 0; i < plugins_filenames.size(); i++) {
-					PluginConfig config = load_plugin_config(config_file, plugins_dir.plus_file(plugins_filenames[i]));
+					PluginConfigIOS config = load_plugin_config(config_file, plugins_dir.plus_file(plugins_filenames[i]));
 					if (config.valid_config) {
 						loaded_plugins.push_back(config);
 					} else {
@@ -275,11 +275,11 @@ public:
 		return loaded_plugins;
 	}
 
-	static Vector<PluginConfig> get_enabled_plugins(const Ref<EditorExportPreset> &p_presets) {
-		Vector<PluginConfig> enabled_plugins;
-		Vector<PluginConfig> all_plugins = get_plugins();
+	static Vector<PluginConfigIOS> get_enabled_plugins(const Ref<EditorExportPreset> &p_presets) {
+		Vector<PluginConfigIOS> enabled_plugins;
+		Vector<PluginConfigIOS> all_plugins = get_plugins();
 		for (int i = 0; i < all_plugins.size(); i++) {
-			PluginConfig plugin = all_plugins[i];
+			PluginConfigIOS plugin = all_plugins[i];
 			bool enabled = p_presets->get("plugins/" + plugin.name);
 			if (enabled) {
 				enabled_plugins.push_back(plugin);
@@ -360,7 +360,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version"), "1.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
 
-	Vector<PluginConfig> found_plugins = get_plugins();
+	Vector<PluginConfigIOS> found_plugins = get_plugins();
 	for (int i = 0; i < found_plugins.size(); i++) {
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "plugins/" + found_plugins[i].name), false));
 	}
@@ -1345,7 +1345,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 	Vector<String> plugin_embedded_dependencies;
 	Vector<String> plugin_files;
 
-	Vector<PluginConfig> enabled_plugins = get_enabled_plugins(p_preset);
+	Vector<PluginConfigIOS> enabled_plugins = get_enabled_plugins(p_preset);
 
 	Vector<String> added_linked_dependenciy_names;
 	Vector<String> added_embedded_dependenciy_names;
@@ -1354,7 +1354,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 	Error err;
 
 	for (int i = 0; i < enabled_plugins.size(); i++) {
-		PluginConfig plugin = enabled_plugins[i];
+		PluginConfigIOS plugin = enabled_plugins[i];
 
 		// Export plugin binary.
 		if (!plugin.supports_targets) {

--- a/platform/iphone/plugin/godot_plugin_config.h
+++ b/platform/iphone/plugin/godot_plugin_config.h
@@ -35,23 +35,6 @@
 #include "core/io/config_file.h"
 #include "core/string/ustring.h"
 
-static const char *PLUGIN_CONFIG_EXT = ".gdip";
-
-static const char *CONFIG_SECTION = "config";
-static const char *CONFIG_NAME_KEY = "name";
-static const char *CONFIG_BINARY_KEY = "binary";
-static const char *CONFIG_INITIALIZE_KEY = "initialization";
-static const char *CONFIG_DEINITIALIZE_KEY = "deinitialization";
-
-static const char *DEPENDENCIES_SECTION = "dependencies";
-static const char *DEPENDENCIES_LINKED_KEY = "linked";
-static const char *DEPENDENCIES_EMBEDDED_KEY = "embedded";
-static const char *DEPENDENCIES_SYSTEM_KEY = "system";
-static const char *DEPENDENCIES_CAPABILITIES_KEY = "capabilities";
-static const char *DEPENDENCIES_FILES_KEY = "files";
-
-static const char *PLIST_SECTION = "plist";
-
 /*
  The `config` section and fields are required and defined as follow:
 - **name**: name of the plugin
@@ -68,7 +51,24 @@ The `plist` section are optional.
 - **key**: key and value that would be added in Info.plist file.
  */
 
-struct PluginConfig {
+struct PluginConfigIOS {
+	inline static const char *PLUGIN_CONFIG_EXT = ".gdip";
+
+	inline static const char *CONFIG_SECTION = "config";
+	inline static const char *CONFIG_NAME_KEY = "name";
+	inline static const char *CONFIG_BINARY_KEY = "binary";
+	inline static const char *CONFIG_INITIALIZE_KEY = "initialization";
+	inline static const char *CONFIG_DEINITIALIZE_KEY = "deinitialization";
+
+	inline static const char *DEPENDENCIES_SECTION = "dependencies";
+	inline static const char *DEPENDENCIES_LINKED_KEY = "linked";
+	inline static const char *DEPENDENCIES_EMBEDDED_KEY = "embedded";
+	inline static const char *DEPENDENCIES_SYSTEM_KEY = "system";
+	inline static const char *DEPENDENCIES_CAPABILITIES_KEY = "capabilities";
+	inline static const char *DEPENDENCIES_FILES_KEY = "files";
+
+	inline static const char *PLIST_SECTION = "plist";
+
 	// Set to true when the config file is properly loaded.
 	bool valid_config = false;
 	bool supports_targets = false;
@@ -159,7 +159,7 @@ static inline Vector<String> resolve_system_dependencies(Vector<String> p_paths)
 	return paths;
 }
 
-static inline bool validate_plugin(PluginConfig &plugin_config) {
+static inline bool validate_plugin(PluginConfigIOS &plugin_config) {
 	bool valid_name = !plugin_config.name.is_empty();
 	bool valid_binary_name = !plugin_config.binary.is_empty();
 	bool valid_initialize = !plugin_config.initialization_method.is_empty();
@@ -185,7 +185,7 @@ static inline bool validate_plugin(PluginConfig &plugin_config) {
 	return plugin_config.valid_config;
 }
 
-static inline uint64_t get_plugin_modification_time(const PluginConfig &plugin_config, const String &config_path) {
+static inline uint64_t get_plugin_modification_time(const PluginConfigIOS &plugin_config, const String &config_path) {
 	uint64_t last_updated = FileAccess::get_modified_time(config_path);
 
 	if (!plugin_config.supports_targets) {
@@ -203,8 +203,8 @@ static inline uint64_t get_plugin_modification_time(const PluginConfig &plugin_c
 	return last_updated;
 }
 
-static inline PluginConfig load_plugin_config(Ref<ConfigFile> config_file, const String &path) {
-	PluginConfig plugin_config = {};
+static inline PluginConfigIOS load_plugin_config(Ref<ConfigFile> config_file, const String &path) {
+	PluginConfigIOS plugin_config = {};
 
 	if (!config_file.is_valid()) {
 		return plugin_config;
@@ -218,18 +218,18 @@ static inline PluginConfig load_plugin_config(Ref<ConfigFile> config_file, const
 
 	String config_base_dir = path.get_base_dir();
 
-	plugin_config.name = config_file->get_value(CONFIG_SECTION, CONFIG_NAME_KEY, String());
-	plugin_config.initialization_method = config_file->get_value(CONFIG_SECTION, CONFIG_INITIALIZE_KEY, String());
-	plugin_config.deinitialization_method = config_file->get_value(CONFIG_SECTION, CONFIG_DEINITIALIZE_KEY, String());
+	plugin_config.name = config_file->get_value(PluginConfigIOS::CONFIG_SECTION, PluginConfigIOS::CONFIG_NAME_KEY, String());
+	plugin_config.initialization_method = config_file->get_value(PluginConfigIOS::CONFIG_SECTION, PluginConfigIOS::CONFIG_INITIALIZE_KEY, String());
+	plugin_config.deinitialization_method = config_file->get_value(PluginConfigIOS::CONFIG_SECTION, PluginConfigIOS::CONFIG_DEINITIALIZE_KEY, String());
 
-	String binary_path = config_file->get_value(CONFIG_SECTION, CONFIG_BINARY_KEY, String());
+	String binary_path = config_file->get_value(PluginConfigIOS::CONFIG_SECTION, PluginConfigIOS::CONFIG_BINARY_KEY, String());
 	plugin_config.binary = resolve_local_dependency_path(config_base_dir, binary_path);
 
-	if (config_file->has_section(DEPENDENCIES_SECTION)) {
-		Vector<String> linked_dependencies = config_file->get_value(DEPENDENCIES_SECTION, DEPENDENCIES_LINKED_KEY, Vector<String>());
-		Vector<String> embedded_dependencies = config_file->get_value(DEPENDENCIES_SECTION, DEPENDENCIES_EMBEDDED_KEY, Vector<String>());
-		Vector<String> system_dependencies = config_file->get_value(DEPENDENCIES_SECTION, DEPENDENCIES_SYSTEM_KEY, Vector<String>());
-		Vector<String> files = config_file->get_value(DEPENDENCIES_SECTION, DEPENDENCIES_FILES_KEY, Vector<String>());
+	if (config_file->has_section(PluginConfigIOS::DEPENDENCIES_SECTION)) {
+		Vector<String> linked_dependencies = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_LINKED_KEY, Vector<String>());
+		Vector<String> embedded_dependencies = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_EMBEDDED_KEY, Vector<String>());
+		Vector<String> system_dependencies = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_SYSTEM_KEY, Vector<String>());
+		Vector<String> files = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_FILES_KEY, Vector<String>());
 
 		plugin_config.linked_dependencies = resolve_local_dependencies(config_base_dir, linked_dependencies);
 		plugin_config.embedded_dependencies = resolve_local_dependencies(config_base_dir, embedded_dependencies);
@@ -237,15 +237,15 @@ static inline PluginConfig load_plugin_config(Ref<ConfigFile> config_file, const
 
 		plugin_config.files_to_copy = resolve_local_dependencies(config_base_dir, files);
 
-		plugin_config.capabilities = config_file->get_value(DEPENDENCIES_SECTION, DEPENDENCIES_CAPABILITIES_KEY, Vector<String>());
+		plugin_config.capabilities = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_CAPABILITIES_KEY, Vector<String>());
 	}
 
-	if (config_file->has_section(PLIST_SECTION)) {
+	if (config_file->has_section(PluginConfigIOS::PLIST_SECTION)) {
 		List<String> keys;
-		config_file->get_section_keys(PLIST_SECTION, &keys);
+		config_file->get_section_keys(PluginConfigIOS::PLIST_SECTION, &keys);
 
 		for (int i = 0; i < keys.size(); i++) {
-			String value = config_file->get_value(PLIST_SECTION, keys[i], String());
+			String value = config_file->get_value(PluginConfigIOS::PLIST_SECTION, keys[i], String());
 
 			if (value.is_empty()) {
 				continue;


### PR DESCRIPTION
Should cover `C++ One Definition Rule` warning for `PluginConfig` struct from: https://github.com/godotengine/godot/issues/45179

Added a prefixes for platform's `PluginConfig` struct and plugin constants to remove possible name collisions.

This changes are already cherry-picked for https://github.com/godotengine/godot/pull/41340