### PR TITLE
[3.2] [iOS] Earlier plugin initialization

### DIFF
--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -114,6 +114,8 @@ int OSIPhone::get_current_video_driver() const {
 }
 
 void OSIPhone::start() {
+	godot_ios_plugins_initialize();
+
 	Main::start();
 
 	if (joypad_iphone) {
@@ -195,8 +197,6 @@ MainLoop *OSIPhone::get_main_loop() const {
 };
 
 void OSIPhone::set_main_loop(MainLoop *p_main_loop) {
-	godot_ios_plugins_initialize();
-
 	main_loop = p_main_loop;
 
 	if (main_loop) {


### PR DESCRIPTION
Moved plugin initialization code to perform before `Main::setup()` call.
This allows to have access to plugins in scripts `_init` method.
