### PR TITLE
[3.x] Fix Chinese&Japanese erroneous newline

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1596,6 +1596,7 @@ void RichTextLabel::add_text(const String &p_text) {
 		else
 			line = p_text.substr(pos, end - pos);
 
+		int lipos = 0;
 		while (lipos < line.length()) {
 			if (line[lipos] >= 0x3040 && line[lipos] < 0xfaff) {
 				//Chinese or Japanese word condition

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1599,13 +1599,13 @@ void RichTextLabel::add_text(const String &p_text) {
 			line = p_text.substr(pos, end - pos);
 
 #define IS_CJK(index) ((line[index] >= 0x3040 && line[index] <= 0x9fbf) || (line[index] >= 0xf900 && line[index] <= 0xfaff))
-//add more rule here,to support more languages
+		//add more rule here,to support more languages
 
 		int lipos = 0;
 		while (lipos < line.length()) {
 			if (IS_CJK(lipos)) {
 				//Chinese or Japanese word condition
-				int o;//length of CJK
+				int o; //length of CJK
 				for (o = 1; o < (line.length() - lipos) && IS_CJK(lipos + o); o++) {
 				}
 				ItemText *item = memnew(ItemText);
@@ -1615,11 +1615,11 @@ void RichTextLabel::add_text(const String &p_text) {
 				lipos += o;
 			} else {
 				//English word condition
-				int o;//length of English words
+				int o; //length of English words
 				for (o = 1; o < (line.length() - lipos) && !(IS_CJK(lipos + o)); o++) {
 				}
 				if (lipos == 0 && current->subitems.size() && current->subitems.back()->get()->type == ITEM_TEXT &&
-					!(static_cast<ItemText *>(current->subitems.back()->get())->isCJK)) {
+						!(static_cast<ItemText *>(current->subitems.back()->get())->isCJK)) {
 					//append text condition!
 					ItemText *ti = static_cast<ItemText *>(current->subitems.back()->get());
 					ti->text += line.substr(lipos, o);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -406,7 +406,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 							cw = tab_size * font->get_char_size(' ').width;
 						}
 
-						if (end > 0 && w + cw + begin > p_width) {
+						if (end > 0 && (w + cw + begin > p_width || (text->isCJK && wofs - backtrack + w + cw > p_width))) {
 							break; //don't allow lines longer than assigned width
 						}
 
@@ -414,8 +414,6 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 						fw += cw;
 
 						end++;
-						if (text->isCJK)
-							break;
 					}
 					CHECK_HEIGHT(fh);
 					ENSURE_WIDTH(w);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1596,19 +1596,32 @@ void RichTextLabel::add_text(const String &p_text) {
 		else
 			line = p_text.substr(pos, end - pos);
 
-		if (line.length() > 0) {
-
-			if (current->subitems.size() && current->subitems.back()->get()->type == ITEM_TEXT) {
-				//append text condition!
-				ItemText *ti = static_cast<ItemText *>(current->subitems.back()->get());
-				ti->text += line;
-				_invalidate_current_line(main);
-
-			} else {
-				//append item condition
+		while (lipos < line.length()) {
+			if (line[lipos] >= 0x3040 && line[lipos] < 0xfaff) {
+				//Chinese or Japanese word condition
 				ItemText *item = memnew(ItemText);
-				item->text = line;
+				item->text = line.substr(lipos, 1);
 				_add_item(item, false);
+				//append one by one
+				lipos++;
+			} else {
+				//English word condition
+				int o;//length of English words
+				for (o = 1; o < (line.length() - lipos) && (line[lipos + o] < 0x3040 || line[lipos + o] > 0xfaff); o++) {
+				}
+				if (current->subitems.size() && current->subitems.back()->get()->type == ITEM_TEXT) {
+					//append text condition!
+					ItemText *ti = static_cast<ItemText *>(current->subitems.back()->get());
+					ti->text += line.substr(lipos, o);
+					_invalidate_current_line(main);
+
+				} else {
+					//append item condition
+					ItemText *item = memnew(ItemText);
+					item->text = line.substr(lipos, o);
+					_add_item(item, false);
+				}
+				lipos += o;
 			}
 		}
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1596,8 +1596,8 @@ void RichTextLabel::add_text(const String &p_text) {
 		else
 			line = p_text.substr(pos, end - pos);
 
-#define IS_CJK(index) ((line[index] >= 0x3040 && line[index] <= 0x9fbf) || (line[index] >= 0xf900 && line[index] <= 0xfaff))
-		//add more rule here,to support more languages
+#define IS_CJK(index) (line[index] >= 0x3040 && ((line[index] >= 0x31c0 && line[index] <= 0x9fff) || line[index] <= 0x30ff || (line[index] >= 0xf900 && line[index] <= 0xfaff)))
+		//add more rule here,to support more languages 3040~30ff 31c0~9fff f900~faff
 
 		int lipos = 0;
 		while (lipos < line.length()) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1598,10 +1598,9 @@ void RichTextLabel::add_text(const String &p_text) {
 		else
 			line = p_text.substr(pos, end - pos);
 
-#define IS_CJK(index) (line[index] >= 0x3040 && line[index] <= 0x9fbf) || \
-			(line[index] >= 0xf900 && line[index] <= 0xfaff) \
-			/*add more rule here,to support more languages*/
-			
+#define IS_CJK(index) ((line[index] >= 0x3040 && line[index] <= 0x9fbf) || (line[index] >= 0xf900 && line[index] <= 0xfaff))
+//add more rule here,to support more languages
+
 		int lipos = 0;
 		while (lipos < line.length()) {
 			if (IS_CJK(lipos)) {
@@ -1637,7 +1636,7 @@ void RichTextLabel::add_text(const String &p_text) {
 			}
 		}
 #undef IS_CJK
-		
+
 		if (eol) {
 
 			ItemNewline *item = memnew(ItemNewline);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -143,6 +143,7 @@ private:
 
 	struct ItemText : public Item {
 		String text;
+		bool isCJK;
 		ItemText() { type = ITEM_TEXT; }
 	};
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
## Problem

Chinese&Japanese erroneous newline.For examples:
`parse_bbcode("向最坏处着想,向最好处努力")`
![image](https://user-images.githubusercontent.com/77611914/104926130-b9360580-59da-11eb-8b1c-be9f08d72286.png)
It's correct newline.But,when I add bbcode tag:
`parse_bbcode("向[b]最坏处着想,向最好处努力")`
![image](https://user-images.githubusercontent.com/77611914/104926716-788abc00-59db-11eb-924c-b8531dfb6d80.png)
It's wrong newline.Around at bbcode tag instead of correct place.
`parse_bbcode("向[b]最坏[/b]处着想,向最好处努力")`
![image](https://user-images.githubusercontent.com/77611914/104927757-c7852100-59dc-11eb-91f6-26b65ce4e57c.png)

## Reason

Chinese&Japanese do not use space or any character for separating words.
So,a Chinese&Japanese sentence will be considered as a word.
BBcode tag will separate words,rich text lable try to put a word in one line,
then,it will newline in erroneous place.

## Solve

For Chinese&Japanese,unicode greater than 0x3040 and less than 0xfaff,add them to the tag stack one by one.

![image](https://user-images.githubusercontent.com/77611914/104929259-9ad20900-59de-11eb-8785-7d1a614d04e0.png)

My code causes other language and punctuation "sticking" to previous Chinese&Japanese char.
——For punctuation,it conforms to the Chinese grammar standard.
——For other language,it can be solved by adding a space between other language and Chinese&Japanese.