### PR TITLE
Fix flicker in control nodes due to pivot offset

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -462,11 +462,6 @@ void Control::_update_canvas_item_transform() {
 	Transform2D xform = _get_internal_transform();
 	xform[2] += get_position();
 
-	// We use a little workaround to avoid flickering when moving the pivot with _edit_set_pivot()
-	if (is_inside_tree() && Math::abs(Math::sin(data.rotation * 4.0f)) < 0.00001f && get_viewport()->is_snap_controls_to_pixels_enabled()) {
-		xform[2] = xform[2].round();
-	}
-
 	VisualServer::get_singleton()->canvas_item_set_transform(get_canvas_item(), xform);
 }
 

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -315,6 +315,7 @@ void ScrollContainer::_notification(int p_what) {
 					r.size.height = minsize.height;
 			}
 			r.position += ofs;
+			r.position = r.position.floor();
 			fit_child_in_rect(c, r);
 		}
 


### PR DESCRIPTION
Fixes #28804 for 3.x
Closes https://github.com/godotengine/godot/issues/36974

Based on suggested fix from this comment, which is already implemented on the master branch anyway. 
https://github.com/godotengine/godot/issues/36087#issuecomment-771593146

We're using this internally for our project and it doesn't seem to have any regressions anywhere, so it is safe to merge.

Before:

https://user-images.githubusercontent.com/43449832/109133964-954aaa00-7766-11eb-97ec-6bc1b842a506.mp4




After:

https://user-images.githubusercontent.com/43449832/109133830-73512780-7766-11eb-8311-6bd8ae06b1a4.mp4





