### PR TITLE
Add named resources and debug labels

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1078,6 +1078,12 @@ public:
 
 	virtual uint64_t get_memory_usage() const;
 
+	virtual void set_resource_name(RID p_id, const String p_name);
+
+	virtual void draw_command_begin_label(String p_label_name, const Color p_color = Color(1, 1, 1, 1));
+	virtual void draw_command_insert_label(String p_label_name, const Color p_color = Color(1, 1, 1, 1));
+	virtual void draw_command_end_label();
+
 	RenderingDeviceVulkan();
 	~RenderingDeviceVulkan();
 };

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -119,6 +119,7 @@ class VulkanContext {
 	bool VK_GOOGLE_display_timing_enabled = true;
 	uint32_t enabled_extension_count = 0;
 	const char *extension_names[MAX_EXTENSIONS];
+	bool enabled_debug_utils = false;
 
 	uint32_t enabled_layer_count = 0;
 	const char *enabled_layers[MAX_LAYERS];
@@ -208,6 +209,11 @@ public:
 	Error prepare_buffers();
 	Error swap_buffers();
 	Error initialize();
+
+	void command_begin_label(VkCommandBuffer p_command_buffer, String p_label_name, const Color p_color);
+	void command_insert_label(VkCommandBuffer p_command_buffer, String p_label_name, const Color p_color);
+	void command_end_label(VkCommandBuffer p_command_buffer);
+	void set_object_name(VkObjectType p_object_type, uint64_t p_object_handle, String p_object_name);
 
 	VulkanContext();
 	virtual ~VulkanContext();

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -5332,9 +5332,11 @@ void RendererSceneRenderRD::_process_ssao(RID p_render_buffers, RID p_environmen
 			tf.array_layers = 4;
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
 			rb->ssao.depth = RD::get_singleton()->texture_create(tf, RD::TextureView());
+			RD::get_singleton()->set_resource_name(rb->ssao.depth, "SSAO Depth");
 			for (uint32_t i = 0; i < tf.mipmaps; i++) {
 				RID slice = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rb->ssao.depth, 0, i, RD::TEXTURE_SLICE_2D_ARRAY);
 				rb->ssao.depth_slices.push_back(slice);
+				RD::get_singleton()->set_resource_name(rb->ssao.depth_slices[i], "SSAO Depth Mip " + itos(i) + " ");
 			}
 		}
 
@@ -5347,9 +5349,11 @@ void RendererSceneRenderRD::_process_ssao(RID p_render_buffers, RID p_environmen
 			tf.array_layers = 4;
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
 			rb->ssao.ao_deinterleaved = RD::get_singleton()->texture_create(tf, RD::TextureView());
+			RD::get_singleton()->set_resource_name(rb->ssao.ao_deinterleaved, "SSAO De-interleaved Array");
 			for (uint32_t i = 0; i < 4; i++) {
 				RID slice = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rb->ssao.ao_deinterleaved, i, 0);
 				rb->ssao.ao_deinterleaved_slices.push_back(slice);
+				RD::get_singleton()->set_resource_name(rb->ssao.ao_deinterleaved_slices[i], "SSAO De-interleaved Array Layer " + itos(i) + " ");
 			}
 		}
 
@@ -5362,9 +5366,11 @@ void RendererSceneRenderRD::_process_ssao(RID p_render_buffers, RID p_environmen
 			tf.array_layers = 4;
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
 			rb->ssao.ao_pong = RD::get_singleton()->texture_create(tf, RD::TextureView());
+			RD::get_singleton()->set_resource_name(rb->ssao.ao_pong, "SSAO De-interleaved Array Pong");
 			for (uint32_t i = 0; i < 4; i++) {
 				RID slice = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rb->ssao.ao_pong, i, 0);
 				rb->ssao.ao_pong_slices.push_back(slice);
+				RD::get_singleton()->set_resource_name(rb->ssao.ao_deinterleaved_slices[i], "SSAO De-interleaved Array Layer " + itos(i) + " Pong");
 			}
 		}
 
