### PR TITLE
Use integer coordinates for the font glyphs rendering.

### DIFF
--- a/modules/text_server_adv/bitmap_font_adv.cpp
+++ b/modules/text_server_adv/bitmap_font_adv.cpp
@@ -540,7 +540,7 @@ Vector2 BitmapFontDataAdvanced::draw_glyph(RID p_canvas, int p_size, const Vecto
 	ERR_FAIL_COND_V(c == nullptr, Vector2());
 	ERR_FAIL_COND_V(c->texture_idx < -1 || c->texture_idx >= textures.size(), Vector2());
 	if (c->texture_idx != -1) {
-		Point2 cpos = p_pos;
+		Point2i cpos = p_pos;
 		cpos += c->align * (float(p_size) / float(base_size));
 		cpos.y -= ascent * (float(p_size) / float(base_size));
 		if (RenderingServer::get_singleton() != nullptr) {

--- a/modules/text_server_adv/dynamic_font_adv.cpp
+++ b/modules/text_server_adv/dynamic_font_adv.cpp
@@ -946,7 +946,7 @@ Vector2 DynamicFontDataAdvanced::draw_glyph(RID p_canvas, int p_size, const Vect
 		ERR_FAIL_COND_V(ch.texture_idx < -1 || ch.texture_idx >= fds->textures.size(), Vector2());
 
 		if (ch.texture_idx != -1) {
-			Point2 cpos = p_pos;
+			Point2i cpos = p_pos;
 			cpos += ch.align;
 			Color modulate = p_color;
 			if (FT_HAS_COLOR(fds->face)) {
@@ -977,7 +977,7 @@ Vector2 DynamicFontDataAdvanced::draw_glyph_outline(RID p_canvas, int p_size, in
 		ERR_FAIL_COND_V(ch.texture_idx < -1 || ch.texture_idx >= fds->textures.size(), Vector2());
 
 		if (ch.texture_idx != -1) {
-			Point2 cpos = p_pos;
+			Point2i cpos = p_pos;
 			cpos += ch.align;
 			Color modulate = p_color;
 			if (FT_HAS_COLOR(fds->face)) {

--- a/modules/text_server_fb/bitmap_font_fb.cpp
+++ b/modules/text_server_fb/bitmap_font_fb.cpp
@@ -321,7 +321,7 @@ Vector2 BitmapFontDataFallback::draw_glyph(RID p_canvas, int p_size, const Vecto
 	ERR_FAIL_COND_V(c == nullptr, Vector2());
 	ERR_FAIL_COND_V(c->texture_idx < -1 || c->texture_idx >= textures.size(), Vector2());
 	if (c->texture_idx != -1) {
-		Point2 cpos = p_pos;
+		Point2i cpos = p_pos;
 		cpos += c->align * (float(p_size) / float(base_size));
 		cpos.y -= ascent * (float(p_size) / float(base_size));
 

--- a/modules/text_server_fb/dynamic_font_fb.cpp
+++ b/modules/text_server_fb/dynamic_font_fb.cpp
@@ -626,7 +626,7 @@ Vector2 DynamicFontDataFallback::draw_glyph(RID p_canvas, int p_size, const Vect
 		ERR_FAIL_COND_V(ch.texture_idx < -1 || ch.texture_idx >= fds->textures.size(), Vector2());
 
 		if (ch.texture_idx != -1) {
-			Point2 cpos = p_pos;
+			Point2i cpos = p_pos;
 			cpos += ch.align;
 
 			Color modulate = p_color;
@@ -658,7 +658,7 @@ Vector2 DynamicFontDataFallback::draw_glyph_outline(RID p_canvas, int p_size, in
 		ERR_FAIL_COND_V(ch.texture_idx < -1 || ch.texture_idx >= fds->textures.size(), Vector2());
 
 		if (ch.texture_idx != -1) {
-			Point2 cpos = p_pos;
+			Point2i cpos = p_pos;
 			cpos += ch.align;
 
 			Color modulate = p_color;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -306,10 +306,10 @@ void Button::_notification(int p_what) {
 			Color font_outline_color = get_theme_color("font_outline_color");
 			int outline_size = get_theme_constant("outline_size");
 			if (outline_size > 0 && font_outline_color.a > 0) {
-				text_buf->draw_outline(ci, text_ofs.floor(), outline_size, font_outline_color);
+				text_buf->draw_outline(ci, text_ofs, outline_size, font_outline_color);
 			}
 
-			text_buf->draw(ci, text_ofs.floor(), color);
+			text_buf->draw(ci, text_ofs, color);
 
 			if (!_icon.is_null() && icon_region.size.width > 0) {
 				draw_texture_rect_region(_icon, icon_region, Rect2(Point2(), _icon->get_size()), color_icon);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1194,7 +1194,6 @@ void ItemList::_notification(int p_what) {
 				}
 
 				if (icon_mode == ICON_MODE_TOP && max_text_lines > 0) {
-					text_ofs = text_ofs.floor();
 					text_ofs += base_ofs;
 					text_ofs += items[i].rect_cache.position;
 
@@ -1217,7 +1216,6 @@ void ItemList::_notification(int p_what) {
 						text_ofs.y += (items[i].rect_cache.size.height - size2.y) / 2;
 					}
 
-					text_ofs = text_ofs.floor();
 					text_ofs += base_ofs;
 					text_ofs += items[i].rect_cache.position;
 


### PR DESCRIPTION
Rounds font glyph coordinates in the font itself, instead of doing it in the individual control drawing code.

Fixes #45037 and potential similar issues in the future.