### PR TITLE
Label::set_lines_skipped Fail if passed a negative value

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -566,6 +566,7 @@ float Label::get_percent_visible() const {
 }
 
 void Label::set_lines_skipped(int p_lines) {
+	ERR_FAIL_COND(p_lines < 0);
 	lines_skipped = p_lines;
 	_update_visible();
 	update();


### PR DESCRIPTION
Fixes #46283 (cherry-pickable for 3.2).

Or should it maybe ensure the value is not negative and proceed instead of failing?
```
if (p_lines < 0) {
	p_lines = 0;
}
...
```
vs
```
ERR_FAIL_COND(p_lines < 0);
```