### PR TITLE
[3.2] Settings: Change rendering/2d/options/ninepatch_mode default value to…

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1034,7 +1034,7 @@
 			Fix to improve physics jitter, specially on monitors where refresh rate is different than the physics FPS.
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_jitter_fix] instead.
 		</member>
-		<member name="rendering/2d/options/ninepatch_mode" type="int" setter="" getter="" default="0">
+		<member name="rendering/2d/options/ninepatch_mode" type="int" setter="" getter="" default="1">
 			Choose between default mode where corner scalings are preserved matching the artwork, and scaling mode.
 			Not available in GLES3 when [member rendering/batching/options/use_batching] is off.
 		</member>

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2449,7 +2449,7 @@ VisualServer::VisualServer() {
 	ProjectSettings::get_singleton()->set_custom_property_info(sz_balance_render_tree, PropertyInfo(Variant::REAL, sz_balance_render_tree, PROPERTY_HINT_RANGE, "0.0,1.0,0.01"));
 
 	GLOBAL_DEF("rendering/2d/options/use_software_skinning", true);
-	GLOBAL_DEF("rendering/2d/options/ninepatch_mode", 0);
+	GLOBAL_DEF("rendering/2d/options/ninepatch_mode", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/options/ninepatch_mode", PropertyInfo(Variant::INT, "rendering/2d/options/ninepatch_mode", PROPERTY_HINT_ENUM, "Default,Scaling"));
 
 	GLOBAL_DEF("rendering/batching/options/use_batching", true);


### PR DESCRIPTION
… match 3.2.3-stable behavior.

Fix #46835

If we want the new behavior as default, this PR can be closed.