### PR TITLE
Open error in dominant script when checked

### DIFF
--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -37,11 +37,12 @@
 
 Array DebuggerMarshalls::ScriptStackDump::serialize() {
 	Array arr;
-	arr.push_back(frames.size() * 3);
+	arr.push_back(frames.size() * 4);
 	for (int i = 0; i < frames.size(); i++) {
 		arr.push_back(frames[i].file);
 		arr.push_back(frames[i].line);
 		arr.push_back(frames[i].func);
+		arr.push_back(frames[i].owner);
 	}
 	return arr;
 }
@@ -51,13 +52,14 @@ bool DebuggerMarshalls::ScriptStackDump::deserialize(const Array &p_arr) {
 	uint32_t size = p_arr[0];
 	CHECK_SIZE(p_arr, size, "ScriptStackDump");
 	int idx = 1;
-	for (uint32_t i = 0; i < size / 3; i++) {
+	for (uint32_t i = 0; i < size / 4; i++) {
 		ScriptLanguage::StackInfo sf;
 		sf.file = p_arr[idx];
 		sf.line = p_arr[idx + 1];
 		sf.func = p_arr[idx + 2];
+		sf.owner = p_arr[idx + 3];
 		frames.push_back(sf);
-		idx += 3;
+		idx += 4;
 	}
 	CHECK_END(p_arr, idx, "ScriptStackDump");
 	return true;

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -38,6 +38,7 @@
 #include "core/input/input.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
+#include "scene/main/node.h"
 
 class RemoteDebugger::PerformanceProfiler : public EngineProfiler {
 	Object *performance = nullptr;
@@ -420,6 +421,14 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 					frame.file = script_lang->debug_get_stack_level_source(i);
 					frame.line = script_lang->debug_get_stack_level_line(i);
 					frame.func = script_lang->debug_get_stack_level_function(i);
+
+					if (ScriptInstance *instance = script_lang->debug_get_stack_level_instance(i)) {
+						Object *owner = instance->get_owner();
+						if (Node *node = Object::cast_to<Node>(owner)) {
+							frame.owner = node->get_scene_file_path();
+						}
+					}
+
 					dump.frames.push_back(frame);
 				}
 				send_message("stack_dump", dump.serialize());

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -389,6 +389,7 @@ public:
 	struct StackInfo {
 		String file;
 		String func;
+		String owner;
 		int line;
 	};
 

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -136,6 +136,18 @@ void EditorDebuggerNode::_stack_frame_selected(int p_debugger) {
 	if (dbg != get_current_debugger()) {
 		return;
 	}
+
+	bool use_external_editor = EDITOR_GET("text_editor/external/use_external_editor");
+	const bool open_dominant = EDITOR_GET("text_editor/behavior/files/open_dominant_script_on_scene_change");
+	if (open_dominant && !use_external_editor) {
+		const String owner = dbg->get_stack_script_owner();
+		if (owner.length() != 0) {
+			EditorData &editor_data = EditorNode::get_editor_data();
+			EditorInterface::get_singleton()->open_scene_from_path(owner);
+			editor_data.notify_edited_scene_changed();
+		}
+	}
+
 	_text_editor_stack_goto(dbg);
 }
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -399,10 +399,11 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			d["file"] = stack.frames[i].file;
 			d["function"] = stack.frames[i].func;
 			d["line"] = stack.frames[i].line;
+			d["owner"] = stack.frames[i].owner;
 			stack_dump_info.push_back(d);
 			s->set_metadata(0, d);
 
-			String line = itos(i) + " - " + String(d["file"]) + ":" + itos(d["line"]) + " - at function: " + String(d["function"]);
+			String line = itos(i) + " - " + String(d["file"]) + ":" + itos(d["line"]) + " - at function: " + String(d["function"]) + " - at scene: " + String(d["owner"]);
 			s->set_text(0, line);
 
 			if (i == 0) {
@@ -1248,6 +1249,15 @@ int ScriptEditorDebugger::get_stack_script_frame() const {
 	}
 	Dictionary d = ti->get_metadata(0);
 	return d["frame"];
+}
+
+String ScriptEditorDebugger::get_stack_script_owner() const {
+	TreeItem *ti = stack_dump->get_selected();
+	if (!ti) {
+		return "";
+	}
+	Dictionary d = ti->get_metadata(0);
+	return d["owner"];
 }
 
 bool ScriptEditorDebugger::request_stack_dump(const int &p_frame) {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -251,6 +251,7 @@ public:
 	String get_stack_script_file() const;
 	int get_stack_script_line() const;
 	int get_stack_script_frame() const;
+	String get_stack_script_owner() const;
 
 	bool request_stack_dump(const int &p_frame);
 


### PR DESCRIPTION
Fix [#5646](https://github.com/godotengine/godot/issues/5646).
Looks like that there is no `owner.filename` and needs proper handling.

