### PR TITLE
GLES2 fix for consistent light ordering with BVH

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -88,6 +88,10 @@ public:
 	uint32_t current_refprobe_index;
 	uint32_t current_shader_index;
 
+private:
+	uint32_t _light_counter;
+
+public:
 	RasterizerStorageGLES2 *storage;
 	struct State {
 
@@ -527,6 +531,10 @@ public:
 		uint16_t light_directional_index;
 
 		Rect2 directional_rect;
+
+		// an ever increasing counter for each light added,
+		// used for sorting lights for a consistent render
+		uint32_t light_counter;
 
 		Set<RID> shadow_atlases; // atlases where this light is registered
 	};


### PR DESCRIPTION
Due to multi pass approach to lighting in GLES2, it has become apparent that in some situations the rendered result can look different if lights are presented in a different order.

The order (aside from directional lights) seems to be simply copied from the culling routine (octree or bvh or portals) which is essentially arbitrary. While octree is usually consistent with order, bvh uses a trickle optimize which may result in lights occurring in different order from frame to frame.

This PR adds an extra layer of sorting on GLES2 lights in order to get some kind of order consistency.

Fixes #46353.

## Notes
* Making this draft as I want to get some opinion from @clayjohn before finalizing.
* Should we make this consistent ordering occur in all cases, or limit (as I have here) to when `fog_transmit` is used? I suspect that there may be more cases where ordering matters. On the other hand if we make it global we will never find out when it is, and when not required.
* Here I am just sorting by memory address. This is arbitrary, but should be consistent on a 'run' of the program. Maybe there's something slightly better we could sort by. Position in the scene tree?
* There is the slight possibility of this having an interaction with some other sorting (I'm not super familiar with GLES2 3d rasterizer), so that is something to bear in mind as we get close to 3.2.4 stable.

This whole area is interesting, because it suggests that the current rendered result of some GLES2 scenes is subject to some random effects (e.g. some lights relatively brighter than others). To me, the whole order dependence is a 'render smell', however practically speaking it may come with the territory of multipass rendering.

I suspect GLES2 has been vulnerable to issue #46353 all along, even with octree, but the visual result was harder to notice until the flickering caused by bvh made it apparent.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
