### PR TITLE
Fix for "Save Branch as Scene"

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2321,10 +2321,14 @@ void SceneTreeDock::_new_scene_from(String p_file) {
 
 	Node *base = selection.front()->get();
 
-	Map<Node *, Node *> reown;
-	reown[editor_data->get_edited_scene_root()] = base;
-	Node *copy = base->duplicate_and_reown(reown);
+	Map<const Node *, Node *> duplimap;
+	Node *copy = base->duplicate_from_editor(duplimap);
+
 	if (copy) {
+		for (int i = 0; i < copy->get_child_count(); i++) {
+			_set_node_owner_recursive(copy->get_child(i), copy);
+		}
+
 		Ref<PackedScene> sdata = memnew(PackedScene);
 		Error err = sdata->pack(copy);
 		memdelete(copy);
@@ -2351,6 +2355,16 @@ void SceneTreeDock::_new_scene_from(String p_file) {
 		accept->set_text(TTR("Error duplicating scene to save it."));
 		accept->popup_centered();
 		return;
+	}
+}
+
+void SceneTreeDock::_set_node_owner_recursive(Node *p_node, Node *p_owner) {
+	if (!p_node->get_owner()) {
+		p_node->set_owner(p_owner);
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_set_node_owner_recursive(p_node->get_child(i), p_owner);
 	}
 }
 

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -203,6 +203,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _import_subscene();
 
 	void _new_scene_from(String p_file);
+	void _set_node_owner_recursive(Node *p_node, Node *p_owner);
 
 	bool _validate_no_foreign();
 	bool _validate_no_instance();

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -173,7 +173,6 @@ private:
 	Array _get_node_and_resource(const NodePath &p_path);
 
 	void _duplicate_signals(const Node *p_original, Node *p_copy) const;
-	void _duplicate_and_reown(Node *p_new_parent, const Map<Node *, Node *> &p_reown_map) const;
 	Node *_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap = nullptr) const;
 
 	TypedArray<Node> _get_children() const;
@@ -366,7 +365,6 @@ public:
 	bool is_processing_unhandled_key_input() const;
 
 	Node *duplicate(int p_flags = DUPLICATE_GROUPS | DUPLICATE_SIGNALS | DUPLICATE_SCRIPTS) const;
-	Node *duplicate_and_reown(const Map<Node *, Node *> &p_reown_map) const;
 #ifdef TOOLS_ENABLED
 	Node *duplicate_from_editor(Map<const Node *, Node *> &r_duplimap) const;
 	Node *duplicate_from_editor(Map<const Node *, Node *> &r_duplimap, const Map<RES, RES> &p_resource_remap) const;


### PR DESCRIPTION
Fixes #42611.

Hello Godoters! This PR is for discussion on my solution for #42611. While the PR solves the problems described in the original ticket, I'm new to the Godot engine and therefore appreciate your feedback on this solution. 

**Result of my analysis:**
The original "Save Branch as Scene" function of the SceneTreeDock uses the ```duplicate_and_reown``` function of the ```Node``` class to create a clone of the selected node, saving it to a file and then replacing the subtree by the scene instance. My analysis showed that ```duplicate_and_reown``` has the following flaws:

1. Editable flag of instanced scenes gets lost
2. Recursive ```_duplicate_and_reown``` skips children of instanced scenes (owner check at the beginning of the method)

While [1] was rather easy to fix, [2] was not easily possible, as there would have been a lot of special cases to handle, which the ```duplicate_and_reown``` method currently isn't aware of (e.g. changed properties of editable children, nodes added to editable children). 

I found out the the Node class has three "duplicate" methods:

- ```duplicate```
- ```duplicate_from_editor``` (used in SceneTreeDock's "Duplicate" function)
- ```duplicate_and_reown``` (used in SceneTreeDock's "Save Branch as Scene" function, looked a bit _outdated_)

I've checked the ```duplicate_from_editor``` and found out that it is aware of creating duplicates with (editable) instanced scenes. Using the "Duplicate" function in Godot v4 editor together with the MRP from #42611 showed good results. Only issue was that the "editable" flag got lost as well (but can be fixed easily).

**Summary of changes in this PR:**
1. Modified SceneTreeDock's "Save Branch as Scene" to use ```duplicate_from_editor``` instead of ```duplicate_and_reown```.
2. Removed ```duplicate_and_reown``` as it was only used in "Save Branch as Scene" (and not exposed to scripting)
3. <del>Added ```Node::reown``` method to recursively change owners of a tree (was originally part of ```duplicate_and_reown```) - use it in the modified "Save Branch as Scene" function to update the owner in the duplicated subtree</del>
4. Fixed ```Node::duplicate_from_editor``` to copy the "editable" flag of instanced children

I'm looking forward to your feedback on these changes. :-)

PS: During development I've recognized that when saving a .tscn, Godot 4.0 writes out a **script = null** for each node without a script. I'm not sure whether this is a bug or a feature, but I just want to point out that this has nothing to do with the changes in this PR in case you wonder. It happens with vanilla Godot 4.0 from master branch when saving a scene.

Edit: Updated formatting + added minor clarifications

Edit 2: Updated list of changes (removed ```reown``` function after code review)