### PR TITLE
[3.2] Fix Joint2D/Joint node path reset on scene switch

### DIFF
--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -48,18 +48,10 @@ void Joint2D::_disconnect_signals() {
 		body_b->disconnect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
 }
 
-void Joint2D::_body_exit_tree(const ObjectID &p_body_id) {
+void Joint2D::_body_exit_tree() {
 
 	_disconnect_signals();
-	Object *object = ObjectDB::get_instance(p_body_id);
-	PhysicsBody2D *body = Object::cast_to<PhysicsBody2D>(object);
-	ERR_FAIL_NULL(body);
-	RID body_rid = body->get_rid();
-	if (ba == body_rid)
-		a = NodePath();
-	if (bb == body_rid)
-		b = NodePath();
-	_update_joint();
+	_update_joint(true);
 }
 
 void Joint2D::_update_joint(bool p_only_free) {
@@ -135,8 +127,8 @@ void Joint2D::_update_joint(bool p_only_free) {
 	ba = body_a->get_rid();
 	bb = body_b->get_rid();
 
-	body_a->connect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(body_a->get_instance_id()));
-	body_b->connect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(body_b->get_instance_id()));
+	body_a->connect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+	body_b->connect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
 
 	Physics2DServer::get_singleton()->joint_disable_collisions_between_bodies(joint, exclude_from_collision);
 }
@@ -233,7 +225,7 @@ String Joint2D::get_configuration_warning() const {
 
 void Joint2D::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_body_exit_tree", "body_rid"), &Joint2D::_body_exit_tree);
+	ClassDB::bind_method(D_METHOD("_body_exit_tree"), &Joint2D::_body_exit_tree);
 
 	ClassDB::bind_method(D_METHOD("set_node_a", "node"), &Joint2D::set_node_a);
 	ClassDB::bind_method(D_METHOD("get_node_a"), &Joint2D::get_node_a);

--- a/scene/2d/joints_2d.h
+++ b/scene/2d/joints_2d.h
@@ -51,7 +51,7 @@ class Joint2D : public Node2D {
 
 protected:
 	void _disconnect_signals();
-	void _body_exit_tree(const ObjectID &p_body_id);
+	void _body_exit_tree();
 	void _update_joint(bool p_only_free = false);
 
 	void _notification(int p_what);

--- a/scene/3d/physics_joint.cpp
+++ b/scene/3d/physics_joint.cpp
@@ -45,18 +45,10 @@ void Joint::_disconnect_signals() {
 		body_b->disconnect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
 }
 
-void Joint::_body_exit_tree(const ObjectID &p_body_id) {
+void Joint::_body_exit_tree() {
 
 	_disconnect_signals();
-	Object *object = ObjectDB::get_instance(p_body_id);
-	PhysicsBody *body = Object::cast_to<PhysicsBody>(object);
-	ERR_FAIL_NULL(body);
-	RID body_rid = body->get_rid();
-	if (ba == body_rid)
-		a = NodePath();
-	if (bb == body_rid)
-		b = NodePath();
-	_update_joint();
+	_update_joint(true);
 }
 
 void Joint::_update_joint(bool p_only_free) {
@@ -126,12 +118,12 @@ void Joint::_update_joint(bool p_only_free) {
 
 	if (body_a) {
 		ba = body_a->get_rid();
-		body_a->connect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(body_a->get_instance_id()));
+		body_a->connect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
 	}
 
 	if (body_b) {
 		bb = body_b->get_rid();
-		body_b->connect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(body_b->get_instance_id()));
+		body_b->connect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
 	}
 
 	PhysicsServer::get_singleton()->joint_disable_collisions_between_bodies(joint, exclude_from_collision);
@@ -228,7 +220,7 @@ String Joint::get_configuration_warning() const {
 
 void Joint::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_body_exit_tree", "body_rid"), &Joint::_body_exit_tree);
+	ClassDB::bind_method(D_METHOD("_body_exit_tree"), &Joint::_body_exit_tree);
 
 	ClassDB::bind_method(D_METHOD("set_node_a", "node"), &Joint::set_node_a);
 	ClassDB::bind_method(D_METHOD("get_node_a"), &Joint::get_node_a);

--- a/scene/3d/physics_joint.h
+++ b/scene/3d/physics_joint.h
@@ -51,7 +51,7 @@ class Joint : public Spatial {
 
 protected:
 	void _disconnect_signals();
-	void _body_exit_tree(const ObjectID &p_body_id);
+	void _body_exit_tree();
 	void _update_joint(bool p_only_free = false);
 
 	void _notification(int p_what);


### PR DESCRIPTION
When one of the bodies exited the tree, the corresponding node path was reset instead of just resetting the joint from the physics server. That was causing the node path to be reset on scene switch when one of the bodies is under the joint in the scene tree.

Backported from PR #46578

Regression from #44703
Fixes #46571
Tested with case from #44510, still fixed.
