### PR TITLE
Batching - fix custom MODULATE shader applying modulate twice

### DIFF
--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -480,10 +480,10 @@ FRAGMENT_SHADER_CODE
 #endif
 	}
 
+#if !defined(MODULATE_USED)
 #ifdef USE_ATTRIB_MODULATE
 	color *= modulate_interp;
 #else
-#if !defined(MODULATE_USED)
 	color *= final_modulate;
 #endif
 #endif


### PR DESCRIPTION
One of the new fvf types (FVF_MODULATED) allows batching custom shaders that use modulate. The only slight oversight is that there is a special define when MODULATE is used in a custom shader, called MODULATE_USED, that is checked, and if set it does NOT apply final_modulate as part of canvas.glsl.

This MODULATE_USED define wasn't checked when the new FVF was used and modulate was passed in an attribute.

This PR moves the application of the final_modulate into the #ifndef MODULATE_USED section.

Fixes #46546

## Notes
* I'll have to do some rigorous testing on this. It fixes the bug which looks like a small oversight in the canvas.glsl when I added the modulate attribute, but I'm a bit rusty on the batching and we don't want to introduce any regressions so close to release.
* I *think* this should be okay, because MODULATE_USED in the shader gets set by the line:
```
	actions[VS::SHADER_CANVAS_ITEM].usage_defines["MODULATE"] = "#define MODULATE_USED\n";
```
which is a property of the shader / material. So by definition it will only have an effect in a custom shader that uses MODULATE, and should not affect custom shaders that e.g. just use COLOR but not MODULATE.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
