### PR TITLE
Make use of export path when exporting PCK/ZIP

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -830,6 +830,12 @@ void ProjectExportDialog::_refresh_parent_checks(TreeItem *p_item) {
 }
 
 void ProjectExportDialog::_export_pck_zip() {
+	Ref<EditorExportPreset> current = get_current_preset();
+	ERR_FAIL_COND(current.is_null());
+
+	String dir = current->get_export_path().get_base_dir();
+	export_pck_zip->set_current_dir(dir);
+
 	export_pck_zip->popup_file_dialog();
 }
 


### PR DESCRIPTION
Ensures that the directory set in `Export Path` is used as the default for the editor file dialog pop up when `Export PCK/ZIP` is selected.

Closes #39769
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
