### PR TITLE
Assorted CPU lightmapper fixes

### DIFF
--- a/scene/3d/baked_lightmap.h
+++ b/scene/3d/baked_lightmap.h
@@ -91,6 +91,7 @@ public:
 	Rect2 get_user_lightmap_uv_rect(int p_user) const;
 	int get_user_instance(int p_user) const;
 	void clear_users();
+	void clear_data();
 
 	virtual RID get_rid() const;
 	BakedLightmapData();


### PR DESCRIPTION
- Fix crash when a ray hits a texel with a UV2 coordinate exactly equal to 1.0. Fixes #45529.
- Take BakedLightmap extents into account. Fixes #45358.
- Clear capture data between bakes. Mentioned in #45574.
- Fix minor issues with seams correction.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
