### PR TITLE
Remove useless "else" statements from vector3.h

### DIFF
--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -324,48 +324,40 @@ bool Vector3::operator<(const Vector3 &p_v) const {
 	if (x == p_v.x) {
 		if (y == p_v.y) {
 			return z < p_v.z;
-		} else {
-			return y < p_v.y;
 		}
-	} else {
-		return x < p_v.x;
+		return y < p_v.y;
 	}
+	return x < p_v.x;
 }
 
 bool Vector3::operator>(const Vector3 &p_v) const {
 	if (x == p_v.x) {
 		if (y == p_v.y) {
 			return z > p_v.z;
-		} else {
-			return y > p_v.y;
 		}
-	} else {
-		return x > p_v.x;
+		return y > p_v.y;
 	}
+	return x > p_v.x;
 }
 
 bool Vector3::operator<=(const Vector3 &p_v) const {
 	if (x == p_v.x) {
 		if (y == p_v.y) {
 			return z <= p_v.z;
-		} else {
-			return y < p_v.y;
 		}
-	} else {
-		return x < p_v.x;
+		return y < p_v.y;
 	}
+	return x < p_v.x;
 }
 
 bool Vector3::operator>=(const Vector3 &p_v) const {
 	if (x == p_v.x) {
 		if (y == p_v.y) {
 			return z >= p_v.z;
-		} else {
-			return y > p_v.y;
 		}
-	} else {
-		return x > p_v.x;
+		return y > p_v.y;
 	}
+	return x > p_v.x;
 }
 
 _FORCE_INLINE_ Vector3 vec3_cross(const Vector3 &p_a, const Vector3 &p_b) {


### PR DESCRIPTION
A minor thing I found when looking over #38090. These "else" statements are useless and not present in C#, so remove them.