### PR TITLE
Disable Skeleton3D when compiling without 3D

### DIFF
--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -4,6 +4,5 @@ Import("env")
 
 if env["disable_3d"]:
     env.add_source_files(env.scene_sources, "node_3d.cpp")
-    env.add_source_files(env.scene_sources, "skeleton_3d.cpp")
 else:
     env.add_source_files(env.scene_sources, "*.cpp")

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -337,7 +337,6 @@ void Skeleton3D::_notification(int p_what) {
 
 		} break;
 
-#ifndef _3D_DISABLED
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			// This is active only if the skeleton animates the physical bones
 			// and the state of the bone is not active.
@@ -356,7 +355,6 @@ void Skeleton3D::_notification(int p_what) {
 				set_physics_process_internal(true);
 			}
 		} break;
-#endif
 	}
 }
 
@@ -621,8 +619,6 @@ void Skeleton3D::localize_rests() {
 	}
 }
 
-#ifndef _3D_DISABLED
-
 void Skeleton3D::set_animate_physical_bones(bool p_animate) {
 	animate_physical_bones = p_animate;
 
@@ -783,8 +779,6 @@ void Skeleton3D::physical_bones_remove_collision_exception(RID p_exception) {
 	_physical_bones_add_remove_collision_exception(false, this, p_exception);
 }
 
-#endif // _3D_DISABLED
-
 void Skeleton3D::_skin_changed() {
 	_make_dirty();
 }
@@ -898,8 +892,6 @@ void Skeleton3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("bone_transform_to_world_transform", "bone_transform"), &Skeleton3D::bone_transform_to_world_transform);
 	ClassDB::bind_method(D_METHOD("world_transform_to_bone_transform", "world_transform"), &Skeleton3D::world_transform_to_bone_transform);
 
-#ifndef _3D_DISABLED
-
 	ClassDB::bind_method(D_METHOD("set_animate_physical_bones"), &Skeleton3D::set_animate_physical_bones);
 	ClassDB::bind_method(D_METHOD("get_animate_physical_bones"), &Skeleton3D::get_animate_physical_bones);
 
@@ -909,7 +901,6 @@ void Skeleton3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("physical_bones_remove_collision_exception", "exception"), &Skeleton3D::physical_bones_remove_collision_exception);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "animate_physical_bones"), "set_animate_physical_bones", "get_animate_physical_bones");
-#endif // _3D_DISABLED
 
 #ifdef TOOLS_ENABLED
 	ADD_SIGNAL(MethodInfo("pose_updated"));

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -35,12 +35,9 @@
 #include "scene/3d/node_3d.h"
 #include "scene/resources/skin.h"
 
-#ifndef _3D_DISABLED
 typedef int BoneId;
 
 class PhysicalBone3D;
-#endif // _3D_DISABLED
-
 class Skeleton3D;
 
 class SkinReference : public Reference {
@@ -92,10 +89,8 @@ private:
 		bool global_pose_override_reset = false;
 		Transform3D global_pose_override;
 
-#ifndef _3D_DISABLED
 		PhysicalBone3D *physical_bone = nullptr;
 		PhysicalBone3D *cache_parent_physical_bone = nullptr;
-#endif // _3D_DISABLED
 
 		List<ObjectID> nodes_bound;
 	};
@@ -181,7 +176,6 @@ public:
 	Transform3D bone_transform_to_world_transform(Transform3D p_transform);
 	Transform3D world_transform_to_bone_transform(Transform3D p_transform);
 
-#ifndef _3D_DISABLED
 	// Physical bone API
 
 	void set_animate_physical_bones(bool p_animate);
@@ -203,7 +197,6 @@ public:
 	void physical_bones_start_simulation_on(const TypedArray<StringName> &p_bones);
 	void physical_bones_add_collision_exception(RID p_exception);
 	void physical_bones_remove_collision_exception(RID p_exception);
-#endif // _3D_DISABLED
 
 public:
 	Skeleton3D();

