### PR TITLE
[macOS] Ignore mouse move event caused by mouse mode switch.

### DIFF
--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -93,6 +93,7 @@ public:
 
 	List<WarpEvent> warp_events;
 	NSTimeInterval last_warp = 0;
+	bool ignore_warp = false;
 
 	Vector<KeyEvent> key_event_buffer;
 	int key_event_pos;

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -871,6 +871,15 @@ static void _mouseDownEvent(DisplayServer::WindowID window_id, NSEvent *event, i
 	NSPoint delta = NSMakePoint([event deltaX], [event deltaY]);
 	NSPoint mpos = [event locationInWindow];
 
+	if (DS_OSX->ignore_warp) {
+		// Discard late events, before warp
+		if (([event timestamp]) < DS_OSX->last_warp) {
+			return;
+		}
+		DS_OSX->ignore_warp = false;
+		return;
+	}
+
 	if (DS_OSX->mouse_mode == DisplayServer::MOUSE_MODE_CONFINED) {
 		// Discard late events
 		if (([event timestamp]) < DS_OSX->last_warp) {
@@ -2098,6 +2107,8 @@ void DisplayServerOSX::mouse_set_mode(MouseMode p_mode) {
 		CGAssociateMouseAndMouseCursorPosition(true);
 	}
 
+	last_warp = [[NSProcessInfo processInfo] systemUptime];
+	ignore_warp = true;
 	warp_events.clear();
 	mouse_mode = p_mode;
 }


### PR DESCRIPTION
Fixes issue caused by #42327 (moving mouse cursor to the center of screen on mouse capture, which was producing unwanted mouse move event with large deltas).

Fixes #45966 and fixes #46030