### PR TITLE
[3.2] Reduce lightmaps file size.

### DIFF
--- a/doc/classes/BakedLightmap.xml
+++ b/doc/classes/BakedLightmap.xml
@@ -78,8 +78,14 @@
 		<member name="quality" type="int" setter="set_bake_quality" getter="get_bake_quality" enum="BakedLightmap.BakeQuality" default="1">
 			Determines the amount of samples per texel used in indrect light baking. The amount of samples for each quality level can be configured in the project settings.
 		</member>
+		<member name="use_color" type="bool" setter="set_use_color" getter="is_using_color" default="true">
+			Store full color values in the lightmap textures. When disabled, lightmap textures will store a single brightness channel. Can be disabled to reduce disk usage if the scene contains only white lights or you don't mind losing color information in indirect lighting.
+		</member>
 		<member name="use_denoiser" type="bool" setter="set_use_denoiser" getter="is_using_denoiser" default="true">
 			When enabled, a lightmap denoiser will be used to reduce the noise inherent to Monte Carlo based global illumination.
+		</member>
+		<member name="use_hdr" type="bool" setter="set_use_hdr" getter="is_using_hdr" default="true">
+			Store the lightmap textures in a Hight Dynamic Range format (EXR). Can be disabled to reduce disk usage, but light values over 1.0 will be clamped and you may see banding caused by the reduced precision.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/BakedLightmapData.xml
+++ b/doc/classes/BakedLightmapData.xml
@@ -23,6 +23,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="clear_data">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="clear_users">
 			<return type="void">
 			</return>

--- a/modules/denoise/SCsub
+++ b/modules/denoise/SCsub
@@ -108,6 +108,9 @@ env_thirdparty = env_oidn.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
+if env["platform"] == "windows" and not env.msvc:
+    env_thirdparty.Append(CPPFLAGS=["-mstackrealign"])
+
 weights_in_path = thirdparty_dir + "weights/rtlightmap_hdr.tza"
 weights_out_path = thirdparty_dir + "weights/rtlightmap_hdr.gen.cpp"
 

