### PR TITLE
[3.2] Improve Godot Android plugin methods registration

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
@@ -44,7 +44,7 @@ import androidx.fragment.app.FragmentActivity;
  * It's also a reference implementation for how to setup and use the {@link Godot} fragment
  * within an Android app.
  */
-public abstract class FullScreenGodotApp extends FragmentActivity {
+public abstract class FullScreenGodotApp extends FragmentActivity implements GodotHost {
 
 	@Nullable
 	private Godot godotFragment;
@@ -65,6 +65,8 @@ public abstract class FullScreenGodotApp extends FragmentActivity {
 	public void onNewIntent(Intent intent) {
 		if (godotFragment != null) {
 			godotFragment.onNewIntent(intent);
+		} else {
+			super.onNewIntent(intent);
 		}
 	}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -108,6 +108,7 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -143,6 +144,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	// Used to dispatch events to the main thread.
 	private final Handler mainThreadHandler = new Handler(Looper.getMainLooper());
 
+	private GodotHost godotHost;
 	private GodotPluginRegistry pluginRegistry;
 
 	static private Intent mCurrentIntent;
@@ -231,7 +233,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 
 		protected void onGLDrawFrame(GL10 gl) {}
 		protected void onGLSurfaceChanged(GL10 gl, int width, int height) {} // singletons will always miss first onGLSurfaceChanged call
-		//protected void onGLSurfaceCreated(GL10 gl, EGLConfig config) {} // singletons won't be ready until first GodotLib.step()
+		// protected void onGLSurfaceCreated(GL10 gl, EGLConfig config) {} // singletons won't be ready until first GodotLib.step()
 
 		public void registerMethods() {}
 	}
@@ -270,6 +272,22 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	public ResultCallback result_callback;
 
 	@Override
+	public void onAttach(Context context) {
+		super.onAttach(context);
+		if (getParentFragment() instanceof GodotHost) {
+			godotHost = (GodotHost)getParentFragment();
+		} else if (getActivity() instanceof GodotHost) {
+			godotHost = (GodotHost)getActivity();
+		}
+	}
+
+	@Override
+	public void onDetach() {
+		super.onDetach();
+		godotHost = null;
+	}
+
+	@Override
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
 		if (result_callback != null) {
 			result_callback.callback(requestCode, resultCode, data);
@@ -300,12 +318,30 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	};
 
 	/**
+	 * Invoked on the render thread when the Godot setup is complete.
+	 */
+	@CallSuper
+	protected void onGodotSetupCompleted() {
+		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
+			plugin.onGodotSetupCompleted();
+		}
+
+		if (godotHost != null) {
+			godotHost.onGodotSetupCompleted();
+		}
+	}
+
+	/**
 	 * Invoked on the render thread when the Godot main loop has started.
 	 */
 	@CallSuper
 	protected void onGodotMainLoopStarted() {
 		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
 			plugin.onGodotMainLoopStarted();
+		}
+
+		if (godotHost != null) {
+			godotHost.onGodotMainLoopStarted();
 		}
 	}
 
@@ -409,7 +445,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 					v.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE));
 				} else {
-					//deprecated in API 26
+					// deprecated in API 26
 					v.vibrate(durationMs);
 				}
 			}
