### PR TITLE
Expose RichTextLabel selection to script

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -80,6 +80,27 @@
 				Returns the total number of paragraphs (newlines or [code]p[/code] tags in the tag stack's text tags). Considers wrapped text as one paragraph.
 			</description>
 		</method>
+		<method name="get_selected_text" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the current selection text. Does not include BBCodes.
+			</description>
+		</method>
+		<method name="get_selection_from" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the current selection first character index if a selection is active, [code]-1[/code] otherwise. Does not include BBCodes.
+			</description>
+		</method>
+		<method name="get_selection_to" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the current selection last character index if a selection is active, [code]-1[/code] otherwise. Does not include BBCodes.
+			</description>
+		</method>
 		<method name="get_total_character_count" qualifiers="const">
 			<return type="int">
 			</return>

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -389,7 +389,7 @@ private:
 
 	void _find_click(ItemFrame *p_frame, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr, bool *r_outside = nullptr);
 
-	String _get_line_text(ItemFrame *p_frame, int p_line, Selection p_sel);
+	String _get_line_text(ItemFrame *p_frame, int p_line, Selection p_sel) const;
 	bool _search_line(ItemFrame *p_frame, int p_line, const String &p_string, Item *p_from, Item *p_to);
 
 	void _shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width, int *r_char_offset);
@@ -427,8 +427,8 @@ private:
 	void _scroll_changed(double);
 
 	void _gui_input(Ref<InputEvent> p_event);
-	Item *_get_next_item(Item *p_item, bool p_free = false);
-	Item *_get_prev_item(Item *p_item, bool p_free = false);
+	Item *_get_next_item(Item *p_item, bool p_free = false) const;
+	Item *_get_prev_item(Item *p_item, bool p_free = false) const;
 
 	Rect2 _get_text_rect();
 	Ref<RichTextEffect> _get_custom_effect_by_code(String p_bbcode_identifier);
@@ -524,7 +524,9 @@ public:
 
 	void set_selection_enabled(bool p_enabled);
 	bool is_selection_enabled() const;
-	String get_selected_text();
+	int get_selection_from() const;
+	int get_selection_to() const;
+	String get_selected_text() const;
 	void selection_copy();
 
 	Error parse_bbcode(const String &p_bbcode);


### PR DESCRIPTION
Expose existing `get_selection_text` and add methods to get the current selection index from and index to.

Implements proposal https://github.com/godotengine/godot-proposals/issues/1558

Test projects:
3.2 - [richtextlabel-tests.zip](https://github.com/godotengine/godot/files/5966887/richtextlabel-tests.zip)
4.0 - [richtextlabel-tests-4.0.zip](https://github.com/godotengine/godot/files/5966886/richtextlabel-tests-4.0.zip)
