### PR TITLE
CODEOWNERS: Update with newly added teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,56 +2,168 @@
 # Each line is a file pattern followed by one or more owners.
 # Owners can be @users, @org/teams or emails
 
-/doc/                @godotengine/documentation
-doc_classes/*        @godotengine/documentation
+# Core
 
-# Rendering
-/drivers/gl_context/ @reduz
-/drivers/gles2/      @reduz
-/drivers/gles3/      @reduz
+/core/                              @godotengine/core
+/core/crypto/                       @godotengine/network
+/core/debugger/                     @godotengine/debugger
+/core/input/                        @godotengine/input
 
-# Audio
-/drivers/alsa/       @marcelofg55
-/drivers/alsamidi/   @marcelofg55
-/drivers/coreaudio/  @marcelofg55
-/drivers/coremidi/   @marcelofg55
-/drivers/pulseaudio/ @marcelofg55
-/drivers/wasapi/     @marcelofg55
-/drivers/winmidi/    @marcelofg55
-/drivers/xaudio2/    @marcelofg55
+# Doc
 
-/drivers/unix/       @hpvb
-/drivers/windows/    @hpvb
+/doc/                               @godotengine/documentation
+doc_classes/*                       @godotengine/documentation
 
-/editor/icons/       @djrm
+# Drivers
 
-/misc/               @akien-mga
+## Audio
+/drivers/alsa/                      @godotengine/audio
+/drivers/alsamidi/                  @godotengine/audio
+/drivers/coreaudio/                 @godotengine/audio
+/drivers/coremidi/                  @godotengine/audio
+/drivers/pulseaudio/                @godotengine/audio
+/drivers/wasapi/                    @godotengine/audio
+/drivers/winmidi/                   @godotengine/audio
+/drivers/xaudio2/                   @godotengine/audio
 
-/modules/bullet/     @AndreaCatania
-/modules/csg/        @BastiaanOlij
-/modules/enet/       @godotengine/network
-/modules/gdnative/*arvr/ @BastiaanOlij
-/modules/gdnative/text/ @bruvzg
-/modules/gdscript/   @vnen
-/modules/mbedtls/    @godotengine/network
-/modules/mobile_vr/  @BastiaanOlij
-/modules/mono/       @neikeq
-/modules/mono/glue/GodotSharp @aaronfranke
-/modules/opensimplex/ @JFonS
-/modules/regex/      @LeeZH
-/modules/text_server_*/ @bruvzg
-/modules/upnp/       @godotengine/network
-/modules/websocket/  @godotengine/network
+## Rendering
+/drivers/dummy/                     @godotengine/rendering
+/drivers/spirv-reflect/             @godotengine/rendering
+/drivers/vulkan/                    @godotengine/rendering
 
-/platform/javascript/ @eska014
-/platform/uwp/       @vnen
+## OS
+/drivers/unix/                      @godotengine/_platforms
+/drivers/windows/                   @godotengine/windows
 
-/scene/resources/font.* @bruvzg
-/scene/resources/text_line.* @bruvzg
-/scene/resources/text_paragraph.* @bruvzg
+# Editor
 
