### PR TITLE
Make glue generation shutdown more graceful

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2561,8 +2561,10 @@ void Main::force_redraw() {
  * so that the engine closes cleanly without leaking memory or crashing.
  * The order matters as some of those steps are linked with each other.
  */
-void Main::cleanup() {
-	ERR_FAIL_COND(!_start_success);
+void Main::cleanup(bool p_force) {
+	if (!p_force) {
+		ERR_FAIL_COND(!_start_success);
+	}
 
 	EngineDebugger::deinitialize();
 

--- a/main/main.h
+++ b/main/main.h
@@ -59,7 +59,7 @@ public:
 
 	static bool is_iterating();
 
-	static void cleanup();
+	static void cleanup(bool p_force = false);
 };
 
 // Test main override is for the testing behaviour.

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -39,6 +39,7 @@
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 #include "core/string/ucaps.h"
+#include "main/main.h"
 
 #include "../glue/cs_glue_version.gen.h"
 #include "../godotsharp_defs.h"
@@ -3649,6 +3650,7 @@ void BindingsGenerator::handle_cmdline_args(const List<String> &p_cmdline_args) 
 
 		if (!bindings_generator.initialized) {
 			ERR_PRINT("Failed to initialize the bindings generator");
+			Main::cleanup(true);
 			::exit(0);
 		}
 
@@ -3675,6 +3677,7 @@ void BindingsGenerator::handle_cmdline_args(const List<String> &p_cmdline_args) 
 		}
 
 		// Exit once done
+		Main::cleanup(true);
 		::exit(0);
 	}
 }


### PR DESCRIPTION
After the rewrite of the multi-threading classes, shutting forcefully down the engine it's a worse idea because there's a higher risk of running into issues due to the undetermined order of destruction of globals/statics.

Once case of that was what happens to abort the rest of the startup and close the engine after the Mono glue has been generated.

This PR tries to give a more graceful way to do that. However, there's the possibility that where we were failing to do enough cleanup, now we are doing too much. That's why some testing on different platforms is needed.

Fixes #46238.