### PR TITLE
[TextServer] Restore character and space extra spacing support.

### DIFF
--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -329,10 +329,10 @@
 	</methods>
 	<members>
 		<member name="extra_spacing_bottom" type="int" setter="set_spacing" getter="get_spacing" default="0">
-			Extra spacing at the bottom in pixels.
+			Extra spacing at the bottom of the line in pixels.
 		</member>
 		<member name="extra_spacing_top" type="int" setter="set_spacing" getter="get_spacing" default="0">
-			Extra character spacing in pixels.
+			Extra spacing at the top of the line in pixels.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -154,6 +154,15 @@
 				Returns list of script support overrides.
 			</description>
 		</method>
+		<method name="get_spacing" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="type" type="int">
+			</argument>
+			<description>
+				Returns the spacing for the given [code]type[/code] (see [enum SpacingType]).
+			</description>
+		</method>
 		<method name="get_supported_chars" qualifiers="const">
 			<return type="String">
 			</return>
@@ -296,6 +305,17 @@
 				Adds override for [method is_script_supported].
 			</description>
 		</method>
+		<method name="set_spacing">
+			<return type="void">
+			</return>
+			<argument index="0" name="type" type="int">
+			</argument>
+			<argument index="1" name="value" type="int">
+			</argument>
+			<description>
+				Sets the spacing for [code]type[/code] (see [enum SpacingType]) to [code]value[/code] in pixels (not relative to the font size).
+			</description>
+		</method>
 		<method name="set_variation">
 			<return type="void">
 			</return>
@@ -318,6 +338,14 @@
 		<member name="distance_field_hint" type="bool" setter="set_distance_field_hint" getter="get_distance_field_hint" default="false">
 			If [code]true[/code], distance field hint is enabled.
 		</member>
+		<member name="extra_spacing_glyph" type="int" setter="set_spacing" getter="get_spacing" default="0">
+			Extra spacing for each glyphs in pixels.
+			This can be a negative number to make the distance between glyphs smaller.
+		</member>
+		<member name="extra_spacing_space" type="int" setter="set_spacing" getter="get_spacing" default="0">
+			Extra spacing for the space character in pixels.
+			This can be a negative number to make the distance between words smaller.
+		</member>
 		<member name="force_autohinter" type="bool" setter="set_force_autohinter" getter="get_force_autohinter" default="false">
 			If [code]true[/code], default autohinter is used for font hinting.
 		</member>
@@ -326,5 +354,11 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="SPACING_GLYPH" value="0" enum="SpacingType">
+			Spacing for each glyph.
+		</constant>
+		<constant name="SPACING_SPACE" value="1" enum="SpacingType">
+			Spacing for the space character.
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -295,6 +295,24 @@
 				Returns list of script support overrides.
 			</description>
 		</method>
+		<method name="font_get_spacing_glyph" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<description>
+				Returns extra spacing for each glyphs in pixels.
+			</description>
+		</method>
+		<method name="font_get_spacing_space" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<description>
+				Sets extra spacing for each glyphs in pixels.
+			</description>
+		</method>
 		<method name="font_get_supported_chars" qualifiers="const">
 			<return type="String">
 			</return>
@@ -488,6 +506,28 @@
 			</argument>
 			<description>
 				Adds override for [method font_is_script_supported].
+			</description>
+		</method>
+		<method name="font_set_spacing_glyph">
+			<return type="void">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<argument index="1" name="value" type="int">
+			</argument>
+			<description>
+				Returns extra spacing for the space character in pixels.
+			</description>
+		</method>
+		<method name="font_set_spacing_space">
+			<return type="void">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<argument index="1" name="value" type="int">
+			</argument>
+			<description>
+				Sets extra spacing for the space character in pixels.
 			</description>
 		</method>
 		<method name="font_set_variation">

