### PR TITLE
Make Range return 1.0 ratio if minimum and maximum values are equal

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -171,7 +171,10 @@ void Range::set_as_ratio(double p_value) {
 }
 
 double Range::get_as_ratio() const {
-	ERR_FAIL_COND_V_MSG(Math::is_equal_approx(get_max(), get_min()), 0.0, "Cannot get ratio when minimum and maximum value are equal.");
+	if (Math::is_equal_approx(get_max(), get_min())) {
+		// Avoid division by zero.
+		return 1.0;
+	}
 
 	if (shared->exp_ratio && get_min() >= 0) {
 		double exp_min = get_min() == 0 ? 0.0 : Math::log(get_min()) / Math::log((double)2);


### PR DESCRIPTION
An error message is also no longer printed. This matches the behavior found in most UI frameworks where having equal minimum and maximum values is considered acceptable.

This closes #43179.