### PR TITLE
[3.x] Prevent use of Opaque Pre-Pass's threshold on top of Alpha Scissor

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1695,9 +1695,13 @@ FRAGMENT_SHADER_CODE
 #endif // ALPHA_SCISSOR_USED
 
 #ifdef USE_DEPTH_PREPASS
+#if !defined(ALPHA_SCISSOR_USED)
+
 	if (alpha < 0.1) {
 		discard;
 	}
+
+#endif // not ALPHA_SCISSOR_USED
 #endif // USE_DEPTH_PREPASS
 
 #endif // !USE_SHADOW_TO_OPACITY
@@ -2255,9 +2259,13 @@ FRAGMENT_SHADER_CODE
 #endif // ALPHA_SCISSOR_USED
 
 #ifdef USE_DEPTH_PREPASS
+#if !defined(ALPHA_SCISSOR_USED)
+
 	if (alpha < 0.1) {
 		discard;
 	}
+
+#endif // not ALPHA_SCISSOR_USED
 #endif // USE_DEPTH_PREPASS
 
 #endif // !USE_SHADOW_TO_OPACITY

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1902,11 +1902,13 @@ FRAGMENT_SHADER_CODE
 #endif // ALPHA_SCISSOR_USED
 
 #ifdef USE_OPAQUE_PREPASS //ubershader-runtime
+#if !defined(ALPHA_SCISSOR_USED)
 
 	if (alpha < opaque_prepass_threshold) {
 		discard;
 	}
 
+#endif // not ALPHA_SCISSOR_USED
 #endif // USE_OPAQUE_PREPASS //ubershader-runtime
 
 #endif // !USE_SHADOW_TO_OPACITY
@@ -2282,10 +2284,13 @@ FRAGMENT_SHADER_CODE
 #endif // ALPHA_SCISSOR_USED
 
 #ifdef USE_OPAQUE_PREPASS //ubershader-runtime
+#if !defined(ALPHA_SCISSOR_USED)
+
 	if (alpha < opaque_prepass_threshold) {
 		discard;
 	}
 
+#endif // not ALPHA_SCISSOR_USED
 #endif // USE_OPAQUE_PREPASS //ubershader-runtime
 
 #endif // USE_SHADOW_TO_OPACITY


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
In SpatialMaterials and ShaderMaterials, both Alpha Scissor and Opaque Pre-Pass can discard fragments (== create fully-transparent pixels), but Opaque Pre-Pass has a hardcoded threshold of 0.1 that the end-developer cannot modify.

This PR makes SpatialMaterials use the alpha scissor threshold instead of Opaque Pre-Pass's own threshold whenever Alpha Scissor is in use. This prevents the strange behavior where any fragment with an ALPHA value under 0.1 would be discarded, no matter what Alpha Scissor value you set.

Using blue noise for ALPHA_SCISSOR and a radial gradient:

![image](https://user-images.githubusercontent.com/29317321/105544760-a2095780-5cfb-11eb-8ed4-898d677ff83c.png)
![image](https://user-images.githubusercontent.com/29317321/105544829-b0f00a00-5cfb-11eb-9be2-78ceeeb66d90.png)

Scene in image: [PrepassTesting.zip](https://github.com/godotengine/godot/files/5858488/PrepassTesting.zip)

Related: [#45288](https://github.com/godotengine/godot/pull/45288)

**Do tell me if this breaks the intent of Opaque Pre-Pass.**