### PR TITLE
Make Color::from_hsv use Color::set_hsv

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -452,56 +452,9 @@ String Color::to_html(bool p_alpha) const {
 }
 
 Color Color::from_hsv(float p_h, float p_s, float p_v, float p_a) const {
-	p_h = Math::fmod(p_h * 360.0f, 360.0f);
-	if (p_h < 0.0) {
-		p_h += 360.0f;
-	}
-
-	const float h_ = p_h / 60.0f;
-	const float c = p_v * p_s;
-	const float x = c * (1.0f - Math::abs(Math::fmod(h_, 2.0f) - 1.0f));
-	float r, g, b;
-
-	switch ((int)h_) {
-		case 0: {
-			r = c;
-			g = x;
-			b = 0;
-		} break;
-		case 1: {
-			r = x;
-			g = c;
-			b = 0;
-		} break;
-		case 2: {
-			r = 0;
-			g = c;
-			b = x;
-		} break;
-		case 3: {
-			r = 0;
-			g = x;
-			b = c;
-		} break;
-		case 4: {
-			r = x;
-			g = 0;
-			b = c;
-		} break;
-		case 5: {
-			r = c;
-			g = 0;
-			b = x;
-		} break;
-		default: {
-			r = 0;
-			g = 0;
-			b = 0;
-		} break;
-	}
-
-	const float m = p_v - c;
-	return Color(m + r, m + g, m + b, p_a);
+	Color c;
+	c.set_hsv(p_h, p_s, p_v, p_a);
+	return c;
 }
 
 Color::operator String() const {


### PR DESCRIPTION
Fixes #46393 (needs to be cherry-picked for 3.2).

For some reason `Color::from_hsv` were using a little different conversion algorithm than `Color::set_hsv`. It seems the one used by `Color::from_hsv` was numerically worse / less stable.
https://github.com/godotengine/godot/blob/494e1cb1487c90425e3f5ae2cdf9e4046c3f550c/core/math/color.cpp#L156-L208
https://github.com/godotengine/godot/blob/494e1cb1487c90425e3f5ae2cdf9e4046c3f550c/core/math/color.cpp#L454-L505