### PR TITLE
Fix memory leak in VulkanContext

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -1705,7 +1705,7 @@ VulkanContext::~VulkanContext() {
 				vkDestroySemaphore(device, image_ownership_semaphores[i], nullptr);
 			}
 		}
-		if (inst_initialized && use_validation_layers) {
+		if (inst_initialized && enabled_debug_utils) {
 			DestroyDebugUtilsMessengerEXT(inst, dbg_messenger, nullptr);
 		}
 		vkDestroyDevice(device, nullptr);


### PR DESCRIPTION
Fixes this memory leak:
```
Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7fce34051517 in malloc (/lib/x86_64-linux-gnu/libasan.so.6+0xb0517)
    #1 0x7452c01 in loader_instance_heap_alloc thirdparty/vulkan/loader/loader.c:157
    #2 0x76f1fac in terminator_CreateDebugUtilsMessengerEXT thirdparty/vulkan/loader/debug_utils.c:333
    #3 0x76ef734 in debug_utils_CreateDebugUtilsMessengerEXT thirdparty/vulkan/loader/debug_utils.c:80
    #4 0x732b352 in VulkanContext::_create_physical_device() drivers/vulkan/vulkan_context.cpp:519
    #5 0x734045d in VulkanContext::initialize() drivers/vulkan/vulkan_context.cpp:1188
    #6 0x1ecd3c3 in DisplayServerX11::DisplayServerX11(String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) platform/linuxbsd/display_server_x11.cpp:4009
    #7 0x1ebd63d in DisplayServerX11::create_func(String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) platform/linuxbsd/display_server_x11.cpp:3636
    #8 0xf84e06d in DisplayServer::create(int, String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) servers/display_server.cpp:613
    #9 0x1f5c927 in Main::setup2(unsigned long) main/main.cpp:1526
    #10 0x1f576c4 in Main::setup(char const*, int, char**, bool) main/main.cpp:1387
    #11 0x1e1bf25 in main platform/linuxbsd/godot_linuxbsd.cpp:51
    #12 0x7fce3316c0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
```