### PR TITLE
Improve height limit of PopupMenu of OptionButton/MenuButton

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -58,14 +58,37 @@ void MenuButton::_unhandled_key_input(Ref<InputEvent> p_event) {
 void MenuButton::pressed() {
 	Size2 size = get_size();
 
-	Point2 gp = get_screen_position();
-	gp.y += get_size().y;
+	int screen_height = popup->get_usable_parent_rect().size.height;
+	int content_height = popup->get_contents_size().height;
 
-	popup->set_position(gp);
+	int min_height = MIN(screen_height, content_height);
+
+	int button_height = size.height * get_global_transform().get_scale().y;
+	int button_bottom_position = get_screen_position().y + button_height;
+
+	// Decide if the popup shows below the button
+	bool popup_below = true;
+	if (screen_height - button_bottom_position < min_height && screen_height - button_bottom_position < get_screen_position().y) {
+		popup_below = false;
+	}
+
+	// Set the popup position
+	if (popup_below) {
+		// Set a valid height limit to override the default one (the usable parent rect height)
+		popup->set_height_limit(screen_height - get_screen_position().y - button_height);
+
+		popup->set_position(get_screen_position() + Size2(0, button_height));
+	} else {
+		popup->set_height_limit(get_screen_position().y);
+
+		if (min_height < get_screen_position().y) {
+			popup->set_position(get_screen_position() - Size2(0, min_height));
+		} else {
+			popup->set_position(Size2(get_screen_position().x, 0));
+		}
+	}
 
 	popup->set_size(Size2(size.width, 0));
-	popup->set_parent_rect(Rect2(Point2(gp - popup->get_position()), get_size()));
-	popup->take_mouse_focus();
 	popup->popup();
 }
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -116,7 +116,37 @@ void OptionButton::_selected(int p_which) {
 
 void OptionButton::pressed() {
 	Size2 size = get_size();
-	popup->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
+
+	int screen_height = popup->get_usable_parent_rect().size.height;
+	int content_height = popup->get_contents_size().height;
+
+	int min_height = MIN(screen_height, content_height);
+
+	int button_height = size.height * get_global_transform().get_scale().y;
+	int button_bottom_position = get_screen_position().y + button_height;
+
+	// Decide if the popup shows below the button
+	bool popup_below = true;
+	if (screen_height - button_bottom_position < min_height && screen_height - button_bottom_position < get_screen_position().y) {
+		popup_below = false;
+	}
+
+	// Set the popup position
+	if (popup_below) {
+		// Set a valid height limit to override the default one (the usable parent rect height)
+		popup->set_height_limit(screen_height - get_screen_position().y - button_height);
+
+		popup->set_position(get_screen_position() + Size2(0, button_height));
+	} else {
+		popup->set_height_limit(get_screen_position().y);
+
+		if (min_height < get_screen_position().y) {
+			popup->set_position(get_screen_position() - Size2(0, min_height));
+		} else {
+			popup->set_position(Size2(get_screen_position().x, 0));
+		}
+	}
+
 	popup->set_size(Size2(size.width, 0));
 	popup->popup();
 }

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -45,7 +45,7 @@ String PopupMenu::_get_accel_text(const Item &p_item) const {
 	return String();
 }
 
-Size2 PopupMenu::_get_contents_minimum_size() const {
+Size2 PopupMenu::get_contents_size() const {
 	int vseparation = get_theme_constant("vseparation");
 	int hseparation = get_theme_constant("hseparation");
 
@@ -96,10 +96,18 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 		minsize.width += check_w;
 	}
 
+	return minsize;
+}
+
+Size2 PopupMenu::_get_contents_minimum_size() const {
+	Size2 minsize = get_contents_size();
+
 	if (is_inside_tree()) {
-		int height_limit = get_usable_parent_rect().size.height;
-		if (minsize.height > height_limit) {
-			minsize.height = height_limit;
+		// If a valid height limit is set, use it. Else, use the usable parent rect height as limit
+		if (get_height_limit() > -1) {
+			minsize.height = MIN(minsize.height, get_height_limit());
+		} else {
+			minsize.height = MIN(minsize.height, get_usable_parent_rect().size.height);
 		}
 	}
 
@@ -1541,6 +1549,14 @@ void PopupMenu::set_allow_search(bool p_allow) {
 
 bool PopupMenu::get_allow_search() const {
 	return allow_search;
+}
+
+void PopupMenu::set_height_limit(int p_height_limit) {
+	height_limit = p_height_limit;
+}
+
+int PopupMenu::get_height_limit() const {
+	return height_limit;
 }
 
 String PopupMenu::get_tooltip(const Point2 &p_pos) const {

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -139,6 +139,8 @@ class PopupMenu : public Popup {
 	void _minimum_lifetime_timeout();
 	void _close_pressed();
 
+	int height_limit = -1;
+
 protected:
 	friend class MenuButton;
 	void _notification(int p_what);
@@ -248,6 +250,11 @@ public:
 	virtual void popup(const Rect2 &p_bounds = Rect2());
 
 	void take_mouse_focus();
+
+	void set_height_limit(int p_height_limit);
+	int get_height_limit() const;
+
+	Size2 get_contents_size() const;
 
 	PopupMenu();
 	~PopupMenu();


### PR DESCRIPTION
Fixes #46545. The issue has been there for a while (since I started using Godot 4.0 actually). I solved the issue by adding an additional property `extra_height_limit` to PopupMenu (not exposed to users). I don't know if this is acceptable or if there are more appropriate solutions, so any suggestions are welcome.

Result:
![popup_menu_3](https://user-images.githubusercontent.com/28705694/109596892-154f8600-7b52-11eb-8d6f-30c78ce2c6cf.gif)
![popup_menu_4](https://user-images.githubusercontent.com/28705694/109596894-15e81c80-7b52-11eb-9064-803fdbee7b38.gif)

Along the way I made this fix, I found another bug related to PopupMenu in Project Settings and Editor Settings when Single Window Mode is enabled. But that isn't caused by this PR.
![popup_menu_5](https://user-images.githubusercontent.com/28705694/109597237-cf46f200-7b52-11eb-95d5-d898f7d0c4b0.gif)