### PR TITLE
Return setseek position if one exists in get_playback_position.

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -342,6 +342,9 @@ bool AudioStreamPlayer2D::is_playing() const {
 
 float AudioStreamPlayer2D::get_playback_position() {
 	if (stream_playback.is_valid()) {
+		if (setseek >= 0.0) {
+			return setseek;
+		}
 		return stream_playback->get_playback_position();
 	}
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -714,6 +714,9 @@ bool AudioStreamPlayer3D::is_playing() const {
 
 float AudioStreamPlayer3D::get_playback_position() {
 	if (stream_playback.is_valid()) {
+		if (setseek >= 0.0) {
+			return setseek;
+		}
 		return stream_playback->get_playback_position();
 	}
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -267,6 +267,9 @@ bool AudioStreamPlayer::is_playing() const {
 
 float AudioStreamPlayer::get_playback_position() {
 	if (stream_playback.is_valid()) {
+		if (setseek >= 0.0) {
+			return setseek;
+		}
 		return stream_playback->get_playback_position();
 	}
 


### PR DESCRIPTION
Fixes #41389

This issue seems to be caused by the setseek logic only ever being executed if the audio stream is playing, so I added logic in the three `get_playback_position` functions to check for a pending seek operation and return the position to be seeked to, if one exists, instead of the current playback position.

How to test:
Download a slightly patched version of the original issue's minimal example project
[audiostreamplayer_seek_test.zip](https://github.com/godotengine/godot/files/5979562/audiostreamplayer_seek_test.zip)

Run through the following actions before and after applying these changes:
1. Run the project
2. Pause and unpause, and confirm that the playback position after unpausing matches the expected value (nonzero)
3. Pause and reset, and confirm that the playback position after resetting is zero after applying these changes.
4. Unpause and then reset, and confirm that the playback position after resetting is zero again, after applying these changes.
5. Change the type of the player to an AudioStreamPlayer2D and retest, then to a AudioStreamPlayer3D to retest again.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
