### PR TITLE
Fix BBCode tables overlap with bottom text (Fix #47012)

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -588,7 +588,8 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 					offset.x += table->columns[column].width + hseparation + frame->padding.size.x;
 
 					row_height = MAX(yofs, row_height);
-					if (column == col_count - 1) {
+					// Add row height after last column of the row or last cell of the table.
+					if (column == col_count - 1 || E->next() == nullptr) {
 						offset.x = 0;
 						row_height += vseparation;
 						table->total_height += row_height;


### PR DESCRIPTION
Fix #47012

### Issue : 

In RichTextLabel, text after a [table] element overlaps with table last row if the last row doesn't use all columns.

**Before :** 

![before](https://user-images.githubusercontent.com/3649998/111284873-d84ebd80-8640-11eb-9baa-89c8e17b89ca.gif)

### Fix proposal : 

The height of the row was only added if `column == col_count - 1` => if all the columns was used.
I've added an other condition : `(column == col_count - 1 || E->next() == nullptr)` =>  if all the columns was used OR if it's the last element of the table (even if it's not on the last column).

**After :**

![after](https://user-images.githubusercontent.com/3649998/111285192-2b287500-8641-11eb-84e7-9eb8ea0bef73.gif)
