### PR TITLE
Improved 3D Scene Importer

### DIFF
--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -115,6 +115,9 @@ public:
 		ImportOption() {}
 	};
 
+	virtual bool has_advanced_options() const { return false; }
+	virtual void show_advanced_options(const String &p_path) {}
+
 	virtual int get_preset_count() const { return 0; }
 	virtual String get_preset_name(int p_idx) const { return String(); }
 

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -203,7 +203,7 @@ class EditorFileSystem : public Node {
 
 	void _update_extensions();
 
-	void _reimport_file(const String &p_file);
+	void _reimport_file(const String &p_file, const Map<StringName, Variant> *p_custom_options = nullptr, const String &p_custom_importer = String());
 	Error _reimport_group(const String &p_group_file, const Vector<String> &p_files);
 
 	bool _test_for_reimport(const String &p_path, bool p_only_imported_files);
@@ -256,6 +256,8 @@ public:
 	EditorFileSystemDirectory *find_file(const String &p_file, int *r_index) const;
 
 	void reimport_files(const Vector<String> &p_files);
+
+	void reimport_file_with_custom_parameters(const String &p_file, const String &p_importer, const Map<StringName, Variant> &p_custom_params);
 
 	void update_script_classes();
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -102,6 +102,7 @@
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
 #include "editor/import/resource_importer_wav.h"
+#include "editor/import/scene_import_settings.h"
 #include "editor/import/scene_importer_mesh_node_3d.h"
 #include "editor/import_dock.h"
 #include "editor/multi_node_edit.h"
@@ -6178,6 +6179,9 @@ EditorNode::EditorNode() {
 
 	project_settings = memnew(ProjectSettingsEditor(&editor_data));
 	gui_base->add_child(project_settings);
+
+	scene_import_settings = memnew(SceneImportSettings);
+	gui_base->add_child(scene_import_settings);
 
 	export_template_manager = memnew(ExportTemplateManager);
 	gui_base->add_child(export_template_manager);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -88,6 +88,7 @@ class Button;
 class VSplitContainer;
 class Window;
 class SubViewport;
+class SceneImportSettings;
 
 class EditorNode : public Node {
 	GDCLASS(EditorNode, Node);
@@ -410,6 +411,7 @@ private:
 	EditorResourcePreview *resource_preview;
 	EditorFolding editor_folding;
 
+	SceneImportSettings *scene_import_settings;
 	struct BottomPanelItem {
 		String name;
 		Control *control = nullptr;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -945,7 +945,25 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 		}
 	} else if (fpath != "Favorites") {
 		if (ResourceLoader::get_resource_type(fpath) == "PackedScene") {
-			editor->open_request(fpath);
+			bool is_imported = false;
+
+			{
+				List<String> importer_exts;
+				ResourceImporterScene::get_singleton()->get_recognized_extensions(&importer_exts);
+				String extension = fpath.get_extension();
+				for (List<String>::Element *E = importer_exts.front(); E; E = E->next()) {
+					if (extension.nocasecmp_to(E->get())) {
+						is_imported = true;
+						break;
+					}
+				}
+			}
+
+			if (is_imported) {
+				ResourceImporterScene::get_singleton()->show_advanced_options(fpath);
+			} else {
+				editor->open_request(fpath);
+			}
 		} else {
 			editor->load_resource(fpath);
 		}

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -427,7 +427,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, int p_bake_fps, List<String> *r_missing_deps, Error *r_err) {
 	List<Ref<Mesh>> meshes;
 
-	Error err = _parse_obj(p_path, meshes, false, p_flags & IMPORT_GENERATE_TANGENT_ARRAYS, p_flags & IMPORT_USE_COMPRESSION, Vector3(1, 1, 1), Vector3(0, 0, 0), r_missing_deps);
+	Error err = _parse_obj(p_path, meshes, false, p_flags & IMPORT_GENERATE_TANGENT_ARRAYS, 0, Vector3(1, 1, 1), Vector3(0, 0, 0), r_missing_deps);
 
 	if (err != OK) {
 		if (r_err) {

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -32,7 +32,9 @@
 
 #include "core/io/resource_saver.h"
 #include "editor/editor_node.h"
+#include "editor/import/scene_import_settings.h"
 #include "editor/import/scene_importer_mesh_node_3d.h"
+#include "scene/3d/area_3d.h"
 #include "scene/3d/collision_shape_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/navigation_region_3d.h"
@@ -111,20 +113,14 @@ void EditorSceneImporter::_bind_methods() {
 
 	BIND_CONSTANT(IMPORT_SCENE);
 	BIND_CONSTANT(IMPORT_ANIMATION);
-	BIND_CONSTANT(IMPORT_ANIMATION_DETECT_LOOP);
-	BIND_CONSTANT(IMPORT_ANIMATION_OPTIMIZE);
-	BIND_CONSTANT(IMPORT_ANIMATION_FORCE_ALL_TRACKS_IN_ALL_CLIPS);
-	BIND_CONSTANT(IMPORT_ANIMATION_KEEP_VALUE_TRACKS);
-	BIND_CONSTANT(IMPORT_GENERATE_TANGENT_ARRAYS);
 	BIND_CONSTANT(IMPORT_FAIL_ON_MISSING_DEPENDENCIES);
-	BIND_CONSTANT(IMPORT_MATERIALS_IN_INSTANCES);
-	BIND_CONSTANT(IMPORT_USE_COMPRESSION);
+	BIND_CONSTANT(IMPORT_GENERATE_TANGENT_ARRAYS);
+	BIND_CONSTANT(IMPORT_USE_NAMED_SKIN_BINDS);
 }
 
 /////////////////////////////////
 void EditorScenePostImport::_bind_methods() {
 	BIND_VMETHOD(MethodInfo(Variant::OBJECT, "post_import", PropertyInfo(Variant::OBJECT, "scene")));
-	ClassDB::bind_method(D_METHOD("get_source_folder"), &EditorScenePostImport::get_source_folder);
 	ClassDB::bind_method(D_METHOD("get_source_file"), &EditorScenePostImport::get_source_file);
 }
 
@@ -136,16 +132,11 @@ Node *EditorScenePostImport::post_import(Node *p_scene) {
 	return p_scene;
 }
 
-String EditorScenePostImport::get_source_folder() const {
-	return source_folder;
-}
-
 String EditorScenePostImport::get_source_file() const {
 	return source_file;
 }
 
-void EditorScenePostImport::init(const String &p_source_folder, const String &p_source_file) {
-	source_folder = p_source_folder;
+void EditorScenePostImport::init(const String &p_source_file) {
 	source_file = p_source_file;
 }
 
@@ -183,29 +174,9 @@ bool ResourceImporterScene::get_option_visibility(const String &p_option, const 
 		if (p_option != "animation/import" && !bool(p_options["animation/import"])) {
 			return false;
 		}
-
-		if (p_option == "animation/keep_custom_tracks" && int(p_options["animation/storage"]) == 0) {
-			return false;
-		}
-
-		if (p_option.begins_with("animation/optimizer/") && p_option != "animation/optimizer/enabled" && !bool(p_options["animation/optimizer/enabled"])) {
-			return false;
-		}
-
-		if (p_option.begins_with("animation/clip_")) {
-			int max_clip = p_options["animation/clips/amount"];
-			int clip = p_option.get_slice("/", 1).get_slice("_", 1).to_int() - 1;
-			if (clip >= max_clip) {
-				return false;
-			}
-		}
 	}
 
-	if (p_option == "materials/keep_on_reimport" && int(p_options["materials/storage"]) == 0) {
-		return false;
-	}
-
-	if (p_option == "meshes/lightmap_texel_size" && int(p_options["meshes/light_baking"]) < 2) {
+	if (p_option == "meshes/lightmap_texel_size" && int(p_options["meshes/light_baking"]) < 3) {
 		return false;
 	}
 
@@ -213,34 +184,11 @@ bool ResourceImporterScene::get_option_visibility(const String &p_option, const 
 }
 
 int ResourceImporterScene::get_preset_count() const {
-	return PRESET_MAX;
+	return 0;
 }
 
 String ResourceImporterScene::get_preset_name(int p_idx) const {
-	switch (p_idx) {
-		case PRESET_SINGLE_SCENE:
-			return TTR("Import as Single Scene");
-		case PRESET_SEPARATE_ANIMATIONS:
-			return TTR("Import with Separate Animations");
-		case PRESET_SEPARATE_MATERIALS:
-			return TTR("Import with Separate Materials");
-		case PRESET_SEPARATE_MESHES:
-			return TTR("Import with Separate Objects");
-		case PRESET_SEPARATE_MESHES_AND_MATERIALS:
-			return TTR("Import with Separate Objects+Materials");
-		case PRESET_SEPARATE_MESHES_AND_ANIMATIONS:
-			return TTR("Import with Separate Objects+Animations");
-		case PRESET_SEPARATE_MATERIALS_AND_ANIMATIONS:
-			return TTR("Import with Separate Materials+Animations");
-		case PRESET_SEPARATE_MESHES_MATERIALS_AND_ANIMATIONS:
-			return TTR("Import with Separate Objects+Materials+Animations");
-		case PRESET_MULTIPLE_SCENES:
-			return TTR("Import as Multiple Scenes");
-		case PRESET_MULTIPLE_SCENES_AND_MATERIALS:
-			return TTR("Import as Multiple Scenes+Materials");
-	}
-
-	return "";
+	return String();
 }
 
 static bool _teststr(const String &p_what, const String &p_str) {
@@ -299,10 +247,24 @@ static void _gen_shape_list(const Ref<Mesh> &mesh, List<Ref<Shape3D>> &r_shape_l
 	}
 }
 
-Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>, List<Ref<Shape3D>>> &collision_map, LightBakeMode p_light_bake_mode) {
+static void _pre_gen_shape_list(const Ref<EditorSceneImporterMesh> &mesh, List<Ref<Shape3D>> &r_shape_list, bool p_convex) {
+	if (!p_convex) {
+		Ref<Shape3D> shape = mesh->create_trimesh_shape();
+		r_shape_list.push_back(shape);
+	} else {
+		Vector<Ref<Shape3D>> cd = mesh->convex_decompose();
+		if (cd.size()) {
+			for (int i = 0; i < cd.size(); i++) {
+				r_shape_list.push_back(cd[i]);
+			}
+		}
+	}
+}
+
+Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<EditorSceneImporterMesh>, List<Ref<Shape3D>>> &collision_map) {
 	// children first
 	for (int i = 0; i < p_node->get_child_count(); i++) {
-		Node *r = _fix_node(p_node->get_child(i), p_root, collision_map, p_light_bake_mode);
+		Node *r = _pre_fix_node(p_node->get_child(i), p_root, collision_map);
 		if (!r) {
 			i--; //was erased
 		}
@@ -317,32 +279,28 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 		return nullptr;
 	}
 
-	if (Object::cast_to<MeshInstance3D>(p_node)) {
-		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(p_node);
+	if (Object::cast_to<EditorSceneImporterMeshNode3D>(p_node)) {
+		EditorSceneImporterMeshNode3D *mi = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
 
-		Ref<ArrayMesh> m = mi->get_mesh();
+		Ref<EditorSceneImporterMesh> m = mi->get_mesh();
 
 		if (m.is_valid()) {
 			for (int i = 0; i < m->get_surface_count(); i++) {
-				Ref<StandardMaterial3D> mat = m->surface_get_material(i);
+				Ref<BaseMaterial3D> mat = m->get_surface_material(i);
 				if (!mat.is_valid()) {
 					continue;
 				}
 
 				if (_teststr(mat->get_name(), "alpha")) {
-					mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+					mat->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
 					mat->set_name(_fixstr(mat->get_name(), "alpha"));
 				}
 				if (_teststr(mat->get_name(), "vcol")) {
-					mat->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
-					mat->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
+					mat->set_flag(BaseMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
+					mat->set_flag(BaseMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
 					mat->set_name(_fixstr(mat->get_name(), "vcol"));
 				}
 			}
-		}
-
-		if (p_light_bake_mode != LIGHT_BAKE_DISABLED) {
-			mi->set_gi_mode(GeometryInstance3D::GI_MODE_BAKED);
 		}
 	}
 
@@ -367,6 +325,17 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 					}
 				}
 			}
+
+			String animname = E->get();
+			const int loop_string_count = 3;
+			static const char *loop_strings[loop_string_count] = { "loops", "loop", "cycle" };
+			for (int i = 0; i < loop_string_count; i++) {
+				if (_teststr(animname, loop_strings[i])) {
+					anim->set_loop(true);
+					animname = _fixstr(animname, loop_strings[i]);
+					ap->rename_animation(E->get(), animname);
+				}
+			}
 		}
 	}
 
@@ -374,9 +343,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 		if (isroot) {
 			return p_node;
 		}
-		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(p_node);
+		EditorSceneImporterMeshNode3D *mi = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
 		if (mi) {
-			Ref<Mesh> mesh = mi->get_mesh();
+			Ref<EditorSceneImporterMesh> mesh = mi->get_mesh();
 
 			if (mesh.is_valid()) {
 				List<Ref<Shape3D>> shapes;
@@ -384,10 +353,10 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 				if (collision_map.has(mesh)) {
 					shapes = collision_map[mesh];
 				} else if (_teststr(name, "colonly")) {
-					_gen_shape_list(mesh, shapes, false);
+					_pre_gen_shape_list(mesh, shapes, false);
 					collision_map[mesh] = shapes;
 				} else if (_teststr(name, "convcolonly")) {
-					_gen_shape_list(mesh, shapes, true);
+					_pre_gen_shape_list(mesh, shapes, true);
 					collision_map[mesh] = shapes;
 				}
 
@@ -454,13 +423,13 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 			colshape->set_owner(sb->get_owner());
 		}
 
-	} else if (_teststr(name, "rigid") && Object::cast_to<MeshInstance3D>(p_node)) {
+	} else if (_teststr(name, "rigid") && Object::cast_to<EditorSceneImporterMeshNode3D>(p_node)) {
 		if (isroot) {
 			return p_node;
 		}
 
-		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(p_node);
-		Ref<Mesh> mesh = mi->get_mesh();
+		EditorSceneImporterMeshNode3D *mi = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
+		Ref<EditorSceneImporterMesh> mesh = mi->get_mesh();
 
 		if (mesh.is_valid()) {
 			List<Ref<Shape3D>> shapes;
@@ -492,10 +461,10 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 			}
 		}
 
-	} else if ((_teststr(name, "col") || (_teststr(name, "convcol"))) && Object::cast_to<MeshInstance3D>(p_node)) {
-		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(p_node);
+	} else if ((_teststr(name, "col") || (_teststr(name, "convcol"))) && Object::cast_to<EditorSceneImporterMeshNode3D>(p_node)) {
+		EditorSceneImporterMeshNode3D *mi = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
 
-		Ref<Mesh> mesh = mi->get_mesh();
+		Ref<EditorSceneImporterMesh> mesh = mi->get_mesh();
 
 		if (mesh.is_valid()) {
 			List<Ref<Shape3D>> shapes;
@@ -542,71 +511,31 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 			}
 		}
 
-	} else if (_teststr(name, "navmesh") && Object::cast_to<MeshInstance3D>(p_node)) {
+	} else if (_teststr(name, "navmesh") && Object::cast_to<EditorSceneImporterMeshNode3D>(p_node)) {
 		if (isroot) {
 			return p_node;
 		}
 
-		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(p_node);
+		EditorSceneImporterMeshNode3D *mi = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
 
-		Ref<ArrayMesh> mesh = mi->get_mesh();
+		Ref<EditorSceneImporterMesh> mesh = mi->get_mesh();
 		ERR_FAIL_COND_V(mesh.is_null(), nullptr);
 		NavigationRegion3D *nmi = memnew(NavigationRegion3D);
 
 		nmi->set_name(_fixstr(name, "navmesh"));
-		Ref<NavigationMesh> nmesh = memnew(NavigationMesh);
-		nmesh->create_from_mesh(mesh);
+		Ref<NavigationMesh> nmesh = mesh->create_navigation_mesh();
 		nmi->set_navigation_mesh(nmesh);
 		Object::cast_to<Node3D>(nmi)->set_transform(mi->get_transform());
 		p_node->replace_by(nmi);
 		memdelete(p_node);
 		p_node = nmi;
-	} else if (_teststr(name, "vehicle")) {
-		if (isroot) {
-			return p_node;
-		}
 
-		Node *owner = p_node->get_owner();
-		Node3D *s = Object::cast_to<Node3D>(p_node);
-		VehicleBody3D *bv = memnew(VehicleBody3D);
-		String n = _fixstr(p_node->get_name(), "vehicle");
-		bv->set_name(n);
-		p_node->replace_by(bv);
-		p_node->set_name(n);
-		bv->add_child(p_node);
-		bv->set_owner(owner);
-		p_node->set_owner(owner);
-		bv->set_transform(s->get_transform());
-		s->set_transform(Transform());
-
-		p_node = bv;
-
-	} else if (_teststr(name, "wheel")) {
-		if (isroot) {
-			return p_node;
-		}
-
-		Node *owner = p_node->get_owner();
-		Node3D *s = Object::cast_to<Node3D>(p_node);
-		VehicleWheel3D *bv = memnew(VehicleWheel3D);
-		String n = _fixstr(p_node->get_name(), "wheel");
-		bv->set_name(n);
-		p_node->replace_by(bv);
-		p_node->set_name(n);
-		bv->add_child(p_node);
-		bv->set_owner(owner);
-		p_node->set_owner(owner);
-		bv->set_transform(s->get_transform());
-		s->set_transform(Transform());
-
-		p_node = bv;
-
-	} else if (Object::cast_to<MeshInstance3D>(p_node)) {
+	} else if (Object::cast_to<EditorSceneImporterMeshNode3D>(p_node)) {
 		//last attempt, maybe collision inside the mesh data
 
-		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(p_node);
+		EditorSceneImporterMeshNode3D *mi = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
 
-		Ref<ArrayMesh> mesh = mi->get_mesh();
+		Ref<EditorSceneImporterMesh> mesh = mi->get_mesh();
 		if (!mesh.is_null()) {
 			List<Ref<Shape3D>> shapes;
 			if (collision_map.has(mesh)) {
@@ -644,27 +573,314 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 	return p_node;
 }
 
-void ResourceImporterScene::_create_clips(Node *scene, const Array &p_clips, bool p_bake_all) {
-	if (!scene->has_node(String("AnimationPlayer"))) {
-		return;
+Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<EditorSceneImporterMesh>, List<Ref<Shape3D>>> &collision_map, Set<Ref<EditorSceneImporterMesh>> &r_scanned_meshes, const Dictionary &p_node_data, const Dictionary &p_material_data, const Dictionary &p_animation_data, float p_animation_fps) {
+	// children first
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		Node *r = _post_fix_node(p_node->get_child(i), p_root, collision_map, r_scanned_meshes, p_node_data, p_material_data, p_animation_data, p_animation_fps);
+		if (!r) {
+			i--; //was erased
+		}
 	}
 
-	Node *n = scene->get_node(String("AnimationPlayer"));
-	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
-	ERR_FAIL_COND(!anim);
+	bool isroot = p_node == p_root;
 
+	String import_id;
+
+	if (p_node->has_meta("import_id")) {
+		import_id = p_node->get_meta("import_id");
+	} else {
+		import_id = "PATH:" + p_root->get_path_to(p_node);
+	}
+
+	Dictionary node_settings;
+	if (p_node_data.has(import_id)) {
+		node_settings = p_node_data[import_id];
+	}
+
+	if (!isroot && (node_settings.has("import/skip_import") && bool(node_settings["import/skip_import"]))) {
+		memdelete(p_node);
+		return nullptr;
+	}
+
+	if (Object::cast_to<EditorSceneImporterMeshNode3D>(p_node)) {
+		EditorSceneImporterMeshNode3D *mi = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
+
+		Ref<EditorSceneImporterMesh> m = mi->get_mesh();
+
+		if (m.is_valid()) {
+			if (!r_scanned_meshes.has(m)) {
+				for (int i = 0; i < m->get_surface_count(); i++) {
+					Ref<Material> mat = m->get_surface_material(i);
+					if (mat.is_valid()) {
+						String mat_id;
+						if (mat->has_meta("import_id")) {
+							mat_id = mat->get_meta("import_id");
+						} else {
+							mat_id = mat->get_name();
+						}
+
+						if (mat_id != String() && p_material_data.has(mat_id)) {
+							Dictionary matdata = p_material_data[mat_id];
+							if (matdata.has("use_external/enabled") && bool(matdata["use_external/enabled"]) && matdata.has("use_external/path")) {
+								String path = matdata["use_external/path"];
+								Ref<Material> external_mat = ResourceLoader::load(path);
+								if (external_mat.is_valid()) {
+									m->set_surface_material(i, external_mat);
+								}
+							}
+						}
+					}
+				}
+
+				r_scanned_meshes.insert(m);
+			}
+
+			if (node_settings.has("generate/physics")) {
+				int mesh_physics_mode = node_settings["generate/physics"];
+
+				if (mesh_physics_mode != MESH_PHYSICS_DISABLED) {
+					List<Ref<Shape3D>> shapes;
+
+					if (collision_map.has(m)) {
+						shapes = collision_map[m];
+					} else {
+						switch (mesh_physics_mode) {
+							case MESH_PHYSICS_MESH_AND_STATIC_COLLIDER: {
+								_pre_gen_shape_list(m, shapes, false);
+							} break;
+							case MESH_PHYSICS_RIGID_BODY_AND_MESH: {
+								_pre_gen_shape_list(m, shapes, true);
+							} break;
+							case MESH_PHYSICS_STATIC_COLLIDER_ONLY: {
+								_pre_gen_shape_list(m, shapes, false);
+							} break;
+							case MESH_PHYSICS_AREA_ONLY: {
+								_pre_gen_shape_list(m, shapes, true);
+							} break;
+						}
+					}
+
+					if (shapes.size()) {
+						CollisionObject3D *base = nullptr;
+						switch (mesh_physics_mode) {
+							case MESH_PHYSICS_MESH_AND_STATIC_COLLIDER: {
+								StaticBody3D *col = memnew(StaticBody3D);
+								col->set_name("Collider");
+								p_node->add_child(col);
+								base = col;
+							} break;
+							case MESH_PHYSICS_RIGID_BODY_AND_MESH: {
+								RigidBody3D *rigid_body = memnew(RigidBody3D);
+								rigid_body->set_name(p_node->get_name());
+								p_node->replace_by(rigid_body);
+								rigid_body->set_transform(mi->get_transform());
+								p_node = rigid_body;
+								mi->set_name("mesh");
+								mi->set_transform(Transform());
+								rigid_body->add_child(mi);
+								mi->set_owner(rigid_body->get_owner());
+								base = rigid_body;
+							} break;
+							case MESH_PHYSICS_STATIC_COLLIDER_ONLY: {
+								StaticBody3D *col = memnew(StaticBody3D);
+								col->set_transform(mi->get_transform());
+								col->set_name(p_node->get_name());
+								p_node->replace_by(col);
+								memdelete(p_node);
+								p_node = col;
+								base = col;
+							} break;
+							case MESH_PHYSICS_AREA_ONLY: {
+								Area3D *area = memnew(Area3D);
+								area->set_transform(mi->get_transform());
+								area->set_name(p_node->get_name());
+								p_node->replace_by(area);
+								memdelete(p_node);
+								p_node = area;
+								base = area;
+
+							} break;
+						}
+
+						int idx = 0;
+						for (List<Ref<Shape3D>>::Element *E = shapes.front(); E; E = E->next()) {
+							CollisionShape3D *cshape = memnew(CollisionShape3D);
+							cshape->set_shape(E->get());
+							base->add_child(cshape);
+
+							cshape->set_name("shape" + itos(idx));
+							cshape->set_owner(base->get_owner());
+							idx++;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	//navmesh (node may have changed type above)
+	if (Object::cast_to<EditorSceneImporterMeshNode3D>(p_node)) {
+		EditorSceneImporterMeshNode3D *mi = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
+
+		Ref<EditorSceneImporterMesh> m = mi->get_mesh();
+
+		if (m.is_valid()) {
+			if (node_settings.has("generate/navmesh")) {
+				int navmesh_mode = node_settings["generate/navmesh"];
+
+				if (navmesh_mode != NAVMESH_DISABLED) {
+					NavigationRegion3D *nmi = memnew(NavigationRegion3D);
+
+					Ref<NavigationMesh> nmesh = m->create_navigation_mesh();
+					nmi->set_navigation_mesh(nmesh);
+
+					if (navmesh_mode == NAVMESH_NAVMESH_ONLY) {
+						nmi->set_transform(mi->get_transform());
+						p_node->replace_by(nmi);
+						memdelete(p_node);
+						p_node = nmi;
+					} else {
+						mi->add_child(nmi);
+						nmi->set_owner(mi->get_owner());
+					}
+				}
+			}
+		}
+	}
+
+	if (Object::cast_to<AnimationPlayer>(p_node)) {
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
+
+		{
+			//make sure this is unique
+			node_settings = node_settings.duplicate(true);
+			//fill node settings for this node with default values
+			List<ImportOption> iopts;
+			get_internal_import_options(INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE, &iopts);
+			for (List<ImportOption>::Element *E = iopts.front(); E; E = E->next()) {
+				if (!node_settings.has(E->get().option.name)) {
+					node_settings[E->get().option.name] = E->get().default_value;
+				}
+			}
+		}
+
+		bool use_optimizer = node_settings["optimizer/enabled"];
+		float anim_optimizer_linerr = node_settings["optimizer/max_linear_error"];
+		float anim_optimizer_angerr = node_settings["optimizer/max_angular_error"];
+		float anim_optimizer_maxang = node_settings["optimizer/max_angle"];
+
+		if (use_optimizer) {
+			_optimize_animations(ap, anim_optimizer_linerr, anim_optimizer_angerr, anim_optimizer_maxang);
+		}
+
+		Array animation_clips;
+		{
+			int clip_count = node_settings["clips/amount"];
+
+			for (int i = 0; i < clip_count; i++) {
+				String name = node_settings["clip_" + itos(i + 1) + "/name"];
+				int from_frame = node_settings["clip_" + itos(i + 1) + "/start_frame"];
+				int end_frame = node_settings["clip_" + itos(i + 1) + "/end_frame"];
+				bool loop = node_settings["clip_" + itos(i + 1) + "/loops"];
+				bool save_to_file = node_settings["clip_" + itos(i + 1) + "/save_to_file/enabled"];
+				bool save_to_path = node_settings["clip_" + itos(i + 1) + "/save_to_file/path"];
+				bool save_to_file_keep_custom = node_settings["clip_" + itos(i + 1) + "/save_to_file/keep_custom_tracks"];
+
+				animation_clips.push_back(name);
+				animation_clips.push_back(from_frame / p_animation_fps);
+				animation_clips.push_back(end_frame / p_animation_fps);
+				animation_clips.push_back(loop);
+				animation_clips.push_back(save_to_file);
+				animation_clips.push_back(save_to_path);
+				animation_clips.push_back(save_to_file_keep_custom);
+			}
+		}
+
+		if (animation_clips.size()) {
+			_create_clips(ap, animation_clips, true);
+		} else {
+			List<StringName> anims;
+			ap->get_animation_list(&anims);
+			for (List<StringName>::Element *E = anims.front(); E; E = E->next()) {
+				String name = E->get();
+				Ref<Animation> anim = ap->get_animation(name);
+				if (p_animation_data.has(name)) {
+					Dictionary anim_settings = p_animation_data[name];
+					{
+						//fill with default values
+						List<ImportOption> iopts;
+						get_internal_import_options(INTERNAL_IMPORT_CATEGORY_ANIMATION, &iopts);
+						for (List<ImportOption>::Element *F = iopts.front(); F; F = F->next()) {
+							if (!anim_settings.has(F->get().option.name)) {
+								anim_settings[F->get().option.name] = F->get().default_value;
+							}
+						}
+					}
+
+					anim->set_loop(anim_settings["settings/loops"]);
+					bool save = anim_settings["save_to_file/enabled"];
+					String path = anim_settings["save_to_file/path"];
+					bool keep_custom = anim_settings["save_to_file/keep_custom_tracks"];
+
+					Ref<Animation> saved_anim = _save_animation_to_file(anim, save, path, keep_custom);
+
+					if (saved_anim != anim) {
+						ap->add_animation(name, saved_anim); //replace
+					}
+				}
+			}
+		}
+	}
+
+	return p_node;
+}
+
+Ref<Animation> ResourceImporterScene::_save_animation_to_file(Ref<Animation> anim, bool p_save_to_file, String p_save_to_path, bool p_keep_custom_tracks) {
+	if (!p_save_to_file || !p_save_to_path.is_resource_file()) {
+		return anim;
+	}
+
+	if (FileAccess::exists(p_save_to_path) && p_keep_custom_tracks) {
+		// Copy custom animation tracks from previously imported files.
+		Ref<Animation> old_anim = ResourceLoader::load(p_save_to_path, "Animation", ResourceFormatLoader::CACHE_MODE_IGNORE);
+		if (old_anim.is_valid()) {
+			for (int i = 0; i < old_anim->get_track_count(); i++) {
+				if (!old_anim->track_is_imported(i)) {
+					old_anim->copy_track(i, anim);
+				}
+			}
+			anim->set_loop(old_anim->has_loop());
+		}
+	}
+
+	if (ResourceCache::has(p_save_to_path)) {
+		Ref<Animation> old_anim = Ref<Resource>(ResourceCache::get(p_save_to_path));
+		if (old_anim.is_valid()) {
+			old_anim->copy_from(anim);
+			anim = old_anim;
+		}
+	}
+	anim->set_path(p_save_to_path, true); // Set path to save externally.
+	Error err = ResourceSaver::save(p_save_to_path, anim, ResourceSaver::FLAG_CHANGE_PATH);
+	ERR_FAIL_COND_V_MSG(err != OK, anim, "Saving of animation failed: " + p_save_to_path);
+	return anim;
+}
+
+void ResourceImporterScene::_create_clips(AnimationPlayer *anim, const Array &p_clips, bool p_bake_all) {
 	if (!anim->has_animation("default")) {
 		return;
 	}
 
 	Ref<Animation> default_anim = anim->get_animation("default");
 
-	for (int i = 0; i < p_clips.size(); i += 4) {
+	for (int i = 0; i < p_clips.size(); i += 7) {
 		String name = p_clips[i];
 		float from = p_clips[i + 1];
 		float to = p_clips[i + 2];
 		bool loop = p_clips[i + 3];
+		bool save_to_file = p_clips[i + 4];
+		String save_to_path = p_clips[i + 5];
+		bool keep_current = p_clips[i + 6];
 		if (from >= to) {
 			continue;
 		}
@@ -752,141 +968,17 @@ void ResourceImporterScene::_create_clips(Node *scene, const Array &p_clips, boo
 		new_anim->set_loop(loop);
 		new_anim->set_length(to - from);
 		anim->add_animation(name, new_anim);
+
+		Ref<Animation> saved_anim = _save_animation_to_file(new_anim, save_to_file, save_to_path, keep_current);
+		if (saved_anim != new_anim) {
+			anim->add_animation(name, saved_anim);
+		}
 	}
 
 	anim->remove_animation("default"); //remove default (no longer needed)
 }
 
-void ResourceImporterScene::_filter_anim_tracks(Ref<Animation> anim, Set<String> &keep) {
-	Ref<Animation> a = anim;
-	ERR_FAIL_COND(!a.is_valid());
-
-	for (int j = 0; j < a->get_track_count(); j++) {
-		String path = a->track_get_path(j);
-
-		if (!keep.has(path)) {
-			a->remove_track(j);
-			j--;
-		}
-	}
-}
-
-void ResourceImporterScene::_filter_tracks(Node *scene, const String &p_text) {
-	if (!scene->has_node(String("AnimationPlayer"))) {
-		return;
-	}
-	Node *n = scene->get_node(String("AnimationPlayer"));
-	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
-	ERR_FAIL_COND(!anim);
-
-	Vector<String> strings = p_text.split("\n");
-	for (int i = 0; i < strings.size(); i++) {
-		strings.write[i] = strings[i].strip_edges();
-	}
-
-	List<StringName> anim_names;
-	anim->get_animation_list(&anim_names);
-	for (List<StringName>::Element *E = anim_names.front(); E; E = E->next()) {
-		String name = E->get();
-		bool valid_for_this = false;
-		bool valid = false;
-
-		Set<String> keep;
-		Set<String> keep_local;
-
-		for (int i = 0; i < strings.size(); i++) {
-			if (strings[i].begins_with("@")) {
-				valid_for_this = false;
-				for (Set<String>::Element *F = keep_local.front(); F; F = F->next()) {
-					keep.insert(F->get());
-				}
-				keep_local.clear();
-
-				Vector<String> filters = strings[i].substr(1, strings[i].length()).split(",");
-				for (int j = 0; j < filters.size(); j++) {
-					String fname = filters[j].strip_edges();
-					if (fname == "") {
-						continue;
-					}
-					int fc = fname[0];
-					bool plus;
-					if (fc == '+') {
-						plus = true;
-					} else if (fc == '-') {
-						plus = false;
-					} else {
-						continue;
-					}
-
-					String filter = fname.substr(1, fname.length()).strip_edges();
-
-					if (!name.matchn(filter)) {
-						continue;
-					}
-					valid_for_this = plus;
-				}
-
-				if (valid_for_this) {
-					valid = true;
-				}
-
-			} else if (valid_for_this) {
-				Ref<Animation> a = anim->get_animation(name);
-				if (!a.is_valid()) {
-					continue;
-				}
-
-				for (int j = 0; j < a->get_track_count(); j++) {
-					String path = a->track_get_path(j);
-
-					String tname = strings[i];
-					if (tname == "") {
-						continue;
-					}
-					int fc = tname[0];
-					bool plus;
-					if (fc == '+') {
-						plus = true;
-					} else if (fc == '-') {
-						plus = false;
-					} else {
-						continue;
-					}
-
-					String filter = tname.substr(1, tname.length()).strip_edges();
-
-					if (!path.matchn(filter)) {
-						continue;
-					}
-
-					if (plus) {
-						keep_local.insert(path);
-					} else if (!keep.has(path)) {
-						keep_local.erase(path);
-					}
-				}
-			}
-		}
-
-		if (valid) {
-			for (Set<String>::Element *F = keep_local.front(); F; F = F->next()) {
-				keep.insert(F->get());
-			}
-			_filter_anim_tracks(anim->get_animation(name), keep);
-		}
-	}
-}
-
-void ResourceImporterScene::_optimize_animations(Node *scene, float p_max_lin_error, float p_max_ang_error, float p_max_angle) {
-	if (!scene->has_node(String("AnimationPlayer"))) {
-		return;
-	}
-	Node *n = scene->get_node(String("AnimationPlayer"));
-	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
-	ERR_FAIL_COND(!anim);
-
+void ResourceImporterScene::_optimize_animations(AnimationPlayer *anim, float p_max_lin_error, float p_max_ang_error, float p_max_angle) {
 	List<StringName> anim_names;
 	anim->get_animation_list(&anim_names);
 	for (List<StringName>::Element *E = anim_names.front(); E; E = E->next()) {
@@ -895,208 +987,99 @@ void ResourceImporterScene::_optimize_animations(Node *scene, float p_max_lin_er
 	}
 }
 
-static String _make_extname(const String &p_str) {
-	String ext_name = p_str.replace(".", "_");
-	ext_name = ext_name.replace(":", "_");
-	ext_name = ext_name.replace("\"", "_");
-	ext_name = ext_name.replace("<", "_");
-	ext_name = ext_name.replace(">", "_");
-	ext_name = ext_name.replace("/", "_");
-	ext_name = ext_name.replace("|", "_");
-	ext_name = ext_name.replace("\\", "_");
-	ext_name = ext_name.replace("?", "_");
-	ext_name = ext_name.replace("*", "_");
+void ResourceImporterScene::get_internal_import_options(InternalImportCategory p_category, List<ImportOption> *r_options) const {
+	switch (p_category) {
+		case INTERNAL_IMPORT_CATEGORY_NODE: {
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "import/skip_import", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE: {
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "import/skip_import", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/physics", PROPERTY_HINT_ENUM, "Disabled,Mesh + Static Collider,Rigid Body + Mesh,Static Collider Only,Area Only"), 0));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/navmesh", PROPERTY_HINT_ENUM, "Disabled,Mesh + NavMesh,NavMesh Only"), 0));
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_MESH: {
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_to_file/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "save_to_file/path", PROPERTY_HINT_SAVE_FILE, "*.res,*.tres"), ""));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_to_file/make_streamable"), ""));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/shadow_meshes", PROPERTY_HINT_ENUM, "Default,Enable,Disable"), 0));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/lightmap_uv", PROPERTY_HINT_ENUM, "Default,Enable,Disable"), 0));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/lods", PROPERTY_HINT_ENUM, "Default,Enable,Disable"), 0));
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_MATERIAL: {
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "use_external/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "use_external/path", PROPERTY_HINT_FILE, "*.material,*.res,*.tres"), ""));
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_ANIMATION: {
+			r_options->push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "settings/loops"), false));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_to_file/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "save_to_file/path", PROPERTY_HINT_SAVE_FILE, "*.res,*.tres"), ""));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_to_file/keep_custom_tracks"), ""));
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE: {
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "import/skip_import", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "optimizer/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), true));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "optimizer/max_linear_error"), 0.05));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "optimizer/max_angular_error"), 0.01));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "optimizer/max_angle"), 22));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "slices/amount", PROPERTY_HINT_RANGE, "0,256,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 0));
 
-	return ext_name;
+			for (int i = 0; i < 256; i++) {
+				r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "slice_" + itos(i + 1) + "/name"), ""));
+				r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "slice_" + itos(i + 1) + "/start_frame"), 0));
+				r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "slice_" + itos(i + 1) + "/end_frame"), 0));
+				r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "slice_" + itos(i + 1) + "/loops"), false));
+				r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "slice_" + itos(i + 1) + "/save_to_file/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
+				r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "slice_" + itos(i + 1) + "/save_to_file/path", PROPERTY_HINT_SAVE_FILE, ".res,*.tres"), ""));
+				r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "slice_" + itos(i + 1) + "/save_to_file/keep_custom_tracks"), false));
+			}
+		} break;
+		default: {
+		}
+	}
 }
 
