### PR TITLE
Add an editor actions API

### DIFF
--- a/core/callable.cpp
+++ b/core/callable.cpp
@@ -58,7 +58,8 @@ Callable Callable::bind(const Variant **p_arguments, int p_argcount) const {
 	Vector<Variant> args;
 	args.resize(p_argcount);
 	for (int i = 0; i < p_argcount; i++) {
-		args.write[i] = *p_arguments[i];
+		auto ptr = p_arguments[i]; 
+		args.write[i] = *ptr;
 	}
 	return Callable(memnew(CallableCustomBind(*this, args)));
 }

--- a/editor/editor_actions.cpp
+++ b/editor/editor_actions.cpp
@@ -1,0 +1,173 @@
+/*************************************************************************/
+/*  editor_actions.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor/editor_actions.h"
+
+void EditorActions::add_action(StringName p_name, const Callable &p_callable) {
+	ERR_FAIL_COND_MSG(callables.has(p_name), "The EditorAction '" + String(p_name) + "' already exists. Unable to add it.");
+	callables[p_name] = p_callable;
+}
+
+void EditorActions::add_action_obj(StringName p_name, const Object *p_object, const StringName &p_method) {
+	ERR_FAIL_COND_MSG(callables.has(p_name), "The EditorAction '" + String(p_name) + "' already exists. Unable to add it.");
+	callables[p_name] = Callable(p_object, p_method);
+}
+
+void EditorActions::remove_action(StringName p_name) {
+	ERR_FAIL_COND_MSG(!callables.has(p_name), "The EditorAction '" + String(p_name) + "' does not exist. Unable to remove it.");
+	callables.erase(p_name);
+}
+
+void EditorActions::get_action_list(List<StringName> *p_list) const {
+	//callables.get_key_list(p_list);
+}
+
+Callable EditorActions::get_action(StringName p_name) {
+	ERR_FAIL_COND_V_MSG(!callables.has(p_name), Callable(), "The EditorAction '" + String(p_name) + "' does not exist. Unable to get it.");
+	return callables[p_name];
+}
+
+void EditorActions::add_on_action_executing(StringName p_name, const Callable &p_callable, Array params) {
+	ERR_FAIL_COND_MSG(callables_on_executing.has(p_name), "Callback for '" + String(p_name) + "' already exists. Unable to add it.");
+	callables_on_executing[p_name].push_back(Pair<Callable, Array>(p_callable, params));
+}
+
+void EditorActions::add_on_action_executed(StringName p_name, const Callable &p_callable, Array params) {
+	ERR_FAIL_COND_MSG(callables_on_executed.has(p_name), "Callback for '" + String(p_name) + "' already exists. Unable to add it.");
+	print_line(p_name);
+	callables_on_executed[p_name].push_back(Pair<Callable, Array>(p_callable, params));
+}
+
+void EditorActions::execute_action(StringName action_name, const Variant **params, int p_argcount) {
+	ERR_FAIL_COND_MSG(!callables.has(action_name), "Execute action " + String(action_name) + " not found");
+	if (callables_on_executing.has(action_name)) {
+		for (List<Pair<Callable, Array>>::Element *E = callables_on_executing[action_name].front(); E; E = E->next()) {
+			Array &c_params = E->get().second;
+			Vector<Variant> v_arr;
+			for (int i = 0; i < c_params.size(); i++) {
+				v_arr.push_back(c_params[i]);
+			}
+			for (int i = 0; i < p_argcount; i++) {
+				v_arr.push_back(*params[i]);
+			}
+			const Variant *co_params = v_arr.ptr();
+			E->get().first.call_deferred(&co_params, c_params.size() + p_argcount);
+		}
+	}
+	callables[action_name].call_deferred(params, p_argcount);
+	if (callables_on_executed.has(action_name)) {
+		for (List<Pair<Callable, Array>>::Element *E = callables_on_executed[action_name].front(); E; E = E->next()) {
+			Array &c_params = E->get().second;
+			Vector<Variant> v_arr;
+			for (int i = 0; i < c_params.size(); i++) {
+				v_arr.push_back(c_params[i]);
+			}
+			for (int i = 0; i < p_argcount; i++) {
+				v_arr.push_back(*params[i]);
+			}
+			const Variant *co_params = v_arr.ptr();
+			E->get().first.call_deferred(&co_params, c_params.size() + p_argcount);
+		}
+	}
+}
+
+Variant EditorActions::execute_action_fold(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	const Variant &p_name = *p_args[p_argcount - 1];
+	ERR_FAIL_COND_V_MSG(p_name.get_type() != Variant::STRING_NAME, Variant(), "Execute action failed because name was not StringName");
+	execute_action(p_name, p_args, p_argcount - 1);
+	return Variant();
+}
+
+void EditorActions::_execute_action(StringName action_name, Array params) {
+	Vector<Variant> v_arr;
+	for (int i = 0; i < params.size(); i++) {
+		v_arr.push_back(params[i]);
+	}
+	const Variant *ptr = v_arr.ptr();
+	execute_action(action_name, &ptr, v_arr.size());
+}
+
+Callable EditorActions::get_execute_callable() {
+	return Callable(this, "execute_action_fold");
+}
+
+void EditorActions::clear_execute_cb() {
+	callables_on_executed.clear();
+	callables_on_executing.clear();
+}
+
+Array EditorActions::_get_action_list() const {
+	Array ret;
+	List<StringName> lst;
+	get_action_list(&lst);
+	for (List<StringName>::Element *E = lst.front(); E; E = E->next()) {
+		ret.append(E->get());
+	}
+	return ret;
+}
+
+void EditorActions::_bind_methods() {
+	//ClassDB::bind_method(D_METHOD("add_action", "name", "callable"), &EditorActions::add_action);
+	//ClassDB::bind_method(D_METHOD("add_action_obj", "name", "object", "method"), &EditorActions::add_action_obj);
+	//ClassDB::bind_method(D_METHOD("remove_action", "name"), &EditorActions::remove_action);
+
+	ClassDB::bind_method("get_action_list", &EditorActions::_get_action_list);
+	ClassDB::bind_method(D_METHOD("get_action", "name"), &EditorActions::get_action);
+
+	ClassDB::bind_method(D_METHOD("add_on_action_executing", "name", "callable", "params"), &EditorActions::add_on_action_executing);
+	ClassDB::bind_method(D_METHOD("add_on_action_executed", "name", "callable", "params"), &EditorActions::add_on_action_executed);
+
+	ClassDB::bind_method(D_METHOD("execute_action", "action", "params"), &EditorActions::_execute_action);
+
+	{
+		MethodInfo mi;
+		mi.name = "execute_action_fold";
+		mi.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "name"));
+		mi.arguments.push_back(PropertyInfo(Variant::VARIANT_MAX, "p1"));
+		mi.arguments.push_back(PropertyInfo(Variant::VARIANT_MAX, "p2"));
+		mi.arguments.push_back(PropertyInfo(Variant::VARIANT_MAX, "p3"));
+		mi.arguments.push_back(PropertyInfo(Variant::VARIANT_MAX, "p4"));
+		mi.arguments.push_back(PropertyInfo(Variant::VARIANT_MAX, "p5"));
+
+		Vector<Variant> v_arr;
+		v_arr.push_back("");
+		v_arr.push_back(Variant());
+		v_arr.push_back(Variant());
+		v_arr.push_back(Variant());
+		v_arr.push_back(Variant());
+		v_arr.push_back(Variant());
+
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "execute_action_fold", &EditorActions::execute_action_fold, mi, v_arr, false);
+	}
+
+	ClassDB::bind_method("clear_execute_cb", &EditorActions::clear_execute_cb);
+}
+
+EditorActions::EditorActions() {}

--- a/editor/editor_actions.h
+++ b/editor/editor_actions.h
@@ -1,0 +1,72 @@
+/*************************************************************************/
+/*  editor_actions.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef EDITOR_ACTIONS_H
+#define EDITOR_ACTIONS_H
+
+#include "core/pair.h"
+#include "core/reference.h"
+
+class EditorActions : public Reference {
+	GDCLASS(EditorActions, Reference);
+
+	HashMap<String, Callable> callables;
+
+	HashMap<StringName, List<Pair<Callable, Array>>> callables_on_executing;
+	HashMap<StringName, List<Pair<Callable, Array>>> callables_on_executed;
+
+protected:
+	static void _bind_methods();
+	Array _get_action_list() const;
+
+public:
+	EditorActions();
+
+	void add_action(StringName p_name, const Callable &p_callable);
+	void add_action_obj(StringName p_name, const Object *p_object, const StringName &p_method);
+	void remove_action(StringName p_name);
+
+	void get_action_list(List<StringName> *p_list) const;
+	Callable get_action(StringName p_name);
+
+	void add_on_action_executing(StringName p_name, const Callable &p_callable, Array params);
+	void add_on_action_executed(StringName p_name, const Callable &p_callable, Array params);
+
+	void execute_action(StringName action_name, const Variant **params, int p_argcount);
+	Variant execute_action_fold(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	Callable get_execute_callable();
+
+	void clear_execute_cb();
+
+protected:
+	void _execute_action(StringName action_name, Array params);
+};
+
+#endif EDITOR_ACTIONS_H

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -68,6 +68,7 @@
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/dependency_editor.h"
 #include "editor/editor_about.h"
+#include "editor/editor_actions.h"
 #include "editor/editor_audio_buses.h"
 #include "editor/editor_export.h"
 #include "editor/editor_feature_profile.h"
@@ -3623,6 +3624,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<ScriptCreateDialog>();
 	ClassDB::register_class<EditorFeatureProfile>();
 	ClassDB::register_class<EditorSpinSlider>();
+	ClassDB::register_virtual_class<EditorActions>();
 	ClassDB::register_virtual_class<FileSystemDock>();
 
 	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?
@@ -5515,6 +5517,8 @@ EditorNode::EditorNode() {
 	ResourceLoader::clear_path_remaps();
 
 	Input *id = Input::get_singleton();
+
+	editor_actions.instance();
 
 	if (id) {
 		bool found_touchscreen = false;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -31,6 +31,7 @@
 #ifndef EDITOR_NODE_H
 #define EDITOR_NODE_H
 
+#include "editor/editor_actions.h"
 #include "editor/editor_data.h"
 #include "editor/editor_export.h"
 #include "editor/editor_folding.h"
@@ -52,6 +53,7 @@ class Control;
 class DependencyEditor;
 class DependencyErrorDialog;
 class EditorAbout;
+class EditorActions;
 class EditorExport;
 class EditorFeatureProfileManager;
 class EditorFileServer;
@@ -432,6 +434,8 @@ private:
 	List<String> previous_scenes;
 	bool opening_prev;
 
+	Ref<EditorActions> editor_actions;
+
 	void _dialog_action(String p_file);
 
 	void _edit_current();
@@ -764,6 +768,8 @@ public:
 	static UndoRedo *get_undo_redo() { return &singleton->editor_data.get_undo_redo(); }
 
 	EditorSelection *get_editor_selection() { return editor_selection; }
+
+	static Ref<EditorActions> &get_actions() { return singleton->editor_actions; }
 
 	void set_convert_old_scene(bool p_old) { convert_old = p_old; }
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -222,6 +222,10 @@ ScriptEditor *EditorInterface::get_script_editor() {
 	return ScriptEditor::get_singleton();
 }
 
+Ref<EditorActions> EditorInterface::get_editor_actions() {
+	return EditorNode::get_actions();
+}
+
 void EditorInterface::select_file(const String &p_file) {
 	EditorNode::get_singleton()->get_filesystem_dock()->select_file(p_file);
 }
@@ -320,6 +324,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
 	ClassDB::bind_method(D_METHOD("get_resource_filesystem"), &EditorInterface::get_resource_file_system);
 	ClassDB::bind_method(D_METHOD("get_editor_viewport"), &EditorInterface::get_editor_viewport);
+	ClassDB::bind_method(D_METHOD("get_editor_actions"), &EditorInterface::get_editor_actions);
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 	ClassDB::bind_method(D_METHOD("select_file", "file"), &EditorInterface::select_file);
 	ClassDB::bind_method(D_METHOD("get_selected_path"), &EditorInterface::get_selected_path);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -34,6 +34,7 @@
 #include "core/io/config_file.h"
 #include "core/undo_redo.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/editor_actions.h"
 #include "editor/editor_inspector.h"
 #include "editor/editor_translation_parser.h"
 #include "editor/import/editor_import_plugin.h"
@@ -56,6 +57,7 @@ class EditorFileSystem;
 class EditorToolAddons;
 class FileSystemDock;
 class ScriptEditor;
+class EditorActions;
 
 class EditorInterface : public Node {
 	GDCLASS(EditorInterface, Node);
@@ -84,6 +86,8 @@ public:
 	Node *get_edited_scene_root();
 	Array get_open_scenes() const;
 	ScriptEditor *get_script_editor();
+
+	Ref<EditorActions> get_editor_actions();
 
 	void select_file(const String &p_file);
 	String get_selected_path() const;

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1169,11 +1169,19 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 		tree->connect("empty_tree_rmb_selected", callable_mp(this, &SceneTreeEditor::_rmb_select));
 	}
 
+	//EditorNode::get_actions()->add_action("SceneTreeEditor/_selected_changed", callable_mp(this, &SceneTreeEditor::_selected_changed));
+	//tree->connect("cell_selected", EditorNode::get_actions()->get_execute_callable(), varray("SceneTreeEditor/_selected_changed", Array()));
 	tree->connect("cell_selected", callable_mp(this, &SceneTreeEditor::_selected_changed));
 	tree->connect("item_edited", callable_mp(this, &SceneTreeEditor::_renamed), varray(), CONNECT_DEFERRED);
 	tree->connect("multi_selected", callable_mp(this, &SceneTreeEditor::_cell_multi_selected));
-	tree->connect("button_pressed", callable_mp(this, &SceneTreeEditor::_cell_button_pressed));
-	tree->connect("nothing_selected", callable_mp(this, &SceneTreeEditor::_deselect_items));
+
+	//tree->connect("button_pressed", callable_mp(this, &SceneTreeEditor::_cell_button_pressed));
+	EditorNode::get_actions()->add_action("scene_tree_editor/button_pressed", callable_mp(this, &SceneTreeEditor::_cell_button_pressed));
+	tree->connect("button_pressed", EditorNode::get_actions()->get_execute_callable(), varray(StringName ("scene_tree_editor/button_pressed")));
+
+	EditorNode::get_actions()->add_action("scene_tree_editor/nothing_selected", callable_mp(this, &SceneTreeEditor::_deselect_items));
+	tree->connect("nothing_selected", EditorNode::get_actions()->get_execute_callable(), varray(StringName("scene_tree_editor/nothing_selected")));
+
 	//tree->connect("item_edited", this,"_renamed",Vector<Variant>(),true);
 
 	error = memnew(AcceptDialog);


### PR DESCRIPTION
Closes [#70](https://github.com/godotengine/godot-proposals/issues/70)
Related to [#1444](https://github.com/godotengine/godot-proposals/issues/1444)
---
This PR adds a class that can control the editor from plugins or from the engine itself with a simplified API.
For each interaction in the editor, an entry in the API can be created, and for each execution of this action, user-stored callbacks can be triggered.

As an example, if I wanted to toggle the visibility of a node:

![image](https://user-images.githubusercontent.com/38469823/111071575-70349600-84df-11eb-8f0e-8fbb2fcf6e49.png)

The code that does this is in [scene_tree_editor.cpp](https://github.com/firststef/godot/blob/d3ac102c2ce58a907958c86529d23763fd3f025b/editor/scene_tree_editor.cpp#L1180):

![image](https://user-images.githubusercontent.com/38469823/111071597-92c6af00-84df-11eb-8fc9-29e18e5c2ab2.png)

Now if we want to react to the action of pressing the hide button, a good way to do this would be by making editor actions listen to the signal for this function and execute its callbacks and the function itself:

![image](https://user-images.githubusercontent.com/38469823/111071688-fa7cfa00-84df-11eb-8773-67607f591e08.png)

The EditorActions class enables you to bind StringNames to Callables as an "EditorAction". It also allows users to bind methods to be executed before or after each EditorAction using the `add_on_action_executing` and `add_on_action_executed` methods respectively. These EditorActions are accessible to both C++ Editor code and scripted tools with access to the EditorInterface.

To illustrate how could someone use the API from a plugin, for example for making a history plugin for activated actions, I have created a project [here](https://github.com/firststef/GodotEditorHistoryPlugin).

![image](https://user-images.githubusercontent.com/38469823/111071991-52683080-84e1-11eb-9eca-5c0bbac5bb47.png)

![image](https://user-images.githubusercontent.com/38469823/111072241-5cd6fa00-84e2-11eb-9d65-81917db540c4.png)

Features:
1. Ability to add/remove callbacks to new/existing actions.
2. Ability to add/remove callbacks that execute before or after an existing action.
3. Ability to access the API both from inside the C++ engine and from the scripting API.
4. Ability to bind N number of arguments to methods bound to the EditorActions API.

TODOs:
- it would be useful to add a description and tag for every action
- also we should consider having submitted executing/executed bindings include a priority integer value that defaults to 0. And on update they are sorted by priority.
---
I have to mention that this was based on the work of @willnationsdev.

Unfortunately I won't have much time due to strict schedule until August of this year, so someone else, if interested, should continue this work. We are currently discussing with @Bhu1-V if he will be able to use this for his command pallette functionality ([#1444](https://github.com/godotengine/godot-proposals/issues/1444)) but nothing is set in stone, he might not choose this way of implementing.