### PR TITLE
Fix a pop in AudioStreamPlaybackResampled

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -44,9 +44,14 @@ void AudioStreamPlaybackResampled::_begin_resample() {
 	//mix buffer
 	_mix_internal(internal_buffer + 4, INTERNAL_BUFFER_LEN);
 	mix_offset = 0;
+	ready = true;
 }
 
 void AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
+	if (!ready) {
+		return;
+	}
+
 	float target_rate = AudioServer::get_singleton()->get_mix_rate();
 	float global_rate_scale = AudioServer::get_singleton()->get_global_rate_scale();
 

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -66,6 +66,8 @@ class AudioStreamPlaybackResampled : public AudioStreamPlayback {
 	AudioFrame internal_buffer[INTERNAL_BUFFER_LEN + CUBIC_INTERP_HISTORY];
 	uint64_t mix_offset;
 
+	bool ready = false;
+
 protected:
 	void _begin_resample();
 	virtual void _mix_internal(AudioFrame *p_buffer, int p_frames) = 0;


### PR DESCRIPTION
This should fix some of the worst pops tracked by #22016. That issue seems to also be tracking some issues involving NaNs in the audio buffer though so I don't think this PR should close it.

The root cause of this pop seems to be related to the fact that `start()` calls in these streams trigger `_begin_resample` on the calling thread (usually the main thread, I'd think). Meanwhile, the stream is already active, so the audio thread is free to call its mix function at any time. This change prevents mixing from happening on both the audio thread and the main thread at the same time. There might be other ways to accomplish this, but this is what came to mind.

Notably, There's still a faint crackle on a AudioStreamPlayer2/3D's `play()` even with this change applied. I'm not sure what's causing that.

Testing is most easily done in this project or something similar:
[sound_pop.zip](https://github.com/godotengine/godot/files/5984720/sound_pop.zip)

What's important is the fact that it creates and initializes a new AudioStream every few seconds and plays it. This means there are lots of opportunities for the bug to crop up. It is nondeterministic, so you might have to wait 15-30 seconds, but usually not any longer in my experience. The pop I'm fixing in this PR is very harsh and pretty hard to miss.

To reproduce the issue open up the repro project and run it, then switch to an ogg or mp3 stream, and switch to an AudioStream2D or AudioStream3D.

I'm not entirely sure why but this pop doesn't repro at all on a regular AudioStreamPlayer (perhaps it has some kind of fade-in mechanism that the others don't?)