-void ResourceImporterScene::_find_meshes(Node *p_node, Map<Ref<ArrayMesh>, Transform> &meshes) {
-	List<PropertyInfo> pi;
-	p_node->get_property_list(&pi);
-
-	MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(p_node);
-
-	if (mi) {
-		Ref<ArrayMesh> mesh = mi->get_mesh();
-
-		if (mesh.is_valid() && !meshes.has(mesh)) {
-			Node3D *s = mi;
-			Transform transform;
-			while (s) {
-				transform = transform * s->get_transform();
-				s = Object::cast_to<Node3D>(s->get_parent());
+bool ResourceImporterScene::get_internal_option_visibility(InternalImportCategory p_category, const String &p_option, const Map<StringName, Variant> &p_options) const {
+	if (p_options.has("import/skip_import") && p_option != "import/skip_import" && bool(p_options["import/skip_import"])) {
+		return false; //if skip import
+	}
+	switch (p_category) {
+		case INTERNAL_IMPORT_CATEGORY_NODE: {
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE: {
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_MESH: {
+			if (p_option == "save_to_file/path" || p_option == "save_to_file/make_streamable") {
+				return p_options["save_to_file/enabled"];
+			}
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_MATERIAL: {
+			if (p_option == "use_external/path") {
+				return p_options["use_external/enabled"];
+			}
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_ANIMATION: {
+			if (p_option == "save_to_file/path" || p_option == "save_to_file/keep_custom_tracks") {
+				return p_options["save_to_file/enabled"];
+			}
+		} break;
+		case INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE: {
+			if (p_option.begins_with("animation/optimizer/") && p_option != "animation/optimizer/enabled" && !bool(p_options["animation/optimizer/enabled"])) {
+				return false;
 			}
 
-			meshes[mesh] = transform;
-		}
-	}
-	for (int i = 0; i < p_node->get_child_count(); i++) {
-		_find_meshes(p_node->get_child(i), meshes);
-	}
-}
-
-void ResourceImporterScene::_make_external_resources(Node *p_node, const String &p_base_path, bool p_make_animations, bool p_animations_as_text, bool p_keep_animations, bool p_make_materials, bool p_materials_as_text, bool p_keep_materials, bool p_make_meshes, bool p_meshes_as_text, Map<Ref<Animation>, Ref<Animation>> &p_animations, Map<Ref<Material>, Ref<Material>> &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh>> &p_meshes) {
-	List<PropertyInfo> pi;
-
-	if (p_make_animations) {
-		if (Object::cast_to<AnimationPlayer>(p_node)) {
-			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
-
-			List<StringName> anims;
-			ap->get_animation_list(&anims);
-			for (List<StringName>::Element *E = anims.front(); E; E = E->next()) {
-				Ref<Animation> anim = ap->get_animation(E->get());
-				ERR_CONTINUE(anim.is_null());
-
-				if (!p_animations.has(anim)) {
-					// Tracks from source file should be set as imported, anything else is a custom track.
-					for (int i = 0; i < anim->get_track_count(); i++) {
-						anim->track_set_imported(i, true);
-					}
-
-					String ext_name;
-
-					if (p_animations_as_text) {
-						ext_name = p_base_path.plus_file(_make_extname(E->get()) + ".tres");
-					} else {
-						ext_name = p_base_path.plus_file(_make_extname(E->get()) + ".anim");
-					}
-
-					if (FileAccess::exists(ext_name) && p_keep_animations) {
-						// Copy custom animation tracks from previously imported files.
-						Ref<Animation> old_anim = ResourceLoader::load(ext_name, "Animation", ResourceFormatLoader::CACHE_MODE_IGNORE);
-						if (old_anim.is_valid()) {
-							for (int i = 0; i < old_anim->get_track_count(); i++) {
-								if (!old_anim->track_is_imported(i)) {
-									old_anim->copy_track(i, anim);
-								}
-							}
-							anim->set_loop(old_anim->has_loop());
-						}
-					}
-
-					anim->set_path(ext_name, true); // Set path to save externally.
-					ResourceSaver::save(ext_name, anim, ResourceSaver::FLAG_CHANGE_PATH);
-					p_animations[anim] = anim;
+			if (p_option.begins_with("animation/slice_")) {
+				int max_slice = p_options["animation/slices/amount"];
+				int slice = p_option.get_slice("/", 1).get_slice("_", 1).to_int() - 1;
+				if (slice >= max_slice) {
+					return false;
 				}
 			}
+		} break;
+		default: {
 		}
 	}
 
-	p_node->get_property_list(&pi);
-
-	for (List<PropertyInfo>::Element *E = pi.front(); E; E = E->next()) {
-		if (E->get().type == Variant::OBJECT) {
-			Ref<Material> mat = p_node->get(E->get().name);
-
-			if (p_make_materials && mat.is_valid() && mat->get_name() != "") {
-				if (!p_materials.has(mat)) {
-					String ext_name;
-
-					if (p_materials_as_text) {
-						ext_name = p_base_path.plus_file(_make_extname(mat->get_name()) + ".tres");
-					} else {
-						ext_name = p_base_path.plus_file(_make_extname(mat->get_name()) + ".material");
-					}
-
-					if (p_keep_materials && FileAccess::exists(ext_name)) {
-						//if exists, use it
-						p_materials[mat] = ResourceLoader::load(ext_name);
-					} else {
-						ResourceSaver::save(ext_name, mat, ResourceSaver::FLAG_CHANGE_PATH);
-						p_materials[mat] = ResourceLoader::load(ext_name, "", ResourceFormatLoader::CACHE_MODE_IGNORE); // disable loading from the cache.
-					}
-				}
-
-				if (p_materials[mat] != mat) {
-					p_node->set(E->get().name, p_materials[mat]);
-				}
-			} else {
-				Ref<ArrayMesh> mesh = p_node->get(E->get().name);
-
-				if (mesh.is_valid()) {
-					bool mesh_just_added = false;
-
-					if (p_make_meshes) {
-						if (!p_meshes.has(mesh)) {
-							//meshes are always overwritten, keeping them is not practical
-							String ext_name;
-
-							if (p_meshes_as_text) {
-								ext_name = p_base_path.plus_file(_make_extname(mesh->get_name()) + ".tres");
-							} else {
-								ext_name = p_base_path.plus_file(_make_extname(mesh->get_name()) + ".mesh");
-							}
-
-							ResourceSaver::save(ext_name, mesh, ResourceSaver::FLAG_CHANGE_PATH);
-							p_meshes[mesh] = ResourceLoader::load(ext_name);
-							p_node->set(E->get().name, p_meshes[mesh]);
-							mesh_just_added = true;
-						}
-					}
-
-					if (p_make_materials) {
-						if (mesh_just_added || !p_meshes.has(mesh)) {
-							for (int i = 0; i < mesh->get_surface_count(); i++) {
-								mat = mesh->surface_get_material(i);
-
-								if (!mat.is_valid()) {
-									continue;
-								}
-								if (mat->get_name() == "") {
-									continue;
-								}
-
-								if (!p_materials.has(mat)) {
-									String ext_name;
-
-									if (p_materials_as_text) {
-										ext_name = p_base_path.plus_file(_make_extname(mat->get_name()) + ".tres");
-									} else {
-										ext_name = p_base_path.plus_file(_make_extname(mat->get_name()) + ".material");
-									}
-
-									if (p_keep_materials && FileAccess::exists(ext_name)) {
-										//if exists, use it
-										p_materials[mat] = ResourceLoader::load(ext_name);
-									} else {
-										ResourceSaver::save(ext_name, mat, ResourceSaver::FLAG_CHANGE_PATH);
-										p_materials[mat] = ResourceLoader::load(ext_name, "", ResourceFormatLoader::CACHE_MODE_IGNORE); // disable loading from the cache.
-									}
-								}
-
-								if (p_materials[mat] != mat) {
-									mesh->surface_set_material(i, p_materials[mat]);
-
-									//re-save the mesh since a material is now assigned
-									if (p_make_meshes) {
-										String ext_name;
-
-										if (p_meshes_as_text) {
-											ext_name = p_base_path.plus_file(_make_extname(mesh->get_name()) + ".tres");
-										} else {
-											ext_name = p_base_path.plus_file(_make_extname(mesh->get_name()) + ".mesh");
-										}
-
-										ResourceSaver::save(ext_name, mesh, ResourceSaver::FLAG_CHANGE_PATH);
-										p_meshes[mesh] = ResourceLoader::load(ext_name);
-									}
-								}
-							}
-
-							if (!p_make_meshes) {
-								p_meshes[mesh] = Ref<ArrayMesh>(); //save it anyway, so it won't be checked again
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	for (int i = 0; i < p_node->get_child_count(); i++) {
-		_make_external_resources(p_node->get_child(i), p_base_path, p_make_animations, p_animations_as_text, p_keep_animations, p_make_materials, p_materials_as_text, p_keep_materials, p_make_meshes, p_meshes_as_text, p_animations, p_materials, p_meshes);
-	}
+	return true;
 }
 
 void ResourceImporterScene::get_import_options(List<ImportOption> *r_options, int p_preset) const {
@@ -1115,42 +1098,18 @@ void ResourceImporterScene::get_import_options(List<ImportOption> *r_options, in
 		script_ext_hint += "*." + E->get();
 	}
 
-	bool materials_out = p_preset == PRESET_SEPARATE_MATERIALS || p_preset == PRESET_SEPARATE_MESHES_AND_MATERIALS || p_preset == PRESET_MULTIPLE_SCENES_AND_MATERIALS || p_preset == PRESET_SEPARATE_MATERIALS_AND_ANIMATIONS || p_preset == PRESET_SEPARATE_MESHES_MATERIALS_AND_ANIMATIONS;
-	bool meshes_out = p_preset == PRESET_SEPARATE_MESHES || p_preset == PRESET_SEPARATE_MESHES_AND_MATERIALS || p_preset == PRESET_SEPARATE_MESHES_AND_ANIMATIONS || p_preset == PRESET_SEPARATE_MESHES_MATERIALS_AND_ANIMATIONS;
-	bool scenes_out = p_preset == PRESET_MULTIPLE_SCENES || p_preset == PRESET_MULTIPLE_SCENES_AND_MATERIALS;
-	bool animations_out = p_preset == PRESET_SEPARATE_ANIMATIONS || p_preset == PRESET_SEPARATE_MESHES_AND_ANIMATIONS || p_preset == PRESET_SEPARATE_MATERIALS_AND_ANIMATIONS || p_preset == PRESET_SEPARATE_MESHES_MATERIALS_AND_ANIMATIONS;
-
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "nodes/root_scale", PROPERTY_HINT_RANGE, "0.001,1000,0.001"), 1.0));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "nodes/custom_script", PROPERTY_HINT_FILE, script_ext_hint), ""));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "nodes/storage", PROPERTY_HINT_ENUM, "Single Scene,Instanced Sub-Scenes"), scenes_out ? 1 : 0));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "materials/location", PROPERTY_HINT_ENUM, "Node,Mesh"), (meshes_out || materials_out) ? 1 : 0));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "materials/storage", PROPERTY_HINT_ENUM, "Built-In,Files (.material),Files (.tres)", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), materials_out ? 1 : 0));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "materials/keep_on_reimport"), materials_out));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/ensure_tangents"), true));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "meshes/storage", PROPERTY_HINT_ENUM, "Built-In,Files (.mesh),Files (.tres)"), meshes_out ? 1 : 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/generate_lods"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/create_shadow_meshes"), true));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "meshes/light_baking", PROPERTY_HINT_ENUM, "Disabled,Enable,Gen Lightmaps", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "meshes/light_baking", PROPERTY_HINT_ENUM, "Disabled,Dynamic,Static,Static Lightmaps", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 2));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "meshes/lightmap_texel_size", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 0.1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "skins/use_named_skins"), true));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "external_files/store_in_subdir"), false));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/import", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), true));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/import"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "animation/fps", PROPERTY_HINT_RANGE, "1,120,1"), 15));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "animation/filter_script", PROPERTY_HINT_MULTILINE_TEXT), ""));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "animation/storage", PROPERTY_HINT_ENUM, "Built-In,Files (.anim),Files (.tres)", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), animations_out));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/keep_custom_tracks"), animations_out));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/optimizer/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), true));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "animation/optimizer/max_linear_error"), 0.05));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "animation/optimizer/max_angular_error"), 0.01));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "animation/optimizer/max_angle"), 22));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/optimizer/remove_unused_tracks"), true));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "animation/clips/amount", PROPERTY_HINT_RANGE, "0,256,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 0));
-	for (int i = 0; i < 256; i++) {
-		r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "animation/clip_" + itos(i + 1) + "/name"), ""));
-		r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "animation/clip_" + itos(i + 1) + "/start_frame"), 0));
-		r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "animation/clip_" + itos(i + 1) + "/end_frame"), 0));
-		r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/clip_" + itos(i + 1) + "/loops"), false));
-	}
+	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "import_script/path", PROPERTY_HINT_FILE, script_ext_hint), ""));
+
+	r_options->push_back(ImportOption(PropertyInfo(Variant::DICTIONARY, "_subresources", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), Dictionary()));
 }
 
 void ResourceImporterScene::_replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner) {
@@ -1222,7 +1181,7 @@ Ref<Animation> ResourceImporterScene::import_animation_from_other_importer(Edito
 	return importer->import_animation(p_path, p_flags, p_bake_fps);
 }
 
-void ResourceImporterScene::_generate_meshes(Node *p_node, bool p_generate_lods, bool p_create_shadow_meshes) {
+void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<uint8_t> &r_dst_lightmap_cache) {
 	EditorSceneImporterMeshNode3D *src_mesh_node = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
 	if (src_mesh_node) {
 		//is mesh
@@ -1235,14 +1194,94 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, bool p_generate_lods,
 			Ref<ArrayMesh> mesh;
 			if (!src_mesh_node->get_mesh()->has_mesh()) {
 				//do mesh processing
-				if (p_generate_lods) {
+
+				bool generate_lods = p_generate_lods;
+				bool create_shadow_meshes = p_create_shadow_meshes;
+				bool bake_lightmaps = p_light_bake_mode == LIGHT_BAKE_STATIC_LIGHTMAPS;
+				String save_to_file;
+
+				String mesh_id;
+
+				if (src_mesh_node->get_mesh()->has_meta("import_id")) {
+					mesh_id = src_mesh_node->get_mesh()->get_meta("import_id");
+				} else {
+					mesh_id = src_mesh_node->get_mesh()->get_name();
+				}
+
+				if (mesh_id != String() && p_mesh_data.has(mesh_id)) {
+					Dictionary mesh_settings = p_mesh_data[mesh_id];
+
+					if (mesh_settings.has("generate/shadow_meshes")) {
+						int shadow_meshes = mesh_settings["generate/shadow_meshes"];
+						if (shadow_meshes == MESH_OVERRIDE_ENABLE) {
+							create_shadow_meshes = true;
+						} else if (shadow_meshes == MESH_OVERRIDE_DISABLE) {
+							create_shadow_meshes = false;
+						}
+					}
+
+					if (mesh_settings.has("generate/lightmap_uv")) {
+						int lightmap_uv = mesh_settings["generate/lightmap_uv"];
+						if (lightmap_uv == MESH_OVERRIDE_ENABLE) {
+							bake_lightmaps = true;
+						} else if (lightmap_uv == MESH_OVERRIDE_DISABLE) {
+							bake_lightmaps = false;
+						}
+					}
+
+					if (mesh_settings.has("generate/lods")) {
+						int lods = mesh_settings["generate/lods"];
+						if (lods == MESH_OVERRIDE_ENABLE) {
+							generate_lods = true;
+						} else if (lods == MESH_OVERRIDE_DISABLE) {
+							generate_lods = false;
+						}
+					}
+
+					if (mesh_settings.has("save_to_file/enabled") && bool(mesh_settings["save_to_file/enabled"]) && mesh_settings.has("save_to_file/path")) {
+						save_to_file = mesh_settings["save_to_file/path"];
+						if (!save_to_file.is_resource_file()) {
+							save_to_file = "";
+						}
+					}
+				}
+
+				if (generate_lods) {
 					src_mesh_node->get_mesh()->generate_lods();
 				}
-				if (p_create_shadow_meshes) {
+				if (create_shadow_meshes) {
 					src_mesh_node->get_mesh()->create_shadow_mesh();
 				}
+
+				if (bake_lightmaps) {
+					Transform xf;
+					Node3D *n = src_mesh_node;
+					while (n) {
+						xf = n->get_transform() * xf;
+						n = n->get_parent_spatial();
+					}
+
+					//use xf as transform for mesh, and bake it
+				}
+
+				if (save_to_file != String()) {
+					Ref<Mesh> existing = Ref<Resource>(ResourceCache::get(save_to_file));
+					if (existing.is_valid()) {
+						//if somehow an existing one is useful, create
+						existing->reset_state();
+					}
+					mesh = src_mesh_node->get_mesh()->get_mesh(existing);
+
+					ResourceSaver::save(save_to_file, mesh); //override
+
+					mesh->set_path(save_to_file, true); //takeover existing, if needed
+
+				} else {
+					mesh = src_mesh_node->get_mesh()->get_mesh();
+				}
+			} else {
+				mesh = src_mesh_node->get_mesh()->get_mesh();
 			}
-			mesh = src_mesh_node->get_mesh()->get_mesh();
 
 			if (mesh.is_valid()) {
 				mesh_node->set_mesh(mesh);
@@ -1251,15 +1290,68 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, bool p_generate_lods,
 				}
 			}
 		}
+
+		switch (p_light_bake_mode) {
+			case LIGHT_BAKE_DISABLED: {
+				mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_DISABLED);
+			} break;
+			case LIGHT_BAKE_DYNAMIC: {
+				mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_DYNAMIC);
+			} break;
+			case LIGHT_BAKE_STATIC:
+			case LIGHT_BAKE_STATIC_LIGHTMAPS: {
+				mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_BAKED);
+			} break;
+		}
+
 		p_node->replace_by(mesh_node);
 		memdelete(p_node);
 		p_node = mesh_node;
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
-		_generate_meshes(p_node->get_child(i), p_generate_lods, p_create_shadow_meshes);
+		_generate_meshes(p_node->get_child(i), p_mesh_data, p_generate_lods, p_create_shadow_meshes, p_light_bake_mode, p_lightmap_texel_size, p_src_lightmap_cache, r_dst_lightmap_cache);
 	}
 }
