### PR TITLE
Optionally disable srgb decode gles3 feature (globally or per vendor)

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8410,7 +8410,6 @@ void RasterizerStorageGLES3::initialize() {
 	config.support_npot_repeat_mipmap = true;
 
 	config.pvrtc_supported = config.extensions.has("GL_IMG_texture_compression_pvrtc");
-	config.srgb_decode_supported = config.extensions.has("GL_EXT_texture_sRGB_decode");
 
 	config.anisotropic_level = 1.0;
 	config.use_anisotropic_filter = config.extensions.has("GL_EXT_texture_filter_anisotropic");
@@ -8599,6 +8598,21 @@ void RasterizerStorageGLES3::initialize() {
 
 			if (renderer.findn(v) != -1) {
 				config.use_depth_prepass = false;
+			}
+		}
+	}
+
+	config.srgb_decode_supported = GLOBAL_GET("rendering/quality/srgb_decode/enable") && config.extensions.has("GL_EXT_texture_sRGB_decode");
+	if (config.srgb_decode_supported) {
+		String vendors = GLOBAL_GET("rendering/quality/srgb_decode/disable_for_vendors");
+		Vector<String> vendor_match = vendors.split(",");
+		for (int i = 0; i < vendor_match.size(); i++) {
+			String v = vendor_match[i].strip_edges();
+			if (v == String())
+				continue;
+
+			if (renderer.findn(v) != -1) {
+				config.srgb_decode_supported = false;
 			}
 		}
 	}

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2439,6 +2439,9 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/quality/depth_prepass/enable", true);
 	GLOBAL_DEF("rendering/quality/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
 
+	GLOBAL_DEF("rendering/quality/srgb_decode/enable", true);
+	GLOBAL_DEF("rendering/quality/srgb_decode/disable_for_vendors", "Mali");
+
 	GLOBAL_DEF("rendering/quality/filters/anisotropic_filter_level", 4);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/filters/anisotropic_filter_level", PropertyInfo(Variant::INT, "rendering/quality/filters/anisotropic_filter_level", PROPERTY_HINT_RANGE, "1,16,1"));
 	GLOBAL_DEF("rendering/quality/filters/use_nearest_mipmap_filter", false);


### PR DESCRIPTION
This fixes dark textures on android+mali devices. closes #39279, closes #43342

Actually, Mali devices don't like mipmaps + internal srgb based format. I dive into some research but did not find anything directly related to the problem. I've tested on iPhone6, Xiaomi Redmi 5 (Adreno) and Kindle Fire HDX (Mali).

<details>
  <summary>Extensions per device may be useful for diving in:</summary>

```
# iPhone 6s
GL_APPLE_clip_distance
GL_APPLE_color_buffer_packed_float
GL_APPLE_copy_texture_levels
GL_APPLE_rgb_422
GL_APPLE_texture_format_BGRA8888
GL_EXT_color_buffer_half_float
GL_EXT_debug_label
GL_EXT_debug_marker
GL_EXT_pvrtc_sRGB
GL_EXT_read_format_bgra
GL_EXT_separate_shader_objects
GL_EXT_shader_framebuffer_fetch
GL_EXT_shader_texture_lod
GL_EXT_shadow_samplers
GL_EXT_texture_filter_anisotropic
GL_IMG_read_format
GL_IMG_texture_compression_pvrtc
GL_KHR_texture_compression_astc_ldr
GL_OES_standard_derivatives
```

```
# Xiaomi Redmi 5 (Adreno)
GL_AMD_compressed_ATC_texture
GL_ANDROID_extension_pack_es31a
GL_ARM_shader_framebuffer_fetch_depth_stencil
GL_EXT_EGL_image_array
GL_EXT_YUV_target
GL_EXT_blit_framebuffer_params
GL_EXT_buffer_storage
GL_EXT_clip_cull_distance
GL_EXT_color_buffer_float
GL_EXT_color_buffer_half_float
GL_EXT_copy_image
GL_EXT_debug_label
GL_EXT_debug_marker
GL_EXT_discard_framebuffer
GL_EXT_disjoint_timer_query
GL_EXT_draw_buffers_indexed
GL_EXT_external_buffer
GL_EXT_geometry_shader
GL_EXT_gpu_shader5
GL_EXT_memory_object
GL_EXT_memory_object_fd
GL_EXT_multisampled_render_to_texture
GL_EXT_multisampled_render_to_texture2
GL_EXT_primitive_bounding_box
GL_EXT_protected_textures
GL_EXT_robustness
GL_EXT_sRGB
GL_EXT_sRGB_write_control
GL_EXT_shader_framebuffer_fetch
GL_EXT_shader_io_blocks
GL_EXT_shader_non_constant_global_initializers
GL_EXT_tessellation_shader
GL_EXT_texture_border_clamp
GL_EXT_texture_buffer
GL_EXT_texture_cube_map_array
GL_EXT_texture_filter_anisotropic
GL_EXT_texture_format_BGRA8888
GL_EXT_texture_norm16
GL_EXT_texture_sRGB_R8
GL_EXT_texture_sRGB_decode
GL_EXT_texture_type_2_10_10_10_REV
GL_KHR_blend_equation_advanced
GL_KHR_blend_equation_advanced_coherent
GL_KHR_debug
GL_KHR_no_error
GL_KHR_texture_compression_astc_hdr
GL_KHR_texture_compression_astc_ldr
GL_NV_shader_noperspective_interpolation
GL_OES_EGL_image
GL_OES_EGL_image_external
GL_OES_EGL_image_external_essl3
GL_OES_EGL_sync
GL_OES_compressed_ETC1_RGB8_texture
GL_OES_depth24
GL_OES_depth_texture
GL_OES_depth_texture_cube_map
GL_OES_element_index_uint
GL_OES_framebuffer_object
GL_OES_get_program_binary
GL_OES_packed_depth_stencil
GL_OES_rgb8_rgba8
GL_OES_sample_shading
GL_OES_sample_variables
GL_OES_shader_image_atomic
GL_OES_shader_multisample_interpolation
GL_OES_standard_derivatives
GL_OES_surfaceless_context
GL_OES_texture_3D
GL_OES_texture_compression_astc
GL_OES_texture_float
GL_OES_texture_float_linear
GL_OES_texture_half_float
GL_OES_texture_half_float_linear
GL_OES_texture_npot
GL_OES_texture_stencil8
GL_OES_texture_storage_multisample_2d_array
GL_OES_vertex_array_object
GL_OES_vertex_half_float
GL_OVR_multiview
GL_OVR_multiview2
GL_OVR_multiview_multisampled_render_to_texture
GL_QCOM_alpha_test
GL_QCOM_shader_framebuffer_fetch_noncoherent
GL_QCOM_texture_foveated
GL_QCOM_tiled_rendering
```
```
# Kindle Fire HDX (Mali)
GL_ANDROID_extension_pack_es31a
GL_ARM_mali_program_binary
GL_ARM_mali_shader_binary
GL_ARM_rgba8
GL_ARM_shader_framebuffer_fetch
GL_ARM_shader_framebuffer_fetch_depth_stencil
GL_EXT_EGL_image_array
GL_EXT_YUV_target
GL_EXT_blend_minmax
GL_EXT_buffer_storage
GL_EXT_color_buffer_float
GL_EXT_color_buffer_half_float
GL_EXT_copy_image
GL_EXT_debug_marker
GL_EXT_discard_framebuffer
GL_EXT_disjoint_timer_query
GL_EXT_draw_buffers_indexed
GL_EXT_draw_elements_base_vertex
GL_EXT_geometry_shader
GL_EXT_gpu_shader5
GL_EXT_multisampled_render_to_texture
GL_EXT_multisampled_render_to_texture2
GL_EXT_occlusion_query_boolean
GL_EXT_primitive_bounding_box
GL_EXT_protected_textures
GL_EXT_read_format_bgra
GL_EXT_robustness
GL_EXT_sRGB
GL_EXT_sRGB_write_control
GL_EXT_shader_io_blocks
GL_EXT_shader_non_constant_global_initializers
GL_EXT_shader_pixel_local_storage
GL_EXT_shadow_samplers
GL_EXT_tessellation_shader
GL_EXT_texture_border_clamp
GL_EXT_texture_buffer
GL_EXT_texture_cube_map_array
GL_EXT_texture_filter_anisotropic
GL_EXT_texture_format_BGRA8888
GL_EXT_texture_rg
GL_EXT_texture_sRGB_R8
GL_EXT_texture_sRGB_RG8
GL_EXT_texture_sRGB_decode
GL_EXT_texture_storage
GL_EXT_texture_type_2_10_10_10_REV
GL_KHR_blend_equation_advanced
GL_KHR_blend_equation_advanced_coherent
GL_KHR_debug
GL_KHR_robust_buffer_access_behavior
GL_KHR_robustness
GL_KHR_texture_compression_astc_hdr
GL_KHR_texture_compression_astc_ldr
GL_KHR_texture_compression_astc_sliced_3d
GL_OES_EGL_image
GL_OES_EGL_image_external
GL_OES_EGL_image_external_essl3
GL_OES_EGL_sync
GL_OES_compressed_ETC1_RGB8_texture
GL_OES_compressed_paletted_texture
GL_OES_copy_image
GL_OES_depth24
GL_OES_depth_texture
GL_OES_depth_texture_cube_map
GL_OES_draw_buffers_indexed
GL_OES_draw_elements_base_vertex
GL_OES_element_index_uint
GL_OES_fbo_render_mipmap
GL_OES_geometry_shader
GL_OES_get_program_binary
GL_OES_gpu_shader5
GL_OES_mapbuffer
GL_OES_packed_depth_stencil
GL_OES_primitive_bounding_box
GL_OES_required_internalformat
GL_OES_rgb8_rgba8
GL_OES_sample_shading
GL_OES_sample_variables
GL_OES_shader_image_atomic
GL_OES_shader_io_blocks
GL_OES_shader_multisample_interpolation
GL_OES_standard_derivatives
GL_OES_surfaceless_context
GL_OES_tessellation_shader
GL_OES_texture_3D
GL_OES_texture_border_clamp
GL_OES_texture_buffer
GL_OES_texture_compression_astc
GL_OES_texture_cube_map_array
GL_OES_texture_npot
GL_OES_texture_stencil8
GL_OES_texture_storage_multisample_2d_array
GL_OES_vertex_array_object
GL_OES_vertex_half_float
GL_OVR_multiview
GL_OVR_multiview2
GL_OVR_multiview_multisampled_render_to_texture
```
</details>

As far as this PR is only about GLES3 backend, there is nothing to do with master.