### PR TITLE
Fix incorrect switching port type in VisualShaderNodeStep

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -3032,7 +3032,7 @@ void VisualShaderNodeStep::set_op_type(OpType p_op_type) {
 				set_input_port_default_value(0, 0.0); // edge
 			}
 			if (op_type == OP_TYPE_SCALAR) {
-				set_input_port_default_value(1, 0.0); // x
+				set_input_port_default_value(1, Vector3(0.0, 0.0, 0.0)); // x
 			}
 			break;
 		default:


### PR DESCRIPTION
Fix
![bug](https://user-images.githubusercontent.com/3036176/109456815-aba87c80-7a6a-11eb-8662-8056cdda09b1.gif)
(leads to generate incorrect shader code)