### PR TITLE
Add String/Comment tracking, AutoComplete and hints to CodeEdit

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -474,9 +474,13 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	default_builtin_cache.insert("ui_text_completion_query", inputs);
 
 	inputs = List<Ref<InputEvent>>();
-	inputs.push_back(InputEventKey::create_reference(KEY_TAB));
 	inputs.push_back(InputEventKey::create_reference(KEY_ENTER));
+	inputs.push_back(InputEventKey::create_reference(KEY_KP_ENTER));
 	default_builtin_cache.insert("ui_text_completion_accept", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(KEY_TAB));
+	default_builtin_cache.insert("ui_text_completion_replace", inputs);
 
 	// Newlines
 	inputs = List<Ref<InputEvent>>();

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -242,6 +242,8 @@ public:
 };
 
 struct ScriptCodeCompletionOption {
+	/* Keep enum in Sync with:                               */
+	/* /scene/gui/code_edit.h - CodeEdit::CodeCompletionKind */
 	enum Kind {
 		KIND_CLASS,
 		KIND_FUNCTION,

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -8,6 +8,91 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_confirm_code_completion" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="replace" type="bool">
+			</argument>
+			<description>
+				Override this method to define how the selected entry should be inserted. If [code]replace[/code] is true, any existing text should be replaced.
+			</description>
+		</method>
+		<method name="_filter_code_completion_candidates" qualifiers="virtual">
+			<return type="Array">
+			</return>
+			<argument index="0" name="candidates" type="Array">
+			</argument>
+			<description>
+				Override this method to define what items in [code]candidates[/code] should be displayed.
+				Both [code]candidates[/code] and the return is a [Array] of [Dictionary], see [method get_code_completion_option] for [Dictionary] content.
+			</description>
+		</method>
+		<method name="_request_code_completion" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="force" type="bool">
+			</argument>
+			<description>
+				Override this method to define what happens when the user requests code completion. If [code]force[/code] is true, any checks should be bypassed.
+			</description>
+		</method>
+		<method name="add_code_completion_option">
+			<return type="void">
+			</return>
+			<argument index="0" name="type" type="int" enum="CodeEdit.CodeCompletionKind">
+			</argument>
+			<argument index="1" name="display_text" type="String">
+			</argument>
+			<argument index="2" name="insert_text" type="String">
+			</argument>
+			<argument index="3" name="text_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			</argument>
+			<argument index="4" name="icon" type="Resource" default="null">
+			</argument>
+			<argument index="5" name="value" type="Variant" default="0">
+			</argument>
+			<description>
+				Submits an item to the queue of potential candidates for the autocomplete menu. Call [method update_code_completion_options] to update the list.
+				[b]Note[/b]: This list will replace all current candidates.
+			</description>
+		</method>
+		<method name="add_comment_delimiter">
+			<return type="void">
+			</return>
+			<argument index="0" name="start_key" type="String">
+			</argument>
+			<argument index="1" name="end_key" type="String">
+			</argument>
+			<argument index="2" name="line_only" type="bool" default="false">
+			</argument>
+			<description>
+				Adds a comment delimiter.
+				Both the start and end keys must be symbols. Only the start key has to be unique.
+				Line only denotes if the region should continue until the end of the line or carry over on to the next line. If the end key is blank this is automatically set to [code]true[/code].
+			</description>
+		</method>
+		<method name="add_string_delimiter">
+			<return type="void">
+			</return>
+			<argument index="0" name="start_key" type="String">
+			</argument>
+			<argument index="1" name="end_key" type="String">
+			</argument>
+			<argument index="2" name="line_only" type="bool" default="false">
+			</argument>
+			<description>
+				Adds a string delimiter.
+				Both the start and end keys must be symbols. Only the start key has to be unique.
+				Line only denotes if the region should continue until the end of the line or carry over on to the next line. If the end key is blank this is automatically set to [code]true[/code].
+			</description>
+		</method>
+		<method name="cancel_code_completion">
+			<return type="void">
+			</return>
+			<description>
+				Cancels the autocomplete menu.
+			</description>
+		</method>
 		<method name="clear_bookmarked_lines">
 			<return type="void">
 			</return>
@@ -20,10 +105,33 @@
 			<description>
 			</description>
 		</method>
+		<method name="clear_comment_delimiters">
+			<return type="void">
+			</return>
+			<description>
+				Removes all comment delimiters.
+			</description>
+		</method>
 		<method name="clear_executing_lines">
 			<return type="void">
 			</return>
 			<description>
+			</description>
+		</method>
+		<method name="clear_string_delimiters">
+			<return type="void">
+			</return>
+			<description>
+				Removes all string delimiters.
+			</description>
+		</method>
+		<method name="confirm_code_completion">
+			<return type="void">
+			</return>
+			<argument index="0" name="replace" type="bool" default="false">
+			</argument>
+			<description>
+				Inserts the selected entry into the text. If [code]replace[/code] is true, any existing text is replaced rather then merged.
 			</description>
 		</method>
 		<method name="get_bookmarked_lines" qualifiers="const">
@@ -38,10 +146,126 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_code_completion_option" qualifiers="const">
+			<return type="Dictionary">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+				Gets the completion option at [code]index[/code]. The return [Dictionary] has the following key-values:
+				[code]kind[/code]: [enum CodeCompletionKind]
+				[code]display_text[/code]: Text that is shown on the autocomplete menu.
+				[code]insert_text[/code]: Text that is to be inserted when this item is selected.
+				[code]font_color[/code]: Color of the text on the autocomplete menu.
+				[code]icon[/code]: Icon to draw on the autocomplete menu.
+				[code]default_value[/code]: Value of the symbol.
+			</description>
+		</method>
+		<method name="get_code_completion_options" qualifiers="const">
+			<return type="Dictionary[]">
+			</return>
+			<description>
+				Gets all completion options, see [method get_code_completion_option] for return content.
+			</description>
+		</method>
+		<method name="get_code_completion_selected_index" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Gets the index of the current selected completion option.
+			</description>
+		</method>
+		<method name="get_delimiter_end_key" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="delimiter_index" type="int">
+			</argument>
+			<description>
+				Gets the end key for a string or comment region index.
+			</description>
+		</method>
+		<method name="get_delimiter_end_postion" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="column" type="int">
+			</argument>
+			<description>
+				If [code]line[/code] [code]column[/code] is in a string or comment, returns the end position of the region. If not or no end could be found, both [Vector2] values will be [code]-1[/code].
+			</description>
+		</method>
+		<method name="get_delimiter_start_key" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="delimiter_index" type="int">
+			</argument>
+			<description>
+				Gets the start key for a string or comment region index.
+			</description>
+		</method>
+		<method name="get_delimiter_start_postion" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="column" type="int">
+			</argument>
+			<description>
+				If [code]line[/code] [code]column[/code] is in a string or comment, returns the start position of the region. If not or no start could be found, both [Vector2] values will be [code]-1[/code].
+			</description>
+		</method>
 		<method name="get_executing_lines" qualifiers="const">
 			<return type="Array">
 			</return>
 			<description>
+			</description>
+		</method>
+		<method name="get_text_for_code_completion" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the full text with char [code]0xFFFF[/code] at the caret location.
+			</description>
+		</method>
+		<method name="has_comment_delimiter" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="start_key" type="String">
+			</argument>
+			<description>
+				Returns [code]true[/code] if comment [code]start_key[/code] exists.
+			</description>
+		</method>
+		<method name="has_string_delimiter" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="start_key" type="String">
+			</argument>
+			<description>
+				Returns [code]true[/code] if string [code]start_key[/code] exists.
+			</description>
+		</method>
+		<method name="is_in_comment" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="column" type="int" default="-1">
+			</argument>
+			<description>
+				Return delimiter index if [code]line[/code] [code]column[/code] is in a comment. If [code]column[/code] is not provided, will return delimiter index if the entire [code]line[/code] is a comment. Otherwise [code]-1[/code].
+			</description>
+		</method>
+		<method name="is_in_string" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="column" type="int" default="-1">
+			</argument>
+			<description>
+				Return the delimiter index if [code]line[/code] [code]column[/code] is in a string. If [code]column[/code] is not provided, will return the delimiter index if the entire [code]line[/code] is a string. Otherwise [code]-1[/code].
 			</description>
 		</method>
 		<method name="is_line_bookmarked" qualifiers="const">
@@ -66,6 +290,60 @@
 			<argument index="0" name="line" type="int">
 			</argument>
 			<description>
+			</description>
+		</method>
+		<method name="remove_comment_delimiter">
+			<return type="void">
+			</return>
+			<argument index="0" name="start_key" type="String">
+			</argument>
+			<description>
+				Removes the comment delimiter with [code]start_key[/code].
+			</description>
+		</method>
+		<method name="remove_string_delimiter">
+			<return type="void">
+			</return>
+			<argument index="0" name="start_key" type="String">
+			</argument>
+			<description>
+				Removes the string delimiter with [code]start_key[/code].
+			</description>
+		</method>
+		<method name="request_code_completion">
+			<return type="void">
+			</return>
+			<argument index="0" name="force" type="bool" default="false">
+			</argument>
+			<description>
+				Emits [signal request_code_completion], if [code]force[/code] is true will bypass all checks. Otherwise will check that the caret is in a word or in front of a prefix. Will ignore the request if all current options are of type file path, node path or signal.
+			</description>
+		</method>
+		<method name="set_code_completion_selected_index">
+			<return type="void">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+				Sets the current selected completion option.
+			</description>
+		</method>
+		<method name="set_code_hint">
+			<return type="void">
+			</return>
+			<argument index="0" name="code_hint" type="String">
+			</argument>
+			<description>
+				Sets the code hint text. Pass an empty string to clear.
+			</description>
+		</method>
+		<method name="set_code_hint_draw_below">
+			<return type="void">
+			</return>
+			<argument index="0" name="draw_below" type="bool">
+			</argument>
+			<description>
+				Sets if the code hint should draw below the text.
 			</description>
 		</method>
 		<method name="set_line_as_bookmarked">
@@ -98,8 +376,30 @@
 			<description>
 			</description>
 		</method>
+		<method name="update_code_completion_options">
+			<return type="void">
+			</return>
+			<argument index="0" name="force" type="bool">
+			</argument>
+			<description>
+				Submits all completion options added with [method add_code_completion_option]. Will try to force the autoccomplete menu to popup, if [code]force[/code] is [code]true[/code].
+				[b]Note[/b]: This will replace all current candidates.
+			</description>
+		</method>
 	</methods>
 	<members>
+		<member name="code_completion_enabled" type="bool" setter="set_code_completion_enabled" getter="is_code_completion_enabled" default="false">
+			Sets whether code completion is allowed.
+		</member>
+		<member name="code_completion_prefixes" type="String[]" setter="set_code_completion_prefixes" getter="get_code_comletion_prefixes" default="[  ]">
+			Sets prefixes that will trigger code completion.
+		</member>
+		<member name="delimiter_comments" type="String[]" setter="set_comment_delimiters" getter="get_comment_delimiters" default="[  ]">
+			Sets the comment delimiters. All existing comment delimiters will be removed.
+		</member>
+		<member name="delimiter_strings" type="String[]" setter="set_string_delimiters" getter="get_string_delimiters" default="[  ]">
+			Sets the string delimiters. All existing string delimiters will be removed.
+		</member>
 		<member name="draw_bookmarks" type="bool" setter="set_draw_bookmarks_gutter" getter="is_drawing_bookmarks_gutter" default="false">
 		</member>
 		<member name="draw_breakpoints_gutter" type="bool" setter="set_draw_breakpoints_gutter" getter="is_drawing_breakpoints_gutter" default="false">
@@ -123,8 +423,33 @@
 			<description>
 			</description>
 		</signal>
+		<signal name="request_code_completion">
+			<description>
+				Emitted when the user requests code completion.
+			</description>
+		</signal>
 	</signals>
 	<constants>
+		<constant name="KIND_CLASS" value="0" enum="CodeCompletionKind">
+		</constant>
+		<constant name="KIND_FUNCTION" value="1" enum="CodeCompletionKind">
+		</constant>
+		<constant name="KIND_SIGNAL" value="2" enum="CodeCompletionKind">
+		</constant>
+		<constant name="KIND_VARIABLE" value="3" enum="CodeCompletionKind">
+		</constant>
+		<constant name="KIND_MEMBER" value="4" enum="CodeCompletionKind">
+		</constant>
+		<constant name="KIND_ENUM" value="5" enum="CodeCompletionKind">
+		</constant>
+		<constant name="KIND_CONSTANT" value="6" enum="CodeCompletionKind">
+		</constant>
+		<constant name="KIND_NODE_PATH" value="7" enum="CodeCompletionKind">
+		</constant>
+		<constant name="KIND_FILE_PATH" value="8" enum="CodeCompletionKind">
+		</constant>
+		<constant name="KIND_PLAIN_TEXT" value="9" enum="CodeCompletionKind">
+		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="background_color" type="Color" default="Color( 0, 0, 0, 0 )">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -703,6 +703,8 @@
 		</member>
 		<member name="input/ui_text_completion_query" type="Dictionary" setter="" getter="">
 		</member>
+		<member name="input/ui_text_completion_replace" type="Dictionary" setter="" getter="">
+		</member>
 		<member name="input/ui_text_dedent" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_delete" type="Dictionary" setter="" getter="">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -128,6 +128,13 @@
 				Folds the given line, if possible (see [method can_fold]).
 			</description>
 		</method>
+		<method name="get_caret_draw_pos" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<description>
+				Gets the caret pixel draw poistion.
+			</description>
+		</method>
 		<method name="get_gutter_count" qualifiers="const">
 			<return type="int">
 			</return>
@@ -313,6 +320,13 @@
 			</argument>
 			<description>
 				Insert the specified text at the cursor position.
+			</description>
+		</method>
+		<method name="is_caret_visible" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the caret is visible on the screen.
 			</description>
 		</method>
 		<method name="is_folded" qualifiers="const">
@@ -812,10 +826,6 @@
 			<description>
 			</description>
 		</signal>
-		<signal name="request_completion">
-			<description>
-			</description>
-		</signal>
 		<signal name="symbol_lookup">
 			<argument index="0" name="symbol" type="String">
 			</argument>
@@ -963,24 +973,6 @@
 		<theme_item name="caret_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 		</theme_item>
 		<theme_item name="code_folding_color" type="Color" default="Color( 0.8, 0.8, 0.8, 0.8 )">
-		</theme_item>
-		<theme_item name="completion" type="StyleBox">
-		</theme_item>
-		<theme_item name="completion_background_color" type="Color" default="Color( 0.17, 0.16, 0.2, 1 )">
-		</theme_item>
-		<theme_item name="completion_existing_color" type="Color" default="Color( 0.87, 0.87, 0.87, 0.13 )">
-		</theme_item>
-		<theme_item name="completion_font_color" type="Color" default="Color( 0.67, 0.67, 0.67, 1 )">
-		</theme_item>
-		<theme_item name="completion_lines" type="int" default="7">
-		</theme_item>
-		<theme_item name="completion_max_width" type="int" default="50">
-		</theme_item>
-		<theme_item name="completion_scroll_color" type="Color" default="Color( 1, 1, 1, 1 )">
-		</theme_item>
-		<theme_item name="completion_scroll_width" type="int" default="3">
-		</theme_item>
-		<theme_item name="completion_selected_color" type="Color" default="Color( 0.26, 0.26, 0.27, 1 )">
 		</theme_item>
 		<theme_item name="current_line_color" type="Color" default="Color( 0.25, 0.25, 0.26, 0.8 )">
 			Sets the [Color] of the breakpoints. [member breakpoint_gutter] has to be enabled.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1564,9 +1564,7 @@ void CodeTextEditor::_on_settings_change() {
 			EDITOR_GET("text_editor/completion/code_complete_delay"));
 
 	// Call hint settings.
-	text_editor->set_callhint_settings(
-			EDITOR_GET("text_editor/completion/put_callhint_tooltip_below_current_line"),
-			EDITOR_GET("text_editor/completion/callhint_tooltip_offset"));
+	text_editor->set_code_hint_draw_below(EDITOR_GET("text_editor/completion/put_callhint_tooltip_below_current_line"));
 
 	idle->set_wait_time(EDITOR_GET("text_editor/completion/idle_parse_delay"));
 }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -571,7 +571,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/completion/code_complete_delay", 0.3);
 	hints["text_editor/completion/code_complete_delay"] = PropertyInfo(Variant::FLOAT, "text_editor/completion/code_complete_delay", PROPERTY_HINT_RANGE, "0.01, 5, 0.01");
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);
-	_initial_set("text_editor/completion/callhint_tooltip_offset", Vector2());
 	_initial_set("text_editor/completion/complete_file_paths", true);
 	_initial_set("text_editor/completion/add_type_hints", false);
 	_initial_set("text_editor/completion/use_single_quotes", false);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -203,6 +203,26 @@ void ScriptTextEditor::_set_theme_for_script() {
 	CodeEdit *text_edit = code_editor->get_text_editor();
 	text_edit->get_syntax_highlighter()->update_cache();
 
+	List<String> strings;
+	script->get_language()->get_string_delimiters(&strings);
+	text_edit->clear_string_delimiters();
+	for (List<String>::Element *E = strings.front(); E; E = E->next()) {
+		String string = E->get();
+		String beg = string.get_slice(" ", 0);
+		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
+		text_edit->add_string_delimiter(beg, end, end == "");
+	}
+
+	List<String> comments;
+	script->get_language()->get_comment_delimiters(&comments);
+	text_edit->clear_comment_delimiters();
+	for (List<String>::Element *E = comments.front(); E; E = E->next()) {
+		String comment = E->get();
+		String beg = comment.get_slice(" ", 0);
+		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
+		text_edit->add_comment_delimiter(beg, end, end == "");
+	}
+
 	/* add keywords for auto completion */
 	// singleton autoloads (as types, just as engine singletons are)
 	Map<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1824,9 +1824,7 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	update_settings();
 
-	code_editor->get_text_editor()->set_callhint_settings(
-			EditorSettings::get_singleton()->get("text_editor/completion/put_callhint_tooltip_below_current_line"),
-			EditorSettings::get_singleton()->get("text_editor/completion/callhint_tooltip_offset"));
+	code_editor->get_text_editor()->set_code_hint_draw_below(EditorSettings::get_singleton()->get("text_editor/completion/put_callhint_tooltip_below_current_line"));
 
 	code_editor->get_text_editor()->set_select_identifiers_on_hover(true);
 	code_editor->get_text_editor()->set_context_menu_enabled(false);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1076,7 +1076,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			_edit_option_toggle_inline_comment();
 		} break;
 		case EDIT_COMPLETE: {
-			tx->query_code_comple();
+			tx->request_code_completion(true);
 		} break;
 		case EDIT_AUTO_INDENT: {
 			String text = tx->get_text();

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -663,9 +663,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &ShaderEditor::_editor_settings_changed));
 	ProjectSettingsEditor::get_singleton()->connect("confirmed", callable_mp(this, &ShaderEditor::_project_settings_changed));
 
