### PR TITLE
SCons: Propagate the user's OS environment in env["ENV"]

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -61,14 +61,9 @@ elif platform_arg == "javascript":
     # Use generic POSIX build toolchain for Emscripten.
     custom_tools = ["cc", "c++", "ar", "link", "textfile", "zip"]
 
-env_base = Environment(
-    ENV={
-        "PATH": os.getenv("PATH"),
-        "PKG_CONFIG_PATH": os.getenv("PKG_CONFIG_PATH"),
-        "TERM": os.getenv("TERM"),
-    },
-    tools=custom_tools,
-)
+# Construct the environment using the user's host env variables.
+env_base = Environment(ENV=os.environ, tools=custom_tools)
+
 env_base.disabled_modules = []
 env_base.module_version_string = ""
 env_base.msvc = False


### PR DESCRIPTION
This fixes a regression from #46774 where `env["ENV"]` would miss some
important env variables on Windows, such as `SystemRoot`, `PATHEXT`, etc.

To have those, we can either use the default `ENV` created by SCons, or
propagate the whole external environment.

Fixes #46790.

----

For additional context, we debugged this with @BastiaanOlij, and indeed on Linux the previous code was fine as the default `env["ENV"]` only includes:
```
{'PATH': '/usr/local/bin:/opt/bin:/bin:/usr/bin:/snap/bin'}
```
Which is superseded by any decent external `PATH` definition.

But on Windows, `env["ENV"]` includes a lot more relevant parts of the Windows environment such as `SystemDrive`, `SystemRoot`, `TEMP`, `TMP`, `COMSPEC`, `PATHEXT`. Setting `ENV` to an incomplete dictionary while creating the `Environment` leads to not having those defined unless also passed manually. Yet that's the example given in SCons' documentation: https://www.scons.org/doc/HTML/scons-man.html

![Screenshot_20210309_092700](https://user-images.githubusercontent.com/4701338/110441048-a0340180-80b9-11eb-8801-a739fb9d982b.png)

We therefore have two options:
1. Either create the `Environment` without specifying `ENV` to let SCons initialize it properly on each OS, and then **prepend** the `PATH` to keep solving what #46774 was addressing,
2. Or pull in the whole user environment and expect it to be a valid compilation environment.

Option 1. is safer but option 2. is nicer, so we'll do 2. in `master` and 1. in `3.2`. (And if we found that 2. causes issues in `master`, we might revert back to 1. there too.)