### PR TITLE
Transform snapping moved to AdvancedSettings

### DIFF
--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -33,6 +33,7 @@
 #include "core/authors.gen.h"
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
+#include "core/snappers.h"
 #include "core/version.h"
 #include "core/version_hash.gen.h"
 
@@ -228,13 +229,21 @@ Engine::Engine() {
 	_target_fps = 0;
 	_time_scale = 1.0;
 	_gpu_pixel_snap = false;
-	_snap_2d_transforms = false;
 	_physics_frames = 0;
 	_idle_frames = 0;
 	_in_physics = false;
 	_frame_ticks = 0;
 	_frame_step = 0;
 	editor_hint = false;
+
+	_snappers = memnew(Snappers);
+}
+
+Engine::~Engine() {
+	if (_snappers) {
+		memdelete(_snappers);
+		_snappers = nullptr;
+	}
 }
 
 Engine::Singleton::Singleton(const StringName &p_name, Object *p_ptr) :

--- a/core/engine.h
+++ b/core/engine.h
@@ -36,6 +36,8 @@
 #include "core/ustring.h"
 #include "core/vector.h"
 
+class Snappers;
+
 class Engine {
 
 public:
@@ -58,14 +60,14 @@ private:
 	float _fps;
 	int _target_fps;
 	float _time_scale;
-	bool _gpu_pixel_snap;
-	bool _snap_2d_transforms;
-	bool _snap_2d_viewports;
 	uint64_t _physics_frames;
 	float _physics_interpolation_fraction;
 
 	uint64_t _idle_frames;
 	bool _in_physics;
+
+	bool _gpu_pixel_snap;
+	Snappers *_snappers;
 
 	List<Singleton> singletons;
 	Map<StringName, Object *> singleton_ptrs;
@@ -109,8 +111,8 @@ public:
 	Object *get_singleton_object(const String &p_name) const;
 
 	_FORCE_INLINE_ bool get_use_gpu_pixel_snap() const { return _gpu_pixel_snap; }
-	bool get_snap_2d_transforms() const { return _snap_2d_transforms; }
-	bool get_snap_2d_viewports() const { return _snap_2d_viewports; }
+	const Snappers &get_snappers() const { return *_snappers; }
+	Snappers &get_snappers() { return *_snappers; }
 
 #ifdef TOOLS_ENABLED
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) { editor_hint = p_enabled; }
@@ -128,7 +130,7 @@ public:
 	String get_license_text() const;
 
 	Engine();
-	virtual ~Engine() {}
+	virtual ~Engine();
 };
 
 #endif // ENGINE_H

