### PR TITLE
Fix unchecked array access in build_*_planes

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -775,6 +775,8 @@ Vector<Plane> Geometry3D::build_box_planes(const Vector3 &p_extents) {
 }
 
 Vector<Plane> Geometry3D::build_cylinder_planes(real_t p_radius, real_t p_height, int p_sides, Vector3::Axis p_axis) {
+	ERR_FAIL_INDEX_V(p_axis, 3, Vector<Plane>());
+
 	Vector<Plane> planes;
 
 	const double sides_step = Math_TAU / p_sides;
@@ -796,6 +798,8 @@ Vector<Plane> Geometry3D::build_cylinder_planes(real_t p_radius, real_t p_height
 }
 
 Vector<Plane> Geometry3D::build_sphere_planes(real_t p_radius, int p_lats, int p_lons, Vector3::Axis p_axis) {
+	ERR_FAIL_INDEX_V(p_axis, 3, Vector<Plane>());
+
 	Vector<Plane> planes;
 
 	Vector3 axis;
@@ -827,6 +831,8 @@ Vector<Plane> Geometry3D::build_sphere_planes(real_t p_radius, int p_lats, int p
 }
 
 Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height, int p_sides, int p_lats, Vector3::Axis p_axis) {
+	ERR_FAIL_INDEX_V(p_axis, 3, Vector<Plane>());
+
 	Vector<Plane> planes;
 
 	Vector3 axis;


### PR DESCRIPTION
Fixes #46225.

Also fixes the same problem in `build_sphere_planes` and `build_cylinder_planes`.