### PR TITLE
Moving GI and Sky code from RendererSceneRenderRD into separate classes

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_environment_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_environment_rd.cpp
@@ -1,0 +1,126 @@
+/*************************************************************************/
+/*  renderer_scene_environment_rd.cpp                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "servers/rendering/renderer_rd/renderer_scene_environment_rd.h"
+
+uint64_t RendererSceneEnvironmentRD::auto_exposure_counter = 2;
+
+void RendererSceneEnvironmentRD::set_ambient_light(const Color &p_color, RS::EnvironmentAmbientSource p_ambient, float p_energy, float p_sky_contribution, RS::EnvironmentReflectionSource p_reflection_source, const Color &p_ao_color) {
+	ambient_light = p_color;
+	ambient_source = p_ambient;
+	ambient_light_energy = p_energy;
+	ambient_sky_contribution = p_sky_contribution;
+	reflection_source = p_reflection_source;
+	ao_color = p_ao_color;
+}
+
+void RendererSceneEnvironmentRD::set_tonemap(RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) {
+	exposure = p_exposure;
+	tone_mapper = p_tone_mapper;
+	if (!auto_exposure && p_auto_exposure) {
+		auto_exposure_version = ++auto_exposure_counter;
+	}
+	auto_exposure = p_auto_exposure;
+	white = p_white;
+	min_luminance = p_min_luminance;
+	max_luminance = p_max_luminance;
+	auto_exp_speed = p_auto_exp_speed;
+	auto_exp_scale = p_auto_exp_scale;
+}
+
+void RendererSceneEnvironmentRD::set_glow(bool p_enable, Vector<float> p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap) {
+	ERR_FAIL_COND_MSG(p_levels.size() != 7, "Size of array of glow levels must be 7");
+	glow_enabled = p_enable;
+	glow_levels = p_levels;
+	glow_intensity = p_intensity;
+	glow_strength = p_strength;
+	glow_mix = p_mix;
+	glow_bloom = p_bloom_threshold;
+	glow_blend_mode = p_blend_mode;
+	glow_hdr_bleed_threshold = p_hdr_bleed_threshold;
+	glow_hdr_bleed_scale = p_hdr_bleed_scale;
+	glow_hdr_luminance_cap = p_hdr_luminance_cap;
+}
+
+void RendererSceneEnvironmentRD::set_sdfgi(bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) {
+	sdfgi_enabled = p_enable;
+	sdfgi_cascades = p_cascades;
+	sdfgi_min_cell_size = p_min_cell_size;
+	sdfgi_use_occlusion = p_use_occlusion;
+	sdfgi_bounce_feedback = p_bounce_feedback;
+	sdfgi_read_sky_light = p_read_sky;
+	sdfgi_energy = p_energy;
+	sdfgi_normal_bias = p_normal_bias;
+	sdfgi_probe_bias = p_probe_bias;
+	sdfgi_y_scale = p_y_scale;
+}
+
+void RendererSceneEnvironmentRD::set_fog(bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_fog_aerial_perspective) {
+	fog_enabled = p_enable;
+	fog_light_color = p_light_color;
+	fog_light_energy = p_light_energy;
+	fog_sun_scatter = p_sun_scatter;
+	fog_density = p_density;
+	fog_height = p_height;
+	fog_height_density = p_height_density;
+	fog_aerial_perspective = p_fog_aerial_perspective;
+}
+
+void RendererSceneEnvironmentRD::set_volumetric_fog(bool p_enable, float p_density, const Color &p_light, float p_light_energy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount) {
+	volumetric_fog_enabled = p_enable;
+	volumetric_fog_density = p_density;
+	volumetric_fog_light = p_light;
+	volumetric_fog_light_energy = p_light_energy;
+	volumetric_fog_length = p_length;
+	volumetric_fog_detail_spread = p_detail_spread;
+	volumetric_fog_gi_inject = p_gi_inject;
+	volumetric_fog_temporal_reprojection = p_temporal_reprojection;
+	volumetric_fog_temporal_reprojection_amount = p_temporal_reprojection_amount;
+}
+
+void RendererSceneEnvironmentRD::set_ssr(bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance) {
+	ssr_enabled = p_enable;
+	ssr_max_steps = p_max_steps;
+	ssr_fade_in = p_fade_int;
+	ssr_fade_out = p_fade_out;
+	ssr_depth_tolerance = p_depth_tolerance;
+}
+
+void RendererSceneEnvironmentRD::set_ssao(bool p_enable, float p_radius, float p_intensity, float p_power, float p_detail, float p_horizon, float p_sharpness, float p_light_affect, float p_ao_channel_affect) {
+	ssao_enabled = p_enable;
+	ssao_radius = p_radius;
+	ssao_intensity = p_intensity;
+	ssao_power = p_power;
+	ssao_detail = p_detail;
+	ssao_horizon = p_horizon;
+	ssao_sharpness = p_sharpness;
+	ssao_direct_light_affect = p_light_affect;
+	ssao_ao_channel_affect = p_ao_channel_affect;
+}

--- a/servers/rendering/renderer_rd/renderer_scene_environment_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_environment_rd.h
@@ -1,0 +1,155 @@
+/*************************************************************************/
+/*  renderer_scene_environment_rd.h                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RENDERING_SERVER_SCENE_ENVIRONMENT_RD_H
+#define RENDERING_SERVER_SCENE_ENVIRONMENT_RD_H
+
+#include "servers/rendering/renderer_scene_render.h"
+#include "servers/rendering/rendering_device.h"
+
+class RendererSceneEnvironmentRD {
+private:
+	static uint64_t auto_exposure_counter;
+
+public:
+	// BG
+	RS::EnvironmentBG background = RS::ENV_BG_CLEAR_COLOR;
+	RID sky;
+	float sky_custom_fov = 0.0;
+	Basis sky_orientation;
+	Color bg_color;
+	float bg_energy = 1.0;
+	int canvas_max_layer = 0;
+	RS::EnvironmentAmbientSource ambient_source = RS::ENV_AMBIENT_SOURCE_BG;
+	Color ambient_light;
+	float ambient_light_energy = 1.0;
+	float ambient_sky_contribution = 1.0;
+	RS::EnvironmentReflectionSource reflection_source = RS::ENV_REFLECTION_SOURCE_BG;
+	Color ao_color;
+
+	/// Tonemap
+
+	RS::EnvironmentToneMapper tone_mapper;
+	float exposure = 1.0;
+	float white = 1.0;
+	bool auto_exposure = false;
+	float min_luminance = 0.2;
+	float max_luminance = 8.0;
+	float auto_exp_speed = 0.2;
+	float auto_exp_scale = 0.5;
+	uint64_t auto_exposure_version = 0;
+
+	// Fog
+	bool fog_enabled = false;
+	Color fog_light_color = Color(0.5, 0.6, 0.7);
+	float fog_light_energy = 1.0;
+	float fog_sun_scatter = 0.0;
+	float fog_density = 0.001;
+	float fog_height = 0.0;
+	float fog_height_density = 0.0; //can be negative to invert effect
+	float fog_aerial_perspective = 0.0;
+
+	/// Volumetric Fog
+	///
+	bool volumetric_fog_enabled = false;
+	float volumetric_fog_density = 0.01;
+	Color volumetric_fog_light = Color(0, 0, 0);
+	float volumetric_fog_light_energy = 0.0;
+	float volumetric_fog_length = 64.0;
+	float volumetric_fog_detail_spread = 2.0;
+	float volumetric_fog_gi_inject = 0.0;
+	bool volumetric_fog_temporal_reprojection = true;
+	float volumetric_fog_temporal_reprojection_amount = 0.9;
+
+	/// Glow
+
+	bool glow_enabled = false;
+	Vector<float> glow_levels;
+	float glow_intensity = 0.8;
+	float glow_strength = 1.0;
+	float glow_bloom = 0.0;
+	float glow_mix = 0.01;
+	RS::EnvironmentGlowBlendMode glow_blend_mode = RS::ENV_GLOW_BLEND_MODE_SOFTLIGHT;
+	float glow_hdr_bleed_threshold = 1.0;
+	float glow_hdr_luminance_cap = 12.0;
+	float glow_hdr_bleed_scale = 2.0;
+
+	/// SSAO
+
+	bool ssao_enabled = false;
+	float ssao_radius = 1.0;
+	float ssao_intensity = 2.0;
+	float ssao_power = 1.5;
+	float ssao_detail = 0.5;
+	float ssao_horizon = 0.06;
+	float ssao_sharpness = 0.98;
+	float ssao_direct_light_affect = 0.0;
+	float ssao_ao_channel_affect = 0.0;
+
+	/// SSR
+	///
+	bool ssr_enabled = false;
+	int ssr_max_steps = 64;
+	float ssr_fade_in = 0.15;
+	float ssr_fade_out = 2.0;
+	float ssr_depth_tolerance = 0.2;
+
+	/// SDFGI
+	bool sdfgi_enabled = false;
+	RS::EnvironmentSDFGICascades sdfgi_cascades;
+	float sdfgi_min_cell_size = 0.2;
+	bool sdfgi_use_occlusion = false;
+	float sdfgi_bounce_feedback = 0.0;
+	bool sdfgi_read_sky_light = false;
+	float sdfgi_energy = 1.0;
+	float sdfgi_normal_bias = 1.1;
+	float sdfgi_probe_bias = 1.1;
+	RS::EnvironmentSDFGIYScale sdfgi_y_scale = RS::ENV_SDFGI_Y_SCALE_DISABLED;
+
+	/// Adjustments
+
+	bool adjustments_enabled = false;
+	float adjustments_brightness = 1.0f;
+	float adjustments_contrast = 1.0f;
+	float adjustments_saturation = 1.0f;
+	bool use_1d_color_correction = false;
+	RID color_correction = RID();
+
+	void set_ambient_light(const Color &p_color, RS::EnvironmentAmbientSource p_ambient, float p_energy, float p_sky_contribution, RS::EnvironmentReflectionSource p_reflection_source, const Color &p_ao_color);
+	void set_tonemap(RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale);
+	void set_glow(bool p_enable, Vector<float> p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap);
+	void set_sdfgi(bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias);
+	void set_fog(bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_fog_aerial_perspective);
+	void set_volumetric_fog(bool p_enable, float p_density, const Color &p_light, float p_light_energy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount);
+	void set_ssr(bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance);
+	void set_ssao(bool p_enable, float p_radius, float p_intensity, float p_power, float p_detail, float p_horizon, float p_sharpness, float p_light_affect, float p_ao_channel_affect);
+};
+
+#endif /* !RENDERING_SERVER_SCENE_ENVIRONMENT_RD_H */

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
@@ -1,0 +1,3383 @@
+/*************************************************************************/
+/*  renderer_scene_gi_rd.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "renderer_scene_gi_rd.h"
+
+#include "core/config/project_settings.h"
+#include "renderer_compositor_rd.h"
+#include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
+#include "servers/rendering/rendering_server_default.h"
+
+const Vector3i RendererSceneGIRD::SDFGI::Cascade::DIRTY_ALL = Vector3i(0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF);
+
+////////////////////////////////////////////////////////////////////////////////
+// SDFGI
+
+void RendererSceneGIRD::SDFGI::create(RendererSceneEnvironmentRD *p_env, const Vector3 &p_world_position, uint32_t p_requested_history_size, RendererSceneGIRD *p_gi) {
+	storage = p_gi->storage;
+	gi = p_gi;
+	cascade_mode = p_env->sdfgi_cascades;
+	min_cell_size = p_env->sdfgi_min_cell_size;
+	uses_occlusion = p_env->sdfgi_use_occlusion;
+	y_scale_mode = p_env->sdfgi_y_scale;
+	static const float y_scale[3] = { 1.0, 1.5, 2.0 };
+	y_mult = y_scale[y_scale_mode];
+	static const int cascasde_size[3] = { 4, 6, 8 };
+	cascades.resize(cascasde_size[cascade_mode]);
+	probe_axis_count = SDFGI::PROBE_DIVISOR + 1;
+	solid_cell_ratio = gi->sdfgi_solid_cell_ratio;
+	solid_cell_count = uint32_t(float(cascade_size * cascade_size * cascade_size) * solid_cell_ratio);
+
+	float base_cell_size = min_cell_size;
+
+	RD::TextureFormat tf_sdf;
+	tf_sdf.format = RD::DATA_FORMAT_R8_UNORM;
+	tf_sdf.width = cascade_size; // Always 64x64
+	tf_sdf.height = cascade_size;
+	tf_sdf.depth = cascade_size;
+	tf_sdf.texture_type = RD::TEXTURE_TYPE_3D;
+	tf_sdf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+
+	{
+		RD::TextureFormat tf_render = tf_sdf;
+		tf_render.format = RD::DATA_FORMAT_R16_UINT;
+		render_albedo = RD::get_singleton()->texture_create(tf_render, RD::TextureView());
+		tf_render.format = RD::DATA_FORMAT_R32_UINT;
+		render_emission = RD::get_singleton()->texture_create(tf_render, RD::TextureView());
+		render_emission_aniso = RD::get_singleton()->texture_create(tf_render, RD::TextureView());
+
+		tf_render.format = RD::DATA_FORMAT_R8_UNORM; //at least its easy to visualize
+
+		for (int i = 0; i < 8; i++) {
+			render_occlusion[i] = RD::get_singleton()->texture_create(tf_render, RD::TextureView());
+		}
+
+		tf_render.format = RD::DATA_FORMAT_R32_UINT;
+		render_geom_facing = RD::get_singleton()->texture_create(tf_render, RD::TextureView());
+
+		tf_render.format = RD::DATA_FORMAT_R8G8B8A8_UINT;
+		render_sdf[0] = RD::get_singleton()->texture_create(tf_render, RD::TextureView());
+		render_sdf[1] = RD::get_singleton()->texture_create(tf_render, RD::TextureView());
+
+		tf_render.width /= 2;
+		tf_render.height /= 2;
+		tf_render.depth /= 2;
+
+		render_sdf_half[0] = RD::get_singleton()->texture_create(tf_render, RD::TextureView());
+		render_sdf_half[1] = RD::get_singleton()->texture_create(tf_render, RD::TextureView());
+	}
+
+	RD::TextureFormat tf_occlusion = tf_sdf;
+	tf_occlusion.format = RD::DATA_FORMAT_R16_UINT;
+	tf_occlusion.shareable_formats.push_back(RD::DATA_FORMAT_R16_UINT);
+	tf_occlusion.shareable_formats.push_back(RD::DATA_FORMAT_R4G4B4A4_UNORM_PACK16);
+	tf_occlusion.depth *= cascades.size(); //use depth for occlusion slices
+	tf_occlusion.width *= 2; //use width for the other half
+
+	RD::TextureFormat tf_light = tf_sdf;
+	tf_light.format = RD::DATA_FORMAT_R32_UINT;
+	tf_light.shareable_formats.push_back(RD::DATA_FORMAT_R32_UINT);
+	tf_light.shareable_formats.push_back(RD::DATA_FORMAT_E5B9G9R9_UFLOAT_PACK32);
+
+	RD::TextureFormat tf_aniso0 = tf_sdf;
+	tf_aniso0.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+	RD::TextureFormat tf_aniso1 = tf_sdf;
+	tf_aniso1.format = RD::DATA_FORMAT_R8G8_UNORM;
+
+	int passes = nearest_shift(cascade_size) - 1;
+
+	//store lightprobe SH
+	RD::TextureFormat tf_probes;
+	tf_probes.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+	tf_probes.width = probe_axis_count * probe_axis_count;
+	tf_probes.height = probe_axis_count * SDFGI::SH_SIZE;
+	tf_probes.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+	tf_probes.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
+
+	history_size = p_requested_history_size;
+
+	RD::TextureFormat tf_probe_history = tf_probes;
+	tf_probe_history.format = RD::DATA_FORMAT_R16G16B16A16_SINT; //signed integer because SH are signed
+	tf_probe_history.array_layers = history_size;
+
+	RD::TextureFormat tf_probe_average = tf_probes;
+	tf_probe_average.format = RD::DATA_FORMAT_R32G32B32A32_SINT; //signed integer because SH are signed
+	tf_probe_average.texture_type = RD::TEXTURE_TYPE_2D;
+
+	lightprobe_history_scroll = RD::get_singleton()->texture_create(tf_probe_history, RD::TextureView());
+	lightprobe_average_scroll = RD::get_singleton()->texture_create(tf_probe_average, RD::TextureView());
+
+	{
+		//octahedral lightprobes
+		RD::TextureFormat tf_octprobes = tf_probes;
+		tf_octprobes.array_layers = cascades.size() * 2;
+		tf_octprobes.format = RD::DATA_FORMAT_R32_UINT; //pack well with RGBE
+		tf_octprobes.width = probe_axis_count * probe_axis_count * (SDFGI::LIGHTPROBE_OCT_SIZE + 2);
+		tf_octprobes.height = probe_axis_count * (SDFGI::LIGHTPROBE_OCT_SIZE + 2);
+		tf_octprobes.shareable_formats.push_back(RD::DATA_FORMAT_R32_UINT);
+		tf_octprobes.shareable_formats.push_back(RD::DATA_FORMAT_E5B9G9R9_UFLOAT_PACK32);
+		//lightprobe texture is an octahedral texture
+
+		lightprobe_data = RD::get_singleton()->texture_create(tf_octprobes, RD::TextureView());
+		RD::TextureView tv;
+		tv.format_override = RD::DATA_FORMAT_E5B9G9R9_UFLOAT_PACK32;
+		lightprobe_texture = RD::get_singleton()->texture_create_shared(tv, lightprobe_data);
+
+		//texture handling ambient data, to integrate with volumetric foc
+		RD::TextureFormat tf_ambient = tf_probes;
+		tf_ambient.array_layers = cascades.size();
+		tf_ambient.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT; //pack well with RGBE
+		tf_ambient.width = probe_axis_count * probe_axis_count;
+		tf_ambient.height = probe_axis_count;
+		tf_ambient.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
+		//lightprobe texture is an octahedral texture
+		ambient_texture = RD::get_singleton()->texture_create(tf_ambient, RD::TextureView());
+	}
+
+	cascades_ubo = RD::get_singleton()->uniform_buffer_create(sizeof(SDFGI::Cascade::UBO) * SDFGI::MAX_CASCADES);
+
+	occlusion_data = RD::get_singleton()->texture_create(tf_occlusion, RD::TextureView());
+	{
+		RD::TextureView tv;
+		tv.format_override = RD::DATA_FORMAT_R4G4B4A4_UNORM_PACK16;
+		occlusion_texture = RD::get_singleton()->texture_create_shared(tv, occlusion_data);
+	}
+
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		SDFGI::Cascade &cascade = cascades[i];
+
+		/* 3D Textures */
+
+		cascade.sdf_tex = RD::get_singleton()->texture_create(tf_sdf, RD::TextureView());
+
+		cascade.light_data = RD::get_singleton()->texture_create(tf_light, RD::TextureView());
+
+		cascade.light_aniso_0_tex = RD::get_singleton()->texture_create(tf_aniso0, RD::TextureView());
+		cascade.light_aniso_1_tex = RD::get_singleton()->texture_create(tf_aniso1, RD::TextureView());
+
+		{
+			RD::TextureView tv;
+			tv.format_override = RD::DATA_FORMAT_E5B9G9R9_UFLOAT_PACK32;
+			cascade.light_tex = RD::get_singleton()->texture_create_shared(tv, cascade.light_data);
+
+			RD::get_singleton()->texture_clear(cascade.light_tex, Color(0, 0, 0, 0), 0, 1, 0, 1);
+			RD::get_singleton()->texture_clear(cascade.light_aniso_0_tex, Color(0, 0, 0, 0), 0, 1, 0, 1);
+			RD::get_singleton()->texture_clear(cascade.light_aniso_1_tex, Color(0, 0, 0, 0), 0, 1, 0, 1);
+		}
+
+		cascade.cell_size = base_cell_size;
+		Vector3 world_position = p_world_position;
+		world_position.y *= y_mult;
+		int32_t probe_cells = cascade_size / SDFGI::PROBE_DIVISOR;
+		Vector3 probe_size = Vector3(1, 1, 1) * cascade.cell_size * probe_cells;
+		Vector3i probe_pos = Vector3i((world_position / probe_size + Vector3(0.5, 0.5, 0.5)).floor());
+		cascade.position = probe_pos * probe_cells;
+
+		cascade.dirty_regions = SDFGI::Cascade::DIRTY_ALL;
+
+		base_cell_size *= 2.0;
+
+		/* Probe History */
+
+		cascade.lightprobe_history_tex = RD::get_singleton()->texture_create(tf_probe_history, RD::TextureView());
+		RD::get_singleton()->texture_clear(cascade.lightprobe_history_tex, Color(0, 0, 0, 0), 0, 1, 0, tf_probe_history.array_layers); //needs to be cleared for average to work
+
+		cascade.lightprobe_average_tex = RD::get_singleton()->texture_create(tf_probe_average, RD::TextureView());
+		RD::get_singleton()->texture_clear(cascade.lightprobe_average_tex, Color(0, 0, 0, 0), 0, 1, 0, 1); //needs to be cleared for average to work
+
+		/* Buffers */
+
+		cascade.solid_cell_buffer = RD::get_singleton()->storage_buffer_create(sizeof(SDFGI::Cascade::SolidCell) * solid_cell_count);
+		cascade.solid_cell_dispatch_buffer = RD::get_singleton()->storage_buffer_create(sizeof(uint32_t) * 4, Vector<uint8_t>(), RD::STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT);
+		cascade.lights_buffer = RD::get_singleton()->storage_buffer_create(sizeof(SDGIShader::Light) * MAX(SDFGI::MAX_STATIC_LIGHTS, SDFGI::MAX_DYNAMIC_LIGHTS));
+		{
+			Vector<RD::Uniform> uniforms;
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 1;
+				u.ids.push_back(render_sdf[(passes & 1) ? 1 : 0]); //if passes are even, we read from buffer 0, else we read from buffer 1
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 2;
+				u.ids.push_back(render_albedo);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 3;
+				for (int j = 0; j < 8; j++) {
+					u.ids.push_back(render_occlusion[j]);
+				}
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 4;
+				u.ids.push_back(render_emission);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 5;
+				u.ids.push_back(render_emission_aniso);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 6;
+				u.ids.push_back(render_geom_facing);
+				uniforms.push_back(u);
+			}
+
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 7;
+				u.ids.push_back(cascade.sdf_tex);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 8;
+				u.ids.push_back(occlusion_data);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.binding = 10;
+				u.ids.push_back(cascade.solid_cell_dispatch_buffer);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.binding = 11;
+				u.ids.push_back(cascade.solid_cell_buffer);
+				uniforms.push_back(u);
+			}
+
+			cascade.sdf_store_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_STORE), 0);
+		}
+
+		{
+			Vector<RD::Uniform> uniforms;
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 1;
+				u.ids.push_back(render_albedo);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 2;
+				u.ids.push_back(render_geom_facing);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 3;
+				u.ids.push_back(render_emission);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 4;
+				u.ids.push_back(render_emission_aniso);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.binding = 5;
+				u.ids.push_back(cascade.solid_cell_dispatch_buffer);
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.binding = 6;
+				u.ids.push_back(cascade.solid_cell_buffer);
+				uniforms.push_back(u);
+			}
+
+			cascade.scroll_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_SCROLL), 0);
+		}
+		{
+			Vector<RD::Uniform> uniforms;
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 1;
+				for (int j = 0; j < 8; j++) {
+					u.ids.push_back(render_occlusion[j]);
+				}
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+				u.binding = 2;
+				u.ids.push_back(occlusion_data);
+				uniforms.push_back(u);
+			}
+
+			cascade.scroll_occlusion_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_SCROLL_OCCLUSION), 0);
+		}
+	}
+
+	//direct light
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		SDFGI::Cascade &cascade = cascades[i];
+
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.binding = 1;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
+				if (j < cascades.size()) {
+					u.ids.push_back(cascades[j].sdf_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 2;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 3;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.ids.push_back(cascade.solid_cell_dispatch_buffer);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 4;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.ids.push_back(cascade.solid_cell_buffer);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 5;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.ids.push_back(cascade.light_data);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 6;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.ids.push_back(cascade.light_aniso_0_tex);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 7;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.ids.push_back(cascade.light_aniso_1_tex);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 8;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.ids.push_back(cascades_ubo);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 9;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.ids.push_back(cascade.lights_buffer);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 10;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.ids.push_back(lightprobe_texture);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 11;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.ids.push_back(occlusion_texture);
+			uniforms.push_back(u);
+		}
+
+		cascade.sdf_direct_light_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.direct_light.version_get_shader(gi->sdfgi_shader.direct_light_shader, 0), 0);
+	}
+
+	//preprocess initialize uniform set
+	{
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 1;
+			u.ids.push_back(render_albedo);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 2;
+			u.ids.push_back(render_sdf[0]);
+			uniforms.push_back(u);
+		}
+
+		sdf_initialize_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_JUMP_FLOOD_INITIALIZE), 0);
+	}
+
+	{
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 1;
+			u.ids.push_back(render_albedo);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 2;
+			u.ids.push_back(render_sdf_half[0]);
+			uniforms.push_back(u);
+		}
+
+		sdf_initialize_half_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_JUMP_FLOOD_INITIALIZE_HALF), 0);
+	}
+
+	//jump flood uniform set
+	{
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 1;
+			u.ids.push_back(render_sdf[0]);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 2;
+			u.ids.push_back(render_sdf[1]);
+			uniforms.push_back(u);
+		}
+
+		jump_flood_uniform_set[0] = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_JUMP_FLOOD), 0);
+		SWAP(uniforms.write[0].ids.write[0], uniforms.write[1].ids.write[0]);
+		jump_flood_uniform_set[1] = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_JUMP_FLOOD), 0);
+	}
+	//jump flood half uniform set
+	{
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 1;
+			u.ids.push_back(render_sdf_half[0]);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 2;
+			u.ids.push_back(render_sdf_half[1]);
+			uniforms.push_back(u);
+		}
+
+		jump_flood_half_uniform_set[0] = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_JUMP_FLOOD), 0);
+		SWAP(uniforms.write[0].ids.write[0], uniforms.write[1].ids.write[0]);
+		jump_flood_half_uniform_set[1] = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_JUMP_FLOOD), 0);
+	}
+
+	//upscale half size sdf
+	{
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 1;
+			u.ids.push_back(render_albedo);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 2;
+			u.ids.push_back(render_sdf_half[(passes & 1) ? 0 : 1]); //reverse pass order because half size
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 3;
+			u.ids.push_back(render_sdf[(passes & 1) ? 0 : 1]); //reverse pass order because it needs an extra JFA pass
+			uniforms.push_back(u);
+		}
+
+		upscale_jfa_uniform_set_index = (passes & 1) ? 0 : 1;
+		sdf_upscale_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_JUMP_FLOOD_UPSCALE), 0);
+	}
+
+	//occlusion uniform set
+	{
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 1;
+			u.ids.push_back(render_albedo);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 2;
+			for (int i = 0; i < 8; i++) {
+				u.ids.push_back(render_occlusion[i]);
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 3;
+			u.ids.push_back(render_geom_facing);
+			uniforms.push_back(u);
+		}
+
+		occlusion_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.preprocess.version_get_shader(gi->sdfgi_shader.preprocess_shader, SDGIShader::PRE_PROCESS_OCCLUSION), 0);
+	}
+
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		//integrate uniform
+
+		Vector<RD::Uniform> uniforms;
+
+		{
+			RD::Uniform u;
+			u.binding = 1;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
+				if (j < cascades.size()) {
+					u.ids.push_back(cascades[j].sdf_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 2;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
+				if (j < cascades.size()) {
+					u.ids.push_back(cascades[j].light_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 3;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
+				if (j < cascades.size()) {
+					u.ids.push_back(cascades[j].light_aniso_0_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 4;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
+				if (j < cascades.size()) {
+					u.ids.push_back(cascades[j].light_aniso_1_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+			u.binding = 6;
+			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+			uniforms.push_back(u);
+		}
+
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.binding = 7;
+			u.ids.push_back(cascades_ubo);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 8;
+			u.ids.push_back(lightprobe_data);
+			uniforms.push_back(u);
+		}
+
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 9;
+			u.ids.push_back(cascades[i].lightprobe_history_tex);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 10;
+			u.ids.push_back(cascades[i].lightprobe_average_tex);
+			uniforms.push_back(u);
+		}
+
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 11;
+			u.ids.push_back(lightprobe_history_scroll);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 12;
+			u.ids.push_back(lightprobe_average_scroll);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 13;
+			RID parent_average;
+			if (i < cascades.size() - 1) {
+				parent_average = cascades[i + 1].lightprobe_average_tex;
+			} else {
+				parent_average = cascades[i - 1].lightprobe_average_tex; //to use something, but it won't be used
+			}
+			u.ids.push_back(parent_average);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 14;
+			u.ids.push_back(ambient_texture);
+			uniforms.push_back(u);
+		}
+
+		cascades[i].integrate_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.integrate.version_get_shader(gi->sdfgi_shader.integrate_shader, 0), 0);
+	}
+
+	bounce_feedback = p_env->sdfgi_bounce_feedback;
+	energy = p_env->sdfgi_energy;
+	normal_bias = p_env->sdfgi_normal_bias;
+	probe_bias = p_env->sdfgi_probe_bias;
+	reads_sky = p_env->sdfgi_read_sky_light;
+}
+
+void RendererSceneGIRD::SDFGI::erase() {
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		const SDFGI::Cascade &c = cascades[i];
+		RD::get_singleton()->free(c.light_data);
+		RD::get_singleton()->free(c.light_aniso_0_tex);
+		RD::get_singleton()->free(c.light_aniso_1_tex);
+		RD::get_singleton()->free(c.sdf_tex);
+		RD::get_singleton()->free(c.solid_cell_dispatch_buffer);
+		RD::get_singleton()->free(c.solid_cell_buffer);
+		RD::get_singleton()->free(c.lightprobe_history_tex);
+		RD::get_singleton()->free(c.lightprobe_average_tex);
+		RD::get_singleton()->free(c.lights_buffer);
+	}
+
+	RD::get_singleton()->free(render_albedo);
+	RD::get_singleton()->free(render_emission);
+	RD::get_singleton()->free(render_emission_aniso);
+
+	RD::get_singleton()->free(render_sdf[0]);
+	RD::get_singleton()->free(render_sdf[1]);
+
+	RD::get_singleton()->free(render_sdf_half[0]);
+	RD::get_singleton()->free(render_sdf_half[1]);
+
+	for (int i = 0; i < 8; i++) {
+		RD::get_singleton()->free(render_occlusion[i]);
+	}
+
+	RD::get_singleton()->free(render_geom_facing);
+
+	RD::get_singleton()->free(lightprobe_data);
+	RD::get_singleton()->free(lightprobe_history_scroll);
+	RD::get_singleton()->free(occlusion_data);
+	RD::get_singleton()->free(ambient_texture);
+
+	RD::get_singleton()->free(cascades_ubo);
+}
+
+void RendererSceneGIRD::SDFGI::update(RendererSceneEnvironmentRD *p_env, const Vector3 &p_world_position) {
+	bounce_feedback = p_env->sdfgi_bounce_feedback;
+	energy = p_env->sdfgi_energy;
+	normal_bias = p_env->sdfgi_normal_bias;
+	probe_bias = p_env->sdfgi_probe_bias;
+	reads_sky = p_env->sdfgi_read_sky_light;
+
+	int32_t drag_margin = (cascade_size / SDFGI::PROBE_DIVISOR) / 2;
+
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		SDFGI::Cascade &cascade = cascades[i];
+		cascade.dirty_regions = Vector3i();
+
+		Vector3 probe_half_size = Vector3(1, 1, 1) * cascade.cell_size * float(cascade_size / SDFGI::PROBE_DIVISOR) * 0.5;
+		probe_half_size = Vector3(0, 0, 0);
+
+		Vector3 world_position = p_world_position;
+		world_position.y *= y_mult;
+		Vector3i pos_in_cascade = Vector3i((world_position + probe_half_size) / cascade.cell_size);
+
+		for (int j = 0; j < 3; j++) {
+			if (pos_in_cascade[j] < cascade.position[j]) {
+				while (pos_in_cascade[j] < (cascade.position[j] - drag_margin)) {
+					cascade.position[j] -= drag_margin * 2;
+					cascade.dirty_regions[j] += drag_margin * 2;
+				}
+			} else if (pos_in_cascade[j] > cascade.position[j]) {
+				while (pos_in_cascade[j] > (cascade.position[j] + drag_margin)) {
+					cascade.position[j] += drag_margin * 2;
+					cascade.dirty_regions[j] -= drag_margin * 2;
+				}
+			}
+
+			if (cascade.dirty_regions[j] == 0) {
+				continue; // not dirty
+			} else if (uint32_t(ABS(cascade.dirty_regions[j])) >= cascade_size) {
+				//moved too much, just redraw everything (make all dirty)
+				cascade.dirty_regions = SDFGI::Cascade::DIRTY_ALL;
+				break;
+			}
+		}
+
+		if (cascade.dirty_regions != Vector3i() && cascade.dirty_regions != SDFGI::Cascade::DIRTY_ALL) {
+			//see how much the total dirty volume represents from the total volume
+			uint32_t total_volume = cascade_size * cascade_size * cascade_size;
+			uint32_t safe_volume = 1;
+			for (int j = 0; j < 3; j++) {
+				safe_volume *= cascade_size - ABS(cascade.dirty_regions[j]);
+			}
+			uint32_t dirty_volume = total_volume - safe_volume;
+			if (dirty_volume > (safe_volume / 2)) {
+				//more than half the volume is dirty, make all dirty so its only rendered once
+				cascade.dirty_regions = SDFGI::Cascade::DIRTY_ALL;
+			}
+		}
+	}
+}
+
+void RendererSceneGIRD::SDFGI::update_light() {
+	RD::get_singleton()->draw_command_begin_label("SDFGI Update dynamic Light");
+
+	/* Update dynamic light */
+
+	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.direct_light_pipeline[SDGIShader::DIRECT_LIGHT_MODE_DYNAMIC]);
+
+	SDGIShader::DirectLightPushConstant push_constant;
+
+	push_constant.grid_size[0] = cascade_size;
+	push_constant.grid_size[1] = cascade_size;
+	push_constant.grid_size[2] = cascade_size;
+	push_constant.max_cascades = cascades.size();
+	push_constant.probe_axis_size = probe_axis_count;
+	push_constant.bounce_feedback = bounce_feedback;
+	push_constant.y_mult = y_mult;
+	push_constant.use_occlusion = uses_occlusion;
+
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		SDFGI::Cascade &cascade = cascades[i];
+		push_constant.light_count = cascade_dynamic_light_count[i];
+		push_constant.cascade = i;
+
+		if (cascades[i].all_dynamic_lights_dirty || gi->sdfgi_frames_to_update_light == RS::ENV_SDFGI_UPDATE_LIGHT_IN_1_FRAME) {
+			push_constant.process_offset = 0;
+			push_constant.process_increment = 1;
+		} else {
+			static uint32_t frames_to_update_table[RS::ENV_SDFGI_UPDATE_LIGHT_MAX] = {
+				1, 2, 4, 8, 16
+			};
+
+			uint32_t frames_to_update = frames_to_update_table[gi->sdfgi_frames_to_update_light];
+
+			push_constant.process_offset = RSG::rasterizer->get_frame_number() % frames_to_update;
+			push_constant.process_increment = frames_to_update;
+		}
+		cascades[i].all_dynamic_lights_dirty = false;
+
+		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cascade.sdf_direct_light_uniform_set, 0);
+		RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::DirectLightPushConstant));
+		RD::get_singleton()->compute_list_dispatch_indirect(compute_list, cascade.solid_cell_dispatch_buffer, 0);
+	}
+	RD::get_singleton()->compute_list_end(RD::BARRIER_MASK_COMPUTE);
+	RD::get_singleton()->draw_command_end_label();
+}
+
+void RendererSceneGIRD::SDFGI::update_probes(RendererSceneEnvironmentRD *p_env, RendererSceneSkyRD::Sky *p_sky) {
+	RD::get_singleton()->draw_command_begin_label("SDFGI Update Probes");
+
+	SDGIShader::IntegratePushConstant push_constant;
+	push_constant.grid_size[1] = cascade_size;
+	push_constant.grid_size[2] = cascade_size;
+	push_constant.grid_size[0] = cascade_size;
+	push_constant.max_cascades = cascades.size();
+	push_constant.probe_axis_size = probe_axis_count;
+	push_constant.history_index = render_pass % history_size;
+	push_constant.history_size = history_size;
+	static const uint32_t ray_count[RS::ENV_SDFGI_RAY_COUNT_MAX] = { 4, 8, 16, 32, 64, 96, 128 };
+	push_constant.ray_count = ray_count[gi->sdfgi_ray_count];
+	push_constant.ray_bias = probe_bias;
+	push_constant.image_size[0] = probe_axis_count * probe_axis_count;
+	push_constant.image_size[1] = probe_axis_count;
+	push_constant.store_ambient_texture = p_env->volumetric_fog_enabled;
+
+	RID sky_uniform_set = gi->sdfgi_shader.integrate_default_sky_uniform_set;
+	push_constant.sky_mode = SDGIShader::IntegratePushConstant::SKY_MODE_DISABLED;
+	push_constant.y_mult = y_mult;
+
+	if (reads_sky && p_env) {
+		push_constant.sky_energy = p_env->bg_energy;
+
+		if (p_env->background == RS::ENV_BG_CLEAR_COLOR) {
+			push_constant.sky_mode = SDGIShader::IntegratePushConstant::SKY_MODE_COLOR;
+			Color c = storage->get_default_clear_color().to_linear();
+			push_constant.sky_color[0] = c.r;
+			push_constant.sky_color[1] = c.g;
+			push_constant.sky_color[2] = c.b;
+		} else if (p_env->background == RS::ENV_BG_COLOR) {
+			push_constant.sky_mode = SDGIShader::IntegratePushConstant::SKY_MODE_COLOR;
+			Color c = p_env->bg_color;
+			push_constant.sky_color[0] = c.r;
+			push_constant.sky_color[1] = c.g;
+			push_constant.sky_color[2] = c.b;
+
+		} else if (p_env->background == RS::ENV_BG_SKY) {
+			if (p_sky && p_sky->radiance.is_valid()) {
+				if (integrate_sky_uniform_set.is_null() || !RD::get_singleton()->uniform_set_is_valid(integrate_sky_uniform_set)) {
+					Vector<RD::Uniform> uniforms;
+
+					{
+						RD::Uniform u;
+						u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+						u.binding = 0;
+						u.ids.push_back(p_sky->radiance);
+						uniforms.push_back(u);
+					}
+
+					{
+						RD::Uniform u;
+						u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+						u.binding = 1;
+						u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+						uniforms.push_back(u);
+					}
+
+					integrate_sky_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.integrate.version_get_shader(gi->sdfgi_shader.integrate_shader, 0), 1);
+				}
+				sky_uniform_set = integrate_sky_uniform_set;
+				push_constant.sky_mode = SDGIShader::IntegratePushConstant::SKY_MODE_SKY;
+			}
+		}
+	}
+
+	render_pass++;
+
+	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin(true);
+	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.integrate_pipeline[SDGIShader::INTEGRATE_MODE_PROCESS]);
+
+	int32_t probe_divisor = cascade_size / SDFGI::PROBE_DIVISOR;
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		push_constant.cascade = i;
+		push_constant.world_offset[0] = cascades[i].position.x / probe_divisor;
+		push_constant.world_offset[1] = cascades[i].position.y / probe_divisor;
+		push_constant.world_offset[2] = cascades[i].position.z / probe_divisor;
+
+		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cascades[i].integrate_uniform_set, 0);
+		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, sky_uniform_set, 1);
+
+		RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::IntegratePushConstant));
+		RD::get_singleton()->compute_list_dispatch_threads(compute_list, probe_axis_count * probe_axis_count, probe_axis_count, 1);
+	}
+
+	//end later after raster to avoid barriering on layout changes
+	//RD::get_singleton()->compute_list_end(RD::BARRIER_MASK_NO_BARRIER);
+
+	RD::get_singleton()->draw_command_end_label();
+}
+
+void RendererSceneGIRD::SDFGI::store_probes() {
+	RD::get_singleton()->barrier(RD::BARRIER_MASK_COMPUTE, RD::BARRIER_MASK_COMPUTE);
+	RD::get_singleton()->draw_command_begin_label("SDFGI Store Probes");
+
+	SDGIShader::IntegratePushConstant push_constant;
+	push_constant.grid_size[1] = cascade_size;
+	push_constant.grid_size[2] = cascade_size;
+	push_constant.grid_size[0] = cascade_size;
+	push_constant.max_cascades = cascades.size();
+	push_constant.probe_axis_size = probe_axis_count;
+	push_constant.history_index = render_pass % history_size;
+	push_constant.history_size = history_size;
+	static const uint32_t ray_count[RS::ENV_SDFGI_RAY_COUNT_MAX] = { 4, 8, 16, 32, 64, 96, 128 };
+	push_constant.ray_count = ray_count[gi->sdfgi_ray_count];
+	push_constant.ray_bias = probe_bias;
+	push_constant.image_size[0] = probe_axis_count * probe_axis_count;
+	push_constant.image_size[1] = probe_axis_count;
+	push_constant.store_ambient_texture = false;
+
+	push_constant.sky_mode = 0;
+	push_constant.y_mult = y_mult;
+
+	// Then store values into the lightprobe texture. Separating these steps has a small performance hit, but it allows for multiple bounces
+	RENDER_TIMESTAMP("Average Probes");
+
+	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.integrate_pipeline[SDGIShader::INTEGRATE_MODE_STORE]);
+
+	//convert to octahedral to store
+	push_constant.image_size[0] *= SDFGI::LIGHTPROBE_OCT_SIZE;
+	push_constant.image_size[1] *= SDFGI::LIGHTPROBE_OCT_SIZE;
+
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		push_constant.cascade = i;
+		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cascades[i].integrate_uniform_set, 0);
+		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, gi->sdfgi_shader.integrate_default_sky_uniform_set, 1);
+		RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::IntegratePushConstant));
+		RD::get_singleton()->compute_list_dispatch_threads(compute_list, probe_axis_count * probe_axis_count * SDFGI::LIGHTPROBE_OCT_SIZE, probe_axis_count * SDFGI::LIGHTPROBE_OCT_SIZE, 1);
+	}
+
+	RD::get_singleton()->compute_list_end(RD::BARRIER_MASK_COMPUTE);
+
+	RD::get_singleton()->draw_command_end_label();
+}
+
+int RendererSceneGIRD::SDFGI::get_pending_region_data(int p_region, Vector3i &r_local_offset, Vector3i &r_local_size, AABB &r_bounds) const {
+	int dirty_count = 0;
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		const SDFGI::Cascade &c = cascades[i];
+
+		if (c.dirty_regions == SDFGI::Cascade::DIRTY_ALL) {
+			if (dirty_count == p_region) {
+				r_local_offset = Vector3i();
+				r_local_size = Vector3i(1, 1, 1) * cascade_size;
+
+				r_bounds.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + c.position)) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
+				r_bounds.size = Vector3(r_local_size) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
+				return i;
+			}
+			dirty_count++;
+		} else {
+			for (int j = 0; j < 3; j++) {
+				if (c.dirty_regions[j] != 0) {
+					if (dirty_count == p_region) {
+						Vector3i from = Vector3i(0, 0, 0);
+						Vector3i to = Vector3i(1, 1, 1) * cascade_size;
+
+						if (c.dirty_regions[j] > 0) {
+							//fill from the beginning
+							to[j] = c.dirty_regions[j];
+						} else {
+							//fill from the end
+							from[j] = to[j] + c.dirty_regions[j];
+						}
+
+						for (int k = 0; k < j; k++) {
+							// "chip" away previous regions to avoid re-voxelizing the same thing
+							if (c.dirty_regions[k] > 0) {
+								from[k] += c.dirty_regions[k];
+							} else if (c.dirty_regions[k] < 0) {
+								to[k] += c.dirty_regions[k];
+							}
+						}
+
+						r_local_offset = from;
+						r_local_size = to - from;
+
+						r_bounds.position = Vector3(from + Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + c.position) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
+						r_bounds.size = Vector3(r_local_size) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
+
+						return i;
+					}
+
+					dirty_count++;
+				}
+			}
+		}
+	}
+	return -1;
+}
+
+void RendererSceneGIRD::SDFGI::update_cascades() {
+	//update cascades
+	SDFGI::Cascade::UBO cascade_data[SDFGI::MAX_CASCADES];
+	int32_t probe_divisor = cascade_size / SDFGI::PROBE_DIVISOR;
+
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		Vector3 pos = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[i].position)) * cascades[i].cell_size;
+
+		cascade_data[i].offset[0] = pos.x;
+		cascade_data[i].offset[1] = pos.y;
+		cascade_data[i].offset[2] = pos.z;
+		cascade_data[i].to_cell = 1.0 / cascades[i].cell_size;
+		cascade_data[i].probe_offset[0] = cascades[i].position.x / probe_divisor;
+		cascade_data[i].probe_offset[1] = cascades[i].position.y / probe_divisor;
+		cascade_data[i].probe_offset[2] = cascades[i].position.z / probe_divisor;
+		cascade_data[i].pad = 0;
+	}
+
+	RD::get_singleton()->buffer_update(cascades_ubo, 0, sizeof(SDFGI::Cascade::UBO) * SDFGI::MAX_CASCADES, cascade_data, RD::BARRIER_MASK_COMPUTE);
+}
+
+void RendererSceneGIRD::SDFGI::debug_draw(const CameraMatrix &p_projection, const Transform &p_transform, int p_width, int p_height, RID p_render_target, RID p_texture) {
+	// !BAS! Need to find a nicer way then adding width/height/renderbuffer/texture as parameters
+
+	if (!debug_uniform_set.is_valid() || !RD::get_singleton()->uniform_set_is_valid(debug_uniform_set)) {
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.binding = 1;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t i = 0; i < SDFGI::MAX_CASCADES; i++) {
+				if (i < cascades.size()) {
+					u.ids.push_back(cascades[i].sdf_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 2;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t i = 0; i < SDFGI::MAX_CASCADES; i++) {
+				if (i < cascades.size()) {
+					u.ids.push_back(cascades[i].light_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 3;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t i = 0; i < SDFGI::MAX_CASCADES; i++) {
+				if (i < cascades.size()) {
+					u.ids.push_back(cascades[i].light_aniso_0_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 4;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t i = 0; i < SDFGI::MAX_CASCADES; i++) {
+				if (i < cascades.size()) {
+					u.ids.push_back(cascades[i].light_aniso_1_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 5;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.ids.push_back(occlusion_texture);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 8;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 9;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.ids.push_back(cascades_ubo);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 10;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.ids.push_back(p_texture);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 11;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.ids.push_back(lightprobe_texture);
+			uniforms.push_back(u);
+		}
+		debug_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.debug_shader_version, 0);
+	}
+
+	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.debug_pipeline);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, debug_uniform_set, 0);
+
+	SDGIShader::DebugPushConstant push_constant;
+	push_constant.grid_size[0] = cascade_size;
+	push_constant.grid_size[1] = cascade_size;
+	push_constant.grid_size[2] = cascade_size;
+	push_constant.max_cascades = cascades.size();
+	push_constant.screen_size[0] = p_width;
+	push_constant.screen_size[1] = p_height;
+	push_constant.probe_axis_size = probe_axis_count;
+	push_constant.use_occlusion = uses_occlusion;
+	push_constant.y_mult = y_mult;
+
+	Vector2 vp_half = p_projection.get_viewport_half_extents();
+	push_constant.cam_extent[0] = vp_half.x;
+	push_constant.cam_extent[1] = vp_half.y;
+	push_constant.cam_extent[2] = -p_projection.get_z_near();
+
+	push_constant.cam_transform[0] = p_transform.basis.elements[0][0];
+	push_constant.cam_transform[1] = p_transform.basis.elements[1][0];
+	push_constant.cam_transform[2] = p_transform.basis.elements[2][0];
+	push_constant.cam_transform[3] = 0;
+	push_constant.cam_transform[4] = p_transform.basis.elements[0][1];
+	push_constant.cam_transform[5] = p_transform.basis.elements[1][1];
+	push_constant.cam_transform[6] = p_transform.basis.elements[2][1];
+	push_constant.cam_transform[7] = 0;
+	push_constant.cam_transform[8] = p_transform.basis.elements[0][2];
+	push_constant.cam_transform[9] = p_transform.basis.elements[1][2];
+	push_constant.cam_transform[10] = p_transform.basis.elements[2][2];
+	push_constant.cam_transform[11] = 0;
+	push_constant.cam_transform[12] = p_transform.origin.x;
+	push_constant.cam_transform[13] = p_transform.origin.y;
+	push_constant.cam_transform[14] = p_transform.origin.z;
+	push_constant.cam_transform[15] = 1;
+
+	RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::DebugPushConstant));
+
+	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_width, p_height, 1);
+	RD::get_singleton()->compute_list_end();
+
+	Size2 rtsize = storage->render_target_get_size(p_render_target);
+	storage->get_effects()->copy_to_fb_rect(p_texture, storage->render_target_get_rd_framebuffer(p_render_target), Rect2(Vector2(), rtsize), true);
+}
+
+void RendererSceneGIRD::SDFGI::debug_probes(RD::DrawListID p_draw_list, RID p_framebuffer, const CameraMatrix &p_camera_with_transform) {
+	SDGIShader::DebugProbesPushConstant push_constant;
+
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			push_constant.projection[i * 4 + j] = p_camera_with_transform.matrix[i][j];
+		}
+	}
+
+	//gen spheres from strips
+	uint32_t band_points = 16;
+	push_constant.band_power = 4;
+	push_constant.sections_in_band = ((band_points / 2) - 1);
+	push_constant.band_mask = band_points - 2;
+	push_constant.section_arc = Math_TAU / float(push_constant.sections_in_band);
+	push_constant.y_mult = y_mult;
+
+	uint32_t total_points = push_constant.sections_in_band * band_points;
+	uint32_t total_probes = probe_axis_count * probe_axis_count * probe_axis_count;
+
+	push_constant.grid_size[0] = cascade_size;
+	push_constant.grid_size[1] = cascade_size;
+	push_constant.grid_size[2] = cascade_size;
+	push_constant.cascade = 0;
+
+	push_constant.probe_axis_size = probe_axis_count;
+
+	if (!debug_probes_uniform_set.is_valid() || !RD::get_singleton()->uniform_set_is_valid(debug_probes_uniform_set)) {
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.binding = 1;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.ids.push_back(cascades_ubo);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 2;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.ids.push_back(lightprobe_texture);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 3;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 4;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.ids.push_back(occlusion_texture);
+			uniforms.push_back(u);
+		}
+
+		debug_probes_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->sdfgi_shader.debug_probes.version_get_shader(gi->sdfgi_shader.debug_probes_shader, 0), 0);
+	}
+
+	RD::get_singleton()->draw_list_bind_render_pipeline(p_draw_list, gi->sdfgi_shader.debug_probes_pipeline[SDGIShader::PROBE_DEBUG_PROBES].get_render_pipeline(RD::INVALID_FORMAT_ID, RD::get_singleton()->framebuffer_get_format(p_framebuffer)));
+	RD::get_singleton()->draw_list_bind_uniform_set(p_draw_list, debug_probes_uniform_set, 0);
+	RD::get_singleton()->draw_list_set_push_constant(p_draw_list, &push_constant, sizeof(SDGIShader::DebugProbesPushConstant));
+	RD::get_singleton()->draw_list_draw(p_draw_list, false, total_probes, total_points);
+
+	if (gi->sdfgi_debug_probe_dir != Vector3()) {
+		print_line("CLICK DEBUG ME?");
+		uint32_t cascade = 0;
+		Vector3 offset = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[cascade].position)) * cascades[cascade].cell_size * Vector3(1.0, 1.0 / y_mult, 1.0);
+		Vector3 probe_size = cascades[cascade].cell_size * (cascade_size / SDFGI::PROBE_DIVISOR) * Vector3(1.0, 1.0 / y_mult, 1.0);
+		Vector3 ray_from = gi->sdfgi_debug_probe_pos;
+		Vector3 ray_to = gi->sdfgi_debug_probe_pos + gi->sdfgi_debug_probe_dir * cascades[cascade].cell_size * Math::sqrt(3.0) * cascade_size;
+		float sphere_radius = 0.2;
+		float closest_dist = 1e20;
+		gi->sdfgi_debug_probe_enabled = false;
+
+		Vector3i probe_from = cascades[cascade].position / (cascade_size / SDFGI::PROBE_DIVISOR);
+		for (int i = 0; i < (SDFGI::PROBE_DIVISOR + 1); i++) {
+			for (int j = 0; j < (SDFGI::PROBE_DIVISOR + 1); j++) {
+				for (int k = 0; k < (SDFGI::PROBE_DIVISOR + 1); k++) {
+					Vector3 pos = offset + probe_size * Vector3(i, j, k);
+					Vector3 res;
+					if (Geometry3D::segment_intersects_sphere(ray_from, ray_to, pos, sphere_radius, &res)) {
+						float d = ray_from.distance_to(res);
+						if (d < closest_dist) {
+							closest_dist = d;
+							gi->sdfgi_debug_probe_enabled = true;
+							gi->sdfgi_debug_probe_index = probe_from + Vector3i(i, j, k);
+						}
+					}
+				}
+			}
+		}
+
+		if (gi->sdfgi_debug_probe_enabled) {
+			print_line("found: " + gi->sdfgi_debug_probe_index);
+		} else {
+			print_line("no found");
+		}
+		gi->sdfgi_debug_probe_dir = Vector3();
+	}
+
+	if (gi->sdfgi_debug_probe_enabled) {
+		uint32_t cascade = 0;
+		uint32_t probe_cells = (cascade_size / SDFGI::PROBE_DIVISOR);
+		Vector3i probe_from = cascades[cascade].position / probe_cells;
+		Vector3i ofs = gi->sdfgi_debug_probe_index - probe_from;
+		if (ofs.x < 0 || ofs.y < 0 || ofs.z < 0) {
+			return;
+		}
+		if (ofs.x > SDFGI::PROBE_DIVISOR || ofs.y > SDFGI::PROBE_DIVISOR || ofs.z > SDFGI::PROBE_DIVISOR) {
+			return;
+		}
+
+		uint32_t mult = (SDFGI::PROBE_DIVISOR + 1);
+		uint32_t index = ofs.z * mult * mult + ofs.y * mult + ofs.x;
+
+		push_constant.probe_debug_index = index;
+
+		uint32_t cell_count = probe_cells * 2 * probe_cells * 2 * probe_cells * 2;
+
+		RD::get_singleton()->draw_list_bind_render_pipeline(p_draw_list, gi->sdfgi_shader.debug_probes_pipeline[SDGIShader::PROBE_DEBUG_VISIBILITY].get_render_pipeline(RD::INVALID_FORMAT_ID, RD::get_singleton()->framebuffer_get_format(p_framebuffer)));
+		RD::get_singleton()->draw_list_bind_uniform_set(p_draw_list, debug_probes_uniform_set, 0);
+		RD::get_singleton()->draw_list_set_push_constant(p_draw_list, &push_constant, sizeof(SDGIShader::DebugProbesPushConstant));
+		RD::get_singleton()->draw_list_draw(p_draw_list, false, cell_count, total_points);
+	}
+}
+
+void RendererSceneGIRD::SDFGI::pre_process_gi(const Transform &p_transform, RendererSceneRenderRD *p_scene_render) {
+	/* Update general SDFGI Buffer */
+
+	SDFGIData sdfgi_data;
+
+	sdfgi_data.grid_size[0] = cascade_size;
+	sdfgi_data.grid_size[1] = cascade_size;
+	sdfgi_data.grid_size[2] = cascade_size;
+
+	sdfgi_data.max_cascades = cascades.size();
+	sdfgi_data.probe_axis_size = probe_axis_count;
+	sdfgi_data.cascade_probe_size[0] = sdfgi_data.probe_axis_size - 1; //float version for performance
+	sdfgi_data.cascade_probe_size[1] = sdfgi_data.probe_axis_size - 1;
+	sdfgi_data.cascade_probe_size[2] = sdfgi_data.probe_axis_size - 1;
+
+	float csize = cascade_size;
+	sdfgi_data.probe_to_uvw = 1.0 / float(sdfgi_data.cascade_probe_size[0]);
+	sdfgi_data.use_occlusion = uses_occlusion;
+	//sdfgi_data.energy = energy;
+
+	sdfgi_data.y_mult = y_mult;
+
+	float cascade_voxel_size = (csize / sdfgi_data.cascade_probe_size[0]);
+	float occlusion_clamp = (cascade_voxel_size - 0.5) / cascade_voxel_size;
+	sdfgi_data.occlusion_clamp[0] = occlusion_clamp;
+	sdfgi_data.occlusion_clamp[1] = occlusion_clamp;
+	sdfgi_data.occlusion_clamp[2] = occlusion_clamp;
+	sdfgi_data.normal_bias = (normal_bias / csize) * sdfgi_data.cascade_probe_size[0];
+
+	//vec2 tex_pixel_size = 1.0 / vec2(ivec2( (OCT_SIZE+2) * params.probe_axis_size * params.probe_axis_size, (OCT_SIZE+2) * params.probe_axis_size ) );
+	//vec3 probe_uv_offset = (ivec3(OCT_SIZE+2,OCT_SIZE+2,(OCT_SIZE+2) * params.probe_axis_size)) * tex_pixel_size.xyx;
+
+	uint32_t oct_size = SDFGI::LIGHTPROBE_OCT_SIZE;
+
+	sdfgi_data.lightprobe_tex_pixel_size[0] = 1.0 / ((oct_size + 2) * sdfgi_data.probe_axis_size * sdfgi_data.probe_axis_size);
+	sdfgi_data.lightprobe_tex_pixel_size[1] = 1.0 / ((oct_size + 2) * sdfgi_data.probe_axis_size);
+	sdfgi_data.lightprobe_tex_pixel_size[2] = 1.0;
+
+	sdfgi_data.energy = energy;
+
+	sdfgi_data.lightprobe_uv_offset[0] = float(oct_size + 2) * sdfgi_data.lightprobe_tex_pixel_size[0];
+	sdfgi_data.lightprobe_uv_offset[1] = float(oct_size + 2) * sdfgi_data.lightprobe_tex_pixel_size[1];
+	sdfgi_data.lightprobe_uv_offset[2] = float((oct_size + 2) * sdfgi_data.probe_axis_size) * sdfgi_data.lightprobe_tex_pixel_size[0];
+
+	sdfgi_data.occlusion_renormalize[0] = 0.5;
+	sdfgi_data.occlusion_renormalize[1] = 1.0;
+	sdfgi_data.occlusion_renormalize[2] = 1.0 / float(sdfgi_data.max_cascades);
+
+	int32_t probe_divisor = cascade_size / SDFGI::PROBE_DIVISOR;
+
+	for (uint32_t i = 0; i < sdfgi_data.max_cascades; i++) {
+		SDFGIData::ProbeCascadeData &c = sdfgi_data.cascades[i];
+		Vector3 pos = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[i].position)) * cascades[i].cell_size;
+		Vector3 cam_origin = p_transform.origin;
+		cam_origin.y *= y_mult;
+		pos -= cam_origin; //make pos local to camera, to reduce numerical error
+		c.position[0] = pos.x;
+		c.position[1] = pos.y;
+		c.position[2] = pos.z;
+		c.to_probe = 1.0 / (float(cascade_size) * cascades[i].cell_size / float(probe_axis_count - 1));
+
+		Vector3i probe_ofs = cascades[i].position / probe_divisor;
+		c.probe_world_offset[0] = probe_ofs.x;
+		c.probe_world_offset[1] = probe_ofs.y;
+		c.probe_world_offset[2] = probe_ofs.z;
+
+		c.to_cell = 1.0 / cascades[i].cell_size;
+	}
+
+	RD::get_singleton()->buffer_update(gi->sdfgi_ubo, 0, sizeof(SDFGIData), &sdfgi_data, RD::BARRIER_MASK_COMPUTE);
+
+	/* Update dynamic lights in SDFGI cascades */
+
+	for (uint32_t i = 0; i < cascades.size(); i++) {
+		SDFGI::Cascade &cascade = cascades[i];
+
+		SDGIShader::Light lights[SDFGI::MAX_DYNAMIC_LIGHTS];
+		uint32_t idx = 0;
+		for (uint32_t j = 0; j < (uint32_t)p_scene_render->render_state.sdfgi_update_data->directional_lights->size(); j++) {
+			if (idx == SDFGI::MAX_DYNAMIC_LIGHTS) {
+				break;
+			}
+
+			RendererSceneRenderRD::LightInstance *li = p_scene_render->light_instance_owner.getornull(p_scene_render->render_state.sdfgi_update_data->directional_lights->get(j));
+			ERR_CONTINUE(!li);
+
+			if (storage->light_directional_is_sky_only(li->light)) {
+				continue;
+			}
+
+			Vector3 dir = -li->transform.basis.get_axis(Vector3::AXIS_Z);
+			dir.y *= y_mult;
+			dir.normalize();
+			lights[idx].direction[0] = dir.x;
+			lights[idx].direction[1] = dir.y;
+			lights[idx].direction[2] = dir.z;
+			Color color = storage->light_get_color(li->light);
+			color = color.to_linear();
+			lights[idx].color[0] = color.r;
+			lights[idx].color[1] = color.g;
+			lights[idx].color[2] = color.b;
+			lights[idx].type = RS::LIGHT_DIRECTIONAL;
+			lights[idx].energy = storage->light_get_param(li->light, RS::LIGHT_PARAM_ENERGY);
+			lights[idx].has_shadow = storage->light_has_shadow(li->light);
+
+			idx++;
+		}
+
+		AABB cascade_aabb;
+		cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascade.position)) * cascade.cell_size;
+		cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cascade.cell_size;
+
+		for (uint32_t j = 0; j < p_scene_render->render_state.sdfgi_update_data->positional_light_count; j++) {
+			if (idx == SDFGI::MAX_DYNAMIC_LIGHTS) {
+				break;
+			}
+
+			RendererSceneRenderRD::LightInstance *li = p_scene_render->light_instance_owner.getornull(p_scene_render->render_state.sdfgi_update_data->positional_light_instances[j]);
+			ERR_CONTINUE(!li);
+
+			uint32_t max_sdfgi_cascade = storage->light_get_max_sdfgi_cascade(li->light);
+			if (i > max_sdfgi_cascade) {
+				continue;
+			}
+
+			if (!cascade_aabb.intersects(li->aabb)) {
+				continue;
+			}
+
+			Vector3 dir = -li->transform.basis.get_axis(Vector3::AXIS_Z);
+			//faster to not do this here
+			//dir.y *= y_mult;
+			//dir.normalize();
+			lights[idx].direction[0] = dir.x;
+			lights[idx].direction[1] = dir.y;
+			lights[idx].direction[2] = dir.z;
+			Vector3 pos = li->transform.origin;
+			pos.y *= y_mult;
+			lights[idx].position[0] = pos.x;
+			lights[idx].position[1] = pos.y;
+			lights[idx].position[2] = pos.z;
+			Color color = storage->light_get_color(li->light);
+			color = color.to_linear();
+			lights[idx].color[0] = color.r;
+			lights[idx].color[1] = color.g;
+			lights[idx].color[2] = color.b;
+			lights[idx].type = storage->light_get_type(li->light);
+			lights[idx].energy = storage->light_get_param(li->light, RS::LIGHT_PARAM_ENERGY);
+			lights[idx].has_shadow = storage->light_has_shadow(li->light);
+			lights[idx].attenuation = storage->light_get_param(li->light, RS::LIGHT_PARAM_ATTENUATION);
+			lights[idx].radius = storage->light_get_param(li->light, RS::LIGHT_PARAM_RANGE);
+			lights[idx].cos_spot_angle = Math::cos(Math::deg2rad(storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ANGLE)));
+			lights[idx].inv_spot_attenuation = 1.0f / storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ATTENUATION);
+
+			idx++;
+		}
+
+		if (idx > 0) {
+			RD::get_singleton()->buffer_update(cascade.lights_buffer, 0, idx * sizeof(SDGIShader::Light), lights, RD::BARRIER_MASK_COMPUTE);
+		}
+
+		cascade_dynamic_light_count[i] = idx;
+	}
+}
+
+void RendererSceneGIRD::SDFGI::render_region(RID p_render_buffers, int p_region, const PagedArray<RendererSceneRender::GeometryInstance *> &p_instances, RendererSceneRenderRD *p_scene_render) {
+	//print_line("rendering region " + itos(p_region));
+	RendererSceneRenderRD::RenderBuffers *rb = p_scene_render->render_buffers_owner.getornull(p_render_buffers);
+	ERR_FAIL_COND(!rb); // we wouldn't be here if this failed but...
+	AABB bounds;
+	Vector3i from;
+	Vector3i size;
+
+	int cascade_prev = get_pending_region_data(p_region - 1, from, size, bounds);
+	int cascade_next = get_pending_region_data(p_region + 1, from, size, bounds);
+	int cascade = get_pending_region_data(p_region, from, size, bounds);
+	ERR_FAIL_COND(cascade < 0);
+
+	if (cascade_prev != cascade) {
+		//initialize render
+		RD::get_singleton()->texture_clear(render_albedo, Color(0, 0, 0, 0), 0, 1, 0, 1);
+		RD::get_singleton()->texture_clear(render_emission, Color(0, 0, 0, 0), 0, 1, 0, 1);
+		RD::get_singleton()->texture_clear(render_emission_aniso, Color(0, 0, 0, 0), 0, 1, 0, 1);
+		RD::get_singleton()->texture_clear(render_geom_facing, Color(0, 0, 0, 0), 0, 1, 0, 1);
+	}
+
+	//print_line("rendering cascade " + itos(p_region) + " objects: " + itos(p_cull_count) + " bounds: " + bounds + " from: " + from + " size: " + size + " cell size: " + rtos(cascades[cascade].cell_size));
+	p_scene_render->_render_sdfgi(p_render_buffers, from, size, bounds, p_instances, render_albedo, render_emission, render_emission_aniso, render_geom_facing);
+
+	if (cascade_next != cascade) {
+		RD::get_singleton()->draw_command_begin_label("SDFGI Pre-Process Cascade");
+
+		RENDER_TIMESTAMP(">SDFGI Update SDF");
+		//done rendering! must update SDF
+		//clear dispatch indirect data
+
+		SDGIShader::PreprocessPushConstant push_constant;
+		zeromem(&push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+
+		RENDER_TIMESTAMP("Scroll SDF");
+
+		//scroll
+		if (cascades[cascade].dirty_regions != SDFGI::Cascade::DIRTY_ALL) {
+			//for scroll
+			Vector3i dirty = cascades[cascade].dirty_regions;
+			push_constant.scroll[0] = dirty.x;
+			push_constant.scroll[1] = dirty.y;
+			push_constant.scroll[2] = dirty.z;
+		} else {
+			//for no scroll
+			push_constant.scroll[0] = 0;
+			push_constant.scroll[1] = 0;
+			push_constant.scroll[2] = 0;
+		}
+
+		cascades[cascade].all_dynamic_lights_dirty = true;
+
+		push_constant.grid_size = cascade_size;
+		push_constant.cascade = cascade;
+
+		if (cascades[cascade].dirty_regions != SDFGI::Cascade::DIRTY_ALL) {
+			RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+
+			//must pre scroll existing data because not all is dirty
+			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_SCROLL]);
+			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cascades[cascade].scroll_uniform_set, 0);
+
+			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+			RD::get_singleton()->compute_list_dispatch_indirect(compute_list, cascades[cascade].solid_cell_dispatch_buffer, 0);
+			// no barrier do all together
+
+			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_SCROLL_OCCLUSION]);
+			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cascades[cascade].scroll_occlusion_uniform_set, 0);
+
+			Vector3i dirty = cascades[cascade].dirty_regions;
+			Vector3i groups;
+			groups.x = cascade_size - ABS(dirty.x);
+			groups.y = cascade_size - ABS(dirty.y);
+			groups.z = cascade_size - ABS(dirty.z);
+
+			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+			RD::get_singleton()->compute_list_dispatch_threads(compute_list, groups.x, groups.y, groups.z);
+
+			//no barrier, continue together
+
+			{
+				//scroll probes and their history also
+
+				SDGIShader::IntegratePushConstant ipush_constant;
+				ipush_constant.grid_size[1] = cascade_size;
+				ipush_constant.grid_size[2] = cascade_size;
+				ipush_constant.grid_size[0] = cascade_size;
+				ipush_constant.max_cascades = cascades.size();
+				ipush_constant.probe_axis_size = probe_axis_count;
+				ipush_constant.history_index = 0;
+				ipush_constant.history_size = history_size;
+				ipush_constant.ray_count = 0;
+				ipush_constant.ray_bias = 0;
+				ipush_constant.sky_mode = 0;
+				ipush_constant.sky_energy = 0;
+				ipush_constant.sky_color[0] = 0;
+				ipush_constant.sky_color[1] = 0;
+				ipush_constant.sky_color[2] = 0;
+				ipush_constant.y_mult = y_mult;
+				ipush_constant.store_ambient_texture = false;
+
+				ipush_constant.image_size[0] = probe_axis_count * probe_axis_count;
+				ipush_constant.image_size[1] = probe_axis_count;
+
+				int32_t probe_divisor = cascade_size / SDFGI::PROBE_DIVISOR;
+				ipush_constant.cascade = cascade;
+				ipush_constant.world_offset[0] = cascades[cascade].position.x / probe_divisor;
+				ipush_constant.world_offset[1] = cascades[cascade].position.y / probe_divisor;
+				ipush_constant.world_offset[2] = cascades[cascade].position.z / probe_divisor;
+
+				ipush_constant.scroll[0] = dirty.x / probe_divisor;
+				ipush_constant.scroll[1] = dirty.y / probe_divisor;
+				ipush_constant.scroll[2] = dirty.z / probe_divisor;
+
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.integrate_pipeline[SDGIShader::INTEGRATE_MODE_SCROLL]);
+				RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cascades[cascade].integrate_uniform_set, 0);
+				RD::get_singleton()->compute_list_bind_uniform_set(compute_list, gi->sdfgi_shader.integrate_default_sky_uniform_set, 1);
+				RD::get_singleton()->compute_list_set_push_constant(compute_list, &ipush_constant, sizeof(SDGIShader::IntegratePushConstant));
+				RD::get_singleton()->compute_list_dispatch_threads(compute_list, probe_axis_count * probe_axis_count, probe_axis_count, 1);
+
+				RD::get_singleton()->compute_list_add_barrier(compute_list);
+
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.integrate_pipeline[SDGIShader::INTEGRATE_MODE_SCROLL_STORE]);
+				RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cascades[cascade].integrate_uniform_set, 0);
+				RD::get_singleton()->compute_list_bind_uniform_set(compute_list, gi->sdfgi_shader.integrate_default_sky_uniform_set, 1);
+				RD::get_singleton()->compute_list_set_push_constant(compute_list, &ipush_constant, sizeof(SDGIShader::IntegratePushConstant));
+				RD::get_singleton()->compute_list_dispatch_threads(compute_list, probe_axis_count * probe_axis_count, probe_axis_count, 1);
+
+				RD::get_singleton()->compute_list_add_barrier(compute_list);
+
+				if (bounce_feedback > 0.0) {
+					//multibounce requires this to be stored so direct light can read from it
+
+					RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.integrate_pipeline[SDGIShader::INTEGRATE_MODE_STORE]);
+
+					//convert to octahedral to store
+					ipush_constant.image_size[0] *= SDFGI::LIGHTPROBE_OCT_SIZE;
+					ipush_constant.image_size[1] *= SDFGI::LIGHTPROBE_OCT_SIZE;
+
+					RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cascades[cascade].integrate_uniform_set, 0);
+					RD::get_singleton()->compute_list_bind_uniform_set(compute_list, gi->sdfgi_shader.integrate_default_sky_uniform_set, 1);
+					RD::get_singleton()->compute_list_set_push_constant(compute_list, &ipush_constant, sizeof(SDGIShader::IntegratePushConstant));
+					RD::get_singleton()->compute_list_dispatch_threads(compute_list, probe_axis_count * probe_axis_count * SDFGI::LIGHTPROBE_OCT_SIZE, probe_axis_count * SDFGI::LIGHTPROBE_OCT_SIZE, 1);
+				}
+			}
+
+			//ok finally barrier
+			RD::get_singleton()->compute_list_end();
+		}
+
+		//clear dispatch indirect data
+		uint32_t dispatch_indirct_data[4] = { 0, 0, 0, 0 };
+		RD::get_singleton()->buffer_update(cascades[cascade].solid_cell_dispatch_buffer, 0, sizeof(uint32_t) * 4, dispatch_indirct_data);
+
+		RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+
+		bool half_size = true; //much faster, very little difference
+		static const int optimized_jf_group_size = 8;
+
+		if (half_size) {
+			push_constant.grid_size >>= 1;
+
+			uint32_t cascade_half_size = cascade_size >> 1;
+			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_JUMP_FLOOD_INITIALIZE_HALF]);
+			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, sdf_initialize_half_uniform_set, 0);
+			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+			RD::get_singleton()->compute_list_dispatch_threads(compute_list, cascade_half_size, cascade_half_size, cascade_half_size);
+			RD::get_singleton()->compute_list_add_barrier(compute_list);
+
+			//must start with regular jumpflood
+
+			push_constant.half_size = true;
+			{
+				RENDER_TIMESTAMP("SDFGI Jump Flood (Half Size)");
+
+				uint32_t s = cascade_half_size;
+
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_JUMP_FLOOD]);
+
+				int jf_us = 0;
+				//start with regular jump flood for very coarse reads, as this is impossible to optimize
+				while (s > 1) {
+					s /= 2;
+					push_constant.step_size = s;
+					RD::get_singleton()->compute_list_bind_uniform_set(compute_list, jump_flood_half_uniform_set[jf_us], 0);
+					RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+					RD::get_singleton()->compute_list_dispatch_threads(compute_list, cascade_half_size, cascade_half_size, cascade_half_size);
+					RD::get_singleton()->compute_list_add_barrier(compute_list);
+					jf_us = jf_us == 0 ? 1 : 0;
+
+					if (cascade_half_size / (s / 2) >= optimized_jf_group_size) {
+						break;
+					}
+				}
+
+				RENDER_TIMESTAMP("SDFGI Jump Flood Optimized (Half Size)");
+
+				//continue with optimized jump flood for smaller reads
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_JUMP_FLOOD_OPTIMIZED]);
+				while (s > 1) {
+					s /= 2;
+					push_constant.step_size = s;
+					RD::get_singleton()->compute_list_bind_uniform_set(compute_list, jump_flood_half_uniform_set[jf_us], 0);
+					RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+					RD::get_singleton()->compute_list_dispatch_threads(compute_list, cascade_half_size, cascade_half_size, cascade_half_size);
+					RD::get_singleton()->compute_list_add_barrier(compute_list);
+					jf_us = jf_us == 0 ? 1 : 0;
+				}
+			}
+
+			// restore grid size for last passes
+			push_constant.grid_size = cascade_size;
+
+			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_JUMP_FLOOD_UPSCALE]);
+			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, sdf_upscale_uniform_set, 0);
+			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+			RD::get_singleton()->compute_list_dispatch_threads(compute_list, cascade_size, cascade_size, cascade_size);
+			RD::get_singleton()->compute_list_add_barrier(compute_list);
+
+			//run one pass of fullsize jumpflood to fix up half size arctifacts
+
+			push_constant.half_size = false;
+			push_constant.step_size = 1;
+			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_JUMP_FLOOD_OPTIMIZED]);
+			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, jump_flood_uniform_set[upscale_jfa_uniform_set_index], 0);
+			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+			RD::get_singleton()->compute_list_dispatch_threads(compute_list, cascade_size, cascade_size, cascade_size);
+			RD::get_singleton()->compute_list_add_barrier(compute_list);
+
+		} else {
+			//full size jumpflood
+			RENDER_TIMESTAMP("SDFGI Jump Flood");
+
+			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_JUMP_FLOOD_INITIALIZE]);
+			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, sdf_initialize_uniform_set, 0);
+			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+			RD::get_singleton()->compute_list_dispatch_threads(compute_list, cascade_size, cascade_size, cascade_size);
+
+			RD::get_singleton()->compute_list_add_barrier(compute_list);
+
+			push_constant.half_size = false;
+			{
+				uint32_t s = cascade_size;
+
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_JUMP_FLOOD]);
+
+				int jf_us = 0;
+				//start with regular jump flood for very coarse reads, as this is impossible to optimize
+				while (s > 1) {
+					s /= 2;
+					push_constant.step_size = s;
+					RD::get_singleton()->compute_list_bind_uniform_set(compute_list, jump_flood_uniform_set[jf_us], 0);
+					RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+					RD::get_singleton()->compute_list_dispatch_threads(compute_list, cascade_size, cascade_size, cascade_size);
+					RD::get_singleton()->compute_list_add_barrier(compute_list);
+					jf_us = jf_us == 0 ? 1 : 0;
+
+					if (cascade_size / (s / 2) >= optimized_jf_group_size) {
+						break;
+					}
+				}
+
+				RENDER_TIMESTAMP("SDFGI Jump Flood Optimized");
+
+				//continue with optimized jump flood for smaller reads
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_JUMP_FLOOD_OPTIMIZED]);
+				while (s > 1) {
+					s /= 2;
+					push_constant.step_size = s;
+					RD::get_singleton()->compute_list_bind_uniform_set(compute_list, jump_flood_uniform_set[jf_us], 0);
+					RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+					RD::get_singleton()->compute_list_dispatch_threads(compute_list, cascade_size, cascade_size, cascade_size);
+					RD::get_singleton()->compute_list_add_barrier(compute_list);
+					jf_us = jf_us == 0 ? 1 : 0;
+				}
+			}
+		}
+
+		RENDER_TIMESTAMP("SDFGI Occlusion");
+
+		// occlusion
+		{
+			uint32_t probe_size = cascade_size / SDFGI::PROBE_DIVISOR;
+			Vector3i probe_global_pos = cascades[cascade].position / probe_size;
+
+			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_OCCLUSION]);
+			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, occlusion_uniform_set, 0);
+			for (int i = 0; i < 8; i++) {
+				//dispatch all at once for performance
+				Vector3i offset(i & 1, (i >> 1) & 1, (i >> 2) & 1);
+
+				if ((probe_global_pos.x & 1) != 0) {
+					offset.x = (offset.x + 1) & 1;
+				}
+				if ((probe_global_pos.y & 1) != 0) {
+					offset.y = (offset.y + 1) & 1;
+				}
+				if ((probe_global_pos.z & 1) != 0) {
+					offset.z = (offset.z + 1) & 1;
+				}
+				push_constant.probe_offset[0] = offset.x;
+				push_constant.probe_offset[1] = offset.y;
+				push_constant.probe_offset[2] = offset.z;
+				push_constant.occlusion_index = i;
+				RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+
+				Vector3i groups = Vector3i(probe_size + 1, probe_size + 1, probe_size + 1) - offset; //if offset, it's one less probe per axis to compute
+				RD::get_singleton()->compute_list_dispatch(compute_list, groups.x, groups.y, groups.z);
+			}
+			RD::get_singleton()->compute_list_add_barrier(compute_list);
+		}
+
+		RENDER_TIMESTAMP("SDFGI Store");
+
+		// store
+		RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.preprocess_pipeline[SDGIShader::PRE_PROCESS_STORE]);
+		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cascades[cascade].sdf_store_uniform_set, 0);
+		RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDGIShader::PreprocessPushConstant));
+		RD::get_singleton()->compute_list_dispatch_threads(compute_list, cascade_size, cascade_size, cascade_size);
+
+		RD::get_singleton()->compute_list_end();
+
+		//clear these textures, as they will have previous garbage on next draw
+		RD::get_singleton()->texture_clear(cascades[cascade].light_tex, Color(0, 0, 0, 0), 0, 1, 0, 1);
+		RD::get_singleton()->texture_clear(cascades[cascade].light_aniso_0_tex, Color(0, 0, 0, 0), 0, 1, 0, 1);
+		RD::get_singleton()->texture_clear(cascades[cascade].light_aniso_1_tex, Color(0, 0, 0, 0), 0, 1, 0, 1);
+
+#if 0
+		Vector<uint8_t> data = RD::get_singleton()->texture_get_data(cascades[cascade].sdf, 0);
+		Ref<Image> img;
+		img.instance();
+		for (uint32_t i = 0; i < cascade_size; i++) {
+			Vector<uint8_t> subarr = data.subarray(128 * 128 * i, 128 * 128 * (i + 1) - 1);
+			img->create(cascade_size, cascade_size, false, Image::FORMAT_L8, subarr);
+			img->save_png("res://cascade_sdf_" + itos(cascade) + "_" + itos(i) + ".png");
+		}
+
+		//finalize render and update sdf
+#endif
+
+#if 0
+		Vector<uint8_t> data = RD::get_singleton()->texture_get_data(render_albedo, 0);
+		Ref<Image> img;
+		img.instance();
+		for (uint32_t i = 0; i < cascade_size; i++) {
+			Vector<uint8_t> subarr = data.subarray(128 * 128 * i * 2, 128 * 128 * (i + 1) * 2 - 1);
+			img->createcascade_size, cascade_size, false, Image::FORMAT_RGB565, subarr);
+			img->convert(Image::FORMAT_RGBA8);
+			img->save_png("res://cascade_" + itos(cascade) + "_" + itos(i) + ".png");
+		}
+
+		//finalize render and update sdf
+#endif
+
+		RENDER_TIMESTAMP("<SDFGI Update SDF");
+		RD::get_singleton()->draw_command_end_label();
+	}
+}
+
+void RendererSceneGIRD::SDFGI::render_static_lights(RID p_render_buffers, uint32_t p_cascade_count, const uint32_t *p_cascade_indices, const PagedArray<RID> *p_positional_light_cull_result, RendererSceneRenderRD *p_scene_render) {
+	RendererSceneRenderRD::RenderBuffers *rb = p_scene_render->render_buffers_owner.getornull(p_render_buffers);
+	ERR_FAIL_COND(!rb); // we wouldn't be here if this failed but...
+
+	RD::get_singleton()->draw_command_begin_label("SDFGI Render Static Lighs");
+
+	update_cascades();
+	; //need cascades updated for this
+
+	SDGIShader::Light lights[SDFGI::MAX_STATIC_LIGHTS];
+	uint32_t light_count[SDFGI::MAX_STATIC_LIGHTS];
+
+	for (uint32_t i = 0; i < p_cascade_count; i++) {
+		ERR_CONTINUE(p_cascade_indices[i] >= cascades.size());
+
+		SDFGI::Cascade &cc = cascades[p_cascade_indices[i]];
+
+		{ //fill light buffer
+
+			AABB cascade_aabb;
+			cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cc.position)) * cc.cell_size;
+			cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cc.cell_size;
+
+			int idx = 0;
+
+			for (uint32_t j = 0; j < (uint32_t)p_positional_light_cull_result[i].size(); j++) {
+				if (idx == SDFGI::MAX_STATIC_LIGHTS) {
+					break;
+				}
+
+				RendererSceneRenderRD::LightInstance *li = p_scene_render->light_instance_owner.getornull(p_positional_light_cull_result[i][j]);
+				ERR_CONTINUE(!li);
+
+				uint32_t max_sdfgi_cascade = storage->light_get_max_sdfgi_cascade(li->light);
+				if (p_cascade_indices[i] > max_sdfgi_cascade) {
+					continue;
+				}
+
+				if (!cascade_aabb.intersects(li->aabb)) {
+					continue;
+				}
+
+				lights[idx].type = storage->light_get_type(li->light);
+
+				Vector3 dir = -li->transform.basis.get_axis(Vector3::AXIS_Z);
+				if (lights[idx].type == RS::LIGHT_DIRECTIONAL) {
+					dir.y *= y_mult; //only makes sense for directional
+					dir.normalize();
+				}
+				lights[idx].direction[0] = dir.x;
+				lights[idx].direction[1] = dir.y;
+				lights[idx].direction[2] = dir.z;
+				Vector3 pos = li->transform.origin;
+				pos.y *= y_mult;
+				lights[idx].position[0] = pos.x;
+				lights[idx].position[1] = pos.y;
+				lights[idx].position[2] = pos.z;
+				Color color = storage->light_get_color(li->light);
+				color = color.to_linear();
+				lights[idx].color[0] = color.r;
+				lights[idx].color[1] = color.g;
+				lights[idx].color[2] = color.b;
+				lights[idx].energy = storage->light_get_param(li->light, RS::LIGHT_PARAM_ENERGY);
+				lights[idx].has_shadow = storage->light_has_shadow(li->light);
+				lights[idx].attenuation = storage->light_get_param(li->light, RS::LIGHT_PARAM_ATTENUATION);
+				lights[idx].radius = storage->light_get_param(li->light, RS::LIGHT_PARAM_RANGE);
+				lights[idx].cos_spot_angle = Math::cos(Math::deg2rad(storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ANGLE)));
+				lights[idx].inv_spot_attenuation = 1.0f / storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ATTENUATION);
+
+				idx++;
+			}
+
+			if (idx > 0) {
+				RD::get_singleton()->buffer_update(cc.lights_buffer, 0, idx * sizeof(SDGIShader::Light), lights);
+			}
+
+			light_count[i] = idx;
+		}
+	}
+
+	/* Static Lights */
+	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+
+	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->sdfgi_shader.direct_light_pipeline[SDGIShader::DIRECT_LIGHT_MODE_STATIC]);
+
+	SDGIShader::DirectLightPushConstant dl_push_constant;
+
+	dl_push_constant.grid_size[0] = cascade_size;
+	dl_push_constant.grid_size[1] = cascade_size;
+	dl_push_constant.grid_size[2] = cascade_size;
+	dl_push_constant.max_cascades = cascades.size();
+	dl_push_constant.probe_axis_size = probe_axis_count;
+	dl_push_constant.bounce_feedback = 0.0; // this is static light, do not multibounce yet
+	dl_push_constant.y_mult = y_mult;
+	dl_push_constant.use_occlusion = uses_occlusion;
+
+	//all must be processed
+	dl_push_constant.process_offset = 0;
+	dl_push_constant.process_increment = 1;
+
+	for (uint32_t i = 0; i < p_cascade_count; i++) {
+		ERR_CONTINUE(p_cascade_indices[i] >= cascades.size());
+
+		SDFGI::Cascade &cc = cascades[p_cascade_indices[i]];
+
+		dl_push_constant.light_count = light_count[i];
+		dl_push_constant.cascade = p_cascade_indices[i];
+
+		if (dl_push_constant.light_count > 0) {
+			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, cc.sdf_direct_light_uniform_set, 0);
+			RD::get_singleton()->compute_list_set_push_constant(compute_list, &dl_push_constant, sizeof(SDGIShader::DirectLightPushConstant));
+			RD::get_singleton()->compute_list_dispatch_indirect(compute_list, cc.solid_cell_dispatch_buffer, 0);
+		}
+	}
+
+	RD::get_singleton()->compute_list_end();
+
+	RD::get_singleton()->draw_command_end_label();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// GIProbeInstance
+
+void RendererSceneGIRD::GIProbeInstance::update(bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RendererSceneRender::GeometryInstance *> &p_dynamic_objects, RendererSceneRenderRD *p_scene_render) {
+	uint32_t data_version = storage->gi_probe_get_data_version(probe);
+
+	// (RE)CREATE IF NEEDED
+
+	if (last_probe_data_version != data_version) {
+		//need to re-create everything
+		if (texture.is_valid()) {
+			RD::get_singleton()->free(texture);
+			RD::get_singleton()->free(write_buffer);
+			mipmaps.clear();
+		}
+
+		for (int i = 0; i < dynamic_maps.size(); i++) {
+			RD::get_singleton()->free(dynamic_maps[i].texture);
+			RD::get_singleton()->free(dynamic_maps[i].depth);
+		}
+
+		dynamic_maps.clear();
+
+		Vector3i octree_size = storage->gi_probe_get_octree_size(probe);
+
+		if (octree_size != Vector3i()) {
+			//can create a 3D texture
+			Vector<int> levels = storage->gi_probe_get_level_counts(probe);
+
+			RD::TextureFormat tf;
+			tf.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+			tf.width = octree_size.x;
+			tf.height = octree_size.y;
+			tf.depth = octree_size.z;
+			tf.texture_type = RD::TEXTURE_TYPE_3D;
+			tf.mipmaps = levels.size();
+
+			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+
+			texture = RD::get_singleton()->texture_create(tf, RD::TextureView());
+
+			RD::get_singleton()->texture_clear(texture, Color(0, 0, 0, 0), 0, levels.size(), 0, 1);
+
+			{
+				int total_elements = 0;
+				for (int i = 0; i < levels.size(); i++) {
+					total_elements += levels[i];
+				}
+
+				write_buffer = RD::get_singleton()->storage_buffer_create(total_elements * 16);
+			}
+
+			for (int i = 0; i < levels.size(); i++) {
+				GIProbeInstance::Mipmap mipmap;
+				mipmap.texture = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), texture, 0, i, RD::TEXTURE_SLICE_3D);
+				mipmap.level = levels.size() - i - 1;
+				mipmap.cell_offset = 0;
+				for (uint32_t j = 0; j < mipmap.level; j++) {
+					mipmap.cell_offset += levels[j];
+				}
+				mipmap.cell_count = levels[mipmap.level];
+
+				Vector<RD::Uniform> uniforms;
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.binding = 1;
+					u.ids.push_back(storage->gi_probe_get_octree_buffer(probe));
+					uniforms.push_back(u);
+				}
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.binding = 2;
+					u.ids.push_back(storage->gi_probe_get_data_buffer(probe));
+					uniforms.push_back(u);
+				}
+
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.binding = 4;
+					u.ids.push_back(write_buffer);
+					uniforms.push_back(u);
+				}
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+					u.binding = 9;
+					u.ids.push_back(storage->gi_probe_get_sdf_texture(probe));
+					uniforms.push_back(u);
+				}
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+					u.binding = 10;
+					u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+					uniforms.push_back(u);
+				}
+
+				{
+					Vector<RD::Uniform> copy_uniforms = uniforms;
+					if (i == 0) {
+						{
+							RD::Uniform u;
+							u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+							u.binding = 3;
+							u.ids.push_back(gi->gi_probe_lights_uniform);
+							copy_uniforms.push_back(u);
+						}
+
+						mipmap.uniform_set = RD::get_singleton()->uniform_set_create(copy_uniforms, gi->giprobe_lighting_shader_version_shaders[GI_PROBE_SHADER_VERSION_COMPUTE_LIGHT], 0);
+
+						copy_uniforms = uniforms; //restore
+
+						{
+							RD::Uniform u;
+							u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+							u.binding = 5;
+							u.ids.push_back(texture);
+							copy_uniforms.push_back(u);
+						}
+						mipmap.second_bounce_uniform_set = RD::get_singleton()->uniform_set_create(copy_uniforms, gi->giprobe_lighting_shader_version_shaders[GI_PROBE_SHADER_VERSION_COMPUTE_SECOND_BOUNCE], 0);
+					} else {
+						mipmap.uniform_set = RD::get_singleton()->uniform_set_create(copy_uniforms, gi->giprobe_lighting_shader_version_shaders[GI_PROBE_SHADER_VERSION_COMPUTE_MIPMAP], 0);
+					}
+				}
+
+				{
+					RD::Uniform u;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+					u.binding = 5;
+					u.ids.push_back(mipmap.texture);
+					uniforms.push_back(u);
+				}
+
+				mipmap.write_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->giprobe_lighting_shader_version_shaders[GI_PROBE_SHADER_VERSION_WRITE_TEXTURE], 0);
+
+				mipmaps.push_back(mipmap);
+			}
+
+			{
+				uint32_t dynamic_map_size = MAX(MAX(octree_size.x, octree_size.y), octree_size.z);
+				uint32_t oversample = nearest_power_of_2_templated(4);
+				int mipmap_index = 0;
+
+				while (mipmap_index < mipmaps.size()) {
+					GIProbeInstance::DynamicMap dmap;
+
+					if (oversample > 0) {
+						dmap.size = dynamic_map_size * (1 << oversample);
+						dmap.mipmap = -1;
+						oversample--;
+					} else {
+						dmap.size = dynamic_map_size >> mipmap_index;
+						dmap.mipmap = mipmap_index;
+						mipmap_index++;
+					}
+
+					RD::TextureFormat dtf;
+					dtf.width = dmap.size;
+					dtf.height = dmap.size;
+					dtf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+					dtf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT;
+
+					if (dynamic_maps.size() == 0) {
+						dtf.usage_bits |= RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+					}
+					dmap.texture = RD::get_singleton()->texture_create(dtf, RD::TextureView());
+
+					if (dynamic_maps.size() == 0) {
+						//render depth for first one
+						dtf.format = RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_D32_SFLOAT, RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ? RD::DATA_FORMAT_D32_SFLOAT : RD::DATA_FORMAT_X8_D24_UNORM_PACK32;
+						dtf.usage_bits = RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+						dmap.fb_depth = RD::get_singleton()->texture_create(dtf, RD::TextureView());
+					}
+
+					//just use depth as-is
+					dtf.format = RD::DATA_FORMAT_R32_SFLOAT;
+					dtf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+
+					dmap.depth = RD::get_singleton()->texture_create(dtf, RD::TextureView());
+
+					if (dynamic_maps.size() == 0) {
+						dtf.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+						dtf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+						dmap.albedo = RD::get_singleton()->texture_create(dtf, RD::TextureView());
+						dmap.normal = RD::get_singleton()->texture_create(dtf, RD::TextureView());
+						dmap.orm = RD::get_singleton()->texture_create(dtf, RD::TextureView());
+
+						Vector<RID> fb;
+						fb.push_back(dmap.albedo);
+						fb.push_back(dmap.normal);
+						fb.push_back(dmap.orm);
+						fb.push_back(dmap.texture); //emission
+						fb.push_back(dmap.depth);
+						fb.push_back(dmap.fb_depth);
+
+						dmap.fb = RD::get_singleton()->framebuffer_create(fb);
+
+						{
+							Vector<RD::Uniform> uniforms;
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+								u.binding = 3;
+								u.ids.push_back(gi->gi_probe_lights_uniform);
+								uniforms.push_back(u);
+							}
+
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+								u.binding = 5;
+								u.ids.push_back(dmap.albedo);
+								uniforms.push_back(u);
+							}
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+								u.binding = 6;
+								u.ids.push_back(dmap.normal);
+								uniforms.push_back(u);
+							}
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+								u.binding = 7;
+								u.ids.push_back(dmap.orm);
+								uniforms.push_back(u);
+							}
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+								u.binding = 8;
+								u.ids.push_back(dmap.fb_depth);
+								uniforms.push_back(u);
+							}
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+								u.binding = 9;
+								u.ids.push_back(storage->gi_probe_get_sdf_texture(probe));
+								uniforms.push_back(u);
+							}
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+								u.binding = 10;
+								u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+								uniforms.push_back(u);
+							}
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+								u.binding = 11;
+								u.ids.push_back(dmap.texture);
+								uniforms.push_back(u);
+							}
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+								u.binding = 12;
+								u.ids.push_back(dmap.depth);
+								uniforms.push_back(u);
+							}
+
+							dmap.uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->giprobe_lighting_shader_version_shaders[GI_PROBE_SHADER_VERSION_DYNAMIC_OBJECT_LIGHTING], 0);
+						}
+					} else {
+						bool plot = dmap.mipmap >= 0;
+						bool write = dmap.mipmap < (mipmaps.size() - 1);
+
+						Vector<RD::Uniform> uniforms;
+
+						{
+							RD::Uniform u;
+							u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+							u.binding = 5;
+							u.ids.push_back(dynamic_maps[dynamic_maps.size() - 1].texture);
+							uniforms.push_back(u);
+						}
+						{
+							RD::Uniform u;
+							u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+							u.binding = 6;
+							u.ids.push_back(dynamic_maps[dynamic_maps.size() - 1].depth);
+							uniforms.push_back(u);
+						}
+
+						if (write) {
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+								u.binding = 7;
+								u.ids.push_back(dmap.texture);
+								uniforms.push_back(u);
+							}
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+								u.binding = 8;
+								u.ids.push_back(dmap.depth);
+								uniforms.push_back(u);
+							}
+						}
+
+						{
+							RD::Uniform u;
+							u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+							u.binding = 9;
+							u.ids.push_back(storage->gi_probe_get_sdf_texture(probe));
+							uniforms.push_back(u);
+						}
+						{
+							RD::Uniform u;
+							u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+							u.binding = 10;
+							u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+							uniforms.push_back(u);
+						}
+
+						if (plot) {
+							{
+								RD::Uniform u;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+								u.binding = 11;
+								u.ids.push_back(mipmaps[dmap.mipmap].texture);
+								uniforms.push_back(u);
+							}
+						}
+
+						dmap.uniform_set = RD::get_singleton()->uniform_set_create(
+								uniforms,
+								gi->giprobe_lighting_shader_version_shaders[(write && plot) ? GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_WRITE_PLOT : (write ? GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_WRITE : GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_PLOT)],
+								0);
+					}
+
+					dynamic_maps.push_back(dmap);
+				}
+			}
+		}
+
+		last_probe_data_version = data_version;
+		p_update_light_instances = true; //just in case
+
+		p_scene_render->_base_uniforms_changed();
+	}
+
+	// UDPDATE TIME
+
+	if (has_dynamic_object_data) {
+		//if it has dynamic object data, it needs to be cleared
+		RD::get_singleton()->texture_clear(texture, Color(0, 0, 0, 0), 0, mipmaps.size(), 0, 1);
+	}
+
+	uint32_t light_count = 0;
+
+	if (p_update_light_instances || p_dynamic_objects.size() > 0) {
+		light_count = MIN(gi->gi_probe_max_lights, (uint32_t)p_light_instances.size());
+
+		{
+			Transform to_cell = storage->gi_probe_get_to_cell_xform(probe);
+			Transform to_probe_xform = (transform * to_cell.affine_inverse()).affine_inverse();
+			//update lights
+
+			for (uint32_t i = 0; i < light_count; i++) {
+				GIProbeLight &l = gi->gi_probe_lights[i];
+				RID light_instance = p_light_instances[i];
+				RID light = p_scene_render->light_instance_get_base_light(light_instance);
+
+				l.type = storage->light_get_type(light);
+				if (l.type == RS::LIGHT_DIRECTIONAL && storage->light_directional_is_sky_only(light)) {
+					light_count--;
+					continue;
+				}
+
+				l.attenuation = storage->light_get_param(light, RS::LIGHT_PARAM_ATTENUATION);
+				l.energy = storage->light_get_param(light, RS::LIGHT_PARAM_ENERGY) * storage->light_get_param(light, RS::LIGHT_PARAM_INDIRECT_ENERGY);
+				l.radius = to_cell.basis.xform(Vector3(storage->light_get_param(light, RS::LIGHT_PARAM_RANGE), 0, 0)).length();
+				Color color = storage->light_get_color(light).to_linear();
+				l.color[0] = color.r;
+				l.color[1] = color.g;
+				l.color[2] = color.b;
+
+				l.cos_spot_angle = Math::cos(Math::deg2rad(storage->light_get_param(light, RS::LIGHT_PARAM_SPOT_ANGLE)));
+				l.inv_spot_attenuation = 1.0f / storage->light_get_param(light, RS::LIGHT_PARAM_SPOT_ATTENUATION);
+
+				Transform xform = p_scene_render->light_instance_get_base_transform(light_instance);
+
+				Vector3 pos = to_probe_xform.xform(xform.origin);
+				Vector3 dir = to_probe_xform.basis.xform(-xform.basis.get_axis(2)).normalized();
+
+				l.position[0] = pos.x;
+				l.position[1] = pos.y;
+				l.position[2] = pos.z;
+
+				l.direction[0] = dir.x;
+				l.direction[1] = dir.y;
+				l.direction[2] = dir.z;
+
+				l.has_shadow = storage->light_has_shadow(light);
+			}
+
+			RD::get_singleton()->buffer_update(gi->gi_probe_lights_uniform, 0, sizeof(GIProbeLight) * light_count, gi->gi_probe_lights);
+		}
+	}
+
+	if (has_dynamic_object_data || p_update_light_instances || p_dynamic_objects.size()) {
+		// PROCESS MIPMAPS
+		if (mipmaps.size()) {
+			//can update mipmaps
+
+			Vector3i probe_size = storage->gi_probe_get_octree_size(probe);
+
+			GIProbePushConstant push_constant;
+
+			push_constant.limits[0] = probe_size.x;
+			push_constant.limits[1] = probe_size.y;
+			push_constant.limits[2] = probe_size.z;
+			push_constant.stack_size = mipmaps.size();
+			push_constant.emission_scale = 1.0;
+			push_constant.propagation = storage->gi_probe_get_propagation(probe);
+			push_constant.dynamic_range = storage->gi_probe_get_dynamic_range(probe);
+			push_constant.light_count = light_count;
+			push_constant.aniso_strength = 0;
+
+			/*		print_line("probe update to version " + itos(last_probe_version));
+			print_line("propagation " + rtos(push_constant.propagation));
+			print_line("dynrange " + rtos(push_constant.dynamic_range));
+	*/
+			RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+
+			int passes;
+			if (p_update_light_instances) {
+				passes = storage->gi_probe_is_using_two_bounces(probe) ? 2 : 1;
+			} else {
+				passes = 1; //only re-blitting is necessary
+			}
+			int wg_size = 64;
+			int wg_limit_x = RD::get_singleton()->limit_get(RD::LIMIT_MAX_COMPUTE_WORKGROUP_COUNT_X);
+
+			for (int pass = 0; pass < passes; pass++) {
+				if (p_update_light_instances) {
+					for (int i = 0; i < mipmaps.size(); i++) {
+						if (i == 0) {
+							RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->giprobe_lighting_shader_version_pipelines[pass == 0 ? GI_PROBE_SHADER_VERSION_COMPUTE_LIGHT : GI_PROBE_SHADER_VERSION_COMPUTE_SECOND_BOUNCE]);
+						} else if (i == 1) {
+							RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->giprobe_lighting_shader_version_pipelines[GI_PROBE_SHADER_VERSION_COMPUTE_MIPMAP]);
+						}
+
+						if (pass == 1 || i > 0) {
+							RD::get_singleton()->compute_list_add_barrier(compute_list); //wait til previous step is done
+						}
+						if (pass == 0 || i > 0) {
+							RD::get_singleton()->compute_list_bind_uniform_set(compute_list, mipmaps[i].uniform_set, 0);
+						} else {
+							RD::get_singleton()->compute_list_bind_uniform_set(compute_list, mipmaps[i].second_bounce_uniform_set, 0);
+						}
+
+						push_constant.cell_offset = mipmaps[i].cell_offset;
+						push_constant.cell_count = mipmaps[i].cell_count;
+
+						int wg_todo = (mipmaps[i].cell_count - 1) / wg_size + 1;
+						while (wg_todo) {
+							int wg_count = MIN(wg_todo, wg_limit_x);
+							RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(GIProbePushConstant));
+							RD::get_singleton()->compute_list_dispatch(compute_list, wg_count, 1, 1);
+							wg_todo -= wg_count;
+							push_constant.cell_offset += wg_count * wg_size;
+						}
+					}
+
+					RD::get_singleton()->compute_list_add_barrier(compute_list); //wait til previous step is done
+				}
+
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->giprobe_lighting_shader_version_pipelines[GI_PROBE_SHADER_VERSION_WRITE_TEXTURE]);
+
+				for (int i = 0; i < mipmaps.size(); i++) {
+					RD::get_singleton()->compute_list_bind_uniform_set(compute_list, mipmaps[i].write_uniform_set, 0);
+
+					push_constant.cell_offset = mipmaps[i].cell_offset;
+					push_constant.cell_count = mipmaps[i].cell_count;
+
+					int wg_todo = (mipmaps[i].cell_count - 1) / wg_size + 1;
+					while (wg_todo) {
+						int wg_count = MIN(wg_todo, wg_limit_x);
+						RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(GIProbePushConstant));
+						RD::get_singleton()->compute_list_dispatch(compute_list, wg_count, 1, 1);
+						wg_todo -= wg_count;
+						push_constant.cell_offset += wg_count * wg_size;
+					}
+				}
+			}
+
+			RD::get_singleton()->compute_list_end();
+		}
+	}
+
+	has_dynamic_object_data = false; //clear until dynamic object data is used again
+
+	if (p_dynamic_objects.size() && dynamic_maps.size()) {
+		Vector3i octree_size = storage->gi_probe_get_octree_size(probe);
+		int multiplier = dynamic_maps[0].size / MAX(MAX(octree_size.x, octree_size.y), octree_size.z);
+
+		Transform oversample_scale;
+		oversample_scale.basis.scale(Vector3(multiplier, multiplier, multiplier));
+
+		Transform to_cell = oversample_scale * storage->gi_probe_get_to_cell_xform(probe);
+		Transform to_world_xform = transform * to_cell.affine_inverse();
+		Transform to_probe_xform = to_world_xform.affine_inverse();
+
+		AABB probe_aabb(Vector3(), octree_size);
+
+		//this could probably be better parallelized in compute..
+		for (int i = 0; i < (int)p_dynamic_objects.size(); i++) {
+			RendererSceneRender::GeometryInstance *instance = p_dynamic_objects[i];
+
+			//transform aabb to giprobe
+			AABB aabb = (to_probe_xform * p_scene_render->geometry_instance_get_transform(instance)).xform(p_scene_render->geometry_instance_get_aabb(instance));
+
+			//this needs to wrap to grid resolution to avoid jitter
+			//also extend margin a bit just in case
+			Vector3i begin = aabb.position - Vector3i(1, 1, 1);
+			Vector3i end = aabb.position + aabb.size + Vector3i(1, 1, 1);
+
+			for (int j = 0; j < 3; j++) {
+				if ((end[j] - begin[j]) & 1) {
+					end[j]++; //for half extents split, it needs to be even
+				}
+				begin[j] = MAX(begin[j], 0);
+				end[j] = MIN(end[j], octree_size[j] * multiplier);
+			}
+
+			//aabb = aabb.intersection(probe_aabb); //intersect
+			aabb.position = begin;
+			aabb.size = end - begin;
+
+			//print_line("aabb: " + aabb);
+
+			for (int j = 0; j < 6; j++) {
+				//if (j != 0 && j != 3) {
+				//	continue;
+				//}
+				static const Vector3 render_z[6] = {
+					Vector3(1, 0, 0),
+					Vector3(0, 1, 0),
+					Vector3(0, 0, 1),
+					Vector3(-1, 0, 0),
+					Vector3(0, -1, 0),
+					Vector3(0, 0, -1),
+				};
+				static const Vector3 render_up[6] = {
+					Vector3(0, 1, 0),
+					Vector3(0, 0, 1),
+					Vector3(0, 1, 0),
+					Vector3(0, 1, 0),
+					Vector3(0, 0, 1),
+					Vector3(0, 1, 0),
+				};
+
+				Vector3 render_dir = render_z[j];
+				Vector3 up_dir = render_up[j];
+
+				Vector3 center = aabb.position + aabb.size * 0.5;
+				Transform xform;
+				xform.set_look_at(center - aabb.size * 0.5 * render_dir, center, up_dir);
+
+				Vector3 x_dir = xform.basis.get_axis(0).abs();
+				int x_axis = int(Vector3(0, 1, 2).dot(x_dir));
+				Vector3 y_dir = xform.basis.get_axis(1).abs();
+				int y_axis = int(Vector3(0, 1, 2).dot(y_dir));
+				Vector3 z_dir = -xform.basis.get_axis(2);
+				int z_axis = int(Vector3(0, 1, 2).dot(z_dir.abs()));
+
+				Rect2i rect(aabb.position[x_axis], aabb.position[y_axis], aabb.size[x_axis], aabb.size[y_axis]);
+				bool x_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_axis(0)) < 0);
+				bool y_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_axis(1)) < 0);
+				bool z_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_axis(2)) > 0);
+
+				CameraMatrix cm;
+				cm.set_orthogonal(-rect.size.width / 2, rect.size.width / 2, -rect.size.height / 2, rect.size.height / 2, 0.0001, aabb.size[z_axis]);
+
+				if (p_scene_render->cull_argument.size() == 0) {
+					p_scene_render->cull_argument.push_back(nullptr);
+				}
+				p_scene_render->cull_argument[0] = instance;
+
+				p_scene_render->_render_material(to_world_xform * xform, cm, true, p_scene_render->cull_argument, dynamic_maps[0].fb, Rect2i(Vector2i(), rect.size));
+
+				GIProbeDynamicPushConstant push_constant;
+				zeromem(&push_constant, sizeof(GIProbeDynamicPushConstant));
+				push_constant.limits[0] = octree_size.x;
+				push_constant.limits[1] = octree_size.y;
+				push_constant.limits[2] = octree_size.z;
+				push_constant.light_count = p_light_instances.size();
+				push_constant.x_dir[0] = x_dir[0];
+				push_constant.x_dir[1] = x_dir[1];
+				push_constant.x_dir[2] = x_dir[2];
+				push_constant.y_dir[0] = y_dir[0];
+				push_constant.y_dir[1] = y_dir[1];
+				push_constant.y_dir[2] = y_dir[2];
+				push_constant.z_dir[0] = z_dir[0];
+				push_constant.z_dir[1] = z_dir[1];
+				push_constant.z_dir[2] = z_dir[2];
+				push_constant.z_base = xform.origin[z_axis];
+				push_constant.z_sign = (z_flip ? -1.0 : 1.0);
+				push_constant.pos_multiplier = float(1.0) / multiplier;
+				push_constant.dynamic_range = storage->gi_probe_get_dynamic_range(probe);
+				push_constant.flip_x = x_flip;
+				push_constant.flip_y = y_flip;
+				push_constant.rect_pos[0] = rect.position[0];
+				push_constant.rect_pos[1] = rect.position[1];
+				push_constant.rect_size[0] = rect.size[0];
+				push_constant.rect_size[1] = rect.size[1];
+				push_constant.prev_rect_ofs[0] = 0;
+				push_constant.prev_rect_ofs[1] = 0;
+				push_constant.prev_rect_size[0] = 0;
+				push_constant.prev_rect_size[1] = 0;
+				push_constant.on_mipmap = false;
+				push_constant.propagation = storage->gi_probe_get_propagation(probe);
+				push_constant.pad[0] = 0;
+				push_constant.pad[1] = 0;
+				push_constant.pad[2] = 0;
+
+				//process lighting
+				RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->giprobe_lighting_shader_version_pipelines[GI_PROBE_SHADER_VERSION_DYNAMIC_OBJECT_LIGHTING]);
+				RD::get_singleton()->compute_list_bind_uniform_set(compute_list, dynamic_maps[0].uniform_set, 0);
+				RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(GIProbeDynamicPushConstant));
+				RD::get_singleton()->compute_list_dispatch(compute_list, (rect.size.x - 1) / 8 + 1, (rect.size.y - 1) / 8 + 1, 1);
+				//print_line("rect: " + itos(i) + ": " + rect);
+
+				for (int k = 1; k < dynamic_maps.size(); k++) {
+					// enlarge the rect if needed so all pixels fit when downscaled,
+					// this ensures downsampling is smooth and optimal because no pixels are left behind
+
+					//x
+					if (rect.position.x & 1) {
+						rect.size.x++;
+						push_constant.prev_rect_ofs[0] = 1; //this is used to ensure reading is also optimal
+					} else {
+						push_constant.prev_rect_ofs[0] = 0;
+					}
+					if (rect.size.x & 1) {
+						rect.size.x++;
+					}
+
+					rect.position.x >>= 1;
+					rect.size.x = MAX(1, rect.size.x >> 1);
+
+					//y
+					if (rect.position.y & 1) {
+						rect.size.y++;
+						push_constant.prev_rect_ofs[1] = 1;
+					} else {
+						push_constant.prev_rect_ofs[1] = 0;
+					}
+					if (rect.size.y & 1) {
+						rect.size.y++;
+					}
+
+					rect.position.y >>= 1;
+					rect.size.y = MAX(1, rect.size.y >> 1);
+
+					//shrink limits to ensure plot does not go outside map
+					if (dynamic_maps[k].mipmap > 0) {
+						for (int l = 0; l < 3; l++) {
+							push_constant.limits[l] = MAX(1, push_constant.limits[l] >> 1);
+						}
+					}
+
+					//print_line("rect: " + itos(i) + ": " + rect);
+					push_constant.rect_pos[0] = rect.position[0];
+					push_constant.rect_pos[1] = rect.position[1];
+					push_constant.prev_rect_size[0] = push_constant.rect_size[0];
+					push_constant.prev_rect_size[1] = push_constant.rect_size[1];
+					push_constant.rect_size[0] = rect.size[0];
+					push_constant.rect_size[1] = rect.size[1];
+					push_constant.on_mipmap = dynamic_maps[k].mipmap > 0;
+
+					RD::get_singleton()->compute_list_add_barrier(compute_list);
+
+					if (dynamic_maps[k].mipmap < 0) {
+						RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->giprobe_lighting_shader_version_pipelines[GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_WRITE]);
+					} else if (k < dynamic_maps.size() - 1) {
+						RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->giprobe_lighting_shader_version_pipelines[GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_WRITE_PLOT]);
+					} else {
+						RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, gi->giprobe_lighting_shader_version_pipelines[GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_PLOT]);
+					}
+					RD::get_singleton()->compute_list_bind_uniform_set(compute_list, dynamic_maps[k].uniform_set, 0);
+					RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(GIProbeDynamicPushConstant));
+					RD::get_singleton()->compute_list_dispatch(compute_list, (rect.size.x - 1) / 8 + 1, (rect.size.y - 1) / 8 + 1, 1);
+				}
+
+				RD::get_singleton()->compute_list_end();
+			}
+		}
+
+		has_dynamic_object_data = true; //clear until dynamic object data is used again
+	}
+
+	last_probe_version = storage->gi_probe_get_version(probe);
+}
+
+void RendererSceneGIRD::GIProbeInstance::debug(RD::DrawListID p_draw_list, RID p_framebuffer, const CameraMatrix &p_camera_with_transform, bool p_lighting, bool p_emission, float p_alpha) {
+	if (mipmaps.size() == 0) {
+		return;
+	}
+
+	CameraMatrix cam_transform = (p_camera_with_transform * CameraMatrix(transform)) * CameraMatrix(storage->gi_probe_get_to_cell_xform(probe).affine_inverse());
+
+	int level = 0;
+	Vector3i octree_size = storage->gi_probe_get_octree_size(probe);
+
+	GIProbeDebugPushConstant push_constant;
+	push_constant.alpha = p_alpha;
+	push_constant.dynamic_range = storage->gi_probe_get_dynamic_range(probe);
+	push_constant.cell_offset = mipmaps[level].cell_offset;
+	push_constant.level = level;
+
+	push_constant.bounds[0] = octree_size.x >> level;
+	push_constant.bounds[1] = octree_size.y >> level;
+	push_constant.bounds[2] = octree_size.z >> level;
+	push_constant.pad = 0;
+
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			push_constant.projection[i * 4 + j] = cam_transform.matrix[i][j];
+		}
+	}
+
+	if (gi->giprobe_debug_uniform_set.is_valid()) {
+		RD::get_singleton()->free(gi->giprobe_debug_uniform_set);
+	}
+	Vector<RD::Uniform> uniforms;
+	{
+		RD::Uniform u;
+		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+		u.binding = 1;
+		u.ids.push_back(storage->gi_probe_get_data_buffer(probe));
+		uniforms.push_back(u);
+	}
+	{
+		RD::Uniform u;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+		u.binding = 2;
+		u.ids.push_back(texture);
+		uniforms.push_back(u);
+	}
+	{
+		RD::Uniform u;
+		u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+		u.binding = 3;
+		u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+		uniforms.push_back(u);
+	}
+
+	int cell_count;
+	if (!p_emission && p_lighting && has_dynamic_object_data) {
+		cell_count = push_constant.bounds[0] * push_constant.bounds[1] * push_constant.bounds[2];
+	} else {
+		cell_count = mipmaps[level].cell_count;
+	}
+
+	gi->giprobe_debug_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, gi->giprobe_debug_shader_version_shaders[0], 0);
+
+	int giprobe_debug_pipeline = GI_PROBE_DEBUG_COLOR;
+	if (p_emission) {
+		giprobe_debug_pipeline = GI_PROBE_DEBUG_EMISSION;
+	} else if (p_lighting) {
+		giprobe_debug_pipeline = has_dynamic_object_data ? GI_PROBE_DEBUG_LIGHT_FULL : GI_PROBE_DEBUG_LIGHT;
+	}
+	RD::get_singleton()->draw_list_bind_render_pipeline(
+			p_draw_list,
+			gi->giprobe_debug_shader_version_pipelines[giprobe_debug_pipeline].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_framebuffer)));
+	RD::get_singleton()->draw_list_bind_uniform_set(p_draw_list, gi->giprobe_debug_uniform_set, 0);
+	RD::get_singleton()->draw_list_set_push_constant(p_draw_list, &push_constant, sizeof(GIProbeDebugPushConstant));
+	RD::get_singleton()->draw_list_draw(p_draw_list, false, cell_count, 36);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// GIRD
+
+RendererSceneGIRD::RendererSceneGIRD() {
+	sdfgi_ray_count = RS::EnvironmentSDFGIRayCount(CLAMP(int32_t(GLOBAL_GET("rendering/global_illumination/sdfgi/probe_ray_count")), 0, int32_t(RS::ENV_SDFGI_RAY_COUNT_MAX - 1)));
+	sdfgi_frames_to_converge = RS::EnvironmentSDFGIFramesToConverge(CLAMP(int32_t(GLOBAL_GET("rendering/global_illumination/sdfgi/frames_to_converge")), 0, int32_t(RS::ENV_SDFGI_CONVERGE_MAX - 1)));
+	sdfgi_frames_to_update_light = RS::EnvironmentSDFGIFramesToUpdateLight(CLAMP(int32_t(GLOBAL_GET("rendering/global_illumination/sdfgi/frames_to_update_lights")), 0, int32_t(RS::ENV_SDFGI_UPDATE_LIGHT_MAX - 1)));
+}
+
+RendererSceneGIRD::~RendererSceneGIRD() {
+}
+
+void RendererSceneGIRD::init_gi(RendererStorageRD *p_storage) {
+	storage = p_storage;
+
+	{
+		//kinda complicated to compute the amount of slots, we try to use as many as we can
+
+		gi_probe_max_lights = 32;
+
+		gi_probe_lights = memnew_arr(GIProbeLight, gi_probe_max_lights);
+		gi_probe_lights_uniform = RD::get_singleton()->uniform_buffer_create(gi_probe_max_lights * sizeof(GIProbeLight));
+		gi_probe_quality = RS::GIProbeQuality(CLAMP(int(GLOBAL_GET("rendering/global_illumination/gi_probes/quality")), 0, 1));
+
+		String defines = "\n#define MAX_LIGHTS " + itos(gi_probe_max_lights) + "\n";
+
+		Vector<String> versions;
+		versions.push_back("\n#define MODE_COMPUTE_LIGHT\n");
+		versions.push_back("\n#define MODE_SECOND_BOUNCE\n");
+		versions.push_back("\n#define MODE_UPDATE_MIPMAPS\n");
+		versions.push_back("\n#define MODE_WRITE_TEXTURE\n");
+		versions.push_back("\n#define MODE_DYNAMIC\n#define MODE_DYNAMIC_LIGHTING\n");
+		versions.push_back("\n#define MODE_DYNAMIC\n#define MODE_DYNAMIC_SHRINK\n#define MODE_DYNAMIC_SHRINK_WRITE\n");
+		versions.push_back("\n#define MODE_DYNAMIC\n#define MODE_DYNAMIC_SHRINK\n#define MODE_DYNAMIC_SHRINK_PLOT\n");
+		versions.push_back("\n#define MODE_DYNAMIC\n#define MODE_DYNAMIC_SHRINK\n#define MODE_DYNAMIC_SHRINK_PLOT\n#define MODE_DYNAMIC_SHRINK_WRITE\n");
+
+		giprobe_shader.initialize(versions, defines);
+		giprobe_lighting_shader_version = giprobe_shader.version_create();
+		for (int i = 0; i < GI_PROBE_SHADER_VERSION_MAX; i++) {
+			giprobe_lighting_shader_version_shaders[i] = giprobe_shader.version_get_shader(giprobe_lighting_shader_version, i);
+			giprobe_lighting_shader_version_pipelines[i] = RD::get_singleton()->compute_pipeline_create(giprobe_lighting_shader_version_shaders[i]);
+		}
+	}
+
+	{
+		String defines;
+		Vector<String> versions;
+		versions.push_back("\n#define MODE_DEBUG_COLOR\n");
+		versions.push_back("\n#define MODE_DEBUG_LIGHT\n");
+		versions.push_back("\n#define MODE_DEBUG_EMISSION\n");
+		versions.push_back("\n#define MODE_DEBUG_LIGHT\n#define MODE_DEBUG_LIGHT_FULL\n");
+
+		giprobe_debug_shader.initialize(versions, defines);
+		giprobe_debug_shader_version = giprobe_debug_shader.version_create();
+		for (int i = 0; i < GI_PROBE_DEBUG_MAX; i++) {
+			giprobe_debug_shader_version_shaders[i] = giprobe_debug_shader.version_get_shader(giprobe_debug_shader_version, i);
+
+			RD::PipelineRasterizationState rs;
+			rs.cull_mode = RD::POLYGON_CULL_FRONT;
+			RD::PipelineDepthStencilState ds;
+			ds.enable_depth_test = true;
+			ds.enable_depth_write = true;
+			ds.depth_compare_operator = RD::COMPARE_OP_LESS_OR_EQUAL;
+
+			giprobe_debug_shader_version_pipelines[i].setup(giprobe_debug_shader_version_shaders[i], RD::RENDER_PRIMITIVE_TRIANGLES, rs, RD::PipelineMultisampleState(), ds, RD::PipelineColorBlendState::create_disabled(), 0);
+		}
+	}
+}
+
+void RendererSceneGIRD::init_sdfgi(RendererSceneSkyRD *p_sky) {
+	{
+		Vector<String> preprocess_modes;
+		preprocess_modes.push_back("\n#define MODE_SCROLL\n");
+		preprocess_modes.push_back("\n#define MODE_SCROLL_OCCLUSION\n");
+		preprocess_modes.push_back("\n#define MODE_INITIALIZE_JUMP_FLOOD\n");
+		preprocess_modes.push_back("\n#define MODE_INITIALIZE_JUMP_FLOOD_HALF\n");
+		preprocess_modes.push_back("\n#define MODE_JUMPFLOOD\n");
+		preprocess_modes.push_back("\n#define MODE_JUMPFLOOD_OPTIMIZED\n");
+		preprocess_modes.push_back("\n#define MODE_UPSCALE_JUMP_FLOOD\n");
+		preprocess_modes.push_back("\n#define MODE_OCCLUSION\n");
+		preprocess_modes.push_back("\n#define MODE_STORE\n");
+		String defines = "\n#define OCCLUSION_SIZE " + itos(SDFGI::CASCADE_SIZE / SDFGI::PROBE_DIVISOR) + "\n";
+		sdfgi_shader.preprocess.initialize(preprocess_modes, defines);
+		sdfgi_shader.preprocess_shader = sdfgi_shader.preprocess.version_create();
+		for (int i = 0; i < SDGIShader::PRE_PROCESS_MAX; i++) {
+			sdfgi_shader.preprocess_pipeline[i] = RD::get_singleton()->compute_pipeline_create(sdfgi_shader.preprocess.version_get_shader(sdfgi_shader.preprocess_shader, i));
+		}
+	}
+
+	{
+		//calculate tables
+		String defines = "\n#define OCT_SIZE " + itos(SDFGI::LIGHTPROBE_OCT_SIZE) + "\n";
+
+		Vector<String> direct_light_modes;
+		direct_light_modes.push_back("\n#define MODE_PROCESS_STATIC\n");
+		direct_light_modes.push_back("\n#define MODE_PROCESS_DYNAMIC\n");
+		sdfgi_shader.direct_light.initialize(direct_light_modes, defines);
+		sdfgi_shader.direct_light_shader = sdfgi_shader.direct_light.version_create();
+		for (int i = 0; i < SDGIShader::DIRECT_LIGHT_MODE_MAX; i++) {
+			sdfgi_shader.direct_light_pipeline[i] = RD::get_singleton()->compute_pipeline_create(sdfgi_shader.direct_light.version_get_shader(sdfgi_shader.direct_light_shader, i));
+		}
+	}
+
+	{
+		//calculate tables
+		String defines = "\n#define OCT_SIZE " + itos(SDFGI::LIGHTPROBE_OCT_SIZE) + "\n";
+		defines += "\n#define SH_SIZE " + itos(SDFGI::SH_SIZE) + "\n";
+		if (p_sky->sky_use_cubemap_array) {
+			defines += "\n#define USE_CUBEMAP_ARRAY\n";
+		}
+
+		Vector<String> integrate_modes;
+		integrate_modes.push_back("\n#define MODE_PROCESS\n");
+		integrate_modes.push_back("\n#define MODE_STORE\n");
+		integrate_modes.push_back("\n#define MODE_SCROLL\n");
+		integrate_modes.push_back("\n#define MODE_SCROLL_STORE\n");
+		sdfgi_shader.integrate.initialize(integrate_modes, defines);
+		sdfgi_shader.integrate_shader = sdfgi_shader.integrate.version_create();
+
+		for (int i = 0; i < SDGIShader::INTEGRATE_MODE_MAX; i++) {
+			sdfgi_shader.integrate_pipeline[i] = RD::get_singleton()->compute_pipeline_create(sdfgi_shader.integrate.version_get_shader(sdfgi_shader.integrate_shader, i));
+		}
+
+		{
+			Vector<RD::Uniform> uniforms;
+
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+				u.binding = 0;
+				u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_CUBEMAP_WHITE));
+				uniforms.push_back(u);
+			}
+			{
+				RD::Uniform u;
+				u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+				u.binding = 1;
+				u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+				uniforms.push_back(u);
+			}
+
+			sdfgi_shader.integrate_default_sky_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, sdfgi_shader.integrate.version_get_shader(sdfgi_shader.integrate_shader, 0), 1);
+		}
+	}
+
+	//GK
+	{
+		//calculate tables
+		String defines = "\n#define SDFGI_OCT_SIZE " + itos(SDFGI::LIGHTPROBE_OCT_SIZE) + "\n";
+		Vector<String> gi_modes;
+		gi_modes.push_back("\n#define USE_GIPROBES\n");
+		gi_modes.push_back("\n#define USE_SDFGI\n");
+		gi_modes.push_back("\n#define USE_SDFGI\n\n#define USE_GIPROBES\n");
+		gi_modes.push_back("\n#define MODE_HALF_RES\n#define USE_GIPROBES\n");
+		gi_modes.push_back("\n#define MODE_HALF_RES\n#define USE_SDFGI\n");
+		gi_modes.push_back("\n#define MODE_HALF_RES\n#define USE_SDFGI\n\n#define USE_GIPROBES\n");
+
+		shader.initialize(gi_modes, defines);
+		shader_version = shader.version_create();
+		for (int i = 0; i < MODE_MAX; i++) {
+			pipelines[i] = RD::get_singleton()->compute_pipeline_create(shader.version_get_shader(shader_version, i));
+		}
+
+		sdfgi_ubo = RD::get_singleton()->uniform_buffer_create(sizeof(SDFGIData));
+	}
+	{
+		String defines = "\n#define OCT_SIZE " + itos(SDFGI::LIGHTPROBE_OCT_SIZE) + "\n";
+		Vector<String> debug_modes;
+		debug_modes.push_back("");
+		sdfgi_shader.debug.initialize(debug_modes, defines);
+		sdfgi_shader.debug_shader = sdfgi_shader.debug.version_create();
+		sdfgi_shader.debug_shader_version = sdfgi_shader.debug.version_get_shader(sdfgi_shader.debug_shader, 0);
+		sdfgi_shader.debug_pipeline = RD::get_singleton()->compute_pipeline_create(sdfgi_shader.debug_shader_version);
+	}
+	{
+		String defines = "\n#define OCT_SIZE " + itos(SDFGI::LIGHTPROBE_OCT_SIZE) + "\n";
+
+		Vector<String> versions;
+		versions.push_back("\n#define MODE_PROBES\n");
+		versions.push_back("\n#define MODE_VISIBILITY\n");
+
+		sdfgi_shader.debug_probes.initialize(versions, defines);
+		sdfgi_shader.debug_probes_shader = sdfgi_shader.debug_probes.version_create();
+
+		{
+			RD::PipelineRasterizationState rs;
+			rs.cull_mode = RD::POLYGON_CULL_DISABLED;
+			RD::PipelineDepthStencilState ds;
+			ds.enable_depth_test = true;
+			ds.enable_depth_write = true;
+			ds.depth_compare_operator = RD::COMPARE_OP_LESS_OR_EQUAL;
+			for (int i = 0; i < SDGIShader::PROBE_DEBUG_MAX; i++) {
+				RID debug_probes_shader_version = sdfgi_shader.debug_probes.version_get_shader(sdfgi_shader.debug_probes_shader, i);
+				sdfgi_shader.debug_probes_pipeline[i].setup(debug_probes_shader_version, RD::RENDER_PRIMITIVE_TRIANGLE_STRIPS, rs, RD::PipelineMultisampleState(), ds, RD::PipelineColorBlendState::create_disabled(), 0);
+			}
+		}
+	}
+	default_giprobe_buffer = RD::get_singleton()->uniform_buffer_create(sizeof(GIProbeData) * MAX_GIPROBES);
+}
+
+void RendererSceneGIRD::free() {
+	RD::get_singleton()->free(default_giprobe_buffer);
+	RD::get_singleton()->free(gi_probe_lights_uniform);
+	RD::get_singleton()->free(sdfgi_ubo);
+
+	giprobe_debug_shader.version_free(giprobe_debug_shader_version);
+	giprobe_shader.version_free(giprobe_lighting_shader_version);
+	shader.version_free(shader_version);
+	sdfgi_shader.debug_probes.version_free(sdfgi_shader.debug_probes_shader);
+	sdfgi_shader.debug.version_free(sdfgi_shader.debug_shader);
+	sdfgi_shader.direct_light.version_free(sdfgi_shader.direct_light_shader);
+	sdfgi_shader.integrate.version_free(sdfgi_shader.integrate_shader);
+	sdfgi_shader.preprocess.version_free(sdfgi_shader.preprocess_shader);
+
+	memdelete_arr(gi_probe_lights);
+}
+
+RendererSceneGIRD::SDFGI *RendererSceneGIRD::create_sdfgi(RendererSceneEnvironmentRD *p_env, const Vector3 &p_world_position, uint32_t p_requested_history_size) {
+	SDFGI *sdfgi = memnew(SDFGI);
+
+	sdfgi->create(p_env, p_world_position, p_requested_history_size, this);
+
+	return sdfgi;
+}
+
+void RendererSceneGIRD::setup_giprobes(RID p_render_buffers, const Transform &p_transform, const PagedArray<RID> &p_gi_probes, uint32_t &r_gi_probes_used, RendererSceneRenderRD *p_scene_render) {
+	r_gi_probes_used = 0;
+
+	// feels a little dirty to use our container this way but....
+	RendererSceneRenderRD::RenderBuffers *rb = p_scene_render->render_buffers_owner.getornull(p_render_buffers);
+	ERR_FAIL_COND(rb == nullptr);
+
+	RID gi_probe_buffer = p_scene_render->render_buffers_get_gi_probe_buffer(p_render_buffers);
+
+	RD::get_singleton()->draw_command_begin_label("GIProbes Setup");
+
+	GIProbeData gi_probe_data[MAX_GIPROBES];
+
+	bool giprobes_changed = false;
+
+	Transform to_camera;
+	to_camera.origin = p_transform.origin; //only translation, make local
+
+	for (int i = 0; i < MAX_GIPROBES; i++) {
+		RID texture;
+		if (i < (int)p_gi_probes.size()) {
+			GIProbeInstance *gipi = gi_probe_instance_owner.getornull(p_gi_probes[i]);
+
+			if (gipi) {
+				texture = gipi->texture;
+				GIProbeData &gipd = gi_probe_data[i];
+
+				RID base_probe = gipi->probe;
+
+				Transform to_cell = storage->gi_probe_get_to_cell_xform(gipi->probe) * gipi->transform.affine_inverse() * to_camera;
+
+				gipd.xform[0] = to_cell.basis.elements[0][0];
+				gipd.xform[1] = to_cell.basis.elements[1][0];
+				gipd.xform[2] = to_cell.basis.elements[2][0];
+				gipd.xform[3] = 0;
+				gipd.xform[4] = to_cell.basis.elements[0][1];
+				gipd.xform[5] = to_cell.basis.elements[1][1];
+				gipd.xform[6] = to_cell.basis.elements[2][1];
+				gipd.xform[7] = 0;
+				gipd.xform[8] = to_cell.basis.elements[0][2];
+				gipd.xform[9] = to_cell.basis.elements[1][2];
+				gipd.xform[10] = to_cell.basis.elements[2][2];
+				gipd.xform[11] = 0;
+				gipd.xform[12] = to_cell.origin.x;
+				gipd.xform[13] = to_cell.origin.y;
+				gipd.xform[14] = to_cell.origin.z;
+				gipd.xform[15] = 1;
+
+				Vector3 bounds = storage->gi_probe_get_octree_size(base_probe);
+
+				gipd.bounds[0] = bounds.x;
+				gipd.bounds[1] = bounds.y;
+				gipd.bounds[2] = bounds.z;
+
+				gipd.dynamic_range = storage->gi_probe_get_dynamic_range(base_probe) * storage->gi_probe_get_energy(base_probe);
+				gipd.bias = storage->gi_probe_get_bias(base_probe);
+				gipd.normal_bias = storage->gi_probe_get_normal_bias(base_probe);
+				gipd.blend_ambient = !storage->gi_probe_is_interior(base_probe);
+				gipd.anisotropy_strength = 0;
+				gipd.ao = storage->gi_probe_get_ao(base_probe);
+				gipd.ao_size = Math::pow(storage->gi_probe_get_ao_size(base_probe), 4.0f);
+				gipd.mipmaps = gipi->mipmaps.size();
+			}
+
+			r_gi_probes_used++;
+		}
+
+		if (texture == RID()) {
+			texture = storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+		}
+
+		if (texture != rb->gi.giprobe_textures[i]) {
+			giprobes_changed = true;
+			rb->gi.giprobe_textures[i] = texture;
+		}
+	}
+
+	if (giprobes_changed) {
+		if (RD::get_singleton()->uniform_set_is_valid(rb->gi_uniform_set)) {
+			RD::get_singleton()->free(rb->gi_uniform_set);
+		}
+		rb->gi_uniform_set = RID();
+		if (rb->volumetric_fog) {
+			if (RD::get_singleton()->uniform_set_is_valid(rb->volumetric_fog->uniform_set)) {
+				RD::get_singleton()->free(rb->volumetric_fog->uniform_set);
+				RD::get_singleton()->free(rb->volumetric_fog->uniform_set2);
+			}
+			rb->volumetric_fog->uniform_set = RID();
+			rb->volumetric_fog->uniform_set2 = RID();
+		}
+	}
+
+	if (p_gi_probes.size() > 0) {
+		RD::get_singleton()->buffer_update(gi_probe_buffer, 0, sizeof(GIProbeData) * MIN((uint64_t)MAX_GIPROBES, p_gi_probes.size()), gi_probe_data, RD::BARRIER_MASK_COMPUTE);
+	}
+
+	RD::get_singleton()->draw_command_end_label();
+}
+
+void RendererSceneGIRD::process_gi(RID p_render_buffers, RID p_normal_roughness_buffer, RID p_gi_probe_buffer, RID p_environment, const CameraMatrix &p_projection, const Transform &p_transform, const PagedArray<RID> &p_gi_probes, RendererSceneRenderRD *p_scene_render) {
+	RD::get_singleton()->draw_command_begin_label("GI Render");
+
+	RendererSceneRenderRD::RenderBuffers *rb = p_scene_render->render_buffers_owner.getornull(p_render_buffers);
+	ERR_FAIL_COND(rb == nullptr);
+	RendererSceneEnvironmentRD *env = p_scene_render->environment_owner.getornull(p_environment);
+
+	if (rb->ambient_buffer.is_null() || rb->using_half_size_gi != half_resolution) {
+		if (rb->ambient_buffer.is_valid()) {
+			RD::get_singleton()->free(rb->ambient_buffer);
+			RD::get_singleton()->free(rb->reflection_buffer);
+		}
+
+		RD::TextureFormat tf;
+		tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+		tf.width = rb->width;
+		tf.height = rb->height;
+		if (half_resolution) {
+			tf.width >>= 1;
+			tf.height >>= 1;
+		}
+		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
+		rb->reflection_buffer = RD::get_singleton()->texture_create(tf, RD::TextureView());
+		rb->ambient_buffer = RD::get_singleton()->texture_create(tf, RD::TextureView());
+		rb->using_half_size_gi = half_resolution;
+
+		p_scene_render->_render_buffers_uniform_set_changed(p_render_buffers);
+	}
+
+	PushConstant push_constant;
+
+	push_constant.screen_size[0] = rb->width;
+	push_constant.screen_size[1] = rb->height;
+	push_constant.z_near = p_projection.get_z_near();
+	push_constant.z_far = p_projection.get_z_far();
+	push_constant.orthogonal = p_projection.is_orthogonal();
+	push_constant.proj_info[0] = -2.0f / (rb->width * p_projection.matrix[0][0]);
+	push_constant.proj_info[1] = -2.0f / (rb->height * p_projection.matrix[1][1]);
+	push_constant.proj_info[2] = (1.0f - p_projection.matrix[0][2]) / p_projection.matrix[0][0];
+	push_constant.proj_info[3] = (1.0f + p_projection.matrix[1][2]) / p_projection.matrix[1][1];
+	push_constant.max_giprobes = MIN((uint64_t)MAX_GIPROBES, p_gi_probes.size());
+	push_constant.high_quality_vct = gi_probe_quality == RS::GI_PROBE_QUALITY_HIGH;
+
+	bool use_sdfgi = rb->sdfgi != nullptr;
+	bool use_giprobes = push_constant.max_giprobes > 0;
+
+	if (env) {
+		push_constant.ao_color[0] = env->ao_color.r;
+		push_constant.ao_color[1] = env->ao_color.g;
+		push_constant.ao_color[2] = env->ao_color.b;
+	} else {
+		push_constant.ao_color[0] = 0;
+		push_constant.ao_color[1] = 0;
+		push_constant.ao_color[2] = 0;
+	}
+
+	push_constant.cam_rotation[0] = p_transform.basis[0][0];
+	push_constant.cam_rotation[1] = p_transform.basis[1][0];
+	push_constant.cam_rotation[2] = p_transform.basis[2][0];
+	push_constant.cam_rotation[3] = 0;
+	push_constant.cam_rotation[4] = p_transform.basis[0][1];
+	push_constant.cam_rotation[5] = p_transform.basis[1][1];
+	push_constant.cam_rotation[6] = p_transform.basis[2][1];
+	push_constant.cam_rotation[7] = 0;
+	push_constant.cam_rotation[8] = p_transform.basis[0][2];
+	push_constant.cam_rotation[9] = p_transform.basis[1][2];
+	push_constant.cam_rotation[10] = p_transform.basis[2][2];
+	push_constant.cam_rotation[11] = 0;
+
+	if (rb->gi_uniform_set.is_null() || !RD::get_singleton()->uniform_set_is_valid(rb->gi_uniform_set)) {
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.binding = 1;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
+				if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
+					u.ids.push_back(rb->sdfgi->cascades[j].sdf_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 2;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
+				if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
+					u.ids.push_back(rb->sdfgi->cascades[j].light_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 3;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
+				if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
+					u.ids.push_back(rb->sdfgi->cascades[j].light_aniso_0_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.binding = 4;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
+				if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
+					u.ids.push_back(rb->sdfgi->cascades[j].light_aniso_1_tex);
+				} else {
+					u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				}
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 5;
+			if (rb->sdfgi) {
+				u.ids.push_back(rb->sdfgi->occlusion_texture);
+			} else {
+				u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+			u.binding = 6;
+			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+			u.binding = 7;
+			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
+			uniforms.push_back(u);
+		}
+
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 9;
+			u.ids.push_back(rb->ambient_buffer);
+			uniforms.push_back(u);
+		}
+
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
+			u.binding = 10;
+			u.ids.push_back(rb->reflection_buffer);
+			uniforms.push_back(u);
+		}
+
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 11;
+			if (rb->sdfgi) {
+				u.ids.push_back(rb->sdfgi->lightprobe_texture);
+			} else {
+				u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE));
+			}
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 12;
+			u.ids.push_back(rb->depth_texture);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 13;
+			u.ids.push_back(p_normal_roughness_buffer);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 14;
+			RID buffer = p_gi_probe_buffer.is_valid() ? p_gi_probe_buffer : storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_BLACK);
+			u.ids.push_back(buffer);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.binding = 15;
+			u.ids.push_back(sdfgi_ubo);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.binding = 16;
+			u.ids.push_back(rb->gi.giprobe_buffer);
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 17;
+			for (int i = 0; i < MAX_GIPROBES; i++) {
+				u.ids.push_back(rb->gi.giprobe_textures[i]);
+			}
+			uniforms.push_back(u);
+		}
+
+		rb->gi_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, shader.version_get_shader(shader_version, 0), 0);
+	}
+
+	Mode mode;
+
+	if (rb->using_half_size_gi) {
+		mode = (use_sdfgi && use_giprobes) ? MODE_HALF_RES_COMBINED : (use_sdfgi ? MODE_HALF_RES_SDFGI : MODE_HALF_RES_GIPROBE);
+	} else {
+		mode = (use_sdfgi && use_giprobes) ? MODE_COMBINED : (use_sdfgi ? MODE_SDFGI : MODE_GIPROBE);
+	}
+	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin(true);
+	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, pipelines[mode]);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, rb->gi_uniform_set, 0);
+	RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(PushConstant));
+
+	if (rb->using_half_size_gi) {
+		RD::get_singleton()->compute_list_dispatch_threads(compute_list, rb->width >> 1, rb->height >> 1, 1);
+	} else {
+		RD::get_singleton()->compute_list_dispatch_threads(compute_list, rb->width, rb->height, 1);
+	}
+	//do barrier later to allow oeverlap
+	//RD::get_singleton()->compute_list_end(RD::BARRIER_MASK_NO_BARRIER); //no barriers, let other compute, raster and transfer happen at the same time
+	RD::get_singleton()->draw_command_end_label();
+}
+
+RID RendererSceneGIRD::gi_probe_instance_create(RID p_base) {
+	GIProbeInstance gi_probe;
+	gi_probe.gi = this;
+	gi_probe.storage = storage;
+	gi_probe.probe = p_base;
+	RID rid = gi_probe_instance_owner.make_rid(gi_probe);
+	return rid;
+}
+
+void RendererSceneGIRD::debug_giprobe(RID p_gi_probe, RD::DrawListID p_draw_list, RID p_framebuffer, const CameraMatrix &p_camera_with_transform, bool p_lighting, bool p_emission, float p_alpha) {
+	GIProbeInstance *gi_probe = gi_probe_instance_owner.getornull(p_gi_probe);
+	ERR_FAIL_COND(!gi_probe);
+
+	gi_probe->debug(p_draw_list, p_framebuffer, p_camera_with_transform, p_lighting, p_emission, p_alpha);
+}

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.h
@@ -1,0 +1,653 @@
+/*************************************************************************/
+/*  renderer_scene_gi_rd.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RENDERING_SERVER_SCENE_GI_RD_H
+#define RENDERING_SERVER_SCENE_GI_RD_H
+
+#include "core/templates/local_vector.h"
+#include "core/templates/rid_owner.h"
+#include "servers/rendering/renderer_rd/renderer_scene_environment_rd.h"
+#include "servers/rendering/renderer_rd/renderer_scene_sky_rd.h"
+#include "servers/rendering/renderer_rd/shaders/gi.glsl.gen.h"
+#include "servers/rendering/renderer_rd/shaders/giprobe.glsl.gen.h"
+#include "servers/rendering/renderer_rd/shaders/giprobe_debug.glsl.gen.h"
+#include "servers/rendering/renderer_rd/shaders/sdfgi_debug.glsl.gen.h"
+#include "servers/rendering/renderer_rd/shaders/sdfgi_debug_probes.glsl.gen.h"
+#include "servers/rendering/renderer_rd/shaders/sdfgi_direct_light.glsl.gen.h"
+#include "servers/rendering/renderer_rd/shaders/sdfgi_integrate.glsl.gen.h"
+#include "servers/rendering/renderer_rd/shaders/sdfgi_preprocess.glsl.gen.h"
+#include "servers/rendering/renderer_scene_render.h"
+#include "servers/rendering/rendering_device.h"
+
+// Forward declare RendererSceneRenderRD so we can pass it into some of our methods, these classes are pretty tightly bound
+class RendererSceneRenderRD;
+
+class RendererSceneGIRD {
+private:
+	// !BAS! need to see which things become internal..
+
+	RendererStorageRD *storage;
+
+public:
+	/* GIPROBE INSTANCE */
+
+	struct GIProbeLight {
+		uint32_t type;
+		float energy;
+		float radius;
+		float attenuation;
+
+		float color[3];
+		float cos_spot_angle;
+
+		float position[3];
+		float inv_spot_attenuation;
+
+		float direction[3];
+		uint32_t has_shadow;
+	};
+
+	struct GIProbePushConstant {
+		int32_t limits[3];
+		uint32_t stack_size;
+
+		float emission_scale;
+		float propagation;
+		float dynamic_range;
+		uint32_t light_count;
+
+		uint32_t cell_offset;
+		uint32_t cell_count;
+		float aniso_strength;
+		uint32_t pad;
+	};
+
+	struct GIProbeDynamicPushConstant {
+		int32_t limits[3];
+		uint32_t light_count;
+		int32_t x_dir[3];
+		float z_base;
+		int32_t y_dir[3];
+		float z_sign;
+		int32_t z_dir[3];
+		float pos_multiplier;
+		uint32_t rect_pos[2];
+		uint32_t rect_size[2];
+		uint32_t prev_rect_ofs[2];
+		uint32_t prev_rect_size[2];
+		uint32_t flip_x;
+		uint32_t flip_y;
+		float dynamic_range;
+		uint32_t on_mipmap;
+		float propagation;
+		float pad[3];
+	};
+
+	struct GIProbeInstance {
+		// access to our containers
+		RendererStorageRD *storage;
+		RendererSceneGIRD *gi;
+
+		RID probe;
+		RID texture;
+		RID write_buffer;
+
+		struct Mipmap {
+			RID texture;
+			RID uniform_set;
+			RID second_bounce_uniform_set;
+			RID write_uniform_set;
+			uint32_t level;
+			uint32_t cell_offset;
+			uint32_t cell_count;
+		};
+		Vector<Mipmap> mipmaps;
+
+		struct DynamicMap {
+			RID texture; //color normally, or emission on first pass
+			RID fb_depth; //actual depth buffer for the first pass, float depth for later passes
+			RID depth; //actual depth buffer for the first pass, float depth for later passes
+			RID normal; //normal buffer for the first pass
+			RID albedo; //emission buffer for the first pass
+			RID orm; //orm buffer for the first pass
+			RID fb; //used for rendering, only valid on first map
+			RID uniform_set;
+			uint32_t size;
+			int mipmap; // mipmap to write to, -1 if no mipmap assigned
+		};
+
+		Vector<DynamicMap> dynamic_maps;
+
+		int slot = -1;
+		uint32_t last_probe_version = 0;
+		uint32_t last_probe_data_version = 0;
+
+		//uint64_t last_pass = 0;
+		uint32_t render_index = 0;
+
+		bool has_dynamic_object_data = false;
+
+		Transform transform;
+
+		void update(bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RendererSceneRender::GeometryInstance *> &p_dynamic_objects, RendererSceneRenderRD *p_scene_render);
+		void debug(RD::DrawListID p_draw_list, RID p_framebuffer, const CameraMatrix &p_camera_with_transform, bool p_lighting, bool p_emission, float p_alpha);
+	};
+
+	GIProbeLight *gi_probe_lights;
+	uint32_t gi_probe_max_lights;
+	RID gi_probe_lights_uniform;
+
+	enum {
+		GI_PROBE_SHADER_VERSION_COMPUTE_LIGHT,
+		GI_PROBE_SHADER_VERSION_COMPUTE_SECOND_BOUNCE,
+		GI_PROBE_SHADER_VERSION_COMPUTE_MIPMAP,
+		GI_PROBE_SHADER_VERSION_WRITE_TEXTURE,
+		GI_PROBE_SHADER_VERSION_DYNAMIC_OBJECT_LIGHTING,
+		GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_WRITE,
+		GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_PLOT,
+		GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_WRITE_PLOT,
+		GI_PROBE_SHADER_VERSION_MAX
+	};
+
+	GiprobeShaderRD giprobe_shader;
+	RID giprobe_lighting_shader_version;
+	RID giprobe_lighting_shader_version_shaders[GI_PROBE_SHADER_VERSION_MAX];
+	RID giprobe_lighting_shader_version_pipelines[GI_PROBE_SHADER_VERSION_MAX];
+
+	mutable RID_Owner<GIProbeInstance> gi_probe_instance_owner;
+
+	RS::GIProbeQuality gi_probe_quality = RS::GI_PROBE_QUALITY_HIGH;
+
+	enum {
+		GI_PROBE_DEBUG_COLOR,
+		GI_PROBE_DEBUG_LIGHT,
+		GI_PROBE_DEBUG_EMISSION,
+		GI_PROBE_DEBUG_LIGHT_FULL,
+		GI_PROBE_DEBUG_MAX
+	};
+
+	struct GIProbeDebugPushConstant {
+		float projection[16];
+		uint32_t cell_offset;
+		float dynamic_range;
+		float alpha;
+		uint32_t level;
+		int32_t bounds[3];
+		uint32_t pad;
+	};
+
+	GiprobeDebugShaderRD giprobe_debug_shader;
+	RID giprobe_debug_shader_version;
+	RID giprobe_debug_shader_version_shaders[GI_PROBE_DEBUG_MAX];
+	PipelineCacheRD giprobe_debug_shader_version_pipelines[GI_PROBE_DEBUG_MAX];
+	RID giprobe_debug_uniform_set;
+
+	/* SDFGI */
+
+	struct SDFGI {
+		enum {
+			MAX_CASCADES = 8,
+			CASCADE_SIZE = 128,
+			PROBE_DIVISOR = 16,
+			ANISOTROPY_SIZE = 6,
+			MAX_DYNAMIC_LIGHTS = 128,
+			MAX_STATIC_LIGHTS = 1024,
+			LIGHTPROBE_OCT_SIZE = 6,
+			SH_SIZE = 16
+		};
+
+		struct Cascade {
+			struct UBO {
+				float offset[3];
+				float to_cell;
+				int32_t probe_offset[3];
+				uint32_t pad;
+			};
+
+			//cascade blocks are full-size for volume (128^3), half size for albedo/emission
+			RID sdf_tex;
+			RID light_tex;
+			RID light_aniso_0_tex;
+			RID light_aniso_1_tex;
+
+			RID light_data;
+			RID light_aniso_0_data;
+			RID light_aniso_1_data;
+
+			struct SolidCell { // this struct is unused, but remains as reference for size
+				uint32_t position;
+				uint32_t albedo;
+				uint32_t static_light;
+				uint32_t static_light_aniso;
+			};
+
+			RID solid_cell_dispatch_buffer; //buffer for indirect compute dispatch
+			RID solid_cell_buffer;
+
+			RID lightprobe_history_tex;
+			RID lightprobe_average_tex;
+
+			float cell_size;
+			Vector3i position;
+
+			static const Vector3i DIRTY_ALL;
+			Vector3i dirty_regions; //(0,0,0 is not dirty, negative is refresh from the end, DIRTY_ALL is refresh all.
+
+			RID sdf_store_uniform_set;
+			RID sdf_direct_light_uniform_set;
+			RID scroll_uniform_set;
+			RID scroll_occlusion_uniform_set;
+			RID integrate_uniform_set;
+			RID lights_buffer;
+
+			bool all_dynamic_lights_dirty = true;
+		};
+
+		// access to our containers
+		RendererStorageRD *storage;
+		RendererSceneGIRD *gi;
+
+		// used for rendering (voxelization)
+		RID render_albedo;
+		RID render_emission;
+		RID render_emission_aniso;
+		RID render_occlusion[8];
+		RID render_geom_facing;
+
+		RID render_sdf[2];
+		RID render_sdf_half[2];
+
+		// used for ping pong processing in cascades
+		RID sdf_initialize_uniform_set;
+		RID sdf_initialize_half_uniform_set;
+		RID jump_flood_uniform_set[2];
+		RID jump_flood_half_uniform_set[2];
+		RID sdf_upscale_uniform_set;
+		int upscale_jfa_uniform_set_index;
+		RID occlusion_uniform_set;
+
+		uint32_t cascade_size = 128;
+
+		LocalVector<Cascade> cascades;
+
+		RID lightprobe_texture;
+		RID lightprobe_data;
+		RID occlusion_texture;
+		RID occlusion_data;
+		RID ambient_texture; //integrates with volumetric fog
+
+		RID lightprobe_history_scroll; //used for scrolling lightprobes
+		RID lightprobe_average_scroll; //used for scrolling lightprobes
+
+		uint32_t history_size = 0;
+		float solid_cell_ratio = 0;
+		uint32_t solid_cell_count = 0;
+
+		RS::EnvironmentSDFGICascades cascade_mode;
+		float min_cell_size = 0;
+		uint32_t probe_axis_count = 0; //amount of probes per axis, this is an odd number because it encloses endpoints
+
+		RID debug_uniform_set;
+		RID debug_probes_uniform_set;
+		RID cascades_ubo;
+
+		bool uses_occlusion = false;
+		float bounce_feedback = 0.0;
+		bool reads_sky = false;
+		float energy = 1.0;
+		float normal_bias = 1.1;
+		float probe_bias = 1.1;
+		RS::EnvironmentSDFGIYScale y_scale_mode = RS::ENV_SDFGI_Y_SCALE_DISABLED;
+
+		float y_mult = 1.0;
+
+		uint32_t render_pass = 0;
+
+		int32_t cascade_dynamic_light_count[SDFGI::MAX_CASCADES]; //used dynamically
+		RID integrate_sky_uniform_set;
+
+		void create(RendererSceneEnvironmentRD *p_env, const Vector3 &p_world_position, uint32_t p_requested_history_size, RendererSceneGIRD *p_gi);
+		void erase();
+		void update(RendererSceneEnvironmentRD *p_env, const Vector3 &p_world_position);
+		void update_light();
+		void update_probes(RendererSceneEnvironmentRD *p_env, RendererSceneSkyRD::Sky *p_sky);
+		void store_probes();
+		int get_pending_region_data(int p_region, Vector3i &r_local_offset, Vector3i &r_local_size, AABB &r_bounds) const;
+		void update_cascades();
+
+		void debug_draw(const CameraMatrix &p_projection, const Transform &p_transform, int p_width, int p_height, RID p_render_target, RID p_texture);
+		void debug_probes(RD::DrawListID p_draw_list, RID p_framebuffer, const CameraMatrix &p_camera_with_transform);
+
+		void pre_process_gi(const Transform &p_transform, RendererSceneRenderRD *p_scene_render);
+		void render_region(RID p_render_buffers, int p_region, const PagedArray<RendererSceneRender::GeometryInstance *> &p_instances, RendererSceneRenderRD *p_scene_render);
+		void render_static_lights(RID p_render_buffers, uint32_t p_cascade_count, const uint32_t *p_cascade_indices, const PagedArray<RID> *p_positional_light_cull_result, RendererSceneRenderRD *p_scene_render);
+	};
+
+	RS::EnvironmentSDFGIRayCount sdfgi_ray_count = RS::ENV_SDFGI_RAY_COUNT_16;
+	RS::EnvironmentSDFGIFramesToConverge sdfgi_frames_to_converge = RS::ENV_SDFGI_CONVERGE_IN_10_FRAMES;
+	RS::EnvironmentSDFGIFramesToUpdateLight sdfgi_frames_to_update_light = RS::ENV_SDFGI_UPDATE_LIGHT_IN_4_FRAMES;
+
+	float sdfgi_solid_cell_ratio = 0.25;
+	Vector3 sdfgi_debug_probe_pos;
+	Vector3 sdfgi_debug_probe_dir;
+	bool sdfgi_debug_probe_enabled = false;
+	Vector3i sdfgi_debug_probe_index;
+
+	struct SDGIShader {
+		enum SDFGIPreprocessShaderVersion {
+			PRE_PROCESS_SCROLL,
+			PRE_PROCESS_SCROLL_OCCLUSION,
+			PRE_PROCESS_JUMP_FLOOD_INITIALIZE,
+			PRE_PROCESS_JUMP_FLOOD_INITIALIZE_HALF,
+			PRE_PROCESS_JUMP_FLOOD,
+			PRE_PROCESS_JUMP_FLOOD_OPTIMIZED,
+			PRE_PROCESS_JUMP_FLOOD_UPSCALE,
+			PRE_PROCESS_OCCLUSION,
+			PRE_PROCESS_STORE,
+			PRE_PROCESS_MAX
+		};
+
+		struct PreprocessPushConstant {
+			int32_t scroll[3];
+			int32_t grid_size;
+
+			int32_t probe_offset[3];
+			int32_t step_size;
+
+			int32_t half_size;
+			uint32_t occlusion_index;
+			int32_t cascade;
+			uint32_t pad;
+		};
+
+		SdfgiPreprocessShaderRD preprocess;
+		RID preprocess_shader;
+		RID preprocess_pipeline[PRE_PROCESS_MAX];
+
+		struct DebugPushConstant {
+			float grid_size[3];
+			uint32_t max_cascades;
+
+			int32_t screen_size[2];
+			uint32_t use_occlusion;
+			float y_mult;
+
+			float cam_extent[3];
+			uint32_t probe_axis_size;
+
+			float cam_transform[16];
+		};
+
+		SdfgiDebugShaderRD debug;
+		RID debug_shader;
+		RID debug_shader_version;
+		RID debug_pipeline;
+
+		enum ProbeDebugMode {
+			PROBE_DEBUG_PROBES,
+			PROBE_DEBUG_VISIBILITY,
+			PROBE_DEBUG_MAX
+		};
+
+		struct DebugProbesPushConstant {
+			float projection[16];
+
+			uint32_t band_power;
+			uint32_t sections_in_band;
+			uint32_t band_mask;
+			float section_arc;
+
+			float grid_size[3];
+			uint32_t cascade;
+
+			uint32_t pad;
+			float y_mult;
+			int32_t probe_debug_index;
+			int32_t probe_axis_size;
+		};
+
+		SdfgiDebugProbesShaderRD debug_probes;
+		RID debug_probes_shader;
+		RID debug_probes_shader_version;
+
+		PipelineCacheRD debug_probes_pipeline[PROBE_DEBUG_MAX];
+
+		struct Light {
+			float color[3];
+			float energy;
+
+			float direction[3];
+			uint32_t has_shadow;
+
+			float position[3];
+			float attenuation;
+
+			uint32_t type;
+			float cos_spot_angle;
+			float inv_spot_attenuation;
+			float radius;
+
+			float shadow_color[4];
+		};
+
+		struct DirectLightPushConstant {
+			float grid_size[3];
+			uint32_t max_cascades;
+
+			uint32_t cascade;
+			uint32_t light_count;
+			uint32_t process_offset;
+			uint32_t process_increment;
+
+			int32_t probe_axis_size;
+			float bounce_feedback;
+			float y_mult;
+			uint32_t use_occlusion;
+		};
+
+		enum {
+			DIRECT_LIGHT_MODE_STATIC,
+			DIRECT_LIGHT_MODE_DYNAMIC,
+			DIRECT_LIGHT_MODE_MAX
+		};
+		SdfgiDirectLightShaderRD direct_light;
+		RID direct_light_shader;
+		RID direct_light_pipeline[DIRECT_LIGHT_MODE_MAX];
+
+		enum {
+			INTEGRATE_MODE_PROCESS,
+			INTEGRATE_MODE_STORE,
+			INTEGRATE_MODE_SCROLL,
+			INTEGRATE_MODE_SCROLL_STORE,
+			INTEGRATE_MODE_MAX
+		};
+		struct IntegratePushConstant {
+			enum {
+				SKY_MODE_DISABLED,
+				SKY_MODE_COLOR,
+				SKY_MODE_SKY,
+			};
+
+			float grid_size[3];
+			uint32_t max_cascades;
+
+			uint32_t probe_axis_size;
+			uint32_t cascade;
+			uint32_t history_index;
+			uint32_t history_size;
+
+			uint32_t ray_count;
+			float ray_bias;
+			int32_t image_size[2];
+
+			int32_t world_offset[3];
+			uint32_t sky_mode;
+
+			int32_t scroll[3];
+			float sky_energy;
+
+			float sky_color[3];
+			float y_mult;
+
+			uint32_t store_ambient_texture;
+			uint32_t pad[3];
+		};
+
+		SdfgiIntegrateShaderRD integrate;
+		RID integrate_shader;
+		RID integrate_pipeline[INTEGRATE_MODE_MAX];
+
+		RID integrate_default_sky_uniform_set;
+
+	} sdfgi_shader;
+
+	/* SDFGI UPDATE */
+
+	int sdfgi_get_lightprobe_octahedron_size() const { return SDFGI::LIGHTPROBE_OCT_SIZE; }
+
+	/* GI */
+	enum {
+		MAX_GIPROBES = 8
+	};
+
+	// Struct for use in render buffer
+	struct RenderBuffersGI {
+		RID giprobe_textures[MAX_GIPROBES];
+		RID giprobe_buffer;
+
+		RID full_buffer;
+		RID full_dispatch;
+		RID full_mask;
+	};
+
+	// struct GI {
+	struct SDFGIData {
+		float grid_size[3];
+		uint32_t max_cascades;
+
+		uint32_t use_occlusion;
+		int32_t probe_axis_size;
+		float probe_to_uvw;
+		float normal_bias;
+
+		float lightprobe_tex_pixel_size[3];
+		float energy;
+
+		float lightprobe_uv_offset[3];
+		float y_mult;
+
+		float occlusion_clamp[3];
+		uint32_t pad3;
+
+		float occlusion_renormalize[3];
+		uint32_t pad4;
+
+		float cascade_probe_size[3];
+		uint32_t pad5;
+
+		struct ProbeCascadeData {
+			float position[3]; //offset of (0,0,0) in world coordinates
+			float to_probe; // 1/bounds * grid_size
+			int32_t probe_world_offset[3];
+			float to_cell; // 1/bounds * grid_size
+		};
+
+		ProbeCascadeData cascades[SDFGI::MAX_CASCADES];
+	};
+
+	struct GIProbeData {
+		float xform[16];
+		float bounds[3];
+		float dynamic_range;
+
+		float bias;
+		float normal_bias;
+		uint32_t blend_ambient;
+		uint32_t texture_slot;
+
+		float anisotropy_strength;
+		float ao;
+		float ao_size;
+		uint32_t mipmaps;
+	};
+
+	struct PushConstant {
+		int32_t screen_size[2];
+		float z_near;
+		float z_far;
+
+		float proj_info[4];
+		float ao_color[3];
+		uint32_t max_giprobes;
+
+		uint32_t high_quality_vct;
+		uint32_t orthogonal;
+		uint32_t pad[2];
+
+		float cam_rotation[12];
+	};
+
+	RID sdfgi_ubo;
+	enum Mode {
+		MODE_GIPROBE,
+		MODE_SDFGI,
+		MODE_COMBINED,
+		MODE_HALF_RES_GIPROBE,
+		MODE_HALF_RES_SDFGI,
+		MODE_HALF_RES_COMBINED,
+		MODE_MAX
+	};
+
+	RID default_giprobe_buffer;
+
+	bool half_resolution = false;
+	GiShaderRD shader;
+	RID shader_version;
+	RID pipelines[MODE_MAX];
+	// } gi;
+
+	RendererSceneGIRD();
+	~RendererSceneGIRD();
+
+	// !BAS! Can we merge these two inits? Possibly, need to check
+	void init_gi(RendererStorageRD *p_storage);
+	void init_sdfgi(RendererSceneSkyRD *p_sky);
+	void free();
+
+	SDFGI *create_sdfgi(RendererSceneEnvironmentRD *p_env, const Vector3 &p_world_position, uint32_t p_requested_history_size);
+
+	void setup_giprobes(RID p_render_buffers, const Transform &p_transform, const PagedArray<RID> &p_gi_probes, uint32_t &r_gi_probes_used, RendererSceneRenderRD *p_scene_render);
+	void process_gi(RID p_render_buffers, RID p_normal_roughness_buffer, RID p_gi_probe_buffer, RID p_environment, const CameraMatrix &p_projection, const Transform &p_transform, const PagedArray<RID> &p_gi_probes, RendererSceneRenderRD *p_scene_render);
+
+	RID gi_probe_instance_create(RID p_base);
+	void debug_giprobe(RID p_gi_probe, RD::DrawListID p_draw_list, RID p_framebuffer, const CameraMatrix &p_camera_with_transform, bool p_lighting, bool p_emission, float p_alpha);
+};
+
+#endif /* !RENDERING_SERVER_SCENE_GI_RD_H */

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -35,68 +35,21 @@
 #include "core/templates/rid_owner.h"
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/renderer_rd/cluster_builder_rd.h"
+#include "servers/rendering/renderer_rd/renderer_scene_environment_rd.h"
+#include "servers/rendering/renderer_rd/renderer_scene_gi_rd.h"
+#include "servers/rendering/renderer_rd/renderer_scene_sky_rd.h"
 #include "servers/rendering/renderer_rd/renderer_storage_rd.h"
