### PR TITLE
Record the version of the Godot engine for the Android platform

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -2553,6 +2553,7 @@ public:
 			cmdline.push_back("-Pplugins_maven_repos=" + custom_maven_repos); // argument to specify the list of custom maven repos for the plugins dependencies.
 			cmdline.push_back("-Pperform_zipalign=" + zipalign_flag); // argument to specify whether the build should be zipaligned.
 			cmdline.push_back("-Pperform_signing=" + sign_flag); // argument to specify whether the build should be signed.
+			cmdline.push_back("-Pgodot_editor_version=" + String(VERSION_FULL_CONFIG));
 
 			// NOTE: The release keystore is not included in the verbose logging
 			// to avoid accidentally leaking sensitive information when sharing verbose logs for troubleshooting.

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -22,6 +22,11 @@
         tools:ignore="GoogleAppIndexingWarning"
         android:icon="@mipmap/icon" >
 
+        <!-- Records the version of the Godot editor used for building -->
+        <meta-data
+            android:name="org.godotengine.editor.version"
+            android:value="${godotEditorVersion}" />
+
         <!-- The following metadata values are replaced when Godot exports, modifying them here has no effect. -->
         <!-- Do these changes in the export preset. Adding new ones is fine. -->
 

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -85,6 +85,8 @@ android {
             abiFilters export_abi_list
         }
 
+        manifestPlaceholders = [godotEditorVersion: getGodotEditorVersion()]
+
         // Feel free to modify the application id to your own.
         applicationId getExportPackageName()
         versionCode getExportVersionCode()

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -50,6 +50,55 @@ ext.getExportVersionName = { ->
     return versionName
 }
 
+ext.getGodotEditorVersion = { ->
+    String editorVersion = project.hasProperty("godot_editor_version") ? project.property("godot_editor_version") : ""
+    if (editorVersion == null || editorVersion.isEmpty()) {
+        // Try the library version first
+        editorVersion = getGodotLibraryVersion()
+
+        if (editorVersion.isEmpty()) {
+            // Fallback value.
+            editorVersion = "custom_build"
+        }
+    }
+    return editorVersion
+}
+
+ext.getGodotLibraryVersion = { ->
+    // Attempt to read the version from the `version.py` file.
+    String libraryVersion = ""
+
+    File versionFile = new File("../../../version.py")
+    if (versionFile.isFile()) {
+        List<String> requiredKeys = ["major", "minor", "patch", "status", "module_config"]
+        def map = [:]
+
+        List<String> lines = versionFile.readLines()
+        for (String line in lines) {
+            String[] keyValue = line.split("=")
+            String key = keyValue[0].trim()
+            String value = keyValue[1].trim().replaceAll("\"", "")
+
+            if (requiredKeys.contains(key)) {
+                if (!value.isEmpty()) {
+                    map[key] = value
+                }
+                requiredKeys.remove(key)
+            }
+        }
+
+        if (requiredKeys.empty) {
+            libraryVersion = map.values().join(".")
+        }
+    }
+
+    if (libraryVersion.isEmpty()) {
+        // Fallback value in case we're unable to read the file.
+        libraryVersion = "custom_build"
+    }
+    return libraryVersion
+}
+
 final String PLUGIN_VALUE_SEPARATOR_REGEX = "\\|"
 
 // get the list of ABIs the project should be exported to

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -165,12 +165,6 @@ task cleanGodotTemplates(type: Delete) {
     // Delete the library generated AAR files
     delete("lib/build/outputs/aar")
 
-    // Delete the godotpayment libs directory contents
-    delete("plugins/godotpayment/libs")
-
-    // Delete the generated godotpayment aar
-    delete("plugins/godotpayment/build/outputs/aar")
-
     // Delete the app libs directory contents
     delete("app/libs")
 

--- a/platform/android/java/lib/AndroidManifest.xml
+++ b/platform/android/java/lib/AndroidManifest.xml
@@ -6,6 +6,11 @@
 
     <application>
 
+        <!-- Records the version of the Godot library -->
+        <meta-data
+            android:name="org.godotengine.library.version"
+            android:value="${godotLibraryVersion}" />
+
         <service android:name=".GodotDownloaderService" />
 
     </application>

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -18,6 +18,8 @@ android {
     defaultConfig {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
+
+        manifestPlaceholders = [godotLibraryVersion: getGodotLibraryVersion()]
     }
 
     compileOptions {


### PR DESCRIPTION
This introduces two `meta-data` tags use to record the version of the Godot Android library and the version of the Godot Android editor used to generate a Godot binary.

By default, the versions are populated by the version info in `version.py`.
For custom builds, the version is retrieved from the engine at runtime and passed to the gradle build.