### PR TITLE
Remove Quat set methods in favour of constructors

### DIFF
--- a/core/math/quat.h
+++ b/core/math/quat.h
@@ -65,19 +65,14 @@ public:
 	Quat inverse() const;
 	_FORCE_INLINE_ real_t dot(const Quat &p_q) const;
 
-	void set_euler_xyz(const Vector3 &p_euler);
 	Vector3 get_euler_xyz() const;
-	void set_euler_yxz(const Vector3 &p_euler);
 	Vector3 get_euler_yxz() const;
-
-	void set_euler(const Vector3 &p_euler) { set_euler_yxz(p_euler); };
 	Vector3 get_euler() const { return get_euler_yxz(); };
 
 	Quat slerp(const Quat &p_to, const real_t &p_weight) const;
 	Quat slerpni(const Quat &p_to, const real_t &p_weight) const;
 	Quat cubic_slerp(const Quat &p_b, const Quat &p_pre_a, const Quat &p_post_b, const real_t &p_weight) const;
 
-	void set_axis_angle(const Vector3 &axis, const real_t &angle);
 	_FORCE_INLINE_ void get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 		r_angle = 2 * Math::acos(w);
 		real_t r = ((real_t)1) / Math::sqrt(1 - w * w);
@@ -124,23 +119,19 @@ public:
 
 	operator String() const;
 
-	inline void set(real_t p_x, real_t p_y, real_t p_z, real_t p_w) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-		w = p_w;
-	}
-
 	_FORCE_INLINE_ Quat() {}
+
 	_FORCE_INLINE_ Quat(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
 			x(p_x),
 			y(p_y),
 			z(p_z),
 			w(p_w) {
 	}
-	Quat(const Vector3 &axis, const real_t &angle) { set_axis_angle(axis, angle); }
 
-	Quat(const Vector3 &euler) { set_euler(euler); }
+	Quat(const Vector3 &p_axis, real_t p_angle);
+
+	Quat(const Vector3 &p_euler);
+
 	Quat(const Quat &p_q) :
 			x(p_q.x),
 			y(p_q.y),

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1126,10 +1126,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(Quat, cubic_slerp, sarray("b", "pre_a", "post_b", "weight"), varray());
 	bind_method(Quat, get_euler, sarray(), varray());
 
-	// FIXME: Quat is atomic, this should be done via construcror
-	//ADDFUNC1(QUAT, NIL, Quat, set_euler, VECTOR3, "euler", varray());
-	//ADDFUNC2(QUAT, NIL, Quat, set_axis_angle, VECTOR3, "axis", FLOAT, "angle", varray());
-
 	/* Color */
 
 	bind_method(Color, to_argb32, sarray(), varray());

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5287,8 +5287,7 @@ void GLTFDocument::_convert_mult_mesh_instance_to_gltf(Node *p_scene_parent, con
 				transform.origin =
 						Vector3(xform_2d.get_origin().x, 0, xform_2d.get_origin().y);
 				real_t rotation = xform_2d.get_rotation();
-				Quat quat;
-				quat.set_axis_angle(Vector3(0, 1, 0), rotation);
+				Quat quat(Vector3(0, 1, 0), rotation);
 				Size2 scale = xform_2d.get_scale();
 				transform.basis.set_quat_scale(quat,
 						Vector3(scale.x, 0, scale.y));
@@ -6040,14 +6039,12 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 			p_track.rotation_track.interpolation = gltf_interpolation;
 
 			for (int32_t key_i = 0; key_i < key_count; key_i++) {
-				Quat rotation;
 				Vector3 rotation_degrees = p_animation->track_get_key_value(p_track_i, key_i);
 				Vector3 rotation_radian;
 				rotation_radian.x = Math::deg2rad(rotation_degrees.x);
 				rotation_radian.y = Math::deg2rad(rotation_degrees.y);
 				rotation_radian.z = Math::deg2rad(rotation_degrees.z);
-				rotation.set_euler(rotation_radian);
-				p_track.rotation_track.values.write[key_i] = rotation;
+				p_track.rotation_track.values.write[key_i] = Quat(rotation_radian);
 			}
 		} else if (path.find(":scale") != -1) {
 			p_track.scale_track.times = times;


### PR DESCRIPTION
https://github.com/godotengine/godot/blob/d39f6386ce3a7916dbb94fef5ff65e7599e060f0/core/variant/variant_call.cpp#L1129-L1131
A `Quat` should be immutable. It should not have `set_*` methods. When required, a new `Quat` should be created using the equivalent constructor.

This PR removes the `Quat` `set_*` methods, and, where used, replaces them with the constructor equivalents. Note: This PR does not make `Quat` immutable. It's components are still public and they can still be (and are) changed within the engine.

For reference, deprecating them was originally suggested by @aaronfranke [here](https://github.com/godotengine/godot/issues/16863#issuecomment-515892880) as part of #16863.