### PR TITLE
add search extensions for Scons' path

### DIFF
--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -68,7 +68,7 @@ android {
         File sconsExecutableFile = null
         def sconsName = "scons"
         def sconsExts = (org.gradle.internal.os.OperatingSystem.current().isWindows()
-            ? [".bat", ".exe"]
+            ? [".bat", ".cmd", ".ps1", ".exe"]
             : [""])
         logger.lifecycle("Looking for $sconsName executable path")
         for (ext in sconsExts) {


### PR DESCRIPTION
Add extensions for searching Scons' path, as Scons installed via scoop will only create shims of `.ps1` and `.cmd`.