### PR TITLE
Fix some inconsistent ISO-639 language codes

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -39,13 +39,14 @@
 #include "main/main.h"
 #endif
 
-// ISO 639-1 language codes, with the addition of glibc locales with their
-// regional identifiers. This list must match the language names (in English)
-// of locale_names.
+// ISO 639-1 language codes (and a couple of three-letter ISO 639-2 codes),
+// with the addition of glibc locales with their regional identifiers.
+// This list must match the language names (in English) of locale_names.
 //
 // References:
 // - https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 // - https://lh.2xlibre.net/locales/
+// - https://iso639-3.sil.org/
 
 static const char *locale_list[] = {
 	"aa", //  Afar
@@ -100,6 +101,7 @@ static const char *locale_list[] = {
 	"bo", //  Tibetan
 	"bo_CN", //  Tibetan (China)
 	"bo_IN", //  Tibetan (India)
+	"br", //  Breton
 	"br_FR", //  Breton (France)
 	"brx_IN", //  Bodo (India)
 	"bs_BA", //  Bosnian (Bosnia and Herzegovina)
@@ -201,6 +203,7 @@ static const char *locale_list[] = {
 	"gd_GB", //  Scottish Gaelic (United Kingdom)
 	"gez_ER", //  Geez (Eritrea)
 	"gez_ET", //  Geez (Ethiopia)
+	"gl", //  Galician
 	"gl_ES", //  Galician (Spain)
 	"gu_IN", //  Gujarati (India)
 	"gv_GB", //  Manx (United Kingdom)
@@ -273,6 +276,7 @@ static const char *locale_list[] = {
 	"ml_IN", //  Malayalam (India)
 	"mni_IN", //  Manipuri (India)
 	"mn_MN", //  Mongolian (Mongolia)
+	"mr", //  Marathi
 	"mr_IN", //  Marathi (India)
 	"ms", //  Malay
 	"ms_MY", //  Malay (Malaysia)
@@ -302,6 +306,7 @@ static const char *locale_list[] = {
 	"om", //  Oromo
 	"om_ET", //  Oromo (Ethiopia)
 	"om_KE", //  Oromo (Kenya)
+	"or", //  Oriya
 	"or_IN", //  Oriya (India)
 	"os_RU", //  Ossetian (Russia)
 	"pa_IN", //  Panjabi (India)
@@ -386,6 +391,8 @@ static const char *locale_list[] = {
 	"tr_TR", //  Turkish (Turkey)
 	"ts_ZA", //  Tsonga (South Africa)
 	"tt_RU", //  Tatar (Russia)
+	"tzm", // Central Atlas Tamazight
+	"tzm_MA", // Central Atlas Tamazight (Marrocos)
 	"ug_CN", //  Uighur (China)
 	"uk", //  Ukrainian
 	"uk_UA", //  Ukrainian (Ukraine)
@@ -468,6 +475,7 @@ static const char *locale_names[] = {
 	"Tibetan",
 	"Tibetan (China)",
 	"Tibetan (India)",
+	"Breton",
 	"Breton (France)",
 	"Bodo (India)",
 	"Bosnian (Bosnia and Herzegovina)",
@@ -569,6 +577,7 @@ static const char *locale_names[] = {
 	"Scottish Gaelic (United Kingdom)",
 	"Geez (Eritrea)",
 	"Geez (Ethiopia)",
+	"Galician",
 	"Galician (Spain)",
 	"Gujarati (India)",
 	"Manx (United Kingdom)",
@@ -641,6 +650,7 @@ static const char *locale_names[] = {
 	"Malayalam (India)",
 	"Manipuri (India)",
 	"Mongolian (Mongolia)",
+	"Marathi",
 	"Marathi (India)",
 	"Malay",
 	"Malay (Malaysia)",
@@ -670,6 +680,7 @@ static const char *locale_names[] = {
 	"Oromo",
 	"Oromo (Ethiopia)",
 	"Oromo (Kenya)",
+	"Oriya",
 	"Oriya (India)",
 	"Ossetian (Russia)",
 	"Panjabi (India)",
@@ -754,6 +765,8 @@ static const char *locale_names[] = {
 	"Turkish (Turkey)",
 	"Tsonga (South Africa)",
 	"Tatar (Russia)",
+	"Central Atlas Tamazight",
+	"Central Atlas Tamazight (Marrocos)",
 	"Uighur (China)",
 	"Ukrainian",
 	"Ukrainian (Ukraine)",


### PR DESCRIPTION
There are some languages (br, gl, mr, or, tzm) in the project manager language selector that are displayed without a locale name (only with their language code). Mainly because in locale_list they have their regional variants, but not their normal variants.

The last language (tzm) wasn't displayed simply because it wasn't on the list, so I added it.

Also, small nitckpic. The comment above the declaration of locale_list says that it is a list of ISO 639-1 codes, but actually all codes of three letters are from ISO 639-2. Just to avoid confusion.