### PR TITLE
Allow disabling low-processor mode on headless platforms

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -469,7 +469,7 @@ void OS::close_midi_inputs() {
 	}
 }
 
-void OS::add_frame_delay(bool p_can_draw) {
+void OS::add_frame_delay() {
 	const uint32_t frame_delay = Engine::get_singleton()->get_frame_delay();
 	if (frame_delay) {
 		// Add fixed frame delay to decrease CPU/GPU usage. This doesn't take
@@ -482,7 +482,7 @@ void OS::add_frame_delay(bool p_can_draw) {
 	// Add a dynamic frame delay to decrease CPU/GPU usage. This takes the
 	// previous frame time into account for a smoother result.
 	uint64_t dynamic_delay = 0;
-	if (is_in_low_processor_usage_mode() || !p_can_draw) {
+	if (is_in_low_processor_usage_mode()) {
 		dynamic_delay = get_low_processor_usage_mode_sleep_usec();
 	}
 	const int target_fps = Engine::get_singleton()->get_target_fps();

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -209,7 +209,7 @@ public:
 	virtual double get_unix_time() const;
 
 	virtual void delay_usec(uint32_t p_usec) const = 0;
-	virtual void add_frame_delay(bool p_can_draw);
+	virtual void add_frame_delay();
 
 	virtual uint64_t get_ticks_usec() const = 0;
 	uint32_t get_ticks_msec() const;

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -286,8 +286,14 @@
 		<member name="application/run/low_processor_mode" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables low-processor usage mode. This setting only works on desktop platforms. The screen is not redrawn if nothing changes visually. This is meant for writing applications and editors, but is pretty useless (and can hurt performance) in most games.
 		</member>
+		<member name="application/run/low_processor_mode.Server" type="bool" setter="" getter="" default="true">
+			Server (headless) override for the [member application/run/low_processor_mode] setting to decrease CPU usage.
+		</member>
 		<member name="application/run/low_processor_mode_sleep_usec" type="int" setter="" getter="" default="6900">
-			Amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage.
+			Amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage. The default value is roughly equal to 144 FPS and is chosen to match 144 Hz monitors (V-Sync will take care of limiting the frame rate below that if needed).
+		</member>
+		<member name="application/run/low_processor_mode_sleep_usec.Server" type="int" setter="" getter="" default="16600">
+			Server (headless) override for the [member application/run/low_processor_mode_sleep_usec] setting. This value effectively determines the rate at which [method Node._process] will run on server platforms. The default value is chosen to decrease CPU usage and is roughly equal to 60 FPS.
 		</member>
 		<member name="application/run/main_scene" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to the main scene file that will be loaded when the project runs.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1368,13 +1368,19 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	OS::get_singleton()->set_low_processor_usage_mode(GLOBAL_DEF("application/run/low_processor_mode", false));
+	// In headless environments, we want to save CPU usage by default.
+	OS::get_singleton()->set_low_processor_usage_mode(GLOBAL_DEF("application/run/low_processor_mode.Server", true));
+
 	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(
-			GLOBAL_DEF("application/run/low_processor_mode_sleep_usec", 6900)); // Roughly 144 FPS
+			GLOBAL_DEF("application/run/low_processor_mode_sleep_usec", 6900)); // Roughly 144 FPS.
+	// A common tick rate in multiplayer games is 60 Hz, so set the default limit to match that.
+	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(
+			GLOBAL_DEF("application/run/low_processor_mode_sleep_usec.Server", 16600)); // Roughly 60 FPS.
 	ProjectSettings::get_singleton()->set_custom_property_info("application/run/low_processor_mode_sleep_usec",
 			PropertyInfo(Variant::INT,
 					"application/run/low_processor_mode_sleep_usec",
 					PROPERTY_HINT_RANGE,
-					"0,33200,1,or_greater")); // No negative numbers
+					"0,33200,1,or_greater")); // No negative numbers.
 
 	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
 	GLOBAL_DEF("input_devices/pointing/ios/touch_delay", 0.150);
@@ -2555,7 +2561,7 @@ bool Main::iteration() {
 		return exit;
 	}
 
-	OS::get_singleton()->add_frame_delay(DisplayServer::get_singleton()->window_can_draw());
+	OS::get_singleton()->add_frame_delay();
 
 #ifdef TOOLS_ENABLED
 	if (auto_build_solutions) {

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -81,7 +81,7 @@ public:
 	String get_name() const override;
 	// Override default OS implementation which would block the main thread with delay_usec.
 	// Implemented in javascript_main.cpp loop callback instead.
-	void add_frame_delay(bool p_can_draw) override {}
+	void add_frame_delay() override {}
 
 	String get_cache_path() const override;
 	String get_config_path() const override;


### PR DESCRIPTION
This can be used when you want processing to happen as fast as possible (at the cost of high CPU usage). This is generally not what you want for a dedicated game server, so low processor-mode is still enabled by default on headless platforms.

- Enable low-processor mode by default on headless platforms (mimics the previous behavior).
- Use a 60 FPS limit on headless mode by default (down from 144 FPS). This can be overridden by changing the Server override for `application/run/low_processor_mode_sleep_usec`. This allows effectively changing the server's `_process()` tick rate, balancing CPU usage and network bandwidth usage with latency.

This closes https://github.com/godotengine/godot/issues/32404.

**Question:** Can someone check if [feature tags](https://docs.godotengine.org/en/stable/getting_started/workflow/export/feature_tags.html) are actually case-sensitive? The documentation claims they are, but I noticed the Windows pen driver code uses `.windows` instead of `.Windows` to override the default setting. cc @bruvzg