### PR TITLE
[3.3] Fix documentation for Vector2/3.sign()

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -280,7 +280,7 @@
 			<return type="Vector2">
 			</return>
 			<description>
-				Returns the vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GDScript.sign] on each component.
+				Returns the vector with each component set to one or negative one, depending on the signs of the components. If a component is zero, it returns positive one.
 			</description>
 		</method>
 		<method name="slerp">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -280,7 +280,7 @@
 			<return type="Vector3">
 			</return>
 			<description>
-				Returns a vector with each component set to one or negative one, depending on the signs of this vector's components, or zero if the component is zero, by calling [method @GDScript.sign] on each component.
+				Returns a vector with each component set to one or negative one, depending on the signs of this vector's components. If a component is zero, it returns positive one.
 			</description>
 		</method>
 		<method name="slerp">


### PR DESCRIPTION
Fixes a documentation issue pointed out in https://github.com/godotengine/godot/issues/44841#issuecomment-792337095, which is a regression from #40581. Thanks to @Lucrecious