### PR TITLE
Fixed 'nonexistent action' errors spammed at startup on OSX

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -694,7 +694,7 @@ void InputMap::load_default() {
 
 			// For the editor, only add keyboard actions.
 			if (iek.is_valid()) {
-				action_add_event(fullname, I->get());
+				action_add_event(name, I->get());
 			}
 		}
 	}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1578,11 +1578,11 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 		if (k->is_pressed()) {
 			bool handled = false;
 
-			if (k->is_action("ui_pageup") && vscroll->is_visible_in_tree()) {
+			if (k->is_action("ui_page_up") && vscroll->is_visible_in_tree()) {
 				vscroll->set_value(vscroll->get_value() - vscroll->get_page());
 				handled = true;
 			}
-			if (k->is_action("ui_pagedown") && vscroll->is_visible_in_tree()) {
+			if (k->is_action("ui_page_down") && vscroll->is_visible_in_tree()) {
 				vscroll->set_value(vscroll->get_value() + vscroll->get_page());
 				handled = true;
 			}


### PR DESCRIPTION
Fixes #46369