### PR TITLE
Improve the `get_node()` error message to be more descriptive

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1442,7 +1442,15 @@ Node *Node::get_node_or_null(const NodePath &p_path) const {
 
 Node *Node::get_node(const NodePath &p_path) const {
 	Node *node = get_node_or_null(p_path);
-	ERR_FAIL_COND_V_MSG(!node, nullptr, "Node not found: " + p_path + ".");
+
+	if (p_path.is_absolute()) {
+		ERR_FAIL_COND_V_MSG(!node, nullptr,
+				vformat(R"(Node not found: "%s" (absolute path attempted from "%s").)", p_path, get_path()));
+	} else {
+		ERR_FAIL_COND_V_MSG(!node, nullptr,
+				vformat(R"(Node not found: "%s" (relative to "%s").)", p_path, get_path()));
+	}
+
 	return node;
 }
 


### PR DESCRIPTION
- Mention the origin of the `get_node()` call.
- Mention whether the attempted path is absolute or relative.

See #46214.

**Test project:** [test_get_node_error.zip](https://github.com/godotengine/godot/files/6013854/test_get_node_error.zip) 

## Preview

### Before

```
ERROR: Node not found: SomeChildNodeDoesntExist.
   at: get_node (scene/main/node.cpp:1405)
ERROR: Node not found: ../SomeChildNodeDoesntExist.
   at: get_node (scene/main/node.cpp:1405)
ERROR: Node not found: /root/ThisDoesntExist.
   at: get_node (scene/main/node.cpp:1405)
```

### After

```
ERROR: Node not found: "SomeChildNodeDoesntExist" (relative to "/root/Node2D").
   at: get_node (scene/main/node.cpp:1455)
ERROR: Node not found: "../SomeChildNodeDoesntExist" (relative to "/root/Node2D").
   at: get_node (scene/main/node.cpp:1455)
ERROR: Node not found: "/root/ThisDoesntExist" (absolute path attempted from "/root/Node2D").
   at: get_node (scene/main/node.cpp:1450)
```