### PR TITLE
Remove optional 'text/css' attribute from HTML templates

### DIFF
--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8" />
 	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
 	<title>$GODOT_PROJECT_NAME</title>
-	<style type="text/css">
+	<style>
 
 		body {
 			margin: 0;
@@ -223,8 +223,8 @@ $GODOT_HEAD_INCLUDE
 		<div id="output-container"><div id="output-scroll"></div></div>
 	</div>
 
-	<script type="text/javascript" src="$GODOT_BASENAME.js"></script>
-	<script type="text/javascript">//<![CDATA[
+	<script src="$GODOT_BASENAME.js"></script>
+	<script>//<![CDATA[
 
 		var engine = new Engine;
 

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -5,7 +5,7 @@
 	<meta name='viewport' content='width=device-width, user-scalable=no' />
 	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
 	<title>$GODOT_PROJECT_NAME</title>
-	<style type='text/css'>
+	<style>
 
 		body {
 			touch-action: none;
@@ -134,8 +134,8 @@ $GODOT_HEAD_INCLUDE
 		<div id='status-notice' class='godot' style='display: none;'></div>
 	</div>
 
-	<script type='text/javascript' src='$GODOT_URL'></script>
-	<script type='text/javascript'>//<![CDATA[
+	<script src='$GODOT_URL'></script>
+	<script>//<![CDATA[
 
 		const GODOT_CONFIG = $GODOT_CONFIG;
 		var engine = new Engine(GODOT_CONFIG);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
This removes the `type='text/css'` from the style elements. According to [here](https://www.h3xed.com/web-development/is-type-text-css-needed-for-style-and-link-tags) it is unnecessary. 