-/servers/physics*/    @reduz @AndreaCatania
-/servers/text_server.* @bruvzg
-/servers/visual*/     @reduz
+/editor/*debugger*                  @godotengine/debugger
+/editor/icons/                      @godotengine/usability
+/editor/import/                     @godotengine/import
+/editor/plugins/*2d_*.*             @godotengine/2d-editor
+/editor/plugins/*3d_*.*             @godotengine/3d-editor
+/editor/plugins/script_*.*          @godotengine/script-editor
+/editor/plugins/*shader*.*          @godotengine/shaders
+/editor/code_editor.*               @godotengine/script-editor
+/editor/*dock*.*                    @godotengine/docks
+/editor/*shader*.*                  @godotengine/shaders
 
-/thirdparty/         @akien-mga
+# Main
+
+/main/                              @godotengine/core
+
+# Misc
+
+/misc/                              @godotengine/buildsystem
+
+# Modules
+
+## Audio (+ video)
+/modules/minimp3/                   @godotengine/audio
+/modules/ogg/                       @godotengine/audio
+/modules/opus/                      @godotengine/audio
+/modules/stb_vorbis/                @godotengine/audio
+/modules/theora/                    @godotengine/audio
+/modules/vorbis/                    @godotengine/audio
+/modules/webm/                      @godotengine/audio
+
+## Import
+/modules/basis_universal/           @godotengine/import
+/modules/bmp/                       @godotengine/import
+/modules/cvtt/                      @godotengine/import
+/modules/dds/                       @godotengine/import
+/modules/etc/                       @godotengine/import
+/modules/fbx/                       @godotengine/import
+/modules/gltf/                      @godotengine/import
+/modules/hdr/                       @godotengine/import
+/modules/jpg/                       @godotengine/import
+/modules/pvr/                       @godotengine/import
+/modules/squish/                    @godotengine/import
+/modules/svg/                       @godotengine/import
+/modules/tga/                       @godotengine/import
+/modules/tinyexr/                   @godotengine/import
+/modules/webp/                      @godotengine/import
+
+## Network
+/modules/enet/                      @godotengine/network
+/modules/mbedtls/                   @godotengine/network
+/modules/upnp/                      @godotengine/network
+/modules/webrtc/                    @godotengine/network
+/modules/websocket/                 @godotengine/network
+
+## Rendering
+/modules/denoise/                   @godotengine/rendering
+/modules/glslang/                   @godotengine/rendering
+/modules/lightmapper_rd/            @godotengine/rendering
+/modules/meshoptimizer/             @godotengine/rendering
+/modules/vhacd/                     @godotengine/rendering
+/modules/xatlas_unwrap/             @godotengine/rendering
+
+## Scripting
+/modules/gdnative/                  @godotengine/gdnative
+/modules/gdscript/                  @godotengine/gdscript
+/modules/jsonrpc/                   @godotengine/gdscript
+/modules/mono/                      @godotengine/mono
+/modules/visual_script/             @godotengine/visualscript
+
+## Text
+/modules/freetype/                  @godotengine/buildsystem
+/modules/gdnative/text/             @godotengine/gui-nodes
+/modules/text_server_adv/           @godotengine/gui-nodes
+/modules/text_server_fb/            @godotengine/gui-nodes
+
+## XR
+/modules/camera/                    @godotengine/xr
+/modules/gdnative/xr/               @godotengine/xr
+/modules/mobile_vr/                 @godotengine/xr
+/modules/webxr/                     @godotengine/xr
+
+## Misc
+/modules/bullet/                    @godotengine/physics
+/modules/csg/                       @godotengine/3d-nodes
+/modules/gdnavigation/              @godotengine/navigation
+/modules/gridmap/                   @godotengine/3d-nodes
+/modules/opensimplex/               @godotengine/3d-nodes
+/modules/regex/                     @godotengine/core
+
+# Platform
+
+/platform/android/                  @godotengine/android
+/platform/iphone/                   @godotengine/iphone
+/platform/javascript/               @godotengine/html5
+/platform/linuxbsd/                 @godotengine/linuxbsd
+/platform/osx/                      @godotengine/macos
+/platform/uwp/                      @godotengine/uwp
+/platform/windows/                  @godotengine/windows
+
+# Scene
+
+/scene/2d/                          @godotengine/2d-nodes
+/scene/3d/                          @godotengine/3d-nodes
+/scene/animation/                   @godotengine/animation
+/scene/audio/                       @godotengine/audio
+/scene/debugger/                    @godotengine/debugger
+/scene/gui/                         @godotengine/gui-nodes
+/scene/main/                        @godotengine/core
+/scene/resources/font.*             @godotengine/gui-nodes
+/scene/resources/text_line.*        @godotengine/gui-nodes
+/scene/resources/text_paragraph.*   @godotengine/gui-nodes
+
+# Servers
+
+/servers/audio*                     @godotengine/audio
+/servers/camera*                    @godotengine/xr
+/servers/display_server.*           @godotengine/_platforms
+/servers/navigation_server*.*       @godotengine/navigation
+/servers/physics*                   @godotengine/physics
+/servers/rendering*                 @godotengine/rendering
+/servers/text_server.*              @godotengine/gui-nodes
+/servers/xr*                        @godotengine/xr
+
+# Tests
+
+/tests/                             @godotengine/tests
+
+# Thirdparty
+
+/thirdparty/                        @godotengine/buildsystem


### PR DESCRIPTION
I did not do a full dive into `editor/` and `scene/resources/` to assign every single file to the most relevant team in each case. It's a bit tedious and error prone so I think it's fine as is and we can keep doing manual assignments of relevant teams for PRs which are not accurately auto-assigned.

As we now have teams for most topics, I removed manually assignments of specific contributors who are part of the team now assigned for that same path. This is open to discussion if some of you would still prefer to be nominally asked for review and not just as part of your team that covers this area. (This of course doesn't mean that I don't want you to "own" that code, but shared ownership within a team is likely the best way to grow teams without having bottlenecks on a single reviewer - even if one person within the team may be the owner of a specific file/folder.)