### PR TITLE
renamed .*spatial.* to .*node_3d.* for consistency

### DIFF
--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -133,7 +133,7 @@
 				Returns the [EditorNode3DGizmoPlugin] that owns this gizmo. It's useful to retrieve materials using [method EditorNode3DGizmoPlugin.get_material].
 			</description>
 		</method>
-		<method name="get_spatial_node" qualifiers="const">
+		<method name="get_node_3d" qualifiers="const">
 			<return type="Node3D">
 			</return>
 			<description>
@@ -179,7 +179,7 @@
 				Sets the gizmo's hidden state. If [code]true[/code], the gizmo will be hidden. If [code]false[/code], it will be shown.
 			</description>
 		</method>
-		<method name="set_spatial_node">
+		<method name="set_node_3d">
 			<return type="void">
 			</return>
 			<argument index="0" name="node" type="Node">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -118,7 +118,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="add_spatial_gizmo_plugin">
+		<method name="add_node_3d_gizmo_plugin">
 			<return type="void">
 			</return>
 			<argument index="0" name="plugin" type="EditorNode3DGizmoPlugin">
@@ -289,7 +289,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="forward_spatial_draw_over_viewport" qualifiers="virtual">
+		<method name="forward_node_3d_draw_over_viewport" qualifiers="virtual">
 			<return type="void">
 			</return>
 			<argument index="0" name="overlay" type="Control">
@@ -298,11 +298,11 @@
 				Called by the engine when the 3D editor's viewport is updated. Use the [code]overlay[/code] [Control] for drawing. You can update the viewport manually by calling [method update_overlays].
 				[codeblocks]
 				[gdscript]
-				func forward_spatial_draw_over_viewport(overlay):
+				func forward_node_3d_draw_over_viewport(overlay):
 				    # Draw a circle at cursor position.
 				    overlay.draw_circle(overlay.get_local_mouse_position(), 64)
 
-				func forward_spatial_gui_input(camera, event):
+				func forward_node_3d_gui_input(camera, event):
 				    if event is InputEventMouseMotion:
 				        # Redraw viewport when cursor is moved.
 				        update_overlays()
@@ -329,17 +329,17 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="forward_spatial_force_draw_over_viewport" qualifiers="virtual">
+		<method name="forward_node_3d_force_draw_over_viewport" qualifiers="virtual">
 			<return type="void">
 			</return>
 			<argument index="0" name="overlay" type="Control">
 			</argument>
 			<description>
-				This method is the same as [method forward_spatial_draw_over_viewport], except it draws on top of everything. Useful when you need an extra layer that shows over anything else.
+				This method is the same as [method forward_node_3d_draw_over_viewport], except it draws on top of everything. Useful when you need an extra layer that shows over anything else.
 				You need to enable calling of this method by using [method set_force_draw_over_forwarding_enabled].
 			</description>
 		</method>
-		<method name="forward_spatial_gui_input" qualifiers="virtual">
+		<method name="forward_node_3d_gui_input" qualifiers="virtual">
 			<return type="bool">
 			</return>
 			<argument index="0" name="camera" type="Camera3D">
@@ -351,7 +351,7 @@
 				[codeblocks]
 				[gdscript]
 				# Prevents the InputEvent to reach other Editor classes.
-				func forward_spatial_gui_input(camera, event):
+				func forward_node_3d_gui_input(camera, event):
 				    return true
 				[/gdscript]
 				[csharp]
@@ -366,7 +366,7 @@
 				[codeblocks]
 				[gdscript]
 				# Consumes InputEventMouseMotion and forwards other InputEvent types.
-				func forward_spatial_gui_input(camera, event):
+				func forward_node_3d_gui_input(camera, event):
 				    return event is InputEventMouseMotion
 				[/gdscript]
 				[csharp]
@@ -465,7 +465,7 @@
 			<argument index="0" name="object" type="Object">
 			</argument>
 			<description>
-				Implement this function if your plugin edits a specific type of object (Resource or Node). If you return [code]true[/code], then you will get the functions [method edit] and [method make_visible] called when the editor requests them. If you have declared the methods [method forward_canvas_gui_input] and [method forward_spatial_gui_input] these will be called too.
+				Implement this function if your plugin edits a specific type of object (Resource or Node). If you return [code]true[/code], then you will get the functions [method edit] and [method make_visible] called when the editor requests them. If you have declared the methods [method forward_canvas_gui_input] and [method forward_node_3d_gui_input] these will be called too.
 			</description>
 		</method>
 		<method name="has_main_screen" qualifiers="virtual">
@@ -594,7 +594,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="remove_spatial_gizmo_plugin">
+		<method name="remove_node_3d_gizmo_plugin">
 			<return type="void">
 			</return>
 			<argument index="0" name="plugin" type="EditorNode3DGizmoPlugin">
@@ -631,14 +631,14 @@
 			<return type="void">
 			</return>
 			<description>
-				Enables calling of [method forward_canvas_force_draw_over_viewport] for the 2D editor and [method forward_spatial_force_draw_over_viewport] for the 3D editor when their viewports are updated. You need to call this method only once and it will work permanently for this plugin.
+				Enables calling of [method forward_canvas_force_draw_over_viewport] for the 2D editor and [method forward_node_3d_force_draw_over_viewport] for the 3D editor when their viewports are updated. You need to call this method only once and it will work permanently for this plugin.
 			</description>
 		</method>
 		<method name="set_input_event_forwarding_always_enabled">
 			<return type="void">
 			</return>
 			<description>
-				Use this method if you always want to receive inputs from 3D view screen inside [method forward_spatial_gui_input]. It might be especially usable if your plugin will want to use raycast in the scene.
+				Use this method if you always want to receive inputs from 3D view screen inside [method forward_node_3d_gui_input]. It might be especially usable if your plugin will want to use raycast in the scene.
 			</description>
 		</method>
 		<method name="set_state" qualifiers="virtual">
@@ -663,7 +663,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Updates the overlays of the 2D and 3D editor viewport. Causes methods [method forward_canvas_draw_over_viewport], [method forward_canvas_force_draw_over_viewport], [method forward_spatial_draw_over_viewport] and [method forward_spatial_force_draw_over_viewport] to be called.
+				Updates the overlays of the 2D and 3D editor viewport. Causes methods [method forward_canvas_draw_over_viewport], [method forward_canvas_force_draw_over_viewport], [method forward_node_3d_draw_over_viewport] and [method forward_node_3d_force_draw_over_viewport] to be called.
 			</description>
 		</method>
 	</methods>

--- a/doc/translations/ar.po
+++ b/doc/translations/ar.po
@@ -19162,7 +19162,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/ca.po
+++ b/doc/translations/ca.po
@@ -19193,7 +19193,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/classes.pot
+++ b/doc/translations/classes.pot
@@ -19163,7 +19163,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/cs.po
+++ b/doc/translations/cs.po
@@ -19659,7 +19659,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/de.po
+++ b/doc/translations/de.po
@@ -19519,7 +19519,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/fa.po
+++ b/doc/translations/fa.po
@@ -19168,7 +19168,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/fi.po
+++ b/doc/translations/fi.po
@@ -19181,7 +19181,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/fr.po
+++ b/doc/translations/fr.po
@@ -19513,7 +19513,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/id.po
+++ b/doc/translations/id.po
@@ -19194,7 +19194,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/it.po
+++ b/doc/translations/it.po
@@ -19455,7 +19455,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/ja.po
+++ b/doc/translations/ja.po
@@ -20404,7 +20404,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/ko.po
+++ b/doc/translations/ko.po
@@ -19170,7 +19170,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/nl.po
+++ b/doc/translations/nl.po
@@ -19196,7 +19196,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/pl.po
+++ b/doc/translations/pl.po
@@ -19215,7 +19215,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/pt_BR.po
+++ b/doc/translations/pt_BR.po
@@ -19209,7 +19209,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/ro.po
+++ b/doc/translations/ro.po
@@ -19170,7 +19170,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/sr_Cyrl.po
+++ b/doc/translations/sr_Cyrl.po
@@ -19180,7 +19180,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/th.po
+++ b/doc/translations/th.po
@@ -19186,7 +19186,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/tr.po
+++ b/doc/translations/tr.po
@@ -19162,7 +19162,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/zh_Hans.po
+++ b/doc/translations/zh_Hans.po
@@ -19397,7 +19397,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/doc/translations/zh_Hant.po
+++ b/doc/translations/zh_Hant.po
@@ -19199,7 +19199,7 @@ msgstr ""
 #: doc/classes/EditorPlugin.xml:502
 msgid ""
 "Use this method if you always want to receive inputs from 3D view screen "
-"inside [method forward_spatial_gui_input]. It might be especially usable if "
+"inside [method forward_node_3d_gui_input]. It might be especially usable if "
 "your plugin will want to use raycast in the scene."
 msgstr ""
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6902,7 +6902,7 @@ bool EditorPluginList::forward_spatial_gui_input(Camera3D *p_camera, const Ref<I
 			continue;
 		}
 
-		if (plugins_list[i]->forward_spatial_gui_input(p_camera, p_event)) {
+		if (plugins_list[i]->forward_node_3d_gui_input(p_camera, p_event)) {
 			discard = true;
 		}
 	}
@@ -6924,13 +6924,13 @@ void EditorPluginList::forward_canvas_force_draw_over_viewport(Control *p_overla
 
 void EditorPluginList::forward_spatial_draw_over_viewport(Control *p_overlay) {
 	for (int i = 0; i < plugins_list.size(); i++) {
-		plugins_list[i]->forward_spatial_draw_over_viewport(p_overlay);
+		plugins_list[i]->forward_node_3d_draw_over_viewport(p_overlay);
 	}
 }
 
 void EditorPluginList::forward_spatial_force_draw_over_viewport(Control *p_overlay) {
 	for (int i = 0; i < plugins_list.size(); i++) {
-		plugins_list[i]->forward_spatial_force_draw_over_viewport(p_overlay);
+		plugins_list[i]->forward_node_3d_force_draw_over_viewport(p_overlay);
 	}
 }
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -575,23 +575,23 @@ int EditorPlugin::update_overlays() const {
 	}
 }
 
-bool EditorPlugin::forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
-	if (get_script_instance() && get_script_instance()->has_method("forward_spatial_gui_input")) {
-		return get_script_instance()->call("forward_spatial_gui_input", p_camera, p_event);
+bool EditorPlugin::forward_node_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
+	if (get_script_instance() && get_script_instance()->has_method("forward_node_3d_gui_input")) {
+		return get_script_instance()->call("forward_node_3d_gui_input", p_camera, p_event);
 	}
 
 	return false;
 }
 
