### PR TITLE
support for instantiating rasterizer dummy in headless mode

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -565,6 +565,8 @@ public:
 	void mesh_set_custom_aabb(RID p_mesh, const AABB &p_aabb) override {}
 	AABB mesh_get_custom_aabb(RID p_mesh) const override { return AABB(); }
 
+	void mesh_set_shadow_mesh(RID p_mesh, RID p_shadow_mesh) override {}
+
 	AABB mesh_get_aabb(RID p_mesh, RID p_skeleton = RID()) override { return AABB(); }
 	void mesh_clear(RID p_mesh) override {}
 


### PR DESCRIPTION
small fix for instantiating rasterizer_dummy if you run in headless mode