### PR TITLE
[3.2] Properly hide GraphEdit's minimap

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1620,7 +1620,12 @@ bool GraphEdit::is_minimap_enabled() const {
 }
 
 void GraphEdit::_minimap_toggled() {
-	minimap->update();
+	if (is_minimap_enabled()) {
+		minimap->set_visible(true);
+		minimap->update();
+	} else {
+		minimap->set_visible(false);
+	}
 }
 
 HBoxContainer *GraphEdit::get_zoom_hbox() {


### PR DESCRIPTION
A backport of #46563. Fixes #46556 for `3.2`.