### PR TITLE
Disallow antialiasing for software skinned 2d polys

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1143,6 +1143,7 @@
 		<member name="rendering/quality/2d/use_software_skinning" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], performs 2D skinning on the CPU rather than the GPU. This provides greater compatibility with a wide range of hardware, and also may be faster in some circumstances.
 			Currently only available when [member rendering/batching/options/use_batching] is active.
+			[b]Note:[/b] Antialiased software skinned polys are not supported, and will be rendered without antialiasing.
 		</member>
 		<member name="rendering/quality/2d/use_transform_snap" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], forces snapping of 2D object transforms to the nearest whole coordinate.

--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -2282,7 +2282,16 @@ PREAMBLE(bool)::prefill_joined_item(FillState &r_fill_state, int &r_command_star
 #ifdef GLES_OVER_GL
 				// anti aliasing not accelerated .. it is problematic because it requires a 2nd line drawn around the outside of each
 				// poly, which would require either a second list of indices or a second list of vertices for this step
+				bool use_legacy_path = false;
+
 				if (polygon->antialiased) {
+					// anti aliasing is also not supported for software skinned meshes.
+					// we can't easily revert, so we force software skinned meshes to run through
+					// batching path with no AA.
+					use_legacy_path = !bdata.settings_use_software_skinning || p_item->skeleton == RID();
+				}
+
+				if (use_legacy_path) {
 					// not accelerated
 					_prefill_default_batch(r_fill_state, command_num, *p_item);
 				} else {
@@ -2298,9 +2307,9 @@ PREAMBLE(bool)::prefill_joined_item(FillState &r_fill_state, int &r_command_star
 						bool buffer_full = false;
 
 						if (send_light_angles) {
-							// NYI
+							// polygon with light angles is not yet implemented
+							// for batching .. this means software skinned with light angles won't work
 							_prefill_default_batch(r_fill_state, command_num, *p_item);
-							//buffer_full = prefill_polygon<true>(polygon, r_fill_state, r_command_start, command_num, command_count, p_item, multiply_final_modulate);
 						} else
 							buffer_full = _prefill_polygon<false>(polygon, r_fill_state, r_command_start, command_num, command_count, p_item, multiply_final_modulate);
 


### PR DESCRIPTION
Antialiasing is not supported for batched polys. Currently due to the fallback mechanism, skinned antialiased polys will be rendered without applying animation.

This PR simply treats such polys as if antialiasing had not been selected. The class reference is updated to reflect this.

Fixes #46466.

## Notes
I was wavering between two of the options in the linked issue, they both have plus and negative points:

3) Automatically turn off anti-aliasing in skinned polys when software skinning is on
4) Put in a warning / error message, and put a note in the docs

In the absence of feedback, and on reflection I've gone for (3) here as it will pretty much run fine even if you weren't aware of the limitation. It's probably a good compromise, but I can change if there are preferences to other methods. 

Strictly speaking software skinned polys _could_ be rendered with anti aliasing, but it would require another codepath, and I'm not convinced of the need to implement it currently. The problem is compounded because software skinned meshes can be batched together and rendered in one drawcall (e.g. 100 can render as 1 drawcall). But if antialiasing was used that would no longer possible, and the logic would need to be added for this. 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
