### PR TITLE
Removed _change_notify(property)

### DIFF
--- a/core/core_string_names.cpp
+++ b/core/core_string_names.cpp
@@ -76,5 +76,6 @@ CoreStringNames::CoreStringNames() :
 		bind(StaticCString::create("bind")),
 		unbind(StaticCString::create("unbind")),
 		emit(StaticCString::create("emit")),
-		notification(StaticCString::create("notification")) {
+		notification(StaticCString::create("notification")),
+		property_list_changed(StaticCString::create("property_list_changed")) {
 }

--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -96,6 +96,7 @@ public:
 	StringName unbind;
 	StringName emit;
 	StringName notification;
+	StringName property_list_changed;
 };
 
 #endif // CORE_STRING_NAMES_H

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -87,7 +87,6 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 		ResourceCache::lock.write_unlock();
 	}
 
-	_change_notify("resource_path");
 	_resource_path_changed();
 }
 
@@ -105,7 +104,6 @@ int Resource::get_subindex() const {
 
 void Resource::set_name(const String &p_name) {
 	name = p_name;
-	_change_notify("resource_name");
 }
 
 String Resource::get_name() const {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -808,21 +808,6 @@ String Object::to_string() {
 	return "[" + get_class() + ":" + itos(get_instance_id()) + "]";
 }
 
-void Object::_changed_callback(Object *p_changed, const char *p_prop) {
-}
-
-void Object::add_change_receptor(Object *p_receptor) {
-	change_receptors.insert(p_receptor);
-}
-
-void Object::remove_change_receptor(Object *p_receptor) {
-	change_receptors.erase(p_receptor);
-}
-
-void Object::property_list_changed_notify() {
-	_change_notify();
-}
-
 void Object::set_script_and_instance(const Variant &p_script, ScriptInstance *p_instance) {
 	//this function is not meant to be used in any of these ways
 	ERR_FAIL_COND(p_script.is_null());
@@ -856,7 +841,7 @@ void Object::set_script(const Variant &p_script) {
 		}
 	}
 
-	_change_notify(); //scripts may add variables, so refresh is desired
+	notify_property_list_changed(); //scripts may add variables, so refresh is desired
 	emit_signal(CoreStringNames::get_singleton()->script_changed);
 }
 
@@ -1496,6 +1481,10 @@ void Object::clear_internal_resource_paths() {
 	}
 }
 
+void Object::notify_property_list_changed() {
+	emit_signal(CoreStringNames::get_singleton()->property_list_changed);
+}
+
 void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_class"), &Object::get_class);
 	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class);
@@ -1562,7 +1551,7 @@ void Object::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_block_signals", "enable"), &Object::set_block_signals);
 	ClassDB::bind_method(D_METHOD("is_blocking_signals"), &Object::is_blocking_signals);
-	ClassDB::bind_method(D_METHOD("property_list_changed_notify"), &Object::property_list_changed_notify);
+	ClassDB::bind_method(D_METHOD("notify_property_list_changed"), &Object::notify_property_list_changed);
 
 	ClassDB::bind_method(D_METHOD("set_message_translation", "enable"), &Object::set_message_translation);
 	ClassDB::bind_method(D_METHOD("can_translate_messages"), &Object::can_translate_messages);
