### PR TITLE
Always call start() on audio stream before mixing

### DIFF
--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -105,7 +105,7 @@ void AudioStreamPlayer::_mix_audio() {
 	}
 
 	if (stream_paused) {
-		if (stream_paused_fade) {
+		if (stream_paused_fade && stream_playback->is_playing()) {
 			_mix_internal(true);
 			stream_paused_fade = false;
 		}

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -50,7 +50,7 @@ private:
 	Ref<AudioStream> stream;
 	Vector<AudioFrame> mix_buffer;
 	Vector<AudioFrame> fadeout_buffer;
-	bool use_fadeout;
+	bool use_fadeout = false;
 
 	SafeNumeric<float> setseek{ -1.0 };
 	SafeFlag active;


### PR DESCRIPTION
Fixes #28110

This is the AudioStreamPlayer counterpart of #46151. This bug seems to only crop up when people pause in a scene's `_ready()` or immediately after playing an AudioStreamPlayer.

The problematic codepath seems to be:

1. `play()` being called and setting active = true (can be done in script or through autoplay+entering the tree)
2. pausing the node, which causes `set_stream_paused(true)` to be called
3. `_mix_audio()` being called which triggers the fadeout code, leading to a `mix()` call on an `AudioStreamPlaybackResampled` (like for an ogg or mp3), which doesn't have a check that `start()` has first been called.

This triggers unintialized memory being copied into the audio buffer. If any of the values in that block of memory are NaN, they get propagated through into whatever audio effect chain the project has. At least for a reverb effect, that NaNs out the entire audio stream coming out of that bus.

This PR also adds a false-initialization to use_fadeout since before it would just be uninitialized garbage.

HUGE thank you to @jjmontesl for the help testing this one, and on your insights in the comments on the bug!

Testing can be done with this project which is specifically configured to repro the bug.

[mix_before_start.zip](https://github.com/godotengine/godot/files/6007706/mix_before_start.zip)

As always with these audio bugs, please watch your volume while reproducing the bug, especially if you wear headphones or have good speakers.