### PR TITLE
Fix incorrect version requirement in the SCons compilation DB comment

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -308,7 +308,7 @@ if selected_platform in platform_list:
     else:
         env = env_base.Clone()
 
-    # Compilation DB requires SCons 3.1.1+.
+    # Generating the compilation DB (`compile_commands.json`) requires SCons 4.0.0 or later.
     from SCons import __version__ as scons_raw_version
 
     scons_ver = env._get_major_minor_revision(scons_raw_version)


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/39883#issuecomment-770830415.

I've also added `compile_commands.json` so it appears in full-text searches.