### PR TITLE
Silence AudioPlayer2D if transform NaNs would poison audio system.

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -228,6 +228,12 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 
 					float pan = CLAMP(point_in_screen.x / screen_size.width, 0.0, 1.0);
 
+					// Silence if NaNs would poison the audio system (if the Transform had NaN values).
+					if (!isfinite(pan) || !isfinite(multiplier)) {
+						pan = 0.5f;
+						multiplier = 0.0f;
+					}
+
 					float l = 1.0 - pan;
 					float r = pan;
 


### PR DESCRIPTION
This cheap check prevents using NaN values for panning and volume in AudioStreamPlayer2D, which would result in NaN values being mixed as a result of multiplying samples by those values.

This NaN volume and panning would appear if the Transform has NaN values (this should not happen, but if it does it may poison the audio system through effects).

I thought of adding `ERR_PRINT_ONCE` to inform about this, but I'm not sure if that's appropriate. If so, please feel free to add a message (showing the offending node path might be interesting too but might potentially create a lot of output).

I think this is a safe and useful fix to backport to 3.2, especially now that other audio fixes are being applied.