### PR TITLE
[HTML5] Implement OS.get_processor_count(), 4.0 fixes

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -92,9 +92,9 @@ def configure(env):
         if not env["threads_enabled"]:
             print("Threads must be enabled to build the editor. Please add the 'threads_enabled=yes' option")
             sys.exit(255)
-        if env["initial_memory"] < 32:
-            print("Editor build requires at least 32MiB of initial memory. Forcing it.")
-            env["initial_memory"] = 32
+        if env["initial_memory"] < 64:
+            print("Editor build requires at least 64MiB of initial memory. Forcing it.")
+            env["initial_memory"] = 64
     elif env["builtin_icu"]:
         env.Append(CCFLAGS=["-frtti"])
     else:
@@ -233,3 +233,11 @@ def configure(env):
 
     # Add code that allow exiting runtime.
     env.Append(LINKFLAGS=["-s", "EXIT_RUNTIME=1"])
+
+    # TODO remove once we have GLES support back (temporary fix undefined symbols due to dead code elimination).
+    env.Append(
+        LINKFLAGS=[
+            "-s",
+            "EXPORTED_FUNCTIONS=['_main', '_emscripten_webgl_get_current_context', '_emscripten_webgl_commit_frame', '_emscripten_webgl_create_context']",
+        ]
+    )

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -49,6 +49,7 @@ extern int godot_js_os_fs_is_persistent();
 extern void godot_js_os_fs_sync(void (*p_callback)());
 extern int godot_js_os_execute(const char *p_json);
 extern void godot_js_os_shell_open(const char *p_uri);
+extern int godot_js_os_hw_concurrency_get();
 
 // Display
 extern int godot_js_display_screen_dpi_get();

--- a/platform/javascript/js/libs/library_godot_os.js
+++ b/platform/javascript/js/libs/library_godot_os.js
@@ -282,6 +282,11 @@ const GodotOS = {
 	godot_js_os_shell_open: function (p_uri) {
 		window.open(GodotRuntime.parseString(p_uri), '_blank');
 	},
+
+	godot_js_os_hw_concurrency_get__sig: 'i',
+	godot_js_os_hw_concurrency_get: function () {
+		return navigator.hardwareConcurrency || 1;
+	},
 };
 
 autoAddDeps(GodotOS, '$GodotOS');

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -129,6 +129,10 @@ int OS_JavaScript::get_process_id() const {
 	ERR_FAIL_V_MSG(0, "OS::get_process_id() is not available on the HTML5 platform.");
 }
 
+int OS_JavaScript::get_processor_count() const {
+	return godot_js_os_hw_concurrency_get();
+}
+
 bool OS_JavaScript::_check_internal_feature_support(const String &p_feature) {
 	if (p_feature == "HTML5" || p_feature == "web") {
 		return true;

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -74,6 +74,7 @@ public:
 	Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr) override;
 	Error kill(const ProcessID &p_pid) override;
 	int get_process_id() const override;
+	int get_processor_count() const override;
 
 	String get_executable_path() const override;
 	Error shell_open(String p_uri) override;


### PR DESCRIPTION
In this PR:

- RasterizerDummy now instances Image(s).
   Avoid crash on start-up, we will need to slowly re-implement the various methods with dummy objects so exporting works again like in 3.2
- Fix compilation issues in 4.0
  More memory is needed, and a Workaround to avoid undefined symbol due to dead code elimination.
- Implement `OS.get_processor_count`.
  Which is needed by `ThreadWorkPool`.

I'll make a separate `3.2` PR including only the `get_processor_count` change.