### PR TITLE
Changed SCsub for shaders to find shaders automatically

### DIFF
--- a/servers/rendering/renderer_rd/shaders/SCsub
+++ b/servers/rendering/renderer_rd/shaders/SCsub
@@ -3,46 +3,15 @@
 Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:
-    env.RD_GLSL("canvas.glsl")
-    env.RD_GLSL("canvas_occlusion.glsl")
-    env.RD_GLSL("canvas_sdf.glsl")
-    env.RD_GLSL("copy.glsl")
-    env.RD_GLSL("copy_to_fb.glsl")
-    env.RD_GLSL("cubemap_roughness.glsl")
-    env.RD_GLSL("cubemap_downsampler.glsl")
-    env.RD_GLSL("cubemap_filter.glsl")
-    env.RD_GLSL("scene_forward_clustered.glsl")
-    env.RD_GLSL("sky.glsl")
-    env.RD_GLSL("tonemap.glsl")
-    env.RD_GLSL("cube_to_dp.glsl")
-    env.RD_GLSL("giprobe.glsl")
-    env.RD_GLSL("giprobe_debug.glsl")
-    env.RD_GLSL("giprobe_sdf.glsl")
-    env.RD_GLSL("luminance_reduce.glsl")
-    env.RD_GLSL("bokeh_dof.glsl")
-    env.RD_GLSL("ssao.glsl")
-    env.RD_GLSL("ssao_downsample.glsl")
-    env.RD_GLSL("ssao_importance_map.glsl")
-    env.RD_GLSL("ssao_blur.glsl")
-    env.RD_GLSL("ssao_interleave.glsl")
-    env.RD_GLSL("roughness_limiter.glsl")
-    env.RD_GLSL("screen_space_reflection.glsl")
-    env.RD_GLSL("screen_space_reflection_filter.glsl")
-    env.RD_GLSL("screen_space_reflection_scale.glsl")
-    env.RD_GLSL("subsurface_scattering.glsl")
-    env.RD_GLSL("specular_merge.glsl")
-    env.RD_GLSL("gi.glsl")
-    env.RD_GLSL("resolve.glsl")
-    env.RD_GLSL("sdfgi_preprocess.glsl")
-    env.RD_GLSL("sdfgi_integrate.glsl")
-    env.RD_GLSL("sdfgi_direct_light.glsl")
-    env.RD_GLSL("sdfgi_debug.glsl")
-    env.RD_GLSL("sdfgi_debug_probes.glsl")
-    env.RD_GLSL("volumetric_fog.glsl")
-    env.RD_GLSL("particles.glsl")
-    env.RD_GLSL("particles_copy.glsl")
-    env.RD_GLSL("sort.glsl")
-    env.RD_GLSL("skeleton.glsl")
-    env.RD_GLSL("cluster_render.glsl")
-    env.RD_GLSL("cluster_store.glsl")
-    env.RD_GLSL("cluster_debug.glsl")
+    # find all include files
+    gl_include_files = [str(f) for f in Glob("*_inc.glsl")]
+
+    # find all shader code(all glsl files excluding our include files)
+    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
+
+    # make sure we recompile shaders if include files change
+    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files)
+
+    # compile shaders
+    for glsl_file in glsl_files:
+        env.RD_GLSL(glsl_file)


### PR DESCRIPTION
Currently our SCsub file that compiles our shaders requires us to list by hand which shaders should be compiled. Also this completely ignores our include file so making a change to an include file won't trigger re-compilation of the shaders.

This PR solves both issues. 

We have a naming convention that include files are suffixed with `_inc.glsl` and shaders with `.glsl` and our logic picks up on that by building a list of include files, and then building a list of all shaders and excluding our include files from this list.

We then register our shaders for compilation and we called `Depends` to tell scons our shaders depend on our include files resulting in a change in an include file triggering recompilation.

Unfortunately we currently do not have a way to detect which shaders use what include files like scons is able to so with other source code (open to suggestions here) so right now editing an include file recompiles all shaders. 