### PR TITLE
Change BVH default to off

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -172,7 +172,7 @@ static String get_full_version_string() {
 void initialize_physics() {
 
 	// This must be defined BEFORE the 3d physics server is created
-	GLOBAL_DEF("physics/3d/godot_physics/use_bvh", true);
+	GLOBAL_DEF("physics/3d/godot_physics/use_bvh", false);
 
 	/// 3D Physics Server
 	physics_server = PhysicsServerManager::new_server(ProjectSettings::get_singleton()->get(PhysicsServerManager::setting_property_name));

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -3656,7 +3656,7 @@ VisualServerScene::VisualServerScene() {
 
 	render_pass = 1;
 	singleton = this;
-	_use_bvh = GLOBAL_DEF("rendering/quality/spatial_partitioning/use_bvh", true);
+	_use_bvh = GLOBAL_DEF("rendering/quality/spatial_partitioning/use_bvh", false);
 }
 
 VisualServerScene::~VisualServerScene() {


### PR DESCRIPTION
Although a couple of bugs have been fixed since beta 6, there is still at least one nasty bug, likely in the pairing which is causing issue reports. I now have a reproducable project from qarmin which should enable me to track this down, but it may take some time.

Until this is fixed it may be an idea to change the default to off for the next beta. On the other hand we might get more useful bug reports, but then this should be possible too with people using beta 6.

So I'm making the PR for this, and will leave up to @akien-mga  to decide. :grin: 

Related to #45461, #45292

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
