### PR TITLE
Linux: Enable udev support by default

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -71,7 +71,7 @@ def get_opts():
         BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
         BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
         BoolVariable("pulseaudio", "Detect and use PulseAudio", True),
-        BoolVariable("udev", "Use udev for gamepad connection callbacks", False),
+        BoolVariable("udev", "Use udev for gamepad connection callbacks", True),
         EnumVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", "yes", ("yes", "no")),
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("touch", "Enable touch events", True),


### PR DESCRIPTION
This has been enabled for years in official binaries, and users making custom builds
may end up not enabling it unknowingly, so it's best if we default to the same as
what official builds do.

The original reason for having it opt-in was likely the addition of a dependency on
libudev, but that should be fairly ubiquitous by now (at least we have yet to see a bug
report from users who can't use official Godot editor builds or templates due to not
having udev installed).