### PR TITLE
Prevent distortion filter from introducing NaNs in the audio buffer

### DIFF
--- a/servers/audio/effects/audio_effect_distortion.cpp
+++ b/servers/audio/effects/audio_effect_distortion.cpp
@@ -58,7 +58,8 @@ void AudioEffectDistortionInstance::process(const AudioFrame *p_src_frames, Audi
 
 		switch (base->mode) {
 			case AudioEffectDistortion::MODE_CLIP: {
-				a = powf(a, 1.0001 - drive_f);
+				float a_sign = a < 0 ? -1.0f : 1.0f;
+				a = powf(abs(a), 1.0001 - drive_f) * a_sign;
 				if (a > 1.0) {
 					a = 1.0;
 				} else if (a < (-1.0)) {


### PR DESCRIPTION
Fixes #38372

Currently the base argument passed to `powf()` is negative sometimes. I don't understand the math here well enough to catch what that means conceptually or if it's indicative of a larger problem, but I do understand that for non-integer exponents that's going to cause `powf()` to NaN, which propagates a discontinuity in the output beyond just this filter. I tried this change and it works well. Distorted audio sounds nice and distorted, and undistorted audio also sounds clear since there aren't NaNs propagating through.

Notably, I tried to just clamp the value of `a` before the `powf()` step to the range [0,inf), but the distortion didn't sound good and the parameters applied to the filter didn't seem like they were changing things much. I dug a bit deeper and noticed that the `undenormalise` step if I understand it correctly seems to have an output range of (-inf,-1] and [1,inf). So I figured that sign was important and decided to try passing the sign bit through and only using the magnitude of the number for `powf`. This sounds great, but will definitely need a closer look by someone who knows what this filter is actually doing (reduz?).

Test using the minimal repro project for #38372.