### PR TITLE
Document different unit of measurements for sensor data on iOS and Android

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -51,7 +51,7 @@
 			<description>
 				Returns the acceleration of the device's accelerometer sensor, if the device has one. Otherwise, the method returns [constant Vector3.ZERO].
 				Note this method returns an empty [Vector3] when running from the editor even when your device has an accelerometer. You must export your project to a supported device to read values from the accelerometer.
-				[b]Note:[/b] This method only works on iOS, Android, and UWP. On other platforms, it always returns [constant Vector3.ZERO].
+				[b]Note:[/b] This method only works on iOS, Android, and UWP. On other platforms, it always returns [constant Vector3.ZERO]. On Android the unit of measurement for each axis is m/s² while on iOS and UWP it's a multiple of the Earth's gravitational acceleration [code]g[/code] (~9.81 m/s²).
 			</description>
 		</method>
 		<method name="get_action_raw_strength" qualifiers="const">
@@ -107,7 +107,7 @@
 			</return>
 			<description>
 				Returns the gravity of the device's accelerometer sensor, if the device has one. Otherwise, the method returns [constant Vector3.ZERO].
-				[b]Note:[/b] This method only works on Android and iOS. On other platforms, it always returns [constant Vector3.ZERO].
+				[b]Note:[/b] This method only works on Android and iOS. On other platforms, it always returns [constant Vector3.ZERO]. On Android the unit of measurement for each axis is m/s² while on iOS it's a multiple of the Earth's gravitational acceleration [code]g[/code] (~9.81 m/s²).
 			</description>
 		</method>
 		<method name="get_gyroscope" qualifiers="const">


### PR DESCRIPTION
The unit of measurement for the acceleration sensors are different on iOS and Android.

Android (m/s²): https://developer.android.com/guide/topics/sensors/sensors_motion
iOS (g):  https://developer.apple.com/documentation/coremotion/getting_raw_accelerometer_events