### PR TITLE
'Editor Settings','Project Settings','Property Name' display translation

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1622,6 +1622,9 @@ void EditorInspector::update_tree() {
 
 	Color sscolor = get_theme_color("prop_subsection", "Editor");
 
+	bool _translation = (bool)EditorSettings::get_singleton()->get("interface/editor/editor_setting_translation");
+	bool _name_translation = (bool)EditorSettings::get_singleton()->get("interface/editor/property_name_translation");
+
 	for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
 		Ref<EditorInspectorPlugin> ped = E->get();
 		ped->parse_begin(object);
@@ -1704,7 +1707,7 @@ void EditorInspector::update_tree() {
 				}
 			}
 			category->label = type;
-
+			_translation = _name_translation;
 			category->bg_color = get_theme_color("prop_category", "Editor");
 			if (use_doc_hints) {
 				StringName type2 = p.name;
@@ -1829,7 +1832,8 @@ void EditorInspector::update_tree() {
 
 					Color c = sscolor;
 					c.a /= level;
-					section->setup(acc_path, path_name, object, c, use_folding);
+					section->setup(acc_path, _translation ? TTR(path_name) : path_name, object, c, use_folding);
+					section->set_tooltip(path_name);
 
 					VBoxContainer *vb = section->get_vbox();
 					item_path[acc_path] = vb;
@@ -1939,7 +1943,7 @@ void EditorInspector::update_tree() {
 							ep->set_label(F->get().label);
 						} else {
 							//use existin one
-							ep->set_label(name);
+							ep->set_label(_translation ? TTR(name) : name);
 						}
 						for (int i = 0; i < F->get().properties.size(); i++) {
 							String prop = F->get().properties[i];

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_sectioned_inspector.h"
 
+#include "editor_node.h"
 #include "editor_scale.h"
 
 class SectionedInspectorFilter : public Object {
@@ -221,6 +222,8 @@ void SectionedInspector::update_category_list() {
 		filter = search_box->get_text();
 	}
 
+	bool name_translation = (bool)EditorSettings::get_singleton()->get("interface/editor/property_name_translation");
+
 	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
 		PropertyInfo pi = E->get();
 
@@ -261,7 +264,9 @@ void SectionedInspector::update_category_list() {
 			if (!section_map.has(metasection)) {
 				TreeItem *ms = sections->create_item(parent);
 				section_map[metasection] = ms;
-				ms->set_text(0, sectionarr[i].capitalize());
+				String item_name = sectionarr[i].capitalize();
+				ms->set_text(0, name_translation ? TTR(item_name) : item_name);
+				ms->set_tooltip(0, item_name);
 				ms->set_metadata(0, metasection);
 				ms->set_selectable(0, false);
 			}

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -325,6 +325,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* Interface */
 
 	// Editor
+	_initial_set("interface/editor/editor_setting_translation", true);
+	_initial_set("interface/editor/property_name_translation", false);
 	_initial_set("interface/editor/display_scale", 0);
 	hints["interface/editor/display_scale"] = PropertyInfo(Variant::INT, "interface/editor/display_scale", PROPERTY_HINT_ENUM, "Auto,75%,100%,125%,150%,175%,200%,Custom", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/custom_display_scale", 1.0f);

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -219,7 +219,8 @@ void EditorSettingsDialog::_update_shortcuts() {
 			section = shortcuts->create_item(root);
 
 			String item_name = section_name.capitalize();
-			section->set_text(0, item_name);
+			section->set_text(0, TTR(item_name));
+			section->set_tooltip(0, item_name);
 
 			if (collapsed.has(item_name)) {
 				section->set_collapsed(collapsed[item_name]);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
![Attribute](https://user-images.githubusercontent.com/14800320/105520477-b8bca800-5d15-11eb-8459-ddd5f4ed866c.png)

(English from Google Translate)

'Editor Settings','Project Settings','Property Name' display translation
.po add msg

'set_tooltip' is added to show the original text


把原来没翻译的地方,让其可以翻译.
添加了几个set_tooltip,用来显示英文原文
编辑器设置中添加了'property_name_translation'属性,用来开启是否翻译这些英文
extract.py现在可以提取 _initial_set 和  GLOBAL_DEF 的文本了
 3.2 #45383