### PR TITLE
Input: Swap events for ui_redo to favor Shift+Ctrl+Z over Ctrl+Y

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -434,8 +434,8 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	default_builtin_cache.insert("ui_undo", inputs);
 
 	inputs = List<Ref<InputEvent>>();
-	inputs.push_back(InputEventKey::create_reference(KEY_Y | KEY_MASK_CMD));
 	inputs.push_back(InputEventKey::create_reference(KEY_Z | KEY_MASK_CMD | KEY_MASK_SHIFT));
+	inputs.push_back(InputEventKey::create_reference(KEY_Y | KEY_MASK_CMD));
 	default_builtin_cache.insert("ui_redo", inputs);
 
 	// ///// UI Text Input Shortcuts /////


### PR DESCRIPTION
That's the most common one we've been using for the general editor, and while the script editor
also supports Ctrl+Y, it should have lower priority.

In theory this code should make both be supported the same but for some reason the general editor
only seems to use the first entry (the script editor does support both).

---

That's a follow up to #43663 and a workaround, a better solution might be to fix what causes the main editor's undo redo not to match the second `InputEventKey` assigned to `ui_redo`. We might still want to merge this to have Shift+Ctrl+Z as the first / favored action, which makes it appear in the contextual menu:

![Screenshot_20210222_150625](https://user-images.githubusercontent.com/4701338/108719180-8a520880-751f-11eb-96f8-ac37c34eaa6f.png)