### PR TITLE
Always dynamically allocate PropertyTable

### DIFF
--- a/modules/fbx/fbx_parser/FBXDocumentUtil.cpp
+++ b/modules/fbx/fbx_parser/FBXDocumentUtil.cpp
@@ -160,7 +160,7 @@ const PropertyTable *GetPropertyTable(const Document &doc,
 			DOMWarning("property table (Properties70) not found", element);
 		}
 		if (templateProps) {
-			return templateProps;
+			return new const PropertyTable(templateProps);
 		} else {
 			return new const PropertyTable();
 		}

--- a/modules/fbx/fbx_parser/FBXProperties.cpp
+++ b/modules/fbx/fbx_parser/FBXProperties.cpp
@@ -150,6 +150,11 @@ PropertyTable::PropertyTable() :
 }
 
 // ------------------------------------------------------------------------------------------------
+PropertyTable::PropertyTable(const PropertyTable *templateProps) :
+		templateProps(templateProps), element() {
+}
+
+// ------------------------------------------------------------------------------------------------
 PropertyTable::PropertyTable(const ElementPtr element, const PropertyTable *templateProps) :
 		templateProps(templateProps), element(element) {
 	const ScopePtr scope = GetRequiredScope(element);

--- a/modules/fbx/fbx_parser/FBXProperties.h
+++ b/modules/fbx/fbx_parser/FBXProperties.h
@@ -137,6 +137,7 @@ class PropertyTable {
 public:
 	// in-memory property table with no source element
 	PropertyTable();
+	PropertyTable(const PropertyTable *templateProps);
 	PropertyTable(const ElementPtr element, const PropertyTable *templateProps);
 	~PropertyTable();
 


### PR DESCRIPTION
- `Texture::~Texture` expects `props` to be dynamically allocated.

- `GetPropertyTable` returned a pointer to an existing `PropertyTable`
  but is expected to return a newly, dynamically allocated one.

- `PropertyTable::PropertyTable()` suggests that an empty `element`
  member is valid.

fix #46876
fix #45573
