### PR TITLE
Change default ninepatch mode to scaling

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1034,8 +1034,8 @@
 			Fix to improve physics jitter, specially on monitors where refresh rate is different than the physics FPS.
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_jitter_fix] instead.
 		</member>
-		<member name="rendering/2d/options/ninepatch_mode" type="int" setter="" getter="" default="0">
-			Choose between default mode where corner scalings are preserved matching the artwork, and scaling mode.
+		<member name="rendering/2d/options/ninepatch_mode" type="int" setter="" getter="" default="1">
+			Choose between fixed mode where corner scalings are preserved matching the artwork, and scaling mode.
 			Not available in GLES3 when [member rendering/batching/options/use_batching] is off.
 		</member>
 		<member name="rendering/2d/options/use_nvidia_rect_flicker_workaround" type="bool" setter="" getter="" default="false">

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2448,9 +2448,9 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF(sz_balance_render_tree, 0.0f);
 	ProjectSettings::get_singleton()->set_custom_property_info(sz_balance_render_tree, PropertyInfo(Variant::REAL, sz_balance_render_tree, PROPERTY_HINT_RANGE, "0.0,1.0,0.01"));
 
-	GLOBAL_DEF("rendering/2d/options/use_software_skinning", true);
-	GLOBAL_DEF("rendering/2d/options/ninepatch_mode", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/options/ninepatch_mode", PropertyInfo(Variant::INT, "rendering/2d/options/ninepatch_mode", PROPERTY_HINT_ENUM, "Default,Scaling"));
+	GLOBAL_DEF_RST("rendering/2d/options/use_software_skinning", true);
+	GLOBAL_DEF_RST("rendering/2d/options/ninepatch_mode", 1);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/options/ninepatch_mode", PropertyInfo(Variant::INT, "rendering/2d/options/ninepatch_mode", PROPERTY_HINT_ENUM, "Fixed,Scaling"));
 
 	GLOBAL_DEF("rendering/batching/options/use_batching", true);
 	GLOBAL_DEF_RST("rendering/batching/options/use_batching_in_editor", true);


### PR DESCRIPTION
Changes default ninepatch mode to preserve compatibility, and renames default mode to 'fixed'.

Also adds an editor restart to changing ninepatch mode and software skinning, which will be more user friendly.

Fixes #46835 (initial bug mentioned)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
