### PR TITLE
[3.2] Fix issue with NVIDIA and axis mapping for joysticks.

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/Joystick.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/Joystick.java
@@ -30,9 +30,10 @@
 
 package org.godotengine.godot.input;
 
-import android.view.InputDevice.MotionRange;
+import android.util.SparseArray;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * POJO class to represent a Joystick input device.
@@ -40,6 +41,12 @@ import java.util.ArrayList;
 class Joystick {
 	int device_id;
 	String name;
-	ArrayList<MotionRange> axes;
-	ArrayList<MotionRange> hats;
+	List<Integer> axes = new ArrayList<Integer>();
+	protected boolean hasAxisHat = false;
+	/*
+	 * Keep track of values so we can prevent flooding the engine with useless events.
+	 */
+	protected final SparseArray axesValues = new SparseArray<Float>(4);
+	protected int hatX;
+	protected int hatY;
 }


### PR DESCRIPTION
Issues addressed:

a) Axis mappings were including virtual mouse axes on NVIDIA Shield TV.

The virtual mouse axes have the same axis numbers as the normal analog stick numbers. This was completely breaking joypad support on NVIDIA Shield TV.

b) Joypads were being tracked in a List with the index in the list being treated as the Godot device id.

If a device were to be removed, any device later in the list would be shifted, potentially causing future events with the shifted joypads to have incorrect IDs according to the Godot engine.

c) Unnecessary events were being sent to the Godot engine.

A check was added (per Joystick) that will prevent sending events for all axes when only a single axis value changed.
A similar check was added for "HATs".

See #45712 and #12696.

This pull request is separate from the one for master because of member name changes which were applied in master in the Java shim files.

*Bugsquad edit: `3.2` version of https://github.com/godotengine/godot/pull/45771.*