### PR TITLE
doc: explain TouchScreenButton passby mode

### DIFF
--- a/doc/classes/TouchScreenButton.xml
+++ b/doc/classes/TouchScreenButton.xml
@@ -30,7 +30,8 @@
 			The button's texture for the normal state.
 		</member>
 		<member name="passby_press" type="bool" setter="set_passby_press" getter="is_passby_press_enabled" default="false">
-			If [code]true[/code], pass-by presses are enabled.
+			If [code]true[/code], the [signal pressed] and [signal released] signals are emitted whenever a pressed finger goes in and out of the button, even if the pressure started outside the active area of the button.
+			[b]Note:[/b] this is a "pass-by" (not "bypass") press mode.
 		</member>
 		<member name="pressed" type="Texture2D" setter="set_texture_pressed" getter="get_texture_pressed">
 			The button's texture for the pressed state.


### PR DESCRIPTION
This explains the concept of pass-by presses (which are otherwise undocumented), and clarifies what I believe is a common misreading of the property name.

Moved here following https://github.com/godotengine/godot-docs/pull/4645