### PR TITLE
Use the correct .write proxies while swapping audio effect buffers.

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -374,7 +374,7 @@ void AudioServer::_mix_step() {
 					if (!(buses[i]->channels[k].active || bus->channels[k].effect_instances[j]->process_silence())) {
 						continue;
 					}
-					SWAP(bus->channels.write[k].buffer, temp_buffer.write[k]);
+					SWAP(bus->channels.write[k].buffer.write, temp_buffer.write[k].write);
 				}
 
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
edit: before anyone gets their hopes up too much, this breaks effects completely. 1am me didn't realize that at first so I jumped the gun on making the PR. But I think this might be close to where the actual problem is. Will continue working at a more reasonable time.

Fixes #38372

This was a fun one to track down. It seems like it was introduced in https://github.com/godotengine/godot/commit/0e29f7974b59e4440cf02e1388fb9d8ab2b5c5fd and wasn't caught by the compiler presumably because of the semantics of the SWAP operation? I don't fully understand what's going on here so hopefully somebody with a bit of knowledge on the COW stuff and the audio server can review. What I do know is that buffers seem to get shuffled around in ways that are extremely difficult to predict without this patch.

Testing can be done with the minimal repro project in #38372

Since I'm in the audio server making this change, let me know if there's something that would make more sense than SWAP here, or if everything should be fine now that it's just using the write proxies.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
