### PR TITLE
[3.2] Fix uninitialized GridMapEditor::node

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1222,6 +1222,7 @@ void GridMapEditor::_bind_methods() {
 GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 
 	input_action = INPUT_NONE;
+	node = NULL;
 	editor = p_editor;
 	undo_redo = p_editor->get_undo_redo();
 


### PR DESCRIPTION
This PR closes #34178. The issue has already been resolved on master by #43109.

Tested on 3.2 (3ddab1c9d1)