### PR TITLE
Fix various small issues with PopupMenu

### DIFF
--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -101,6 +101,7 @@ class PopupMenu : public Popup {
 	int _get_mouse_over(const Point2 &p_over) const;
 	virtual Size2 _get_contents_minimum_size() const override;
 
+	int _get_item_height(int p_item) const;
 	int _get_items_total_height() const;
 	void _scroll_to_item(int p_item);
 


### PR DESCRIPTION
- Textless items aren't completely squished anymore.
- Check icon's height are now taken into account.
  - And so separators as well!

**Before / After:**
![Screenshot_20210216_004438](https://user-images.githubusercontent.com/30739239/108017505-fce95280-700c-11eb-811d-de20380837d4.png)

I actually stumbled into a bug with `StyleBoxLine` while doing this, but the fix can also be applied to 3.2.*, so it will be done in another PR.

Fixes #44894.