### PR TITLE
Switch to 4 point 4th order optimal resampling for wavs

### DIFF
--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -100,7 +100,7 @@ private:
 	friend class AudioStreamPlaybackSample;
 
 	enum {
-		DATA_PAD = 16 //padding for interpolation
+		DATA_PAD = sizeof(float) * 6 //padding for interpolation
 	};
 
 	Format format = FORMAT_8_BITS;


### PR DESCRIPTION
This ports over the resampling algorithm from #46086 to wav files.

Unlike the issue with mp3s and oggs, I've been unable to reproduce any resampling artifacts in wav file resampling even when I force resampling to occur by using wavs that use weird sample rates. This is really odd to me because wavs use linear interpolation instead of cubic like mp3s and oggs did (until recently). And I could *very* easily hear a difference for oggs and mp3s. To be perfectly honest, without being able to repro the bug I don't think it makes sense to merge this PR, but I'm sending it out anyway because I said I would and I try to stick to my promises 😄 There's also an argument to be made that we should use the same algorithm everywhere like @Calinou said. Plus a lot of the bugs complaining about resampling artifacts make a point to mention it happens with wavs as well. So maybe doing this is a good idea? Not sure.

Notes on the changes:

I think I adjusted `DATA_PAD` correctly to account for the increased distance I'm looking backwards in the buffer, but I'm not sure of that so I'd appreciate a reviewer taking a critical look at that particular change. Also, perhaps I should be using look-ahead instead of look-behind here?

This should fix #40630 also. I fixed the mono ogg issue in an earlier PR so I think we can call that issue done once the resampling artifacts are taken care of.
