### PR TITLE
Disable 3D-only modules when 3D is disabled

### DIFF
--- a/modules/bullet/config.py
+++ b/modules/bullet/config.py
@@ -1,6 +1,7 @@
 def can_build(env, platform):
     # API Changed and bullet is disabled at the moment
     return False
+    # Later change to return not env["disable_3d"]
 
 
 def configure(env):

--- a/modules/csg/config.py
+++ b/modules/csg/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return True
+    return not env["disable_3d"]
 
 
 def configure(env):

--- a/modules/gridmap/config.py
+++ b/modules/gridmap/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return True
+    return not env["disable_3d"]
 
 
 def configure(env):

--- a/modules/meshoptimizer/config.py
+++ b/modules/meshoptimizer/config.py
@@ -1,6 +1,6 @@
 def can_build(env, platform):
     # Having this on release by default, it's small and a lot of users like to do procedural stuff
-    return True
+    return not env["disable_3d"]
 
 
 def configure(env):

--- a/modules/mobile_vr/config.py
+++ b/modules/mobile_vr/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return True
+    return not env["disable_3d"]
 
 
 def configure(env):

--- a/modules/vhacd/config.py
+++ b/modules/vhacd/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return True
+    return not env["disable_3d"]
 
 
 def configure(env):

--- a/modules/webxr/config.py
+++ b/modules/webxr/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return True
+    return not env["disable_3d"]
 
 
 def configure(env):


### PR DESCRIPTION
When 3D is disabled, there are many modules that are no longer relevant. GLTF already disables itself. This PR does:

* Disable CSG
* Disable GridMap
* Disable MeshOptimizer
* Disable VHACD
* Leave a note that Bullet should be disabled too (currently it's force-disabled)
* Disable all XR modules: MobileVR and WebXR

On a `production=yes` release build, when 3D is disabled, this reduces the size of Godot to 48.9 MB, compared to 49.2 MB on master, a reduction of 0.6%. A 3D-enabled build is 53.3 MB, so this PR changes builds with 3D disabled from 7.7% smaller to 8.3%.

