### PR TITLE
Provide missing include path for custom modules

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -242,13 +242,16 @@ for path in module_search_paths:
         # Built-in modules don't have nested modules,
         # so save the time it takes to parse directories.
         modules = methods.detect_modules(path, recursive=False)
-    else:  # External.
+    else:  # Custom.
         modules = methods.detect_modules(path, env_base["custom_modules_recursive"])
+        # Provide default include path for both the custom module search `path`
+        # and the base directory containing custom modules, as it may be different
+        # from the built-in "modules" name (e.g. "custom_modules/summator/summator.h"),
+        # so it can be referenced simply as `#include "summator/summator.h"`
+        # independently of where a module is located on user's filesystem.
+        env_base.Prepend(CPPPATH=[path, os.path.dirname(path)])
     # Note: custom modules can override built-in ones.
     modules_detected.update(modules)
-    include_path = os.path.dirname(path)
-    if include_path:
-        env_base.Prepend(CPPPATH=[include_path])
 
 # Add module options.
 for name, path in modules_detected.items():


### PR DESCRIPTION
Allows to use a module as a library, where an include path may start with module's name itself.

It means that the following:
```c++
#include "summator/summator.h"
#include "modules/summator/summator.h"
#include "custom_modules/summator/summator.h" // If the base directory is not "modules" on user filesystem...
```
are acceptable ways to reference paths in Godot sources.

Godot can still follow existing include path conventions, as it doesn't affect built-in modules.