### PR TITLE
Optimize transform propagation for hidden 3d objects

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -246,10 +246,7 @@ void Spatial::set_transform(const Transform &p_transform) {
 
 void Spatial::set_global_transform(const Transform &p_transform) {
 
-	Transform xform =
-			(data.parent && !data.toplevel_active) ?
-					  data.parent->get_global_transform().affine_inverse() * p_transform :
-					  p_transform;
+	Transform xform = (data.parent && !data.toplevel_active) ? data.parent->get_global_transform().affine_inverse() * p_transform : p_transform;
 
 	set_transform(xform);
 }
@@ -541,8 +538,9 @@ void Spatial::show() {
 
 	data.visible = true;
 
-	if (!is_inside_tree())
+	if (!is_inside_tree()) {
 		return;
+	}
 
 	_propagate_visibility_changed();
 }
@@ -554,8 +552,9 @@ void Spatial::hide() {
 
 	data.visible = false;
 
-	if (!is_inside_tree())
+	if (!is_inside_tree()) {
 		return;
+	}
 
 	_propagate_visibility_changed();
 }
@@ -833,6 +832,8 @@ Spatial::Spatial() :
 	data.inside_world = false;
 	data.visible = true;
 	data.disable_scale = false;
+
+	data.spatial_flags = SPATIAL_FLAG_VI_VISIBLE;
 
 #ifdef TOOLS_ENABLED
 	data.gizmo_disabled = false;

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -54,6 +54,15 @@ class Spatial : public Node {
 	GDCLASS(Spatial, Node);
 	OBJ_CATEGORY("3D");
 
+public:
+	enum SpatialFlags {
+		// this is cached, and only currently kept up to date in visual instances
+		// this is set if a visual instance is
+		// (a) in the tree AND (b) visible via is_visible_in_tree() call
+		SPATIAL_FLAG_VI_VISIBLE = 1 << 0,
+	};
+
+private:
 	enum TransformDirty {
 		DIRTY_NONE = 0,
 		DIRTY_VECTORS = 1,
@@ -64,6 +73,9 @@ class Spatial : public Node {
 	mutable SelfList<Node> xform_change;
 
 	struct Data {
+
+		// defined in Spatial::SpatialFlags
+		uint32_t spatial_flags;
 
 		mutable Transform global_transform;
 		mutable Transform local_transform;
@@ -108,6 +120,16 @@ protected:
 	_FORCE_INLINE_ void set_ignore_transform_notification(bool p_ignore) { data.ignore_notification = p_ignore; }
 
 	_FORCE_INLINE_ void _update_local_transform() const;
+
+	uint32_t _get_spatial_flags() const { return data.spatial_flags; }
+	void _replace_spatial_flags(uint32_t p_flags) { data.spatial_flags = p_flags; }
+	void _set_spatial_flag(uint32_t p_flag, bool p_set) {
+		if (p_set) {
+			data.spatial_flags |= p_flag;
+		} else {
+			data.spatial_flags &= ~p_flag;
+		}
+	}
 
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
When visual instances are hidden, there is no need to update their global transforms and send these to the visual server. This only needs to be done when the objects are reshown.

## Explanation
I'm currently looking at optimizing performance of hidden objects, as I've noticed they surprisingly can slow down frame rates significantly. While #45576 deals with the case of static objects, there is still a performance problem when hidden 3d objects are moved.

### Benchmarks:
_0 objects_
6500 fps

_10,000 objects, hidden and static (with #45576)_
5500 fps

_10,000 objects, hidden but moved each frame via moving parent node_
158 fps

_10,000 objects, hidden but moved each frame via moving parent node, with this PR_
360 fps

Clearly the drop with dynamic objects is very significant, and should in theory be totally unnecessary.

Profiling revealed a lot of time was spent calling `get_global_transform()` and sending the transform to the visual server.

This example PR keeps a local flag for visibility state (something we should probably be doing anyway, as `is_visible_in_tree` can be expensive), doesn't update these transforms when the node is not visible.

This increases fps to 360 fps. While an improvement it is still not as good as can be. This is a profile with this PR applied. Still there is a lot of iterations of the propagation code (12,000000).

And actually the BVH seems to be taking some time which shouldn't be happening, will investigate - ah .. this is a false problem, it is because this PR is without #45576 applied which cures that. :grin: 

![dynamic_visibility_profile](https://user-images.githubusercontent.com/21999379/106360709-f4f19900-6311-11eb-856a-d358fbe0c9ca.png)

Ideally though we would like to be able to get to a hidden node, and disable propagation of transforms below that node in the scene tree. This is not (afaik) currently supported, presumably because even though child nodes of a hidden node may not need to be visible, they still may need the transform (e.g. physics objects).

I'm currently investigating whether it might be worth us having a single, or set of `disable` modes to prevent propagation of transforms, or perhaps other propagated features.

Any comments welcome. The flags BTW is because it is clear from the node source that there are a number of bools that are intended to be converted to flags but no one has got round to it, so I'm potentially getting the ball rolling on that idea. You could either have access functions for the flags or access the data directly to use bit operations, whichever is preferable. Maybe the latter actually having seen this pattern used in other parts of Godot. Or we could use a bool in this PR, and leave all the conversions to flags in another PR - whichever is preferred.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
