### PR TITLE
Use space indentation for all YAML files in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,8 @@ indent_size = 4
 indent_style = space
 indent_size = 4
 
-[.travis.yml]
+# YAML requires indentation with spaces instead of tabs.
+[*.{yml,yaml}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
YAML only accepts spaces for indentation, not tabs.