-void EditorPlugin::forward_spatial_draw_over_viewport(Control *p_overlay) {
-	if (get_script_instance() && get_script_instance()->has_method("forward_spatial_draw_over_viewport")) {
-		get_script_instance()->call("forward_spatial_draw_over_viewport", p_overlay);
+void EditorPlugin::forward_node_3d_draw_over_viewport(Control *p_overlay) {
+	if (get_script_instance() && get_script_instance()->has_method("forward_node_3d_draw_over_viewport")) {
+		get_script_instance()->call("forward_node_3d_draw_over_viewport", p_overlay);
 	}
 }
 
-void EditorPlugin::forward_spatial_force_draw_over_viewport(Control *p_overlay) {
-	if (get_script_instance() && get_script_instance()->has_method("forward_spatial_force_draw_over_viewport")) {
-		get_script_instance()->call("forward_spatial_force_draw_over_viewport", p_overlay);
+void EditorPlugin::forward_node_3d_force_draw_over_viewport(Control *p_overlay) {
+	if (get_script_instance() && get_script_instance()->has_method("forward_node_3d_force_draw_over_viewport")) {
+		get_script_instance()->call("forward_node_3d_force_draw_over_viewport", p_overlay);
 	}
 }
 
@@ -719,11 +719,11 @@ void EditorPlugin::remove_export_plugin(const Ref<EditorExportPlugin> &p_exporte
 	EditorExport::get_singleton()->remove_export_plugin(p_exporter);
 }
 
-void EditorPlugin::add_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
+void EditorPlugin::add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
 	Node3DEditor::get_singleton()->add_gizmo_plugin(p_gizmo_plugin);
 }
 
-void EditorPlugin::remove_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
+void EditorPlugin::remove_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
 	Node3DEditor::get_singleton()->remove_gizmo_plugin(p_gizmo_plugin);
 }
 
@@ -850,8 +850,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_scene_import_plugin", "scene_importer"), &EditorPlugin::remove_scene_import_plugin);
 	ClassDB::bind_method(D_METHOD("add_export_plugin", "plugin"), &EditorPlugin::add_export_plugin);
 	ClassDB::bind_method(D_METHOD("remove_export_plugin", "plugin"), &EditorPlugin::remove_export_plugin);
-	ClassDB::bind_method(D_METHOD("add_spatial_gizmo_plugin", "plugin"), &EditorPlugin::add_spatial_gizmo_plugin);
-	ClassDB::bind_method(D_METHOD("remove_spatial_gizmo_plugin", "plugin"), &EditorPlugin::remove_spatial_gizmo_plugin);
+	ClassDB::bind_method(D_METHOD("add_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::add_node_3d_gizmo_plugin);
+	ClassDB::bind_method(D_METHOD("remove_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::remove_node_3d_gizmo_plugin);
 	ClassDB::bind_method(D_METHOD("add_inspector_plugin", "plugin"), &EditorPlugin::add_inspector_plugin);
 	ClassDB::bind_method(D_METHOD("remove_inspector_plugin", "plugin"), &EditorPlugin::remove_inspector_plugin);
 	ClassDB::bind_method(D_METHOD("set_input_event_forwarding_always_enabled"), &EditorPlugin::set_input_event_forwarding_always_enabled);
@@ -865,9 +865,9 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_canvas_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_canvas_force_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_spatial_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera3D"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_spatial_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_spatial_force_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_node_3d_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera3D"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_node_3d_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_node_3d_force_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_plugin_name"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "get_plugin_icon"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "has_main_screen"));

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -193,9 +193,9 @@ public:
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay);
 	virtual void forward_canvas_force_draw_over_viewport(Control *p_overlay);
 
-	virtual bool forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event);
-	virtual void forward_spatial_draw_over_viewport(Control *p_overlay);
-	virtual void forward_spatial_force_draw_over_viewport(Control *p_overlay);
+	virtual bool forward_node_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event);
+	virtual void forward_node_3d_draw_over_viewport(Control *p_overlay);
+	virtual void forward_node_3d_force_draw_over_viewport(Control *p_overlay);
 
 	virtual String get_name() const;
 	virtual const Ref<Texture2D> get_icon() const;
@@ -238,8 +238,8 @@ public:
 	void add_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
 	void remove_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
 
-	void add_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
-	void remove_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
+	void add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
+	void remove_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
 
 	void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -71,16 +71,16 @@
 #define HANDLE_HALF_SIZE 9.5
 
 bool EditorNode3DGizmo::is_editable() const {
-	ERR_FAIL_COND_V(!spatial_node, false);
-	Node *edited_root = spatial_node->get_tree()->get_edited_scene_root();
-	if (spatial_node == edited_root) {
+	ERR_FAIL_COND_V(!node_3d, false);
+	Node *edited_root = node_3d->get_tree()->get_edited_scene_root();
+	if (node_3d == edited_root) {
 		return true;
 	}
-	if (spatial_node->get_owner() == edited_root) {
+	if (node_3d->get_owner() == edited_root) {
 		return true;
 	}
 
-	if (edited_root->is_editable_instance(spatial_node->get_owner())) {
+	if (edited_root->is_editable_instance(node_3d->get_owner())) {
 		return true;
 	}
 
@@ -159,9 +159,9 @@ void EditorNode3DGizmo::commit_handle(int p_idx, const Variant &p_restore, bool 
 	gizmo_plugin->commit_handle(this, p_idx, p_restore, p_cancel);
 }
 
-void EditorNode3DGizmo::set_spatial_node(Node3D *p_node) {
+void EditorNode3DGizmo::set_node_3d(Node3D *p_node) {
 	ERR_FAIL_NULL(p_node);
-	spatial_node = p_node;
+	node_3d = p_node;
 }
 
 void EditorNode3DGizmo::Instance::create_instance(Node3D *p_base, bool p_hidden) {
@@ -179,7 +179,7 @@ void EditorNode3DGizmo::Instance::create_instance(Node3D *p_base, bool p_hidden)
 }
 
 void EditorNode3DGizmo::add_mesh(const Ref<ArrayMesh> &p_mesh, bool p_billboard, const Ref<SkinReference> &p_skin_reference, const Ref<Material> &p_material) {
-	ERR_FAIL_COND(!spatial_node);
+	ERR_FAIL_COND(!node_3d);
 	Instance ins;
 
 	ins.billboard = p_billboard;
@@ -187,8 +187,8 @@ void EditorNode3DGizmo::add_mesh(const Ref<ArrayMesh> &p_mesh, bool p_billboard,
 	ins.skin_reference = p_skin_reference;
 	ins.material = p_material;
 	if (valid) {
-		ins.create_instance(spatial_node, hidden);
-		RS::get_singleton()->instance_set_transform(ins.instance, spatial_node->get_global_transform());
+		ins.create_instance(node_3d, hidden);
+		RS::get_singleton()->instance_set_transform(ins.instance, node_3d->get_global_transform());
 		if (ins.material.is_valid()) {
 			RS::get_singleton()->instance_geometry_set_material_override(ins.instance, p_material->get_rid());
 		}
@@ -202,7 +202,7 @@ void EditorNode3DGizmo::add_lines(const Vector<Vector3> &p_lines, const Ref<Mate
 		return;
 	}
 
-	ERR_FAIL_COND(!spatial_node);
+	ERR_FAIL_COND(!node_3d);
 	Instance ins;
 
 	Ref<ArrayMesh> mesh = memnew(ArrayMesh);
@@ -242,15 +242,15 @@ void EditorNode3DGizmo::add_lines(const Vector<Vector3> &p_lines, const Ref<Mate
 	ins.billboard = p_billboard;
 	ins.mesh = mesh;
 	if (valid) {
-		ins.create_instance(spatial_node, hidden);
-		RS::get_singleton()->instance_set_transform(ins.instance, spatial_node->get_global_transform());
+		ins.create_instance(node_3d, hidden);
+		RS::get_singleton()->instance_set_transform(ins.instance, node_3d->get_global_transform());
 	}
 
 	instances.push_back(ins);
 }
 
 void EditorNode3DGizmo::add_unscaled_billboard(const Ref<Material> &p_material, float p_scale, const Color &p_modulate) {
-	ERR_FAIL_COND(!spatial_node);
+	ERR_FAIL_COND(!node_3d);
 	Instance ins;
 
 	Vector<Vector3> vs;
@@ -304,8 +304,8 @@ void EditorNode3DGizmo::add_unscaled_billboard(const Ref<Material> &p_material, 
 	ins.unscaled = true;
 	ins.billboard = true;
 	if (valid) {
-		ins.create_instance(spatial_node, hidden);
-		RS::get_singleton()->instance_set_transform(ins.instance, spatial_node->get_global_transform());
+		ins.create_instance(node_3d, hidden);
+		RS::get_singleton()->instance_set_transform(ins.instance, node_3d->get_global_transform());
 	}
 
 	selectable_icon_size = p_scale;
@@ -332,7 +332,7 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 		return;
 	}
 
-	ERR_FAIL_COND(!spatial_node);
+	ERR_FAIL_COND(!node_3d);
 
 	Instance ins;
 
@@ -376,8 +376,8 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 	ins.billboard = p_billboard;
 	ins.extra_margin = true;
 	if (valid) {
-		ins.create_instance(spatial_node, hidden);
-		RS::get_singleton()->instance_set_transform(ins.instance, spatial_node->get_global_transform());
+		ins.create_instance(node_3d, hidden);
+		RS::get_singleton()->instance_set_transform(ins.instance, node_3d->get_global_transform());
 	}
 	instances.push_back(ins);
 	if (!p_secondary) {
@@ -396,7 +396,7 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 }
 
 void EditorNode3DGizmo::add_solid_box(Ref<Material> &p_material, Vector3 p_size, Vector3 p_position) {
-	ERR_FAIL_COND(!spatial_node);
+	ERR_FAIL_COND(!node_3d);
 
 	BoxMesh box_mesh;
 	box_mesh.set_size(p_size);
@@ -418,7 +418,7 @@ void EditorNode3DGizmo::add_solid_box(Ref<Material> &p_material, Vector3 p_size,
 }
 
 bool EditorNode3DGizmo::intersect_frustum(const Camera3D *p_camera, const Vector<Plane> &p_frustum) {
-	ERR_FAIL_COND_V(!spatial_node, false);
+	ERR_FAIL_COND_V(!node_3d, false);
 	ERR_FAIL_COND_V(!valid, false);
 
 	if (hidden && !gizmo_plugin->is_selectable_when_hidden()) {
@@ -426,7 +426,7 @@ bool EditorNode3DGizmo::intersect_frustum(const Camera3D *p_camera, const Vector
 	}
 
 	if (selectable_icon_size > 0.0f) {
-		Vector3 origin = spatial_node->get_global_transform().get_origin();
+		Vector3 origin = node_3d->get_global_transform().get_origin();
 
 		const Plane *p = p_frustum.ptr();
 		int fc = p_frustum.size();
@@ -449,7 +449,7 @@ bool EditorNode3DGizmo::intersect_frustum(const Camera3D *p_camera, const Vector
 
 		int vc = collision_segments.size();
 		const Vector3 *vptr = collision_segments.ptr();
-		Transform t = spatial_node->get_global_transform();
+		Transform t = node_3d->get_global_transform();
 
 		bool any_out = false;
 		for (int j = 0; j < fc; j++) {
@@ -471,7 +471,7 @@ bool EditorNode3DGizmo::intersect_frustum(const Camera3D *p_camera, const Vector
 	}
 
 	if (collision_mesh.is_valid()) {
-		Transform t = spatial_node->get_global_transform();
+		Transform t = node_3d->get_global_transform();
 
 		Vector3 mesh_scale = t.get_basis().get_scale();
 		t.orthonormalize();
@@ -494,7 +494,7 @@ bool EditorNode3DGizmo::intersect_frustum(const Camera3D *p_camera, const Vector
 }
 
 bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point, Vector3 &r_pos, Vector3 &r_normal, int *r_gizmo_handle, bool p_sec_first) {
-	ERR_FAIL_COND_V(!spatial_node, false);
+	ERR_FAIL_COND_V(!node_3d, false);
 	ERR_FAIL_COND_V(!valid, false);
 
 	if (hidden && !gizmo_plugin->is_selectable_when_hidden()) {
@@ -502,7 +502,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 	}
 
 	if (r_gizmo_handle && !hidden) {
-		Transform t = spatial_node->get_global_transform();
+		Transform t = node_3d->get_global_transform();
 		if (billboard_handle) {
 			t.set_look_at(t.origin, t.origin - p_camera->get_transform().basis.get_axis(2), p_camera->get_transform().basis.get_axis(1));
 		}
@@ -554,7 +554,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 	}
 
 	if (selectable_icon_size > 0.0f) {
-		Transform t = spatial_node->get_global_transform();
+		Transform t = node_3d->get_global_transform();
 		Vector3 camera_position = p_camera->get_camera_transform().origin;
 		if (camera_position.distance_squared_to(t.origin) > 0.01) {
 			t.set_look_at(t.origin, camera_position, Vector3(0, 1, 0));
@@ -603,7 +603,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 
 		int vc = collision_segments.size();
 		const Vector3 *vptr = collision_segments.ptr();
-		Transform t = spatial_node->get_global_transform();
+		Transform t = node_3d->get_global_transform();
 		if (billboard_handle) {
 			t.set_look_at(t.origin, t.origin - p_camera->get_transform().basis.get_axis(2), p_camera->get_transform().basis.get_axis(1));
 		}
@@ -651,7 +651,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 	}
 
 	if (collision_mesh.is_valid()) {
-		Transform gt = spatial_node->get_global_transform();
+		Transform gt = node_3d->get_global_transform();
 
 		if (billboard_handle) {
 			gt.set_look_at(gt.origin, gt.origin - p_camera->get_transform().basis.get_axis(2), p_camera->get_transform().basis.get_axis(1));
@@ -673,27 +673,27 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 }
 
 void EditorNode3DGizmo::create() {
-	ERR_FAIL_COND(!spatial_node);
+	ERR_FAIL_COND(!node_3d);
 	ERR_FAIL_COND(valid);
 	valid = true;
 
 	for (int i = 0; i < instances.size(); i++) {
-		instances.write[i].create_instance(spatial_node, hidden);
+		instances.write[i].create_instance(node_3d, hidden);
 	}
 
 	transform();
 }
 
 void EditorNode3DGizmo::transform() {
-	ERR_FAIL_COND(!spatial_node);
+	ERR_FAIL_COND(!node_3d);
 	ERR_FAIL_COND(!valid);
 	for (int i = 0; i < instances.size(); i++) {
-		RS::get_singleton()->instance_set_transform(instances[i].instance, spatial_node->get_global_transform());
+		RS::get_singleton()->instance_set_transform(instances[i].instance, node_3d->get_global_transform());
 	}
 }
 
 void EditorNode3DGizmo::free() {
-	ERR_FAIL_COND(!spatial_node);
+	ERR_FAIL_COND(!node_3d);
 	ERR_FAIL_COND(!valid);
 
 	for (int i = 0; i < instances.size(); i++) {
@@ -727,8 +727,8 @@ void EditorNode3DGizmo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_collision_triangles", "triangles"), &EditorNode3DGizmo::add_collision_triangles);
 	ClassDB::bind_method(D_METHOD("add_unscaled_billboard", "material", "default_scale", "modulate"), &EditorNode3DGizmo::add_unscaled_billboard, DEFVAL(1), DEFVAL(Color(1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("add_handles", "handles", "material", "billboard", "secondary"), &EditorNode3DGizmo::add_handles, DEFVAL(false), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("set_spatial_node", "node"), &EditorNode3DGizmo::_set_spatial_node);
-	ClassDB::bind_method(D_METHOD("get_spatial_node"), &EditorNode3DGizmo::get_spatial_node);
+	ClassDB::bind_method(D_METHOD("set_node_3d", "node"), &EditorNode3DGizmo::_set_node_3d);
+	ClassDB::bind_method(D_METHOD("get_node_3d"), &EditorNode3DGizmo::get_node_3d);
 	ClassDB::bind_method(D_METHOD("get_plugin"), &EditorNode3DGizmo::get_plugin);
 	ClassDB::bind_method(D_METHOD("clear"), &EditorNode3DGizmo::clear);
 	ClassDB::bind_method(D_METHOD("set_hidden", "hidden"), &EditorNode3DGizmo::set_hidden);
@@ -754,7 +754,7 @@ EditorNode3DGizmo::EditorNode3DGizmo() {
 	base = nullptr;
 	selected = false;
 	instanced = false;
-	spatial_node = nullptr;
+	node_3d = nullptr;
 	gizmo_plugin = nullptr;
 	selectable_icon_size = -1.0f;
 }
@@ -788,8 +788,8 @@ Light3DGizmoPlugin::Light3DGizmoPlugin() {
 	create_handle_material("handles_billboard", true);
 }
 
-bool Light3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
-	return Object::cast_to<Light3D>(p_spatial) != nullptr;
+bool Light3DGizmoPlugin::has_gizmo(Node3D *p_node_3d) {
+	return Object::cast_to<Light3D>(p_node_3d) != nullptr;
 }
 
 String Light3DGizmoPlugin::get_gizmo_name() const {
@@ -809,7 +809,7 @@ String Light3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int
 }
 
 Variant Light3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	Light3D *light = Object::cast_to<Light3D>(p_gizmo->get_spatial_node());
+	Light3D *light = Object::cast_to<Light3D>(p_gizmo->get_node_3d());
 	if (p_idx == 0) {
 		return light->get_param(Light3D::PARAM_RANGE);
 	}
@@ -848,7 +848,7 @@ static float _find_closest_angle_to_half_pi_arc(const Vector3 &p_from, const Vec
 }
 
 void Light3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	Light3D *light = Object::cast_to<Light3D>(p_gizmo->get_spatial_node());
+	Light3D *light = Object::cast_to<Light3D>(p_gizmo->get_node_3d());
 	Transform gt = light->get_global_transform();
 	Transform gi = gt.affine_inverse();
 
@@ -892,7 +892,7 @@ void Light3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camer
 }
 
 void Light3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	Light3D *light = Object::cast_to<Light3D>(p_gizmo->get_spatial_node());
+	Light3D *light = Object::cast_to<Light3D>(p_gizmo->get_node_3d());
 	if (p_cancel) {
 		light->set_param(p_idx == 0 ? Light3D::PARAM_RANGE : Light3D::PARAM_SPOT_ANGLE, p_restore);
 
@@ -912,7 +912,7 @@ void Light3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, co
 }
 
 void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Light3D *light = Object::cast_to<Light3D>(p_gizmo->get_spatial_node());
+	Light3D *light = Object::cast_to<Light3D>(p_gizmo->get_node_3d());
 
 	Color color = light->get_color();
 	// Make the gizmo color as bright as possible for better visibility
@@ -1057,8 +1057,8 @@ AudioStreamPlayer3DGizmoPlugin::AudioStreamPlayer3DGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-bool AudioStreamPlayer3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
-	return Object::cast_to<AudioStreamPlayer3D>(p_spatial) != nullptr;
+bool AudioStreamPlayer3DGizmoPlugin::has_gizmo(Node3D *p_node_3d) {
+	return Object::cast_to<AudioStreamPlayer3D>(p_node_3d) != nullptr;
 }
 
 String AudioStreamPlayer3DGizmoPlugin::get_gizmo_name() const {
@@ -1074,12 +1074,12 @@ String AudioStreamPlayer3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *
 }
 
 Variant AudioStreamPlayer3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_spatial_node());
+	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
 	return player->get_emission_angle();
 }
 
 void AudioStreamPlayer3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_spatial_node());
+	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
 
 	Transform gt = player->get_global_transform();
 	Transform gi = gt.affine_inverse();
@@ -1116,7 +1116,7 @@ void AudioStreamPlayer3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int 
 }
 
 void AudioStreamPlayer3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_spatial_node());
+	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
 
 	if (p_cancel) {
 		player->set_emission_angle(p_restore);
@@ -1131,7 +1131,7 @@ void AudioStreamPlayer3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, i
 }
 
 void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	const AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_spatial_node());
+	const AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -1191,8 +1191,8 @@ Camera3DGizmoPlugin::Camera3DGizmoPlugin() {
 	create_handle_material("handles");
 }
 
-bool Camera3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
-	return Object::cast_to<Camera3D>(p_spatial) != nullptr;
+bool Camera3DGizmoPlugin::has_gizmo(Node3D *p_node_3d) {
+	return Object::cast_to<Camera3D>(p_node_3d) != nullptr;
 }
 
 String Camera3DGizmoPlugin::get_gizmo_name() const {
@@ -1204,7 +1204,7 @@ int Camera3DGizmoPlugin::get_priority() const {
 }
 
 String Camera3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_spatial_node());
+	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_node_3d());
 
 	if (camera->get_projection() == Camera3D::PROJECTION_PERSPECTIVE) {
 		return "FOV";
@@ -1214,7 +1214,7 @@ String Camera3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, in
 }
 
 Variant Camera3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_spatial_node());
+	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_node_3d());
 
 	if (camera->get_projection() == Camera3D::PROJECTION_PERSPECTIVE) {
 		return camera->get_fov();
@@ -1224,7 +1224,7 @@ Variant Camera3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_
 }
 
 void Camera3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_spatial_node());
+	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_node_3d());
 
 	Transform gt = camera->get_global_transform();
 	Transform gi = gt.affine_inverse();
@@ -1253,7 +1253,7 @@ void Camera3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Came
 }
 
 void Camera3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_spatial_node());
+	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_node_3d());
 
 	if (camera->get_projection() == Camera3D::PROJECTION_PERSPECTIVE) {
 		if (p_cancel) {
@@ -1280,7 +1280,7 @@ void Camera3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, c
 }
 
 void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_spatial_node());
+	Camera3D *camera = Object::cast_to<Camera3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -1445,7 +1445,7 @@ bool MeshInstance3DGizmoPlugin::can_be_hidden() const {
 }
 
 void MeshInstance3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	MeshInstance3D *mesh = Object::cast_to<MeshInstance3D>(p_gizmo->get_spatial_node());
+	MeshInstance3D *mesh = Object::cast_to<MeshInstance3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -1482,7 +1482,7 @@ bool Sprite3DGizmoPlugin::can_be_hidden() const {
 }
 
 void Sprite3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Sprite3D *sprite = Object::cast_to<Sprite3D>(p_gizmo->get_spatial_node());
+	Sprite3D *sprite = Object::cast_to<Sprite3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -1565,7 +1565,7 @@ int Skeleton3DGizmoPlugin::get_priority() const {
 }
 
 void Skeleton3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Skeleton3D *skel = Object::cast_to<Skeleton3D>(p_gizmo->get_spatial_node());
+	Skeleton3D *skel = Object::cast_to<Skeleton3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -1769,7 +1769,7 @@ int PhysicalBone3DGizmoPlugin::get_priority() const {
 void PhysicalBone3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	p_gizmo->clear();
 
-	PhysicalBone3D *physical_bone = Object::cast_to<PhysicalBone3D>(p_gizmo->get_spatial_node());
+	PhysicalBone3D *physical_bone = Object::cast_to<PhysicalBone3D>(p_gizmo->get_node_3d());
 
 	if (!physical_bone) {
 		return;
@@ -1904,7 +1904,7 @@ int RayCast3DGizmoPlugin::get_priority() const {
 }
 
 void RayCast3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	RayCast3D *raycast = Object::cast_to<RayCast3D>(p_gizmo->get_spatial_node());
+	RayCast3D *raycast = Object::cast_to<RayCast3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -1923,7 +1923,7 @@ void RayCast3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 /////
 
 void SpringArm3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	SpringArm3D *spring_arm = Object::cast_to<SpringArm3D>(p_gizmo->get_spatial_node());
+	SpringArm3D *spring_arm = Object::cast_to<SpringArm3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -1975,7 +1975,7 @@ int VehicleWheel3DGizmoPlugin::get_priority() const {
 }
 
 void VehicleWheel3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	VehicleWheel3D *car_wheel = Object::cast_to<VehicleWheel3D>(p_gizmo->get_spatial_node());
+	VehicleWheel3D *car_wheel = Object::cast_to<VehicleWheel3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -2051,7 +2051,7 @@ bool SoftBody3DGizmoPlugin::is_selectable_when_hidden() const {
 }
 
 void SoftBody3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_spatial_node());
+	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -2086,17 +2086,17 @@ String SoftBody3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, 
 }
 
 Variant SoftBody3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_spatial_node());
+	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_node_3d());
 	return Variant(soft_body->is_point_pinned(p_idx));
 }
 
 void SoftBody3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_spatial_node());
+	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_node_3d());
 	soft_body->pin_point_toggle(p_idx);
 }
 
 bool SoftBody3DGizmoPlugin::is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int idx) const {
-	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_spatial_node());
+	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_node_3d());
 	return soft_body->is_point_pinned(idx);
 }
 
@@ -2142,12 +2142,12 @@ String VisibilityNotifier3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo 
 }
 
 Variant VisibilityNotifier3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	VisibilityNotifier3D *notifier = Object::cast_to<VisibilityNotifier3D>(p_gizmo->get_spatial_node());
