### PR TITLE
Tweak the 3D editor grid default to not go below subdivisions of 1 meter

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -620,8 +620,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// is increased significantly more than it really should need to be.
 	hints["editors/3d/grid_division_level_max"] = PropertyInfo(Variant::INT, "editors/3d/grid_division_level_max", PROPERTY_HINT_RANGE, "-1,3,1", PROPERTY_USAGE_DEFAULT);
 
-	// Default smallest grid size is 1cm, 10^-2.
-	_initial_set("editors/3d/grid_division_level_min", -2);
+	// Default smallest grid size is 1m, 10^0.
+	_initial_set("editors/3d/grid_division_level_min", 0);
 	// Lower values produce graphical artifacts regardless of view clipping planes, so limit to -2 as a lower bound.
 	hints["editors/3d/grid_division_level_min"] = PropertyInfo(Variant::INT, "editors/3d/grid_division_level_min", PROPERTY_HINT_RANGE, "-2,2,1", PROPERTY_USAGE_DEFAULT);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5820,7 +5820,7 @@ void Node3DEditor::_init_grid() {
 	// Offsets division_level for bigger or smaller grids.
 	// Default value is -0.2. -1.0 gives Blender-like behavior, 0.5 gives huge grids.
 	real_t division_level_bias = EditorSettings::get_singleton()->get("editors/3d/grid_division_level_bias");
-	// Default largest grid size is 100m, 10^2 (default value is 2).
+	// Default largest grid size is 8^2 when primary_grid_steps is 8 (64m apart, so primary grid lines are 512m apart).
 	int division_level_max = EditorSettings::get_singleton()->get("editors/3d/grid_division_level_max");
 	// Default smallest grid size is 1cm, 10^-2 (default value is -2).
 	int division_level_min = EditorSettings::get_singleton()->get("editors/3d/grid_division_level_min");


### PR DESCRIPTION
Small subdivisions aren't useful that often and make it difficult for people to get a sense of scale in 3D.

This closes https://github.com/godotengine/godot/issues/47110.