### PR TITLE
Fix BVH set_pairable and masks.

### DIFF
--- a/core/math/bvh_cull.inc
+++ b/core/math/bvh_cull.inc
@@ -8,7 +8,10 @@ struct CullParams {
 	int result_max;
 	T **result_array;
 	int *subindex_array;
+
+	// nobody truly understands how masks are intended to work.
 	uint32_t mask;
+	uint32_t pairable_type;
 
 	// optional components for different tests
 	Vector3 point;
@@ -138,8 +141,14 @@ void _cull_hit(uint32_t p_ref_id, CullParams &p) {
 	if (USE_PAIRS) {
 		const ItemExtra &ex = _extra[p_ref_id];
 
-		if (!(p.mask & ex.pairable_type))
-			return;
+		// double check this as a possible source of bugs in future.
+		bool from_match_to = p.mask & ex.pairable_type;
+
+		if (!from_match_to) {
+			bool to_match_from = ex.pairable_mask & p.pairable_type;
+			if (!to_match_from)
+				return;
+		}
 	}
 
 	_cull_hits.push_back(p_ref_id);

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -196,6 +196,7 @@ void item_fill_cullparams(BVHHandle p_handle, CullParams &r_params) const {
 
 	// we take into account the mask of the item testing from
 	r_params.mask = extra.pairable_mask;
+	r_params.pairable_type = extra.pairable_type;
 }
 
 bool item_is_pairable(const BVHHandle &p_handle) {


### PR DESCRIPTION
Calling set_pairable now will update collisions (rather than waiting for the next item_move).
Mask behaviour used for pairing now (hopefully) matches octree.

Fixes #45247
Fixes #45246

## Notes
* The BVH is pretty much a black box, and the use of masks is a godot specific addon, as such I have to try and match the existing behaviour
* After doing some research it turns out that the masks passed to the BVH by the rendering tree are NOT layer masks, they are instance types. I have written some notes on this in comments, because it is not clear at all from the renderer source code.


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
