### PR TITLE
Accomodate blend shape ranges of -1 to +1 for GLES

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -4476,8 +4476,10 @@ void RasterizerStorageGLES3::mesh_render_blend_shapes(Surface *s, const float *p
 	for (int ti = 0; ti < mtc; ti++) {
 		float weight = p_weights[ti];
 
-		if (weight < 0.00001) //not bother with this one
+		if (Math::is_zero_approx(weight)) {
+			//not bother with this one
 			continue;
+		}
 
 		glBindVertexArray(s->blend_shapes[ti].array_id);
 		glBindBuffer(GL_ARRAY_BUFFER, resources.transform_feedback_buffers[0]);

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -98,7 +98,7 @@ void MeshInstance::_get_property_list(List<PropertyInfo> *p_list) const {
 	ls.sort();
 
 	for (List<String>::Element *E = ls.front(); E; E = E->next()) {
-		p_list->push_back(PropertyInfo(Variant::REAL, E->get(), PROPERTY_HINT_RANGE, "0,1,0.00001"));
+		p_list->push_back(PropertyInfo(Variant::REAL, E->get(), PROPERTY_HINT_RANGE, "-1,1,0.00001"));
 	}
 
 	if (mesh.is_valid()) {


### PR DESCRIPTION
Edits made to the blend shape editor and underlying `MeshInstance` identical to #43445 with the exception that the requested edits by code reviewers have been made.

As was specified by @AndreaCatania , this change should be targeted at 3.2 for reasons outlined in the original pull request.

Concerns were raised in the original pull request regarding artifacting that is hardware-specific, of which I am not sure is related to #45690, but regardless, the changes outlined in this PR are purely in changing the limits for the current system for the sake of useability with models that are built around the notion of blend shape ranges being normalized to ranges of `-1` to `+1`.

Hopefully, the amendments made will help expedite merging this change into the main codebase, as it is something I am currently doing custom builds to accommodate support for.