### PR TITLE
Added LocalVector to Visual Studio debugger visualization

### DIFF
--- a/platform/windows/godot.natvis
+++ b/platform/windows/godot.natvis
@@ -10,6 +10,16 @@
 		</Expand>
 	</Type>
 
+	<Type Name="LocalVector&lt;*&gt;">
+		<Expand>
+			<Item Name="[size]">count</Item>
+			<ArrayItems>
+				<Size>count</Size>
+				<ValuePointer>data</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
 	<Type Name="List&lt;*&gt;">
 		<Expand>
 			<Item Name="[size]">_data ? (_data->size_cache) : 0</Item>


### PR DESCRIPTION
Updated .natvis file so LocalVector elements can be visualized correctly in the Visual Studio debugger. LocalVector is the same on 3.2 and 4.0 so it works for both.