### PR TITLE
Change fallback icon for abstract nodes to have a grayed out color

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -236,7 +236,10 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 	bool can_instance = (p_cpp_type && ClassDB::can_instance(p_type)) || !p_cpp_type;
 	if (!can_instance) {
 		r_item->set_custom_color(0, search_options->get_theme_color("disabled_font_color", "Editor"));
+		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, "NodeDisabled"));
 		r_item->set_selectable(0, false);
+	} else {
+		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
 	}
 
 	if (search_box->get_text() != "") {
@@ -253,7 +256,6 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 
 	const String &description = DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description);
 	r_item->set_tooltip(0, description);
-	r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
 
 	if (!p_cpp_type && !script_type) {
 		Ref<Texture2D> icon = EditorNode::get_editor_data().get_custom_types()[custom_type_parents[p_type]][custom_type_indices[p_type]].icon;

--- a/editor/icons/NodeDisabled.svg
+++ b/editor/icons/NodeDisabled.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m8 2a6 6 0 0 0 -6 6 6 6 0 0 0 6 6 6 6 0 0 0 6-6 6 6 0 0 0 -6-6zm0 2a4 4 0 0 1 4 4 4 4 0 0 1 -4 4 4 4 0 0 1 -4-4 4 4 0 0 1 4-4z" fill="#999"/></svg>


### PR DESCRIPTION
In the current master, abstract nodes without an icon fallback to the "Node" icon. This is a bit strange because it makes them look just like Node, it makes them look the same as custom classes without an icon, and it makes them look clickable. This PR changes the icon to be a grayed out color, so that they look unique and look unclickable.

Before:

![before](https://user-images.githubusercontent.com/1646875/108248441-d963fc00-7121-11eb-82f4-eed0bb6da278.png)

After:

![after](https://user-images.githubusercontent.com/1646875/108248447-dc5eec80-7121-11eb-9c79-0bfe8d0aa6d9.png)
