### PR TITLE
Remove reference to CanvasLayer in WebXR example, because it can cause rendering issues in AR

### DIFF
--- a/modules/webxr/doc_classes/WebXRInterface.xml
+++ b/modules/webxr/doc_classes/WebXRInterface.xml
@@ -14,9 +14,9 @@
         var vr_supported = false
 
         func _ready():
-            # We assume this node has a canvas layer with a button on it as a child.
+            # We assume this node has a button as a child.
             # This button is for the user to consent to entering immersive VR mode.
-            $CanvasLayer/Button.connect("pressed", self, "_on_Button_pressed")
+            $Button.connect("pressed", self, "_on_Button_pressed")
 
             webxr_interface = XRServer.find_interface("WebXR")
             if webxr_interface:
@@ -65,6 +65,7 @@
                 return
 
         func _webxr_session_started():
+            $Button.visible = false
             # This tells Godot to start rendering to the headset.
             get_viewport().xr = true
             # This will be the reference space type you ultimately got, out of the
@@ -73,6 +74,7 @@
             print ("Reference space type: " + webxr_interface.reference_space_type)
 
         func _webxr_session_ended():
+            $Button.visible = true
             # If the user exits immersive mode, then we tell Godot to render to the web
             # page again.
             get_viewport().xr = false


### PR DESCRIPTION
Fixes #45505 

The WebXR example in the docs recommends putting the "Enter VR" button under a `CanvasLayer`. While no one has seen this cause issues with VR, it has been shown to cause rendering problems in AR with Android smartphones.

To avoid folks encountering this problem when trying to use WebXR with AR in the future, let's remove that recommendation from the docs!

This should cherry-pick cleanly to Godot 3.2.