### PR TITLE
Improve EditorImportPlugin docs.

### DIFF
--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -16,7 +16,7 @@
 		    return "my.special.plugin"
 
 		func get_visible_name():
-		    return "Special Mesh Importer"
+		    return "Special Mesh"
 
 		func get_recognized_extensions():
 		    return ["special", "spec"]
@@ -44,8 +44,7 @@
 		    # Fill the Mesh with data read in "file", left as an exercise to the reader.
 
 		    var filename = save_path + "." + get_save_extension()
-		    ResourceSaver.save(filename, mesh)
-		    return OK
+		    return ResourceSaver.save(filename, mesh)
 		[/gdscript]
 		[csharp]
 		using Godot;
@@ -60,7 +59,7 @@
 
 		    public override String GetVisibleName()
 		    {
-		        return "Special Mesh Importer";
+		        return "Special Mesh";
 		    }
 
 		    public override Godot.Collections.Array GetRecognizedExtensions()
@@ -104,8 +103,7 @@
 		        var mesh = new ArrayMesh();
 		        // Fill the Mesh with data read in "file", left as an exercise to the reader.
 		        String filename = savePath + "." + GetSaveExtension();
-		        ResourceSaver.Save(filename, mesh);
-		        return (int)Error.Ok;
+		        return (int)ResourceSaver.Save(filename, mesh);
 		    }
 		}
 		[/csharp]
@@ -220,7 +218,7 @@
 			<return type="String">
 			</return>
 			<description>
-				Gets the name to display in the import window.
+				Gets the name to display in the import window. You should choose this name as a continuation to "Import as", e.g. "Import as Special Mesh".
 			</description>
 		</method>
 		<method name="import" qualifiers="virtual">


### PR DESCRIPTION
- `EditorImportPlugin.get_visible_name` should be a continuation of "Import as"
- The example code ignores any error from `ResourceSaver.save`, but I think we should return it?

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->