### PR TITLE
Don't handle BaseException in JavaScript build script

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -57,12 +57,11 @@ def get_flags():
 
 
 def configure(env):
-    if not isinstance(env["initial_memory"], int):
-        try:
-            env["initial_memory"] = int(env["initial_memory"])
-        except:
-            print("Initial memory must be a valid integer")
-            sys.exit(255)
+    try:
+        env["initial_memory"] = int(env["initial_memory"])
+    except Exception:
+        print("Initial memory must be a valid integer")
+        sys.exit(255)
 
     ## Build type
     if env["target"] == "release":


### PR DESCRIPTION
As identified by [LGTM](https://lgtm.com/projects/g/godotengine/godot/rev/abb8d8e8ca75b8aaa614f768bebed41ad88ff39f), when ensuring that `initial_memory` value is an integer, the JavaScript build script is catching all exceptions including the BaseException. The `BaseException` includes `SystemExit` and `KeyboardInterrupt` exceptions. `SystemExit` and `KeyboardInterrupt` exceptions should not be caught unless they're specifically being handled.

Note: This was introduced by abb8d8e8ca75b, which partially reverted the previous attempt to not handle the `BaseException` in #44315, which incorrectly assumed it was being used to simply check whether or not the value was an integer. Therefore, this PR includes fully reverting that change and just correctly only handling `Exception` as should have been done in #44315.
