### PR TITLE
Add screen_get_refresh_rate to DisplayServer

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -567,7 +567,6 @@
 			</argument>
 			<description>
 				Return's the screen refresh rate.
-				[b]Note:[/b] On macOS and iPhone, this will always be 60.
 			</description>
 		</method>
 		<method name="screen_get_scale" qualifiers="const">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -560,6 +560,16 @@
 			<description>
 			</description>
 		</method>
+		<method name="screen_get_refresh_rate" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="screen" type="int" default="-1">
+			</argument>
+			<description>
+				Return's the screen refresh rate.
+				[b]Note:[/b] On macOS and iPhone, this will always be 60.
+			</description>
+		</method>
 		<method name="screen_get_scale" qualifiers="const">
 			<return type="float">
 			</return>

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -139,17 +139,10 @@ Size2i DisplayServerAndroid::screen_get_size(int p_screen) const {
 }
 
 float DisplayServerAndroid::screen_get_refresh_rate(int p_screen) const {
-	print_line("Test for getting Display.Mode from JNI");
-	JNIEnv *env = get_jni_env();
-	jclass display_class = env->FindClass("android/view/Display");
-	jmethodID get_mode_id = env->GetMethodID(display_class, "getMode", "()Landroid/view/Display/Mode");
-	if(get_mode_id == 0) {
-		return 60.0;
-	}
-	else {
-		print_line("Got method id");
-		return -1.0;
-	}
+	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
+	ERR_FAIL_COND_V(!godot_io_java, 60.0);
+
+	return godot_io_java->get_screen_refresh_rate();
 }
 
 Rect2i DisplayServerAndroid::screen_get_usable_rect(int p_screen) const {

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -139,8 +139,16 @@ Size2i DisplayServerAndroid::screen_get_size(int p_screen) const {
 }
 
 float DisplayServerAndroid::screen_get_refresh_rate(int p_screen) const {
-	// Most Android devices have 60hz displays.
-	return 60.0;
+	print_line("Test for getting Display.Mode from JNI");
+	JNIEnv *env = OS_Android::get_singleton()->get_godot_io_java().get_jni_env();
+	jclass display_class = env->FindClass("android/view/Display");
+	jmethodID get_mode_id = env->GetMethodID(env, display_class, "getMode", "()Landroid/view/Display/Mode");
+	if(get_mode_id == 0) {
+		return 60.0;
+	}
+	else {
+		print_line("Got method id");
+	}
 }
 
 Rect2i DisplayServerAndroid::screen_get_usable_rect(int p_screen) const {

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -148,6 +148,7 @@ float DisplayServerAndroid::screen_get_refresh_rate(int p_screen) const {
 	}
 	else {
 		print_line("Got method id");
+		return -1.0;
 	}
 }
 

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -138,6 +138,11 @@ Size2i DisplayServerAndroid::screen_get_size(int p_screen) const {
 	return OS_Android::get_singleton()->get_display_size();
 }
 
+float DisplayServerAndroid::screen_get_refresh_rate(int p_screen) const {
+	// Most Android devices have 60hz displays.
+	return 60.0;
+}
+
 Rect2i DisplayServerAndroid::screen_get_usable_rect(int p_screen) const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	ERR_FAIL_COND_V(!godot_io_java, Rect2i());

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -140,9 +140,9 @@ Size2i DisplayServerAndroid::screen_get_size(int p_screen) const {
 
 float DisplayServerAndroid::screen_get_refresh_rate(int p_screen) const {
 	print_line("Test for getting Display.Mode from JNI");
-	JNIEnv *env = OS_Android::get_singleton()->get_godot_io_java().get_jni_env();
+	JNIEnv *env = OS_Android::get_singleton()->get_godot_io_java()->get_jni_env();
 	jclass display_class = env->FindClass("android/view/Display");
-	jmethodID get_mode_id = env->GetMethodID(env, display_class, "getMode", "()Landroid/view/Display/Mode");
+	jmethodID get_mode_id = env->GetMethodID(display_class, "getMode", "()Landroid/view/Display/Mode");
 	if(get_mode_id == 0) {
 		return 60.0;
 	}

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -140,7 +140,7 @@ Size2i DisplayServerAndroid::screen_get_size(int p_screen) const {
 
 float DisplayServerAndroid::screen_get_refresh_rate(int p_screen) const {
 	print_line("Test for getting Display.Mode from JNI");
-	JNIEnv *env = OS_Android::get_singleton()->get_godot_io_java()->get_jni_env();
+	JNIEnv *env = get_jni_env();
 	jclass display_class = env->FindClass("android/view/Display");
 	jmethodID get_mode_id = env->GetMethodID(display_class, "getMode", "()Landroid/view/Display/Mode");
 	if(get_mode_id == 0) {

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -119,6 +119,7 @@ public:
 	virtual int get_screen_count() const;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const;

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -52,6 +52,7 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 		_get_locale = p_env->GetMethodID(cls, "getLocale", "()Ljava/lang/String;");
 		_get_model = p_env->GetMethodID(cls, "getModel", "()Ljava/lang/String;");
 		_get_screen_DPI = p_env->GetMethodID(cls, "getScreenDPI", "()I");
+		_get_refresh_rate = p_env->GetMethodID(env->FindClass("android/view/Display"), "getRefreshRate", "()F");
 		_screen_get_usable_rect = p_env->GetMethodID(cls, "screenGetUsableRect", "()[I"),
 		_get_unique_id = p_env->GetMethodID(cls, "getUniqueID", "()Ljava/lang/String;");
 		_show_keyboard = p_env->GetMethodID(cls, "showKeyboard", "(Ljava/lang/String;ZIII)V");
@@ -121,6 +122,16 @@ int GodotIOJavaWrapper::get_screen_dpi() {
 		return env->CallIntMethod(godot_io_instance, _get_screen_DPI);
 	} else {
 		return 160;
+	}
+}
+
+float GodotIOJavaWrapper::get_screen_refresh_rate() {
+	if(_get_refresh_rate) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, 60.0);
+		return env->CallFloatMethod(godot_io_instance, _get_refresh_rate);
+	} else {
+		return 60.0;
 	}
 }
 

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -52,7 +52,7 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 		_get_locale = p_env->GetMethodID(cls, "getLocale", "()Ljava/lang/String;");
 		_get_model = p_env->GetMethodID(cls, "getModel", "()Ljava/lang/String;");
 		_get_screen_DPI = p_env->GetMethodID(cls, "getScreenDPI", "()I");
-		_get_refresh_rate = p_env->GetMethodID(env->FindClass("android/view/Display"), "getRefreshRate", "()F");
+		_get_refresh_rate = p_env->GetMethodID(p_env->FindClass("android/view/Display"), "getRefreshRate", "()F");
 		_screen_get_usable_rect = p_env->GetMethodID(cls, "screenGetUsableRect", "()[I"),
 		_get_unique_id = p_env->GetMethodID(cls, "getUniqueID", "()Ljava/lang/String;");
 		_show_keyboard = p_env->GetMethodID(cls, "showKeyboard", "(Ljava/lang/String;ZIII)V");

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -126,7 +126,7 @@ int GodotIOJavaWrapper::get_screen_dpi() {
 }
 
 float GodotIOJavaWrapper::get_screen_refresh_rate() {
-	if(_get_refresh_rate) {
+	if (_get_refresh_rate) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_COND_V(env == nullptr, 60.0);
 		return env->CallFloatMethod(godot_io_instance, _get_refresh_rate);

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -50,6 +50,7 @@ private:
 	jmethodID _get_locale = 0;
 	jmethodID _get_model = 0;
 	jmethodID _get_screen_DPI = 0;
+	jmethodID _get_refresh_rate = 0;
 	jmethodID _screen_get_usable_rect = 0;
 	jmethodID _get_unique_id = 0;
 	jmethodID _show_keyboard = 0;
@@ -69,6 +70,7 @@ public:
 	String get_locale();
 	String get_model();
 	int get_screen_dpi();
+	float get_screen_refresh_rate();
 	void screen_get_usable_rect(int (&p_rect_xywh)[4]);
 	String get_unique_id();
 	bool has_vk();

--- a/platform/iphone/display_server_iphone.h
+++ b/platform/iphone/display_server_iphone.h
@@ -124,6 +124,7 @@ public:
 	virtual int get_screen_count() const override;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;

--- a/platform/iphone/display_server_iphone.mm
+++ b/platform/iphone/display_server_iphone.mm
@@ -346,6 +346,11 @@ Size2i DisplayServerIPhone::screen_get_size(int p_screen) const {
 	return Size2i(layer.bounds.size.width, layer.bounds.size.height) * screen_get_scale(p_screen);
 }
 
+float DisplayServerIPhone::screen_get_refresh_rate(int p_screen) const {
+	// Most if not all Apple devices have 60hz displays.
+	return 60.0;
+}
+
 Rect2i DisplayServerIPhone::screen_get_usable_rect(int p_screen) const {
 	if (@available(iOS 11, *)) {
 		UIEdgeInsets insets = UIEdgeInsetsZero;

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -742,6 +742,27 @@ Size2i DisplayServerX11::screen_get_size(int p_screen) const {
 	return screen_get_usable_rect(p_screen).size;
 }
 
+float DisplayServerX11::screen_get_refresh_rate(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	if (p_screen == SCREEN_OF_MAIN_WINDOW) {
+		p_screen = window_get_current_screen();
+	}
+
+	//invalid screen?
+	ERR_FAIL_INDEX_V(p_screen, get_screen_count(), 0);
+
+	float refresh_rate = 60.0; //Default to 60 hz if the engine was unable to get the refresh rate.
+
+	if (xrandr_ext_ok) {
+		if (xrr_get_monitors) {
+			XRRScreenConfiguration *conf = XRRGetScreenInfo(x11_display, windows[MAIN_WINDOW_ID].x11_window);
+			refresh_rate = XRRConfigCurrentRate(conf);
+		}
+	}
+	return refresh_rate;
+}
+
 Rect2i DisplayServerX11::screen_get_usable_rect(int p_screen) const {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -287,6 +287,7 @@ public:
 	virtual int get_screen_count() const;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const;

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -225,6 +225,7 @@ public:
 	virtual int get_screen_count() const override;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_max_scale() const override;

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -2285,6 +2285,13 @@ Size2i DisplayServerOSX::screen_get_size(int p_screen) const {
 	return Size2i();
 }
 
+float DisplayServerOSX::screen_get_refresh_rate(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+	// There's no way to get the screen refresh rate using AppKit
+	// and most if not all Apple devices have 60hz displays anyways.
+	return 60.0;
+}
+
 int DisplayServerOSX::screen_get_dpi(int p_screen) const {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -328,6 +328,15 @@ Size2i DisplayServerWindows::screen_get_size(int p_screen) const {
 	return data.size;
 }
 
+float DisplayServerWindows::screen_get_refresh_rate(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	DEVMODE data;
+	memset(&data, 0, sizeof(data));
+	EnumDisplaySettingsA(NULL, ENUM_CURRENT_SETTINGS, &data);
+	return data.dmDisplayFrequency;
+}
+
 static BOOL CALLBACK _MonitorEnumProcUsableSize(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData) {
 	EnumRectData *data = (EnumRectData *)dwData;
 	if (data->count == data->screen) {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -457,6 +457,7 @@ public:
 	virtual int get_screen_count() const;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -396,6 +396,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_screen_count"), &DisplayServer::get_screen_count);
 	ClassDB::bind_method(D_METHOD("screen_get_position", "screen"), &DisplayServer::screen_get_position, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_size", "screen"), &DisplayServer::screen_get_size, DEFVAL(SCREEN_OF_MAIN_WINDOW));
+	ClassDB::bind_method(D_METHOD("screen_get_refresh_rate", "screen"), &DisplayServer::screen_get_refresh_rate, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_usable_rect", "screen"), &DisplayServer::screen_get_usable_rect, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_dpi", "screen"), &DisplayServer::screen_get_dpi, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_scale", "screen"), &DisplayServer::screen_get_scale, DEFVAL(SCREEN_OF_MAIN_WINDOW));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -164,6 +164,7 @@ public:
 	virtual int get_screen_count() const = 0;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
+	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const;


### PR DESCRIPTION
Closes godotengine/godot-proposals#1284.

Allows you to get the Screen's refresh rate by using `DisplayServer.screen_get_refresh_rate()`

![image](https://user-images.githubusercontent.com/12436824/111929672-0a1eb480-8a85-11eb-857b-6a5ac86534f3.png)
![image](https://user-images.githubusercontent.com/12436824/111929688-173ba380-8a85-11eb-9b52-3fd571a3867e.png)

Since 3.2 doesn't use DisplayServer, I would imagine this can't be cherry-picked. I've already made a 3.x version that uses OS instead. I will make a separate PR for the 3.x branch if this gets merged.