### PR TITLE
Document that ShaderMaterial doesn't support GIProbe emission

### DIFF
--- a/doc/classes/GIProbe.xml
+++ b/doc/classes/GIProbe.xml
@@ -6,6 +6,7 @@
 	<description>
 		[GIProbe]s are used to provide high-quality real-time indirect light to scenes. They precompute the effect of objects that emit light and the effect of static geometry to simulate the behavior of complex light in real-time. [GIProbe]s need to be baked before using, however, once baked, dynamic objects will receive light from them. Further, lights can be fully dynamic or baked.
 		Having [GIProbe]s in a scene can be expensive, the quality of the probe can be turned down in exchange for better performance in the [ProjectSettings] using [member ProjectSettings.rendering/quality/voxel_cone_tracing/high_quality].
+		[b]Note:[/b] Due to a renderer limitation, emissive [ShaderMaterial]s cannot emit light when used in a [GIProbe]. Only emissive [SpatialMaterial]s can emit light in a [GIProbe].
 	</description>
 	<tutorials>
 		<link title="GI probes">https://docs.godotengine.org/en/3.2/tutorials/3d/gi_probes.html</link>

--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A material that uses a custom [Shader] program to render either items to screen or process particles. You can create multiple materials for the same shader but configure different values for the uniforms defined in the shader.
+		[b]Note:[/b] Due to a renderer limitation, emissive [ShaderMaterial]s cannot emit light when used in a [GIProbe]. Only emissive [SpatialMaterial]s can emit light in a [GIProbe].
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/3.2/tutorials/shading/index.html</link>


### PR DESCRIPTION
This limitation only applies to 3.2.x, not 4.0.