### PR TITLE
Type consistencies in core

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -261,11 +261,11 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			r_v = v;
 		} break;
 		case VARIANT_COLOR: {
-			Color v;
-			v.r = f->get_real();
-			v.g = f->get_real();
-			v.b = f->get_real();
-			v.a = f->get_real();
+			Color v; // Colors should always be in single-precision.
+			v.r = f->get_float();
+			v.g = f->get_float();
+			v.b = f->get_float();
+			v.a = f->get_float();
 			r_v = v;
 
 		} break;

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -107,8 +107,8 @@ public:
 	Variant intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const;
 	Variant intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const;
 
-	_FORCE_INLINE_ void quantize(float p_unit);
-	_FORCE_INLINE_ AABB quantized(float p_unit) const;
+	_FORCE_INLINE_ void quantize(real_t p_unit);
+	_FORCE_INLINE_ AABB quantized(real_t p_unit) const;
 
 	_FORCE_INLINE_ void set_end(const Vector3 &p_end) {
 		size = p_end - position;
@@ -430,7 +430,7 @@ void AABB::grow_by(real_t p_amount) {
 	size.z += 2.0 * p_amount;
 }
 
-void AABB::quantize(float p_unit) {
+void AABB::quantize(real_t p_unit) {
 	size += position;
 
 	position.x -= Math::fposmodp(position.x, p_unit);
@@ -448,7 +448,7 @@ void AABB::quantize(float p_unit) {
 	size -= position;
 }
 
-AABB AABB::quantized(float p_unit) const {
+AABB AABB::quantized(real_t p_unit) const {
 	AABB ret = *this;
 	ret.quantize(p_unit);
 	return ret;

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -544,12 +544,12 @@ Color Color::operator*(const Color &p_color) const {
 			a * p_color.a);
 }
 
-Color Color::operator*(real_t p_rvalue) const {
+Color Color::operator*(float p_scalar) const {
 	return Color(
-			r * p_rvalue,
-			g * p_rvalue,
-			b * p_rvalue,
-			a * p_rvalue);
+			r * p_scalar,
+			g * p_scalar,
+			b * p_scalar,
+			a * p_scalar);
 }
 
 void Color::operator*=(const Color &p_color) {
@@ -559,11 +559,11 @@ void Color::operator*=(const Color &p_color) {
 	a = a * p_color.a;
 }
 
-void Color::operator*=(real_t p_rvalue) {
-	r = r * p_rvalue;
-	g = g * p_rvalue;
-	b = b * p_rvalue;
-	a = a * p_rvalue;
+void Color::operator*=(float p_scalar) {
+	r = r * p_scalar;
+	g = g * p_scalar;
+	b = b * p_scalar;
+	a = a * p_scalar;
 }
 
 Color Color::operator/(const Color &p_color) const {
@@ -574,12 +574,12 @@ Color Color::operator/(const Color &p_color) const {
 			a / p_color.a);
 }
 
-Color Color::operator/(real_t p_rvalue) const {
+Color Color::operator/(float p_scalar) const {
 	return Color(
-			r / p_rvalue,
-			g / p_rvalue,
-			b / p_rvalue,
-			a / p_rvalue);
+			r / p_scalar,
+			g / p_scalar,
+			b / p_scalar,
+			a / p_scalar);
 }
 
 void Color::operator/=(const Color &p_color) {
@@ -589,18 +589,11 @@ void Color::operator/=(const Color &p_color) {
 	a = a / p_color.a;
 }
 
-void Color::operator/=(real_t p_rvalue) {
-	if (p_rvalue == 0) {
-		r = 1.0;
-		g = 1.0;
-		b = 1.0;
-		a = 1.0;
-	} else {
-		r = r / p_rvalue;
-		g = g / p_rvalue;
-		b = b / p_rvalue;
-		a = a / p_rvalue;
-	}
+void Color::operator/=(float p_scalar) {
+	r = r / p_scalar;
+	g = g / p_scalar;
+	b = b / p_scalar;
+	a = a / p_scalar;
 }
 
 Color Color::operator-() const {

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -78,14 +78,14 @@ struct Color {
 	void operator-=(const Color &p_color);
 
 	Color operator*(const Color &p_color) const;
-	Color operator*(real_t p_rvalue) const;
+	Color operator*(float p_scalar) const;
 	void operator*=(const Color &p_color);
-	void operator*=(real_t p_rvalue);
+	void operator*=(float p_scalar);
 
 	Color operator/(const Color &p_color) const;
-	Color operator/(real_t p_rvalue) const;
+	Color operator/(float p_scalar) const;
 	void operator/=(const Color &p_color);
-	void operator/=(real_t p_rvalue);
+	void operator/=(float p_scalar);
 
 	bool is_equal_approx(const Color &p_color) const;
 
@@ -259,8 +259,8 @@ bool Color::operator<(const Color &p_color) const {
 	}
 }
 
-_FORCE_INLINE_ Color operator*(real_t p_real, const Color &p_color) {
-	return p_color * p_real;
+_FORCE_INLINE_ Color operator*(float p_scalar, const Color &p_color) {
+	return p_color * p_scalar;
 }
 
 #endif // COLOR_H

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1409,8 +1409,9 @@ String String::num(double p_num, int p_decimals) {
 				if (digit == MAX_DIGITS) //no point in going to infinite
 					break;
 
-				if ((dec - (double)((int)dec)) < 1e-6)
+				if (dec - (double)((int)dec) < 1e-6) {
 					break;
+				}
 			}
 
 			if (digit == p_decimals)
@@ -3255,8 +3256,8 @@ float String::similarity(const String &p_string) const {
 	int src_size = src_bigrams.size();
 	int tgt_size = tgt_bigrams.size();
 
-	double sum = src_size + tgt_size;
-	double inter = 0;
+	int sum = src_size + tgt_size;
+	int inter = 0;
 	for (int i = 0; i < src_size; i++) {
 		for (int j = 0; j < tgt_size; j++) {
 			if (src_bigrams[i] == tgt_bigrams[j]) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1212,7 +1212,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Basis, transposed, sarray(), varray());
 	bind_method(Basis, orthonormalized, sarray(), varray());
 	bind_method(Basis, determinant, sarray(), varray());
-	bind_methodv(Basis, rotated, static_cast<Basis (Basis::*)(const Vector3 &, float) const>(&Basis::rotated), sarray("axis", "phi"), varray());
+	bind_methodv(Basis, rotated, static_cast<Basis (Basis::*)(const Vector3 &, real_t) const>(&Basis::rotated), sarray("axis", "phi"), varray());
 	bind_method(Basis, scaled, sarray("scale"), varray());
 	bind_method(Basis, get_scale, sarray(), varray());
 	bind_method(Basis, get_euler, sarray(), varray());


### PR DESCRIPTION
Fixes #45307:

* Remove Color's `/= real_t` or `/= float` check for if the divisor is zero. This needs approval from @reduz.

* Color's operators are changed from `real_t` to `float` because `Color` never has a need for more precision than `float` (using `double` is useless for `Color`).

* Color's operators have the parameter name `p_rvalue` changed to `p_scalar` (this is what the vectors use).

Additionally:

* Use `get_float()` for `Color` in `core/io/resource_format_binary.cpp`

* Use `real_t` for `AABB` quantizing methods (new in #44656).

* Use `real_t` for `Basis` rotated binding.

* Use `int` instead of `double` for integer calculations in `String::similarity`.