### PR TITLE
Fix sprite editor conversion tools to handle compressed textures

### DIFF
--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -173,6 +173,11 @@ void Sprite2DEditor::_update_mesh_data() {
 
 	Ref<Image> image = texture->get_data();
 	ERR_FAIL_COND(image.is_null());
+
+	if (image->is_compressed()) {
+		image->decompress();
+	}
+
 	Rect2 rect;
 	if (node->is_region()) {
 		rect = node->get_region_rect();


### PR DESCRIPTION
Fixes #44291.

Some textures can be imported as compressed, but image manipulation requires those to be decompressed first.