### PR TITLE
Fix Joint2D/Joint3D node path reset on scene switch

### DIFF
--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -49,19 +49,9 @@ void Joint2D::_disconnect_signals() {
 	}
 }
 
-void Joint2D::_body_exit_tree(const ObjectID &p_body_id) {
+void Joint2D::_body_exit_tree() {
 	_disconnect_signals();
-	Object *object = ObjectDB::get_instance(p_body_id);
-	PhysicsBody2D *body = Object::cast_to<PhysicsBody2D>(object);
-	ERR_FAIL_NULL(body);
-	RID body_rid = body->get_rid();
-	if (ba == body_rid) {
-		a = NodePath();
-	}
-	if (bb == body_rid) {
-		b = NodePath();
-	}
-	_update_joint();
+	_update_joint(true);
 }
 
 void Joint2D::_update_joint(bool p_only_free) {
@@ -142,8 +132,8 @@ void Joint2D::_update_joint(bool p_only_free) {
 	ba = body_a->get_rid();
 	bb = body_b->get_rid();
 
-	body_a->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree), make_binds(body_a->get_instance_id()));
-	body_b->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree), make_binds(body_b->get_instance_id()));
+	body_a->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree));
+	body_b->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint2D::_body_exit_tree));
 
 	PhysicsServer2D::get_singleton()->joint_disable_collisions_between_bodies(joint, exclude_from_collision);
 }

--- a/scene/2d/joints_2d.h
+++ b/scene/2d/joints_2d.h
@@ -51,7 +51,7 @@ class Joint2D : public Node2D {
 
 protected:
 	void _disconnect_signals();
-	void _body_exit_tree(const ObjectID &p_body_id);
+	void _body_exit_tree();
 	void _update_joint(bool p_only_free = false);
 
 	void _notification(int p_what);

--- a/scene/3d/physics_joint_3d.cpp
+++ b/scene/3d/physics_joint_3d.cpp
@@ -46,19 +46,9 @@ void Joint3D::_disconnect_signals() {
 	}
 }
 
-void Joint3D::_body_exit_tree(const ObjectID &p_body_id) {
+void Joint3D::_body_exit_tree() {
 	_disconnect_signals();
-	Object *object = ObjectDB::get_instance(p_body_id);
-	PhysicsBody3D *body = Object::cast_to<PhysicsBody3D>(object);
-	ERR_FAIL_NULL(body);
-	RID body_rid = body->get_rid();
-	if (ba == body_rid) {
-		a = NodePath();
-	}
-	if (bb == body_rid) {
-		b = NodePath();
-	}
-	_update_joint();
+	_update_joint(true);
 }
 
 void Joint3D::_update_joint(bool p_only_free) {
@@ -133,12 +123,12 @@ void Joint3D::_update_joint(bool p_only_free) {
 
 	if (body_a) {
 		ba = body_a->get_rid();
-		body_a->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint3D::_body_exit_tree), make_binds(body_a->get_instance_id()));
+		body_a->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint3D::_body_exit_tree));
 	}
 
 	if (body_b) {
 		bb = body_b->get_rid();
-		body_b->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint3D::_body_exit_tree), make_binds(body_b->get_instance_id()));
+		body_b->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Joint3D::_body_exit_tree));
 	}
 
 	PhysicsServer3D::get_singleton()->joint_disable_collisions_between_bodies(joint, exclude_from_collision);

--- a/scene/3d/physics_joint_3d.h
+++ b/scene/3d/physics_joint_3d.h
@@ -51,7 +51,7 @@ class Joint3D : public Node3D {
 
 protected:
 	void _disconnect_signals();
-	void _body_exit_tree(const ObjectID &p_body_id);
+	void _body_exit_tree();
 	void _update_joint(bool p_only_free = false);
 
 	void _notification(int p_what);


### PR DESCRIPTION
When one of the bodies exited the tree, the corresponding node path was reset instead of just resetting the joint from the physics server. That was causing the node path to be reset on scene switch when one of the bodies is under the joint in the scene tree.

Regression from #44703
Fixes #46571
Tested with case from #44510, still fixed.