### PR TITLE
Tweak the "Auto" editor setting hints to be more indicative

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5581,6 +5581,8 @@ EditorNode::EditorNode() {
 		switch (display_scale) {
 			case 0: {
 				// Try applying a suitable display scale automatically.
+				// The code below is adapted in `editor/editor_settings.cpp` and `editor/project_manager.cpp`.
+				// Make sure to update those when modifying the code below.
 #ifdef OSX_ENABLED
 				editor_set_scale(DisplayServer::get_singleton()->screen_get_max_scale());
 #else

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2371,6 +2371,8 @@ ProjectManager::ProjectManager() {
 		switch (display_scale) {
 			case 0: {
 				// Try applying a suitable display scale automatically.
+				// The code below is adapted in `editor/editor_settings.cpp` and `editor/editor_node.cpp`.
+				// Make sure to update those when modifying the code below.
 #ifdef OSX_ENABLED
 				editor_set_scale(DisplayServer::get_singleton()->screen_get_max_scale());
 #else


### PR DESCRIPTION
This affects the editor scale and font hinting settings which will now display their automatically chosen value in parentheses.