### PR TITLE
Batching - add protection against invalid polys

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -1539,8 +1539,9 @@ bool C_PREAMBLE::_prefill_polygon(RasterizerCanvas::Item::CommandPolygon *p_poly
 	int num_inds = p_poly->indices.size();
 
 	// nothing to draw?
-	if (!num_inds)
+	if (!num_inds || !p_poly->points.size()) {
 		return false;
+	}
 
 	// we aren't using indices, so will transform verts more than once .. less efficient.
 	// could be done with a temporary vertex buffer
@@ -1666,6 +1667,13 @@ bool C_PREAMBLE::_prefill_polygon(RasterizerCanvas::Item::CommandPolygon *p_poly
 			int ind = p_poly->indices[n];
 
 			RAST_DEV_DEBUG_ASSERT(ind < p_poly->points.size());
+
+			// recover at runtime from invalid polys (the editor may send invalid polys)
+			if ((unsigned int)ind >= (unsigned int)num_verts) {
+				// will recover as long as there is at least one vertex.
+				// if there are no verts, we will have quick rejected earlier in this function
+				ind = 0;
+			}
 
 			// this could be moved outside the loop
 			if (software_transform) {
@@ -1807,6 +1815,14 @@ PREAMBLE(bool)::_software_skin_poly(RasterizerCanvas::Item::CommandPolygon *p_po
 		int ind = p_poly->indices[n];
 
 		RAST_DEV_DEBUG_ASSERT(ind < num_verts);
+
+		// recover at runtime from invalid polys (the editor may send invalid polys)
+		if ((unsigned int)ind >= (unsigned int)num_verts) {
+			// will recover as long as there is at least one vertex.
+			// if there are no verts, we will have quick rejected earlier in this function
+			ind = 0;
+		}
+
 		const Point2 &pos = pTemps[ind];
 		bvs[n].pos.set(pos.x, pos.y);
 


### PR DESCRIPTION
The editor under certain circumstances is passing invalid polys to the renderer. This should be fixed upstream but just in case this PR adds fault tolerance for invalid indices.

Fixes crash in #46698 (but not the underlying problem which is in the editor).

## Notes
* Using unsigned comparison enables checking values both above `num_verts` and below zero (as they will cast to high number). This is a performance sensitive check.
* The `num_verts` etc could possibly be unsigned throughout, this is to quell the overzealous compiler warnings, and it may not be wise at this stage to risk further bugs due to converting everything to unsigned.
* We could possibly put a `WARN_PRINT_ONCE` to flag this error condition. Let me know if this is preferred in addition.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
