### PR TITLE
Prevent fatal error in WebXR when 'immersize-ar' loses and regains tracking

### DIFF
--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -380,6 +380,11 @@ const GodotWebXR = {
 				gl.deleteTexture(texture);
 			}
 			GodotWebXR.textures[i] = null;
+
+			const texture_id = GodotWebXR.texture_ids[i];
+			if (texture_id !== null) {
+				GL.textures[texture_id] = null;
+			}
 			GodotWebXR.texture_ids[i] = null;
 		}
 
@@ -460,13 +465,20 @@ const GodotWebXR = {
 	godot_webxr_get_external_texture_for_eye__proxy: 'sync',
 	godot_webxr_get_external_texture_for_eye__sig: 'ii',
 	godot_webxr_get_external_texture_for_eye: function (p_eye) {
-		if (!GodotWebXR.session || !GodotWebXR.pose) {
+		if (!GodotWebXR.session) {
 			return 0;
 		}
 
 		const view_index = (p_eye === 2 /* ARVRInterface::EYE_RIGHT */) ? 1 : 0;
 		if (GodotWebXR.texture_ids[view_index]) {
 			return GodotWebXR.texture_ids[view_index];
+		}
+
+		// Check pose separately and after returning the cached texture id,
+		// because we won't get a pose in some cases if we lose tracking, and
+		// we don't want to return 0 just because tracking was lost.
+		if (!GodotWebXR.pose) {
+			return 0;
 		}
 
 		const glLayer = GodotWebXR.session.renderState.baseLayer;

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -47,7 +47,6 @@ class WebXRInterfaceJS : public WebXRInterface {
 private:
 	bool initialized;
 
-	// @todo Should these really use enums instead of strings?
 	String session_mode;
 	String required_features;
 	String optional_features;
@@ -55,6 +54,7 @@ private:
 	String reference_space_type;
 
 	bool controllers_state[2];
+	Size2 render_targetsize;
 
 	Transform _js_matrix_to_transform(float *p_js_matrix);
 	void _update_tracker(int p_controller_id);


### PR DESCRIPTION
Fixes #45504

When tracking is lost, WebXR would start returning 0 for the eye texture and 0x0 for the eye texture dimensions, which was causing Godot to delete the old texture, leading to a fatal error when tracking came back and it tried to use the same texture again.

This PR fixes that, as well as a couple of areas (that I discovered while debugging this) where WebXR wasn't cleaning up after itself when it was uninitialized or an error was reached.

I tested 'immersive-vr' on Oculus Quest, Google Cardboard and the WebXR emulator. And I tested 'immersize-ar' on my Samsung Note 8 phone.

As always more testing on more devices is appreciated! Here is a version of my demo that includes this patch if anyone has an opportunity to test it:

http://bit.ly/godot-webxr-08

This won't cherry-pick cleanly to 3.2, so I'll make a separate PR in a moment.