### PR TITLE
Fix Camera2D frame delay

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -231,8 +231,9 @@ void Camera2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 
-			if (!is_processing_internal() && !is_physics_processing_internal())
+			if (!smoothing_enabled || Engine::get_singleton()->is_editor_hint()) {
 				_update_scroll();
+			}
 
 		} break;
 		case NOTIFICATION_ENTER_TREE: {


### PR DESCRIPTION
Fixes camera frame delay by always doing a scroll update except when smoothing is active.

From discussion with reduz we identified the problem of the frame delay comes down to two things:

1) The scroll update when receiving transform notification is only done when process and internal process are inactive, which was probably a longhand for when the smoothing was off.
2) Users can create scripts which turn on process (and this PR #4407 possibly), or something is (see below) thus this logic fails.

The solution was to check directly a flag for when smoothing is switched on.

Fixes #28492
Fixes #43800

## Notes
* Also although in theory it should be on all the time because it is a bug, I want to sound out whether we should have a bool to allow the previous delay, which could be seen as a feature(!) by some :grin: 
* This is alternative approach to that in #46569
* Also I've spotted that in `_update_process_mode()` it sets the process mode as a one-off depending on whether you have it set to `CAMERA2D_PROCESS_IDLE` or not. This could also be the root cause of the bug, because it is not switching this on and off according to whether smoothing is on or off, so causing the logic to fail.


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
