### PR TITLE
Renaming rendering/2d project settings.

### DIFF
--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -227,7 +227,7 @@ Engine::Engine() {
 	_fps = 1;
 	_target_fps = 0;
 	_time_scale = 1.0;
-	_pixel_snap = false;
+	_gpu_pixel_snap = false;
 	_snap_2d_transforms = false;
 	_physics_frames = 0;
 	_idle_frames = 0;

--- a/core/engine.h
+++ b/core/engine.h
@@ -58,7 +58,7 @@ private:
 	float _fps;
 	int _target_fps;
 	float _time_scale;
-	bool _pixel_snap;
+	bool _gpu_pixel_snap;
 	bool _snap_2d_transforms;
 	bool _snap_2d_viewports;
 	uint64_t _physics_frames;
@@ -108,7 +108,7 @@ public:
 	bool has_singleton(const String &p_name) const;
 	Object *get_singleton_object(const String &p_name) const;
 
-	_FORCE_INLINE_ bool get_use_pixel_snap() const { return _pixel_snap; }
+	_FORCE_INLINE_ bool get_use_gpu_pixel_snap() const { return _gpu_pixel_snap; }
 	bool get_snap_2d_transforms() const { return _snap_2d_transforms; }
 	bool get_snap_2d_viewports() const { return _snap_2d_viewports; }
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -435,7 +435,7 @@
 		<member name="debug/shapes/collision/max_contacts_displayed" type="int" setter="" getter="" default="10000">
 			Maximum number of contact points between collision shapes to display when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
-		<member name="debug/shapes/collision/shape_color" type="Color" setter="" getter="" default="Color( 0, 0.6, 0.7, 0.5 )">
+		<member name="debug/shapes/collision/shape_color" type="Color" setter="" getter="" default="Color( 0, 0.6, 0.7, 0.42 )">
 			Color of the collision shapes, visible when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
 		<member name="debug/shapes/navigation/disabled_geometry_color" type="Color" setter="" getter="" default="Color( 1, 0.7, 0.1, 0.4 )">
@@ -1031,6 +1031,32 @@
 			Fix to improve physics jitter, specially on monitors where refresh rate is different than the physics FPS.
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_jitter_fix] instead.
 		</member>
+		<member name="rendering/2d/options/ninepatch_mode" type="int" setter="" getter="" default="0">
+			Choose between default mode where corner scalings are preserved matching the artwork, and scaling mode.
+			Not available in GLES3 when [member rendering/batching/options/use_batching] is off.
+		</member>
+		<member name="rendering/2d/options/use_nvidia_rect_flicker_workaround" type="bool" setter="" getter="" default="false">
+			Some NVIDIA GPU drivers have a bug which produces flickering issues for the [code]draw_rect[/code] method, especially as used in [TileMap]. Refer to [url=https://github.com/godotengine/godot/issues/9913]GitHub issue 9913[/url] for details.
+			If [code]true[/code], this option enables a "safe" code path for such NVIDIA GPUs at the cost of performance. This option affects GLES2 and GLES3 rendering, but only on desktop platforms.
+		</member>
+		<member name="rendering/2d/options/use_software_skinning" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], performs 2D skinning on the CPU rather than the GPU. This provides greater compatibility with a wide range of hardware, and also may be faster in some circumstances.
+			Currently only available when [member rendering/batching/options/use_batching] is active.
+			[b]Note:[/b] Antialiased software skinned polys are not supported, and will be rendered without antialiasing.
+		</member>
+		<member name="rendering/2d/snapping/use_camera_snap" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], forces snapping of 2D viewports to the nearest whole coordinate.
+			Can reduce unwanted camera relative movement in pixel art styles.
+		</member>
+		<member name="rendering/2d/snapping/use_gpu_pixel_snap" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], forces snapping of vertices to pixels in 2D rendering. May help in some pixel art styles.
+			This snapping is performed on the GPU in the vertex shader.
+			Consider using the project setting [member rendering/batching/precision/uv_contract] to prevent artifacts.
+		</member>
+		<member name="rendering/2d/snapping/use_transform_snap" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], forces snapping of 2D object transforms to the nearest whole coordinate.
+			Can help prevent unwanted relative movement in pixel art styles.
+		</member>
 		<member name="rendering/batching/debug/diagnose_frame" type="bool" setter="" getter="" default="false">
 			When batching is on, this regularly prints a frame diagnosis log. Note that this will degrade performance.
 		</member>
@@ -1123,31 +1149,6 @@
 		</member>
 		<member name="rendering/limits/time/time_rollover_secs" type="float" setter="" getter="" default="3600">
 			Shaders have a time variable that constantly increases. At some point, it needs to be rolled back to zero to avoid precision errors on shader animations. This setting specifies when (in seconds).
