### PR TITLE
[CTL] Do not break line on the span (e.g. RTL BBCode tag) edges.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1602,11 +1602,18 @@ bool TextServerAdvanced::shaped_text_update_breaks(RID p_shaped) {
 
 	HashMap<int, bool> breaks;
 	UErrorCode err = U_ZERO_ERROR;
-	for (int i = 0; i < sd->spans.size(); i++) {
-		UBreakIterator *bi = ubrk_open(UBRK_LINE, sd->spans[i].language.ascii().get_data(), data + _convert_pos_inv(sd, sd->spans[i].start), _convert_pos_inv(sd, sd->spans[i].end - sd->spans[i].start), &err);
+	int i = 0;
+	while (i < sd->spans.size()) {
+		String language = sd->spans[i].language;
+		int r_start = sd->spans[i].start;
+		while (i + 1 < sd->spans.size() && language == sd->spans[i + 1].language) {
+			i++;
+		}
+		int r_end = sd->spans[i].end;
+		UBreakIterator *bi = ubrk_open(UBRK_LINE, language.ascii().get_data(), data + _convert_pos_inv(sd, r_start), _convert_pos_inv(sd, r_end - r_start), &err);
 		if (U_FAILURE(err)) {
 			//No data loaded - use fallback.
-			for (int j = sd->spans[i].start; j < sd->spans[i].end; j++) {
+			for (int j = r_start; j < r_end; j++) {
 				char32_t c = sd->text[j - sd->start];
 				if (is_whitespace(c)) {
 					breaks[j] = false;
@@ -1617,8 +1624,8 @@ bool TextServerAdvanced::shaped_text_update_breaks(RID p_shaped) {
 			}
 		} else {
 			while (ubrk_next(bi) != UBRK_DONE) {
-				int pos = _convert_pos(sd, ubrk_current(bi)) + sd->spans[i].start - 1;
-				if (pos != sd->spans[i].end) {
+				int pos = _convert_pos(sd, ubrk_current(bi)) + r_start - 1;
+				if (pos != r_end) {
 					if ((ubrk_getRuleStatus(bi) >= UBRK_LINE_HARD) && (ubrk_getRuleStatus(bi) < UBRK_LINE_HARD_LIMIT)) {
 						breaks[pos] = true;
 					} else if ((ubrk_getRuleStatus(bi) >= UBRK_LINE_SOFT) && (ubrk_getRuleStatus(bi) < UBRK_LINE_SOFT_LIMIT)) {
@@ -1628,6 +1635,7 @@ bool TextServerAdvanced::shaped_text_update_breaks(RID p_shaped) {
 			}
 		}
 		ubrk_close(bi);
+		i++;
 	}
 
 	sd->sort_valid = false;
@@ -1636,7 +1644,7 @@ bool TextServerAdvanced::shaped_text_update_breaks(RID p_shaped) {
 	const char32_t *ch = sd->text.ptr();
 	Glyph *sd_glyphs = sd->glyphs.ptrw();
 
-	for (int i = 0; i < sd_size; i++) {
+	for (i = 0; i < sd_size; i++) {
 		if (sd_glyphs[i].count > 0) {
 			char32_t c = ch[sd_glyphs[i].start - sd->start];
 			if (c == 0xfffc) {


### PR DESCRIPTION
Do not break line on the span (e.g. RTL BBCode tag) edges (except "language" tags which implies line breaking rules change).

Fixes #41963, fixes #31089

https://user-images.githubusercontent.com/7645683/105675163-55876d00-5ef1-11eb-9d65-c37bbf65787b.mov

