### PR TITLE
[TextServer] Restores bitmap font dynamic construction functions.

### DIFF
--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -11,6 +11,45 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="bitmap_add_char">
+			<return type="void">
+			</return>
+			<argument index="0" name="char" type="int">
+			</argument>
+			<argument index="1" name="texture_idx" type="int">
+			</argument>
+			<argument index="2" name="rect" type="Rect2">
+			</argument>
+			<argument index="3" name="align" type="Vector2">
+			</argument>
+			<argument index="4" name="advance" type="float">
+			</argument>
+			<description>
+				Adds a character to the font, where [code]character[/code] is the Unicode value, [code]texture[/code] is the texture index, [code]rect[/code] is the region in the texture (in pixels!), [code]align[/code] is the (optional) alignment for the character and [code]advance[/code] is the (optional) advance.
+			</description>
+		</method>
+		<method name="bitmap_add_kerning_pair">
+			<return type="void">
+			</return>
+			<argument index="0" name="A" type="int">
+			</argument>
+			<argument index="1" name="B" type="int">
+			</argument>
+			<argument index="2" name="kerning" type="int">
+			</argument>
+			<description>
+				Adds a kerning pair to the bitmap font as a difference. Kerning pairs are special cases where a typeface advance is determined by the next character.
+			</description>
+		</method>
+		<method name="bitmap_add_texture">
+			<return type="void">
+			</return>
+			<argument index="0" name="texture" type="Texture">
+			</argument>
+			<description>
+				Adds a texture to the bitmap font.
+			</description>
+		</method>
 		<method name="draw_glyph" qualifiers="const">
 			<return type="Vector2">
 			</return>
@@ -254,6 +293,19 @@
 			<description>
 				Creates new font from the file.
 				Note: For non-scalable fonts [code]base_size[/code] is ignored, use [method get_base_size] to check actual font size.
+			</description>
+		</method>
+		<method name="new_bitmap">
+			<return type="void">
+			</return>
+			<argument index="0" name="height" type="float">
+			</argument>
+			<argument index="1" name="ascent" type="float">
+			</argument>
+			<argument index="2" name="base_size" type="int">
+			</argument>
+			<description>
+				Creates new, empty bitmap font.
 			</description>
 		</method>
 		<method name="remove_language_support_override">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -9,6 +9,19 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="create_font_bitmap">
+			<return type="RID">
+			</return>
+			<argument index="0" name="height" type="float">
+			</argument>
+			<argument index="1" name="ascent" type="float">
+			</argument>
+			<argument index="2" name="base_size" type="int">
+			</argument>
+			<description>
+				Creates new, empty bitmap font. To free the resulting font, use [method free_rid] method.
+			</description>
+		</method>
 		<method name="create_font_memory">
 			<return type="RID">
 			</return>
@@ -76,6 +89,51 @@
 			</argument>
 			<description>
 				Draws box displaying character hexadecimal code. Used for replacing missing characters.
+			</description>
+		</method>
+		<method name="font_bitmap_add_char">
+			<return type="void">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<argument index="1" name="char" type="int">
+			</argument>
+			<argument index="2" name="texture_idx" type="int">
+			</argument>
+			<argument index="3" name="rect" type="Rect2">
+			</argument>
+			<argument index="4" name="align" type="Vector2">
+			</argument>
+			<argument index="5" name="advance" type="float">
+			</argument>
+			<description>
+				Adds a character to the font, where [code]character[/code] is the Unicode value, [code]texture[/code] is the texture index, [code]rect[/code] is the region in the texture (in pixels!), [code]align[/code] is the (optional) alignment for the character and [code]advance[/code] is the (optional) advance.
+			</description>
+		</method>
+		<method name="font_bitmap_add_kerning_pair">
+			<return type="void">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<argument index="1" name="A" type="int">
+			</argument>
+			<argument index="2" name="B" type="int">
+			</argument>
+			<argument index="3" name="kerning" type="int">
+			</argument>
+			<description>
+				Adds a kerning pair to the bitmap font as a difference. Kerning pairs are special cases where a typeface advance is determined by the next character.
+			</description>
+		</method>
+		<method name="font_bitmap_add_texture">
+			<return type="void">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<argument index="1" name="texture" type="Texture">
+			</argument>
+			<description>
+				Adds a texture to the bitmap font.
 			</description>
 		</method>
 		<method name="font_draw_glyph" qualifiers="const">

