### PR TITLE
Keep selected node visible after filter change

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -129,6 +129,8 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 	updating_scene_tree = true;
 	const String last_path = get_selected_path();
 	const String filter = EditorNode::get_singleton()->get_scene_tree_dock()->get_filter();
+	bool filter_changed = filter != last_filter;
+	TreeItem *scroll_item = nullptr;
 
 	// Nodes are in a flatten list, depth first. Use a stack of parents, avoid recursion.
 	List<Pair<TreeItem *, int>> parents;
@@ -162,11 +164,17 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		if (debugger_id == p_debugger) { // Can use remote id.
 			if (node.id == inspected_object_id) {
 				item->select(0);
+				if (filter_changed) {
+					scroll_item = item;
+				}
 			}
 		} else { // Must use path
 			if (last_path == _get_path(item)) {
 				updating_scene_tree = false; // Force emission of new selection
 				item->select(0);
+				if (filter_changed) {
+					scroll_item = item;
+				}
 				updating_scene_tree = true;
 			}
 		}
@@ -183,6 +191,9 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 				}
 				parent->remove_child(item);
 				memdelete(item);
+				if (scroll_item == item) {
+					scroll_item = nullptr;
+				}
 				if (had_siblings) {
 					break; // Parent must survive.
 				}
@@ -199,6 +210,10 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		}
 	}
 	debugger_id = p_debugger; // Needed by hook, could be avoided if every debugger had its own tree
+	if (scroll_item) {
+		call_deferred("scroll_to_item", scroll_item);
+	}
+	last_filter = filter;
 	updating_scene_tree = false;
 }
 

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -51,6 +51,7 @@ private:
 	Set<ObjectID> unfold_cache;
 	PopupMenu *item_menu = nullptr;
 	EditorFileDialog *file_dialog = nullptr;
+	String last_filter;
 
 	String _get_path(TreeItem *p_item);
 	void _scene_tree_folded(Object *p_obj);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -156,7 +156,7 @@ void SceneTreeEditor::_toggle_visible(Node *p_node) {
 	}
 }
 
-bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
+bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll_to_selected) {
 	if (!p_node) {
 		return false;
 	}
@@ -391,15 +391,19 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		}
 	}
 
+	bool scroll = false;
+
 	if (editor_selection) {
 		if (editor_selection->is_selected(p_node)) {
 			item->select(0);
+			scroll = p_scroll_to_selected;
 		}
 	}
 
 	if (selected == p_node) {
 		if (!editor_selection) {
 			item->select(0);
+			scroll = p_scroll_to_selected;
 		}
 		item->set_as_cursor(0);
 	}
@@ -407,7 +411,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	bool keep = (filter.is_subsequence_ofi(String(p_node->get_name())));
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
-		bool child_keep = _add_nodes(p_node->get_child(i), item);
+		bool child_keep = _add_nodes(p_node->get_child(i), item, p_scroll_to_selected);
 
 		keep = keep || child_keep;
 	}
@@ -438,6 +442,9 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		memdelete(item);
 		return false;
 	} else {
+		if (scroll) {
+			tree->scroll_to_item(item);
+		}
 		return true;
 	}
 }
@@ -525,7 +532,7 @@ void SceneTreeEditor::_node_renamed(Node *p_node) {
 	}
 }
 
-void SceneTreeEditor::_update_tree() {
+void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 	if (!is_inside_tree()) {
 		tree_dirty = false;
 		return;
@@ -534,7 +541,7 @@ void SceneTreeEditor::_update_tree() {
 	updating_tree = true;
 	tree->clear();
 	if (get_scene_node()) {
-		_add_nodes(get_scene_node(), nullptr);
+		_add_nodes(get_scene_node(), nullptr, p_scroll_to_selected);
 		last_hash = hash_djb2_one_64(0);
 		_compute_hash(get_scene_node(), last_hash);
 	}
@@ -817,7 +824,7 @@ void SceneTreeEditor::set_marked(Node *p_marked, bool p_selectable, bool p_child
 
 void SceneTreeEditor::set_filter(const String &p_filter) {
 	filter = p_filter;
-	_update_tree();
+	_update_tree(true);
 }
 
 String SceneTreeEditor::get_filter() const {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -71,9 +71,9 @@ class SceneTreeEditor : public Control {
 
 	void _compute_hash(Node *p_node, uint64_t &hash);
 
-	bool _add_nodes(Node *p_node, TreeItem *p_parent);
+	bool _add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll_to_selected = false);
 	void _test_update_tree();
-	void _update_tree();
+	void _update_tree(bool p_scroll_to_selected = false);
 	void _tree_changed();
 	void _node_removed(Node *p_node);
 	void _node_renamed(Node *p_node);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4174,6 +4174,7 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_column_title_language", "column"), &Tree::get_column_title_language);
 
 	ClassDB::bind_method(D_METHOD("get_scroll"), &Tree::get_scroll);
+	ClassDB::bind_method(D_METHOD("scroll_to_item", "item"), &Tree::_scroll_to_item);
 
 	ClassDB::bind_method(D_METHOD("set_hide_folding", "hide"), &Tree::set_hide_folding);
 	ClassDB::bind_method(D_METHOD("is_folding_hidden"), &Tree::is_folding_hidden);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -564,6 +564,10 @@ protected:
 		return get_item_rect(Object::cast_to<TreeItem>(p_item), p_column);
 	}
 
+	void _scroll_to_item(Object *p_item) {
+		scroll_to_item(Object::cast_to<TreeItem>(p_item));
+	}
+
 public:
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 


### PR DESCRIPTION
This reliefs frustration when you set a filter to quickly search for one node but want to keep seeing the full tree, since it will keep the selected node at sight instead of scrolling all the way back to the top when the filter is cleared.

(Implemented both for the local and remote scene tree docks.)

![tree](https://user-images.githubusercontent.com/11797174/107164687-671c4a80-69b0-11eb-96b0-086f882a6f41.gif)

**NOTE:** Separate PR for 3.2 submitted.