### PR TITLE
BVH broadphase creates objects with updated AABB to avoid extra checks

### DIFF
--- a/servers/physics/broad_phase_basic.cpp
+++ b/servers/physics/broad_phase_basic.cpp
@@ -32,7 +32,7 @@
 #include "core/list.h"
 #include "core/print_string.h"
 
-BroadPhaseSW::ID BroadPhaseBasic::create(CollisionObjectSW *p_object, int p_subindex) {
+BroadPhaseSW::ID BroadPhaseBasic::create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb) {
 
 	ERR_FAIL_COND_V(p_object == NULL, 0);
 

--- a/servers/physics/broad_phase_basic.h
+++ b/servers/physics/broad_phase_basic.h
@@ -83,7 +83,7 @@ class BroadPhaseBasic : public BroadPhaseSW {
 
 public:
 	// 0 is an invalid ID
-	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0);
+	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0, const AABB &p_aabb = AABB());
 	virtual void move(ID p_id, const AABB &p_aabb);
 	virtual void set_static(ID p_id, bool p_static);
 	virtual void remove(ID p_id);

--- a/servers/physics/broad_phase_bvh.cpp
+++ b/servers/physics/broad_phase_bvh.cpp
@@ -32,9 +32,9 @@
 #include "collision_object_sw.h"
 #include "core/project_settings.h"
 
-BroadPhaseSW::ID BroadPhaseBVH::create(CollisionObjectSW *p_object, int p_subindex) {
+BroadPhaseSW::ID BroadPhaseBVH::create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb) {
 
-	ID oid = bvh.create(p_object, AABB(), p_subindex, false, 1 << p_object->get_type(), 0);
+	ID oid = bvh.create(p_object, p_aabb, p_subindex, false, 1 << p_object->get_type(), 0);
 	return oid + 1;
 }
 

--- a/servers/physics/broad_phase_bvh.h
+++ b/servers/physics/broad_phase_bvh.h
@@ -48,7 +48,7 @@ class BroadPhaseBVH : public BroadPhaseSW {
 
 public:
 	// 0 is an invalid ID
-	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0);
+	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0, const AABB &p_aabb = AABB());
 	virtual void move(ID p_id, const AABB &p_aabb);
 	virtual void set_static(ID p_id, bool p_static);
 	virtual void remove(ID p_id);

--- a/servers/physics/broad_phase_octree.cpp
+++ b/servers/physics/broad_phase_octree.cpp
@@ -31,7 +31,7 @@
 #include "broad_phase_octree.h"
 #include "collision_object_sw.h"
 
-BroadPhaseSW::ID BroadPhaseOctree::create(CollisionObjectSW *p_object, int p_subindex) {
+BroadPhaseSW::ID BroadPhaseOctree::create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb) {
 
 	ID oid = octree.create(p_object, AABB(), p_subindex, false, 1 << p_object->get_type(), 0);
 	return oid;

--- a/servers/physics/broad_phase_octree.h
+++ b/servers/physics/broad_phase_octree.h
@@ -48,7 +48,7 @@ class BroadPhaseOctree : public BroadPhaseSW {
 
 public:
 	// 0 is an invalid ID
-	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0);
+	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0, const AABB &p_aabb = AABB());
 	virtual void move(ID p_id, const AABB &p_aabb);
 	virtual void set_static(ID p_id, bool p_static);
 	virtual void remove(ID p_id);

--- a/servers/physics/broad_phase_sw.h
+++ b/servers/physics/broad_phase_sw.h
@@ -49,7 +49,7 @@ public:
 	typedef void (*UnpairCallback)(CollisionObjectSW *A, int p_subindex_A, CollisionObjectSW *B, int p_subindex_B, void *p_data, void *p_userdata);
 
 	// 0 is an invalid ID
-	virtual ID create(CollisionObjectSW *p_object_, int p_subindex = 0) = 0;
+	virtual ID create(CollisionObjectSW *p_object_, int p_subindex = 0, const AABB &p_aabb = AABB()) = 0;
 	virtual void move(ID p_id, const AABB &p_aabb) = 0;
 	virtual void set_static(ID p_id, bool p_static) = 0;
 	virtual void remove(ID p_id) = 0;

