### PR TITLE
Linux: Fix fallback logic when udev fails creating a context

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -105,11 +105,13 @@ void JoypadLinux::run_joypad_thread() {
 		udev *_udev = udev_new();
 		if (!_udev) {
 			use_udev = false;
-			ERR_FAIL_MSG("Failed getting an udev context, falling back to parsing /dev/input.");
+			ERR_PRINT("Failed getting an udev context, falling back to parsing /dev/input.");
+			monitor_joypads();
+		} else {
+			enumerate_joypads(_udev);
+			monitor_joypads(_udev);
+			udev_unref(_udev);
 		}
-		enumerate_joypads(_udev);
-		monitor_joypads(_udev);
-		udev_unref(_udev);
 	} else {
 		monitor_joypads();
 	}


### PR DESCRIPTION
Thanks to Noshyaar for pointing out the bug.

Tiny regression from #46117, I assumed `run_joypad_thread()` was being called repeatedly in a thread and the fallback would happen on the next iteration, but the loop is actually in `monitor_joypads()`, this is only the setup method.