@@ -5375,7 +5381,9 @@ void RendererSceneRenderRD::_process_ssao(RID p_render_buffers, RID p_environmen
 			tf.height = half_height;
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
 			rb->ssao.importance_map[0] = RD::get_singleton()->texture_create(tf, RD::TextureView());
+			RD::get_singleton()->set_resource_name(rb->ssao.importance_map[0], "SSAO Importance Map");
 			rb->ssao.importance_map[1] = RD::get_singleton()->texture_create(tf, RD::TextureView());
+			RD::get_singleton()->set_resource_name(rb->ssao.importance_map[1], "SSAO Importance Map Pong");
 		}
 		{
 			RD::TextureFormat tf;
@@ -5384,6 +5392,7 @@ void RendererSceneRenderRD::_process_ssao(RID p_render_buffers, RID p_environmen
 			tf.height = rb->height;
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
 			rb->ssao.ao_final = RD::get_singleton()->texture_create(tf, RD::TextureView());
+			RD::get_singleton()->set_resource_name(rb->ssao.ao_final, "SSAO Final");
 			_render_buffers_uniform_set_changed(p_render_buffers);
 		}
 		ssao_using_half_size = ssao_half_size;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -343,6 +343,12 @@ void RenderingDevice::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("create_local_device"), &RenderingDevice::create_local_device);
 
+	ClassDB::bind_method(D_METHOD("set_resource_name"), &RenderingDevice::set_resource_name);
+
+	ClassDB::bind_method(D_METHOD("draw_command_begin_label", "name", "color"), &RenderingDevice::draw_command_begin_label);
+	ClassDB::bind_method(D_METHOD("draw_command_insert_label", "name", "color"), &RenderingDevice::draw_command_insert_label);
+	ClassDB::bind_method(D_METHOD("draw_command_end_label"), &RenderingDevice::draw_command_end_label);
+
 	BIND_ENUM_CONSTANT(DATA_FORMAT_R4G4_UNORM_PACK8);
 	BIND_ENUM_CONSTANT(DATA_FORMAT_R4G4B4A4_UNORM_PACK16);
 	BIND_ENUM_CONSTANT(DATA_FORMAT_B4G4R4A4_UNORM_PACK16);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1060,6 +1060,12 @@ public:
 
 	virtual RenderingDevice *create_local_device() = 0;
 
+	virtual void set_resource_name(RID p_id, const String p_name) = 0;
+
+	virtual void draw_command_begin_label(String p_label_name, const Color p_color = Color(1, 1, 1, 1)) = 0;
+	virtual void draw_command_insert_label(String p_label_name, const Color p_color = Color(1, 1, 1, 1)) = 0;
+	virtual void draw_command_end_label() = 0;
+
 	static RenderingDevice *get_singleton();
 	RenderingDevice();
 


### PR DESCRIPTION
This PR adds the ability to name Vulkan resources and set debug labels for use in frame capture programs like RenderDoc.

I have started labelling events and naming resources, but I will wait for others input before continuing. 

Before merging, I think it is worth discussing the API for named resources as well. I decided to add a function called ``set_resource_name`` which uses a system similar to ``free`` where it checks all the RID owners to see if the resource belongs to someone and then calls the appropriate function. Another options would be to pass ``p_name`` as an optional argument to resource creation functions. For example, ``texture_create()`` could take a string ``p_name`` and then name the texture immediately after creation. This approach may be nice and would allow us to name certain resources that are never exposed (like vkShaderModules).

For example, here is the event browser before and after notice how every event is grouped into an arbtrary compute/depth/colour pass:

_Before_
![Screenshot (83)](https://user-images.githubusercontent.com/16521339/105622979-e152a980-5dca-11eb-90b9-caadff37e99c.png)

_After_
![Screenshot (81)](https://user-images.githubusercontent.com/16521339/105622879-e5ca9280-5dc9-11eb-9ed0-6481c2665c9d.png)

And here is what a typical pipeline state looks like before and after, note how the resources are given number names based on their types:

_Before_
![Screenshot (84)](https://user-images.githubusercontent.com/16521339/105622981-e44d9a00-5dca-11eb-9f67-11ec0786d189.png)

_After_
![Screenshot (82)](https://user-images.githubusercontent.com/16521339/105622881-ee22cd80-5dc9-11eb-95d9-b9a2c295b4ff.png)

