### PR TITLE
Navigating to error line number in Rider from Godot editor debugger console is off-by-one.

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -104,7 +104,7 @@ namespace GodotTools.Ides.Rider
             if (line >= 0)
             {
                 args.Add("--line");
-                args.Add(line.ToString());
+                args.Add((line + 1).ToString()); // https://github.com/JetBrains/godot-support/issues/61
             }
             args.Add(scriptPath);
             try


### PR DESCRIPTION
Fix https://github.com/JetBrains/godot-support/issues/61