### PR TITLE
[Net] Better EOF handling in HTTPRequest.

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -415,6 +415,7 @@ bool HTTPRequest::_update_connection() {
 			} else if (client->get_status() == HTTPClient::STATUS_DISCONNECTED) {
 				// We read till EOF, with no errors. Request is done.
 				call_deferred("_request_done", RESULT_SUCCESS, response_code, response_headers, body);
+				return true;
 			}
 
 			return false;


### PR DESCRIPTION
This fix request_completed being emitted two times, the first with the result, the second as a failure when retrieving responses served with read-until-EOF.

A follow-up fix for #21976 with only 2 years delay. read-till-eof is dead. Long live read-till-eof.