### PR TITLE
[3.2] [HTML5] Handle contextmenu, webglcontextlost internally.

### DIFF
--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -86,6 +86,7 @@ extern int godot_js_display_gamepad_sample_get(int p_idx, float r_btns[16], int3
 extern void godot_js_display_notification_cb(void (*p_callback)(int p_notification), int p_enter, int p_exit, int p_in, int p_out);
 extern void godot_js_display_paste_cb(void (*p_callback)(const char *p_text));
 extern void godot_js_display_drop_files_cb(void (*p_callback)(char **p_filev, int p_filec));
+extern void godot_js_display_setup_canvas();
 #ifdef __cplusplus
 }
 #endif

--- a/platform/javascript/js/engine/engine.js
+++ b/platform/javascript/js/engine/engine.js
@@ -107,17 +107,6 @@ const Engine = (function () {
 				me.canvas.tabIndex = 0;
 			}
 
-			// Disable right-click context menu.
-			me.canvas.addEventListener('contextmenu', function (ev) {
-				ev.preventDefault();
-			}, false);
-
-			// Until context restoration is implemented warn the user of context loss.
-			me.canvas.addEventListener('webglcontextlost', function (ev) {
-				alert('WebGL context lost, please reload the page'); // eslint-disable-line no-alert
-				ev.preventDefault();
-			}, false);
-
 			// Browser locale, or custom one if defined.
 			let locale = me.customLocale;
 			if (!locale) {

--- a/platform/javascript/js/libs/library_godot_display.js
+++ b/platform/javascript/js/libs/library_godot_display.js
@@ -619,6 +619,18 @@ const GodotDisplay = {
 		GodotDisplayListeners.add(canvas, 'drop', GodotDisplayDragDrop.handler(dropFiles));
 	},
 
+	godot_js_display_setup_canvas__sig: 'v',
+	godot_js_display_setup_canvas: function () {
+		const canvas = GodotConfig.canvas;
+		GodotDisplayListeners.add(canvas, 'contextmenu', function (ev) {
+			ev.preventDefault();
+		}, false);
+		GodotDisplayListeners.add(canvas, 'webglcontextlost', function (ev) {
+			alert('WebGL context lost, please reload the page'); // eslint-disable-line no-alert
+			ev.preventDefault();
+		}, false);
+	},
+
 	/*
 	 * Gamepads
 	 */

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -814,6 +814,7 @@ void OS_JavaScript::initialize_core() {
 
 Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {
 
+	godot_js_display_setup_canvas(); // Handle contextmenu, webglcontextlost
 	swap_ok_cancel = godot_js_display_is_swap_ok_cancel() == 1;
 
 	EmscriptenWebGLContextAttributes attributes;


### PR DESCRIPTION
This way they are automatically cleaned up when the engine exits,
landing a hand to browsers garbage collectors.

`3.2` version of #45883