### PR TITLE
Fix resize collision shape for tile when vertex outside of tilesheet

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -1611,6 +1611,13 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 					const real_t grab_threshold = EDITOR_GET("editors/poly_editor/point_grab_radius");
 					shape_anchor += current_tile_region.position;
 					if (tools[TOOL_SELECT]->is_pressed()) {
+						if (current_shape.size() > 0) {
+							for (int i = 0; i < current_shape.size(); i++) {
+								current_shape.set(i, snap_point(current_shape[i]));
+							}
+							workspace->update();
+						}
+
 						if (mb.is_valid()) {
 							if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
 								if (edit_mode != EDITMODE_PRIORITY && current_shape.size() > 0) {


### PR DESCRIPTION
Complements pull request #42150 which did not completely resolve the issue.
![34970](https://user-images.githubusercontent.com/28615299/110271664-43482680-7fa7-11eb-8e51-54c68380eb4b.gif)

**Version:** _v3.2.4.rc.custom_build.4f891b706_

<i>Bugsquad edit</i>: Fix #34970