### PR TITLE
GDScript typed arrays

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -547,6 +547,22 @@ void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Var
 	_p->typed.where = "TypedArray";
 }
 
+bool Array::is_typed() const {
+	return _p->typed.type != Variant::NIL;
+}
+
+uint32_t Array::get_typed_builtin() const {
+	return _p->typed.type;
+}
+
+StringName Array::get_typed_class_name() const {
+	return _p->typed.class_name;
+}
+
+Variant Array::get_typed_script() const {
+	return _p->typed.script;
+}
+
 Array::Array(const Array &p_from) {
 	_p = nullptr;
 	_ref(p_from);

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -48,7 +48,7 @@ class Array {
 
 protected:
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
-	void _assign(const Array &p_array);
+	bool _assign(const Array &p_array);
 
 public:
 	Variant &operator[](int p_idx);
@@ -111,6 +111,7 @@ public:
 
 	const void *id() const;
 
+	bool typed_assign(const Array &p_other);
 	void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);
 	Array();

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -113,6 +113,10 @@ public:
 
 	bool typed_assign(const Array &p_other);
 	void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
+	bool is_typed() const;
+	uint32_t get_typed_builtin() const;
+	StringName get_typed_class_name() const;
+	Variant get_typed_script() const;
 	Array(const Array &p_from);
 	Array();
 	~Array();

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -875,65 +875,64 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 		static uint64_t get_indexed_size(const Variant *base) { return m_max; }                                                    \
 	};
 
-#define INDEXED_SETGET_STRUCT_VARIANT(m_base_type)                                                    \
-	struct VariantIndexedSetGet_##m_base_type {                                                       \
-		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {              \
-			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                 \
-			if (index < 0) {                                                                          \
-				index += size;                                                                        \
-			}                                                                                         \
-			if (index < 0 || index >= size) {                                                         \
-				*oob = true;                                                                          \
-				return;                                                                               \
-			}                                                                                         \
-			*value = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];                     \
-			*oob = false;                                                                             \
-		}                                                                                             \
-		static void ptr_get(const void *base, int64_t index, void *member) {                          \
-			/* avoid ptrconvert for performance*/                                                     \
-			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base);                      \
-			if (index < 0)                                                                            \
-				index += v.size();                                                                    \
-			OOB_TEST(index, v.size());                                                                \
-			PtrToArg<Variant>::encode(v[index], member);                                              \
-		}                                                                                             \
-		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) { \
-			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                 \
-			if (index < 0) {                                                                          \
-				index += size;                                                                        \
-			}                                                                                         \
-			if (index < 0 || index >= size) {                                                         \
-				*oob = true;                                                                          \
-				*valid = false;                                                                       \
-				return;                                                                               \
-			}                                                                                         \
-			(*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index] = *value;                     \
-			*oob = false;                                                                             \
-			*valid = true;                                                                            \
-		}                                                                                             \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {    \
-			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                 \
-			if (index < 0) {                                                                          \
-				index += size;                                                                        \
-			}                                                                                         \
-			if (index < 0 || index >= size) {                                                         \
-				*oob = true;                                                                          \
-				return;                                                                               \
-			}                                                                                         \
-			(*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index] = *value;                     \
-			*oob = false;                                                                             \
-		}                                                                                             \
-		static void ptr_set(void *base, int64_t index, const void *member) {                          \
-			/* avoid ptrconvert for performance*/                                                     \
-			m_base_type &v = *reinterpret_cast<m_base_type *>(base);                                  \
-			if (index < 0)                                                                            \
-				index += v.size();                                                                    \
-			OOB_TEST(index, v.size());                                                                \
-			v[index] = PtrToArg<Variant>::convert(member);                                            \
-		}                                                                                             \
-		static Variant::Type get_index_type() { return Variant::NIL; }                                \
-		static uint64_t get_indexed_size(const Variant *base) { return 0; }                           \
-	};
+struct VariantIndexedSetGet_Array {
+	static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {
+		int64_t size = VariantGetInternalPtr<Array>::get_ptr(base)->size();
+		if (index < 0) {
+			index += size;
+		}
+		if (index < 0 || index >= size) {
+			*oob = true;
+			return;
+		}
+		*value = (*VariantGetInternalPtr<Array>::get_ptr(base))[index];
+		*oob = false;
+	}
+	static void ptr_get(const void *base, int64_t index, void *member) {
+		/* avoid ptrconvert for performance*/
+		const Array &v = *reinterpret_cast<const Array *>(base);
+		if (index < 0)
+			index += v.size();
+		OOB_TEST(index, v.size());
+		PtrToArg<Variant>::encode(v[index], member);
+	}
+	static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {
+		int64_t size = VariantGetInternalPtr<Array>::get_ptr(base)->size();
+		if (index < 0) {
+			index += size;
+		}
+		if (index < 0 || index >= size) {
+			*oob = true;
+			*valid = false;
+			return;
+		}
+		VariantGetInternalPtr<Array>::get_ptr(base)->set(index, *value);
+		*oob = false;
+		*valid = true;
+	}
+	static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {
+		int64_t size = VariantGetInternalPtr<Array>::get_ptr(base)->size();
+		if (index < 0) {
+			index += size;
+		}
+		if (index < 0 || index >= size) {
+			*oob = true;
+			return;
+		}
+		VariantGetInternalPtr<Array>::get_ptr(base)->set(index, *value);
+		*oob = false;
+	}
+	static void ptr_set(void *base, int64_t index, const void *member) {
+		/* avoid ptrconvert for performance*/
+		Array &v = *reinterpret_cast<Array *>(base);
+		if (index < 0)
+			index += v.size();
+		OOB_TEST(index, v.size());
+		v.set(index, PtrToArg<Variant>::convert(member));
+	}
+	static Variant::Type get_index_type() { return Variant::NIL; }
+	static uint64_t get_indexed_size(const Variant *base) { return 0; }
+};
 
 #define INDEXED_SETGET_STRUCT_DICT(m_base_type)                                                                                     \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                     \
