### PR TITLE
Use real_t in 3D nodes

### DIFF
--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -153,7 +153,7 @@ Transform3D Camera3D::get_camera_transform() const {
 	return tr;
 }
 
-void Camera3D::set_perspective(float p_fovy_degrees, float p_z_near, float p_z_far) {
+void Camera3D::set_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far) {
 	if (!force_change && fov == p_fovy_degrees && p_z_near == near && p_z_far == far && mode == PROJECTION_PERSPECTIVE) {
 		return;
 	}
@@ -168,7 +168,7 @@ void Camera3D::set_perspective(float p_fovy_degrees, float p_z_near, float p_z_f
 	force_change = false;
 }
 
-void Camera3D::set_orthogonal(float p_size, float p_z_near, float p_z_far) {
+void Camera3D::set_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far) {
 	if (!force_change && size == p_size && p_z_near == near && p_z_far == far && mode == PROJECTION_ORTHOGONAL) {
 		return;
 	}
@@ -184,7 +184,7 @@ void Camera3D::set_orthogonal(float p_size, float p_z_near, float p_z_far) {
 	update_gizmos();
 }
 
-void Camera3D::set_frustum(float p_size, Vector2 p_offset, float p_z_near, float p_z_far) {
+void Camera3D::set_frustum(real_t p_size, Vector2 p_offset, real_t p_z_near, real_t p_z_far) {
 	if (!force_change && size == p_size && frustum_offset == p_offset && p_z_near == near && p_z_far == far && mode == PROJECTION_FRUSTUM) {
 		return;
 	}
@@ -295,7 +295,7 @@ Vector3 Camera3D::project_ray_origin(const Point2 &p_pos) const {
 		return get_camera_transform().origin;
 	} else {
 		Vector2 pos = cpos / viewport_size;
-		float vsize, hsize;
+		real_t vsize, hsize;
 		if (keep_aspect == KEEP_WIDTH) {
 			vsize = size / viewport_size.aspect();
 			hsize = size;
@@ -368,7 +368,7 @@ Point2 Camera3D::unproject_position(const Vector3 &p_pos) const {
 	return res;
 }
 
-Vector3 Camera3D::project_position(const Point2 &p_point, float p_z_depth) const {
+Vector3 Camera3D::project_position(const Point2 &p_point, real_t p_z_depth) const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
 
 	if (p_z_depth == 0 && mode != PROJECTION_ORTHOGONAL) {
@@ -531,15 +531,15 @@ void Camera3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOPPLER_TRACKING_PHYSICS_STEP);
 }
 
-float Camera3D::get_fov() const {
+real_t Camera3D::get_fov() const {
 	return fov;
 }
 
-float Camera3D::get_size() const {
+real_t Camera3D::get_size() const {
 	return size;
 }
 
-float Camera3D::get_near() const {
+real_t Camera3D::get_near() const {
 	return near;
 }
 
@@ -547,7 +547,7 @@ Vector2 Camera3D::get_frustum_offset() const {
 	return frustum_offset;
 }
 
-float Camera3D::get_far() const {
+real_t Camera3D::get_far() const {
 	return far;
 }
 
@@ -555,19 +555,19 @@ Camera3D::Projection Camera3D::get_projection() const {
 	return mode;
 }
 
-void Camera3D::set_fov(float p_fov) {
+void Camera3D::set_fov(real_t p_fov) {
 	ERR_FAIL_COND(p_fov < 1 || p_fov > 179);
 	fov = p_fov;
 	_update_camera_mode();
 }
 
-void Camera3D::set_size(float p_size) {
+void Camera3D::set_size(real_t p_size) {
 	ERR_FAIL_COND(p_size < 0.1 || p_size > 16384);
 	size = p_size;
 	_update_camera_mode();
 }
 
-void Camera3D::set_near(float p_near) {
+void Camera3D::set_near(real_t p_near) {
 	near = p_near;
 	_update_camera_mode();
 }
@@ -577,7 +577,7 @@ void Camera3D::set_frustum_offset(Vector2 p_offset) {
 	_update_camera_mode();
 }
 
-void Camera3D::set_far(float p_far) {
+void Camera3D::set_far(real_t p_far) {
 	far = p_far;
 	_update_camera_mode();
 }
@@ -630,21 +630,21 @@ bool Camera3D::is_position_in_frustum(const Vector3 &p_position) const {
 	return true;
 }
 
-void Camera3D::set_v_offset(float p_offset) {
+void Camera3D::set_v_offset(real_t p_offset) {
 	v_offset = p_offset;
 	_update_camera();
 }
 
-float Camera3D::get_v_offset() const {
+real_t Camera3D::get_v_offset() const {
 	return v_offset;
 }
 
-void Camera3D::set_h_offset(float p_offset) {
+void Camera3D::set_h_offset(real_t p_offset) {
 	h_offset = p_offset;
 	_update_camera();
 }
 
-float Camera3D::get_h_offset() const {
+real_t Camera3D::get_h_offset() const {
 	return h_offset;
 }
 
@@ -672,11 +672,11 @@ Camera3D::~Camera3D() {
 
 ////////////////////////////////////////
 
-void ClippedCamera3D::set_margin(float p_margin) {
+void ClippedCamera3D::set_margin(real_t p_margin) {
 	margin = p_margin;
 }
 
-float ClippedCamera3D::get_margin() const {
+real_t ClippedCamera3D::get_margin() const {
 	return margin;
 }
 
@@ -746,7 +746,7 @@ void ClippedCamera3D::_notification(int p_what) {
 		xf.origin = ray_from;
 		xf.orthonormalize();
 
-		float closest_safe = 1.0f, closest_unsafe = 1.0f;
+		real_t closest_safe = 1.0f, closest_unsafe = 1.0f;
 		if (dspace->cast_motion(pyramid_shape, xf, cam_pos - ray_from, margin, closest_safe, closest_unsafe, exclude, collision_mask, clip_to_bodies, clip_to_areas)) {
 			clip_offset = cam_pos.distance_to(ray_from + (cam_pos - ray_from) * closest_safe);
 		}
@@ -813,7 +813,7 @@ void ClippedCamera3D::clear_exceptions() {
 	exclude.clear();
 }
 
-float ClippedCamera3D::get_clip_offset() const {
+real_t ClippedCamera3D::get_clip_offset() const {
 	return clip_offset;
 }
 

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -63,13 +63,13 @@ private:
 
 	Projection mode = PROJECTION_PERSPECTIVE;
 
-	float fov = 0.0;
-	float size = 1.0;
+	real_t fov = 0.0;
+	real_t size = 1.0;
 	Vector2 frustum_offset;
-	float near = 0.0;
-	float far = 0.0;
-	float v_offset = 0.0;
-	float h_offset = 0.0;
+	real_t near = 0.0;
+	real_t far = 0.0;
+	real_t v_offset = 0.0;
+	real_t h_offset = 0.0;
 	KeepAspect keep_aspect = KEEP_HEIGHT;
 
 	RID camera;
@@ -107,10 +107,9 @@ public:
 		NOTIFICATION_LOST_CURRENT = 51
 	};
 
-	void set_perspective(float p_fovy_degrees, float p_z_near, float p_z_far);
-	void set_orthogonal(float p_size, float p_z_near, float p_z_far);
-	void set_frustum(float p_size, Vector2 p_offset, float p_z_near,
-			float p_z_far);
+	void set_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far);
+	void set_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far);
+	void set_frustum(real_t p_size, Vector2 p_offset, real_t p_z_near, real_t p_z_far);
 	void set_projection(Camera3D::Projection p_mode);
 
 	void make_current();
@@ -120,18 +119,18 @@ public:
 
 	RID get_camera() const;
 
-	float get_fov() const;
-	float get_size() const;
-	float get_far() const;
-	float get_near() const;
+	real_t get_fov() const;
+	real_t get_size() const;
+	real_t get_far() const;
+	real_t get_near() const;
 	Vector2 get_frustum_offset() const;
 
 	Projection get_projection() const;
 
-	void set_fov(float p_fov);
-	void set_size(float p_size);
-	void set_far(float p_far);
-	void set_near(float p_near);
+	void set_fov(real_t p_fov);
+	void set_size(real_t p_size);
+	void set_far(real_t p_far);
+	void set_near(real_t p_near);
 	void set_frustum_offset(Vector2 p_offset);
 
 	virtual Transform3D get_camera_transform() const;
@@ -141,8 +140,7 @@ public:
 	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const;
 	virtual Point2 unproject_position(const Vector3 &p_pos) const;
 	bool is_position_behind(const Vector3 &p_pos) const;
-	virtual Vector3 project_position(const Point2 &p_point,
-			float p_z_depth) const;
+	virtual Vector3 project_position(const Point2 &p_point, real_t p_z_depth) const;
 
 	Vector<Vector3> get_near_plane_points() const;
 
@@ -164,11 +162,11 @@ public:
 	void set_keep_aspect_mode(KeepAspect p_aspect);
 	KeepAspect get_keep_aspect_mode() const;
 
-	void set_v_offset(float p_offset);
-	float get_v_offset() const;
+	void set_v_offset(real_t p_offset);
+	real_t get_v_offset() const;
 
-	void set_h_offset(float p_offset);
-	float get_h_offset() const;
+	void set_h_offset(real_t p_offset);
+	real_t get_h_offset() const;
 
 	void set_doppler_tracking(DopplerTracking p_tracking);
 	DopplerTracking get_doppler_tracking() const;
@@ -195,8 +193,8 @@ public:
 private:
 	ClipProcessCallback process_callback = CLIP_PROCESS_PHYSICS;
 	RID pyramid_shape;
-	float margin = 0.0;
-	float clip_offset = 0.0;
+	real_t margin = 0.0;
+	real_t clip_offset = 0.0;
 	uint32_t collision_mask = 1;
 	bool clip_to_areas = false;
 	bool clip_to_bodies = true;
@@ -217,8 +215,8 @@ public:
 	void set_clip_to_bodies(bool p_clip);
 	bool is_clip_to_bodies_enabled() const;
 
-	void set_margin(float p_margin);
-	float get_margin() const;
+	void set_margin(real_t p_margin);
+	real_t get_margin() const;
 
 	void set_process_callback(ClipProcessCallback p_mode);
 	ClipProcessCallback get_process_callback() const;
@@ -235,7 +233,7 @@ public:
 	void remove_exception(const Object *p_object);
 	void clear_exceptions();
 
-	float get_clip_offset() const;
+	real_t get_clip_offset() const;
 
 	ClippedCamera3D();
 	~ClippedCamera3D();

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -91,11 +91,11 @@ void CPUParticles3D::set_pre_process_time(float p_time) {
 	pre_process_time = p_time;
 }
 
-void CPUParticles3D::set_explosiveness_ratio(float p_ratio) {
+void CPUParticles3D::set_explosiveness_ratio(real_t p_ratio) {
 	explosiveness_ratio = p_ratio;
 }
 
-void CPUParticles3D::set_randomness_ratio(float p_ratio) {
+void CPUParticles3D::set_randomness_ratio(real_t p_ratio) {
 	randomness_ratio = p_ratio;
 }
 
@@ -107,7 +107,7 @@ void CPUParticles3D::set_use_local_coordinates(bool p_enable) {
 	local_coords = p_enable;
 }
 
-void CPUParticles3D::set_speed_scale(float p_scale) {
+void CPUParticles3D::set_speed_scale(real_t p_scale) {
 	speed_scale = p_scale;
 }
 
@@ -131,11 +131,11 @@ float CPUParticles3D::get_pre_process_time() const {
 	return pre_process_time;
 }
 
-float CPUParticles3D::get_explosiveness_ratio() const {
+real_t CPUParticles3D::get_explosiveness_ratio() const {
 	return explosiveness_ratio;
 }
 
-float CPUParticles3D::get_randomness_ratio() const {
+real_t CPUParticles3D::get_randomness_ratio() const {
 	return randomness_ratio;
 }
 
@@ -147,7 +147,7 @@ bool CPUParticles3D::get_use_local_coordinates() const {
 	return local_coords;
 }
 
-float CPUParticles3D::get_speed_scale() const {
+real_t CPUParticles3D::get_speed_scale() const {
 	return speed_scale;
 }
 
@@ -247,47 +247,47 @@ Vector3 CPUParticles3D::get_direction() const {
 	return direction;
 }
 
-void CPUParticles3D::set_spread(float p_spread) {
+void CPUParticles3D::set_spread(real_t p_spread) {
 	spread = p_spread;
 }
 
-float CPUParticles3D::get_spread() const {
+real_t CPUParticles3D::get_spread() const {
 	return spread;
 }
 
-void CPUParticles3D::set_flatness(float p_flatness) {
+void CPUParticles3D::set_flatness(real_t p_flatness) {
 	flatness = p_flatness;
 }
 
-float CPUParticles3D::get_flatness() const {
+real_t CPUParticles3D::get_flatness() const {
 	return flatness;
 }
 
-void CPUParticles3D::set_param(Parameter p_param, float p_value) {
+void CPUParticles3D::set_param(Parameter p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 
 	parameters[p_param] = p_value;
 }
 
-float CPUParticles3D::get_param(Parameter p_param) const {
+real_t CPUParticles3D::get_param(Parameter p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 
 	return parameters[p_param];
 }
 
-void CPUParticles3D::set_param_randomness(Parameter p_param, float p_value) {
+void CPUParticles3D::set_param_randomness(Parameter p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 
 	randomness[p_param] = p_value;
 }
 
-float CPUParticles3D::get_param_randomness(Parameter p_param) const {
+real_t CPUParticles3D::get_param_randomness(Parameter p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 
 	return randomness[p_param];
 }
 
-static void _adjust_curve_range(const Ref<Curve> &p_curve, float p_min, float p_max) {
+static void _adjust_curve_range(const Ref<Curve> &p_curve, real_t p_min, real_t p_max) {
 	Ref<Curve> curve = p_curve;
 	if (!curve.is_valid()) {
 		return;
@@ -381,7 +381,7 @@ void CPUParticles3D::set_emission_shape(EmissionShape p_shape) {
 	emission_shape = p_shape;
 }
 
-void CPUParticles3D::set_emission_sphere_radius(float p_radius) {
+void CPUParticles3D::set_emission_sphere_radius(real_t p_radius) {
 	emission_sphere_radius = p_radius;
 }
 
@@ -405,19 +405,19 @@ void CPUParticles3D::set_emission_ring_axis(Vector3 p_axis) {
 	emission_ring_axis = p_axis;
 }
 
-void CPUParticles3D::set_emission_ring_height(float p_height) {
+void CPUParticles3D::set_emission_ring_height(real_t p_height) {
 	emission_ring_height = p_height;
 }
 
-void CPUParticles3D::set_emission_ring_radius(float p_radius) {
+void CPUParticles3D::set_emission_ring_radius(real_t p_radius) {
 	emission_ring_radius = p_radius;
 }
 
-void CPUParticles3D::set_emission_ring_inner_radius(float p_radius) {
+void CPUParticles3D::set_emission_ring_inner_radius(real_t p_radius) {
 	emission_ring_inner_radius = p_radius;
 }
 
-float CPUParticles3D::get_emission_sphere_radius() const {
+real_t CPUParticles3D::get_emission_sphere_radius() const {
 	return emission_sphere_radius;
 }
 
@@ -441,15 +441,15 @@ Vector3 CPUParticles3D::get_emission_ring_axis() const {
 	return emission_ring_axis;
 }
 
-float CPUParticles3D::get_emission_ring_height() const {
+real_t CPUParticles3D::get_emission_ring_height() const {
 	return emission_ring_height;
 }
 
-float CPUParticles3D::get_emission_ring_radius() const {
+real_t CPUParticles3D::get_emission_ring_radius() const {
 	return emission_ring_radius;
 }
 
-float CPUParticles3D::get_emission_ring_inner_radius() const {
+real_t CPUParticles3D::get_emission_ring_inner_radius() const {
 	return emission_ring_inner_radius;
 }
 
@@ -498,7 +498,7 @@ static uint32_t idhash(uint32_t x) {
 	return x;
 }
 
-static float rand_from_seed(uint32_t &seed) {
+static real_t rand_from_seed(uint32_t &seed) {
 	int k;
 	int s = int(seed);
 	if (s == 0) {
@@ -510,7 +510,7 @@ static float rand_from_seed(uint32_t &seed) {
 		s += 2147483647;
 	}
 	seed = uint32_t(s);
-	return float(seed % uint32_t(65536)) / 65535.0;
+	return (seed % uint32_t(65536)) / 65535.0;
 }
 
 void CPUParticles3D::_update_internal() {
@@ -627,7 +627,7 @@ void CPUParticles3D::_particles_process(float p_delta) {
 		// The phase is a ratio between 0 (birth) and 1 (end of life) for each particle.
 		// While we use time in tests later on, for randomness we use the phase as done in the
 		// original shader code, and we later multiply by lifetime to get the time.
-		float restart_phase = float(i) / float(pcount);
+		real_t restart_phase = real_t(i) / real_t(pcount);
 
 		if (randomness_ratio > 0.0) {
 			uint32_t seed = cycle;
@@ -636,8 +636,8 @@ void CPUParticles3D::_particles_process(float p_delta) {
 			}
 			seed *= uint32_t(pcount);
 			seed += uint32_t(i);
-			float random = float(idhash(seed) % uint32_t(65536)) / 65536.0;
-			restart_phase += randomness_ratio * random * 1.0 / float(pcount);
+			real_t random = (idhash(seed) % uint32_t(65536)) / real_t(65536.0);
+			restart_phase += randomness_ratio * random * 1.0 / pcount;
 		}
 
 		restart_phase *= (1.0 - explosiveness_ratio);
@@ -682,17 +682,17 @@ void CPUParticles3D::_particles_process(float p_delta) {
 			}
 			p.active = true;
 
-			/*float tex_linear_velocity = 0;
+			/*real_t tex_linear_velocity = 0;
 			if (curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
 				tex_linear_velocity = curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY]->interpolate(0);
 			}*/
 
-			float tex_angle = 0.0;
+			real_t tex_angle = 0.0;
 			if (curve_parameters[PARAM_ANGLE].is_valid()) {
 				tex_angle = curve_parameters[PARAM_ANGLE]->interpolate(tv);
 			}
 
-			float tex_anim_offset = 0.0;
+			real_t tex_anim_offset = 0.0;
 			if (curve_parameters[PARAM_ANGLE].is_valid()) {
 				tex_anim_offset = curve_parameters[PARAM_ANGLE]->interpolate(tv);
 			}
@@ -705,26 +705,26 @@ void CPUParticles3D::_particles_process(float p_delta) {
 			p.anim_offset_rand = Math::randf();
 
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-				float angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
+				real_t angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
 				Vector3 rot = Vector3(Math::cos(angle1_rad), Math::sin(angle1_rad), 0.0);
-				p.velocity = rot * parameters[PARAM_INITIAL_LINEAR_VELOCITY] * Math::lerp(1.0f, float(Math::randf()), randomness[PARAM_INITIAL_LINEAR_VELOCITY]);
+				p.velocity = rot * parameters[PARAM_INITIAL_LINEAR_VELOCITY] * Math::lerp((real_t)1.0, real_t(Math::randf()), randomness[PARAM_INITIAL_LINEAR_VELOCITY]);
 			} else {
 				//initiate velocity spread in 3D
-				float angle1_rad = Math::atan2(direction.x, direction.z) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
-				float angle2_rad = Math::atan2(direction.y, Math::abs(direction.z)) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * (1.0 - flatness) * spread);
+				real_t angle1_rad = Math::atan2(direction.x, direction.z) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
+				real_t angle2_rad = Math::atan2(direction.y, Math::abs(direction.z)) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * (1.0 - flatness) * spread);
 
 				Vector3 direction_xz = Vector3(Math::sin(angle1_rad), 0, Math::cos(angle1_rad));
 				Vector3 direction_yz = Vector3(0, Math::sin(angle2_rad), Math::cos(angle2_rad));
 				direction_yz.z = direction_yz.z / MAX(0.0001, Math::sqrt(ABS(direction_yz.z))); //better uniform distribution
 				Vector3 direction = Vector3(direction_xz.x * direction_yz.z, direction_yz.y, direction_xz.z * direction_yz.z);
 				direction.normalize();
-				p.velocity = direction * parameters[PARAM_INITIAL_LINEAR_VELOCITY] * Math::lerp(1.0f, float(Math::randf()), randomness[PARAM_INITIAL_LINEAR_VELOCITY]);
+				p.velocity = direction * parameters[PARAM_INITIAL_LINEAR_VELOCITY] * Math::lerp((real_t)1.0, real_t(Math::randf()), randomness[PARAM_INITIAL_LINEAR_VELOCITY]);
 			}
 
-			float base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp(1.0f, p.angle_rand, randomness[PARAM_ANGLE]);
+			real_t base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp((real_t)1.0, p.angle_rand, randomness[PARAM_ANGLE]);
 			p.custom[0] = Math::deg2rad(base_angle); //angle
 			p.custom[1] = 0.0; //phase
-			p.custom[2] = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp(1.0f, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]); //animation offset (0-1)
+			p.custom[2] = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp((real_t)1.0, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]); //animation offset (0-1)
 			p.transform = Transform3D();
 			p.time = 0;
 			p.lifetime = lifetime * (1.0 - Math::randf() * lifetime_randomness);
@@ -783,8 +783,8 @@ void CPUParticles3D::_particles_process(float p_delta) {
 					}
 				} break;
 				case EMISSION_SHAPE_RING: {
-					float ring_random_angle = Math::randf() * 2.0 * Math_PI;
-					float ring_random_radius = Math::randf() * (emission_ring_radius - emission_ring_inner_radius) + emission_ring_inner_radius;
+					real_t ring_random_angle = Math::randf() * Math_TAU;
+					real_t ring_random_radius = Math::randf() * (emission_ring_radius - emission_ring_inner_radius) + emission_ring_inner_radius;
 					Vector3 axis = emission_ring_axis.normalized();
 					Vector3 ortho_axis = Vector3();
 					if (axis == Vector3(1.0, 0.0, 0.0)) {
@@ -824,53 +824,53 @@ void CPUParticles3D::_particles_process(float p_delta) {
 			p.custom[1] = p.time / lifetime;
 			tv = p.time / p.lifetime;
 
-			float tex_linear_velocity = 0.0;
+			real_t tex_linear_velocity = 0.0;
 			if (curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
 				tex_linear_velocity = curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY]->interpolate(tv);
 			}
 
-			float tex_orbit_velocity = 0.0;
+			real_t tex_orbit_velocity = 0.0;
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 				if (curve_parameters[PARAM_ORBIT_VELOCITY].is_valid()) {
 					tex_orbit_velocity = curve_parameters[PARAM_ORBIT_VELOCITY]->interpolate(tv);
 				}
 			}
 
-			float tex_angular_velocity = 0.0;
+			real_t tex_angular_velocity = 0.0;
 			if (curve_parameters[PARAM_ANGULAR_VELOCITY].is_valid()) {
 				tex_angular_velocity = curve_parameters[PARAM_ANGULAR_VELOCITY]->interpolate(tv);
 			}
 
-			float tex_linear_accel = 0.0;
+			real_t tex_linear_accel = 0.0;
 			if (curve_parameters[PARAM_LINEAR_ACCEL].is_valid()) {
 				tex_linear_accel = curve_parameters[PARAM_LINEAR_ACCEL]->interpolate(tv);
 			}
 
-			float tex_tangential_accel = 0.0;
+			real_t tex_tangential_accel = 0.0;
 			if (curve_parameters[PARAM_TANGENTIAL_ACCEL].is_valid()) {
 				tex_tangential_accel = curve_parameters[PARAM_TANGENTIAL_ACCEL]->interpolate(tv);
 			}
 
-			float tex_radial_accel = 0.0;
+			real_t tex_radial_accel = 0.0;
 			if (curve_parameters[PARAM_RADIAL_ACCEL].is_valid()) {
 				tex_radial_accel = curve_parameters[PARAM_RADIAL_ACCEL]->interpolate(tv);
 			}
 
-			float tex_damping = 0.0;
+			real_t tex_damping = 0.0;
 			if (curve_parameters[PARAM_DAMPING].is_valid()) {
 				tex_damping = curve_parameters[PARAM_DAMPING]->interpolate(tv);
 			}
 
-			float tex_angle = 0.0;
+			real_t tex_angle = 0.0;
 			if (curve_parameters[PARAM_ANGLE].is_valid()) {
 				tex_angle = curve_parameters[PARAM_ANGLE]->interpolate(tv);
 			}
-			float tex_anim_speed = 0.0;
+			real_t tex_anim_speed = 0.0;
 			if (curve_parameters[PARAM_ANIM_SPEED].is_valid()) {
 				tex_anim_speed = curve_parameters[PARAM_ANIM_SPEED]->interpolate(tv);
 			}
 
-			float tex_anim_offset = 0.0;
+			real_t tex_anim_offset = 0.0;
 			if (curve_parameters[PARAM_ANIM_OFFSET].is_valid()) {
 				tex_anim_offset = curve_parameters[PARAM_ANIM_OFFSET]->interpolate(tv);
 			}
@@ -881,28 +881,28 @@ void CPUParticles3D::_particles_process(float p_delta) {
 				position.z = 0.0;
 			}
 			//apply linear acceleration
-			force += p.velocity.length() > 0.0 ? p.velocity.normalized() * (parameters[PARAM_LINEAR_ACCEL] + tex_linear_accel) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_LINEAR_ACCEL]) : Vector3();
+			force += p.velocity.length() > 0.0 ? p.velocity.normalized() * (parameters[PARAM_LINEAR_ACCEL] + tex_linear_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_LINEAR_ACCEL]) : Vector3();
 			//apply radial acceleration
 			Vector3 org = emission_xform.origin;
 			Vector3 diff = position - org;
-			force += diff.length() > 0.0 ? diff.normalized() * (parameters[PARAM_RADIAL_ACCEL] + tex_radial_accel) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_RADIAL_ACCEL]) : Vector3();
+			force += diff.length() > 0.0 ? diff.normalized() * (parameters[PARAM_RADIAL_ACCEL] + tex_radial_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_RADIAL_ACCEL]) : Vector3();
 			//apply tangential acceleration;
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 				Vector2 yx = Vector2(diff.y, diff.x);
 				Vector2 yx2 = (yx * Vector2(-1.0, 1.0)).normalized();
-				force += yx.length() > 0.0 ? Vector3(yx2.x, yx2.y, 0.0) * ((parameters[PARAM_TANGENTIAL_ACCEL] + tex_tangential_accel) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_TANGENTIAL_ACCEL])) : Vector3();
+				force += yx.length() > 0.0 ? Vector3(yx2.x, yx2.y, 0.0) * ((parameters[PARAM_TANGENTIAL_ACCEL] + tex_tangential_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_TANGENTIAL_ACCEL])) : Vector3();
 
 			} else {
 				Vector3 crossDiff = diff.normalized().cross(gravity.normalized());
-				force += crossDiff.length() > 0.0 ? crossDiff.normalized() * ((parameters[PARAM_TANGENTIAL_ACCEL] + tex_tangential_accel) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_TANGENTIAL_ACCEL])) : Vector3();
+				force += crossDiff.length() > 0.0 ? crossDiff.normalized() * ((parameters[PARAM_TANGENTIAL_ACCEL] + tex_tangential_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_TANGENTIAL_ACCEL])) : Vector3();
 			}
 			//apply attractor forces
 			p.velocity += force * local_delta;
 			//orbit velocity
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-				float orbit_amount = (parameters[PARAM_ORBIT_VELOCITY] + tex_orbit_velocity) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_ORBIT_VELOCITY]);
+				real_t orbit_amount = (parameters[PARAM_ORBIT_VELOCITY] + tex_orbit_velocity) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_ORBIT_VELOCITY]);
 				if (orbit_amount != 0.0) {
-					float ang = orbit_amount * local_delta * Math_TAU;
+					real_t ang = orbit_amount * local_delta * Math_TAU;
 					// Not sure why the ParticlesMaterial code uses a clockwise rotation matrix,
 					// but we use -ang here to reproduce its behavior.
 					Transform2D rot = Transform2D(-ang, Vector2());
@@ -915,8 +915,8 @@ void CPUParticles3D::_particles_process(float p_delta) {
 				p.velocity = p.velocity.normalized() * tex_linear_velocity;
 			}
 			if (parameters[PARAM_DAMPING] + tex_damping > 0.0) {
-				float v = p.velocity.length();
-				float damp = (parameters[PARAM_DAMPING] + tex_damping) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_DAMPING]);
+				real_t v = p.velocity.length();
+				real_t damp = (parameters[PARAM_DAMPING] + tex_damping) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_DAMPING]);
 				v -= damp * local_delta;
 				if (v < 0.0) {
 					p.velocity = Vector3();
@@ -924,27 +924,27 @@ void CPUParticles3D::_particles_process(float p_delta) {
 					p.velocity = p.velocity.normalized() * v;
 				}
 			}
-			float base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp(1.0f, p.angle_rand, randomness[PARAM_ANGLE]);
-			base_angle += p.custom[1] * lifetime * (parameters[PARAM_ANGULAR_VELOCITY] + tex_angular_velocity) * Math::lerp(1.0f, rand_from_seed(alt_seed) * 2.0f - 1.0f, randomness[PARAM_ANGULAR_VELOCITY]);
+			real_t base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp((real_t)1.0, p.angle_rand, randomness[PARAM_ANGLE]);
+			base_angle += p.custom[1] * lifetime * (parameters[PARAM_ANGULAR_VELOCITY] + tex_angular_velocity) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed) * 2.0f - 1.0f, randomness[PARAM_ANGULAR_VELOCITY]);
 			p.custom[0] = Math::deg2rad(base_angle); //angle
-			p.custom[2] = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp(1.0f, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]) + p.custom[1] * (parameters[PARAM_ANIM_SPEED] + tex_anim_speed) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_ANIM_SPEED]); //angle
+			p.custom[2] = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp((real_t)1.0, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]) + p.custom[1] * (parameters[PARAM_ANIM_SPEED] + tex_anim_speed) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_ANIM_SPEED]); //angle
 		}
 		//apply color
 		//apply hue rotation
 
-		float tex_scale = 1.0;
+		real_t tex_scale = 1.0;
 		if (curve_parameters[PARAM_SCALE].is_valid()) {
 			tex_scale = curve_parameters[PARAM_SCALE]->interpolate(tv);
 		}
 
-		float tex_hue_variation = 0.0;
+		real_t tex_hue_variation = 0.0;
 		if (curve_parameters[PARAM_HUE_VARIATION].is_valid()) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->interpolate(tv);
 		}
 
-		float hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
-		float hue_rot_c = Math::cos(hue_rot_angle);
-		float hue_rot_s = Math::sin(hue_rot_angle);
+		real_t hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
+		real_t hue_rot_c = Math::cos(hue_rot_angle);
+		real_t hue_rot_s = Math::sin(hue_rot_angle);
 
 		Basis hue_rot_mat;
 		{
@@ -1013,9 +1013,9 @@ void CPUParticles3D::_particles_process(float p_delta) {
 		}
 
 		//scale by scale
-		float base_scale = tex_scale * Math::lerp(parameters[PARAM_SCALE], 1.0f, p.scale_rand * randomness[PARAM_SCALE]);
-		if (base_scale < 0.000001) {
-			base_scale = 0.000001;
+		real_t base_scale = tex_scale * Math::lerp(parameters[PARAM_SCALE], (real_t)1.0, p.scale_rand * randomness[PARAM_SCALE]);
+		if (base_scale < CMP_EPSILON) {
+			base_scale = CMP_EPSILON;
 		}
 
 		p.transform.basis.scale(Vector3(1, 1, 1) * base_scale);

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -89,10 +89,10 @@ private:
 		float custom[4] = {};
 		Vector3 velocity;
 		bool active = false;
-		float angle_rand = 0.0;
-		float scale_rand = 0.0;
-		float hue_rot_rand = 0.0;
-		float anim_offset_rand = 0.0;
+		real_t angle_rand = 0.0;
+		real_t scale_rand = 0.0;
+		real_t hue_rot_rand = 0.0;
+		real_t anim_offset_rand = 0.0;
 		float time = 0.0;
 		float lifetime = 0.0;
 		Color base_color;
@@ -134,8 +134,8 @@ private:
 
 	float lifetime = 1.0;
 	float pre_process_time = 0.0;
-	float explosiveness_ratio = 0.0;
-	float randomness_ratio = 0.0;
+	real_t explosiveness_ratio = 0.0;
+	real_t randomness_ratio = 0.0;
 	float lifetime_randomness = 0.0;
 	float speed_scale = 1.0;
 	bool local_coords = true;
@@ -153,11 +153,11 @@ private:
 	////////
 
 	Vector3 direction = Vector3(1, 0, 0);
-	float spread = 45.0;
-	float flatness = 0.0;
+	real_t spread = 45.0;
+	real_t flatness = 0.0;
 
-	float parameters[PARAM_MAX];
-	float randomness[PARAM_MAX] = {};
+	real_t parameters[PARAM_MAX];
+	real_t randomness[PARAM_MAX] = {};
 
 	Ref<Curve> curve_parameters[PARAM_MAX];
 	Color color = Color(1, 1, 1, 1);
@@ -166,16 +166,16 @@ private:
 	bool particle_flags[PARTICLE_FLAG_MAX] = {};
 
 	EmissionShape emission_shape = EMISSION_SHAPE_POINT;
-	float emission_sphere_radius = 1.0;
+	real_t emission_sphere_radius = 1.0;
 	Vector3 emission_box_extents = Vector3(1, 1, 1);
 	Vector<Vector3> emission_points;
 	Vector<Vector3> emission_normals;
 	Vector<Color> emission_colors;
 	int emission_point_count = 0;
 	Vector3 emission_ring_axis;
-	float emission_ring_height;
-	float emission_ring_radius;
-	float emission_ring_inner_radius;
+	real_t emission_ring_height;
+	real_t emission_ring_radius;
+	real_t emission_ring_inner_radius;
 
 	Vector3 gravity = Vector3(0, -9.8, 0);
 
@@ -203,24 +203,24 @@ public:
 	void set_lifetime(float p_lifetime);
 	void set_one_shot(bool p_one_shot);
 	void set_pre_process_time(float p_time);
-	void set_explosiveness_ratio(float p_ratio);
-	void set_randomness_ratio(float p_ratio);
+	void set_explosiveness_ratio(real_t p_ratio);
+	void set_randomness_ratio(real_t p_ratio);
 	void set_lifetime_randomness(float p_random);
 	void set_visibility_aabb(const AABB &p_aabb);
 	void set_use_local_coordinates(bool p_enable);
-	void set_speed_scale(float p_scale);
+	void set_speed_scale(real_t p_scale);
 
 	bool is_emitting() const;
 	int get_amount() const;
 	float get_lifetime() const;
 	bool get_one_shot() const;
 	float get_pre_process_time() const;
-	float get_explosiveness_ratio() const;
-	float get_randomness_ratio() const;
+	real_t get_explosiveness_ratio() const;
+	real_t get_randomness_ratio() const;
 	float get_lifetime_randomness() const;
 	AABB get_visibility_aabb() const;
 	bool get_use_local_coordinates() const;
-	float get_speed_scale() const;
+	real_t get_speed_scale() const;
 
 	void set_fixed_fps(int p_count);
 	int get_fixed_fps() const;
@@ -242,17 +242,17 @@ public:
 	void set_direction(Vector3 p_direction);
 	Vector3 get_direction() const;
 
-	void set_spread(float p_spread);
-	float get_spread() const;
+	void set_spread(real_t p_spread);
+	real_t get_spread() const;
 
-	void set_flatness(float p_flatness);
-	float get_flatness() const;
+	void set_flatness(real_t p_flatness);
+	real_t get_flatness() const;
 
-	void set_param(Parameter p_param, float p_value);
-	float get_param(Parameter p_param) const;
+	void set_param(Parameter p_param, real_t p_value);
+	real_t get_param(Parameter p_param) const;
 
-	void set_param_randomness(Parameter p_param, float p_value);
-	float get_param_randomness(Parameter p_param) const;
+	void set_param_randomness(Parameter p_param, real_t p_value);
+	real_t get_param_randomness(Parameter p_param) const;
 
 	void set_param_curve(Parameter p_param, const Ref<Curve> &p_curve);
 	Ref<Curve> get_param_curve(Parameter p_param) const;
@@ -267,28 +267,28 @@ public:
 	bool get_particle_flag(ParticleFlags p_particle_flag) const;
 
 	void set_emission_shape(EmissionShape p_shape);
-	void set_emission_sphere_radius(float p_radius);
+	void set_emission_sphere_radius(real_t p_radius);
 	void set_emission_box_extents(Vector3 p_extents);
 	void set_emission_points(const Vector<Vector3> &p_points);
 	void set_emission_normals(const Vector<Vector3> &p_normals);
 	void set_emission_colors(const Vector<Color> &p_colors);
 	void set_emission_point_count(int p_count);
 	void set_emission_ring_axis(Vector3 p_axis);
-	void set_emission_ring_height(float p_height);
-	void set_emission_ring_radius(float p_radius);
-	void set_emission_ring_inner_radius(float p_radius);
+	void set_emission_ring_height(real_t p_height);
+	void set_emission_ring_radius(real_t p_radius);
+	void set_emission_ring_inner_radius(real_t p_radius);
 
 	EmissionShape get_emission_shape() const;
-	float get_emission_sphere_radius() const;
+	real_t get_emission_sphere_radius() const;
 	Vector3 get_emission_box_extents() const;
 	Vector<Vector3> get_emission_points() const;
 	Vector<Vector3> get_emission_normals() const;
 	Vector<Color> get_emission_colors() const;
 	int get_emission_point_count() const;
 	Vector3 get_emission_ring_axis() const;
-	float get_emission_ring_height() const;
-	float get_emission_ring_radius() const;
-	float get_emission_ring_inner_radius() const;
+	real_t get_emission_ring_height() const;
+	real_t get_emission_ring_radius() const;
+	real_t get_emission_ring_inner_radius() const;
 
 	void set_gravity(const Vector3 &p_gravity);
 	Vector3 get_gravity() const;

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -53,48 +53,48 @@ Ref<Texture2D> Decal::get_texture(DecalTexture p_type) const {
 	return textures[p_type];
 }
 
-void Decal::set_emission_energy(float p_energy) {
+void Decal::set_emission_energy(real_t p_energy) {
 	emission_energy = p_energy;
 	RS::get_singleton()->decal_set_emission_energy(decal, emission_energy);
 }
 
-float Decal::get_emission_energy() const {
+real_t Decal::get_emission_energy() const {
 	return emission_energy;
 }
 
-void Decal::set_albedo_mix(float p_mix) {
+void Decal::set_albedo_mix(real_t p_mix) {
 	albedo_mix = p_mix;
 	RS::get_singleton()->decal_set_albedo_mix(decal, albedo_mix);
 }
 
-float Decal::get_albedo_mix() const {
+real_t Decal::get_albedo_mix() const {
 	return albedo_mix;
 }
 
-void Decal::set_upper_fade(float p_fade) {
+void Decal::set_upper_fade(real_t p_fade) {
 	upper_fade = p_fade;
 	RS::get_singleton()->decal_set_fade(decal, upper_fade, lower_fade);
 }
 
-float Decal::get_upper_fade() const {
+real_t Decal::get_upper_fade() const {
 	return upper_fade;
 }
 
-void Decal::set_lower_fade(float p_fade) {
+void Decal::set_lower_fade(real_t p_fade) {
 	lower_fade = p_fade;
 	RS::get_singleton()->decal_set_fade(decal, upper_fade, lower_fade);
 }
 
-float Decal::get_lower_fade() const {
+real_t Decal::get_lower_fade() const {
 	return lower_fade;
 }
 
-void Decal::set_normal_fade(float p_fade) {
+void Decal::set_normal_fade(real_t p_fade) {
 	normal_fade = p_fade;
 	RS::get_singleton()->decal_set_normal_fade(decal, normal_fade);
 }
 
-float Decal::get_normal_fade() const {
+real_t Decal::get_normal_fade() const {
 	return normal_fade;
 }
 
@@ -117,21 +117,21 @@ bool Decal::is_distance_fade_enabled() const {
 	return distance_fade_enabled;
 }
 
-void Decal::set_distance_fade_begin(float p_distance) {
+void Decal::set_distance_fade_begin(real_t p_distance) {
 	distance_fade_begin = p_distance;
 	RS::get_singleton()->decal_set_distance_fade(decal, distance_fade_enabled, distance_fade_begin, distance_fade_length);
 }
 
-float Decal::get_distance_fade_begin() const {
+real_t Decal::get_distance_fade_begin() const {
 	return distance_fade_begin;
 }
 
-void Decal::set_distance_fade_length(float p_length) {
+void Decal::set_distance_fade_length(real_t p_length) {
 	distance_fade_length = p_length;
 	RS::get_singleton()->decal_set_distance_fade(decal, distance_fade_enabled, distance_fade_begin, distance_fade_length);
 }
 
-float Decal::get_distance_fade_length() const {
+real_t Decal::get_distance_fade_length() const {
 	return distance_fade_length;
 }
 

--- a/scene/3d/decal.h
+++ b/scene/3d/decal.h
@@ -51,16 +51,16 @@ private:
 	RID decal;
 	Vector3 extents = Vector3(1, 1, 1);
 	Ref<Texture2D> textures[TEXTURE_MAX];
-	float emission_energy = 1.0;
-	float albedo_mix = 1.0;
+	real_t emission_energy = 1.0;
+	real_t albedo_mix = 1.0;
 	Color modulate = Color(1, 1, 1, 1);
 	uint32_t cull_mask = (1 << 20) - 1;
-	float normal_fade = 0.0;
-	float upper_fade = 0.3;
-	float lower_fade = 0.3;
+	real_t normal_fade = 0.0;
+	real_t upper_fade = 0.3;
+	real_t lower_fade = 0.3;
 	bool distance_fade_enabled = false;
-	float distance_fade_begin = 10.0;
-	float distance_fade_length = 1.0;
+	real_t distance_fade_begin = 10.0;
+	real_t distance_fade_length = 1.0;
 
 protected:
 	static void _bind_methods();
@@ -75,32 +75,32 @@ public:
 	void set_texture(DecalTexture p_type, const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture(DecalTexture p_type) const;
 
-	void set_emission_energy(float p_energy);
-	float get_emission_energy() const;
+	void set_emission_energy(real_t p_energy);
+	real_t get_emission_energy() const;
 
-	void set_albedo_mix(float p_mix);
-	float get_albedo_mix() const;
+	void set_albedo_mix(real_t p_mix);
+	real_t get_albedo_mix() const;
 
 	void set_modulate(Color p_modulate);
 	Color get_modulate() const;
 
-	void set_upper_fade(float p_energy);
-	float get_upper_fade() const;
+	void set_upper_fade(real_t p_energy);
+	real_t get_upper_fade() const;
 
-	void set_lower_fade(float p_fade);
-	float get_lower_fade() const;
+	void set_lower_fade(real_t p_fade);
+	real_t get_lower_fade() const;
 
-	void set_normal_fade(float p_fade);
-	float get_normal_fade() const;
+	void set_normal_fade(real_t p_fade);
+	real_t get_normal_fade() const;
 
 	void set_enable_distance_fade(bool p_enable);
 	bool is_distance_fade_enabled() const;
 
-	void set_distance_fade_begin(float p_distance);
-	float get_distance_fade_begin() const;
+	void set_distance_fade_begin(real_t p_distance);
+	real_t get_distance_fade_begin() const;
 
-	void set_distance_fade_length(float p_length);
-	float get_distance_fade_length() const;
+	void set_distance_fade_length(real_t p_length);
+	real_t get_distance_fade_length() const;
 
 	void set_cull_mask(uint32_t p_layers);
 	uint32_t get_cull_mask() const;

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -38,7 +38,7 @@ bool Light3D::_can_gizmo_scale() const {
 	return false;
 }
 
-void Light3D::set_param(Param p_param, float p_value) {
+void Light3D::set_param(Param p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 	param[p_param] = p_value;
 
@@ -53,7 +53,7 @@ void Light3D::set_param(Param p_param, float p_value) {
 	}
 }
 
-float Light3D::get_param(Param p_param) const {
+real_t Light3D::get_param(Param p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 	return param[p_param];
 }
@@ -128,8 +128,8 @@ AABB Light3D::get_aabb() const {
 		return AABB(Vector3(-1, -1, -1) * param[PARAM_RANGE], Vector3(2, 2, 2) * param[PARAM_RANGE]);
 
 	} else if (type == RenderingServer::LIGHT_SPOT) {
-		float len = param[PARAM_RANGE];
-		float size = Math::tan(Math::deg2rad(param[PARAM_SPOT_ANGLE])) * len;
+		real_t len = param[PARAM_RANGE];
+		real_t size = Math::tan(Math::deg2rad(param[PARAM_SPOT_ANGLE])) * len;
 		return AABB(Vector3(-size, -size, -len), Vector3(size * 2, size * 2, len));
 	}
 

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -71,7 +71,7 @@ public:
 
 private:
 	Color color;
-	float param[PARAM_MAX] = {};
+	real_t param[PARAM_MAX] = {};
 	Color shadow_color;
 	bool shadow = false;
 	bool negative = false;
@@ -102,8 +102,8 @@ public:
 	void set_editor_only(bool p_editor_only);
 	bool is_editor_only() const;
 
-	void set_param(Param p_param, float p_value);
-	float get_param(Param p_param) const;
+	void set_param(Param p_param, real_t p_value);
+	real_t get_param(Param p_param) const;
 
 	void set_shadow(bool p_enable);
 	bool has_shadow() const;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -588,31 +588,31 @@ bool Node3D::is_visible() const {
 	return data.visible;
 }
 
-void Node3D::rotate_object_local(const Vector3 &p_axis, float p_angle) {
+void Node3D::rotate_object_local(const Vector3 &p_axis, real_t p_angle) {
 	Transform3D t = get_transform();
 	t.basis.rotate_local(p_axis, p_angle);
 	set_transform(t);
 }
 
-void Node3D::rotate(const Vector3 &p_axis, float p_angle) {
+void Node3D::rotate(const Vector3 &p_axis, real_t p_angle) {
 	Transform3D t = get_transform();
 	t.basis.rotate(p_axis, p_angle);
 	set_transform(t);
 }
 
-void Node3D::rotate_x(float p_angle) {
+void Node3D::rotate_x(real_t p_angle) {
 	Transform3D t = get_transform();
 	t.basis.rotate(Vector3(1, 0, 0), p_angle);
 	set_transform(t);
 }
 
-void Node3D::rotate_y(float p_angle) {
+void Node3D::rotate_y(real_t p_angle) {
 	Transform3D t = get_transform();
 	t.basis.rotate(Vector3(0, 1, 0), p_angle);
 	set_transform(t);
 }
 
-void Node3D::rotate_z(float p_angle) {
+void Node3D::rotate_z(real_t p_angle) {
 	Transform3D t = get_transform();
 	t.basis.rotate(Vector3(0, 0, 1), p_angle);
 	set_transform(t);
@@ -644,7 +644,7 @@ void Node3D::scale_object_local(const Vector3 &p_scale) {
 	set_transform(t);
 }
 
-void Node3D::global_rotate(const Vector3 &p_axis, float p_angle) {
+void Node3D::global_rotate(const Vector3 &p_axis, real_t p_angle) {
 	Transform3D t = get_global_transform();
 	t.basis.rotate(p_axis, p_angle);
 	set_global_transform(t);

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -167,18 +167,18 @@ public:
 
 	Transform3D get_relative_transform(const Node *p_parent) const;
 
-	void rotate(const Vector3 &p_axis, float p_angle);
-	void rotate_x(float p_angle);
-	void rotate_y(float p_angle);
-	void rotate_z(float p_angle);
+	void rotate(const Vector3 &p_axis, real_t p_angle);
+	void rotate_x(real_t p_angle);
+	void rotate_y(real_t p_angle);
+	void rotate_z(real_t p_angle);
 	void translate(const Vector3 &p_offset);
 	void scale(const Vector3 &p_ratio);
 
-	void rotate_object_local(const Vector3 &p_axis, float p_angle);
+	void rotate_object_local(const Vector3 &p_axis, real_t p_angle);
 	void scale_object_local(const Vector3 &p_scale);
 	void translate_object_local(const Vector3 &p_offset);
 
-	void global_rotate(const Vector3 &p_axis, float p_angle);
+	void global_rotate(const Vector3 &p_axis, real_t p_angle);
 	void global_scale(const Vector3 &p_scale);
 	void global_translate(const Vector3 &p_offset);
 

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -94,13 +94,13 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 		return;
 	}
 
-	float bl = c->get_baked_length();
+	real_t bl = c->get_baked_length();
 	if (bl == 0.0) {
 		return;
 	}
-	float bi = c->get_bake_interval();
-	float o_next = offset + bi;
-	float o_prev = offset - bi;
+	real_t bi = c->get_bake_interval();
+	real_t o_next = offset + bi;
+	real_t o_prev = offset - bi;
 
 	if (loop) {
 		o_next = Math::fposmod(o_next, bl);
@@ -169,8 +169,8 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 			Vector3 t_cur = (c->interpolate_baked(offset + delta_offset, cubic) - pos).normalized();
 
 			Vector3 axis = t_prev.cross(t_cur);
-			float dot = t_prev.dot(t_cur);
-			float angle = Math::acos(CLAMP(dot, -1, 1));
+			real_t dot = t_prev.dot(t_cur);
+			real_t angle = Math::acos(CLAMP(dot, -1, 1));
 
 			if (likely(!Math::is_zero_approx(angle))) {
 				if (rotation_mode == ROTATION_Y) {
@@ -189,7 +189,7 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 			}
 
 			// do the additional tilting
-			float tilt_angle = c->interpolate_baked_tilt(offset);
+			real_t tilt_angle = c->interpolate_baked_tilt(offset);
 			Vector3 tilt_axis = t_cur; // not sure what tilt is supposed to do, is this correct??
 
 			if (likely(!Math::is_zero_approx(Math::abs(tilt_angle)))) {
@@ -244,7 +244,7 @@ bool PathFollow3D::get_cubic_interpolation() const {
 
 void PathFollow3D::_validate_property(PropertyInfo &property) const {
 	if (property.name == "offset") {
-		float max = 10000;
+		real_t max = 10000;
 		if (path && path->get_curve().is_valid()) {
 			max = path->get_curve()->get_baked_length();
 		}
@@ -307,13 +307,13 @@ void PathFollow3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(ROTATION_ORIENTED);
 }
 
-void PathFollow3D::set_offset(float p_offset) {
+void PathFollow3D::set_offset(real_t p_offset) {
 	delta_offset = p_offset - offset;
 	offset = p_offset;
 
 	if (path) {
 		if (path->get_curve().is_valid()) {
-			float path_length = path->get_curve()->get_baked_length();
+			real_t path_length = path->get_curve()->get_baked_length();
 
 			if (loop) {
 				offset = Math::fposmod(offset, path_length);
@@ -329,39 +329,39 @@ void PathFollow3D::set_offset(float p_offset) {
 	}
 }
 
-void PathFollow3D::set_h_offset(float p_h_offset) {
+void PathFollow3D::set_h_offset(real_t p_h_offset) {
 	h_offset = p_h_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-float PathFollow3D::get_h_offset() const {
+real_t PathFollow3D::get_h_offset() const {
 	return h_offset;
 }
 
-void PathFollow3D::set_v_offset(float p_v_offset) {
+void PathFollow3D::set_v_offset(real_t p_v_offset) {
 	v_offset = p_v_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-float PathFollow3D::get_v_offset() const {
+real_t PathFollow3D::get_v_offset() const {
 	return v_offset;
 }
 
-float PathFollow3D::get_offset() const {
+real_t PathFollow3D::get_offset() const {
 	return offset;
 }
 
-void PathFollow3D::set_unit_offset(float p_unit_offset) {
+void PathFollow3D::set_unit_offset(real_t p_unit_offset) {
 	if (path && path->get_curve().is_valid() && path->get_curve()->get_baked_length()) {
 		set_offset(p_unit_offset * path->get_curve()->get_baked_length());
 	}
 }
 
-float PathFollow3D::get_unit_offset() const {
+real_t PathFollow3D::get_unit_offset() const {
 	if (path && path->get_curve().is_valid() && path->get_curve()->get_baked_length()) {
 		return get_offset() / path->get_curve()->get_baked_length();
 	} else {

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -83,17 +83,17 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_offset(float p_offset);
-	float get_offset() const;
+	void set_offset(real_t p_offset);
+	real_t get_offset() const;
 
-	void set_h_offset(float p_h_offset);
-	float get_h_offset() const;
+	void set_h_offset(real_t p_h_offset);
+	real_t get_h_offset() const;
 
-	void set_v_offset(float p_v_offset);
-	float get_v_offset() const;
+	void set_v_offset(real_t p_v_offset);
+	real_t get_v_offset() const;
 
-	void set_unit_offset(float p_unit_offset);
-	float get_unit_offset() const;
+	void set_unit_offset(real_t p_unit_offset);
+	real_t get_unit_offset() const;
 
 	void set_loop(bool p_loop);
 	bool has_loop() const;

--- a/scene/3d/proximity_group_3d.h
+++ b/scene/3d/proximity_group_3d.h
@@ -49,7 +49,7 @@ private:
 	DispatchMode dispatch_mode = MODE_PROXY;
 	Vector3 grid_radius = Vector3(1, 1, 1);
 
-	float cell_size = 1.0;
+	real_t cell_size = 1.0;
 	uint32_t group_version = 0;
 
 	void _clear_groups();

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -366,7 +366,7 @@ void Skeleton3D::clear_bones_global_pose_override() {
 	_make_dirty();
 }
 
-void Skeleton3D::set_bone_global_pose_override(int p_bone, const Transform3D &p_pose, float p_amount, bool p_persistent) {
+void Skeleton3D::set_bone_global_pose_override(int p_bone, const Transform3D &p_pose, real_t p_amount, bool p_persistent) {
 	ERR_FAIL_INDEX(p_bone, bones.size());
 	bones.write[p_bone].global_pose_override_amount = p_amount;
 	bones.write[p_bone].global_pose_override = p_pose;

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -85,7 +85,7 @@ private:
 		bool custom_pose_enable = false;
 		Transform3D custom_pose;
 
-		float global_pose_override_amount = 0.0;
+		real_t global_pose_override_amount = 0.0;
 		bool global_pose_override_reset = false;
 		Transform3D global_pose_override;
 
@@ -147,7 +147,7 @@ public:
 	Transform3D get_bone_global_pose_no_override(int p_bone) const;
 
 	void clear_bones_global_pose_override();
-	void set_bone_global_pose_override(int p_bone, const Transform3D &p_pose, float p_amount, bool p_persistent = false);
+	void set_bone_global_pose_override(int p_bone, const Transform3D &p_pose, real_t p_amount, bool p_persistent = false);
 
 	void set_bone_enabled(int p_bone, bool p_enabled);
 	bool is_bone_enabled(int p_bone) const;

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -85,7 +85,7 @@ bool FabrikInverseKinematic::build_chain(Task *p_task, bool p_force_simple_chain
 			chain_sub_tip = p_task->skeleton->get_bone_parent(chain_sub_tip);
 		}
 
-		BoneId middle_chain_item_id = (((float)sub_chain_size) * 0.5);
+		BoneId middle_chain_item_id = (BoneId)(sub_chain_size * 0.5);
 
 		// Build chain by reading chain ids in reverse order
 		// For each chain item id will be created a ChainItem if doesn't exists

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -132,12 +132,12 @@ Color SpriteBase3D::get_modulate() const {
 	return modulate;
 }
 
-void SpriteBase3D::set_pixel_size(float p_amount) {
+void SpriteBase3D::set_pixel_size(real_t p_amount) {
 	pixel_size = p_amount;
 	_queue_update();
 }
 
-float SpriteBase3D::get_pixel_size() const {
+real_t SpriteBase3D::get_pixel_size() const {
 	return pixel_size;
 }
 
@@ -203,7 +203,7 @@ Ref<TriangleMesh> SpriteBase3D::generate_triangle_mesh() const {
 		return Ref<TriangleMesh>();
 	}
 
-	float pixel_size = get_pixel_size();
+	real_t pixel_size = get_pixel_size();
 
 	Vector2 vertices[4] = {
 
@@ -470,7 +470,7 @@ void Sprite3D::_draw() {
 	Color color = _get_color_accum();
 	color.a *= get_opacity();
 
-	float pixel_size = get_pixel_size();
+	real_t pixel_size = get_pixel_size();
 
 	Vector2 vertices[4] = {
 
@@ -837,7 +837,7 @@ void AnimatedSprite3D::_draw() {
 	Color color = _get_color_accum();
 	color.a *= get_opacity();
 
-	float pixel_size = get_pixel_size();
+	real_t pixel_size = get_pixel_size();
 
 	Vector2 vertices[4] = {
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -72,7 +72,7 @@ private:
 	float opacity = 1.0;
 
 	Vector3::Axis axis = Vector3::AXIS_Z;
-	float pixel_size = 0.01;
+	real_t pixel_size = 0.01;
 	AABB aabb;
 
 	RID mesh;
@@ -130,8 +130,8 @@ public:
 	void set_opacity(float p_amount);
 	float get_opacity() const;
 
-	void set_pixel_size(float p_amount);
-	float get_pixel_size() const;
+	void set_pixel_size(real_t p_amount);
+	real_t get_pixel_size() const;
 
 	void set_axis(Vector3::Axis p_axis);
 	Vector3::Axis get_axis() const;

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -56,20 +56,20 @@ static _FORCE_INLINE_ void get_uv_and_normal(const Vector3 &p_pos, const Vector3
 	Vector3 v1 = p_vtx[2] - p_vtx[0];
 	Vector3 v2 = p_pos - p_vtx[0];
 
-	float d00 = v0.dot(v0);
-	float d01 = v0.dot(v1);
-	float d11 = v1.dot(v1);
-	float d20 = v2.dot(v0);
-	float d21 = v2.dot(v1);
-	float denom = (d00 * d11 - d01 * d01);
+	real_t d00 = v0.dot(v0);
+	real_t d01 = v0.dot(v1);
+	real_t d11 = v1.dot(v1);
+	real_t d20 = v2.dot(v0);
+	real_t d21 = v2.dot(v1);
+	real_t denom = (d00 * d11 - d01 * d01);
 	if (denom == 0) {
 		r_uv = p_uv[0];
 		r_normal = p_normal[0];
 		return;
 	}
-	float v = (d11 * d20 - d01 * d21) / denom;
-	float w = (d00 * d21 - d01 * d20) / denom;
-	float u = 1.0f - v - w;
+	real_t v = (d11 * d20 - d01 * d21) / denom;
+	real_t w = (d00 * d21 - d01 * d20) / denom;
+	real_t u = 1.0f - v - w;
 
 	r_uv = p_uv[0] * u + p_uv[1] * v + p_uv[2] * w;
 	r_normal = (p_normal[0] * u + p_normal[1] * v + p_normal[2] * w).normalized();
@@ -81,7 +81,7 @@ void Voxelizer::_plot_face(int p_idx, int p_level, int p_x, int p_y, int p_z, co
 
 		//find best axis to map to, for scanning values
 		int closest_axis = 0;
-		float closest_dot = 0;
+		real_t closest_dot = 0;
 
 		Plane plane = Plane(p_vtx[0], p_vtx[1], p_vtx[2]);
 		Vector3 normal = plane.normal;
@@ -89,7 +89,7 @@ void Voxelizer::_plot_face(int p_idx, int p_level, int p_x, int p_y, int p_z, co
 		for (int i = 0; i < 3; i++) {
 			Vector3 axis;
 			axis[i] = 1.0;
-			float dot = ABS(normal.dot(axis));
+			real_t dot = ABS(normal.dot(axis));
 			if (i == 0 || dot > closest_dot) {
 				closest_axis = i;
 				closest_dot = dot;
@@ -103,8 +103,8 @@ void Voxelizer::_plot_face(int p_idx, int p_level, int p_x, int p_y, int p_z, co
 		Vector3 t2;
 		t2[(closest_axis + 2) % 3] = 1.0;
 
-		t1 *= p_aabb.size[(closest_axis + 1) % 3] / float(color_scan_cell_width);
-		t2 *= p_aabb.size[(closest_axis + 2) % 3] / float(color_scan_cell_width);
+		t1 *= p_aabb.size[(closest_axis + 1) % 3] / real_t(color_scan_cell_width);
+		t2 *= p_aabb.size[(closest_axis + 2) % 3] / real_t(color_scan_cell_width);
 
 		Color albedo_accum;
 		Color emission_accum;
@@ -114,10 +114,10 @@ void Voxelizer::_plot_face(int p_idx, int p_level, int p_x, int p_y, int p_z, co
 
 		//map to a grid average in the best axis for this face
 		for (int i = 0; i < color_scan_cell_width; i++) {
-			Vector3 ofs_i = float(i) * t1;
+			Vector3 ofs_i = real_t(i) * t1;
 
 			for (int j = 0; j < color_scan_cell_width; j++) {
-				Vector3 ofs_j = float(j) * t2;
+				Vector3 ofs_j = real_t(j) * t2;
 
 				Vector3 from = p_aabb.position + ofs_i + ofs_j;
 				Vector3 to = from + t1 + t2 + axis * p_aabb.size[closest_axis];
@@ -155,8 +155,8 @@ void Voxelizer::_plot_face(int p_idx, int p_level, int p_x, int p_y, int p_z, co
 					lnormal = normal;
 				}
 
-				int uv_x = CLAMP(int(Math::fposmod(uv.x, 1.0f) * bake_texture_size), 0, bake_texture_size - 1);
-				int uv_y = CLAMP(int(Math::fposmod(uv.y, 1.0f) * bake_texture_size), 0, bake_texture_size - 1);
+				int uv_x = CLAMP(int(Math::fposmod(uv.x, (real_t)1.0) * bake_texture_size), 0, bake_texture_size - 1);
+				int uv_y = CLAMP(int(Math::fposmod(uv.y, (real_t)1.0) * bake_texture_size), 0, bake_texture_size - 1);
 
 				int ofs = uv_y * bake_texture_size + uv_x;
 				albedo_accum.r += p_material.albedo[ofs].r;
@@ -187,8 +187,8 @@ void Voxelizer::_plot_face(int p_idx, int p_level, int p_x, int p_y, int p_z, co
 				lnormal = normal;
 			}
 
-			int uv_x = CLAMP(Math::fposmod(uv.x, 1.0f) * bake_texture_size, 0, bake_texture_size - 1);
-			int uv_y = CLAMP(Math::fposmod(uv.y, 1.0f) * bake_texture_size, 0, bake_texture_size - 1);
+			int uv_x = CLAMP(Math::fposmod(uv.x, (real_t)1.0) * bake_texture_size, 0, bake_texture_size - 1);
+			int uv_y = CLAMP(Math::fposmod(uv.y, (real_t)1.0) * bake_texture_size, 0, bake_texture_size - 1);
 
 			int ofs = uv_y * bake_texture_size + uv_x;
 
@@ -636,7 +636,7 @@ void Voxelizer::begin_bake(int p_subdiv, const AABB &p_bounds) {
 		}
 
 		axis_cell_size[i] = axis_cell_size[longest_axis];
-		float axis_size = po2_bounds.size[longest_axis];
+		real_t axis_size = po2_bounds.size[longest_axis];
 
 		//shrink until fit subdiv
 		while (axis_size / 2.0 >= po2_bounds.size[i]) {
@@ -954,7 +954,7 @@ Ref<MultiMesh> Voxelizer::create_debug_multimesh() {
 			Vector3 face_points[4];
 
 			for (int j = 0; j < 4; j++) {
-				float v[3];
+				real_t v[3];
 				v[0] = 1.0;
 				v[1] = 1 - 2 * ((j >> 1) & 1);
 				v[2] = v[1] * (1 - 2 * (j & 1));

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -124,7 +124,7 @@ Point2 XRCamera3D::unproject_position(const Vector3 &p_pos) const {
 	return res;
 };
 
-Vector3 XRCamera3D::project_position(const Point2 &p_point, float p_z_depth) const {
+Vector3 XRCamera3D::project_position(const Point2 &p_point, real_t p_z_depth) const {
 	// get our XRServer
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, Vector3());
@@ -544,7 +544,7 @@ void XROrigin3D::clear_tracked_camera_if(XRCamera3D *p_tracked_camera) {
 	};
 };
 
-float XROrigin3D::get_world_scale() const {
+real_t XROrigin3D::get_world_scale() const {
 	// get our XRServer
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, 1.0);
@@ -552,7 +552,7 @@ float XROrigin3D::get_world_scale() const {
 	return xr_server->get_world_scale();
 };
 
-void XROrigin3D::set_world_scale(float p_world_scale) {
+void XROrigin3D::set_world_scale(real_t p_world_scale) {
 	// get our XRServer
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -54,7 +54,7 @@ public:
 
 	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const override;
 	virtual Point2 unproject_position(const Vector3 &p_pos) const override;
-	virtual Vector3 project_position(const Point2 &p_point, float p_z_depth) const override;
+	virtual Vector3 project_position(const Point2 &p_point, real_t p_z_depth) const override;
 	virtual Vector<Plane> get_frustum() const override;
 
 	XRCamera3D() {}
@@ -163,8 +163,8 @@ public:
 	void set_tracked_camera(XRCamera3D *p_tracked_camera);
 	void clear_tracked_camera_if(XRCamera3D *p_tracked_camera);
 
-	float get_world_scale() const;
-	void set_world_scale(float p_world_scale);
+	real_t get_world_scale() const;
+	void set_world_scale(real_t p_world_scale);
 
 	XROrigin3D() {}
 	~XROrigin3D() {}


### PR DESCRIPTION
This is similar to other recent `real_t` PRs I've made, but this PR specifically focuses on 3D nodes.

Some notes:

* I made `Camera3D` use `real_t` because `CameraMatrix` already does.

* All code related to time was intentionally left unchanged. Code that works with time should be `double`, not `real_t`, but that would change behavior, so I think it's worth doing in a separate PR.