### PR TITLE
Fix anchor dragging (part 2)

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1662,17 +1662,15 @@ void Control::set_global_position(const Point2 &p_point, bool p_keep_offsets) {
 
 void Control::_compute_anchors(Rect2 p_rect, const float p_offsets[4], float (&r_anchors)[4]) {
 	Size2 parent_rect_size = get_parent_anchorable_rect().size;
-	ERR_FAIL_COND(parent_rect_size.x == 0.0);
-	ERR_FAIL_COND(parent_rect_size.y == 0.0);
 
 	float x = p_rect.position.x;
 	if (is_layout_rtl()) {
 		x = parent_rect_size.x - x - p_rect.size.x;
 	}
-	r_anchors[0] = (x - p_offsets[0]) / parent_rect_size.x;
-	r_anchors[1] = (p_rect.position.y - p_offsets[1]) / parent_rect_size.y;
-	r_anchors[2] = (x + p_rect.size.x - p_offsets[2]) / parent_rect_size.x;
-	r_anchors[3] = (p_rect.position.y + p_rect.size.y - p_offsets[3]) / parent_rect_size.y;
+	r_anchors[0] = (parent_rect_size.x == 0) ? 0.0 : (x - p_offsets[0]) / parent_rect_size.x;
+	r_anchors[1] = (parent_rect_size.y == 0) ? 0.0 : (p_rect.position.y - p_offsets[1]) / parent_rect_size.y;
+	r_anchors[2] = (parent_rect_size.x == 0) ? 0.0 : (x + p_rect.size.x - p_offsets[2]) / parent_rect_size.x;
+	r_anchors[3] = (parent_rect_size.y == 0) ? 0.0 : (p_rect.position.y + p_rect.size.y - p_offsets[3]) / parent_rect_size.y;
 }
 
 void Control::_compute_offsets(Rect2 p_rect, const float p_anchors[4], float (&r_offsets)[4]) {


### PR DESCRIPTION
- Fixes a regression from df0a69bbaca690e1954d5048cc238acc8adeddb8 that was only partially fixed by #42371.

Problem:

- The following error occurs when attempting to drag anchors when the parent has no size (i.e., no Control node parent but anchor icon is enabled, causing `"_edit_use_anchors_": true` in tscn file):

      scene/gui/control.cpp:1800 - Condition "parent_rect_size.x = 0.0" is true.

Solution:

- Set the anchors to zero in this special case, which allows dragging the Node to a new position instead of failing with a C++ error message. I see no reason to disallow this behavior, and the current behavior is unexpected and unfriendly to newcomers (I'm not a Godot expert by any means but I've been using it for about 6 months and it was no easy task to decipher what was going on here).

Steps to Reproduce:

- Select a Node in a scene, say a RichTextField.

- Click the green anchor symbol in the scene window toolbar so that it changes to blue. (The tooltip says "When active, moving Control nodes changes their anchors instead of their margins.")

- Attempt to drag the node to a new position.

- The editor's Output window will spam the following error in red:

      scene/gui/control.cpp:1800 - Condition "parent_rect_size.x == 0.0" is true.
      scene/gui/control.cpp:1800 - Condition "parent_rect_size.x == 0.0" is true.
      scene/gui/control.cpp:1800 - Condition "parent_rect_size.x == 0.0" is true.
      scene/gui/control.cpp:1800 - Condition "parent_rect_size.x == 0.0" is true.
      scene/gui/control.cpp:1800 - Condition "parent_rect_size.x == 0.0" is true.
      scene/gui/control.cpp:1800 - Condition "parent_rect_size.x == 0.0" is true.

Environment:

- Godot_mono 3.3 RC 6
- macOS 11.2.2 (Big Sur)
- .NET 5 

Testing:

- Confirmed the fix works in Godot 4. It allows a Node without a Control node as a parent to be dragged to a new position without any error, even with the anchor icon enabled.

Related to #41212.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
