### PR TITLE
Added option in project settings to draw Shape2D outlines

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -460,6 +460,9 @@
 		<member name="debug/shapes/collision/contact_color" type="Color" setter="" getter="" default="Color( 1, 0.2, 0.1, 0.8 )">
 			Color of the contact points between collision shapes, visible when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
+		<member name="debug/shapes/collision/draw_2d_outlines" type="bool" setter="" getter="" default="true">
+			Sets whether 2D physics will display collision outlines in game when "Visible Collision Shapes" is enabled in the Debug menu.
+		</member>
 		<member name="debug/shapes/collision/max_contacts_displayed" type="int" setter="" getter="" default="10000">
 			Maximum number of contact points between collision shapes to display when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1350,6 +1350,8 @@ SceneTree::SceneTree() {
 	collision_debug_contacts = GLOBAL_DEF("debug/shapes/collision/max_contacts_displayed", 10000);
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/shapes/collision/max_contacts_displayed", PropertyInfo(Variant::INT, "debug/shapes/collision/max_contacts_displayed", PROPERTY_HINT_RANGE, "0,20000,1")); // No negative
 
+	GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
+
 	// Create with mainloop.
 
 	root = memnew(Window);

--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -85,9 +85,11 @@ void CapsuleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
-	RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
-	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
-	RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
+	if (is_collision_outline_enabled()) {
+		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
+		// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+		RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
+	}
 }
 
 Rect2 CapsuleShape2D::get_rect() const {

--- a/scene/resources/circle_shape_2d.cpp
+++ b/scene/resources/circle_shape_2d.cpp
@@ -79,9 +79,11 @@ void CircleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
-	RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
-	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
-	RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
+	if (is_collision_outline_enabled()) {
+		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
+		// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+		RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
+	}
 }
 
 CircleShape2D::CircleShape2D() :

--- a/scene/resources/convex_polygon_shape_2d.cpp
+++ b/scene/resources/convex_polygon_shape_2d.cpp
@@ -75,9 +75,11 @@ void ConvexPolygonShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
-	RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
-	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
-	RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
+	if (is_collision_outline_enabled()) {
+		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
+		// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+		RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
+	}
 }
 
 Rect2 ConvexPolygonShape2D::get_rect() const {

--- a/scene/resources/rectangle_shape_2d.cpp
+++ b/scene/resources/rectangle_shape_2d.cpp
@@ -47,23 +47,25 @@ Vector2 RectangleShape2D::get_size() const {
 }
 
 void RectangleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
-	// Draw an outlined rectangle to make individual shapes easier to distinguish.
-	Vector<Vector2> stroke_points;
-	stroke_points.resize(5);
-	stroke_points.write[0] = -size * 0.5;
-	stroke_points.write[1] = Vector2(size.x, -size.y) * 0.5;
-	stroke_points.write[2] = size * 0.5;
-	stroke_points.write[3] = Vector2(-size.x, size.y) * 0.5;
-	stroke_points.write[4] = -size * 0.5;
-
-	Vector<Color> stroke_colors;
-	stroke_colors.resize(5);
-	for (int i = 0; i < 5; i++) {
-		stroke_colors.write[i] = (p_color);
-	}
-
 	RenderingServer::get_singleton()->canvas_item_add_rect(p_to_rid, Rect2(-size * 0.5, size), p_color);
-	RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, stroke_points, stroke_colors);
+	if (is_collision_outline_enabled()) {
+		// Draw an outlined rectangle to make individual shapes easier to distinguish.
+		Vector<Vector2> stroke_points;
+		stroke_points.resize(5);
+		stroke_points.write[0] = -size * 0.5;
+		stroke_points.write[1] = Vector2(size.x, -size.y) * 0.5;
+		stroke_points.write[2] = size * 0.5;
+		stroke_points.write[3] = Vector2(-size.x, size.y) * 0.5;
+		stroke_points.write[4] = -size * 0.5;
+
+		Vector<Color> stroke_colors;
+		stroke_colors.resize(5);
+		for (int i = 0; i < 5; i++) {
+			stroke_colors.write[i] = (p_color);
+		}
+
+		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, stroke_points, stroke_colors);
+	}
 }
 
 Rect2 RectangleShape2D::get_rect() const {

--- a/scene/resources/shape_2d.cpp
+++ b/scene/resources/shape_2d.cpp
@@ -29,7 +29,11 @@
 /*************************************************************************/
 
 #include "shape_2d.h"
+
+#include "core/config/engine.h"
+#include "core/config/project_settings.h"
 #include "servers/physics_server_2d.h"
+
 RID Shape2D::get_rid() const {
 	return shape;
 }
@@ -103,6 +107,15 @@ void Shape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "color"), &Shape2D::draw);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_solver_bias", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_custom_solver_bias", "get_custom_solver_bias");
+}
+
+bool Shape2D::is_collision_outline_enabled() {
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return true;
+	}
+#endif
+	return GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
 }
 
 Shape2D::Shape2D(const RID &p_rid) {

--- a/scene/resources/shape_2d.h
+++ b/scene/resources/shape_2d.h
@@ -61,6 +61,9 @@ public:
 	/// Returns the radius of a circle that fully enclose this shape
 	virtual real_t get_enclosing_radius() const = 0;
 	virtual RID get_rid() const override;
+
+	static bool is_collision_outline_enabled();
+
 	Shape2D();
 	~Shape2D();
 };


### PR DESCRIPTION
Disabling collision outlines can be useful for performance when the game is running and many collision shapes are displayed.

Fixes #46410