### PR TITLE
Add anisotropic filtering to GLES2 backend

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -56,6 +56,7 @@ public:
 
 		bool shrink_textures_x2;
 		bool use_fast_texture_filter;
+		bool use_anisotropic_filter;
 		bool use_skeleton_software;
 		bool use_lightmap_filter_bicubic;
 
@@ -81,6 +82,8 @@ public:
 
 		bool use_rgba_2d_shadows;
 		bool use_rgba_3d_shadows;
+
+		float anisotropic_level;
 
 		bool support_32_bits_indices;
 		bool support_write_depth;

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -408,9 +408,6 @@ void RasterizerGLES3::make_current() {
 }
 
 void RasterizerGLES3::register_config() {
-
-	GLOBAL_DEF("rendering/quality/filters/anisotropic_filter_level", 4);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/filters/anisotropic_filter_level", PropertyInfo(Variant::INT, "rendering/quality/filters/anisotropic_filter_level", PROPERTY_HINT_RANGE, "1,16,1"));
 }
 
 // returns NULL if no error, or an error string

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8355,7 +8355,6 @@ void RasterizerStorageGLES3::initialize() {
 
 	config.shrink_textures_x2 = false;
 	config.use_fast_texture_filter = int(ProjectSettings::get_singleton()->get("rendering/quality/filters/use_nearest_mipmap_filter"));
-	config.use_anisotropic_filter = config.extensions.has("rendering/quality/filters/anisotropic_filter_level");
 
 	config.etc_supported = config.extensions.has("GL_OES_compressed_ETC1_RGB8_texture");
 	config.latc_supported = config.extensions.has("GL_EXT_texture_compression_latc");

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2437,6 +2437,8 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/quality/depth_prepass/enable", true);
 	GLOBAL_DEF("rendering/quality/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
 
+	GLOBAL_DEF("rendering/quality/filters/anisotropic_filter_level", 4);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/filters/anisotropic_filter_level", PropertyInfo(Variant::INT, "rendering/quality/filters/anisotropic_filter_level", PROPERTY_HINT_RANGE, "1,16,1"));
 	GLOBAL_DEF("rendering/quality/filters/use_nearest_mipmap_filter", false);
 
 	GLOBAL_DEF("rendering/quality/skinning/software_skinning_fallback", true);


### PR DESCRIPTION
Fixes #45641

I made this change by copying the relevant code from the GLES3 backend to the GLES2 backend. In so doing, I noticed a strange line, line 8358 of rasterizer_storage_gles3.cpp:

`config.use_anisotropic_filter = config.extensions.has("rendering/quality/filters/anisotropic_filter_level");`

The strange thing about it is, as far as I can tell, this variable soon gets overwritten without having been used. Still, I copied this line even though I'm not sure it has any effect.

(EDIT: I have discussed this line with other devs and removed it from the GLES2 backend. It's still in the GLES3 backend, though.)

(EDIT: It's gone from both backends now.)