### PR TITLE
SCons: Use default env["ENV"] and prepend PATH to it

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -61,8 +61,14 @@ elif platform_arg == "javascript":
     # Use generic POSIX build toolchain for Emscripten.
     custom_tools = ["cc", "c++", "ar", "link", "textfile", "zip"]
 
-# Construct the environment using the user's host env variables.
-env_base = Environment(ENV=os.environ, tools=custom_tools)
+# We let SCons build its default ENV as it includes OS-specific things which we don't
+# want to have to pull in manually.
+# Then we prepend PATH to make it take precedence, while preserving SCons' own entries.
+env_base = Environment(tools=custom_tools)
+env_base.PrependENVPath("PATH", os.getenv("PATH"))
+env_base.PrependENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
+if "TERM" in os.environ:  # Used for colored output.
+    env_base["ENV"]["TERM"] = os.environ["TERM"]
 
 env_base.disabled_modules = []
 env_base.module_version_string = ""


### PR DESCRIPTION
See discussion in #46814. Now going with the safe option again (like in 3.2)
as it turns out that we can't rely on user environments on Windows, since each
shell has a different set of env variables (especially the ones necessary to
use MSVC).

SCons does its own magic when we don't pass it an `ENV` dictionary, so we
should preserve it and only add things in a second step.

Fixes this warning when compiling with MSVC using git-bash.exe:
```
Missing environment variable: WindowsSdkDir
```

Possibly fixes build issues when having both MinGW and MSVC installed and an
older SCons version.

---

This is the same as #46815 already used for `3.2`.