### PR TITLE
Fix missing ImageTexture::create_from_image call in GPUParticles3DEditor::_generate_emission_points

### DIFF
--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -328,7 +328,6 @@ void GPUParticles3DEditor::edit(GPUParticles3D *p_particles) {
 }
 
 void GPUParticles3DEditor::_generate_emission_points() {
-	/// hacer codigo aca
 	Vector<Vector3> points;
 	Vector<Vector3> normals;
 
@@ -360,6 +359,7 @@ void GPUParticles3DEditor::_generate_emission_points() {
 
 	Ref<ImageTexture> tex;
 	tex.instance();
+	tex->create_from_image(image);
 
 	Ref<ParticlesMaterial> material = node->get_process_material();
 	ERR_FAIL_COND(material.is_null());
@@ -388,6 +388,7 @@ void GPUParticles3DEditor::_generate_emission_points() {
 
 		Ref<ImageTexture> tex2;
 		tex2.instance();
+		tex2->create_from_image(image2);
 
 		material->set_emission_normal_texture(tex2);
 	} else {


### PR DESCRIPTION
From my understand, the texture for emission particles is create in this function. Additionally, there is the option to also generate a normal map, enabling the use of _direct emission points_.

It is likely that the `create_from_image` call got lost during some refactoring as mentioned in the related issue. While I have not tested this feature, it does not look like dead code to me, and the difference might be hard to notice for very bright, small particles. The code looks _more correct_ to me with this patch.

- - -

Images for emission point texture and normals were created, but not
transferred to textures.

fix #43643

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
