### PR TITLE
Bump version to 3.3-rc

### DIFF
--- a/misc/dist/osx_tools.app/Contents/Info.plist
+++ b/misc/dist/osx_tools.app/Contents/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.4</string>
+	<string>3.3</string>
 	<key>CFBundleSignature</key>
 	<string>godot</string>
 	<key>CFBundleVersion</key>
-	<string>3.2.4</string>
+	<string>3.3</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Microphone access is required to capture audio.</string>
 	<key>NSCameraUsageDescription</key>

--- a/misc/dist/windows/godot.iss
+++ b/misc/dist/windows/godot.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Godot Engine"
-#define MyAppVersion "3.2.4"
+#define MyAppVersion "3.3"
 #define MyAppPublisher "Godot Engine contributors"
 #define MyAppURL "https://godotengine.org/"
 #define MyAppExeName "godot.exe"

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
@@ -6,8 +6,8 @@
     <Authors>Godot Engine contributors</Authors>
 
     <PackageId>Godot.NET.Sdk</PackageId>
-    <Version>3.2.4</Version>
-    <PackageVersion>3.2.4</PackageVersion>
+    <Version>3.3</Version>
+    <PackageVersion>3.3</PackageVersion>
     <PackageProjectUrl>https://github.com/godotengine/godot/tree/master/modules/mono/editor/Godot.NET.Sdk</PackageProjectUrl>
     <PackageType>MSBuildSdk</PackageType>
     <PackageTags>MSBuildSdk</PackageTags>

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -8,7 +8,7 @@ namespace GodotTools.ProjectEditor
 {
     public static class ProjectGenerator
     {
-        public const string GodotSdkVersionToUse = "3.2.4";
+        public const string GodotSdkVersionToUse = "3.3";
         public const string GodotSdkNameToUse = "Godot.NET.Sdk";
 
         public static ProjectRootElement GenGameProject(string name)

--- a/version.py
+++ b/version.py
@@ -1,8 +1,8 @@
 short_name = "godot"
 name = "Godot Engine"
 major = 3
-minor = 2
-patch = 4
+minor = 3
+patch = 0
 status = "rc"
 module_config = ""
 year = 2021


### PR DESCRIPTION
We decided to rename the upcoming 3.2.4 release to 3.3 to better reflect that
it is a significant feature release, and not a maintenance update.

The `3.2` branch was also renamed to `3.x` and will now be the development
branch for future 3.x releases (3.3, 3.4, etc.).

*Edit:* See announcement: #47057.

---

@neikeq Could you confirm that the Mono changes are good too?