--- a/servers/physics/collision_object_sw.cpp
+++ b/servers/physics/collision_object_sw.cpp
@@ -150,12 +150,7 @@ void CollisionObjectSW::_update_shapes() {
 		return;
 
 	for (int i = 0; i < shapes.size(); i++) {
-
 		Shape &s = shapes.write[i];
-		if (s.bpid == 0) {
-			s.bpid = space->get_broadphase()->create(this, i);
-			space->get_broadphase()->set_static(s.bpid, _static);
-		}
 
 		//not quite correct, should compute the next matrix..
 		AABB shape_aabb = s.shape->get_aabb();
@@ -167,6 +162,10 @@ void CollisionObjectSW::_update_shapes() {
 		Vector3 scale = xform.get_basis().get_scale();
 		s.area_cache = s.shape->get_area() * scale.x * scale.y * scale.z;
 
+		if (s.bpid == 0) {
+			s.bpid = space->get_broadphase()->create(this, i, s.aabb_cache);
+			space->get_broadphase()->set_static(s.bpid, _static);
+		}
 		space->get_broadphase()->move(s.bpid, s.aabb_cache);
 	}
 }
@@ -177,12 +176,7 @@ void CollisionObjectSW::_update_shapes_with_motion(const Vector3 &p_motion) {
 		return;
 
 	for (int i = 0; i < shapes.size(); i++) {
-
 		Shape &s = shapes.write[i];
-		if (s.bpid == 0) {
-			s.bpid = space->get_broadphase()->create(this, i);
-			space->get_broadphase()->set_static(s.bpid, _static);
-		}
 
 		//not quite correct, should compute the next matrix..
 		AABB shape_aabb = s.shape->get_aabb();
@@ -191,6 +185,10 @@ void CollisionObjectSW::_update_shapes_with_motion(const Vector3 &p_motion) {
 		shape_aabb = shape_aabb.merge(AABB(shape_aabb.position + p_motion, shape_aabb.size)); //use motion
 		s.aabb_cache = shape_aabb;
 
+		if (s.bpid == 0) {
+			s.bpid = space->get_broadphase()->create(this, i, s.aabb_cache);
+			space->get_broadphase()->set_static(s.bpid, _static);
+		}
 		space->get_broadphase()->move(s.bpid, shape_aabb);
 	}
 }


### PR DESCRIPTION
**Description**

When `set_static` is called on a newly added object, the forced collision check in BVH `set_pairable` was using an empty AABB, which caused unnecessary collision checks at the origin, then a call to move was checking again at the right position.

These changes ensure broadphase objects are added to the BVH tree with proper AABB so collision checks are correctly done right away.

Octree & Basic broadphase types are not affected by these changes.

I'm not doing the same changes in the 2D physics interface because there's no use for them in the 2D broadphase at the moment.

---

**Test Scenario**

Test project:
[physics_tests.zip](https://github.com/godotengine/godot/files/5838068/physics_tests.zip)

Scene:
res://tests/performance/test_perf_broadphase.tscn

This test adds 125000 non-overlapping objects in physics at once, moves them all then removes them all. It logs timings for the different operations and physics ticks for the following frames.

---

**Test Results**

I'm getting almost 30% improvement on adding objects in this test scenario, which makes the dynamic BVH slightly better than Octree when it comes to adding objects.

Detailed results (release_debug):

<details>
<summary>BVH - Previous version</summary>

```
* Creating objects...
  Create Time: 2319.604 ms
  Physics Tick: 2324.632 ms (total = 2324.632 ms)
  Physics Tick: 12.727 ms (total = 2337.359 ms)
  Physics Tick: 1.553 ms (total = 2338.912 ms)
  Physics Tick: 1.879 ms (total = 2340.791 ms)
  Physics Tick: 1.469 ms (total = 2342.260 ms)
* Adding objects...
  Add Time: 1752.401 ms
  Physics Tick: 1803.262 ms (total = 1803.262 ms)
  Physics Tick: 281.146 ms (total = 2084.408 ms)
  Physics Tick: 209.415 ms (total = 2293.823 ms)
  Physics Tick: 212.772 ms (total = 2506.595 ms)
  Physics Tick: 211.445 ms (total = 2718.040 ms)
* Moving objects...
  Move Time: 188.680 ms
  Physics Tick: 304.528 ms (total = 304.528 ms)
  Physics Tick: 774.700 ms (total = 1079.228 ms)
  Physics Tick: 2.476 ms (total = 1081.704 ms)
  Physics Tick: 1.803 ms (total = 1083.507 ms)
  Physics Tick: 1.735 ms (total = 1085.242 ms)
* Removing objects...
  Remove Time: 371.098 ms
  Physics Tick: 392.731 ms (total = 392.731 ms)
  Physics Tick: 3.450 ms (total = 396.181 ms)
  Physics Tick: 1.797 ms (total = 397.978 ms)
  Physics Tick: 2.015 ms (total = 399.993 ms)
  Physics Tick: 1.297 ms (total = 401.290 ms)
* Done
```

</details>

<details>
<summary>BVH - This PR</summary>

```
* Creating objects...
  Create Time: 2325.229 ms
  Physics Tick: 2328.636 ms (total = 2328.636 ms)
  Physics Tick: 12.296 ms (total = 2340.932 ms)
  Physics Tick: 1.775 ms (total = 2342.707 ms)
  Physics Tick: 1.569 ms (total = 2344.276 ms)
  Physics Tick: 2.075 ms (total = 2346.351 ms)
* Adding objects...
  Add Time: 1235.450 ms
  Physics Tick: 1286.196 ms (total = 1286.196 ms)
  Physics Tick: 282.293 ms (total = 1568.489 ms)
  Physics Tick: 211.901 ms (total = 1780.390 ms)
  Physics Tick: 212.310 ms (total = 1992.700 ms)
  Physics Tick: 216.016 ms (total = 2208.716 ms)
* Moving objects...
  Move Time: 190.718 ms
  Physics Tick: 306.591 ms (total = 306.591 ms)
  Physics Tick: 616.173 ms (total = 922.764 ms)
  Physics Tick: 2.454 ms (total = 925.218 ms)
  Physics Tick: 1.759 ms (total = 926.977 ms)
  Physics Tick: 1.373 ms (total = 928.350 ms)
* Removing objects...
  Remove Time: 368.543 ms
  Physics Tick: 390.314 ms (total = 390.314 ms)
  Physics Tick: 1.936 ms (total = 392.250 ms)
  Physics Tick: 3.294 ms (total = 395.544 ms)
  Physics Tick: 1.561 ms (total = 397.105 ms)
  Physics Tick: 1.795 ms (total = 398.900 ms)
* Done.
```

</details>

</details>

<details>
<summary>Octree</summary>

```
* Creating objects...
  Create Time: 2271.760 ms
  Physics Tick: 2277.866 ms (total = 2277.866 ms)
  Physics Tick: 12.711 ms (total = 2290.577 ms)
  Physics Tick: 2.808 ms (total = 2293.385 ms)
  Physics Tick: 1.337 ms (total = 2294.722 ms)
  Physics Tick: 1.816 ms (total = 2296.538 ms)
* Adding objects...
  Add Time: 1389.967 ms
  Physics Tick: 1441.042 ms (total = 1441.042 ms)
  Physics Tick: 443.207 ms (total = 1884.249 ms)
  Physics Tick: 296.553 ms (total = 2180.802 ms)
  Physics Tick: 293.483 ms (total = 2474.285 ms)
  Physics Tick: 305.871 ms (total = 2780.156 ms)
* Moving objects...
  Move Time: 194.261 ms
  Physics Tick: 614.988 ms (total = 614.988 ms)
  Physics Tick: 291.280 ms (total = 906.268 ms)
  Physics Tick: 3.030 ms (total = 909.298 ms)
  Physics Tick: 2.032 ms (total = 911.330 ms)
  Physics Tick: 2.002 ms (total = 913.332 ms)
* Removing objects...
  Remove Time: 525.276 ms
  Physics Tick: 546.061 ms (total = 546.061 ms)
  Physics Tick: 2.721 ms (total = 548.782 ms)
  Physics Tick: 2.039 ms (total = 550.821 ms)
  Physics Tick: 1.447 ms (total = 552.268 ms)
  Physics Tick: 1.107 ms (total = 553.375 ms)
* Done.
```

</details>