### PR TITLE
Improve TreeItem API and allow to move nodes

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -30,7 +30,7 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		To iterate over all the [TreeItem] objects in a [Tree] object, use [method TreeItem.get_next] and [method TreeItem.get_children] after getting the root through [method get_root]. You can use [method Object.free] on a [TreeItem] to remove it from the [Tree].
+		To iterate over all the [TreeItem] objects in a [Tree] object, use [method TreeItem.get_next] and [method TreeItem.get_first_child] after getting the root through [method get_root]. You can use [method Object.free] on a [TreeItem] to remove it from the [Tree].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -63,6 +63,16 @@
 				Removes all OpenType features.
 			</description>
 		</method>
+		<method name="create_child">
+			<return type="TreeItem">
+			</return>
+			<argument index="0" name="idx" type="int" default="-1">
+			</argument>
+			<description>
+				Creates an item and adds it as a child.
+				The new item will be inserted as position [code]idx[/code] (the default value [code]-1[/code] means the last position), or it will be the last child if [code]idx[/code] is higher than the child count.
+			</description>
+		</method>
 		<method name="deselect">
 			<return type="void">
 			</return>
@@ -123,11 +133,28 @@
 				Returns the column's cell mode.
 			</description>
 		</method>
-		<method name="get_children">
+		<method name="get_child">
 			<return type="TreeItem">
 			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
 			<description>
-				Returns the TreeItem's first child item or a null object if there is none.
+				Returns a child item by its index (see [method get_child_count]). This method is often used for iterating all children of an item.
+				Negative indices access the children from the last one.
+			</description>
+		</method>
+		<method name="get_child_count">
+			<return type="int">
+			</return>
+			<description>
+				Returns the number of child items.
+			</description>
+		</method>
+		<method name="get_children">
+			<return type="Array">
+			</return>
+			<description>
+				Returns an array of references to the item's children.
 			</description>
 		</method>
 		<method name="get_custom_bg_color" qualifiers="const">
@@ -155,6 +182,13 @@
 			</argument>
 			<description>
 				Returns [code]true[/code] if [code]expand_right[/code] is set.
+			</description>
+		</method>
+		<method name="get_first_child">
+			<return type="TreeItem">
+			</return>
+			<description>
+				Returns the TreeItem's first child.
 			</description>
 		</method>
 		<method name="get_icon" qualifiers="const">
@@ -191,6 +225,13 @@
 			</argument>
 			<description>
 				Returns the icon [Texture2D] region as [Rect2].
+			</description>
+		</method>
+		<method name="get_index">
+			<return type="int">
+			</return>
+			<description>
+				Returns the node's order in the tree. For example, if called on the first child item the position is [code]0[/code].
 			</description>
 		</method>
 		<method name="get_language" qualifiers="const">
@@ -342,6 +383,13 @@
 				Returns the given column's tooltip.
 			</description>
 		</method>
+		<method name="get_tree">
+			<return type="Tree">
+			</return>
+			<description>
+				Returns the [Tree] that owns this TreeItem.
+			</description>
+		</method>
 		<method name="is_button_disabled" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -397,18 +445,24 @@
 				Returns [code]true[/code] if column [code]column[/code] is selected.
 			</description>
 		</method>
-		<method name="move_to_bottom">
+		<method name="move_after">
 			<return type="void">
 			</return>
+			<argument index="0" name="item" type="Object">
+			</argument>
 			<description>
-				Moves this TreeItem to the bottom in the [Tree] hierarchy.
+				Moves this TreeItem right after the given [code]item[/code].
+				[b]Note:[/b] You can't move to the root or move the root.
 			</description>
 		</method>
-		<method name="move_to_top">
+		<method name="move_before">
 			<return type="void">
 			</return>
+			<argument index="0" name="item" type="Object">
+			</argument>
 			<description>
