### PR TITLE
Document shape metadata for `TileMap`

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Node for 2D tile-based maps. Tilemaps use a [TileSet] which contain a list of tiles (textures plus optional collision, navigation, and/or occluder shapes) which are used to create grid-based maps.
+		When doing physics queries against the tilemap, the cell coordinates are encoded as [code]metadata[/code] for each detected collision shape returned by methods such as [method PhysicsDirectSpaceState2D.intersect_shape], [method PhysicsDirectBodyState2D.get_contact_collider_shape_metadata] etc.
 	</description>
 	<tutorials>
 		<link title="Using Tilemaps">https://docs.godotengine.org/en/latest/tutorials/2d/using_tilemaps.html</link>


### PR DESCRIPTION
Closes #45367, because I confused collider metadata with collision *shape* metadata...

See use cases in
- https://github.com/godotengine/godot/issues/6256#issuecomment-292225864
- https://kidscancode.org/godot_recipes/2d/tilemap_collision/
