### PR TITLE
Make Animation's SceneTreeDialog filter nodes properly

### DIFF
--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -499,6 +499,10 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _insert_animation_key(NodePath p_path, const Variant &p_value);
 
+	void _pick_track_filter_text_changed(const String &p_newtext);
+	void _pick_track_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates);
+	void _pick_track_filter_input(const Ref<InputEvent> &p_ie);
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -181,6 +181,7 @@ protected:
 public:
 	void popup_scenetree_dialog();
 	SceneTreeEditor *get_scene_tree() { return tree; }
+	LineEdit *get_filter_line_edit() { return filter; }
 	SceneTreeDialog();
 	~SceneTreeDialog();
 };


### PR DESCRIPTION
Actually that's a "bug" which bothers me for many months already.

During work on my game I am creating a lot animations within AnimationPlayer.

What's not working as intended, is the first dialog, when selecting Node to animate - it has a "filter" input, but:
- it is NOT focused immediately after dialog pops up
- it doesn't accept Enter key events
- it doesn't allow to use cursor keys (up,down,pgup,pgdown) to move selection on the tree
- it does filter the list of nodes, but doesn't select them (according to partial name match)

Fun fact is that, after Node is picked, then second screen, with tree of properties/methods works properly - it immediately allows to filter, use arrow keys, and pick-up properties/methods, without using mouse at all.

This PR fixes the problem, and makes first dialog work similar to the second one, e.g - as it should from the very beginning :)

OLD behavior:

![old](https://user-images.githubusercontent.com/1110337/110963391-4e59d880-8352-11eb-894b-ab49061e642f.gif)

NEW behavior:

![new](https://user-images.githubusercontent.com/1110337/110963422-5580e680-8352-11eb-8c40-4f41952d2fd0.gif)

 With small adjustments it can be also fixed for 3.x. I will do that as soon, this branch will be merged.