### PR TITLE
Only unload the library if the reloadable flag is true

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1728,7 +1728,7 @@ void NativeScriptLanguage::unregister_script(NativeScript *script) {
 			library_script_users.erase(S);
 
 			Map<String, Ref<GDNative>>::Element *G = library_gdnatives.find(script->lib_path);
-			if (G) {
+			if (G && G->get()->get_library()->is_reloadable()) {
 				G->get()->terminate();
 				library_gdnatives.erase(G);
 			}


### PR DESCRIPTION
A recent change allowed Godot to unload a GDNative library when all script objects using it got destroyed. Unfortunately there are GDNative libraries that do more then just nativescript which now get unloaded while still in use.

We had similar issues with tool based libraries where Godot would unload a library when focus was lost so you could hotload a newly compiled library. To prevent this the `reloadable` flag was introduced. If set to false Godot will keep the GDNative library loaded until the application terminates.

This PR simply adheres to this same flag in order to prevent premature unloading of the library. 

Fixes #45952