### PR TITLE
Remove thread after use to prevent memory leak

### DIFF
--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -71,7 +71,7 @@ public:
 	static Error set_name(const String &p_name);
 	_FORCE_INLINE_ static ID get_main_id() { return _main_thread_id; } ///< get the ID of the main thread
 	static ID get_caller_id(); ///< get the ID of the caller function ID
-	static void wait_to_finish(Thread *p_thread); ///< waits until thread is finished, and deallocates it.
+	static void wait_to_finish(Thread *p_thread); ///< waits until thread is finished
 	static Thread *create(ThreadCreateCallback p_callback, void *p_user, const Settings &p_settings = Settings()); ///< Static function to create a thread, will call p_callback
 
 	virtual ~Thread();

--- a/modules/lightmapper_cpu/lightmapper_cpu.cpp
+++ b/modules/lightmapper_cpu/lightmapper_cpu.cpp
@@ -264,6 +264,7 @@ bool LightmapperCPU::_parallel_run(int p_count, const String &p_description, Bak
 	}
 	thread_cancelled = cancelled;
 	Thread::wait_to_finish(runner_thread);
+	memdelete(runner_thread);
 #endif
 
 	thread_cancelled = false;


### PR DESCRIPTION
Removes leaks like
```
Direct leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7f4996a1e517 in malloc (/lib/x86_64-linux-gnu/libasan.so.6+0xb0517)
    #1 0x117ec91f in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:82
    #2 0x117ec81e in operator new(unsigned long, char const*) core/os/memory.cpp:42
    #3 0x78aea3b in ThreadPosix::create_func_posix(void (*)(void*), void*, Thread::Settings const&) drivers/unix/thread_posix.cpp:83
    #4 0x118035c9 in Thread::create(void (*)(void*), void*, Thread::Settings const&) core/os/thread.cpp:51
    #5 0x336d395 in LightmapperCPU::_parallel_run(int, String const&, void (LightmapperCPU::*)(unsigned int, void*), void*, bool (*)(float, String const&, void*, bool)) modules/lightmapper_cpu/lightmapper_cpu.cpp:254
    #6 0x339e87c in LightmapperCPU::bake(Lightmapper::BakeQuality, bool, int, float, bool, int, Ref<Image> const&, Basis const&, bool (*)(float, String const&, void*, bool), void*, bool (*)(float, String const&, void*, bool)) modules/lightmapper_cpu/lightmapper_cpu.cpp:1395
    #7 0xd041426 in BakedLightmap::bake(Node*, String) scene/3d/baked_lightmap.cpp:750
    #8 0x9d0bc2d in BakedLightmapEditorPlugin::_bake_select_file(String const&) editor/plugins/baked_lightmap_editor_plugin.cpp:39
    #9 0x1ade0ce in MethodBind1<String const&>::call(Object*, Variant const**, int, Variant::CallError&) core/method_bind.gen.inc:775
    #10 0x112b137b in Object::call(StringName const&, Variant const**, int, Variant::CallError&) core/object.cpp:919
    #11 0x112bb1dc in Object::emit_signal(StringName const&, Variant const**, int) core/object.cpp:1246
    #12 0x112bd212 in Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) core/object.cpp:1303
    #13 0x8443916 in EditorFileDialog::_action_pressed() editor/editor_file_dialog.cpp:472
    #14 0x1a83331 in MethodBind0::call(Object*, Variant const**, int, Variant::CallError&) core/method_bind.gen.inc:59
    #15 0x112b137b in Object::call(StringName const&, Variant const**, int, Variant::CallError&) core/object.cpp:919
    #16 0x112bb1dc in Object::emit_signal(StringName const&, Variant const**, int) core/object.cpp:1246
    #17 0x112bd212 in Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) core/object.cpp:1303
    #18 0xc445fac in AcceptDialog::_ok_pressed() scene/gui/dialogs.cpp:410
    #19 0x1a83331 in MethodBind0::call(Object*, Variant const**, int, Variant::CallError&) core/method_bind.gen.inc:59
    #20 0x112b137b in Object::call(StringName const&, Variant const**, int, Variant::CallError&) core/object.cpp:919
    #21 0x112bb1dc in Object::emit_signal(StringName const&, Variant const**, int) core/object.cpp:1246
    #22 0x112bd212 in Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) core/object.cpp:1303
    #23 0xc1e40e1 in BaseButton::_pressed() scene/gui/base_button.cpp:135
    #24 0xc1e7ef3 in BaseButton::on_action_event(Ref<InputEvent>) scene/gui/base_button.cpp:169
    #25 0xc1e0a17 in BaseButton::_gui_input(Ref<InputEvent>) scene/gui/base_button.cpp:64
    #26 0x8f2aa44 in MethodBind1<Ref<InputEvent> >::call(Object*, Variant const**, int, Variant::CallError&) core/method_bind.gen.inc:775
    #27 0x112acfa4 in Object::call_multilevel(StringName const&, Variant const**, int) core/object.cpp:761
    #28 0x112b00a0 in Object::call_multilevel(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) core/object.cpp:861
    #29 0xc0ca0ec in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1688

```