### PR TITLE
[3.2] Workaround for alpha scissoring with opaque pre-pass in SpatialMaterial

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -879,7 +879,13 @@ void SpatialMaterial::_update_shader() {
 		code += "\tALPHA = 1.0;\n";
 
 	} else if (features[FEATURE_TRANSPARENT] || flags[FLAG_USE_ALPHA_SCISSOR] || flags[FLAG_USE_SHADOW_TO_OPACITY] || (distance_fade == DISTANCE_FADE_PIXEL_ALPHA) || proximity_fade_enabled) {
-		code += "\tALPHA = albedo.a * albedo_tex.a;\n";
+		if (ddm == DEPTH_DRAW_ALPHA_OPAQUE_PREPASS) {
+			code += "\tif (alpha_scissor_threshold > albedo.a * albedo_tex.a) {\n";
+			code += "\t\tdiscard;\n";
+			code += "\t}\n";
+		} else {
+			code += "\tALPHA = albedo.a * albedo_tex.a;\n";
+		}
 	}
 
 	if (proximity_fade_enabled) {
@@ -1041,10 +1047,6 @@ void SpatialMaterial::_update_shader() {
 		code += "\tvec3 detail_norm = mix(NORMALMAP,detail_norm_tex.rgb,detail_tex.a);\n";
 		code += "\tNORMALMAP = mix(NORMALMAP,detail_norm,detail_mask_tex.r);\n";
 		code += "\tALBEDO.rgb = mix(ALBEDO.rgb,detail,detail_mask_tex.r);\n";
-	}
-
-	if (flags[FLAG_USE_ALPHA_SCISSOR]) {
-		code += "\tALPHA_SCISSOR=alpha_scissor_threshold;\n";
 	}
 
 	code += "}\n";


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. ren

dering
fixes for the 3.2 branch).
-->
This implements a workaround for broken alpha scissoring with opaque pre-pass in 3.2.

Video:
https://user-images.githubusercontent.com/55308941/104935573-af48de00-59ab-11eb-8308-e909c4e7deea.mp4

with workaround:
https://user-images.githubusercontent.com/55308941/104942616-fab3ba00-59b4-11eb-937e-325d82ce2d6d.mp4

This doesn't fix the real issue, because alpha scissoring will still be broken if used with `ALPHA_SCISSOR=alpha_scissor_threshold;`, but this will be reimplemented in 4.0, so I think this workaround is good enough for now.

(workaround by AsherGlick and Arnklit here: #36669)

MRP: [alpha_scissor_workaround.zip](https://github.com/godotengine/godot/files/5831485/alpha_scissor_workaround.zip)