### PR TITLE
[4.0] [GUI] Fix LineEdit clearing

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -121,13 +121,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 			selection.creating = false;
 			selection.doubleclick = false;
 
-			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
-				if (selection.enabled) {
-					DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), false, max_length, selection.begin, selection.end);
-				} else {
-					DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), false, max_length, cursor_pos);
-				}
-			}
+			show_virtual_keyboard();
 		}
 
 		update();
@@ -953,14 +947,7 @@ void LineEdit::_notification(int p_what) {
 				DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + cursor_pos, get_viewport()->get_window_id());
 			}
 
-			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
-				if (selection.enabled) {
-					DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), false, max_length, selection.begin, selection.end);
-				} else {
-					DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), false, max_length, cursor_pos);
-				}
-			}
-
+			show_virtual_keyboard();
 		} break;
 		case NOTIFICATION_FOCUS_EXIT: {
 			if (caret_blink_enabled && !caret_force_displayed) {
@@ -1407,6 +1394,21 @@ Array LineEdit::get_structured_text_bidi_override_options() const {
 void LineEdit::clear() {
 	clear_internal();
 	_text_changed();
+
+	// This should reset virtual keyboard state if needed.
+	if (has_focus()) {
+		show_virtual_keyboard();
+	}
+}
+
+void LineEdit::show_virtual_keyboard() {
+	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
+		if (selection.enabled) {
+			DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), false, max_length, selection.begin, selection.end);
+		} else {
+			DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), false, max_length, cursor_pos);
+		}
+	}
 }
 
 String LineEdit::get_text() const {

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -306,6 +306,9 @@ public:
 	Ref<Texture2D> get_right_icon();
 
 	virtual bool is_text_field() const override;
+
+	void show_virtual_keyboard();
+
 	LineEdit();
 	~LineEdit();
 };


### PR DESCRIPTION
Fixes `LineEdit` not updating text value for iOS backing `UITextView`.
Also should fix Android's not clearing suggestions on clearing the `LineEdit`.

Fixes https://github.com/godotengine/godot/issues/45245 in `master`