### PR TITLE
SCons: Fix Godot detection in custom modules logic

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -174,9 +174,7 @@ def detect_modules(search_path, recursive=False):
         version_path = os.path.join(path, "version.py")
         if os.path.exists(version_path):
             with open(version_path) as f:
-                version = {}
-                exec(f.read(), version)
-                if version.get("short_name") == "godot":
+                if 'short_name = "godot"' in f.read():
                     return True
         return False
 


### PR DESCRIPTION
`exec()` was not a good idea as it assumes a certain type of `version.py` file
similar to Godot's own file, which is not always a reliable assumption (see
https://github.com/godotengine/godot/pull/43057#issuecomment-777632900).

Also restores Python 2 support for the 3.2 branch.

Supersedes #45896.
Supersedes #45897.