+	VisibilityNotifier3D *notifier = Object::cast_to<VisibilityNotifier3D>(p_gizmo->get_node_3d());
 	return notifier->get_aabb();
 }
 
 void VisibilityNotifier3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	VisibilityNotifier3D *notifier = Object::cast_to<VisibilityNotifier3D>(p_gizmo->get_spatial_node());
+	VisibilityNotifier3D *notifier = Object::cast_to<VisibilityNotifier3D>(p_gizmo->get_node_3d());
 
 	Transform gt = notifier->get_global_transform();
 
@@ -2199,7 +2199,7 @@ void VisibilityNotifier3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int
 }
 
 void VisibilityNotifier3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	VisibilityNotifier3D *notifier = Object::cast_to<VisibilityNotifier3D>(p_gizmo->get_spatial_node());
+	VisibilityNotifier3D *notifier = Object::cast_to<VisibilityNotifier3D>(p_gizmo->get_node_3d());
 
 	if (p_cancel) {
 		notifier->set_aabb(p_restore);
@@ -2214,7 +2214,7 @@ void VisibilityNotifier3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, 
 }
 
 void VisibilityNotifier3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	VisibilityNotifier3D *notifier = Object::cast_to<VisibilityNotifier3D>(p_gizmo->get_spatial_node());
+	VisibilityNotifier3D *notifier = Object::cast_to<VisibilityNotifier3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -2334,12 +2334,12 @@ String GPUParticles3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_giz
 }
 
 Variant GPUParticles3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	GPUParticles3D *particles = Object::cast_to<GPUParticles3D>(p_gizmo->get_spatial_node());
+	GPUParticles3D *particles = Object::cast_to<GPUParticles3D>(p_gizmo->get_node_3d());
 	return particles->get_visibility_aabb();
 }
 
 void GPUParticles3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	GPUParticles3D *particles = Object::cast_to<GPUParticles3D>(p_gizmo->get_spatial_node());
+	GPUParticles3D *particles = Object::cast_to<GPUParticles3D>(p_gizmo->get_node_3d());
 
 	Transform gt = particles->get_global_transform();
 	Transform gi = gt.affine_inverse();
@@ -2390,7 +2390,7 @@ void GPUParticles3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx
 }
 
 void GPUParticles3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	GPUParticles3D *particles = Object::cast_to<GPUParticles3D>(p_gizmo->get_spatial_node());
+	GPUParticles3D *particles = Object::cast_to<GPUParticles3D>(p_gizmo->get_node_3d());
 
 	if (p_cancel) {
 		particles->set_visibility_aabb(p_restore);
@@ -2405,7 +2405,7 @@ void GPUParticles3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_
 }
 
 void GPUParticles3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	GPUParticles3D *particles = Object::cast_to<GPUParticles3D>(p_gizmo->get_spatial_node());
+	GPUParticles3D *particles = Object::cast_to<GPUParticles3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -2478,7 +2478,7 @@ int GPUParticlesCollision3DGizmoPlugin::get_priority() const {
 }
 
 String GPUParticlesCollision3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	const Node3D *cs = p_gizmo->get_spatial_node();
+	const Node3D *cs = p_gizmo->get_node_3d();
 
 	if (Object::cast_to<GPUParticlesCollisionSphere>(cs) || Object::cast_to<GPUParticlesAttractorSphere>(cs)) {
 		return "Radius";
@@ -2492,21 +2492,21 @@ String GPUParticlesCollision3DGizmoPlugin::get_handle_name(const EditorNode3DGiz
 }
 
 Variant GPUParticlesCollision3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	const Node3D *cs = p_gizmo->get_spatial_node();
+	const Node3D *cs = p_gizmo->get_node_3d();
 
 	if (Object::cast_to<GPUParticlesCollisionSphere>(cs) || Object::cast_to<GPUParticlesAttractorSphere>(cs)) {
-		return p_gizmo->get_spatial_node()->call("get_radius");
+		return p_gizmo->get_node_3d()->call("get_radius");
 	}
 
 	if (Object::cast_to<GPUParticlesCollisionBox>(cs) || Object::cast_to<GPUParticlesAttractorBox>(cs) || Object::cast_to<GPUParticlesAttractorVectorField>(cs) || Object::cast_to<GPUParticlesCollisionSDF>(cs) || Object::cast_to<GPUParticlesCollisionHeightField>(cs)) {
-		return Vector3(p_gizmo->get_spatial_node()->call("get_extents"));
+		return Vector3(p_gizmo->get_node_3d()->call("get_extents"));
 	}
 
 	return Variant();
 }
 
 void GPUParticlesCollision3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	Node3D *sn = p_gizmo->get_spatial_node();
+	Node3D *sn = p_gizmo->get_node_3d();
 
 	Transform gt = sn->get_global_transform();
 	Transform gi = gt.affine_inverse();
@@ -2552,7 +2552,7 @@ void GPUParticlesCollision3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, 
 }
 
 void GPUParticlesCollision3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	Node3D *sn = p_gizmo->get_spatial_node();
+	Node3D *sn = p_gizmo->get_node_3d();
 
 	if (Object::cast_to<GPUParticlesCollisionSphere>(sn) || Object::cast_to<GPUParticlesAttractorSphere>(sn)) {
 		if (p_cancel) {
@@ -2582,7 +2582,7 @@ void GPUParticlesCollision3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizm
 }
 
 void GPUParticlesCollision3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Node3D *cs = p_gizmo->get_spatial_node();
+	Node3D *cs = p_gizmo->get_node_3d();
 
 	print_line("redraw request " + itos(cs != nullptr));
 	p_gizmo->clear();
@@ -2761,12 +2761,12 @@ String ReflectionProbeGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gi
 }
 
 Variant ReflectionProbeGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	ReflectionProbe *probe = Object::cast_to<ReflectionProbe>(p_gizmo->get_spatial_node());
+	ReflectionProbe *probe = Object::cast_to<ReflectionProbe>(p_gizmo->get_node_3d());
 	return AABB(probe->get_extents(), probe->get_origin_offset());
 }
 
 void ReflectionProbeGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	ReflectionProbe *probe = Object::cast_to<ReflectionProbe>(p_gizmo->get_spatial_node());
+	ReflectionProbe *probe = Object::cast_to<ReflectionProbe>(p_gizmo->get_node_3d());
 	Transform gt = probe->get_global_transform();
 
 	Transform gi = gt.affine_inverse();
@@ -2823,7 +2823,7 @@ void ReflectionProbeGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_id
 }
 
 void ReflectionProbeGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	ReflectionProbe *probe = Object::cast_to<ReflectionProbe>(p_gizmo->get_spatial_node());
+	ReflectionProbe *probe = Object::cast_to<ReflectionProbe>(p_gizmo->get_node_3d());
 
 	AABB restore = p_restore;
 
@@ -2843,7 +2843,7 @@ void ReflectionProbeGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p
 }
 
 void ReflectionProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	ReflectionProbe *probe = Object::cast_to<ReflectionProbe>(p_gizmo->get_spatial_node());
+	ReflectionProbe *probe = Object::cast_to<ReflectionProbe>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -2940,12 +2940,12 @@ String DecalGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p
 }
 
 Variant DecalGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	Decal *decal = Object::cast_to<Decal>(p_gizmo->get_spatial_node());
+	Decal *decal = Object::cast_to<Decal>(p_gizmo->get_node_3d());
 	return decal->get_extents();
 }
 
 void DecalGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	Decal *decal = Object::cast_to<Decal>(p_gizmo->get_spatial_node());
+	Decal *decal = Object::cast_to<Decal>(p_gizmo->get_node_3d());
 	Transform gt = decal->get_global_transform();
 
 	Transform gi = gt.affine_inverse();
@@ -2976,7 +2976,7 @@ void DecalGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3
 }
 
 void DecalGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	Decal *decal = Object::cast_to<Decal>(p_gizmo->get_spatial_node());
+	Decal *decal = Object::cast_to<Decal>(p_gizmo->get_node_3d());
 
 	Vector3 restore = p_restore;
 
@@ -2993,7 +2993,7 @@ void DecalGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, cons
 }
 
 void DecalGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Decal *decal = Object::cast_to<Decal>(p_gizmo->get_spatial_node());
+	Decal *decal = Object::cast_to<Decal>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -3081,12 +3081,12 @@ String GIProbeGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int
 }
 
 Variant GIProbeGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	GIProbe *probe = Object::cast_to<GIProbe>(p_gizmo->get_spatial_node());
+	GIProbe *probe = Object::cast_to<GIProbe>(p_gizmo->get_node_3d());
 	return probe->get_extents();
 }
 
 void GIProbeGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	GIProbe *probe = Object::cast_to<GIProbe>(p_gizmo->get_spatial_node());
+	GIProbe *probe = Object::cast_to<GIProbe>(p_gizmo->get_node_3d());
 
 	Transform gt = probe->get_global_transform();
 	Transform gi = gt.affine_inverse();
@@ -3117,7 +3117,7 @@ void GIProbeGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camer
 }
 
 void GIProbeGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	GIProbe *probe = Object::cast_to<GIProbe>(p_gizmo->get_spatial_node());
+	GIProbe *probe = Object::cast_to<GIProbe>(p_gizmo->get_node_3d());
 
 	Vector3 restore = p_restore;
 
@@ -3134,7 +3134,7 @@ void GIProbeGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, co
 }
 
 void GIProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	GIProbe *probe = Object::cast_to<GIProbe>(p_gizmo->get_spatial_node());
+	GIProbe *probe = Object::cast_to<GIProbe>(p_gizmo->get_node_3d());
 
 	Ref<Material> material = get_material("gi_probe_material", p_gizmo);
 	Ref<Material> icon = get_material("gi_probe_icon", p_gizmo);
@@ -3264,7 +3264,7 @@ int BakedLightmapGizmoPlugin::get_priority() const {
 
 void BakedLightmapGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Ref<Material> icon = get_material("baked_indirect_light_icon", p_gizmo);
-	BakedLightmap *baker = Object::cast_to<BakedLightmap>(p_gizmo->get_spatial_node());
+	BakedLightmap *baker = Object::cast_to<BakedLightmap>(p_gizmo->get_node_3d());
 	Ref<BakedLightmapData> data = baker->get_light_data();
 
 	p_gizmo->add_unscaled_billboard(icon, 0.05);
@@ -3529,7 +3529,7 @@ int CollisionShape3DGizmoPlugin::get_priority() const {
 }
 
 String CollisionShape3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	const CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_spatial_node());
