### PR TITLE
Fixed bug that caused collision not to be properly reenabled when joi…

### DIFF
--- a/scene/3d/physics_joint_3d.cpp
+++ b/scene/3d/physics_joint_3d.cpp
@@ -64,6 +64,7 @@ void Joint3D::_body_exit_tree(const ObjectID &p_body_id) {
 void Joint3D::_update_joint(bool p_only_free) {
 	if (ba.is_valid() && bb.is_valid()) {
 		PhysicsServer3D::get_singleton()->body_remove_collision_exception(ba, bb);
+		PhysicsServer3D::get_singleton()->body_remove_collision_exception(bb, ba);
 	}
 
 	ba = RID();


### PR DESCRIPTION
I have setup 6dof joint with `exclude_from_collision=true` that connects two bodies and then unset it using this script:
```gdscript
		joint.set_node_a(NodePath())
		joint.set_node_b(NodePath())
```

After that operation bodies didn't have collisions anymore.

I implemented a fix that pairs the calls properly to `joint_disable_collisions_between_bodies` which disables the collisions in the first place. `body_add_collision_exception` is called on both ba:bb, and bb:ba pairs.

I tested this fix on 100% repro, now each time after this code is executed the bodies have collision reenabled properly.