### PR TITLE
Improve process logic in Camera2D

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -65,15 +65,13 @@ void Camera2D::_update_scroll() {
 
 void Camera2D::_update_process_mode() {
 
-	if (Engine::get_singleton()->is_editor_hint()) {
-		set_process_internal(false);
-		set_physics_process_internal(false);
-	} else if (process_mode == CAMERA2D_PROCESS_IDLE) {
-		set_process_internal(true);
+	// smoothing can be enabled in the editor but will never be active
+	if (process_mode == CAMERA2D_PROCESS_IDLE) {
+		set_process_internal(smoothing_active);
 		set_physics_process_internal(false);
 	} else {
 		set_process_internal(false);
-		set_physics_process_internal(true);
+		set_physics_process_internal(smoothing_active);
 	}
 }
 
@@ -160,12 +158,11 @@ Transform2D Camera2D::get_camera_transform() {
 				camera_pos.y -= screen_rect.position.y - limit[MARGIN_TOP];
 		}
 
-		if (smoothing_enabled && !Engine::get_singleton()->is_editor_hint()) {
+		if (smoothing_active) {
 
 			float c = smoothing * (process_mode == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time());
 			smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
 			ret_camera_pos = smoothed_camera_pos;
-			//camera_pos=camera_pos*(1.0-smoothing)+new_camera_pos*smoothing;
 		} else {
 
 			ret_camera_pos = smoothed_camera_pos = camera_pos;
@@ -231,7 +228,7 @@ void Camera2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 
-			if (!smoothing_enabled || Engine::get_singleton()->is_editor_hint()) {
+			if (!smoothing_active) {
 				_update_scroll();
 			}
 
@@ -528,10 +525,6 @@ void Camera2D::align() {
 void Camera2D::set_follow_smoothing(float p_speed) {
 
 	smoothing = p_speed;
-	if (smoothing > 0 && !(is_inside_tree() && Engine::get_singleton()->is_editor_hint()))
-		set_process_internal(true);
-	else
-		set_process_internal(false);
 }
 
 float Camera2D::get_follow_smoothing() const {
@@ -591,17 +584,23 @@ float Camera2D::get_h_offset() const {
 	return h_ofs;
 }
 
-void Camera2D::_set_old_smoothing(float p_enable) {
-	//compatibility
-	if (p_enable > 0) {
-		smoothing_enabled = true;
-		set_follow_smoothing(p_enable);
-	}
-}
-
 void Camera2D::set_enable_follow_smoothing(bool p_enabled) {
 
+	// watch for situation where an pre-enabled camera is added to the tree
+	// processing must be resumed and bypass this noop check
+	// (this currently works but is a possible future bug)
+	if (smoothing_enabled == p_enabled) {
+		return;
+	}
+
+	// Separate the logic between enabled and active, because the smoothing
+	// cannot be active in the editor. This can be done without a separate flag
+	// but is bug prone so this approach is easier to follow.
 	smoothing_enabled = p_enabled;
+	smoothing_active = smoothing_enabled && !Engine::get_singleton()->is_editor_hint();
+
+	// keep the processing up to date after each change
+	_update_process_mode();
 }
 
 bool Camera2D::is_follow_smoothing_enabled() const {
@@ -740,8 +739,6 @@ void Camera2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reset_smoothing"), &Camera2D::reset_smoothing);
 	ClassDB::bind_method(D_METHOD("align"), &Camera2D::align);
 
-	ClassDB::bind_method(D_METHOD("_set_old_smoothing", "follow_smoothing"), &Camera2D::_set_old_smoothing);
-
 	ClassDB::bind_method(D_METHOD("set_screen_drawing_enabled", "screen_drawing_enabled"), &Camera2D::set_screen_drawing_enabled);
 	ClassDB::bind_method(D_METHOD("is_screen_drawing_enabled"), &Camera2D::is_screen_drawing_enabled);
 
@@ -812,6 +809,7 @@ Camera2D::Camera2D() {
 	camera_pos = Vector2();
 	first = true;
 	smoothing_enabled = false;
+	smoothing_active = false;
 	limit_smoothing_enabled = false;
 	custom_viewport = NULL;
 	custom_viewport_id = 0;

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -68,6 +68,7 @@ protected:
 	bool current;
 	float smoothing;
 	bool smoothing_enabled;
+	bool smoothing_active; // smoothing can be enabled but not active in the editor
 	int limit[4];
 	bool limit_smoothing_enabled;
 	float drag_margin[4];
@@ -86,8 +87,6 @@ protected:
 
 	void _make_current(Object *p_which);
 	void _set_current(bool p_current);
-
-	void _set_old_smoothing(float p_enable);
 
 	bool screen_drawing_enabled;
 	bool limit_drawing_enabled;


### PR DESCRIPTION
The logic for internal process and internal physics process in Camera2D was very buggy and convoluted for historical reasons.

This is a cleanup to make the logic simpler and easier to follow.

## Notes
* Moved this out of draft to try and get some eyes on..
* I've added an active flag rather than complicated the logic with lots of `is_editor_hint` spread all over the place. The active flag is set in one place, and makes it far easier to read / should make it less bug prone.
* This deprecates the ability to turn off processing by setting `follow_smoothing` to zero, and the old `_set_old_smoothing` function.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