+	const CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_node_3d());
 
 	Ref<Shape3D> s = cs->get_shape();
 	if (s.is_null()) {
@@ -3560,7 +3560,7 @@ String CollisionShape3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_g
 }
 
 Variant CollisionShape3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_spatial_node());
+	CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_node_3d());
 
 	Ref<Shape3D> s = cs->get_shape();
 	if (s.is_null()) {
@@ -3596,7 +3596,7 @@ Variant CollisionShape3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo
 }
 
 void CollisionShape3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_spatial_node());
+	CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_node_3d());
 
 	Ref<Shape3D> s = cs->get_shape();
 	if (s.is_null()) {
@@ -3713,7 +3713,7 @@ void CollisionShape3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_i
 }
 
 void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_spatial_node());
+	CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_node_3d());
 
 	Ref<Shape3D> s = cs->get_shape();
 	if (s.is_null()) {
@@ -3818,7 +3818,7 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 }
 
 void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_spatial_node());
+	CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -4129,7 +4129,7 @@ int CollisionPolygon3DGizmoPlugin::get_priority() const {
 }
 
 void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	CollisionPolygon3D *polygon = Object::cast_to<CollisionPolygon3D>(p_gizmo->get_spatial_node());
+	CollisionPolygon3D *polygon = Object::cast_to<CollisionPolygon3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 
@@ -4176,7 +4176,7 @@ int NavigationRegion3DGizmoPlugin::get_priority() const {
 }
 
 void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	NavigationRegion3D *navmesh = Object::cast_to<NavigationRegion3D>(p_gizmo->get_spatial_node());
+	NavigationRegion3D *navmesh = Object::cast_to<NavigationRegion3D>(p_gizmo->get_node_3d());
 
 	Ref<Material> edge_material = get_material("navigation_edge_material", p_gizmo);
 	Ref<Material> edge_material_disabled = get_material("navigation_edge_material_disabled", p_gizmo);
@@ -4541,7 +4541,7 @@ int Joint3DGizmoPlugin::get_priority() const {
 }
 
 void Joint3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Joint3D *joint = Object::cast_to<Joint3D>(p_gizmo->get_spatial_node());
+	Joint3D *joint = Object::cast_to<Joint3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 

--- a/editor/plugins/collision_polygon_3d_editor_plugin.h
+++ b/editor/plugins/collision_polygon_3d_editor_plugin.h
@@ -100,7 +100,7 @@ class Polygon3DEditorPlugin : public EditorPlugin {
 	EditorNode *editor;
 
 public:
-	virtual bool forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return collision_polygon_editor->forward_spatial_gui_input(p_camera, p_event); }
+	virtual bool forward_node_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return collision_polygon_editor->forward_spatial_gui_input(p_camera, p_event); }
 
 	virtual String get_name() const override { return "Polygon3DEditor"; }
 	bool has_main_screen() const override { return false; }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -354,7 +354,7 @@ void Node3DEditorViewport::_update_camera(float p_interp_delta) {
 
 		update_transform_gizmo_view();
 		rotation_control->update();
-		spatial_editor->update_grid();
+		node_3d_editor->update_grid();
 	}
 }
 
@@ -396,15 +396,15 @@ int Node3DEditorViewport::get_selected_count() const {
 }
 
 float Node3DEditorViewport::get_znear() const {
-	return CLAMP(spatial_editor->get_znear(), MIN_Z, MAX_Z);
+	return CLAMP(node_3d_editor->get_znear(), MIN_Z, MAX_Z);
 }
 
 float Node3DEditorViewport::get_zfar() const {
-	return CLAMP(spatial_editor->get_zfar(), MIN_Z, MAX_Z);
+	return CLAMP(node_3d_editor->get_zfar(), MIN_Z, MAX_Z);
 }
 
 float Node3DEditorViewport::get_fov() const {
-	return CLAMP(spatial_editor->get_fov(), MIN_FOV, MAX_FOV);
+	return CLAMP(node_3d_editor->get_fov(), MIN_FOV, MAX_FOV);
 }
 
 Transform Node3DEditorViewport::_get_camera_transform() const {
@@ -759,8 +759,8 @@ void Node3DEditorViewport::_compute_edit(const Point2 &p_point) {
 	_edit.click_ray = _get_ray(Vector2(p_point.x, p_point.y));
 	_edit.click_ray_pos = _get_ray_pos(Vector2(p_point.x, p_point.y));
 	_edit.plane = TRANSFORM_VIEW;
-	spatial_editor->update_transform_gizmo();
-	_edit.center = spatial_editor->get_gizmo_transform().origin;
+	node_3d_editor->update_transform_gizmo();
+	_edit.center = node_3d_editor->get_gizmo_transform().origin;
 
 	List<Node *> &selection = editor_selection->get_selected_node_list();
 
@@ -813,12 +813,12 @@ static int _get_key_modifier(Ref<InputEventWithModifiers> e) {
 }
 
 bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_highlight_only) {
-	if (!spatial_editor->is_gizmo_visible()) {
+	if (!node_3d_editor->is_gizmo_visible()) {
 		return false;
 	}
 	if (get_selected_count() == 0) {
 		if (p_highlight_only) {
-			spatial_editor->select_gizmo_highlight_axis(-1);
+			node_3d_editor->select_gizmo_highlight_axis(-1);
 		}
 		return false;
 	}
@@ -826,10 +826,10 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 	Vector3 ray_pos = _get_ray_pos(Vector2(p_screenpos.x, p_screenpos.y));
 	Vector3 ray = _get_ray(Vector2(p_screenpos.x, p_screenpos.y));
 
-	Transform gt = spatial_editor->get_gizmo_transform();
+	Transform gt = node_3d_editor->get_gizmo_transform();
 	float gs = gizmo_scale;
 
-	if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE) {
+	if (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE) {
 		int col_axis = -1;
 		float col_d = 1e20;
 
@@ -879,7 +879,7 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 
 		if (col_axis != -1) {
 			if (p_highlight_only) {
-				spatial_editor->select_gizmo_highlight_axis(col_axis + (is_plane_translate ? 6 : 0));
+				node_3d_editor->select_gizmo_highlight_axis(col_axis + (is_plane_translate ? 6 : 0));
 
 			} else {
 				//handle plane translate
@@ -891,7 +891,7 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 		}
 	}
 
-	if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE) {
+	if (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE) {
 		int col_axis = -1;
 		float col_d = 1e20;
 
@@ -918,7 +918,7 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 
 		if (col_axis != -1) {
 			if (p_highlight_only) {
-				spatial_editor->select_gizmo_highlight_axis(col_axis + 3);
+				node_3d_editor->select_gizmo_highlight_axis(col_axis + 3);
 			} else {
 				//handle rotate
 				_edit.mode = TRANSFORM_ROTATE;
@@ -929,7 +929,7 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 		}
 	}
 
-	if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE) {
+	if (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE) {
 		int col_axis = -1;
 		float col_d = 1e20;
 
@@ -979,7 +979,7 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 
 		if (col_axis != -1) {
 			if (p_highlight_only) {
-				spatial_editor->select_gizmo_highlight_axis(col_axis + (is_plane_scale ? 12 : 9));
+				node_3d_editor->select_gizmo_highlight_axis(col_axis + (is_plane_scale ? 12 : 9));
 
 			} else {
 				//handle scale
@@ -992,7 +992,7 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 	}
 
 	if (p_highlight_only) {
-		spatial_editor->select_gizmo_highlight_axis(-1);
+		node_3d_editor->select_gizmo_highlight_axis(-1);
 	}
 
 	return false;
@@ -1041,7 +1041,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 		selection_results.clear();
 
 		if (clicked.is_valid()) {
-			_select_clicked(clicked_wants_append, true, spatial_editor->get_tool_mode() != Node3DEditor::TOOL_MODE_LIST_SELECT);
+			_select_clicked(clicked_wants_append, true, node_3d_editor->get_tool_mode() != Node3DEditor::TOOL_MODE_LIST_SELECT);
 			clicked = ObjectID();
 		}
 
@@ -1237,13 +1237,13 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						break;
 					}
 
-					if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_LIST_SELECT) {
+					if (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_LIST_SELECT) {
 						_list_select(b);
 						break;
 					}
 
 					_edit.mouse_pos = b->get_position();
-					_edit.snap = spatial_editor->is_snap_enabled();
+					_edit.snap = node_3d_editor->is_snap_enabled();
 					_edit.mode = TRANSFORM_NONE;
 
 					//gizmo has priority over everything
@@ -1255,8 +1255,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						can_select_gizmos = view_menu->get_popup()->is_item_checked(idx);
 					}
 
-					if (can_select_gizmos && spatial_editor->get_selected()) {
-						Ref<EditorNode3DGizmo> seg = spatial_editor->get_selected()->get_gizmo();
+					if (can_select_gizmos && node_3d_editor->get_selected()) {
+						Ref<EditorNode3DGizmo> seg = node_3d_editor->get_selected()->get_gizmo();
 						if (seg.is_valid()) {
 							int handle = -1;
 							Vector3 point;
@@ -1278,7 +1278,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					clicked = ObjectID();
 					clicked_includes_current = false;
 
-					if ((spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT && b->get_control()) || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE) {
+					if ((node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT && b->get_control()) || node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE) {
 						/* HANDLE ROTATION */
 						if (get_selected_count() == 0) {
 							break; //bye
@@ -1289,7 +1289,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						break;
 					}
 
-					if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE) {
+					if (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE) {
 						if (get_selected_count() == 0) {
 							break; //bye
 						}
@@ -1299,7 +1299,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						break;
 					}
 
-					if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE) {
+					if (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE) {
 						if (get_selected_count() == 0) {
 							break; //bye
 						}
@@ -1403,8 +1403,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	if (m.is_valid()) {
 		_edit.mouse_pos = m->get_position();
 
-		if (spatial_editor->get_selected()) {
-			Ref<EditorNode3DGizmo> seg = spatial_editor->get_selected()->get_gizmo();
+		if (node_3d_editor->get_selected()) {
+			Ref<EditorNode3DGizmo> seg = node_3d_editor->get_selected()->get_gizmo();
 			if (seg.is_valid()) {
 				int selected_handle = -1;
 
@@ -1416,17 +1416,17 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					selected_handle = handle;
 				}
 
-				if (selected_handle != spatial_editor->get_over_gizmo_handle()) {
-					spatial_editor->set_over_gizmo_handle(selected_handle);
-					spatial_editor->get_selected()->update_gizmo();
+				if (selected_handle != node_3d_editor->get_over_gizmo_handle()) {
+					node_3d_editor->set_over_gizmo_handle(selected_handle);
+					node_3d_editor->get_selected()->update_gizmo();
 					if (selected_handle != -1) {
-						spatial_editor->select_gizmo_highlight_axis(-1);
+						node_3d_editor->select_gizmo_highlight_axis(-1);
 					}
 				}
 			}
 		}
 
-		if (spatial_editor->get_over_gizmo_handle() == -1 && !(m->get_button_mask() & 1) && !_edit.gizmo.is_valid()) {
+		if (node_3d_editor->get_over_gizmo_handle() == -1 && !(m->get_button_mask() & 1) && !_edit.gizmo.is_valid()) {
 			_gizmo_select(_edit.mouse_pos, true);
 		}
 
@@ -1488,30 +1488,30 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 								plane = Plane(_edit.center, _get_camera_normal());
 								break;
 							case TRANSFORM_X_AXIS:
-								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(0);
+								motion_mask = node_3d_editor->get_gizmo_transform().basis.get_axis(0);
 								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
 								break;
 							case TRANSFORM_Y_AXIS:
-								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(1);
+								motion_mask = node_3d_editor->get_gizmo_transform().basis.get_axis(1);
 								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
 								break;
 							case TRANSFORM_Z_AXIS:
-								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2);
+								motion_mask = node_3d_editor->get_gizmo_transform().basis.get_axis(2);
 								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
 								break;
 							case TRANSFORM_YZ:
-								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2) + spatial_editor->get_gizmo_transform().basis.get_axis(1);
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(0));
+								motion_mask = node_3d_editor->get_gizmo_transform().basis.get_axis(2) + node_3d_editor->get_gizmo_transform().basis.get_axis(1);
+								plane = Plane(_edit.center, node_3d_editor->get_gizmo_transform().basis.get_axis(0));
 								plane_mv = true;
 								break;
 							case TRANSFORM_XZ:
-								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2) + spatial_editor->get_gizmo_transform().basis.get_axis(0);
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(1));
+								motion_mask = node_3d_editor->get_gizmo_transform().basis.get_axis(2) + node_3d_editor->get_gizmo_transform().basis.get_axis(0);
+								plane = Plane(_edit.center, node_3d_editor->get_gizmo_transform().basis.get_axis(1));
 								plane_mv = true;
 								break;
 							case TRANSFORM_XY:
-								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(0) + spatial_editor->get_gizmo_transform().basis.get_axis(1);
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(2));
+								motion_mask = node_3d_editor->get_gizmo_transform().basis.get_axis(0) + node_3d_editor->get_gizmo_transform().basis.get_axis(1);
+								plane = Plane(_edit.center, node_3d_editor->get_gizmo_transform().basis.get_axis(2));
 								plane_mv = true;
 								break;
 						}
@@ -1552,10 +1552,10 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						List<Node *> &selection = editor_selection->get_selected_node_list();
 
 						// Disable local transformation for TRANSFORM_VIEW
-						bool local_coords = (spatial_editor->are_local_coords_enabled() && _edit.plane != TRANSFORM_VIEW);
+						bool local_coords = (node_3d_editor->are_local_coords_enabled() && _edit.plane != TRANSFORM_VIEW);
 
-						if (_edit.snap || spatial_editor->is_snap_enabled()) {
-							snap = spatial_editor->get_scale_snap() / 100;
+						if (_edit.snap || node_3d_editor->is_snap_enabled()) {
+							snap = node_3d_editor->get_scale_snap() / 100;
 						}
 						Vector3 motion_snapped = motion;
 						motion_snapped.snap(Vector3(snap, snap, snap));
@@ -1588,7 +1588,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 								Basis g = original.basis.orthonormalized();
 								Vector3 local_motion = g.inverse().xform(motion);
 
-								if (_edit.snap || spatial_editor->is_snap_enabled()) {
+								if (_edit.snap || node_3d_editor->is_snap_enabled()) {
 									local_motion.snap(Vector3(snap, snap, snap));
 								}
 
@@ -1603,7 +1603,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 								}
 
 							} else {
-								if (_edit.snap || spatial_editor->is_snap_enabled()) {
+								if (_edit.snap || node_3d_editor->is_snap_enabled()) {
 									motion.snap(Vector3(snap, snap, snap));
 								}
 
@@ -1630,27 +1630,27 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 								plane = Plane(_edit.center, _get_camera_normal());
 								break;
 							case TRANSFORM_X_AXIS:
-								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(0);
+								motion_mask = node_3d_editor->get_gizmo_transform().basis.get_axis(0);
 								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
 								break;
 							case TRANSFORM_Y_AXIS:
-								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(1);
+								motion_mask = node_3d_editor->get_gizmo_transform().basis.get_axis(1);
 								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
 								break;
 							case TRANSFORM_Z_AXIS:
-								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2);
+								motion_mask = node_3d_editor->get_gizmo_transform().basis.get_axis(2);
 								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
 								break;
 							case TRANSFORM_YZ:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(0));
+								plane = Plane(_edit.center, node_3d_editor->get_gizmo_transform().basis.get_axis(0));
 								plane_mv = true;
 								break;
 							case TRANSFORM_XZ:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(1));
+								plane = Plane(_edit.center, node_3d_editor->get_gizmo_transform().basis.get_axis(1));
 								plane_mv = true;
 								break;
 							case TRANSFORM_XY:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(2));
+								plane = Plane(_edit.center, node_3d_editor->get_gizmo_transform().basis.get_axis(2));
 								plane_mv = true;
 								break;
 						}
@@ -1675,10 +1675,10 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						List<Node *> &selection = editor_selection->get_selected_node_list();
 
 						// Disable local transformation for TRANSFORM_VIEW
-						bool local_coords = (spatial_editor->are_local_coords_enabled() && _edit.plane != TRANSFORM_VIEW);
+						bool local_coords = (node_3d_editor->are_local_coords_enabled() && _edit.plane != TRANSFORM_VIEW);
 
-						if (_edit.snap || spatial_editor->is_snap_enabled()) {
-							snap = spatial_editor->get_translate_snap();
+						if (_edit.snap || node_3d_editor->is_snap_enabled()) {
+							snap = node_3d_editor->get_translate_snap();
 						}
 						Vector3 motion_snapped = motion;
 						motion_snapped.snap(Vector3(snap, snap, snap));
@@ -1704,7 +1704,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							Transform t;
 
 							if (local_coords) {
-								if (_edit.snap || spatial_editor->is_snap_enabled()) {
+								if (_edit.snap || node_3d_editor->is_snap_enabled()) {
 									Basis g = original.basis.orthonormalized();
 									Vector3 local_motion = g.inverse().xform(motion);
 									local_motion.snap(Vector3(snap, snap, snap));
@@ -1713,7 +1713,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 								}
 
 							} else {
-								if (_edit.snap || spatial_editor->is_snap_enabled()) {
+								if (_edit.snap || node_3d_editor->is_snap_enabled()) {
 									motion.snap(Vector3(snap, snap, snap));
 								}
 							}
@@ -1737,15 +1737,15 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 								plane = Plane(_edit.center, _get_camera_normal());
 								break;
 							case TRANSFORM_X_AXIS:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(0));
+								plane = Plane(_edit.center, node_3d_editor->get_gizmo_transform().basis.get_axis(0));
 								axis = Vector3(1, 0, 0);
 								break;
 							case TRANSFORM_Y_AXIS:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(1));
+								plane = Plane(_edit.center, node_3d_editor->get_gizmo_transform().basis.get_axis(1));
 								axis = Vector3(0, 1, 0);
 								break;
 							case TRANSFORM_Z_AXIS:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(2));
+								plane = Plane(_edit.center, node_3d_editor->get_gizmo_transform().basis.get_axis(2));
 								axis = Vector3(0, 0, 1);
 								break;
 							case TRANSFORM_YZ:
@@ -1769,8 +1769,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 						float angle = Math::atan2(x_axis.dot(intersection - _edit.center), y_axis.dot(intersection - _edit.center));
 
-						if (_edit.snap || spatial_editor->is_snap_enabled()) {
-							snap = spatial_editor->get_rotate_snap();
+						if (_edit.snap || node_3d_editor->is_snap_enabled()) {
+							snap = node_3d_editor->get_rotate_snap();
 						}
 						angle = Math::rad2deg(angle) + snap * 0.5; //else it won't reach +180
 						angle -= Math::fmod(angle, snap);
@@ -1779,7 +1779,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 						List<Node *> &selection = editor_selection->get_selected_node_list();
 
-						bool local_coords = (spatial_editor->are_local_coords_enabled() && _edit.plane != TRANSFORM_VIEW); // Disable local transformation for TRANSFORM_VIEW
+						bool local_coords = (node_3d_editor->are_local_coords_enabled() && _edit.plane != TRANSFORM_VIEW); // Disable local transformation for TRANSFORM_VIEW
 
 						for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 							Node3D *sp = Object::cast_to<Node3D>(E->get());
@@ -1965,47 +1965,47 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
-		if (ED_IS_SHORTCUT("spatial_editor/snap", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/snap", p_event)) {
 			if (_edit.mode != TRANSFORM_NONE) {
 				_edit.snap = !_edit.snap;
 			}
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/bottom_view", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/bottom_view", p_event)) {
 			_menu_option(VIEW_BOTTOM);
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/top_view", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/top_view", p_event)) {
 			_menu_option(VIEW_TOP);
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/rear_view", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/rear_view", p_event)) {
 			_menu_option(VIEW_REAR);
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/front_view", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/front_view", p_event)) {
 			_menu_option(VIEW_FRONT);
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/left_view", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/left_view", p_event)) {
 			_menu_option(VIEW_LEFT);
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/right_view", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/right_view", p_event)) {
 			_menu_option(VIEW_RIGHT);
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/focus_origin", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/focus_origin", p_event)) {
 			_menu_option(VIEW_CENTER_TO_ORIGIN);
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/focus_selection", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/focus_selection", p_event)) {
 			_menu_option(VIEW_CENTER_TO_SELECTION);
 		}
 		// Orthgonal mode doesn't work in freelook.
