### PR TITLE
[3.x] Support for duplication of nested instanced scenes

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -658,7 +658,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			editor_data->get_undo_redo().add_do_method(editor_selection, "clear");
 
 			Node *dupsingle = NULL;
-			List<Node *> editable_children;
 
 			selection.sort_custom<Node::Comparator>();
 
@@ -674,9 +673,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				Map<const Node *, Node *> duplimap;
 				Node *dup = node->duplicate_from_editor(duplimap);
-
-				if (EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node))
-					editable_children.push_back(dup);
 
 				ERR_CONTINUE(!dup);
 
@@ -711,10 +707,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			if (dupsingle)
 				editor->push_item(dupsingle);
-
-			for (List<Node *>::Element *E = editable_children.back(); E; E = E->prev())
-				_toggle_editable_children(E->get());
-
 		} break;
 		case TOOL_REPARENT: {
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1994,6 +1994,7 @@ Node *Node::_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap) const
 
 	if (get_filename() != "") { //an instance
 		node->set_filename(get_filename());
+		node->data.editable_instance = data.editable_instance;
 	}
 
 	StringName script_property_name = CoreStringNames::get_singleton()->_script;
@@ -2006,19 +2007,26 @@ Node *Node::_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap) const
 		// Since nodes in the instanced hierarchy won't be duplicated explicitly, we need to make an inventory
 		// of all the nodes in the tree of the instanced scene in order to transfer the values of the properties
 
+		Vector<const Node *> instance_roots;
+		instance_roots.push_back(this);
+
 		for (List<const Node *>::Element *N = node_tree.front(); N; N = N->next()) {
 			for (int i = 0; i < N->get()->get_child_count(); ++i) {
 
 				Node *descendant = N->get()->get_child(i);
 				// Skip nodes not really belonging to the instanced hierarchy; they'll be processed normally later
 				// but remember non-instanced nodes that are hidden below instanced ones
-				if (descendant->data.owner != this) {
-					if (descendant->get_parent() && descendant->get_parent() != this && descendant->get_parent()->data.owner == this && descendant->data.owner != descendant->get_parent())
+				if (instance_roots.find(descendant->get_owner()) == -1) {
+					if (descendant->get_parent() && descendant->get_parent() != this && descendant->data.owner != descendant->get_parent())
 						hidden_roots.push_back(descendant);
 					continue;
 				}
 
 				node_tree.push_back(descendant);
+
+				if (descendant->get_filename() != "" && instance_roots.find(descendant->get_owner()) != -1) {
+					instance_roots.push_back(descendant);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
So far Godot couldn't handle duplicating scenes with instances that were themselves instancing other scenes. This PR makes it possible.

A project for testing:
([download link](https://downgit.github.io/#/home?url=https://github.com/hilfazer/Projects/tree/master/Godot/EngineIssues/NestedSceneInstancesDuplication_godot32))
https://github.com/hilfazer/Projects/tree/master/Godot/EngineIssues/NestedSceneInstancesDuplication_godot32

And a little demonstration screenshot:
![DuplicatedNestedInstancedScenes](https://user-images.githubusercontent.com/29497869/108633005-27566800-7472-11eb-8d82-e5cb8413be58.png)

*Bugsquad edit:* Fixes #47790.