### PR TITLE
Check limits on texture or framebuffer creation

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -124,6 +124,12 @@ void RasterizerSceneGLES2::shadow_atlas_set_size(RID p_atlas, int p_size) {
 		glGenFramebuffers(1, &shadow_atlas->fbo);
 		glBindFramebuffer(GL_FRAMEBUFFER, shadow_atlas->fbo);
 
+		if (shadow_atlas->size > storage->config.max_viewport_dimensions[0] || shadow_atlas->size > storage->config.max_viewport_dimensions[1]) {
+			WARN_PRINTS("Cannot set shadow atlas size larger than maximum hardware supported size of (" + itos(storage->config.max_viewport_dimensions[0]) + ", " + itos(storage->config.max_viewport_dimensions[1]) + "). Setting size to maximum.");
+			shadow_atlas->size = MIN(shadow_atlas->size, storage->config.max_viewport_dimensions[0]);
+			shadow_atlas->size = MIN(shadow_atlas->size, storage->config.max_viewport_dimensions[1]);
+		}
+
 		// create a depth texture
 		glActiveTexture(GL_TEXTURE0);
 
@@ -540,6 +546,13 @@ bool RasterizerSceneGLES2::reflection_probe_instance_begin_render(RID p_instance
 
 		//update cubemap if resolution changed
 		int size = rpi->probe_ptr->resolution;
+
+		if (size > storage->config.max_viewport_dimensions[0] || size > storage->config.max_viewport_dimensions[1]) {
+			WARN_PRINT_ONCE("Cannot set reflection probe resolution larger than maximum hardware supported size of (" + itos(storage->config.max_viewport_dimensions[0]) + ", " + itos(storage->config.max_viewport_dimensions[1]) + "). Setting size to maximum.");
+			size = MIN(size, storage->config.max_viewport_dimensions[0]);
+			size = MIN(size, storage->config.max_viewport_dimensions[1]);
+		}
+
 		rpi->current_resolution = size;
 
 		GLenum internal_format = GL_RGB;
@@ -4010,6 +4023,12 @@ void RasterizerSceneGLES2::initialize() {
 
 		directional_shadow.light_count = 0;
 		directional_shadow.size = next_power_of_2(GLOBAL_GET("rendering/quality/directional_shadow/size"));
+
+		if (directional_shadow.size > storage->config.max_viewport_dimensions[0] || directional_shadow.size > storage->config.max_viewport_dimensions[1]) {
+			WARN_PRINTS("Cannot set directional shadow size larger than maximum hardware supported size of (" + itos(storage->config.max_viewport_dimensions[0]) + ", " + itos(storage->config.max_viewport_dimensions[1]) + "). Setting size to maximum.");
+			directional_shadow.size = MIN(directional_shadow.size, storage->config.max_viewport_dimensions[0]);
+			directional_shadow.size = MIN(directional_shadow.size, storage->config.max_viewport_dimensions[1]);
+		}
 
 		glGenFramebuffers(1, &directional_shadow.fbo);
 		glBindFramebuffer(GL_FRAMEBUFFER, directional_shadow.fbo);

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -558,6 +558,13 @@ void RasterizerStorageGLES2::texture_allocate(RID p_texture, int p_width, int p_
 	texture->width = p_width;
 	texture->height = p_height;
 	texture->format = p_format;
+
+	if (texture->width > config.max_texture_size || texture->height > config.max_texture_size) {
+		WARN_PRINTS("Cannot create texture larger than maximum hardware supported size of " + itos(config.max_texture_size) + ". Setting size to maximum.");
+		texture->width = MIN(texture->width, config.max_texture_size);
+		texture->height = MIN(texture->height, config.max_texture_size);
+	}
+
 	texture->flags = p_flags;
 	texture->stored_cube_sides = 0;
 	texture->type = p_type;
@@ -4740,6 +4747,12 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 		return;
 	}
 
+	if (rt->width > config.max_viewport_dimensions[0] || rt->height > config.max_viewport_dimensions[1]) {
+		WARN_PRINTS("Cannot create render target larger than maximum hardware supported size of (" + itos(config.max_viewport_dimensions[0]) + ", " + itos(config.max_viewport_dimensions[1]) + "). Setting size to maximum.");
+		rt->width = MIN(rt->width, config.max_viewport_dimensions[0]);
+		rt->height = MIN(rt->height, config.max_viewport_dimensions[1]);
+	}
+
 	GLuint color_internal_format;
 	GLuint color_format;
 	GLuint color_type = GL_UNSIGNED_BYTE;
@@ -6176,6 +6189,7 @@ void RasterizerStorageGLES2::initialize() {
 	glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &config.max_vertex_texture_image_units);
 	glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &config.max_texture_image_units);
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &config.max_texture_size);
+	glGetIntegerv(GL_MAX_VIEWPORT_DIMS, config.max_viewport_dimensions);
 
 	// the use skeleton software path should be used if either float texture is not supported,
 	// OR max_vertex_texture_image_units is zero

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -63,6 +63,7 @@ public:
 		int max_vertex_texture_image_units;
 		int max_texture_image_units;
 		int max_texture_size;
+		int max_viewport_dimensions[2];
 
 		// TODO implement wireframe in GLES2
 		// bool generate_wireframes;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/38879

Check for max viewport size when initializing drivers. When users try to create a texture or viewport larger than the max size, warn them and shrink the size. This will help a lot in 3D when users try to have large shadows. And will help in 2D when users use textures that are too large. 

supercedes: https://github.com/godotengine/godot/pull/45454 

