### PR TITLE
[HTML5] Fix loading when mime-type is missing.

### DIFF
--- a/platform/javascript/js/engine/engine.js
+++ b/platform/javascript/js/engine/engine.js
@@ -102,7 +102,7 @@ const Engine = (function () {
 				const me = this;
 				function doInit(promise) {
 					return promise.then(function (response) {
-						return Godot(me.config.getModuleConfig(loadPath, response.clone()));
+						return Godot(me.config.getModuleConfig(loadPath, new Response(response.clone().body, { 'headers': [['content-type', 'application/wasm']] })));
 					}).then(function (module) {
 						const paths = me.config.persistentPaths;
 						return module['initFS'](paths).then(function (err) {


### PR DESCRIPTION
`WebAssembly.instantiateStreaming` requires the mime-type to be `application/wasm`, but some servers (including most debug servers) do not provide the content-type header.

This commit forces it via JavaScript, by creating a `Response` object with the `wasm` content, and explicitly defined `content-type` header.

Will need cherry-pick for `3.3` :(