### PR TITLE
Keep Hue value when Saturation or Value is zero

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -166,10 +166,13 @@ void ColorPicker::_value_changed(double) {
 	}
 
 	if (hsv_mode_enabled) {
-		color.set_hsv(scroll[0]->get_value() / 360.0,
-				scroll[1]->get_value() / 100.0,
-				scroll[2]->get_value() / 100.0,
-				scroll[3]->get_value() / 255.0);
+		h = scroll[0]->get_value() / 360.0;
+		s = scroll[1]->get_value() / 100.0;
+		v = scroll[2]->get_value() / 100.0;
+		color.set_hsv(h, s, v, scroll[3]->get_value() / 255.0);
+
+		last_hsv = color;
+
 	} else {
 		for (int i = 0; i < 4; i++) {
 			color.components[i] = scroll[i]->get_value() / (raw_mode_enabled ? 1.0 : 255.0);


### PR DESCRIPTION
In ColorPicker, when Saturation or Value slider is zero, The UV and W box is reset to red. And the hue slider won't work.

![output](https://user-images.githubusercontent.com/13400398/108536621-3c66b600-730f-11eb-9c19-d82a0900c332.gif)

This happened when color was set from sliders. Then the UV and W boxes need to update after the color changes. The received new HSV values are converted from the new RGB color. If R == G == B (Gray), The original hue value is lost.

This PR updating HSV from slider values directly to avoid to lost the original hue value.

![output2](https://user-images.githubusercontent.com/13400398/108536645-4092d380-730f-11eb-8513-9d2aafbe09a3.gif)

Should help solve some bug in #46110.