### PR TITLE
Batching - prevent CPU transform for non-rects using large FVF

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -1310,7 +1310,9 @@ PREAMBLE(bool)::_prefill_line(RasterizerCanvas::Item::CommandLine *p_line, FillS
 	Vector2 from = p_line->from;
 	Vector2 to = p_line->to;
 
-	if (r_fill_state.transform_mode != TM_NONE) {
+	const bool use_large_verts = bdata.use_large_verts;
+
+	if ((r_fill_state.transform_mode != TM_NONE) && (!use_large_verts)) {
 		_software_transform_vertex(from, r_fill_state.transform_combined);
 		_software_transform_vertex(to, r_fill_state.transform_combined);
 	}
@@ -1658,13 +1660,15 @@ bool C_PREAMBLE::_prefill_polygon(RasterizerCanvas::Item::CommandPolygon *p_poly
 
 	if (!_software_skin_poly(p_poly, p_item, bvs, vertex_colors, r_fill_state, precalced_colors)) {
 
+		bool software_transform = (r_fill_state.transform_mode != TM_NONE) && (!use_large_verts);
+
 		for (int n = 0; n < num_inds; n++) {
 			int ind = p_poly->indices[n];
 
 			RAST_DEV_DEBUG_ASSERT(ind < p_poly->points.size());
 
 			// this could be moved outside the loop
-			if (r_fill_state.transform_mode != TM_NONE) {
+			if (software_transform) {
 				Vector2 pos = p_poly->points[ind];
 				_software_transform_vertex(pos, r_fill_state.transform_combined);
 				bvs[n].pos.set(pos.x, pos.y);


### PR DESCRIPTION
Large FVF which encodes the transform in a vertex attribute is triggered by reading from VERTEX in a custom shader. This means that the local vertex position must be available in the shader, so the only way to batch is to also pass the transform as an attribute.

The large FVF path already disabled CPU transform in the case of rects, but not in other primitives, which this PR fixes. Without these fixes, the transform will be applied twice, i.e. position 10, 10 will become 20, 20 etc.

Note that large FVF is incompatible with 2d software skinning. So reading from VERTEX in a custom shader which uses skinning will not work.

Fixes #47090

## Notes
* I'm going to have a look at seeing whether the software skinning case can be addressed in another PR. It should be rare, and for now, worst case users can turn off software skinning manually if they want to use a skinning shader that reads from VERTEX. But hopefully we can detect this and switch to legacy skinning automatically.
* This PR should be low risk.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
