### PR TITLE
Fix bad translation key for Last Modified in Project Manager (Fix #47196)

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2503,7 +2503,7 @@ ProjectManager::ProjectManager() {
 		Vector<String> sort_filter_titles;
 		sort_filter_titles.push_back(TTR("Name"));
 		sort_filter_titles.push_back(TTR("Path"));
-		sort_filter_titles.push_back(TTR("Last Edited"));
+		sort_filter_titles.push_back(TTR("Last Modified"));
 
 		for (int i = 0; i < sort_filter_titles.size(); i++) {
 			filter_option->add_item(sort_filter_titles[i]);


### PR DESCRIPTION
Fix #47196

### Issue : 

The "Last Edited" item of the Project Manager filtering list is not translated with non english languages.

### Cause : 

In project_manager.cpp, the translation key for this item is "Last Edited" but the key in all the po file is "Last Modified".

### Fix proposal : 

Change the key to match the key of the po files. ("Last Modified")

### Before : 
French :
![french](https://user-images.githubusercontent.com/3649998/111881323-33b9dc00-89b0-11eb-8e56-3ae49ecd5038.png)
Spanish :
![esp](https://user-images.githubusercontent.com/3649998/111881380-7c719500-89b0-11eb-8c38-48d261c05e3f.png)

### After : 
French :
![after_fr](https://user-images.githubusercontent.com/3649998/111881328-36b4cc80-89b0-11eb-9f3f-2d49f6fec9fb.png)
Spanish :
![fix_es](https://user-images.githubusercontent.com/3649998/111881373-77144a80-89b0-11eb-8275-82cf32bd1631.png)

