### PR TITLE
Rationalize property reversion

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -42,6 +42,8 @@ public:
 	static bool may_node_be_in_instance(Node *p_node);
 	static bool get_instantiated_node_original_property(Node *p_node, const StringName &p_prop, Variant &value);
 	static bool is_node_property_different(Node *p_node, const Variant &p_current, const Variant &p_orig);
+	static bool is_property_value_different(const Variant &p_a, const Variant &p_b);
+	static Variant get_property_revert_value(Object *p_object, const StringName &p_property);
 
 	static bool can_property_revert(Object *p_object, const StringName &p_property);
 };


### PR DESCRIPTION
This PR changes the algorithm used to determine if a reset (circle arrow) icon must be shown on a property in the editor, which means the current value is different from the default one (the one in the scene it instances or inherits from, the default as declared in the script or the default according to the builtin class).

This PR aims to fix some defects in the current algorithm. For instance, the complaint that in a derived scene the value considered the default for a property is the default in the parent script, instead of the one in the parent, which may already be overriding the default in the script, so that is the new default that matters. (See this complaint: https://github.com/godotengine/godot-proposals/issues/2280#issuecomment-778832767)

**UPDATE:** After an additional push, it also ensures the value a property gets reverted to is the same that was considered to check for "revertability".
**UPDATE:** Some additional little issues have been taken care of.

Fixes #50781.

**UPDATE:** Separate version needed for 3.x: #51166