### PR TITLE
Select non-perfect matches if necessary in the Search Help dialog

### DIFF
--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -124,6 +124,7 @@ class EditorHelpSearch::Runner : public Reference {
 	TreeItem *root_item = nullptr;
 	Map<String, TreeItem *> class_items;
 	TreeItem *matched_item = nullptr;
+	float match_highest_score = 0;
 
 	bool _is_class_disabled_by_feature_profile(const StringName &p_class);
 


### PR DESCRIPTION
This makes the Search Help dialog imitate the behavior of the Create dialog, as in, if no perfect match is found, select the item that is the closest one.

![Peek 2021-03-27 21-58](https://user-images.githubusercontent.com/30739239/112739088-d3eba400-8f60-11eb-84f9-14d521c8030f.gif)