### PR TITLE
[3.2] Follow up on bootsplash handling on Android

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1307,7 +1307,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	MAIN_PRINT("Main: Setup Logo");
 
-#ifdef JAVASCRIPT_ENABLED
+#if defined(JAVASCRIPT_ENABLED) || defined(ANDROID_ENABLED)
 	bool show_logo = false;
 #else
 	bool show_logo = true;

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -202,6 +202,19 @@ static const char *android_perms[] = {
 
 static const char *SPLASH_IMAGE_EXPORT_PATH = "res/drawable/splash.png";
 static const char *SPLASH_BG_COLOR_PATH = "res/drawable/splash_bg_color.png";
+static const char *SPLASH_CONFIG_PATH = "res://android/build/res/drawable/splash_drawable.xml";
+
+const String SPLASH_CONFIG_XML_CONTENT = R"SPLASH(<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+	<item android:drawable="@drawable/splash_bg_color" />
+	<item>
+		<bitmap
+				android:gravity="%s"
+				android:filter="%s"
+				android:src="@drawable/splash" />
+	</item>
+</layer-list>
+)SPLASH";
 
 struct LauncherIcon {
 	const char *export_path;
@@ -1508,8 +1521,9 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		}
 	}
 
-	void load_splash_refs(Ref<Image> &splash_image, Ref<Image> &splash_bg_color_image) {
-		// TODO: Figure out how to handle remaining boot splash parameters (e.g: fullsize, filter)
+	String load_splash_refs(Ref<Image> &splash_image, Ref<Image> &splash_bg_color_image) {
+		bool scale_splash = ProjectSettings::get_singleton()->get("application/boot_splash/fullsize");
+		bool apply_filter = ProjectSettings::get_singleton()->get("application/boot_splash/use_filter");
 		String project_splash_path = ProjectSettings::get_singleton()->get("application/boot_splash/image");
 
 		if (!project_splash_path.empty()) {
@@ -1541,6 +1555,10 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		splash_bg_color_image.instance();
 		splash_bg_color_image->create(splash_image->get_width(), splash_image->get_height(), false, splash_image->get_format());
 		splash_bg_color_image->fill(bg_color);
+
+		String gravity = scale_splash ? "fill" : "center";
+		String processed_splash_config_xml = vformat(SPLASH_CONFIG_XML_CONTENT, gravity, bool_to_string(apply_filter));
+		return processed_splash_config_xml;
 	}
 
 	void load_icon_refs(const Ref<EditorExportPreset> &p_preset, Ref<Image> &icon, Ref<Image> &foreground, Ref<Image> &background) {
@@ -1584,11 +1602,18 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 	}
 
 	void _copy_icons_to_gradle_project(const Ref<EditorExportPreset> &p_preset,
+			const String &processed_splash_config_xml,
 			const Ref<Image> &splash_image,
 			const Ref<Image> &splash_bg_color_image,
 			const Ref<Image> &main_image,
 			const Ref<Image> &foreground,
 			const Ref<Image> &background) {
+		// Store the splash configuration
+		if (!processed_splash_config_xml.empty()) {
+			print_verbose("Storing processed splash configuration: " + String("\n") + processed_splash_config_xml);
+			store_string_at_path(SPLASH_CONFIG_PATH, processed_splash_config_xml);
+		}
+
 		// Store the splash image
 		if (splash_image.is_valid() && !splash_image->empty()) {
 			print_verbose("Storing splash image in " + String(SPLASH_IMAGE_EXPORT_PATH));
@@ -2751,7 +2776,7 @@ public:
 
 		Ref<Image> splash_image;
 		Ref<Image> splash_bg_color_image;
-		load_splash_refs(splash_image, splash_bg_color_image);
+		String processed_splash_config_xml = load_splash_refs(splash_image, splash_bg_color_image);
 
 		Ref<Image> main_image;
 		Ref<Image> foreground;
@@ -2812,7 +2837,7 @@ public:
 				EditorNode::add_io_error("Unable to overwrite res://android/build/res/*.xml files with project name");
 			}
 			// Copies the project icon files into the appropriate Gradle project directory.
-			_copy_icons_to_gradle_project(p_preset, splash_image, splash_bg_color_image, main_image, foreground, background);
+			_copy_icons_to_gradle_project(p_preset, processed_splash_config_xml, splash_image, splash_bg_color_image, main_image, foreground, background);
 			// Write an AndroidManifest.xml file into the Gradle project directory.
 			_write_tmp_manifest(p_preset, p_give_internet, p_debug);
 			_update_custom_build_project();

--- a/platform/android/java/app/res/drawable/splash_drawable.xml
+++ b/platform/android/java/app/res/drawable/splash_drawable.xml
@@ -6,7 +6,7 @@
 	<item>
 		<bitmap
 				android:gravity="center"
+				android:filter="false"
 				android:src="@drawable/splash" />
 	</item>
-
 </layer-list>


### PR DESCRIPTION
Disables engine splash logic on Android; this is now handled by the Android theme api.
This finishes the work started in #42389 to address #21824.

In addition, this adds support for scaling and applying filter to the splash screen on Android.
One limitation of the Android api being used is that the **splash screen aspect ratio is not maintained when it's scaled up**. While it's a platform limitation, this may look like a regression for some users, so I'm open to feedback on how it should be handled.

Fix #43726 
