### PR TITLE
Camera2D: Fix crash calling align when not in tree

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -94,7 +94,7 @@ Vector2 Camera2D::get_zoom() const {
 
 Transform2D Camera2D::get_camera_transform() {
 
-	if (!get_tree())
+	if (!get_tree() || !viewport)
 		return Transform2D();
 
 	ERR_FAIL_COND_V(custom_viewport && !ObjectDB::get_instance(custom_viewport_id), Transform2D());
@@ -498,6 +498,7 @@ void Camera2D::reset_smoothing() {
 
 void Camera2D::align() {
 
+	ERR_FAIL_COND(!is_inside_tree() || !viewport);
 	ERR_FAIL_COND(custom_viewport && !ObjectDB::get_instance(custom_viewport_id));
 
 	Size2 screen_size = viewport->get_visible_rect().size;


### PR DESCRIPTION
Fixes #45976.

The `master` branch is not affected, the code changed there and it won't do a null pointer dereference.