### PR TITLE
[3.3] Fix crash in GLES3 renderer on release builds

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4961,6 +4961,11 @@ bool RasterizerSceneGLES3::free(RID p_rid) {
 
 		LightInstance *light_instance = light_instance_owner.getptr(p_rid);
 
+		// Make sure first_directional_light is invalidated
+		if (p_rid == first_directional_light) {
+			first_directional_light = RID();
+		}
+
 		//remove from shadow atlases..
 		for (Set<RID>::Element *E = light_instance->shadow_atlases.front(); E; E = E->next()) {
 			ShadowAtlas *shadow_atlas = shadow_atlas_owner.get(E->get());


### PR DESCRIPTION
Make sure the `first_directional_light` RID is properly invalidated when freed.

Attempt to fix #46960, but I haven't done any thorough test.
