### PR TITLE
Display loading text while the project manager is loading

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2015,6 +2015,10 @@ void ProjectManager::_confirm_update_settings() {
 }
 
 void ProjectManager::_open_selected_projects() {
+	// Show loading text to tell the user that the project manager is busy loading.
+	// This is especially important for the HTML5 project manager.
+	loading_label->set_modulate(Color(1, 1, 1));
+
 	const Set<String> &selected_list = _project_list->get_selected_project_keys();
 
 	for (const Set<String>::Element *E = selected_list.front(); E; E = E->next()) {
@@ -2268,11 +2272,6 @@ void ProjectManager::_restart_confirm() {
 	get_tree()->quit();
 }
 
-void ProjectManager::_exit_dialog() {
-	_dim_window();
-	get_tree()->quit();
-}
-
 void ProjectManager::_install_project(const String &p_zip_path, const String &p_title) {
 	npdialog->set_mode(ProjectDialog::MODE_INSTALL);
 	npdialog->set_zip_path(p_zip_path);
@@ -2351,7 +2350,6 @@ void ProjectManager::_on_search_term_changed(const String &p_term) {
 }
 
 void ProjectManager::_bind_methods() {
-	ClassDB::bind_method("_exit_dialog", &ProjectManager::_exit_dialog);
 	ClassDB::bind_method("_unhandled_key_input", &ProjectManager::_unhandled_key_input);
 	ClassDB::bind_method("_update_project_buttons", &ProjectManager::_update_project_buttons);
 }
@@ -2481,7 +2479,12 @@ ProjectManager::ProjectManager() {
 		search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		hb->add_child(search_box);
 
-		hb->add_spacer();
+		loading_label = memnew(Label(TTR("Loading, please wait...")));
+		loading_label->add_theme_font_override("font", get_theme_font("bold", "EditorFonts"));
+		loading_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		hb->add_child(loading_label);
+		// Hide the label but make it still take up space. This prevents reflows when showing the label.
+		loading_label->set_modulate(Color(0, 0, 0, 0));
 
 		Label *sort_label = memnew(Label);
 		sort_label->set_text(TTR("Sort:"));

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -54,6 +54,7 @@ class ProjectManager : public Control {
 	ProjectList *_project_list;
 
 	LineEdit *search_box;
+	Label *loading_label;
 	OptionButton *filter_option;
 
 	Button *run_btn;
@@ -98,7 +99,6 @@ class ProjectManager : public Control {
 	void _update_project_buttons();
 	void _language_selected(int p_id);
 	void _restart_confirm();
-	void _exit_dialog();
 	void _confirm_update_settings();
 	void _nonempty_confirmation_ok_pressed();
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/46026.

This hints the user that the project manager is currently busy loading the project. This is important for the HTML5 editor as the current feedback isn't very obvious.

This also removes the unused `_exit_dialog` function (also unused in `3.2`).

## Preview

![image](https://user-images.githubusercontent.com/180032/107133469-9ff0ec80-68e8-11eb-92be-5669a8d4e7e6.png)
