### PR TITLE
Follow up on bootsplash handling on Android

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1602,7 +1602,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	MAIN_PRINT("Main: Setup Logo");
 
-#ifdef JAVASCRIPT_ENABLED
+#if defined(JAVASCRIPT_ENABLED) || defined(ANDROID_ENABLED)
 	bool show_logo = false;
 #else
 	bool show_logo = true;

--- a/platform/android/java/app/res/drawable/splash_drawable.xml
+++ b/platform/android/java/app/res/drawable/splash_drawable.xml
@@ -6,7 +6,7 @@
 	<item>
 		<bitmap
 				android:gravity="center"
+				android:filter="false"
 				android:src="@drawable/splash" />
 	</item>
-
 </layer-list>


### PR DESCRIPTION
Disables engine splash logic on Android; this is now handled by the Android theme api.
This finishes the work started in #42389 to address #21824.

In addition, this adds support for scaling and applying filter to the splash screen on Android.
One limitation of the Android api being used is that the **splash screen aspect ratio is not maintained when it's scaled up**. While it's a platform limitation, this may look like a regression for some users, so I'm open to feedback on how it should be handled.

Fix #43726 
