### PR TITLE
Improved CollisionPolygon2D debug draw

### DIFF
--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -132,24 +132,28 @@ void CollisionPolygon2D::_notification(int p_what) {
 				break;
 			}
 
-			for (int i = 0; i < polygon.size(); i++) {
-				Vector2 p = polygon[i];
-				Vector2 n = polygon[(i + 1) % polygon.size()];
-				// draw line with width <= 1, so it does not scale with zoom and break pixel exact editing
-				draw_line(p, n, Color(0.9, 0.2, 0.0, 0.8), 1);
-			}
+			Color color = get_tree()->get_debug_collisions_color();
+
+			draw_polyline(polygon, color);
+			// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+			draw_line(polygon[polygon.size() - 1], polygon[0], color);
+
 #define DEBUG_DECOMPOSE
 #if defined(TOOLS_ENABLED) && defined(DEBUG_DECOMPOSE)
-
 			Vector<Vector<Vector2>> decomp = _decompose_in_convex();
 
-			Color c(0.4, 0.9, 0.1);
+			Color c = color;
+			float min_value = 0.2;
 			for (int i = 0; i < decomp.size(); i++) {
-				c.set_hsv(Math::fmod(c.get_h() + 0.738, 1), c.get_s(), c.get_v(), 0.5);
 				draw_colored_polygon(decomp[i], c);
+				float new_value = Math::fmod(c.get_v() + 0.738, 1.0);
+				if (new_value < min_value) {
+					new_value += min_value;
+				}
+				c.set_hsv(c.get_h(), c.get_s(), new_value, c.a);
 			}
 #else
-			draw_colored_polygon(polygon, get_tree()->get_debug_collisions_color());
+			draw_colored_polygon(polygon, color);
 #endif
 
 			if (one_way_collision) {


### PR DESCRIPTION
Draw polygon shapes with the same colors as other 2D shapes to make it more consistent, and alternate values instead of hues when drawing the different convex shapes from decomposition to make it easier to read.

Before:
<img width="400" src="https://user-images.githubusercontent.com/1075032/108545308-dfceb100-72a4-11eb-9595-ec99e3889807.png">

After:
<img width="400" src="https://user-images.githubusercontent.com/1075032/108545371-efe69080-72a4-11eb-8b9c-2bd5509b5d4b.png">