### PR TITLE
Add missing semicolons to webxr.eterns.js

### DIFF
--- a/modules/webxr/native/webxr.externs.js
+++ b/modules/webxr/native/webxr.externs.js
@@ -33,7 +33,7 @@ XR.prototype.ondevicechanged;
  *
  * @return {!Promise<boolean>}
  */
-XR.prototype.isSessionSupported = function(mode) {}
+XR.prototype.isSessionSupported = function(mode) {};
 
 /**
  * @param {string} mode
@@ -41,7 +41,7 @@ XR.prototype.isSessionSupported = function(mode) {}
  *
  * @return {!Promise<XRSession>}
  */
-XR.prototype.requestSession = function(mode, options) {}
+XR.prototype.requestSession = function(mode, options) {};
 
 /**
  * @constructor


### PR DESCRIPTION
As identified by [LGTM](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=javascript&ruleFocus=4860080), #44154 missed some semicolons. This PR explicitly adds the implicitly added semicolons.
