### PR TITLE
Fix "editor/editor_help" shortcut overwriting when restarting editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6265,7 +6265,7 @@ EditorNode::EditorNode() {
 
 	p = help_menu->get_popup();
 	p->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
-	p->add_icon_shortcut(gui_base->get_theme_icon("HelpSearch", "EditorIcons"), ED_SHORTCUT("editor/editor_help", TTR("Search"), KEY_MASK_SHIFT | KEY_F1), HELP_SEARCH);
+	p->add_icon_shortcut(gui_base->get_theme_icon("HelpSearch", "EditorIcons"), ED_SHORTCUT("editor/editor_help", TTR("Search")), HELP_SEARCH);
 	p->add_separator();
 	p->add_icon_shortcut(gui_base->get_theme_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/online_docs", TTR("Online Docs")), HELP_DOCS);
 	p->add_icon_shortcut(gui_base->get_theme_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/q&a", TTR("Q&A")), HELP_QA);


### PR DESCRIPTION
When restarting the editor, the shortcut is constantly reset to <kbd>Shift+F1</kbd>. I looked at the sources, I think the error is obvious:

https://github.com/godotengine/godot/blob/7e14a276da1ab8e7dda4f4f5041056edc1910c25/editor/editor_node.cpp#L6268-L6271

https://github.com/godotengine/godot/blob/7e14a276da1ab8e7dda4f4f5041056edc1910c25/editor/editor_node.cpp#L6840-L6842

The problem is reproduced in 3.2.