### PR TITLE
[3.2] [GLES2] Fix binding 3D Transforms to mat4 uniforms

### DIFF
--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -827,27 +827,49 @@ void ShaderGLES2::use_material(void *p_material) {
 
 				case ShaderLanguage::TYPE_MAT4: {
 
-					Transform2D tr = V->get();
-					GLfloat matrix[16] = { /* build a 16x16 matrix */
-						tr.elements[0][0],
-						tr.elements[0][1],
-						0,
-						0,
-						tr.elements[1][0],
-						tr.elements[1][1],
-						0,
-						0,
-						0,
-						0,
-						1,
-						0,
-						tr.elements[2][0],
-						tr.elements[2][1],
-						0,
-						1
-					};
-
-					glUniformMatrix4fv(location, 1, GL_FALSE, matrix);
+					if (V->get().get_type() == Variant::TRANSFORM) {
+						Transform tr = V->get();
+						GLfloat matrix[16] = { /* build a 16x16 matrix */
+							tr.basis.elements[0][0],
+							tr.basis.elements[1][0],
+							tr.basis.elements[2][0],
+							0,
+							tr.basis.elements[0][1],
+							tr.basis.elements[1][1],
+							tr.basis.elements[2][1],
+							0,
+							tr.basis.elements[0][2],
+							tr.basis.elements[1][2],
+							tr.basis.elements[2][2],
+							0,
+							tr.origin.x,
+							tr.origin.y,
+							tr.origin.z,
+							1
+						};
+						glUniformMatrix4fv(location, 1, GL_FALSE, matrix);
+					} else {
+						Transform2D tr = V->get();
+						GLfloat matrix[16] = { /* build a 16x16 matrix */
+							tr.elements[0][0],
+							tr.elements[0][1],
+							0,
+							0,
+							tr.elements[1][0],
+							tr.elements[1][1],
+							0,
+							0,
+							0,
+							0,
+							1,
+							0,
+							tr.elements[2][0],
+							tr.elements[2][1],
+							0,
+							1
+						};
+						glUniformMatrix4fv(location, 1, GL_FALSE, matrix);
+					}
 
 				} break;
 


### PR DESCRIPTION
In the current 3.2 branch, the GLES2 shader binding code assumes that any mat4 uniform is bound to a Transform2D Variant. This PR updates the logic to match GLES3 shader binding by checking the Variant type before binding as a Transform or Transform2D.
