### PR TITLE
Fix crash when allocation exceeds uint max range

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -278,6 +278,7 @@ Error CowData<T>::resize(int p_size) {
 	size_t current_alloc_size = _get_alloc_size(current_size);
 	size_t alloc_size;
 	ERR_FAIL_COND_V(!_get_alloc_size_checked(p_size, &alloc_size), ERR_OUT_OF_MEMORY);
+	ERR_FAIL_COND_V_MSG(alloc_size == 0 && p_size > 0, ERR_INVALID_PARAMETER, "Attempted a memory allocation with a size greater than `MAX_INT`.");
 
 	if (p_size > current_size) {
 		if (alloc_size != current_alloc_size) {


### PR DESCRIPTION
Fix #46842

When Godot resize an array, it calculates the memory allocation needed by calling `next_power_of_2`, but when the value is greater than `INT_MAX`, the value returned by `next_power_of_2` is `0` because the value exceeds the maximum of `unsigned int` (by 1).

This lead to crash in the loop as the pointer on `get_size()` is `nullptr`

`for (int i = *_get_size(); i < p_size; i++) {`

This fix check after the allocation if the value is `0` while `p_size` is not `0` (the check could be added in `_get_alloc_size_checked` but that prevent to have a custom message)
