### PR TITLE
CPUParticles3D crash fix

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -152,6 +152,7 @@ float CPUParticles3D::get_speed_scale() const {
 }
 
 void CPUParticles3D::set_draw_order(DrawOrder p_order) {
+	ERR_FAIL_INDEX(p_order, DRAW_ORDER_MAX);
 	draw_order = p_order;
 }
 
@@ -1011,6 +1012,7 @@ void CPUParticles3D::_update_particle_data_buffer() {
 			sorter.compare.particles = r;
 			sorter.sort(order, pc);
 		} else if (draw_order == DRAW_ORDER_VIEW_DEPTH) {
+			ERR_FAIL_NULL(get_viewport());
 			Camera3D *c = get_viewport()->get_camera();
 			if (c) {
 				Vector3 dir = c->get_global_transform().basis.get_axis(2); //far away to close

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -43,6 +43,7 @@ public:
 		DRAW_ORDER_INDEX,
 		DRAW_ORDER_LIFETIME,
 		DRAW_ORDER_VIEW_DEPTH,
+		DRAW_ORDER_MAX
 	};
 
 	enum Parameter {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Adds null check and range check to prevent crash in CPUParticles3D
Fixes #46058