### PR TITLE
[3.2] Fix invalid memory usage when modifying locked image

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1311,8 +1311,8 @@ static void _generate_po2_mipmap(const Component *p_src, Component *p_dst, uint3
 }
 
 void Image::expand_x2_hq2x() {
-
 	ERR_FAIL_COND(!_can_modify(format));
+	ERR_FAIL_COND_MSG(write_lock.ptr(), "Cannot modify image when it is locked.");
 
 	bool used_mipmaps = has_mipmaps();
 	if (used_mipmaps) {
@@ -2915,6 +2915,7 @@ Ref<Image> Image::rgbe_to_srgb() {
 
 void Image::bumpmap_to_normalmap(float bump_scale) {
 	ERR_FAIL_COND(!_can_modify(format));
+	ERR_FAIL_COND_MSG(write_lock.ptr(), "Cannot modify image when it is locked.");
 	convert(Image::FORMAT_RF);
 
 	PoolVector<uint8_t> result_image; //rgba output


### PR DESCRIPTION
This PR fixes #46483.

The crash is caused by a failed `convert()` from `L8` to `RGBA8` due to locking. The resulting input buffer is too small for `hq2x_resize()`.

https://github.com/godotengine/godot/blob/3ddab1c9d171dc69a3ebf1ad747dfaea19e49339/core/image.cpp#L1324-L1325

The same goes for `bumpmap_to_normalmap()`:

https://github.com/godotengine/godot/blob/3ddab1c9d171dc69a3ebf1ad747dfaea19e49339/core/image.cpp#L2916-L2918

This PR targets 3.2 because the `lock()`/`unlock()` mechanism is removed in `master`, so `convert()` can only fail with compressed format. The functions won't crash thanks to the `_can_modify()` checks.