### PR TITLE
BVH add support for visibility (activation)

### DIFF
--- a/core/math/bvh_logic.inc
+++ b/core/math/bvh_logic.inc
@@ -5,6 +5,10 @@ void _logic_item_remove_and_reinsert(uint32_t p_ref_id) {
 	// get the reference
 	ItemRef &ref = _refs[p_ref_id];
 
+	// no need to optimize inactive items
+	if (!ref.is_active())
+		return;
+
 	// special case of debug draw
 	if (ref.item_id == BVHCommon::INVALID)
 		return;

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -1,5 +1,5 @@
 public:
-BVHHandle item_add(T *p_userdata, const AABB &p_aabb, int32_t p_subindex, bool p_pairable, uint32_t p_pairable_type, uint32_t p_pairable_mask, bool p_invisible = false) {
+BVHHandle item_add(T *p_userdata, bool p_active, const AABB &p_aabb, int32_t p_subindex, bool p_pairable, uint32_t p_pairable_type, uint32_t p_pairable_mask, bool p_invisible = false) {
 #ifdef BVH_VERBOSE_TREE
 	VERBOSE_PRINT("\nitem_add BEFORE");
 	_debug_recursive_print_tree(0);
@@ -60,15 +60,19 @@ BVHHandle item_add(T *p_userdata, const AABB &p_aabb, int32_t p_subindex, bool p
 	create_root_node(_current_tree);
 
 	// we must choose where to add to tree
-	ref->tnode_id = _logic_choose_item_add_node(_root_node_id[_current_tree], abb);
+	if (p_active) {
+		ref->tnode_id = _logic_choose_item_add_node(_root_node_id[_current_tree], abb);
 
-	bool refit = _node_add_item(ref->tnode_id, ref_id, abb);
+		bool refit = _node_add_item(ref->tnode_id, ref_id, abb);
 
-	if (refit) {
-		// only need to refit from the parent
-		const TNode &add_node = _nodes[ref->tnode_id];
-		if (add_node.parent_id != BVHCommon::INVALID)
-			refit_upward_and_balance(add_node.parent_id);
+		if (refit) {
+			// only need to refit from the parent
+			const TNode &add_node = _nodes[ref->tnode_id];
+			if (add_node.parent_id != BVHCommon::INVALID)
+				refit_upward_and_balance(add_node.parent_id);
+		}
+	} else {
+		ref->set_inactive();
 	}
 
 #ifdef BVH_VERBOSE
@@ -100,11 +104,14 @@ void _debug_print_refs() {
 bool item_move(BVHHandle p_handle, const AABB &p_aabb) {
 	uint32_t ref_id = p_handle.id();
 
-	BVH_ABB abb;
-	abb.from(p_aabb);
-
 	// get the reference
 	ItemRef &ref = _refs[ref_id];
+	if (!ref.is_active()) {
+		return false;
+	}
+
+	BVH_ABB abb;
+	abb.from(p_aabb);
 
 	BVH_ASSERT(ref.tnode_id != BVHCommon::INVALID);
 	TNode &tnode = _nodes[ref.tnode_id];
@@ -117,7 +124,14 @@ bool item_move(BVHHandle p_handle, const AABB &p_aabb) {
 		// for accurate collision detection
 		TLeaf &leaf = _node_get_leaf(tnode);
 
-		leaf.get_aabb(ref.item_id) = abb;
+		BVH_ABB &leaf_abb = leaf.get_aabb(ref.item_id);
+
+		// no change?
+		if (leaf_abb == abb) {
+			return false;
+		}
+
+		leaf_abb = abb;
 		_integrity_check_all();
 
 		return true;
@@ -168,8 +182,10 @@ void item_remove(BVHHandle p_handle) {
 	_extra[ref_id_moved_back].active_ref_id = active_ref_id;
 	////////////////////////////////////////
 
-	// remove the item from the node
-	node_remove_item(ref_id);
+	// remove the item from the node (only if active)
+	if (_refs[ref_id].is_active()) {
+		node_remove_item(ref_id);
+	}
 
 	// remove the item reference
 	_refs.free(ref_id);
@@ -184,6 +200,54 @@ void item_remove(BVHHandle p_handle) {
 #ifdef BVH_VERBOSE_TREE
 	_debug_recursive_print_tree(_current_tree);
 #endif
+}
+
+// returns success
+bool item_activate(BVHHandle p_handle, const AABB &p_aabb) {
+	uint32_t ref_id = p_handle.id();
+	ItemRef &ref = _refs[ref_id];
+	if (ref.is_active()) {
+		// noop
+		return false;
+	}
+
+	// add to tree
+	BVH_ABB abb;
+	abb.from(p_aabb);
+
+	_current_tree = _handle_get_tree_id(p_handle);
+
+	// we must choose where to add to tree
+	ref.tnode_id = _logic_choose_item_add_node(_root_node_id[_current_tree], abb);
+	_node_add_item(ref.tnode_id, ref_id, abb);
+
+	refit_upward_and_balance(ref.tnode_id);
+
+	return true;
+}
+
+// returns success
+bool item_deactivate(BVHHandle p_handle) {
+	uint32_t ref_id = p_handle.id();
+	ItemRef &ref = _refs[ref_id];
+	if (!ref.is_active()) {
+		// noop
+		return false;
+	}
+
+	// remove from tree
+	BVH_ABB abb;
+	node_remove_item(ref_id, &abb);
+
+	// mark as inactive
+	ref.set_inactive();
+	return true;
+}
+
+bool item_get_active(BVHHandle p_handle) const {
+	uint32_t ref_id = p_handle.id();
+	const ItemRef &ref = _refs[ref_id];
+	return ref.is_active();
 }
 
 // during collision testing, we want to set the mask and whether pairable for the item testing from
@@ -226,7 +290,10 @@ void item_set_pairable(const BVHHandle &p_handle, bool p_pairable, uint32_t p_pa
 	ex.pairable_type = p_pairable_type;
 	ex.pairable_mask = p_pairable_mask;
 
-	if ((ex.pairable != 0) != p_pairable) {
+	bool active = ref.is_active();
+	bool pairable_changed = (ex.pairable != 0) != p_pairable;
+
+	if (active && pairable_changed) {
 		// record abb
 		TNode &tnode = _nodes[ref.tnode_id];
 		TLeaf &leaf = _node_get_leaf(tnode);
@@ -238,6 +305,8 @@ void item_set_pairable(const BVHHandle &p_handle, bool p_pairable, uint32_t p_pa
 		// remove from old tree
 		node_remove_item(ref_id);
 
+		// we must set the pairable AFTER getting the current tree
+		// because the pairable status determines which tree
 		ex.pairable = p_pairable;
 
 		// add to new tree
@@ -255,6 +324,9 @@ void item_set_pairable(const BVHHandle &p_handle, bool p_pairable, uint32_t p_pa
 			if (add_node.parent_id != BVHCommon::INVALID)
 				refit_upward_and_balance(add_node.parent_id);
 		}
+	} else {
+		// always keep this up to date
+		ex.pairable = p_pairable;
 	}
 }
 

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -3,6 +3,12 @@ public:
 struct ItemRef {
 	uint32_t tnode_id; // -1 is invalid
 	uint32_t item_id; // in the leaf
+
+	bool is_active() const { return tnode_id != BVHCommon::INACTIVE; }
+	void set_inactive() {
+		tnode_id = BVHCommon::INACTIVE;
+		item_id = BVHCommon::INACTIVE;
+	}
 };
 
 // extra info kept in separate parallel list to the references,

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -73,7 +73,11 @@
 
 // really just a namespace
 struct BVHCommon {
+	// these could possibly also be the same constant,
+	// although this may be useful for debugging.
+	// or use zero for invalid and +1 based indices.
 	static const uint32_t INVALID = (0xffffffff);
+	static const uint32_t INACTIVE = (0xfffffffe);
 };
 
 // really a handle, can be anything

--- a/servers/physics/broad_phase_bvh.cpp
+++ b/servers/physics/broad_phase_bvh.cpp
@@ -34,7 +34,7 @@
 
 BroadPhaseSW::ID BroadPhaseBVH::create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb) {
 
-	ID oid = bvh.create(p_object, p_aabb, p_subindex, false, 1 << p_object->get_type(), 0);
+	ID oid = bvh.create(p_object, true, p_aabb, p_subindex, false, 1 << p_object->get_type(), 0);
 	return oid + 1;
 }
 

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -117,6 +117,8 @@ public:
 		virtual SpatialPartitionID create(Instance *p_userdata, const AABB &p_aabb = AABB(), int p_subindex = 0, bool p_pairable = false, uint32_t p_pairable_type = 0, uint32_t pairable_mask = 1) = 0;
 		virtual void erase(SpatialPartitionID p_handle) = 0;
 		virtual void move(SpatialPartitionID p_handle, const AABB &p_aabb) = 0;
+		virtual void activate(SpatialPartitionID p_handle, const AABB &p_aabb) {}
+		virtual void deactivate(SpatialPartitionID p_handle) {}
 		virtual void update() {}
 		virtual void update_collisions() {}
 		virtual void set_pairable(SpatialPartitionID p_handle, bool p_pairable, uint32_t p_pairable_type, uint32_t p_pairable_mask) = 0;
@@ -164,6 +166,8 @@ public:
 		SpatialPartitionID create(Instance *p_userdata, const AABB &p_aabb = AABB(), int p_subindex = 0, bool p_pairable = false, uint32_t p_pairable_type = 0, uint32_t p_pairable_mask = 1);
 		void erase(SpatialPartitionID p_handle);
 		void move(SpatialPartitionID p_handle, const AABB &p_aabb);
+		void activate(SpatialPartitionID p_handle, const AABB &p_aabb);
+		void deactivate(SpatialPartitionID p_handle);
 		void update();
 		void update_collisions();
 		void set_pairable(SpatialPartitionID p_handle, bool p_pairable, uint32_t p_pairable_type, uint32_t p_pairable_mask);


### PR DESCRIPTION
A major feature lacking in the octree was proper support for setting visibility / activation. This meant that invisible objects were still causing lots of processing in the tree unnecessarily.

This PR adds proper support for activation, items are temporarily removed from the tree and collision detection when inactive, however their data is retained.

## Explanation
Users of Godot would assume that hiding items or areas in the scene tree would greatly increase performance in large maps. However that is not currently always the case. There is very little support for deactivating items aside from physically removing them from the scene tree.

In terms of visibility one of problems is that invisible objects were not removed from the octree, they were still there eating up performance and slowing down collision checks on the items that were visible.

One of the advantages of the fresh BVH implementation is it makes it easier to add a proper mechanism for activating / deactivating items. This can be used for render objects, and potentially for physics objects (although not yet supported in this PR, I will investigate later whether there is a sensible mechanism for this in Godot physics).

## Notes
* An alternative approach would be to totally remove them from the tree client side, however this would make the client code less readable and more complex, so having this facility in the BVH is a good compromise.
* The activating / deactivating could be made less complex by storing the item data in a separate backup block of memory when deactivated, then simply adding and removing items using an intermediate layer. This is an option but it would use more memory and be less efficient, and complicate things because we want to keep the SpatialPartionID consistent to the client side.

## Benefits
This is most likely to be useful in large maps where areas are being hidden, for example using occlusion culling. In these situations the performance benefits can be very significant (e.g. above 10x increase in frame rate). It will nearly always have some benefit when some objects are hidden.

## Limitations
Tests show that with this in place, static hidden objects use very little performance. However, a note of caution - currently, moving hidden objects is still very expensive, even indirectly (by moving a parent node). This is something to be aware of making e.g. space games.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
