### PR TITLE
Fix create c# script from editor after partial class type is necessary

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -328,7 +328,7 @@ Ref<Script> CSharpLanguage::get_template(const String &p_class_name, const Strin
 	String script_template = "using " BINDINGS_NAMESPACE ";\n"
 							 "using System;\n"
 							 "\n"
-							 "public class %CLASS% : %BASE%\n"
+							 "public partial class %CLASS% : %BASE%\n"
 							 "{\n"
 							 "    // Declare member variables here. Examples:\n"
 							 "    // private int a = 2;\n"


### PR DESCRIPTION
This fix is adding the partial class keyword to new scripts generated by the editor or by the plugin creator since partial class type is required for mono scripts.

![image](https://user-images.githubusercontent.com/76991284/111037013-89c3d800-8422-11eb-9b15-2391b1a69b7a.png)
![image](https://user-images.githubusercontent.com/76991284/111037018-96e0c700-8422-11eb-90c3-20d6f8fb7623.png)

