### PR TITLE
Rename Sprite.region_enabled getter and setter methods to match properties

### DIFF
--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -73,10 +73,10 @@
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
 			The texture's drawing offset.
 		</member>
-		<member name="region_enabled" type="bool" setter="set_region" getter="is_region" default="false">
+		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 			If [code]true[/code], texture is cut from a larger atlas texture. See [member region_rect].
 		</member>
-		<member name="region_filter_clip" type="bool" setter="set_region_filter_clip" getter="is_region_filter_clip_enabled" default="false">
+		<member name="region_filter_clip_enabled" type="bool" setter="set_region_filter_clip_enabled" getter="is_region_filter_clip_enabled" default="false">
 			If [code]true[/code], the outermost pixels get blurred out. [member region_enabled] must be [code]true[/code].
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2( 0, 0, 0, 0 )">

--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -20,7 +20,7 @@
 		<member name="hframes" type="int" setter="set_hframes" getter="get_hframes" default="1">
 			The number of columns in the sprite sheet.
 		</member>
-		<member name="region_enabled" type="bool" setter="set_region" getter="is_region" default="false">
+		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 			If [code]true[/code], texture will be cut from a larger atlas texture. See [member region_rect].
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2( 0, 0, 0, 0 )">

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -179,7 +179,7 @@ void Sprite2DEditor::_update_mesh_data() {
 	}
 
 	Rect2 rect;
