### PR TITLE
Adjust auto scale on 4k monitors to 150%

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5671,6 +5671,10 @@ EditorNode::EditorNode() {
 				if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && DisplayServer::get_singleton()->screen_get_size(screen).y >= 1400) {
 					// hiDPI display.
 					scale = 2.0;
+				} else if (DisplayServer::get_singleton()->screen_get_size(screen).y >= 1700) {
+					// Likely a hiDPI display, but we aren't certain due to the returned DPI.
+					// Use an intermediate scale to handle this situation.
+					scale = 1.5;
 				} else if (DisplayServer::get_singleton()->screen_get_size(screen).y <= 800) {
 					// Small loDPI display. Use a smaller display scale so that editor elements fit more easily.
 					// Icons won't look great, but this is better than having editor elements overflow from its window.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -337,6 +337,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && DisplayServer::get_singleton()->screen_get_size(screen).y >= 1400) {
 		// hiDPI display.
 		scale = 2.0;
+	} else if (DisplayServer::get_singleton()->screen_get_size(screen).y >= 1700) {
+		// Likely a hiDPI display, but we aren't certain due to the returned DPI.
+		// Use an intermediate scale to handle this situation.
+		scale = 1.5;
 	} else if (DisplayServer::get_singleton()->screen_get_size(screen).y <= 800) {
 		// Small loDPI display. Use a smaller display scale so that editor elements fit more easily.
 		// Icons won't look great, but this is better than having editor elements overflow from its window.

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2385,6 +2385,10 @@ ProjectManager::ProjectManager() {
 				if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && DisplayServer::get_singleton()->screen_get_size(screen).y >= 1400) {
 					// hiDPI display.
 					scale = 2.0;
+				} else if (DisplayServer::get_singleton()->screen_get_size(screen).y >= 1700) {
+					// Likely a hiDPI display, but we aren't certain due to the returned DPI.
+					// Use an intermediate scale to handle this situation.
+					scale = 1.5;
 				} else if (DisplayServer::get_singleton()->screen_get_size(screen).y <= 800) {
 					// Small loDPI display. Use a smaller display scale so that editor elements fit more easily.
 					// Icons won't look great, but this is better than having editor elements overflow from its window.


### PR DESCRIPTION
Right now the automatic editor scale is either 100% or 200%, depending on resolution and dpi. While this works fine on smaller screens (e.g. laptops) it can cause issues on larger screens.
As discussed with @Calinou on rocketchat this PR aims to add a middle ground (150%) between 100% and 200% for larger hidpi displays.

EDIT: Not sure if you are still cherry-picking stuff for 3.2, but in theory, it should be possible to use this as is.