### PR TITLE
Add size check in Control::_edit_set_state()  to fix crash

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -73,6 +73,10 @@ Dictionary Control::_edit_get_state() const {
 }
 
 void Control::_edit_set_state(const Dictionary &p_state) {
+	ERR_FAIL_COND((p_state.size() <= 0) ||
+				  p_state["rotation"].is_null() || p_state["scale"].is_null() ||
+				  p_state["pivot"].is_null() || p_state["anchors"].is_null() || p_state["offsets"].is_null());
+
 	Dictionary state = p_state;
 
 	set_rotation(state["rotation"]);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #46017
add size check to prevent crash when executing ```Control.new()._edit_set_state({})```