### PR TITLE
Accomodate blend shape ranges of -1 to +1 for Vulkan

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -95,7 +95,7 @@ void MeshInstance3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	ls.sort();
 
 	for (List<String>::Element *E = ls.front(); E; E = E->next()) {
-		p_list->push_back(PropertyInfo(Variant::FLOAT, E->get(), PROPERTY_HINT_RANGE, "0,1,0.00001"));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, E->get(), PROPERTY_HINT_RANGE, "-1,1,0.00001"));
 	}
 
 	if (mesh.is_valid()) {

--- a/servers/rendering/renderer_rd/shaders/skeleton.glsl
+++ b/servers/rendering/renderer_rd/shaders/skeleton.glsl
@@ -100,7 +100,7 @@ void main() {
 
 		for (uint i = 0; i < params.blend_shape_count; i++) {
 			float w = blend_shape_weights.data[i];
-			if (w > 0.0001) {
+			if ((w < 0.0001) || (w > 0.0001)) {
 				uint base_offset = (params.vertex_count * i + index) * params.vertex_stride;
 
 				blend_vertex += uintBitsToFloat(uvec3(src_blend_shapes.data[base_offset + 0], src_blend_shapes.data[base_offset + 1], src_blend_shapes.data[base_offset + 2])) * w;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/15730577/107449910-53055400-6b3c-11eb-8965-7f79e0f7937e.png)

A sibling PR to #45837 , providing the same functionality but targeted specifically at the Vulkan renderer. As discussed in that PR, both requests are intended to be merged individually on their respective branches as they do not share a common implementation.