### PR TITLE
Fix .gitignore files ignore part of the repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,9 +243,6 @@ xcuserdata/
 x64/
 x86/
 
-# Do not ignore x86 folders anywhere under thirdparty libraries
-!thirdparty/**/x86/
-
 [Ww][Ii][Nn]32/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
@@ -254,6 +251,12 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+
+# Do not ignore arch-specific folders anywhere under thirdparty libraries
+!thirdparty/**/x64/
+!thirdparty/**/x86/
+!thirdparty/**/arm/
+!thirdparty/**/arm64/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/misc/dist/ios_xcode/godot_ios/vulkan/icd.d/MoltenVK_icd.json
+++ b/misc/dist/ios_xcode/godot_ios/vulkan/icd.d/MoltenVK_icd.json
@@ -1,7 +1,0 @@
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "./../../Frameworks/MoltenVK.framework/MoltenVK",
-        "api_version" : "1.0.0"
-    }
-}


### PR DESCRIPTION
At the moment, if you download the Godot release .zip, decompress it into a new git repo, add the entire contents, clean the git repo, and try to build Godot, the build is broken. Turns out Godot has several critical files (and a few less-critical files) included in its .gitignore.

----

From my perspective, the most important ones are the entire `modules/mono/editor/GodotTools/GodotTools/Build/` directory, which breaks the Mono build if they don't exist. These are filtered out due to the `build/` entry. As near as I can tell, that entry is part of the .gitignore template, and Godot does not actually use any directory named `build/`. So I just took that line out. This may have been the wrong decision if Godot's build process is markedly different on other operating systems.

----

The second most important ones are a bunch of Vulkan files for various Apple operating systems:

misc/dist/ios_xcode/godot_ios/vulkan/icd.d
misc/dist/osx_template.app/Contents/Resources/vulkan/icd.d
misc/dist/osx_tools.app/Contents/Resources/vulkan/icd.d

In all of these cases it's the .d suffix causing problems. I added a .gitignore in misc/dist to cover `icd.d`, mostly because it was easy, but it's possible this should be three separate .gitignore's in the exact relevant directory. Alternatively: does Godot even use the .d extension? If it does, it's probably on Linux, and I don't have a good way to do a Linux build right now. But if it doesn't, that could probably just be removed from the .gitignore.

----

The last was the `updown.png` file in the default theme, removed because it happens to match gcov/lcov code coverage files, change added in 5b4d74ed. I just unfiltered all the .png files in that directory. This is the fix I like the least - this really *should* be filtering out gcov/lcov in some other way, not ignoring a pile of generically-named files throughout the entire repository - but I have no idea what directory names gcov/lcov uses.

----

Obviously I am dissatisfied with these fixes.

On the other hand, now I can build Godot in a fresh Git repo. So . . . it's better, at least.