### PR TITLE
Camera2D: Update scrolls when the Viewport is resized

### DIFF
--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -84,6 +84,7 @@ protected:
 	Point2 camera_screen_center;
 	void _update_process_mode();
 	void _update_scroll();
+	void _setup_viewport();
 
 	void _make_current(Object *p_which);
 	void _set_current(bool p_current);


### PR DESCRIPTION
Factored the `viewport`/`custom_viewport` setup code which was used in two
locations to ensure consistency.

Fixes #46826.