### PR TITLE
[mono] handle marshalling of nullable types

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/MarshalUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/MarshalUtils.cs
@@ -41,6 +41,8 @@ namespace Godot
 
         static bool TypeIsGenericIDictionary(Type type) => type.GetGenericTypeDefinition() == typeof(IDictionary<,>);
 
+        static bool TypeIsGenericNullable(Type type) => type.GetGenericTypeDefinition() == typeof(Nullable<>);
+
         static void ArrayGetElementType(Type arrayType, out Type elementType)
         {
             elementType = arrayType.GetGenericArguments()[0];
@@ -51,6 +53,11 @@ namespace Godot
             var genericArgs = dictionaryType.GetGenericArguments();
             keyType = genericArgs[0];
             valueType = genericArgs[1];
+        }
+
+        static void NullableGetUnderlyingType(Type nullableType, out Type underlyingType)
+        {
+            underlyingType = Nullable.GetUnderlyingType(nullableType);
         }
 
         static Type MakeGenericArrayType(Type elemType)

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -180,9 +180,11 @@ void CachedData::clear_godot_api_cache() {
 	methodthunk_MarshalUtils_TypeIsGenericIEnumerable.nullify();
 	methodthunk_MarshalUtils_TypeIsGenericICollection.nullify();
 	methodthunk_MarshalUtils_TypeIsGenericIDictionary.nullify();
+	methodthunk_MarshalUtils_TypeIsGenericNullable.nullify();
 
 	methodthunk_MarshalUtils_ArrayGetElementType.nullify();
 	methodthunk_MarshalUtils_DictionaryGetKeyValueTypes.nullify();
+	methodthunk_MarshalUtils_NullableGetUnderlyingType.nullify();
 
 	methodthunk_MarshalUtils_MakeGenericArrayType.nullify();
 	methodthunk_MarshalUtils_MakeGenericDictionaryType.nullify();
@@ -306,9 +308,11 @@ void update_godot_api_cache() {
 	CACHE_METHOD_THUNK_AND_CHECK(MarshalUtils, TypeIsGenericIEnumerable, GODOT_API_CLASS(MarshalUtils)->get_method("TypeIsGenericIEnumerable", 1));
 	CACHE_METHOD_THUNK_AND_CHECK(MarshalUtils, TypeIsGenericICollection, GODOT_API_CLASS(MarshalUtils)->get_method("TypeIsGenericICollection", 1));
 	CACHE_METHOD_THUNK_AND_CHECK(MarshalUtils, TypeIsGenericIDictionary, GODOT_API_CLASS(MarshalUtils)->get_method("TypeIsGenericIDictionary", 1));
+	CACHE_METHOD_THUNK_AND_CHECK(MarshalUtils, TypeIsGenericNullable, GODOT_API_CLASS(MarshalUtils)->get_method("TypeIsGenericNullable", 1));
 
 	CACHE_METHOD_THUNK_AND_CHECK(MarshalUtils, ArrayGetElementType, GODOT_API_CLASS(MarshalUtils)->get_method("ArrayGetElementType", 2));
 	CACHE_METHOD_THUNK_AND_CHECK(MarshalUtils, DictionaryGetKeyValueTypes, GODOT_API_CLASS(MarshalUtils)->get_method("DictionaryGetKeyValueTypes", 3));
+	CACHE_METHOD_THUNK_AND_CHECK(MarshalUtils, NullableGetUnderlyingType, GODOT_API_CLASS(MarshalUtils)->get_method("NullableGetUnderlyingType", 2));
 
 	CACHE_METHOD_THUNK_AND_CHECK(MarshalUtils, MakeGenericArrayType, GODOT_API_CLASS(MarshalUtils)->get_method("MakeGenericArrayType", 1));
 	CACHE_METHOD_THUNK_AND_CHECK(MarshalUtils, MakeGenericDictionaryType, GODOT_API_CLASS(MarshalUtils)->get_method("MakeGenericDictionaryType", 2));

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -151,9 +151,11 @@ struct CachedData {
 	GDMonoMethodThunkR<MonoBoolean, MonoReflectionType *> methodthunk_MarshalUtils_TypeIsGenericIEnumerable;
 	GDMonoMethodThunkR<MonoBoolean, MonoReflectionType *> methodthunk_MarshalUtils_TypeIsGenericICollection;
 	GDMonoMethodThunkR<MonoBoolean, MonoReflectionType *> methodthunk_MarshalUtils_TypeIsGenericIDictionary;
+	GDMonoMethodThunkR<MonoBoolean, MonoReflectionType *> methodthunk_MarshalUtils_TypeIsGenericNullable;
 
 	GDMonoMethodThunk<MonoReflectionType *, MonoReflectionType **> methodthunk_MarshalUtils_ArrayGetElementType;
 	GDMonoMethodThunk<MonoReflectionType *, MonoReflectionType **, MonoReflectionType **> methodthunk_MarshalUtils_DictionaryGetKeyValueTypes;
+	GDMonoMethodThunk<MonoReflectionType *, MonoReflectionType **> methodthunk_MarshalUtils_NullableGetUnderlyingType;
 
 	GDMonoMethodThunkR<MonoReflectionType *, MonoReflectionType *> methodthunk_MarshalUtils_MakeGenericArrayType;
 	GDMonoMethodThunkR<MonoReflectionType *, MonoReflectionType *, MonoReflectionType *> methodthunk_MarshalUtils_MakeGenericDictionaryType;

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -450,6 +450,19 @@ MonoObject *variant_to_mono_object_of_genericinst(const Variant &p_var, GDMonoCl
 		return GDMonoUtils::create_managed_from(p_var.operator Array(), godot_array_class);
 	}
 
+	if (GDMonoUtils::Marshal::type_is_generic_nullable(reftype)) {
+		if (p_var.get_type() == Variant::Type::NIL) {
+			return nullptr;
+		}
+
+		MonoReflectionType *underlying_reftype;
+		GDMonoUtils::Marshal::nullable_get_underlying_type(reftype, &underlying_reftype);
+		MonoType *underlying_monotype = mono_reflection_type_get_type(underlying_reftype);
+		GDMonoClass *underlying_class = GDMono::get_singleton()->get_class(mono_class_from_mono_type(underlying_monotype));
+
+		return variant_to_mono_object(p_var, ManagedType(mono_type_get_type(underlying_monotype), underlying_class));
+	}
+
 	ERR_FAIL_V_MSG(nullptr, "Attempted to convert Variant to unsupported generic type: '" +
 									p_type_class->get_full_name() + "'.");
 }

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -266,6 +266,14 @@ Variant::Type managed_to_variant_type(const ManagedType &p_type, bool *r_nil_is_
 			if (GDMonoUtils::Marshal::type_is_generic_icollection(reftype) || GDMonoUtils::Marshal::type_is_generic_ienumerable(reftype)) {
 				return Variant::ARRAY;
 			}
+
+			// INullable
+			if (GDMonoUtils::Marshal::type_is_generic_nullable(reftype)) {
+				MonoReflectionType *underlying_reftype;
+				GDMonoUtils::Marshal::nullable_get_underlying_type(reftype, &underlying_reftype);
+
+				return managed_to_variant_type(ManagedType::from_reftype(underlying_reftype), r_nil_is_variant);
+			}
 		} break;
 
 		default: {
@@ -457,10 +465,7 @@ MonoObject *variant_to_mono_object_of_genericinst(const Variant &p_var, GDMonoCl
 
 		MonoReflectionType *underlying_reftype;
 		GDMonoUtils::Marshal::nullable_get_underlying_type(reftype, &underlying_reftype);
-		MonoType *underlying_monotype = mono_reflection_type_get_type(underlying_reftype);
-		GDMonoClass *underlying_class = GDMono::get_singleton()->get_class(mono_class_from_mono_type(underlying_monotype));
-
-		return variant_to_mono_object(p_var, ManagedType(mono_type_get_type(underlying_monotype), underlying_class));
+		return variant_to_mono_object(p_var, ManagedType::from_reftype(underlying_reftype));
 	}
 
 	ERR_FAIL_V_MSG(nullptr, "Attempted to convert Variant to unsupported generic type: '" +

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -1224,6 +1224,20 @@ Variant mono_object_to_variant_impl(MonoObject *p_obj, const ManagedType &p_type
 				GDMonoUtils::Marshal::array_get_element_type(reftype, &elem_reftype);
 				return system_generic_list_to_Array_variant(p_obj, p_type.type_class, elem_reftype);
 			}
+
+			// Nullable
+			if (GDMonoUtils::Marshal::type_is_generic_nullable(reftype)) {
+				ERR_PRINT("Just checking...");
+				MonoReflectionType *underlying_reftype;
+				GDMonoUtils::Marshal::nullable_get_underlying_type(reftype, &underlying_reftype);
+
+				MonoClass *klass = mono_class_from_mono_type(mono_reflection_type_get_type(reftype));
+				const char *class_name = mono_class_get_name(klass);
+				MonoProperty *value_property = mono_class_get_property_from_name(klass, "Value");
+				MonoObject *underlying_object = mono_property_get_value(value_property, p_obj, nullptr, nullptr);
+
+				return mono_object_to_variant_impl(underlying_object, ManagedType::from_reftype(underlying_reftype), p_fail_with_err);
+			}
 		} break;
 	}
 

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -626,6 +626,14 @@ bool type_is_generic_idictionary(MonoReflectionType *p_reftype) {
 	return (bool)res;
 }
 
+bool type_is_generic_nullable(MonoReflectionType *p_reftype) {
+	NO_GLUE_RET(false);
+	MonoException *exc = NULL;
+	MonoBoolean res = CACHED_METHOD_THUNK(MarshalUtils, TypeIsGenericNullable).invoke(p_reftype, &exc);
+	UNHANDLED_EXCEPTION(exc);
+	return (bool)res;
+}
+
 void array_get_element_type(MonoReflectionType *p_array_reftype, MonoReflectionType **r_elem_reftype) {
 	MonoException *exc = nullptr;
 	CACHED_METHOD_THUNK(MarshalUtils, ArrayGetElementType).invoke(p_array_reftype, r_elem_reftype, &exc);
@@ -635,6 +643,12 @@ void array_get_element_type(MonoReflectionType *p_array_reftype, MonoReflectionT
 void dictionary_get_key_value_types(MonoReflectionType *p_dict_reftype, MonoReflectionType **r_key_reftype, MonoReflectionType **r_value_reftype) {
 	MonoException *exc = nullptr;
 	CACHED_METHOD_THUNK(MarshalUtils, DictionaryGetKeyValueTypes).invoke(p_dict_reftype, r_key_reftype, r_value_reftype, &exc);
+	UNHANDLED_EXCEPTION(exc);
+}
+
+void nullable_get_underlying_type(MonoReflectionType *p_nullable_reftype, MonoReflectionType **r_underlying_reftype) {
+	MonoException *exc = NULL;
+	CACHED_METHOD_THUNK(MarshalUtils, NullableGetUnderlyingType).invoke(p_nullable_reftype, r_underlying_reftype, &exc);
 	UNHANDLED_EXCEPTION(exc);
 }
 

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -61,9 +61,11 @@ bool type_is_system_generic_dictionary(MonoReflectionType *p_reftype);
 bool type_is_generic_ienumerable(MonoReflectionType *p_reftype);
 bool type_is_generic_icollection(MonoReflectionType *p_reftype);
 bool type_is_generic_idictionary(MonoReflectionType *p_reftype);
+bool type_is_generic_nullable(MonoReflectionType *p_reftype);
 
 void array_get_element_type(MonoReflectionType *p_array_reftype, MonoReflectionType **r_elem_reftype);
 void dictionary_get_key_value_types(MonoReflectionType *p_dict_reftype, MonoReflectionType **r_key_reftype, MonoReflectionType **r_value_reftype);
+void nullable_get_underlying_type(MonoReflectionType *p_nullable_reftype, MonoReflectionType **r_underlying_reftype);
 
 GDMonoClass *make_generic_array_type(MonoReflectionType *p_elem_reftype);
 GDMonoClass *make_generic_dictionary_type(MonoReflectionType *p_key_reftype, MonoReflectionType *p_value_reftype);

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -110,6 +110,8 @@ MonoObject *create_managed_from(const RID &p_from);
 MonoObject *create_managed_from(const Array &p_from, GDMonoClass *p_class);
 MonoObject *create_managed_from(const Dictionary &p_from, GDMonoClass *p_class);
 
+MonoObject *create_nullable(MonoObject *p_from, MonoClass *p_class, GDMonoClass *p_class_from);
+
 MonoDomain *create_domain(const String &p_friendly_name);
 
 String get_type_desc(MonoType *p_type);


### PR DESCRIPTION
Hey 🙂 

At the moment, the following code will throw a marshalling error because of `Vector2?`. This PR makes sure the marshaller actually uses the underlying type instead of the nullable generics instance.
```csharp
public class Foo
{
    public void SomeMethod(Vector2? vector)
    {
    }

    public override void _Ready()
    {
        CallDeferred("SomeMethod", new object[] { new Vector2(1f, 1f); });
    }
}
```

I'm not a big fan of the recursive call to `variant_to_mono_object` because `variant_to_mono_object_of_genericinst` could also be called from `variant_to_managed_unboxed` 🤔 but that last function has been introduced in Godot 4, and I'm not 100% sure about how to handle this situation. Please feel free to chime in on that.

I can make another PR for 3.2 if that's needed (this one probably can't be cherry-picked directly).