### PR TITLE
Expose set_environment to GDScript

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -276,6 +276,10 @@ String _OS::get_environment(const String &p_var) const {
 	return OS::get_singleton()->get_environment(p_var);
 }
 
+bool _OS::set_environment(const String &p_var, const String &p_value) const {
+	return OS::get_singleton()->set_environment(p_var, p_value);
+}
+
 String _OS::get_name() const {
 	return OS::get_singleton()->get_name();
 }
@@ -712,6 +716,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_process_id"), &_OS::get_process_id);
 
 	ClassDB::bind_method(D_METHOD("get_environment", "environment"), &_OS::get_environment);
+	ClassDB::bind_method(D_METHOD("set_environment", "environment", "value"), &_OS::set_environment);
 	ClassDB::bind_method(D_METHOD("has_environment", "environment"), &_OS::has_environment);
 
 	ClassDB::bind_method(D_METHOD("get_name"), &_OS::get_name);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -172,6 +172,7 @@ public:
 
 	bool has_environment(const String &p_var) const;
 	String get_environment(const String &p_var) const;
+	bool set_environment(const String &p_var, const String &p_value) const;
 
 	String get_name() const;
 	Vector<String> get_cmdline_args();

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -501,6 +501,17 @@
 				[b]Note:[/b] This method is implemented on Android.
 			</description>
 		</method>
+		<method name="set_environment" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="environment" type="String">
+			</argument>
+			<argument index="1" name="value" type="String">
+			</argument>
+			<description>
+				Change the value of an environment variable.
+			</description>
+		</method>
 		<method name="set_thread_name">
 			<return type="int" enum="Error">
 			</return>


### PR DESCRIPTION
master version of https://github.com/godotengine/godot/pull/46413

'set_environment' is nicely implemented in our OS class but not exposed to GDScript while 'get_environment' and 'has_environment' are.
Especially when building editor plugins being able to change environment settings can be extremely handy.