### PR TITLE
C conformance: Include stdbool.h to define `bool` 

### DIFF
--- a/modules/gdnative/include/gdnative/math_defs.h
+++ b/modules/gdnative/include/gdnative/math_defs.h
@@ -35,6 +35,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 
 ////// bool


### PR DESCRIPTION
"bool" does not exist in C - when this header is consumed by a C compiler it fails
to compile.   This replaces `bool` with `char`.   Found this when trying to use this
header from Swift, which uses plain C for its interop.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
