### PR TITLE
[3.2] Update the logic to load Godot Android plugins packaged into the binary.

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -817,8 +817,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 		manifest_text += _get_xr_features_tag(p_preset);
 		manifest_text += _get_instrumentation_tag(p_preset);
-		String plugins_names = get_plugins_names(get_enabled_plugins(p_preset));
-		manifest_text += _get_application_tag(p_preset, plugins_names);
+		manifest_text += _get_application_tag(p_preset);
 		manifest_text += "</manifest>\n";
 		String manifest_path = vformat("res://android/build/src/%s/AndroidManifest.xml", (p_debug ? "debug" : "release"));
 
@@ -868,8 +867,6 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 		int xr_mode_index = p_preset->get("xr_features/xr_mode");
 		bool focus_awareness = p_preset->get("xr_features/focus_awareness");
-
-		String plugins_names = get_plugins_names(get_enabled_plugins(p_preset));
 
 		Vector<String> perms;
 		// Write permissions into the perms variable.
@@ -1022,11 +1019,6 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 						if (tname == "meta-data" && attrname == "value" && is_focus_aware_metadata) {
 							// Update the focus awareness meta-data value
 							encode_uint32(xr_mode_index == /* XRMode.OVR */ 1 && focus_awareness ? 0xFFFFFFFF : 0, &p_manifest.write[iofs + 16]);
-						}
-
-						if (tname == "meta-data" && attrname == "value" && value == "plugins_value" && !plugins_names.empty()) {
-							// Update the meta-data 'android:value' attribute with the list of enabled plugins.
-							string_table.write[attr_value] = plugins_names;
 						}
 
 						is_focus_aware_metadata = tname == "meta-data" && attrname == "name" && value == "com.oculus.vr.focusaware";

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -257,14 +257,6 @@ String _get_instrumentation_tag(const Ref<EditorExportPreset> &p_preset) {
 	return manifest_instrumentation_text;
 }
 
-String _get_plugins_tag(const String &plugins_names) {
-	if (!plugins_names.empty()) {
-		return vformat("    <meta-data tools:node=\"replace\" android:name=\"plugins\" android:value=\"%s\" />\n", plugins_names);
-	} else {
-		return "    <meta-data tools:node=\"remove\" android:name=\"plugins\" />\n";
-	}
-}
-
 String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 	bool uses_xr = (int)(p_preset->get("xr_features/xr_mode")) == 1;
 	String orientation = _get_android_orientation_label(_get_screen_orientation());
@@ -283,7 +275,7 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 	return manifest_activity_text;
 }
 
