### PR TITLE
[3.2] Batch of lightmapper fixes and minor improvements

### DIFF
--- a/doc/classes/BakedLightmap.xml
+++ b/doc/classes/BakedLightmap.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		Baked lightmaps are an alternative workflow for adding indirect (or baked) lighting to a scene. Unlike the [GIProbe] approach, baked lightmaps work fine on low-end PCs and mobile devices as they consume almost no resources in run-time.
-		[b]Note:[/b] This node has many known bugs and will be [url=https://godotengine.org/article/godot-40-will-get-new-modernized-lightmapper]rewritten for Godot 4.0[/url]. See [url=https://github.com/godotengine/godot/issues/30929]GitHub issue #30929[/url].
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/3.2/tutorials/3d/baked_lightmaps.html</link>
@@ -62,6 +61,9 @@
 		</member>
 		<member name="environment_custom_sky_rotation_degrees" type="Vector3" setter="set_environment_custom_sky_rotation_degrees" getter="get_environment_custom_sky_rotation_degrees">
 			The rotation of the baked custom sky.
+		</member>
+		<member name="environment_min_light" type="Color" setter="set_environment_min_light" getter="get_environment_min_light" default="Color( 0, 0, 0, 1 )">
+			Minimum ambient light for all the lightmap texels. This doesn't take into account any occlusion from the scene's geometry, it simply ensures a minimum amount of light on all the lightmap texels. Can be used for artistic control on shadow color.
 		</member>
 		<member name="environment_mode" type="int" setter="set_environment_mode" getter="get_environment_mode" enum="BakedLightmap.EnvironmentMode" default="0">
 			Decides which environment to use during baking.

--- a/doc/classes/BakedLightmapData.xml
+++ b/doc/classes/BakedLightmapData.xml
@@ -66,6 +66,10 @@
 		<member name="cell_subdiv" type="int" setter="set_cell_subdiv" getter="get_cell_subdiv" default="1">
 		</member>
 		<member name="energy" type="float" setter="set_energy" getter="get_energy" default="1.0">
+			Global energy multiplier for baked and dynamic capture objects.
+		</member>
+		<member name="interior" type="bool" setter="set_interior" getter="is_interior" default="false">
+			Controls whether dynamic capture objects receive environment lighting or not.
 		</member>
 		<member name="octree" type="PoolByteArray" setter="set_octree" getter="get_octree" default="PoolByteArray(  )">
 		</member>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -2323,6 +2323,15 @@
 				Returns the cell transform for this lightmap capture's octree.
 			</description>
 		</method>
+		<method name="lightmap_capture_is_interior" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="capture" type="RID">
+			</argument>
+			<description>
+				Returns [code]true[/code] if capture is in "interior" mode.
+			</description>
+		</method>
 		<method name="lightmap_capture_set_bounds">
 			<return type="void">
 			</return>
@@ -2343,6 +2352,17 @@
 			</argument>
 			<description>
 				Sets the energy multiplier for this lightmap capture. Equivalent to [member BakedLightmapData.energy].
+			</description>
+		</method>
+		<method name="lightmap_capture_set_interior">
+			<return type="void">
+			</return>
+			<argument index="0" name="capture" type="RID">
+			</argument>
+			<argument index="1" name="interior" type="bool">
+			</argument>
+			<description>
+				Sets the "interior" mode for this lightmap capture. Equivalent to [member BakedLightmapData.interior].
 			</description>
 		</method>
 		<method name="lightmap_capture_set_octree">

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -655,6 +655,8 @@ public:
 	int lightmap_capture_get_octree_cell_subdiv(RID p_capture) const { return 0; }
 	void lightmap_capture_set_energy(RID p_capture, float p_energy) {}
 	float lightmap_capture_get_energy(RID p_capture) const { return 0.0; }
+	void lightmap_capture_set_interior(RID p_capture, bool p_interior) {}
+	bool lightmap_capture_is_interior(RID p_capture) const { return false; }
 	const PoolVector<LightmapCaptureOctree> *lightmap_capture_get_octree_ptr(RID p_capture) const {
 		const LightmapCapture *capture = lightmap_capture_data_owner.getornull(p_capture);
 		ERR_FAIL_COND_V(!capture, NULL);

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2598,7 +2598,6 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 
 		if (use_lightmap_capture) { //this is per instance, must be set always if present
 			glUniform4fv(state.scene_shader.get_uniform_location(SceneShaderGLES2::LIGHTMAP_CAPTURES), 12, (const GLfloat *)e->instance->lightmap_capture_data.ptr());
-			state.scene_shader.set_uniform(SceneShaderGLES2::LIGHTMAP_CAPTURE_SKY, false);
 		}
 
 		_render_geometry(e);

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4521,6 +4521,10 @@ void RasterizerStorageGLES2::lightmap_capture_set_energy(RID p_capture, float p_
 	LightmapCapture *capture = lightmap_capture_data_owner.getornull(p_capture);
 	ERR_FAIL_COND(!capture);
 	capture->energy = p_energy;
+
+	if (!capture->update_list.in_list()) {
+		capture_update_list.add(&capture->update_list);
+	}
 }
 
 float RasterizerStorageGLES2::lightmap_capture_get_energy(RID p_capture) const {
@@ -4528,6 +4532,30 @@ float RasterizerStorageGLES2::lightmap_capture_get_energy(RID p_capture) const {
 	const LightmapCapture *capture = lightmap_capture_data_owner.getornull(p_capture);
 	ERR_FAIL_COND_V(!capture, 0);
 	return capture->energy;
+}
+
+void RasterizerStorageGLES2::lightmap_capture_set_interior(RID p_capture, bool p_interior) {
+	LightmapCapture *capture = lightmap_capture_data_owner.getornull(p_capture);
+	ERR_FAIL_COND(!capture);
+	capture->interior = p_interior;
+
+	if (!capture->update_list.in_list()) {
+		capture_update_list.add(&capture->update_list);
+	}
+}
+
+bool RasterizerStorageGLES2::lightmap_capture_is_interior(RID p_capture) const {
+	const LightmapCapture *capture = lightmap_capture_data_owner.getornull(p_capture);
+	ERR_FAIL_COND_V(!capture, false);
+	return capture->interior;
+}
+
+void RasterizerStorageGLES2::update_dirty_captures() {
+	while (capture_update_list.first()) {
+		LightmapCapture *capture = capture_update_list.first()->self();
+		capture->instance_change_notify(false, true);
+		capture_update_list.remove(capture_update_list.first());
+	}
 }
 
 const PoolVector<RasterizerStorage::LightmapCaptureOctree> *RasterizerStorageGLES2::lightmap_capture_get_octree_ptr(RID p_capture) const {
@@ -6361,6 +6389,7 @@ void RasterizerStorageGLES2::update_dirty_resources() {
 	update_dirty_materials();
 	update_dirty_skeletons();
 	update_dirty_multimeshes();
+	update_dirty_captures();
 }
 
 RasterizerStorageGLES2::RasterizerStorageGLES2() {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1096,11 +1096,21 @@ public:
 		Transform cell_xform;
 		int cell_subdiv;
 		float energy;
-		LightmapCapture() {
+		bool interior;
+
+		SelfList<LightmapCapture> update_list;
+
+		LightmapCapture() :
+				update_list(this) {
 			energy = 1.0;
 			cell_subdiv = 1;
+			interior = false;
 		}
 	};
+
+	SelfList<LightmapCapture>::List capture_update_list;
+
+	void update_dirty_captures();
 
 	mutable RID_Owner<LightmapCapture> lightmap_capture_data_owner;
 
@@ -1115,6 +1125,9 @@ public:
 	virtual int lightmap_capture_get_octree_cell_subdiv(RID p_capture) const;
 	virtual void lightmap_capture_set_energy(RID p_capture, float p_energy);
 	virtual float lightmap_capture_get_energy(RID p_capture) const;
+	virtual void lightmap_capture_set_interior(RID p_capture, bool p_interior);
+	virtual bool lightmap_capture_is_interior(RID p_capture) const;
+
 	virtual const PoolVector<LightmapCaptureOctree> *lightmap_capture_get_octree_ptr(RID p_capture) const;
 
 	/* PARTICLES */

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -956,8 +956,6 @@ vec4 texture2D_bicubic(sampler2D tex, vec2 uv) {
 
 #ifdef USE_LIGHTMAP_CAPTURE
 uniform mediump vec4 lightmap_captures[12];
-uniform bool lightmap_capture_sky;
-
 #endif
 
 #ifdef USE_RADIANCE_MAP
@@ -1781,8 +1779,9 @@ FRAGMENT_SHADER_CODE
 
 		captured /= sum;
 
-		if (lightmap_capture_sky) {
-			ambient_light = mix(ambient_light, captured.rgb, captured.a);
+		// Alpha channel is used to indicate if dynamic objects keep the environment lighting
+		if (lightmap_captures[0].a > 0.5) {
+			ambient_light += captured.rgb;
 		} else {
 			ambient_light = captured.rgb;
 		}

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1941,7 +1941,6 @@ void RasterizerSceneGLES3::_setup_light(RenderList::Element *e, const Transform 
 	} else if (!e->instance->lightmap_capture_data.empty()) {
 
 		glUniform4fv(state.scene_shader.get_uniform_location(SceneShaderGLES3::LIGHTMAP_CAPTURES), 12, (const GLfloat *)e->instance->lightmap_capture_data.ptr());
-		state.scene_shader.set_uniform(SceneShaderGLES3::LIGHTMAP_CAPTURE_SKY, false);
 
 	} else if (e->instance->lightmap.is_valid()) {
 		RasterizerStorageGLES3::Texture *lightmap = storage->texture_owner.getornull(e->instance->lightmap);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1152,6 +1152,8 @@ public:
 
 	virtual void lightmap_capture_set_energy(RID p_capture, float p_energy);
 	virtual float lightmap_capture_get_energy(RID p_capture) const;
+	virtual void lightmap_capture_set_interior(RID p_capture, bool p_interior);
+	virtual bool lightmap_capture_is_interior(RID p_capture) const;
 
 	virtual const PoolVector<LightmapCaptureOctree> *lightmap_capture_get_octree_ptr(RID p_capture) const;
 
@@ -1162,11 +1164,21 @@ public:
 		Transform cell_xform;
 		int cell_subdiv;
 		float energy;
-		LightmapCapture() {
+		bool interior;
+
+		SelfList<LightmapCapture> update_list;
+
+		LightmapCapture() :
+				update_list(this) {
 			energy = 1.0;
 			cell_subdiv = 1;
+			interior = false;
 		}
 	};
+
+	SelfList<LightmapCapture>::List capture_update_list;
+
+	void update_dirty_captures();
 
 	mutable RID_Owner<LightmapCapture> lightmap_capture_data_owner;
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1548,8 +1548,6 @@ vec4 textureArray_bicubic(sampler2DArray tex, vec3 uv) {
 
 #ifdef USE_LIGHTMAP_CAPTURE
 uniform mediump vec4[12] lightmap_captures;
-uniform bool lightmap_capture_sky;
-
 #endif
 
 #ifdef USE_GI_PROBES
@@ -1964,8 +1962,9 @@ FRAGMENT_SHADER_CODE
 
 		captured /= sum;
 
-		if (lightmap_capture_sky) {
-			ambient_light = mix(ambient_light, captured.rgb, captured.a);
+		// Alpha channel is used to indicate if dynamic objects keep the environment lighting
+		if (lightmap_captures[0].a > 0.5) {
+			ambient_light += captured.rgb;
 		} else {
 			ambient_light = captured.rgb;
 		}

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -230,6 +230,9 @@
 		<member name="mesh_library" type="MeshLibrary" setter="set_mesh_library" getter="get_mesh_library">
 			The assigned [MeshLibrary].
 		</member>
+		<member name="use_in_baked_light" type="bool" setter="set_use_in_baked_light" getter="get_use_in_baked_light" default="false">
+			Controls whether this GridMap will be baked in a [BakedLightmap] or not.
+		</member>
 	</members>
 	<signals>
 		<signal name="cell_size_changed">

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -210,6 +210,14 @@ Ref<MeshLibrary> GridMap::get_mesh_library() const {
 	return mesh_library;
 }
 
+void GridMap::set_use_in_baked_light(bool p_use_baked_light) {
+	use_in_baked_light = p_use_baked_light;
+}
+
+bool GridMap::get_use_in_baked_light() const {
+	return use_in_baked_light;
+}
+
 void GridMap::set_cell_size(const Vector3 &p_size) {
 	ERR_FAIL_COND(p_size.x < 0.001 || p_size.y < 0.001 || p_size.z < 0.001);
 	cell_size = p_size;
@@ -864,7 +872,11 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_baked_meshes"), &GridMap::clear_baked_meshes);
 	ClassDB::bind_method(D_METHOD("make_baked_meshes", "gen_lightmap_uv", "lightmap_uv_texel_size"), &GridMap::make_baked_meshes, DEFVAL(false), DEFVAL(0.1));
 
+	ClassDB::bind_method(D_METHOD("set_use_in_baked_light", "use_in_baked_light"), &GridMap::set_use_in_baked_light);
+	ClassDB::bind_method(D_METHOD("get_use_in_baked_light"), &GridMap::get_use_in_baked_light);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh_library", PROPERTY_HINT_RESOURCE_TYPE, "MeshLibrary"), "set_mesh_library", "get_mesh_library");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_in_baked_light"), "set_use_in_baked_light", "get_use_in_baked_light");
 	ADD_GROUP("Cell", "cell_");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "cell_size"), "set_cell_size", "get_cell_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_octant_size", PROPERTY_HINT_RANGE, "1,1024,1"), "set_octant_size", "get_octant_size");
@@ -1066,6 +1078,10 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 
 Array GridMap::get_bake_meshes() {
 
+	if (!use_in_baked_light) {
+		return Array();
+	}
+
 	if (!baked_meshes.size()) {
 		make_baked_meshes(true);
 	}
@@ -1107,6 +1123,8 @@ GridMap::GridMap() {
 	navigation = NULL;
 	set_notify_transform(true);
 	recreating_octants = false;
+
+	use_in_baked_light = false;
 }
 
 GridMap::~GridMap() {

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -158,6 +158,7 @@ class GridMap : public Spatial {
 	Vector3::Axis clip_axis;
 
 	Ref<MeshLibrary> mesh_library;
+	bool use_in_baked_light;
 
 	Map<OctantKey, Octant *> octant_map;
 	Map<IndexKey, Cell> cell_map;
@@ -229,6 +230,9 @@ public:
 
 	void set_mesh_library(const Ref<MeshLibrary> &p_mesh_library);
 	Ref<MeshLibrary> get_mesh_library() const;
+
+	void set_use_in_baked_light(bool p_use_baked_light);
+	bool get_use_in_baked_light() const;
 
 	void set_cell_size(const Vector3 &p_size);
 	Vector3 get_cell_size() const;

--- a/modules/raycast/lightmap_raycaster.cpp
+++ b/modules/raycast/lightmap_raycaster.cpp
@@ -33,6 +33,7 @@
 // From Embree.
 #include <math/vec2.h>
 #include <math/vec3.h>
+#include <xmmintrin.h>
 
 using namespace embree;
 
@@ -185,12 +186,18 @@ void embree_error_handler(void *p_user_data, RTCError p_code, const char *p_str)
 }
 
 LightmapRaycasterEmbree::LightmapRaycasterEmbree() {
+	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+	_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+
 	embree_device = rtcNewDevice(nullptr);
 	rtcSetDeviceErrorFunction(embree_device, &embree_error_handler, nullptr);
 	embree_scene = rtcNewScene(embree_device);
 }
 
 LightmapRaycasterEmbree::~LightmapRaycasterEmbree() {
+	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
+	_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
+
 	if (embree_scene != nullptr)
 		rtcReleaseScene(embree_scene);
 	if (embree_device != nullptr)

--- a/scene/3d/baked_lightmap.h
+++ b/scene/3d/baked_lightmap.h
@@ -44,6 +44,7 @@ class BakedLightmapData : public Resource {
 	RID baked_light;
 	AABB bounds;
 	float energy;
+	bool interior;
 	int cell_subdiv;
 	Transform cell_space_xform;
 
@@ -82,6 +83,9 @@ public:
 
 	void set_energy(float p_energy);
 	float get_energy() const;
+
+	void set_interior(bool p_interior);
+	bool is_interior() const;
 
 	void add_user(const NodePath &p_path, const Ref<Resource> &p_lightmap, int p_lightmap_slice, const Rect2 &p_lightmap_uv_rect, int p_instance);
 	int get_user_count() const;
@@ -169,6 +173,7 @@ private:
 	Vector3 environment_custom_sky_rotation_degrees;
 	Color environment_custom_color;
 	float environment_custom_energy;
+	Color environment_min_light;
 
 	BakeQuality capture_quality;
 	float capture_propagation;
@@ -246,6 +251,9 @@ public:
 
 	void set_environment_custom_energy(float p_energy);
 	float get_environment_custom_energy() const;
+
+	void set_environment_min_light(Color p_min_light);
+	Color get_environment_min_light() const;
 
 	void set_use_denoiser(bool p_enable);
 	bool is_using_denoiser() const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -514,6 +514,8 @@ public:
 	virtual int lightmap_capture_get_octree_cell_subdiv(RID p_capture) const = 0;
 	virtual void lightmap_capture_set_energy(RID p_capture, float p_energy) = 0;
 	virtual float lightmap_capture_get_energy(RID p_capture) const = 0;
+	virtual void lightmap_capture_set_interior(RID p_capture, bool p_interior) = 0;
+	virtual bool lightmap_capture_is_interior(RID p_capture) const = 0;
 	virtual const PoolVector<LightmapCaptureOctree> *lightmap_capture_get_octree_ptr(RID p_capture) const = 0;
 
 	/* PARTICLES */

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -396,6 +396,9 @@ public:
 	BIND2(lightmap_capture_set_energy, RID, float)
 	BIND1RC(float, lightmap_capture_get_energy, RID)
 
+	BIND2(lightmap_capture_set_interior, RID, bool)
+	BIND1RC(bool, lightmap_capture_is_interior, RID)
+
 	/* PARTICLES */
 
 	BIND0R(RID, particles_create)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -330,6 +330,8 @@ public:
 	FUNC1RC(int, lightmap_capture_get_octree_cell_subdiv, RID)
 	FUNC2(lightmap_capture_set_energy, RID, float)
 	FUNC1RC(float, lightmap_capture_get_energy, RID)
+	FUNC2(lightmap_capture_set_interior, RID, bool)
+	FUNC1RC(bool, lightmap_capture_is_interior, RID)
 
 	/* PARTICLES */
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1830,6 +1830,8 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("lightmap_capture_get_octree", "capture"), &VisualServer::lightmap_capture_get_octree);
 	ClassDB::bind_method(D_METHOD("lightmap_capture_set_energy", "capture", "energy"), &VisualServer::lightmap_capture_set_energy);
 	ClassDB::bind_method(D_METHOD("lightmap_capture_get_energy", "capture"), &VisualServer::lightmap_capture_get_energy);
+	ClassDB::bind_method(D_METHOD("lightmap_capture_set_interior", "capture", "interior"), &VisualServer::lightmap_capture_set_interior);
+	ClassDB::bind_method(D_METHOD("lightmap_capture_is_interior", "capture"), &VisualServer::lightmap_capture_is_interior);
 #endif
 	ClassDB::bind_method(D_METHOD("particles_create"), &VisualServer::particles_create);
 	ClassDB::bind_method(D_METHOD("particles_set_emitting", "particles", "emitting"), &VisualServer::particles_set_emitting);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -558,6 +558,8 @@ public:
 	virtual PoolVector<uint8_t> lightmap_capture_get_octree(RID p_capture) const = 0;
 	virtual void lightmap_capture_set_energy(RID p_capture, float p_energy) = 0;
 	virtual float lightmap_capture_get_energy(RID p_capture) const = 0;
+	virtual void lightmap_capture_set_interior(RID p_capture, bool p_interior) = 0;
+	virtual bool lightmap_capture_is_interior(RID p_capture) const = 0;
 
 	/* PARTICLES API */
 


### PR DESCRIPTION
- Fix objects with no material being considered as fully transparent by the lightmapper. Fixes #46861.
- Added "environment_min_light" property: gives artistic control over the shadow color. 
- Fixed "Custom Color" environment mode, it was ignored before.
- Added "interior" property to BakedLightmapData: controls whether dynamic capture objects receive environment light or not. Fixes #46591.
- Automatically update dynamic capture objects when the capture data changes (also works for "energy" which used to require object movement to trigger the update).
- Added "use_in_baked_light" property to GridMap: controls whether the GridMap will be included in BakedLightmap bakes.
- Set "flush zero" and "denormal zero" mode for SSE2 instructions in the Embree raycaster. According to Embree docs it should give a performance improvement.
