### PR TITLE
Refactored cpu_particles_2d.cpp _notification Method

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1032,66 +1032,64 @@ void CPUParticles2D::_update_render_thread() {
 }
 
 void CPUParticles2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		set_process_internal(emitting);
-	}
-
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		_set_redraw(false);
-	}
-
-	if (p_what == NOTIFICATION_DRAW) {
-		// first update before rendering to avoid one frame delay after emitting starts
-		if (emitting && (time == 0)) {
-			_update_internal();
-		}
-
-		if (!redraw) {
-			return; // don't add to render list
-		}
-
-		RID texrid;
-		if (texture.is_valid()) {
-			texrid = texture->get_rid();
-		}
-
-		RS::get_singleton()->canvas_item_add_multimesh(get_canvas_item(), multimesh, texrid);
-	}
-
-	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
-		_update_internal();
-	}
-
-	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
-		inv_emission_transform = get_global_transform().affine_inverse();
-
-		if (!local_coords) {
-			int pc = particles.size();
-
-			float *w = particle_data.ptrw();
-			const Particle *r = particles.ptr();
-			float *ptr = w;
-
-			for (int i = 0; i < pc; i++) {
-				Transform2D t = inv_emission_transform * r[i].transform;
-
-				if (r[i].active) {
-					ptr[0] = t.elements[0][0];
-					ptr[1] = t.elements[1][0];
-					ptr[2] = 0;
-					ptr[3] = t.elements[2][0];
-					ptr[4] = t.elements[0][1];
-					ptr[5] = t.elements[1][1];
-					ptr[6] = 0;
-					ptr[7] = t.elements[2][1];
-
-				} else {
-					zeromem(ptr, sizeof(float) * 8);
-				}
-
-				ptr += 16;
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			set_process_internal(emitting);
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			_set_redraw(false);
+		} break;
+		case NOTIFICATION_DRAW: {
+			// first update before rendering to avoid one frame delay after emitting starts
+			if (emitting && (time == 0)) {
+				_update_internal();
 			}
-		}
+
+			if (!redraw) {
+				return; // don't add to render list
+			}
+
+			RID texrid;
+			if (texture.is_valid()) {
+				texrid = texture->get_rid();
+			}
+
+			RS::get_singleton()->canvas_item_add_multimesh(get_canvas_item(), multimesh, texrid);
+		} break;
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			_update_internal();
+		} break;
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			inv_emission_transform = get_global_transform().affine_inverse();
+
+			if (!local_coords) {
+				int pc = particles.size();
+
+				float *w = particle_data.ptrw();
+				const Particle *r = particles.ptr();
+				float *ptr = w;
+
+				for (int i = 0; i < pc; i++) {
+					Transform2D t = inv_emission_transform * r[i].transform;
+
+					if (r[i].active) {
+						ptr[0] = t.elements[0][0];
+						ptr[1] = t.elements[1][0];
+						ptr[2] = 0;
+						ptr[3] = t.elements[2][0];
+						ptr[4] = t.elements[0][1];
+						ptr[5] = t.elements[1][1];
+						ptr[6] = 0;
+						ptr[7] = t.elements[2][1];
+
+					} else {
+						zeromem(ptr, sizeof(float) * 8);
+					}
+
+					ptr += 16;
+				}
+			}
+		} break;
 	}
 }
 


### PR DESCRIPTION
Refactors the _notification method in cpu_particles_2d.cpp to use a switch statement instead of if statements for readability and to bring it inline with other classes like node.cpp and timer.cpp.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
