### PR TITLE
Fix bug causing `project.godot` to be ignored when `project.binary` is missing

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -643,7 +643,6 @@ Error ProjectSettings::_load_settings_text_or_binary(const String &p_text_path, 
 	} else if (err != ERR_FILE_NOT_FOUND) {
 		// If the file exists but can't be loaded, we want to know it.
 		ERR_PRINT("Couldn't load file '" + p_bin_path + "', error code " + itos(err) + ".");
-		return err;
 	}
 
 	// Fallback to text-based project.godot file if binary was not found.
@@ -652,7 +651,6 @@ Error ProjectSettings::_load_settings_text_or_binary(const String &p_text_path, 
 		return OK;
 	} else if (err != ERR_FILE_NOT_FOUND) {
 		ERR_PRINT("Couldn't load file '" + p_text_path + "', error code " + itos(err) + ".");
-		return err;
 	}
 
 	return err;


### PR DESCRIPTION
Addresses the comment made in https://github.com/godotengine/godot/pull/42980/files/37d515e99c2da449397511cbc9b25fee84dd66fc#diff-d06617966387fb7135d4af8cf52217b94e7a4c658c6ed9f259bbf8cd801e31d5.