### PR TITLE
Make the pagination buttons wider in the asset library browser

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -969,14 +969,16 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	for (int i = from; i < to; i++) {
 		if (i == p_page) {
 			Button *current = memnew(Button);
-			current->set_text(itos(i + 1));
+			// Keep the extended padding for the currently active page (see below).
+			current->set_text(vformat(" %d ", i + 1));
 			current->set_disabled(true);
 			current->set_focus_mode(Control::FOCUS_NONE);
 
 			hbc->add_child(current);
 		} else {
 			Button *current = memnew(Button);
-			current->set_text(itos(i + 1));
+			// Add padding to make page number buttons easier to click.
+			current->set_text(vformat(" %d ", i + 1));
 			current->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(i));
 
 			hbc->add_child(current);


### PR DESCRIPTION
This makes the page number buttons easier to click. In general, pagination buttons should have a roughly square-ish shape, and this seems to fit the bill nicely.

## Preview

### Before

![2021-03-07_20 10 29](https://user-images.githubusercontent.com/180032/110251583-7081de00-7f81-11eb-8669-e000ec333fb8.png)

### After

![2021-03-07_20 09 08](https://user-images.githubusercontent.com/180032/110251580-6fe94780-7f81-11eb-986e-169644a1726e.png)