### PR TITLE
[3.2] Fix memory when loading dynamic font

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -132,6 +132,7 @@ Error DynamicFontAtSize::_load() {
 		f->get_buffer(font->_fontdata.ptrw(), len);
 		font->set_font_ptr(font->_fontdata.ptr(), len);
 		f->close();
+		memdelete(f);
 	}
 
 	if (font->font_mem) {


### PR DESCRIPTION
Fixes leak
```
Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7f2a5dae4bc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
    #1 0x119d929d in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:82
    #2 0x119d919c in operator new(unsigned long, char const*) core/os/memory.cpp:42
    #3 0x79aa0f5 in FileAccess* FileAccess::_create_builtin<FileAccessUnix>() core/os/file_access.h:77
    #4 0x118fb5ee in FileAccess::create(FileAccess::AccessType) core/os/file_access.cpp:49
    #5 0x118fba71 in FileAccess::create_for_path(String const&) core/os/file_access.cpp:76
    #6 0x118fbde4 in FileAccess::open(String const&, int, Error*) core/os/file_access.cpp:108
    #7 0xe991f9e in DynamicFontAtSize::_load() scene/resources/dynamic_font.cpp:123
    #8 0xe98da6e in DynamicFontData::_get_dynamic_font_at_size(DynamicFontData::CacheID) scene/resources/dynamic_font.cpp:59
    #9 0xe9a803d in DynamicFont::_reload_cache() scene/resources/dynamic_font.cpp:662
    #10 0xe9a96c2 in DynamicFont::set_font_data(Ref<DynamicFontData> const&) scene/resources/dynamic_font.cpp:684
    #11 0xe9fa679 in MethodBind1<Ref<DynamicFontData> const&>::call(Object*, Variant const**, int, Variant::CallError&) core/method_bind.gen.inc:775
    #12 0x1122b974 in ClassDB::set_property(Object*, StringName const&, Variant const&, bool*) core/class_db.cpp:1049
    #13 0x11489b92 in Object::set(StringName const&, Variant const&, bool*) core/object.cpp:423
    #14 0xef95526 in ResourceInteractiveLoaderText::poll() scene/resources/resource_format_text.cpp:603
    #15 0x11ea7dd6 in ResourceFormatLoader::load(String const&, String const&, Error*) core/io/resource_loader.cpp:197
    #16 0x11eadb70 in ResourceLoader::_load(String const&, String const&, String const&, bool, Error*) core/io/resource_loader.cpp:270
    #17 0x11eb0b78 in ResourceLoader::load(String const&, String const&, bool, Error*) core/io/resource_loader.cpp:402
    #18 0xef89f88 in ResourceInteractiveLoaderText::poll() scene/resources/resource_format_text.cpp:433
    #19 0x11ea7dd6 in ResourceFormatLoader::load(String const&, String const&, Error*) core/io/resource_loader.cpp:197
    #20 0x11eadb70 in ResourceLoader::_load(String const&, String const&, String const&, bool, Error*) core/io/resource_loader.cpp:270
    #21 0x11eb0b78 in ResourceLoader::load(String const&, String const&, bool, Error*) core/io/resource_loader.cpp:402
    #22 0xef89f88 in ResourceInteractiveLoaderText::poll() scene/resources/resource_format_text.cpp:433
    #23 0x11ea7dd6 in ResourceFormatLoader::load(String const&, String const&, Error*) core/io/resource_loader.cpp:197
    #24 0x11eadb70 in ResourceLoader::_load(String const&, String const&, String const&, bool, Error*) core/io/resource_loader.cpp:270
    #25 0x11eb0b78 in ResourceLoader::load(String const&, String const&, bool, Error*) core/io/resource_loader.cpp:402
    #26 0xef89f88 in ResourceInteractiveLoaderText::poll() scene/resources/resource_format_text.cpp:433
    #27 0x11ea7dd6 in ResourceFormatLoader::load(String const&, String const&, Error*) core/io/resource_loader.cpp:197
    #28 0x11eadb70 in ResourceLoader::_load(String const&, String const&, String const&, bool, Error*) core/io/resource_loader.cpp:270
    #29 0x11eb0b78 in ResourceLoader::load(String const&, String const&, bool, Error*) core/io/resource_loader.cpp:402
```

Code is different in 4.0 branch and doesn't need this fix.

Example leak https://github.com/qarmin/The-worst-Godot-test-project/runs/1716262944?check_suite_focus=true