### PR TITLE
C# Go To Method for external editor

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -38,6 +38,8 @@
 #include "utils/naming_utils.h"
 #include "utils/string_utils.h"
 
+#include "modules/regex/regex.h"
+
 #ifdef GD_MONO_HOT_RELOAD
 #include "managed_callable.h"
 #include "utils/path_utils.h"
@@ -2751,8 +2753,23 @@ void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
 }
 
 int CSharpScript::get_member_line(const StringName &p_member) const {
-	// TODO omnisharp
-	return -1;
+	int p_line = -1;
+	RegEx pattern("\\w+\\s{0,}" + p_member + "\\s{0,}\\([^()]*\\)\\s{0,}\\{{1,}");
+	Ref<RegExMatch> ref = pattern.search(get_source_code());
+	if (ref != NULL) {
+		RegExMatch *match = ref.ptr();
+		String tmp_str = match->get_string(0).split("\n")[0];
+
+		Vector<String> source_code_line = get_source_code().split("\n");
+		for (int i = 0; i < source_code_line.size(); i = i + 1) {
+			int tmp_col = source_code_line[i].find(tmp_str);
+			if (tmp_col > 0) {
+				p_line = i;
+				break;
+			}
+		}
+	}
+	return p_line;
 }
 
 const Variant CSharpScript::get_rpc_config() const {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
(English from Google Translate)
Operation error, re PR, sorry .

This is a temporary code

mono maybe should use
`mono_debug_method_lookup_location`

Try to use 'mono_debug_method_lookup_location' in 'gd_mono_class->fetch_methods_with_godot_api_checks'.
Not familiar with MONO, so I failed.


![effect](https://user-images.githubusercontent.com/14800320/105317052-b74b8c80-5bfc-11eb-97fd-2085d90355a9.gif)

 Closed #45344
