### PR TITLE
Add ability to change Icon Saturation

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2985,6 +2985,26 @@ void Image::set_pixel(int p_x, int p_y, const Color &p_color) {
 	_set_color_at_ofs(data.ptrw(), ofs, p_color);
 }
 
+void Image::adjust_bcs(float p_brightness, float p_contrast, float p_saturation) {
+	uint8_t *w = data.ptrw();
+	uint32_t pixel_size = get_format_pixel_size(format);
+	uint32_t pixel_count = data.size() / pixel_size;
+
+	for (uint32_t i = 0; i < pixel_count; i++) {
+		Color c = _get_color_at_ofs(w, i);
+		Vector3 rgb(c.r, c.g, c.b);
+
+		rgb *= p_brightness;
+		rgb = Vector3(0.5, 0.5, 0.5).lerp(rgb, p_contrast);
+		float center = (rgb.x + rgb.y + rgb.z) / 3.0;
+		rgb = Vector3(center, center, center).lerp(rgb, p_saturation);
+		c.r = rgb.x;
+		c.g = rgb.y;
+		c.b = rgb.z;
+		_set_color_at_ofs(w, i, c);
+	}
+}
+
 Image::UsedChannels Image::detect_used_channels(CompressSource p_source) {
 	ERR_FAIL_COND_V(data.size() == 0, USED_CHANNELS_RGBA);
 	ERR_FAIL_COND_V(is_compressed(), USED_CHANNELS_RGBA);
@@ -3131,6 +3151,8 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pixel", "x", "y"), &Image::get_pixel);
 	ClassDB::bind_method(D_METHOD("set_pixelv", "point", "color"), &Image::set_pixelv);
 	ClassDB::bind_method(D_METHOD("set_pixel", "x", "y", "color"), &Image::set_pixel);
+
+	ClassDB::bind_method(D_METHOD("adjust_bcs", "brightness", "contrast", "saturation"), &Image::adjust_bcs);
 
 	ClassDB::bind_method(D_METHOD("load_png_from_buffer", "buffer"), &Image::load_png_from_buffer);
 	ClassDB::bind_method(D_METHOD("load_jpg_from_buffer", "buffer"), &Image::load_jpg_from_buffer);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -390,6 +390,8 @@ public:
 	void set_pixelv(const Point2i &p_point, const Color &p_color);
 	void set_pixel(int p_x, int p_y, const Color &p_color);
 
+	void adjust_bcs(float p_brightness, float p_contrast, float p_saturation);
+
 	void set_as_black();
 
 	void copy_internals_from(const Ref<Image> &p_image) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -392,6 +392,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/theme/accent_color"] = PropertyInfo(Variant::COLOR, "interface/theme/accent_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/theme/contrast", 0.25);
 	hints["interface/theme/contrast"] = PropertyInfo(Variant::FLOAT, "interface/theme/contrast", PROPERTY_HINT_RANGE, "0.01, 1, 0.01");
+	_initial_set("interface/theme/icon_saturation", 1.0);
+	hints["interface/theme/icon_saturation"] = PropertyInfo(Variant::FLOAT, "interface/theme/icon_saturation", PROPERTY_HINT_RANGE, "0,2,0.01", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/theme/relationship_line_opacity", 0.1);
 	hints["interface/theme/relationship_line_opacity"] = PropertyInfo(Variant::FLOAT, "interface/theme/relationship_line_opacity", PROPERTY_HINT_RANGE, "0.00, 1, 0.01");
 	_initial_set("interface/theme/highlight_tabs", false);


### PR DESCRIPTION
* Allows for more theme freedom
* Allows for entirely B&W themes.

Examples:

![image](https://user-images.githubusercontent.com/6265307/107786333-89092a80-6d2c-11eb-99d4-83a7d20fa3e9.png)
