### PR TITLE
Exposed `find_next_valid_focus` and `find_prev_valid_focus`.

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -306,6 +306,20 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="find_next_valid_focus" qualifiers="const">
+			<return type="Control">
+			</return>
+			<description>
+				Finds the next (below in the tree) [Control] that can receive the focus.
+			</description>
+		</method>
+		<method name="find_prev_valid_focus" qualifiers="const">
+			<return type="Control">
+			</return>
+			<description>
+				Finds the previous (above in the tree) [Control] that can receive the focus.
+			</description>
+		</method>
 		<method name="force_drag">
 			<return type="void">
 			</return>

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2785,6 +2785,8 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_focus"), &Control::has_focus);
 	ClassDB::bind_method(D_METHOD("grab_focus"), &Control::grab_focus);
 	ClassDB::bind_method(D_METHOD("release_focus"), &Control::release_focus);
+	ClassDB::bind_method(D_METHOD("find_prev_valid_focus"), &Control::find_prev_valid_focus);
+	ClassDB::bind_method(D_METHOD("find_next_valid_focus"), &Control::find_next_valid_focus);
 	ClassDB::bind_method(D_METHOD("get_focus_owner"), &Control::get_focus_owner);
 
 	ClassDB::bind_method(D_METHOD("set_h_size_flags", "flags"), &Control::set_h_size_flags);


### PR DESCRIPTION
Fixes #29357.