### PR TITLE
Remove unnecessary file existence check when saving scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2316,7 +2316,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			int scene_idx = (p_option == FILE_SAVE_SCENE) ? -1 : tab_closing;
 
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
-			if (scene && scene->get_filename() != "" && FileAccess::exists(scene->get_filename())) {
+			if (scene && scene->get_filename() != "") {
 				if (scene_idx != editor_data.get_edited_scene()) {
 					_save_scene_with_preview(scene->get_filename(), scene_idx);
 				} else {


### PR DESCRIPTION
Fix #45031 for `master` branch

The check for file existence caused a save dialog to appear when the scene already has a save path assigned but file there is yet to be created