### PR TITLE
Restore Python 2.x support

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -40,12 +40,12 @@ jobs:
             ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
             ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
-      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
-      - name: Set up Python 3.x
+      # Test Python 2.x support for Godot 3.2.
+      - name: Set up Python 2.x
         uses: actions/setup-python@v2
         with:
           # Semantic version range syntax or exact version of a Python version
-          python-version: '3.x'
+          python-version: '2.x'
           # Optional - x64 or x86 architecture, defaults to x64
           architecture: 'x64'
 

--- a/methods.py
+++ b/methods.py
@@ -164,7 +164,7 @@ def detect_modules(search_path, recursive=False):
         if os.path.exists(version_path):
             with open(version_path) as f:
                 version = {}
-                exec(f.read(), version)
+                exec(f.read(), version) in locals()
                 if version.get("short_name") == "godot":
                     return True
         return False


### PR DESCRIPTION
Caused by using `exec` usage within nested functions (https://github.com/godotengine/godot/pull/43057#issuecomment-777495271), which works in Python 2.7.18, but not in Python 2.7.3.

Moved `is_engine()` outside of `detect_modules()` closer to `is_module()`, which was already outside `detect_modules()` anyways.

Also added `Python 2.x` to Linux CI checks, even if it's not able to test Python versions older than 2.7.17 out of the box...
