### PR TITLE
Allow setting the preview sun angle with angular altitude and azimuth numbers

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -764,6 +764,8 @@ private:
 	VBoxContainer *sun_vb;
 	Popup *sun_environ_popup;
 	Control *sun_direction;
+	EditorSpinSlider *sun_angle_altitude;
+	EditorSpinSlider *sun_angle_azimuth;
 	ColorPickerButton *sun_color;
 	EditorSpinSlider *sun_energy;
 	EditorSpinSlider *sun_max_distance;
@@ -771,8 +773,9 @@ private:
 
 	void _sun_direction_draw();
 	void _sun_direction_input(const Ref<InputEvent> &p_event);
+	void _sun_direction_angle_set();
 
-	Basis sun_rotation;
+	Vector2 sun_rotation;
 
 	Ref<Shader> sun_direction_shader;
 	Ref<ShaderMaterial> sun_direction_material;


### PR DESCRIPTION
https://user-images.githubusercontent.com/1646875/109368234-74697e00-7866-11eb-8988-127cef971535.mp4

This PR builds upon #46315 and adds the ability to specify the sun angle in terms of angular altitude and azimuth.

* The sun angular altitude can be specified in degrees such that a positive number goes up (see below image). 0 degrees is the horizon, 90 degrees is the zenith, and -90 degrees is the nadir. The default value is 60 degrees. On any not-tidally-locked planet, a sun would have an angular altitude of 60 degrees as the average of all points on the sphere at noon, so this choice of a default value isn't just culture/location/season agnostic on Earth, it's universally agnostic :)

* The sun azimuth can be specified in degrees such that a positive number is clockwise from north (see below image). 0 degrees is north, 90 degrees is east, 180 degrees is south, 270 or -90 degrees is west. The default is 30 degrees, which is mostly an arbitrary choice, but really it's good with any value that isn't directly on an axis, and it's close to the default in the current master (after @reduz's PR) which is equivalent to 45 degrees.

* When clicking "Add Sun to Scene", the Euler angles are such that X rotation is the negative angular altitude, and the Y rotation is 180 degrees minus the azimuth. For example, the default rotation of the preview sun is (-60, 150, 0) in Euler angles in degrees. Internally, `sun_rotation` stores Euler angles in radians.

* The preview ball has been updated to respect the camera's orientation. It now acts as if it were an actual ball placed into the scene and a camera was looking at it. The above video showcases this in action.

This is the convention that was followed, with positive angular altitude for a higher sun, and positive azimuth clockwise from north:

![](https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Azimuth-Altitude_schematic.svg/436px-Azimuth-Altitude_schematic.svg.png)

Here is what the menu looks like with the default settings and the default camera orientation:

![Screenshot from 2021-02-26 18-56-50](https://user-images.githubusercontent.com/1646875/109367728-e345d780-7864-11eb-9ffb-bec973234a84.png)

Implements and closes https://github.com/godotengine/godot-proposals/issues/2438