### PR TITLE
Fix mismatched define in scene_forward.glsl for POSITION override

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward.glsl
@@ -203,7 +203,7 @@ void main() {
 	uv2_interp = uv2_attrib;
 #endif
 
-#ifdef USE_OVERRIDE_POSITION
+#ifdef OVERRIDE_POSITION
 	vec4 position;
 #endif
 
@@ -298,7 +298,7 @@ VERTEX_SHADER_CODE
 
 #endif //MODE_RENDER_DEPTH
 
-#ifdef USE_OVERRIDE_POSITION
+#ifdef OVERRIDE_POSITION
 	gl_Position = position;
 #else
 	gl_Position = projection_matrix * vec4(vertex_interp, 1.0);


### PR DESCRIPTION
Fixes a shader error when position is used:
```
   at: ShaderRD::_compile_variant (servers\rendering\renderer_rd\shader_rd.cpp:338)
ERROR: Failed parse:
ERROR: 0:703: 'position' : undeclared identifier
ERROR: 0:703: '' : compilation terminated
```

You can see in `servers/rendering/renderer_rd/renderer_scene_render_forward.cpp` and `servers/rendering/renderer_rd/shader_compiler_rd.cpp`, the define is named `OVERRIDE_POSITION` but in `scene_forward.glsl`, it is referred to as `USE_OVERRIDE_POSITION`
```cpp
		actions.usage_defines["POSITION"] = "#define OVERRIDE_POSITION\n";

```

