### PR TITLE
MultiplayerAPI is_network_server Fails Silently

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -1170,9 +1170,7 @@ int MultiplayerAPI::get_network_unique_id() const {
 }
 
 bool MultiplayerAPI::is_network_server() const {
-	// XXX Maybe fail silently? Maybe should actually return true to make development of both local and online multiplayer easier?
-	ERR_FAIL_COND_V_MSG(!network_peer.is_valid(), false, "No network peer is assigned. I can't be a server.");
-	return network_peer->is_server();
+	return network_peer.is_valid() && network_peer->is_server();
 }
 
 void MultiplayerAPI::set_refuse_new_network_connections(bool p_refuse) {


### PR DESCRIPTION
Removes the error message when the network peer is not valid and returns false instead.

This makes it simpler to make games that are both on/offline by replacing server checks of

```
if is_instance_valid(get_tree().network_peer) and get_tree().is_network_server():
	# Do server things
```

with

```
if get_tree().is_network_server():
	# Do server things
```

I've had to use the former method in many of my own personal projects. In cases when the user needs to check if the instance is valid, they can do that separately in gdscript. To me, this seems to work better in most use-cases.

Requires no changes to the docs because both the MultiplayerAPI and SceneTree docs don't mention the error.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
