### PR TITLE
Fix crash on calling play() in a uninitialized AnimatedSprite2D (Fix #46013)

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -382,6 +382,7 @@ bool AnimatedSprite2D::_is_playing() const {
 }
 
 void AnimatedSprite2D::play(const StringName &p_animation, const bool p_backwards) {
+	ERR_FAIL_NULL_MSG(frames, "Can't play AnimatedSprite2D without a valid SpriteFrames resource.");
 	backwards = p_backwards;
 
 	if (p_animation) {


### PR DESCRIPTION
Fix #46013

### Issue Fixed

When AnimatedSprite2D::play() was called before SpriteFrames has been initialized, a crash occurred.

### Cause of crash

In AnimatedSprite2D::play(), frames->get_frame() can be called even if frames is null.
Occurs when play() is called before frames are initialized.

### Fix proposal

An informative error message on null check test has been added to prevent crash.
`ERR_FAIL_NULL_MSG(frames, "SpriteFrames reference is invalid (NULL) in AnimatedSprite2D::play()");`