-String _get_application_tag(const Ref<EditorExportPreset> &p_preset, const String &plugins_names) {
+String _get_application_tag(const Ref<EditorExportPreset> &p_preset) {
 	bool uses_xr = (int)(p_preset->get("xr_features/xr_mode")) == 1;
 	String manifest_application_text =
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
@@ -291,7 +283,6 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, const Strin
 			"        android:icon=\"@mipmap/icon\">\n\n"
 			"        <meta-data tools:node=\"remove\" android:name=\"xr_mode_metadata_name\" />\n";
 
-	manifest_application_text += _get_plugins_tag(plugins_names);
 	if (uses_xr) {
 		manifest_application_text += "        <meta-data tools:node=\"replace\" android:name=\"com.samsung.android.vr.application.mode\" android:value=\"vr_only\" />\n";
 	}

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -42,11 +42,6 @@
             android:name="xr_mode_metadata_name"
             android:value="xr_mode_metadata_value" />
 
-        <!-- Metadata populated at export time and used by Godot to figure out which plugins must be enabled. -->
-        <meta-data
-            android:name="plugins"
-            android:value="plugins_value"/>
-
         <activity
             android:name=".GodotApp"
             android:label="@string/godot_project_name_string"

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -99,7 +99,7 @@ ext.getGodotLibraryVersion = { ->
     return libraryVersion
 }
 
-final String PLUGIN_VALUE_SEPARATOR_REGEX = "\\|"
+final String VALUE_SEPARATOR_REGEX = "\\|"
 
 // get the list of ABIs the project should be exported to
 ext.getExportEnabledABIs = { ->
@@ -108,7 +108,7 @@ ext.getExportEnabledABIs = { ->
         enabledABIs = "armeabi-v7a|arm64-v8a|x86|x86_64|"
     }
     Set<String> exportAbiFilter = [];
-    for (String abi_name : enabledABIs.split(PLUGIN_VALUE_SEPARATOR_REGEX)) {
+    for (String abi_name : enabledABIs.split(VALUE_SEPARATOR_REGEX)) {
         if (!abi_name.trim().isEmpty()){
             exportAbiFilter.add(abi_name);
         }
@@ -143,7 +143,7 @@ ext.getGodotPluginsMavenRepos = { ->
     if (project.hasProperty("plugins_maven_repos")) {
         String mavenReposProperty = project.property("plugins_maven_repos")
         if (mavenReposProperty != null && !mavenReposProperty.trim().isEmpty()) {
-            for (String mavenRepoUrl : mavenReposProperty.split(PLUGIN_VALUE_SEPARATOR_REGEX)) {
+            for (String mavenRepoUrl : mavenReposProperty.split(VALUE_SEPARATOR_REGEX)) {
                 mavenRepos += mavenRepoUrl.trim()
             }
         }
@@ -163,7 +163,7 @@ ext.getGodotPluginsRemoteBinaries = { ->
     if (project.hasProperty("plugins_remote_binaries")) {
         String remoteDepsList = project.property("plugins_remote_binaries")
         if (remoteDepsList != null && !remoteDepsList.trim().isEmpty()) {
-            for (String dep: remoteDepsList.split(PLUGIN_VALUE_SEPARATOR_REGEX)) {
+            for (String dep: remoteDepsList.split(VALUE_SEPARATOR_REGEX)) {
                 remoteDeps += dep.trim()
             }
         }
@@ -182,7 +182,7 @@ ext.getGodotPluginsLocalBinaries = { ->
     if (project.hasProperty("plugins_local_binaries")) {
         String pluginsList = project.property("plugins_local_binaries")
         if (pluginsList != null && !pluginsList.trim().isEmpty()) {
-            for (String plugin : pluginsList.split(PLUGIN_VALUE_SEPARATOR_REGEX)) {
+            for (String plugin : pluginsList.split(VALUE_SEPARATOR_REGEX)) {
                 binDeps += plugin.trim()
             }
         }

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPluginRegistry.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPluginRegistry.java
@@ -44,8 +44,6 @@ import androidx.annotation.Nullable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -56,13 +54,6 @@ public final class GodotPluginRegistry {
 	private static final String TAG = GodotPluginRegistry.class.getSimpleName();
 
 	private static final String GODOT_PLUGIN_V1_NAME_PREFIX = "org.godotengine.plugin.v1.";
-
-	/**
-	 * Name for the metadata containing the list of Godot plugins to enable.
-	 */
-	private static final String GODOT_ENABLED_PLUGINS_LABEL = "plugins";
-
-	private static final String PLUGIN_VALUE_SEPARATOR_REGEX = "\\|";
 
 	private static GodotPluginRegistry instance;
 	private final ConcurrentHashMap<String, GodotPlugin> registry;
@@ -133,37 +124,11 @@ public final class GodotPluginRegistry {
 				return;
 			}
 
-			// When using the Godot editor for building and exporting the apk, this is used to check
-			// which plugins to enable.
-			// When using a custom process to generate the apk, the metadata is not needed since
-			// it's assumed that the developer is aware of the dependencies included in the apk.
-			final Set<String> enabledPluginsSet;
-			if (metaData.containsKey(GODOT_ENABLED_PLUGINS_LABEL)) {
-				String enabledPlugins = metaData.getString(GODOT_ENABLED_PLUGINS_LABEL, "");
-				String[] enabledPluginsList = enabledPlugins.split(PLUGIN_VALUE_SEPARATOR_REGEX);
-				if (enabledPluginsList.length == 0) {
-					// No plugins to enable. Aborting early.
-					return;
-				}
-
-				enabledPluginsSet = new HashSet<>();
-				for (String enabledPlugin : enabledPluginsList) {
-					enabledPluginsSet.add(enabledPlugin.trim());
-				}
-			} else {
-				enabledPluginsSet = null;
-			}
-
 			int godotPluginV1NamePrefixLength = GODOT_PLUGIN_V1_NAME_PREFIX.length();
 			for (String metaDataName : metaData.keySet()) {
 				// Parse the meta-data looking for entry with the Godot plugin name prefix.
 				if (metaDataName.startsWith(GODOT_PLUGIN_V1_NAME_PREFIX)) {
 					String pluginName = metaDataName.substring(godotPluginV1NamePrefixLength).trim();
-					if (enabledPluginsSet != null && !enabledPluginsSet.contains(pluginName)) {
-						Log.w(TAG, "Plugin " + pluginName + " is listed in the dependencies but is not enabled.");
-						continue;
-					}
-
 					Log.i(TAG, "Initializing Godot plugin " + pluginName);
 
 					// Retrieve the plugin class full name.
@@ -178,8 +143,7 @@ public final class GodotPluginRegistry {
 																				 .getConstructor(Godot.class);
 							GodotPlugin pluginHandle = pluginConstructor.newInstance(godot);
 
-							// Load the plugin initializer into the registry using the plugin name
-							// as key.
+							// Load the plugin initializer into the registry using the plugin name as key.
 							if (!pluginName.equals(pluginHandle.getPluginName())) {
 								Log.w(TAG,
 										"Meta-data plugin name does not match the value returned by the plugin handle: " + pluginName + " =/= " + pluginHandle.getPluginName());


### PR DESCRIPTION
The previous logic had the side effect of imposing a limit of one plugin per `aar` binary. The update lifts that restriction.
