### PR TITLE
[HTML5] Fix mouse_mode and fullscreen detection.

### DIFF
--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -93,7 +93,7 @@ EM_BOOL DisplayServerJavaScript::fullscreen_change_callback(int p_event_type, co
 	DisplayServerJavaScript *display = get_singleton();
 	// Empty ID is canvas.
 	String target_id = String::utf8(p_event->id);
-	if (target_id.is_empty() || target_id == String::utf8(display->canvas_id)) {
+	if (target_id.is_empty() || target_id == String::utf8(&(display->canvas_id[1]))) {
 		// This event property is the only reliable data on
 		// browser fullscreen state.
 		if (p_event->isFullscreen) {
@@ -455,7 +455,7 @@ DisplayServer::MouseMode DisplayServerJavaScript::mouse_get_mode() const {
 
 	EmscriptenPointerlockChangeEvent ev;
 	emscripten_get_pointerlock_status(&ev);
-	return (ev.isActive && String::utf8(ev.id) == String::utf8(canvas_id)) ? MOUSE_MODE_CAPTURED : MOUSE_MODE_VISIBLE;
+	return (ev.isActive && String::utf8(ev.id) == String::utf8(&canvas_id[1])) ? MOUSE_MODE_CAPTURED : MOUSE_MODE_VISIBLE;
 }
 
 // Wheel


### PR DESCRIPTION
The canvas_id is `#`-prefixed to work with emscripten as a CSS selector.
When comparing to an event target ID (e.g. when checking if the canvas is fullscreen, or is locking the mouse) we need to skip the first char (the hash).

Fixes #44957.
Fixes #44755.

I'll make a separate PR for `3.2`.