### PR TITLE
Script editor: Fix two special cases not being checked in code completion

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2261,10 +2261,9 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					}
 
 					r_arghint = _make_arguments_hint(info, p_argidx);
-					return;
 				}
 
-				if (ClassDB::is_parent_class(class_name, "Node") && (p_method == "get_node" || p_method == "has_node") && p_argidx == 0) {
+				if (p_argidx == 0 && ClassDB::is_parent_class(class_name, "Node") && (p_method == "get_node" || p_method == "has_node")) {
 					// Get autoloads
 					List<PropertyInfo> props;
 					ProjectSettings::get_singleton()->get_property_list(&props);


### PR DESCRIPTION
When this code was changed for 4.0, a "break" statement inside a for loop in 3.x was changed to "return".

This means that the two special cases (autoloads and input actions) are never checked.

Removing the return lets these work properly in the editor.

(Also reorder conditionals to short-circuit and avoid expensive methods.)
