### PR TITLE
CI: Remove file_format.sh changes hard to reproduce on Windows

### DIFF
--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -38,15 +38,6 @@ while IFS= read -rd '' f; do
     # Remove trailing space characters and ensures that files end
     # with newline characters. -l option handles newlines conveniently.
     perl -i -ple 's/\s*$//g' "$f"
-    # Remove the character sequence "== true" if it has a leading space.
-    perl -i -pe 's/\x20== true//g' "$f"
-
-    if [[ $(uname) == "Linux" ]] && [[ "$f" != *"xml" ]]; then
-        # Remove empty lines after the opening brace of indented blocks.
-        sed -z -i 's/\x7B\x0A\x0A\x09/\x7B\x0A\x09/g' "$f"
-        # Remove empty lines before the closing brace (in some cases).
-        sed -z -i 's/\x0A\x0A\x7D/\x0A\x7D/g' "$f"
-    fi
 done
 
 git diff > patch.patch


### PR DESCRIPTION
Until we provide a cross-platform pre-commit hook that can perform those changes
on Windows, this only leads to a lot of frustration from Windows contributors.

The UTF-8, newline and EOF and BOM checks are still good to keep as those are
issues that we'd otherwise have to point out manually in the review.
The removed changes are mostly cosmetic and should be handled by clang-format
ideally, or by some self-developed cross-platform tooling.