### PR TITLE
Improve thread IDs to avoid collisions with threads not created by the Godot API.

### DIFF
--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -62,9 +62,10 @@ private:
 	friend class Main;
 
 	static ID main_thread_id;
-	static SafeNumeric<Thread::ID> last_thread_id;
 
-	ID id = 0;
+	static uint64_t _thread_id_hash(const std::thread::id &p_t);
+
+	ID id = _thread_id_hash(std::thread::id());
 	static thread_local ID caller_id;
 	std::thread thread;
 


### PR DESCRIPTION
Replaces custom thread IDs with `std::thread::id` hashes.

Fixes #46679, fixes #46550 and fixes #46411