### PR TITLE
[3.2] Bugfix: Update transform of collision shape on NOTIFICATION_PARENTED

### DIFF
--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -83,6 +83,7 @@ void CollisionShape::_notification(int p_what) {
 				if (shape.is_valid()) {
 					parent->shape_owner_add_shape(owner_id, shape);
 				}
+				_update_in_shape_owner();
 			}
 		} break;
 		case NOTIFICATION_ENTER_TREE: {


### PR DESCRIPTION
Fixes godotengine/godot#45694.

This pull requests reverts a change in collision_shape.cpp from f93c2ddc926dd2c25b902a7fd41ee4b4eb15c73c where the _update_in_shape_owner() call got removed from NOTIFICATION_PARENTED handler.
