### PR TITLE
[3.x] Added sample code to the bsearch_custom function

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -142,7 +142,27 @@
 			<argument index="3" name="before" type="bool" default="true">
 			</argument>
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search and a custom comparison method. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array. The custom method receives two arguments (an element from the array and the value searched for) and must return [code]true[/code] if the first argument is less than the second, and return [code]false[/code] otherwise.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search and a custom comparison method declared in the [code]obj[/code]. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array. The custom method receives two arguments (an element from the array and the value searched for) and must return [code]true[/code] if the first argument is less than the second, and return [code]false[/code] otherwise.
+				[codeblock]
+				func cardinal_to_algebraic(a):
+				    match a:
+				        "one":
+				            return 1
+				        "two":
+				            return 2
+				        "three":
+				            return 3
+				        four:
+				            return 4
+				
+				func compare(a,b):
+				    return cardinal_to_algebraic(a) &lt; cardinal_to_algebraic(b)
+				
+				func _ready():
+				    var a = ["one", "two", "three", "four"]
+				    # `compare` is defined in this object, so we use `self` as the `obj` parameter.
+				    print(a.bsearch_custom("three", self, "compare", true)) # Expected value is 2
+				[/codeblock]
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>


### PR DESCRIPTION
bsearch_custom arguments

name - type - description
value - Variant - bisection search value
obj - Any object instance - Location of the 2 argument comparison function
func - String - Name of the function declared in obj
before - boolean - first and second resolver

This function is pr against the 3.x series because pr#45698 changed
the call signature to
bsearch_custom, sarray("value", "func", "before"), varray(true));

https://github.com/godotengine/godot-docs/issues/4564

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
