### PR TITLE
[macOS, sandbox] Add `files.user-selected` entitlement support for arbitrary folder access.

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -225,8 +225,8 @@
 			<return type="PackedStringArray">
 			</return>
 			<description>
-				With this function you can get the list of dangerous permissions that have been granted to the Android application.
-				[b]Note:[/b] This method is implemented on Android.
+				On Android devices, this function you can get the list of dangerous permissions that have been granted.
+				On macOS (sandboxed applications only), this function you can get the list of user selected folders accessible to the application. Use [code]request_permission("APP_SANDBOX_FILE_ACCESS")[/code] to request folder access permission.
 			</description>
 		</method>
 		<method name="get_keycode_string" qualifiers="const">
@@ -493,7 +493,10 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				At the moment this function is only used by [code]AudioDriverOpenSL[/code] to request permission for [code]RECORD_AUDIO[/code] on Android.
+				On Android devices, [code]request_permission("RECORD_AUDIO")[/code] is used by [code]AudioDriverOpenSL[/code] to request permission for audio recording (function is called automatically).
+
+				On macOS (sandboxed applications only), [code]request_permission("APP_SANDBOX_FILE_ACCESS")[/code] can be used to request access to the user selected folder. Granted permissions are saved as security-scoped bookmark and automatically granted in subsequent sessions.
+				[b]Note:[/b] To use this function, sandboxed applications must have [code]codesign/entitlements/app_sandbox/files_user_selected[/code] entitlement enabled.
 			</description>
 		</method>
 		<method name="request_permissions">

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -182,6 +182,7 @@ void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_pictures", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_music", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_movies", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_user_selected", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::PACKED_STRING_ARRAY, "codesign/custom_options"), PackedStringArray()));
 
@@ -868,6 +869,14 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_movies") == 2) {
 						ent_f->store_line("<key>com.apple.security.files.movies.read-write</key>");
+						ent_f->store_line("<true/>");
+					}
+					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_user_selected") == 1) {
+						ent_f->store_line("<key>ccom.apple.security.files.user-selected.read-only</key>");
+						ent_f->store_line("<true/>");
+					}
+					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_user_selected") == 2) {
+						ent_f->store_line("<key>com.apple.security.files.user-selected.read-write</key>");
 						ent_f->store_line("<true/>");
 					}
 				}

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -101,6 +101,9 @@ public:
 
 	virtual Error move_to_trash(const String &p_path) override;
 
+	virtual bool request_permission(const String &p_name) override;
+	virtual Vector<String> get_granted_permissions() const override;
+
 	OS_OSX();
 };
 


### PR DESCRIPTION
Adds ability to access arbitrary folders for macOS sandboxed apps (`Entitlements` → `App Sandbox` → `Enabled` is selected during export).

- Adds `files.user-selected` entitlement support to the export dialog.
- Implements `OS_OSX::request_permission("APP_SANDBOX_FILE_ACCESS")` to request access to the folder.
- Implements `OS_OSX::get_granted_permissions()` to get list of accessible folders.
- Granted permissions are preserved across sessions as sandbox security-scoped bookmarks.
- Has no effect for non-sandboxed apps.

https://user-images.githubusercontent.com/7645683/111302684-608e8c00-865c-11eb-91f6-84b27ba79030.mov

*Edit: It's relevant for 3.x as well, but will require separate PR.*
