### PR TITLE
Fix spamming errors when SoftBody pinned nodes have no attachment

### DIFF
--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -768,7 +768,9 @@ void SoftBody3D::_reset_points_offsets() {
 	PinnedPoint *w = pinned_points.ptrw();
 	for (int i = pinned_points.size() - 1; 0 <= i; --i) {
 		if (!r[i].spatial_attachment) {
-			w[i].spatial_attachment = Object::cast_to<Node3D>(get_node(r[i].spatial_attachment_path));
+			if (!r[i].spatial_attachment_path.is_empty() && has_node(r[i].spatial_attachment_path)) {
+				w[i].spatial_attachment = Object::cast_to<Node3D>(get_node(r[i].spatial_attachment_path));
+			}
 		}
 
 		if (!r[i].spatial_attachment) {


### PR DESCRIPTION
There was a specific case where the node path wasn't checked for validity before trying to access the attachment node.

It could cause lots of error log noise in both editor and game.
