### PR TITLE
Allow nullptr with zero length in FileAccess get_buffer

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -286,7 +286,7 @@ uint8_t FileAccessCompressed::get_8() const {
 }
 
 int FileAccessCompressed::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V_MSG(!f, -1, "File must be opened before use.");
 	ERR_FAIL_COND_V_MSG(writing, -1, "File has not been opened in read mode.");

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -237,7 +237,7 @@ uint8_t FileAccessEncrypted::get_8() const {
 }
 
 int FileAccessEncrypted::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V_MSG(writing, -1, "File has not been opened in read mode.");
 

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -138,7 +138,7 @@ uint8_t FileAccessMemory::get_8() const {
 }
 
 int FileAccessMemory::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V(!data, -1);
 

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -366,7 +366,7 @@ void FileAccessNetwork::_queue_page(int p_page) const {
 }
 
 int FileAccessNetwork::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 
 	//bool eof=false;

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -299,7 +299,7 @@ uint8_t FileAccessPack::get_8() const {
 }
 
 int FileAccessPack::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 
 	if (eof) {

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -303,7 +303,7 @@ uint8_t FileAccessZip::get_8() const {
 }
 
 int FileAccessZip::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V(!zfile, -1);
 	at_eof = unzeof(zfile);

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -368,7 +368,7 @@ Vector<String> FileAccess::get_csv_line(const String &p_delim) const {
 }
 
 int FileAccess::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 	int i = 0;
 	for (i = 0; i < p_length && !eof_reached(); i++) {

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -240,7 +240,7 @@ uint8_t FileAccessUnix::get_8() const {
 }
 
 int FileAccessUnix::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V_MSG(!f, -1, "File must be opened before use.");
 	int read = fread(p_dst, 1, p_length, f);

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -253,7 +253,7 @@ uint8_t FileAccessWindows::get_8() const {
 }
 
 int FileAccessWindows::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V(!f, -1);
 	if (flags == READ_WRITE || flags == WRITE_READ) {


### PR DESCRIPTION
fix #47071

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
