### PR TITLE
[3.2.4] Fix lightmapper build on llvm-mingw on Linux

### DIFF
--- a/modules/lightmapper_cpu/lightmapper_cpu.cpp
+++ b/modules/lightmapper_cpu/lightmapper_cpu.cpp
@@ -780,7 +780,8 @@ _ALWAYS_INLINE_ float uniform_rand() {
 	state ^= state << 13;
 	state ^= state >> 17;
 	state ^= state << 5;
-	return float(state) / UINT32_MAX;
+	/* implicit conversion from 'unsigned int' to 'float' changes value from 4294967295 to 4294967296 */
+	return float(state) / float(UINT32_MAX);
 }
 
 void LightmapperCPU::_compute_indirect_light(uint32_t p_idx, void *r_lightmap) {

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -35,7 +35,7 @@
 
 #if !defined(__aligned)
 
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)) && !defined(__CYGWIN__)
+#if defined(_WIN32) && defined(_MSC_VER)
 #define __aligned(...) __declspec(align(__VA_ARGS__))
 #else
 #define __aligned(...) __attribute__((aligned(__VA_ARGS__)))

--- a/thirdparty/embree/common/math/math.h
+++ b/thirdparty/embree/common/math/math.h
@@ -12,8 +12,8 @@
 #include <xmmintrin.h>
 #include <immintrin.h>
 
-#if defined(__WIN32__) && !defined(__MINGW32__)
-#if (__MSV_VER <= 1700)
+#if defined(__WIN32__)
+#if defined(_MSC_VER) && (_MSC_VER <= 1700)
 namespace std
 {
   __forceinline bool isinf ( const float x ) { return _finite(x) == 0; }
@@ -86,7 +86,7 @@ namespace embree
     return _mm_cvtss_f32(c);
   }
 
-#if defined(__WIN32__) && (__MSC_VER <= 1700)
+#if defined(__WIN32__) && defined(_MSC_VER) && (_MSC_VER <= 1700)
   __forceinline float nextafter(float x, float y) { if ((x<y) == (x>0)) return x*(1.1f+float(ulp)); else return x*(0.9f-float(ulp)); }
   __forceinline double nextafter(double x, double y) { return _nextafter(x, y); }
   __forceinline int roundf(float f) { return (int)(f + 0.5f); }

--- a/thirdparty/embree/include/embree3/rtcore_common.h
+++ b/thirdparty/embree/include/embree3/rtcore_common.h
@@ -19,7 +19,7 @@ typedef int ssize_t;
 #endif
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(_MSC_VER)
 #  define RTC_ALIGN(...) __declspec(align(__VA_ARGS__))
 #else
 #  define RTC_ALIGN(...) __attribute__((aligned(__VA_ARGS__)))

--- a/thirdparty/embree/pathces/godot-changes.patch
+++ b/thirdparty/embree/pathces/godot-changes.patch
@@ -2,15 +2,24 @@ diff --git a/common/math/math.h b/common/math/math.h
 index 5af0691a2..1982c27c1 100644
 --- a/common/math/math.h
 +++ b/common/math/math.h
-@@ -12,7 +12,7 @@
- #include <xmmintrin.h>
+@@ -13,7 +13,7 @@
  #include <immintrin.h>
  
--#if defined(__WIN32__)
-+#if defined(__WIN32__) && !defined(__MINGW32__)
- #if (__MSV_VER <= 1700)
+ #if defined(__WIN32__)
+-#if (__MSV_VER <= 1700)
++#if defined(_MSC_VER) && (_MSC_VER <= 1700)
  namespace std
  {
+   __forceinline bool isinf ( const float x ) { return _finite(x) == 0; }
+@@ -86,7 +86,7 @@
+     return _mm_cvtss_f32(c);
+   }
+ 
+-#if defined(__WIN32__) && (__MSC_VER <= 1700)
++#if defined(__WIN32__) && defined(_MSC_VER) && (_MSC_VER <= 1700)
+   __forceinline float nextafter(float x, float y) { if ((x<y) == (x>0)) return x*(1.1f+float(ulp)); else return x*(0.9f-float(ulp)); }
+   __forceinline double nextafter(double x, double y) { return _nextafter(x, y); }
+   __forceinline int roundf(float f) { return (int)(f + 0.5f); }
 diff --git a/common/sys/intrinsics.h b/common/sys/intrinsics.h
 index 3f0619cac..58f5c3bb4 100644
 --- a/common/sys/intrinsics.h
@@ -190,3 +199,15 @@ index 98dba2687..369e5edf0 100644
  #endif
  
  // We need to define these to avoid implicit linkage against
+diff a/include/embree3/rtcore_common.h b/include/embree3/rtcore_common.h
+--- a/include/embree3/rtcore_common.h
++++ b/include/embree3/rtcore_common.h
+@@ -19,7 +19,7 @@
+ #endif
+ #endif
+ 
+-#ifdef _WIN32
++#if defined(_WIN32) && defined(_MSC_VER)
+ #  define RTC_ALIGN(...) __declspec(align(__VA_ARGS__))
+ #else
+ #  define RTC_ALIGN(...) __attribute__((aligned(__VA_ARGS__)))


### PR DESCRIPTION
Collectively, these two fixes allow embree to be cross compiled using llvm-mingw on Linux:
Note that in addition to fixing the typo with _MSC_VER, the defined check must be added to avoid undefined symbols acting as 0.
See embree/embree#310

(Originally posted at @JFonS repo at JFonS#4 : It was later partially addressed, but the typo in the _MSC_VER macro was not fixed.)

Might address the issues at #45097 or #45260