### PR TITLE
GLES - fix some sanitizer warnings

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -1288,7 +1288,8 @@ PREAMBLE(bool)::_prefill_line(RasterizerCanvas::Item::CommandLine *p_line, FillS
 
 		r_fill_state.curr_batch->type = line_batch_type;
 		r_fill_state.curr_batch->color = bcol;
-		r_fill_state.curr_batch->batch_texture_id = -1;
+		// cast is to stop sanitizer benign warning .. watch though in case destination type changes
+		r_fill_state.curr_batch->batch_texture_id = (uint16_t)-1;
 		r_fill_state.curr_batch->first_command = command_num;
 		r_fill_state.curr_batch->num_commands = 1;
 		//r_fill_state.curr_batch->first_quad = bdata.total_quads;

--- a/drivers/gles_common/rasterizer_storage_common.h
+++ b/drivers/gles_common/rasterizer_storage_common.h
@@ -45,7 +45,7 @@ public:
 	// these flags are specifically for batching
 	// some of the logic is thus in rasterizer_storage.cpp
 	// we could alternatively set bitflags for each 'uses' and test on the fly
-	enum BatchFlags {
+	enum BatchFlags : uint32_t {
 		PREVENT_COLOR_BAKING = 1 << 0,
 		PREVENT_VERTEX_BAKING = 1 << 1,
 
@@ -65,7 +65,7 @@ public:
 		BT_DUMMY = 5, // dummy batch is just used to keep the batch creation loop simple
 	};
 
-	enum BatchTypeFlags {
+	enum BatchTypeFlags : uint32_t {
 		BTF_DEFAULT = 1 << BT_DEFAULT,
 		BTF_RECT = 1 << BT_RECT,
 		BTF_LINE = 1 << BT_LINE,

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -81,7 +81,7 @@ public:
 
 	/* TEXTURE API */
 
-	enum TextureFlags {
+	enum TextureFlags : unsigned int { // unsigned to stop sanitizer complaining about bit operations on ints
 		TEXTURE_FLAG_MIPMAPS = 1, /// Enable automatic mipmap generation - when available
 		TEXTURE_FLAG_REPEAT = 2, /// Repeat texture (Tiling), otherwise Clamping
 		TEXTURE_FLAG_FILTER = 4, /// Create texture with linear (or available) filter


### PR DESCRIPTION
These are benign but probably worth fixing as it clears the sanitizer log a bit to find more important errors.

A common problem with the sanitizer is that enums are often used to represent bits (e.g. 1, 2, 4, 8 etc) but without specifying the enum type, the compiler is free to use unsigned or signed int. In this case it uses int, and when it performs bitwise operations on the int type, the sanitizer complains.

This is probably because a bitshift with negative signed value can give undefined behaviour - the sanitizer can't know ahead of time that you are using the enum for sensible bitflags. Also the value after the bitshift is still possibly being interpreted as a signed int (it is kind of difficult to understand the logs).

## Notes
* I don't often run the sanitizer build, there are warnings all over, but I thought it would be good to remove superfluous warnings from the batching.
* Behaviour should be exactly the same.
* There are also some warnings from `shader_gles2` and `shader_gles3` from the conditionals code, which again uses integers for bit operations. I did have a look at fixing them but the chain of calls is quite long and I'm not really familiar with that code to fix without causing regressions.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
