### PR TITLE
Fix internal resource detecting when pasting nodes

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2921,7 +2921,7 @@ void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap)
 		if (v.is_ref()) {
 			RES res = v;
 			if (res.is_valid()) {
-				if (res->get_path() == "" && !r_remap.has(res)) {
+				if ((res->get_path() == "" || res->get_path().find("::") > -1) && !r_remap.has(res)) {
 					_create_remap_for_resource(res, r_remap);
 				}
 			}
@@ -2948,7 +2948,7 @@ void SceneTreeDock::_create_remap_for_resource(RES p_resource, Map<RES, RES> &r_
 		if (v.is_ref()) {
 			RES res = v;
 			if (res.is_valid()) {
-				if (res->get_path() == "" && !r_remap.has(res)) {
+				if ((res->get_path() == "" || res->get_path().find("::") > -1) && !r_remap.has(res)) {
 					_create_remap_for_resource(res, r_remap);
 				}
 			}


### PR DESCRIPTION
While backporting #34892 I discovered a "small" bug. Turns out built-in resources don't always have empty path, so you need additional check.