### PR TITLE
Add size check in BakedLightmapData::_set_user_data()

### DIFF
--- a/scene/3d/baked_lightmap.cpp
+++ b/scene/3d/baked_lightmap.cpp
@@ -78,6 +78,7 @@ void BakedLightmapData::clear_users() {
 }
 
 void BakedLightmapData::_set_user_data(const Array &p_data) {
+	ERR_FAIL_COND(p_data.size() <= 0);
 	ERR_FAIL_COND((p_data.size() % 4) != 0);
 
 	for (int i = 0; i < p_data.size(); i += 4) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #45996
add size check to prevent crash when executing ```BakedLightmapData.new()._set_user_data([])```