### PR TITLE
Fix 2d camera frame delay

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -115,6 +115,9 @@
 		<member name="custom_viewport" type="Node" setter="set_custom_viewport" getter="get_custom_viewport">
 			The custom [Viewport] node attached to the [Camera2D]. If [code]null[/code] or not a [Viewport], uses the default viewport instead.
 		</member>
+		<member name="delay_fix" type="bool" setter="set_delay_fix_enabled" getter="get_delay_fix_enabled" default="false">
+			If [code]true[/code], the update of the camera to take pending scrolling into account is done at the end of the [SceneTree]'s iteration. This should help solve potential delays experienced in some projects.
+		</member>
 		<member name="drag_margin_bottom" type="float" setter="set_drag_margin" getter="get_drag_margin" default="0.2">
 			Bottom margin needed to drag the camera. A value of [code]1[/code] makes the camera move only when reaching the edge of the screen.
 		</member>

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -31,6 +31,7 @@
 #ifndef CAMERA_2D_H
 #define CAMERA_2D_H
 
+#include "core/local_vector.h"
 #include "scene/2d/node_2d.h"
 #include "scene/main/viewport.h"
 
@@ -94,6 +95,9 @@ protected:
 	bool margin_drawing_enabled;
 
 	Camera2DProcessMode process_mode;
+	bool delay_fix;
+
+	bool scroll_dirty;
 
 protected:
 	virtual Transform2D get_camera_transform();
@@ -140,6 +144,9 @@ public:
 	void set_process_mode(Camera2DProcessMode p_mode);
 	Camera2DProcessMode get_process_mode() const;
 
+	void set_delay_fix_enabled(bool p_enable);
+	bool get_delay_fix_enabled() const;
+
 	void make_current();
 	void clear_current();
 	bool is_current() const;
@@ -167,6 +174,11 @@ public:
 	bool is_margin_drawing_enabled() const;
 
 	Camera2D();
+
+	static void flush_pending_scrolls();
+
+private:
+	static LocalVector<ObjectID> _pending_scroll_cameras;
 };
 
 VARIANT_ENUM_CAST(Camera2D::AnchorMode);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -40,6 +40,7 @@
 #include "core/project_settings.h"
 #include "main/input_default.h"
 #include "node.h"
+#include "scene/2d/camera_2d.h"
 #include "scene/debugger/script_debugger_remote.h"
 #include "scene/resources/dynamic_font.h"
 #include "scene/resources/material.h"
@@ -575,6 +576,12 @@ bool SceneTree::idle(float p_time) {
 	}
 
 	flush_transform_notifications(); //additional transforms after timers update
+
+	// flush pending camera scrolls
+	Camera2D::flush_pending_scrolls();
+
+	// any further transform notifications
+	flush_transform_notifications();
 
 	_call_idle_callbacks();
 


### PR DESCRIPTION
2d cameras currently often give a frame delay between moving the camera and see the effects being updated.

This PR adds an option to use a more optimized scroll_update (guaranteed no more than 1 per frame) which occurs after all other scene tree updates, removing the frame delay. This is exposed as a property of the camera.

NEW : The property is now called `delay` and defaults to true, which is compatibility with the old camera. You will have to switch it off to get the improved camera. I think this makes sense for compatibility and how little time we have during RCs, and is safer against any regression.

Fixes #28492
Fixes #43800

## Camera Notes
* It is an expansion on the ideas in #43995 and [here](https://github.com/godotengine/godot/issues/28492#issuecomment-732183992) 

Although #43995 works, it is not very practical for merging as is as we need to have this switchable, in case of problems (at least to start with).

Using a dirty flag arrangement allows protection against multiple transform updates in a single frame hitting the Camera2D, which would result in several calls to _update_scroll in #43995. On the other hand deferring the _update_scroll requires keeping a list of pending cameras, and some care as to when the flush is made so as to work consistently with the existing order of operations.

_(You may need to download these gifs to see at 60fps, depending on your browser. The demo is based on @Securas2010 project from #46504, with a camera child of the player, which should in theory give a static player in the centre of screen. This doesn't work correctly at present (because of the frame delay) but does with the PR.)_

#### Existing Camera2D (delay present, causing ugly jitter)
![cam_delay](https://user-images.githubusercontent.com/21999379/109544581-a7f31500-7abf-11eb-8719-f3bec6252008.gif)

#### This PR with `delay` switched off for Camera2D
![cam_no_delay](https://user-images.githubusercontent.com/21999379/109544699-c6f1a700-7abf-11eb-8715-407e44eec4b6.gif)

#### Test project
Run as is to see the jitter problem as a result of camera delay. Then select the camera, and turn off `delay`, and rerun, to see the new method.
[test_camera_delay.zip](https://github.com/godotengine/godot/files/6063918/test_camera_delay.zip)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
