### PR TITLE
Improve error messages for invalid property access/calls in GDScript

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2186,7 +2186,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 		} else {
 			switch (base.builtin_type) {
 				case Variant::NIL: {
-					push_error(vformat(R"(Invalid get index "%s" on base Nil)", name), p_identifier);
+					push_error(vformat(R"(Value of type Nil does not have the attribute "%s".)", name), p_identifier);
 					return;
 				}
 				case Variant::DICTIONARY: {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -808,7 +808,11 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
 					}
-					err_text = "Invalid get index " + v + " (on base: '" + _get_var_type(src) + "').";
+					if (!src->is_null()) {
+						err_text = "Tried to access attribute " + v + " on a value that is null.";
+					} else {
+						err_text = "Value of type '" + _get_var_type(src) + "' does not have the attribute " + v + ".";
+					}
 					OPCODE_BREAK;
 				}
 				*dst = ret;
@@ -844,7 +848,11 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					} else {
 						v = "of type '" + _get_var_type(key) + "'";
 					}
-					err_text = "Invalid get index " + v + " (on base: '" + _get_var_type(src) + "').";
+					if (!src->is_null()) {
+						err_text = "Tried to access attribute " + v + " on a value that is null.";
+					} else {
+						err_text = "Value of type '" + _get_var_type(src) + "' does not have the attribute " + v + ".";
+					}
 					OPCODE_BREAK;
 				}
 				*dst = ret;
@@ -947,9 +955,17 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					if (src->has_method(*index)) {
-						err_text = "Invalid get index '" + index->operator String() + "' (on base: '" + _get_var_type(src) + "'). Did you mean '." + index->operator String() + "()' or funcref(obj, \"" + index->operator String() + "\") ?";
+						if (!src->is_null()) {
+							err_text = "Tried to access attribute '" + index->operator String() + "' on a value that is null. Did you mean '." + index->operator String() + "()' or funcref(obj, \"" + index->operator String() + "\") ?";
+						} else {
+							err_text = "Value of type '" + _get_var_type(src) + "' does not have the attribute '" + index->operator String() + "'. Did you mean '." + index->operator String() + "()' or funcref(obj, \"" + index->operator String() + "\") ?";
+						}
 					} else {
-						err_text = "Invalid get index '" + index->operator String() + "' (on base: '" + _get_var_type(src) + "').";
+						if (!src->is_null()) {
+							err_text = "Tried to access attribute '" + index->operator String() + "' on a value that is null.";
+						} else {
+							err_text = "Value of type '" + _get_var_type(src) + "' does not have the attribute '" + index->operator String() + "'.";
+						}
 					}
 					OPCODE_BREAK;
 				}


### PR DESCRIPTION
**Marking as draft since I haven't had time to test this yet (especially the `null` check).**

The reversed order of the messages now matches Python.

See #46214.