### PR TITLE
Expose String contents to the GDScript.

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -353,6 +353,24 @@ struct _VariantCall {
 		r_ret = retval;
 	}
 
+	static void _call_String_to_wchar(Variant &r_ret, Variant &p_self, const Variant **p_args) {
+
+		String *s = reinterpret_cast<String *>(p_self._data._mem);
+		if (s->empty()) {
+			r_ret = PoolByteArray();
+			return;
+		}
+
+		PoolByteArray retval;
+		size_t len = s->length() * sizeof(wchar_t);
+		retval.resize(len);
+		PoolByteArray::Write w = retval.write();
+		copymem(w.ptr(), s->ptr(), len);
+		w.release();
+
+		r_ret = retval;
+	}
+
 	VCALL_LOCALMEM1R(Vector2, distance_to);
 	VCALL_LOCALMEM1R(Vector2, distance_squared_to);
 	VCALL_LOCALMEM0R(Vector2, length);
@@ -1645,6 +1663,7 @@ void register_variant_methods() {
 
 	ADDFUNC0R(STRING, POOL_BYTE_ARRAY, String, to_ascii, varray());
 	ADDFUNC0R(STRING, POOL_BYTE_ARRAY, String, to_utf8, varray());
+	ADDFUNC0R(STRING, POOL_BYTE_ARRAY, String, to_wchar, varray());
 
 	ADDFUNC0R(VECTOR2, REAL, Vector2, angle, varray());
 	ADDFUNC1R(VECTOR2, REAL, Vector2, angle_to, VECTOR2, "to", varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -934,6 +934,13 @@
 				Converts the String (which is an array of characters) to [PoolByteArray] (which is an array of bytes). The conversion is a bit slower than [method to_ascii], but supports all UTF-8 characters. Therefore, you should prefer this function over [method to_ascii].
 			</description>
 		</method>
+		<method name="to_wchar">
+			<return type="PoolByteArray">
+			</return>
+			<description>
+				Converts the String (which is an array of characters) to [PoolByteArray] (which is an array of bytes).
+			</description>
+		</method>
 		<method name="trim_prefix">
 			<return type="String">
 			</return>


### PR DESCRIPTION
Adds `to_wchar` function to expose `wchar_t` contents of the `String` as `PoolByteArray`.