### PR TITLE
Fix no tween repeat after stop and restart (Fix #39801)

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -869,8 +869,21 @@ void Tween::start() {
 		return;
 	}
 
+	pending_update++;
+	for (List<InterpolateData>::Element *E = interpolates.front(); E; E = E->next()) {
+		InterpolateData &data = E->get();
+		data.active = true;
+	}
+	pending_update--;
+
 	// We want to be activated
 	set_active(true);
+
+	// Don't resume from current position if stop_all() function has been used
+	if (was_stopped) {
+		seek(0);
+	}
+	was_stopped = false;
 }
 
 void Tween::reset(Object *p_object, StringName p_key) {
@@ -939,7 +952,7 @@ void Tween::stop(Object *p_object, StringName p_key) {
 void Tween::stop_all() {
 	// We no longer need to be active since all tweens have been stopped
 	set_active(false);
-
+	was_stopped = true;
 	// For each interpolation...
 	pending_update++;
 	for (List<InterpolateData>::Element *E = interpolates.front(); E; E = E->next()) {

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -107,6 +107,7 @@ private:
 	float speed_scale = 1.0;
 	mutable int pending_update = 0;
 	int uid = 0;
+	bool was_stopped = false;
 
 	List<InterpolateData> interpolates;
 


### PR DESCRIPTION
Fix #40679

When a tween was stopped, each interpolation in the list was set to active=false
then, the main active bool was set to false.

When starting the tween again, the main active bool was set to true but not each interpolation in the list : so no repeat was happening.

I've added a for loop to reactivate each interpolation in the interpolates list when start() is called.
Need to seek to 0.0 too (only if tween has been stopped by stop_all()) because we don't want start() to act as resume() after stop_all().