### PR TITLE
OS: Fix used resource debug prints

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -356,7 +356,7 @@ void _OS::print_all_textures_by_size() {
 		ResourceCache::get_cached_resources(&rsrc);
 
 		for (Ref<Resource> &res : rsrc) {
-			if (!res->is_class("ImageTexture")) {
+			if (!res->is_class("Texture")) {
 				continue;
 			}
 
@@ -376,14 +376,30 @@ void _OS::print_all_textures_by_size() {
 
 	imgs.sort();
 
-	for (_OSCoreBindImg &E : imgs) {
-		total -= E.vram;
+	if (imgs.size() == 0) {
+		print_line("No textures seem used in this project.");
+	} else {
+		print_line("Textures currently in use, sorted by VRAM usage:\n"
+				   "Path - VRAM usage (Dimensions)");
 	}
+
+	for (const _OSCoreBindImg &img : imgs) {
+		print_line(vformat("%s - %s %s",
+				img.path,
+				String::humanize_size(img.vram),
+				img.size));
+	}
+
+	print_line(vformat("Total VRAM usage: %s.", String::humanize_size(total)));
 }
 
 void _OS::print_resources_by_type(const Vector<String> &p_types) {
-	Map<String, int> type_count;
+	ERR_FAIL_COND_MSG(p_types.size() == 0,
+			"At least one type should be provided to print resources by type.");
 
+	print_line(vformat("Resources currently in use for the following types: %s", p_types));
+
+	Map<String, int> type_count;
 	List<Ref<Resource>> resources;
 	ResourceCache::get_cached_resources(&resources);
 
@@ -404,6 +420,18 @@ void _OS::print_resources_by_type(const Vector<String> &p_types) {
 		}
 
 		type_count[r->get_class()]++;
+
+		print_line(vformat("%s: %s", r->get_class(), r->get_path()));
+
+		List<StringName> metas;
+		r->get_meta_list(&metas);
+		for (const StringName &meta : metas) {
+			print_line(vformat("  %s: %s", meta, r->get_meta(meta)));
+		}
+	}
+
+	for (const KeyValue<String, int> &E : type_count) {
+		print_line(vformat("%s count: %d", E.key, E.value));
 	}
 }
 

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -552,5 +552,7 @@ void ResourceCache::dump(const char *p_file, bool p_short) {
 	}
 
 	lock.read_unlock();
+#else
+	WARN_PRINT("ResourceCache::dump only with in debug builds.");
 #endif
 }

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -178,7 +178,7 @@ static void _OS_printres(Object *p_obj) {
 		return;
 	}
 
-	String str = itos(res->get_instance_id()) + String(res->get_class()) + ":" + String(res->get_name()) + " - " + res->get_path();
+	String str = vformat("%s - %s - %s", res->to_string(), res->get_name(), res->get_path());
 	if (_OSPRF) {
 		_OSPRF->store_line(str);
 	} else {


### PR DESCRIPTION
These methods were broken by 22419082d9bedbc9dc060ea5784bb0871f8710a3
5 years ago and nobody complained, so maybe they're not so useful...
But at least this should restore them to a working state.

Supersedes #38407.

### Notes

- There are at least 5 such debug methods in `OS` and I wonder if anyone really uses them. I also don't see much reason for them to be in `OS` and not e.g. `ResourceLoader` or even `Performance`:
  * `OS.print_all_resources(String p_to_file = "")`
  * `OS.print_all_textures_by_size()`
  * `OS.print_resources_by_type(const Vector<String> &p_types)`
  * `OS.print_resources_in_use(bool p_short = false)`
  * `OS.dump_resources_to_file(const String &p_file)`
  * *Edit:* Also `OS.dump_memory_to_file(const String &p_file)`

- `OS.print_resources_in_use()` doesn't work, because it passes a `NULL` argument to same method called by `OS.dump_resources_to_file()`, but this method no longer has handling of redirecting to stdout if not to a file.

- All in all these methods are quite ancient and it might be better to just remove them in 4.0, and if we want to add back some debugging tools for those, they might be best implemented from scratch, with proper use of `Logger` or similar to handle stdout or file.

- Maybe the feature offered by these ancient debug prints is now better provided by the editor debugger? But this might still be relevant for exported debug builds?

----

Marked as draft until we figure out what should be done exactly, but it should work fine as is to fix the two methods broken by 22419082d9bedbc9dc060ea5784bb0871f8710a3.