### PR TITLE
Rename Array, Dictionary and Variant.duplicate() to copy()

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -234,7 +234,7 @@ Ref<Resource> Resource::duplicate(bool p_subresources) const {
 		Variant p = get(E->get().name);
 
 		if ((p.get_type() == Variant::DICTIONARY || p.get_type() == Variant::ARRAY)) {
-			r->set(E->get().name, p.duplicate(p_subresources));
+			r->set(E->get().name, p.copy(p_subresources));
 		} else if (p.get_type() == Variant::OBJECT && (p_subresources || (E->get().usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE))) {
 			RES sr = p;
 			if (sr.is_valid()) {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -405,7 +405,7 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 
 	} else if (p_name == CoreStringNames::get_singleton()->_meta) {
 		//set_meta(p_name,p_value);
-		metadata = p_value.duplicate();
+		metadata = p_value.copy();
 		if (r_valid) {
 			*r_valid = true;
 		}

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -112,7 +112,7 @@ public:
 		sort_custom<_DefaultComparator<T>>();
 	}
 
-	Vector<T> duplicate() {
+	Vector<T> copy() {
 		return *this;
 	}
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -298,13 +298,13 @@ const Variant &Array::get(int p_idx) const {
 	return operator[](p_idx);
 }
 
-Array Array::duplicate(bool p_deep) const {
+Array Array::copy(bool p_deep) const {
 	Array new_arr;
 	int element_count = size();
 	new_arr.resize(element_count);
 	new_arr._p->typed = _p->typed;
 	for (int i = 0; i < element_count; i++) {
-		new_arr[i] = p_deep ? get(i).duplicate(p_deep) : get(i);
+		new_arr[i] = p_deep ? get(i).copy(p_deep) : get(i);
 	}
 
 	return new_arr;
@@ -348,13 +348,13 @@ Array Array::slice(int p_begin, int p_end, int p_step, bool p_deep) const { // l
 		int dest_idx = 0;
 		for (int idx = begin; idx <= end; idx += p_step) {
 			ERR_FAIL_COND_V_MSG(dest_idx < 0 || dest_idx >= new_arr_size, Array(), "Bug in Array slice()");
-			new_arr[dest_idx++] = p_deep ? get(idx).duplicate(p_deep) : get(idx);
+			new_arr[dest_idx++] = p_deep ? get(idx).copy(p_deep) : get(idx);
 		}
 	} else { // p_step < 0
 		int dest_idx = 0;
 		for (int idx = begin; idx >= end; idx += p_step) {
 			ERR_FAIL_COND_V_MSG(dest_idx < 0 || dest_idx >= new_arr_size, Array(), "Bug in Array slice()");
-			new_arr[dest_idx++] = p_deep ? get(idx).duplicate(p_deep) : get(idx);
+			new_arr[dest_idx++] = p_deep ? get(idx).copy(p_deep) : get(idx);
 		}
 	}
 

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -98,7 +98,7 @@ public:
 	Variant pop_back();
 	Variant pop_front();
 
-	Array duplicate(bool p_deep = false) const;
+	Array copy(bool p_deep = false) const;
 
 	Array slice(int p_begin, int p_end, int p_step = 1, bool p_deep = false) const;
 

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -240,11 +240,11 @@ const Variant *Dictionary::next(const Variant *p_key) const {
 	return nullptr;
 }
 
-Dictionary Dictionary::duplicate(bool p_deep) const {
+Dictionary Dictionary::copy(bool p_deep) const {
 	Dictionary n;
 
 	for (OrderedHashMap<Variant, Variant, VariantHasher, VariantComparator>::Element E = _p->variant_map.front(); E; E = E.next()) {
-		n[E.key()] = p_deep ? E.value().duplicate(true) : E.value();
+		n[E.key()] = p_deep ? E.value().copy(true) : E.value();
 	}
 
 	return n;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -79,7 +79,7 @@ public:
 	Array keys() const;
 	Array values() const;
 
-	Dictionary duplicate(bool p_deep = false) const;
+	Dictionary copy(bool p_deep = false) const;
 
 	const void *id() const;
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -474,7 +474,7 @@ public:
 	static PTROperatorEvaluator get_ptr_operator_evaluator(Operator p_operator, Type p_type_a, Type p_type_b);
 
 	void zero();
-	Variant duplicate(bool deep = false) const;
+	Variant copy(bool deep = false) const;
 	static void blend(const Variant &a, const Variant &b, float c, Variant &r_dst);
 	static void interpolate(const Variant &a, const Variant &b, float c, Variant &r_dst);
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1631,7 +1631,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Dictionary, hash, sarray(), varray());
 	bind_method(Dictionary, keys, sarray(), varray());
 	bind_method(Dictionary, values, sarray(), varray());
-	bind_method(Dictionary, duplicate, sarray("deep"), varray(false));
+	bind_method(Dictionary, copy, sarray("deep"), varray(false));
 	bind_method(Dictionary, get, sarray("key", "default"), varray(Variant()));
 
 	/* Array */
@@ -1664,7 +1664,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(Array, bsearch_custom, sarray("value", "func", "before"), varray(true));
 	bind_method(Array, reverse, sarray(), varray());
-	bind_method(Array, duplicate, sarray("deep"), varray(false));
+	bind_method(Array, copy, sarray("deep"), varray(false));
 	bind_method(Array, slice, sarray("begin", "end", "step", "deep"), varray(1, false));
 	bind_method(Array, max, sarray(), varray());
 	bind_method(Array, min, sarray(), varray());
@@ -1684,7 +1684,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedByteArray, reverse, sarray(), varray());
 	bind_method(PackedByteArray, subarray, sarray("from", "to"), varray());
 	bind_method(PackedByteArray, sort, sarray(), varray());
-	bind_method(PackedByteArray, duplicate, sarray(), varray());
+	bind_method(PackedByteArray, copy, sarray(), varray());
 
 	bind_function(PackedByteArray, get_string_from_ascii, _VariantCall::func_PackedByteArray_get_string_from_ascii, sarray(), varray());
 	bind_function(PackedByteArray, get_string_from_utf8, _VariantCall::func_PackedByteArray_get_string_from_utf8, sarray(), varray());
@@ -1740,7 +1740,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt32Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedInt32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt32Array, sort, sarray(), varray());
-	bind_method(PackedInt32Array, duplicate, sarray(), varray());
+	bind_method(PackedInt32Array, copy, sarray(), varray());
 
 	/* Int64 Array */
 
@@ -1759,7 +1759,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt64Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedInt64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt64Array, sort, sarray(), varray());
-	bind_method(PackedInt64Array, duplicate, sarray(), varray());
+	bind_method(PackedInt64Array, copy, sarray(), varray());
 
 	/* Float32 Array */
 
@@ -1778,7 +1778,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat32Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedFloat32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat32Array, sort, sarray(), varray());
-	bind_method(PackedFloat32Array, duplicate, sarray(), varray());
+	bind_method(PackedFloat32Array, copy, sarray(), varray());
 
 	/* Float64 Array */
 
@@ -1797,7 +1797,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat64Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedFloat64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat64Array, sort, sarray(), varray());
-	bind_method(PackedFloat64Array, duplicate, sarray(), varray());
+	bind_method(PackedFloat64Array, copy, sarray(), varray());
 
 	/* String Array */
 
@@ -1816,7 +1816,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedStringArray, subarray, sarray("from", "to"), varray());
 	bind_method(PackedStringArray, to_byte_array, sarray(), varray());
 	bind_method(PackedStringArray, sort, sarray(), varray());
-	bind_method(PackedStringArray, duplicate, sarray(), varray());
+	bind_method(PackedStringArray, copy, sarray(), varray());
 
 	/* Vector2 Array */
 
@@ -1835,7 +1835,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector2Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedVector2Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector2Array, sort, sarray(), varray());
-	bind_method(PackedVector2Array, duplicate, sarray(), varray());
+	bind_method(PackedVector2Array, copy, sarray(), varray());
 
 	/* Vector3 Array */
 
@@ -1854,7 +1854,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector3Array, subarray, sarray("from", "to"), varray());
 	bind_method(PackedVector3Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector3Array, sort, sarray(), varray());
-	bind_method(PackedVector3Array, duplicate, sarray(), varray());
+	bind_method(PackedVector3Array, copy, sarray(), varray());
 
 	/* Color Array */
 
@@ -1873,7 +1873,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedColorArray, subarray, sarray("from", "to"), varray());
 	bind_method(PackedColorArray, to_byte_array, sarray(), varray());
 	bind_method(PackedColorArray, sort, sarray(), varray());
-	bind_method(PackedColorArray, duplicate, sarray(), varray());
+	bind_method(PackedColorArray, copy, sarray(), varray());
 
 	/* Register constants */
 

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -2012,7 +2012,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 	return Variant();
 }
 
