### PR TITLE
[3.2] Allow static linking with libatomic using clang

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -129,7 +129,6 @@ def configure(env):
             env["CC"] = "clang"
             env["CXX"] = "clang++"
         env.extra_suffix = ".llvm" + env.extra_suffix
-        env.Append(LIBS=["atomic"])
 
     if env["use_lld"]:
         if env["use_llvm"]:
@@ -382,3 +381,9 @@ def configure(env):
         # That doesn't make any sense but it's likely a Ubuntu bug?
         if is64 or env["bits"] == "64":
             env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
+        if env["use_llvm"]:
+            env["LINKCOM"] = env["LINKCOM"] + " -l:libatomic.a"
+
+    else:
+        if env["use_llvm"]:
+            env.Append(LIBS=["atomic"])


### PR DESCRIPTION
When using use_static_cpp we want to statically link with atomic as well
to make sure we don't incur any new runtime dependencies.

Scons doesn't quite support this so we do this little trick.

3.2 version of #46347

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
