### PR TITLE
[HTML5] Fix bogus Web Editor manifest.

### DIFF
--- a/misc/dist/html/manifest.json
+++ b/misc/dist/html/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Godot",
   "description": "Multi-platform 2D and 3D game engine with a feature-rich editor",
   "lang": "en",
-  "start_url": "/godot.tools.html",
+  "start_url": "./godot.tools.html",
   "display": "standalone",
   "orientation": "landscape",
   "theme_color": "#478cbf",


### PR DESCRIPTION
The `start_url` in the PWA manifest.json must be relative for it to work in subfolders (like in the official Web Editor page).