### PR TITLE
[3.x] Fix project icon size in Project Manager

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -246,15 +246,8 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 	// Generate icons.
 	if (!p_only_thumbs) {
 		for (int i = 0; i < editor_icons_count; i++) {
-			float icon_scale = EDSCALE;
-
-			// Always keep the DefaultProjectIcon at the default size
-			if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0) {
-				icon_scale = 1.0f;
-			}
-
 			const int is_exception = exceptions.has(editor_icons_names[i]);
-			const Ref<ImageTexture> icon = editor_generate_icon(i, !is_exception, icon_scale);
+			const Ref<ImageTexture> icon = editor_generate_icon(i, !is_exception);
 
 			p_theme->set_icon(editor_icons_names[i], "EditorIcons", icon);
 		}
@@ -1357,4 +1350,16 @@ Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 	}
 
 	return theme;
+}
+
+Ref<ImageTexture> create_unscaled_default_project_icon() {
+#ifdef SVG_ENABLED
+	for (int i = 0; i < editor_icons_count; i++) {
+		// ESCALE should never affect size of the icon
+		if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0) {
+			return editor_generate_icon(i, false, 1.0);
+		}
+	}
+#endif
+	return Ref<ImageTexture>(memnew(ImageTexture));
 }

--- a/editor/editor_themes.h
+++ b/editor/editor_themes.h
@@ -31,10 +31,13 @@
 #ifndef EDITOR_THEMES_H
 #define EDITOR_THEMES_H
 
+#include "scene/resources/texture.h"
 #include "scene/resources/theme.h"
 
 Ref<Theme> create_editor_theme(Ref<Theme> p_theme = NULL);
 
 Ref<Theme> create_custom_theme(Ref<Theme> p_theme = NULL);
+
+Ref<ImageTexture> create_unscaled_default_project_icon();
 
 #endif

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -504,7 +504,7 @@ private:
 					if (ProjectSettings::get_singleton()->save_custom(dir.plus_file("project.godot"), initial_settings, Vector<String>(), false) != OK) {
 						set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 					} else {
-						ResourceSaver::save(dir.plus_file("icon.png"), get_icon("DefaultProjectIcon", "EditorIcons"));
+						ResourceSaver::save(dir.plus_file("icon.png"), create_unscaled_default_project_icon());
 
 						FileAccess *f = FileAccess::open(dir.plus_file("default_env.tres"), FileAccess::WRITE);
 						if (!f) {


### PR DESCRIPTION
This is a 3.x version of #47186