### PR TITLE
add null check in MeshInstance::_mesh_changed()

### DIFF
--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -701,6 +701,7 @@ bool MeshInstance::is_software_skinning_transform_normals_enabled() const {
 }
 
 void MeshInstance::_mesh_changed() {
+	ERR_FAIL_COND(mesh.is_null());
 	materials.resize(mesh->get_surface_count());
 
 	if (software_skinning) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #45980
add null check to prevent crash when executing `MeshInstance.new()._mesh_changed()`