### PR TITLE
Add missing GLES2 "Enable High Float" non-override setting

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1078,9 +1078,12 @@
 		<member name="rendering/gles2/compatibility/disable_half_float" type="bool" setter="" getter="" default="false">
 			The use of half-float vertex compression may be producing rendering errors on some platforms (especially iOS). These have been seen particularly in particles. Disabling half-float may resolve these problems.
 		</member>
+		<member name="rendering/gles2/compatibility/enable_high_float" type="bool" setter="" getter="" default="true">
+			If [code]true[/code] and available on the target device, enables high floating-point precision for all shader computations in GLES2.
+			[b]Warning:[/b] High floating-point precision can be extremely slow on older devices and is often not available at all. Use with caution.
+		</member>
 		<member name="rendering/gles2/compatibility/enable_high_float.Android" type="bool" setter="" getter="" default="false">
-			If [code]true[/code] and available on the target device, enables high floating point precision for all shader computations in GLES2.
-			[b]Warning:[/b] High floating point precision can be extremely slow on older devices and is often not available at all. Use with caution.
+			Lower-end override for [member rendering/gles2/compatibility/enable_high_float] on Android, due to performance concerns or driver support.
 		</member>
 		<member name="rendering/limits/buffers/blend_shape_max_buffer_size_kb" type="int" setter="" getter="" default="4096">
 			Max buffer size for blend shapes. Any blend shape bigger than this will not work.

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2462,6 +2462,7 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/batching/debug/flash_batching", false);
 	GLOBAL_DEF("rendering/batching/debug/diagnose_frame", false);
 	GLOBAL_DEF("rendering/gles2/compatibility/disable_half_float", false);
+	GLOBAL_DEF("rendering/gles2/compatibility/enable_high_float", true);
 	GLOBAL_DEF("rendering/gles2/compatibility/enable_high_float.Android", false);
 	GLOBAL_DEF("rendering/batching/precision/uv_contract", false);
 	GLOBAL_DEF("rendering/batching/precision/uv_contract_amount", 100);


### PR DESCRIPTION
The lack of a non-override setting was confusing.