### PR TITLE
Fix pinned vertices in SoftBody editor gizmo

### DIFF
--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -2073,7 +2073,13 @@ void SoftBody3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Ref<TriangleMesh> tm = soft_body->get_mesh()->generate_triangle_mesh();
 
 	Vector<Vector3> points;
-	soft_body->get_mesh()->generate_debug_mesh_indices(points);
+	for (int i = 0; i < soft_body->get_mesh()->get_surface_count(); i++) {
+		Array arrays = soft_body->get_mesh()->surface_get_arrays(i);
+		ERR_CONTINUE(arrays.is_empty());
+
+		const Vector<Vector3> &vertices = arrays[Mesh::ARRAY_VERTEX];
+		points.append_array(vertices);
+	}
 
 	Ref<Material> material = get_material("shape_material", p_gizmo);
 


### PR DESCRIPTION
The wrong vertices could be highlighted/selected due to generating a debug triangle mesh to gather points, which can modify the order of vertices.

Helps with #26611 but doesn't fix it completely (there can be still discrepancies in the Bullet implementation).