### PR TITLE
[HTML5] Easier HTML templates, better canvas size handling

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -236,7 +236,7 @@
 	<script type='text/javascript' src='godot.tools.js'></script>
 	<script type='text/javascript'>//<![CDATA[
 
-		var engine = new Engine;
+		var editor = null;
 		var game = null;
 		var setStatusMode;
 		var setStatusNotice;
@@ -321,8 +321,8 @@
 
 		function closeEditor() {
 			closeGame();
-			if (engine) {
-				engine.requestQuit();
+			if (editor) {
+				editor.requestQuit();
 			}
 		}
 
@@ -336,6 +336,7 @@
 			var statusProgressInner = document.getElementById('status-progress-inner');
 			var statusIndeterminate = document.getElementById('status-indeterminate');
 			var statusNotice = document.getElementById('status-notice');
+			var headerDiv = document.getElementById('tabs-buttons');
 
 			var initializing = true;
 			var statusMode = 'hidden';
@@ -349,16 +350,23 @@
 			}
 			requestAnimationFrame(animate);
 
+			var lastScale = 0;
+			var lastWidth = 0;
+			var lastHeight = 0;
 			function adjustCanvasDimensions() {
 				var scale = window.devicePixelRatio || 1;
-				var header = document.getElementById('tabs-buttons');
-				var headerHeight = header.offsetHeight + 1;
+				var headerHeight = headerDiv.offsetHeight + 1;
 				var width = window.innerWidth;
 				var height = window.innerHeight - headerHeight;
-				editorCanvas.width = width * scale;
-				editorCanvas.height = height * scale;
-				editorCanvas.style.width = width + "px";
-				editorCanvas.style.height = height + "px";
+				if (lastScale !== scale || lastWidth !== width || lastHeight !== height) {
+					editorCanvas.width = width * scale;
+					editorCanvas.height = height * scale;
+					editorCanvas.style.width = width + "px";
+					editorCanvas.style.height = height + "px";
+					lastScale = scale;
+					lastWidth = width;
+					lastHeight = height;
+				}
 			}
 			animationCallbacks.push(adjustCanvasDimensions);
 			adjustCanvasDimensions();
@@ -412,24 +420,23 @@
 				});
 			};
 
-			engine.setProgressFunc((current, total) => {
-				if (total > 0) {
-					statusProgressInner.style.width = current/total * 100 + '%';
-					setStatusMode('progress');
-					if (current === total) {
-						// wait for progress bar animation
-						setTimeout(() => {
-							setStatusMode('indeterminate');
-						}, 100);
-					}
-				} else {
-					setStatusMode('indeterminate');
-				}
-			});
+			const gameConfig = {
+				'persistentPaths': persistentPaths,
+				'unloadAfterInit': false,
+				'canvas': gameCanvas,
+				'canvasResizePolicy': 1,
+				'onExit': function () {
+					setGameTabEnabled(false);
+					showTab('editor');
+					game = null;
+				},
+			};
 
