### PR TITLE
CI: Build full Mono version on Linux, with glue

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -25,7 +25,7 @@ jobs:
       # Install all packages (except scons)
       - name: Configure dependencies
         run: |
-          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
+          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev xvfb \
             libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
 
       # Upload cache on completion and check it out now
@@ -63,6 +63,8 @@ jobs:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
           scons tools=yes target=release_debug module_mono_enabled=yes mono_glue=no
+          xvfb-run ./bin/godot.x11.opt.tools.64.mono --generate-mono-glue modules/mono/glue
+          scons tools=yes target=release_debug module_mono_enabled=yes mono_glue=yes
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -112,6 +112,8 @@ android {
         disable 'MissingTranslation', 'UnusedResources'
     }
 
+    ndkVersion versions.ndkVersion
+
     packagingOptions {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -7,7 +7,8 @@ ext.versions = [
     supportCoreUtils   : '1.0.0',
     kotlinVersion      : '1.4.10',
     v4Support          : '1.0.0',
-    javaVersion        : 1.8
+    javaVersion        : 1.8,
+    ndkVersion         : '21.3.6528147' // Also update 'platform/android/detect.py#get_project_ndk_version()' when this is updated.
 
 ]
 

--- a/platform/android/java/nativeSrcsConfigs/build.gradle
+++ b/platform/android/java/nativeSrcsConfigs/build.gradle
@@ -31,6 +31,8 @@ android {
         }
     }
 
+    ndkVersion versions.ndkVersion
+
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"


### PR DESCRIPTION
This makes the artifacts from the Linux Mono build usable.

\+ includes another cherry-pick for `3.2`.