### PR TITLE
Batching - prevent reordering items over a copybackbuffer

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -2716,6 +2716,11 @@ PREAMBLE(bool)::sort_items_from(int p_start) {
 		return false;
 	}
 
+	// disallow sorting over copy back buffer
+	if (second.item->copy_back_buffer) {
+		return false;
+	}
+
 	// which neighbour to test
 	int test_last = 2 + bdata.settings_item_reordering_lookahead;
 	for (int test = 2; test < test_last; test++) {


### PR DESCRIPTION
Reordering an item from `after` a copybackbuffer to `before` would result in the wrong thing being rendered into the backbuffer.
This PR puts in a check to prevent reordering over such a boundary.

Fixes #45838

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
