### PR TITLE
add checks for node type range in add_node function

### DIFF
--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -926,7 +926,7 @@ void AnimationTreePlayer::add_node(NodeType p_type, const StringName &p_node) {
 
 	ERR_FAIL_COND(p_type == NODE_OUTPUT);
 	ERR_FAIL_COND(node_map.has(p_node));
-
+	ERR_FAIL_INDEX(p_type, NODE_MAX);
 	NodeBase *n = NULL;
 
 	switch (p_type) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Adds a check on the node type passed as an argument to add_node to send an error if it is out of the required range.
fixes #46012 
Making a PR for 3.2 branch since the file doesn't exist on master.