### PR TITLE
Add to 2d software skinning classref note about custom shaders

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1046,6 +1046,7 @@
 			If [code]true[/code], performs 2D skinning on the CPU rather than the GPU. This provides greater compatibility with a wide range of hardware, and also may be faster in some circumstances.
 			Currently only available when [member rendering/batching/options/use_batching] is active.
 			[b]Note:[/b] Antialiased software skinned polys are not supported, and will be rendered without antialiasing.
+			[b]Note:[/b] Custom shaders that use the [code]VERTEX[/code] built-in operate with [code]VERTEX[/code] position [i]after[/i] skinning, whereas with hardware skinning, [code]VERTEX[/code] is the position [i]before[/i] skinning.
 		</member>
 		<member name="rendering/2d/snapping/use_gpu_pixel_snap" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], forces snapping of vertices to pixels in 2D rendering. May help in some pixel art styles.


### PR DESCRIPTION
Added note to say that custom shaders operate on VERTEX after the transform with 2d software skinning rather than before (as is the case with hardware skinning).

## Notes
* Given that the transform for software skinning happens on CPU it would not be trivial to make available the same functionality as hardware skinning for custom shaders. It could be done by skinning the transforms instead of the vertex and using large FVF but this may not be worth it, and would certainly require testing etc.
* We could just say reading and writing to VERTEX is unsupported for software skinning.
* On the other hand, being able to operate in world (or camera?) space is actually more useful in many situations than using pre-transformed space. So we could turn a bug into a feature... :slightly_smiling_face: 
* We have to weigh this up against the commitment to support this in future.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