-		if (!freelook_active && ED_IS_SHORTCUT("spatial_editor/switch_perspective_orthogonal", p_event)) {
+		if (!freelook_active && ED_IS_SHORTCUT("node_3d_editor/switch_perspective_orthogonal", p_event)) {
 			_menu_option(orthogonal ? VIEW_PERSPECTIVE : VIEW_ORTHOGONAL);
 			_update_name();
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/align_transform_with_view", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/align_transform_with_view", p_event)) {
 			_menu_option(VIEW_ALIGN_TRANSFORM_WITH_VIEW);
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/align_rotation_with_view", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/align_rotation_with_view", p_event)) {
 			_menu_option(VIEW_ALIGN_ROTATION_WITH_VIEW);
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/insert_anim_key", p_event)) {
+		if (ED_IS_SHORTCUT("node_3d_editor/insert_anim_key", p_event)) {
 			if (!get_selected_count() || _edit.mode != TRANSFORM_NONE) {
 				return;
 			}
@@ -2023,14 +2023,14 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					continue;
 				}
 
-				spatial_editor->emit_signal("transform_key_request", sp, "", sp->get_transform());
+				node_3d_editor->emit_signal("transform_key_request", sp, "", sp->get_transform());
 			}
 
 			set_message(TTR("Animation Key Inserted."));
 		}
 
 		// Freelook doesn't work in orthogonal mode.
