### PR TITLE
Select TreeItem if none is selected

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3342,6 +3342,9 @@ void Tree::item_selected(int p_column, TreeItem *p_item) {
 		//emit_signal("multi_selected",p_item,p_column,true); - NO this is for TreeItem::select
 
 		selected_col = p_column;
+		if (!selected_item) {
+			selected_item = p_item;
+		}
 	} else {
 		select_single_item(p_item, root, p_column);
 	}


### PR DESCRIPTION
Fixes #46074
The issue doesn't seem to happen on master for some reason, but it makes sense that if you select column you also select the item (if it's not selected).