### PR TITLE
Fix minimum_character_width in LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1587,7 +1587,7 @@ Size2 LineEdit::get_minimum_size() const {
 
 	// Minimum size of text.
 	int em_space_size = font->get_char_size('M', 0, font_size).x;
-	min_size.width = get_theme_constant("minimum_character_width'") * em_space_size;
+	min_size.width = get_theme_constant("minimum_character_width") * em_space_size;
 
 	if (expand_to_text_length) {
 		// Add a space because some fonts are too exact, and because cursor needs a bit more when at the end.


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes a small mistake in the "minimum_character_width" constant name for LineEdit.
Error was introduced by this commit: https://github.com/godotengine/godot/commit/28537d8c84a from this PR: https://github.com/godotengine/godot/pull/45923
