### PR TITLE
[3.2] [GUI] Fix LineEdit clearing

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -128,13 +128,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 			selection.creating = false;
 			selection.doubleclick = false;
 
-			if (OS::get_singleton()->has_virtual_keyboard() && virtual_keyboard_enabled) {
-				if (selection.enabled) {
-					OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), false, max_length, selection.begin, selection.end);
-				} else {
-					OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), false, max_length, cursor_pos);
-				}
-			}
+			show_virtual_keyboard();
 		}
 
 		update();
@@ -930,13 +924,7 @@ void LineEdit::_notification(int p_what) {
 				OS::get_singleton()->set_ime_position(get_global_position() + cursor_pos2);
 			}
 
-			if (OS::get_singleton()->has_virtual_keyboard() && virtual_keyboard_enabled) {
-				if (selection.enabled) {
-					OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), false, max_length, selection.begin, selection.end);
-				} else {
-					OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), false, max_length, cursor_pos);
-				}
-			}
+			show_virtual_keyboard();
 		} break;
 		case NOTIFICATION_FOCUS_EXIT: {
 
@@ -1277,6 +1265,21 @@ void LineEdit::clear() {
 
 	clear_internal();
 	_text_changed();
+
+	// This should reset virtual keyboard state if needed.
+	if (has_focus()) {
+		show_virtual_keyboard();
+	}
+}
+
+void LineEdit::show_virtual_keyboard() {
+	if (OS::get_singleton()->has_virtual_keyboard() && virtual_keyboard_enabled) {
+		if (selection.enabled) {
+			OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), false, max_length, selection.begin, selection.end);
+		} else {
+			OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), false, max_length, cursor_pos);
+		}
+	}
 }
 
 String LineEdit::get_text() const {

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -242,6 +242,9 @@ public:
 	Ref<Texture> get_right_icon();
 
 	virtual bool is_text_field() const;
+
+	void show_virtual_keyboard();
+
 	LineEdit();
 	~LineEdit();
 };


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/45369 but for `3.2` branch.

Fixes `LineEdit` not updating text value for iOS backing `UITextView`.
Also should fix Android's not clearing suggestions on clearing the `LineEdit`.

Fixes #45245 in `3.2`

Should probably be also tested on Android, just to make sure this changes doesn't break anything.