### PR TITLE
Fix unnecessary scrolling in TextEdit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2296,7 +2296,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				int prev_col = cursor.column;
 				int prev_line = cursor.line;
 
-				cursor_set_line(row, true, false);
+				cursor_set_line(row, false, false);
 				cursor_set_column(col);
 
 				if (mb->get_shift() && (cursor.column != prev_col || cursor.line != prev_line)) {


### PR DESCRIPTION
Fixes #45770.

**TextEdit** control: When left mouse is pressed to place the cursor, do not immediately adjust the viewport when _cursor_set_line_ is called, but afterwards on _cursor_set_column_ (effectively when the cursor reached **its final position**).
