### PR TITLE
Improve verbose logging for the Android export process

### DIFF
--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -146,6 +146,9 @@ Error store_string_at_path(const String &p_path, const String &p_data) {
 	String dir = p_path.get_base_dir();
 	Error err = create_directory(dir);
 	if (err != OK) {
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			print_error("Unable to write data into " + p_path);
+		}
 		return err;
 	}
 	FileAccess *fa = FileAccess::open(p_path, FileAccess::WRITE);
@@ -162,12 +165,14 @@ Error store_string_at_path(const String &p_path, const String &p_data) {
 // This method will be called ONLY when custom build is enabled.
 Error rename_and_store_file_in_gradle_project(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key) {
 	String dst_path = p_path.replace_first("res://", "res://android/build/assets/");
+	print_verbose("Saving project files from " + p_path + " into " + dst_path);
 	Error err = store_file_at_path(dst_path, p_data);
 	return err;
 }
 
 // Creates strings.xml files inside the gradle project for different locales.
 Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &project_name) {
+	print_verbose("Creating strings resources for supported locales for project " + project_name);
 	// Stores the string into the default values directory.
 	String processed_default_xml_string = vformat(godot_project_name_xml_string, project_name.xml_escape(true));
 	store_string_at_path("res://android/build/res/values/godot_project_name_string.xml", processed_default_xml_string);
@@ -175,6 +180,9 @@ Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset
 	// Searches the Gradle project res/ directory to find all supported locales
 	DirAccessRef da = DirAccess::open("res://android/build/res");
 	if (!da) {
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			print_error("Unable to open Android resources directory.");
+		}
 		return ERR_CANT_OPEN;
 	}
 	da->list_dir_begin();
@@ -193,6 +201,7 @@ Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset
 		if (ProjectSettings::get_singleton()->has_setting(property_name)) {
 			String locale_project_name = ProjectSettings::get_singleton()->get(property_name);
 			String processed_xml_string = vformat(godot_project_name_xml_string, locale_project_name.xml_escape(true));
+			print_verbose("Storing project name for locale " + locale + " under " + locale_directory);
 			store_string_at_path(locale_directory, processed_xml_string);
 		} else {
 			// TODO: Once the legacy build system is deprecated we don't need to have xml files for this else branch


### PR DESCRIPTION
Increase the amount of verbose logging to help with troubleshooting the Android build/export process.

This will enable users to provide us with detailed logs about where the process may be erroring.