### PR TITLE
[3.2] Fix used uninitialized warning in os_x11.cpp

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2172,10 +2172,10 @@ struct Property {
 
 static Property read_property(Display *p_display, Window p_window, Atom p_property) {
 
-	Atom actual_type;
-	int actual_format;
-	unsigned long nitems;
-	unsigned long bytes_after;
+	Atom actual_type = None;
+	int actual_format = 0;
+	unsigned long nitems = 0;
+	unsigned long bytes_after = 0;
 	unsigned char *ret = 0;
 
 	int read_bytes = 1024;


### PR DESCRIPTION
#45684 introduced the possibility of variables being used uninitialized:
```
platform/x11/os_x11.cpp|2185|warning: variable 'actual_format' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]|
platform/x11/os_x11.cpp|2199|note: uninitialized use occurs here|
platform/x11/os_x11.cpp|2185|note: remove the 'if' if its condition is always true|
platform/x11/os_x11.cpp|2176|note: initialize the variable 'actual_format' to silence this warning|
platform/x11/os_x11.cpp|2185|warning: variable 'nitems' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]|
platform/x11/os_x11.cpp|2199|note: uninitialized use occurs here|
platform/x11/os_x11.cpp|2185|note: remove the 'if' if its condition is always true|
platform/x11/os_x11.cpp|2177|note: initialize the variable 'nitems' to silence this warning|
platform/x11/os_x11.cpp|2185|warning: variable 'actual_type' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]|
platform/x11/os_x11.cpp|2199|note: uninitialized use occurs here|
platform/x11/os_x11.cpp|2185|note: remove the 'if' if its condition is always true|
platform/x11/os_x11.cpp|2175|note: initialize the variable 'actual_type' to silence this warning|
```
This initializes the variables to `None` and `0` as is done in master:
https://github.com/godotengine/godot/blob/b70836c8edd504e2f3e331ae30cd8d3c3c4b931c/platform/linuxbsd/display_server_x11.cpp#L2107-L2111
