### PR TITLE
Fix freeze-crash in lightmapper under MinGW-GCC (3.2)

### DIFF
--- a/thirdparty/embree/common/sys/intrinsics.h
+++ b/thirdparty/embree/common/sys/intrinsics.h
@@ -11,12 +11,6 @@
 
 #include <immintrin.h>
 
-// -- GODOT start --
-#if defined(__WIN32__) && defined(__MINGW32__)
-#include <unistd.h>
-#endif
-// -- GODOT end --
-
 #if defined(__BMI__) && defined(__GNUC__) && !defined(__INTEL_COMPILER)
   #if !defined(_tzcnt_u32)
     #define _tzcnt_u32 __tzcnt_u32
@@ -425,16 +419,8 @@ namespace embree
   
   __forceinline void pause_cpu(const size_t N = 8)
   {
-// -- GODOT start --
     for (size_t i=0; i<N; i++)
-#if !(defined(__WIN32__) && defined(__MINGW32__))
-// -- GODOT end --
-      _mm_pause();    
-// -- GODOT start --
-#else
-      __builtin_ia32_pause();
-#endif
-// -- GODOT end --
+      _mm_pause();
   }
   
   /* prefetches */

--- a/thirdparty/embree/common/sys/mutex.h
+++ b/thirdparty/embree/common/sys/mutex.h
@@ -47,17 +47,8 @@ namespace embree
       {
         while (flag.load()) 
         {
-// -- GODOT start --
-#if !(defined (__WIN32__) && defined (__MINGW32__))
-// -- GODOT end --
-          _mm_pause(); 
           _mm_pause();
-// -- GODOT start --
-#else
-          __builtin_ia32_pause();
-          __builtin_ia32_pause();
-#endif
-// -- GODOT end --
+          _mm_pause();
         }
         
         bool expected = false;
@@ -83,17 +74,8 @@ namespace embree
     {
       while(flag.load())
       {
-// -- GODOT start --
-#if !(defined (__WIN32__) && defined(__MINGW32__))
-// -- GODOT end --
-        _mm_pause(); 
         _mm_pause();
-// -- GODOT start --
-#else
-        __builtin_ia32_pause();
-        __builtin_ia32_pause();
-#endif
-// -- GODOT end --
+        _mm_pause();
       }
     }
 

--- a/thirdparty/embree/common/sys/platform.h
+++ b/thirdparty/embree/common/sys/platform.h
@@ -91,7 +91,7 @@
 #define dll_import 
 #endif
 
-#ifdef __WIN32__
+#if defined(__WIN32__) && !defined(__MINGW32__)
 #if !defined(__noinline)
 #define __noinline             __declspec(noinline)
 #endif

--- a/thirdparty/embree/common/tasking/taskschedulerinternal.cpp
+++ b/thirdparty/embree/common/tasking/taskschedulerinternal.cpp
@@ -361,15 +361,7 @@ namespace embree
           if ((loopIndex % LOOP_YIELD_THRESHOLD) == 0)
             yield();
           else
-// -- GODOT start --
-#if !defined(__MINGW32__)
-// -- GODOT end --
             _mm_pause();
-// -- GODOT start --
-#else
-            __builtin_ia32_pause();
-#endif
-// -- GODOT end --
 	  loopIndex++;
 #else
           yield();


### PR DESCRIPTION
The nightly owl strikes again against #45097.

By using a more recent version of GCC for MinGW, I've been able to get a build that fails like the last, as reported by testers, so I think the results I get with this environment may be the same as with the one for the official builds.

Regarding the issues, after some digging I've found a couple of interesting things:
- `_mm_pause()` seems to be fine, so we don't need a replacement;
- the specifier for thread-local storage (and probably some others) was not being interpreted by GCC.

I've also removed the include for `unistd.h`, which I added for an older version of the patch.

With these changes I've been able to get a build that succeeds in lightmapping the test projects (with no LTO; haven't tried with it enabled).

Who knows? Maybe this is the good one...

**NOTE:** I haven't updated the patch file for this PR.