### PR TITLE
Added missed Button `font_hover_pressed_color` style

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -124,6 +124,9 @@
 		<theme_item name="font_hover_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] used when the [Button] is being hovered.
 		</theme_item>
+		<theme_item name="font_hover_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Text [Color] used when the [Button] is being hovered and pressed.
+		</theme_item>
 		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text outline [Color] of the [Button].
 		</theme_item>
@@ -149,7 +152,7 @@
 			Icon modulate [Color] used when the [Button] is being hovered and pressed.
 		</theme_item>
 		<theme_item name="icon_normal_color" type="Color" default="Color( 1, 1, 1, 1 )">
-			Default icon [Color] of the [Button].
+			Default icon modulate [Color] of the [Button].
 		</theme_item>
 		<theme_item name="icon_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Icon modulate [Color] used when the [Button] is being pressed.

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -188,6 +188,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color", "Button", control_font_color);
 	theme->set_color("font_pressed_color", "Button", control_font_pressed_color);
 	theme->set_color("font_hover_color", "Button", control_font_hover_color);
+	theme->set_color("font_hover_pressed_color", "Button", control_font_pressed_color);
 	theme->set_color("font_disabled_color", "Button", control_font_disabled_color);
 	theme->set_color("font_outline_color", "Button", Color(1, 1, 1));
 


### PR DESCRIPTION
Continuation of #38559 - added a style which is still missed.