+
+Node *ResourceImporterScene::pre_import(const String &p_source_file) {
+	Ref<EditorSceneImporter> importer;
+	String ext = p_source_file.get_extension().to_lower();
+
+	EditorProgress progress("pre-import", TTR("Pre-Import Scene"), 0);
+	progress.step(TTR("Importing Scene..."), 0);
+
+	for (Set<Ref<EditorSceneImporter>>::Element *E = importers.front(); E; E = E->next()) {
+		List<String> extensions;
+		E->get()->get_extensions(&extensions);
+
+		for (List<String>::Element *F = extensions.front(); F; F = F->next()) {
+			if (F->get().to_lower() == ext) {
+				importer = E->get();
+				break;
+			}
+		}
+
+		if (importer.is_valid()) {
+			break;
+		}
+	}
+
+	ERR_FAIL_COND_V(!importer.is_valid(), nullptr);
+
+	Error err;
+	Node *scene = importer->import_scene(p_source_file, EditorSceneImporter::IMPORT_ANIMATION | EditorSceneImporter::IMPORT_GENERATE_TANGENT_ARRAYS, 15, nullptr, &err);
+	if (!scene || err != OK) {
+		return nullptr;
+	}
+
+	Map<Ref<EditorSceneImporterMesh>, List<Ref<Shape3D>>> collision_map;
+
+	_pre_fix_node(scene, scene, collision_map);
+
+	return scene;
+}
+
 Error ResourceImporterScene::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	const String &src_path = p_source_file;
 
