### PR TITLE
[3.2] Added option in project settings to draw Shape2D outlines

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -429,6 +429,9 @@
 		<member name="debug/shapes/collision/contact_color" type="Color" setter="" getter="" default="Color( 1, 0.2, 0.1, 0.8 )">
 			Color of the contact points between collision shapes, visible when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
+		<member name="debug/shapes/collision/draw_2d_outlines" type="bool" setter="" getter="" default="true">
+			Sets whether 2D physics will display collision outlines in game when "Visible Collision Shapes" is enabled in the Debug menu.
+		</member>
 		<member name="debug/shapes/collision/max_contacts_displayed" type="int" setter="" getter="" default="10000">
 			Maximum number of contact points between collision shapes to display when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2039,6 +2039,8 @@ SceneTree::SceneTree() {
 	collision_debug_contacts = GLOBAL_DEF("debug/shapes/collision/max_contacts_displayed", 10000);
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/shapes/collision/max_contacts_displayed", PropertyInfo(Variant::INT, "debug/shapes/collision/max_contacts_displayed", PROPERTY_HINT_RANGE, "0,20000,1")); // No negative
 
+	GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
+
 	tree_version = 1;
 	physics_process_time = 1;
 	idle_process_time = 1;

--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -89,9 +89,11 @@ void CapsuleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	VisualServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
-	VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col, 1.0, true);
-	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
-	VisualServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0, true);
+	if (is_collision_outline_enabled()) {
+		VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col, 1.0, true);
+		// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+		VisualServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0, true);
+	}
 }
 
 Rect2 CapsuleShape2D::get_rect() const {

--- a/scene/resources/circle_shape_2d.cpp
+++ b/scene/resources/circle_shape_2d.cpp
@@ -81,9 +81,11 @@ void CircleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	VisualServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
-	VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col, 1.0, true);
-	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
-	VisualServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0, true);
+	if (is_collision_outline_enabled()) {
+		VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col, 1.0, true);
+		// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+		VisualServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0, true);
+	}
 }
 
 CircleShape2D::CircleShape2D() :

--- a/scene/resources/convex_polygon_shape_2d.cpp
+++ b/scene/resources/convex_polygon_shape_2d.cpp
@@ -82,9 +82,11 @@ void ConvexPolygonShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Color> col;
 	col.push_back(p_color);
 	VisualServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
-	VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col, 1.0, true);
-	// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
-	VisualServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0, true);
+	if (is_collision_outline_enabled()) {
+		VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col, 1.0, true);
+		// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
+		VisualServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0, true);
+	}
 }
 
 Rect2 ConvexPolygonShape2D::get_rect() const {

--- a/scene/resources/rectangle_shape_2d.cpp
+++ b/scene/resources/rectangle_shape_2d.cpp
@@ -51,23 +51,25 @@ Vector2 RectangleShape2D::get_extents() const {
 
 void RectangleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 
-	// Draw an outlined rectangle to make individual shapes easier to distinguish.
-	Vector<Vector2> stroke_points;
-	stroke_points.resize(5);
-	stroke_points.write[0] = -extents;
-	stroke_points.write[1] = Vector2(extents.x, -extents.y);
-	stroke_points.write[2] = extents;
-	stroke_points.write[3] = Vector2(-extents.x, extents.y);
-	stroke_points.write[4] = -extents;
-
-	Vector<Color> stroke_colors;
-	stroke_colors.resize(5);
-	for (int i = 0; i < 5; i++) {
-		stroke_colors.write[i] = p_color;
-	}
-
 	VisualServer::get_singleton()->canvas_item_add_rect(p_to_rid, Rect2(-extents, extents * 2.0), p_color);
-	VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, stroke_points, stroke_colors, 1.0, true);
+	if (is_collision_outline_enabled()) {
+		// Draw an outlined rectangle to make individual shapes easier to distinguish.
+		Vector<Vector2> stroke_points;
+		stroke_points.resize(5);
+		stroke_points.write[0] = -extents;
+		stroke_points.write[1] = Vector2(extents.x, -extents.y);
+		stroke_points.write[2] = extents;
+		stroke_points.write[3] = Vector2(-extents.x, extents.y);
+		stroke_points.write[4] = -extents;
+
+		Vector<Color> stroke_colors;
+		stroke_colors.resize(5);
+		for (int i = 0; i < 5; i++) {
+			stroke_colors.write[i] = p_color;
+		}
+
+		VisualServer::get_singleton()->canvas_item_add_polyline(p_to_rid, stroke_points, stroke_colors, 1.0, true);
+	}
 }
 
 Rect2 RectangleShape2D::get_rect() const {

--- a/scene/resources/shape_2d.cpp
+++ b/scene/resources/shape_2d.cpp
@@ -29,7 +29,11 @@
 /*************************************************************************/
 
 #include "shape_2d.h"
+
+#include "core/engine.h"
+#include "core/project_settings.h"
 #include "servers/physics_2d_server.h"
+
 RID Shape2D::get_rid() const {
 
 	return shape;
@@ -107,6 +111,15 @@ void Shape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "color"), &Shape2D::draw);
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "custom_solver_bias", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_custom_solver_bias", "get_custom_solver_bias");
+}
+
+bool Shape2D::is_collision_outline_enabled() {
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return true;
+	}
+#endif
+	return GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
 }
 
 Shape2D::Shape2D(const RID &p_rid) {

--- a/scene/resources/shape_2d.h
+++ b/scene/resources/shape_2d.h
@@ -59,6 +59,9 @@ public:
 	virtual void draw(const RID &p_to_rid, const Color &p_color) {}
 	virtual Rect2 get_rect() const { return Rect2(); }
 	virtual RID get_rid() const;
+
+	bool is_collision_outline_enabled();
+
 	Shape2D();
 	~Shape2D();
 };


### PR DESCRIPTION
Disabling collision outlines can be useful for performance when the game is running and many collision shapes are displayed.

3.2 version of #46416.