### PR TITLE
Fix project icon size in Project Manager

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -241,20 +241,14 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 	// Generate icons.
 	if (!p_only_thumbs) {
 		for (int i = 0; i < editor_icons_count; i++) {
-			float icon_scale = EDSCALE;
 			float saturation = p_icon_saturation;
-
-			// Always keep the DefaultProjectIcon at the default size
-			if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0) {
-				icon_scale = 1.0f;
-			}
 
 			if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0 || strcmp(editor_icons_names[i], "Godot") == 0 || strcmp(editor_icons_names[i], "Logo") == 0) {
 				saturation = 1.0;
 			}
 
 			const int is_exception = exceptions.has(editor_icons_names[i]);
-			const Ref<ImageTexture> icon = editor_generate_icon(i, !is_exception, icon_scale, saturation);
+			const Ref<ImageTexture> icon = editor_generate_icon(i, !is_exception, EDSCALE, saturation);
 
 			p_theme->set_icon(editor_icons_names[i], "EditorIcons", icon);
 		}
@@ -1397,4 +1391,16 @@ Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 	}
 
 	return theme;
+}
+
+Ref<ImageTexture> create_unscaled_default_project_icon() {
+#ifdef MODULE_SVG_ENABLED
+	for (int i = 0; i < editor_icons_count; i++) {
+		// ESCALE should never affect size of the icon
+		if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0) {
+			return editor_generate_icon(i, false, 1.0);
+		}
+	}
+#endif
+	return Ref<ImageTexture>(memnew(ImageTexture));
 }

--- a/editor/editor_themes.h
+++ b/editor/editor_themes.h
@@ -31,10 +31,13 @@
 #ifndef EDITOR_THEMES_H
 #define EDITOR_THEMES_H
 
+#include "scene/resources/texture.h"
 #include "scene/resources/theme.h"
 
 Ref<Theme> create_editor_theme(Ref<Theme> p_theme = nullptr);
 
 Ref<Theme> create_custom_theme(Ref<Theme> p_theme = nullptr);
+
+Ref<ImageTexture> create_unscaled_default_project_icon();
 
 #endif

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -487,7 +487,7 @@ private:
 					if (ProjectSettings::get_singleton()->save_custom(dir.plus_file("project.godot"), initial_settings, Vector<String>(), false) != OK) {
 						set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 					} else {
-						ResourceSaver::save(dir.plus_file("icon.png"), msg->get_theme_icon("DefaultProjectIcon", "EditorIcons"));
+						ResourceSaver::save(dir.plus_file("icon.png"), create_unscaled_default_project_icon());
 
 						FileAccess *f = FileAccess::open(dir.plus_file("default_env.tres"), FileAccess::WRITE);
 						if (!f) {


### PR DESCRIPTION
This PR fixes #45044.

`DefaultProjectIcon` is used at three places:

1. Saved to the newly created projects as `icon.png` (needs fixed scale)
2. Loaded project icons are resized to be the same size as it (needs `EDSCALE`)
3. Shown as the project icon for projects whose icon failed to load (needs `EDSCALE`)

The icon is loaded at 1x scale since #41430. For case 2, only size matters, so multiplying the size with `EDSCALE` is OK. For case 3, I think it's bad to scale the 1x image.

Therefore, I reverted #41430, leaving all theme icons scaled, and added a `create_unscaled_default_project_icon()` function to load an unscaled version of the icon. The function generates a new texture for every call. But I think it's OK since creating a project is not a repetitive task.

Tested on master (62e134a0c0) and 3.x (f50c8062dd)