### PR TITLE
POSIX systems: go through all event devices, not just event[0-32]

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -32,6 +32,7 @@
 
 #include "joypad_linux.h"
 
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/input.h>
@@ -183,13 +184,23 @@ void JoypadLinux::monitor_joypads() {
 		{
 			MutexLock lock(joy_mutex);
 
-			for (int i = 0; i < 32; i++) {
+			DIR *input_directory;
+			input_directory = opendir("/dev/input");
+			if (input_directory) {
+				struct dirent *current;
 				char fname[64];
-				sprintf(fname, "/dev/input/event%d", i);
-				if (attached_devices.find(fname) == -1) {
-					open_joypad(fname);
+
+				while ((current = readdir(input_directory)) != NULL) {
+					if (strncmp(current->d_name, "event", 5) != 0) {
+						continue;
+					}
+					sprintf(fname, "/dev/input/%.*s", 16, current->d_name);
+					if (attached_devices.find(fname) == -1) {
+						open_joypad(fname);
+					}
 				}
 			}
+			closedir(input_directory);
 		}
 		usleep(1000000); // 1s
 	}


### PR DESCRIPTION
There are no guarantees that joypads are in event0-event32
range.  Some devices, such as laptops with detachable keyboards
and wacom can reserve events all the way up to 32.

Some udev rules with e.g. custom controller firmwares may
load the device as /dev/input/eventX, where X is greater than
32.

This patch uses POSIX dirent to enumerate the event devices, so
entries outside 0-32 range are not skipped.