### PR TITLE
Fixed popup not calculating size correctly before adjusting its rect.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1039,6 +1039,9 @@ void Window::popup_centered_ratio(float p_ratio) {
 void Window::popup(const Rect2i &p_screen_rect) {
 	emit_signal("about_to_popup");
 
+	// Update window size to calculate the actual window size based on contents minimum size and minimum size.
+	_update_window_size();
+
 	if (p_screen_rect != Rect2i()) {
 		set_position(p_screen_rect.position);
 		set_size(p_screen_rect.size);


### PR DESCRIPTION
Does not regress the fix from #44906
Fixes #45199 (see my comment in this issue for further details)

MenuButton popups still full width:
![image](https://user-images.githubusercontent.com/41730826/104665796-06d21a00-571e-11eb-8e83-29c3b7112fc5.png)

Popups correctly fit into window:
![image](https://user-images.githubusercontent.com/41730826/104665877-33863180-571e-11eb-92e4-f6047bad7b42.png)
