### PR TITLE
fixed overflow issues for page_value and additional checks for min, max.

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -101,8 +101,9 @@ void Range::set_value(double p_val) {
 }
 
 void Range::set_min(double p_min) {
-	shared->min = p_min;
+	shared->min = MIN(p_min, shared->max);
 	set_value(shared->val);
+	set_page(MIN(shared->page, shared->max - shared->min)); // update page
 
 	shared->emit_changed("min");
 
@@ -110,8 +111,9 @@ void Range::set_min(double p_min) {
 }
 
 void Range::set_max(double p_max) {
-	shared->max = p_max;
+	shared->max = MAX(p_max, shared->min);
 	set_value(shared->val);
+	set_page(MIN(shared->page, shared->max - shared->min)); // update page
 
 	shared->emit_changed("max");
 }
@@ -122,7 +124,7 @@ void Range::set_step(double p_step) {
 }
 
 void Range::set_page(double p_page) {
-	shared->page = p_page;
+	shared->page = MIN(p_page, shared->max - shared->min); // page should be less-than (max - min)
 	set_value(shared->val);
 
 	shared->emit_changed("page");


### PR DESCRIPTION

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixed : #46778
*Bugsquad edit:* Fixes #46863

- [x] made sure min and max work correctly.
- [x] Automatically update page(value) after setting min or max value. 
- [x] made sure page doesn't overflow.
- [ ]  Does clamping page to max-min have any side effects in other node? In this case (**ScrollBar**) it is clear.

Results after Fixing :
![PR-Range fix](https://user-images.githubusercontent.com/70578657/110485870-18c6ac80-8112-11eb-918d-f3a028625067.gif)