### PR TITLE
Make Reference functional at predelete

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -485,7 +485,6 @@ private:
 	_FORCE_INLINE_ void _construct_object(bool p_reference);
 
 	friend class Reference;
-	bool type_is_reference = false;
 	uint32_t instance_binding_count = 0;
 	void *_script_instance_bindings[MAX_SCRIPT_INSTANCE_BINDINGS];
 
@@ -572,7 +571,7 @@ public:
 
 	bool _is_gpl_reversed() const { return false; }
 
-	_FORCE_INLINE_ ObjectID get_instance_id() const { return _instance_id; }
+	_FORCE_INLINE_ ObjectID get_instance_id() const { return ObjectID(static_cast<uint64_t>(_instance_id) & ~(static_cast<uint64_t>(1) << 63)); }
 
 	// this is used for editors
 	void add_change_receptor(Object *p_receptor);
@@ -735,7 +734,9 @@ public:
 
 	void clear_internal_resource_paths();
 
-	_ALWAYS_INLINE_ bool is_reference() const { return type_is_reference; }
+	_ALWAYS_INLINE_ bool is_reference() const { return _instance_id.is_reference(); }
+
+	void stop_being_reference();
 
 	Object();
 	virtual ~Object();
@@ -769,7 +770,7 @@ class ObjectDB {
 	friend void unregister_core_types();
 	static void cleanup();
 
-	static ObjectID add_instance(Object *p_object);
+	static ObjectID add_instance(Object *p_object, bool p_reference);
 	static void remove_instance(Object *p_object);
 
 	friend void register_core_types();

--- a/core/object/object_id.h
+++ b/core/object/object_id.h
@@ -58,6 +58,8 @@ public:
 	_ALWAYS_INLINE_ ObjectID() {}
 	_ALWAYS_INLINE_ explicit ObjectID(const uint64_t p_id) { id = p_id; }
 	_ALWAYS_INLINE_ explicit ObjectID(const int64_t p_id) { id = p_id; }
+
+	void stop_being_reference() { id &= ~(static_cast<uint64_t>(1) << 63); }
 };
 
 #endif // OBJECT_ID_H

--- a/core/object/reference.cpp
+++ b/core/object/reference.cpp
@@ -102,6 +102,12 @@ Reference::Reference() :
 	refcount_init.init();
 }
 
+bool predelete_handler(Reference *p_reference) {
+	p_reference->stop_being_reference();
+	predelete_handler(static_cast<Object *>(p_reference));
+	return true;
+}
+
 Variant WeakRef::get_ref() const {
 	if (ref.is_null()) {
 		return Variant();

--- a/core/object/reference.h
+++ b/core/object/reference.h
@@ -39,6 +39,8 @@ class Reference : public Object {
 	SafeRefCount refcount;
 	SafeRefCount refcount_init;
 
+	friend bool predelete_handler(Reference *);
+
 protected:
 	static void _bind_methods();
 

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2531,6 +2531,7 @@ Variant::Variant(const Object *p_object) {
 	memnew_placement(_data._mem, ObjData);
 
 	if (p_object) {
+		uint64_t ref_bit = 0;
 		if (p_object->is_reference()) {
 			Reference *reference = const_cast<Reference *>(static_cast<const Reference *>(p_object));
 			if (!reference->init_ref()) {
@@ -2538,10 +2539,11 @@ Variant::Variant(const Object *p_object) {
 				_get_obj().id = ObjectID();
 				return;
 			}
+			ref_bit |= ((uint64_t)1) << 63;
 		}
 
 		_get_obj().obj = const_cast<Object *>(p_object);
-		_get_obj().id = p_object->get_instance_id();
+		_get_obj().id = ObjectID((uint64_t)p_object->get_instance_id() | ref_bit);
 	} else {
 		_get_obj().obj = nullptr;
 		_get_obj().id = ObjectID();


### PR DESCRIPTION
This is written as a quick & dirty proof of concept for an approach to fix #31166 I've come up with.

In short:
- Public instance IDs of `Object`s always have the MSB to 0 (the MSB is the one that indicates if it's a `Reference`).
- On predelete of `Reference`, the MSB is set to 0 so `Variant` doesn't check or touch the ref count.

Using `1 << 63` in the code just to avoid the refactoring that a production-quality implementation would need (to use `OBJECTDB_REFERENCE_BIT`).