### PR TITLE
Add viewport resolution to the 3D editor's View Information pane

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2493,6 +2493,13 @@ void Node3DEditorViewport::_notification(int p_what) {
 			text += "Z: " + rtos(current_camera->get_translation().z).pad_decimals(1) + "\n";
 			text += TTR("Pitch") + ": " + itos(Math::round(current_camera->get_rotation_degrees().x)) + "\n";
 			text += TTR("Yaw") + ": " + itos(Math::round(current_camera->get_rotation_degrees().y)) + "\n\n";
+
+			text += TTR("Size") +
+					vformat(
+							": %dx%d (%.1fMP)\n",
+							viewport->get_size().x,
+							viewport->get_size().y,
+							viewport->get_size().x * viewport->get_size().y * 0.000'001);
 			text += TTR("Objects Drawn") + ": " + itos(viewport->get_render_info(Viewport::RENDER_INFO_OBJECTS_IN_FRAME)) + "\n";
 			text += TTR("Material Changes") + ": " + itos(viewport->get_render_info(Viewport::RENDER_INFO_MATERIAL_CHANGES_IN_FRAME)) + "\n";
 			text += TTR("Shader Changes") + ": " + itos(viewport->get_render_info(Viewport::RENDER_INFO_SHADER_CHANGES_IN_FRAME)) + "\n";


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-proposals/issues/2205.

## Preview

*The label is "Size" as it's shorter than "Resolution". Also, debug information  haven't been reimplemented in the `master` branch yet, which is why they're all 0.*

![image](https://user-images.githubusercontent.com/180032/106370478-aa483f00-635a-11eb-918f-7295508908f1.png)
