### PR TITLE
FileDialog: add Back/Forward buttons, add message for inaccessible folders.

### DIFF
--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -84,6 +84,8 @@ public:
 
 	virtual bool file_exists(String p_file) = 0;
 	virtual bool dir_exists(String p_dir) = 0;
+	virtual bool is_readable(String p_dir) { return true; };
+	virtual bool is_writable(String p_dir) { return true; };
 	static bool exists(String p_dir);
 	virtual size_t get_space_left() = 0;
 

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -133,6 +133,9 @@
 		</constant>
 	</constants>
 	<theme_items>
+		<theme_item name="back_folder" type="Texture2D">
+			Custom icon for the back arrow.
+		</theme_item>
 		<theme_item name="file" type="Texture2D">
 			Custom icon for files.
 		</theme_item>
@@ -147,6 +150,9 @@
 		</theme_item>
 		<theme_item name="folder_icon_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
 			The color modulation applied to the folder icon.
+		</theme_item>
+		<theme_item name="forward_folder" type="Texture2D">
+			Custom icon for the forward arrow.
 		</theme_item>
 		<theme_item name="parent_folder" type="Texture2D">
 			Custom icon for the parent folder arrow.

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -102,6 +102,28 @@ bool DirAccessUnix::dir_exists(String p_dir) {
 	return (success && S_ISDIR(flags.st_mode));
 }
 
+bool DirAccessUnix::is_readable(String p_dir) {
+	GLOBAL_LOCK_FUNCTION
+
+	if (p_dir.is_rel_path()) {
+		p_dir = get_current_dir().plus_file(p_dir);
+	}
+
+	p_dir = fix_path(p_dir);
+	return (access(p_dir.utf8().get_data(), R_OK) == 0);
+}
+
+bool DirAccessUnix::is_writable(String p_dir) {
+	GLOBAL_LOCK_FUNCTION
+
+	if (p_dir.is_rel_path()) {
+		p_dir = get_current_dir().plus_file(p_dir);
+	}
+
+	p_dir = fix_path(p_dir);
+	return (access(p_dir.utf8().get_data(), W_OK) == 0);
+}
+
 uint64_t DirAccessUnix::get_modified_time(String p_file) {
 	if (p_file.is_rel_path()) {
 		p_file = current_dir.plus_file(p_file);

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -71,6 +71,8 @@ public:
 
 	virtual bool file_exists(String p_file);
 	virtual bool dir_exists(String p_dir);
+	virtual bool is_readable(String p_dir);
+	virtual bool is_writable(String p_dir);
 
 	virtual uint64_t get_modified_time(String p_file);
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1260,6 +1260,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// FileDialog
 	theme->set_icon("folder", "FileDialog", theme->get_icon("Folder", "EditorIcons"));
 	theme->set_icon("parent_folder", "FileDialog", theme->get_icon("ArrowUp", "EditorIcons"));
+	theme->set_icon("back_folder", "FileDialog", theme->get_icon("Back", "EditorIcons"));
+	theme->set_icon("forward_folder", "FileDialog", theme->get_icon("Forward", "EditorIcons"));
 	theme->set_icon("reload", "FileDialog", theme->get_icon("Reload", "EditorIcons"));
 	theme->set_icon("toggle_hidden", "FileDialog", theme->get_icon("GuiVisibilityVisible", "EditorIcons"));
 	// Use a different color for folder icons to make them easier to distinguish from files.

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -86,12 +86,20 @@ private:
 	DirAccess *dir_access;
 	ConfirmationDialog *confirm_save;
 
+	Label *message;
+
+	Button *dir_prev;
+	Button *dir_next;
 	Button *dir_up;
 
 	Button *refresh;
 	Button *show_hidden;
 
 	Vector<String> filters;
+
+	Vector<String> local_history;
+	int local_history_pos = 0;
+	void _push_history();
 
 	bool mode_overrides_title = true;
 
@@ -119,6 +127,8 @@ private:
 	void _make_dir();
 	void _make_dir_confirm();
 	void _go_up();
+	void _go_back();
+	void _go_forward();
 
 	void _update_drives();
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -628,6 +628,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// File Dialog
 
 	theme->set_icon("parent_folder", "FileDialog", make_icon(icon_parent_folder_png));
+	theme->set_icon("back_folder", "FileDialog", make_icon(arrow_left_png));
+	theme->set_icon("forward_folder", "FileDialog", make_icon(arrow_right_png));
 	theme->set_icon("reload", "FileDialog", make_icon(icon_reload_png));
 	theme->set_icon("toggle_hidden", "FileDialog", make_icon(icon_visibility_png));
 


### PR DESCRIPTION
Follow up to #47056, but independent of it.

Make file dialog more usable in macOS sandboxed apps.

- Adds `Back`/`Forward` buttons (backport from `EditorFileDialog`), without these, the only way to navigate out of inaccessible folders is entering full path manually.
- Adds `DirAccess`, `is_readable`/`is_writable` (Unix implementation only) for inaccessible folder detection.
- Adds message for the inaccessible folders.

<img width="654" alt="file_dialog" src="https://user-images.githubusercontent.com/7645683/111777560-215e7600-88bc-11eb-99e7-b51138058f1b.png">
