### PR TITLE
Adding Raycast3D custom debug shape thickness and color

### DIFF
--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -136,6 +136,13 @@
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
 			The ray's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See [url=https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
+		<member name="debug_shape_custom_color" type="Color" setter="set_debug_shape__custom_color" getter="get_debug_shape_custom_color" default="Color( 0.0, 0.0, 0.0 )">
+			The custom color to use to draw the shape in the editor and at run-time if [b]Visible Collision Shapes[/b] is enabled in the [b]Debug[/b] menu. This color will be highlighted at run-time if the [RayCast3D] is colliding with something.
+			If set to [code]Color(0.0, 0.0, 0.0)[/code] (by default), the color set in [member ProjectSettings.debug/shapes/collision/shape_color] is used.
+		</member>
+		<member name="debug_shape_thickness" type="int" setter="set_debug_shape_thickness" getter="get_debug_shape_thickness" default="1">
+			If set to [code]1[/code], a line is used as the debug shape. Otherwise, a truncated pyramid is drawn to represent the [RayCast3D]. Requires [b]Visible Collision Shapes[/b] to be enabled in the [b]Debug[/b] menu for the debug shape to be visible at run-time.
+		</member>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			If [code]true[/code], collisions will be reported.
 		</member>

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -99,6 +99,7 @@ protected:
 
 public:
 	void add_lines(const Vector<Vector3> &p_lines, const Ref<Material> &p_material, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1));
+	void add_vertices(const Vector<Vector3> &p_vertices, const Ref<Material> &p_material, Mesh::PrimitiveType p_primitive_type, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1));
 	void add_mesh(const Ref<ArrayMesh> &p_mesh, bool p_billboard = false, const Ref<SkinReference> &p_skin_reference = Ref<SkinReference>(), const Ref<Material> &p_material = Ref<Material>());
 	void add_collision_segments(const Vector<Vector3> &p_lines);
 	void add_collision_triangles(const Ref<TriangleMesh> &p_tmesh);

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -37,10 +37,13 @@
 
 void RayCast3D::set_target_position(const Vector3 &p_point) {
 	target_position = p_point;
-	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint())) {
-		update_gizmo();
-	}
-	if (is_inside_tree() && get_tree()->is_debugging_collisions_hint()) {
+	update_gizmo();
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		if (is_inside_tree()) {
+			_update_debug_shape_vertices();
+		}
+	} else if (debug_shape) {
 		_update_debug_shape();
 	}
 }
