### PR TITLE
Hide .gdignore'd folders

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -762,11 +762,18 @@ void EditorFileDialog::update_file_list() {
 			continue;
 		}
 
-		if (show_hidden_files || !dir_access->current_is_hidden()) {
+		if (show_hidden_files) {
 			if (!dir_access->current_is_dir()) {
 				files.push_back(item);
 			} else {
 				dirs.push_back(item);
+			}
+		} else if (!dir_access->current_is_hidden()) {
+			String full_path = cdir == "res://" ? item : dir_access->get_current_dir() + "/" + item;
+			if (dir_access->current_is_dir() && !EditorFileSystem::_should_skip_directory(full_path)) {
+				dirs.push_back(item);
+			} else {
+				files.push_back(item);
 			}
 		}
 	}


### PR DESCRIPTION
Hide `.gdignore`'d folders in the file dialog.

Fixes #37758

*Bugsquad edit:* Also fixes #37638 since `.godot/` is `.gdignore`'d.