### PR TITLE
Bugfix: Update transform of collision shape on NOTIFICATION_PARENTED …

### DIFF
--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -93,6 +93,7 @@ void CollisionShape3D::_notification(int p_what) {
 				if (shape.is_valid()) {
 					parent->shape_owner_add_shape(owner_id, shape);
 				}
+				_update_in_shape_owner();
 			}
 		} break;
 		case NOTIFICATION_ENTER_TREE: {


### PR DESCRIPTION
Fixes #45694.

This pull requests reverts a change in collision_shape.cpp from PR #45102 where the _update_in_shape_owner() call got removed from NOTIFICATION_PARENTED handler.