-#include "servers/rendering/renderer_rd/shaders/gi.glsl.gen.h"
-#include "servers/rendering/renderer_rd/shaders/giprobe.glsl.gen.h"
-#include "servers/rendering/renderer_rd/shaders/giprobe_debug.glsl.gen.h"
-#include "servers/rendering/renderer_rd/shaders/sdfgi_debug.glsl.gen.h"
-#include "servers/rendering/renderer_rd/shaders/sdfgi_debug_probes.glsl.gen.h"
-#include "servers/rendering/renderer_rd/shaders/sdfgi_direct_light.glsl.gen.h"
-#include "servers/rendering/renderer_rd/shaders/sdfgi_integrate.glsl.gen.h"
-#include "servers/rendering/renderer_rd/shaders/sdfgi_preprocess.glsl.gen.h"
-#include "servers/rendering/renderer_rd/shaders/sky.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/volumetric_fog.glsl.gen.h"
 #include "servers/rendering/renderer_scene_render.h"
 #include "servers/rendering/rendering_device.h"
 
 class RendererSceneRenderRD : public RendererSceneRender {
+	friend RendererSceneSkyRD;
+	friend RendererSceneGIRD;
+
 protected:
 	double time;
-
-	// Skys need less info from Directional Lights than the normal shaders
-	struct SkyDirectionalLightData {
-		float direction[3];
-		float energy;
-		float color[3];
-		float size;
-		uint32_t enabled;
-		uint32_t pad[3];
-	};
-
-	struct SkySceneState {
-		struct UBO {
-			uint32_t volumetric_fog_enabled;
-			float volumetric_fog_inv_length;
-			float volumetric_fog_detail_spread;
-
-			float fog_aerial_perspective;
-
-			float fog_light_color[3];
-			float fog_sun_scatter;
-
-			uint32_t fog_enabled;
-			float fog_density;
-
-			float z_far;
-			uint32_t directional_light_count;
-		};
-
-		UBO ubo;
-
-		SkyDirectionalLightData *directional_lights;
-		SkyDirectionalLightData *last_frame_directional_lights;
-		uint32_t max_directional_lights;
-		uint32_t last_frame_directional_light_count;
-		RID directional_light_buffer;
-		RID uniform_set;
-		RID uniform_buffer;
-		RID fog_uniform_set;
-		RID default_fog_uniform_set;
-
-		RID fog_shader;
-		RID fog_material;
-		RID fog_only_texture_uniform_set;
-	} sky_scene_state;
+	double time_step = 0;
 
 	struct RenderBufferData {
 		virtual void configure(RID p_color_buffer, RID p_depth_buffer, int p_width, int p_height, RS::ViewportMSAA p_msaa) = 0;
@@ -107,7 +60,6 @@ protected:
 	void _setup_lights(const PagedArray<RID> &p_lights, const Transform &p_camera_transform, RID p_shadow_atlas, bool p_using_shadows, uint32_t &r_directional_light_count, uint32_t &r_positional_light_count);
 	void _setup_decals(const PagedArray<RID> &p_decals, const Transform &p_camera_inverse_xform);
 	void _setup_reflections(const PagedArray<RID> &p_reflections, const Transform &p_camera_inverse_transform, RID p_environment);
-	void _setup_giprobes(RID p_render_buffers, const Transform &p_transform, const PagedArray<RID> &p_gi_probes, uint32_t &r_gi_probes_used);
 
 	virtual void _render_scene(RID p_render_buffer, const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, const PagedArray<GeometryInstance *> &p_instances, const PagedArray<RID> &p_gi_probes, const PagedArray<RID> &p_lightmaps, RID p_environment, RID p_cluster_buffer, uint32_t p_cluster_size, uint32_t p_cluster_max_elements, RID p_camera_effects, RID p_shadow_atlas, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, const Color &p_default_color, float p_screen_lod_threshold) = 0;
 
@@ -121,7 +73,6 @@ protected:
 	virtual void _render_sdfgi(RID p_render_buffers, const Vector3i &p_from, const Vector3i &p_size, const AABB &p_bounds, const PagedArray<GeometryInstance *> &p_instances, const RID &p_albedo_texture, const RID &p_emission_texture, const RID &p_emission_aniso_texture, const RID &p_geom_facing_texture) = 0;
 	virtual void _render_particle_collider_heightfield(RID p_fb, const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, const PagedArray<GeometryInstance *> &p_instances) = 0;
 
-	virtual void _debug_giprobe(RID p_gi_probe, RenderingDevice::DrawListID p_draw_list, RID p_framebuffer, const CameraMatrix &p_camera_with_transform, bool p_lighting, bool p_emission, float p_alpha);
 	void _debug_sdfgi_probes(RID p_render_buffers, RD::DrawListID p_draw_list, RID p_framebuffer, const CameraMatrix &p_camera_with_transform);
 
 	RenderBufferData *render_buffers_get_data(RID p_render_buffers);
@@ -134,12 +85,6 @@ protected:
 	void _process_ssr(RID p_render_buffers, RID p_dest_framebuffer, RID p_normal_buffer, RID p_specular_buffer, RID p_metallic, const Color &p_metallic_mask, RID p_environment, const CameraMatrix &p_projection, bool p_use_additive);
 	void _process_sss(RID p_render_buffers, const CameraMatrix &p_camera);
 
-	void _setup_sky(RID p_environment, RID p_render_buffers, const CameraMatrix &p_projection, const Transform &p_transform, const Size2i p_screen_size);
-	void _update_sky(RID p_environment, const CameraMatrix &p_projection, const Transform &p_transform);
-	void _draw_sky(bool p_can_continue_color, bool p_can_continue_depth, RID p_fb, RID p_environment, const CameraMatrix &p_projection, const Transform &p_transform);
-	void _pre_process_gi(RID p_render_buffers, const Transform &p_transform);
-	void _process_gi(RID p_render_buffers, RID p_normal_roughness_buffer, RID p_gi_probe_buffer, RID p_environment, const CameraMatrix &p_projection, const Transform &p_transform, const PagedArray<RID> &p_gi_probes);
-
 	bool _needs_post_prepass_render(bool p_use_gi);
 	void _post_prepass_render(bool p_use_gi);
 	void _pre_resolve_render(bool p_use_gi);
@@ -150,190 +95,23 @@ protected:
 	// needed for a single argument calls (material and uv2)
 	PagedArrayPool<GeometryInstance *> cull_argument_pool;
 	PagedArray<GeometryInstance *> cull_argument; //need this to exist
+
+	RendererSceneGIRD gi;
+	RendererSceneSkyRD sky;
+
+	RendererSceneEnvironmentRD *get_environment(RID p_environment) {
+		if (p_environment.is_valid()) {
+			return environment_owner.getornull(p_environment);
+		} else {
+			return nullptr;
+		}
+	}
+
 private:
 	RS::ViewportDebugDraw debug_draw = RS::VIEWPORT_DEBUG_DRAW_DISABLED;
-	double time_step = 0;
 	static RendererSceneRenderRD *singleton;
 
-	int roughness_layers;
-
 	RendererStorageRD *storage;
-
-	struct ReflectionData {
-		struct Layer {
-			struct Mipmap {
-				RID framebuffers[6];
-				RID views[6];
-				Size2i size;
-			};
-			Vector<Mipmap> mipmaps; //per-face view
-			Vector<RID> views; // per-cubemap view
-		};
-
-		struct DownsampleLayer {
-			struct Mipmap {
-				RID view;
-				Size2i size;
-			};
-			Vector<Mipmap> mipmaps;
-		};
-
-		RID radiance_base_cubemap; //cubemap for first layer, first cubemap
-		RID downsampled_radiance_cubemap;
-		DownsampleLayer downsampled_layer;
-		RID coefficient_buffer;
-
-		bool dirty = true;
-
-		Vector<Layer> layers;
-	};
-
-	void _clear_reflection_data(ReflectionData &rd);
-	void _update_reflection_data(ReflectionData &rd, int p_size, int p_mipmaps, bool p_use_array, RID p_base_cube, int p_base_layer, bool p_low_quality);
-	void _create_reflection_fast_filter(ReflectionData &rd, bool p_use_arrays);
-	void _create_reflection_importance_sample(ReflectionData &rd, bool p_use_arrays, int p_cube_side, int p_base_layer);
-	void _update_reflection_mipmaps(ReflectionData &rd, int p_start, int p_end);
-
-	/* Sky shader */
-
-	enum SkyVersion {
-		SKY_VERSION_BACKGROUND,
-		SKY_VERSION_HALF_RES,
-		SKY_VERSION_QUARTER_RES,
-		SKY_VERSION_CUBEMAP,
-		SKY_VERSION_CUBEMAP_HALF_RES,
-		SKY_VERSION_CUBEMAP_QUARTER_RES,
-		SKY_VERSION_MAX
-	};
-
-	struct SkyShader {
-		SkyShaderRD shader;
-		ShaderCompilerRD compiler;
-
-		RID default_shader;
-		RID default_material;
-		RID default_shader_rd;
-	} sky_shader;
-
-	struct SkyShaderData : public RendererStorageRD::ShaderData {
-		bool valid;
-		RID version;
-
-		PipelineCacheRD pipelines[SKY_VERSION_MAX];
-		Map<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
-		Vector<ShaderCompilerRD::GeneratedCode::Texture> texture_uniforms;
-
-		Vector<uint32_t> ubo_offsets;
-		uint32_t ubo_size;
-
-		String path;
-		String code;
-		Map<StringName, RID> default_texture_params;
-
-		bool uses_time;
-		bool uses_position;
-		bool uses_half_res;
-		bool uses_quarter_res;
-		bool uses_light;
-
-		virtual void set_code(const String &p_Code);
-		virtual void set_default_texture_param(const StringName &p_name, RID p_texture);
-		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
-		virtual void get_instance_param_list(List<RendererStorage::InstanceShaderParam> *p_param_list) const;
-		virtual bool is_param_texture(const StringName &p_param) const;
-		virtual bool is_animated() const;
-		virtual bool casts_shadows() const;
-		virtual Variant get_default_parameter(const StringName &p_parameter) const;
-		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
-		SkyShaderData();
-		virtual ~SkyShaderData();
-	};
-
-	RendererStorageRD::ShaderData *_create_sky_shader_func();
-	static RendererStorageRD::ShaderData *_create_sky_shader_funcs() {
-		return static_cast<RendererSceneRenderRD *>(singleton)->_create_sky_shader_func();
-	};
-
-	struct SkyMaterialData : public RendererStorageRD::MaterialData {
-		uint64_t last_frame;
-		SkyShaderData *shader_data;
-		RID uniform_buffer;
-		RID uniform_set;
-		Vector<RID> texture_cache;
-		Vector<uint8_t> ubo_data;
-		bool uniform_set_updated;
-
-		virtual void set_render_priority(int p_priority) {}
-		virtual void set_next_pass(RID p_pass) {}
-		virtual void update_parameters(const Map<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
-		virtual ~SkyMaterialData();
-	};
-
-	RendererStorageRD::MaterialData *_create_sky_material_func(SkyShaderData *p_shader);
-	static RendererStorageRD::MaterialData *_create_sky_material_funcs(RendererStorageRD::ShaderData *p_shader) {
-		return static_cast<RendererSceneRenderRD *>(singleton)->_create_sky_material_func(static_cast<SkyShaderData *>(p_shader));
-	};
-
-	enum SkyTextureSetVersion {
-		SKY_TEXTURE_SET_BACKGROUND,
-		SKY_TEXTURE_SET_HALF_RES,
-		SKY_TEXTURE_SET_QUARTER_RES,
-		SKY_TEXTURE_SET_CUBEMAP,
-		SKY_TEXTURE_SET_CUBEMAP_HALF_RES,
-		SKY_TEXTURE_SET_CUBEMAP_QUARTER_RES,
-		SKY_TEXTURE_SET_MAX
-	};
-
-	enum SkySet {
-		SKY_SET_UNIFORMS,
-		SKY_SET_MATERIAL,
-		SKY_SET_TEXTURES,
-		SKY_SET_FOG,
-		SKY_SET_MAX
-	};
-
-	/* SKY */
-	struct Sky {
-		RID radiance;
-		RID half_res_pass;
-		RID half_res_framebuffer;
-		RID quarter_res_pass;
-		RID quarter_res_framebuffer;
-		Size2i screen_size;
-
-		RID texture_uniform_sets[SKY_TEXTURE_SET_MAX];
-		RID uniform_set;
-
-		RID material;
-		RID uniform_buffer;
-
-		int radiance_size = 256;
-
-		RS::SkyMode mode = RS::SKY_MODE_AUTOMATIC;
-
-		ReflectionData reflection;
-		bool dirty = false;
-		int processing_layer = 0;
-		Sky *dirty_list = nullptr;
-
-		//State to track when radiance cubemap needs updating
-		SkyMaterialData *prev_material;
-		Vector3 prev_position;
-		float prev_time;
-
-		RID sdfgi_integrate_sky_uniform_set;
-	};
-
-	Sky *dirty_sky_list = nullptr;
-
-	void _sky_invalidate(Sky *p_sky);
-	void _update_dirty_skys();
-	RID _get_sky_textures(Sky *p_sky, SkyTextureSetVersion p_version);
-
-	uint32_t sky_ggx_samples_quality;
-	bool sky_use_cubemap_array;
-
-	mutable RID_Owner<Sky, true> sky_owner;
 
 	/* REFLECTION ATLAS */
 
@@ -347,7 +125,7 @@ private:
 
 		struct Reflection {
 			RID owner;
-			ReflectionData data;
+			RendererSceneSkyRD::ReflectionData data;
 			RID fbs[6];
 		};
 
@@ -396,151 +174,6 @@ private:
 	};
 
 	mutable RID_Owner<LightmapInstance> lightmap_instance_owner;
-
-	/* GIPROBE INSTANCE */
-
-	struct GIProbeLight {
-		uint32_t type;
-		float energy;
-		float radius;
-		float attenuation;
-
-		float color[3];
-		float cos_spot_angle;
-
-		float position[3];
-		float inv_spot_attenuation;
-
-		float direction[3];
-		uint32_t has_shadow;
-	};
-
-	struct GIProbePushConstant {
-		int32_t limits[3];
-		uint32_t stack_size;
-
-		float emission_scale;
-		float propagation;
-		float dynamic_range;
-		uint32_t light_count;
-
-		uint32_t cell_offset;
-		uint32_t cell_count;
-		float aniso_strength;
-		uint32_t pad;
-	};
-
-	struct GIProbeDynamicPushConstant {
-		int32_t limits[3];
-		uint32_t light_count;
-		int32_t x_dir[3];
-		float z_base;
-		int32_t y_dir[3];
-		float z_sign;
-		int32_t z_dir[3];
-		float pos_multiplier;
-		uint32_t rect_pos[2];
-		uint32_t rect_size[2];
-		uint32_t prev_rect_ofs[2];
-		uint32_t prev_rect_size[2];
-		uint32_t flip_x;
-		uint32_t flip_y;
-		float dynamic_range;
-		uint32_t on_mipmap;
-		float propagation;
-		float pad[3];
-	};
-
-	struct GIProbeInstance {
-		RID probe;
-		RID texture;
-		RID write_buffer;
-
-		struct Mipmap {
-			RID texture;
-			RID uniform_set;
-			RID second_bounce_uniform_set;
-			RID write_uniform_set;
-			uint32_t level;
-			uint32_t cell_offset;
-			uint32_t cell_count;
-		};
-		Vector<Mipmap> mipmaps;
-
-		struct DynamicMap {
-			RID texture; //color normally, or emission on first pass
-			RID fb_depth; //actual depth buffer for the first pass, float depth for later passes
-			RID depth; //actual depth buffer for the first pass, float depth for later passes
-			RID normal; //normal buffer for the first pass
-			RID albedo; //emission buffer for the first pass
-			RID orm; //orm buffer for the first pass
-			RID fb; //used for rendering, only valid on first map
-			RID uniform_set;
-			uint32_t size;
-			int mipmap; // mipmap to write to, -1 if no mipmap assigned
-		};
-
-		Vector<DynamicMap> dynamic_maps;
-
-		int slot = -1;
-		uint32_t last_probe_version = 0;
-		uint32_t last_probe_data_version = 0;
-
-		//uint64_t last_pass = 0;
-		uint32_t render_index = 0;
-
-		bool has_dynamic_object_data = false;
-
-		Transform transform;
-	};
-
-	GIProbeLight *gi_probe_lights;
-	uint32_t gi_probe_max_lights;
-	RID gi_probe_lights_uniform;
-
-	enum {
-		GI_PROBE_SHADER_VERSION_COMPUTE_LIGHT,
-		GI_PROBE_SHADER_VERSION_COMPUTE_SECOND_BOUNCE,
-		GI_PROBE_SHADER_VERSION_COMPUTE_MIPMAP,
-		GI_PROBE_SHADER_VERSION_WRITE_TEXTURE,
-		GI_PROBE_SHADER_VERSION_DYNAMIC_OBJECT_LIGHTING,
-		GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_WRITE,
-		GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_PLOT,
-		GI_PROBE_SHADER_VERSION_DYNAMIC_SHRINK_WRITE_PLOT,
-		GI_PROBE_SHADER_VERSION_MAX
-	};
-	GiprobeShaderRD giprobe_shader;
-	RID giprobe_lighting_shader_version;
-	RID giprobe_lighting_shader_version_shaders[GI_PROBE_SHADER_VERSION_MAX];
-	RID giprobe_lighting_shader_version_pipelines[GI_PROBE_SHADER_VERSION_MAX];
-
-	mutable RID_Owner<GIProbeInstance> gi_probe_instance_owner;
-
-	RS::GIProbeQuality gi_probe_quality = RS::GI_PROBE_QUALITY_HIGH;
-
-	enum {
-		GI_PROBE_DEBUG_COLOR,
-		GI_PROBE_DEBUG_LIGHT,
-		GI_PROBE_DEBUG_EMISSION,
-		GI_PROBE_DEBUG_LIGHT_FULL,
-		GI_PROBE_DEBUG_MAX
-	};
-
-	struct GIProbeDebugPushConstant {
-		float projection[16];
-		uint32_t cell_offset;
-		float dynamic_range;
-		float alpha;
-		uint32_t level;
-		int32_t bounds[3];
-		uint32_t pad;
-	};
-
-	GiprobeDebugShaderRD giprobe_debug_shader;
-	RID giprobe_debug_shader_version;
-	RID giprobe_debug_shader_version_shaders[GI_PROBE_DEBUG_MAX];
-	PipelineCacheRD giprobe_debug_shader_version_pipelines[GI_PROBE_DEBUG_MAX];
-	RID giprobe_debug_uniform_set;
 
 	/* SHADOW ATLAS */
 
@@ -690,111 +323,6 @@ private:
 
 	/* ENVIRONMENT */
 
-	struct Environment {
-		// BG
-		RS::EnvironmentBG background = RS::ENV_BG_CLEAR_COLOR;
-		RID sky;
-		float sky_custom_fov = 0.0;
-		Basis sky_orientation;
-		Color bg_color;
-		float bg_energy = 1.0;
-		int canvas_max_layer = 0;
-		RS::EnvironmentAmbientSource ambient_source = RS::ENV_AMBIENT_SOURCE_BG;
-		Color ambient_light;
-		float ambient_light_energy = 1.0;
-		float ambient_sky_contribution = 1.0;
-		RS::EnvironmentReflectionSource reflection_source = RS::ENV_REFLECTION_SOURCE_BG;
-		Color ao_color;
-
-		/// Tonemap
-
-		RS::EnvironmentToneMapper tone_mapper;
-		float exposure = 1.0;
-		float white = 1.0;
-		bool auto_exposure = false;
-		float min_luminance = 0.2;
-		float max_luminance = 8.0;
-		float auto_exp_speed = 0.2;
-		float auto_exp_scale = 0.5;
-		uint64_t auto_exposure_version = 0;
-
-		// Fog
-		bool fog_enabled = false;
-		Color fog_light_color = Color(0.5, 0.6, 0.7);
-		float fog_light_energy = 1.0;
-		float fog_sun_scatter = 0.0;
-		float fog_density = 0.001;
-		float fog_height = 0.0;
-		float fog_height_density = 0.0; //can be negative to invert effect
-		float fog_aerial_perspective = 0.0;
-
-		/// Volumetric Fog
-		///
-		bool volumetric_fog_enabled = false;
-		float volumetric_fog_density = 0.01;
-		Color volumetric_fog_light = Color(0, 0, 0);
-		float volumetric_fog_light_energy = 0.0;
-		float volumetric_fog_length = 64.0;
-		float volumetric_fog_detail_spread = 2.0;
-		float volumetric_fog_gi_inject = 0.0;
-		bool volumetric_fog_temporal_reprojection = true;
-		float volumetric_fog_temporal_reprojection_amount = 0.9;
-
-		/// Glow
-
-		bool glow_enabled = false;
-		Vector<float> glow_levels;
-		float glow_intensity = 0.8;
-		float glow_strength = 1.0;
-		float glow_bloom = 0.0;
-		float glow_mix = 0.01;
-		RS::EnvironmentGlowBlendMode glow_blend_mode = RS::ENV_GLOW_BLEND_MODE_SOFTLIGHT;
-		float glow_hdr_bleed_threshold = 1.0;
-		float glow_hdr_luminance_cap = 12.0;
-		float glow_hdr_bleed_scale = 2.0;
-
-		/// SSAO
-
-		bool ssao_enabled = false;
-		float ssao_radius = 1.0;
-		float ssao_intensity = 2.0;
-		float ssao_power = 1.5;
-		float ssao_detail = 0.5;
-		float ssao_horizon = 0.06;
-		float ssao_sharpness = 0.98;
-		float ssao_direct_light_affect = 0.0;
-		float ssao_ao_channel_affect = 0.0;
-
-		/// SSR
-		///
-		bool ssr_enabled = false;
-		int ssr_max_steps = 64;
-		float ssr_fade_in = 0.15;
-		float ssr_fade_out = 2.0;
-		float ssr_depth_tolerance = 0.2;
-
-		/// SDFGI
-		bool sdfgi_enabled = false;
-		RS::EnvironmentSDFGICascades sdfgi_cascades;
-		float sdfgi_min_cell_size = 0.2;
-		bool sdfgi_use_occlusion = false;
-		float sdfgi_bounce_feedback = 0.0;
-		bool sdfgi_read_sky_light = false;
-		float sdfgi_energy = 1.0;
-		float sdfgi_normal_bias = 1.1;
-		float sdfgi_probe_bias = 1.1;
-		RS::EnvironmentSDFGIYScale sdfgi_y_scale = RS::ENV_SDFGI_Y_SCALE_DISABLED;
-
-		/// Adjustments
-
-		bool adjustments_enabled = false;
-		float adjustments_brightness = 1.0f;
-		float adjustments_contrast = 1.0f;
-		float adjustments_saturation = 1.0f;
-		bool use_1d_color_correction = false;
-		RID color_correction = RID();
-	};
-
 	RS::EnvironmentSSAOQuality ssao_quality = RS::ENV_SSAO_QUALITY_MEDIUM;
 	bool ssao_half_size = false;
 	bool ssao_using_half_size = false;
@@ -807,9 +335,7 @@ private:
 	bool glow_high_quality = false;
 	RS::EnvironmentSSRRoughnessQuality ssr_roughness_quality = RS::ENV_SSR_ROUGNESS_QUALITY_LOW;
 
-	static uint64_t auto_exposure_counter;
-
-	mutable RID_Owner<Environment, true> environment_owner;
+	mutable RID_Owner<RendererSceneEnvironmentRD, true> environment_owner;
 
 	/* CAMERA EFFECTS */
 
@@ -842,14 +368,9 @@ private:
 	ClusterBuilderSharedDataRD cluster_builder_shared;
 	ClusterBuilderRD *current_cluster_builder = nullptr;
 
-	struct SDFGI;
 	struct VolumetricFog;
 
 	struct RenderBuffers {
-		enum {
-			MAX_GIPROBES = 8
-		};
-
 		RenderBufferData *data = nullptr;
 		int width = 0, height = 0;
 		RS::ViewportMSAA msaa = RS::VIEWPORT_MSAA_DISABLED;
@@ -864,7 +385,7 @@ private:
 		RID depth_texture; //main depth texture
 
 		RID gi_uniform_set;
-		SDFGI *sdfgi = nullptr;
+		RendererSceneGIRD::SDFGI *sdfgi = nullptr;
 		VolumetricFog *volumetric_fog = nullptr;
 
 		ClusterBuilderRD *cluster_builder = nullptr;
@@ -906,414 +427,14 @@ private:
 			RID blur_radius[2];
 		} ssr;
 
-		RID giprobe_textures[MAX_GIPROBES];
-		RID giprobe_buffer;
-
 		RID ambient_buffer;
 		RID reflection_buffer;
 		bool using_half_size_gi = false;
 
-		struct GI {
-			RID full_buffer;
-			RID full_dispatch;
-			RID full_mask;
-		} gi;
+		RendererSceneGIRD::RenderBuffersGI gi;
 	};
-
-	RID default_giprobe_buffer;
-
-	/* SDFGI */
-
-	struct SDFGI {
-		enum {
-			MAX_CASCADES = 8,
-			CASCADE_SIZE = 128,
-			PROBE_DIVISOR = 16,
-			ANISOTROPY_SIZE = 6,
-			MAX_DYNAMIC_LIGHTS = 128,
-			MAX_STATIC_LIGHTS = 1024,
-			LIGHTPROBE_OCT_SIZE = 6,
-			SH_SIZE = 16
-		};
-
-		struct Cascade {
-			struct UBO {
-				float offset[3];
-				float to_cell;
-				int32_t probe_offset[3];
-				uint32_t pad;
-			};
-
-			//cascade blocks are full-size for volume (128^3), half size for albedo/emission
-			RID sdf_tex;
-			RID light_tex;
-			RID light_aniso_0_tex;
-			RID light_aniso_1_tex;
-
-			RID light_data;
-			RID light_aniso_0_data;
-			RID light_aniso_1_data;
-
-			struct SolidCell { // this struct is unused, but remains as reference for size
-				uint32_t position;
-				uint32_t albedo;
-				uint32_t static_light;
-				uint32_t static_light_aniso;
-			};
-
-			RID solid_cell_dispatch_buffer; //buffer for indirect compute dispatch
-			RID solid_cell_buffer;
-
-			RID lightprobe_history_tex;
-			RID lightprobe_average_tex;
-
-			float cell_size;
-			Vector3i position;
-
-			static const Vector3i DIRTY_ALL;
-			Vector3i dirty_regions; //(0,0,0 is not dirty, negative is refresh from the end, DIRTY_ALL is refresh all.
-
-			RID sdf_store_uniform_set;
-			RID sdf_direct_light_uniform_set;
-			RID scroll_uniform_set;
-			RID scroll_occlusion_uniform_set;
-			RID integrate_uniform_set;
-			RID lights_buffer;
-
-			bool all_dynamic_lights_dirty = true;
-		};
-
-		//used for rendering (voxelization)
-		RID render_albedo;
-		RID render_emission;
-		RID render_emission_aniso;
-		RID render_occlusion[8];
-		RID render_geom_facing;
-
-		RID render_sdf[2];
-		RID render_sdf_half[2];
-
-		//used for ping pong processing in cascades
-		RID sdf_initialize_uniform_set;
-		RID sdf_initialize_half_uniform_set;
-		RID jump_flood_uniform_set[2];
-		RID jump_flood_half_uniform_set[2];
-		RID sdf_upscale_uniform_set;
-		int upscale_jfa_uniform_set_index;
-		RID occlusion_uniform_set;
-
-		uint32_t cascade_size = 128;
-
-		LocalVector<Cascade> cascades;
-
-		RID lightprobe_texture;
-		RID lightprobe_data;
-		RID occlusion_texture;
-		RID occlusion_data;
-		RID ambient_texture; //integrates with volumetric fog
-
-		RID lightprobe_history_scroll; //used for scrolling lightprobes
-		RID lightprobe_average_scroll; //used for scrolling lightprobes
-
-		uint32_t history_size = 0;
-		float solid_cell_ratio = 0;
-		uint32_t solid_cell_count = 0;
-
-		RS::EnvironmentSDFGICascades cascade_mode;
-		float min_cell_size = 0;
-		uint32_t probe_axis_count = 0; //amount of probes per axis, this is an odd number because it encloses endpoints
-
-		RID debug_uniform_set;
-		RID debug_probes_uniform_set;
-		RID cascades_ubo;
-
-		bool uses_occlusion = false;
-		float bounce_feedback = 0.0;
-		bool reads_sky = false;
-		float energy = 1.0;
-		float normal_bias = 1.1;
-		float probe_bias = 1.1;
-		RS::EnvironmentSDFGIYScale y_scale_mode = RS::ENV_SDFGI_Y_SCALE_DISABLED;
-
-		float y_mult = 1.0;
-
-		uint32_t render_pass = 0;
-
-		int32_t cascade_dynamic_light_count[SDFGI::MAX_CASCADES]; //used dynamically
-	};
-
-	void _sdfgi_update_light(RID p_render_buffers, RID p_environment);
-	void _sdfgi_update_probes(RID p_render_buffers, RID p_environment);
-	void _sdfgi_store_probes(RID p_render_buffers);
-
-	RS::EnvironmentSDFGIRayCount sdfgi_ray_count = RS::ENV_SDFGI_RAY_COUNT_16;
-	RS::EnvironmentSDFGIFramesToConverge sdfgi_frames_to_converge = RS::ENV_SDFGI_CONVERGE_IN_10_FRAMES;
-	RS::EnvironmentSDFGIFramesToUpdateLight sdfgi_frames_to_update_light = RS::ENV_SDFGI_UPDATE_LIGHT_IN_4_FRAMES;
-
-	float sdfgi_solid_cell_ratio = 0.25;
-	Vector3 sdfgi_debug_probe_pos;
-	Vector3 sdfgi_debug_probe_dir;
-	bool sdfgi_debug_probe_enabled = false;
-	Vector3i sdfgi_debug_probe_index;
-
-	struct SDGIShader {
-		enum SDFGIPreprocessShaderVersion {
-			PRE_PROCESS_SCROLL,
-			PRE_PROCESS_SCROLL_OCCLUSION,
-			PRE_PROCESS_JUMP_FLOOD_INITIALIZE,
-			PRE_PROCESS_JUMP_FLOOD_INITIALIZE_HALF,
-			PRE_PROCESS_JUMP_FLOOD,
-			PRE_PROCESS_JUMP_FLOOD_OPTIMIZED,
-			PRE_PROCESS_JUMP_FLOOD_UPSCALE,
-			PRE_PROCESS_OCCLUSION,
-			PRE_PROCESS_STORE,
-			PRE_PROCESS_MAX
-		};
-
-		struct PreprocessPushConstant {
-			int32_t scroll[3];
-			int32_t grid_size;
-
-			int32_t probe_offset[3];
-			int32_t step_size;
-
-			int32_t half_size;
-			uint32_t occlusion_index;
-			int32_t cascade;
-			uint32_t pad;
-		};
-
-		SdfgiPreprocessShaderRD preprocess;
-		RID preprocess_shader;
-		RID preprocess_pipeline[PRE_PROCESS_MAX];
-
-		struct DebugPushConstant {
-			float grid_size[3];
-			uint32_t max_cascades;
-
-			int32_t screen_size[2];
-			uint32_t use_occlusion;
-			float y_mult;
-
-			float cam_extent[3];
-			uint32_t probe_axis_size;
-
-			float cam_transform[16];
-		};
-
-		SdfgiDebugShaderRD debug;
-		RID debug_shader;
-		RID debug_shader_version;
-		RID debug_pipeline;
-
-		enum ProbeDebugMode {
-			PROBE_DEBUG_PROBES,
-			PROBE_DEBUG_VISIBILITY,
-			PROBE_DEBUG_MAX
-		};
-
-		struct DebugProbesPushConstant {
-			float projection[16];
-
-			uint32_t band_power;
-			uint32_t sections_in_band;
-			uint32_t band_mask;
-			float section_arc;
-
-			float grid_size[3];
-			uint32_t cascade;
-
-			uint32_t pad;
-			float y_mult;
-			int32_t probe_debug_index;
-			int32_t probe_axis_size;
-		};
-
-		SdfgiDebugProbesShaderRD debug_probes;
-		RID debug_probes_shader;
-		RID debug_probes_shader_version;
-
-		PipelineCacheRD debug_probes_pipeline[PROBE_DEBUG_MAX];
-
-		struct Light {
-			float color[3];
-			float energy;
-
-			float direction[3];
-			uint32_t has_shadow;
-
-			float position[3];
-			float attenuation;
-
-			uint32_t type;
-			float cos_spot_angle;
-			float inv_spot_attenuation;
-			float radius;
-
-			float shadow_color[4];
-		};
-
-		struct DirectLightPushConstant {
-			float grid_size[3];
-			uint32_t max_cascades;
-
-			uint32_t cascade;
-			uint32_t light_count;
-			uint32_t process_offset;
-			uint32_t process_increment;
-
-			int32_t probe_axis_size;
-			float bounce_feedback;
-			float y_mult;
-			uint32_t use_occlusion;
-		};
-
-		enum {
-			DIRECT_LIGHT_MODE_STATIC,
-			DIRECT_LIGHT_MODE_DYNAMIC,
-			DIRECT_LIGHT_MODE_MAX
-		};
-		SdfgiDirectLightShaderRD direct_light;
-		RID direct_light_shader;
-		RID direct_light_pipeline[DIRECT_LIGHT_MODE_MAX];
-
-		enum {
-			INTEGRATE_MODE_PROCESS,
-			INTEGRATE_MODE_STORE,
-			INTEGRATE_MODE_SCROLL,
-			INTEGRATE_MODE_SCROLL_STORE,
-			INTEGRATE_MODE_MAX
-		};
-		struct IntegratePushConstant {
-			enum {
-				SKY_MODE_DISABLED,
-				SKY_MODE_COLOR,
-				SKY_MODE_SKY,
-			};
-
-			float grid_size[3];
-			uint32_t max_cascades;
-
-			uint32_t probe_axis_size;
-			uint32_t cascade;
-			uint32_t history_index;
-			uint32_t history_size;
-
-			uint32_t ray_count;
-			float ray_bias;
-			int32_t image_size[2];
-
-			int32_t world_offset[3];
-			uint32_t sky_mode;
-
-			int32_t scroll[3];
-			float sky_energy;
-
-			float sky_color[3];
-			float y_mult;
-
-			uint32_t store_ambient_texture;
-			uint32_t pad[3];
-		};
-
-		SdfgiIntegrateShaderRD integrate;
-		RID integrate_shader;
-		RID integrate_pipeline[INTEGRATE_MODE_MAX];
-
-		RID integrate_default_sky_uniform_set;
-
-	} sdfgi_shader;
-
-	void _sdfgi_erase(RenderBuffers *rb);
-	int _sdfgi_get_pending_region_data(RID p_render_buffers, int p_region, Vector3i &r_local_offset, Vector3i &r_local_size, AABB &r_bounds) const;
-	void _sdfgi_update_cascades(RID p_render_buffers);
 
 	/* GI */
-
-	struct GI {
-		struct SDFGIData {
-			float grid_size[3];
-			uint32_t max_cascades;
-
-			uint32_t use_occlusion;
-			int32_t probe_axis_size;
-			float probe_to_uvw;
-			float normal_bias;
-
-			float lightprobe_tex_pixel_size[3];
-			float energy;
-
-			float lightprobe_uv_offset[3];
-			float y_mult;
-
-			float occlusion_clamp[3];
-			uint32_t pad3;
-
-			float occlusion_renormalize[3];
-			uint32_t pad4;
-
-			float cascade_probe_size[3];
-			uint32_t pad5;
-
-			struct ProbeCascadeData {
-				float position[3]; //offset of (0,0,0) in world coordinates
-				float to_probe; // 1/bounds * grid_size
-				int32_t probe_world_offset[3];
-				float to_cell; // 1/bounds * grid_size
-			};
-
-			ProbeCascadeData cascades[SDFGI::MAX_CASCADES];
-		};
-
-		struct GIProbeData {
-			float xform[16];
-			float bounds[3];
-			float dynamic_range;
-
-			float bias;
-			float normal_bias;
-			uint32_t blend_ambient;
-			uint32_t texture_slot;
-
-			float anisotropy_strength;
-			float ao;
-			float ao_size;
-			uint32_t mipmaps;
-		};
-
-		struct PushConstant {
-			int32_t screen_size[2];
-			float z_near;
-			float z_far;
-
-			float proj_info[4];
-			float ao_color[3];
-			uint32_t max_giprobes;
-
-			uint32_t high_quality_vct;
-			uint32_t orthogonal;
-			uint32_t pad[2];
-
-			float cam_rotation[12];
-		};
-
-		RID sdfgi_ubo;
-		enum Mode {
-			MODE_GIPROBE,
-			MODE_SDFGI,
-			MODE_COMBINED,
-			MODE_HALF_RES_GIPROBE,
-			MODE_HALF_RES_SDFGI,
-			MODE_HALF_RES_COMBINED,
-			MODE_MAX
-		};
-
-		bool half_resolution = false;
-		GiShaderRD shader;
-		RID shader_version;
-		RID pipelines[MODE_MAX];
-	} gi;
-
 	bool screen_space_roughness_limiter = false;
 	float screen_space_roughness_limiter_amount = 0.25;
 	float screen_space_roughness_limiter_limit = 0.18;
@@ -1326,7 +447,6 @@ private:
 
 	void _render_buffers_debug_draw(RID p_render_buffers, RID p_shadow_atlas);
 	void _render_buffers_post_process_and_tonemap(RID p_render_buffers, RID p_environment, RID p_camera_effects, const CameraMatrix &p_projection);
-	void _sdfgi_debug_draw(RID p_render_buffers, const CameraMatrix &p_projection, const Transform &p_transform);
 
 	/* Cluster */
 
@@ -1592,17 +712,17 @@ private:
 	uint64_t scene_pass = 0;
 	uint64_t shadow_atlas_realloc_tolerance_msec = 500;
 
+	/* !BAS! is this used anywhere?
 	struct SDFGICosineNeighbour {
 		uint32_t neighbour;
 		float weight;
 	};
+	*/
 
 	uint32_t max_cluster_elements = 512;
 	bool low_end = false;
 
 	void _render_shadow_pass(RID p_light, RID p_shadow_atlas, int p_pass, const PagedArray<GeometryInstance *> &p_instances, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0, float p_screen_lod_threshold = 0.0, bool p_open_pass = true, bool p_close_pass = true, bool p_clear_region = true);
-	void _render_sdfgi_region(RID p_render_buffers, int p_region, const PagedArray<GeometryInstance *> &p_instances);
-	void _render_sdfgi_static_lights(RID p_render_buffers, uint32_t p_cascade_count, const uint32_t *p_cascade_indices, const PagedArray<RID> *p_positional_light_cull_result);
 
 public:
 	virtual Transform geometry_instance_get_transform(GeometryInstance *p_instance) = 0;
@@ -1646,12 +766,12 @@ public:
 
 	/* SDFGI UPDATE */
 
-	int sdfgi_get_lightprobe_octahedron_size() const { return SDFGI::LIGHTPROBE_OCT_SIZE; }
 	virtual void sdfgi_update(RID p_render_buffers, RID p_environment, const Vector3 &p_world_position);
 	virtual int sdfgi_get_pending_region_count(RID p_render_buffers) const;
 	virtual AABB sdfgi_get_pending_region_bounds(RID p_render_buffers, int p_region) const;
 	virtual uint32_t sdfgi_get_pending_region_cascade(RID p_render_buffers, int p_region) const;
 	RID sdfgi_get_ubo() const { return gi.sdfgi_ubo; }
+
 	/* SKY API */
 
 	virtual RID sky_allocate();
@@ -1661,10 +781,6 @@ public:
 	void sky_set_mode(RID p_sky, RS::SkyMode p_mode);
 	void sky_set_material(RID p_sky, RID p_material);
 	Ref<Image> sky_bake_panorama(RID p_sky, float p_energy, bool p_bake_irradiance, const Size2i &p_size);
-
-	RID sky_get_radiance_texture_rd(RID p_sky) const;
-	RID sky_get_radiance_uniform_set_rd(RID p_sky, RID p_shader, int p_set) const;
-	RID sky_get_material(RID p_sky) const;
 
 	/* ENVIRONMENT API */
 
@@ -1974,52 +1090,54 @@ public:
 		return li->transform;
 	}
 
