### PR TITLE
Sleep the coreaudio driver in-editor after 15s of silence

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -243,27 +243,35 @@ OSStatus AudioDriverCoreAudio::input_callback(void *inRefCon,
 }
 
 void AudioDriverCoreAudio::start() {
-	if (!active && !sleeping) {
+	if (active) {
+		return;
+	}
+	if (!sleeping) {
 		OSStatus result = AudioOutputUnitStart(audio_unit);
 		if (result != noErr) {
 			ERR_PRINT("AudioOutputUnitStart failed, code: " + itos(result));
 		} else {
 			active = true;
 		}
-	} else if (!active && sleeping) {
+	} else {
+		// Driver is sleeping, so don't call AudioOutputUnitStart yet.
 		active = true;
 	}
 };
 
 void AudioDriverCoreAudio::stop() {
-	if (active && !sleeping) {
+	if (!active) {
+		return;
+	}
+	if (!sleeping) {
 		OSStatus result = AudioOutputUnitStop(audio_unit);
 		if (result != noErr) {
 			ERR_PRINT("AudioOutputUnitStop failed, code: " + itos(result));
 		} else {
 			active = false;
 		}
-	} else if (active && sleeping) {
+	} else {
+		// Driver is sleeping so no need to call AudioOutputUnitStop.
 		active = false;
 	}
 }

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -45,6 +45,7 @@ class AudioDriverCoreAudio : public AudioDriver {
 	AudioComponentInstance input_unit = nullptr;
 
 	bool active = false;
+	bool sleeping = false;
 	Mutex mutex;
 
 	String device_name = "Default";
@@ -93,6 +94,7 @@ public:
 
 	virtual Error init();
 	virtual void start();
+	virtual void set_sleep_state(bool p_sleeping);
 	virtual int get_mix_rate() const;
 	virtual SpeakerMode get_speaker_mode() const;
 

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -88,6 +88,9 @@ private:
 	float max_distance = 2000.0;
 	float attenuation = 1.0;
 
+	bool has_playback_lock = false;
+	Mutex playback_lock_mutex;
+
 protected:
 	void _validate_property(PropertyInfo &property) const override;
 	void _notification(int p_what);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -125,6 +125,9 @@ private:
 
 	float max_distance = 0.0;
 
+	bool has_playback_lock = false;
+	Mutex playback_lock_mutex;
+
 	Ref<VelocityTracker3D> velocity_tracker;
 
 	DopplerTracking doppler_tracking = DOPPLER_TRACKING_DISABLED;

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -66,6 +66,9 @@ private:
 
 	MixTarget mix_target = MIX_TARGET_STEREO;
 
+	bool has_playback_lock = false;
+	Mutex playback_lock_mutex;
+
 	void _mix_internal(bool p_fadeout);
 	void _mix_audio();
 	static void _mix_audios(void *self) { reinterpret_cast<AudioStreamPlayer *>(self)->_mix_audio(); }

--- a/scene/gui/video_player.h
+++ b/scene/gui/video_player.h
@@ -71,6 +71,9 @@ class VideoPlayer : public Control {
 
 	StringName bus;
 
+	bool has_playback_lock = false;
+	Mutex playback_lock_mutex;
+
 	void _mix_audio();
 	static int _audio_mix_callback(void *p_udata, const float *p_data, int p_frames);
 	static void _mix_audios(void *p_self);

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1050,7 +1050,7 @@ void AudioServer::update() {
 	}
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		// Allow the audio driver to sleep in the engine after 15 seconds of inactivity.
+		// Allow the audio driver to sleep in the editor after 15 seconds of inactivity.
 		MutexLock lock(playing_sources_mutex);
 		if (playing_sources_count == 0 && last_playback_time_msec < OS::get_singleton()->get_ticks_msec() - 15000) {
 			AudioDriver::get_singleton()->set_sleep_state(true);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -111,6 +111,8 @@ public:
 	unsigned int get_input_position() { return input_position; }
 	unsigned int get_input_size() { return input_size; }
 
+	virtual void set_sleep_state(bool p_sleep) {}
+
 #ifdef DEBUG_ENABLED
 	uint64_t get_profiling_time() const { return prof_time; }
 	void reset_profiling_time() { prof_time = 0; }
@@ -243,6 +245,10 @@ private:
 	Set<CallbackItem> callbacks;
 	Set<CallbackItem> update_callbacks;
 
+	Mutex playing_sources_mutex;
+	size_t playing_sources_count;
+	uint64_t last_playback_time_msec;
+
 	friend class AudioDriver;
 	void _driver_process(int p_frames, int32_t *p_buffer);
 
@@ -318,6 +324,9 @@ public:
 
 	void set_global_rate_scale(float p_scale);
 	float get_global_rate_scale() const;
+
+	void notify_source_playing();
+	void notify_source_stopped_playing();
 
 	virtual void init();
 	virtual void finish();

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -245,7 +245,6 @@ private:
 	Set<CallbackItem> callbacks;
 	Set<CallbackItem> update_callbacks;
 
-	Mutex playing_sources_mutex;
 	size_t playing_sources_count;
 	uint64_t last_playback_time_msec;
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #28039
Should help mitigate #38154 but might not solve the root cause

This PR allows the coreaudio driver to enter a sleep state when the AudioServer requests it to. Mutexes have been added to all audio players and the video player to prevent a play() call acquiring a playback "lock" from racing with a _mix_audio call releasing it. I'm not a C++ expert so maybe there's some fancy RAII way to do this but I figured I'd start simple and avoid overengineering.

How to test:

1. Build & run the editor with these changes on a mac
2. Create each kind of AudioStreamPlayer. Play the players one at a time and watch Godot's "Preventing Sleep" status in Activity Monitor flip from "No" to "Yes" within a few seconds of starting the player, then flip back to "No" about 15 seconds after the audio is finished playing.

I have been unable to test video players. They don't seem to work in latest master as far as I can tell.