### PR TITLE
Fix contact points debug for 3D Physics

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -567,6 +567,12 @@ void Viewport::_notification(int p_what) {
 				int point_count = PhysicsServer3D::get_singleton()->space_get_contact_count(find_world_3d()->get_space());
 
 				RS::get_singleton()->multimesh_set_visible_instances(contact_3d_debug_multimesh, point_count);
+
+				for (int i = 0; i < point_count; i++) {
+					Transform point_transform;
+					point_transform.origin = points[i];
+					RS::get_singleton()->multimesh_instance_set_transform(contact_3d_debug_multimesh, i, point_transform);
+				}
 			}
 		} break;
 		case NOTIFICATION_WM_MOUSE_EXIT: {


### PR DESCRIPTION
Setting each point's position was missing for 3D. Now enabling collision render debug will display contact points for 3D physics, the same way it does for 2D physics.

Note: Multimesh rendering seems not to work in this scenario on master, but it's working fine on 3.2.