### PR TITLE
[HTML5] Better editor HTML, small refactor.

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -66,11 +66,11 @@ public:
 	/* SHADOW ATLAS API */
 
 	RID shadow_atlas_create() override { return RID(); }
-	void shadow_atlas_set_size(RID p_atlas, int p_size) override {}
+	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) override {}
 	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) override {}
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) override { return false; }
 
-	void directional_shadow_atlas_set_size(int p_size) override {}
+	void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) override {}
 	int get_directional_light_shadow_size(RID p_light_intance) override { return 0; }
 	void set_directional_shadow_count(int p_count) override {}
 
@@ -116,6 +116,7 @@ public:
 
 	void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) override {}
 	void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) override {}
+	void environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) override {}
 
 	void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) override {}
 
@@ -189,6 +190,7 @@ public:
 
 	RID render_buffers_create() override { return RID(); }
 	void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding) override {}
+	void gi_set_use_half_resolution(bool p_enable) override {}
 
 	void screen_space_roughness_limiter_set_active(bool p_enable, float p_amount, float p_curve) override {}
 	bool screen_space_roughness_limiter_is_active() const override { return false; }

--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -4,7 +4,7 @@
 	<meta charset='utf-8' />
 	<meta name='viewport' content='width=device-width, user-scalable=no' />
 	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
