### PR TITLE
BUGFIX: Fix uninitialized cursor_shape on windows display server

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -417,7 +417,7 @@ private:
 	WNDCLASSEXW wc;
 
 	HCURSOR cursors[CURSOR_MAX] = { nullptr };
-	CursorShape cursor_shape;
+	CursorShape cursor_shape = CursorShape::CURSOR_ARROW;
 	Map<CursorShape, Vector<Variant>> cursors_cache;
 
 	void _drag_event(WindowID p_window, float p_x, float p_y, int idx);


### PR DESCRIPTION
Simple bug-fix where cursor_shape is uninitialized on windows, and you get a screaming error message on debug.