### PR TITLE
Fix asserts take only constant strings

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1234,8 +1234,8 @@ void GDScriptAnalyzer::resolve_assert(GDScriptParser::AssertNode *p_assert) {
 	reduce_expression(p_assert->condition);
 	if (p_assert->message != nullptr) {
 		reduce_expression(p_assert->message);
-		if (!p_assert->message->is_constant || p_assert->message->reduced_value.get_type() != Variant::STRING) {
-			push_error(R"(Expected constant string for assert error message.)", p_assert->message);
+		if (p_assert->message->get_datatype().builtin_type != Variant::STRING) {
+			push_error(R"(Expected string for assert error message.)", p_assert->message);
 		}
 	}
 


### PR DESCRIPTION
fix #47157
the `reduce_expression()` will check `nullptr` thus I removed the if statement, and edited the wrong method of getting type