### PR TITLE
FileSystem: Force update when we delete a folder from the editor and …

### DIFF
--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -102,6 +102,8 @@ public:
 	int find_file_index(const String &p_file) const;
 	int find_dir_index(const String &p_dir) const;
 
+	void force_update();
+
 	EditorFileSystemDirectory();
 	~EditorFileSystemDirectory();
 };

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1465,6 +1465,10 @@ void FileSystemDock::_folder_removed(String p_folder) {
 	}
 
 	current_path->set_text(path);
+	EditorFileSystemDirectory *efd = EditorFileSystem::get_singleton()->get_filesystem_path(path);
+	if (efd) {
+		efd->force_update();
+	}
 }
 
 void FileSystemDock::_rename_operation_confirm() {


### PR DESCRIPTION
…searching changes only if we change the directory successfully in the scan_fs_changes

Fix #46469 

I gave the explanation of this in the issue. I think this is the best idea to fix this bug without changing the performance.

And I don't found a better name to `force_update`... `reset_modified_time` maybe is better.