### PR TITLE
Improve framebuffer creation error message to mention size limits

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4820,7 +4820,7 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 			rt->depth = 0;
 			texture->tex_id = 0;
 			texture->active = false;
-			WARN_PRINT("Could not create framebuffer!!");
+			ERR_PRINT("Couldn't create framebuffer. Is the framebuffer size too large for the target hardware?");
 			return;
 		}
 


### PR DESCRIPTION
Low-end hardware is often limited to framebuffers with a width/height of 2048 or 4096 pixels.

This also turns the warning message into an error message.

This closes https://github.com/godotengine/godot/issues/38879.