### PR TITLE
Fix broken gdnative variant test

### DIFF
--- a/modules/gdnative/tests/test_variant.h
+++ b/modules/gdnative/tests/test_variant.h
@@ -124,6 +124,7 @@ TEST_CASE("[GDNative Variant] Variant evaluate") {
 	godot_variant_new_int(&two, 2);
 
 	godot_variant three;
+	godot_variant_new_nil(&three);
 	bool valid = false;
 
 	godot_variant_evaluate(GODOT_VARIANT_OP_ADD, &one, &two, &three, &valid);


### PR DESCRIPTION
This test was failing with the following error which seems to come from the `core/variant.cpp` code trying to free what it thinks is a reference but is actually uninitialized memory. Solution was to initialize the destination Variant before passing it on.
```
[doctest] doctest version is "2.4.4"
[doctest] run with "--help" for options
===============================================================================
./modules/gdnative/tests/test_variant.h:120:
TEST CASE:  [GDNative Variant] Variant evaluate

./modules/gdnative/tests/test_variant.h:120: FATAL ERROR: test case CRASHED: SIGSEGV - Segmentation violation signal

===============================================================================
[doctest] test cases:  7 |  6 passed | 1 failed | 291 skipped
[doctest] assertions: 11 | 11 passed | 0 failed |
[doctest] Status: FAILURE!
handle_crash: Program crashed with signal 11
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /lib/x86_64-linux-gnu/libpthread.so.0(+0x153c0) [0x7fa72f15b3c0] (??:0)
[2] Variant::clear() (/home/henry/workspace/godot/./core/variant/variant.h:256)
[3] Variant::reference(Variant const&) (/home/henry/workspace/godot/core/variant/variant.cpp:1042)
[4] Variant::operator=(Variant const&) (/home/henry/workspace/godot/core/variant/variant.cpp:2691)
[5] OperatorEvaluatorAdd<long, long, long>::evaluate(Variant const&, Variant const&, Variant*, bool&) (/home/henry/workspace/godot/core/variant/variant_op.cpp:43 (discriminator 2))
[6] Variant::evaluate(Variant::Operator const&, Variant const&, Variant const&, Variant&, bool&) (/home/henry/workspace/godot/core/variant/variant_op.cpp:1941)
[7] bin/godot.linuxbsd.tools.64(godot_variant_evaluate+0x6b) [0x2aec36b] (/home/henry/workspace/godot/modules/gdnative/gdnative/variant.cpp:586)
[8] bin/godot.linuxbsd.tools.64() [0x1f3fc89] (/home/henry/workspace/godot/./modules/gdnative/tests/test_variant.h:131)
[9] doctest::Context::run() (/home/henry/workspace/godot/./thirdparty/doctest/doctest.h:6292)
[10] test_main(int, char**) (/home/henry/workspace/godot/tests/test_main.cpp:134)
[11] Main::test_entrypoint(int, char**, bool&) (/home/henry/workspace/godot/main/main.cpp:470)
[12] bin/godot.linuxbsd.tools.64(main+0x71) [0x1df7f27] (/home/henry/workspace/godot/platform/linuxbsd/godot_linuxbsd.cpp:45)
[13] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fa72ee240b3] (??:0)
[14] bin/godot.linuxbsd.tools.64(_start+0x2e) [0x1df7dfe] (??:?)
-- END OF BACKTRACE --
```