@@ -990,7 +989,6 @@ INDEXED_SETGET_STRUCT_TYPED(PackedVector3Array, Vector3)
 INDEXED_SETGET_STRUCT_TYPED(PackedStringArray, String)
 INDEXED_SETGET_STRUCT_TYPED(PackedColorArray, Color)
 
-INDEXED_SETGET_STRUCT_VARIANT(Array)
 INDEXED_SETGET_STRUCT_DICT(Dictionary)
 
 struct VariantIndexedSetterGetterInfo {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -103,10 +103,11 @@ class GDScriptAnalyzer {
 	bool validate_call_arg(const MethodInfo &p_method, const GDScriptParser::CallNode *p_call);
 	GDScriptParser::DataType get_operation_type(Variant::Operator p_operation, const GDScriptParser::DataType &p_a, const GDScriptParser::DataType &p_b, bool &r_valid, const GDScriptParser::Node *p_source);
 	GDScriptParser::DataType get_operation_type(Variant::Operator p_operation, const GDScriptParser::DataType &p_a, bool &r_valid, const GDScriptParser::Node *p_source);
+	void update_array_literal_element_type(const GDScriptParser::DataType &p_base_type, GDScriptParser::ArrayNode *p_array_literal);
 	bool is_type_compatible(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source, bool p_allow_implicit_conversion = false) const;
 	void push_error(const String &p_message, const GDScriptParser::Node *p_origin);
 	void mark_node_unsafe(const GDScriptParser::Node *p_node);
-	bool class_exists(const StringName &p_class);
+	bool class_exists(const StringName &p_class) const;
 	Ref<GDScriptParserRef> get_parser_for(const String &p_path);
 #ifdef DEBUG_ENABLED
 	bool is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -445,6 +445,7 @@ public:
 	virtual void write_call_script_function(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
 	virtual void write_construct(const Address &p_target, Variant::Type p_type, const Vector<Address> &p_arguments) override;
 	virtual void write_construct_array(const Address &p_target, const Vector<Address> &p_arguments) override;
+	virtual void write_construct_typed_array(const Address &p_target, const GDScriptDataType &p_element_type, const Vector<Address> &p_arguments) override;
 	virtual void write_construct_dictionary(const Address &p_target, const Vector<Address> &p_arguments) override;
 	virtual void write_await(const Address &p_target, const Address &p_operand) override;
 	virtual void write_if(const Address &p_condition) override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -137,6 +137,7 @@ public:
 	virtual void write_call_script_function(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
 	virtual void write_construct(const Address &p_target, Variant::Type p_type, const Vector<Address> &p_arguments) = 0;
 	virtual void write_construct_array(const Address &p_target, const Vector<Address> &p_arguments) = 0;
+	virtual void write_construct_typed_array(const Address &p_target, const GDScriptDataType &p_element_type, const Vector<Address> &p_arguments) = 0;
 	virtual void write_construct_dictionary(const Address &p_target, const Vector<Address> &p_arguments) = 0;
 	virtual void write_await(const Address &p_target, const Address &p_operand) = 0;
 	virtual void write_if(const Address &p_condition) = 0;

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -322,6 +322,14 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				incr += 4;
 			} break;
+			case OPCODE_ASSIGN_TYPED_ARRAY: {
+				text += "assign typed array ";
+				text += DADDR(1);
+				text += " = ";
+				text += DADDR(2);
+
+				incr += 3;
+			} break;
 			case OPCODE_ASSIGN_TYPED_NATIVE: {
 				text += "assign typed native (";
 				text += DADDR(3);
@@ -413,6 +421,39 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 			case OPCODE_CONSTRUCT_ARRAY: {
 				int argc = _code_ptr[ip + 1 + instr_var_args];
 				text += " make_array ";
+				text += DADDR(1 + argc);
+				text += " = [";
+
+				for (int i = 0; i < argc; i++) {
+					if (i > 0)
+						text += ", ";
+					text += DADDR(1 + i);
+				}
+
+				text += "]";
+
+				incr += 3 + argc;
+			} break;
+			case OPCODE_CONSTRUCT_TYPED_ARRAY: {
+				int argc = _code_ptr[ip + 1 + instr_var_args];
+
+				Ref<Script> script_type = get_constant(_code_ptr[ip + argc + 2]);
+				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + argc + 4];
+				StringName native_type = get_global_name(_code_ptr[ip + argc + 5]);
+
+				String type_name;
+				if (script_type.is_valid() && script_type->is_valid()) {
+					type_name = script_type->get_path();
+				} else if (native_type != StringName()) {
+					type_name = native_type;
+				} else {
+					type_name = Variant::get_type_name(builtin_type);
+				}
+
+				text += " make_typed_array (";
+				text += type_name;
+				text += ") ";
+
 				text += DADDR(1 + argc);
 				text += " = [";
 


### PR DESCRIPTION
This add typed arrays as valid GDScript.

### Syntax 

```gdscript
var my_array: Array[int] = [1, 2, 3]
```

Borrowing from Python since @pycbouh convinced me. It makes it easier to change from a typed array to a generic one and gets more consistent. It open margins for other collection types as well.

Inference is also possible:

```gdscript
var my_array := [1, 2, 3]
```

There's not an exact way to create a typed array literal. This is inferred by the context: if assigned to a typed variable or passed as a function argument to a typed parameter, then the array is typed (assuming all elements if of the same type). If this is deemed not enough we may consider adding one later, but for now I don't see a need.

### Caveats

This relies on the typed array implementation from #38063. This shows an error in the console but it doesn't break the execution of the script. ~~I've also had some issues with the API like `Node.get_children()` which in theory returns a typed array but it doesn't have any validation if you try to change it (this is separate from this PR though and should be fixed on the typed array implementation).~~

**Edit:** I've included here the needed changes in Array. You still don't get breakpoints when some errors happen though, as they are deep into the Array implementation and GDScript can't know about those.

----

Incidentally, this fixes issues with uninitialized values:
Fix #41631
Fix #44442
Fix #44793
