### PR TITLE
Make the Open Project Folder button more visible in the project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1375,11 +1375,10 @@ void ProjectList::create_project_item_control(int p_index) {
 	vb->add_child(path_hb);
 
 	Button *show = memnew(Button);
-	// Display a folder icon if the project directory can be opened, or a "broken file" icon if it can't
+	// Display a folder icon if the project directory can be opened, or a "broken file" icon if it can't.
 	show->set_icon(get_theme_icon(!item.missing ? "Load" : "FileBroken", "EditorIcons"));
-	show->set_flat(true);
 	if (!item.grayed) {
-		// Don't make the icon less prominent if the parent is already grayed out
+		// Don't make the icon less prominent if the parent is already grayed out.
 		show->set_modulate(Color(1, 1, 1, 0.5));
 	}
 	path_hb->add_child(show);


### PR DESCRIPTION
The difference is mainly noticeable when hovering or selecting a project, but I think this makes it obvious enough now.

This closes https://github.com/godotengine/godot-proposals/issues/619.

## Preview

### Before

![Project manager](https://user-images.githubusercontent.com/180032/106505836-2496d180-64c9-11eb-9f0e-6980aee89cb0.png)

### After

![Project manager](https://user-images.githubusercontent.com/180032/106505404-8dca1500-64c8-11eb-9e4d-6c32fa0bec71.png)
