### PR TITLE
[HTML5] Better editor persistent folders, automatically open zip import popup

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -566,6 +566,7 @@ public:
 	AABB mesh_get_custom_aabb(RID p_mesh) const override { return AABB(); }
 
 	AABB mesh_get_aabb(RID p_mesh, RID p_skeleton = RID()) override { return AABB(); }
+	void mesh_set_shadow_mesh(RID p_mesh, RID p_shadow_mesh) override {}
 	void mesh_clear(RID p_mesh) override {}
 
 	/* MULTIMESH API */

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2281,6 +2281,11 @@ void ProjectManager::_install_project(const String &p_zip_path, const String &p_
 }
 
 void ProjectManager::_files_dropped(PackedStringArray p_files, int p_screen) {
+	if (p_files.size() == 1 && p_files[0].ends_with(".zip")) {
+		const String file = p_files[0].get_file();
+		_install_project(p_files[0], file.substr(0, file.length() - 4).capitalize());
+		return;
+	}
 	Set<String> folders_set;
 	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	for (int i = 0; i < p_files.size(); i++) {

--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -326,7 +326,7 @@
 
 		function startEditor(zip) {
 			const INDETERMINATE_STATUS_STEP_MS = 100;
-			const persistentPaths = ['/home/web_user/.config', '/home/web_user/.cache', '/home/web_user/projects'];
+			const persistentPaths = ['/home/web_user/'];
 
 			var editorCanvas = document.getElementById('editor-canvas');
 			var gameCanvas = document.getElementById('game-canvas');
@@ -493,11 +493,11 @@
 				engine.setUnloadAfterInit(false); // Don't want to reload when starting game.
 				engine.init('godot.tools').then(function() {
 					if (zip) {
-						engine.copyToFS("/home/web_user/preload.zip", zip);
+						engine.copyToFS("/tmp/preload.zip", zip);
 					}
 					try {
 						// Avoid user creating project in the persistent root folder.
-						engine.copyToFS("/home/web_user/projects/keep", new Uint8Array());
+						engine.copyToFS("/home/web_user/keep", new Uint8Array());
 					} catch(e) {
 						// File exists
 					}

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -88,6 +88,13 @@ extern EMSCRIPTEN_KEEPALIVE int godot_js_main(int argc, char *argv[]) {
 
 	Main::start();
 	os->get_main_loop()->initialize();
+#ifdef TOOLS_ENABLED
+	if (Main::is_project_manager() && FileAccess::exists("/tmp/preload.zip")) {
+		PackedStringArray ps;
+		ps.push_back("/tmp/preload.zip");
+		os->get_main_loop()->emit_signal("files_dropped", ps, -1);
+	}
+#endif
 	emscripten_set_main_loop(main_loop_callback, -1, false);
 	// Immediately run the first iteration.
 	// We are inside an animation frame, we want to immediately draw on the newly setup canvas.


### PR DESCRIPTION
In this PR:

- Usual `RasterizerDummy` sync.
- [Editor] Import zip via drag and drop in project manager (still not working on HTML5 because the file is not used immediately).
  Dropping a single ZIP file in the project manager will now prompt the import dialog.
- [HTML5] Make home (`/home/web_user`) path persistent in editor.
  We used to only persist specific sub-folders of `/home/web_user/` when running the Web Editor. 
  This resulted in bad UX about default project creation path etc.
  This PR makes the whole folder persistent, move the zip preloading to a different folder (to avoid persisting it), and automatically prompt the user to import it if present.

![dropimport](https://user-images.githubusercontent.com/1687918/106899385-96536300-66f5-11eb-8cce-1bd43bac142b.gif)


Fixes #44754 .
**Note**: As mentioned above, only preloading works on HTML5, not drag and drop of the zip file from your file system.