### PR TITLE
Keep selected node visible after filter change (3.2)

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -161,7 +161,7 @@ void SceneTreeEditor::_toggle_visible(Node *p_node) {
 	}
 }
 
-bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
+bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll_to_selected) {
 
 	if (!p_node)
 		return false;
@@ -393,16 +393,21 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		}
 	}
 
+	bool scroll = false;
+
 	if (editor_selection) {
 		if (editor_selection->is_selected(p_node)) {
 
 			item->select(0);
+			scroll = p_scroll_to_selected;
 		}
 	}
 
 	if (selected == p_node) {
-		if (!editor_selection)
+		if (!editor_selection) {
 			item->select(0);
+			scroll = p_scroll_to_selected;
+		}
 		item->set_as_cursor(0);
 	}
 
@@ -410,7 +415,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 
-		bool child_keep = _add_nodes(p_node->get_child(i), item);
+		bool child_keep = _add_nodes(p_node->get_child(i), item, p_scroll_to_selected);
 
 		keep = keep || child_keep;
 	}
@@ -441,6 +446,9 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		memdelete(item);
 		return false;
 	} else {
+		if (scroll) {
+			tree->scroll_to_item(item);
+		}
 		return true;
 	}
 }
@@ -543,7 +551,7 @@ void SceneTreeEditor::_node_renamed(Node *p_node) {
 	}
 }
 
-void SceneTreeEditor::_update_tree() {
+void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 
 	if (!is_inside_tree()) {
 		tree_dirty = false;
@@ -553,7 +561,7 @@ void SceneTreeEditor::_update_tree() {
 	updating_tree = true;
 	tree->clear();
 	if (get_scene_node()) {
-		_add_nodes(get_scene_node(), NULL);
+		_add_nodes(get_scene_node(), NULL, p_scroll_to_selected);
 		last_hash = hash_djb2_one_64(0);
 		_compute_hash(get_scene_node(), last_hash);
 	}
@@ -836,7 +844,7 @@ void SceneTreeEditor::set_marked(Node *p_marked, bool p_selectable, bool p_child
 void SceneTreeEditor::set_filter(const String &p_filter) {
 
 	filter = p_filter;
-	_update_tree();
+	_update_tree(true);
 }
 
 String SceneTreeEditor::get_filter() const {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -72,9 +72,9 @@ class SceneTreeEditor : public Control {
 
 	void _compute_hash(Node *p_node, uint64_t &hash);
 
-	bool _add_nodes(Node *p_node, TreeItem *p_parent);
+	bool _add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll_to_selected = false);
 	void _test_update_tree();
-	void _update_tree();
+	void _update_tree(bool p_scroll_to_selected = false);
 	void _tree_changed();
 	void _node_removed(Node *p_node);
 	void _node_renamed(Node *p_node);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -472,6 +472,7 @@ int ScriptEditorDebugger::_update_scene_tree(TreeItem *parent, const Array &node
 	}
 	item->set_metadata(0, id);
 
+	bool scroll = false;
 	if (id == inspected_object_id) {
 		TreeItem *cti = item->get_parent();
 		while (cti) {
@@ -479,6 +480,7 @@ int ScriptEditorDebugger::_update_scene_tree(TreeItem *parent, const Array &node
 			cti = cti->get_parent();
 		}
 		item->select(0);
+		scroll = filter != last_filter;
 	}
 
 	// Set current item as collapsed if necessary
@@ -509,6 +511,12 @@ int ScriptEditorDebugger::_update_scene_tree(TreeItem *parent, const Array &node
 	if (!keep && !item->get_children() && parent) {
 		parent->remove_child(item);
 		memdelete(item);
+	} else if (scroll) {
+		inspect_scene_tree->call_deferred("scroll_to_item", item);
+	}
+
+	if (!parent) {
+		last_filter = filter;
 	}
 
 	return items_count;

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -98,6 +98,7 @@ private:
 	float inspect_edited_object_timeout;
 	bool auto_switch_remote_scene_tree;
 	ObjectID inspected_object_id;
+	String last_filter;
 	ScriptEditorDebuggerVariables *variables;
 	Map<ObjectID, ScriptEditorDebuggerInspectedObject *> remote_objects;
 	Set<RES> remote_dependencies;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4017,6 +4017,7 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_column_title", "column", "title"), &Tree::set_column_title);
 	ClassDB::bind_method(D_METHOD("get_column_title", "column"), &Tree::get_column_title);
 	ClassDB::bind_method(D_METHOD("get_scroll"), &Tree::get_scroll);
+	ClassDB::bind_method(D_METHOD("scroll_to_item", "item"), &Tree::_scroll_to_item);
 
 	ClassDB::bind_method(D_METHOD("set_hide_folding", "hide"), &Tree::set_hide_folding);
 	ClassDB::bind_method(D_METHOD("is_folding_hidden"), &Tree::is_folding_hidden);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -529,6 +529,10 @@ protected:
 		return get_item_rect(Object::cast_to<TreeItem>(p_item), p_column);
 	}
 
+	void _scroll_to_item(Object *p_item) {
+		scroll_to_item(Object::cast_to<TreeItem>(p_item));
+	}
+
 public:
 	virtual String get_tooltip(const Point2 &p_pos) const;
 


### PR DESCRIPTION
Version of #45812 for 3.2.

**NOTE:** Intended for 3.2.5, to avoid the small, although existing, risk of introducing regressions.