### PR TITLE
Improve Project Settings Editor

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -72,17 +72,9 @@ void ProjectSettingsEditor::_setting_edited(const String &p_name) {
 	queue_save();
 }
 
-void ProjectSettingsEditor::_advanced_pressed() {
-	if (advanced->is_pressed()) {
-		_update_advanced_bar();
-		advanced_bar->show();
-		EditorSettings::get_singleton()->set_project_metadata("project_settings", "advanced_mode", true);
-		inspector->set_restrict_to_basic_settings(false);
-	} else {
-		advanced_bar->hide();
-		EditorSettings::get_singleton()->set_project_metadata("project_settings", "advanced_mode", false);
-		inspector->set_restrict_to_basic_settings(true);
-	}
+void ProjectSettingsEditor::_advanced_toggled(bool p_button_pressed) {
+	EditorSettings::get_singleton()->set_project_metadata("project_settings", "advanced_mode", p_button_pressed);
+	inspector->set_restrict_to_basic_settings(!p_button_pressed);
 }
 
 void ProjectSettingsEditor::_setting_selected(const String &p_path) {
@@ -90,12 +82,9 @@ void ProjectSettingsEditor::_setting_selected(const String &p_path) {
 		return;
 	}
 
-	category_box->set_text(inspector->get_current_section());
-	property_box->set_text(p_path);
+	property_box->set_text(inspector->get_current_section() + "/" + p_path);
 
-	if (advanced_bar->is_visible()) {
-		_update_advanced_bar(); // set_text doesn't trigger text_changed
-	}
+	_update_property_box(); // set_text doesn't trigger text_changed
 }
 
 void ProjectSettingsEditor::_add_setting() {
@@ -104,7 +93,7 @@ void ProjectSettingsEditor::_add_setting() {
 	// Initialize the property with the default value for the given type.
 	Callable::CallError ce;
 	Variant value;
-	Variant::construct(Variant::Type(type->get_selected_id()), value, nullptr, 0, ce);
+	Variant::construct(Variant::Type(type_box->get_selected_id()), value, nullptr, 0, ce);
 
 	undo_redo->create_action(TTR("Add Project Setting"));
 	undo_redo->add_do_property(ps, setting, value);
@@ -117,18 +106,13 @@ void ProjectSettingsEditor::_add_setting() {
 	undo_redo->commit_action();
 
 	inspector->set_current_section(setting.get_slice("/", 1));
+	add_button->release_focus();
 }
 
-void ProjectSettingsEditor::_delete_setting(bool p_confirmed) {
+void ProjectSettingsEditor::_delete_setting() {
 	String setting = _get_setting_name();
 	Variant value = ps->get(setting);
 	int order = ps->get_order(setting);
-
-	if (!p_confirmed) {
-		del_confirmation->set_text(vformat(TTR("Are you sure you want to delete '%s'?"), setting));
-		del_confirmation->popup_centered();
-		return;
-	}
 
 	undo_redo->create_action(TTR("Delete Item"));
 
@@ -144,65 +128,84 @@ void ProjectSettingsEditor::_delete_setting(bool p_confirmed) {
 	undo_redo->commit_action();
 
 	property_box->clear();
+	del_button->release_focus();
 }
 
-void ProjectSettingsEditor::_text_field_changed(const String &p_text) {
-	_update_advanced_bar();
+void ProjectSettingsEditor::_property_box_changed(const String &p_text) {
+	_update_property_box();
 }
 
 void ProjectSettingsEditor::_feature_selected(int p_index) {
-	_update_advanced_bar();
+	Vector<String> t = property_box->get_text().strip_edges().split(".", true, 1);
+	const String feature = p_index ? "." + feature_box->get_item_text(p_index) : "";
+	property_box->set_text(t[0] + feature);
+	_update_property_box();
 }
 
-void ProjectSettingsEditor::_update_advanced_bar() {
-	const String property_text = property_box->get_text().strip_edges();
+void ProjectSettingsEditor::_update_property_box() {
+	const String setting = _get_setting_name();
+	const Vector<String> t = setting.split(".", true, 1);
+	const String name = t[0];
+	const String feature = (t.size() == 2) ? t[1] : "";
+	bool feature_invalid = (t.size() == 2) && (t[1] == "");
 
-	String error_msg = "";
-	bool disable_add = true;
-	bool disable_del = true;
+	add_button->set_disabled(true);
+	del_button->set_disabled(true);
 
-	if (!property_box->get_text().is_empty()) {
-		const String setting = _get_setting_name();
-		bool setting_exists = ps->has_setting(setting);
-		if (setting_exists) {
-			error_msg = TTR(" - Cannot add already existing setting.");
-
-			disable_del = ps->is_builtin_setting(setting);
-			if (disable_del) {
-				String msg = TTR(" - Cannot delete built-in setting.");
-				error_msg += (error_msg == "") ? msg : "\n" + msg;
-			}
-		} else {
-			bool bad_category = false; // Allow empty string.
-			Vector<String> cats = category_box->get_text().strip_edges().split("/");
-			for (int i = 0; i < cats.size(); i++) {
-				if (!cats[i].is_valid_identifier()) {
-					bad_category = true;
-					error_msg = TTR(" - Invalid category name.");
-					break;
-				}
-			}
-
-			disable_add = bad_category;
-
-			if (!property_text.is_valid_identifier()) {
-				disable_add = true;
-				String msg = TTR(" - Invalid property name.");
-				error_msg += (error_msg == "") ? msg : "\n" + msg;
+	if (feature != "") {
+		feature_invalid = true;
+		for (int i = 1; i < feature_box->get_item_count(); i++) {
+			if (feature == feature_box->get_item_text(i)) {
+				feature_invalid = false;
+				feature_box->select(i);
+				break;
 			}
 		}
 	}
 
-	add_button->set_disabled(disable_add);
-	del_button->set_disabled(disable_del);
+	if (feature == "" || feature_invalid) {
+		feature_box->select(0);
+	}
+
+	if (property_box->get_text() == "") {
+		return;
+	}
+
+	if (ps->has_setting(setting)) {
+		del_button->set_disabled(ps->is_builtin_setting(setting));
+		_select_type(ps->get_setting(setting).get_type());
+	} else {
+		if (ps->has_setting(name)) {
+			_select_type(ps->get_setting(name).get_type());
+		} else {
+			type_box->select(0);
+		}
+
+		if (feature_invalid) {
+			return;
+		}
+
+		const Vector<String> names = name.split("/");
+		for (int i = 0; i < names.size(); i++) {
+			if (!names[i].is_valid_identifier()) {
+				return;
+			}
+		}
+
+		add_button->set_disabled(false);
+	}
+}
+
+void ProjectSettingsEditor::_select_type(Variant::Type p_type) {
+	type_box->select(type_box->get_item_index(p_type));
 }
 
 String ProjectSettingsEditor::_get_setting_name() const {
-	const String cat = category_box->get_text();
-	const String name = (cat.is_empty() ? "global" : cat.strip_edges()).plus_file(property_box->get_text().strip_edges());
-	const String feature = feature_override->get_item_text(feature_override->get_selected());
-
-	return (feature == "") ? name : (name + "." + feature);
+	String name = property_box->get_text().strip_edges();
+	if (name.find("/") == -1) {
+		name = "global/" + name;
+	}
+	return name;
 }
 
 void ProjectSettingsEditor::_add_feature_overrides() {
@@ -248,11 +251,11 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 		}
 	}
 
-	feature_override->clear();
-	feature_override->add_item("", 0); // So it is always on top.
+	feature_box->clear();
+	feature_box->add_item(TTR("(All)"), 0); // So it is always on top.
 	int id = 1;
 	for (Set<String>::Element *E = presets.front(); E; E = E->next()) {
-		feature_override->add_item(E->get(), id++);
+		feature_box->add_item(E->get(), id++);
 	}
 }
 
@@ -480,9 +483,6 @@ void ProjectSettingsEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			inspector->edit(ps);
 
-			add_button->set_icon(get_theme_icon("Add", "EditorIcons"));
-			del_button->set_icon(get_theme_icon("Remove", "EditorIcons"));
-
 			search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
 			search_box->set_clear_button_enabled(true);
 
@@ -525,87 +525,56 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	general_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_container->add_child(general_editor);
 
-	VBoxContainer *header = memnew(VBoxContainer);
-	header->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	HBoxContainer *search_bar = memnew(HBoxContainer);
+	general_editor->add_child(search_bar);
+
+	search_box = memnew(LineEdit);
+	search_box->set_placeholder(TTR("Filter Settings"));
+	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_bar->add_child(search_box);
+
+	advanced = memnew(CheckButton);
+	advanced->set_text(TTR("Advanced Settings"));
+	advanced->connect("toggled", callable_mp(this, &ProjectSettingsEditor::_advanced_toggled));
+	search_bar->add_child(advanced);
+
+	HBoxContainer *header = memnew(HBoxContainer);
 	general_editor->add_child(header);
 
-	{
-		// Search bar.
-		search_bar = memnew(HBoxContainer);
-		search_bar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		header->add_child(search_bar);
+	property_box = memnew(LineEdit);
+	property_box->set_placeholder(TTR("Select a setting or type its name"));
+	property_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	property_box->connect("text_changed", callable_mp(this, &ProjectSettingsEditor::_property_box_changed));
+	header->add_child(property_box);
 
-		search_box = memnew(LineEdit);
-		search_box->set_placeholder(TTR("Search"));
-		search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		search_bar->add_child(search_box);
+	feature_box = memnew(OptionButton);
+	feature_box->set_custom_minimum_size(Size2(120, 0) * EDSCALE);
+	feature_box->connect("item_selected", callable_mp(this, &ProjectSettingsEditor::_feature_selected));
+	header->add_child(feature_box);
 
-		advanced = memnew(CheckButton);
-		advanced->set_text(TTR("Advanced Settings"));
-		advanced->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_advanced_pressed));
-		search_bar->add_child(advanced);
-	}
+	type_box = memnew(OptionButton);
+	type_box->set_custom_minimum_size(Size2(120, 0) * EDSCALE);
+	header->add_child(type_box);
 
-	{
-		// Advanced bar.
-		advanced_bar = memnew(HBoxContainer);
-		advanced_bar->hide();
-		header->add_child(advanced_bar);
-
-		HBoxContainer *hbc = advanced_bar;
-		hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-
-		category_box = memnew(LineEdit);
-		category_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		category_box->connect("text_changed", callable_mp(this, &ProjectSettingsEditor::_text_field_changed));
-		category_box->set_placeholder(TTR("Category"));
-		hbc->add_child(category_box);
-
-		Label *l = memnew(Label);
-		l->set_text(" / ");
-		hbc->add_child(l);
-
-		property_box = memnew(LineEdit);
-		property_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		property_box->set_placeholder(TTR("Property"));
-		property_box->connect("text_changed", callable_mp(this, &ProjectSettingsEditor::_text_field_changed));
-		hbc->add_child(property_box);
-
-		l = memnew(Label);
-		l->set_text(TTR("Type:"));
-		hbc->add_child(l);
-
-		type = memnew(OptionButton);
-		type->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
-		hbc->add_child(type);
-
-		for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-			// There's no point in adding Nil types, and Object types
-			// can't be serialized correctly in the project settings.
-			if (i != Variant::NIL && i != Variant::OBJECT) {
-				type->add_item(Variant::get_type_name(Variant::Type(i)), i);
-			}
+	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+		// There's no point in adding Nil types, and Object types
+		// can't be serialized correctly in the project settings.
+		if (i != Variant::NIL && i != Variant::OBJECT) {
+			type_box->add_item(Variant::get_type_name(Variant::Type(i)), i);
 		}
-
-		l = memnew(Label);
-		l->set_text(TTR("Feature Override:"));
-		hbc->add_child(l);
-
-		feature_override = memnew(OptionButton);
-		feature_override->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
-		feature_override->connect("item_selected", callable_mp(this, &ProjectSettingsEditor::_feature_selected));
-		hbc->add_child(feature_override);
-
-		add_button = memnew(Button);
-		add_button->set_flat(true);
-		add_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_add_setting));
-		hbc->add_child(add_button);
-
-		del_button = memnew(Button);
-		del_button->set_flat(true);
-		del_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_delete_setting), varray(false));
-		hbc->add_child(del_button);
 	}
+
+	add_button = memnew(Button);
+	add_button->set_text(TTR("Add"));
+	add_button->set_disabled(true);
+	add_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_add_setting));
+	header->add_child(add_button);
+
+	del_button = memnew(Button);
+	del_button->set_text(TTR("Delete"));
+	del_button->set_disabled(true);
+	del_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_delete_setting));
+	header->add_child(del_button);
 
 	inspector = memnew(SectionedInspector);
 	inspector->get_inspector()->set_undo_redo(EditorNode::get_singleton()->get_undo_redo());
