### PR TITLE
GraphNode: Add properties for custom icons

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -71,6 +71,8 @@ bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 		si.enable_left = p_value;
 	} else if (what == "left_type") {
 		si.type_left = p_value;
+	} else if (what == "left_icon") {
+		si.custom_slot_left = p_value;
 	} else if (what == "left_color") {
 		si.color_left = p_value;
 	} else if (what == "right_enabled") {
@@ -79,11 +81,13 @@ bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 		si.type_right = p_value;
 	} else if (what == "right_color") {
 		si.color_right = p_value;
+	} else if (what == "right_icon") {
+		si.custom_slot_right = p_value;
 	} else {
 		return false;
 	}
 
-	set_slot(idx, si.enable_left, si.type_left, si.color_left, si.enable_right, si.type_right, si.color_right);
+	set_slot(idx, si.enable_left, si.type_left, si.color_left, si.enable_right, si.type_right, si.color_right, si.custom_slot_left, si.custom_slot_right);
 	update();
 	return true;
 }
@@ -120,12 +124,16 @@ bool GraphNode::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = si.type_left;
 	} else if (what == "left_color") {
 		r_ret = si.color_left;
+	} else if (what == "left_icon") {
+		r_ret = si.custom_slot_left;
 	} else if (what == "right_enabled") {
 		r_ret = si.enable_right;
 	} else if (what == "right_type") {
 		r_ret = si.type_right;
 	} else if (what == "right_color") {
 		r_ret = si.color_right;
+	} else if (what == "right_icon") {
+		r_ret = si.custom_slot_right;
 	} else {
 		return false;
 	}
@@ -152,9 +160,11 @@ void GraphNode::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::BOOL, base + "left_enabled"));
 		p_list->push_back(PropertyInfo(Variant::INT, base + "left_type"));
 		p_list->push_back(PropertyInfo(Variant::COLOR, base + "left_color"));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, base + "left_icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
 		p_list->push_back(PropertyInfo(Variant::BOOL, base + "right_enabled"));
 		p_list->push_back(PropertyInfo(Variant::INT, base + "right_type"));
 		p_list->push_back(PropertyInfo(Variant::COLOR, base + "right_color"));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, base + "right_icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
 
 		idx++;
 	}
@@ -355,7 +365,9 @@ void GraphNode::_shape() {
 void GraphNode::set_slot(int p_idx, bool p_enable_left, int p_type_left, const Color &p_color_left, bool p_enable_right, int p_type_right, const Color &p_color_right, const Ref<Texture2D> &p_custom_left, const Ref<Texture2D> &p_custom_right) {
 	ERR_FAIL_COND(p_idx < 0);
 
-	if (!p_enable_left && p_type_left == 0 && p_color_left == Color(1, 1, 1, 1) && !p_enable_right && p_type_right == 0 && p_color_right == Color(1, 1, 1, 1)) {
+	if (!p_enable_left && p_type_left == 0 && p_color_left == Color(1, 1, 1, 1) &&
+			!p_enable_right && p_type_right == 0 && p_color_right == Color(1, 1, 1, 1) &&
+			!p_custom_left.is_valid() && !p_custom_right.is_valid()) {
 		slot_info.erase(p_idx);
 		return;
 	}


### PR DESCRIPTION
Add properties for the slots' icon textures, so they can be set easily in the editor.

Fixes #45487.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
