### PR TITLE
Fix rounding error in Clip Content [4.0]

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -148,6 +148,8 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		} else {
 			ci->final_clip_rect = global_rect;
 		}
+		ci->final_clip_rect.position = ci->final_clip_rect.position.round();
+		ci->final_clip_rect.size = ci->final_clip_rect.size.round();
 		ci->final_clip_owner = ci;
 
 	} else {


### PR DESCRIPTION
Rounds the position and size of the final clip rect to avoid flickering issues.

Fixes https://github.com/godotengine/godot/issues/46493

3.2 version: https://github.com/godotengine/godot/pull/46495
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Before (notice the artifact at bottom and clipped edge at the top)
![image](https://user-images.githubusercontent.com/43449832/109403881-b03d3a00-7971-11eb-9957-86df8f3720ed.png)

After (notice the smooth edge at the top)
![image](https://user-images.githubusercontent.com/43449832/109403869-9bf93d00-7971-11eb-9b25-585af15bb988.png)

