### PR TITLE
Fix typo in theming methods ("botton" -> "bottom")

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -41,16 +41,16 @@
 #include "modules/svg/image_loader_svg.h"
 #endif
 
-static Ref<StyleBoxTexture> make_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_botton, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_botton = -1, bool p_draw_center = true) {
+static Ref<StyleBoxTexture> make_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, bool p_draw_center = true) {
 	Ref<StyleBoxTexture> style(memnew(StyleBoxTexture));
 	style->set_texture(p_texture);
 	style->set_margin_size(SIDE_LEFT, p_left * EDSCALE);
 	style->set_margin_size(SIDE_RIGHT, p_right * EDSCALE);
-	style->set_margin_size(SIDE_BOTTOM, p_botton * EDSCALE);
+	style->set_margin_size(SIDE_BOTTOM, p_bottom * EDSCALE);
 	style->set_margin_size(SIDE_TOP, p_top * EDSCALE);
 	style->set_default_margin(SIDE_LEFT, p_margin_left * EDSCALE);
 	style->set_default_margin(SIDE_RIGHT, p_margin_right * EDSCALE);
-	style->set_default_margin(SIDE_BOTTOM, p_margin_botton * EDSCALE);
+	style->set_default_margin(SIDE_BOTTOM, p_margin_bottom * EDSCALE);
 	style->set_default_margin(SIDE_TOP, p_margin_top * EDSCALE);
 	style->set_draw_center(p_draw_center);
 	return style;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -46,7 +46,7 @@ static TexCacheMap *tex_cache;
 static float scale = 1;
 
 template <class T>
-static Ref<StyleBoxTexture> make_stylebox(T p_src, float p_left, float p_top, float p_right, float p_botton, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_botton = -1, bool p_draw_center = true) {
+static Ref<StyleBoxTexture> make_stylebox(T p_src, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, bool p_draw_center = true) {
 	Ref<ImageTexture> texture;
 
 	if (tex_cache->has(p_src)) {
@@ -66,11 +66,11 @@ static Ref<StyleBoxTexture> make_stylebox(T p_src, float p_left, float p_top, fl
 	style->set_texture(texture);
 	style->set_margin_size(SIDE_LEFT, p_left * scale);
 	style->set_margin_size(SIDE_RIGHT, p_right * scale);
-	style->set_margin_size(SIDE_BOTTOM, p_botton * scale);
+	style->set_margin_size(SIDE_BOTTOM, p_bottom * scale);
 	style->set_margin_size(SIDE_TOP, p_top * scale);
 	style->set_default_margin(SIDE_LEFT, p_margin_left * scale);
 	style->set_default_margin(SIDE_RIGHT, p_margin_right * scale);
-	style->set_default_margin(SIDE_BOTTOM, p_margin_botton * scale);
+	style->set_default_margin(SIDE_BOTTOM, p_margin_bottom * scale);
 	style->set_default_margin(SIDE_TOP, p_margin_top * scale);
 	style->set_draw_center(p_draw_center);
 
@@ -88,11 +88,11 @@ static Ref<StyleBoxFlat> make_flat_stylebox(Color p_color, float p_margin_left =
 	return style;
 }
 
-static Ref<StyleBoxTexture> sb_expand(Ref<StyleBoxTexture> p_sbox, float p_left, float p_top, float p_right, float p_botton) {
+static Ref<StyleBoxTexture> sb_expand(Ref<StyleBoxTexture> p_sbox, float p_left, float p_top, float p_right, float p_bottom) {
 	p_sbox->set_expand_margin_size(SIDE_LEFT, p_left * scale);
 	p_sbox->set_expand_margin_size(SIDE_TOP, p_top * scale);
 	p_sbox->set_expand_margin_size(SIDE_RIGHT, p_right * scale);
-	p_sbox->set_expand_margin_size(SIDE_BOTTOM, p_botton * scale);
+	p_sbox->set_expand_margin_size(SIDE_BOTTOM, p_bottom * scale);
 	return p_sbox;
 }
 
@@ -127,12 +127,12 @@ static Ref<Texture2D> flip_icon(Ref<Texture2D> p_texture, bool p_flip_y = false,
 	return texture;
 }
 
-static Ref<StyleBox> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_botton = -1) {
+static Ref<StyleBox> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {
 	Ref<StyleBox> style(memnew(StyleBoxEmpty));
 
 	style->set_default_margin(SIDE_LEFT, p_margin_left * scale);
 	style->set_default_margin(SIDE_RIGHT, p_margin_right * scale);
-	style->set_default_margin(SIDE_BOTTOM, p_margin_botton * scale);
+	style->set_default_margin(SIDE_BOTTOM, p_margin_bottom * scale);
 	style->set_default_margin(SIDE_TOP, p_margin_top * scale);
 
 	return style;

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -395,10 +395,10 @@ void StyleBoxFlat::set_corner_radius_all(int radius) {
 	emit_changed();
 }
 
-void StyleBoxFlat::set_corner_radius_individual(const int radius_top_left, const int radius_top_right, const int radius_botton_right, const int radius_bottom_left) {
+void StyleBoxFlat::set_corner_radius_individual(const int radius_top_left, const int radius_top_right, const int radius_bottom_right, const int radius_bottom_left) {
 	corner_radius[0] = radius_top_left;
 	corner_radius[1] = radius_top_right;
-	corner_radius[2] = radius_botton_right;
+	corner_radius[2] = radius_bottom_right;
 	corner_radius[3] = radius_bottom_left;
 
 	emit_changed();

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -183,7 +183,7 @@ public:
 
 	//CORNER
 	void set_corner_radius_all(int radius);
-	void set_corner_radius_individual(const int radius_top_left, const int radius_top_right, const int radius_botton_right, const int radius_bottom_left);
+	void set_corner_radius_individual(const int radius_top_left, const int radius_top_right, const int radius_bottom_right, const int radius_bottom_left);
 
 	void set_corner_radius(Corner p_corner, const int radius);
 	int get_corner_radius(Corner p_corner) const;


### PR DESCRIPTION
I found this typo while writing https://github.com/godotengine/godot-proposals/issues/2141 :wink: