### PR TITLE
Batching - prevent joining of lightmasked items

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1277,7 +1277,12 @@ bool RasterizerCanvasGLES2::try_join_item(Item *p_ci, RenderItemState &r_ris, bo
 	r_batch_break = false;
 	bool join = true;
 
-	// light_masked may possibly need state checking here. Check for regressions!
+	// light_masked objects we just don't currently support for joining
+	// (this could possibly be improved at a later date)
+	if (p_ci->light_masked) {
+		join = false;
+		r_batch_break = true;
+	}
 
 	// we will now allow joining even if final modulate is different
 	// we will instead bake the final modulate into the vertex colors

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1678,7 +1678,12 @@ bool RasterizerCanvasGLES3::try_join_item(Item *p_ci, RenderItemState &r_ris, bo
 	r_batch_break = false;
 	bool join = true;
 
-	// light_masked may possibly need state checking here. Check for regressions!
+	// light_masked objects we just don't currently support for joining
+	// (this could possibly be improved at a later date)
+	if (p_ci->light_masked) {
+		join = false;
+		r_batch_break = true;
+	}
 
 	// we will now allow joining even if final modulate is different
 	// we will instead bake the final modulate into the vertex colors


### PR DESCRIPTION
It turns out lights masking misbehaves when items that are masked are joined. This PR simply disables joining in this case.

## Notes
* Turns out I had a note already in the code that this might be an issue in future.
* It's possible that this case could be handled slightly more optimally, but it requires some time investment to investigate, and it doesn't seem that common a use case.
* Everything outside the zone of such a masking light will batch as normal.

Fixes #46154
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
