### PR TITLE
Use real_t in 2D nodes

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -157,7 +157,7 @@ Transform2D Camera2D::get_camera_transform() {
 		}
 
 		if (smoothing_enabled && !Engine::get_singleton()->is_editor_hint()) {
-			float c = smoothing * (process_callback == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time());
+			real_t c = smoothing * (process_callback == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time());
 			smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
 			ret_camera_pos = smoothed_camera_pos;
 			//camera_pos=camera_pos*(1.0-smoothing)+new_camera_pos*smoothing;
@@ -172,7 +172,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 	Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5 * zoom) : Point2());
 
-	float angle = get_global_transform().get_rotation();
+	real_t angle = get_global_transform().get_rotation();
 	if (rotating) {
 		screen_offset = screen_offset.rotated(angle);
 	}
@@ -271,7 +271,7 @@ void Camera2D::_notification(int p_what) {
 
 			if (screen_drawing_enabled) {
 				Color area_axis_color(0.5, 0.42, 0.87, 0.63);
-				float area_axis_width = 1;
+				real_t area_axis_width = 1;
 				if (is_current()) {
 					area_axis_width = 3;
 					area_axis_color.a = 0.83;
@@ -296,7 +296,7 @@ void Camera2D::_notification(int p_what) {
 
 			if (limit_drawing_enabled) {
 				Color limit_drawing_color(1, 1, 0, 0.63);
-				float limit_drawing_width = 1;
+				real_t limit_drawing_width = 1;
 				if (is_current()) {
 					limit_drawing_color.a = 0.83;
 					limit_drawing_width = 3;
@@ -318,7 +318,7 @@ void Camera2D::_notification(int p_what) {
 
 			if (margin_drawing_enabled) {
 				Color margin_drawing_color(0, 1, 1, 0.63);
-				float margin_drawing_width = 1;
+				real_t margin_drawing_width = 1;
 				if (is_current()) {
 					margin_drawing_width = 3;
 					margin_drawing_color.a = 0.83;
@@ -446,13 +446,13 @@ bool Camera2D::is_limit_smoothing_enabled() const {
 	return limit_smoothing_enabled;
 }
 
-void Camera2D::set_drag_margin(Side p_side, float p_drag_margin) {
+void Camera2D::set_drag_margin(Side p_side, real_t p_drag_margin) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 	drag_margin[p_side] = p_drag_margin;
 	update();
 }
 
-float Camera2D::get_drag_margin(Side p_side) const {
+real_t Camera2D::get_drag_margin(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
 	return drag_margin[p_side];
 }
@@ -494,7 +494,7 @@ void Camera2D::align() {
 	_update_scroll();
 }
 
-void Camera2D::set_follow_smoothing(float p_speed) {
+void Camera2D::set_follow_smoothing(real_t p_speed) {
 	smoothing = p_speed;
 	if (smoothing > 0 && !(is_inside_tree() && Engine::get_singleton()->is_editor_hint())) {
 		set_process_internal(true);
@@ -503,7 +503,7 @@ void Camera2D::set_follow_smoothing(float p_speed) {
 	}
 }
 
-float Camera2D::get_follow_smoothing() const {
+real_t Camera2D::get_follow_smoothing() const {
 	return smoothing;
 }
 
@@ -535,7 +535,7 @@ bool Camera2D::is_drag_vertical_enabled() const {
 	return drag_vertical_enabled;
 }
 
-void Camera2D::set_drag_vertical_offset(float p_offset) {
+void Camera2D::set_drag_vertical_offset(real_t p_offset) {
 	drag_vertical_offset = p_offset;
 	drag_vertical_offset_changed = true;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
@@ -543,11 +543,11 @@ void Camera2D::set_drag_vertical_offset(float p_offset) {
 	smoothed_camera_pos = old_smoothed_camera_pos;
 }
 
-float Camera2D::get_drag_vertical_offset() const {
+real_t Camera2D::get_drag_vertical_offset() const {
 	return drag_vertical_offset;
 }
 
-void Camera2D::set_drag_horizontal_offset(float p_offset) {
+void Camera2D::set_drag_horizontal_offset(real_t p_offset) {
 	drag_horizontal_offset = p_offset;
 	drag_horizontal_offset_changed = true;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
@@ -555,11 +555,11 @@ void Camera2D::set_drag_horizontal_offset(float p_offset) {
 	smoothed_camera_pos = old_smoothed_camera_pos;
 }
 
-float Camera2D::get_drag_horizontal_offset() const {
+real_t Camera2D::get_drag_horizontal_offset() const {
 	return drag_horizontal_offset;
 }
 
-void Camera2D::_set_old_smoothing(float p_enable) {
+void Camera2D::_set_old_smoothing(real_t p_enable) {
 	//compatibility
 	if (p_enable > 0) {
 		smoothing_enabled = true;

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -65,16 +65,16 @@ protected:
 	AnchorMode anchor_mode = ANCHOR_MODE_DRAG_CENTER;
 	bool rotating = false;
 	bool current = false;
-	float smoothing = 5.0;
+	real_t smoothing = 5.0;
 	bool smoothing_enabled = false;
 	int limit[4];
 	bool limit_smoothing_enabled = false;
 
-	float drag_margin[4];
+	real_t drag_margin[4];
 	bool drag_horizontal_enabled = false;
 	bool drag_vertical_enabled = false;
-	float drag_horizontal_offset = 0.0;
-	float drag_vertical_offset = 0.0;
+	real_t drag_horizontal_offset = 0.0;
+	real_t drag_vertical_offset = 0.0;
 	bool drag_horizontal_offset_changed = false;
 	bool drag_vertical_offset_changed = false;
 
@@ -85,7 +85,7 @@ protected:
 	void _make_current(Object *p_which);
 	void _set_current(bool p_current);
 
-	void _set_old_smoothing(float p_enable);
+	void _set_old_smoothing(real_t p_enable);
 
 	bool screen_drawing_enabled = true;
 	bool limit_drawing_enabled = false;
@@ -124,20 +124,20 @@ public:
 	void set_drag_vertical_enabled(bool p_enabled);
 	bool is_drag_vertical_enabled() const;
 
-	void set_drag_margin(Side p_side, float p_drag_margin);
-	float get_drag_margin(Side p_side) const;
+	void set_drag_margin(Side p_side, real_t p_drag_margin);
+	real_t get_drag_margin(Side p_side) const;
 
-	void set_drag_horizontal_offset(float p_offset);
-	float get_drag_horizontal_offset() const;
+	void set_drag_horizontal_offset(real_t p_offset);
+	real_t get_drag_horizontal_offset() const;
 
-	void set_drag_vertical_offset(float p_offset);
-	float get_drag_vertical_offset() const;
+	void set_drag_vertical_offset(real_t p_offset);
+	real_t get_drag_vertical_offset() const;
 
 	void set_enable_follow_smoothing(bool p_enabled);
 	bool is_follow_smoothing_enabled() const;
 
-	void set_follow_smoothing(float p_speed);
-	float get_follow_smoothing() const;
+	void set_follow_smoothing(real_t p_speed);
+	real_t get_follow_smoothing() const;
 
 	void set_process_callback(Camera2DProcessCallback p_mode);
 	Camera2DProcessCallback get_process_callback() const;

--- a/scene/2d/canvas_group.cpp
+++ b/scene/2d/canvas_group.cpp
@@ -30,7 +30,7 @@
 
 #include "canvas_group.h"
 
-void CanvasGroup::set_fit_margin(float p_fit_margin) {
+void CanvasGroup::set_fit_margin(real_t p_fit_margin) {
 	ERR_FAIL_COND(p_fit_margin < 0.0);
 
 	fit_margin = p_fit_margin;
@@ -39,11 +39,11 @@ void CanvasGroup::set_fit_margin(float p_fit_margin) {
 	update();
 }
 
-float CanvasGroup::get_fit_margin() const {
+real_t CanvasGroup::get_fit_margin() const {
 	return fit_margin;
 }
 
-void CanvasGroup::set_clear_margin(float p_clear_margin) {
+void CanvasGroup::set_clear_margin(real_t p_clear_margin) {
 	ERR_FAIL_COND(p_clear_margin < 0.0);
 
 	clear_margin = p_clear_margin;
@@ -52,7 +52,7 @@ void CanvasGroup::set_clear_margin(float p_clear_margin) {
 	update();
 }
 
-float CanvasGroup::get_clear_margin() const {
+real_t CanvasGroup::get_clear_margin() const {
 	return clear_margin;
 }
 

--- a/scene/2d/canvas_group.h
+++ b/scene/2d/canvas_group.h
@@ -35,19 +35,19 @@
 
 class CanvasGroup : public Node2D {
 	GDCLASS(CanvasGroup, Node2D)
-	float fit_margin = 10.0;
-	float clear_margin = 10.0;
+	real_t fit_margin = 10.0;
+	real_t clear_margin = 10.0;
 	bool use_mipmaps = false;
 
 protected:
 	static void _bind_methods();
 
 public:
-	void set_fit_margin(float p_fit_margin);
-	float get_fit_margin() const;
+	void set_fit_margin(real_t p_fit_margin);
+	real_t get_fit_margin() const;
 
-	void set_clear_margin(float p_clear_margin);
-	float get_clear_margin() const;
+	void set_clear_margin(real_t p_clear_margin);
+	real_t get_clear_margin() const;
 
 	void set_use_mipmaps(bool p_use_mipmaps);
 	bool is_using_mipmaps() const;

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -78,11 +78,11 @@ void CPUParticles2D::set_pre_process_time(float p_time) {
 	pre_process_time = p_time;
 }
 
-void CPUParticles2D::set_explosiveness_ratio(float p_ratio) {
+void CPUParticles2D::set_explosiveness_ratio(real_t p_ratio) {
 	explosiveness_ratio = p_ratio;
 }
 
-void CPUParticles2D::set_randomness_ratio(float p_ratio) {
+void CPUParticles2D::set_randomness_ratio(real_t p_ratio) {
 	randomness_ratio = p_ratio;
 }
 
@@ -95,7 +95,7 @@ void CPUParticles2D::set_use_local_coordinates(bool p_enable) {
 	set_notify_transform(!p_enable);
 }
 
-void CPUParticles2D::set_speed_scale(float p_scale) {
+void CPUParticles2D::set_speed_scale(real_t p_scale) {
 	speed_scale = p_scale;
 }
 
@@ -119,11 +119,11 @@ float CPUParticles2D::get_pre_process_time() const {
 	return pre_process_time;
 }
 
-float CPUParticles2D::get_explosiveness_ratio() const {
+real_t CPUParticles2D::get_explosiveness_ratio() const {
 	return explosiveness_ratio;
 }
 
-float CPUParticles2D::get_randomness_ratio() const {
+real_t CPUParticles2D::get_randomness_ratio() const {
 	return randomness_ratio;
 }
 
@@ -135,7 +135,7 @@ bool CPUParticles2D::get_use_local_coordinates() const {
 	return local_coords;
 }
 
-float CPUParticles2D::get_speed_scale() const {
+real_t CPUParticles2D::get_speed_scale() const {
 	return speed_scale;
 }
 
@@ -289,39 +289,39 @@ Vector2 CPUParticles2D::get_direction() const {
 	return direction;
 }
 
-void CPUParticles2D::set_spread(float p_spread) {
+void CPUParticles2D::set_spread(real_t p_spread) {
 	spread = p_spread;
 }
 
-float CPUParticles2D::get_spread() const {
+real_t CPUParticles2D::get_spread() const {
 	return spread;
 }
 
-void CPUParticles2D::set_param(Parameter p_param, float p_value) {
+void CPUParticles2D::set_param(Parameter p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 
 	parameters[p_param] = p_value;
 }
 
-float CPUParticles2D::get_param(Parameter p_param) const {
+real_t CPUParticles2D::get_param(Parameter p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 
 	return parameters[p_param];
 }
 
-void CPUParticles2D::set_param_randomness(Parameter p_param, float p_value) {
+void CPUParticles2D::set_param_randomness(Parameter p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 
 	randomness[p_param] = p_value;
 }
 
-float CPUParticles2D::get_param_randomness(Parameter p_param) const {
+real_t CPUParticles2D::get_param_randomness(Parameter p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 
 	return randomness[p_param];
 }
 
-static void _adjust_curve_range(const Ref<Curve> &p_curve, float p_min, float p_max) {
+static void _adjust_curve_range(const Ref<Curve> &p_curve, real_t p_min, real_t p_max) {
 	Ref<Curve> curve = p_curve;
 	if (!curve.is_valid()) {
 		return;
@@ -413,7 +413,7 @@ void CPUParticles2D::set_emission_shape(EmissionShape p_shape) {
 	notify_property_list_changed();
 }
 
-void CPUParticles2D::set_emission_sphere_radius(float p_radius) {
+void CPUParticles2D::set_emission_sphere_radius(real_t p_radius) {
 	emission_sphere_radius = p_radius;
 }
 
@@ -433,7 +433,7 @@ void CPUParticles2D::set_emission_colors(const Vector<Color> &p_colors) {
 	emission_colors = p_colors;
 }
 
-float CPUParticles2D::get_emission_sphere_radius() const {
+real_t CPUParticles2D::get_emission_sphere_radius() const {
 	return emission_sphere_radius;
 }
 
@@ -502,7 +502,7 @@ static uint32_t idhash(uint32_t x) {
 	return x;
 }
 
-static float rand_from_seed(uint32_t &seed) {
+static real_t rand_from_seed(uint32_t &seed) {
 	int k;
 	int s = int(seed);
 	if (s == 0) {
@@ -514,7 +514,7 @@ static float rand_from_seed(uint32_t &seed) {
 		s += 2147483647;
 	}
 	seed = uint32_t(s);
-	return float(seed % uint32_t(65536)) / 65535.0;
+	return (seed % uint32_t(65536)) / 65535.0;
 }
 
 void CPUParticles2D::_update_internal() {
@@ -625,7 +625,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 		// The phase is a ratio between 0 (birth) and 1 (end of life) for each particle.
 		// While we use time in tests later on, for randomness we use the phase as done in the
 		// original shader code, and we later multiply by lifetime to get the time.
-		float restart_phase = float(i) / float(pcount);
+		real_t restart_phase = real_t(i) / real_t(pcount);
 
 		if (randomness_ratio > 0.0) {
 			uint32_t seed = cycle;
@@ -634,8 +634,8 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			}
 			seed *= uint32_t(pcount);
 			seed += uint32_t(i);
-			float random = float(idhash(seed) % uint32_t(65536)) / 65536.0;
-			restart_phase += randomness_ratio * random * 1.0 / float(pcount);
+			real_t random = (idhash(seed) % uint32_t(65536)) / 65536.0;
+			restart_phase += randomness_ratio * random * 1.0 / pcount;
 		}
 
 		restart_phase *= (1.0 - explosiveness_ratio);
@@ -680,17 +680,17 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			}
 			p.active = true;
 
-			/*float tex_linear_velocity = 0;
+			/*real_t tex_linear_velocity = 0;
 			if (curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
 				tex_linear_velocity = curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY]->interpolate(0);
 			}*/
 
-			float tex_angle = 0.0;
+			real_t tex_angle = 0.0;
 			if (curve_parameters[PARAM_ANGLE].is_valid()) {
 				tex_angle = curve_parameters[PARAM_ANGLE]->interpolate(tv);
 			}
 
-			float tex_anim_offset = 0.0;
+			real_t tex_anim_offset = 0.0;
 			if (curve_parameters[PARAM_ANGLE].is_valid()) {
 				tex_anim_offset = curve_parameters[PARAM_ANGLE]->interpolate(tv);
 			}
@@ -702,16 +702,16 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			p.hue_rot_rand = Math::randf();
 			p.anim_offset_rand = Math::randf();
 
-			float angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
+			real_t angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
 			Vector2 rot = Vector2(Math::cos(angle1_rad), Math::sin(angle1_rad));
-			p.velocity = rot * parameters[PARAM_INITIAL_LINEAR_VELOCITY] * Math::lerp(1.0f, float(Math::randf()), randomness[PARAM_INITIAL_LINEAR_VELOCITY]);
+			p.velocity = rot * parameters[PARAM_INITIAL_LINEAR_VELOCITY] * Math::lerp((real_t)1.0, real_t(Math::randf()), randomness[PARAM_INITIAL_LINEAR_VELOCITY]);
 
-			float base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp(1.0f, p.angle_rand, randomness[PARAM_ANGLE]);
+			real_t base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp((real_t)1.0, p.angle_rand, randomness[PARAM_ANGLE]);
 			p.rotation = Math::deg2rad(base_angle);
 
 			p.custom[0] = 0.0; // unused
 			p.custom[1] = 0.0; // phase [0..1]
-			p.custom[2] = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp(1.0f, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]); //animation phase [0..1]
+			p.custom[2] = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp((real_t)1.0, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]); //animation phase [0..1]
 			p.custom[3] = 0.0;
 			p.transform = Transform2D();
 			p.time = 0;
@@ -723,8 +723,8 @@ void CPUParticles2D::_particles_process(float p_delta) {
 					//do none
 				} break;
 				case EMISSION_SHAPE_SPHERE: {
-					float s = Math::randf(), t = Math_TAU * Math::randf();
-					float radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
+					real_t s = Math::randf(), t = Math_TAU * Math::randf();
+					real_t radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
 					p.transform[2] = Vector2(Math::cos(t), Math::sin(t)) * radius;
 				} break;
 				case EMISSION_SHAPE_RECTANGLE: {
@@ -775,51 +775,51 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			p.custom[1] = p.time / lifetime;
 			tv = p.time / p.lifetime;
 
-			float tex_linear_velocity = 0.0;
+			real_t tex_linear_velocity = 0.0;
 			if (curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
 				tex_linear_velocity = curve_parameters[PARAM_INITIAL_LINEAR_VELOCITY]->interpolate(tv);
 			}
 
-			float tex_orbit_velocity = 0.0;
+			real_t tex_orbit_velocity = 0.0;
 			if (curve_parameters[PARAM_ORBIT_VELOCITY].is_valid()) {
 				tex_orbit_velocity = curve_parameters[PARAM_ORBIT_VELOCITY]->interpolate(tv);
 			}
 
-			float tex_angular_velocity = 0.0;
+			real_t tex_angular_velocity = 0.0;
 			if (curve_parameters[PARAM_ANGULAR_VELOCITY].is_valid()) {
 				tex_angular_velocity = curve_parameters[PARAM_ANGULAR_VELOCITY]->interpolate(tv);
 			}
 
-			float tex_linear_accel = 0.0;
+			real_t tex_linear_accel = 0.0;
 			if (curve_parameters[PARAM_LINEAR_ACCEL].is_valid()) {
 				tex_linear_accel = curve_parameters[PARAM_LINEAR_ACCEL]->interpolate(tv);
 			}
 
-			float tex_tangential_accel = 0.0;
+			real_t tex_tangential_accel = 0.0;
 			if (curve_parameters[PARAM_TANGENTIAL_ACCEL].is_valid()) {
 				tex_tangential_accel = curve_parameters[PARAM_TANGENTIAL_ACCEL]->interpolate(tv);
 			}
 
-			float tex_radial_accel = 0.0;
+			real_t tex_radial_accel = 0.0;
 			if (curve_parameters[PARAM_RADIAL_ACCEL].is_valid()) {
 				tex_radial_accel = curve_parameters[PARAM_RADIAL_ACCEL]->interpolate(tv);
 			}
 
-			float tex_damping = 0.0;
+			real_t tex_damping = 0.0;
 			if (curve_parameters[PARAM_DAMPING].is_valid()) {
 				tex_damping = curve_parameters[PARAM_DAMPING]->interpolate(tv);
 			}
 
-			float tex_angle = 0.0;
+			real_t tex_angle = 0.0;
 			if (curve_parameters[PARAM_ANGLE].is_valid()) {
 				tex_angle = curve_parameters[PARAM_ANGLE]->interpolate(tv);
 			}
-			float tex_anim_speed = 0.0;
+			real_t tex_anim_speed = 0.0;
 			if (curve_parameters[PARAM_ANIM_SPEED].is_valid()) {
 				tex_anim_speed = curve_parameters[PARAM_ANIM_SPEED]->interpolate(tv);
 			}
 
-			float tex_anim_offset = 0.0;
+			real_t tex_anim_offset = 0.0;
 			if (curve_parameters[PARAM_ANIM_OFFSET].is_valid()) {
 				tex_anim_offset = curve_parameters[PARAM_ANIM_OFFSET]->interpolate(tv);
 			}
@@ -828,20 +828,20 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			Vector2 pos = p.transform[2];
 
 			//apply linear acceleration
-			force += p.velocity.length() > 0.0 ? p.velocity.normalized() * (parameters[PARAM_LINEAR_ACCEL] + tex_linear_accel) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_LINEAR_ACCEL]) : Vector2();
+			force += p.velocity.length() > 0.0 ? p.velocity.normalized() * (parameters[PARAM_LINEAR_ACCEL] + tex_linear_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_LINEAR_ACCEL]) : Vector2();
 			//apply radial acceleration
 			Vector2 org = emission_xform[2];
 			Vector2 diff = pos - org;
-			force += diff.length() > 0.0 ? diff.normalized() * (parameters[PARAM_RADIAL_ACCEL] + tex_radial_accel) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_RADIAL_ACCEL]) : Vector2();
+			force += diff.length() > 0.0 ? diff.normalized() * (parameters[PARAM_RADIAL_ACCEL] + tex_radial_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_RADIAL_ACCEL]) : Vector2();
 			//apply tangential acceleration;
 			Vector2 yx = Vector2(diff.y, diff.x);
-			force += yx.length() > 0.0 ? (yx * Vector2(-1.0, 1.0)).normalized() * ((parameters[PARAM_TANGENTIAL_ACCEL] + tex_tangential_accel) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_TANGENTIAL_ACCEL])) : Vector2();
+			force += yx.length() > 0.0 ? (yx * Vector2(-1.0, 1.0)).normalized() * ((parameters[PARAM_TANGENTIAL_ACCEL] + tex_tangential_accel) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_TANGENTIAL_ACCEL])) : Vector2();
 			//apply attractor forces
 			p.velocity += force * local_delta;
 			//orbit velocity
-			float orbit_amount = (parameters[PARAM_ORBIT_VELOCITY] + tex_orbit_velocity) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_ORBIT_VELOCITY]);
+			real_t orbit_amount = (parameters[PARAM_ORBIT_VELOCITY] + tex_orbit_velocity) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_ORBIT_VELOCITY]);
 			if (orbit_amount != 0.0) {
-				float ang = orbit_amount * local_delta * Math_TAU;
+				real_t ang = orbit_amount * local_delta * Math_TAU;
 				// Not sure why the ParticlesMaterial code uses a clockwise rotation matrix,
 				// but we use -ang here to reproduce its behavior.
 				Transform2D rot = Transform2D(-ang, Vector2());
@@ -853,8 +853,8 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			}
 
 			if (parameters[PARAM_DAMPING] + tex_damping > 0.0) {
-				float v = p.velocity.length();
-				float damp = (parameters[PARAM_DAMPING] + tex_damping) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_DAMPING]);
+				real_t v = p.velocity.length();
+				real_t damp = (parameters[PARAM_DAMPING] + tex_damping) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_DAMPING]);
 				v -= damp * local_delta;
 				if (v < 0.0) {
 					p.velocity = Vector2();
@@ -862,28 +862,28 @@ void CPUParticles2D::_particles_process(float p_delta) {
 					p.velocity = p.velocity.normalized() * v;
 				}
 			}
-			float base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp(1.0f, p.angle_rand, randomness[PARAM_ANGLE]);
-			base_angle += p.custom[1] * lifetime * (parameters[PARAM_ANGULAR_VELOCITY] + tex_angular_velocity) * Math::lerp(1.0f, rand_from_seed(alt_seed) * 2.0f - 1.0f, randomness[PARAM_ANGULAR_VELOCITY]);
+			real_t base_angle = (parameters[PARAM_ANGLE] + tex_angle) * Math::lerp((real_t)1.0, p.angle_rand, randomness[PARAM_ANGLE]);
+			base_angle += p.custom[1] * lifetime * (parameters[PARAM_ANGULAR_VELOCITY] + tex_angular_velocity) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed) * 2.0f - 1.0f, randomness[PARAM_ANGULAR_VELOCITY]);
 			p.rotation = Math::deg2rad(base_angle); //angle
-			float animation_phase = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp(1.0f, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]) + p.custom[1] * (parameters[PARAM_ANIM_SPEED] + tex_anim_speed) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_ANIM_SPEED]);
+			real_t animation_phase = (parameters[PARAM_ANIM_OFFSET] + tex_anim_offset) * Math::lerp((real_t)1.0, p.anim_offset_rand, randomness[PARAM_ANIM_OFFSET]) + p.custom[1] * (parameters[PARAM_ANIM_SPEED] + tex_anim_speed) * Math::lerp((real_t)1.0, rand_from_seed(alt_seed), randomness[PARAM_ANIM_SPEED]);
 			p.custom[2] = animation_phase;
 		}
 		//apply color
 		//apply hue rotation
 
-		float tex_scale = 1.0;
+		real_t tex_scale = 1.0;
 		if (curve_parameters[PARAM_SCALE].is_valid()) {
 			tex_scale = curve_parameters[PARAM_SCALE]->interpolate(tv);
 		}
 
-		float tex_hue_variation = 0.0;
+		real_t tex_hue_variation = 0.0;
 		if (curve_parameters[PARAM_HUE_VARIATION].is_valid()) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->interpolate(tv);
 		}
 
-		float hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
-		float hue_rot_c = Math::cos(hue_rot_angle);
-		float hue_rot_s = Math::sin(hue_rot_angle);
+		real_t hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
+		real_t hue_rot_c = Math::cos(hue_rot_angle);
+		real_t hue_rot_s = Math::sin(hue_rot_angle);
 
 		Basis hue_rot_mat;
 		{
@@ -921,7 +921,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 		}
 
 		//scale by scale
-		float base_scale = tex_scale * Math::lerp(parameters[PARAM_SCALE], 1.0f, p.scale_rand * randomness[PARAM_SCALE]);
+		real_t base_scale = tex_scale * Math::lerp(parameters[PARAM_SCALE], (real_t)1.0, p.scale_rand * randomness[PARAM_SCALE]);
 		if (base_scale < 0.000001) {
 			base_scale = 0.000001;
 		}

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -84,13 +84,13 @@ private:
 		Transform2D transform;
 		Color color;
 		float custom[4] = {};
-		float rotation = 0.0;
+		real_t rotation = 0.0;
 		Vector2 velocity;
 		bool active = false;
-		float angle_rand = 0.0;
-		float scale_rand = 0.0;
-		float hue_rot_rand = 0.0;
-		float anim_offset_rand = 0.0;
+		real_t angle_rand = 0.0;
+		real_t scale_rand = 0.0;
+		real_t hue_rot_rand = 0.0;
+		real_t anim_offset_rand = 0.0;
 		float time = 0.0;
 		float lifetime = 0.0;
 		Color base_color;
@@ -133,10 +133,10 @@ private:
 
 	float lifetime = 1.0;
 	float pre_process_time = 0.0;
-	float explosiveness_ratio = 0.0;
-	float randomness_ratio = 0.0;
-	float lifetime_randomness = 0.0;
-	float speed_scale = 1.0;
+	real_t explosiveness_ratio = 0.0;
+	real_t randomness_ratio = 0.0;
+	real_t lifetime_randomness = 0.0;
+	real_t speed_scale = 1.0;
 	bool local_coords;
 	int fixed_fps = 0;
 	bool fractional_delta = true;
@@ -150,10 +150,10 @@ private:
 	////////
 
 	Vector2 direction = Vector2(1, 0);
-	float spread = 45.0;
+	real_t spread = 45.0;
 
-	float parameters[PARAM_MAX];
-	float randomness[PARAM_MAX];
+	real_t parameters[PARAM_MAX];
+	real_t randomness[PARAM_MAX];
 
 	Ref<Curve> curve_parameters[PARAM_MAX];
 	Color color;
@@ -162,7 +162,7 @@ private:
 	bool particle_flags[PARTICLE_FLAG_MAX];
 
 	EmissionShape emission_shape = EMISSION_SHAPE_POINT;
-	float emission_sphere_radius = 1.0;
+	real_t emission_sphere_radius = 1.0;
 	Vector2 emission_rect_extents = Vector2(1, 1);
 	Vector<Vector2> emission_points;
 	Vector<Vector2> emission_normals;
@@ -196,24 +196,24 @@ public:
 	void set_lifetime(float p_lifetime);
 	void set_one_shot(bool p_one_shot);
 	void set_pre_process_time(float p_time);
-	void set_explosiveness_ratio(float p_ratio);
-	void set_randomness_ratio(float p_ratio);
+	void set_explosiveness_ratio(real_t p_ratio);
+	void set_randomness_ratio(real_t p_ratio);
 	void set_lifetime_randomness(float p_random);
 	void set_visibility_aabb(const Rect2 &p_aabb);
 	void set_use_local_coordinates(bool p_enable);
-	void set_speed_scale(float p_scale);
+	void set_speed_scale(real_t p_scale);
 
 	bool is_emitting() const;
 	int get_amount() const;
 	float get_lifetime() const;
 	bool get_one_shot() const;
 	float get_pre_process_time() const;
-	float get_explosiveness_ratio() const;
-	float get_randomness_ratio() const;
+	real_t get_explosiveness_ratio() const;
+	real_t get_randomness_ratio() const;
 	float get_lifetime_randomness() const;
 	Rect2 get_visibility_aabb() const;
 	bool get_use_local_coordinates() const;
-	float get_speed_scale() const;
+	real_t get_speed_scale() const;
 
 	void set_fixed_fps(int p_count);
 	int get_fixed_fps() const;
@@ -235,14 +235,14 @@ public:
 	void set_direction(Vector2 p_direction);
 	Vector2 get_direction() const;
 
-	void set_spread(float p_spread);
-	float get_spread() const;
+	void set_spread(real_t p_spread);
+	real_t get_spread() const;
 
-	void set_param(Parameter p_param, float p_value);
-	float get_param(Parameter p_param) const;
+	void set_param(Parameter p_param, real_t p_value);
+	real_t get_param(Parameter p_param) const;
 
-	void set_param_randomness(Parameter p_param, float p_value);
-	float get_param_randomness(Parameter p_param) const;
+	void set_param_randomness(Parameter p_param, real_t p_value);
+	real_t get_param_randomness(Parameter p_param) const;
 
 	void set_param_curve(Parameter p_param, const Ref<Curve> &p_curve);
 	Ref<Curve> get_param_curve(Parameter p_param) const;
@@ -257,7 +257,7 @@ public:
 	bool get_particle_flag(ParticleFlags p_particle_flag) const;
 
 	void set_emission_shape(EmissionShape p_shape);
-	void set_emission_sphere_radius(float p_radius);
+	void set_emission_sphere_radius(real_t p_radius);
 	void set_emission_rect_extents(Vector2 p_extents);
 	void set_emission_points(const Vector<Vector2> &p_points);
 	void set_emission_normals(const Vector<Vector2> &p_normals);
@@ -265,7 +265,7 @@ public:
 	void set_emission_point_count(int p_count);
 
 	EmissionShape get_emission_shape() const;
-	float get_emission_sphere_radius() const;
+	real_t get_emission_sphere_radius() const;
 	Vector2 get_emission_rect_extents() const;
 	Vector<Vector2> get_emission_points() const;
 	Vector<Vector2> get_emission_normals() const;

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -84,21 +84,21 @@ Color Light2D::get_color() const {
 	return color;
 }
 
-void Light2D::set_height(float p_height) {
+void Light2D::set_height(real_t p_height) {
 	height = p_height;
 	RS::get_singleton()->canvas_light_set_height(canvas_light, height);
 }
 
-float Light2D::get_height() const {
+real_t Light2D::get_height() const {
 	return height;
 }
 
-void Light2D::set_energy(float p_energy) {
+void Light2D::set_energy(real_t p_energy) {
 	energy = p_energy;
 	RS::get_singleton()->canvas_light_set_energy(canvas_light, energy);
 }
 
-float Light2D::get_energy() const {
+real_t Light2D::get_energy() const {
 	return energy;
 }
 
@@ -213,12 +213,12 @@ void Light2D::_notification(int p_what) {
 	}
 }
 
-void Light2D::set_shadow_smooth(float p_amount) {
+void Light2D::set_shadow_smooth(real_t p_amount) {
 	shadow_smooth = p_amount;
 	RS::get_singleton()->canvas_light_set_shadow_smooth(canvas_light, shadow_smooth);
 }
 
-float Light2D::get_shadow_smooth() const {
+real_t Light2D::get_shadow_smooth() const {
 	return shadow_smooth;
 }
 
@@ -403,7 +403,7 @@ String PointLight2D::get_configuration_warning() const {
 	return warning;
 }
 
-void PointLight2D::set_texture_scale(float p_scale) {
+void PointLight2D::set_texture_scale(real_t p_scale) {
 	_scale = p_scale;
 	// Avoid having 0 scale values, can lead to errors in physics and rendering.
 	if (_scale == 0) {
@@ -413,7 +413,7 @@ void PointLight2D::set_texture_scale(float p_scale) {
 	item_rect_changed();
 }
 
-float PointLight2D::get_texture_scale() const {
+real_t PointLight2D::get_texture_scale() const {
 	return _scale;
 }
 
@@ -439,12 +439,12 @@ PointLight2D::PointLight2D() {
 
 //////////
 
-void DirectionalLight2D::set_max_distance(float p_distance) {
+void DirectionalLight2D::set_max_distance(real_t p_distance) {
 	max_distance = p_distance;
 	RS::get_singleton()->canvas_light_set_directional_distance(_get_light(), max_distance);
 }
 
-float DirectionalLight2D::get_max_distance() const {
+real_t DirectionalLight2D::get_max_distance() const {
 	return max_distance;
 }
 

--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -57,15 +57,15 @@ private:
 	bool shadow = false;
 	Color color = Color(1, 1, 1);
 	Color shadow_color = Color(0, 0, 0, 0);
-	float height = 0.0;
-	float energy = 1.0;
+	real_t height = 0.0;
+	real_t energy = 1.0;
 	int z_min = -1024;
 	int z_max = 1024;
 	int layer_min = 0;
 	int layer_max = 0;
 	int item_mask = 1;
 	int item_shadow_mask = 1;
-	float shadow_smooth = 0.0;
+	real_t shadow_smooth = 0.0;
 	Ref<Texture2D> texture;
 	Vector2 texture_offset;
 	ShadowFilter shadow_filter = SHADOW_FILTER_NONE;
@@ -89,11 +89,11 @@ public:
 	void set_color(const Color &p_color);
 	Color get_color() const;
 
-	void set_height(float p_height);
-	float get_height() const;
+	void set_height(real_t p_height);
+	real_t get_height() const;
 
-	void set_energy(float p_energy);
-	float get_energy() const;
+	void set_energy(real_t p_energy);
+	real_t get_energy() const;
 
 	void set_z_range_min(int p_min_z);
 	int get_z_range_min() const;
@@ -122,8 +122,8 @@ public:
 	void set_shadow_color(const Color &p_shadow_color);
 	Color get_shadow_color() const;
 
-	void set_shadow_smooth(float p_amount);
-	float get_shadow_smooth() const;
+	void set_shadow_smooth(real_t p_amount);
+	real_t get_shadow_smooth() const;
 
 	void set_blend_mode(BlendMode p_mode);
 	BlendMode get_blend_mode() const;
@@ -139,7 +139,7 @@ class PointLight2D : public Light2D {
 	GDCLASS(PointLight2D, Light2D);
 
 private:
-	float _scale = 1.0;
+	real_t _scale = 1.0;
 	Ref<Texture2D> texture;
 	Vector2 texture_offset;
 
@@ -166,8 +166,8 @@ public:
 	void set_texture_offset(const Vector2 &p_offset);
 	Vector2 get_texture_offset() const;
 
-	void set_texture_scale(float p_scale);
-	float get_texture_scale() const;
+	void set_texture_scale(real_t p_scale);
+	real_t get_texture_scale() const;
 
 	String get_configuration_warning() const override;
 
@@ -177,14 +177,14 @@ public:
 class DirectionalLight2D : public Light2D {
 	GDCLASS(DirectionalLight2D, Light2D);
 
-	float max_distance = 10000.0;
+	real_t max_distance = 10000.0;
 
 protected:
 	static void _bind_methods();
 
 public:
-	void set_max_distance(float p_distance);
-	float get_max_distance() const;
+	void set_max_distance(real_t p_distance);
+	real_t get_max_distance() const;
 
 	DirectionalLight2D();
 };

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -71,12 +71,12 @@ Size2 Node2D::_edit_get_scale() const {
 	return _scale;
 }
 
-void Node2D::_edit_set_rotation(float p_rotation) {
+void Node2D::_edit_set_rotation(real_t p_rotation) {
 	angle = p_rotation;
 	_update_transform();
 }
 
-float Node2D::_edit_get_rotation() const {
+real_t Node2D::_edit_get_rotation() const {
 	return angle;
 }
 
@@ -148,7 +148,7 @@ void Node2D::set_position(const Point2 &p_pos) {
 	_update_transform();
 }
 
-void Node2D::set_rotation(float p_radians) {
+void Node2D::set_rotation(real_t p_radians) {
 	if (_xform_dirty) {
 		((Node2D *)this)->_update_xform_values();
 	}
@@ -156,7 +156,7 @@ void Node2D::set_rotation(float p_radians) {
 	_update_transform();
 }
 
-void Node2D::set_skew(float p_radians) {
+void Node2D::set_skew(real_t p_radians) {
 	if (_xform_dirty) {
 		((Node2D *)this)->_update_xform_values();
 	}
@@ -164,11 +164,11 @@ void Node2D::set_skew(float p_radians) {
 	_update_transform();
 }
 
-void Node2D::set_rotation_degrees(float p_degrees) {
+void Node2D::set_rotation_degrees(real_t p_degrees) {
 	set_rotation(Math::deg2rad(p_degrees));
 }
 
-void Node2D::set_skew_degrees(float p_degrees) {
+void Node2D::set_skew_degrees(real_t p_degrees) {
 	set_skew(Math::deg2rad(p_degrees));
 }
 
@@ -194,7 +194,7 @@ Point2 Node2D::get_position() const {
 	return pos;
 }
 
-float Node2D::get_rotation() const {
+real_t Node2D::get_rotation() const {
 	if (_xform_dirty) {
 		((Node2D *)this)->_update_xform_values();
 	}
@@ -202,7 +202,7 @@ float Node2D::get_rotation() const {
 	return angle;
 }
 
-float Node2D::get_skew() const {
+real_t Node2D::get_skew() const {
 	if (_xform_dirty) {
 		((Node2D *)this)->_update_xform_values();
 	}
@@ -210,11 +210,11 @@ float Node2D::get_skew() const {
 	return skew;
 }
 
-float Node2D::get_rotation_degrees() const {
+real_t Node2D::get_rotation_degrees() const {
 	return Math::rad2deg(get_rotation());
 }
 
-float Node2D::get_skew_degrees() const {
+real_t Node2D::get_skew_degrees() const {
 	return Math::rad2deg(get_skew());
 }
 
@@ -230,7 +230,7 @@ Transform2D Node2D::get_transform() const {
 	return _mat;
 }
 
-void Node2D::rotate(float p_radians) {
+void Node2D::rotate(real_t p_radians) {
 	set_rotation(get_rotation() + p_radians);
 }
 
@@ -246,7 +246,7 @@ void Node2D::apply_scale(const Size2 &p_amount) {
 	set_scale(get_scale() * p_amount);
 }
 
-void Node2D::move_x(float p_delta, bool p_scaled) {
+void Node2D::move_x(real_t p_delta, bool p_scaled) {
 	Transform2D t = get_transform();
 	Vector2 m = t[0];
 	if (!p_scaled) {
@@ -255,7 +255,7 @@ void Node2D::move_x(float p_delta, bool p_scaled) {
 	set_position(t[2] + m * p_delta);
 }
 
-void Node2D::move_y(float p_delta, bool p_scaled) {
+void Node2D::move_y(real_t p_delta, bool p_scaled) {
 	Transform2D t = get_transform();
 	Vector2 m = t[1];
 	if (!p_scaled) {
@@ -279,25 +279,25 @@ void Node2D::set_global_position(const Point2 &p_pos) {
 	}
 }
 
-float Node2D::get_global_rotation() const {
+real_t Node2D::get_global_rotation() const {
 	return get_global_transform().get_rotation();
 }
 
-void Node2D::set_global_rotation(float p_radians) {
+void Node2D::set_global_rotation(real_t p_radians) {
 	CanvasItem *pi = get_parent_item();
 	if (pi) {
-		const float parent_global_rot = pi->get_global_transform().get_rotation();
+		const real_t parent_global_rot = pi->get_global_transform().get_rotation();
 		set_rotation(p_radians - parent_global_rot);
 	} else {
 		set_rotation(p_radians);
 	}
 }
 
-float Node2D::get_global_rotation_degrees() const {
+real_t Node2D::get_global_rotation_degrees() const {
 	return Math::rad2deg(get_global_rotation());
 }
 
-void Node2D::set_global_rotation_degrees(float p_degrees) {
+void Node2D::set_global_rotation_degrees(real_t p_degrees) {
 	set_global_rotation(Math::deg2rad(p_degrees));
 }
 
@@ -379,7 +379,7 @@ void Node2D::look_at(const Vector2 &p_pos) {
 	rotate(get_angle_to(p_pos));
 }
 
-float Node2D::get_angle_to(const Vector2 &p_pos) const {
+real_t Node2D::get_angle_to(const Vector2 &p_pos) const {
 	return (to_local(p_pos) * get_scale()).angle();
 }
 

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -37,9 +37,9 @@ class Node2D : public CanvasItem {
 	GDCLASS(Node2D, CanvasItem);
 
 	Point2 pos;
-	float angle = 0.0;
+	real_t angle = 0.0;
 	Size2 _scale = Vector2(1, 1);
-	float skew = 0.0;
+	real_t skew = 0.0;
 	int z_index = 0;
 	bool z_relative = true;
 
@@ -65,51 +65,51 @@ public:
 	virtual void _edit_set_scale(const Size2 &p_scale) override;
 	virtual Size2 _edit_get_scale() const override;
 
-	virtual void _edit_set_rotation(float p_rotation) override;
-	virtual float _edit_get_rotation() const override;
+	virtual void _edit_set_rotation(real_t p_rotation) override;
+	virtual real_t _edit_get_rotation() const override;
 	virtual bool _edit_use_rotation() const override;
 
 	virtual void _edit_set_rect(const Rect2 &p_edit_rect) override;
 #endif
 
 	void set_position(const Point2 &p_pos);
-	void set_rotation(float p_radians);
-	void set_rotation_degrees(float p_degrees);
-	void set_skew(float p_radians);
-	void set_skew_degrees(float p_radians);
+	void set_rotation(real_t p_radians);
+	void set_rotation_degrees(real_t p_degrees);
+	void set_skew(real_t p_radians);
+	void set_skew_degrees(real_t p_radians);
 	void set_scale(const Size2 &p_scale);
 
-	void rotate(float p_radians);
-	void move_x(float p_delta, bool p_scaled = false);
-	void move_y(float p_delta, bool p_scaled = false);
+	void rotate(real_t p_radians);
+	void move_x(real_t p_delta, bool p_scaled = false);
+	void move_y(real_t p_delta, bool p_scaled = false);
 	void translate(const Vector2 &p_amount);
 	void global_translate(const Vector2 &p_amount);
 	void apply_scale(const Size2 &p_amount);
 
 	Point2 get_position() const;
-	float get_rotation() const;
-	float get_skew() const;
-	float get_rotation_degrees() const;
-	float get_skew_degrees() const;
+	real_t get_rotation() const;
+	real_t get_skew() const;
+	real_t get_rotation_degrees() const;
+	real_t get_skew_degrees() const;
 	Size2 get_scale() const;
 
 	Point2 get_global_position() const;
-	float get_global_rotation() const;
-	float get_global_rotation_degrees() const;
+	real_t get_global_rotation() const;
+	real_t get_global_rotation_degrees() const;
 	Size2 get_global_scale() const;
 
 	void set_transform(const Transform2D &p_transform);
 	void set_global_transform(const Transform2D &p_transform);
 	void set_global_position(const Point2 &p_pos);
-	void set_global_rotation(float p_radians);
-	void set_global_rotation_degrees(float p_degrees);
+	void set_global_rotation(real_t p_radians);
+	void set_global_rotation_degrees(real_t p_degrees);
 	void set_global_scale(const Size2 &p_scale);
 
 	void set_z_index(int p_z);
 	int get_z_index() const;
 
 	void look_at(const Vector2 &p_pos);
-	float get_angle_to(const Vector2 &p_pos) const;
+	real_t get_angle_to(const Vector2 &p_pos) const;
 
 	Point2 to_local(Point2 p_global) const;
 	Point2 to_global(Point2 p_local) const;

--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -51,11 +51,11 @@ void ParallaxBackground::_camera_moved(const Transform2D &p_transform, const Poi
 	set_scroll_offset(p_transform.get_origin());
 }
 
-void ParallaxBackground::set_scroll_scale(float p_scale) {
+void ParallaxBackground::set_scroll_scale(real_t p_scale) {
 	scale = p_scale;
 }
 
-float ParallaxBackground::get_scroll_scale() const {
+real_t ParallaxBackground::get_scroll_scale() const {
 	return scale;
 }
 

--- a/scene/2d/parallax_background.h
+++ b/scene/2d/parallax_background.h
@@ -39,7 +39,7 @@ class ParallaxBackground : public CanvasLayer {
 	GDCLASS(ParallaxBackground, CanvasLayer);
 
 	Point2 offset;
-	float scale = 1.0;
+	real_t scale = 1.0;
 	Point2 base_offset;
 	Point2 base_scale = Vector2(1, 1);
 	Point2 screen_offset;
@@ -61,8 +61,8 @@ public:
 	void set_scroll_offset(const Point2 &p_ofs);
 	Point2 get_scroll_offset() const;
 
-	void set_scroll_scale(float p_scale);
-	float get_scroll_scale() const;
+	void set_scroll_scale(real_t p_scale);
+	real_t get_scroll_scale() const;
 
 	void set_scroll_base_offset(const Point2 &p_ofs);
 	Point2 get_scroll_base_offset() const;

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -39,7 +39,7 @@ void ParallaxLayer::set_motion_scale(const Size2 &p_scale) {
 	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
 	if (pb && is_inside_tree()) {
 		Vector2 ofs = pb->get_final_offset();
-		float scale = pb->get_scroll_scale();
+		real_t scale = pb->get_scroll_scale();
 		set_base_offset_and_scale(ofs, scale, screen_offset);
 	}
 }
@@ -54,7 +54,7 @@ void ParallaxLayer::set_motion_offset(const Size2 &p_offset) {
 	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
 	if (pb && is_inside_tree()) {
 		Vector2 ofs = pb->get_final_offset();
-		float scale = pb->get_scroll_scale();
+		real_t scale = pb->get_scroll_scale();
 		set_base_offset_and_scale(ofs, scale, screen_offset);
 	}
 }
@@ -107,7 +107,7 @@ void ParallaxLayer::_notification(int p_what) {
 	}
 }
 
-void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, float p_scale, const Point2 &p_screen_offset) {
+void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, real_t p_scale, const Point2 &p_screen_offset) {
 	screen_offset = p_screen_offset;
 
 	if (!is_inside_tree()) {

--- a/scene/2d/parallax_layer.h
+++ b/scene/2d/parallax_layer.h
@@ -59,7 +59,7 @@ public:
 	void set_mirroring(const Size2 &p_mirroring);
 	Size2 get_mirroring() const;
 
-	void set_base_offset_and_scale(const Point2 &p_offset, float p_scale, const Point2 &p_screen_offset);
+	void set_base_offset_and_scale(const Point2 &p_offset, real_t p_scale, const Point2 &p_screen_offset);
 
 	virtual String get_configuration_warning() const override;
 	ParallaxLayer();

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -96,9 +96,9 @@ void Path2D::_notification(int p_what) {
 		}
 
 #ifdef TOOLS_ENABLED
-		const float line_width = 2 * EDSCALE;
+		const real_t line_width = 2 * EDSCALE;
 #else
-		const float line_width = 2;
+		const real_t line_width = 2;
 #endif
 		const Color color = Color(0.5, 0.6, 1.0, 0.7);
 
@@ -164,14 +164,14 @@ void PathFollow2D::_update_transform() {
 		return;
 	}
 
-	float path_length = c->get_baked_length();
+	real_t path_length = c->get_baked_length();
 	if (path_length == 0) {
 		return;
 	}
 	Vector2 pos = c->interpolate_baked(offset, cubic);
 
 	if (rotates) {
-		float ahead = offset + lookahead;
+		real_t ahead = offset + lookahead;
 
 		if (loop && ahead >= path_length) {
 			// If our lookahead will loop, we need to check if the path is closed.
@@ -240,7 +240,7 @@ bool PathFollow2D::get_cubic_interpolation() const {
 
 void PathFollow2D::_validate_property(PropertyInfo &property) const {
 	if (property.name == "offset") {
-		float max = 10000.0;
+		real_t max = 10000.0;
 		if (path && path->get_curve().is_valid()) {
 			max = path->get_curve()->get_baked_length();
 		}
@@ -301,11 +301,11 @@ void PathFollow2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lookahead", PROPERTY_HINT_RANGE, "0.001,1024.0,0.001"), "set_lookahead", "get_lookahead");
 }
 
-void PathFollow2D::set_offset(float p_offset) {
+void PathFollow2D::set_offset(real_t p_offset) {
 	offset = p_offset;
 	if (path) {
 		if (path->get_curve().is_valid()) {
-			float path_length = path->get_curve()->get_baked_length();
+			real_t path_length = path->get_curve()->get_baked_length();
 
 			if (loop) {
 				offset = Math::fposmod(offset, path_length);
@@ -321,39 +321,39 @@ void PathFollow2D::set_offset(float p_offset) {
 	}
 }
 
-void PathFollow2D::set_h_offset(float p_h_offset) {
+void PathFollow2D::set_h_offset(real_t p_h_offset) {
 	h_offset = p_h_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-float PathFollow2D::get_h_offset() const {
+real_t PathFollow2D::get_h_offset() const {
 	return h_offset;
 }
 
-void PathFollow2D::set_v_offset(float p_v_offset) {
+void PathFollow2D::set_v_offset(real_t p_v_offset) {
 	v_offset = p_v_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-float PathFollow2D::get_v_offset() const {
+real_t PathFollow2D::get_v_offset() const {
 	return v_offset;
 }
 
-float PathFollow2D::get_offset() const {
+real_t PathFollow2D::get_offset() const {
 	return offset;
 }
 
-void PathFollow2D::set_unit_offset(float p_unit_offset) {
+void PathFollow2D::set_unit_offset(real_t p_unit_offset) {
 	if (path && path->get_curve().is_valid() && path->get_curve()->get_baked_length()) {
 		set_offset(p_unit_offset * path->get_curve()->get_baked_length());
 	}
 }
 
-float PathFollow2D::get_unit_offset() const {
+real_t PathFollow2D::get_unit_offset() const {
 	if (path && path->get_curve().is_valid() && path->get_curve()->get_baked_length()) {
 		return get_offset() / path->get_curve()->get_baked_length();
 	} else {
@@ -361,11 +361,11 @@ float PathFollow2D::get_unit_offset() const {
 	}
 }
 
-void PathFollow2D::set_lookahead(float p_lookahead) {
+void PathFollow2D::set_lookahead(real_t p_lookahead) {
 	lookahead = p_lookahead;
 }
 
-float PathFollow2D::get_lookahead() const {
+real_t PathFollow2D::get_lookahead() const {
 	return lookahead;
 }
 

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -81,20 +81,20 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_offset(float p_offset);
-	float get_offset() const;
+	void set_offset(real_t p_offset);
+	real_t get_offset() const;
 
-	void set_h_offset(float p_h_offset);
-	float get_h_offset() const;
+	void set_h_offset(real_t p_h_offset);
+	real_t get_h_offset() const;
 
-	void set_v_offset(float p_v_offset);
-	float get_v_offset() const;
+	void set_v_offset(real_t p_v_offset);
+	real_t get_v_offset() const;
 
-	void set_unit_offset(float p_unit_offset);
-	float get_unit_offset() const;
+	void set_unit_offset(real_t p_unit_offset);
+	real_t get_unit_offset() const;
 
-	void set_lookahead(float p_lookahead);
-	float get_lookahead() const;
+	void set_lookahead(real_t p_lookahead);
+	real_t get_lookahead() const;
 
 	void set_loop(bool p_loop);
 	bool has_loop() const;

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -160,8 +160,8 @@ void Polygon2D::_notification(int p_what) {
 			if (invert) {
 				Rect2 bounds;
 				int highest_idx = -1;
-				float highest_y = -1e20;
-				float sum = 0.0;
+				real_t highest_y = -1e20;
+				real_t sum = 0.0;
 
 				for (int i = 0; i < len; i++) {
 					if (i == 0) {
@@ -279,7 +279,7 @@ void Polygon2D::_notification(int p_what) {
 
 				//normalize the weights
 				for (int i = 0; i < vc; i++) {
-					float tw = 0.0;
+					real_t tw = 0.0;
 					for (int j = 0; j < 4; j++) {
 						tw += weightsw[i * 4 + j];
 					}
@@ -432,20 +432,20 @@ Vector2 Polygon2D::get_texture_offset() const {
 	return tex_ofs;
 }
 
-void Polygon2D::set_texture_rotation(float p_rot) {
+void Polygon2D::set_texture_rotation(real_t p_rot) {
 	tex_rot = p_rot;
 	update();
 }
 
-float Polygon2D::get_texture_rotation() const {
+real_t Polygon2D::get_texture_rotation() const {
 	return tex_rot;
 }
 
-void Polygon2D::set_texture_rotation_degrees(float p_rot) {
+void Polygon2D::set_texture_rotation_degrees(real_t p_rot) {
 	set_texture_rotation(Math::deg2rad(p_rot));
 }
 
-float Polygon2D::get_texture_rotation_degrees() const {
+real_t Polygon2D::get_texture_rotation_degrees() const {
 	return Math::rad2deg(get_texture_rotation());
 }
 
@@ -477,12 +477,12 @@ bool Polygon2D::get_antialiased() const {
 	return antialiased;
 }
 
-void Polygon2D::set_invert_border(float p_invert_border) {
+void Polygon2D::set_invert_border(real_t p_invert_border) {
 	invert_border = p_invert_border;
 	update();
 }
 
-float Polygon2D::get_invert_border() const {
+real_t Polygon2D::get_invert_border() const {
 	return invert_border;
 }
 

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -55,9 +55,9 @@ class Polygon2D : public Node2D {
 	Size2 tex_scale = Vector2(1, 1);
 	Vector2 tex_ofs;
 	bool tex_tile = true;
-	float tex_rot = 0.0;
+	real_t tex_rot = 0.0;
 	bool invert = false;
-	float invert_border = 100.0;
+	real_t invert_border = 100.0;
 	bool antialiased = false;
 
 	Vector2 offset;
@@ -115,11 +115,11 @@ public:
 	void set_texture_offset(const Vector2 &p_offset);
 	Vector2 get_texture_offset() const;
 
-	void set_texture_rotation(float p_rot);
-	float get_texture_rotation() const;
+	void set_texture_rotation(real_t p_rot);
+	real_t get_texture_rotation() const;
 
-	void set_texture_rotation_degrees(float p_rot);
-	float get_texture_rotation_degrees() const;
+	void set_texture_rotation_degrees(real_t p_rot);
+	real_t get_texture_rotation_degrees() const;
 
 	void set_texture_scale(const Size2 &p_scale);
 	Size2 get_texture_scale() const;
@@ -130,8 +130,8 @@ public:
 	void set_antialiased(bool p_antialiased);
 	bool get_antialiased() const;
 
-	void set_invert_border(float p_invert_border);
-	float get_invert_border() const;
+	void set_invert_border(real_t p_invert_border);
+	real_t get_invert_border() const;
 
 	void set_offset(const Vector2 &p_offset);
 	Vector2 get_offset() const;

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -33,10 +33,10 @@
 #include "core/config/engine.h"
 #include "scene/resources/texture.h"
 
-const float DEFAULT_GIZMO_EXTENTS = 10.0;
+const real_t DEFAULT_GIZMO_EXTENTS = 10.0;
 
 void Position2D::_draw_cross() {
-	float extents = get_gizmo_extents();
+	real_t extents = get_gizmo_extents();
 	// Colors taken from `axis_x_color` and `axis_y_color` (defined in `editor/editor_themes.cpp`)
 	draw_line(Point2(-extents, 0), Point2(+extents, 0), Color(0.96, 0.20, 0.32));
 	draw_line(Point2(0, -extents), Point2(0, +extents), Color(0.53, 0.84, 0.01));
@@ -44,7 +44,7 @@ void Position2D::_draw_cross() {
 
 #ifdef TOOLS_ENABLED
 Rect2 Position2D::_edit_get_rect() const {
-	float extents = get_gizmo_extents();
+	real_t extents = get_gizmo_extents();
 	return Rect2(Point2(-extents, -extents), Size2(extents * 2, extents * 2));
 }
 
@@ -70,7 +70,7 @@ void Position2D::_notification(int p_what) {
 	}
 }
 
-void Position2D::set_gizmo_extents(float p_extents) {
+void Position2D::set_gizmo_extents(real_t p_extents) {
 	if (p_extents == DEFAULT_GIZMO_EXTENTS) {
 		set_meta("_gizmo_extents_", Variant());
 	} else {
@@ -80,7 +80,7 @@ void Position2D::set_gizmo_extents(float p_extents) {
 	update();
 }
 
-float Position2D::get_gizmo_extents() const {
+real_t Position2D::get_gizmo_extents() const {
 	if (has_meta("_gizmo_extents_")) {
 		return get_meta("_gizmo_extents_");
 	} else {

--- a/scene/2d/position_2d.h
+++ b/scene/2d/position_2d.h
@@ -48,8 +48,8 @@ public:
 	virtual bool _edit_use_rect() const override;
 #endif
 
-	void set_gizmo_extents(float p_extents);
-	float get_gizmo_extents() const;
+	void set_gizmo_extents(real_t p_extents);
+	real_t get_gizmo_extents() const;
 
 	Position2D();
 };

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -119,11 +119,11 @@ void Bone2D::apply_rest() {
 	set_transform(rest);
 }
 
-void Bone2D::set_default_length(float p_length) {
+void Bone2D::set_default_length(real_t p_length) {
 	default_length = p_length;
 }
 
-float Bone2D::get_default_length() const {
+real_t Bone2D::get_default_length() const {
 	return default_length;
 }
 

--- a/scene/2d/skeleton_2d.h
+++ b/scene/2d/skeleton_2d.h
@@ -46,7 +46,7 @@ class Bone2D : public Node2D {
 	Bone2D *parent_bone = nullptr;
 	Skeleton2D *skeleton = nullptr;
 	Transform2D rest;
-	float default_length = 16.0;
+	real_t default_length = 16.0;
 
 	int skeleton_index = -1;
 
@@ -62,8 +62,8 @@ public:
 
 	String get_configuration_warning() const override;
 
-	void set_default_length(float p_length);
-	float get_default_length() const;
+	void set_default_length(real_t p_length);
+	real_t get_default_length() const;
 
 	int get_index_in_skeleton() const;
 

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -39,7 +39,7 @@ class Sprite2D : public Node2D {
 
 	Ref<Texture2D> texture;
 	Color specular_color;
-	float shininess = 0.0;
+	real_t shininess = 0.0;
 
 	bool centered = true;
 	Point2 offset;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -136,11 +136,11 @@ bool Control::_edit_use_rect() const {
 	return true;
 }
 
-void Control::_edit_set_rotation(float p_rotation) {
+void Control::_edit_set_rotation(real_t p_rotation) {
 	set_rotation(p_rotation);
 }
 
-float Control::_edit_get_rotation() const {
+real_t Control::_edit_get_rotation() const {
 	return get_rotation();
 }
 
@@ -1238,10 +1238,10 @@ Size2 Control::get_parent_area_size() const {
 void Control::_size_changed() {
 	Rect2 parent_rect = get_parent_anchorable_rect();
 
-	float edge_pos[4];
+	real_t edge_pos[4];
 
 	for (int i = 0; i < 4; i++) {
-		float area = parent_rect.size[i & 1];
+		real_t area = parent_rect.size[i & 1];
 		edge_pos[i] = data.offset[i] + (data.anchor[i] * area);
 	}
 
@@ -1295,13 +1295,13 @@ void Control::_size_changed() {
 	}
 }
 
-void Control::set_anchor(Side p_side, float p_anchor, bool p_keep_offset, bool p_push_opposite_anchor) {
+void Control::set_anchor(Side p_side, real_t p_anchor, bool p_keep_offset, bool p_push_opposite_anchor) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 
 	Rect2 parent_rect = get_parent_anchorable_rect();
-	float parent_range = (p_side == SIDE_LEFT || p_side == SIDE_RIGHT) ? parent_rect.size.x : parent_rect.size.y;
-	float previous_pos = data.offset[p_side] + data.anchor[p_side] * parent_range;
-	float previous_opposite_pos = data.offset[(p_side + 2) % 4] + data.anchor[(p_side + 2) % 4] * parent_range;
+	real_t parent_range = (p_side == SIDE_LEFT || p_side == SIDE_RIGHT) ? parent_rect.size.x : parent_rect.size.y;
+	real_t previous_pos = data.offset[p_side] + data.anchor[p_side] * parent_range;
+	real_t previous_opposite_pos = data.offset[(p_side + 2) % 4] + data.anchor[(p_side + 2) % 4] * parent_range;
 
 	data.anchor[p_side] = p_anchor;
 
@@ -1327,11 +1327,11 @@ void Control::set_anchor(Side p_side, float p_anchor, bool p_keep_offset, bool p
 	update();
 }
 
-void Control::_set_anchor(Side p_side, float p_anchor) {
+void Control::_set_anchor(Side p_side, real_t p_anchor) {
 	set_anchor(p_side, p_anchor);
 }
 
-void Control::set_anchor_and_offset(Side p_side, float p_anchor, float p_pos, bool p_push_opposite_anchor) {
+void Control::set_anchor_and_offset(Side p_side, real_t p_anchor, real_t p_pos, bool p_push_opposite_anchor) {
 	set_anchor(p_side, p_anchor, false, p_push_opposite_anchor);
 	set_offset(p_side, p_pos);
 }
@@ -1468,7 +1468,7 @@ void Control::set_offsets_preset(LayoutPreset p_preset, LayoutPresetMode p_resiz
 
 	Rect2 parent_rect = get_parent_anchorable_rect();
 
-	float x = parent_rect.size.x;
+	real_t x = parent_rect.size.x;
 	if (is_layout_rtl()) {
 		x = parent_rect.size.x - x - new_size.x;
 	}
@@ -1592,13 +1592,13 @@ void Control::set_anchors_and_offsets_preset(LayoutPreset p_preset, LayoutPreset
 	set_offsets_preset(p_preset, p_resize_mode, p_margin);
 }
 
-float Control::get_anchor(Side p_side) const {
+real_t Control::get_anchor(Side p_side) const {
 	ERR_FAIL_INDEX_V(int(p_side), 4, 0.0);
 
 	return data.anchor[p_side];
 }
 
-void Control::set_offset(Side p_side, float p_value) {
+void Control::set_offset(Side p_side, real_t p_value) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 
 	data.offset[p_side] = p_value;
@@ -1617,7 +1617,7 @@ void Control::set_end(const Size2 &p_point) {
 	_size_changed();
 }
 
-float Control::get_offset(Side p_side) const {
+real_t Control::get_offset(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
 
 	return data.offset[p_side];
@@ -1660,12 +1660,12 @@ void Control::set_global_position(const Point2 &p_point, bool p_keep_offsets) {
 	set_position(inv.xform(p_point), p_keep_offsets);
 }
 
-void Control::_compute_anchors(Rect2 p_rect, const float p_offsets[4], float (&r_anchors)[4]) {
+void Control::_compute_anchors(Rect2 p_rect, const real_t p_offsets[4], real_t (&r_anchors)[4]) {
 	Size2 parent_rect_size = get_parent_anchorable_rect().size;
 	ERR_FAIL_COND(parent_rect_size.x == 0.0);
 	ERR_FAIL_COND(parent_rect_size.y == 0.0);
 
-	float x = p_rect.position.x;
+	real_t x = p_rect.position.x;
 	if (is_layout_rtl()) {
 		x = parent_rect_size.x - x - p_rect.size.x;
 	}
@@ -1675,10 +1675,10 @@ void Control::_compute_anchors(Rect2 p_rect, const float p_offsets[4], float (&r
 	r_anchors[3] = (p_rect.position.y + p_rect.size.y - p_offsets[3]) / parent_rect_size.y;
 }
 
-void Control::_compute_offsets(Rect2 p_rect, const float p_anchors[4], float (&r_offsets)[4]) {
+void Control::_compute_offsets(Rect2 p_rect, const real_t p_anchors[4], real_t (&r_offsets)[4]) {
 	Size2 parent_rect_size = get_parent_anchorable_rect().size;
 
-	float x = p_rect.position.x;
+	real_t x = p_rect.position.x;
 	if (is_layout_rtl()) {
 		x = parent_rect_size.x - x - p_rect.size.x;
 	}
@@ -2257,7 +2257,7 @@ Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
 		return c;
 	}
 
-	float dist = 1e7;
+	real_t dist = 1e7;
 	Control *result = nullptr;
 
 	Point2 points[4];
@@ -2278,10 +2278,10 @@ Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
 
 	Vector2 vdir = dir[p_side];
 
-	float maxd = -1e7;
+	real_t maxd = -1e7;
 
 	for (int i = 0; i < 4; i++) {
-		float d = vdir.dot(points[i]);
+		real_t d = vdir.dot(points[i]);
 		if (d > maxd) {
 			maxd = d;
 		}
@@ -2308,7 +2308,7 @@ Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
 	return result;
 }
 
-void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, const Point2 *p_points, float p_min, float &r_closest_dist, Control **r_closest) {
+void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, const Point2 *p_points, real_t p_min, real_t &r_closest_dist, Control **r_closest) {
 	if (Object::cast_to<Viewport>(p_at)) {
 		return; //bye
 	}
@@ -2325,10 +2325,10 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 		points[2] = xform.xform(c->get_size());
 		points[3] = xform.xform(Point2(0, c->get_size().y));
 
-		float min = 1e7;
+		real_t min = 1e7;
 
 		for (int i = 0; i < 4; i++) {
-			float d = p_dir.dot(points[i]);
+			real_t d = p_dir.dot(points[i]);
 			if (d < min) {
 				min = d;
 			}
@@ -2344,8 +2344,8 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 					Vector2 fb = points[(j + 1) % 4];
 
 					Vector2 pa, pb;
-					float d = Geometry2D::get_closest_points_between_segments(la, lb, fa, fb, pa, pb);
-					//float d = Geometry2D::get_closest_distance_between_segments(Vector3(la.x,la.y,0),Vector3(lb.x,lb.y,0),Vector3(fa.x,fa.y,0),Vector3(fb.x,fb.y,0));
+					real_t d = Geometry2D::get_closest_points_between_segments(la, lb, fa, fb, pa, pb);
+					//real_t d = Geometry2D::get_closest_distance_between_segments(Vector3(la.x,la.y,0),Vector3(lb.x,lb.y,0),Vector3(fa.x,fa.y,0),Vector3(fb.x,fb.y,0));
 					if (d < r_closest_dist) {
 						r_closest_dist = d;
 						*r_closest = c;
@@ -2385,7 +2385,7 @@ void Control::set_v_size_flags(int p_flags) {
 	emit_signal(SceneStringNames::get_singleton()->size_flags_changed);
 }
 
-void Control::set_stretch_ratio(float p_ratio) {
+void Control::set_stretch_ratio(real_t p_ratio) {
 	if (data.expand == p_ratio) {
 		return;
 	}
@@ -2394,7 +2394,7 @@ void Control::set_stretch_ratio(float p_ratio) {
 	emit_signal(SceneStringNames::get_singleton()->size_flags_changed);
 }
 
-float Control::get_stretch_ratio() const {
+real_t Control::get_stretch_ratio() const {
 	return data.expand;
 }
 
@@ -2566,21 +2566,21 @@ Vector<Vector2i> Control::structured_text_parser(StructuredTextParser p_node_typ
 	return ret;
 }
 
-void Control::set_rotation(float p_radians) {
+void Control::set_rotation(real_t p_radians) {
 	data.rotation = p_radians;
 	update();
 	_notify_transform();
 }
 
-float Control::get_rotation() const {
+real_t Control::get_rotation() const {
 	return data.rotation;
 }
 
-void Control::set_rotation_degrees(float p_degrees) {
+void Control::set_rotation_degrees(real_t p_degrees) {
 	set_rotation(Math::deg2rad(p_degrees));
 }
 
-float Control::get_rotation_degrees() const {
+real_t Control::get_rotation_degrees() const {
 	return Math::rad2deg(get_rotation());
 }
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -171,22 +171,22 @@ private:
 		Size2 last_minimum_size;
 		bool updating_last_minimum_size = false;
 
-		float offset[4] = { 0.0, 0.0, 0.0, 0.0 };
-		float anchor[4] = { ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN };
+		real_t offset[4] = { 0.0, 0.0, 0.0, 0.0 };
+		real_t anchor[4] = { ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN };
 		FocusMode focus_mode = FOCUS_NONE;
 		GrowDirection h_grow = GROW_DIRECTION_END;
 		GrowDirection v_grow = GROW_DIRECTION_END;
 
 		LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
 
-		float rotation = 0.0;
+		real_t rotation = 0.0;
 		Vector2 scale = Vector2(1, 1);
 		Vector2 pivot_offset;
 		bool size_warning = true;
 
 		int h_size_flags = SIZE_FILL;
 		int v_size_flags = SIZE_FILL;
-		float expand = 1.0;
+		real_t expand = 1.0;
 		Point2 custom_minimum_size;
 
 		MouseFilter mouse_filter = MOUSE_FILTER_STOP;
@@ -224,10 +224,10 @@ private:
 	// used internally
 	Control *_find_control_at_pos(CanvasItem *p_node, const Point2 &p_pos, const Transform2D &p_xform, Transform2D &r_inv_xform);
 
-	void _window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, const Point2 *p_points, float p_min, float &r_closest_dist, Control **r_closest);
+	void _window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, const Point2 *p_points, real_t p_min, real_t &r_closest_dist, Control **r_closest);
 	Control *_get_focus_neighbor(Side p_side, int p_count = 0);
 
-	void _set_anchor(Side p_side, float p_anchor);
+	void _set_anchor(Side p_side, real_t p_anchor);
 	void _set_position(const Point2 &p_point);
 	void _set_global_position(const Point2 &p_point);
 	void _set_size(const Size2 &p_size);
@@ -239,8 +239,8 @@ private:
 	void _clear_size_warning();
 	void _update_scroll();
 
-	void _compute_offsets(Rect2 p_rect, const float p_anchors[4], float (&r_offsets)[4]);
-	void _compute_anchors(Rect2 p_rect, const float p_offsets[4], float (&r_anchors)[4]);
+	void _compute_offsets(Rect2 p_rect, const real_t p_anchors[4], real_t (&r_offsets)[4]);
+	void _compute_anchors(Rect2 p_rect, const real_t p_offsets[4], real_t (&r_anchors)[4]);
 
 	void _size_changed();
 	String _get_tooltip() const;
@@ -325,8 +325,8 @@ public:
 	virtual Rect2 _edit_get_rect() const override;
 	virtual bool _edit_use_rect() const override;
 
-	virtual void _edit_set_rotation(float p_rotation) override;
-	virtual float _edit_get_rotation() const override;
+	virtual void _edit_set_rotation(real_t p_rotation) override;
+	virtual real_t _edit_get_rotation() const override;
 	virtual bool _edit_use_rotation() const override;
 
 	virtual void _edit_set_pivot(const Point2 &p_pivot) override;
@@ -364,13 +364,13 @@ public:
 	void set_offsets_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode = PRESET_MODE_MINSIZE, int p_margin = 0);
 	void set_anchors_and_offsets_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode = PRESET_MODE_MINSIZE, int p_margin = 0);
 
-	void set_anchor(Side p_side, float p_anchor, bool p_keep_offset = true, bool p_push_opposite_anchor = true);
-	float get_anchor(Side p_side) const;
+	void set_anchor(Side p_side, real_t p_anchor, bool p_keep_offset = true, bool p_push_opposite_anchor = true);
+	real_t get_anchor(Side p_side) const;
 
-	void set_offset(Side p_side, float p_value);
-	float get_offset(Side p_side) const;
+	void set_offset(Side p_side, real_t p_value);
+	real_t get_offset(Side p_side) const;
 
-	void set_anchor_and_offset(Side p_side, float p_anchor, float p_pos, bool p_push_opposite_anchor = true);
+	void set_anchor_and_offset(Side p_side, real_t p_anchor, real_t p_pos, bool p_push_opposite_anchor = true);
 
 	void set_begin(const Point2 &p_point); // helper
 	void set_end(const Point2 &p_point); // helper
@@ -395,10 +395,10 @@ public:
 
 	void set_rect(const Rect2 &p_rect); // Reset anchors to begin and set rect, for faster container children sorting.
 
-	void set_rotation(float p_radians);
-	void set_rotation_degrees(float p_degrees);
-	float get_rotation() const;
-	float get_rotation_degrees() const;
+	void set_rotation(real_t p_radians);
+	void set_rotation_degrees(real_t p_degrees);
+	real_t get_rotation() const;
+	real_t get_rotation_degrees() const;
 
 	void set_h_grow_direction(GrowDirection p_direction);
 	GrowDirection get_h_grow_direction() const;
@@ -421,8 +421,8 @@ public:
 	void set_v_size_flags(int p_flags);
 	int get_v_size_flags() const;
 
-	void set_stretch_ratio(float p_ratio);
-	float get_stretch_ratio() const;
+	void set_stretch_ratio(real_t p_ratio);
+	real_t get_stretch_ratio() const;
 
 	void minimum_size_changed();
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -729,13 +729,13 @@ void CanvasItem::item_rect_changed(bool p_size_changed) {
 	emit_signal(SceneStringNames::get_singleton()->item_rect_changed);
 }
 
-void CanvasItem::draw_line(const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width) {
+void CanvasItem::draw_line(const Point2 &p_from, const Point2 &p_to, const Color &p_color, real_t p_width) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	RenderingServer::get_singleton()->canvas_item_add_line(canvas_item, p_from, p_to, p_color, p_width);
 }
 
-void CanvasItem::draw_polyline(const Vector<Point2> &p_points, const Color &p_color, float p_width, bool p_antialiased) {
+void CanvasItem::draw_polyline(const Vector<Point2> &p_points, const Color &p_color, real_t p_width, bool p_antialiased) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	Vector<Color> colors;
@@ -743,25 +743,25 @@ void CanvasItem::draw_polyline(const Vector<Point2> &p_points, const Color &p_co
 	RenderingServer::get_singleton()->canvas_item_add_polyline(canvas_item, p_points, colors, p_width, p_antialiased);
 }
 
-void CanvasItem::draw_polyline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width, bool p_antialiased) {
+void CanvasItem::draw_polyline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, real_t p_width, bool p_antialiased) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	RenderingServer::get_singleton()->canvas_item_add_polyline(canvas_item, p_points, p_colors, p_width, p_antialiased);
 }
 
-void CanvasItem::draw_arc(const Vector2 &p_center, float p_radius, float p_start_angle, float p_end_angle, int p_point_count, const Color &p_color, float p_width, bool p_antialiased) {
+void CanvasItem::draw_arc(const Vector2 &p_center, real_t p_radius, real_t p_start_angle, real_t p_end_angle, int p_point_count, const Color &p_color, real_t p_width, bool p_antialiased) {
 	Vector<Point2> points;
 	points.resize(p_point_count);
-	const float delta_angle = p_end_angle - p_start_angle;
+	const real_t delta_angle = p_end_angle - p_start_angle;
 	for (int i = 0; i < p_point_count; i++) {
-		float theta = (i / (p_point_count - 1.0f)) * delta_angle + p_start_angle;
+		real_t theta = (i / (p_point_count - 1.0f)) * delta_angle + p_start_angle;
 		points.set(i, p_center + Vector2(Math::cos(theta), Math::sin(theta)) * p_radius);
 	}
 
 	draw_polyline(points, p_color, p_width, p_antialiased);
 }
 
-void CanvasItem::draw_multiline(const Vector<Point2> &p_points, const Color &p_color, float p_width) {
+void CanvasItem::draw_multiline(const Vector<Point2> &p_points, const Color &p_color, real_t p_width) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	Vector<Color> colors;
@@ -769,13 +769,13 @@ void CanvasItem::draw_multiline(const Vector<Point2> &p_points, const Color &p_c
 	RenderingServer::get_singleton()->canvas_item_add_multiline(canvas_item, p_points, colors, p_width);
 }
 
-void CanvasItem::draw_multiline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width) {
+void CanvasItem::draw_multiline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, real_t p_width) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	RenderingServer::get_singleton()->canvas_item_add_multiline(canvas_item, p_points, p_colors, p_width);
 }
 
-void CanvasItem::draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_filled, float p_width) {
+void CanvasItem::draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_filled, real_t p_width) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	if (p_filled) {
@@ -787,7 +787,7 @@ void CanvasItem::draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_fil
 	} else {
 		// Thick lines are offset depending on their width to avoid partial overlapping.
 		// Thin lines don't require an offset, so don't apply one in this case
-		float offset;
+		real_t offset;
 		if (p_width >= 2) {
 			offset = p_width / 2.0;
 		} else {
@@ -821,7 +821,7 @@ void CanvasItem::draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_fil
 	}
 }
 
-void CanvasItem::draw_circle(const Point2 &p_pos, float p_radius, const Color &p_color) {
+void CanvasItem::draw_circle(const Point2 &p_pos, real_t p_radius, const Color &p_color) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	RenderingServer::get_singleton()->canvas_item_add_circle(canvas_item, p_pos, p_radius, p_color);
@@ -856,14 +856,14 @@ void CanvasItem::draw_style_box(const Ref<StyleBox> &p_style_box, const Rect2 &p
 	p_style_box->draw(canvas_item, p_rect);
 }
 
-void CanvasItem::draw_primitive(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture2D> p_texture, float p_width) {
+void CanvasItem::draw_primitive(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture2D> p_texture, real_t p_width) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	RID rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 	RenderingServer::get_singleton()->canvas_item_add_primitive(canvas_item, p_points, p_colors, p_uvs, rid, p_width);
 }
 
-void CanvasItem::draw_set_transform(const Point2 &p_offset, float p_rot, const Size2 &p_scale) {
+void CanvasItem::draw_set_transform(const Point2 &p_offset, real_t p_rot, const Size2 &p_scale) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
 	Transform2D xform(p_rot, p_offset);
@@ -907,19 +907,19 @@ void CanvasItem::draw_multimesh(const Ref<MultiMesh> &p_multimesh, const Ref<Tex
 	RenderingServer::get_singleton()->canvas_item_add_multimesh(canvas_item, p_multimesh->get_rid(), texture_rid);
 }
 
-void CanvasItem::draw_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HAlign p_align, float p_width, int p_size, const Color &p_modulate, int p_outline_size, const Color &p_outline_modulate, uint8_t p_flags) const {
+void CanvasItem::draw_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HAlign p_align, real_t p_width, int p_size, const Color &p_modulate, int p_outline_size, const Color &p_outline_modulate, uint8_t p_flags) const {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 	ERR_FAIL_COND(p_font.is_null());
 	p_font->draw_string(canvas_item, p_pos, p_text, p_align, p_width, p_size, p_modulate, p_outline_size, p_outline_modulate, p_flags);
 }
 
-void CanvasItem::draw_multiline_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HAlign p_align, float p_width, int p_max_lines, int p_size, const Color &p_modulate, int p_outline_size, const Color &p_outline_modulate, uint8_t p_flags) const {
+void CanvasItem::draw_multiline_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HAlign p_align, real_t p_width, int p_max_lines, int p_size, const Color &p_modulate, int p_outline_size, const Color &p_outline_modulate, uint8_t p_flags) const {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 	ERR_FAIL_COND(p_font.is_null());
 	p_font->draw_multiline_string(canvas_item, p_pos, p_text, p_align, p_width, p_max_lines, p_size, p_modulate, p_outline_size, p_outline_modulate, p_flags);
 }
 
-float CanvasItem::draw_char(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, const String &p_next, int p_size, const Color &p_modulate, int p_outline_size, const Color &p_outline_modulate) const {
+real_t CanvasItem::draw_char(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, const String &p_next, int p_size, const Color &p_modulate, int p_outline_size, const Color &p_outline_modulate) const {
 	ERR_FAIL_COND_V_MSG(!drawing, 0.f, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 	ERR_FAIL_COND_V(p_font.is_null(), 0.f);
 	ERR_FAIL_COND_V(p_char.length() != 1, 0.f);
@@ -1441,6 +1441,7 @@ void CanvasTexture::set_specular_texture(const Ref<Texture2D> &p_specular) {
 	RID tex_rid = specular_texture.is_valid() ? specular_texture->get_rid() : RID();
 	RS::get_singleton()->canvas_texture_set_channel(canvas_texture, RS::CANVAS_TEXTURE_CHANNEL_SPECULAR, tex_rid);
 }
+
 Ref<Texture2D> CanvasTexture::get_specular_texture() const {
 	return specular_texture;
 }
@@ -1449,15 +1450,17 @@ void CanvasTexture::set_specular_color(const Color &p_color) {
 	specular = p_color;
 	RS::get_singleton()->canvas_texture_set_shading_parameters(canvas_texture, specular, shininess);
 }
+
 Color CanvasTexture::get_specular_color() const {
 	return specular;
 }
 
-void CanvasTexture::set_specular_shininess(float p_shininess) {
+void CanvasTexture::set_specular_shininess(real_t p_shininess) {
 	shininess = p_shininess;
 	RS::get_singleton()->canvas_texture_set_shading_parameters(canvas_texture, specular, shininess);
 }
-float CanvasTexture::get_specular_shininess() const {
+
+real_t CanvasTexture::get_specular_shininess() const {
 	return shininess;
 }
 

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -290,8 +290,8 @@ public:
 
 	// Used to rotate the node
 	virtual bool _edit_use_rotation() const { return false; };
-	virtual void _edit_set_rotation(float p_rotation) {}
-	virtual float _edit_get_rotation() const { return 0.0; };
+	virtual void _edit_set_rotation(real_t p_rotation) {}
+	virtual real_t _edit_get_rotation() const { return 0.0; };
 
 	// Used to resize/move the node
 	virtual bool _edit_use_rect() const { return false; }; // MAYBE REPLACE BY A _edit_get_editmode()
@@ -331,30 +331,30 @@ public:
 
 	/* DRAWING API */
 
-	void draw_line(const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width = 1.0);
-	void draw_polyline(const Vector<Point2> &p_points, const Color &p_color, float p_width = 1.0, bool p_antialiased = false);
-	void draw_polyline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width = 1.0, bool p_antialiased = false);
-	void draw_arc(const Vector2 &p_center, float p_radius, float p_start_angle, float p_end_angle, int p_point_count, const Color &p_color, float p_width = 1.0, bool p_antialiased = false);
-	void draw_multiline(const Vector<Point2> &p_points, const Color &p_color, float p_width = 1.0);
-	void draw_multiline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width = 1.0);
-	void draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_filled = true, float p_width = 1.0);
-	void draw_circle(const Point2 &p_pos, float p_radius, const Color &p_color);
+	void draw_line(const Point2 &p_from, const Point2 &p_to, const Color &p_color, real_t p_width = 1.0);
+	void draw_polyline(const Vector<Point2> &p_points, const Color &p_color, real_t p_width = 1.0, bool p_antialiased = false);
+	void draw_polyline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, real_t p_width = 1.0, bool p_antialiased = false);
+	void draw_arc(const Vector2 &p_center, real_t p_radius, real_t p_start_angle, real_t p_end_angle, int p_point_count, const Color &p_color, real_t p_width = 1.0, bool p_antialiased = false);
+	void draw_multiline(const Vector<Point2> &p_points, const Color &p_color, real_t p_width = 1.0);
+	void draw_multiline_colors(const Vector<Point2> &p_points, const Vector<Color> &p_colors, real_t p_width = 1.0);
+	void draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_filled = true, real_t p_width = 1.0);
+	void draw_circle(const Point2 &p_pos, real_t p_radius, const Color &p_color);
 	void draw_texture(const Ref<Texture2D> &p_texture, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1, 1));
 	void draw_texture_rect(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false);
 	void draw_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
 	void draw_style_box(const Ref<StyleBox> &p_style_box, const Rect2 &p_rect);
-	void draw_primitive(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture2D> p_texture = Ref<Texture2D>(), float p_width = 1);
+	void draw_primitive(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture2D> p_texture = Ref<Texture2D>(), real_t p_width = 1);
 	void draw_polygon(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs = Vector<Point2>(), Ref<Texture2D> p_texture = Ref<Texture2D>());
 	void draw_colored_polygon(const Vector<Point2> &p_points, const Color &p_color, const Vector<Point2> &p_uvs = Vector<Point2>(), Ref<Texture2D> p_texture = Ref<Texture2D>());
 
 	void draw_mesh(const Ref<Mesh> &p_mesh, const Ref<Texture2D> &p_texture, const Transform2D &p_transform = Transform2D(), const Color &p_modulate = Color(1, 1, 1));
 	void draw_multimesh(const Ref<MultiMesh> &p_multimesh, const Ref<Texture2D> &p_texture);
 
-	void draw_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HAlign p_align = HALIGN_LEFT, float p_width = -1, int p_size = -1, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0), uint8_t p_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
-	void draw_multiline_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HAlign p_align = HALIGN_LEFT, float p_width = -1, int p_max_lines = -1, int p_size = -1, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0), uint8_t p_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
-	float draw_char(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, const String &p_next = "", int p_size = -1, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0)) const;
+	void draw_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HAlign p_align = HALIGN_LEFT, real_t p_width = -1, int p_size = -1, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0), uint8_t p_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
+	void draw_multiline_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HAlign p_align = HALIGN_LEFT, real_t p_width = -1, int p_max_lines = -1, int p_size = -1, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0), uint8_t p_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
+	real_t draw_char(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, const String &p_next = "", int p_size = -1, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0)) const;
 
-	void draw_set_transform(const Point2 &p_offset, float p_rot = 0.0, const Size2 &p_scale = Size2(1.0, 1.0));
+	void draw_set_transform(const Point2 &p_offset, real_t p_rot = 0.0, const Size2 &p_scale = Size2(1.0, 1.0));
 	void draw_set_transform_matrix(const Transform2D &p_matrix);
 
 	static CanvasItem *get_current_item_drawn();
@@ -437,7 +437,7 @@ class CanvasTexture : public Texture2D {
 	Ref<Texture2D> normal_texture;
 	Ref<Texture2D> specular_texture;
 	Color specular = Color(1, 1, 1, 1);
-	float shininess = 1.0;
+	real_t shininess = 1.0;
 
 	RID canvas_texture;
 
@@ -460,8 +460,8 @@ public:
 	void set_specular_color(const Color &p_color);
 	Color get_specular_color() const;
 
-	void set_specular_shininess(float p_shininess);
-	float get_specular_shininess() const;
+	void set_specular_shininess(real_t p_shininess);
+	real_t get_specular_shininess() const;
 
 	void set_texture_filter(CanvasItem::TextureFilter p_filter);
 	CanvasItem::TextureFilter get_texture_filter() const;


### PR DESCRIPTION
This is similar to other recent `real_t` PRs I've made, but this PR specifically focuses on 2D nodes.

All code related to time was intentionally left unchanged. Code that works with time should be `double`, not `real_t`, but that would change behavior, so I think it's worth doing in a separate PR.