-		if (!orthogonal && ED_IS_SHORTCUT("spatial_editor/freelook_toggle", p_event)) {
+		if (!orthogonal && ED_IS_SHORTCUT("node_3d_editor/freelook_toggle", p_event)) {
 			set_freelook_active(!is_freelook_active());
 
 		} else if (k->get_keycode() == KEY_ESCAPE) {
@@ -2288,31 +2288,31 @@ void Node3DEditorViewport::_update_freelook(real_t delta) {
 
 	Vector3 direction;
 
-	if (is_shortcut_pressed("spatial_editor/freelook_left")) {
+	if (is_shortcut_pressed("node_3d_editor/freelook_left")) {
 		direction -= right;
 	}
-	if (is_shortcut_pressed("spatial_editor/freelook_right")) {
+	if (is_shortcut_pressed("node_3d_editor/freelook_right")) {
 		direction += right;
 	}
-	if (is_shortcut_pressed("spatial_editor/freelook_forward")) {
+	if (is_shortcut_pressed("node_3d_editor/freelook_forward")) {
 		direction += forward;
 	}
-	if (is_shortcut_pressed("spatial_editor/freelook_backwards")) {
+	if (is_shortcut_pressed("node_3d_editor/freelook_backwards")) {
 		direction -= forward;
 	}
-	if (is_shortcut_pressed("spatial_editor/freelook_up")) {
+	if (is_shortcut_pressed("node_3d_editor/freelook_up")) {
 		direction += up;
 	}
-	if (is_shortcut_pressed("spatial_editor/freelook_down")) {
+	if (is_shortcut_pressed("node_3d_editor/freelook_down")) {
 		direction -= up;
 	}
 
 	real_t speed = freelook_speed;
 
-	if (is_shortcut_pressed("spatial_editor/freelook_speed_modifier")) {
+	if (is_shortcut_pressed("node_3d_editor/freelook_speed_modifier")) {
 		speed *= 3.0;
 	}
-	if (is_shortcut_pressed("spatial_editor/freelook_slow_modifier")) {
+	if (is_shortcut_pressed("node_3d_editor/freelook_slow_modifier")) {
 		speed *= 0.333333;
 	}
 
@@ -2403,7 +2403,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 			Transform t = sp->get_global_gizmo_transform();
 			VisualInstance3D *vi = Object::cast_to<VisualInstance3D>(sp);
-			AABB new_aabb = vi ? vi->get_aabb() : _calculate_spatial_bounds(sp);
+			AABB new_aabb = vi ? vi->get_aabb() : _calculate_node_3d_bounds(sp);
 
 			exist = true;
 			if (se->last_xform == t && se->aabb == new_aabb && !se->last_xform_dirty) {
@@ -2426,8 +2426,8 @@ void Node3DEditorViewport::_notification(int p_what) {
 			RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray, t);
 		}
 
-		if (changed || (spatial_editor->is_gizmo_visible() && !exist)) {
-			spatial_editor->update_transform_gizmo();
+		if (changed || (node_3d_editor->is_gizmo_visible() && !exist)) {
+			node_3d_editor->update_transform_gizmo();
 		}
 
 		if (message_time > 0) {
@@ -3132,35 +3132,35 @@ void Node3DEditorViewport::_init_gizmo_instance(int p_idx) {
 
 	for (int i = 0; i < 3; i++) {
 		move_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(move_gizmo_instance[i], spatial_editor->get_move_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_base(move_gizmo_instance[i], node_3d_editor->get_move_gizmo(i)->get_rid());
 		RS::get_singleton()->instance_set_scenario(move_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(move_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(move_gizmo_instance[i], layer);
 
 		move_plane_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(move_plane_gizmo_instance[i], spatial_editor->get_move_plane_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_base(move_plane_gizmo_instance[i], node_3d_editor->get_move_plane_gizmo(i)->get_rid());
 		RS::get_singleton()->instance_set_scenario(move_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(move_plane_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(move_plane_gizmo_instance[i], layer);
 
 		rotate_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(rotate_gizmo_instance[i], spatial_editor->get_rotate_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_base(rotate_gizmo_instance[i], node_3d_editor->get_rotate_gizmo(i)->get_rid());
 		RS::get_singleton()->instance_set_scenario(rotate_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(rotate_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(rotate_gizmo_instance[i], layer);
 
 		scale_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(scale_gizmo_instance[i], spatial_editor->get_scale_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_base(scale_gizmo_instance[i], node_3d_editor->get_scale_gizmo(i)->get_rid());
 		RS::get_singleton()->instance_set_scenario(scale_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(scale_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(scale_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(scale_gizmo_instance[i], layer);
 
 		scale_plane_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(scale_plane_gizmo_instance[i], spatial_editor->get_scale_plane_gizmo(i)->get_rid());
+		RS::get_singleton()->instance_set_base(scale_plane_gizmo_instance[i], node_3d_editor->get_scale_plane_gizmo(i)->get_rid());
 		RS::get_singleton()->instance_set_scenario(scale_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(scale_plane_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
@@ -3169,7 +3169,7 @@ void Node3DEditorViewport::_init_gizmo_instance(int p_idx) {
 
 	// Rotation white outline
 	rotate_gizmo_instance[3] = RS::get_singleton()->instance_create();
-	RS::get_singleton()->instance_set_base(rotate_gizmo_instance[3], spatial_editor->get_rotate_gizmo(3)->get_rid());
+	RS::get_singleton()->instance_set_base(rotate_gizmo_instance[3], node_3d_editor->get_rotate_gizmo(3)->get_rid());
 	RS::get_singleton()->instance_set_scenario(rotate_gizmo_instance[3], get_tree()->get_root()->get_world_3d()->get_scenario());
 	RS::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], false);
 	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(rotate_gizmo_instance[3], RS::SHADOW_CASTING_SETTING_OFF);
@@ -3241,7 +3241,7 @@ void Node3DEditorViewport::_selection_result_pressed(int p_result) {
 	clicked = selection_results[p_result].item->get_instance_id();
 
 	if (clicked.is_valid()) {
-		_select_clicked(clicked_wants_append, true, spatial_editor->get_tool_mode() != Node3DEditor::TOOL_MODE_LIST_SELECT);
+		_select_clicked(clicked_wants_append, true, node_3d_editor->get_tool_mode() != Node3DEditor::TOOL_MODE_LIST_SELECT);
 		clicked = ObjectID();
 	}
 }
@@ -3265,7 +3265,7 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 		return;
 	}
 
-	Transform xform = spatial_editor->get_gizmo_transform();
+	Transform xform = node_3d_editor->get_gizmo_transform();
 
 	Transform camera_xform = camera->get_transform();
 
@@ -3307,19 +3307,19 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 
 	for (int i = 0; i < 3; i++) {
 		RenderingServer::get_singleton()->instance_set_transform(move_gizmo_instance[i], xform);
-		RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], spatial_editor->is_gizmo_visible() && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
+		RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], node_3d_editor->is_gizmo_visible() && (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
 		RenderingServer::get_singleton()->instance_set_transform(move_plane_gizmo_instance[i], xform);
-		RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], spatial_editor->is_gizmo_visible() && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
+		RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], node_3d_editor->is_gizmo_visible() && (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
 		RenderingServer::get_singleton()->instance_set_transform(rotate_gizmo_instance[i], xform);
-		RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], spatial_editor->is_gizmo_visible() && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE));
+		RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], node_3d_editor->is_gizmo_visible() && (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE));
 		RenderingServer::get_singleton()->instance_set_transform(scale_gizmo_instance[i], xform);
-		RenderingServer::get_singleton()->instance_set_visible(scale_gizmo_instance[i], spatial_editor->is_gizmo_visible() && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
+		RenderingServer::get_singleton()->instance_set_visible(scale_gizmo_instance[i], node_3d_editor->is_gizmo_visible() && (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
 		RenderingServer::get_singleton()->instance_set_transform(scale_plane_gizmo_instance[i], xform);
-		RenderingServer::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], spatial_editor->is_gizmo_visible() && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
+		RenderingServer::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], node_3d_editor->is_gizmo_visible() && (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
 	}
 	// Rotation white outline
 	RenderingServer::get_singleton()->instance_set_transform(rotate_gizmo_instance[3], xform);
-	RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], spatial_editor->is_gizmo_visible() && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE));
+	RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], node_3d_editor->is_gizmo_visible() && (node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT || node_3d_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE));
 }
 
 void Node3DEditorViewport::set_state(const Dictionary &p_state) {
@@ -3604,7 +3604,7 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos) const 
 	return point + offset;
 }
 
-AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, bool p_exclude_top_level_transform) {
+AABB Node3DEditorViewport::_calculate_node_3d_bounds(const Node3D *p_parent, bool p_exclude_top_level_transform) {
 	AABB bounds;
 
 	const MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(p_parent);
@@ -3615,7 +3615,7 @@ AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, boo
 	for (int i = 0; i < p_parent->get_child_count(); i++) {
 		Node3D *child = Object::cast_to<Node3D>(p_parent->get_child(i));
 		if (child) {
-			AABB child_bounds = _calculate_spatial_bounds(child, false);
+			AABB child_bounds = _calculate_node_3d_bounds(child, false);
 
 			if (bounds.size == Vector3() && p_parent->get_class_name() == StringName("Node3D")) {
 				bounds = child_bounds;
@@ -3659,7 +3659,7 @@ void Node3DEditorViewport::_create_preview(const Vector<String> &files) const {
 			editor->get_scene_root()->add_child(preview_node);
 		}
 	}
-	*preview_bounds = _calculate_spatial_bounds(preview_node);
+	*preview_bounds = _calculate_node_3d_bounds(preview_node);
 }
 
 void Node3DEditorViewport::_remove_preview() {
@@ -3745,7 +3745,7 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 			global_transform = parent_node3d->get_global_gizmo_transform();
 		}
 
-		global_transform.origin = spatial_editor->snap_point(_get_instance_position(p_point));
+		global_transform.origin = node_3d_editor->snap_point(_get_instance_position(p_point));
 		global_transform.basis *= node3d->get_transform().basis;
 
 		editor_data->get_undo_redo().add_do_method(instanced_scene, "set_global_transform", global_transform);
@@ -3887,7 +3887,7 @@ void Node3DEditorViewport::drop_data_fw(const Point2 &p_point, const Variant &p_
 	_perform_drop_data();
 }
 
-Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, EditorNode *p_editor, int p_index) {
+Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_node_3d_editor, EditorNode *p_editor, int p_index) {
 	cpu_time_history_index = 0;
 	gpu_time_history_index = 0;
 
@@ -3910,7 +3910,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	message_time = 0;
 	zoom_indicator_delay = 0.0;
 
-	spatial_editor = p_spatial_editor;
+	node_3d_editor = p_node_3d_editor;
 	SubViewportContainer *c = memnew(SubViewportContainer);
 	subviewport_container = c;
 	c->set_stretch(true);
@@ -3945,26 +3945,26 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	display_submenu = memnew(PopupMenu);
 	view_menu->get_popup()->add_child(display_submenu);
 
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/top_view"), VIEW_TOP);
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/bottom_view"), VIEW_BOTTOM);
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/left_view"), VIEW_LEFT);
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/right_view"), VIEW_RIGHT);
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/front_view"), VIEW_FRONT);
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/rear_view"), VIEW_REAR);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/top_view"), VIEW_TOP);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/bottom_view"), VIEW_BOTTOM);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/left_view"), VIEW_LEFT);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/right_view"), VIEW_RIGHT);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/front_view"), VIEW_FRONT);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/rear_view"), VIEW_REAR);
 	view_menu->get_popup()->add_separator();
-	view_menu->get_popup()->add_radio_check_item(TTR("Perspective") + " (" + ED_GET_SHORTCUT("spatial_editor/switch_perspective_orthogonal")->get_as_text() + ")", VIEW_PERSPECTIVE);
-	view_menu->get_popup()->add_radio_check_item(TTR("Orthogonal") + " (" + ED_GET_SHORTCUT("spatial_editor/switch_perspective_orthogonal")->get_as_text() + ")", VIEW_ORTHOGONAL);
+	view_menu->get_popup()->add_radio_check_item(TTR("Perspective") + " (" + ED_GET_SHORTCUT("node_3d_editor/switch_perspective_orthogonal")->get_as_text() + ")", VIEW_PERSPECTIVE);
+	view_menu->get_popup()->add_radio_check_item(TTR("Orthogonal") + " (" + ED_GET_SHORTCUT("node_3d_editor/switch_perspective_orthogonal")->get_as_text() + ")", VIEW_ORTHOGONAL);
 	view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_PERSPECTIVE), true);
 	view_menu->get_popup()->add_check_item(TTR("Auto Orthogonal Enabled"), VIEW_AUTO_ORTHOGONAL);
 	view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_AUTO_ORTHOGONAL), true);
 	view_menu->get_popup()->add_separator();
-	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_lock_rotation", TTR("Lock View Rotation")), VIEW_LOCK_ROTATION);
+	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_lock_rotation", TTR("Lock View Rotation")), VIEW_LOCK_ROTATION);
 	view_menu->get_popup()->add_separator();
-	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_normal", TTR("Display Normal")), VIEW_DISPLAY_NORMAL);
-	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_wireframe", TTR("Display Wireframe")), VIEW_DISPLAY_WIREFRAME);
-	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_overdraw", TTR("Display Overdraw")), VIEW_DISPLAY_OVERDRAW);
-	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_lighting", TTR("Display Lighting")), VIEW_DISPLAY_LIGHTING);
-	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_unshaded", TTR("Display Unshaded")), VIEW_DISPLAY_SHADELESS);
+	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/view_display_normal", TTR("Display Normal")), VIEW_DISPLAY_NORMAL);
+	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/view_display_wireframe", TTR("Display Wireframe")), VIEW_DISPLAY_WIREFRAME);
+	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/view_display_overdraw", TTR("Display Overdraw")), VIEW_DISPLAY_OVERDRAW);
+	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/view_display_lighting", TTR("Display Lighting")), VIEW_DISPLAY_LIGHTING);
+	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/view_display_unshaded", TTR("Display Unshaded")), VIEW_DISPLAY_SHADELESS);
 	view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_DISPLAY_NORMAL), true);
 	display_submenu->add_radio_check_item(TTR("Directional Shadow Splits"), VIEW_DISPLAY_DEBUG_PSSM_SPLITS);
 	display_submenu->add_separator();
@@ -3992,26 +3992,26 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	display_submenu->set_name("display_advanced");
 	view_menu->get_popup()->add_submenu_item(TTR("Display Advanced..."), "display_advanced", VIEW_DISPLAY_ADVANCED);
 	view_menu->get_popup()->add_separator();
-	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_environment", TTR("View Environment")), VIEW_ENVIRONMENT);
-	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_gizmos", TTR("View Gizmos")), VIEW_GIZMOS);
-	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_information", TTR("View Information")), VIEW_INFORMATION);
-	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_fps", TTR("View Frame Time")), VIEW_FRAME_TIME);
+	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_environment", TTR("View Environment")), VIEW_ENVIRONMENT);
+	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_gizmos", TTR("View Gizmos")), VIEW_GIZMOS);
+	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_information", TTR("View Information")), VIEW_INFORMATION);
+	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_fps", TTR("View Frame Time")), VIEW_FRAME_TIME);
 	view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_ENVIRONMENT), true);
 	view_menu->get_popup()->add_separator();
-	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_half_resolution", TTR("Half Resolution")), VIEW_HALF_RESOLUTION);
+	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_half_resolution", TTR("Half Resolution")), VIEW_HALF_RESOLUTION);
 	view_menu->get_popup()->add_separator();
-	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_listener", TTR("Audio Listener")), VIEW_AUDIO_LISTENER);
-	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_doppler", TTR("Enable Doppler")), VIEW_AUDIO_DOPPLER);
+	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_audio_listener", TTR("Audio Listener")), VIEW_AUDIO_LISTENER);
+	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_audio_doppler", TTR("Enable Doppler")), VIEW_AUDIO_DOPPLER);
 	view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_GIZMOS), true);
 
 	view_menu->get_popup()->add_separator();
-	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_cinematic_preview", TTR("Cinematic Preview")), VIEW_CINEMATIC_PREVIEW);
+	view_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_cinematic_preview", TTR("Cinematic Preview")), VIEW_CINEMATIC_PREVIEW);
 
 	view_menu->get_popup()->add_separator();
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
-	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
+	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("node_3d_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);
 	view_menu->get_popup()->connect("id_pressed", callable_mp(this, &Node3DEditorViewport::_menu_option));
 	display_submenu->connect("id_pressed", callable_mp(this, &Node3DEditorViewport::_menu_option));
 	view_menu->set_disable_shortcuts(true);
@@ -4037,14 +4037,14 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 		view_menu->get_popup()->set_item_tooltip(shadeless_idx, unsupported_tooltip);
 	}
 
-	ED_SHORTCUT("spatial_editor/freelook_left", TTR("Freelook Left"), KEY_A);
-	ED_SHORTCUT("spatial_editor/freelook_right", TTR("Freelook Right"), KEY_D);
-	ED_SHORTCUT("spatial_editor/freelook_forward", TTR("Freelook Forward"), KEY_W);
-	ED_SHORTCUT("spatial_editor/freelook_backwards", TTR("Freelook Backwards"), KEY_S);
-	ED_SHORTCUT("spatial_editor/freelook_up", TTR("Freelook Up"), KEY_E);
-	ED_SHORTCUT("spatial_editor/freelook_down", TTR("Freelook Down"), KEY_Q);
-	ED_SHORTCUT("spatial_editor/freelook_speed_modifier", TTR("Freelook Speed Modifier"), KEY_SHIFT);
-	ED_SHORTCUT("spatial_editor/freelook_slow_modifier", TTR("Freelook Slow Modifier"), KEY_ALT);
+	ED_SHORTCUT("node_3d_editor/freelook_left", TTR("Freelook Left"), KEY_A);
+	ED_SHORTCUT("node_3d_editor/freelook_right", TTR("Freelook Right"), KEY_D);
+	ED_SHORTCUT("node_3d_editor/freelook_forward", TTR("Freelook Forward"), KEY_W);
+	ED_SHORTCUT("node_3d_editor/freelook_backwards", TTR("Freelook Backwards"), KEY_S);
+	ED_SHORTCUT("node_3d_editor/freelook_up", TTR("Freelook Up"), KEY_E);
+	ED_SHORTCUT("node_3d_editor/freelook_down", TTR("Freelook Down"), KEY_Q);
+	ED_SHORTCUT("node_3d_editor/freelook_speed_modifier", TTR("Freelook Speed Modifier"), KEY_SHIFT);
+	ED_SHORTCUT("node_3d_editor/freelook_slow_modifier", TTR("Freelook Slow Modifier"), KEY_ALT);
 
 	preview_camera = memnew(CheckBox);
 	preview_camera->set_text(TTR("Preview"));
@@ -4522,9 +4522,9 @@ void Node3DEditor::update_transform_gizmo() {
 
 void _update_all_gizmos(Node *p_node) {
 	for (int i = p_node->get_child_count() - 1; 0 <= i; --i) {
-		Node3D *spatial_node = Object::cast_to<Node3D>(p_node->get_child(i));
-		if (spatial_node) {
-			spatial_node->update_gizmo();
+		Node3D *node_3d = Object::cast_to<Node3D>(p_node->get_child(i));
+		if (node_3d) {
+			node_3d->update_gizmo();
 		}
 
 		_update_all_gizmos(p_node->get_child(i));
@@ -4721,7 +4721,7 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 		Array vp = d["viewports"];
 		uint32_t vp_size = static_cast<uint32_t>(vp.size());
 		if (vp_size > VIEWPORTS_COUNT) {
-			WARN_PRINT("Ignoring superfluous viewport settings from spatial editor state.");
+			WARN_PRINT("Ignoring superfluous viewport settings from node 3d editor state.");
 			vp_size = VIEWPORTS_COUNT;
 		}
 
@@ -4779,8 +4779,8 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 	}
 }
 
-void Node3DEditor::edit(Node3D *p_spatial) {
-	if (p_spatial != selected) {
+void Node3DEditor::edit(Node3D *p_node_3d) {
+	if (p_node_3d != selected) {
 		if (selected) {
 			Ref<EditorNode3DGizmo> seg = selected->get_gizmo();
 			if (seg.is_valid()) {
@@ -4789,7 +4789,7 @@ void Node3DEditor::edit(Node3D *p_spatial) {
 			}
 		}
 
-		selected = p_spatial;
+		selected = p_node_3d;
 		over_gizmo_handle = -1;
 
 		if (selected) {
@@ -5073,17 +5073,17 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *spatial = Object::cast_to<Node3D>(E->get());
-				if (!spatial || !spatial->is_inside_tree()) {
+				Node3D *node_3d = Object::cast_to<Node3D>(E->get());
+				if (!node_3d || !node_3d->is_inside_tree()) {
 					continue;
 				}
 
-				if (spatial->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
+				if (node_3d->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
 					continue;
 				}
 
-				undo_redo->add_do_method(spatial, "set_meta", "_edit_lock_", true);
-				undo_redo->add_undo_method(spatial, "remove_meta", "_edit_lock_");
+				undo_redo->add_do_method(node_3d, "set_meta", "_edit_lock_", true);
+				undo_redo->add_undo_method(node_3d, "remove_meta", "_edit_lock_");
 				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
 			}
@@ -5098,17 +5098,17 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *spatial = Object::cast_to<Node3D>(E->get());
-				if (!spatial || !spatial->is_inside_tree()) {
+				Node3D *node_3d = Object::cast_to<Node3D>(E->get());
+				if (!node_3d || !node_3d->is_inside_tree()) {
 					continue;
 				}
 
-				if (spatial->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
+				if (node_3d->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
 					continue;
 				}
 
-				undo_redo->add_do_method(spatial, "remove_meta", "_edit_lock_");
-				undo_redo->add_undo_method(spatial, "set_meta", "_edit_lock_", true);
+				undo_redo->add_do_method(node_3d, "remove_meta", "_edit_lock_");
+				undo_redo->add_undo_method(node_3d, "set_meta", "_edit_lock_", true);
 				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
 			}
@@ -5123,17 +5123,17 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *spatial = Object::cast_to<Node3D>(E->get());
-				if (!spatial || !spatial->is_inside_tree()) {
+				Node3D *node_3d = Object::cast_to<Node3D>(E->get());
+				if (!node_3d || !node_3d->is_inside_tree()) {
 					continue;
 				}
 
-				if (spatial->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
+				if (node_3d->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
 					continue;
 				}
 
-				undo_redo->add_do_method(spatial, "set_meta", "_edit_group_", true);
-				undo_redo->add_undo_method(spatial, "remove_meta", "_edit_group_");
+				undo_redo->add_do_method(node_3d, "set_meta", "_edit_group_", true);
+				undo_redo->add_undo_method(node_3d, "remove_meta", "_edit_group_");
 				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
 			}
@@ -5147,17 +5147,17 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-				Node3D *spatial = Object::cast_to<Node3D>(E->get());
-				if (!spatial || !spatial->is_inside_tree()) {
+				Node3D *node_3d = Object::cast_to<Node3D>(E->get());
+				if (!node_3d || !node_3d->is_inside_tree()) {
 					continue;
 				}
 
-				if (spatial->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
+				if (node_3d->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
 					continue;
 				}
 
-				undo_redo->add_do_method(spatial, "remove_meta", "_edit_group_");
-				undo_redo->add_undo_method(spatial, "set_meta", "_edit_group_", true);
+				undo_redo->add_do_method(node_3d, "remove_meta", "_edit_group_");
+				undo_redo->add_undo_method(node_3d, "set_meta", "_edit_group_", true);
 				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
 			}
@@ -5916,7 +5916,7 @@ void Node3DEditor::snap_selected_nodes_to_floor() {
 			}
 
 			// We add a bit of margin to the from position to avoid it from snapping
-			// when the spatial is already on a floor and there's another floor under
+			// when the node_3d is already on a floor and there's another floor under
 			// it
 			from = from + Vector3(0.0, 0.2, 0.0);
 
@@ -6273,7 +6273,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SELECT]->set_pressed(true);
 	button_binds.write[0] = MENU_TOOL_SELECT;
 	tool_button[TOOL_MODE_SELECT]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
-	tool_button[TOOL_MODE_SELECT]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_select", TTR("Select Mode"), KEY_Q));
+	tool_button[TOOL_MODE_SELECT]->set_shortcut(ED_SHORTCUT("node_3d_editor/tool_select", TTR("Select Mode"), KEY_Q));
 	tool_button[TOOL_MODE_SELECT]->set_shortcut_context(this);
 	tool_button[TOOL_MODE_SELECT]->set_tooltip(keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate\nAlt+Drag: Move\nAlt+RMB: Depth list selection"));
 
@@ -6285,7 +6285,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_MOVE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_MOVE;
 	tool_button[TOOL_MODE_MOVE]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
-	tool_button[TOOL_MODE_MOVE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_move", TTR("Move Mode"), KEY_W));
+	tool_button[TOOL_MODE_MOVE]->set_shortcut(ED_SHORTCUT("node_3d_editor/tool_move", TTR("Move Mode"), KEY_W));
 	tool_button[TOOL_MODE_MOVE]->set_shortcut_context(this);
 
 	tool_button[TOOL_MODE_ROTATE] = memnew(Button);
@@ -6294,7 +6294,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_ROTATE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_ROTATE;
 	tool_button[TOOL_MODE_ROTATE]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
-	tool_button[TOOL_MODE_ROTATE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_rotate", TTR("Rotate Mode"), KEY_E));
+	tool_button[TOOL_MODE_ROTATE]->set_shortcut(ED_SHORTCUT("node_3d_editor/tool_rotate", TTR("Rotate Mode"), KEY_E));
 	tool_button[TOOL_MODE_ROTATE]->set_shortcut_context(this);
 
 	tool_button[TOOL_MODE_SCALE] = memnew(Button);
@@ -6303,7 +6303,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SCALE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_SCALE;
 	tool_button[TOOL_MODE_SCALE]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
-	tool_button[TOOL_MODE_SCALE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_scale", TTR("Scale Mode"), KEY_R));
+	tool_button[TOOL_MODE_SCALE]->set_shortcut(ED_SHORTCUT("node_3d_editor/tool_scale", TTR("Scale Mode"), KEY_R));
 	tool_button[TOOL_MODE_SCALE]->set_shortcut_context(this);
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -6352,7 +6352,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_LOCAL_COORDS;
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect("toggled", callable_mp(this, &Node3DEditor::_menu_item_toggled), button_binds);
-	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_shortcut(ED_SHORTCUT("spatial_editor/local_coords", TTR("Use Local Space"), KEY_T));
+	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_shortcut(ED_SHORTCUT("node_3d_editor/local_coords", TTR("Use Local Space"), KEY_T));
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_shortcut_context(this);
 
 	tool_option_button[TOOL_OPT_USE_SNAP] = memnew(Button);
@@ -6361,7 +6361,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_USE_SNAP;
 	tool_option_button[TOOL_OPT_USE_SNAP]->connect("toggled", callable_mp(this, &Node3DEditor::_menu_item_toggled), button_binds);
-	tool_option_button[TOOL_OPT_USE_SNAP]->set_shortcut(ED_SHORTCUT("spatial_editor/snap", TTR("Use Snap"), KEY_Y));
+	tool_option_button[TOOL_OPT_USE_SNAP]->set_shortcut(ED_SHORTCUT("node_3d_editor/snap", TTR("Use Snap"), KEY_Y));
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_shortcut_context(this);
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -6381,19 +6381,19 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	preview_node = memnew(Node3D);
 	preview_bounds = AABB();
 
-	ED_SHORTCUT("spatial_editor/bottom_view", TTR("Bottom View"), KEY_MASK_ALT + KEY_KP_7);
-	ED_SHORTCUT("spatial_editor/top_view", TTR("Top View"), KEY_KP_7);
-	ED_SHORTCUT("spatial_editor/rear_view", TTR("Rear View"), KEY_MASK_ALT + KEY_KP_1);
-	ED_SHORTCUT("spatial_editor/front_view", TTR("Front View"), KEY_KP_1);
-	ED_SHORTCUT("spatial_editor/left_view", TTR("Left View"), KEY_MASK_ALT + KEY_KP_3);
-	ED_SHORTCUT("spatial_editor/right_view", TTR("Right View"), KEY_KP_3);
-	ED_SHORTCUT("spatial_editor/switch_perspective_orthogonal", TTR("Switch Perspective/Orthogonal View"), KEY_KP_5);
-	ED_SHORTCUT("spatial_editor/insert_anim_key", TTR("Insert Animation Key"), KEY_K);
-	ED_SHORTCUT("spatial_editor/focus_origin", TTR("Focus Origin"), KEY_O);
-	ED_SHORTCUT("spatial_editor/focus_selection", TTR("Focus Selection"), KEY_F);
-	ED_SHORTCUT("spatial_editor/align_transform_with_view", TTR("Align Transform with View"), KEY_MASK_ALT + KEY_MASK_CMD + KEY_M);
-	ED_SHORTCUT("spatial_editor/align_rotation_with_view", TTR("Align Rotation with View"), KEY_MASK_ALT + KEY_MASK_CMD + KEY_F);
-	ED_SHORTCUT("spatial_editor/freelook_toggle", TTR("Toggle Freelook"), KEY_MASK_SHIFT + KEY_F);
+	ED_SHORTCUT("node_3d_editor/bottom_view", TTR("Bottom View"), KEY_MASK_ALT + KEY_KP_7);
+	ED_SHORTCUT("node_3d_editor/top_view", TTR("Top View"), KEY_KP_7);
+	ED_SHORTCUT("node_3d_editor/rear_view", TTR("Rear View"), KEY_MASK_ALT + KEY_KP_1);
+	ED_SHORTCUT("node_3d_editor/front_view", TTR("Front View"), KEY_KP_1);
+	ED_SHORTCUT("node_3d_editor/left_view", TTR("Left View"), KEY_MASK_ALT + KEY_KP_3);
+	ED_SHORTCUT("node_3d_editor/right_view", TTR("Right View"), KEY_KP_3);
+	ED_SHORTCUT("node_3d_editor/switch_perspective_orthogonal", TTR("Switch Perspective/Orthogonal View"), KEY_KP_5);
+	ED_SHORTCUT("node_3d_editor/insert_anim_key", TTR("Insert Animation Key"), KEY_K);
+	ED_SHORTCUT("node_3d_editor/focus_origin", TTR("Focus Origin"), KEY_O);
+	ED_SHORTCUT("node_3d_editor/focus_selection", TTR("Focus Selection"), KEY_F);
+	ED_SHORTCUT("node_3d_editor/align_transform_with_view", TTR("Align Transform with View"), KEY_MASK_ALT + KEY_MASK_CMD + KEY_M);
+	ED_SHORTCUT("node_3d_editor/align_rotation_with_view", TTR("Align Rotation with View"), KEY_MASK_ALT + KEY_MASK_CMD + KEY_F);
+	ED_SHORTCUT("node_3d_editor/freelook_toggle", TTR("Toggle Freelook"), KEY_MASK_SHIFT + KEY_F);
 
 	PopupMenu *p;
 
@@ -6404,11 +6404,11 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(transform_menu);
 
 	p = transform_menu->get_popup();
-	p->add_shortcut(ED_SHORTCUT("spatial_editor/snap_to_floor", TTR("Snap Object to Floor"), KEY_PAGEDOWN), MENU_SNAP_TO_FLOOR);
-	p->add_shortcut(ED_SHORTCUT("spatial_editor/transform_dialog", TTR("Transform Dialog...")), MENU_TRANSFORM_DIALOG);
+	p->add_shortcut(ED_SHORTCUT("node_3d_editor/snap_to_floor", TTR("Snap Object to Floor"), KEY_PAGEDOWN), MENU_SNAP_TO_FLOOR);
+	p->add_shortcut(ED_SHORTCUT("node_3d_editor/transform_dialog", TTR("Transform Dialog...")), MENU_TRANSFORM_DIALOG);
 
 	p->add_separator();
-	p->add_shortcut(ED_SHORTCUT("spatial_editor/configure_snap", TTR("Configure Snap...")), MENU_TRANSFORM_CONFIGURE_SNAP);
+	p->add_shortcut(ED_SHORTCUT("node_3d_editor/configure_snap", TTR("Configure Snap...")), MENU_TRANSFORM_CONFIGURE_SNAP);
 
 	p->connect("id_pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed));
 
@@ -6423,22 +6423,22 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	accept = memnew(AcceptDialog);
 	editor->get_gui_base()->add_child(accept);
 
-	p->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/1_viewport", TTR("1 Viewport"), KEY_MASK_CMD + KEY_1), MENU_VIEW_USE_1_VIEWPORT);
-	p->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/2_viewports", TTR("2 Viewports"), KEY_MASK_CMD + KEY_2), MENU_VIEW_USE_2_VIEWPORTS);
-	p->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/2_viewports_alt", TTR("2 Viewports (Alt)"), KEY_MASK_ALT + KEY_MASK_CMD + KEY_2), MENU_VIEW_USE_2_VIEWPORTS_ALT);
-	p->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/3_viewports", TTR("3 Viewports"), KEY_MASK_CMD + KEY_3), MENU_VIEW_USE_3_VIEWPORTS);
-	p->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/3_viewports_alt", TTR("3 Viewports (Alt)"), KEY_MASK_ALT + KEY_MASK_CMD + KEY_3), MENU_VIEW_USE_3_VIEWPORTS_ALT);
-	p->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/4_viewports", TTR("4 Viewports"), KEY_MASK_CMD + KEY_4), MENU_VIEW_USE_4_VIEWPORTS);
+	p->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/1_viewport", TTR("1 Viewport"), KEY_MASK_CMD + KEY_1), MENU_VIEW_USE_1_VIEWPORT);
+	p->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/2_viewports", TTR("2 Viewports"), KEY_MASK_CMD + KEY_2), MENU_VIEW_USE_2_VIEWPORTS);
+	p->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/2_viewports_alt", TTR("2 Viewports (Alt)"), KEY_MASK_ALT + KEY_MASK_CMD + KEY_2), MENU_VIEW_USE_2_VIEWPORTS_ALT);
+	p->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/3_viewports", TTR("3 Viewports"), KEY_MASK_CMD + KEY_3), MENU_VIEW_USE_3_VIEWPORTS);
+	p->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/3_viewports_alt", TTR("3 Viewports (Alt)"), KEY_MASK_ALT + KEY_MASK_CMD + KEY_3), MENU_VIEW_USE_3_VIEWPORTS_ALT);
+	p->add_radio_check_shortcut(ED_SHORTCUT("node_3d_editor/4_viewports", TTR("4 Viewports"), KEY_MASK_CMD + KEY_4), MENU_VIEW_USE_4_VIEWPORTS);
 	p->add_separator();
 
 	p->add_submenu_item(TTR("Gizmos"), "GizmosMenu");
 
 	p->add_separator();
-	p->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_origin", TTR("View Origin")), MENU_VIEW_ORIGIN);
-	p->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid", TTR("View Grid")), MENU_VIEW_GRID);
+	p->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_origin", TTR("View Origin")), MENU_VIEW_ORIGIN);
+	p->add_check_shortcut(ED_SHORTCUT("node_3d_editor/view_grid", TTR("View Grid")), MENU_VIEW_GRID);
 
 	p->add_separator();
-	p->add_shortcut(ED_SHORTCUT("spatial_editor/settings", TTR("Settings...")), MENU_VIEW_CAMERA_SETTINGS);
+	p->add_shortcut(ED_SHORTCUT("node_3d_editor/settings", TTR("Settings...")), MENU_VIEW_CAMERA_SETTINGS);
 
 	p->set_item_checked(p->get_item_index(MENU_VIEW_ORIGIN), true);
 	p->set_item_checked(p->get_item_index(MENU_VIEW_GRID), true);
@@ -6596,7 +6596,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	selected = nullptr;
 
 	set_process_unhandled_key_input(true);
-	add_to_group("_spatial_editor_group");
+	add_to_group("_node_3d_editor_group");
 
 	EDITOR_DEF("editors/3d/manipulator_gizmo_size", 80);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "editors/3d/manipulator_gizmo_size", PROPERTY_HINT_RANGE, "16,160,1"));
@@ -6613,17 +6613,17 @@ Node3DEditor::~Node3DEditor() {
 
 void Node3DEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		spatial_editor->show();
-		spatial_editor->set_process(true);
+		node_3d_editor->show();
+		node_3d_editor->set_process(true);
 
 	} else {
-		spatial_editor->hide();
-		spatial_editor->set_process(false);
+		node_3d_editor->hide();
+		node_3d_editor->set_process(false);
 	}
 }
 
 void Node3DEditorPlugin::edit(Object *p_object) {
-	spatial_editor->edit(Object::cast_to<Node3D>(p_object));
+	node_3d_editor->edit(Object::cast_to<Node3D>(p_object));
 }
 
 bool Node3DEditorPlugin::handles(Object *p_object) const {
@@ -6631,11 +6631,11 @@ bool Node3DEditorPlugin::handles(Object *p_object) const {
 }
 
 Dictionary Node3DEditorPlugin::get_state() const {
-	return spatial_editor->get_state();
+	return node_3d_editor->get_state();
 }
 
 void Node3DEditorPlugin::set_state(const Dictionary &p_state) {
-	spatial_editor->set_state(p_state);
+	node_3d_editor->set_state(p_state);
 }
 
 void Node3DEditor::snap_cursor_to_plane(const Plane &p_plane) {
@@ -6689,7 +6689,7 @@ void Node3DEditorPlugin::_bind_methods() {
 }
 
 void Node3DEditorPlugin::snap_cursor_to_plane(const Plane &p_plane) {
-	spatial_editor->snap_cursor_to_plane(p_plane);
+	node_3d_editor->snap_cursor_to_plane(p_plane);
 }
 
 struct _GizmoPluginPriorityComparator {
@@ -6728,12 +6728,12 @@ void Node3DEditor::remove_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin) {
 
 Node3DEditorPlugin::Node3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
-	spatial_editor = memnew(Node3DEditor(p_node));
-	spatial_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_main_control()->add_child(spatial_editor);
+	node_3d_editor = memnew(Node3DEditor(p_node));
+	node_3d_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	editor->get_main_control()->add_child(node_3d_editor);
 
-	spatial_editor->hide();
-	spatial_editor->connect("transform_key_request", Callable(editor->get_inspector_dock(), "_transform_keyed"));
+	node_3d_editor->hide();
+	node_3d_editor->connect("transform_key_request", Callable(editor->get_inspector_dock(), "_transform_keyed"));
 }
 
 Node3DEditorPlugin::~Node3DEditorPlugin() {
@@ -6882,19 +6882,19 @@ int EditorNode3DGizmoPlugin::get_priority() const {
 	return 0;
 }
 
-Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::get_gizmo(Node3D *p_spatial) {
+Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::get_gizmo(Node3D *p_node_3d) {
 	if (get_script_instance() && get_script_instance()->has_method("get_gizmo")) {
-		return get_script_instance()->call("get_gizmo", p_spatial);
+		return get_script_instance()->call("get_gizmo", p_node_3d);
 	}
 
-	Ref<EditorNode3DGizmo> ref = create_gizmo(p_spatial);
+	Ref<EditorNode3DGizmo> ref = create_gizmo(p_node_3d);
 
 	if (ref.is_null()) {
 		return ref;
 	}
 
 	ref->set_plugin(this);
-	ref->set_spatial_node(p_spatial);
+	ref->set_node_3d(p_node_3d);
 	ref->set_hidden(current_state == HIDDEN);
 
 	current_gizmos.push_back(ref.ptr());
@@ -6904,8 +6904,8 @@ Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::get_gizmo(Node3D *p_spatial) {
 void EditorNode3DGizmoPlugin::_bind_methods() {
 #define GIZMO_REF PropertyInfo(Variant::OBJECT, "gizmo", PROPERTY_HINT_RESOURCE_TYPE, "EditorNode3DGizmo")
 
-	BIND_VMETHOD(MethodInfo(Variant::BOOL, "has_gizmo", PropertyInfo(Variant::OBJECT, "spatial", PROPERTY_HINT_RESOURCE_TYPE, "Node3D")));
-	BIND_VMETHOD(MethodInfo(GIZMO_REF, "create_gizmo", PropertyInfo(Variant::OBJECT, "spatial", PROPERTY_HINT_RESOURCE_TYPE, "Node3D")));
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "has_gizmo", PropertyInfo(Variant::OBJECT, "node_3d", PROPERTY_HINT_RESOURCE_TYPE, "Node3D")));
+	BIND_VMETHOD(MethodInfo(GIZMO_REF, "create_gizmo", PropertyInfo(Variant::OBJECT, "node_3d", PROPERTY_HINT_RESOURCE_TYPE, "Node3D")));
 
 	ClassDB::bind_method(D_METHOD("create_material", "name", "color", "billboard", "on_top", "use_vertex_color"), &EditorNode3DGizmoPlugin::create_material, DEFVAL(false), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("create_icon_material", "name", "texture", "on_top", "color"), &EditorNode3DGizmoPlugin::create_icon_material, DEFVAL(false), DEFVAL(Color(1, 1, 1, 1)));
@@ -6936,20 +6936,20 @@ void EditorNode3DGizmoPlugin::_bind_methods() {
 #undef GIZMO_REF
 }
 
-bool EditorNode3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
+bool EditorNode3DGizmoPlugin::has_gizmo(Node3D *p_node_3d) {
 	if (get_script_instance() && get_script_instance()->has_method("has_gizmo")) {
-		return get_script_instance()->call("has_gizmo", p_spatial);
+		return get_script_instance()->call("has_gizmo", p_node_3d);
 	}
 	return false;
 }
 
-Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::create_gizmo(Node3D *p_spatial) {
+Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::create_gizmo(Node3D *p_node_3d) {
 	if (get_script_instance() && get_script_instance()->has_method("create_gizmo")) {
-		return get_script_instance()->call("create_gizmo", p_spatial);
+		return get_script_instance()->call("create_gizmo", p_node_3d);
 	}
 
 	Ref<EditorNode3DGizmo> ref;
-	if (has_gizmo(p_spatial)) {
+	if (has_gizmo(p_node_3d)) {
 		ref.instance();
 	}
 	return ref;
@@ -7031,7 +7031,7 @@ EditorNode3DGizmoPlugin::EditorNode3DGizmoPlugin() {
 EditorNode3DGizmoPlugin::~EditorNode3DGizmoPlugin() {
 	for (int i = 0; i < current_gizmos.size(); ++i) {
 		current_gizmos[i]->set_plugin(nullptr);
-		current_gizmos[i]->get_spatial_node()->set_gizmo(nullptr);
+		current_gizmos[i]->get_node_3d()->set_gizmo(nullptr);
 	}
 	if (Node3DEditor::get_singleton()) {
 		Node3DEditor::get_singleton()->update_all_gizmos();

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -86,10 +86,10 @@ public:
 	bool hidden;
 	Node3D *base;
 	Vector<Instance> instances;
-	Node3D *spatial_node;
+	Node3D *node_3d;
 	EditorNode3DGizmoPlugin *gizmo_plugin;
 
-	void _set_spatial_node(Node *p_node) { set_spatial_node(Object::cast_to<Node3D>(p_node)); }
+	void _set_node_3d(Node *p_node) { set_node_3d(Object::cast_to<Node3D>(p_node)); }
 
 protected:
 	static void _bind_methods();
@@ -109,8 +109,8 @@ public:
 	virtual void set_handle(int p_idx, Camera3D *p_camera, const Point2 &p_point);
 	virtual void commit_handle(int p_idx, const Variant &p_restore, bool p_cancel = false);
 
-	void set_spatial_node(Node3D *p_node);
-	Node3D *get_spatial_node() const { return spatial_node; }
+	void set_node_3d(Node3D *p_node);
+	Node3D *get_node_3d() const { return node_3d; }
 	Ref<EditorNode3DGizmoPlugin> get_plugin() const { return gizmo_plugin; }
 	Vector3 get_handle_pos(int p_idx) const;
 	bool intersect_frustum(const Camera3D *p_camera, const Vector<Plane> &p_frustum);
@@ -430,7 +430,7 @@ private:
 
 	void _sinput(const Ref<InputEvent> &p_event);
 	void _update_freelook(real_t delta);
-	Node3DEditor *spatial_editor;
+	Node3DEditor *node_3d_editor;
 
 	Camera3D *previewing;
 	Camera3D *preview;
@@ -448,7 +448,7 @@ private:
 	Point2i _get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const;
 
 	Vector3 _get_instance_position(const Point2 &p_pos) const;
-	static AABB _calculate_spatial_bounds(const Node3D *p_parent, bool p_exclude_top_level_transform = true);
+	static AABB _calculate_node_3d_bounds(const Node3D *p_parent, bool p_exclude_top_level_transform = true);
 	void _create_preview(const Vector<String> &files) const;
 	void _remove_preview();
 	bool _cyclical_dependency_exists(const String &p_target_scene_path, Node *p_desired_node);
@@ -482,7 +482,7 @@ public:
 	SubViewport *get_viewport_node() { return viewport; }
 	Camera3D *get_camera() { return camera; } // return the default camera object.
 
-	Node3DEditorViewport(Node3DEditor *p_spatial_editor, EditorNode *p_editor, int p_index);
+	Node3DEditorViewport(Node3DEditor *p_node_3d_editor, EditorNode *p_editor, int p_index);
 	~Node3DEditorViewport();
 };
 
@@ -806,7 +806,7 @@ public:
 	void add_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin);
 	void remove_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin);
 
-	void edit(Node3D *p_spatial);
+	void edit(Node3D *p_node_3d);
 	void clear();
 
 	Node3DEditor(EditorNode *p_editor);
@@ -816,7 +816,7 @@ public:
 class Node3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Node3DEditorPlugin, EditorPlugin);
 
-	Node3DEditor *spatial_editor;
+	Node3DEditor *node_3d_editor;
 	EditorNode *editor;
 
 protected:
@@ -825,7 +825,7 @@ protected:
 public:
 	void snap_cursor_to_plane(const Plane &p_plane);
 
-	Node3DEditor *get_spatial_editor() { return spatial_editor; }
+	Node3DEditor *get_node_3d_editor() { return node_3d_editor; }
 	virtual String get_name() const override { return "3D"; }
 	bool has_main_screen() const override { return true; }
 	virtual void make_visible(bool p_visible) override;
@@ -834,7 +834,7 @@ public:
 
 	virtual Dictionary get_state() const override;
 	virtual void set_state(const Dictionary &p_state) override;
-	virtual void clear() override { spatial_editor->clear(); }
+	virtual void clear() override { node_3d_editor->clear(); }
 
 	virtual void edited_scene_changed() override;
 
@@ -856,8 +856,8 @@ protected:
 	HashMap<String, Vector<Ref<StandardMaterial3D>>> materials;
 
 	static void _bind_methods();
-	virtual bool has_gizmo(Node3D *p_spatial);
-	virtual Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_spatial);
+	virtual bool has_gizmo(Node3D *p_node_3d);
+	virtual Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_node_3d);
 
 public:
 	void create_material(const String &p_name, const Color &p_color, bool p_billboard = false, bool p_on_top = false, bool p_use_vertex_color = false);
@@ -879,7 +879,7 @@ public:
 	virtual void commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel = false);
 	virtual bool is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int p_idx) const;
 
-	Ref<EditorNode3DGizmo> get_gizmo(Node3D *p_spatial);
+	Ref<EditorNode3DGizmo> get_gizmo(Node3D *p_node_3d);
 	void set_state(int p_state);
 	int get_state() const;
 	void unregister_gizmo(EditorNode3DGizmo *p_gizmo);

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -289,12 +289,12 @@ void Path3DGizmo::redraw() {
 
 Path3DGizmo::Path3DGizmo(Path3D *p_path) {
 	path = p_path;
-	set_spatial_node(p_path);
+	set_node_3d(p_path);
 	orig_in_length = 0;
 	orig_out_length = 0;
 }
 
-bool Path3DEditorPlugin::forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
+bool Path3DEditorPlugin::forward_node_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
 	if (!path) {
 		return false;
 	}
@@ -621,10 +621,10 @@ Path3DEditorPlugin::Path3DEditorPlugin(EditorNode *p_node) {
 Path3DEditorPlugin::~Path3DEditorPlugin() {
 }
 
-Ref<EditorNode3DGizmo> Path3DGizmoPlugin::create_gizmo(Node3D *p_spatial) {
+Ref<EditorNode3DGizmo> Path3DGizmoPlugin::create_gizmo(Node3D *p_node_3d) {
 	Ref<Path3DGizmo> ref;
 
-	Path3D *path = Object::cast_to<Path3D>(p_spatial);
+	Path3D *path = Object::cast_to<Path3D>(p_node_3d);
 	if (path) {
 		ref = Ref<Path3DGizmo>(memnew(Path3DGizmo(path)));
 	}

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -56,7 +56,7 @@ class Path3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(Path3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
 protected:
-	Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_spatial) override;
+	Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_node_3d) override;
 
 public:
 	String get_gizmo_name() const override;
@@ -98,7 +98,7 @@ public:
 	Path3D *get_edited_path() { return path; }
 
 	static Path3DEditorPlugin *singleton;
-	virtual bool forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override;
+	virtual bool forward_node_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override;
 
 	virtual String get_name() const override { return "Path3D"; }
 	bool has_main_screen() const override { return false; }

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1066,8 +1066,8 @@ void SceneTreeDock::_notification(int p_what) {
 			}
 
 			Node3DEditorPlugin *spatial_editor_plugin = Object::cast_to<Node3DEditorPlugin>(editor_data->get_editor("3D"));
-			spatial_editor_plugin->get_spatial_editor()->connect("item_lock_status_changed", Callable(scene_tree, "_update_tree"));
-			spatial_editor_plugin->get_spatial_editor()->connect("item_group_status_changed", Callable(scene_tree, "_update_tree"));
+			spatial_editor_plugin->get_node_3d_editor()->connect("item_lock_status_changed", Callable(scene_tree, "_update_tree"));
+			spatial_editor_plugin->get_node_3d_editor()->connect("item_group_status_changed", Callable(scene_tree, "_update_tree"));
 
 			button_add->set_icon(get_theme_icon("Add", "EditorIcons"));
 			button_instance->set_icon(get_theme_icon("Instance", "EditorIcons"));
@@ -2573,7 +2573,7 @@ void SceneTreeDock::_focus_node() {
 		editor->get_canvas_item_editor()->focus_selection();
 	} else {
 		Node3DEditorPlugin *editor = Object::cast_to<Node3DEditorPlugin>(editor_data->get_editor("3D"));
-		editor->get_spatial_editor()->get_editor_viewport(0)->focus_selection();
+		editor->get_node_3d_editor()->get_editor_viewport(0)->focus_selection();
 	}
 }
 

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -49,7 +49,7 @@ CSGShape3DGizmoPlugin::CSGShape3DGizmoPlugin() {
 }
 
 String CSGShape3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_spatial_node());
+	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_node_3d());
 
 	if (Object::cast_to<CSGSphere3D>(cs)) {
 		return "Radius";
@@ -71,7 +71,7 @@ String CSGShape3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, 
 }
 
 Variant CSGShape3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int p_idx) const {
-	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_spatial_node());
+	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_node_3d());
 
 	if (Object::cast_to<CSGSphere3D>(cs)) {
 		CSGSphere3D *s = Object::cast_to<CSGSphere3D>(cs);
@@ -97,7 +97,7 @@ Variant CSGShape3DGizmoPlugin::get_handle_value(EditorNode3DGizmo *p_gizmo, int 
 }
 
 void CSGShape3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
-	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_spatial_node());
+	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_node_3d());
 
 	Transform gt = cs->get_global_transform();
 	//gt.orthonormalize();
@@ -194,7 +194,7 @@ void CSGShape3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Ca
 }
 
 void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, const Variant &p_restore, bool p_cancel) {
-	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_spatial_node());
+	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_node_3d());
 
 	if (Object::cast_to<CSGSphere3D>(cs)) {
 		CSGSphere3D *s = Object::cast_to<CSGSphere3D>(cs);
@@ -275,8 +275,8 @@ void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx,
 	}
 }
 
-bool CSGShape3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
-	return Object::cast_to<CSGSphere3D>(p_spatial) || Object::cast_to<CSGBox3D>(p_spatial) || Object::cast_to<CSGCylinder3D>(p_spatial) || Object::cast_to<CSGTorus3D>(p_spatial) || Object::cast_to<CSGMesh3D>(p_spatial) || Object::cast_to<CSGPolygon3D>(p_spatial);
+bool CSGShape3DGizmoPlugin::has_gizmo(Node3D *p_node) {
+	return Object::cast_to<CSGSphere3D>(p_node) || Object::cast_to<CSGBox3D>(p_node) || Object::cast_to<CSGCylinder3D>(p_node) || Object::cast_to<CSGTorus3D>(p_node) || Object::cast_to<CSGMesh3D>(p_node) || Object::cast_to<CSGPolygon3D>(p_node);
 }
 
 String CSGShape3DGizmoPlugin::get_gizmo_name() const {
@@ -292,7 +292,7 @@ bool CSGShape3DGizmoPlugin::is_selectable_when_hidden() const {
 }
 
 void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_spatial_node());
+	CSGShape3D *cs = Object::cast_to<CSGShape3D>(p_gizmo->get_node_3d());
 
 	p_gizmo->clear();
 

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -251,7 +251,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual bool forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return grid_map_editor->forward_spatial_input_event(p_camera, p_event); }
+	virtual bool forward_node_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return grid_map_editor->forward_spatial_input_event(p_camera, p_event); }
 	virtual String get_name() const override { return "GridMap"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Renamed methods names in EditorPlugins and EditorGizmoPlugins etc... that where still using spatial to use node_3d for consistency with rest of godot 4.0.