### PR TITLE
Move Add Track buttons direclty to Timeline

### DIFF
--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -63,7 +63,16 @@ class AnimationTimelineEdit : public Range {
 	Button *loop;
 	TextureRect *time_icon;
 
-	MenuButton *add_track;
+	HBoxContainer *track_buttons_hb;
+	Button *property_track_button;
+	Button *transform_track_button;
+	Button *method_track_button;
+	Button *curve_track_button;
+	Button *audio_track_button;
+	Button *animation_track_button;
+
+	Button *_create_track_button(const String &p_title, int p_index);
+
 	Control *play_position; //separate control used to draw so updates for only position changed are much faster
 	HScrollBar *hscroll;
 


### PR DESCRIPTION
That's my follow-up to https://github.com/godotengine/godot/pull/46938

Adding multiple animation tracks can be cumbersome, if we always repeat the same, unnecessary steps.
What I've found (and probably - the others too) tedious - is requirement to always click on "Add Track" button to reveal types of tracks to choose.

What this PR brings - is Quality Of Life improvement - moving aforementioned track types buttons, directly to Timeline, very easily accesible out-of-the box, reducing amount of redundant clicks dramatically :)

(please, do not attach to whashed-up colors in the second GIF, my recording tool seems to be a bit wonky)

Old behavior:

![old](https://user-images.githubusercontent.com/1110337/111081356-37a6b380-8503-11eb-9a3b-d5f8dd800e88.gif)

New behavior:

![new](https://user-images.githubusercontent.com/1110337/111081363-3d03fe00-8503-11eb-8be4-4e3aad22044d.gif)
