### PR TITLE
Fix Node can not be reselected

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -626,7 +626,7 @@ void SceneTreeEditor::_selected_changed() {
 }
 
 void SceneTreeEditor::_deselect_items() {
-	// Clear currently elected items in scene tree dock.
+	// Clear currently selected items in scene tree dock.
 	if (editor_selection) {
 		editor_selection->clear();
 		emit_signal("node_changed");
@@ -1172,6 +1172,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	tree->set_anchor(SIDE_BOTTOM, ANCHOR_END);
 	tree->set_begin(Point2(0, p_label ? 18 : 0));
 	tree->set_end(Point2(0, 0));
+	tree->set_allow_reselect(true);
 	tree->add_theme_constant_override("button_margin", 0);
 
 	add_child(tree);


### PR DESCRIPTION
Fix #46935, fix #46633
This will remove selection after clicking script icon so that node can be selected again
Edit: Both problem #46935 #46633 are caused by the change #46079
which added the following code
```
if (!selected_item) {
			selected_item = p_item;
}
``` 