### PR TITLE
Vulkan: Fix crash when opening a ShaderMaterial with code saved as an external .shader file 

### DIFF
--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -233,7 +233,7 @@ public:
 	FUNC2(shader_set_code, RID, const String &)
 	FUNC1RC(String, shader_get_code, RID)
 
-	FUNC2C(shader_get_param_list, RID, List<PropertyInfo> *)
+	FUNC2SC(shader_get_param_list, RID, List<PropertyInfo> *)
 
 	FUNC3(shader_set_default_texture_param, RID, const StringName &, RID)
 	FUNC2RC(RID, shader_get_default_texture_param, RID, const StringName &)


### PR DESCRIPTION
Fix for crashing vulkan on opening shader materials with code saves as external shader file.

Issue comes from a unsynced call of "shader_get_param_list" inside the rendering_server_default.h

Fixes #46053 