### PR TITLE
[3.2] SCons: Use default env["ENV"] and prepend PATH to it

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -61,14 +61,15 @@ elif platform_arg == "javascript":
     # Use generic POSIX build toolchain for Emscripten.
     custom_tools = ["cc", "c++", "ar", "link", "textfile", "zip"]
 
-env_base = Environment(
-    ENV={
-        "PATH": os.getenv("PATH"),
-        "PKG_CONFIG_PATH": os.getenv("PKG_CONFIG_PATH"),
-        "TERM": os.getenv("TERM"),
-    },
-    tools=custom_tools,
-)
+# We let SCons build its default ENV as it includes OS-specific things which we don't
+# want to have to pull in manually.
+# Then we prepend PATH to make it take precedence, while preserving SCons' own entries.
+env_base = Environment(tools=custom_tools)
+env_base.PrependENVPath("PATH", os.getenv("PATH"))
+env_base.PrependENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
+if "TERM" in os.environ:  # Used for colored output.
+    env_base["ENV"]["TERM"] = os.environ["TERM"]
+
 env_base.disabled_modules = []
 env_base.use_ptrcall = False
 env_base.module_version_string = ""


### PR DESCRIPTION
This fixes a regression from #46774 where `env["ENV"]` would miss some
important env variables on Windows, such as `SystemRoot`, `PATHEXT`, etc.

So we go back to the previous setup (letting SCons initialize `env["ENV"]`
as it sees fit for the host OS) but use `PrependENVPath` instead of
`AppendENVPath` to preserve the intended fix from #46774.

Fixes #46790 for 3.2.

---

See discussion in #46814 - we use a simpler but riskier fix in `master`, but for `3.2` we're going back to what was proven working until now.