### PR TITLE
UWP: Incorporate toolchain for building ANGLE using Ninja

### DIFF
--- a/platform/uwp/context_egl_uwp.cpp
+++ b/platform/uwp/context_egl_uwp.cpp
@@ -128,8 +128,9 @@ Error ContextEGL_UWP::initialize() {
 
 			// EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER is an optimization that can have large performance benefits on mobile devices.
 			// Its syntax is subject to change, though. Please update your Visual Studio templates if you experience compilation issues with it.
-			EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER,
-			EGL_TRUE,
+			// TODO: these does not seem available anymore.
+			// EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER,
+			// EGL_TRUE,
 
 			// EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE is an option that enables ANGLE to automatically call
 			// the IDXGIDevice3::Trim method on behalf of the application when it gets suspended.


### PR DESCRIPTION
Microsoft ANGLE sources are outdated as noted in the documentation for [compiling for UWP](https://docs.godotengine.org/en/latest/development/compiling/compiling_for_uwp.html).

This PR aims to add a front-end to https://chromium.googlesource.com/angle/angle project. You are expected to setup necessary toolchains for building ANGLE itself: https://chromium.googlesource.com/angle/angle/+/HEAD/doc/DevSetup.md. Once this is done, SCons will call `autoninja` to compile ANGLE along with Godot.

Have to compile with `scons angle_toolchain=ninja`. I've preserved the previous build toolchain using MSVC, but I don't guarantee it to still work (not being able to compile ANGLE using MSVC is one of the motivations behind making this PR).

~~Even though I've managed to build ANGLE and some Godot export templates that way, I have no way to actually test this due to export/signing issues, see #30558, even with official builds of Godot, so I'm losing motivation in working on this further.~~ Seems like there's a way at the end of the day: https://github.com/godotengine/godot/issues/30558#issuecomment-797831794.

`arm` does not seem to be available in ANGLE master branch, only `arm64`.

Note that this was done purely out of personal interest/educational purpose, there's a lot of thing I don't even understand, but since there's no active UWP maintainers, I decided to submit this PR. Perhaps @vnen could find something useful from this. 🙂

Some useful snippets:
```bat
set ANGLE_SRC_PATH=d:/src/angle
vcvarsall.bat x64
scons platform=uwp tools=no target=release_debug angle_toolchain=ninja
```

## To-do
- [ ] Figure out how to compile for `arm64` (host/target args).
- [ ] Add concurrent job option to ANGLE.
