### PR TITLE
Don't use trashy max_decals value to prevent crashes

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -8785,6 +8785,14 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 		default_giprobe_buffer = RD::get_singleton()->uniform_buffer_create(sizeof(GI::GIProbeData) * RenderBuffers::MAX_GIPROBES);
 	}
 
+	{ //decals
+		cluster.max_decals = max_cluster_elements;
+		uint32_t decal_buffer_size = cluster.max_decals * sizeof(Cluster::DecalData);
+		cluster.decals = memnew_arr(Cluster::DecalData, cluster.max_decals);
+		cluster.decal_sort = memnew_arr(Cluster::InstanceSort<DecalInstance>, cluster.max_decals);
+		cluster.decal_buffer = RD::get_singleton()->storage_buffer_create(decal_buffer_size);
+	}
+
 	{ //reflections
 
 		cluster.max_reflections = max_cluster_elements;
@@ -8813,14 +8821,6 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 		uint32_t directional_light_buffer_size = cluster.max_directional_lights * sizeof(Cluster::DirectionalLightData);
 		cluster.directional_lights = memnew_arr(Cluster::DirectionalLightData, cluster.max_directional_lights);
 		cluster.directional_light_buffer = RD::get_singleton()->uniform_buffer_create(directional_light_buffer_size);
-	}
-
-	{ //decals
-		cluster.max_decals = max_cluster_elements;
-		uint32_t decal_buffer_size = cluster.max_decals * sizeof(Cluster::DecalData);
-		cluster.decals = memnew_arr(Cluster::DecalData, cluster.max_decals);
-		cluster.decal_sort = memnew_arr(Cluster::InstanceSort<DecalInstance>, cluster.max_decals);
-		cluster.decal_buffer = RD::get_singleton()->storage_buffer_create(decal_buffer_size);
 	}
 
 	if (!low_end) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/45384

Before, due to uninitialized max_decals variable, Godot tried to allocate too small or to big amount of memory (in my tests `1930322029` bytes instead proper `512` bytes)

This caused memory allocation failure and printing at the end 
```
ERROR: Condition "p_ptr == nullptr" is true.
   at: free_static (core/os/memory.cpp:150)
```
or just usage of memory beyond allowed area