@@ -146,6 +149,9 @@ bool RayCast3D::get_exclude_parent_body() const {
 void RayCast3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			if (Engine::get_singleton()->is_editor_hint()) {
+				_update_debug_shape_vertices();
+			}
 			if (enabled && !Engine::get_singleton()->is_editor_hint()) {
 				set_physics_process_internal(true);
 			} else {
@@ -183,10 +189,7 @@ void RayCast3D::_notification(int p_what) {
 			bool prev_collision_state = collided;
 			_update_raycast_state();
 			if (prev_collision_state != collided && get_tree()->is_debugging_collisions_hint()) {
-				if (debug_material.is_valid()) {
-					Ref<StandardMaterial3D> line_material = static_cast<Ref<StandardMaterial3D>>(debug_material);
-					line_material->set_albedo(collided ? Color(1.0, 0, 0) : Color(1.0, 0.8, 0.6));
-				}
+				_update_debug_shape_material(true);
 			}
 
 		} break;
@@ -310,6 +313,12 @@ void RayCast3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &RayCast3D::set_collide_with_bodies);
 	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &RayCast3D::is_collide_with_bodies_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_debug_shape_custom_color", "debug_shape_custom_color"), &RayCast3D::set_debug_shape_custom_color);
+	ClassDB::bind_method(D_METHOD("get_debug_shape_custom_color"), &RayCast3D::get_debug_shape_custom_color);
+
+	ClassDB::bind_method(D_METHOD("set_debug_shape_thickness", "debug_shape_thickness"), &RayCast3D::set_debug_shape_thickness);
+	ClassDB::bind_method(D_METHOD("get_debug_shape_thickness"), &RayCast3D::get_debug_shape_thickness);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclude_parent"), "set_exclude_parent_body", "get_exclude_parent_body");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "target_position"), "set_target_position", "get_target_position");
@@ -318,16 +327,80 @@ void RayCast3D::_bind_methods() {
 	ADD_GROUP("Collide With", "collide_with");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_areas", "is_collide_with_areas_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
+
+	ADD_GROUP("Debug Shape", "debug_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_shape_custom_color"), "set_debug_shape_custom_color", "get_debug_shape_custom_color");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_shape_thickness", PROPERTY_HINT_RANGE, "1,5"), "set_debug_shape_thickness", "get_debug_shape_thickness");
+}
+
+float RayCast3D::get_debug_shape_thickness() const {
+	return debug_shape_thickness;
+}
+
+void RayCast3D::_update_debug_shape_vertices() {
+	debug_shape_vertices.clear();
+	debug_line_vertices.clear();
+
+	if (target_position == Vector3()) {
+		return;
+	}
+
+	debug_line_vertices.push_back(Vector3());
+	debug_line_vertices.push_back(target_position);
+
+	if (debug_shape_thickness > 1) {
+		float scale_factor = 100.0;
+		Vector3 dir = Vector3(target_position).normalized();
+		// Draw truncated pyramid
+		Vector3 normal = (fabs(dir.x) + fabs(dir.y) > CMP_EPSILON) ? Vector3(-dir.y, dir.x, 0).normalized() : Vector3(0, -dir.z, dir.y).normalized();
+		normal *= debug_shape_thickness / scale_factor;
+		int vertices_strip_order[14] = { 4, 5, 0, 1, 2, 5, 6, 4, 7, 0, 3, 2, 7, 6 };
+		for (int v = 0; v < 14; v++) {
+			Vector3 vertex = vertices_strip_order[v] < 4 ? normal : normal / 3.0 + target_position;
+			debug_shape_vertices.push_back(vertex.rotated(dir, Math_PI * (0.5 * (vertices_strip_order[v] % 4) + 0.25)));
+		}
+	}
+}
+
+void RayCast3D::set_debug_shape_thickness(const float p_debug_shape_thickness) {
+	debug_shape_thickness = p_debug_shape_thickness;
+	update_gizmo();
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		if (is_inside_tree()) {
+			_update_debug_shape_vertices();
+		}
+	} else if (debug_shape) {
+		_update_debug_shape();
+	}
+}
+
+const Vector<Vector3> &RayCast3D::get_debug_shape_vertices() const {
+	return debug_shape_vertices;
+}
+
+const Vector<Vector3> &RayCast3D::get_debug_line_vertices() const {
+	return debug_line_vertices;
+}
+
+void RayCast3D::set_debug_shape_custom_color(const Color &p_color) {
+	debug_shape_custom_color = p_color;
+	if (debug_material.is_valid()) {
+		_update_debug_shape_material();
+	}
+}
+
+Ref<StandardMaterial3D> RayCast3D::get_debug_material() {
+	_update_debug_shape_material();
+	return debug_material;
+}
+
+const Color &RayCast3D::get_debug_shape_custom_color() const {
+	return debug_shape_custom_color;
 }
 
 void RayCast3D::_create_debug_shape() {
-	if (!debug_material.is_valid()) {
-		debug_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-
-		Ref<StandardMaterial3D> line_material = static_cast<Ref<StandardMaterial3D>>(debug_material);
-		line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-		line_material->set_albedo(Color(1.0, 0.8, 0.6));
-	}
+	_update_debug_shape_material();
 
 	Ref<ArrayMesh> mesh = memnew(ArrayMesh);
 
@@ -336,6 +409,35 @@ void RayCast3D::_create_debug_shape() {
 
 	add_child(mi);
 	debug_shape = mi;
+}
+
+void RayCast3D::_update_debug_shape_material(bool p_check_collision) {
+	if (!debug_material.is_valid()) {
+		Ref<StandardMaterial3D> material = memnew(StandardMaterial3D);
+		debug_material = material;
+
+		material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+		material->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
+	}
+
+	Color color = debug_shape_custom_color;
+	if (color == Color(0.0, 0.0, 0.0)) {
+		// Use the default debug shape color defined in the Project Settings.
+		color = get_tree()->get_debug_collisions_color();
+	}
+
+	if (p_check_collision) {
+		if ((color.get_h() < 0.055 || color.get_h() > 0.945) && color.get_s() > 0.5 && color.get_v() > 0.5) {
+			// If base color is already quite reddish, hightlight collision with green color
+			color = Color(0.0, 1.0, 0.0, color.a);
+		} else {
+			// Else, hightlight collision with red color
+			color = Color(1.0, 0, 0, color.a);
+		}
+	}
+
+	Ref<StandardMaterial3D> material = static_cast<Ref<StandardMaterial3D>>(debug_material);
+	material->set_albedo(color);
 }
 
 void RayCast3D::_update_debug_shape() {
@@ -353,26 +455,28 @@ void RayCast3D::_update_debug_shape() {
 		return;
 	}
 
-	Vector<Vector3> verts;
-	verts.push_back(Vector3());
-	verts.push_back(target_position);
+	_update_debug_shape_vertices();
 
-	if (mesh->get_surface_count() == 0) {
-		Array a;
-		a.resize(Mesh::ARRAY_MAX);
-		a[Mesh::ARRAY_VERTEX] = verts;
+	mesh->clear_surfaces();
 
-		uint32_t flags = Mesh::ARRAY_FLAG_USE_DYNAMIC_UPDATE;
+	Array a;
+	a.resize(Mesh::ARRAY_MAX);
 
+	uint32_t flags = 0;
+	int surface_count = 0;
+
+	if (!debug_line_vertices.is_empty()) {
+		a[Mesh::ARRAY_VERTEX] = debug_line_vertices;
 		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, a, Array(), Dictionary(), flags);
-		mesh->surface_set_material(0, debug_material);
-	} else {
-		Vector<uint8_t> byte_array;
-		int array_size = sizeof(Vector3) * verts.size();
-		byte_array.resize(array_size);
-		copymem(byte_array.ptrw(), verts.ptr(), array_size);
+		mesh->surface_set_material(surface_count, debug_material);
+		++surface_count;
+	}
 
-		RS::get_singleton()->mesh_surface_update_region(mesh->get_rid(), 0, 0, byte_array);
+	if (!debug_shape_vertices.is_empty()) {
+		a[Mesh::ARRAY_VERTEX] = debug_shape_vertices;
+		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLE_STRIP, a, Array(), Dictionary(), flags);
+		mesh->surface_set_material(surface_count, debug_material);
+		++surface_count;
 	}
 }
 

