### PR TITLE
Add preview Sun and Environment

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -37,7 +37,10 @@
 #include "scene/3d/immediate_geometry_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/visual_instance_3d.h"
+#include "scene/3d/world_environment.h"
 #include "scene/gui/panel_container.h"
+#include "scene/resources/environment.h"
+#include "scene/resources/sky_material.h"
 
 class Camera3D;
 class Node3DEditor;
@@ -732,6 +735,7 @@ private:
 
 	static Node3DEditor *singleton;
 
+	void _node_added(Node *p_node);
 	void _node_removed(Node *p_node);
 	Vector<Ref<EditorNode3DGizmoPlugin>> gizmo_plugins_by_priority;
 	Vector<Ref<EditorNode3DGizmoPlugin>> gizmo_plugins_by_name;
@@ -743,6 +747,61 @@ private:
 	bool is_any_freelook_active() const;
 
 	void _refresh_menu_icons();
+
+	// Preview Sun and Environment
+
+	uint32_t world_env_count = 0;
+	uint32_t directional_light_count = 0;
+
+	Button *sun_button;
+	Label *sun_state;
+	Label *sun_title;
+	VBoxContainer *sun_vb;
+	Popup *sun_environ_popup;
+	Control *sun_direction;
+	ColorPickerButton *sun_color;
+	EditorSpinSlider *sun_energy;
+	EditorSpinSlider *sun_max_distance;
+	Button *sun_add_to_scene;
+
+	void _sun_direction_draw();
+	void _sun_direction_input(const Ref<InputEvent> &p_event);
+
+	Basis sun_rotation;
+
+	Ref<Shader> sun_direction_shader;
+	Ref<ShaderMaterial> sun_direction_material;
+
+	Button *environ_button;
+	Label *environ_state;
+	Label *environ_title;
+	VBoxContainer *environ_vb;
+	ColorPickerButton *environ_sky_color;
+	ColorPickerButton *environ_ground_color;
+	EditorSpinSlider *environ_energy;
+	Button *environ_ao_button;
+	Button *environ_glow_button;
+	Button *environ_tonemap_button;
+	Button *environ_gi_button;
+	Button *environ_add_to_scene;
+
+	Button *sun_environ_settings;
+
+	DirectionalLight3D *preview_sun;
+	WorldEnvironment *preview_environment;
+	Ref<Environment> environment;
+	Ref<ProceduralSkyMaterial> sky_material;
+
+	bool sun_environ_updating = false;
+
+	void _load_default_preview_settings();
+	void _update_preview_environment();
+
+	void _preview_settings_changed();
+	void _sun_environ_settings_pressed();
+
+	void _add_sun_to_scene();
+	void _add_environment_to_scene();
 
 protected:
 	void _notification(int p_what);

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -35,51 +35,69 @@
 void WorldEnvironment::_notification(int p_what) {
 	if (p_what == Node3D::NOTIFICATION_ENTER_WORLD || p_what == Node3D::NOTIFICATION_ENTER_TREE) {
 		if (environment.is_valid()) {
-			if (get_viewport()->find_world_3d()->get_environment().is_valid()) {
-				WARN_PRINT("World already has an environment (Another WorldEnvironment?), overriding.");
-			}
-			get_viewport()->find_world_3d()->set_environment(environment);
 			add_to_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+			_update_current_environment();
 		}
 
 		if (camera_effects.is_valid()) {
-			if (get_viewport()->find_world_3d()->get_camera_effects().is_valid()) {
-				WARN_PRINT("World already has a camera effects (Another WorldEnvironment?), overriding.");
-			}
-			get_viewport()->find_world_3d()->set_camera_effects(camera_effects);
 			add_to_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+			_update_current_camera_effects();
 		}
 
 	} else if (p_what == Node3D::NOTIFICATION_EXIT_WORLD || p_what == Node3D::NOTIFICATION_EXIT_TREE) {
-		if (environment.is_valid() && get_viewport()->find_world_3d()->get_environment() == environment) {
-			get_viewport()->find_world_3d()->set_environment(Ref<Environment>());
+		if (environment.is_valid()) {
 			remove_from_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+			_update_current_environment();
 		}
 
-		if (camera_effects.is_valid() && get_viewport()->find_world_3d()->get_camera_effects() == camera_effects) {
-			get_viewport()->find_world_3d()->set_camera_effects(Ref<CameraEffects>());
+		if (camera_effects.is_valid()) {
 			remove_from_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+			_update_current_camera_effects();
 		}
 	}
 }
 
-void WorldEnvironment::set_environment(const Ref<Environment> &p_environment) {
-	if (is_inside_tree() && environment.is_valid() && get_viewport()->find_world_3d()->get_environment() == environment) {
+void WorldEnvironment::_update_current_environment() {
+	WorldEnvironment *first = Object::cast_to<WorldEnvironment>(get_tree()->get_first_node_in_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id())));
+
+	if (first) {
+		get_viewport()->find_world_3d()->set_environment(first->environment);
+	} else {
 		get_viewport()->find_world_3d()->set_environment(Ref<Environment>());
+	}
+	get_tree()->call_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()), "update_configuration_warning");
+}
+
+void WorldEnvironment::_update_current_camera_effects() {
+	WorldEnvironment *first = Object::cast_to<WorldEnvironment>(get_tree()->get_first_node_in_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id())));
+	if (first) {
+		get_viewport()->find_world_3d()->set_camera_effects(first->camera_effects);
+	} else {
+		get_viewport()->find_world_3d()->set_camera_effects(Ref<CameraEffects>());
+	}
+
+	get_tree()->call_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()), "update_configuration_warning");
+}
+
+void WorldEnvironment::set_environment(const Ref<Environment> &p_environment) {
+	if (environment == p_environment) {
+		return;
+	}
+	if (is_inside_tree() && environment.is_valid()) {
 		remove_from_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
-		//clean up
 	}
 
 	environment = p_environment;
+
 	if (is_inside_tree() && environment.is_valid()) {
-		if (get_viewport()->find_world_3d()->get_environment().is_valid()) {
-			WARN_PRINT("World already has an environment (Another WorldEnvironment?), overriding.");
-		}
-		get_viewport()->find_world_3d()->set_environment(environment);
 		add_to_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 	}
 
-	update_configuration_warning();
+	if (is_inside_tree()) {
+		_update_current_environment();
+	} else {
+		update_configuration_warning();
+	}
 }
 
 Ref<Environment> WorldEnvironment::get_environment() const {
@@ -87,22 +105,24 @@ Ref<Environment> WorldEnvironment::get_environment() const {
 }
 
 void WorldEnvironment::set_camera_effects(const Ref<CameraEffects> &p_camera_effects) {
+	if (camera_effects == p_camera_effects) {
+		return;
+	}
+
 	if (is_inside_tree() && camera_effects.is_valid() && get_viewport()->find_world_3d()->get_camera_effects() == camera_effects) {
-		get_viewport()->find_world_3d()->set_camera_effects(Ref<CameraEffects>());
 		remove_from_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
-		//clean up
 	}
 
 	camera_effects = p_camera_effects;
 	if (is_inside_tree() && camera_effects.is_valid()) {
-		if (get_viewport()->find_world_3d()->get_camera_effects().is_valid()) {
-			WARN_PRINT("World already has an camera_effects (Another WorldEnvironment?), overriding.");
-		}
-		get_viewport()->find_world_3d()->set_camera_effects(camera_effects);
 		add_to_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 	}
 
-	update_configuration_warning();
+	if (is_inside_tree()) {
+		_update_current_camera_effects();
+	} else {
+		update_configuration_warning();
+	}
 }
 
 Ref<CameraEffects> WorldEnvironment::get_camera_effects() const {
@@ -123,14 +143,18 @@ String WorldEnvironment::get_configuration_warning() const {
 		return warning;
 	}
 
-	List<Node *> nodes;
-	get_tree()->get_nodes_in_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()), &nodes);
-
-	if (nodes.size() > 1) {
+	if (environment.is_valid() && get_viewport()->find_world_3d()->get_environment() != environment) {
 		if (!warning.is_empty()) {
 			warning += "\n\n";
 		}
-		warning += TTR("Only one WorldEnvironment is allowed per scene (or set of instanced scenes).");
+		warning += TTR("Only the first Environment has an effect in a scene (or set of instantiated scenes).");
+	}
+
+	if (camera_effects.is_valid() && get_viewport()->find_world_3d()->get_camera_effects() != camera_effects) {
+		if (!warning.is_empty()) {
+			warning += "\n\n";
+		}
+		warning += TTR("Only the first CameraEffects has an effect in a scene (or set of instantiated scenes).");
 	}
 
 	return warning;

--- a/scene/3d/world_environment.h
+++ b/scene/3d/world_environment.h
@@ -41,6 +41,9 @@ class WorldEnvironment : public Node {
 	Ref<Environment> environment;
 	Ref<CameraEffects> camera_effects;
 
+	void _update_current_environment();
+	void _update_current_camera_effects();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -56,6 +56,11 @@ Size2 Button::get_minimum_size() const {
 		}
 	}
 
+	Ref<Font> font = get_theme_font("font");
+	float font_height = font->get_height(get_theme_font_size("font_size"));
+
+	minsize.height = MAX(font_height, minsize.height);
+
 	return get_theme_stylebox("normal")->get_minimum_size() + minsize;
 }
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -956,6 +956,21 @@ bool SceneTree::has_group(const StringName &p_identifier) const {
 	return group_map.has(p_identifier);
 }
 
