### PR TITLE
Fix duplicate check for bone names in FBX import

### DIFF
--- a/modules/fbx/data/fbx_skeleton.cpp
+++ b/modules/fbx/data/fbx_skeleton.cpp
@@ -69,7 +69,7 @@ void FBXSkeleton::init_skeleton(const ImportState &state) {
 			// Make sure the bone name is unique.
 			const String bone_name = bone->bone_name;
 			int same_name_count = 0;
-			for (int y = x; y < skeleton_bone_count; y++) {
+			for (int y = x + 1; y < skeleton_bone_count; y++) {
 				Ref<FBXBone> other_bone = skeleton_bones[y];
 				if (other_bone.is_valid()) {
 					if (other_bone->bone_name == bone_name) {


### PR DESCRIPTION
This fixes a really dumb little regression in the FBX import that caused the check for duplicate bone names to find itself as the duplicate. 

@RevoluPowered is fixing this in master as part of a bigger set of improvements, but as it's rather important I'm putting the fix forward for 3.2.4 :)