### PR TITLE
[3.x] Improved GLES2 errors in shaders

### DIFF
--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -752,7 +752,7 @@ private:
 
 	Error _validate_datatype(DataType p_type);
 
-	bool _validate_function_call(BlockNode *p_block, OperatorNode *p_func, DataType *r_ret_type);
+	bool _validate_function_call(BlockNode *p_block, OperatorNode *p_func, DataType *r_ret_type, bool p_is_constructor);
 	bool _parse_function_arguments(BlockNode *p_block, const Map<StringName, BuiltInInfo> &p_builtin_types, OperatorNode *p_func, int *r_complete_arg = NULL);
 
 	Node *_parse_expression(BlockNode *p_block, const Map<StringName, BuiltInInfo> &p_builtin_types);


### PR DESCRIPTION
When calling functions that have overloads that are only available
in GLES3, Godot would throw `Built-in function "$name" is only supported
on high-end platform` instead of `invalid arguments for built-in function:
$name`
Fixes #46744.

Should I also check if the arguments are the same of the GLES3 overload, in which case throw `Built-in function "$name" is only supported on high-end platform`?