### PR TITLE
Use safer `add_theme_constant_override()` in MarginContainer code sample

### DIFF
--- a/doc/classes/MarginContainer.xml
+++ b/doc/classes/MarginContainer.xml
@@ -7,11 +7,12 @@
 		Adds a top, left, bottom, and right margin to all [Control] nodes that are direct children of the container. To control the [MarginContainer]'s margin, use the [code]margin_*[/code] theme properties listed below.
 		[b]Note:[/b] Be careful, [Control] margin values are different than the constant margin values. If you want to change the custom margin values of the [MarginContainer] by code, you should use the following examples:
 		[codeblock]
+		# This code sample assumes the current script is extending MarginContainer.
 		var margin_value = 100
-		set("custom_constants/margin_top", margin_value)
-		set("custom_constants/margin_left", margin_value)
-		set("custom_constants/margin_bottom", margin_value)
-		set("custom_constants/margin_right", margin_value)
+		add_constant_override("margin_top", margin_value)
+		add_constant_override("margin_left", margin_value)
+		add_constant_override("margin_bottom", margin_value)
+		add_constant_override("margin_right", margin_value)
 		[/codeblock]
 	</description>
 	<tutorials>


### PR DESCRIPTION
`3.2` version of https://github.com/godotengine/godot/pull/46663.

Control has magic setters to set custom theme items, but using the dedicated Control methods is less prone to typos so it should be favored.