### PR TITLE
Bitmap opaque_to_polygons documentation

### DIFF
--- a/doc/classes/BitMap.xml
+++ b/doc/classes/BitMap.xml
@@ -71,6 +71,12 @@
 			<argument index="1" name="epsilon" type="float" default="2.0">
 			</argument>
 			<description>
+				Creates an [Array] of polygons covering a rectangular portion of the bitmap. It uses a marching squares algorithm, followed by Ramer-Douglas-Peucker (RDP) reduction of the number of vertices. Each polygon is described as a [PackedVector2Array] of its vertices.
+				To get polygons covering the whole bitmap, pass:
+				[codeblock]
+				Rect2(Vector2(), get_size())
+				[/codeblock]
+				[code]epsilon[/code] is passed to RDP to control how accurately the polygons cover the bitmap: a lower [code]epsilon[/code] corresponds to more points in the polygons.
 			</description>
 		</method>
 		<method name="set_bit">


### PR DESCRIPTION
Let's add documentation to opaque_to_polygons

Context: [link](https://godotengine.org/qa/98607/opaque_to_polygons-gives-empty-array-as-input).