### PR TITLE
Fix LineEdit minimum width

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2841,7 +2841,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTR("Filter nodes"));
 	filter_hbc->add_child(filter);
-	filter->add_theme_constant_override("minimum_spaces", 0);
+	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect("text_changed", callable_mp(this, &SceneTreeDock::_filter_changed));
 
 	button_create_script = memnew(Button);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1260,7 +1260,7 @@ SceneTreeDialog::SceneTreeDialog() {
 	filter = memnew(LineEdit);
 	filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTR("Filter nodes"));
-	filter->add_theme_constant_override("minimum_spaces", 0);
+	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect("text_changed", callable_mp(this, &SceneTreeDialog::_filter_changed));
 	vbc->add_child(filter);
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1172,7 +1172,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	floor->set_min(-32767);
 	floor->set_max(32767);
 	floor->set_step(1);
-	floor->get_line_edit()->add_theme_constant_override("minimum_spaces", 16);
+	floor->get_line_edit()->add_theme_constant_override("minimum_character_width", 16);
 
 	spatial_editor_hb->add_child(floor);
 	floor->connect("value_changed", callable_mp(this, &GridMapEditor::_floor_changed));

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1568,12 +1568,12 @@ Size2 LineEdit::get_minimum_size() const {
 	Size2 min_size;
 
 	// Minimum size of text.
-	int space_size = font->get_char_size(' ', 0, font_size).x;
-	min_size.width = get_theme_constant("minimum_spaces") * space_size;
+	int em_space_size = font->get_char_size('M', 0, font_size).x;
+	min_size.width = get_theme_constant("minimum_character_width'") * em_space_size;
 
 	if (expand_to_text_length) {
 		// Add a space because some fonts are too exact, and because cursor needs a bit more when at the end.
-		min_size.width = MAX(min_size.width, full_width + space_size);
+		min_size.width = MAX(min_size.width, full_width + em_space_size);
 	}
 
 	min_size.height = MAX(TS->shaped_text_get_size(text_rid).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM), font->get_height(font_size));

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1380,7 +1380,7 @@ void TextEdit::_notification(int p_what) {
 											l_caret.size.y = h;
 										}
 										l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
-										l_caret.size.x = cache.font->get_char_size('m', 0, cache.font_size).x;
+										l_caret.size.x = cache.font->get_char_size('M', 0, cache.font_size).x;
 
 										draw_rect(l_caret, cache.caret_color, false);
 									}

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -394,7 +394,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("clear_button_color", "LineEdit", control_font_color);
 	theme->set_color("clear_button_color_pressed", "LineEdit", control_font_pressed_color);
 
-	theme->set_constant("minimum_spaces", "LineEdit", 12 * scale);
+	theme->set_constant("minimum_character_width", "LineEdit", 4);
 
 	theme->set_icon("clear", "LineEdit", make_icon(line_edit_clear_png));
 


### PR DESCRIPTION
-Changed theme setting name to make more sense of what it does
-Reduced amount of minimum characters, so minimum size is smaller.

As a reference, small LineEdit properties now look fixed:
![image](https://user-images.githubusercontent.com/6265307/107778183-8275b580-6d22-11eb-8dd7-381f019b776b.png)

~~Supersedes #45922 (which should likely be reverted).~~ Done on top of it, as tab changes were correct.
