### PR TITLE
[iOS] '.xcframework' support in plugins

### DIFF
--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -1357,16 +1357,10 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 		PluginConfigIOS plugin = enabled_plugins[i];
 
 		// Export plugin binary.
-		if (!plugin.supports_targets) {
-			err = _copy_asset(dest_dir, plugin.binary, nullptr, true, true, r_exported_assets);
-		} else {
-			String plugin_binary_dir = plugin.binary.get_base_dir();
-			String plugin_name_prefix = plugin.binary.get_basename().get_file();
-			String plugin_file = plugin_name_prefix + "." + (p_debug ? "debug" : "release") + ".a";
-			String result_file_name = plugin.binary.get_file();
+		String plugin_main_binary = get_plugin_main_binary(plugin, p_debug);
+		String plugin_binary_result_file = plugin.binary.get_file();
 
-			err = _copy_asset(dest_dir, plugin_binary_dir.plus_file(plugin_file), &result_file_name, true, true, r_exported_assets);
-		}
+		err = _copy_asset(dest_dir, plugin_main_binary, &plugin_binary_result_file, true, true, r_exported_assets);
 
 		ERR_FAIL_COND_V(err, err);
 

--- a/platform/iphone/plugin/godot_plugin_config.h
+++ b/platform/iphone/plugin/godot_plugin_config.h
@@ -167,22 +167,44 @@ static inline bool validate_plugin(PluginConfigIOS &plugin_config) {
 
 	bool fields_value = valid_name && valid_binary_name && valid_initialize && valid_deinitialize;
 
-	if (fields_value && FileAccess::exists(plugin_config.binary)) {
+	if (!fields_value) {
+		return false;
+	}
+
+	String plugin_extension = plugin_config.binary.get_extension().to_lower();
+
+	if ((plugin_extension == "a" && FileAccess::exists(plugin_config.binary)) ||
+			(plugin_extension == "xcframework" && DirAccess::exists(plugin_config.binary))) {
 		plugin_config.valid_config = true;
 		plugin_config.supports_targets = false;
-	} else if (fields_value) {
+	} else {
 		String file_path = plugin_config.binary.get_base_dir();
 		String file_name = plugin_config.binary.get_basename().get_file();
-		String release_file_name = file_path.plus_file(file_name + ".release.a");
-		String debug_file_name = file_path.plus_file(file_name + ".debug.a");
+		String file_extension = plugin_config.binary.get_extension();
+		String release_file_name = file_path.plus_file(file_name + ".release." + file_extension);
+		String debug_file_name = file_path.plus_file(file_name + ".debug." + file_extension);
 
-		if (FileAccess::exists(release_file_name) && FileAccess::exists(debug_file_name)) {
+		if ((plugin_extension == "a" && FileAccess::exists(release_file_name) && FileAccess::exists(debug_file_name)) ||
+				(plugin_extension == "xcframework" && DirAccess::exists(release_file_name) && DirAccess::exists(debug_file_name))) {
 			plugin_config.valid_config = true;
 			plugin_config.supports_targets = true;
 		}
 	}
 
 	return plugin_config.valid_config;
+}
+
+static inline String get_plugin_main_binary(PluginConfigIOS &plugin_config, bool p_debug) {
+	if (!plugin_config.supports_targets) {
+		return plugin_config.binary;
+	}
+
+	String plugin_binary_dir = plugin_config.binary.get_base_dir();
+	String plugin_name_prefix = plugin_config.binary.get_basename().get_file();
+	String plugin_extension = plugin_config.binary.get_extension();
+	String plugin_file = plugin_name_prefix + "." + (p_debug ? "debug" : "release") + "." + plugin_extension;
+
+	return plugin_binary_dir.plus_file(plugin_file);
 }
 
 static inline uint64_t get_plugin_modification_time(const PluginConfigIOS &plugin_config, const String &config_path) {


### PR DESCRIPTION
Adds a support for `.xcframework` for iOS plugins. 
This should allow building for arm64 simulator on M1 macs.
Both `.a` and `.xcframework` support `.debug`/`.release` configurations through specific binary file name.
Also moved main binary search from `export.cpp` to make code cleaner.

Should be cherry-pickable to `3.2`.