### PR TITLE
Draw an outline for 2D debug collision shapes

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2032,7 +2032,7 @@ SceneTree::SceneTree() {
 	debug_collisions_hint = false;
 	debug_navigation_hint = false;
 #endif
-	debug_collisions_color = GLOBAL_DEF("debug/shapes/collision/shape_color", Color(0.0, 0.6, 0.7, 0.5));
+	debug_collisions_color = GLOBAL_DEF("debug/shapes/collision/shape_color", Color(0.0, 0.6, 0.7, 0.42));
 	debug_collision_contact_color = GLOBAL_DEF("debug/shapes/collision/contact_color", Color(1.0, 0.2, 0.1, 0.8));
 	debug_navigation_color = GLOBAL_DEF("debug/shapes/navigation/geometry_color", Color(0.1, 1.0, 0.7, 0.4));
 	debug_navigation_disabled_color = GLOBAL_DEF("debug/shapes/navigation/disabled_geometry_color", Color(1.0, 0.7, 0.1, 0.4));

--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -89,6 +89,9 @@ void CapsuleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	VisualServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
+	VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col, 1.0, true);
+	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+	VisualServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0, true);
 }
 
 Rect2 CapsuleShape2D::get_rect() const {

--- a/scene/resources/circle_shape_2d.cpp
+++ b/scene/resources/circle_shape_2d.cpp
@@ -81,6 +81,9 @@ void CircleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	VisualServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
+	VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col, 1.0, true);
+	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+	VisualServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0, true);
 }
 
 CircleShape2D::CircleShape2D() :

--- a/scene/resources/convex_polygon_shape_2d.cpp
+++ b/scene/resources/convex_polygon_shape_2d.cpp
@@ -82,6 +82,9 @@ void ConvexPolygonShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	VisualServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
+	VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col, 1.0, true);
+	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+	VisualServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0, true);
 }
 
 Rect2 ConvexPolygonShape2D::get_rect() const {

--- a/scene/resources/rectangle_shape_2d.cpp
+++ b/scene/resources/rectangle_shape_2d.cpp
@@ -51,7 +51,23 @@ Vector2 RectangleShape2D::get_extents() const {
 
 void RectangleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 
+	// Draw an outlined rectangle to make individual shapes easier to distinguish.
+	Vector<Vector2> stroke_points;
+	stroke_points.resize(5);
+	stroke_points.write[0] = -extents;
+	stroke_points.write[1] = Vector2(extents.x, -extents.y);
+	stroke_points.write[2] = extents;
+	stroke_points.write[3] = Vector2(-extents.x, extents.y);
+	stroke_points.write[4] = -extents;
+
+	Vector<Color> stroke_colors;
+	stroke_colors.resize(5);
+	for (int i = 0; i < 5; i++) {
+		stroke_colors.write[i] = p_color;
+	}
+
 	VisualServer::get_singleton()->canvas_item_add_rect(p_to_rid, Rect2(-extents, extents * 2.0), p_color);
+	VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, stroke_points, stroke_colors, 1.0, true);
 }
 
 Rect2 RectangleShape2D::get_rect() const {


### PR DESCRIPTION
`3.2` version of https://github.com/godotengine/godot/pull/34923.

This makes 2D collision shapes easier to distinguish, especially when used in a TileMap.

The default color's opacity has been slightly decreased to account for the new outline.

## Preview

Tested on the `3.2` branch today:

![image](https://user-images.githubusercontent.com/180032/108632240-258aa580-746e-11eb-80c9-7dcf694c79b7.png)