### PR TITLE
Use get_char_size(' ') to calculate space width.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1568,7 +1568,7 @@ Size2 LineEdit::get_minimum_size() const {
 	Size2 min_size;
 
 	// Minimum size of text.
-	int space_size = font->get_char_size('m', 0, font_size).x;
+	int space_size = font->get_char_size(' ', 0, font_size).x;
 	min_size.width = get_theme_constant("minimum_spaces") * space_size;
 
 	if (expand_to_text_length) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -220,7 +220,7 @@ void RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 
 	if (tab_size > 0) { // Align inline tabs.
 		Vector<float> tabs;
-		tabs.push_back(tab_size * p_base_font->get_char_size('m', 0, p_base_font_size).width);
+		tabs.push_back(tab_size * p_base_font->get_char_size(' ', 0, p_base_font_size).width);
 		l.text_buf->tab_align(tabs);
 	}
 
@@ -392,7 +392,7 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 
 	if (tab_size > 0) { // Align inline tabs.
 		Vector<float> tabs;
-		tabs.push_back(tab_size * p_base_font->get_char_size('m', 0, p_base_font_size).width);
+		tabs.push_back(tab_size * p_base_font->get_char_size(' ', 0, p_base_font_size).width);
 		l.text_buf->tab_align(tabs);
 	}
 
@@ -1859,7 +1859,7 @@ int RichTextLabel::_find_margin(Item *p_item, const Ref<Font> &p_base_font, int 
 			if (font_size == -1) {
 				font_size = p_base_font_size;
 			}
-			margin += tab_size * font->get_char_size('m', 0, font_size).width;
+			margin += tab_size * font->get_char_size(' ', 0, font_size).width;
 
 		} else if (item->type == ITEM_LIST) {
 			Ref<Font> font = _find_font(item);
@@ -1870,7 +1870,7 @@ int RichTextLabel::_find_margin(Item *p_item, const Ref<Font> &p_base_font, int 
 			if (font_size == -1) {
 				font_size = p_base_font_size;
 			}
-			margin += tab_size * font->get_char_size('m', 0, font_size).width;
+			margin += tab_size * font->get_char_size(' ', 0, font_size).width;
 		}
 
 		item = item->parent;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -202,7 +202,7 @@ void TextEdit::Text::invalidate_cache(int p_line, int p_column, const String &p_
 	// Apply tab align.
 	if (indent_size > 0) {
 		Vector<float> tabs;
-		tabs.push_back(font->get_char_size('m', 0, font_size).width * indent_size);
+		tabs.push_back(font->get_char_size(' ', 0, font_size).width * indent_size);
 		text.write[p_line].data_buf->tab_align(tabs);
 	}
 }
@@ -212,7 +212,7 @@ void TextEdit::Text::invalidate_all_lines() {
 		text.write[i].data_buf->set_width(width);
 		if (indent_size > 0) {
 			Vector<float> tabs;
-			tabs.push_back(font->get_char_size('m', 0, font_size).width * indent_size);
+			tabs.push_back(font->get_char_size(' ', 0, font_size).width * indent_size);
 			text.write[i].data_buf->tab_align(tabs);
 		}
 	}
@@ -1050,7 +1050,7 @@ void TextEdit::_notification(int p_what) {
 
 						// Give visual indication of empty selected line.
 						if (selection.active && line >= selection.from_line && line <= selection.to_line && char_margin >= xmargin_beg) {
-							int char_w = cache.font->get_char_size('m', 0, cache.font_size).width;
+							int char_w = cache.font->get_char_size(' ', 0, cache.font_size).width;
 							if (rtl) {
 								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - xmargin_beg - ofs_x - char_w, ofs_y, char_w, row_height), cache.selection_color);
 							} else {


### PR DESCRIPTION
Fixes regressing form Text Server implementation (`get_char_size('m')` was accidentally used.)
