### PR TITLE
[3.2] Added atom checks to X11 XChangeProperty and XGetWindowProperty

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -385,14 +385,18 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 		hints.flags = 2;
 		hints.decorations = 0;
 		property = XInternAtom(x11_display, "_MOTIF_WM_HINTS", True);
-		XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+		if (property != None) {
+			XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+		}
 	}
 
 	// make PID known to X11
 	{
 		const long pid = this->get_process_id();
 		Atom net_wm_pid = XInternAtom(x11_display, "_NET_WM_PID", False);
-		XChangeProperty(x11_display, x11_window, net_wm_pid, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&pid, 1);
+		if (net_wm_pid != None) {
+			XChangeProperty(x11_display, x11_window, net_wm_pid, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&pid, 1);
+		}
 	}
 
 	// disable resizable window
@@ -584,7 +588,9 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	//Set Xdnd (drag & drop) support
 	Atom XdndAware = XInternAtom(x11_display, "XdndAware", False);
 	Atom version = 5;
-	XChangeProperty(x11_display, x11_window, XdndAware, XA_ATOM, 32, PropModeReplace, (unsigned char *)&version, 1);
+	if (XdndAware != None) {
+		XChangeProperty(x11_display, x11_window, XdndAware, XA_ATOM, 32, PropModeReplace, (unsigned char *)&version, 1);
+	}
 
 	xdnd_enter = XInternAtom(x11_display, "XdndEnter", False);
 	xdnd_position = XInternAtom(x11_display, "XdndPosition", False);
@@ -998,7 +1004,9 @@ void OS_X11::set_window_title(const String &p_title) {
 
 	Atom _net_wm_name = XInternAtom(x11_display, "_NET_WM_NAME", false);
 	Atom utf8_string = XInternAtom(x11_display, "UTF8_STRING", false);
-	XChangeProperty(x11_display, x11_window, _net_wm_name, utf8_string, 8, PropModeReplace, (unsigned char *)p_title.utf8().get_data(), p_title.utf8().length());
+	if (_net_wm_name != None && utf8_string != None) {
+		XChangeProperty(x11_display, x11_window, _net_wm_name, utf8_string, 8, PropModeReplace, (unsigned char *)p_title.utf8().get_data(), p_title.utf8().length());
+	}
 }
 
 void OS_X11::set_window_mouse_passthrough(const PoolVector2Array &p_region) {
@@ -1046,7 +1054,9 @@ void OS_X11::set_wm_fullscreen(bool p_enabled) {
 		hints.flags = 2;
 		hints.decorations = 0;
 		property = XInternAtom(x11_display, "_MOTIF_WM_HINTS", True);
-		XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+		if (property != None) {
+			XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+		}
 	}
 
 	if (p_enabled && !is_window_resizable()) {
@@ -1078,7 +1088,9 @@ void OS_X11::set_wm_fullscreen(bool p_enabled) {
 	// set bypass compositor hint
 	Atom bypass_compositor = XInternAtom(x11_display, "_NET_WM_BYPASS_COMPOSITOR", False);
 	unsigned long compositing_disable_on = p_enabled ? 1 : 0;
-	XChangeProperty(x11_display, x11_window, bypass_compositor, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&compositing_disable_on, 1);
+	if (bypass_compositor != None) {
+		XChangeProperty(x11_display, x11_window, bypass_compositor, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&compositing_disable_on, 1);
+	}
 
 	XFlush(x11_display);
 
@@ -1115,7 +1127,9 @@ void OS_X11::set_wm_fullscreen(bool p_enabled) {
 		hints.flags = 2;
 		hints.decorations = current_videomode.borderless_window ? 0 : 1;
 		property = XInternAtom(x11_display, "_MOTIF_WM_HINTS", True);
-		XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+		if (property != None) {
+			XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+		}
 	}
 }
 
@@ -1551,6 +1565,9 @@ void OS_X11::set_window_minimized(bool p_enabled) {
 bool OS_X11::is_window_minimized() const {
 	// Using ICCCM -- Inter-Client Communication Conventions Manual
 	Atom property = XInternAtom(x11_display, "WM_STATE", True);
+	if (property == None) {
+		return false;
+	}
 	Atom type;
 	int format;
 	unsigned long len;
@@ -1629,6 +1646,10 @@ bool OS_X11::window_maximize_check(const char *p_atom_name) const {
 	unsigned long remaining;
 	unsigned char *data = NULL;
 	bool retval = false;
+
+	if (property == None) {
+		return false;
+	}
 
 	int result = XGetWindowProperty(
 			x11_display,
@@ -1715,7 +1736,9 @@ void OS_X11::set_borderless_window(bool p_borderless) {
 	hints.flags = 2;
 	hints.decorations = current_videomode.borderless_window ? 0 : 1;
 	property = XInternAtom(x11_display, "_MOTIF_WM_HINTS", True);
-	XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+	if (property != None) {
+		XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+	}
 
 	// Preserve window size
 	set_window_size(Size2(current_videomode.width, current_videomode.height));
@@ -2159,17 +2182,19 @@ static Property read_property(Display *p_display, Window p_window, Atom p_proper
 
 	//Keep trying to read the property until there are no
 	//bytes unread.
-	do {
-		if (ret != 0)
-			XFree(ret);
+	if (p_property != None) {
+		do {
+			if (ret != 0)
+				XFree(ret);
 
-		XGetWindowProperty(p_display, p_window, p_property, 0, read_bytes, False, AnyPropertyType,
-				&actual_type, &actual_format, &nitems, &bytes_after,
-				&ret);
+			XGetWindowProperty(p_display, p_window, p_property, 0, read_bytes, False, AnyPropertyType,
+					&actual_type, &actual_format, &nitems, &bytes_after,
+					&ret);
 
-		read_bytes *= 2;
+			read_bytes *= 2;
 
-	} while (bytes_after != 0);
+		} while (bytes_after != 0);
+	}
 
 	Property p = { ret, actual_format, (int)nitems, actual_type };
 
@@ -3564,7 +3589,9 @@ void OS_X11::set_icon(const Ref<Image> &p_icon) {
 				pr += 4;
 			}
 
-			XChangeProperty(x11_display, x11_window, net_wm_icon, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)pd.ptr(), pd.size());
+			if (net_wm_icon != None) {
+				XChangeProperty(x11_display, x11_window, net_wm_icon, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)pd.ptr(), pd.size());
+			}
 
 			if (!g_set_icon_error)
 				break;


### PR DESCRIPTION
Should be the same as https://github.com/godotengine/godot/pull/43545 but for 3.2.