### PR TITLE
Fix mono->stereo conversion for oggs

### DIFF
--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -47,7 +47,7 @@ void AudioStreamPlaybackOGGVorbis::_mix_internal(AudioFrame *p_buffer, int p_fra
 		int mixed = stb_vorbis_get_samples_float_interleaved(ogg_stream, 2, buffer, todo * 2);
 		if (vorbis_stream->channels == 1 && mixed > 0) {
 			//mix mono to stereo
-			for (int i = start_buffer; i < mixed; i++) {
+			for (int i = start_buffer; i < start_buffer + mixed; i++) {
 				p_buffer[i].r = p_buffer[i].l;
 			}
 		}


### PR DESCRIPTION
This is a one-line fix that fixes one of the bugs reported in #40630.

To test, download the example project in that issue and set up the audio stream player node to play the Mono OGG file. Behavior before the fix will be a corrupted stereo channel as described in the bug. After the fix, you should hear the 174hz tone normally.