### PR TITLE
[3.2] Various light culling fixes

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2317,8 +2317,8 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 
 			if (!unshaded && e->light_index < RenderList::MAX_LIGHTS) {
 				light = render_light_instances[e->light_index];
-				if (e->instance->baked_light && light->light_ptr->bake_mode == VS::LIGHT_BAKE_ALL) {
-					light = NULL; // Don't use this light, it is already included in the lightmap
+				if ((e->instance->baked_light && light->light_ptr->bake_mode == VS::LIGHT_BAKE_ALL) || (e->instance->layer_mask & light->light_ptr->cull_mask) == 0) {
+					light = NULL; // Don't use this light, it is culled or already included in the lightmap
 				}
 			}
 

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -831,6 +831,7 @@ public:
 
 	LightInstance *directional_light;
 	LightInstance *directional_lights[RenderList::MAX_DIRECTIONAL_LIGHTS];
+	RID first_directional_light;
 
 	RenderList render_list;
 


### PR DESCRIPTION
**GLES3**

This commit makes it possible to disable 3D directional lights by using the light's cull mask. It also automatically disables directionals when the object has baked lighting and the light is set to "bake all".

While these changes work fine, they have some downsides due to the current structure of the GLES3 renderer:
- Object sorting is done only once for all directional lights, so there is no way to sort the enabled/disabled objects for each light. 
This results in more GL state changes and can have some performance hit (only happens if directional lights affect some objects and not others).

- Environment lighting is always done in the first pass, regardless of the corresponding directional light being enabled or not.
This means in some cases there will be a first pass with env light only (disabled light) and a second pass with an enabled light only, instead of merging the two passes in a single one.

**GLES2**

Added a check for the light cull mask, since it was previously ignored.



Fixes #46332. Fixes #19438.