### PR TITLE
Improve PCF13 shadow rendering in GLES2 by using a soft PCF filter

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1261,6 +1261,7 @@
 		</member>
 		<member name="rendering/quality/shadows/filter_mode" type="int" setter="" getter="" default="1">
 			Shadow filter mode. Higher-quality settings result in smoother shadows that flicker less when moving. "Disabled" is the fastest option, but also has the lowest quality. "PCF5" is smoother but is also slower. "PCF13" is the smoothest option, but is also the slowest.
+			[b]Note:[/b] When using the GLES2 backend, the "PCF13" option actually uses 16 samples to emulate linear filtering in the shader. This results in a shadow appearance similar to the one produced by the GLES3 backend.
 		</member>
 		<member name="rendering/quality/shadows/filter_mode.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/quality/shadows/filter_mode] on mobile devices, due to performance concerns or driver support.


### PR DESCRIPTION
This suppresses the blocky shadow appearance, bringing the shadow rendering much closer to GLES3. This soft filter is more demanding as it requires more lookups, but it makes PCF13 shadows more usable.

## Preview

### Before (PCF13)

![2021-02-21_23 16 07](https://user-images.githubusercontent.com/180032/108640593-e9ba0500-749a-11eb-8e61-5e02a4c0c044.png)

### After ("PCF16 Soft" as PCF13)

![2021-02-21_22 52 09](https://user-images.githubusercontent.com/180032/108640000-9c886400-7497-11eb-9816-d4c571bc8824.png)

### In motion

*The directional shadow size was set to 2048 (instead of the default 4096) to make the smoothness more visible.*

https://user-images.githubusercontent.com/180032/108640222-be361b00-7498-11eb-9928-86ba20b32e01.mp4