### PR TITLE
Fix always capitalized properties in subinspector (Fix #46961)

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2915,7 +2915,7 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->set_use_doc_hints(true);
 
 				sub_inspector->set_sub_inspector(true);
-				sub_inspector->set_enable_capitalize_paths(true);
+				sub_inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));
 
 				sub_inspector->connect("property_keyed", callable_mp(this, &EditorPropertyResource::_sub_inspector_property_keyed));
 				sub_inspector->connect("resource_selected", callable_mp(this, &EditorPropertyResource::_sub_inspector_resource_selected));


### PR DESCRIPTION
As described in the comments of the issue #46961 , properties capitalization for subinspector panels (like shaders' subinspector) doesn't check `Editor Settings > Interface > Inspector > Capitalize Properties` before enabling capitalization.

This PR correctly  initialize capitalization in subinspectors with the editor settings. 

Can be cherrypicked easily for 3.2 branch.

*Bugsquad edit:* Fixes #46961.