### PR TITLE
Deselect column only if belongs to deselected item

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3354,10 +3354,10 @@ void Tree::item_selected(int p_column, TreeItem *p_item) {
 void Tree::item_deselected(int p_column, TreeItem *p_item) {
 	if (selected_item == p_item) {
 		selected_item = nullptr;
-	}
 
-	if (selected_col == p_column) {
-		selected_col = -1;
+		if (selected_col == p_column) {
+			selected_col = -1;
+		}
 	}
 
 	if (select_mode == SELECT_MULTI || select_mode == SELECT_SINGLE) {


### PR DESCRIPTION
Another regression from #45806 🙄

Fixes #46589
I didn't investigate thoroughly, but I assume what caused the issue was something like
-item1 gets selected
-item2 gets deselected
-the same column is selected, so it's deselected by item2

This PR prevents that. Doesn't seem like deselecting column from another TreeItem happens anywhere, so hopefully nothing will break this time.