### PR TITLE
Fix crash in lightmapper under MinGW-GCC Windows (3.2)

### DIFF
--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -77,6 +77,8 @@ env_embree.Append(
 
 if not env_embree.msvc:
     env_embree.Append(CPPFLAGS=["-mxsave"])
+    if env["platform"] == "windows":
+        env_embree.Append(CPPFLAGS=["-mstackrealign"])
 
 if env["platform"] == "windows":
     if env.msvc:


### PR DESCRIPTION
Now the freeze is gone, this should fix the crash once for all.

This is the fundamental piece of information I was hoping to find: http://www.peterstock.co.uk/games/mingw_sse/

My first attempt has been to add the attribute mentioned there to key elements of Embree (first, to the thread entry point only; then, to all the threading and task scheduling code), to no avail. The only thing that worked has been to enable stack alignment check globally on Embree. The downside is that functions that don't really need to do the check are doing it, maybe stealing a bit of performance? Anyway, my attempts to do it more selectively have failed, so this is the best we have now. At least, I'm quite confident this will at least get us a working lightmapper for Windows.

Fixes #45097.