### PR TITLE
Fix errors and crash with empty ConvexPolygonShape2D

### DIFF
--- a/scene/resources/convex_polygon_shape_2d.cpp
+++ b/scene/resources/convex_polygon_shape_2d.cpp
@@ -72,6 +72,10 @@ void ConvexPolygonShape2D::_bind_methods() {
 }
 
 void ConvexPolygonShape2D::draw(const RID &p_to_rid, const Color &p_color) {
+	if (points.size() < 3) {
+		return;
+	}
+
 	Vector<Color> col;
 	col.push_back(p_color);
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);


### PR DESCRIPTION
Fixes crash mentioned in https://github.com/godotengine/godot/issues/45724#issuecomment-790620260, regression from #46291 and errors that were already present when trying to draw an invalid convex polygon.