### PR TITLE
[3.3] Documentation: Correct CanvasItem.draw_string position description

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -297,7 +297,7 @@
 			<argument index="4" name="clip_w" type="int" default="-1">
 			</argument>
 			<description>
-				Draws [code]text[/code] using the specified [code]font[/code] at the [code]position[/code] (top-left corner). The text will have its color multiplied by [code]modulate[/code]. If [code]clip_w[/code] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
+				Draws [code]text[/code] using the specified [code]font[/code] at the [code]position[/code] (bottom-left corner using the baseline of the font). The text will have its color multiplied by [code]modulate[/code]. If [code]clip_w[/code] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
 				[b]Example using the default project font:[/b]
 				[codeblock]
 				# If using this method in a script that redraws constantly, move the

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -65,7 +65,7 @@
 			<argument index="1" name="next" type="int" default="0">
 			</argument>
 			<description>
-				Returns the size of a character, optionally taking kerning into account if the next character is provided.
+				Returns the size of a character, optionally taking kerning into account if the next character is provided. Note that the height returned is the font height (see [method get_height]) and has no relation to the glyph height.
 			</description>
 		</method>
 		<method name="get_descent" qualifiers="const">
@@ -88,7 +88,7 @@
 			<argument index="0" name="string" type="String">
 			</argument>
 			<description>
-				Returns the size of a string, taking kerning and advance into account.
+				Returns the size of a string, taking kerning and advance into account. Note that the height returned is the font height (see [method get_height]) and has no relation to the string.
 			</description>
 		</method>
 		<method name="get_wordwrap_string_size" qualifiers="const">


### PR DESCRIPTION
https://github.com/godotengine/godot-docs/issues/4599
Clarify some potential sources of confusion about font height and positioning.