--- a/modules/gdnative/include/text/godot_text.h
+++ b/modules/gdnative/include/text/godot_text.h
@@ -79,6 +79,10 @@ typedef struct {
 	float (*font_get_descent)(void *, godot_rid *, int);
 	float (*font_get_underline_position)(void *, godot_rid *, int);
 	float (*font_get_underline_thickness)(void *, godot_rid *, int);
+	int (*font_get_spacing_space)(void *, godot_rid *);
+	void (*font_set_spacing_space)(void *, godot_rid *, int);
+	int (*font_get_spacing_glyph)(void *, godot_rid *);
+	void (*font_set_spacing_glyph)(void *, godot_rid *, int);
 	void (*font_set_antialiased)(void *, godot_rid *, bool);
 	bool (*font_get_antialiased)(void *, godot_rid *);
 	godot_dictionary (*font_get_feature_list)(void *, godot_rid *);

--- a/modules/gdnative/text/text_server_gdnative.cpp
+++ b/modules/gdnative/text/text_server_gdnative.cpp
@@ -138,6 +138,26 @@ float TextServerGDNative::font_get_underline_thickness(RID p_font, int p_size) c
 	return interface->font_get_underline_thickness(data, (godot_rid *)&p_font, p_size);
 }
 
+int TextServerGDNative::font_get_spacing_space(RID p_font) const {
+	ERR_FAIL_COND_V(interface == nullptr, 0);
+	return interface->font_get_spacing_space(data, (godot_rid *)&p_font);
+}
+
+void TextServerGDNative::font_set_spacing_space(RID p_font, int p_value) {
+	ERR_FAIL_COND(interface == nullptr);
+	interface->font_set_spacing_space(data, (godot_rid *)&p_font, p_value);
+}
+
+int TextServerGDNative::font_get_spacing_glyph(RID p_font) const {
+	ERR_FAIL_COND_V(interface == nullptr, 0);
+	return interface->font_get_spacing_glyph(data, (godot_rid *)&p_font);
+}
+
+void TextServerGDNative::font_set_spacing_glyph(RID p_font, int p_value) {
+	ERR_FAIL_COND(interface == nullptr);
+	interface->font_set_spacing_glyph(data, (godot_rid *)&p_font, p_value);
+}
+
 void TextServerGDNative::font_set_antialiased(RID p_font, bool p_antialiased) {
 	ERR_FAIL_COND(interface == nullptr);
 	interface->font_set_antialiased(data, (godot_rid *)&p_font, p_antialiased);

--- a/modules/gdnative/text/text_server_gdnative.h
+++ b/modules/gdnative/text/text_server_gdnative.h
@@ -72,6 +72,12 @@ public:
 	virtual float font_get_underline_position(RID p_font, int p_size) const override;
 	virtual float font_get_underline_thickness(RID p_font, int p_size) const override;
 
+	virtual int font_get_spacing_space(RID p_font) const override;
+	virtual void font_set_spacing_space(RID p_font, int p_value) override;
+
+	virtual int font_get_spacing_glyph(RID p_font) const override;
+	virtual void font_set_spacing_glyph(RID p_font, int p_value) override;
+
 	virtual void font_set_antialiased(RID p_font, bool p_antialiased) override;
 	virtual bool font_get_antialiased(RID p_font) const override;
 

--- a/modules/text_server_adv/font_adv.h
+++ b/modules/text_server_adv/font_adv.h
@@ -39,6 +39,8 @@ struct FontDataAdvanced {
 	Map<String, bool> lang_support_overrides;
 	Map<String, bool> script_support_overrides;
 	bool valid = false;
+	int spacing_space = 0;
+	int spacing_glyph = 0;
 
 	virtual void clear_cache() = 0;
 
@@ -57,6 +59,18 @@ struct FontDataAdvanced {
 
 	virtual float get_underline_position(int p_size) const = 0;
 	virtual float get_underline_thickness(int p_size) const = 0;
+
+	virtual int get_spacing_space() const { return spacing_space; };
+	virtual void set_spacing_space(int p_value) {
+		spacing_space = p_value;
+		clear_cache();
+	};
+
+	virtual int get_spacing_glyph() const { return spacing_glyph; };
+	virtual void set_spacing_glyph(int p_value) {
+		spacing_glyph = p_value;
+		clear_cache();
+	};
 
 	virtual void set_antialiased(bool p_antialiased) = 0;
 	virtual bool get_antialiased() const = 0;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -601,6 +601,34 @@ float TextServerAdvanced::font_get_underline_thickness(RID p_font, int p_size) c
 	return fd->get_underline_thickness(p_size);
 }
 
+int TextServerAdvanced::font_get_spacing_space(RID p_font) const {
+	_THREAD_SAFE_METHOD_
+	const FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND_V(!fd, 0);
+	return fd->get_spacing_space();
+}
+
+void TextServerAdvanced::font_set_spacing_space(RID p_font, int p_value) {
+	_THREAD_SAFE_METHOD_
+	FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->set_spacing_space(p_value);
+}
+
+int TextServerAdvanced::font_get_spacing_glyph(RID p_font) const {
+	_THREAD_SAFE_METHOD_
+	const FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND_V(!fd, 0);
+	return fd->get_spacing_glyph();
+}
+
+void TextServerAdvanced::font_set_spacing_glyph(RID p_font, int p_value) {
+	_THREAD_SAFE_METHOD_
+	FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->set_spacing_glyph(p_value);
+}
+
 void TextServerAdvanced::font_set_antialiased(RID p_font, bool p_antialiased) {
 	_THREAD_SAFE_METHOD_
 	FontDataAdvanced *fd = font_owner.getornull(p_font);
@@ -2048,6 +2076,11 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 				}
 				gl.x_off = Math::round(glyph_pos[i].x_offset / (64.0 / fd->get_font_scale(fs)));
 				gl.y_off = -Math::round(glyph_pos[i].y_offset / (64.0 / fd->get_font_scale(fs)));
+			}
+			if (fd->get_spacing_space() && is_whitespace(p_sd->text[glyph_info[i].cluster])) {
+				gl.advance += fd->get_spacing_space();
+			} else {
+				gl.advance += fd->get_spacing_glyph();
 			}
 
 			if (p_sd->preserve_control) {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -134,6 +134,12 @@ public:
 	virtual float font_get_underline_position(RID p_font, int p_size) const override;
 	virtual float font_get_underline_thickness(RID p_font, int p_size) const override;
 
+	virtual int font_get_spacing_space(RID p_font) const override;
+	virtual void font_set_spacing_space(RID p_font, int p_value) override;
+
+	virtual int font_get_spacing_glyph(RID p_font) const override;
+	virtual void font_set_spacing_glyph(RID p_font, int p_value) override;
+
 	virtual void font_set_antialiased(RID p_font, bool p_antialiased) override;
 	virtual bool font_get_antialiased(RID p_font) const override;
 

--- a/modules/text_server_fb/font_fb.h
+++ b/modules/text_server_fb/font_fb.h
@@ -37,6 +37,8 @@ struct FontDataFallback {
 	Map<String, bool> lang_support_overrides;
 	Map<String, bool> script_support_overrides;
 	bool valid = false;
+	int spacing_space = 0;
+	int spacing_glyph = 0;
 
 	virtual void clear_cache() = 0;
 
@@ -49,6 +51,18 @@ struct FontDataFallback {
 
 	virtual float get_underline_position(int p_size) const = 0;
 	virtual float get_underline_thickness(int p_size) const = 0;
+
+	virtual int get_spacing_space() const { return spacing_space; };
+	virtual void set_spacing_space(int p_value) {
+		spacing_space = p_value;
+		clear_cache();
+	};
+
+	virtual int get_spacing_glyph() const { return spacing_glyph; };
+	virtual void set_spacing_glyph(int p_value) {
+		spacing_glyph = p_value;
+		clear_cache();
+	};
 
 	virtual void set_antialiased(bool p_antialiased) = 0;
 	virtual bool get_antialiased() const = 0;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -179,6 +179,34 @@ float TextServerFallback::font_get_underline_thickness(RID p_font, int p_size) c
 	return fd->get_underline_thickness(p_size);
 }
 
+int TextServerFallback::font_get_spacing_space(RID p_font) const {
+	_THREAD_SAFE_METHOD_
+	const FontDataFallback *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND_V(!fd, 0);
+	return fd->get_spacing_space();
+}
+
+void TextServerFallback::font_set_spacing_space(RID p_font, int p_value) {
+	_THREAD_SAFE_METHOD_
+	FontDataFallback *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->set_spacing_space(p_value);
+}
+
+int TextServerFallback::font_get_spacing_glyph(RID p_font) const {
+	_THREAD_SAFE_METHOD_
+	const FontDataFallback *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND_V(!fd, 0);
+	return fd->get_spacing_glyph();
+}
+
+void TextServerFallback::font_set_spacing_glyph(RID p_font, int p_value) {
+	_THREAD_SAFE_METHOD_
+	FontDataFallback *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->set_spacing_glyph(p_value);
+}
+
 void TextServerFallback::font_set_antialiased(RID p_font, bool p_antialiased) {
 	_THREAD_SAFE_METHOD_
 	FontDataFallback *fd = font_owner.getornull(p_font);
@@ -1183,6 +1211,11 @@ bool TextServerFallback::shaped_text_shape(RID p_shaped) {
 							sd->ascent = MAX(sd->ascent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
 							sd->descent = MAX(sd->descent, Math::round(fd->get_advance(gl.index, gl.font_size).x * 0.5));
 						}
+					}
+					if (fd->get_spacing_space() && is_whitespace(sd->text[j])) {
+						gl.advance += fd->get_spacing_space();
+					} else {
+						gl.advance += fd->get_spacing_glyph();
 					}
 					sd->upos = MAX(sd->upos, fd->get_underline_position(gl.font_size));
 					sd->uthk = MAX(sd->uthk, fd->get_underline_thickness(gl.font_size));

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -89,6 +89,12 @@ public:
 	virtual float font_get_underline_position(RID p_font, int p_size) const override;
 	virtual float font_get_underline_thickness(RID p_font, int p_size) const override;
 
+	virtual int font_get_spacing_space(RID p_font) const override;
+	virtual void font_set_spacing_space(RID p_font, int p_value) override;
+
+	virtual int font_get_spacing_glyph(RID p_font) const override;
+	virtual void font_set_spacing_glyph(RID p_font, int p_value) override;
+
 	virtual void font_set_antialiased(RID p_font, bool p_antialiased) override;
 	virtual bool font_get_antialiased(RID p_font) const override;
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -50,6 +50,9 @@ void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_underline_position", "size"), &FontData::get_underline_position);
 	ClassDB::bind_method(D_METHOD("get_underline_thickness", "size"), &FontData::get_underline_thickness);
 
+	ClassDB::bind_method(D_METHOD("get_spacing", "type"), &FontData::get_spacing);
+	ClassDB::bind_method(D_METHOD("set_spacing", "type", "value"), &FontData::set_spacing);
+
 	ClassDB::bind_method(D_METHOD("set_antialiased", "antialiased"), &FontData::set_antialiased);
 	ClassDB::bind_method(D_METHOD("get_antialiased"), &FontData::get_antialiased);
 
@@ -100,6 +103,13 @@ void FontData::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distance_field_hint"), "set_distance_field_hint", "get_distance_field_hint");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), "set_hinting", "get_hinting");
+
+	ADD_GROUP("Extra Spacing", "extra_spacing");
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "extra_spacing_glyph"), "set_spacing", "get_spacing", SPACING_GLYPH);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "extra_spacing_space"), "set_spacing", "get_spacing", SPACING_SPACE);
+
+	BIND_ENUM_CONSTANT(SPACING_GLYPH);
+	BIND_ENUM_CONSTANT(SPACING_SPACE);
 }
 
 bool FontData::_set(const StringName &p_name, const Variant &p_value) {
@@ -287,6 +297,27 @@ double FontData::get_variation(const String &p_name) const {
 		return 0;
 	}
 	return TS->font_get_variation(rid, p_name);
+}
+
+int FontData::get_spacing(int p_type) const {
+	if (rid == RID()) {
+		return 0;
+	}
+	if (p_type == SPACING_GLYPH) {
+		return TS->font_get_spacing_glyph(rid);
+	} else {
+		return TS->font_get_spacing_space(rid);
+	}
+}
+
+void FontData::set_spacing(int p_type, int p_value) {
+	ERR_FAIL_COND(rid == RID());
+	if (p_type == SPACING_GLYPH) {
+		TS->font_set_spacing_glyph(rid, p_value);
+	} else {
+		TS->font_set_spacing_space(rid, p_value);
+	}
+	emit_changed();
 }
 
 void FontData::set_antialiased(bool p_antialiased) {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -42,6 +42,13 @@
 class FontData : public Resource {
 	GDCLASS(FontData, Resource);
 
+public:
+	enum SpacingType {
+		SPACING_GLYPH,
+		SPACING_SPACE,
+	};
+
+private:
 	RID rid;
 	int base_size = 16;
 	String path;
@@ -77,6 +84,9 @@ public:
 
 	float get_underline_position(int p_size) const;
 	float get_underline_thickness(int p_size) const;
+
+	int get_spacing(int p_type) const;
+	void set_spacing(int p_type, int p_value);
 
 	void set_antialiased(bool p_antialiased);
 	bool get_antialiased() const;
@@ -134,7 +144,7 @@ class Font : public Resource {
 public:
 	enum SpacingType {
 		SPACING_TOP,
-		SPACING_BOTTOM
+		SPACING_BOTTOM,
 	};
 
 private:
@@ -199,6 +209,7 @@ public:
 	~Font();
 };
 
+VARIANT_ENUM_CAST(FontData::SpacingType);
 VARIANT_ENUM_CAST(Font::SpacingType);
 
 /*************************************************************************/

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -227,6 +227,12 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("font_get_underline_position", "font", "size"), &TextServer::font_get_underline_position);
 	ClassDB::bind_method(D_METHOD("font_get_underline_thickness", "font", "size"), &TextServer::font_get_underline_thickness);
 
+	ClassDB::bind_method(D_METHOD("font_get_spacing_space", "font"), &TextServer::font_get_spacing_space);
+	ClassDB::bind_method(D_METHOD("font_set_spacing_space", "font", "value"), &TextServer::font_set_spacing_space);
+
+	ClassDB::bind_method(D_METHOD("font_get_spacing_glyph", "font"), &TextServer::font_get_spacing_glyph);
+	ClassDB::bind_method(D_METHOD("font_set_spacing_glyph", "font", "value"), &TextServer::font_set_spacing_glyph);
+
 	ClassDB::bind_method(D_METHOD("font_set_antialiased", "font", "antialiased"), &TextServer::font_set_antialiased);
 	ClassDB::bind_method(D_METHOD("font_get_antialiased", "font"), &TextServer::font_get_antialiased);
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -241,6 +241,12 @@ public:
 	virtual float font_get_ascent(RID p_font, int p_size) const = 0;
 	virtual float font_get_descent(RID p_font, int p_size) const = 0;
 
+	virtual int font_get_spacing_space(RID p_font) const = 0;
+	virtual void font_set_spacing_space(RID p_font, int p_value) = 0;
+
+	virtual int font_get_spacing_glyph(RID p_font) const = 0;
+	virtual void font_set_spacing_glyph(RID p_font, int p_value) = 0;
+
 	virtual float font_get_underline_position(RID p_font, int p_size) const = 0;
 	virtual float font_get_underline_thickness(RID p_font, int p_size) const = 0;
 


### PR DESCRIPTION
Reimplement character / glyph and space extra spacing support (in the `FontData` for both bitmap and dynamic fonts).

<img width="651" alt="Screenshot 2021-02-15 at 10 42 55" src="https://user-images.githubusercontent.com/7645683/107924527-bef01e00-6f7b-11eb-99b9-70f373433d6b.png">
<img width="651" alt="Screenshot 2021-02-15 at 10 43 19" src="https://user-images.githubusercontent.com/7645683/107924536-c44d6880-6f7b-11eb-8de3-cb2b440a035d.png">
<img width="651" alt="Screenshot 2021-02-15 at 10 43 43" src="https://user-images.githubusercontent.com/7645683/107924544-c7e0ef80-6f7b-11eb-97cb-ed38d84735f5.png">

*On screenshots spacing is set for the Latin FontData only*

