### PR TITLE
BVH - fix physics expecting plus one based IDs.

### DIFF
--- a/core/math/bvh_debug.inc
+++ b/core/math/bvh_debug.inc
@@ -7,19 +7,19 @@ void _debug_recursive_print_tree(int p_tree_id) const {
 
 String _debug_aabb_to_string(const BVH_ABB &aabb) const {
 	String sz = "(";
-	sz += itos(-aabb.neg_min.x);
+	sz += itos(aabb.min.x);
 	sz += " ~ ";
-	sz += itos(aabb.max.x);
+	sz += itos(-aabb.neg_max.x);
 	sz += ") (";
 
-	sz += itos(-aabb.neg_min.y);
+	sz += itos(aabb.min.y);
 	sz += " ~ ";
-	sz += itos(aabb.max.y);
+	sz += itos(-aabb.neg_max.y);
 	sz += ") (";
 
-	sz += itos(-aabb.neg_min.z);
+	sz += itos(aabb.min.z);
 	sz += " ~ ";
-	sz += itos(aabb.max.z);
+	sz += itos(-aabb.neg_max.z);
 	sz += ") ";
 
 	Vector3 size = aabb.calculate_size();
@@ -41,14 +41,14 @@ void _debug_recursive_print_tree_node(uint32_t p_node_id, int depth = 0) const {
 	if (tnode.is_leaf()) {
 		sz += " L";
 		sz += itos(tnode.height) + " ";
-		const TLeaf *leaf = node_get_leaf(tnode);
+		const TLeaf &leaf = _node_get_leaf(tnode);
 
 		sz += "[";
-		for (int n = 0; n < leaf->num_items; n++) {
+		for (int n = 0; n < leaf.num_items; n++) {
 			if (n)
 				sz += ", ";
 			sz += "r";
-			sz += itos(leaf->get_item_ref_id(n));
+			sz += itos(leaf.get_item_ref_id(n));
 		}
 		sz += "]  ";
 	} else {

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -2,7 +2,7 @@ public:
 BVHHandle item_add(T *p_userdata, const AABB &p_aabb, int32_t p_subindex, bool p_pairable, uint32_t p_pairable_type, uint32_t p_pairable_mask, bool p_invisible = false) {
 #ifdef BVH_VERBOSE_TREE
 	VERBOSE_PRINT("\nitem_add BEFORE");
-	_recursive_print_tree();
+	_debug_recursive_print_tree(0);
 	VERBOSE_PRINT("\n");
 #endif
 
@@ -182,7 +182,7 @@ void item_remove(BVHHandle p_handle) {
 	//refit_all(_current_tree);
 
 #ifdef BVH_VERBOSE_TREE
-	_recursive_print_tree(tree_id);
+	_debug_recursive_print_tree(_current_tree);
 #endif
 }
 
@@ -281,6 +281,7 @@ void incremental_optimize() {
 	_logic_item_remove_and_reinsert(ref_id);
 
 #ifdef BVH_VERBOSE
+	/*
 	// memory use
 	int mem_refs = _refs.estimate_memory_use();
 	int mem_nodes = _nodes.estimate_memory_use();
@@ -292,7 +293,7 @@ void incremental_optimize() {
 	sz += "mem_leaves : " + itos(mem_leaves) + " ";
 	sz += ", num nodes : " + itos(_nodes.size());
 	print_line(sz);
-
+	*/
 #endif
 }
 

--- a/servers/physics/broad_phase_bvh.cpp
+++ b/servers/physics/broad_phase_bvh.cpp
@@ -35,37 +35,37 @@
 BroadPhaseSW::ID BroadPhaseBVH::create(CollisionObjectSW *p_object, int p_subindex) {
 
 	ID oid = bvh.create(p_object, AABB(), p_subindex, false, 1 << p_object->get_type(), 0);
-	return oid;
+	return oid + 1;
 }
 
 void BroadPhaseBVH::move(ID p_id, const AABB &p_aabb) {
 
-	bvh.move(p_id, p_aabb);
+	bvh.move(p_id - 1, p_aabb);
 }
 
 void BroadPhaseBVH::set_static(ID p_id, bool p_static) {
 
-	CollisionObjectSW *it = bvh.get(p_id);
-	bvh.set_pairable(p_id, !p_static, 1 << it->get_type(), p_static ? 0 : 0xFFFFF); //pair everything, don't care 1?
+	CollisionObjectSW *it = bvh.get(p_id - 1);
+	bvh.set_pairable(p_id - 1, !p_static, 1 << it->get_type(), p_static ? 0 : 0xFFFFF); //pair everything, don't care 1?
 }
 void BroadPhaseBVH::remove(ID p_id) {
 
-	bvh.erase(p_id);
+	bvh.erase(p_id - 1);
 }
 
 CollisionObjectSW *BroadPhaseBVH::get_object(ID p_id) const {
 
-	CollisionObjectSW *it = bvh.get(p_id);
+	CollisionObjectSW *it = bvh.get(p_id - 1);
 	ERR_FAIL_COND_V(!it, NULL);
 	return it;
 }
 bool BroadPhaseBVH::is_static(ID p_id) const {
 
-	return !bvh.is_pairable(p_id);
+	return !bvh.is_pairable(p_id - 1);
 }
 int BroadPhaseBVH::get_subindex(ID p_id) const {
 
-	return bvh.get_subindex(p_id);
+	return bvh.get_subindex(p_id - 1);
 }
 
 int BroadPhaseBVH::cull_point(const Vector3 &p_point, CollisionObjectSW **p_results, int p_max_results, int *p_result_indices) {


### PR DESCRIPTION
Godot physics relies on ID zero being invalid, whereas BVH 0 is a valid ID.
This was causing the first object to be added to the BVH twice, which later caused collisions with itself.

Also fixed up a few debug printing things (that are compiled out normally).

Fixes #45180

## Notes
* I had a look at changing the interface internally to use +1 basis, but this ended up being more confusing than doing it externally, so I've left it external for now.
* Ultimately I'd like to switch the IDs to be plus one based in the BVH, perhaps by creating dummy first BVH reference object.
* I can revisit this when we've tested the BVH properly and are in a position to remove octree, then we can use typesafe BVHHandles in the client code (at the moment they are stored as uint32_t in client code).

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
