### PR TITLE
[4.0] Add GDNative Framework support for macOS, add Unix symlink API. 

### DIFF
--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -245,6 +245,10 @@ public:
 
 	uint64_t get_space_left();
 
+	virtual bool is_link(String p_file) { return false; }
+	virtual String read_link(String p_file) { return p_file; }
+	virtual Error create_link(String p_source, String p_target) { return FAILED; }
+
 	virtual String get_filesystem_type() const;
 
 	DirAccessPack();

--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -50,7 +50,7 @@ private:
 	AccessType _access_type = ACCESS_FILESYSTEM;
 	static CreateFunc create_func[ACCESS_MAX]; ///< set this to instance a filesystem object
 
-	Error _copy_dir(DirAccess *p_target_da, String p_to, int p_chmod_flags);
+	Error _copy_dir(DirAccess *p_target_da, String p_to, int p_chmod_flags, bool p_copy_links);
 
 protected:
 	String _get_root_path() const;
@@ -89,10 +89,14 @@ public:
 	static bool exists(String p_dir);
 	virtual uint64_t get_space_left() = 0;
 
-	Error copy_dir(String p_from, String p_to, int p_chmod_flags = -1);
+	Error copy_dir(String p_from, String p_to, int p_chmod_flags = -1, bool p_copy_links = false);
 	virtual Error copy(String p_from, String p_to, int p_chmod_flags = -1);
 	virtual Error rename(String p_from, String p_to) = 0;
 	virtual Error remove(String p_name) = 0;
+
+	virtual bool is_link(String p_file) = 0;
+	virtual String read_link(String p_file) = 0;
+	virtual Error create_link(String p_source, String p_target) = 0;
 
 	// Meant for editor code when we want to quickly remove a file without custom
 	// handling (e.g. removing a cache file).

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -79,6 +79,10 @@ public:
 	virtual Error rename(String p_path, String p_new_path);
 	virtual Error remove(String p_path);
 
+	virtual bool is_link(String p_file);
+	virtual String read_link(String p_file);
+	virtual Error create_link(String p_source, String p_target);
+
 	virtual uint64_t get_space_left();
 
 	virtual String get_filesystem_type() const;

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -78,6 +78,11 @@ public:
 	virtual Error rename(String p_path, String p_new_path);
 	virtual Error remove(String p_path);
 
+	virtual bool is_link(String p_file) { return false; };
+	virtual String read_link(String p_file) { return p_file; };
+	virtual Error create_link(String p_source, String p_target) { return FAILED; };
+
+	//virtual FileType get_file_type() const;
 	uint64_t get_space_left();
 
 	virtual String get_filesystem_type() const;

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -82,7 +82,6 @@ public:
 	virtual String read_link(String p_file) { return p_file; };
 	virtual Error create_link(String p_source, String p_target) { return FAILED; };
 
-	//virtual FileType get_file_type() const;
 	uint64_t get_space_left();
 
 	virtual String get_filesystem_type() const;

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -131,7 +131,7 @@ void GDNativeLibraryEditor::_on_item_button(Object *item, int column, int id) {
 		EditorFileDialog::FileMode mode = EditorFileDialog::FILE_MODE_OPEN_FILE;
 		if (id == BUTTON_SELECT_DEPENDENCES) {
 			mode = EditorFileDialog::FILE_MODE_OPEN_FILES;
-		} else if (treeItem->get_text(0) == "iOS") {
+		} else if (treeItem->get_text(0) == "iOS" || treeItem->get_text(0) == "macOS") {
 			mode = EditorFileDialog::FILE_MODE_OPEN_ANY;
 		}
 
@@ -278,11 +278,10 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 		platforms["X11"] = platform_linux;
 
 		NativePlatformConfig platform_osx;
-		platform_osx.name = "Mac OSX";
+		platform_osx.name = "macOS";
 		platform_osx.entries.push_back("64");
-		platform_osx.entries.push_back("32");
-		platform_osx.library_extension = "*.dylib";
-		platforms["OSX"] = platform_osx;
+		platform_osx.library_extension = "*.framework; Framework, *.dylib; Dynamic Library";
+		platforms["macOS"] = platform_osx;
 
 		NativePlatformConfig platform_haiku;
 		platform_haiku.name = "Haiku";

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -74,6 +74,10 @@ public:
 	virtual Error rename(String p_from, String p_to);
 	virtual Error remove(String p_name);
 
+	virtual bool is_link(String p_file) { return false; }
+	virtual String read_link(String p_file) { return p_file; }
+	virtual Error create_link(String p_source, String p_target) { return FAILED; }
+
 	virtual String get_filesystem_type() const;
 
 	uint64_t get_space_left();


### PR DESCRIPTION
Adds ability to select, load and export (both `.dmg` and `.zip`) macOS ".frameworks" as GDNative libraries.
Adds minimal symlink API to `DirAccess` (frameworks usually contain multiple relative symlinks).

Framework export won't work from Windows (If there are symlinks in the framework). NTFS have support for symlinks, but I do not see any way to get relative symlink target path, all functions seems to return full path. And creating symlinks seems to require privilege elevation. Not sure what to do with it (currently it will print a warning).

*Edit:* Relative symlinks are supported and `DeviceIoControl(FSCTL_GET_REPARSE_POINT)` function can get correct relative path, but none of Windows apps seems to use them and all Windows ZIP software extract symlinks as text files with the target path. Even if working `readlink` equivalent is added, Windows users won't be able to acquire macOS framework with correct structure in the first place.

Version for 3.2 - #46860