--- a/core/snappers.cpp
+++ b/core/snappers.cpp
@@ -1,0 +1,74 @@
+/*************************************************************************/
+/*  snappers.cpp                                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "snappers.h"
+#include "core/project_settings.h"
+
+void Snappers::snap_read_item(Vector2 &r_pos) const {
+	if (snapper_canvas_item_read.is_enabled()) {
+		snapper_canvas_item_read.snap(r_pos);
+	} else if (_gpu_snap_enabled) {
+		r_pos = r_pos.floor();
+	}
+}
+
+void Snappers::set_stretch_mode(String p_mode) {
+	_stretch_mode_viewport = p_mode == "viewport";
+}
+
+void Snappers::set_transform_snap_2d(AdvancedSettings::Snap2DType p_type, AdvancedSettings::RoundMode p_mode_x, AdvancedSettings::RoundMode p_mode_y) {
+	switch (p_type) {
+		case AdvancedSettings::SNAP2D_TYPE_ITEM_PRE: {
+			snapper_canvas_item_pre.set_snap_modes(p_mode_x, p_mode_y);
+		} break;
+		case AdvancedSettings::SNAP2D_TYPE_ITEM_POST: {
+			snapper_canvas_item_post.set_snap_modes(p_mode_x, p_mode_y);
+		} break;
+		case AdvancedSettings::SNAP2D_TYPE_ITEM_READ: {
+			snapper_canvas_item_read.set_snap_modes(p_mode_x, p_mode_y);
+		} break;
+		case AdvancedSettings::SNAP2D_TYPE_VIEWPORT_PRE: {
+			snapper_viewport_pre.set_snap_modes(p_mode_x, p_mode_y);
+		} break;
+		case AdvancedSettings::SNAP2D_TYPE_VIEWPORT_POST: {
+			snapper_viewport_post.set_snap_modes(p_mode_x, p_mode_y);
+		} break;
+		case AdvancedSettings::SNAP2D_TYPE_VIEWPORT_PARENT_PRE: {
+			snapper_viewport_parent_pre.set_snap_modes(p_mode_x, p_mode_y);
+		} break;
+		default: {
+		} break;
+	}
+}
+
+void Snappers::initialize(bool p_gpu_snap) {
+	_gpu_snap_enabled = p_gpu_snap;
+	_snap_transforms_enabled = false;
+}

--- a/core/snappers.h
+++ b/core/snappers.h
@@ -1,0 +1,108 @@
+/*************************************************************************/
+/*  snappers.h                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SNAPPERS_H
+#define SNAPPERS_H
+
+#include "core/math/math_funcs.h"
+#include "core/math/vector2.h"
+#include "scene/main/advanced_settings.h"
+
+// generic class for handling 2d snapping
+class Snapper2D {
+public:
+	void snap(Vector2 &r_pos) const {
+		if (!_enabled) {
+			return;
+		}
+
+		r_pos.x = snap_value(r_pos.x, _snap_mode_x);
+		r_pos.y = snap_value(r_pos.y, _snap_mode_y);
+	}
+
+	void set_snap_modes(AdvancedSettings::RoundMode p_mode_x, AdvancedSettings::RoundMode p_mode_y) {
+		_snap_mode_x = p_mode_x;
+		_snap_mode_y = p_mode_y;
+		_enabled = !((_snap_mode_x == AdvancedSettings::ROUND_MODE_DISABLED) && (_snap_mode_y == AdvancedSettings::ROUND_MODE_DISABLED));
+	}
+
+	bool is_enabled() const { return _enabled; }
+
+private:
+	real_t snap_value(real_t p_value, AdvancedSettings::RoundMode p_mode) const {
+		switch (p_mode) {
+			default:
+				break;
+			case AdvancedSettings::ROUND_MODE_FLOOR: {
+				return Math::floor(p_value);
+			} break;
+			case AdvancedSettings::ROUND_MODE_CEILING: {
+				return Math::ceil(p_value);
+			} break;
+			case AdvancedSettings::ROUND_MODE_ROUND: {
+				return Math::round(p_value);
+			} break;
+		}
+		return p_value;
+	}
+
+	bool _enabled = false;
+	AdvancedSettings::RoundMode _snap_mode_x = AdvancedSettings::ROUND_MODE_DISABLED;
+	AdvancedSettings::RoundMode _snap_mode_y = AdvancedSettings::ROUND_MODE_DISABLED;
+};
+
+// All the 2D snapping in one place.
+// This is called from the various places it needs to be introduced, but the logic
+// can be self contained here to make it easier to change / debug.
+class Snappers {
+public:
+	void initialize(bool p_gpu_snap);
+	void set_stretch_mode(String p_mode);
+	void set_transform_snap_2d(AdvancedSettings::Snap2DType p_type, AdvancedSettings::RoundMode p_mode_x, AdvancedSettings::RoundMode p_mode_y);
+
+	// for positioning of sprites etc, not the main draw call
+	void snap_read_item(Vector2 &r_pos) const;
+
+	Snapper2D snapper_canvas_item_pre;
+	Snapper2D snapper_canvas_item_post;
+	Snapper2D snapper_canvas_item_read;
+
+	Snapper2D snapper_viewport_pre;
+	Snapper2D snapper_viewport_post;
+	Snapper2D snapper_viewport_parent_pre;
+
+private:
+	// local version
+	bool _gpu_snap_enabled = false;
+	bool _snap_transforms_enabled = false;
+	bool _stretch_mode_viewport = false;
+};
+
+#endif // SNAPPERS_H

--- a/doc/classes/AdvancedSettings.xml
+++ b/doc/classes/AdvancedSettings.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AdvancedSettings" inherits="Reference" version="3.2">
+	<brief_description>
+		Access to engine advanced settings.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="set_transform_snap_2d">
+			<return type="void">
+			</return>
+			<argument index="0" name="snap_type" type="int" enum="AdvancedSettings.Snap2DType">
+			</argument>
+			<argument index="1" name="mode_x" type="int" enum="AdvancedSettings.RoundMode">
+				Round mode applied to x coordinate.
+			</argument>
+			<argument index="2" name="mode_y" type="int" enum="AdvancedSettings.RoundMode">
+				Round mode applied to y coordinate.
+				Note that in Godot 2D, y increases down the screen, so using ceiling mode may give a better result than floor.
+			</argument>
+			<description>
+				Gives total control over CPU transform snapping.
+				The engine defaults to all transform snapping disabled, but you can specify rounding modes for each part of the 2d pipeline. Items are items to be drawn, and viewports normally equate to cameras.
+				In general, for [code]viewport[/code] window stretch mode, pre transform snapping is most relevant, and for [code]2d[/code] window stretch mode, post transform snapping is most relevant.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="SNAP2D_TYPE_ITEM_PRE" value="0" enum="Snap2DType">
+			Snap the item local position when drawing.
+		</constant>
+		<constant name="SNAP2D_TYPE_ITEM_POST" value="1" enum="Snap2DType">
+			Snap the item position after applying parent transform when drawing.
+		</constant>
+		<constant name="SNAP2D_TYPE_ITEM_READ" value="2" enum="Snap2DType">
+			Snap the item local position when reading.
+		</constant>
+		<constant name="SNAP2D_TYPE_VIEWPORT_PRE" value="3" enum="Snap2DType">
+			Snap canvas position.
+		</constant>
+		<constant name="SNAP2D_TYPE_VIEWPORT_POST" value="4" enum="Snap2DType">
+			Snap canvas position after applying global transform.
+		</constant>
+		<constant name="SNAP2D_TYPE_VIEWPORT_PARENT_PRE" value="5" enum="Snap2DType">
+			Snap canvas parent transform.
+		</constant>
+		<constant name="ROUND_MODE_DISABLED" value="0" enum="RoundMode">
+			No snapping applied.
+		</constant>
+		<constant name="ROUND_MODE_FLOOR" value="1" enum="RoundMode">
+			Snapping uses floor function (rounds down to the nearest whole number).
+		</constant>
+		<constant name="ROUND_MODE_CEILING" value="2" enum="RoundMode">
+			Snapping uses ceiling function (rounds up to the nearest whole number).
+		</constant>
+		<constant name="ROUND_MODE_ROUND" value="3" enum="RoundMode">
+			Snapping uses round function (rounds to the nearest whole number).
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1044,18 +1044,10 @@
 			Currently only available when [member rendering/batching/options/use_batching] is active.
 			[b]Note:[/b] Antialiased software skinned polys are not supported, and will be rendered without antialiasing.
 		</member>
-		<member name="rendering/2d/snapping/use_camera_snap" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], forces snapping of 2D viewports to the nearest whole coordinate.
-			Can reduce unwanted camera relative movement in pixel art styles.
-		</member>
 		<member name="rendering/2d/snapping/use_gpu_pixel_snap" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], forces snapping of vertices to pixels in 2D rendering. May help in some pixel art styles.
 			This snapping is performed on the GPU in the vertex shader.
 			Consider using the project setting [member rendering/batching/precision/uv_contract] to prevent artifacts.
-		</member>
-		<member name="rendering/2d/snapping/use_transform_snap" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], forces snapping of 2D object transforms to the nearest whole coordinate.
-			Can help prevent unwanted relative movement in pixel art styles.
 		</member>
 		<member name="rendering/batching/debug/diagnose_frame" type="bool" setter="" getter="" default="false">
 			When batching is on, this regularly prints a frame diagnosis log. Note that this will degrade performance.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -45,6 +45,7 @@
 #include "core/register_core_types.h"
 #include "core/script_debugger_local.h"
 #include "core/script_language.h"
+#include "core/snappers.h"
 #include "core/translation.h"
 #include "core/version.h"
 #include "core/version_hash.gen.h"
@@ -1125,8 +1126,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	Engine::get_singleton()->_gpu_pixel_snap = GLOBAL_DEF("rendering/2d/snapping/use_gpu_pixel_snap", false);
-	Engine::get_singleton()->_snap_2d_transforms = GLOBAL_DEF("rendering/2d/snapping/use_transform_snap", false);
-	Engine::get_singleton()->_snap_2d_viewports = GLOBAL_DEF("rendering/2d/snapping/use_camera_snap", false);
+	Engine::get_singleton()->_snappers->initialize(Engine::get_singleton()->get_use_gpu_pixel_snap());
+
 	OS::get_singleton()->_keep_screen_on = GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
 	if (rtm == -1) {
 		rtm = GLOBAL_DEF("rendering/threads/thread_model", OS::RENDER_THREAD_SAFE);
@@ -1823,11 +1824,15 @@ bool Main::start() {
 			Size2i stretch_size = Size2(GLOBAL_DEF("display/window/size/width", 0), GLOBAL_DEF("display/window/size/height", 0));
 			real_t stretch_shrink = GLOBAL_DEF("display/window/stretch/shrink", 1.0);
 
+			// the snappers need to know the stretch_mode
+			Engine::get_singleton()->_snappers->set_stretch_mode(stretch_mode);
+
 			SceneTree::StretchMode sml_sm = SceneTree::STRETCH_MODE_DISABLED;
 			if (stretch_mode == "2d")
 				sml_sm = SceneTree::STRETCH_MODE_2D;
-			else if (stretch_mode == "viewport")
+			else if (stretch_mode == "viewport") {
 				sml_sm = SceneTree::STRETCH_MODE_VIEWPORT;
+			}
 
 			SceneTree::StretchAspect sml_aspect = SceneTree::STRETCH_ASPECT_IGNORE;
 			if (stretch_aspect == "keep")

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -31,6 +31,7 @@
 #include "animated_sprite.h"
 
 #include "core/os/os.h"
+#include "core/snappers.h"
 #include "scene/scene_string_names.h"
 
 #define NORMAL_SUFFIX "_normal"
@@ -452,11 +453,7 @@ void AnimatedSprite::_notification(int p_what) {
 			if (centered)
 				ofs -= s / 2;
 
-			if (Engine::get_singleton()->get_snap_2d_transforms()) {
-				ofs = ofs.round();
-			} else if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
-				ofs = ofs.floor();
-			}
+			Engine::get_singleton()->get_snappers().snap_read_item(ofs);
 			Rect2 dst_rect(ofs, s);
 
 			if (hflip)

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -31,6 +31,7 @@
 #include "sprite.h"
 #include "core/core_string_names.h"
 #include "core/os/os.h"
+#include "core/snappers.h"
 #include "scene/main/viewport.h"
 #include "scene/scene_string_names.h"
 
@@ -100,11 +101,7 @@ void Sprite::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_cli
 	if (centered)
 		dest_offset -= frame_size / 2;
 
-	if (Engine::get_singleton()->get_snap_2d_transforms()) {
-		dest_offset = dest_offset.round();
-	} else if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
-		dest_offset = dest_offset.floor();
-	}
+	Engine::get_singleton()->get_snappers().snap_read_item(dest_offset);
 
 	r_dst_rect = Rect2(dest_offset, frame_size);
 
@@ -381,11 +378,8 @@ Rect2 Sprite::get_rect() const {
 	Point2 ofs = offset;
 	if (centered)
 		ofs -= Size2(s) / 2;
-	if (Engine::get_singleton()->get_snap_2d_transforms()) {
-		ofs = ofs.round();
-	} else if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
-		ofs = ofs.floor();
-	}
+
+	Engine::get_singleton()->get_snappers().snap_read_item(ofs);
 
 	if (s == Size2(0, 0))
 		s = Size2(1, 1);

--- a/scene/main/advanced_settings.cpp
+++ b/scene/main/advanced_settings.cpp
@@ -1,0 +1,57 @@
+/*************************************************************************/
+/*  advanced_settings.cpp                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "advanced_settings.h"
+#include "core/engine.h"
+#include "core/snappers.h"
+
+VARIANT_ENUM_CAST(AdvancedSettings::Snap2DType);
+VARIANT_ENUM_CAST(AdvancedSettings::RoundMode);
+
+void AdvancedSettings::set_transform_snap_2d(Snap2DType p_type, RoundMode p_mode_x, RoundMode p_mode_y) {
+	Engine::get_singleton()->get_snappers().set_transform_snap_2d(p_type, p_mode_x, p_mode_y);
+}
+
+void AdvancedSettings::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("set_transform_snap_2d", "snap_type", "mode_x", "mode_y"), &AdvancedSettings::set_transform_snap_2d);
+
+	BIND_ENUM_CONSTANT(SNAP2D_TYPE_ITEM_PRE);
+	BIND_ENUM_CONSTANT(SNAP2D_TYPE_ITEM_POST);
+	BIND_ENUM_CONSTANT(SNAP2D_TYPE_ITEM_READ);
+	BIND_ENUM_CONSTANT(SNAP2D_TYPE_VIEWPORT_PRE);
+	BIND_ENUM_CONSTANT(SNAP2D_TYPE_VIEWPORT_POST);
+	BIND_ENUM_CONSTANT(SNAP2D_TYPE_VIEWPORT_PARENT_PRE);
+
+	BIND_ENUM_CONSTANT(ROUND_MODE_DISABLED);
+	BIND_ENUM_CONSTANT(ROUND_MODE_FLOOR);
+	BIND_ENUM_CONSTANT(ROUND_MODE_CEILING);
+	BIND_ENUM_CONSTANT(ROUND_MODE_ROUND);
+}

--- a/scene/main/advanced_settings.h
+++ b/scene/main/advanced_settings.h
@@ -1,0 +1,62 @@
+/*************************************************************************/
+/*  advanced_settings.h                                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ADVANCED_SETTINGS_H
+#define ADVANCED_SETTINGS_H
+
+#include "scene/main/node.h"
+
+class AdvancedSettings : public Reference {
+	GDCLASS(AdvancedSettings, Reference);
+
+public:
+	enum Snap2DType {
+		SNAP2D_TYPE_ITEM_PRE,
+		SNAP2D_TYPE_ITEM_POST,
+		SNAP2D_TYPE_ITEM_READ,
+		SNAP2D_TYPE_VIEWPORT_PRE,
+		SNAP2D_TYPE_VIEWPORT_POST,
+		SNAP2D_TYPE_VIEWPORT_PARENT_PRE,
+	};
+
+	enum RoundMode {
+		ROUND_MODE_DISABLED,
+		ROUND_MODE_FLOOR,
+		ROUND_MODE_CEILING,
+		ROUND_MODE_ROUND,
+	};
+
+	void set_transform_snap_2d(Snap2DType p_type, RoundMode p_mode_x, RoundMode p_mode_y);
+
+protected:
+	static void _bind_methods();
+};
+
+#endif // ADVANCED_SETTINGS_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -120,6 +120,7 @@
 #include "scene/gui/tree.h"
 #include "scene/gui/video_player.h"
 #include "scene/gui/viewport_container.h"
+#include "scene/main/advanced_settings.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/http_request.h"
 #include "scene/main/instance_placeholder.h"
@@ -267,6 +268,7 @@ void register_scene_types() {
 	ClassDB::register_class<ViewportTexture>();
 	ClassDB::register_class<HTTPRequest>();
 	ClassDB::register_class<Timer>();
+	ClassDB::register_class<AdvancedSettings>();
 	ClassDB::register_class<CanvasLayer>();
 	ClassDB::register_class<CanvasModulate>();
 	ClassDB::register_class<ResourcePreloader>();

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -158,7 +158,6 @@ public:
 	RID_Owner<RasterizerCanvas::Light> canvas_light_owner;
 
 	bool disable_scale;
-	bool snap_2d_transforms;
 
 private:
 	void _render_canvas_item_tree(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RasterizerCanvas::Light *p_lights);

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -31,6 +31,7 @@
 #include "visual_server_viewport.h"
 
 #include "core/project_settings.h"
+#include "core/snappers.h"
 #include "visual_server_canvas.h"
 #include "visual_server_globals.h"
 #include "visual_server_scene.h"
@@ -41,23 +42,25 @@ static Transform2D _canvas_get_transform(VisualServerViewport::Viewport *p_viewp
 
 	float scale = 1.0;
 
-	bool snap = Engine::get_singleton()->get_snap_2d_viewports();
+	const Snappers &snappers = Engine::get_singleton()->get_snappers();
 
 	if (p_viewport->canvas_map.has(p_canvas->parent)) {
 
 		Transform2D c_xform = p_viewport->canvas_map[p_canvas->parent].transform;
-		if (snap) {
-			c_xform.elements[2] = c_xform.elements[2].round();
-		}
+
+		snappers.snapper_viewport_parent_pre.snap(c_xform.elements[2]);
+
 		xf = xf * c_xform;
 		scale = p_canvas->parent_scale;
 	}
 
 	Transform2D c_xform = p_canvas_data->transform;
-	if (snap) {
-		c_xform.elements[2] = c_xform.elements[2].round();
-	}
+
+	// opportunity to snap pre and post the transform being applied..
+	// pre may be better for stretch_mode viewport, post better for stretch_mode 2D
+	snappers.snapper_viewport_pre.snap(c_xform.elements[2]);
 	xf = xf * c_xform;
+	snappers.snapper_viewport_post.snap(xf.elements[2]);
 
 	if (scale != 1.0 && !VSG::canvas->disable_scale) {
 		Vector2 pivot = p_vp_size * 0.5;


### PR DESCRIPTION
Transform snapping is made totally customizable, but is removed from project settings. It can now only be set from script etc using a new GDCLASS, AdvancedSettings.

This PR is one of two options, the other is #46615.

## About
As 3.2.4 release is approaching rapidly, I have to admit there are several aspects I'm not happy with concerning the `transform_snapping` (originally proposed by m6502).

* Although it offers a lot of potential, it seems to introduce as many problems as it solves.
* In particular it has the tendency to introduce judder due to aliasing (or sampling error) between the snapped items and the fractional actual positions of items, and of course the position of the camera which is again fractional.
* This aliasing also occurs with anything off of the grid, such as fractionally scaled parallax layers.
* There is an interaction with physics, whereby physics vibrations can cause jarring amplified vibrations in the snapped result.
* The best snapping settings may vary in different games (and especially varies according to window `stretch_mode`).
* It is clear that users have an oversimplified and idealistic view of how `transform_snapping` will work and fix their games.

So at this stage we have 3 choices as I see it:
1) Fully expose snapping settings as project settings, as in #46569
2) Remove transform snapping, and perhaps revisit it in 3.2.5
3) Keep the functionality available, but hide it

So far I've been working along the lines of (1), but feedback so far indicates that the majority of people interested in trying the technique are not aware of how it works, when it should be used, and what the pitfalls are. This all suggests that if we make the functionality readily accessible we will be deluged by support requests for issues that are bogus.

There is, as yet, no facility for advanced project settings in 3.2. Even a UI accessible advanced option can be problematic because users are likely to change these while experimenting, and file bogus issue reports for the inevitable side effects.

So instead I'm quite a fan of adding some hidden settings to the engine, that are pretty much 'don't mess with these unless you know what you are doing'. This would seem to be a good place to put snapping functionality, at least for the time being.

I see having the functions available from script as being a compromise between removing the snapping from 3.2.4 entirely, and exposing something which is clearly problematic for beginners.

## Typical use
```
func _ready():
	var ad = AdvancedSettings.new()
	ad.set_transform_snap_2d(AdvancedSettings.SNAP2D_TYPE_ITEM_PRE, AdvancedSettings.ROUND_MODE_ROUND, AdvancedSettings.ROUND_MODE_ROUND)
```
The AdvancedSettings class is currently derived from Reference rather than Node, I don't think it needs to be a Node. The settings can be set as a one off at startup of the project. This also has the advantage it is harder to accidentally leave one of them set incorrectly, and they are only active at runtime.

#### Camera
As an aside, the camera delay fixes are very easy to use and definitely beneficial so I'll be splitting these into a separate PR later this morning (I really shouldn't have combined them in the same PR initially).

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
