### PR TITLE
Add rule of thirds guides to the Camera3D editor preview

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -553,6 +553,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/3d/grid_xy_plane", false);
 	_initial_set("editors/3d/grid_yz_plane", false);
 
+	_initial_set("editors/3d/show_camera_preview_guides", true);
+
 	// Use a lower default FOV for the 3D camera compared to the
 	// Camera3D node as the 3D viewport doesn't span the whole screen.
 	// This means it's technically viewed from a further distance, which warrants a narrower FOV.


### PR DESCRIPTION
Rule of thirds guides are often used to help with visual composition.

This also darkens the area outside the defined project aspect ratio to help with cutscene design.

Camera guides and darkening can be disabled in the Editor Settings by unchecking **Editors > 3d > Show Camera Preview Guides**.

This closes https://github.com/godotengine/godot-proposals/issues/2136.

## Preview

*Click to view at full size. Even though lines are drawn to be visible on all backgrounds, they're still quite subtle and are invisible in the preview.*

![Rule of third guides](https://user-images.githubusercontent.com/180032/106402783-8c96da80-642b-11eb-8c7b-443194d95291.png)

<details>
<summary>Older revision of this PR</summary>

### Viewport aspect ratio is less wide than the project aspect ratio (the Camera3D uses Keep Height)

![rule_of_thirds_narrow](https://user-images.githubusercontent.com/180032/104868060-a839b580-5942-11eb-8ac9-f096b08bf563.png)

### Viewport aspect ratio is wider than the project aspect ratio (the Camera3D uses Keep Height)

![rule_of_thirds_wide](https://user-images.githubusercontent.com/180032/104868059-a7088880-5942-11eb-8458-c970c499808e.png)
</details>