### PR TITLE
Save ProjectSettings on editor restart

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -258,6 +258,7 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 }
 
 void ProjectSettingsEditor::_editor_restart() {
+	ProjectSettings::get_singleton()->save();
 	EditorNode::get_singleton()->save_all_scenes();
 	EditorNode::get_singleton()->restart_editor();
 }


### PR DESCRIPTION
Fixes #46444
I don't know why it's not reproducible on master, but one additional save won't hurt. I also tested that it fixes the bug on 3.2 branch.