--- a/scene/animation/animation_cache.cpp
+++ b/scene/animation/animation_cache.cpp
@@ -81,6 +81,7 @@ void AnimationCache::_update_cache() {
 		Ref<Resource> res;
 
 		if (animation->track_get_type(i) == Animation::TYPE_TRANSFORM3D) {
+#ifndef _3D_DISABLED
 			if (np.get_subname_count() > 1) {
 				path_cache.push_back(Path());
 				ERR_CONTINUE_MSG(animation->track_get_type(i) == Animation::TYPE_TRANSFORM3D, "Transform tracks can't have a subpath '" + np + "'.");
@@ -113,8 +114,8 @@ void AnimationCache::_update_cache() {
 				path.skeleton = sk;
 			}
 
-			path.spatial = sp;
-
+			path.node_3d = sp;
+#endif // _3D_DISABLED
 		} else {
 			if (np.get_subname_count() > 0) {
 				RES res2;
@@ -179,14 +180,16 @@ void AnimationCache::set_track_transform(int p_idx, const Transform3D &p_transfo
 		return;
 	}
 
+#ifndef _3D_DISABLED
 	ERR_FAIL_COND(!p.node);
-	ERR_FAIL_COND(!p.spatial);
+	ERR_FAIL_COND(!p.node_3d);
 
 	if (p.skeleton) {
 		p.skeleton->set_bone_pose(p.bone_idx, p_transform);
 	} else {
-		p.spatial->set_transform(p_transform);
+		p.node_3d->set_transform(p_transform);
 	}
+#endif // _3D_DISABLED
 }
 
 void AnimationCache::set_track_value(int p_idx, const Variant &p_value) {

--- a/scene/animation/animation_cache.h
+++ b/scene/animation/animation_cache.h
@@ -40,9 +40,11 @@ class AnimationCache : public Object {
 	struct Path {
 		RES resource;
 		Object *object = nullptr;
-		Skeleton3D *skeleton = nullptr; // haxor
+#ifndef _3D_DISABLED
+		Skeleton3D *skeleton = nullptr;
+		Node3D *node_3d = nullptr;
+#endif // _3D_DISABLED
 		Node *node = nullptr;
-		Node3D *spatial = nullptr;
 
 		int bone_idx = -1;
 		Vector<StringName> subpath;

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -93,9 +93,11 @@ private:
 		uint32_t id = 0;
 		RES resource;
 		Node *node = nullptr;
-		Node3D *spatial = nullptr;
 		Node2D *node_2d = nullptr;
+#ifndef _3D_DISABLED
+		Node3D *node_3d = nullptr;
 		Skeleton3D *skeleton = nullptr;
+#endif // _3D_DISABLED
 		int bone_idx = -1;
 		// accumulated transforms
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -582,21 +582,22 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 
 					} break;
 					case Animation::TYPE_TRANSFORM3D: {
-						Node3D *spatial = Object::cast_to<Node3D>(child);
+#ifndef _3D_DISABLED
+						Node3D *node_3d = Object::cast_to<Node3D>(child);
 
-						if (!spatial) {
-							ERR_PRINT("AnimationTree: '" + String(E->get()) + "', transform track does not point to spatial:  '" + String(path) + "'");
+						if (!node_3d) {
+							ERR_PRINT("AnimationTree: '" + String(E->get()) + "', transform track does not point to Node3D:  '" + String(path) + "'");
 							continue;
 						}
 
 						TrackCacheTransform *track_xform = memnew(TrackCacheTransform);
 
-						track_xform->spatial = spatial;
+						track_xform->node_3d = node_3d;
 						track_xform->skeleton = nullptr;
 						track_xform->bone_idx = -1;
 
-						if (path.get_subname_count() == 1 && Object::cast_to<Skeleton3D>(spatial)) {
-							Skeleton3D *sk = Object::cast_to<Skeleton3D>(spatial);
+						if (path.get_subname_count() == 1 && Object::cast_to<Skeleton3D>(node_3d)) {
+							Skeleton3D *sk = Object::cast_to<Skeleton3D>(node_3d);
 							track_xform->skeleton = sk;
 							int bone_idx = sk->find_bone(path.get_subname(0));
 							if (bone_idx != -1) {
@@ -604,11 +605,11 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 							}
 						}
 
-						track_xform->object = spatial;
+						track_xform->object = node_3d;
 						track_xform->object_id = track_xform->object->get_instance_id();
 
 						track = track_xform;
-
+#endif // _3D_DISABLED
 					} break;
 					case Animation::TYPE_METHOD: {
 						TrackCacheMethod *track_method = memnew(TrackCacheMethod);
@@ -845,6 +846,7 @@ void AnimationTree::_process_graph(float p_delta) {
 
 				switch (track->type) {
 					case Animation::TYPE_TRANSFORM3D: {
+#ifndef _3D_DISABLED
 						TrackCacheTransform *t = static_cast<TrackCacheTransform *>(track);
 
 						if (track->root_motion) {
@@ -930,7 +932,7 @@ void AnimationTree::_process_graph(float p_delta) {
 							}
 							t->scale = t->scale.lerp(scale, blend);
 						}
-
+#endif // _3D_DISABLED
 					} break;
 					case Animation::TYPE_VALUE: {
 						TrackCacheValue *t = static_cast<TrackCacheValue *>(track);
@@ -1189,6 +1191,7 @@ void AnimationTree::_process_graph(float p_delta) {
 
 			switch (track->type) {
 				case Animation::TYPE_TRANSFORM3D: {
+#ifndef _3D_DISABLED
 					TrackCacheTransform *t = static_cast<TrackCacheTransform *>(track);
 
 					Transform3D xform;
@@ -1206,9 +1209,9 @@ void AnimationTree::_process_graph(float p_delta) {
 						t->skeleton->set_bone_pose(t->bone_idx, xform);
 
 					} else if (!t->skeleton) {
-						t->spatial->set_transform(xform);
+						t->node_3d->set_transform(xform);
 					}
-
+#endif // _3D_DISABLED
 				} break;
 				case Animation::TYPE_VALUE: {
 					TrackCacheValue *t = static_cast<TrackCacheValue *>(track);

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -184,8 +184,10 @@ private:
 	};
 
 	struct TrackCacheTransform : public TrackCache {
-		Node3D *spatial = nullptr;
+#ifndef _3D_DISABLED
+		Node3D *node_3d = nullptr;
 		Skeleton3D *skeleton = nullptr;
+#endif // _3D_DISABLED
 		int bone_idx = -1;
 		Vector3 loc;
 		Quat rot;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -180,10 +180,6 @@
 #include "scene/resources/world_margin_shape_3d.h"
 #include "scene/scene_string_names.h"
 
-// Needed by animation code, so keep when 3D disabled.
-#include "scene/3d/node_3d.h"
-#include "scene/3d/skeleton_3d.h"
-
 #include "scene/main/shader_globals_override.h"
 
 #ifndef _3D_DISABLED
@@ -208,6 +204,7 @@
 #include "scene/3d/navigation_agent_3d.h"
 #include "scene/3d/navigation_obstacle_3d.h"
 #include "scene/3d/navigation_region_3d.h"
+#include "scene/3d/node_3d.h"
 #include "scene/3d/occluder_instance_3d.h"
 #include "scene/3d/path_3d.h"
 #include "scene/3d/physics_body_3d.h"
@@ -217,6 +214,7 @@
 #include "scene/3d/ray_cast_3d.h"
 #include "scene/3d/reflection_probe.h"
 #include "scene/3d/remote_transform_3d.h"
+#include "scene/3d/skeleton_3d.h"
 #include "scene/3d/skeleton_ik_3d.h"
 #include "scene/3d/soft_body_3d.h"
 #include "scene/3d/spring_arm_3d.h"
@@ -395,14 +393,7 @@ void register_scene_types() {
 	AcceptDialog::set_swap_cancel_ok(swap_cancel_ok);
 #endif
 
-	/* REGISTER 3D */
-
-	// Needed even with _3D_DISABLED as used in animation code.
-	ClassDB::register_class<Node3D>();
-	ClassDB::register_virtual_class<Node3DGizmo>();
-	ClassDB::register_class<Skin>();
-	ClassDB::register_virtual_class<SkinReference>();
-	ClassDB::register_class<Skeleton3D>();
+	/* REGISTER ANIMATION */
 
 	ClassDB::register_class<AnimationPlayer>();
 	ClassDB::register_class<Tween>();
@@ -432,7 +423,14 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); //may take time to init
 
+	/* REGISTER 3D */
+
 #ifndef _3D_DISABLED
+	ClassDB::register_class<Node3D>();
+	ClassDB::register_virtual_class<Node3DGizmo>();
+	ClassDB::register_class<Skin>();
+	ClassDB::register_virtual_class<SkinReference>();
+	ClassDB::register_class<Skeleton3D>();
 	ClassDB::register_virtual_class<VisualInstance3D>();
 	ClassDB::register_virtual_class<GeometryInstance3D>();
 	ClassDB::register_class<Camera3D>();


### PR DESCRIPTION
This PR makes animation code not depend on Skeleton3D or even Node3D (but Node3D is still compiled as of this PR). It also removes `#ifndef _3D_DISABLED` from Skeleton3D itself, since the whole thing is disabled instead.

On a stripped release build, when 3D is disabled, this reduces the size of Godot to 44.8 MB, compared to 44.9 MB on master, a reduction of 0.2%. A 3D-enabled build is 48.3 MB, so this PR changes builds with 3D disabled from 7.0% smaller to 7.2%.

This may not seem like a big change, but here is some larger context: I'm working on making it so that disabling 3D will also disable more things such as physics and Node3D (it already works locally, just need to make it into easy-to-merge PRs). However, disabling Skeleton3D is a prerequisite to disabling those. It's also a fairly isolated change, so I made this into its own PR.
