### PR TITLE
Fix ScrollContainer deadzone issues on touch screens.

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -31,7 +31,6 @@
 			If [code]true[/code], the ScrollContainer will automatically scroll to focused children (including indirect children) to make sure they are fully visible.
 		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
-		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			The current horizontal scroll value.

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -45,6 +45,9 @@
 		<member name="scroll_vertical_enabled" type="bool" setter="set_enable_v_scroll" getter="is_v_scroll_enabled" default="true">
 			If [code]true[/code], enables vertical scrolling.
 		</member>
+		<member name="scroll_deadzone" type="bool" setter="set_enable_v_scroll" getter="is_v_scroll_enabled" default="true">
+			The minimum difference in position required to actually scroll when using momentum-based scrolling. (i.e. when using touch) If the movement of the touch point is less than this, a scroll event will not be triggered, and child nodes may receive click/tap events.
+		</member>
 	</members>
 	<signals>
 		<signal name="scroll_ended">

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -45,7 +45,7 @@
 		<member name="scroll_vertical_enabled" type="bool" setter="set_enable_v_scroll" getter="is_v_scroll_enabled" default="true">
 			If [code]true[/code], enables vertical scrolling.
 		</member>
-		<member name="scroll_deadzone" type="bool" setter="set_enable_v_scroll" getter="is_v_scroll_enabled" default="true">
+		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 			The minimum difference in position required to actually scroll when using momentum-based scrolling. (i.e. when using touch) If the movement of the touch point is less than this, a scroll event will not be triggered, and child nodes may receive click/tap events.
 		</member>
 	</members>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -31,7 +31,6 @@
 			If [code]true[/code], the ScrollContainer will automatically scroll to focused children (including indirect children) to make sure they are fully visible.
 		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
-		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			The current horizontal scroll value.
 		</member>

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -178,8 +178,10 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					emit_signal("scroll_started");
 
 					beyond_deadzone = true;
-					// resetting drag_accum here ensures smooth scrolling after reaching deadzone
-					drag_accum = -motion;
+					
+					// Removes the deadzone from drag_accum to remove "jump" to current position
+					drag_accum.x -= deadzone * (drag_accum.x < 0 ? -1 : 1);
+					drag_accum.y -= deadzone * (drag_accum.y < 0 ? -1 : 1);
 				}
 				Vector2 diff = drag_from + drag_accum;
 				if (scroll_h) {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -178,7 +178,7 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					emit_signal("scroll_started");
 
 					beyond_deadzone = true;
-					
+
 					// Removes the deadzone from drag_accum to remove "jump" to current position
 					drag_accum.x -= deadzone * (drag_accum.x < 0 ? -1 : 1);
 					drag_accum.y -= deadzone * (drag_accum.y < 0 ? -1 : 1);


### PR DESCRIPTION
This pull request resolves an issue where ScrollContainers with a deadzone would behave erratically on touch (https://github.com/godotengine/godot/issues/45402)
The rationale and code for this fix can be found [in it's commit.](https://github.com/godotengine/godot/commit/e47728ec7e7f4dc7b9e420110c1c78e434382fd0)

Additionally, it adds previously missing documentation for the deadzone parameter.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Resolves godotengine/godot#45402