### PR TITLE
RichTextLabel::add_image Fail if passed image has no area

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2253,6 +2253,8 @@ void RichTextLabel::add_image(const Ref<Texture2D> &p_image, const int p_width, 
 	}
 
 	ERR_FAIL_COND(p_image.is_null());
+	ERR_FAIL_COND(p_image->get_width() == 0);
+	ERR_FAIL_COND(p_image->get_height() == 0);
 	ItemImage *item = memnew(ItemImage);
 
 	item->image = p_image;


### PR DESCRIPTION
Fixes #46016 (needs to be cherry-picked for 3.2).
