### PR TITLE
Update PR template with a link to the docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,7 @@ Do not create a pull request for stable branches unless the change is already
 available in the `master` branch and it cannot be easily cherry-picked.
 Alternatively, if the change is only relevant for that branch (e.g. rendering
 fixes for the 3.2 branch).
+
+If you are adding a new feature please consider documenting it in the official
+Godot documentation here: https://github.com/godotengine/godot-docs.
 -->


### PR DESCRIPTION
As someone who contributes to the docs there's too many features that get added with no documentation. I understand that we can't require people to document their features, but we should at least encourage it.

