### PR TITLE
Add cwrap to EXTRA_EXPORTED_RUNTIME_METHODS

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -229,7 +229,7 @@ def configure(env):
     env.Append(LINKFLAGS=["-s", "OFFSCREEN_FRAMEBUFFER=1"])
 
     # callMain for manual start.
-    env.Append(LINKFLAGS=["-s", "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']"])
+    env.Append(LINKFLAGS=["-s", "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain','cwrap']"])
 
     # Add code that allow exiting runtime.
     env.Append(LINKFLAGS=["-s", "EXIT_RUNTIME=1"])


### PR DESCRIPTION
Note: I'm putting this PR against master because I think that's the standard procedure. The fix may not be testable on master because I'm not sure if 4.0 has WASM support yet. This PR is primarily to fix 3.2, but I think eventually master will need it as well.

This PR fixes https://github.com/godotengine/godot/issues/38241. It looks like the problem was that in some previous version Emscripten stopped adding `cwrap` to the `Module` object by default. Mono seems to depend on `cwrap` to start background processing, and one of the background tasks is the garbage collector. The result was that the game would launch but would leak a lot of memory and would often crash.

This PR simply changes Emscripten config to explicitly request `cwrap`.