### PR TITLE
improve error message when travel() is called on an AnimationNodeStateMachine when the state machine is not playing

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -317,7 +317,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 					// stopped, invalid state
 					String node_name = start_request;
 					start_request = StringName(); //clear start request
-					ERR_FAIL_V_MSG(0, "Can't travel to '" + node_name + "' if state machine is not playing.");
+					ERR_FAIL_V_MSG(0, "Can't travel to '" + node_name + "' if state machine is not playing. Maybe you need to enable Autoplay on Load for one of the nodes in your state machine or call .start() first?");
 				}
 			} else {
 				if (!_travel(p_state_machine, start_request)) {


### PR DESCRIPTION
Update the error message so when users run across the issue from #28969, the error message provides a suggestion: https://github.com/godotengine/godot/issues/28969#issuecomment-660541263