### PR TITLE
Don't add degenerate triangles to trimesh shape

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -244,13 +244,21 @@ Ref<Shape3D> Mesh::create_trimesh_shape() const {
 
 	Vector<Vector3> face_points;
 	face_points.resize(faces.size() * 3);
+	int good_points = 0;
 
 	for (int i = 0; i < face_points.size(); i += 3) {
 		Face3 f = faces.get(i / 3);
+		if (f.is_degenerate()) {
+			continue;
+		}
+
+		good_points += 3;
 		face_points.set(i, f.vertex[0]);
 		face_points.set(i + 1, f.vertex[1]);
 		face_points.set(i + 2, f.vertex[2]);
 	}
+
+	face_points.resize(good_points);
 
 	Ref<ConcavePolygonShape3D> shape = memnew(ConcavePolygonShape3D);
 	shape->set_faces(face_points);


### PR DESCRIPTION
Degenerate triangles can cause errors in collision detection as they
have no normal.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
