### PR TITLE
Add Vector3:linear_interpolate back

### DIFF
--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -201,6 +201,14 @@ Vector3 Vector3::lerp(const Vector3 &p_to, real_t p_weight) const {
 			z + (p_weight * (p_to.z - z)));
 }
 
+Vector3 Vector3::linear_interpolate(const Vector3 &p_b, real_t p_t) const {
+
+	return Vector3(
+			x + (p_t * (p_b.x - x)),
+			y + (p_t * (p_b.y - y)),
+			z + (p_t * (p_b.z - z)));
+}
+
 Vector3 Vector3::slerp(const Vector3 &p_to, real_t p_weight) const {
 	real_t theta = angle_to(p_to);
 	return rotated(cross(p_to).normalized(), theta * p_weight);


### PR DESCRIPTION
When I was making an FPS controller, GDscript said there wasn't a linear_interpolate in Vector3.
And as it turned out, in the source code, there isn't.
So I added it back from the 3.2 branch.