### PR TITLE
Implement more ProgressBar progress label formats

### DIFF
--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -4,15 +4,15 @@
 		General-purpose progress bar.
 	</brief_description>
 	<description>
-		General-purpose progress bar. Shows fill percentage from right to left.
+		General-purpose progress bar. If defined, shows the progress label.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 	</methods>
 	<members>
-		<member name="percent_visible" type="bool" setter="set_percent_visible" getter="is_percent_visible" default="true">
-			If [code]true[/code], the fill percentage is displayed on the bar.
+		<member name="progress_label_format" type="int" setter="set_progress_label_format" getter="get_progress_label_format" default="1">
+			Defines the format of the progress label displayed on the bar.
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0" />
 		<member name="step" type="float" setter="set_step" getter="get_step" override="true" default="0.01" />
@@ -27,7 +27,7 @@
 			The style of the progress (i.e. the part that fills the bar).
 		</theme_item>
 		<theme_item name="font" type="Font">
-			Font used to draw the fill percentage if [member percent_visible] is [code]true[/code].
+			Font used to draw the progress label.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			The color of the text.
@@ -39,7 +39,7 @@
 			The color of the text's shadow.
 		</theme_item>
 		<theme_item name="font_size" type="int">
-			Font size used to draw the fill percentage if [member percent_visible] is [code]true[/code].
+			Font size used to draw the progress label.
 		</theme_item>
 		<theme_item name="outline_size" type="int" default="0">
 			The size of the text outline.

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -223,7 +223,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 				}
 			}
 
-			pb->set_percent_visible(false);
+			pb->set_progress_label_format(ProgressBar::ProgressLabelFormat::FORMAT_NONE);
 			pb->set_custom_minimum_size(Vector2(0, 14) * EDSCALE);
 			animations[E->get()] = pb;
 			node->add_child(pb);

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -36,18 +36,29 @@
 class ProgressBar : public Range {
 	GDCLASS(ProgressBar, Range);
 
-	bool percent_visible = true;
+public:
+	enum ProgressLabelFormat {
+		FORMAT_NONE,
+		FORMAT_PERCENTAGE,
+		FORMAT_DECIMAL,
+		FORMAT_FRACTION
+	};
+
+private:
+	ProgressLabelFormat progress_label_format = FORMAT_PERCENTAGE;
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	void set_percent_visible(bool p_visible);
-	bool is_percent_visible() const;
+	void set_progress_label_format(ProgressLabelFormat p_type);
+	ProgressLabelFormat get_progress_label_format() const;
 
 	Size2 get_minimum_size() const override;
 	ProgressBar();
 };
+
+VARIANT_ENUM_CAST(ProgressBar::ProgressLabelFormat);
 
 #endif // PROGRESS_BAR_H


### PR DESCRIPTION
The PR refactors ProgressBar's `percent_visible` property into an enumeration, and adds 2 more formats to display progress label: decimal and fraction.

Resolves godotengine/godot-proposals#2399.