### PR TITLE
Prevent thread wait on itself for finish

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -92,6 +92,7 @@ bool Thread::is_started() const {
 
 void Thread::wait_to_finish() {
 	if (id != 0) {
+		ERR_FAIL_COND_MSG(id == get_caller_id(), "A Thread can't wait for itself to finish.");
 		thread.join();
 		std::thread empty_thread;
 		thread.swap(empty_thread);


### PR DESCRIPTION
That a thread joins (wait for finish on) itself is never correct, because, obviously, that would deadlock.

Before the MT rewrite, underlying APIs like pthread where just returning an error code about that, so we could ignore the problem just fine.

After the rewrite based on `std::thread`, we need to check, because the deadlock case is otherwise detected by it and handled in a not so graceful fashion. On the bright side, this also gives Godot the opportunity to tell the user they are doing something wrong.

Fixes #46412.