### PR TITLE
Added word wrap shortcut Functionality.

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1284,6 +1284,10 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				_lookup_symbol(text, tx->get_caret_line(), tx->get_caret_column());
 			}
 		} break;
+		case APPEARANCE_TOGGLE_WORD_WRAP: {
+			bool word_wrap = EditorSettings::get_singleton()->get("text_editor/appearance/word_wrap");
+			EditorSettings::get_singleton()->set("text_editor/appearance/word_wrap", !word_wrap);
+		} break;
 	}
 }
 
@@ -1814,6 +1818,7 @@ void ScriptTextEditor::_enable_code_editor() {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/auto_indent"), EDIT_AUTO_INDENT);
 	edit_menu->get_popup()->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_edit_option));
 	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/word_wrap", TTR("Toggle Word Wrap"), KeyModifierMask::CTRL | Key::E), APPEARANCE_TOGGLE_WORD_WRAP);
 
 	edit_menu->get_popup()->add_child(convert_case);
 	edit_menu->get_popup()->add_submenu_item(TTR("Convert Case"), "convert_case");

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -147,6 +147,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 		DEBUG_GOTO_PREV_BREAKPOINT,
 		HELP_CONTEXTUAL,
 		LOOKUP_SYMBOL,
+		APPEARANCE_TOGGLE_WORD_WRAP,
 	};
 
 	void _enable_code_editor();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Enhancement made for proposal :  [#1548](https://github.com/godotengine/godot-proposals/issues/1548)
Added a Word Wrap short-cut (***Edit:`Ctrl + E`)

also added a popup Item in the Edit menu of the Script Editor.

Sorry for not discussing in the  [#1548](https://github.com/godotengine/godot-proposals/issues/1548) before PR because this took really less changes to get desired result. But I'm open for suggestions.

Result : 
![54dXl0kpNv](https://user-images.githubusercontent.com/70578657/110577752-4e5aac80-8189-11eb-9444-c8df358cc643.gif)


