### PR TITLE
[3.2] Don't handle BaseException in JavaScript build script

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -59,7 +59,7 @@ def get_flags():
 def configure(env):
     try:
         env["initial_memory"] = int(env["initial_memory"])
-    except:
+    except Exception:
         print("Initial memory must be a valid integer")
         sys.exit(255)
 


### PR DESCRIPTION
3.2 version of #45539.