@@ -1574,6 +1563,7 @@ void Object::_bind_methods() {
 	ClassDB::add_virtual_method("Object", MethodInfo("free"), false);
 
 	ADD_SIGNAL(MethodInfo("script_changed"));
+	ADD_SIGNAL(MethodInfo("property_list_changed"));
 
 	BIND_VMETHOD(MethodInfo("_notification", PropertyInfo(Variant::INT, "what")));
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_set", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::NIL, "value")));

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -454,7 +454,6 @@ private:
 #endif
 	bool _block_signals = false;
 	int _predelete_ok = 0;
-	Set<Object *> change_receptors;
 	ObjectID _instance_id;
 	bool _predelete();
 	void _postinitialize();
@@ -523,9 +522,6 @@ protected:
 	static void get_valid_parents_static(List<String> *p_parents);
 	static void _get_valid_parents_static(List<String> *p_parents);
 
-	void property_list_changed_notify();
-	virtual void _changed_callback(Object *p_changed, const char *p_prop);
-
 	//Variant _call_bind(const StringName& p_name, const Variant& p_arg1 = Variant(), const Variant& p_arg2 = Variant(), const Variant& p_arg3 = Variant(), const Variant& p_arg4 = Variant());
 	//void _call_deferred_bind(const StringName& p_name, const Variant& p_arg1 = Variant(), const Variant& p_arg2 = Variant(), const Variant& p_arg3 = Variant(), const Variant& p_arg4 = Variant());
 
@@ -555,16 +551,8 @@ public: //should be protected, but bug in clang++
 	_FORCE_INLINE_ static void register_custom_data_to_otdb() {}
 
 public:
-#ifdef TOOLS_ENABLED
-	_FORCE_INLINE_ void _change_notify(const char *p_property = "") {
-		_edited = true;
-		for (Set<Object *>::Element *E = change_receptors.front(); E; E = E->next()) {
-			((Object *)(E->get()))->_changed_callback(this, p_property);
-		}
-	}
-#else
-	_FORCE_INLINE_ void _change_notify(const char *p_what = "") {}
-#endif
+	void notify_property_list_changed();
+
 	static void *get_class_ptr_static() {
 		static int ptr;
 		return &ptr;
@@ -573,10 +561,6 @@ public:
 	bool _is_gpl_reversed() const { return false; }
 
 	_FORCE_INLINE_ ObjectID get_instance_id() const { return _instance_id; }
-
-	// this is used for editors
-	void add_change_receptor(Object *p_receptor);
-	void remove_change_receptor(Object *p_receptor);
 
 	template <class T>
 	static T *cast_to(Object *p_object) {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -515,7 +515,7 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 	}
 
 	if (owner && owner->get_script_instance() == this) {
-		owner->_change_notify();
+		owner->notify_property_list_changed();
 	}
 	//change notify
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -634,7 +634,7 @@ public:
 	bool use_fps = false;
 
 	void notify_change() {
-		_change_notify();
+		notify_property_list_changed();
 	}
 
 	Node *get_root_path() {
@@ -643,7 +643,7 @@ public:
 
 	void set_use_fps(bool p_enable) {
 		use_fps = p_enable;
-		_change_notify();
+		notify_property_list_changed();
 	}
 };
 
@@ -1276,7 +1276,7 @@ public:
 	UndoRedo *undo_redo = nullptr;
 
 	void notify_change() {
-		_change_notify();
+		notify_property_list_changed();
 	}
 
 	Node *get_root_path() {
@@ -1285,7 +1285,7 @@ public:
 
 	void set_use_fps(bool p_enable) {
 		use_fps = p_enable;
-		_change_notify();
+		notify_property_list_changed();
 	}
 };
 
@@ -4283,7 +4283,6 @@ void AnimationTrackEditor::_animation_update() {
 	_update_step_spinbox();
 	emit_signal("animation_step_changed", animation->get_step());
 	emit_signal("animation_len_changed", animation->get_length());
-	EditorNode::get_singleton()->get_inspector()->refresh();
 
 	animation_changing_awaiting_update = false;
 }

--- a/editor/array_property_edit.cpp
+++ b/editor/array_property_edit.cpp
@@ -49,11 +49,7 @@ Variant ArrayPropertyEdit::get_array() const {
 }
 
 void ArrayPropertyEdit::_notif_change() {
-	_change_notify();
-}
-
-void ArrayPropertyEdit::_notif_changev(const String &p_v) {
-	_change_notify(p_v.utf8().get_data());
+	notify_property_list_changed();
 }
 
 void ArrayPropertyEdit::_set_size(int p_size) {
@@ -120,7 +116,7 @@ bool ArrayPropertyEdit::_set(const StringName &p_name, const Variant &p_value) {
 		}
 		if (pn == "array/page") {
 			page = p_value;
-			_change_notify();
+			notify_property_list_changed();
 			return true;
 		}
 
@@ -159,8 +155,6 @@ bool ArrayPropertyEdit::_set(const StringName &p_name, const Variant &p_value) {
 			ur->create_action(TTR("Change Array Value"));
 			ur->add_do_method(this, "_set_value", idx, p_value);
 			ur->add_undo_method(this, "_set_value", idx, value);
-			ur->add_do_method(this, "_notif_changev", p_name);
-			ur->add_undo_method(this, "_notif_changev", p_name);
 			ur->commit_action();
 			return true;
 		}
@@ -288,7 +282,6 @@ void ArrayPropertyEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_size"), &ArrayPropertyEdit::_set_size);
 	ClassDB::bind_method(D_METHOD("_set_value"), &ArrayPropertyEdit::_set_value);
 	ClassDB::bind_method(D_METHOD("_notif_change"), &ArrayPropertyEdit::_notif_change);
-	ClassDB::bind_method(D_METHOD("_notif_changev"), &ArrayPropertyEdit::_notif_changev);
 	ClassDB::bind_method(D_METHOD("_dont_undo_redo"), &ArrayPropertyEdit::_dont_undo_redo);
 }
 

--- a/editor/array_property_edit.h
+++ b/editor/array_property_edit.h
@@ -47,7 +47,6 @@ class ArrayPropertyEdit : public Reference {
 	Variant::Type default_type;
 
 	void _notif_change();
-	void _notif_changev(const String &p_v);
 	void _set_size(int p_size);
 	void _set_value(int p_idx, const Variant &p_value);
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -98,7 +98,7 @@ public:
 	}
 
 	void notify_changed() {
-		_change_notify();
+		notify_property_list_changed();
 	}
 
 	ConnectDialogBinds() {

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -58,7 +58,7 @@ public:
 		prop_values.clear();
 	}
 
-	void update() { _change_notify(); }
+	void update() { notify_property_list_changed(); }
 
 	EditorDebuggerRemoteObject() {}
 };

--- a/editor/dictionary_property_edit.cpp
+++ b/editor/dictionary_property_edit.cpp
@@ -32,11 +32,7 @@
 #include "editor_node.h"
 
 void DictionaryPropertyEdit::_notif_change() {
-	_change_notify();
-}
-
-void DictionaryPropertyEdit::_notif_changev(const String &p_v) {
-	_change_notify(p_v.utf8().get_data());
+	notify_property_list_changed();
 }
 
 void DictionaryPropertyEdit::_set_key(const Variant &p_old_key, const Variant &p_new_key) {
@@ -107,7 +103,6 @@ void DictionaryPropertyEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_key"), &DictionaryPropertyEdit::_set_key);
 	ClassDB::bind_method(D_METHOD("_set_value"), &DictionaryPropertyEdit::_set_value);
 	ClassDB::bind_method(D_METHOD("_notif_change"), &DictionaryPropertyEdit::_notif_change);
-	ClassDB::bind_method(D_METHOD("_notif_changev"), &DictionaryPropertyEdit::_notif_changev);
 	ClassDB::bind_method(D_METHOD("_dont_undo_redo"), &DictionaryPropertyEdit::_dont_undo_redo);
 }
 
@@ -128,8 +123,6 @@ bool DictionaryPropertyEdit::_set(const StringName &p_name, const Variant &p_val
 			ur->create_action(TTR("Change Dictionary Key"));
 			ur->add_do_method(this, "_set_key", key, p_value);
 			ur->add_undo_method(this, "_set_key", p_value, key);
-			ur->add_do_method(this, "_notif_changev", p_name);
-			ur->add_undo_method(this, "_notif_changev", p_name);
 			ur->commit_action();
 
 			return true;
@@ -142,8 +135,6 @@ bool DictionaryPropertyEdit::_set(const StringName &p_name, const Variant &p_val
 				ur->create_action(TTR("Change Dictionary Value"));
 				ur->add_do_method(this, "_set_value", key, p_value);
 				ur->add_undo_method(this, "_set_value", key, value);
-				ur->add_do_method(this, "_notif_changev", p_name);
-				ur->add_undo_method(this, "_notif_changev", p_name);
 				ur->commit_action();
 
 				return true;

--- a/editor/dictionary_property_edit.h
+++ b/editor/dictionary_property_edit.h
@@ -40,7 +40,6 @@ class DictionaryPropertyEdit : public Reference {
 	StringName property;
 
 	void _notif_change();
-	void _notif_changev(const String &p_v);
 	void _set_key(const Variant &p_old_key, const Variant &p_new_key);
 	void _set_value(const Variant &p_key, const Variant &p_value);
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -98,6 +98,8 @@ private:
 
 	mutable String tooltip_text;
 
+	Map<StringName, Variant> cache;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -152,6 +154,8 @@ public:
 	virtual void collapse_all_folding();
 
 	virtual Variant get_drag_data(const Point2 &p_point) override;
+	virtual void update_cache();
+	virtual bool is_cache_valid() const;
 
 	void set_selectable(bool p_selectable);
 	bool is_selectable() const;
@@ -326,7 +330,7 @@ class EditorInspector : public ScrollContainer {
 
 	void _node_removed(Node *p_node);
 
-	void _changed_callback(Object *p_changed, const char *p_prop) override;
+	void _changed_callback();
 	void _edit_request_change(Object *p_object, const String &p_prop);
 
 	void _filter_changed(const String &p_text);
@@ -356,9 +360,6 @@ public:
 
 	void update_tree();
 	void update_property(const String &p_prop);
-
-	void refresh();
-
 	void edit(Object *p_object);
 	Object *get_edited_object();
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1791,7 +1791,7 @@ void EditorNode::_dialog_action(String p_file) {
 			ObjectID current = editor_history.get_current();
 			Object *current_obj = current.is_valid() ? ObjectDB::get_instance(current) : nullptr;
 			ERR_FAIL_COND(!current_obj);
-			current_obj->_change_notify();
+			current_obj->notify_property_list_changed();
 		} break;
 		case SETTINGS_LAYOUT_SAVE: {
 			if (p_file.is_empty()) {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2913,7 +2913,6 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->edit(res.ptr());
 			}
 
-			sub_inspector->refresh();
 		} else {
 			if (sub_inspector) {
 				set_bottom_editor(nullptr);

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -116,12 +116,12 @@ public:
 	void set_section(const String &p_section, bool p_allow_sub) {
 		section = p_section;
 		allow_sub = p_allow_sub;
-		_change_notify();
+		notify_property_list_changed();
 	}
 
 	void set_edited(Object *p_edited) {
 		edited = p_edited;
-		_change_notify();
+		notify_property_list_changed();
 	}
 };
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -441,7 +441,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/filesystem/always_show_folders", true);
 
 	// Property editor
-	_initial_set("docks/property_editor/auto_refresh_interval", 0.3);
+	_initial_set("docks/property_editor/auto_refresh_interval", 0.2); //update 5 times per second by default
 
 	/* Text editor */
 

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -48,7 +48,7 @@ public:
 			values[p_name] = p_value;
 			if (checking) {
 				checked.insert(p_name);
-				_change_notify();
+				notify_property_list_changed();
 			}
 			return true;
 		}
@@ -81,7 +81,7 @@ public:
 	}
 
 	void update() {
-		_change_notify();
+		notify_property_list_changed();
 	}
 
 	ImportDockParameters() {

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -78,7 +78,6 @@ void AnimationPlayerEditor::_notification(int p_what) {
 				}
 				frame->set_value(player->get_current_animation_position());
 				track_editor->set_anim_pos(player->get_current_animation_position());
-				EditorNode::get_singleton()->get_inspector()->refresh();
 
 			} else if (!player->is_valid()) {
 				// Reset timeline when the player has been stopped externally
@@ -1072,8 +1071,6 @@ void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag)
 	frame->set_value(Math::snapped(p_pos, _get_editor_step()));
 	updating = false;
 	_seek_value_changed(p_pos, !p_drag);
-
-	EditorNode::get_singleton()->get_inspector()->refresh();
 }
 
 void AnimationPlayerEditor::_animation_tool_menu(int p_option) {

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -96,7 +96,7 @@ void AudioStreamEditor::_preview_changed(ObjectID p_which) {
 	}
 }
 
-void AudioStreamEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+void AudioStreamEditor::_audio_changed() {
 	if (!is_visible()) {
 		return;
 	}
@@ -172,7 +172,7 @@ void AudioStreamEditor::_seek_to(real_t p_x) {
 
 void AudioStreamEditor::edit(Ref<AudioStream> p_stream) {
 	if (!stream.is_null()) {
-		stream->remove_change_receptor(this);
+		stream->disconnect("changed", callable_mp(this, &AudioStreamEditor::_audio_changed));
 	}
 
 	stream = p_stream;
@@ -182,7 +182,7 @@ void AudioStreamEditor::edit(Ref<AudioStream> p_stream) {
 	_duration_label->set_text(text);
 
 	if (!stream.is_null()) {
-		stream->add_change_receptor(this);
+		stream->connect("changed", callable_mp(this, &AudioStreamEditor::_audio_changed));
 		update();
 	} else {
 		hide();

--- a/editor/plugins/audio_stream_editor_plugin.h
+++ b/editor/plugins/audio_stream_editor_plugin.h
@@ -53,6 +53,8 @@ class AudioStreamEditor : public ColorRect {
 	float _current;
 	bool _dragging;
 
+	void _audio_changed();
+
 protected:
 	void _notification(int p_what);
 	void _preview_changed(ObjectID p_which);
@@ -63,7 +65,6 @@ protected:
 	void _draw_indicator();
 	void _on_input_indicator(Ref<InputEvent> p_event);
 	void _seek_to(real_t p_x);
-	void _changed_callback(Object *p_changed, const char *p_prop) override;
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -207,7 +207,7 @@ void CollisionShape2DEditor::set_handle(int idx, Point2 &p_point) {
 
 		} break;
 	}
-	node->get_shape()->_change_notify();
+	node->get_shape()->notify_property_list_changed();
 }
 
 void CollisionShape2DEditor::commit_handle(int idx, Variant &p_org) {

--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -145,7 +145,7 @@ int ItemListOptionButtonPlugin::get_flags() const {
 
 void ItemListOptionButtonPlugin::add_item() {
 	ob->add_item(vformat(TTR("Item %d"), ob->get_item_count()));
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int ItemListOptionButtonPlugin::get_item_count() const {
@@ -154,7 +154,7 @@ int ItemListOptionButtonPlugin::get_item_count() const {
 
 void ItemListOptionButtonPlugin::erase(int p_idx) {
 	ob->remove_item(p_idx);
-	_change_notify();
+	notify_property_list_changed();
 }
 
 ItemListOptionButtonPlugin::ItemListOptionButtonPlugin() {
@@ -181,7 +181,7 @@ int ItemListPopupMenuPlugin::get_flags() const {
 
 void ItemListPopupMenuPlugin::add_item() {
 	pp->add_item(vformat(TTR("Item %d"), pp->get_item_count()));
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int ItemListPopupMenuPlugin::get_item_count() const {
@@ -190,7 +190,7 @@ int ItemListPopupMenuPlugin::get_item_count() const {
 
 void ItemListPopupMenuPlugin::erase(int p_idx) {
 	pp->remove_item(p_idx);
-	_change_notify();
+	notify_property_list_changed();
 }
 
 ItemListPopupMenuPlugin::ItemListPopupMenuPlugin() {
@@ -213,7 +213,7 @@ int ItemListItemListPlugin::get_flags() const {
 
 void ItemListItemListPlugin::add_item() {
 	pp->add_item(vformat(TTR("Item %d"), pp->get_item_count()));
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int ItemListItemListPlugin::get_item_count() const {
@@ -222,7 +222,7 @@ int ItemListItemListPlugin::get_item_count() const {
 
 void ItemListItemListPlugin::erase(int p_idx) {
 	pp->remove_item(p_idx);
-	_change_notify();
+	notify_property_list_changed();
 }
 
 ItemListItemListPlugin::ItemListItemListPlugin() {

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -57,7 +57,7 @@ void Texture3DEditor::_notification(int p_what) {
 	}
 }
 
-void Texture3DEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+void Texture3DEditor::_texture_changed() {
 	if (!is_visible()) {
 		return;
 	}
@@ -118,7 +118,7 @@ void Texture3DEditor::_texture_rect_update_area() {
 
 void Texture3DEditor::edit(Ref<Texture3D> p_texture) {
 	if (!texture.is_null()) {
-		texture->remove_change_receptor(this);
+		texture->disconnect("changed", callable_mp(this, &Texture3DEditor::_texture_changed));
 	}
 
 	texture = p_texture;
@@ -128,7 +128,7 @@ void Texture3DEditor::edit(Ref<Texture3D> p_texture) {
 			_make_shaders();
 		}
 
-		texture->add_change_receptor(this);
+		texture->connect("changed", callable_mp(this, &Texture3DEditor::_texture_changed));
 		update();
 		texture_rect->set_material(material);
 		setting = true;
@@ -184,7 +184,7 @@ Texture3DEditor::Texture3DEditor() {
 
 Texture3DEditor::~Texture3DEditor() {
 	if (!texture.is_null()) {
-		texture->remove_change_receptor(this);
+		texture->disconnect("changed", callable_mp(this, &Texture3DEditor::_texture_changed));
 	}
 }
 

--- a/editor/plugins/texture_3d_editor_plugin.h
+++ b/editor/plugins/texture_3d_editor_plugin.h
@@ -61,10 +61,12 @@ class Texture3DEditor : public Control {
 	void _texture_rect_update_area();
 	void _texture_rect_draw();
 
+	void _texture_changed();
+
 protected:
 	void _notification(int p_what);
 	void _gui_input(Ref<InputEvent> p_event);
-	void _changed_callback(Object *p_changed, const char *p_prop) override;
+
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -104,7 +104,7 @@ void TextureEditor::_notification(int p_what) {
 	}
 }
 
-void TextureEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+void TextureEditor::_texture_changed() {
 	if (!is_visible()) {
 		return;
 	}
@@ -113,13 +113,13 @@ void TextureEditor::_changed_callback(Object *p_changed, const char *p_prop) {
 
 void TextureEditor::edit(Ref<Texture2D> p_texture) {
 	if (!texture.is_null()) {
-		texture->remove_change_receptor(this);
+		texture->disconnect("changed", callable_mp(this, &TextureEditor::_texture_changed));
 	}
 
 	texture = p_texture;
 
 	if (!texture.is_null()) {
-		texture->add_change_receptor(this);
+		texture->connect("changed", callable_mp(this, &TextureEditor::_texture_changed));
 		update();
 	} else {
 		hide();
@@ -137,7 +137,7 @@ TextureEditor::TextureEditor() {
 
 TextureEditor::~TextureEditor() {
 	if (!texture.is_null()) {
-		texture->remove_change_receptor(this);
+		texture->disconnect("changed", callable_mp(this, &TextureEditor::_texture_changed));
 	}
 }
 

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -43,7 +43,7 @@ class TextureEditor : public Control {
 protected:
 	void _notification(int p_what);
 	void _gui_input(Ref<InputEvent> p_event);
-	void _changed_callback(Object *p_changed, const char *p_prop) override;
+	void _texture_changed();
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -63,7 +63,7 @@ void TextureLayeredEditor::_notification(int p_what) {
 	}
 }
 
-void TextureLayeredEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+void TextureLayeredEditor::_texture_changed() {
 	if (!is_visible()) {
 		return;
 	}
@@ -173,7 +173,7 @@ void TextureLayeredEditor::_texture_rect_update_area() {
 
 void TextureLayeredEditor::edit(Ref<TextureLayered> p_texture) {
 	if (!texture.is_null()) {
-		texture->remove_change_receptor(this);
+		texture->disconnect("changed", callable_mp(this, &TextureLayeredEditor::_texture_changed));
 	}
 
 	texture = p_texture;
@@ -183,7 +183,7 @@ void TextureLayeredEditor::edit(Ref<TextureLayered> p_texture) {
 			_make_shaders();
 		}
 
-		texture->add_change_receptor(this);
+		texture->connect("changed", callable_mp(this, &TextureLayeredEditor::_texture_changed));
 		update();
 		texture_rect->set_material(materials[texture->get_layered_type()]);
 		setting = true;
@@ -248,9 +248,6 @@ TextureLayeredEditor::TextureLayeredEditor() {
 }
 
 TextureLayeredEditor::~TextureLayeredEditor() {
-	if (!texture.is_null()) {
-		texture->remove_change_receptor(this);
-	}
 }
 
 //

--- a/editor/plugins/texture_layered_editor_plugin.h
+++ b/editor/plugins/texture_layered_editor_plugin.h
@@ -63,10 +63,11 @@ class TextureLayeredEditor : public Control {
 	void _texture_rect_update_area();
 	void _texture_rect_draw();
 
+	void _texture_changed();
+
 protected:
 	void _notification(int p_what);
 	void _gui_input(Ref<InputEvent> p_event);
-	void _changed_callback(Object *p_changed, const char *p_prop) override;
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -863,19 +863,19 @@ Sprite2D *TextureRegionEditor::get_sprite() {
 
 void TextureRegionEditor::edit(Object *p_obj) {
 	if (node_sprite) {
-		node_sprite->remove_change_receptor(this);
+		node_sprite->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (node_sprite_3d) {
-		node_sprite_3d->remove_change_receptor(this);
+		node_sprite_3d->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (node_ninepatch) {
-		node_ninepatch->remove_change_receptor(this);
+		node_ninepatch->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (obj_styleBox.is_valid()) {
-		obj_styleBox->remove_change_receptor(this);
+		obj_styleBox->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (atlas_tex.is_valid()) {
-		atlas_tex->remove_change_receptor(this);
+		atlas_tex->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (p_obj) {
 		node_sprite = Object::cast_to<Sprite2D>(p_obj);
@@ -887,7 +887,7 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		if (Object::cast_to<AtlasTexture>(p_obj)) {
 			atlas_tex = Ref<AtlasTexture>(Object::cast_to<AtlasTexture>(p_obj));
 		}
-		p_obj->add_change_receptor(this);
+		p_obj->connect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 		_edit_region();
 	} else {
 		node_sprite = nullptr;
@@ -905,14 +905,11 @@ void TextureRegionEditor::edit(Object *p_obj) {
 	}
 }
 
-void TextureRegionEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+void TextureRegionEditor::_texture_changed() {
 	if (!is_visible()) {
 		return;
 	}
-	String prop = p_prop;
-	if (prop == "atlas" || prop == "texture" || prop == "region") {
-		_edit_region();
-	}
+	_edit_region();
 }
 
 void TextureRegionEditor::_edit_region() {

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -117,14 +117,14 @@ class TextureRegionEditor : public VBoxContainer {
 	void _update_rect();
 	void _update_autoslice();
 
+	void _texture_changed();
+
 protected:
 	void _notification(int p_what);
 	void _node_removed(Object *p_obj);
 	static void _bind_methods();
 
 	Vector2 snap_point(Vector2 p_target) const;
-
-	virtual void _changed_callback(Object *p_changed, const char *p_prop) override;
 
 public:
 	void _edit_region();

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -39,7 +39,6 @@
 
 void TileSetEditor::edit(const Ref<TileSet> &p_tileset) {
 	tileset = p_tileset;
-	tileset->add_change_receptor(this);
 
 	texture_list->clear();
 	texture_map.clear();
@@ -1859,7 +1858,7 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 			_update_toggle_shape_button();
 			workspace->update();
 			workspace_container->update();
-			helper->_change_notify("");
+			helper->notify_property_list_changed();
 		}
 	} else if (p_tool == SELECT_NEXT) {
 		_select_next_shape();
@@ -2287,7 +2286,7 @@ void TileSetEditor::_select_next_shape() {
 		}
 		workspace->update();
 		workspace_container->update();
-		helper->_change_notify("");
+		helper->notify_property_list_changed();
 	}
 }
 
@@ -2349,7 +2348,7 @@ void TileSetEditor::_select_previous_shape() {
 		}
 		workspace->update();
 		workspace_container->update();
-		helper->_change_notify("");
+		helper->notify_property_list_changed();
 	}
 }
 
@@ -3012,7 +3011,7 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 		undo_redo->add_undo_method(this, "_select_edited_shape_coord");
 		undo_redo->commit_action();
 	}
-	tileset->_change_notify("");
+	tileset->notify_property_list_changed();
 }
 
 void TileSetEditor::select_coord(const Vector2 &coord) {
@@ -3115,7 +3114,7 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 	}
 	workspace->update();
 	workspace_container->update();
-	helper->_change_notify("");
+	helper->notify_property_list_changed();
 }
 
 Vector2 TileSetEditor::snap_point(const Vector2 &point) {
@@ -3225,7 +3224,7 @@ void TileSetEditor::update_texture_list() {
 		workspace_overlay->update();
 	}
 	update_texture_list_icon();
-	helper->_change_notify("");
+	helper->notify_property_list_changed();
 }
 
 void TileSetEditor::update_texture_list_icon() {
@@ -3389,7 +3388,7 @@ int TileSetEditor::get_current_tile() const {
 void TileSetEditor::set_current_tile(int p_id) {
 	if (current_tile != p_id) {
 		current_tile = p_id;
-		helper->_change_notify("");
+		helper->notify_property_list_changed();
 		select_coord(Vector2(0, 0));
 		update_workspace_tile_mode();
 		if (p_id == -1) {
@@ -3414,7 +3413,7 @@ void TilesetEditorContext::set_tileset(const Ref<TileSet> &p_tileset) {
 
 void TilesetEditorContext::set_snap_options_visible(bool p_visible) {
 	snap_options_visible = p_visible;
-	_change_notify("");
+	notify_property_list_changed();
 }
 
 bool TilesetEditorContext::_set(const StringName &p_name, const Variant &p_value) {
@@ -3450,7 +3449,7 @@ bool TilesetEditorContext::_set(const StringName &p_name, const Variant &p_value
 			tileset->set(String::num(tileset_editor->get_current_tile(), 0) + "/" + name2, p_value, &v);
 		}
 		if (v) {
-			tileset->_change_notify("");
+			tileset->notify_property_list_changed();
 			tileset_editor->workspace->update();
 			tileset_editor->workspace_overlay->update();
 		}

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -427,7 +427,7 @@ void ShaderGlobalsEditor::_variable_deleted(const String &p_variable) {
 void ShaderGlobalsEditor::_changed() {
 	emit_signal("globals_changed");
 	if (!interface->block_update) {
-		interface->_change_notify();
+		interface->notify_property_list_changed();
 	}
 }
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -59,7 +59,7 @@ void CSGShape3D::set_use_collision(bool p_enable) {
 		root_collision_instance = RID();
 		root_collision_shape.unref();
 	}
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool CSGShape3D::is_using_collision() const {
@@ -1033,7 +1033,6 @@ void CSGSphere3D::set_radius(const float p_radius) {
 	radius = p_radius;
 	_make_dirty();
 	update_gizmo();
-	_change_notify("radius");
 }
 
 float CSGSphere3D::get_radius() const {
@@ -1203,7 +1202,6 @@ void CSGBox3D::set_size(const Vector3 &p_size) {
 	size = p_size;
 	_make_dirty();
 	update_gizmo();
-	_change_notify("size");
 }
 
 Vector3 CSGBox3D::get_size() const {
@@ -1385,7 +1383,6 @@ void CSGCylinder3D::set_radius(const float p_radius) {
 	radius = p_radius;
 	_make_dirty();
 	update_gizmo();
-	_change_notify("radius");
 }
 
 float CSGCylinder3D::get_radius() const {
@@ -1396,7 +1393,6 @@ void CSGCylinder3D::set_height(const float p_height) {
 	height = p_height;
 	_make_dirty();
 	update_gizmo();
-	_change_notify("height");
 }
 
 float CSGCylinder3D::get_height() const {
@@ -1606,7 +1602,6 @@ void CSGTorus3D::set_inner_radius(const float p_inner_radius) {
 	inner_radius = p_inner_radius;
 	_make_dirty();
 	update_gizmo();
-	_change_notify("inner_radius");
 }
 
 float CSGTorus3D::get_inner_radius() const {
@@ -1617,7 +1612,6 @@ void CSGTorus3D::set_outer_radius(const float p_outer_radius) {
 	outer_radius = p_outer_radius;
 	_make_dirty();
 	update_gizmo();
-	_change_notify("outer_radius");
 }
 
 float CSGTorus3D::get_outer_radius() const {
@@ -2264,7 +2258,7 @@ void CSGPolygon3D::set_mode(Mode p_mode) {
 	mode = p_mode;
 	_make_dirty();
 	update_gizmo();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 CSGPolygon3D::Mode CSGPolygon3D::get_mode() const {

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -257,7 +257,7 @@ void GDNativeLibraryEditor::_translate_to_config_file() {
 			}
 		}
 
-		library->_change_notify();
+		library->notify_property_list_changed();
 	}
 }
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -189,7 +189,6 @@ void GridMap::set_mesh_library(const Ref<MeshLibrary> &p_mesh_library) {
 	}
 
 	_recreate_octant_data();
-	_change_notify("mesh_library");
 }
 
 Ref<MeshLibrary> GridMap::get_mesh_library() const {
@@ -700,8 +699,6 @@ void GridMap::_update_visibility() {
 	if (!is_inside_tree()) {
 		return;
 	}
-
-	_change_notify("visible");
 
 	for (Map<OctantKey, Octant *>::Element *e = octant_map.front(); e; e = e->next()) {
 		Octant *octant = e->value();

--- a/modules/opensimplex/noise_texture.cpp
+++ b/modules/opensimplex/noise_texture.cpp
@@ -216,7 +216,7 @@ void NoiseTexture::set_as_normal_map(bool p_as_normal_map) {
 	}
 	as_normal_map = p_as_normal_map;
 	_queue_update();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool NoiseTexture::is_normal_map() {

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -647,7 +647,7 @@ String VisualScriptBuiltinFunc::get_caption() const {
 void VisualScriptBuiltinFunc::set_func(BuiltinFunc p_which) {
 	ERR_FAIL_INDEX(p_which, FUNC_MAX);
 	func = p_which;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -61,7 +61,7 @@ protected:
 	}
 
 	void _sig_changed() {
-		_change_notify();
+		notify_property_list_changed();
 		emit_signal("changed");
 	}
 
@@ -172,7 +172,7 @@ protected:
 public:
 	void edit(const StringName &p_sig) {
 		sig = p_sig;
-		_change_notify();
+		notify_property_list_changed();
 	}
 
 	VisualScriptEditorSignalEdit() { undo_redo = nullptr; }
@@ -195,11 +195,10 @@ protected:
 	}
 
 	void _var_changed() {
-		_change_notify();
+		notify_property_list_changed();
 		emit_signal("changed");
 	}
 	void _var_value_changed() {
-		_change_notify("value"); // So the whole tree is not redrawn, makes editing smoother in general.
 		emit_signal("changed");
 	}
 
@@ -331,7 +330,7 @@ protected:
 public:
 	void edit(const StringName &p_var) {
 		var = p_var;
-		_change_notify();
+		notify_property_list_changed();
 	}
 
 	VisualScriptEditorVariableEdit() { undo_redo = nullptr; }

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -63,7 +63,7 @@ bool VisualScriptExpression::_set(const StringName &p_name, const Variant &p_val
 		}
 		expression_dirty = true;
 		ports_changed_notify();
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -628,7 +628,7 @@ VisualScriptNodeInstance *VisualScriptSwitch::instance(VisualScriptInstance *p_i
 bool VisualScriptSwitch::_set(const StringName &p_name, const Variant &p_value) {
 	if (String(p_name) == "case_count") {
 		case_values.resize(p_value);
-		_change_notify();
+		notify_property_list_changed();
 		ports_changed_notify();
 		return true;
 	}
@@ -638,7 +638,7 @@ bool VisualScriptSwitch::_set(const StringName &p_name, const Variant &p_value) 
 		ERR_FAIL_INDEX_V(idx, case_values.size(), false);
 
 		case_values.write[idx].type = Variant::Type(int(p_value));
-		_change_notify();
+		notify_property_list_changed();
 		ports_changed_notify();
 
 		return true;
@@ -733,7 +733,7 @@ void VisualScriptTypeCast::set_base_type(const StringName &p_type) {
 	}
 
 	base_type = p_type;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -747,7 +747,7 @@ void VisualScriptTypeCast::set_base_script(const String &p_path) {
 	}
 
 	script = p_path;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -281,7 +281,7 @@ void VisualScriptFunctionCall::set_basic_type(Variant::Type p_type) {
 	}
 	basic_type = p_type;
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -295,7 +295,7 @@ void VisualScriptFunctionCall::set_base_type(const StringName &p_type) {
 	}
 
 	base_type = p_type;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -309,7 +309,7 @@ void VisualScriptFunctionCall::set_base_script(const String &p_path) {
 	}
 
 	base_script = p_path;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -328,7 +328,7 @@ void VisualScriptFunctionCall::set_singleton(const StringName &p_type) {
 		base_type = obj->get_class();
 	}
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -425,7 +425,7 @@ void VisualScriptFunctionCall::set_function(const StringName &p_type) {
 		_update_method_cache();
 	}
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -439,7 +439,7 @@ void VisualScriptFunctionCall::set_base_path(const NodePath &p_type) {
 	}
 
 	base_path = p_type;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -453,7 +453,7 @@ void VisualScriptFunctionCall::set_call_mode(CallMode p_mode) {
 	}
 
 	call_mode = p_mode;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -476,7 +476,7 @@ void VisualScriptFunctionCall::set_rpc_call_mode(VisualScriptFunctionCall::RPCCa
 	}
 	rpc_call_mode = p_mode;
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 VisualScriptFunctionCall::RPCCallMode VisualScriptFunctionCall::get_rpc_call_mode() const {
@@ -1067,7 +1067,7 @@ void VisualScriptPropertySet::set_basic_type(Variant::Type p_type) {
 	}
 	basic_type = p_type;
 
-	_change_notify();
+	notify_property_list_changed();
 	_update_base_type();
 	ports_changed_notify();
 }
@@ -1082,7 +1082,7 @@ void VisualScriptPropertySet::set_base_type(const StringName &p_type) {
 	}
 
 	base_type = p_type;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1096,7 +1096,7 @@ void VisualScriptPropertySet::set_base_script(const String &p_path) {
 	}
 
 	base_script = p_path;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1191,7 +1191,7 @@ void VisualScriptPropertySet::set_property(const StringName &p_type) {
 	property = p_type;
 	index = StringName();
 	_update_cache();
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1206,7 +1206,7 @@ void VisualScriptPropertySet::set_base_path(const NodePath &p_type) {
 
 	base_path = p_type;
 	_update_base_type();
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1221,7 +1221,7 @@ void VisualScriptPropertySet::set_call_mode(CallMode p_mode) {
 
 	call_mode = p_mode;
 	_update_base_type();
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1243,7 +1243,7 @@ void VisualScriptPropertySet::set_index(const StringName &p_type) {
 	}
 	index = p_type;
 	_update_cache();
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1259,7 +1259,7 @@ void VisualScriptPropertySet::set_assign_op(AssignOp p_op) {
 
 	assign_op = p_op;
 	_update_cache();
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1760,7 +1760,7 @@ void VisualScriptPropertyGet::set_base_type(const StringName &p_type) {
 	}
 
 	base_type = p_type;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1774,7 +1774,7 @@ void VisualScriptPropertyGet::set_base_script(const String &p_path) {
 	}
 
 	base_script = p_path;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1871,7 +1871,7 @@ void VisualScriptPropertyGet::set_property(const StringName &p_type) {
 	property = p_type;
 
 	_update_cache();
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1885,7 +1885,7 @@ void VisualScriptPropertyGet::set_base_path(const NodePath &p_type) {
 	}
 
 	base_path = p_type;
-	_change_notify();
+	notify_property_list_changed();
 	_update_base_type();
 	ports_changed_notify();
 }
@@ -1900,7 +1900,7 @@ void VisualScriptPropertyGet::set_call_mode(CallMode p_mode) {
 	}
 
 	call_mode = p_mode;
-	_change_notify();
+	notify_property_list_changed();
 	_update_base_type();
 	ports_changed_notify();
 }
@@ -1915,7 +1915,7 @@ void VisualScriptPropertyGet::set_basic_type(Variant::Type p_type) {
 	}
 	basic_type = p_type;
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1937,7 +1937,7 @@ void VisualScriptPropertyGet::set_index(const StringName &p_type) {
 	}
 	index = p_type;
 	_update_cache();
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -2261,7 +2261,7 @@ void VisualScriptEmitSignal::set_signal(const StringName &p_type) {
 
 	name = p_type;
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -57,7 +57,7 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 			arguments.write[i].type = Variant::NIL;
 		}
 		ports_changed_notify();
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 	if (String(p_name).begins_with("argument_")) {
@@ -312,7 +312,7 @@ VisualScriptFunction::VisualScriptFunction() {
 
 void VisualScriptFunction::set_stack_less(bool p_enable) {
 	stack_less = p_enable;
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool VisualScriptFunction::is_stack_less() const {
@@ -421,7 +421,7 @@ bool VisualScriptLists::_set(const StringName &p_name, const Variant &p_value) {
 			inputports.write[i].type = Variant::NIL;
 		}
 		ports_changed_notify();
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 	if (String(p_name).begins_with("input_") && is_input_port_editable()) {
@@ -457,7 +457,7 @@ bool VisualScriptLists::_set(const StringName &p_name, const Variant &p_value) {
 			outputports.write[i].type = Variant::NIL;
 		}
 		ports_changed_notify();
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 	if (String(p_name).begins_with("output_") && is_output_port_editable()) {
@@ -578,7 +578,7 @@ void VisualScriptLists::add_input_data_port(Variant::Type p_type, const String &
 	}
 
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void VisualScriptLists::set_input_data_port_type(int p_idx, Variant::Type p_type) {
@@ -590,7 +590,7 @@ void VisualScriptLists::set_input_data_port_type(int p_idx, Variant::Type p_type
 
 	inputports.write[p_idx].type = p_type;
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void VisualScriptLists::set_input_data_port_name(int p_idx, const String &p_name) {
@@ -602,7 +602,7 @@ void VisualScriptLists::set_input_data_port_name(int p_idx, const String &p_name
 
 	inputports.write[p_idx].name = p_name;
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void VisualScriptLists::remove_input_data_port(int p_argidx) {
@@ -615,7 +615,7 @@ void VisualScriptLists::remove_input_data_port(int p_argidx) {
 	inputports.remove(p_argidx);
 
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 // output data port interaction
@@ -634,7 +634,7 @@ void VisualScriptLists::add_output_data_port(Variant::Type p_type, const String 
 	}
 
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void VisualScriptLists::set_output_data_port_type(int p_idx, Variant::Type p_type) {
@@ -646,7 +646,7 @@ void VisualScriptLists::set_output_data_port_type(int p_idx, Variant::Type p_typ
 
 	outputports.write[p_idx].type = p_type;
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void VisualScriptLists::set_output_data_port_name(int p_idx, const String &p_name) {
@@ -658,7 +658,7 @@ void VisualScriptLists::set_output_data_port_name(int p_idx, const String &p_nam
 
 	outputports.write[p_idx].name = p_name;
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void VisualScriptLists::remove_output_data_port(int p_argidx) {
@@ -671,7 +671,7 @@ void VisualScriptLists::remove_output_data_port(int p_argidx) {
 	outputports.remove(p_argidx);
 
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 // sequences
@@ -1433,7 +1433,7 @@ void VisualScriptConstant::set_constant_type(Variant::Type p_type) {
 	Callable::CallError ce;
 	Variant::construct(type, value, nullptr, 0, ce);
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Variant::Type VisualScriptConstant::get_constant_type() const {
@@ -1764,7 +1764,7 @@ String VisualScriptGlobalConstant::get_caption() const {
 
 void VisualScriptGlobalConstant::set_global_constant(int p_which) {
 	index = p_which;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1850,7 +1850,7 @@ String VisualScriptClassConstant::get_caption() const {
 
 void VisualScriptClassConstant::set_class_constant(const StringName &p_which) {
 	name = p_which;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1876,7 +1876,7 @@ void VisualScriptClassConstant::set_base_type(const StringName &p_which) {
 	} else {
 		name = "";
 	}
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -1983,7 +1983,7 @@ String VisualScriptBasicTypeConstant::get_text() const {
 
 void VisualScriptBasicTypeConstant::set_basic_type_constant(const StringName &p_which) {
 	name = p_which;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -2010,7 +2010,7 @@ void VisualScriptBasicTypeConstant::set_basic_type(Variant::Type p_which) {
 	} else {
 		name = "";
 	}
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -2140,7 +2140,7 @@ String VisualScriptMathConstant::get_caption() const {
 
 void VisualScriptMathConstant::set_math_constant(MathConstant p_which) {
 	constant = p_which;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -2233,7 +2233,7 @@ String VisualScriptEngineSingleton::get_caption() const {
 void VisualScriptEngineSingleton::set_singleton(const String &p_string) {
 	singleton = p_string;
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -2342,7 +2342,7 @@ String VisualScriptSceneNode::get_caption() const {
 
 void VisualScriptSceneNode::set_node_path(const NodePath &p_path) {
 	path = p_path;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -2620,7 +2620,7 @@ String VisualScriptResourcePath::get_caption() const {
 
 void VisualScriptResourcePath::set_resource_path(const String &p_path) {
 	path = p_path;
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -3748,7 +3748,7 @@ void VisualScriptDeconstruct::set_deconstruct_type(Variant::Type p_type) {
 	type = p_type;
 	_update_elements();
 	ports_changed_notify();
-	_change_notify(); //to make input appear/disappear
+	notify_property_list_changed(); //to make input appear/disappear
 }
 
 Variant::Type VisualScriptDeconstruct::get_deconstruct_type() const {

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -152,7 +152,7 @@ void VisualScriptYield::set_yield_mode(YieldMode p_mode) {
 	}
 	yield_mode = p_mode;
 	ports_changed_notify();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 VisualScriptYield::YieldMode VisualScriptYield::get_yield_mode() {
@@ -359,7 +359,7 @@ void VisualScriptYieldSignal::set_base_type(const StringName &p_type) {
 
 	base_type = p_type;
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -374,7 +374,7 @@ void VisualScriptYieldSignal::set_signal(const StringName &p_type) {
 
 	signal = p_type;
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -389,7 +389,7 @@ void VisualScriptYieldSignal::set_base_path(const NodePath &p_type) {
 
 	base_path = p_type;
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 
@@ -404,7 +404,7 @@ void VisualScriptYieldSignal::set_call_mode(CallMode p_mode) {
 
 	call_mode = p_mode;
 
-	_change_notify();
+	notify_property_list_changed();
 	ports_changed_notify();
 }
 

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -409,7 +409,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 					}
 
 					update();
-					_change_notify("frame");
+
 					emit_signal(SceneStringNames::get_singleton()->frame_changed);
 				}
 
@@ -477,7 +477,7 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 		set_frame(frame);
 	}
 
-	_change_notify();
+	notify_property_list_changed();
 	_reset_timeout();
 	update();
 	update_configuration_warning();
@@ -510,7 +510,7 @@ void AnimatedSprite2D::set_frame(int p_frame) {
 	frame = p_frame;
 	_reset_timeout();
 	update();
-	_change_notify("frame");
+
 	emit_signal(SceneStringNames::get_singleton()->frame_changed);
 }
 
@@ -546,7 +546,6 @@ void AnimatedSprite2D::set_offset(const Point2 &p_offset) {
 	offset = p_offset;
 	update();
 	item_rect_changed();
-	_change_notify("offset");
 }
 
 Point2 AnimatedSprite2D::get_offset() const {
@@ -573,8 +572,7 @@ bool AnimatedSprite2D::is_flipped_v() const {
 
 void AnimatedSprite2D::_res_changed() {
 	set_frame(frame);
-	_change_notify("frame");
-	_change_notify("animation");
+
 	update();
 }
 
@@ -642,7 +640,7 @@ void AnimatedSprite2D::set_animation(const StringName &p_animation) {
 	animation = p_animation;
 	_reset_timeout();
 	set_frame(0);
-	_change_notify();
+	notify_property_list_changed();
 	update();
 }
 

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -249,15 +249,11 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 			setseek = setplay;
 			active = true;
 			setplay = -1;
-			//do not update, this makes it easier to animate (will shut off otherwise)
-			//_change_notify("playing"); //update property in editor
 		}
 
 		//stop playing if no longer active
 		if (!active) {
 			set_physics_process_internal(false);
-			//do not update, this makes it easier to animate (will shut off otherwise)
-			//_change_notify("playing"); //update property in editor
 			emit_signal("finished");
 		}
 	}
@@ -404,7 +400,7 @@ void AudioStreamPlayer2D::_validate_property(PropertyInfo &property) const {
 }
 
 void AudioStreamPlayer2D::_bus_layout_changed() {
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void AudioStreamPlayer2D::set_max_distance(float p_pixels) {

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -410,7 +410,7 @@ bool CPUParticles2D::get_particle_flag(ParticleFlags p_particle_flag) const {
 void CPUParticles2D::set_emission_shape(EmissionShape p_shape) {
 	ERR_FAIL_INDEX(p_shape, EMISSION_SHAPE_MAX);
 	emission_shape = p_shape;
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void CPUParticles2D::set_emission_sphere_radius(float p_radius) {
@@ -599,7 +599,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 		cycle++;
 		if (one_shot && cycle > 0) {
 			set_emitting(false);
-			_change_notify();
+			notify_property_list_changed();
 		}
 	}
 

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -101,7 +101,6 @@ void GPUParticles2D::set_visibility_rect(const Rect2 &p_visibility_rect) {
 
 	RS::get_singleton()->particles_set_custom_aabb(particles, aabb);
 
-	_change_notify("visibility_rect");
 	update();
 }
 
@@ -305,7 +304,7 @@ void GPUParticles2D::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
 		if (one_shot && !is_emitting()) {
-			_change_notify();
+			notify_property_list_changed();
 			set_process_internal(false);
 		}
 	}

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -377,7 +377,6 @@ void PointLight2D::set_texture_offset(const Vector2 &p_offset) {
 	texture_offset = p_offset;
 	RS::get_singleton()->canvas_light_set_texture_offset(_get_light(), texture_offset);
 	item_rect_changed();
-	_change_notify("offset");
 }
 
 Vector2 PointLight2D::get_texture_offset() const {

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -71,7 +71,6 @@ void MeshInstance2D::set_texture(const Ref<Texture2D> &p_texture) {
 	texture = p_texture;
 	update();
 	emit_signal("texture_changed");
-	_change_notify("texture");
 }
 
 void MeshInstance2D::set_normal_map(const Ref<Texture2D> &p_texture) {

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -71,7 +71,6 @@ void MultiMeshInstance2D::set_texture(const Ref<Texture2D> &p_texture) {
 	texture = p_texture;
 	update();
 	emit_signal("texture_changed");
-	_change_notify("texture");
 }
 
 Ref<Texture2D> MultiMeshInstance2D::get_texture() const {

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -481,7 +481,6 @@ void NavigationRegion2D::set_navigation_polygon(const Ref<NavigationPolygon> &p_
 	}
 	_navpoly_changed();
 
-	_change_notify("navpoly");
 	update_configuration_warning();
 }
 

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -53,12 +53,6 @@ void Node2D::_edit_set_state(const Dictionary &p_state) {
 	skew = p_state["skew"];
 
 	_update_transform();
-	_change_notify("rotation");
-	_change_notify("rotation_degrees");
-	_change_notify("scale");
-	_change_notify("skew");
-	_change_notify("skew_degrees");
-	_change_notify("position");
 }
 
 void Node2D::_edit_set_position(const Point2 &p_position) {
@@ -80,8 +74,6 @@ Size2 Node2D::_edit_get_scale() const {
 void Node2D::_edit_set_rotation(float p_rotation) {
 	angle = p_rotation;
 	_update_transform();
-	_change_notify("rotation");
-	_change_notify("rotation_degrees");
 }
 
 float Node2D::_edit_get_rotation() const {
@@ -124,8 +116,6 @@ void Node2D::_edit_set_rect(const Rect2 &p_edit_rect) {
 	_scale *= new_scale;
 
 	_update_transform();
-	_change_notify("scale");
-	_change_notify("position");
 }
 #endif
 
@@ -156,7 +146,6 @@ void Node2D::set_position(const Point2 &p_pos) {
 	}
 	pos = p_pos;
 	_update_transform();
-	_change_notify("position");
 }
 
 void Node2D::set_rotation(float p_radians) {
@@ -165,8 +154,6 @@ void Node2D::set_rotation(float p_radians) {
 	}
 	angle = p_radians;
 	_update_transform();
-	_change_notify("rotation");
-	_change_notify("rotation_degrees");
 }
 
 void Node2D::set_skew(float p_radians) {
@@ -175,8 +162,6 @@ void Node2D::set_skew(float p_radians) {
 	}
 	skew = p_radians;
 	_update_transform();
-	_change_notify("skew");
-	_change_notify("skew_degrees");
 }
 
 void Node2D::set_rotation_degrees(float p_degrees) {
@@ -200,7 +185,6 @@ void Node2D::set_scale(const Size2 &p_scale) {
 		_scale.y = CMP_EPSILON;
 	}
 	_update_transform();
-	_change_notify("scale");
 }
 
 Point2 Node2D::get_position() const {
@@ -358,7 +342,6 @@ void Node2D::set_z_index(int p_z) {
 	ERR_FAIL_COND(p_z > RS::CANVAS_ITEM_Z_MAX);
 	z_index = p_z;
 	RS::get_singleton()->canvas_item_set_z_index(get_canvas_item(), z_index);
-	_change_notify("z_index");
 }
 
 void Node2D::set_z_as_relative(bool p_enabled) {

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -319,8 +319,6 @@ void PathFollow2D::set_offset(float p_offset) {
 
 		_update_transform();
 	}
-	_change_notify("offset");
-	_change_notify("unit_offset");
 }
 
 void PathFollow2D::set_h_offset(float p_h_offset) {

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -483,7 +483,6 @@ void Polygon2D::set_offset(const Vector2 &p_offset) {
 	offset = p_offset;
 	rect_cache_dirty = true;
 	update();
-	_change_notify("offset");
 }
 
 Vector2 Polygon2D::get_offset() const {

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -155,7 +155,6 @@ void Sprite2D::set_texture(const Ref<Texture2D> &p_texture) {
 	update();
 	emit_signal("texture_changed");
 	item_rect_changed();
-	_change_notify("texture");
 }
 
 Ref<Texture2D> Sprite2D::get_texture() const {
@@ -176,7 +175,6 @@ void Sprite2D::set_offset(const Point2 &p_offset) {
 	offset = p_offset;
 	update();
 	item_rect_changed();
-	_change_notify("offset");
 }
 
 Point2 Sprite2D::get_offset() const {
@@ -224,8 +222,6 @@ void Sprite2D::set_region_rect(const Rect2 &p_region_rect) {
 	if (region) {
 		item_rect_changed();
 	}
-
-	_change_notify("region_rect");
 }
 
 Rect2 Sprite2D::get_region_rect() const {
@@ -250,8 +246,6 @@ void Sprite2D::set_frame(int p_frame) {
 
 	frame = p_frame;
 
-	_change_notify("frame");
-	_change_notify("frame_coords");
 	emit_signal(SceneStringNames::get_singleton()->frame_changed);
 }
 
@@ -275,7 +269,7 @@ void Sprite2D::set_vframes(int p_amount) {
 	vframes = p_amount;
 	update();
 	item_rect_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int Sprite2D::get_vframes() const {
@@ -287,7 +281,7 @@ void Sprite2D::set_hframes(int p_amount) {
 	hframes = p_amount;
 	update();
 	item_rect_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int Sprite2D::get_hframes() const {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -165,7 +165,6 @@ void TileMap::_update_quadrant_transform() {
 void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 	if (tile_set.is_valid()) {
 		tile_set->disconnect("changed", callable_mp(this, &TileMap::_recreate_quadrants));
-		tile_set->remove_change_receptor(this);
 	}
 
 	_clear_quadrants();
@@ -173,7 +172,6 @@ void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 
 	if (tile_set.is_valid()) {
 		tile_set->connect("changed", callable_mp(this, &TileMap::_recreate_quadrants));
-		tile_set->add_change_receptor(this);
 	} else {
 		clear();
 	}
@@ -1330,7 +1328,7 @@ void TileMap::set_collision_use_parent(bool p_use_parent) {
 	}
 
 	_recreate_quadrants();
-	_change_notify();
+	notify_property_list_changed();
 	update_configuration_warning();
 }
 
@@ -1865,21 +1863,11 @@ void TileMap::_bind_methods() {
 	BIND_ENUM_CONSTANT(TILE_ORIGIN_BOTTOM_LEFT);
 }
 
-void TileMap::_changed_callback(Object *p_changed, const char *p_prop) {
-	if (tile_set.is_valid() && tile_set.ptr() == p_changed) {
-		emit_signal("settings_changed");
-	}
-}
-
 TileMap::TileMap() {
 	set_notify_transform(true);
 	set_notify_local_transform(false);
 }
 
 TileMap::~TileMap() {
-	if (tile_set.is_valid()) {
-		tile_set->remove_change_receptor(this);
-	}
-
 	clear();
 }

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -232,7 +232,6 @@ protected:
 	static void _bind_methods();
 
 	virtual void _validate_property(PropertyInfo &property) const override;
-	virtual void _changed_callback(Object *p_changed, const char *p_prop) override;
 
 public:
 	enum {

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -89,8 +89,6 @@ void VisibilityNotifier2D::set_rect(const Rect2 &p_rect) {
 			item_rect_changed();
 		}
 	}
-
-	_change_notify("rect");
 }
 
 Rect2 VisibilityNotifier2D::get_rect() const {

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -605,15 +605,11 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 			setseek = setplay;
 			active = true;
 			setplay = -1;
-			//do not update, this makes it easier to animate (will shut off otherwise)
-			///_change_notify("playing"); //update property in editor
 		}
 
 		//stop playing if no longer active
 		if (!active) {
 			set_physics_process_internal(false);
-			//do not update, this makes it easier to animate (will shut off otherwise)
-			//_change_notify("playing"); //update property in editor
 			emit_signal("finished");
 		}
 	}
@@ -776,7 +772,7 @@ void AudioStreamPlayer3D::_validate_property(PropertyInfo &property) const {
 }
 
 void AudioStreamPlayer3D::_bus_layout_changed() {
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void AudioStreamPlayer3D::set_max_distance(float p_metres) {
@@ -809,7 +805,6 @@ void AudioStreamPlayer3D::set_emission_angle(float p_angle) {
 	ERR_FAIL_COND(p_angle < 0 || p_angle > 90);
 	emission_angle = p_angle;
 	update_gizmo();
-	_change_notify("emission_angle");
 }
 
 float AudioStreamPlayer3D::get_emission_angle() const {

--- a/scene/3d/baked_lightmap.cpp
+++ b/scene/3d/baked_lightmap.cpp
@@ -1302,7 +1302,7 @@ bool BakedLightmap::is_interior() const {
 
 void BakedLightmap::set_environment_mode(EnvironmentMode p_mode) {
 	environment_mode = p_mode;
-	_change_notify();
+	notify_property_list_changed();
 }
 
 BakedLightmap::EnvironmentMode BakedLightmap::get_environment_mode() const {

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -209,7 +209,7 @@ void Camera3D::set_projection(Camera3D::Projection p_mode) {
 	if (p_mode == PROJECTION_PERSPECTIVE || p_mode == PROJECTION_ORTHOGONAL || p_mode == PROJECTION_FRUSTUM) {
 		mode = p_mode;
 		_update_camera_mode();
-		_change_notify();
+		notify_property_list_changed();
 	}
 }
 
@@ -432,7 +432,7 @@ void Camera3D::set_keep_aspect_mode(KeepAspect p_aspect) {
 	keep_aspect = p_aspect;
 	RenderingServer::get_singleton()->camera_set_use_vertical_aspect(camera, p_aspect == KEEP_WIDTH);
 	_update_camera_mode();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Camera3D::KeepAspect Camera3D::get_keep_aspect_mode() const {
@@ -562,14 +562,12 @@ void Camera3D::set_fov(float p_fov) {
 	ERR_FAIL_COND(p_fov < 1 || p_fov > 179);
 	fov = p_fov;
 	_update_camera_mode();
-	_change_notify("fov");
 }
 
 void Camera3D::set_size(float p_size) {
 	ERR_FAIL_COND(p_size < 0.1 || p_size > 16384);
 	size = p_size;
 	_update_camera_mode();
-	_change_notify("size");
 }
 
 void Camera3D::set_near(float p_near) {

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -372,7 +372,7 @@ void CPUParticles3D::set_particle_flag(ParticleFlags p_particle_flag, bool p_ena
 	ERR_FAIL_INDEX(p_particle_flag, PARTICLE_FLAG_MAX);
 	particle_flags[p_particle_flag] = p_enable;
 	if (p_particle_flag == PARTICLE_FLAG_DISABLE_Z) {
-		_change_notify();
+		notify_property_list_changed();
 	}
 }
 
@@ -575,7 +575,7 @@ void CPUParticles3D::_particles_process(float p_delta) {
 		cycle++;
 		if (one_shot && cycle > 0) {
 			set_emitting(false);
-			_change_notify();
+			notify_property_list_changed();
 		}
 	}
 

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -34,7 +34,6 @@ void Decal::set_extents(const Vector3 &p_extents) {
 	extents = p_extents;
 	RS::get_singleton()->decal_set_extents(decal, p_extents);
 	update_gizmo();
-	_change_notify("extents");
 }
 
 Vector3 Decal::get_extents() const {

--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -323,7 +323,6 @@ GIProbe::Subdiv GIProbe::get_subdiv() const {
 void GIProbe::set_extents(const Vector3 &p_extents) {
 	extents = p_extents;
 	update_gizmo();
-	_change_notify("extents");
 }
 
 Vector3 GIProbe::get_extents() const {
@@ -486,7 +485,7 @@ void GIProbe::bake(Node *p_from_node, bool p_create_visual_debug) {
 		bake_end_function();
 	}
 
-	_change_notify(); //bake property may have changed
+	notify_property_list_changed(); //bake property may have changed
 }
 
 void GIProbe::_debug_bake() {

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -100,7 +100,6 @@ void GPUParticles3D::set_visibility_aabb(const AABB &p_aabb) {
 	visibility_aabb = p_aabb;
 	RS::get_singleton()->particles_set_custom_aabb(particles, visibility_aabb);
 	update_gizmo();
-	_change_notify("visibility_aabb");
 }
 
 void GPUParticles3D::set_use_local_coordinates(bool p_enable) {
@@ -190,7 +189,7 @@ void GPUParticles3D::set_draw_passes(int p_count) {
 	ERR_FAIL_COND(p_count < 1);
 	draw_passes.resize(p_count);
 	RS::get_singleton()->particles_set_draw_passes(particles, p_count);
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int GPUParticles3D::get_draw_passes() const {
@@ -353,7 +352,7 @@ void GPUParticles3D::_notification(int p_what) {
 	// the shot ends the editor can properly update
 	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
 		if (one_shot && !is_emitting()) {
-			_change_notify();
+			notify_property_list_changed();
 			set_process_internal(false);
 		}
 	}

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -48,11 +48,7 @@ void Light3D::set_param(Param p_param, float p_value) {
 		update_gizmo();
 
 		if (p_param == PARAM_SPOT_ANGLE) {
-			_change_notify("spot_angle");
 			update_configuration_warning();
-		} else if (p_param == PARAM_RANGE) {
-			_change_notify("omni_range");
-			_change_notify("spot_range");
 		}
 	}
 }
@@ -184,8 +180,6 @@ void Light3D::_update_visibility() {
 #endif
 
 	RS::get_singleton()->instance_set_visible(get_instance(), is_visible_in_tree() && editor_ok);
-
-	_change_notify("geometry/visible");
 }
 
 void Light3D::_notification(int p_what) {

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -135,7 +135,7 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 
 	update_gizmo();
 
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Ref<Mesh> MeshInstance3D::get_mesh() const {
@@ -152,7 +152,7 @@ void MeshInstance3D::_resolve_skeleton_path() {
 			if (skin_internal.is_null()) {
 				//a skin was created for us
 				skin_internal = new_skin_reference->get_skin();
-				_change_notify();
+				notify_property_list_changed();
 			}
 		}
 	}

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -124,13 +124,13 @@ void NavigationRegion3D::set_navigation_mesh(const Ref<NavigationMesh> &p_navmes
 	}
 
 	if (navmesh.is_valid()) {
-		navmesh->remove_change_receptor(this);
+		navmesh->disconnect("changed", callable_mp(this, &NavigationRegion3D::_navigation_changed));
 	}
 
 	navmesh = p_navmesh;
 
 	if (navmesh.is_valid()) {
-		navmesh->add_change_receptor(this);
+		navmesh->connect("changed", callable_mp(this, &NavigationRegion3D::_navigation_changed));
 	}
 
 	NavigationServer3D::get_singleton()->region_set_navmesh(region, p_navmesh);
@@ -230,7 +230,7 @@ void NavigationRegion3D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("bake_finished"));
 }
 
-void NavigationRegion3D::_changed_callback(Object *p_changed, const char *p_prop) {
+void NavigationRegion3D::_navigation_changed() {
 	update_gizmo();
 	update_configuration_warning();
 }
@@ -242,7 +242,7 @@ NavigationRegion3D::NavigationRegion3D() {
 
 NavigationRegion3D::~NavigationRegion3D() {
 	if (navmesh.is_valid()) {
-		navmesh->remove_change_receptor(this);
+		navmesh->disconnect("changed", callable_mp(this, &NavigationRegion3D::_navigation_changed));
 	}
 	NavigationServer3D::get_singleton()->free(region);
 }

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -48,10 +48,11 @@ class NavigationRegion3D : public Node3D {
 	Node *debug_view = nullptr;
 	Thread bake_thread;
 
+	void _navigation_changed();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	void _changed_callback(Object *p_changed, const char *p_prop) override;
 
 public:
 	void set_enabled(bool p_enabled);

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -226,10 +226,6 @@ void Node3D::_notification(int p_what) {
 void Node3D::set_transform(const Transform &p_transform) {
 	data.local_transform = p_transform;
 	data.dirty |= DIRTY_VECTORS;
-	_change_notify("translation");
-	_change_notify("rotation");
-	_change_notify("rotation_degrees");
-	_change_notify("scale");
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
 		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
@@ -307,7 +303,6 @@ Transform Node3D::get_relative_transform(const Node *p_parent) const {
 
 void Node3D::set_translation(const Vector3 &p_translation) {
 	data.local_transform.origin = p_translation;
-	_change_notify("transform");
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
 		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
@@ -322,7 +317,6 @@ void Node3D::set_rotation(const Vector3 &p_euler_rad) {
 
 	data.rotation = p_euler_rad;
 	data.dirty |= DIRTY_LOCAL;
-	_change_notify("transform");
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
 		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
@@ -341,7 +335,6 @@ void Node3D::set_scale(const Vector3 &p_scale) {
 
 	data.scale = p_scale;
 	data.dirty |= DIRTY_LOCAL;
-	_change_notify("transform");
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
 		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
@@ -495,7 +488,6 @@ Ref<World3D> Node3D::get_world_3d() const {
 void Node3D::_propagate_visibility_changed() {
 	notification(NOTIFICATION_VISIBILITY_CHANGED);
 	emit_signal(SceneStringNames::get_singleton()->visibility_changed);
-	_change_notify("visible");
 #ifdef TOOLS_ENABLED
 	if (data.gizmo.is_valid()) {
 		_update_gizmo();

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -323,8 +323,6 @@ void PathFollow3D::set_offset(float p_offset) {
 
 		_update_transform();
 	}
-	_change_notify("offset");
-	_change_notify("unit_offset");
 }
 
 void PathFollow3D::set_h_offset(float p_h_offset) {

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -2327,7 +2327,7 @@ void PhysicalBone3D::set_joint_type(JointType p_joint_type) {
 	_reload_joint();
 
 #ifdef TOOLS_ENABLED
-	_change_notify();
+	notify_property_list_changed();
 	if (get_gizmo().is_valid()) {
 		get_gizmo()->redraw();
 	}
@@ -2342,7 +2342,6 @@ void PhysicalBone3D::set_joint_offset(const Transform &p_offset) {
 	joint_offset = p_offset;
 
 	_update_joint_offset();
-	_change_notify("joint_rotation_degrees");
 }
 
 const Transform &PhysicalBone3D::get_joint_offset() const {
@@ -2353,7 +2352,6 @@ void PhysicalBone3D::set_joint_rotation(const Vector3 &p_euler_rad) {
 	joint_offset.basis.set_euler_scale(p_euler_rad, joint_offset.basis.get_scale());
 
 	_update_joint_offset();
-	_change_notify("joint_offset");
 }
 
 Vector3 PhysicalBone3D::get_joint_rotation() const {

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -42,7 +42,7 @@ float ReflectionProbe::get_intensity() const {
 void ReflectionProbe::set_ambient_mode(AmbientMode p_mode) {
 	ambient_mode = p_mode;
 	RS::get_singleton()->reflection_probe_set_ambient_mode(probe, RS::ReflectionProbeAmbientMode(p_mode));
-	_change_notify();
+	notify_property_list_changed();
 }
 
 ReflectionProbe::AmbientMode ReflectionProbe::get_ambient_mode() const {
@@ -95,13 +95,12 @@ void ReflectionProbe::set_extents(const Vector3 &p_extents) {
 
 		if (extents[i] - 0.01 < ABS(origin_offset[i])) {
 			origin_offset[i] = SGN(origin_offset[i]) * (extents[i] - 0.01);
-			_change_notify("origin_offset");
 		}
 	}
 
 	RS::get_singleton()->reflection_probe_set_extents(probe, extents);
 	RS::get_singleton()->reflection_probe_set_origin_offset(probe, origin_offset);
-	_change_notify("extents");
+
 	update_gizmo();
 }
 
@@ -120,7 +119,6 @@ void ReflectionProbe::set_origin_offset(const Vector3 &p_extents) {
 	RS::get_singleton()->reflection_probe_set_extents(probe, extents);
 	RS::get_singleton()->reflection_probe_set_origin_offset(probe, origin_offset);
 
-	_change_notify("origin_offset");
 	update_gizmo();
 }
 

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -245,13 +245,11 @@ bool SoftBody3D::_get_property_pinned_points(int p_item, const String &p_what, V
 	return true;
 }
 
-void SoftBody3D::_changed_callback(Object *p_changed, const char *p_prop) {
+void SoftBody3D::_softbody_changed() {
 	prepare_physics_server();
 	_reset_points_offsets();
 #ifdef TOOLS_ENABLED
-	if (p_changed == this) {
-		update_configuration_warning();
-	}
+	update_configuration_warning();
 #endif
 }
 
@@ -259,7 +257,9 @@ void SoftBody3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_WORLD: {
 			if (Engine::get_singleton()->is_editor_hint()) {
-				add_change_receptor(this);
+				// I have no idea what this is supposed to do, it's really weird
+				// leaving for upcoming PK work on physics
+				//add_change_receptor(this);
 			}
 
 			RID space = get_world_3d()->get_space();

--- a/scene/3d/soft_body_3d.h
+++ b/scene/3d/soft_body_3d.h
@@ -98,6 +98,8 @@ private:
 
 	void _update_pickable();
 
+	void _softbody_changed();
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
@@ -106,8 +108,6 @@ protected:
 	bool _set_property_pinned_points_indices(const Array &p_indices);
 	bool _set_property_pinned_points_attachment(int p_item, const String &p_what, const Variant &p_value);
 	bool _get_property_pinned_points(int p_item, const String &p_what, Variant &r_ret) const;
-
-	virtual void _changed_callback(Object *p_changed, const char *p_prop) override;
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -543,8 +543,6 @@ void Sprite3D::set_frame(int p_frame) {
 
 	_queue_update();
 
-	_change_notify("frame");
-	_change_notify("frame_coords");
 	emit_signal(SceneStringNames::get_singleton()->frame_changed);
 }
 
@@ -567,7 +565,7 @@ void Sprite3D::set_vframes(int p_amount) {
 	ERR_FAIL_COND(p_amount < 1);
 	vframes = p_amount;
 	_queue_update();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int Sprite3D::get_vframes() const {
@@ -578,7 +576,7 @@ void Sprite3D::set_hframes(int p_amount) {
 	ERR_FAIL_COND(p_amount < 1);
 	hframes = p_amount;
 	_queue_update();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int Sprite3D::get_hframes() const {
@@ -895,7 +893,6 @@ void AnimatedSprite3D::_notification(int p_what) {
 					}
 
 					_queue_update();
-					_change_notify("frame");
 				}
 
 				float to_process = MIN(timeout, remaining);
@@ -921,7 +918,7 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 		set_frame(frame);
 	}
 
-	_change_notify();
+	notify_property_list_changed();
 	_reset_timeout();
 	_queue_update();
 	update_configuration_warning();
@@ -954,7 +951,7 @@ void AnimatedSprite3D::set_frame(int p_frame) {
 	frame = p_frame;
 	_reset_timeout();
 	_queue_update();
-	_change_notify("frame");
+
 	emit_signal(SceneStringNames::get_singleton()->frame_changed);
 }
 
@@ -990,8 +987,6 @@ Rect2 AnimatedSprite3D::get_item_rect() const {
 
 void AnimatedSprite3D::_res_changed() {
 	set_frame(frame);
-	_change_notify("frame");
-	_change_notify("animation");
 	_queue_update();
 }
 
@@ -1048,7 +1043,7 @@ void AnimatedSprite3D::set_animation(const StringName &p_animation) {
 	animation = p_animation;
 	_reset_timeout();
 	set_frame(0);
-	_change_notify();
+	notify_property_list_changed();
 	_queue_update();
 }
 

--- a/scene/3d/visibility_notifier_3d.cpp
+++ b/scene/3d/visibility_notifier_3d.cpp
@@ -69,7 +69,6 @@ void VisibilityNotifier3D::set_aabb(const AABB &p_aabb) {
 		get_world_3d()->_update_notifier(this, get_global_transform().xform(aabb));
 	}
 
-	_change_notify("aabb");
 	update_gizmo();
 }
 

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -43,7 +43,6 @@ void VisualInstance3D::_update_visibility() {
 		return;
 	}
 
-	_change_notify("visible");
 	RS::get_singleton()->instance_set_visible(get_instance(), is_visible_in_tree());
 }
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -34,7 +34,6 @@
 
 void AnimationNodeAnimation::set_animation(const StringName &p_name) {
 	animation = p_name;
-	_change_notify("animation");
 }
 
 StringName AnimationNodeAnimation::get_animation() const {
@@ -583,7 +582,6 @@ float AnimationNodeTimeSeek::process(float p_time, bool p_seek) {
 	} else if (seek_pos >= 0) {
 		float ret = blend_input(0, seek_pos, true, 1.0, FILTER_IGNORE, false);
 		set_parameter(this->seek_pos, -1.0); //reset
-		_change_notify("seek_pos");
 		return ret;
 	} else {
 		return blend_input(0, p_time, false, 1.0, FILTER_IGNORE, false);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -969,7 +969,7 @@ Error AnimationPlayer::add_animation(const StringName &p_name, const Ref<Animati
 	}
 
 	_ref_anim(p_animation);
-	_change_notify();
+	notify_property_list_changed();
 	return OK;
 }
 
@@ -981,7 +981,7 @@ void AnimationPlayer::remove_animation(const StringName &p_name) {
 	animation_set.erase(p_name);
 
 	clear_caches();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void AnimationPlayer::_ref_anim(const Ref<Animation> &p_anim) {
@@ -1039,7 +1039,7 @@ void AnimationPlayer::rename_animation(const StringName &p_name, const StringNam
 	}
 
 	clear_caches();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool AnimationPlayer::has_animation(const StringName &p_name) const {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1394,7 +1394,7 @@ void AnimationTree::_update_properties() {
 
 	properties_dirty = false;
 
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool AnimationTree::_set(const StringName &p_name, const Variant &p_value) {
@@ -1404,9 +1404,6 @@ bool AnimationTree::_set(const StringName &p_name, const Variant &p_value) {
 
 	if (property_map.has(p_name)) {
 		property_map[p_name] = p_value;
-#ifdef TOOLS_ENABLED
-		_change_notify(p_name.operator String().utf8().get_data());
-#endif
 		return true;
 	}
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -344,7 +344,7 @@ void AudioStreamPlayer::_validate_property(PropertyInfo &property) const {
 }
 
 void AudioStreamPlayer::_bus_layout_changed() {
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Ref<AudioStreamPlayback> AudioStreamPlayer::get_stream_playback() {

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -199,7 +199,6 @@ void BaseButton::set_disabled(bool p_disabled) {
 		status.pressing_inside = false;
 	}
 	update();
-	_change_notify("disabled");
 }
 
 bool BaseButton::is_disabled() const {
@@ -213,7 +212,6 @@ void BaseButton::set_pressed(bool p_pressed) {
 	if (status.pressed == p_pressed) {
 		return;
 	}
-	_change_notify("pressed");
 	status.pressed = p_pressed;
 
 	if (p_pressed) {

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -338,7 +338,6 @@ void Button::set_text(const String &p_text) {
 		_shape();
 
 		update();
-		_change_notify("text");
 		minimum_size_changed();
 	}
 }
@@ -399,7 +398,6 @@ void Button::set_icon(const Ref<Texture2D> &p_icon) {
 	if (icon != p_icon) {
 		icon = p_icon;
 		update();
-		_change_notify("icon");
 		minimum_size_changed();
 	}
 }
@@ -424,7 +422,6 @@ void Button::set_flat(bool p_flat) {
 	if (flat != p_flat) {
 		flat = p_flat;
 		update();
-		_change_notify("flat");
 	}
 }
 
@@ -474,7 +471,7 @@ bool Button::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		}
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1275,7 +1275,6 @@ void Control::_size_changed() {
 		}
 		if (pos_changed || size_changed) {
 			item_rect_changed(size_changed);
-			_change_notify_offsets();
 			_notify_transform();
 		}
 
@@ -1315,10 +1314,6 @@ void Control::set_anchor(Side p_side, float p_anchor, bool p_keep_offset, bool p
 	}
 
 	update();
-	_change_notify("anchor_left");
-	_change_notify("anchor_right");
-	_change_notify("anchor_top");
-	_change_notify("anchor_bottom");
 }
 
 void Control::_set_anchor(Side p_side, float p_anchor) {
@@ -1592,16 +1587,6 @@ float Control::get_anchor(Side p_side) const {
 	return data.anchor[p_side];
 }
 
-void Control::_change_notify_offsets() {
-	// this avoids sending the whole object data again on a change
-	_change_notify("offset_left");
-	_change_notify("offset_top");
-	_change_notify("offset_right");
-	_change_notify("offset_bottom");
-	_change_notify("rect_position");
-	_change_notify("rect_size");
-}
-
 void Control::set_offset(Side p_side, float p_value) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 
@@ -1699,10 +1684,6 @@ void Control::_set_position(const Size2 &p_point) {
 void Control::set_position(const Size2 &p_point, bool p_keep_offsets) {
 	if (p_keep_offsets) {
 		_compute_anchors(Rect2(p_point, data.size_cache), data.offset, data.anchor);
-		_change_notify("anchor_left");
-		_change_notify("anchor_right");
-		_change_notify("anchor_top");
-		_change_notify("anchor_bottom");
 	} else {
 		_compute_offsets(Rect2(p_point, data.size_cache), data.anchor, data.offset);
 	}
@@ -1736,10 +1717,6 @@ void Control::set_size(const Size2 &p_size, bool p_keep_offsets) {
 
 	if (p_keep_offsets) {
 		_compute_anchors(Rect2(data.pos_cache, new_size), data.offset, data.anchor);
-		_change_notify("anchor_left");
-		_change_notify("anchor_right");
-		_change_notify("anchor_top");
-		_change_notify("anchor_bottom");
 	} else {
 		_compute_offsets(Rect2(data.pos_cache, new_size), data.anchor, data.offset);
 	}
@@ -2577,7 +2554,6 @@ void Control::set_rotation(float p_radians) {
 	data.rotation = p_radians;
 	update();
 	_notify_transform();
-	_change_notify("rect_rotation");
 }
 
 float Control::get_rotation() const {
@@ -2602,7 +2578,6 @@ void Control::set_pivot_offset(const Vector2 &p_pivot) {
 	data.pivot_offset = p_pivot;
 	update();
 	_notify_transform();
-	_change_notify("rect_pivot_offset");
 }
 
 Vector2 Control::get_pivot_offset() const {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -233,7 +233,6 @@ private:
 
 	void _theme_changed();
 
-	void _change_notify_offsets();
 	void _update_minimum_size();
 
 	void _update_scroll();

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -51,7 +51,7 @@ bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		}
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 
@@ -484,7 +484,6 @@ void GraphNode::set_title(const String &p_title) {
 	_shape();
 
 	update();
-	_change_notify("title");
 	minimum_size_changed();
 }
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -538,7 +538,6 @@ void Label::set_visible_characters(int p_amount) {
 	if (get_total_character_count() > 0) {
 		percent_visible = (float)p_amount / (float)get_total_character_count();
 	}
-	_change_notify("percent_visible");
 	update();
 }
 
@@ -555,7 +554,6 @@ void Label::set_percent_visible(float p_percent) {
 		visible_chars = get_total_character_count() * p_percent;
 		percent_visible = p_percent;
 	}
-	_change_notify("visible_chars");
 	update();
 }
 
@@ -610,7 +608,7 @@ bool Label::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		}
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1958,7 +1958,6 @@ void LineEdit::_text_changed() {
 
 void LineEdit::_emit_text_change() {
 	emit_signal("text_changed", text);
-	_change_notify("text");
 	text_changed_dirty = false;
 }
 
@@ -2091,7 +2090,7 @@ bool LineEdit::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		}
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -231,7 +231,7 @@ bool LinkButton::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		}
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -98,7 +98,6 @@ void NinePatchRect::set_texture(const Ref<Texture2D> &p_tex) {
 	*/
 	minimum_size_changed();
 	emit_signal("texture_changed");
-	_change_notify("texture");
 }
 
 Ref<Texture2D> NinePatchRect::get_texture() const {
@@ -110,20 +109,6 @@ void NinePatchRect::set_patch_margin(Side p_side, int p_size) {
 	margin[p_side] = p_size;
 	update();
 	minimum_size_changed();
-	switch (p_side) {
-		case SIDE_LEFT:
-			_change_notify("patch_margin_left");
-			break;
-		case SIDE_TOP:
-			_change_notify("patch_margin_top");
-			break;
-		case SIDE_RIGHT:
-			_change_notify("patch_margin_right");
-			break;
-		case SIDE_BOTTOM:
-			_change_notify("patch_margin_bottom");
-			break;
-	}
 }
 
 int NinePatchRect::get_patch_margin(Side p_side) const {
@@ -139,7 +124,6 @@ void NinePatchRect::set_region_rect(const Rect2 &p_region_rect) {
 	region_rect = p_region_rect;
 
 	item_rect_changed();
-	_change_notify("region_rect");
 }
 
 Rect2 NinePatchRect::get_region_rect() const {

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -47,7 +47,6 @@ void Range::_value_changed_notify() {
 	_value_changed(shared->val);
 	emit_signal("value_changed", shared->val);
 	update();
-	_change_notify("value");
 }
 
 void Range::Shared::emit_value_changed() {
@@ -63,7 +62,6 @@ void Range::Shared::emit_value_changed() {
 void Range::_changed_notify(const char *p_what) {
 	emit_signal("changed");
 	update();
-	_change_notify(p_what);
 }
 
 void Range::Shared::emit_changed(const char *p_what) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3722,7 +3722,6 @@ void RichTextLabel::set_percent_visible(float p_percent) {
 		}
 		main->first_invalid_line = 0; //invalidate ALL
 		_validate_line_caches(main);
-		_change_notify("visible_characters");
 		update();
 	}
 }
@@ -3948,7 +3947,6 @@ void RichTextLabel::set_visible_characters(int p_visible) {
 			percent_visible = (float)p_visible / (float)total_char_count;
 		}
 	}
-	_change_notify("percent_visible");
 	update();
 }
 

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -102,7 +102,7 @@ void SplitContainer::_resort() {
 		middle_sep += clamped_split_offset;
 		if (should_clamp_split_offset) {
 			split_offset = clamped_split_offset;
-			_change_notify("split_offset");
+
 			should_clamp_split_offset = false;
 		}
 	}

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -747,8 +747,6 @@ void TabContainer::set_current_tab(int p_current) {
 
 	_repaint();
 
-	_change_notify("current_tab");
-
 	if (pending_previous == current) {
 		emit_signal("tab_selected", current);
 	} else {
@@ -967,8 +965,6 @@ void TabContainer::set_tab_align(TabAlign p_align) {
 	ERR_FAIL_INDEX(p_align, 3);
 	align = p_align;
 	update();
-
-	_change_notify("tab_align");
 }
 
 TabContainer::TabAlign TabContainer::get_tab_align() const {

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -481,7 +481,6 @@ void Tabs::set_current_tab(int p_current) {
 	previous = current;
 	current = p_current;
 
-	_change_notify("current_tab");
 	_update_cache();
 	update();
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6906,7 +6906,7 @@ bool TextEdit::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		}
-		_change_notify();
+		notify_property_list_changed();
 		return true;
 	}
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -203,7 +203,7 @@ CanvasItemMaterial::LightMode CanvasItemMaterial::get_light_mode() const {
 void CanvasItemMaterial::set_particles_animation(bool p_particles_anim) {
 	particles_animation = p_particles_anim;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool CanvasItemMaterial::get_particles_animation() const {
@@ -387,7 +387,6 @@ void CanvasItem::show() {
 	}
 
 	_propagate_visibility_changed(true);
-	_change_notify("visible");
 }
 
 void CanvasItem::hide() {
@@ -403,7 +402,6 @@ void CanvasItem::hide() {
 	}
 
 	_propagate_visibility_changed(false);
-	_change_notify("visible");
 }
 
 CanvasItem *CanvasItem::current_item_drawn = nullptr;
@@ -1035,7 +1033,7 @@ void CanvasItem::set_material(const Ref<Material> &p_material) {
 		rid = material->get_rid();
 	}
 	RS::get_singleton()->canvas_item_set_material(canvas_item, rid);
-	_change_notify(); //properties for material exposed
+	notify_property_list_changed(); //properties for material exposed
 }
 
 void CanvasItem::set_use_parent_material(bool p_use_parent_material) {
@@ -1341,7 +1339,7 @@ void CanvasItem::set_texture_filter(TextureFilter p_texture_filter) {
 	}
 	texture_filter = p_texture_filter;
 	_update_texture_filter_changed(true);
-	_change_notify();
+	notify_property_list_changed();
 }
 
 CanvasItem::TextureFilter CanvasItem::get_texture_filter() const {
@@ -1381,7 +1379,7 @@ void CanvasItem::set_texture_repeat(TextureRepeat p_texture_repeat) {
 	}
 	texture_repeat = p_texture_repeat;
 	_update_texture_repeat_changed(true);
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void CanvasItem::set_clip_children(bool p_enabled) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -367,8 +367,6 @@ void Node::set_physics_process(bool p_process) {
 	} else {
 		remove_from_group("physics_process");
 	}
-
-	_change_notify("physics_process");
 }
 
 bool Node::is_physics_processing() const {
@@ -387,8 +385,6 @@ void Node::set_physics_process_internal(bool p_process_internal) {
 	} else {
 		remove_from_group("physics_process_internal");
 	}
-
-	_change_notify("physics_process_internal");
 }
 
 bool Node::is_physics_processing_internal() const {
@@ -863,8 +859,6 @@ void Node::set_process(bool p_process) {
 	} else {
 		remove_from_group("process");
 	}
-
-	_change_notify("process");
 }
 
 bool Node::is_processing() const {
@@ -883,8 +877,6 @@ void Node::set_process_internal(bool p_process_internal) {
 	} else {
 		remove_from_group("process_internal");
 	}
-
-	_change_notify("process_internal");
 }
 
 bool Node::is_processing_internal() const {

--- a/scene/resources/box_shape_3d.cpp
+++ b/scene/resources/box_shape_3d.cpp
@@ -60,7 +60,6 @@ void BoxShape3D::set_size(const Vector3 &p_size) {
 	size = p_size;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("size");
 }
 
 Vector3 BoxShape3D::get_size() const {

--- a/scene/resources/camera_effects.cpp
+++ b/scene/resources/camera_effects.cpp
@@ -41,7 +41,7 @@ RID CameraEffects::get_rid() const {
 void CameraEffects::set_dof_blur_far_enabled(bool p_enabled) {
 	dof_blur_far_enabled = p_enabled;
 	_update_dof_blur();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool CameraEffects::is_dof_blur_far_enabled() const {
@@ -69,7 +69,7 @@ float CameraEffects::get_dof_blur_far_transition() const {
 void CameraEffects::set_dof_blur_near_enabled(bool p_enabled) {
 	dof_blur_near_enabled = p_enabled;
 	_update_dof_blur();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool CameraEffects::is_dof_blur_near_enabled() const {

--- a/scene/resources/capsule_shape_3d.cpp
+++ b/scene/resources/capsule_shape_3d.cpp
@@ -82,7 +82,6 @@ void CapsuleShape3D::set_radius(float p_radius) {
 	radius = p_radius;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("radius");
 }
 
 float CapsuleShape3D::get_radius() const {
@@ -93,7 +92,6 @@ void CapsuleShape3D::set_height(float p_height) {
 	height = p_height;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("height");
 }
 
 float CapsuleShape3D::get_height() const {

--- a/scene/resources/cylinder_shape_3d.cpp
+++ b/scene/resources/cylinder_shape_3d.cpp
@@ -75,7 +75,6 @@ void CylinderShape3D::set_radius(float p_radius) {
 	radius = p_radius;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("radius");
 }
 
 float CylinderShape3D::get_radius() const {
@@ -86,7 +85,6 @@ void CylinderShape3D::set_height(float p_height) {
 	height = p_height;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("height");
 }
 
 float CylinderShape3D::get_height() const {

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -44,7 +44,7 @@ RID Environment::get_rid() const {
 void Environment::set_background(BGMode p_bg) {
 	bg_mode = p_bg;
 	RS::get_singleton()->environment_set_background(environment, RS::EnvironmentBG(p_bg));
-	_change_notify();
+	notify_property_list_changed();
 	if (bg_mode != BG_SKY) {
 		set_fog_aerial_perspective(0.0);
 	}
@@ -138,7 +138,7 @@ Color Environment::get_ambient_light_color() const {
 void Environment::set_ambient_source(AmbientSource p_source) {
 	ambient_source = p_source;
 	_update_ambient_light();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Environment::AmbientSource Environment::get_ambient_source() const {
@@ -166,7 +166,7 @@ float Environment::get_ambient_light_sky_contribution() const {
 void Environment::set_reflection_source(ReflectionSource p_source) {
 	reflection_source = p_source;
 	_update_ambient_light();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Environment::ReflectionSource Environment::get_reflection_source() const {
@@ -224,7 +224,7 @@ float Environment::get_tonemap_white() const {
 void Environment::set_tonemap_auto_exposure_enabled(bool p_enabled) {
 	tonemap_auto_exposure_enabled = p_enabled;
 	_update_tonemap();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool Environment::is_tonemap_auto_exposure_enabled() const {
@@ -285,7 +285,7 @@ void Environment::_update_tonemap() {
 void Environment::set_ssr_enabled(bool p_enabled) {
 	ssr_enabled = p_enabled;
 	_update_ssr();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool Environment::is_ssr_enabled() const {
@@ -343,7 +343,7 @@ void Environment::_update_ssr() {
 void Environment::set_ssao_enabled(bool p_enabled) {
 	ssao_enabled = p_enabled;
 	_update_ssao();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool Environment::is_ssao_enabled() const {
@@ -458,8 +458,6 @@ Environment::SDFGICascades Environment::get_sdfgi_cascades() const {
 
 void Environment::set_sdfgi_min_cell_size(float p_size) {
 	sdfgi_min_cell_size = p_size;
-	_change_notify("sdfgi_max_distance");
-	_change_notify("sdfgi_cascade0_distance");
 	_update_sdfgi();
 }
 
@@ -475,8 +473,6 @@ void Environment::set_sdfgi_max_distance(float p_distance) {
 		p_distance *= 0.5; //halve for each cascade
 	}
 	sdfgi_min_cell_size = p_distance;
-	_change_notify("sdfgi_min_cell_size");
-	_change_notify("sdfgi_cascade0_distance");
 	_update_sdfgi();
 }
 
@@ -493,8 +489,6 @@ float Environment::get_sdfgi_max_distance() const {
 
 void Environment::set_sdfgi_cascade0_distance(float p_distance) {
 	sdfgi_min_cell_size = p_distance / 64.0;
-	_change_notify("sdfgi_min_cell_size");
-	_change_notify("sdfgi_max_distance");
 	_update_sdfgi();
 }
 
@@ -584,7 +578,7 @@ void Environment::_update_sdfgi() {
 void Environment::set_glow_enabled(bool p_enabled) {
 	glow_enabled = p_enabled;
 	_update_glow();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool Environment::is_glow_enabled() const {
@@ -654,7 +648,7 @@ float Environment::get_glow_bloom() const {
 void Environment::set_glow_blend_mode(GlowBlendMode p_mode) {
 	glow_blend_mode = p_mode;
 	_update_glow();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Environment::GlowBlendMode Environment::get_glow_blend_mode() const {
@@ -722,7 +716,7 @@ void Environment::_update_glow() {
 void Environment::set_fog_enabled(bool p_enabled) {
 	fog_enabled = p_enabled;
 	_update_fog();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool Environment::is_fog_enabled() const {
@@ -802,7 +796,7 @@ void Environment::_update_volumetric_fog() {
 void Environment::set_volumetric_fog_enabled(bool p_enable) {
 	volumetric_fog_enabled = p_enable;
 	_update_volumetric_fog();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool Environment::is_volumetric_fog_enabled() const {
@@ -874,7 +868,7 @@ float Environment::get_volumetric_fog_temporal_reprojection_amount() const {
 void Environment::set_adjustment_enabled(bool p_enabled) {
 	adjustment_enabled = p_enabled;
 	_update_adjustment();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool Environment::is_adjustment_enabled() const {
@@ -1427,7 +1421,7 @@ Environment::Environment() {
 	_update_fog();
 	_update_adjustment();
 	_update_volumetric_fog();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Environment::~Environment() {

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -509,7 +509,7 @@ void Font::_data_changed() {
 	cache_wrap.clear();
 
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool Font::_set(const StringName &p_name, const Variant &p_value) {
@@ -600,7 +600,7 @@ void Font::add_data(const Ref<FontData> &p_data) {
 	cache_wrap.clear();
 
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void Font::set_data(int p_idx, const Ref<FontData> &p_data) {
@@ -621,7 +621,7 @@ void Font::set_data(int p_idx, const Ref<FontData> &p_data) {
 	cache_wrap.clear();
 
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int Font::get_data_count() const {
@@ -646,7 +646,7 @@ void Font::remove_data(int p_idx) {
 	cache_wrap.clear();
 
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Dictionary Font::get_feature_list() const {
@@ -718,7 +718,7 @@ void Font::set_spacing(int p_type, int p_value) {
 	}
 
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 // Drawing string and string sizes, cached.

--- a/scene/resources/height_map_shape_3d.cpp
+++ b/scene/resources/height_map_shape_3d.cpp
@@ -107,8 +107,6 @@ void HeightMapShape3D::set_map_width(int p_new) {
 
 		_update_shape();
 		notify_change_to_owners();
-		_change_notify("map_width");
-		_change_notify("map_data");
 	}
 }
 
@@ -133,8 +131,6 @@ void HeightMapShape3D::set_map_depth(int p_new) {
 
 		_update_shape();
 		notify_change_to_owners();
-		_change_notify("map_depth");
-		_change_notify("map_data");
 	}
 }
 
@@ -171,7 +167,6 @@ void HeightMapShape3D::set_map_data(PackedFloat32Array p_new) {
 
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("map_data");
 }
 
 PackedFloat32Array HeightMapShape3D::get_map_data() const {

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -192,7 +192,7 @@ Variant ShaderMaterial::property_get_revert(const String &p_name) {
 
 void ShaderMaterial::set_shader(const Ref<Shader> &p_shader) {
 	// Only connect/disconnect the signal when running in the editor.
-	// This can be a slow operation, and `_change_notify()` (which is called by `_shader_changed()`)
+	// This can be a slow operation, and `notify_property_list_changed()` (which is called by `_shader_changed()`)
 	// does nothing in non-editor builds anyway. See GH-34741 for details.
 	if (shader.is_valid() && Engine::get_singleton()->is_editor_hint()) {
 		shader->disconnect("changed", callable_mp(this, &ShaderMaterial::_shader_changed));
@@ -210,7 +210,7 @@ void ShaderMaterial::set_shader(const Ref<Shader> &p_shader) {
 	}
 
 	RS::get_singleton()->material_set_shader(_get_material(), rid);
-	_change_notify(); //properties for shader exposed
+	notify_property_list_changed(); //properties for shader exposed
 	emit_changed();
 }
 
@@ -227,7 +227,7 @@ Variant ShaderMaterial::get_shader_param(const StringName &p_param) const {
 }
 
 void ShaderMaterial::_shader_changed() {
-	_change_notify(); //update all properties
+	notify_property_list_changed(); //update all properties
 }
 
 void ShaderMaterial::_bind_methods() {
@@ -1489,7 +1489,7 @@ void BaseMaterial3D::set_transparency(Transparency p_transparency) {
 
 	transparency = p_transparency;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 BaseMaterial3D::Transparency BaseMaterial3D::get_transparency() const {
@@ -1503,7 +1503,7 @@ void BaseMaterial3D::set_alpha_antialiasing(AlphaAntiAliasing p_alpha_aa) {
 
 	alpha_antialiasing_mode = p_alpha_aa;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 BaseMaterial3D::AlphaAntiAliasing BaseMaterial3D::get_alpha_antialiasing() const {
@@ -1517,7 +1517,7 @@ void BaseMaterial3D::set_shading_mode(ShadingMode p_shading_mode) {
 
 	shading_mode = p_shading_mode;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 BaseMaterial3D::ShadingMode BaseMaterial3D::get_shading_mode() const {
@@ -1585,7 +1585,7 @@ void BaseMaterial3D::set_flag(Flags p_flag, bool p_enabled) {
 
 	flags[p_flag] = p_enabled;
 	if (p_flag == FLAG_USE_SHADOW_TO_OPACITY || p_flag == FLAG_USE_TEXTURE_REPEAT || p_flag == FLAG_SUBSURFACE_MODE_SKIN) {
-		_change_notify();
+		notify_property_list_changed();
 	}
 	_queue_shader_change();
 }
@@ -1602,7 +1602,7 @@ void BaseMaterial3D::set_feature(Feature p_feature, bool p_enabled) {
 	}
 
 	features[p_feature] = p_enabled;
-	_change_notify();
+	notify_property_list_changed();
 	_queue_shader_change();
 }
 
@@ -1620,7 +1620,7 @@ void BaseMaterial3D::set_texture(TextureParam p_param, const Ref<Texture2D> &p_t
 		RS::get_singleton()->material_set_param(_get_material(), shader_names->albedo_texture_size,
 				Vector2i(p_texture->get_width(), p_texture->get_height()));
 	}
-	_change_notify();
+	notify_property_list_changed();
 	_queue_shader_change();
 }
 
@@ -1860,7 +1860,7 @@ float BaseMaterial3D::get_uv2_triplanar_blend_sharpness() const {
 void BaseMaterial3D::set_billboard_mode(BillboardMode p_mode) {
 	billboard_mode = p_mode;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 BaseMaterial3D::BillboardMode BaseMaterial3D::get_billboard_mode() const {
@@ -1897,7 +1897,7 @@ bool BaseMaterial3D::get_particles_anim_loop() const {
 void BaseMaterial3D::set_heightmap_deep_parallax(bool p_enable) {
 	deep_parallax = p_enable;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool BaseMaterial3D::is_heightmap_deep_parallax_enabled() const {
@@ -1943,7 +1943,7 @@ bool BaseMaterial3D::get_heightmap_deep_parallax_flip_binormal() const {
 void BaseMaterial3D::set_grow_enabled(bool p_enable) {
 	grow_enabled = p_enable;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool BaseMaterial3D::is_grow_enabled() const {
@@ -2093,7 +2093,7 @@ void BaseMaterial3D::set_on_top_of_alpha() {
 void BaseMaterial3D::set_proximity_fade(bool p_enable) {
 	proximity_fade_enabled = p_enable;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 bool BaseMaterial3D::is_proximity_fade_enabled() const {
@@ -2112,7 +2112,7 @@ float BaseMaterial3D::get_proximity_fade_distance() const {
 void BaseMaterial3D::set_distance_fade(DistanceFadeMode p_mode) {
 	distance_fade = p_mode;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 BaseMaterial3D::DistanceFadeMode BaseMaterial3D::get_distance_fade() const {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1156,7 +1156,7 @@ void ArrayMesh::add_surface(uint32_t p_format, PrimitiveType p_primitive, const 
 	RenderingServer::get_singleton()->mesh_add_surface(mesh, sd);
 
 	clear_cache();
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -1278,7 +1278,6 @@ void ArrayMesh::surface_set_material(int p_idx, const Ref<Material> &p_material)
 	surfaces.write[p_idx].material = p_material;
 	RenderingServer::get_singleton()->mesh_surface_set_material(mesh, p_idx, p_material.is_null() ? RID() : p_material->get_rid());
 
-	_change_notify("material");
 	emit_changed();
 }
 
@@ -1633,7 +1632,7 @@ void ArrayMesh::reload_from_file() {
 
 	Resource::reload_from_file();
 
-	_change_notify();
+	notify_property_list_changed();
 }
 
 ArrayMesh::ArrayMesh() {

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -109,14 +109,14 @@ void MeshLibrary::create_item(int p_item) {
 	ERR_FAIL_COND(p_item < 0);
 	ERR_FAIL_COND(item_map.has(p_item));
 	item_map[p_item] = Item();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_name(int p_item, const String &p_name) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].name = p_name;
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
@@ -124,25 +124,25 @@ void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
 	item_map[p_item].mesh = p_mesh;
 	notify_change_to_owners();
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].shapes = p_shapes;
-	_change_notify();
+	notify_property_list_changed();
 	notify_change_to_owners();
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_navmesh(int p_item, const Ref<NavigationMesh> &p_navmesh) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].navmesh = p_navmesh;
-	_change_notify();
+	notify_property_list_changed();
 	notify_change_to_owners();
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_navmesh_transform(int p_item, const Transform &p_transform) {
@@ -150,14 +150,14 @@ void MeshLibrary::set_item_navmesh_transform(int p_item, const Transform &p_tran
 	item_map[p_item].navmesh_transform = p_transform;
 	notify_change_to_owners();
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].preview = p_preview;
 	emit_changed();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 String MeshLibrary::get_item_name(int p_item) const {
@@ -198,14 +198,14 @@ void MeshLibrary::remove_item(int p_item) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map.erase(p_item);
 	notify_change_to_owners();
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
 void MeshLibrary::clear() {
 	item_map.clear();
 	notify_change_to_owners();
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -74,7 +74,7 @@ int NavigationMesh::get_sample_partition_type() const {
 void NavigationMesh::set_parsed_geometry_type(int p_value) {
 	ERR_FAIL_COND(p_value >= PARSED_GEOMETRY_MAX);
 	parsed_geometry_type = static_cast<ParsedGeometryType>(p_value);
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int NavigationMesh::get_parsed_geometry_type() const {
@@ -106,7 +106,7 @@ bool NavigationMesh::get_collision_mask_bit(int p_bit) const {
 void NavigationMesh::set_source_geometry_mode(int p_geometry_mode) {
 	ERR_FAIL_INDEX(p_geometry_mode, SOURCE_GEOMETRY_MAX);
 	source_geometry_mode = static_cast<SourceGeometryMode>(p_geometry_mode);
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int NavigationMesh::get_source_geometry_mode() const {
@@ -251,7 +251,7 @@ bool NavigationMesh::get_filter_walkable_low_height_spans() const {
 
 void NavigationMesh::set_vertices(const Vector<Vector3> &p_vertices) {
 	vertices = p_vertices;
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Vector<Vector3> NavigationMesh::get_vertices() const {
@@ -263,7 +263,7 @@ void NavigationMesh::_set_polygons(const Array &p_array) {
 	for (int i = 0; i < p_array.size(); i++) {
 		polygons.write[i].indices = p_array[i];
 	}
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Array NavigationMesh::_get_polygons() const {
@@ -280,7 +280,7 @@ void NavigationMesh::add_polygon(const Vector<int> &p_polygon) {
 	Polygon polygon;
 	polygon.indices = p_polygon;
 	polygons.push_back(polygon);
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int NavigationMesh::get_polygon_count() const {

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -911,7 +911,7 @@ void ParticlesMaterial::set_color_ramp(const Ref<Texture2D> &p_texture) {
 	color_ramp = p_texture;
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->color_ramp, p_texture);
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 Ref<Texture2D> ParticlesMaterial::get_color_ramp() const {
@@ -923,7 +923,7 @@ void ParticlesMaterial::set_particle_flag(ParticleFlags p_particle_flag, bool p_
 	particle_flags[p_particle_flag] = p_enable;
 	_queue_shader_change();
 	if (p_particle_flag == PARTICLE_FLAG_DISABLE_Z) {
-		_change_notify();
+		notify_property_list_changed();
 	}
 }
 
@@ -935,7 +935,7 @@ bool ParticlesMaterial::get_particle_flag(ParticleFlags p_particle_flag) const {
 void ParticlesMaterial::set_emission_shape(EmissionShape p_shape) {
 	ERR_FAIL_INDEX(p_shape, EMISSION_SHAPE_MAX);
 	emission_shape = p_shape;
-	_change_notify();
+	notify_property_list_changed();
 	_queue_shader_change();
 }
 
@@ -1066,7 +1066,7 @@ void ParticlesMaterial::_validate_property(PropertyInfo &property) const {
 void ParticlesMaterial::set_sub_emitter_mode(SubEmitterMode p_sub_emitter_mode) {
 	sub_emitter_mode = p_sub_emitter_mode;
 	_queue_shader_change();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 ParticlesMaterial::SubEmitterMode ParticlesMaterial::get_sub_emitter_mode() const {

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -214,7 +214,7 @@ void PrimitiveMesh::set_material(const Ref<Material> &p_material) {
 	if (!pending_request) {
 		// just apply it, else it'll happen when _update is called.
 		RenderingServer::get_singleton()->mesh_surface_set_material(mesh, 0, material.is_null() ? RID() : material->get_rid());
-		_change_notify();
+		notify_property_list_changed();
 		emit_changed();
 	};
 }

--- a/scene/resources/ray_shape_3d.cpp
+++ b/scene/resources/ray_shape_3d.cpp
@@ -56,7 +56,6 @@ void RayShape3D::set_length(float p_length) {
 	length = p_length;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("length");
 }
 
 float RayShape3D::get_length() const {
@@ -67,7 +66,6 @@ void RayShape3D::set_slips_on_slope(bool p_active) {
 	slips_on_slope = p_active;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("slips_on_slope");
 }
 
 bool RayShape3D::get_slips_on_slope() const {
@@ -90,6 +88,4 @@ RayShape3D::RayShape3D() :
 	/* Code copied from setters to prevent the use of uninitialized variables */
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("length");
-	_change_notify("slips_on_slope");
 }

--- a/scene/resources/skin.cpp
+++ b/scene/resources/skin.cpp
@@ -58,7 +58,7 @@ void Skin::set_bind_name(int p_index, const StringName &p_name) {
 	binds_ptr[p_index].name = p_name;
 	emit_changed();
 	if (notify_change) {
-		_change_notify();
+		notify_property_list_changed();
 	}
 }
 

--- a/scene/resources/sphere_shape_3d.cpp
+++ b/scene/resources/sphere_shape_3d.cpp
@@ -66,7 +66,6 @@ void SphereShape3D::set_radius(float p_radius) {
 	radius = p_radius;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("radius");
 }
 
 float SphereShape3D::get_radius() const {

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -123,7 +123,6 @@ void StyleBoxTexture::set_texture(Ref<Texture2D> p_texture) {
 	}
 	emit_signal("texture_changed");
 	emit_changed();
-	_change_notify("texture");
 }
 
 Ref<Texture2D> StyleBoxTexture::get_texture() const {
@@ -135,13 +134,6 @@ void StyleBoxTexture::set_margin_size(Side p_side, float p_size) {
 
 	margin[p_side] = p_size;
 	emit_changed();
-	static const char *margin_prop[4] = {
-		"content_margin_left",
-		"content_margin_top",
-		"content_margin_right",
-		"content_margin_bottom",
-	};
-	_change_notify(margin_prop[p_side]);
 }
 
 float StyleBoxTexture::get_margin_size(Side p_side) const {
@@ -228,7 +220,6 @@ void StyleBoxTexture::set_region_rect(const Rect2 &p_region_rect) {
 
 	region_rect = p_region_rect;
 	emit_changed();
-	_change_notify("region");
 }
 
 Rect2 StyleBoxTexture::get_region_rect() const {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -94,7 +94,7 @@ void ImageTexture::reload_from_file() {
 		create_from_image(img);
 	} else {
 		Resource::reload_from_file();
-		_change_notify();
+		notify_property_list_changed();
 		emit_changed();
 	}
 }
@@ -146,7 +146,7 @@ void ImageTexture::_reload_hook(const RID &p_hook) {
 	RID new_texture = RenderingServer::get_singleton()->texture_2d_create(img);
 	RenderingServer::get_singleton()->texture_replace(texture, new_texture);
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -163,7 +163,7 @@ void ImageTexture::create_from_image(const Ref<Image> &p_image) {
 		RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_image);
 		RenderingServer::get_singleton()->texture_replace(texture, new_texture);
 	}
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 
 	image_stored = true;
@@ -189,7 +189,7 @@ void ImageTexture::update(const Ref<Image> &p_image, bool p_immediate) {
 		RenderingServer::get_singleton()->texture_2d_update(texture, p_image);
 	}
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 
 	alpha_cache.unref();
@@ -612,7 +612,7 @@ Error StreamTexture2D::load(const String &p_path) {
 	}
 
 #endif
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 	return OK;
 }
@@ -959,7 +959,7 @@ Error StreamTexture3D::load(const String &p_path) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 	return OK;
 }
@@ -1110,7 +1110,6 @@ void AtlasTexture::set_atlas(const Ref<Texture2D> &p_atlas) {
 	}
 	atlas = p_atlas;
 	emit_changed();
-	_change_notify("atlas");
 }
 
 Ref<Texture2D> AtlasTexture::get_atlas() const {
@@ -1123,7 +1122,6 @@ void AtlasTexture::set_region(const Rect2 &p_region) {
 	}
 	region = p_region;
 	emit_changed();
-	_change_notify("region");
 }
 
 Rect2 AtlasTexture::get_region() const {
@@ -1136,7 +1134,6 @@ void AtlasTexture::set_margin(const Rect2 &p_margin) {
 	}
 	margin = p_margin;
 	emit_changed();
-	_change_notify("margin");
 }
 
 Rect2 AtlasTexture::get_margin() const {
@@ -1146,7 +1143,6 @@ Rect2 AtlasTexture::get_margin() const {
 void AtlasTexture::set_filter_clip(const bool p_enable) {
 	filter_clip = p_enable;
 	emit_changed();
-	_change_notify("filter_clip");
 }
 
 bool AtlasTexture::has_filter_clip() const {
@@ -1904,7 +1900,7 @@ void AnimatedTexture::_update_proxy() {
 				}
 			}
 			time -= frame_limit;
-			_change_notify("current_frame");
+
 		} else {
 			break;
 		}
@@ -2355,7 +2351,7 @@ Error StreamTextureLayered::load(const String &p_path) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 	return OK;
 }
@@ -2554,7 +2550,7 @@ Ref<Image> CameraTexture::get_data() const {
 
 void CameraTexture::set_camera_feed_id(int p_new_id) {
 	camera_feed_id = p_new_id;
-	_change_notify();
+	notify_property_list_changed();
 }
 
 int CameraTexture::get_camera_feed_id() const {
@@ -2563,7 +2559,7 @@ int CameraTexture::get_camera_feed_id() const {
 
 void CameraTexture::set_which_feed(CameraServer::FeedImage p_which) {
 	which_feed = p_which;
-	_change_notify();
+	notify_property_list_changed();
 }
 
 CameraServer::FeedImage CameraTexture::get_which_feed() const {
@@ -2574,7 +2570,7 @@ void CameraTexture::set_camera_active(bool p_active) {
 	Ref<CameraFeed> feed = CameraServer::get_singleton()->get_feed_by_id(camera_feed_id);
 	if (feed.is_valid()) {
 		feed->set_active(p_active);
-		_change_notify();
+		notify_property_list_changed();
 	}
 }
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -358,7 +358,7 @@ void Theme::set_default_theme_font(const Ref<Font> &p_default_font) {
 		default_theme_font->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -373,7 +373,7 @@ void Theme::set_default_theme_font_size(int p_font_size) {
 
 	default_theme_font_size = p_font_size;
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -436,7 +436,7 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, co
 	}
 
 	if (new_value) {
-		_change_notify();
+		notify_property_list_changed();
 		emit_changed();
 	}
 }
@@ -463,7 +463,7 @@ void Theme::clear_icon(const StringName &p_name, const StringName &p_node_type) 
 
 	icon_map[p_node_type].erase(p_name);
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -506,7 +506,7 @@ void Theme::set_stylebox(const StringName &p_name, const StringName &p_node_type
 	}
 
 	if (new_value) {
-		_change_notify();
+		notify_property_list_changed();
 	}
 	emit_changed();
 }
@@ -533,7 +533,7 @@ void Theme::clear_stylebox(const StringName &p_name, const StringName &p_node_ty
 
 	style_map[p_node_type].erase(p_name);
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -576,7 +576,7 @@ void Theme::set_font(const StringName &p_name, const StringName &p_node_type, co
 	}
 
 	if (new_value) {
-		_change_notify();
+		notify_property_list_changed();
 		emit_changed();
 	}
 }
@@ -604,7 +604,7 @@ void Theme::clear_font(const StringName &p_name, const StringName &p_node_type) 
 	}
 
 	font_map[p_node_type].erase(p_name);
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -637,7 +637,7 @@ void Theme::set_font_size(const StringName &p_name, const StringName &p_node_typ
 	font_size_map[p_node_type][p_name] = p_font_size;
 
 	if (new_value) {
-		_change_notify();
+		notify_property_list_changed();
 		emit_changed();
 	}
 }
@@ -661,7 +661,7 @@ void Theme::clear_font_size(const StringName &p_name, const StringName &p_node_t
 	ERR_FAIL_COND(!font_size_map[p_node_type].has(p_name));
 
 	font_size_map[p_node_type].erase(p_name);
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -685,7 +685,7 @@ void Theme::set_color(const StringName &p_name, const StringName &p_node_type, c
 	color_map[p_node_type][p_name] = p_color;
 
 	if (new_value) {
-		_change_notify();
+		notify_property_list_changed();
 		emit_changed();
 	}
 }
@@ -707,7 +707,7 @@ void Theme::clear_color(const StringName &p_name, const StringName &p_node_type)
 	ERR_FAIL_COND(!color_map[p_node_type].has(p_name));
 
 	color_map[p_node_type].erase(p_name);
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -739,7 +739,7 @@ void Theme::set_constant(const StringName &p_name, const StringName &p_node_type
 	constant_map[p_node_type][p_name] = p_constant;
 
 	if (new_value) {
-		_change_notify();
+		notify_property_list_changed();
 		emit_changed();
 	}
 }
@@ -761,7 +761,7 @@ void Theme::clear_constant(const StringName &p_name, const StringName &p_node_ty
 	ERR_FAIL_COND(!constant_map[p_node_type].has(p_name));
 
 	constant_map[p_node_type].erase(p_name);
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -835,7 +835,7 @@ void Theme::clear() {
 	color_map.clear();
 	constant_map.clear();
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -887,7 +887,7 @@ void Theme::copy_theme(const Ref<Theme> &p_other) {
 	color_map = p_other->color_map;
 	constant_map = p_other->constant_map;
 
-	_change_notify();
+	notify_property_list_changed();
 	emit_changed();
 }
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -369,14 +369,14 @@ void TileSet::create_tile(int p_id) {
 	ERR_FAIL_COND(tile_map.has(p_id));
 	tile_map[p_id] = TileData();
 	tile_map[p_id].autotile_data = AutotileData();
-	_change_notify("");
+	notify_property_list_changed();
 	emit_changed();
 }
 
 void TileSet::autotile_set_bitmask_mode(int p_id, BitmaskMode p_mode) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].autotile_data.bitmask_mode = p_mode;
-	_change_notify("");
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -389,7 +389,6 @@ void TileSet::tile_set_texture(int p_id, const Ref<Texture2D> &p_texture) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].texture = p_texture;
 	emit_changed();
-	_change_notify("texture");
 }
 
 Ref<Texture2D> TileSet::tile_get_texture(int p_id) const {
@@ -412,7 +411,6 @@ void TileSet::tile_set_modulate(int p_id, const Color &p_modulate) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].modulate = p_modulate;
 	emit_changed();
-	_change_notify("modulate");
 }
 
 Color TileSet::tile_get_modulate(int p_id) const {
@@ -435,7 +433,6 @@ void TileSet::tile_set_region(int p_id, const Rect2 &p_region) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].region = p_region;
 	emit_changed();
-	_change_notify("region");
 }
 
 Rect2 TileSet::tile_get_region(int p_id) const {
@@ -447,7 +444,6 @@ void TileSet::tile_set_tile_mode(int p_id, TileMode p_tile_mode) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].tile_mode = p_tile_mode;
 	emit_changed();
-	_change_notify("tile_mode");
 }
 
 TileSet::TileMode TileSet::tile_get_tile_mode(int p_id) const {
@@ -669,7 +665,6 @@ void TileSet::tile_set_name(int p_id, const String &p_name) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].name = p_name;
 	emit_changed();
-	_change_notify("name");
 }
 
 String TileSet::tile_get_name(int p_id) const {
@@ -1060,7 +1055,7 @@ bool TileSet::is_tile_bound(int p_drawn_id, int p_neighbor_id) {
 void TileSet::remove_tile(int p_id) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map.erase(p_id);
-	_change_notify("");
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -1083,7 +1078,7 @@ int TileSet::find_tile_by_name(const String &p_name) const {
 
 void TileSet::clear() {
 	tile_map.clear();
-	_change_notify("");
+	notify_property_list_changed();
 	emit_changed();
 }
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -730,7 +730,7 @@ void VisualShader::set_mode(Mode p_mode) {
 	}
 
 	_queue_update();
-	_change_notify();
+	notify_property_list_changed();
 }
 
 void VisualShader::set_graph_offset(const Vector2 &p_offset) {

--- a/scene/resources/world_margin_shape_3d.cpp
+++ b/scene/resources/world_margin_shape_3d.cpp
@@ -69,7 +69,6 @@ void WorldMarginShape3D::set_plane(Plane p_plane) {
 	plane = p_plane;
 	_update_shape();
 	notify_change_to_owners();
-	_change_notify("plane");
 }
 
 Plane WorldMarginShape3D::get_plane() const {


### PR DESCRIPTION
* For inspector refresh, the inspector now detects if a property change by polling a few times per second and then does update the control if so. This process is very cheap.
* For property list refresh, a new signal (property_list_changed) was added to Object. _change_notify() is replaced by notify_property_list_changed()
* Changed all objects using the old method to the signal, or just deleted the calls to _change_notify(<property>) since they are unnecessary now.
