### PR TITLE
lightmap capture broken on webgl1.0

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -955,7 +955,7 @@ vec4 texture2D_bicubic(sampler2D tex, vec2 uv) {
 #endif
 
 #ifdef USE_LIGHTMAP_CAPTURE
-uniform mediump vec4[12] lightmap_captures;
+uniform mediump vec4 lightmap_captures[12];
 uniform bool lightmap_capture_sky;
 
 #endif


### PR DESCRIPTION
lightmap capture uniform definition caused shader compile errors on WebGL1.0

Fixes https://github.com/godotengine/godot/issues/45584