### PR TITLE
Fix Spatial Shader default for render_mode

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1357,7 +1357,7 @@ LIGHT_SHADER_CODE
 
 #elif defined(SPECULAR_DISABLED)
 		// none..
-#else defined(SPECULAR_SCHLICK_GGX)
+#else
 		// shlick+ggx as default
 
 #if defined(LIGHT_USE_ANISOTROPY)

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1357,7 +1357,7 @@ LIGHT_SHADER_CODE
 
 #elif defined(SPECULAR_DISABLED)
 		// none..
-#elif defined(SPECULAR_SCHLICK_GGX)
+#else defined(SPECULAR_SCHLICK_GGX)
 		// shlick+ggx as default
 
 #if defined(LIGHT_USE_ANISOTROPY)


### PR DESCRIPTION
Spatial Shader fix

godot/drivers/gles3/shaders/scene.glsl
Changed #elif for Spatial Shader to #else

godot/drivers/gles2/shaders/scene.glsl
Changed #elif for Spatial Shader to #else

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/46838.*

