### PR TITLE
NoiseTexture: Fix regression in starting thread

### DIFF
--- a/modules/opensimplex/noise_texture.cpp
+++ b/modules/opensimplex/noise_texture.cpp
@@ -162,7 +162,7 @@ void NoiseTexture::_update_texture() {
 #endif
 	if (use_thread) {
 
-		if (noise_thread.is_started()) {
+		if (!noise_thread.is_started()) {
 			noise_thread.start(_thread_function, this);
 			regen_queued = false;
 		} else {


### PR DESCRIPTION
Was a regression from #45618.

Fixes #46907.

---

Not needed in `master` as the bug had been fixed there prior to merging the Thread modernization, but the fix was not propagated to the `3.2` PR :(