### PR TITLE
Fix AudioEffectCapture buffer length cannot be changed (Fix #47107)

### DIFF
--- a/doc/classes/AudioEffectCapture.xml
+++ b/doc/classes/AudioEffectCapture.xml
@@ -67,7 +67,7 @@
 	</methods>
 	<members>
 		<member name="buffer_length" type="float" setter="set_buffer_length" getter="get_buffer_length" default="0.1">
-			Length of the internal ring buffer, in seconds.
+			Length of the internal ring buffer, in seconds. Setting the buffer length will have no effect if already initialized.
 		</member>
 	</members>
 	<constants>

--- a/servers/audio/effects/audio_effect_capture.cpp
+++ b/servers/audio/effects/audio_effect_capture.cpp
@@ -91,8 +91,6 @@ Ref<AudioEffectInstance> AudioEffectCapture::instance() {
 }
 
 void AudioEffectCapture::set_buffer_length(float p_buffer_length_seconds) {
-	ERR_FAIL_COND(buffer_initialized);
-
 	buffer_length_seconds = p_buffer_length_seconds;
 }
 


### PR DESCRIPTION
Fix #47107

### Issue : 

AudioEffectCapture buffer length cannot be changed, neither by code nor by editor interface.

### Cause : 

Error check in set_buffer_length() prevents from changing size of a the buffer.

### Fix proposal : 

Inverse the test and set a more clear error message.

`ERR_FAIL_COND_MSG(!buffer_initialized, "Can't set AudioEffectCapture buffer length. Buffer is not initialized.");`


Edit : Following Iyuma advice, I've removed the check and updated the xml doc.