### PR TITLE
Revert "Fix flicker in control nodes due to pivot offset"

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -462,6 +462,11 @@ void Control::_update_canvas_item_transform() {
 	Transform2D xform = _get_internal_transform();
 	xform[2] += get_position();
 
+	// We use a little workaround to avoid flickering when moving the pivot with _edit_set_pivot()
+	if (is_inside_tree() && Math::abs(Math::sin(data.rotation * 4.0f)) < 0.00001f && get_viewport()->is_snap_controls_to_pixels_enabled()) {
+		xform[2] = xform[2].round();
+	}
+
 	VisualServer::get_singleton()->canvas_item_set_transform(get_canvas_item(), xform);
 }
 

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -315,7 +315,6 @@ void ScrollContainer::_notification(int p_what) {
 					r.size.height = minsize.height;
 			}
 			r.position += ofs;
-			r.position = r.position.floor();
 			fit_child_in_rect(c, r);
 		}
 


### PR DESCRIPTION
Reverts godotengine/godot#46409

Fixes #46850.

See https://github.com/godotengine/godot/pull/46409#issuecomment-796618180 for details.

Users who need this fix can try to disable `gui/common/snap_controls_to_pixels` which should be equivalent. It *may* however cause other regressions, which is why we're reverting this for now and we'll investigate further for a more thorough fix in 3.2.5 (hopefully!).