### PR TITLE
Update ColorPicker controls when entering tree

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -52,6 +52,7 @@ void ColorPicker::_notification(int p_what) {
 			btn_pick->set_icon(get_theme_icon("screen_picker", "ColorPicker"));
 			bt_add_preset->set_icon(get_theme_icon("add_preset"));
 
+			_update_controls();
 			_update_color();
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Closes #45832.

The ColorPicker is not yet inside the tree when the hsv mode is set after opening a scene/playing the project, so `_update_control` was never called from `set_hsv_mode`.