### PR TITLE
Linux: Build with use_static_cpp=yes by default

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -64,7 +64,7 @@ def get_opts():
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
         BoolVariable("use_lld", "Use the LLD linker", False),
         BoolVariable("use_thinlto", "Use ThinLTO", False),
-        BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", False),
+        BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", True),
         BoolVariable("use_coverage", "Test Godot coverage", False),
         BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
         BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
@@ -390,4 +390,7 @@ def configure(env):
 
     # Link those statically for portability
     if env["use_static_cpp"]:
-        env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
+        # Workaround for GH-31743, Ubuntu 18.04 i386 crashes when it's used.
+        # That doesn't make any sense but it's likely a Ubuntu bug?
+        if is64 or env["bits"] == "64":
+            env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])


### PR DESCRIPTION
This enables `-static-libgcc -static-libstdc++` which help make custom Linux
builds more portable (official builds have been using this option for years).

---

Note: I need to do some tests before merging as for official builds on Ubuntu 14.04 i386 I'm actually not using those, I probably ran into issues in the past and forgot to document them... 
https://github.com/godotengine/godot-build-scripts/blob/master/build-linux/build.sh#L15-L17

*Edit:* "Solved", see below.

---

Note: Distro packagers should typically set this option to `no` to keep using the distro-provided shared libgcc and libstdc++. This option is only for builds that need to be shared with users on other distros (which is the main use case for custom Godot builds, but not the one Linux distro packages).