### PR TITLE
Focus all windows only on mouse clicks

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -890,15 +890,18 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	}
 
 	if (exclusive_child != nullptr) {
-		Window *focus_target = exclusive_child;
-		focus_target->grab_focus();
-		while (focus_target->exclusive_child != nullptr) {
-			focus_target = focus_target->exclusive_child;
+		Ref<InputEventMouseButton> b = p_ev;
+		if (b.is_valid() && b->is_pressed() && b->get_button_index() == 0) {
+			Window *focus_target = exclusive_child;
 			focus_target->grab_focus();
-		}
+			while (focus_target->exclusive_child != nullptr) {
+				focus_target = focus_target->exclusive_child;
+				focus_target->grab_focus();
+			}
 
-		if (!is_embedding_subwindows()) { //not embedding, no need for event
-			return;
+			if (!is_embedding_subwindows()) { //not embedding, no need for event
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #40227.

Apparently all windows would get instantly focused on any input event, making it impossible to move from the `OptionButton` to its popup without refocusing its parent window and closing it.

I have no idea if that was intended behaviour, if it is, feel free to close this PR.