### PR TITLE
Document workaround for storing 64-bit floats in PoolRealArray

### DIFF
--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -6,7 +6,7 @@
 	<description>
 		An [Array] specifically designed to hold floating-point values. Optimized for memory usage, does not fragment the memory.
 		[b]Note:[/b] This type is passed by value and not by reference.
-		[b]Note:[/b] Unlike primitive [float]s which are 64-bit, numbers stored in [PoolRealArray] are 32-bit floats. This means values stored in [PoolRealArray] have lower precision compared to primitive [float]s.
+		[b]Note:[/b] Unlike primitive [float]s which are 64-bit, numbers stored in [PoolRealArray] are 32-bit floats. This means values stored in [PoolRealArray] have lower precision compared to primitive [float]s. If you need to store 64-bit floats in an array, use a generic [Array] with [float] elements as these will still be 64-bit. However, using a generic [Array] to store [float]s will use roughly 6 times more memory compared to a [PoolRealArray].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/45230#issuecomment-761614812. Thanks @aaronfranke :slightly_smiling_face: