### PR TITLE
Fix removal of `rect_min_size` not triggering resize

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -285,15 +285,11 @@ void Control::_update_minimum_size() {
 	}
 
 	Size2 minsize = get_combined_minimum_size();
-	if (minsize.x > data.size_cache.x ||
-			minsize.y > data.size_cache.y) {
-		_size_changed();
-	}
-
 	data.updating_last_minimum_size = false;
 
 	if (minsize != data.last_minimum_size) {
 		data.last_minimum_size = minsize;
+		_size_changed();
 		emit_signal(SceneStringNames::get_singleton()->minimum_size_changed);
 	}
 }


### PR DESCRIPTION
When you had a `minimum size` and remove it, the control wasn't be resized. Instead it jumped to the automatically calculated size on the next change of the actual size. With this change the control will recalculate it's size, when the minimum size is removed (`Vector(0,0)`)

fixes #46672
*Bugsquad edit:* Fixes #21803 Fixes #40454