### PR TITLE
Fix Tree focus border disappears when Border Size is set to 0

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -852,7 +852,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	Ref<StyleBoxFlat> style_tree_cursor = style_default->duplicate();
 	style_tree_cursor->set_draw_center(false);
-	style_tree_cursor->set_border_width_all(border_width);
+	style_tree_cursor->set_border_width_all(MAX(1, border_width));
 	style_tree_cursor->set_border_color(contrast_color_1);
 
 	Ref<StyleBoxFlat> style_tree_title = style_default->duplicate();


### PR DESCRIPTION
Fix #46502
I changed this refer to popup which has border when Border Size is set to 0
Edited: I did some wrong git operation cause closing of previous PR #46899