### PR TITLE
[3.x] Remove redundant thread sync counter draw_pending

### DIFF
--- a/servers/visual/visual_server_wrap_mt.cpp
+++ b/servers/visual/visual_server_wrap_mt.cpp
@@ -37,13 +37,10 @@ void VisualServerWrapMT::thread_exit() {
 }
 
 void VisualServerWrapMT::thread_draw(bool p_swap_buffers, double frame_step) {
-	if (!draw_pending.decrement()) {
-		visual_server->draw(p_swap_buffers, frame_step);
-	}
+	visual_server->draw(p_swap_buffers, frame_step);
 }
 
 void VisualServerWrapMT::thread_flush() {
-	draw_pending.decrement();
 }
 
 void VisualServerWrapMT::_thread_callback(void *_instance) {
@@ -75,7 +72,6 @@ void VisualServerWrapMT::thread_loop() {
 
 void VisualServerWrapMT::sync() {
 	if (create_thread) {
-		draw_pending.increment();
 		command_queue.push_and_sync(this, &VisualServerWrapMT::thread_flush);
 	} else {
 		command_queue.flush_all(); //flush all pending from other threads
@@ -84,7 +80,6 @@ void VisualServerWrapMT::sync() {
 
 void VisualServerWrapMT::draw(bool p_swap_buffers, double frame_step) {
 	if (create_thread) {
-		draw_pending.increment();
 		command_queue.push(this, &VisualServerWrapMT::thread_draw, p_swap_buffers, frame_step);
 	} else {
 		visual_server->draw(p_swap_buffers, frame_step);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -51,7 +51,6 @@ class VisualServerWrapMT : public VisualServer {
 	SafeFlag draw_thread_up;
 	bool create_thread;
 
-	SafeNumeric<uint64_t> draw_pending;
 	void thread_draw(bool p_swap_buffers, double frame_step);
 	void thread_flush();
 


### PR DESCRIPTION
The functions that used it already use a threadsafe FIFO queue
to communicate between threads and a sync to have the main thread
wait for the render thread.

Cherry-Picked from #35758, which is the same fix against the master branch (there have been renames)

Fixes #35718