### PR TITLE
Fixes crash when using VisualShader::set_mode with invalid mode

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -675,6 +675,8 @@ void VisualShader::get_node_connections(Type p_type, List<Connection> *r_connect
 }
 
 void VisualShader::set_mode(Mode p_mode) {
+	ERR_FAIL_INDEX_MSG(p_mode, Mode::MODE_MAX, vformat("Invalid shader mode: %d.", p_mode));
+
 	if (shader_mode == p_mode) {
 		return;
 	}


### PR DESCRIPTION
This fixes #46062.

This is my first contribution to an open source project, so I hope everything is alright. If not let me know.

One thing though. I only tested that this works in version 3.2.4, as that was the version the issue was posted in, and because my laptop doesn't support vulkan; so I can't test it in version 4.0.
But I imagined that this fix is so simple that it should be all right.