### PR TITLE
Constrain docks to window size in single window mode

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 #include "editor_node.h"
-
+#include "floating_window.h"
 #include "core/config/project_settings.h"
 #include "core/core_bind.h"
 #include "core/input/input.h"
@@ -390,31 +390,6 @@ void EditorNode::_update_title() {
 	DisplayServer::get_singleton()->window_set_title(title);
 }
 
-void EditorNode::_on_window_event(const Ref<InputEvent> &p_event, Control *dock) {
-	bool single_window_mode = EditorSettings::get_singleton()->get_setting(
-			"interface/editor/single_window_mode");
-	if (single_window_mode) {
-		Window *window = (Window *)dock->get_parent()->get_parent();
-		gui_base = get_gui_base();
-		Size2 size = gui_base->get_size();
-		print_line("Window size:");
-		print_line(window->get_position());
-		print_line("Gui base size:");
-		print_line(size);
-		Vector2 window_position = window->get_position();
-		Rect2 window_size = window->get_visible_rect();
-		if (size.x < (window_position.x + window_size.size.x)) {
-			window->set_position(Vector2((size.x - window_size.size.x), window_position.y));
-		} else if (window_position.x < 0) {
-			window->set_position(Vector2(0, window_position.y));
-		}
-		if (window_position.y < 0) {
-			window->set_position(Vector2(window_position.x, 20));
-		} else if (size.y < window_position.y) {
-			window->set_position(Vector2(window_position.x, size.y));
-		}
-	}
-};
 
 void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
