### PR TITLE
Clarify Curve.get_closest_point uses baked points.

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -63,7 +63,7 @@
 			<argument index="0" name="to_point" type="Vector2">
 			</argument>
 			<description>
-				Returns the closest point (in curve's local space) to [code]to_point[/code].
+				Returns the closest baked point (in curve's local space) to [code]to_point[/code].
 				[code]to_point[/code] must be in this curve's local space.
 			</description>
 		</method>

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -78,7 +78,7 @@
 			<argument index="0" name="to_point" type="Vector3">
 			</argument>
 			<description>
-				Returns the closest point (in curve's local space) to [code]to_point[/code].
+				Returns the closest baked point (in curve's local space) to [code]to_point[/code].
 				[code]to_point[/code] must be in this curve's local space.
 			</description>
 		</method>


### PR DESCRIPTION
Based on the doc, I wasn't sure if get_closest_point would return the
closest baked point or the closest "source" point. It seems to use
baked:
https://github.com/godotengine/godot/blob/8faecd6a470aeef41084a32d74f4a131a5ef42b6/scene/resources/curve.cpp#L809


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->