### PR TITLE
Improved PopupMenu visuals. Removed x-y margin, made it 'padding' instead

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -710,9 +710,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// PopupMenu
 	const int popup_menu_margin_size = default_margin_size * 1.5 * EDSCALE;
 	Ref<StyleBoxFlat> style_popup_menu = style_popup->duplicate();
-	style_popup_menu->set_default_margin(SIDE_LEFT, popup_menu_margin_size);
+	// Use 1 pixel for the sides, since if 0 is used, the highlight of hovered items is drawn
+	// on top of the popup border. This causes a 'gap' in the panel border when an item is highlighted,
+	// and it looks weird. 1px solves this.
+	style_popup_menu->set_default_margin(SIDE_LEFT, 1 * EDSCALE);
 	style_popup_menu->set_default_margin(SIDE_TOP, popup_menu_margin_size);
-	style_popup_menu->set_default_margin(SIDE_RIGHT, popup_menu_margin_size);
+	style_popup_menu->set_default_margin(SIDE_RIGHT, 1 * EDSCALE);
 	style_popup_menu->set_default_margin(SIDE_BOTTOM, popup_menu_margin_size);
 
 	theme->set_stylebox("panel", "PopupMenu", style_popup_menu);
@@ -734,7 +737,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("visibility_hidden", "PopupMenu", theme->get_icon("GuiVisibilityHidden", "EditorIcons"));
 	theme->set_icon("visibility_visible", "PopupMenu", theme->get_icon("GuiVisibilityVisible", "EditorIcons"));
 	theme->set_icon("visibility_xray", "PopupMenu", theme->get_icon("GuiVisibilityXray", "EditorIcons"));
+
 	theme->set_constant("vseparation", "PopupMenu", (extra_spacing + default_margin_size + 1) * EDSCALE);
+	theme->set_constant("item_start_padding", "PopupMenu", popup_menu_margin_size * EDSCALE);
+	theme->set_constant("item_end_padding", "PopupMenu", popup_menu_margin_size * EDSCALE);
 
 	for (int i = 0; i < 16; i++) {
 		Color si_base_color = accent_color;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -89,7 +89,9 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 		minsize.height += size.height;
 	}
 
-	minsize.width += max_w + icon_w + accel_max_w;
+	int item_side_padding = get_theme_constant("item_start_padding") + get_theme_constant("item_end_padding");
+	minsize.width += max_w + icon_w + accel_max_w + item_side_padding;
+
 	if (has_check) {
 		minsize.width += check_w;
 	}
@@ -451,6 +453,10 @@ void PopupMenu::_draw_items() {
 	margin_size.width = margin_container->get_theme_constant("margin_right") + margin_container->get_theme_constant("margin_left");
 	margin_size.height = margin_container->get_theme_constant("margin_top") + margin_container->get_theme_constant("margin_bottom");
 
+	// Space between the item content and the sides of popup menu.
+	int item_start_padding = get_theme_constant("item_start_padding");
+	int item_end_padding = get_theme_constant("item_end_padding");
+
 	bool rtl = control->is_layout_rtl();
 	Ref<StyleBox> style = get_theme_stylebox("panel");
 	Ref<StyleBox> hover = get_theme_stylebox("hover");
@@ -537,11 +543,14 @@ void PopupMenu::_draw_items() {
 					labeled_separator_right->draw(ci, Rect2(Point2(text_right, item_ofs.y + Math::floor((h - sep_h) / 2.0)), Size2(MAX(0, display_width - text_right), sep_h)));
 				}
 			} else {
-				separator->draw(ci, Rect2(item_ofs + Point2(0, Math::floor((h - sep_h) / 2.0)), Size2(display_width, sep_h)));
+				separator->draw(ci, Rect2(item_ofs, Size2(display_width, sep_h)));
 			}
 		}
 
 		Color icon_color(1, 1, 1, items[i].disabled ? 0.5 : 1);
+
+		// For non-separator items, add some padding for the content.
+		item_ofs.x += item_start_padding;
 
 		// Checkboxes
 		if (items[i].checkable_type) {
@@ -565,9 +574,9 @@ void PopupMenu::_draw_items() {
 		// Submenu arrow on right hand side
 		if (items[i].submenu != "") {
 			if (rtl) {
-				submenu->draw(ci, Point2(scroll_width + style->get_margin(SIDE_LEFT), item_ofs.y + Math::floor(h - submenu->get_height()) / 2), icon_color);
+				submenu->draw(ci, Point2(scroll_width + style->get_margin(SIDE_LEFT) + item_end_padding, item_ofs.y + Math::floor(h - submenu->get_height()) / 2), icon_color);
 			} else {
-				submenu->draw(ci, Point2(display_width - style->get_margin(SIDE_RIGHT) - submenu->get_width(), item_ofs.y + Math::floor(h - submenu->get_height()) / 2), icon_color);
+				submenu->draw(ci, Point2(display_width - style->get_margin(SIDE_RIGHT) - submenu->get_width() - item_end_padding, item_ofs.y + Math::floor(h - submenu->get_height()) / 2), icon_color);
 			}
 		}
 
@@ -603,9 +612,9 @@ void PopupMenu::_draw_items() {
 		// Accelerator / Shortcut
 		if (items[i].accel || (items[i].shortcut.is_valid() && items[i].shortcut->is_valid())) {
 			if (rtl) {
-				item_ofs.x = scroll_width + style->get_margin(SIDE_LEFT);
+				item_ofs.x = scroll_width + style->get_margin(SIDE_LEFT) + item_end_padding;
 			} else {
-				item_ofs.x = display_width - style->get_margin(SIDE_RIGHT) - items[i].accel_text_buf->get_size().x;
+				item_ofs.x = display_width - style->get_margin(SIDE_RIGHT) - items[i].accel_text_buf->get_size().x - item_end_padding;
 			}
 			Vector2 text_pos = item_ofs + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
 			if (outline_size > 0 && font_outline_color.a > 0) {

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -644,6 +644,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("hseparation", "PopupMenu", 4 * scale);
 	theme->set_constant("vseparation", "PopupMenu", 4 * scale);
 	theme->set_constant("outline_size", "PopupMenu", 0);
+	theme->set_constant("item_start_padding", "PopupMenu", 2 * scale);
+	theme->set_constant("item_end_padding", "PopupMenu", 2 * scale);
 
 	// GraphNode
 


### PR DESCRIPTION
Improved look as per discussion in #45607
Helps modernise the UI. If you take a look, most applications I have tested have a margin on top and bottom, and little/none on the sides. The item highlight goes all the way across, and there is some padding on either side.

**Before:**
![image](https://user-images.githubusercontent.com/41730826/106896607-85c6db00-673d-11eb-8568-3b8775fb5b03.png)

**After:**
![image](https://user-images.githubusercontent.com/41730826/106897590-dc80e480-673e-11eb-96b6-30b5c74eaa7d.png)