--- a/modules/gdnative/include/text/godot_text.h
+++ b/modules/gdnative/include/text/godot_text.h
@@ -74,6 +74,10 @@ typedef struct {
 	godot_rid (*create_font_system)(void *, const godot_string *, int);
 	godot_rid (*create_font_resource)(void *, const godot_string *, int);
 	godot_rid (*create_font_memory)(void *, const uint8_t *, size_t, godot_string *, int);
+	godot_rid (*create_font_bitmap)(void *, float, float, int);
+	void (*font_bitmap_add_texture)(void *, godot_rid *, const godot_object *);
+	void (*font_bitmap_add_char)(void *, godot_rid *, char32_t, int, const godot_rect2 *, const godot_vector2 *, float);
+	void (*font_bitmap_add_kerning_pair)(void *, godot_rid *, char32_t, char32_t, int);
 	float (*font_get_height)(void *, godot_rid *, int);
 	float (*font_get_ascent)(void *, godot_rid *, int);
 	float (*font_get_descent)(void *, godot_rid *, int);

--- a/modules/gdnative/text/text_server_gdnative.cpp
+++ b/modules/gdnative/text/text_server_gdnative.cpp
@@ -113,6 +113,28 @@ RID TextServerGDNative::create_font_memory(const uint8_t *p_data, size_t p_size,
 	return rid;
 }
 
+RID TextServerGDNative::create_font_bitmap(float p_height, float p_ascent, int p_base_size) {
+	ERR_FAIL_COND_V(interface == nullptr, RID());
+	godot_rid result = interface->create_font_bitmap(data, p_height, p_ascent, p_base_size);
+	RID rid = *(RID *)&result;
+	return rid;
+}
+
+void TextServerGDNative::font_bitmap_add_texture(RID p_font, const Ref<Texture> &p_texture) {
+	ERR_FAIL_COND(interface == nullptr);
+	interface->font_bitmap_add_texture(data, (godot_rid *)&p_font, (const godot_object *)p_texture.ptr());
+}
+
+void TextServerGDNative::font_bitmap_add_char(RID p_font, char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) {
+	ERR_FAIL_COND(interface == nullptr);
+	interface->font_bitmap_add_char(data, (godot_rid *)&p_font, p_char, p_texture_idx, (const godot_rect2 *)&p_rect, (const godot_vector2 *)&p_align, p_advance);
+}
+
+void TextServerGDNative::font_bitmap_add_kerning_pair(RID p_font, char32_t p_A, char32_t p_B, int p_kerning) {
+	ERR_FAIL_COND(interface == nullptr);
+	interface->font_bitmap_add_kerning_pair(data, (godot_rid *)&p_font, p_A, p_B, p_kerning);
+}
+
 float TextServerGDNative::font_get_height(RID p_font, int p_size) const {
 	ERR_FAIL_COND_V(interface == nullptr, 0.f);
 	return interface->font_get_height(data, (godot_rid *)&p_font, p_size);

--- a/modules/gdnative/text/text_server_gdnative.h
+++ b/modules/gdnative/text/text_server_gdnative.h
@@ -64,6 +64,11 @@ public:
 	virtual RID create_font_system(const String &p_name, int p_base_size = 16) override;
 	virtual RID create_font_resource(const String &p_filename, int p_base_size = 16) override;
 	virtual RID create_font_memory(const uint8_t *p_data, size_t p_size, const String &p_type, int p_base_size = 16) override;
+	virtual RID create_font_bitmap(float p_height, float p_ascent, int p_base_size = 16) override;
+
+	virtual void font_bitmap_add_texture(RID p_font, const Ref<Texture> &p_texture) override;
+	virtual void font_bitmap_add_char(RID p_font, char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) override;
+	virtual void font_bitmap_add_kerning_pair(RID p_font, char32_t p_A, char32_t p_B, int p_kerning) override;
 
 	virtual float font_get_height(RID p_font, int p_size) const override;
 	virtual float font_get_ascent(RID p_font, int p_size) const override;

--- a/modules/text_server_adv/bitmap_font_adv.cpp
+++ b/modules/text_server_adv/bitmap_font_adv.cpp
@@ -367,61 +367,63 @@ Error BitmapFontDataAdvanced::load_from_file(const String &p_filename, int p_bas
 	return OK;
 }
 
-Error BitmapFontDataAdvanced::load_from_memory(const uint8_t *p_data, size_t p_size, int p_base_size) {
-	_THREAD_SAFE_METHOD_
-	ERR_FAIL_COND_V(p_data == nullptr, ERR_CANT_CREATE);
-	ERR_FAIL_COND_V(p_size != sizeof(TextServer::BitmapFontData), ERR_CANT_CREATE);
-
-	const TextServer::BitmapFontData *data = (const TextServer::BitmapFontData *)p_data;
-
-	if (RenderingServer::get_singleton() != nullptr) {
-		Ref<Image> image = memnew(Image(data->img));
-		Ref<ImageTexture> tex = memnew(ImageTexture);
-		tex->create_from_image(image);
-
-		textures.push_back(tex);
-	}
-
-	for (int i = 0; i < data->charcount; i++) {
-		const int *c = &data->char_rects[i * 8];
-
-		Character chr;
-		chr.rect.position.x = c[1];
-		chr.rect.position.y = c[2];
-		chr.rect.size.x = c[3];
-		chr.rect.size.y = c[4];
-		if (c[7] < 0) {
-			chr.advance.x = c[3];
-		} else {
-			chr.advance.x = c[7];
-		}
-		chr.align = Vector2(c[6], c[5]);
-		char_map[c[0]] = chr;
-	}
-
-	for (int i = 0; i < data->kerning_count; i++) {
-		KerningPairKey kpk;
-		kpk.A = data->kernings[i * 3 + 0];
-		kpk.B = data->kernings[i * 3 + 1];
-
-		if (data->kernings[i * 3 + 2] == 0 && kerning_map.has(kpk)) {
-			kerning_map.erase(kpk);
-		} else {
-			kerning_map[kpk] = data->kernings[i * 3 + 2];
-		}
-	}
-
-	height = data->height;
-	ascent = data->ascent;
+Error BitmapFontDataAdvanced::bitmap_new(float p_height, float p_ascent, int p_base_size) {
+	height = p_height;
+	ascent = p_ascent;
 
 	base_size = p_base_size;
 	if (base_size == 0) {
 		base_size = height;
 	}
 
+	char_map.clear();
+	textures.clear();
+	kerning_map.clear();
+
+	for (Map<float, hb_font_t *>::Element *E = cache.front(); E; E = E->next()) {
+		hb_font_destroy(E->get());
+	}
+	cache.clear();
+
 	valid = true;
 
 	return OK;
+}
+
+void BitmapFontDataAdvanced::bitmap_add_texture(const Ref<Texture> &p_texture) {
+	ERR_FAIL_COND(!valid);
+	ERR_FAIL_COND_MSG(p_texture.is_null(), "It's not a reference to a valid Texture object.");
+
+	textures.push_back(p_texture);
+}
+
+void BitmapFontDataAdvanced::bitmap_add_char(char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) {
+	ERR_FAIL_COND(!valid);
+
+	Character chr;
+	chr.rect = p_rect;
+	chr.texture_idx = p_texture_idx;
+	if (p_advance < 0) {
+		chr.advance.x = chr.rect.size.x;
+	} else {
+		chr.advance.x = p_advance;
+	}
+	chr.align = p_align;
+	char_map[p_char] = chr;
+}
+
+void BitmapFontDataAdvanced::bitmap_add_kerning_pair(char32_t p_A, char32_t p_B, int p_kerning) {
+	ERR_FAIL_COND(!valid);
+
+	KerningPairKey kpk;
+	kpk.A = p_A;
+	kpk.B = p_B;
+
+	if (p_kerning == 0 && kerning_map.has(kpk)) {
+		kerning_map.erase(kpk);
+	} else {
+		kerning_map[kpk] = p_kerning;
+	}
 }
 
 float BitmapFontDataAdvanced::get_height(int p_size) const {

--- a/modules/text_server_adv/bitmap_font_adv.h
+++ b/modules/text_server_adv/bitmap_font_adv.h
@@ -74,7 +74,11 @@ public:
 	virtual void clear_cache() override{};
 
 	virtual Error load_from_file(const String &p_filename, int p_base_size) override;
-	virtual Error load_from_memory(const uint8_t *p_data, size_t p_size, int p_base_size) override;
+	virtual Error bitmap_new(float p_height, float p_ascent, int p_base_size) override;
+
+	virtual void bitmap_add_texture(const Ref<Texture> &p_texture) override;
+	virtual void bitmap_add_char(char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) override;
+	virtual void bitmap_add_kerning_pair(char32_t p_A, char32_t p_B, int p_kerning) override;
 
 	virtual float get_height(int p_size) const override;
 	virtual float get_ascent(int p_size) const override;

--- a/modules/text_server_adv/font_adv.h
+++ b/modules/text_server_adv/font_adv.h
@@ -42,8 +42,13 @@ struct FontDataAdvanced {
 
 	virtual void clear_cache() = 0;
 
-	virtual Error load_from_file(const String &p_filename, int p_base_size) = 0;
-	virtual Error load_from_memory(const uint8_t *p_data, size_t p_size, int p_base_size) = 0;
+	virtual Error load_from_file(const String &p_filename, int p_base_size) { return ERR_CANT_CREATE; };
+	virtual Error load_from_memory(const uint8_t *p_data, size_t p_size, int p_base_size) { return ERR_CANT_CREATE; };
+	virtual Error bitmap_new(float p_height, float p_ascent, int p_base_size) { return ERR_CANT_CREATE; };
+
+	virtual void bitmap_add_texture(const Ref<Texture> &p_texture) { ERR_FAIL_MSG("Not supported."); };
+	virtual void bitmap_add_char(char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) { ERR_FAIL_MSG("Not supported."); };
+	virtual void bitmap_add_kerning_pair(char32_t p_A, char32_t p_B, int p_kerning) { ERR_FAIL_MSG("Not supported."); };
 
 	virtual float get_height(int p_size) const = 0;
 	virtual float get_ascent(int p_size) const = 0;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -566,6 +566,39 @@ RID TextServerAdvanced::create_font_memory(const uint8_t *p_data, size_t p_size,
 	return font_owner.make_rid(fd);
 }
 
+RID TextServerAdvanced::create_font_bitmap(float p_height, float p_ascent, int p_base_size) {
+	_THREAD_SAFE_METHOD_
+	FontDataAdvanced *fd = memnew(BitmapFontDataAdvanced);
+	Error err = fd->bitmap_new(p_height, p_ascent, p_base_size);
+	if (err != OK) {
+		memdelete(fd);
+		return RID();
+	}
+
+	return font_owner.make_rid(fd);
+}
+
+void TextServerAdvanced::font_bitmap_add_texture(RID p_font, const Ref<Texture> &p_texture) {
+	_THREAD_SAFE_METHOD_
+	FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->bitmap_add_texture(p_texture);
+}
+
+void TextServerAdvanced::font_bitmap_add_char(RID p_font, char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) {
+	_THREAD_SAFE_METHOD_
+	FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->bitmap_add_char(p_char, p_texture_idx, p_rect, p_align, p_advance);
+}
+
+void TextServerAdvanced::font_bitmap_add_kerning_pair(RID p_font, char32_t p_A, char32_t p_B, int p_kerning) {
+	_THREAD_SAFE_METHOD_
+	FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->bitmap_add_kerning_pair(p_A, p_B, p_kerning);
+}
+
 float TextServerAdvanced::font_get_height(RID p_font, int p_size) const {
 	_THREAD_SAFE_METHOD_
 	const FontDataAdvanced *fd = font_owner.getornull(p_font);

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -126,6 +126,11 @@ public:
 	virtual RID create_font_system(const String &p_name, int p_base_size = 16) override;
 	virtual RID create_font_resource(const String &p_filename, int p_base_size = 16) override;
 	virtual RID create_font_memory(const uint8_t *p_data, size_t p_size, const String &p_type, int p_base_size = 16) override;
+	virtual RID create_font_bitmap(float p_height, float p_ascent, int p_base_size = 16) override;
+
+	virtual void font_bitmap_add_texture(RID p_font, const Ref<Texture> &p_texture) override;
+	virtual void font_bitmap_add_char(RID p_font, char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) override;
+	virtual void font_bitmap_add_kerning_pair(RID p_font, char32_t p_A, char32_t p_B, int p_kerning) override;
 
 	virtual float font_get_height(RID p_font, int p_size) const override;
 	virtual float font_get_ascent(RID p_font, int p_size) const override;

--- a/modules/text_server_fb/bitmap_font_fb.cpp
+++ b/modules/text_server_fb/bitmap_font_fb.cpp
@@ -175,61 +175,58 @@ Error BitmapFontDataFallback::load_from_file(const String &p_filename, int p_bas
 	return OK;
 }
 
-Error BitmapFontDataFallback::load_from_memory(const uint8_t *p_data, size_t p_size, int p_base_size) {
-	_THREAD_SAFE_METHOD_
-	ERR_FAIL_COND_V(p_data == nullptr, ERR_CANT_CREATE);
-	ERR_FAIL_COND_V(p_size != sizeof(TextServer::BitmapFontData), ERR_CANT_CREATE);
-
-	const TextServer::BitmapFontData *data = (const TextServer::BitmapFontData *)p_data;
-
-	if (RenderingServer::get_singleton() != nullptr) {
-		Ref<Image> image = memnew(Image(data->img));
-		Ref<ImageTexture> tex = memnew(ImageTexture);
-		tex->create_from_image(image);
-
-		textures.push_back(tex);
-	}
-
-	for (int i = 0; i < data->charcount; i++) {
-		const int *c = &data->char_rects[i * 8];
-
-		Character chr;
-		chr.rect.position.x = c[1];
-		chr.rect.position.y = c[2];
-		chr.rect.size.x = c[3];
-		chr.rect.size.y = c[4];
-		if (c[7] < 0) {
-			chr.advance.x = c[3];
-		} else {
-			chr.advance.x = c[7];
-		}
-		chr.align = Vector2(c[6], c[5]);
-		char_map[c[0]] = chr;
-	}
-
-	for (int i = 0; i < data->kerning_count; i++) {
-		KerningPairKey kpk;
-		kpk.A = data->kernings[i * 3 + 0];
-		kpk.B = data->kernings[i * 3 + 1];
-
-		if (data->kernings[i * 3 + 2] == 0 && kerning_map.has(kpk)) {
-			kerning_map.erase(kpk);
-		} else {
-			kerning_map[kpk] = data->kernings[i * 3 + 2];
-		}
-	}
-
-	height = data->height;
-	ascent = data->ascent;
+Error BitmapFontDataFallback::bitmap_new(float p_height, float p_ascent, int p_base_size) {
+	height = p_height;
+	ascent = p_ascent;
 
 	base_size = p_base_size;
 	if (base_size == 0) {
 		base_size = height;
 	}
 
+	char_map.clear();
+	textures.clear();
+	kerning_map.clear();
+
 	valid = true;
 
 	return OK;
+}
+
+void BitmapFontDataFallback::bitmap_add_texture(const Ref<Texture> &p_texture) {
+	ERR_FAIL_COND(!valid);
+	ERR_FAIL_COND_MSG(p_texture.is_null(), "It's not a reference to a valid Texture object.");
+
+	textures.push_back(p_texture);
+}
+
+void BitmapFontDataFallback::bitmap_add_char(char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) {
+	ERR_FAIL_COND(!valid);
+
+	Character chr;
+	chr.rect = p_rect;
+	chr.texture_idx = p_texture_idx;
+	if (p_advance < 0) {
+		chr.advance.x = chr.rect.size.x;
+	} else {
+		chr.advance.x = p_advance;
+	}
+	chr.align = p_align;
+	char_map[p_char] = chr;
+}
+
+void BitmapFontDataFallback::bitmap_add_kerning_pair(char32_t p_A, char32_t p_B, int p_kerning) {
+	ERR_FAIL_COND(!valid);
+
+	KerningPairKey kpk;
+	kpk.A = p_A;
+	kpk.B = p_B;
+
+	if (p_kerning == 0 && kerning_map.has(kpk)) {
+		kerning_map.erase(kpk);
+	} else {
+		kerning_map[kpk] = p_kerning;
+	}
 }
 
 float BitmapFontDataFallback::get_height(int p_size) const {

--- a/modules/text_server_fb/bitmap_font_fb.h
+++ b/modules/text_server_fb/bitmap_font_fb.h
@@ -70,7 +70,11 @@ public:
 	virtual void clear_cache() override{};
 
 	virtual Error load_from_file(const String &p_filename, int p_base_size) override;
-	virtual Error load_from_memory(const uint8_t *p_data, size_t p_size, int p_base_size) override;
+	virtual Error bitmap_new(float p_height, float p_ascent, int p_base_size) override;
+
+	virtual void bitmap_add_texture(const Ref<Texture> &p_texture) override;
+	virtual void bitmap_add_char(char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) override;
+	virtual void bitmap_add_kerning_pair(char32_t p_A, char32_t p_B, int p_kerning) override;
 
 	virtual float get_height(int p_size) const override;
 	virtual float get_ascent(int p_size) const override;

--- a/modules/text_server_fb/font_fb.h
+++ b/modules/text_server_fb/font_fb.h
@@ -40,8 +40,13 @@ struct FontDataFallback {
 
 	virtual void clear_cache() = 0;
 
-	virtual Error load_from_file(const String &p_filename, int p_base_size) = 0;
-	virtual Error load_from_memory(const uint8_t *p_data, size_t p_size, int p_base_size) = 0;
+	virtual Error load_from_file(const String &p_filename, int p_base_size) { return ERR_CANT_CREATE; };
+	virtual Error load_from_memory(const uint8_t *p_data, size_t p_size, int p_base_size) { return ERR_CANT_CREATE; };
+	virtual Error bitmap_new(float p_height, float p_ascent, int p_base_size) { return ERR_CANT_CREATE; };
+
+	virtual void bitmap_add_texture(const Ref<Texture> &p_texture) { ERR_FAIL_MSG("Not supported."); };
+	virtual void bitmap_add_char(char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) { ERR_FAIL_MSG("Not supported."); };
+	virtual void bitmap_add_kerning_pair(char32_t p_A, char32_t p_B, int p_kerning) { ERR_FAIL_MSG("Not supported."); };
 
 	virtual float get_height(int p_size) const = 0;
 	virtual float get_ascent(int p_size) const = 0;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -144,6 +144,39 @@ RID TextServerFallback::create_font_memory(const uint8_t *p_data, size_t p_size,
 	return font_owner.make_rid(fd);
 }
 
+RID TextServerFallback::create_font_bitmap(float p_height, float p_ascent, int p_base_size) {
+	_THREAD_SAFE_METHOD_
+	FontDataFallback *fd = memnew(BitmapFontDataFallback);
+	Error err = fd->bitmap_new(p_height, p_ascent, p_base_size);
+	if (err != OK) {
+		memdelete(fd);
+		return RID();
+	}
+
+	return font_owner.make_rid(fd);
+}
+
+void TextServerFallback::font_bitmap_add_texture(RID p_font, const Ref<Texture> &p_texture) {
+	_THREAD_SAFE_METHOD_
+	FontDataFallback *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->bitmap_add_texture(p_texture);
+}
+
+void TextServerFallback::font_bitmap_add_char(RID p_font, char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) {
+	_THREAD_SAFE_METHOD_
+	FontDataFallback *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->bitmap_add_char(p_char, p_texture_idx, p_rect, p_align, p_advance);
+}
+
+void TextServerFallback::font_bitmap_add_kerning_pair(RID p_font, char32_t p_A, char32_t p_B, int p_kerning) {
+	_THREAD_SAFE_METHOD_
+	FontDataFallback *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->bitmap_add_kerning_pair(p_A, p_B, p_kerning);
+}
+
 float TextServerFallback::font_get_height(RID p_font, int p_size) const {
 	_THREAD_SAFE_METHOD_
 	const FontDataFallback *fd = font_owner.getornull(p_font);

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -81,6 +81,11 @@ public:
 	virtual RID create_font_system(const String &p_name, int p_base_size = 16) override;
 	virtual RID create_font_resource(const String &p_filename, int p_base_size = 16) override;
 	virtual RID create_font_memory(const uint8_t *p_data, size_t p_size, const String &p_type, int p_base_size = 16) override;
+	virtual RID create_font_bitmap(float p_height, float p_ascent, int p_base_size = 16) override;
+
+	virtual void font_bitmap_add_texture(RID p_font, const Ref<Texture> &p_texture) override;
+	virtual void font_bitmap_add_char(RID p_font, char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) override;
+	virtual void font_bitmap_add_kerning_pair(RID p_font, char32_t p_A, char32_t p_B, int p_kerning) override;
 
 	virtual float font_get_height(RID p_font, int p_size) const override;
 	virtual float font_get_ascent(RID p_font, int p_size) const override;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -128,6 +128,38 @@ static Ref<Texture2D> flip_icon(Ref<Texture2D> p_texture, bool p_flip_y = false,
 	return texture;
 }
 
+static Ref<FontData> make_font(int p_height, int p_ascent, int p_charcount, const int *p_char_rects, int p_kerning_count, const int *p_kernings, int p_w, int p_h, const unsigned char *p_img) {
+	Ref<FontData> font(memnew(FontData));
+	font->new_bitmap(p_height, p_ascent, p_height);
+
+	Ref<Image> image = memnew(Image(p_img));
+	Ref<ImageTexture> tex = memnew(ImageTexture);
+	tex->create_from_image(image);
+
+	font->bitmap_add_texture(tex);
+
+	for (int i = 0; i < p_charcount; i++) {
+		const int *c = &p_char_rects[i * 8];
+
+		int chr = c[0];
+		Rect2 frect;
+		frect.position.x = c[1];
+		frect.position.y = c[2];
+		frect.size.x = c[3];
+		frect.size.y = c[4];
+		Point2 align(c[6], c[5]);
+		int advance = c[7];
+
+		font->bitmap_add_char(chr, 0, frect, align, advance);
+	}
+
+	for (int i = 0; i < p_kerning_count; i++) {
+		font->bitmap_add_kerning_pair(p_kernings[i * 3 + 0], p_kernings[i * 3 + 1], p_kernings[i * 3 + 2]);
+	}
+
+	return font;
+}
+
 static Ref<StyleBox> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {
 	Ref<StyleBox> style(memnew(StyleBoxEmpty));
 
@@ -987,41 +1019,11 @@ void make_default_theme(bool p_hidpi, Ref<Font> p_font) {
 	if (p_font.is_valid()) {
 		default_font = p_font;
 	} else if (p_hidpi) {
-		TextServer::BitmapFontData data;
-		data.height = _hidpi_font_height;
-		data.ascent = _hidpi_font_ascent;
-		data.charcount = _hidpi_font_charcount;
-		data.char_rects = &_hidpi_font_charrects[0][0];
-		data.kerning_count = _hidpi_font_kerning_pair_count;
-		data.kernings = &_hidpi_font_kerning_pairs[0][0];
-		data.w = _hidpi_font_img_width;
-		data.h = _hidpi_font_img_height;
-		data.img = _hidpi_font_img_data;
-
-		Ref<FontData> font_data;
-		font_data.instance();
-		font_data->load_memory((const uint8_t *)&data, sizeof(data), "fnt");
-		default_font_size = font_data->get_base_size();
-
+		Ref<FontData> font_data = make_font(_hidpi_font_height, _hidpi_font_ascent, _hidpi_font_charcount, &_hidpi_font_charrects[0][0], _hidpi_font_kerning_pair_count, &_hidpi_font_kerning_pairs[0][0], _hidpi_font_img_width, _hidpi_font_img_height, _hidpi_font_img_data);
 		default_font.instance();
 		default_font->add_data(font_data);
 	} else {
-		TextServer::BitmapFontData data;
-		data.height = _lodpi_font_height;
-		data.ascent = _lodpi_font_ascent;
-		data.charcount = _lodpi_font_charcount;
-		data.char_rects = &_lodpi_font_charrects[0][0];
-		data.kerning_count = _lodpi_font_kerning_pair_count;
-		data.kernings = &_lodpi_font_kerning_pairs[0][0];
-		data.w = _lodpi_font_img_width;
-		data.h = _lodpi_font_img_height;
-		data.img = _lodpi_font_img_data;
-
-		Ref<FontData> font_data;
-		font_data.instance();
-		font_data->load_memory((const uint8_t *)&data, sizeof(data), "fnt");
-		default_font_size = font_data->get_base_size();
-
+		Ref<FontData> font_data = make_font(_lodpi_font_height, _lodpi_font_ascent, _lodpi_font_charcount, &_lodpi_font_charrects[0][0], _lodpi_font_kerning_pair_count, &_lodpi_font_kerning_pairs[0][0], _lodpi_font_img_width, _lodpi_font_img_height, _lodpi_font_img_data);
 		default_font.instance();
 		default_font->add_data(font_data);
 	}

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -39,6 +39,11 @@
 void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_resource", "filename", "base_size"), &FontData::load_resource, DEFVAL(16));
 	ClassDB::bind_method(D_METHOD("load_memory", "data", "type", "base_size"), &FontData::_load_memory, DEFVAL(16));
+	ClassDB::bind_method(D_METHOD("new_bitmap", "height", "ascent", "base_size"), &FontData::new_bitmap);
+
+	ClassDB::bind_method(D_METHOD("bitmap_add_texture", "texture"), &FontData::bitmap_add_texture);
+	ClassDB::bind_method(D_METHOD("bitmap_add_char", "char", "texture_idx", "rect", "align", "advance"), &FontData::bitmap_add_char);
+	ClassDB::bind_method(D_METHOD("bitmap_add_kerning_pair", "A", "B", "kerning"), &FontData::bitmap_add_kerning_pair);
 
 	ClassDB::bind_method(D_METHOD("set_data_path", "path"), &FontData::set_data_path);
 	ClassDB::bind_method(D_METHOD("get_data_path"), &FontData::get_data_path);
@@ -217,6 +222,34 @@ void FontData::load_memory(const uint8_t *p_data, size_t p_size, const String &p
 	path = TTR("(Memory: " + p_type.to_upper() + " @ 0x" + String::num_int64((uint64_t)p_data, 16, true) + ")");
 	base_size = TS->font_get_base_size(rid);
 	emit_changed();
+}
+
+void FontData::new_bitmap(float p_height, float p_ascent, int p_base_size) {
+	if (rid != RID()) {
+		TS->free(rid);
+	}
+	rid = TS->create_font_bitmap(p_height, p_ascent, p_base_size);
+	path = TTR("(Bitmap: " + String::num_int64(rid.get_id(), 16, true) + ")");
+	base_size = TS->font_get_base_size(rid);
+	emit_changed();
+}
+
+void FontData::bitmap_add_texture(const Ref<Texture> &p_texture) {
+	if (rid != RID()) {
+		TS->font_bitmap_add_texture(rid, p_texture);
+	}
+}
+
+void FontData::bitmap_add_char(char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) {
+	if (rid != RID()) {
+		TS->font_bitmap_add_char(rid, p_char, p_texture_idx, p_rect, p_align, p_advance);
+	}
+}
+
+void FontData::bitmap_add_kerning_pair(char32_t p_A, char32_t p_B, int p_kerning) {
+	if (rid != RID()) {
+		TS->font_bitmap_add_kerning_pair(rid, p_A, p_B, p_kerning);
+	}
 }
 
 void FontData::set_data_path(const String &p_path) {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -62,6 +62,12 @@ public:
 	void load_memory(const uint8_t *p_data, size_t p_size, const String &p_type, int p_base_size = 16);
 	void _load_memory(const PackedByteArray &p_data, const String &p_type, int p_base_size = 16);
 
+	void new_bitmap(float p_height, float p_ascent, int p_base_size = 16);
+
+	void bitmap_add_texture(const Ref<Texture> &p_texture);
+	void bitmap_add_char(char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance);
+	void bitmap_add_kerning_pair(char32_t p_A, char32_t p_B, int p_kerning);
+
 	void set_data_path(const String &p_path);
 	String get_data_path() const;
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -219,6 +219,11 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_font_system", "name", "base_size"), &TextServer::create_font_system, DEFVAL(16));
 	ClassDB::bind_method(D_METHOD("create_font_resource", "filename", "base_size"), &TextServer::create_font_resource, DEFVAL(16));
 	ClassDB::bind_method(D_METHOD("create_font_memory", "data", "type", "base_size"), &TextServer::_create_font_memory, DEFVAL(16));
+	ClassDB::bind_method(D_METHOD("create_font_bitmap", "height", "ascent", "base_size"), &TextServer::create_font_bitmap);
+
+	ClassDB::bind_method(D_METHOD("font_bitmap_add_texture", "font", "texture"), &TextServer::font_bitmap_add_texture);
+	ClassDB::bind_method(D_METHOD("font_bitmap_add_char", "font", "char", "texture_idx", "rect", "align", "advance"), &TextServer::font_bitmap_add_char);
+	ClassDB::bind_method(D_METHOD("font_bitmap_add_kerning_pair", "font", "A", "B", "kerning"), &TextServer::font_bitmap_add_kerning_pair);
 
 	ClassDB::bind_method(D_METHOD("font_get_height", "font", "size"), &TextServer::font_get_height);
 	ClassDB::bind_method(D_METHOD("font_get_ascent", "font", "size"), &TextServer::font_get_ascent);

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -192,18 +192,6 @@ public:
 		Vector<TextServer::Glyph> glyphs_logical;
 	};
 
-	struct BitmapFontData {
-		int height = 0;
-		int ascent = 0;
-		int charcount = 0;
-		const int *char_rects = nullptr;
-		int kerning_count = 0;
-		const int *kernings = nullptr;
-		int w = 0;
-		int h = 0;
-		const unsigned char *img = nullptr;
-	};
-
 protected:
 	static void _bind_methods();
 
@@ -236,6 +224,11 @@ public:
 	virtual RID create_font_system(const String &p_name, int p_base_size = 16) = 0;
 	virtual RID create_font_resource(const String &p_filename, int p_base_size = 16) = 0;
 	virtual RID create_font_memory(const uint8_t *p_data, size_t p_size, const String &p_type, int p_base_size = 16) = 0;
+	virtual RID create_font_bitmap(float p_height, float p_ascent, int p_base_size = 16) = 0;
+
+	virtual void font_bitmap_add_texture(RID p_font, const Ref<Texture> &p_texture) = 0;
+	virtual void font_bitmap_add_char(RID p_font, char32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance) = 0;
+	virtual void font_bitmap_add_kerning_pair(RID p_font, char32_t p_A, char32_t p_B, int p_kerning) = 0;
 
 	virtual float font_get_height(RID p_font, int p_size) const = 0;
 	virtual float font_get_ascent(RID p_font, int p_size) const = 0;


### PR DESCRIPTION
Reimplement support for creating bitmap fonts from texture in runtime, by adding `new_bitmap`, `bitmap_add_char`, `bitmap_add_kerning_pair` and `bitmap_add_texture` functions to the `FontData`.

![Screenshot 2021-02-15 at 11 51 55](https://user-images.githubusercontent.com/7645683/107930939-535e7e80-6f84-11eb-9ddf-5cfe67232eab.png)

