### PR TITLE
Allow disabling 2D when compiling export templates

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -261,6 +261,7 @@ opts.Add(BoolVariable("vsproj", "Generate a Visual Studio solution", False))
 opts.Add("vsproj_name", "Name of the Visual Studio solution", "godot")
 opts.Add("import_env_vars", "A comma-separated list of environment variables to copy from the outer environment.", "")
 opts.Add(BoolVariable("disable_exceptions", "Force disabling exception handling code", True))
+opts.Add(BoolVariable("disable_2d", "Disable 2D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
 opts.Add(BoolVariable("disable_physics_2d", "Disable 2D physics nodes and server", False))
@@ -1057,6 +1058,7 @@ sys.modules.pop("detect")
 if env.editor_build:
     unsupported_opts = []
     for disable_opt in [
+        "disable_2d",
         "disable_3d",
         "disable_advanced_gui",
         "disable_physics_2d",
@@ -1074,6 +1076,10 @@ if env.editor_build:
         )
         Exit(255)
 
+if env["disable_2d"]:
+    env.Append(CPPDEFINES=["_2D_DISABLED"])
+    env["disable_navigation_2d"] = True
+    env["disable_physics_2d"] = True
 if env["disable_3d"]:
     env.Append(CPPDEFINES=["_3D_DISABLED"])
     env["disable_navigation_3d"] = True

--- a/SConstruct
+++ b/SConstruct
@@ -261,6 +261,7 @@ opts.Add(BoolVariable("vsproj", "Generate a Visual Studio solution", False))
 opts.Add("vsproj_name", "Name of the Visual Studio solution", "godot")
 opts.Add("import_env_vars", "A comma-separated list of environment variables to copy from the outer environment.", "")
 opts.Add(BoolVariable("disable_exceptions", "Force disabling exception handling code", True))
+opts.Add(BoolVariable("disable_2d", "Disable 2D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
 opts.Add(BoolVariable("disable_physics_2d", "Disable 2D physics nodes and server", False))
@@ -1033,6 +1034,7 @@ sys.modules.pop("detect")
 if env.editor_build:
     unsupported_opts = []
     for disable_opt in [
+        "disable_2d",
         "disable_3d",
         "disable_advanced_gui",
         "disable_physics_2d",
@@ -1050,6 +1052,11 @@ if env.editor_build:
         )
         Exit(255)
 
+if env["disable_2d"]:
+    env.Append(CPPDEFINES=["_2D_DISABLED"])
+    env["disable_navigation_2d"] = True
+    env["disable_physics_2d"] = True
+    env["tests"] = False
 if env["disable_3d"]:
     env.Append(CPPDEFINES=["_3D_DISABLED"])
     env["disable_navigation_3d"] = True

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -51,6 +51,7 @@
 
 const char *EditorBuildProfile::build_option_identifiers[BUILD_OPTION_MAX] = {
 	// This maps to SCons build options.
+	"disable_2d",
 	"disable_3d",
 	"disable_navigation_2d",
 	"disable_navigation_3d",
@@ -84,6 +85,7 @@ const char *EditorBuildProfile::build_option_identifiers[BUILD_OPTION_MAX] = {
 
 const bool EditorBuildProfile::build_option_disabled_by_default[BUILD_OPTION_MAX] = {
 	// This maps to SCons build options.
+	false, // 2D
 	false, // 3D
 	false, // NAVIGATION_2D
 	false, // NAVIGATION_3D
@@ -117,6 +119,7 @@ const bool EditorBuildProfile::build_option_disabled_by_default[BUILD_OPTION_MAX
 
 const bool EditorBuildProfile::build_option_disable_values[BUILD_OPTION_MAX] = {
 	// This maps to SCons build options.
+	true, // 2D
 	true, // 3D
 	true, // NAVIGATION_2D
 	true, // NAVIGATION_3D
@@ -150,6 +153,7 @@ const bool EditorBuildProfile::build_option_disable_values[BUILD_OPTION_MAX] = {
 
 // Options that require some resource explicitly asking for them when detecting from the project.
 const bool EditorBuildProfile::build_option_explicit_use[BUILD_OPTION_MAX] = {
+	false, // 2D
 	false, // 3D
 	false, // NAVIGATION_2D
 	false, // NAVIGATION_3D
@@ -182,6 +186,7 @@ const bool EditorBuildProfile::build_option_explicit_use[BUILD_OPTION_MAX] = {
 };
 
 const EditorBuildProfile::BuildOptionCategory EditorBuildProfile::build_option_category[BUILD_OPTION_MAX] = {
+	BUILD_OPTION_CATEGORY_GENERAL, // 2D
 	BUILD_OPTION_CATEGORY_GENERAL, // 3D
 	BUILD_OPTION_CATEGORY_GENERAL, // NAVIGATION_2D
 	BUILD_OPTION_CATEGORY_GENERAL, // NAVIGATION_3D
@@ -262,6 +267,13 @@ const HashMap<EditorBuildProfile::BuildOption, LocalVector<EditorBuildProfile::B
 
 // Should also contain classes not derived from either `Resource` or `Node`.
 const HashMap<EditorBuildProfile::BuildOption, LocalVector<String>> EditorBuildProfile::build_option_classes = {
+	{ BUILD_OPTION_2D, {
+			"Curve2D",
+			"Node2D",
+			"OccluderPolygon2D",
+			"SkeletonModificationStack2D",
+			"SkeletonModification2D",
+	} },
 	{ BUILD_OPTION_3D, {
 			"Node3D",
 	} },
@@ -407,6 +419,7 @@ String EditorBuildProfile::get_force_detect_classes() const {
 String EditorBuildProfile::get_build_option_name(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, String());
 	const char *build_option_names[BUILD_OPTION_MAX] = {
+		TTRC("2D Engine"),
 		TTRC("3D Engine"),
 		TTRC("Navigation (2D)"),
 		TTRC("Navigation (3D)"),
@@ -444,6 +457,7 @@ String EditorBuildProfile::get_build_option_description(BuildOption p_build_opti
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, String());
 
 	const char *build_option_descriptions[BUILD_OPTION_MAX] = {
+		TTRC("2D Nodes for 2D games. Does not include Control nodes, which are always available."),
 		TTRC("3D Nodes as well as RenderingServer access to 3D features.\nNote that the Geometry3D singleton remains available even with this item disabled."),
 		TTRC("NavigationServer and capabilities for 2D."),
 		TTRC("NavigationServer and capabilities for 3D."),
@@ -620,6 +634,7 @@ void EditorBuildProfile::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_to_file", "path"), &EditorBuildProfile::save_to_file);
 	ClassDB::bind_method(D_METHOD("load_from_file", "path"), &EditorBuildProfile::load_from_file);
 
+	BIND_ENUM_CONSTANT(BUILD_OPTION_2D);
 	BIND_ENUM_CONSTANT(BUILD_OPTION_3D);
 	BIND_ENUM_CONSTANT(BUILD_OPTION_NAVIGATION_2D);
 	BIND_ENUM_CONSTANT(BUILD_OPTION_NAVIGATION_3D);

--- a/editor/settings/editor_build_profile.h
+++ b/editor/settings/editor_build_profile.h
@@ -40,6 +40,7 @@ class EditorBuildProfile : public RefCounted {
 
 public:
 	enum BuildOption {
+		BUILD_OPTION_2D,
 		BUILD_OPTION_3D,
 		BUILD_OPTION_NAVIGATION_2D,
 		BUILD_OPTION_NAVIGATION_3D,

--- a/modules/tilemap/config.py
+++ b/modules/tilemap/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return True
+    return not env["disable_2d"]
 
 
 def configure(env):

--- a/scene/2d/SCsub
+++ b/scene/2d/SCsub
@@ -3,10 +3,18 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env.add_source_files(env.scene_sources, "*.cpp")
-
-# Chain load SCsubs
-if not env["disable_physics_2d"]:
-    SConscript("physics/SCsub")
-if not env["disable_navigation_2d"]:
-    SConscript("navigation/SCsub")
+if env["disable_2d"]:
+    if not env["disable_advanced_gui"]:
+        # GraphEdit has a strong dependency on Line2D, so always compile for advanced GUI builds.
+        # However, these just serve as internal classes, we don't need to expose them, since 2D is supposed to be disabled.
+        env.add_source_files(env.scene_sources, "line_2d.cpp")
+        env.add_source_files(env.scene_sources, "line_builder.cpp")
+        env.add_source_files(env.scene_sources, "node_2d.cpp")
+        env.add_source_files(env.scene_sources, "sprite_2d.cpp")
+else:
+    env.add_source_files(env.scene_sources, "*.cpp")
+    # Chain load SCsubs
+    if not env["disable_navigation_2d"]:
+        SConscript("navigation/SCsub")
+    if not env["disable_physics_2d"]:
+        SConscript("physics/SCsub")

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -11,9 +11,9 @@ env.add_source_files(env.scene_sources, "*.cpp")
 # Chain load SCsubs
 SConscript("main/SCsub")
 SConscript("gui/SCsub")
+SConscript("2d/SCsub")
 if not env["disable_3d"]:
     SConscript("3d/SCsub")
-SConscript("2d/SCsub")
 SConscript("animation/SCsub")
 SConscript("audio/SCsub")
 SConscript("resources/SCsub")

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -11,9 +11,10 @@ env.add_source_files(env.scene_sources, "*.cpp")
 # Chain load SCsubs
 SConscript("main/SCsub")
 SConscript("gui/SCsub")
+if not env["disable_2d"]:
+    SConscript("2d/SCsub")
 if not env["disable_3d"]:
     SConscript("3d/SCsub")
-SConscript("2d/SCsub")
 SConscript("animation/SCsub")
 SConscript("audio/SCsub")
 SConscript("resources/SCsub")

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -291,14 +291,18 @@ void RuntimeNodeSelect::_set_camera_override_enabled(bool p_enabled) {
 	camera_override = p_enabled;
 
 	if (camera_first_override) {
+#ifndef _2D_DISABLED
 		_reset_camera_2d();
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 		_reset_camera_3d();
 #endif // _3D_DISABLED
 
 		camera_first_override = false;
 	} else if (p_enabled) {
+#ifndef _2D_DISABLED
 		_update_view_2d();
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 		Window *root = SceneTree::get_singleton()->get_root();
@@ -1156,7 +1160,9 @@ void RuntimeNodeSelect::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_ev
 	view_2d_offset.x -= scroll.x / view_2d_zoom;
 	view_2d_offset.y -= scroll.y / view_2d_zoom;
 
+#ifndef _2D_DISABLED
 	_update_view_2d();
+#endif // _2D_DISABLED
 }
 
 // A very shallow copy of the same function inside CanvasItemEditor.
@@ -1179,9 +1185,12 @@ void RuntimeNodeSelect::_zoom_callback(float p_zoom_factor, Vector2 p_origin, Re
 		view_2d_offset = view_offset_int + (view_offset_frac * closest_zoom_factor).round() / closest_zoom_factor;
 	}
 
+#ifndef _2D_DISABLED
 	_update_view_2d();
+#endif // _2D_DISABLED
 }
 
+#ifndef _2D_DISABLED
 void RuntimeNodeSelect::_reset_camera_2d() {
 	camera_first_override = true;
 	Window *root = SceneTree::get_singleton()->get_root();
@@ -1212,6 +1221,7 @@ void RuntimeNodeSelect::_update_view_2d() {
 
 	_queue_selection_update();
 }
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 

--- a/scene/debugger/runtime_node_select.h
+++ b/scene/debugger/runtime_node_select.h
@@ -183,8 +183,10 @@ private:
 	void _find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_node, Vector<SelectResult> &r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
 	void _pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event);
 	void _zoom_callback(float p_zoom_factor, Vector2 p_origin, Ref<InputEvent> p_event);
+#ifndef _2D_DISABLED
 	void _reset_camera_2d();
 	void _update_view_2d();
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 	void _find_3d_items_at_pos(const Point2 &p_pos, Vector<SelectResult> &r_items);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -274,7 +274,9 @@ Error SceneDebugger::_msg_override_cameras(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
 	bool enable = p_args[0];
 	bool from_editor = p_args[1];
+#ifndef _2D_DISABLED
 	SceneTree::get_singleton()->get_root()->enable_camera_2d_override(enable);
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	SceneTree::get_singleton()->get_root()->enable_camera_3d_override(enable);
 #endif // _3D_DISABLED
@@ -477,6 +479,7 @@ Error SceneDebugger::_msg_runtime_node_select_set_prefer_group(const Array &p_ar
 	return OK;
 }
 
+#ifndef _2D_DISABLED
 Error SceneDebugger::_msg_runtime_node_select_reset_camera_2d(const Array &p_args) {
 	RuntimeNodeSelect::get_singleton()->_reset_camera_2d();
 	return OK;
@@ -492,6 +495,7 @@ Error SceneDebugger::_msg_transform_camera_2d(const Array &p_args) {
 	RuntimeNodeSelect::get_singleton()->_queue_selection_update();
 	return OK;
 }
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 Error SceneDebugger::_msg_runtime_node_select_reset_camera_3d(const Array &p_args) {
@@ -622,7 +626,9 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["hdr_output_request_state"] = _msg_hdr_output_request_state;
 	message_handlers["hdr_output_toggle_requested"] = _msg_hdr_output_toggle_requested;
 	message_handlers["override_cameras"] = _msg_override_cameras;
+#ifndef _2D_DISABLED
 	message_handlers["transform_camera_2d"] = _msg_transform_camera_2d;
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	message_handlers["transform_camera_3d"] = _msg_transform_camera_3d;
 #endif // _3D_DISABLED
@@ -651,10 +657,12 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["runtime_node_select_set_visible"] = _msg_runtime_node_select_set_visible;
 	message_handlers["runtime_node_select_set_avoid_locked"] = _msg_runtime_node_select_set_avoid_locked;
 	message_handlers["runtime_node_select_set_prefer_group"] = _msg_runtime_node_select_set_prefer_group;
+#ifndef _2D_DISABLED
 	message_handlers["runtime_node_select_reset_camera_2d"] = _msg_runtime_node_select_reset_camera_2d;
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	message_handlers["runtime_node_select_reset_camera_3d"] = _msg_runtime_node_select_reset_camera_3d;
-#endif
+#endif // _3D_DISABLED
 	message_handlers["rq_screenshot"] = _msg_rq_screenshot;
 	message_handlers["report_window_focused"] = _msg_report_window_focused;
 }

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -281,7 +281,9 @@ Error SceneDebugger::_msg_override_cameras(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
 	bool enable = p_args[0];
 	bool from_editor = p_args[1];
+#ifndef _2D_DISABLED
 	SceneTree::get_singleton()->get_root()->enable_camera_2d_override(enable);
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	SceneTree::get_singleton()->get_root()->enable_camera_3d_override(enable);
 #endif // _3D_DISABLED
@@ -484,6 +486,7 @@ Error SceneDebugger::_msg_runtime_node_select_set_prefer_group(const Array &p_ar
 	return OK;
 }
 
+#ifndef _2D_DISABLED
 Error SceneDebugger::_msg_runtime_node_select_reset_camera_2d(const Array &p_args) {
 	RuntimeNodeSelect::get_singleton()->_reset_camera_2d();
 	return OK;
@@ -499,6 +502,7 @@ Error SceneDebugger::_msg_transform_camera_2d(const Array &p_args) {
 	RuntimeNodeSelect::get_singleton()->_queue_selection_update();
 	return OK;
 }
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 Error SceneDebugger::_msg_runtime_node_select_reset_camera_3d(const Array &p_args) {
@@ -630,7 +634,9 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["hdr_output_toggle_requested"] = _msg_hdr_output_toggle_requested;
 	message_handlers["set_debug_collisions"] = _msg_set_debug_collisions;
 	message_handlers["override_cameras"] = _msg_override_cameras;
+#ifndef _2D_DISABLED
 	message_handlers["transform_camera_2d"] = _msg_transform_camera_2d;
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	message_handlers["transform_camera_3d"] = _msg_transform_camera_3d;
 #endif // _3D_DISABLED
@@ -659,10 +665,12 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["runtime_node_select_set_visible"] = _msg_runtime_node_select_set_visible;
 	message_handlers["runtime_node_select_set_avoid_locked"] = _msg_runtime_node_select_set_avoid_locked;
 	message_handlers["runtime_node_select_set_prefer_group"] = _msg_runtime_node_select_set_prefer_group;
+#ifndef _2D_DISABLED
 	message_handlers["runtime_node_select_reset_camera_2d"] = _msg_runtime_node_select_reset_camera_2d;
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	message_handlers["runtime_node_select_reset_camera_3d"] = _msg_runtime_node_select_reset_camera_3d;
-#endif
+#endif // _3D_DISABLED
 	message_handlers["rq_screenshot"] = _msg_rq_screenshot;
 	message_handlers["report_window_focused"] = _msg_report_window_focused;
 }

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -114,8 +114,10 @@ private:
 	static Error _msg_rq_screenshot(const Array &p_args);
 	static Error _msg_report_window_focused(const Array &p_args);
 
+#ifndef _2D_DISABLED
 	static Error _msg_runtime_node_select_reset_camera_2d(const Array &p_args);
 	static Error _msg_transform_camera_2d(const Array &p_args);
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	static Error _msg_runtime_node_select_reset_camera_3d(const Array &p_args);
 	static Error _msg_transform_camera_3d(const Array &p_args);

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -115,8 +115,10 @@ private:
 	static Error _msg_rq_screenshot(const Array &p_args);
 	static Error _msg_report_window_focused(const Array &p_args);
 
+#ifndef _2D_DISABLED
 	static Error _msg_runtime_node_select_reset_camera_2d(const Array &p_args);
 	static Error _msg_transform_camera_2d(const Array &p_args);
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	static Error _msg_runtime_node_select_reset_camera_3d(const Array &p_args);
 	static Error _msg_transform_camera_3d(const Array &p_args);

--- a/scene/gui/SCsub
+++ b/scene/gui/SCsub
@@ -4,3 +4,11 @@ from misc.utility.scons_hints import *
 Import("env")
 
 env.add_source_files(env.scene_sources, "*.cpp")
+
+# HACK: GraphEdit has a strong dependency on Line2D, so always compile for advanced GUI builds.
+# However, these just serve as internal classes, we don't need to expose them, since 2D is supposed to be disabled.
+# Proper fix: Refactor GraphEdit to not depend on Line2D, use lower level line drawing APIs instead.
+if env["disable_2d"] and not env["disable_advanced_gui"]:
+    env.add_source_files(env.scene_sources, "../2d/line_2d.cpp")
+    env.add_source_files(env.scene_sources, "../2d/line_builder.cpp")
+    env.add_source_files(env.scene_sources, "../2d/node_2d.cpp")

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -35,7 +35,9 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#ifndef _2D_DISABLED
 #include "scene/2d/canvas_group.h"
+#endif // _2D_DISABLED
 #include "scene/main/canvas_layer.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
@@ -1401,11 +1403,13 @@ PackedStringArray CanvasItem::get_configuration_warnings() const {
 				warned_about_ancestor_clipping = true;
 			}
 
+#ifndef _2D_DISABLED
 			CanvasGroup *as_canvas_group = Object::cast_to<CanvasGroup>(n);
 			if (!warned_about_canvasgroup_ancestor && as_canvas_group) {
 				warnings.push_back(vformat(RTR("Ancestor \"%s\" is a CanvasGroup, so this node will not be able to clip its children."), as_canvas_group->get_name()));
 				warned_about_canvasgroup_ancestor = true;
 			}
+#endif // _2D_DISABLED
 
 			// Only break out early once both warnings have been triggered, so
 			// that the user is aware of both possible reasons for clipping not working.
@@ -1855,10 +1859,12 @@ void CanvasItem::set_clip_children_mode(ClipChildrenMode p_clip_mode) {
 
 	update_configuration_warnings();
 
+#ifndef _2D_DISABLED
 	if (Object::cast_to<CanvasGroup>(this) != nullptr) {
 		//avoid accidental bugs, make this not work on CanvasGroup
 		return;
 	}
+#endif // _2D_DISABLED
 
 	RS::get_singleton()->canvas_item_set_canvas_group_mode(get_canvas_item(), RSE::CanvasGroupMode(clip_children_mode));
 }

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2095,7 +2095,9 @@ SceneTree::SceneTree() {
 	// Initialize network state.
 	set_multiplayer(MultiplayerAPI::create_default_interface());
 
+#ifndef _2D_DISABLED
 	root->set_as_audio_listener_2d(true);
+#endif // _2D_DISABLED
 	current_scene = nullptr;
 
 	const int msaa_mode_2d = GLOBAL_GET("rendering/anti_aliasing/quality/msaa_2d");

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2101,7 +2101,9 @@ SceneTree::SceneTree() {
 	// Initialize network state.
 	set_multiplayer(MultiplayerAPI::create_default_interface());
 
+#ifndef _2D_DISABLED
 	root->set_as_audio_listener_2d(true);
+#endif // _2D_DISABLED
 	current_scene = nullptr;
 
 	const int msaa_mode_2d = GLOBAL_GET("rendering/anti_aliasing/quality/msaa_2d");

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -51,16 +51,17 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "scene/resources/dpi_texture.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/text_line.h"
+#include "scene/resources/world_2d.h"
 #include "servers/audio/audio_server.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/rendering_server_globals.h"
 
-// 2D.
+#ifndef _2D_DISABLED
 #include "scene/2d/audio_listener_2d.h"
 #include "scene/2d/camera_2d.h"
-#include "scene/resources/world_2d.h"
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 #include "scene/3d/audio_listener_3d.h"
@@ -900,6 +901,8 @@ void Viewport::_process_picking() {
 			pos = st->get_position();
 		}
 
+		// Avoid unused variable warning if 2D and 3D are both disabled.
+		(void)is_mouse;
 #ifndef PHYSICS_2D_DISABLED
 		if (ss2d) {
 			// Send to 2D.
@@ -4469,6 +4472,7 @@ void Viewport::_update_audio_listener_2d() {
 	}
 }
 
+#ifndef _2D_DISABLED
 void Viewport::_audio_listener_2d_set(AudioListener2D *p_audio_listener) {
 	if (audio_listener_2d == p_audio_listener) {
 		return;
@@ -4643,6 +4647,7 @@ Camera2D *Viewport::get_override_camera_2d() const {
 	return camera_2d_override.is_enabled() ? get_camera_2d() : nullptr;
 }
 #endif // DEBUG_ENABLED
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 AudioListener3D *Viewport::get_audio_listener_3d() const {
@@ -5303,10 +5308,12 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_process_picking"), &Viewport::_process_picking);
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
 
+#ifndef _2D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_as_audio_listener_2d", "enable"), &Viewport::set_as_audio_listener_2d);
 	ClassDB::bind_method(D_METHOD("is_audio_listener_2d"), &Viewport::is_audio_listener_2d);
 	ClassDB::bind_method(D_METHOD("get_audio_listener_2d"), &Viewport::get_audio_listener_2d);
 	ClassDB::bind_method(D_METHOD("get_camera_2d"), &Viewport::get_camera_2d);
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_world_3d", "world_3d"), &Viewport::set_world_3d);
@@ -5392,7 +5399,9 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "canvas_item_default_texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Linear Mipmap,Nearest Mipmap,Inherit"), "set_default_canvas_item_texture_filter", "get_default_canvas_item_texture_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "canvas_item_default_texture_repeat", PROPERTY_HINT_ENUM, "Disabled,Enabled,Mirror,Inherit"), "set_default_canvas_item_texture_repeat", "get_default_canvas_item_texture_repeat");
 	ADD_GROUP("Audio Listener", "audio_listener_");
+#ifndef _2D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_listener_enable_2d"), "set_as_audio_listener_2d", "is_audio_listener_2d");
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_listener_enable_3d"), "set_as_audio_listener_3d", "is_audio_listener_3d");
 #endif // _3D_DISABLED
@@ -5899,7 +5908,9 @@ T *Viewport::CameraOverride<T>::get_overridden_camera() const {
 
 // Explicit template instantiation to allow template definitions inside cpp file
 // and prevent instantiation using other than the desired camera types.
+#ifndef _2D_DISABLED
 template class Viewport::CameraOverride<Camera2D>;
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 template class Viewport::CameraOverride<Camera3D>;
 #endif // _3D_DISABLED

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -51,16 +51,17 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "scene/resources/dpi_texture.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/text_line.h"
+#include "scene/resources/world_2d.h"
 #include "servers/audio/audio_server.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/rendering_server_globals.h"
 
-// 2D.
+#ifndef _2D_DISABLED
 #include "scene/2d/audio_listener_2d.h"
 #include "scene/2d/camera_2d.h"
-#include "scene/resources/world_2d.h"
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 #include "scene/3d/audio_listener_3d.h"
@@ -900,6 +901,8 @@ void Viewport::_process_picking() {
 			pos = st->get_position();
 		}
 
+		// Avoid unused variable warning if 2D and 3D are both disabled.
+		(void)is_mouse;
 #ifndef PHYSICS_2D_DISABLED
 		if (ss2d) {
 			// Send to 2D.
@@ -4469,6 +4472,7 @@ void Viewport::_update_audio_listener_2d() {
 	}
 }
 
+#ifndef _2D_DISABLED
 void Viewport::_audio_listener_2d_set(AudioListener2D *p_audio_listener) {
 	if (audio_listener_2d == p_audio_listener) {
 		return;
@@ -4643,6 +4647,7 @@ Camera2D *Viewport::get_override_camera_2d() const {
 	return camera_2d_override.is_enabled() ? get_camera_2d() : nullptr;
 }
 #endif // DEBUG_ENABLED
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 AudioListener3D *Viewport::get_audio_listener_3d() const {
@@ -5318,10 +5323,12 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_process_picking"), &Viewport::_process_picking);
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
 
+#ifndef _2D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_as_audio_listener_2d", "enable"), &Viewport::set_as_audio_listener_2d);
 	ClassDB::bind_method(D_METHOD("is_audio_listener_2d"), &Viewport::is_audio_listener_2d);
 	ClassDB::bind_method(D_METHOD("get_audio_listener_2d"), &Viewport::get_audio_listener_2d);
 	ClassDB::bind_method(D_METHOD("get_camera_2d"), &Viewport::get_camera_2d);
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_world_3d", "world_3d"), &Viewport::set_world_3d);
@@ -5407,7 +5414,9 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "canvas_item_default_texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Linear Mipmap,Nearest Mipmap,Inherit"), "set_default_canvas_item_texture_filter", "get_default_canvas_item_texture_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "canvas_item_default_texture_repeat", PROPERTY_HINT_ENUM, "Disabled,Enabled,Mirror,Inherit"), "set_default_canvas_item_texture_repeat", "get_default_canvas_item_texture_repeat");
 	ADD_GROUP("Audio Listener", "audio_listener_");
+#ifndef _2D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_listener_enable_2d"), "set_as_audio_listener_2d", "is_audio_listener_2d");
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_listener_enable_3d"), "set_as_audio_listener_3d", "is_audio_listener_3d");
 #endif // _3D_DISABLED
@@ -5914,7 +5923,9 @@ T *Viewport::CameraOverride<T>::get_overridden_camera() const {
 
 // Explicit template instantiation to allow template definitions inside cpp file
 // and prevent instantiation using other than the desired camera types.
+#ifndef _2D_DISABLED
 template class Viewport::CameraOverride<Camera2D>;
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 template class Viewport::CameraOverride<Camera3D>;
 #endif // _3D_DISABLED

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -781,6 +781,7 @@ private:
 	};
 #endif // DEBUG_ENABLED
 
+#ifndef _2D_DISABLED
 	// 2D audio, camera, and physics. (don't put World2D here because World2D is needed for Control nodes).
 	friend class AudioListener2D; // Needs _audio_listener_2d_set and _audio_listener_2d_remove
 	AudioListener2D *audio_listener_2d = nullptr;
@@ -811,6 +812,7 @@ private:
 	// Cleans up colliders corresponding to old frames or all of them.
 	void _cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paused_only, uint64_t p_frame_reference = 0);
 #endif // PHYSICS_2D_DISABLED
+#endif // _2D_DISABLED
 
 public:
 	AudioListener2D *get_audio_listener_2d() const;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -169,6 +169,7 @@
 #include "scene/resources/texture_rd.h"
 #include "scene/resources/theme.h"
 #include "scene/resources/video_stream.h"
+#include "scene/resources/world_2d.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
@@ -177,7 +178,7 @@
 #include "scene/resources/animated_texture.h"
 #endif
 
-// 2D
+#ifndef _2D_DISABLED
 #include "scene/2d/animated_sprite_2d.h"
 #include "scene/2d/audio_listener_2d.h"
 #include "scene/2d/audio_stream_player_2d.h"
@@ -208,11 +209,11 @@
 #include "scene/resources/2d/skeleton/skeleton_modification_2d_stackholder.h"
 #include "scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.h"
 #include "scene/resources/2d/skeleton/skeleton_modification_stack_2d.h"
-#include "scene/resources/world_2d.h"
 #ifndef DISABLE_DEPRECATED
 #include "scene/2d/parallax_background.h"
 #include "scene/2d/parallax_layer.h"
 #endif
+#endif // _2D_DISABLED
 
 #ifndef NAVIGATION_2D_DISABLED
 #include "scene/2d/navigation/navigation_agent_2d.h"
@@ -800,14 +801,17 @@ void register_scene_types() {
 	CanvasItemMaterial::init_shaders();
 	GDREGISTER_CLASS(BlitMaterial);
 
+	// SpriteFrames is needed by both AnimatedSprite2D and AnimatedSprite3D.
+	GDREGISTER_CLASS(SpriteFrames);
+
 	/* REGISTER 2D */
 
+#ifndef _2D_DISABLED
 	GDREGISTER_CLASS(Node2D);
 	GDREGISTER_CLASS(CanvasGroup);
 	GDREGISTER_CLASS(CPUParticles2D);
 	GDREGISTER_CLASS(GPUParticles2D);
 	GDREGISTER_CLASS(Sprite2D);
-	GDREGISTER_CLASS(SpriteFrames);
 	GDREGISTER_CLASS(AnimatedSprite2D);
 	GDREGISTER_CLASS(Marker2D);
 	GDREGISTER_CLASS(Line2D);
@@ -872,6 +876,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(SkeletonModification2DJiggle);
 	GDREGISTER_CLASS(SkeletonModification2DPhysicalBones);
 #endif // PHYSICS_2D_DISABLED
+#endif // _2D_DISABLED
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -1035,6 +1040,7 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); // may take time to init
 
+#ifndef _2D_DISABLED
 	GDREGISTER_CLASS(AudioStreamPlayer2D);
 	GDREGISTER_CLASS(Curve2D);
 	GDREGISTER_CLASS(Path2D);
@@ -1076,6 +1082,7 @@ void register_scene_types() {
 	StaticBody2D::navmesh_parse_init();
 #endif // PHYSICS_2D_DISABLED
 #endif // NAVIGATION_2D_DISABLED
+#endif // _2D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED
 	// 3D nodes that support navmesh baking need to server register their source geometry parsers.

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -169,6 +169,7 @@
 #include "scene/resources/texture_rd.h"
 #include "scene/resources/theme.h"
 #include "scene/resources/video_stream.h"
+#include "scene/resources/world_2d.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
@@ -177,7 +178,7 @@
 #include "scene/resources/animated_texture.h"
 #endif
 
-// 2D
+#ifndef _2D_DISABLED
 #include "scene/2d/animated_sprite_2d.h"
 #include "scene/2d/audio_listener_2d.h"
 #include "scene/2d/audio_stream_player_2d.h"
@@ -208,11 +209,11 @@
 #include "scene/resources/2d/skeleton/skeleton_modification_2d_stackholder.h"
 #include "scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.h"
 #include "scene/resources/2d/skeleton/skeleton_modification_stack_2d.h"
-#include "scene/resources/world_2d.h"
 #ifndef DISABLE_DEPRECATED
 #include "scene/2d/parallax_background.h"
 #include "scene/2d/parallax_layer.h"
 #endif
+#endif // _2D_DISABLED
 
 #ifndef NAVIGATION_2D_DISABLED
 #include "scene/2d/navigation/navigation_agent_2d.h"
@@ -560,7 +561,9 @@ void register_scene_types() {
 	GDREGISTER_CLASS(GraphElement);
 	GDREGISTER_CLASS(GraphNode);
 	GDREGISTER_CLASS(GraphFrame);
+#ifndef _2D_DISABLED
 	GDREGISTER_CLASS(GraphEdit);
+#endif // _2D_DISABLED
 
 	GDREGISTER_CLASS(FoldableGroup);
 	GDREGISTER_CLASS(FoldableContainer);
@@ -790,6 +793,7 @@ void register_scene_types() {
 
 	/* REGISTER 2D */
 
+#ifndef _2D_DISABLED
 	GDREGISTER_CLASS(Node2D);
 	GDREGISTER_CLASS(CanvasGroup);
 	GDREGISTER_CLASS(CPUParticles2D);
@@ -860,6 +864,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(SkeletonModification2DJiggle);
 	GDREGISTER_CLASS(SkeletonModification2DPhysicalBones);
 #endif // PHYSICS_2D_DISABLED
+#endif // _2D_DISABLED
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -1023,6 +1028,7 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); // may take time to init
 
+#ifndef _2D_DISABLED
 	GDREGISTER_CLASS(AudioStreamPlayer2D);
 	GDREGISTER_CLASS(Curve2D);
 	GDREGISTER_CLASS(Path2D);
@@ -1064,6 +1070,7 @@ void register_scene_types() {
 	StaticBody2D::navmesh_parse_init();
 #endif // PHYSICS_2D_DISABLED
 #endif // NAVIGATION_2D_DISABLED
+#endif // _2D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED
 	// 3D nodes that support navmesh baking need to server register their source geometry parsers.

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -29,7 +29,8 @@ env.scene_sources += scene_obj
 # Needed to force rebuilding the scene files when the thirdparty code is updated.
 env.Depends(scene_obj, thirdparty_obj)
 
-SConscript("2d/SCsub")
+if not env["disable_2d"]:
+    SConscript("2d/SCsub")
 if not env["disable_3d"]:
     SConscript("3d/SCsub")
 SConscript("audio/SCsub")

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -40,11 +40,14 @@
 #include "core/templates/local_vector.h"
 #include "core/variant/callable_bind.h"
 #include "core/variant/container_type_validate.h"
-#include "scene/2d/node_2d.h"
 #include "scene/gui/control.h"
 #include "scene/main/instance_placeholder.h"
 #include "scene/main/missing_node.h"
 #include "scene/property_utils.h"
+
+#ifndef _2D_DISABLED
+#include "scene/2d/node_2d.h"
+#endif // _2D_DISABLED
 
 #ifndef _3D_DISABLED
 #include "scene/3d/node_3d.h"
@@ -409,8 +412,10 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 					if (n.parent >= 0 && n.parent < nc && ret_nodes[n.parent]) {
 						if (Object::cast_to<Control>(ret_nodes[n.parent])) {
 							obj = memnew(Control);
+#ifndef _2D_DISABLED
 						} else if (Object::cast_to<Node2D>(ret_nodes[n.parent])) {
 							obj = memnew(Node2D);
+#endif // _2D_DISABLED
 #ifndef _3D_DISABLED
 						} else if (Object::cast_to<Node3D>(ret_nodes[n.parent])) {
 							obj = memnew(Node3D);

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -40,6 +40,7 @@ class VisibleOnScreenNotifier2D;
 class Viewport;
 struct SpatialIndexer2D;
 
+// World2D is needed for Viewport for CanvasItem rendering even when 2D is disabled.
 class World2D : public Resource {
 	GDCLASS(World2D, Resource);
 


### PR DESCRIPTION
Implements and closes https://github.com/godotengine/godot-proposals/issues/1653 and https://github.com/godotengine/godot-proposals/issues/190.

This PR allows disabling 2D when compiling export templates. The 2D rendering stuff isn't disabled as it's needed for Control nodes, but all of the nodes under `scene/2d` are disabled (except for Line2D/Sprite2D/Node2D), as well as 2D physics and many 2D-only resources.

With optimized `production=yes` builds of export templates, with 2D enabled the file size is 56.4 MB, and with 2D disabled the file size is 50.8 MB. This is a reduction of 5.6 MB, about 9.9%.

Disabling 2D with this PR actually gives even better gains than the current `disable_3d=yes` option for 3D, which optimized `production=yes` builds of export templates, with `disable_3d=yes`, the size is 52.4 MB (a reduction of 4.0 MB or 7.1%).

This PR adds the `#ifndef`s and SCons code to add support for disabling 2D when compiling export templates. When compiling with `disable_2d=yes`, `_2D_DISABLED` is defined. Everything is disabled in `scene/2d`, `scene/resources/2d`, except Line2D which is needed by GraphEdit.

This PR has two main use cases: 3D games (which only need 3D and UI, not 2D), and UI-only projects (which only need UI, not 2D or 3D, and 3D can already be disabled), which helps solve https://github.com/godotengine/godot-proposals/issues/190.

- *Bugsquad edit:* closes godotengine/godot-proposals#190