### PR TITLE
Allow to use a Reference during NOTIFICATION_PREDELETE

### DIFF
--- a/core/object/reference.cpp
+++ b/core/object/reference.cpp
@@ -102,6 +102,21 @@ Reference::Reference() :
 	refcount_init.init();
 }
 
+bool predelete_handler(Reference *p_reference) {
+	// Allow to use p_reference during predelete
+	// The refcount should be incremented twice to prevent crashes
+	p_reference->refcount.force_ref();
+	p_reference->refcount.force_ref();
+	bool ok = predelete_handler(static_cast<Object *>(p_reference));
+
+#ifdef DEBUG_ENABLED
+	if (p_reference->reference_get_count() > 2) {
+		ERR_PRINT("There are references still alive after handling NOTIFICATION_PREDELETE");
+	}
+#endif
+	return ok;
+}
+
 Variant WeakRef::get_ref() const {
 	if (ref.is_null()) {
 		return Variant();

--- a/core/object/reference.h
+++ b/core/object/reference.h
@@ -39,6 +39,8 @@ class Reference : public Object {
 	SafeRefCount refcount;
 	SafeRefCount refcount_init;
 
+	friend bool predelete_handler(Reference *);
+
 protected:
 	static void _bind_methods();
 

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -158,6 +158,10 @@ public:
 		return count.conditional_increment() != 0;
 	}
 
+	_ALWAYS_INLINE_ void force_ref() {
+		count.increment();
+	}
+
 	_ALWAYS_INLINE_ uint32_t refval() { // none-zero on success
 		return count.conditional_increment();
 	}
@@ -287,6 +291,10 @@ public:
 		} else {
 			return false;
 		}
+	}
+
+	_ALWAYS_INLINE_ void force_ref() {
+		++count;
 	}
 
 	_ALWAYS_INLINE_ uint32_t refval() { // none-zero on success

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -692,6 +692,7 @@
 		</constant>
 		<constant name="NOTIFICATION_PREDELETE" value="1">
 			Called before the object is about to be deleted.
+			[b]Warning:[/b] Don't keep a reference of self or emit a signal when handling this notification because it will cause a crash.
 		</constant>
 		<constant name="CONNECT_DEFERRED" value="1" enum="ConnectFlags">
 			Connects a signal in deferred mode. This way, signal emissions are stored in a queue, then set on idle time.


### PR DESCRIPTION
Fixes #31166

The issue happens because the refcount can't be incremented during the predelete, so objects that require to increment it (e.g. Variant) will fail.
This PR workaround the issue by setting the refcount to 1 before calling notification, so the reference seems valid during the predelete.