### PR TITLE
Fix Control::_edit_set_state bogus error check

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -72,7 +72,7 @@ Dictionary Control::_edit_get_state() const {
 void Control::_edit_set_state(const Dictionary &p_state) {
 	ERR_FAIL_COND((p_state.size() <= 0) ||
 				  !p_state.has("rotation") || !p_state.has("scale") ||
-				  !p_state.has("pivot") || !p_state.has("anchors") || !p_state.has("offsets"));
+				  !p_state.has("pivot") || !p_state.has("anchors") || !p_state.has("margins"));
 	Dictionary state = p_state;
 
 	set_rotation(state["rotation"]);


### PR DESCRIPTION
My mistake when cherry-picking #46699 with f8ee8b1b7344db274d6830b25a9760e02de0a0a6,
I forgot to amend the cherry-pick to change 'offsets' back to 'margins' for the 3.2
branch.

Fixes #46979.