### PR TITLE
Fix inertial scroll, add smooth scroll +more

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -104,7 +104,7 @@ namespace GodotTools.Ides.Rider
             if (line >= 0)
             {
                 args.Add("--line");
-                args.Add(line.ToString());
+                args.Add((line + 1).ToString()); // https://github.com/JetBrains/godot-support/issues/61
             }
             args.Add(scriptPath);
             try

--- a/tests/test_object.h
+++ b/tests/test_object.h
@@ -31,11 +31,102 @@
 #ifndef TEST_OBJECT_H
 #define TEST_OBJECT_H
 
+#include "core/core_string_names.h"
 #include "core/object/object.h"
 
 #include "thirdparty/doctest/doctest.h"
 
+// Declared in global namespace because of GDCLASS macro warning (Windows):
+// "Unqualified friend declaration referring to type outside of the nearest enclosing namespace
+// is a Microsoft extension; add a nested name specifier".
+class _TestDerivedObject : public Object {
+	GDCLASS(_TestDerivedObject, Object);
+
+	int property_value;
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("set_property", "property"), &_TestDerivedObject::set_property);
+		ClassDB::bind_method(D_METHOD("get_property"), &_TestDerivedObject::get_property);
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "property"), "set_property", "get_property");
+	}
+
+public:
+	void set_property(int value) { property_value = value; }
+	int get_property() const { return property_value; }
+};
+
 namespace TestObject {
+
+class _MockScriptInstance : public ScriptInstance {
+	StringName property_name = "NO_NAME";
+	Variant property_value;
+
+public:
+	bool set(const StringName &p_name, const Variant &p_value) override {
+		property_name = p_name;
+		property_value = p_value;
+		return true;
+	}
+	bool get(const StringName &p_name, Variant &r_ret) const override {
+		if (property_name == p_name) {
+			r_ret = property_value;
+			return true;
+		}
+		return false;
+	}
+	void get_property_list(List<PropertyInfo> *p_properties) const override {
+	}
+	Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid) const override {
+		return Variant::PACKED_FLOAT32_ARRAY;
+	}
+	void get_method_list(List<MethodInfo> *p_list) const override {
+	}
+	bool has_method(const StringName &p_method) const override {
+		return false;
+	}
+	Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override {
+		return Variant();
+	}
+	void notification(int p_notification) override {
+	}
+	Ref<Script> get_script() const override {
+		return Ref<Script>();
+	}
+	Vector<ScriptNetData> get_rpc_methods() const override {
+		return Vector<ScriptNetData>();
+	}
+	uint16_t get_rpc_method_id(const StringName &p_method) const override {
+		return 0;
+	}
+	StringName get_rpc_method(uint16_t p_id) const override {
+		return StringName();
+	}
+	MultiplayerAPI::RPCMode get_rpc_mode_by_id(uint16_t p_id) const override {
+		return MultiplayerAPI::RPC_MODE_PUPPET;
+	}
+	MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const override {
+		return MultiplayerAPI::RPC_MODE_PUPPET;
+	}
+	Vector<ScriptNetData> get_rset_properties() const override {
+		return Vector<ScriptNetData>();
+	}
+	uint16_t get_rset_property_id(const StringName &p_variable) const override {
+		return 0;
+	}
+	StringName get_rset_property(uint16_t p_id) const override {
+		return StringName();
+	}
+	MultiplayerAPI::RPCMode get_rset_mode_by_id(uint16_t p_id) const override {
+		return MultiplayerAPI::RPC_MODE_PUPPET;
+	}
+	MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const override {
+		return MultiplayerAPI::RPC_MODE_PUPPET;
+	}
+	ScriptLanguage *get_language() override {
+		return nullptr;
+	}
+};
 
 TEST_CASE("[Object] Core getters") {
 	Object object;
@@ -55,6 +146,15 @@ TEST_CASE("[Object] Core getters") {
 	CHECK_MESSAGE(
 			object.get_save_class() == "Object",
 			"The returned save class should match the expected value.");
+
+	List<String> inheritance_list;
+	object.get_inheritance_list_static(&inheritance_list);
+	CHECK_MESSAGE(
+			inheritance_list.size() == 1,
+			"The inheritance list should consist of Object only");
+	CHECK_MESSAGE(
+			inheritance_list[0] == "Object",
+			"The inheritance list should consist of Object only");
 }
 
 TEST_CASE("[Object] Metadata") {
@@ -86,6 +186,119 @@ TEST_CASE("[Object] Metadata") {
 	CHECK_MESSAGE(
 			meta_list2.size() == 0,
 			"The metadata list should contain 0 items after removing all metadata items.");
+}
+
+TEST_CASE("[Object] Construction") {
+	Object object;
+
+	CHECK_MESSAGE(
+			!object.is_reference(),
+			"Object is not a Reference.");
+
+	Object *p_db = ObjectDB::get_instance(object.get_instance_id());
+	CHECK_MESSAGE(
+			p_db == &object,
+			"The database pointer returned by the object id should reference same object.");
+}
+
+TEST_CASE("[Object] Script instance property setter") {
+	Object object;
+	_MockScriptInstance *script_instance = memnew(_MockScriptInstance);
+	object.set_script_instance(script_instance);
+
+	bool valid = false;
+	object.set("some_name", 100, &valid);
+	CHECK(valid);
+	Variant actual_value;
+	CHECK_MESSAGE(
+			script_instance->get("some_name", actual_value),
+			"The assigned script instance should successfully retrieve value by name.");
+	CHECK_MESSAGE(
+			actual_value == Variant(100),
+			"The returned value should equal the one which was set by the object.");
+}
+
+TEST_CASE("[Object] Script instance property getter") {
+	Object object;
+	_MockScriptInstance *script_instance = memnew(_MockScriptInstance);
+	script_instance->set("some_name", 100); // Make sure script instance has the property
+	object.set_script_instance(script_instance);
+
+	bool valid = false;
+	const Variant &actual_value = object.get("some_name", &valid);
+	CHECK(valid);
+	CHECK_MESSAGE(
+			actual_value == Variant(100),
+			"The returned value should equal the one which was set by the script instance.");
+}
+
+TEST_CASE("[Object] Built-in property setter") {
+	ClassDB::register_class<_TestDerivedObject>();
+	_TestDerivedObject derived_object;
+
+	bool valid = false;
+	derived_object.set("property", 100, &valid);
+	CHECK(valid);
+	CHECK_MESSAGE(
+			derived_object.get_property() == 100,
+			"The property value should equal the one which was set with built-in setter.");
+}
+
+TEST_CASE("[Object] Built-in property getter") {
+	ClassDB::register_class<_TestDerivedObject>();
+	_TestDerivedObject derived_object;
+	derived_object.set_property(100);
+
+	bool valid = false;
+	const Variant &actual_value = derived_object.get("property", &valid);
+	CHECK(valid);
+	CHECK_MESSAGE(
+			actual_value == Variant(100),
+			"The returned value should equal the one which was set with built-in setter.");
+}
+
+TEST_CASE("[Object] Script property setter") {
+	Object object;
+	Variant script;
+
+	bool valid = false;
+	object.set(CoreStringNames::get_singleton()->_script, script, &valid);
+	CHECK(valid);
+	CHECK_MESSAGE(
+			object.get_script() == script,
+			"The object script should be equal to the assigned one.");
+}
+
+TEST_CASE("[Object] Script property getter") {
+	Object object;
+	Variant script;
+	object.set_script(script);
+
+	bool valid = false;
+	const Variant &actual_value = object.get(CoreStringNames::get_singleton()->_script, &valid);
+	CHECK(valid);
+	CHECK_MESSAGE(
+			actual_value == script,
+			"The returned value should be equal to the assigned script.");
+}
+
+TEST_CASE("[Object] Absent name setter") {
+	Object object;
+
+	bool valid = true;
+	object.set("absent_name", 100, &valid);
+	CHECK(!valid);
+}
+
+TEST_CASE("[Object] Absent name getter") {
+	Object object;
+
+	bool valid = true;
+	const Variant &actual_value = object.get("absent_name", &valid);
+	CHECK(!valid);
+	CHECK_MESSAGE(
+			actual_value == Variant(),
+			"The returned value should equal nil variant.");
 }
 } // namespace TestObject
 


### PR DESCRIPTION
## Summary
I made quite a few changes, however all are interlocked so they can't really be split to multiple branches.
I tried to be as thorough as possible with the description below, however, in short: 
- Scroll behaves much nicer on mobile
- A bunch of options have been added

## List of Changes
- New options have been added to project settings under a new gui>scroll section
- Completely rewrote inertial scrolling on touch. This fixes various issues, and make things far more consistent.
     - Various issues involving scroll_deadzone are now fixed. (Resolves godotengine/godot#45402)
     - Inertial scroll now decelerates quadratically instead of linear. This is more accurate to real-life friction, more consistent with other mobile applications, and subjectively feels better. It also fixes an issue where deceleration would be far too much on scaled nodes or windows.
     - The amount of inertia can be configured in project settings  (gui>scroll>intertial_scroll_duration_touch)
- Added a scroll_step parameter. When scrolling with the mouse wheel, each notch will scroll by one page * scroll_step. The default is 1/8, which is the same as the previously hard-coded behavior.
     - The default value of scroll_step can be set in project settings (gui>scroll>default_scroll_step)
- When focus is within a scroll container, ui_page_up and ui_page_down input actions will now work as expected. (Previously they did nothing)
- Added a scroll_smooth parameter. This will enable Windows 10 - style smooth scrolling when scrolling using the mouse wheel, page up & down, or with follow_focus
     - The default value of scroll_smooth can be set in project settings (gui>scroll>default_scroll_smoothed)
     - The duration of the smooth scrolling animation can be set in project settings (gui>scroll>smooth_scroll_duration_button)


## Changes to default behavior
I have done my best to make these changes without breaking compatibility or changing default behavior. By default only the following are changed:
- The default focus mode of a scroll_container is not CLICK instead of NONE. This is required for page up & down to work. It can manually be changed back to NONE, which revert page up & down to doing nothing, unless a child element is focused.
- Inertial scrolling will always use the new, fixed physics.
- The default_scroll_deadzone project setting is now under gui>scroll instead of gui>common
All other new functionality requires settings to be manually changed by the user.

## Context
Tested with:
 - 3.2.3:
     - Windows (in editor, exported debug, exported release)
     - Android (debug, release, custom build)
 - 4.0.dev:
     - Windows (in editor, debug)
     - Android (debug)

I previously submitted a similar pull request that only fixed bugs, however I closed it in favor of this one. This pull fixes all of the bugs fixed by the first one and more, by fixing the underlying issues.
This pull request *does not* include documentation for the new options. If/once it is merged to master, I will submit a second pull with new documentation added.
I have a 3.2 compatible version ready if desired, see [threethan/godot#3.2](https://github.com/threethan/godot/tree/3.2)

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/12965.*