### PR TITLE
Enable `doNotStrip` when doing development/debugging within Android Studio

### DIFF
--- a/platform/android/java/app/assets/.gitignore
+++ b/platform/android/java/app/assets/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -77,7 +77,7 @@ android {
     defaultConfig {
         // The default ignore pattern for the 'assets' directory includes hidden files and directories which are used by Godot projects.
         aaptOptions {
-            ignoreAssetsPattern "!.svn:!.git:!.ds_store:!*.scc:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"
+            ignoreAssetsPattern "!.svn:!.git:!.gitignore:!.ds_store:!*.scc:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"
         }
 
         ndk {
@@ -106,8 +106,10 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
 
-        // Should be uncommented for development purpose within Android Studio
-        // doNotStrip '**/*.so'
+        // 'doNotStrip' is enabled for development within Android Studio
+        if (shouldNotStrip()) {
+            doNotStrip '**/*.so'
+        }
     }
 
     signingConfigs {

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -209,10 +209,19 @@ ext.getReleaseKeyAlias = { ->
     return keyAlias
 }
 
+ext.isAndroidStudio = { ->
+    def sysProps = System.getProperties()
+    return sysProps != null && sysProps['idea.platform.prefix'] != null
+}
+
 ext.shouldZipAlign = { ->
     String zipAlignFlag = project.hasProperty("perform_zipalign") ? project.property("perform_zipalign") : ""
     if (zipAlignFlag == null || zipAlignFlag.isEmpty()) {
-        zipAlignFlag = "false"
+        if (isAndroidStudio()) {
+            zipAlignFlag = "true"
+        } else {
+            zipAlignFlag = "false"
+        }
     }
     return Boolean.parseBoolean(zipAlignFlag)
 }
@@ -220,7 +229,15 @@ ext.shouldZipAlign = { ->
 ext.shouldSign = { ->
     String signFlag = project.hasProperty("perform_signing") ? project.property("perform_signing") : ""
     if (signFlag == null || signFlag.isEmpty()) {
-        signFlag = "false"
+        if (isAndroidStudio()) {
+            signFlag = "true"
+        } else {
+            signFlag = "false"
+        }
     }
     return Boolean.parseBoolean(signFlag)
+}
+
+ext.shouldNotStrip = { ->
+    return isAndroidStudio()
 }

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -36,8 +36,10 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
 
-        // Should be uncommented for development purpose within Android Studio
-        // doNotStrip '**/*.so'
+        // 'doNotStrip' is enabled for development within Android Studio
+        if (shouldNotStrip()) {
+            doNotStrip '**/*.so'
+        }
     }
 
     sourceSets {

--- a/platform/android/java/nativeSrcsConfigs/build.gradle
+++ b/platform/android/java/nativeSrcsConfigs/build.gradle
@@ -20,9 +20,6 @@ android {
     packagingOptions {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
-
-        // Should be uncommented for development purpose within Android Studio
-        // doNotStrip '**/*.so'
     }
 
     sourceSets {


### PR DESCRIPTION
The updated logic automatically detect when running within Android Studio, and enable `doNotStrip` in order to keep around the debug symbols.