### PR TITLE
Batching - large FVF forces non-hardware transform

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -227,7 +227,7 @@ public:
 
 		// we are always splitting items with lots of commands,
 		// and items with unhandled primitives (default)
-		bool use_hardware_transform() const { return num_item_refs == 1; }
+		bool use_hardware_transform() const { return (num_item_refs == 1) && !(flags & RasterizerStorageCommon::USE_LARGE_FVF); }
 	};
 
 	struct BItemRef {


### PR DESCRIPTION
This is something that I missed from the initial implementation of large FVF. In large FVF the transform is sent per vertex in an attribute, and the vertex position is the original vertex position. This is so that the original vertex position can be read and modified in a custom shader.

This whole system is therefore incompatible with the legacy hardware transform method, whereby the transform is sent in a uniform. The shader already correctly ignores the uniform transform, but there are some parts of the CPU side logic that can be confused treating large FVF batches as if they were hardware transform.

This PR completes the logic by making the CPU treat large FVF as though it was software transform.

Fixes #46897

## Notes
* For 1 line, this is perhaps the most massive PR I've done in a while.
* It has massive implications, and also potential for regressions, but I'm pretty sure this is the right fix to the whole set of related problems. Although regressions should be limited to custom shaders that read from VERTEX, and given that these may be broken in a lot of situations, maybe it isn't quite so risky.
* Absolute pain I didn't notice it at the time when I first implemented unified batching, as it would have been fresher in my mind, but hey ho.

I'm in two minds about whether we should merge this for 3.2.4. I'm going to do as much testing as possible, but it is one of those things that is highly likely to cause regressions (in affected custom shaders). If we had had an issue report earlier it would have been different...

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
