### PR TITLE
Fix node rename dialog no longer pops up inside of the viewport

### DIFF
--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -285,7 +285,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	// ---- Dialog related
 
-	set_min_size(Size2(383, 0));
+	set_min_size(Size2(0, 0));
 	get_ok_button()->set_text(TTR("Rename"));
 	Button *but_reset = add_button(TTR("Reset"));
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixed Bug: 
When renaming or right-clicking a node, the dialog pops up somewhere else in the editor (In my case in the top-left of the viewport). This is now fixed, and both the rename dialog and the right-click context menu pop up where they should.