### PR TITLE
Multiply vertex lit DirectionalLights by albedo in GLES3

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2159,12 +2159,13 @@ FRAGMENT_SHADER_CODE
 
 #endif //#USE_LIGHT_DIRECTIONAL
 
+#ifdef USE_VERTEX_LIGHTING
+	diffuse_light *= albedo;
+#endif
+
 #ifdef USE_FORWARD_LIGHTING
 
-#ifdef USE_VERTEX_LIGHTING
-
-	diffuse_light *= albedo;
-#else
+#ifndef USE_VERTEX_LIGHTING
 
 	for (int i = 0; i < omni_light_count; i++) {
 		light_process_omni(omni_light_indices[i], vertex, eye_vec, normal, binormal, tangent, albedo, transmission, roughness, metallic, specular, rim, rim_tint, clearcoat, clearcoat_gloss, anisotropy, specular_blob_intensity, diffuse_light, specular_light, alpha);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/43760

DirectionalLights are drawn with multiple passes. On subsequent passes ``USE_FORWARD_LIGHTING`` is false. On subsequent DirectionalLight passes diffuse still needs to be multiplied by albedo.