### PR TITLE
Use Interleaved gradient noise for shadow samples

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward.glsl
@@ -787,13 +787,11 @@ LIGHT_SHADER_CODE
 
 #ifndef USE_NO_SHADOWS
 
-// Produces cheap white noise, optimized for window-space
-// Comes from: https://www.shadertoy.com/view/4djSRW
-// Copyright: Dave Hoskins, MIT License
+// Interleaved Gradient Noise
+// http://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
 float quick_hash(vec2 pos) {
-	vec3 p3 = fract(vec3(pos.xyx) * .1031);
-	p3 += dot(p3, p3.yzx + 33.33);
-	return fract((p3.x + p3.y) * p3.z);
+	const vec3 magic = vec3(0.06711056f, 0.00583715f, 52.9829189f);
+	return fract(magic.z * fract(dot(pos, magic.xy)));
 }
 
 float sample_directional_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec4 coord) {


### PR DESCRIPTION
Instead of using white noise for shadowmap lookup, rotate samples with [interleaved gradient noise](http://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare) (IGN). IGN is described as being halfway between a dither pattern and noise. It is extremely fast to compute (about half the instructions of our previous noise), and most importantly has very little low frequency properties. This means that it looks more uniformly "random". White noise tends to have "clumping" artifacts making the noise more obvious. 

I didn't go with this initially because I was afraid of the obvious dither pattern. But as I read more and use the engine more it is clear that white noise is just not as good. 

_Comparison image: Top is white noise, bottom is IGN_
![compare](https://user-images.githubusercontent.com/16521339/105134775-c8cd5100-5aa3-11eb-8e41-556eafc987cc.jpg)