-	if (node->is_region()) {
+	if (node->is_region_enabled()) {
 		rect = node->get_region_rect();
 	} else {
 		rect.size = Size2(image->get_width(), image->get_height());

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -897,7 +897,7 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		atlas_tex = Ref<AtlasTexture>(nullptr);
 	}
 	edit_draw->update();
-	if ((node_sprite && !node_sprite->is_region()) || (node_sprite_3d && !node_sprite_3d->is_region())) {
+	if ((node_sprite && !node_sprite->is_region_enabled()) || (node_sprite_3d && !node_sprite_3d->is_region_enabled())) {
 		set_process(true);
 	}
 	if (!p_obj) {
@@ -1115,7 +1115,7 @@ void TextureRegionEditorPlugin::_editor_visiblity_changed() {
 void TextureRegionEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		texture_region_button->show();
-		bool is_node_configured = region_editor->is_stylebox() || region_editor->is_atlas_texture() || region_editor->is_ninepatch() || (region_editor->get_sprite() && region_editor->get_sprite()->is_region()) || (region_editor->get_sprite_3d() && region_editor->get_sprite_3d()->is_region());
+		bool is_node_configured = region_editor->is_stylebox() || region_editor->is_atlas_texture() || region_editor->is_ninepatch() || (region_editor->get_sprite() && region_editor->get_sprite()->is_region_enabled()) || (region_editor->get_sprite_3d() && region_editor->get_sprite_3d()->is_region_enabled());
 		if ((is_node_configured && !manually_hidden) || texture_region_button->is_pressed()) {
 			editor->make_bottom_panel_item_visible(region_editor);
 		}

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -80,7 +80,7 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 		Vector2 phys_offset;
 		Size2 s;
 
-		if (mi->is_region()) {
+		if (mi->is_region_enabled()) {
 			s = mi->get_region_rect().size;
 			p_library->tile_set_region(id, mi->get_region_rect());
 		} else {

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -46,16 +46,16 @@ class Sprite2D : public Node2D {
 
 	bool hflip = false;
 	bool vflip = false;
-	bool region = false;
+	bool region_enabled = false;
 	Rect2 region_rect;
-	bool region_filter_clip = false;
+	bool region_filter_clip_enabled = false;
 
 	int frame = 0;
 
 	int vframes = 1;
 	int hframes = 1;
 
-	void _get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_clip) const;
+	void _get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_clip_enabled) const;
 
 	void _texture_changed();
 
@@ -97,10 +97,10 @@ public:
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
 
-	void set_region(bool p_region);
-	bool is_region() const;
+	void set_region_enabled(bool p_enabled);
+	bool is_region_enabled() const;
 
-	void set_region_filter_clip(bool p_enable);
+	void set_region_filter_clip_enabled(bool p_enabled);
 	bool is_region_filter_clip_enabled() const;
 
 	void set_region_rect(const Rect2 &p_region_rect);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -366,7 +366,7 @@ void Sprite3D::_draw() {
 	}
 
 	Rect2 base_rect;
-	if (region) {
+	if (region_enabled) {
 		base_rect = region_rect;
 	} else {
 		base_rect = Rect2(0, 0, texture->get_width(), texture->get_height());
@@ -511,24 +511,24 @@ Ref<Texture2D> Sprite3D::get_texture() const {
 	return texture;
 }
 
-void Sprite3D::set_region(bool p_region) {
-	if (p_region == region) {
+void Sprite3D::set_region_enabled(bool p_region_enabled) {
+	if (p_region_enabled == region_enabled) {
 		return;
 	}
 
-	region = p_region;
+	region_enabled = p_region_enabled;
 	_queue_update();
 	notify_property_list_changed();
 }
 
-bool Sprite3D::is_region() const {
-	return region;
+bool Sprite3D::is_region_enabled() const {
+	return region_enabled;
 }
 
 void Sprite3D::set_region_rect(const Rect2 &p_region_rect) {
 	bool changed = region_rect != p_region_rect;
 	region_rect = p_region_rect;
-	if (region && changed) {
+	if (region_enabled && changed) {
 		_queue_update();
 	}
 }
@@ -595,7 +595,7 @@ Rect2 Sprite3D::get_item_rect() const {
 
 	Size2i s;
 
-	if (region) {
+	if (region_enabled) {
 		s = region_rect.size;
 	} else {
 		s = texture->get_size();
@@ -625,7 +625,7 @@ void Sprite3D::_validate_property(PropertyInfo &property) const {
 		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
 
-	if (!region && property.name == "region_rect") {
+	if (!region_enabled && property.name == "region_rect") {
 		property.usage = PROPERTY_USAGE_NOEDITOR;
 	}
 }
@@ -634,8 +634,8 @@ void Sprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &Sprite3D::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture"), &Sprite3D::get_texture);
 
-	ClassDB::bind_method(D_METHOD("set_region", "enabled"), &Sprite3D::set_region);
-	ClassDB::bind_method(D_METHOD("is_region"), &Sprite3D::is_region);
+	ClassDB::bind_method(D_METHOD("set_region_enabled", "enabled"), &Sprite3D::set_region_enabled);
+	ClassDB::bind_method(D_METHOD("is_region_enabled"), &Sprite3D::is_region_enabled);
 
 	ClassDB::bind_method(D_METHOD("set_region_rect", "rect"), &Sprite3D::set_region_rect);
 	ClassDB::bind_method(D_METHOD("get_region_rect"), &Sprite3D::get_region_rect);
@@ -659,14 +659,14 @@ void Sprite3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frame"), "set_frame", "get_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "frame_coords", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_frame_coords", "get_frame_coords");
 	ADD_GROUP("Region", "region_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "region_enabled"), "set_region", "is_region");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "region_enabled"), "set_region_enabled", "is_region_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "region_rect"), "set_region_rect", "get_region_rect");
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 }
 
 Sprite3D::Sprite3D() {
-	region = false;
+	region_enabled = false;
 	frame = 0;
 	vframes = 1;
 	hframes = 1;

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -107,8 +107,8 @@ public:
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
 
-	void set_region(bool p_region);
-	bool is_region() const;
+	void set_region_enabled(bool p_region_enabled);
+	bool is_region_enabled() const;
 
 	void set_region_rect(const Rect2 &p_region_rect);
 	Rect2 get_region_rect() const;
@@ -147,7 +147,7 @@ class Sprite3D : public SpriteBase3D {
 	GDCLASS(Sprite3D, SpriteBase3D);
 	Ref<Texture2D> texture;
 
-	bool region;
+	bool region_enabled;
 	Rect2 region_rect;
 
 	int frame;
@@ -167,8 +167,8 @@ public:
 	void set_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture() const;
 
-	void set_region(bool p_region);
-	bool is_region() const;
+	void set_region_enabled(bool p_region_enabled);
+	bool is_region_enabled() const;
 
 	void set_region_rect(const Rect2 &p_region_rect);
 	Rect2 get_region_rect() const;


### PR DESCRIPTION
Also renames `region_filter_clip` property and its setter to `region_filter_clip_enabled` and `set_region_filter_clip_enabled`.

Part of #16863.