### PR TITLE
Fix GDScript Tokenizer being very strict about the number of underscores

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -633,6 +633,8 @@ GDScriptTokenizer::Token GDScriptTokenizer::number() {
 				push_error(error);
 			}
 			previous_was_underscore = true;
+		} else {
+			previous_was_underscore = false;
 		}
 		_advance();
 	}
@@ -704,6 +706,8 @@ GDScriptTokenizer::Token GDScriptTokenizer::number() {
 						push_error(error);
 					}
 					previous_was_underscore = true;
+				} else {
+					previous_was_underscore = false;
 				}
 				_advance();
 			}


### PR DESCRIPTION
I was to lazy to open an issue, too. So here the bug:
```gdscript
var score : int = 0b000_000_000
```
results in:
```
  built-in:12 - Parse Error: Only one underscore can be used as a numeric separator.
  modules\gdscript\gdscript.cpp:816 - Method/function failed. Returning: ERR_PARSE_ERROR
```
According to the 3.2 docs the above is valid for any number. This issue applies to any number, not just binaries. As the issue applies to all numbers, the fix does too 😄 
(For the reference, I group by three bits, because I make a quick'n dirty tic tac toe game)