### PR TITLE
[3.2] Use -latomic when linking whe using clang on Linux

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -129,6 +129,7 @@ def configure(env):
             env["CC"] = "clang"
             env["CXX"] = "clang++"
         env.extra_suffix = ".llvm" + env.extra_suffix
+        env.Append(LIBS=["atomic"])
 
     if env["use_lld"]:
         if env["use_llvm"]:


### PR DESCRIPTION
According to the LLVM documentation when using GNU's libstdc++ clang
will not automatically link with -latomic. This is necessary since we
merged c++11 atomics support.

This fixes linking using Clang on Linux

*Bugsquad edit:* `3.2` version of #46255.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
