### PR TITLE
Fix connecting signal to `SceneTreeEditor::update_timer`

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1194,7 +1194,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	blocked = 0;
 
 	update_timer = memnew(Timer);
-	update_timer->connect("timeout", callable_mp(this, &SceneTreeEditor::_update_tree));
+	update_timer->connect("timeout", callable_mp(this, &SceneTreeEditor::_update_tree), varray(false));
 	update_timer->set_one_shot(true);
 	update_timer->set_wait_time(0.5);
 	add_child(update_timer);


### PR DESCRIPTION
Detected and fixed the following editor spam upon switching scenes:

![image](https://user-images.githubusercontent.com/3036176/108500475-df441380-72c0-11eb-9d34-707d18ab5e68.png)

