### PR TITLE
fix set_joint_i_to_name to use the provided argument

### DIFF
--- a/modules/gltf/gltf_skin.cpp
+++ b/modules/gltf/gltf_skin.cpp
@@ -142,7 +142,7 @@ void GLTFSkin::set_joint_i_to_name(Dictionary p_joint_i_to_name) {
 	joint_i_to_name = Map<int, StringName>();
 	Array keys = p_joint_i_to_name.keys();
 	for (int i = 0; i < keys.size(); i++) {
-		joint_i_to_name[keys[i]] = joint_i_to_name[keys[i]];
+		joint_i_to_name[keys[i]] = p_joint_i_to_name[keys[i]];
 	}
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Changes set_joint_i_to_name function to actually use the dictionary provided in the argument
Not yet tested. fixes #45371