### PR TITLE
print_stray_nodes() also prints node's script

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2837,7 +2837,16 @@ static void _Node_debug_sn(Object *p_obj) {
 	} else {
 		path = String(p->get_name()) + "/" + p->get_path_to(n);
 	}
-	print_line(itos(p_obj->get_instance_id()) + " - Stray Node: " + path + " (Type: " + n->get_class() + ")");
+
+	String script_file_string;
+	if (!n->get_script().is_null()) {
+		Ref<Script> script = n->get_script();
+		if (script.is_valid()) {
+			script_file_string = ", Script: " + script->get_path();
+		}
+	}
+
+	print_line(itos(p_obj->get_instance_id()) + " - Stray Node: " + path + " (Type: " + n->get_class() + script_file_string + ")");
 }
 #endif // DEBUG_ENABLED
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->


It makes print_stray_nodes() a bit more useful by also printing their scripts if any are attached.

![printStrayNodesWithScript](https://user-images.githubusercontent.com/29497869/111830922-eb86b500-88ee-11eb-9868-6a882a031610.png)
On the screenshot we can see an unnamed node of type Node. It can be difficult to track where it was created. Knowing its script helps with that.

The PR is for 3.x only because on master branch  Godot hangs* if any of the stray nodes has a script. I wasn't able to determine what causes this. 

*Godot hangs in case print_stray_nodes() is called by a tool script in the editor. Otherwise only the game hangs.