### PR TITLE
AnimationPlayer: Handle "started" event for animations of TYPE_AUDIO

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -604,7 +604,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 					continue;
 				}
 
-				if (p_seeked) {
+				if (p_seeked || p_started) {
 					//find whathever should be playing
 					int idx = a->track_find_key(i, p_time);
 					if (idx < 0) {


### PR DESCRIPTION
Fixes #45759.

With this PR the animation process for Animation::TYPE_AUDIO has been slightly changed to not only "reconsider" and updating the current playing position on a "seek" event, but also when the animation gets (re-)started.
