### PR TITLE
Revert AGP to version 4.0.1

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-    androidGradlePlugin: '4.1.0',
+    androidGradlePlugin: '4.0.1',
     compileSdk         : 29,
     minSdk             : 18,
     targetSdk          : 29,


### PR DESCRIPTION
This is a workaround to https://issuetracker.google.com/issues/171235570 in version 4.1.x

Fix #45821