### PR TITLE
Fix incorrect auto-indentation in multiline brackets (fix #46384)

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2199,9 +2199,14 @@ void TextEdit::_new_line(bool p_split_current_line, bool p_above) {
 
 				// No need to move the brace below if we are not taking the text with us.
 				char32_t closing_char = _get_right_pair_symbol(indent_char);
-				if ((closing_char != 0) && (closing_char == text[cursor.line][cursor.column]) && !p_split_current_line) {
-					brace_indent = true;
-					ins += "\n" + ins.substr(1, ins.length() - 2);
+				if ((closing_char != 0) && (closing_char == text[cursor.line][cursor.column])) {
+					if (p_split_current_line) {
+						brace_indent = true;
+						ins += "\n" + ins.substr(1, ins.length() - 2);
+					} else {
+						brace_indent = false;
+						ins = "\n" + ins.substr(1, ins.length() - 2);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fix #46384 

Closing bracket was not send at the correct indentation when a new line was added inside a pair of brackets.

Changed made in this PR :

In the function TextEdit::_new_line() : p_split_current_line boolean test was not correct (a true value couldn't pass the testing condition and p_split_current_line is true for a classic new line (ENTER).

![brace_ident](https://user-images.githubusercontent.com/3649998/109852446-12898980-7c55-11eb-9cec-4ff238b9bb62.gif)
