### PR TITLE
[3.x] Take resolution into account when setting the max shadow cubemap size (omni light shadow jaggies fix)

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -3728,7 +3728,7 @@ void RasterizerSceneGLES2::render_shadow(RID p_light, RID p_shadow_atlas, int p_
 
 				// find an appropriate cubemap to render to
 				for (int i = shadow_cubemaps.size() - 1; i >= 0; i--) {
-					if (shadow_cubemaps[i].size > shadow_size * 2) {
+					if (shadow_cubemaps[i].size > shadow_size) {
 						break;
 					}
 
@@ -4006,7 +4006,7 @@ void RasterizerSceneGLES2::initialize() {
 
 	// cubemaps for shadows
 	if (storage->config.support_shadow_cubemaps) { //not going to be used
-		int max_shadow_cubemap_sampler_size = 512;
+		int max_shadow_cubemap_sampler_size = CLAMP(int(next_power_of_2(GLOBAL_GET("rendering/quality/shadow_atlas/size")) >> 1), 256, storage->config.max_cubemap_texture_size);
 
 		int cube_size = max_shadow_cubemap_sampler_size;
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -6217,6 +6217,7 @@ void RasterizerStorageGLES2::initialize() {
 	glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &config.max_vertex_texture_image_units);
 	glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &config.max_texture_image_units);
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &config.max_texture_size);
+	glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE, &config.max_cubemap_texture_size);
 	glGetIntegerv(GL_MAX_VIEWPORT_DIMS, config.max_viewport_dimensions);
 
 	// the use skeleton software path should be used if either float texture is not supported,

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -63,6 +63,7 @@ public:
 		int max_vertex_texture_image_units;
 		int max_texture_image_units;
 		int max_texture_size;
+		int max_cubemap_texture_size;
 		int max_viewport_dimensions[2];
 
 		// TODO implement wireframe in GLES2

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4811,7 +4811,7 @@ void RasterizerSceneGLES3::render_shadow(RID p_light, RID p_shadow_atlas, int p_
 
 				for (int i = shadow_cubemaps.size() - 1; i >= 0; i--) {
 					//find appropriate cubemap to render to
-					if (shadow_cubemaps[i].size > shadow_size * 2)
+					if (shadow_cubemaps[i].size > shadow_size)
 						break;
 
 					cubemap_index = i;
@@ -5105,7 +5105,7 @@ void RasterizerSceneGLES3::initialize() {
 
 	shadow_atlas_realloc_tolerance_msec = 500;
 
-	int max_shadow_cubemap_sampler_size = 512;
+	int max_shadow_cubemap_sampler_size = CLAMP(int(next_power_of_2(GLOBAL_GET("rendering/quality/shadow_atlas/size")) >> 1), 256, storage->config.max_cubemap_texture_size);
 
 	int cube_size = max_shadow_cubemap_sampler_size;
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8498,6 +8498,7 @@ void RasterizerStorageGLES3::initialize() {
 
 	glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &config.max_texture_image_units);
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &config.max_texture_size);
+	glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE, &config.max_cubemap_texture_size);
 
 	config.use_rgba_2d_shadows = !config.framebuffer_float_supported;
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -97,6 +97,7 @@ public:
 
 		int max_texture_image_units;
 		int max_texture_size;
+		int max_cubemap_texture_size;
 
 		bool generate_wireframes;
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2403,10 +2403,10 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/limits/time/time_rollover_secs", 3600);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/time/time_rollover_secs", PropertyInfo(Variant::REAL, "rendering/limits/time/time_rollover_secs", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"));
 
-	GLOBAL_DEF("rendering/quality/directional_shadow/size", 4096);
+	GLOBAL_DEF_RST("rendering/quality/directional_shadow/size", 4096);
 	GLOBAL_DEF("rendering/quality/directional_shadow/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/directional_shadow/size", PropertyInfo(Variant::INT, "rendering/quality/directional_shadow/size", PROPERTY_HINT_RANGE, "256,16384"));
-	GLOBAL_DEF("rendering/quality/shadow_atlas/size", 4096);
+	GLOBAL_DEF_RST("rendering/quality/shadow_atlas/size", 4096);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384"));
 	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_0_subdiv", 1);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

#37678 fixed shadow issues for 4.0, but #24587 still occurs in 3.x. Specifically, omni lights used a hardcoded value for max shadow cubemap size.

Screenshots are from the reproduction project in #24587
2048x2048
![image](https://user-images.githubusercontent.com/48544263/111738219-2ed51b00-883e-11eb-84b2-55ae7bb38e3c.png)
4096x4096
![image](https://user-images.githubusercontent.com/48544263/111738195-24b31c80-883e-11eb-88fe-cd1af4d94615.png)
8192x8192
![image](https://user-images.githubusercontent.com/48544263/111738157-16650080-883e-11eb-85b7-73afabac87f1.png)
16384x16384
![image](https://user-images.githubusercontent.com/48544263/111738101-fd5c4f80-883d-11eb-98ec-c6b24e0a64d7.png)
![image](https://user-images.githubusercontent.com/48544263/111738273-4ca28000-883e-11eb-967e-580c5e24571a.png)


