### PR TITLE
Improve bitmap font scaling. Fix default theme font size.

### DIFF
--- a/modules/text_server_adv/bitmap_font_adv.h
+++ b/modules/text_server_adv/bitmap_font_adv.h
@@ -63,11 +63,11 @@ private:
 
 	HashMap<uint32_t, Character> char_map;
 	Map<KerningPairKey, int> kerning_map;
-	Map<float, hb_font_t *> cache;
+	hb_font_t *hb_handle = nullptr;
 
 	float height = 0.f;
 	float ascent = 0.f;
-	float base_size = 0.f;
+	int base_size = 0;
 	bool distance_field_hint = false;
 
 public:
@@ -101,6 +101,7 @@ public:
 
 	virtual bool has_outline() const override { return false; };
 	virtual float get_base_size() const override;
+	virtual float get_font_scale(int p_size) const override;
 
 	virtual hb_font_t *get_hb_handle(int p_size) override;
 

--- a/modules/text_server_fb/bitmap_font_fb.cpp
+++ b/modules/text_server_fb/bitmap_font_fb.cpp
@@ -319,14 +319,13 @@ Vector2 BitmapFontDataFallback::draw_glyph(RID p_canvas, int p_size, const Vecto
 	ERR_FAIL_COND_V(c->texture_idx < -1 || c->texture_idx >= textures.size(), Vector2());
 	if (c->texture_idx != -1) {
 		Point2i cpos = p_pos;
-		cpos += c->align * (float(p_size) / float(base_size));
-		cpos.y -= ascent * (float(p_size) / float(base_size));
-
+		cpos += (c->align + Vector2(0, -ascent)) * (float(p_size) / float(base_size));
+		Size2i csize = c->rect.size * (float(p_size) / float(base_size));
 		if (RenderingServer::get_singleton() != nullptr) {
 			//if (distance_field_hint) { // Not implemented.
 			//	RenderingServer::get_singleton()->canvas_item_set_distance_field_mode(p_canvas, true);
 			//}
-			RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, c->rect.size * (float(p_size) / float(base_size))), textures[c->texture_idx]->get_rid(), c->rect, p_color, false, false);
+			RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, csize), textures[c->texture_idx]->get_rid(), c->rect, p_color, false, false);
 			//if (distance_field_hint) {
 			//	RenderingServer::get_singleton()->canvas_item_set_distance_field_mode(p_canvas, false);
 			//}

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -1017,7 +1017,7 @@ void make_default_theme(bool p_hidpi, Ref<Font> p_font) {
 	Ref<StyleBox> default_style;
 	Ref<Texture2D> default_icon;
 	Ref<Font> default_font;
-	int default_font_size = 16;
+	int default_font_size = 14;
 	if (p_font.is_valid()) {
 		default_font = p_font;
 	} else if (p_hidpi) {


### PR DESCRIPTION
Fix default theme font size (actual font files are 14 not 16).
Improve bitmap font scaling:
- Use single HarfBuzz font handle for all sizes.
- Fix ascent precision loss on fractional scaling.

Before (size 16):
![before](https://user-images.githubusercontent.com/3649998/110257062-5275a700-7f9c-11eb-852d-544c4f73e748.gif)

After (size 14 and 16):
![after](https://user-images.githubusercontent.com/7645683/110292290-a5c81380-7ff5-11eb-8e65-38395e9f64c3.png)