### PR TITLE
Remove deprecation warning messages from InterpolatedCamera

### DIFF
--- a/scene/3d/interpolated_camera.cpp
+++ b/scene/3d/interpolated_camera.cpp
@@ -37,8 +37,6 @@ void InterpolatedCamera::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 
-			WARN_DEPRECATED_MSG("InterpolatedCamera has been deprecated and will be removed in Godot 4.0.");
-
 			if (Engine::get_singleton()->is_editor_hint() && enabled)
 				set_process_internal(false);
 
@@ -131,11 +129,6 @@ void InterpolatedCamera::set_speed(real_t p_speed) {
 real_t InterpolatedCamera::get_speed() const {
 
 	return speed;
-}
-
-String InterpolatedCamera::get_configuration_warning() const {
-
-	return TTR("InterpolatedCamera has been deprecated and will be removed in Godot 4.0.");
 }
 
 void InterpolatedCamera::_bind_methods() {

--- a/scene/3d/interpolated_camera.h
+++ b/scene/3d/interpolated_camera.h
@@ -57,8 +57,6 @@ public:
 	void set_interpolation_enabled(bool p_enable);
 	bool is_interpolation_enabled() const;
 
-	String get_configuration_warning() const;
-
 	InterpolatedCamera();
 };
 


### PR DESCRIPTION
Partial revert of https://github.com/godotengine/godot/pull/42113.

Since Godot 4.0's release is still a while away, warning users every time the project starts might be a bit too dramatic. The note in the documentation is still present as InterpolatedCamera will still be removed in 4.0.