### PR TITLE
Allow to not optimize release build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -115,7 +115,7 @@ opts.Add(BoolVariable("tools", "Build the tools (a.k.a. the Godot editor)", True
 opts.Add(EnumVariable("target", "Compilation target", "debug", ("debug", "release_debug", "release")))
 opts.Add("arch", "Platform-dependent architecture (arm/arm64/x86/x64/mips/...)", "")
 opts.Add(EnumVariable("bits", "Target platform bits", "default", ("default", "32", "64")))
-opts.Add(EnumVariable("optimize", "Optimization type", "speed", ("speed", "size")))
+opts.Add(EnumVariable("optimize", "Optimization type", "speed", ("speed", "size", "none")))
 opts.Add(BoolVariable("production", "Set defaults to build Godot for use in production", False))
 opts.Add(BoolVariable("use_lto", "Use link-time optimization", False))
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -197,12 +197,11 @@ def configure(env):
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Append(LINKFLAGS=["-O2"])
             env.Append(CCFLAGS=["-O2", "-fomit-frame-pointer"])
-            env.Append(CPPDEFINES=["NDEBUG"])
-        else:  # optimize for size
+        elif env["optimize"] == "size":  # optimize for size
             env.Append(CCFLAGS=["-Os"])
-            env.Append(CPPDEFINES=["NDEBUG"])
             env.Append(LINKFLAGS=["-Os"])
 
+        env.Append(CPPDEFINES=["NDEBUG"])
         if can_vectorize:
             env.Append(CCFLAGS=["-ftree-vectorize"])
         if env["target"] == "release_debug":

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -54,7 +54,7 @@ def configure(env):
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Append(CCFLAGS=["-O2", "-ftree-vectorize", "-fomit-frame-pointer"])
             env.Append(LINKFLAGS=["-O2"])
-        else:  # optimize for size
+        elif env["optimize"] == "size":  # optimize for size
             env.Append(CCFLAGS=["-Os", "-ftree-vectorize"])
             env.Append(LINKFLAGS=["-Os"])
 

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -64,21 +64,21 @@ def configure(env):
         sys.exit(255)
 
     ## Build type
-    if env["target"] == "release":
+    if env["target"].startswith("release"):
         # Use -Os to prioritize optimizing for reduced file size. This is
         # particularly valuable for the web platform because it directly
         # decreases download time.
         # -Os reduces file size by around 5 MiB over -O3. -Oz only saves about
         # 100 KiB over -Os, which does not justify the negative impact on
         # run-time performance.
-        env.Append(CCFLAGS=["-Os"])
-        env.Append(LINKFLAGS=["-Os"])
-    elif env["target"] == "release_debug":
-        env.Append(CCFLAGS=["-Os"])
-        env.Append(LINKFLAGS=["-Os"])
-        env.Append(CPPDEFINES=["DEBUG_ENABLED"])
-        # Retain function names for backtraces at the cost of file size.
-        env.Append(LINKFLAGS=["--profiling-funcs"])
+        if env["optimize"] != "none":
+            env.Append(CCFLAGS=["-Os"])
+            env.Append(LINKFLAGS=["-Os"])
+
+        if env["target"] == "release_debug":
+            env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+            # Retain function names for backtraces at the cost of file size.
+            env.Append(LINKFLAGS=["--profiling-funcs"])
     else:  # "debug"
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
         env.Append(CCFLAGS=["-O1", "-g"])

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -90,7 +90,7 @@ def configure(env):
     if env["target"] == "release":
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Prepend(CCFLAGS=["-O3"])
-        else:  # optimize for size
+        elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])
 
         if env["debug_symbols"]:
@@ -99,7 +99,7 @@ def configure(env):
     elif env["target"] == "release_debug":
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Prepend(CCFLAGS=["-O2"])
-        else:  # optimize for size
+        elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])
         env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
 

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -50,7 +50,7 @@ def configure(env):
     if env["target"] == "release":
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Prepend(CCFLAGS=["-O3", "-fomit-frame-pointer", "-ftree-vectorize"])
-        else:  # optimize for size
+        elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os", "-ftree-vectorize"])
         if env["arch"] != "arm64":
             env.Prepend(CCFLAGS=["-msse2"])
@@ -61,7 +61,7 @@ def configure(env):
     elif env["target"] == "release_debug":
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Prepend(CCFLAGS=["-O2"])
-        else:  # optimize for size
+        elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])
         env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
         if env["debug_symbols"]:

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -56,7 +56,7 @@ def configure(env):
     if env["target"] == "release":
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Prepend(CCFLAGS=["-O3"])
-        else:  # optimize for size
+        elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])
 
         if env["debug_symbols"]:
@@ -65,7 +65,7 @@ def configure(env):
     elif env["target"] == "release_debug":
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Prepend(CCFLAGS=["-O2"])
-        else:  # optimize for size
+        elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])
         env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
 

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -54,16 +54,19 @@ def configure(env):
     ## Build type
 
     if env["target"] == "release":
-        env.Append(CCFLAGS=["/O2", "/GL"])
         env.Append(CCFLAGS=["/MD"])
-        env.Append(LINKFLAGS=["/SUBSYSTEM:WINDOWS", "/LTCG"])
+        env.Append(LINKFLAGS=["/SUBSYSTEM:WINDOWS"])
+        if env["optimize"] != "none":
+            env.Append(CCFLAGS=["/O2", "/GL"])
+            env.Append(LINKFLAGS=["/LTCG"])
 
     elif env["target"] == "release_debug":
-        env.Append(CCFLAGS=["/O2", "/Zi"])
         env.Append(CCFLAGS=["/MD"])
-        env.Append(CPPDEFINES=["DEBUG_ENABLED"])
         env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
         env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
+        env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+        if env["optimize"] != "none":
+            env.Append(CCFLAGS=["/O2", "/Zi"])
 
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["/Zi"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -190,18 +190,20 @@ def configure_msvc(env, manual_msvc_config):
     if env["target"] == "release":
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Append(CCFLAGS=["/O2"])
-        else:  # optimize for size
+            env.Append(LINKFLAGS=["/OPT:REF"])
+        elif env["optimize"] == "size":  # optimize for size
             env.Append(CCFLAGS=["/O1"])
+            env.Append(LINKFLAGS=["/OPT:REF"])
         env.Append(LINKFLAGS=["/ENTRY:mainCRTStartup"])
-        env.Append(LINKFLAGS=["/OPT:REF"])
 
     elif env["target"] == "release_debug":
         if env["optimize"] == "speed":  # optimize for speed (default)
             env.Append(CCFLAGS=["/O2"])
-        else:  # optimize for size
+            env.Append(LINKFLAGS=["/OPT:REF"])
+        elif env["optimize"] == "size":  # optimize for size
             env.Append(CCFLAGS=["/O1"])
+            env.Append(LINKFLAGS=["/OPT:REF"])
         env.AppendUnique(CPPDEFINES=["DEBUG_ENABLED"])
-        env.Append(LINKFLAGS=["/OPT:REF"])
 
     elif env["target"] == "debug":
         env.AppendUnique(CCFLAGS=["/Zi", "/FS", "/Od", "/EHsc"])


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/2457

This will allow to speedup compilation for people, that want to test Godot without `DEBUG_ENABLED` flag

If fix is good, then I will do the same for others platform
