### PR TITLE
Improve error reporting when parsing CSV translation files.

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -441,6 +441,11 @@ Vector<String> FileAccess::get_csv_line(const String &p_delim) const {
 			current += c;
 		}
 	}
+
+	if (in_quote) {
+		WARN_PRINT(vformat("Reached end of file before closing '\"' in CSV file '%s'.", get_path()));
+	}
+
 	strings.push_back(current);
 
 	return strings;

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -107,18 +107,17 @@ Error ResourceImporterCSVTranslation::import(const String &p_source_file, const 
 		translations.push_back(translation);
 	}
 
-	line = f->get_csv_line(delimiter);
-
-	while (line.size() == locales.size() + 1) {
+	do {
+		line = f->get_csv_line(delimiter);
 		String key = line[0];
 		if (!key.is_empty()) {
+			ERR_FAIL_COND_V_MSG(line.size() != locales.size() + 1, ERR_PARSE_ERROR, vformat("Error importing CSV translation: expected %d locale(s), but the '%s' key has %d locale(s).", locales.size(), key, line.size() - 1));
+
 			for (int i = 1; i < line.size(); i++) {
 				translations.write[i - 1]->add_message(key, line[i].c_unescape());
 			}
 		}
-
-		line = f->get_csv_line(delimiter);
-	}
+	} while (!f->eof_reached());
 
 	for (int i = 0; i < translations.size(); i++) {
 		Ref<Translation> xlt = translations[i];

--- a/tests/core/io/test_file_access.h
+++ b/tests/core/io/test_file_access.h
@@ -38,25 +38,27 @@
 namespace TestFileAccess {
 
 TEST_CASE("[FileAccess] CSV read") {
-	Ref<FileAccess> f = FileAccess::open(TestUtils::get_data_path("translations.csv"), FileAccess::READ);
+	Ref<FileAccess> f = FileAccess::open(TestUtils::get_data_path("testdata.csv"), FileAccess::READ);
 	REQUIRE(!f.is_null());
 
 	Vector<String> header = f->get_csv_line(); // Default delimiter: ",".
-	REQUIRE(header.size() == 3);
+	REQUIRE(header.size() == 4);
 
 	Vector<String> row1 = f->get_csv_line(","); // Explicit delimiter, should be the same.
-	REQUIRE(row1.size() == 3);
+	REQUIRE(row1.size() == 4);
 	CHECK(row1[0] == "GOOD_MORNING");
 	CHECK(row1[1] == "Good Morning");
 	CHECK(row1[2] == "Guten Morgen");
+	CHECK(row1[3] == "Bonjour");
 
 	Vector<String> row2 = f->get_csv_line();
-	REQUIRE(row2.size() == 3);
+	REQUIRE(row2.size() == 4);
 	CHECK(row2[0] == "GOOD_EVENING");
 	CHECK(row2[1] == "Good Evening");
 	CHECK(row2[2].is_empty()); // Use case: not yet translated!
 	// https://github.com/godotengine/godot/issues/44269
 	CHECK_MESSAGE(row2[2] != "\"", "Should not parse empty string as a single double quote.");
+	CHECK(row2[3] == "\"\""); // Intentionally testing only escaped double quotes.
 
 	Vector<String> row3 = f->get_csv_line();
 	REQUIRE(row3.size() == 6);

--- a/tests/data/testdata.csv
+++ b/tests/data/testdata.csv
@@ -1,0 +1,8 @@
+Header 1,Header 2,Header 3,Header 4
+GOOD_MORNING,"Good Morning","Guten Morgen","Bonjour"
+GOOD_EVENING,"Good Evening","",""""""
+Without quotes,"With, comma","With ""inner"" quotes","With ""inner"", quotes"","" and comma","With ""inner
+split"" quotes and
+line breaks","With \nnewline chars"
+Some other~delimiter~should still work, shouldn't it?
+What about	tab separated	lines, good?

--- a/tests/data/translations.csv
+++ b/tests/data/translations.csv
@@ -1,8 +1,3 @@
-keys,en,de
-GOOD_MORNING,"Good Morning","Guten Morgen"
-GOOD_EVENING,"Good Evening",""
-Without quotes,"With, comma","With ""inner"" quotes","With ""inner"", quotes"","" and comma","With ""inner
-split"" quotes and
-line breaks","With \nnewline chars"
-Some other~delimiter~should still work, shouldn't it?
-What about	tab separated	lines, good?
+keys,en,de,ja,fa
+GOOD_MORNING,"Good Morning","Guten Morgen","おはよう","صبح بخیر"
+GOOD_EVENING,"Good Evening","","こんばんは","عصر بخیر"


### PR DESCRIPTION
I think that this completely solves #46682 

If you forget to add a closing " in the CSV file now there is a warning. And if there is an incorrect number of lang values, it shows a helpful error instead of silently continuing. 

Note: should the closing " thing give an error instead of a warning? I think that it should, but then I suppose that ResourceImporterCSVTranslation::import should also return an error, and that would mean that there would be two errors messages. I don't know if that's more confusing. 

Edit: upsi, my editor suggested me to change `key != ""` to `!key.empty()` and I didn't check if it compiled :p

*Bugsquad edit:*
- Fixes #46682