### PR TITLE
Converted sensor acceleration units to m/s² on iOS and UWP

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -49,9 +49,9 @@
 			<return type="Vector3">
 			</return>
 			<description>
-				Returns the acceleration of the device's accelerometer sensor, if the device has one. Otherwise, the method returns [constant Vector3.ZERO].
+				Returns the acceleration in m/s² of the device's accelerometer sensor, if the device has one. Otherwise, the method returns [constant Vector3.ZERO].
 				Note this method returns an empty [Vector3] when running from the editor even when your device has an accelerometer. You must export your project to a supported device to read values from the accelerometer.
-				[b]Note:[/b] This method only works on iOS, Android, and UWP. On other platforms, it always returns [constant Vector3.ZERO]. On Android the unit of measurement for each axis is m/s² while on iOS and UWP it's a multiple of the Earth's gravitational acceleration [code]g[/code] (~9.81 m/s²).
+				[b]Note:[/b] This method only works on iOS, Android, and UWP. On other platforms, it always returns [constant Vector3.ZERO].
 			</description>
 		</method>
 		<method name="get_action_raw_strength" qualifiers="const">
@@ -106,8 +106,8 @@
 			<return type="Vector3">
 			</return>
 			<description>
-				Returns the gravity of the device's accelerometer sensor, if the device has one. Otherwise, the method returns [constant Vector3.ZERO].
-				[b]Note:[/b] This method only works on Android and iOS. On other platforms, it always returns [constant Vector3.ZERO]. On Android the unit of measurement for each axis is m/s² while on iOS it's a multiple of the Earth's gravitational acceleration [code]g[/code] (~9.81 m/s²).
+				Returns the gravity in m/s² of the device's accelerometer sensor, if the device has one. Otherwise, the method returns [constant Vector3.ZERO].
+				[b]Note:[/b] This method only works on Android and iOS. On other platforms, it always returns [constant Vector3.ZERO].
 			</description>
 		</method>
 		<method name="get_gyroscope" qualifiers="const">

--- a/platform/iphone/godot_view.mm
+++ b/platform/iphone/godot_view.mm
@@ -39,6 +39,7 @@
 #import <CoreMotion/CoreMotion.h>
 
 static const int max_touches = 8;
+static const float earth_gravity = 9.80665;
 
 @interface GodotView () {
 	UITouch *godot_touches[max_touches];
@@ -402,9 +403,18 @@ static const int max_touches = 8;
 	// https://developer.apple.com/reference/coremotion/cmmotionmanager?language=objc
 
 	// Apple splits our accelerometer date into a gravity and user movement
-	// component. We add them back together
+	// component. We add them back together.
 	CMAcceleration gravity = self.motionManager.deviceMotion.gravity;
 	CMAcceleration acceleration = self.motionManager.deviceMotion.userAcceleration;
+
+	// To be consistent with Android we convert the unit of measurement from g (Earth's gravity)
+	// to m/s^2.
+	gravity.x *= earth_gravity;
+	gravity.y *= earth_gravity;
+	gravity.z *= earth_gravity;
+	acceleration.x *= earth_gravity;
+	acceleration.y *= earth_gravity;
+	acceleration.z *= earth_gravity;
 
 	///@TODO We don't seem to be getting data here, is my device broken or
 	/// is this code incorrect?

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -62,6 +62,8 @@ using namespace Windows::Devices::Sensors;
 using namespace Windows::ApplicationModel::DataTransfer;
 using namespace concurrency;
 
+static const float earth_gravity = 9.80665;
+
 int OS_UWP::get_video_driver_count() const {
 	return 2;
 }
@@ -372,9 +374,9 @@ void OS_UWP::ManagedType::on_accelerometer_reading_changed(Accelerometer ^ sende
 	AccelerometerReading ^ reading = args->Reading;
 
 	os->input->set_accelerometer(Vector3(
-			reading->AccelerationX,
-			reading->AccelerationY,
-			reading->AccelerationZ));
+			reading->AccelerationX * earth_gravity,
+			reading->AccelerationY * earth_gravity,
+			reading->AccelerationZ * earth_gravity));
 }
 
 void OS_UWP::ManagedType::on_magnetometer_reading_changed(Magnetometer ^ sender, MagnetometerReadingChangedEventArgs ^ args) {


### PR DESCRIPTION
This is because on Android these values are already in `m/s²` while on iOS they are in `g`. This just makes the behaviour on both platforms consistent.

Note that i did not test this. I could test this on real hardware later, but i'm not sure if the current master branch even runs on iOS. **Edit**: I'm just going to test this on the 3.x branch tomorrow, so marking this as WIP for now..but should be fine.

Follow-up PR to #47070