### PR TITLE
Improve Completion Panel Position in Shader Editor

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1566,7 +1566,7 @@ void TextEdit::_notification(int p_what) {
 					completion_rect.position.x = rect_left_border_x;
 				}
 
-				if (cursor_pos.y + row_height + total_height > get_size().height) {
+				if (cursor_pos.y + row_height + total_height > get_size().height && cursor_pos.y > total_height) {
 					// Completion panel above the cursor line
 					completion_rect.position.y = cursor_pos.y - total_height;
 				} else {


### PR DESCRIPTION
Fixes #46207.

Result:
![completion](https://user-images.githubusercontent.com/28705694/108622822-553dab80-7476-11eb-9400-cb68461f4fcf.gif)