@@ -1289,25 +1381,19 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 
 	float fps = p_options["animation/fps"];
 
-	int import_flags = EditorSceneImporter::IMPORT_ANIMATION_DETECT_LOOP;
-	if (!bool(p_options["animation/optimizer/remove_unused_tracks"])) {
-		import_flags |= EditorSceneImporter::IMPORT_ANIMATION_FORCE_ALL_TRACKS_IN_ALL_CLIPS;
-	}
+	int import_flags = 0;
 
 	if (bool(p_options["animation/import"])) {
 		import_flags |= EditorSceneImporter::IMPORT_ANIMATION;
 	}
 
-	if (bool(p_options["meshes/ensure_tangents"])) {
-		import_flags |= EditorSceneImporter::IMPORT_GENERATE_TANGENT_ARRAYS;
-	}
-
-	if (int(p_options["materials/location"]) == 0) {
-		import_flags |= EditorSceneImporter::IMPORT_MATERIALS_IN_INSTANCES;
-	}
-
 	if (bool(p_options["skins/use_named_skins"])) {
 		import_flags |= EditorSceneImporter::IMPORT_USE_NAMED_SKIN_BINDS;
+	}
+
+	bool ensure_tangents = p_options["meshes/ensure_tangents"];
+	if (ensure_tangents) {
+		import_flags |= EditorSceneImporter::IMPORT_GENERATE_TANGENT_ARRAYS;
 	}
 
 	Error err = OK;
@@ -1316,6 +1402,29 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	if (!scene || err != OK) {
 		return err;
 	}
+
+	Dictionary subresources = p_options["_subresources"];
+
+	Dictionary node_data;
+	if (subresources.has("nodes")) {
+		node_data = subresources["nodes"];
+	}
+
+	Dictionary material_data;
+	if (subresources.has("materials")) {
+		material_data = subresources["materials"];
+	}
+
+	Dictionary animation_data;
+	if (subresources.has("animations")) {
+		animation_data = subresources["animations"];
+	}
+
+	Set<Ref<EditorSceneImporterMesh>> scanned_meshes;
+	Map<Ref<EditorSceneImporterMesh>, List<Ref<Shape3D>>> collision_map;
+
+	_pre_fix_node(scene, scene, collision_map);
+	_post_fix_node(scene, scene, collision_map, scanned_meshes, node_data, material_data, animation_data, fps);
 
 	String root_type = p_options["nodes/root_type"];
 	root_type = root_type.split(" ")[0]; // full root_type is "ClassName (filename.gd)" for a script global class.
@@ -1354,73 +1463,35 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 
 	bool gen_lods = bool(p_options["meshes/generate_lods"]);
 	bool create_shadow_meshes = bool(p_options["meshes/create_shadow_meshes"]);
+	int light_bake_mode = p_options["meshes/light_baking"];
+	float texel_size = p_options["meshes/lightmap_texel_size"];
+	float lightmap_texel_size = MAX(0.001, texel_size);
 
-	_generate_meshes(scene, gen_lods, create_shadow_meshes);
+	Vector<uint8_t> src_lightmap_cache;
+	Vector<uint8_t> dst_lightmap_cache;
 
+	{
+		src_lightmap_cache = FileAccess::get_file_as_array(p_source_file + ".unwrap_cache", &err);
+		if (err != OK) {
+			src_lightmap_cache.clear();
+		}
+	}
+
+	Dictionary mesh_data;
+	if (subresources.has("meshes")) {
+		mesh_data = subresources["meshes"];
+	}
+	_generate_meshes(scene, mesh_data, gen_lods, create_shadow_meshes, LightBakeMode(light_bake_mode), lightmap_texel_size, src_lightmap_cache, dst_lightmap_cache);
+
+	if (dst_lightmap_cache.size()) {
+		FileAccessRef f = FileAccess::open(p_source_file + ".unwrap_cache", FileAccess::WRITE);
+		if (f) {
+			f->store_buffer(dst_lightmap_cache.ptr(), dst_lightmap_cache.size());
+		}
+	}
 	err = OK;
 
-	String animation_filter = String(p_options["animation/filter_script"]).strip_edges();
-
-	bool use_optimizer = p_options["animation/optimizer/enabled"];
-	float anim_optimizer_linerr = p_options["animation/optimizer/max_linear_error"];
-	float anim_optimizer_angerr = p_options["animation/optimizer/max_angular_error"];
-	float anim_optimizer_maxang = p_options["animation/optimizer/max_angle"];
-	int light_bake_mode = p_options["meshes/light_baking"];
-
-	Map<Ref<Mesh>, List<Ref<Shape3D>>> collision_map;
-
-	scene = _fix_node(scene, scene, collision_map, LightBakeMode(light_bake_mode));
-
-	if (use_optimizer) {
-		_optimize_animations(scene, anim_optimizer_linerr, anim_optimizer_angerr, anim_optimizer_maxang);
-	}
-
-	Array animation_clips;
-	{
-		int clip_count = p_options["animation/clips/amount"];
-
-		for (int i = 0; i < clip_count; i++) {
-			String name = p_options["animation/clip_" + itos(i + 1) + "/name"];
-			int from_frame = p_options["animation/clip_" + itos(i + 1) + "/start_frame"];
-			int end_frame = p_options["animation/clip_" + itos(i + 1) + "/end_frame"];
-			bool loop = p_options["animation/clip_" + itos(i + 1) + "/loops"];
-
-			animation_clips.push_back(name);
-			animation_clips.push_back(from_frame / fps);
-			animation_clips.push_back(end_frame / fps);
-			animation_clips.push_back(loop);
-		}
-	}
-	if (animation_clips.size()) {
-		_create_clips(scene, animation_clips, !bool(p_options["animation/optimizer/remove_unused_tracks"]));
-	}
-
-	if (animation_filter != "") {
-		_filter_tracks(scene, animation_filter);
-	}
-
-	bool external_animations = int(p_options["animation/storage"]) == 1 || int(p_options["animation/storage"]) == 2;
-	bool external_animations_as_text = int(p_options["animation/storage"]) == 2;
-	bool keep_custom_tracks = p_options["animation/keep_custom_tracks"];
-	bool external_materials = int(p_options["materials/storage"]) == 1 || int(p_options["materials/storage"]) == 2;
-	bool external_materials_as_text = int(p_options["materials/storage"]) == 2;
-	bool external_meshes = int(p_options["meshes/storage"]) == 1 || int(p_options["meshes/storage"]) == 2;
-	bool external_meshes_as_text = int(p_options["meshes/storage"]) == 2;
-	bool external_scenes = int(p_options["nodes/storage"]) == 1;
-
-	String base_path = p_source_file.get_base_dir();
-
-	if (external_animations || external_materials || external_meshes || external_scenes) {
-		if (bool(p_options["external_files/store_in_subdir"])) {
-			String subdir_name = p_source_file.get_file().get_basename();
-			DirAccess *da = DirAccess::open(base_path);
-			Error err2 = da->make_dir(subdir_name);
-			memdelete(da);
-			ERR_FAIL_COND_V_MSG(err2 != OK && err2 != ERR_ALREADY_EXISTS, err2, "Cannot make directory '" + subdir_name + "'.");
-			base_path = base_path.plus_file(subdir_name);
-		}
-	}
-
+#if 0
 	if (light_bake_mode == 2 /* || generate LOD */) {
 		Map<Ref<ArrayMesh>, Transform> meshes;
 		_find_meshes(scene, meshes);
@@ -1445,9 +1516,6 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 			}
 		}
 
