### PR TITLE
[3.3] Backport hex_to_int/bin_to_int zero check and C# changes

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1670,9 +1670,10 @@ String::String(const StrRange &p_range) {
 }
 
 int String::hex_to_int(bool p_with_prefix) const {
-
-	if (p_with_prefix && length() < 3)
+	int len = length();
+	if (len == 0 || (p_with_prefix && len < 3)) {
 		return 0;
+	}
 
 	const CharType *s = ptr();
 
@@ -1755,9 +1756,10 @@ int64_t String::hex_to_int64(bool p_with_prefix) const {
 }
 
 int64_t String::bin_to_int64(bool p_with_prefix) const {
-
-	if (p_with_prefix && length() < 3)
+	int len = length();
+	if (len == 0 || (p_with_prefix && len < 3)) {
 		return 0;
+	}
 
 	const CharType *s = ptr();
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -97,6 +97,36 @@ namespace Godot
             return b;
         }
 
+        /// <summary>
+        /// Converts a string containing a binary number into an integer.
+        /// Binary strings can either be prefixed with `0b` or not,
+        /// and they can also start with a `-` before the optional prefix.
+        /// </summary>
+        /// <param name="instance">The string to convert.</param>
+        /// <returns>The converted string.</returns>
+        public static int BinToInt(this string instance)
+        {
+            if (instance.Length == 0)
+            {
+                return 0;
+            }
+
+            int sign = 1;
+
+            if (instance[0] == '-')
+            {
+                sign = -1;
+                instance = instance.Substring(1);
+            }
+
+            if (instance.StartsWith("0b"))
+            {
+                instance = instance.Substring(2);
+            }
+
+            return sign * Convert.ToInt32(instance, 2);;
+        }
+
         // <summary>
         // Return the amount of substrings in string.
         // </summary>
@@ -457,7 +487,7 @@ namespace Godot
         /// <summary>
         /// Returns a hexadecimal representation of this byte as a string.
         /// </summary>
-        /// <param name="bytes">The byte to encode.</param>
+        /// <param name="b">The byte to encode.</param>
         /// <returns>The hexadecimal representation of this byte.</returns>
         internal static string HexEncode(this byte b)
         {
@@ -501,11 +531,20 @@ namespace Godot
             return ret;
         }
 
-        // <summary>
-        // Convert a string containing an hexadecimal number into an int.
-        // </summary>
+        /// <summary>
+        /// Converts a string containing a hexadecimal number into an integer.
+        /// Hexadecimal strings can either be prefixed with `0x` or not,
+        /// and they can also start with a `-` before the optional prefix.
+        /// </summary>
+        /// <param name="instance">The string to convert.</param>
+        /// <returns>The converted string.</returns>
         public static int HexToInt(this string instance)
         {
+            if (instance.Length == 0)
+            {
+                return 0;
+            }
+
             int sign = 1;
 
             if (instance[0] == '-')
@@ -514,10 +553,12 @@ namespace Godot
                 instance = instance.Substring(1);
             }
 
-            if (!instance.StartsWith("0x"))
-                return 0;
+            if (instance.StartsWith("0x"))
+            {
+                instance = instance.Substring(2);
+            }
 
-            return sign * int.Parse(instance.Substring(2), NumberStyles.HexNumber);
+            return sign * int.Parse(instance, NumberStyles.HexNumber);
         }
 
         // <summary>


### PR DESCRIPTION
See #43978. This backports the zero check, and also backports the C# changes including adding `BinToInt`.

Crashing with a zero length string can't be done from GDScript in Godot 3.2, but could potentially be done elsewhere.