### PR TITLE
[3.2] Mono: Fix support for Unicode identifiers

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2696,7 +2696,7 @@ int CSharpScript::_try_get_member_export_hint(IMonoClassMember *p_member, Manage
 				name_only_hint_string += ",";
 			}
 
-			String enum_field_name = mono_field_get_name(field);
+			String enum_field_name = String::utf8(mono_field_get_name(field));
 			r_hint_string += enum_field_name;
 			name_only_hint_string += enum_field_name;
 

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -377,8 +377,8 @@ GDMonoClass *GDMonoAssembly::get_class(MonoClass *p_mono_class) {
 	if (match)
 		return match->value();
 
-	StringName namespace_name = mono_class_get_namespace(p_mono_class);
-	StringName class_name = mono_class_get_name(p_mono_class);
+	StringName namespace_name = String::utf8(mono_class_get_namespace(p_mono_class));
+	StringName class_name = String::utf8(mono_class_get_name(p_mono_class));
 
 	GDMonoClass *wrapped_class = memnew(GDMonoClass(namespace_name, class_name, p_mono_class, this));
 

--- a/modules/mono/mono_gd/gd_mono_class.cpp
+++ b/modules/mono/mono_gd/gd_mono_class.cpp
@@ -175,7 +175,7 @@ void GDMonoClass::fetch_methods_with_godot_api_checks(GDMonoClass *p_native_base
 	void *iter = NULL;
 	MonoMethod *raw_method = NULL;
 	while ((raw_method = mono_class_get_methods(get_mono_ptr(), &iter)) != NULL) {
-		StringName name = mono_method_get_name(raw_method);
+		StringName name = String::utf8(mono_method_get_name(raw_method));
 
 		// get_method implicitly fetches methods and adds them to this->methods
 		GDMonoMethod *method = get_method(raw_method, name);
@@ -318,7 +318,7 @@ GDMonoMethod *GDMonoClass::get_method(MonoMethod *p_raw_method) {
 	MonoMethodSignature *sig = mono_method_signature(p_raw_method);
 
 	int params_count = mono_signature_get_param_count(sig);
-	StringName method_name = mono_method_get_name(p_raw_method);
+	StringName method_name = String::utf8(mono_method_get_name(p_raw_method));
 
 	return get_method(p_raw_method, method_name, params_count);
 }
@@ -391,7 +391,7 @@ const Vector<GDMonoField *> &GDMonoClass::get_all_fields() {
 	void *iter = NULL;
 	MonoClassField *raw_field = NULL;
 	while ((raw_field = mono_class_get_fields(mono_class, &iter)) != NULL) {
-		StringName name = mono_field_get_name(raw_field);
+		StringName name = String::utf8(mono_field_get_name(raw_field));
 
 		Map<StringName, GDMonoField *>::Element *match = fields.find(name);
 
@@ -439,7 +439,7 @@ const Vector<GDMonoProperty *> &GDMonoClass::get_all_properties() {
 	void *iter = NULL;
 	MonoProperty *raw_property = NULL;
 	while ((raw_property = mono_class_get_properties(mono_class, &iter)) != NULL) {
-		StringName name = mono_property_get_name(raw_property);
+		StringName name = String::utf8(mono_property_get_name(raw_property));
 
 		Map<StringName, GDMonoProperty *>::Element *match = properties.find(name);
 
@@ -465,14 +465,14 @@ const Vector<GDMonoClass *> &GDMonoClass::get_all_delegates() {
 	MonoClass *raw_class = NULL;
 	while ((raw_class = mono_class_get_nested_types(mono_class, &iter)) != NULL) {
 		if (mono_class_is_delegate(raw_class)) {
-			StringName name = mono_class_get_name(raw_class);
+			StringName name = String::utf8(mono_class_get_name(raw_class));
 
 			Map<StringName, GDMonoClass *>::Element *match = delegates.find(name);
 
 			if (match) {
 				delegates_list.push_back(match->get());
 			} else {
-				GDMonoClass *delegate = memnew(GDMonoClass(mono_class_get_namespace(raw_class), mono_class_get_name(raw_class), raw_class, assembly));
+				GDMonoClass *delegate = memnew(GDMonoClass(String::utf8(mono_class_get_namespace(raw_class)), String::utf8(mono_class_get_name(raw_class)), raw_class, assembly));
 				delegates.insert(name, delegate);
 				delegates_list.push_back(delegate);
 			}
@@ -490,7 +490,7 @@ const Vector<GDMonoMethod *> &GDMonoClass::get_all_methods() {
 		void *iter = NULL;
 		MonoMethod *raw_method = NULL;
 		while ((raw_method = mono_class_get_methods(get_mono_ptr(), &iter)) != NULL) {
-			method_list.push_back(memnew(GDMonoMethod(mono_method_get_name(raw_method), raw_method)));
+			method_list.push_back(memnew(GDMonoMethod(String::utf8(mono_method_get_name(raw_method)), raw_method)));
 		}
 
 		method_list_fetched = true;

--- a/modules/mono/mono_gd/gd_mono_field.cpp
+++ b/modules/mono/mono_gd/gd_mono_field.cpp
@@ -574,7 +574,7 @@ IMonoClassMember::Visibility GDMonoField::get_visibility() {
 GDMonoField::GDMonoField(MonoClassField *p_mono_field, GDMonoClass *p_owner) {
 	owner = p_owner;
 	mono_field = p_mono_field;
-	name = mono_field_get_name(mono_field);
+	name = String::utf8(mono_field_get_name(mono_field));
 	MonoType *field_type = mono_field_get_type(mono_field);
 	type.type_encoding = mono_type_get_type(field_type);
 	MonoClass *field_type_class = mono_class_from_mono_type(field_type);

--- a/modules/mono/mono_gd/gd_mono_property.cpp
+++ b/modules/mono/mono_gd/gd_mono_property.cpp
@@ -40,7 +40,7 @@
 GDMonoProperty::GDMonoProperty(MonoProperty *p_mono_property, GDMonoClass *p_owner) {
 	owner = p_owner;
 	mono_property = p_mono_property;
-	name = mono_property_get_name(mono_property);
+	name = String::utf8(mono_property_get_name(mono_property));
 
 	MonoMethod *prop_method = mono_property_get_get_method(mono_property);
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->


`
        [Export]
        private string dq当前动作 = "idle";
`

Garbled code will be displayed in the editor

add
`String::utf8()`

Normal display in editor

[4.0](https://github.com/godotengine/godot/pull/45310)