### PR TITLE
SCons: Work around compilation issue on Linux ARM64

### DIFF
--- a/modules/denoise/config.py
+++ b/modules/denoise/config.py
@@ -8,6 +8,15 @@ def can_build(env, platform):
     supported_platform = platform in ["x11", "osx", "windows", "server"]
     supported_bits = env["bits"] == "64"
     supported_arch = env["arch"] != "arm64"
+
+    # Hack to disable on Linux arm64. This won't work well for cross-compilation (checks
+    # host, not target) and would need a more thorough fix by refactoring our arch and
+    # bits-handling code.
+    from platform import machine
+
+    if platform == "x11" and machine() != "x86_64":
+        supported_arch = False
+
     return env["tools"] and supported_platform and supported_bits and supported_arch
 
 

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -6,6 +6,15 @@ def can_build(env, platform):
     supported_platform = platform in ["x11", "osx", "windows", "server"]
     supported_bits = env["bits"] == "64"
     supported_arch = env["arch"] != "arm64"
+
+    # Hack to disable on Linux arm64. This won't work well for cross-compilation (checks
+    # host, not target) and would need a more thorough fix by refactoring our arch and
+    # bits-handling code.
+    from platform import machine
+
+    if platform == "x11" and machine() != "x86_64":
+        supported_arch = False
+
     return env["tools"] and supported_platform and supported_bits and supported_arch
 
 


### PR DESCRIPTION
Fixes #45687.

This is really just a band-aid, our current buildsystem doesn't work well for
cross-compilation and needs a thorough refactoring to do so.