### PR TITLE
Improve editor text appearance in (un)zoomed GraphEdit-based editors

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -45,11 +45,18 @@
 	m_name->add_fallback(FontJapanese); \
 	m_name->add_fallback(FontFallback);
 
+// Enable filtering and mipmaps on the editor fonts to improve text appearance
+// in editors that are zoomed in/out without having dedicated fonts to generate.
+// This is the case in GraphEdit-based editors such as the visual script and
+// visual shader editors.
+
 // the custom spacings might only work with Noto Sans
 #define MAKE_DEFAULT_FONT(m_name, m_size)                       \
 	Ref<DynamicFont> m_name;                                    \
 	m_name.instance();                                          \
 	m_name->set_size(m_size);                                   \
+	m_name->set_use_filter(true);                               \
+	m_name->set_use_mipmaps(true);                              \
 	if (CustomFont.is_valid()) {                                \
 		m_name->set_font_data(CustomFont);                      \
 		m_name->add_fallback(DefaultFont);                      \
@@ -64,6 +71,8 @@
 	Ref<DynamicFont> m_name;                                    \
 	m_name.instance();                                          \
 	m_name->set_size(m_size);                                   \
+	m_name->set_use_filter(true);                               \
+	m_name->set_use_mipmaps(true);                              \
 	if (CustomFontBold.is_valid()) {                            \
 		m_name->set_font_data(CustomFontBold);                  \
 		m_name->add_fallback(DefaultFontBold);                  \
@@ -78,6 +87,8 @@
 	Ref<DynamicFont> m_name;                                    \
 	m_name.instance();                                          \
 	m_name->set_size(m_size);                                   \
+	m_name->set_use_filter(true);                               \
+	m_name->set_use_mipmaps(true);                              \
 	if (CustomFontSource.is_valid()) {                          \
 		m_name->set_font_data(CustomFontSource);                \
 		m_name->add_fallback(dfmono);                           \


### PR DESCRIPTION
Enabling filtering and mipmaps on the editor fonts makes the text look slightly better. While not as good as SDF-based fonts, it should be more usable already. This change impacts the visual script and visual shader editors.

Opened against the `3.2` branch as DynamicFonts are already filtered by default in the `master` branch.

This partially addresses #16220.

## Preview

### 100% zoom

![image](https://user-images.githubusercontent.com/180032/107126471-7a47f100-68b0-11eb-84f8-a5d0780f46e9.png)

### Unzoomed by 1 step

![image](https://user-images.githubusercontent.com/180032/107126477-82079580-68b0-11eb-9cdb-a77bb4c447a2.png)

### Unzoomed by 2 steps

![image](https://user-images.githubusercontent.com/180032/107126485-8b90fd80-68b0-11eb-865b-ef1db7546653.png)

### Unzoomed by 3 steps

![image](https://user-images.githubusercontent.com/180032/107126493-95b2fc00-68b0-11eb-8d9c-423191b52c63.png)

### Fully zoomed in

![image](https://user-images.githubusercontent.com/180032/107126506-ab282600-68b0-11eb-8fc8-e1edb6fd0970.png)