+Node *SceneTree::get_first_node_in_group(const StringName &p_group) {
+	Map<StringName, Group>::Element *E = group_map.find(p_group);
+	if (!E) {
+		return nullptr; //no group
+	}
+
+	_update_group_order(E->get()); //update order just in case
+
+	if (E->get().nodes.size() == 0) {
+		return nullptr;
+	}
+
+	return E->get().nodes[0];
+}
+
 void SceneTree::get_nodes_in_group(const StringName &p_group, List<Node *> *p_list) {
 	Map<StringName, Group>::Element *E = group_map.find(p_group);
 	if (!E) {
@@ -1216,6 +1231,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_group", "group", "property", "value"), &SceneTree::set_group);
 
 	ClassDB::bind_method(D_METHOD("get_nodes_in_group", "group"), &SceneTree::_get_nodes_in_group);
+	ClassDB::bind_method(D_METHOD("get_first_node_in_group", "group"), &SceneTree::get_first_node_in_group);
 
 	ClassDB::bind_method(D_METHOD("set_current_scene", "child_node"), &SceneTree::set_current_scene);
 	ClassDB::bind_method(D_METHOD("get_current_scene"), &SceneTree::get_current_scene);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -302,6 +302,7 @@ public:
 	void queue_delete(Object *p_object);
 
 	void get_nodes_in_group(const StringName &p_group, List<Node *> *p_list);
+	Node *get_first_node_in_group(const StringName &p_group);
 	bool has_group(const StringName &p_identifier) const;
 
 	//void change_scene(const String& p_path);


### PR DESCRIPTION
* Adds both a preview sun and preview environment to the 3D editor.
* They are valid as long as a DirectionalLight3D and WorldEnvironment are not in the scene.
* If any is added to the scene, the respective preview is disabled.
* Changed WorldEnvironment to better handle multiple node versions.
* Added a function in SceneTree to get the first node in a group.
* Fixed button minimum size to also consider font height if no text is there, this broke with the TextSever PR.

![image](https://user-images.githubusercontent.com/6265307/108718571-5665eb80-74fd-11eb-8fe3-a97266e7dc80.png)

I am aware that users might ask adding more options to environment such as panoramas or physical sky, but this aims to be a MVP. If what is there does not suffice and more features are requested by many users, we will add them.
