### PR TITLE
Fix a pop on play() in AudioStreamPlayer2D and 3D

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -311,7 +311,6 @@ void AudioStreamPlayer2D::play(float p_from_pos) {
 	}
 
 	if (stream_playback.is_valid()) {
-		active = true;
 		setplay = p_from_pos;
 		output_ready = false;
 		set_physics_process_internal(true);
@@ -334,7 +333,7 @@ void AudioStreamPlayer2D::stop() {
 
 bool AudioStreamPlayer2D::is_playing() const {
 	if (stream_playback.is_valid()) {
-		return active; // && stream_playback->is_playing();
+		return active || setplay >= 0;
 	}
 
 	return false;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -683,7 +683,6 @@ void AudioStreamPlayer3D::play(float p_from_pos) {
 	}
 
 	if (stream_playback.is_valid()) {
-		active = true;
 		setplay = p_from_pos;
 		output_ready = false;
 		set_physics_process_internal(true);
@@ -706,7 +705,7 @@ void AudioStreamPlayer3D::stop() {
 
 bool AudioStreamPlayer3D::is_playing() const {
 	if (stream_playback.is_valid()) {
-		return active; // && stream_playback->is_playing();
+		return active || setplay >= 0;
 	}
 
 	return false;


### PR DESCRIPTION
Successor to #46078.

This fixes pops by ensuring that audio stream players start their playback streams before attempting to mix them. This issue was introduced in https://github.com/godotengine/godot/commit/016f7bd8f8e9bebceab6ef1cfc9c1fdc9c786871 and causes _mix_audio() to occasionally attempt to mix using a playback stream before the physics process notification has properly started it. Specifically, if `setseek` is left unset, the audio stream playback's start() method will never be called. If you're having difficulty reproducing the pop that this fixes, try halving your physics framerate until you can repro it.

In addition to reverting the change referenced above, I added some logic so I don't reintroduce the issue it fixed.

While I think it fixes the worst of the pops, I'm not sure if it would be appropriate to call #22016 completely solved with it, since there may be other issues. AudioStreamPlayer2D and 3D still have pops on stop() but they sound just as clean at the beginning of playback as a regular AudioStreamPlayer now.

To test, download this sample project.

[new_test_project.zip](https://github.com/godotengine/godot/files/5999993/new_test_project.zip)

Run the test project and select the options to play an OGG or MP3 using both 3D and 2D player nodes. WAV files will be unaffected because they don't need to be started before being used.