### PR TITLE
Fix Window returning `INVALID_WINDOW_ID` when being embedded

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -826,6 +826,9 @@ bool Window::is_using_font_oversampling() const {
 }
 
 DisplayServer::WindowID Window::get_window_id() const {
+	if (embedder) {
+		return parent->get_window_id();
+	}
 	return window_id;
 }
 


### PR DESCRIPTION
The ScrollContainer should not access the DisplayServer, if it is embedded. ~Depends on #46515, but could also be done, by checking if window_id != -1~
fixes #46370