### PR TITLE
Fix for crash after joint connected node is set to null

### DIFF
--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -205,15 +205,6 @@ PinJoint2DSW::PinJoint2DSW(const Vector2 &p_pos, Body2DSW *p_body_a, Body2DSW *p
 	}
 }
 
-PinJoint2DSW::~PinJoint2DSW() {
-	if (A) {
-		A->remove_constraint(this, 0);
-	}
-	if (B) {
-		B->remove_constraint(this, 1);
-	}
-}
-
 //////////////////////////////////////////////
 //////////////////////////////////////////////
 //////////////////////////////////////////////
@@ -346,11 +337,6 @@ GrooveJoint2DSW::GrooveJoint2DSW(const Vector2 &p_a_groove1, const Vector2 &p_a_
 	B->add_constraint(this, 1);
 }
 
-GrooveJoint2DSW::~GrooveJoint2DSW() {
-	A->remove_constraint(this, 0);
-	B->remove_constraint(this, 1);
-}
-
 //////////////////////////////////////////////
 //////////////////////////////////////////////
 //////////////////////////////////////////////
@@ -441,9 +427,4 @@ DampedSpringJoint2DSW::DampedSpringJoint2DSW(const Vector2 &p_anchor_a, const Ve
 
 	A->add_constraint(this, 0);
 	B->add_constraint(this, 1);
-}
-
-DampedSpringJoint2DSW::~DampedSpringJoint2DSW() {
-	A->remove_constraint(this, 0);
-	B->remove_constraint(this, 1);
 }

--- a/servers/physics_2d/joints_2d_sw.h
+++ b/servers/physics_2d/joints_2d_sw.h
@@ -60,6 +60,15 @@ public:
 		bias = 0;
 		max_force = max_bias = 3.40282e+38;
 	};
+
+	virtual ~Joint2DSW() {
+		for (int i = 0; i < get_body_count(); i++) {
+			Body2DSW *body = get_body_ptr()[i];
+			if (body) {
+				body->remove_constraint(this, i);
+			}
+		}
+	};
 };
 
 class PinJoint2DSW : public Joint2DSW {
@@ -90,7 +99,6 @@ public:
 	real_t get_param(PhysicsServer2D::PinJointParam p_param) const;
 
 	PinJoint2DSW(const Vector2 &p_pos, Body2DSW *p_body_a, Body2DSW *p_body_b = nullptr);
-	~PinJoint2DSW();
 };
 
 class GrooveJoint2DSW : public Joint2DSW {
@@ -124,7 +132,6 @@ public:
 	virtual void solve(real_t p_step);
 
 	GrooveJoint2DSW(const Vector2 &p_a_groove1, const Vector2 &p_a_groove2, const Vector2 &p_b_anchor, Body2DSW *p_body_a, Body2DSW *p_body_b);
-	~GrooveJoint2DSW();
 };
 
 class DampedSpringJoint2DSW : public Joint2DSW {
@@ -160,7 +167,6 @@ public:
 	real_t get_param(PhysicsServer2D::DampedSpringParam p_param) const;
 
 	DampedSpringJoint2DSW(const Vector2 &p_anchor_a, const Vector2 &p_anchor_b, Body2DSW *p_body_a, Body2DSW *p_body_b);
-	~DampedSpringJoint2DSW();
 };
 
 #endif // JOINTS_2D_SW_H

--- a/servers/physics_3d/joints_3d_sw.h
+++ b/servers/physics_3d/joints_3d_sw.h
@@ -49,6 +49,15 @@ public:
 	_FORCE_INLINE_ Joint3DSW(Body3DSW **p_body_ptr = nullptr, int p_body_count = 0) :
 			Constraint3DSW(p_body_ptr, p_body_count) {
 	}
+
+	virtual ~Joint3DSW() {
+		for (int i = 0; i < get_body_count(); i++) {
+			Body3DSW *body = get_body_ptr()[i];
+			if (body) {
+				body->remove_constraint(this);
+			}
+		}
+	}
 };
 
 #endif // JOINTS_SW_H

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -1312,9 +1312,6 @@ void PhysicsServer3DSW::free(RID p_rid) {
 	} else if (joint_owner.owns(p_rid)) {
 		Joint3DSW *joint = joint_owner.getornull(p_rid);
 
-		for (int i = 0; i < joint->get_body_count(); i++) {
-			joint->get_body_ptr()[i]->remove_constraint(joint);
-		}
 		joint_owner.free(p_rid);
 		memdelete(joint);
 


### PR DESCRIPTION
Hello!

In this PR I have fixed two issues with constraints/joints in Godot 4.

# Fix for crash after joint is destroyed
Commit: `Fixed crash in islands update after destroying`

Once I set up joint connecting two bodies and unset at least one of them from scripts
```gdscript
		joint.set_node_a(NodePath())
		joint.set_node_b(NodePath())
```
The engine was crashing because the dangling pointer to just removed the joint was still stored inside the constraint_map of the body. The crash was happening in `Step3DSW::_setup_island`

```cpp
void Step3DSW::_setup_island(Constraint3DSW *p_island, real_t p_delta) {
	Constraint3DSW *ci = p_island;
	while (ci) {
		ci->setup(p_delta);
		//todo remove from island if process fails
		ci = ci->get_island_next(); // <<<< get_island_next was pure virtual in my case
	}
}
```

I tested the fix on 100% repro. After the fix didn't observe any anomalies. 