-		float texel_size = p_options["meshes/lightmap_texel_size"];
-		texel_size = MAX(0.001, texel_size);
-
 		Map<String, unsigned int> used_unwraps;
 
 		EditorProgress progress2("gen_lightmaps", TTR("Generating Lightmaps"), meshes.size());
@@ -1469,7 +1537,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 			if (err2 != OK) {
 				EditorNode::add_io_error("Mesh '" + name + "' failed lightmap generation. Please fix geometry.");
 			} else {
-				String hash = String::md5((unsigned char *)ret_cache_data);
+`				String hash = String::md5((unsigned char *)ret_cache_data);
 				used_unwraps.insert(hash, ret_cache_size);
 
 				if (!ret_used_cache) {
@@ -1482,7 +1550,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 					} else {
 						int current_size = cache_data.size();
 						cache_data.resize(cache_data.size() + ret_cache_size);
-						unsigned char *ptrw = cache_data.ptrw();
+							unsigned char *ptrw = cache_data.ptrw();
 						memcpy(&ptrw[current_size], ret_cache_data, ret_cache_size);
 						int *data = (int *)ptrw;
 						data[0] += 1;
@@ -1530,20 +1598,11 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 			file->close();
 		}
 	}
-
-	if (external_animations || external_materials || external_meshes) {
-		Map<Ref<Animation>, Ref<Animation>> anim_map;
-		Map<Ref<Material>, Ref<Material>> mat_map;
-		Map<Ref<ArrayMesh>, Ref<ArrayMesh>> mesh_map;
-
-		bool keep_materials = bool(p_options["materials/keep_on_reimport"]);
-
-		_make_external_resources(scene, base_path, external_animations, external_animations_as_text, keep_custom_tracks, external_materials, external_materials_as_text, keep_materials, external_meshes, external_meshes_as_text, anim_map, mat_map, mesh_map);
-	}
+#endif
 
 	progress.step(TTR("Running Custom Script..."), 2);
 
-	String post_import_script_path = p_options["nodes/custom_script"];
+	String post_import_script_path = p_options["import_script/path"];
 	Ref<EditorScenePostImport> post_import_script;
 
 	if (post_import_script_path != "") {
@@ -1562,7 +1621,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	}
 
 	if (post_import_script.is_valid()) {
-		post_import_script->init(base_path, p_source_file);
+		post_import_script->init(p_source_file);
 		scene = post_import_script->post_import(scene);
 		if (!scene) {
 			EditorNode::add_io_error(
@@ -1573,29 +1632,6 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	}
 
 	progress.step(TTR("Saving..."), 104);
-
-	if (external_scenes) {
-		//save sub-scenes as instances!
-		for (int i = 0; i < scene->get_child_count(); i++) {
-			Node *child = scene->get_child(i);
-			if (child->get_owner() != scene) {
-				continue; //not a real child probably created by scene type (ig, a scrollbar)
-			}
-			_replace_owner(child, scene, child);
-
-			String cn = String(child->get_name()).strip_edges().replace(".", "_").replace(":", "_");
-			if (cn == String()) {
-				cn = "ChildNode" + itos(i);
-			}
-			String path = base_path.plus_file(cn + ".scn");
-			child->set_filename(path);
-
-			Ref<PackedScene> packer = memnew(PackedScene);
-			packer->pack(child);
-			err = ResourceSaver::save(path, packer); //do not take over, let the changed files reload themselves
-			ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + path + "'.");
-		}
-	}
 
 	Ref<PackedScene> packer = memnew(PackedScene);
 	packer->pack(scene);
@@ -1612,6 +1648,13 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 }
 
 ResourceImporterScene *ResourceImporterScene::singleton = nullptr;
+
+bool ResourceImporterScene::ResourceImporterScene::has_advanced_options() const {
+	return true;
+}
+void ResourceImporterScene::ResourceImporterScene::show_advanced_options(const String &p_path) {
+	SceneImportSettings::get_singleton()->open_settings(p_path);
+}
 
 ResourceImporterScene::ResourceImporterScene() {
 	singleton = this;

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -1,0 +1,1199 @@
+/*************************************************************************/
+/*  scene_import_settings.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "scene_import_settings.h"
+#include "editor/editor_node.h"
+#include "editor/editor_scale.h"
+#include "editor/import/scene_importer_mesh_node_3d.h"
+#include "scene/resources/surface_tool.h"
+
+class SceneImportSettingsData : public Object {
+	GDCLASS(SceneImportSettingsData, Object)
+	friend class SceneImportSettings;
+	Map<StringName, Variant> *settings = nullptr;
+	Map<StringName, Variant> current;
+	Map<StringName, Variant> defaults;
+	List<ResourceImporter::ImportOption> options;
+
+	ResourceImporterScene::InternalImportCategory category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX;
+
+	bool _set(const StringName &p_name, const Variant &p_value) {
+		if (settings) {
+			if (defaults.has(p_name) && defaults[p_name] == p_value) {
+				settings->erase(p_name);
+			} else {
+				(*settings)[p_name] = p_value;
+			}
+
+			current[p_name] = p_value;
+			return true;
+		}
+		return false;
+	}
+	bool _get(const StringName &p_name, Variant &r_ret) const {
+		if (settings) {
+			if (settings->has(p_name)) {
+				r_ret = (*settings)[p_name];
+				return true;
+			}
+		}
+		if (defaults.has(p_name)) {
+			r_ret = defaults[p_name];
+			return true;
+		}
+		return false;
+	}
+	void _get_property_list(List<PropertyInfo> *p_list) const {
+		for (const List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
+			if (ResourceImporterScene::get_singleton()->get_internal_option_visibility(category, E->get().option.name, current)) {
+				p_list->push_back(E->get().option);
+			}
+		}
+	}
+};
+
+void SceneImportSettings::_fill_material(Tree *p_tree, const Ref<Material> &p_material, TreeItem *p_parent) {
+	String import_id;
+	bool has_import_id = false;
+
+	if (p_material->has_meta("import_id")) {
+		import_id = p_material->get_meta("import_id");
+		has_import_id = true;
+	} else if (p_material->get_name() != "") {
+		import_id = p_material->get_name();
+		has_import_id = true;
+	} else {
+		import_id = "@MATERIAL:" + itos(material_set.size());
+	}
+
+	if (!material_map.has(import_id)) {
+		MaterialData md;
+		md.has_import_id = has_import_id;
+		md.material = p_material;
+
+		_load_default_subresource_settings(md.settings, "materials", import_id, ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MATERIAL);
+
+		material_map[import_id] = md;
+	}
+
+	MaterialData &material_data = material_map[import_id];
+
+	Ref<Texture2D> icon = get_theme_icon("StandardMaterial3D", "EditorIcons");
+
+	TreeItem *item = p_tree->create_item(p_parent);
+	item->set_text(0, p_material->get_name());
+	item->set_icon(0, icon);
+
+	bool created = false;
+	if (!material_set.has(p_material)) {
+		material_set.insert(p_material);
+		created = true;
+	}
+
+	item->set_meta("type", "Material");
+	item->set_meta("import_id", import_id);
+	item->set_tooltip(0, vformat(TTR("Import ID: %s"), import_id));
+	item->set_selectable(0, true);
+
+	if (p_tree == scene_tree) {
+		material_data.scene_node = item;
+	} else if (p_tree == mesh_tree) {
+		material_data.mesh_node = item;
+	} else {
+		material_data.material_node = item;
+	}
+
+	if (created) {
+		_fill_material(material_tree, p_material, material_tree->get_root());
+	}
+}
+
+void SceneImportSettings::_fill_mesh(Tree *p_tree, const Ref<Mesh> &p_mesh, TreeItem *p_parent) {
+	String import_id;
+
+	bool has_import_id = false;
+	if (p_mesh->has_meta("import_id")) {
+		import_id = p_mesh->get_meta("import_id");
+		has_import_id = true;
+	} else if (p_mesh->get_name() != String()) {
+		import_id = p_mesh->get_name();
+		has_import_id = true;
+	} else {
+		import_id = "@MESH:" + itos(mesh_set.size());
+	}
+
+	if (!mesh_map.has(import_id)) {
+		MeshData md;
+		md.has_import_id = has_import_id;
+		md.mesh = p_mesh;
+
+		_load_default_subresource_settings(md.settings, "meshes", import_id, ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MESH);
+
+		mesh_map[import_id] = md;
+	}
+
+	MeshData &mesh_data = mesh_map[import_id];
+
+	Ref<Texture2D> icon = get_theme_icon("Mesh", "EditorIcons");
+
+	TreeItem *item = p_tree->create_item(p_parent);
+	item->set_text(0, p_mesh->get_name());
+	item->set_icon(0, icon);
+
+	bool created = false;
+	if (!mesh_set.has(p_mesh)) {
+		mesh_set.insert(p_mesh);
+		created = true;
+	}
+
+	item->set_meta("type", "Mesh");
+	item->set_meta("import_id", import_id);
+	item->set_tooltip(0, vformat(TTR("Import ID: %s"), import_id));
+
+	item->set_selectable(0, true);
+
+	if (p_tree == scene_tree) {
+		mesh_data.scene_node = item;
+	} else {
+		mesh_data.mesh_node = item;
+	}
+
+	item->set_collapsed(true);
+
+	for (int i = 0; i < p_mesh->get_surface_count(); i++) {
+		Ref<Material> mat = p_mesh->surface_get_material(i);
+		if (mat.is_valid()) {
+			_fill_material(p_tree, mat, item);
+		}
+	}
+
+	if (created) {
+		_fill_mesh(mesh_tree, p_mesh, mesh_tree->get_root());
+	}
+}
+
+void SceneImportSettings::_fill_animation(Tree *p_tree, const Ref<Animation> &p_anim, const String &p_name, TreeItem *p_parent) {
+	if (!animation_map.has(p_name)) {
+		AnimationData ad;
+		ad.animation = p_anim;
+
+		_load_default_subresource_settings(ad.settings, "animations", p_name, ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION);
+
+		animation_map[p_name] = ad;
+	}
+
+	AnimationData &animation_data = animation_map[p_name];
+
+	Ref<Texture2D> icon = get_theme_icon("Animation", "EditorIcons");
+
+	TreeItem *item = p_tree->create_item(p_parent);
+	item->set_text(0, p_name);
+	item->set_icon(0, icon);
+
+	item->set_meta("type", "Animation");
+	item->set_meta("import_id", p_name);
+
+	item->set_selectable(0, true);
+
+	animation_data.scene_node = item;
+}
+
+void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
+	String import_id;
+
+	if (p_node->has_meta("import_id")) {
+		import_id = p_node->get_meta("import_id");
+	} else {
+		import_id = "PATH:" + String(scene->get_path_to(p_node));
+		p_node->set_meta("import_id", import_id);
+	}
+
+	EditorSceneImporterMeshNode3D *src_mesh_node = Object::cast_to<EditorSceneImporterMeshNode3D>(p_node);
+
+	if (src_mesh_node) {
+		MeshInstance3D *mesh_node = memnew(MeshInstance3D);
+		mesh_node->set_name(src_mesh_node->get_name());
+		mesh_node->set_transform(src_mesh_node->get_transform());
+		mesh_node->set_skin(src_mesh_node->get_skin());
+		mesh_node->set_skeleton_path(src_mesh_node->get_skeleton_path());
+		if (src_mesh_node->get_mesh().is_valid()) {
+			Ref<EditorSceneImporterMesh> editor_mesh = src_mesh_node->get_mesh();
+			mesh_node->set_mesh(editor_mesh->get_mesh());
+		}
+
+		p_node->replace_by(mesh_node);
+		memdelete(p_node);
+		p_node = mesh_node;
+	}
+
+	String type = p_node->get_class();
+
+	if (!has_theme_icon(type, "EditorIcons")) {
+		type = "Node3D";
+	}
+
+	Ref<Texture2D> icon = get_theme_icon(type, "EditorIcons");
+
+	TreeItem *item = scene_tree->create_item(p_parent_item);
+	item->set_text(0, p_node->get_name());
+
+	if (p_node == scene) {
+		icon = get_theme_icon("PackedScene", "EditorIcons");
+		item->set_text(0, "Scene");
+	}
+
+	item->set_icon(0, icon);
+
+	item->set_meta("type", "Node");
+	item->set_meta("class", type);
+	item->set_meta("import_id", import_id);
+	item->set_tooltip(0, vformat(TTR("Type: %s\nImport ID: %s"), type, import_id));
+
+	item->set_selectable(0, true);
+
+	if (!node_map.has(import_id)) {
+		NodeData nd;
+
+		if (p_node != scene) {
+			ResourceImporterScene::InternalImportCategory category;
+			if (src_mesh_node) {
+				category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE;
+			} else if (Object::cast_to<AnimationPlayer>(p_node)) {
+				category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE;
+			} else {
+				category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_NODE;
+			}
+
+			_load_default_subresource_settings(nd.settings, "nodes", import_id, category);
+		}
+
+		node_map[import_id] = nd;
+	}
+	NodeData &node_data = node_map[import_id];
+
+	node_data.node = p_node;
+	node_data.scene_node = item;
+
+	AnimationPlayer *anim_node = Object::cast_to<AnimationPlayer>(p_node);
+	if (anim_node) {
+		List<StringName> animations;
+		anim_node->get_animation_list(&animations);
+		for (List<StringName>::Element *E = animations.front(); E; E = E->next()) {
+			_fill_animation(scene_tree, anim_node->get_animation(E->get()), E->get(), item);
+		}
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_fill_scene(p_node->get_child(i), item);
+	}
+	MeshInstance3D *mesh_node = Object::cast_to<MeshInstance3D>(p_node);
+	if (mesh_node && mesh_node->get_mesh().is_valid()) {
+		_fill_mesh(scene_tree, mesh_node->get_mesh(), item);
+
+		Transform accum_xform;
+		Node3D *base = mesh_node;
+		while (base) {
+			accum_xform = base->get_transform() * accum_xform;
+			base = Object::cast_to<Node3D>(base->get_parent());
+		}
+
+		AABB aabb = accum_xform.xform(mesh_node->get_mesh()->get_aabb());
+		if (first_aabb) {
+			contents_aabb = aabb;
+			first_aabb = false;
+		} else {
+			contents_aabb.merge_with(aabb);
+		}
+	}
+}
+
+void SceneImportSettings::_update_scene() {
+	scene_tree->clear();
+	material_tree->clear();
+	mesh_tree->clear();
+
+	//hiden roots
+	material_tree->create_item();
+	mesh_tree->create_item();
+
+	_fill_scene(scene, nullptr);
+}
+
+void SceneImportSettings::_update_camera() {
+	AABB camera_aabb;
+
+	float rot_x = cam_rot_x;
+	float rot_y = cam_rot_y;
+	float zoom = cam_zoom;
+
+	if (selected_type == "Node" || selected_type == "") {
+		camera_aabb = contents_aabb;
+	} else {
+		if (mesh_preview->get_mesh().is_valid()) {
+			camera_aabb = mesh_preview->get_transform().xform(mesh_preview->get_mesh()->get_aabb());
+		} else {
+			camera_aabb = AABB(Vector3(-1, -1, -1), Vector3(2, 2, 2));
+		}
+		if (selected_type == "Mesh" && mesh_map.has(selected_id)) {
+			const MeshData &md = mesh_map[selected_id];
+			rot_x = md.cam_rot_x;
+			rot_y = md.cam_rot_y;
+			zoom = md.cam_zoom;
+		} else if (selected_type == "Material" && material_map.has(selected_id)) {
+			const MaterialData &md = material_map[selected_id];
+			rot_x = md.cam_rot_x;
+			rot_y = md.cam_rot_y;
+			zoom = md.cam_zoom;
+		}
+	}
+
+	Vector3 center = camera_aabb.position + camera_aabb.size * 0.5;
+	float camera_size = camera_aabb.get_longest_axis_size();
+
+	camera->set_orthogonal(camera_size * zoom, 0.0001, camera_size * 2);
+
+	Transform xf;
+	xf.basis = Basis(Vector3(0, 1, 0), rot_y) * Basis(Vector3(1, 0, 0), rot_x);
+	xf.origin = center;
+	xf.translate(0, 0, camera_size);
+
+	camera->set_transform(xf);
+}
+
+void SceneImportSettings::_load_default_subresource_settings(Map<StringName, Variant> &settings, const String &p_type, const String &p_import_id, ResourceImporterScene::InternalImportCategory p_category) {
+	if (base_subresource_settings.has(p_type)) {
+		Dictionary d = base_subresource_settings[p_type];
+		if (d.has(p_import_id)) {
+			d = d[p_import_id];
+			List<ResourceImporterScene::ImportOption> options;
+			ResourceImporterScene::get_singleton()->get_internal_import_options(p_category, &options);
+			for (List<ResourceImporterScene::ImportOption>::Element *E = options.front(); E; E = E->next()) {
+				String key = E->get().option.name;
+				if (d.has(key)) {
+					settings[key] = d[key];
+				}
+			}
+		}
+	}
+}
+
+void SceneImportSettings::open_settings(const String &p_path) {
+	if (scene) {
+		memdelete(scene);
+		scene = nullptr;
+	}
+	scene = ResourceImporterScene::get_singleton()->pre_import(p_path);
+	if (scene == nullptr) {
+		EditorNode::get_singleton()->show_warning(TTR("Error opening scene"));
+		return;
+	}
+
+	base_path = p_path;
+
+	material_set.clear();
+	mesh_set.clear();
+	material_map.clear();
+	mesh_map.clear();
+	node_map.clear();
+	defaults.clear();
+
+	selected_id = "";
+	selected_type = "";
+
+	cam_rot_x = -Math_PI / 4;
+	cam_rot_y = -Math_PI / 4;
+	cam_zoom = 1;
+
+	{
+		base_subresource_settings.clear();
+
+		Ref<ConfigFile> config;
+		config.instance();
+		Error err = config->load(p_path + ".import");
+		if (err == OK) {
+			List<String> keys;
+			config->get_section_keys("params", &keys);
+			for (List<String>::Element *E = keys.front(); E; E = E->next()) {
+				Variant value = config->get_value("params", E->get());
+				if (E->get() == "_subresources") {
+					base_subresource_settings = value;
+				} else {
+					defaults[E->get()] = value;
+				}
+			}
+		}
+	}
+
+	first_aabb = true;
+
+	_update_scene();
+
+	base_viewport->add_child(scene);
+
+	if (first_aabb) {
+		contents_aabb = AABB(Vector3(-1, -1, -1), Vector3(2, 2, 2));
+		first_aabb = false;
+	}
+
+	popup_centered_ratio();
+	_update_camera();
+
+	set_title(vformat(TTR("Advanced Import Settings for '%s'"), base_path.get_file()));
+}
+
+SceneImportSettings *SceneImportSettings::singleton = nullptr;
+
+SceneImportSettings *SceneImportSettings::get_singleton() {
+	return singleton;
+}
+
+void SceneImportSettings::_select(Tree *p_from, String p_type, String p_id) {
+	selecting = true;
+
+	if (p_type == "Node") {
+		node_selected->hide(); //always hide just in case
+		mesh_preview->hide();
+		if (Object::cast_to<Node3D>(scene)) {
+			Object::cast_to<Node3D>(scene)->show();
+		}
+		//NodeData &nd=node_map[p_id];
+		material_tree->deselect_all();
+		mesh_tree->deselect_all();
+		NodeData &nd = node_map[p_id];
+
+		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(nd.node);
+		if (mi) {
+			Ref<Mesh> base_mesh = mi->get_mesh();
+			if (base_mesh.is_valid()) {
+				AABB aabb = base_mesh->get_aabb();
+				Transform aabb_xf;
+				aabb_xf.basis.scale(aabb.size);
+				aabb_xf.origin = aabb.position;
+
+				aabb_xf = mi->get_global_transform() * aabb_xf;
+				node_selected->set_transform(aabb_xf);
+				node_selected->show();
+			}
+		}
+
+		if (nd.node == scene) {
+			scene_import_settings_data->settings = &defaults;
+			scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX;
+		} else {
+			scene_import_settings_data->settings = &nd.settings;
+			if (mi) {
+				scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE;
+			} else if (Object::cast_to<AnimationPlayer>(nd.node)) {
+				scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE;
+			} else {
+				scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_NODE;
+			}
+		}
+	} else if (p_type == "Animation") {
+		node_selected->hide(); //always hide just in case
+		mesh_preview->hide();
+		if (Object::cast_to<Node3D>(scene)) {
+			Object::cast_to<Node3D>(scene)->show();
+		}
+		//NodeData &nd=node_map[p_id];
+		material_tree->deselect_all();
+		mesh_tree->deselect_all();
+		AnimationData &ad = animation_map[p_id];
+
+		scene_import_settings_data->settings = &ad.settings;
+		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION;
+	} else if (p_type == "Mesh") {
+		node_selected->hide();
+		if (Object::cast_to<Node3D>(scene)) {
+			Object::cast_to<Node3D>(scene)->hide();
+		}
+
+		MeshData &md = mesh_map[p_id];
+		if (p_from != mesh_tree) {
+			md.mesh_node->uncollapse_tree();
+			md.mesh_node->select(0);
+			mesh_tree->ensure_cursor_is_visible();
+		}
+		if (p_from != scene_tree) {
+			md.scene_node->uncollapse_tree();
+			md.scene_node->select(0);
+			scene_tree->ensure_cursor_is_visible();
+		}
+
+		mesh_preview->set_mesh(md.mesh);
+		mesh_preview->show();
+
+		material_tree->deselect_all();
+
+		scene_import_settings_data->settings = &md.settings;
+		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MESH;
+	} else if (p_type == "Material") {
+		node_selected->hide();
+		if (Object::cast_to<Node3D>(scene)) {
+			Object::cast_to<Node3D>(scene)->hide();
+		}
+
+		mesh_preview->show();
+
+		MaterialData &md = material_map[p_id];
+
+		material_preview->set_material(md.material);
+		mesh_preview->set_mesh(material_preview);
+
+		if (p_from != mesh_tree) {
+			md.mesh_node->uncollapse_tree();
+			md.mesh_node->select(0);
+			mesh_tree->ensure_cursor_is_visible();
+		}
+		if (p_from != scene_tree) {
+			md.scene_node->uncollapse_tree();
+			md.scene_node->select(0);
+			scene_tree->ensure_cursor_is_visible();
+		}
+		if (p_from != material_tree) {
+			md.material_node->uncollapse_tree();
+			md.material_node->select(0);
+			material_tree->ensure_cursor_is_visible();
+		}
+
+		scene_import_settings_data->settings = &md.settings;
+		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MATERIAL;
+	}
+
+	selected_type = p_type;
+	selected_id = p_id;
+
+	selecting = false;
+
+	_update_camera();
+
+	List<ResourceImporter::ImportOption> options;
+
+	if (scene_import_settings_data->category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX) {
+		ResourceImporterScene::get_singleton()->get_import_options(&options);
+	} else {
+		ResourceImporterScene::get_singleton()->get_internal_import_options(scene_import_settings_data->category, &options);
+	}
+
+	scene_import_settings_data->defaults.clear();
+	scene_import_settings_data->current.clear();
+
+	for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
+		scene_import_settings_data->defaults[E->get().option.name] = E->get().default_value;
+		//needed for visibility toggling (fails if something is missing)
+		if (scene_import_settings_data->settings->has(E->get().option.name)) {
+			scene_import_settings_data->current[E->get().option.name] = (*scene_import_settings_data->settings)[E->get().option.name];
+		} else {
+			scene_import_settings_data->current[E->get().option.name] = E->get().default_value;
+		}
+	}
+	scene_import_settings_data->options = options;
+	inspector->edit(scene_import_settings_data);
+	scene_import_settings_data->notify_property_list_changed();
+}
+
+void SceneImportSettings::_material_tree_selected() {
+	if (selecting) {
+		return;
+	}
+	TreeItem *item = material_tree->get_selected();
+	String type = item->get_meta("type");
+	String import_id = item->get_meta("import_id");
+
+	_select(material_tree, type, import_id);
+}
+void SceneImportSettings::_mesh_tree_selected() {
+	if (selecting) {
+		return;
+	}
+
+	TreeItem *item = mesh_tree->get_selected();
+	String type = item->get_meta("type");
+	String import_id = item->get_meta("import_id");
+
+	_select(mesh_tree, type, import_id);
+}
+void SceneImportSettings::_scene_tree_selected() {
+	if (selecting) {
+		return;
+	}
+	TreeItem *item = scene_tree->get_selected();
+	String type = item->get_meta("type");
+	String import_id = item->get_meta("import_id");
+
+	_select(scene_tree, type, import_id);
+}
+
+void SceneImportSettings::_viewport_input(const Ref<InputEvent> &p_input) {
+	float *rot_x = &cam_rot_x;
+	float *rot_y = &cam_rot_y;
+	float *zoom = &cam_zoom;
+
+	if (selected_type == "Mesh" && mesh_map.has(selected_id)) {
+		MeshData &md = mesh_map[selected_id];
+		rot_x = &md.cam_rot_x;
+		rot_y = &md.cam_rot_y;
+		zoom = &md.cam_zoom;
+	} else if (selected_type == "Material" && material_map.has(selected_id)) {
+		MaterialData &md = material_map[selected_id];
+		rot_x = &md.cam_rot_x;
+		rot_y = &md.cam_rot_y;
+		zoom = &md.cam_zoom;
+	}
+	Ref<InputEventMouseMotion> mm = p_input;
+	if (mm.is_valid() && mm->get_button_mask() & BUTTON_MASK_LEFT) {
+		(*rot_x) -= mm->get_relative().y * 0.01 * EDSCALE;
+		(*rot_y) -= mm->get_relative().x * 0.01 * EDSCALE;
+		(*rot_x) = CLAMP((*rot_x), -Math_PI / 2, Math_PI / 2);
+		_update_camera();
+	}
+	Ref<InputEventMouseButton> mb = p_input;
+	if (mb.is_valid() && mb->get_button_index() == BUTTON_WHEEL_DOWN) {
+		(*zoom) *= 1.1;
+		if ((*zoom) > 10.0) {
+			(*zoom) = 10.0;
+		}
+		_update_camera();
+	}
+	if (mb.is_valid() && mb->get_button_index() == BUTTON_WHEEL_UP) {
+		(*zoom) /= 1.1;
+		if ((*zoom) < 0.1) {
+			(*zoom) = 0.1;
+		}
+		_update_camera();
+	}
+}
+
+void SceneImportSettings::_re_import() {
+	Map<StringName, Variant> main_settings;
+
+	main_settings = defaults;
+	main_settings.erase("_subresources");
+	Dictionary nodes;
+	Dictionary materials;
+	Dictionary meshes;
+	Dictionary animations;
+
+	Dictionary subresources;
+
+	for (Map<String, NodeData>::Element *E = node_map.front(); E; E = E->next()) {
+		if (E->get().settings.size()) {
+			Dictionary d;
+			for (Map<StringName, Variant>::Element *F = E->get().settings.front(); F; F = F->next()) {
+				d[String(F->key())] = F->get();
+			}
+			nodes[E->key()] = d;
+		}
+	}
+	if (nodes.size()) {
+		subresources["nodes"] = nodes;
+	}
+
+	for (Map<String, MaterialData>::Element *E = material_map.front(); E; E = E->next()) {
+		if (E->get().settings.size()) {
+			Dictionary d;
+			for (Map<StringName, Variant>::Element *F = E->get().settings.front(); F; F = F->next()) {
+				d[String(F->key())] = F->get();
+			}
+			materials[E->key()] = d;
+		}
+	}
+	if (materials.size()) {
+		subresources["materials"] = materials;
+	}
+
+	for (Map<String, MeshData>::Element *E = mesh_map.front(); E; E = E->next()) {
+		if (E->get().settings.size()) {
+			Dictionary d;
+			for (Map<StringName, Variant>::Element *F = E->get().settings.front(); F; F = F->next()) {
+				d[String(F->key())] = F->get();
+			}
+			meshes[E->key()] = d;
+		}
+	}
+	if (meshes.size()) {
+		subresources["meshes"] = meshes;
+	}
+
+	for (Map<String, AnimationData>::Element *E = animation_map.front(); E; E = E->next()) {
+		if (E->get().settings.size()) {
+			Dictionary d;
+			for (Map<StringName, Variant>::Element *F = E->get().settings.front(); F; F = F->next()) {
+				d[String(F->key())] = F->get();
+			}
+			animations[E->key()] = d;
+		}
+	}
+	if (animations.size()) {
+		subresources["animations"] = animations;
+	}
+
+	if (subresources.size()) {
+		main_settings["_subresources"] = subresources;
+	}
+
+	EditorFileSystem::get_singleton()->reimport_file_with_custom_parameters(base_path, "scene", main_settings);
+}
+
+void SceneImportSettings::_notification(int p_what) {
+	if (p_what == NOTIFICATION_READY) {
+		connect("confirmed", callable_mp(this, &SceneImportSettings::_re_import));
+	}
+}
+
+void SceneImportSettings::_menu_callback(int p_id) {
+	switch (p_id) {
+		case ACTION_EXTRACT_MATERIALS: {
+			save_path->set_text(TTR("Select folder to extract material resources"));
+			external_extension_type->select(0);
+		} break;
+		case ACTION_CHOOSE_MESH_SAVE_PATHS: {
+			save_path->set_text(TTR("Select folder where mesh resources will save on import"));
+			external_extension_type->select(1);
+		} break;
+		case ACTION_CHOOSE_ANIMATION_SAVE_PATHS: {
+			save_path->set_text(TTR("Select folder where animations will save on import"));
+			external_extension_type->select(1);
+		} break;
+	}
+
+	save_path->set_current_dir(base_path.get_base_dir());
+	current_action = p_id;
+	save_path->popup_centered_ratio();
+}
+
+void SceneImportSettings::_save_path_changed(const String &p_path) {
+	save_path_item->set_text(1, p_path);
+
+	if (FileAccess::exists(p_path)) {
+		save_path_item->set_text(2, "Warning: File exists");
+		save_path_item->set_tooltip(2, TTR("Existing file with the same name will be replaced."));
+		save_path_item->set_icon(2, get_theme_icon("StatusWarning", "EditorIcons"));
+
+	} else {
+		save_path_item->set_text(2, "Will create new File");
+		save_path_item->set_icon(2, get_theme_icon("StatusSuccess", "EditorIcons"));
+	}
+}
+
+void SceneImportSettings::_browse_save_callback(Object *p_item, int p_column, int p_id) {
+	TreeItem *item = Object::cast_to<TreeItem>(p_item);
+
+	String path = item->get_text(1);
+
+	item_save_path->set_current_file(path);
+	save_path_item = item;
+
+	item_save_path->popup_centered_ratio();
+}
+
+void SceneImportSettings::_save_dir_callback(const String &p_path) {
+	external_path_tree->clear();
+	TreeItem *root = external_path_tree->create_item();
+	save_path_items.clear();
+
+	switch (current_action) {
+		case ACTION_EXTRACT_MATERIALS: {
+			for (Map<String, MaterialData>::Element *E = material_map.front(); E; E = E->next()) {
+				MaterialData &md = material_map[E->key()];
+
+				TreeItem *item = external_path_tree->create_item(root);
+
+				String name = md.material_node->get_text(0);
+
+				item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+				item->set_icon(0, get_theme_icon("StandardMaterial3D", "EditorIcons"));
+				item->set_text(0, name);
+
+				if (md.has_import_id) {
+					if (md.settings.has("use_external/enabled") && bool(md.settings["use_external/enabled"])) {
+						item->set_text(2, "Already External");
+						item->set_tooltip(2, TTR("This material already references an external file, no action will be taken.\nDisable the external property for it to be extracted again."));
+					} else {
+						item->set_metadata(0, E->key());
+						item->set_editable(0, true);
+						item->set_checked(0, true);
+						String path = p_path.plus_file(name);
+						if (external_extension_type->get_selected() == 0) {
+							path += ".tres";
+						} else {
+							path += ".res";
+						}
+
+						item->set_text(1, path);
+						if (FileAccess::exists(path)) {
+							item->set_text(2, "Warning: File exists");
+							item->set_tooltip(2, TTR("Existing file with the same name will be replaced."));
+							item->set_icon(2, get_theme_icon("StatusWarning", "EditorIcons"));
+
+						} else {
+							item->set_text(2, "Will create new File");
+							item->set_icon(2, get_theme_icon("StatusSuccess", "EditorIcons"));
+						}
+
+						item->add_button(1, get_theme_icon("Folder", "EditorIcons"));
+					}
+
+				} else {
+					item->set_text(2, "No import ID");
+					item->set_tooltip(2, TTR("Material has no name nor any other way to identify on re-import.\nPlease name it or ensure it is exported with an unique ID."));
+					item->set_icon(2, get_theme_icon("StatusError", "EditorIcons"));
+				}
+
+				save_path_items.push_back(item);
+			}
+
+			external_paths->set_title(TTR("Extract Materials to Resource Files"));
+			external_paths->get_ok_button()->set_text(TTR("Extract"));
+		} break;
+		case ACTION_CHOOSE_MESH_SAVE_PATHS: {
+			for (Map<String, MeshData>::Element *E = mesh_map.front(); E; E = E->next()) {
+				MeshData &md = mesh_map[E->key()];
+
+				TreeItem *item = external_path_tree->create_item(root);
+
+				String name = md.mesh_node->get_text(0);
+
+				item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+				item->set_icon(0, get_theme_icon("Mesh", "EditorIcons"));
+				item->set_text(0, name);
+
+				if (md.has_import_id) {
+					if (md.settings.has("save_to_file/enabled") && bool(md.settings["save_to_file/enabled"])) {
+						item->set_text(2, "Already Saving");
+						item->set_tooltip(2, TTR("This mesh already saves to an external resource, no action will be taken."));
+					} else {
+						item->set_metadata(0, E->key());
+						item->set_editable(0, true);
+						item->set_checked(0, true);
+						String path = p_path.plus_file(name);
+						if (external_extension_type->get_selected() == 0) {
+							path += ".tres";
+						} else {
+							path += ".res";
+						}
+
+						item->set_text(1, path);
+						if (FileAccess::exists(path)) {
+							item->set_text(2, "Warning: File exists");
+							item->set_tooltip(2, TTR("Existing file with the same name will be replaced on import."));
+							item->set_icon(2, get_theme_icon("StatusWarning", "EditorIcons"));
+
+						} else {
+							item->set_text(2, "Will save to new File");
+							item->set_icon(2, get_theme_icon("StatusSuccess", "EditorIcons"));
+						}
+
+						item->add_button(1, get_theme_icon("Folder", "EditorIcons"));
+					}
+
+				} else {
+					item->set_text(2, "No import ID");
+					item->set_tooltip(2, TTR("Mesh has no name nor any other way to identify on re-import.\nPlease name it or ensure it is exported with an unique ID."));
+					item->set_icon(2, get_theme_icon("StatusError", "EditorIcons"));
+				}
+
+				save_path_items.push_back(item);
+			}
+
+			external_paths->set_title(TTR("Set paths to save meshes as resource files on Reimport"));
+			external_paths->get_ok_button()->set_text(TTR("Set Paths"));
+		} break;
+		case ACTION_CHOOSE_ANIMATION_SAVE_PATHS: {
+			for (Map<String, AnimationData>::Element *E = animation_map.front(); E; E = E->next()) {
+				AnimationData &ad = animation_map[E->key()];
+
+				TreeItem *item = external_path_tree->create_item(root);
+
+				String name = ad.scene_node->get_text(0);
+
+				item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+				item->set_icon(0, get_theme_icon("Animation", "EditorIcons"));
+				item->set_text(0, name);
+
+				if (ad.settings.has("save_to_file/enabled") && bool(ad.settings["save_to_file/enabled"])) {
+					item->set_text(2, "Already Saving");
+					item->set_tooltip(2, TTR("This animation already saves to an external resource, no action will be taken."));
+				} else {
+					item->set_metadata(0, E->key());
+					item->set_editable(0, true);
+					item->set_checked(0, true);
+					String path = p_path.plus_file(name);
+					if (external_extension_type->get_selected() == 0) {
+						path += ".tres";
+					} else {
+						path += ".res";
+					}
+
+					item->set_text(1, path);
+					if (FileAccess::exists(path)) {
+						item->set_text(2, "Warning: File exists");
+						item->set_tooltip(2, TTR("Existing file with the same name will be replaced on import."));
+						item->set_icon(2, get_theme_icon("StatusWarning", "EditorIcons"));
+
+					} else {
+						item->set_text(2, "Will save to new File");
+						item->set_icon(2, get_theme_icon("StatusSuccess", "EditorIcons"));
+					}
+
+					item->add_button(1, get_theme_icon("Folder", "EditorIcons"));
+				}
+
+				save_path_items.push_back(item);
+			}
+
+			external_paths->set_title(TTR("Set paths to save animations as resource files on Reimport"));
+			external_paths->get_ok_button()->set_text(TTR("Set Paths"));
+
+		} break;
+	}
+
+	external_paths->popup_centered_ratio();
+}
+
+void SceneImportSettings::_save_dir_confirm() {
+	for (int i = 0; i < save_path_items.size(); i++) {
+		TreeItem *item = save_path_items[i];
+		if (!item->is_checked(0)) {
+			continue; //ignore
+		}
+		String path = item->get_text(1);
+		if (!path.is_resource_file()) {
+			continue;
+		}
+
+		String id = item->get_metadata(0);
+
+		switch (current_action) {
+			case ACTION_EXTRACT_MATERIALS: {
+				ERR_CONTINUE(!material_map.has(id));
+				MaterialData &md = material_map[id];
+
+				Error err = ResourceSaver::save(path, md.material);
+				if (err != OK) {
+					EditorNode::get_singleton()->add_io_error(TTR("Can't make material external to file, write error:") + "\n\t" + path);
+					continue;
+				}
+
+				md.settings["use_external/enabled"] = true;
+				md.settings["use_external/path"] = path;
+
+			} break;
+			case ACTION_CHOOSE_MESH_SAVE_PATHS: {
+				ERR_CONTINUE(!mesh_map.has(id));
+				MeshData &md = mesh_map[id];
+
+				md.settings["save_to_file/enabled"] = true;
+				md.settings["save_to_file/path"] = path;
+			} break;
+			case ACTION_CHOOSE_ANIMATION_SAVE_PATHS: {
+				ERR_CONTINUE(!animation_map.has(id));
+				AnimationData &ad = animation_map[id];
+
+				ad.settings["save_to_file/enabled"] = true;
+				ad.settings["save_to_file/path"] = path;
+
+			} break;
+		}
+	}
+
+	if (current_action == ACTION_EXTRACT_MATERIALS) {
+		//as this happens right now, the scene needs to be saved and reimported.
+		_re_import();
+		open_settings(base_path);
+	} else {
+		scene_import_settings_data->notify_property_list_changed();
+	}
+}
+
+SceneImportSettings::SceneImportSettings() {
+	singleton = this;
+
+	VBoxContainer *main_vb = memnew(VBoxContainer);
+	add_child(main_vb);
+	HBoxContainer *menu_hb = memnew(HBoxContainer);
+	main_vb->add_child(menu_hb);
+
+	action_menu = memnew(MenuButton);
+	action_menu->set_text(TTR("Actions..."));
+	menu_hb->add_child(action_menu);
+
+	action_menu->get_popup()->add_item(TTR("Extract Materials"), ACTION_EXTRACT_MATERIALS);
+	action_menu->get_popup()->add_separator();
+	action_menu->get_popup()->add_item(TTR("Set Animation Save Paths"), ACTION_CHOOSE_ANIMATION_SAVE_PATHS);
+	action_menu->get_popup()->add_item(TTR("Set Mesh Save Paths"), ACTION_CHOOSE_MESH_SAVE_PATHS);
+
+	action_menu->get_popup()->connect("id_pressed", callable_mp(this, &SceneImportSettings::_menu_callback));
+
+	tree_split = memnew(HSplitContainer);
+	main_vb->add_child(tree_split);
+	tree_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
+	data_mode = memnew(TabContainer);
+	tree_split->add_child(data_mode);
+	data_mode->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
+
+	property_split = memnew(HSplitContainer);
+	tree_split->add_child(property_split);
+	property_split->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+	scene_tree = memnew(Tree);
+	scene_tree->set_name(TTR("Scene"));
+	data_mode->add_child(scene_tree);
+	scene_tree->connect("cell_selected", callable_mp(this, &SceneImportSettings::_scene_tree_selected));
+
+	mesh_tree = memnew(Tree);
+	mesh_tree->set_name(TTR("Meshes"));
+	data_mode->add_child(mesh_tree);
+	mesh_tree->set_hide_root(true);
+	mesh_tree->connect("cell_selected", callable_mp(this, &SceneImportSettings::_mesh_tree_selected));
+
+	material_tree = memnew(Tree);
+	material_tree->set_name(TTR("Materials"));
+	data_mode->add_child(material_tree);
+	material_tree->connect("cell_selected", callable_mp(this, &SceneImportSettings::_material_tree_selected));
+
+	material_tree->set_hide_root(true);
+
+	SubViewportContainer *vp_container = memnew(SubViewportContainer);
+	vp_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vp_container->set_custom_minimum_size(Size2(10, 10));
+	vp_container->set_stretch(true);
+	vp_container->connect("gui_input", callable_mp(this, &SceneImportSettings::_viewport_input));
+	property_split->add_child(vp_container);
+
+	base_viewport = memnew(SubViewport);
+	vp_container->add_child(base_viewport);
+
+	base_viewport->set_use_own_world_3d(true);
+
+	camera = memnew(Camera3D);
+	base_viewport->add_child(camera);
+	camera->make_current();
+
+	light = memnew(DirectionalLight3D);
+	light->set_transform(Transform().looking_at(Vector3(-1, -2, -0.6), Vector3(0, 1, 0)));
+	base_viewport->add_child(light);
+	light->set_shadow(true);
+
+	{
+		Ref<StandardMaterial3D> selection_mat;
+		selection_mat.instance();
+		selection_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+		selection_mat->set_albedo(Color(1, 0.8, 1.0));
+
+		Ref<SurfaceTool> st;
+		st.instance();
+		st->begin(Mesh::PRIMITIVE_LINES);
+
+		AABB base_aabb;
+		base_aabb.size = Vector3(1, 1, 1);
+
+		for (int i = 0; i < 12; i++) {
+			Vector3 a, b;
+			base_aabb.get_edge(i, a, b);
+
+			st->add_vertex(a);
+			st->add_vertex(a.lerp(b, 0.2));
+			st->add_vertex(b);
+			st->add_vertex(b.lerp(a, 0.2));
+		}
+
+		selection_mesh.instance();
+		st->commit(selection_mesh);
+		selection_mesh->surface_set_material(0, selection_mat);
+
+		node_selected = memnew(MeshInstance3D);
+		node_selected->set_mesh(selection_mesh);
+		base_viewport->add_child(node_selected);
+		node_selected->hide();
+	}
+
+	{
+		mesh_preview = memnew(MeshInstance3D);
+		base_viewport->add_child(mesh_preview);
+		mesh_preview->hide();
+
+		material_preview.instance();
+	}
+
+	inspector = memnew(EditorInspector);
+	inspector->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
+
+	property_split->add_child(inspector);
+
+	scene_import_settings_data = memnew(SceneImportSettingsData);
+
+	get_ok_button()->set_text(TTR("Reimport"));
+	get_cancel_button()->set_text(TTR("Close"));
+
+	external_paths = memnew(ConfirmationDialog);
+	add_child(external_paths);
+	external_path_tree = memnew(Tree);
+	external_paths->add_child(external_path_tree);
+	external_path_tree->connect("button_pressed", callable_mp(this, &SceneImportSettings::_browse_save_callback));
+	external_paths->connect("confirmed", callable_mp(this, &SceneImportSettings::_save_dir_confirm));
+	external_path_tree->set_columns(3);
+	external_path_tree->set_column_titles_visible(true);
+	external_path_tree->set_column_expand(0, true);
+	external_path_tree->set_column_min_width(0, 100 * EDSCALE);
+	external_path_tree->set_column_title(0, TTR("Resource"));
+	external_path_tree->set_column_expand(1, true);
+	external_path_tree->set_column_min_width(1, 100 * EDSCALE);
+	external_path_tree->set_column_title(1, TTR("Path"));
+	external_path_tree->set_column_expand(2, false);
+	external_path_tree->set_column_min_width(2, 200 * EDSCALE);
+	external_path_tree->set_column_title(2, TTR("Status"));
+	save_path = memnew(EditorFileDialog);
+	save_path->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
+	HBoxContainer *extension_hb = memnew(HBoxContainer);
+	save_path->get_vbox()->add_child(extension_hb);
+	extension_hb->add_spacer();
+	extension_hb->add_child(memnew(Label(TTR("Save Extension: "))));
+	external_extension_type = memnew(OptionButton);
+	extension_hb->add_child(external_extension_type);
+	external_extension_type->add_item(TTR("Text: *.tres"));
+	external_extension_type->add_item(TTR("Binary: *.res"));
+	external_path_tree->set_hide_root(true);
+	add_child(save_path);
+
+	item_save_path = memnew(EditorFileDialog);
+	item_save_path->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+	item_save_path->add_filter("*.tres;Text Resource");
+	item_save_path->add_filter("*.res;Binary Resource");
+	add_child(item_save_path);
+	item_save_path->connect("file_selected", callable_mp(this, &SceneImportSettings::_save_path_changed));
+
+	save_path->connect("dir_selected", callable_mp(this, &SceneImportSettings::_save_dir_callback));
+}
+
+SceneImportSettings::~SceneImportSettings() {
+	memdelete(scene_import_settings_data);
+}

--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -1,0 +1,199 @@
+/*************************************************************************/
+/*  scene_import_settings.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SCENEIMPORTSETTINGS_H
+#define SCENEIMPORTSETTINGS_H
+
+#include "editor/editor_file_dialog.h"
+#include "editor/editor_inspector.h"
+#include "editor/import/resource_importer_scene.h"
+#include "scene/3d/camera_3d.h"
+#include "scene/3d/light_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/item_list.h"
+#include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
+#include "scene/gui/split_container.h"
+#include "scene/gui/subviewport_container.h"
+#include "scene/gui/tab_container.h"
+#include "scene/gui/tree.h"
+#include "scene/resources/primitive_meshes.h"
+
+class SceneImportSettingsData;
+
+class SceneImportSettings : public ConfirmationDialog {
+	GDCLASS(SceneImportSettings, ConfirmationDialog)
+
+	static SceneImportSettings *singleton;
+
+	enum Actions {
+		ACTION_EXTRACT_MATERIALS,
+		ACTION_CHOOSE_MESH_SAVE_PATHS,
+		ACTION_CHOOSE_ANIMATION_SAVE_PATHS,
+	};
+
+	Node *scene = nullptr;
+
+	HSplitContainer *tree_split;
+	HSplitContainer *property_split;
+	TabContainer *data_mode;
+	Tree *scene_tree;
+	Tree *mesh_tree;
+	Tree *material_tree;
+
+	EditorInspector *inspector;
+
+	SubViewport *base_viewport;
+
+	Camera3D *camera;
+	bool first_aabb = false;
+	AABB contents_aabb;
+
+	DirectionalLight3D *light;
+	Ref<ArrayMesh> selection_mesh;
+	MeshInstance3D *node_selected;
+
+	MeshInstance3D *mesh_preview;
+	Ref<SphereMesh> material_preview;
+
+	float cam_rot_x;
+	float cam_rot_y;
+	float cam_zoom;
+
+	void _update_scene();
+
+	struct MaterialData {
+		bool has_import_id;
+		Ref<Material> material;
+		TreeItem *scene_node;
+		TreeItem *mesh_node;
+		TreeItem *material_node;
+
+		float cam_rot_x = -Math_PI / 4;
+		float cam_rot_y = -Math_PI / 4;
+		float cam_zoom = 1;
+
+		Map<StringName, Variant> settings;
+	};
+	Map<String, MaterialData> material_map;
+
+	struct MeshData {
+		bool has_import_id;
+		Ref<Mesh> mesh;
+		TreeItem *scene_node;
+		TreeItem *mesh_node;
+
+		float cam_rot_x = -Math_PI / 4;
+		float cam_rot_y = -Math_PI / 4;
+		float cam_zoom = 1;
+		Map<StringName, Variant> settings;
+	};
+	Map<String, MeshData> mesh_map;
+
+	struct AnimationData {
+		Ref<Animation> animation;
+		TreeItem *scene_node;
+		Map<StringName, Variant> settings;
+	};
+	Map<String, AnimationData> animation_map;
+
+	struct NodeData {
+		Node *node;
+		TreeItem *scene_node;
+		Map<StringName, Variant> settings;
+	};
+	Map<String, NodeData> node_map;
+
+	void _fill_material(Tree *p_tree, const Ref<Material> &p_material, TreeItem *p_parent);
+	void _fill_mesh(Tree *p_tree, const Ref<Mesh> &p_mesh, TreeItem *p_parent);
+	void _fill_animation(Tree *p_tree, const Ref<Animation> &p_anim, const String &p_name, TreeItem *p_parent);
+	void _fill_scene(Node *p_node, TreeItem *p_parent_item);
+
+	Set<Ref<Mesh>> mesh_set;
+	Set<Ref<Material>> material_set;
+
+	String selected_type;
+	String selected_id;
+
+	bool selecting = false;
+
+	void _update_camera();
+	void _select(Tree *p_from, String p_type, String p_id);
+	void _material_tree_selected();
+	void _mesh_tree_selected();
+	void _scene_tree_selected();
+
+	void _viewport_input(const Ref<InputEvent> &p_input);
+
+	Map<StringName, Variant> defaults;
+
+	SceneImportSettingsData *scene_import_settings_data;
+
+	void _re_import();
+
+	String base_path;
+
+	MenuButton *action_menu;
+
+	ConfirmationDialog *external_paths;
+	Tree *external_path_tree;
+	EditorFileDialog *save_path;
+	OptionButton *external_extension_type;
+
+	EditorFileDialog *item_save_path;
+
+	void _menu_callback(int p_id);
+	void _save_dir_callback(const String &p_path);
+
+	int current_action;
+
+	Vector<TreeItem *> save_path_items;
+
+	TreeItem *save_path_item = nullptr;
+	void _save_path_changed(const String &p_path);
+	void _browse_save_callback(Object *p_item, int p_column, int p_id);
+	void _save_dir_confirm();
+
+	Dictionary base_subresource_settings;
+
+	void _load_default_subresource_settings(Map<StringName, Variant> &settings, const String &p_type, const String &p_import_id, ResourceImporterScene::InternalImportCategory p_category);
+
+protected:
+	void _notification(int p_what);
+
+public:
+	void open_settings(const String &p_path);
+	static SceneImportSettings *get_singleton();
+	SceneImportSettings();
+	~SceneImportSettings();
+};
+
+#endif // SCENEIMPORTSETTINGS_H

--- a/editor/import/scene_importer_mesh.h
+++ b/editor/import/scene_importer_mesh.h
@@ -32,7 +32,10 @@
 #define EDITOR_SCENE_IMPORTER_MESH_H
 
 #include "core/io/resource.h"
+#include "scene/resources/concave_polygon_shape_3d.h"
+#include "scene/resources/convex_polygon_shape_3d.h"
 #include "scene/resources/mesh.h"
+#include "scene/resources/navigation_mesh.h"
 // The following classes are used by importers instead of ArrayMesh and MeshInstance3D
 // so the data is not registered (hence, quality loss), importing happens faster and
 // its easier to modify before saving
@@ -63,6 +66,8 @@ class EditorSceneImporterMesh : public Resource {
 
 	Ref<EditorSceneImporterMesh> shadow_mesh;
 
+	Size2i lightmap_size_hint;
+
 protected:
 	void _set_data(const Dictionary &p_data);
 	Dictionary _get_data() const;
@@ -89,13 +94,24 @@ public:
 	float get_surface_lod_size(int p_surface, int p_lod) const;
 	Ref<Material> get_surface_material(int p_surface) const;
 
+	void set_surface_material(int p_surface, const Ref<Material> &p_material);
+
 	void generate_lods();
 
 	void create_shadow_mesh();
 	Ref<EditorSceneImporterMesh> get_shadow_mesh() const;
 
+	Vector<Face3> get_faces() const;
+	Vector<Ref<Shape3D>> convex_decompose() const;
+	Ref<Shape3D> create_trimesh_shape() const;
+	Ref<NavigationMesh> create_navigation_mesh();
+	Error lightmap_unwrap_cached(int *&r_cache_data, unsigned int &r_cache_size, bool &r_used_cache, const Transform &p_base_transform, float p_texel_size);
+
+	void set_lightmap_size_hint(const Size2i &p_size);
+	Size2i get_lightmap_size_hint() const;
+
 	bool has_mesh() const;
-	Ref<ArrayMesh> get_mesh();
+	Ref<ArrayMesh> get_mesh(const Ref<Mesh> &p_base = Ref<Mesh>());
 	void clear();
 };
 #endif // EDITOR_SCENE_IMPORTER_MESH_H

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -156,6 +156,14 @@ void ImportDock::_update_options(const Ref<ConfigFile> &p_config) {
 
 	params->update();
 	_update_preset_menu();
+
+	if (params->paths.size() == 1 && params->importer->has_advanced_options()) {
+		advanced->show();
+		advanced_spacer->show();
+	} else {
+		advanced->hide();
+		advanced_spacer->hide();
+	}
 }
 
 void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
@@ -258,6 +266,14 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 	preset->set_disabled(false);
 
 	imported->set_text(vformat(TTR("%d Files"), p_paths.size()));
+
+	if (params->paths.size() == 1 && params->importer->has_advanced_options()) {
+		advanced->show();
+		advanced_spacer->show();
+	} else {
+		advanced->hide();
+		advanced_spacer->hide();
+	}
 }
 
 void ImportDock::_update_preset_menu() {
@@ -422,6 +438,11 @@ void ImportDock::_reimport_and_restart() {
 	EditorNode::get_singleton()->restart_editor();
 }
 
+void ImportDock::_advanced_options() {
+	if (params->paths.size() == 1 && params->importer.is_valid()) {
+		params->importer->show_advanced_options(params->paths[0]);
+	}
+}
 void ImportDock::_reimport() {
 	for (int i = 0; i < params->paths.size(); i++) {
 		Ref<ConfigFile> config;
@@ -531,9 +552,26 @@ ImportDock::ImportDock() {
 	import->set_text(TTR("Reimport"));
 	import->set_disabled(true);
 	import->connect("pressed", callable_mp(this, &ImportDock::_reimport_attempt));
+	if (!DisplayServer::get_singleton()->get_swap_cancel_ok()) {
+		advanced_spacer = hb->add_spacer();
+		advanced = memnew(Button);
+		advanced->set_text(TTR("Advanced..."));
+		hb->add_child(advanced);
+	}
 	hb->add_spacer();
 	hb->add_child(import);
 	hb->add_spacer();
+
+	if (DisplayServer::get_singleton()->get_swap_cancel_ok()) {
+		advanced = memnew(Button);
+		advanced->set_text(TTR("Advanced..."));
+		hb->add_child(advanced);
+		advanced_spacer = hb->add_spacer();
+	}
+
+	advanced->hide();
+	advanced_spacer->hide();
+	advanced->connect("pressed", callable_mp(this, &ImportDock::_advanced_options));
 
 	reimport_confirm = memnew(ConfirmationDialog);
 	reimport_confirm->get_ok_button()->set_text(TTR("Save Scenes, Re-Import, and Restart"));

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -57,6 +57,9 @@ class ImportDock : public VBoxContainer {
 	Label *label_warning;
 	Button *import;
 
+	Control *advanced_spacer;
+	Button *advanced;
+
 	ImportDockParameters *params;
 
 	void _preset_selected(int p_idx);
@@ -69,6 +72,7 @@ class ImportDock : public VBoxContainer {
 	void _reimport_and_restart();
 	void _reimport();
 
+	void _advanced_options();
 	enum {
 		ITEM_SET_AS_DEFAULT = 100,
 		ITEM_LOAD_DEFAULT,

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -628,7 +628,7 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 						mesh_data_precached->mesh_node = fbx_node;
 
 						// mesh node, mesh id
-						mesh_node = mesh_data_precached->create_fbx_mesh(state, mesh_geometry, fbx_node->fbx_model, (p_flags & IMPORT_USE_COMPRESSION) != 0);
+						mesh_node = mesh_data_precached->create_fbx_mesh(state, mesh_geometry, fbx_node->fbx_model, 0);
 						if (!state.MeshNodes.has(mesh_id)) {
 							state.MeshNodes.insert(mesh_id, fbx_node);
 						}

--- a/modules/gltf/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor_scene_importer_gltf.cpp
@@ -99,7 +99,9 @@ Node *PackedSceneGLTF::import_scene(const String &p_path, uint32_t p_flags,
 	Ref<GLTFDocument> gltf_document;
 	gltf_document.instance();
 	Error err = gltf_document->parse(r_state, p_path);
-	*r_err = err;
+	if (r_err) {
+		*r_err = err;
+	}
 	ERR_FAIL_COND_V(err != Error::OK, nullptr);
 
 	Node3D *root = memnew(Node3D);

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -313,7 +313,7 @@ BoxContainer::AlignMode BoxContainer::get_alignment() const {
 	return align;
 }
 
-void BoxContainer::add_spacer(bool p_begin) {
+Control *BoxContainer::add_spacer(bool p_begin) {
 	Control *c = memnew(Control);
 	c->set_mouse_filter(MOUSE_FILTER_PASS); //allow spacer to pass mouse events
 
@@ -327,6 +327,8 @@ void BoxContainer::add_spacer(bool p_begin) {
 	if (p_begin) {
 		move_child(c, 0);
 	}
+
+	return c;
 }
 
 BoxContainer::BoxContainer(bool p_vertical) {

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -55,7 +55,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_spacer(bool p_begin = false);
+	Control *add_spacer(bool p_begin = false);
 
 	void set_alignment(AlignMode p_align);
 	AlignMode get_alignment() const;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -410,6 +410,14 @@ bool TreeItem::is_collapsed() {
 	return collapsed;
 }
 
+void TreeItem::uncollapse_tree() {
+	TreeItem *t = this;
+	while (t) {
+		t->set_collapsed(false);
+		t = t->parent;
+	}
+}
+
 void TreeItem::set_custom_minimum_height(int p_height) {
 	custom_min_height = p_height;
 	_changed_notify();
@@ -841,6 +849,8 @@ void TreeItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_collapsed", "enable"), &TreeItem::set_collapsed);
 	ClassDB::bind_method(D_METHOD("is_collapsed"), &TreeItem::is_collapsed);
+
+	ClassDB::bind_method(D_METHOD("uncollapse_tree"), &TreeItem::uncollapse_tree);
 
 	ClassDB::bind_method(D_METHOD("set_custom_minimum_height", "height"), &TreeItem::set_custom_minimum_height);
 	ClassDB::bind_method(D_METHOD("get_custom_minimum_height"), &TreeItem::get_custom_minimum_height);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -229,6 +229,8 @@ public:
 	void set_collapsed(bool p_collapsed);
 	bool is_collapsed();
 
+	void uncollapse_tree();
+
 	void set_custom_minimum_height(int p_height);
 	int get_custom_minimum_height() const;
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -893,12 +893,13 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	}
 
 	if (exclusive_child != nullptr) {
+		/*
 		Window *focus_target = exclusive_child;
 		focus_target->grab_focus();
 		while (focus_target->exclusive_child != nullptr) {
 			focus_target = focus_target->exclusive_child;
 			focus_target->grab_focus();
-		}
+		}*/
 
 		if (!is_embedding_subwindows()) { //not embedding, no need for event
 			return;

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -1059,6 +1059,10 @@ void SurfaceTool::set_material(const Ref<Material> &p_material) {
 	material = p_material;
 }
 
+Ref<Material> SurfaceTool::get_material() const {
+	return material;
+}
+
 void SurfaceTool::clear() {
 	begun = false;
 	primitive = Mesh::PRIMITIVE_LINES;
@@ -1087,6 +1091,10 @@ void SurfaceTool::set_custom_format(int p_index, CustomFormat p_format) {
 	ERR_FAIL_INDEX(p_index, RS::ARRAY_CUSTOM_COUNT);
 	ERR_FAIL_COND(begun);
 	last_custom_format[p_index] = p_format;
+}
+
+Mesh::PrimitiveType SurfaceTool::get_primitive() const {
+	return primitive;
 }
 SurfaceTool::CustomFormat SurfaceTool::get_custom_format(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, RS::ARRAY_CUSTOM_COUNT, CUSTOM_MAX);
@@ -1174,6 +1182,7 @@ void SurfaceTool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("generate_lod", "nd_threshold", "target_index_count"), &SurfaceTool::generate_lod, DEFVAL(3));
 
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &SurfaceTool::set_material);
+	ClassDB::bind_method(D_METHOD("get_primitive"), &SurfaceTool::get_primitive);
 
 	ClassDB::bind_method(D_METHOD("clear"), &SurfaceTool::clear);
 

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -143,6 +143,8 @@ public:
 	void set_custom_format(int p_index, CustomFormat p_format);
 	CustomFormat get_custom_format(int p_index) const;
 
+	Mesh::PrimitiveType get_primitive() const;
+
 	void begin(Mesh::PrimitiveType p_primitive);
 
 	void set_color(Color p_color);
@@ -171,6 +173,7 @@ public:
 	Vector<int> generate_lod(float p_threshold, int p_target_index_count = 3);
 
 	void set_material(const Ref<Material> &p_material);
+	Ref<Material> get_material() const;
 
 	void clear();
 


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/1823

* Added option for importers to show an Advanced settings dialog
* Created advanced settings dialog for Scene Importer
* Cleaned up importers (remove many old/unused options)
* Added the ability to customize every node, material, mesh and animation individually
* Saving to animations and meshes to files is now a manual process, making it more predictable
* Added the ability for materials to be replaced by external files (or to be made external, up to you).
* When doubleclicking an impoted scene in the filesystem dock, it automatically shows the import settings instead of asking to open it.

![image](https://user-images.githubusercontent.com/6265307/111787383-a0908180-889d-11eb-8870-96b616d02e8a.png)

![image](https://user-images.githubusercontent.com/6265307/111786267-5d81de80-889c-11eb-84ef-8df0d48eaf3a.png)

WARNING: Lightmap UV unwrap is not working, it needs to be re-made.
