### PR TITLE
Fix freeze-crash in lightmapper under MinGW-GCC (3.2)

### DIFF
--- a/thirdparty/embree/common/sys/intrinsics.h
+++ b/thirdparty/embree/common/sys/intrinsics.h
@@ -432,7 +432,7 @@ namespace embree
       _mm_pause();    
 // -- GODOT start --
 #else
-      usleep(1);
+      __builtin_ia32_pause();
 #endif
 // -- GODOT end --
   }

--- a/thirdparty/embree/common/sys/mutex.h
+++ b/thirdparty/embree/common/sys/mutex.h
@@ -54,7 +54,8 @@ namespace embree
           _mm_pause();
 // -- GODOT start --
 #else
-          usleep(1);
+          __builtin_ia32_pause();
+          __builtin_ia32_pause();
 #endif
 // -- GODOT end --
         }
@@ -89,7 +90,8 @@ namespace embree
         _mm_pause();
 // -- GODOT start --
 #else
-        usleep(1);
+        __builtin_ia32_pause();
+        __builtin_ia32_pause();
 #endif
 // -- GODOT end --
       }

--- a/thirdparty/embree/common/tasking/taskschedulerinternal.cpp
+++ b/thirdparty/embree/common/tasking/taskschedulerinternal.cpp
@@ -367,7 +367,7 @@ namespace embree
             _mm_pause();
 // -- GODOT start --
 #else
-            usleep(1);
+            __builtin_ia32_pause();
 #endif
 // -- GODOT end --
 	  loopIndex++;

--- a/thirdparty/embree/patches/godot-changes.patch
+++ b/thirdparty/embree/patches/godot-changes.patch
@@ -90,7 +90,7 @@ diff --git a/common/sys/mutex.h b/common/sys/mutex.h
 index 1164210f2..f0f55340a 100644
 --- a/common/sys/mutex.h
 +++ b/common/sys/mutex.h
-@@ -47,8 +47,16 @@ namespace embree
+@@ -47,8 +47,17 @@ namespace embree
        {
          while (flag.load()) 
          {
@@ -101,13 +101,14 @@ index 1164210f2..f0f55340a 100644
            _mm_pause();
 +// -- GODOT start --
 +#else
-+          usleep(1);
++          __builtin_ia32_pause();
++          __builtin_ia32_pause();
 +#endif
 +// -- GODOT end --
          }
          
          bool expected = false;
-@@ -74,8 +82,16 @@ namespace embree
+@@ -74,8 +82,17 @@ namespace embree
      {
        while(flag.load())
        {
@@ -118,7 +119,8 @@ index 1164210f2..f0f55340a 100644
          _mm_pause();
 +// -- GODOT start --
 +#else
-+        usleep(1);
++        __builtin_ia32_pause();
++        __builtin_ia32_pause();
 +#endif
 +// -- GODOT end --
        }


### PR DESCRIPTION
Why not another attempt at fixing #45097?

I've found a non-hacky way to emit the `PAUSE` instruction, via an intrinsic that seems to work. Something feels different... The _Preparing data structures_ step now is almost immediate.

I've tested with one more project this time.

@akien-mga, a couple of remarks:
- I'm not actually building on Fedora, but on Windows with MinGW-w64. I know the results may vary, but they seem to be very similar most of the time.
- I've "reconciled" the new patch with the stored one manually, so the patch file may be wrong. (Reverse-applying the patch in order to get a new one with all the changes didn't work for me; I don't know why.) I guess if this works we can take care of that later.