### PR TITLE
[3.2] Fix undeclared identifier error (rand) in lightmapper_cpu

### DIFF
--- a/modules/lightmapper_cpu/lightmapper_cpu.cpp
+++ b/modules/lightmapper_cpu/lightmapper_cpu.cpp
@@ -777,7 +777,7 @@ void LightmapperCPU::_compute_direct_light(uint32_t p_idx, void *r_lightmap) {
 
 _ALWAYS_INLINE_ float uniform_rand() {
 	/* Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs" */
-	static thread_local uint32_t state = rand();
+	static thread_local uint32_t state = Math::rand();
 	state ^= state << 13;
 	state ^= state >> 17;
 	state ^= state << 5;


### PR DESCRIPTION
Compiling with latest clang on macOS produced this error: use of undeclared identifier 'rand'.

Fixes godotengine/godot#45342

This file is not present in 4.0/master.
