### PR TITLE
C#: Fix ScriptPathAttribute generator with none or nested namespaces

### DIFF
--- a/modules/mono/SdkPackageVersions.props
+++ b/modules/mono/SdkPackageVersions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageVersion_Godot_NET_Sdk>4.0.0-dev4</PackageVersion_Godot_NET_Sdk>
-    <PackageVersion_Godot_SourceGenerators>4.0.0-dev1</PackageVersion_Godot_SourceGenerators>
+    <PackageVersion_Godot_NET_Sdk>4.0.0-dev5</PackageVersion_Godot_NET_Sdk>
+    <PackageVersion_Godot_SourceGenerators>4.0.0-dev2</PackageVersion_Godot_SourceGenerators>
   </PropertyGroup>
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
@@ -23,11 +23,12 @@
 
   <ItemGroup>
     <!-- Package Sdk\Sdk.props and Sdk\Sdk.targets file -->
-    <None Include="Sdk\Sdk.props" Pack="true" PackagePath="Sdk" Visible="false" />
-    <None Include="Sdk\Sdk.targets" Pack="true" PackagePath="Sdk" Visible="false" />
+    <None Include="Sdk\Sdk.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\Sdk.targets" Pack="true" PackagePath="Sdk" />
     <!-- SdkPackageVersions.props -->
-
-    <None Include="..\..\..\SdkPackageVersions.props" Pack="true" PackagePath="Sdk" Visible="false" />
+    <None Include="..\..\..\SdkPackageVersions.props" Pack="true" PackagePath="Sdk">
+      <Link>Sdk\SdkPackageVersions.props</Link>
+    </None>
   </ItemGroup>
 
   <Target Name="CopyNupkgToSConsOutputDir" AfterTargets="Pack">

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -82,5 +82,8 @@ namespace Godot.SourceGenerators
 
         public static string FullQualifiedName(this INamedTypeSymbol symbol)
             => symbol.ToDisplayString(NullableFlowState.NotNull, FullyQualifiedFormatOmitGlobal);
+
+        public static string FullQualifiedName(this INamespaceSymbol namespaceSymbol)
+            => namespaceSymbol.ToDisplayString(FullyQualifiedFormatOmitGlobal);
     }
 }


### PR DESCRIPTION
The following two bugs were fixed:
- For classes without namespace we were still generating `namespace {` without a namespace identifier, causing a syntax error.
- For classes with nested namespaces we were generating only the innermost part of the namespace was being generated, e.g.: for `Foo.Bar` we were generating `namespace Bar {` instead of `namespace Foo.Bar {`.
  This wasn't causing any build error, but because of the wrong namespace Godot wasn't able to find the class associated with the script.

Fixes #46879
