### PR TITLE
Allow clamping vectors and colors in addition to floats and ints

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -211,6 +211,14 @@ bool Color::is_equal_approx(const Color &p_color) const {
 	return Math::is_equal_approx(r, p_color.r) && Math::is_equal_approx(g, p_color.g) && Math::is_equal_approx(b, p_color.b) && Math::is_equal_approx(a, p_color.a);
 }
 
+Color Color::clamp(const Color &p_min, const Color &p_max) const {
+	return Color(
+			CLAMP(r, p_min.r, p_max.r),
+			CLAMP(g, p_min.g, p_max.g),
+			CLAMP(b, p_min.b, p_max.b),
+			CLAMP(a, p_min.a, p_max.a));
+}
+
 void Color::invert() {
 	r = 1.0 - r;
 	g = 1.0 - g;

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -89,6 +89,7 @@ struct Color {
 
 	bool is_equal_approx(const Color &p_color) const;
 
+	Color clamp(const Color &p_min = Color(0, 0, 0, 0), const Color &p_max = Color(1, 1, 1, 1)) const;
 	void invert();
 	Color inverted() const;
 

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -122,6 +122,12 @@ Vector2 Vector2::project(const Vector2 &p_to) const {
 	return p_to * (dot(p_to) / p_to.length_squared());
 }
 
+Vector2 Vector2::clamp(const Vector2 &p_min, const Vector2 &p_max) const {
+	return Vector2(
+			CLAMP(x, p_min.x, p_max.x),
+			CLAMP(y, p_min.y, p_max.y));
+}
+
 Vector2 Vector2::snapped(const Vector2 &p_step) const {
 	return Vector2(
 			Math::snapped(x, p_step.x),
@@ -188,6 +194,12 @@ bool Vector2::is_equal_approx(const Vector2 &p_v) const {
 }
 
 /* Vector2i */
+
+Vector2i Vector2i::clamp(const Vector2i &p_min, const Vector2i &p_max) const {
+	return Vector2i(
+			CLAMP(x, p_min.x, p_max.x),
+			CLAMP(y, p_min.y, p_max.y));
+}
 
 Vector2i Vector2i::operator+(const Vector2i &p_v) const {
 	return Vector2i(x + p_v.x, y + p_v.y);

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -128,8 +128,8 @@ Vector2 Vector2::snapped(const Vector2 &p_step) const {
 			Math::snapped(y, p_step.y));
 }
 
-Vector2 Vector2::clamped(real_t p_len) const {
-	real_t l = length();
+Vector2 Vector2::limit_length(const real_t p_len) const {
+	const real_t l = length();
 	Vector2 v = *this;
 	if (l > 0 && p_len < l) {
 		v /= l;

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -84,6 +84,7 @@ struct Vector2 {
 
 	real_t length() const;
 	real_t length_squared() const;
+	Vector2 limit_length(const real_t p_len = 1.0) const;
 
 	Vector2 min(const Vector2 &p_vector2) const {
 		return Vector2(MIN(x, p_vector2.x), MIN(y, p_vector2.y));
@@ -106,8 +107,6 @@ struct Vector2 {
 	Vector2 project(const Vector2 &p_to) const;
 
 	Vector2 plane_project(real_t p_d, const Vector2 &p_vec) const;
-
-	Vector2 clamped(real_t p_len) const;
 
 	_FORCE_INLINE_ Vector2 lerp(const Vector2 &p_to, real_t p_weight) const;
 	_FORCE_INLINE_ Vector2 slerp(const Vector2 &p_to, real_t p_weight) const;

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -162,6 +162,7 @@ struct Vector2 {
 	Vector2 ceil() const;
 	Vector2 round() const;
 	Vector2 snapped(const Vector2 &p_by) const;
+	Vector2 clamp(const Vector2 &p_min, const Vector2 &p_max) const;
 	real_t aspect() const { return width / height; }
 
 	operator String() const { return String::num(x) + ", " + String::num(y); }
@@ -337,6 +338,7 @@ struct Vector2i {
 	real_t aspect() const { return width / (real_t)height; }
 	Vector2i sign() const { return Vector2i(SGN(x), SGN(y)); }
 	Vector2i abs() const { return Vector2i(ABS(x), ABS(y)); }
+	Vector2i clamp(const Vector2i &p_min, const Vector2i &p_max) const;
 
 	operator String() const { return String::num(x) + ", " + String::num(y); }
 

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -52,6 +52,13 @@ real_t Vector3::get_axis(int p_axis) const {
 	return operator[](p_axis);
 }
 
+Vector3 Vector3::clamp(const Vector3 &p_min, const Vector3 &p_max) const {
+	return Vector3(
+			CLAMP(x, p_min.x, p_max.x),
+			CLAMP(y, p_min.y, p_max.y),
+			CLAMP(z, p_min.z, p_max.z));
+}
+
 void Vector3::snap(Vector3 p_step) {
 	x = Math::snapped(x, p_step.x);
 	y = Math::snapped(y, p_step.y);

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -64,6 +64,17 @@ Vector3 Vector3::snapped(Vector3 p_step) const {
 	return v;
 }
 
+Vector3 Vector3::limit_length(const real_t p_len) const {
+	const real_t l = length();
+	Vector3 v = *this;
+	if (l > 0 && p_len < l) {
+		v /= l;
+		v *= p_len;
+	}
+
+	return v;
+}
+
 Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const {
 	Vector3 p0 = p_pre_a;
 	Vector3 p1 = *this;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -113,6 +113,7 @@ struct Vector3 {
 	_FORCE_INLINE_ Vector3 sign() const;
 	_FORCE_INLINE_ Vector3 ceil() const;
 	_FORCE_INLINE_ Vector3 round() const;
+	Vector3 clamp(const Vector3 &p_min, const Vector3 &p_max) const;
 
 	_FORCE_INLINE_ real_t distance_to(const Vector3 &p_to) const;
 	_FORCE_INLINE_ real_t distance_squared_to(const Vector3 &p_to) const;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -86,6 +86,7 @@ struct Vector3 {
 	_FORCE_INLINE_ Vector3 normalized() const;
 	_FORCE_INLINE_ bool is_normalized() const;
 	_FORCE_INLINE_ Vector3 inverse() const;
+	Vector3 limit_length(const real_t p_len = 1.0) const;
 
 	_FORCE_INLINE_ void zero();
 

--- a/core/math/vector3i.cpp
+++ b/core/math/vector3i.cpp
@@ -48,6 +48,13 @@ int Vector3i::max_axis() const {
 	return x < y ? (y < z ? 2 : 1) : (x < z ? 2 : 0);
 }
 
+Vector3i Vector3i::clamp(const Vector3i &p_min, const Vector3i &p_max) const {
+	return Vector3i(
+			CLAMP(x, p_min.x, p_max.x),
+			CLAMP(y, p_min.y, p_max.y),
+			CLAMP(z, p_min.z, p_max.z));
+}
+
 Vector3i::operator String() const {
 	return (itos(x) + ", " + itos(y) + ", " + itos(z));
 }

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -69,6 +69,7 @@ struct Vector3i {
 
 	_FORCE_INLINE_ Vector3i abs() const;
 	_FORCE_INLINE_ Vector3i sign() const;
+	Vector3i clamp(const Vector3i &p_min, const Vector3i &p_max) const;
 
 	/* Operators */
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1443,6 +1443,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2, cross, sarray("with"), varray());
 	bind_method(Vector2, abs, sarray(), varray());
 	bind_method(Vector2, sign, sarray(), varray());
+	bind_method(Vector2, clamp, sarray("min", "max"), varray());
 	bind_method(Vector2, snapped, sarray("step"), varray());
 
 	/* Vector2i */
@@ -1450,6 +1451,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2i, aspect, sarray(), varray());
 	bind_method(Vector2i, sign, sarray(), varray());
 	bind_method(Vector2i, abs, sarray(), varray());
+	bind_method(Vector2i, clamp, sarray("min", "max"), varray());
 
 	/* Rect2 */
 
@@ -1498,6 +1500,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3, is_normalized, sarray(), varray());
 	bind_method(Vector3, is_equal_approx, sarray("to"), varray());
 	bind_method(Vector3, inverse, sarray(), varray());
+	bind_method(Vector3, clamp, sarray("min", "max"), varray());
 	bind_method(Vector3, snapped, sarray("step"), varray());
 	bind_method(Vector3, rotated, sarray("by_axis", "phi"), varray());
 	bind_method(Vector3, lerp, sarray("to", "weight"), varray());
@@ -1526,6 +1529,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3i, max_axis, sarray(), varray());
 	bind_method(Vector3i, sign, sarray(), varray());
 	bind_method(Vector3i, abs, sarray(), varray());
+	bind_method(Vector3i, clamp, sarray("min", "max"), varray());
 
 	/* Plane */
 
@@ -1563,6 +1567,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Color, to_abgr64, sarray(), varray());
 	bind_method(Color, to_rgba64, sarray(), varray());
 
+	bind_method(Color, clamp, sarray("min", "max"), varray(Color(0, 0, 0, 0), Color(1, 1, 1, 1)));
 	bind_method(Color, inverted, sarray(), varray());
 	bind_method(Color, lerp, sarray("to", "weight"), varray());
 	bind_method(Color, lightened, sarray("amount"), varray());

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1419,6 +1419,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2, distance_squared_to, sarray("to"), varray());
 	bind_method(Vector2, length, sarray(), varray());
 	bind_method(Vector2, length_squared, sarray(), varray());
+	bind_method(Vector2, limit_length, sarray("length"), varray(1.0));
 	bind_method(Vector2, normalized, sarray(), varray());
 	bind_method(Vector2, is_normalized, sarray(), varray());
 	bind_method(Vector2, is_equal_approx, sarray("to"), varray());
@@ -1443,7 +1444,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2, abs, sarray(), varray());
 	bind_method(Vector2, sign, sarray(), varray());
 	bind_method(Vector2, snapped, sarray("step"), varray());
-	bind_method(Vector2, clamped, sarray("length"), varray());
 
 	/* Vector2i */
 
@@ -1493,6 +1493,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3, distance_squared_to, sarray("b"), varray());
 	bind_method(Vector3, length, sarray(), varray());
 	bind_method(Vector3, length_squared, sarray(), varray());
+	bind_method(Vector3, limit_length, sarray("length"), varray(1.0));
 	bind_method(Vector3, normalized, sarray(), varray());
 	bind_method(Vector3, is_normalized, sarray(), varray());
 	bind_method(Vector3, is_equal_approx, sarray("to"), varray());

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -136,6 +136,17 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="clamp" qualifiers="const">
+			<return type="Color">
+			</return>
+			<argument index="0" name="min" type="Color" default="Color( 0, 0, 0, 0 )">
+			</argument>
+			<argument index="1" name="max" type="Color" default="Color( 1, 1, 1, 1 )">
+			</argument>
+			<description>
+				Returns a new color with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+			</description>
+		</method>
 		<method name="darkened" qualifiers="const">
 			<return type="Color">
 			</return>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -110,6 +110,17 @@
 				Returns the vector with all components rounded up (towards positive infinity).
 			</description>
 		</method>
+		<method name="clamp" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="min" type="Vector2">
+			</argument>
+			<argument index="1" name="max" type="Vector2">
+			</argument>
+			<description>
+				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+			</description>
+		</method>
 		<method name="cross" qualifiers="const">
 			<return type="float">
 			</return>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -110,15 +110,6 @@
 				Returns the vector with all components rounded up (towards positive infinity).
 			</description>
 		</method>
-		<method name="clamped" qualifiers="const">
-			<return type="Vector2">
-			</return>
-			<argument index="0" name="length" type="float">
-			</argument>
-			<description>
-				Returns the vector with a maximum length by limiting its length to [code]length[/code].
-			</description>
-		</method>
 		<method name="cross" qualifiers="const">
 			<return type="float">
 			</return>
@@ -230,6 +221,15 @@
 			</argument>
 			<description>
 				Returns the result of the linear interpolation between this vector and [code]to[/code] by amount [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+			</description>
+		</method>
+		<method name="limit_length" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="length" type="float" default="1.0">
+			</argument>
+			<description>
+				Returns the vector with a maximum length by limiting its length to [code]length[/code].
 			</description>
 		</method>
 		<method name="move_toward" qualifiers="const">

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -64,6 +64,17 @@
 				Returns the ratio of [member x] to [member y].
 			</description>
 		</method>
+		<method name="clamp" qualifiers="const">
+			<return type="Vector2i">
+			</return>
+			<argument index="0" name="min" type="Vector2i">
+			</argument>
+			<argument index="1" name="max" type="Vector2i">
+			</argument>
+			<description>
+				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+			</description>
+		</method>
 		<method name="operator !=" qualifiers="operator">
 			<return type="bool">
 			</return>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -87,6 +87,17 @@
 				Returns a new vector with all components rounded up (towards positive infinity).
 			</description>
 		</method>
+		<method name="clamp" qualifiers="const">
+			<return type="Vector3">
+			</return>
+			<argument index="0" name="min" type="Vector3">
+			</argument>
+			<argument index="1" name="max" type="Vector3">
+			</argument>
+			<description>
+				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+			</description>
+		</method>
 		<method name="cross" qualifiers="const">
 			<return type="Vector3">
 			</return>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -207,6 +207,15 @@
 				Returns the result of the linear interpolation between this vector and [code]to[/code] by amount [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
+		<method name="limit_length" qualifiers="const">
+			<return type="Vector3">
+			</return>
+			<argument index="0" name="length" type="float" default="1.0">
+			</argument>
+			<description>
+				Returns the vector with a maximum length by limiting its length to [code]length[/code].
+			</description>
+		</method>
 		<method name="max_axis" qualifiers="const">
 			<return type="int">
 			</return>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -58,6 +58,17 @@
 			<description>
 			</description>
 		</method>
+		<method name="clamp" qualifiers="const">
+			<return type="Vector3i">
+			</return>
+			<argument index="0" name="min" type="Vector3i">
+			</argument>
+			<argument index="1" name="max" type="Vector3i">
+			</argument>
+			<description>
+				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+			</description>
+		</method>
 		<method name="max_axis" qualifiers="const">
 			<return type="int">
 			</return>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -257,6 +257,27 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns a new color with all components clamped between the
+        /// components of `min` and `max` using
+        /// <see cref="Mathf.Clamp(float, float, float)"/>.
+        /// </summary>
+        /// <param name="min">The color with minimum allowed values.</param>
+        /// <param name="max">The color with maximum allowed values.</param>
+        /// <returns>The color with all components clamped.</returns>
+        public Color Clamp(Color? min = null, Color? max = null)
+        {
+            Color minimum = min ?? new Color(0, 0, 0, 0);
+            Color maximum = max ?? new Color(1, 1, 1, 1);
+            return new Color
+            (
+                (float)Mathf.Clamp(r, minimum.r, maximum.r),
+                (float)Mathf.Clamp(g, minimum.g, maximum.g),
+                (float)Mathf.Clamp(b, minimum.b, maximum.b),
+                (float)Mathf.Clamp(a, minimum.a, maximum.a)
+            );
+        }
+
+        /// <summary>
         /// Returns a new color resulting from making this color darker
         /// by the specified ratio (on the range of 0 to 1).
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -160,6 +160,23 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns a new vector with all components clamped between the
+        /// components of `min` and `max` using
+        /// <see cref="Mathf.Clamp(real_t, real_t, real_t)"/>.
+        /// </summary>
+        /// <param name="min">The vector with minimum allowed values.</param>
+        /// <param name="max">The vector with maximum allowed values.</param>
+        /// <returns>The vector with all components clamped.</returns>
+        public Vector2 Clamp(Vector2 min, Vector2 max)
+        {
+            return new Vector2
+            (
+                Mathf.Clamp(x, min.x, max.x),
+                Mathf.Clamp(y, min.y, max.y)
+            );
+        }
+
+        /// <summary>
         /// Returns the cross product of this vector and `b`.
         /// </summary>
         /// <param name="b">The other vector.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -160,25 +160,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the vector with a maximum length by limiting its length to `length`.
-        /// </summary>
-        /// <param name="length">The length to limit to.</param>
-        /// <returns>The vector with its length limited.</returns>
-        public Vector2 Clamped(real_t length)
-        {
-            var v = this;
-            real_t l = Length();
-
-            if (l > 0 && length < l)
-            {
-                v /= l;
-                v *= length;
-            }
-
-            return v;
-        }
-
-        /// <summary>
         /// Returns the cross product of this vector and `b`.
         /// </summary>
         /// <param name="b">The other vector.</param>
@@ -332,6 +313,25 @@ namespace Godot
                 Mathf.Lerp(x, to.x, weight.x),
                 Mathf.Lerp(y, to.y, weight.y)
             );
+        }
+
+        /// <summary>
+        /// Returns the vector with a maximum length by limiting its length to `length`.
+        /// </summary>
+        /// <param name="length">The length to limit to.</param>
+        /// <returns>The vector with its length limited.</returns>
+        public Vector2 LimitLength(real_t length = 1.0f)
+        {
+            Vector2 v = this;
+            real_t l = Length();
+
+            if (l > 0 && length < l)
+            {
+                v /= l;
+                v *= length;
+            }
+
+            return v;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -120,6 +120,23 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns a new vector with all components clamped between the
+        /// components of `min` and `max` using
+        /// <see cref="Mathf.Clamp(int, int, int)"/>.
+        /// </summary>
+        /// <param name="min">The vector with minimum allowed values.</param>
+        /// <param name="max">The vector with maximum allowed values.</param>
+        /// <returns>The vector with all components clamped.</returns>
+        public Vector2i Clamp(Vector2i min, Vector2i max)
+        {
+            return new Vector2i
+            (
+                Mathf.Clamp(x, min.x, max.x),
+                Mathf.Clamp(y, min.y, max.y)
+            );
+        }
+
+        /// <summary>
         /// Returns the cross product of this vector and `b`.
         /// </summary>
         /// <param name="b">The other vector.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -140,6 +140,24 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns a new vector with all components clamped between the
+        /// components of `min` and `max` using
+        /// <see cref="Mathf.Clamp(real_t, real_t, real_t)"/>.
+        /// </summary>
+        /// <param name="min">The vector with minimum allowed values.</param>
+        /// <param name="max">The vector with maximum allowed values.</param>
+        /// <returns>The vector with all components clamped.</returns>
+        public Vector3 Clamp(Vector3 min, Vector3 max)
+        {
+            return new Vector3
+            (
+                Mathf.Clamp(x, min.x, max.x),
+                Mathf.Clamp(y, min.y, max.y),
+                Mathf.Clamp(z, min.z, max.z)
+            );
+        }
+
+        /// <summary>
         /// Returns the cross product of this vector and `b`.
         /// </summary>
         /// <param name="b">The other vector.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -313,6 +313,25 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the vector with a maximum length by limiting its length to `length`.
+        /// </summary>
+        /// <param name="length">The length to limit to.</param>
+        /// <returns>The vector with its length limited.</returns>
+        public Vector3 LimitLength(real_t length = 1.0f)
+        {
+            Vector3 v = this;
+            real_t l = Length();
+
+            if (l > 0 && length < l)
+            {
+                v /= l;
+                v *= length;
+            }
+
+            return v;
+        }
+
+        /// <summary>
         /// Returns the axis of the vector's largest value. See <see cref="Axis"/>.
         /// If all components are equal, this method returns <see cref="Axis.X"/>.
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -89,6 +89,24 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns a new vector with all components clamped between the
+        /// components of `min` and `max` using
+        /// <see cref="Mathf.Clamp(int, int, int)"/>.
+        /// </summary>
+        /// <param name="min">The vector with minimum allowed values.</param>
+        /// <param name="max">The vector with maximum allowed values.</param>
+        /// <returns>The vector with all components clamped.</returns>
+        public Vector3i Clamp(Vector3i min, Vector3i max)
+        {
+            return new Vector3i
+            (
+                Mathf.Clamp(x, min.x, max.x),
+                Mathf.Clamp(y, min.y, max.y),
+                Mathf.Clamp(z, min.z, max.z)
+            );
+        }
+
+        /// <summary>
         /// Returns the squared distance between this vector and `b`.
         /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
         /// you need to compare vectors or need the squared distance for some formula.

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -322,7 +322,7 @@ bool GrooveJoint2DSW::setup(real_t p_step) {
 	Vector2 delta = (B->get_transform().get_origin() + rB) - (A->get_transform().get_origin() + rA);
 
 	real_t _b = get_bias();
-	gbias = (delta * -(_b == 0 ? space->get_constraint_bias() : _b) * (1.0 / p_step)).clamped(get_max_bias());
+	gbias = (delta * -(_b == 0 ? space->get_constraint_bias() : _b) * (1.0 / p_step)).limit_length(get_max_bias());
 
 	correct = true;
 	return true;
@@ -348,7 +348,7 @@ void GrooveJoint2DSW::solve(real_t p_step) {
 	Vector2 jOld = jn_acc;
 	j += jOld;
 
-	jn_acc = (((clamp * j.cross(xf_normal)) > 0) ? j : j.project(xf_normal)).clamped(jn_max);
+	jn_acc = (((clamp * j.cross(xf_normal)) > 0) ? j : j.project(xf_normal)).limit_length(jn_max);
 
 	j = jn_acc - jOld;
 


### PR DESCRIPTION
Implements and closes #13926. Specifically, implements the API described in [this comment](https://github.com/godotengine/godot/issues/13926#issuecomment-628897087) in both core and C#:

* Rename `Vector2.clamped` to `Vector2.limit_length`. I also gave it a default value of `1.0`.

* Add `Vector3.limit_length` to be consistent with `Vector2`. This part closes #30058.

* Add `Vector2.clamp(min, max)` where `min` and `max` are of type `Vector2`.

* Add `Vector2i.clamp(min, max)` where `min` and `max` are of type `Vector2i`.

* Add `Vector3.clamp(min, max)` where `min` and `max` are of type `Vector3`.

* Add `Vector3i.clamp(min, max)` where `min` and `max` are of type `Vector3i`.

* Add `Color.clamp(min, max)` where `min` and `max` are of type `Color`.

    * `Color.clamp` has default values of `min = Color(0, 0, 0, 0)` and `max = Color(1, 1, 1, 1)`, since clamping a color to this range seems like it would be a relatively common operation. You can also specify only `min` as `Color.black` to clamp to non-transparent colors, since black is `Color(0, 0, 0, 1)` and so alpha will always be 1.

This PR used to have 3 commits, but the third was un-done. For reference, here was that third commit: https://github.com/aaronfranke/godot/commit/9e041002e863780fe02abd315ace57f8eb5663a9