### PR TITLE
[WIP] Enable retention of the Godot fragment across Activity lifecycle events

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -521,6 +521,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	@Override
 	public void onCreate(Bundle icicle) {
 		super.onCreate(icicle);
+		setRetainInstance(true);
 
 		final Activity activity = getActivity();
 		Window window = activity.getWindow();


### PR DESCRIPTION
Among other benefits, when Godot is in subview mode, this will prevent the activity from attempting to recreate the Godot instance and all its native state for each activity lifecycle events (e.g: screen rotations). 