### PR TITLE
Android: Bump NDK version to 21.4.7075529

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -373,7 +373,7 @@ def configure(env):
 # Return the project NDK version.
 # This is kept in sync with the value in 'platform/android/java/app/config.gradle'.
 def get_project_ndk_version():
-    return "21.3.6528147"
+    return "21.4.7075529"
 
 
 # Return NDK version string in source.properties (adapted from the Chromium project).

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -8,7 +8,7 @@ ext.versions = [
     kotlinVersion      : '1.4.10',
     v4Support          : '1.0.0',
     javaVersion        : 1.8,
-    ndkVersion         : '21.3.6528147' // Also update 'platform/android/detect.py#get_project_ndk_version()' when this is updated.
+    ndkVersion         : '21.4.7075529' // Also update 'platform/android/detect.py#get_project_ndk_version()' when this is updated.
 
 ]
 


### PR DESCRIPTION
This is what GitHub Actions now provide and they removed the previous 21.3.6528147.
A bit annoying to have our hand forced this way but it's still 21.x so should be good
to upgrade.