### PR TITLE
Fix crash on HTTPClient::poll method

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -96,6 +96,11 @@ Error HTTPClient::connect_to_host(const String &p_host, int p_port, bool p_ssl, 
 void HTTPClient::set_connection(const Ref<StreamPeer> &p_connection) {
 	ERR_FAIL_COND_MSG(p_connection.is_null(), "Connection is not a reference to a valid StreamPeer object.");
 
+	if (ssl) {
+		ERR_FAIL_NULL_MSG(Object::cast_to<StreamPeerSSL>(p_connection.ptr()),
+				"Connection is not a reference to a valid StreamPeerSSL object.");
+	}
+
 	if (connection == p_connection) {
 		return;
 	}


### PR DESCRIPTION
The problem happened because `poll` assumed that when the SSL flag was true, the `connection` would be a subclass of StreamPeerSSL. However that invariant could be broken by calling HTTPClient::set_connection with a `connection` that is not a subclass of StreamPeerSSL.

Fixes #46138