### PR TITLE
Add support for numeric XML entities to XMLParser

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -36,63 +36,6 @@
 
 VARIANT_ENUM_CAST(XMLParser::NodeType);
 
-static bool _equalsn(const char32_t *str1, const char32_t *str2, int len) {
-	int i;
-	for (i = 0; i < len && str1[i] && str2[i]; ++i) {
-		if (str1[i] != str2[i]) {
-			return false;
-		}
-	}
-
-	// if one (or both) of the strings was smaller then they
-	// are only equal if they have the same length
-	return (i == len) || (str1[i] == 0 && str2[i] == 0);
-}
-
-String XMLParser::_replace_special_characters(const String &origstr) {
-	int pos = origstr.find("&");
-	int oldPos = 0;
-
-	if (pos == -1) {
-		return origstr;
-	}
-
-	String newstr;
-
-	while (pos != -1 && pos < origstr.length() - 2) {
-		// check if it is one of the special characters
-
-		int specialChar = -1;
-		for (int i = 0; i < (int)special_characters.size(); ++i) {
-			const char32_t *p = &origstr[pos] + 1;
-
-			if (_equalsn(&special_characters[i][1], p, special_characters[i].length() - 1)) {
-				specialChar = i;
-				break;
-			}
-		}
-
-		if (specialChar != -1) {
-			newstr += (origstr.substr(oldPos, pos - oldPos));
-			newstr += (special_characters[specialChar][0]);
-			pos += special_characters[specialChar].length();
-		} else {
-			newstr += (origstr.substr(oldPos, pos - oldPos + 1));
-			pos += 1;
-		}
-
-		// find next &
-		oldPos = pos;
-		pos = origstr.find("&", pos);
-	}
-
-	if (oldPos < origstr.length() - 1) {
-		newstr += (origstr.substr(oldPos, origstr.length() - oldPos));
-	}
-
-	return newstr;
-}
-
 static inline bool _is_white_space(char c) {
 	return (c == ' ' || c == '\t' || c == '\n' || c == '\r');
 }
