### PR TITLE
Fix New Tree References Null Stylebox

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3506,9 +3506,12 @@ int Tree::get_column_width(int p_column) const {
 		return columns[p_column].min_width;
 	}
 
+	int expand_area = get_size().width;
+	
 	Ref<StyleBox> bg = cache.bg;
-
-	int expand_area = get_size().width - (bg->get_margin(SIDE_LEFT) + bg->get_margin(SIDE_RIGHT));
+	
+	if (bg.is_valid())
+		expand_area -= (bg->get_margin(SIDE_LEFT) + bg->get_margin(SIDE_RIGHT));
 
 	if (v_scroll->is_visible_in_tree()) {
 		expand_area -= v_scroll->get_combined_minimum_size().width;


### PR DESCRIPTION
Creating a new Tree and attempting to read `get_column_width(0)` will crash Godot because of a null reference to cache StyleBox

Add an `is_valid` check for the StyleBox will let the script run normally

Fix #46005 

