### PR TITLE
[3.2] Remove usage of deleted element in Area::_area_inout

### DIFF
--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -385,7 +385,7 @@ void Area::_area_inout(int p_status, const RID &p_area, int p_instance, int p_ar
 			if (node) {
 				node->disconnect(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
-				if (E->get().in_tree) {
+				if (in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/45227

This one thing was missing in https://github.com/godotengine/godot/pull/42514 which changes this code - 4.0 version of this commit doesn't have this issue. 
