### PR TITLE
[3.2] Fix const warnings in FBX (build failure on macOS)

### DIFF
--- a/modules/fbx/fbx_parser/FBXDocument.h
+++ b/modules/fbx/fbx_parser/FBXDocument.h
@@ -107,7 +107,7 @@ public:
 		return (flags & FAILED_TO_CONSTRUCT) != 0;
 	}
 
-	const ElementPtr GetElement() const {
+	ElementPtr GetElement() const {
 		return element;
 	}
 
@@ -136,7 +136,7 @@ public:
 
 	virtual ~Object();
 
-	const ElementPtr SourceElement() const {
+	ElementPtr SourceElement() const {
 		return element;
 	}
 

--- a/modules/fbx/fbx_parser/FBXParser.cpp
+++ b/modules/fbx/fbx_parser/FBXParser.cpp
@@ -1186,8 +1186,8 @@ std::string ParseTokenAsString(const TokenPtr t) {
 
 // ------------------------------------------------------------------------------------------------
 // extract a required element from a scope, abort if the element cannot be found
-const ElementPtr GetRequiredElement(const ScopePtr sc, const std::string &index, const ElementPtr element /*= NULL*/) {
-	const ElementPtr el = sc->GetElement(index);
+ElementPtr GetRequiredElement(const ScopePtr sc, const std::string &index, const ElementPtr element /*= NULL*/) {
+	ElementPtr el = sc->GetElement(index);
 	TokenPtr token = el->KeyToken();
 	ERR_FAIL_COND_V(!token, nullptr);
 	if (!el) {
@@ -1207,14 +1207,14 @@ bool HasElement(const ScopePtr sc, const std::string &index) {
 
 // ------------------------------------------------------------------------------------------------
 // extract a required element from a scope, abort if the element cannot be found
-const ElementPtr GetOptionalElement(const ScopePtr sc, const std::string &index, const ElementPtr element /*= NULL*/) {
-	const ElementPtr el = sc->GetElement(index);
+ElementPtr GetOptionalElement(const ScopePtr sc, const std::string &index, const ElementPtr element /*= NULL*/) {
+	ElementPtr el = sc->GetElement(index);
 	return el;
 }
 
 // ------------------------------------------------------------------------------------------------
 // extract required compound scope
-const ScopePtr GetRequiredScope(const ElementPtr el) {
+ScopePtr GetRequiredScope(const ElementPtr el) {
 	if (el) {
 		ScopePtr s = el->Compound();
 		TokenPtr token = el->KeyToken();

--- a/modules/fbx/fbx_parser/FBXParser.h
+++ b/modules/fbx/fbx_parser/FBXParser.h
@@ -191,7 +191,7 @@ public:
 	Parser(const TokenList &tokens, bool is_binary);
 	~Parser();
 
-	const ScopePtr GetRootScope() const {
+	ScopePtr GetRootScope() const {
 		return root;
 	}
 
@@ -247,11 +247,11 @@ void ParseVectorDataArray(std::vector<int64_t> &out, const ElementPtr el);
 bool HasElement(const ScopePtr sc, const std::string &index);
 
 // extract a required element from a scope, abort if the element cannot be found
-const ElementPtr GetRequiredElement(const ScopePtr sc, const std::string &index, const ElementPtr element = nullptr);
-const ScopePtr GetRequiredScope(const ElementPtr el); // New in 2020. (less likely to destroy application)
-const ElementPtr GetOptionalElement(const ScopePtr sc, const std::string &index, const ElementPtr element = nullptr);
+ElementPtr GetRequiredElement(const ScopePtr sc, const std::string &index, const ElementPtr element = nullptr);
+ScopePtr GetRequiredScope(const ElementPtr el); // New in 2020. (less likely to destroy application)
+ElementPtr GetOptionalElement(const ScopePtr sc, const std::string &index, const ElementPtr element = nullptr);
 // extract required compound scope
-const ScopePtr GetRequiredScope(const ElementPtr el);
+ScopePtr GetRequiredScope(const ElementPtr el);
 // get token at a particular index
 TokenPtr GetRequiredToken(const ElementPtr el, unsigned int index);
 

--- a/modules/fbx/fbx_parser/FBXProperties.h
+++ b/modules/fbx/fbx_parser/FBXProperties.h
@@ -143,7 +143,7 @@ public:
 	PropertyPtr Get(const std::string &name) const;
 
 	// PropertyTable's need not be coupled with FBX elements so this can be NULL
-	const ElementPtr GetElement() const {
+	ElementPtr GetElement() const {
 		return element;
 	}
 


### PR DESCRIPTION
Fixes several instances of error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]

This looks like it was fixed in 6607fc7da90d1e17f6bb952b8325d02bc593cccc when FBX was merged into the 4.0 master branch:

"- fixed const correctness with C++/C version change"