### PR TITLE
[3.2] [iOS] Native loading screen implementation

### DIFF
--- a/platform/iphone/godot_view.h
+++ b/platform/iphone/godot_view.h
@@ -37,12 +37,20 @@
 
 class String;
 
+@class GodotView;
 @protocol DisplayLayer;
 @protocol GodotViewRendererProtocol;
+
+@protocol GodotViewDelegate
+
+- (BOOL)godotViewFinishedSetup:(GodotView *)view;
+
+@end
 
 @interface GodotView : UIView
 
 @property(assign, nonatomic) id<GodotViewRendererProtocol> renderer;
+@property(assign, nonatomic) id<GodotViewDelegate> delegate;
 
 @property(assign, readonly, nonatomic) BOOL isActive;
 

--- a/platform/iphone/godot_view.mm
+++ b/platform/iphone/godot_view.mm
@@ -113,6 +113,7 @@ static const int max_touches = 8;
 	[self stopRendering];
 
 	self.renderer = nil;
+	self.delegate = nil;
 
 	if (self.renderingLayer) {
 		[self.renderingLayer removeFromSuperlayer];
@@ -233,6 +234,14 @@ static const int max_touches = 8;
 
 	if ([self.renderer setupView:self]) {
 		return;
+	}
+
+	if (self.delegate) {
+		BOOL delegateFinishedSetup = [self.delegate godotViewFinishedSetup:self];
+
+		if (!delegateFinishedSetup) {
+			return;
+		}
 	}
 
 	[self handleMotion];

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -37,11 +37,13 @@
 #import "native_video_view.h"
 #include "os_iphone.h"
 
-@interface ViewController ()
+@interface ViewController () <GodotViewDelegate>
 
 @property(strong, nonatomic) GodotViewRenderer *renderer;
 @property(strong, nonatomic) GodotNativeVideoView *videoView;
 @property(strong, nonatomic) GodotKeyboardInputView *keyboardView;
+
+@property(strong, nonatomic) UIView *godotLoadingOverlay;
 
 @end
 
@@ -61,6 +63,7 @@
 	self.view = view;
 
 	view.renderer = self.renderer;
+	view.delegate = self;
 }
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
@@ -96,6 +99,7 @@
 	[super viewDidLoad];
 
 	[self observeKeyboard];
+	[self displayLoadingOverlay];
 
 	if (@available(iOS 11.0, *)) {
 		[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
@@ -120,6 +124,31 @@
 				 object:nil];
 }
 
+- (void)displayLoadingOverlay {
+	NSBundle *bundle = [NSBundle mainBundle];
+	NSString *storyboardName = @"Launch Screen";
+
+	if ([bundle pathForResource:storyboardName ofType:@"storyboardc"] == nil) {
+		return;
+	}
+
+	UIStoryboard *launchStoryboard = [UIStoryboard storyboardWithName:storyboardName bundle:bundle];
+
+	UIViewController *controller = [launchStoryboard instantiateInitialViewController];
+	self.godotLoadingOverlay = controller.view;
+	self.godotLoadingOverlay.frame = self.view.bounds;
+	self.godotLoadingOverlay.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+
+	[self.view addSubview:self.godotLoadingOverlay];
+}
+
+- (BOOL)godotViewFinishedSetup:(GodotView *)view {
+	[self.godotLoadingOverlay removeFromSuperview];
+	self.godotLoadingOverlay = nil;
+
+	return YES;
+}
+
 - (void)dealloc {
 	[self.videoView stopVideo];
 	self.videoView = nil;
@@ -127,6 +156,11 @@
 	self.keyboardView = nil;
 
 	self.renderer = nil;
+
+	if (self.godotLoadingOverlay) {
+		[self.godotLoadingOverlay removeFromSuperview];
+		self.godotLoadingOverlay = nil;
+	}
 
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 }


### PR DESCRIPTION
Same as #40766 for `3.2`

> If storyboard named Launch Screen is present it will be used as overlay while Main performs setup and setup2.

Removes the black screen that appears after initial launch screen disappears and before game starts.