### PR TITLE
Fix crash trying to destroy an ImageTexture object containing a null texture

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -151,7 +151,7 @@ void ImageTexture::_reload_hook(const RID &p_hook) {
 }
 
 void ImageTexture::create_from_image(const Ref<Image> &p_image) {
-	ERR_FAIL_COND_MSG(p_image.is_null(), "Invalid image");
+	ERR_FAIL_COND_MSG(p_image.is_null() || p_image->is_empty(), "Invalid image");
 	w = p_image->get_width();
 	h = p_image->get_height();
 	format = p_image->get_format();


### PR DESCRIPTION
The problem happened when `ImageTexture::create_from_image` was called with an empty image. In this situation an RID was allocated despite the texture being null. The destructor would then crash trying to acess this null texture.

Fixes #46274