### PR TITLE
Changed `non functional` to `non-functional` in  `platform/android/java/nativeSrcsConfigs/README.md`

### DIFF
--- a/platform/android/java/nativeSrcsConfigs/README.md
+++ b/platform/android/java/nativeSrcsConfigs/README.md
@@ -1,4 +1,4 @@
 ## Native sources configs
 
-This is a non functional Android library used to provide Android Studio editor support to the Godot project native files.
+This is a non-functional Android library used to provide Android Studio editor support to the Godot project native files.
 Nothing else should be added to this library.


### PR DESCRIPTION
Non-functional is proper spelling where as of non functional is not.