### PR TITLE
Fix a crash when using Input.get_joy_button_index_from_string()

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -1296,7 +1296,7 @@ static const char *_buttons[JOY_BUTTON_MAX] = {
 	"DPAD Up",
 	"DPAD Down",
 	"DPAD Left",
-	"DPAD Right"
+	"DPAD Right",
 	"Misc 1",
 	"Paddle 1",
 	"Paddle 2",


### PR DESCRIPTION
 **Issue** : Executing InputDefault::get_joy_button_index_from_string crashes Godot #46619

The initialization size of the __buttons_ variable is larger than its number of elements which causes a crash when _get_joy_button_index_from_string()_ loops over it and performs a string comparison on its elements.

I've fixed it by following what has been done with another array _(_axes_) : which is simply adding a new element as an empty string to the __buttons_ array so the number of elements match the size.

*Bugsquad edit:* Fixes #46619.