### PR TITLE
Documentation: Correct CanvasItem.draw_string position description.

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -318,7 +318,7 @@
 			<argument index="9" name="flags" type="int" default="3">
 			</argument>
 			<description>
-				Draws [code]text[/code] using the specified [code]font[/code] at the [code]position[/code] (top-left corner). The text will have its color multiplied by [code]modulate[/code]. If [code]clip_w[/code] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
+				Draws [code]text[/code] using the specified [code]font[/code] at the [code]position[/code] (bottom-left corner using the baseline of the font). The text will have its color multiplied by [code]modulate[/code]. If [code]clip_w[/code] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
 				[b]Example using the default project font:[/b]
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -175,7 +175,7 @@
 			</argument>
 			<description>
 				Returns the size of a character, optionally taking kerning into account if the next character is provided.
-				[b]Note:[/b] Do not use this function to calculate width of the string character by character, use [method get_string_size] or [TextLine] instead.
+				[b]Note:[/b] Do not use this function to calculate width of the string character by character, use [method get_string_size] or [TextLine] instead. The height returned is the font height (see also [method get_height]) and has no relation to the glyph height.
 			</description>
 		</method>
 		<method name="get_data" qualifiers="const">
@@ -248,6 +248,7 @@
 			</argument>
 			<description>
 				Returns the size size of a bounding box of a string, taking kerning and advance into account.
+				[b]Note:[/b] Real height of the string is context-dependent and can be significantly different from the value returned by [method get_height].
 				See also [method draw_string].
 			</description>
 		</method>


### PR DESCRIPTION
4.0 version of #45577 
godotengine/godot-docs#4599
Clarify some potential sources of confusion about font height and positioning.

Behaviour confirmed on all three changes/additions.
`CanvasItem.draw_string` positioning:
![image](https://user-images.githubusercontent.com/5397662/111477991-937d7080-877f-11eb-96f3-9713cfbd5d52.png)
![image](https://user-images.githubusercontent.com/5397662/111477958-89f40880-877f-11eb-8012-864c64cf25f3.png)

`Font.get_char_size` and `Font.get_string_size`:
![image](https://user-images.githubusercontent.com/5397662/111478244-d0e1fe00-877f-11eb-8d89-775d268eb239.png)
![image](https://user-images.githubusercontent.com/5397662/111478206-c58ed280-877f-11eb-80dc-f83ce5d48971.png)
