### PR TITLE
Prevent 'Change Type' on nodes from a foreign scene

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -205,6 +205,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _new_scene_from(String p_file);
 
 	bool _validate_no_foreign();
+	bool _validate_no_instance();
 	void _selection_changed();
 	void _update_script_button();
 


### PR DESCRIPTION
Fixes #45912.

Checking for foreign nodes is not enough since the root of an instanced scene does not count as a foreign node. Therefore i've added `SceneTreeDock::_validate_no_instance()`. The error messege for popup window is taken from existing code in SceneTreeDock.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
