### PR TITLE
SCons: Properly handle overriding default values to bool options

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -55,7 +55,7 @@ custom_tools = ["default"]
 
 platform_arg = ARGUMENTS.get("platform", ARGUMENTS.get("p", False))
 
-if os.name == "nt" and (platform_arg == "android" or ARGUMENTS.get("use_mingw", False)):
+if os.name == "nt" and (platform_arg == "android" or methods.get_cmdline_bool("use_mingw", False)):
     custom_tools = ["mingw"]
 elif platform_arg == "javascript":
     # Use generic POSIX build toolchain for Emscripten.
@@ -95,7 +95,7 @@ env_base.SConsignFile(".sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL))
 
 customs = ["custom.py"]
 
-profile = ARGUMENTS.get("profile", False)
+profile = methods.get_cmdline_bool("profile", False)
 if profile:
     if os.path.isfile(profile):
         customs.append(profile)
@@ -322,15 +322,16 @@ if selected_platform in platform_list:
         env.Alias("compiledb", env.CompilationDatabase())
 
     # 'dev' and 'production' are aliases to set default options if they haven't been set
-    # manually by the user. We use `ARGUMENTS.get()` to check if they were manually set.
+    # manually by the user.
     if env["dev"]:
-        env["verbose"] = ARGUMENTS.get("verbose", True)
+        env["verbose"] = methods.get_cmdline_bool("verbose", True)
         env["warnings"] = ARGUMENTS.get("warnings", "extra")
-        env["werror"] = ARGUMENTS.get("werror", True)
+        env["werror"] = methods.get_cmdline_bool("werror", True)
     if env["production"]:
-        env["use_static_cpp"] = ARGUMENTS.get("use_static_cpp", True)
-        env["use_lto"] = ARGUMENTS.get("use_lto", True)
-        env["debug_symbols"] = ARGUMENTS.get("debug_symbols", False)
+        env["use_static_cpp"] = methods.get_cmdline_bool("use_static_cpp", True)
+        env["use_lto"] = methods.get_cmdline_bool("use_lto", True)
+        print("use_lto is: " + str(env["use_lto"]))
+        env["debug_symbols"] = methods.get_cmdline_bool("debug_symbols", False)
         if not env["tools"] and env["target"] == "debug":
             print(
                 "WARNING: Requested `production` build with `tools=no target=debug`, "

--- a/methods.py
+++ b/methods.py
@@ -6,7 +6,9 @@ from collections import OrderedDict
 from compat import iteritems, isbasestring, open_utf8, decode_utf8, qualname
 
 from SCons import Node
+from SCons.Script import ARGUMENTS
 from SCons.Script import Glob
+from SCons.Variables.BoolVariable import _text2bool
 
 
 def add_source_files(self, sources, files, warn_duplicates=True):
@@ -132,6 +134,17 @@ def parse_cg_file(fname, uniforms, sizes, conditionals):
         line = fs.readline()
 
     fs.close()
+
+
+def get_cmdline_bool(option, default):
+    """We use `ARGUMENTS.get()` to check if options were manually overridden on the command line,
+    and SCons' _text2bool helper to convert them to booleans, otherwise they're handled as strings.
+    """
+    cmdline_val = ARGUMENTS.get(option)
+    if cmdline_val is not None:
+        return _text2bool(cmdline_val)
+    else:
+        return default
 
 
 def detect_modules(search_path, recursive=False):

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -22,6 +22,7 @@ SConscript("pluginscript/SCsub")
 SConscript("videodecoder/SCsub")
 
 
+from methods import get_cmdline_bool
 from platform_methods import run_in_subprocess
 import gdnative_builders
 
@@ -35,7 +36,7 @@ env_gdnative.add_source_files(env.modules_sources, [gensource])
 env.use_ptrcall = True
 
 
-if ARGUMENTS.get("gdnative_wrapper", False):
+if get_cmdline_bool("gdnative_wrapper", False):
     (gensource,) = env_gdnative.CommandNoCache(
         "gdnative_wrapper_code.gen.cpp",
         "gdnative_api.json",


### PR DESCRIPTION
The `dev=yes` and `production=yes` options work as aliases to set a number of
options, while still aiming to allow overriding specific options if the user
wishes so. (E.g. `production=yes use_lto=no` should work to enable production
defaults *but* disable LTO.)

That wasn't working as `ARGUMENTS.get()` returns a string and not a boolean as
expected by `BoolVariable`, and this wasn't flagged as a bug... So added a
helper method using SCons' `BoolVariable._text2bool` to do the conversion
manually.

---

Tested with:
```diff
diff --git a/SConstruct b/SConstruct
index 3922e7f484..fc0459df70 100644
--- a/SConstruct
+++ b/SConstruct
@@ -330,6 +330,7 @@ if selected_platform in platform_list:
     if env["production"]:
         env["use_static_cpp"] = methods.get_cmdline_bool("use_static_cpp", True)
         env["use_lto"] = methods.get_cmdline_bool("use_lto", True)
+        print("use_lto is: " + str(env["use_lto"]))
         env["debug_symbols"] = methods.get_cmdline_bool("debug_symbols", False)
         if not env["tools"] and env["target"] == "debug":
             print(
```

```
$ scons p=x11 production=yes
scons: Reading SConscript files ...
use_lto is: True

$ scons p=x11 production=yes use_lto=no
scons: Reading SConscript files ...
use_lto is: False

$ scons p=x11 use_lto=0 production=yes
scons: Reading SConscript files ...
use_lto is: False

$ scons p=x11 production=yes use_lto=42
scons: Reading SConscript files ...

scons: *** Error converting option: use_lto
Invalid value for boolean option: 42
File "/home/akien/Projects/godot/godot-3.2/SConstruct", line 181, in <module>
```