### PR TITLE
Add `use_asan` option for MSVC to enable AddressSanitizer

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -72,6 +72,7 @@ def get_opts():
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
         BoolVariable("use_thinlto", "Use ThinLTO", False),
         BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True),
+        BoolVariable("use_asan", "Use address sanitizer (ASAN)", False),
     ]
 
 
@@ -305,6 +306,12 @@ def configure_msvc(env, manual_msvc_config):
     if manual_msvc_config:
         env.Prepend(CPPPATH=[p for p in os.getenv("INCLUDE").split(";")])
         env.Append(LIBPATH=[p for p in os.getenv("LIB").split(";")])
+
+    # Sanitizers
+    if env["use_asan"]:
+        env.extra_suffix += ".s"
+        env.Append(LINKFLAGS=["/INFERASANLIBS"])
+        env.Append(CCFLAGS=["/fsanitize=address"])
 
     # Incremental linking fix
     env["BUILDERS"]["ProgramOriginal"] = env["BUILDERS"]["Program"]


### PR DESCRIPTION
Exposes AddressSanitizer support in MSVC compiler. Can be installed via individual components in the Visual Studio 2019 Installer.

See https://devblogs.microsoft.com/cppblog/address-sanitizer-for-msvc-now-generally-available/ and https://docs.microsoft.com/en-us/cpp/sanitizers/asan?view=msvc-160.

Disabled by default. Compile the engine with `scons use_asan=yes` similarly to Linux builds (especially useful with `scons tests=yes use_asan=yes`).

Example output on Windows so you can see it works:
```
PS D:\src\godot\gd4> ./bin/godot.windows.tools.64.s.exe --test --source-file="*test_array*"
[doctest] doctest version is "2.4.4"
[doctest] run with "--help" for options
=================================================================
==8148==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x127ef8a007d4 at pc 0x7ff74da49771 bp 0x00acaa5fd950 sp 0x00acaa5fd958
READ of size 4 at 0x127ef8a007d4 thread T0
    #0 0x7ff74da49770 in TestArray::_DOCTEST_ANON_FUNC_314 D:\src\godot\gd4\tests\test_array.h:130
    #1 0x7ff74de67c0a in doctest::Context::run(void) D:\src\godot\gd4\thirdparty\doctest\doctest.h:6291
    #2 0x7ff74da277f8 in test_main(int, char **const) D:\src\godot\gd4\tests\test_main.cpp:139
    #3 0x7ff74d9d1548 in Main::test_entrypoint(int, char **const, bool &) D:\src\godot\gd4\main\main.cpp:481
    #4 0x7ff74d9024bb in widechar_main(int, wchar_t **) D:\src\godot\gd4\platform\windows\godot_windows.cpp:149
    #5 0x7ff74d902962 in _main(void) D:\src\godot\gd4\platform\windows\godot_windows.cpp:185
    #6 0x7ff74d9029d1 in main D:\src\godot\gd4\platform\windows\godot_windows.cpp:199
    #7 0x7ff7575035e7 in __scrt_common_main_seh d:\agent\_work\63\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #8 0x7fff24887c23  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017c23)
    #9 0x7fff24e4d720  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18006d720)

0x127ef8a007d4 is located 4 bytes to the right of 400-byte region [0x127ef8a00640,0x127ef8a007d0)
freed by thread T0 here:
    #0 0x7ff74d9cf722 in operator delete[](void *) D:\agent\_work\63\s\src\vctools\crt\asan\llvm\compiler-rt\lib\asan\asan_new_delete.cc:163
    #1 0x7ff74da496e9 in TestArray::_DOCTEST_ANON_FUNC_314 D:\src\godot\gd4\tests\test_array.h:129
    #2 0x7ff74de67c0a in doctest::Context::run(void) D:\src\godot\gd4\thirdparty\doctest\doctest.h:6291
    #3 0x7ff74da277f8 in test_main(int, char **const) D:\src\godot\gd4\tests\test_main.cpp:139
    #4 0x7ff74d9d1548 in Main::test_entrypoint(int, char **const, bool &) D:\src\godot\gd4\main\main.cpp:481
    #5 0x7ff74d9024bb in widechar_main(int, wchar_t **) D:\src\godot\gd4\platform\windows\godot_windows.cpp:149
    #6 0x7ff74d902962 in _main(void) D:\src\godot\gd4\platform\windows\godot_windows.cpp:185
    #7 0x7ff74d9029d1 in main D:\src\godot\gd4\platform\windows\godot_windows.cpp:199
    #8 0x7ff7575035e7 in __scrt_common_main_seh d:\agent\_work\63\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #9 0x7fff24887c23  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017c23)
    #10 0x7fff24e4d720  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18006d720)

previously allocated by thread T0 here:
    #0 0x7ff74d9cf202 in operator new[](unsigned __int64) D:\agent\_work\63\s\src\vctools\crt\asan\llvm\compiler-rt\lib\asan\asan_new_delete.cc:102
    #1 0x7ff74da496b4 in TestArray::_DOCTEST_ANON_FUNC_314 D:\src\godot\gd4\tests\test_array.h:128
    #2 0x7ff74de67c0a in doctest::Context::run(void) D:\src\godot\gd4\thirdparty\doctest\doctest.h:6291
    #3 0x7ff74da277f8 in test_main(int, char **const) D:\src\godot\gd4\tests\test_main.cpp:139
    #4 0x7ff74d9d1548 in Main::test_entrypoint(int, char **const, bool &) D:\src\godot\gd4\main\main.cpp:481
    #5 0x7ff74d9024bb in widechar_main(int, wchar_t **) D:\src\godot\gd4\platform\windows\godot_windows.cpp:149
    #6 0x7ff74d902962 in _main(void) D:\src\godot\gd4\platform\windows\godot_windows.cpp:185
    #7 0x7ff74d9029d1 in main D:\src\godot\gd4\platform\windows\godot_windows.cpp:199
    #8 0x7ff7575035e7 in __scrt_common_main_seh d:\agent\_work\63\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #9 0x7fff24887c23  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017c23)
    #10 0x7fff24e4d720  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18006d720)

SUMMARY: AddressSanitizer: heap-buffer-overflow D:\src\godot\gd4\tests\test_array.h:130 in TestArray::_DOCTEST_ANON_FUNC_314
Shadow bytes around the buggy address:
  0x04a6d7b400a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x04a6d7b400b0: 00 00 00 00 00 00 00 00 00 00 fa fa fa fa fa fa
  0x04a6d7b400c0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x04a6d7b400d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x04a6d7b400e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x04a6d7b400f0: fd fd fd fd fd fd fd fd fd fd[fa]fa fa fa fa fa
  0x04a6d7b40100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x04a6d7b40110: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x04a6d7b40120: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x04a6d7b40130: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x04a6d7b40140: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==8148==ABORTING
```
With bogus code:
```c++
int *i = new int[100];
delete[] i;
print_line(itos(i[101]));
```