### PR TITLE
fix Label visible_characters bad precision (Fix #46775)

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -260,7 +260,8 @@ void Label::_notification(int p_what) {
 					}
 				}
 			}
-			visible_glyphs = total_glyphs * percent_visible;
+
+			visible_glyphs = MIN(total_glyphs, visible_chars);
 		}
 
 		Vector2 ofs;
@@ -541,6 +542,8 @@ void Label::set_visible_characters(int p_amount) {
 	visible_chars = p_amount;
 	if (get_total_character_count() > 0) {
 		percent_visible = (float)p_amount / (float)get_total_character_count();
+	} else {
+		percent_visible = 1.0;
 	}
 	update();
 }


### PR DESCRIPTION
Fix #46775

When using long text in Label, the number of characters shown with visible_characters property was not accurate.

The percent_visible was used instead of visible_characters number that causes a rounding imprecision.

Before : 

![Label_bug](https://user-images.githubusercontent.com/3649998/110257507-894cbc80-7f9e-11eb-8d7a-ccbca2a89953.gif)

After : 

![Label_fix](https://user-images.githubusercontent.com/3649998/110257062-5275a700-7f9c-11eb-852d-544c4f73e748.gif)


Also, setting percent_visible to 1.0 was setting visible_characters to -1 but setting visible_characters to -1 didn't set percent_visible to 1.0. It's now fixed too.