### PR TITLE
Batching - use FINAL_MODULATE_ALIAS in shaders

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -911,7 +911,7 @@ ShaderCompilerGLES2::ShaderCompilerGLES2() {
 	actions[VS::SHADER_CANVAS_ITEM].renames["INSTANCE_CUSTOM"] = "instance_custom";
 
 	actions[VS::SHADER_CANVAS_ITEM].renames["COLOR"] = "color";
-	actions[VS::SHADER_CANVAS_ITEM].renames["MODULATE"] = "final_modulate";
+	actions[VS::SHADER_CANVAS_ITEM].renames["MODULATE"] = "final_modulate_alias";
 	actions[VS::SHADER_CANVAS_ITEM].renames["NORMAL"] = "normal";
 	actions[VS::SHADER_CANVAS_ITEM].renames["NORMALMAP"] = "normal_map";
 	actions[VS::SHADER_CANVAS_ITEM].renames["NORMALMAP_DEPTH"] = "normal_depth";

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -31,6 +31,17 @@ attribute vec2 uv_attrib; // attrib:4
 attribute highp vec4 modulate_attrib; // attrib:5
 #endif
 
+// Usually, final_modulate is passed as a uniform. However during batching
+// If larger fvfs are used, final_modulate is passed as an attribute.
+// we need to read from the attribute in custom vertex shader
+// rather than the uniform. We do this by specifying final_modulate_alias
+// in shaders rather than final_modulate directly.
+#ifdef USE_ATTRIB_MODULATE
+#define final_modulate_alias modulate_attrib
+#else
+#define final_modulate_alias final_modulate
+#endif
+
 #ifdef USE_ATTRIB_LARGE_VERTEX
 // shared with skeleton attributes, not used in batched shader
 attribute highp vec2 translate_attrib; // attrib:6
@@ -469,6 +480,18 @@ void main() {
 		normal_used = true;
 #endif
 
+		// If larger fvfs are used, final_modulate is passed as an attribute.
+		// we need to read from this in custom fragment shaders or applying in the post step,
+		// rather than using final_modulate directly.
+#if defined(final_modulate_alias)
+#undef final_modulate_alias
+#endif
+#ifdef USE_ATTRIB_MODULATE
+#define final_modulate_alias modulate_interp
+#else
+#define final_modulate_alias final_modulate
+#endif
+
 		/* clang-format off */
 
 FRAGMENT_SHADER_CODE
@@ -481,11 +504,7 @@ FRAGMENT_SHADER_CODE
 	}
 
 #if !defined(MODULATE_USED)
-#ifdef USE_ATTRIB_MODULATE
-	color *= modulate_interp;
-#else
-	color *= final_modulate;
-#endif
+	color *= final_modulate_alias;
 #endif
 
 #ifdef USE_LIGHTING

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -891,7 +891,7 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 	actions[VS::SHADER_CANVAS_ITEM].renames["INSTANCE_CUSTOM"] = "instance_custom";
 
 	actions[VS::SHADER_CANVAS_ITEM].renames["COLOR"] = "color";
-	actions[VS::SHADER_CANVAS_ITEM].renames["MODULATE"] = "final_modulate";
+	actions[VS::SHADER_CANVAS_ITEM].renames["MODULATE"] = "final_modulate_alias";
 	actions[VS::SHADER_CANVAS_ITEM].renames["NORMAL"] = "normal";
 	actions[VS::SHADER_CANVAS_ITEM].renames["NORMALMAP"] = "normal_map";
 	actions[VS::SHADER_CANVAS_ITEM].renames["NORMALMAP_DEPTH"] = "normal_depth";


### PR DESCRIPTION
As part of the improvements to batch more cases, batching can store final_modulate as an attribute in the vertex format rather than sending as a uniform. This allows draw calls with different final_modulate to be batched together.

However custom shader code was reading from only the final_modulate uniform, and not the attribute when it was in use. This was leading to visual errors.

This is tricky to solve, because we cannot use the same name for the attribute in the vertex and fragment shaders, because one is an attribute and one a varying, whereas a uniform is accessible anywhere. To get around this, a macro is used which can translate to the most appropriate variable depending on whether uniform or attribute or varying is required.

Fixes #46873

## Notes
* This needs a good consultation with @clayjohn. There may be more than one way of fixing this, and it does seem a bit like a sledgehammer to crack a walnut, there may be a better way.
* In particular any use of `final_modulate` directly to create a shader from the c++ source code (i.e. not using MODULATE) will read from the wrong color. I couldn't immediately see any cases of this by searching but it is a possibility.
* Although this fixes the bug, I noticed that when you have an error in your shader, it ends up in some kind of half way situation where the color read is incorrect. I'm assuming that `USE_ATTRIB_MODULATE` does not get defined if the shader is broken. This is not a massive problem as a broken shader can't be expected to behave correctly but it would be nice to track this down.
* Unfortunately this does have the possibility of regressions. I'll try and test as much as possible. Alternatively I could see whether it would be possible to temporarily turn off this batching path for 3.2.4, although that might be just as risky.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
