### PR TITLE
Enhance RasterizerStorageGLES3 to support software skeleton fallback

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8232,6 +8232,9 @@ bool RasterizerStorageGLES3::has_os_feature(const String &p_feature) const {
 	if (p_feature == "pvrtc")
 		return config.pvrtc_supported;
 
+	if (p_feature == "skinning_fallback")
+		return config.use_skeleton_software;
+
 	return false;
 }
 
@@ -8473,6 +8476,8 @@ void RasterizerStorageGLES3::initialize() {
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &config.max_texture_size);
 
 	config.use_rgba_2d_shadows = !config.framebuffer_float_supported;
+
+	config.use_skeleton_software = !config.texture_float_linear_supported;
 
 	//generic quadie for copying
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -75,6 +75,7 @@ public:
 		bool use_fast_texture_filter;
 		bool use_anisotropic_filter;
 		bool use_lightmap_filter_bicubic;
+		bool use_skeleton_software;
 
 		bool s3tc_supported;
 		bool latc_supported;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/46715

On iOS 12.5.1, devices that had supported hardware skinning will no longer support it.  Given that iOS 12 brought the deprecation of OpenGL, I suspect that the initial implementation of the OpenGL -> Metal layer had a bug that didn't allow the "GL_OES_texture_float_linear" extension to be used/exposed.

Similar to RasterizerStorageGLES2's check for float textures, this performs a check for linear float textures, which in testing seems to be the necessary extension for skeleton software, and allows for the GLES3 version to support the "skinning_fallback" `has_os_feature`.


