### PR TITLE
Cache world in VisibilityNotifier3D to avoid crash

### DIFF
--- a/scene/3d/visibility_notifier_3d.cpp
+++ b/scene/3d/visibility_notifier_3d.cpp
@@ -80,13 +80,16 @@ AABB VisibilityNotifier3D::get_aabb() const {
 void VisibilityNotifier3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_WORLD: {
-			get_world_3d()->_register_notifier(this, get_global_transform().xform(aabb));
+			world = get_world_3d();
+			ERR_FAIL_COND(!world.is_valid());
+			world->_register_notifier(this, get_global_transform().xform(aabb));
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			get_world_3d()->_update_notifier(this, get_global_transform().xform(aabb));
+			world->_update_notifier(this, get_global_transform().xform(aabb));
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {
-			get_world_3d()->_remove_notifier(this);
+			ERR_FAIL_COND(!world.is_valid());
+			world->_remove_notifier(this);
 		} break;
 	}
 }

--- a/scene/3d/visibility_notifier_3d.h
+++ b/scene/3d/visibility_notifier_3d.h
@@ -33,10 +33,12 @@
 
 #include "scene/3d/node_3d.h"
 
+class World3D;
 class Camera3D;
 class VisibilityNotifier3D : public Node3D {
 	GDCLASS(VisibilityNotifier3D, Node3D);
 
+	Ref<World3D> world;
 	Set<Camera3D *> cameras;
 
 	AABB aabb;


### PR DESCRIPTION
Fixes #45508
Not sure why the world was null, but if it works...