### PR TITLE
Tweak shader errors for features only usable in GLES3

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2230,7 +2230,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, OperatorNode *p
 			arglist += get_datatype_name(builtin_func_defs[builtin_idx].args[i]);
 		}
 
-		String err = "Built-in function \"" + String(name) + "(" + arglist + ")\" is supported only on high-end platform!";
+		String err = "Built-in function \"" + String(name) + "(" + arglist + ")\" is only supported on the GLES3 backend, but your project is using GLES2.";
 		_set_error(err);
 		return false;
 	}
@@ -3988,7 +3988,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const Map<StringName, Bui
 					bool unknown_size = false;
 
 					if (VisualServer::get_singleton()->is_low_end() && is_const) {
-						_set_error("Local const arrays are supported only on high-end platform!");
+						_set_error("Local const arrays are only supported on the GLES3 backend, but your project is using GLES2.");
 						return ERR_PARSE_ERROR;
 					}
 
@@ -4029,7 +4029,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const Map<StringName, Bui
 					if (tk.type == TK_OP_ASSIGN) {
 
 						if (VisualServer::get_singleton()->is_low_end()) {
-							_set_error("Array initialization is supported only on high-end platform!");
+							_set_error("Array initialization is only supported on the GLES3 backend, but your project is using GLES2.");
 							return ERR_PARSE_ERROR;
 						}
 
@@ -4314,7 +4314,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const Map<StringName, Bui
 		} else if (tk.type == TK_CF_SWITCH) {
 
 			if (VisualServer::get_singleton()->is_low_end()) {
-				_set_error("\"switch\" operator is supported only on high-end platform!");
+				_set_error("\"switch\" operator is only supported on the GLES3 backend, but your project is using GLES2.");
 				return ERR_PARSE_ERROR;
 			}
 
@@ -4824,7 +4824,7 @@ Error ShaderLanguage::_validate_datatype(DataType p_type) {
 		}
 
 		if (invalid_type) {
-			_set_error(vformat("\"%s\" type is supported only on high-end platform!", get_datatype_name(p_type)));
+			_set_error(vformat("\"%s\" type is only supported on the GLES3 backend, but your project is using GLES2.", get_datatype_name(p_type)));
 			return ERR_UNAVAILABLE;
 		}
 	}


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/42719#issuecomment-792168504.

Since 3.2.x won't get additional rendering backends, we can hardcode the reference to GLES3.