### PR TITLE
[3.x] Add a reference to function state during `resume()`

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1807,7 +1807,14 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 
 	state.result = p_arg;
 	Variant::CallError err;
+
+	// Keep at least one reference to the function state to prevent
+	// it from being freed and preserve the local variables
+	reference();
 	Variant ret = function->call(nullptr, nullptr, 0, err, &state);
+	if (unreference()) {
+		memdelete(this);
+	}
 
 	bool completed = true;
 


### PR DESCRIPTION
Fixes #44863. The function state is now referenced during the function execution in `resume()` call.
The deletion of the function state object during it's method execution slightly worries me. Seems to work fine but I would like to get a comment on that from a more experienced developer.