### PR TITLE
Fix ThreadedArrayProcessor init when NO_THREADS.

### DIFF
--- a/core/os/threaded_array_processor.h
+++ b/core/os/threaded_array_processor.h
@@ -95,7 +95,7 @@ void thread_process_array(uint32_t p_elements, C *p_instance, M p_method, U p_us
 	data.method = p_method;
 	data.instance = p_instance;
 	data.userdata = p_userdata;
-	data.index = 0;
+	data.index.set(0);
 	data.elements = p_elements;
 	for (uint32_t i = 0; i < p_elements; i++) {
 		data.process(i);


### PR DESCRIPTION
Another bit that slipped my testing in the new threads.
The error only shows up on master, because the file is not included in `3.2` for `NO_THREADS` build.
Nevertheless, it's probably worth backporting.

```
[ 61%] In file included from modules/gdnavigation/nav_map.cpp:33:
./core/os/threaded_array_processor.h:98:13: error: no viable overloaded '='
        data.index = 0;
        ~~~~~~~~~~ ^ ~
modules/gdnavigation/nav_map.cpp:735:3: note: in instantiation of function template specialization 'thread_process_array<NavMap, void (NavMap::*)(unsigned int, RvoAgent **), RvoAgent **>' requested here
[ 61%]          thread_process_array(
                ^
./core/templates/safe_refcount.h:195:7: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'int' to 'const SafeNumeric<unsigned int>' for 1st argument
class SafeNumeric {
      ^
./core/templates/safe_refcount.h:195:7: note: candidate function (the implicit move assignment operator) not viable: no known conversion from 'int' to 'SafeNumeric<unsigned int>' for 1st argument
[ 61%] 1 error generated.
```