### PR TITLE
[HTML5] Drag and drop zip in project manager.

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -502,7 +502,7 @@
 									showTab('loader');
 									setLoaderEnabled(true);
 								};
-								editor.start({'args': args});
+								editor.start({'args': args, 'persistentDrops': is_project_manager});
 							});
 						}, 0);
 						OnEditorExit = null;
@@ -563,7 +563,7 @@
 					//selectVideoMode();
 					showTab('editor');
 					setLoaderEnabled(false);
-					editor.start({'args': ['--video-driver', video_driver]}).then(function() {
+					editor.start({'args': ['--project-manager', '--video-driver', video_driver], 'persistentDrops': true}).then(function() {
 						setStatusMode('hidden');
 						initializing = false;
 					});

--- a/platform/javascript/js/engine/config.js
+++ b/platform/javascript/js/engine/config.js
@@ -105,6 +105,11 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		persistentPaths: ['/userfs'],
 		/**
 		 * @ignore
+		 * @type {boolean}
+		 */
+		persistentDrops: false,
+		/**
+		 * @ignore
 		 * @type {Array.<string>}
 		 */
 		gdnativeLibs: [],
@@ -231,6 +236,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		this.locale = parse('locale', this.locale);
 		this.canvasResizePolicy = parse('canvasResizePolicy', this.canvasResizePolicy);
 		this.persistentPaths = parse('persistentPaths', this.persistentPaths);
+		this.persistentDrops = parse('persistentDrops', this.persistentDrops);
 		this.experimentalVK = parse('experimentalVK', this.experimentalVK);
 		this.gdnativeLibs = parse('gdnativeLibs', this.gdnativeLibs);
 		this.fileSizes = parse('fileSizes', this.fileSizes);
@@ -316,6 +322,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 			'canvas': this.canvas,
 			'canvasResizePolicy': this.canvasResizePolicy,
 			'locale': locale,
+			'persistentDrops': this.persistentDrops,
 			'virtualKeyboard': this.experimentalVK,
 			'onExecute': this.onExecute,
 			'onExit': function (p_code) {

--- a/platform/javascript/js/libs/library_godot_os.js
+++ b/platform/javascript/js/libs/library_godot_os.js
@@ -60,6 +60,7 @@ const GodotConfig = {
 		locale: 'en',
 		canvas_resize_policy: 2, // Adaptive
 		virtual_keyboard: false,
+		persistent_drops: false,
 		on_execute: null,
 		on_exit: null,
 
@@ -68,6 +69,7 @@ const GodotConfig = {
 			GodotConfig.canvas = p_opts['canvas'];
 			GodotConfig.locale = p_opts['locale'] || GodotConfig.locale;
 			GodotConfig.virtual_keyboard = p_opts['virtualKeyboard'];
+			GodotConfig.persistent_drops = !!p_opts['persistentDrops'];
 			GodotConfig.on_execute = p_opts['onExecute'];
 			GodotConfig.on_exit = p_opts['onExit'];
 		},
@@ -80,6 +82,7 @@ const GodotConfig = {
 			GodotConfig.locale = 'en';
 			GodotConfig.canvas_resize_policy = 2;
 			GodotConfig.virtual_keyboard = false;
+			GodotConfig.persistent_drops = false;
 			GodotConfig.on_execute = null;
 			GodotConfig.on_exit = null;
 		},


### PR DESCRIPTION
With a very nice hack, a new hidden configuration option that delays
dropped files removal at exit.

This still leaks while the project manager is running, but will clear
memory as soon as it exits or load something.
(reminder, dropped files are reguarly removed after the signal is
emitted specifically to avoid leaks, but I prefer hacking the HTML5
config then the project manager).

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
