### PR TITLE
BVH fix pairing AABB init and mask checks

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -90,10 +90,10 @@ public:
 
 	BVHHandle create(T *p_userdata, const AABB &p_aabb = AABB(), int p_subindex = 0, bool p_pairable = false, uint32_t p_pairable_type = 0, uint32_t p_pairable_mask = 1) {
 
-		// not completely sure why, but the order of the pairing callbacks seems to be causing problems in
-		// the render tree unless these are flushed before creating a new object
+		// not sure if absolutely necessary to flush collisions here. It will cost performance to, instead
+		// of waiting for update, so only uncomment this if there are bugs.
 		if (USE_PAIRS) {
-			_check_for_collisions();
+			//_check_for_collisions();
 		}
 
 #ifdef TOOLS_ENABLED
@@ -107,7 +107,15 @@ public:
 		BVHHandle h = tree.item_add(p_userdata, p_aabb, p_subindex, p_pairable, p_pairable_type, p_pairable_mask);
 
 		if (USE_PAIRS) {
-			_add_changed_item(h, p_aabb);
+			// for safety initialize the expanded AABB
+			AABB &expanded_aabb = tree._pairs[h.id()].expanded_aabb;
+			expanded_aabb = p_aabb;
+			expanded_aabb.grow_by(tree._pairing_expansion);
+
+			// force a collision check no matter the AABB
+			_add_changed_item(h, p_aabb, false);
+
+			_check_for_collisions(true);
 		}
 
 		return h;
@@ -170,6 +178,8 @@ public:
 		}
 
 		tree.item_remove(p_handle);
+
+		_check_for_collisions(true);
 	}
 
 	// call e.g. once per frame (this does a trickle optimize)
@@ -192,11 +202,9 @@ public:
 
 		if (USE_PAIRS) {
 
-			// not completely sure why, but the order of the pairing callbacks seems to be causing problems in
-			// the render tree unless these are flushed before creating a new object.. we will do this for set_pairable
-			// to just in case. This may not be required, and may slow things down slightly when there are a lot
-			// of visibility changes in a frame
-			_check_for_collisions();
+			// not sure if absolutely necessary to flush collisions here. It will cost performance to, instead
+			// of waiting for update, so only uncomment this if there are bugs.
+			//_check_for_collisions();
 
 			// when the pairable state changes, we need to force a collision check because newly pairable
 			// items may be in collision, and unpairable items might move out of collision.

--- a/core/math/bvh_pair.inc
+++ b/core/math/bvh_pair.inc
@@ -14,6 +14,7 @@ struct ItemPairs {
 	void clear() {
 		num_pairs = 0;
 		extended_pairs.reset();
+		expanded_aabb = AABB();
 	}
 
 	AABB expanded_aabb;


### PR DESCRIPTION
Fix bug whereby AABBs were reused from previous items due to use of a pool, resulting in missed collisions.
Also use full mask collision checks for all cases except generic update.

All these bugs have not been in the BVH itself, but in the collision pairing, which is an extra layer on top of the BVH to meet the interface of 3.2. In 4.0, the pairing is currently done externally to the spatial partitioning. The pairing is quite error prone, as it relies both on masks and can be sensitive to the order of operations. The mask checks could be done everytime, but this would unnecessarily slow down collision detection, so in the long run it is worth working through these difficult bugs.

## Notes
* I now think the previous PR was only working in a test case by accident - the bug exhibits much like a race condition and is timing dependent.
* The AABBs not being reset on reuse in the pool explains why forcing the pool to not reuse items cured the bug (however it resulted in a memory leak instead, so this proper fix was required).
* The need for a full mask collision check was resulting rarely in some incorrect pairings when a cheaper no mask test was being used.
* Full mask collision checks are more expensive, so it can be a good idea to avoid them when not strictly necessary. For that reason full mask collision checks are used in all flushes, except the regular frame update. This means the regular frame update should be cheap, as move objects will only be moving and not changing their masks on a frame to frame basis.
* It is possible that the full mask check is not needed in some of the other situations, but I've always used it for safety at the moment, due to the bugs created being so difficult to solve.

Fixes #45461
_(I hope! :grinning: )_
May fix #45292
Fixes #45543

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
