### PR TITLE
Fix AnimationTree editor crash when renaming node

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -139,7 +139,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			name->set_expand_to_text_length(true);
 			node->add_child(name);
 			node->set_slot(0, false, 0, Color(), true, 0, get_theme_color("font_color", "Label"));
-			name->connect("text_entered", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed), varray(agnode));
+			name->connect("text_entered", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed), varray(agnode), CONNECT_DEFERRED);
 			name->connect("focus_exited", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed_focus_out), varray(name, agnode), CONNECT_DEFERRED);
 			base = 1;
 			node->set_show_close_button(true);


### PR DESCRIPTION
Before this PR, Godot crashes when renaming a node in AnimationNodeBlendTree editor.

This is caused by freeing the `LineEdit` itself inside the handling of its `text_entered` signal. Connecting the signal with `CONNECT_DEFERRED` flag resolves the crash.

To reproduce the crash:

1. Add an `AnimationTree` node
2. Create an `AnimationNodeBlendTree` as tree root
3. In the graph, add a Transition node
4. Rename the node, hit enter.

The editor crashes immediately if compiled with AddressSanitizer (`use_asan=yes`). Without the sanitizer, renaming the node crashes the editor occasionally.

Tested on 3.2 (48708b8e3d) & master (6eef187a81).

<details>
<summary>3.2 Crash Dump</summary>