-		</member>
-		<member name="rendering/quality/2d/ninepatch_mode" type="int" setter="" getter="" default="0">
-			Choose between default mode where corner scalings are preserved matching the artwork, and scaling mode.
-			Not available in GLES3 when [member rendering/batching/options/use_batching] is off.
-		</member>
-		<member name="rendering/quality/2d/use_camera_snap" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], forces snapping of 2D viewports to the nearest whole coordinate.
-			Can reduce unwanted camera relative movement in pixel art styles.
-		</member>
-		<member name="rendering/quality/2d/use_nvidia_rect_flicker_workaround" type="bool" setter="" getter="" default="false">
-			Some NVIDIA GPU drivers have a bug which produces flickering issues for the [code]draw_rect[/code] method, especially as used in [TileMap]. Refer to [url=https://github.com/godotengine/godot/issues/9913]GitHub issue 9913[/url] for details.
-			If [code]true[/code], this option enables a "safe" code path for such NVIDIA GPUs at the cost of performance. This option affects GLES2 and GLES3 rendering, but only on desktop platforms.
-		</member>
-		<member name="rendering/quality/2d/use_pixel_snap" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], forces snapping of polygons to pixels in 2D rendering. May help in some pixel art styles.
-			Consider using the project setting [member rendering/batching/precision/uv_contract] to prevent artifacts.
-		</member>
-		<member name="rendering/quality/2d/use_software_skinning" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], performs 2D skinning on the CPU rather than the GPU. This provides greater compatibility with a wide range of hardware, and also may be faster in some circumstances.
-			Currently only available when [member rendering/batching/options/use_batching] is active.
-			[b]Note:[/b] Antialiased software skinned polys are not supported, and will be rendered without antialiasing.
-		</member>
-		<member name="rendering/quality/2d/use_transform_snap" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], forces snapping of 2D object transforms to the nearest whole coordinate.
-			Can help prevent unwanted relative movement in pixel art styles.
 		</member>
 		<member name="rendering/quality/depth/hdr" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], allocates the main framebuffer with high dynamic range. High dynamic range allows the use of [Color] values greater than 1.

--- a/drivers/gles2/rasterizer_canvas_base_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_base_gles2.cpp
@@ -1074,7 +1074,7 @@ void RasterizerCanvasBaseGLES2::initialize() {
 
 	state.lens_shader.init();
 
-	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_PIXEL_SNAP, GLOBAL_DEF("rendering/quality/2d/use_pixel_snap", false));
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_PIXEL_SNAP, GLOBAL_DEF("rendering/2d/snapping/use_gpu_pixel_snap", false));
 
 	state.using_light = NULL;
 	state.using_transparent_rt = false;

--- a/drivers/gles3/rasterizer_canvas_base_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_base_gles3.cpp
@@ -1292,7 +1292,7 @@ void RasterizerCanvasBaseGLES3::initialize() {
 	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_RGBA_SHADOWS, storage->config.use_rgba_2d_shadows);
 	state.canvas_shadow_shader.set_conditional(CanvasShadowShaderGLES3::USE_RGBA_SHADOWS, storage->config.use_rgba_2d_shadows);
 
