### PR TITLE
Fix import selector resetting in Import Defaults Editor

### DIFF
--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -75,6 +75,7 @@ void ImportDefaultsEditor::_reset() {
 		settings->notify_property_list_changed();
 	}
 }
+
 void ImportDefaultsEditor::_save() {
 	if (settings->importer.is_valid()) {
 		Dictionary modified;
@@ -140,12 +141,22 @@ void ImportDefaultsEditor::_update_importer() {
 
 	inspector->edit(settings);
 }
+
 void ImportDefaultsEditor::_importer_selected(int p_index) {
 	_update_importer();
 }
+
 void ImportDefaultsEditor::clear() {
+	String last_selected;
+	if (importers->get_selected() > 0) {
+		last_selected = importers->get_item_text(importers->get_selected());
+	}
+
 	importers->clear();
+
 	importers->add_item("<" + TTR("Select Importer") + ">");
+	importers->set_item_disabled(0, true);
+
 	List<Ref<ResourceImporter>> importer_list;
 	ResourceFormatImporter::get_singleton()->get_importers(&importer_list);
 	Vector<String> names;
@@ -157,11 +168,17 @@ void ImportDefaultsEditor::clear() {
 
 	for (int i = 0; i < names.size(); i++) {
 		importers->add_item(names[i]);
+
+		if (names[i] == last_selected) {
+			importers->select(i + 1);
+		}
 	}
 }
+
 void ImportDefaultsEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("project_settings_changed"));
 }
+
 ImportDefaultsEditor::ImportDefaultsEditor() {
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->add_child(memnew(Label(TTR("Importer:"))));


### PR DESCRIPTION
Before, the selector would go back to the "<Select Importer>" option when the settings was reopened, even if the import options are remembered. This fixes that.

I also took the liberty to make the "<Select Importer>" option disabled, which means it can't be reselect, as there's no point.