### PR TITLE
[3.2] Linux: Fix PRIME detection on Steam

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -264,7 +264,10 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 			use_prime = 0;
 		}
 
-		if (getenv("LD_LIBRARY_PATH")) {
+		// Some tools use fake libGL libraries and have them override the real one using
+		// LD_LIBRARY_PATH, so we skip them. *But* Steam also sets LD_LIBRARY_PATH for its
+		// runtime and includes system `/lib` and `/lib64`... so ignore Steam.
+		if (use_prime == -1 && getenv("LD_LIBRARY_PATH") && !getenv("STEAM_RUNTIME_LIBRARY_PATH")) {
 			String ld_library_path(getenv("LD_LIBRARY_PATH"));
 			Vector<String> libraries = ld_library_path.split(":");
 


### PR DESCRIPTION
To avoid trying to do PRIME detection on fake `libGL.so` as used by e.g.
Renderdoc or Primus, we skip detection if there's a `libGL.so` in
`LD_LIBRARY_PATH`... and our luck is that Steam defines it and includes
system paths too, thus the actual system `libGL`... 🤦

So if we detect Steam, we skip this check.

---

`3.2` version of #46792.