### PR TITLE
Warn and return when attempting to load invalid MP3s

### DIFF
--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -159,7 +159,8 @@ void AudioStreamMP3::set_data(const Vector<uint8_t> &p_data) {
 	const uint8_t *src_datar = p_data.ptr();
 
 	mp3dec_ex_t mp3d;
-	mp3dec_ex_open_buf(&mp3d, src_datar, src_data_len, MP3D_SEEK_TO_SAMPLE);
+	int err = mp3dec_ex_open_buf(&mp3d, src_datar, src_data_len, MP3D_SEEK_TO_SAMPLE);
+	ERR_FAIL_COND(err != 0);
 
 	channels = mp3d.info.channels;
 	sample_rate = mp3d.info.hz;


### PR DESCRIPTION
Fixes #45995

This also adds a warning for unspecified MP3 loading error codes, even though no action is taken. Looking at the code for mp3dec_ex_open_buf, It's not clear how other error codes should be handled, so I've elected to preserve previous behavior but warn to assist with debugging if developers have issues.

To test, run the following in a node's `_ready` method or something like that:

```
var stream = AudioStreamMP3.new()
stream.data = []
```

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
