### PR TITLE
Fix wrong width with PopupMenus on first opening in the editor

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -722,6 +722,7 @@ void PopupMenu::_notification(int p_what) {
 			for (int i = 0; i < items.size(); i++) {
 				items.write[i].xl_text = tr(items[i].text);
 				items.write[i].dirty = true;
+				_shape_item(i);
 			}
 
 			child_controls_changed();


### PR DESCRIPTION
This fixes the outdated text widths causing `PopupMenu`s in the editor having the wrong size on first opening. This is reproducible when the font size is different from the default value, for example.

Fixes #46779.