+	// !BAS! Need to check which of these we move into RenderSceneGIRD or whether we keep this the way it is now
+
 	RID gi_probe_instance_create(RID p_base);
 	void gi_probe_instance_set_transform_to_data(RID p_probe, const Transform &p_xform);
 	bool gi_probe_needs_update(RID p_probe) const;
 	void gi_probe_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RendererSceneRender::GeometryInstance *> &p_dynamic_objects);
 
-	void gi_probe_set_quality(RS::GIProbeQuality p_quality) { gi_probe_quality = p_quality; }
+	void gi_probe_set_quality(RS::GIProbeQuality p_quality) { gi.gi_probe_quality = p_quality; }
 
 	_FORCE_INLINE_ uint32_t gi_probe_instance_get_slot(RID p_probe) {
-		GIProbeInstance *gi_probe = gi_probe_instance_owner.getornull(p_probe);
+		RendererSceneGIRD::GIProbeInstance *gi_probe = gi.gi_probe_instance_owner.getornull(p_probe);
 		return gi_probe->slot;
 	}
 	_FORCE_INLINE_ RID gi_probe_instance_get_base_probe(RID p_probe) {
-		GIProbeInstance *gi_probe = gi_probe_instance_owner.getornull(p_probe);
+		RendererSceneGIRD::GIProbeInstance *gi_probe = gi.gi_probe_instance_owner.getornull(p_probe);
 		return gi_probe->probe;
 	}
 	_FORCE_INLINE_ Transform gi_probe_instance_get_transform_to_cell(RID p_probe) {
-		GIProbeInstance *gi_probe = gi_probe_instance_owner.getornull(p_probe);
+		RendererSceneGIRD::GIProbeInstance *gi_probe = gi.gi_probe_instance_owner.getornull(p_probe);
 		return storage->gi_probe_get_to_cell_xform(gi_probe->probe) * gi_probe->transform.affine_inverse();
 	}
 
 	_FORCE_INLINE_ RID gi_probe_instance_get_texture(RID p_probe) {
-		GIProbeInstance *gi_probe = gi_probe_instance_owner.getornull(p_probe);
+		RendererSceneGIRD::GIProbeInstance *gi_probe = gi.gi_probe_instance_owner.getornull(p_probe);
 		return gi_probe->texture;
 	}
 
 	_FORCE_INLINE_ void gi_probe_instance_set_render_index(RID p_instance, uint32_t p_render_index) {
-		GIProbeInstance *gi_probe = gi_probe_instance_owner.getornull(p_instance);
+		RendererSceneGIRD::GIProbeInstance *gi_probe = gi.gi_probe_instance_owner.getornull(p_instance);
 		ERR_FAIL_COND(!gi_probe);
 		gi_probe->render_index = p_render_index;
 	}
 
 	_FORCE_INLINE_ uint32_t gi_probe_instance_get_render_index(RID p_instance) {
-		GIProbeInstance *gi_probe = gi_probe_instance_owner.getornull(p_instance);
+		RendererSceneGIRD::GIProbeInstance *gi_probe = gi.gi_probe_instance_owner.getornull(p_instance);
 		ERR_FAIL_COND_V(!gi_probe, 0);
 
 		return gi_probe->render_index;
 	}
 	/*
 	_FORCE_INLINE_ void gi_probe_instance_set_render_pass(RID p_instance, uint32_t p_render_pass) {
-		GIProbeInstance *g_probe = gi_probe_instance_owner.getornull(p_instance);
+		RendererSceneGIRD::GIProbeInstance *g_probe = gi_probe_instance_owner.getornull(p_instance);
 		ERR_FAIL_COND(!g_probe);
 		g_probe->last_pass = p_render_pass;
 	}
 
 	_FORCE_INLINE_ uint32_t gi_probe_instance_get_render_pass(RID p_instance) {
-		GIProbeInstance *g_probe = gi_probe_instance_owner.getornull(p_instance);
+		RendererSceneGIRD::GIProbeInstance *g_probe = gi_probe_instance_owner.getornull(p_instance);
 		ERR_FAIL_COND_V(!g_probe, 0);
 
 		return g_probe->last_pass;

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -1,0 +1,1491 @@
+/*************************************************************************/
+/*  renderer_scene_sky_rd.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "renderer_scene_sky_rd.h"
+#include "core/config/project_settings.h"
+#include "renderer_scene_render_rd.h"
+#include "servers/rendering/rendering_server_default.h"
+
+////////////////////////////////////////////////////////////////////////////////
+// SKY SHADER
+
+void RendererSceneSkyRD::SkyShaderData::set_code(const String &p_code) {
+	//compile
+
+	code = p_code;
+	valid = false;
+	ubo_size = 0;
+	uniforms.clear();
+
+	if (code == String()) {
+		return; //just invalid, but no error
+	}
+
+	ShaderCompilerRD::GeneratedCode gen_code;
+	ShaderCompilerRD::IdentifierActions actions;
+
+	uses_time = false;
+	uses_half_res = false;
+	uses_quarter_res = false;
+	uses_position = false;
+	uses_light = false;
+
+	actions.render_mode_flags["use_half_res_pass"] = &uses_half_res;
+	actions.render_mode_flags["use_quarter_res_pass"] = &uses_quarter_res;
+
+	actions.usage_flag_pointers["TIME"] = &uses_time;
+	actions.usage_flag_pointers["POSITION"] = &uses_position;
+	actions.usage_flag_pointers["LIGHT0_ENABLED"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT0_ENERGY"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT0_DIRECTION"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT0_COLOR"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT0_SIZE"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT1_ENABLED"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT1_ENERGY"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT1_DIRECTION"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT1_COLOR"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT1_SIZE"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT2_ENABLED"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT2_ENERGY"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT2_DIRECTION"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT2_COLOR"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT2_SIZE"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT3_ENABLED"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT3_ENERGY"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT3_DIRECTION"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT3_COLOR"] = &uses_light;
+	actions.usage_flag_pointers["LIGHT3_SIZE"] = &uses_light;
+
+	actions.uniforms = &uniforms;
+
+	// !BAS! Contemplate making `SkyShader sky` accessible from this struct or even part of this struct.
+	RendererSceneRenderRD *scene_singleton = (RendererSceneRenderRD *)RendererSceneRenderRD::singleton;
+
+	Error err = scene_singleton->sky.sky_shader.compiler.compile(RS::SHADER_SKY, code, &actions, path, gen_code);
+
+	ERR_FAIL_COND(err != OK);
+
+	if (version.is_null()) {
+		version = scene_singleton->sky.sky_shader.shader.version_create();
+	}
+
+#if 0
+	print_line("**compiling shader:");
+	print_line("**defines:\n");
+	for (int i = 0; i < gen_code.defines.size(); i++) {
+		print_line(gen_code.defines[i]);
+	}
+	print_line("\n**uniforms:\n" + gen_code.uniforms);
+	//	print_line("\n**vertex_globals:\n" + gen_code.vertex_global);
+	//	print_line("\n**vertex_code:\n" + gen_code.vertex);
+	print_line("\n**fragment_globals:\n" + gen_code.fragment_global);
+	print_line("\n**fragment_code:\n" + gen_code.fragment);
+	print_line("\n**light_code:\n" + gen_code.light);
+#endif
+
+	scene_singleton->sky.sky_shader.shader.version_set_code(version, gen_code.uniforms, gen_code.vertex_global, gen_code.vertex, gen_code.fragment_global, gen_code.light, gen_code.fragment, gen_code.defines);
+	ERR_FAIL_COND(!scene_singleton->sky.sky_shader.shader.version_is_valid(version));
+
+	ubo_size = gen_code.uniform_total_size;
+	ubo_offsets = gen_code.uniform_offsets;
+	texture_uniforms = gen_code.texture_uniforms;
+
+	//update pipelines
+
+	for (int i = 0; i < SKY_VERSION_MAX; i++) {
+		RD::PipelineDepthStencilState depth_stencil_state;
+		depth_stencil_state.enable_depth_test = true;
+		depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_LESS_OR_EQUAL;
+
+		RID shader_variant = scene_singleton->sky.sky_shader.shader.version_get_shader(version, i);
+		pipelines[i].setup(shader_variant, RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), depth_stencil_state, RD::PipelineColorBlendState::create_disabled(), 0);
+	}
+
+	valid = true;
+}
+
+void RendererSceneSkyRD::SkyShaderData::set_default_texture_param(const StringName &p_name, RID p_texture) {
+	if (!p_texture.is_valid()) {
+		default_texture_params.erase(p_name);
+	} else {
+		default_texture_params[p_name] = p_texture;
+	}
+}
+
+void RendererSceneSkyRD::SkyShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+	Map<int, StringName> order;
+
+	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
+		if (E->get().scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_GLOBAL || E->get().scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+			continue;
+		}
+
+		if (E->get().texture_order >= 0) {
+			order[E->get().texture_order + 100000] = E->key();
+		} else {
+			order[E->get().order] = E->key();
+		}
+	}
+
+	for (Map<int, StringName>::Element *E = order.front(); E; E = E->next()) {
+		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E->get()]);
+		pi.name = E->get();
+		p_param_list->push_back(pi);
+	}
+}
+
+void RendererSceneSkyRD::SkyShaderData::get_instance_param_list(List<RendererStorage::InstanceShaderParam> *p_param_list) const {
+	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
+		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+			continue;
+		}
+
+		RendererStorage::InstanceShaderParam p;
+		p.info = ShaderLanguage::uniform_to_property_info(E->get());
+		p.info.name = E->key(); //supply name
+		p.index = E->get().instance_index;
+		p.default_value = ShaderLanguage::constant_value_to_variant(E->get().default_value, E->get().type, E->get().hint);
+		p_param_list->push_back(p);
+	}
+}
+
+bool RendererSceneSkyRD::SkyShaderData::is_param_texture(const StringName &p_param) const {
+	if (!uniforms.has(p_param)) {
+		return false;
+	}
+
+	return uniforms[p_param].texture_order >= 0;
+}
+
+bool RendererSceneSkyRD::SkyShaderData::is_animated() const {
+	return false;
+}
+
+bool RendererSceneSkyRD::SkyShaderData::casts_shadows() const {
+	return false;
+}
+
+Variant RendererSceneSkyRD::SkyShaderData::get_default_parameter(const StringName &p_parameter) const {
+	if (uniforms.has(p_parameter)) {
+		ShaderLanguage::ShaderNode::Uniform uniform = uniforms[p_parameter];
+		Vector<ShaderLanguage::ConstantNode::Value> default_value = uniform.default_value;
+		return ShaderLanguage::constant_value_to_variant(default_value, uniform.type, uniform.hint);
+	}
+	return Variant();
+}
+
+RS::ShaderNativeSourceCode RendererSceneSkyRD::SkyShaderData::get_native_source_code() const {
+	RendererSceneRenderRD *scene_singleton = (RendererSceneRenderRD *)RendererSceneRenderRD::singleton;
+
+	return scene_singleton->sky.sky_shader.shader.version_get_native_source_code(version);
+}
+
+RendererSceneSkyRD::SkyShaderData::SkyShaderData() {
+	valid = false;
+}
+
+RendererSceneSkyRD::SkyShaderData::~SkyShaderData() {
+	RendererSceneRenderRD *scene_singleton = (RendererSceneRenderRD *)RendererSceneRenderRD::singleton;
+	ERR_FAIL_COND(!scene_singleton);
+	//pipeline variants will clear themselves if shader is gone
+	if (version.is_valid()) {
+		scene_singleton->sky.sky_shader.shader.version_free(version);
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Sky material
+
+void RendererSceneSkyRD::SkyMaterialData::update_parameters(const Map<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) {
+	RendererSceneRenderRD *scene_singleton = (RendererSceneRenderRD *)RendererSceneRenderRD::singleton;
+
+	uniform_set_updated = true;
+
+	if ((uint32_t)ubo_data.size() != shader_data->ubo_size) {
+		p_uniform_dirty = true;
+		if (uniform_buffer.is_valid()) {
+			RD::get_singleton()->free(uniform_buffer);
+			uniform_buffer = RID();
+		}
+
+		ubo_data.resize(shader_data->ubo_size);
+		if (ubo_data.size()) {
+			uniform_buffer = RD::get_singleton()->uniform_buffer_create(ubo_data.size());
+			memset(ubo_data.ptrw(), 0, ubo_data.size()); //clear
+		}
+
+		//clear previous uniform set
+		if (uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(uniform_set)) {
+			RD::get_singleton()->free(uniform_set);
+			uniform_set = RID();
+		}
+	}
+
+	//check whether buffer changed
+	if (p_uniform_dirty && ubo_data.size()) {
+		update_uniform_buffer(shader_data->uniforms, shader_data->ubo_offsets.ptr(), p_parameters, ubo_data.ptrw(), ubo_data.size(), false);
+		RD::get_singleton()->buffer_update(uniform_buffer, 0, ubo_data.size(), ubo_data.ptrw());
+	}
+
+	uint32_t tex_uniform_count = shader_data->texture_uniforms.size();
+
+	if ((uint32_t)texture_cache.size() != tex_uniform_count) {
+		texture_cache.resize(tex_uniform_count);
+		p_textures_dirty = true;
+
+		//clear previous uniform set
+		if (uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(uniform_set)) {
+			RD::get_singleton()->free(uniform_set);
+			uniform_set = RID();
+		}
+	}
+
+	if (p_textures_dirty && tex_uniform_count) {
+		update_textures(p_parameters, shader_data->default_texture_params, shader_data->texture_uniforms, texture_cache.ptrw(), true);
+	}
+
+	if (shader_data->ubo_size == 0 && shader_data->texture_uniforms.size() == 0) {
+		// This material does not require an uniform set, so don't create it.
+		return;
+	}
+
+	if (!p_textures_dirty && uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(uniform_set)) {
+		//no reason to update uniform set, only UBO (or nothing) was needed to update
+		return;
+	}
+
+	Vector<RD::Uniform> uniforms;
+
+	{
+		if (shader_data->ubo_size) {
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.binding = 0;
+			u.ids.push_back(uniform_buffer);
+			uniforms.push_back(u);
+		}
+
+		const RID *textures = texture_cache.ptrw();
+		for (uint32_t i = 0; i < tex_uniform_count; i++) {
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 1 + i;
+			u.ids.push_back(textures[i]);
+			uniforms.push_back(u);
+		}
+	}
+
+	uniform_set = RD::get_singleton()->uniform_set_create(uniforms, scene_singleton->sky.sky_shader.shader.version_get_shader(shader_data->version, 0), SKY_SET_MATERIAL);
+}
+
+RendererSceneSkyRD::SkyMaterialData::~SkyMaterialData() {
+	if (uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(uniform_set)) {
+		RD::get_singleton()->free(uniform_set);
+	}
+
+	if (uniform_buffer.is_valid()) {
+		RD::get_singleton()->free(uniform_buffer);
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ReflectionData
+
+void RendererSceneSkyRD::ReflectionData::clear_reflection_data() {
+	layers.clear();
+	radiance_base_cubemap = RID();
+	if (downsampled_radiance_cubemap.is_valid()) {
+		RD::get_singleton()->free(downsampled_radiance_cubemap);
+	}
+	downsampled_radiance_cubemap = RID();
+	downsampled_layer.mipmaps.clear();
+	coefficient_buffer = RID();
+}
+
+void RendererSceneSkyRD::ReflectionData::update_reflection_data(int p_size, int p_mipmaps, bool p_use_array, RID p_base_cube, int p_base_layer, bool p_low_quality, int p_roughness_layers) {
+	//recreate radiance and all data
+
+	int mipmaps = p_mipmaps;
+	uint32_t w = p_size, h = p_size;
+
+	if (p_use_array) {
+		int num_layers = p_low_quality ? 8 : p_roughness_layers;
+
+		for (int i = 0; i < num_layers; i++) {
+			ReflectionData::Layer layer;
+			uint32_t mmw = w;
+			uint32_t mmh = h;
+			layer.mipmaps.resize(mipmaps);
+			layer.views.resize(mipmaps);
+			for (int j = 0; j < mipmaps; j++) {
+				ReflectionData::Layer::Mipmap &mm = layer.mipmaps.write[j];
+				mm.size.width = mmw;
+				mm.size.height = mmh;
+				for (int k = 0; k < 6; k++) {
+					mm.views[k] = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), p_base_cube, p_base_layer + i * 6 + k, j);
+					Vector<RID> fbtex;
+					fbtex.push_back(mm.views[k]);
+					mm.framebuffers[k] = RD::get_singleton()->framebuffer_create(fbtex);
+				}
+
+				layer.views.write[j] = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), p_base_cube, p_base_layer + i * 6, j, RD::TEXTURE_SLICE_CUBEMAP);
+
+				mmw = MAX(1, mmw >> 1);
+				mmh = MAX(1, mmh >> 1);
+			}
+
+			layers.push_back(layer);
+		}
+
+	} else {
+		mipmaps = p_low_quality ? 8 : mipmaps;
+		//regular cubemap, lower quality (aliasing, less memory)
+		ReflectionData::Layer layer;
+		uint32_t mmw = w;
+		uint32_t mmh = h;
+		layer.mipmaps.resize(mipmaps);
+		layer.views.resize(mipmaps);
+		for (int j = 0; j < mipmaps; j++) {
+			ReflectionData::Layer::Mipmap &mm = layer.mipmaps.write[j];
+			mm.size.width = mmw;
+			mm.size.height = mmh;
+			for (int k = 0; k < 6; k++) {
+				mm.views[k] = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), p_base_cube, p_base_layer + k, j);
+				Vector<RID> fbtex;
+				fbtex.push_back(mm.views[k]);
+				mm.framebuffers[k] = RD::get_singleton()->framebuffer_create(fbtex);
+			}
+
+			layer.views.write[j] = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), p_base_cube, p_base_layer, j, RD::TEXTURE_SLICE_CUBEMAP);
+
+			mmw = MAX(1, mmw >> 1);
+			mmh = MAX(1, mmh >> 1);
+		}
+
+		layers.push_back(layer);
+	}
+
+	radiance_base_cubemap = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), p_base_cube, p_base_layer, 0, RD::TEXTURE_SLICE_CUBEMAP);
+
+	RD::TextureFormat tf;
+	tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+	tf.width = 64; // Always 64x64
+	tf.height = 64;
+	tf.texture_type = RD::TEXTURE_TYPE_CUBE;
+	tf.array_layers = 6;
+	tf.mipmaps = 7;
+	tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+
+	downsampled_radiance_cubemap = RD::get_singleton()->texture_create(tf, RD::TextureView());
+	{
+		uint32_t mmw = 64;
+		uint32_t mmh = 64;
+		downsampled_layer.mipmaps.resize(7);
+		for (int j = 0; j < downsampled_layer.mipmaps.size(); j++) {
+			ReflectionData::DownsampleLayer::Mipmap &mm = downsampled_layer.mipmaps.write[j];
+			mm.size.width = mmw;
+			mm.size.height = mmh;
+			mm.view = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), downsampled_radiance_cubemap, 0, j, RD::TEXTURE_SLICE_CUBEMAP);
+
+			mmw = MAX(1, mmw >> 1);
+			mmh = MAX(1, mmh >> 1);
+		}
+	}
+}
+
+void RendererSceneSkyRD::ReflectionData::create_reflection_fast_filter(RendererStorageRD *p_storage, bool p_use_arrays) {
+	p_storage->get_effects()->cubemap_downsample(radiance_base_cubemap, downsampled_layer.mipmaps[0].view, downsampled_layer.mipmaps[0].size);
+
+	for (int i = 1; i < downsampled_layer.mipmaps.size(); i++) {
+		p_storage->get_effects()->cubemap_downsample(downsampled_layer.mipmaps[i - 1].view, downsampled_layer.mipmaps[i].view, downsampled_layer.mipmaps[i].size);
+	}
+
+	Vector<RID> views;
+	if (p_use_arrays) {
+		for (int i = 1; i < layers.size(); i++) {
+			views.push_back(layers[i].views[0]);
+		}
+	} else {
+		for (int i = 1; i < layers[0].views.size(); i++) {
+			views.push_back(layers[0].views[i]);
+		}
+	}
+
+	p_storage->get_effects()->cubemap_filter(downsampled_radiance_cubemap, views, p_use_arrays);
+}
+
+void RendererSceneSkyRD::ReflectionData::create_reflection_importance_sample(RendererStorageRD *p_storage, bool p_use_arrays, int p_cube_side, int p_base_layer, uint32_t p_sky_ggx_samples_quality) {
+	if (p_use_arrays) {
+		//render directly to the layers
+		p_storage->get_effects()->cubemap_roughness(radiance_base_cubemap, layers[p_base_layer].views[0], p_cube_side, p_sky_ggx_samples_quality, float(p_base_layer) / (layers.size() - 1.0), layers[p_base_layer].mipmaps[0].size.x);
+	} else {
+		p_storage->get_effects()->cubemap_roughness(
+				layers[0].views[p_base_layer - 1],
+				layers[0].views[p_base_layer],
+				p_cube_side,
+				p_sky_ggx_samples_quality,
+				float(p_base_layer) / (layers[0].mipmaps.size() - 1.0),
+				layers[0].mipmaps[p_base_layer].size.x);
+	}
+}
+
+void RendererSceneSkyRD::ReflectionData::update_reflection_mipmaps(RendererStorageRD *p_storage, int p_start, int p_end) {
+	for (int i = p_start; i < p_end; i++) {
+		for (int j = 0; j < layers[i].views.size() - 1; j++) {
+			RID view = layers[i].views[j];
+			RID texture = layers[i].views[j + 1];
+			Size2i size = layers[i].mipmaps[j + 1].size;
+			p_storage->get_effects()->cubemap_downsample(view, texture, size);
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// RendererSceneSkyRD::Sky
+
+void RendererSceneSkyRD::Sky::free(RendererStorageRD *p_storage) {
+	if (radiance.is_valid()) {
+		RD::get_singleton()->free(radiance);
+		radiance = RID();
+	}
+	reflection.clear_reflection_data();
+
+	if (uniform_buffer.is_valid()) {
+		RD::get_singleton()->free(uniform_buffer);
+		uniform_buffer = RID();
+	}
+
+	if (half_res_pass.is_valid()) {
+		RD::get_singleton()->free(half_res_pass);
+		half_res_pass = RID();
+	}
+
+	if (quarter_res_pass.is_valid()) {
+		RD::get_singleton()->free(quarter_res_pass);
+		quarter_res_pass = RID();
+	}
+
+	if (material.is_valid()) {
+		p_storage->free(material);
+	}
+}
+
+RID RendererSceneSkyRD::Sky::get_textures(RendererStorageRD *p_storage, SkyTextureSetVersion p_version, RID p_default_shader_rd) {
+	if (texture_uniform_sets[p_version].is_valid() && RD::get_singleton()->uniform_set_is_valid(texture_uniform_sets[p_version])) {
+		return texture_uniform_sets[p_version];
+	}
+	Vector<RD::Uniform> uniforms;
+	{
+		RD::Uniform u;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+		u.binding = 0;
+		if (radiance.is_valid() && p_version <= SKY_TEXTURE_SET_QUARTER_RES) {
+			u.ids.push_back(radiance);
+		} else {
+			u.ids.push_back(p_storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
+		}
+		uniforms.push_back(u);
+	}
+	{
+		RD::Uniform u;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+		u.binding = 1; // half res
+		if (half_res_pass.is_valid() && p_version != SKY_TEXTURE_SET_HALF_RES && p_version != SKY_TEXTURE_SET_CUBEMAP_HALF_RES) {
+			if (p_version >= SKY_TEXTURE_SET_CUBEMAP) {
+				u.ids.push_back(reflection.layers[0].views[1]);
+			} else {
+				u.ids.push_back(half_res_pass);
+			}
+		} else {
+			if (p_version < SKY_TEXTURE_SET_CUBEMAP) {
+				u.ids.push_back(p_storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_WHITE));
+			} else {
+				u.ids.push_back(p_storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
+			}
+		}
+		uniforms.push_back(u);
+	}
+	{
+		RD::Uniform u;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+		u.binding = 2; // quarter res
+		if (quarter_res_pass.is_valid() && p_version != SKY_TEXTURE_SET_QUARTER_RES && p_version != SKY_TEXTURE_SET_CUBEMAP_QUARTER_RES) {
+			if (p_version >= SKY_TEXTURE_SET_CUBEMAP) {
+				u.ids.push_back(reflection.layers[0].views[2]);
+			} else {
+				u.ids.push_back(quarter_res_pass);
+			}
+		} else {
+			if (p_version < SKY_TEXTURE_SET_CUBEMAP) {
+				u.ids.push_back(p_storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_WHITE));
+			} else {
+				u.ids.push_back(p_storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
+			}
+		}
+		uniforms.push_back(u);
+	}
+
+	texture_uniform_sets[p_version] = RD::get_singleton()->uniform_set_create(uniforms, p_default_shader_rd, SKY_SET_TEXTURES);
+	return texture_uniform_sets[p_version];
+}
+
+bool RendererSceneSkyRD::Sky::set_radiance_size(int p_radiance_size) {
+	ERR_FAIL_COND_V(p_radiance_size < 32 || p_radiance_size > 2048, false);
+	if (radiance_size == p_radiance_size) {
+		return false;
+	}
+	radiance_size = p_radiance_size;
+
+	if (mode == RS::SKY_MODE_REALTIME && radiance_size != 256) {
+		WARN_PRINT("Realtime Skies can only use a radiance size of 256. Radiance size will be set to 256 internally.");
+		radiance_size = 256;
+	}
+
+	if (radiance.is_valid()) {
+		RD::get_singleton()->free(radiance);
+		radiance = RID();
+	}
+	reflection.clear_reflection_data();
+
+	return true;
+}
+
+bool RendererSceneSkyRD::Sky::set_mode(RS::SkyMode p_mode) {
+	if (mode == p_mode) {
+		return false;
+	}
+
+	mode = p_mode;
+
+	if (mode == RS::SKY_MODE_REALTIME && radiance_size != 256) {
+		WARN_PRINT("Realtime Skies can only use a radiance size of 256. Radiance size will be set to 256 internally.");
+		set_radiance_size(256);
+	}
+
+	if (radiance.is_valid()) {
+		RD::get_singleton()->free(radiance);
+		radiance = RID();
+	}
+	reflection.clear_reflection_data();
+
+	return true;
+}
+
+bool RendererSceneSkyRD::Sky::set_material(RID p_material) {
+	if (material == p_material) {
+		return false;
+	}
+
+	material = p_material;
+	return true;
+}
+
+Ref<Image> RendererSceneSkyRD::Sky::bake_panorama(RendererStorageRD *p_storage, float p_energy, int p_roughness_layers, const Size2i &p_size) {
+	if (radiance.is_valid()) {
+		RD::TextureFormat tf;
+		tf.format = RD::DATA_FORMAT_R32G32B32A32_SFLOAT;
+		tf.width = p_size.width;
+		tf.height = p_size.height;
+		tf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+
+		RID rad_tex = RD::get_singleton()->texture_create(tf, RD::TextureView());
+		p_storage->get_effects()->copy_cubemap_to_panorama(radiance, rad_tex, p_size, p_roughness_layers, reflection.layers.size() > 1);
+		Vector<uint8_t> data = RD::get_singleton()->texture_get_data(rad_tex, 0);
+		RD::get_singleton()->free(rad_tex);
+
+		Ref<Image> img;
+		img.instance();
+		img->create(p_size.width, p_size.height, false, Image::FORMAT_RGBAF, data);
+		for (int i = 0; i < p_size.width; i++) {
+			for (int j = 0; j < p_size.height; j++) {
+				Color c = img->get_pixel(i, j);
+				c.r *= p_energy;
+				c.g *= p_energy;
+				c.b *= p_energy;
+				img->set_pixel(i, j, c);
+			}
+		}
+		return img;
+	}
+
+	return Ref<Image>();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// RendererSceneSkyRD
+
+RendererStorageRD::ShaderData *RendererSceneSkyRD::_create_sky_shader_func() {
+	SkyShaderData *shader_data = memnew(SkyShaderData);
+	return shader_data;
+}
+
+RendererStorageRD::ShaderData *RendererSceneSkyRD::_create_sky_shader_funcs() {
+	// !BAS! Why isn't _create_sky_shader_func not just static too?
+	return static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton)->sky._create_sky_shader_func();
+};
+
+RendererStorageRD::MaterialData *RendererSceneSkyRD::_create_sky_material_func(SkyShaderData *p_shader) {
+	SkyMaterialData *material_data = memnew(SkyMaterialData);
+	material_data->shader_data = p_shader;
+	material_data->last_frame = false;
+	//update will happen later anyway so do nothing.
+	return material_data;
+}
+
+RendererStorageRD::MaterialData *RendererSceneSkyRD::_create_sky_material_funcs(RendererStorageRD::ShaderData *p_shader) {
+	// !BAS! same here, we could just make _create_sky_material_func static?
+	return static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton)->sky._create_sky_material_func(static_cast<SkyShaderData *>(p_shader));
+};
+
+RendererSceneSkyRD::RendererSceneSkyRD() {
+	roughness_layers = GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers");
+	sky_ggx_samples_quality = GLOBAL_GET("rendering/reflections/sky_reflections/ggx_samples");
+	sky_use_cubemap_array = GLOBAL_GET("rendering/reflections/sky_reflections/texture_array_reflections");
+}
+
+void RendererSceneSkyRD::init(RendererStorageRD *p_storage) {
+	storage = p_storage;
+
+	{
+		// Start with the directional lights for the sky
+		sky_scene_state.max_directional_lights = 4;
+		uint32_t directional_light_buffer_size = sky_scene_state.max_directional_lights * sizeof(SkyDirectionalLightData);
+		sky_scene_state.directional_lights = memnew_arr(SkyDirectionalLightData, sky_scene_state.max_directional_lights);
+		sky_scene_state.last_frame_directional_lights = memnew_arr(SkyDirectionalLightData, sky_scene_state.max_directional_lights);
+		sky_scene_state.last_frame_directional_light_count = sky_scene_state.max_directional_lights + 1;
+		sky_scene_state.directional_light_buffer = RD::get_singleton()->uniform_buffer_create(directional_light_buffer_size);
+
+		String defines = "\n#define MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS " + itos(sky_scene_state.max_directional_lights) + "\n";
+
+		// Initialize sky
+		Vector<String> sky_modes;
+		sky_modes.push_back(""); // Full size
+		sky_modes.push_back("\n#define USE_HALF_RES_PASS\n"); // Half Res
+		sky_modes.push_back("\n#define USE_QUARTER_RES_PASS\n"); // Quarter res
+		sky_modes.push_back("\n#define USE_CUBEMAP_PASS\n"); // Cubemap
+		sky_modes.push_back("\n#define USE_CUBEMAP_PASS\n#define USE_HALF_RES_PASS\n"); // Half Res Cubemap
+		sky_modes.push_back("\n#define USE_CUBEMAP_PASS\n#define USE_QUARTER_RES_PASS\n"); // Quarter res Cubemap
+		sky_shader.shader.initialize(sky_modes, defines);
+	}
+
+	// register our shader funds
+	storage->shader_set_data_request_function(RendererStorageRD::SHADER_TYPE_SKY, _create_sky_shader_funcs);
+	storage->material_set_data_request_function(RendererStorageRD::SHADER_TYPE_SKY, _create_sky_material_funcs);
+
+	{
+		ShaderCompilerRD::DefaultIdentifierActions actions;
+
+		actions.renames["COLOR"] = "color";
+		actions.renames["ALPHA"] = "alpha";
+		actions.renames["EYEDIR"] = "cube_normal";
+		actions.renames["POSITION"] = "params.position_multiplier.xyz";
+		actions.renames["SKY_COORDS"] = "panorama_coords";
+		actions.renames["SCREEN_UV"] = "uv";
+		actions.renames["TIME"] = "params.time";
+		actions.renames["HALF_RES_COLOR"] = "half_res_color";
+		actions.renames["QUARTER_RES_COLOR"] = "quarter_res_color";
+		actions.renames["RADIANCE"] = "radiance";
+		actions.renames["FOG"] = "custom_fog";
+		actions.renames["LIGHT0_ENABLED"] = "directional_lights.data[0].enabled";
+		actions.renames["LIGHT0_DIRECTION"] = "directional_lights.data[0].direction_energy.xyz";
+		actions.renames["LIGHT0_ENERGY"] = "directional_lights.data[0].direction_energy.w";
+		actions.renames["LIGHT0_COLOR"] = "directional_lights.data[0].color_size.xyz";
+		actions.renames["LIGHT0_SIZE"] = "directional_lights.data[0].color_size.w";
+		actions.renames["LIGHT1_ENABLED"] = "directional_lights.data[1].enabled";
+		actions.renames["LIGHT1_DIRECTION"] = "directional_lights.data[1].direction_energy.xyz";
+		actions.renames["LIGHT1_ENERGY"] = "directional_lights.data[1].direction_energy.w";
+		actions.renames["LIGHT1_COLOR"] = "directional_lights.data[1].color_size.xyz";
+		actions.renames["LIGHT1_SIZE"] = "directional_lights.data[1].color_size.w";
+		actions.renames["LIGHT2_ENABLED"] = "directional_lights.data[2].enabled";
+		actions.renames["LIGHT2_DIRECTION"] = "directional_lights.data[2].direction_energy.xyz";
+		actions.renames["LIGHT2_ENERGY"] = "directional_lights.data[2].direction_energy.w";
+		actions.renames["LIGHT2_COLOR"] = "directional_lights.data[2].color_size.xyz";
+		actions.renames["LIGHT2_SIZE"] = "directional_lights.data[2].color_size.w";
+		actions.renames["LIGHT3_ENABLED"] = "directional_lights.data[3].enabled";
+		actions.renames["LIGHT3_DIRECTION"] = "directional_lights.data[3].direction_energy.xyz";
+		actions.renames["LIGHT3_ENERGY"] = "directional_lights.data[3].direction_energy.w";
+		actions.renames["LIGHT3_COLOR"] = "directional_lights.data[3].color_size.xyz";
+		actions.renames["LIGHT3_SIZE"] = "directional_lights.data[3].color_size.w";
+		actions.renames["AT_CUBEMAP_PASS"] = "AT_CUBEMAP_PASS";
+		actions.renames["AT_HALF_RES_PASS"] = "AT_HALF_RES_PASS";
+		actions.renames["AT_QUARTER_RES_PASS"] = "AT_QUARTER_RES_PASS";
+		actions.custom_samplers["RADIANCE"] = "material_samplers[3]";
+		actions.usage_defines["HALF_RES_COLOR"] = "\n#define USES_HALF_RES_COLOR\n";
+		actions.usage_defines["QUARTER_RES_COLOR"] = "\n#define USES_QUARTER_RES_COLOR\n";
+		actions.render_mode_defines["disable_fog"] = "#define DISABLE_FOG\n";
+
+		actions.sampler_array_name = "material_samplers";
+		actions.base_texture_binding_index = 1;
+		actions.texture_layout_set = 1;
+		actions.base_uniform_string = "material.";
+		actions.base_varying_index = 10;
+
+		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
+		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
+		actions.global_buffer_array_variable = "global_variables.data";
+
+		sky_shader.compiler.initialize(actions);
+	}
+
+	{
+		// default material and shader for sky shader
+		sky_shader.default_shader = storage->shader_allocate();
+		storage->shader_initialize(sky_shader.default_shader);
+
+		storage->shader_set_code(sky_shader.default_shader, "shader_type sky; void fragment() { COLOR = vec3(0.0); } \n");
+
+		sky_shader.default_material = storage->material_allocate();
+		storage->material_initialize(sky_shader.default_material);
+
+		storage->material_set_shader(sky_shader.default_material, sky_shader.default_shader);
+
+		SkyMaterialData *md = (SkyMaterialData *)storage->material_get_data(sky_shader.default_material, RendererStorageRD::SHADER_TYPE_SKY);
+		sky_shader.default_shader_rd = sky_shader.shader.version_get_shader(md->shader_data->version, SKY_VERSION_BACKGROUND);
+
+		sky_scene_state.uniform_buffer = RD::get_singleton()->uniform_buffer_create(sizeof(SkySceneState::UBO));
+
+		Vector<RD::Uniform> uniforms;
+
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+			u.binding = 0;
+			u.ids.resize(12);
+			RID *ids_ptr = u.ids.ptrw();
+			ids_ptr[0] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			ids_ptr[1] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			ids_ptr[2] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			ids_ptr[3] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			ids_ptr[4] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			ids_ptr[5] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			ids_ptr[6] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST, RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
+			ids_ptr[7] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
+			ids_ptr[8] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
+			ids_ptr[9] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
+			ids_ptr[10] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC, RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
+			ids_ptr[11] = storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC, RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
+			uniforms.push_back(u);
+		}
+
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.binding = 1;
+			u.ids.push_back(storage->global_variables_get_storage_buffer());
+			uniforms.push_back(u);
+		}
+
+		{
+			RD::Uniform u;
+			u.binding = 2;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.ids.push_back(sky_scene_state.uniform_buffer);
+			uniforms.push_back(u);
+		}
+
+		{
+			RD::Uniform u;
+			u.binding = 3;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.ids.push_back(sky_scene_state.directional_light_buffer);
+			uniforms.push_back(u);
+		}
+
+		sky_scene_state.uniform_set = RD::get_singleton()->uniform_set_create(uniforms, sky_shader.default_shader_rd, SKY_SET_UNIFORMS);
+	}
+
+	{
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.binding = 0;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			RID vfog = storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+			u.ids.push_back(vfog);
+			uniforms.push_back(u);
+		}
+
+		sky_scene_state.default_fog_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, sky_shader.default_shader_rd, SKY_SET_FOG);
+	}
+
+	{
+		// Need defaults for using fog with clear color
+		sky_scene_state.fog_shader = storage->shader_allocate();
+		storage->shader_initialize(sky_scene_state.fog_shader);
+
+		storage->shader_set_code(sky_scene_state.fog_shader, "shader_type sky; uniform vec4 clear_color; void fragment() { COLOR = clear_color.rgb; } \n");
+		sky_scene_state.fog_material = storage->material_allocate();
+		storage->material_initialize(sky_scene_state.fog_material);
+
+		storage->material_set_shader(sky_scene_state.fog_material, sky_scene_state.fog_shader);
+
+		Vector<RD::Uniform> uniforms;
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 0;
+			u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 1;
+			u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_WHITE));
+			uniforms.push_back(u);
+		}
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 2;
+			u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_WHITE));
+			uniforms.push_back(u);
+		}
+
+		sky_scene_state.fog_only_texture_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, sky_shader.default_shader_rd, SKY_SET_TEXTURES);
+	}
+}
+
+void RendererSceneSkyRD::setup(RendererSceneEnvironmentRD *p_env, RID p_render_buffers, const CameraMatrix &p_projection, const Transform &p_transform, const Size2i p_screen_size, RendererSceneRenderRD *p_scene_render) {
+	ERR_FAIL_COND(!p_env); // I guess without an environment we also can't have a sky...
+
+	SkyMaterialData *material = nullptr;
+	Sky *sky = get_sky(p_env->sky);
+
+	RID sky_material;
+
+	SkyShaderData *shader_data = nullptr;
+
+	RS::EnvironmentBG background = p_env->background;
+
+	if (!(background == RS::ENV_BG_CLEAR_COLOR || background == RS::ENV_BG_COLOR) || sky) {
+		// !BAS! Possibly silently fail here, we now get error spam when you select sky as the background but haven't setup the sky yet.
+		ERR_FAIL_COND(!sky);
+		sky_material = sky_get_material(p_env->sky);
+
+		if (sky_material.is_valid()) {
+			material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+			if (!material || !material->shader_data->valid) {
+				material = nullptr;
+			}
+		}
+
+		if (!material) {
+			sky_material = sky_shader.default_material;
+			material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+		}
+
+		ERR_FAIL_COND(!material);
+
+		shader_data = material->shader_data;
+
+		ERR_FAIL_COND(!shader_data);
+	}
+
+	if (sky) {
+		// Invalidate supbass buffers if screen size changes
+		if (sky->screen_size != p_screen_size) {
+			sky->screen_size = p_screen_size;
+			sky->screen_size.x = sky->screen_size.x < 4 ? 4 : sky->screen_size.x;
+			sky->screen_size.y = sky->screen_size.y < 4 ? 4 : sky->screen_size.y;
+			if (shader_data->uses_half_res) {
+				if (sky->half_res_pass.is_valid()) {
+					RD::get_singleton()->free(sky->half_res_pass);
+					sky->half_res_pass = RID();
+				}
+				invalidate_sky(sky);
+			}
+			if (shader_data->uses_quarter_res) {
+				if (sky->quarter_res_pass.is_valid()) {
+					RD::get_singleton()->free(sky->quarter_res_pass);
+					sky->quarter_res_pass = RID();
+				}
+				invalidate_sky(sky);
+			}
+		}
+
+		// Create new subpass buffers if necessary
+		if ((shader_data->uses_half_res && sky->half_res_pass.is_null()) ||
+				(shader_data->uses_quarter_res && sky->quarter_res_pass.is_null()) ||
+				sky->radiance.is_null()) {
+			invalidate_sky(sky);
+			update_dirty_skys();
+		}
+
+		if (shader_data->uses_time && p_scene_render->time - sky->prev_time > 0.00001) {
+			sky->prev_time = p_scene_render->time;
+			sky->reflection.dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (material != sky->prev_material) {
+			sky->prev_material = material;
+			sky->reflection.dirty = true;
+		}
+
+		if (material->uniform_set_updated) {
+			material->uniform_set_updated = false;
+			sky->reflection.dirty = true;
+		}
+
+		if (!p_transform.origin.is_equal_approx(sky->prev_position) && shader_data->uses_position) {
+			sky->prev_position = p_transform.origin;
+			sky->reflection.dirty = true;
+		}
+
+		if (shader_data->uses_light) {
+			// Check whether the directional_light_buffer changes
+			bool light_data_dirty = false;
+
+			if (sky_scene_state.ubo.directional_light_count != sky_scene_state.last_frame_directional_light_count) {
+				light_data_dirty = true;
+				for (uint32_t i = sky_scene_state.ubo.directional_light_count; i < sky_scene_state.max_directional_lights; i++) {
+					sky_scene_state.directional_lights[i].enabled = false;
+				}
+			}
+			if (!light_data_dirty) {
+				for (uint32_t i = 0; i < sky_scene_state.ubo.directional_light_count; i++) {
+					if (sky_scene_state.directional_lights[i].direction[0] != sky_scene_state.last_frame_directional_lights[i].direction[0] ||
+							sky_scene_state.directional_lights[i].direction[1] != sky_scene_state.last_frame_directional_lights[i].direction[1] ||
+							sky_scene_state.directional_lights[i].direction[2] != sky_scene_state.last_frame_directional_lights[i].direction[2] ||
+							sky_scene_state.directional_lights[i].energy != sky_scene_state.last_frame_directional_lights[i].energy ||
+							sky_scene_state.directional_lights[i].color[0] != sky_scene_state.last_frame_directional_lights[i].color[0] ||
+							sky_scene_state.directional_lights[i].color[1] != sky_scene_state.last_frame_directional_lights[i].color[1] ||
+							sky_scene_state.directional_lights[i].color[2] != sky_scene_state.last_frame_directional_lights[i].color[2] ||
+							sky_scene_state.directional_lights[i].enabled != sky_scene_state.last_frame_directional_lights[i].enabled ||
+							sky_scene_state.directional_lights[i].size != sky_scene_state.last_frame_directional_lights[i].size) {
+						light_data_dirty = true;
+						break;
+					}
+				}
+			}
+
+			if (light_data_dirty) {
+				RD::get_singleton()->buffer_update(sky_scene_state.directional_light_buffer, 0, sizeof(SkyDirectionalLightData) * sky_scene_state.max_directional_lights, sky_scene_state.directional_lights);
+
+				SkyDirectionalLightData *temp = sky_scene_state.last_frame_directional_lights;
+				sky_scene_state.last_frame_directional_lights = sky_scene_state.directional_lights;
+				sky_scene_state.directional_lights = temp;
+				sky_scene_state.last_frame_directional_light_count = sky_scene_state.ubo.directional_light_count;
+				sky->reflection.dirty = true;
+			}
+		}
+	}
+
+	//setup fog variables
+	sky_scene_state.ubo.volumetric_fog_enabled = false;
+	if (p_render_buffers.is_valid()) {
+		if (p_scene_render->render_buffers_has_volumetric_fog(p_render_buffers)) {
+			sky_scene_state.ubo.volumetric_fog_enabled = true;
+
+			float fog_end = p_scene_render->render_buffers_get_volumetric_fog_end(p_render_buffers);
+			if (fog_end > 0.0) {
+				sky_scene_state.ubo.volumetric_fog_inv_length = 1.0 / fog_end;
+			} else {
+				sky_scene_state.ubo.volumetric_fog_inv_length = 1.0;
+			}
+
+			float fog_detail_spread = p_scene_render->render_buffers_get_volumetric_fog_detail_spread(p_render_buffers); //reverse lookup
+			if (fog_detail_spread > 0.0) {
+				sky_scene_state.ubo.volumetric_fog_detail_spread = 1.0 / fog_detail_spread;
+			} else {
+				sky_scene_state.ubo.volumetric_fog_detail_spread = 1.0;
+			}
+		}
+
+		RID fog_uniform_set = p_scene_render->render_buffers_get_volumetric_fog_sky_uniform_set(p_render_buffers);
+
+		if (fog_uniform_set != RID()) {
+			sky_scene_state.fog_uniform_set = fog_uniform_set;
+		} else {
+			sky_scene_state.fog_uniform_set = sky_scene_state.default_fog_uniform_set;
+		}
+	}
+
+	sky_scene_state.ubo.z_far = p_projection.get_z_far();
+	sky_scene_state.ubo.fog_enabled = p_env->fog_enabled;
+	sky_scene_state.ubo.fog_density = p_env->fog_density;
+	sky_scene_state.ubo.fog_aerial_perspective = p_env->fog_aerial_perspective;
+	Color fog_color = p_env->fog_light_color.to_linear();
+	float fog_energy = p_env->fog_light_energy;
+	sky_scene_state.ubo.fog_light_color[0] = fog_color.r * fog_energy;
+	sky_scene_state.ubo.fog_light_color[1] = fog_color.g * fog_energy;
+	sky_scene_state.ubo.fog_light_color[2] = fog_color.b * fog_energy;
+	sky_scene_state.ubo.fog_sun_scatter = p_env->fog_sun_scatter;
+
+	RD::get_singleton()->buffer_update(sky_scene_state.uniform_buffer, 0, sizeof(SkySceneState::UBO), &sky_scene_state.ubo);
+}
+
+void RendererSceneSkyRD::update(RendererSceneEnvironmentRD *p_env, const CameraMatrix &p_projection, const Transform &p_transform, double p_time) {
+	ERR_FAIL_COND(!p_env);
+
+	Sky *sky = get_sky(p_env->sky);
+	ERR_FAIL_COND(!sky);
+
+	RID sky_material = sky_get_material(p_env->sky);
+
+	SkyMaterialData *material = nullptr;
+
+	if (sky_material.is_valid()) {
+		material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+		if (!material || !material->shader_data->valid) {
+			material = nullptr;
+		}
+	}
+
+	if (!material) {
+		sky_material = sky_shader.default_material;
+		material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+	}
+
+	ERR_FAIL_COND(!material);
+
+	SkyShaderData *shader_data = material->shader_data;
+
+	ERR_FAIL_COND(!shader_data);
+
+	float multiplier = p_env->bg_energy;
+
+	bool update_single_frame = sky->mode == RS::SKY_MODE_REALTIME || sky->mode == RS::SKY_MODE_QUALITY;
+	RS::SkyMode sky_mode = sky->mode;
+
+	if (sky_mode == RS::SKY_MODE_AUTOMATIC) {
+		if (shader_data->uses_time || shader_data->uses_position) {
+			update_single_frame = true;
+			sky_mode = RS::SKY_MODE_REALTIME;
+		} else if (shader_data->uses_light || shader_data->ubo_size > 0) {
+			update_single_frame = false;
+			sky_mode = RS::SKY_MODE_INCREMENTAL;
+		} else {
+			update_single_frame = true;
+			sky_mode = RS::SKY_MODE_QUALITY;
+		}
+	}
+
+	if (sky->processing_layer == 0 && sky_mode == RS::SKY_MODE_INCREMENTAL) {
+		// On the first frame after creating sky, rebuild in single frame
+		update_single_frame = true;
+		sky_mode = RS::SKY_MODE_QUALITY;
+	}
+
+	int max_processing_layer = sky_use_cubemap_array ? sky->reflection.layers.size() : sky->reflection.layers[0].mipmaps.size();
+
+	// Update radiance cubemap
+	if (sky->reflection.dirty && (sky->processing_layer >= max_processing_layer || update_single_frame)) {
+		static const Vector3 view_normals[6] = {
+			Vector3(+1, 0, 0),
+			Vector3(-1, 0, 0),
+			Vector3(0, +1, 0),
+			Vector3(0, -1, 0),
+			Vector3(0, 0, +1),
+			Vector3(0, 0, -1)
+		};
+		static const Vector3 view_up[6] = {
+			Vector3(0, -1, 0),
+			Vector3(0, -1, 0),
+			Vector3(0, 0, +1),
+			Vector3(0, 0, -1),
+			Vector3(0, -1, 0),
+			Vector3(0, -1, 0)
+		};
+
+		CameraMatrix cm;
+		cm.set_perspective(90, 1, 0.01, 10.0);
+		CameraMatrix correction;
+		correction.set_depth_correction(true);
+		cm = correction * cm;
+
+		if (shader_data->uses_quarter_res) {
+			PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_CUBEMAP_QUARTER_RES];
+
+			Vector<Color> clear_colors;
+			clear_colors.push_back(Color(0.0, 0.0, 0.0));
+			RD::DrawListID cubemap_draw_list;
+
+			for (int i = 0; i < 6; i++) {
+				Transform local_view;
+				local_view.set_look_at(Vector3(0, 0, 0), view_normals[i], view_up[i]);
+				RID texture_uniform_set = sky->get_textures(storage, SKY_TEXTURE_SET_CUBEMAP_QUARTER_RES, sky_shader.default_shader_rd);
+
+				cubemap_draw_list = RD::get_singleton()->draw_list_begin(sky->reflection.layers[0].mipmaps[2].framebuffers[i], RD::INITIAL_ACTION_KEEP, RD::FINAL_ACTION_READ, RD::INITIAL_ACTION_KEEP, RD::FINAL_ACTION_DISCARD);
+				storage->get_effects()->render_sky(cubemap_draw_list, p_time, sky->reflection.layers[0].mipmaps[2].framebuffers[i], sky_scene_state.uniform_set, sky_scene_state.fog_uniform_set, pipeline, material->uniform_set, texture_uniform_set, cm, local_view.basis, multiplier, p_transform.origin);
+				RD::get_singleton()->draw_list_end();
+			}
+		}
+
+		if (shader_data->uses_half_res) {
+			PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_CUBEMAP_HALF_RES];
+
+			Vector<Color> clear_colors;
+			clear_colors.push_back(Color(0.0, 0.0, 0.0));
+			RD::DrawListID cubemap_draw_list;
+
+			for (int i = 0; i < 6; i++) {
+				Transform local_view;
+				local_view.set_look_at(Vector3(0, 0, 0), view_normals[i], view_up[i]);
+				RID texture_uniform_set = sky->get_textures(storage, SKY_TEXTURE_SET_CUBEMAP_HALF_RES, sky_shader.default_shader_rd);
+
+				cubemap_draw_list = RD::get_singleton()->draw_list_begin(sky->reflection.layers[0].mipmaps[1].framebuffers[i], RD::INITIAL_ACTION_KEEP, RD::FINAL_ACTION_READ, RD::INITIAL_ACTION_KEEP, RD::FINAL_ACTION_DISCARD);
+				storage->get_effects()->render_sky(cubemap_draw_list, p_time, sky->reflection.layers[0].mipmaps[1].framebuffers[i], sky_scene_state.uniform_set, sky_scene_state.fog_uniform_set, pipeline, material->uniform_set, texture_uniform_set, cm, local_view.basis, multiplier, p_transform.origin);
+				RD::get_singleton()->draw_list_end();
+			}
+		}
+
+		RD::DrawListID cubemap_draw_list;
+		PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_CUBEMAP];
+
+		for (int i = 0; i < 6; i++) {
+			Transform local_view;
+			local_view.set_look_at(Vector3(0, 0, 0), view_normals[i], view_up[i]);
+			RID texture_uniform_set = sky->get_textures(storage, SKY_TEXTURE_SET_CUBEMAP, sky_shader.default_shader_rd);
+
+			cubemap_draw_list = RD::get_singleton()->draw_list_begin(sky->reflection.layers[0].mipmaps[0].framebuffers[i], RD::INITIAL_ACTION_KEEP, RD::FINAL_ACTION_READ, RD::INITIAL_ACTION_KEEP, RD::FINAL_ACTION_DISCARD);
+			storage->get_effects()->render_sky(cubemap_draw_list, p_time, sky->reflection.layers[0].mipmaps[0].framebuffers[i], sky_scene_state.uniform_set, sky_scene_state.fog_uniform_set, pipeline, material->uniform_set, texture_uniform_set, cm, local_view.basis, multiplier, p_transform.origin);
+			RD::get_singleton()->draw_list_end();
+		}
+
+		if (sky_mode == RS::SKY_MODE_REALTIME) {
+			sky->reflection.create_reflection_fast_filter(storage, sky_use_cubemap_array);
+			if (sky_use_cubemap_array) {
+				sky->reflection.update_reflection_mipmaps(storage, 0, sky->reflection.layers.size());
+			}
+		} else {
+			if (update_single_frame) {
+				for (int i = 1; i < max_processing_layer; i++) {
+					sky->reflection.create_reflection_importance_sample(storage, sky_use_cubemap_array, 10, i, sky_ggx_samples_quality);
+				}
+				if (sky_use_cubemap_array) {
+					sky->reflection.update_reflection_mipmaps(storage, 0, sky->reflection.layers.size());
+				}
+			} else {
+				if (sky_use_cubemap_array) {
+					// Multi-Frame so just update the first array level
+					sky->reflection.update_reflection_mipmaps(storage, 0, 1);
+				}
+			}
+			sky->processing_layer = 1;
+		}
+
+		sky->reflection.dirty = false;
+
+	} else {
+		if (sky_mode == RS::SKY_MODE_INCREMENTAL && sky->processing_layer < max_processing_layer) {
+			sky->reflection.create_reflection_importance_sample(storage, sky_use_cubemap_array, 10, sky->processing_layer, sky_ggx_samples_quality);
+
+			if (sky_use_cubemap_array) {
+				sky->reflection.update_reflection_mipmaps(storage, sky->processing_layer, sky->processing_layer + 1);
+			}
+
+			sky->processing_layer++;
+		}
+	}
+}
+
+void RendererSceneSkyRD::draw(RendererSceneEnvironmentRD *p_env, bool p_can_continue_color, bool p_can_continue_depth, RID p_fb, const CameraMatrix &p_projection, const Transform &p_transform, double p_time) {
+	ERR_FAIL_COND(!p_env);
+
+	Sky *sky = get_sky(p_env->sky);
+	ERR_FAIL_COND(!sky);
+
+	SkyMaterialData *material = nullptr;
+	RID sky_material;
+
+	RS::EnvironmentBG background = p_env->background;
+
+	if (!(background == RS::ENV_BG_CLEAR_COLOR || background == RS::ENV_BG_COLOR) || sky) {
+		ERR_FAIL_COND(!sky);
+		sky_material = sky_get_material(p_env->sky);
+
+		if (sky_material.is_valid()) {
+			material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+			if (!material || !material->shader_data->valid) {
+				material = nullptr;
+			}
+		}
+
+		if (!material) {
+			sky_material = sky_shader.default_material;
+			material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+		}
+	}
+
+	if (background == RS::ENV_BG_CLEAR_COLOR || background == RS::ENV_BG_COLOR) {
+		sky_material = sky_scene_state.fog_material;
+		material = (SkyMaterialData *)storage->material_get_data(sky_material, RendererStorageRD::SHADER_TYPE_SKY);
+	}
+
+	ERR_FAIL_COND(!material);
+
+	SkyShaderData *shader_data = material->shader_data;
+
+	ERR_FAIL_COND(!shader_data);
+
+	Basis sky_transform = p_env->sky_orientation;
+	sky_transform.invert();
+
+	float multiplier = p_env->bg_energy;
+	float custom_fov = p_env->sky_custom_fov;
+	// Camera
+	CameraMatrix camera;
+
+	if (custom_fov) {
+		float near_plane = p_projection.get_z_near();
+		float far_plane = p_projection.get_z_far();
+		float aspect = p_projection.get_aspect();
+
+		camera.set_perspective(custom_fov, aspect, near_plane, far_plane);
+
+	} else {
+		camera = p_projection;
+	}
+
+	sky_transform = p_transform.basis * sky_transform;
+
+	if (shader_data->uses_quarter_res) {
+		PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_QUARTER_RES];
+
+		RID texture_uniform_set = sky->get_textures(storage, SKY_TEXTURE_SET_QUARTER_RES, sky_shader.default_shader_rd);
+
+		Vector<Color> clear_colors;
+		clear_colors.push_back(Color(0.0, 0.0, 0.0));
+
+		RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(sky->quarter_res_framebuffer, RD::INITIAL_ACTION_CLEAR, RD::FINAL_ACTION_READ, RD::INITIAL_ACTION_CLEAR, RD::FINAL_ACTION_DISCARD, clear_colors);
+		storage->get_effects()->render_sky(draw_list, p_time, sky->quarter_res_framebuffer, sky_scene_state.uniform_set, sky_scene_state.fog_uniform_set, pipeline, material->uniform_set, texture_uniform_set, camera, sky_transform, multiplier, p_transform.origin);
+		RD::get_singleton()->draw_list_end();
+	}
+
+	if (shader_data->uses_half_res) {
+		PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_HALF_RES];
+
+		RID texture_uniform_set = sky->get_textures(storage, SKY_TEXTURE_SET_HALF_RES, sky_shader.default_shader_rd);
+
+		Vector<Color> clear_colors;
+		clear_colors.push_back(Color(0.0, 0.0, 0.0));
+
+		RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(sky->half_res_framebuffer, RD::INITIAL_ACTION_CLEAR, RD::FINAL_ACTION_READ, RD::INITIAL_ACTION_CLEAR, RD::FINAL_ACTION_DISCARD, clear_colors);
+		storage->get_effects()->render_sky(draw_list, p_time, sky->half_res_framebuffer, sky_scene_state.uniform_set, sky_scene_state.fog_uniform_set, pipeline, material->uniform_set, texture_uniform_set, camera, sky_transform, multiplier, p_transform.origin);
+		RD::get_singleton()->draw_list_end();
+	}
+
+	PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_BACKGROUND];
+
+	RID texture_uniform_set;
+	if (sky) {
+		texture_uniform_set = sky->get_textures(storage, SKY_TEXTURE_SET_BACKGROUND, sky_shader.default_shader_rd);
+	} else {
+		texture_uniform_set = sky_scene_state.fog_only_texture_uniform_set;
+	}
+
+	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_fb, RD::INITIAL_ACTION_CONTINUE, p_can_continue_color ? RD::FINAL_ACTION_CONTINUE : RD::FINAL_ACTION_READ, RD::INITIAL_ACTION_CONTINUE, p_can_continue_depth ? RD::FINAL_ACTION_CONTINUE : RD::FINAL_ACTION_READ);
+	storage->get_effects()->render_sky(draw_list, p_time, p_fb, sky_scene_state.uniform_set, sky_scene_state.fog_uniform_set, pipeline, material->uniform_set, texture_uniform_set, camera, sky_transform, multiplier, p_transform.origin);
+	RD::get_singleton()->draw_list_end();
+}
+
+void RendererSceneSkyRD::invalidate_sky(Sky *p_sky) {
+	if (!p_sky->dirty) {
+		p_sky->dirty = true;
+		p_sky->dirty_list = dirty_sky_list;
+		dirty_sky_list = p_sky;
+	}
+}
+
+void RendererSceneSkyRD::update_dirty_skys() {
+	Sky *sky = dirty_sky_list;
+
+	while (sky) {
+		bool texture_set_dirty = false;
+		//update sky configuration if texture is missing
+
+		if (sky->radiance.is_null()) {
+			int mipmaps = Image::get_image_required_mipmaps(sky->radiance_size, sky->radiance_size, Image::FORMAT_RGBAH) + 1;
+
+			uint32_t w = sky->radiance_size, h = sky->radiance_size;
+			int layers = roughness_layers;
+			if (sky->mode == RS::SKY_MODE_REALTIME) {
+				layers = 8;
+				if (roughness_layers != 8) {
+					WARN_PRINT("When using REALTIME skies, roughness_layers should be set to 8 in the project settings for best quality reflections");
+				}
+			}
+
+			if (sky_use_cubemap_array) {
+				//array (higher quality, 6 times more memory)
+				RD::TextureFormat tf;
+				tf.array_layers = layers * 6;
+				tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+				tf.texture_type = RD::TEXTURE_TYPE_CUBE_ARRAY;
+				tf.mipmaps = mipmaps;
+				tf.width = w;
+				tf.height = h;
+				tf.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
+
+				sky->radiance = RD::get_singleton()->texture_create(tf, RD::TextureView());
+
+				sky->reflection.update_reflection_data(sky->radiance_size, mipmaps, true, sky->radiance, 0, sky->mode == RS::SKY_MODE_REALTIME, roughness_layers);
+
+			} else {
+				//regular cubemap, lower quality (aliasing, less memory)
+				RD::TextureFormat tf;
+				tf.array_layers = 6;
+				tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+				tf.texture_type = RD::TEXTURE_TYPE_CUBE;
+				tf.mipmaps = MIN(mipmaps, layers);
+				tf.width = w;
+				tf.height = h;
+				tf.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
+
+				sky->radiance = RD::get_singleton()->texture_create(tf, RD::TextureView());
+
+				sky->reflection.update_reflection_data(sky->radiance_size, MIN(mipmaps, layers), false, sky->radiance, 0, sky->mode == RS::SKY_MODE_REALTIME, roughness_layers);
+			}
+			texture_set_dirty = true;
+		}
+
+		// Create subpass buffers if they haven't been created already
+		if (sky->half_res_pass.is_null() && !RD::get_singleton()->texture_is_valid(sky->half_res_pass) && sky->screen_size.x >= 4 && sky->screen_size.y >= 4) {
+			RD::TextureFormat tformat;
+			tformat.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+			tformat.width = sky->screen_size.x / 2;
+			tformat.height = sky->screen_size.y / 2;
+			tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+			tformat.texture_type = RD::TEXTURE_TYPE_2D;
+
+			sky->half_res_pass = RD::get_singleton()->texture_create(tformat, RD::TextureView());
+			Vector<RID> texs;
+			texs.push_back(sky->half_res_pass);
+			sky->half_res_framebuffer = RD::get_singleton()->framebuffer_create(texs);
+			texture_set_dirty = true;
+		}
+
+		if (sky->quarter_res_pass.is_null() && !RD::get_singleton()->texture_is_valid(sky->quarter_res_pass) && sky->screen_size.x >= 4 && sky->screen_size.y >= 4) {
+			RD::TextureFormat tformat;
+			tformat.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+			tformat.width = sky->screen_size.x / 4;
+			tformat.height = sky->screen_size.y / 4;
+			tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+			tformat.texture_type = RD::TEXTURE_TYPE_2D;
+
+			sky->quarter_res_pass = RD::get_singleton()->texture_create(tformat, RD::TextureView());
+			Vector<RID> texs;
+			texs.push_back(sky->quarter_res_pass);
+			sky->quarter_res_framebuffer = RD::get_singleton()->framebuffer_create(texs);
+			texture_set_dirty = true;
+		}
+
+		if (texture_set_dirty) {
+			for (int i = 0; i < SKY_TEXTURE_SET_MAX; i++) {
+				if (sky->texture_uniform_sets[i].is_valid() && RD::get_singleton()->uniform_set_is_valid(sky->texture_uniform_sets[i])) {
+					RD::get_singleton()->free(sky->texture_uniform_sets[i]);
+					sky->texture_uniform_sets[i] = RID();
+				}
+			}
+		}
+
+		sky->reflection.dirty = true;
+		sky->processing_layer = 0;
+
+		Sky *next = sky->dirty_list;
+		sky->dirty_list = nullptr;
+		sky->dirty = false;
+		sky = next;
+	}
+
+	dirty_sky_list = nullptr;
+}
+
+RID RendererSceneSkyRD::sky_get_material(RID p_sky) const {
+	Sky *sky = get_sky(p_sky);
+	ERR_FAIL_COND_V(!sky, RID());
+
+	return sky->material;
+}
+
+RID RendererSceneSkyRD::allocate_sky_rid() {
+	return sky_owner.allocate_rid();
+}
+
+void RendererSceneSkyRD::initialize_sky_rid(RID p_rid) {
+	sky_owner.initialize_rid(p_rid, Sky());
+}
+
+RendererSceneSkyRD::Sky *RendererSceneSkyRD::get_sky(RID p_sky) const {
+	return sky_owner.getornull(p_sky);
+}
+
+void RendererSceneSkyRD::free_sky(RID p_sky) {
+	Sky *sky = get_sky(p_sky);
+	ERR_FAIL_COND(!sky);
+
+	sky->free(storage);
+	sky_owner.free(p_sky);
+}
+
+void RendererSceneSkyRD::sky_set_radiance_size(RID p_sky, int p_radiance_size) {
+	Sky *sky = get_sky(p_sky);
+	ERR_FAIL_COND(!sky);
+
+	if (sky->set_radiance_size(p_radiance_size)) {
+		invalidate_sky(sky);
+	}
+}
+
+void RendererSceneSkyRD::sky_set_mode(RID p_sky, RS::SkyMode p_mode) {
+	Sky *sky = get_sky(p_sky);
+	ERR_FAIL_COND(!sky);
+
+	if (sky->set_mode(p_mode)) {
+		invalidate_sky(sky);
+	}
+}
+
+void RendererSceneSkyRD::sky_set_material(RID p_sky, RID p_material) {
+	Sky *sky = get_sky(p_sky);
+	ERR_FAIL_COND(!sky);
+
+	if (sky->set_material(p_material)) {
+		invalidate_sky(sky);
+	}
+}
+
+Ref<Image> RendererSceneSkyRD::sky_bake_panorama(RID p_sky, float p_energy, bool p_bake_irradiance, const Size2i &p_size) {
+	Sky *sky = get_sky(p_sky);
+	ERR_FAIL_COND_V(!sky, Ref<Image>());
+
+	update_dirty_skys();
+
+	return sky->bake_panorama(storage, p_energy, p_bake_irradiance ? roughness_layers : 0, p_size);
+}
+
+RID RendererSceneSkyRD::sky_get_radiance_texture_rd(RID p_sky) const {
+	Sky *sky = get_sky(p_sky);
+	ERR_FAIL_COND_V(!sky, RID());
+
+	return sky->radiance;
+}

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
@@ -1,0 +1,292 @@
+/*************************************************************************/
+/*  renderer_scene_sky_rd.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RENDERING_SERVER_SCENE_SKY_RD_H
+#define RENDERING_SERVER_SCENE_SKY_RD_H
+
+#include "core/templates/rid_owner.h"
+#include "servers/rendering/renderer_compositor.h"
+#include "servers/rendering/renderer_rd/renderer_scene_environment_rd.h"
+#include "servers/rendering/renderer_rd/renderer_storage_rd.h"
+#include "servers/rendering/renderer_rd/shaders/sky.glsl.gen.h"
+#include "servers/rendering/renderer_scene_render.h"
+#include "servers/rendering/rendering_device.h"
+
+// Forward declare RendererSceneRenderRD so we can pass it into some of our methods, these classes are pretty tightly bound
+class RendererSceneRenderRD;
+
+class RendererSceneSkyRD {
+private:
+	RendererStorageRD *storage;
+
+public:
+	enum SkySet {
+		SKY_SET_UNIFORMS,
+		SKY_SET_MATERIAL,
+		SKY_SET_TEXTURES,
+		SKY_SET_FOG,
+		SKY_SET_MAX
+	};
+
+	enum SkyTextureSetVersion {
+		SKY_TEXTURE_SET_BACKGROUND,
+		SKY_TEXTURE_SET_HALF_RES,
+		SKY_TEXTURE_SET_QUARTER_RES,
+		SKY_TEXTURE_SET_CUBEMAP,
+		SKY_TEXTURE_SET_CUBEMAP_HALF_RES,
+		SKY_TEXTURE_SET_CUBEMAP_QUARTER_RES,
+		SKY_TEXTURE_SET_MAX
+	};
+
+	enum SkyVersion {
+		SKY_VERSION_BACKGROUND,
+		SKY_VERSION_HALF_RES,
+		SKY_VERSION_QUARTER_RES,
+		SKY_VERSION_CUBEMAP,
+		SKY_VERSION_CUBEMAP_HALF_RES,
+		SKY_VERSION_CUBEMAP_QUARTER_RES,
+		SKY_VERSION_MAX
+	};
+
+	// Skys need less info from Directional Lights than the normal shaders
+	struct SkyDirectionalLightData {
+		float direction[3];
+		float energy;
+		float color[3];
+		float size;
+		uint32_t enabled;
+		uint32_t pad[3];
+	};
+
+	struct SkySceneState {
+		struct UBO {
+			uint32_t volumetric_fog_enabled;
+			float volumetric_fog_inv_length;
+			float volumetric_fog_detail_spread;
+
+			float fog_aerial_perspective;
+
+			float fog_light_color[3];
+			float fog_sun_scatter;
+
+			uint32_t fog_enabled;
+			float fog_density;
+
+			float z_far;
+			uint32_t directional_light_count;
+		};
+
+		UBO ubo;
+
+		SkyDirectionalLightData *directional_lights;
+		SkyDirectionalLightData *last_frame_directional_lights;
+		uint32_t max_directional_lights;
+		uint32_t last_frame_directional_light_count;
+		RID directional_light_buffer;
+		RID uniform_set;
+		RID uniform_buffer;
+		RID fog_uniform_set;
+		RID default_fog_uniform_set;
+
+		RID fog_shader;
+		RID fog_material;
+		RID fog_only_texture_uniform_set;
+	} sky_scene_state;
+
+	struct ReflectionData {
+		struct Layer {
+			struct Mipmap {
+				RID framebuffers[6];
+				RID views[6];
+				Size2i size;
+			};
+			Vector<Mipmap> mipmaps; //per-face view
+			Vector<RID> views; // per-cubemap view
+		};
+
+		struct DownsampleLayer {
+			struct Mipmap {
+				RID view;
+				Size2i size;
+			};
+			Vector<Mipmap> mipmaps;
+		};
+
+		RID radiance_base_cubemap; //cubemap for first layer, first cubemap
+		RID downsampled_radiance_cubemap;
+		DownsampleLayer downsampled_layer;
+		RID coefficient_buffer;
+
+		bool dirty = true;
+
+		Vector<Layer> layers;
+
+		void clear_reflection_data();
+		void update_reflection_data(int p_size, int p_mipmaps, bool p_use_array, RID p_base_cube, int p_base_layer, bool p_low_quality, int p_roughness_layers);
+		void create_reflection_fast_filter(RendererStorageRD *p_storage, bool p_use_arrays);
+		void create_reflection_importance_sample(RendererStorageRD *p_storage, bool p_use_arrays, int p_cube_side, int p_base_layer, uint32_t p_sky_ggx_samples_quality);
+		void update_reflection_mipmaps(RendererStorageRD *p_storage, int p_start, int p_end);
+	};
+
+	struct SkyShaderData : public RendererStorageRD::ShaderData {
+		bool valid;
+		RID version;
+
+		PipelineCacheRD pipelines[SKY_VERSION_MAX];
+		Map<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
+		Vector<ShaderCompilerRD::GeneratedCode::Texture> texture_uniforms;
+
+		Vector<uint32_t> ubo_offsets;
+		uint32_t ubo_size;
+
+		String path;
+		String code;
+		Map<StringName, RID> default_texture_params;
+
+		bool uses_time;
+		bool uses_position;
+		bool uses_half_res;
+		bool uses_quarter_res;
+		bool uses_light;
+
+		virtual void set_code(const String &p_Code);
+		virtual void set_default_texture_param(const StringName &p_name, RID p_texture);
+		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		virtual void get_instance_param_list(List<RendererStorage::InstanceShaderParam> *p_param_list) const;
+		virtual bool is_param_texture(const StringName &p_param) const;
+		virtual bool is_animated() const;
+		virtual bool casts_shadows() const;
+		virtual Variant get_default_parameter(const StringName &p_parameter) const;
+		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+		SkyShaderData();
+		virtual ~SkyShaderData();
+	};
+
+	/* Sky shader */
+
+	struct SkyShader {
+		SkyShaderRD shader;
+		ShaderCompilerRD compiler;
+
+		RID default_shader;
+		RID default_material;
+		RID default_shader_rd;
+	} sky_shader;
+
+	struct SkyMaterialData : public RendererStorageRD::MaterialData {
+		uint64_t last_frame;
+		SkyShaderData *shader_data;
+		RID uniform_buffer;
+		RID uniform_set;
+		Vector<RID> texture_cache;
+		Vector<uint8_t> ubo_data;
+		bool uniform_set_updated;
+
+		virtual void set_render_priority(int p_priority) {}
+		virtual void set_next_pass(RID p_pass) {}
+		virtual void update_parameters(const Map<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
+		virtual ~SkyMaterialData();
+	};
+
+	struct Sky {
+		RID radiance;
+		RID half_res_pass;
+		RID half_res_framebuffer;
+		RID quarter_res_pass;
+		RID quarter_res_framebuffer;
+		Size2i screen_size;
+
+		RID texture_uniform_sets[SKY_TEXTURE_SET_MAX];
+		RID uniform_set;
+
+		RID material;
+		RID uniform_buffer;
+
+		int radiance_size = 256;
+
+		RS::SkyMode mode = RS::SKY_MODE_AUTOMATIC;
+
+		ReflectionData reflection;
+		bool dirty = false;
+		int processing_layer = 0;
+		Sky *dirty_list = nullptr;
+
+		//State to track when radiance cubemap needs updating
+		SkyMaterialData *prev_material;
+		Vector3 prev_position;
+		float prev_time;
+
+		void free(RendererStorageRD *p_storage);
+
+		RID get_textures(RendererStorageRD *p_storage, SkyTextureSetVersion p_version, RID p_default_shader_rd);
+		bool set_radiance_size(int p_radiance_size);
+		bool set_mode(RS::SkyMode p_mode);
+		bool set_material(RID p_material);
+		Ref<Image> bake_panorama(RendererStorageRD *p_storage, float p_energy, int p_roughness_layers, const Size2i &p_size);
+	};
+
+	uint32_t sky_ggx_samples_quality;
+	bool sky_use_cubemap_array;
+	Sky *dirty_sky_list = nullptr;
+	mutable RID_Owner<Sky, true> sky_owner;
+	int roughness_layers;
+
+	RendererStorageRD::ShaderData *_create_sky_shader_func();
+	static RendererStorageRD::ShaderData *_create_sky_shader_funcs();
+
+	RendererStorageRD::MaterialData *_create_sky_material_func(SkyShaderData *p_shader);
+	static RendererStorageRD::MaterialData *_create_sky_material_funcs(RendererStorageRD::ShaderData *p_shader);
+
+	RendererSceneSkyRD();
+
+	void init(RendererStorageRD *p_storage);
+
+	void setup(RendererSceneEnvironmentRD *p_env, RID p_render_buffers, const CameraMatrix &p_projection, const Transform &p_transform, const Size2i p_screen_size, RendererSceneRenderRD *p_scene_render);
+	void update(RendererSceneEnvironmentRD *p_env, const CameraMatrix &p_projection, const Transform &p_transform, double p_time);
+	void draw(RendererSceneEnvironmentRD *p_env, bool p_can_continue_color, bool p_can_continue_depth, RID p_fb, const CameraMatrix &p_projection, const Transform &p_transform, double p_time);
+
+	void invalidate_sky(Sky *p_sky);
+	void update_dirty_skys();
+
+	RID sky_get_material(RID p_sky) const;
+
+	RID allocate_sky_rid();
+	void initialize_sky_rid(RID p_rid);
+	Sky *get_sky(RID p_sky) const;
+	void free_sky(RID p_sky);
+	void sky_set_radiance_size(RID p_sky, int p_radiance_size);
+	void sky_set_mode(RID p_sky, RS::SkyMode p_mode);
+	void sky_set_material(RID p_sky, RID p_material);
+	Ref<Image> sky_bake_panorama(RID p_sky, float p_energy, bool p_bake_irradiance, const Size2i &p_size);
+
+	RID sky_get_radiance_texture_rd(RID p_sky) const;
+};
+
+#endif /* RENDERING_SERVER_SCENE_SKY_RD_H */


### PR DESCRIPTION
This will take a few days to complete but Reduz asked us to see if we could move the GI and Sky shader code into separate classes to make it easier to maintain.

It was originally planned to do these as two separate PRs but seeing there were a bunch of links between the two I've done both together.

Anyway the approach I'm taking here is following the following steps:
1) Move all data into a class making all members public for now, change the code in RendererSceneRenderRD to point to the new class but keep the methods unchanged otherwise (finished for GI).
2) Start moving methods related to GI from RendererSceneRenderRD into RendererSceneGIRD and adjust them where needed (in progress)
3) Evaluate members that should be private and make them private, further tidy up work (might do this in separate PRs)