### PR TITLE
Prevent selecting hidden nodes in 3D and Canvas Item editors

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -629,9 +629,9 @@ void CanvasItemEditor::_get_canvas_items_at_pos(const Point2 &p_pos, Vector<_Sel
 		Node *node = r_items[i].item;
 
 		// Make sure the selected node is in the current scene, or editable
-		while (node && node != get_tree()->get_edited_scene_root() && node->get_owner() != scene && !scene->is_editable_instance(node->get_owner())) {
-			node = node->get_parent();
-		};
+		if (node && node != get_tree()->get_edited_scene_root()) {
+			node = scene->get_deepest_editable_node(node);
+		}
 
 		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(node);
 		if (!p_allow_locked) {
@@ -762,7 +762,7 @@ void CanvasItemEditor::_find_canvas_items_in_rect(const Rect2 &p_rect, Node *p_n
 	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
 	Node *scene = editor->get_edited_scene();
 
-	bool editable = p_node == scene || p_node->get_owner() == scene || scene->is_editable_instance(p_node->get_owner());
+	bool editable = p_node == scene || p_node->get_owner() == scene || p_node == scene->get_deepest_editable_node(p_node);
 	bool lock_children = p_node->has_meta("_edit_group_") && p_node->get_meta("_edit_group_");
 	bool locked = _is_node_locked(p_node);
 
@@ -3867,7 +3867,7 @@ bool CanvasItemEditor::_build_bones_list(Node *p_node) {
 
 	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
 	Node *scene = editor->get_edited_scene();
-	if (!canvas_item || !canvas_item->is_visible() || (canvas_item != scene && canvas_item->get_owner() != scene && !scene->is_editable_instance(canvas_item->get_owner()))) {
+	if (!canvas_item || !canvas_item->is_visible() || (canvas_item != scene && canvas_item->get_owner() != scene && canvas_item != scene->get_deepest_editable_node(canvas_item))) {
 		return false;
 	}
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -534,10 +534,7 @@ ObjectID Node3DEditorViewport::_select_ray(const Point2 &p_pos, bool p_append, b
 		}
 
 		if (dist < closest_dist) {
-			item = Object::cast_to<Node>(spat);
-			while (item->get_owner() && item->get_owner() != edited_scene && !edited_scene->is_editable_instance(item->get_owner())) {
-				item = item->get_owner();
-			}
+			item = edited_scene->get_deepest_editable_node(Object::cast_to<Node>(spat));
 
 			closest = item->get_instance_id();
 			closest_dist = dist;
@@ -696,10 +693,7 @@ void Node3DEditorViewport::_select_region() {
 			continue;
 		}
 
-		Node *item = Object::cast_to<Node>(sp);
-		while (item->get_owner() && item->get_owner() != edited_scene && !edited_scene->is_editable_instance(item->get_owner())) {
-			item = item->get_owner();
-		}
+		Node *item = edited_scene->get_deepest_editable_node(Object::cast_to<Node>(sp));
 
 		// Replace the node by the group if grouped
 		if (item->is_class("Node3D")) {
@@ -1027,7 +1021,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 
 	for (int i = 0; i < selection_results.size(); i++) {
 		Node3D *item = selection_results[i].item;
-		if (item != scene && item->get_owner() != scene && !scene->is_editable_instance(item->get_owner())) {
+		if (item != scene && item->get_owner() != scene && item != scene->get_deepest_editable_node(item)) {
 			//invalid result
 			selection_results.remove(i);
 			i--;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1966,6 +1966,23 @@ bool Node::is_editable_instance(const Node *p_node) const {
 	return p_node->data.editable_instance;
 }
 
+Node *Node::get_deepest_editable_node(Node *p_start_node) const {
+	ERR_FAIL_NULL_V(p_start_node, nullptr);
+	ERR_FAIL_COND_V(!is_a_parent_of(p_start_node), nullptr);
+
+	Node const *iterated_item = p_start_node;
+	Node *node = p_start_node;
+
+	while (iterated_item->get_owner() && iterated_item->get_owner() != this) {
+		if (!is_editable_instance(iterated_item->get_owner()))
+			node = iterated_item->get_owner();
+
+		iterated_item = iterated_item->get_owner();
+	}
+
+	return node;
+}
+
 void Node::set_scene_instance_state(const Ref<SceneState> &p_state) {
 	data.instance_state = p_state;
 }

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -330,6 +330,7 @@ public:
 
 	void set_editable_instance(Node *p_node, bool p_editable);
 	bool is_editable_instance(const Node *p_node) const;
+	Node *get_deepest_editable_node(Node *p_start_node) const;
 
 	/* NOTIFICATIONS */
 


### PR DESCRIPTION
This is a version of https://github.com/godotengine/godot/pull/46141 + https://github.com/godotengine/godot/pull/46261 for the master branch.

Project for testing:
https://github.com/hilfazer/Projects/tree/EngineIssues/Godot/EngineIssues/SelectingHiddenNodesIn3DandCanvasEditors_godot40

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
