### PR TITLE
Make FreeType optional for export templates.

### DIFF
--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -38,6 +38,7 @@ def make_icu_data(target, source, env):
 # Thirdparty source files
 
 thirdparty_obj = []
+freetype_enabled = env.module_check_dependencies("text_server_adv", ["freetype"])
 
 if env["builtin_harfbuzz"]:
     env_harfbuzz = env_modules.Clone()
@@ -57,11 +58,9 @@ if env["builtin_harfbuzz"]:
         "src/hb-face.cc",
         "src/hb-fallback-shape.cc",
         "src/hb-font.cc",
-        "src/hb-ft.cc",
         #'src/hb-gdi.cc',
         #'src/hb-glib.cc',
         #'src/hb-gobject-structs.cc',
-        "src/hb-graphite2.cc",
         "src/hb-icu.cc",
         "src/hb-map.cc",
         "src/hb-number.cc",
@@ -109,16 +108,28 @@ if env["builtin_harfbuzz"]:
         "src/hb-unicode.cc",
         #'src/hb-uniscribe.cc'
     ]
+
+    if freetype_enabled:
+        thirdparty_sources += [
+            "src/hb-ft.cc",
+            "src/hb-graphite2.cc",
+        ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_harfbuzz.Append(
         CPPPATH=[
             "#thirdparty/harfbuzz/src",
-            "#thirdparty/freetype/include",
-            "#thirdparty/graphite/include",
             "#thirdparty/icu4c/common/",
         ]
     )
+
+    if freetype_enabled:
+        env_harfbuzz.Append(
+            CPPPATH=[
+                "#thirdparty/freetype/include",
+                "#thirdparty/graphite/include",
+            ]
+        )
 
     if env["platform"] == "android" or env["platform"] == "linuxbsd" or env["platform"] == "server":
         env_harfbuzz.Append(CCFLAGS=["-DHAVE_PTHREAD"])
@@ -133,11 +144,17 @@ if env["builtin_harfbuzz"]:
         CCFLAGS=[
             "-DHAVE_ICU_BUILTIN",
             "-DHAVE_ICU",
-            "-DHAVE_FREETYPE",
-            "-DHAVE_GRAPHITE2",
-            "-DGRAPHITE2_STATIC",
         ]
     )
+
+    if freetype_enabled:
+        env_harfbuzz.Append(
+            CCFLAGS=[
+                "-DHAVE_FREETYPE",
+                "-DHAVE_GRAPHITE2",
+                "-DGRAPHITE2_STATIC",
+            ]
+        )
 
     lib = env_harfbuzz.add_library("harfbuzz_builtin", thirdparty_sources)
     thirdparty_obj += lib
@@ -156,7 +173,7 @@ if env["builtin_harfbuzz"]:
         env.Append(LIBS=[lib])
 
 
-if env["builtin_graphite"]:
+if env["builtin_graphite"] and freetype_enabled:
     env_graphite = env_modules.Clone()
     env_graphite.disable_warnings()
 
@@ -488,11 +505,17 @@ if env_text_server_adv["tools"]:
 env_text_server_adv.Append(
     CPPPATH=[
         "#thirdparty/harfbuzz/src",
-        "#thirdparty/freetype/include",
-        "#thirdparty/graphite/include",
         "#thirdparty/icu4c/common/",
     ]
 )
+
+if freetype_enabled:
+    env_text_server_adv.Append(
+        CPPPATH=[
+            "#thirdparty/freetype/include",
+            "#thirdparty/graphite/include",
+        ]
+    )
 
 env_text_server_adv.add_source_files(module_obj, "*.cpp")
 env.modules_sources += module_obj

--- a/modules/text_server_adv/config.py
+++ b/modules/text_server_adv/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env.module_check_dependencies("text_server_adv", ["freetype"])
+    return True
 
 
 def configure(env):

--- a/modules/text_server_adv/dynamic_font_adv.cpp
+++ b/modules/text_server_adv/dynamic_font_adv.cpp
@@ -30,6 +30,8 @@
 
 #include "dynamic_font_adv.h"
 
+#ifdef MODULE_FREETYPE_ENABLED
+
 #include FT_STROKER_H
 #include FT_ADVANCES_H
 #include FT_MULTIPLE_MASTERS_H
@@ -1001,3 +1003,5 @@ DynamicFontDataAdvanced::~DynamicFontDataAdvanced() {
 		FT_Done_FreeType(library);
 	}
 }
+
+#endif // MODULE_FREETYPE_ENABLED

--- a/modules/text_server_adv/dynamic_font_adv.h
+++ b/modules/text_server_adv/dynamic_font_adv.h
@@ -33,6 +33,10 @@
 
 #include "font_adv.h"
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_FREETYPE_ENABLED
+
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_TRUETYPE_TABLES_H
@@ -184,5 +188,7 @@ public:
 
 	virtual ~DynamicFontDataAdvanced() override;
 };