```
ERROR: ~Object: Object [Object:19814] was freed or unreferenced while a signal is being emitted from it. Try connecting to the signal using 'CONNECT_DEFERRED' flag, or use queue_free() to free the object (if this object is a Node) to avoid this error and potential crashes.
   At: core/object.cpp:2014.
=================================================================
==21935==ERROR: AddressSanitizer: heap-use-after-free on address 0x61a0000e5ee9 at pc 0x0001226fb73d bp 0x7ffee28668b0 sp 0x7ffee28668a8
WRITE of size 1 at 0x61a0000e5ee9 thread T0
    #0 0x1226fb73c in Object::emit_signal(StringName const&, Variant const**, int) object.cpp:1247
    #1 0x1226f2f97 in Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:1303
    #2 0x11c970505 in LineEdit::_gui_input(Ref<InputEvent>) line_edit.cpp:320
    #3 0x11c420eef in MethodBind1<Ref<InputEvent> >::call(Object*, Variant const**, int, Variant::CallError&) method_bind.gen.inc:775
    #4 0x1226e97de in Object::call_multilevel(StringName const&, Variant const**, int) object.cpp:761
    #5 0x1226edfd9 in Object::call_multilevel(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:861
    #6 0x11c2f0392 in Viewport::_gui_input_event(Ref<InputEvent>) viewport.cpp:2484
    #7 0x11c2c5679 in Viewport::input(Ref<InputEvent> const&) viewport.cpp:2923
    #8 0x11c2c4cbf in Viewport::_vp_input(Ref<InputEvent> const&) viewport.cpp:1481
    #9 0x122e377d3 in MethodBind1<Ref<InputEvent> const&>::call(Object*, Variant const**, int, Variant::CallError&) method_bind.gen.inc:775
    #10 0x1226ef6c7 in Object::call(StringName const&, Variant const**, int, Variant::CallError&) object.cpp:919
    #11 0x1226ed836 in Object::call(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:845
    #12 0x11c1643d6 in SceneTree::call_group_flags(unsigned int, StringName const&, StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) scene_tree.cpp:276
    #13 0x11c16b2f2 in SceneTree::input_event(Ref<InputEvent> const&) scene_tree.cpp:432
    #14 0x10d49a2bf in InputDefault::_parse_input_event_impl(Ref<InputEvent> const&, bool) input_default.cpp:455
    #15 0x10d48f1ad in InputDefault::parse_input_event(Ref<InputEvent> const&) input_default.cpp:272
    #16 0x10d4aafff in InputDefault::flush_accumulated_events() input_default.cpp:691
    #17 0x10d400bd6 in OS_OSX::process_events() os_osx.mm:3178
    #18 0x10d40666b in OS_OSX::run() os_osx.mm:3269
    #19 0x10d45b6e5 in main godot_main_osx.mm:71
    #20 0x7fff204bc620 in start+0x0 (libdyld.dylib:x86_64+0x15620)

0x61a0000e5ee9 is located 105 bytes inside of 1280-byte region [0x61a0000e5e80,0x61a0000e6380)
freed by thread T0 here:
    #0 0x1367b42c6 in wrap_free+0xa6 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x492c6)
    #1 0x122f0f04c in Memory::free_static(void*, bool) memory.cpp:178
    #2 0x118f37722 in void memdelete<Node>(Node*) memory.h:119
    #3 0x11c000c09 in Node::_notification(int) node.cpp:175
    #4 0x11bed501e in Node::_notificationv(int, bool) node.h:46
    #5 0x11bed4c37 in CanvasItem::_notificationv(int, bool) canvas_item.h:166
    #6 0x11bed4707 in Control::_notificationv(int, bool) control.h:48
    #7 0x11bef2d27 in Container::_notificationv(int, bool) container.h:38
    #8 0x11c85b0b7 in GraphNode::_notificationv(int, bool) graph_node.h:38
    #9 0x1226dbf8c in Object::notification(int, bool) object.cpp:929
    #10 0x1226dbb74 in Object::_predelete() object.cpp:387
    #11 0x12272c9e2 in predelete_handler(Object*) object.cpp:2055
    #12 0x118f375bd in void memdelete<Node>(Node*) memory.h:114
    #13 0x11a735775 in AnimationNodeBlendTreeEditor::_update_graph() animation_blend_tree_editor_plugin.cpp:120
    #14 0x11a777f70 in AnimationNodeBlendTreeEditor::_node_renamed(String const&, Ref<AnimationNode>) animation_blend_tree_editor_plugin.cpp:902
    #15 0x11a7a59fa in MethodBind2<String const&, Ref<AnimationNode> >::call(Object*, Variant const**, int, Variant::CallError&) method_bind.gen.inc:1523
    #16 0x1226ef6c7 in Object::call(StringName const&, Variant const**, int, Variant::CallError&) object.cpp:919
    #17 0x1226fb642 in Object::emit_signal(StringName const&, Variant const**, int) object.cpp:1246
    #18 0x1226f2f97 in Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:1303
    #19 0x11c970505 in LineEdit::_gui_input(Ref<InputEvent>) line_edit.cpp:320
    #20 0x11c420eef in MethodBind1<Ref<InputEvent> >::call(Object*, Variant const**, int, Variant::CallError&) method_bind.gen.inc:775
    #21 0x1226e97de in Object::call_multilevel(StringName const&, Variant const**, int) object.cpp:761
    #22 0x1226edfd9 in Object::call_multilevel(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:861
    #23 0x11c2f0392 in Viewport::_gui_input_event(Ref<InputEvent>) viewport.cpp:2484
    #24 0x11c2c5679 in Viewport::input(Ref<InputEvent> const&) viewport.cpp:2923
    #25 0x11c2c4cbf in Viewport::_vp_input(Ref<InputEvent> const&) viewport.cpp:1481
    #26 0x122e377d3 in MethodBind1<Ref<InputEvent> const&>::call(Object*, Variant const**, int, Variant::CallError&) method_bind.gen.inc:775
    #27 0x1226ef6c7 in Object::call(StringName const&, Variant const**, int, Variant::CallError&) object.cpp:919
    #28 0x1226ed836 in Object::call(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:845
    #29 0x11c1643d6 in SceneTree::call_group_flags(unsigned int, StringName const&, StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) scene_tree.cpp:276

previously allocated by thread T0 here:
    #0 0x1367b417d in wrap_malloc+0x9d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4917d)
    #1 0x122f0da51 in Memory::alloc_static(unsigned long, bool) memory.cpp:82
    #2 0x122f0d8c4 in operator new(unsigned long, char const*) memory.cpp:42
    #3 0x11a736d63 in AnimationNodeBlendTreeEditor::_update_graph() animation_blend_tree_editor_plugin.cpp:144
    #4 0x11a77bf52 in AnimationNodeBlendTreeEditor::edit(Ref<AnimationNode> const&) animation_blend_tree_editor_plugin.cpp:927
    #5 0x11a8fd1d1 in AnimationTreeEditor::edit_path(Vector<String> const&) animation_tree_editor_plugin.cpp:123
    #6 0x11a901b4b in AnimationTreeEditor::_notification(int) animation_tree_editor_plugin.cpp:160
    #7 0x11a90e26e in AnimationTreeEditor::_notificationv(int, bool) animation_tree_editor_plugin.h:53
    #8 0x1226dbf8c in Object::notification(int, bool) object.cpp:929
    #9 0x11c17027f in SceneTree::_notify_group_pause(StringName const&, int) scene_tree.cpp:992
    #10 0x11c1729fa in SceneTree::idle(float) scene_tree.cpp:529
    #11 0x10d566a48 in Main::iteration() main.cpp:2117
    #12 0x10d406785 in OS_OSX::run() os_osx.mm:3272
    #13 0x10d45b6e5 in main godot_main_osx.mm:71
    #14 0x7fff204bc620 in start+0x0 (libdyld.dylib:x86_64+0x15620)

SUMMARY: AddressSanitizer: heap-use-after-free object.cpp:1247 in Object::emit_signal(StringName const&, Variant const**, int)
Shadow bytes around the buggy address:
  0x1c340001cb80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c340001cb90: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c340001cba0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c340001cbb0: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa fa
  0x1c340001cbc0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x1c340001cbd0: fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd fd
  0x1c340001cbe0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c340001cbf0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c340001cc00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c340001cc10: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c340001cc20: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==21935==ABORTING
Abort trap: 6
```

