### PR TITLE
[macOS, 3.2] Ignore mouse move event caused by mouse mode switch.

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -71,6 +71,7 @@ public:
 	};
 	List<WarpEvent> warp_events;
 	NSTimeInterval last_warp = 0;
+	bool ignore_warp = false;
 
 	Vector<KeyEvent> key_event_buffer;
 	int key_event_pos;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -738,6 +738,15 @@ static void _mouseDownEvent(NSEvent *event, int index, int mask, bool pressed) {
 	NSPoint delta = NSMakePoint([event deltaX], [event deltaY]);
 	NSPoint mpos = [event locationInWindow];
 
+	if (OS_OSX::singleton->ignore_warp) {
+		// Discard late events, before warp
+		if (([event timestamp]) < OS_OSX::singleton->last_warp) {
+			return;
+		}
+		OS_OSX::singleton->ignore_warp = false;
+		return;
+	}
+
 	if (OS_OSX::singleton->mouse_mode == OS::MOUSE_MODE_CONFINED) {
 		// Discard late events
 		if (([event timestamp]) < OS_OSX::singleton->last_warp) {
@@ -3306,6 +3315,8 @@ void OS_OSX::set_mouse_mode(MouseMode p_mode) {
 		CGAssociateMouseAndMouseCursorPosition(true);
 	}
 
+	last_warp = [[NSProcessInfo processInfo] systemUptime];
+	ignore_warp = true;
 	warp_events.clear();
 	mouse_mode = p_mode;
 }


### PR DESCRIPTION
Same as #46033 for 3.2
