### PR TITLE
Fix out of bounds access into empty image data

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3590,15 +3590,17 @@ void DisplayServerX11::set_icon(const Ref<Image> &p_icon) {
 
 			const uint8_t *r = img->get_data().ptr();
 
-			long *wr = &pd.write[2];
-			uint8_t const *pr = r;
+			if (w > 0 && h > 0) {
+				long *wr = &pd.write[2];
+				uint8_t const *pr = r;
 
-			for (int i = 0; i < w * h; i++) {
-				long v = 0;
-				//    A             R             G            B
-				v |= pr[3] << 24 | pr[0] << 16 | pr[1] << 8 | pr[2];
-				*wr++ = v;
-				pr += 4;
+				for (int i = 0; i < w * h; i++) {
+					long v = 0;
+					//    A             R             G            B
+					v |= pr[3] << 24 | pr[0] << 16 | pr[1] << 8 | pr[2];
+					*wr++ = v;
+					pr += 4;
+				}
 			}
 
 			if (net_wm_icon != None) {


### PR DESCRIPTION
Fixes #46189.

This issue only affects X11.

Cherry-picking this does not seem possible due to restructuring. I have submitted #46249 to apply this fix to the 3.2 branch.