### PR TITLE
Fix disconnection between Gizmo and inspector values on BakedLightmap

### DIFF
--- a/scene/3d/baked_lightmap.cpp
+++ b/scene/3d/baked_lightmap.cpp
@@ -1055,7 +1055,7 @@ float BakedLightmap::get_capture_cell_size() const {
 void BakedLightmap::set_extents(const Vector3 &p_extents) {
 	extents = p_extents;
 	update_gizmo();
-	_change_notify("bake_extents");
+	_change_notify("extents");
 }
 
 Vector3 BakedLightmap::get_extents() const {


### PR DESCRIPTION
After adding `_change_notify("extents");` to `set_extents()` method in `BakedLightmap` class
the issue was fixed

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/45317.*

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