-			engine.setPersistentPaths(persistentPaths);
-
-			engine.setOnExecute(function(args) {
+			var OnEditorExit = function () {
+				showTab('loader');
+				setLoaderEnabled(true);
+			};
+			function Execute(args) {
 				const is_editor = args.filter(function(v) { return v == '--editor' || v == '-e' }).length != 0;
 				const is_project_manager = args.filter(function(v) { return v == '--project-manager' }).length != 0;
 				const is_game = !is_editor && !is_project_manager;
@@ -442,42 +449,60 @@
 						return;
 					}
 					setGameTabEnabled(true);
-					game = new Engine();
-					game.setPersistentPaths(persistentPaths);
-					game.setUnloadAfterInit(false);
-					game.setOnExecute(engine.onExecute);
-					game.setCanvas(gameCanvas);
-					game.setCanvasResizedOnStart(true);
-					game.setOnExit(function() {
-						setGameTabEnabled(false);
-						showTab('editor');
-						game = null;
-					});
+					game = new Engine(gameConfig);
 					showTab('game');
 					game.init().then(function() {
 						requestAnimationFrame(function() {
-							game.start.apply(game, args).then(function() {
+							game.start({'args': args}).then(function() {
 								gameCanvas.focus();
 							});
 						});
 					});
 				} else { // New editor instances will be run in the same canvas. We want to wait for it to exit.
-					engine.setOnExit(function(code) {
+					OnEditorExit = function(code) {
 						setLoaderEnabled(true);
 						setTimeout(function() {
-							engine.init().then(function() {
+							editor.init().then(function() {
 								setLoaderEnabled(false);
-								engine.setOnExit(function() {
+								OnEditorExit = function() {
 									showTab('loader');
 									setLoaderEnabled(true);
-								});
-								engine.start.apply(engine, args);
+								};
+								editor.start({'args': args});
 							});
 						}, 0);
-						engine.setOnExit(null);
-					});
+						OnEditorExit = null;
+					};
 				}
-			});
+			}
+
+			const editorConfig = {
+				'unloadAfterInit': false,
+				'onProgress': function progressFunction (current, total) {
+					if (total > 0) {
+						statusProgressInner.style.width = current/total * 100 + '%';
+						setStatusMode('progress');
+						if (current === total) {
+							// wait for progress bar animation
+							setTimeout(() => {
+								setStatusMode('indeterminate');
+							}, 100);
+						}
+					} else {
+						setStatusMode('indeterminate');
+					}
+				},
+				'canvas': editorCanvas,
+				'canvasResizePolicy': 0,
+				'onExit': function() {
+					if (OnEditorExit) {
+						OnEditorExit();
+					}
+				},
+				'onExecute': Execute,
+				'persistentPaths': persistentPaths,
+			};
+			editor = new Engine(editorConfig);
 
 			function displayFailureNotice(err) {
 				var msg = err.message || err;
@@ -491,26 +516,20 @@
 				displayFailureNotice('WebGL not available');
 			} else {
 				setStatusMode('indeterminate');
-				engine.setCanvas(editorCanvas);
-				engine.setUnloadAfterInit(false); // Don't want to reload when starting game.
-				engine.init('godot.tools').then(function() {
+				editor.init('godot.tools').then(function() {
 					if (zip) {
-						engine.copyToFS("/tmp/preload.zip", zip);
+						editor.copyToFS("/tmp/preload.zip", zip);
 					}
 					try {
 						// Avoid user creating project in the persistent root folder.
-						engine.copyToFS("/home/web_user/keep", new Uint8Array());
+						editor.copyToFS("/home/web_user/keep", new Uint8Array());
 					} catch(e) {
 						// File exists
 					}
 					//selectVideoMode();
 					showTab('editor');
 					setLoaderEnabled(false);
-					engine.setOnExit(function() {
-						showTab('loader');
-						setLoaderEnabled(true);
-					});
-					engine.start('--video-driver', video_driver).then(function() {
+					editor.start({'args': ['--video-driver', video_driver]}).then(function() {
 						setStatusMode('hidden');
 						initializing = false;
 					});

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -161,23 +161,6 @@ $GODOT_HEAD_INCLUDE
 			}
 			requestAnimationFrame(animate);
 
-			function adjustCanvasDimensions() {
-				const scale = window.devicePixelRatio || 1;
-				if (lastWidth != window.innerWidth || lastHeight != window.innerHeight || lastScale != scale) {
-					lastScale = scale;
-					lastWidth = window.innerWidth;
-					lastHeight = window.innerHeight;
-					canvas.width = Math.floor(lastWidth * scale);
-					canvas.height = Math.floor(lastHeight * scale);
-					canvas.style.width = lastWidth + "px";
-					canvas.style.height = lastHeight + "px";
-				}
-			}
-			if (GODOT_CONFIG['canvasResizePolicy'] == 2) {
-				animationCallbacks.push(adjustCanvasDimensions);
-				adjustCanvasDimensions();
-			}
-
 			function setStatusMode(mode) {
 
 				if (statusMode === mode || !initializing)

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -134,21 +134,14 @@ $GODOT_HEAD_INCLUDE
 		<div id='status-notice' class='godot' style='display: none;'></div>
 	</div>
 
-	<script type='text/javascript' src='$GODOT_BASENAME.js'></script>
+	<script type='text/javascript' src='$GODOT_URL'></script>
 	<script type='text/javascript'>//<![CDATA[
 
-		var engine = new Engine;
-		var setStatusMode;
-		var setStatusNotice;
+		const GODOT_CONFIG = $GODOT_CONFIG;
+		var engine = new Engine(GODOT_CONFIG);
 
 		(function() {
-			const EXECUTABLE_NAME = '$GODOT_BASENAME';
-			const MAIN_PACK = '$GODOT_BASENAME.pck';
-			const EXTRA_ARGS = JSON.parse('$GODOT_ARGS');
-			const GDNATIVE_LIBS = [$GODOT_GDNATIVE_LIBS];
 			const INDETERMINATE_STATUS_STEP_MS = 100;
-			const FULL_WINDOW = $GODOT_FULL_WINDOW;
-
 			var canvas = document.getElementById('canvas');
 			var statusProgress = document.getElementById('status-progress');
 			var statusProgressInner = document.getElementById('status-progress-inner');
@@ -180,14 +173,13 @@ $GODOT_HEAD_INCLUDE
 					canvas.style.height = lastHeight + "px";
 				}
 			}
-			if (FULL_WINDOW) {
+			if (GODOT_CONFIG['canvasResizePolicy'] == 2) {
 				animationCallbacks.push(adjustCanvasDimensions);
 				adjustCanvasDimensions();
-			} else {
-				engine.setCanvasResizedOnStart(true);
 			}
 
-			setStatusMode = function setStatusMode(mode) {
+			function setStatusMode(mode) {
+
 				if (statusMode === mode || !initializing)
 					return;
 				[statusProgress, statusIndeterminate, statusNotice].forEach(elem => {
@@ -213,7 +205,7 @@ $GODOT_HEAD_INCLUDE
 						throw new Error('Invalid status mode');
 				}
 				statusMode = mode;
-			};
+			}
 
 			function animateStatusIndeterminate(ms) {
 				var i = Math.floor(ms / INDETERMINATE_STATUS_STEP_MS % 8);
@@ -225,7 +217,7 @@ $GODOT_HEAD_INCLUDE
 				}
 			}
 
-			setStatusNotice = function setStatusNotice(text) {
+			function setStatusNotice(text) {
 				while (statusNotice.lastChild) {
 					statusNotice.removeChild(statusNotice.lastChild);
 				}
@@ -235,21 +227,6 @@ $GODOT_HEAD_INCLUDE
 					statusNotice.appendChild(document.createElement('br'));
 				});
 			};
-
-			engine.setProgressFunc((current, total) => {
-				if (total > 0) {
-					statusProgressInner.style.width = current/total * 100 + '%';
-					setStatusMode('progress');
-					if (current === total) {
-						// wait for progress bar animation
-						setTimeout(() => {
-							setStatusMode('indeterminate');
-						}, 500);
-					}
-				} else {
-					setStatusMode('indeterminate');
-				}
-			});
 
 			function displayFailureNotice(err) {
 				var msg = err.message || err;
@@ -263,9 +240,22 @@ $GODOT_HEAD_INCLUDE
 				displayFailureNotice('WebGL not available');
 			} else {
 				setStatusMode('indeterminate');
-				engine.setCanvas(canvas);
-				engine.setGDNativeLibraries(GDNATIVE_LIBS);
-				engine.startGame(EXECUTABLE_NAME, MAIN_PACK, EXTRA_ARGS).then(() => {
+				engine.startGame({
+					'onProgress': function (current, total) {
+						if (total > 0) {
+							statusProgressInner.style.width = current/total * 100 + '%';
+							setStatusMode('progress');
+							if (current === total) {
+								// wait for progress bar animation
+								setTimeout(() => {
+									setStatusMode('indeterminate');
+								}, 500);
+							}
+						} else {
+							setStatusMode('indeterminate');
+						}
+					},
+				}).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/platform/javascript/.eslintrc.engine.js
+++ b/platform/javascript/.eslintrc.engine.js
@@ -3,6 +3,7 @@ module.exports = {
 		"./.eslintrc.js",
 	],
 	"globals": {
+		"EngineConfig": true,
 		"Godot": true,
 		"Preloader": true,
 		"Utils": true,

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -74,6 +74,7 @@ sys_env.Depends(build[0], sys_env["JS_EXTERNS"])
 engine = [
     "js/engine/preloader.js",
     "js/engine/utils.js",
+    "js/engine/config.js",
     "js/engine/engine.js",
 ]
 externs = [env.File("#platform/javascript/js/engine/engine.externs.js")]

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -59,34 +59,13 @@ bool DisplayServerJavaScript::is_canvas_focused() {
 }
 
 bool DisplayServerJavaScript::check_size_force_redraw() {
-	int canvas_width;
-	int canvas_height;
-	emscripten_get_canvas_element_size(DisplayServerJavaScript::canvas_id, &canvas_width, &canvas_height);
-	if (last_width != canvas_width || last_height != canvas_height) {
-		last_width = canvas_width;
-		last_height = canvas_height;
-		// Update the framebuffer size for redraw.
-		emscripten_set_canvas_element_size(DisplayServerJavaScript::canvas_id, canvas_width, canvas_height);
-		return true;
-	}
-	return false;
+	return godot_js_display_size_update() != 0;
 }
 
 Point2 DisplayServerJavaScript::compute_position_in_canvas(int p_x, int p_y) {
-	DisplayServerJavaScript *display = get_singleton();
-	int canvas_x;
-	int canvas_y;
-	godot_js_display_canvas_bounding_rect_position_get(&canvas_x, &canvas_y);
-	int canvas_width;
-	int canvas_height;
-	emscripten_get_canvas_element_size(display->canvas_id, &canvas_width, &canvas_height);
-
-	double element_width;
-	double element_height;
-	emscripten_get_element_css_size(display->canvas_id, &element_width, &element_height);
-
-	return Point2((int)(canvas_width / element_width * (p_x - canvas_x)),
-			(int)(canvas_height / element_height * (p_y - canvas_y)));
+	int point[2];
+	godot_js_display_compute_position(p_x, p_y, point, point + 1);
+	return Point2(point[0], point[1]);
 }
 
 EM_BOOL DisplayServerJavaScript::fullscreen_change_callback(int p_event_type, const EmscriptenFullscreenChangeEvent *p_event, void *p_user_data) {
@@ -704,7 +683,7 @@ DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_drive
 	godot_js_config_canvas_id_get(canvas_id, 256);
 
 	// Handle contextmenu, webglcontextlost
-	godot_js_display_setup_canvas();
+	godot_js_display_setup_canvas(p_resolution.x, p_resolution.y, p_mode == WINDOW_MODE_FULLSCREEN);
 
 	// Check if it's windows.
 	swap_cancel_ok = godot_js_display_is_swap_ok_cancel() == 1;
@@ -747,11 +726,6 @@ DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_drive
 
 	video_driver_index = p_video_driver;
 #endif
-
-	window_set_mode(p_mode);
-	if (godot_js_config_canvas_resize_policy_get() == 1) {
-		window_set_size(p_resolution);
-	}
 
 	EMSCRIPTEN_RESULT result;
 #define EM_CHECK(ev)                         \
@@ -842,17 +816,15 @@ Point2i DisplayServerJavaScript::screen_get_position(int p_screen) const {
 }
 
 Size2i DisplayServerJavaScript::screen_get_size(int p_screen) const {
-	EmscriptenFullscreenChangeEvent ev;
-	EMSCRIPTEN_RESULT result = emscripten_get_fullscreen_status(&ev);
-	ERR_FAIL_COND_V(result != EMSCRIPTEN_RESULT_SUCCESS, Size2i());
-	double scale = godot_js_display_pixel_ratio_get();
-	return Size2i(ev.screenWidth * scale, ev.screenHeight * scale);
+	int size[2];
+	godot_js_display_screen_size_get(size, size + 1);
+	return Size2(size[0], size[1]);
 }
 
 Rect2i DisplayServerJavaScript::screen_get_usable_rect(int p_screen) const {
-	int canvas[2];
-	emscripten_get_canvas_element_size(canvas_id, canvas, canvas + 1);
-	return Rect2i(0, 0, canvas[0], canvas[1]);
+	int size[2];
+	godot_js_display_window_size_get(size, size + 1);
+	return Rect2i(0, 0, size[0], size[1]);
 }
 
 int DisplayServerJavaScript::screen_get_dpi(int p_screen) const {
@@ -942,17 +914,13 @@ Size2i DisplayServerJavaScript::window_get_min_size(WindowID p_window) const {
 }
 
 void DisplayServerJavaScript::window_set_size(const Size2i p_size, WindowID p_window) {
-	last_width = p_size.x;
-	last_height = p_size.y;
-	double scale = godot_js_display_pixel_ratio_get();
-	emscripten_set_canvas_element_size(canvas_id, p_size.x, p_size.y);
-	emscripten_set_element_css_size(canvas_id, p_size.x / scale, p_size.y / scale);
+	godot_js_display_desired_size_set(p_size.x, p_size.y);
 }
 
 Size2i DisplayServerJavaScript::window_get_size(WindowID p_window) const {
-	int canvas[2];
-	emscripten_get_canvas_element_size(canvas_id, canvas, canvas + 1);
-	return Size2(canvas[0], canvas[1]);
+	int size[2];
+	godot_js_display_window_size_get(size, size + 1);
+	return Size2i(size[0], size[1]);
 }
 
 Size2i DisplayServerJavaScript::window_get_real_size(WindowID p_window) const {
@@ -966,20 +934,13 @@ void DisplayServerJavaScript::window_set_mode(WindowMode p_mode, WindowID p_wind
 	switch (p_mode) {
 		case WINDOW_MODE_WINDOWED: {
 			if (window_mode == WINDOW_MODE_FULLSCREEN) {
-				emscripten_exit_fullscreen();
+				godot_js_display_fullscreen_exit();
 			}
 			window_mode = WINDOW_MODE_WINDOWED;
-			window_set_size(Size2i(last_width, last_height));
 		} break;
 		case WINDOW_MODE_FULLSCREEN: {
-			EmscriptenFullscreenStrategy strategy;
-			strategy.scaleMode = EMSCRIPTEN_FULLSCREEN_SCALE_STRETCH;
-			strategy.canvasResolutionScaleMode = EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_STDDEF;
-			strategy.filteringMode = EMSCRIPTEN_FULLSCREEN_FILTERING_DEFAULT;
-			strategy.canvasResizedCallback = nullptr;
-			EMSCRIPTEN_RESULT result = emscripten_request_fullscreen_strategy(canvas_id, false, &strategy);
-			ERR_FAIL_COND_MSG(result == EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED, "Enabling fullscreen is only possible from an input callback for the HTML5 platform.");
-			ERR_FAIL_COND_MSG(result != EMSCRIPTEN_RESULT_SUCCESS, "Enabling fullscreen is only possible from an input callback for the HTML5 platform.");
+			int result = godot_js_display_fullscreen_request();
+			ERR_FAIL_COND_MSG(result, "The request was denied. Remember that enabling fullscreen is only possible from an input callback for the HTML5 platform.");
 		} break;
 		case WINDOW_MODE_MAXIMIZED:
 		case WINDOW_MODE_MINIMIZED:

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -749,7 +749,7 @@ DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_drive
 #endif
 
 	window_set_mode(p_mode);
-	if (godot_js_config_is_resize_on_start()) {
+	if (godot_js_config_canvas_resize_policy_get() == 1) {
 		window_set_size(p_resolution);
 	}
 

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -57,9 +57,6 @@ private:
 	double last_click_ms = 0;
 	int last_click_button_index = -1;
 
-	int last_width = 0;
-	int last_height = 0;
-
 	bool swap_cancel_ok = false;
 
 	// utilities

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -296,7 +296,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 		args.push_back(flags[i]);
 	}
 	Dictionary config;
-	config["canvasResizePolicy"] = p_preset->get("html/full_window_size") ? 2 : 1;
+	config["canvasResizePolicy"] = p_preset->get("html/canvas_resize_policy");
 	config["gdnativeLibs"] = libs;
 	config["executable"] = p_name;
 	config["args"] = args;
@@ -350,7 +350,7 @@ void EditorExportPlatformJavaScript::get_export_options(List<ExportOption> *r_op
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/custom_html_shell", PROPERTY_HINT_FILE, "*.html"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/head_include", PROPERTY_HINT_MULTILINE_TEXT), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/full_window_size"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "html/canvas_resize_policy", PROPERTY_HINT_ENUM, "None,Project,Adaptive"), 2));
 }
 
 String EditorExportPlatformJavaScript::get_name() const {

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -40,7 +40,7 @@ extern "C" {
 // Config
 extern void godot_js_config_locale_get(char *p_ptr, int p_ptr_max);
 extern void godot_js_config_canvas_id_get(char *p_ptr, int p_ptr_max);
-extern int godot_js_config_is_resize_on_start();
+extern int godot_js_config_canvas_resize_policy_get();
 
 // OS
 extern void godot_js_os_finish_async(void (*p_callback)());

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -40,7 +40,6 @@ extern "C" {
 // Config
 extern void godot_js_config_locale_get(char *p_ptr, int p_ptr_max);
 extern void godot_js_config_canvas_id_get(char *p_ptr, int p_ptr_max);
-extern int godot_js_config_canvas_resize_policy_get();
 
 // OS
 extern void godot_js_os_finish_async(void (*p_callback)());
@@ -61,10 +60,15 @@ extern int godot_js_display_is_swap_ok_cancel();
 // Display canvas
 extern void godot_js_display_canvas_focus();
 extern int godot_js_display_canvas_is_focused();
-extern void godot_js_display_canvas_bounding_rect_position_get(int32_t *p_x, int32_t *p_y);
 
 // Display window
-extern void godot_js_display_window_request_fullscreen();
+extern void godot_js_display_desired_size_set(int p_width, int p_height);
+extern int godot_js_display_size_update();
+extern void godot_js_display_window_size_get(int32_t *p_x, int32_t *p_y);
+extern void godot_js_display_screen_size_get(int32_t *p_x, int32_t *p_y);
+extern int godot_js_display_fullscreen_request();
+extern int godot_js_display_fullscreen_exit();
+extern void godot_js_display_compute_position(int p_x, int p_y, int32_t *r_x, int32_t *r_y);
 extern void godot_js_display_window_title_set(const char *p_text);
 extern void godot_js_display_window_icon_set(const uint8_t *p_ptr, int p_len);
 
@@ -88,7 +92,7 @@ extern int godot_js_display_gamepad_sample_get(int p_idx, float r_btns[16], int3
 extern void godot_js_display_notification_cb(void (*p_callback)(int p_notification), int p_enter, int p_exit, int p_in, int p_out);
 extern void godot_js_display_paste_cb(void (*p_callback)(const char *p_text));
 extern void godot_js_display_drop_files_cb(void (*p_callback)(char **p_filev, int p_filec));
-extern void godot_js_display_setup_canvas();
+extern void godot_js_display_setup_canvas(int p_width, int p_height, int p_fullscreen);
 #ifdef __cplusplus
 }
 #endif

--- a/platform/javascript/js/engine/config.js
+++ b/platform/javascript/js/engine/config.js
@@ -1,0 +1,100 @@
+/** @constructor */
+function EngineConfig(opts) {
+	// Module config
+	this.unloadAfterInit = true;
+	this.onPrintError = function () {
+		console.error.apply(console, Array.from(arguments)); // eslint-disable-line no-console
+	};
+	this.onPrint = function () {
+		console.log.apply(console, Array.from(arguments)); // eslint-disable-line no-console
+	};
+	this.onProgress = null;
+
+	// Godot Config
+	this.canvas = null;
+	this.executable = '';
+	this.mainPack = null;
+	this.locale = null;
+	this.canvasResizePolicy = false;
+	this.persistentPaths = ['/userfs'];
+	this.gdnativeLibs = [];
+	this.args = [];
+	this.onExecute = null;
+	this.onExit = null;
+	this.update(opts);
+}
+
+EngineConfig.prototype.update = function (opts) {
+	const config = opts || {};
+	function parse(key, def) {
+		if (typeof (config[key]) === 'undefined') {
+			return def;
+		}
+		return config[key];
+	}
+	// Module config
+	this.unloadAfterInit = parse('unloadAfterInit', this.unloadAfterInit);
+	this.onPrintError = parse('onPrintError', this.onPrintError);
+	this.onPrint = parse('onPrint', this.onPrint);
+	this.onProgress = parse('onProgress', this.onProgress);
+
+	// Godot config
+	this.canvas = parse('canvas', this.canvas);
+	this.executable = parse('executable', this.executable);
+	this.mainPack = parse('mainPack', this.mainPack);
+	this.locale = parse('locale', this.locale);
+	this.canvasResizePolicy = parse('canvasResizePolicy', this.canvasResizePolicy);
+	this.persistentPaths = parse('persistentPaths', this.persistentPaths);
+	this.gdnativeLibs = parse('gdnativeLibs', this.gdnativeLibs);
+	this.args = parse('args', this.args);
+	this.onExecute = parse('onExecute', this.onExecute);
+	this.onExit = parse('onExit', this.onExit);
+};
+
+EngineConfig.prototype.getModuleConfig = function (loadPath, loadPromise) {
+	const me = this;
+	return {
+		'print': this.onPrint,
+		'printErr': this.onPrintError,
+		'locateFile': Utils.createLocateRewrite(loadPath),
+		'instantiateWasm': Utils.createInstantiatePromise(loadPromise),
+		'thisProgram': me.executable,
+		'noExitRuntime': true,
+		'dynamicLibraries': [`${me.executable}.side.wasm`],
+	};
+};
+
+EngineConfig.prototype.getGodotConfig = function (cleanup) {
+	if (!(this.canvas instanceof HTMLCanvasElement)) {
+		this.canvas = Utils.findCanvas();
+		if (!this.canvas) {
+			throw new Error('No canvas found in page');
+		}
+	}
+
+	// Canvas can grab focus on click, or key events won't work.
+	if (this.canvas.tabIndex < 0) {
+		this.canvas.tabIndex = 0;
+	}
+
+	// Browser locale, or custom one if defined.
+	let locale = this.locale;
+	if (!locale) {
+		locale = navigator.languages ? navigator.languages[0] : navigator.language;
+		locale = locale.split('.')[0];
+	}
+	const onExit = this.onExit;
+	// Godot configuration.
+	return {
+		'canvas': this.canvas,
+		'canvasResizePolicy': this.canvasResizePolicy,
+		'locale': locale,
+		'onExecute': this.onExecute,
+		'onExit': function (p_code) {
+			cleanup(); // We always need to call the cleanup callback to free memory.
+			if (typeof (onExit) === 'function') {
+				onExit(p_code);
+			}
+		},
+	};
+};

--- a/platform/javascript/js/engine/engine.js
+++ b/platform/javascript/js/engine/engine.js
@@ -1,20 +1,14 @@
 const Engine = (function () {
 	const preloader = new Preloader();
 
-	let wasmExt = '.wasm';
-	let unloadAfterInit = true;
-	let loadPath = '';
 	let loadPromise = null;
+	let loadPath = '';
 	let initPromise = null;
-	let stderr = null;
-	let stdout = null;
-	let progressFunc = null;
 
 	function load(basePath) {
 		if (loadPromise == null) {
 			loadPath = basePath;
-			loadPromise = preloader.loadPromise(basePath + wasmExt);
-			preloader.setProgressFunc(progressFunc);
+			loadPromise = preloader.loadPromise(`${loadPath}.wasm`);
 			requestAnimationFrame(preloader.animateProgress);
 		}
 		return loadPromise;
@@ -25,16 +19,9 @@ const Engine = (function () {
 	}
 
 	/** @constructor */
-	function Engine() { // eslint-disable-line no-shadow
-		this.canvas = null;
-		this.executableName = '';
+	function Engine(opts) { // eslint-disable-line no-shadow
+		this.config = new EngineConfig(opts);
 		this.rtenv = null;
-		this.customLocale = null;
-		this.resizeCanvasOnStart = false;
-		this.onExecute = null;
-		this.onExit = null;
-		this.persistentPaths = ['/userfs'];
-		this.gdnativeLibs = [];
 	}
 
 	Engine.prototype.init = /** @param {string=} basePath */ function (basePath) {
@@ -48,25 +35,14 @@ const Engine = (function () {
 			}
 			load(basePath);
 		}
-		let config = {};
-		if (typeof stdout === 'function') {
-			config.print = stdout;
-		}
-		if (typeof stderr === 'function') {
-			config.printErr = stderr;
-		}
+		preloader.setProgressFunc(this.config.onProgress);
+		let config = this.config.getModuleConfig(loadPath, loadPromise);
 		const me = this;
 		initPromise = new Promise(function (resolve, reject) {
-			config['locateFile'] = Utils.createLocateRewrite(loadPath);
-			config['instantiateWasm'] = Utils.createInstantiatePromise(loadPromise);
-			// Emscripten configuration.
-			config['thisProgram'] = me.executableName;
-			config['noExitRuntime'] = true;
-			config['dynamicLibraries'] = [`${me.executableName}.side.wasm`].concat(me.gdnativeLibs);
 			Godot(config).then(function (module) {
-				module['initFS'](me.persistentPaths).then(function (fs_err) {
+				module['initFS'](me.config.persistentPaths).then(function (fs_err) {
 					me.rtenv = module;
-					if (unloadAfterInit) {
+					if (me.config.unloadAfterInit) {
 						unload();
 					}
 					resolve();
@@ -83,150 +59,58 @@ const Engine = (function () {
 	};
 
 	/** @type {function(...string):Object} */
-	Engine.prototype.start = function () {
-		// Start from arguments.
-		const args = [];
-		for (let i = 0; i < arguments.length; i++) {
-			args.push(arguments[i]);
-		}
+	Engine.prototype.start = function (override) {
+		this.config.update(override);
 		const me = this;
 		return me.init().then(function () {
 			if (!me.rtenv) {
 				return Promise.reject(new Error('The engine must be initialized before it can be started'));
 			}
 
-			if (!(me.canvas instanceof HTMLCanvasElement)) {
-				me.canvas = Utils.findCanvas();
-				if (!me.canvas) {
-					return Promise.reject(new Error('No canvas found in page'));
-				}
-			}
-
-			// Canvas can grab focus on click, or key events won't work.
-			if (me.canvas.tabIndex < 0) {
-				me.canvas.tabIndex = 0;
-			}
-
-			// Browser locale, or custom one if defined.
-			let locale = me.customLocale;
-			if (!locale) {
-				locale = navigator.languages ? navigator.languages[0] : navigator.language;
-				locale = locale.split('.')[0];
+			let config = {};
+			try {
+				config = me.config.getGodotConfig(function () {
+					me.rtenv = null;
+				});
+			} catch (e) {
+				return Promise.reject(e);
 			}
 			// Godot configuration.
-			me.rtenv['initConfig']({
-				'resizeCanvasOnStart': me.resizeCanvasOnStart,
-				'canvas': me.canvas,
-				'locale': locale,
-				'onExecute': function (p_args) {
-					if (me.onExecute) {
-						me.onExecute(p_args);
-						return 0;
-					}
-					return 1;
-				},
-				'onExit': function (p_code) {
-					me.rtenv['deinitFS']();
-					if (me.onExit) {
-						me.onExit(p_code);
-					}
-					me.rtenv = null;
-				},
-			});
+			me.rtenv['initConfig'](config);
 
-			return new Promise(function (resolve, reject) {
-				preloader.preloadedFiles.forEach(function (file) {
-					me.rtenv['copyToFS'](file.path, file.buffer);
+			// Preload GDNative libraries.
+			const libs = [];
+			me.config.gdnativeLibs.forEach(function (lib) {
+				libs.push(me.rtenv['loadDynamicLibrary'](lib, { 'loadAsync': true }));
+			});
+			return Promise.all(libs).then(function () {
+				return new Promise(function (resolve, reject) {
+					preloader.preloadedFiles.forEach(function (file) {
+						me.rtenv['copyToFS'](file.path, file.buffer);
+					});
+					preloader.preloadedFiles.length = 0; // Clear memory
+					me.rtenv['callMain'](me.config.args);
+					initPromise = null;
+					resolve();
 				});
-				preloader.preloadedFiles.length = 0; // Clear memory
-				me.rtenv['callMain'](args);
-				initPromise = null;
-				resolve();
 			});
 		});
 	};
 
-	Engine.prototype.startGame = function (execName, mainPack, extraArgs) {
+	Engine.prototype.startGame = function (override) {
+		this.config.update(override);
+		// Add main-pack argument.
+		const exe = this.config.executable;
+		const pack = this.config.mainPack || `${exe}.pck`;
+		this.config.args = ['--main-pack', pack].concat(this.config.args);
 		// Start and init with execName as loadPath if not inited.
-		this.executableName = execName;
 		const me = this;
 		return Promise.all([
-			this.init(execName),
-			this.preloadFile(mainPack, mainPack),
+			this.init(exe),
+			this.preloadFile(pack, pack),
 		]).then(function () {
-			let args = ['--main-pack', mainPack];
-			if (extraArgs) {
-				args = args.concat(extraArgs);
-			}
-			return me.start.apply(me, args);
+			return me.start.apply(me);
 		});
-	};
-
-	Engine.prototype.setWebAssemblyFilenameExtension = function (override) {
-		if (String(override).length === 0) {
-			throw new Error('Invalid WebAssembly filename extension override');
-		}
-		wasmExt = String(override);
-	};
-
-	Engine.prototype.setUnloadAfterInit = function (enabled) {
-		unloadAfterInit = enabled;
-	};
-
-	Engine.prototype.setCanvas = function (canvasElem) {
-		this.canvas = canvasElem;
-	};
-
-	Engine.prototype.setCanvasResizedOnStart = function (enabled) {
-		this.resizeCanvasOnStart = enabled;
-	};
-
-	Engine.prototype.setLocale = function (locale) {
-		this.customLocale = locale;
-	};
-
-	Engine.prototype.setExecutableName = function (newName) {
-		this.executableName = newName;
-	};
-
-	Engine.prototype.setProgressFunc = function (func) {
-		progressFunc = func;
-	};
-
-	Engine.prototype.setStdoutFunc = function (func) {
-		const print = function (text) {
-			let msg = text;
-			if (arguments.length > 1) {
-				msg = Array.prototype.slice.call(arguments).join(' ');
-			}
-			func(msg);
-		};
-		if (this.rtenv) {
-			this.rtenv.print = print;
-		}
-		stdout = print;
-	};
-
-	Engine.prototype.setStderrFunc = function (func) {
-		const printErr = function (text) {
-			let msg = text;
-			if (arguments.length > 1) {
-				msg = Array.prototype.slice.call(arguments).join(' ');
-			}
-			func(msg);
-		};
-		if (this.rtenv) {
-			this.rtenv.printErr = printErr;
-		}
-		stderr = printErr;
-	};
-
-	Engine.prototype.setOnExecute = function (onExecute) {
-		this.onExecute = onExecute;
-	};
-
-	Engine.prototype.setOnExit = function (onExit) {
-		this.onExit = onExit;
 	};
 
 	Engine.prototype.copyToFS = function (path, buffer) {
@@ -234,14 +118,6 @@ const Engine = (function () {
 			throw new Error('Engine must be inited before copying files');
 		}
 		this.rtenv['copyToFS'](path, buffer);
-	};
-
-	Engine.prototype.setPersistentPaths = function (persistentPaths) {
-		this.persistentPaths = persistentPaths;
-	};
-
-	Engine.prototype.setGDNativeLibraries = function (gdnativeLibs) {
-		this.gdnativeLibs = gdnativeLibs;
 	};
 
 	Engine.prototype.requestQuit = function () {
@@ -259,20 +135,7 @@ const Engine = (function () {
 	Engine.prototype['preloadFile'] = Engine.prototype.preloadFile;
 	Engine.prototype['start'] = Engine.prototype.start;
 	Engine.prototype['startGame'] = Engine.prototype.startGame;
-	Engine.prototype['setWebAssemblyFilenameExtension'] = Engine.prototype.setWebAssemblyFilenameExtension;
-	Engine.prototype['setUnloadAfterInit'] = Engine.prototype.setUnloadAfterInit;
-	Engine.prototype['setCanvas'] = Engine.prototype.setCanvas;
-	Engine.prototype['setCanvasResizedOnStart'] = Engine.prototype.setCanvasResizedOnStart;
-	Engine.prototype['setLocale'] = Engine.prototype.setLocale;
-	Engine.prototype['setExecutableName'] = Engine.prototype.setExecutableName;
-	Engine.prototype['setProgressFunc'] = Engine.prototype.setProgressFunc;
-	Engine.prototype['setStdoutFunc'] = Engine.prototype.setStdoutFunc;
-	Engine.prototype['setStderrFunc'] = Engine.prototype.setStderrFunc;
-	Engine.prototype['setOnExecute'] = Engine.prototype.setOnExecute;
-	Engine.prototype['setOnExit'] = Engine.prototype.setOnExit;
 	Engine.prototype['copyToFS'] = Engine.prototype.copyToFS;
-	Engine.prototype['setPersistentPaths'] = Engine.prototype.setPersistentPaths;
-	Engine.prototype['setGDNativeLibraries'] = Engine.prototype.setGDNativeLibraries;
 	Engine.prototype['requestQuit'] = Engine.prototype.requestQuit;
 	return Engine;
 }());

--- a/platform/javascript/js/libs/library_godot_os.js
+++ b/platform/javascript/js/libs/library_godot_os.js
@@ -91,11 +91,6 @@ const GodotConfig = {
 	godot_js_config_locale_get: function (p_ptr, p_ptr_max) {
 		GodotRuntime.stringToHeap(GodotConfig.locale, p_ptr, p_ptr_max);
 	},
-
-	godot_js_config_canvas_resize_policy_get__sig: 'i',
-	godot_js_config_canvas_resize_policy_get: function () {
-		return GodotConfig.canvas_resize_policy;
-	},
 };
 
 autoAddDeps(GodotConfig, '$GodotConfig');


### PR DESCRIPTION
In this PR:

- Implementation of godotengine/godot-proposals#2182 (improved).
- Better canvas size handling.

HTML Templates
----

Improving on the proposal, now the minimum JS code is just the collowing:
```javascript
var engine = new Engine($GODOT_RUN_OPTIONS);
engine.startGame();
```

The minimal HTML example is as folowing:
```html
<!DOCTYPE html>
<html>
	<head>
		<meta charset="UTF-8">
	</head>
	<body>
		<canvas id="canvas"></canvas>
		<script src="$GODOT_URL"></script>
		<script>
			var engine = new Engine($GODOT_CONFIG);
			engine.startGame();
		</script>
	</body>
</html>
```

You'll be able to set overrides during `start` and `startGame` phases, e.g.:
```javascript
engine.startGame({
	"onExit": function (code) {
		alert("Game exited...");
	}
});
```

There are 2 additional tags that are recommended but optional:
- `$GODOT_HEAD_INCLUDE` - the custom HTML head include.
- `$GODOT_PROJECT_NAME` - for the project title (if you want to set it as the title in the page for better browser caching).

Canvas Size
-----

The full window option is now renamed to `Canvas Resize Policy` and is a 3-state enum:
- `None`: Godot window settings are ignored.
- `Project`: Godot handles the canvas like a native app (resizing it   when setting the window size).
- `Adaptive`: Canvas size will always adapt to browser window size.

Use `None` if you want to control the canvas size with custom JavaScript code.

Both canvas resizing functions and fullscreen functions has been moved to an internal implementation.

![Export window screenshot](https://user-images.githubusercontent.com/1687918/108427427-749dc400-723d-11eb-8944-13be34f70da9.png)


There is a `3.2` branch that can be tested here: https://github.com/Faless/godot/tree/js/3.x_canvas_size_pr