### PR TITLE
Linux: Fix PRIME detection on Steam

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -4030,7 +4030,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 				use_prime = 0;
 			}
 
-			if (getenv("LD_LIBRARY_PATH")) {
+			// Some tools use fake libGL libraries and have them override the real one using
+			// LD_LIBRARY_PATH, so we skip them. *But* Steam also sets LD_LIBRARY_PATH for its
+			// runtime and includes system `/lib` and `/lib64`... so ignore Steam.
+			if (use_prime == -1 && getenv("LD_LIBRARY_PATH") && !getenv("STEAM_RUNTIME_LIBRARY_PATH")) {
 				String ld_library_path(getenv("LD_LIBRARY_PATH"));
 				Vector<String> libraries = ld_library_path.split(":");
 


### PR DESCRIPTION
To avoid trying to do PRIME detection on fake `libGL.so` as used by e.g.
Renderdoc or Primus, we skip detection if there's a `libGL.so` in
`LD_LIBRARY_PATH`... and our luck is that Steam defines it and includes
system paths too, thus the actual system `libGL`... 🤦

So if we detect Steam, we skip this check.

Will do matching PR for `3.2`.

---

One concern with this fix though - do we risk running into issues for users that do `primusrun %command%` in a Steam context? Or is the previous check robust enough to exclude all bumblebee hacks?