### PR TITLE
Move caller_id init to Thread constructor to fix UWP build.

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -47,7 +47,7 @@ uint64_t Thread::_thread_id_hash(const std::thread::id &p_t) {
 }
 
 Thread::ID Thread::main_thread_id = _thread_id_hash(std::this_thread::get_id());
-thread_local Thread::ID Thread::caller_id = _thread_id_hash(std::this_thread::get_id());
+thread_local Thread::ID Thread::caller_id = 0;
 
 void Thread::_set_platform_funcs(
 		Error (*p_set_name_func)(const String &),
@@ -110,6 +110,10 @@ Error Thread::set_name(const String &p_name) {
 	}
 
 	return ERR_UNAVAILABLE;
+}
+
+Thread::Thread() {
+	caller_id = _thread_id_hash(std::this_thread::get_id());
 }
 
 Thread::~Thread() {

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -98,6 +98,7 @@ public:
 	///< waits until thread is finished, and deallocates it.
 	void wait_to_finish();
 
+	Thread();
 	~Thread();
 #else
 	_FORCE_INLINE_ ID get_id() const { return 0; }


### PR DESCRIPTION
Should work the same way as before (`caller_id` is set to current thread ID).

And fix: `core\os\thread.cpp(50): error C2482: 'caller_id': dynamic initialization of thread local data not allowed in WinRT code` error on UWP.

Tested on to work macOS, Linux and Wine (MinGW build), need to be tested on Windows/UWP.