### PR TITLE
Fix selection error after commenting or indenting text (Fix #46477 issue)

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2993,8 +2993,6 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					} else {
 						if (cursor.line < selection.selecting_line || (cursor.line == selection.selecting_line && cursor.column < selection.selecting_column)) {
 							if (selection.shiftclick_left) {
-								SWAP(selection.from_column, selection.to_column);
-								SWAP(selection.from_line, selection.to_line);
 								selection.shiftclick_left = !selection.shiftclick_left;
 							}
 							selection.from_column = cursor.column;


### PR DESCRIPTION
Fix #46477

This problem happens in the master branch too.

As described in the issue, an error message appears in the console when : 
- selecting code from the bottom to the top
- then, commenting it (CTRL+K or popup menu) or indenting it (Tab key or popup menu)
- then Shift - Left click to resize the selection from the end of the previous one to the new cursor position.

It that case, selection end and selection begin were swaped in the code but they don't need to and cause the error message.

The 2 swaps lines has been removed in this PR and code selection is now working as expected in all cases I test.

![selection](https://user-images.githubusercontent.com/3649998/109559084-88b5b100-7ada-11eb-89ea-6cb3f57912a7.gif)


