### PR TITLE
Clarify that create_timer does not require cleanup.

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -75,6 +75,7 @@
 				    yield(get_tree().create_timer(1.0), "timeout")
 				    print("end")
 				[/codeblock]
+				The timer will be automatically freed after its time elapses.
 			</description>
 		</method>
 		<method name="get_frame" qualifiers="const">


### PR DESCRIPTION
This is how I would expect it to work, but the docs didn't clarify, so I
had to check the source just to make sure I wasn't responsible for
freeing the timer:

https://github.com/godotengine/godot/blob/d39f6386ce3a7916dbb94fef5ff65e7599e060f0/scene/main/scene_tree.cpp#L473


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->