### PR TITLE
Make audio bus channels' peak volume consistent

### DIFF
--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -47,6 +47,9 @@ static inline float undenormalise(volatile float f) {
 	return (v.i & 0x7f800000) < 0x08000000 ? 0.0f : f;
 }
 
+static const float AUDIO_PEAK_OFFSET = 0.0000000001f;
+static const float AUDIO_MIN_PEAK_DB = -200.0f; // linear2db(AUDIO_PEAK_OFFSET)
+
 struct AudioFrame {
 	//left and right samples
 	float l, r;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -401,6 +401,7 @@ void AudioServer::_mix_step() {
 
 		for (int k = 0; k < bus->channels.size(); k++) {
 			if (!bus->channels[k].active) {
+				bus->channels.write[k].peak_volume = AudioFrame(AUDIO_MIN_PEAK_DB, AUDIO_MIN_PEAK_DB);
 				continue;
 			}
 
@@ -434,7 +435,7 @@ void AudioServer::_mix_step() {
 				}
 			}
 
-			bus->channels.write[k].peak_volume = AudioFrame(Math::linear2db(peak.l + 0.0000000001), Math::linear2db(peak.r + 0.0000000001));
+			bus->channels.write[k].peak_volume = AudioFrame(Math::linear2db(peak.l + AUDIO_PEAK_OFFSET), Math::linear2db(peak.r + AUDIO_PEAK_OFFSET));
 
 			if (!bus->channels[k].used) {
 				//see if any audio is contained, because channel was not used

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -199,7 +199,7 @@ private:
 				last_mix_with_audio = 0;
 				used = false;
 				active = false;
-				peak_volume = AudioFrame(0, 0);
+				peak_volume = AudioFrame(AUDIO_MIN_PEAK_DB, AUDIO_MIN_PEAK_DB);
 			}
 		};
 


### PR DESCRIPTION
Supersedes #38553. *Bugsquad edit: Closes #38553*

Fixes #37562.

In the bug report, the OP states that silent channels should return -INF as their peak. That may have a point, but Godot is using -200 dB as the minimum possible dB value. Therefore using -200 dB for both audio frames of value 0 and silent channels makes for the best consistency.

You can always map -200 dB to -INF in your scripts, or even query `is_bus_channel_active()` to know if the -200 is due to a short period of silence in the bus or because of no activity on it.