### PR TITLE
SCons: Fix Python 2 support after #43057

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -164,7 +164,7 @@ def detect_modules(search_path, recursive=False):
         if os.path.exists(version_path):
             with open(version_path) as f:
                 version = {}
-                exec(f.read(), version)
+                exec(f.read(), version) in locals()
                 if version.get("short_name") == "godot":
                     return True
         return False


### PR DESCRIPTION
That's not a very pretty way to parse a string from a python file
though, there should definitely be cleaner and more reliable ways
to do this without using `exec()`.