### PR TITLE
Modify float values to display with trailing .0 for clarity

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1365,7 +1365,7 @@ String String::num(double p_num, int p_decimals) {
 				if (buf[z] == '0') {
 					buf[z] = 0;
 				} else if (buf[z] == '.') {
-					buf[z] = 0;
+					buf[z + 1] = '0';
 					break;
 				} else {
 					break;

--- a/tests/test_aabb.h
+++ b/tests/test_aabb.h
@@ -50,7 +50,7 @@ TEST_CASE("[AABB] Constructor methods") {
 
 TEST_CASE("[AABB] String conversion") {
 	CHECK_MESSAGE(
-			String(AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6))) == "-1.5, 2, -2.5 - 4, 5, 6",
+			String(AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6))) == "-1.5, 2.0, -2.5 - 4.0, 5.0, 6.0",
 			"The string representation shouild match the expected value.");
 }
 

--- a/tests/test_color.h
+++ b/tests/test_color.h
@@ -140,7 +140,7 @@ TEST_CASE("[Color] Conversion methods") {
 			cyan.to_rgba64() == 0x0000'ffff'ffff'ffff,
 			"The returned 64-bit BGR number should match the expected value.");
 	CHECK_MESSAGE(
-			String(cyan) == "0, 1, 1, 1",
+			String(cyan) == "0.0, 1.0, 1.0, 1.0",
 			"The string representation should match the expected value.");
 }
 

--- a/tests/test_rect2.h
+++ b/tests/test_rect2.h
@@ -61,7 +61,7 @@ TEST_CASE("[Rect2] Constructor methods") {
 TEST_CASE("[Rect2] String conversion") {
 	// Note: This also depends on the Vector2 string representation.
 	CHECK_MESSAGE(
-			String(Rect2(0, 100, 1280, 720)) == "0, 100, 1280, 720",
+			String(Rect2(0, 100, 1280, 720)) == "0.0, 100.0, 1280.0, 720.0",
 			"The string representation should match the expected value.");
 }
 
@@ -273,7 +273,7 @@ TEST_CASE("[Rect2i] Constructor methods") {
 TEST_CASE("[Rect2i] String conversion") {
 	// Note: This also depends on the Vector2 string representation.
 	CHECK_MESSAGE(
-			String(Rect2i(0, 100, 1280, 720)) == "0, 100, 1280, 720",
+			String(Rect2i(0, 100, 1280, 720)) == "0.0, 100.0, 1280.0, 720.0",
 			"The string representation should match the expected value.");
 }
 


### PR DESCRIPTION
Added toggle to keep a trailing zero when displaying whole number floats so that in
certain circumstances they can be differentiated from integers such as in
exported variables or when printing arrays
![Before](https://user-images.githubusercontent.com/61564136/104983965-76246400-59d3-11eb-8524-66433ef55a29.png)
Made to resolve godotengine/godot-proposals#1693


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
