### PR TITLE
Move the Asset Library API URLs to the Editor Settings

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1364,10 +1364,18 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	search_hb2->add_child(memnew(Label(TTR("Site:") + " ")));
 	repository = memnew(OptionButton);
 
-	repository->add_item("godotengine.org");
-	repository->set_item_metadata(0, "https://godotengine.org/asset-library/api");
-	repository->add_item("localhost");
-	repository->set_item_metadata(1, "http://127.0.0.1/asset-library/api");
+	{
+		Dictionary default_urls;
+		default_urls["godotengine.org"] = "https://godotengine.org/asset-library/api";
+		default_urls["localhost"] = "http://127.0.0.1/asset-library/api";
+		Dictionary available_urls = _EDITOR_DEF("asset_library/available_urls", default_urls, true);
+		Array keys = available_urls.keys();
+		for (int i = 0; i < available_urls.size(); i++) {
+			String key = keys[i];
+			repository->add_item(key);
+			repository->set_item_metadata(i, available_urls[key]);
+		}
+	}
 
 	repository->connect("item_selected", callable_mp(this, &EditorAssetLibrary::_repository_changed));
 


### PR DESCRIPTION
This PR was inspired by #31613. It allows you to set your own Asset Library URLs. Here's what the default looks like:

![Screenshot from 2021-01-15 01-32-01](https://user-images.githubusercontent.com/1646875/104690304-32c7ae00-56d2-11eb-89a8-55f65afbb5f1.png)

These options show up in the (already existing) "Site:" section in the AssetLib main screen.