### PR TITLE
ResourceLoader: Fix inverse 'if' on the cache mode

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -518,7 +518,7 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, Resour
 		local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	}
 
-	if (p_cache_mode == ResourceFormatLoader::CACHE_MODE_IGNORE) {
+	if (p_cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 		thread_load_mutex->lock();
 
 		//Is it already being loaded? poll until done


### PR DESCRIPTION
Debugging this was so funny

Basically Godot wasn't caching the resources that were loaded from `ResourceLoader::load`.
This bug was introduced on f8d03b98e7eeeb726af4f653f1fde8b063cbad14

Before this IF was:
`if (!p_no_cache) {`

and then was modified with:

`if (p_cache_mode == ResourceFormatLoader::CACHE_MODE_IGNORE) {`

So the variable name `p_no_cache` was a bit confused because is a `not` of of `no` cache.

Fix #46077
Because it wasn't caching it, and the function `CanvasItemEditorViewport::_create_nodes` suppose that the resource is on the cache loaded.

Fix #46260 too

And maybe fixes a lot of bugs too.

Another thing, I saw that the resource were loading a lot multiple times. So maybe @reduz would like to re-run some benchmark that you have.