### PR TITLE
Add 'AMD' GPU vendor name to PRIME detector

### DIFF
--- a/platform/linuxbsd/detect_prime_x11.cpp
+++ b/platform/linuxbsd/detect_prime_x11.cpp
@@ -61,6 +61,7 @@ struct vendor {
 
 vendor vendormap[] = {
 	{ "Advanced Micro Devices, Inc.", 30 },
+	{ "AMD", 30 },
 	{ "NVIDIA Corporation", 30 },
 	{ "X.Org", 30 },
 	{ "Intel Open Source Technology Center", 20 },
@@ -128,7 +129,7 @@ void create_context() {
 
 int detect_prime() {
 	pid_t p;
-	int priorities[2];
+	int priorities[2] = {};
 	String vendors[2];
 	String renderers[2];
 


### PR DESCRIPTION
Apparently some recent Mesa version also changed AMD's vendor string. In
addition I found a small uninitialized variable that's corrected now.

Master version of #46242
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
