### PR TITLE
Properly hide GraphEdit's minimap

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1558,7 +1558,12 @@ bool GraphEdit::is_minimap_enabled() const {
 }
 
 void GraphEdit::_minimap_toggled() {
-	minimap->update();
+	if (is_minimap_enabled()) {
+		minimap->set_visible(true);
+		minimap->update();
+	} else {
+		minimap->set_visible(false);
+	}
 }
 
 void GraphEdit::set_connection_lines_thickness(float p_thickness) {


### PR DESCRIPTION
Fixes #46556.

To future readers: there are some pieces of logic in `GraphEdit`'s `gui_input` handling that iterate through *every* child node and try to check if mouse events hit an interactive area of sorts. While minimap wasn't drawn, it was still technically a visible node, which confused those checks. On top of that, there are some further things happening after those checks that caused `gui_input` signal to be incorrectly propagated in visual script editor. I wasn't able to pinpoint them, but properly hiding the node does the trick anyway.