### PR TITLE
CI: Build without debug symbols to reduce cache size

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=android verbose=yes warnings=extra werror=yes --jobs=2 module_text_server_fb_enabled=yes
+  SCONSFLAGS: platform=android verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
   ANDROID_NDK_VERSION: 21.1.6352462
 

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=iphone verbose=yes warnings=extra werror=yes --jobs=2 module_text_server_fb_enabled=yes
+  SCONSFLAGS: platform=iphone verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
 
 jobs:

--- a/.github/workflows/javascript_builds.disabled
+++ b/.github/workflows/javascript_builds.disabled
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=javascript verbose=yes warnings=extra werror=yes --jobs=2
+  SCONSFLAGS: platform=javascript verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2
   SCONS_CACHE_LIMIT: 4096
   EM_VERSION: 1.39.20
   EM_CACHE_FOLDER: 'emsdk-cache'

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=linuxbsd verbose=yes warnings=extra werror=yes --jobs=2 module_text_server_fb_enabled=yes
+  SCONSFLAGS: platform=linuxbsd verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -191,7 +191,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons target=release tools=no module_mono_enabled=yes mono_glue=no debug_symbols=no
+          scons target=release tools=no module_mono_enabled=yes mono_glue=no
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=osx verbose=yes warnings=extra werror=yes --jobs=2 module_text_server_fb_enabled=yes
+  SCONSFLAGS: platform=osx verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -104,7 +104,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons target=release tools=no debug_symbols=no
+          scons target=release tools=no
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 # SCONS_CACHE for windows must be set in the build environment
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=windows verbose=yes warnings=all werror=yes --jobs=2 module_text_server_fb_enabled=yes
+  SCONSFLAGS: platform=windows verbose=yes warnings=all werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_MSVC_CONFIG: true
   SCONS_CACHE_LIMIT: 3072
 
@@ -110,7 +110,7 @@ jobs:
       env:
         SCONS_CACHE: /.scons_cache/
       run: |
-        scons target=release tools=no debug_symbols=no
+        scons target=release tools=no
         ls -l bin/
 
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
We often hit "Too Many Requests" errors when uploading the cache with
`actions/cache` because there's a limit of 10 GB every 5 minutes, and we can
easily go over it when we amend or merge several PRs in a short timespan.

This will make the CI artifacts less useful for debugging crashes but there's
no real way around this.