### PR TITLE
push error if @onready not used with get_node outside a function

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -574,6 +574,17 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 				for (List<GDScriptParser::AnnotationNode *>::Element *E = member.variable->annotations.front(); E; E = E->next()) {
 					E->get()->apply(parser, member.variable);
 				}
+
+				if ((member.variable->initializer->type == GDScriptParser::Node::GET_NODE && !member.variable->onready)) {
+					push_error(vformat(R"*(Cannot get node when the scene tree isn't ready. Use "@onready var %s = get_node(...)" instead.)*", member.variable->identifier->name), member.variable->initializer);
+				}
+
+				if (member.variable->initializer->type == GDScriptParser::Node::CALL) {
+					GDScriptParser::CallNode *p_call = static_cast<GDScriptParser::CallNode *>(member.variable->initializer);
+					if (p_call->function_name == "get_node" && !member.variable->onready) {
+						push_error(vformat(R"*(Cannot get node when the scene tree isn't ready. Use "@onready var %s = get_node(...)" instead.)*", member.variable->identifier->name), member.variable->initializer);
+					}
+				}
 			} break;
 			case GDScriptParser::ClassNode::Member::CONSTANT: {
 				reduce_expression(member.constant->initializer);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #46382