### PR TITLE
Added a mode to AStar/AStar2D for ignore disabled points feature

### DIFF
--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -44,6 +44,8 @@ class AStar : public Reference {
 	GDCLASS(AStar, Reference);
 	friend class AStar2D;
 
+	bool point_disabling_mode = true;
+
 	struct Point {
 		Point() {}
 
@@ -138,6 +140,9 @@ public:
 	void set_point_disabled(int p_id, bool p_disabled = true);
 	bool is_point_disabled(int p_id) const;
 
+	void set_point_disabling_mode(bool p_enabled);
+	bool is_in_point_disabling_mode() const;
+
 	void connect_points(int p_id, int p_with_id, bool bidirectional = true);
 	void disconnect_points(int p_id, int p_with_id, bool bidirectional = true);
 	bool are_points_connected(int p_id, int p_with_id, bool bidirectional = true) const;
@@ -184,6 +189,9 @@ public:
 
 	void set_point_disabled(int p_id, bool p_disabled = true);
 	bool is_point_disabled(int p_id) const;
+
+	void set_point_disabling_mode(bool p_enabled);
+	bool is_in_point_disabling_mode() const;
 
 	void connect_points(int p_id, int p_with_id, bool p_bidirectional = true);
 	void disconnect_points(int p_id, int p_with_id);

--- a/doc/classes/AStar.xml
+++ b/doc/classes/AStar.xml
@@ -386,6 +386,11 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="point_disabling_mode" type="bool" setter="set_point_disabling_mode" getter="is_in_point_disabling_mode" default="true">
+			If [code]true[/code], disabled points are proceeded, as usual, otherwise, they are ignored.
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -355,6 +355,11 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="point_disabling_mode" type="bool" setter="set_point_disabling_mode" getter="is_in_point_disabling_mode" default="true">
+			If [code]true[/code], disabled points are proceeded, as usual, otherwise, they are ignored.
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>


### PR DESCRIPTION
Added a new boolean property called `point_disabling_mode` (which is enabled by default so it's not a breaking change). It's sometimes useful to generate a path regardless of obstacles generated by `set_point_disabled`, without recreating the whole `AStar`. The example is a fog of war in strategy games - you don't know which object is under that fog and assume that there is no obstacle on the path to generating a simple way, but internally they should be marked as disabled points in `AStar`, so when they become visible the same `AStar` can be used with `point_disabled_mode` toggled on to generate a path across the obstacle.
