### PR TITLE
Fix negative VRAM values

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -566,7 +566,7 @@ struct _OSCoreBindImg {
 
 void _OS::print_all_textures_by_size() {
 	List<_OSCoreBindImg> imgs;
-	int total = 0;
+	uint64_t total = 0;
 	{
 		List<Ref<Resource>> rsrc;
 		ResourceCache::get_cached_resources(&rsrc);

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -674,7 +674,7 @@ public:
 	void render_info_end_capture() override {}
 	int get_captured_render_info(RS::RenderInfo p_info) override { return 0; }
 
-	int get_render_info(RS::RenderInfo p_info) override { return 0; }
+	uint64_t get_render_info(RS::RenderInfo p_info) override { return 0; }
 	String get_video_adapter_name() const override { return String(); }
 	String get_video_adapter_vendor() const override { return String(); }
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -343,7 +343,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		DebuggerMarshalls::ResourceUsage usage;
 		usage.deserialize(p_data);
 
-		int total = 0;
+		uint64_t total = 0;
 
 		for (List<DebuggerMarshalls::ResourceInfo>::Element *E = usage.infos.front(); E; E = E->next()) {
 			TreeItem *it = vmem_tree->create_item(root);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -2263,7 +2263,7 @@ public:
 	void render_info_end_capture() {}
 	int get_captured_render_info(RS::RenderInfo p_info) { return 0; }
 
-	int get_render_info(RS::RenderInfo p_info) { return 0; }
+	uint64_t get_render_info(RS::RenderInfo p_info) { return 0; }
 	String get_video_adapter_name() const { return String(); }
 	String get_video_adapter_vendor() const { return String(); }
 

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -608,7 +608,7 @@ public:
 	virtual void render_info_end_capture() = 0;
 	virtual int get_captured_render_info(RS::RenderInfo p_info) = 0;
 
-	virtual int get_render_info(RS::RenderInfo p_info) = 0;
+	virtual uint64_t get_render_info(RS::RenderInfo p_info) = 0;
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
 

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -257,7 +257,7 @@ void RenderingServerDefault::finish() {
 
 /* STATUS INFORMATION */
 
-int RenderingServerDefault::get_render_info(RenderInfo p_info) {
+uint64_t RenderingServerDefault::get_render_info(RenderInfo p_info) {
 	return RSG::storage->get_render_info(p_info);
 }
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -901,7 +901,7 @@ public:
 
 	/* STATUS INFORMATION */
 
-	virtual int get_render_info(RenderInfo p_info) override;
+	virtual uint64_t get_render_info(RenderInfo p_info) override;
 	virtual String get_video_adapter_name() const override;
 	virtual String get_video_adapter_vendor() const override;
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1419,7 +1419,7 @@ public:
 		INFO_VERTEX_MEM_USED,
 	};
 
-	virtual int get_render_info(RenderInfo p_info) = 0;
+	virtual uint64_t get_render_info(RenderInfo p_info) = 0;
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes negative values for VRAM when usage exceeds 2GB.

I have no way to physically test this as my graphics card has only 2GB VRAM; plus, the monitors aren't working on `master` yet..? But I introduced artificial values to test, and it seems to work:
![image](https://user-images.githubusercontent.com/6501975/110177572-1526e300-7dfd-11eb-9ab3-2ade670e1f12.png)

Fixes #46692