### PR TITLE
Improving the Raycast2D debug Shape 

### DIFF
--- a/scene/2d/ray_cast_2d.h
+++ b/scene/2d/ray_cast_2d.h
@@ -51,6 +51,8 @@ class RayCast2D : public Node2D {
 	bool collide_with_areas = false;
 	bool collide_with_bodies = true;
 
+	void _draw_debug_shape();
+
 protected:
 	void _notification(int p_what);
 	void _update_raycast_state();


### PR DESCRIPTION
This is the 2D sister of #46529. 

This PR improves the usage of the debug shape for Raycast2D (and match the 3D behaviour):

![ray2DOld](https://user-images.githubusercontent.com/6397893/110024627-a54a2700-7d2e-11eb-9c25-028c55a86867.png)

- Highlight the shape when the ray collide (like in 3D)
- Correct the size of the ray, currently the shape displayed is bigger than the actual ray (the arrowhead exceeds) which is confusing.
- Decrease a bit the thickness to make the usability better for low resolution game.

![before-after](https://user-images.githubusercontent.com/6397893/110024697-b430d980-7d2e-11eb-8eb6-738c2f6f0293.png)