### PR TITLE
Several GI related optimizations and fixes

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -3104,6 +3104,7 @@ VkRenderPass RenderingDeviceVulkan::_render_pass_create(const Vector<AttachmentF
 		// the read.  If this is a performance issue, one could track the actual last accessor of each resource, adding only that
 		// stage
 		switch (is_depth_stencil ? p_initial_depth_action : p_initial_color_action) {
+			case INITIAL_ACTION_CLEAR_REGION:
 			case INITIAL_ACTION_CLEAR: {
 				description.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 				description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -3116,9 +3117,9 @@ VkRenderPass RenderingDeviceVulkan::_render_pass_create(const Vector<AttachmentF
 					description.initialLayout = is_sampled ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : (is_storage ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 					description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 				} else if (p_format[i].usage_flags & TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
-					description.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-					description.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED; //don't care what is there
-					description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+					description.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+					description.initialLayout = is_sampled ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : (is_storage ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+					description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
 					dependency_from_external.srcStageMask |= reading_stages;
 				} else {
 					description.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
@@ -5726,11 +5727,18 @@ Error RenderingDeviceVulkan::_draw_list_render_pass_begin(Framebuffer *framebuff
 	render_pass_begin.pNext = nullptr;
 	render_pass_begin.renderPass = render_pass;
 	render_pass_begin.framebuffer = vkframebuffer;
-
+	/*
+	 * Given how API works, it makes sense to always fully operate on the whole framebuffer.
+	 * This allows better continue operations for operations like shadowmapping.
 	render_pass_begin.renderArea.extent.width = viewport_size.width;
 	render_pass_begin.renderArea.extent.height = viewport_size.height;
 	render_pass_begin.renderArea.offset.x = viewport_offset.x;
 	render_pass_begin.renderArea.offset.y = viewport_offset.y;
+	*/
+	render_pass_begin.renderArea.extent.width = framebuffer->size.width;
+	render_pass_begin.renderArea.extent.height = framebuffer->size.height;
+	render_pass_begin.renderArea.offset.x = 0;
+	render_pass_begin.renderArea.offset.y = 0;
 
 	Vector<VkClearValue> clear_values;
 	clear_values.resize(framebuffer->texture_ids.size());
@@ -5879,11 +5887,11 @@ RenderingDevice::DrawListID RenderingDeviceVulkan::draw_list_begin(RID p_framebu
 		viewport_offset = regioni.position;
 		viewport_size = regioni.size;
 
-		if (p_initial_color_action == INITIAL_ACTION_CLEAR) {
+		if (p_initial_color_action == INITIAL_ACTION_CLEAR_REGION) {
 			needs_clear_color = true;
 			p_initial_color_action = INITIAL_ACTION_KEEP;
 		}
-		if (p_initial_depth_action == INITIAL_ACTION_CLEAR) {
+		if (p_initial_depth_action == INITIAL_ACTION_CLEAR_REGION) {
 			needs_clear_depth = true;
 			p_initial_depth_action = INITIAL_ACTION_KEEP;
 		}
@@ -5969,11 +5977,11 @@ Error RenderingDeviceVulkan::draw_list_begin_split(RID p_framebuffer, uint32_t p
 		viewport_offset = regioni.position;
 		viewport_size = regioni.size;
 
-		if (p_initial_color_action == INITIAL_ACTION_CLEAR) {
+		if (p_initial_color_action == INITIAL_ACTION_CLEAR_REGION) {
 			needs_clear_color = true;
 			p_initial_color_action = INITIAL_ACTION_KEEP;
 		}
-		if (p_initial_depth_action == INITIAL_ACTION_CLEAR) {
+		if (p_initial_depth_action == INITIAL_ACTION_CLEAR_REGION) {
 			needs_clear_depth = true;
 			p_initial_depth_action = INITIAL_ACTION_KEEP;
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -498,6 +498,11 @@ void EditorNode::_notification(int p_what) {
 				float sss_scale = GLOBAL_GET("rendering/quality/subsurface_scattering/subsurface_scattering_scale");
 				float sss_depth_scale = GLOBAL_GET("rendering/quality/subsurface_scattering/subsurface_scattering_depth_scale");
 				RS::get_singleton()->sub_surface_scattering_set_scale(sss_scale, sss_depth_scale);
+
+				uint32_t directional_shadow_size = GLOBAL_GET("rendering/quality/directional_shadow/size");
+				uint32_t directional_shadow_16_bits = GLOBAL_GET("rendering/quality/directional_shadow/16_bits");
+				RS::get_singleton()->directional_shadow_atlas_set_size(directional_shadow_size, directional_shadow_16_bits);
+
 				RS::ShadowQuality shadows_quality = RS::ShadowQuality(int(GLOBAL_GET("rendering/quality/shadows/soft_shadow_quality")));
 				RS::get_singleton()->shadows_quality_set(shadows_quality);
 				RS::ShadowQuality directional_shadow_quality = RS::ShadowQuality(int(GLOBAL_GET("rendering/quality/directional_shadow/soft_shadow_quality")));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -516,6 +516,9 @@ void EditorNode::_notification(int p_what) {
 				RS::get_singleton()->environment_set_volumetric_fog_positional_shadow_shrink_size(GLOBAL_GET("rendering/volumetric_fog/positional_shadow_shrink"));
 				RS::get_singleton()->canvas_set_shadow_texture_size(GLOBAL_GET("rendering/quality/2d_shadow_atlas/size"));
 
+				bool use_half_res_gi = GLOBAL_DEF("rendering/quality/gi/use_half_resolution", false);
+				RS::get_singleton()->gi_set_use_half_resolution(use_half_res_gi);
+
 				bool snap_2d_transforms = GLOBAL_GET("rendering/quality/2d/snap_2d_transforms_to_pixel");
 				scene_root->set_snap_2d_transforms_to_pixel(snap_2d_transforms);
 				bool snap_2d_vertices = GLOBAL_GET("rendering/quality/2d/snap_2d_vertices_to_pixel");

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2445,12 +2445,14 @@ void Node3DEditorViewport::_notification(int p_what) {
 		//update shadow atlas if changed
 
 		int shadowmap_size = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/size");
+		bool shadowmap_16_bits = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/16_bits");
 		int atlas_q0 = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/quadrant_0_subdiv");
 		int atlas_q1 = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/quadrant_1_subdiv");
 		int atlas_q2 = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/quadrant_2_subdiv");
 		int atlas_q3 = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/quadrant_3_subdiv");
 
 		viewport->set_shadow_atlas_size(shadowmap_size);
+		viewport->set_shadow_atlas_16_bits(shadowmap_16_bits);
 		viewport->set_shadow_atlas_quadrant_subdiv(0, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q0));
 		viewport->set_shadow_atlas_quadrant_subdiv(1, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q1));
 		viewport->set_shadow_atlas_quadrant_subdiv(2, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q2));

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2151,11 +2151,6 @@ bool Main::start() {
 		}
 #endif
 
-		{
-			int directional_atlas_size = GLOBAL_GET("rendering/quality/directional_shadow/size");
-			RenderingServer::get_singleton()->directional_shadow_atlas_set_size(directional_atlas_size);
-		}
-
 		if (!editor && !project_manager) {
 			//standard helpers that can be changed from main config
 
@@ -2198,22 +2193,6 @@ bool Main::start() {
 #else
 			DisplayServer::get_singleton()->window_set_title(appname);
 #endif
-
-			int shadow_atlas_size = GLOBAL_GET("rendering/quality/shadow_atlas/size");
-			int shadow_atlas_q0_subdiv = GLOBAL_GET("rendering/quality/shadow_atlas/quadrant_0_subdiv");
-			int shadow_atlas_q1_subdiv = GLOBAL_GET("rendering/quality/shadow_atlas/quadrant_1_subdiv");
-			int shadow_atlas_q2_subdiv = GLOBAL_GET("rendering/quality/shadow_atlas/quadrant_2_subdiv");
-			int shadow_atlas_q3_subdiv = GLOBAL_GET("rendering/quality/shadow_atlas/quadrant_3_subdiv");
-
-			sml->get_root()->set_shadow_atlas_size(shadow_atlas_size);
-			sml->get_root()->set_shadow_atlas_quadrant_subdiv(0, Viewport::ShadowAtlasQuadrantSubdiv(
-																		 shadow_atlas_q0_subdiv));
-			sml->get_root()->set_shadow_atlas_quadrant_subdiv(1, Viewport::ShadowAtlasQuadrantSubdiv(
-																		 shadow_atlas_q1_subdiv));
-			sml->get_root()->set_shadow_atlas_quadrant_subdiv(2, Viewport::ShadowAtlasQuadrantSubdiv(
-																		 shadow_atlas_q2_subdiv));
-			sml->get_root()->set_shadow_atlas_quadrant_subdiv(3, Viewport::ShadowAtlasQuadrantSubdiv(
-																		 shadow_atlas_q3_subdiv));
 
 			bool snap_controls = GLOBAL_DEF("gui/common/snap_controls_to_pixels", true);
 			sml->get_root()->set_snap_controls_to_pixels(snap_controls);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -171,6 +171,8 @@ static bool disable_render_loop = false;
 static int fixed_fps = -1;
 static bool print_fps = false;
 
+bool profile_gpu = false;
+
 /* Helper methods */
 
 // Used by Mono module, should likely be registered in Engine singleton instead
@@ -357,6 +359,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --disable-crash-handler          Disable crash handler when supported by the platform code.\n");
 	OS::get_singleton()->print("  --fixed-fps <fps>                Force a fixed number of frames per second. This setting disables real-time synchronization.\n");
 	OS::get_singleton()->print("  --print-fps                      Print the frames per second to the stdout.\n");
+	OS::get_singleton()->print("  --profile-gpu                    Show a simple profile of the tasks that took more time during frame rendering.\n");
 	OS::get_singleton()->print("\n");
 
 	OS::get_singleton()->print("Standalone tools:\n");
@@ -1006,6 +1009,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			}
 		} else if (I->get() == "--print-fps") {
 			print_fps = true;
+		} else if (I->get() == "--profile-gpu") {
+			profile_gpu = true;
 		} else if (I->get() == "--disable-crash-handler") {
 			OS::get_singleton()->disable_crash_handler();
 		} else if (I->get() == "--skip-breakpoints") {
@@ -1573,6 +1578,10 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	rendering_server->init();
 	rendering_server->set_render_loop_enabled(!disable_render_loop);
+
+	if (profile_gpu) {
+		rendering_server->set_print_gpu_profile(true);
+	}
 
 	OS::get_singleton()->initialize_joypads();
 

--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -520,7 +520,10 @@ String GIProbe::get_configuration_warning() const {
 			warning += "\n\n";
 		}
 		warning += TTR("GIProbes are not supported by the GLES2 video driver.\nUse a BakedLightmap instead.");
+	} else if (probe_data.is_null()) {
+		warning += TTR("No GIProbe data set, so this node is disabled. Bake static objects to enable GI.");
 	}
+
 	return warning;
 }
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1372,6 +1372,26 @@ SceneTree::SceneTree() {
 	bool snap_2d_vertices = GLOBAL_DEF("rendering/quality/2d/snap_2d_vertices_to_pixel", false);
 	root->set_snap_2d_vertices_to_pixel(snap_2d_vertices);
 
+	int shadowmap_size = GLOBAL_DEF("rendering/quality/shadow_atlas/size", 4096);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384"));
+	GLOBAL_DEF("rendering/quality/shadow_atlas/size.mobile", 2048);
+	bool shadowmap_16_bits = GLOBAL_DEF("rendering/quality/shadow_atlas/16_bits", true);
+	int atlas_q0 = GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_0_subdiv", 2);
+	int atlas_q1 = GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_1_subdiv", 2);
+	int atlas_q2 = GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_2_subdiv", 3);
+	int atlas_q3 = GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_3_subdiv", 4);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/quadrant_0_subdiv", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/quadrant_0_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/quadrant_1_subdiv", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/quadrant_1_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/quadrant_2_subdiv", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/quadrant_2_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/quadrant_3_subdiv", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/quadrant_3_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
+
+	root->set_shadow_atlas_size(shadowmap_size);
+	root->set_shadow_atlas_16_bits(shadowmap_16_bits);
+	root->set_shadow_atlas_quadrant_subdiv(0, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q0));
+	root->set_shadow_atlas_quadrant_subdiv(1, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q1));
+	root->set_shadow_atlas_quadrant_subdiv(2, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q2));
+	root->set_shadow_atlas_quadrant_subdiv(3, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q3));
+
 	Viewport::SDFOversize sdf_oversize = Viewport::SDFOversize(int(GLOBAL_DEF("rendering/quality/2d_sdf/oversize", 1)));
 	root->set_sdf_oversize(sdf_oversize);
 	Viewport::SDFScale sdf_scale = Viewport::SDFScale(int(GLOBAL_DEF("rendering/quality/2d_sdf/scale", 1)));

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1416,18 +1416,26 @@ Ref<ViewportTexture> Viewport::get_texture() const {
 }
 
 void Viewport::set_shadow_atlas_size(int p_size) {
-	if (shadow_atlas_size == p_size) {
-		return;
-	}
-
 	shadow_atlas_size = p_size;
-	RS::get_singleton()->viewport_set_shadow_atlas_size(viewport, p_size);
+	RS::get_singleton()->viewport_set_shadow_atlas_size(viewport, p_size, shadow_atlas_16_bits);
 }
 
 int Viewport::get_shadow_atlas_size() const {
 	return shadow_atlas_size;
 }
 
+void Viewport::set_shadow_atlas_16_bits(bool p_16_bits) {
+	if (shadow_atlas_16_bits == p_16_bits) {
+		return;
+	}
+
+	shadow_atlas_16_bits = p_16_bits;
+	RS::get_singleton()->viewport_set_shadow_atlas_size(viewport, shadow_atlas_size, shadow_atlas_16_bits);
+}
+
+bool Viewport::get_shadow_atlas_16_bits() const {
+	return shadow_atlas_16_bits;
+}
 void Viewport::set_shadow_atlas_quadrant_subdiv(int p_quadrant, ShadowAtlasQuadrantSubdiv p_subdiv) {
 	ERR_FAIL_INDEX(p_quadrant, 4);
 	ERR_FAIL_INDEX(p_subdiv, SHADOW_ATLAS_QUADRANT_SUBDIV_MAX);
@@ -3481,6 +3489,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shadow_atlas_size", "size"), &Viewport::set_shadow_atlas_size);
 	ClassDB::bind_method(D_METHOD("get_shadow_atlas_size"), &Viewport::get_shadow_atlas_size);
 
+	ClassDB::bind_method(D_METHOD("set_shadow_atlas_16_bits", "enable"), &Viewport::set_shadow_atlas_16_bits);
+	ClassDB::bind_method(D_METHOD("get_shadow_atlas_16_bits"), &Viewport::get_shadow_atlas_16_bits);
+
 	ClassDB::bind_method(D_METHOD("set_snap_controls_to_pixels", "enabled"), &Viewport::set_snap_controls_to_pixels);
 	ClassDB::bind_method(D_METHOD("is_snap_controls_to_pixels_enabled"), &Viewport::is_snap_controls_to_pixels_enabled);
 
@@ -3548,6 +3559,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdf_scale", PROPERTY_HINT_ENUM, "100%,50%,25%"), "set_sdf_scale", "get_sdf_scale");
 	ADD_GROUP("Shadow Atlas", "shadow_atlas_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_atlas_size"), "set_shadow_atlas_size", "get_shadow_atlas_size");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shadow_atlas_16_bits"), "set_shadow_atlas_16_bits", "get_shadow_atlas_16_bits");
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_0", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 0);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_1", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 1);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_2", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 2);
@@ -3662,7 +3674,10 @@ Viewport::Viewport() {
 	physics_has_last_mousepos = false;
 	physics_last_mousepos = Vector2(Math_INF, Math_INF);
 
-	shadow_atlas_size = 0;
+	shadow_atlas_16_bits = true;
+	shadow_atlas_size = 2048;
+	set_shadow_atlas_size(shadow_atlas_size);
+
 	for (int i = 0; i < 4; i++) {
 		shadow_atlas_quadrant_subdiv[i] = SHADOW_ATLAS_QUADRANT_SUBDIV_MAX;
 	}

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -297,6 +297,7 @@ private:
 	DebugDraw debug_draw;
 
 	int shadow_atlas_size;
+	bool shadow_atlas_16_bits = true;
 	ShadowAtlasQuadrantSubdiv shadow_atlas_quadrant_subdiv[4];
 
 	MSAA msaa;
@@ -536,6 +537,9 @@ public:
 
 	void set_shadow_atlas_size(int p_size);
 	int get_shadow_atlas_size() const;
+
+	void set_shadow_atlas_16_bits(bool p_16_bits);
+	bool get_shadow_atlas_16_bits() const;
 
 	void set_shadow_atlas_quadrant_subdiv(int p_quadrant, ShadowAtlasQuadrantSubdiv p_subdiv);
 	ShadowAtlasQuadrantSubdiv get_shadow_atlas_quadrant_subdiv(int p_quadrant) const;

--- a/servers/rendering/renderer_rd/effects_rd.h
+++ b/servers/rendering/renderer_rd/effects_rd.h
@@ -234,18 +234,17 @@ class EffectsRD {
 	} luminance_reduce;
 
 	struct CopyToDPPushConstant {
-		int32_t screen_size[2];
-		int32_t dest_offset[2];
-		float bias;
 		float z_far;
 		float z_near;
 		uint32_t z_flip;
+		uint32_t pad;
+		float screen_rect[4];
 	};
 
 	struct CoptToDP {
 		CubeToDpShaderRD shader;
 		RID shader_version;
-		RID pipeline;
+		PipelineCacheRD pipeline;
 	} cube_to_dp;
 
 	struct BokehPushConstant {
@@ -687,7 +686,7 @@ public:
 
 	void cubemap_roughness(RID p_source_rd_texture, RID p_dest_framebuffer, uint32_t p_face_id, uint32_t p_sample_count, float p_roughness, float p_size);
 	void make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const Size2i &p_size);
-	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, float p_z_near, float p_z_far, float p_bias, bool p_dp_flip);
+	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dest_texture, const Rect2 &p_rect, float p_z_near, float p_z_far, bool p_dp_flip);
 	void luminance_reduction(RID p_source_texture, const Size2i p_source_size, const Vector<RID> p_reduce, RID p_prev_luminance, float p_min_luminance, float p_max_luminance, float p_adjust, bool p_set = false);
 	void bokeh_dof(RID p_base_texture, RID p_depth_texture, const Size2i &p_base_texture_size, RID p_secondary_texture, RID p_bokeh_texture1, RID p_bokeh_texture2, bool p_dof_far, float p_dof_far_begin, float p_dof_far_size, bool p_dof_near, float p_dof_near_begin, float p_dof_near_size, float p_bokeh_size, RS::DOFBokehShape p_bokeh_shape, RS::DOFBlurQuality p_quality, bool p_use_jitter, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_forward.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward.h
@@ -213,9 +213,6 @@ class RendererSceneRenderForward : public RendererSceneRenderRD {
 		RID normal_roughness_buffer;
 		RID giprobe_buffer;
 
-		RID ambient_buffer;
-		RID reflection_buffer;
-
 		RS::ViewportMSAA msaa;
 		RD::TextureSamples texture_samples;
 
@@ -236,7 +233,6 @@ class RendererSceneRenderForward : public RendererSceneRenderRD {
 
 		RID render_sdfgi_uniform_set;
 		void ensure_specular();
-		void ensure_gi();
 		void ensure_giprobe();
 		void clear();
 		virtual void configure(RID p_color_buffer, RID p_depth_buffer, int p_width, int p_height, RS::ViewportMSAA p_msaa);
@@ -258,8 +254,6 @@ class RendererSceneRenderForward : public RendererSceneRenderRD {
 	void _render_buffers_clear_uniform_set(RenderBufferDataForward *rb);
 	virtual void _render_buffers_uniform_set_changed(RID p_render_buffers);
 	virtual RID _render_buffers_get_normal_texture(RID p_render_buffers);
-	virtual RID _render_buffers_get_ambient_texture(RID p_render_buffers);
-	virtual RID _render_buffers_get_reflection_texture(RID p_render_buffers);
 
 	void _update_render_base_uniform_set();
 	RID _setup_sdfgi_render_pass_uniform_set(RID p_albedo_texture, RID p_emission_texture, RID p_emission_aniso_texture, RID p_geom_facing_texture);

--- a/servers/rendering/renderer_rd/renderer_scene_render_forward.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward.h
@@ -257,7 +257,7 @@ class RendererSceneRenderForward : public RendererSceneRenderRD {
 
 	void _update_render_base_uniform_set();
 	RID _setup_sdfgi_render_pass_uniform_set(RID p_albedo_texture, RID p_emission_texture, RID p_emission_aniso_texture, RID p_geom_facing_texture);
-	RID _setup_render_pass_uniform_set(RID p_render_buffers, RID p_radiance_texture, RID p_shadow_atlas, RID p_reflection_atlas, RID p_cluster_buffer, const PagedArray<RID> &p_gi_probes, const PagedArray<RID> &p_lightmaps);
+	RID _setup_render_pass_uniform_set(RID p_render_buffers, RID p_radiance_texture, RID p_shadow_atlas, RID p_reflection_atlas, RID p_cluster_buffer, const PagedArray<RID> &p_gi_probes, const PagedArray<RID> &p_lightmaps, bool p_use_directional_shadow_atlas = false);
 
 	struct LightmapData {
 		float normal_xform[12];
@@ -701,7 +701,7 @@ class RendererSceneRenderForward : public RendererSceneRenderRD {
 
 protected:
 	virtual void _render_scene(RID p_render_buffer, const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, const PagedArray<GeometryInstance *> &p_instances, int p_directional_light_count, const PagedArray<RID> &p_gi_probes, const PagedArray<RID> &p_lightmaps, RID p_environment, RID p_cluster_buffer, uint32_t p_cluster_size, uint32_t p_max_cluster_elements, RID p_camera_effects, RID p_shadow_atlas, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, const Color &p_default_bg_color, float p_lod_threshold);
-	virtual void _render_shadow(RID p_framebuffer, const PagedArray<GeometryInstance *> &p_instances, const CameraMatrix &p_projection, const Transform &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_use_dp, bool p_use_dp_flip, bool p_use_pancake, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0.0, float p_screen_lod_threshold = 0.0);
+	virtual void _render_shadow(RID p_framebuffer, const PagedArray<GeometryInstance *> &p_instances, const CameraMatrix &p_projection, const Transform &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_use_dp, bool use_dp_flip, bool p_use_pancake, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0.0, float p_screen_lod_threshold = 0.0, const Rect2i &p_rect = Rect2i(), bool p_flip_y = false, bool p_clear_region = true, bool p_begin = true, bool p_end = true);
 	virtual void _render_material(const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, const PagedArray<GeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region);
 	virtual void _render_uv2(const PagedArray<GeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region);
 	virtual void _render_sdfgi(RID p_render_buffers, const Vector3i &p_from, const Vector3i &p_size, const AABB &p_bounds, const PagedArray<GeometryInstance *> &p_instances, const RID &p_albedo_texture, const RID &p_emission_texture, const RID &p_emission_aniso_texture, const RID &p_geom_facing_texture);

--- a/servers/rendering/renderer_rd/shaders/cube_to_dp.glsl
+++ b/servers/rendering/renderer_rd/shaders/cube_to_dp.glsl
@@ -1,33 +1,48 @@
-#[compute]
+#[vertex]
 
 #version 450
 
 VERSION_DEFINES
 
-layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+layout(push_constant, binding = 1, std430) uniform Params {
+	float z_far;
+	float z_near;
+	bool z_flip;
+	uint pad;
+	vec4 screen_rect;
+}
+params;
+
+layout(location = 0) out vec2 uv_interp;
+
+void main() {
+	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
+	uv_interp = base_arr[gl_VertexIndex];
+	vec2 screen_pos = uv_interp * params.screen_rect.zw + params.screen_rect.xy;
+	gl_Position = vec4(screen_pos * 2.0 - 1.0, 0.0, 1.0);
+}
+
+#[fragment]
+
+#version 450
+
+VERSION_DEFINES
+
+layout(location = 0) in vec2 uv_interp;
 
 layout(set = 0, binding = 0) uniform samplerCube source_cube;
 
 layout(push_constant, binding = 1, std430) uniform Params {
-	ivec2 screen_size;
-	ivec2 offset;
-	float bias;
 	float z_far;
 	float z_near;
 	bool z_flip;
+	uint pad;
+	vec4 screen_rect;
 }
 params;
 
-layout(r32f, set = 1, binding = 0) uniform restrict writeonly image2D depth_buffer;
-
 void main() {
-	ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
-	if (any(greaterThan(pos, params.screen_size))) { //too large, do nothing
-		return;
-	}
-
-	vec2 pixel_size = 1.0 / vec2(params.screen_size);
-	vec2 uv = (vec2(pos) + 0.5) * pixel_size;
+	vec2 uv = uv_interp;
 
 	vec3 normal = vec3(uv * 2.0 - 1.0, 0.0);
 
@@ -65,5 +80,5 @@ void main() {
 	float linear_depth = 2.0 * params.z_near * params.z_far / (params.z_far + params.z_near - depth * (params.z_far - params.z_near));
 	depth = (linear_depth * depth_fix) / params.z_far;
 
-	imageStore(depth_buffer, pos + params.offset, vec4(depth));
+	gl_FragDepth = depth;
 }

--- a/servers/rendering/renderer_rd/shaders/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/gi.glsl
@@ -655,7 +655,8 @@ void main() {
 		return;
 	}
 
-	vec4 ambient_light = vec4(0.0), reflection_light = vec4(0.0);
+	vec4 ambient_light = vec4(0.0);
+	vec4 reflection_light = vec4(0.0);
 
 	vec3 vertex = reconstruct_position(pos);
 	vertex.y = -vertex.y;

--- a/servers/rendering/renderer_rd/shaders/resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/resolve.glsl
@@ -71,19 +71,19 @@ void main() {
 	group1.y = texelFetch(source_depth, pos, 1).r;
 
 	//4X
-	if (params.sample_count <= 4) {
+	if (params.sample_count >= 4) {
 		group1.z = texelFetch(source_depth, pos, 2).r;
 		group1.w = texelFetch(source_depth, pos, 3).r;
 	}
 	//8X
-	if (params.sample_count <= 8) {
+	if (params.sample_count >= 8) {
 		group2.x = texelFetch(source_depth, pos, 4).r;
 		group2.y = texelFetch(source_depth, pos, 5).r;
 		group2.z = texelFetch(source_depth, pos, 6).r;
 		group2.w = texelFetch(source_depth, pos, 7).r;
 	}
 	//16X
-	if (params.sample_count <= 16) {
+	if (params.sample_count >= 16) {
 		group3.x = texelFetch(source_depth, pos, 8).r;
 		group3.y = texelFetch(source_depth, pos, 9).r;
 		group3.z = texelFetch(source_depth, pos, 10).r;
@@ -115,7 +115,6 @@ void main() {
 		}
 		if (freq.w < min_f) {
 			best_index = 3;
-			min_f = freq.w;
 		}
 	} else if (params.sample_count == 8) {
 		vec4 freq0 = vec4(equal(group1, vec4(group1.x)));

--- a/servers/rendering/renderer_rd/shaders/resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/resolve.glsl
@@ -58,6 +58,117 @@ void main() {
 
 #else
 
+#if 1
+
+	vec4 group1;
+	vec4 group2;
+	vec4 group3;
+	vec4 group4;
+	int best_index = 0;
+
+	//2X
+	group1.x = texelFetch(source_depth, pos, 0).r;
+	group1.y = texelFetch(source_depth, pos, 1).r;
+
+	//4X
+	if (params.sample_count <= 4) {
+		group1.z = texelFetch(source_depth, pos, 2).r;
+		group1.w = texelFetch(source_depth, pos, 3).r;
+	}
+	//8X
+	if (params.sample_count <= 8) {
+		group2.x = texelFetch(source_depth, pos, 4).r;
+		group2.y = texelFetch(source_depth, pos, 5).r;
+		group2.z = texelFetch(source_depth, pos, 6).r;
+		group2.w = texelFetch(source_depth, pos, 7).r;
+	}
+	//16X
+	if (params.sample_count <= 16) {
+		group3.x = texelFetch(source_depth, pos, 8).r;
+		group3.y = texelFetch(source_depth, pos, 9).r;
+		group3.z = texelFetch(source_depth, pos, 10).r;
+		group3.w = texelFetch(source_depth, pos, 11).r;
+
+		group4.x = texelFetch(source_depth, pos, 12).r;
+		group4.y = texelFetch(source_depth, pos, 13).r;
+		group4.z = texelFetch(source_depth, pos, 14).r;
+		group4.w = texelFetch(source_depth, pos, 15).r;
+	}
+
+	if (params.sample_count == 2) {
+		best_index = (pos.x & 1) ^ ((pos.y >> 1) & 1); //not much can be done here
+	} else if (params.sample_count == 4) {
+		vec4 freq = vec4(equal(group1, vec4(group1.x)));
+		freq += vec4(equal(group1, vec4(group1.y)));
+		freq += vec4(equal(group1, vec4(group1.z)));
+		freq += vec4(equal(group1, vec4(group1.w)));
+
+		float min_f = freq.x;
+		best_index = 0;
+		if (freq.y < min_f) {
+			best_index = 1;
+			min_f = freq.y;
+		}
+		if (freq.z < min_f) {
+			best_index = 2;
+			min_f = freq.z;
+		}
+		if (freq.w < min_f) {
+			best_index = 3;
+			min_f = freq.w;
+		}
+	} else if (params.sample_count == 8) {
+		vec4 freq0 = vec4(equal(group1, vec4(group1.x)));
+		vec4 freq1 = vec4(equal(group2, vec4(group1.x)));
+		freq0 += vec4(equal(group1, vec4(group1.y)));
+		freq1 += vec4(equal(group2, vec4(group1.y)));
+		freq0 += vec4(equal(group1, vec4(group1.z)));
+		freq1 += vec4(equal(group2, vec4(group1.z)));
+		freq0 += vec4(equal(group1, vec4(group1.w)));
+		freq1 += vec4(equal(group2, vec4(group1.w)));
+		freq0 += vec4(equal(group1, vec4(group2.x)));
+		freq1 += vec4(equal(group2, vec4(group2.x)));
+		freq0 += vec4(equal(group1, vec4(group2.y)));
+		freq1 += vec4(equal(group2, vec4(group2.y)));
+		freq0 += vec4(equal(group1, vec4(group2.z)));
+		freq1 += vec4(equal(group2, vec4(group2.z)));
+		freq0 += vec4(equal(group1, vec4(group2.w)));
+		freq1 += vec4(equal(group2, vec4(group2.w)));
+
+		float min_f0 = freq0.x;
+		int best_index0 = 0;
+		if (freq0.y < min_f0) {
+			best_index0 = 1;
+			min_f0 = freq0.y;
+		}
+		if (freq0.z < min_f0) {
+			best_index0 = 2;
+			min_f0 = freq0.z;
+		}
+		if (freq0.w < min_f0) {
+			best_index0 = 3;
+			min_f0 = freq0.w;
+		}
+
+		float min_f1 = freq1.x;
+		int best_index1 = 4;
+		if (freq1.y < min_f1) {
+			best_index1 = 5;
+			min_f1 = freq1.y;
+		}
+		if (freq1.z < min_f1) {
+			best_index1 = 6;
+			min_f1 = freq1.z;
+		}
+		if (freq1.w < min_f1) {
+			best_index1 = 7;
+			min_f1 = freq1.w;
+		}
+
+		best_index = mix(best_index0, best_index1, min_f0 < min_f1);
+	}
+
+#else
 	float depths[16];
 	int depth_indices[16];
 	int depth_amount[16];
@@ -91,7 +202,7 @@ void main() {
 			depth_least = depth_amount[j];
 		}
 	}
-
+#endif
 	best_depth = texelFetch(source_depth, pos, best_index).r;
 	best_normal_roughness = texelFetch(source_normal_roughness, pos, best_index);
 #ifdef GIPROBE_RESOLVE

--- a/servers/rendering/renderer_rd/shaders/scene_forward.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward.glsl
@@ -2371,17 +2371,17 @@ FRAGMENT_SHADER_CODE
 
 	if (bool(draw_call.flags & INSTANCE_FLAGS_USE_GI_BUFFERS)) { //use GI buffers
 
-		ivec2 coord;
+		vec2 coord;
 
 		if (scene_data.gi_upscale_for_msaa) {
-			ivec2 base_coord = ivec2(gl_FragCoord.xy);
-			ivec2 closest_coord = base_coord;
-			float closest_ang = dot(normal, texelFetch(sampler2D(normal_roughness_buffer, material_samplers[SAMPLER_LINEAR_CLAMP]), base_coord, 0).xyz * 2.0 - 1.0);
+			vec2 base_coord = screen_uv;
+			vec2 closest_coord = base_coord;
+			float closest_ang = dot(normal, textureLod(sampler2D(normal_roughness_buffer, material_samplers[SAMPLER_LINEAR_CLAMP]), base_coord, 0.0).xyz * 2.0 - 1.0);
 
 			for (int i = 0; i < 4; i++) {
-				const ivec2 neighbours[4] = ivec2[](ivec2(-1, 0), ivec2(1, 0), ivec2(0, -1), ivec2(0, 1));
-				ivec2 neighbour_coord = base_coord + neighbours[i];
-				float neighbour_ang = dot(normal, texelFetch(sampler2D(normal_roughness_buffer, material_samplers[SAMPLER_LINEAR_CLAMP]), neighbour_coord, 0).xyz * 2.0 - 1.0);
+				const vec2 neighbours[4] = vec2[](vec2(-1, 0), vec2(1, 0), vec2(0, -1), vec2(0, 1));
+				vec2 neighbour_coord = base_coord + neighbours[i] * scene_data.screen_pixel_size;
+				float neighbour_ang = dot(normal, textureLod(sampler2D(normal_roughness_buffer, material_samplers[SAMPLER_LINEAR_CLAMP]), neighbour_coord, 0.0).xyz * 2.0 - 1.0);
 				if (neighbour_ang > closest_ang) {
 					closest_ang = neighbour_ang;
 					closest_coord = neighbour_coord;
@@ -2391,11 +2391,11 @@ FRAGMENT_SHADER_CODE
 			coord = closest_coord;
 
 		} else {
-			coord = ivec2(gl_FragCoord.xy);
+			coord = screen_uv;
 		}
 
-		vec4 buffer_ambient = texelFetch(sampler2D(ambient_buffer, material_samplers[SAMPLER_LINEAR_CLAMP]), coord, 0);
-		vec4 buffer_reflection = texelFetch(sampler2D(reflection_buffer, material_samplers[SAMPLER_LINEAR_CLAMP]), coord, 0);
+		vec4 buffer_ambient = textureLod(sampler2D(ambient_buffer, material_samplers[SAMPLER_LINEAR_CLAMP]), coord, 0.0);
+		vec4 buffer_reflection = textureLod(sampler2D(reflection_buffer, material_samplers[SAMPLER_LINEAR_CLAMP]), coord, 0.0);
 
 		ambient_light = mix(ambient_light, buffer_ambient.rgb, buffer_ambient.a);
 		specular_light = mix(specular_light, buffer_reflection.rgb, buffer_reflection.a);

--- a/servers/rendering/renderer_rd/shaders/scene_forward.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward.glsl
@@ -1282,7 +1282,7 @@ float light_process_spot_shadow(uint idx, vec3 vertex, vec3 normal) {
 		} else {
 #endif
 			//hard shadow
-			vec4 shadow_uv = vec4(splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy, z_norm, 1.0);
+			vec4 shadow_uv = vec4(splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy, splane.z, 1.0);
 
 			shadow = sample_pcf_shadow(shadow_atlas, spot_lights.data[idx].soft_shadow_scale * scene_data.shadow_atlas_pixel_size, shadow_uv);
 #ifdef USE_SOFT_SHADOWS

--- a/servers/rendering/renderer_rd/shaders/scene_forward_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_inc.glsl
@@ -153,22 +153,22 @@ scene_data;
 #define INSTANCE_FLAGS_SKELETON (1 << 19)
 #define INSTANCE_FLAGS_NON_UNIFORM_SCALE (1 << 20)
 
-layout(set = 0, binding = 5, std430) restrict readonly buffer OmniLights {
+layout(set = 0, binding = 4, std430) restrict readonly buffer OmniLights {
 	LightData data[];
 }
 omni_lights;
 
-layout(set = 0, binding = 6, std430) restrict readonly buffer SpotLights {
+layout(set = 0, binding = 5, std430) restrict readonly buffer SpotLights {
 	LightData data[];
 }
 spot_lights;
 
-layout(set = 0, binding = 7) buffer restrict readonly ReflectionProbeData {
+layout(set = 0, binding = 6) buffer restrict readonly ReflectionProbeData {
 	ReflectionData data[];
 }
 reflections;
 
-layout(set = 0, binding = 8, std140) uniform DirectionalLights {
+layout(set = 0, binding = 7, std140) uniform DirectionalLights {
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
 }
 directional_lights;
@@ -180,7 +180,7 @@ struct Lightmap {
 	mat3 normal_xform;
 };
 
-layout(set = 0, binding = 10, std140) restrict readonly buffer Lightmaps {
+layout(set = 0, binding = 8, std140) restrict readonly buffer Lightmaps {
 	Lightmap data[];
 }
 lightmaps;
@@ -189,22 +189,20 @@ struct LightmapCapture {
 	vec4 sh[9];
 };
 
-layout(set = 0, binding = 11, std140) restrict readonly buffer LightmapCaptures {
+layout(set = 0, binding = 9, std140) restrict readonly buffer LightmapCaptures {
 	LightmapCapture data[];
 }
 lightmap_captures;
 
-layout(set = 0, binding = 12) uniform texture2D decal_atlas;
-layout(set = 0, binding = 13) uniform texture2D decal_atlas_srgb;
+layout(set = 0, binding = 10) uniform texture2D decal_atlas;
+layout(set = 0, binding = 11) uniform texture2D decal_atlas_srgb;
 
-layout(set = 0, binding = 14, std430) restrict readonly buffer Decals {
+layout(set = 0, binding = 12, std430) restrict readonly buffer Decals {
 	DecalData data[];
 }
 decals;
 
-layout(set = 0, binding = 15) uniform texture2D directional_shadow_atlas;
-
-layout(set = 0, binding = 16, std430) restrict readonly buffer GlobalVariableData {
+layout(set = 0, binding = 13, std430) restrict readonly buffer GlobalVariableData {
 	vec4 data[];
 }
 global_variables;
@@ -218,7 +216,7 @@ struct SDFGIProbeCascadeData {
 	float to_cell; // 1/bounds * grid_size
 };
 
-layout(set = 0, binding = 17, std140) uniform SDFGI {
+layout(set = 0, binding = 14, std140) uniform SDFGI {
 	vec3 grid_size;
 	uint max_cascades;
 
@@ -268,13 +266,15 @@ layout(set = 1, binding = 1) uniform textureCubeArray reflection_atlas;
 
 layout(set = 1, binding = 2) uniform texture2D shadow_atlas;
 
-layout(set = 1, binding = 3) uniform texture2DArray lightmap_textures[MAX_LIGHTMAP_TEXTURES];
+layout(set = 1, binding = 3) uniform texture2D directional_shadow_atlas;
+
+layout(set = 1, binding = 4) uniform texture2DArray lightmap_textures[MAX_LIGHTMAP_TEXTURES];
 
 #ifndef LOW_END_MODE
-layout(set = 1, binding = 4) uniform texture3D gi_probe_textures[MAX_GI_PROBES];
+layout(set = 1, binding = 5) uniform texture3D gi_probe_textures[MAX_GI_PROBES];
 #endif
 
-layout(set = 1, binding = 5, std430) buffer restrict readonly ClusterBuffer {
+layout(set = 1, binding = 6, std430) buffer restrict readonly ClusterBuffer {
 	uint data[];
 }
 cluster_buffer;
@@ -283,10 +283,10 @@ cluster_buffer;
 
 #ifdef MODE_RENDER_SDF
 
-layout(r16ui, set = 1, binding = 6) uniform restrict writeonly uimage3D albedo_volume_grid;
-layout(r32ui, set = 1, binding = 7) uniform restrict writeonly uimage3D emission_grid;
-layout(r32ui, set = 1, binding = 8) uniform restrict writeonly uimage3D emission_aniso_grid;
-layout(r32ui, set = 1, binding = 9) uniform restrict uimage3D geom_facing_grid;
+layout(r16ui, set = 1, binding = 7) uniform restrict writeonly uimage3D albedo_volume_grid;
+layout(r32ui, set = 1, binding = 8) uniform restrict writeonly uimage3D emission_grid;
+layout(r32ui, set = 1, binding = 9) uniform restrict writeonly uimage3D emission_aniso_grid;
+layout(r32ui, set = 1, binding = 10) uniform restrict uimage3D geom_facing_grid;
 
 //still need to be present for shaders that use it, so remap them to something
 #define depth_buffer shadow_atlas
@@ -295,17 +295,17 @@ layout(r32ui, set = 1, binding = 9) uniform restrict uimage3D geom_facing_grid;
 
 #else
 
-layout(set = 1, binding = 6) uniform texture2D depth_buffer;
-layout(set = 1, binding = 7) uniform texture2D color_buffer;
+layout(set = 1, binding = 7) uniform texture2D depth_buffer;
+layout(set = 1, binding = 8) uniform texture2D color_buffer;
 
 #ifndef LOW_END_MODE
 
-layout(set = 1, binding = 8) uniform texture2D normal_roughness_buffer;
-layout(set = 1, binding = 9) uniform texture2D ao_buffer;
-layout(set = 1, binding = 10) uniform texture2D ambient_buffer;
-layout(set = 1, binding = 11) uniform texture2D reflection_buffer;
-layout(set = 1, binding = 12) uniform texture2DArray sdfgi_lightprobe_texture;
-layout(set = 1, binding = 13) uniform texture3D sdfgi_occlusion_cascades;
+layout(set = 1, binding = 9) uniform texture2D normal_roughness_buffer;
+layout(set = 1, binding = 10) uniform texture2D ao_buffer;
+layout(set = 1, binding = 11) uniform texture2D ambient_buffer;
+layout(set = 1, binding = 12) uniform texture2D reflection_buffer;
+layout(set = 1, binding = 13) uniform texture2DArray sdfgi_lightprobe_texture;
+layout(set = 1, binding = 14) uniform texture3D sdfgi_occlusion_cascades;
 
 struct GIProbeData {
 	mat4 xform;
@@ -323,12 +323,12 @@ struct GIProbeData {
 	uint mipmaps;
 };
 
-layout(set = 1, binding = 14, std140) uniform GIProbes {
+layout(set = 1, binding = 15, std140) uniform GIProbes {
 	GIProbeData data[MAX_GI_PROBES];
 }
 gi_probes;
 
-layout(set = 1, binding = 15) uniform texture3D volumetric_fog_texture;
+layout(set = 1, binding = 16) uniform texture3D volumetric_fog_texture;
 
 #endif // LOW_END_MODE
 

--- a/servers/rendering/renderer_rd/shaders/sdfgi_debug.glsl
+++ b/servers/rendering/renderer_rd/shaders/sdfgi_debug.glsl
@@ -97,6 +97,8 @@ void main() {
 	float blend = 0.0;
 
 #if 1
+	// No interpolation
+
 	vec3 inv_dir = 1.0 / ray_dir;
 
 	float rough = 0.5;
@@ -161,113 +163,10 @@ void main() {
 
 		hit_light *= (dot(max(vec3(0.0), (hit_normal * hit_aniso0)), vec3(1.0)) + dot(max(vec3(0.0), (-hit_normal * hit_aniso1)), vec3(1.0)));
 
-		if (blend > 0.0) {
-			light = mix(light, hit_light, blend);
-			blend = 0.0;
-		} else {
-			light = hit_light;
-
-			//process blend
-			float blend_from = (float(params.probe_axis_size - 1) / 2.0) - 2.5;
-			float blend_to = blend_from + 2.0;
-
-			vec3 cam_pos = params.cam_transform[3].xyz - cascades.data[i].offset;
-			cam_pos *= cascades.data[i].to_cell;
-
-			pos += ray_dir * min(advance, max_advance);
-			vec3 inner_pos = pos - cam_pos;
-
-			inner_pos = inner_pos * float(params.probe_axis_size - 1) / params.grid_size.x;
-
-			float len = length(inner_pos);
-
-			inner_pos = abs(normalize(inner_pos));
-			len *= max(inner_pos.x, max(inner_pos.y, inner_pos.z));
-
-			if (len >= blend_from) {
-				blend = smoothstep(blend_from, blend_to, len);
-
-				pos /= cascades.data[i].to_cell;
-				pos += cascades.data[i].offset;
-				ray_pos = pos;
-				hit = false; //continue trace for blend
-
-				continue;
-			}
-		}
+		light = hit_light;
 
 		break;
 	}
-
-	light = mix(light, vec3(0.0), blend);
-
-#else
-
-	vec3 inv_dir = 1.0 / ray_dir;
-
-	bool hit = false;
-	vec4 light_accum = vec4(0.0);
-
-	float blend_size = (params.grid_size.x / float(params.probe_axis_size - 1)) * 0.5;
-
-	float radius_sizes[MAX_CASCADES];
-	for (uint i = 0; i < params.max_cascades; i++) {
-		radius_sizes[i] = (1.0 / cascades.data[i].to_cell) * (params.grid_size.x * 0.5 - blend_size);
-	}
-
-	float max_distance = radius_sizes[params.max_cascades - 1];
-	float advance = 0;
-	while (advance < max_distance) {
-		for (uint i = 0; i < params.max_cascades; i++) {
-			if (advance < radius_sizes[i]) {
-				vec3 pos = (ray_pos + ray_dir * advance) - cascades.data[i].offset;
-				pos *= cascades.data[i].to_cell * pos_to_uvw;
-
-				float distance = texture(sampler3D(sdf_cascades[i], linear_sampler), pos).r * 255.0 - 1.0;
-
-				vec4 hit_light = vec4(0.0);
-				if (distance < 1.0) {
-					hit_light.a = max(0.0, 1.0 - distance);
-					hit_light.rgb = texture(sampler3D(light_cascades[i], linear_sampler), pos).rgb;
-					hit_light.rgb *= hit_light.a;
-				}
-
-				distance /= cascades.data[i].to_cell;
-
-				if (i < (params.max_cascades - 1)) {
-					pos = (ray_pos + ray_dir * advance) - cascades.data[i + 1].offset;
-					pos *= cascades.data[i + 1].to_cell * pos_to_uvw;
-
-					float distance2 = texture(sampler3D(sdf_cascades[i + 1], linear_sampler), pos).r * 255.0 - 1.0;
-
-					vec4 hit_light2 = vec4(0.0);
-					if (distance2 < 1.0) {
-						hit_light2.a = max(0.0, 1.0 - distance2);
-						hit_light2.rgb = texture(sampler3D(light_cascades[i + 1], linear_sampler), pos).rgb;
-						hit_light2.rgb *= hit_light2.a;
-					}
-
-					float prev_radius = i == 0 ? 0.0 : radius_sizes[i - 1];
-					float blend = (advance - prev_radius) / (radius_sizes[i] - prev_radius);
-
-					distance2 /= cascades.data[i + 1].to_cell;
-
-					hit_light = mix(hit_light, hit_light2, blend);
-					distance = mix(distance, distance2, blend);
-				}
-
-				light_accum += hit_light;
-				advance += distance;
-				break;
-			}
-		}
-
-		if (light_accum.a > 0.98) {
-			break;
-		}
-	}
-
-	light = light_accum.rgb / light_accum.a;
 
 #endif
 

--- a/servers/rendering/renderer_rd/shaders/sdfgi_direct_light.glsl
+++ b/servers/rendering/renderer_rd/shaders/sdfgi_direct_light.glsl
@@ -125,7 +125,10 @@ void main() {
 	uint voxel_index = uint(gl_GlobalInvocationID.x);
 
 	//used for skipping voxels every N frames
-	voxel_index = params.process_offset + voxel_index * params.process_increment;
+	if (params.process_increment > 1) {
+		voxel_index *= params.process_increment;
+		voxel_index += params.process_offset;
+	}
 
 	if (voxel_index >= dispatch_data.total_count) {
 		return;

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -95,7 +95,7 @@ public:
 	virtual Variant instance_geometry_get_shader_parameter(RID p_instance, const StringName &p_parameter) const = 0;
 	virtual Variant instance_geometry_get_shader_parameter_default_value(RID p_instance, const StringName &p_parameter) const = 0;
 
-	virtual void directional_shadow_atlas_set_size(int p_size) = 0;
+	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) = 0;
 
 	/* SKY API */
 
@@ -173,7 +173,7 @@ public:
 	virtual void directional_shadow_quality_set(RS::ShadowQuality p_quality) = 0;
 
 	virtual RID shadow_atlas_create() = 0;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size) = 0;
+	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_use_16_bits = false) = 0;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) = 0;
 
 	/* Render Buffers */

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -140,6 +140,7 @@ public:
 
 	virtual void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) = 0;
 	virtual void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) = 0;
+	virtual void environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) = 0;
 
 	virtual void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) = 0;
 
@@ -179,6 +180,8 @@ public:
 
 	virtual RID render_buffers_create() = 0;
 	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding) = 0;
+
+	virtual void gi_set_use_half_resolution(bool p_enable) = 0;
 
 	virtual void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) = 0;
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -795,6 +795,7 @@ public:
 			lightmaps.set_page_pool(p_rid_pool);
 			reflections.set_page_pool(p_rid_pool);
 			decals.set_page_pool(p_rid_pool);
+			gi_probes.set_page_pool(p_rid_pool);
 			mesh_instances.set_page_pool(p_rid_pool);
 			for (int i = 0; i < RendererSceneRender::MAX_DIRECTIONAL_LIGHTS; i++) {
 				for (int j = 0; j < RendererSceneRender::MAX_DIRECTIONAL_LIGHT_CASCADES; j++) {
@@ -995,6 +996,7 @@ public:
 	PASS11(environment_set_sdfgi, RID, bool, RS::EnvironmentSDFGICascades, float, RS::EnvironmentSDFGIYScale, bool, bool, bool, float, float, float)
 	PASS1(environment_set_sdfgi_ray_count, RS::EnvironmentSDFGIRayCount)
 	PASS1(environment_set_sdfgi_frames_to_converge, RS::EnvironmentSDFGIFramesToConverge)
+	PASS1(environment_set_sdfgi_frames_to_update_light, RS::EnvironmentSDFGIFramesToUpdateLight)
 
 	PASS1RC(RS::EnvironmentBG, environment_get_background, RID)
 	PASS1RC(int, environment_get_canvas_max_layer, RID)
@@ -1024,6 +1026,7 @@ public:
 
 	PASS0R(RID, render_buffers_create)
 	PASS7(render_buffers_configure, RID, RID, int, int, RS::ViewportMSAA, RS::ViewportScreenSpaceAA, bool)
+	PASS1(gi_set_use_half_resolution, bool)
 
 	/* Shadow Atlas */
 	PASS0R(RID, shadow_atlas_create)

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -947,7 +947,7 @@ public:
 
 #define PASSBASE scene_render
 
-	PASS1(directional_shadow_atlas_set_size, int)
+	PASS2(directional_shadow_atlas_set_size, int, bool)
 	PASS1(gi_probe_set_quality, RS::GIProbeQuality)
 
 	/* SKY API */
@@ -1030,7 +1030,7 @@ public:
 
 	/* Shadow Atlas */
 	PASS0R(RID, shadow_atlas_create)
-	PASS2(shadow_atlas_set_size, RID, int)
+	PASS3(shadow_atlas_set_size, RID, int, bool)
 	PASS3(shadow_atlas_set_quadrant_subdivision, RID, int, int)
 
 	PASS1(set_debug_draw_mode, RS::ViewportDebugDraw)

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -73,11 +73,11 @@ public:
 
 	virtual RID
 	shadow_atlas_create() = 0;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size) = 0;
+	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) = 0;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) = 0;
 	virtual bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) = 0;
 
-	virtual void directional_shadow_atlas_set_size(int p_size) = 0;
+	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) = 0;
 	virtual int get_directional_light_shadow_size(RID p_light_intance) = 0;
 	virtual void set_directional_shadow_count(int p_count) = 0;
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -136,6 +136,7 @@ public:
 
 	virtual void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) = 0;
 	virtual void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) = 0;
+	virtual void environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) = 0;
 
 	virtual void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) = 0;
 
@@ -208,6 +209,7 @@ public:
 
 	virtual RID render_buffers_create() = 0;
 	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding) = 0;
+	virtual void gi_set_use_half_resolution(bool p_enable) = 0;
 
 	virtual void screen_space_roughness_limiter_set_active(bool p_enable, float p_amount, float p_limit) = 0;
 	virtual bool screen_space_roughness_limiter_is_active() const = 0;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -831,13 +831,14 @@ void RendererViewport::viewport_set_canvas_stacking(RID p_viewport, RID p_canvas
 	viewport->canvas_map[p_canvas].sublayer = p_sublayer;
 }
 
-void RendererViewport::viewport_set_shadow_atlas_size(RID p_viewport, int p_size) {
+void RendererViewport::viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits) {
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);
 
 	viewport->shadow_atlas_size = p_size;
+	viewport->shadow_atlas_16_bits = p_16_bits;
 
-	RSG::scene->shadow_atlas_set_size(viewport->shadow_atlas, viewport->shadow_atlas_size);
+	RSG::scene->shadow_atlas_set_size(viewport->shadow_atlas, viewport->shadow_atlas_size, viewport->shadow_atlas_16_bits);
 }
 
 void RendererViewport::viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv) {

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -81,6 +81,7 @@ public:
 
 		RID shadow_atlas;
 		int shadow_atlas_size;
+		bool shadow_atlas_16_bits = false;
 
 		bool sdf_active;
 
@@ -217,7 +218,7 @@ public:
 	void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform);
 	void viewport_set_canvas_stacking(RID p_viewport, RID p_canvas, int p_layer, int p_sublayer);
 
-	void viewport_set_shadow_atlas_size(RID p_viewport, int p_size);
+	void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = false);
 	void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv);
 
 	void viewport_set_msaa(RID p_viewport, RS::ViewportMSAA p_msaa);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -745,6 +745,7 @@ void RenderingDevice::_bind_methods() {
 	BIND_ENUM_CONSTANT(DYNAMIC_STATE_STENCIL_REFERENCE);
 
 	BIND_ENUM_CONSTANT(INITIAL_ACTION_CLEAR); //start rendering and clear the framebuffer (supply params)
+	BIND_ENUM_CONSTANT(INITIAL_ACTION_CLEAR_REGION); //start rendering and clear the framebuffer (supply params)
 	BIND_ENUM_CONSTANT(INITIAL_ACTION_KEEP); //start rendering); but keep attached color texture contents (depth will be cleared)
 	BIND_ENUM_CONSTANT(INITIAL_ACTION_DROP); //start rendering); ignore what is there); just write above it
 	BIND_ENUM_CONSTANT(INITIAL_ACTION_CONTINUE); //continue rendering (framebuffer must have been left in "continue" state as final action previously)

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -931,7 +931,8 @@ public:
 	/********************/
 
 	enum InitialAction {
-		INITIAL_ACTION_CLEAR, //start rendering and clear the framebuffer (supply params)
+		INITIAL_ACTION_CLEAR, //start rendering and clear the whole framebuffer (region or not) (supply params)
+		INITIAL_ACTION_CLEAR_REGION, //start rendering and clear the framebuffer in the specified region (supply params)
 		INITIAL_ACTION_KEEP, //start rendering, but keep attached color texture contents (depth will be cleared)
 		INITIAL_ACTION_DROP, //start rendering, ignore what is there, just write above it
 		INITIAL_ACTION_CONTINUE, //continue rendering (framebuffer must have been left in "continue" state as final action previously)

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -551,7 +551,7 @@ public:
 
 	BIND2(viewport_set_global_canvas_transform, RID, const Transform2D &)
 	BIND4(viewport_set_canvas_stacking, RID, RID, int, int)
-	BIND2(viewport_set_shadow_atlas_size, RID, int)
+	BIND3(viewport_set_shadow_atlas_size, RID, int, bool)
 	BIND3(viewport_set_sdf_oversize_and_scale, RID, ViewportSDFOversize, ViewportSDFScale)
 	BIND3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	BIND2(viewport_set_msaa, RID, ViewportMSAA)
@@ -572,7 +572,7 @@ public:
 //from now on, calls forwarded to this singleton
 #define BINDBASE RSG::scene
 
-	BIND1(directional_shadow_atlas_set_size, int)
+	BIND2(directional_shadow_atlas_set_size, int, bool)
 	BIND1(gi_probe_set_quality, GIProbeQuality)
 
 	/* SKY API */

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -32,6 +32,7 @@
 #define RENDERING_SERVER_DEFAULT_H
 
 #include "core/math/octree.h"
+#include "core/templates/ordered_hash_map.h"
 #include "renderer_canvas_cull.h"
 #include "renderer_scene_cull.h"
 #include "renderer_viewport.h"
@@ -73,6 +74,12 @@ class RenderingServerDefault : public RenderingServer {
 	Vector<FrameProfileArea> frame_profile;
 
 	float frame_setup_time = 0;
+
+	//for printing
+	bool print_gpu_profile = false;
+	OrderedHashMap<String, float> print_gpu_profile_task_time;
+	uint64_t print_frame_profile_ticks_from = 0;
+	uint32_t print_frame_profile_frame_count = 0;
 
 public:
 	//if editor is redrawing when it shouldn't, enable this and put a breakpoint in _changes_changed()
@@ -616,6 +623,7 @@ public:
 	BIND11(environment_set_sdfgi, RID, bool, EnvironmentSDFGICascades, float, EnvironmentSDFGIYScale, bool, bool, bool, float, float, float)
 	BIND1(environment_set_sdfgi_ray_count, EnvironmentSDFGIRayCount)
 	BIND1(environment_set_sdfgi_frames_to_converge, EnvironmentSDFGIFramesToConverge)
+	BIND1(environment_set_sdfgi_frames_to_update_light, EnvironmentSDFGIFramesToUpdateLight)
 
 	BIND3R(Ref<Image>, environment_bake_panorama, RID, bool, const Size2i &)
 
@@ -687,6 +695,8 @@ public:
 	BIND2C(instance_geometry_get_shader_parameter_list, RID, List<PropertyInfo> *)
 
 	BIND3R(TypedArray<Image>, bake_render_uv2, RID, const Vector<RID> &, const Size2i &)
+
+	BIND1(gi_set_use_half_resolution, bool)
 
 #undef BINDBASE
 //from now on, calls forwarded to this singleton
@@ -864,6 +874,8 @@ public:
 	virtual bool is_low_end() const;
 
 	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir);
+
+	virtual void set_print_gpu_profile(bool p_enable);
 
 	RenderingServerDefault();
 	~RenderingServerDefault();

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -445,7 +445,7 @@ public:
 
 	FUNC2(viewport_set_global_canvas_transform, RID, const Transform2D &)
 	FUNC4(viewport_set_canvas_stacking, RID, RID, int, int)
-	FUNC2(viewport_set_shadow_atlas_size, RID, int)
+	FUNC3(viewport_set_shadow_atlas_size, RID, int, bool)
 	FUNC3(viewport_set_sdf_oversize_and_scale, RID, ViewportSDFOversize, ViewportSDFScale)
 
 	FUNC3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
@@ -470,7 +470,7 @@ public:
 		return rendering_server->viewport_get_measured_render_time_gpu(p_viewport);
 	}
 
-	FUNC1(directional_shadow_atlas_set_size, int)
+	FUNC2(directional_shadow_atlas_set_size, int, bool)
 
 	/* SKY API */
 

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -507,6 +507,7 @@ public:
 	FUNC11(environment_set_sdfgi, RID, bool, EnvironmentSDFGICascades, float, EnvironmentSDFGIYScale, bool, bool, bool, float, float, float)
 	FUNC1(environment_set_sdfgi_ray_count, EnvironmentSDFGIRayCount)
 	FUNC1(environment_set_sdfgi_frames_to_converge, EnvironmentSDFGIFramesToConverge)
+	FUNC1(environment_set_sdfgi_frames_to_update_light, EnvironmentSDFGIFramesToUpdateLight)
 
 	FUNC11(environment_set_glow, RID, bool, Vector<float>, float, float, float, float, EnvironmentGlowBlendMode, float, float, float)
 	FUNC1(environment_glow_set_use_bicubic_upscale, bool)
@@ -744,6 +745,8 @@ public:
 		return rendering_server->get_video_adapter_vendor();
 	}
 
+	FUNC1(gi_set_use_half_resolution, bool)
+
 	FUNC4(set_boot_image, const Ref<Image> &, const Color &, bool, bool)
 	FUNC1(set_default_clear_color, const Color &)
 
@@ -784,6 +787,10 @@ public:
 
 	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) {
 		rendering_server->sdfgi_set_debug_probe_select(p_position, p_dir);
+	}
+
+	virtual void set_print_gpu_profile(bool p_enable) {
+		rendering_server->set_print_gpu_profile(p_enable);
 	}
 
 	RenderingServerWrapMT(RenderingServer *p_contained, bool p_create_thread);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1661,7 +1661,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_transparent_background", "viewport", "enabled"), &RenderingServer::viewport_set_transparent_background);
 	ClassDB::bind_method(D_METHOD("viewport_set_global_canvas_transform", "viewport", "transform"), &RenderingServer::viewport_set_global_canvas_transform);
 	ClassDB::bind_method(D_METHOD("viewport_set_canvas_stacking", "viewport", "canvas", "layer", "sublayer"), &RenderingServer::viewport_set_canvas_stacking);
-	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_size", "viewport", "size"), &RenderingServer::viewport_set_shadow_atlas_size);
+	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_size", "viewport", "size", "use_16_bits"), &RenderingServer::viewport_set_shadow_atlas_size, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_quadrant_subdivision", "viewport", "quadrant", "subdivision"), &RenderingServer::viewport_set_shadow_atlas_quadrant_subdivision);
 	ClassDB::bind_method(D_METHOD("viewport_set_msaa", "viewport", "msaa"), &RenderingServer::viewport_set_msaa);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_debanding", "viewport", "enable"), &RenderingServer::viewport_set_use_debanding);
@@ -2272,6 +2272,7 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/quality/directional_shadow/soft_shadow_quality", 2);
 	GLOBAL_DEF("rendering/quality/directional_shadow/soft_shadow_quality.mobile", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/directional_shadow/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/quality/directional_shadow/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"));
+	GLOBAL_DEF("rendering/quality/directional_shadow/16_bits", true);
 
 	GLOBAL_DEF("rendering/quality/shadows/soft_shadow_quality", 2);
 	GLOBAL_DEF("rendering/quality/shadows/soft_shadow_quality.mobile", 0);
@@ -2281,18 +2282,6 @@ RenderingServer::RenderingServer() {
 
 	GLOBAL_DEF("rendering/quality/rd_renderer/use_low_end_renderer", false);
 	GLOBAL_DEF("rendering/quality/rd_renderer/use_low_end_renderer.mobile", true);
-
-	GLOBAL_DEF("rendering/quality/shadow_atlas/size", 4096);
-	GLOBAL_DEF("rendering/quality/shadow_atlas/size.mobile", 2048);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384"));
-	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_0_subdiv", 1);
-	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_1_subdiv", 2);
-	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_2_subdiv", 3);
-	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_3_subdiv", 4);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/quadrant_0_subdiv", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/quadrant_0_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/quadrant_1_subdiv", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/quadrant_1_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/quadrant_2_subdiv", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/quadrant_2_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/quadrant_3_subdiv", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/quadrant_3_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
 
 	GLOBAL_DEF("rendering/quality/reflections/roughness_layers", 8);
 	GLOBAL_DEF("rendering/quality/reflections/texture_array_reflections", true);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2304,6 +2304,8 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/quality/reflection_atlas/reflection_size.mobile", 128);
 	GLOBAL_DEF("rendering/quality/reflection_atlas/reflection_count", 64);
 
+	GLOBAL_DEF("rendering/quality/gi/use_half_resolution", false);
+
 	GLOBAL_DEF("rendering/quality/gi_probes/anisotropic", false);
 	GLOBAL_DEF("rendering/quality/gi_probes/quality", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/gi_probes/quality", PropertyInfo(Variant::INT, "rendering/quality/gi_probes/quality", PROPERTY_HINT_ENUM, "Low (4 Cones - Fast),High (6 Cones - Slow)"));
@@ -2367,10 +2369,12 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/lightmapper/probe_capture_update_speed", 15);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/lightmapper/probe_capture_update_speed", PropertyInfo(Variant::FLOAT, "rendering/lightmapper/probe_capture_update_speed", PROPERTY_HINT_RANGE, "0.001,256,0.001"));
 
-	GLOBAL_DEF("rendering/sdfgi/probe_ray_count", 2);
+	GLOBAL_DEF("rendering/sdfgi/probe_ray_count", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/sdfgi/probe_ray_count", PropertyInfo(Variant::INT, "rendering/sdfgi/probe_ray_count", PROPERTY_HINT_ENUM, "8 (Fastest),16,32,64,96,128 (Slowest)"));
-	GLOBAL_DEF("rendering/sdfgi/frames_to_converge", 1);
+	GLOBAL_DEF("rendering/sdfgi/frames_to_converge", 4);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/sdfgi/frames_to_converge", PropertyInfo(Variant::INT, "rendering/sdfgi/frames_to_converge", PROPERTY_HINT_ENUM, "5 (Less Latency but Lower Quality),10,15,20,25,30 (More Latency but Higher Quality)"));
+	GLOBAL_DEF("rendering/sdfgi/frames_to_update_lights", 2);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/sdfgi/frames_to_update_lights", PropertyInfo(Variant::INT, "rendering/sdfgi/frames_to_update_lights", PROPERTY_HINT_ENUM, "1 (Slower),2,4,8,16 (Faster)"));
 
 	GLOBAL_DEF("rendering/volumetric_fog/volume_size", 64);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/volumetric_fog/volume_size", PropertyInfo(Variant::INT, "rendering/volumetric_fog/volume_size", PROPERTY_HINT_RANGE, "16,512,1"));

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -798,7 +798,7 @@ public:
 
 	virtual void viewport_set_sdf_oversize_and_scale(RID p_viewport, ViewportSDFOversize p_oversize, ViewportSDFScale p_scale) = 0;
 
-	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size) = 0;
+	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = false) = 0;
 	virtual void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv) = 0;
 
 	enum ViewportMSAA {
@@ -868,7 +868,7 @@ public:
 	virtual float viewport_get_measured_render_time_cpu(RID p_viewport) const = 0;
 	virtual float viewport_get_measured_render_time_gpu(RID p_viewport) const = 0;
 
-	virtual void directional_shadow_atlas_set_size(int p_size) = 0;
+	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) = 0;
 
 	/* SKY API */
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -986,6 +986,7 @@ public:
 	virtual void environment_set_sdfgi(RID p_env, bool p_enable, EnvironmentSDFGICascades p_cascades, float p_min_cell_size, EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) = 0;
 
 	enum EnvironmentSDFGIRayCount {
+		ENV_SDFGI_RAY_COUNT_4,
 		ENV_SDFGI_RAY_COUNT_8,
 		ENV_SDFGI_RAY_COUNT_16,
 		ENV_SDFGI_RAY_COUNT_32,
@@ -1008,6 +1009,17 @@ public:
 	};
 
 	virtual void environment_set_sdfgi_frames_to_converge(EnvironmentSDFGIFramesToConverge p_frames) = 0;
+
+	enum EnvironmentSDFGIFramesToUpdateLight {
+		ENV_SDFGI_UPDATE_LIGHT_IN_1_FRAME,
+		ENV_SDFGI_UPDATE_LIGHT_IN_2_FRAMES,
+		ENV_SDFGI_UPDATE_LIGHT_IN_4_FRAMES,
+		ENV_SDFGI_UPDATE_LIGHT_IN_8_FRAMES,
+		ENV_SDFGI_UPDATE_LIGHT_IN_16_FRAMES,
+		ENV_SDFGI_UPDATE_LIGHT_MAX,
+	};
+
+	virtual void environment_set_sdfgi_frames_to_update_light(EnvironmentSDFGIFramesToUpdateLight p_update) = 0;
 
 	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective) = 0;
 
@@ -1430,6 +1442,8 @@ public:
 
 	virtual float get_frame_setup_time_cpu() const = 0;
 
+	virtual void gi_set_use_half_resolution(bool p_enable) = 0;
+
 	/* TESTING */
 
 	virtual RID get_test_cube() = 0;
@@ -1461,6 +1475,8 @@ public:
 	virtual void call_set_use_vsync(bool p_enable) = 0;
 
 	virtual bool is_low_end() const = 0;
+
+	virtual void set_print_gpu_profile(bool p_enable) = 0;
 
 	RenderingDevice *create_local_rendering_device() const;
 


### PR DESCRIPTION
-SDFGI direct light is done over many frames
-SDFGI Changed settings for rays/frame
-SDFGI Misc optimizations
-SDFGI Bug fix on probe scroll

-GIProbe was not working, got it to work again
-GIProbe dynamic objects were not working, fixed

-Added a half size GI option.

-Added a --profile-gpu command line option to make it easier to profile graphics from command line.

-All shadow rendering is done with raster now (no compute)
-All shadow rendering is done by rendering directly to the shadow atlas
-Improved how buffer clearing is done to optimize the above.
-16 bits shadow map support, and made the default