### PR TITLE
SCons: Make freetype module a mandatory editor dependency

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -617,7 +617,7 @@ if selected_platform in platform_list:
     if env["minizip"]:
         env.Append(CPPDEFINES=["MINIZIP_ENABLED"])
 
-    editor_module_list = ["regex"]
+    editor_module_list = ["freetype", "regex"]
     if env["tools"] and not env.module_check_dependencies("tools", editor_module_list):
         print(
             "Build option 'module_"


### PR DESCRIPTION
Fixes #28650.

---

Note: I didn't actually test using an export template without freetype support. I expect that it might work as long as you don't use any `DynamicFont`... pretty limiting, especially as we might use one in the default theme in 4.0, but I guess it could be used if really wanted (and maybe one could have a custom module reimplementing DynamicFont support with another library, like `stb_truetype`).