### PR TITLE
Fix Create Plugin after GD Annotation Changes

### DIFF
--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -86,7 +86,7 @@ void PluginConfigDialog::_on_confirmed() {
 			// Hard-coded GDScript template to keep usability until we use script templates.
 			Ref<Script> gdscript = memnew(GDScript);
 			gdscript->set_source_code(
-					"tool\n"
+					"@tool\n"
 					"extends EditorPlugin\n"
 					"\n"
 					"\n"


### PR DESCRIPTION
Fix a issue after creating a plugin by editor, because changing annotations for gdscript ("tool" to "@tool")

![image](https://user-images.githubusercontent.com/76991284/111015994-b4267e80-83ab-11eb-92c8-30a864431e5a.png)
![image](https://user-images.githubusercontent.com/76991284/111016004-c0124080-83ab-11eb-9cef-d4755d3e9e95.png)

Issue comes from
https://github.com/godotengine/godot/commit/5d6e8538065050d5f5579ec03cfa9e241811e062