-	shader_editor->get_text_editor()->set_callhint_settings(
-			EditorSettings::get_singleton()->get("text_editor/completion/put_callhint_tooltip_below_current_line"),
-			EditorSettings::get_singleton()->get("text_editor/completion/callhint_tooltip_offset"));
+	shader_editor->get_text_editor()->set_code_hint_draw_below(EditorSettings::get_singleton()->get("text_editor/completion/put_callhint_tooltip_below_current_line"));
 
 	shader_editor->get_text_editor()->set_select_identifiers_on_hover(true);
 	shader_editor->get_text_editor()->set_context_menu_enabled(false);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -352,7 +352,7 @@ void ShaderEditor::_menu_option(int p_option) {
 
 		} break;
 		case EDIT_COMPLETE: {
-			shader_editor->get_text_editor()->query_code_comple();
+			shader_editor->get_text_editor()->request_code_completion();
 		} break;
 		case SEARCH_FIND: {
 			shader_editor->get_find_replace_bar()->popup_search();

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -154,6 +154,10 @@ void ShaderTextEditor::_load_theme_settings() {
 	syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
 	syntax_highlighter->add_color_region("//", "", comment_color, true);
 
+	text_editor->clear_comment_delimiters();
+	text_editor->add_comment_delimiter("/*", "*/", false);
+	text_editor->add_comment_delimiter("//", "", true);
+
 	if (warnings_panel) {
 		// Warnings panel
 		warnings_panel->add_theme_font_override("normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("main", "EditorFonts"));

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -848,6 +848,10 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		expression_syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
 		expression_syntax_highlighter->add_color_region("//", "", comment_color, true);
 
+		expression_box->clear_comment_delimiters();
+		expression_box->add_comment_delimiter("/*", "*/", false);
+		expression_box->add_comment_delimiter("//", "", true);
+
 		expression_box->set_text(expression);
 		expression_box->set_context_menu_enabled(false);
 		expression_box->set_draw_line_numbers(true);
@@ -2983,6 +2987,10 @@ void VisualShaderEditor::_notification(int p_what) {
 			syntax_highlighter->clear_color_regions();
 			syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
 			syntax_highlighter->add_color_region("//", "", comment_color, true);
+
+			preview_text->clear_comment_delimiters();
+			preview_text->add_comment_delimiter("/*", "*/", false);
+			preview_text->add_comment_delimiter("//", "", true);
 
 			error_text->add_theme_font_override("font", get_theme_font("status_source", "EditorFonts"));
 			error_text->add_theme_font_size_override("font_size", get_theme_font_size("status_source_size", "EditorFonts"));

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -160,6 +160,12 @@ private:
 	void _clear_delimiters(DelimiterType p_type);
 	TypedArray<String> _get_delimiters(DelimiterType p_type) const;
 
+	/* Code Hint */
+	String code_hint = "";
+
+	bool code_hint_draw_below = true;
+	int code_hint_xpos = -0xFFFF;
+
 	/* Code Completion */
 	bool code_completion_enabled = false;
 	bool code_completion_forced = false;
@@ -261,6 +267,10 @@ public:
 
 	Point2 get_delimiter_start_position(int p_line, int p_column) const;
 	Point2 get_delimiter_end_position(int p_line, int p_column) const;
+
+	/* Code hint */
+	void set_code_hint(const String &p_hint);
+	void set_code_hint_draw_below(bool p_below);
 
 	/* Code Completion */
 	void set_code_completion_enabled(bool p_enable);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2210,8 +2210,6 @@ void TextEdit::_move_cursor_up(bool p_select) {
 	if (p_select) {
 		_post_shift_selection();
 	}
-
-	_cancel_code_hint();
 }
 
 void TextEdit::_move_cursor_down(bool p_select) {
@@ -2234,8 +2232,6 @@ void TextEdit::_move_cursor_down(bool p_select) {
 	if (p_select) {
 		_post_shift_selection();
 	}
-
-	_cancel_code_hint();
 }
 
 void TextEdit::_move_cursor_to_line_start(bool p_select) {
@@ -2275,8 +2271,6 @@ void TextEdit::_move_cursor_to_line_start(bool p_select) {
 	if (p_select) {
 		_post_shift_selection();
 	}
-
-	completion_hint = "";
 }
 
 void TextEdit::_move_cursor_to_line_end(bool p_select) {
@@ -2302,7 +2296,6 @@ void TextEdit::_move_cursor_to_line_end(bool p_select) {
 	if (p_select) {
 		_post_shift_selection();
 	}
-	completion_hint = "";
 }
 
 void TextEdit::_move_cursor_page_up(bool p_select) {
@@ -2319,8 +2312,6 @@ void TextEdit::_move_cursor_page_up(bool p_select) {
 	if (p_select) {
 		_post_shift_selection();
 	}
-
-	completion_hint = "";
 }
 
 void TextEdit::_move_cursor_page_down(bool p_select) {
@@ -2337,8 +2328,6 @@ void TextEdit::_move_cursor_page_down(bool p_select) {
 	if (p_select) {
 		_post_shift_selection();
 	}
-
-	completion_hint = "";
 }
 
 void TextEdit::_backspace(bool p_word, bool p_all_to_left) {
@@ -2487,11 +2476,6 @@ void TextEdit::_handle_unicode_character(uint32_t unicode, bool p_had_selection)
 	}
 
 	const char32_t chr[2] = { (char32_t)unicode, 0 };
-
-	// Clear completion hint when function closed
-	if (completion_hint != "" && unicode == ')') {
-		completion_hint = "";
-	}
 
 	if (auto_brace_completion_enabled && _is_pair_symbol(chr[0])) {
 		_consume_pair_symbol(chr[0]);
@@ -3067,7 +3051,6 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		// MISC.
-
 		if (k->is_action("ui_menu", true)) {
 			if (context_menu_enabled) {
 				menu->set_position(get_screen_transform().xform(_get_cursor_pixel_pos()));
@@ -3081,14 +3064,6 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 		if (k->is_action("ui_text_toggle_insert_mode", true)) {
 			set_insert_mode(!insert_mode);
-			accept_event();
-			return;
-		}
-		if (k->is_action("ui_cancel", true)) {
-			if (completion_hint != "") {
-				completion_hint = "";
-				update();
-			}
 			accept_event();
 			return;
 		}
@@ -5510,7 +5485,6 @@ void TextEdit::undo() {
 	if (undo_stack_pos->get().type == TextOperation::TYPE_REMOVE) {
 		cursor_set_line(undo_stack_pos->get().to_line, false);
 		cursor_set_column(undo_stack_pos->get().to_column);
-		_cancel_code_hint();
 	} else {
 		cursor_set_line(undo_stack_pos->get().from_line, false);
 		cursor_set_column(undo_stack_pos->get().from_column);
@@ -5784,17 +5758,6 @@ void TextEdit::set_v_scroll_speed(float p_speed) {
 
 float TextEdit::get_v_scroll_speed() const {
 	return v_scroll_speed;
-}
-
-void TextEdit::_cancel_code_hint() {
-	completion_hint = "";
-	update();
-}
-
-void TextEdit::set_code_hint(const String &p_hint) {
-	completion_hint = p_hint;
-	completion_hint_offset = -0xFFFF;
-	update();
 }
 
 String TextEdit::get_word_at_pos(const Vector2 &p_pos) const {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -329,11 +329,6 @@ private:
 
 	bool next_operation_is_complex = false;
 
-	bool callhint_below = false;
-	Vector2 callhint_offset;
-	String completion_hint = "";
-	int completion_hint_offset = 0;
-
 	String search_text;
 	uint32_t search_flags = 0;
 	int search_result_line = 0;
@@ -427,7 +422,6 @@ private:
 	PopupMenu *menu_ctl;
 
 	void _clear();
-	void _cancel_code_hint();
 
 	int _calculate_spaces_till_next_left_indent(int column);
 	int _calculate_spaces_till_next_right_indent(int column);
@@ -666,10 +660,6 @@ public:
 		brace_matching_enabled = p_enabled;
 		update();
 	}
-	inline void set_callhint_settings(bool below, Vector2 offset) {
-		callhint_below = below;
-		callhint_offset = offset;
-	}
 	void set_auto_indent(bool p_auto_indent);
 
 	void center_viewport_to_cursor();
@@ -797,8 +787,6 @@ public:
 	bool is_hiding_enabled() const;
 
 	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
-
-	void set_code_hint(const String &p_hint);
 
 	void set_select_identifiers_on_hover(bool p_enable);
 	bool is_selecting_identifiers_on_hover_enabled() const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -173,6 +173,8 @@ private:
 	};
 
 	struct Cursor {
+		Point2 draw_pos;
+		bool visible = false;
 		int last_fit_x = 0;
 		int line = 0;
 		int column = 0; ///< cursor
@@ -239,20 +241,6 @@ private:
 
 	Dictionary _get_line_syntax_highlighting(int p_line);
 
-	Set<String> completion_prefixes;
-	bool completion_enabled = false;
-	List<ScriptCodeCompletionOption> completion_sources;
-	Vector<ScriptCodeCompletionOption> completion_options;
-	bool completion_active = false;
-	bool completion_forced = false;
-	ScriptCodeCompletionOption completion_current;
-	String completion_base;
-	int completion_index = 0;
-	Rect2i completion_rect;
-	int completion_line_ofs = 0;
-	String completion_hint;
-	int completion_hint_offset = 0;
-
 	bool setting_text = false;
 
 	// data
@@ -306,10 +294,10 @@ private:
 
 	bool highlight_all_occurrences = false;
 	bool scroll_past_end_of_file_enabled = false;
-	bool auto_brace_completion_enabled = false;
 	bool brace_matching_enabled = false;
 	bool highlight_current_line = false;
 	bool auto_indent = false;
+
 	String cut_copy_line;
 	bool insert_mode = false;
 	bool select_identifiers_enabled = false;
@@ -343,6 +331,8 @@ private:
 
 	bool callhint_below = false;
 	Vector2 callhint_offset;
+	String completion_hint = "";
+	int completion_hint_offset = 0;
 
 	String search_text;
 	uint32_t search_flags = 0;
@@ -437,10 +427,7 @@ private:
 	PopupMenu *menu_ctl;
 
 	void _clear();
-	void _cancel_completion();
 	void _cancel_code_hint();
-	void _confirm_completion();
-	void _update_completion_candidates();
 
 	int _calculate_spaces_till_next_left_indent(int column);
 	int _calculate_spaces_till_next_right_indent(int column);
@@ -463,9 +450,11 @@ private:
 	void _delete_selection();
 	void _move_cursor_document_start(bool p_select);
 	void _move_cursor_document_end(bool p_select);
-	void _handle_unicode_character(uint32_t unicode, bool p_had_selection, bool p_update_auto_complete);
+	void _handle_unicode_character(uint32_t unicode, bool p_had_selection);
 
 protected:
+	bool auto_brace_completion_enabled = false;
+
 	struct Cache {
 		Ref<Texture2D> tab_icon;
 		Ref<Texture2D> space_icon;
@@ -477,10 +466,6 @@ protected:
 		int font_size = 16;
 		int outline_size = 0;
 		Color outline_color;
-		Color completion_background_color;
-		Color completion_selected_color;
-		Color completion_existing_color;
-		Color completion_font_color;
 		Color caret_color;
 		Color caret_background_color;
 		Color font_color;
@@ -505,7 +490,7 @@ protected:
 	void _insert_text(int p_line, int p_char, const String &p_text, int *r_end_line = nullptr, int *r_end_char = nullptr);
 	void _remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
 	void _insert_text_at_cursor(const String &p_text);
-	void _gui_input(const Ref<InputEvent> &p_gui_input);
+	virtual void _gui_input(const Ref<InputEvent> &p_gui_input);
 	void _notification(int p_what);
 
 	void _consume_pair_symbol(char32_t ch);
@@ -695,6 +680,8 @@ public:
 	void cursor_set_column(int p_col, bool p_adjust_viewport = true);
 	void cursor_set_line(int p_row, bool p_adjust_viewport = true, bool p_can_be_hidden = true, int p_wrap_index = 0);
 
+	Point2 get_caret_draw_pos() const;
+	bool is_caret_visible() const;
 	int cursor_get_column() const;
 	int cursor_get_line() const;
 	Vector2i _get_cursor_pixel_pos(bool p_adjust_viewport = true);
@@ -811,10 +798,7 @@ public:
 
 	void set_tooltip_request_func(Object *p_obj, const StringName &p_function, const Variant &p_udata);
 
-	void set_completion(bool p_enabled, const Vector<String> &p_prefixes);
-	void code_complete(const List<ScriptCodeCompletionOption> &p_strings, bool p_forced = false);
 	void set_code_hint(const String &p_hint);
-	void query_code_comple();
 
 	void set_select_identifiers_on_hover(bool p_enable);
 	bool is_selecting_identifiers_on_hover_enabled() const;
@@ -833,7 +817,6 @@ public:
 
 	PopupMenu *get_menu() const;
 
-	String get_text_for_completion();
 	String get_text_for_lookup_completion();
 
 	virtual bool is_text_field() const override;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -432,7 +432,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("normal", "TextEdit", make_stylebox(tree_bg_png, 3, 3, 3, 3, 0, 0, 0, 0));
 	theme->set_stylebox("focus", "TextEdit", focus);
 	theme->set_stylebox("read_only", "TextEdit", make_stylebox(tree_bg_disabled_png, 4, 4, 4, 4, 0, 0, 0, 0));
-	theme->set_stylebox("completion", "TextEdit", make_stylebox(tree_bg_png, 3, 3, 3, 3, 0, 0, 0, 0));
 
 	theme->set_icon("tab", "TextEdit", make_icon(tab_png));
 	theme->set_icon("space", "TextEdit", make_icon(space_png));
@@ -441,11 +440,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "TextEdit", -1);
 
 	theme->set_color("background_color", "TextEdit", Color(0, 0, 0, 0));
-	theme->set_color("completion_background_color", "TextEdit", Color(0.17, 0.16, 0.2));
-	theme->set_color("completion_selected_color", "TextEdit", Color(0.26, 0.26, 0.27));
-	theme->set_color("completion_existing_color", "TextEdit", Color(0.87, 0.87, 0.87, 0.13));
-	theme->set_color("completion_scroll_color", "TextEdit", control_font_pressed_color);
-	theme->set_color("completion_font_color", "TextEdit", Color(0.67, 0.67, 0.67));
 	theme->set_color("font_color", "TextEdit", control_font_color);
 	theme->set_color("font_selected_color", "TextEdit", Color(0, 0, 0));
 	theme->set_color("font_readonly_color", "TextEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
@@ -458,9 +452,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("brace_mismatch_color", "TextEdit", Color(1, 0.2, 0.2));
 	theme->set_color("word_highlighted_color", "TextEdit", Color(0.8, 0.9, 0.9, 0.15));
 
-	theme->set_constant("completion_lines", "TextEdit", 7);
-	theme->set_constant("completion_max_width", "TextEdit", 50);
-	theme->set_constant("completion_scroll_width", "TextEdit", 3);
 	theme->set_constant("line_spacing", "TextEdit", 4 * scale);
 	theme->set_constant("outline_size", "TextEdit", 0);
 


### PR DESCRIPTION
Continuation of #31739

Builds on top of #42775 and blocked by #43663.

----

The main aim of this PR is abstracting out the auto complete system into `CodeEdit`, in order to do so it needed a system to track `Strings`.

The implementation of `String` tracking will also track `Comments`. The system closely follows that of the syntax highlighter, using the idea of regions. 

It exposes `add_[string|comment]_delimiter` methods to register the begin and end keys for each type. Once registered `CodeEdit` will keep track of the region. It's possible to check regions via `is_in_[string|comment]` methods, if no column is provided it will return `true` if the entire line is a `String` or `Comment`. It is also possible to get the start and end position of regions via `get_delimiter_[start|end]_position`.

Regions are updated on the `lines_edited_from` signal, I've tried to make this somewhat fast to hopefully have minimal impact on performance.

AutoComplete is now exposed to the `GDScript`, items are added via `add_code_completion_option`. Once all items are added a call to `update_code_completion_options` will update the list of possible completions in the drop down.  In addition to this there are three overridable methods:
* `_request_code_completion` -> Checks and emits `request_code_completion` signal.
* `_filter_code_completion_candidates` -> Filters the list of options.
* `_confirm_code_completion` -> Inserts the selected option

There are also various ways to query autocomplete getting the current selected, setting the selected item and getting the full list of options. 

As part of the refactor I've attempted to remove the editor specific code and added a couple of new features. The first one allowing the user to force autocomplete. Secondly, adding a second shortcut to replace the existing text rather then inserting ontop. This is currently bound to `Tab`, the old behaviour is preserved by using `Enter / KP Enter`.
 
In addition to this the `request_completion` signal has been renamed to `request_code_completion`

To handle drawing, I've added two methods to `TextEdit` to get the `caret` draw position and to check if the `caret` is visible.

Finally `CodeHint` has also been moved and exposed, and `callhint_offset` has been removed.

----

**TODO**
* ~~Remove old code from `TextEdit`~~
* ~~Update input handling after #43663~~
* ~~Update draw code and remove `callhint_offset`~~
* ~~Fix initial '$' completion~~

---

closes #22196
closes #36833
closes #23756
closes #34168
closes #24077
closes #44000

Should solve some of #38847 and godotengine/godot-proposals/issues/1514