### PR TITLE
[3.x] Fix Tween.is_active() always true after stop() and then start() (Fix #39760 & #39801) 

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -855,8 +855,22 @@ bool Tween::start() {
 		return true;
 	}
 
+	pending_update++;
+	for (List<InterpolateData>::Element *E = interpolates.front(); E; E = E->next()) {
+		InterpolateData &data = E->get();
+		data.active = true;
+	}
+	pending_update--;
+
 	// We want to be activated
 	set_active(true);
+
+	// Don't resume from current position if stop_all() function has been used
+	if (was_stopped) {
+		seek(0);
+	}
+	was_stopped = false;
+
 	return true;
 }
 
@@ -925,6 +939,7 @@ bool Tween::stop(Object *p_object, StringName p_key) {
 bool Tween::stop_all() {
 	// We no longer need to be active since all tweens have been stopped
 	set_active(false);
+	was_stopped = true;
 
 	// For each interpolation...
 	pending_update++;

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -115,7 +115,7 @@ private:
 	float speed_scale;
 	mutable int pending_update;
 	int uid;
-
+	bool was_stopped = false;
 	List<InterpolateData> interpolates;
 
 	struct PendingCommand {


### PR DESCRIPTION
Fix #39760 & #39801 for 3.2 branch

These issues were fixed in 4.0 master branch (and closed) but are still active in the 3.2 branch.

### Issues : 

- Tween always active after stop() and (re) start() #39760 
- Tween never repeat after stop() and (re) start() even if repeat is true #39801 (this issue is a consequence from the previous)

### Cause : 
When a tween was stopped, each interpolation in the list was set to active=false
then, the main active bool was set to false.

When starting the tween again, the main active bool was set to true but not each interpolation in the list : so no repeat was happening.

### Fix proposal : (Backport from my previous merged PR #46609 for 4.0)

I've added a for loop to reactivate each interpolation in the interpolates list when start() is called.
Need to seek to 0.0 too (only if tween has been stopped by stop_all()) because we don't want start() to act as resume() after stop_all().