### PR TITLE
Fix uninitialized `BaseMaterial3D::features` variable.

### DIFF
--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -519,7 +519,7 @@ private:
 
 	AlphaAntiAliasing alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 
-	bool features[FEATURE_MAX];
+	bool features[FEATURE_MAX] = {};
 
 	Ref<Texture2D> textures[TEXTURE_MAX];
 


### PR DESCRIPTION
In the #45845 `features` initialization was removed from constructor, but default value was not added to the class declaration.

Fixes #45908