### PR TITLE
Define GDNative sizes using sizeof(godot_real_t) and sizeof(int32_t)

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -211,11 +211,11 @@ Vector2i Vector2i::operator*(const Vector2i &p_v1) const {
 	return Vector2i(x * p_v1.x, y * p_v1.y);
 }
 
-Vector2i Vector2i::operator*(const int &rvalue) const {
+Vector2i Vector2i::operator*(const int32_t &rvalue) const {
 	return Vector2i(x * rvalue, y * rvalue);
 }
 
-void Vector2i::operator*=(const int &rvalue) {
+void Vector2i::operator*=(const int32_t &rvalue) {
 	x *= rvalue;
 	y *= rvalue;
 }
@@ -224,11 +224,11 @@ Vector2i Vector2i::operator/(const Vector2i &p_v1) const {
 	return Vector2i(x / p_v1.x, y / p_v1.y);
 }
 
-Vector2i Vector2i::operator/(const int &rvalue) const {
+Vector2i Vector2i::operator/(const int32_t &rvalue) const {
 	return Vector2i(x / rvalue, y / rvalue);
 }
 
-void Vector2i::operator/=(const int &rvalue) {
+void Vector2i::operator/=(const int32_t &rvalue) {
 	x /= rvalue;
 	y /= rvalue;
 }
@@ -237,11 +237,11 @@ Vector2i Vector2i::operator%(const Vector2i &p_v1) const {
 	return Vector2i(x % p_v1.x, y % p_v1.y);
 }
 
-Vector2i Vector2i::operator%(const int &rvalue) const {
+Vector2i Vector2i::operator%(const int32_t &rvalue) const {
 	return Vector2i(x % rvalue, y % rvalue);
 }
 
-void Vector2i::operator%=(const int &rvalue) {
+void Vector2i::operator%=(const int32_t &rvalue) {
 	x %= rvalue;
 	y %= rvalue;
 }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -265,18 +265,18 @@ struct Vector2i {
 	};
 
 	union {
-		int x = 0;
-		int width;
+		int32_t x = 0;
+		int32_t width;
 	};
 	union {
-		int y = 0;
-		int height;
+		int32_t y = 0;
+		int32_t height;
 	};
 
-	_FORCE_INLINE_ int &operator[](int p_idx) {
+	_FORCE_INLINE_ int32_t &operator[](int p_idx) {
 		return p_idx ? y : x;
 	}
-	_FORCE_INLINE_ const int &operator[](int p_idx) const {
+	_FORCE_INLINE_ const int32_t &operator[](int p_idx) const {
 		return p_idx ? y : x;
 	}
 
@@ -286,16 +286,16 @@ struct Vector2i {
 	void operator-=(const Vector2i &p_v);
 	Vector2i operator*(const Vector2i &p_v1) const;
 
-	Vector2i operator*(const int &rvalue) const;
-	void operator*=(const int &rvalue);
+	Vector2i operator*(const int32_t &rvalue) const;
+	void operator*=(const int32_t &rvalue);
 
 	Vector2i operator/(const Vector2i &p_v1) const;
-	Vector2i operator/(const int &rvalue) const;
-	void operator/=(const int &rvalue);
+	Vector2i operator/(const int32_t &rvalue) const;
+	void operator/=(const int32_t &rvalue);
 
 	Vector2i operator%(const Vector2i &p_v1) const;
-	Vector2i operator%(const int &rvalue) const;
-	void operator%=(const int &rvalue);
+	Vector2i operator%(const int32_t &rvalue) const;
+	void operator%=(const int32_t &rvalue);
 
 	Vector2i operator-() const;
 	bool operator<(const Vector2i &p_vec2) const { return (x == p_vec2.x) ? (y < p_vec2.y) : (x < p_vec2.x); }
@@ -317,10 +317,10 @@ struct Vector2i {
 
 	inline Vector2i() {}
 	inline Vector2i(const Vector2 &p_vec2) {
-		x = (int)p_vec2.x;
-		y = (int)p_vec2.y;
+		x = (int32_t)p_vec2.x;
+		y = (int32_t)p_vec2.y;
 	}
-	inline Vector2i(int p_x, int p_y) {
+	inline Vector2i(int32_t p_x, int32_t p_y) {
 		x = p_x;
 		y = p_y;
 	}

--- a/modules/gdnative/include/gdnative/aabb.h
+++ b/modules/gdnative/include/gdnative/aabb.h
@@ -35,9 +35,9 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
 
-#define GODOT_AABB_SIZE 24
+#define GODOT_AABB_SIZE (sizeof(godot_real_t) * 6)
 
 #ifndef GODOT_CORE_API_GODOT_AABB_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_AABB_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/basis.h
+++ b/modules/gdnative/include/gdnative/basis.h
@@ -35,9 +35,9 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
 
-#define GODOT_BASIS_SIZE 36
+#define GODOT_BASIS_SIZE (sizeof(godot_real_t) * 9)
 
 #ifndef GODOT_CORE_API_GODOT_BASIS_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_BASIS_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/math_defs.h
+++ b/modules/gdnative/include/gdnative/math_defs.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  color.h                                                              */
+/*  math_defs.h                                                          */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,31 +28,38 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_COLOR_H
-#define GODOT_COLOR_H
+#ifndef GODOT_GDNATIVE_MATH_DEFS_H
+#define GODOT_GDNATIVE_MATH_DEFS_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <gdnative/math_defs.h>
+#include <stdint.h>
 
-// Colors should always use 32-bit floats, so don't use real_t here.
-#define GODOT_COLOR_SIZE (sizeof(float) * 4)
+////// bool
 
-#ifndef GODOT_CORE_API_GODOT_COLOR_TYPE_DEFINED
-#define GODOT_CORE_API_GODOT_COLOR_TYPE_DEFINED
-typedef struct {
-	uint8_t _dont_touch_that[GODOT_COLOR_SIZE];
-} godot_color;
+typedef bool godot_bool;
+
+#define GODOT_TRUE 1
+#define GODOT_FALSE 0
+
+/////// int
+
+typedef int64_t godot_int;
+
+/////// float
+
+typedef double godot_float;
+
+#ifdef REAL_T_IS_DOUBLE
+typedef double godot_real_t;
+#else
+typedef float godot_real_t;
 #endif
-
-#include <gdnative/gdnative.h>
-
-void GDAPI godot_color_new(godot_color *p_self);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // GODOT_COLOR_H
+#endif // GODOT_C_H

--- a/modules/gdnative/include/gdnative/plane.h
+++ b/modules/gdnative/include/gdnative/plane.h
@@ -35,9 +35,9 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
 
-#define GODOT_PLANE_SIZE 16
+#define GODOT_PLANE_SIZE (sizeof(godot_real_t) * 4)
 
 #ifndef GODOT_CORE_API_GODOT_PLANE_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_PLANE_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/quat.h
+++ b/modules/gdnative/include/gdnative/quat.h
@@ -35,9 +35,9 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
 
-#define GODOT_QUAT_SIZE 16
+#define GODOT_QUAT_SIZE (sizeof(godot_real_t) * 4)
 
 #ifndef GODOT_CORE_API_GODOT_QUAT_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_QUAT_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/rect2.h
+++ b/modules/gdnative/include/gdnative/rect2.h
@@ -35,19 +35,23 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
+
+#define GODOT_RECT2_SIZE (sizeof(godot_real_t) * 4)
 
 #ifndef GODOT_CORE_API_GODOT_RECT2_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_RECT2_TYPE_DEFINED
 typedef struct godot_rect2 {
-	uint8_t _dont_touch_that[16];
+	uint8_t _dont_touch_that[GODOT_RECT2_SIZE];
 } godot_rect2;
 #endif
+
+#define GODOT_RECT2I_SIZE (sizeof(int32_t) * 4)
 
 #ifndef GODOT_CORE_API_GODOT_RECT2I_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_RECT2I_TYPE_DEFINED
 typedef struct godot_rect2i {
-	uint8_t _dont_touch_that[16];
+	uint8_t _dont_touch_that[GODOT_RECT2I_SIZE];
 } godot_rect2i;
 #endif
 

--- a/modules/gdnative/include/gdnative/transform.h
+++ b/modules/gdnative/include/gdnative/transform.h
@@ -35,9 +35,9 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
 
-#define GODOT_TRANSFORM_SIZE 48
+#define GODOT_TRANSFORM_SIZE (sizeof(godot_real_t) * 12)
 
 #ifndef GODOT_CORE_API_GODOT_TRANSFORM_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_TRANSFORM_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/transform2d.h
+++ b/modules/gdnative/include/gdnative/transform2d.h
@@ -35,9 +35,9 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
 
-#define GODOT_TRANSFORM2D_SIZE 24
+#define GODOT_TRANSFORM2D_SIZE (sizeof(godot_real_t) * 6)
 
 #ifndef GODOT_CORE_API_GODOT_TRANSFORM2D_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_TRANSFORM2D_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -35,24 +35,9 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
 
-////// bool
-
-typedef bool godot_bool;
-
-#define GODOT_TRUE 1
-#define GODOT_FALSE 0
-
-/////// int
-
-typedef int64_t godot_int;
-
-/////// float
-
-typedef double godot_float;
-
-#define GODOT_VARIANT_SIZE (16 + sizeof(int64_t))
+#define GODOT_VARIANT_SIZE (sizeof(godot_real_t) * 4 + sizeof(int64_t))
 
 #ifndef GODOT_CORE_API_GODOT_VARIANT_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_VARIANT_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/vector2.h
+++ b/modules/gdnative/include/gdnative/vector2.h
@@ -35,9 +35,9 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
 
-#define GODOT_VECTOR2_SIZE 8
+#define GODOT_VECTOR2_SIZE (sizeof(godot_real_t) * 2)
 
 #ifndef GODOT_CORE_API_GODOT_VECTOR2_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_VECTOR2_TYPE_DEFINED
@@ -46,7 +46,7 @@ typedef struct {
 } godot_vector2;
 #endif
 
-#define GODOT_VECTOR2I_SIZE 8
+#define GODOT_VECTOR2I_SIZE (sizeof(int32_t) * 2)
 
 #ifndef GODOT_CORE_API_GODOT_VECTOR2I_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_VECTOR2I_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/vector3.h
+++ b/modules/gdnative/include/gdnative/vector3.h
@@ -35,9 +35,9 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <gdnative/math_defs.h>
 
-#define GODOT_VECTOR3_SIZE 12
+#define GODOT_VECTOR3_SIZE (sizeof(godot_real_t) * 3)
 
 #ifndef GODOT_CORE_API_GODOT_VECTOR3_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_VECTOR3_TYPE_DEFINED
@@ -46,7 +46,7 @@ typedef struct {
 } godot_vector3;
 #endif
 
-#define GODOT_VECTOR3I_SIZE 12
+#define GODOT_VECTOR3I_SIZE (sizeof(int32_t) * 3)
 
 #ifndef GODOT_CORE_API_GODOT_VECTOR3I_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_VECTOR3I_TYPE_DEFINED


### PR DESCRIPTION
Previously these values were hard-coded, so it wouldn't work if `sizeof(real_t)` is some other size. I also defined Vector2i/Vector3i/Rect2i with `sizeof(int32_t)` for consistency. I could just add this to #21922 but this can be reviewed and merged by itself so I decided to submit it separately for @vnen and/or @bruvzg to look at.