### PR TITLE
Add GLOBAL_DEF_ALIAS and alias for rename of pixel_snap

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -894,6 +894,21 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 	}
 }
 
+Variant _GLOBAL_DEF_ALIAS(const String &p_var, const String &p_old_name, const Variant &p_default, bool p_restart_if_changed) {
+	// if the new name setting isn't present, try the old one
+	if (!ProjectSettings::get_singleton()->has_setting(p_var)) {
+
+		if (ProjectSettings::get_singleton()->has_setting(p_old_name)) {
+
+			// if the old setting is present, get the value and set it in the new setting
+			Variant value = ProjectSettings::get_singleton()->get(p_old_name);
+			ProjectSettings::get_singleton()->set(p_var, value);
+		}
+	}
+
+	return _GLOBAL_DEF(p_var, p_default, p_restart_if_changed);
+}
+
 Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed) {
 
 	Variant ret;

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -163,8 +163,11 @@ public:
 
 //not a macro any longer
 Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false);
+Variant _GLOBAL_DEF_ALIAS(const String &p_var, const String &p_old_name, const Variant &p_default, bool p_restart_if_changed = false);
 #define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
 #define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
+#define GLOBAL_DEF_ALIAS(m_var, m_old_name, m_value) _GLOBAL_DEF_ALIAS(m_var, m_old_name, m_value)
+#define GLOBAL_DEF_ALIAS_RST(m_var, m_old_name, m_value) _GLOBAL_DEF(m_var, m_old_name, m_value, true)
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get(m_var)
 
 #endif

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1126,7 +1126,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->_allow_layered = false;
 	}
 
-	Engine::get_singleton()->_gpu_pixel_snap = GLOBAL_DEF("rendering/2d/snapping/use_gpu_pixel_snap", false);
+	Engine::get_singleton()->_gpu_pixel_snap = GLOBAL_DEF_ALIAS("rendering/2d/snapping/use_gpu_pixel_snap", "rendering/quality/2d/use_pixel_snap", false);
 
 	OS::get_singleton()->_keep_screen_on = GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
 	if (rtm == -1) {


### PR DESCRIPTION
Having to rename project settings is rare, but when it does occur it can cause user confusion. In order to make compatibility more seamless this PR introduces two new GLOBAL_DEF functions,

GLOBAL_DEF_ALIAS(new_name, old_name, default)
GLOBAL_DEF_ALIAS_RST(new_name, old_name, default)

These are the same as the existing GLOBAL_DEF functions except that if the new setting is not found, it attempts to load from the old setting name. If the old setting is found, it stores it into the new setting, and then calls the regular GLOBAL_DEF functions.

As well as introducing the new functions it uses them to alias the new `gpu_pixel_snap` setting.

Fixes #46822

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
