### PR TITLE
Use Vector3.UP as a default value for look_at's up vector

### DIFF
--- a/core/math/transform.h
+++ b/core/math/transform.h
@@ -51,8 +51,8 @@ public:
 	void rotate(const Vector3 &p_axis, real_t p_phi);
 	void rotate_basis(const Vector3 &p_axis, real_t p_phi);
 
-	void set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up);
-	Transform looking_at(const Vector3 &p_target, const Vector3 &p_up) const;
+	void set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
+	Transform looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0)) const;
 
 	void scale(const Vector3 &p_scale);
 	Transform scaled(const Vector3 &p_scale) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1257,7 +1257,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform, rotated, sarray("axis", "phi"), varray());
 	bind_method(Transform, scaled, sarray("scale"), varray());
 	bind_method(Transform, translated, sarray("offset"), varray());
-	bind_method(Transform, looking_at, sarray("target", "up"), varray());
+	bind_method(Transform, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
 	bind_method(Transform, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform, is_equal_approx, sarray("xform"), varray());
 

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -557,7 +557,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 		Transform t = spatial_node->get_global_transform();
 		Vector3 camera_position = p_camera->get_camera_transform().origin;
 		if (camera_position.distance_squared_to(t.origin) > 0.01) {
-			t.set_look_at(t.origin, camera_position, Vector3(0, 1, 0));
+			t.set_look_at(t.origin, camera_position);
 		}
 
 		float scale = t.origin.distance_to(p_camera->get_camera_transform().origin);
@@ -574,7 +574,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 
 		if (orig_camera_transform.origin.distance_squared_to(t.origin) > 0.01 &&
 				ABS(orig_camera_transform.basis.get_axis(Vector3::AXIS_Z).dot(Vector3(0, 1, 0))) < 0.99) {
-			p_camera->look_at(t.origin, Vector3(0, 1, 0));
+			p_camera->look_at(t.origin);
 		}
 
 		Vector3 c0 = t.xform(Vector3(selectable_icon_size, selectable_icon_size, 0) * scale);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -388,7 +388,7 @@ PhysicalBone3D *Skeleton3DEditor::create_physical_bone(int bone_id, int bone_chi
 	bone_shape->set_transform(capsule_transform);
 
 	Transform body_transform;
-	body_transform.set_look_at(Vector3(0, 0, 0), child_rest.origin, Vector3(0, 1, 0));
+	body_transform.set_look_at(Vector3(0, 0, 0), child_rest.origin);
 	body_transform.origin = body_transform.basis.xform(Vector3(0, 0, -half_height));
 
 	Transform joint_transform;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -747,8 +747,8 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("orthonormalize"), &Node3D::orthonormalize);
 	ClassDB::bind_method(D_METHOD("set_identity"), &Node3D::set_identity);
 
-	ClassDB::bind_method(D_METHOD("look_at", "target", "up"), &Node3D::look_at);
-	ClassDB::bind_method(D_METHOD("look_at_from_position", "position", "target", "up"), &Node3D::look_at_from_position);
+	ClassDB::bind_method(D_METHOD("look_at", "target", "up"), &Node3D::look_at, DEFVAL(Vector3(0, 1, 0)));
+	ClassDB::bind_method(D_METHOD("look_at_from_position", "position", "target", "up"), &Node3D::look_at_from_position, DEFVAL(Vector3(0, 1, 0)));
 
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Node3D::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Node3D::to_global);

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -173,8 +173,8 @@ public:
 	void global_scale(const Vector3 &p_scale);
 	void global_translate(const Vector3 &p_offset);
 
-	void look_at(const Vector3 &p_target, const Vector3 &p_up);
-	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up);
+	void look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
+	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
 
 	Vector3 to_local(Vector3 p_global) const;
 	Vector3 to_global(Vector3 p_local) const;

--- a/tests/test_render.cpp
+++ b/tests/test_render.cpp
@@ -183,8 +183,8 @@ public:
 		//vs->light_set_shadow( lightaux, true );
 		light = vs->instance_create2(lightaux, scenario);
 		Transform lla;
-		//lla.set_look_at(Vector3(),Vector3(1,-1,1),Vector3(0,1,0));
-		lla.set_look_at(Vector3(), Vector3(-0.000000, -0.836026, -0.548690), Vector3(0, 1, 0));
+		//lla.set_look_at(Vector3(),Vector3(1, -1, 1));
+		lla.set_look_at(Vector3(), Vector3(0.0, -0.836026, -0.548690));
 
 		vs->instance_set_transform(light, lla);
 


### PR DESCRIPTION
`Vector3.UP` is the most common argument to use for `look_at`, so it would be a nice idea to have it as the default argument.

Some statistics from the Godot demo projects, 10 out of 13 use `Vector3.UP`, or 4 out of 5 if we exclude the IK demo:

```
$ grep -RIni "look_at("
3d/ik/addons/sade/ik_fabrik.gd:154:                             bone_nodes[i].look_at(get_bone_transform(i+1).origin + skeleton.global_transform.origin, Vector3.UP)
3d/navmesh/navmesh.gd:55:                       robot.look_at(look_at_point, Vector3.UP)
viewport/gui_in_3d/gui_3d.gd:167:               node_area.look_at(look, Vector3.UP)

$ grep -RIni "looking_at("
3d/platformer/enemy/enemy.gd:64:                get_node("Armature").set_transform(Transform().looking_at(-dir, up))
3d/ik/addons/sade/ik_fabrik.gd:286:                             bone_trans = bone_trans.looking_at(b_target.origin + dir, Vector3.UP)
3d/ik/addons/sade/ik_fabrik.gd:296:                             bone_trans = bone_trans.looking_at(b_target.origin, Vector3.UP)
3d/ik/addons/sade/ik_fabrik.gd:322:                     bone_trans = bone_trans.looking_at(b_target.origin + dir, Vector3.UP)
3d/ik/addons/sade/ik_look_at.gd:87:             rest = rest.looking_at(target_pos, Vector3.RIGHT)
3d/ik/addons/sade/ik_look_at.gd:89:             rest = rest.looking_at(target_pos, Vector3.UP)
3d/ik/addons/sade/ik_look_at.gd:91:             rest = rest.looking_at(target_pos, Vector3.FORWARD)
3d/ik/addons/sade/ik_look_at.gd:93:             rest = rest.looking_at(target_pos, Vector3.UP)
3d/waypoints/waypoint.gd:70:            var look = camera_transform.looking_at(parent_translation, Vector3.UP)
misc/matrix_transform/marker/AxisMarker3D.gd:15:        holder.transform = holder.transform.looking_at(translation, Vector3.UP)
```