### PR TITLE
Further changes in GDNative API

### DIFF
--- a/modules/gdnative/gdnative/aabb.cpp
+++ b/modules/gdnative/gdnative/aabb.cpp
@@ -42,6 +42,10 @@ void GDAPI godot_aabb_new(godot_aabb *p_self) {
 	memnew_placement(p_self, AABB);
 }
 
+void GDAPI godot_aabb_new_copy(godot_aabb *r_dest, const godot_aabb *p_src) {
+	memnew_placement(r_dest, AABB(*(AABB *)p_src));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/gdnative/gdnative/array.cpp
+++ b/modules/gdnative/gdnative/array.cpp
@@ -43,6 +43,10 @@ void GDAPI godot_array_new(godot_array *p_self) {
 	memnew_placement(p_self, Array);
 }
 
+void GDAPI godot_array_new_copy(godot_array *r_dest, const godot_array *p_src) {
+	memnew_placement(r_dest, Array(*(Array *)p_src));
+}
+
 void GDAPI godot_array_destroy(godot_array *p_self) {
 	((Array *)p_self)->~Array();
 }

--- a/modules/gdnative/gdnative/basis.cpp
+++ b/modules/gdnative/gdnative/basis.cpp
@@ -42,6 +42,10 @@ void GDAPI godot_basis_new(godot_basis *p_self) {
 	memnew_placement(p_self, Basis);
 }
 
+void GDAPI godot_basis_new_copy(godot_basis *r_dest, const godot_basis *p_src) {
+	memnew_placement(r_dest, Basis(*(Basis *)p_src));
+}
+
 godot_vector3 GDAPI *godot_basis_operator_index(godot_basis *p_self, godot_int p_index) {
 	Basis *self = (Basis *)p_self;
 	return (godot_vector3 *)&self->operator[](p_index);

--- a/modules/gdnative/gdnative/callable.cpp
+++ b/modules/gdnative/gdnative/callable.cpp
@@ -43,6 +43,10 @@ void GDAPI godot_callable_new(godot_callable *p_self) {
 	memnew_placement(p_self, Callable);
 }
 
+void GDAPI godot_callable_new_copy(godot_callable *r_dest, const godot_callable *p_src) {
+	memnew_placement(r_dest, Callable(*(Callable *)p_src));
+}
+
 void GDAPI godot_callable_destroy(godot_callable *p_self) {
 	Callable *self = (Callable *)p_self;
 	self->~Callable();

--- a/modules/gdnative/gdnative/color.cpp
+++ b/modules/gdnative/gdnative/color.cpp
@@ -42,6 +42,10 @@ void GDAPI godot_color_new(godot_color *p_self) {
 	memnew_placement(p_self, Color);
 }
 
+void GDAPI godot_color_new_copy(godot_color *r_dest, const godot_color *p_src) {
+	memnew_placement(r_dest, Color(*(Color *)p_src));
+}
+
 float GDAPI *godot_color_operator_index(godot_color *p_self, godot_int p_index) {
 	Color *self = (Color *)p_self;
 	return (float *)&self->operator[](p_index);

--- a/modules/gdnative/gdnative/dictionary.cpp
+++ b/modules/gdnative/gdnative/dictionary.cpp
@@ -43,6 +43,10 @@ void GDAPI godot_dictionary_new(godot_dictionary *p_self) {
 	memnew_placement(p_self, Dictionary);
 }
 
+void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *p_src) {
+	memnew_placement(r_dest, Dictionary(*(Dictionary *)p_src));
+}
+
 void GDAPI godot_dictionary_destroy(godot_dictionary *p_self) {
 	Dictionary *self = (Dictionary *)p_self;
 	self->~Dictionary();

--- a/modules/gdnative/gdnative/node_path.cpp
+++ b/modules/gdnative/gdnative/node_path.cpp
@@ -42,6 +42,10 @@ void GDAPI godot_node_path_new(godot_node_path *p_self) {
 	memnew_placement(p_self, NodePath);
 }
 
+void GDAPI godot_node_path_new_copy(godot_node_path *r_dest, const godot_node_path *p_src) {
+	memnew_placement(r_dest, NodePath(*(NodePath *)p_src));
+}
+
 void GDAPI godot_node_path_destroy(godot_node_path *p_self) {
 	NodePath *self = (NodePath *)p_self;
 	self->~NodePath();

--- a/modules/gdnative/gdnative/packed_arrays.cpp
+++ b/modules/gdnative/gdnative/packed_arrays.cpp
@@ -59,6 +59,10 @@ void GDAPI godot_packed_byte_array_new(godot_packed_byte_array *p_self) {
 	memnew_placement(p_self, PackedByteArray);
 }
 
+void GDAPI godot_packed_byte_array_new_copy(godot_packed_byte_array *r_dest, const godot_packed_byte_array *p_src) {
+	memnew_placement(r_dest, PackedByteArray(*(PackedByteArray *)p_src));
+}
+
 void GDAPI godot_packed_byte_array_destroy(godot_packed_byte_array *p_self) {
 	((PackedByteArray *)p_self)->~PackedByteArray();
 }
@@ -77,6 +81,10 @@ const uint8_t GDAPI *godot_packed_byte_array_operator_index_const(const godot_pa
 
 void GDAPI godot_packed_int32_array_new(godot_packed_int32_array *p_self) {
 	memnew_placement(p_self, PackedInt32Array);
+}
+
+void GDAPI godot_packed_int32_array_new_copy(godot_packed_int32_array *r_dest, const godot_packed_int32_array *p_src) {
+	memnew_placement(r_dest, PackedInt32Array(*(PackedInt32Array *)p_src));
 }
 
 void GDAPI godot_packed_int32_array_destroy(godot_packed_int32_array *p_self) {
@@ -99,6 +107,10 @@ void GDAPI godot_packed_int64_array_new(godot_packed_int64_array *p_self) {
 	memnew_placement(p_self, PackedInt64Array);
 }
 
+void GDAPI godot_packed_int64_array_new_copy(godot_packed_int64_array *r_dest, const godot_packed_int64_array *p_src) {
+	memnew_placement(r_dest, PackedInt64Array(*(PackedInt64Array *)p_src));
+}
+
 void GDAPI godot_packed_int64_array_destroy(godot_packed_int64_array *p_self) {
 	((PackedInt64Array *)p_self)->~PackedInt64Array();
 }
@@ -117,6 +129,10 @@ const int64_t GDAPI *godot_packed_int64_array_operator_index_const(const godot_p
 
 void GDAPI godot_packed_float32_array_new(godot_packed_float32_array *p_self) {
 	memnew_placement(p_self, PackedFloat32Array);
+}
+
+void GDAPI godot_packed_float32_array_new_copy(godot_packed_float32_array *r_dest, const godot_packed_float32_array *p_src) {
+	memnew_placement(r_dest, PackedFloat32Array(*(PackedFloat32Array *)p_src));
 }
 
 void GDAPI godot_packed_float32_array_destroy(godot_packed_float32_array *p_self) {
@@ -139,6 +155,10 @@ void GDAPI godot_packed_float64_array_new(godot_packed_float64_array *p_self) {
 	memnew_placement(p_self, PackedFloat64Array);
 }
 
+void GDAPI godot_packed_float64_array_new_copy(godot_packed_float64_array *r_dest, const godot_packed_float64_array *p_src) {
+	memnew_placement(r_dest, PackedFloat64Array(*(PackedFloat64Array *)p_src));
+}
+
 void GDAPI godot_packed_float64_array_destroy(godot_packed_float64_array *p_self) {
 	((PackedFloat64Array *)p_self)->~PackedFloat64Array();
 }
@@ -157,6 +177,10 @@ const double GDAPI *godot_packed_float64_array_operator_index_const(const godot_
 
 void GDAPI godot_packed_string_array_new(godot_packed_string_array *p_self) {
 	memnew_placement(p_self, PackedStringArray);
+}
+
+void GDAPI godot_packed_string_array_new_copy(godot_packed_string_array *r_dest, const godot_packed_string_array *p_src) {
+	memnew_placement(r_dest, PackedStringArray(*(PackedStringArray *)p_src));
 }
 
 void GDAPI godot_packed_string_array_destroy(godot_packed_string_array *p_self) {
@@ -179,6 +203,10 @@ void GDAPI godot_packed_vector2_array_new(godot_packed_vector2_array *p_self) {
 	memnew_placement(p_self, PackedVector2Array);
 }
 
+void GDAPI godot_packed_vector2_array_new_copy(godot_packed_vector2_array *r_dest, const godot_packed_vector2_array *p_src) {
+	memnew_placement(r_dest, PackedVector2Array(*(PackedVector2Array *)p_src));
+}
+
 void GDAPI godot_packed_vector2_array_destroy(godot_packed_vector2_array *p_self) {
 	((PackedVector2Array *)p_self)->~PackedVector2Array();
 }
@@ -197,6 +225,10 @@ const godot_vector2 GDAPI *godot_packed_vector2_array_operator_index_const(const
 
 void GDAPI godot_packed_vector2i_array_new(godot_packed_vector2i_array *p_self) {
 	memnew_placement(p_self, Vector<Vector2i>);
+}
+
+void GDAPI godot_packed_vector2i_array_new_copy(godot_packed_vector2i_array *r_dest, const godot_packed_vector2i_array *p_src) {
+	memnew_placement(r_dest, Vector<Vector2i>(*(Vector<Vector2i> *)p_src));
 }
 
 void GDAPI godot_packed_vector2i_array_destroy(godot_packed_vector2i_array *p_self) {
@@ -219,6 +251,10 @@ void GDAPI godot_packed_vector3_array_new(godot_packed_vector3_array *p_self) {
 	memnew_placement(p_self, PackedVector3Array);
 }
 
+void GDAPI godot_packed_vector3_array_new_copy(godot_packed_vector3_array *r_dest, const godot_packed_vector3_array *p_src) {
+	memnew_placement(r_dest, PackedVector3Array(*(PackedVector3Array *)p_src));
+}
+
 void GDAPI godot_packed_vector3_array_destroy(godot_packed_vector3_array *p_self) {
 	((PackedVector3Array *)p_self)->~PackedVector3Array();
 }
@@ -239,6 +275,10 @@ void GDAPI godot_packed_vector3i_array_new(godot_packed_vector3i_array *p_self) 
 	memnew_placement(p_self, Vector<Vector3i>);
 }
 
+void GDAPI godot_packed_vector3i_array_new_copy(godot_packed_vector3i_array *r_dest, const godot_packed_vector3i_array *p_src) {
+	memnew_placement(r_dest, Vector<Vector3i>(*(Vector<Vector3i> *)p_src));
+}
+
 void GDAPI godot_packed_vector3i_array_destroy(godot_packed_vector3i_array *p_self) {
 	((Vector<Vector3i> *)p_self)->~Vector();
 }
@@ -257,6 +297,10 @@ const godot_vector3i GDAPI *godot_packed_vector3i_array_operator_index_const(con
 
 void GDAPI godot_packed_color_array_new(godot_packed_color_array *p_self) {
 	memnew_placement(p_self, PackedColorArray);
+}
+
+void GDAPI godot_packed_color_array_new_copy(godot_packed_color_array *r_dest, const godot_packed_color_array *p_src) {
+	memnew_placement(r_dest, PackedColorArray(*(PackedColorArray *)p_src));
 }
 
 void GDAPI godot_packed_color_array_destroy(godot_packed_color_array *p_self) {

--- a/modules/gdnative/gdnative/plane.cpp
+++ b/modules/gdnative/gdnative/plane.cpp
@@ -42,6 +42,10 @@ void GDAPI godot_plane_new(godot_plane *p_self) {
 	memnew_placement(p_self, Plane);
 }
 
+void GDAPI godot_plane_new_copy(godot_plane *r_dest, const godot_plane *p_src) {
+	memnew_placement(r_dest, Plane(*(Plane *)p_src));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/gdnative/gdnative/quat.cpp
+++ b/modules/gdnative/gdnative/quat.cpp
@@ -42,6 +42,10 @@ void GDAPI godot_quat_new(godot_quat *p_self) {
 	memnew_placement(p_self, Quat);
 }
 
+void GDAPI godot_quat_new_copy(godot_quat *r_dest, const godot_quat *p_src) {
+	memnew_placement(r_dest, Quat(*(Quat *)p_src));
+}
+
 godot_real_t GDAPI *godot_quat_operator_index(godot_quat *p_self, godot_int p_index) {
 	Quat *self = (Quat *)p_self;
 	return (godot_real_t *)&self->operator[](p_index);

--- a/modules/gdnative/gdnative/rect2.cpp
+++ b/modules/gdnative/gdnative/rect2.cpp
@@ -43,8 +43,16 @@ void GDAPI godot_rect2_new(godot_rect2 *p_self) {
 	memnew_placement(p_self, Rect2);
 }
 
+void GDAPI godot_rect2_new_copy(godot_rect2 *r_dest, const godot_rect2 *p_src) {
+	memnew_placement(r_dest, Rect2(*(Rect2 *)p_src));
+}
+
 void GDAPI godot_rect2i_new(godot_rect2i *p_self) {
 	memnew_placement(p_self, Rect2i);
+}
+
+void GDAPI godot_rect2i_new_copy(godot_rect2i *r_dest, const godot_rect2i *p_src) {
+	memnew_placement(r_dest, Rect2i(*(Rect2i *)p_src));
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/gdnative/rid.cpp
+++ b/modules/gdnative/gdnative/rid.cpp
@@ -43,6 +43,10 @@ void GDAPI godot_rid_new(godot_rid *p_self) {
 	memnew_placement(p_self, RID);
 }
 
+void GDAPI godot_rid_new_copy(godot_rid *r_dest, const godot_rid *p_src) {
+	memnew_placement(r_dest, RID(*(RID *)p_src));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/gdnative/gdnative/signal.cpp
+++ b/modules/gdnative/gdnative/signal.cpp
@@ -43,6 +43,10 @@ void GDAPI godot_signal_new(godot_signal *p_self) {
 	memnew_placement(p_self, Signal);
 }
 
+void GDAPI godot_signal_new_copy(godot_signal *r_dest, const godot_signal *p_src) {
+	memnew_placement(r_dest, Signal(*(Signal *)p_src));
+}
+
 void GDAPI godot_signal_destroy(godot_signal *p_self) {
 	Signal *self = (Signal *)p_self;
 	self->~Signal();

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -45,10 +45,7 @@ void GDAPI godot_string_new(godot_string *r_dest) {
 }
 
 void GDAPI godot_string_new_copy(godot_string *r_dest, const godot_string *p_src) {
-	String *dest = (String *)r_dest;
-	const String *src = (const String *)p_src;
-	memnew_placement(dest, String);
-	*dest = String(*src);
+	memnew_placement(r_dest, String(*(String *)p_src));
 }
 
 void GDAPI godot_string_new_with_latin1_chars(godot_string *r_dest, const char *p_contents) {
@@ -123,6 +120,45 @@ void GDAPI godot_string_new_with_wide_chars_and_len(godot_string *r_dest, const 
 		memnew_placement(dest, String);
 		*dest = String((const char32_t *)p_contents, p_size);
 	}
+}
+
+const char GDAPI *godot_string_to_latin1_chars(const godot_string *p_self) {
+	String *self = (String *)p_self;
+	return self->ascii(true).get_data();
+}
+
+const char GDAPI *godot_string_to_utf8_chars(const godot_string *p_self) {
+	String *self = (String *)p_self;
+	return self->utf8().get_data();
+}
+
+const char16_t GDAPI *godot_string_to_utf16_chars(const godot_string *p_self) {
+	String *self = (String *)p_self;
+	return self->utf16().get_data();
+}
+
+const char32_t GDAPI *godot_string_to_utf32_chars(const godot_string *p_self) {
+	String *self = (String *)p_self;
+	return self->get_data();
+}
+
+const wchar_t GDAPI *godot_string_to_wide_chars(const godot_string *p_self) {
+	String *self = (String *)p_self;
+	if (sizeof(wchar_t) == 2) {
+		return (const wchar_t *)self->utf16().get_data();
+	} else {
+		return (const wchar_t *)self->get_data();
+	}
+}
+
+char32_t GDAPI *godot_string_operator_index(godot_string *p_self, godot_int p_index) {
+	String *self = (String *)p_self;
+	return self->ptrw();
+}
+
+const char32_t GDAPI *godot_string_operator_index_const(const godot_string *p_self, godot_int p_index) {
+	const String *self = (const String *)p_self;
+	return self->ptr();
 }
 
 void GDAPI godot_string_destroy(godot_string *p_self) {

--- a/modules/gdnative/gdnative/string_name.cpp
+++ b/modules/gdnative/gdnative/string_name.cpp
@@ -44,9 +44,7 @@ void GDAPI godot_string_name_new(godot_string_name *r_dest) {
 }
 
 void GDAPI godot_string_name_new_copy(godot_string_name *r_dest, const godot_string_name *p_src) {
-	StringName *dest = (StringName *)r_dest;
-	const StringName *src = (const StringName *)p_src;
-	memnew_placement(dest, StringName(*src));
+	memnew_placement(r_dest, StringName(*(StringName *)p_src));
 }
 
 void GDAPI godot_string_name_new_with_latin1_chars(godot_string_name *r_dest, const char *p_contents) {

--- a/modules/gdnative/gdnative/transform.cpp
+++ b/modules/gdnative/gdnative/transform.cpp
@@ -42,6 +42,10 @@ void GDAPI godot_transform_new(godot_transform *p_self) {
 	memnew_placement(p_self, Transform);
 }
 
+void GDAPI godot_transform_new_copy(godot_transform *r_dest, const godot_transform *p_src) {
+	memnew_placement(r_dest, Transform(*(Transform *)p_src));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/gdnative/gdnative/transform2d.cpp
+++ b/modules/gdnative/gdnative/transform2d.cpp
@@ -42,6 +42,10 @@ void GDAPI godot_transform2d_new(godot_transform2d *p_self) {
 	memnew_placement(p_self, Transform2D);
 }
 
+void GDAPI godot_transform2d_new_copy(godot_transform2d *r_dest, const godot_transform2d *p_src) {
+	memnew_placement(r_dest, Transform2D(*(Transform2D *)p_src));
+}
+
 godot_vector2 GDAPI *godot_transform2d_operator_index(godot_transform2d *p_self, godot_int p_index) {
 	Transform2D *self = (Transform2D *)p_self;
 	return (godot_vector2 *)&self->operator[](p_index);

--- a/modules/gdnative/gdnative/variant.cpp
+++ b/modules/gdnative/gdnative/variant.cpp
@@ -599,7 +599,7 @@ void GDAPI godot_variant_call_static(godot_variant_type p_type, const godot_stri
 	const Variant **args = (const Variant **)p_args;
 	Variant ret;
 	Callable::CallError error;
-	Variant().call_static(type, *method, args, p_argcount, ret, error);
+	Variant::call_static(type, *method, args, p_argcount, ret, error);
 	memnew_placement_custom(r_return, Variant, Variant(ret));
 
 	if (r_error) {
@@ -615,7 +615,7 @@ void GDAPI godot_variant_call_static_with_cstring(godot_variant_type p_type, con
 	const Variant **args = (const Variant **)p_args;
 	Variant ret;
 	Callable::CallError error;
-	Variant().call_static(type, method, args, p_argcount, ret, error);
+	Variant::call_static(type, method, args, p_argcount, ret, error);
 	memnew_placement_custom(r_return, Variant, Variant(ret));
 
 	if (r_error) {

--- a/modules/gdnative/gdnative/variant.cpp
+++ b/modules/gdnative/gdnative/variant.cpp
@@ -577,6 +577,54 @@ void GDAPI godot_variant_call(godot_variant *p_self, const godot_string_name *p_
 	}
 }
 
+void GDAPI godot_variant_call_with_cstring(godot_variant *p_self, const char *p_method, const godot_variant **p_args, const godot_int p_argcount, godot_variant *r_return, godot_variant_call_error *r_error) {
+	Variant *self = (Variant *)p_self;
+	const StringName method(p_method);
+	const Variant **args = (const Variant **)p_args;
+	Variant ret;
+	Callable::CallError error;
+	self->call(method, args, p_argcount, ret, error);
+	memnew_placement_custom(r_return, Variant, Variant(ret));
+
+	if (r_error) {
+		r_error->error = (godot_variant_call_error_error)error.error;
+		r_error->argument = error.argument;
+		r_error->expected = (godot_variant_type)error.expected;
+	}
+}
+
+void GDAPI godot_variant_call_static(godot_variant_type p_type, const godot_string_name *p_method, const godot_variant **p_args, const godot_int p_argcount, godot_variant *r_return, godot_variant_call_error *r_error) {
+	Variant::Type type = (Variant::Type)p_type;
+	const StringName *method = (const StringName *)p_method;
+	const Variant **args = (const Variant **)p_args;
+	Variant ret;
+	Callable::CallError error;
+	Variant().call_static(type, *method, args, p_argcount, ret, error);
+	memnew_placement_custom(r_return, Variant, Variant(ret));
+
+	if (r_error) {
+		r_error->error = (godot_variant_call_error_error)error.error;
+		r_error->argument = error.argument;
+		r_error->expected = (godot_variant_type)error.expected;
+	}
+}
+
+void GDAPI godot_variant_call_static_with_cstring(godot_variant_type p_type, const char *p_method, const godot_variant **p_args, const godot_int p_argcount, godot_variant *r_return, godot_variant_call_error *r_error) {
+	Variant::Type type = (Variant::Type)p_type;
+	const StringName method(p_method);
+	const Variant **args = (const Variant **)p_args;
+	Variant ret;
+	Callable::CallError error;
+	Variant().call_static(type, method, args, p_argcount, ret, error);
+	memnew_placement_custom(r_return, Variant, Variant(ret));
+
+	if (r_error) {
+		r_error->error = (godot_variant_call_error_error)error.error;
+		r_error->argument = error.argument;
+		r_error->expected = (godot_variant_type)error.expected;
+	}
+}
+
 void GDAPI godot_variant_evaluate(godot_variant_operator p_op, const godot_variant *p_a, const godot_variant *p_b, godot_variant *r_return, bool *r_valid) {
 	Variant::Operator op = (Variant::Operator)p_op;
 	const Variant *a = (const Variant *)p_a;
@@ -593,12 +641,20 @@ void GDAPI godot_variant_set(godot_variant *p_self, const godot_variant *p_key, 
 	self->set(*key, *value, r_valid);
 }
 
-void GDAPI godot_variant_set_named(godot_variant *p_self, const godot_string_name *p_name, const godot_variant *p_value, bool *r_valid) {
+void GDAPI godot_variant_set_named(godot_variant *p_self, const godot_string_name *p_key, const godot_variant *p_value, bool *r_valid) {
 	Variant *self = (Variant *)p_self;
-	const StringName *name = (const StringName *)p_name;
+	const StringName *key = (const StringName *)p_key;
 	const Variant *value = (const Variant *)p_value;
 
-	self->set_named(*name, *value, *r_valid);
+	self->set_named(*key, *value, *r_valid);
+}
+
+void GDAPI godot_variant_set_named_with_cstring(godot_variant *p_self, const char *p_key, const godot_variant *p_value, bool *r_valid) {
+	Variant *self = (Variant *)p_self;
+	const StringName key(p_key);
+	const Variant *value = (const Variant *)p_value;
+
+	self->set_named(key, *value, *r_valid);
 }
 
 void GDAPI godot_variant_set_keyed(godot_variant *p_self, const godot_variant *p_key, const godot_variant *p_value, bool *r_valid) {
@@ -628,6 +684,17 @@ godot_variant GDAPI godot_variant_get(const godot_variant *p_self, const godot_v
 }
 
 godot_variant GDAPI godot_variant_get_named(const godot_variant *p_self, const godot_string_name *p_key, bool *r_valid) {
+	const Variant *self = (const Variant *)p_self;
+	const StringName *key = (const StringName *)p_key;
+	Variant ret;
+
+	ret = self->get_named(*key, *r_valid);
+	godot_variant result;
+	memnew_placement_custom(&result, Variant, Variant(ret));
+	return result;
+}
+
+godot_variant GDAPI godot_variant_get_named_with_cstring(const godot_variant *p_self, const char *p_key, bool *r_valid) {
 	const Variant *self = (const Variant *)p_self;
 	const StringName *key = (const StringName *)p_key;
 	Variant ret;
@@ -822,6 +889,14 @@ bool GDAPI godot_variant_is_builtin_method_const(godot_variant_type p_type, cons
 
 bool GDAPI godot_variant_is_builtin_method_const_with_cstring(godot_variant_type p_type, const char *p_method) {
 	return Variant::is_builtin_method_const((Variant::Type)p_type, StringName(p_method));
+}
+
+bool GDAPI godot_variant_is_builtin_method_static(godot_variant_type p_type, const godot_string_name *p_method) {
+	return Variant::is_builtin_method_static((Variant::Type)p_type, *((const StringName *)p_method));
+}
+
+bool GDAPI godot_variant_is_builtin_method_static_with_cstring(godot_variant_type p_type, const char *p_method) {
+	return Variant::is_builtin_method_static((Variant::Type)p_type, StringName(p_method));
 }
 
 bool GDAPI godot_variant_is_builtin_method_vararg(godot_variant_type p_type, const godot_string_name *p_method) {

--- a/modules/gdnative/gdnative/vector2.cpp
+++ b/modules/gdnative/gdnative/vector2.cpp
@@ -43,8 +43,16 @@ void GDAPI godot_vector2_new(godot_vector2 *p_self) {
 	memnew_placement(p_self, Vector2);
 }
 
+void GDAPI godot_vector2_new_copy(godot_vector2 *r_dest, const godot_vector2 *p_src) {
+	memnew_placement(r_dest, Vector2(*(Vector2 *)p_src));
+}
+
 void GDAPI godot_vector2i_new(godot_vector2i *p_self) {
 	memnew_placement(p_self, Vector2i);
+}
+
+void GDAPI godot_vector2i_new_copy(godot_vector2i *r_dest, const godot_vector2i *p_src) {
+	memnew_placement(r_dest, Vector2i(*(Vector2i *)p_src));
 }
 
 godot_real_t GDAPI *godot_vector2_operator_index(godot_vector2 *p_self, godot_int p_index) {

--- a/modules/gdnative/gdnative/vector3.cpp
+++ b/modules/gdnative/gdnative/vector3.cpp
@@ -43,8 +43,16 @@ void GDAPI godot_vector3_new(godot_vector3 *p_self) {
 	memnew_placement(p_self, Vector3);
 }
 
+void GDAPI godot_vector3_new_copy(godot_vector3 *r_dest, const godot_vector3 *p_src) {
+	memnew_placement(r_dest, Vector3(*(Vector3 *)p_src));
+}
+
 void GDAPI godot_vector3i_new(godot_vector3i *p_self) {
 	memnew_placement(p_self, Vector3i);
+}
+
+void GDAPI godot_vector3i_new_copy(godot_vector3i *r_dest, const godot_vector3i *p_src) {
+	memnew_placement(r_dest, Vector3i(*(Vector3i *)p_src));
 }
 
 godot_real_t GDAPI *godot_vector3_operator_index(godot_vector3 *p_self, godot_int p_index) {

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -1143,6 +1143,36 @@
 				]
 			},
 			{
+				"name": "godot_variant_call_with_cstring",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_variant *",
+						"p_self"
+					],
+					[
+						"const char *",
+						"p_method"
+					],
+					[
+						"const godot_variant **",
+						"p_args"
+					],
+					[
+						"const godot_int",
+						"p_argument_count"
+					],
+					[
+						"godot_variant *",
+						"r_return"
+					],
+					[
+						"godot_variant_call_error *",
+						"r_error"
+					]
+				]
+			},
+			{
 				"name": "godot_variant_evaluate",
 				"return_type": "void",
 				"arguments": [
@@ -1200,7 +1230,29 @@
 					],
 					[
 						"const godot_string_name *",
-						"p_name"
+						"p_key"
+					],
+					[
+						"const godot_variant *",
+						"p_value"
+					],
+					[
+						"bool *",
+						"r_valid"
+					]
+				]
+			},
+			{
+				"name": "godot_variant_set_named_with_cstring",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_variant *",
+						"p_self"
+					],
+					[
+						"const char *",
+						"p_key"
 					],
 					[
 						"const godot_variant *",
@@ -1288,6 +1340,24 @@
 					],
 					[
 						"const godot_string_name *",
+						"p_key"
+					],
+					[
+						"bool *",
+						"r_valid"
+					]
+				]
+			},
+			{
+				"name": "godot_variant_get_named_with_cstring",
+				"return_type": "godot_variant",
+				"arguments": [
+					[
+						"const godot_variant *",
+						"p_self"
+					],
+					[
+						"const char *",
 						"p_key"
 					],
 					[
@@ -1802,6 +1872,34 @@
 			},
 			{
 				"name": "godot_variant_is_builtin_method_const_with_cstring",
+				"return_type": "bool",
+				"arguments": [
+					[
+						"godot_variant_type",
+						"p_type"
+					],
+					[
+						"const char *",
+						"p_method"
+					]
+				]
+			},
+			{
+				"name": "godot_variant_is_builtin_method_static",
+				"return_type": "bool",
+				"arguments": [
+					[
+						"godot_variant_type",
+						"p_type"
+					],
+					[
+						"const godot_string_name *",
+						"p_method"
+					]
+				]
+			},
+			{
+				"name": "godot_variant_is_builtin_method_static_with_cstring",
 				"return_type": "bool",
 				"arguments": [
 					[
@@ -2752,12 +2850,40 @@
 				]
 			},
 			{
+				"name": "godot_aabb_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_aabb *",
+						"r_dest"
+					],
+					[
+						"const godot_aabb *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_array_new",
 				"return_type": "void",
 				"arguments": [
 					[
 						"godot_array *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_array *",
+						"r_dest"
+					],
+					[
+						"const godot_array *",
+						"p_src"
 					]
 				]
 			},
@@ -2810,6 +2936,20 @@
 				]
 			},
 			{
+				"name": "godot_basis_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_basis *",
+						"r_dest"
+					],
+					[
+						"const godot_basis *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_basis_operator_index",
 				"return_type": "godot_vector3 *",
 				"arguments": [
@@ -2848,6 +2988,20 @@
 				]
 			},
 			{
+				"name": "godot_callable_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_callable *",
+						"r_dest"
+					],
+					[
+						"const godot_callable *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_callable_destroy",
 				"return_type": "void",
 				"arguments": [
@@ -2864,6 +3018,20 @@
 					[
 						"godot_color *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_color_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_color *",
+						"r_dest"
+					],
+					[
+						"const godot_color *",
+						"p_src"
 					]
 				]
 			},
@@ -2902,6 +3070,20 @@
 					[
 						"godot_dictionary *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_dictionary_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_dictionary *",
+						"r_dest"
+					],
+					[
+						"const godot_dictionary *",
+						"p_src"
 					]
 				]
 			},
@@ -2954,6 +3136,20 @@
 				]
 			},
 			{
+				"name": "godot_node_path_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_node_path *",
+						"r_dest"
+					],
+					[
+						"const godot_node_path *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_node_path_destroy",
 				"return_type": "void",
 				"arguments": [
@@ -2970,6 +3166,20 @@
 					[
 						"godot_packed_byte_array *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_packed_byte_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_byte_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_byte_array *",
+						"p_src"
 					]
 				]
 			},
@@ -3022,6 +3232,20 @@
 				]
 			},
 			{
+				"name": "godot_packed_int32_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_int32_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_int32_array *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_packed_int32_array_destroy",
 				"return_type": "void",
 				"arguments": [
@@ -3066,6 +3290,20 @@
 					[
 						"godot_packed_int64_array *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_packed_int64_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_int64_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_int64_array *",
+						"p_src"
 					]
 				]
 			},
@@ -3118,6 +3356,20 @@
 				]
 			},
 			{
+				"name": "godot_packed_float32_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_float32_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_float32_array *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_packed_float32_array_destroy",
 				"return_type": "void",
 				"arguments": [
@@ -3162,6 +3414,20 @@
 					[
 						"godot_packed_float64_array *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_packed_float64_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_float64_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_float64_array *",
+						"p_src"
 					]
 				]
 			},
@@ -3214,6 +3480,20 @@
 				]
 			},
 			{
+				"name": "godot_packed_string_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_string_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_string_array *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_packed_string_array_destroy",
 				"return_type": "void",
 				"arguments": [
@@ -3258,6 +3538,20 @@
 					[
 						"godot_packed_vector2_array *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_packed_vector2_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_vector2_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_vector2_array *",
+						"p_src"
 					]
 				]
 			},
@@ -3310,6 +3604,20 @@
 				]
 			},
 			{
+				"name": "godot_packed_vector2i_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_vector2i_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_vector2i_array *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_packed_vector2i_array_destroy",
 				"return_type": "void",
 				"arguments": [
@@ -3354,6 +3662,20 @@
 					[
 						"godot_packed_vector3_array *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_packed_vector3_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_vector3_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_vector3_array *",
+						"p_src"
 					]
 				]
 			},
@@ -3406,6 +3728,20 @@
 				]
 			},
 			{
+				"name": "godot_packed_vector3i_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_vector3i_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_vector3i_array *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_packed_vector3i_array_destroy",
 				"return_type": "void",
 				"arguments": [
@@ -3450,6 +3786,20 @@
 					[
 						"godot_packed_color_array *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_packed_color_array_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_packed_color_array *",
+						"r_dest"
+					],
+					[
+						"const godot_packed_color_array *",
+						"p_src"
 					]
 				]
 			},
@@ -3502,12 +3852,40 @@
 				]
 			},
 			{
+				"name": "godot_plane_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_plane *",
+						"r_dest"
+					],
+					[
+						"const godot_plane *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_quat_new",
 				"return_type": "void",
 				"arguments": [
 					[
 						"godot_quat *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_quat_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_quat *",
+						"r_dest"
+					],
+					[
+						"const godot_quat *",
+						"p_src"
 					]
 				]
 			},
@@ -3550,12 +3928,40 @@
 				]
 			},
 			{
+				"name": "godot_rect2_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_rect2 *",
+						"r_dest"
+					],
+					[
+						"const godot_rect2 *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_rect2i_new",
 				"return_type": "void",
 				"arguments": [
 					[
 						"godot_rect2i *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_rect2i_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_rect2i *",
+						"r_dest"
+					],
+					[
+						"const godot_rect2i *",
+						"p_src"
 					]
 				]
 			},
@@ -3570,12 +3976,40 @@
 				]
 			},
 			{
+				"name": "godot_rid_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_rid *",
+						"r_dest"
+					],
+					[
+						"const godot_rid *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_signal_new",
 				"return_type": "void",
 				"arguments": [
 					[
 						"godot_signal *",
 						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_signal_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_signal *",
+						"r_dest"
+					],
+					[
+						"const godot_signal *",
+						"p_src"
 					]
 				]
 			},
@@ -3784,6 +4218,84 @@
 				]
 			},
 			{
+				"name": "godot_string_to_latin1_chars",
+				"return_type": "const char *",
+				"arguments": [
+					[
+						"const godot_string *",
+						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_string_to_utf8_chars",
+				"return_type": "const char *",
+				"arguments": [
+					[
+						"const godot_string *",
+						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_string_to_utf16_chars",
+				"return_type": "const char16_t *",
+				"arguments": [
+					[
+						"const godot_string *",
+						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_string_to_utf32_chars",
+				"return_type": "const char32_t *",
+				"arguments": [
+					[
+						"const godot_string *",
+						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_string_to_wide_chars",
+				"return_type": "const wchar_t *",
+				"arguments": [
+					[
+						"const godot_string *",
+						"p_self"
+					]
+				]
+			},
+			{
+				"name": "godot_string_operator_index",
+				"return_type": "char32_t *",
+				"arguments": [
+					[
+						"godot_string *",
+						"p_self"
+					],
+					[
+						"godot_int",
+						"p_index"
+					]
+				]
+			},
+			{
+				"name": "godot_string_operator_index_const",
+				"return_type": "const char32_t *",
+				"arguments": [
+					[
+						"const godot_string *",
+						"p_self"
+					],
+					[
+						"godot_int",
+						"p_index"
+					]
+				]
+			},
+			{
 				"name": "godot_string_name_new",
 				"return_type": "void",
 				"arguments": [
@@ -3842,12 +4354,40 @@
 				]
 			},
 			{
+				"name": "godot_transform_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_transform *",
+						"r_dest"
+					],
+					[
+						"const godot_transform *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_transform2d_new",
 				"return_type": "void",
 				"arguments": [
 					[
 						"godot_transform2d *",
 						"r_dest"
+					]
+				]
+			},
+			{
+				"name": "godot_transform2d_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_transform2d *",
+						"r_dest"
+					],
+					[
+						"const godot_transform2d *",
+						"p_src"
 					]
 				]
 			},
@@ -3890,6 +4430,20 @@
 				]
 			},
 			{
+				"name": "godot_vector2_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_vector2 *",
+						"r_dest"
+					],
+					[
+						"const godot_vector2 *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_vector2_operator_index",
 				"return_type": "godot_real_t *",
 				"arguments": [
@@ -3924,6 +4478,20 @@
 					[
 						"godot_vector2i *",
 						"r_dest"
+					]
+				]
+			},
+			{
+				"name": "godot_vector2i_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_vector2i *",
+						"r_dest"
+					],
+					[
+						"const godot_vector2i *",
+						"p_src"
 					]
 				]
 			},
@@ -3966,6 +4534,20 @@
 				]
 			},
 			{
+				"name": "godot_vector3_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_vector3 *",
+						"r_dest"
+					],
+					[
+						"const godot_vector3 *",
+						"p_src"
+					]
+				]
+			},
+			{
 				"name": "godot_vector3_operator_index",
 				"return_type": "godot_real_t *",
 				"arguments": [
@@ -4000,6 +4582,20 @@
 					[
 						"godot_vector3i *",
 						"r_dest"
+					]
+				]
+			},
+			{
+				"name": "godot_vector3i_new_copy",
+				"return_type": "void",
+				"arguments": [
+					[
+						"godot_vector3i *",
+						"r_dest"
+					],
+					[
+						"const godot_vector3i *",
+						"p_src"
 					]
 				]
 			},

--- a/modules/gdnative/include/gdnative/aabb.h
+++ b/modules/gdnative/include/gdnative/aabb.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_aabb_new(godot_aabb *p_self);
+void GDAPI godot_aabb_new_copy(godot_aabb *r_dest, const godot_aabb *p_src);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/gdnative/array.h
+++ b/modules/gdnative/include/gdnative/array.h
@@ -50,6 +50,7 @@ typedef struct {
 #include <gdnative/variant_struct.h>
 
 void GDAPI godot_array_new(godot_array *p_self);
+void GDAPI godot_array_new_copy(godot_array *r_dest, const godot_array *p_src);
 void GDAPI godot_array_destroy(godot_array *p_self);
 godot_variant GDAPI *godot_array_operator_index(godot_array *p_self, godot_int p_index);
 const godot_variant GDAPI *godot_array_operator_index_const(const godot_array *p_self, godot_int p_index);

--- a/modules/gdnative/include/gdnative/basis.h
+++ b/modules/gdnative/include/gdnative/basis.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_basis_new(godot_basis *p_self);
+void GDAPI godot_basis_new_copy(godot_basis *r_dest, const godot_basis *p_src);
 godot_vector3 GDAPI *godot_basis_operator_index(godot_basis *p_self, godot_int p_index);
 const godot_vector3 GDAPI *godot_basis_operator_index_const(const godot_basis *p_self, godot_int p_index);
 

--- a/modules/gdnative/include/gdnative/callable.h
+++ b/modules/gdnative/include/gdnative/callable.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_callable_new(godot_callable *p_self);
+void GDAPI godot_callable_new_copy(godot_callable *r_dest, const godot_callable *p_src);
 void GDAPI godot_callable_destroy(godot_callable *p_self);
 
 #ifdef __cplusplus

--- a/modules/gdnative/include/gdnative/color.h
+++ b/modules/gdnative/include/gdnative/color.h
@@ -50,6 +50,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_color_new(godot_color *p_self);
+void GDAPI godot_color_new_copy(godot_color *r_dest, const godot_color *p_src);
 float GDAPI *godot_color_operator_index(godot_color *p_self, godot_int p_index);
 const float GDAPI *godot_color_operator_index_const(const godot_color *p_self, godot_int p_index);
 

--- a/modules/gdnative/include/gdnative/dictionary.h
+++ b/modules/gdnative/include/gdnative/dictionary.h
@@ -50,6 +50,7 @@ typedef struct {
 #include <gdnative/variant_struct.h>
 
 void GDAPI godot_dictionary_new(godot_dictionary *p_self);
+void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *p_src);
 void GDAPI godot_dictionary_destroy(godot_dictionary *p_self);
 godot_variant GDAPI *godot_dictionary_operator_index(godot_dictionary *p_self, const godot_variant *p_key);
 const godot_variant GDAPI *godot_dictionary_operator_index_const(const godot_dictionary *p_self, const godot_variant *p_key);

--- a/modules/gdnative/include/gdnative/node_path.h
+++ b/modules/gdnative/include/gdnative/node_path.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_node_path_new(godot_node_path *p_self);
+void GDAPI godot_node_path_new_copy(godot_node_path *r_dest, const godot_node_path *p_src);
 void GDAPI godot_node_path_destroy(godot_node_path *p_self);
 
 #ifdef __cplusplus

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -163,6 +163,7 @@ typedef struct {
 // Byte.
 
 void GDAPI godot_packed_byte_array_new(godot_packed_byte_array *p_self);
+void GDAPI godot_packed_byte_array_new_copy(godot_packed_byte_array *r_dest, const godot_packed_byte_array *p_src);
 void GDAPI godot_packed_byte_array_destroy(godot_packed_byte_array *p_self);
 uint8_t GDAPI *godot_packed_byte_array_operator_index(godot_packed_byte_array *p_self, godot_int p_index);
 const uint8_t GDAPI *godot_packed_byte_array_operator_index_const(const godot_packed_byte_array *p_self, godot_int p_index);
@@ -170,6 +171,7 @@ const uint8_t GDAPI *godot_packed_byte_array_operator_index_const(const godot_pa
 // Int32.
 
 void GDAPI godot_packed_int32_array_new(godot_packed_int32_array *p_self);
+void GDAPI godot_packed_int32_array_new_copy(godot_packed_int32_array *r_dest, const godot_packed_int32_array *p_src);
 void GDAPI godot_packed_int32_array_destroy(godot_packed_int32_array *p_self);
 int32_t GDAPI *godot_packed_int32_array_operator_index(godot_packed_int32_array *p_self, godot_int p_index);
 const int32_t GDAPI *godot_packed_int32_array_operator_index_const(const godot_packed_int32_array *p_self, godot_int p_index);
@@ -177,6 +179,7 @@ const int32_t GDAPI *godot_packed_int32_array_operator_index_const(const godot_p
 // Int64.
 
 void GDAPI godot_packed_int64_array_new(godot_packed_int64_array *p_self);
+void GDAPI godot_packed_int64_array_new_copy(godot_packed_int64_array *r_dest, const godot_packed_int64_array *p_src);
 void GDAPI godot_packed_int64_array_destroy(godot_packed_int64_array *p_self);
 int64_t GDAPI *godot_packed_int64_array_operator_index(godot_packed_int64_array *p_self, godot_int p_index);
 const int64_t GDAPI *godot_packed_int64_array_operator_index_const(const godot_packed_int64_array *p_self, godot_int p_index);
@@ -184,6 +187,7 @@ const int64_t GDAPI *godot_packed_int64_array_operator_index_const(const godot_p
 // Float32.
 
 void GDAPI godot_packed_float32_array_new(godot_packed_float32_array *p_self);
+void GDAPI godot_packed_float32_array_new_copy(godot_packed_float32_array *r_dest, const godot_packed_float32_array *p_src);
 void GDAPI godot_packed_float32_array_destroy(godot_packed_float32_array *p_self);
 float GDAPI *godot_packed_float32_array_operator_index(godot_packed_float32_array *p_self, godot_int p_index);
 const float GDAPI *godot_packed_float32_array_operator_index_const(const godot_packed_float32_array *p_self, godot_int p_index);
@@ -191,6 +195,7 @@ const float GDAPI *godot_packed_float32_array_operator_index_const(const godot_p
 // Float64.
 
 void GDAPI godot_packed_float64_array_new(godot_packed_float64_array *p_self);
+void GDAPI godot_packed_float64_array_new_copy(godot_packed_float64_array *r_dest, const godot_packed_float64_array *p_src);
 void GDAPI godot_packed_float64_array_destroy(godot_packed_float64_array *p_self);
 double GDAPI *godot_packed_float64_array_operator_index(godot_packed_float64_array *p_self, godot_int p_index);
 const double GDAPI *godot_packed_float64_array_operator_index_const(const godot_packed_float64_array *p_self, godot_int p_index);
@@ -198,6 +203,7 @@ const double GDAPI *godot_packed_float64_array_operator_index_const(const godot_
 // String.
 
 void GDAPI godot_packed_string_array_new(godot_packed_string_array *p_self);
+void GDAPI godot_packed_string_array_new_copy(godot_packed_string_array *r_dest, const godot_packed_string_array *p_src);
 void GDAPI godot_packed_string_array_destroy(godot_packed_string_array *p_self);
 godot_string GDAPI *godot_packed_string_array_operator_index(godot_packed_string_array *p_self, godot_int p_index);
 const godot_string GDAPI *godot_packed_string_array_operator_index_const(const godot_packed_string_array *p_self, godot_int p_index);
@@ -205,6 +211,7 @@ const godot_string GDAPI *godot_packed_string_array_operator_index_const(const g
 // Vector2.
 
 void GDAPI godot_packed_vector2_array_new(godot_packed_vector2_array *p_self);
+void GDAPI godot_packed_vector2_array_new_copy(godot_packed_vector2_array *r_dest, const godot_packed_vector2_array *p_src);
 void GDAPI godot_packed_vector2_array_destroy(godot_packed_vector2_array *p_self);
 godot_vector2 GDAPI *godot_packed_vector2_array_operator_index(godot_packed_vector2_array *p_self, godot_int p_index);
 const godot_vector2 GDAPI *godot_packed_vector2_array_operator_index_const(const godot_packed_vector2_array *p_self, godot_int p_index);
@@ -212,6 +219,7 @@ const godot_vector2 GDAPI *godot_packed_vector2_array_operator_index_const(const
 // Vector2i.
 
 void GDAPI godot_packed_vector2i_array_new(godot_packed_vector2i_array *p_self);
+void GDAPI godot_packed_vector2i_array_new_copy(godot_packed_vector2i_array *r_dest, const godot_packed_vector2i_array *p_src);
 void GDAPI godot_packed_vector2i_array_destroy(godot_packed_vector2i_array *p_self);
 godot_vector2i GDAPI *godot_packed_vector2i_array_operator_index(godot_packed_vector2i_array *p_self, godot_int p_index);
 const godot_vector2i GDAPI *godot_packed_vector2i_array_operator_index_const(const godot_packed_vector2i_array *p_self, godot_int p_index);
@@ -219,6 +227,7 @@ const godot_vector2i GDAPI *godot_packed_vector2i_array_operator_index_const(con
 // Vector3.
 
 void GDAPI godot_packed_vector3_array_new(godot_packed_vector3_array *p_self);
+void GDAPI godot_packed_vector3_array_new_copy(godot_packed_vector3_array *r_dest, const godot_packed_vector3_array *p_src);
 void GDAPI godot_packed_vector3_array_destroy(godot_packed_vector3_array *p_self);
 godot_vector3 GDAPI *godot_packed_vector3_array_operator_index(godot_packed_vector3_array *p_self, godot_int p_index);
 const godot_vector3 GDAPI *godot_packed_vector3_array_operator_index_const(const godot_packed_vector3_array *p_self, godot_int p_index);
@@ -226,6 +235,7 @@ const godot_vector3 GDAPI *godot_packed_vector3_array_operator_index_const(const
 // Vector3i.
 
 void GDAPI godot_packed_vector3i_array_new(godot_packed_vector3i_array *p_self);
+void GDAPI godot_packed_vector3i_array_new_copy(godot_packed_vector3i_array *r_dest, const godot_packed_vector3i_array *p_src);
 void GDAPI godot_packed_vector3i_array_destroy(godot_packed_vector3i_array *p_self);
 godot_vector3i GDAPI *godot_packed_vector3i_array_operator_index(godot_packed_vector3i_array *p_self, godot_int p_index);
 const godot_vector3i GDAPI *godot_packed_vector3i_array_operator_index_const(const godot_packed_vector3i_array *p_self, godot_int p_index);
@@ -233,6 +243,7 @@ const godot_vector3i GDAPI *godot_packed_vector3i_array_operator_index_const(con
 // Color.
 
 void GDAPI godot_packed_color_array_new(godot_packed_color_array *p_self);
+void GDAPI godot_packed_color_array_new_copy(godot_packed_color_array *r_dest, const godot_packed_color_array *p_src);
 void GDAPI godot_packed_color_array_destroy(godot_packed_color_array *p_self);
 godot_color GDAPI *godot_packed_color_array_operator_index(godot_packed_color_array *p_self, godot_int p_index);
 const godot_color GDAPI *godot_packed_color_array_operator_index_const(const godot_packed_color_array *p_self, godot_int p_index);

--- a/modules/gdnative/include/gdnative/plane.h
+++ b/modules/gdnative/include/gdnative/plane.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_plane_new(godot_plane *p_self);
+void GDAPI godot_plane_new_copy(godot_plane *r_dest, const godot_plane *p_src);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/gdnative/quat.h
+++ b/modules/gdnative/include/gdnative/quat.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_quat_new(godot_quat *p_self);
+void GDAPI godot_quat_new_copy(godot_quat *r_dest, const godot_quat *p_src);
 godot_real_t GDAPI *godot_quat_operator_index(godot_quat *p_self, godot_int p_index);
 const godot_real_t GDAPI *godot_quat_operator_index_const(const godot_quat *p_self, godot_int p_index);
 

--- a/modules/gdnative/include/gdnative/rect2.h
+++ b/modules/gdnative/include/gdnative/rect2.h
@@ -58,7 +58,9 @@ typedef struct godot_rect2i {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_rect2_new(godot_rect2 *p_self);
+void GDAPI godot_rect2_new_copy(godot_rect2 *r_dest, const godot_rect2 *p_src);
 void GDAPI godot_rect2i_new(godot_rect2i *p_self);
+void GDAPI godot_rect2i_new_copy(godot_rect2i *r_dest, const godot_rect2i *p_src);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/gdnative/rid.h
+++ b/modules/gdnative/include/gdnative/rid.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_rid_new(godot_rid *p_self);
+void GDAPI godot_rid_new_copy(godot_rid *r_dest, const godot_rid *p_src);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/gdnative/signal.h
+++ b/modules/gdnative/include/gdnative/signal.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_signal_new(godot_signal *p_self);
+void GDAPI godot_signal_new_copy(godot_signal *r_dest, const godot_signal *p_src);
 void GDAPI godot_signal_destroy(godot_signal *p_self);
 
 #ifdef __cplusplus

--- a/modules/gdnative/include/gdnative/string.h
+++ b/modules/gdnative/include/gdnative/string.h
@@ -55,6 +55,7 @@ typedef struct {
 #endif
 
 #include <gdnative/gdnative.h>
+#include <gdnative/math_defs.h>
 
 void GDAPI godot_string_new(godot_string *r_dest);
 void GDAPI godot_string_new_copy(godot_string *r_dest, const godot_string *p_src);
@@ -71,6 +72,15 @@ void GDAPI godot_string_new_with_utf8_chars_and_len(godot_string *r_dest, const 
 void GDAPI godot_string_new_with_utf16_chars_and_len(godot_string *r_dest, const char16_t *p_contents, const int p_size);
 void GDAPI godot_string_new_with_utf32_chars_and_len(godot_string *r_dest, const char32_t *p_contents, const int p_size);
 void GDAPI godot_string_new_with_wide_chars_and_len(godot_string *r_dest, const wchar_t *p_contents, const int p_size);
+
+const char GDAPI *godot_string_to_latin1_chars(const godot_string *p_self);
+const char GDAPI *godot_string_to_utf8_chars(const godot_string *p_self);
+const char16_t GDAPI *godot_string_to_utf16_chars(const godot_string *p_self);
+const char32_t GDAPI *godot_string_to_utf32_chars(const godot_string *p_self);
+const wchar_t GDAPI *godot_string_to_wide_chars(const godot_string *p_self);
+
+char32_t GDAPI *godot_string_operator_index(godot_string *p_self, godot_int p_index);
+const char32_t GDAPI *godot_string_operator_index_const(const godot_string *p_self, godot_int p_index);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/gdnative/transform.h
+++ b/modules/gdnative/include/gdnative/transform.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_transform_new(godot_transform *p_self);
+void GDAPI godot_transform_new_copy(godot_transform *r_dest, const godot_transform *p_src);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/gdnative/transform2d.h
+++ b/modules/gdnative/include/gdnative/transform2d.h
@@ -49,6 +49,7 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_transform2d_new(godot_transform2d *p_self);
+void GDAPI godot_transform2d_new_copy(godot_transform2d *r_dest, const godot_transform2d *p_src);
 godot_vector2 GDAPI *godot_transform2d_operator_index(godot_transform2d *p_self, godot_int p_index);
 const godot_vector2 GDAPI *godot_transform2d_operator_index_const(const godot_transform2d *p_self, godot_int p_index);
 

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -272,6 +272,8 @@ void GDAPI godot_variant_destroy(godot_variant *p_self);
 
 void GDAPI godot_variant_call(godot_variant *p_self, const godot_string_name *p_method, const godot_variant **p_args, const godot_int p_argument_count, godot_variant *r_return, godot_variant_call_error *r_error);
 void GDAPI godot_variant_call_with_cstring(godot_variant *p_self, const char *p_method, const godot_variant **p_args, const godot_int p_argument_count, godot_variant *r_return, godot_variant_call_error *r_error);
+void GDAPI godot_variant_call_static(godot_variant_type p_type, const godot_string_name *p_method, const godot_variant **p_args, const godot_int p_argument_count, godot_variant *r_return, godot_variant_call_error *r_error);
+void GDAPI godot_variant_call_static_with_cstring(godot_variant_type p_type, const char *p_method, const godot_variant **p_args, const godot_int p_argument_count, godot_variant *r_return, godot_variant_call_error *r_error);
 void GDAPI godot_variant_evaluate(godot_variant_operator p_op, const godot_variant *p_a, const godot_variant *p_b, godot_variant *r_return, bool *r_valid);
 void GDAPI godot_variant_set(godot_variant *p_self, const godot_variant *p_key, const godot_variant *p_value, bool *r_valid);
 void GDAPI godot_variant_set_named(godot_variant *p_self, const godot_string_name *p_name, const godot_variant *p_value, bool *r_valid);
@@ -323,6 +325,8 @@ godot_variant_type GDAPI godot_variant_get_builtin_method_return_type(godot_vari
 godot_variant_type GDAPI godot_variant_get_builtin_method_return_type_with_cstring(godot_variant_type p_type, const char *p_method);
 bool GDAPI godot_variant_is_builtin_method_const(godot_variant_type p_type, const godot_string_name *p_method);
 bool GDAPI godot_variant_is_builtin_method_const_with_cstring(godot_variant_type p_type, const char *p_method);
+bool GDAPI godot_variant_is_builtin_method_static(godot_variant_type p_type, const godot_string_name *p_method);
+bool GDAPI godot_variant_is_builtin_method_static_with_cstring(godot_variant_type p_type, const char *p_method);
 bool GDAPI godot_variant_is_builtin_method_vararg(godot_variant_type p_type, const godot_string_name *p_method);
 bool GDAPI godot_variant_is_builtin_method_vararg_with_cstring(godot_variant_type p_type, const char *p_method);
 int GDAPI godot_variant_get_builtin_method_count(godot_variant_type p_type);

--- a/modules/gdnative/include/gdnative/vector2.h
+++ b/modules/gdnative/include/gdnative/vector2.h
@@ -58,7 +58,9 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_vector2_new(godot_vector2 *p_self);
+void GDAPI godot_vector2_new_copy(godot_vector2 *r_dest, const godot_vector2 *p_src);
 void GDAPI godot_vector2i_new(godot_vector2i *p_self);
+void GDAPI godot_vector2i_new_copy(godot_vector2i *r_dest, const godot_vector2i *p_src);
 godot_real_t GDAPI *godot_vector2_operator_index(godot_vector2 *p_self, godot_int p_index);
 const godot_real_t GDAPI *godot_vector2_operator_index_const(const godot_vector2 *p_self, godot_int p_index);
 int32_t GDAPI *godot_vector2i_operator_index(godot_vector2i *p_self, godot_int p_index);

--- a/modules/gdnative/include/gdnative/vector3.h
+++ b/modules/gdnative/include/gdnative/vector3.h
@@ -58,7 +58,9 @@ typedef struct {
 #include <gdnative/gdnative.h>
 
 void GDAPI godot_vector3_new(godot_vector3 *p_self);
+void GDAPI godot_vector3_new_copy(godot_vector3 *r_dest, const godot_vector3 *p_src);
 void GDAPI godot_vector3i_new(godot_vector3i *p_self);
+void GDAPI godot_vector3i_new_copy(godot_vector3i *r_dest, const godot_vector3i *p_src);
 godot_real_t GDAPI *godot_vector3_operator_index(godot_vector3 *p_self, godot_int p_index);
 const godot_real_t GDAPI *godot_vector3_operator_index_const(const godot_vector3 *p_self, godot_int p_index);
 int32_t GDAPI *godot_vector3i_operator_index(godot_vector3i *p_self, godot_int p_index);

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -71,6 +71,7 @@ struct MethodAPI {
 	bool is_editor = false;
 	bool is_noscript = false;
 	bool is_const = false;
+	bool is_static = false; // For builtin types.
 	bool is_reverse = false;
 	bool is_virtual = false;
 	bool is_from_script = false;
@@ -528,6 +529,7 @@ List<ClassAPI> generate_c_builtin_api_types() {
 			method_api.argument_count = Variant::get_builtin_method_argument_count(type, method_name);
 			method_api.has_varargs = Variant::is_builtin_method_vararg(type, method_name);
 			method_api.is_const = Variant::is_builtin_method_const(type, method_name);
+			method_api.is_static = Variant::is_builtin_method_static(type, method_name);
 
 			for (int i = 0; i < method_api.argument_count; i++) {
 				method_api.argument_names.push_back(Variant::get_builtin_method_argument_name(type, method_name, i));
@@ -757,6 +759,7 @@ static void write_builtin_method(StringBuilder &p_source, const MethodAPI &p_met
 	append_indented(p_source, vformat(R"("name": "%s",)", p_method.method_name));
 	append_indented(p_source, vformat(R"("return_type": "%s",)", p_method.return_type));
 	append_indented(p_source, vformat(R"("is_const": %s,)", p_method.is_const ? "true" : "false"));
+	append_indented(p_source, vformat(R"("is_static": %s,)", p_method.is_static ? "true" : "false"));
 	append_indented(p_source, vformat(R"("has_varargs": %s,)", p_method.has_varargs ? "true" : "false"));
 
 	append_indented(p_source, R"("arguments": [)");


### PR DESCRIPTION
- Added new_copy to all types, since trivial copy won't work for all
  types.
- Added functions to convert from String to char array types, which is
  not provided by the methods bound in Variant.
- Added operator index to String.
- Added missing cstring version of some Variant functions. They existed
  in the header but didn't have the implementation and were missing from
  the gdnative_api.json file.
- Added support for static calls on Variant types.

Also add information of static methods in the generated builtin API JSON.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
