### PR TITLE
Fix SkeletonIK 3D Scaling Bug

### DIFF
--- a/scene/animation/skeleton_ik.cpp
+++ b/scene/animation/skeleton_ik.cpp
@@ -297,7 +297,7 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 		p_task->skeleton->set_bone_global_pose_override(p_task->chain.tips[i].chain_item->bone, Transform(), 0.0, true);
 	}
 
-	make_goal(p_task, p_task->skeleton->get_global_transform().affine_inverse().scaled(p_task->skeleton->get_global_transform().get_basis().get_scale()), blending_delta);
+	make_goal(p_task, p_task->skeleton->get_global_transform().affine_inverse(), blending_delta);
 
 	update_chain(p_task->skeleton, &p_task->chain.chain_root);
 


### PR DESCRIPTION
Some of us are aware of the 3D SkeletonIK Scaling Bug (https://github.com/godotengine/godot/issues/40466). This happens because the scale is reapplied to the skeleton. With this fix, the reapplied scale is removed. Not sure if it applies to 4.0 as there are issues with skins in that version last I checked. This fix was tested on a version around the pull request when the AspectRatioContainer node was added with scales of 0.011, 1, and 3

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/40466.*