### PR TITLE
Improved Inspector Sub-Resource Editing

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -343,6 +343,8 @@ class EditorInspector : public ScrollContainer {
 
 	bool _is_property_disabled_by_feature_profile(const StringName &p_property);
 
+	void _update_inspector_bg();
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
@@ -394,6 +396,7 @@ public:
 
 	void set_use_wide_editors(bool p_enable);
 	void set_sub_inspector(bool p_enable);
+	bool is_sub_inspector() const { return sub_inspector; }
 
 	void set_use_deletable_properties(bool p_enabled);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5858,7 +5858,7 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("interface/inspector/horizontal_vector2_editing", false);
 	EDITOR_DEF("interface/inspector/horizontal_vector_types_editing", true);
 	EDITOR_DEF("interface/inspector/open_resources_in_current_inspector", true);
-	EDITOR_DEF("interface/inspector/resources_to_open_in_new_inspector", "StandardMaterial3D,ORMMaterial3D,Script,MeshLibrary,TileSet");
+	EDITOR_DEF("interface/inspector/resources_to_open_in_new_inspector", "Script,MeshLibrary,TileSet");
 	EDITOR_DEF("interface/inspector/default_color_picker_mode", 0);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_color_picker_mode", PROPERTY_HINT_ENUM, "RGB,HSV,RAW", PROPERTY_USAGE_DEFAULT));
 	EDITOR_DEF("run/auto_save/save_before_running", true);

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -654,6 +654,9 @@ class EditorPropertyResource : public EditorProperty {
 
 	bool opened_editor;
 
+	bool updating_theme = false;
+	void _update_property_bg();
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -442,6 +442,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Property editor
 	_initial_set("docks/property_editor/auto_refresh_interval", 0.2); //update 5 times per second by default
+	_initial_set("docks/property_editor/subresource_hue_tint", 0.75);
+	hints["docks/property_editor/subresource_hue_tint"] = PropertyInfo(Variant::FLOAT, "docks/property_editor/subresource_hue_tint", PROPERTY_HINT_RANGE, "0,1,0.01", PROPERTY_USAGE_DEFAULT);
 
 	/* Text editor */
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -724,14 +724,58 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("visibility_xray", "PopupMenu", theme->get_icon("GuiVisibilityXray", "EditorIcons"));
 	theme->set_constant("vseparation", "PopupMenu", (extra_spacing + default_margin_size + 1) * EDSCALE);
 
-	Ref<StyleBoxFlat> sub_inspector_bg = make_flat_stylebox(dark_color_1.lerp(accent_color, 0.08), 2, 0, 2, 2);
-	sub_inspector_bg->set_border_width(SIDE_LEFT, 2);
-	sub_inspector_bg->set_border_width(SIDE_RIGHT, 2);
-	sub_inspector_bg->set_border_width(SIDE_BOTTOM, 2);
-	sub_inspector_bg->set_border_color(accent_color * Color(1, 1, 1, 0.3));
-	sub_inspector_bg->set_draw_center(true);
+	for (int i = 0; i < 16; i++) {
+		Color si_base_color = accent_color;
 
-	theme->set_stylebox("sub_inspector_bg", "Editor", sub_inspector_bg);
+		float hue_rotate = (i * 2 % 16) / 16.0;
+		si_base_color.set_hsv(Math::fmod(float(si_base_color.get_h() + hue_rotate), float(1.0)), si_base_color.get_s(), si_base_color.get_v());
+		si_base_color = accent_color.lerp(si_base_color, float(EDITOR_GET("docks/property_editor/subresource_hue_tint")));
+
+		Ref<StyleBoxFlat> sub_inspector_bg;
+
+		sub_inspector_bg = make_flat_stylebox(dark_color_1.lerp(si_base_color, 0.08), 2, 0, 2, 2);
+
+		sub_inspector_bg->set_border_width(SIDE_LEFT, 2);
+		sub_inspector_bg->set_border_width(SIDE_RIGHT, 2);
+		sub_inspector_bg->set_border_width(SIDE_BOTTOM, 2);
+		sub_inspector_bg->set_border_width(SIDE_TOP, 2);
+		sub_inspector_bg->set_default_margin(SIDE_LEFT, 3);
+		sub_inspector_bg->set_default_margin(SIDE_RIGHT, 3);
+		sub_inspector_bg->set_default_margin(SIDE_BOTTOM, 10);
+		sub_inspector_bg->set_default_margin(SIDE_TOP, 5);
+		sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
+		sub_inspector_bg->set_draw_center(true);
+
+		theme->set_stylebox("sub_inspector_bg" + itos(i), "Editor", sub_inspector_bg);
+
+		Ref<StyleBoxFlat> bg_color;
+		bg_color.instance();
+		bg_color->set_bg_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
+		bg_color->set_border_width_all(0);
+
+		Ref<StyleBoxFlat> bg_color_selected;
+		bg_color_selected.instance();
+		bg_color_selected->set_border_width_all(0);
+		bg_color_selected->set_bg_color(si_base_color * Color(0.8, 0.8, 0.8, 0.8));
+
+		theme->set_stylebox("sub_inspector_property_bg" + itos(i), "Editor", bg_color);
+		theme->set_stylebox("sub_inspector_property_bg_selected" + itos(i), "Editor", bg_color_selected);
+	}
+
+	theme->set_color("sub_inspector_property_color", "Editor", dark_theme ? Color(1, 1, 1, 1) : Color(0, 0, 0, 1));
+	theme->set_constant("sub_inspector_font_offset", "Editor", 4 * EDSCALE);
+
+	Ref<StyleBoxFlat> style_property_bg = style_default->duplicate();
+	style_property_bg->set_bg_color(highlight_color);
+	style_property_bg->set_border_width_all(0);
+
+	theme->set_constant("font_offset", "EditorProperty", 1 * EDSCALE);
+	theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg);
+	theme->set_stylebox("bg", "EditorProperty", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
+	theme->set_constant("vseparation", "EditorProperty", (extra_spacing + default_margin_size) * EDSCALE);
+	theme->set_color("error_color", "EditorProperty", error_color);
+	theme->set_color("property_color", "EditorProperty", property_color);
+
 	theme->set_constant("inspector_margin", "Editor", 8 * EDSCALE);
 
 	// Tree & ItemList background


### PR DESCRIPTION
Based on ideas from @LucyLavend and @RPicster, posted in https://github.com/godotengine/godot-proposals/issues/2230

* Better margins
* Colors to delimit subresources better.

How it looks:

![image](https://user-images.githubusercontent.com/6265307/107698872-fc129280-6c93-11eb-950a-bd4866be7373.png)


*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/2230.*