### PR TITLE
Change the icon of the custom MIME type for project files.

### DIFF
--- a/misc/dist/linux/x-godot-project.xml
+++ b/misc/dist/linux/x-godot-project.xml
@@ -2,7 +2,7 @@
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/x-godot-project">
     <comment>Godot Engine project</comment>
-    <icon name="godot" />
+    <icon name="godot-project" />
     <glob pattern="*.godot" weight="100" />
   </mime-type>
 </mime-info>


### PR DESCRIPTION
I have no idea what `misc/dist/project_icon.svg` is for. Initially I thought that it was for the custom MIME type, but there's actually no reference of it, not even when it was last updated. If I'm wrong, or if it was supposed to be deleted, feel free to close this PR.
For anyone wondering I'm talking about this file:
![weird icon](https://raw.githubusercontent.com/godotengine/godot/master/misc/dist/project_icon.svg)