### PR TITLE
[docs] Clarification on theme's get_stylebox

### DIFF
--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -236,7 +236,8 @@
 			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns the icon [StyleBox] at [code]name[/code] if the theme has [code]node_type[/code].
+				Returns the [StyleBox] at [code]name[/code] if the theme has [code]node_type[/code].
+				Valid [code]name[/code]s may be found using [method get_stylebox_list]. Valid [code]node_type[/code]s may be found using [method get_stylebox_type_list].
 			</description>
 		</method>
 		<method name="get_stylebox_list" qualifiers="const">
@@ -246,6 +247,7 @@
 			</argument>
 			<description>
 				Returns all the [StyleBox]s as a [PackedStringArray] filled with each [StyleBox]'s name, for use in [method get_stylebox], if the theme has [code]node_type[/code].
+				Valid [code]node_type[/code]s may be found using [method get_stylebox_type_list].
 			</description>
 		</method>
 		<method name="get_stylebox_type_list" qualifiers="const">


### PR DESCRIPTION
Remove reference to "icon" (must have been a copy-paste error) & clarify where to find out what names & node_types are valid.