### PR TITLE
SCons: Fix profile type. It is a string

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -95,7 +95,7 @@ env_base.SConsignFile(".sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL))
 
 customs = ["custom.py"]
 
-profile = methods.get_cmdline_bool("profile", False)
+profile = ARGUMENTS.get("profile", "")
 if profile:
     if os.path.isfile(profile):
         customs.append(profile)


### PR DESCRIPTION
It's very simple, but you got an error if you put something in the profile and it's happening on 3.2.4 RC3, so should be cherry picked.