@@ -4126,7 +4101,7 @@ void EditorNode::_dock_make_float() {
 	int dock_index = dock->get_index();
 	dock_slot[dock_popup_selected]->remove_child(dock);
 
-	Window *window = memnew(Window);
+	Window *window = memnew(FloatingWindow);
 	window->set_title(dock->get_name());
 	Panel *p = memnew(Panel);
 	p->set_mode(Panel::MODE_FOREGROUND);
@@ -4146,7 +4121,6 @@ void EditorNode::_dock_make_float() {
 	window->set_position(dock_screen_pos);
 	window->set_transient(true);
 	window->connect("close_requested", callable_mp(this, &EditorNode::_dock_floating_close_request), varray(dock));
-	window->connect("window_input", callable_mp(this, &EditorNode::_on_window_event), varray(dock));
 	window->set_meta("dock_slot", dock_popup_selected);
 	window->set_meta("dock_index", dock_index);
 	gui_base->add_child(window);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -29,7 +29,6 @@
 /*************************************************************************/
 
 #include "editor_node.h"
-#include "floating_window.h"
 #include "core/config/project_settings.h"
 #include "core/core_bind.h"
 #include "core/input/input.h"
@@ -47,6 +46,7 @@
 #include "core/string/print_string.h"
 #include "core/string/translation.h"
 #include "core/version.h"
+#include "floating_window.h"
 #include "main/main.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/control.h"
@@ -389,7 +389,6 @@ void EditorNode::_update_title() {
 
 	DisplayServer::get_singleton()->window_set_title(title);
 }
-
 
 void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -29,10 +29,10 @@
 /*************************************************************************/
 
 #include "editor_node.h"
+
 #include "core/config/project_settings.h"
 #include "core/core_bind.h"
 #include "core/input/input.h"
-#include "core/input/input_event.h"
 #include "core/io/config_file.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"
@@ -6028,6 +6028,7 @@ EditorNode::EditorNode() {
 	dock_float->set_focus_mode(Control::FOCUS_NONE);
 	dock_float->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	dock_float->connect("pressed", callable_mp(this, &EditorNode::_dock_make_float));
+
 	dock_vb->add_child(dock_float);
 
 	dock_select_popup->set_as_minsize();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -513,6 +513,8 @@ private:
 
 	bool convert_old;
 
+	void _on_window_event(const Ref<InputEvent> &p_event, Control *dock);
+
 	void _unhandled_input(const Ref<InputEvent> &p_event);
 
 	static void _load_error_notify(void *p_ud, const String &p_text);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -513,8 +513,6 @@ private:
 
 	bool convert_old;
 
-	void _on_window_event(const Ref<InputEvent> &p_event, Control *dock);
-
 	void _unhandled_input(const Ref<InputEvent> &p_event);
 
 	static void _load_error_notify(void *p_ud, const String &p_text);

--- a/editor/floating_window.cpp
+++ b/editor/floating_window.cpp
@@ -44,10 +44,6 @@ void FloatingWindow::_on_window_event(const Ref<InputEvent> &p_event) {
 	if (single_window_mode) {
 		Size2i editor_window_size = get_parent_rect().size;
 		Vector2 window_position = this->get_position();
-		print_line("Window position:");
-		print_line(window_position);
-		print_line("Size");
-		print_line(editor_window_size);
 		Rect2 window_size = this->get_visible_rect();
 		if (editor_window_size.x < (window_position.x + window_size.size.x)) {
 			this->set_position(Vector2((editor_window_size.x - window_size.size.x), window_position.y));

--- a/editor/floating_window.cpp
+++ b/editor/floating_window.cpp
@@ -1,9 +1,39 @@
+/*************************************************************************/
+/*  floating_window.cpp                                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
 #include "floating_window.h"
 
 void FloatingWindow::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-		this->connect("window_input", callable_mp(this, &FloatingWindow::_on_window_event));
+			this->connect("window_input", callable_mp(this, &FloatingWindow::_on_window_event));
 		} break;
 	}
 };

--- a/editor/floating_window.cpp
+++ b/editor/floating_window.cpp
@@ -1,0 +1,33 @@
+#include "floating_window.h"
+
+void FloatingWindow::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+		this->connect("window_input", callable_mp(this, &FloatingWindow::_on_window_event));
+		} break;
+	}
+};
+
+void FloatingWindow::_on_window_event(const Ref<InputEvent> &p_event) {
+	bool single_window_mode = EditorSettings::get_singleton()->get_setting(
+			"interface/editor/single_window_mode");
+	if (single_window_mode) {
+		Size2i editor_window_size = get_parent_rect().size;
+		Vector2 window_position = this->get_position();
+		print_line("Window position:");
+		print_line(window_position);
+		print_line("Size");
+		print_line(editor_window_size);
+		Rect2 window_size = this->get_visible_rect();
+		if (editor_window_size.x < (window_position.x + window_size.size.x)) {
+			this->set_position(Vector2((editor_window_size.x - window_size.size.x), window_position.y));
+		} else if (window_position.x < 0) {
+			this->set_position(Vector2(0, window_position.y));
+		}
+		if (window_position.y < 0) {
+			this->set_position(Vector2(window_position.x, 20));
+		} else if (editor_window_size.y < window_position.y) {
+			this->set_position(Vector2(window_position.x, editor_window_size.y));
+		}
+	}
+};

--- a/editor/floating_window.h
+++ b/editor/floating_window.h
@@ -32,11 +32,11 @@
 
 class Window;
 
-class FloatingWindow: public Window {
+class FloatingWindow : public Window {
 	GDCLASS(FloatingWindow, Window);
 
-	protected:
-		void _notification(int p_what);
+protected:
+	void _notification(int p_what);
 
 	void _on_window_event(const Ref<InputEvent> &p_event);
 };

--- a/editor/floating_window.h
+++ b/editor/floating_window.h
@@ -1,0 +1,42 @@
+/*************************************************************************/
+/*  floating_window.h                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor/editor_data.h"
+
+class Window;
+
+class FloatingWindow: public Window {
+	GDCLASS(FloatingWindow, Window);
+
+	protected:
+		void _notification(int p_what);
+
+	void _on_window_event(const Ref<InputEvent> &p_event);
+};

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -39,6 +39,7 @@
 #include "editor/editor_log.h"
 #include "editor/editor_properties.h"
 #include "editor/editor_scale.h"
+#include "editor/floating_window.h"
 #include "scene/animation/animation_player.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
@@ -3421,7 +3422,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	// PREVIEW WINDOW
 	///////////////////////////////////////
 
-	preview_window = memnew(Window);
+	preview_window = memnew(FloatingWindow);
 	preview_window->set_title(TTR("Generated shader code"));
 	preview_window->set_visible(preview_showed);
 	preview_window->connect("close_requested", callable_mp(this, &VisualShaderEditor::_preview_close_requested));


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/44439

I created a separate node which listens for the `window_input` event. If the editor is in `single_window_mode` it will prevent the window from being positioned outside of the editor window. 

https://user-images.githubusercontent.com/6378569/111897681-a3df5680-89de-11eb-8b8d-a8bc16629f08.mp4

Note: You'll notice an unrelated bug. Dragging a window after dragging a different window will move that window to the previous windows position. 