### PR TITLE
[4.0] [iOS] Earlier plugin initialization

### DIFF
--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -144,8 +144,6 @@ void OSIPhone::deinitialize_modules() {
 }
 
 void OSIPhone::set_main_loop(MainLoop *p_main_loop) {
-	godot_ios_plugins_initialize();
-
 	main_loop = p_main_loop;
 
 	if (main_loop) {
@@ -179,6 +177,8 @@ bool OSIPhone::iterate() {
 }
 
 void OSIPhone::start() {
+	godot_ios_plugins_initialize();
+
 	Main::start();
 
 	if (joypad_iphone) {


### PR DESCRIPTION
Moved plugin initialization code to perform before `Main::setup()` call.
This allows to have access to plugins in scripts `_init` method.

Same as #45664 for `master`