### PR TITLE
[FBX - WIP] Various improvements for blender FBX specifically.

### DIFF
--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -351,9 +351,6 @@ EditorSceneImporterMeshNode3D *FBXMeshData::create_fbx_mesh(const ImportState &s
 						normals_ptr[vertex]);
 			}
 
-			if (state.is_blender_fbx) {
-				morph_st->generate_normals();
-			}
 			morph_st->generate_tangents();
 			surface->morphs.push_back(morph_st->commit_to_arrays());
 		}
@@ -376,9 +373,6 @@ EditorSceneImporterMeshNode3D *FBXMeshData::create_fbx_mesh(const ImportState &s
 	for (const SurfaceId *surface_id = surfaces.next(nullptr); surface_id != nullptr; surface_id = surfaces.next(surface_id)) {
 		SurfaceData *surface = surfaces.getptr(*surface_id);
 
-		if (state.is_blender_fbx) {
-			surface->surface_tool->generate_normals();
-		}
 		// you can't generate them without a valid uv map.
 		if (uvs_0_raw.size() > 0) {
 			surface->surface_tool->generate_tangents();
@@ -771,7 +765,7 @@ void FBXMeshData::add_vertex(
 		const Vector3 &p_morph_normal) {
 	ERR_FAIL_INDEX_MSG(p_vertex, (Vertex)p_vertices_position.size(), "FBX file is corrupted, the position of the vertex can't be retrieved.");
 
-	if (p_normals.has(p_vertex) && !state.is_blender_fbx) {
+	if (p_normals.has(p_vertex)) {
 		p_surface_tool->set_normal(p_normals[p_vertex] + p_morph_normal);
 	}
 

--- a/modules/fbx/data/fbx_skeleton.cpp
+++ b/modules/fbx/data/fbx_skeleton.cpp
@@ -69,7 +69,7 @@ void FBXSkeleton::init_skeleton(const ImportState &state) {
 			// Make sure the bone name is unique.
 			const String bone_name = bone->bone_name;
 			int same_name_count = 0;
-			for (int y = x; y < skeleton_bone_count; y++) {
+			for (int y = x + 1; y < skeleton_bone_count; y++) {
 				Ref<FBXBone> other_bone = skeleton_bones[y];
 				if (other_bone.is_valid()) {
 					if (other_bone->bone_name == bone_name) {

--- a/modules/fbx/data/pivot_transform.h
+++ b/modules/fbx/data/pivot_transform.h
@@ -92,9 +92,11 @@ struct PivotTransform : Reference, ModelAbstraction {
 
 	/* Extract into xforms and calculate once */
 	void ComputePivotTransform();
+	// blender only pivot transform
+	void ComputeBlenderTransform();
 
 	/* Execute the command for the pivot generation */
-	void Execute();
+	void Execute(ImportState &state);
 
 	void set_parent(Ref<PivotTransform> p_parent) {
 		parent_transform = p_parent;

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -737,7 +737,6 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 				// reparent to armature
 				skeleton_node->godot_node->add_child(mesh->godot_mesh_instance);
 				mesh->godot_mesh_instance->set_owner(state.root_owner);
-				mesh->godot_mesh_instance->set_transform(Transform());
 
 				reparented = true;
 			}

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -524,7 +524,7 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 	if (state.fbx_bone_map.size() > 0) {
 		// We are using a single skeleton only method here
 		// this is because we really have no concept of skeletons in FBX
-		// their are bones in a scene but they have no specific armature
+		// there are bones in a scene but they have no specific armature
 		// we can detect armatures but the issue lies in the complexity
 		// we opted to merge the entire scene onto one skeleton for now
 		// if we need to change this we have an archive of the old code.
@@ -721,7 +721,7 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 						bone->bone_name, get_unscaled_transform(cluster->TransformLink().affine_inverse(), state.scale));
 			}
 
-			if (!reparented) {
+			if (!reparented && state.is_blender_fbx) {
 				// remove
 				Node *mesh_parent = mesh->godot_mesh_instance->get_parent();
 				mesh_parent->remove_child(mesh->godot_mesh_instance);

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -1135,8 +1135,15 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 								rot_key_value.z = -rot_key_value.z;
 								rot_key_value.w = -rot_key_value.w;
 							}
+
 							// pre_post rotation possibly could fix orientation
-							Quat final_rotation = pre_rotation * rot_key_value * post_rotation;
+							Quat final_rotation;
+
+							if (state.is_blender_fbx) {
+								final_rotation = rot_key_value;
+							} else {
+								final_rotation = pre_rotation * rot_key_value * post_rotation;
+							}
 
 							lastQuat = final_rotation;
 
@@ -1211,10 +1218,9 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 							}
 
 							time += increment;
-							if (time > anim_length) {
+							if (time >= anim_length) {
 								last = true;
 								time = anim_length;
-								break;
 							}
 						}
 					}

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -1177,6 +1177,10 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 						const Vector3 def_scale = scale_keys.has_default ? scale_keys.default_value : bone_rest.basis.get_scale();
 						print_verbose("track defaults: p(" + def_pos + ") s(" + def_scale + ") r(" + def_rot + ")");
 
+						Vector3 last_pos;
+						Quat last_rot;
+						Quat last_scale;
+
 						while (true) {
 							Vector3 pos = def_pos;
 							Quat rot = def_rot;
@@ -1211,7 +1215,13 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 								pos = t.origin;
 							}
 
-							animation->transform_track_insert_key(track_idx, time, pos, rot, scale);
+							if (!last_pos.is_equal_approx(pos) || !last_rot.is_equal_approx(rot) || !last_scale.is_equal_approx(scale)) {
+								animation->transform_track_insert_key(track_idx, time, pos, rot, scale);
+
+								last_pos = pos;
+								last_scale = scale;
+								last_rot = rot;
+							}
 
 							if (last) {
 								break;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -70,7 +70,7 @@ private:
 		bool loop_wrap = true;
 		NodePath path; // path to something
 		bool imported = false;
-		bool enabled = false;
+		bool enabled = true;
 		Track() {}
 		virtual ~Track() {}
 	};

--- a/scene/resources/skin.cpp
+++ b/scene/resources/skin.cpp
@@ -68,6 +68,16 @@ void Skin::set_bind_bone(int p_index, int p_bone) {
 	emit_changed();
 }
 
+bool Skin::has_named_bind(const String &p_name) {
+	for (int x = 0; x < get_bind_count(); x++) {
+		if (get_bind_name(x) == p_name) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void Skin::set_bind_pose(int p_index, const Transform &p_pose) {
 	ERR_FAIL_INDEX(p_index, bind_count);
 	binds_ptr[p_index].pose = p_pose;

--- a/scene/resources/skin.h
+++ b/scene/resources/skin.h
@@ -66,6 +66,8 @@ public:
 	void set_bind_pose(int p_index, const Transform &p_pose);
 	void set_bind_name(int p_index, const StringName &p_name);
 
+	bool has_named_bind(const String &p_name);
+
 	inline int get_bind_bone(int p_index) const {
 #ifdef DEBUG_ENABLED
 		ERR_FAIL_INDEX_V(p_index, bind_count, -1);

--- a/tests/test_compiler_sanity.h
+++ b/tests/test_compiler_sanity.h
@@ -1,0 +1,64 @@
+/*************************************************************************/
+/*  test_compiler_sanity.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_SANITY_H
+#define TEST_SANITY_H
+
+#include "core/os/os.h"
+#include "core/string/ustring.h"
+#include "scene/resources/material.h"
+#include "tests/test_macros.h"
+
+namespace TestSanity {
+
+class ArrayInitializerTest : public Reference {
+public:
+	static const int max_size = 10;
+	bool class_member_2[max_size] = {}; // will all be zero
+	bool class_member_3[max_size] = { false }; // will all be zero
+};
+
+TEST_CASE("[Sanity] Check basic definition has zeros") {
+	for (size_t x = 0; x < 100000; x++) {
+		Ref<ArrayInitializerTest> mat;
+		mat.instance();
+		for (int y = 0; y < ArrayInitializerTest::max_size; y++) {
+			bool yv1 = mat->class_member_2[y];
+			bool yv2 = mat->class_member_3[y];
+
+			CHECK(!yv1);
+			CHECK(!yv2);
+		}
+	}
+}
+
+} // namespace TestSanity
+
+#endif // TEST_SANITY_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -39,6 +39,7 @@
 #include "test_class_db.h"
 #include "test_color.h"
 #include "test_command_queue.h"
+#include "test_compiler_sanity.h"
 #include "test_config_file.h"
 #include "test_crypto.h"
 #include "test_curve.h"


### PR DESCRIPTION
Added a sanity check test, because I saw a bug on my PC which seems very rare, can be removed when this pr is ready I don't mind.

Fixes:
- normal data is now working from blender fbx files
- skinned meshes work more of the time from blender.
- blender fbx's *only* will reparent the mesh to the skeleton.
- blender has no support for pivots in an fbx.
- kenny character model skin is fixed.

:) 🍰 
<img width="1133" alt="Screenshot 2021-02-28 at 18 33 26" src="https://user-images.githubusercontent.com/748770/109431905-b1697800-7a00-11eb-9b84-4cf42e38ac19.png">

TODO:
- Fix animation time basis
- Remove pivots for blender fbx keyframes 
- default keys for blender fbx tracks probably need disabled

Bugs in engine:
- aabb's of skinned meshes are of the mesh without the skin (orientation then for the aabb is wrong, but maybe we can fix this?)
