### PR TITLE
Fix unexpected behavior when setting position of KinematicBody2D with Sync to Physics enabled

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1210,10 +1210,6 @@ void KinematicBody2D::_notification(int p_what) {
 		//used by sync to physics, send the new transform to the physics
 		Transform2D new_transform = get_global_transform();
 		PhysicsServer2D::get_singleton()->body_set_state(get_rid(), PhysicsServer2D::BODY_STATE_TRANSFORM, new_transform);
-		//but then revert changes
-		set_notify_local_transform(false);
-		set_global_transform(last_valid_transform);
-		set_notify_local_transform(true);
 	}
 }
 


### PR DESCRIPTION
As I understood in the "Sync to Physics" mode, any change in position causes the following chain of events:
1. all changes in transform for objects with "Sync to Physics" enabled are transferred to the "PhysicsServer2D" queue
2. when all changes are transferred and the "Physics frame" occurs, the physics is calculated
3. "PhysicsDirectBodyState2D" is passed to all objects with "Sync to Physics" and the transform is changed

The problem here is that at the first step after passing the transform of the object, it is restored to the old one (since this position will then come to the object through a callback). Thus, with the "Sync to Physics" mode enabled, you should make single changes to transform in "_process".

As a solution, I suggest not to restore the transform to the old one after the transfer.

I am new to this project and am not sure that such a solution will not cause new bugs.

<i>Bugsquad edit</i>: Fix #45483