### PR TITLE
Improve documentation for AtlasTexture

### DIFF
--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AtlasTexture" inherits="Texture2D" version="4.0">
 	<brief_description>
-		Packs multiple small textures in a single, bigger one. Helps to optimize video memory costs and render calls.
+		Crops out one part of a texture, such as a texture from a texture atlas.
 	</brief_description>
 	<description>
-		[Texture2D] resource aimed at managing big textures files that pack multiple smaller textures. Consists of a [Texture2D], a margin that defines the border width, and a region that defines the actual area of the AtlasTexture.
+		[Texture2D] resource that crops out one part of the [member atlas] texture, defined by [member region]. The main use case is cropping out textures from a texture atlas, which is a big texture file that packs multiple smaller textures. Consists of a [Texture2D] for the [member atlas], a [member region] that defines the area of [member atlas] to use, and a [member margin] that defines the border width.
+		[AtlasTexture] cannot be used in an [AnimatedTexture], cannot be tiled in nodes such as [TextureRect], and does not work properly if used inside of other [AtlasTexture] resources. Multiple [AtlasTexture] resources can be used to crop multiple textures from the atlas. Using a texture atlas helps to optimize video memory costs and render calls compared to using multiple small files.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
The existing brief description was "Packs multiple small textures in a single, bigger one". However, this is a description of a texture atlas, not AtlasTexture. The AtlasTexture resource is for using texture atlases, not making them, so AtlasTexture actually does the opposite - it *un*packs textures by cropping the image to just one of them. Marking this as bug because it's incorrect.

For the long description, the first line describes how AtlasTexture works, and the second line describes what it can't be used for and how and why use it. The note about the limitation that it doesn't support repetition was added in the 3.2 branch in #43278 but @Calinou forgot to add this to the master branch.

These improvements can be cherry-picked to 3.2, but the line added in #43278 should be kept (maybe needs rewording/reorganizing to fit better since this PR also includes a list of limitations), only in 3.2 because these flags are not in master.