### PR TITLE
Fix tile origin = bottom left for isometric tiles

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -884,15 +884,15 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 
 			if (p_transpose) {
 				if (p_flip_h) {
-					rect.position.x -= cell_size.x;
+					rect.position.x -= cell_size.x - rect.size.x;
 				} else {
-					rect.position.x += cell_size.x;
+					rect.position.x += cell_size.x - rect.size.x;
 				}
 			} else {
 				if (p_flip_v) {
-					rect.position.y -= cell_size.y;
+					rect.position.y -= cell_size.y - rect.size.y;
 				} else {
-					rect.position.y += cell_size.y;
+					rect.position.y += cell_size.y - rect.size.y;
 				}
 			}
 
@@ -900,15 +900,15 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 			rect.position += tile_ofs;
 
 			if (p_flip_h) {
-				rect.position.x -= cell_size.x / 2;
+				rect.position.x -= cell_size.x / 2 - rect.size.x / 2;
 			} else {
-				rect.position.x += cell_size.x / 2;
+				rect.position.x += cell_size.x / 2 - rect.size.x / 2;
 			}
 
 			if (p_flip_v) {
-				rect.position.y -= cell_size.y / 2;
+				rect.position.y -= cell_size.y / 2 - rect.size.y / 2;
 			} else {
-				rect.position.y += cell_size.y / 2;
+				rect.position.y += cell_size.y / 2 - rect.size.y / 2;
 			}
 		}
 	} else {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -497,15 +497,15 @@ void TileMap::update_dirty_quadrants() {
 
 					if (c.transpose) {
 						if (c.flip_h) {
-							rect.position.x -= cell_size.x;
+							rect.position.x -= cell_size.x - rect.size.x;
 						} else {
-							rect.position.x += cell_size.x;
+							rect.position.x += cell_size.x - rect.size.x;
 						}
 					} else {
 						if (c.flip_v) {
-							rect.position.y -= cell_size.y;
+							rect.position.y -= cell_size.y - rect.size.y;
 						} else {
-							rect.position.y += cell_size.y;
+							rect.position.y += cell_size.y - rect.size.y;
 						}
 					}
 
@@ -513,15 +513,15 @@ void TileMap::update_dirty_quadrants() {
 					rect.position += tile_ofs;
 
 					if (c.flip_h) {
-						rect.position.x -= cell_size.x / 2;
+						rect.position.x -= cell_size.x / 2 - rect.size.x / 2;
 					} else {
-						rect.position.x += cell_size.x / 2;
+						rect.position.x += cell_size.x / 2 - rect.size.x / 2;
 					}
 
 					if (c.flip_v) {
-						rect.position.y -= cell_size.y / 2;
+						rect.position.y -= cell_size.y / 2 - rect.size.y / 2;
 					} else {
-						rect.position.y += cell_size.y / 2;
+						rect.position.y += cell_size.y / 2 - rect.size.y / 2;
 					}
 				}
 			} else {


### PR DESCRIPTION
In compatibility mode tile origin was calculated without regards of sprite height.

Before:
![2021-01-29-101223](https://user-images.githubusercontent.com/1177068/106245817-2c7f1900-621e-11eb-935b-09294a71882b.gif)


After:
![2021-01-29-095924](https://user-images.githubusercontent.com/1177068/106245841-3a349e80-621e-11eb-86f6-0d4c65b86145.gif)

Fixes: https://github.com/godotengine/godot/issues/45533

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
