### PR TITLE
Use /Zi and /FS for including debugger symbols on Windows with MSVC

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -204,12 +204,12 @@ def configure_msvc(env, manual_msvc_config):
         env.Append(LINKFLAGS=["/OPT:REF"])
 
     elif env["target"] == "debug":
-        env.AppendUnique(CCFLAGS=["/Z7", "/Od", "/EHsc"])
+        env.AppendUnique(CCFLAGS=["/Zi", "/FS", "/Od", "/EHsc"])
         env.AppendUnique(CPPDEFINES=["DEBUG_ENABLED"])
         env.Append(LINKFLAGS=["/DEBUG"])
 
     if env["debug_symbols"]:
-        env.AppendUnique(CCFLAGS=["/Z7"])
+        env.AppendUnique(CCFLAGS=["/Zi", "/FS"])
         env.AppendUnique(LINKFLAGS=["/DEBUG"])
 
     if env["windows_subsystem"] == "gui":
@@ -224,6 +224,7 @@ def configure_msvc(env, manual_msvc_config):
         env.AppendUnique(CCFLAGS=["/MT"])
     else:
         env.AppendUnique(CCFLAGS=["/MD"])
+
     env.AppendUnique(CCFLAGS=["/Gd", "/GR", "/nologo"])
     # Force to use Unicode encoding
     env.AppendUnique(CCFLAGS=["/utf-8"])


### PR DESCRIPTION
I went down a rabbit hole with this one but eventually decided on just making these two changes.

We were previously using `/Z7` which results in version 7.0 compatible compiler settings. Not sure if that is to old or something else but this was not working with VS Code and the `cppvsdbg` debugger. 

Switching to `/Zi` (all debug symbols) resolves that. 

`/FS` was needed to allow threadsafe updating of the pdb file if you're using parallel compiling (scons `-jn` switch). 

I also wanted to make sure that debug compiles use `/MTd` and `/MDd` instead of `/MT` and `/MD` respectively but I ran into all sorts of problems with that. `basic_universal` forces the iteration debug level to be set to 1 (no debugging of iterators) while the rest of Godot is compiled with 2 and the linker doesn't like that. 
Solving that by including `-DBASISU_NO_ITERATOR_DEBUG_LEVEL` allows us to compile the module but Godot will take ages to start and often crashes on locking on memory allocation during startup so I parked this. I think this should be revisited at some point. 