### PR TITLE
Update Polygon2D documentation for Anti-aliasing

### DIFF
--- a/doc/classes/Polygon2D.xml
+++ b/doc/classes/Polygon2D.xml
@@ -87,6 +87,7 @@
 	<members>
 		<member name="antialiased" type="bool" setter="set_antialiased" getter="get_antialiased" default="false">
 			If [code]true[/code], polygon edges will be anti-aliased.
+			[b]Note:[/b] Doing this doesn't enable anti-aliasing automatically. HDR must be turned off in GLES3. Also doesn't work for HTML5.
 		</member>
 		<member name="bones" type="Array" setter="_set_bones" getter="_get_bones" default="[  ]">
 		</member>


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fixes #46465. Update Documentation as listed in the issue.
Added a Note under Anti-Aliasing that it doesn't automatically work. For it to work HDR must be turned off in GLES3. Also AA doesn't work for HTML5 as listed in #10241.