--- a/scene/3d/ray_cast_3d.h
+++ b/scene/3d/ray_cast_3d.h
@@ -51,9 +51,15 @@ class RayCast3D : public Node3D {
 
 	Node *debug_shape = nullptr;
 	Ref<Material> debug_material;
+	Color debug_shape_custom_color = Color(0.0, 0.0, 0.0);
+	int debug_shape_thickness = 2;
+	Vector<Vector3> debug_shape_vertices;
+	Vector<Vector3> debug_line_vertices;
 
 	void _create_debug_shape();
 	void _update_debug_shape();
+	void _update_debug_shape_material(bool p_check_collision = false);
+	void _update_debug_shape_vertices();
 	void _clear_debug_shape();
 
 	bool collide_with_areas = false;
@@ -85,6 +91,17 @@ public:
 
 	void set_exclude_parent_body(bool p_exclude_parent_body);
 	bool get_exclude_parent_body() const;
+
+	const Color &get_debug_shape_custom_color() const;
+	void set_debug_shape_custom_color(const Color &p_color);
+
+	const Vector<Vector3> &get_debug_shape_vertices() const;
+	const Vector<Vector3> &get_debug_line_vertices() const;
+
+	Ref<StandardMaterial3D> get_debug_material();
+
+	float get_debug_shape_thickness() const;
+	void set_debug_shape_thickness(const float p_debug_thickness);
 
 	void force_raycast_update();
 	bool is_colliding() const;


### PR DESCRIPTION
*Bugsquad edit: `master` version of https://github.com/godotengine/godot/pull/49726.*

### What is the problem solved by this PR and use cases ?

During the development of a game with my teammate @Fabriceci, we had a hard time with the "debug shape" of Raycast3D.
A Raycast is a bit special, because contrary to CollisionShape, they don’t “cover a mesh” which you can easily refer to.

This leads to make difficult the debugging of certain Raycast3D :

- the Raycast3D is represented by a white line, it’s often hard to see it (collapsed by the grid, aligned with the axis...)
- if we have multiple Raycasts on a Node, it’s hard to make the distinction between them. For example, a ball rotate/cube and you want to keep track of all directions with Raycast3D, you can’t.
- If the background is white or bright, the Raycast become nearly invisible.
- You can't see the direction of the ray
![before](https://user-images.githubusercontent.com/3649998/109434006-758bde00-7a13-11eb-88ac-f8d012c362cd.png)

### How does this Pull Request fix these problems ?

This PR is done in the simplest way possible by: adding 2 optional parameters to be able to set a per Raycast3D custom color and / or thickness.

By default, the behaviour is the same as now, the thickness is set by default to 1 which draw a line and default color is the same as current default color.

The goal is to allow highlighting some chosen Raycast3Ds in order to make debugging easier.
When the thickness is more than 1, a parallelepiped is drawn, instead of the line, with a bit larger base than the target point to show the direction.
![after](https://user-images.githubusercontent.com/3649998/109434039-8f2d2580-7a13-11eb-929b-55f320964ca4.png)

https://user-images.githubusercontent.com/3649998/109434370-48402f80-7a15-11eb-8070-542800c25154.mp4