@@ -676,10 +645,6 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	timer->set_one_shot(true);
 	add_child(timer);
 
-	del_confirmation = memnew(ConfirmationDialog);
-	del_confirmation->connect("confirmed", callable_mp(this, &ProjectSettingsEditor::_delete_setting), varray(true));
-	add_child(del_confirmation);
-
 	get_ok_button()->set_text(TTR("Close"));
 	set_hide_on_ok(true);
 
@@ -687,7 +652,6 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	if (use_advanced) {
 		advanced->set_pressed(true);
-		advanced_bar->show();
 	}
 
 	inspector->set_restrict_to_basic_settings(!use_advanced);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -51,25 +51,20 @@ class ProjectSettingsEditor : public AcceptDialog {
 
 	TabContainer *tab_container;
 	SectionedInspector *inspector;
+	ActionMapEditor *action_map;
 	LocalizationEditor *localization_editor;
 	EditorAutoloadSettings *autoload_settings;
 	ShaderGlobalsEditor *shaders_global_variables_editor;
 	EditorPluginSettings *plugin_settings;
 
-	ActionMapEditor *action_map;
-	HBoxContainer *search_bar;
 	LineEdit *search_box;
 	CheckButton *advanced;
 
-	HBoxContainer *advanced_bar;
-	LineEdit *category_box;
 	LineEdit *property_box;
+	OptionButton *feature_box;
+	OptionButton *type_box;
 	Button *add_button;
 	Button *del_button;
-	OptionButton *type;
-	OptionButton *feature_override;
-
-	ConfirmationDialog *del_confirmation;
 
 	Label *restart_label;
 	TextureRect *restart_icon;
@@ -80,16 +75,17 @@ class ProjectSettingsEditor : public AcceptDialog {
 	EditorData *data;
 	UndoRedo *undo_redo;
 
-	void _advanced_pressed();
-	void _update_advanced_bar();
-	void _text_field_changed(const String &p_text);
+	void _advanced_toggled(bool p_button_pressed);
+	void _property_box_changed(const String &p_text);
+	void _update_property_box();
 	void _feature_selected(int p_index);
+	void _select_type(Variant::Type p_type);
 
 	String _get_setting_name() const;
 	void _setting_edited(const String &p_name);
 	void _setting_selected(const String &p_path);
 	void _add_setting();
-	void _delete_setting(bool p_confirmed);
+	void _delete_setting();
 
 	void _editor_restart_request();
 	void _editor_restart();


### PR DESCRIPTION
Closes godotengine/godot-proposals#1545.
Closes godotengine/godot-proposals#2452.

---

* The Category and Name fields are merged into one.
* The Feature and Type fields are updated according to the selected setting.
* Delete confirmation deleted, since it is a reversible operation ([comment](https://github.com/godotengine/godot/pull/45716#discussion_r571997450)).
* The interface of the top panel has become more compact and similar to the interface of the top panel of the Input Map tab.
* The field with the name of the setting is not hidden in the advanced mode, so that it can always be quickly copied.
* Fixed several bugs.

---

![](https://user-images.githubusercontent.com/47700418/108626131-ab532480-745f-11eb-8881-0aa4c02639b8.gif)