### PR TITLE
Fix crash during drag if user queue_free'd the drag preview

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -869,7 +869,7 @@
 			<argument index="0" name="control" type="Control">
 			</argument>
 			<description>
-				Shows the given control at the mouse pointer. A good time to call this method is in [method get_drag_data]. The control must not be in the scene tree.
+				Shows the given control at the mouse pointer. A good time to call this method is in [method get_drag_data]. The control must not be in the scene tree. You should not free the control, and you should not keep a reference to the control beyond the duration of the drag. It will be deleted automatically after the drag has ended.
 				[codeblocks]
 				[gdscript]
 				export (Color, RGBA) var color = Color(1, 0, 0, 1)

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -357,7 +357,7 @@ private:
 		Point2 drag_accum;
 		bool drag_attempted = false;
 		Variant drag_data;
-		Control *drag_preview = nullptr;
+		ObjectID drag_preview_id;
 		float tooltip_timer = -1.0;
 		float tooltip_delay = 0.0;
 		Transform2D focus_inv_xform;
@@ -415,6 +415,7 @@ private:
 
 	void _gui_force_drag(Control *p_base, const Variant &p_data, Control *p_control);
 	void _gui_set_drag_preview(Control *p_base, Control *p_control);
+	Control *_gui_get_drag_preview();
 
 	void _gui_remove_focus_for_window(Node *p_window);
 	void _gui_remove_focus();


### PR DESCRIPTION
Fixes #36724.
*Bugsquad edit:* Resolves #46335

I'm not sure about this one. Maybe this should be considered more of a Request For Comments than a finished solution.

This feels like a band-aid solution to a structural problem. The user creates a control instance in GDScript and the C++ side then takes ownership of said instance, dereferencing and deleting it as it sees fit. The user on the other hand is free to retain a reference to the instance as well and even `queue_free`'ing it, as seen in #36724. This patch protects the C++ side against the latter, but it still potentially leaves the user with a dangling pointer (or whatever the equivalent is in GDScript terms). The effect of which can be seen in #46335.

A better solution would likely involve changes to the API that potentially break existing code. Maybe the control could be duplicated in the `set_drag_preview` call. Maybe `Viewport` shouldn't delete the Control instance. I don't know...

Also, viewport.cpp:1780 has now grown to a magnificent length of 237 columns from an already impressive 194. Is there any kind of general rule when to break the line up?