### PR TITLE
Two spaces after a comma

### DIFF
--- a/thirdparty/freetype/FTL.TXT
+++ b/thirdparty/freetype/FTL.TXT
@@ -158,7 +158,7 @@ Legal Terms
 
     o freetype-devel@nongnu.org
 
-      Discusses bugs,  as well  as engine internals,  design issues,
+      Discusses bugs, as well  as engine internals,  design issues,
       specific licenses, porting, etc.
 
   Our home page can be found at


### PR DESCRIPTION
As I was reading it I found two spaces after a comma so I fixed it. Because it is properly only one space.