### PR TITLE
[HTML5] Respect allow_hidpi option during setup

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -488,7 +488,7 @@
 			Position offset for tooltips, relative to the mouse cursor's hotspot.
 		</member>
 		<member name="display/window/dpi/allow_hidpi" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], allows HiDPI display on Windows and macOS. This setting has no effect on desktop Linux, as DPI-awareness fallbacks are not supported there.
+			If [code]true[/code], allows HiDPI display on Windows, macOS, and the HTML5 platform. This setting has no effect on desktop Linux, as DPI-awareness fallbacks are not supported there.
 		</member>
 		<member name="display/window/energy_saving/keep_screen_on" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], keeps the screen on (even in case of inactivity), so the screensaver does not take over. Works on desktop and mobile platforms.

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -683,7 +683,7 @@ DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_drive
 	godot_js_config_canvas_id_get(canvas_id, 256);
 
 	// Handle contextmenu, webglcontextlost
-	godot_js_display_setup_canvas(p_resolution.x, p_resolution.y, p_mode == WINDOW_MODE_FULLSCREEN);
+	godot_js_display_setup_canvas(p_resolution.x, p_resolution.y, p_mode == WINDOW_MODE_FULLSCREEN, OS::get_singleton()->is_hidpi_allowed() ? 1 : 0);
 
 	// Check if it's windows.
 	swap_cancel_ok = godot_js_display_is_swap_ok_cancel() == 1;

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -92,7 +92,7 @@ extern int godot_js_display_gamepad_sample_get(int p_idx, float r_btns[16], int3
 extern void godot_js_display_notification_cb(void (*p_callback)(int p_notification), int p_enter, int p_exit, int p_in, int p_out);
 extern void godot_js_display_paste_cb(void (*p_callback)(const char *p_text));
 extern void godot_js_display_drop_files_cb(void (*p_callback)(char **p_filev, int p_filec));
-extern void godot_js_display_setup_canvas(int p_width, int p_height, int p_fullscreen);
+extern void godot_js_display_setup_canvas(int p_width, int p_height, int p_fullscreen, int p_hidpi);
 #ifdef __cplusplus
 }
 #endif

--- a/platform/javascript/js/libs/library_godot_display.js
+++ b/platform/javascript/js/libs/library_godot_display.js
@@ -400,6 +400,10 @@ const GodotDisplayScreen = {
 	$GodotDisplayScreen__deps: ['$GodotConfig', '$GodotOS', '$GL', 'emscripten_webgl_get_current_context'],
 	$GodotDisplayScreen: {
 		desired_size: [0, 0],
+		hidpi: true,
+		getPixelRatio: function () {
+			return GodotDisplayScreen.hidpi ? window.devicePixelRatio || 1 : 1;
+		},
 		isFullscreen: function () {
 			const elem = document.fullscreenElement || document.mozFullscreenElement
 				|| document.webkitFullscreenElement || document.msFullscreenElement;
@@ -477,7 +481,7 @@ const GodotDisplayScreen = {
 				}
 				return 0;
 			}
-			const scale = window.devicePixelRatio || 1;
+			const scale = GodotDisplayScreen.getPixelRatio();
 			if (isFullscreen || wantsFullWindow) {
 				// We need to match screen size.
 				width = window.innerWidth * scale;
@@ -555,7 +559,7 @@ const GodotDisplay = {
 
 	godot_js_display_pixel_ratio_get__sig: 'f',
 	godot_js_display_pixel_ratio_get: function () {
-		return window.devicePixelRatio || 1;
+		return GodotDisplayScreen.getPixelRatio();
 	},
 
 	godot_js_display_fullscreen_request__sig: 'i',
@@ -581,7 +585,7 @@ const GodotDisplay = {
 
 	godot_js_display_screen_size_get__sig: 'vii',
 	godot_js_display_screen_size_get: function (width, height) {
-		const scale = window.devicePixelRatio || 1;
+		const scale = GodotDisplayScreen.getPixelRatio();
 		GodotRuntime.setHeapValue(width, window.screen.width * scale, 'i32');
 		GodotRuntime.setHeapValue(height, window.screen.height * scale, 'i32');
 	},
@@ -776,8 +780,8 @@ const GodotDisplay = {
 		GodotDisplayListeners.add(canvas, 'drop', GodotDisplayDragDrop.handler(dropFiles));
 	},
 
-	godot_js_display_setup_canvas__sig: 'viii',
-	godot_js_display_setup_canvas: function (p_width, p_height, p_fullscreen) {
+	godot_js_display_setup_canvas__sig: 'viiii',
+	godot_js_display_setup_canvas: function (p_width, p_height, p_fullscreen, p_hidpi) {
 		const canvas = GodotConfig.canvas;
 		GodotDisplayListeners.add(canvas, 'contextmenu', function (ev) {
 			ev.preventDefault();
@@ -786,6 +790,7 @@ const GodotDisplay = {
 			alert('WebGL context lost, please reload the page'); // eslint-disable-line no-alert
 			ev.preventDefault();
 		}, false);
+		GodotDisplayScreen.hidpi = !!p_hidpi;
 		switch (GodotConfig.canvas_resize_policy) {
 		case 0: // None
 			GodotDisplayScreen.desired_size = [canvas.width, canvas.height];


### PR DESCRIPTION
The option was forced to `true` before, unlike on other platforms.

This fixes the HTML5 part of #28666 , which also seem to have slightly diverged from OP issue.