### PR TITLE
Fix translations update in window & Dialogs (AcceptDialog/ConfirmationDialog/FileDialog) (Fix 39320, 39258 &  45887)

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -256,7 +256,7 @@ Button *AcceptDialog::add_button(const String &p_text, bool p_right, const Strin
 Button *AcceptDialog::add_cancel_button(const String &p_cancel) {
 	String c = p_cancel;
 	if (p_cancel == "") {
-		c = RTR("Cancel");
+		c = TTRC("Cancel");
 	}
 	Button *b = swap_cancel_ok ? add_button(c, true) : add_button(c);
 	b->connect("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed));
@@ -317,13 +317,13 @@ AcceptDialog::AcceptDialog() {
 
 	hbc->add_spacer();
 	ok = memnew(Button);
-	ok->set_text(RTR("OK"));
+	ok->set_text(TTRC("OK"));
 	hbc->add_child(ok);
 	hbc->add_spacer();
 
 	ok->connect("pressed", callable_mp(this, &AcceptDialog::_ok_pressed));
 
-	set_title(RTR("Alert!"));
+	set_title(TTRC("Alert!"));
 
 	connect("window_input", callable_mp(this, &AcceptDialog::_input_from_window));
 }
@@ -342,7 +342,7 @@ Button *ConfirmationDialog::get_cancel_button() {
 }
 
 ConfirmationDialog::ConfirmationDialog() {
-	set_title(RTR("Please Confirm..."));
+	set_title(TTRC("Please Confirm..."));
 #ifdef TOOLS_ENABLED
 	set_min_size(Size2(200, 70) * EDSCALE);
 #endif

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -272,7 +272,7 @@ void FileDialog::_action_pressed() {
 		}
 
 		if (dir_access->file_exists(f)) {
-			confirm_save->set_text(RTR("File exists, overwrite?"));
+			confirm_save->set_text(TTRC("File exists, overwrite?"));
 			confirm_save->popup_centered(Size2(200, 80));
 		} else {
 			emit_signal("file_selected", f);
@@ -329,10 +329,10 @@ void FileDialog::deselect_all() {
 		switch (mode) {
 			case FILE_MODE_OPEN_FILE:
 			case FILE_MODE_OPEN_FILES:
-				get_ok_button()->set_text(RTR("Open"));
+				get_ok_button()->set_text(TTRC("Open"));
 				break;
 			case FILE_MODE_OPEN_DIR:
-				get_ok_button()->set_text(RTR("Select Current Folder"));
+				get_ok_button()->set_text(TTRC("Select Current Folder"));
 				break;
 			case FILE_MODE_OPEN_ANY:
 			case FILE_MODE_SAVE_FILE:
@@ -356,7 +356,7 @@ void FileDialog::_tree_selected() {
 	if (!d["dir"]) {
 		file->set_text(d["name"]);
 	} else if (mode == FILE_MODE_OPEN_DIR) {
-		get_ok_button()->set_text(RTR("Select This Folder"));
+		get_ok_button()->set_text(TTRC("Select This Folder"));
 	}
 
 	get_ok_button()->set_disabled(_is_open_should_be_disabled());
@@ -549,7 +549,7 @@ void FileDialog::update_filters() {
 			all_filters += ", ...";
 		}
 
-		filter->add_item(RTR("All Recognized") + " (" + all_filters + ")");
+		filter->add_item(String(TTRC("All Recognized")) + " (" + all_filters + ")");
 	}
 	for (int i = 0; i < filters.size(); i++) {
 		String flt = filters[i].get_slice(";", 0).strip_edges();
@@ -561,7 +561,7 @@ void FileDialog::update_filters() {
 		}
 	}
 
-	filter->add_item(RTR("All Files (*)"));
+	filter->add_item(TTRC("All Files (*)"));
 }
 
 void FileDialog::clear_filters() {
@@ -646,37 +646,37 @@ void FileDialog::set_file_mode(FileMode p_mode) {
 	mode = p_mode;
 	switch (mode) {
 		case FILE_MODE_OPEN_FILE:
-			get_ok_button()->set_text(RTR("Open"));
+			get_ok_button()->set_text(TTRC("Open"));
 			if (mode_overrides_title) {
-				set_title(RTR("Open a File"));
+				set_title(TTRC("Open a File"));
 			}
 			makedir->hide();
 			break;
 		case FILE_MODE_OPEN_FILES:
-			get_ok_button()->set_text(RTR("Open"));
+			get_ok_button()->set_text(TTRC("Open"));
 			if (mode_overrides_title) {
-				set_title(RTR("Open File(s)"));
+				set_title(TTRC("Open File(s)"));
 			}
 			makedir->hide();
 			break;
 		case FILE_MODE_OPEN_DIR:
-			get_ok_button()->set_text(RTR("Select Current Folder"));
+			get_ok_button()->set_text(TTRC("Select Current Folder"));
 			if (mode_overrides_title) {
-				set_title(RTR("Open a Directory"));
+				set_title(TTRC("Open a Directory"));
 			}
 			makedir->show();
 			break;
 		case FILE_MODE_OPEN_ANY:
-			get_ok_button()->set_text(RTR("Open"));
+			get_ok_button()->set_text(TTRC("Open"));
 			if (mode_overrides_title) {
-				set_title(RTR("Open a File or Directory"));
+				set_title(TTRC("Open a File or Directory"));
 			}
 			makedir->show();
 			break;
 		case FILE_MODE_SAVE_FILE:
-			get_ok_button()->set_text(RTR("Save"));
+			get_ok_button()->set_text(TTRC("Save"));
 			if (mode_overrides_title) {
-				set_title(RTR("Save a File"));
+				set_title(TTRC("Save a File"));
 			}
 			makedir->show();
 			break;
@@ -857,17 +857,17 @@ FileDialog::FileDialog() {
 	vbox->connect("theme_changed", callable_mp(this, &FileDialog::_theme_changed));
 
 	mode = FILE_MODE_SAVE_FILE;
-	set_title(RTR("Save a File"));
+	set_title(TTRC("Save a File"));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 
 	dir_up = memnew(Button);
 	dir_up->set_flat(true);
-	dir_up->set_tooltip(RTR("Go to parent folder."));
+	dir_up->set_tooltip(TTRC("Go to parent folder."));
 	hbc->add_child(dir_up);
 	dir_up->connect("pressed", callable_mp(this, &FileDialog::_go_up));
 
-	hbc->add_child(memnew(Label(RTR("Path:"))));
+	hbc->add_child(memnew(Label(TTRC("Path:"))));
 
 	drives_container = memnew(HBoxContainer);
 	hbc->add_child(drives_container);
@@ -883,7 +883,7 @@ FileDialog::FileDialog() {
 
 	refresh = memnew(Button);
 	refresh->set_flat(true);
-	refresh->set_tooltip(RTR("Refresh files."));
+	refresh->set_tooltip(TTRC("Refresh files."));
 	refresh->connect("pressed", callable_mp(this, &FileDialog::update_file_list));
 	hbc->add_child(refresh);
 
@@ -891,7 +891,7 @@ FileDialog::FileDialog() {
 	show_hidden->set_flat(true);
 	show_hidden->set_toggle_mode(true);
 	show_hidden->set_pressed(is_showing_hidden_files());
-	show_hidden->set_tooltip(RTR("Toggle the visibility of hidden files."));
+	show_hidden->set_tooltip(TTRC("Toggle the visibility of hidden files."));
 	show_hidden->connect("toggled", callable_mp(this, &FileDialog::set_show_hidden_files));
 	hbc->add_child(show_hidden);
 
@@ -899,17 +899,17 @@ FileDialog::FileDialog() {
 	hbc->add_child(shortcuts_container);
 
 	makedir = memnew(Button);
-	makedir->set_text(RTR("Create Folder"));
+	makedir->set_text(TTRC("Create Folder"));
 	makedir->connect("pressed", callable_mp(this, &FileDialog::_make_dir));
 	hbc->add_child(makedir);
 	vbox->add_child(hbc);
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
-	vbox->add_margin_child(RTR("Directories & Files:"), tree, true);
+	vbox->add_margin_child(TTRC("Directories & Files:"), tree, true);
 
 	file_box = memnew(HBoxContainer);
-	file_box->add_child(memnew(Label(RTR("File:"))));
+	file_box->add_child(memnew(Label(TTRC("File:"))));
 	file = memnew(LineEdit);
 	file->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
 	file->set_stretch_ratio(4);
@@ -941,22 +941,22 @@ FileDialog::FileDialog() {
 	confirm_save->connect("confirmed", callable_mp(this, &FileDialog::_save_confirm_pressed));
 
 	makedialog = memnew(ConfirmationDialog);
-	makedialog->set_title(RTR("Create Folder"));
+	makedialog->set_title(TTRC("Create Folder"));
 	VBoxContainer *makevb = memnew(VBoxContainer);
 	makedialog->add_child(makevb);
 
 	makedirname = memnew(LineEdit);
 	makedirname->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
-	makevb->add_margin_child(RTR("Name:"), makedirname);
+	makevb->add_margin_child(TTRC("Name:"), makedirname);
 	add_child(makedialog);
 	makedialog->register_text_enter(makedirname);
 	makedialog->connect("confirmed", callable_mp(this, &FileDialog::_make_dir_confirm));
 	mkdirerr = memnew(AcceptDialog);
-	mkdirerr->set_text(RTR("Could not create folder."));
+	mkdirerr->set_text(TTRC("Could not create folder."));
 	add_child(mkdirerr);
 
 	exterr = memnew(AcceptDialog);
-	exterr->set_text(RTR("Must use a valid extension."));
+	exterr->set_text(TTRC("Must use a valid extension."));
 	add_child(exterr);
 
 	update_filters();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -232,7 +232,7 @@ void Window::_make_window() {
 	DisplayServer::get_singleton()->window_set_current_screen(current_screen, window_id);
 	DisplayServer::get_singleton()->window_set_max_size(max_size, window_id);
 	DisplayServer::get_singleton()->window_set_min_size(min_size, window_id);
-	DisplayServer::get_singleton()->window_set_title(title, window_id);
+	DisplayServer::get_singleton()->window_set_title(tr(title), window_id);
 	DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
 
 	_update_window_size();
@@ -757,6 +757,10 @@ void Window::_notification(int p_what) {
 		if (wrap_controls) {
 			_update_child_controls();
 		}
+	}
+
+	if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
+		child_controls_changed();
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {


### PR DESCRIPTION
- - Fix #39320 by handling `NOTIFICATION_TRANSLATION_CHANGED` in the Window object

https://user-images.githubusercontent.com/6397893/110219413-597ab780-7ebf-11eb-810a-0b2c92bb5565.mp4

- Fix #39258 where title variable on Window was used as translation instead of the translation key.

https://user-images.githubusercontent.com/6397893/110219409-4ec02280-7ebf-11eb-87e2-3cfe065a348a.mp4

[Edit]
Updated to also fix #45887

**For reviewers**:

For refreshing the window:

```c++
// I used
child_controls_changed();
// but this works too
if (embedder) {
	embedder->_sub_window_update(this);
}
```
However, I don't understand well the difference between `_sub_windows_update` and `child_controls_changed` as the last one end by calling `_sub_windows_update`. Both works, but I'm not sure which is the best.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
