### PR TITLE
[HTML5] Make editor HTML build tag scons4-proof.

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -4,7 +4,7 @@
 	<meta charset='utf-8' />
 	<meta name='viewport' content='width=device-width, user-scalable=no' />
 	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
-	<title>Godot Engine Web Editor ($GODOT_VERSION)</title>
+	<title>Godot Engine Web Editor (@GODOT_VERSION@)</title>
 	<style>
 		*:focus {
 			/* More visible outline for better keyboard navigation. */
@@ -205,7 +205,7 @@
 				<br />
 				<img src="logo.svg" width="1024" height="414" style="width: auto; height: auto; max-width: 85%; max-height: 250px" />
 				<br />
-				$GODOT_VERSION
+				@GODOT_VERSION@
 				<br />
 				<a href="releases/">Need an old version?</a>
 				<br />

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -97,7 +97,7 @@ out_files = [
 ]
 html_file = "#misc/dist/html/full-size.html"
 if env["tools"]:
-    subst_dict = {"\$GODOT_VERSION": env.GetBuildVersion()}
+    subst_dict = {"@GODOT_VERSION@": env.GetBuildVersion()}
     html_file = env.Substfile(
         target="#bin/godot${PROGSUFFIX}.html", source="#misc/dist/html/editor.html", SUBST_DICT=subst_dict
     )


### PR DESCRIPTION
We used to have it like `$GODOT_VERSION` which caused inconsistencies between different scons versions when substituting it.
It's now `@GODOT_VERSION@`, which is safe on both scons3 and scons4.