### PR TITLE
Working on fixes for Android and Vulkan

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -268,7 +268,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 
 		GodotLib.setup(command_line);
 
-		final String videoDriver = GodotLib.getGlobal("rendering/quality/driver/driver_name");
+		final String videoDriver = GodotLib.getGlobal("rendering/driver/driver_name");
 		if (videoDriver.equals("Vulkan")) {
 			mRenderView = new GodotVulkanRenderView(activity, this);
 		} else {

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -38,6 +38,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 		return false;
 
 	JNIEnv *env = get_jni_env();
+	ERR_FAIL_COND_V(env == nullptr, false);
 
 	MethodInfo *method = nullptr;
 	for (List<MethodInfo>::Element *E = M->get().front(); E; E = E->next()) {
@@ -965,6 +966,7 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 		return class_cache[p_class];
 
 	JNIEnv *env = get_jni_env();
+	ERR_FAIL_COND_V(env == nullptr, Ref<JavaClass>());
 
 	jclass bclass = env->FindClass(p_class.utf8().get_data());
 	ERR_FAIL_COND_V(!bclass, Ref<JavaClass>());
@@ -1149,6 +1151,7 @@ JavaClassWrapper::JavaClassWrapper(jobject p_activity) {
 	singleton = this;
 
 	JNIEnv *env = get_jni_env();
+	ERR_FAIL_COND(env == nullptr);
 
 	jclass activityClass = env->FindClass("android/app/Activity");
 	jmethodID getClassLoader = env->GetMethodID(activityClass, "getClassLoader", "()Ljava/lang/ClassLoader;");

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -73,6 +73,7 @@ jobject GodotIOJavaWrapper::get_instance() {
 Error GodotIOJavaWrapper::open_uri(const String &p_uri) {
 	if (_open_URI) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, ERR_UNAVAILABLE);
 		jstring jStr = env->NewStringUTF(p_uri.utf8().get_data());
 		return env->CallIntMethod(godot_io_instance, _open_URI, jStr) ? ERR_CANT_OPEN : OK;
 	} else {
@@ -83,6 +84,7 @@ Error GodotIOJavaWrapper::open_uri(const String &p_uri) {
 String GodotIOJavaWrapper::get_user_data_dir() {
 	if (_get_data_dir) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_data_dir);
 		return jstring_to_string(s, env);
 	} else {
@@ -93,6 +95,7 @@ String GodotIOJavaWrapper::get_user_data_dir() {
 String GodotIOJavaWrapper::get_locale() {
 	if (_get_locale) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_locale);
 		return jstring_to_string(s, env);
 	} else {
@@ -103,6 +106,7 @@ String GodotIOJavaWrapper::get_locale() {
 String GodotIOJavaWrapper::get_model() {
 	if (_get_model) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_model);
 		return jstring_to_string(s, env);
 	} else {
@@ -113,6 +117,7 @@ String GodotIOJavaWrapper::get_model() {
 int GodotIOJavaWrapper::get_screen_dpi() {
 	if (_get_screen_DPI) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, 160);
 		return env->CallIntMethod(godot_io_instance, _get_screen_DPI);
 	} else {
 		return 160;
@@ -122,6 +127,7 @@ int GodotIOJavaWrapper::get_screen_dpi() {
 void GodotIOJavaWrapper::screen_get_usable_rect(int (&p_rect_xywh)[4]) {
 	if (_screen_get_usable_rect) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
 		jintArray returnArray = (jintArray)env->CallObjectMethod(godot_io_instance, _screen_get_usable_rect);
 		ERR_FAIL_COND(env->GetArrayLength(returnArray) != 4);
 		jint *arrayBody = env->GetIntArrayElements(returnArray, JNI_FALSE);
@@ -135,6 +141,7 @@ void GodotIOJavaWrapper::screen_get_usable_rect(int (&p_rect_xywh)[4]) {
 String GodotIOJavaWrapper::get_unique_id() {
 	if (_get_unique_id) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_unique_id);
 		return jstring_to_string(s, env);
 	} else {
@@ -149,6 +156,7 @@ bool GodotIOJavaWrapper::has_vk() {
 void GodotIOJavaWrapper::show_vk(const String &p_existing, bool p_multiline, int p_max_input_length, int p_cursor_start, int p_cursor_end) {
 	if (_show_keyboard) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
 		jstring jStr = env->NewStringUTF(p_existing.utf8().get_data());
 		env->CallVoidMethod(godot_io_instance, _show_keyboard, jStr, p_multiline, p_max_input_length, p_cursor_start, p_cursor_end);
 	}
@@ -157,6 +165,7 @@ void GodotIOJavaWrapper::show_vk(const String &p_existing, bool p_multiline, int
 void GodotIOJavaWrapper::hide_vk() {
 	if (_hide_keyboard) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
 		env->CallVoidMethod(godot_io_instance, _hide_keyboard);
 	}
 }
@@ -164,6 +173,7 @@ void GodotIOJavaWrapper::hide_vk() {
 void GodotIOJavaWrapper::set_screen_orientation(int p_orient) {
 	if (_set_screen_orientation) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
 		env->CallVoidMethod(godot_io_instance, _set_screen_orientation, p_orient);
 	}
 }
@@ -171,6 +181,7 @@ void GodotIOJavaWrapper::set_screen_orientation(int p_orient) {
 int GodotIOJavaWrapper::get_screen_orientation() {
 	if (_get_screen_orientation) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, 0);
 		return env->CallIntMethod(godot_io_instance, _get_screen_orientation);
 	} else {
 		return 0;
@@ -180,6 +191,7 @@ int GodotIOJavaWrapper::get_screen_orientation() {
 String GodotIOJavaWrapper::get_system_dir(int p_dir) {
 	if (_get_system_dir) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, String("."));
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_system_dir, p_dir);
 		return jstring_to_string(s, env);
 	} else {

--- a/platform/android/java_godot_view_wrapper.cpp
+++ b/platform/android/java_godot_view_wrapper.cpp
@@ -34,6 +34,7 @@
 
 GodotJavaViewWrapper::GodotJavaViewWrapper(jobject godot_view) {
 	JNIEnv *env = get_jni_env();
+	ERR_FAIL_COND(env == nullptr);
 
 	_godot_view = env->NewGlobalRef(godot_view);
 
@@ -48,6 +49,8 @@ GodotJavaViewWrapper::GodotJavaViewWrapper(jobject godot_view) {
 void GodotJavaViewWrapper::request_pointer_capture() {
 	if (_request_pointer_capture != 0) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+
 		env->CallVoidMethod(_godot_view, _request_pointer_capture);
 	}
 }
@@ -55,12 +58,16 @@ void GodotJavaViewWrapper::request_pointer_capture() {
 void GodotJavaViewWrapper::release_pointer_capture() {
 	if (_request_pointer_capture != 0) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+
 		env->CallVoidMethod(_godot_view, _release_pointer_capture);
 	}
 }
 
 GodotJavaViewWrapper::~GodotJavaViewWrapper() {
 	JNIEnv *env = get_jni_env();
+	ERR_FAIL_COND(env == nullptr);
+
 	env->DeleteGlobalRef(_godot_view);
 	env->DeleteGlobalRef(_cls);
 }

--- a/platform/android/java_godot_view_wrapper.h
+++ b/platform/android/java_godot_view_wrapper.h
@@ -34,6 +34,8 @@
 #include <android/log.h>
 #include <jni.h>
 
+#include "string_android.h"
+
 // Class that makes functions in java/src/org/godotengine/godot/GodotView.java callable from C++
 class GodotJavaViewWrapper {
 private:

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -94,6 +94,8 @@ jobject GodotJavaWrapper::get_member_object(const char *p_name, const char *p_cl
 		if (p_env == nullptr)
 			p_env = get_jni_env();
 
+		ERR_FAIL_COND_V(p_env == nullptr, nullptr);
+
 		jfieldID fid = p_env->GetStaticFieldID(godot_class, p_name, p_class);
 		return p_env->GetStaticObjectField(godot_class, fid);
 	} else {
@@ -104,6 +106,8 @@ jobject GodotJavaWrapper::get_member_object(const char *p_name, const char *p_cl
 jobject GodotJavaWrapper::get_class_loader() {
 	if (_get_class_loader) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, nullptr);
+
 		return env->CallObjectMethod(activity, _get_class_loader);
 	} else {
 		return nullptr;
@@ -115,6 +119,8 @@ GodotJavaViewWrapper *GodotJavaWrapper::get_godot_view() {
 		return _godot_view;
 	}
 	JNIEnv *env = get_jni_env();
+	ERR_FAIL_COND_V(env == nullptr, nullptr);
+
 	jmethodID godot_view_getter = env->GetMethodID(godot_class, "getRenderView", "()Lorg/godotengine/godot/GodotRenderView;");
 	_godot_view = new GodotJavaViewWrapper(env->CallObjectMethod(godot_instance, godot_view_getter));
 	return _godot_view;
@@ -124,6 +130,7 @@ void GodotJavaWrapper::on_video_init(JNIEnv *p_env) {
 	if (_on_video_init) {
 		if (p_env == nullptr)
 			p_env = get_jni_env();
+		ERR_FAIL_COND(p_env == nullptr);
 
 		p_env->CallVoidMethod(godot_instance, _on_video_init);
 	}
@@ -143,6 +150,7 @@ void GodotJavaWrapper::on_godot_main_loop_started(JNIEnv *p_env) {
 		if (p_env == nullptr) {
 			p_env = get_jni_env();
 		}
+		ERR_FAIL_COND(p_env == nullptr);
 		p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_started);
 	}
 }
@@ -151,6 +159,7 @@ void GodotJavaWrapper::restart(JNIEnv *p_env) {
 	if (_restart) {
 		if (p_env == nullptr)
 			p_env = get_jni_env();
+		ERR_FAIL_COND(p_env == nullptr);
 
 		p_env->CallVoidMethod(godot_instance, _restart);
 	}
@@ -160,6 +169,7 @@ void GodotJavaWrapper::force_quit(JNIEnv *p_env) {
 	if (_finish) {
 		if (p_env == nullptr)
 			p_env = get_jni_env();
+		ERR_FAIL_COND(p_env == nullptr);
 
 		p_env->CallVoidMethod(godot_instance, _finish);
 	}
@@ -168,6 +178,8 @@ void GodotJavaWrapper::force_quit(JNIEnv *p_env) {
 void GodotJavaWrapper::set_keep_screen_on(bool p_enabled) {
 	if (_set_keep_screen_on) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+
 		env->CallVoidMethod(godot_instance, _set_keep_screen_on, p_enabled);
 	}
 }
@@ -175,6 +187,8 @@ void GodotJavaWrapper::set_keep_screen_on(bool p_enabled) {
 void GodotJavaWrapper::alert(const String &p_message, const String &p_title) {
 	if (_alert) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+
 		jstring jStrMessage = env->NewStringUTF(p_message.utf8().get_data());
 		jstring jStrTitle = env->NewStringUTF(p_title.utf8().get_data());
 		env->CallVoidMethod(godot_instance, _alert, jStrMessage, jStrTitle);
@@ -183,6 +197,8 @@ void GodotJavaWrapper::alert(const String &p_message, const String &p_title) {
 
 int GodotJavaWrapper::get_gles_version_code() {
 	JNIEnv *env = get_jni_env();
+	ERR_FAIL_COND_V(env == nullptr, 0);
+
 	if (_get_GLES_version_code) {
 		return env->CallIntMethod(godot_instance, _get_GLES_version_code);
 	}
@@ -197,6 +213,8 @@ bool GodotJavaWrapper::has_get_clipboard() {
 String GodotJavaWrapper::get_clipboard() {
 	if (_get_clipboard) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, String());
+
 		jstring s = (jstring)env->CallObjectMethod(godot_instance, _get_clipboard);
 		return jstring_to_string(s, env);
 	} else {
@@ -207,6 +225,8 @@ String GodotJavaWrapper::get_clipboard() {
 String GodotJavaWrapper::get_input_fallback_mapping() {
 	if (_get_input_fallback_mapping) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, String());
+
 		jstring fallback_mapping = (jstring)env->CallObjectMethod(godot_instance, _get_input_fallback_mapping);
 		return jstring_to_string(fallback_mapping, env);
 	} else {
@@ -221,6 +241,8 @@ bool GodotJavaWrapper::has_set_clipboard() {
 void GodotJavaWrapper::set_clipboard(const String &p_text) {
 	if (_set_clipboard) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+
 		jstring jStr = env->NewStringUTF(p_text.utf8().get_data());
 		env->CallVoidMethod(godot_instance, _set_clipboard, jStr);
 	}
@@ -229,6 +251,8 @@ void GodotJavaWrapper::set_clipboard(const String &p_text) {
 bool GodotJavaWrapper::request_permission(const String &p_name) {
 	if (_request_permission) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, false);
+
 		jstring jStrName = env->NewStringUTF(p_name.utf8().get_data());
 		return env->CallBooleanMethod(godot_instance, _request_permission, jStrName);
 	} else {
@@ -239,6 +263,8 @@ bool GodotJavaWrapper::request_permission(const String &p_name) {
 bool GodotJavaWrapper::request_permissions() {
 	if (_request_permissions) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, false);
+
 		return env->CallBooleanMethod(godot_instance, _request_permissions);
 	} else {
 		return false;
@@ -249,6 +275,8 @@ Vector<String> GodotJavaWrapper::get_granted_permissions() const {
 	Vector<String> permissions_list;
 	if (_get_granted_permissions) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, permissions_list);
+
 		jobject permissions_object = env->CallObjectMethod(godot_instance, _get_granted_permissions);
 		jobjectArray *arr = reinterpret_cast<jobjectArray *>(&permissions_object);
 
@@ -267,6 +295,8 @@ Vector<String> GodotJavaWrapper::get_granted_permissions() const {
 void GodotJavaWrapper::init_input_devices() {
 	if (_init_input_devices) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+
 		env->CallVoidMethod(godot_instance, _init_input_devices);
 	}
 }
@@ -274,6 +304,8 @@ void GodotJavaWrapper::init_input_devices() {
 jobject GodotJavaWrapper::get_surface() {
 	if (_get_surface) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, nullptr);
+
 		return env->CallObjectMethod(godot_instance, _get_surface);
 	} else {
 		return nullptr;
@@ -283,6 +315,8 @@ jobject GodotJavaWrapper::get_surface() {
 bool GodotJavaWrapper::is_activity_resumed() {
 	if (_is_activity_resumed) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, false);
+
 		return env->CallBooleanMethod(godot_instance, _is_activity_resumed);
 	} else {
 		return false;
@@ -292,6 +326,8 @@ bool GodotJavaWrapper::is_activity_resumed() {
 void GodotJavaWrapper::vibrate(int p_duration_ms) {
 	if (_vibrate) {
 		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+
 		env->CallVoidMethod(godot_instance, _vibrate, p_duration_ms);
 	}
 }

--- a/platform/android/thread_jandroid.cpp
+++ b/platform/android/thread_jandroid.cpp
@@ -30,17 +30,34 @@
 
 #include "thread_jandroid.h"
 
+#include <android/log.h>
+
 #include "core/os/thread.h"
 
 static JavaVM *java_vm = nullptr;
 static thread_local JNIEnv *env = nullptr;
 
+// The logic here need to improve, init_thread/term_tread are designed to work with Thread::callback
+// Calling init_thread from setup_android_thread and get_jni_env to setup an env we're keeping and not detaching
+// could cause issues on app termination.
+//
+// We should be making sure that any thread started calls a nice cleanup function when it's done,
+// especially now that we use many more threads.
+
 static void init_thread() {
+	if (env) {
+		// thread never detached! just keep using...
+		return;
+	}
+
 	java_vm->AttachCurrentThread(&env, nullptr);
 }
 
 static void term_thread() {
 	java_vm->DetachCurrentThread();
+
+	// this is no longer valid, must called init_thread to re-establish
+	env = nullptr;
 }
 
 void init_thread_jandroid(JavaVM *p_jvm, JNIEnv *p_env) {
@@ -50,9 +67,17 @@ void init_thread_jandroid(JavaVM *p_jvm, JNIEnv *p_env) {
 }
 
 void setup_android_thread() {
-	init_thread();
+	if (!env) {
+		// !BAS! see remarks above
+		init_thread();
+	}
 }
 
 JNIEnv *get_jni_env() {
+	if (!env) {
+		// !BAS! see remarks above
+		init_thread();
+	}
+
 	return env;
 }


### PR DESCRIPTION
Fixes a few crash related issues on Android.

- Correct vulkan context is now created again instead of an OpenGL context (related setting was checked incorrectly)
- Added checks for valid ENV in wrapper
- Added a solution to make sure our thread is properly bound to the JavaVM for calling

That last one needs more work, I did the bare minimum to make it work without a big rewrite that would have much more far reaching consequences. Ideally we should have code that binds on first use (which we do now) but cleans up when the thread terminates. The current solution is workable and basically does what its always done but it can be made better.