### PR TITLE
add null check in MeshInstance::_mesh_changed()

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -319,6 +319,7 @@ Ref<Material> MeshInstance3D::get_active_material(int p_surface) const {
 }
 
 void MeshInstance3D::_mesh_changed() {
+	ERR_FAIL_COND(mesh.is_null());
 	materials.resize(mesh->get_surface_count());
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #45980
add null check to prevent crash when executing `MeshInstance.new()._mesh_changed()`