### PR TITLE
[3.2] Fix highlight color for class attributes that are also keywords

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -191,19 +191,21 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 				col = text_editor->get_keyword_color(word);
 			} else if (text_editor->has_member_color(word)) {
 				col = text_editor->get_member_color(word);
+			}
+
+			if (col != Color()) {
 				for (int k = j - 1; k >= 0; k--) {
 					if (str[k] == '.') {
-						col = Color(); //member indexing not allowed
+						col = Color(); // keyword & member indexing not allowed
 						break;
 					} else if (str[k] > 32) {
 						break;
 					}
 				}
-			}
-
-			if (col != Color()) {
-				in_keyword = true;
-				keyword_color = col;
+				if (col != Color()) {
+					in_keyword = true;
+					keyword_color = col;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #45338. 

This PR also makes any word after a  `.` not highlight as a keyword, i.e. the `cos`
in `Color.cos` will highlight the same as any other class constant. Additionally,
trying to do things like `.print()` will not highlight print as a keyword but as
a class function. (Hopefully this was not intended behavior!)

#45338 is fixed in master by #45144
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
