### PR TITLE
Fix EditorInspector not updating its theme on rare occasions

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2436,10 +2436,10 @@ void EditorInspector::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
 		EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &EditorInspector::_feature_profile_changed));
 		set_process(is_visible_in_tree());
+		_update_inspector_bg();
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		_update_inspector_bg();
 		if (!sub_inspector) {
 			get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 		}


### PR DESCRIPTION
This fixes very rare cases where the `EditorInspector`'s theme will not update at the start, with the weirdest one being when the "Node" dock is not on the right side of the editor...?
![Screenshot at 2021-03-13 15-26-26](https://user-images.githubusercontent.com/30739239/111040186-b3343200-8429-11eb-85e8-1ae789e3a683.png)