### PR TITLE
Tweak the editor splash screen color to better match the default theme

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1662,7 +1662,13 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 			}
 		}
 
-		Color boot_bg_color = GLOBAL_DEF("application/boot_splash/bg_color", boot_splash_bg_color);
+#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
+		const Color boot_bg_color =
+				GLOBAL_DEF("application/boot_splash/bg_color",
+						(editor || project_manager) ? boot_splash_editor_bg_color : boot_splash_bg_color);
+#else
+		const Color boot_bg_color = GLOBAL_DEF("application/boot_splash/bg_color", boot_splash_bg_color);
+#endif
 		if (boot_logo.is_valid()) {
 			RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color, boot_logo_scale,
 					boot_logo_filter);

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -17,6 +17,7 @@ def make_splash(target, source, env):
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef BOOT_SPLASH_H\n")
         g.write("#define BOOT_SPLASH_H\n")
+        # Use a neutral gray color to better fit various kinds of projects.
         g.write("static const Color boot_splash_bg_color = Color(0.14, 0.14, 0.14);\n")
         g.write("static const unsigned char boot_splash_png[] = {\n")
         for i in range(len(buf)):
@@ -36,7 +37,9 @@ def make_splash_editor(target, source, env):
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef BOOT_SPLASH_EDITOR_H\n")
         g.write("#define BOOT_SPLASH_EDITOR_H\n")
-        g.write("static const Color boot_splash_editor_bg_color = Color(0.14, 0.14, 0.14);\n")
+        # The editor splash background color is taken from the default editor theme's background color.
+        # This helps achieve a visually "smoother" transition between the splash screen and the editor.
+        g.write("static const Color boot_splash_editor_bg_color = Color(0.125, 0.145, 0.192);\n")
         g.write("static const unsigned char boot_splash_editor_png[] = {\n")
         for i in range(len(buf)):
             g.write(str(buf[i]) + ",\n")


### PR DESCRIPTION
This helps achieve a visually "smoother" transition between the splash screen and the editor. This is a well-known trick often used in Electron applications :slightly_smiling_face: 

This change doesn't apply to the default splash screen used by projects. The neutral gray tone is kept there to better suit most kinds of projects.

**Note:** Not testable on the `master` branch as splash screen rendering is broken there. Instead, you can cherry-pick this to the `3.x` branch and build it.

## Preview

### Before

https://user-images.githubusercontent.com/180032/111544204-67102700-8774-11eb-8bfb-d3d0dff76502.mp4

### After

https://user-images.githubusercontent.com/180032/111544200-66779080-8774-11eb-8041-e4c4b29ab64c.mp4