### PR TITLE
Rename PHashTranslation to OptimizedTranslation

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -68,7 +68,7 @@
 #include "core/object/class_db.h"
 #include "core/object/undo_redo.h"
 #include "core/os/main_loop.h"
-#include "core/string/compressed_translation.h"
+#include "core/string/optimized_translation.h"
 #include "core/string/translation.h"
 
 static Ref<ResourceFormatSaverBinary> resource_saver_binary;
@@ -183,7 +183,7 @@ void register_core_types() {
 	ClassDB::register_class<MultiplayerAPI>();
 	ClassDB::register_class<MainLoop>();
 	ClassDB::register_class<Translation>();
-	ClassDB::register_class<PHashTranslation>();
+	ClassDB::register_class<OptimizedTranslation>();
 	ClassDB::register_class<UndoRedo>();
 	ClassDB::register_class<HTTPClient>();
 	ClassDB::register_class<TriangleMesh>();

--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  compressed_translation.h                                             */
+/*  optimized_translation.h                                              */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,13 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef COMPRESSED_TRANSLATION_H
-#define COMPRESSED_TRANSLATION_H
+#ifndef OPTIMIZED_TRANSLATION_H
+#define OPTIMIZED_TRANSLATION_H
 
 #include "core/string/translation.h"
 
-class PHashTranslation : public Translation {
-	GDCLASS(PHashTranslation, Translation);
+class OptimizedTranslation : public Translation {
+	GDCLASS(OptimizedTranslation, Translation);
 
 	//this translation uses a sort of modified perfect hash algorithm
 	//it requires hashing strings twice and then does a binary search,
@@ -83,7 +83,7 @@ public:
 	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
 	void generate(const Ref<Translation> &p_from);
 
-	PHashTranslation() {}
+	OptimizedTranslation() {}
 };
 
-#endif // COMPRESSED_TRANSLATION_H
+#endif // OPTIMIZED_TRANSLATION_H

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -275,7 +275,7 @@ void TranslationPO::erase_message(const StringName &p_src_text, const StringName
 }
 
 void TranslationPO::get_message_list(List<StringName> *r_messages) const {
-	// PHashTranslation uses this function to get the list of msgid.
+	// OptimizedTranslation uses this function to get the list of msgid.
 	// Return all the keys of translation_map under "" context.
 
 	List<StringName> context_l;

--- a/doc/classes/OptimizedTranslation.xml
+++ b/doc/classes/OptimizedTranslation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="PHashTranslation" inherits="Translation" version="4.0">
+<class name="OptimizedTranslation" inherits="Translation" version="4.0">
 	<brief_description>
 		Optimized translation.
 	</brief_description>

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -32,7 +32,7 @@
 
 #include "core/io/resource_saver.h"
 #include "core/os/file_access.h"
-#include "core/string/compressed_translation.h"
+#include "core/string/optimized_translation.h"
 #include "core/string/translation.h"
 
 String ResourceImporterCSVTranslation::get_importer_name() const {
@@ -126,7 +126,7 @@ Error ResourceImporterCSVTranslation::import(const String &p_source_file, const 
 		Ref<Translation> xlt = translations[i];
 
 		if (compress) {
-			Ref<PHashTranslation> cxl = memnew(PHashTranslation);
+			Ref<OptimizedTranslation> cxl = memnew(OptimizedTranslation);
 			cxl->generate(xlt);
 			xlt = cxl;
 		}

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -37,7 +37,7 @@
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
 #include "core/os/os.h"
-#include "core/string/compressed_translation.h"
+#include "core/string/optimized_translation.h"
 #include "editor_data.h"
 #include "editor_node.h"
 #include "editor_scale.h"


### PR DESCRIPTION
Part of  #16863.

Note: The suggestion was to rename it `CompressedTranslation`. However, although it does compress the translation, as the [documentation](https://docs.godotengine.org/en/stable/classes/class_phashtranslation.html) indicates, it's an "Optimized Translation" that uses compression. This is supported by the implementation, which uses a `struct` to hold the compressed form. This PR includes renaming this `struct` to make this clear.