@@ -116,7 +59,7 @@ bool XMLParser::_set_text(char *start, char *end) {
 
 	// set current text to the parsed text, and replace xml special characters
 	String s = String::utf8(start, (int)(end - start));
-	node_name = _replace_special_characters(s);
+	node_name = s.xml_unescape();
 
 	// current XML node type is text
 	node_type = NODE_TEXT;
@@ -292,7 +235,7 @@ void XMLParser::_parse_opening_xml_element() {
 				String s = String::utf8(attributeValueBegin,
 						(int)(attributeValueEnd - attributeValueBegin));
 
-				attr.value = _replace_special_characters(s);
+				attr.value = s.xml_unescape();
 				attributes.push_back(attr);
 			} else {
 				// tag is closed directly
@@ -555,11 +498,6 @@ int XMLParser::get_current_line() const {
 }
 
 XMLParser::XMLParser() {
-	special_characters.push_back("&amp;");
-	special_characters.push_back("<lt;");
-	special_characters.push_back(">gt;");
-	special_characters.push_back("\"quot;");
-	special_characters.push_back("'apos;");
 }
 
 XMLParser::~XMLParser() {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -70,6 +70,7 @@
 #include "test_text_server.h"
 #include "test_validate_testing.h"
 #include "test_variant.h"
+#include "test_xml_parser.h"
 
 #include "modules/modules_tests.gen.h"
 

--- a/tests/test_xml_parser.h
+++ b/tests/test_xml_parser.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  xml_parser.h                                                         */
+/*  test_xml_parser.h                                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,94 +28,47 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef XML_PARSER_H
-#define XML_PARSER_H
+#ifndef TEST_XML_PARSER_H
+#define TEST_XML_PARSER_H
 
-#include "core/object/reference.h"
-#include "core/os/file_access.h"
+#include <inttypes.h>
+
+#include "core/io/xml_parser.h"
 #include "core/string/ustring.h"
-#include "core/templates/vector.h"
 
-/*
-  Based on irrXML (see their zlib license). Added mainly for compatibility with their Collada loader.
-*/
+#include "tests/test_macros.h"
 
-class XMLParser : public Reference {
-	GDCLASS(XMLParser, Reference);
+namespace TestXMLParser {
+TEST_CASE("[XMLParser] End-to-end") {
+	String source = "<?xml version = \"1.0\" encoding=\"UTF-8\" ?>\
+<top attr=\"attr value\">\
+  Text&lt;&#65;&#x42;&gt;\
+</top>";
+	Vector<uint8_t> buff = source.to_utf8_buffer();
 
-public:
-	//! Enumeration of all supported source text file formats
-	enum SourceFormat {
-		SOURCE_ASCII,
-		SOURCE_UTF8,
-		SOURCE_UTF16_BE,
-		SOURCE_UTF16_LE,
-		SOURCE_UTF32_BE,
-		SOURCE_UTF32_LE
-	};
+	XMLParser parser;
+	parser.open_buffer(buff);
 
-	enum NodeType {
-		NODE_NONE,
-		NODE_ELEMENT,
-		NODE_ELEMENT_END,
-		NODE_TEXT,
-		NODE_COMMENT,
-		NODE_CDATA,
-		NODE_UNKNOWN
-	};
+	// <?xml ...?> gets parsed as NODE_UNKNOWN
+	CHECK(parser.read() == OK);
+	CHECK(parser.get_node_type() == XMLParser::NodeType::NODE_UNKNOWN);
 
-private:
-	char *data = nullptr;
-	char *P = nullptr;
-	uint64_t length = 0;
-	String node_name;
-	bool node_empty = false;
-	NodeType node_type = NODE_NONE;
-	uint64_t node_offset = 0;
+	CHECK(parser.read() == OK);
+	CHECK(parser.get_node_type() == XMLParser::NodeType::NODE_ELEMENT);
+	CHECK(parser.get_node_name() == "top");
+	CHECK(parser.has_attribute("attr"));
+	CHECK(parser.get_attribute_value("attr") == "attr value");
 
-	struct Attribute {
-		String name;
-		String value;
-	};
+	CHECK(parser.read() == OK);
+	CHECK(parser.get_node_type() == XMLParser::NodeType::NODE_TEXT);
+	CHECK(parser.get_node_data().lstrip(" \t") == "Text<AB>");
 
-	Vector<Attribute> attributes;
+	CHECK(parser.read() == OK);
+	CHECK(parser.get_node_type() == XMLParser::NodeType::NODE_ELEMENT_END);
+	CHECK(parser.get_node_name() == "top");
 
-	String _replace_special_characters(const String &origstr);
-	bool _set_text(char *start, char *end);
-	void _parse_closing_xml_element();
-	void _ignore_definition();
-	bool _parse_cdata();
-	void _parse_comment();
-	void _parse_opening_xml_element();
-	void _parse_current_node();
+	parser.close();
+}
+} // namespace TestXMLParser
 
-	static void _bind_methods();
-
-public:
-	Error read();
-	NodeType get_node_type();
-	String get_node_name() const;
-	String get_node_data() const;
-	uint64_t get_node_offset() const;
-	int get_attribute_count() const;
-	String get_attribute_name(int p_idx) const;
-	String get_attribute_value(int p_idx) const;
-	bool has_attribute(const String &p_name) const;
-	String get_attribute_value(const String &p_name) const;
-	String get_attribute_value_safe(const String &p_name) const; // do not print error if doesn't exist
-	bool is_empty() const;
-	int get_current_line() const;
-
-	void skip_section();
-	Error seek(uint64_t p_pos);
-
-	Error open(const String &p_path);
-	Error open_buffer(const Vector<uint8_t> &p_buffer);
-
-	void close();
-
-	XMLParser();
-	~XMLParser();
-};
-
-#endif // XML_PARSER_H
+#endif // TEST_XML_PARSER_H


### PR DESCRIPTION
* Add support for decimal numeric entities to String::xml_unescape
* Add more error checks to String::xml_unescape
* Refactor XMLParser to use String::xml_unescape instead of an internal
implementation

Fixes #45841
