### PR TITLE
Revert backport of 2D transform and camera snapping options

### DIFF
--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -228,7 +228,6 @@ Engine::Engine() {
 	_target_fps = 0;
 	_time_scale = 1.0;
 	_gpu_pixel_snap = false;
-	_snap_2d_transforms = false;
 	_physics_frames = 0;
 	_idle_frames = 0;
 	_in_physics = false;

--- a/core/engine.h
+++ b/core/engine.h
@@ -59,8 +59,6 @@ private:
 	int _target_fps;
 	float _time_scale;
 	bool _gpu_pixel_snap;
-	bool _snap_2d_transforms;
-	bool _snap_2d_viewports;
 	uint64_t _physics_frames;
 	float _physics_interpolation_fraction;
 
@@ -109,8 +107,6 @@ public:
 	Object *get_singleton_object(const String &p_name) const;
 
 	_FORCE_INLINE_ bool get_use_gpu_pixel_snap() const { return _gpu_pixel_snap; }
-	bool get_snap_2d_transforms() const { return _snap_2d_transforms; }
-	bool get_snap_2d_viewports() const { return _snap_2d_viewports; }
 
 #ifdef TOOLS_ENABLED
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) { editor_hint = p_enabled; }

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1046,18 +1046,10 @@
 			Currently only available when [member rendering/batching/options/use_batching] is active.
 			[b]Note:[/b] Antialiased software skinned polys are not supported, and will be rendered without antialiasing.
 		</member>
-		<member name="rendering/2d/snapping/use_camera_snap" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], forces snapping of 2D viewports to the nearest whole coordinate.
-			Can reduce unwanted camera relative movement in pixel art styles.
-		</member>
 		<member name="rendering/2d/snapping/use_gpu_pixel_snap" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], forces snapping of vertices to pixels in 2D rendering. May help in some pixel art styles.
 			This snapping is performed on the GPU in the vertex shader.
 			Consider using the project setting [member rendering/batching/precision/uv_contract] to prevent artifacts.
-		</member>
-		<member name="rendering/2d/snapping/use_transform_snap" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], forces snapping of 2D object transforms to the nearest whole coordinate.
-			Can help prevent unwanted relative movement in pixel art styles.
 		</member>
 		<member name="rendering/batching/debug/diagnose_frame" type="bool" setter="" getter="" default="false">
 			When batching is on, this regularly prints a frame diagnosis log. Note that this will degrade performance.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1127,8 +1127,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	Engine::get_singleton()->_gpu_pixel_snap = GLOBAL_DEF("rendering/2d/snapping/use_gpu_pixel_snap", false);
-	Engine::get_singleton()->_snap_2d_transforms = GLOBAL_DEF("rendering/2d/snapping/use_transform_snap", false);
-	Engine::get_singleton()->_snap_2d_viewports = GLOBAL_DEF("rendering/2d/snapping/use_camera_snap", false);
+
 	OS::get_singleton()->_keep_screen_on = GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
 	if (rtm == -1) {
 		rtm = GLOBAL_DEF("rendering/threads/thread_model", OS::RENDER_THREAD_SAFE);

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -452,9 +452,7 @@ void AnimatedSprite::_notification(int p_what) {
 			if (centered)
 				ofs -= s / 2;
 
-			if (Engine::get_singleton()->get_snap_2d_transforms()) {
-				ofs = ofs.round();
-			} else if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
+			if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
 				ofs = ofs.floor();
 			}
 			Rect2 dst_rect(ofs, s);

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -100,9 +100,7 @@ void Sprite::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_cli
 	if (centered)
 		dest_offset -= frame_size / 2;
 
-	if (Engine::get_singleton()->get_snap_2d_transforms()) {
-		dest_offset = dest_offset.round();
-	} else if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
+	if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
 		dest_offset = dest_offset.floor();
 	}
 
@@ -381,9 +379,7 @@ Rect2 Sprite::get_rect() const {
 	Point2 ofs = offset;
 	if (centered)
 		ofs -= Size2(s) / 2;
-	if (Engine::get_singleton()->get_snap_2d_transforms()) {
-		ofs = ofs.round();
-	} else if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
+	if (Engine::get_singleton()->get_use_gpu_pixel_snap()) {
 		ofs = ofs.floor();
 	}
 

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -99,9 +99,6 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 
 	Rect2 rect = ci->get_rect();
 	Transform2D xform = ci->xform;
-	if (snap_2d_transforms) {
-		xform.elements[2] = xform.elements[2].round();
-	}
 	xform = p_transform * xform;
 
 	Rect2 global_rect = xform.xform(rect);
@@ -1484,7 +1481,6 @@ VisualServerCanvas::VisualServerCanvas() {
 	z_last_list = (RasterizerCanvas::Item **)memalloc(z_range * sizeof(RasterizerCanvas::Item *));
 
 	disable_scale = false;
-	snap_2d_transforms = Engine::get_singleton()->get_snap_2d_transforms();
 }
 
 VisualServerCanvas::~VisualServerCanvas() {

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -158,7 +158,6 @@ public:
 	RID_Owner<RasterizerCanvas::Light> canvas_light_owner;
 
 	bool disable_scale;
-	bool snap_2d_transforms;
 
 private:
 	void _render_canvas_item_tree(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RasterizerCanvas::Light *p_lights);

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -41,22 +41,14 @@ static Transform2D _canvas_get_transform(VisualServerViewport::Viewport *p_viewp
 
 	float scale = 1.0;
 
-	bool snap = Engine::get_singleton()->get_snap_2d_viewports();
-
 	if (p_viewport->canvas_map.has(p_canvas->parent)) {
 
 		Transform2D c_xform = p_viewport->canvas_map[p_canvas->parent].transform;
-		if (snap) {
-			c_xform.elements[2] = c_xform.elements[2].round();
-		}
 		xf = xf * c_xform;
 		scale = p_canvas->parent_scale;
 	}
 
 	Transform2D c_xform = p_canvas_data->transform;
-	if (snap) {
-		c_xform.elements[2] = c_xform.elements[2].round();
-	}
 	xf = xf * c_xform;
 
 	if (scale != 1.0 && !VSG::canvas->disable_scale) {


### PR DESCRIPTION
As discussed in https://github.com/godotengine/godot/pull/46615#issuecomment-790647994 I think there are a number of problem with `transform_snapping` currently and we should leave this until 3.2.5.

We can either mark the existing functions as experimental or revert, personally I'm in favour of reverting for 3.2.4, because I'm not keen on having broken functionality in stable release. Some might argue that the existing functions were helpful but we have to weigh that up against user confusion and expectations.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
