### PR TITLE
Partially revert change to BVH render tree update method

### DIFF
--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -104,7 +104,6 @@ void VisualServerRaster::draw(bool p_swap_buffers, double frame_step) {
 	VSG::rasterizer->begin_frame(frame_step);
 
 	VSG::scene->update_dirty_instances(); //update scene stuff
-	VSG::scene->update_scenarios(); // render tree collision detection (pairing)
 
 	VSG::viewport->draw_viewports();
 	VSG::scene->render_probes();

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -3578,47 +3578,24 @@ void VisualServerScene::_update_dirty_instance(Instance *p_instance) {
 	p_instance->update_materials = false;
 }
 
-void VisualServerScene::update_scenarios() {
-	// go through all scenarios and update BVH in each
-	if (!_use_bvh) {
-		return;
-	}
-
-	List<RID> owned;
-	scenario_owner.get_owned_list(&owned);
-
-	for (List<RID>::Element *E = owned.front(); E; E = E->next()) {
-		RID rid = E->get();
-		Scenario *scenario = scenario_owner.get(rid);
-
-		scenario->sps->update();
-	}
-}
-
 void VisualServerScene::update_dirty_instances() {
 
 	VSG::storage->update_dirty_resources();
 
-	// only define this if you run into problems with missed pairing collisions for debugging
-//#define GODOT_RENDER_SPS_EXTRA_COLLISION_CHECKS
-#ifdef GODOT_RENDER_SPS_EXTRA_COLLISION_CHECKS
 	// this is just to get access to scenario so we can update the spatial partitioning scheme
 	Scenario *scenario = nullptr;
 	if (_instance_update_list.first()) {
 		scenario = _instance_update_list.first()->self()->scenario;
 	}
-#endif
 
 	while (_instance_update_list.first()) {
 
 		_update_dirty_instance(_instance_update_list.first()->self());
 	}
 
-#ifdef GODOT_RENDER_SPS_EXTRA_COLLISION_CHECKS
 	if (scenario) {
-		scenario->sps->update_collisions();
+		scenario->sps->update();
 	}
-#endif
 }
 
 bool VisualServerScene::free(RID p_rid) {

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -554,7 +554,6 @@ public:
 	void render_camera(RID p_camera, RID p_scenario, Size2 p_viewport_size, RID p_shadow_atlas);
 	void render_camera(Ref<ARVRInterface> &p_interface, ARVRInterface::Eyes p_eye, RID p_camera, RID p_scenario, Size2 p_viewport_size, RID p_shadow_atlas);
 	void update_dirty_instances();
-	void update_scenarios();
 
 	//probes
 	struct GIProbeDataHeader {


### PR DESCRIPTION
Leaves in the bug fixes, but reverts the change to the update method from #45311.

Turns out the new update method of getting the scenarios was causing problems, I will need to consult with reduz on the best way of getting access to the scenarios for a single update per frame.

Doing multiple updates isn't terrible but it should be nicer to get a single update working, as it should be more efficient, and give a single point for pairing callbacks.

Fixes #45332.

## Notes
* I'd been using the function `scenario_owner.get_owned_list` to get a list of scenarios to update per frame (each scenario contains a BVH tree).
* I hadn't seen the function is debug only, and is also causing a bug presumably due to it not being thread safe.
* The scenarios don't seem to be currently designed with an 'update' paradigm hence making the single update being a bit more tricky to shoehorn in.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
