### PR TITLE
C#: Fix disconnecting event signals twice

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2018,22 +2018,20 @@ void CSharpInstance::connect_event_signals() {
 		// TODO: Use pooling for ManagedCallable instances.
 		auto event_signal_callable = memnew(EventSignalCallable(owner, &event_signal));
 
-		owner->connect(signal_name, Callable(event_signal_callable));
+		Callable callable(event_signal_callable);
+		connected_event_signals.push_back(callable);
+		owner->connect(signal_name, callable);
 	}
 }
 
 void CSharpInstance::disconnect_event_signals() {
-	for (const Map<StringName, CSharpScript::EventSignal>::Element *E = script->event_signals.front(); E; E = E->next()) {
-		const CSharpScript::EventSignal &event_signal = E->value();
-
-		StringName signal_name = event_signal.field->get_name();
-
-		// TODO: It would be great if we could store this EventSignalCallable on the stack.
-		// The problem is that Callable memdeletes it when it's destructed...
-		auto event_signal_callable = memnew(EventSignalCallable(owner, &event_signal));
-
-		owner->disconnect(signal_name, Callable(event_signal_callable));
+	for (const List<Callable>::Element *E = connected_event_signals.front(); E; E = E->next()) {
+		const Callable &callable = E->get();
+		auto event_signal_callable = static_cast<const EventSignalCallable *>(callable.get_custom());
+		owner->disconnect(event_signal_callable->get_signal(), callable);
 	}
+
+	connected_event_signals.clear();
 }
 
 void CSharpInstance::refcount_incremented() {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -271,6 +271,8 @@ class CSharpInstance : public ScriptInstance {
 	Ref<CSharpScript> script;
 	MonoGCHandleData gchandle;
 
+	List<Callable> connected_event_signals;
+
 	bool _reference_owner_unsafe();
 
 	/*


### PR DESCRIPTION
`disconnect_event_signals` can be called twice (when managed instance
is disposed and from the ScriptInstance destructor).
