### PR TITLE
Fix stale tab names in TabContainer

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1023,6 +1023,7 @@ void TabContainer::set_tab_title(int p_tab, const String &p_title) {
 	Control *child = _get_tab(p_tab);
 	ERR_FAIL_COND(!child);
 	child->set_meta("_tab_name", p_title);
+	_refresh_texts();
 	update();
 }
 


### PR DESCRIPTION
Currently, setting a custom name to a tab in `TabContainer` doesn't refresh text buffers for tab titles, however size calculations respect the new titles. This results in tabs having the correct size, but wrong text in them. Not sure if this is showing anywhere currently, but I have run into it working on the editor UI.

Somewhat similar to #44328.