--- a/modules/denoise/denoise_wrapper.cpp
+++ b/modules/denoise/denoise_wrapper.cpp
@@ -43,9 +43,7 @@ void *oidn_denoiser_init() {
 bool oidn_denoise(void *deviceptr, float *p_floats, int p_width, int p_height) {
 	OIDNDeviceImpl *device = (OIDNDeviceImpl *)deviceptr;
 	OIDNFilter filter = oidnNewFilter(device, "RTLightmap");
-	void *input_buffer = memalloc(p_width * p_height * 3 * sizeof(float));
-	copymem(input_buffer, p_floats, p_width * p_height * 3 * sizeof(float));
-	oidnSetSharedFilterImage(filter, "color", input_buffer, OIDN_FORMAT_FLOAT3, p_width, p_height, 0, 0, 0);
+	oidnSetSharedFilterImage(filter, "color", (void *)p_floats, OIDN_FORMAT_FLOAT3, p_width, p_height, 0, 0, 0);
 	oidnSetSharedFilterImage(filter, "output", (void *)p_floats, OIDN_FORMAT_FLOAT3, p_width, p_height, 0, 0, 0);
 	oidnSetFilter1b(filter, "hdr", true);
 	oidnCommitFilter(filter);

--- a/modules/lightmapper_cpu/lightmapper_cpu.cpp
+++ b/modules/lightmapper_cpu/lightmapper_cpu.cpp
@@ -1369,6 +1369,7 @@ LightmapperCPU::BakeError LightmapperCPU::bake(BakeQuality p_quality, bool p_use
 	if (parameters.environment_panorama.is_valid()) {
 		parameters.environment_panorama->lock();
 	}
+
 	for (unsigned int i = 0; i < mesh_instances.size(); i++) {
 
 		if (!mesh_instances[i].generate_lightmap) {
@@ -1389,6 +1390,7 @@ LightmapperCPU::BakeError LightmapperCPU::bake(BakeQuality p_quality, bool p_use
 			}
 		}
 	}
+
 	if (parameters.environment_panorama.is_valid()) {
 		parameters.environment_panorama->unlock();
 	}

--- a/modules/tinyexr/SCsub
+++ b/modules/tinyexr/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_tinyexr = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 # Not unbundled for now as they are not commonly available as shared library
 thirdparty_dir = "#thirdparty/tinyexr/"
 thirdparty_sources = [
@@ -20,7 +23,15 @@ env_tinyexr.Append(CPPDEFINES=["TINYEXR_USE_THREAD"])
 
 env_thirdparty = env_tinyexr.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
-# Godot's own source files
-env_tinyexr.add_source_files(env.modules_sources, "*.cpp")
+# Godot source files
+
+module_obj = []
+
+env_tinyexr.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -42,7 +42,8 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 
-	PoolVector<uint8_t>::Write w = src_image.write();
+	PoolVector<uint8_t>::Write img_write = src_image.write();
+	uint8_t *w = img_write.ptr();
 
 	f->get_buffer(&w[0], src_image_len);
 
@@ -56,36 +57,37 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 	EXRVersion exr_version;
 	EXRImage exr_image;
 	EXRHeader exr_header;
-	const char *err = NULL;
+	const char *err = nullptr;
 
 	InitEXRHeader(&exr_header);
 
-	int ret = ParseEXRVersionFromMemory(&exr_version, w.ptr(), src_image_len);
+	int ret = ParseEXRVersionFromMemory(&exr_version, w, src_image_len);
 	if (ret != TINYEXR_SUCCESS) {
-
 		return ERR_FILE_CORRUPT;
 	}
 
-	ret = ParseEXRHeaderFromMemory(&exr_header, &exr_version, w.ptr(), src_image_len, &err);
+	ret = ParseEXRHeaderFromMemory(&exr_header, &exr_version, w, src_image_len, &err);
 	if (ret != TINYEXR_SUCCESS) {
 		if (err) {
-			ERR_PRINTS(String(err));
+			ERR_PRINT(String(err));
 		}
 		return ERR_FILE_CORRUPT;
 	}
 
 	// Read HALF channel as FLOAT. (GH-13490)
+	bool use_float16 = false;
 	for (int i = 0; i < exr_header.num_channels; i++) {
 		if (exr_header.pixel_types[i] == TINYEXR_PIXELTYPE_HALF) {
+			use_float16 = true;
 			exr_header.requested_pixel_types[i] = TINYEXR_PIXELTYPE_FLOAT;
 		}
 	}
 
 	InitEXRImage(&exr_image);
-	ret = LoadEXRImageFromMemory(&exr_image, &exr_header, w.ptr(), src_image_len, &err);
+	ret = LoadEXRImageFromMemory(&exr_image, &exr_header, w, src_image_len, &err);
 	if (ret != TINYEXR_SUCCESS) {
 		if (err) {
-			ERR_PRINTS(String(err));
+			ERR_PRINT(String(err));
 		}
 		return ERR_FILE_CORRUPT;
 	}
@@ -104,33 +106,10 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 			idxB = c;
 		} else if (strcmp(exr_header.channels[c].name, "A") == 0) {
 			idxA = c;
-		}
-	}
-
-	if (exr_header.num_channels == 1) {
-		// Grayscale channel only.
-		idxR = 0;
-		idxG = 0;
-		idxB = 0;
-		idxA = 0;
-	} else {
-		// Assume RGB(A)
-		if (idxR == -1) {
-			ERR_PRINT("TinyEXR: R channel not found.");
-			// @todo { free exr_image }
-			return ERR_FILE_CORRUPT;
-		}
-
-		if (idxG == -1) {
-			ERR_PRINT("TinyEXR: G channel not found.");
-			// @todo { free exr_image }
-			return ERR_FILE_CORRUPT;
-		}
-
-		if (idxB == -1) {
-			ERR_PRINT("TinyEXR: B channel not found.");
-			// @todo { free exr_image }
-			return ERR_FILE_CORRUPT;
+		} else if (strcmp(exr_header.channels[c].name, "Y") == 0) {
+			idxR = c;
+			idxG = c;
+			idxB = c;
 		}
 	}
 
@@ -140,16 +119,27 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 	Image::Format format;
 	int output_channels = 0;
 
+	int channel_size = use_float16 ? 2 : 4;
 	if (idxA != -1) {
-
-		imgdata.resize(exr_image.width * exr_image.height * 8); //RGBA16
-		format = Image::FORMAT_RGBAH;
+		imgdata.resize(exr_image.width * exr_image.height * 4 * channel_size); //RGBA
+		format = use_float16 ? Image::FORMAT_RGBAH : Image::FORMAT_RGBAF;
 		output_channels = 4;
-	} else {
-
-		imgdata.resize(exr_image.width * exr_image.height * 6); //RGB16
-		format = Image::FORMAT_RGBH;
+	} else if (idxB != -1) {
+		ERR_FAIL_COND_V(idxG == -1, ERR_FILE_CORRUPT);
+		ERR_FAIL_COND_V(idxR == -1, ERR_FILE_CORRUPT);
+		imgdata.resize(exr_image.width * exr_image.height * 3 * channel_size); //RGB
+		format = use_float16 ? Image::FORMAT_RGBH : Image::FORMAT_RGBF;
 		output_channels = 3;
+	} else if (idxG != -1) {
+		ERR_FAIL_COND_V(idxR == -1, ERR_FILE_CORRUPT);
+		imgdata.resize(exr_image.width * exr_image.height * 2 * channel_size); //RG
+		format = use_float16 ? Image::FORMAT_RGH : Image::FORMAT_RGF;
+		output_channels = 2;
+	} else {
+		ERR_FAIL_COND_V(idxR == -1, ERR_FILE_CORRUPT);
+		imgdata.resize(exr_image.width * exr_image.height * 1 * channel_size); //R
+		format = use_float16 ? Image::FORMAT_RH : Image::FORMAT_RF;
+		output_channels = 1;
 	}
 
 	EXRTile single_image_tile;
@@ -179,54 +169,115 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 		exr_tiles = exr_image.tiles;
 	}
 
+	//print_line("reading format: " + Image::get_format_name(format));
 	{
-		PoolVector<uint8_t>::Write wd = imgdata.write();
-		uint16_t *iw = (uint16_t *)wd.ptr();
+
+		PoolVector<uint8_t>::Write imgdata_write = imgdata.write();
+		uint8_t *wd = imgdata_write.ptr();
+		uint16_t *iw16 = (uint16_t *)wd;
+		float *iw32 = (float *)wd;
 
 		// Assume `out_rgba` have enough memory allocated.
 		for (int tile_index = 0; tile_index < num_tiles; tile_index++) {
-
 			const EXRTile &tile = exr_tiles[tile_index];
 
 			int tw = tile.width;
 			int th = tile.height;
 
 			const float *r_channel_start = reinterpret_cast<const float *>(tile.images[idxR]);
-			const float *g_channel_start = reinterpret_cast<const float *>(tile.images[idxG]);
-			const float *b_channel_start = reinterpret_cast<const float *>(tile.images[idxB]);
-			const float *a_channel_start = NULL;
+			const float *g_channel_start = nullptr;
+			const float *b_channel_start = nullptr;
+			const float *a_channel_start = nullptr;
 
+			if (idxG != -1) {
+				g_channel_start = reinterpret_cast<const float *>(tile.images[idxG]);
+			}
+			if (idxB != -1) {
+				b_channel_start = reinterpret_cast<const float *>(tile.images[idxB]);
+			}
 			if (idxA != -1) {
 				a_channel_start = reinterpret_cast<const float *>(tile.images[idxA]);
 			}
 
-			uint16_t *first_row_w = iw + (tile.offset_y * tile_height * exr_image.width + tile.offset_x * tile_width) * output_channels;
+			uint16_t *first_row_w16 = iw16 + (tile.offset_y * tile_height * exr_image.width + tile.offset_x * tile_width) * output_channels;
+			float *first_row_w32 = iw32 + (tile.offset_y * tile_height * exr_image.width + tile.offset_x * tile_width) * output_channels;
 
 			for (int y = 0; y < th; y++) {
 				const float *r_channel = r_channel_start + y * tile_width;
-				const float *g_channel = g_channel_start + y * tile_width;
-				const float *b_channel = b_channel_start + y * tile_width;
-				const float *a_channel = NULL;
-
+				const float *g_channel = nullptr;
+				const float *b_channel = nullptr;
+				const float *a_channel = nullptr;
+				if (g_channel_start) {
+					g_channel = g_channel_start + y * tile_width;
+				}
+				if (b_channel_start) {
+					b_channel = b_channel_start + y * tile_width;
+				}
 				if (a_channel_start) {
 					a_channel = a_channel_start + y * tile_width;
 				}
 
-				uint16_t *row_w = first_row_w + (y * exr_image.width * output_channels);
+				if (use_float16) {
+					uint16_t *row_w = first_row_w16 + (y * exr_image.width * output_channels);
 
-				for (int x = 0; x < tw; x++) {
+					for (int x = 0; x < tw; x++) {
+						Color color;
+						color.r = *r_channel++;
+						if (g_channel) {
+							color.g = *g_channel++;
+						}
+						if (b_channel) {
+							color.b = *b_channel++;
+						}
+						if (a_channel) {
+							color.a = *a_channel++;
+						}
 
-					Color color(*r_channel++, *g_channel++, *b_channel++);
+						if (p_force_linear) {
+							color = color.to_linear();
+						}
 
-					if (p_force_linear)
-						color = color.to_linear();
+						*row_w++ = Math::make_half_float(color.r);
+						if (g_channel) {
+							*row_w++ = Math::make_half_float(color.g);
+						}
+						if (b_channel) {
+							*row_w++ = Math::make_half_float(color.b);
+						}
+						if (a_channel) {
+							*row_w++ = Math::make_half_float(color.a);
+						}
+					}
+				} else {
+					float *row_w = first_row_w32 + (y * exr_image.width * output_channels);
 
-					*row_w++ = Math::make_half_float(color.r);
-					*row_w++ = Math::make_half_float(color.g);
-					*row_w++ = Math::make_half_float(color.b);
+					for (int x = 0; x < tw; x++) {
+						Color color;
+						color.r = *r_channel++;
+						if (g_channel) {
+							color.g = *g_channel++;
+						}
+						if (b_channel) {
+							color.b = *b_channel++;
+						}
+						if (a_channel) {
+							color.a = *a_channel++;
+						}
 
-					if (idxA != -1) {
-						*row_w++ = Math::make_half_float(*a_channel++);
+						if (p_force_linear) {
+							color = color.to_linear();
+						}
+
+						*row_w++ = color.r;
+						if (g_channel) {
+							*row_w++ = color.g;
+						}
+						if (b_channel) {
+							*row_w++ = color.b;
+						}
+						if (a_channel) {
+							*row_w++ = color.a;
+						}
 					}
 				}
 			}
@@ -235,7 +286,7 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 
 	p_image->create(exr_image.width, exr_image.height, false, format, imgdata);
 
-	w.release();
+	img_write.release();
 
 	FreeEXRHeader(&exr_header);
 	FreeEXRImage(&exr_image);
@@ -244,7 +295,6 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_f
 }
 
 void ImageLoaderTinyEXR::get_recognized_extensions(List<String> *p_extensions) const {
-
 	p_extensions->push_back("exr");
 }
 

--- a/modules/tinyexr/image_loader_tinyexr.h
+++ b/modules/tinyexr/image_loader_tinyexr.h
@@ -34,7 +34,6 @@
 #include "core/io/image_loader.h"
 
 class ImageLoaderTinyEXR : public ImageFormatLoader {
-
 public:
 	virtual Error load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;

--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -58,7 +58,8 @@ static bool is_supported_format(Image::Format p_format) {
 enum SrcPixelType {
 	SRC_FLOAT,
 	SRC_HALF,
-	SRC_BYTE
+	SRC_BYTE,
+	SRC_UNSUPPORTED
 };
 
 static SrcPixelType get_source_pixel_type(Image::Format p_format) {
@@ -79,7 +80,7 @@ static SrcPixelType get_source_pixel_type(Image::Format p_format) {
 		case Image::FORMAT_RGBA8:
 			return SRC_BYTE;
 		default:
-			CRASH_NOW();
+			return SRC_UNSUPPORTED;
 	}
 }
 
@@ -101,7 +102,7 @@ static int get_target_pixel_type(Image::Format p_format) {
 		case Image::FORMAT_RGBA8:
 			return TINYEXR_PIXELTYPE_HALF;
 		default:
-			CRASH_NOW();
+			return -1;
 	}
 }
 
@@ -112,7 +113,7 @@ static int get_pixel_type_size(int p_pixel_type) {
 		case TINYEXR_PIXELTYPE_FLOAT:
 			return 4;
 	}
-	CRASH_NOW();
+	return -1;
 }
 
 static int get_channel_count(Image::Format p_format) {
@@ -134,12 +135,11 @@ static int get_channel_count(Image::Format p_format) {
 		case Image::FORMAT_RGBA8:
 			return 4;
 		default:
-			CRASH_NOW();
+			return -1;
 	}
 }
 
 Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) {
-
 	Image::Format format = p_img->get_format();
 
 	if (!is_supported_format(format)) {
@@ -173,11 +173,15 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 	};
 
 	int channel_count = get_channel_count(format);
+	ERR_FAIL_COND_V(channel_count < 0, ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(p_grayscale && channel_count != 1, ERR_INVALID_PARAMETER);
 
 	int target_pixel_type = get_target_pixel_type(format);
+	ERR_FAIL_COND_V(target_pixel_type < 0, ERR_UNAVAILABLE);
 	int target_pixel_type_size = get_pixel_type_size(target_pixel_type);
+	ERR_FAIL_COND_V(target_pixel_type_size < 0, ERR_UNAVAILABLE);
 	SrcPixelType src_pixel_type = get_source_pixel_type(format);
+	ERR_FAIL_COND_V(src_pixel_type == SRC_UNSUPPORTED, ERR_UNAVAILABLE);
 	const int pixel_count = p_img->get_width() * p_img->get_height();
 
 	const int *channel_mapping = channel_mappings[channel_count - 1];
@@ -187,7 +191,6 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 		PoolByteArray::Read src_r = src_data.read();
 
 		for (int channel_index = 0; channel_index < channel_count; ++channel_index) {
-
 			// De-interleave channels
 
 			PoolByteArray &dst = channels[channel_index];
@@ -196,7 +199,6 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 			PoolByteArray::Write dst_w = dst.write();
 
 			if (src_pixel_type == SRC_FLOAT && target_pixel_type == TINYEXR_PIXELTYPE_FLOAT) {
-
 				// Note: we don't save mipmaps
 				CRASH_COND(src_data.size() < pixel_count * channel_count * target_pixel_type_size);
 
@@ -208,7 +210,6 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 				}
 
 			} else if (src_pixel_type == SRC_HALF && target_pixel_type == TINYEXR_PIXELTYPE_HALF) {
-
 				CRASH_COND(src_data.size() < pixel_count * channel_count * target_pixel_type_size);
 
 				const uint16_t *src_rp = (uint16_t *)src_r.ptr();
@@ -219,7 +220,6 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 				}
 
 			} else if (src_pixel_type == SRC_BYTE && target_pixel_type == TINYEXR_PIXELTYPE_HALF) {
-
 				CRASH_COND(src_data.size() < pixel_count * channel_count);
 
 				const uint8_t *src_rp = (uint8_t *)src_r.ptr();
@@ -262,13 +262,21 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 	header.channels = channel_infos;
 	header.pixel_types = pixel_types;
 	header.requested_pixel_types = requested_pixel_types;
+	header.compression_type = TINYEXR_COMPRESSIONTYPE_PIZ;
 
-	CharString utf8_filename = p_path.utf8();
-	const char *err;
-	int ret = SaveEXRImageToFile(&image, &header, utf8_filename.ptr(), &err);
-	if (ret != TINYEXR_SUCCESS) {
+	unsigned char *mem = nullptr;
+	const char *err = nullptr;
+
+	size_t bytes = SaveEXRImageToMemory(&image, &header, &mem, &err);
+
+	if (bytes == 0) {
 		print_error(String("Saving EXR failed. Error: {0}").format(varray(err)));
 		return ERR_FILE_CANT_WRITE;
+	} else {
+		FileAccessRef ref = FileAccess::open(p_path, FileAccess::WRITE);
+		ERR_FAIL_COND_V(!ref, ERR_FILE_CANT_WRITE);
+		ref->store_buffer(mem, bytes);
+		free(mem);
 	}
 
 	return OK;

--- a/scene/3d/baked_lightmap.h
+++ b/scene/3d/baked_lightmap.h
@@ -161,6 +161,8 @@ private:
 	bool capture_enabled;
 	int bounces;
 	bool use_denoiser;
+	bool use_hdr;
+	bool use_color;
 
 	EnvironmentMode environment_mode;
 	Ref<Sky> environment_custom_sky;
@@ -186,6 +188,7 @@ private:
 	Vector2i _compute_lightmap_size(const MeshesFound &p_mesh);
 
 	static bool _lightmap_bake_step_function(float p_completion, const String &p_text, void *ud, bool p_refresh);
+	void _save_image(String &r_base_path, Ref<Image> p_img, bool p_use_srgb);
 
 protected:
 	static void _bind_methods();
@@ -246,6 +249,12 @@ public:
 
 	void set_use_denoiser(bool p_enable);
 	bool is_using_denoiser() const;
+
+	void set_use_hdr(bool p_enable);
+	bool is_using_hdr() const;
+
+	void set_use_color(bool p_enable);
+	bool is_using_color() const;
 
 	void set_bounces(int p_bounces);
 	int get_bounces() const;


### PR DESCRIPTION
A couple of commits that should help reduce the lightmap's file size:

* Backport EXR compression support from master: this alone already makes a big difference, with EXR files being about 1/3 in size compared to their uncompressed equivalent.
* Added options to reduce file size even further:
  - Use LDR: save the lightmaps as PNG files instead of EXR. This results in much smaller files, but it means light values above 1.0 get clamped and that precision is much lower, creating banding in some situations.
  - Use grayscale: lightmaps only store one channel per texel, so color information is removed and only brightness is taken into account. Closes https://github.com/godotengine/godot-proposals/issues/2142.
  
  These two options can be used independently or can be combined to get the smallest texture file size possible.

I changed the denoiser to work in a single buffer, reducing RAM usage, and also added the `-mstackrealign` flag in the denoiser compilation for MinGW builds. This flag helped fix a bug in Embree, so I want to see if it will also help with #45296.