-				Moves this TreeItem to the top in the [Tree] hierarchy.
+				Moves this TreeItem right before the given [code]item[/code].
+				[b]Note:[/b] You can't move to the root or move the root.
 			</description>
 		</method>
 		<method name="remove_child">

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -122,9 +122,9 @@ void InputEventConfigurationDialog::_set_event(const Ref<InputEvent> &p_event) {
 
 		// Update selected item in input list for keys, joybuttons and joyaxis only (since the mouse cannot be "listened" for).
 		if (k.is_valid() || joyb.is_valid() || joym.is_valid()) {
-			TreeItem *category = input_list_tree->get_root()->get_children();
+			TreeItem *category = input_list_tree->get_root()->get_first_child();
 			while (category) {
-				TreeItem *input_item = category->get_children();
+				TreeItem *input_item = category->get_first_child();
 
 				// has_type this should be always true, unless the tree structure has been misconfigured.
 				bool has_type = input_item->get_parent()->has_meta("__type");

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5216,7 +5216,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			track_clipboard.clear();
 			TreeItem *root = track_copy_select->get_root();
 			if (root) {
-				TreeItem *it = root->get_children();
+				TreeItem *it = root->get_first_child();
 				while (it) {
 					Dictionary md = it->get_metadata(0);
 					int idx = md["track_idx"];
@@ -5602,7 +5602,7 @@ void AnimationTrackEditor::_show_imported_anim_warning() {
 }
 
 void AnimationTrackEditor::_select_all_tracks_for_copy() {
-	TreeItem *track = track_copy_select->get_root()->get_children();
+	TreeItem *track = track_copy_select->get_root()->get_first_child();
 	if (!track) {
 		return;
 	}
@@ -5616,7 +5616,7 @@ void AnimationTrackEditor::_select_all_tracks_for_copy() {
 		track = track->get_next();
 	}
 
-	track = track_copy_select->get_root()->get_children();
+	track = track_copy_select->get_root()->get_first_child();
 	while (track) {
 		track->set_checked(0, !all_selected);
 		track = track->get_next();
@@ -5681,7 +5681,7 @@ void AnimationTrackEditor::_pick_track_select_recursive(TreeItem *p_item, const 
 		p_select_candidates.push_back(node);
 	}
 
-	TreeItem *c = p_item->get_children();
+	TreeItem *c = p_item->get_first_child();
 
 	while (c) {
 		_pick_track_select_recursive(c, p_filter, p_select_candidates);

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -655,7 +655,7 @@ void ConnectionsDock::_disconnect_all() {
 		return;
 	}
 
-	TreeItem *child = item->get_children();
+	TreeItem *child = item->get_first_child();
 	String signalName = item->get_metadata(0).operator Dictionary()["name"];
 	undo_redo->create_action(vformat(TTR("Disconnect all from signal: '%s'"), signalName));
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -220,7 +220,7 @@ void ScriptEditorDebugger::_file_selected(const String &p_file) {
 			file->store_csv_line(headers);
 
 			if (vmem_tree->get_root()) {
-				TreeItem *ti = vmem_tree->get_root()->get_children();
+				TreeItem *ti = vmem_tree->get_root()->get_first_child();
 				while (ti) {
 					Vector<String> values;
 					values.resize(vmem_tree->get_columns());
@@ -1319,7 +1319,7 @@ bool ScriptEditorDebugger::is_skip_breakpoints() {
 void ScriptEditorDebugger::_error_activated() {
 	TreeItem *selected = error_tree->get_selected();
 
-	TreeItem *ci = selected->get_children();
+	TreeItem *ci = selected->get_first_child();
 	if (ci) {
 		selected->set_collapsed(!selected->is_collapsed());
 	}
@@ -1341,7 +1341,7 @@ void ScriptEditorDebugger::_expand_errors_list() {
 		return;
 	}
 
-	TreeItem *item = root->get_children();
+	TreeItem *item = root->get_first_child();
 	while (item) {
 		item->set_collapsed(false);
 		item = item->get_next();
@@ -1354,7 +1354,7 @@ void ScriptEditorDebugger::_collapse_errors_list() {
 		return;
 	}
 
-	TreeItem *item = root->get_children();
+	TreeItem *item = root->get_first_child();
 	while (item) {
 		item->set_collapsed(true);
 		item = item->get_next();
@@ -1403,7 +1403,7 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 			int rpad_len = text.length();
 
 			text = type + text + ti->get_text(1) + "\n";
-			TreeItem *ci = ti->get_children();
+			TreeItem *ci = ti->get_first_child();
 			while (ci) {
 				text += "  " + ci->get_text(0).rpad(rpad_len) + ci->get_text(1) + "\n";
 				ci = ci->get_next();
@@ -1419,7 +1419,7 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 			}
 
 			// We only need the first child here (C++ source stack trace).
-			TreeItem *ci = ti->get_children();
+			TreeItem *ci = ti->get_first_child();
 			// Parse back the `file:line @ method()` string.
 			const Vector<String> file_line_number = ci->get_text(1).split("@")[0].strip_edges().split(":");
 			ERR_FAIL_COND_MSG(file_line_number.size() < 2, "Incorrect C++ source stack trace file:line format (please report).");

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -725,8 +725,8 @@ void OrphanResourcesDialog::_find_to_delete(TreeItem *p_item, List<String> &path
 			paths.push_back(p_item->get_metadata(0));
 		}
 
-		if (p_item->get_children()) {
-			_find_to_delete(p_item->get_children(), paths);
+		if (p_item->get_first_child()) {
+			_find_to_delete(p_item->get_first_child(), paths);
 		}
 
 		p_item = p_item->get_next();

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -45,8 +45,8 @@ void EditorAssetInstaller::_update_subitems(TreeItem *p_item, bool p_check, bool
 		p_item->set_checked(0, false);
 	}
 
-	if (p_item->get_children()) {
-		_update_subitems(p_item->get_children(), p_check);
+	if (p_item->get_first_child()) {
+		_update_subitems(p_item->get_first_child(), p_check);
 	}
 
 	if (!p_first && p_item->get_next()) {
@@ -60,7 +60,7 @@ void EditorAssetInstaller::_uncheck_parent(TreeItem *p_item) {
 	}
 
 	bool any_checked = false;
-	TreeItem *item = p_item->get_children();
+	TreeItem *item = p_item->get_first_child();
 	while (item) {
 		if (item->is_checked(0)) {
 			any_checked = true;

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -135,7 +135,7 @@ void SectionedInspector::_section_selected() {
 	}
 
 	selected_category = sections->get_selected()->get_metadata(0);
-	filter->set_section(selected_category, sections->get_selected()->get_children() == nullptr);
+	filter->set_section(selected_category, sections->get_selected()->get_first_child() == nullptr);
 	inspector->set_property_prefix(selected_category + "/");
 }
 
@@ -187,8 +187,8 @@ void SectionedInspector::edit(Object *p_object) {
 
 		TreeItem *first_item = sections->get_root();
 		if (first_item) {
-			while (first_item->get_children()) {
-				first_item = first_item->get_children();
+			while (first_item->get_first_child()) {
+				first_item = first_item->get_first_child();
 			}
 
 			first_item->select(0);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -180,12 +180,12 @@ Vector<String> FileSystemDock::_compute_uncollapsed_paths() {
 	Vector<String> uncollapsed_paths;
 	TreeItem *root = tree->get_root();
 	if (root) {
-		TreeItem *favorites_item = root->get_children();
+		TreeItem *favorites_item = root->get_first_child();
 		if (!favorites_item->is_collapsed()) {
 			uncollapsed_paths.push_back(favorites_item->get_metadata(0));
 		}
 
-		TreeItem *resTree = root->get_children()->get_next();
+		TreeItem *resTree = root->get_first_child()->get_next();
 		if (resTree) {
 			Vector<TreeItem *> needs_check;
 			needs_check.push_back(resTree);
@@ -193,7 +193,7 @@ Vector<String> FileSystemDock::_compute_uncollapsed_paths() {
 			while (needs_check.size()) {
 				if (!needs_check[0]->is_collapsed()) {
 					uncollapsed_paths.push_back(needs_check[0]->get_metadata(0));
-					TreeItem *child = needs_check[0]->get_children();
+					TreeItem *child = needs_check[0]->get_first_child();
 					while (child) {
 						needs_check.push_back(child);
 						child = child->get_next();
@@ -464,7 +464,7 @@ void FileSystemDock::_tree_multi_selected(Object *p_item, int p_column, bool p_s
 		return;
 	}
 
-	TreeItem *favorites_item = tree->get_root()->get_children();
+	TreeItem *favorites_item = tree->get_root()->get_first_child();
 	if (selected->get_parent() == favorites_item && !String(selected->get_metadata(0)).ends_with("/")) {
 		// Go to the favorites if we click in the favorites and the path has changed.
 		path = "Favorites";
@@ -1644,7 +1644,7 @@ Vector<String> FileSystemDock::_tree_get_selected(bool remove_self_inclusion) {
 	// Build a list of selected items with the active one at the first position.
 	Vector<String> selected_strings;
 
-	TreeItem *favorites_item = tree->get_root()->get_children();
+	TreeItem *favorites_item = tree->get_root()->get_first_child();
 	TreeItem *active_selected = tree->get_selected();
 	if (active_selected && active_selected != favorites_item) {
 		selected_strings.push_back(active_selected->get_metadata(0));
@@ -1700,7 +1700,7 @@ void FileSystemDock::_tree_rmb_option(int p_option) {
 				while (needs_check.size()) {
 					needs_check[0]->set_collapsed(is_collapsed);
 
-					TreeItem *child = needs_check[0]->get_children();
+					TreeItem *child = needs_check[0]->get_first_child();
 					while (child) {
 						needs_check.push_back(child);
 						child = child->get_next();
@@ -2062,13 +2062,13 @@ Variant FileSystemDock::get_drag_data_fw(const Point2 &p_point, Control *p_from)
 		// Check if the first selected is in favorite.
 		TreeItem *selected = tree->get_next_selected(tree->get_root());
 		while (selected) {
-			TreeItem *favorites_item = tree->get_root()->get_children();
+			TreeItem *favorites_item = tree->get_root()->get_first_child();
 			if (selected == favorites_item) {
 				// The "Favorites" item is not draggable.
 				return Variant();
 			}
 
-			bool is_favorite = selected->get_parent() != nullptr && tree->get_root()->get_children() == selected->get_parent();
+			bool is_favorite = selected->get_parent() != nullptr && tree->get_root()->get_first_child() == selected->get_parent();
 			all_favorites &= is_favorite;
 			all_not_favorites &= !is_favorite;
 			selected = tree->get_next_selected(selected);
@@ -2114,7 +2114,7 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		}
 
 		int drop_section = tree->get_drop_section_at_position(p_point);
-		TreeItem *favorites_item = tree->get_root()->get_children();
+		TreeItem *favorites_item = tree->get_root()->get_first_child();
 
 		TreeItem *resources_item = favorites_item->get_next();
 
@@ -2190,7 +2190,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 
 		int drop_position;
 		Vector<String> files = drag_data["files"];
-		TreeItem *favorites_item = tree->get_root()->get_children();
+		TreeItem *favorites_item = tree->get_root()->get_first_child();
 		TreeItem *resources_item = favorites_item->get_next();
 
 		if (ti == favorites_item) {
@@ -2328,10 +2328,10 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 		int section = tree->get_drop_section_at_position(p_point);
 		if (ti) {
 			// Check the favorites first.
-			if (ti == tree->get_root()->get_children() && section >= 0) {
+			if (ti == tree->get_root()->get_first_child() && section >= 0) {
 				target_favorites = true;
 				return;
-			} else if (ti->get_parent() == tree->get_root()->get_children()) {
+			} else if (ti->get_parent() == tree->get_root()->get_first_child()) {
 				target_favorites = true;
 				return;
 			} else {
@@ -2347,7 +2347,7 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 						return;
 					}
 				} else {
-					if (ti->get_parent() != tree->get_root()->get_children()) {
+					if (ti->get_parent() != tree->get_root()->get_first_child()) {
 						// Not in the favorite section.
 						if (fpath != "res://") {
 							// We drop between two files

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -838,7 +838,7 @@ void FindInFilesPanel::_on_replace_all_clicked() {
 		String fpath = file_item->get_metadata(0);
 
 		Vector<Result> locations;
-		for (TreeItem *item = file_item->get_children(); item; item = item->get_next()) {
+		for (TreeItem *item = file_item->get_first_child(); item; item = item->get_next()) {
 			if (!item->is_checked(0)) {
 				continue;
 			}

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -52,7 +52,7 @@ void GroupDialog::_group_selected() {
 	selected_group = groups->get_selected()->get_text(0);
 	_load_nodes(scene_tree->get_edited_scene_root());
 
-	group_empty->set_visible(!remove_node_root->get_children());
+	group_empty->set_visible(!remove_node_root->get_first_child());
 }
 
 void GroupDialog::_load_nodes(Node *p_current) {
@@ -217,7 +217,7 @@ void GroupDialog::_group_renamed() {
 	}
 
 	const String name = renamed_group->get_text(0).strip_edges();
-	for (TreeItem *E = groups_root->get_children(); E; E = E->get_next()) {
+	for (TreeItem *E = groups_root->get_first_child(); E; E = E->get_next()) {
 		if (E != renamed_group && E->get_text(0) == name) {
 			renamed_group->set_text(0, selected_group);
 			error->set_text(TTR("Group name already exists."));
@@ -274,7 +274,7 @@ void GroupDialog::_rename_group_item(const String &p_old_name, const String &p_n
 
 	selected_group = p_new_name;
 
-	for (TreeItem *E = groups_root->get_children(); E; E = E->get_next()) {
+	for (TreeItem *E = groups_root->get_first_child(); E; E = E->get_next()) {
 		if (E->get_text(0) == p_old_name) {
 			E->set_text(0, p_new_name);
 			return;
@@ -351,7 +351,7 @@ void GroupDialog::_delete_group_item(const String &p_name) {
 		selected_group = "";
 	}
 
-	for (TreeItem *E = groups_root->get_children(); E; E = E->get_next()) {
+	for (TreeItem *E = groups_root->get_first_child(); E; E = E->get_next()) {
 		if (E->get_text(0) == p_name) {
 			groups_root->remove_child(E);
 			return;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -339,13 +339,13 @@ void ScriptEditorQuickOpen::_update_search() {
 		if ((search_box->get_text() == "" || file.findn(search_box->get_text()) != -1)) {
 			TreeItem *ti = search_options->create_item(root);
 			ti->set_text(0, file);
-			if (root->get_children() == ti) {
+			if (root->get_first_child() == ti) {
 				ti->select(0);
 			}
 		}
 	}
 
-	get_ok_button()->set_disabled(root->get_children() == nullptr);
+	get_ok_button()->set_disabled(root->get_first_child() == nullptr);
 }
 
 void ScriptEditorQuickOpen::_confirmed() {

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -321,7 +321,7 @@ void ThemeItemImportTree::_toggle_type_items(bool p_collapse) {
 		return;
 	}
 
-	TreeItem *type_node = root->get_children();
+	TreeItem *type_node = root->get_first_child();
 	while (type_node) {
 		type_node->set_collapsed(p_collapse);
 		type_node = type_node->get_next();
@@ -491,7 +491,7 @@ void ThemeItemImportTree::_tree_item_edited() {
 }
 
 void ThemeItemImportTree::_select_all_subitems(TreeItem *p_root_item, bool p_select_with_data) {
-	TreeItem *child_item = p_root_item->get_children();
+	TreeItem *child_item = p_root_item->get_first_child();
 	while (child_item) {
 		child_item->set_checked(IMPORT_ITEM, true);
 		if (p_select_with_data) {
@@ -505,7 +505,7 @@ void ThemeItemImportTree::_select_all_subitems(TreeItem *p_root_item, bool p_sel
 }
 
 void ThemeItemImportTree::_deselect_all_subitems(TreeItem *p_root_item, bool p_deselect_completely) {
-	TreeItem *child_item = p_root_item->get_children();
+	TreeItem *child_item = p_root_item->get_first_child();
 	while (child_item) {
 		child_item->set_checked(IMPORT_ITEM_DATA, false);
 		if (p_deselect_completely) {
@@ -527,7 +527,7 @@ void ThemeItemImportTree::_update_parent_items(TreeItem *p_root_item) {
 	bool any_checked = false;
 	bool any_checked_with_data = false;
 
-	TreeItem *child_item = parent_item->get_children();
+	TreeItem *child_item = parent_item->get_first_child();
 	while (child_item) {
 		if (child_item->is_checked(IMPORT_ITEM)) {
 			any_checked = true;

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -2587,7 +2587,7 @@ bool TileMapEditorTerrainsPlugin::forward_canvas_gui_input(const Ref<InputEvent>
 							}
 
 							if (need_tree_item_switch) {
-								for (tree_item = terrains_tree->get_root()->get_children(); tree_item; tree_item = tree_item->get_next_visible()) {
+								for (tree_item = terrains_tree->get_root()->get_first_child(); tree_item; tree_item = tree_item->get_next_visible()) {
 									Dictionary metadata_dict = tree_item->get_metadata(0);
 									if (metadata_dict.has("terrain_set") && metadata_dict.has("terrain_id")) {
 										int terrain_set = metadata_dict["terrain_set"];

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -180,7 +180,7 @@ void VersionControlEditorPlugin::_stage_selected() {
 	staged_files_count = 0;
 	TreeItem *root = stage_files->get_root();
 	if (root) {
-		TreeItem *file_entry = root->get_children();
+		TreeItem *file_entry = root->get_first_child();
 		while (file_entry) {
 			if (file_entry->is_checked(0)) {
 				EditorVCSInterface::get_singleton()->stage_file(file_entry->get_metadata(0));
@@ -207,7 +207,7 @@ void VersionControlEditorPlugin::_stage_all() {
 	staged_files_count = 0;
 	TreeItem *root = stage_files->get_root();
 	if (root) {
-		TreeItem *file_entry = root->get_children();
+		TreeItem *file_entry = root->get_first_child();
 		while (file_entry) {
 			EditorVCSInterface::get_singleton()->stage_file(file_entry->get_metadata(0));
 			file_entry->set_icon_modulate(0, EditorNode::get_singleton()->get_gui_base()->get_theme_color("success_color", "Editor"));

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2762,10 +2762,10 @@ void VisualShaderEditor::_notification(int p_what) {
 
 		// collapse tree by default
 
-		TreeItem *category = members->get_root()->get_children();
+		TreeItem *category = members->get_root()->get_first_child();
 		while (category) {
 			category->set_collapsed(true);
-			TreeItem *sub_category = category->get_children();
+			TreeItem *sub_category = category->get_first_child();
 			while (sub_category) {
 				sub_category->set_collapsed(true);
 				sub_category = sub_category->get_next();
@@ -3210,14 +3210,14 @@ void VisualShaderEditor::_member_cancel() {
 }
 
 void VisualShaderEditor::_tools_menu_option(int p_idx) {
-	TreeItem *category = members->get_root()->get_children();
+	TreeItem *category = members->get_root()->get_first_child();
 
 	switch (p_idx) {
 		case EXPAND_ALL:
 
 			while (category) {
 				category->set_collapsed(false);
-				TreeItem *sub_category = category->get_children();
+				TreeItem *sub_category = category->get_first_child();
 				while (sub_category) {
 					sub_category->set_collapsed(false);
 					sub_category = sub_category->get_next();
@@ -3231,7 +3231,7 @@ void VisualShaderEditor::_tools_menu_option(int p_idx) {
 
 			while (category) {
 				category->set_collapsed(true);
-				TreeItem *sub_category = category->get_children();
+				TreeItem *sub_category = category->get_first_child();
 				while (sub_category) {
 					sub_category->set_collapsed(true);
 					sub_category = sub_category->get_next();

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -795,7 +795,7 @@ void ProjectExportDialog::_tree_changed() {
 }
 
 void ProjectExportDialog::_check_dir_recursive(TreeItem *p_dir, bool p_checked) {
-	for (TreeItem *child = p_dir->get_children(); child; child = child->get_next()) {
+	for (TreeItem *child = p_dir->get_first_child(); child; child = child->get_next()) {
 		String path = child->get_metadata(0);
 
 		child->set_checked(0, p_checked);
@@ -818,7 +818,7 @@ void ProjectExportDialog::_refresh_parent_checks(TreeItem *p_item) {
 	}
 
 	bool checked = true;
-	for (TreeItem *child = parent->get_children(); child; child = child->get_next()) {
+	for (TreeItem *child = parent->get_first_child(); child; child = child->get_next()) {
 		checked = checked && child->is_checked(0);
 		if (!checked) {
 			break;

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -52,7 +52,7 @@ void PropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 				search_box->accept_event();
 
 				TreeItem *root = search_options->get_root();
-				if (!root->get_children()) {
+				if (!root->get_first_child()) {
 					break;
 				}
 
@@ -150,7 +150,7 @@ void PropertySelector::_update_search() {
 
 		for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 			if (E->get().usage == PROPERTY_USAGE_CATEGORY) {
-				if (category && category->get_children() == nullptr) {
+				if (category && category->get_first_child() == nullptr) {
 					memdelete(category); //old category was unused
 				}
 				category = search_options->create_item(root);
@@ -192,7 +192,7 @@ void PropertySelector::_update_search() {
 			item->set_selectable(0, true);
 		}
 
-		if (category && category->get_children() == nullptr) {
+		if (category && category->get_first_child() == nullptr) {
 			memdelete(category); //old category was unused
 		}
 	} else {
@@ -225,7 +225,7 @@ void PropertySelector::_update_search() {
 
 		for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
 			if (E->get().name.begins_with("*")) {
-				if (category && category->get_children() == nullptr) {
+				if (category && category->get_first_child() == nullptr) {
 					memdelete(category); //old category was unused
 				}
 				category = search_options->create_item(root);
@@ -316,12 +316,12 @@ void PropertySelector::_update_search() {
 			}
 		}
 
-		if (category && category->get_children() == nullptr) {
+		if (category && category->get_first_child() == nullptr) {
 			memdelete(category); //old category was unused
 		}
 	}
 
-	get_ok_button()->set_disabled(root->get_children() == nullptr);
+	get_ok_button()->set_disabled(root->get_first_child() == nullptr);
 }
 
 void PropertySelector::_confirmed() {

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -102,7 +102,7 @@ void EditorQuickOpen::_update_search() {
 			ti->set_icon(0, *icons.lookup_ptr(entries[i].path.get_extension()));
 		}
 
-		TreeItem *to_select = root->get_children();
+		TreeItem *to_select = root->get_first_child();
 		to_select->select(0);
 		to_select->set_as_cursor(0);
 		search_options->scroll_to_item(to_select);
@@ -170,7 +170,7 @@ void EditorQuickOpen::_sbox_input(const Ref<InputEvent> &p_ie) {
 
 				if (allow_multi_select) {
 					TreeItem *root = search_options->get_root();
-					if (!root->get_children()) {
+					if (!root->get_first_child()) {
 						break;
 					}
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1833,7 +1833,7 @@ bool SceneTreeDock::_is_collapsed_recursive(TreeItem *p_item) const {
 		TreeItem *item = needs_check.back()->get();
 		needs_check.pop_back();
 
-		TreeItem *child = item->get_children();
+		TreeItem *child = item->get_first_child();
 		is_branch_collapsed = item->is_collapsed() && child;
 
 		if (is_branch_collapsed) {
@@ -1857,7 +1857,7 @@ void SceneTreeDock::_set_collapsed_recursive(TreeItem *p_item, bool p_collapsed)
 
 		item->set_collapsed(p_collapsed);
 
-		TreeItem *child = item->get_children();
+		TreeItem *child = item->get_first_child();
 		while (child) {
 			to_collapse.push_back(child);
 			child = child->get_next();

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -699,7 +699,7 @@ TreeItem *SceneTreeEditor::_find(TreeItem *p_node, const NodePath &p_path) {
 		return p_node;
 	}
 
-	TreeItem *children = p_node->get_children();
+	TreeItem *children = p_node->get_first_child();
 	while (children) {
 		TreeItem *n = _find(children, p_path);
 		if (n) {
@@ -883,7 +883,7 @@ void SceneTreeEditor::_update_selection(TreeItem *item) {
 		item->deselect(0);
 	}
 
-	TreeItem *c = item->get_children();
+	TreeItem *c = item->get_first_child();
 
 	while (c) {
 		_update_selection(c);

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -235,8 +235,8 @@ void EditorSettingsDialog::_update_shortcuts() {
 	// Before clearing the tree, take note of which categories are collapsed so that this state can be maintained when the tree is repopulated.
 	Map<String, bool> collapsed;
 
-	if (shortcuts->get_root() && shortcuts->get_root()->get_children()) {
-		for (TreeItem *item = shortcuts->get_root()->get_children(); item; item = item->get_next()) {
+	if (shortcuts->get_root() && shortcuts->get_root()->get_first_child()) {
+		for (TreeItem *item = shortcuts->get_root()->get_first_child(); item; item = item->get_next()) {
 			collapsed[item->get_text(0)] = item->is_collapsed();
 		}
 	}
@@ -380,7 +380,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 	// remove sections with no shortcuts
 	for (Map<String, TreeItem *>::Element *E = sections.front(); E; E = E->next()) {
 		TreeItem *section = E->get();
-		if (section->get_children() == nullptr) {
+		if (section->get_first_child() == nullptr) {
 			root->remove_child(section);
 		}
 	}

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1168,7 +1168,7 @@ void VisualScriptEditor::_member_selected() {
 
 	selected = ti->get_metadata(0);
 
-	if (ti->get_parent() == members->get_root()->get_children()) {
+	if (ti->get_parent() == members->get_root()->get_first_child()) {
 #ifdef OSX_ENABLED
 		bool held_ctrl = Input::get_singleton()->is_key_pressed(KEY_META);
 #else
@@ -1214,7 +1214,7 @@ void VisualScriptEditor::_member_edited() {
 
 	TreeItem *root = members->get_root();
 
-	if (ti->get_parent() == root->get_children()) {
+	if (ti->get_parent() == root->get_first_child()) {
 		selected = new_name;
 
 		int node_id = script->get_function_node_id(name);
@@ -1255,7 +1255,7 @@ void VisualScriptEditor::_member_edited() {
 		return; // Or crash because it will become invalid.
 	}
 
-	if (ti->get_parent() == root->get_children()->get_next()) {
+	if (ti->get_parent() == root->get_first_child()->get_next()) {
 		selected = new_name;
 		undo_redo->create_action(TTR("Rename Variable"));
 		undo_redo->add_do_method(script.ptr(), "rename_variable", name, new_name);
@@ -1271,7 +1271,7 @@ void VisualScriptEditor::_member_edited() {
 		return; // Or crash because it will become invalid.
 	}
 
-	if (ti->get_parent() == root->get_children()->get_next()->get_next()) {
+	if (ti->get_parent() == root->get_first_child()->get_next()->get_next()) {
 		selected = new_name;
 		undo_redo->create_action(TTR("Rename Signal"));
 		undo_redo->add_do_method(script.ptr(), "rename_custom_signal", name, new_name);
@@ -1405,7 +1405,7 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 
 	if (ti->get_parent() == root) {
 		//main buttons
-		if (ti == root->get_children()) {
+		if (ti == root->get_first_child()) {
 			// Add function, this one uses menu.
 
 			if (p_button == 1) {
@@ -1442,7 +1442,7 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 			return; // Or crash because it will become invalid.
 		}
 
-		if (ti == root->get_children()->get_next()) {
+		if (ti == root->get_first_child()->get_next()) {
 			// Add variable.
 			String name = _validate_name("new_variable");
 			selected = name;
@@ -1458,7 +1458,7 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 			return; // Or crash because it will become invalid.
 		}
 
-		if (ti == root->get_children()->get_next()->get_next()) {
+		if (ti == root->get_first_child()->get_next()->get_next()) {
 			// Add variable.
 			String name = _validate_name("new_signal");
 			selected = name;
@@ -1473,7 +1473,7 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 			undo_redo->commit_action();
 			return; // Or crash because it will become invalid.
 		}
-	} else if (ti->get_parent() == root->get_children()) {
+	} else if (ti->get_parent() == root->get_first_child()) {
 		selected = ti->get_text(0);
 		function_name_edit->set_position(Input::get_singleton()->get_mouse_position() - Vector2(60, -10));
 		function_name_edit->popup();
@@ -1841,13 +1841,13 @@ void VisualScriptEditor::_members_gui_input(const Ref<InputEvent> &p_event) {
 			TreeItem *ti = members->get_selected();
 			if (ti) {
 				TreeItem *root = members->get_root();
-				if (ti->get_parent() == root->get_children()) {
+				if (ti->get_parent() == root->get_first_child()) {
 					member_type = MEMBER_FUNCTION;
 				}
-				if (ti->get_parent() == root->get_children()->get_next()) {
+				if (ti->get_parent() == root->get_first_child()->get_next()) {
 					member_type = MEMBER_VARIABLE;
 				}
-				if (ti->get_parent() == root->get_children()->get_next()->get_next()) {
+				if (ti->get_parent() == root->get_first_child()->get_next()->get_next()) {
 					member_type = MEMBER_SIGNAL;
 				}
 				member_name = ti->get_text(0);
@@ -1864,7 +1864,7 @@ void VisualScriptEditor::_members_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> btn = p_event;
 	if (btn.is_valid() && btn->is_double_click()) {
 		TreeItem *ti = members->get_selected();
-		if (ti && ti->get_parent() == members->get_root()->get_children()) { // to check if it's a function
+		if (ti && ti->get_parent() == members->get_root()->get_first_child()) { // to check if it's a function
 			_center_on_node(script->get_function_node_id(ti->get_metadata(0)));
 		}
 	}
@@ -1946,13 +1946,13 @@ Variant VisualScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 		Dictionary dd;
 		TreeItem *root = members->get_root();
 
-		if (it->get_parent() == root->get_children()) {
+		if (it->get_parent() == root->get_first_child()) {
 			dd["type"] = "visual_script_function_drag";
 			dd["function"] = type;
-		} else if (it->get_parent() == root->get_children()->get_next()) {
+		} else if (it->get_parent() == root->get_first_child()->get_next()) {
 			dd["type"] = "visual_script_variable_drag";
 			dd["variable"] = type;
-		} else if (it->get_parent() == root->get_children()->get_next()->get_next()) {
+		} else if (it->get_parent() == root->get_first_child()->get_next()->get_next()) {
 			dd["type"] = "visual_script_signal_drag";
 			dd["signal"] = type;
 
@@ -4115,7 +4115,7 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 
 	Ref<Texture2D> edit_icon = Control::get_theme_icon("Edit", "EditorIcons");
 
-	if (ti->get_parent() == root->get_children()) {
+	if (ti->get_parent() == root->get_first_child()) {
 		member_type = MEMBER_FUNCTION;
 		member_name = ti->get_text(0);
 		member_popup->add_icon_shortcut(edit_icon, ED_GET_SHORTCUT("visual_script_editor/edit_member"), MEMBER_EDIT);
@@ -4125,7 +4125,7 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 		return;
 	}
 
-	if (ti->get_parent() == root->get_children()->get_next()) {
+	if (ti->get_parent() == root->get_first_child()->get_next()) {
 		member_type = MEMBER_VARIABLE;
 		member_name = ti->get_text(0);
 		member_popup->add_icon_shortcut(edit_icon, ED_GET_SHORTCUT("visual_script_editor/edit_member"), MEMBER_EDIT);
@@ -4135,7 +4135,7 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 		return;
 	}
 
-	if (ti->get_parent() == root->get_children()->get_next()->get_next()) {
+	if (ti->get_parent() == root->get_first_child()->get_next()->get_next()) {
 		member_type = MEMBER_SIGNAL;
 		member_name = ti->get_text(0);
 		member_popup->add_icon_shortcut(edit_icon, ED_GET_SHORTCUT("visual_script_editor/edit_member"), MEMBER_EDIT);

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -59,7 +59,7 @@ void VisualScriptPropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 				search_box->accept_event();
 
 				TreeItem *root = search_options->get_root();
-				if (!root->get_children()) {
+				if (!root->get_first_child()) {
 					break;
 				}
 
@@ -265,7 +265,7 @@ void VisualScriptPropertySelector::_update_search() {
 			item->set_metadata(2, connecting);
 		}
 
-		if (category && category->get_children() == nullptr) {
+		if (category && category->get_first_child() == nullptr) {
 			memdelete(category); //old category was unused
 		}
 	}
@@ -310,7 +310,7 @@ void VisualScriptPropertySelector::_update_search() {
 		found = true;
 	}
 
-	get_ok_button()->set_disabled(root->get_children() == nullptr);
+	get_ok_button()->set_disabled(root->get_first_child() == nullptr);
 }
 
 void VisualScriptPropertySelector::create_visualscript_item(const String &name, TreeItem *const root, const String &search_input, const String &text) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -589,8 +589,8 @@ void FileDialog::update_file_list() {
 		files.pop_front();
 	}
 
-	if (tree->get_root() && tree->get_root()->get_children() && tree->get_selected() == nullptr) {
-		tree->get_root()->get_children()->select(0);
+	if (tree->get_root() && tree->get_root()->get_first_child() && tree->get_selected() == nullptr) {
+		tree->get_root()->get_first_child()->select(0);
 	}
 }
 


### PR DESCRIPTION
Partially fixes godotengine/godot-proposals#2088
Fixes #19796 by renaming get_children to get_first_child, as suggested in #19796 and in #16863 3 times.

This PR adds:

- Some getters to reduce the number of manual iteration over the tree.
- `Tree get_tree()`.
- `get_first_child` to replace `get_children`.
- `TreeItem.create_child`.
- A pointer to the previous item to speed up get_prev() (the old code still exists but now is an edge case).
- `move_before` and `move_after` for moving items (see below), and remove `move_to_top` and `move_to_bottom` as they are not necessary anymore.

The new move_\* methods allows moving items over the tree and (unlikely the current system), allow reparent and even moving the item and its children to another tree.
Those methods move `self` before (or after) the specified item. For me, this is the simplest (and less error-prone) approach, but I'm open to suggestions.

<details>
<summary> An example of cross-tree move </summary>

![Move](https://user-images.githubusercontent.com/33117082/110358439-b354bc00-803c-11eb-8225-d2a27aa9b2dd.gif)
```gdscript
@tool
extends Control

@onready var root: TreeItem = $Tree.create_item()
@onready var level1: TreeItem = $Tree.create_item()
@onready var level2: TreeItem = level1.create_child()

func _ready():
    root.set_text(0, "Root")
    level1.set_text(0, "Level 1")
    level2.set_text(0, "Level 2")
    
    $Tree2.create_item()
    var dummy: TreeItem = $Tree2.create_item()
    await get_tree().create_timer(3.0).timeout
    level1.move_after(dummy)
    dummy.free()
```

</details>

<!-- After this PR is merged, I'd work in migrating the editor to use the new methods. -->