### PR TITLE
Make 2D navigation consider scale

### DIFF
--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -132,7 +132,8 @@ static Vector<Vector2> vector_v3_to_v2(const Vector<Vector3> &d) {
 static Transform trf2_to_trf3(const Transform2D &d) {
 	Vector3 o(v2_to_v3(d.get_origin()));
 	Basis b;
-	b.rotate(Vector3(0, 1, 0), d.get_rotation());
+	b.rotate(Vector3(0, -1, 0), d.get_rotation());
+	b.scale(v2_to_v3(d.get_scale()));
 	return Transform(b, o);
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Discovered while working on TileMap navigation. This make it so scaled NavigationRegion2D works correctly, as scale was ignored before.
