### PR TITLE
Batching - more frame diagnose information

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1942,12 +1942,9 @@ void RasterizerCanvasGLES2::render_joined_item(const BItemJoined &p_bij, RenderI
 
 	storage->info.render._2d_item_count++;
 
-#ifdef DEBUG_ENABLED
+#if defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED)
 	if (bdata.diagnose_frame) {
-		bdata.frame_string += "\tjoined_item " + itos(p_bij.num_item_refs) + " refs\n";
-		if (p_bij.z_index != 0) {
-			bdata.frame_string += "\t\t(z " + itos(p_bij.z_index) + ")\n";
-		}
+		bdata.frame_string += _diagnose_make_item_joined_string(p_bij);
 	}
 #endif
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1194,12 +1194,9 @@ void RasterizerCanvasGLES3::render_batches(Item::Command *const *p_commands, Ite
 void RasterizerCanvasGLES3::render_joined_item(const BItemJoined &p_bij, RenderItemState &r_ris) {
 	storage->info.render._2d_item_count++;
 
-#ifdef DEBUG_ENABLED
+#if defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED)
 	if (bdata.diagnose_frame) {
-		bdata.frame_string += "\tjoined_item " + itos(p_bij.num_item_refs) + " refs\n";
-		if (p_bij.z_index != 0) {
-			bdata.frame_string += "\t\t(z " + itos(p_bij.z_index) + ")\n";
-		}
+		bdata.frame_string += _diagnose_make_item_joined_string(p_bij);
 	}
 #endif
 

--- a/drivers/gles_common/batch_diagnose.inc
+++ b/drivers/gles_common/batch_diagnose.inc
@@ -41,6 +41,54 @@ void _debug_write_garbage() {
 #endif
 }
 
+String _diagnose_make_item_joined_string(const BItemJoined &p_bij) const {
+	String sz;
+	if (p_bij.use_hardware_transform()) {
+		sz = "hxform";
+	} else {
+		sz = "sxform";
+	}
+	sz += _diagnose_batch_flags_to_string(p_bij.flags);
+
+	String sz_long;
+	sz_long = "\tjoined_item " + itos(p_bij.num_item_refs) + " refs, " + sz + "\n";
+	if (p_bij.z_index != 0) {
+		sz_long += "\t\t(z " + itos(p_bij.z_index) + ")\n";
+	}
+
+	return sz_long;
+}
+
+String _diagnose_batch_flags_to_string(uint32_t p_flags) const {
+	String sz;
+
+	if (p_flags) {
+		sz += " ( ";
+	}
+
+	if (p_flags & RasterizerStorageCommon::PREVENT_COLOR_BAKING) {
+		sz += "prevent_color_baking, ";
+	}
+	if (p_flags & RasterizerStorageCommon::PREVENT_VERTEX_BAKING) {
+		sz += "prevent_vertex_baking, ";
+	}
+	if (p_flags & RasterizerStorageCommon::PREVENT_ITEM_JOINING) {
+		sz += "prevent_item_joining, ";
+	}
+	if (p_flags & RasterizerStorageCommon::USE_MODULATE_FVF) {
+		sz += "use_modulate_fvf, ";
+	}
+	if (p_flags & RasterizerStorageCommon::USE_LARGE_FVF) {
+		sz += "use_large_fvf, ";
+	}
+
+	if (p_flags) {
+		sz += " )";
+	}
+
+	return sz;
+}
+
 String get_command_type_string(const RasterizerCanvas::Item::Command &p_command) const {
 	String sz = "";
 
@@ -86,6 +134,8 @@ String get_command_type_string(const RasterizerCanvas::Item::Command &p_command)
 
 			sz += " ";
 			sz += String(Variant(mat.elements[2]));
+			sz += String(Variant(mat.elements[0]));
+			sz += String(Variant(mat.elements[1]));
 			sz += " ";
 		} break;
 		case RasterizerCanvas::Item::Command::TYPE_CLIP_IGNORE: {


### PR DESCRIPTION
Added slightly more detail to diagnose_frame option. This is helpful for debugging issues.

```
items
	joined_item 1 refs, hxform ( prevent_vertex_baking, use_large_fvf,  )
			batch R 1-1 [0 - 150] {255 255 255 255 }
	joined_item 1 refs, hxform
			batch R 1-1 [0 - 150] {255 255 255 255 }
```

## Notes
* Adds hardware / software transform info for joined item, and joined_item flags if present.
* Also adds basis info for transform commands.
* This should :tm: be risk free as it is only used when diagnose is on. It is compiled out in release builds.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
