### PR TITLE
Fix 3D scene preview generation.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1408,8 +1408,9 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 		} else {
 			// The 3D editor may be disabled as a feature, but scenes can still be opened.
 			// This check prevents the preview from regenerating in case those scenes are then saved.
+			// The preview will be generated if no feature profile is set (as the 3D editor is enabled by default).
 			Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
-			if (profile.is_valid() && !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
+			if (!profile.is_valid() || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
 				img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_image();
 			}
 		}


### PR DESCRIPTION
The previous check for creating a preview image for 3D scenes erroneously evaluated to false when no actual editor feature profile was set in the editor which means no preview images for 3D scenes were created in the file system dock at all.

I fixed the check so 3D scene previews will now correctly generate when no feature profile is set.

This applies to current master as well as  the current 3.x branch.

This fixes #47171.
