### PR TITLE
[3.2] Fix glTF import of scenes without buffers

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -425,7 +425,9 @@ Error EditorSceneImporterGLTF::_parse_buffers(GLTFState &state, const String &p_
 
 Error EditorSceneImporterGLTF::_parse_buffer_views(GLTFState &state) {
 
-	ERR_FAIL_COND_V(!state.json.has("bufferViews"), ERR_FILE_CORRUPT);
+	if (!state.json.has("bufferViews"))
+		return OK;
+
 	const Array &buffers = state.json["bufferViews"];
 	for (GLTFBufferViewIndex i = 0; i < buffers.size(); i++) {
 
@@ -483,7 +485,9 @@ EditorSceneImporterGLTF::GLTFType EditorSceneImporterGLTF::_get_type_from_str(co
 
 Error EditorSceneImporterGLTF::_parse_accessors(GLTFState &state) {
 
-	ERR_FAIL_COND_V(!state.json.has("accessors"), ERR_FILE_CORRUPT);
+	if (!state.json.has("accessors"))
+		return OK;
+
 	const Array &accessors = state.json["accessors"];
 	for (GLTFAccessorIndex i = 0; i < accessors.size(); i++) {
 


### PR DESCRIPTION
Fixes #34066

`bufferViews` and `acessors` fields are optional in glTF but the code assumes they are required. This is what keeps the samples in the issue above from working. There are two limitations:

1. This only fixes the 3.2 branch and AFAIK master has the same issue.
2. Empty nodes still don't work with import hints like `-colonly` which the linked issue also seems to track (?)

I have a solution for that but I assume I should put that in a separate PR?