-	<title></title>
+	<title>Godot Engine Web Editor ($GODOT_VERSION)</title>
 	<style type='text/css'>
 
 		*:focus {
@@ -189,7 +189,16 @@
 				<br />
 				<img src="logo.svg" width="1024" height="414" style="width: auto; height: auto; max-width: 85%; max-height: 250px" />
 				<br />
+				$GODOT_VERSION
+				<br />
+				<a href="releases/">Need an old version?</a>
+				<br />
+				<br />
+				<br />
 				<label for="zip-file" style="margin-right: 1rem">Preload project ZIP:</label> <input id="zip-file" type="file" id="files" name="files" style="margin-bottom: 1rem"/>
+				<br />
+<a href="demo.zip">(Try this for example)</a>
+				<br />
 				<br />
 				<button id="startButton" class="btn" style="margin-bottom: 4rem">Start Godot editor</button>
 				<br />

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -42,8 +42,6 @@ if env["gdnative_enabled"]:
     sys_env["LIBS"] = []
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
     sys_env.Append(LIBS=["idbfs.js"])
-    # JS prepended to the module code loading the side library.
-    sys_env.Append(LINKFLAGS=["--pre-js", sys_env.File("js/dynlink.pre.js")])
     # Configure it as a main module (dynamic linking support).
     sys_env.Append(CCFLAGS=["-s", "MAIN_MODULE=1"])
     sys_env.Append(LINKFLAGS=["-s", "MAIN_MODULE=1"])
@@ -53,7 +51,6 @@ if env["gdnative_enabled"]:
     sys_env["ENV"]["EMCC_FORCE_STDLIBS"] = "libc,libc++,libc++abi"
     # The main emscripten runtime, with exported standard libraries.
     sys = sys_env.Program(build_targets, ["javascript_runtime.cpp"])
-    sys_env.Depends(sys, "js/dynlink.pre.js")
 
     # The side library, containing all Godot code.
     wasm_env = env.Clone()
@@ -97,7 +94,13 @@ out_files = [
     zip_dir.File(binary_name + ".html"),
     zip_dir.File(binary_name + ".audio.worklet.js"),
 ]
-html_file = "#misc/dist/html/editor.html" if env["tools"] else "#misc/dist/html/full-size.html"
+html_file = "#misc/dist/html/full-size.html"
+if env["tools"]:
+    subst_dict = {"\$GODOT_VERSION": env.GetBuildVersion()}
+    html_file = env.Substfile(
+        target="#bin/godot${PROGSUFFIX}.html", source="#misc/dist/html/editor.html", SUBST_DICT=subst_dict
+    )
+
 in_files = [js_wrapped, build[1], html_file, "#platform/javascript/js/libs/audio.worklet.js"]
 if env["gdnative_enabled"]:
     in_files.append(build[2])  # Runtime

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -51,8 +51,11 @@ def get_flags():
 
 def configure(env):
     if not isinstance(env["initial_memory"], int):
-        print("Initial memory must be a valid integer")
-        sys.exit(255)
+        try:
+            env["initial_memory"] = int(env["initial_memory"])
+        except:
+            print("Initial memory must be a valid integer")
+            sys.exit(255)
 
     ## Build type
 

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -1,7 +1,14 @@
 import os
 import sys
 
-from emscripten_helpers import run_closure_compiler, create_engine_file, add_js_libraries, add_js_pre, add_js_externs
+from emscripten_helpers import (
+    run_closure_compiler,
+    create_engine_file,
+    add_js_libraries,
+    add_js_pre,
+    add_js_externs,
+    get_build_version,
+)
 from methods import get_compiler_version
 from SCons.Util import WhereIs
 
@@ -58,7 +65,6 @@ def configure(env):
             sys.exit(255)
 
     ## Build type
-
     if env["target"] == "release":
         # Use -Os to prioritize optimizing for reduced file size. This is
         # particularly valuable for the web platform because it directly
@@ -141,6 +147,9 @@ def configure(env):
     env.AddMethod(add_js_libraries, "AddJSLibraries")
     env.AddMethod(add_js_pre, "AddJSPre")
     env.AddMethod(add_js_externs, "AddJSExterns")
+
+    # Add method for getting build version string.
+    env.AddMethod(get_build_version, "GetBuildVersion")
 
     # Add method that joins/compiles our Engine files.
     env.AddMethod(create_engine_file, "CreateEngineFile")

--- a/platform/javascript/emscripten_helpers.py
+++ b/platform/javascript/emscripten_helpers.py
@@ -15,6 +15,15 @@ def run_closure_compiler(target, source, env, for_signature):
     return " ".join(cmd)
 
 
+def get_build_version(env):
+    import version
+
+    name = "custom_build"
+    if os.getenv("BUILD_NAME") != None:
+        name = os.getenv("BUILD_NAME")
+    return "%d.%d.%d.%s.%s" % (version.major, version.minor, version.patch, version.status, name)
+
+
 def create_engine_file(env, target, source, externs):
     if env["use_closure_compiler"]:
         return env.BuildJS(target, source, JSEXTERNS=externs)

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -135,6 +135,7 @@ public:
 		s += "Access-Control-Allow-Origin: *\r\n";
 		s += "Cross-Origin-Opener-Policy: same-origin\r\n";
 		s += "Cross-Origin-Embedder-Policy: require-corp\r\n";
+		s += "Cache-Control: no-store, max-age=0\r\n";
 		s += "\r\n";
 		CharString cs = s.utf8();
 		Error err = connection->put_data((const uint8_t *)cs.get_data(), cs.size() - 1);

--- a/platform/javascript/js/dynlink.pre.js
+++ b/platform/javascript/js/dynlink.pre.js
@@ -1,1 +1,0 @@
-Module['dynamicLibraries'] = [Module['thisProgram'] + '.side.wasm'].concat(Module['dynamicLibraries'] ? Module['dynamicLibraries'] : []);

--- a/platform/javascript/js/engine/engine.js
+++ b/platform/javascript/js/engine/engine.js
@@ -62,7 +62,7 @@ const Engine = (function () {
 			// Emscripten configuration.
 			config['thisProgram'] = me.executableName;
 			config['noExitRuntime'] = true;
-			config['dynamicLibraries'] = me.gdnativeLibs;
+			config['dynamicLibraries'] = [`${me.executableName}.side.wasm`].concat(me.gdnativeLibs);
 			Godot(config).then(function (module) {
 				module['initFS'](me.persistentPaths).then(function (fs_err) {
 					me.rtenv = module;


### PR DESCRIPTION
In this PR:

- Side and GDNative libraries are now added by engine.js , the dynlink pre js had been deleted.
- Better styling for the editor page (see screenshot below).
- Fix "initial_memory" build option parsing.
- Usual rasterizer fixes.
- Added cache `no-store` header to debug HTTP server (prevents browser from caching results from the debug server).
![web-style](https://user-images.githubusercontent.com/1687918/105756101-77faa400-5f4c-11eb-869e-46503f33441a.png)
