### PR TITLE
Add missing ERR_FAIL_INDEX check to Variant::construct

### DIFF
--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -773,6 +773,7 @@ void Variant::_unregister_variant_constructors() {
 }
 
 void Variant::construct(Variant::Type p_type, Variant &base, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	ERR_FAIL_INDEX(p_type, Variant::VARIANT_MAX);
 	uint32_t s = construct_data[p_type].size();
 	for (uint32_t i = 0; i < s; i++) {
 		int argc = construct_data[p_type][i].argument_count;


### PR DESCRIPTION
Other functions in the same file validate parameters using the ERR_FAIL
macros. This validation was missing for Variant::construct resulting in
a crash when called with invalid data (p_type < 0).

fix #46067

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