-	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_PIXEL_SNAP, GLOBAL_DEF("rendering/quality/2d/use_pixel_snap", false));
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_PIXEL_SNAP, GLOBAL_DEF("rendering/2d/snapping/use_gpu_pixel_snap", false));
 }
 
 void RasterizerCanvasBaseGLES3::finalize() {

--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -969,7 +969,7 @@ PREAMBLE(void)::batch_constructor() {
 	bdata.settings_use_batching = false;
 
 #ifdef GLES_OVER_GL
-	use_nvidia_rect_workaround = GLOBAL_GET("rendering/quality/2d/use_nvidia_rect_flicker_workaround");
+	use_nvidia_rect_workaround = GLOBAL_GET("rendering/2d/options/use_nvidia_rect_flicker_workaround");
 #else
 	// Not needed (a priori) on GLES devices
 	use_nvidia_rect_workaround = false;
@@ -983,8 +983,8 @@ PREAMBLE(void)::batch_initialize() {
 	bdata.settings_item_reordering_lookahead = GLOBAL_GET("rendering/batching/parameters/item_reordering_lookahead");
 	bdata.settings_light_max_join_items = GLOBAL_GET("rendering/batching/lights/max_join_items");
 	bdata.settings_use_single_rect_fallback = GLOBAL_GET("rendering/batching/options/single_rect_fallback");
-	bdata.settings_use_software_skinning = GLOBAL_GET("rendering/quality/2d/use_software_skinning");
-	bdata.settings_ninepatch_mode = GLOBAL_GET("rendering/quality/2d/ninepatch_mode");
+	bdata.settings_use_software_skinning = GLOBAL_GET("rendering/2d/options/use_software_skinning");
+	bdata.settings_ninepatch_mode = GLOBAL_GET("rendering/2d/options/ninepatch_mode");
 
 	// alternatively only enable uv contract if pixel snap in use,
 	// but with this enable bool, it should not be necessary

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1040,7 +1040,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF("rendering/quality/driver/fallback_to_gles2", false);
 
 	// Assigning here, to be sure that it appears in docs
-	GLOBAL_DEF("rendering/quality/2d/use_nvidia_rect_flicker_workaround", false);
+	GLOBAL_DEF("rendering/2d/options/use_nvidia_rect_flicker_workaround", false);
 
 	GLOBAL_DEF("display/window/size/width", 1024);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/width", PropertyInfo(Variant::INT, "display/window/size/width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
@@ -1124,9 +1124,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->_allow_layered = false;
 	}
 
-	Engine::get_singleton()->_pixel_snap = GLOBAL_DEF("rendering/quality/2d/use_pixel_snap", false);
-	Engine::get_singleton()->_snap_2d_transforms = GLOBAL_DEF("rendering/quality/2d/use_transform_snap", false);
-	Engine::get_singleton()->_snap_2d_viewports = GLOBAL_DEF("rendering/quality/2d/use_camera_snap", false);
+	Engine::get_singleton()->_gpu_pixel_snap = GLOBAL_DEF("rendering/2d/snapping/use_gpu_pixel_snap", false);
+	Engine::get_singleton()->_snap_2d_transforms = GLOBAL_DEF("rendering/2d/snapping/use_transform_snap", false);
+	Engine::get_singleton()->_snap_2d_viewports = GLOBAL_DEF("rendering/2d/snapping/use_camera_snap", false);
 	OS::get_singleton()->_keep_screen_on = GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
 	if (rtm == -1) {
 		rtm = GLOBAL_DEF("rendering/threads/thread_model", OS::RENDER_THREAD_SAFE);

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -454,7 +454,7 @@ void AnimatedSprite::_notification(int p_what) {
 
 			if (Engine::get_singleton()->get_snap_2d_transforms()) {
 				ofs = ofs.round();
-			} else if (Engine::get_singleton()->get_use_pixel_snap()) {
+			} else if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
 				ofs = ofs.floor();
 			}
 			Rect2 dst_rect(ofs, s);

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -102,7 +102,7 @@ void Sprite::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_cli
 
 	if (Engine::get_singleton()->get_snap_2d_transforms()) {
 		dest_offset = dest_offset.round();
-	} else if (Engine::get_singleton()->get_use_pixel_snap()) {
+	} else if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
 		dest_offset = dest_offset.floor();
 	}
 
@@ -383,7 +383,7 @@ Rect2 Sprite::get_rect() const {
 		ofs -= Size2(s) / 2;
 	if (Engine::get_singleton()->get_snap_2d_transforms()) {
 		ofs = ofs.round();
-	} else if (Engine::get_singleton()->get_use_pixel_snap()) {
+	} else if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
 		ofs = ofs.floor();
 	}
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2448,9 +2448,9 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF(sz_balance_render_tree, 0.0f);
 	ProjectSettings::get_singleton()->set_custom_property_info(sz_balance_render_tree, PropertyInfo(Variant::REAL, sz_balance_render_tree, PROPERTY_HINT_RANGE, "0.0,1.0,0.01"));
 
-	GLOBAL_DEF("rendering/quality/2d/use_software_skinning", true);
-	GLOBAL_DEF("rendering/quality/2d/ninepatch_mode", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/2d/ninepatch_mode", PropertyInfo(Variant::INT, "rendering/quality/2d/ninepatch_mode", PROPERTY_HINT_ENUM, "Default,Scaling"));
+	GLOBAL_DEF("rendering/2d/options/use_software_skinning", true);
+	GLOBAL_DEF("rendering/2d/options/ninepatch_mode", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/options/ninepatch_mode", PropertyInfo(Variant::INT, "rendering/2d/options/ninepatch_mode", PROPERTY_HINT_ENUM, "Default,Scaling"));
 
 	GLOBAL_DEF("rendering/batching/options/use_batching", true);
 	GLOBAL_DEF_RST("rendering/batching/options/use_batching_in_editor", true);


### PR DESCRIPTION
The `rendering/quality/2d` section of project settings is becoming considerably expanded in 3.2.4, and arguably was not the correct place for settings that were not really to do with quality.

3.2.4 is the last sensible opportunity we will have to move these settings, as the only existing one likely to break compatibility in a small way is `pixel_snap`, and given that the whole snapping area is being overhauled we can draw attention to the fact it has changed in the release notes.

Class reference is also updated and slightly improved.

`pixel_snap` is renamed to `gpu_pixel_snap` in the project settings and code to help differentiate from CPU side transform snapping.

![projsettings2d](https://user-images.githubusercontent.com/21999379/109492930-9f7ce900-7a83-11eb-9f9f-aaaf176cdbf0.png)

## Notes
* We had a small discussion this morning and generally seemed ok with the idea of fixing this.
* People using the existing `pixel_snap` setting will need to set `gpu_pixel_snap` in the new 2d tab to get the same behaviour.
* `use_nvidia_workaround` also changes, but few people will effectively be using this now that batching is the default for GLES2 and GLES3.
* As usual let me know any suggestions for improvements / better names.
* It is clear we now have a source of confusion between `pixel_snap` and `transform_snap`. Renaming to `gpu_pixel_snap` is a compromise to try and differentiate the two. It will probably require a page in the documentation to fully go over these options once everything is finalized.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