</details>

<details>
<summary>4.0 Crash Dump</summary>

```
ERROR: Object [Object:2612531379697] was freed or unreferenced while a signal is being emitted from it. Try connecting to the signal using 'CONNECT_DEFERRED' flag, or use queue_free() to free the object (if this object is a Node) to avoid this error and potential crashes.
   at: ~Object (core/object/object.cpp:1777)
=================================================================
==24584==ERROR: AddressSanitizer: heap-use-after-free on address 0x61a001046ac9 at pc 0x00012495e828 bp 0x7ffee1a34590 sp 0x7ffee1a34588
WRITE of size 1 at 0x61a001046ac9 thread T0
    #0 0x12495e827 in Object::emit_signal(StringName const&, Variant const**, int) object.cpp:1045
    #1 0x124956527 in Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:1099
    #2 0x11b7040d7 in LineEdit::_gui_input(Ref<InputEvent>) line_edit.cpp:358
    #3 0x11b0b0d7b in void call_with_variant_args_helper<__UnexistingClass, Ref<InputEvent>, 0ul>(__UnexistingClass*, void (__UnexistingClass::*)(Ref<InputEvent>), Variant const**, Callable::CallError&, IndexSequence<0ul>) binder_common.h:197
    #4 0x11b0b0842 in void call_with_variant_args_dv<__UnexistingClass, Ref<InputEvent> >(__UnexistingClass*, void (__UnexistingClass::*)(Ref<InputEvent>), Variant const**, int, Callable::CallError&, Vector<Variant> const&) binder_common.h:314
    #5 0x11b0ae5d8 in MethodBindT<Ref<InputEvent> >::call(Object*, Variant const**, int, Callable::CallError&) method_bind.h:282
    #6 0x124953c77 in Object::call(StringName const&, Variant const**, int, Callable::CallError&) object.cpp:784
    #7 0x124952542 in Object::call(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:728
    #8 0x11ae2842b in Viewport::_gui_input_event(Ref<InputEvent>) viewport.cpp:2379
    #9 0x11ae4e4fe in Viewport::input(Ref<InputEvent> const&, bool) viewport.cpp:3062
    #10 0x11afa268e in Window::_window_input(Ref<InputEvent> const&) window.cpp:910
    #11 0x11aff73cb in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) binder_common.h:197
    #12 0x11aff6e7a in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) binder_common.h:281
    #13 0x11aff6664 in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const callable_method_pointer.h:97
    #14 0x1238f6d3a in Callable::call(Variant const**, int, Variant&, Callable::CallError&) const callable.cpp:50
    #15 0x10e28bb00 in DisplayServerOSX::_dispatch_input_event(Ref<InputEvent> const&) display_server_osx.mm:3693
    #16 0x10e28a9c4 in DisplayServerOSX::_dispatch_input_events(Ref<InputEvent> const&) display_server_osx.mm:3672
    #17 0x1237066e1 in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) input.cpp:642
    #18 0x1236f49e8 in Input::parse_input_event(Ref<InputEvent> const&) input.cpp:464
    #19 0x12370fd04 in Input::flush_accumulated_events() input.cpp:857
    #20 0x10e27e079 in DisplayServerOSX::process_events() display_server_osx.mm:3428
    #21 0x10e1d0c21 in OS_OSX::run() os_osx.mm:321
    #22 0x10e307ec6 in main godot_main_osx.mm:79
    #23 0x7fff204bc620 in start+0x0 (libdyld.dylib:x86_64+0x15620)

0x61a001046ac9 is located 73 bytes inside of 1320-byte region [0x61a001046a80,0x61a001046fa8)
freed by thread T0 here:
    #0 0x1402772c6 in wrap_free+0xa6 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x492c6)
    #1 0x122bc5dc1 in Memory::free_static(void*, bool) memory.cpp:169
    #2 0x116f1b9b2 in void memdelete<Node>(Node*) memory.h:118
    #3 0x11ab64ab0 in Node::_notification(int) node.cpp:169
    #4 0x11a8bdf4e in Node::_notificationv(int, bool) node.h:45
    #5 0x11a8bdb67 in CanvasItem::_notificationv(int, bool) canvas_item.h:164
    #6 0x11a8bd637 in Control::_notificationv(int, bool) control.h:47
    #7 0x11a8de147 in Container::_notificationv(int, bool) container.h:37
    #8 0x11b5a5587 in GraphNode::_notificationv(int, bool) graph_node.h:38
    #9 0x12494396c in Object::notification(int, bool) object.cpp:793
    #10 0x124943554 in Object::_predelete() object.cpp:354
    #11 0x12498f432 in predelete_handler(Object*) object.cpp:1814
    #12 0x116f1b84d in void memdelete<Node>(Node*) memory.h:111
    #13 0x118bbbac1 in AnimationNodeBlendTreeEditor::_update_graph() animation_blend_tree_editor_plugin.cpp:114
    #14 0x118bd082a in AnimationNodeBlendTreeEditor::_node_renamed(String const&, Ref<AnimationNode>) animation_blend_tree_editor_plugin.cpp:850
    #15 0x118c1e7c9 in void call_with_variant_args_helper<AnimationNodeBlendTreeEditor, String const&, Ref<AnimationNode>, 0ul, 1ul>(AnimationNodeBlendTreeEditor*, void (AnimationNodeBlendTreeEditor::*)(String const&, Ref<AnimationNode>), Variant const**, Callable::CallError&, IndexSequence<0ul, 1ul>) binder_common.h:197
    #16 0x118c1e1ca in void call_with_variant_args<AnimationNodeBlendTreeEditor, String const&, Ref<AnimationNode> >(AnimationNodeBlendTreeEditor*, void (AnimationNodeBlendTreeEditor::*)(String const&, Ref<AnimationNode>), Variant const**, int, Callable::CallError&) binder_common.h:281
    #17 0x118c1d3c4 in CallableCustomMethodPointer<AnimationNodeBlendTreeEditor, String const&, Ref<AnimationNode> >::call(Variant const**, int, Variant&, Callable::CallError&) const callable_method_pointer.h:97
    #18 0x1238f6d3a in Callable::call(Variant const**, int, Variant&, Callable::CallError&) const callable.cpp:50
    #19 0x12495e739 in Object::emit_signal(StringName const&, Variant const**, int) object.cpp:1044
    #20 0x124956527 in Object::emit_signal(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:1099
    #21 0x11b7040d7 in LineEdit::_gui_input(Ref<InputEvent>) line_edit.cpp:358
    #22 0x11b0b0d7b in void call_with_variant_args_helper<__UnexistingClass, Ref<InputEvent>, 0ul>(__UnexistingClass*, void (__UnexistingClass::*)(Ref<InputEvent>), Variant const**, Callable::CallError&, IndexSequence<0ul>) binder_common.h:197
    #23 0x11b0b0842 in void call_with_variant_args_dv<__UnexistingClass, Ref<InputEvent> >(__UnexistingClass*, void (__UnexistingClass::*)(Ref<InputEvent>), Variant const**, int, Callable::CallError&, Vector<Variant> const&) binder_common.h:314
    #24 0x11b0ae5d8 in MethodBindT<Ref<InputEvent> >::call(Object*, Variant const**, int, Callable::CallError&) method_bind.h:282
    #25 0x124953c77 in Object::call(StringName const&, Variant const**, int, Callable::CallError&) object.cpp:784
    #26 0x124952542 in Object::call(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) object.cpp:728
    #27 0x11ae2842b in Viewport::_gui_input_event(Ref<InputEvent>) viewport.cpp:2379
    #28 0x11ae4e4fe in Viewport::input(Ref<InputEvent> const&, bool) viewport.cpp:3062
    #29 0x11afa268e in Window::_window_input(Ref<InputEvent> const&) window.cpp:910

previously allocated by thread T0 here:
    #0 0x14027717d in wrap_malloc+0x9d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4917d)
    #1 0x122bc47b1 in Memory::alloc_static(unsigned long, bool) memory.cpp:76
    #2 0x122bc4624 in operator new(unsigned long, char const*) memory.cpp:41
    #3 0x118bbd0af in AnimationNodeBlendTreeEditor::_update_graph() animation_blend_tree_editor_plugin.cpp:137
    #4 0x118c0179e in AnimationNodeBlendTreeEditor::edit(Ref<AnimationNode> const&) animation_blend_tree_editor_plugin.cpp:874
    #5 0x118dc991b in AnimationTreeEditor::edit_path(Vector<String> const&) animation_tree_editor_plugin.cpp:120
    #6 0x118dced3d in AnimationTreeEditor::_notification(int) animation_tree_editor_plugin.cpp:153
    #7 0x118ddaf5e in AnimationTreeEditor::_notificationv(int, bool) animation_tree_editor_plugin.h:52
    #8 0x12494396c in Object::notification(int, bool) object.cpp:793
    #9 0x11acb904f in SceneTree::_notify_group_pause(StringName const&, int) scene_tree.cpp:808
    #10 0x11acbbabb in SceneTree::process(float) scene_tree.cpp:442
    #11 0x10e375b99 in Main::iteration() main.cpp:2489
    #12 0x10e1d0d6e in OS_OSX::run() os_osx.mm:325
    #13 0x10e307ec6 in main godot_main_osx.mm:79
    #14 0x7fff204bc620 in start+0x0 (libdyld.dylib:x86_64+0x15620)

SUMMARY: AddressSanitizer: heap-use-after-free object.cpp:1045 in Object::emit_signal(StringName const&, Variant const**, int)
Shadow bytes around the buggy address:
  0x1c3400208d00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400208d10: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400208d20: fd fd fd fd fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3400208d30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3400208d40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x1c3400208d50: fd fd fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd
  0x1c3400208d60: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400208d70: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400208d80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400208d90: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400208da0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==24584==ABORTING
Abort trap: 6
```

</details>

MRP: [Crash.zip](https://github.com/godotengine/godot/files/6142923/Crash-3.2.zip) (small chance to reproduce using normal build)
