### PR TITLE
[HTML5] Properly set canvas size during setup.

### DIFF
--- a/platform/javascript/js/libs/library_godot_display.js
+++ b/platform/javascript/js/libs/library_godot_display.js
@@ -805,6 +805,7 @@ const GodotDisplay = {
 			canvas.style.left = 0;
 			break;
 		}
+		GodotDisplayScreen.updateSize();
 		if (p_fullscreen) {
 			GodotDisplayScreen.requestFullscreen();
 		}


### PR DESCRIPTION
It used to be updated before the first iteration, causing the window/viewport size values to be incorrect during the initialization phase (e.g. during the first `_ready` notification).

Fixes #46843 