-Variant Variant::duplicate(bool deep) const {
+Variant Variant::copy(bool deep) const {
 	switch (type) {
 		case OBJECT: {
 			/*  breaks stuff :(
@@ -2026,27 +2026,27 @@ Variant Variant::duplicate(bool deep) const {
 			return *this;
 		} break;
 		case DICTIONARY:
-			return operator Dictionary().duplicate(deep);
+			return operator Dictionary().copy(deep);
 		case ARRAY:
-			return operator Array().duplicate(deep);
+			return operator Array().copy(deep);
 		case PACKED_BYTE_ARRAY:
-			return operator Vector<uint8_t>().duplicate();
+			return operator Vector<uint8_t>().copy();
 		case PACKED_INT32_ARRAY:
-			return operator Vector<int32_t>().duplicate();
+			return operator Vector<int32_t>().copy();
 		case PACKED_INT64_ARRAY:
-			return operator Vector<int64_t>().duplicate();
+			return operator Vector<int64_t>().copy();
 		case PACKED_FLOAT32_ARRAY:
-			return operator Vector<float>().duplicate();
+			return operator Vector<float>().copy();
 		case PACKED_FLOAT64_ARRAY:
-			return operator Vector<double>().duplicate();
+			return operator Vector<double>().copy();
 		case PACKED_STRING_ARRAY:
-			return operator Vector<String>().duplicate();
+			return operator Vector<String>().copy();
 		case PACKED_VECTOR2_ARRAY:
-			return operator Vector<Vector2>().duplicate();
+			return operator Vector<Vector2>().copy();
 		case PACKED_VECTOR3_ARRAY:
-			return operator Vector<Vector3>().duplicate();
+			return operator Vector<Vector3>().copy();
 		case PACKED_COLOR_ARRAY:
-			return operator Vector<Color>().duplicate();
+			return operator Vector<Color>().copy();
 		default:
 			return *this;
 	}

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -39,7 +39,7 @@
 		[/csharp]
 		[/codeblocks]
 		[b]Note:[/b] Concatenating with the [code]+=[/code] operator will create a new array, which has a cost. If you want to append another array to an existing array, [method append_array] is more efficient.
-		[b]Note:[/b] Arrays are always passed by reference. To get a copy of an array which can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Arrays are always passed by reference. To get a copy of an array which can be modified independently of the original array, use [method copy].
 		[b]Note:[/b] When declaring an array with [code]const[/code], the array itself can still be mutated by defining the values at individual indices or pushing/removing elements. Using [code]const[/code] will only prevent assigning the constant with another value after it was initialized.
 	</description>
 	<tutorials>
@@ -207,6 +207,16 @@
 				Clears the array. This is equivalent to using [method resize] with a size of [code]0[/code].
 			</description>
 		</method>
+		<method name="copy" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="deep" type="bool" default="false">
+			</argument>
+			<description>
+				Returns a copy of the array.
+				If [code]deep[/code] is [code]true[/code], a deep copy is performed: all nested arrays and dictionaries are copied and will not be shared with the original array. If [code]false[/code], a shallow copy is made and references to the original nested arrays and dictionaries are kept, so that modifying a sub-array or dictionary in the copy will also impact those referenced in the source array.
+			</description>
+		</method>
 		<method name="count" qualifiers="const">
 			<return type="int">
 			</return>
@@ -214,16 +224,6 @@
 			</argument>
 			<description>
 				Returns the number of times an element is in the array.
-			</description>
-		</method>
-		<method name="duplicate" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="deep" type="bool" default="false">
-			</argument>
-			<description>
-				Returns a copy of the array.
-				If [code]deep[/code] is [code]true[/code], a deep copy is performed: all nested arrays and dictionaries are duplicated and will not be shared with the original array. If [code]false[/code], a shallow copy is made and references to the original nested arrays and dictionaries are kept, so that modifying a sub-array or dictionary in the copy will also impact those referenced in the source array.
 			</description>
 		</method>
 		<method name="erase">

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -7,7 +7,7 @@
 		Dictionary type. Associative container which contains values referenced by unique keys. Dictionaries are composed of pairs of keys (which must be unique) and values. Dictionaries will preserve the insertion order when adding elements, even though this may not be reflected when printing the dictionary. In other programming languages, this data structure is sometimes referred to as a hash map or associative array.
 		You can define a dictionary by placing a comma-separated list of [code]key: value[/code] pairs in curly braces [code]{}[/code].
 		Erasing elements while iterating over them [b]is not supported[/b] and will result in undefined behavior.
-		[b]Note:[/b] Dictionaries are always passed by reference. To get a copy of a dictionary which can be modified independently of the original dictionary, use [method duplicate].
+		[b]Note:[/b] Dictionaries are always passed by reference. To get a copy of a dictionary which can be modified independently of the original dictionary, use [method copy].
 		Creating a dictionary:
 		[codeblocks]
 		[gdscript]
@@ -206,7 +206,7 @@
 				Clear the dictionary, removing all key/value pairs.
 			</description>
 		</method>
-		<method name="duplicate" qualifiers="const">
+		<method name="copy" qualifiers="const">
 			<return type="Dictionary">
 			</return>
 			<argument index="0" name="deep" type="bool" default="false">

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -61,6 +61,13 @@
 				Returns a new [PackedByteArray] with the data compressed. Set the compression mode using one of [enum File.CompressionMode]'s constants.
 			</description>
 		</method>
+		<method name="copy">
+			<return type="PackedByteArray">
+			</return>
+			<description>
+				Creates a copy of the array, and returns it.
+			</description>
+		</method>
 		<method name="decode_double" qualifiers="const">
 			<return type="float">
 			</return>
@@ -191,13 +198,6 @@
 				Returns a new [PackedByteArray] with the data decompressed. Set the compression mode using one of [enum File.CompressionMode]'s constants. [b]This method only accepts gzip and deflate compression modes.[/b]
 				This method is potentially slower than [code]decompress[/code], as it may have to re-allocate its output buffer multiple times while decompressing, whereas [code]decompress[/code] knows it's output buffer size from the beginning.
 				GZIP has a maximal compression ratio of 1032:1, meaning it's very possible for a small compressed payload to decompress to a potentially very large output. To guard against this, you may provide a maximum size this function is allowed to allocate in bytes via [code]max_output_size[/code]. Passing -1 will allow for unbounded output. If any positive value is passed, and the decompression exceeds that amount in bytes, then an error will be returned.
-			</description>
-		</method>
-		<method name="duplicate">
-			<return type="PackedByteArray">
-			</return>
-			<description>
-				Creates a copy of the array, and returns it.
 			</description>
 		</method>
 		<method name="encode_double">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -52,7 +52,7 @@
 				Appends a [PackedColorArray] at the end of this array.
 			</description>
 		</method>
-		<method name="duplicate">
+		<method name="copy">
 			<return type="PackedColorArray">
 			</return>
 			<description>

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -53,7 +53,7 @@
 				Appends a [PackedFloat32Array] at the end of this array.
 			</description>
 		</method>
-		<method name="duplicate">
+		<method name="copy">
 			<return type="PackedFloat32Array">
 			</return>
 			<description>

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -53,7 +53,7 @@
 				Appends a [PackedFloat64Array] at the end of this array.
 			</description>
 		</method>
-		<method name="duplicate">
+		<method name="copy">
 			<return type="PackedFloat64Array">
 			</return>
 			<description>

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -53,7 +53,7 @@
 				Appends a [PackedInt32Array] at the end of this array.
 			</description>
 		</method>
-		<method name="duplicate">
+		<method name="copy">
 			<return type="PackedInt32Array">
 			</return>
 			<description>

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -53,7 +53,7 @@
 				Appends a [PackedInt64Array] at the end of this array.
 			</description>
 		</method>
-		<method name="duplicate">
+		<method name="copy">
 			<return type="PackedInt64Array">
 			</return>
 			<description>

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -53,7 +53,7 @@
 				Appends a [PackedStringArray] at the end of this array.
 			</description>
 		</method>
-		<method name="duplicate">
+		<method name="copy">
 			<return type="PackedStringArray">
 			</return>
 			<description>

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -53,7 +53,7 @@
 				Appends a [PackedVector2Array] at the end of this array.
 			</description>
 		</method>
-		<method name="duplicate">
+		<method name="copy">
 			<return type="PackedVector2Array">
 			</return>
 			<description>

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -52,7 +52,7 @@
 				Appends a [PackedVector3Array] at the end of this array.
 			</description>
 		</method>
-		<method name="duplicate">
+		<method name="copy">
 			<return type="PackedVector3Array">
 			</return>
 			<description>

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -710,7 +710,7 @@ static bool _is_action_name_valid(const String &p_name) {
 void ActionMapEditor::_event_config_confirmed() {
 	Ref<InputEvent> ev = event_config_dialog->get_event();
 
-	Dictionary new_action = current_action.duplicate();
+	Dictionary new_action = current_action.copy();
 	Array events = new_action["events"];
 
 	if (current_action_event_index == -1) {
@@ -773,7 +773,7 @@ void ActionMapEditor::_action_edited() {
 		// Deadzone Edited
 		String name = ti->get_meta("__name");
 		Dictionary old_action = ti->get_meta("__action");
-		Dictionary new_action = old_action.duplicate();
+		Dictionary new_action = old_action.copy();
 		new_action["deadzone"] = ti->get_range(1);
 
 		// Call deferred so that input can finish propagating through tree, allowing re-making of tree to occur.

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -167,7 +167,7 @@ public:
 		switch (animation->track_get_type(track)) {
 			case Animation::TYPE_TRANSFORM: {
 				Dictionary d_old = animation->track_get_key_value(track, key);
-				Dictionary d_new = d_old.duplicate();
+				Dictionary d_new = d_old.copy();
 				d_new[p_name] = p_value;
 				setting = true;
 				undo_redo->create_action(TTR("Anim Change Transform"));
@@ -203,7 +203,7 @@ public:
 			} break;
 			case Animation::TYPE_METHOD: {
 				Dictionary d_old = animation->track_get_key_value(track, key);
-				Dictionary d_new = d_old.duplicate();
+				Dictionary d_new = d_old.copy();
 
 				bool change_notify_deserved = false;
 				bool mergeable = false;
@@ -783,7 +783,7 @@ public:
 				switch (animation->track_get_type(track)) {
 					case Animation::TYPE_TRANSFORM: {
 						Dictionary d_old = animation->track_get_key_value(track, key);
-						Dictionary d_new = d_old.duplicate();
+						Dictionary d_new = d_old.copy();
 						d_new[p_name] = p_value;
 
 						if (!setting) {
@@ -814,7 +814,7 @@ public:
 					} break;
 					case Animation::TYPE_METHOD: {
 						Dictionary d_old = animation->track_get_key_value(track, key);
-						Dictionary d_new = d_old.duplicate();
+						Dictionary d_new = d_old.copy();
 
 						bool mergeable = false;
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -765,7 +765,7 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 
 			Node *node = Object::cast_to<Node>(object);
 			if (node && EditorPropertyRevert::may_node_be_in_instance(node) && EditorPropertyRevert::get_instanced_node_original_property(node, property, vorig)) {
-				emit_changed(property, vorig.duplicate(true));
+				emit_changed(property, vorig.copy(true));
 				update_property();
 				return;
 			}

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -163,7 +163,7 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 		emit_changed(get_edited_property(), array, "", true);
 
 		if (array.get_type() == Variant::ARRAY) {
-			array = array.call("duplicate"); //dupe, so undo/redo works better
+			array = array.call("copy"); // Copy, so undo/redo works better
 		}
 		object->set_array(array);
 	}
@@ -193,7 +193,7 @@ void EditorPropertyArray::_change_type_menu(int p_index) {
 	emit_changed(get_edited_property(), array, "", true);
 
 	if (array.get_type() == Variant::ARRAY) {
-		array = array.call("duplicate"); //dupe, so undo/redo works better
+		array = array.call("copy"); // Copy, so undo/redo works better
 	}
 
 	object->set_array(array);
@@ -316,7 +316,7 @@ void EditorPropertyArray::update_property() {
 		int amount = MIN(len - offset, page_len);
 
 		if (array.get_type() == Variant::ARRAY) {
-			array = array.call("duplicate");
+			array = array.call("copy");
 		}
 
 		object->set_array(array);
@@ -385,7 +385,7 @@ void EditorPropertyArray::_remove_pressed(int p_index) {
 	array.call("remove", p_index);
 
 	if (array.get_type() == Variant::ARRAY) {
-		array = array.call("duplicate");
+		array = array.call("copy");
 	}
 
 	emit_changed(get_edited_property(), array, "", false);
@@ -459,7 +459,7 @@ void EditorPropertyArray::drop_data_fw(const Point2 &p_point, const Variant &p_d
 		}
 
 		if (array.get_type() == Variant::ARRAY) {
-			array = array.call("duplicate");
+			array = array.call("copy");
 		}
 
 		emit_changed(get_edited_property(), array, "", false);
@@ -530,7 +530,7 @@ void EditorPropertyArray::_length_changed(double p_page) {
 				}
 			}
 		}
-		array = array.call("duplicate"); //dupe, so undo/redo works better
+		array = array.call("copy"); // Copy, so undo/redo works better
 	} else {
 		int size = array.call("size");
 		// Pool*Array don't initialize their elements, have to do it manually
@@ -622,7 +622,7 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 
 		emit_changed(get_edited_property(), dict, "", true);
 
-		dict = dict.duplicate(); //dupe, so undo/redo works better
+		dict = dict.copy(); // Copy, so undo/redo works better
 		object->set_dict(dict);
 	}
 }
@@ -651,7 +651,7 @@ void EditorPropertyDictionary::_add_key_value() {
 
 	emit_changed(get_edited_property(), dict, "", false);
 
-	dict = dict.duplicate(); //dupe, so undo/redo works better
+	dict = dict.copy(); // Copy, so undo/redo works better
 	object->set_dict(dict);
 	update_property();
 }
@@ -685,7 +685,7 @@ void EditorPropertyDictionary::_change_type_menu(int p_index) {
 
 	emit_changed(get_edited_property(), dict, "", false);
 
-	dict = dict.duplicate(); //dupe, so undo/redo works better
+	dict = dict.copy(); // Copy, so undo/redo works better
 	object->set_dict(dict);
 	update_property();
 }
@@ -751,7 +751,7 @@ void EditorPropertyDictionary::update_property() {
 
 		int amount = MIN(len - offset, page_len);
 
-		dict = dict.duplicate();
+		dict = dict.copy();
 
 		object->set_dict(dict);
 		VBoxContainer *add_vbox = nullptr;

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -708,7 +708,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 
 		{
 			//make sure this is unique
-			node_settings = node_settings.duplicate(true);
+			node_settings = node_settings.copy(true);
 			//fill node settings for this node with default values
 			List<ImportOption> iopts;
 			get_internal_import_options(INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE, &iopts);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1345,14 +1345,14 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 	if (Node3DEditor::get_singleton()->is_visible()) {
 		// 3D
 		spatial_edit_state = Node3DEditor::get_singleton()->get_state();
-		Dictionary new_state = spatial_edit_state.duplicate();
+		Dictionary new_state = spatial_edit_state.copy();
 		new_state["show_grid"] = false;
 		new_state["show_origin"] = false;
 		Array orig_vp = spatial_edit_state["viewports"];
 		Array vp;
 		vp.resize(4);
 		for (int i = 0; i < vp.size(); i++) {
-			Dictionary d = ((Dictionary)orig_vp[i]).duplicate();
+			Dictionary d = ((Dictionary)orig_vp[i]).copy();
 			d["use_environment"] = false;
 			d["doppler"] = false;
 			d["gizmos"] = onion.include_gizmos ? d["gizmos"] : Variant(false);
@@ -1365,7 +1365,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 	} else { // CanvasItemEditor
 		// 2D
 		canvas_edit_state = CanvasItemEditor::get_singleton()->get_state();
-		Dictionary new_state = canvas_edit_state.duplicate();
+		Dictionary new_state = canvas_edit_state.copy();
 		new_state["show_grid"] = false;
 		new_state["show_rulers"] = false;
 		new_state["show_guides"] = false;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1176,7 +1176,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 
 				Point2 edited = snap_point(xform.affine_inverse().xform(b->get_position()), SNAP_GRID | SNAP_PIXEL | SNAP_OTHER_NODES);
 				if (drag_type == DRAG_V_GUIDE) {
-					Array prev_vguides = vguides.duplicate();
+					Array prev_vguides = vguides.copy();
 					if (b->get_position().x > RULER_WIDTH) {
 						// Adds a new vertical guide
 						if (dragged_guide_index >= 0) {
@@ -1209,7 +1209,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						}
 					}
 				} else if (drag_type == DRAG_H_GUIDE) {
-					Array prev_hguides = hguides.duplicate();
+					Array prev_hguides = hguides.copy();
 					if (b->get_position().y > RULER_WIDTH) {
 						// Adds a new horizontal guide
 						if (dragged_guide_index >= 0) {
@@ -1242,8 +1242,8 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						}
 					}
 				} else if (drag_type == DRAG_DOUBLE_GUIDE) {
-					Array prev_hguides = hguides.duplicate();
-					Array prev_vguides = vguides.duplicate();
+					Array prev_hguides = hguides.copy();
+					Array prev_vguides = vguides.copy();
 					if (b->get_position().x > RULER_WIDTH && b->get_position().y > RULER_WIDTH) {
 						// Adds a new horizontal guide a new vertical guide
 						vguides.push_back(edited.x);

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -658,7 +658,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 								error->popup_centered();
 							} else {
 								Array polygons = node->get_polygons();
-								polygons = polygons.duplicate(); //copy because its a reference
+								polygons = polygons.copy(); //copy because its a reference
 
 								//todo, could check whether it already exists?
 								polygons.push_back(polygon_create);
@@ -680,7 +680,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 
 				if (uv_move_current == UV_MODE_REMOVE_POLYGON) {
 					Array polygons = node->get_polygons();
-					polygons = polygons.duplicate(); //copy because its a reference
+					polygons = polygons.copy(); //copy because its a reference
 
 					int erase_index = -1;
 					for (int i = polygons.size() - 1; i >= 0; i--) {

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -1839,7 +1839,7 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 			}
 			for (int i = 0; i < sd.size(); i++) {
 				if (sd[i].get("shape") == previous_shape) {
-					undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.duplicate());
+					undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.copy());
 					sd.remove(i);
 					break;
 				}
@@ -1903,7 +1903,7 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 						for (int i = 0; i < sd.size(); i++) {
 							if (sd[i].get("shape") == edited_collision_shape) {
 								undo_redo->create_action(TTR("Remove Collision Polygon"));
-								undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.duplicate());
+								undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.copy());
 								sd.remove(i);
 								undo_redo->add_do_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd);
 								undo_redo->add_do_method(this, "_select_edited_shape_coord");
@@ -2936,7 +2936,7 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 			undo_redo->create_action(TTR("Create Collision Polygon"));
 			// Necessary to get the version that returns a Array instead of a Vector.
 			Array sd = tileset->call("tile_get_shapes", get_current_tile());
-			undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.duplicate());
+			undo_redo->add_undo_method(tileset.ptr(), "tile_set_shapes", get_current_tile(), sd.copy());
 			for (int i = 0; i < sd.size(); i++) {
 				if (sd[i].get("shape") == edited_collision_shape) {
 					sd.remove(i);

--- a/modules/gdnative/gdnative/variant.cpp
+++ b/modules/gdnative/gdnative/variant.cpp
@@ -777,9 +777,9 @@ void GDAPI godot_variant_interpolate(const godot_variant *p_a, const godot_varia
 	Variant::interpolate(*a, *b, p_c, *dst);
 }
 
-godot_variant GDAPI godot_variant_duplicate(const godot_variant *p_self, godot_bool p_deep) {
+godot_variant GDAPI godot_variant_copy(const godot_variant *p_self, godot_bool p_deep) {
 	const Variant *self = (const Variant *)p_self;
-	Variant result = self->duplicate(p_deep);
+	Variant result = self->copy(p_deep);
 	godot_variant ret;
 	memnew_placement_custom(&ret, Variant, Variant(result));
 	return ret;

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -1529,7 +1529,7 @@
 				]
 			},
 			{
-				"name": "godot_variant_duplicate",
+				"name": "godot_variant_copy",
 				"return_type": "godot_variant",
 				"arguments": [
 					[

--- a/modules/gdnative/gdnative_library_singleton_editor.cpp
+++ b/modules/gdnative/gdnative_library_singleton_editor.cpp
@@ -160,9 +160,9 @@ void GDNativeLibrarySingletonEditor::_item_edited() {
 	if (ProjectSettings::get_singleton()->has_setting("gdnative/singletons_disabled")) {
 		disabled_paths = ProjectSettings::get_singleton()->get("gdnative/singletons_disabled");
 		// Duplicate so redo works (not a reference)
-		disabled_paths = disabled_paths.duplicate();
+		disabled_paths = disabled_paths.copy();
 		// For undo, so we can reset the property.
-		undo_paths = disabled_paths.duplicate();
+		undo_paths = disabled_paths.copy();
 	}
 
 	if (enabled) {

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -295,7 +295,7 @@ godot_bool GDAPI godot_variant_hash_compare(const godot_variant *p_self, const g
 godot_bool GDAPI godot_variant_booleanize(const godot_variant *p_self);
 void GDAPI godot_variant_blend(const godot_variant *p_a, const godot_variant *p_b, float p_c, godot_variant *r_dst);
 void GDAPI godot_variant_interpolate(const godot_variant *p_a, const godot_variant *p_b, float p_c, godot_variant *r_dst);
-godot_variant GDAPI godot_variant_duplicate(const godot_variant *p_self, godot_bool p_deep);
+godot_variant GDAPI godot_variant_copy(const godot_variant *p_self, godot_bool p_deep);
 godot_string GDAPI godot_variant_stringify(const godot_variant *p_self);
 
 // Discovery API.

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -194,7 +194,7 @@ Array GDScriptTextDocument::completion(const Dictionary &p_params) {
 			i++;
 		}
 	} else if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
-		arr = native_member_completions.duplicate();
+		arr = native_member_completions.copy();
 
 		for (Map<String, ExtendGDScriptParser *>::Element *E = GDScriptLanguageProtocol::get_singleton()->get_workspace()->scripts.front(); E; E = E->next()) {
 			ExtendGDScriptParser *script = E->get();

--- a/modules/mono/glue/collections_glue.cpp
+++ b/modules/mono/glue/collections_glue.cpp
@@ -115,13 +115,13 @@ Array *godot_icall_Array_Ctor_MonoArray(MonoArray *mono_array) {
 	return godot_array;
 }
 
-Array *godot_icall_Array_Duplicate(Array *ptr, MonoBoolean deep) {
-	return memnew(Array(ptr->duplicate(deep)));
+Array *godot_icall_Array_Copy(Array *ptr, MonoBoolean deep) {
+	return memnew(Array(ptr->copy(deep)));
 }
 
 Array *godot_icall_Array_Concatenate(Array *left, Array *right) {
 	int count = left->size() + right->size();
-	Array *new_array = memnew(Array(left->duplicate(false)));
+	Array *new_array = memnew(Array(left->copy(false)));
 	new_array->resize(count);
 	for (unsigned int i = 0; i < (unsigned int)right->size(); i++) {
 		new_array->operator[](i + left->size()) = right->operator[](i);
@@ -254,8 +254,8 @@ MonoBoolean godot_icall_Dictionary_ContainsKey(Dictionary *ptr, MonoObject *key)
 	return ptr->has(GDMonoMarshal::mono_object_to_variant(key));
 }
 
-Dictionary *godot_icall_Dictionary_Duplicate(Dictionary *ptr, MonoBoolean deep) {
-	return memnew(Dictionary(ptr->duplicate(deep)));
+Dictionary *godot_icall_Dictionary_Copy(Dictionary *ptr, MonoBoolean deep) {
+	return memnew(Dictionary(ptr->copy(deep)));
 }
 
 MonoBoolean godot_icall_Dictionary_RemoveKey(Dictionary *ptr, MonoObject *key) {
@@ -320,7 +320,7 @@ void godot_register_collections_icalls() {
 	GDMonoUtils::add_internal_call("Godot.Collections.Array::godot_icall_Array_Concatenate", godot_icall_Array_Concatenate);
 	GDMonoUtils::add_internal_call("Godot.Collections.Array::godot_icall_Array_Contains", godot_icall_Array_Contains);
 	GDMonoUtils::add_internal_call("Godot.Collections.Array::godot_icall_Array_CopyTo", godot_icall_Array_CopyTo);
-	GDMonoUtils::add_internal_call("Godot.Collections.Array::godot_icall_Array_Duplicate", godot_icall_Array_Duplicate);
+	GDMonoUtils::add_internal_call("Godot.Collections.Array::godot_icall_Array_Copy", godot_icall_Array_Copy);
 	GDMonoUtils::add_internal_call("Godot.Collections.Array::godot_icall_Array_IndexOf", godot_icall_Array_IndexOf);
 	GDMonoUtils::add_internal_call("Godot.Collections.Array::godot_icall_Array_Insert", godot_icall_Array_Insert);
 	GDMonoUtils::add_internal_call("Godot.Collections.Array::godot_icall_Array_Remove", godot_icall_Array_Remove);
@@ -342,7 +342,7 @@ void godot_register_collections_icalls() {
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Clear", godot_icall_Dictionary_Clear);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Contains", godot_icall_Dictionary_Contains);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_ContainsKey", godot_icall_Dictionary_ContainsKey);
-	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Duplicate", godot_icall_Dictionary_Duplicate);
+	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Copy", godot_icall_Dictionary_Copy);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_RemoveKey", godot_icall_Dictionary_RemoveKey);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_Remove", godot_icall_Dictionary_Remove);
 	GDMonoUtils::add_internal_call("Godot.Collections.Dictionary::godot_icall_Dictionary_TryGetValue", godot_icall_Dictionary_TryGetValue);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -221,7 +221,7 @@ protected:
 		Dictionary d = script->call("get_variable_info", var);
 
 		if (String(p_name) == "type") {
-			Dictionary dc = d.duplicate();
+			Dictionary dc = d.copy();
 			dc["type"] = p_value;
 			undo_redo->create_action(TTR("Set Variable Type"));
 			undo_redo->add_do_method(script.ptr(), "set_variable_info", var, dc);
@@ -246,7 +246,7 @@ protected:
 		}
 
 		if (String(p_name) == "hint") {
-			Dictionary dc = d.duplicate();
+			Dictionary dc = d.copy();
 			dc["hint"] = p_value;
 			undo_redo->create_action(TTR("Set Variable Type"));
 			undo_redo->add_do_method(script.ptr(), "set_variable_info", var, dc);
@@ -258,7 +258,7 @@ protected:
 		}
 
 		if (String(p_name) == "hint_string") {
-			Dictionary dc = d.duplicate();
+			Dictionary dc = d.copy();
 			dc["hint_string"] = p_value;
 			undo_redo->create_action(TTR("Set Variable Type"));
 			undo_redo->add_do_method(script.ptr(), "set_variable_info", var, dc);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2100,7 +2100,7 @@ Node *Node::_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap) const
 				continue;
 			}
 
-			Variant value = N->get()->get(name).duplicate(true);
+			Variant value = N->get()->get(name).copy(true);
 
 			if (E->get().usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE) {
 				Resource *res = Object::cast_to<Resource>(value);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -242,7 +242,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 								}
 							}
 						} else if (p_edit_state == GEN_EDIT_STATE_INSTANCE) {
-							value = value.duplicate(true); // Duplicate arrays and dictionaries for the editor
+							value = value.copy(true); // Copy arrays and dictionaries for the editor
 						}
 						node->set(snames[nprops[j].name], value, &valid);
 					}


### PR DESCRIPTION
Does the same internally for `Vector<>`, which includes all `PackedArray` types.

Part of #16863.

Note: The [original suggestion](https://github.com/godotengine/godot/issues/16863#issuecomment-441376010) suggested either `copy()` or `clone()` and #16863 actually suggests `clone()`, but all the documentation uses the work "copy" in the descriptions; so I think it makes more sense to use `copy()`.
