### PR TITLE
Line2D::set_point_position Fail if passed index is out of bounds

### DIFF
--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -116,6 +116,7 @@ Vector<Vector2> Line2D::get_points() const {
 }
 
 void Line2D::set_point_position(int i, Vector2 p_pos) {
+	ERR_FAIL_INDEX(i, _points.size());
 	_points.set(i, p_pos);
 	update();
 }


### PR DESCRIPTION
Fixes #46276 (cherry-pickable for 3.2).