### PR TITLE
Support mono devices in WebXR

### DIFF
--- a/modules/webxr/godot_webxr.h
+++ b/modules/webxr/godot_webxr.h
@@ -61,6 +61,7 @@ extern void godot_webxr_initialize(
 		GodotWebXRSimpleEventCallback p_on_simple_event);
 extern void godot_webxr_uninitialize();
 
+extern int godot_webxr_get_view_count();
 extern int *godot_webxr_get_render_targetsize();
 extern float *godot_webxr_get_transform_for_eye(int p_eye);
 extern float *godot_webxr_get_projection_for_eye(int p_eye);

--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -394,6 +394,15 @@ const GodotWebXR = {
 		GodotWebXR.pauseResumeMainLoop();
 	},
 
+	godot_webxr_get_view_count__proxy: 'sync',
+	godot_webxr_get_view_count__sig: 'i',
+	godot_webxr_get_view_count: function () {
+		if (!GodotWebXR.session || !GodotWebXR.pose) {
+			return 0;
+		}
+		return GodotWebXR.pose.views.length;
+	},
+
 	godot_webxr_get_render_targetsize__proxy: 'sync',
 	godot_webxr_get_render_targetsize__sig: 'i',
 	godot_webxr_get_render_targetsize: function () {

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -197,12 +197,11 @@ StringName WebXRInterfaceJS::get_name() const {
 };
 
 int WebXRInterfaceJS::get_capabilities() const {
-	return XRInterface::XR_STEREO;
+	return XRInterface::XR_STEREO | XRInterface::XR_MONO;
 };
 
 bool WebXRInterfaceJS::is_stereo() {
-	// @todo WebXR can be mono! So, how do we know? Count the views in the frame?
-	return true;
+	return godot_webxr_get_view_count() == 2;
 };
 
 bool WebXRInterfaceJS::is_initialized() const {


### PR DESCRIPTION
Currently, the webxr module is hardcoded to always render in stereo. This PR attempts to detect and support mono devices. It seems to work in some really quick testing (on 3.2, of course!), but I'd like to keep this as a draft for a few days to get some more testing on a couple more devices.

This won't cleanly cherry-pick back to 3.2, so I'll make a separate PR for that.

Fixes #45412
