### PR TITLE
Improve Godot Android plugin methods registration

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
@@ -44,7 +44,7 @@ import androidx.fragment.app.FragmentActivity;
  * It's also a reference implementation for how to setup and use the {@link Godot} fragment
  * within an Android app.
  */
-public abstract class FullScreenGodotApp extends FragmentActivity {
+public abstract class FullScreenGodotApp extends FragmentActivity implements GodotHost {
 	@Nullable
 	private Godot godotFragment;
 
@@ -64,6 +64,8 @@ public abstract class FullScreenGodotApp extends FragmentActivity {
 	public void onNewIntent(Intent intent) {
 		if (godotFragment != null) {
 			godotFragment.onNewIntent(intent);
+		} else {
+			super.onNewIntent(intent);
 		}
 	}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  GodotPluginInfoProvider.java                                         */
+/*  GodotHost.java                                                       */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,45 +28,29 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-package org.godotengine.godot.plugin;
-
-import androidx.annotation.NonNull;
+package org.godotengine.godot;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 /**
- * Provides the set of information expected from a Godot plugin.
+ * Denotate a component (e.g: Activity, Fragment) that hosts the {@link Godot} fragment.
  */
-public interface GodotPluginInfoProvider {
+public interface GodotHost {
 	/**
-	 * Returns the name of the plugin.
+	 * Provides a set of command line parameters to setup the engine.
 	 */
-	@NonNull
-	String getPluginName();
-
-	/**
-	 * Returns the list of signals to be exposed to Godot.
-	 */
-	@NonNull
-	default Set<SignalInfo> getPluginSignals() {
-		return Collections.emptySet();
+	default List<String> getCommandLine() {
+		return Collections.emptyList();
 	}
 
 	/**
-	 * Returns the paths for the plugin's gdnative libraries (if any).
-	 *
-	 * The paths must be relative to the 'assets' directory and point to a '*.gdnlib' file.
+	 * Invoked on the render thread when the Godot setup is complete.
 	 */
-	@NonNull
-	default Set<String> getPluginGDNativeLibrariesPaths() {
-		return Collections.emptySet();
-	}
+	default void onGodotSetupCompleted() {}
 
 	/**
-	 * This is invoked on the render thread when the plugin described by this instance has been
-	 * registered.
+	 * Invoked on the render thread when the Godot main loop has started.
 	 */
-	default void onPluginRegistered() {
-	}
+	default void onGodotMainLoopStarted() {}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/UsedByGodot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/UsedByGodot.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  GodotPluginInfoProvider.java                                         */
+/*  UsedByGodot.java                                                     */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -30,43 +30,16 @@
 
 package org.godotengine.godot.plugin;
 
-import androidx.annotation.NonNull;
-
-import java.util.Collections;
-import java.util.Set;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Provides the set of information expected from a Godot plugin.
+ * Annotation to indicate a method is being invoked from the Godot game logic.
+ *
+ * At runtime, annotated plugin methods are detected and automatically registered.
  */
-public interface GodotPluginInfoProvider {
-	/**
-	 * Returns the name of the plugin.
-	 */
-	@NonNull
-	String getPluginName();
-
-	/**
-	 * Returns the list of signals to be exposed to Godot.
-	 */
-	@NonNull
-	default Set<SignalInfo> getPluginSignals() {
-		return Collections.emptySet();
-	}
-
-	/**
-	 * Returns the paths for the plugin's gdnative libraries (if any).
-	 *
-	 * The paths must be relative to the 'assets' directory and point to a '*.gdnlib' file.
-	 */
-	@NonNull
-	default Set<String> getPluginGDNativeLibrariesPaths() {
-		return Collections.emptySet();
-	}
-
-	/**
-	 * This is invoked on the render thread when the plugin described by this instance has been
-	 * registered.
-	 */
-	default void onPluginRegistered() {
-	}
-}
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UsedByGodot {}

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -155,7 +155,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jc
 	}
 
 	if (err != OK) {
-		return; //should exit instead and print the error
+		return; // should exit instead and print the error
 	}
 
 	java_class_wrapper = memnew(JavaClassWrapper(godot_java->get_activity()));
@@ -217,9 +217,10 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jcl
 
 	if (step == 1) {
 		if (!Main::start()) {
-			return; //should exit instead and print the error
+			return; // should exit instead and print the error
 		}
 
+		godot_java->on_godot_setup_completed(env);
 		os_android->main_loop_begin();
 		godot_java->on_godot_main_loop_started(env);
 		++step;

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -74,6 +74,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_is_activity_resumed = p_env->GetMethodID(godot_class, "isActivityResumed", "()Z");
 	_vibrate = p_env->GetMethodID(godot_class, "vibrate", "(I)V");
 	_get_input_fallback_mapping = p_env->GetMethodID(godot_class, "getInputFallbackMapping", "()Ljava/lang/String;");
+	_on_godot_setup_completed = p_env->GetMethodID(godot_class, "onGodotSetupCompleted", "()V");
 	_on_godot_main_loop_started = p_env->GetMethodID(godot_class, "onGodotMainLoopStarted", "()V");
 
 	// get some Activity method pointers...
@@ -120,11 +121,21 @@ GodotJavaViewWrapper *GodotJavaWrapper::get_godot_view() {
 }
 
 void GodotJavaWrapper::on_video_init(JNIEnv *p_env) {
-	if (_on_video_init)
+	if (_on_video_init) {
 		if (p_env == nullptr)
 			p_env = get_jni_env();
 
-	p_env->CallVoidMethod(godot_instance, _on_video_init);
+		p_env->CallVoidMethod(godot_instance, _on_video_init);
+	}
+}
+
+void GodotJavaWrapper::on_godot_setup_completed(JNIEnv *p_env) {
+	if (_on_godot_setup_completed) {
+		if (p_env == nullptr) {
+			p_env = get_jni_env();
+		}
+		p_env->CallVoidMethod(godot_instance, _on_godot_setup_completed);
+	}
 }
 
 void GodotJavaWrapper::on_godot_main_loop_started(JNIEnv *p_env) {
@@ -132,24 +143,26 @@ void GodotJavaWrapper::on_godot_main_loop_started(JNIEnv *p_env) {
 		if (p_env == nullptr) {
 			p_env = get_jni_env();
 		}
+		p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_started);
 	}
-	p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_started);
 }
 
 void GodotJavaWrapper::restart(JNIEnv *p_env) {
-	if (_restart)
+	if (_restart) {
 		if (p_env == nullptr)
 			p_env = get_jni_env();
 
-	p_env->CallVoidMethod(godot_instance, _restart);
+		p_env->CallVoidMethod(godot_instance, _restart);
+	}
 }
 
 void GodotJavaWrapper::force_quit(JNIEnv *p_env) {
-	if (_finish)
+	if (_finish) {
 		if (p_env == nullptr)
 			p_env = get_jni_env();
 
-	p_env->CallVoidMethod(godot_instance, _finish);
+		p_env->CallVoidMethod(godot_instance, _finish);
+	}
 }
 
 void GodotJavaWrapper::set_keep_screen_on(bool p_enabled) {

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -66,6 +66,7 @@ private:
 	jmethodID _is_activity_resumed = 0;
 	jmethodID _vibrate = 0;
 	jmethodID _get_input_fallback_mapping = 0;
+	jmethodID _on_godot_setup_completed = 0;
 	jmethodID _on_godot_main_loop_started = 0;
 	jmethodID _get_class_loader = 0;
 
@@ -80,6 +81,7 @@ public:
 	GodotJavaViewWrapper *get_godot_view();
 
 	void on_video_init(JNIEnv *p_env = nullptr);
+	void on_godot_setup_completed(JNIEnv *p_env = nullptr);
 	void on_godot_main_loop_started(JNIEnv *p_env = nullptr);
 	void restart(JNIEnv *p_env = nullptr);
 	void force_quit(JNIEnv *p_env = nullptr);


### PR DESCRIPTION
This PR introduces a `@UsedByGodot` annotation which is used by Godot Android plugins to annotate methods that should be registered and made available to the scripting logic.