### PR TITLE
General improvements to the MIME source file

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.xml
+++ b/misc/dist/linux/org.godotengine.Godot.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/x-godot-project">
+    <comment>Godot Engine project</comment>
+    <icon name="x-godot-project" />
+    <glob pattern="*.godot"/>
+  </mime-type>
+
+  <mime-type type="application/x-godot-resource">
+    <comment>Godot Engine resource</comment>
+    <icon name="x-godot-resource" />
+    <glob pattern="*.res"/>
+    <glob pattern="*.tres"/>
+  </mime-type>
+
+  <mime-type type="application/x-godot-scene">
+    <comment>Godot Engine scene</comment>
+    <icon name="x-godot-scene" />
+    <glob pattern="*.scn"/>
+    <glob pattern="*.tscn"/>
+    <glob pattern="*.escn"/>
+  </mime-type>
+
+  <mime-type type="application/x-gdscript">
+    <comment>GDScript script</comment>
+    <icon name="x-gdscript" />
+    <glob pattern="*.gd"/>
+  </mime-type>
+</mime-info>

--- a/misc/dist/linux/x-godot-project.xml
+++ b/misc/dist/linux/x-godot-project.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
-  <mime-type type="application/x-godot-project">
-    <comment>Godot Engine project</comment>
-    <icon name="godot" />
-    <glob pattern="*.godot" weight="100" />
-  </mime-type>
-</mime-info>


### PR DESCRIPTION
Supercedes #45834.

This PR does a few of the things discussed on RocketChat about improving the general XDG integration with Godot. Further changes will be added later, after some more experiments and discussions.

It adds MIME definitions for resources, scenes and scripts along to the one for projects, removes the "weight" property, since the old value of 100 was excessive (it's *meant* to not be 100) and renames everything to follow various conventions (x-godot-project.xml -> org.godotengine.Godot.xml and the various mime types now point to icons named the same way as them). Also, it replaces the old godot icon with the ones in `misc/dist/document_icons`. Note that as of now the new mime types aren't associated to anything, as it would require some extra stuff on which I'm still working on.

Now a project, in this case the third person shooter demo, looks like this in Thunar.
![project tree](https://user-images.githubusercontent.com/31065808/107523535-1fb2db80-6bb5-11eb-8de0-3e5bdfc1308d.png)
![player folder](https://user-images.githubusercontent.com/31065808/107523709-4ffa7a00-6bb5-11eb-852f-a9abf038fe87.png)