### PR TITLE
[HTML5] Editor: ensure canvas focus when switching tabs.

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -284,6 +284,10 @@
 			tabs.forEach(function (elem) {
 				if (elem.id == 'tab-' + name) {
 					elem.style.display = 'block';
+					if (name == 'editor' || name == 'game') {
+						const canvas = document.getElementById(name + '-canvas');
+						canvas.focus();
+					}
 				} else {
 					elem.style.display = 'none';
 				}


### PR DESCRIPTION
I wanted to attach a fix for #45800 to this PR, but it will require some work on the EditorData/EditorInterface which might not land in time for next RC. So only apply this for now (which at least mitigates the problem).