### PR TITLE
Prevent invalid values when resizing window (X11)

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1421,15 +1421,19 @@ void OS_X11::set_window_size(const Size2 p_size) {
 	int old_w = xwa.width;
 	int old_h = xwa.height;
 
+	Size2 size = p_size;
+	size.x = MAX(1, size.x);
+	size.y = MAX(1, size.y);
+
 	// If window resizable is disabled we need to update the attributes first
 	XSizeHints *xsh;
 	xsh = XAllocSizeHints();
 	if (!is_window_resizable()) {
 		xsh->flags = PMinSize | PMaxSize;
-		xsh->min_width = p_size.x;
-		xsh->max_width = p_size.x;
-		xsh->min_height = p_size.y;
-		xsh->max_height = p_size.y;
+		xsh->min_width = size.x;
+		xsh->max_width = size.x;
+		xsh->min_height = size.y;
+		xsh->max_height = size.y;
 	} else {
 		xsh->flags = 0L;
 		if (min_size != Size2()) {
@@ -1447,11 +1451,11 @@ void OS_X11::set_window_size(const Size2 p_size) {
 	XFree(xsh);
 
 	// Resize the window
-	XResizeWindow(x11_display, x11_window, p_size.x, p_size.y);
+	XResizeWindow(x11_display, x11_window, size.x, size.y);
 
 	// Update our videomode width and height
-	current_videomode.width = p_size.x;
-	current_videomode.height = p_size.y;
+	current_videomode.width = size.x;
+	current_videomode.height = size.y;
 
 	for (int timeout = 0; timeout < 50; ++timeout) {
 		XSync(x11_display, False);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #46187 by preventing negative or null values when resizing the window. Since this was fixed on `master` with the rewrite to the DisplayServer, I've redone the [same behaviour](https://github.com/godotengine/godot/blob/master/platform/linuxbsd/display_server_x11.cpp#L1245) for `3.2`.

I haven't touched any other `os_*.cpp` files because I don't know if their APIs handle this scenario implicitly, but it seems logic to apply this fail-safe to all systems, so I can apply this everywhere if that's desired.