### PR TITLE
[iOS] Fix embedding of plugin libraries

### DIFF
--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -1359,8 +1359,9 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 		// Export plugin binary.
 		String plugin_main_binary = get_plugin_main_binary(plugin, p_debug);
 		String plugin_binary_result_file = plugin.binary.get_file();
-
-		err = _copy_asset(dest_dir, plugin_main_binary, &plugin_binary_result_file, true, true, r_exported_assets);
+		// We shouldn't embed .xcframework that contains static libraries.
+		// Static libraries are not embedded anyway.
+		err = _copy_asset(dest_dir, plugin_main_binary, &plugin_binary_result_file, true, false, r_exported_assets);
 
 		ERR_FAIL_COND_V(err, err);
 


### PR DESCRIPTION
Since Godot plugin is a static library even when stored as `.xcframework` it should not be embedded. 
Embedding a `.xcframework` with static libraries will result in application keeping addtional copy of `.a` library, increasing application size in the end.

A follow-up PR for https://github.com/godotengine/godot/pull/45250. 
Should also be cherry-picked with https://github.com/godotengine/godot/pull/45250 to `3.2` to fix plugin support.