### PR TITLE
[HTML5] Fix HTTPClient request_raw.

### DIFF
--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -104,7 +104,11 @@ Error HTTPClient::request_raw(Method p_method, const String &p_url, const Vector
 	Error err = prepare_request(p_method, p_url, p_headers);
 	if (err != OK)
 		return err;
-	godot_xhr_send_data(xhr_id, p_body.ptr(), p_body.size());
+	if (p_body.is_empty()) {
+		godot_xhr_send(xhr_id, nullptr, 0);
+	} else {
+		godot_xhr_send(xhr_id, p_body.ptr(), p_body.size());
+	}
 	return OK;
 }
 
@@ -112,7 +116,12 @@ Error HTTPClient::request(Method p_method, const String &p_url, const Vector<Str
 	Error err = prepare_request(p_method, p_url, p_headers);
 	if (err != OK)
 		return err;
-	godot_xhr_send_string(xhr_id, p_body.utf8().get_data());
+	if (p_body.is_empty()) {
+		godot_xhr_send(xhr_id, nullptr, 0);
+	} else {
+		const CharString cs = p_body.utf8();
+		godot_xhr_send(xhr_id, cs.get_data(), cs.length());
+	}
 	return OK;
 }
 

--- a/platform/javascript/http_request.h
+++ b/platform/javascript/http_request.h
@@ -53,9 +53,7 @@ extern int godot_xhr_open(int p_xhr_id, const char *p_method, const char *p_url,
 
 extern void godot_xhr_set_request_header(int p_xhr_id, const char *p_header, const char *p_value);
 
-extern void godot_xhr_send_null(int p_xhr_id);
-extern void godot_xhr_send_string(int p_xhr_id, const char *p_data);
-extern void godot_xhr_send_data(int p_xhr_id, const void *p_data, int p_len);
+extern void godot_xhr_send(int p_xhr_id, const void *p_data, int p_len);
 extern void godot_xhr_abort(int p_xhr_id);
 
 /* this is an HTTPClient::ResponseCode, not ::Status */

--- a/platform/javascript/js/libs/library_godot_http_request.js
+++ b/platform/javascript/js/libs/library_godot_http_request.js
@@ -82,31 +82,13 @@ const GodotHTTPRequest = {
 		GodotHTTPRequest.requests[xhrId].setRequestHeader(GodotRuntime.parseString(header), GodotRuntime.parseString(value));
 	},
 
-	godot_xhr_send_null__sig: 'vi',
-	godot_xhr_send_null: function (xhrId) {
-		GodotHTTPRequest.requests[xhrId].send();
-	},
-
-	godot_xhr_send_string__sig: 'vii',
-	godot_xhr_send_string: function (xhrId, strPtr) {
-		if (!strPtr) {
-			GodotRuntime.error('Failed to send string per XHR: null pointer');
-			return;
+	godot_xhr_send__sig: 'viii',
+	godot_xhr_send: function (xhrId, p_ptr, p_len) {
+		let data = null;
+		if (p_ptr && p_len) {
+			data = GodotRuntime.heapCopy(HEAP8, p_ptr, p_len);
 		}
-		GodotHTTPRequest.requests[xhrId].send(GodotRuntime.parseString(strPtr));
-	},
-
-	godot_xhr_send_data__sig: 'viii',
-	godot_xhr_send_data: function (xhrId, ptr, len) {
-		if (!ptr) {
-			GodotRuntime.error('Failed to send data per XHR: null pointer');
-			return;
-		}
-		if (len < 0) {
-			GodotRuntime.error('Failed to send data per XHR: buffer length less than 0');
-			return;
-		}
-		GodotHTTPRequest.requests[xhrId].send(HEAPU8.subarray(ptr, ptr + len));
+		GodotHTTPRequest.requests[xhrId].send(data);
 	},
 
 	godot_xhr_abort__sig: 'vi',


### PR DESCRIPTION
Now send data according to the spec, properly handle null data.
Simplify JS code since we are at it.

Fixes #45877