### PR TITLE
Fix mesh library remove selected item menu option

### DIFF
--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -232,7 +232,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 		} break;
 		case MENU_OPTION_REMOVE_ITEM: {
 			String p = InspectorDock::get_inspector_singleton()->get_selected_path();
-			if (p.begins_with("/MeshLibrary/item") && p.get_slice_count("/") >= 3) {
+			if (p.begins_with("/MeshLibrary/item") && p.get_slice_count("/") >= 2) {
 				to_erase = p.get_slice("/", 3).to_int();
 				cd_remove->set_text(vformat(TTR("Remove item %d?"), to_erase));
 				cd_remove->popup_centered(Size2(300, 60));


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes #45969. The "Remove Selected Item" in the Mesh Library menu now removes the selected item from the MeshLibrary item list inspector list.

![image](https://user-images.githubusercontent.com/25291631/109247403-dd42ee80-77b1-11eb-96b0-428477c64cd4.png)
![image](https://user-images.githubusercontent.com/25291631/109247461-f9df2680-77b1-11eb-8ae4-130d609f9468.png)
![image](https://user-images.githubusercontent.com/25291631/109247524-154a3180-77b2-11eb-9c5e-6759495627f8.png)

