### PR TITLE
[Net] Make debugger peer less CPU intensive.

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -190,13 +190,18 @@ Error RemoteDebuggerPeerTCP::connect_to_host(const String &p_host, uint16_t p_po
 }
 
 void RemoteDebuggerPeerTCP::_thread_func(void *p_ud) {
+	const uint64_t min_tick = 100;
 	RemoteDebuggerPeerTCP *peer = (RemoteDebuggerPeerTCP *)p_ud;
 	while (peer->running && peer->is_peer_connected()) {
+		uint64_t ticks_usec = OS::get_singleton()->get_ticks_usec();
 		peer->_poll();
 		if (!peer->is_peer_connected()) {
 			break;
 		}
-		peer->tcp_client->poll(NetSocket::POLL_TYPE_IN_OUT, 1);
+		ticks_usec = OS::get_singleton()->get_ticks_usec() - ticks_usec;
+		if (ticks_usec < min_tick) {
+			OS::get_singleton()->delay_usec(min_tick - ticks_usec);
+		}
 	}
 }
 


### PR DESCRIPTION
Make sure that RemoteDebuggerPeer wait at least 100us between polls (effectively forcing a min tick of 100 microseconds).

This greatly improve performances (the call to poll was useless since during low traffic, writes would always be available, and during high traffic, reads would always be available, effectively making it a busy-waiting loop). We could further improve this, by separating the two polls, and adjust the min tick based on load, but this is most likely more than enough already without sacrificing too much on high loads.

Fixes #47026