### PR TITLE
Fix negative VRAM values

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1021,7 +1021,7 @@ struct _OSCoreBindImg {
 void _OS::print_all_textures_by_size() {
 
 	List<_OSCoreBindImg> imgs;
-	int total = 0;
+	uint64_t total = 0;
 	{
 		List<Ref<Resource> > rsrc;
 		ResourceCache::get_cached_resources(&rsrc);

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -763,7 +763,7 @@ public:
 	void render_info_end_capture() {}
 	int get_captured_render_info(VS::RenderInfo p_info) { return 0; }
 
-	int get_render_info(VS::RenderInfo p_info) { return 0; }
+	uint64_t get_render_info(VS::RenderInfo p_info) { return 0; }
 	String get_video_adapter_name() const { return String(); }
 	String get_video_adapter_vendor() const { return String(); }
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5946,7 +5946,7 @@ int RasterizerStorageGLES2::get_captured_render_info(VS::RenderInfo p_info) {
 	}
 }
 
-int RasterizerStorageGLES2::get_render_info(VS::RenderInfo p_info) {
+uint64_t RasterizerStorageGLES2::get_render_info(VS::RenderInfo p_info) {
 	switch (p_info) {
 		case VS::INFO_OBJECTS_IN_FRAME:
 			return info.render_final.object_count;

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1345,7 +1345,7 @@ public:
 	virtual void render_info_end_capture();
 	virtual int get_captured_render_info(VS::RenderInfo p_info);
 
-	virtual int get_render_info(VS::RenderInfo p_info);
+	virtual uint64_t get_render_info(VS::RenderInfo p_info);
 	virtual String get_video_adapter_name() const;
 	virtual String get_video_adapter_vendor() const;
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8294,7 +8294,7 @@ int RasterizerStorageGLES3::get_captured_render_info(VS::RenderInfo p_info) {
 	}
 }
 
-int RasterizerStorageGLES3::get_render_info(VS::RenderInfo p_info) {
+uint64_t RasterizerStorageGLES3::get_render_info(VS::RenderInfo p_info) {
 
 	switch (p_info) {
 		case VS::INFO_OBJECTS_IN_FRAME:

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1507,7 +1507,7 @@ public:
 	virtual void render_info_end_capture();
 	virtual int get_captured_render_info(VS::RenderInfo p_info);
 
-	virtual int get_render_info(VS::RenderInfo p_info);
+	virtual uint64_t get_render_info(VS::RenderInfo p_info);
 	virtual String get_video_adapter_name() const;
 	virtual String get_video_adapter_vendor() const;
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -717,7 +717,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		vmem_tree->clear();
 		TreeItem *root = vmem_tree->create_item();
 
-		int total = 0;
+		uint64_t total = 0;
 
 		for (int i = 0; i < p_data.size(); i += 4) {
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -601,7 +601,7 @@ public:
 	virtual void render_info_end_capture() = 0;
 	virtual int get_captured_render_info(VS::RenderInfo p_info) = 0;
 
-	virtual int get_render_info(VS::RenderInfo p_info) = 0;
+	virtual uint64_t get_render_info(VS::RenderInfo p_info) = 0;
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
 

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -148,7 +148,7 @@ void VisualServerRaster::finish() {
 
 /* STATUS INFORMATION */
 
-int VisualServerRaster::get_render_info(RenderInfo p_info) {
+uint64_t VisualServerRaster::get_render_info(RenderInfo p_info) {
 
 	return VSG::storage->get_render_info(p_info);
 }

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -685,7 +685,7 @@ public:
 
 	/* STATUS INFORMATION */
 
-	virtual int get_render_info(RenderInfo p_info);
+	virtual uint64_t get_render_info(RenderInfo p_info);
 	virtual String get_video_adapter_name() const;
 	virtual String get_video_adapter_vendor() const;
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -605,7 +605,7 @@ public:
 	/* RENDER INFO */
 
 	//this passes directly to avoid stalling
-	virtual int get_render_info(RenderInfo p_info) {
+	virtual uint64_t get_render_info(RenderInfo p_info) {
 		return visual_server->get_render_info(p_info);
 	}
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1038,7 +1038,7 @@ public:
 		INFO_VERTEX_MEM_USED,
 	};
 
-	virtual int get_render_info(RenderInfo p_info) = 0;
+	virtual uint64_t get_render_info(RenderInfo p_info) = 0;
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes negative values for VRAM when usage exceeds 2GB.

Reimplementation of #46709 for the `3.2` branch.