@@ -464,6 +500,21 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 
 	@CallSuper
 	protected String[] getCommandLine() {
+		String[] original = parseCommandLine();
+		String[] updated;
+		List<String> hostCommandLine = godotHost != null ? godotHost.getCommandLine() : null;
+		if (hostCommandLine == null || hostCommandLine.isEmpty()) {
+			updated = original;
+		} else {
+			updated = Arrays.copyOf(original, original.length + hostCommandLine.size());
+			for (int i = 0; i < hostCommandLine.size(); i++) {
+				updated[original.length + i] = hostCommandLine.get(i);
+			}
+		}
+		return updated;
+	}
+
+	private String[] parseCommandLine() {
 		InputStream is;
 		try {
 			is = getActivity().getAssets().open("_cl_");
@@ -584,7 +635,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		mClipboard = (ClipboardManager)activity.getSystemService(Context.CLIPBOARD_SERVICE);
 		pluginRegistry = GodotPluginRegistry.initializePluginRegistry(this);
 
-		//check for apk expansion API
+		// check for apk expansion API
 		boolean md5mismatch = false;
 		command_line = getCommandLine();
 		String main_pack_md5 = null;
@@ -642,9 +693,9 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 			command_line = new_args.toArray(new String[new_args.size()]);
 		}
 		if (use_apk_expansion && main_pack_md5 != null && main_pack_key != null) {
-			//check that environment is ok!
+			// check that environment is ok!
 			if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-				//show popup and die
+				// show popup and die
 			}
 
 			// Build the full path to the app's expansion files

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  GodotPluginInfoProvider.java                                         */
+/*  GodotHost.java                                                       */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,46 +28,30 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-package org.godotengine.godot.plugin;
-
-import androidx.annotation.NonNull;
+package org.godotengine.godot;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 /**
- * Provides the set of information expected from a Godot plugin.
+ * Denotate a component (e.g: Activity, Fragment) that hosts the {@link Godot} fragment.
  */
-public interface GodotPluginInfoProvider {
+public interface GodotHost {
 
 	/**
-	 * Returns the name of the plugin.
+	 * Provides a set of command line parameters to setup the engine.
 	 */
-	@NonNull
-	String getPluginName();
-
-	/**
-	 * Returns the list of signals to be exposed to Godot.
-	 */
-	@NonNull
-	default Set<SignalInfo> getPluginSignals() {
-		return Collections.emptySet();
+	default List<String> getCommandLine() {
+		return Collections.emptyList();
 	}
 
 	/**
-	 * Returns the paths for the plugin's gdnative libraries (if any).
-	 *
-	 * The paths must be relative to the 'assets' directory and point to a '*.gdnlib' file.
+	 * Invoked on the render thread when the Godot setup is complete.
 	 */
-	@NonNull
-	default Set<String> getPluginGDNativeLibrariesPaths() {
-		return Collections.emptySet();
-	}
+	default void onGodotSetupCompleted() {}
 
 	/**
-	 * This is invoked on the render thread when the plugin described by this instance has been
-	 * registered.
+	 * Invoked on the render thread when the Godot main loop has started.
 	 */
-	default void onPluginRegistered() {
-	}
+	default void onGodotMainLoopStarted() {}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
@@ -46,6 +46,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -109,31 +110,9 @@ public abstract class GodotPlugin {
 	 * This method is invoked on the render thread.
 	 */
 	public final void onRegisterPluginWithGodotNative() {
-		registeredSignals.putAll(registerPluginWithGodotNative(this, new GodotPluginInfoProvider() {
-			@NonNull
-			@Override
-			public String getPluginName() {
-				return GodotPlugin.this.getPluginName();
-			}
-
-			@NonNull
-			@Override
-			public List<String> getPluginMethods() {
-				return GodotPlugin.this.getPluginMethods();
-			}
-
-			@NonNull
-			@Override
-			public Set<SignalInfo> getPluginSignals() {
-				return GodotPlugin.this.getPluginSignals();
-			}
-
-			@NonNull
-			@Override
-			public Set<String> getPluginGDNativeLibrariesPaths() {
-				return GodotPlugin.this.getPluginGDNativeLibrariesPaths();
-			}
-		}));
+		registeredSignals.putAll(
+				registerPluginWithGodotNative(this, getPluginName(), getPluginMethods(), getPluginSignals(),
+						getPluginGDNativeLibrariesPaths()));
 	}
 
 	/**
@@ -141,23 +120,41 @@ public abstract class GodotPlugin {
 	 *
 	 * This method must be invoked on the render thread.
 	 */
-	public static Map<String, SignalInfo> registerPluginWithGodotNative(Object pluginObject, GodotPluginInfoProvider pluginInfoProvider) {
-		nativeRegisterSingleton(pluginInfoProvider.getPluginName(), pluginObject);
+	public static void registerPluginWithGodotNative(Object pluginObject,
+			GodotPluginInfoProvider pluginInfoProvider) {
+		registerPluginWithGodotNative(pluginObject, pluginInfoProvider.getPluginName(),
+				Collections.emptyList(), pluginInfoProvider.getPluginSignals(),
+				pluginInfoProvider.getPluginGDNativeLibrariesPaths());
 
+		// Notify that registration is complete.
+		pluginInfoProvider.onPluginRegistered();
+	}
+
+	private static Map<String, SignalInfo> registerPluginWithGodotNative(Object pluginObject,
+			String pluginName, List<String> pluginMethods, Set<SignalInfo> pluginSignals,
+			Set<String> pluginGDNativeLibrariesPaths) {
+		nativeRegisterSingleton(pluginName, pluginObject);
+
+		Set<Method> filteredMethods = new HashSet<>();
 		Class clazz = pluginObject.getClass();
+
 		Method[] methods = clazz.getDeclaredMethods();
 		for (Method method : methods) {
-			boolean found = false;
-
-			for (String s : pluginInfoProvider.getPluginMethods()) {
-				if (s.equals(method.getName())) {
-					found = true;
-					break;
+			// Check if the method is annotated with {@link UsedByGodot}.
+			if (method.getAnnotation(UsedByGodot.class) != null) {
+				filteredMethods.add(method);
+			} else {
+				// For backward compatibility, process the methods from the given <pluginMethods> argument.
+				for (String methodName : pluginMethods) {
+					if (methodName.equals(method.getName())) {
+						filteredMethods.add(method);
+						break;
+					}
 				}
 			}
-			if (!found)
-				continue;
+		}
 
+		for (Method method : filteredMethods) {
 			List<String> ptr = new ArrayList<>();
 
 			Class[] paramTypes = method.getParameterTypes();
@@ -168,21 +165,20 @@ public abstract class GodotPlugin {
 			String[] pt = new String[ptr.size()];
 			ptr.toArray(pt);
 
-			nativeRegisterMethod(pluginInfoProvider.getPluginName(), method.getName(), method.getReturnType().getName(), pt);
+			nativeRegisterMethod(pluginName, method.getName(), method.getReturnType().getName(), pt);
 		}
 
 		// Register the signals for this plugin.
 		Map<String, SignalInfo> registeredSignals = new HashMap<>();
-		for (SignalInfo signalInfo : pluginInfoProvider.getPluginSignals()) {
+		for (SignalInfo signalInfo : pluginSignals) {
 			String signalName = signalInfo.getName();
-			nativeRegisterSignal(pluginInfoProvider.getPluginName(), signalName, signalInfo.getParamTypesNames());
+			nativeRegisterSignal(pluginName, signalName, signalInfo.getParamTypesNames());
 			registeredSignals.put(signalName, signalInfo);
 		}
 
 		// Get the list of gdnative libraries to register.
-		Set<String> gdnativeLibrariesPaths = pluginInfoProvider.getPluginGDNativeLibrariesPaths();
-		if (!gdnativeLibrariesPaths.isEmpty()) {
-			nativeRegisterGDNativeLibraries(gdnativeLibrariesPaths.toArray(new String[0]));
+		if (!pluginGDNativeLibrariesPaths.isEmpty()) {
+			nativeRegisterGDNativeLibraries(pluginGDNativeLibrariesPaths.toArray(new String[0]));
 		}
 
 		return registeredSignals;
@@ -236,6 +232,11 @@ public abstract class GodotPlugin {
 	public boolean onMainBackPressed() { return false; }
 
 	/**
+	 * Invoked on the render thread when the Godot setup is complete.
+	 */
+	public void onGodotSetupCompleted() {}
+
+	/**
 	 * Invoked on the render thread when the Godot main loop has started.
 	 */
 	public void onGodotMainLoopStarted() {}
@@ -266,8 +267,11 @@ public abstract class GodotPlugin {
 
 	/**
 	 * Returns the list of methods to be exposed to Godot.
+	 *
+	 * @deprecated Used the {@link UsedByGodot} annotation instead.
 	 */
 	@NonNull
+	@Deprecated
 	public List<String> getPluginMethods() {
 		return Collections.emptyList();
 	}

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/UsedByGodot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/UsedByGodot.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  GodotPluginInfoProvider.java                                         */
+/*  UsedByGodot.java                                                     */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -30,44 +30,16 @@
 
 package org.godotengine.godot.plugin;
 
-import androidx.annotation.NonNull;
-
-import java.util.Collections;
-import java.util.Set;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Provides the set of information expected from a Godot plugin.
+ * Annotation to indicate a method is being invoked from the Godot game logic.
+ *
+ * At runtime, annotated plugin methods are detected and automatically registered.
  */
-public interface GodotPluginInfoProvider {
-
-	/**
-	 * Returns the name of the plugin.
-	 */
-	@NonNull
-	String getPluginName();
-
-	/**
-	 * Returns the list of signals to be exposed to Godot.
-	 */
-	@NonNull
-	default Set<SignalInfo> getPluginSignals() {
-		return Collections.emptySet();
-	}
-
-	/**
-	 * Returns the paths for the plugin's gdnative libraries (if any).
-	 *
-	 * The paths must be relative to the 'assets' directory and point to a '*.gdnlib' file.
-	 */
-	@NonNull
-	default Set<String> getPluginGDNativeLibrariesPaths() {
-		return Collections.emptySet();
-	}
-
-	/**
-	 * This is invoked on the render thread when the plugin described by this instance has been
-	 * registered.
-	 */
-	default void onPluginRegistered() {
-	}
-}
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UsedByGodot {}

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -201,7 +201,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jc
 	}
 
 	if (err != OK) {
-		return; //should exit instead and print the error
+		return; // should exit instead and print the error
 	}
 
 	java_class_wrapper = memnew(JavaClassWrapper(godot_java->get_activity()));
@@ -252,9 +252,10 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jcl
 
 	if (step == 1) {
 		if (!Main::start()) {
-			return; //should exit instead and print the error
+			return; // should exit instead and print the error
 		}
 
+		godot_java->on_godot_setup_completed(env);
 		os_android->main_loop_begin();
 		godot_java->on_godot_main_loop_started(env);
 		++step;

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -74,6 +74,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_is_activity_resumed = p_env->GetMethodID(godot_class, "isActivityResumed", "()Z");
 	_vibrate = p_env->GetMethodID(godot_class, "vibrate", "(I)V");
 	_get_input_fallback_mapping = p_env->GetMethodID(godot_class, "getInputFallbackMapping", "()Ljava/lang/String;");
+	_on_godot_setup_completed = p_env->GetMethodID(godot_class, "onGodotSetupCompleted", "()V");
 	_on_godot_main_loop_started = p_env->GetMethodID(godot_class, "onGodotMainLoopStarted", "()V");
 
 	// get some Activity method pointers...
@@ -117,11 +118,21 @@ void GodotJavaWrapper::gfx_init(bool gl2) {
 }
 
 void GodotJavaWrapper::on_video_init(JNIEnv *p_env) {
-	if (_on_video_init)
+	if (_on_video_init) {
 		if (p_env == NULL)
 			p_env = get_jni_env();
 
-	p_env->CallVoidMethod(godot_instance, _on_video_init);
+		p_env->CallVoidMethod(godot_instance, _on_video_init);
+	}
+}
+
+void GodotJavaWrapper::on_godot_setup_completed(JNIEnv *p_env) {
+	if (_on_godot_setup_completed) {
+		if (p_env == NULL) {
+			p_env = get_jni_env();
+		}
+		p_env->CallVoidMethod(godot_instance, _on_godot_setup_completed);
+	}
 }
 
 void GodotJavaWrapper::on_godot_main_loop_started(JNIEnv *p_env) {
@@ -129,24 +140,26 @@ void GodotJavaWrapper::on_godot_main_loop_started(JNIEnv *p_env) {
 		if (p_env == NULL) {
 			p_env = get_jni_env();
 		}
+		p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_started);
 	}
-	p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_started);
 }
 
 void GodotJavaWrapper::restart(JNIEnv *p_env) {
-	if (_restart)
+	if (_restart) {
 		if (p_env == NULL)
 			p_env = get_jni_env();
 
-	p_env->CallVoidMethod(godot_instance, _restart);
+		p_env->CallVoidMethod(godot_instance, _restart);
+	}
 }
 
 void GodotJavaWrapper::force_quit(JNIEnv *p_env) {
-	if (_finish)
+	if (_finish) {
 		if (p_env == NULL)
 			p_env = get_jni_env();
 
-	p_env->CallVoidMethod(godot_instance, _finish);
+		p_env->CallVoidMethod(godot_instance, _finish);
+	}
 }
 
 void GodotJavaWrapper::set_keep_screen_on(bool p_enabled) {

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -63,6 +63,7 @@ private:
 	jmethodID _is_activity_resumed = 0;
 	jmethodID _vibrate = 0;
 	jmethodID _get_input_fallback_mapping = 0;
+	jmethodID _on_godot_setup_completed = 0;
 	jmethodID _on_godot_main_loop_started = 0;
 	jmethodID _get_class_loader = 0;
 
@@ -77,6 +78,7 @@ public:
 
 	void gfx_init(bool gl2);
 	void on_video_init(JNIEnv *p_env = NULL);
+	void on_godot_setup_completed(JNIEnv *p_env = NULL);
 	void on_godot_main_loop_started(JNIEnv *p_env = NULL);
 	void restart(JNIEnv *p_env = NULL);
 	void force_quit(JNIEnv *p_env = NULL);


### PR DESCRIPTION
This PR introduces a `@UsedByGodot` annotation which is used by Godot Android plugins to annotate methods that should be registered and made available to the scripting logic.