### PR TITLE
[iOS] Rework/Fix APNS usage.

### DIFF
--- a/platform/iphone/godot_app_delegate.h
+++ b/platform/iphone/godot_app_delegate.h
@@ -31,6 +31,7 @@
 #import <UIKit/UIKit.h>
 
 typedef NSObject<UIApplicationDelegate> ApplicationDelegateService;
+typedef void (^APNSNotification)(UIBackgroundFetchResult);
 
 @interface GodotApplicalitionDelegate : NSObject <UIApplicationDelegate>
 
@@ -38,4 +39,27 @@ typedef NSObject<UIApplicationDelegate> ApplicationDelegateService;
 
 + (void)addService:(ApplicationDelegateService *)service;
 
+- (void)godot:(UIApplication *)application receivedNotificationToken:(NSData *)deviceToken;
+- (void)godot:(UIApplication *)application receivedNotificationError:(NSError *)error;
+- (void)godot:(UIApplication *)application receivedNotification:(NSDictionary *)userInfo completion:(APNSNotification)completionHandler;
+
 @end
+
+#define GODOT_ENABLE_PUSH_NOTIFICATIONS                                                                                                \
+	@interface GodotApplicalitionDelegate (PushNotifications)                                                                          \
+	@end                                                                                                                               \
+	@implementation GodotApplicalitionDelegate (PushNotifications)                                                                     \
+	-(void)application : (UIApplication *)application                                                                                  \
+								 didRegisterForRemoteNotificationsWithDeviceToken : (NSData *)deviceToken {                            \
+		[self godot:application receivedNotificationToken:deviceToken];                                                                \
+	}                                                                                                                                  \
+	-(void)application : (UIApplication *)application                                                                                  \
+								 didFailToRegisterForRemoteNotificationsWithError : (NSError *)error {                                 \
+		[self godot:application receivedNotificationError:error];                                                                      \
+	}                                                                                                                                  \
+	-(void)application : (UIApplication *)application                                                                                  \
+								 didReceiveRemoteNotification : (NSDictionary *)userInfo                                               \
+																		fetchCompletionHandler : (APNSNotification)completionHandler { \
+		[self godot:application receivedNotification:userInfo completion:completionHandler];                                           \
+	}                                                                                                                                  \
+	@end

--- a/platform/iphone/godot_app_delegate.m
+++ b/platform/iphone/godot_app_delegate.m
@@ -302,7 +302,7 @@ static NSMutableArray<ApplicationDelegateService *> *services = nil;
 
 // MARK: Remote Notification
 
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+- (void)godot:(UIApplication *)application receivedNotificationToken:(NSData *)deviceToken {
 	for (ApplicationDelegateService *service in services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;
@@ -312,7 +312,7 @@ static NSMutableArray<ApplicationDelegateService *> *services = nil;
 	}
 }
 
-- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+- (void)godot:(UIApplication *)application receivedNotificationError:(NSError *)error {
 	for (ApplicationDelegateService *service in services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;
@@ -322,7 +322,7 @@ static NSMutableArray<ApplicationDelegateService *> *services = nil;
 	}
 }
 
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
+- (void)godot:(UIApplication *)application receivedNotification:(NSDictionary *)userInfo completion:(APNSNotification)completionHandler {
 	for (ApplicationDelegateService *service in services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/45478

Hides iOS push notifications methods behind `GODOT_ENABLE_PUSH_NOTIFICATIONS ` macro. This should silence both console output and AppStore warning e-mail about incorrect method/configuration usage.

Plugins will require to use macro as a way to enable push notifications support like it's done in example repo: https://github.com/naithar/godot_ios_plugin_apns/commit/3365b560077567a23710691b1dfe70d2fd56a32b

In case multiple plugin will require push notification support, it might be a good idea to provide a single plugin that enables this functionality.

Can be cherry-picked to `3.2`