### PR TITLE
[4.0] [iOS] Additional 'linker_flags' plugin parameter

### DIFF
--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -1351,6 +1351,8 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 	Vector<String> added_embedded_dependenciy_names;
 	HashMap<String, String> plist_values;
 
+	Set<String> plugin_linker_flags;
+
 	Error err;
 
 	for (int i = 0; i < enabled_plugins.size(); i++) {
@@ -1415,6 +1417,13 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 			}
 
 			p_config_data.capabilities.push_back(capability);
+		}
+
+		// Linker flags
+		// Checking duplicates
+		for (int j = 0; j < plugin.linker_flags.size(); j++) {
+			String linker_flag = plugin.linker_flags[j];
+			plugin_linker_flags.insert(linker_flag);
 		}
 
 		// Plist
@@ -1497,6 +1506,27 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 
 		p_config_data.cpp_code += plugin_cpp_code.format(plugin_format, "$_");
 	}
+
+	// Update Linker Flag Values
+	{
+		String result_linker_flags = " ";
+		for (Set<String>::Element *E = plugin_linker_flags.front(); E; E = E->next()) {
+			const String &flag = E->get();
+
+			if (flag.length() == 0) {
+				continue;
+			}
+
+			if (result_linker_flags.length() > 0) {
+				result_linker_flags += ' ';
+			}
+
+			result_linker_flags += flag;
+		}
+		result_linker_flags = result_linker_flags.replace("\"", "\\\"");
+		p_config_data.linker_flags += result_linker_flags;
+	}
+
 	return OK;
 }
 

--- a/platform/iphone/plugin/godot_plugin_config.h
+++ b/platform/iphone/plugin/godot_plugin_config.h
@@ -66,6 +66,7 @@ struct PluginConfigIOS {
 	inline static const char *DEPENDENCIES_SYSTEM_KEY = "system";
 	inline static const char *DEPENDENCIES_CAPABILITIES_KEY = "capabilities";
 	inline static const char *DEPENDENCIES_FILES_KEY = "files";
+	inline static const char *DEPENDENCIES_LINKER_FLAGS = "linker_flags";
 
 	inline static const char *PLIST_SECTION = "plist";
 
@@ -88,6 +89,8 @@ struct PluginConfigIOS {
 
 	Vector<String> files_to_copy;
 	Vector<String> capabilities;
+
+	Vector<String> linker_flags;
 
 	// Optional plist section
 	// Supports only string types for now
@@ -260,6 +263,8 @@ static inline PluginConfigIOS load_plugin_config(Ref<ConfigFile> config_file, co
 		plugin_config.files_to_copy = resolve_local_dependencies(config_base_dir, files);
 
 		plugin_config.capabilities = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_CAPABILITIES_KEY, Vector<String>());
+
+		plugin_config.linker_flags = config_file->get_value(PluginConfigIOS::DEPENDENCIES_SECTION, PluginConfigIOS::DEPENDENCIES_LINKER_FLAGS, Vector<String>());
 	}
 
 	if (config_file->has_section(PluginConfigIOS::PLIST_SECTION)) {


### PR DESCRIPTION
Same as #45685 for `master` branch.

> 
> Extends iOS plugin .gdip config files to provide linker flags values with linker_flags field.
> This allows to specify specific linker flags that plugin might require to function properly.
> For example .xcframework plugins that extend GodotAppDelegate in any way require -ObjC flag to be added.