+
+#endif // MODULE_FREETYPE_ENABLED
 
 #endif // DYNAMIC_FONT_ADV_H

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -529,10 +529,12 @@ RID TextServerAdvanced::create_font_system(const String &p_name, int p_base_size
 RID TextServerAdvanced::create_font_resource(const String &p_filename, int p_base_size) {
 	_THREAD_SAFE_METHOD_
 	FontDataAdvanced *fd = nullptr;
-	if (p_filename.get_extension() == "ttf" || p_filename.get_extension() == "otf" || p_filename.get_extension() == "woff") {
-		fd = memnew(DynamicFontDataAdvanced);
-	} else if (p_filename.get_extension() == "fnt" || p_filename.get_extension() == "font") {
+	if (p_filename.get_extension() == "fnt" || p_filename.get_extension() == "font") {
 		fd = memnew(BitmapFontDataAdvanced);
+#ifdef MODULE_FREETYPE_ENABLED
+	} else if (p_filename.get_extension() == "ttf" || p_filename.get_extension() == "otf" || p_filename.get_extension() == "woff") {
+		fd = memnew(DynamicFontDataAdvanced);
+#endif
 	} else {
 		return RID();
 	}
@@ -549,10 +551,12 @@ RID TextServerAdvanced::create_font_resource(const String &p_filename, int p_bas
 RID TextServerAdvanced::create_font_memory(const uint8_t *p_data, size_t p_size, const String &p_type, int p_base_size) {
 	_THREAD_SAFE_METHOD_
 	FontDataAdvanced *fd = nullptr;
-	if (p_type == "ttf" || p_type == "otf" || p_type == "woff") {
-		fd = memnew(DynamicFontDataAdvanced);
-	} else if (p_type == "fnt" || p_type == "font") {
+	if (p_type == "fnt" || p_type == "font") {
 		fd = memnew(BitmapFontDataAdvanced);
+#ifdef MODULE_FREETYPE_ENABLED
+	} else if (p_type == "ttf" || p_type == "otf" || p_type == "woff") {
+		fd = memnew(DynamicFontDataAdvanced);
+#endif
 	} else {
 		return RID();
 	}

--- a/modules/text_server_fb/config.py
+++ b/modules/text_server_fb/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env.module_check_dependencies("text_server_fb", ["freetype"])
+    return True
 
 
 def configure(env):

--- a/modules/text_server_fb/dynamic_font_fb.cpp
+++ b/modules/text_server_fb/dynamic_font_fb.cpp
@@ -30,6 +30,8 @@
 
 #include "dynamic_font_fb.h"
 
+#ifdef MODULE_FREETYPE_ENABLED
+
 #include FT_STROKER_H
 #include FT_ADVANCES_H
 
@@ -684,3 +686,5 @@ DynamicFontDataFallback::~DynamicFontDataFallback() {
 		FT_Done_FreeType(library);
 	}
 }
+
+#endif // MODULE_FREETYPE_ENABLED

--- a/modules/text_server_fb/dynamic_font_fb.h
+++ b/modules/text_server_fb/dynamic_font_fb.h
@@ -33,6 +33,10 @@
 
 #include "font_fb.h"
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_FREETYPE_ENABLED
+
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
@@ -162,5 +166,7 @@ public:
 
 	virtual ~DynamicFontDataFallback() override;
 };
+
+#endif // MODULE_FREETYPE_ENABLED
 
 #endif // DYNAMIC_FONT_FALLBACK_H

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -107,10 +107,12 @@ RID TextServerFallback::create_font_system(const String &p_name, int p_base_size
 RID TextServerFallback::create_font_resource(const String &p_filename, int p_base_size) {
 	_THREAD_SAFE_METHOD_
 	FontDataFallback *fd = nullptr;
-	if (p_filename.get_extension() == "ttf" || p_filename.get_extension() == "otf" || p_filename.get_extension() == "woff") {
-		fd = memnew(DynamicFontDataFallback);
-	} else if (p_filename.get_extension() == "fnt" || p_filename.get_extension() == "font") {
+	if (p_filename.get_extension() == "fnt" || p_filename.get_extension() == "font") {
 		fd = memnew(BitmapFontDataFallback);
+#ifdef MODULE_FREETYPE_ENABLED
+	} else if (p_filename.get_extension() == "ttf" || p_filename.get_extension() == "otf" || p_filename.get_extension() == "woff") {
+		fd = memnew(DynamicFontDataFallback);
+#endif
 	} else {
 		return RID();
 	}
@@ -127,10 +129,12 @@ RID TextServerFallback::create_font_resource(const String &p_filename, int p_bas
 RID TextServerFallback::create_font_memory(const uint8_t *p_data, size_t p_size, const String &p_type, int p_base_size) {
 	_THREAD_SAFE_METHOD_
 	FontDataFallback *fd = nullptr;
-	if (p_type == "ttf" || p_type == "otf" || p_type == "woff") {
-		fd = memnew(DynamicFontDataFallback);
-	} else if (p_type == "fnt" || p_type == "font") {
+	if (p_type == "fnt" || p_type == "font") {
 		fd = memnew(BitmapFontDataFallback);
+#ifdef MODULE_FREETYPE_ENABLED
+	} else if (p_type == "ttf" || p_type == "otf" || p_type == "woff") {
+		fd = memnew(DynamicFontDataFallback);
+#endif
 	} else {
 		return RID();
 	}


### PR DESCRIPTION
Allow building export templates without FreeType module enabled.

Disables loading of dynamic fonts, Graphite and FreeType related portion of HarfBuzz (export templates without FreeType still support BiDi and limited shaping for bitmap fonts).

Fixes #28650 for export templates.