### PR TITLE
SCons: Fix parsing PATH when constructing base environment

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -61,11 +61,14 @@ elif platform_arg == "javascript":
     # Use generic POSIX build toolchain for Emscripten.
     custom_tools = ["cc", "c++", "ar", "link", "textfile", "zip"]
 
-env_base = Environment(tools=custom_tools)
-if "TERM" in os.environ:
-    env_base["ENV"]["TERM"] = os.environ["TERM"]
-env_base.AppendENVPath("PATH", os.getenv("PATH"))
-env_base.AppendENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
+env_base = Environment(
+    ENV={
+        "PATH": os.getenv("PATH"),
+        "PKG_CONFIG_PATH": os.getenv("PKG_CONFIG_PATH"),
+        "TERM": os.getenv("TERM"),
+    },
+    tools=custom_tools,
+)
 env_base.disabled_modules = []
 env_base.module_version_string = ""
 env_base.msvc = False


### PR DESCRIPTION
We constructed the SCons environment without taking any (shell) environment
variables into account, and then appended a few, but too late. This would
cause variables like `env["CXX"]` not to be properly expanded to respect a
non-standard `PATH`.

With this fix, setting:
```
PATH=$GODOT_SDK/bin:$PATH
```
will now properly use `$GODOT_SDK/bin/gcc` if available over `/usr/bin/gcc`.

----

For now I went with a conservative fix (same intent as the previous code), but we could also consider pulling in the whole `os.environ` with:
```
env_base = Environment(ENV=os.environ, tools=custom_tools)
```

The [SCons documentation](https://www.scons.org/doc/HTML/scons-man.html) mentions it but also specifies that it can be risky:

> Or you may explicitly propagate the invoking user's complete external environment: [snip]
> This comes at the expense of making your build dependent on the user's environment being set correctly, but it may be more convenient for many configurations. It should not cause problems if done in a build setup which tightly controls how the environment is set up before invoking scons, as in many continuous integration setups.

I want something safe to cherry-pick for `3.2.4` so not giving this a try now, but we can reconsider later.