### PR TITLE
Fix EditorSpinSlider grabber zoom issues (Fix #46632)

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -175,7 +175,9 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
-		float grabbing_ofs = (grabber->get_transform().xform(mm->get_position()).x - grabbing_from) / float(grabber_range);
+		float scale_x = get_global_transform_with_canvas().get_scale().x;
+		ERR_FAIL_COND(Math::is_zero_approx(scale_x));
+		float grabbing_ofs = (grabber->get_transform().xform(mm->get_position()).x - grabbing_from) / float(grabber_range) / scale_x;
 		set_as_ratio(grabbing_ratio + grabbing_ofs);
 		update();
 	}
@@ -300,8 +302,10 @@ void EditorSpinSlider::_notification(int p_what) {
 					grabber->set_texture(grabber_tex);
 				}
 
+				Vector2 scale = get_global_transform_with_canvas().get_scale();
+				grabber->set_scale(scale);
 				grabber->set_size(Size2(0, 0));
-				grabber->set_position(get_global_position() + grabber_rect.position + grabber_rect.size * 0.5 - grabber->get_size() * 0.5);
+				grabber->set_position(get_global_position() + (grabber_rect.position + grabber_rect.size * 0.5 - grabber->get_size() * 0.5) * scale);
 
 				if (mousewheel_over_grabber) {
 					Input::get_singleton()->warp_mouse_position(grabber->get_position() + grabber_rect.size);


### PR DESCRIPTION
### Fix #46632 issue
As described in the issue mentionned,  EditorSpinSlider grabber was not at the correct position when GraphEdit zoom wasn't set to 1.

### Cause :
The grabber textureRect is in top_level mode so it doesn't inherit its scale from its parents. Scale need to be applied manually.

### Solution : 

Scale in now applied when calculating the grabber position.
I use get_global_transform_with_canvas().get_scale() to get the scale.

Also, the visual size of the grabber is now correctly scaled.

### Zoom fix :
![slider](https://user-images.githubusercontent.com/3649998/110128452-189f7780-7dc7-11eb-9117-64a0180ba4e7.gif)