### PR TITLE
Rename Control getters and setters to match properties

### DIFF
--- a/doc/classes/AspectRatioContainer.xml
+++ b/doc/classes/AspectRatioContainer.xml
@@ -36,7 +36,7 @@
 		</constant>
 		<constant name="STRETCH_COVER" value="3" enum="StretchMode">
 			The width and height of child controls is automatically adjusted to make their bounding rectangle cover the entire area of the container while keeping the aspect ratio.
-			When the bounding rectangle of child controls exceed the container's size and [member Control.rect_clip_content] is enabled, this allows to show only the container's area restricted by its own bounding rectangle.
+			When the bounding rectangle of child controls exceed the container's size and [member Control.rect_clip_contents] is enabled, this allows to show only the container's area restricted by its own bounding rectangle.
 		</constant>
 		<constant name="ALIGN_BEGIN" value="0" enum="AlignMode">
 			Aligns child controls with the beginning (left or top) of the container.

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -26,7 +26,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Virtual method to be implemented by the user. Returns whether [method _gui_input] should not be called for children controls outside this control's rectangle. Input will be clipped to the Rect of this [Control]. Similar to [member rect_clip_content], but doesn't affect visibility.
+				Virtual method to be implemented by the user. Returns whether [method _gui_input] should not be called for children controls outside this control's rectangle. Input will be clipped to the Rect of this [Control]. Similar to [member rect_clip_contents], but doesn't affect visibility.
 				If not overridden, defaults to [code]false[/code].
 			</description>
 		</method>
@@ -34,7 +34,7 @@
 			<return type="Vector2">
 			</return>
 			<description>
-				Virtual method to be implemented by the user. Returns the minimum size for this control. Alternative to [member rect_min_size] for controlling minimum size via code. The actual minimum size will be the max value of these two (in each axis separately).
+				Virtual method to be implemented by the user. Returns the minimum size for this control. Alternative to [member rect_minimum_size] for controlling minimum size via code. The actual minimum size will be the max value of these two (in each axis separately).
 				If not overridden, defaults to [constant Vector2.ZERO].
 			</description>
 		</method>
@@ -72,7 +72,7 @@
 				* control has [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
 				* control is obstructed by another [Control] on top of it, which doesn't have [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
 				* control's parent has [member mouse_filter] set to [constant MOUSE_FILTER_STOP] or has accepted the event;
-				* it happens outside parent's rectangle and the parent has either [member rect_clip_content] or [method _clips_input] enabled.
+				* it happens outside parent's rectangle and the parent has either [member rect_clip_contents] or [method _clips_input] enabled.
 			</description>
 		</method>
 		<method name="_make_custom_tooltip" qualifiers="virtual">
@@ -81,10 +81,10 @@
 			<argument index="0" name="for_text" type="String">
 			</argument>
 			<description>
-				Virtual method to be implemented by the user. Returns a [Control] node that should be used as a tooltip instead of the default one. The [code]for_text[/code] includes the contents of the [member hint_tooltip] property.
+				Virtual method to be implemented by the user. Returns a [Control] node that should be used as a tooltip instead of the default one. The [code]for_text[/code] includes the contents of the [member tooltip] property.
 				The returned node must be of type [Control] or Control-derived. It can have child nodes of any type. It is freed when the tooltip disappears, so make sure you always provide a new instance (if you want to use a pre-existing node from your scene tree, you can duplicate it and pass the duplicated instance).When [code]null[/code] or a non-Control node is returned, the default tooltip will be used instead.
-				The returned node will be added as child to a [PopupPanel], so you should only provide the contents of that panel. That [PopupPanel] can be themed using [method Theme.set_stylebox] for the type [code]"TooltipPanel"[/code] (see [member hint_tooltip] for an example).
-				[b]Note:[/b] The tooltip is shrunk to minimal size. If you want to ensure it's fully visible, you might want to set its [member rect_min_size] to some non-zero value.
+				The returned node will be added as child to a [PopupPanel], so you should only provide the contents of that panel. That [PopupPanel] can be themed using [method Theme.set_stylebox] for the type [code]"TooltipPanel"[/code] (see [member tooltip] for an example).
+				[b]Note:[/b] The tooltip is shrunk to minimal size. If you want to ensure it's fully visible, you might want to set its [member rect_minimum_size] to some non-zero value.
 				[b]Note:[/b] The node (and any relevant children) should be [member CanvasItem.visible] when returned, otherwise the viewport that instantiates it will not be able to calculate its minimum size reliably.
 				Example of usage with a custom-constructed node:
 				[codeblocks]
@@ -352,16 +352,7 @@
 			<return type="Vector2">
 			</return>
 			<description>
-				Returns combined minimum size from [member rect_min_size] and [method get_minimum_size].
-			</description>
-		</method>
-		<method name="get_cursor_shape" qualifiers="const">
-			<return type="int" enum="Control.CursorShape">
-			</return>
-			<argument index="0" name="position" type="Vector2" default="Vector2( 0, 0 )">
-			</argument>
-			<description>
-				Returns the mouse cursor shape the control displays on mouse hover. See [enum CursorShape].
+				Returns combined minimum size from [member rect_minimum_size] and [method get_minimum_size].
 			</description>
 		</method>
 		<method name="get_drag_data" qualifiers="virtual">
@@ -424,7 +415,16 @@
 			<return type="Vector2">
 			</return>
 			<description>
-				Returns the minimum size for this control. See [member rect_min_size].
+				Returns the minimum size for this control. See [member rect_minimum_size].
+			</description>
+		</method>
+		<method name="get_mouse_cursor_shape" qualifiers="const">
+			<return type="int" enum="Control.CursorShape">
+			</return>
+			<argument index="0" name="position" type="Vector2" default="Vector2( 0, 0 )">
+			</argument>
+			<description>
+				Returns the mouse cursor shape the control displays on mouse hover. See [enum CursorShape].
 			</description>
 		</method>
 		<method name="get_offset" qualifiers="const">
@@ -541,7 +541,7 @@
 			<argument index="0" name="at_position" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<description>
-				Returns the tooltip, which will appear when the cursor is resting over this control. See [member hint_tooltip].
+				Returns the tooltip, which will appear when the cursor is resting over this control. See [member tooltip].
 			</description>
 		</method>
 		<method name="grab_click_focus">
@@ -719,7 +719,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Invalidates the size cache in this node and in parent nodes up to top_level. Intended to be used with [method get_minimum_size] when the return value is changed. Setting [member rect_min_size] directly calls this method automatically.
+				Invalidates the size cache in this node and in parent nodes up to top_level. Intended to be used with [method get_minimum_size] when the return value is changed. Setting [member rect_minimum_size] directly calls this method automatically.
 			</description>
 		</method>
 		<method name="release_focus">
@@ -972,18 +972,6 @@
 				Sets the anchor for the specified [enum Side] to the [Control] at [code]neighbor[/code] node path. A setter method for [member focus_neighbor_bottom], [member focus_neighbor_left], [member focus_neighbor_right] and [member focus_neighbor_top].
 			</description>
 		</method>
-		<method name="set_global_position">
-			<return type="void">
-			</return>
-			<argument index="0" name="position" type="Vector2">
-			</argument>
-			<argument index="1" name="keep_offsets" type="bool" default="false">
-			</argument>
-			<description>
-				Sets the [member rect_global_position] to given [code]position[/code].
-				If [code]keep_offsets[/code] is [code]true[/code], control's anchors will be updated instead of offsets.
-			</description>
-		</method>
 		<method name="set_offset">
 			<return type="void">
 			</return>
@@ -1010,7 +998,7 @@
 				Use parameter [code]margin[/code] to determine the gap between the [Control] and the edges.
 			</description>
 		</method>
-		<method name="set_position">
+		<method name="set_rect_global_position">
 			<return type="void">
 			</return>
 			<argument index="0" name="position" type="Vector2">
@@ -1018,11 +1006,21 @@
 			<argument index="1" name="keep_offsets" type="bool" default="false">
 			</argument>
 			<description>
-				Sets the [member rect_position] to given [code]position[/code].
+				Sets the [member rect_global_position] to given [code]position[/code].
 				If [code]keep_offsets[/code] is [code]true[/code], control's anchors will be updated instead of offsets.
 			</description>
 		</method>
-		<method name="set_size">
+		<method name="set_rect_position">
+			<return type="void">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<argument index="1" name="keep_offsets" type="bool" default="false">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_rect_size">
 			<return type="void">
 			</return>
 			<argument index="0" name="size" type="Vector2">
@@ -1080,40 +1078,18 @@
 			Tells Godot which node it should give keyboard focus to if the user presses [kbd]Shift + Tab[/kbd] on a keyboard by default. You can change the key by editing the [code]ui_focus_prev[/code] input action.
 			If this property is not set, Godot will select a "best guess" based on surrounding nodes in the scene tree.
 		</member>
-		<member name="grow_horizontal" type="int" setter="set_h_grow_direction" getter="get_h_grow_direction" enum="Control.GrowDirection" default="1">
+		<member name="grow_horizontal" type="int" setter="set_grow_horizontal" getter="get_grow_horizontal" enum="Control.GrowDirection" default="1">
 			Controls the direction on the horizontal axis in which the control should grow if its horizontal minimum size is changed to be greater than its current size, as the control always has to be at least the minimum size.
 		</member>
-		<member name="grow_vertical" type="int" setter="set_v_grow_direction" getter="get_v_grow_direction" enum="Control.GrowDirection" default="1">
+		<member name="grow_vertical" type="int" setter="set_grow_vertical" getter="get_grow_vertical" enum="Control.GrowDirection" default="1">
 			Controls the direction on the vertical axis in which the control should grow if its vertical minimum size is changed to be greater than its current size, as the control always has to be at least the minimum size.
-		</member>
-		<member name="hint_tooltip" type="String" setter="set_tooltip" getter="_get_tooltip" default="&quot;&quot;">
-			Changes the tooltip text. The tooltip appears when the user's mouse cursor stays idle over this control for a few moments, provided that the [member mouse_filter] property is not [constant MOUSE_FILTER_IGNORE]. You can change the time required for the tooltip to appear with [code]gui/timers/tooltip_delay_sec[/code] option in Project Settings.
-			The tooltip popup will use either a default implementation, or a custom one that you can provide by overriding [method _make_custom_tooltip]. The default tooltip includes a [PopupPanel] and [Label] whose theme properties can be customized using [Theme] methods with the [code]"TooltipPanel"[/code] and [code]"TooltipLabel"[/code] respectively. For example:
-			[codeblocks]
-			[gdscript]
-			var style_box = StyleBoxFlat.new()
-			style_box.set_bg_color(Color(1, 1, 0))
-			style_box.set_border_width_all(2)
-			# We assume here that the `theme` property has been assigned a custom Theme beforehand.
-			theme.set_stylebox("panel", "TooltipPanel", style_box)
-			theme.set_color("font_color", "TooltipLabel", Color(0, 1, 1))
-			[/gdscript]
-			[csharp]
-			var styleBox = new StyleBoxFlat();
-			styleBox.SetBgColor(new Color(1, 1, 0));
-			styleBox.SetBorderWidthAll(2);
-			// We assume here that the `Theme` property has been assigned a custom Theme beforehand.
-			Theme.SetStyleBox("panel", "TooltipPanel", styleBox);
-			Theme.SetColor("font_color", "TooltipLabel", new Color(0, 1, 1));
-			[/csharp]
-			[/codeblocks]
 		</member>
 		<member name="layout_direction" type="int" setter="set_layout_direction" getter="get_layout_direction" enum="Control.LayoutDirection" default="0">
 			Controls layout direction and text writing direction. Right-to-left layouts are necessary for certain languages (e.g. Arabic and Hebrew).
 		</member>
-		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" enum="Control.CursorShape" default="0">
-			The default cursor shape for this control. Useful for Godot plugins and applications or games that use the system's mouse cursors.
-			[b]Note:[/b] On Linux, shapes may vary depending on the cursor theme of the system.
+		<member name="mouse_default_cursor_shape" type="int" setter="set_mouse_default_cursor_shape" getter="get_mouse_default_cursor_shape" enum="Control.CursorShape" default="0">
+			The default mouse cursor shape for this control. Useful for Godot plugins and applications or games that use the system's mouse cursors.
+			[b]Note:[/b] On Linux, shapes may vary depending on the mouse cursor theme of the system.
 		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" enum="Control.MouseFilter" default="0">
 			Controls whether the control will be able to receive mouse button input events through [method _gui_input] and how these events should be handled. Also controls whether the control can receive the [signal mouse_entered], and [signal mouse_exited] signals. See the constants to learn what each does.
@@ -1134,46 +1110,68 @@
 			Distance between the node's top edge and its parent control, based on [member anchor_top].
 			Offsets are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Offsets update automatically when you move or resize the node.
 		</member>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" default="false">
+		<member name="rect_clip_contents" type="bool" setter="set_rect_clip_contents" getter="is_rect_clipping_contents" default="false">
 			Enables whether rendering of [CanvasItem] based children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visibly outside of this control's rectangle will not be rendered.
 		</member>
-		<member name="rect_global_position" type="Vector2" setter="_set_global_position" getter="get_global_position">
+		<member name="rect_global_position" type="Vector2" setter="_set_rect_global_position" getter="get_rect_global_position">
 			The node's global position, relative to the world (usually to the top-left corner of the window).
 		</member>
-		<member name="rect_min_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" default="Vector2( 0, 0 )">
+		<member name="rect_minimum_size" type="Vector2" setter="set_rect_minimum_size" getter="get_rect_minimum_size" default="Vector2( 0, 0 )">
 			The minimum size of the node's bounding rectangle. If you set it to a value greater than (0, 0), the node's bounding rectangle will always have at least this size, even if its content is smaller. If it's set to (0, 0), the node sizes automatically to fit its content, be it a texture or child nodes.
 		</member>
-		<member name="rect_pivot_offset" type="Vector2" setter="set_pivot_offset" getter="get_pivot_offset" default="Vector2( 0, 0 )">
+		<member name="rect_pivot_offset" type="Vector2" setter="set_rect_pivot_offset" getter="get_rect_pivot_offset" default="Vector2( 0, 0 )">
 			By default, the node's pivot is its top-left corner. When you change its [member rect_scale], it will scale around this pivot. Set this property to [member rect_size] / 2 to center the pivot in the node's rectangle.
 		</member>
-		<member name="rect_position" type="Vector2" setter="_set_position" getter="get_position" default="Vector2( 0, 0 )">
+		<member name="rect_position" type="Vector2" setter="_set_rect_position" getter="get_rect_position" default="Vector2( 0, 0 )">
 			The node's position, relative to its parent. It corresponds to the rectangle's top-left corner. The property is not affected by [member rect_pivot_offset].
 		</member>
-		<member name="rect_rotation" type="float" setter="set_rotation" getter="get_rotation" default="0.0">
+		<member name="rect_rotation" type="float" setter="set_rect_rotation" getter="get_rect_rotation" default="0.0">
 			The node's rotation around its pivot, in radians. See [member rect_pivot_offset] to change the pivot's position.
 		</member>
-		<member name="rect_rotation_degrees" type="float" setter="set_rotation_degrees" getter="get_rotation_degrees" default="0.0">
+		<member name="rect_rotation_degrees" type="float" setter="set_rect_rotation_degrees" getter="get_rect_rotation_degrees" default="0.0">
 			The node's rotation around its pivot, in degrees. See [member rect_pivot_offset] to change the pivot's position.
 		</member>
-		<member name="rect_scale" type="Vector2" setter="set_scale" getter="get_scale" default="Vector2( 1, 1 )">
-			The node's scale, relative to its [member rect_size]. Change this property to scale the node around its [member rect_pivot_offset]. The Control's [member hint_tooltip] will also scale according to this value.
+		<member name="rect_scale" type="Vector2" setter="set_rect_scale" getter="get_rect_scale" default="Vector2( 1, 1 )">
+			The node's scale, relative to its [member rect_size]. Change this property to scale the node around its [member rect_pivot_offset]. The Control's [member tooltip] will also scale according to this value.
 			[b]Note:[/b] This property is mainly intended to be used for animation purposes. Text inside the Control will look pixelated or blurry when the Control is scaled. To support multiple resolutions in your project, use an appropriate viewport stretch mode as described in the [url=https://docs.godotengine.org/en/latest/tutorials/viewports/multiple_resolutions.html]documentation[/url] instead of scaling Controls individually.
 			[b]Note:[/b] If the Control node is a child of a [Container] node, the scale will be reset to [code]Vector2(1, 1)[/code] when the scene is instanced. To set the Control's scale when it's instanced, wait for one frame using [code]yield(get_tree(), "idle_frame")[/code] then set its [member rect_scale] property.
 		</member>
-		<member name="rect_size" type="Vector2" setter="_set_size" getter="get_size" default="Vector2( 0, 0 )">
+		<member name="rect_size" type="Vector2" setter="_set_rect_size" getter="get_rect_size" default="Vector2( 0, 0 )">
 			The size of the node's bounding rectangle, in pixels. [Container] nodes update this property automatically.
 		</member>
-		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags" default="1">
+		<member name="size_flags_horizontal" type="int" setter="set_size_flags_horizontal" getter="get_size_flags_horizontal" default="1">
 			Tells the parent [Container] nodes how they should resize and place the node on the X axis. Use one of the [enum SizeFlags] constants to change the flags. See the constants to learn what each does.
 		</member>
-		<member name="size_flags_stretch_ratio" type="float" setter="set_stretch_ratio" getter="get_stretch_ratio" default="1.0">
+		<member name="size_flags_stretch_ratio" type="float" setter="set_size_flags_stretch_ratio" getter="get_size_flags_stretch_ratio" default="1.0">
 			If the node and at least one of its neighbors uses the [constant SIZE_EXPAND] size flag, the parent [Container] will let it take more or less space depending on this property. If this node has a stretch ratio of 2 and its neighbor a ratio of 1, this node will take two thirds of the available space.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" default="1">
+		<member name="size_flags_vertical" type="int" setter="set_size_flags_vertical" getter="get_size_flags_vertical" default="1">
 			Tells the parent [Container] nodes how they should resize and place the node on the Y axis. Use one of the [enum SizeFlags] constants to change the flags. See the constants to learn what each does.
 		</member>
 		<member name="theme" type="Theme" setter="set_theme" getter="get_theme">
 			Changing this property replaces the current [Theme] resource this node and all its [Control] children use.
+		</member>
+		<member name="tooltip" type="String" setter="set_tooltip" getter="_get_tooltip" default="&quot;&quot;">
+			Changes the tooltip text. The tooltip appears when the user's mouse cursor stays idle over this control for a few moments, provided that the [member mouse_filter] property is not [constant MOUSE_FILTER_IGNORE]. You can change the time required for the tooltip to appear with [code]gui/timers/tooltip_delay_sec[/code] option in Project Settings.
+			The tooltip popup will use either a default implementation, or a custom one that you can provide by overriding [method _make_custom_tooltip]. The default tooltip includes a [PopupPanel] and [Label] whose theme properties can be customized using [Theme] methods with the [code]"TooltipPanel"[/code] and [code]"TooltipLabel"[/code] respectively. For example:
+			[codeblocks]
+			[gdscript]
+			var style_box = StyleBoxFlat.new()
+			style_box.set_bg_color(Color(1, 1, 0))
+			style_box.set_border_width_all(2)
+			# We assume here that the `theme` property has been assigned a custom Theme beforehand.
+			theme.set_stylebox("panel", "TooltipPanel", style_box)
+			theme.set_color("font_color", "TooltipLabel", Color(0, 1, 1))
+			[/gdscript]
+			[csharp]
+			var styleBox = new StyleBoxFlat();
+			styleBox.SetBgColor(new Color(1, 1, 0));
+			styleBox.SetBorderWidthAll(2);
+			// We assume here that the `Theme` property has been assigned a custom Theme beforehand.
+			Theme.SetStyleBox("panel", "TooltipPanel", styleBox);
+			Theme.SetColor("font_color", "TooltipLabel", new Color(0, 1, 1));
+			[/csharp]
+			[/codeblocks]
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -190,7 +190,7 @@
 		<member name="minimap_size" type="Vector2" setter="set_minimap_size" getter="get_minimap_size" default="Vector2( 240, 160 )">
 			The size of the minimap rectangle. The map itself is based on the size of the grid area and is scaled to fit this rectangle.
 		</member>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
+		<member name="rect_clip_contents" type="bool" setter="set_rect_clip_contents" getter="is_rect_clipping_contents" override="true" default="true" />
 		<member name="right_disconnects" type="bool" setter="set_right_disconnects" getter="is_right_disconnects_enabled" default="false">
 			If [code]true[/code], enables disconnection of existing connections in the GraphEdit by dragging the right end.
 		</member>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -504,7 +504,7 @@
 			Maximum lines of text allowed in each item. Space will be reserved even when there is not enough lines of text to display.
 			[b]Note:[/b] This property takes effect only when [member icon_mode] is [constant ICON_MODE_TOP]. To make the text wrap, [member fixed_column_width] should be greater than zero.
 		</member>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
+		<member name="rect_clip_contents" type="bool" setter="set_rect_clip_contents" getter="is_rect_clipping_contents" override="true" default="true" />
 		<member name="same_column_width" type="bool" setter="set_same_column_width" getter="is_same_column_width" default="false">
 			Whether all columns will have the same width.
 			If [code]true[/code], the width is equal to the largest column width of all columns.

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Label displays plain text on the screen. It gives you control over the horizontal and vertical alignment, and can wrap the text inside the node's bounding rectangle. It doesn't support bold, italics or other formatting. For that, use [RichTextLabel] instead.
-		[b]Note:[/b] Contrarily to most other [Control]s, Label's [member Control.mouse_filter] defaults to [constant Control.MOUSE_FILTER_IGNORE] (i.e. it doesn't react to mouse input events). This implies that a label won't display any configured [member Control.hint_tooltip], unless you change its mouse filter.
+		[b]Note:[/b] Contrarily to most other [Control]s, Label's [member Control.mouse_filter] defaults to [constant Control.MOUSE_FILTER_IGNORE] (i.e. it doesn't react to mouse input events). This implies that a label won't display any configured [member Control.tooltip], unless you change its mouse filter.
 	</description>
 	<tutorials>
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/515</link>
@@ -94,7 +94,7 @@
 		<member name="percent_visible" type="float" setter="set_percent_visible" getter="get_percent_visible" default="1.0">
 			Limits the amount of visible characters. If you set [code]percent_visible[/code] to 0.5, only up to half of the text's characters will display on screen. Useful to animate the text in a dialog box.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="4" />
+		<member name="size_flags_vertical" type="int" setter="set_size_flags_vertical" getter="get_size_flags_vertical" override="true" default="4" />
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="Control.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
 		</member>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -196,7 +196,7 @@
 		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length" default="0">
 			Maximum amount of characters that can be entered inside the [LineEdit]. If [code]0[/code], there is no limit.
 		</member>
-		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
+		<member name="mouse_default_cursor_shape" type="int" setter="set_mouse_default_cursor_shape" getter="get_mouse_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
 		<member name="placeholder_alpha" type="float" setter="set_placeholder_alpha" getter="get_placeholder_alpha" default="0.6">
 			Opacity of the [member placeholder_text]. From [code]0[/code] to [code]1[/code].
 		</member>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -43,7 +43,7 @@
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>
-		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="2" />
+		<member name="mouse_default_cursor_shape" type="int" setter="set_mouse_default_cursor_shape" getter="get_mouse_default_cursor_shape" override="true" enum="Control.CursorShape" default="2" />
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="Control.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
 		</member>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -14,7 +14,7 @@
 		<member name="percent_visible" type="bool" setter="set_percent_visible" getter="is_percent_visible" default="true">
 			If [code]true[/code], the fill percentage is displayed on the bar.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0" />
+		<member name="size_flags_vertical" type="int" setter="set_size_flags_vertical" getter="get_size_flags_vertical" override="true" default="0" />
 		<member name="step" type="float" setter="set_step" getter="get_step" override="true" default="0.01" />
 	</members>
 	<constants>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -471,7 +471,7 @@
 			The range of characters to display, as a [float] between 0.0 and 1.0. When assigned an out of range value, it's the same as assigning 1.0.
 			[b]Note:[/b] Setting this property updates [member visible_characters] based on current [method get_total_character_count].
 		</member>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
+		<member name="rect_clip_contents" type="bool" setter="set_rect_clip_contents" getter="is_rect_clipping_contents" override="true" default="true" />
 		<member name="scroll_active" type="bool" setter="set_scroll_active" getter="is_scroll_active" default="true">
 			If [code]true[/code], the scrollbar is visible. Setting this to [code]false[/code] does not block scrolling completely. See [method scroll_to_line].
 		</member>

--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -14,7 +14,7 @@
 		<member name="custom_step" type="float" setter="set_custom_step" getter="get_custom_step" default="-1.0">
 			Overrides the step used when clicking increment and decrement buttons or when using arrow keys when the [ScrollBar] is focused.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0" />
+		<member name="size_flags_vertical" type="int" setter="set_size_flags_vertical" getter="get_size_flags_vertical" override="true" default="0" />
 		<member name="step" type="float" setter="set_step" getter="get_step" override="true" default="0.0" />
 	</members>
 	<signals>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		A ScrollContainer node meant to contain a [Control] child.
-		ScrollContainers will automatically create a scrollbar child ([HScrollBar], [VScrollBar], or both) when needed and will only draw the Control within the ScrollContainer area. Scrollbars will automatically be drawn at the right (for vertical) or bottom (for horizontal) and will enable dragging to move the viewable Control (and its children) within the ScrollContainer. Scrollbars will also automatically resize the grabber based on the [member Control.rect_min_size] of the Control relative to the ScrollContainer.
+		ScrollContainers will automatically create a scrollbar child ([HScrollBar], [VScrollBar], or both) when needed and will only draw the Control within the ScrollContainer area. Scrollbars will automatically be drawn at the right (for vertical) or bottom (for horizontal) and will enable dragging to move the viewable Control (and its children) within the ScrollContainer. Scrollbars will also automatically resize the grabber based on the [member Control.rect_minimum_size] of the Control relative to the ScrollContainer.
 		Works great with a [Panel] control. You can set [code]EXPAND[/code] on the children's size flags, so they will upscale to the ScrollContainer's size if it's larger (scroll is invisible for the chosen dimension).
 	</description>
 	<tutorials>
@@ -30,7 +30,7 @@
 		<member name="follow_focus" type="bool" setter="set_follow_focus" getter="is_following_focus" default="false">
 			If [code]true[/code], the ScrollContainer will automatically scroll to focused children (including indirect children) to make sure they are fully visible.
 		</member>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
+		<member name="rect_clip_contents" type="bool" setter="set_rect_clip_contents" getter="is_rect_clipping_contents" override="true" default="true" />
 		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -19,7 +19,7 @@
 		<member name="scrollable" type="bool" setter="set_scrollable" getter="is_scrollable" default="true">
 			If [code]true[/code], the value can be changed using the mouse wheel.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="0" />
+		<member name="size_flags_vertical" type="int" setter="set_size_flags_vertical" getter="get_size_flags_vertical" override="true" default="0" />
 		<member name="tick_count" type="int" setter="set_ticks" getter="get_ticks" default="0">
 			Number of ticks displayed on the slider, including border ticks. Ticks are uniformly-distributed value markers.
 		</member>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -706,7 +706,7 @@
 		<member name="minimap_width" type="int" setter="set_minimap_width" getter="get_minimap_width" default="80">
 			The width, in pixels, of the minimap.
 		</member>
-		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
+		<member name="mouse_default_cursor_shape" type="int" setter="set_mouse_default_cursor_shape" getter="get_mouse_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
 		<member name="override_selected_font_color" type="bool" setter="set_override_selected_font_color" getter="is_overriding_selected_font_color" default="false">
 			If [code]true[/code], custom [code]font_selected_color[/code] will be used for selected text.
 		</member>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -371,7 +371,7 @@
 		<member name="hide_root" type="bool" setter="set_hide_root" getter="is_root_hidden" default="false">
 			If [code]true[/code], the tree's root is hidden.
 		</member>
-		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
+		<member name="rect_clip_contents" type="bool" setter="set_rect_clip_contents" getter="is_rect_clipping_contents" override="true" default="true" />
 		<member name="select_mode" type="int" setter="set_select_mode" getter="get_select_mode" enum="Tree.SelectMode" default="0">
 			Allows single or multiple selection. See the [enum SelectMode] constants.
 		</member>

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -11,8 +11,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags" override="true" default="0" />
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="1" />
+		<member name="size_flags_horizontal" type="int" setter="set_size_flags_horizontal" getter="get_size_flags_horizontal" override="true" default="0" />
+		<member name="size_flags_vertical" type="int" setter="set_size_flags_vertical" getter="get_size_flags_vertical" override="true" default="1" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VSlider.xml
+++ b/doc/classes/VSlider.xml
@@ -12,8 +12,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags" override="true" default="0" />
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="1" />
+		<member name="size_flags_horizontal" type="int" setter="set_size_flags_horizontal" getter="get_size_flags_horizontal" override="true" default="0" />
+		<member name="size_flags_vertical" type="int" setter="set_size_flags_vertical" getter="get_size_flags_vertical" override="true" default="1" />
 	</members>
 	<constants>
 	</constants>

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -590,7 +590,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	tab_container = memnew(TabContainer);
 	tab_container->set_tab_align(TabContainer::TabAlign::ALIGN_LEFT);
 	tab_container->set_use_hidden_tabs_for_min_size(true);
-	tab_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tab_container->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	tab_container->connect("tab_selected", callable_mp(this, &InputEventConfigurationDialog::_tab_selected));
 	main_vbox->add_child(tab_container);
 
@@ -605,20 +605,20 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 
 	VBoxContainer *manual_vbox = memnew(VBoxContainer);
 	manual_vbox->set_name("Manual Selection");
-	manual_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	manual_vbox->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	tab_container->add_child(manual_vbox);
 
 	input_list_search = memnew(LineEdit);
-	input_list_search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	input_list_search->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	input_list_search->set_placeholder(TTR("Filter Inputs"));
 	input_list_search->set_clear_button_enabled(true);
 	input_list_search->connect("text_changed", callable_mp(this, &InputEventConfigurationDialog::_search_term_updated));
 	manual_vbox->add_child(input_list_search);
 
 	input_list_tree = memnew(Tree);
-	input_list_tree->set_custom_minimum_size(Size2(0, 100 * EDSCALE)); // Min height for tree
+	input_list_tree->set_rect_minimum_size(Size2(0, 100 * EDSCALE)); // Min height for tree
 	input_list_tree->connect("item_selected", callable_mp(this, &InputEventConfigurationDialog::_input_list_item_selected));
-	input_list_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	input_list_tree->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	manual_vbox->add_child(input_list_tree);
 
 	input_list_tree->set_hide_root(true);
@@ -636,14 +636,14 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 
 	// Device Selection
 	device_container = memnew(HBoxContainer);
-	device_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	device_container->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	Label *device_label = memnew(Label);
 	device_label->set_text("Device:");
 	device_container->add_child(device_label);
 
 	device_id_option = memnew(OptionButton);
-	device_id_option->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	device_id_option->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	device_container->add_child(device_id_option);
 
 	for (int i = -1; i < 8; i++) {
@@ -1108,7 +1108,7 @@ ActionMapEditor::ActionMapEditor() {
 	main_vbox->add_child(top_hbox);
 
 	action_list_search = memnew(LineEdit);
-	action_list_search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	action_list_search->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	action_list_search->set_placeholder(TTR("Filter Actions"));
 	action_list_search->set_clear_button_enabled(true);
 	action_list_search->connect("text_changed", callable_mp(this, &ActionMapEditor::_search_term_updated));
@@ -1122,10 +1122,10 @@ ActionMapEditor::ActionMapEditor() {
 
 	// Adding Action line edit + button
 	add_hbox = memnew(HBoxContainer);
-	add_hbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	add_hbox->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	add_edit = memnew(LineEdit);
-	add_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	add_edit->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	add_edit->set_placeholder(TTR("Add New Action"));
 	add_edit->set_clear_button_enabled(true);
 	add_edit->connect("text_entered", callable_mp(this, &ActionMapEditor::_add_action));
@@ -1140,7 +1140,7 @@ ActionMapEditor::ActionMapEditor() {
 
 	// Action Editor Tree
 	action_tree = memnew(Tree);
-	action_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	action_tree->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	action_tree->set_columns(3);
 	action_tree->set_hide_root(true);
 	action_tree->set_column_titles_visible(true);

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -37,7 +37,7 @@
 float AnimationBezierTrackEdit::_bezier_h_to_pixel(float p_h) {
 	float h = p_h;
 	h = (h - v_scroll) / v_zoom;
-	h = (get_size().height / 2) - h;
+	h = (get_rect_size().height / 2) - h;
 	return h;
 }
 
@@ -55,7 +55,7 @@ static _FORCE_INLINE_ Vector2 _bezier_interp(real_t t, const Vector2 &start, con
 void AnimationBezierTrackEdit::_draw_track(int p_track, const Color &p_color) {
 	float scale = timeline->get_zoom_scale();
 	int limit = timeline->get_name_limit();
-	int right_limit = get_size().width - timeline->get_buttons_width();
+	int right_limit = get_rect_size().width - timeline->get_buttons_width();
 
 	//selection may have altered the order of keys
 	Map<float, int> key_order;
@@ -227,12 +227,12 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 		}
 	}
 	if (p_what == NOTIFICATION_RESIZED) {
-		int right_limit = get_size().width - timeline->get_buttons_width();
+		int right_limit = get_rect_size().width - timeline->get_buttons_width();
 		int hsep = get_theme_constant("hseparation", "ItemList");
 		int vsep = get_theme_constant("vseparation", "ItemList");
 
-		handle_mode_option->set_position(Vector2(right_limit + hsep, get_size().height - handle_mode_option->get_combined_minimum_size().height - vsep));
-		handle_mode_option->set_size(Vector2(timeline->get_buttons_width() - hsep * 2, handle_mode_option->get_combined_minimum_size().height));
+		handle_mode_option->set_rect_position(Vector2(right_limit + hsep, get_rect_size().height - handle_mode_option->get_combined_minimum_size().height - vsep));
+		handle_mode_option->set_rect_size(Vector2(timeline->get_buttons_width() - hsep * 2, handle_mode_option->get_combined_minimum_size().height));
 	}
 	if (p_what == NOTIFICATION_DRAW) {
 		if (animation.is_null()) {
@@ -244,7 +244,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 		if (has_focus()) {
 			Color accent = get_theme_color("accent_color", "Editor");
 			accent.a *= 0.7;
-			draw_rect(Rect2(Point2(), get_size()), accent, false);
+			draw_rect(Rect2(Point2(), get_rect_size()), accent, false);
 		}
 
 		Ref<Font> font = get_theme_font("font", "Label");
@@ -255,15 +255,15 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 		Color linecolor = color;
 		linecolor.a = 0.2;
 
-		draw_line(Point2(limit, 0), Point2(limit, get_size().height), linecolor);
+		draw_line(Point2(limit, 0), Point2(limit, get_rect_size().height), linecolor);
 
-		int right_limit = get_size().width - timeline->get_buttons_width();
+		int right_limit = get_rect_size().width - timeline->get_buttons_width();
 
-		draw_line(Point2(right_limit, 0), Point2(right_limit, get_size().height), linecolor);
+		draw_line(Point2(right_limit, 0), Point2(right_limit, get_rect_size().height), linecolor);
 
 		Ref<Texture2D> close_icon = get_theme_icon("Close", "EditorIcons");
 
-		close_icon_rect.position = Vector2(get_size().width - close_icon->get_width() - hsep, hsep);
+		close_icon_rect.position = Vector2(get_rect_size().width - close_icon->get_width() - hsep, hsep);
 		close_icon_rect.size = close_icon->get_size();
 		draw_texture(close_icon, close_icon_rect.position);
 
@@ -375,8 +375,8 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 
 			bool first = true;
 			int prev_iv = 0;
-			for (int i = font->get_height(font_size); i < get_size().height; i++) {
-				float ofs = get_size().height / 2 - i;
+			for (int i = font->get_height(font_size); i < get_rect_size().height; i++) {
+				float ofs = get_rect_size().height / 2 - i;
 				ofs *= v_zoom;
 				ofs += v_scroll;
 
@@ -542,11 +542,11 @@ void AnimationBezierTrackEdit::_play_position_draw() {
 	}
 
 	float scale = timeline->get_zoom_scale();
-	int h = get_size().height;
+	int h = get_rect_size().height;
 
 	int px = (-timeline->get_value() + play_position_pos) * scale + timeline->get_name_limit();
 
-	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
+	if (px >= timeline->get_name_limit() && px < (get_rect_size().width - timeline->get_buttons_width())) {
 		Color color = get_theme_color("accent_color", "Editor");
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 	}
@@ -626,7 +626,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				v_zoom *= 1.2;
 			}
 		}
-		v_scroll = v_scroll + (mb->get_position().y - get_size().y / 2) * (v_zoom - v_zoom_orig);
+		v_scroll = v_scroll + (mb->get_position().y - get_rect_size().y / 2) * (v_zoom - v_zoom_orig);
 		update();
 	}
 
@@ -639,7 +639,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 				v_zoom /= 1.2;
 			}
 		}
-		v_scroll = v_scroll + (mb->get_position().y - get_size().y / 2) * (v_zoom - v_zoom_orig);
+		v_scroll = v_scroll + (mb->get_position().y - get_rect_size().y / 2) * (v_zoom - v_zoom_orig);
 		update();
 	}
 
@@ -656,7 +656,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_RIGHT && mb->is_pressed()) {
 		menu_insert_key = mb->get_position();
-		if (menu_insert_key.x >= timeline->get_name_limit() && menu_insert_key.x <= get_size().width - timeline->get_buttons_width()) {
+		if (menu_insert_key.x >= timeline->get_name_limit() && menu_insert_key.x <= get_rect_size().width - timeline->get_buttons_width()) {
 			Vector2 popup_pos = get_global_transform().xform(mb->get_position());
 
 			menu->clear();
@@ -743,11 +743,11 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		//insert new point
-		if (mb->get_command() && mb->get_position().x >= timeline->get_name_limit() && mb->get_position().x < get_size().width - timeline->get_buttons_width()) {
+		if (mb->get_command() && mb->get_position().x >= timeline->get_name_limit() && mb->get_position().x < get_rect_size().width - timeline->get_buttons_width()) {
 			Array new_point;
 			new_point.resize(5);
 
-			float h = (get_size().height / 2 - mb->get_position().y) * v_zoom + v_scroll;
+			float h = (get_rect_size().height / 2 - mb->get_position().y) * v_zoom + v_scroll;
 
 			new_point[0] = h;
 			new_point[1] = -0.25;
@@ -782,7 +782,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		//box select
-		if (mb->get_position().x >= timeline->get_name_limit() && mb->get_position().x < get_size().width - timeline->get_buttons_width()) {
+		if (mb->get_position().x >= timeline->get_name_limit() && mb->get_position().x < get_rect_size().width - timeline->get_buttons_width()) {
 			box_selecting_attempt = true;
 			box_selecting = false;
 			box_selecting_add = false;
@@ -951,7 +951,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			select_single_attempt = -1;
 		}
 
-		float y = (get_size().height / 2 - mm->get_position().y) * v_zoom + v_scroll;
+		float y = (get_rect_size().height / 2 - mm->get_position().y) * v_zoom + v_scroll;
 		float x = editor->snap_time(((mm->get_position().x - timeline->get_name_limit()) / timeline->get_zoom_scale()) + timeline->get_value());
 
 		moving_selection_offset = Vector2(x - animation->track_get_key_time(track, moving_selection_from_key), y - animation->bezier_track_get_key_value(track, moving_selection_from_key));
@@ -974,7 +974,7 @@ void AnimationBezierTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (moving_handle != 0 && mm.is_valid()) {
-		float y = (get_size().height / 2 - mm->get_position().y) * v_zoom + v_scroll;
+		float y = (get_rect_size().height / 2 - mm->get_position().y) * v_zoom + v_scroll;
 		float x = ((mm->get_position().x - timeline->get_name_limit()) / timeline->get_zoom_scale()) + timeline->get_value();
 
 		Vector2 key_pos = Vector2(animation->track_get_key_time(track, moving_handle_key), animation->bezier_track_get_key_value(track, moving_handle_key));
@@ -1023,7 +1023,7 @@ void AnimationBezierTrackEdit::_menu_selected(int p_index) {
 			Array new_point;
 			new_point.resize(5);
 
-			float h = (get_size().height / 2 - menu_insert_key.y) * v_zoom + v_scroll;
+			float h = (get_rect_size().height / 2 - menu_insert_key.y) * v_zoom + v_scroll;
 
 			new_point[0] = h;
 			new_point[1] = -0.25;
@@ -1174,7 +1174,7 @@ AnimationBezierTrackEdit::AnimationBezierTrackEdit() {
 	v_zoom = 1;
 
 	panning_timeline = false;
-	set_clip_contents(true);
+	set_rect_clip_contents(true);
 	handle_mode = HANDLE_MODE_FREE;
 	handle_mode_option = memnew(OptionButton);
 	add_child(handle_mode_option);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1351,7 +1351,7 @@ int AnimationTimelineEdit::get_name_limit() const {
 
 	int limit = MAX(name_limit, add_track->get_minimum_size().width + hsize_icon->get_width());
 
-	limit = MIN(limit, get_size().width - get_buttons_width() - 1);
+	limit = MIN(limit, get_rect_size().width - get_buttons_width() - 1);
 
 	return limit;
 }
@@ -1372,12 +1372,12 @@ void AnimationTimelineEdit::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_RESIZED) {
-		len_hb->set_position(Vector2(get_size().width - get_buttons_width(), 0));
-		len_hb->set_size(Size2(get_buttons_width(), get_size().height));
+		len_hb->set_rect_position(Vector2(get_rect_size().width - get_buttons_width(), 0));
+		len_hb->set_rect_size(Size2(get_buttons_width(), get_rect_size().height));
 	}
 
 	if (p_what == NOTIFICATION_DRAW) {
-		int key_range = get_size().width - get_buttons_width() - get_name_limit();
+		int key_range = get_rect_size().width - get_buttons_width() - get_name_limit();
 
 		if (!animation.is_valid()) {
 			return;
@@ -1389,7 +1389,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 
 		int zoomw = key_range;
 		float scale = get_zoom_scale();
-		int h = get_size().height;
+		int h = get_rect_size().height;
 
 		float l = animation->get_length();
 		if (l <= 0) {
@@ -1397,7 +1397,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 		}
 
 		Ref<Texture2D> hsize_icon = get_theme_icon("Hsize", "EditorIcons");
-		hsize_rect = Rect2(get_name_limit() - hsize_icon->get_width() - 2 * EDSCALE, (get_size().height - hsize_icon->get_height()) / 2, hsize_icon->get_width(), hsize_icon->get_height());
+		hsize_rect = Rect2(get_name_limit() - hsize_icon->get_width() - 2 * EDSCALE, (get_rect_size().height - hsize_icon->get_height()) / 2, hsize_icon->get_width(), hsize_icon->get_height());
 		draw_texture(hsize_icon, hsize_rect.position);
 
 		{
@@ -1549,7 +1549,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			}
 		}
 
-		draw_line(Vector2(0, get_size().height), get_size(), linecolor, Math::round(EDSCALE));
+		draw_line(Vector2(0, get_rect_size().height), get_rect_size(), linecolor, Math::round(EDSCALE));
 	}
 }
 
@@ -1626,11 +1626,11 @@ void AnimationTimelineEdit::_play_position_draw() {
 	}
 
 	float scale = get_zoom_scale();
-	int h = play_position->get_size().height;
+	int h = play_position->get_rect_size().height;
 
 	int px = (-get_value() + play_position_pos) * scale + get_name_limit();
 
-	if (px >= get_name_limit() && px < (play_position->get_size().width - get_buttons_width())) {
+	if (px >= get_name_limit() && px < (play_position->get_rect_size().width - get_buttons_width())) {
 		Color color = get_theme_color("accent_color", "Editor");
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 		play_position->draw_texture(
@@ -1654,7 +1654,7 @@ void AnimationTimelineEdit::_gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT && dragging_hsize) {
 		dragging_hsize = false;
 	}
-	if (mb.is_valid() && mb->get_position().x > get_name_limit() && mb->get_position().x < (get_size().width - get_buttons_width())) {
+	if (mb.is_valid() && mb->get_position().x > get_name_limit() && mb->get_position().x < (get_rect_size().width - get_buttons_width())) {
 		if (!panning_timeline && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 			int x = mb->get_position().x - get_name_limit();
 
@@ -1683,9 +1683,9 @@ void AnimationTimelineEdit::_gui_input(const Ref<InputEvent> &p_event) {
 	if (mm.is_valid()) {
 		if (hsize_rect.has_point(mm->get_position())) {
 			// Change the cursor to indicate that the track name column's width can be adjusted
-			set_default_cursor_shape(Control::CURSOR_HSIZE);
+			set_mouse_default_cursor_shape(Control::CURSOR_HSIZE);
 		} else {
-			set_default_cursor_shape(Control::CURSOR_ARROW);
+			set_mouse_default_cursor_shape(Control::CURSOR_ARROW);
 		}
 
 		if (dragging_hsize) {
@@ -1751,17 +1751,17 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	play_position->connect("draw", callable_mp(this, &AnimationTimelineEdit::_play_position_draw));
 
 	add_track = memnew(MenuButton);
-	add_track->set_position(Vector2(0, 0));
+	add_track->set_rect_position(Vector2(0, 0));
 	add_child(add_track);
 	add_track->set_text(TTR("Add Track"));
 
 	len_hb = memnew(HBoxContainer);
 
 	Control *expander = memnew(Control);
-	expander->set_h_size_flags(SIZE_EXPAND_FILL);
+	expander->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	len_hb->add_child(expander);
 	time_icon = memnew(TextureRect);
-	time_icon->set_v_size_flags(SIZE_SHRINK_CENTER);
+	time_icon->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 	time_icon->set_tooltip(TTR("Animation length (seconds)"));
 	len_hb->add_child(time_icon);
 	length = memnew(EditorSpinSlider);
@@ -1769,7 +1769,7 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	length->set_max(36000);
 	length->set_step(0.001);
 	length->set_allow_greater(true);
-	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
+	length->set_rect_minimum_size(Vector2(70 * EDSCALE, 0));
 	length->set_hide_slider(true);
 	length->set_tooltip(TTR("Animation length (seconds)"));
 	length->connect("value_changed", callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
@@ -1808,7 +1808,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			Color accent = get_theme_color("accent_color", "Editor");
 			accent.a *= 0.7;
 			// Offside so the horizontal sides aren't cutoff.
-			draw_rect(Rect2(Point2(1 * EDSCALE, 0), get_size() - Size2(1 * EDSCALE, 0)), accent, false);
+			draw_rect(Rect2(Point2(1 * EDSCALE, 0), get_rect_size() - Size2(1 * EDSCALE, 0)), accent, false);
 		}
 
 		Ref<Font> font = get_theme_font("font", "Label");
@@ -1833,12 +1833,12 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 			int ofs = in_group ? check->get_width() : 0; //not the best reference for margin but..
 
-			check_rect = Rect2(Point2(ofs, int(get_size().height - check->get_height()) / 2), check->get_size());
+			check_rect = Rect2(Point2(ofs, int(get_rect_size().height - check->get_height()) / 2), check->get_size());
 			draw_texture(check, check_rect.position);
 			ofs += check->get_width() + hsep;
 
 			Ref<Texture2D> type_icon = type_icons[animation->track_get_type(track)];
-			draw_texture(type_icon, Point2(ofs, int(get_size().height - type_icon->get_height()) / 2));
+			draw_texture(type_icon, Point2(ofs, int(get_rect_size().height - type_icon->get_height()) / 2));
 			ofs += type_icon->get_width() + hsep;
 
 			NodePath path = animation->track_get_path(track);
@@ -1867,7 +1867,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			} else if (node) {
 				Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(node, "Node");
 
-				draw_texture(icon, Point2(ofs, int(get_size().height - icon->get_height()) / 2));
+				draw_texture(icon, Point2(ofs, int(get_rect_size().height - icon->get_height()) / 2));
 				icon_cache = icon;
 
 				text = String() + node->get_name() + ":" + path.get_concatenated_subnames();
@@ -1882,22 +1882,22 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 			path_cache = text;
 
-			path_rect = Rect2(ofs, 0, limit - ofs - hsep, get_size().height);
+			path_rect = Rect2(ofs, 0, limit - ofs - hsep, get_rect_size().height);
 
-			Vector2 string_pos = Point2(ofs, (get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size));
+			Vector2 string_pos = Point2(ofs, (get_rect_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size));
 			string_pos = string_pos.floor();
 			draw_string(font, string_pos, text, HALIGN_LEFT, limit - ofs - hsep, font_size, text_color);
 
-			draw_line(Point2(limit, 0), Point2(limit, get_size().height), linecolor, Math::round(EDSCALE));
+			draw_line(Point2(limit, 0), Point2(limit, get_rect_size().height), linecolor, Math::round(EDSCALE));
 		}
 
 		// KEYFRAMES //
 
-		draw_bg(limit, get_size().width - timeline->get_buttons_width());
+		draw_bg(limit, get_rect_size().width - timeline->get_buttons_width());
 
 		{
 			float scale = timeline->get_zoom_scale();
-			int limit_end = get_size().width - timeline->get_buttons_width();
+			int limit_end = get_rect_size().width - timeline->get_buttons_width();
 
 			for (int i = 0; i < animation->track_get_key_count(track); i++) {
 				float offset = animation->track_get_key_time(track, i) - timeline->get_value();
@@ -1919,7 +1919,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			}
 		}
 
-		draw_fg(limit, get_size().width - timeline->get_buttons_width());
+		draw_fg(limit, get_rect_size().width - timeline->get_buttons_width());
 
 		// BUTTONS //
 
@@ -1941,11 +1941,11 @@ void AnimationTrackEdit::_notification(int p_what) {
 				get_theme_icon("TrackCapture", "EditorIcons")
 			};
 
-			int ofs = get_size().width - timeline->get_buttons_width();
+			int ofs = get_rect_size().width - timeline->get_buttons_width();
 
 			Ref<Texture2D> down_icon = get_theme_icon("select_arrow", "Tree");
 
-			draw_line(Point2(ofs, 0), Point2(ofs, get_size().height), linecolor, Math::round(EDSCALE));
+			draw_line(Point2(ofs, 0), Point2(ofs, get_rect_size().height), linecolor, Math::round(EDSCALE));
 
 			ofs += hsep;
 			{
@@ -1962,7 +1962,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				Ref<Texture2D> update_icon = cont_icon[update_mode];
 
 				update_mode_rect.position.x = ofs;
-				update_mode_rect.position.y = int(get_size().height - update_icon->get_height()) / 2;
+				update_mode_rect.position.y = int(get_rect_size().height - update_icon->get_height()) / 2;
 				update_mode_rect.size = update_icon->get_size();
 
 				if (animation->track_get_type(track) == Animation::TYPE_VALUE) {
@@ -1970,13 +1970,13 @@ void AnimationTrackEdit::_notification(int p_what) {
 				}
 				//make it easier to click
 				update_mode_rect.position.y = 0;
-				update_mode_rect.size.y = get_size().height;
+				update_mode_rect.size.y = get_rect_size().height;
 
 				ofs += update_icon->get_width() + hsep;
 				update_mode_rect.size.x += hsep;
 
 				if (animation->track_get_type(track) == Animation::TYPE_VALUE) {
-					draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
+					draw_texture(down_icon, Vector2(ofs, int(get_rect_size().height - down_icon->get_height()) / 2));
 					update_mode_rect.size.x += down_icon->get_width();
 					bezier_edit_rect = Rect2();
 				} else if (animation->track_get_type(track) == Animation::TYPE_BEZIER) {
@@ -1992,7 +1992,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				}
 
 				ofs += down_icon->get_width();
-				draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_size().height), linecolor, Math::round(EDSCALE));
+				draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_rect_size().height), linecolor, Math::round(EDSCALE));
 				ofs += hsep;
 			}
 
@@ -2004,7 +2004,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				Ref<Texture2D> icon = interp_icon[interp_mode];
 
 				interp_mode_rect.position.x = ofs;
-				interp_mode_rect.position.y = int(get_size().height - icon->get_height()) / 2;
+				interp_mode_rect.position.y = int(get_rect_size().height - icon->get_height()) / 2;
 				interp_mode_rect.size = icon->get_size();
 
 				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM) {
@@ -2012,20 +2012,20 @@ void AnimationTrackEdit::_notification(int p_what) {
 				}
 				//make it easier to click
 				interp_mode_rect.position.y = 0;
-				interp_mode_rect.size.y = get_size().height;
+				interp_mode_rect.size.y = get_rect_size().height;
 
 				ofs += icon->get_width() + hsep;
 				interp_mode_rect.size.x += hsep;
 
 				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM) {
-					draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
+					draw_texture(down_icon, Vector2(ofs, int(get_rect_size().height - down_icon->get_height()) / 2));
 					interp_mode_rect.size.x += down_icon->get_width();
 				} else {
 					interp_mode_rect = Rect2();
 				}
 
 				ofs += down_icon->get_width();
-				draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_size().height), linecolor, Math::round(EDSCALE));
+				draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_rect_size().height), linecolor, Math::round(EDSCALE));
 				ofs += hsep;
 			}
 
@@ -2037,7 +2037,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				Ref<Texture2D> icon = wrap_icon[loop_wrap ? 1 : 0];
 
 				loop_mode_rect.position.x = ofs;
-				loop_mode_rect.position.y = int(get_size().height - icon->get_height()) / 2;
+				loop_mode_rect.position.y = int(get_rect_size().height - icon->get_height()) / 2;
 				loop_mode_rect.size = icon->get_size();
 
 				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM) {
@@ -2045,20 +2045,20 @@ void AnimationTrackEdit::_notification(int p_what) {
 				}
 
 				loop_mode_rect.position.y = 0;
-				loop_mode_rect.size.y = get_size().height;
+				loop_mode_rect.size.y = get_rect_size().height;
 
 				ofs += icon->get_width() + hsep;
 				loop_mode_rect.size.x += hsep;
 
 				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM) {
-					draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
+					draw_texture(down_icon, Vector2(ofs, int(get_rect_size().height - down_icon->get_height()) / 2));
 					loop_mode_rect.size.x += down_icon->get_width();
 				} else {
 					loop_mode_rect = Rect2();
 				}
 
 				ofs += down_icon->get_width();
-				draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_size().height), linecolor, Math::round(EDSCALE));
+				draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_rect_size().height), linecolor, Math::round(EDSCALE));
 				ofs += hsep;
 			}
 
@@ -2067,8 +2067,8 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				Ref<Texture2D> icon = get_theme_icon("Remove", "EditorIcons");
 
-				remove_rect.position.x = ofs + ((get_size().width - ofs) - icon->get_width()) / 2;
-				remove_rect.position.y = int(get_size().height - icon->get_height()) / 2;
+				remove_rect.position.x = ofs + ((get_rect_size().width - ofs) - icon->get_width()) / 2;
+				remove_rect.position.y = int(get_rect_size().height - icon->get_height()) / 2;
 				remove_rect.size = icon->get_size();
 
 				draw_texture(icon, remove_rect.position);
@@ -2076,17 +2076,17 @@ void AnimationTrackEdit::_notification(int p_what) {
 		}
 
 		if (in_group) {
-			draw_line(Vector2(timeline->get_name_limit(), get_size().height), get_size(), linecolor, Math::round(EDSCALE));
+			draw_line(Vector2(timeline->get_name_limit(), get_rect_size().height), get_rect_size(), linecolor, Math::round(EDSCALE));
 		} else {
-			draw_line(Vector2(0, get_size().height), get_size(), linecolor, Math::round(EDSCALE));
+			draw_line(Vector2(0, get_rect_size().height), get_rect_size(), linecolor, Math::round(EDSCALE));
 		}
 
 		if (dropping_at != 0) {
 			Color drop_color = get_theme_color("accent_color", "Editor");
 			if (dropping_at < 0) {
-				draw_line(Vector2(0, 0), Vector2(get_size().width, 0), drop_color, Math::round(EDSCALE));
+				draw_line(Vector2(0, 0), Vector2(get_rect_size().width, 0), drop_color, Math::round(EDSCALE));
 			} else {
-				draw_line(Vector2(0, get_size().height), get_size(), drop_color, Math::round(EDSCALE));
+				draw_line(Vector2(0, get_rect_size().height), get_rect_size(), drop_color, Math::round(EDSCALE));
 			}
 		}
 	}
@@ -2108,7 +2108,7 @@ Rect2 AnimationTrackEdit::get_key_rect(int p_index, float p_pixels_sec) {
 	if (!animation.is_valid()) {
 		return Rect2();
 	}
-	Rect2 rect = Rect2(-type_icon->get_width() / 2, 0, type_icon->get_width(), get_size().height);
+	Rect2 rect = Rect2(-type_icon->get_width() / 2, 0, type_icon->get_width(), get_rect_size().height);
 
 	//make it a big easier to click
 	rect.position.x -= rect.size.x * 0.5;
@@ -2140,7 +2140,7 @@ void AnimationTrackEdit::draw_key_link(int p_index, float p_pixels_sec, int p_x,
 	int from_x = MAX(p_x, p_clip_left);
 	int to_x = MIN(p_next_x, p_clip_right);
 
-	draw_line(Point2(from_x + 1, get_size().height / 2), Point2(to_x, get_size().height / 2), color, Math::round(2 * EDSCALE));
+	draw_line(Point2(from_x + 1, get_rect_size().height / 2), Point2(to_x, get_rect_size().height / 2), color, Math::round(2 * EDSCALE));
 }
 
 void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -2163,7 +2163,7 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 		}
 	}
 
-	Vector2 ofs(p_x - icon_to_draw->get_width() / 2, int(get_size().height - icon_to_draw->get_height()) / 2);
+	Vector2 ofs(p_x - icon_to_draw->get_width() / 2, int(get_rect_size().height - icon_to_draw->get_height()) / 2);
 
 	if (animation->track_get_type(track) == Animation::TYPE_METHOD) {
 		Ref<Font> font = get_theme_font("font", "Label");
@@ -2192,7 +2192,7 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 
 		int limit = MAX(0, p_clip_right - p_x - icon_to_draw->get_width());
 		if (limit > 0) {
-			draw_string(font, Vector2(p_x + icon_to_draw->get_width(), int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), text, HALIGN_LEFT, limit, font_size, color);
+			draw_string(font, Vector2(p_x + icon_to_draw->get_width(), int(get_rect_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), text, HALIGN_LEFT, limit, font_size, color);
 		}
 	}
 
@@ -2202,7 +2202,7 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 //helper
 void AnimationTrackEdit::draw_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled) {
 	int clip_left = timeline->get_name_limit();
-	int clip_right = get_size().width - timeline->get_buttons_width();
+	int clip_right = get_rect_size().width - timeline->get_buttons_width();
 
 	if (p_rect.position.x > clip_right) {
 		return;
@@ -2210,7 +2210,7 @@ void AnimationTrackEdit::draw_rect_clipped(const Rect2 &p_rect, const Color &p_c
 	if (p_rect.position.x + p_rect.size.x < clip_left) {
 		return;
 	}
-	Rect2 clip = Rect2(clip_left, 0, clip_right - clip_left, get_size().height);
+	Rect2 clip = Rect2(clip_left, 0, clip_right - clip_left, get_rect_size().height);
 	draw_rect(clip.intersection(p_rect), p_color, p_filled);
 }
 
@@ -2222,7 +2222,7 @@ void AnimationTrackEdit::draw_fg(int p_clip_left, int p_clip_right) {
 
 void AnimationTrackEdit::draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region) {
 	int clip_left = timeline->get_name_limit();
-	int clip_right = get_size().width - timeline->get_buttons_width();
+	int clip_right = get_rect_size().width - timeline->get_buttons_width();
 
 	//clip left and right
 	if (clip_left > p_rect.position.x + p_rect.size.x) {
@@ -2322,11 +2322,11 @@ void AnimationTrackEdit::_play_position_draw() {
 	}
 
 	float scale = timeline->get_zoom_scale();
-	int h = get_size().height;
+	int h = get_rect_size().height;
 
 	int px = (-timeline->get_value() + play_position_pos) * scale + timeline->get_name_limit();
 
-	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
+	if (px >= timeline->get_name_limit() && px < (get_rect_size().width - timeline->get_buttons_width())) {
 		Color color = get_theme_color("accent_color", "Editor");
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 	}
@@ -2409,7 +2409,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 	}
 
 	int limit = timeline->get_name_limit();
-	int limit_end = get_size().width - timeline->get_buttons_width();
+	int limit_end = get_rect_size().width - timeline->get_buttons_width();
 	// Left Border including space occupied by keyframes on t=0.
 	int limit_start_hitbox = limit - type_icon->get_width();
 
@@ -2631,7 +2631,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 
 		float scale = timeline->get_zoom_scale();
 		int limit = timeline->get_name_limit();
-		int limit_end = get_size().width - timeline->get_buttons_width();
+		int limit_end = get_rect_size().width - timeline->get_buttons_width();
 		// Left Border including space occupied by keyframes on t=0.
 		int limit_start_hitbox = limit - type_icon->get_width();
 
@@ -2689,7 +2689,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_RIGHT) {
 		Point2 pos = mb->get_position();
-		if (pos.x >= timeline->get_name_limit() && pos.x <= get_size().width - timeline->get_buttons_width()) {
+		if (pos.x >= timeline->get_name_limit() && pos.x <= get_rect_size().width - timeline->get_buttons_width()) {
 			// Can do something with menu too! show insert key.
 			float offset = (pos.x - timeline->get_name_limit()) / timeline->get_zoom_scale();
 			if (!menu) {
@@ -2812,7 +2812,7 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 		}
 	}
 
-	if (p_point.y < get_size().height / 2) {
+	if (p_point.y < get_rect_size().height / 2) {
 		dropping_at = -1;
 	} else {
 		dropping_at = 1;
@@ -2916,7 +2916,7 @@ void AnimationTrackEdit::set_in_group(bool p_enable) {
 void AnimationTrackEdit::append_to_selection(const Rect2 &p_box, bool p_deselection) {
 	// Left Border including space occupied by keyframes on t=0.
 	int limit_start_hitbox = timeline->get_name_limit() - type_icon->get_width();
-	Rect2 select_rect(limit_start_hitbox, 0, get_size().width - timeline->get_name_limit() - timeline->get_buttons_width(), get_size().height);
+	Rect2 select_rect(limit_start_hitbox, 0, get_rect_size().width - timeline->get_name_limit() - timeline->get_buttons_width(), get_rect_size().height);
 	select_rect = select_rect.intersection(p_box);
 
 	// Select should happen in the opposite order of drawing for more accurate overlap select.
@@ -3043,24 +3043,24 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 
 		Color bgcol = get_theme_color("dark_color_2", "Editor");
 		bgcol.a *= 0.6;
-		draw_rect(Rect2(Point2(), get_size()), bgcol);
+		draw_rect(Rect2(Point2(), get_rect_size()), bgcol);
 		Color linecolor = color;
 		linecolor.a = 0.2;
 
-		draw_line(Point2(), Point2(get_size().width, 0), linecolor, Math::round(EDSCALE));
-		draw_line(Point2(timeline->get_name_limit(), 0), Point2(timeline->get_name_limit(), get_size().height), linecolor, Math::round(EDSCALE));
-		draw_line(Point2(get_size().width - timeline->get_buttons_width(), 0), Point2(get_size().width - timeline->get_buttons_width(), get_size().height), linecolor, Math::round(EDSCALE));
+		draw_line(Point2(), Point2(get_rect_size().width, 0), linecolor, Math::round(EDSCALE));
+		draw_line(Point2(timeline->get_name_limit(), 0), Point2(timeline->get_name_limit(), get_rect_size().height), linecolor, Math::round(EDSCALE));
+		draw_line(Point2(get_rect_size().width - timeline->get_buttons_width(), 0), Point2(get_rect_size().width - timeline->get_buttons_width(), get_rect_size().height), linecolor, Math::round(EDSCALE));
 
 		int ofs = 0;
-		draw_texture(icon, Point2(ofs, int(get_size().height - icon->get_height()) / 2));
+		draw_texture(icon, Point2(ofs, int(get_rect_size().height - icon->get_height()) / 2));
 		ofs += separation + icon->get_width();
-		draw_string(font, Point2(ofs, int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), node_name, HALIGN_LEFT, timeline->get_name_limit() - ofs, font_size, color);
+		draw_string(font, Point2(ofs, int(get_rect_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), node_name, HALIGN_LEFT, timeline->get_name_limit() - ofs, font_size, color);
 
 		int px = (-timeline->get_value() + timeline->get_play_position()) * timeline->get_zoom_scale() + timeline->get_name_limit();
 
-		if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
+		if (px >= timeline->get_name_limit() && px < (get_rect_size().width - timeline->get_buttons_width())) {
 			Color accent = get_theme_color("accent_color", "Editor");
-			draw_line(Point2(px, 0), Point2(px, get_size().height), accent, Math::round(2 * EDSCALE));
+			draw_line(Point2(px, 0), Point2(px, get_rect_size().height), accent, Math::round(2 * EDSCALE));
 		}
 	}
 }
@@ -4951,7 +4951,7 @@ float AnimationTrackEditor::get_moving_selection_offset() const {
 }
 
 void AnimationTrackEditor::_box_selection_draw() {
-	const Rect2 selection_rect = Rect2(Point2(), box_selection->get_size());
+	const Rect2 selection_rect = Rect2(Point2(), box_selection->get_rect_size());
 	box_selection->draw_rect(selection_rect, get_theme_color("box_selection_fill_color", "Editor"));
 	box_selection->draw_rect(selection_rect, get_theme_color("box_selection_stroke_color", "Editor"), false, Math::round(EDSCALE));
 }
@@ -4979,7 +4979,7 @@ void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 				//only if moved
 				for (int i = 0; i < track_edits.size(); i++) {
 					Rect2 local_rect = box_select_rect;
-					local_rect.position -= track_edits[i]->get_global_position();
+					local_rect.position -= track_edits[i]->get_rect_global_position();
 					track_edits[i]->append_to_selection(local_rect, mb->get_command());
 				}
 
@@ -5028,10 +5028,10 @@ void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 		}
 
 		Rect2 rect(from, to - from);
-		Rect2 scroll_rect = Rect2(scroll->get_global_position(), scroll->get_size());
+		Rect2 scroll_rect = Rect2(scroll->get_rect_global_position(), scroll->get_rect_size());
 		rect = scroll_rect.intersection(rect);
-		box_selection->set_position(rect.position);
-		box_selection->set_size(rect.size);
+		box_selection->set_rect_position(rect.position);
+		box_selection->set_rect_size(rect.size);
 
 		box_select_rect = rect;
 	}
@@ -5713,15 +5713,15 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	main_panel = memnew(PanelContainer);
 	main_panel->set_focus_mode(FOCUS_ALL); // allow panel to have focus so that shortcuts work as expected.
 	add_child(main_panel);
-	main_panel->set_v_size_flags(SIZE_EXPAND_FILL);
+	main_panel->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	HBoxContainer *timeline_scroll = memnew(HBoxContainer);
 	main_panel->add_child(timeline_scroll);
-	timeline_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	timeline_scroll->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	VBoxContainer *timeline_vbox = memnew(VBoxContainer);
 	timeline_scroll->add_child(timeline_vbox);
-	timeline_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
-	timeline_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	timeline_vbox->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	timeline_vbox->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	timeline_vbox->add_theme_constant_override("separation", 0);
 
 	info_message = memnew(Label);
@@ -5729,7 +5729,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	info_message->set_valign(Label::VALIGN_CENTER);
 	info_message->set_align(Label::ALIGN_CENTER);
 	info_message->set_autowrap(true);
-	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	info_message->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_offsets_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	main_panel->add_child(info_message);
 
@@ -5744,7 +5744,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	scroll = memnew(ScrollContainer);
 	timeline_vbox->add_child(scroll);
-	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	scroll->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	VScrollBar *sb = scroll->get_v_scrollbar();
 	scroll->remove_child(sb);
 	timeline_scroll->add_child(sb); //move here so timeline and tracks are always aligned
@@ -5756,10 +5756,10 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bezier_edit->set_editor(this);
 	bezier_edit->set_timeline(timeline);
 	bezier_edit->hide();
-	bezier_edit->set_v_size_flags(SIZE_EXPAND_FILL);
+	bezier_edit->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	bezier_edit->connect("close_request", callable_mp(this, &AnimationTrackEditor::_cancel_bezier_edit));
 
-	timeline_vbox->set_custom_minimum_size(Size2(0, 150) * EDSCALE);
+	timeline_vbox->set_rect_minimum_size(Size2(0, 150) * EDSCALE);
 
 	hscroll = memnew(HScrollBar);
 	hscroll->share(timeline);
@@ -5770,7 +5770,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	track_vbox = memnew(VBoxContainer);
 	scroll->add_child(track_vbox);
-	track_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	track_vbox->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	scroll->set_enable_h_scroll(false);
 	scroll->set_enable_v_scroll(true);
 	track_vbox->add_theme_constant_override("separation", 0);
@@ -5816,7 +5816,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	step->set_max(1000000);
 	step->set_step(0.001);
 	step->set_hide_slider(true);
-	step->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
+	step->set_rect_minimum_size(Size2(100, 0) * EDSCALE);
 	step->set_tooltip(TTR("Animation step value."));
 	bottom_hb->add_child(step);
 	step->connect("value_changed", callable_mp(this, &AnimationTrackEditor::_update_step));
@@ -5832,15 +5832,15 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bottom_hb->add_child(memnew(VSeparator));
 
 	zoom_icon = memnew(TextureRect);
-	zoom_icon->set_v_size_flags(SIZE_SHRINK_CENTER);
+	zoom_icon->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 	bottom_hb->add_child(zoom_icon);
 	zoom = memnew(HSlider);
 	zoom->set_step(0.01);
 	zoom->set_min(0.0);
 	zoom->set_max(2.0);
 	zoom->set_value(1.0);
-	zoom->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
-	zoom->set_v_size_flags(SIZE_SHRINK_CENTER);
+	zoom->set_rect_minimum_size(Size2(200, 0) * EDSCALE);
+	zoom->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 	bottom_hb->add_child(zoom);
 	timeline->set_zoom(zoom);
 
@@ -6014,8 +6014,8 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	track_vbox->add_child(select_all_button);
 
 	track_copy_select = memnew(Tree);
-	track_copy_select->set_h_size_flags(SIZE_EXPAND_FILL);
-	track_copy_select->set_v_size_flags(SIZE_EXPAND_FILL);
+	track_copy_select->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	track_copy_select->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	track_copy_select->set_hide_root(true);
 	track_vbox->add_child(track_copy_select);
 	track_copy_dialog->connect("confirmed", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed), varray(EDIT_COPY_TRACKS_CONFIRM));

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -48,7 +48,7 @@ int AnimationTrackEditBool::get_key_height() const {
 
 Rect2 AnimationTrackEditBool::get_key_rect(int p_index, float p_pixels_sec) {
 	Ref<Texture2D> checked = get_theme_icon("checked", "CheckBox");
-	return Rect2(-checked->get_width() / 2, 0, checked->get_width(), get_size().height);
+	return Rect2(-checked->get_width() / 2, 0, checked->get_width(), get_rect_size().height);
 }
 
 bool AnimationTrackEditBool::is_key_selectable_by_distance() const {
@@ -59,7 +59,7 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 	bool checked = get_animation()->track_get_key_value(get_track(), p_index);
 	Ref<Texture2D> icon = get_theme_icon(checked ? "checked" : "unchecked", "CheckBox");
 
-	Vector2 ofs(p_x - icon->get_width() / 2, int(get_size().height - icon->get_height()) / 2);
+	Vector2 ofs(p_x - icon->get_width() / 2, int(get_rect_size().height - icon->get_height()) / 2);
 
 	if (ofs.x + icon->get_width() / 2 < p_clip_left) {
 		return;
@@ -89,7 +89,7 @@ Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
 	Ref<Font> font = get_theme_font("font", "Label");
 	int font_size = get_theme_font_size("font_size", "Label");
 	int fh = font->get_height(font_size) * 0.8;
-	return Rect2(-fh / 2, 0, fh, get_size().height);
+	return Rect2(-fh / 2, 0, fh, get_rect_size().height);
 }
 
 bool AnimationTrackEditColor::is_key_selectable_by_distance() const {
@@ -108,7 +108,7 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 	x_from = MAX(x_from, p_clip_left);
 	x_to = MIN(x_to, p_clip_right);
 
-	int y_from = (get_size().height - fh) / 2;
+	int y_from = (get_rect_size().height - fh) / 2;
 
 	if (x_from > p_clip_right || x_to < p_clip_left) {
 		return;
@@ -171,7 +171,7 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 	int font_size = get_theme_font_size("font_size", "Label");
 	int fh = font->get_height(font_size) * 0.8;
 
-	Rect2 rect(Vector2(p_x - fh / 2, int(get_size().height - fh) / 2), Size2(fh, fh));
+	Rect2 rect(Vector2(p_x - fh / 2, int(get_rect_size().height - fh) / 2), Size2(fh, fh));
 
 	draw_rect_clipped(Rect2(rect.position, rect.size / 2), Color(0.4, 0.4, 0.4));
 	draw_rect_clipped(Rect2(rect.position + rect.size / 2, rect.size / 2), Color(0.4, 0.4, 0.4));
@@ -237,12 +237,12 @@ Rect2 AnimationTrackEditAudio::get_key_rect(int p_index, float p_pixels_sec) {
 			len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
 		}
 
-		return Rect2(0, 0, len * p_pixels_sec, get_size().height);
+		return Rect2(0, 0, len * p_pixels_sec, get_rect_size().height);
 	} else {
 		Ref<Font> font = get_theme_font("font", "Label");
 		int font_size = get_theme_font_size("font_size", "Label");
 		int fh = font->get_height(font_size) * 0.8;
-		return Rect2(0, 0, fh, get_size().height);
+		return Rect2(0, 0, fh, get_rect_size().height);
 	}
 }
 
@@ -306,7 +306,7 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 		Ref<Font> font = get_theme_font("font", "Label");
 		int font_size = get_theme_font_size("font_size", "Label");
 		float fh = int(font->get_height(font_size) * 1.5);
-		Rect2 rect = Rect2(from_x, (get_size().height - fh) / 2, to_x - from_x, fh);
+		Rect2 rect = Rect2(from_x, (get_rect_size().height - fh) / 2, to_x - from_x, fh);
 		draw_rect(rect, Color(0.25, 0.25, 0.25));
 
 		Vector<Vector2> lines;
@@ -337,7 +337,7 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 		Ref<Font> font = get_theme_font("font", "Label");
 		int font_size = get_theme_font_size("font_size", "Label");
 		int fh = font->get_height(font_size) * 0.8;
-		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
+		Rect2 rect(Vector2(p_x, int(get_rect_size().height - fh) / 2), Size2(fh, fh));
 
 		Color color = get_theme_color("font_color", "Label");
 		draw_rect(rect, color);
@@ -440,7 +440,7 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 	int height = int(font->get_height(font_size) * 2);
 	int width = height * size.width / size.height;
 
-	return Rect2(0, 0, width, get_size().height);
+	return Rect2(0, 0, width, get_rect_size().height);
 }
 
 bool AnimationTrackEditSpriteFrame::is_key_selectable_by_distance() const {
@@ -532,7 +532,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 
 	int width = height * region.size.width / region.size.height;
 
-	Rect2 rect(p_x, int(get_size().height - height) / 2, width, height);
+	Rect2 rect(p_x, int(get_rect_size().height - height) / 2, width, height);
 
 	if (rect.position.x + rect.size.x < p_clip_left) {
 		return;
@@ -597,12 +597,12 @@ Rect2 AnimationTrackEditSubAnim::get_key_rect(int p_index, float p_pixels_sec) {
 			len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
 		}
 
-		return Rect2(0, 0, len * p_pixels_sec, get_size().height);
+		return Rect2(0, 0, len * p_pixels_sec, get_rect_size().height);
 	} else {
 		Ref<Font> font = get_theme_font("font", "Label");
 		int font_size = get_theme_font_size("font_size", "Label");
 		int fh = font->get_height(font_size) * 0.8;
-		return Rect2(0, 0, fh, get_size().height);
+		return Rect2(0, 0, fh, get_rect_size().height);
 	}
 }
 
@@ -658,7 +658,7 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 		int font_size = get_theme_font_size("font_size", "Label");
 		int fh = font->get_height(font_size) * 1.5;
 
-		Rect2 rect(from_x, int(get_size().height - fh) / 2, to_x - from_x, fh);
+		Rect2 rect(from_x, int(get_rect_size().height - fh) / 2, to_x - from_x, fh);
 
 		Color color = get_theme_color("font_color", "Label");
 		Color bg = color;
@@ -699,7 +699,7 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 
 		int limit = to_x - from_x - 4;
 		if (limit > 0) {
-			draw_string(font, Point2(from_x + 2, int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), anim, HALIGN_LEFT, -1, font_size, color);
+			draw_string(font, Point2(from_x + 2, int(get_rect_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), anim, HALIGN_LEFT, -1, font_size, color);
 		}
 
 		if (p_selected) {
@@ -710,7 +710,7 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 		Ref<Font> font = get_theme_font("font", "Label");
 		int font_size = get_theme_font_size("font_size", "Label");
 		int fh = font->get_height(font_size) * 0.8;
-		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
+		Rect2 rect(Vector2(p_x, int(get_rect_size().height - fh) / 2), Size2(fh, fh));
 
 		Color color = get_theme_color("font_color", "Label");
 		draw_rect(rect, color);
@@ -737,7 +737,7 @@ void AnimationTrackEditVolumeDB::draw_bg(int p_clip_left, int p_clip_right) {
 	Ref<Texture2D> volume_texture = get_theme_icon("ColorTrackVu", "EditorIcons");
 	int tex_h = volume_texture->get_height();
 
-	int y_from = (get_size().height - tex_h) / 2;
+	int y_from = (get_rect_size().height - tex_h) / 2;
 	int y_size = tex_h;
 
 	Color color(1, 1, 1, 0.3);
@@ -747,7 +747,7 @@ void AnimationTrackEditVolumeDB::draw_bg(int p_clip_left, int p_clip_right) {
 void AnimationTrackEditVolumeDB::draw_fg(int p_clip_left, int p_clip_right) {
 	Ref<Texture2D> volume_texture = get_theme_icon("ColorTrackVu", "EditorIcons");
 	int tex_h = volume_texture->get_height();
-	int y_from = (get_size().height - tex_h) / 2;
+	int y_from = (get_rect_size().height - tex_h) / 2;
 	int db0 = y_from + (24 / 80.0) * tex_h;
 
 	draw_line(Vector2(p_clip_left, db0), Vector2(p_clip_right, db0), Color(1, 1, 1, 0.3));
@@ -783,7 +783,7 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 	Ref<Texture2D> volume_texture = get_theme_icon("ColorTrackVu", "EditorIcons");
 	int tex_h = volume_texture->get_height();
 
-	int y_from = (get_size().height - tex_h) / 2;
+	int y_from = (get_rect_size().height - tex_h) / 2;
 
 	Color color = get_theme_color("font_color", "Label");
 	color.a *= 0.7;
@@ -838,7 +838,7 @@ Rect2 AnimationTrackEditTypeAudio::get_key_rect(int p_index, float p_pixels_sec)
 		len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
 	}
 
-	return Rect2(0, 0, len * p_pixels_sec, get_size().height);
+	return Rect2(0, 0, len * p_pixels_sec, get_rect_size().height);
 }
 
 bool AnimationTrackEditTypeAudio::is_key_selectable_by_distance() const {
@@ -920,7 +920,7 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 		to_x = from_x + 1;
 	}
 
-	int h = get_size().height;
+	int h = get_rect_size().height;
 	Rect2 rect = Rect2(from_x, (h - fh) / 2, to_x - from_x, fh);
 	draw_rect(rect, Color(0.25, 0.25, 0.25));
 
@@ -971,7 +971,7 @@ AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
 }
 
 bool AnimationTrackEditTypeAudio::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
-	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
+	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_rect_size().width - get_timeline()->get_buttons_width()) {
 		Dictionary drag_data = p_data;
 		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
 			Ref<AudioStream> res = drag_data["resource"];
@@ -997,7 +997,7 @@ bool AnimationTrackEditTypeAudio::can_drop_data(const Point2 &p_point, const Var
 }
 
 void AnimationTrackEditTypeAudio::drop_data(const Point2 &p_point, const Variant &p_data) {
-	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
+	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_rect_size().width - get_timeline()->get_buttons_width()) {
 		Ref<AudioStream> stream;
 		Dictionary drag_data = p_data;
 		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
@@ -1076,16 +1076,16 @@ void AnimationTrackEditTypeAudio::_gui_input(const Ref<InputEvent> &p_event) {
 
 			int end = ofs + len * get_timeline()->get_zoom_scale();
 
-			if (end >= get_timeline()->get_name_limit() && end <= get_size().width - get_timeline()->get_buttons_width() && ABS(mm->get_position().x - end) < 5 * EDSCALE) {
+			if (end >= get_timeline()->get_name_limit() && end <= get_rect_size().width - get_timeline()->get_buttons_width() && ABS(mm->get_position().x - end) < 5 * EDSCALE) {
 				use_hsize_cursor = true;
 				len_resizing_index = i;
 			}
 		}
 
 		if (use_hsize_cursor) {
-			set_default_cursor_shape(CURSOR_HSIZE);
+			set_mouse_default_cursor_shape(CURSOR_HSIZE);
 		} else {
-			set_default_cursor_shape(CURSOR_ARROW);
+			set_mouse_default_cursor_shape(CURSOR_ARROW);
 		}
 	}
 
@@ -1098,7 +1098,7 @@ void AnimationTrackEditTypeAudio::_gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT && get_default_cursor_shape() == CURSOR_HSIZE) {
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT && get_mouse_default_cursor_shape() == CURSOR_HSIZE) {
 		len_resizing = true;
 		len_resizing_start = mb->get_shift();
 		len_resizing_from_px = mb->get_position().x;
@@ -1170,12 +1170,12 @@ Rect2 AnimationTrackEditTypeAnimation::get_key_rect(int p_index, float p_pixels_
 			len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
 		}
 
-		return Rect2(0, 0, len * p_pixels_sec, get_size().height);
+		return Rect2(0, 0, len * p_pixels_sec, get_rect_size().height);
 	} else {
 		Ref<Font> font = get_theme_font("font", "Label");
 		int font_size = get_theme_font_size("font_size", "Label");
 		int fh = font->get_height(font_size) * 0.8;
-		return Rect2(0, 0, fh, get_size().height);
+		return Rect2(0, 0, fh, get_rect_size().height);
 	}
 }
 
@@ -1231,7 +1231,7 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 		int font_size = get_theme_font_size("font_size", "Label");
 		int fh = font->get_height(font_size) * 1.5;
 
-		Rect2 rect(from_x, int(get_size().height - fh) / 2, to_x - from_x, fh);
+		Rect2 rect(from_x, int(get_rect_size().height - fh) / 2, to_x - from_x, fh);
 
 		Color color = get_theme_color("font_color", "Label");
 		Color bg = color;
@@ -1272,7 +1272,7 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 
 		int limit = to_x - from_x - 4;
 		if (limit > 0) {
-			draw_string(font, Point2(from_x + 2, int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), anim, HALIGN_LEFT, -1, font_size, color);
+			draw_string(font, Point2(from_x + 2, int(get_rect_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), anim, HALIGN_LEFT, -1, font_size, color);
 		}
 
 		if (p_selected) {
@@ -1283,7 +1283,7 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 		Ref<Font> font = get_theme_font("font", "Label");
 		int font_size = get_theme_font_size("font_size", "Label");
 		int fh = font->get_height(font_size) * 0.8;
-		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
+		Rect2 rect(Vector2(p_x, int(get_rect_size().height - fh) / 2), Size2(fh, fh));
 
 		Color color = get_theme_color("font_color", "Label");
 		draw_rect(rect, color);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -93,7 +93,7 @@ void FindReplaceBar::_notification(int p_what) {
 		hide_button->set_normal_texture(get_theme_icon("Close", "EditorIcons"));
 		hide_button->set_hover_texture(get_theme_icon("Close", "EditorIcons"));
 		hide_button->set_pressed_texture(get_theme_icon("Close", "EditorIcons"));
-		hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
+		hide_button->set_rect_minimum_size(hide_button->get_normal_texture()->get_size());
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 		set_process_unhandled_input(is_visible_in_tree());
 	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
@@ -102,7 +102,7 @@ void FindReplaceBar::_notification(int p_what) {
 		hide_button->set_normal_texture(get_theme_icon("Close", "EditorIcons"));
 		hide_button->set_hover_texture(get_theme_icon("Close", "EditorIcons"));
 		hide_button->set_pressed_texture(get_theme_icon("Close", "EditorIcons"));
-		hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
+		hide_button->set_rect_minimum_size(hide_button->get_normal_texture()->get_size());
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
 		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color("font_color", "Label") : get_theme_color("error_color", "Editor"));
 	}
@@ -606,7 +606,7 @@ FindReplaceBar::FindReplaceBar() {
 	vbc_lineedit = memnew(VBoxContainer);
 	add_child(vbc_lineedit);
 	vbc_lineedit->set_alignment(ALIGN_CENTER);
-	vbc_lineedit->set_h_size_flags(SIZE_EXPAND_FILL);
+	vbc_lineedit->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	VBoxContainer *vbc_button = memnew(VBoxContainer);
 	add_child(vbc_button);
 	VBoxContainer *vbc_option = memnew(VBoxContainer);
@@ -627,7 +627,7 @@ FindReplaceBar::FindReplaceBar() {
 	// search toolbar
 	search_text = memnew(LineEdit);
 	vbc_lineedit->add_child(search_text);
-	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	search_text->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 	search_text->connect("text_changed", callable_mp(this, &FindReplaceBar::_search_text_changed));
 	search_text->connect("text_entered", callable_mp(this, &FindReplaceBar::_search_text_entered));
 
@@ -662,7 +662,7 @@ FindReplaceBar::FindReplaceBar() {
 	// replace toolbar
 	replace_text = memnew(LineEdit);
 	vbc_lineedit->add_child(replace_text);
-	replace_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	replace_text->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 	replace_text->connect("text_entered", callable_mp(this, &FindReplaceBar::_replace_text_entered));
 
 	replace = memnew(Button);
@@ -685,7 +685,7 @@ FindReplaceBar::FindReplaceBar() {
 	add_child(hide_button);
 	hide_button->set_focus_mode(FOCUS_NONE);
 	hide_button->connect("pressed", callable_mp(this, &FindReplaceBar::_hide_bar));
-	hide_button->set_v_size_flags(SIZE_SHRINK_CENTER);
+	hide_button->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 }
 
 /*** CODE EDITOR ****/
@@ -1455,9 +1455,9 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 void CodeTextEditor::set_error(const String &p_error) {
 	error->set_text(p_error);
 	if (p_error != "") {
-		error->set_default_cursor_shape(CURSOR_POINTING_HAND);
+		error->set_mouse_default_cursor_shape(CURSOR_POINTING_HAND);
 	} else {
-		error->set_default_cursor_shape(CURSOR_ARROW);
+		error->set_mouse_default_cursor_shape(CURSOR_ARROW);
 	}
 }
 
@@ -1708,7 +1708,7 @@ CodeTextEditor::CodeTextEditor() {
 
 	text_editor = memnew(CodeEdit);
 	add_child(text_editor);
-	text_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	text_editor->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	int ot_mode = EditorSettings::get_singleton()->get("interface/editor/code_font_contextual_ligatures");
 	switch (ot_mode) {
@@ -1738,7 +1738,7 @@ CodeTextEditor::CodeTextEditor() {
 	// Added second so it opens at the bottom, so it won't shift the entire text editor when opening.
 	find_replace_bar = memnew(FindReplaceBar);
 	add_child(find_replace_bar);
-	find_replace_bar->set_h_size_flags(SIZE_EXPAND_FILL);
+	find_replace_bar->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	find_replace_bar->hide();
 
 	find_replace_bar->set_text_edit(text_editor);
@@ -1749,8 +1749,8 @@ CodeTextEditor::CodeTextEditor() {
 
 	status_bar = memnew(HBoxContainer);
 	add_child(status_bar);
-	status_bar->set_h_size_flags(SIZE_EXPAND_FILL);
-	status_bar->set_custom_minimum_size(Size2(0, 24 * EDSCALE)); // Adjust for the height of the warning icon.
+	status_bar->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	status_bar->set_rect_minimum_size(Size2(0, 24 * EDSCALE)); // Adjust for the height of the warning icon.
 
 	idle = memnew(Timer);
 	add_child(idle);
@@ -1773,14 +1773,14 @@ CodeTextEditor::CodeTextEditor() {
 
 	// Error
 	ScrollContainer *scroll = memnew(ScrollContainer);
-	scroll->set_h_size_flags(SIZE_EXPAND_FILL);
-	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	scroll->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	scroll->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	scroll->set_enable_v_scroll(false);
 	status_bar->add_child(scroll);
 
 	error = memnew(Label);
 	scroll->add_child(error);
-	error->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
+	error->set_size_flags_vertical(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	error->set_mouse_filter(MOUSE_FILTER_STOP);
 	error->connect("gui_input", callable_mp(this, &CodeTextEditor::_error_pressed));
 	find_replace_bar->connect("error", callable_mp(error, &Label::set_text));
@@ -1789,16 +1789,16 @@ CodeTextEditor::CodeTextEditor() {
 	warning_button = memnew(Button);
 	warning_button->set_flat(true);
 	status_bar->add_child(warning_button);
-	warning_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
-	warning_button->set_default_cursor_shape(CURSOR_POINTING_HAND);
+	warning_button->set_size_flags_vertical(SIZE_EXPAND | SIZE_SHRINK_CENTER);
+	warning_button->set_mouse_default_cursor_shape(CURSOR_POINTING_HAND);
 	warning_button->connect("pressed", callable_mp(this, &CodeTextEditor::_warning_button_pressed));
 	warning_button->set_tooltip(TTR("Warnings"));
 
 	warning_count_label = memnew(Label);
 	status_bar->add_child(warning_count_label);
-	warning_count_label->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
+	warning_count_label->set_size_flags_vertical(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	warning_count_label->set_align(Label::ALIGN_RIGHT);
-	warning_count_label->set_default_cursor_shape(CURSOR_POINTING_HAND);
+	warning_count_label->set_mouse_default_cursor_shape(CURSOR_POINTING_HAND);
 	warning_count_label->set_mouse_filter(MOUSE_FILTER_STOP);
 	warning_count_label->set_tooltip(TTR("Warnings"));
 	warning_count_label->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("warning_color", "Editor"));
@@ -1812,7 +1812,7 @@ CodeTextEditor::CodeTextEditor() {
 	// Line and column
 	line_and_col_txt = memnew(Label);
 	status_bar->add_child(line_and_col_txt);
-	line_and_col_txt->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
+	line_and_col_txt->set_size_flags_vertical(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	line_and_col_txt->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
 	line_and_col_txt->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
 	line_and_col_txt->set_tooltip(TTR("Line and column numbers."));

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -399,11 +399,11 @@ ConnectDialog::ConnectDialog() {
 
 	HBoxContainer *main_hb = memnew(HBoxContainer);
 	vbc->add_child(main_hb);
-	main_hb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_hb->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	VBoxContainer *vbc_left = memnew(VBoxContainer);
 	main_hb->add_child(vbc_left);
-	vbc_left->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbc_left->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	from_signal = memnew(LineEdit);
 	from_signal->set_editable(false);
@@ -426,13 +426,13 @@ ConnectDialog::ConnectDialog() {
 
 	vbc_right = memnew(VBoxContainer);
 	main_hb->add_child(vbc_right);
-	vbc_right->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbc_right->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	vbc_right->hide();
 
 	HBoxContainer *add_bind_hb = memnew(HBoxContainer);
 
 	type_list = memnew(OptionButton);
-	type_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	type_list->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	add_bind_hb->add_child(type_list);
 	type_list->add_item("bool", Variant::BOOL);
 	type_list->add_item("int", Variant::INT);
@@ -470,7 +470,7 @@ ConnectDialog::ConnectDialog() {
 	vbc_left->add_margin_child(TTR("Receiver Method:"), dstm_hb);
 
 	dst_method = memnew(LineEdit);
-	dst_method->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	dst_method->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	dst_method->connect("text_entered", callable_mp(this, &ConnectDialog::_text_entered));
 	dstm_hb->add_child(dst_method);
 
@@ -480,13 +480,13 @@ ConnectDialog::ConnectDialog() {
 	advanced->connect("pressed", callable_mp(this, &ConnectDialog::_advanced_pressed));
 
 	deferred = memnew(CheckBox);
-	deferred->set_h_size_flags(0);
+	deferred->set_size_flags_horizontal(0);
 	deferred->set_text(TTR("Deferred"));
 	deferred->set_tooltip(TTR("Defers the signal, storing it in a queue and only firing it at idle time."));
 	vbc_right->add_child(deferred);
 
 	oneshot = memnew(CheckBox);
-	oneshot->set_h_size_flags(0);
+	oneshot->set_size_flags_horizontal(0);
 	oneshot->set_text(TTR("Oneshot"));
 	oneshot->set_tooltip(TTR("Disconnects the signal after its first emission."));
 	vbc_right->add_child(oneshot);
@@ -838,7 +838,7 @@ void ConnectionsDock::_rmb_pressed(Vector2 position) {
 		return;
 	}
 
-	Vector2 global_position = tree->get_global_position() + position;
+	Vector2 global_position = tree->get_rect_global_position() + position;
 
 	if (_is_item_signal(*item)) {
 		signal_menu->set_position(global_position);
@@ -1081,7 +1081,7 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	VBoxContainer *vbc = this;
 
 	search_box = memnew(LineEdit);
-	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	search_box->set_placeholder(TTR("Filter signals"));
 	search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
 	search_box->set_clear_button_enabled(true);
@@ -1093,7 +1093,7 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	tree->set_select_mode(Tree::SELECT_ROW);
 	tree->set_hide_root(true);
 	vbc->add_child(tree);
-	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tree->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	tree->set_allow_rmb_select(true);
 
 	connect_button = memnew(Button);

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -665,8 +665,8 @@ CreateDialog::CreateDialog() {
 	hsc->add_child(vsc);
 
 	VBoxContainer *fav_vb = memnew(VBoxContainer);
-	fav_vb->set_custom_minimum_size(Size2(150, 100) * EDSCALE);
-	fav_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	fav_vb->set_rect_minimum_size(Size2(150, 100) * EDSCALE);
+	fav_vb->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	vsc->add_child(fav_vb);
 
 	favorites = memnew(Tree);
@@ -684,8 +684,8 @@ CreateDialog::CreateDialog() {
 
 	VBoxContainer *rec_vb = memnew(VBoxContainer);
 	vsc->add_child(rec_vb);
-	rec_vb->set_custom_minimum_size(Size2(150, 100) * EDSCALE);
-	rec_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	rec_vb->set_rect_minimum_size(Size2(150, 100) * EDSCALE);
+	rec_vb->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	recent = memnew(ItemList);
 	rec_vb->add_margin_child(TTR("Recent:"), recent, true);
@@ -695,12 +695,12 @@ CreateDialog::CreateDialog() {
 	recent->add_theme_constant_override("draw_guides", 1);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
-	vbc->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
-	vbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbc->set_rect_minimum_size(Size2(300, 0) * EDSCALE);
+	vbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	hsc->add_child(vbc);
 
 	search_box = memnew(LineEdit);
-	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	search_box->connect("text_changed", callable_mp(this, &CreateDialog::_text_changed));
 	search_box->connect("gui_input", callable_mp(this, &CreateDialog::_sbox_input));
 

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -36,7 +36,7 @@
 #include "servers/display_server.h"
 
 EditorDebuggerTree::EditorDebuggerTree() {
-	set_v_size_flags(SIZE_EXPAND_FILL);
+	set_size_flags_vertical(SIZE_EXPAND_FILL);
 	set_allow_rmb_select(true);
 
 	// Popup

--- a/editor/debugger/editor_network_profiler.cpp
+++ b/editor/debugger/editor_network_profiler.cpp
@@ -148,12 +148,12 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 
 	incoming_bandwidth_text = memnew(LineEdit);
 	incoming_bandwidth_text->set_editable(false);
-	incoming_bandwidth_text->set_custom_minimum_size(Size2(120, 0) * EDSCALE);
+	incoming_bandwidth_text->set_rect_minimum_size(Size2(120, 0) * EDSCALE);
 	incoming_bandwidth_text->set_align(LineEdit::Align::ALIGN_RIGHT);
 	hb->add_child(incoming_bandwidth_text);
 
 	Control *down_up_spacer = memnew(Control);
-	down_up_spacer->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
+	down_up_spacer->set_rect_minimum_size(Size2(30, 0) * EDSCALE);
 	hb->add_child(down_up_spacer);
 
 	lb = memnew(Label);
@@ -162,7 +162,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 
 	outgoing_bandwidth_text = memnew(LineEdit);
 	outgoing_bandwidth_text->set_editable(false);
-	outgoing_bandwidth_text->set_custom_minimum_size(Size2(120, 0) * EDSCALE);
+	outgoing_bandwidth_text->set_rect_minimum_size(Size2(120, 0) * EDSCALE);
 	outgoing_bandwidth_text->set_align(LineEdit::Align::ALIGN_RIGHT);
 	hb->add_child(outgoing_bandwidth_text);
 
@@ -170,8 +170,8 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	set_bandwidth(0, 0);
 
 	counters_display = memnew(Tree);
-	counters_display->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
-	counters_display->set_v_size_flags(SIZE_EXPAND_FILL);
+	counters_display->set_rect_minimum_size(Size2(300, 0) * EDSCALE);
+	counters_display->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	counters_display->set_hide_folding(true);
 	counters_display->set_hide_root(true);
 	counters_display->set_columns(5);

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -118,7 +118,7 @@ void EditorPerformanceProfiler::_monitor_draw() {
 	if (active.size() == 1) {
 		rows = 1;
 	}
-	Size2i cell_size = Size2i(monitor_draw->get_size()) / Size2i(columns, rows);
+	Size2i cell_size = Size2i(monitor_draw->get_rect_size()) / Size2i(columns, rows);
 	float spacing = float(POINT_SEPARATION) / float(columns);
 	float value_multiplier = EditorSettings::get_singleton()->is_dark_theme() ? 1.4f : 0.55f;
 	float hue_shift = 1.0f / float(monitors.size());
@@ -262,7 +262,7 @@ void EditorPerformanceProfiler::_marker_input(const Ref<InputEvent> &p_event) {
 			if (active.size() == 1) {
 				rows = 1;
 			}
-			Size2i cell_size = Size2i(monitor_draw->get_size()) / Size2i(columns, rows);
+			Size2i cell_size = Size2i(monitor_draw->get_rect_size()) / Size2i(columns, rows);
 			Vector2i index = mb->get_position() / cell_size;
 			Rect2i rect(index * cell_size + Point2i(MARGIN, MARGIN), cell_size - Point2i(MARGIN, MARGIN) * 2);
 			if (rect.has_point(mb->get_position())) {
@@ -371,7 +371,7 @@ EditorPerformanceProfiler::EditorPerformanceProfiler() {
 	add_child(monitor_tree);
 
 	monitor_draw = memnew(Control);
-	monitor_draw->set_clip_contents(true);
+	monitor_draw->set_rect_clip_contents(true);
 	monitor_draw->connect("draw", callable_mp(this, &EditorPerformanceProfiler::_monitor_draw));
 	monitor_draw->connect("gui_input", callable_mp(this, &EditorPerformanceProfiler::_marker_input));
 	add_child(monitor_draw);
@@ -381,7 +381,7 @@ EditorPerformanceProfiler::EditorPerformanceProfiler() {
 	info_message->set_valign(Label::VALIGN_CENTER);
 	info_message->set_align(Label::ALIGN_CENTER);
 	info_message->set_autowrap(true);
-	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	info_message->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_offsets_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	monitor_draw->add_child(info_message);
 

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -169,8 +169,8 @@ void EditorProfiler::_item_edited() {
 }
 
 void EditorProfiler::_update_plot() {
-	const int w = graph->get_size().width;
-	const int h = graph->get_size().height;
+	const int w = graph->get_rect_size().width;
+	const int h = graph->get_rect_size().height;
 	bool reset_texture = false;
 	const int desired_len = w * h * 4;
 
@@ -405,12 +405,12 @@ void EditorProfiler::_graph_tex_draw() {
 	}
 	if (seeking) {
 		int frame = cursor_metric_edit->get_value() - _get_frame_metric(0).frame_number;
-		int cur_x = (2 * frame + 1) * graph->get_size().x / (2 * frame_metrics.size()) + 1;
-		graph->draw_line(Vector2(cur_x, 0), Vector2(cur_x, graph->get_size().y), Color(1, 1, 1, 0.8));
+		int cur_x = (2 * frame + 1) * graph->get_rect_size().x / (2 * frame_metrics.size()) + 1;
+		graph->draw_line(Vector2(cur_x, 0), Vector2(cur_x, graph->get_rect_size().y), Color(1, 1, 1, 0.8));
 	}
 	if (hover_metric > -1 && hover_metric < total_metrics) {
-		int cur_x = (2 * hover_metric + 1) * graph->get_size().x / (2 * frame_metrics.size()) + 1;
-		graph->draw_line(Vector2(cur_x, 0), Vector2(cur_x, graph->get_size().y), Color(1, 1, 1, 0.4));
+		int cur_x = (2 * hover_metric + 1) * graph->get_rect_size().x / (2 * frame_metrics.size()) + 1;
+		graph->draw_line(Vector2(cur_x, 0), Vector2(cur_x, graph->get_rect_size().y), Color(1, 1, 1, 0.4));
 	}
 }
 
@@ -441,7 +441,7 @@ void EditorProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 			(mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_LEFT && mb->is_pressed()) ||
 			(mm.is_valid())) {
 		int x = me->get_position().x - 1;
-		x = x * frame_metrics.size() / graph->get_size().width;
+		x = x * frame_metrics.size() / graph->get_rect_size().width;
 
 		hover_metric = x;
 
@@ -595,7 +595,7 @@ EditorProfiler::EditorProfiler() {
 	hb->add_child(memnew(Label(TTR("Frame #:"))));
 
 	cursor_metric_edit = memnew(SpinBox);
-	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
+	cursor_metric_edit->set_size_flags_horizontal(SIZE_FILL);
 	cursor_metric_edit->set_value(0);
 	cursor_metric_edit->set_editable(false);
 	hb->add_child(cursor_metric_edit);
@@ -605,10 +605,10 @@ EditorProfiler::EditorProfiler() {
 
 	h_split = memnew(HSplitContainer);
 	add_child(h_split);
-	h_split->set_v_size_flags(SIZE_EXPAND_FILL);
+	h_split->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	variables = memnew(Tree);
-	variables->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
+	variables->set_rect_minimum_size(Size2(320, 0) * EDSCALE);
 	variables->set_hide_folding(true);
 	h_split->add_child(variables);
 	variables->set_hide_root(true);
@@ -633,7 +633,7 @@ EditorProfiler::EditorProfiler() {
 	graph->connect("mouse_exited", callable_mp(this, &EditorProfiler::_graph_tex_mouse_exit));
 
 	h_split->add_child(graph);
-	graph->set_h_size_flags(SIZE_EXPAND_FILL);
+	graph->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	int metric_size = CLAMP(int(EDITOR_DEF("debugger/profiler_frame_history_size", 600)), 60, 1024);
 	frame_metrics.resize(metric_size);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -144,8 +144,8 @@ void EditorVisualProfiler::_item_selected() {
 }
 
 void EditorVisualProfiler::_update_plot() {
-	int w = graph->get_size().width;
-	int h = graph->get_size().height;
+	int w = graph->get_rect_size().width;
+	int h = graph->get_rect_size().height;
 
 	bool reset_texture = false;
 
@@ -446,18 +446,18 @@ void EditorVisualProfiler::_graph_tex_draw() {
 			frame = 0;
 		}
 
-		int half_width = graph->get_size().x / 2;
+		int half_width = graph->get_rect_size().x / 2;
 		int cur_x = frame * half_width / max_frames;
 		//cur_x /= 2.0;
 
-		graph->draw_line(Vector2(cur_x, 0), Vector2(cur_x, graph->get_size().y), Color(1, 1, 1, 0.8));
-		graph->draw_line(Vector2(cur_x + half_width, 0), Vector2(cur_x + half_width, graph->get_size().y), Color(1, 1, 1, 0.8));
+		graph->draw_line(Vector2(cur_x, 0), Vector2(cur_x, graph->get_rect_size().y), Color(1, 1, 1, 0.8));
+		graph->draw_line(Vector2(cur_x + half_width, 0), Vector2(cur_x + half_width, graph->get_rect_size().y), Color(1, 1, 1, 0.8));
 	}
 
 	if (graph_height_cpu > 0) {
-		int frame_y = graph->get_size().y - graph_limit * graph->get_size().y / graph_height_cpu - 1;
+		int frame_y = graph->get_rect_size().y - graph_limit * graph->get_rect_size().y / graph_height_cpu - 1;
 
-		int half_width = graph->get_size().x / 2;
+		int half_width = graph->get_rect_size().x / 2;
 
 		graph->draw_line(Vector2(0, frame_y), Vector2(half_width, frame_y), Color(1, 1, 1, 0.3));
 
@@ -466,18 +466,18 @@ void EditorVisualProfiler::_graph_tex_draw() {
 	}
 
 	if (graph_height_gpu > 0) {
-		int frame_y = graph->get_size().y - graph_limit * graph->get_size().y / graph_height_gpu - 1;
+		int frame_y = graph->get_rect_size().y - graph_limit * graph->get_rect_size().y / graph_height_gpu - 1;
 
-		int half_width = graph->get_size().x / 2;
+		int half_width = graph->get_rect_size().x / 2;
 
-		graph->draw_line(Vector2(half_width, frame_y), Vector2(graph->get_size().x, frame_y), Color(1, 1, 1, 0.3));
+		graph->draw_line(Vector2(half_width, frame_y), Vector2(graph->get_rect_size().x, frame_y), Color(1, 1, 1, 0.3));
 
 		String limit_str = String::num(graph_limit, 2);
 		graph->draw_string(font, Vector2(half_width * 2 - font->get_string_size(limit_str, font_size).x - 2, frame_y - 2), limit_str, HALIGN_LEFT, -1, font_size, Color(1, 1, 1, 0.6));
 	}
 
 	graph->draw_string(font, Vector2(font->get_string_size("X", font_size).x, font->get_ascent(font_size) + 2), "CPU:", HALIGN_LEFT, -1, font_size, Color(1, 1, 1, 0.8));
-	graph->draw_string(font, Vector2(font->get_string_size("X", font_size).x + graph->get_size().width / 2, font->get_ascent(font_size) + 2), "GPU:", HALIGN_LEFT, -1, font_size, Color(1, 1, 1, 0.8));
+	graph->draw_string(font, Vector2(font->get_string_size("X", font_size).x + graph->get_rect_size().width / 2, font->get_ascent(font_size) + 2), "GPU:", HALIGN_LEFT, -1, font_size, Color(1, 1, 1, 0.8));
 
 	/*
 	if (hover_metric != -1 && frame_metrics[hover_metric].valid) {
@@ -519,7 +519,7 @@ void EditorVisualProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 	if (
 			(mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_LEFT && mb->is_pressed()) ||
 			(mm.is_valid())) {
-		int half_w = graph->get_size().width / 2;
+		int half_w = graph->get_rect_size().width / 2;
 		int x = me->get_position().x;
 		if (x > half_w) {
 			x -= half_w;
@@ -588,11 +588,11 @@ void EditorVisualProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 				frame_delay->start();
 			}
 
-			bool touched_cpu = me->get_position().x < graph->get_size().width * 0.5;
+			bool touched_cpu = me->get_position().x < graph->get_rect_size().width * 0.5;
 
 			const Metric::Area *areas = frame_metrics[metric].areas.ptr();
 			int area_count = frame_metrics[metric].areas.size();
-			float posy = (1.0 - (me->get_position().y / graph->get_size().height)) * (touched_cpu ? graph_height_cpu : graph_height_gpu);
+			float posy = (1.0 - (me->get_position().y / graph->get_rect_size().height)) * (touched_cpu ? graph_height_cpu : graph_height_gpu);
 			int last_valid = -1;
 			bool found = false;
 			for (int i = 0; i < area_count - 1; i++) {
@@ -754,7 +754,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	hb->add_child(memnew(Label(TTR("Frame #:"))));
 
 	cursor_metric_edit = memnew(SpinBox);
-	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
+	cursor_metric_edit->set_size_flags_horizontal(SIZE_FILL);
 	hb->add_child(cursor_metric_edit);
 	cursor_metric_edit->connect("value_changed", callable_mp(this, &EditorVisualProfiler::_cursor_metric_changed));
 
@@ -762,10 +762,10 @@ EditorVisualProfiler::EditorVisualProfiler() {
 
 	h_split = memnew(HSplitContainer);
 	add_child(h_split);
-	h_split->set_v_size_flags(SIZE_EXPAND_FILL);
+	h_split->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	variables = memnew(Tree);
-	variables->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
+	variables->set_rect_minimum_size(Size2(300, 0) * EDSCALE);
 	variables->set_hide_folding(true);
 	h_split->add_child(variables);
 	variables->set_hide_root(true);
@@ -791,7 +791,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	graph->connect("mouse_exited", callable_mp(this, &EditorVisualProfiler::_graph_tex_mouse_exit));
 
 	h_split->add_child(graph);
-	graph->set_h_size_flags(SIZE_EXPAND_FILL);
+	graph->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	int metric_size = CLAMP(int(EDITOR_DEF("debugger/profiler_frame_history_size", 600)), 60, 1024);
 	frame_metrics.resize(metric_size);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1378,7 +1378,7 @@ void ScriptEditorDebugger::_error_tree_item_rmb_selected(const Vector2 &p_pos) {
 	}
 
 	if (item_menu->get_item_count() > 0) {
-		item_menu->set_position(error_tree->get_global_position() + p_pos);
+		item_menu->set_position(error_tree->get_rect_global_position() + p_pos);
 		item_menu->popup();
 	}
 }
@@ -1534,7 +1534,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		reason = memnew(Label);
 		reason->set_text("");
 		hbc->add_child(reason);
-		reason->set_h_size_flags(SIZE_EXPAND_FILL);
+		reason->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		reason->set_autowrap(true);
 		reason->set_max_lines_visible(3);
 		reason->set_mouse_filter(Control::MOUSE_FILTER_PASS);
@@ -1589,20 +1589,20 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 		HSplitContainer *sc = memnew(HSplitContainer);
 		vbc->add_child(sc);
-		sc->set_v_size_flags(SIZE_EXPAND_FILL);
+		sc->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 		stack_dump = memnew(Tree);
 		stack_dump->set_allow_reselect(true);
 		stack_dump->set_columns(1);
 		stack_dump->set_column_titles_visible(true);
 		stack_dump->set_column_title(0, TTR("Stack Frames"));
-		stack_dump->set_h_size_flags(SIZE_EXPAND_FILL);
+		stack_dump->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		stack_dump->set_hide_root(true);
 		stack_dump->connect("cell_selected", callable_mp(this, &ScriptEditorDebugger::_stack_dump_frame_selected));
 		sc->add_child(stack_dump);
 
 		inspector = memnew(EditorDebuggerInspector);
-		inspector->set_h_size_flags(SIZE_EXPAND_FILL);
+		inspector->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		inspector->set_enable_capitalize_paths(false);
 		inspector->set_read_only(true);
 		inspector->connect("object_selected", callable_mp(this, &ScriptEditorDebugger::_remote_object_selected));
@@ -1630,12 +1630,12 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		errhb->add_child(collapse_all);
 
 		Control *space = memnew(Control);
-		space->set_h_size_flags(SIZE_EXPAND_FILL);
+		space->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		errhb->add_child(space);
 
 		clearbutton = memnew(Button);
 		clearbutton->set_text(TTR("Clear"));
-		clearbutton->set_h_size_flags(0);
+		clearbutton->set_size_flags_horizontal(0);
 		clearbutton->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_clear_errors_list));
 		errhb->add_child(clearbutton);
 
@@ -1649,7 +1649,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 		error_tree->set_select_mode(Tree::SELECT_ROW);
 		error_tree->set_hide_root(true);
-		error_tree->set_v_size_flags(SIZE_EXPAND_FILL);
+		error_tree->set_size_flags_vertical(SIZE_EXPAND_FILL);
 		error_tree->set_allow_rmb_select(true);
 		error_tree->connect("item_rmb_selected", callable_mp(this, &ScriptEditorDebugger::_error_tree_item_rmb_selected));
 		errors_tab->add_child(error_tree);
@@ -1698,12 +1698,12 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		VBoxContainer *vmem_vb = memnew(VBoxContainer);
 		HBoxContainer *vmem_hb = memnew(HBoxContainer);
 		Label *vmlb = memnew(Label(TTR("List of Video Memory Usage by Resource:") + " "));
-		vmlb->set_h_size_flags(SIZE_EXPAND_FILL);
+		vmlb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		vmem_hb->add_child(vmlb);
 		vmem_hb->add_child(memnew(Label(TTR("Total:") + " ")));
 		vmem_total = memnew(LineEdit);
 		vmem_total->set_editable(false);
-		vmem_total->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
+		vmem_total->set_rect_minimum_size(Size2(100, 0) * EDSCALE);
 		vmem_hb->add_child(vmem_total);
 		vmem_refresh = memnew(Button);
 		vmem_refresh->set_flat(true);
@@ -1718,10 +1718,10 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 		VBoxContainer *vmmc = memnew(VBoxContainer);
 		vmem_tree = memnew(Tree);
-		vmem_tree->set_v_size_flags(SIZE_EXPAND_FILL);
-		vmem_tree->set_h_size_flags(SIZE_EXPAND_FILL);
+		vmem_tree->set_size_flags_vertical(SIZE_EXPAND_FILL);
+		vmem_tree->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		vmmc->add_child(vmem_tree);
-		vmmc->set_v_size_flags(SIZE_EXPAND_FILL);
+		vmmc->set_size_flags_vertical(SIZE_EXPAND_FILL);
 		vmem_vb->add_child(vmmc);
 
 		vmem_vb->set_name(TTR("Video RAM"));
@@ -1752,7 +1752,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		info_left->set_columns(2);
 		misc->add_child(info_left);
 		clicked_ctrl = memnew(LineEdit);
-		clicked_ctrl->set_h_size_flags(SIZE_EXPAND_FILL);
+		clicked_ctrl->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		info_left->add_child(memnew(Label(TTR("Clicked Control:"))));
 		info_left->add_child(clicked_ctrl);
 		clicked_ctrl_type = memnew(LineEdit);
@@ -1761,7 +1761,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 		scene_tree = memnew(SceneDebuggerTree);
 		live_edit_root = memnew(LineEdit);
-		live_edit_root->set_h_size_flags(SIZE_EXPAND_FILL);
+		live_edit_root->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 		{
 			HBoxContainer *lehb = memnew(HBoxContainer);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -241,7 +241,7 @@ DependencyEditor::DependencyEditor() {
 	vb->add_child(hbc);
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	mc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	mc->add_child(tree);
 	vb->add_child(mc);
@@ -262,7 +262,7 @@ void DependencyEditorOwners::_list_rmb_select(int p_item, const Vector2 &p_pos) 
 		file_options->add_item(TTR("Open"), FILE_OPEN);
 	}
 
-	file_options->set_position(owners->get_global_position() + p_pos);
+	file_options->set_position(owners->get_rect_global_position() + p_pos);
 	file_options->popup();
 }
 
@@ -564,7 +564,7 @@ DependencyRemoveDialog::DependencyRemoveDialog() {
 	owners = memnew(Tree);
 	owners->set_hide_root(true);
 	vb->add_child(owners);
-	owners->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	owners->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 }
 
 //////////////
@@ -616,7 +616,7 @@ DependencyErrorDialog::DependencyErrorDialog() {
 	files = memnew(Tree);
 	files->set_hide_root(true);
 	vb->add_margin_child(TTR("Load failed due to missing dependencies:"), files, true);
-	files->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	files->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	set_min_size(Size2(500, 220) * EDSCALE);
 	get_ok_button()->set_text(TTR("Open Anyway"));

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -73,10 +73,10 @@ TextureRect *EditorAbout::get_logo() const {
 ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<String> &p_sections, const char *const *const p_src[], const int p_flag_single_column) {
 	ScrollContainer *sc = memnew(ScrollContainer);
 	sc->set_name(p_name);
-	sc->set_v_size_flags(Control::SIZE_EXPAND);
+	sc->set_size_flags_vertical(Control::SIZE_EXPAND);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
-	vbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	sc->add_child(vbc);
 
 	for (int i = 0; i < p_sections.size(); i++) {
@@ -88,7 +88,7 @@ ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<St
 			vbc->add_child(lbl);
 
 			ItemList *il = memnew(ItemList);
-			il->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			il->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 			il->set_same_column_width(true);
 			il->set_auto_height(true);
 			il->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
@@ -115,7 +115,7 @@ EditorAbout::EditorAbout() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	vbc->connect("theme_changed", callable_mp(this, &EditorAbout::_theme_changed));
 	HBoxContainer *hbc = memnew(HBoxContainer);
-	hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	hbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	hbc->set_alignment(BoxContainer::ALIGN_CENTER);
 	hbc->add_theme_constant_override("separation", 30 * EDSCALE);
 	add_child(vbc);
@@ -130,15 +130,15 @@ EditorAbout::EditorAbout() {
 	}
 
 	Label *about_text = memnew(Label);
-	about_text->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	about_text->set_size_flags_vertical(Control::SIZE_SHRINK_CENTER);
 	about_text->set_text(VERSION_FULL_NAME + hash +
 						 String::utf8("\n\xc2\xa9 2007-2021 Juan Linietsky, Ariel Manzur.\n\xc2\xa9 2014-2021 ") +
 						 TTR("Godot Engine contributors") + "\n");
 	hbc->add_child(about_text);
 
 	TabContainer *tc = memnew(TabContainer);
-	tc->set_custom_minimum_size(Size2(950, 400) * EDSCALE);
-	tc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tc->set_rect_minimum_size(Size2(950, 400) * EDSCALE);
+	tc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	vbc->add_child(tc);
 
 	// Authors
@@ -175,8 +175,8 @@ EditorAbout::EditorAbout() {
 
 	_license_text = memnew(RichTextLabel);
 	_license_text->set_name(TTR("License"));
-	_license_text->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	_license_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	_license_text->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
+	_license_text->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	_license_text->set_text(String::utf8(GODOT_LICENSE_TEXT));
 	tc->add_child(_license_text);
 
@@ -184,19 +184,19 @@ EditorAbout::EditorAbout() {
 
 	VBoxContainer *license_thirdparty = memnew(VBoxContainer);
 	license_thirdparty->set_name(TTR("Third-party Licenses"));
-	license_thirdparty->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	license_thirdparty->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	tc->add_child(license_thirdparty);
 
 	Label *tpl_label = memnew(Label);
-	tpl_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	tpl_label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	tpl_label->set_autowrap(true);
 	tpl_label->set_text(TTR("Godot Engine relies on a number of third-party free and open source libraries, all compatible with the terms of its MIT license. The following is an exhaustive list of all such third-party components with their respective copyright statements and license terms."));
-	tpl_label->set_size(Size2(630, 1) * EDSCALE);
+	tpl_label->set_rect_size(Size2(630, 1) * EDSCALE);
 	license_thirdparty->add_child(tpl_label);
 
 	HSplitContainer *tpl_hbc = memnew(HSplitContainer);
-	tpl_hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	tpl_hbc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tpl_hbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
+	tpl_hbc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	tpl_hbc->set_split_offset(240 * EDSCALE);
 	license_thirdparty->add_child(tpl_hbc);
 
@@ -250,8 +250,8 @@ EditorAbout::EditorAbout() {
 	tpl_hbc->add_child(_tpl_tree);
 
 	_tpl_text = memnew(RichTextLabel);
-	_tpl_text->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	_tpl_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	_tpl_text->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
+	_tpl_text->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	tpl_hbc->add_child(_tpl_text);
 
 	_tpl_tree->connect("item_selected", callable_mp(this, &EditorAbout::_license_tree_selected));

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -91,17 +91,17 @@ void EditorAudioBus::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_DRAW: {
 			if (is_master) {
-				draw_style_box(get_theme_stylebox("disabled", "Button"), Rect2(Vector2(), get_size()));
+				draw_style_box(get_theme_stylebox("disabled", "Button"), Rect2(Vector2(), get_rect_size()));
 			} else if (has_focus()) {
-				draw_style_box(get_theme_stylebox("focus", "Button"), Rect2(Vector2(), get_size()));
+				draw_style_box(get_theme_stylebox("focus", "Button"), Rect2(Vector2(), get_rect_size()));
 			} else {
-				draw_style_box(get_theme_stylebox("panel", "TabContainer"), Rect2(Vector2(), get_size()));
+				draw_style_box(get_theme_stylebox("panel", "TabContainer"), Rect2(Vector2(), get_rect_size()));
 			}
 
 			if (get_index() != 0 && hovering_drop) {
 				Color accent = get_theme_color("accent_color", "Editor");
 				accent.a *= 0.7;
-				draw_rect(Rect2(Point2(), get_size()), accent, false);
+				draw_rect(Rect2(Point2(), get_rect_size()), accent, false);
 			}
 		} break;
 		case NOTIFICATION_PROCESS: {
@@ -383,13 +383,13 @@ void EditorAudioBus::_show_value(float slider_value) {
 
 	slider->set_tooltip(text);
 	audio_value_preview_label->set_text(text);
-	Vector2 slider_size = slider->get_size();
-	Vector2 slider_position = slider->get_global_position();
+	Vector2 slider_size = slider->get_rect_size();
+	Vector2 slider_position = slider->get_rect_global_position();
 	float left_padding = 5.0f;
 	float vert_padding = 10.0f;
 	Vector2 box_position = Vector2(slider_size.x + left_padding, (slider_size.y - vert_padding) * (1.0f - slider->get_value()) - vert_padding);
-	audio_value_preview_box->set_position(slider_position + box_position);
-	audio_value_preview_box->set_size(audio_value_preview_label->get_size());
+	audio_value_preview_box->set_rect_position(slider_position + box_position);
+	audio_value_preview_box->set_rect_size(audio_value_preview_label->get_rect_size());
 	if (slider->has_focus() && !audio_value_preview_box->is_visible()) {
 		audio_value_preview_box->show();
 	}
@@ -487,7 +487,7 @@ void EditorAudioBus::_effect_edited() {
 	if (effect->get_metadata(0) == Variant()) {
 		Rect2 area = effects->get_item_rect(effect);
 
-		effect_options->set_position(effects->get_global_position() + area.position + Vector2(0, area.size.y));
+		effect_options->set_position(effects->get_rect_global_position() + area.position + Vector2(0, area.size.y));
 		effect_options->popup();
 		//add effect
 	} else {
@@ -536,7 +536,7 @@ void EditorAudioBus::_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_RIGHT && mb->is_pressed()) {
 		Vector2 pos = Vector2(mb->get_position().x, mb->get_position().y);
-		bus_popup->set_position(get_global_position() + pos);
+		bus_popup->set_position(get_rect_global_position() + pos);
 		bus_popup->popup();
 	}
 }
@@ -574,8 +574,8 @@ Variant EditorAudioBus::get_drag_data(const Point2 &p_point) {
 	c->add_child(p);
 	p->set_modulate(Color(1, 1, 1, 0.7));
 	p->add_theme_style_override("panel", get_theme_stylebox("focus", "Button"));
-	p->set_size(get_size());
-	p->set_position(-p_point);
+	p->set_rect_size(get_rect_size());
+	p->set_rect_position(-p_point);
 	set_drag_preview(c);
 	Dictionary d;
 	d["type"] = "move_audio_bus";
@@ -767,7 +767,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	VBoxContainer *vb = memnew(VBoxContainer);
 	add_child(vb);
 
-	set_v_size_flags(SIZE_EXPAND_FILL);
+	set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	track_name = memnew(LineEdit);
 	track_name->connect("text_entered", callable_mp(this, &EditorAudioBus::_name_changed));
@@ -818,17 +818,17 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	slider->set_min(0.0);
 	slider->set_max(1.0);
 	slider->set_step(0.0001);
-	slider->set_clip_contents(false);
+	slider->set_rect_clip_contents(false);
 
 	audio_value_preview_box = memnew(Panel);
 	HBoxContainer *audioprev_hbc = memnew(HBoxContainer);
-	audioprev_hbc->set_v_size_flags(SIZE_EXPAND_FILL);
-	audioprev_hbc->set_h_size_flags(SIZE_EXPAND_FILL);
+	audioprev_hbc->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	audioprev_hbc->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	audio_value_preview_box->add_child(audioprev_hbc);
 
 	audio_value_preview_label = memnew(Label);
-	audio_value_preview_label->set_v_size_flags(SIZE_EXPAND_FILL);
-	audio_value_preview_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	audio_value_preview_label->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	audio_value_preview_label->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	audio_value_preview_label->set_mouse_filter(MOUSE_FILTER_PASS);
 
 	audioprev_hbc->add_child(audio_value_preview_label);
@@ -882,9 +882,9 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 
 	effects = memnew(Tree);
 	effects->set_hide_root(true);
-	effects->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
+	effects->set_rect_minimum_size(Size2(0, 80) * EDSCALE);
 	effects->set_hide_folding(true);
-	effects->set_v_size_flags(SIZE_EXPAND_FILL);
+	effects->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	vb->add_child(effects);
 	effects->connect("item_edited", callable_mp(this, &EditorAudioBus::_effect_edited));
 	effects->connect("cell_selected", callable_mp(this, &EditorAudioBus::_effect_selected));
@@ -923,7 +923,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 
 	bus_options = memnew(MenuButton);
 	bus_options->set_shortcut_context(this);
-	bus_options->set_h_size_flags(SIZE_SHRINK_END);
+	bus_options->set_size_flags_horizontal(SIZE_SHRINK_END);
 	bus_options->set_anchor(SIDE_RIGHT, 0.0);
 	bus_options->set_tooltip(TTR("Bus options"));
 	hbc->add_child(bus_options);
@@ -944,12 +944,12 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 void EditorAudioBusDrop::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			draw_style_box(get_theme_stylebox("normal", "Button"), Rect2(Vector2(), get_size()));
+			draw_style_box(get_theme_stylebox("normal", "Button"), Rect2(Vector2(), get_rect_size()));
 
 			if (hovering_drop) {
 				Color accent = get_theme_color("accent_color", "Editor");
 				accent.a *= 0.7;
-				draw_rect(Rect2(Point2(), get_size()), accent, false);
+				draw_rect(Rect2(Point2(), get_rect_size()), accent, false);
 			}
 		} break;
 		case NOTIFICATION_MOUSE_ENTER: {
@@ -1140,7 +1140,7 @@ void EditorAudioBuses::_request_drop_end() {
 		drop_end = memnew(EditorAudioBusDrop);
 
 		bus_hb->add_child(drop_end);
-		drop_end->set_custom_minimum_size(Object::cast_to<Control>(bus_hb->get_child(0))->get_size());
+		drop_end->set_rect_minimum_size(Object::cast_to<Control>(bus_hb->get_child(0))->get_rect_size());
 		drop_end->connect("dropped", callable_mp(this, &EditorAudioBuses::_drop_at_index), varray(), CONNECT_DEFERRED);
 	}
 }
@@ -1262,7 +1262,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	String layout_path = ProjectSettings::get_singleton()->get("audio/buses/default_bus_layout");
 	file->set_text(String(TTR("Layout")) + ": " + layout_path.get_file());
 	file->set_clip_text(true);
-	file->set_h_size_flags(SIZE_EXPAND_FILL);
+	file->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	top_hb->add_child(file);
 
 	add = memnew(Button);
@@ -1299,12 +1299,12 @@ EditorAudioBuses::EditorAudioBuses() {
 	_new->connect("pressed", callable_mp(this, &EditorAudioBuses::_new_layout));
 
 	bus_scroll = memnew(ScrollContainer);
-	bus_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	bus_scroll->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	bus_scroll->set_enable_h_scroll(true);
 	bus_scroll->set_enable_v_scroll(false);
 	add_child(bus_scroll);
 	bus_hb = memnew(HBoxContainer);
-	bus_hb->set_v_size_flags(SIZE_EXPAND_FILL);
+	bus_hb->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	bus_scroll->add_child(bus_hb);
 
 	save_timer = memnew(Timer);
@@ -1313,7 +1313,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	add_child(save_timer);
 	save_timer->connect("timeout", callable_mp(this, &EditorAudioBuses::_server_save));
 
-	set_v_size_flags(SIZE_EXPAND_FILL);
+	set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	edited_path = ProjectSettings::get_singleton()->get("audio/buses/default_bus_layout");
 
@@ -1415,15 +1415,15 @@ void EditorAudioMeterNotches::_draw_audio_notches() {
 
 	for (int i = 0; i < notches.size(); i++) {
 		AudioNotch n = notches[i];
-		draw_line(Vector2(0, (1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + top_padding),
-				Vector2(line_length, (1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + top_padding),
+		draw_line(Vector2(0, (1.0f - n.relative_position) * (get_rect_size().y - btm_padding - top_padding) + top_padding),
+				Vector2(line_length, (1.0f - n.relative_position) * (get_rect_size().y - btm_padding - top_padding) + top_padding),
 				notch_color,
 				1);
 
 		if (n.render_db_value) {
 			draw_string(font,
 					Vector2(line_length + label_space,
-							(1.0f - n.relative_position) * (get_size().y - btm_padding - top_padding) + (font_height / 4) + top_padding),
+							(1.0f - n.relative_position) * (get_rect_size().y - btm_padding - top_padding) + (font_height / 4) + top_padding),
 					String::num(Math::abs(n.db_value)) + "dB",
 					HALIGN_LEFT, -1, font_size,
 					notch_color);

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -836,7 +836,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	autoload_add_path = memnew(LineEdit);
 	hbc->add_child(autoload_add_path);
-	autoload_add_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	autoload_add_path->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	autoload_add_path->connect("text_changed", callable_mp(this, &EditorAutoloadSettings::_autoload_path_text_changed));
 
 	browse_button = memnew(Button);
@@ -849,7 +849,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	file_dialog->connect("dir_selected", callable_mp(this, &EditorAutoloadSettings::_set_autoload_add_path));
 	file_dialog->connect("files_selected", callable_mp(this, &EditorAutoloadSettings::_set_autoload_add_path));
 
-	hbc->set_h_size_flags(SIZE_EXPAND_FILL);
+	hbc->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	file_dialog->connect("file_selected", callable_mp(this, &EditorAutoloadSettings::_autoload_file_callback));
 
@@ -858,7 +858,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	hbc->add_child(l);
 
 	autoload_add_name = memnew(LineEdit);
-	autoload_add_name->set_h_size_flags(SIZE_EXPAND_FILL);
+	autoload_add_name->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	autoload_add_name->connect("text_entered", callable_mp(this, &EditorAutoloadSettings::_autoload_text_entered));
 	autoload_add_name->connect("text_changed", callable_mp(this, &EditorAutoloadSettings::_autoload_text_changed));
 	hbc->add_child(autoload_add_name);
@@ -899,7 +899,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	tree->connect("item_edited", callable_mp(this, &EditorAutoloadSettings::_autoload_edited));
 	tree->connect("button_pressed", callable_mp(this, &EditorAutoloadSettings::_autoload_button_pressed));
 	tree->connect("item_activated", callable_mp(this, &EditorAutoloadSettings::_autoload_activated));
-	tree->set_v_size_flags(SIZE_EXPAND_FILL);
+	tree->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	add_child(tree, true);
 }

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -796,7 +796,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	name_hbc->add_child(current_profile_name);
 	current_profile_name->set_text(TTR("(none)"));
 	current_profile_name->set_editable(false);
-	current_profile_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	current_profile_name->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	profile_actions[PROFILE_CLEAR] = memnew(Button(TTR("Unset")));
 	name_hbc->add_child(profile_actions[PROFILE_CLEAR]);
 	profile_actions[PROFILE_CLEAR]->set_disabled(true);
@@ -806,7 +806,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 
 	HBoxContainer *profiles_hbc = memnew(HBoxContainer);
 	profile_list = memnew(OptionButton);
-	profile_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	profile_list->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	profiles_hbc->add_child(profile_list);
 	profile_list->connect("item_selected", callable_mp(this, &EditorFeatureProfileManager::_profile_selected));
 
@@ -840,12 +840,12 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	main_vbc->add_margin_child(TTR("Available Profiles:"), profiles_hbc);
 
 	h_split = memnew(HSplitContainer);
-	h_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	h_split->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	main_vbc->add_child(h_split);
 
 	class_list_vbc = memnew(VBoxContainer);
 	h_split->add_child(class_list_vbc);
-	class_list_vbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	class_list_vbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	class_list = memnew(Tree);
 	class_list_vbc->add_margin_child(TTR("Enabled Classes:"), class_list, true);
@@ -858,7 +858,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 
 	property_list_vbc = memnew(VBoxContainer);
 	h_split->add_child(property_list_vbc);
-	property_list_vbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	property_list_vbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	property_list = memnew(Tree);
 	property_list_vbc->add_margin_child(TTR("Class Options:"), property_list, true);
@@ -875,14 +875,14 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	sb->set_default_margin(SIDE_TOP, 20 * EDSCALE);
 	no_profile_selected_help->add_theme_style_override("normal", sb);
 	no_profile_selected_help->set_align(Label::ALIGN_CENTER);
-	no_profile_selected_help->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	no_profile_selected_help->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	h_split->add_child(no_profile_selected_help);
 
 	new_profile_dialog = memnew(ConfirmationDialog);
 	new_profile_dialog->set_title(TTR("New profile name:"));
 	new_profile_name = memnew(LineEdit);
 	new_profile_dialog->add_child(new_profile_name);
-	new_profile_name->set_custom_minimum_size(Size2(300 * EDSCALE, 1));
+	new_profile_name->set_rect_minimum_size(Size2(300 * EDSCALE, 1));
 	add_child(new_profile_dialog);
 	new_profile_dialog->connect("confirmed", callable_mp(this, &EditorFeatureProfileManager::_create_new_profile));
 	new_profile_dialog->register_text_enter(new_profile_name);

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -605,7 +605,7 @@ void EditorFileDialog::_item_list_item_rmb_selected(int p_item, const Vector2 &p
 	}
 
 	if (item_menu->get_item_count() > 0) {
-		item_menu->set_position(item_list->get_global_position() + p_pos);
+		item_menu->set_position(item_list->get_rect_global_position() + p_pos);
 		item_menu->popup();
 	}
 }
@@ -626,7 +626,7 @@ void EditorFileDialog::_item_list_rmb_clicked(const Vector2 &p_pos) {
 	item_menu->add_separator();
 	item_menu->add_icon_item(item_list->get_theme_icon("Filesystem", "EditorIcons"), TTR("Open in File Manager"), ITEM_MENU_SHOW_IN_EXPLORER);
 
-	item_menu->set_position(item_list->get_global_position() + p_pos);
+	item_menu->set_position(item_list->get_rect_global_position() + p_pos);
 	item_menu->popup();
 }
 
@@ -1515,7 +1515,7 @@ EditorFileDialog::EditorFileDialog() {
 	dir = memnew(LineEdit);
 	dir->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
 	pathhb->add_child(dir);
-	dir->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	dir->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	refresh = memnew(Button);
 	refresh->set_flat(true);
@@ -1577,15 +1577,15 @@ EditorFileDialog::EditorFileDialog() {
 
 	vbc->add_child(pathhb);
 	vbc->add_child(list_hb);
-	list_hb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	list_hb->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	VSplitContainer *vsc = memnew(VSplitContainer);
 	list_hb->add_child(vsc);
 
 	VBoxContainer *fav_vb = memnew(VBoxContainer);
 	vsc->add_child(fav_vb);
-	fav_vb->set_custom_minimum_size(Size2(150, 100) * EDSCALE);
-	fav_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	fav_vb->set_rect_minimum_size(Size2(150, 100) * EDSCALE);
+	fav_vb->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	HBoxContainer *fav_hb = memnew(HBoxContainer);
 	fav_vb->add_child(fav_hb);
 	fav_hb->add_child(memnew(Label(TTR("Favorites:"))));
@@ -1601,13 +1601,13 @@ EditorFileDialog::EditorFileDialog() {
 
 	favorites = memnew(ItemList);
 	fav_vb->add_child(favorites);
-	favorites->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	favorites->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	favorites->connect("item_selected", callable_mp(this, &EditorFileDialog::_favorite_selected));
 
 	VBoxContainer *rec_vb = memnew(VBoxContainer);
 	vsc->add_child(rec_vb);
-	rec_vb->set_custom_minimum_size(Size2(150, 100) * EDSCALE);
-	rec_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	rec_vb->set_rect_minimum_size(Size2(150, 100) * EDSCALE);
+	rec_vb->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	recent = memnew(ItemList);
 	recent->set_allow_reselect(true);
 	rec_vb->add_margin_child(TTR("Recent:"), recent, true);
@@ -1615,21 +1615,21 @@ EditorFileDialog::EditorFileDialog() {
 
 	VBoxContainer *item_vb = memnew(VBoxContainer);
 	list_hb->add_child(item_vb);
-	item_vb->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
+	item_vb->set_rect_minimum_size(Size2(320, 0) * EDSCALE);
 
 	HBoxContainer *preview_hb = memnew(HBoxContainer);
-	preview_hb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	preview_hb->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	item_vb->add_child(preview_hb);
 
 	VBoxContainer *list_vb = memnew(VBoxContainer);
-	list_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	list_vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	list_vb->add_child(memnew(Label(TTR("Directories & Files:"))));
 	preview_hb->add_child(list_vb);
 
 	// Item (files and folders) list with context menu.
 
 	item_list = memnew(ItemList);
-	item_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	item_list->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	item_list->connect("item_rmb_selected", callable_mp(this, &EditorFileDialog::_item_list_item_rmb_selected));
 	item_list->connect("rmb_clicked", callable_mp(this, &EditorFileDialog::_item_list_rmb_clicked));
 	item_list->set_allow_rmb_select(true);
@@ -1653,15 +1653,15 @@ EditorFileDialog::EditorFileDialog() {
 	file_box->add_child(memnew(Label(TTR("File:"))));
 	file = memnew(LineEdit);
 	file->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
-	file->set_stretch_ratio(4);
-	file->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	file->set_size_flags_stretch_ratio(4);
+	file->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	file_box->add_child(file);
 	filter = memnew(OptionButton);
-	filter->set_stretch_ratio(3);
-	filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	filter->set_size_flags_stretch_ratio(3);
+	filter->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	filter->set_clip_text(true); // Too many extensions overflow it.
 	file_box->add_child(filter);
-	file_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	file_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	item_vb->add_child(file_box);
 
 	dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1660,13 +1660,13 @@ void EditorHelp::_bind_methods() {
 }
 
 EditorHelp::EditorHelp() {
-	set_custom_minimum_size(Size2(150 * EDSCALE, 0));
+	set_rect_minimum_size(Size2(150 * EDSCALE, 0));
 
 	EDITOR_DEF("text_editor/help/sort_functions_alphabetically", true);
 
 	class_desc = memnew(RichTextLabel);
 	add_child(class_desc);
-	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
+	class_desc->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	class_desc->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
 
 	class_desc->connect("meta_clicked", callable_mp(this, &EditorHelp::_class_desc_select));
@@ -1752,14 +1752,14 @@ EditorHelpBit::EditorHelpBit() {
 	rich_text->connect("meta_clicked", callable_mp(this, &EditorHelpBit::_meta_clicked));
 	rich_text->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
 	rich_text->set_override_selected_font_color(false);
-	set_custom_minimum_size(Size2(0, 70 * EDSCALE));
+	set_rect_minimum_size(Size2(0, 70 * EDSCALE));
 }
 
 FindBar::FindBar() {
 	search_text = memnew(LineEdit);
 	add_child(search_text);
-	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-	search_text->set_h_size_flags(SIZE_EXPAND_FILL);
+	search_text->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
+	search_text->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	search_text->connect("text_changed", callable_mp(this, &FindBar::_search_text_changed));
 	search_text->connect("text_entered", callable_mp(this, &FindBar::_search_text_entered));
 
@@ -1781,7 +1781,7 @@ FindBar::FindBar() {
 
 	Control *space = memnew(Control);
 	add_child(space);
-	space->set_custom_minimum_size(Size2(4, 0) * EDSCALE);
+	space->set_rect_minimum_size(Size2(4, 0) * EDSCALE);
 
 	hide_button = memnew(TextureButton);
 	add_child(hide_button);
@@ -1817,7 +1817,7 @@ void FindBar::_notification(int p_what) {
 			hide_button->set_normal_texture(get_theme_icon("Close", "EditorIcons"));
 			hide_button->set_hover_texture(get_theme_icon("Close", "EditorIcons"));
 			hide_button->set_pressed_texture(get_theme_icon("Close", "EditorIcons"));
-			hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
+			hide_button->set_rect_minimum_size(hide_button->get_normal_texture()->get_size());
 			matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color("font_color", "Label") : get_theme_color("error_color", "Editor"));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -194,8 +194,8 @@ EditorHelpSearch::EditorHelpSearch() {
 	vbox->add_child(hbox);
 
 	search_box = memnew(LineEdit);
-	search_box->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
-	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->set_rect_minimum_size(Size2(200, 0) * EDSCALE);
+	search_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	search_box->connect("gui_input", callable_mp(this, &EditorHelpSearch::_search_box_gui_input));
 	search_box->connect("text_changed", callable_mp(this, &EditorHelpSearch::_search_box_text_changed));
 	register_text_enter(search_box);
@@ -219,8 +219,8 @@ EditorHelpSearch::EditorHelpSearch() {
 	hbox->add_child(hierarchy_button);
 
 	filter_combo = memnew(OptionButton);
-	filter_combo->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
-	filter_combo->set_stretch_ratio(0); // Fixed width.
+	filter_combo->set_rect_minimum_size(Size2(200, 0) * EDSCALE);
+	filter_combo->set_size_flags_stretch_ratio(0); // Fixed width.
 	filter_combo->add_item(TTR("Display All"), SEARCH_ALL);
 	filter_combo->add_separator();
 	filter_combo->add_item(TTR("Classes Only"), SEARCH_CLASSES);
@@ -234,13 +234,13 @@ EditorHelpSearch::EditorHelpSearch() {
 
 	// Create the results tree.
 	results_tree = memnew(Tree);
-	results_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	results_tree->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	results_tree->set_columns(2);
 	results_tree->set_column_title(0, TTR("Name"));
 	results_tree->set_column_title(1, TTR("Member Type"));
 	results_tree->set_column_expand(1, false);
 	results_tree->set_column_min_width(1, 150 * EDSCALE);
-	results_tree->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
+	results_tree->set_rect_minimum_size(Size2(0, 100) * EDSCALE);
 	results_tree->set_hide_root(true);
 	results_tree->set_select_mode(Tree::SELECT_ROW);
 	results_tree->connect("item_activated", callable_mp(this, &EditorHelpSearch::_confirmed));

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -101,7 +101,7 @@ void EditorProperty::emit_changed(const StringName &p_property, const Variant &p
 
 void EditorProperty::_notification(int p_what) {
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 		Rect2 rect;
 		Rect2 bottom_rect;
 
@@ -219,11 +219,11 @@ void EditorProperty::_notification(int p_what) {
 		Color dark_color = get_theme_color("dark_color_2", "Editor");
 		bool rtl = is_layout_rtl();
 
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 		if (bottom_editor) {
 			size.height = bottom_editor->get_offset(SIDE_TOP);
 		} else if (label_reference) {
-			size.height = label_reference->get_size().height;
+			size.height = label_reference->get_rect_size().height;
 		}
 
 		Ref<StyleBox> sb;
@@ -693,7 +693,7 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 	if (me.is_valid()) {
 		Vector2 mpos = me->get_position();
 		if (is_layout_rtl()) {
-			mpos.x = get_size().x - mpos.x;
+			mpos.x = get_rect_size().x - mpos.x;
 		}
 		bool button_left = me->get_button_mask() & MOUSE_BUTTON_MASK_LEFT;
 
@@ -727,7 +727,7 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 		Vector2 mpos = mb->get_position();
 		if (is_layout_rtl()) {
-			mpos.x = get_size().x - mpos.x;
+			mpos.x = get_rect_size().x - mpos.x;
 		}
 
 		if (!selected && selectable) {
@@ -1097,7 +1097,7 @@ void EditorInspectorPlugin::_bind_methods() {
 
 void EditorInspectorCategory::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
-		draw_rect(Rect2(Vector2(), get_size()), bg_color);
+		draw_rect(Rect2(Vector2(), get_rect_size()), bg_color);
 		Ref<Font> font = get_theme_font("font", "Tree");
 		int font_size = get_theme_font_size("font_size", "Tree");
 
@@ -1108,15 +1108,15 @@ void EditorInspectorCategory::_notification(int p_what) {
 			w += hs + icon->get_width();
 		}
 
-		int ofs = (get_size().width - w) / 2;
+		int ofs = (get_rect_size().width - w) / 2;
 
 		if (icon.is_valid()) {
-			draw_texture(icon, Point2(ofs, (get_size().height - icon->get_height()) / 2).floor());
+			draw_texture(icon, Point2(ofs, (get_rect_size().height - icon->get_height()) / 2).floor());
 			ofs += hs + icon->get_width();
 		}
 
 		Color color = get_theme_color("font_color", "Tree");
-		draw_string(font, Point2(ofs, font->get_ascent(font_size) + (get_size().height - font->get_height(font_size)) / 2).floor(), label, HALIGN_LEFT, get_size().width, font_size, color);
+		draw_string(font, Point2(ofs, font->get_ascent(font_size) + (get_rect_size().height - font->get_height(font_size)) / 2).floor(), label, HALIGN_LEFT, get_rect_size().width, font_size, color);
 	}
 }
 
@@ -1197,7 +1197,7 @@ void EditorInspectorSection::_notification(int p_what) {
 			}
 		}
 
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 		Point2 offset;
 		offset.y = font->get_height(font_size);
 		if (arrow.is_valid()) {
@@ -1249,16 +1249,16 @@ void EditorInspectorSection::_notification(int p_what) {
 		}
 		h += get_theme_constant("vseparation", "Tree");
 
-		draw_rect(Rect2(Vector2(), Vector2(get_size().width, h)), bg_color);
+		draw_rect(Rect2(Vector2(), Vector2(get_rect_size().width, h)), bg_color);
 
 		const int arrow_margin = 3;
 		Color color = get_theme_color("font_color", "Tree");
-		float text_width = get_size().width - Math::round((16 + arrow_margin) * EDSCALE);
+		float text_width = get_rect_size().width - Math::round((16 + arrow_margin) * EDSCALE);
 		draw_string(font, Point2(rtl ? 0 : Math::round((16 + arrow_margin) * EDSCALE), font->get_ascent(font_size) + (h - font->get_height(font_size)) / 2).floor(), label, rtl ? HALIGN_RIGHT : HALIGN_LEFT, text_width, font_size, color);
 
 		if (arrow.is_valid()) {
 			if (rtl) {
-				draw_texture(arrow, Point2(get_size().width - arrow->get_width() - Math::round(arrow_margin * EDSCALE), (h - arrow->get_height()) / 2).floor());
+				draw_texture(arrow, Point2(get_rect_size().width - arrow->get_width() - Math::round(arrow_margin * EDSCALE), (h - arrow->get_height()) / 2).floor());
 			} else {
 				draw_texture(arrow, Point2(Math::round(arrow_margin * EDSCALE), (h - arrow->get_height()) / 2).floor());
 			}
@@ -1266,7 +1266,7 @@ void EditorInspectorSection::_notification(int p_what) {
 
 		if (dropping && !vbox->is_visible_in_tree()) {
 			Color accent_color = get_theme_color("accent_color", "Editor");
-			draw_rect(Rect2(Point2(), get_size()), accent_color, false);
+			draw_rect(Rect2(Point2(), get_rect_size()), accent_color, false);
 		}
 	}
 
@@ -2650,7 +2650,7 @@ EditorInspector::EditorInspector() {
 	object = nullptr;
 	undo_redo = nullptr;
 	main_vbox = memnew(VBoxContainer);
-	main_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	main_vbox->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	main_vbox->add_theme_constant_override("separation", 0);
 	add_child(main_vbox);
 	set_enable_h_scroll(false);

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -109,7 +109,7 @@ EditorLayoutsDialog::EditorLayoutsDialog() {
 	layout_names->set_offset(SIDE_TOP, 5);
 	layout_names->set_anchor_and_offset(SIDE_LEFT, Control::ANCHOR_BEGIN, 5);
 	layout_names->set_anchor_and_offset(SIDE_RIGHT, Control::ANCHOR_END, -5);
-	layout_names->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	layout_names->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	layout_names->set_select_mode(ItemList::SELECT_MULTI);
 	layout_names->set_allow_rmb_select(true);
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -154,7 +154,7 @@ EditorLog::EditorLog() {
 	vb->add_child(hb);
 	title = memnew(Label);
 	title->set_text(TTR("Output:"));
-	title->set_h_size_flags(SIZE_EXPAND_FILL);
+	title->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	hb->add_child(title);
 
 	copybutton = memnew(Button);
@@ -175,9 +175,9 @@ EditorLog::EditorLog() {
 	log->set_scroll_follow(true);
 	log->set_selection_enabled(true);
 	log->set_focus_mode(FOCUS_CLICK);
-	log->set_custom_minimum_size(Size2(0, 180) * EDSCALE);
-	log->set_v_size_flags(SIZE_EXPAND_FILL);
-	log->set_h_size_flags(SIZE_EXPAND_FILL);
+	log->set_rect_minimum_size(Size2(0, 180) * EDSCALE);
+	log->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	log->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	vb->add_child(log);
 	add_message(VERSION_FULL_NAME " (c) 2007-2021 Juan Linietsky, Ariel Manzur & Godot Contributors.");
 

--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -41,21 +41,21 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 	RS::ShaderNativeSourceCode nsc = RS::get_singleton()->shader_get_native_source_code(p_shader);
 
 	versions = memnew(TabContainer);
-	versions->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	versions->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	versions->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
+	versions->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	for (int i = 0; i < nsc.versions.size(); i++) {
 		TabContainer *vtab = memnew(TabContainer);
 		vtab->set_name("Version " + itos(i));
-		vtab->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		vtab->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		vtab->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
+		vtab->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		versions->add_child(vtab);
 		for (int j = 0; j < nsc.versions[i].stages.size(); j++) {
 			TextEdit *vtext = memnew(TextEdit);
 			vtext->set_readonly(true);
 			vtext->set_name(nsc.versions[i].stages[j].name);
 			vtext->set_text(nsc.versions[i].stages[j].code);
-			vtext->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-			vtext->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			vtext->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
+			vtext->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 			vtab->add_child(vtext);
 		}
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -339,9 +339,9 @@ void EditorNode::_update_scene_tabs() {
 		// move add button to fixed position on the tabbar
 		if (scene_tab_add->get_parent() == scene_tabs) {
 			if (scene_tabs->is_layout_rtl()) {
-				scene_tab_add->set_position(Point2(tabbar_container->get_size().x - scene_tab_add->get_size().x, 0));
+				scene_tab_add->set_rect_position(Point2(tabbar_container->get_rect_size().x - scene_tab_add->get_rect_size().x, 0));
 			} else {
-				scene_tab_add->set_position(Point2(0, 0));
+				scene_tab_add->set_rect_position(Point2(0, 0));
 			}
 			scene_tabs->remove_child(scene_tab_add);
 			tabbar_container->add_child(scene_tab_add);
@@ -358,9 +358,9 @@ void EditorNode::_update_scene_tabs() {
 			last_tab = scene_tabs->get_tab_rect(scene_tabs->get_tab_count() - 1);
 		}
 		if (scene_tabs->is_layout_rtl()) {
-			scene_tab_add->set_position(Point2(last_tab.get_position().x - scene_tab_add->get_size().x - 3, last_tab.get_position().y));
+			scene_tab_add->set_rect_position(Point2(last_tab.get_position().x - scene_tab_add->get_rect_size().x - 3, last_tab.get_position().y));
 		} else {
-			scene_tab_add->set_position(Point2(last_tab.get_position().x + last_tab.get_size().x + 3, last_tab.get_position().y));
+			scene_tab_add->set_rect_position(Point2(last_tab.get_position().x + last_tab.get_size().x + 3, last_tab.get_position().y));
 		}
 	}
 }
@@ -4108,10 +4108,10 @@ void EditorNode::_dock_make_float() {
 	ERR_FAIL_COND(!dock);
 
 	const Size2i borders = Size2i(4, 4) * EDSCALE;
-	Size2 dock_size = dock->get_size() + borders * 2; //remember size
-	Point2 dock_screen_pos = dock->get_global_position() + get_tree()->get_root()->get_position() - borders;
+	Size2 dock_size = dock->get_rect_size() + borders * 2; //remember size
+	Point2 dock_screen_pos = dock->get_rect_global_position() + get_tree()->get_root()->get_position() - borders;
 
-	print_line("dock pos: " + dock->get_global_position() + " window pos: " + get_tree()->get_root()->get_position());
+	print_line("dock pos: " + dock->get_rect_global_position() + " window pos: " + get_tree()->get_root()->get_position());
 	int dock_index = dock->get_index();
 	dock_slot[dock_popup_selected]->remove_child(dock);
 
@@ -4261,7 +4261,7 @@ void EditorNode::_dock_move_right() {
 }
 
 void EditorNode::_dock_select_draw() {
-	Size2 s = dock_select->get_size();
+	Size2 s = dock_select->get_rect_size();
 	s.y /= 2.0;
 	s.x /= 6.0;
 
@@ -4904,9 +4904,9 @@ void EditorNode::_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_p
 	int p_tab = p_udata.operator signed int();
 	if (p_preview.is_valid()) {
 		Rect2 rect = scene_tabs->get_tab_rect(p_tab);
-		rect.position += scene_tabs->get_global_position();
+		rect.position += scene_tabs->get_rect_global_position();
 		tab_preview->set_texture(p_preview);
-		tab_preview_panel->set_position(rect.position + Vector2(0, rect.size.height));
+		tab_preview_panel->set_rect_position(rect.position + Vector2(0, rect.size.height));
 		tab_preview_panel->show();
 	}
 }
@@ -4943,7 +4943,7 @@ Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item) {
 	bottom_panel_vb->add_child(p_item);
 	bottom_panel_hb->raise();
 	bottom_panel_hb_editors->add_child(tb);
-	p_item->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	p_item->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	p_item->hide();
 	BottomPanelItem bpi;
 	bpi.button = tb;
@@ -5144,7 +5144,7 @@ Variant EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from) {
 
 	p_from->set_drag_preview(drag_control); //wait until it enters scene
 
-	label->set_position(Point2((preview->get_width() - label->get_minimum_size().width) / 2, preview->get_height()));
+	label->set_rect_position(Point2((preview->get_width() - label->get_minimum_size().width) / 2, preview->get_height()));
 
 	Dictionary drag_data;
 	drag_data["type"] = "resource";
@@ -5179,7 +5179,7 @@ Variant EditorNode::drag_files_and_dirs(const Vector<String> &p_paths, Control *
 			icon->set_texture(gui_base->get_theme_icon("File", "EditorIcons"));
 		}
 		icon->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
-		icon->set_size(Size2(16, 16));
+		icon->set_rect_size(Size2(16, 16));
 		hbox->add_child(icon);
 		hbox->add_child(label);
 		vbox->add_child(hbox);
@@ -5930,7 +5930,7 @@ EditorNode::EditorNode() {
 	left_l_hsplit = memnew(HSplitContainer);
 	main_vbox->add_child(left_l_hsplit);
 
-	left_l_hsplit->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	left_l_hsplit->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	left_l_vsplit = memnew(VSplitContainer);
 	left_l_hsplit->add_child(left_l_vsplit);
@@ -5952,10 +5952,10 @@ EditorNode::EditorNode() {
 	left_r_hsplit->add_child(main_hsplit);
 	VBoxContainer *center_vb = memnew(VBoxContainer);
 	main_hsplit->add_child(center_vb);
-	center_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	center_vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	center_split = memnew(VSplitContainer);
-	center_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	center_split->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	center_split->set_collapsed(false);
 	center_vb->add_child(center_split);
 
@@ -6011,7 +6011,7 @@ EditorNode::EditorNode() {
 
 	Label *dock_label = memnew(Label);
 	dock_label->set_text(TTR("Dock Position"));
-	dock_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	dock_label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	dock_label->set_align(Label::ALIGN_CENTER);
 	dock_hb->add_child(dock_label);
 
@@ -6029,17 +6029,17 @@ EditorNode::EditorNode() {
 	dock_vb->add_child(dock_hb);
 
 	dock_select = memnew(Control);
-	dock_select->set_custom_minimum_size(Size2(128, 64) * EDSCALE);
+	dock_select->set_rect_minimum_size(Size2(128, 64) * EDSCALE);
 	dock_select->connect("gui_input", callable_mp(this, &EditorNode::_dock_select_input));
 	dock_select->connect("draw", callable_mp(this, &EditorNode::_dock_select_draw));
 	dock_select->connect("mouse_exited", callable_mp(this, &EditorNode::_dock_popup_exit));
-	dock_select->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	dock_select->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	dock_vb->add_child(dock_select);
 
 	dock_float = memnew(Button);
 	dock_float->set_text(TTR("Make Floating"));
 	dock_float->set_focus_mode(Control::FOCUS_NONE);
-	dock_float->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
+	dock_float->set_size_flags_horizontal(Control::SIZE_SHRINK_CENTER);
 	dock_float->connect("pressed", callable_mp(this, &EditorNode::_dock_make_float));
 
 	dock_vb->add_child(dock_float);
@@ -6048,8 +6048,8 @@ EditorNode::EditorNode() {
 	dock_select_rect_over = -1;
 	dock_popup_selected = -1;
 	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
-		dock_slot[i]->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
-		dock_slot[i]->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		dock_slot[i]->set_rect_minimum_size(Size2(170, 0) * EDSCALE);
+		dock_slot[i]->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		dock_slot[i]->set_popup(dock_select_popup);
 		dock_slot[i]->connect("pre_popup_pressed", callable_mp(this, &EditorNode::_dock_pre_popup), varray(i));
 		dock_slot[i]->set_tab_align(TabContainer::ALIGN_LEFT);
@@ -6067,24 +6067,24 @@ EditorNode::EditorNode() {
 
 	top_split = memnew(VSplitContainer);
 	center_split->add_child(top_split);
-	top_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	top_split->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	top_split->set_collapsed(true);
 
 	VBoxContainer *srt = memnew(VBoxContainer);
-	srt->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	srt->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	top_split->add_child(srt);
 	srt->add_theme_constant_override("separation", 0);
 
 	tab_preview_panel = memnew(Panel);
-	tab_preview_panel->set_size(Size2(100, 100) * EDSCALE);
+	tab_preview_panel->set_rect_size(Size2(100, 100) * EDSCALE);
 	tab_preview_panel->hide();
 	tab_preview_panel->set_self_modulate(Color(1, 1, 1, 0.7));
 	gui_base->add_child(tab_preview_panel);
 
 	tab_preview = memnew(TextureRect);
 	tab_preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	tab_preview->set_size(Size2(96, 96) * EDSCALE);
-	tab_preview->set_position(Point2(2, 2) * EDSCALE);
+	tab_preview->set_rect_size(Size2(96, 96) * EDSCALE);
+	tab_preview->set_rect_position(Point2(2, 2) * EDSCALE);
 	tab_preview_panel->add_child(tab_preview);
 
 	scene_tabs = memnew(Tabs);
@@ -6106,7 +6106,7 @@ EditorNode::EditorNode() {
 	scene_tabs->connect("resized", callable_mp(this, &EditorNode::_update_scene_tabs));
 
 	tabbar_container = memnew(HBoxContainer);
-	scene_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	scene_tabs->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	scene_tabs_context_menu = memnew(PopupMenu);
 	tabbar_container->add_child(scene_tabs_context_menu);
@@ -6136,11 +6136,11 @@ EditorNode::EditorNode() {
 	scene_tab_add->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_NEW_SCENE));
 
 	scene_root_parent = memnew(PanelContainer);
-	scene_root_parent->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
+	scene_root_parent->set_rect_minimum_size(Size2(0, 80) * EDSCALE);
 	scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox("Content", "EditorStyles"));
 	scene_root_parent->set_draw_behind_parent(true);
 	srt->add_child(scene_root_parent);
-	scene_root_parent->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	scene_root_parent->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	scene_root = memnew(SubViewport);
 	//scene_root->set_usage(Viewport::USAGE_2D); canvas BG mode prevents usage of this as 2D
@@ -6150,7 +6150,7 @@ EditorNode::EditorNode() {
 	scene_root->set_as_audio_listener_2d(true);
 
 	main_control = memnew(VBoxContainer);
-	main_control->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_control->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	main_control->add_theme_constant_override("separation", 0);
 	scene_root_parent->add_child(main_control);
 
@@ -6171,7 +6171,7 @@ EditorNode::EditorNode() {
 	prev_scene->set_disabled(true);
 	prev_scene->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_OPEN_PREV));
 	gui_base->add_child(prev_scene);
-	prev_scene->set_position(Point2(3, 24));
+	prev_scene->set_rect_position(Point2(3, 24));
 	prev_scene->hide();
 
 	accept = memnew(AcceptDialog);
@@ -6610,11 +6610,11 @@ EditorNode::EditorNode() {
 	bottom_panel->add_child(bottom_panel_vb);
 
 	bottom_panel_hb = memnew(HBoxContainer);
-	bottom_panel_hb->set_custom_minimum_size(Size2(0, 24 * EDSCALE)); // Adjust for the height of the "Expand Bottom Dock" icon.
+	bottom_panel_hb->set_rect_minimum_size(Size2(0, 24 * EDSCALE)); // Adjust for the height of the "Expand Bottom Dock" icon.
 	bottom_panel_vb->add_child(bottom_panel_hb);
 
 	bottom_panel_hb_editors = memnew(HBoxContainer);
-	bottom_panel_hb_editors->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	bottom_panel_hb_editors->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	bottom_panel_hb->add_child(bottom_panel_hb_editors);
 
 	version_label = memnew(Label);
@@ -6737,7 +6737,7 @@ EditorNode::EditorNode() {
 
 		disk_changed_list = memnew(Tree);
 		vbc->add_child(disk_changed_list);
-		disk_changed_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		disk_changed_list->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 		disk_changed->connect("confirmed", callable_mp(this, &EditorNode::_reload_modified_scenes));
 		disk_changed->connect("confirmed", callable_mp(this, &EditorNode::_reload_project_settings));

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -76,7 +76,7 @@ void EditorPath::_about_to_show() {
 
 	objects.clear();
 	get_popup()->clear();
-	get_popup()->set_size(Size2(get_size().width, 1));
+	get_popup()->set_size(Size2(get_rect_size().width, 1));
 
 	_add_children_to_popup(obj);
 	if (get_popup()->get_item_count() == 0) {

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -203,7 +203,7 @@ EditorPluginSettings::EditorPluginSettings() {
 	add_child(title_hb);
 
 	plugin_list = memnew(Tree);
-	plugin_list->set_v_size_flags(SIZE_EXPAND_FILL);
+	plugin_list->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	plugin_list->set_columns(5);
 	plugin_list->set_column_titles_visible(true);
 	plugin_list->set_column_title(0, TTR("Name:"));
@@ -225,8 +225,8 @@ EditorPluginSettings::EditorPluginSettings() {
 
 	VBoxContainer *mc = memnew(VBoxContainer);
 	mc->add_child(plugin_list);
-	mc->set_v_size_flags(SIZE_EXPAND_FILL);
-	mc->set_h_size_flags(SIZE_EXPAND_FILL);
+	mc->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	mc->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	add_child(mc);
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -151,7 +151,7 @@ void EditorPropertyMultilineText::_notification(int p_what) {
 			open_big_text->set_icon(df);
 			Ref<Font> font = get_theme_font("font", "Label");
 			int font_size = get_theme_font_size("font_size", "Label");
-			text->set_custom_minimum_size(Vector2(0, font->get_height(font_size) * 6));
+			text->set_rect_minimum_size(Vector2(0, font->get_height(font_size) * 6));
 
 		} break;
 	}
@@ -169,7 +169,7 @@ EditorPropertyMultilineText::EditorPropertyMultilineText() {
 	text->set_wrap_enabled(true);
 	add_focusable(text);
 	hb->add_child(text);
-	text->set_h_size_flags(SIZE_EXPAND_FILL);
+	text->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	open_big_text = memnew(Button);
 	open_big_text->set_flat(true);
 	open_big_text->connect("pressed", callable_mp(this, &EditorPropertyMultilineText::_open_big_text));
@@ -299,7 +299,7 @@ EditorPropertyPath::EditorPropertyPath() {
 	path_hb->add_child(path);
 	path->connect("text_entered", callable_mp(this, &EditorPropertyPath::_path_selected));
 	path->connect("focus_exited", callable_mp(this, &EditorPropertyPath::_path_focus_exited));
-	path->set_h_size_flags(SIZE_EXPAND_FILL);
+	path->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	path_edit = memnew(Button);
 	path_edit->set_clip_text(true);
@@ -639,7 +639,7 @@ public:
 		switch (p_what) {
 			case NOTIFICATION_DRAW: {
 				Rect2 rect;
-				rect.size = get_size();
+				rect.size = get_rect_size();
 				flag_rects.clear();
 
 				const int bsize = (rect.size.height * 80 / 100) / 2;
@@ -790,7 +790,7 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	add_child(hb);
 	grid = memnew(EditorPropertyLayersGrid);
 	grid->connect("flag_changed", callable_mp(this, &EditorPropertyLayers::_grid_changed));
-	grid->set_h_size_flags(SIZE_EXPAND_FILL);
+	grid->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	hb->add_child(grid);
 	button = memnew(Button);
 	button->set_toggle_mode(true);
@@ -992,7 +992,7 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 void EditorPropertyEasing::_draw_easing() {
 	RID ci = easing_draw->get_canvas_item();
 
-	Size2 s = easing_draw->get_size();
+	Size2 s = easing_draw->get_rect_size();
 
 	const int points = 48;
 
@@ -1104,7 +1104,7 @@ void EditorPropertyEasing::_notification(int p_what) {
 				preset->add_icon_item(get_theme_icon("CurveInOut", "EditorIcons"), "In-Out", EASING_IN_OUT);
 				preset->add_icon_item(get_theme_icon("CurveOutIn", "EditorIcons"), "Out-In", EASING_OUT_IN);
 			}
-			easing_draw->set_custom_minimum_size(Size2(0, get_theme_font("font", "Label")->get_height(get_theme_font_size("font_size", "Label")) * 2));
+			easing_draw->set_rect_minimum_size(Size2(0, get_theme_font("font", "Label")->get_height(get_theme_font_size("font_size", "Label")) * 2));
 		} break;
 	}
 }
@@ -1116,7 +1116,7 @@ EditorPropertyEasing::EditorPropertyEasing() {
 	easing_draw = memnew(Control);
 	easing_draw->connect("draw", callable_mp(this, &EditorPropertyEasing::_draw_easing));
 	easing_draw->connect("gui_input", callable_mp(this, &EditorPropertyEasing::_drag_easing));
-	easing_draw->set_default_cursor_shape(Control::CURSOR_MOVE);
+	easing_draw->set_mouse_default_cursor_shape(Control::CURSOR_MOVE);
 	add_child(easing_draw);
 
 	preset = memnew(PopupMenu);
@@ -1213,7 +1213,7 @@ EditorPropertyVector2::EditorPropertyVector2(bool p_force_wide) {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyVector2::_value_changed), varray(desc[i]));
 		if (horizontal) {
-			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		}
 	}
 
@@ -1309,7 +1309,7 @@ EditorPropertyRect2::EditorPropertyRect2(bool p_force_wide) {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyRect2::_value_changed), varray(desc[i]));
 		if (horizontal) {
-			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		}
 	}
 
@@ -1404,7 +1404,7 @@ EditorPropertyVector3::EditorPropertyVector3(bool p_force_wide) {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyVector3::_value_changed), varray(desc[i]));
 		if (horizontal) {
-			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		}
 	}
 
@@ -1486,7 +1486,7 @@ EditorPropertyVector2i::EditorPropertyVector2i(bool p_force_wide) {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyVector2i::_value_changed), varray(desc[i]));
 		if (horizontal) {
-			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		}
 	}
 
@@ -1582,7 +1582,7 @@ EditorPropertyRect2i::EditorPropertyRect2i(bool p_force_wide) {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyRect2i::_value_changed), varray(desc[i]));
 		if (horizontal) {
-			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		}
 	}
 
@@ -1665,7 +1665,7 @@ EditorPropertyVector3i::EditorPropertyVector3i(bool p_force_wide) {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyVector3i::_value_changed), varray(desc[i]));
 		if (horizontal) {
-			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		}
 	}
 
@@ -1751,7 +1751,7 @@ EditorPropertyPlane::EditorPropertyPlane(bool p_force_wide) {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyPlane::_value_changed), varray(desc[i]));
 		if (horizontal) {
-			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		}
 	}
 
@@ -1834,7 +1834,7 @@ EditorPropertyQuat::EditorPropertyQuat() {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyQuat::_value_changed), varray(desc[i]));
 		if (horizontal) {
-			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		}
 	}
 
@@ -1912,7 +1912,7 @@ EditorPropertyAABB::EditorPropertyAABB() {
 		spin[i]->set_flat(true);
 
 		g->add_child(spin[i]);
-		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyAABB::_value_changed), varray(desc[i]));
 	}
@@ -1987,7 +1987,7 @@ EditorPropertyTransform2D::EditorPropertyTransform2D() {
 		spin[i]->set_label(desc[i]);
 		spin[i]->set_flat(true);
 		g->add_child(spin[i]);
-		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyTransform2D::_value_changed), varray(desc[i]));
 	}
@@ -2068,7 +2068,7 @@ EditorPropertyBasis::EditorPropertyBasis() {
 		spin[i]->set_label(desc[i]);
 		spin[i]->set_flat(true);
 		g->add_child(spin[i]);
-		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyBasis::_value_changed), varray(desc[i]));
 	}
@@ -2157,7 +2157,7 @@ EditorPropertyTransform::EditorPropertyTransform() {
 		spin[i]->set_label(desc[i]);
 		spin[i]->set_flat(true);
 		g->add_child(spin[i]);
-		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		spin[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyTransform::_value_changed), varray(desc[i]));
 	}
@@ -2351,7 +2351,7 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 	add_child(hbc);
 	assign = memnew(Button);
 	assign->set_flat(true);
-	assign->set_h_size_flags(SIZE_EXPAND_FILL);
+	assign->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
 	assign->connect("pressed", callable_mp(this, &EditorPropertyNodePath::_node_assign));
 	hbc->add_child(assign);
@@ -2634,12 +2634,12 @@ void EditorPropertyResource::_resource_preview(const String &p_path, const Ref<T
 			preview->set_offset(SIDE_LEFT, assign->get_icon()->get_width() + assign->get_theme_stylebox("normal")->get_default_margin(SIDE_LEFT) + get_theme_constant("hseparation", "Button"));
 			if (type == "GradientTexture") {
 				preview->set_stretch_mode(TextureRect::STRETCH_SCALE);
-				assign->set_custom_minimum_size(Size2(1, 1));
+				assign->set_rect_minimum_size(Size2(1, 1));
 			} else {
 				preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 				int thumbnail_size = EditorSettings::get_singleton()->get("filesystem/file_dialog/thumbnail_size");
 				thumbnail_size *= EDSCALE;
-				assign->set_custom_minimum_size(Size2(1, thumbnail_size));
+				assign->set_rect_minimum_size(Size2(1, thumbnail_size));
 			}
 			preview->set_texture(p_preview);
 			assign->set_text("");
@@ -2980,7 +2980,7 @@ void EditorPropertyResource::update_property() {
 	if (res == RES()) {
 		assign->set_icon(Ref<Texture2D>());
 		assign->set_text(TTR("[empty]"));
-		assign->set_custom_minimum_size(Size2(1, 1));
+		assign->set_rect_minimum_size(Size2(1, 1));
 	} else {
 		assign->set_icon(EditorNode::get_singleton()->get_object_icon(res.operator->(), "Object"));
 
@@ -3080,7 +3080,7 @@ void EditorPropertyResource::expand_all_folding() {
 void EditorPropertyResource::_button_draw() {
 	if (dropping) {
 		Color color = get_theme_color("accent_color", "Editor");
-		assign->draw_rect(Rect2(Point2(), assign->get_size()), color, false);
+		assign->draw_rect(Rect2(Point2(), assign->get_rect_size()), color, false);
 	}
 }
 
@@ -3240,7 +3240,7 @@ EditorPropertyResource::EditorPropertyResource() {
 	add_child(hbc);
 	assign = memnew(Button);
 	assign->set_flat(true);
-	assign->set_h_size_flags(SIZE_EXPAND_FILL);
+	assign->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
 	assign->connect("pressed", callable_mp(this, &EditorPropertyResource::_resource_selected));
 	assign->set_drag_forwarding(this);

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -273,24 +273,24 @@ void EditorPropertyArray::update_property() {
 			HBoxContainer *hbc = memnew(HBoxContainer);
 			vbox->add_child(hbc);
 			Label *label = memnew(Label(TTR("Size: ")));
-			label->set_h_size_flags(SIZE_EXPAND_FILL);
+			label->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			hbc->add_child(label);
 			length = memnew(EditorSpinSlider);
 			length->set_step(1);
 			length->set_max(1000000);
-			length->set_h_size_flags(SIZE_EXPAND_FILL);
+			length->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			hbc->add_child(length);
 			length->connect("value_changed", callable_mp(this, &EditorPropertyArray::_length_changed));
 
 			page_hb = memnew(HBoxContainer);
 			vbox->add_child(page_hb);
 			label = memnew(Label(TTR("Page: ")));
-			label->set_h_size_flags(SIZE_EXPAND_FILL);
+			label->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			page_hb->add_child(label);
 			page = memnew(EditorSpinSlider);
 			page->set_step(1);
 			page_hb->add_child(page);
-			page->set_h_size_flags(SIZE_EXPAND_FILL);
+			page->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			page->connect("value_changed", callable_mp(this, &EditorPropertyArray::_page_changed));
 		} else {
 			//bye bye children of the box
@@ -345,7 +345,7 @@ void EditorPropertyArray::update_property() {
 			prop->set_selectable(false);
 			prop->connect("property_changed", callable_mp(this, &EditorPropertyArray::_property_changed));
 			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyArray::_object_id_selected));
-			prop->set_h_size_flags(SIZE_EXPAND_FILL);
+			prop->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 			HBoxContainer *hb = memnew(HBoxContainer);
 
@@ -396,7 +396,7 @@ void EditorPropertyArray::_remove_pressed(int p_index) {
 void EditorPropertyArray::_button_draw() {
 	if (dropping) {
 		Color color = get_theme_color("accent_color", "Editor");
-		edit->draw_rect(Rect2(Point2(), edit->get_size()), color, false);
+		edit->draw_rect(Rect2(Point2(), edit->get_rect_size()), color, false);
 	}
 }
 
@@ -576,7 +576,7 @@ EditorPropertyArray::EditorPropertyArray() {
 	page_len = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
 	edit = memnew(Button);
 	edit->set_flat(true);
-	edit->set_h_size_flags(SIZE_EXPAND_FILL);
+	edit->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
 	edit->connect("pressed", callable_mp(this, &EditorPropertyArray::_edit_pressed));
 	edit->set_toggle_mode(true);
@@ -724,12 +724,12 @@ void EditorPropertyDictionary::update_property() {
 			page_hb = memnew(HBoxContainer);
 			vbox->add_child(page_hb);
 			Label *label = memnew(Label(TTR("Page: ")));
-			label->set_h_size_flags(SIZE_EXPAND_FILL);
+			label->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			page_hb->add_child(label);
 			page = memnew(EditorSpinSlider);
 			page->set_step(1);
 			page_hb->add_child(page);
-			page->set_h_size_flags(SIZE_EXPAND_FILL);
+			page->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			page->connect("value_changed", callable_mp(this, &EditorPropertyDictionary::_page_changed));
 		} else {
 			// Queue children for deletion, deleting immediately might cause errors.
@@ -1009,7 +1009,7 @@ void EditorPropertyDictionary::update_property() {
 				vbox->add_child(hb);
 			}
 			hb->add_child(prop);
-			prop->set_h_size_flags(SIZE_EXPAND_FILL);
+			prop->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			Button *edit = memnew(Button);
 			edit->set_icon(get_theme_icon("Edit", "EditorIcons"));
 			hb->add_child(edit);
@@ -1071,7 +1071,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	page_len = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
 	edit = memnew(Button);
 	edit->set_flat(true);
-	edit->set_h_size_flags(SIZE_EXPAND_FILL);
+	edit->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
 	edit->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_edit_pressed));
 	edit->set_toggle_mode(true);

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -307,20 +307,20 @@ SectionedInspector::SectionedInspector() :
 	add_theme_constant_override("autohide", 1); // Fixes the dragger always showing up
 
 	VBoxContainer *left_vb = memnew(VBoxContainer);
-	left_vb->set_custom_minimum_size(Size2(190, 0) * EDSCALE);
+	left_vb->set_rect_minimum_size(Size2(190, 0) * EDSCALE);
 	add_child(left_vb);
 
-	sections->set_v_size_flags(SIZE_EXPAND_FILL);
+	sections->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	sections->set_hide_root(true);
 
 	left_vb->add_child(sections, true);
 
 	VBoxContainer *right_vb = memnew(VBoxContainer);
-	right_vb->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
-	right_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+	right_vb->set_rect_minimum_size(Size2(300, 0) * EDSCALE);
+	right_vb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	add_child(right_vb);
 
-	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
+	inspector->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	right_vb->add_child(inspector, true);
 	inspector->set_use_doc_hints(true);
 

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -59,7 +59,7 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 			if (mb->is_pressed()) {
 				if (updown_offset != -1 && mb->get_position().x > updown_offset) {
 					//there is an updown, so use it.
-					if (mb->get_position().y < get_size().height / 2) {
+					if (mb->get_position().y < get_rect_size().height / 2) {
 						set_value(get_value() + get_step());
 					} else {
 						set_value(get_value() - get_step());
@@ -215,7 +215,7 @@ void EditorSpinSlider::_notification(int p_what) {
 
 		Ref<StyleBox> sb = get_theme_stylebox("normal", "LineEdit");
 		if (!flat) {
-			draw_style_box(sb, Rect2(Vector2(), get_size()));
+			draw_style_box(sb, Rect2(Vector2(), get_rect_size()));
 		}
 		Ref<Font> font = get_theme_font("font", "LineEdit");
 		int font_size = get_theme_font_size("font_size", "LineEdit");
@@ -223,7 +223,7 @@ void EditorSpinSlider::_notification(int p_what) {
 		int sep = sep_base + sb->get_offset().x; //make it have the same margin on both sides, looks better
 
 		int string_width = font->get_string_size(label, font_size).width;
-		int number_width = get_size().width - sb->get_minimum_size().width - string_width - sep;
+		int number_width = get_rect_size().width - sb->get_minimum_size().width - string_width - sep;
 
 		Ref<Texture2D> updown = get_theme_icon("updown", "SpinBox");
 
@@ -233,7 +233,7 @@ void EditorSpinSlider::_notification(int p_what) {
 
 		String numstr = get_text_value();
 
-		int vofs = (get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
+		int vofs = (get_rect_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
 
 		Color fc = get_theme_color("font_color", "LineEdit");
 		Color lc;
@@ -245,12 +245,12 @@ void EditorSpinSlider::_notification(int p_what) {
 
 		if (flat && label != String()) {
 			Color label_bg_color = get_theme_color("dark_color_3", "Editor");
-			draw_rect(Rect2(Vector2(), Vector2(sb->get_offset().x * 2 + string_width, get_size().height)), label_bg_color);
+			draw_rect(Rect2(Vector2(), Vector2(sb->get_offset().x * 2 + string_width, get_rect_size().height)), label_bg_color);
 		}
 
 		if (has_focus()) {
 			Ref<StyleBox> focus = get_theme_stylebox("focus", "LineEdit");
-			draw_style_box(focus, Rect2(Vector2(), get_size()));
+			draw_style_box(focus, Rect2(Vector2(), get_rect_size()));
 		}
 
 		draw_string(font, Vector2(Math::round(sb->get_offset().x), vofs), label, HALIGN_LEFT, -1, font_size, lc * Color(1, 1, 1, 0.5));
@@ -259,8 +259,8 @@ void EditorSpinSlider::_notification(int p_what) {
 
 		if (get_step() == 1) {
 			Ref<Texture2D> updown2 = get_theme_icon("updown", "SpinBox");
-			int updown_vofs = (get_size().height - updown2->get_height()) / 2;
-			updown_offset = get_size().width - sb->get_margin(SIDE_RIGHT) - updown2->get_width();
+			int updown_vofs = (get_rect_size().height - updown2->get_height()) / 2;
+			updown_offset = get_rect_size().width - sb->get_margin(SIDE_RIGHT) - updown2->get_width();
 			Color c(1, 1, 1);
 			if (hover_updown) {
 				c *= Color(1.2, 1.2, 1.2);
@@ -271,9 +271,9 @@ void EditorSpinSlider::_notification(int p_what) {
 			}
 		} else if (!hide_slider) {
 			int grabber_w = 4 * EDSCALE;
-			int width = get_size().width - sb->get_minimum_size().width - grabber_w;
+			int width = get_rect_size().width - sb->get_minimum_size().width - grabber_w;
 			int ofs = sb->get_offset().x;
-			int svofs = (get_size().height + vofs) / 2 - 1;
+			int svofs = (get_rect_size().height + vofs) / 2 - 1;
 			Color c = fc;
 			c.a = 0.2;
 
@@ -305,12 +305,12 @@ void EditorSpinSlider::_notification(int p_what) {
 				}
 
 				Vector2 scale = get_global_transform_with_canvas().get_scale();
-				grabber->set_scale(scale);
-				grabber->set_size(Size2(0, 0));
-				grabber->set_position(get_global_position() + (grabber_rect.position + grabber_rect.size * 0.5 - grabber->get_size() * 0.5) * scale);
+				grabber->set_rect_scale(scale);
+				grabber->set_rect_size(Size2(0, 0));
+				grabber->set_rect_position(get_rect_global_position() + (grabber_rect.position + grabber_rect.size * 0.5 - grabber->get_rect_size() * 0.5) * scale);
 
 				if (mousewheel_over_grabber) {
-					Input::get_singleton()->warp_mouse_position(grabber->get_position() + grabber_rect.size);
+					Input::get_singleton()->warp_mouse_position(grabber->get_rect_position() + grabber_rect.size);
 				}
 
 				grabber_range = width;

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -80,7 +80,7 @@ void ExportTemplateManager::_update_template_list() {
 			String(VERSION_STATUS) != String("rc");
 
 	Label *current = memnew(Label);
-	current->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	current->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	current_hb->add_child(current);
 
 	if (templates.has(current_version)) {
@@ -125,7 +125,7 @@ void ExportTemplateManager::_update_template_list() {
 		Label *version = memnew(Label);
 		version->set_modulate(current->get_theme_color("disabled_font_color", "Editor"));
 		version->set_text(text);
-		version->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		version->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		hbc->add_child(version);
 
 		Button *uninstall = memnew(Button);
@@ -660,7 +660,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	installed_scroll->add_child(installed_vb);
 	installed_scroll->set_enable_v_scroll(true);
 	installed_scroll->set_enable_h_scroll(false);
-	installed_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	installed_vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	get_cancel_button()->set_text(TTR("Close"));
 	get_ok_button()->set_text(TTR("Install From File"));
@@ -699,7 +699,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	template_downloader->add_child(vbc);
 	ScrollContainer *sc = memnew(ScrollContainer);
-	sc->set_custom_minimum_size(Size2(400, 200) * EDSCALE);
+	sc->set_rect_minimum_size(Size2(400, 200) * EDSCALE);
 	vbc->add_margin_child(TTR("Select mirror from list: (Shift+Click: Open in Browser)"), sc);
 	template_list = memnew(VBoxContainer);
 	sc->add_child(template_list);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -297,7 +297,7 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 		switch (display_mode) {
 			case DISPLAY_MODE_TREE_ONLY:
 				tree->show();
-				tree->set_v_size_flags(SIZE_EXPAND_FILL);
+				tree->set_size_flags_vertical(SIZE_EXPAND_FILL);
 				if (display_mode == DISPLAY_MODE_TREE_ONLY) {
 					toolbar2_hbc->show();
 				} else {
@@ -310,7 +310,7 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 
 			case DISPLAY_MODE_SPLIT:
 				tree->show();
-				tree->set_v_size_flags(SIZE_EXPAND_FILL);
+				tree->set_size_flags_vertical(SIZE_EXPAND_FILL);
 				tree->ensure_cursor_is_visible();
 				toolbar2_hbc->hide();
 				_update_tree(_compute_uncollapsed_paths());
@@ -2488,7 +2488,7 @@ void FileSystemDock::_tree_rmb_empty(const Vector2 &p_pos) {
 	tree_popup->add_icon_item(get_theme_icon("PackedScene", "EditorIcons"), TTR("New Scene..."), FILE_NEW_SCENE);
 	tree_popup->add_icon_item(get_theme_icon("Script", "EditorIcons"), TTR("New Script..."), FILE_NEW_SCRIPT);
 	tree_popup->add_icon_item(get_theme_icon("Object", "EditorIcons"), TTR("New Resource..."), FILE_NEW_RESOURCE);
-	tree_popup->set_position(tree->get_global_position() + p_pos);
+	tree_popup->set_position(tree->get_rect_global_position() + p_pos);
 	tree_popup->popup();
 }
 
@@ -2515,7 +2515,7 @@ void FileSystemDock::_file_list_rmb_select(int p_item, const Vector2 &p_pos) {
 		file_list_popup->clear();
 		file_list_popup->set_size(Size2(1, 1));
 		_file_and_folders_fill_popup(file_list_popup, paths, searched_string.length() == 0);
-		file_list_popup->set_position(files->get_global_position() + p_pos);
+		file_list_popup->set_position(files->get_rect_global_position() + p_pos);
 		file_list_popup->popup();
 	}
 }
@@ -2535,7 +2535,7 @@ void FileSystemDock::_file_list_rmb_pressed(const Vector2 &p_pos) {
 	file_list_popup->add_icon_item(get_theme_icon("Object", "EditorIcons"), TTR("New Resource..."), FILE_NEW_RESOURCE);
 	file_list_popup->add_separator();
 	file_list_popup->add_icon_item(get_theme_icon("Filesystem", "EditorIcons"), TTR("Open in File Manager"), FILE_SHOW_IN_EXPLORER);
-	file_list_popup->set_position(files->get_global_position() + p_pos);
+	file_list_popup->set_position(files->get_rect_global_position() + p_pos);
 	file_list_popup->popup();
 }
 
@@ -2797,7 +2797,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 
 	current_path = memnew(LineEdit);
 	current_path->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
-	current_path->set_h_size_flags(SIZE_EXPAND_FILL);
+	current_path->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	_set_current_path_text(path);
 	toolbar_hbc->add_child(current_path);
 
@@ -2822,7 +2822,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	top_vbc->add_child(toolbar2_hbc);
 
 	tree_search_box = memnew(LineEdit);
-	tree_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	tree_search_box->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	tree_search_box->set_placeholder(TTR("Search files"));
 	tree_search_box->connect("text_changed", callable_mp(this, &FileSystemDock::_search_changed), varray(tree_search_box));
 	toolbar2_hbc->add_child(tree_search_box);
@@ -2839,7 +2839,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	add_child(tree_popup);
 
 	split_box = memnew(VSplitContainer);
-	split_box->set_v_size_flags(SIZE_EXPAND_FILL);
+	split_box->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	add_child(split_box);
 
 	tree = memnew(Tree);
@@ -2848,7 +2848,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	tree->set_drag_forwarding(this);
 	tree->set_allow_rmb_select(true);
 	tree->set_select_mode(Tree::SELECT_MULTI);
-	tree->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
+	tree->set_rect_minimum_size(Size2(0, 15 * EDSCALE));
 	split_box->add_child(tree);
 
 	tree->connect("item_activated", callable_mp(this, &FileSystemDock::_tree_activate_file));
@@ -2859,14 +2859,14 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	tree->connect("gui_input", callable_mp(this, &FileSystemDock::_tree_gui_input));
 
 	file_list_vb = memnew(VBoxContainer);
-	file_list_vb->set_v_size_flags(SIZE_EXPAND_FILL);
+	file_list_vb->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	split_box->add_child(file_list_vb);
 
 	path_hb = memnew(HBoxContainer);
 	file_list_vb->add_child(path_hb);
 
 	file_list_search_box = memnew(LineEdit);
-	file_list_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	file_list_search_box->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	file_list_search_box->set_placeholder(TTR("Search files"));
 	file_list_search_box->connect("text_changed", callable_mp(this, &FileSystemDock::_search_changed), varray(file_list_search_box));
 	path_hb->add_child(file_list_search_box);
@@ -2879,14 +2879,14 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	path_hb->add_child(button_file_list_display_mode);
 
 	files = memnew(ItemList);
-	files->set_v_size_flags(SIZE_EXPAND_FILL);
+	files->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	files->set_select_mode(ItemList::SELECT_MULTI);
 	files->set_drag_forwarding(this);
 	files->connect("item_rmb_selected", callable_mp(this, &FileSystemDock::_file_list_rmb_select));
 	files->connect("gui_input", callable_mp(this, &FileSystemDock::_file_list_gui_input));
 	files->connect("multi_selected", callable_mp(this, &FileSystemDock::_file_multi_selected));
 	files->connect("rmb_clicked", callable_mp(this, &FileSystemDock::_file_list_rmb_pressed));
-	files->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
+	files->set_rect_minimum_size(Size2(0, 15 * EDSCALE));
 	files->set_allow_rmb_select(true);
 	file_list_vb->add_child(files);
 

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -309,7 +309,7 @@ FindInFilesDialog::FindInFilesDialog() {
 	gc->add_child(find_label);
 
 	_search_text_line_edit = memnew(LineEdit);
-	_search_text_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	_search_text_line_edit->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	_search_text_line_edit->connect("text_changed", callable_mp(this, &FindInFilesDialog::_on_search_text_modified));
 	_search_text_line_edit->connect("text_entered", callable_mp(this, &FindInFilesDialog::_on_search_text_entered));
 	gc->add_child(_search_text_line_edit);
@@ -320,7 +320,7 @@ FindInFilesDialog::FindInFilesDialog() {
 	gc->add_child(_replace_label);
 
 	_replace_text_line_edit = memnew(LineEdit);
-	_replace_text_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	_replace_text_line_edit->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	_replace_text_line_edit->connect("text_entered", callable_mp(this, &FindInFilesDialog::_on_replace_text_entered));
 	_replace_text_line_edit->hide();
 	gc->add_child(_replace_text_line_edit);
@@ -353,7 +353,7 @@ FindInFilesDialog::FindInFilesDialog() {
 		hbc->add_child(prefix_label);
 
 		_folder_line_edit = memnew(LineEdit);
-		_folder_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		_folder_line_edit->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		hbc->add_child(_folder_line_edit);
 
 		Button *folder_button = memnew(Button);
@@ -570,8 +570,8 @@ FindInFilesPanel::FindInFilesPanel() {
 		hbc->add_child(_search_text_label);
 
 		_progress_bar = memnew(ProgressBar);
-		_progress_bar->set_h_size_flags(SIZE_EXPAND_FILL);
-		_progress_bar->set_v_size_flags(SIZE_SHRINK_CENTER);
+		_progress_bar->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+		_progress_bar->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 		hbc->add_child(_progress_bar);
 		set_progress_visible(false);
 
@@ -596,7 +596,7 @@ FindInFilesPanel::FindInFilesPanel() {
 	_results_display = memnew(Tree);
 	_results_display->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("source", "EditorFonts"));
 	_results_display->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("source_size", "EditorFonts"));
-	_results_display->set_v_size_flags(SIZE_EXPAND_FILL);
+	_results_display->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	_results_display->connect("item_selected", callable_mp(this, &FindInFilesPanel::_on_result_selected));
 	_results_display->connect("item_edited", callable_mp(this, &FindInFilesPanel::_on_item_edited));
 	_results_display->set_hide_root(true);
@@ -615,7 +615,7 @@ FindInFilesPanel::FindInFilesPanel() {
 		_replace_container->add_child(replace_label);
 
 		_replace_line_edit = memnew(LineEdit);
-		_replace_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
+		_replace_line_edit->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		_replace_line_edit->connect("text_changed", callable_mp(this, &FindInFilesPanel::_on_replace_text_changed));
 		_replace_container->add_child(_replace_line_edit);
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -417,11 +417,11 @@ GroupDialog::GroupDialog() {
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	vbc->add_child(hbc);
-	hbc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	hbc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	VBoxContainer *vbc_left = memnew(VBoxContainer);
 	hbc->add_child(vbc_left);
-	vbc_left->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbc_left->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	Label *group_title = memnew(Label);
 	group_title->set_text(TTR("Groups"));
@@ -433,7 +433,7 @@ GroupDialog::GroupDialog() {
 	groups->set_select_mode(Tree::SELECT_SINGLE);
 	groups->set_allow_reselect(true);
 	groups->set_allow_rmb_select(true);
-	groups->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	groups->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	groups->add_theme_constant_override("draw_guides", 1);
 	groups->connect("item_selected", callable_mp(this, &GroupDialog::_group_selected));
 	groups->connect("button_pressed", callable_mp(this, &GroupDialog::_delete_group_pressed));
@@ -441,11 +441,11 @@ GroupDialog::GroupDialog() {
 
 	HBoxContainer *chbc = memnew(HBoxContainer);
 	vbc_left->add_child(chbc);
-	chbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	chbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	add_group_text = memnew(LineEdit);
 	chbc->add_child(add_group_text);
-	add_group_text->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	add_group_text->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	add_group_text->connect("text_entered", callable_mp(this, &GroupDialog::_add_group_pressed));
 
 	Button *add_group_button = memnew(Button);
@@ -455,7 +455,7 @@ GroupDialog::GroupDialog() {
 
 	VBoxContainer *vbc_add = memnew(VBoxContainer);
 	hbc->add_child(vbc_add);
-	vbc_add->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbc_add->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	Label *out_of_group_title = memnew(Label);
 	out_of_group_title->set_text(TTR("Nodes Not in Group"));
@@ -466,7 +466,7 @@ GroupDialog::GroupDialog() {
 	nodes_to_add->set_hide_root(true);
 	nodes_to_add->set_hide_folding(true);
 	nodes_to_add->set_select_mode(Tree::SELECT_MULTI);
-	nodes_to_add->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	nodes_to_add->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	nodes_to_add->add_theme_constant_override("draw_guides", 1);
 
 	HBoxContainer *add_filter_hbc = memnew(HBoxContainer);
@@ -474,15 +474,15 @@ GroupDialog::GroupDialog() {
 	vbc_add->add_child(add_filter_hbc);
 
 	add_filter = memnew(LineEdit);
-	add_filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	add_filter->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	add_filter->set_placeholder(TTR("Filter nodes"));
 	add_filter_hbc->add_child(add_filter);
 	add_filter->connect("text_changed", callable_mp(this, &GroupDialog::_add_filter_changed));
 
 	VBoxContainer *vbc_buttons = memnew(VBoxContainer);
 	hbc->add_child(vbc_buttons);
-	vbc_buttons->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
-	vbc_buttons->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	vbc_buttons->set_size_flags_horizontal(Control::SIZE_SHRINK_CENTER);
+	vbc_buttons->set_size_flags_vertical(Control::SIZE_SHRINK_CENTER);
 
 	add_button = memnew(Button);
 	add_button->set_flat(true);
@@ -503,7 +503,7 @@ GroupDialog::GroupDialog() {
 
 	VBoxContainer *vbc_remove = memnew(VBoxContainer);
 	hbc->add_child(vbc_remove);
-	vbc_remove->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbc_remove->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	Label *in_group_title = memnew(Label);
 	in_group_title->set_text(TTR("Nodes in Group"));
@@ -511,7 +511,7 @@ GroupDialog::GroupDialog() {
 
 	nodes_to_remove = memnew(Tree);
 	vbc_remove->add_child(nodes_to_remove);
-	nodes_to_remove->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	nodes_to_remove->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	nodes_to_remove->set_hide_root(true);
 	nodes_to_remove->set_hide_folding(true);
 	nodes_to_remove->set_select_mode(Tree::SELECT_MULTI);
@@ -522,7 +522,7 @@ GroupDialog::GroupDialog() {
 	vbc_remove->add_child(remove_filter_hbc);
 
 	remove_filter = memnew(LineEdit);
-	remove_filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	remove_filter->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	remove_filter->set_placeholder(TTR("Filter nodes"));
 	remove_filter_hbc->add_child(remove_filter);
 	remove_filter->connect("text_changed", callable_mp(this, &GroupDialog::_remove_filter_changed));
@@ -532,7 +532,7 @@ GroupDialog::GroupDialog() {
 	group_empty->set_valign(Label::VALIGN_CENTER);
 	group_empty->set_align(Label::ALIGN_CENTER);
 	group_empty->set_autowrap(true);
-	group_empty->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	group_empty->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 	nodes_to_remove->add_child(group_empty);
 	group_empty->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 
@@ -687,7 +687,7 @@ GroupsEditor::GroupsEditor() {
 	vbc->add_child(hbc);
 
 	group_name = memnew(LineEdit);
-	group_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	group_name->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(group_name);
 	group_name->connect("text_entered", callable_mp(this, &GroupsEditor::_add_group));
 
@@ -698,7 +698,7 @@ GroupsEditor::GroupsEditor() {
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
-	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tree->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	vbc->add_child(tree);
 	tree->connect("button_pressed", callable_mp(this, &GroupsEditor::_remove_group));
 	tree->add_theme_constant_override("draw_guides", 1);

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -1054,15 +1054,15 @@ SceneImportSettings::SceneImportSettings() {
 
 	tree_split = memnew(HSplitContainer);
 	main_vb->add_child(tree_split);
-	tree_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tree_split->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	data_mode = memnew(TabContainer);
 	tree_split->add_child(data_mode);
-	data_mode->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
+	data_mode->set_rect_minimum_size(Size2(300 * EDSCALE, 0));
 
 	property_split = memnew(HSplitContainer);
 	tree_split->add_child(property_split);
-	property_split->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	property_split->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	scene_tree = memnew(Tree);
 	scene_tree->set_name(TTR("Scene"));
@@ -1083,8 +1083,8 @@ SceneImportSettings::SceneImportSettings() {
 	material_tree->set_hide_root(true);
 
 	SubViewportContainer *vp_container = memnew(SubViewportContainer);
-	vp_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	vp_container->set_custom_minimum_size(Size2(10, 10));
+	vp_container->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
+	vp_container->set_rect_minimum_size(Size2(10, 10));
 	vp_container->set_stretch(true);
 	vp_container->connect("gui_input", callable_mp(this, &SceneImportSettings::_viewport_input));
 	property_split->add_child(vp_container);
@@ -1145,7 +1145,7 @@ SceneImportSettings::SceneImportSettings() {
 	}
 
 	inspector = memnew(EditorInspector);
-	inspector->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
+	inspector->set_rect_minimum_size(Size2(300 * EDSCALE, 0));
 
 	property_split->add_child(inspector);
 

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -200,7 +200,7 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 	add_child(hb);
 	inspector = memnew(EditorInspector);
 	add_child(inspector);
-	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
+	inspector->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	CenterContainer *cc = memnew(CenterContainer);
 	save_defaults = memnew(Button);
 	save_defaults->set_text(TTR("Save"));

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -572,7 +572,7 @@ ImportDock::ImportDock() {
 	import_as->set_disabled(true);
 	import_as->connect("item_selected", callable_mp(this, &ImportDock::_importer_selected));
 	hb->add_child(import_as);
-	import_as->set_h_size_flags(SIZE_EXPAND_FILL);
+	import_as->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	preset = memnew(MenuButton);
 	preset->set_text(TTR("Preset"));
 	preset->set_disabled(true);
@@ -581,7 +581,7 @@ ImportDock::ImportDock() {
 
 	import_opts = memnew(EditorInspector);
 	add_child(import_opts);
-	import_opts->set_v_size_flags(SIZE_EXPAND_FILL);
+	import_opts->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	import_opts->connect("property_toggled", callable_mp(this, &ImportDock::_property_toggled));
 
 	hb = memnew(HBoxContainer);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -564,7 +564,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	add_child(node_info_hb);
 
 	editor_path = memnew(EditorPath(editor->get_editor_history()));
-	editor_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	editor_path->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	node_info_hb->add_child(editor_path);
 
 	object_menu = memnew(MenuButton);
@@ -580,7 +580,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	new_resource_dialog->connect("create", callable_mp(this, &InspectorDock::_resource_created));
 
 	search = memnew(LineEdit);
-	search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	search->set_placeholder(TTR("Filter properties"));
 	search->set_right_icon(get_theme_icon("Search", "EditorIcons"));
 	search->set_clear_button_enabled(true);
@@ -607,7 +607,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	add_child(inspector);
 	inspector->set_autoclear(true);
 	inspector->set_show_categories(true);
-	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	inspector->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	inspector->set_use_doc_hints(true);
 	inspector->set_hide_script(false);
 	inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -647,7 +647,7 @@ LocalizationEditor::LocalizationEditor() {
 
 	TabContainer *translations = memnew(TabContainer);
 	translations->set_tab_align(TabContainer::ALIGN_LEFT);
-	translations->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	translations->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	add_child(translations);
 
 	{
@@ -665,11 +665,11 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(addtr);
 
 		VBoxContainer *tmc = memnew(VBoxContainer);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tmc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		tvb->add_child(tmc);
 
 		translation_list = memnew(Tree);
-		translation_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		translation_list->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		tmc->add_child(translation_list);
 
 		translation_file_open = memnew(EditorFileDialog);
@@ -693,11 +693,11 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(addtr);
 
 		VBoxContainer *tmc = memnew(VBoxContainer);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tmc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		tvb->add_child(tmc);
 
 		translation_remap = memnew(Tree);
-		translation_remap->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		translation_remap->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		translation_remap->connect("cell_selected", callable_mp(this, &LocalizationEditor::_translation_res_select));
 		translation_remap->connect("button_pressed", callable_mp(this, &LocalizationEditor::_translation_res_delete));
 		tmc->add_child(translation_remap);
@@ -718,11 +718,11 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(addtr);
 
 		tmc = memnew(VBoxContainer);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tmc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		tvb->add_child(tmc);
 
 		translation_remap_options = memnew(Tree);
-		translation_remap_options->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		translation_remap_options->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		translation_remap_options->set_columns(2);
 		translation_remap_options->set_column_title(0, TTR("Path"));
 		translation_remap_options->set_column_title(1, TTR("Locale"));
@@ -746,7 +746,7 @@ LocalizationEditor::LocalizationEditor() {
 		translations->add_child(tvb);
 
 		VBoxContainer *tmc = memnew(VBoxContainer);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tmc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		tvb->add_child(tmc);
 
 		translation_locale_filter_mode = memnew(OptionButton);
@@ -758,7 +758,7 @@ LocalizationEditor::LocalizationEditor() {
 
 		tmc->add_child(memnew(Label(TTR("Locales:"))));
 		translation_filter = memnew(Tree);
-		translation_filter->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		translation_filter->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		translation_filter->set_columns(1);
 		translation_filter->connect("item_edited", callable_mp(this, &LocalizationEditor::_translation_filter_option_changed));
 		tmc->add_child(translation_filter);
@@ -783,11 +783,11 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(generate);
 
 		VBoxContainer *tmc = memnew(VBoxContainer);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tmc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		tvb->add_child(tmc);
 
 		translation_pot_list = memnew(Tree);
-		translation_pot_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		translation_pot_list->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		tmc->add_child(translation_pot_list);
 
 		pot_generate_dialog = memnew(EditorFileDialog);

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -97,7 +97,7 @@ NodeDock::NodeDock() {
 	connections_button->set_text(TTR("Signals"));
 	connections_button->set_toggle_mode(true);
 	connections_button->set_pressed(true);
-	connections_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	connections_button->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	connections_button->set_clip_text(true);
 	mode_hb->add_child(connections_button);
 	connections_button->connect("pressed", callable_mp(this, &NodeDock::show_connections));
@@ -107,7 +107,7 @@ NodeDock::NodeDock() {
 	groups_button->set_text(TTR("Groups"));
 	groups_button->set_toggle_mode(true);
 	groups_button->set_pressed(false);
-	groups_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	groups_button->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	groups_button->set_clip_text(true);
 	mode_hb->add_child(groups_button);
 	groups_button->connect("pressed", callable_mp(this, &NodeDock::show_groups));
@@ -115,19 +115,19 @@ NodeDock::NodeDock() {
 	connections = memnew(ConnectionsDock(EditorNode::get_singleton()));
 	connections->set_undoredo(EditorNode::get_undo_redo());
 	add_child(connections);
-	connections->set_v_size_flags(SIZE_EXPAND_FILL);
+	connections->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	connections->hide();
 
 	groups = memnew(GroupsEditor);
 	groups->set_undo_redo(EditorNode::get_undo_redo());
 	add_child(groups);
-	groups->set_v_size_flags(SIZE_EXPAND_FILL);
+	groups->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	groups->hide();
 
 	select_a_node = memnew(Label);
 	select_a_node->set_text(TTR("Select a single node to edit its signals and groups."));
-	select_a_node->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-	select_a_node->set_v_size_flags(SIZE_EXPAND_FILL);
+	select_a_node->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
+	select_a_node->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	select_a_node->set_valign(Label::VALIGN_CENTER);
 	select_a_node->set_align(Label::ALIGN_CENTER);
 	select_a_node->set_autowrap(true);

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -213,7 +213,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	grid->add_child(desc_lb);
 
 	desc_edit = memnew(TextEdit);
-	desc_edit->set_custom_minimum_size(Size2(400, 80) * EDSCALE);
+	desc_edit->set_rect_minimum_size(Size2(400, 80) * EDSCALE);
 	grid->add_child(desc_edit);
 
 	Label *author_lb = memnew(Label);

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -101,7 +101,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 		menu->set_position(blend_space_draw->get_screen_transform().xform(mb->get_position()));
 		menu->popup();
 
-		add_point_pos = (mb->get_position() / blend_space_draw->get_size()).x;
+		add_point_pos = (mb->get_position() / blend_space_draw->get_rect_size()).x;
 		add_point_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
 		add_point_pos += blend_space->get_min_space();
 
@@ -162,7 +162,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	// *set* the blend
 	if (mb.is_valid() && !mb->is_pressed() && tool_blend->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
-		float blend_pos = mb->get_position().x / blend_space_draw->get_size().x;
+		float blend_pos = mb->get_position().x / blend_space_draw->get_rect_size().x;
 		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
 		blend_pos += blend_space->get_min_space();
 
@@ -179,13 +179,13 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
-		drag_ofs = ((mm->get_position() - drag_from) / blend_space_draw->get_size()) * ((blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, 0));
+		drag_ofs = ((mm->get_position() - drag_from) / blend_space_draw->get_rect_size()) * ((blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, 0));
 		blend_space_draw->update();
 		_update_edited_point_pos();
 	}
 
 	if (mm.is_valid() && tool_blend->is_pressed() && mm->get_button_mask() & MOUSE_BUTTON_MASK_LEFT) {
-		float blend_pos = mm->get_position().x / blend_space_draw->get_size().x;
+		float blend_pos = mm->get_position().x / blend_space_draw->get_rect_size().x;
 		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
 		blend_pos += blend_space->get_min_space();
 
@@ -205,7 +205,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 	Ref<Texture2D> icon = get_theme_icon("KeyValue", "EditorIcons");
 	Ref<Texture2D> icon_selected = get_theme_icon("KeySelected", "EditorIcons");
 
-	Size2 s = blend_space_draw->get_size();
+	Size2 s = blend_space_draw->get_rect_size();
 
 	if (blend_space_draw->has_focus()) {
 		Color color = get_theme_color("accent_color", "Editor");
@@ -667,13 +667,13 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);
-	main_vb->set_v_size_flags(SIZE_EXPAND_FILL);
+	main_vb->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	panel = memnew(PanelContainer);
-	panel->set_clip_contents(true);
+	panel->set_rect_clip_contents(true);
 	main_vb->add_child(panel);
-	panel->set_h_size_flags(SIZE_EXPAND_FILL);
-	panel->set_v_size_flags(SIZE_EXPAND_FILL);
+	panel->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	panel->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	blend_space_draw = memnew(Control);
 	blend_space_draw->connect("gui_input", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_blend_space_gui_input));
@@ -685,7 +685,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	{
 		HBoxContainer *bottom_hb = memnew(HBoxContainer);
 		main_vb->add_child(bottom_hb);
-		bottom_hb->set_h_size_flags(SIZE_EXPAND_FILL);
+		bottom_hb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 		min_value = memnew(SpinBox);
 		min_value->set_min(-10000);
@@ -743,5 +743,5 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	dragging_selected = false;
 	dragging_selected_attempt = false;
 
-	set_custom_minimum_size(Size2(0, 150 * EDSCALE));
+	set_rect_minimum_size(Size2(0, 150 * EDSCALE));
 }

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -123,7 +123,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 		menu->set_position(blend_space_draw->get_screen_transform().xform(mb->get_position()));
 		menu->popup();
-		add_point_pos = (mb->get_position() / blend_space_draw->get_size());
+		add_point_pos = (mb->get_position() / blend_space_draw->get_rect_size());
 		add_point_pos.y = 1.0 - add_point_pos.y;
 		add_point_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
 		add_point_pos += blend_space->get_min_space();
@@ -237,7 +237,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && tool_blend->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
-		Vector2 blend_pos = (mb->get_position() / blend_space_draw->get_size());
+		Vector2 blend_pos = (mb->get_position() / blend_space_draw->get_rect_size());
 		blend_pos.y = 1.0 - blend_pos.y;
 		blend_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
 		blend_pos += blend_space->get_min_space();
@@ -256,7 +256,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
-		drag_ofs = ((mm->get_position() - drag_from) / blend_space_draw->get_size()) * (blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, -1);
+		drag_ofs = ((mm->get_position() - drag_from) / blend_space_draw->get_rect_size()) * (blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, -1);
 		blend_space_draw->update();
 		_update_edited_point_pos();
 	}
@@ -271,7 +271,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mm.is_valid() && tool_blend->is_pressed() && mm->get_button_mask() & MOUSE_BUTTON_MASK_LEFT) {
-		Vector2 blend_pos = (mm->get_position() / blend_space_draw->get_size());
+		Vector2 blend_pos = (mm->get_position() / blend_space_draw->get_rect_size());
 		blend_pos.y = 1.0 - blend_pos.y;
 		blend_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
 		blend_pos += blend_space->get_min_space();
@@ -400,7 +400,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 	Ref<Texture2D> icon = get_theme_icon("KeyValue", "EditorIcons");
 	Ref<Texture2D> icon_selected = get_theme_icon("KeySelected", "EditorIcons");
 
-	Size2 s = blend_space_draw->get_size();
+	Size2 s = blend_space_draw->get_rect_size();
 
 	if (blend_space_draw->has_focus()) {
 		Color color = get_theme_color("accent_color", "Editor");
@@ -927,16 +927,16 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	HBoxContainer *main_hb = memnew(HBoxContainer);
 	add_child(main_hb);
-	main_hb->set_v_size_flags(SIZE_EXPAND_FILL);
+	main_hb->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	GridContainer *main_grid = memnew(GridContainer);
 	main_grid->set_columns(2);
 	main_hb->add_child(main_grid);
-	main_grid->set_h_size_flags(SIZE_EXPAND_FILL);
+	main_grid->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	{
 		VBoxContainer *left_vbox = memnew(VBoxContainer);
 		main_grid->add_child(left_vbox);
-		left_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
+		left_vbox->set_size_flags_vertical(SIZE_EXPAND_FILL);
 		max_y_value = memnew(SpinBox);
 		left_vbox->add_child(max_y_value);
 		left_vbox->add_spacer();
@@ -957,9 +957,9 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	}
 
 	panel = memnew(PanelContainer);
-	panel->set_clip_contents(true);
+	panel->set_rect_clip_contents(true);
 	main_grid->add_child(panel);
-	panel->set_h_size_flags(SIZE_EXPAND_FILL);
+	panel->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	blend_space_draw = memnew(Control);
 	blend_space_draw->connect("gui_input", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_gui_input));
@@ -972,7 +972,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	{
 		HBoxContainer *bottom_vbox = memnew(HBoxContainer);
 		main_grid->add_child(bottom_vbox);
-		bottom_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+		bottom_vbox->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		min_x_value = memnew(SpinBox);
 		bottom_vbox->add_child(min_x_value);
 		bottom_vbox->add_spacer();
@@ -1009,7 +1009,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	undo_redo = EditorNode::get_undo_redo();
 
-	set_custom_minimum_size(Size2(0, 300 * EDSCALE));
+	set_rect_minimum_size(Size2(0, 300 * EDSCALE));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -180,7 +180,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			open_in_editor->set_icon(get_theme_icon("Edit", "EditorIcons"));
 			node->add_child(open_in_editor);
 			open_in_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_open_in_editor), varray(E->get()), CONNECT_DEFERRED);
-			open_in_editor->set_h_size_flags(SIZE_SHRINK_CENTER);
+			open_in_editor->set_size_flags_horizontal(SIZE_SHRINK_CENTER);
 		}
 
 		if (agnode->has_filter()) {
@@ -190,7 +190,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			edit_filters->set_icon(get_theme_icon("AnimationFilter", "EditorIcons"));
 			node->add_child(edit_filters);
 			edit_filters->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_edit_filters), varray(E->get()), CONNECT_DEFERRED);
-			edit_filters->set_h_size_flags(SIZE_SHRINK_CENTER);
+			edit_filters->set_size_flags_horizontal(SIZE_SHRINK_CENTER);
 		}
 
 		Ref<AnimationNodeAnimation> anim = agnode;
@@ -224,7 +224,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			}
 
 			pb->set_percent_visible(false);
-			pb->set_custom_minimum_size(Vector2(0, 14) * EDSCALE);
+			pb->set_rect_minimum_size(Vector2(0, 14) * EDSCALE);
 			animations[E->get()] = pb;
 			node->add_child(pb);
 
@@ -314,7 +314,7 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 	if (use_popup_menu_position) {
 		instance_pos += popup_menu_position;
 	} else {
-		instance_pos += graph->get_size() * 0.5;
+		instance_pos += graph->get_rect_size() * 0.5;
 	}
 
 	instance_pos /= graph->get_zoom();
@@ -813,7 +813,7 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 	undo_redo->commit_action();
 	updating = false;
 	gn->set_name(new_name);
-	gn->set_size(gn->get_minimum_size());
+	gn->set_rect_size(gn->get_minimum_size());
 
 	//change editors accordingly
 	for (int i = 0; i < visible_properties.size(); i++) {
@@ -884,7 +884,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_child(graph);
 	graph->add_valid_right_disconnect_type(0);
 	graph->add_valid_left_disconnect_type(0);
-	graph->set_v_size_flags(SIZE_EXPAND_FILL);
+	graph->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	graph->connect("connection_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_connection_request), varray(), CONNECT_DEFERRED);
 	graph->connect("disconnection_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_disconnection_request), varray(), CONNECT_DEFERRED);
 	graph->connect("node_selected", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_selected));
@@ -940,7 +940,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 
 	filters = memnew(Tree);
 	filter_vbox->add_child(filters);
-	filters->set_v_size_flags(SIZE_EXPAND_FILL);
+	filters->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	filters->set_hide_root(true);
 	filters->connect("item_edited", callable_mp(this, &AnimationNodeBlendTreeEditor::_filter_edited));
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -916,7 +916,7 @@ void AnimationPlayerEditor::forward_canvas_force_draw_over_viewport(Control *p_o
 	src_rect.position.y = onion.capture_size.y - (src_rect.position.y + src_rect.size.y);
 	src_rect.size.y *= -1;
 
-	Rect2 dst_rect = Rect2(Point2(), p_overlay->get_size());
+	Rect2 dst_rect = Rect2(Point2(), p_overlay->get_rect_size());
 
 	float alpha_step = 1.0 / (onion.steps + 1);
 
@@ -1549,8 +1549,8 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	frame = memnew(SpinBox);
 	hb->add_child(frame);
-	frame->set_custom_minimum_size(Size2(60, 0));
-	frame->set_stretch_ratio(2);
+	frame->set_rect_minimum_size(Size2(60, 0));
+	frame->set_size_flags_stretch_ratio(2);
 	frame->set_step(0.0001);
 	frame->set_tooltip(TTR("Animation position (in seconds)."));
 
@@ -1558,8 +1558,8 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	scale = memnew(LineEdit);
 	hb->add_child(scale);
-	scale->set_h_size_flags(SIZE_EXPAND_FILL);
-	scale->set_stretch_ratio(1);
+	scale->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	scale->set_size_flags_stretch_ratio(1);
 	scale->set_tooltip(TTR("Scale animation playback globally for the node."));
 	scale->hide();
 
@@ -1592,7 +1592,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	animation = memnew(OptionButton);
 	hb->add_child(animation);
-	animation->set_h_size_flags(SIZE_EXPAND_FILL);
+	animation->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	animation->set_tooltip(TTR("Display list of animations in player."));
 	animation->set_clip_text(true);
 
@@ -1703,7 +1703,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	set_process_unhandled_key_input(true);
 
 	add_child(track_editor);
-	track_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	track_editor->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	track_editor->connect("timeline_changed", callable_mp(this, &AnimationPlayerEditor::_animation_key_editor_seek));
 	track_editor->connect("animation_len_changed", callable_mp(this, &AnimationPlayerEditor::_animation_key_editor_anim_len_changed));
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -378,9 +378,9 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 		if (over_text != over_text_now) {
 			if (over_text_now) {
-				state_machine_draw->set_default_cursor_shape(CURSOR_IBEAM);
+				state_machine_draw->set_mouse_default_cursor_shape(CURSOR_IBEAM);
 			} else {
-				state_machine_draw->set_default_cursor_shape(CURSOR_ARROW);
+				state_machine_draw->set_mouse_default_cursor_shape(CURSOR_ARROW);
 			}
 
 			over_text = over_text_now;
@@ -582,7 +582,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	}
 
 	if (state_machine_draw->has_focus()) {
-		state_machine_draw->draw_rect(Rect2(Point2(), state_machine_draw->get_size()), accent, false);
+		state_machine_draw->draw_rect(Rect2(Point2(), state_machine_draw->get_rect_size()), accent, false);
 	}
 	int sep = 3 * EDSCALE;
 
@@ -801,19 +801,19 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		}
 	}
 
-	scroll_range.position -= state_machine_draw->get_size();
-	scroll_range.size += state_machine_draw->get_size() * 2.0;
+	scroll_range.position -= state_machine_draw->get_rect_size();
+	scroll_range.size += state_machine_draw->get_rect_size() * 2.0;
 
 	//adjust scrollbars
 	updating = true;
 	h_scroll->set_min(scroll_range.position.x);
 	h_scroll->set_max(scroll_range.position.x + scroll_range.size.x);
-	h_scroll->set_page(state_machine_draw->get_size().x);
+	h_scroll->set_page(state_machine_draw->get_rect_size().x);
 	h_scroll->set_value(state_machine->get_graph_offset().x);
 
 	v_scroll->set_min(scroll_range.position.y);
 	v_scroll->set_max(scroll_range.position.y + scroll_range.size.y);
-	v_scroll->set_page(state_machine_draw->get_size().y);
+	v_scroll->set_page(state_machine_draw->get_rect_size().y);
 	v_scroll->set_value(state_machine->get_graph_offset().y);
 	updating = false;
 
@@ -1278,9 +1278,9 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	top_hb->add_child(play_mode);
 
 	panel = memnew(PanelContainer);
-	panel->set_clip_contents(true);
+	panel->set_rect_clip_contents(true);
 	add_child(panel);
-	panel->set_v_size_flags(SIZE_EXPAND_FILL);
+	panel->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	state_machine_draw = memnew(Control);
 	panel->add_child(state_machine_draw);
@@ -1302,7 +1302,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	h_scroll = memnew(HScrollBar);
 	state_machine_draw->add_child(h_scroll);
 	h_scroll->set_anchors_and_offsets_preset(PRESET_BOTTOM_WIDE);
-	h_scroll->set_offset(SIDE_RIGHT, -v_scroll->get_size().x * EDSCALE);
+	h_scroll->set_offset(SIDE_RIGHT, -v_scroll->get_rect_size().x * EDSCALE);
 	h_scroll->connect("value_changed", callable_mp(this, &AnimationNodeStateMachineEditor::_scroll_changed));
 
 	error_panel = memnew(PanelContainer);
@@ -1313,7 +1313,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	undo_redo = EditorNode::get_undo_redo();
 
-	set_custom_minimum_size(Size2(0, 300 * EDSCALE));
+	set_rect_minimum_size(Size2(0, 300 * EDSCALE));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -168,8 +168,8 @@ void AnimationTreeEditor::add_plugin(AnimationTreeNodeEditorPlugin *p_editor) {
 	ERR_FAIL_COND(p_editor->get_parent());
 	editor_base->add_child(p_editor);
 	editors.push_back(p_editor);
-	p_editor->set_h_size_flags(SIZE_EXPAND_FILL);
-	p_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	p_editor->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	p_editor->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	p_editor->hide();
 }
 
@@ -236,7 +236,7 @@ AnimationTreeEditor::AnimationTreeEditor() {
 
 	singleton = this;
 	editor_base = memnew(MarginContainer);
-	editor_base->set_v_size_flags(SIZE_EXPAND_FILL);
+	editor_base->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	add_child(editor_base);
 
 	add_plugin(memnew(AnimationNodeBlendTreeEditor));
@@ -272,7 +272,7 @@ void AnimationTreeEditorPlugin::make_visible(bool p_visible) {
 AnimationTreeEditorPlugin::AnimationTreeEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	anim_tree_editor = memnew(AnimationTreeEditor);
-	anim_tree_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
+	anim_tree_editor->set_rect_minimum_size(Size2(0, 300) * EDSCALE);
 
 	button = editor->add_bottom_panel_item(TTR("AnimationTree"), anim_tree_editor);
 	button->hide();

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -99,8 +99,8 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 	add_child(hb);
 
 	icon = memnew(TextureButton);
-	icon->set_custom_minimum_size(Size2(64, 64) * EDSCALE);
-	icon->set_default_cursor_shape(CURSOR_POINTING_HAND);
+	icon->set_rect_minimum_size(Size2(64, 64) * EDSCALE);
+	icon->set_mouse_default_cursor_shape(CURSOR_POINTING_HAND);
 	icon->connect("pressed", callable_mp(this, &EditorAssetLibraryItem::_asset_clicked));
 
 	hb->add_child(icon);
@@ -108,7 +108,7 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 	VBoxContainer *vb = memnew(VBoxContainer);
 
 	hb->add_child(vb);
-	vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	title = memnew(LinkButton);
 	title->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
@@ -128,8 +128,8 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 	price = memnew(Label);
 	vb->add_child(price);
 
-	set_custom_minimum_size(Size2(250, 100) * EDSCALE);
-	set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	set_rect_minimum_size(Size2(250, 100) * EDSCALE);
+	set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -160,7 +160,7 @@ void EditorAssetLibraryItemDescription::set_image(int p_type, int p_index, const
 
 						preview_images[i].button->set_icon(tex);
 						// Make it clearer that clicking it will open an external link
-						preview_images[i].button->set_default_cursor_shape(Control::CURSOR_POINTING_HAND);
+						preview_images[i].button->set_mouse_default_cursor_shape(Control::CURSOR_POINTING_HAND);
 					} else {
 						preview_images[i].button->set_icon(p_image);
 					}
@@ -264,35 +264,35 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	item = memnew(EditorAssetLibraryItem);
 
 	desc_vbox->add_child(item);
-	desc_vbox->set_custom_minimum_size(Size2(440 * EDSCALE, 0));
+	desc_vbox->set_rect_minimum_size(Size2(440 * EDSCALE, 0));
 
 	description = memnew(RichTextLabel);
 	desc_vbox->add_child(description);
-	description->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	description->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	description->connect("meta_clicked", callable_mp(this, &EditorAssetLibraryItemDescription::_link_click));
 	description->add_theme_constant_override("line_separation", Math::round(5 * EDSCALE));
 
 	VBoxContainer *previews_vbox = memnew(VBoxContainer);
 	hbox->add_child(previews_vbox);
 	previews_vbox->add_theme_constant_override("separation", 15 * EDSCALE);
-	previews_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	previews_vbox->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	preview = memnew(TextureRect);
 	previews_vbox->add_child(preview);
 	preview->set_expand(true);
 	preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	preview->set_custom_minimum_size(Size2(640 * EDSCALE, 345 * EDSCALE));
+	preview->set_rect_minimum_size(Size2(640 * EDSCALE, 345 * EDSCALE));
 
 	previews_bg = memnew(PanelContainer);
 	previews_vbox->add_child(previews_bg);
-	previews_bg->set_custom_minimum_size(Size2(640 * EDSCALE, 101 * EDSCALE));
+	previews_bg->set_rect_minimum_size(Size2(640 * EDSCALE, 101 * EDSCALE));
 
 	previews = memnew(ScrollContainer);
 	previews_bg->add_child(previews);
 	previews->set_enable_v_scroll(false);
 	previews->set_enable_h_scroll(true);
 	preview_hb = memnew(HBoxContainer);
-	preview_hb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	preview_hb->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	previews->add_child(preview_hb);
 	get_ok_button()->set_text(TTR("Download"));
@@ -487,13 +487,13 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 	hb->add_child(vb);
-	vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	HBoxContainer *title_hb = memnew(HBoxContainer);
 	vb->add_child(title_hb);
 	title = memnew(Label);
 	title_hb->add_child(title);
-	title->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	title->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	dismiss = memnew(TextureButton);
 	dismiss->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDownload::_close));
@@ -526,7 +526,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 
 	hb2->add_child(retry);
 	hb2->add_child(install);
-	set_custom_minimum_size(Size2(310, 0) * EDSCALE);
+	set_rect_minimum_size(Size2(310, 0) * EDSCALE);
 
 	download = memnew(HTTPRequest);
 	add_child(download);
@@ -1347,7 +1347,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 		filter->set_placeholder(TTR("Search assets (excluding templates, projects, and demos)"));
 	}
 	search_hb->add_child(filter);
-	filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	filter->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	filter->connect("text_changed", callable_mp(this, &EditorAssetLibrary::_search_text_changed));
 
 	// Perform a search automatically if the user hasn't entered any text for a certain duration.
@@ -1388,7 +1388,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	search_hb2->add_child(sort);
 
-	sort->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	sort->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	sort->connect("item_selected", callable_mp(this, &EditorAssetLibrary::_rerun_search));
 
 	search_hb2->add_child(memnew(VSeparator));
@@ -1397,7 +1397,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	categories = memnew(OptionButton);
 	categories->add_item(TTR("All"));
 	search_hb2->add_child(categories);
-	categories->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	categories->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	categories->connect("item_selected", callable_mp(this, &EditorAssetLibrary::_rerun_search));
 
 	search_hb2->add_child(memnew(VSeparator));
@@ -1410,7 +1410,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	repository->connect("item_selected", callable_mp(this, &EditorAssetLibrary::_repository_changed));
 
 	search_hb2->add_child(repository);
-	repository->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	repository->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	search_hb2->add_child(memnew(VSeparator));
 
@@ -1429,7 +1429,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	library_scroll_bg = memnew(PanelContainer);
 	library_main->add_child(library_scroll_bg);
-	library_scroll_bg->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	library_scroll_bg->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	library_scroll = memnew(ScrollContainer);
 	library_scroll->set_enable_v_scroll(true);
@@ -1447,10 +1447,10 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	PanelContainer *library_vb_border = memnew(PanelContainer);
 	library_scroll->add_child(library_vb_border);
 	library_vb_border->add_theme_style_override("panel", border2);
-	library_vb_border->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	library_vb_border->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	library_vb = memnew(VBoxContainer);
-	library_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	library_vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	library_vb_border->add_child(library_vb);
 
@@ -1491,7 +1491,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	error_label->add_theme_color_override("color", get_theme_color("error_color", "Editor"));
 	error_hb->add_child(error_label);
 	error_tr = memnew(TextureRect);
-	error_tr->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	error_tr->set_size_flags_vertical(Control::SIZE_SHRINK_CENTER);
 	error_hb->add_child(error_tr);
 
 	description = nullptr;
@@ -1530,7 +1530,7 @@ void AssetLibraryEditorPlugin::make_visible(bool p_visible) {
 AssetLibraryEditorPlugin::AssetLibraryEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	addon_library = memnew(EditorAssetLibrary);
-	addon_library->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	addon_library->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	editor->get_main_control()->add_child(addon_library);
 	addon_library->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	addon_library->hide();

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -65,7 +65,7 @@ void AudioStreamEditor::_notification(int p_what) {
 
 void AudioStreamEditor::_draw_preview() {
 	Rect2 rect = _preview->get_rect();
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 
 	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(stream);
 	float preview_len = preview->get_length();
@@ -198,7 +198,7 @@ void AudioStreamEditor::_bind_methods() {
 }
 
 AudioStreamEditor::AudioStreamEditor() {
-	set_custom_minimum_size(Size2(1, 100) * EDSCALE);
+	set_rect_minimum_size(Size2(1, 100) * EDSCALE);
 
 	_player = memnew(AudioStreamPlayer);
 	_player->connect("finished", callable_mp(this, &AudioStreamEditor::_on_finished));
@@ -209,7 +209,7 @@ AudioStreamEditor::AudioStreamEditor() {
 	add_child(vbox);
 
 	_preview = memnew(ColorRect);
-	_preview->set_v_size_flags(SIZE_EXPAND_FILL);
+	_preview->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	_preview->connect("draw", callable_mp(this, &AudioStreamEditor::_draw_preview));
 	vbox->add_child(_preview);
 
@@ -237,7 +237,7 @@ AudioStreamEditor::AudioStreamEditor() {
 
 	_current_label = memnew(Label);
 	_current_label->set_align(Label::ALIGN_RIGHT);
-	_current_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	_current_label->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	_current_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
 	_current_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
 	_current_label->set_modulate(Color(1, 1, 1, 0.5));

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -100,7 +100,7 @@ public:
 		label = memnew(Label);
 		label->set_text(TTR("Grid Offset:"));
 		child_container->add_child(label);
-		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 		grid_offset_x = memnew(SpinBox);
 		grid_offset_x->set_min(-SPIN_BOX_GRID_RANGE);
@@ -108,7 +108,7 @@ public:
 		grid_offset_x->set_allow_lesser(true);
 		grid_offset_x->set_allow_greater(true);
 		grid_offset_x->set_suffix("px");
-		grid_offset_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		grid_offset_x->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		child_container->add_child(grid_offset_x);
 
 		grid_offset_y = memnew(SpinBox);
@@ -117,20 +117,20 @@ public:
 		grid_offset_y->set_allow_lesser(true);
 		grid_offset_y->set_allow_greater(true);
 		grid_offset_y->set_suffix("px");
-		grid_offset_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		grid_offset_y->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		child_container->add_child(grid_offset_y);
 
 		label = memnew(Label);
 		label->set_text(TTR("Grid Step:"));
 		child_container->add_child(label);
-		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 		grid_step_x = memnew(SpinBox);
 		grid_step_x->set_min(0.01);
 		grid_step_x->set_max(SPIN_BOX_GRID_RANGE);
 		grid_step_x->set_allow_greater(true);
 		grid_step_x->set_suffix("px");
-		grid_step_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		grid_step_x->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		child_container->add_child(grid_step_x);
 
 		grid_step_y = memnew(SpinBox);
@@ -138,7 +138,7 @@ public:
 		grid_step_y->set_max(SPIN_BOX_GRID_RANGE);
 		grid_step_y->set_allow_greater(true);
 		grid_step_y->set_suffix("px");
-		grid_step_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		grid_step_y->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		child_container->add_child(grid_step_y);
 
 		child_container = memnew(GridContainer);
@@ -147,7 +147,7 @@ public:
 
 		label = memnew(Label);
 		label->set_text(TTR("Primary Line Every:"));
-		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		child_container->add_child(label);
 
 		primary_grid_steps = memnew(SpinBox);
@@ -156,7 +156,7 @@ public:
 		primary_grid_steps->set_max(100);
 		primary_grid_steps->set_allow_greater(true);
 		primary_grid_steps->set_suffix(TTR("steps"));
-		primary_grid_steps->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		primary_grid_steps->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		child_container->add_child(primary_grid_steps);
 
 		container->add_child(memnew(HSeparator));
@@ -170,25 +170,25 @@ public:
 		label = memnew(Label);
 		label->set_text(TTR("Rotation Offset:"));
 		child_container->add_child(label);
-		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 		rotation_offset = memnew(SpinBox);
 		rotation_offset->set_min(-SPIN_BOX_ROTATION_RANGE);
 		rotation_offset->set_max(SPIN_BOX_ROTATION_RANGE);
 		rotation_offset->set_suffix("deg");
-		rotation_offset->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		rotation_offset->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		child_container->add_child(rotation_offset);
 
 		label = memnew(Label);
 		label->set_text(TTR("Rotation Step:"));
 		child_container->add_child(label);
-		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 		rotation_step = memnew(SpinBox);
 		rotation_step->set_min(-SPIN_BOX_ROTATION_RANGE);
 		rotation_step->set_max(SPIN_BOX_ROTATION_RANGE);
 		rotation_step->set_suffix("deg");
-		rotation_step->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		rotation_step->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		child_container->add_child(rotation_step);
 
 		container->add_child(memnew(HSeparator));
@@ -199,13 +199,13 @@ public:
 		label = memnew(Label);
 		label->set_text(TTR("Scale Step:"));
 		child_container->add_child(label);
-		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 		scale_step = memnew(SpinBox);
 		scale_step->set_min(SPIN_BOX_SCALE_MIN);
 		scale_step->set_max(SPIN_BOX_SCALE_MAX);
 		scale_step->set_allow_greater(true);
-		scale_step->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		scale_step->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		scale_step->set_step(0.01f);
 		child_container->add_child(scale_step);
 	}
@@ -2844,7 +2844,7 @@ void CanvasItemEditor::_update_cursor() {
 		c = CURSOR_HSIZE;
 	}
 
-	viewport->set_default_cursor_shape(c);
+	viewport->set_mouse_default_cursor_shape(c);
 }
 
 void CanvasItemEditor::_draw_text_at_position(Point2 p_position, String p_string, Side p_side) {
@@ -2887,7 +2887,7 @@ void CanvasItemEditor::_draw_percentage_at_position(float p_value, Point2 p_posi
 void CanvasItemEditor::_draw_focus() {
 	// Draw the focus around the base viewport
 	if (viewport->has_focus()) {
-		get_theme_stylebox("Focus", "EditorStyles")->draw(viewport->get_canvas_item(), Rect2(Point2(), viewport->get_size()));
+		get_theme_stylebox("Focus", "EditorStyles")->draw(viewport->get_canvas_item(), Rect2(Point2(), viewport->get_rect_size()));
 	}
 }
 
@@ -2903,7 +2903,7 @@ void CanvasItemEditor::_draw_guides() {
 				continue;
 			}
 			float x = xform.xform(Point2(vguides[i], 0)).x;
-			viewport->draw_line(Point2(x, 0), Point2(x, viewport->get_size().y), guide_color, Math::round(EDSCALE));
+			viewport->draw_line(Point2(x, 0), Point2(x, viewport->get_rect_size().y), guide_color, Math::round(EDSCALE));
 		}
 	}
 
@@ -2914,7 +2914,7 @@ void CanvasItemEditor::_draw_guides() {
 				continue;
 			}
 			float y = xform.xform(Point2(0, hguides[i])).y;
-			viewport->draw_line(Point2(0, y), Point2(viewport->get_size().x, y), guide_color, Math::round(EDSCALE));
+			viewport->draw_line(Point2(0, y), Point2(viewport->get_rect_size().x, y), guide_color, Math::round(EDSCALE));
 		}
 	}
 
@@ -2928,7 +2928,7 @@ void CanvasItemEditor::_draw_guides() {
 		int font_size = get_theme_font_size("bold_size", "EditorFonts");
 		Size2 text_size = font->get_string_size(str, font_size);
 		viewport->draw_string(font, Point2(dragged_guide_pos.x + 10, RULER_WIDTH + text_size.y / 2 + 10), str, HALIGN_LEFT, -1, font_size, text_color, outline_size, outline_color);
-		viewport->draw_line(Point2(dragged_guide_pos.x, 0), Point2(dragged_guide_pos.x, viewport->get_size().y), guide_color, Math::round(EDSCALE));
+		viewport->draw_line(Point2(dragged_guide_pos.x, 0), Point2(dragged_guide_pos.x, viewport->get_rect_size().y), guide_color, Math::round(EDSCALE));
 	}
 	if (drag_type == DRAG_DOUBLE_GUIDE || drag_type == DRAG_H_GUIDE) {
 		String str = TS->format_number(vformat("%d px", Math::round(xform.affine_inverse().xform(dragged_guide_pos).y)));
@@ -2936,7 +2936,7 @@ void CanvasItemEditor::_draw_guides() {
 		int font_size = get_theme_font_size("bold_size", "EditorFonts");
 		Size2 text_size = font->get_string_size(str, font_size);
 		viewport->draw_string(font, Point2(RULER_WIDTH + 10, dragged_guide_pos.y + text_size.y / 2 + 10), str, HALIGN_LEFT, -1, font_size, text_color, outline_size, outline_color);
-		viewport->draw_line(Point2(0, dragged_guide_pos.y), Point2(viewport->get_size().x, dragged_guide_pos.y), guide_color, Math::round(EDSCALE));
+		viewport->draw_line(Point2(0, dragged_guide_pos.y), Point2(viewport->get_rect_size().x, dragged_guide_pos.y), guide_color, Math::round(EDSCALE));
 	}
 }
 
@@ -2998,10 +2998,10 @@ void CanvasItemEditor::_draw_rulers() {
 
 	// First and last graduations to draw (in the ruler space)
 	Point2 first = (transform * ruler_transform * major_subdivide * minor_subdivide).affine_inverse().xform(Point2(RULER_WIDTH, RULER_WIDTH));
-	Point2 last = (transform * ruler_transform * major_subdivide * minor_subdivide).affine_inverse().xform(viewport->get_size());
+	Point2 last = (transform * ruler_transform * major_subdivide * minor_subdivide).affine_inverse().xform(viewport->get_rect_size());
 
 	// Draw top ruler
-	viewport->draw_rect(Rect2(Point2(RULER_WIDTH, 0), Size2(viewport->get_size().x, RULER_WIDTH)), bg_color);
+	viewport->draw_rect(Rect2(Point2(RULER_WIDTH, 0), Size2(viewport->get_rect_size().x, RULER_WIDTH)), bg_color);
 	for (int i = Math::ceil(first.x); i < last.x; i++) {
 		Point2 position = (transform * ruler_transform * major_subdivide * minor_subdivide).xform(Point2(i, 0)).round();
 		if (i % (major_subdivision * minor_subdivision) == 0) {
@@ -3018,7 +3018,7 @@ void CanvasItemEditor::_draw_rulers() {
 	}
 
 	// Draw left ruler
-	viewport->draw_rect(Rect2(Point2(0, RULER_WIDTH), Size2(RULER_WIDTH, viewport->get_size().y)), bg_color);
+	viewport->draw_rect(Rect2(Point2(0, RULER_WIDTH), Size2(RULER_WIDTH, viewport->get_rect_size().y)), bg_color);
 	for (int i = Math::ceil(first.y); i < last.y; i++) {
 		Point2 position = (transform * ruler_transform * major_subdivide * minor_subdivide).xform(Point2(0, i)).round();
 		if (i % (major_subdivision * minor_subdivision) == 0) {
@@ -3063,7 +3063,7 @@ void CanvasItemEditor::_draw_grid() {
 		const Color primary_grid_color =
 				Color(secondary_grid_color.r, secondary_grid_color.g, secondary_grid_color.b, secondary_grid_color.a * 2.5);
 
-		const Size2 viewport_size = viewport->get_size();
+		const Size2 viewport_size = viewport->get_rect_size();
 		const Transform2D xform = transform.affine_inverse();
 		int last_cell = 0;
 
@@ -3380,7 +3380,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			case DRAG_LEFT:
 			case DRAG_TOP_LEFT:
 			case DRAG_BOTTOM_LEFT:
-				_draw_margin_at_position(control->get_size().width, parent_transform.xform(Vector2((node_pos_in_parent[0] + node_pos_in_parent[2]) / 2, node_pos_in_parent[3])) + Vector2(0, 5), SIDE_BOTTOM);
+				_draw_margin_at_position(control->get_rect_size().width, parent_transform.xform(Vector2((node_pos_in_parent[0] + node_pos_in_parent[2]) / 2, node_pos_in_parent[3])) + Vector2(0, 5), SIDE_BOTTOM);
 				[[fallthrough]];
 			case DRAG_MOVE:
 				start = Vector2(node_pos_in_parent[0], Math::lerp(node_pos_in_parent[1], node_pos_in_parent[3], ratio));
@@ -3395,7 +3395,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			case DRAG_RIGHT:
 			case DRAG_TOP_RIGHT:
 			case DRAG_BOTTOM_RIGHT:
-				_draw_margin_at_position(control->get_size().width, parent_transform.xform(Vector2((node_pos_in_parent[0] + node_pos_in_parent[2]) / 2, node_pos_in_parent[3])) + Vector2(0, 5), SIDE_BOTTOM);
+				_draw_margin_at_position(control->get_rect_size().width, parent_transform.xform(Vector2((node_pos_in_parent[0] + node_pos_in_parent[2]) / 2, node_pos_in_parent[3])) + Vector2(0, 5), SIDE_BOTTOM);
 				[[fallthrough]];
 			case DRAG_MOVE:
 				start = Vector2(node_pos_in_parent[2], Math::lerp(node_pos_in_parent[3], node_pos_in_parent[1], ratio));
@@ -3410,7 +3410,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			case DRAG_TOP:
 			case DRAG_TOP_LEFT:
 			case DRAG_TOP_RIGHT:
-				_draw_margin_at_position(control->get_size().height, parent_transform.xform(Vector2(node_pos_in_parent[2], (node_pos_in_parent[1] + node_pos_in_parent[3]) / 2)) + Vector2(5, 0), SIDE_RIGHT);
+				_draw_margin_at_position(control->get_rect_size().height, parent_transform.xform(Vector2(node_pos_in_parent[2], (node_pos_in_parent[1] + node_pos_in_parent[3]) / 2)) + Vector2(5, 0), SIDE_RIGHT);
 				[[fallthrough]];
 			case DRAG_MOVE:
 				start = Vector2(Math::lerp(node_pos_in_parent[0], node_pos_in_parent[2], ratio), node_pos_in_parent[1]);
@@ -3425,7 +3425,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			case DRAG_BOTTOM:
 			case DRAG_BOTTOM_LEFT:
 			case DRAG_BOTTOM_RIGHT:
-				_draw_margin_at_position(control->get_size().height, parent_transform.xform(Vector2(node_pos_in_parent[2], (node_pos_in_parent[1] + node_pos_in_parent[3]) / 2) + Vector2(5, 0)), SIDE_RIGHT);
+				_draw_margin_at_position(control->get_rect_size().height, parent_transform.xform(Vector2(node_pos_in_parent[2], (node_pos_in_parent[1] + node_pos_in_parent[3]) / 2) + Vector2(5, 0)), SIDE_RIGHT);
 				[[fallthrough]];
 			case DRAG_MOVE:
 				start = Vector2(Math::lerp(node_pos_in_parent[2], node_pos_in_parent[0], ratio), node_pos_in_parent[3]);
@@ -3448,8 +3448,8 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			case DRAG_BOTTOM:
 			case DRAG_BOTTOM_LEFT:
 			case DRAG_MOVE:
-				if (control->get_rotation() != 0.0 || control->get_scale() != Vector2(1, 1)) {
-					Rect2 rect = Rect2(Vector2(node_pos_in_parent[0], node_pos_in_parent[1]), control->get_size());
+				if (control->get_rect_rotation() != 0.0 || control->get_rect_scale() != Vector2(1, 1)) {
+					Rect2 rect = Rect2(Vector2(node_pos_in_parent[0], node_pos_in_parent[1]), control->get_rect_size());
 					viewport->draw_rect(parent_transform.xform(rect), color_base, false, Math::round(EDSCALE));
 				}
 				break;
@@ -3672,7 +3672,7 @@ void CanvasItemEditor::_draw_straight_line(Point2 p_from, Point2 p_to, Color p_c
 	Vector<Point2> points;
 	Point2 from = transform.xform(p_from);
 	Point2 to = transform.xform(p_to);
-	Size2 viewport_size = viewport->get_size();
+	Size2 viewport_size = viewport->get_rect_size();
 
 	if (to.x == from.x) {
 		// Vertical line
@@ -4086,7 +4086,7 @@ void CanvasItemEditor::_notification(int p_what) {
 				float anchors[4];
 				Vector2 pivot;
 
-				pivot = control->get_pivot_offset();
+				pivot = control->get_rect_pivot_offset();
 				anchors[SIDE_LEFT] = control->get_anchor(SIDE_LEFT);
 				anchors[SIDE_RIGHT] = control->get_anchor(SIDE_RIGHT);
 				anchors[SIDE_TOP] = control->get_anchor(SIDE_TOP);
@@ -4376,7 +4376,7 @@ void CanvasItemEditor::_update_scrollbars() {
 
 	// Get the visible frame.
 	Size2 screen_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
-	Rect2 local_rect = Rect2(Point2(), viewport->get_size() - Size2(vmin.width, hmin.height));
+	Rect2 local_rect = Rect2(Point2(), viewport->get_rect_size() - Size2(vmin.width, hmin.height));
 
 	_queue_update_bone_list();
 
@@ -4391,7 +4391,7 @@ void CanvasItemEditor::_update_scrollbars() {
 	canvas_item_rect.position -= screen_rect;
 
 	// Constraints the view offset and updates the scrollbars.
-	Size2 size = viewport->get_size();
+	Size2 size = viewport->get_rect_size();
 	Point2 begin = canvas_item_rect.position;
 	Point2 end = canvas_item_rect.position + canvas_item_rect.size - local_rect.size / zoom;
 	bool constrain_editor_view = bool(EditorSettings::get_singleton()->get("editors/2d/constrain_editor_view"));
@@ -4545,7 +4545,7 @@ void CanvasItemEditor::_set_anchors_and_offsets_to_keep_ratio() {
 		Control *control = Object::cast_to<Control>(E->get());
 		if (control) {
 			Point2 top_left_anchor = _position_to_anchor(control, Point2());
-			Point2 bottom_right_anchor = _position_to_anchor(control, control->get_size());
+			Point2 bottom_right_anchor = _position_to_anchor(control, control->get_rect_size());
 			undo_redo->add_do_method(control, "set_anchor", SIDE_LEFT, top_left_anchor.x, false, true);
 			undo_redo->add_do_method(control, "set_anchor", SIDE_RIGHT, bottom_right_anchor.x, false, true);
 			undo_redo->add_do_method(control, "set_anchor", SIDE_TOP, top_left_anchor.y, false, true);
@@ -4651,15 +4651,15 @@ void CanvasItemEditor::_update_zoom_label() {
 }
 
 void CanvasItemEditor::_button_zoom_minus() {
-	_zoom_on_position(_get_next_zoom_value(-6), viewport_scrollable->get_size() / 2.0);
+	_zoom_on_position(_get_next_zoom_value(-6), viewport_scrollable->get_rect_size() / 2.0);
 }
 
 void CanvasItemEditor::_button_zoom_reset() {
-	_zoom_on_position(1.0 * MAX(1, EDSCALE), viewport_scrollable->get_size() / 2.0);
+	_zoom_on_position(1.0 * MAX(1, EDSCALE), viewport_scrollable->get_rect_size() / 2.0);
 }
 
 void CanvasItemEditor::_button_zoom_plus() {
-	_zoom_on_position(_get_next_zoom_value(6), viewport_scrollable->get_size() / 2.0);
+	_zoom_on_position(_get_next_zoom_value(6), viewport_scrollable->get_rect_size() / 2.0);
 }
 
 void CanvasItemEditor::_button_toggle_smart_snap(bool p_status) {
@@ -4694,7 +4694,7 @@ void CanvasItemEditor::_button_tool_select(int p_index) {
 	_update_cursor();
 
 	// Request immediate refresh of cursor when using hot-keys to switch between tools
-	DisplayServer::CursorShape ds_cursor_shape = (DisplayServer::CursorShape)viewport->get_default_cursor_shape();
+	DisplayServer::CursorShape ds_cursor_shape = (DisplayServer::CursorShape)viewport->get_mouse_default_cursor_shape();
 	DisplayServer::get_singleton()->cursor_set_shape(ds_cursor_shape);
 }
 
@@ -4763,13 +4763,13 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 			Control *ctrl = Object::cast_to<Control>(canvas_item);
 
 			if (key_pos) {
-				AnimationPlayerEditor::singleton->get_track_editor()->insert_node_value_key(ctrl, "rect_position", ctrl->get_position(), p_on_existing);
+				AnimationPlayerEditor::singleton->get_track_editor()->insert_node_value_key(ctrl, "rect_position", ctrl->get_rect_position(), p_on_existing);
 			}
 			if (key_rot) {
-				AnimationPlayerEditor::singleton->get_track_editor()->insert_node_value_key(ctrl, "rect_rotation", ctrl->get_rotation_degrees(), p_on_existing);
+				AnimationPlayerEditor::singleton->get_track_editor()->insert_node_value_key(ctrl, "rect_rotation", ctrl->get_rect_rotation_degrees(), p_on_existing);
 			}
 			if (key_scale) {
-				AnimationPlayerEditor::singleton->get_track_editor()->insert_node_value_key(ctrl, "rect_size", ctrl->get_size(), p_on_existing);
+				AnimationPlayerEditor::singleton->get_track_editor()->insert_node_value_key(ctrl, "rect_size", ctrl->get_rect_size(), p_on_existing);
 			}
 		}
 	}
@@ -5196,7 +5196,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					Control *ctrl = Object::cast_to<Control>(canvas_item);
 
 					if (key_pos) {
-						ctrl->set_position(Point2());
+						ctrl->set_rect_position(Point2());
 					}
 					/*
                                    if (key_scale)
@@ -5388,7 +5388,7 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 
 	if (p_op == VIEW_CENTER_TO_SELECTION) {
 		center = rect.position + rect.size / 2;
-		Vector2 offset = viewport->get_size() / 2 - editor->get_scene_root()->get_global_canvas_transform().xform(center);
+		Vector2 offset = viewport->get_rect_size() / 2 - editor->get_scene_root()->get_global_canvas_transform().xform(center);
 		view_offset.x -= Math::round(offset.x / zoom);
 		view_offset.y -= Math::round(offset.y / zoom);
 		update_viewport();
@@ -5396,8 +5396,8 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 	} else { // VIEW_FRAME_TO_SELECTION
 
 		if (rect.size.x > CMP_EPSILON && rect.size.y > CMP_EPSILON) {
-			float scale_x = viewport->get_size().x / rect.size.x;
-			float scale_y = viewport->get_size().y / rect.size.y;
+			float scale_x = viewport->get_rect_size().x / rect.size.x;
+			float scale_y = viewport->get_rect_size().y / rect.size.y;
 			zoom = scale_x < scale_y ? scale_x : scale_y;
 			zoom *= 0.90;
 			viewport->update();
@@ -5636,7 +5636,7 @@ void CanvasItemEditor::set_state(const Dictionary &p_state) {
 void CanvasItemEditor::add_control_to_info_overlay(Control *p_control) {
 	ERR_FAIL_COND(!p_control);
 
-	p_control->set_h_size_flags(p_control->get_h_size_flags() & ~Control::SIZE_EXPAND_FILL);
+	p_control->set_size_flags_horizontal(p_control->get_size_flags_horizontal() & ~Control::SIZE_EXPAND_FILL);
 	info_overlay->add_child(p_control);
 	info_overlay->set_offset(SIDE_LEFT, (show_rulers ? RULER_WIDTH : 0) + 10);
 }
@@ -5747,18 +5747,18 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	bottom_split = memnew(VSplitContainer);
 	add_child(bottom_split);
-	bottom_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	bottom_split->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	palette_split = memnew(HSplitContainer);
 	bottom_split->add_child(palette_split);
-	palette_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	palette_split->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	viewport_scrollable = memnew(Control);
 	palette_split->add_child(viewport_scrollable);
 	viewport_scrollable->set_mouse_filter(MOUSE_FILTER_PASS);
-	viewport_scrollable->set_clip_contents(true);
-	viewport_scrollable->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	viewport_scrollable->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	viewport_scrollable->set_rect_clip_contents(true);
+	viewport_scrollable->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
+	viewport_scrollable->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	viewport_scrollable->connect("draw", callable_mp(this, &CanvasItemEditor::_update_scrollbars));
 
 	SubViewportContainer *scene_tree = memnew(SubViewportContainer);
@@ -5779,7 +5779,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	viewport_scrollable->add_child(viewport);
 	viewport->set_mouse_filter(MOUSE_FILTER_PASS);
 	viewport->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-	viewport->set_clip_contents(true);
+	viewport->set_rect_clip_contents(true);
 	viewport->set_focus_mode(FOCUS_ALL);
 	viewport->connect("draw", callable_mp(this, &CanvasItemEditor::_draw_viewport));
 	viewport->connect("gui_input", callable_mp(this, &CanvasItemEditor::_gui_input_viewport));
@@ -5788,7 +5788,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	info_overlay->set_anchors_and_offsets_preset(Control::PRESET_BOTTOM_LEFT);
 	info_overlay->set_offset(SIDE_LEFT, 10);
 	info_overlay->set_offset(SIDE_BOTTOM, -15);
-	info_overlay->set_v_grow_direction(Control::GROW_DIRECTION_BEGIN);
+	info_overlay->set_grow_vertical(Control::GROW_DIRECTION_BEGIN);
 	info_overlay->add_theme_constant_override("separation", 10);
 	viewport_scrollable->add_child(info_overlay);
 
@@ -5841,7 +5841,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	zoom_reset->set_focus_mode(FOCUS_NONE);
 	zoom_reset->set_text_align(Button::TextAlign::ALIGN_CENTER);
 	// Prevent the button's size from changing when the text size changes
-	zoom_reset->set_custom_minimum_size(Size2(75 * EDSCALE, 0));
+	zoom_reset->set_rect_minimum_size(Size2(75 * EDSCALE, 0));
 
 	zoom_plus = memnew(Button);
 	zoom_plus->set_flat(true);
@@ -5949,7 +5949,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	snap_config_menu = memnew(MenuButton);
 	snap_config_menu->set_shortcut_context(this);
 	hb->add_child(snap_config_menu);
-	snap_config_menu->set_h_size_flags(SIZE_SHRINK_END);
+	snap_config_menu->set_size_flags_horizontal(SIZE_SHRINK_END);
 	snap_config_menu->set_tooltip(TTR("Snapping Options"));
 	snap_config_menu->set_switch_on_hover(true);
 
@@ -6213,7 +6213,7 @@ void CanvasItemEditorPlugin::set_state(const Dictionary &p_state) {
 CanvasItemEditorPlugin::CanvasItemEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	canvas_item_editor = memnew(CanvasItemEditor(editor));
-	canvas_item_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	canvas_item_editor->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	editor->get_main_control()->add_child(canvas_item_editor);
 	canvas_item_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	canvas_item_editor->hide();
@@ -6654,13 +6654,13 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	selector->add_child(vbc);
-	vbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	vbc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	vbc->set_custom_minimum_size(Size2(240, 260) * EDSCALE);
+	vbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
+	vbc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
+	vbc->set_rect_minimum_size(Size2(240, 260) * EDSCALE);
 
 	btn_group = memnew(VBoxContainer);
 	vbc->add_child(btn_group);
-	btn_group->set_h_size_flags(0);
+	btn_group->set_size_flags_horizontal(0);
 
 	button_group.instance();
 	for (int i = 0; i < types.size(); i++) {

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -46,7 +46,7 @@ CurveEditor::CurveEditor() {
 	_has_undo_data = false;
 
 	set_focus_mode(FOCUS_ALL);
-	set_clip_contents(true);
+	set_rect_clip_contents(true);
 
 	_context_menu = memnew(PopupMenu);
 	_context_menu->connect("id_pressed", callable_mp(this, &CurveEditor::on_context_menu_item_selected));
@@ -532,7 +532,7 @@ void CurveEditor::update_view_transform() {
 
 	const Rect2 world_rect = Rect2(Curve::MIN_X, min_y, Curve::MAX_X, max_y - min_y);
 	const Size2 view_margin(margin, margin);
-	const Size2 view_size = get_size() - view_margin * 2;
+	const Size2 view_size = get_rect_size() - view_margin * 2;
 	const Vector2 scale = view_size / world_rect.size;
 
 	Transform2D world_trans;

--- a/editor/plugins/font_editor_plugin.cpp
+++ b/editor/plugins/font_editor_plugin.cpp
@@ -37,10 +37,10 @@ void FontDataPreview::_notification(int p_what) {
 		Color text_color = get_theme_color("font_color", "Label");
 		Color line_color = text_color;
 		line_color.a *= 0.6;
-		Vector2 pos = (get_size() - line->get_size()) / 2;
+		Vector2 pos = (get_rect_size() - line->get_size()) / 2;
 		line->draw(get_canvas_item(), pos, text_color);
 		draw_line(Vector2(0, pos.y + line->get_line_ascent()), Vector2(pos.x - 5, pos.y + line->get_line_ascent()), line_color);
-		draw_line(Vector2(pos.x + line->get_size().x + 5, pos.y + line->get_line_ascent()), Vector2(get_size().x, pos.y + line->get_line_ascent()), line_color);
+		draw_line(Vector2(pos.x + line->get_size().x + 5, pos.y + line->get_line_ascent()), Vector2(get_rect_size().x, pos.y + line->get_line_ascent()), line_color);
 	}
 }
 
@@ -126,30 +126,30 @@ FontDataPreview::FontDataPreview() {
 
 void FontDataEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
-		int split_width = get_name_split_ratio() * get_size().width;
-		button->set_size(Size2(get_theme_icon("Add", "EditorIcons")->get_width(), get_size().height));
+		int split_width = get_name_split_ratio() * get_rect_size().width;
+		button->set_rect_size(Size2(get_theme_icon("Add", "EditorIcons")->get_width(), get_rect_size().height));
 		if (is_layout_rtl()) {
 			if (le != nullptr) {
-				fit_child_in_rect(le, Rect2(Vector2(split_width, 0), Size2(split_width, get_size().height)));
+				fit_child_in_rect(le, Rect2(Vector2(split_width, 0), Size2(split_width, get_rect_size().height)));
 			}
-			fit_child_in_rect(chk, Rect2(Vector2(split_width - chk->get_size().x, 0), Size2(chk->get_size().x, get_size().height)));
-			fit_child_in_rect(button, Rect2(Vector2(0, 0), Size2(button->get_size().width, get_size().height)));
+			fit_child_in_rect(chk, Rect2(Vector2(split_width - chk->get_rect_size().x, 0), Size2(chk->get_rect_size().x, get_rect_size().height)));
+			fit_child_in_rect(button, Rect2(Vector2(0, 0), Size2(button->get_rect_size().width, get_rect_size().height)));
 		} else {
 			if (le != nullptr) {
-				fit_child_in_rect(le, Rect2(Vector2(0, 0), Size2(split_width, get_size().height)));
+				fit_child_in_rect(le, Rect2(Vector2(0, 0), Size2(split_width, get_rect_size().height)));
 			}
-			fit_child_in_rect(chk, Rect2(Vector2(split_width, 0), Size2(chk->get_size().x, get_size().height)));
-			fit_child_in_rect(button, Rect2(Vector2(get_size().width - button->get_size().width, 0), Size2(button->get_size().width, get_size().height)));
+			fit_child_in_rect(chk, Rect2(Vector2(split_width, 0), Size2(chk->get_rect_size().x, get_rect_size().height)));
+			fit_child_in_rect(button, Rect2(Vector2(get_rect_size().width - button->get_rect_size().width, 0), Size2(button->get_rect_size().width, get_rect_size().height)));
 		}
 		update();
 	}
 	if (p_what == NOTIFICATION_DRAW) {
-		int split_width = get_name_split_ratio() * get_size().width;
+		int split_width = get_name_split_ratio() * get_rect_size().width;
 		Color dark_color = get_theme_color("dark_color_2", "Editor");
 		if (is_layout_rtl()) {
-			draw_rect(Rect2(Vector2(0, 0), Size2(split_width, get_size().height)), dark_color);
+			draw_rect(Rect2(Vector2(0, 0), Size2(split_width, get_rect_size().height)), dark_color);
 		} else {
-			draw_rect(Rect2(Vector2(split_width, 0), Size2(split_width, get_size().height)), dark_color);
+			draw_rect(Rect2(Vector2(split_width, 0), Size2(split_width, get_rect_size().height)), dark_color);
 		}
 	}
 	if (p_what == NOTIFICATION_THEME_CHANGED) {
@@ -183,7 +183,7 @@ void FontDataEditor::_bind_methods() {
 void FontDataEditor::init_lang_add() {
 	le = memnew(LineEdit);
 	le->set_placeholder("Language code");
-	le->set_custom_minimum_size(Size2(get_size().width / 2, 0));
+	le->set_rect_minimum_size(Size2(get_rect_size().width / 2, 0));
 	le->set_editable(true);
 	add_child(le);
 
@@ -200,7 +200,7 @@ void FontDataEditor::init_lang_edit() {
 void FontDataEditor::init_script_add() {
 	le = memnew(LineEdit);
 	le->set_placeholder("Script code");
-	le->set_custom_minimum_size(Size2(get_size().width / 2, 0));
+	le->set_rect_minimum_size(Size2(get_rect_size().width / 2, 0));
 	le->set_editable(true);
 	add_child(le);
 

--- a/editor/plugins/gi_probe_editor_plugin.cpp
+++ b/editor/plugins/gi_probe_editor_plugin.cpp
@@ -142,7 +142,7 @@ void GIProbeEditorPlugin::_bind_methods() {
 GIProbeEditorPlugin::GIProbeEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	bake_hb = memnew(HBoxContainer);
-	bake_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	bake_hb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	bake_hb->hide();
 	bake = memnew(Button);
 	bake->set_flat(true);
@@ -151,7 +151,7 @@ GIProbeEditorPlugin::GIProbeEditorPlugin(EditorNode *p_node) {
 	bake->connect("pressed", callable_mp(this, &GIProbeEditorPlugin::_bake));
 	bake_hb->add_child(bake);
 	bake_info = memnew(Label);
-	bake_info->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	bake_info->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	bake_info->set_clip_text(true);
 	bake_hb->add_child(bake_info);
 

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -170,7 +170,7 @@ void GPUParticlesCollisionSDFEditorPlugin::_bind_methods() {
 GPUParticlesCollisionSDFEditorPlugin::GPUParticlesCollisionSDFEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	bake_hb = memnew(HBoxContainer);
-	bake_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	bake_hb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	bake_hb->hide();
 	bake = memnew(Button);
 	bake->set_flat(true);
@@ -179,7 +179,7 @@ GPUParticlesCollisionSDFEditorPlugin::GPUParticlesCollisionSDFEditorPlugin(Edito
 	bake->connect("pressed", callable_mp(this, &GPUParticlesCollisionSDFEditorPlugin::_bake));
 	bake_hb->add_child(bake);
 	bake_info = memnew(Label);
-	bake_info->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	bake_info->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	bake_info->set_clip_text(true);
 	bake_hb->add_child(bake_info);
 

--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -340,7 +340,7 @@ ItemListEditor::ItemListEditor() {
 	//dialog->set_child_rect(vbc);
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
-	hbc->set_h_size_flags(SIZE_EXPAND_FILL);
+	hbc->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	vbc->add_child(hbc);
 
 	add_button = memnew(Button);
@@ -357,7 +357,7 @@ ItemListEditor::ItemListEditor() {
 
 	property_editor = memnew(EditorInspector);
 	vbc->add_child(property_editor);
-	property_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	property_editor->set_size_flags_vertical(SIZE_EXPAND_FILL);
 }
 
 ItemListEditor::~ItemListEditor() {

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -58,7 +58,7 @@ void MaterialEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_DRAW) {
 		Ref<Texture2D> checkerboard = get_theme_icon("Checkerboard", "EditorIcons");
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 
 		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
 	}
@@ -151,7 +151,7 @@ MaterialEditor::MaterialEditor() {
 	box_mesh.instance();
 	box_instance->set_mesh(box_mesh);
 
-	set_custom_minimum_size(Size2(1, 150) * EDSCALE);
+	set_rect_minimum_size(Size2(1, 150) * EDSCALE);
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -135,7 +135,7 @@ MeshEditor::MeshEditor() {
 	mesh_instance = memnew(MeshInstance3D);
 	rotation->add_child(mesh_instance);
 
-	set_custom_minimum_size(Size2(1, 150) * EDSCALE);
+	set_rect_minimum_size(Size2(1, 150) * EDSCALE);
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -372,9 +372,9 @@ void MeshInstance3DEditor::_debug_uv_draw() {
 		return;
 	}
 
-	debug_uv->set_clip_contents(true);
-	debug_uv->draw_rect(Rect2(Vector2(), debug_uv->get_size()), Color(0.2, 0.2, 0.0));
-	debug_uv->draw_set_transform(Vector2(), 0, debug_uv->get_size());
+	debug_uv->set_rect_clip_contents(true);
+	debug_uv->draw_rect(Rect2(Vector2(), debug_uv->get_rect_size()), Color(0.2, 0.2, 0.0));
+	debug_uv->draw_set_transform(Vector2(), 0, debug_uv->get_rect_size());
 	debug_uv->draw_multiline(uv_lines, Color(1.0, 0.8, 0.7));
 }
 
@@ -480,7 +480,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	debug_uv_dialog->set_title(TTR("UV Channel Debug"));
 	add_child(debug_uv_dialog);
 	debug_uv = memnew(Control);
-	debug_uv->set_custom_minimum_size(Size2(600, 600) * EDSCALE);
+	debug_uv->set_rect_minimum_size(Size2(600, 600) * EDSCALE);
 	debug_uv->connect("draw", callable_mp(this, &MeshInstance3DEditor::_debug_uv_draw));
 	debug_uv_dialog->add_child(debug_uv);
 }

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -252,7 +252,7 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 
 	menu = memnew(MenuButton);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(menu);
-	menu->set_position(Point2(1, 1));
+	menu->set_rect_position(Point2(1, 1));
 	menu->set_text(TTR("Mesh Library"));
 	menu->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("MeshLibrary", "EditorIcons"));
 	menu->get_popup()->add_item(TTR("Add Item"), MENU_OPTION_ADD_ITEM);

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -285,7 +285,7 @@ MultiMeshEditor::MultiMeshEditor() {
 
 	surface_source = memnew(LineEdit);
 	hbc->add_child(surface_source);
-	surface_source->set_h_size_flags(SIZE_EXPAND_FILL);
+	surface_source->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	Button *b = memnew(Button);
 	hbc->add_child(b);
 	b->set_text("..");
@@ -296,7 +296,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	hbc = memnew(HBoxContainer);
 	mesh_source = memnew(LineEdit);
 	hbc->add_child(mesh_source);
-	mesh_source->set_h_size_flags(SIZE_EXPAND_FILL);
+	mesh_source->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	b = memnew(Button);
 	hbc->add_child(b);
 	b->set_text("..");

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -107,8 +107,8 @@ void ViewportRotationControl::_notification(int p_what) {
 }
 
 void ViewportRotationControl::_draw() {
-	Vector2i center = get_size() / 2.0;
-	float radius = get_size().x / 2.0;
+	Vector2i center = get_rect_size() / 2.0;
+	float radius = get_rect_size().x / 2.0;
 
 	if (focused_axis > -2 || orbiting) {
 		draw_circle(center, radius, Color(0.5, 0.5, 0.5, 0.25));
@@ -135,7 +135,7 @@ void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
 	Color c = focused ? Color(0.9, 0.9, 0.9) : axis_color;
 
 	if (positive) {
-		Vector2i center = get_size() / 2.0;
+		Vector2i center = get_rect_size() / 2.0;
 		draw_line(center, p_axis.screen_point, c, 1.5 * EDSCALE);
 	}
 
@@ -149,8 +149,8 @@ void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
 }
 
 void ViewportRotationControl::_get_sorted_axis(Vector<Axis2D> &r_axis) {
-	Vector2i center = get_size() / 2.0;
-	float radius = get_size().x / 2.0;
+	Vector2i center = get_rect_size() / 2.0;
+	float radius = get_rect_size().x / 2.0;
 
 	float axis_radius = radius - AXIS_CIRCLE_RADIUS - 2.0 * EDSCALE;
 	Basis camera_basis = viewport->to_camera_transform(viewport->cursor).get_basis().inverse();
@@ -191,7 +191,7 @@ void ViewportRotationControl::_gui_input(Ref<InputEvent> p_event) {
 	if (mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 		Vector2 pos = mb->get_position();
 		if (mb->is_pressed()) {
-			if (pos.distance_to(get_size() / 2.0) < get_size().x / 2.0) {
+			if (pos.distance_to(get_rect_size() / 2.0) < get_rect_size().x / 2.0) {
 				orbiting = true;
 			}
 		} else {
@@ -227,7 +227,7 @@ void ViewportRotationControl::_update_focus() {
 	focused_axis = -2;
 	Vector2 mouse_pos = get_local_mouse_position();
 
-	if (mouse_pos.distance_to(get_size() / 2.0) < get_size().x / 2.0) {
+	if (mouse_pos.distance_to(get_rect_size() / 2.0) < get_rect_size().x / 2.0) {
 		focused_axis = -1;
 	}
 
@@ -625,9 +625,9 @@ void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, bool &r_inclu
 Vector3 Node3DEditorViewport::_get_screen_to_space(const Vector3 &p_vector3) {
 	CameraMatrix cm;
 	if (orthogonal) {
-		cm.set_orthogonal(camera->get_size(), get_size().aspect(), get_znear() + p_vector3.z, get_zfar());
+		cm.set_orthogonal(camera->get_size(), get_rect_size().aspect(), get_znear() + p_vector3.z, get_zfar());
 	} else {
-		cm.set_perspective(get_fov(), get_size().aspect(), get_znear() + p_vector3.z, get_zfar());
+		cm.set_perspective(get_fov(), get_rect_size().aspect(), get_znear() + p_vector3.z, get_zfar());
 	}
 	Vector2 screen_he = cm.get_viewport_half_extents();
 
@@ -637,7 +637,7 @@ Vector3 Node3DEditorViewport::_get_screen_to_space(const Vector3 &p_vector3) {
 	camera_transform.basis.rotate(Vector3(0, 1, 0), -cursor.y_rot);
 	camera_transform.translate(0, 0, cursor.distance);
 
-	return camera_transform.xform(Vector3(((p_vector3.x / get_size().width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (p_vector3.y / get_size().height)) * 2.0 - 1.0) * screen_he.y, -(get_znear() + p_vector3.z)));
+	return camera_transform.xform(Vector3(((p_vector3.x / get_rect_size().width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (p_vector3.y / get_rect_size().height)) * 2.0 - 1.0) * screen_he.y, -(get_znear() + p_vector3.z)));
 }
 
 void Node3DEditorViewport::_select_region() {
@@ -755,7 +755,7 @@ void Node3DEditorViewport::_update_name() {
 		view_menu->set_text(view_mode);
 	}
 
-	view_menu->set_size(Vector2(0, 0)); // resets the button size
+	view_menu->set_rect_size(Vector2(0, 0)); // resets the button size
 }
 
 void Node3DEditorViewport::_compute_edit(const Point2 &p_point) {
@@ -2586,12 +2586,12 @@ void Node3DEditorViewport::_notification(int p_what) {
 		bool show_cinema = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_CINEMATIC_PREVIEW));
 		cinema_label->set_visible(show_cinema);
 		if (show_cinema) {
-			float cinema_half_width = cinema_label->get_size().width / 2.0f;
+			float cinema_half_width = cinema_label->get_rect_size().width / 2.0f;
 			cinema_label->set_anchor_and_offset(SIDE_LEFT, 0.5f, -cinema_half_width);
 		}
 
 		if (lock_rotation) {
-			float locked_half_width = locked_label->get_size().width / 2.0f;
+			float locked_half_width = locked_label->get_rect_size().width / 2.0f;
 			locked_label->set_anchor_and_offset(SIDE_LEFT, 0.5f, -locked_half_width);
 		}
 	}
@@ -2642,7 +2642,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 static void draw_indicator_bar(Control &surface, real_t fill, const Ref<Texture2D> icon, const Ref<Font> font, int font_size, const String &text) {
 	// Adjust bar size from control height
-	const Vector2 surface_size = surface.get_size();
+	const Vector2 surface_size = surface.get_rect_size();
 	const real_t h = surface_size.y / 2.0;
 	const real_t y = (surface_size.y - h) / 2.0;
 
@@ -2675,7 +2675,7 @@ void Node3DEditorViewport::_draw() {
 	}
 
 	if (surface->has_focus()) {
-		Size2 size = surface->get_size();
+		Size2 size = surface->get_rect_size();
 		Rect2 r = Rect2(Point2(), size);
 		get_theme_stylebox("Focus", "EditorStyles")->draw(surface->get_canvas_item(), r);
 	}
@@ -2699,7 +2699,7 @@ void Node3DEditorViewport::_draw() {
 	if (message_time > 0) {
 		Ref<Font> font = get_theme_font("font", "Label");
 		int font_size = get_theme_font_size("font_size", "Label");
-		Point2 msgpos = Point2(5, get_size().y - 20);
+		Point2 msgpos = Point2(5, get_rect_size().y - 20);
 		font->draw_string(ci, msgpos + Point2(1, 1), message, HALIGN_LEFT, -1, font_size, Color(0, 0, 0, 0.8));
 		font->draw_string(ci, msgpos + Point2(-1, -1), message, HALIGN_LEFT, -1, font_size, Color(0, 0, 0, 0.8));
 		font->draw_string(ci, msgpos, message, HALIGN_LEFT, -1, font_size, Color(1, 1, 1, 1));
@@ -2737,7 +2737,7 @@ void Node3DEditorViewport::_draw() {
 	if (previewing) {
 		Size2 ss = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
 		float aspect = ss.aspect();
-		Size2 s = get_size();
+		Size2 s = get_rect_size();
 
 		Rect2 draw_rect;
 
@@ -3349,7 +3349,7 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 	const int viewport_base_height = 400 * MAX(1, EDSCALE);
 	gizmo_scale =
 			(gizmo_size / Math::abs(dd)) * MAX(1, EDSCALE) *
-			MIN(viewport_base_height, subviewport_container->get_size().height) / viewport_base_height /
+			MIN(viewport_base_height, subviewport_container->get_rect_size().height) / viewport_base_height /
 			subviewport_container->get_stretch_shrink();
 	Vector3 scale = Vector3(1, 1, 1) * gizmo_scale;
 
@@ -3985,7 +3985,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	surface->set_drag_forwarding(this);
 	add_child(surface);
 	surface->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-	surface->set_clip_contents(true);
+	surface->set_rect_clip_contents(true);
 	camera = memnew(Camera3D);
 	camera->set_disable_gizmo(true);
 	camera->set_cull_mask(((1 << 20) - 1) | (1 << (GIZMO_BASE_LAYER + p_index)) | (1 << GIZMO_EDIT_LAYER) | (1 << GIZMO_GRID_LAYER) | (1 << MISC_TOOL_LAYER));
@@ -3995,11 +3995,11 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 
 	VBoxContainer *vbox = memnew(VBoxContainer);
 	surface->add_child(vbox);
-	vbox->set_position(Point2(10, 10) * EDSCALE);
+	vbox->set_rect_position(Point2(10, 10) * EDSCALE);
 
 	view_menu = memnew(MenuButton);
 	view_menu->set_flat(false);
-	view_menu->set_h_size_flags(0);
+	view_menu->set_size_flags_horizontal(0);
 	view_menu->set_shortcut_context(this);
 	vbox->add_child(view_menu);
 
@@ -4117,7 +4117,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	preview_camera = memnew(CheckBox);
 	preview_camera->set_text(TTR("Preview"));
 	vbox->add_child(preview_camera);
-	preview_camera->set_h_size_flags(0);
+	preview_camera->set_size_flags_horizontal(0);
 	preview_camera->hide();
 	preview_camera->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
 	previewing = nullptr;
@@ -4130,14 +4130,14 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	info_label->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -90 * EDSCALE);
 	info_label->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -10 * EDSCALE);
 	info_label->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -10 * EDSCALE);
-	info_label->set_h_grow_direction(GROW_DIRECTION_BEGIN);
-	info_label->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	info_label->set_grow_horizontal(GROW_DIRECTION_BEGIN);
+	info_label->set_grow_vertical(GROW_DIRECTION_BEGIN);
 	surface->add_child(info_label);
 	info_label->hide();
 
 	cinema_label = memnew(Label);
 	cinema_label->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, 10 * EDSCALE);
-	cinema_label->set_h_grow_direction(GROW_DIRECTION_END);
+	cinema_label->set_grow_horizontal(GROW_DIRECTION_END);
 	cinema_label->set_align(Label::ALIGN_CENTER);
 	surface->add_child(cinema_label);
 	cinema_label->set_text(TTR("Cinematic Preview"));
@@ -4147,8 +4147,8 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	locked_label = memnew(Label);
 	locked_label->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -20 * EDSCALE);
 	locked_label->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -10 * EDSCALE);
-	locked_label->set_h_grow_direction(GROW_DIRECTION_END);
-	locked_label->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	locked_label->set_grow_horizontal(GROW_DIRECTION_END);
+	locked_label->set_grow_vertical(GROW_DIRECTION_BEGIN);
 	locked_label->set_align(Label::ALIGN_CENTER);
 	surface->add_child(locked_label);
 	locked_label->set_text(TTR("View Rotation Locked"));
@@ -4169,15 +4169,15 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 
 	top_right_vbox = memnew(VBoxContainer);
 	top_right_vbox->set_anchors_and_offsets_preset(PRESET_TOP_RIGHT, PRESET_MODE_MINSIZE, 2.0 * EDSCALE);
-	top_right_vbox->set_h_grow_direction(GROW_DIRECTION_BEGIN);
+	top_right_vbox->set_grow_horizontal(GROW_DIRECTION_BEGIN);
 	// Make sure frame time labels don't touch the viewport's edge.
-	top_right_vbox->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
+	top_right_vbox->set_rect_minimum_size(Size2(100, 0) * EDSCALE);
 	// Prevent visible spacing between frame time labels.
 	top_right_vbox->add_theme_constant_override("separation", 0);
 
 	rotation_control = memnew(ViewportRotationControl);
-	rotation_control->set_custom_minimum_size(Size2(80, 80) * EDSCALE);
-	rotation_control->set_h_size_flags(SIZE_SHRINK_END);
+	rotation_control->set_rect_minimum_size(Size2(80, 80) * EDSCALE);
+	rotation_control->set_size_flags_horizontal(SIZE_SHRINK_END);
 	rotation_control->set_viewport(this);
 	top_right_vbox->add_child(rotation_control);
 
@@ -4231,7 +4231,7 @@ void Node3DEditorViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 		if (mb->is_pressed()) {
-			Vector2 size = get_size();
+			Vector2 size = get_rect_size();
 
 			int h_sep = get_theme_constant("separation", "HSplitContainer");
 			int v_sep = get_theme_constant("separation", "VSplitContainer");
@@ -4277,7 +4277,7 @@ void Node3DEditorViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mm.is_valid()) {
 		if (view == VIEW_USE_3_VIEWPORTS || view == VIEW_USE_3_VIEWPORTS_ALT || view == VIEW_USE_4_VIEWPORTS) {
-			Vector2 size = get_size();
+			Vector2 size = get_rect_size();
 
 			int h_sep = get_theme_constant("separation", "HSplitContainer");
 			int v_sep = get_theme_constant("separation", "VSplitContainer");
@@ -4296,15 +4296,15 @@ void Node3DEditorViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (dragging_h) {
-			float new_ratio = drag_begin_ratio.x + (mm->get_position().x - drag_begin_pos.x) / get_size().width;
-			new_ratio = CLAMP(new_ratio, 40 / get_size().width, (get_size().width - 40) / get_size().width);
+			float new_ratio = drag_begin_ratio.x + (mm->get_position().x - drag_begin_pos.x) / get_rect_size().width;
+			new_ratio = CLAMP(new_ratio, 40 / get_rect_size().width, (get_rect_size().width - 40) / get_rect_size().width);
 			ratio_h = new_ratio;
 			queue_sort();
 			update();
 		}
 		if (dragging_v) {
-			float new_ratio = drag_begin_ratio.y + (mm->get_position().y - drag_begin_pos.y) / get_size().height;
-			new_ratio = CLAMP(new_ratio, 40 / get_size().height, (get_size().height - 40) / get_size().height);
+			float new_ratio = drag_begin_ratio.y + (mm->get_position().y - drag_begin_pos.y) / get_rect_size().height;
+			new_ratio = CLAMP(new_ratio, 40 / get_rect_size().height, (get_rect_size().height - 40) / get_rect_size().height);
 			ratio_v = new_ratio;
 			queue_sort();
 			update();
@@ -4326,7 +4326,7 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 		Ref<Texture2D> vdiag_grabber = get_theme_icon("GuiViewportVdiagsplitter", "EditorIcons");
 		Ref<Texture2D> vh_grabber = get_theme_icon("GuiViewportVhsplitter", "EditorIcons");
 
-		Vector2 size = get_size();
+		Vector2 size = get_rect_size();
 
 		int h_sep = get_theme_constant("separation", "HSplitContainer");
 
@@ -4345,37 +4345,37 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 			} break;
 			case VIEW_USE_2_VIEWPORTS: {
 				draw_texture(v_grabber, Vector2((size.width - v_grabber->get_width()) / 2, mid_h - v_grabber->get_height() / 2));
-				set_default_cursor_shape(CURSOR_VSPLIT);
+				set_mouse_default_cursor_shape(CURSOR_VSPLIT);
 
 			} break;
 			case VIEW_USE_2_VIEWPORTS_ALT: {
 				draw_texture(h_grabber, Vector2(mid_w - h_grabber->get_width() / 2, (size.height - h_grabber->get_height()) / 2));
-				set_default_cursor_shape(CURSOR_HSPLIT);
+				set_mouse_default_cursor_shape(CURSOR_HSPLIT);
 
 			} break;
 			case VIEW_USE_3_VIEWPORTS: {
 				if ((hovering_v && hovering_h && !dragging_v && !dragging_h) || (dragging_v && dragging_h)) {
 					draw_texture(hdiag_grabber, Vector2(mid_w - hdiag_grabber->get_width() / 2, mid_h - v_grabber->get_height() / 4));
-					set_default_cursor_shape(CURSOR_DRAG);
+					set_mouse_default_cursor_shape(CURSOR_DRAG);
 				} else if ((hovering_v && !dragging_h) || dragging_v) {
 					draw_texture(v_grabber, Vector2((size.width - v_grabber->get_width()) / 2, mid_h - v_grabber->get_height() / 2));
-					set_default_cursor_shape(CURSOR_VSPLIT);
+					set_mouse_default_cursor_shape(CURSOR_VSPLIT);
 				} else if (hovering_h || dragging_h) {
 					draw_texture(h_grabber, Vector2(mid_w - h_grabber->get_width() / 2, mid_h + v_grabber->get_height() / 2 + (size_bottom - h_grabber->get_height()) / 2));
-					set_default_cursor_shape(CURSOR_HSPLIT);
+					set_mouse_default_cursor_shape(CURSOR_HSPLIT);
 				}
 
 			} break;
 			case VIEW_USE_3_VIEWPORTS_ALT: {
 				if ((hovering_v && hovering_h && !dragging_v && !dragging_h) || (dragging_v && dragging_h)) {
 					draw_texture(vdiag_grabber, Vector2(mid_w - vdiag_grabber->get_width() + v_grabber->get_height() / 4, mid_h - vdiag_grabber->get_height() / 2));
-					set_default_cursor_shape(CURSOR_DRAG);
+					set_mouse_default_cursor_shape(CURSOR_DRAG);
 				} else if ((hovering_v && !dragging_h) || dragging_v) {
 					draw_texture(v_grabber, Vector2((size_left - v_grabber->get_width()) / 2, mid_h - v_grabber->get_height() / 2));
-					set_default_cursor_shape(CURSOR_VSPLIT);
+					set_mouse_default_cursor_shape(CURSOR_VSPLIT);
 				} else if (hovering_h || dragging_h) {
 					draw_texture(h_grabber, Vector2(mid_w - h_grabber->get_width() / 2, (size.height - h_grabber->get_height()) / 2));
-					set_default_cursor_shape(CURSOR_HSPLIT);
+					set_mouse_default_cursor_shape(CURSOR_HSPLIT);
 				}
 
 			} break;
@@ -4383,13 +4383,13 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 				Vector2 half(mid_w, mid_h);
 				if ((hovering_v && hovering_h && !dragging_v && !dragging_h) || (dragging_v && dragging_h)) {
 					draw_texture(vh_grabber, half - vh_grabber->get_size() / 2.0);
-					set_default_cursor_shape(CURSOR_DRAG);
+					set_mouse_default_cursor_shape(CURSOR_DRAG);
 				} else if ((hovering_v && !dragging_h) || dragging_v) {
 					draw_texture(v_grabber, half - v_grabber->get_size() / 2.0);
-					set_default_cursor_shape(CURSOR_VSPLIT);
+					set_mouse_default_cursor_shape(CURSOR_VSPLIT);
 				} else if (hovering_h || dragging_h) {
 					draw_texture(h_grabber, half - h_grabber->get_size() / 2.0);
-					set_default_cursor_shape(CURSOR_HSPLIT);
+					set_mouse_default_cursor_shape(CURSOR_HSPLIT);
 				}
 
 			} break;
@@ -4408,7 +4408,7 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 
 		ERR_FAIL_COND(vc != 4);
 
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 
 		if (size.x < 10 || size.y < 10) {
 			for (int i = 0; i < 4; i++) {
@@ -4521,7 +4521,7 @@ void Node3DEditorViewportContainer::_bind_methods() {
 }
 
 Node3DEditorViewportContainer::Node3DEditorViewportContainer() {
-	set_clip_contents(true);
+	set_rect_clip_contents(true);
 	view = VIEW_USE_1_VIEWPORT;
 	mouseover = false;
 	ratio_h = 0.5;
@@ -6208,7 +6208,7 @@ void Node3DEditor::_unhandled_key_input(Ref<InputEvent> p_event) {
 }
 
 void Node3DEditor::_sun_environ_settings_pressed() {
-	Vector2 pos = sun_environ_settings->get_screen_position() + sun_environ_settings->get_size();
+	Vector2 pos = sun_environ_settings->get_screen_position() + sun_environ_settings->get_rect_size();
 	sun_environ_popup->set_position(pos - Vector2(sun_environ_popup->get_contents_minimum_size().width / 2, 0));
 	sun_environ_popup->popup();
 }
@@ -6295,8 +6295,8 @@ void Node3DEditor::_notification(int p_what) {
 		sun_title->add_theme_font_override("font", get_theme_font("title_font", "Window"));
 		environ_title->add_theme_font_override("font", get_theme_font("title_font", "Window"));
 
-		sun_state->set_custom_minimum_size(sun_vb->get_combined_minimum_size());
-		environ_state->set_custom_minimum_size(environ_vb->get_combined_minimum_size());
+		sun_state->set_rect_minimum_size(sun_vb->get_combined_minimum_size());
+		environ_state->set_rect_minimum_size(environ_vb->get_combined_minimum_size());
 	} else if (p_what == NOTIFICATION_ENTER_TREE) {
 		_register_all_gizmos();
 		_update_gizmos_menu();
@@ -6544,7 +6544,7 @@ void Node3DEditor::clear() {
 }
 
 void Node3DEditor::_sun_direction_draw() {
-	sun_direction->draw_rect(Rect2(Vector2(), sun_direction->get_size()), Color(1, 1, 1, 1));
+	sun_direction->draw_rect(Rect2(Vector2(), sun_direction->get_rect_size()), Color(1, 1, 1, 1));
 	sun_direction_material->set_shader_param("sun_direction", -preview_sun->get_transform().basis.get_axis(Vector3::AXIS_Z));
 	float nrg = sun_energy->get_value();
 	sun_direction_material->set_shader_param("sun_color", Vector3(sun_color->get_pick_color().r * nrg, sun_color->get_pick_color().g * nrg, sun_color->get_pick_color().b * nrg));
@@ -6906,15 +6906,15 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	/* REST OF MENU */
 
 	palette_split = memnew(HSplitContainer);
-	palette_split->set_v_size_flags(SIZE_EXPAND_FILL);
+	palette_split->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	vbc->add_child(palette_split);
 
 	shader_split = memnew(VSplitContainer);
-	shader_split->set_h_size_flags(SIZE_EXPAND_FILL);
+	shader_split->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	palette_split->add_child(shader_split);
 	viewport_base = memnew(Node3DEditorViewportContainer);
 	shader_split->add_child(viewport_base);
-	viewport_base->set_v_size_flags(SIZE_EXPAND_FILL);
+	viewport_base->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
 		viewports[i] = memnew(Node3DEditorViewport(this, editor, i));
 		viewports[i]->connect("toggle_maximize_view", callable_mp(this, &Node3DEditor::_toggle_maximize_view));
@@ -6955,7 +6955,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	settings_dialog->set_title(TTR("Viewport Settings"));
 	add_child(settings_dialog);
 	settings_vbc = memnew(VBoxContainer);
-	settings_vbc->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	settings_vbc->set_rect_minimum_size(Size2(200, 0) * EDSCALE);
 	settings_dialog->add_child(settings_vbc);
 
 	settings_fov = memnew(SpinBox);
@@ -7001,7 +7001,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 
 	for (int i = 0; i < 3; i++) {
 		xform_translate[i] = memnew(LineEdit);
-		xform_translate[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		xform_translate[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		xform_hbc->add_child(xform_translate[i]);
 	}
 
@@ -7014,7 +7014,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 
 	for (int i = 0; i < 3; i++) {
 		xform_rotate[i] = memnew(LineEdit);
-		xform_rotate[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		xform_rotate[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		xform_hbc->add_child(xform_rotate[i]);
 	}
 
@@ -7027,7 +7027,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 
 	for (int i = 0; i < 3; i++) {
 		xform_scale[i] = memnew(LineEdit);
-		xform_scale[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		xform_scale[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 		xform_hbc->add_child(xform_scale[i]);
 	}
 
@@ -7036,7 +7036,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	xform_vbc->add_child(l);
 
 	xform_type = memnew(OptionButton);
-	xform_type->set_h_size_flags(SIZE_EXPAND_FILL);
+	xform_type->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	xform_type->add_item(TTR("Pre"));
 	xform_type->add_item(TTR("Post"));
 	xform_vbc->add_child(xform_type);
@@ -7069,7 +7069,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 
 		sun_vb = memnew(VBoxContainer);
 		sun_environ_hb->add_child(sun_vb);
-		sun_vb->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+		sun_vb->set_rect_minimum_size(Size2(200 * EDSCALE, 0));
 		sun_vb->hide();
 
 		sun_title = memnew(Label);
@@ -7079,12 +7079,12 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 
 		CenterContainer *sun_direction_center = memnew(CenterContainer);
 		sun_direction = memnew(Control);
-		sun_direction->set_custom_minimum_size(Size2i(128, 128) * EDSCALE);
+		sun_direction->set_rect_minimum_size(Size2i(128, 128) * EDSCALE);
 		sun_direction_center->add_child(sun_direction);
 		sun_vb->add_margin_child(TTR("Sun Direction"), sun_direction_center);
 		sun_direction->connect("gui_input", callable_mp(this, &Node3DEditor::_sun_direction_input));
 		sun_direction->connect("draw", callable_mp(this, &Node3DEditor::_sun_direction_draw));
-		sun_direction->set_default_cursor_shape(CURSOR_MOVE);
+		sun_direction->set_mouse_default_cursor_shape(CURSOR_MOVE);
 
 		String sun_dir_shader_code = "shader_type canvas_item; uniform vec3 sun_direction; uniform vec3 sun_color; void fragment() { vec3 n; n.xy = UV * 2.0 - 1.0; n.z = sqrt(max(0.0, 1.0 - dot(n.xy, n.xy))); COLOR.rgb = dot(n,sun_direction) * sun_color; COLOR.a = 1.0 - smoothstep(0.99,1.0,length(n.xy)); }";
 		sun_direction_shader.instance();
@@ -7121,16 +7121,16 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 		sun_environ_hb->add_child(sun_state);
 		sun_state->set_align(Label::ALIGN_CENTER);
 		sun_state->set_valign(Label::VALIGN_CENTER);
-		sun_state->set_h_size_flags(SIZE_EXPAND_FILL);
+		sun_state->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 		VSeparator *sc = memnew(VSeparator);
-		sc->set_custom_minimum_size(Size2(50 * EDSCALE, 0));
-		sc->set_v_size_flags(SIZE_EXPAND_FILL);
+		sc->set_rect_minimum_size(Size2(50 * EDSCALE, 0));
+		sc->set_size_flags_vertical(SIZE_EXPAND_FILL);
 		sun_environ_hb->add_child(sc);
 
 		environ_vb = memnew(VBoxContainer);
 		sun_environ_hb->add_child(environ_vb);
-		environ_vb->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+		environ_vb->set_rect_minimum_size(Size2(200 * EDSCALE, 0));
 		environ_vb->hide();
 
 		environ_title = memnew(Label);
@@ -7151,7 +7151,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 		environ_energy->set_max(8.0);
 		environ_vb->add_margin_child(TTR("Sky Energy"), environ_energy);
 		HBoxContainer *fx_vb = memnew(HBoxContainer);
-		fx_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+		fx_vb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 		environ_ao_button = memnew(Button);
 		environ_ao_button->set_text(TTR("AO"));
@@ -7185,7 +7185,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 		sun_environ_hb->add_child(environ_state);
 		environ_state->set_align(Label::ALIGN_CENTER);
 		environ_state->set_valign(Label::VALIGN_CENTER);
-		environ_state->set_h_size_flags(SIZE_EXPAND_FILL);
+		environ_state->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 		preview_sun = memnew(DirectionalLight3D);
 		preview_sun->set_shadow(true);
@@ -7327,7 +7327,7 @@ void Node3DEditor::remove_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin) {
 Node3DEditorPlugin::Node3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	spatial_editor = memnew(Node3DEditor(p_node));
-	spatial_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	spatial_editor->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	editor->get_main_control()->add_child(spatial_editor);
 
 	spatial_editor->hide();

--- a/editor/plugins/ot_features_plugin.cpp
+++ b/editor/plugins/ot_features_plugin.cpp
@@ -52,7 +52,7 @@ void OpenTypeFeaturesEditor::_notification(int p_what) {
 		Color base = get_theme_color("accent_color", "Editor");
 
 		button->set_icon(get_theme_icon("Remove", "EditorIcons"));
-		button->set_size(get_theme_icon("Remove", "EditorIcons")->get_size());
+		button->set_rect_size(get_theme_icon("Remove", "EditorIcons")->get_size());
 		spin->set_custom_label_color(true, base);
 	}
 }
@@ -73,7 +73,7 @@ OpenTypeFeaturesEditor::OpenTypeFeaturesEditor() {
 	bc->add_child(spin);
 	add_focusable(spin);
 	spin->connect("value_changed", callable_mp(this, &OpenTypeFeaturesEditor::_value_changed));
-	spin->set_h_size_flags(SIZE_EXPAND_FILL);
+	spin->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	spin->set_min(0);
 	spin->set_max(65536);
@@ -134,7 +134,7 @@ void OpenTypeFeaturesAdd::update_property() {
 }
 
 void OpenTypeFeaturesAdd::_features_menu() {
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	menu->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
 	menu->popup();
 }
@@ -143,7 +143,7 @@ void OpenTypeFeaturesAdd::_notification(int p_what) {
 	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
 		set_label("");
 		button->set_icon(get_theme_icon("Add", "EditorIcons"));
-		button->set_size(get_theme_icon("Add", "EditorIcons")->get_size());
+		button->set_rect_size(get_theme_icon("Add", "EditorIcons")->get_size());
 	}
 }
 

--- a/editor/plugins/physical_bone_3d_editor_plugin.cpp
+++ b/editor/plugins/physical_bone_3d_editor_plugin.cpp
@@ -49,7 +49,7 @@ void PhysicalBone3DEditor::_set_move_joint() {
 PhysicalBone3DEditor::PhysicalBone3DEditor(EditorNode *p_editor) :
 		editor(p_editor) {
 	spatial_editor_hb = memnew(HBoxContainer);
-	spatial_editor_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	spatial_editor_hb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	spatial_editor_hb->set_alignment(BoxContainer::ALIGN_BEGIN);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(spatial_editor_hb);
 

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -958,7 +958,7 @@ void Polygon2DEditor::_uv_draw() {
 
 	if (snap_show_grid) {
 		Color grid_color = Color(1.0, 1.0, 1.0, 0.15);
-		Size2 s = uv_edit_draw->get_size();
+		Size2 s = uv_edit_draw->get_rect_size();
 		int last_cell = 0;
 
 		if (snap_step.x != 0) {
@@ -1158,28 +1158,28 @@ void Polygon2DEditor::_uv_draw() {
 		uv_edit_draw->draw_circle(bone_paint_pos, bone_paint_radius->get_value() * EDSCALE, Color(1, 1, 1, 0.1));
 	}
 
-	rect.position = -uv_edit_draw->get_size();
-	rect.size = uv_edit_draw->get_size() * 2.0 + base_tex->get_size() * uv_draw_zoom;
+	rect.position = -uv_edit_draw->get_rect_size();
+	rect.size = uv_edit_draw->get_rect_size() * 2.0 + base_tex->get_size() * uv_draw_zoom;
 
 	updating_uv_scroll = true;
 
 	uv_hscroll->set_min(rect.position.x);
 	uv_hscroll->set_max(rect.position.x + rect.size.x);
-	if (ABS(rect.position.x - (rect.position.x + rect.size.x)) <= uv_edit_draw->get_size().x) {
+	if (ABS(rect.position.x - (rect.position.x + rect.size.x)) <= uv_edit_draw->get_rect_size().x) {
 		uv_hscroll->hide();
 	} else {
 		uv_hscroll->show();
-		uv_hscroll->set_page(uv_edit_draw->get_size().x);
+		uv_hscroll->set_page(uv_edit_draw->get_rect_size().x);
 		uv_hscroll->set_value(uv_draw_ofs.x);
 	}
 
 	uv_vscroll->set_min(rect.position.y);
 	uv_vscroll->set_max(rect.position.y + rect.size.y);
-	if (ABS(rect.position.y - (rect.position.y + rect.size.y)) <= uv_edit_draw->get_size().y) {
+	if (ABS(rect.position.y - (rect.position.y + rect.size.y)) <= uv_edit_draw->get_rect_size().y) {
 		uv_vscroll->hide();
 	} else {
 		uv_vscroll->show();
-		uv_vscroll->set_page(uv_edit_draw->get_size().y);
+		uv_vscroll->set_page(uv_edit_draw->get_rect_size().y);
 		uv_vscroll->set_value(uv_draw_ofs.y);
 	}
 
@@ -1297,8 +1297,8 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 
 	bone_paint_strength = memnew(HSlider);
 	uv_mode_hb->add_child(bone_paint_strength);
-	bone_paint_strength->set_custom_minimum_size(Size2(75 * EDSCALE, 0));
-	bone_paint_strength->set_v_size_flags(SIZE_SHRINK_CENTER);
+	bone_paint_strength->set_rect_minimum_size(Size2(75 * EDSCALE, 0));
+	bone_paint_strength->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 	bone_paint_strength->set_min(0);
 	bone_paint_strength->set_max(1);
 	bone_paint_strength->set_step(0.01);
@@ -1319,15 +1319,15 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 
 	HSplitContainer *uv_main_hsc = memnew(HSplitContainer);
 	uv_main_vb->add_child(uv_main_hsc);
-	uv_main_hsc->set_v_size_flags(SIZE_EXPAND_FILL);
+	uv_main_hsc->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	uv_edit_draw = memnew(Panel);
 	uv_main_hsc->add_child(uv_edit_draw);
-	uv_edit_draw->set_h_size_flags(SIZE_EXPAND_FILL);
-	uv_edit_draw->set_custom_minimum_size(Size2(200, 200) * EDSCALE);
+	uv_edit_draw->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	uv_edit_draw->set_rect_minimum_size(Size2(200, 200) * EDSCALE);
 
 	Control *space = memnew(Control);
 	uv_mode_hb->add_child(space);
-	space->set_h_size_flags(SIZE_EXPAND_FILL);
+	space->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	uv_menu = memnew(MenuButton);
 	uv_mode_hb->add_child(uv_menu);
@@ -1413,13 +1413,13 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_zoom->set_max(16);
 	uv_zoom->set_value(1);
 	uv_zoom->set_step(0.01);
-	uv_zoom->set_v_size_flags(SIZE_SHRINK_CENTER);
+	uv_zoom->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 
 	uv_mode_hb->add_child(uv_zoom);
-	uv_zoom->set_custom_minimum_size(Size2(80 * EDSCALE, 0));
+	uv_zoom->set_rect_minimum_size(Size2(80 * EDSCALE, 0));
 	uv_zoom_value = memnew(SpinBox);
 	uv_zoom->share(uv_zoom_value);
-	uv_zoom_value->set_custom_minimum_size(Size2(50, 0));
+	uv_zoom_value->set_rect_minimum_size(Size2(50, 0));
 	uv_mode_hb->add_child(uv_zoom_value);
 	uv_zoom->connect("value_changed", callable_mp(this, &Polygon2DEditor::_uv_scroll_changed));
 
@@ -1434,17 +1434,17 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 
 	bone_scroll_main_vb = memnew(VBoxContainer);
 	bone_scroll_main_vb->hide();
-	bone_scroll_main_vb->set_custom_minimum_size(Size2(150 * EDSCALE, 0));
+	bone_scroll_main_vb->set_rect_minimum_size(Size2(150 * EDSCALE, 0));
 	sync_bones = memnew(Button(TTR("Sync Bones to Polygon")));
 	bone_scroll_main_vb->add_child(sync_bones);
-	sync_bones->set_h_size_flags(0);
+	sync_bones->set_size_flags_horizontal(0);
 	sync_bones->connect("pressed", callable_mp(this, &Polygon2DEditor::_sync_bones));
 	uv_main_hsc->add_child(bone_scroll_main_vb);
 	bone_scroll = memnew(ScrollContainer);
 	bone_scroll->set_v_scroll(true);
 	bone_scroll->set_h_scroll(false);
 	bone_scroll_main_vb->add_child(bone_scroll);
-	bone_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	bone_scroll->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	bone_scroll_vb = memnew(VBoxContainer);
 	bone_scroll->add_child(bone_scroll_vb);
 
@@ -1460,7 +1460,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	error = memnew(AcceptDialog);
 	add_child(error);
 
-	uv_edit_draw->set_clip_contents(true);
+	uv_edit_draw->set_rect_clip_contents(true);
 }
 
 Polygon2DEditorPlugin::Polygon2DEditorPlugin(EditorNode *p_node) :

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -371,7 +371,7 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	tree->set_column_min_width(1, 3);
 	tree->set_column_expand(0, true);
 	tree->set_column_expand(1, true);
-	tree->set_v_size_flags(SIZE_EXPAND_FILL);
+	tree->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	tree->set_drag_forwarding(this);
 	vbc->add_child(tree);
@@ -419,7 +419,7 @@ void ResourcePreloaderEditorPlugin::make_visible(bool p_visible) {
 ResourcePreloaderEditorPlugin::ResourcePreloaderEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	preloader_editor = memnew(ResourcePreloaderEditor);
-	preloader_editor->set_custom_minimum_size(Size2(0, 250) * EDSCALE);
+	preloader_editor->set_rect_minimum_size(Size2(0, 250) * EDSCALE);
 
 	button = editor->add_bottom_panel_item(TTR("ResourcePreloader"), preloader_editor);
 	button->hide();

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -248,7 +248,7 @@ EditorPropertyRootMotion::EditorPropertyRootMotion() {
 	add_child(hbc);
 	assign = memnew(Button);
 	assign->set_flat(true);
-	assign->set_h_size_flags(SIZE_EXPAND_FILL);
+	assign->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
 	assign->connect("pressed", callable_mp(this, &EditorPropertyRootMotion::_node_assign));
 	hbc->add_child(assign);
@@ -265,7 +265,7 @@ EditorPropertyRootMotion::EditorPropertyRootMotion() {
 
 	filters = memnew(Tree);
 	filter_dialog->add_child(filters);
-	filters->set_v_size_flags(SIZE_EXPAND_FILL);
+	filters->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	filters->set_hide_root(true);
 	filters->connect("item_activated", callable_mp(this, &EditorPropertyRootMotion::_confirmed));
 	//filters->connect("item_edited", this, "_filter_edited");

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3290,14 +3290,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	script_split = memnew(HSplitContainer);
 	main_container->add_child(script_split);
-	script_split->set_v_size_flags(SIZE_EXPAND_FILL);
+	script_split->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	list_split = memnew(VSplitContainer);
 	script_split->add_child(list_split);
-	list_split->set_v_size_flags(SIZE_EXPAND_FILL);
+	list_split->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	scripts_vbox = memnew(VBoxContainer);
-	scripts_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
+	scripts_vbox->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	list_split->add_child(scripts_vbox);
 
 	filter_scripts = memnew(LineEdit);
@@ -3308,8 +3308,8 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	script_list = memnew(ItemList);
 	scripts_vbox->add_child(script_list);
-	script_list->set_custom_minimum_size(Size2(150, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
-	script_list->set_v_size_flags(SIZE_EXPAND_FILL);
+	script_list->set_rect_minimum_size(Size2(150, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
+	script_list->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	script_split->set_split_offset(70 * EDSCALE);
 	_sort_list_on_update = true;
 	script_list->connect("gui_input", callable_mp(this, &ScriptEditor::_script_list_gui_input), varray(), CONNECT_DEFERRED);
@@ -3321,8 +3321,8 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	context_menu->connect("id_pressed", callable_mp(this, &ScriptEditor::_menu_option));
 
 	overview_vbox = memnew(VBoxContainer);
-	overview_vbox->set_custom_minimum_size(Size2(0, 90));
-	overview_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
+	overview_vbox->set_rect_minimum_size(Size2(0, 90));
+	overview_vbox->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	list_split->add_child(overview_vbox);
 	buttons_hbox = memnew(HBoxContainer);
@@ -3330,7 +3330,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	filename = memnew(Label);
 	filename->set_clip_text(true);
-	filename->set_h_size_flags(SIZE_EXPAND_FILL);
+	filename->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	filename->add_theme_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("normal", "LineEdit"));
 	buttons_hbox->add_child(filename);
 
@@ -3353,21 +3353,21 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	overview_vbox->add_child(members_overview);
 
 	members_overview->set_allow_reselect(true);
-	members_overview->set_custom_minimum_size(Size2(0, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
-	members_overview->set_v_size_flags(SIZE_EXPAND_FILL);
+	members_overview->set_rect_minimum_size(Size2(0, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
+	members_overview->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	members_overview->set_allow_rmb_select(true);
 
 	help_overview = memnew(ItemList);
 	overview_vbox->add_child(help_overview);
 	help_overview->set_allow_reselect(true);
-	help_overview->set_custom_minimum_size(Size2(0, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
-	help_overview->set_v_size_flags(SIZE_EXPAND_FILL);
+	help_overview->set_rect_minimum_size(Size2(0, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
+	help_overview->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	tab_container = memnew(TabContainer);
 	tab_container->set_tabs_visible(false);
-	tab_container->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	tab_container->set_rect_minimum_size(Size2(200, 0) * EDSCALE);
 	script_split->add_child(tab_container);
-	tab_container->set_h_size_flags(SIZE_EXPAND_FILL);
+	tab_container->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	ED_SHORTCUT("script_editor/window_sort", TTR("Sort"));
 	ED_SHORTCUT("script_editor/window_move_up", TTR("Move Up"), KEY_MASK_SHIFT | KEY_MASK_ALT | KEY_UP);
@@ -3527,7 +3527,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 		disk_changed_list = memnew(Tree);
 		vbc->add_child(disk_changed_list);
-		disk_changed_list->set_v_size_flags(SIZE_EXPAND_FILL);
+		disk_changed_list->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 		disk_changed->connect("confirmed", callable_mp(this, &ScriptEditor::_reload_scripts));
 		disk_changed->get_ok_button()->set_text(TTR("Reload"));
@@ -3558,7 +3558,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	add_child(find_in_files_dialog);
 	find_in_files = memnew(FindInFilesPanel);
 	find_in_files_button = editor->add_bottom_panel_item(TTR("Search Results"), find_in_files);
-	find_in_files->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
+	find_in_files->set_rect_minimum_size(Size2(0, 200) * EDSCALE);
 	find_in_files->connect(FindInFilesPanel::SIGNAL_RESULT_SELECTED, callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
 	find_in_files->connect(FindInFilesPanel::SIGNAL_FILES_MODIFIED, callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));
 	find_in_files->hide();
@@ -3662,7 +3662,7 @@ ScriptEditorPlugin::ScriptEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	script_editor = memnew(ScriptEditor(p_node));
 	editor->get_main_control()->add_child(script_editor);
-	script_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	script_editor->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	script_editor->hide();
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -102,7 +102,7 @@ ConnectionInfoDialog::ConnectionInfoDialog() {
 	tree->set_column_title(1, TTR("Signal"));
 	tree->set_column_title(2, TTR("Target"));
 	vbc->add_child(tree);
-	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tree->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	tree->set_allow_rmb_select(true);
 }
 
@@ -1517,7 +1517,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 
 	CodeEdit *tx = code_editor->get_text_editor();
 	if (mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_RIGHT && mb->is_pressed()) {
-		local_pos = mb->get_global_position() - tx->get_global_position();
+		local_pos = mb->get_global_position() - tx->get_rect_global_position();
 		create_menu = true;
 	} else if (k.is_valid() && k->get_keycode() == KEY_MENU) {
 		local_pos = tx->_get_cursor_pixel_pos();
@@ -1679,7 +1679,7 @@ void ScriptTextEditor::_enable_code_editor() {
 	VSplitContainer *editor_box = memnew(VSplitContainer);
 	add_child(editor_box);
 	editor_box->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-	editor_box->set_v_size_flags(SIZE_EXPAND_FILL);
+	editor_box->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	editor_box->add_child(code_editor);
 	code_editor->connect("show_warnings_panel", callable_mp(this, &ScriptTextEditor::_show_warnings_panel));
@@ -1813,7 +1813,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor->add_theme_constant_override("separation", 2);
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	code_editor->set_code_complete_func(_code_complete_scripts, this);
-	code_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	code_editor->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	code_editor->get_text_editor()->set_draw_breakpoints_gutter(true);
 	code_editor->get_text_editor()->set_draw_executing_lines_gutter(true);
@@ -1826,8 +1826,8 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor->get_text_editor()->set_gutter_type(connection_gutter, TextEdit::GUTTER_TPYE_ICON);
 
 	warnings_panel = memnew(RichTextLabel);
-	warnings_panel->set_custom_minimum_size(Size2(0, 100 * EDSCALE));
-	warnings_panel->set_h_size_flags(SIZE_EXPAND_FILL);
+	warnings_panel->set_rect_minimum_size(Size2(0, 100 * EDSCALE));
+	warnings_panel->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	warnings_panel->set_meta_underline(true);
 	warnings_panel->set_selection_enabled(true);
 	warnings_panel->set_focus_mode(FOCUS_CLICK);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -463,7 +463,7 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		if (mb->get_button_index() == MOUSE_BUTTON_RIGHT && mb->is_pressed()) {
 			int col, row;
 			CodeEdit *tx = shader_editor->get_text_editor();
-			tx->_get_mouse_pos(mb->get_global_position() - tx->get_global_position(), row, col);
+			tx->_get_mouse_pos(mb->get_global_position() - tx->get_rect_global_position(), row, col);
 			tx->set_right_click_moves_caret(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
 
 			if (tx->is_right_click_moving_caret()) {
@@ -556,7 +556,7 @@ void ShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) {
 
 ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	shader_editor = memnew(ShaderTextEditor);
-	shader_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	shader_editor->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	shader_editor->add_theme_constant_override("separation", 0);
 	shader_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 
@@ -711,7 +711,7 @@ ShaderEditorPlugin::ShaderEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	shader_editor = memnew(ShaderEditor(p_node));
 
-	shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
+	shader_editor->set_rect_minimum_size(Size2(0, 300) * EDSCALE);
 	button = editor->add_bottom_panel_item(TTR("Shader"), shader_editor);
 	button->hide();
 

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -253,11 +253,11 @@ ShaderFileEditor::ShaderFileEditor(EditorNode *p_node) {
 
 	versions = memnew(ItemList);
 	versions->connect("item_selected", callable_mp(this, &ShaderFileEditor::_version_selected));
-	versions->set_custom_minimum_size(Size2i(200 * EDSCALE, 0));
+	versions->set_rect_minimum_size(Size2i(200 * EDSCALE, 0));
 	main_hs->add_child(versions);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
-	main_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+	main_vb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	main_hs->add_child(main_vb);
 
 	static const char *stage_str[RD::SHADER_STAGE_MAX] = {
@@ -284,7 +284,7 @@ ShaderFileEditor::ShaderFileEditor(EditorNode *p_node) {
 	}
 
 	error_text = memnew(RichTextLabel);
-	error_text->set_v_size_flags(SIZE_EXPAND_FILL);
+	error_text->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	main_vb->add_child(error_text);
 }
 
@@ -315,7 +315,7 @@ ShaderFileEditorPlugin::ShaderFileEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	shader_editor = memnew(ShaderFileEditor(p_node));
 
-	shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
+	shader_editor->set_rect_minimum_size(Size2(0, 300) * EDSCALE);
 	button = editor->add_bottom_panel_item(TTR("ShaderFile"), shader_editor);
 	button->hide();
 }

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -121,23 +121,23 @@ void BoneTransformEditor::_notification(int p_what) {
 			buffer.y += font->get_height(font_size);
 			buffer.y += get_theme_constant("vseparation", "Tree");
 
-			const float vector_height = translation_property->get_size().y;
-			const float transform_height = transform_property->get_size().y;
-			const float button_height = key_button->get_size().y;
+			const float vector_height = translation_property->get_rect_size().y;
+			const float transform_height = transform_property->get_rect_size().y;
+			const float button_height = key_button->get_rect_size().y;
 
-			const float width = get_size().x - get_theme_constant("inspector_margin", "Editor");
+			const float width = get_rect_size().x - get_theme_constant("inspector_margin", "Editor");
 			Vector<Rect2> input_rects;
 			if (keyable && section->get_vbox()->is_visible()) {
-				input_rects.push_back(Rect2(key_button->get_position() + buffer, Size2(width, button_height)));
+				input_rects.push_back(Rect2(key_button->get_rect_position() + buffer, Size2(width, button_height)));
 			} else {
 				input_rects.push_back(Rect2(0, 0, 0, 0));
 			}
 
 			if (section->get_vbox()->is_visible()) {
-				input_rects.push_back(Rect2(translation_property->get_position() + buffer, Size2(width, vector_height)));
-				input_rects.push_back(Rect2(rotation_property->get_position() + buffer, Size2(width, vector_height)));
-				input_rects.push_back(Rect2(scale_property->get_position() + buffer, Size2(width, vector_height)));
-				input_rects.push_back(Rect2(transform_property->get_position() + buffer, Size2(width, transform_height)));
+				input_rects.push_back(Rect2(translation_property->get_rect_position() + buffer, Size2(width, vector_height)));
+				input_rects.push_back(Rect2(rotation_property->get_rect_position() + buffer, Size2(width, vector_height)));
+				input_rects.push_back(Rect2(scale_property->get_rect_position() + buffer, Size2(width, vector_height)));
+				input_rects.push_back(Rect2(transform_property->get_rect_position() + buffer, Size2(width, transform_height)));
 			} else {
 				const int32_t start = input_rects.size();
 				const int32_t empty_input_rect_elements = 4;
@@ -574,7 +574,7 @@ void Skeleton3DEditor::update_editors() {
 }
 
 void Skeleton3DEditor::create_editors() {
-	set_h_size_flags(SIZE_EXPAND_FILL);
+	set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	add_theme_constant_override("separation", 0);
 
 	set_focus_mode(FOCUS_ALL);
@@ -598,8 +598,8 @@ void Skeleton3DEditor::create_editors() {
 	bones_section->unfold();
 
 	ScrollContainer *s_con = memnew(ScrollContainer);
-	s_con->set_h_size_flags(SIZE_EXPAND_FILL);
-	s_con->set_custom_minimum_size(Size2(1, 350) * EDSCALE);
+	s_con->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	s_con->set_rect_minimum_size(Size2(1, 350) * EDSCALE);
 	bones_section->get_vbox()->add_child(s_con);
 
 	joint_tree = memnew(Tree);
@@ -607,8 +607,8 @@ void Skeleton3DEditor::create_editors() {
 	joint_tree->set_focus_mode(Control::FocusMode::FOCUS_NONE);
 	joint_tree->set_select_mode(Tree::SELECT_SINGLE);
 	joint_tree->set_hide_root(true);
-	joint_tree->set_v_size_flags(SIZE_EXPAND_FILL);
-	joint_tree->set_h_size_flags(SIZE_EXPAND_FILL);
+	joint_tree->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	joint_tree->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	joint_tree->set_allow_rmb_select(true);
 	joint_tree->set_drag_forwarding(this);
 	s_con->add_child(joint_tree);

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -476,9 +476,9 @@ void Sprite2DEditor::_debug_uv_draw() {
 	Point2 draw_pos_offset = Point2(1.0, 1.0);
 	Size2 draw_size_offset = Size2(2.0, 2.0);
 
-	debug_uv->set_clip_contents(true);
+	debug_uv->set_rect_clip_contents(true);
 	debug_uv->draw_texture(tex, draw_pos_offset);
-	debug_uv->set_custom_minimum_size(tex->get_size() + draw_size_offset);
+	debug_uv->set_rect_minimum_size(tex->get_size() + draw_size_offset);
 	debug_uv->draw_set_transform(draw_pos_offset, 0, Size2(1.0, 1.0));
 
 	Color color = Color(1.0, 0.8, 0.7);
@@ -525,7 +525,7 @@ Sprite2DEditor::Sprite2DEditor() {
 	VBoxContainer *vb = memnew(VBoxContainer);
 	debug_uv_dialog->add_child(vb);
 	ScrollContainer *scroll = memnew(ScrollContainer);
-	scroll->set_custom_minimum_size(Size2(800, 500) * EDSCALE);
+	scroll->set_rect_minimum_size(Size2(800, 500) * EDSCALE);
 	scroll->set_enable_h_scroll(true);
 	scroll->set_enable_v_scroll(true);
 	vb->add_margin_child(TTR("Preview:"), scroll, true);

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -55,7 +55,7 @@ void SpriteFramesEditor::_open_sprite_sheet() {
 }
 
 void SpriteFramesEditor::_sheet_preview_draw() {
-	Size2i size = split_sheet_preview->get_size();
+	Size2i size = split_sheet_preview->get_rect_size();
 	int h = split_sheet_h->get_value();
 	int v = split_sheet_v->get_value();
 	int width = size.width / h;
@@ -106,7 +106,7 @@ void SpriteFramesEditor::_sheet_preview_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
-		Size2i size = split_sheet_preview->get_size();
+		Size2i size = split_sheet_preview->get_rect_size();
 		int h = split_sheet_h->get_value();
 		int v = split_sheet_v->get_value();
 
@@ -206,7 +206,7 @@ void SpriteFramesEditor::_sheet_zoom_in() {
 	if (sheet_zoom < max_sheet_zoom) {
 		sheet_zoom *= scale_ratio;
 		Size2 texture_size = split_sheet_preview->get_texture()->get_size();
-		split_sheet_preview->set_custom_minimum_size(texture_size * sheet_zoom);
+		split_sheet_preview->set_rect_minimum_size(texture_size * sheet_zoom);
 	}
 }
 
@@ -214,7 +214,7 @@ void SpriteFramesEditor::_sheet_zoom_out() {
 	if (sheet_zoom > min_sheet_zoom) {
 		sheet_zoom /= scale_ratio;
 		Size2 texture_size = split_sheet_preview->get_texture()->get_size();
-		split_sheet_preview->set_custom_minimum_size(texture_size * sheet_zoom);
+		split_sheet_preview->set_rect_minimum_size(texture_size * sheet_zoom);
 	}
 }
 
@@ -222,7 +222,7 @@ void SpriteFramesEditor::_sheet_zoom_reset() {
 	// Default the zoom to match the editor scale, but don't dezoom on editor scales below 100% to prevent pixel art from looking bad.
 	sheet_zoom = MAX(1.0, EDSCALE);
 	Size2 texture_size = split_sheet_preview->get_texture()->get_size();
-	split_sheet_preview->set_custom_minimum_size(texture_size * sheet_zoom);
+	split_sheet_preview->set_rect_minimum_size(texture_size * sheet_zoom);
 }
 
 void SpriteFramesEditor::_sheet_select_clear_all_frames() {
@@ -972,11 +972,11 @@ void SpriteFramesEditor::_bind_methods() {
 SpriteFramesEditor::SpriteFramesEditor() {
 	VBoxContainer *vbc_animlist = memnew(VBoxContainer);
 	add_child(vbc_animlist);
-	vbc_animlist->set_custom_minimum_size(Size2(150, 0) * EDSCALE);
+	vbc_animlist->set_rect_minimum_size(Size2(150, 0) * EDSCALE);
 
 	VBoxContainer *sub_vb = memnew(VBoxContainer);
 	vbc_animlist->add_margin_child(TTR("Animations:"), sub_vb, true);
-	sub_vb->set_v_size_flags(SIZE_EXPAND_FILL);
+	sub_vb->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	HBoxContainer *hbc_animlist = memnew(HBoxContainer);
 	sub_vb->add_child(hbc_animlist);
@@ -995,7 +995,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	animations = memnew(Tree);
 	sub_vb->add_child(animations);
-	animations->set_v_size_flags(SIZE_EXPAND_FILL);
+	animations->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	animations->set_hide_root(true);
 	animations->connect("cell_selected", callable_mp(this, &SpriteFramesEditor::_animation_select));
 	animations->connect("item_edited", callable_mp(this, &SpriteFramesEditor::_animation_name_edited));
@@ -1009,7 +1009,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	anim_speed->set_min(0);
 	anim_speed->set_max(100);
 	anim_speed->set_step(0.01);
-	anim_speed->set_h_size_flags(SIZE_EXPAND_FILL);
+	anim_speed->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	hbc_anim_speed->add_child(anim_speed);
 	anim_speed->connect("value_changed", callable_mp(this, &SpriteFramesEditor::_animation_fps_changed));
 
@@ -1020,7 +1020,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
-	vbc->set_h_size_flags(SIZE_EXPAND_FILL);
+	vbc->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	sub_vb = memnew(VBoxContainer);
 	vbc->add_margin_child(TTR("Animation Frames:"), sub_vb, true);
@@ -1101,7 +1101,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	add_child(file);
 
 	tree = memnew(ItemList);
-	tree->set_v_size_flags(SIZE_EXPAND_FILL);
+	tree->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	tree->set_icon_mode(ItemList::ICON_MODE_TOP);
 
 	tree->set_max_columns(0);
@@ -1173,8 +1173,8 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_vb->add_child(split_sheet_hb);
 
 	PanelContainer *split_sheet_panel = memnew(PanelContainer);
-	split_sheet_panel->set_h_size_flags(SIZE_EXPAND_FILL);
-	split_sheet_panel->set_v_size_flags(SIZE_EXPAND_FILL);
+	split_sheet_panel->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	split_sheet_panel->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	split_sheet_vb->add_child(split_sheet_panel);
 
 	split_sheet_preview = memnew(TextureRect);
@@ -1190,14 +1190,14 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_panel->add_child(splite_sheet_scroll);
 	CenterContainer *cc = memnew(CenterContainer);
 	cc->add_child(split_sheet_preview);
-	cc->set_h_size_flags(SIZE_EXPAND_FILL);
-	cc->set_v_size_flags(SIZE_EXPAND_FILL);
+	cc->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	cc->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	splite_sheet_scroll->add_child(cc);
 
 	MarginContainer *split_sheet_zoom_margin = memnew(MarginContainer);
 	split_sheet_panel->add_child(split_sheet_zoom_margin);
-	split_sheet_zoom_margin->set_h_size_flags(0);
-	split_sheet_zoom_margin->set_v_size_flags(0);
+	split_sheet_zoom_margin->set_size_flags_horizontal(0);
+	split_sheet_zoom_margin->set_size_flags_vertical(0);
 	split_sheet_zoom_margin->add_theme_constant_override("margin_top", 5);
 	split_sheet_zoom_margin->add_theme_constant_override("margin_left", 5);
 	HBoxContainer *split_sheet_zoom_hb = memnew(HBoxContainer);
@@ -1287,7 +1287,7 @@ void SpriteFramesEditorPlugin::make_visible(bool p_visible) {
 SpriteFramesEditorPlugin::SpriteFramesEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	frames_editor = memnew(SpriteFramesEditor);
-	frames_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
+	frames_editor->set_rect_minimum_size(Size2(0, 300) * EDSCALE);
 	button = editor->add_bottom_panel_item(TTR("SpriteFrames"), frames_editor);
 	button->hide();
 }

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -85,8 +85,8 @@ void StyleBoxPreview::_bind_methods() {
 
 StyleBoxPreview::StyleBoxPreview() {
 	preview = memnew(Control);
-	preview->set_custom_minimum_size(Size2(0, 150 * EDSCALE));
-	preview->set_clip_contents(true);
+	preview->set_rect_minimum_size(Size2(0, 150 * EDSCALE));
+	preview->set_rect_clip_contents(true);
 	preview->connect("draw", callable_mp(this, &StyleBoxPreview::_redraw));
 	add_margin_child(TTR("Preview:"), preview);
 }

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -472,7 +472,7 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		if (mb->get_button_index() == MOUSE_BUTTON_RIGHT) {
 			int col, row;
 			CodeEdit *tx = code_editor->get_text_editor();
-			tx->_get_mouse_pos(mb->get_global_position() - tx->get_global_position(), row, col);
+			tx->_get_mouse_pos(mb->get_global_position() - tx->get_rect_global_position(), row, col);
 
 			tx->set_right_click_moves_caret(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
 			bool can_fold = tx->can_fold(row);
@@ -549,7 +549,7 @@ TextEditor::TextEditor() {
 	code_editor->connect("load_theme_settings", callable_mp(this, &TextEditor::_load_theme_settings));
 	code_editor->connect("validate_script", callable_mp(this, &TextEditor::_validate_script));
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-	code_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	code_editor->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	update_settings();
 

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -38,7 +38,7 @@ void Texture3DEditor::_gui_input(Ref<InputEvent> p_event) {
 }
 
 void Texture3DEditor::_texture_rect_draw() {
-	texture_rect->draw_rect(Rect2(Point2(), texture_rect->get_size()), Color(1, 1, 1, 1));
+	texture_rect->draw_rect(Rect2(Point2(), texture_rect->get_rect_size()), Color(1, 1, 1, 1));
 }
 
 void Texture3DEditor::_notification(int p_what) {
@@ -51,7 +51,7 @@ void Texture3DEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_DRAW) {
 		Ref<Texture2D> checkerboard = get_theme_icon("Checkerboard", "EditorIcons");
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 
 		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
 	}
@@ -92,7 +92,7 @@ void Texture3DEditor::_make_shaders() {
 }
 
 void Texture3DEditor::_texture_rect_update_area() {
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	int tex_width = texture->get_width() * size.height / texture->get_height();
 	int tex_height = size.height;
 
@@ -112,8 +112,8 @@ void Texture3DEditor::_texture_rect_update_area() {
 	int ofs_x = (size.width - tex_width) / 2;
 	int ofs_y = (size.height - tex_height) / 2;
 
-	texture_rect->set_position(Vector2(ofs_x, ofs_y));
-	texture_rect->set_size(Vector2(tex_width, tex_height));
+	texture_rect->set_rect_position(Vector2(ofs_x, ofs_y));
+	texture_rect->set_rect_size(Vector2(tex_width, tex_height));
 }
 
 void Texture3DEditor::edit(Ref<Texture3D> p_texture) {
@@ -150,7 +150,7 @@ void Texture3DEditor::_bind_methods() {
 
 Texture3DEditor::Texture3DEditor() {
 	set_texture_repeat(TextureRepeat::TEXTURE_REPEAT_ENABLED);
-	set_custom_minimum_size(Size2(1, 150));
+	set_rect_minimum_size(Size2(1, 150));
 	texture_rect = memnew(Control);
 	texture_rect->connect("draw", callable_mp(this, &Texture3DEditor::_texture_rect_draw));
 	texture_rect->set_mouse_filter(MOUSE_FILTER_IGNORE);
@@ -162,7 +162,7 @@ Texture3DEditor::Texture3DEditor() {
 	add_child(layer);
 	layer->set_anchor(SIDE_RIGHT, 1);
 	layer->set_anchor(SIDE_LEFT, 1);
-	layer->set_h_grow_direction(GROW_DIRECTION_BEGIN);
+	layer->set_grow_horizontal(GROW_DIRECTION_BEGIN);
 	layer->set_modulate(Color(1, 1, 1, 0.8));
 	info = memnew(Label);
 	add_child(info);
@@ -170,8 +170,8 @@ Texture3DEditor::Texture3DEditor() {
 	info->set_anchor(SIDE_LEFT, 1);
 	info->set_anchor(SIDE_BOTTOM, 1);
 	info->set_anchor(SIDE_TOP, 1);
-	info->set_h_grow_direction(GROW_DIRECTION_BEGIN);
-	info->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	info->set_grow_horizontal(GROW_DIRECTION_BEGIN);
+	info->set_grow_vertical(GROW_DIRECTION_BEGIN);
 	info->add_theme_color_override("font_color", Color(1, 1, 1, 1));
 	info->add_theme_color_override("font_shadow_color", Color(0, 0, 0, 0.5));
 	info->add_theme_constant_override("shadow_as_outline", 1);

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -44,7 +44,7 @@ void TextureEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_DRAW) {
 		Ref<Texture2D> checkerboard = get_theme_icon("Checkerboard", "EditorIcons");
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 
 		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
 
@@ -132,7 +132,7 @@ void TextureEditor::_bind_methods() {
 
 TextureEditor::TextureEditor() {
 	set_texture_repeat(TextureRepeat::TEXTURE_REPEAT_ENABLED);
-	set_custom_minimum_size(Size2(1, 150));
+	set_rect_minimum_size(Size2(1, 150));
 }
 
 TextureEditor::~TextureEditor() {

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -46,7 +46,7 @@ void TextureLayeredEditor::_gui_input(Ref<InputEvent> p_event) {
 }
 
 void TextureLayeredEditor::_texture_rect_draw() {
-	texture_rect->draw_rect(Rect2(Point2(), texture_rect->get_size()), Color(1, 1, 1, 1));
+	texture_rect->draw_rect(Rect2(Point2(), texture_rect->get_rect_size()), Color(1, 1, 1, 1));
 }
 
 void TextureLayeredEditor::_notification(int p_what) {
@@ -59,7 +59,7 @@ void TextureLayeredEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_DRAW) {
 		Ref<Texture2D> checkerboard = get_theme_icon("Checkerboard", "EditorIcons");
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 
 		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
 	}
@@ -149,7 +149,7 @@ void TextureLayeredEditor::_make_shaders() {
 }
 
 void TextureLayeredEditor::_texture_rect_update_area() {
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	int tex_width = texture->get_width() * size.height / texture->get_height();
 	int tex_height = size.height;
 
@@ -169,8 +169,8 @@ void TextureLayeredEditor::_texture_rect_update_area() {
 	int ofs_x = (size.width - tex_width) / 2;
 	int ofs_y = (size.height - tex_height) / 2;
 
-	texture_rect->set_position(Vector2(ofs_x, ofs_y));
-	texture_rect->set_size(Vector2(tex_width, tex_height));
+	texture_rect->set_rect_position(Vector2(ofs_x, ofs_y));
+	texture_rect->set_rect_size(Vector2(tex_width, tex_height));
 }
 
 void TextureLayeredEditor::edit(Ref<TextureLayered> p_texture) {
@@ -217,7 +217,7 @@ void TextureLayeredEditor::_bind_methods() {
 
 TextureLayeredEditor::TextureLayeredEditor() {
 	set_texture_repeat(TextureRepeat::TEXTURE_REPEAT_ENABLED);
-	set_custom_minimum_size(Size2(1, 150));
+	set_rect_minimum_size(Size2(1, 150));
 	texture_rect = memnew(Control);
 	texture_rect->connect("draw", callable_mp(this, &TextureLayeredEditor::_texture_rect_draw));
 	texture_rect->set_mouse_filter(MOUSE_FILTER_IGNORE);
@@ -229,7 +229,7 @@ TextureLayeredEditor::TextureLayeredEditor() {
 	add_child(layer);
 	layer->set_anchor(SIDE_RIGHT, 1);
 	layer->set_anchor(SIDE_LEFT, 1);
-	layer->set_h_grow_direction(GROW_DIRECTION_BEGIN);
+	layer->set_grow_horizontal(GROW_DIRECTION_BEGIN);
 	layer->set_modulate(Color(1, 1, 1, 0.8));
 	info = memnew(Label);
 	add_child(info);
@@ -237,8 +237,8 @@ TextureLayeredEditor::TextureLayeredEditor() {
 	info->set_anchor(SIDE_LEFT, 1);
 	info->set_anchor(SIDE_BOTTOM, 1);
 	info->set_anchor(SIDE_TOP, 1);
-	info->set_h_grow_direction(GROW_DIRECTION_BEGIN);
-	info->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	info->set_grow_horizontal(GROW_DIRECTION_BEGIN);
+	info->set_grow_vertical(GROW_DIRECTION_BEGIN);
 	info->add_theme_color_override("font_color", Color(1, 1, 1, 1));
 	info->add_theme_color_override("font_shadow_color", Color(0, 0, 0, 0.5));
 	info->add_theme_constant_override("shadow_as_outline", 1);

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -89,7 +89,7 @@ void TextureRegionEditor::_region_draw() {
 
 	if (snap_mode == SNAP_GRID) {
 		Color grid_color = Color(1.0, 1.0, 1.0, 0.15);
-		Size2 s = edit_draw->get_size();
+		Size2 s = edit_draw->get_rect_size();
 		int last_cell = 0;
 
 		if (snap_step.x != 0) {
@@ -199,7 +199,7 @@ void TextureRegionEditor::_region_draw() {
 		scroll_rect.expand_to(raw_endpoints[i]);
 	}
 
-	const Size2 scroll_margin = edit_draw->get_size() / draw_zoom;
+	const Size2 scroll_margin = edit_draw->get_rect_size() / draw_zoom;
 	scroll_rect.position -= scroll_margin;
 	scroll_rect.size += scroll_margin * 2;
 
@@ -256,10 +256,10 @@ void TextureRegionEditor::_region_draw() {
 			-mtx.basis_xform(Vector2(margins[3], 0)) + Vector2(endpoints[2].x - draw_ofs.x * draw_zoom, 0)
 		};
 
-		draw_margin_line(edit_draw, pos[0], pos[0] + Vector2(edit_draw->get_size().x, 0));
-		draw_margin_line(edit_draw, pos[1], pos[1] + Vector2(edit_draw->get_size().x, 0));
-		draw_margin_line(edit_draw, pos[2], pos[2] + Vector2(0, edit_draw->get_size().y));
-		draw_margin_line(edit_draw, pos[3], pos[3] + Vector2(0, edit_draw->get_size().y));
+		draw_margin_line(edit_draw, pos[0], pos[0] + Vector2(edit_draw->get_rect_size().x, 0));
+		draw_margin_line(edit_draw, pos[1], pos[1] + Vector2(edit_draw->get_rect_size().x, 0));
+		draw_margin_line(edit_draw, pos[2], pos[2] + Vector2(0, edit_draw->get_rect_size().y));
+		draw_margin_line(edit_draw, pos[3], pos[3] + Vector2(0, edit_draw->get_rect_size().y));
 	}
 }
 
@@ -682,15 +682,15 @@ void TextureRegionEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
 }
 
 void TextureRegionEditor::_zoom_in() {
-	_zoom_on_position(draw_zoom * 1.5, edit_draw->get_size() / 2.0);
+	_zoom_on_position(draw_zoom * 1.5, edit_draw->get_rect_size() / 2.0);
 }
 
 void TextureRegionEditor::_zoom_reset() {
-	_zoom_on_position(1.0, edit_draw->get_size() / 2.0);
+	_zoom_on_position(1.0, edit_draw->get_rect_size() / 2.0);
 }
 
 void TextureRegionEditor::_zoom_out() {
-	_zoom_on_position(draw_zoom / 1.5, edit_draw->get_size() / 2.0);
+	_zoom_on_position(draw_zoom / 1.5, edit_draw->get_rect_size() / 2.0);
 }
 
 void TextureRegionEditor::apply_rect(const Rect2 &p_rect) {
@@ -1058,12 +1058,12 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 
 	edit_draw = memnew(Panel);
 	add_child(edit_draw);
-	edit_draw->set_v_size_flags(SIZE_EXPAND_FILL);
+	edit_draw->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	edit_draw->connect("draw", callable_mp(this, &TextureRegionEditor::_region_draw));
 	edit_draw->connect("gui_input", callable_mp(this, &TextureRegionEditor::_region_input));
 
 	draw_zoom = 1.0;
-	edit_draw->set_clip_contents(true);
+	edit_draw->set_rect_clip_contents(true);
 
 	HBoxContainer *zoom_hb = memnew(HBoxContainer);
 	edit_draw->add_child(zoom_hb);
@@ -1175,7 +1175,7 @@ TextureRegionEditorPlugin::TextureRegionEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 
 	region_editor = memnew(TextureRegionEditor(p_node));
-	region_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
+	region_editor->set_rect_minimum_size(Size2(0, 200) * EDSCALE);
 	region_editor->hide();
 	region_editor->connect("visibility_changed", callable_mp(this, &TextureRegionEditorPlugin::_editor_visiblity_changed));
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -568,7 +568,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	add_child(edit_dialog_hs);
 
 	VBoxContainer *edit_dialog_side_vb = memnew(VBoxContainer);
-	edit_dialog_side_vb->set_custom_minimum_size(Size2(200.0, 0.0) * EDSCALE);
+	edit_dialog_side_vb->set_rect_minimum_size(Size2(200.0, 0.0) * EDSCALE);
 	edit_dialog_hs->add_child(edit_dialog_side_vb);
 
 	Label *edit_type_label = memnew(Label);
@@ -576,7 +576,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	edit_dialog_side_vb->add_child(edit_type_label);
 
 	edit_type_list = memnew(ItemList);
-	edit_type_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	edit_type_list->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	edit_dialog_side_vb->add_child(edit_type_list);
 	edit_type_list->connect("item_selected", callable_mp(this, &ThemeItemEditorDialog::_edited_type_selected));
 
@@ -587,7 +587,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	HBoxContainer *edit_add_class = memnew(HBoxContainer);
 	edit_dialog_side_vb->add_child(edit_add_class);
 	edit_add_class_options = memnew(OptionButton);
-	edit_add_class_options->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	edit_add_class_options->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	edit_add_class->add_child(edit_add_class_options);
 	Button *edit_add_class_button = memnew(Button);
 	edit_add_class_button->set_text(TTR("Add"));
@@ -601,7 +601,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	HBoxContainer *edit_add_custom = memnew(HBoxContainer);
 	edit_dialog_side_vb->add_child(edit_add_custom);
 	edit_add_custom_value = memnew(LineEdit);
-	edit_add_custom_value->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	edit_add_custom_value->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	edit_add_custom->add_child(edit_add_custom_value);
 	Button *edit_add_custom_button = memnew(Button);
 	edit_add_custom_button->set_text(TTR("Add"));
@@ -609,7 +609,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	edit_add_custom_button->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_add_custom_type));
 
 	VBoxContainer *edit_items_vb = memnew(VBoxContainer);
-	edit_items_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	edit_items_vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	edit_dialog_hs->add_child(edit_items_vb);
 
 	HBoxContainer *edit_items_toolbar = memnew(HBoxContainer);
@@ -689,7 +689,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	edit_items_remove_all->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_remove_all_items));
 
 	edit_items_tree = memnew(Tree);
-	edit_items_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	edit_items_tree->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	edit_items_tree->set_hide_root(true);
 	edit_items_tree->set_columns(1);
 	edit_items_vb->add_child(edit_items_tree);
@@ -1080,15 +1080,15 @@ ThemeEditor::ThemeEditor() {
 	add_child(scroll);
 	scroll->set_enable_v_scroll(true);
 	scroll->set_enable_h_scroll(true);
-	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	scroll->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	MarginContainer *root_container = memnew(MarginContainer);
 	scroll->add_child(root_container);
 	root_container->set_theme(Theme::get_default());
-	root_container->set_clip_contents(true);
-	root_container->set_custom_minimum_size(Size2(700, 0) * EDSCALE);
-	root_container->set_v_size_flags(SIZE_EXPAND_FILL);
-	root_container->set_h_size_flags(SIZE_EXPAND_FILL);
+	root_container->set_rect_clip_contents(true);
+	root_container->set_rect_minimum_size(Size2(700, 0) * EDSCALE);
+	root_container->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	root_container->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	//// Preview Controls ////
 
@@ -1107,7 +1107,7 @@ ThemeEditor::ThemeEditor() {
 
 	VBoxContainer *first_vb = memnew(VBoxContainer);
 	main_hb->add_child(first_vb);
-	first_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+	first_vb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	first_vb->add_theme_constant_override("separation", 10 * EDSCALE);
 
 	first_vb->add_child(memnew(Label("Label")));
@@ -1167,7 +1167,7 @@ ThemeEditor::ThemeEditor() {
 	first_vb->add_child(memnew(ColorPickerButton));
 
 	VBoxContainer *second_vb = memnew(VBoxContainer);
-	second_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+	second_vb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	main_hb->add_child(second_vb);
 	second_vb->add_theme_constant_override("separation", 10 * EDSCALE);
 	LineEdit *le = memnew(LineEdit);
@@ -1179,13 +1179,13 @@ ThemeEditor::ThemeEditor() {
 	second_vb->add_child(le);
 	TextEdit *te = memnew(TextEdit);
 	te->set_text("TextEdit");
-	te->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
+	te->set_rect_minimum_size(Size2(0, 100) * EDSCALE);
 	second_vb->add_child(te);
 	second_vb->add_child(memnew(SpinBox));
 
 	HBoxContainer *vhb = memnew(HBoxContainer);
 	second_vb->add_child(vhb);
-	vhb->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
+	vhb->set_rect_minimum_size(Size2(0, 100) * EDSCALE);
 	vhb->add_child(memnew(VSlider));
 	VScrollBar *vsb = memnew(VScrollBar);
 	vsb->set_page(25);
@@ -1194,7 +1194,7 @@ ThemeEditor::ThemeEditor() {
 	VBoxContainer *hvb = memnew(VBoxContainer);
 	vhb->add_child(hvb);
 	hvb->set_alignment(ALIGN_CENTER);
-	hvb->set_h_size_flags(SIZE_EXPAND_FILL);
+	hvb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	hvb->add_child(memnew(HSlider));
 	HScrollBar *hsb = memnew(HScrollBar);
 	hsb->set_page(25);
@@ -1208,13 +1208,13 @@ ThemeEditor::ThemeEditor() {
 	hvb->add_child(pb);
 
 	VBoxContainer *third_vb = memnew(VBoxContainer);
-	third_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+	third_vb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	third_vb->add_theme_constant_override("separation", 10 * EDSCALE);
 	main_hb->add_child(third_vb);
 
 	TabContainer *tc = memnew(TabContainer);
 	third_vb->add_child(tc);
-	tc->set_custom_minimum_size(Size2(0, 135) * EDSCALE);
+	tc->set_rect_minimum_size(Size2(0, 135) * EDSCALE);
 	Control *tcc = memnew(Control);
 	tcc->set_name(TTR("Tab 1"));
 	tc->add_child(tcc);
@@ -1228,7 +1228,7 @@ ThemeEditor::ThemeEditor() {
 
 	Tree *test_tree = memnew(Tree);
 	third_vb->add_child(test_tree);
-	test_tree->set_custom_minimum_size(Size2(0, 175) * EDSCALE);
+	test_tree->set_rect_minimum_size(Size2(0, 175) * EDSCALE);
 	test_tree->add_theme_constant_override("draw_relationship_lines", 1);
 
 	TreeItem *item = test_tree->create_item();
@@ -1297,7 +1297,7 @@ void ThemeEditorPlugin::make_visible(bool p_visible) {
 ThemeEditorPlugin::ThemeEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	theme_editor = memnew(ThemeEditor);
-	theme_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
+	theme_editor->set_rect_minimum_size(Size2(0, 200) * EDSCALE);
 
 	button = editor->add_bottom_panel_item(TTR("Theme"), theme_editor);
 	button->hide();

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -1644,7 +1644,7 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 	Transform2D xform = CanvasItemEditor::get_singleton()->get_canvas_transform() * node->get_global_transform();
 	Transform2D xform_inv = xform.affine_inverse();
 
-	Size2 screen_size = p_overlay->get_size();
+	Size2 screen_size = p_overlay->get_rect_size();
 	{
 		Rect2 aabb;
 		aabb.position = node->world_to_map(xform_inv.xform(Vector2()));
@@ -2056,14 +2056,14 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 
 	search_box = memnew(LineEdit);
 	search_box->set_placeholder(TTR("Filter tiles"));
-	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	search_box->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	search_box->connect("text_entered", callable_mp(this, &TileMapEditor::_text_entered));
 	search_box->connect("text_changed", callable_mp(this, &TileMapEditor::_text_changed));
 	search_box->connect("gui_input", callable_mp(this, &TileMapEditor::_sbox_input));
 	add_child(search_box);
 
 	size_slider = memnew(HSlider);
-	size_slider->set_h_size_flags(SIZE_EXPAND_FILL);
+	size_slider->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	size_slider->set_min(0.1f);
 	size_slider->set_max(4.0f);
 	size_slider->set_step(0.1f);
@@ -2074,14 +2074,14 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	int mw = EDITOR_DEF("editors/tile_map/palette_min_width", 80);
 
 	VSplitContainer *palette_container = memnew(VSplitContainer);
-	palette_container->set_v_size_flags(SIZE_EXPAND_FILL);
-	palette_container->set_custom_minimum_size(Size2(mw, 0));
+	palette_container->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	palette_container->set_rect_minimum_size(Size2(mw, 0));
 	add_child(palette_container);
 
 	// Add tile palette.
 	palette = memnew(ItemList);
-	palette->set_h_size_flags(SIZE_EXPAND_FILL);
-	palette->set_v_size_flags(SIZE_EXPAND_FILL);
+	palette->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	palette->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	palette->set_max_columns(0);
 	palette->set_icon_mode(ItemList::ICON_MODE_TOP);
 	palette->set_max_text_lines(2);
@@ -2098,14 +2098,14 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	info_message->set_valign(Label::VALIGN_CENTER);
 	info_message->set_align(Label::ALIGN_CENTER);
 	info_message->set_autowrap(true);
-	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	info_message->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_offsets_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	palette->add_child(info_message);
 
 	// Add autotile override palette.
 	manual_palette = memnew(ItemList);
-	manual_palette->set_h_size_flags(SIZE_EXPAND_FILL);
-	manual_palette->set_v_size_flags(SIZE_EXPAND_FILL);
+	manual_palette->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	manual_palette->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	manual_palette->set_max_columns(0);
 	manual_palette->set_icon_mode(ItemList::ICON_MODE_TOP);
 	manual_palette->set_max_text_lines(2);
@@ -2176,7 +2176,7 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	// Container to the right of the toolbar.
 	toolbar_right = memnew(HBoxContainer);
 	toolbar_right->hide();
-	toolbar_right->set_h_size_flags(SIZE_EXPAND_FILL);
+	toolbar_right->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	toolbar_right->set_alignment(BoxContainer::ALIGN_END);
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(toolbar_right);
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -337,8 +337,8 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 
 	texture_list = memnew(ItemList);
 	left_container->add_child(texture_list);
-	texture_list->set_v_size_flags(SIZE_EXPAND_FILL);
-	texture_list->set_custom_minimum_size(Size2(200, 0));
+	texture_list->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	texture_list->set_rect_minimum_size(Size2(200, 0));
 	texture_list->connect("item_selected", callable_mp(this, &TileSetEditor::_on_texture_list_selected));
 	texture_list->set_drag_forwarding(this);
 
@@ -358,7 +358,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->set_tooltip(TTR("Remove selected Texture from TileSet."));
 
 	Control *toolbar_separator = memnew(Control);
-	toolbar_separator->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	toolbar_separator->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	tileset_toolbar_container->add_child(toolbar_separator);
 
 	tileset_toolbar_tools = memnew(MenuButton);
@@ -371,7 +371,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 
 	//---------------
 	VBoxContainer *right_container = memnew(VBoxContainer);
-	right_container->set_v_size_flags(SIZE_EXPAND_FILL);
+	right_container->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	add_child(right_container);
 
 	dragging_point = -1;
@@ -379,11 +379,11 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	snap_step = Vector2(32, 32);
 	snap_offset = WORKSPACE_MARGIN;
 
-	set_custom_minimum_size(Size2(0, 150));
+	set_rect_minimum_size(Size2(0, 150));
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	right_container->add_child(main_vb);
-	main_vb->set_v_size_flags(SIZE_EXPAND_FILL);
+	main_vb->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	HBoxContainer *tool_hb = memnew(HBoxContainer);
 	Ref<ButtonGroup> g(memnew(ButtonGroup));
@@ -404,7 +404,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	}
 
 	Control *spacer = memnew(Control);
-	spacer->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	spacer->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	tool_hb->add_child(spacer);
 	tool_hb->move_child(spacer, WORKSPACE_CREATE_SINGLE);
 
@@ -548,7 +548,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	spin_priority->set_min(1);
 	spin_priority->set_max(255);
 	spin_priority->set_step(1);
-	spin_priority->set_custom_minimum_size(Size2(100, 0));
+	spin_priority->set_rect_minimum_size(Size2(100, 0));
 	spin_priority->connect("value_changed", callable_mp(this, &TileSetEditor::_on_priority_changed));
 	spin_priority->hide();
 	toolbar->add_child(spin_priority);
@@ -557,7 +557,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	spin_z_index->set_min(RS::CANVAS_ITEM_Z_MIN);
 	spin_z_index->set_max(RS::CANVAS_ITEM_Z_MAX);
 	spin_z_index->set_step(1);
-	spin_z_index->set_custom_minimum_size(Size2(100, 0));
+	spin_z_index->set_rect_minimum_size(Size2(100, 0));
 	spin_z_index->connect("value_changed", callable_mp(this, &TileSetEditor::_on_z_index_changed));
 	spin_z_index->hide();
 	toolbar->add_child(spin_z_index);
@@ -578,7 +578,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	toolbar->add_child(tools[TOOL_GRID_SNAP]);
 
 	Control *separator = memnew(Control);
-	separator->set_h_size_flags(SIZE_EXPAND_FILL);
+	separator->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	toolbar->add_child(separator);
 
 	tools[ZOOM_OUT] = memnew(Button);
@@ -607,17 +607,17 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 
 	scroll = memnew(ScrollContainer);
 	main_vb->add_child(scroll);
-	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	scroll->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	scroll->connect("gui_input", callable_mp(this, &TileSetEditor::_on_scroll_container_input));
-	scroll->set_clip_contents(true);
+	scroll->set_rect_clip_contents(true);
 
 	empty_message = memnew(Label);
 	empty_message->set_text(TTR("Add or select a texture on the left panel to edit the tiles bound to it."));
 	empty_message->set_valign(Label::VALIGN_CENTER);
 	empty_message->set_align(Label::ALIGN_CENTER);
 	empty_message->set_autowrap(true);
-	empty_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-	empty_message->set_v_size_flags(SIZE_EXPAND_FILL);
+	empty_message->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
+	empty_message->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	main_vb->add_child(empty_message);
 
 	workspace_container = memnew(Control);
@@ -757,7 +757,7 @@ void TileSetEditor::_on_texture_list_selected(int p_index) {
 	} else {
 		current_item_index = -1;
 		preview->set_texture(nullptr);
-		workspace->set_custom_minimum_size(Size2i());
+		workspace->set_rect_minimum_size(Size2i());
 		update_workspace_tile_mode();
 	}
 
@@ -1180,7 +1180,7 @@ void TileSetEditor::_on_workspace_overlay_draw() {
 
 			Rect2 region = tileset->tile_get_region(t_id);
 			region.position += WORKSPACE_MARGIN;
-			region.position *= workspace->get_scale().x;
+			region.position *= workspace->get_rect_scale().x;
 			Color c;
 			if (tileset->tile_get_tile_mode(t_id) == TileSet::SINGLE_TILE) {
 				c = COLOR_SINGLE;
@@ -1209,7 +1209,7 @@ void TileSetEditor::_on_workspace_overlay_draw() {
 	Ref<Texture2D> handle = get_theme_icon("EditorHandle", "EditorIcons");
 	if (draw_handles) {
 		for (int i = 0; i < current_shape.size(); i++) {
-			workspace_overlay->draw_texture(handle, current_shape[i] * workspace->get_scale().x - handle->get_size() * 0.5);
+			workspace_overlay->draw_texture(handle, current_shape[i] * workspace->get_rect_scale().x - handle->get_size() * 0.5);
 		}
 	}
 }
@@ -1306,8 +1306,8 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 	if (mm.is_valid()) {
 		if (mm->get_button_mask() & MOUSE_BUTTON_MASK_MIDDLE) {
 			Vector2 dragged(mm->get_relative().x, mm->get_relative().y);
-			scroll->set_h_scroll(scroll->get_h_scroll() - dragged.x * workspace->get_scale().x);
-			scroll->set_v_scroll(scroll->get_v_scroll() - dragged.y * workspace->get_scale().x);
+			scroll->set_h_scroll(scroll->get_h_scroll() - dragged.x * workspace->get_rect_scale().x);
+			scroll->set_v_scroll(scroll->get_v_scroll() - dragged.y * workspace->get_rect_scale().x);
 		}
 	}
 
@@ -1339,16 +1339,16 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 						undo_redo->add_undo_method(tileset.ptr(), "tile_set_region", get_current_tile(), tileset->tile_get_region(get_current_tile()));
 
 						Size2 tile_workspace_size = edited_region.position + edited_region.size + WORKSPACE_MARGIN * 2;
-						Size2 workspace_minsize = workspace->get_custom_minimum_size();
+						Size2 workspace_minsize = workspace->get_rect_minimum_size();
 						// If the new region is bigger, just directly change the workspace size to avoid checking all other tiles.
 						if (tile_workspace_size.x > workspace_minsize.x || tile_workspace_size.y > workspace_minsize.y) {
 							Size2 max_workspace_size = Size2(MAX(tile_workspace_size.x, workspace_minsize.x), MAX(tile_workspace_size.y, workspace_minsize.y));
-							undo_redo->add_do_method(workspace, "set_custom_minimum_size", max_workspace_size);
-							undo_redo->add_undo_method(workspace, "set_custom_minimum_size", workspace_minsize);
-							undo_redo->add_do_method(workspace_container, "set_custom_minimum_size", max_workspace_size);
-							undo_redo->add_undo_method(workspace_container, "set_custom_minimum_size", workspace_minsize);
-							undo_redo->add_do_method(workspace_overlay, "set_custom_minimum_size", max_workspace_size);
-							undo_redo->add_undo_method(workspace_overlay, "set_custom_minimum_size", workspace_minsize);
+							undo_redo->add_do_method(workspace, "set_rect_minimum_size", max_workspace_size);
+							undo_redo->add_undo_method(workspace, "set_rect_minimum_size", workspace_minsize);
+							undo_redo->add_do_method(workspace_container, "set_rect_minimum_size", max_workspace_size);
+							undo_redo->add_undo_method(workspace_container, "set_rect_minimum_size", workspace_minsize);
+							undo_redo->add_do_method(workspace_overlay, "set_rect_minimum_size", max_workspace_size);
+							undo_redo->add_undo_method(workspace_overlay, "set_rect_minimum_size", workspace_minsize);
 						} else if (workspace_minsize.x > get_current_texture()->get_size().x + WORKSPACE_MARGIN.x * 2 || workspace_minsize.y > get_current_texture()->get_size().y + WORKSPACE_MARGIN.y * 2) {
 							undo_redo->add_do_method(this, "update_workspace_minsize");
 							undo_redo->add_undo_method(this, "update_workspace_minsize");
@@ -1381,15 +1381,15 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 						edit_mode = EDITMODE_COLLISION;
 
 						Size2 tile_workspace_size = edited_region.position + edited_region.size + WORKSPACE_MARGIN * 2;
-						Size2 workspace_minsize = workspace->get_custom_minimum_size();
+						Size2 workspace_minsize = workspace->get_rect_minimum_size();
 						if (tile_workspace_size.x > workspace_minsize.x || tile_workspace_size.y > workspace_minsize.y) {
 							Size2 new_workspace_minsize = Size2(MAX(tile_workspace_size.x, workspace_minsize.x), MAX(tile_workspace_size.y, workspace_minsize.y));
-							undo_redo->add_do_method(workspace, "set_custom_minimum_size", new_workspace_minsize);
-							undo_redo->add_undo_method(workspace, "set_custom_minimum_size", workspace_minsize);
-							undo_redo->add_do_method(workspace_container, "set_custom_minimum_size", new_workspace_minsize);
-							undo_redo->add_undo_method(workspace_container, "set_custom_minimum_size", workspace_minsize);
-							undo_redo->add_do_method(workspace_overlay, "set_custom_minimum_size", new_workspace_minsize);
-							undo_redo->add_undo_method(workspace_overlay, "set_custom_minimum_size", workspace_minsize);
+							undo_redo->add_do_method(workspace, "set_rect_minimum_size", new_workspace_minsize);
+							undo_redo->add_undo_method(workspace, "set_rect_minimum_size", workspace_minsize);
+							undo_redo->add_do_method(workspace_container, "set_rect_minimum_size", new_workspace_minsize);
+							undo_redo->add_undo_method(workspace_container, "set_rect_minimum_size", workspace_minsize);
+							undo_redo->add_do_method(workspace_overlay, "set_rect_minimum_size", new_workspace_minsize);
+							undo_redo->add_undo_method(workspace_overlay, "set_rect_minimum_size", workspace_minsize);
 						}
 
 						edited_region = Rect2();
@@ -2433,29 +2433,29 @@ void TileSetEditor::_undo_tile_removal(int p_id) {
 }
 
 void TileSetEditor::_zoom_in() {
-	float scale = workspace->get_scale().x;
+	float scale = workspace->get_rect_scale().x;
 	if (scale < max_scale) {
 		scale *= scale_ratio;
-		workspace->set_scale(Vector2(scale, scale));
-		workspace_container->set_custom_minimum_size(workspace->get_rect().size * scale);
-		workspace_overlay->set_custom_minimum_size(workspace->get_rect().size * scale);
+		workspace->set_rect_scale(Vector2(scale, scale));
+		workspace_container->set_rect_minimum_size(workspace->get_rect().size * scale);
+		workspace_overlay->set_rect_minimum_size(workspace->get_rect().size * scale);
 	}
 }
 
 void TileSetEditor::_zoom_out() {
-	float scale = workspace->get_scale().x;
+	float scale = workspace->get_rect_scale().x;
 	if (scale > min_scale) {
 		scale /= scale_ratio;
-		workspace->set_scale(Vector2(scale, scale));
-		workspace_container->set_custom_minimum_size(workspace->get_rect().size * scale);
-		workspace_overlay->set_custom_minimum_size(workspace->get_rect().size * scale);
+		workspace->set_rect_scale(Vector2(scale, scale));
+		workspace_container->set_rect_minimum_size(workspace->get_rect().size * scale);
+		workspace_overlay->set_rect_minimum_size(workspace->get_rect().size * scale);
 	}
 }
 
 void TileSetEditor::_zoom_reset() {
-	workspace->set_scale(Vector2(1, 1));
-	workspace_container->set_custom_minimum_size(workspace->get_rect().size);
-	workspace_overlay->set_custom_minimum_size(workspace->get_rect().size);
+	workspace->set_rect_scale(Vector2(1, 1));
+	workspace_container->set_rect_minimum_size(workspace->get_rect().size);
+	workspace_overlay->set_rect_minimum_size(workspace->get_rect().size);
 }
 
 void TileSetEditor::draw_highlight_current_tile() {
@@ -2509,16 +2509,16 @@ void TileSetEditor::draw_highlight_subtile(Vector2 coord, const Vector<Vector2> 
 		workspace->draw_rect(Rect2(0, coord.y + size.y, workspace->get_rect().size.x, workspace->get_rect().size.y - size.y - coord.y), shadow_color);
 	}
 
-	coord += Vector2(1, 1) / workspace->get_scale().x;
-	workspace->draw_rect(Rect2(coord, size - Vector2(2, 2) / workspace->get_scale().x), Color(1, 0, 0), false);
+	coord += Vector2(1, 1) / workspace->get_rect_scale().x;
+	workspace->draw_rect(Rect2(coord, size - Vector2(2, 2) / workspace->get_rect_scale().x), Color(1, 0, 0), false);
 	for (int i = 0; i < other_highlighted.size(); i++) {
 		coord = other_highlighted[i];
 		coord.x *= (size.x + spacing);
 		coord.y *= (size.y + spacing);
 		coord += region.position;
 		coord += WORKSPACE_MARGIN;
-		coord += Vector2(1, 1) / workspace->get_scale().x;
-		workspace->draw_rect(Rect2(coord, size - Vector2(2, 2) / workspace->get_scale().x), Color(1, 0.5, 0.5), false);
+		coord += Vector2(1, 1) / workspace->get_rect_scale().x;
+		workspace->draw_rect(Rect2(coord, size - Vector2(2, 2) / workspace->get_rect_scale().x), Color(1, 0.5, 0.5), false);
 	}
 }
 
@@ -2593,7 +2593,7 @@ void TileSetEditor::draw_edited_region_subdivision() const {
 void TileSetEditor::draw_grid_snap() {
 	if (tools[TOOL_GRID_SNAP]->is_pressed()) {
 		Color grid_color = Color(0.4, 0, 1);
-		Size2 s = workspace->get_size();
+		Size2 s = workspace->get_rect_size();
 
 		int width_count = Math::floor((s.width - WORKSPACE_MARGIN.x) / (snap_step.x + snap_separation.x));
 		int height_count = Math::floor((s.height - WORKSPACE_MARGIN.y) / (snap_step.y + snap_separation.y));
@@ -3354,9 +3354,9 @@ void TileSetEditor::update_workspace_minsize() {
 	}
 	delete tiles;
 
-	workspace->set_custom_minimum_size(workspace_min_size + WORKSPACE_MARGIN * 2);
-	workspace_container->set_custom_minimum_size(workspace_min_size * workspace->get_scale() + WORKSPACE_MARGIN * 2);
-	workspace_overlay->set_custom_minimum_size(workspace_min_size * workspace->get_scale() + WORKSPACE_MARGIN * 2);
+	workspace->set_rect_minimum_size(workspace_min_size + WORKSPACE_MARGIN * 2);
+	workspace_container->set_rect_minimum_size(workspace_min_size * workspace->get_rect_scale() + WORKSPACE_MARGIN * 2);
+	workspace_overlay->set_rect_minimum_size(workspace_min_size * workspace->get_rect_scale() + WORKSPACE_MARGIN * 2);
 }
 
 void TileSetEditor::update_edited_region(const Vector2 &end_point) {
@@ -3672,7 +3672,7 @@ TileSetEditorPlugin::TileSetEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	tileset_editor = memnew(TileSetEditor(p_node));
 
-	tileset_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
+	tileset_editor->set_rect_minimum_size(Size2(0, 200) * EDSCALE);
 	tileset_editor->hide();
 
 	tileset_editor_button = p_node->add_bottom_panel_item(TTR("TileSet"), tileset_editor);

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -363,7 +363,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_dialog->add_child(set_up_vbc);
 
 	set_up_hbc = memnew(HBoxContainer);
-	set_up_hbc->set_h_size_flags(HBoxContainer::SIZE_EXPAND_FILL);
+	set_up_hbc->set_size_flags_horizontal(HBoxContainer::SIZE_EXPAND_FILL);
 	set_up_vbc->add_child(set_up_hbc);
 
 	set_up_vcs_status = memnew(RichTextLabel);
@@ -375,7 +375,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_hbc->add_child(set_up_vcs_label);
 
 	set_up_choice = memnew(OptionButton);
-	set_up_choice->set_h_size_flags(HBoxContainer::SIZE_EXPAND_FILL);
+	set_up_choice->set_size_flags_horizontal(HBoxContainer::SIZE_EXPAND_FILL);
 	set_up_choice->connect("item_selected", callable_mp(this, &VersionControlEditorPlugin::_selected_a_vcs));
 	set_up_hbc->add_child(set_up_choice);
 
@@ -391,8 +391,8 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	commit_box_vbc = memnew(VBoxContainer);
 	commit_box_vbc->set_alignment(VBoxContainer::ALIGN_BEGIN);
-	commit_box_vbc->set_h_size_flags(VBoxContainer::SIZE_EXPAND_FILL);
-	commit_box_vbc->set_v_size_flags(VBoxContainer::SIZE_EXPAND_FILL);
+	commit_box_vbc->set_size_flags_horizontal(VBoxContainer::SIZE_EXPAND_FILL);
+	commit_box_vbc->set_size_flags_vertical(VBoxContainer::SIZE_EXPAND_FILL);
 	version_commit_dock->add_child(commit_box_vbc);
 
 	stage_tools = memnew(HSplitContainer);
@@ -400,7 +400,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	commit_box_vbc->add_child(stage_tools);
 
 	staging_area_label = memnew(Label);
-	staging_area_label->set_h_size_flags(Label::SIZE_EXPAND_FILL);
+	staging_area_label->set_size_flags_horizontal(Label::SIZE_EXPAND_FILL);
 	staging_area_label->set_text(TTR("Staging area"));
 	stage_tools->add_child(staging_area_label);
 
@@ -412,8 +412,8 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	stage_tools->add_child(refresh_button);
 
 	stage_files = memnew(Tree);
-	stage_files->set_h_size_flags(Tree::SIZE_EXPAND_FILL);
-	stage_files->set_v_size_flags(Tree::SIZE_EXPAND_FILL);
+	stage_files->set_size_flags_horizontal(Tree::SIZE_EXPAND_FILL);
+	stage_files->set_size_flags_vertical(Tree::SIZE_EXPAND_FILL);
 	stage_files->set_columns(1);
 	stage_files->set_column_title(0, TTR("Changes"));
 	stage_files->set_column_titles_visible(true);
@@ -443,7 +443,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	commit_box_vbc->add_child(stage_buttons);
 
 	stage_selected_button = memnew(Button);
-	stage_selected_button->set_h_size_flags(Button::SIZE_EXPAND_FILL);
+	stage_selected_button->set_size_flags_horizontal(Button::SIZE_EXPAND_FILL);
 	stage_selected_button->set_text(TTR("Stage Selected"));
 	stage_selected_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_stage_selected));
 	stage_buttons->add_child(stage_selected_button);
@@ -456,10 +456,10 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	commit_box_vbc->add_child(memnew(HSeparator));
 
 	commit_message = memnew(TextEdit);
-	commit_message->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	commit_message->set_h_grow_direction(Control::GrowDirection::GROW_DIRECTION_BEGIN);
-	commit_message->set_v_grow_direction(Control::GrowDirection::GROW_DIRECTION_END);
-	commit_message->set_custom_minimum_size(Size2(200, 100));
+	commit_message->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
+	commit_message->set_grow_horizontal(Control::GrowDirection::GROW_DIRECTION_BEGIN);
+	commit_message->set_grow_vertical(Control::GrowDirection::GROW_DIRECTION_END);
+	commit_message->set_rect_minimum_size(Size2(200, 100));
 	commit_message->set_wrap_enabled(true);
 	commit_message->connect("text_changed", callable_mp(this, &VersionControlEditorPlugin::_update_commit_button));
 	commit_box_vbc->add_child(commit_message);
@@ -475,16 +475,16 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	commit_box_vbc->add_child(commit_status);
 
 	version_control_dock = memnew(PanelContainer);
-	version_control_dock->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	version_control_dock->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	version_control_dock->hide();
 
 	diff_vbc = memnew(VBoxContainer);
-	diff_vbc->set_h_size_flags(HBoxContainer::SIZE_FILL);
-	diff_vbc->set_v_size_flags(HBoxContainer::SIZE_FILL);
+	diff_vbc->set_size_flags_horizontal(HBoxContainer::SIZE_FILL);
+	diff_vbc->set_size_flags_vertical(HBoxContainer::SIZE_FILL);
 	version_control_dock->add_child(diff_vbc);
 
 	diff_hbc = memnew(HBoxContainer);
-	diff_hbc->set_h_size_flags(HBoxContainer::SIZE_FILL);
+	diff_hbc->set_size_flags_horizontal(HBoxContainer::SIZE_FILL);
 	diff_vbc->add_child(diff_hbc);
 
 	diff_heading = memnew(Label);
@@ -494,7 +494,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	diff_file_name = memnew(Label);
 	diff_file_name->set_text(TTR("No file diff is active"));
-	diff_file_name->set_h_size_flags(Label::SIZE_EXPAND_FILL);
+	diff_file_name->set_size_flags_horizontal(Label::SIZE_EXPAND_FILL);
 	diff_file_name->set_align(Label::ALIGN_RIGHT);
 	diff_hbc->add_child(diff_file_name);
 
@@ -505,8 +505,8 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	diff_hbc->add_child(diff_refresh_button);
 
 	diff = memnew(RichTextLabel);
-	diff->set_h_size_flags(TextEdit::SIZE_EXPAND_FILL);
-	diff->set_v_size_flags(TextEdit::SIZE_EXPAND_FILL);
+	diff->set_size_flags_horizontal(TextEdit::SIZE_EXPAND_FILL);
+	diff->set_size_flags_vertical(TextEdit::SIZE_EXPAND_FILL);
 	diff->set_selection_enabled(true);
 	diff_vbc->add_child(diff);
 }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -131,7 +131,7 @@ void VisualShaderGraphPlugin::show_port_preview(VisualShader::Type p_type, int p
 		if (links[p_node_id].preview_visible && !is_dirty() && links[p_node_id].preview_box != nullptr) {
 			links[p_node_id].graph_node->remove_child(links[p_node_id].preview_box);
 			memdelete(links[p_node_id].preview_box);
-			links[p_node_id].graph_node->set_size(Vector2(-1, -1));
+			links[p_node_id].graph_node->set_rect_size(Vector2(-1, -1));
 			links[p_node_id].preview_visible = false;
 		}
 
@@ -147,12 +147,12 @@ void VisualShaderGraphPlugin::show_port_preview(VisualShader::Type p_type, int p
 			}
 
 			Control *offset = memnew(Control);
-			offset->set_custom_minimum_size(Size2(0, 5 * EDSCALE));
+			offset->set_rect_minimum_size(Size2(0, 5 * EDSCALE));
 			vbox->add_child(offset);
 
 			VisualShaderNodePortPreview *port_preview = memnew(VisualShaderNodePortPreview);
 			port_preview->setup(visual_shader, visual_shader->get_shader_type(), p_node_id, p_port_id);
-			port_preview->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
+			port_preview->set_size_flags_horizontal(Control::SIZE_SHRINK_CENTER);
 			vbox->add_child(port_preview);
 			links[p_node_id].preview_visible = true;
 			links[p_node_id].preview_box = vbox;
@@ -182,7 +182,7 @@ void VisualShaderGraphPlugin::set_input_port_default_value(VisualShader::Type p_
 
 	switch (p_value.get_type()) {
 		case Variant::COLOR: {
-			button->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
+			button->set_rect_minimum_size(Size2(30, 0) * EDSCALE);
 			if (!button->is_connected("draw", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_draw_color_over_button))) {
 				button->connect("draw", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_draw_color_over_button), varray(button, p_value));
 			}
@@ -235,7 +235,7 @@ void VisualShaderGraphPlugin::update_constant(VisualShader::Type p_type, int p_n
 		return;
 	}
 	links[p_node_id].const_op->select(get_constant_index(float_const->get_constant()));
-	links[p_node_id].graph_node->set_size(Size2(-1, -1));
+	links[p_node_id].graph_node->set_rect_size(Size2(-1, -1));
 }
 
 void VisualShaderGraphPlugin::set_expression(VisualShader::Type p_type, int p_node_id, const String &p_expression) {
@@ -249,7 +249,7 @@ void VisualShaderGraphPlugin::update_node_size(int p_node_id) {
 	if (!links.has(p_node_id)) {
 		return;
 	}
-	links[p_node_id].graph_node->set_size(Size2(-1, -1));
+	links[p_node_id].graph_node->set_rect_size(Size2(-1, -1));
 }
 
 void VisualShaderGraphPlugin::register_default_input_button(int p_node_id, int p_port_id, Button *p_button) {
@@ -290,7 +290,7 @@ void VisualShaderGraphPlugin::set_node_position(VisualShader::Type p_type, int p
 
 void VisualShaderGraphPlugin::set_node_size(VisualShader::Type p_type, int p_id, const Vector2 &p_size) {
 	if (visual_shader->get_shader_type() == p_type && links.has(p_id)) {
-		links[p_id].graph_node->set_size(p_size);
+		links[p_id].graph_node->set_rect_size(p_size);
 	}
 }
 
@@ -396,8 +396,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 			Label *comment_label = memnew(Label);
 			node->add_child(comment_label);
-			comment_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-			comment_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+			comment_label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
+			comment_label->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 			comment_label->set_mouse_filter(Control::MouseFilter::MOUSE_FILTER_STOP);
 			comment_label->set_text(comment_node->get_description());
 		}
@@ -447,7 +447,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		}
 
 		HBoxContainer *hbox = memnew(HBoxContainer);
-		custom_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		custom_editor->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		hbox->add_child(custom_editor);
 		custom_editor = hbox;
 	}
@@ -482,8 +482,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			CurveEditor *curve_editor = memnew(CurveEditor);
 			node->add_child(curve_editor);
 			register_curve_editor(p_id, curve_editor);
-			curve_editor->set_custom_minimum_size(Size2(300, 0));
-			curve_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			curve_editor->set_rect_minimum_size(Size2(300, 0));
+			curve_editor->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 			if (curve->get_texture().is_valid()) {
 				curve_editor->set_curve(curve->get_texture()->get_curve());
 			}
@@ -492,7 +492,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			preview->set_toggle_mode(true);
 			preview->set_normal_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiVisibilityHidden", "EditorIcons"));
 			preview->set_pressed_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiVisibilityVisible", "EditorIcons"));
-			preview->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+			preview->set_size_flags_vertical(Control::SIZE_SHRINK_CENTER);
 
 			register_output_port(p_id, 0, preview);
 
@@ -513,7 +513,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 	if (is_group) {
 		offset = memnew(Control);
-		offset->set_custom_minimum_size(Size2(0, 6 * EDSCALE));
+		offset->set_rect_minimum_size(Size2(0, 6 * EDSCALE));
 		node->add_child(offset);
 
 		if (group_node->is_editable()) {
@@ -600,7 +600,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 		if (i == 0 && custom_editor) {
 			hb->add_child(custom_editor);
-			custom_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			custom_editor->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		} else {
 			if (valid_left) {
 				if (is_group) {
@@ -613,13 +613,13 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					type_box->add_item(TTR("Transform"));
 					type_box->add_item(TTR("Sampler"));
 					type_box->select(group_node->get_input_port_type(i));
-					type_box->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+					type_box->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 					type_box->connect("item_selected", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_change_input_port_type), varray(p_id, i), CONNECT_DEFERRED);
 
 					LineEdit *name_box = memnew(LineEdit);
 					hb->add_child(name_box);
-					name_box->set_custom_minimum_size(Size2(65 * EDSCALE, 0));
-					name_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+					name_box->set_rect_minimum_size(Size2(65 * EDSCALE, 0));
+					name_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 					name_box->set_text(name_left);
 					name_box->connect("text_entered", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_change_input_port_name), varray(name_box, p_id, i), CONNECT_DEFERRED);
 					name_box->connect("focus_exited", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_port_name_focus_out), varray(name_box, p_id, i, false), CONNECT_DEFERRED);
@@ -659,8 +659,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 					LineEdit *name_box = memnew(LineEdit);
 					hb->add_child(name_box);
-					name_box->set_custom_minimum_size(Size2(65 * EDSCALE, 0));
-					name_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+					name_box->set_rect_minimum_size(Size2(65 * EDSCALE, 0));
+					name_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 					name_box->set_text(name_right);
 					name_box->connect("text_entered", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_change_output_port_name), varray(name_box, p_id, i), CONNECT_DEFERRED);
 					name_box->connect("focus_exited", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_port_name_focus_out), varray(name_box, p_id, i, true), CONNECT_DEFERRED);
@@ -673,7 +673,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					type_box->add_item(TTR("Boolean"));
 					type_box->add_item(TTR("Transform"));
 					type_box->select(group_node->get_output_port_type(i));
-					type_box->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+					type_box->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 					type_box->connect("item_selected", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_change_output_port_type), varray(p_id, i), CONNECT_DEFERRED);
 				} else {
 					Label *label = memnew(Label);
@@ -689,7 +689,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			preview->set_toggle_mode(true);
 			preview->set_normal_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiVisibilityHidden", "EditorIcons"));
 			preview->set_pressed_texture(VisualShaderEditor::get_singleton()->get_theme_icon("GuiVisibilityVisible", "EditorIcons"));
-			preview->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+			preview->set_size_flags_vertical(Control::SIZE_SHRINK_CENTER);
 
 			register_output_port(p_id, i, preview);
 
@@ -699,7 +699,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 		if (is_group) {
 			offset = memnew(Control);
-			offset->set_custom_minimum_size(Size2(0, 5 * EDSCALE));
+			offset->set_rect_minimum_size(Size2(0, 5 * EDSCALE));
 			node->add_child(offset);
 			port_offset++;
 		}
@@ -714,7 +714,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	}
 
 	offset = memnew(Control);
-	offset->set_custom_minimum_size(Size2(0, 4 * EDSCALE));
+	offset->set_rect_minimum_size(Size2(0, 4 * EDSCALE));
 	node->add_child(offset);
 
 	String error = vsnode->get_warning(visual_shader->get_mode(), p_type);
@@ -1171,7 +1171,7 @@ void VisualShaderEditor::_draw_color_over_button(Object *obj, Color p_color) {
 	}
 
 	Ref<StyleBox> normal = get_theme_stylebox("normal", "Button");
-	button->draw_rect(Rect2(normal->get_offset(), button->get_size() - normal->get_minimum_size()), p_color);
+	button->draw_rect(Rect2(normal->get_offset(), button->get_rect_size() - normal->get_minimum_size()), p_color);
 }
 
 void VisualShaderEditor::_update_created_node(GraphNode *node) {
@@ -1592,7 +1592,7 @@ void VisualShaderEditor::_set_node_size(int p_type, int p_node, const Vector2 &p
 		if (!expression_node.is_null()) {
 			text_box = expression_node->get_control(0);
 			if (text_box) {
-				text_box->set_custom_minimum_size(Size2(0, 0));
+				text_box->set_rect_minimum_size(Size2(0, 0));
 			}
 		}
 
@@ -1603,22 +1603,22 @@ void VisualShaderEditor::_set_node_size(int p_type, int p_node, const Vector2 &p
 			return;
 		}
 
-		gn->set_custom_minimum_size(size);
-		gn->set_size(Size2(1, 1));
+		gn->set_rect_minimum_size(size);
+		gn->set_rect_size(Size2(1, 1));
 
 		if (!expression_node.is_null() && text_box) {
 			Size2 box_size = size;
 			if (gn != nullptr) {
 				if (box_size.x < 150 * EDSCALE || box_size.y < 0) {
-					box_size.x = gn->get_size().x;
+					box_size.x = gn->get_rect_size().x;
 				}
 			}
 			box_size.x -= text_box->get_offset(SIDE_LEFT);
 			box_size.x -= 28 * EDSCALE;
 			box_size.y -= text_box->get_offset(SIDE_TOP);
 			box_size.y -= 28 * EDSCALE;
-			text_box->set_custom_minimum_size(Size2(box_size.x, box_size.y));
-			text_box->set_size(Size2(1, 1));
+			text_box->set_rect_minimum_size(Size2(box_size.x, box_size.y));
+			text_box->set_rect_size(Size2(1, 1));
 		}
 	}
 }
@@ -1666,7 +1666,7 @@ void VisualShaderEditor::_comment_title_popup_show(const Point2 &p_position, int
 }
 
 void VisualShaderEditor::_comment_title_text_changed(const String &p_new_text) {
-	comment_title_change_edit->set_size(Size2(-1, -1));
+	comment_title_change_edit->set_rect_size(Size2(-1, -1));
 	comment_title_change_popup->set_size(Size2(-1, -1));
 }
 
@@ -1711,7 +1711,7 @@ void VisualShaderEditor::_comment_desc_popup_show(const Point2 &p_position, int 
 }
 
 void VisualShaderEditor::_comment_desc_text_changed() {
-	comment_desc_change_edit->set_size(Size2(-1, -1));
+	comment_desc_change_edit->set_rect_size(Size2(-1, -1));
 	comment_desc_change_popup->set_size(Size2(-1, -1));
 }
 
@@ -1811,7 +1811,7 @@ void VisualShaderEditor::_edit_port_default_input(Object *p_button, int p_node, 
 	Button *button = Object::cast_to<Button>(p_button);
 	ERR_FAIL_COND(!button);
 	Variant value = vsn->get_input_port_default_value(p_port);
-	property_editor->set_position(button->get_screen_position() + Vector2(0, button->get_size().height));
+	property_editor->set_position(button->get_screen_position() + Vector2(0, button->get_rect_size().height));
 	property_editor->edit(nullptr, "", value.get_type(), value, 0, "");
 	property_editor->popup();
 	editing_node = p_node;
@@ -2091,7 +2091,7 @@ VisualShaderNode *VisualShaderEditor::_add_node(int p_idx, int p_op_idx) {
 	if (saved_node_pos_dirty) {
 		position += saved_node_pos;
 	} else {
-		position += graph->get_size() * 0.5;
+		position += graph->get_rect_size() * 0.5;
 		position /= EDSCALE;
 	}
 	saved_node_pos_dirty = false;
@@ -2732,7 +2732,7 @@ void VisualShaderEditor::_show_members_dialog(bool at_mouse_pos) {
 	} else {
 		members_dialog->popup();
 		saved_node_pos_dirty = false;
-		members_dialog->set_position(graph->get_global_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
+		members_dialog->set_position(graph->get_rect_global_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
 	}
 
 	// keep dialog within window bounds
@@ -3407,7 +3407,7 @@ void VisualShaderEditor::_preview_close_requested() {
 }
 
 void VisualShaderEditor::_preview_size_changed() {
-	preview_vbox->set_custom_minimum_size(preview_window->get_size());
+	preview_vbox->set_rect_minimum_size(preview_window->get_size());
 }
 
 static ShaderLanguage::DataType _get_global_variable_type(const StringName &p_variable) {
@@ -3496,9 +3496,9 @@ VisualShaderEditor::VisualShaderEditor() {
 	from_slot = -1;
 
 	graph = memnew(GraphEdit);
-	graph->get_zoom_hbox()->set_h_size_flags(SIZE_EXPAND_FILL);
-	graph->set_v_size_flags(SIZE_EXPAND_FILL);
-	graph->set_h_size_flags(SIZE_EXPAND_FILL);
+	graph->get_zoom_hbox()->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	graph->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	graph->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	add_child(graph);
 	graph->set_drag_forwarding(this);
 	float graph_minimap_opacity = EditorSettings::get_singleton()->get("editors/visual_editors/minimap_opacity");
@@ -3510,7 +3510,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	graph->add_valid_right_disconnect_type(VisualShaderNode::PORT_TYPE_TRANSFORM);
 	graph->add_valid_right_disconnect_type(VisualShaderNode::PORT_TYPE_SAMPLER);
 	//graph->add_valid_left_disconnect_type(0);
-	graph->set_v_size_flags(SIZE_EXPAND_FILL);
+	graph->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	graph->connect("connection_request", callable_mp(this, &VisualShaderEditor::_connection_request), varray(), CONNECT_DEFERRED);
 	graph->connect("disconnection_request", callable_mp(this, &VisualShaderEditor::_disconnection_request), varray(), CONNECT_DEFERRED);
 	graph->connect("node_selected", callable_mp(this, &VisualShaderEditor::_node_selected));
@@ -3605,7 +3605,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	preview_text = memnew(CodeEdit);
 	syntax_highlighter.instance();
 	preview_vbox->add_child(preview_text);
-	preview_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	preview_text->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	preview_text->set_syntax_highlighter(syntax_highlighter);
 	preview_text->set_draw_line_numbers(true);
 	preview_text->set_readonly(true);
@@ -3634,7 +3634,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	///////////////////////////////////////
 
 	VBoxContainer *members_vb = memnew(VBoxContainer);
-	members_vb->set_v_size_flags(SIZE_EXPAND_FILL);
+	members_vb->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	HBoxContainer *filter_hb = memnew(HBoxContainer);
 	members_vb->add_child(filter_hb);
@@ -3643,7 +3643,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	filter_hb->add_child(node_filter);
 	node_filter->connect("text_changed", callable_mp(this, &VisualShaderEditor::_member_filter_changed));
 	node_filter->connect("gui_input", callable_mp(this, &VisualShaderEditor::_sbox_input));
-	node_filter->set_h_size_flags(SIZE_EXPAND_FILL);
+	node_filter->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	node_filter->set_placeholder(TTR("Search"));
 
 	tools = memnew(MenuButton);
@@ -3656,12 +3656,12 @@ VisualShaderEditor::VisualShaderEditor() {
 	members = memnew(Tree);
 	members_vb->add_child(members);
 	members->set_drag_forwarding(this);
-	members->set_h_size_flags(SIZE_EXPAND_FILL);
-	members->set_v_size_flags(SIZE_EXPAND_FILL);
+	members->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	members->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	members->set_hide_root(true);
 	members->set_allow_reselect(true);
 	members->set_hide_folding(false);
-	members->set_custom_minimum_size(Size2(180 * EDSCALE, 200 * EDSCALE));
+	members->set_rect_minimum_size(Size2(180 * EDSCALE, 200 * EDSCALE));
 	members->connect("item_activated", callable_mp(this, &VisualShaderEditor::_member_create));
 	members->connect("item_selected", callable_mp(this, &VisualShaderEditor::_member_selected));
 	members->connect("nothing_selected", callable_mp(this, &VisualShaderEditor::_member_unselected));
@@ -3684,9 +3684,9 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	node_desc = memnew(RichTextLabel);
 	members_vb->add_child(node_desc);
-	node_desc->set_h_size_flags(SIZE_EXPAND_FILL);
-	node_desc->set_v_size_flags(SIZE_FILL);
-	node_desc->set_custom_minimum_size(Size2(0, 70 * EDSCALE));
+	node_desc->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	node_desc->set_size_flags_vertical(SIZE_FILL);
+	node_desc->set_rect_minimum_size(Size2(0, 70 * EDSCALE));
 
 	members_dialog = memnew(ConfirmationDialog);
 	members_dialog->set_title(TTR("Create Shader Node"));
@@ -3702,7 +3702,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	alert->get_label()->set_autowrap(true);
 	alert->get_label()->set_align(Label::ALIGN_CENTER);
 	alert->get_label()->set_valign(Label::VALIGN_CENTER);
-	alert->get_label()->set_custom_minimum_size(Size2(400, 60) * EDSCALE);
+	alert->get_label()->set_rect_minimum_size(Size2(400, 60) * EDSCALE);
 	add_child(alert);
 
 	comment_title_change_popup = memnew(PopupPanel);
@@ -3711,7 +3711,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	comment_title_change_edit->connect("text_changed", callable_mp(this, &VisualShaderEditor::_comment_title_text_changed));
 	comment_title_change_edit->connect("text_entered", callable_mp(this, &VisualShaderEditor::_comment_title_text_entered));
 	comment_title_change_popup->add_child(comment_title_change_edit);
-	comment_title_change_edit->set_size(Size2(-1, -1));
+	comment_title_change_edit->set_rect_size(Size2(-1, -1));
 	comment_title_change_popup->set_size(Size2(-1, -1));
 	comment_title_change_popup->connect("focus_exited", callable_mp(this, &VisualShaderEditor::_comment_title_popup_focus_out));
 	comment_title_change_popup->connect("popup_hide", callable_mp(this, &VisualShaderEditor::_comment_title_popup_hide));
@@ -3723,8 +3723,8 @@ VisualShaderEditor::VisualShaderEditor() {
 	comment_desc_change_edit = memnew(TextEdit);
 	comment_desc_change_edit->connect("text_changed", callable_mp(this, &VisualShaderEditor::_comment_desc_text_changed));
 	comment_desc_vbox->add_child(comment_desc_change_edit);
-	comment_desc_change_edit->set_custom_minimum_size(Size2(300 * EDSCALE, 150 * EDSCALE));
-	comment_desc_change_edit->set_size(Size2(-1, -1));
+	comment_desc_change_edit->set_rect_minimum_size(Size2(300 * EDSCALE, 150 * EDSCALE));
+	comment_desc_change_edit->set_rect_size(Size2(-1, -1));
 	comment_desc_change_popup->set_size(Size2(-1, -1));
 	comment_desc_change_popup->connect("focus_exited", callable_mp(this, &VisualShaderEditor::_comment_desc_confirm));
 	comment_desc_change_popup->connect("popup_hide", callable_mp(this, &VisualShaderEditor::_comment_desc_popup_hide));
@@ -4246,7 +4246,7 @@ void VisualShaderEditorPlugin::make_visible(bool p_visible) {
 VisualShaderEditorPlugin::VisualShaderEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	visual_shader_editor = memnew(VisualShaderEditor);
-	visual_shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
+	visual_shader_editor->set_rect_minimum_size(Size2(0, 300) * EDSCALE);
 
 	button = editor->add_bottom_panel_item(TTR("VisualShader"), visual_shader_editor);
 	button->hide();
@@ -4432,7 +4432,7 @@ public:
 
 		for (int i = 0; i < p_properties.size(); i++) {
 			HBoxContainer *hbox = memnew(HBoxContainer);
-			hbox->set_h_size_flags(SIZE_EXPAND_FILL);
+			hbox->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			add_child(hbox);
 
 			Label *prop_name = memnew(Label);
@@ -4443,7 +4443,7 @@ public:
 			hbox->add_child(prop_name);
 			prop_names.push_back(prop_name);
 
-			p_properties[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			p_properties[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			hbox->add_child(p_properties[i]);
 
 			bool res_prop = Object::cast_to<EditorPropertyResource>(p_properties[i]);
@@ -4515,13 +4515,13 @@ Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_par
 
 		if (Object::cast_to<EditorPropertyResource>(prop)) {
 			Object::cast_to<EditorPropertyResource>(prop)->set_use_sub_inspector(false);
-			prop->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+			prop->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 		} else if (Object::cast_to<EditorPropertyTransform>(prop) || Object::cast_to<EditorPropertyVector3>(prop)) {
-			prop->set_custom_minimum_size(Size2(250 * EDSCALE, 0));
+			prop->set_rect_minimum_size(Size2(250 * EDSCALE, 0));
 		} else if (Object::cast_to<EditorPropertyFloat>(prop)) {
-			prop->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+			prop->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 		} else if (Object::cast_to<EditorPropertyEnum>(prop)) {
-			prop->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+			prop->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 			Object::cast_to<EditorPropertyEnum>(prop)->set_option_button_clip(false);
 		}
 
@@ -4720,13 +4720,13 @@ void VisualShaderNodePortPreview::_notification(int p_what) {
 		points.push_back(Vector2());
 		uvs.push_back(Vector2(0, 0));
 		colors.push_back(Color(1, 1, 1, 1));
-		points.push_back(Vector2(get_size().width, 0));
+		points.push_back(Vector2(get_rect_size().width, 0));
 		uvs.push_back(Vector2(1, 0));
 		colors.push_back(Color(1, 1, 1, 1));
-		points.push_back(get_size());
+		points.push_back(get_rect_size());
 		uvs.push_back(Vector2(1, 1));
 		colors.push_back(Color(1, 1, 1, 1));
-		points.push_back(Vector2(0, get_size().height));
+		points.push_back(Vector2(0, get_rect_size().height));
 		uvs.push_back(Vector2(0, 1));
 		colors.push_back(Color(1, 1, 1, 1));
 

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -48,11 +48,11 @@ void BackgroundProgress::_add_task(const String &p_task, const String &p_label, 
 	t.progress->set_max(p_steps);
 	t.progress->set_value(p_steps);
 	Control *ec = memnew(Control);
-	ec->set_h_size_flags(SIZE_EXPAND_FILL);
-	ec->set_v_size_flags(SIZE_EXPAND_FILL);
+	ec->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	ec->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	t.progress->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	ec->add_child(t.progress);
-	ec->set_custom_minimum_size(Size2(80, 5) * EDSCALE);
+	ec->set_rect_minimum_size(Size2(80, 5) * EDSCALE);
 	t.hb->add_child(ec);
 
 	add_child(t.hb);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -997,12 +997,12 @@ ProjectExportDialog::ProjectExportDialog() {
 	add_child(main_vb);
 	HSplitContainer *hbox = memnew(HSplitContainer);
 	main_vb->add_child(hbox);
-	hbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	hbox->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	// Presets list.
 
 	VBoxContainer *preset_vb = memnew(VBoxContainer);
-	preset_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	preset_vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	hbox->add_child(preset_vb);
 
 	HBoxContainer *preset_hb = memnew(HBoxContainer);
@@ -1016,7 +1016,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	preset_hb->add_child(add_preset);
 	MarginContainer *mc = memnew(MarginContainer);
 	preset_vb->add_child(mc);
-	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	mc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	presets = memnew(ItemList);
 #ifndef _MSC_VER
 #warning must reimplement drag forward
@@ -1036,7 +1036,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	// Preset settings.
 
 	VBoxContainer *settings_vb = memnew(VBoxContainer);
-	settings_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	settings_vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	hbox->add_child(settings_vb);
 
 	name = memnew(LineEdit);
@@ -1061,14 +1061,14 @@ ProjectExportDialog::ProjectExportDialog() {
 	sections->set_tab_align(TabContainer::ALIGN_LEFT);
 	sections->set_use_hidden_tabs_for_min_size(true);
 	settings_vb->add_child(sections);
-	sections->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	sections->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 
 	// Main preset parameters.
 
 	parameters = memnew(EditorInspector);
 	sections->add_child(parameters);
 	parameters->set_name(TTR("Options"));
-	parameters->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	parameters->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	parameters->connect("property_edited", callable_mp(this, &ProjectExportDialog::_update_parameters));
 	EditorExport::get_singleton()->connect("export_presets_updated", callable_mp(this, &ProjectExportDialog::_force_update_current_preset_parameters));
 
@@ -1090,7 +1090,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	include_label->set_text(TTR("Resources to export:"));
 	resources_vb->add_child(include_label);
 	include_margin = memnew(MarginContainer);
-	include_margin->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	include_margin->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	resources_vb->add_child(include_margin);
 
 	include_files = memnew(Tree);
@@ -1123,7 +1123,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	custom_features->connect("text_changed", callable_mp(this, &ProjectExportDialog::_custom_features_changed));
 	feature_vb->add_margin_child(TTR("Custom (comma-separated):"), custom_features);
 	custom_feature_display = memnew(RichTextLabel);
-	custom_feature_display->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	custom_feature_display->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	feature_vb->add_margin_child(TTR("Feature List:"), custom_feature_display, true);
 	sections->add_child(feature_vb);
 
@@ -1249,7 +1249,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	LinkButton *download_templates = memnew(LinkButton);
 	download_templates->set_text(TTR("Manage Export Templates"));
-	download_templates->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	download_templates->set_size_flags_vertical(Control::SIZE_SHRINK_CENTER);
 	export_templates_error->add_child(download_templates);
 	download_templates->connect("pressed", callable_mp(this, &ProjectExportDialog::_open_export_template_manager));
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -778,7 +778,7 @@ public:
 		name_container->add_child(pnhb);
 
 		project_name = memnew(LineEdit);
-		project_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		project_name->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		pnhb->add_child(project_name);
 
 		create_dir = memnew(Button);
@@ -797,7 +797,7 @@ public:
 		path_container->add_child(pphb);
 
 		project_path = memnew(LineEdit);
-		project_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		project_path->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		project_path->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
 		pphb->add_child(project_path);
 
@@ -812,7 +812,7 @@ public:
 		install_path_container->add_child(iphb);
 
 		install_path = memnew(LineEdit);
-		install_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		install_path->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		install_path->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
 		iphb->add_child(install_path);
 
@@ -851,7 +851,7 @@ public:
 		rasterizer_button_group.instance();
 
 		Container *rvb = memnew(VBoxContainer);
-		rvb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		rvb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		rshb->add_child(rvb);
 		Button *rs_button = memnew(CheckBox);
 		rs_button->set_button_group(rasterizer_button_group);
@@ -870,7 +870,7 @@ public:
 				TTR("The GLES2 renderer is currently unavailable, as it needs to be reworked for Godot 4.0.\nUse Godot 3.2 if you need GLES2 support.");
 
 		rvb = memnew(VBoxContainer);
-		rvb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		rvb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		rshb->add_child(rvb);
 		rs_button = memnew(CheckBox);
 		rs_button->set_button_group(rasterizer_button_group);
@@ -891,7 +891,7 @@ public:
 		l = memnew(Label);
 		l->set_text(TTR("The renderer can be changed later, but scenes may need to be adjusted."));
 		// Add some extra spacing to separate it from the list above and the buttons below.
-		l->set_custom_minimum_size(Size2(0, 40) * EDSCALE);
+		l->set_rect_minimum_size(Size2(0, 40) * EDSCALE);
 		l->set_align(Label::ALIGN_CENTER);
 		l->set_valign(Label::VALIGN_CENTER);
 		l->set_modulate(Color(1, 1, 1, 0.7));
@@ -952,7 +952,7 @@ public:
 			} break;
 			case NOTIFICATION_DRAW: {
 				if (hover) {
-					draw_style_box(get_theme_stylebox("hover", "Tree"), Rect2(Point2(), get_size()));
+					draw_style_box(get_theme_stylebox("hover", "Tree"), Rect2(Point2(), get_rect_size()));
 				}
 			} break;
 		}
@@ -1094,7 +1094,7 @@ struct ProjectListComparator {
 ProjectList::ProjectList() {
 	_order_option = FilterOption::NAME;
 	_scroll_children = memnew(VBoxContainer);
-	_scroll_children->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	_scroll_children->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	add_child(_scroll_children);
 
 	_icon_load_index = 0;
@@ -1340,7 +1340,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	// The project icon may not be loaded by the time the control is displayed,
 	// so use a loading placeholder.
 	tf->set_texture(get_theme_icon("ProjectIconLoading", "EditorIcons"));
-	tf->set_v_size_flags(SIZE_SHRINK_CENTER);
+	tf->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 	if (item.missing) {
 		tf->set_modulate(Color(1, 1, 1, 0.5));
 	}
@@ -1351,10 +1351,10 @@ void ProjectList::create_project_item_control(int p_index) {
 	if (item.grayed) {
 		vb->set_modulate(Color(1, 1, 1, 0.5));
 	}
-	vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	hb->add_child(vb);
 	Control *ec = memnew(Control);
-	ec->set_custom_minimum_size(Size2(0, 1));
+	ec->set_rect_minimum_size(Size2(0, 1));
 	ec->set_mouse_filter(MOUSE_FILTER_PASS);
 	vb->add_child(ec);
 	Label *title = memnew(Label(!item.missing ? item.project_name : TTR("Missing Project")));
@@ -1365,7 +1365,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	vb->add_child(title);
 
 	HBoxContainer *path_hb = memnew(HBoxContainer);
-	path_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	path_hb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	vb->add_child(path_hb);
 
 	Button *show = memnew(Button);
@@ -1387,7 +1387,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	Label *fpath = memnew(Label(item.path));
 	fpath->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
 	path_hb->add_child(fpath);
-	fpath->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	fpath->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	fpath->set_modulate(Color(1, 1, 1, 0.5));
 	fpath->add_theme_color_override("font_color", font_color);
 	fpath->set_clip_text(true);
@@ -1471,14 +1471,14 @@ Vector<ProjectList::Item> ProjectList::get_selected_projects() const {
 void ProjectList::ensure_project_visible(int p_index) {
 	const Item &item = _projects[p_index];
 
-	int item_top = item.control->get_position().y;
-	int item_bottom = item.control->get_position().y + item.control->get_size().y;
+	int item_top = item.control->get_rect_position().y;
+	int item_bottom = item.control->get_rect_position().y + item.control->get_rect_size().y;
 
 	if (item_top < get_v_scroll()) {
 		set_v_scroll(item_top);
 
-	} else if (item_bottom > get_v_scroll() + get_size().y) {
-		set_v_scroll(item_bottom - get_size().y);
+	} else if (item_bottom > get_v_scroll() + get_rect_size().y) {
+		set_v_scroll(item_bottom - get_rect_size().y);
 	}
 }
 
@@ -1721,15 +1721,15 @@ void ProjectList::_panel_draw(Node *p_hb) {
 	Control *hb = Object::cast_to<Control>(p_hb);
 
 	if (is_layout_rtl() && get_v_scrollbar()->is_visible_in_tree()) {
-		hb->draw_line(Point2(get_v_scrollbar()->get_minimum_size().x, hb->get_size().y + 1), Point2(hb->get_size().x, hb->get_size().y + 1), get_theme_color("guide_color", "Tree"));
+		hb->draw_line(Point2(get_v_scrollbar()->get_minimum_size().x, hb->get_rect_size().y + 1), Point2(hb->get_rect_size().x, hb->get_rect_size().y + 1), get_theme_color("guide_color", "Tree"));
 	} else {
-		hb->draw_line(Point2(0, hb->get_size().y + 1), Point2(hb->get_size().x, hb->get_size().y + 1), get_theme_color("guide_color", "Tree"));
+		hb->draw_line(Point2(0, hb->get_rect_size().y + 1), Point2(hb->get_rect_size().x, hb->get_rect_size().y + 1), get_theme_color("guide_color", "Tree"));
 	}
 
 	String key = _projects[p_hb->get_index()].project_key;
 
 	if (_selected_project_keys.has(key)) {
-		hb->draw_style_box(get_theme_stylebox("selected", "Tree"), Rect2(Point2(), hb->get_size()));
+		hb->draw_style_box(get_theme_stylebox("selected", "Tree"), Rect2(Point2(), hb->get_rect_size()));
 	}
 }
 
@@ -2470,7 +2470,7 @@ ProjectManager::ProjectManager() {
 	vb->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 8 * EDSCALE);
 
 	Control *center_box = memnew(Control);
-	center_box->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	center_box->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	vb->add_child(center_box);
 
 	tabs = memnew(TabContainer);
@@ -2487,22 +2487,22 @@ ProjectManager::ProjectManager() {
 		// Projects + search bar
 		VBoxContainer *search_tree_vb = memnew(VBoxContainer);
 		projects_hb->add_child(search_tree_vb);
-		search_tree_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		search_tree_vb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 		HBoxContainer *hb = memnew(HBoxContainer);
-		hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		hb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		search_tree_vb->add_child(hb);
 
 		search_box = memnew(LineEdit);
 		search_box->set_placeholder(TTR("Filter projects"));
 		search_box->set_tooltip(TTR("This field filters projects by name and last path component.\nTo filter projects by name and full path, the query must contain at least one `/` character."));
 		search_box->connect("text_changed", callable_mp(this, &ProjectManager::_on_search_term_changed));
-		search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		search_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		hb->add_child(search_box);
 
 		loading_label = memnew(Label(TTR("Loading, please wait...")));
 		loading_label->add_theme_font_override("font", get_theme_font("bold", "EditorFonts"));
-		loading_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		loading_label->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		hb->add_child(loading_label);
 		// Hide the label but make it still take up space. This prevents reflows when showing the label.
 		loading_label->set_modulate(Color(0, 0, 0, 0));
@@ -2513,7 +2513,7 @@ ProjectManager::ProjectManager() {
 
 		filter_option = memnew(OptionButton);
 		filter_option->set_clip_text(true);
-		filter_option->set_custom_minimum_size(Size2(150 * EDSCALE, 10 * EDSCALE));
+		filter_option->set_rect_minimum_size(Size2(150 * EDSCALE, 10 * EDSCALE));
 		filter_option->connect("item_selected", callable_mp(this, &ProjectManager::_on_order_option_changed));
 		hb->add_child(filter_option);
 
@@ -2528,7 +2528,7 @@ ProjectManager::ProjectManager() {
 
 		PanelContainer *pc = memnew(PanelContainer);
 		pc->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-		pc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		pc->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 		search_tree_vb->add_child(pc);
 
 		_project_list = memnew(ProjectList);
@@ -2541,7 +2541,7 @@ ProjectManager::ProjectManager() {
 	{
 		// Project tab side bar
 		VBoxContainer *tree_vb = memnew(VBoxContainer);
-		tree_vb->set_custom_minimum_size(Size2(120, 120));
+		tree_vb->set_rect_minimum_size(Size2(120, 120));
 		projects_hb->add_child(tree_vb);
 
 		Button *create = memnew(Button);
@@ -2598,7 +2598,7 @@ ProjectManager::ProjectManager() {
 		// Version info and language options
 		settings_hb = memnew(HBoxContainer);
 		settings_hb->set_alignment(BoxContainer::ALIGN_END);
-		settings_hb->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
+		settings_hb->set_grow_horizontal(Control::GROW_DIRECTION_BEGIN);
 		settings_hb->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT);
 
 		Label *version_label = memnew(Label);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -522,22 +522,22 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	VBoxContainer *general_editor = memnew(VBoxContainer);
 	general_editor->set_name(TTR("General"));
 	general_editor->set_alignment(BoxContainer::ALIGN_BEGIN);
-	general_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	general_editor->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	tab_container->add_child(general_editor);
 
 	VBoxContainer *header = memnew(VBoxContainer);
-	header->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	header->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	general_editor->add_child(header);
 
 	{
 		// Search bar.
 		search_bar = memnew(HBoxContainer);
-		search_bar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		search_bar->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		header->add_child(search_bar);
 
 		search_box = memnew(LineEdit);
 		search_box->set_placeholder(TTR("Search"));
-		search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		search_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		search_bar->add_child(search_box);
 
 		advanced = memnew(CheckButton);
@@ -553,10 +553,10 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		header->add_child(advanced_bar);
 
 		HBoxContainer *hbc = advanced_bar;
-		hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		hbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 		category_box = memnew(LineEdit);
-		category_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		category_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		category_box->connect("text_changed", callable_mp(this, &ProjectSettingsEditor::_text_field_changed));
 		category_box->set_placeholder(TTR("Category"));
 		hbc->add_child(category_box);
@@ -566,7 +566,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		hbc->add_child(l);
 
 		property_box = memnew(LineEdit);
-		property_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		property_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		property_box->set_placeholder(TTR("Property"));
 		property_box->connect("text_changed", callable_mp(this, &ProjectSettingsEditor::_text_field_changed));
 		hbc->add_child(property_box);
@@ -576,7 +576,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		hbc->add_child(l);
 
 		type = memnew(OptionButton);
-		type->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
+		type->set_rect_minimum_size(Size2(100, 0) * EDSCALE);
 		hbc->add_child(type);
 
 		for (int i = 0; i < Variant::VARIANT_MAX; i++) {
@@ -592,7 +592,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		hbc->add_child(l);
 
 		feature_override = memnew(OptionButton);
-		feature_override->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
+		feature_override->set_rect_minimum_size(Size2(100, 0) * EDSCALE);
 		feature_override->connect("item_selected", callable_mp(this, &ProjectSettingsEditor::_feature_selected));
 		hbc->add_child(feature_override);
 
@@ -609,7 +609,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	inspector = memnew(SectionedInspector);
 	inspector->get_inspector()->set_undo_redo(EditorNode::get_singleton()->get_undo_redo());
-	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	inspector->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	inspector->register_search_box(search_box);
 	inspector->get_inspector()->connect("property_selected", callable_mp(this, &ProjectSettingsEditor::_setting_selected));
 	inspector->get_inspector()->connect("property_edited", callable_mp(this, &ProjectSettingsEditor::_setting_edited));
@@ -624,7 +624,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	restart_container->add_child(restart_hb);
 
 	restart_icon = memnew(TextureRect);
-	restart_icon->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	restart_icon->set_size_flags_vertical(Control::SIZE_SHRINK_CENTER);
 	restart_hb->add_child(restart_icon);
 
 	restart_label = memnew(Label);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -353,12 +353,12 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 			CheckBox *c = checks20[0];
 			c->set_text("True");
-			checks20gc->set_position(Vector2(4, 4) * EDSCALE);
+			checks20gc->set_rect_position(Vector2(4, 4) * EDSCALE);
 			c->set_pressed(v);
 			c->show();
 
-			checks20gc->set_size(checks20gc->get_minimum_size());
-			set_size(checks20gc->get_position() + checks20gc->get_size() + c->get_size() + Vector2(4, 4) * EDSCALE);
+			checks20gc->set_rect_size(checks20gc->get_minimum_size());
+			set_size(checks20gc->get_rect_position() + checks20gc->get_rect_size() + c->get_rect_size() + Vector2(4, 4) * EDSCALE);
 
 		} break;
 		case Variant::INT:
@@ -461,10 +461,10 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 				show();
 
-				checks20gc->set_position(Vector2(4, 4) * EDSCALE);
-				checks20gc->set_size(checks20gc->get_minimum_size());
+				checks20gc->set_rect_position(Vector2(4, 4) * EDSCALE);
+				checks20gc->set_rect_size(checks20gc->get_minimum_size());
 
-				set_size(Vector2(4, 4) * EDSCALE + checks20gc->get_position() + checks20gc->get_size());
+				set_size(Vector2(4, 4) * EDSCALE + checks20gc->get_rect_position() + checks20gc->get_rect_size());
 
 			} else if (hint == PROPERTY_HINT_EXP_EASING) {
 				easing_draw->set_anchor_and_offset(SIDE_LEFT, Control::ANCHOR_BEGIN, 5 * EDSCALE);
@@ -1393,7 +1393,7 @@ void CustomPropertyEditor::_drag_easing(const Ref<InputEvent> &p_ev) {
 void CustomPropertyEditor::_draw_easing() {
 	RID ci = easing_draw->get_canvas_item();
 
-	Size2 s = easing_draw->get_size();
+	Size2 s = easing_draw->get_rect_size();
 	Rect2 r(Point2(), s);
 	r = r.grow(3);
 	easing_draw->get_theme_stylebox("normal", "LineEdit")->draw(ci, r);
@@ -1701,9 +1701,9 @@ void CustomPropertyEditor::config_action_buttons(const List<String> &p_strings) 
 	}
 
 	for (int i = 0; i < p_strings.size(); i++) {
-		Size2 btn_m_size = action_buttons[i]->get_size();
-		action_buttons[i]->set_position(Point2(0, height) + Point2(margin_left, margin_top));
-		action_buttons[i]->set_size(Size2(max_width, btn_m_size.height));
+		Size2 btn_m_size = action_buttons[i]->get_rect_size();
+		action_buttons[i]->set_rect_position(Point2(0, height) + Point2(margin_left, margin_top));
+		action_buttons[i]->set_rect_size(Size2(max_width, btn_m_size.height));
 
 		height += btn_m_size.height;
 	}
@@ -1771,7 +1771,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		value_label[i]->hide();
 		value_editor[i] = memnew(LineEdit);
 		value_hboxes[hbox_idx]->add_child(value_editor[i]);
-		value_editor[i]->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		value_editor[i]->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 		value_editor[i]->hide();
 		value_editor[i]->connect("text_entered", callable_mp(this, &CustomPropertyEditor::_modified));
 		value_editor[i]->connect("focus_entered", callable_mp(this, &CustomPropertyEditor::_focus_enter));
@@ -1795,7 +1795,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	for (int i = 0; i < 20; i++) {
 		if (i == 5 || i == 15) {
 			Control *space = memnew(Control);
-			space->set_custom_minimum_size(Size2(20, 0) * EDSCALE);
+			space->set_rect_minimum_size(Size2(20, 0) * EDSCALE);
 			checks20gc->add_child(space);
 		}
 
@@ -1853,7 +1853,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	easing_draw->hide();
 	easing_draw->connect("draw", callable_mp(this, &CustomPropertyEditor::_draw_easing));
 	easing_draw->connect("gui_input", callable_mp(this, &CustomPropertyEditor::_drag_easing));
-	easing_draw->set_default_cursor_shape(Control::CURSOR_MOVE);
+	easing_draw->set_mouse_default_cursor_shape(Control::CURSOR_MOVE);
 
 	type_button = memnew(MenuButton);
 	add_child(type_button);

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -55,7 +55,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	GridContainer *grd_main = memnew(GridContainer);
 	grd_main->set_columns(2);
-	grd_main->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	grd_main->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	vbc->add_child(grd_main);
 
 	// ---- 1st & 2nd row
@@ -65,14 +65,14 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	lne_search = memnew(LineEdit);
 	lne_search->set_name("lne_search");
-	lne_search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	lne_search->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	Label *lbl_replace = memnew(Label);
 	lbl_replace->set_text(TTR("Replace:"));
 
 	lne_replace = memnew(LineEdit);
 	lne_replace->set_name("lne_replace");
-	lne_replace->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	lne_replace->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	grd_main->add_child(lbl_search);
 	grd_main->add_child(lbl_replace);
@@ -86,14 +86,14 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	lne_prefix = memnew(LineEdit);
 	lne_prefix->set_name("lne_prefix");
-	lne_prefix->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	lne_prefix->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	Label *lbl_suffix = memnew(Label);
 	lbl_suffix->set_text(TTR("Suffix:"));
 
 	lne_suffix = memnew(LineEdit);
 	lne_suffix->set_name("lne_suffix");
-	lne_suffix->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	lne_suffix->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	grd_main->add_child(lbl_prefix);
 	grd_main->add_child(lbl_suffix);
@@ -118,7 +118,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	// ---- Tab Substitute
 
 	VBoxContainer *vbc_substitute = memnew(VBoxContainer);
-	vbc_substitute->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbc_substitute->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	vbc_substitute->set_name(TTR("Substitute"));
 	tabc_features->add_child(vbc_substitute);
@@ -138,7 +138,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_name->set_tooltip(String("${NAME}\n") + TTR("Node name."));
 	but_insert_name->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_name->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${NAME}"));
-	but_insert_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	but_insert_name->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_name);
 
 	// Parent
@@ -148,7 +148,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_parent->set_tooltip(String("${PARENT}\n") + TTR("Node's parent name, if available."));
 	but_insert_parent->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_parent->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${PARENT}"));
-	but_insert_parent->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	but_insert_parent->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_parent);
 
 	// Type
@@ -158,7 +158,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_type->set_tooltip(String("${TYPE}\n") + TTR("Node type."));
 	but_insert_type->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_type->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${TYPE}"));
-	but_insert_type->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	but_insert_type->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_type);
 
 	// Scene
@@ -168,7 +168,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_scene->set_tooltip(String("${SCENE}\n") + TTR("Current scene name."));
 	but_insert_scene->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_scene->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${SCENE}"));
-	but_insert_scene->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	but_insert_scene->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_scene);
 
 	// Root
@@ -178,7 +178,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_root->set_tooltip(String("${ROOT}\n") + TTR("Root node name."));
 	but_insert_root->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_root->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${ROOT}"));
-	but_insert_root->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	but_insert_root->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_root);
 
 	// Count
@@ -188,7 +188,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_count->set_tooltip(String("${COUNTER}\n") + TTR("Sequential integer counter.\nCompare counter options."));
 	but_insert_count->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_count->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${COUNTER}"));
-	but_insert_count->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	but_insert_count->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_count);
 
 	chk_per_level_counter = memnew(CheckBox);
@@ -233,7 +233,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	// ---- Tab Process
 
 	VBoxContainer *vbc_process = memnew(VBoxContainer);
-	vbc_process->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbc_process->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	vbc_process->set_name(TTR("Post-Process"));
 	tabc_features->add_child(vbc_process);
 
@@ -274,7 +274,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	// -- Preview
 
 	HSeparator *sep_preview = memnew(HSeparator);
-	sep_preview->set_custom_minimum_size(Size2(10, 20));
+	sep_preview->set_rect_minimum_size(Size2(10, 20));
 	vbc->add_child(sep_preview);
 
 	lbl_preview_title = memnew(Label);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1208,7 +1208,7 @@ void SceneTreeDock::_notification(int p_what) {
 			// create_root_dialog
 			HBoxContainer *top_row = memnew(HBoxContainer);
 			top_row->set_name("NodeShortcutsTopRow");
-			top_row->set_h_size_flags(SIZE_EXPAND_FILL);
+			top_row->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 			top_row->add_child(memnew(Label(TTR("Create Root Node:"))));
 			top_row->add_spacer();
 
@@ -1769,7 +1769,7 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 				editor_data->get_undo_redo().add_do_method(node, "set_global_transform", Object::cast_to<Node3D>(node)->get_global_transform());
 			}
 			if (Object::cast_to<Control>(node)) {
-				editor_data->get_undo_redo().add_do_method(node, "set_global_position", Object::cast_to<Control>(node)->get_global_position());
+				editor_data->get_undo_redo().add_do_method(node, "set_global_position", Object::cast_to<Control>(node)->get_rect_global_position());
 			}
 		}
 
@@ -1813,7 +1813,7 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 				editor_data->get_undo_redo().add_undo_method(node, "set_transform", Object::cast_to<Node3D>(node)->get_transform());
 			}
 			if (Object::cast_to<Control>(node)) {
-				editor_data->get_undo_redo().add_undo_method(node, "set_position", Object::cast_to<Control>(node)->get_position());
+				editor_data->get_undo_redo().add_undo_method(node, "set_position", Object::cast_to<Control>(node)->get_rect_position());
 			}
 		}
 	}
@@ -2109,9 +2109,9 @@ void SceneTreeDock::_do_create(Node *p_parent) {
 			ms.height = 40;
 		}
 		if (ct->is_layout_rtl()) {
-			ct->set_position(ct->get_position() - Vector2(ms.x, 0));
+			ct->set_rect_position(ct->get_rect_position() - Vector2(ms.x, 0));
 		}
-		ct->set_size(ms);
+		ct->set_rect_size(ms);
 	}
 
 	emit_signal("node_created", c);
@@ -3078,7 +3078,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	vbc->add_child(filter_hbc);
 	filter = memnew(LineEdit);
-	filter->set_h_size_flags(SIZE_EXPAND_FILL);
+	filter->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTR("Filter nodes"));
 	filter_hbc->add_child(filter);
 	filter->add_theme_constant_override("minimum_character_width", 0);
@@ -3106,7 +3106,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	edit_remote = memnew(Button);
 	edit_remote->set_flat(true);
 	button_hb->add_child(edit_remote);
-	edit_remote->set_h_size_flags(SIZE_EXPAND_FILL);
+	edit_remote->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	edit_remote->set_text(TTR("Remote"));
 	edit_remote->set_toggle_mode(true);
 	edit_remote->set_tooltip(TTR("If selected, the Remote scene tree dock will cause the project to stutter every time it updates.\nSwitch back to the Local scene tree dock to improve performance."));
@@ -3115,7 +3115,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	edit_local = memnew(Button);
 	edit_local->set_flat(true);
 	button_hb->add_child(edit_local);
-	edit_local->set_h_size_flags(SIZE_EXPAND_FILL);
+	edit_local->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	edit_local->set_text(TTR("Local"));
 	edit_local->set_toggle_mode(true);
 	edit_local->set_pressed(true);
@@ -3131,7 +3131,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	scene_tree = memnew(SceneTreeEditor(false, true, true));
 
 	vbc->add_child(scene_tree);
-	scene_tree->set_v_size_flags(SIZE_EXPAND | SIZE_FILL);
+	scene_tree->set_size_flags_vertical(SIZE_EXPAND | SIZE_FILL);
 	scene_tree->connect("rmb_pressed", callable_mp(this, &SceneTreeDock::_tree_rmb));
 
 	scene_tree->connect("node_selected", callable_mp(this, &SceneTreeDock::_node_selected), varray(), CONNECT_DEFERRED);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1161,7 +1161,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 
 	if (p_label) {
 		Label *label = memnew(Label);
-		label->set_position(Point2(10, 0));
+		label->set_rect_position(Point2(10, 0));
 		label->set_text(TTR("Scene Tree (Nodes):"));
 
 		add_child(label);
@@ -1270,14 +1270,14 @@ SceneTreeDialog::SceneTreeDialog() {
 	add_child(vbc);
 
 	filter = memnew(LineEdit);
-	filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	filter->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTR("Filter nodes"));
 	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect("text_changed", callable_mp(this, &SceneTreeDialog::_filter_changed));
 	vbc->add_child(filter);
 
 	tree = memnew(SceneTreeEditor(false, false, true));
-	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tree->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	tree->get_scene_tree()->connect("item_activated", callable_mp(this, &SceneTreeDialog::_select));
 	vbc->add_child(tree);
 }

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -783,13 +783,13 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	script_name_warning_label->hide();
 
 	status_panel = memnew(PanelContainer);
-	status_panel->set_h_size_flags(Control::SIZE_FILL);
+	status_panel->set_size_flags_horizontal(Control::SIZE_FILL);
 	status_panel->add_child(vb);
 
 	/* Spacing */
 
 	Control *spacing = memnew(Control);
-	spacing->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
+	spacing->set_rect_minimum_size(Size2(0, 10 * EDSCALE));
 
 	vb = memnew(VBoxContainer);
 	vb->add_child(gc);
@@ -803,8 +803,8 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Language */
 
 	language_menu = memnew(OptionButton);
-	language_menu->set_custom_minimum_size(Size2(250, 0) * EDSCALE);
-	language_menu->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	language_menu->set_rect_minimum_size(Size2(250, 0) * EDSCALE);
+	language_menu->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	gc->add_child(memnew(Label(TTR("Language:"))));
 	gc->add_child(language_menu);
 
@@ -828,10 +828,10 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	base_type = "Object";
 
 	hb = memnew(HBoxContainer);
-	hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	hb->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	parent_name = memnew(LineEdit);
 	parent_name->connect("text_changed", callable_mp(this, &ScriptCreateDialog::_parent_name_changed));
-	parent_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	parent_name->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	hb->add_child(parent_name);
 	parent_search_button = memnew(Button);
 	parent_search_button->set_flat(true);
@@ -849,7 +849,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	class_name = memnew(LineEdit);
 	class_name->connect("text_changed", callable_mp(this, &ScriptCreateDialog::_class_name_changed));
-	class_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	class_name->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	gc->add_child(memnew(Label(TTR("Class Name:"))));
 	gc->add_child(class_name);
 
@@ -874,7 +874,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	hb->connect("sort_children", callable_mp(this, &ScriptCreateDialog::_path_hbox_sorted));
 	file_path = memnew(LineEdit);
 	file_path->connect("text_changed", callable_mp(this, &ScriptCreateDialog::_path_changed));
-	file_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	file_path->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	hb->add_child(file_path);
 	path_button = memnew(Button);
 	path_button->set_flat(true);
@@ -899,7 +899,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	alert->get_label()->set_autowrap(true);
 	alert->get_label()->set_align(Label::ALIGN_CENTER);
 	alert->get_label()->set_valign(Label::VALIGN_CENTER);
-	alert->get_label()->set_custom_minimum_size(Size2(325, 60) * EDSCALE);
+	alert->get_label()->set_rect_minimum_size(Size2(325, 60) * EDSCALE);
 	add_child(alert);
 
 	set_hide_on_ok(false);

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -568,18 +568,18 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	tab_general->set_name(TTR("General"));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
-	hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	hbc->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	tab_general->add_child(hbc);
 
 	search_box = memnew(LineEdit);
 	search_box->set_placeholder(TTR("Search"));
-	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(search_box);
 
 	inspector = memnew(SectionedInspector);
 	inspector->get_inspector()->set_use_filter(true);
 	inspector->register_search_box(search_box);
-	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	inspector->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	inspector->get_inspector()->set_undo_redo(undo_redo);
 	tab_general->add_child(inspector);
 	inspector->get_inspector()->connect("property_edited", callable_mp(this, &EditorSettingsDialog::_settings_property_edited));
@@ -590,7 +590,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	HBoxContainer *restart_hb = memnew(HBoxContainer);
 	restart_container->add_child(restart_hb);
 	restart_icon = memnew(TextureRect);
-	restart_icon->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	restart_icon->set_size_flags_vertical(Control::SIZE_SHRINK_CENTER);
 	restart_hb->add_child(restart_icon);
 	restart_label = memnew(Label);
 	restart_label->set_text(TTR("The editor must be restarted for changes to take effect."));
@@ -615,12 +615,12 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	shortcut_search_box = memnew(LineEdit);
 	shortcut_search_box->set_placeholder(TTR("Search"));
-	shortcut_search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	shortcut_search_box->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	tab_shortcuts->add_child(shortcut_search_box);
 	shortcut_search_box->connect("text_changed", callable_mp(this, &EditorSettingsDialog::_filter_shortcuts));
 
 	shortcuts = memnew(Tree);
-	shortcuts->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	shortcuts->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	shortcuts->set_columns(2);
 	shortcuts->set_hide_root(true);
 	shortcuts->set_column_titles_visible(true);

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -454,12 +454,12 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 
 	add_menu_hb->add_child(memnew(Label(TTR("Name:"))));
 	variable_name = memnew(LineEdit);
-	variable_name->set_h_size_flags(SIZE_EXPAND_FILL);
+	variable_name->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	add_menu_hb->add_child(variable_name);
 
 	add_menu_hb->add_child(memnew(Label(TTR("Type:"))));
 	variable_type = memnew(OptionButton);
-	variable_type->set_h_size_flags(SIZE_EXPAND_FILL);
+	variable_type->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	add_menu_hb->add_child(variable_type);
 
 	for (int i = 0; i < RS::GLOBAL_VAR_TYPE_MAX; i++) {
@@ -471,7 +471,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 	variable_add->connect("pressed", callable_mp(this, &ShaderGlobalsEditor::_variable_added));
 
 	inspector = memnew(EditorInspector);
-	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
+	inspector->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	add_child(inspector);
 	inspector->set_use_wide_editors(true);
 	inspector->set_enable_capitalize_paths(false);

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -335,7 +335,7 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 	label->set_text(TTR("Platform:"));
 	hbox->add_child(label);
 	filter = memnew(MenuButton);
-	filter->set_h_size_flags(SIZE_EXPAND_FILL);
+	filter->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	filter->set_text_align(filter->ALIGN_LEFT);
 	hbox->add_child(filter);
 	PopupMenu *filter_list = filter->get_popup();
@@ -352,7 +352,7 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 
 	tree = memnew(Tree);
 	container->add_child(tree);
-	tree->set_v_size_flags(SIZE_EXPAND_FILL);
+	tree->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	tree->set_hide_root(true);
 	tree->set_column_titles_visible(true);
 	tree->set_columns(4);
@@ -380,7 +380,7 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 	new_architecture_dialog->set_title(TTR("Add an architecture entry"));
 	new_architecture_input = memnew(LineEdit);
 	new_architecture_dialog->add_child(new_architecture_input);
-	//	new_architecture_dialog->set_custom_minimum_size(Vector2(300, 80) * EDSCALE);
+	//	new_architecture_dialog->set_rect_minimum_size(Vector2(300, 80) * EDSCALE);
 	new_architecture_input->set_anchors_and_offsets_preset(PRESET_HCENTER_WIDE, PRESET_MODE_MINSIZE, 5 * EDSCALE);
 	new_architecture_dialog->get_ok_button()->connect("pressed", callable_mp(this, &GDNativeLibraryEditor::_on_create_new_entry));
 }
@@ -411,7 +411,7 @@ void GDNativeLibraryEditorPlugin::make_visible(bool p_visible) {
 
 GDNativeLibraryEditorPlugin::GDNativeLibraryEditorPlugin(EditorNode *p_node) {
 	library_editor = memnew(GDNativeLibraryEditor);
-	library_editor->set_custom_minimum_size(Size2(0, 250 * EDSCALE));
+	library_editor->set_rect_minimum_size(Size2(0, 250 * EDSCALE));
 	button = p_node->add_bottom_panel_item(TTR("GDNativeLibrary"), library_editor);
 	button->hide();
 }

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1157,11 +1157,11 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 
 	int mw = EDITOR_DEF("editors/grid_map/palette_min_width", 230);
 	Control *ec = memnew(Control);
-	ec->set_custom_minimum_size(Size2(mw, 0) * EDSCALE);
+	ec->set_rect_minimum_size(Size2(mw, 0) * EDSCALE);
 	add_child(ec);
 
 	spatial_editor_hb = memnew(HBoxContainer);
-	spatial_editor_hb->set_h_size_flags(SIZE_EXPAND_FILL);
+	spatial_editor_hb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	spatial_editor_hb->set_alignment(BoxContainer::ALIGN_END);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(spatial_editor_hb);
 
@@ -1224,7 +1224,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	settings_dialog->set_title(TTR("GridMap Settings"));
 	add_child(settings_dialog);
 	settings_vbc = memnew(VBoxContainer);
-	settings_vbc->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	settings_vbc->set_rect_minimum_size(Size2(200, 0) * EDSCALE);
 	settings_dialog->add_child(settings_vbc);
 
 	settings_pick_distance = memnew(SpinBox);
@@ -1238,10 +1238,10 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
-	hb->set_h_size_flags(SIZE_EXPAND_FILL);
+	hb->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	search_box = memnew(LineEdit);
-	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	search_box->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	search_box->set_placeholder(TTR("Filter meshes"));
 	hb->add_child(search_box);
 	search_box->connect("text_changed", callable_mp(this, &GridMapEditor::_text_changed));
@@ -1264,7 +1264,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	mode_list->connect("pressed", callable_mp(this, &GridMapEditor::_set_display_mode), varray(DISPLAY_LIST));
 
 	size_slider = memnew(HSlider);
-	size_slider->set_h_size_flags(SIZE_EXPAND_FILL);
+	size_slider->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	size_slider->set_min(0.2f);
 	size_slider->set_max(4.0f);
 	size_slider->set_step(0.1f);
@@ -1276,7 +1276,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 
 	mesh_library_palette = memnew(ItemList);
 	add_child(mesh_library_palette);
-	mesh_library_palette->set_v_size_flags(SIZE_EXPAND_FILL);
+	mesh_library_palette->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	mesh_library_palette->connect("gui_input", callable_mp(this, &GridMapEditor::_mesh_library_palette_input));
 
 	info_message = memnew(Label);
@@ -1284,7 +1284,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	info_message->set_valign(Label::VALIGN_CENTER);
 	info_message->set_align(Label::ALIGN_CENTER);
 	info_message->set_autowrap(true);
-	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	info_message->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_offsets_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	mesh_library_palette->add_child(info_message);
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -728,7 +728,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			Ref<VisualScriptComment> vsc = node;
 			gnode->set_comment(true);
 			gnode->set_resizable(true);
-			gnode->set_custom_minimum_size(vsc->get_size() * EDSCALE);
+			gnode->set_rect_minimum_size(vsc->get_size() * EDSCALE);
 			gnode->connect("resize_request", callable_mp(this, &VisualScriptEditor::_comment_node_resized), varray(E->get()));
 		}
 
@@ -841,7 +841,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					if (nd_list->is_input_port_name_editable()) {
 						LineEdit *name_box = memnew(LineEdit);
 						hbc->add_child(name_box);
-						name_box->set_custom_minimum_size(Size2(60 * EDSCALE, 0));
+						name_box->set_rect_minimum_size(Size2(60 * EDSCALE, 0));
 						name_box->set_text(left_name);
 						name_box->set_expand_to_text_length_enabled(true);
 						name_box->connect("resized", callable_mp(this, &VisualScriptEditor::_update_node_size), varray(E->get()));
@@ -856,7 +856,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							opbtn->add_item(Variant::get_type_name(Variant::Type(j)));
 						}
 						opbtn->select(left_type);
-						opbtn->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+						opbtn->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 						hbc->add_child(opbtn);
 						opbtn->connect("item_selected", callable_mp(this, &VisualScriptEditor::_change_port_type), varray(E->get(), i, true), CONNECT_DEFERRED);
 					}
@@ -882,7 +882,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					}
 
 					if (left_type == Variant::COLOR) {
-						button->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
+						button->set_rect_minimum_size(Size2(30, 0) * EDSCALE);
 						button->connect("draw", callable_mp(this, &VisualScriptEditor::_draw_color_over_button), varray(button, value));
 					} else if (left_type == Variant::OBJECT && Ref<Resource>(value).is_valid()) {
 						Ref<Resource> res = value;
@@ -901,7 +901,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				}
 			} else {
 				Control *c = memnew(Control);
-				c->set_custom_minimum_size(Size2(10, 0) * EDSCALE);
+				c->set_rect_minimum_size(Size2(10, 0) * EDSCALE);
 				hbc->add_child(c);
 			}
 
@@ -928,7 +928,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							opbtn->add_item(Variant::get_type_name(Variant::Type(j)));
 						}
 						opbtn->select(right_type);
-						opbtn->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+						opbtn->set_rect_minimum_size(Size2(100 * EDSCALE, 0));
 						hbc->add_child(opbtn);
 						opbtn->connect("item_selected", callable_mp(this, &VisualScriptEditor::_change_port_type), varray(E->get(), i, false), CONNECT_DEFERRED);
 					}
@@ -936,7 +936,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					if (nd_list->is_output_port_name_editable()) {
 						LineEdit *name_box = memnew(LineEdit);
 						hbc->add_child(name_box);
-						name_box->set_custom_minimum_size(Size2(60 * EDSCALE, 0));
+						name_box->set_rect_minimum_size(Size2(60 * EDSCALE, 0));
 						name_box->set_text(right_name);
 						name_box->set_expand_to_text_length_enabled(true);
 						name_box->connect("resized", callable_mp(this, &VisualScriptEditor::_update_node_size), varray(E->get()));
@@ -1009,7 +1009,7 @@ void VisualScriptEditor::_change_port_type(int p_select, int p_id, int p_port, b
 void VisualScriptEditor::_update_node_size(int p_id) {
 	Node *node = graph->get_node(itos(p_id));
 	if (Object::cast_to<Control>(node)) {
-		Object::cast_to<Control>(node)->set_size(Vector2(1, 1)); // Shrink if text is smaller.
+		Object::cast_to<Control>(node)->set_rect_size(Vector2(1, 1)); // Shrink if text is smaller.
 	}
 }
 
@@ -1348,19 +1348,19 @@ void VisualScriptEditor::_create_function() {
 }
 
 void VisualScriptEditor::_add_node_dialog() {
-	_generic_search(script->get_instance_base_type(), graph->get_global_position() + Vector2(55, 80), true);
+	_generic_search(script->get_instance_base_type(), graph->get_rect_global_position() + Vector2(55, 80), true);
 }
 
 void VisualScriptEditor::_add_func_input() {
 	HBoxContainer *hbox = memnew(HBoxContainer);
-	hbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	hbox->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	Label *name_label = memnew(Label);
 	name_label->set_text(TTR("Name:"));
 	hbox->add_child(name_label);
 
 	LineEdit *name_box = memnew(LineEdit);
-	name_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	name_box->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	name_box->set_text("input");
 	name_box->connect("focus_entered", callable_mp(this, &VisualScriptEditor::_deselect_input_names));
 	hbox->add_child(name_box);
@@ -1370,7 +1370,7 @@ void VisualScriptEditor::_add_func_input() {
 	hbox->add_child(type_label);
 
 	OptionButton *type_box = memnew(OptionButton);
-	type_box->set_custom_minimum_size(Size2(120 * EDSCALE, 0));
+	type_box->set_rect_minimum_size(Size2(120 * EDSCALE, 0));
 	for (int i = Variant::NIL; i < Variant::VARIANT_MAX; i++) {
 		type_box->add_item(Variant::get_type_name(Variant::Type(i)));
 	}
@@ -1627,7 +1627,7 @@ void VisualScriptEditor::_expression_text_changed(const String &p_text, int p_id
 
 	Node *node = graph->get_node(itos(p_id));
 	if (Object::cast_to<Control>(node)) {
-		Object::cast_to<Control>(node)->set_size(Vector2(1, 1)); // Shrink if text is smaller.
+		Object::cast_to<Control>(node)->set_rect_size(Vector2(1, 1)); // Shrink if text is smaller.
 	}
 
 	updating_graph = false;
@@ -1635,7 +1635,7 @@ void VisualScriptEditor::_expression_text_changed(const String &p_text, int p_id
 
 Vector2 VisualScriptEditor::_get_available_pos(bool centered, Vector2 ofs) const {
 	if (centered) {
-		ofs = graph->get_scroll_ofs() + graph->get_size() * 0.5;
+		ofs = graph->get_scroll_ofs() + graph->get_rect_size() * 0.5;
 	}
 
 	if (graph->is_using_snap()) {
@@ -1808,15 +1808,15 @@ void VisualScriptEditor::_on_nodes_duplicate() {
 
 void VisualScriptEditor::_generic_search(String p_base_type, Vector2 pos, bool node_centered) {
 	if (node_centered) {
-		port_action_pos = graph->get_size() / 2.0f;
+		port_action_pos = graph->get_rect_size() / 2.0f;
 	} else {
-		port_action_pos = graph->get_viewport()->get_mouse_position() - graph->get_global_position();
+		port_action_pos = graph->get_viewport()->get_mouse_position() - graph->get_rect_global_position();
 	}
 
 	new_connect_node_select->select_from_visual_script(p_base_type, false, false); // neither connecting nor reset text
 
 	// Ensure that the dialog fits inside the graph.
-	Size2 bounds = graph->get_global_position() + graph->get_size() - new_connect_node_select->get_size();
+	Size2 bounds = graph->get_rect_global_position() + graph->get_rect_size() - new_connect_node_select->get_size();
 	pos.x = pos.x > bounds.x ? bounds.x : pos.x;
 	pos.y = pos.y > bounds.y ? bounds.y : pos.y;
 
@@ -2461,7 +2461,7 @@ void VisualScriptEditor::_draw_color_over_button(Object *obj, Color p_color) {
 	}
 
 	Ref<StyleBox> normal = get_theme_stylebox("normal", "Button");
-	button->draw_rect(Rect2(normal->get_offset(), button->get_size() - normal->get_minimum_size()), p_color);
+	button->draw_rect(Rect2(normal->get_offset(), button->get_rect_size() - normal->get_minimum_size()), p_color);
 }
 
 void VisualScriptEditor::_button_resource_previewed(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, Variant p_ud) {
@@ -2594,7 +2594,7 @@ void VisualScriptEditor::_center_on_node(int p_id) {
 
 	if (gn) {
 		gn->set_selected(true);
-		Vector2 new_scroll = gn->get_position_offset() - graph->get_size() * 0.5 + gn->get_size() * 0.5;
+		Vector2 new_scroll = gn->get_position_offset() - graph->get_rect_size() * 0.5 + gn->get_rect_size() * 0.5;
 		graph->set_scroll_ofs(new_scroll);
 		script->set_scroll(new_scroll / EDSCALE);
 		script->set_edited(true);
@@ -3123,7 +3123,7 @@ void VisualScriptEditor::_port_action_menu(int p_option) {
 			}
 			// Ensure that the dialog fits inside the graph.
 			Vector2 pos = mouse_up_position;
-			Size2 bounds = graph->get_global_position() + graph->get_size() - new_connect_node_select->get_size();
+			Size2 bounds = graph->get_rect_global_position() + graph->get_rect_size() - new_connect_node_select->get_size();
 			pos.x = pos.x > bounds.x ? bounds.x : pos.x;
 			pos.y = pos.y > bounds.y ? bounds.y : pos.y;
 			new_connect_node_select->set_position(pos);
@@ -3147,7 +3147,7 @@ void VisualScriptEditor::_port_action_menu(int p_option) {
 			}
 			// Ensure that the dialog fits inside the graph.
 			Vector2 pos = mouse_up_position;
-			Size2 bounds = graph->get_global_position() + graph->get_size() - new_connect_node_select->get_size();
+			Size2 bounds = graph->get_rect_global_position() + graph->get_rect_size() - new_connect_node_select->get_size();
 			pos.x = pos.x > bounds.x ? bounds.x : pos.x;
 			pos.y = pos.y > bounds.y ? bounds.y : pos.y;
 			new_connect_node_select->set_position(pos);
@@ -3559,7 +3559,7 @@ void VisualScriptEditor::_default_value_edited(Node *p_button, int p_id, int p_i
 		Variant::construct(pinfo.type, existing, &existingp, 1, ce);
 	}
 
-	default_value_edit->set_position(Object::cast_to<Control>(p_button)->get_global_position() + Vector2(0, Object::cast_to<Control>(p_button)->get_size().y));
+	default_value_edit->set_position(Object::cast_to<Control>(p_button)->get_rect_global_position() + Vector2(0, Object::cast_to<Control>(p_button)->get_rect_size().y));
 	default_value_edit->set_size(Size2(1, 1));
 
 	if (pinfo.type == Variant::NODE_PATH) {
@@ -3706,8 +3706,8 @@ void VisualScriptEditor::_comment_node_resized(const Vector2 &p_new_size, int p_
 	undo_redo->add_undo_method(vsc.ptr(), "set_size", vsc->get_size());
 	undo_redo->commit_action();
 
-	gn->set_custom_minimum_size(new_size);
-	gn->set_size(Size2(1, 1));
+	gn->set_rect_minimum_size(new_size);
+	gn->set_rect_size(Size2(1, 1));
 	graph->set_block_minimum_size_adjust(false);
 	updating_graph = false;
 }
@@ -4111,10 +4111,10 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 	ERR_FAIL_COND(!ti);
 
 	member_popup->clear();
-	member_popup->set_position(members->get_global_position() + p_pos);
+	member_popup->set_position(members->get_rect_global_position() + p_pos);
 	member_popup->set_size(Vector2());
 
-	function_name_edit->set_position(members->get_global_position() + p_pos);
+	function_name_edit->set_position(members->get_rect_global_position() + p_pos);
 	function_name_edit->set_size(Vector2());
 
 	TreeItem *root = members->get_root();
@@ -4291,7 +4291,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	members_section = memnew(VBoxContainer);
 	// Add but wait until done setting up this.
 	ScriptEditor::get_singleton()->get_left_list_split()->call_deferred("add_child", members_section);
-	members_section->set_v_size_flags(SIZE_EXPAND_FILL);
+	members_section->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	CheckButton *tool_script_check = memnew(CheckButton);
 	tool_script_check->set_text(TTR("Make Tool:"));
@@ -4302,7 +4302,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	members = memnew(Tree);
 	members_section->add_margin_child(TTR("Members:"), members, true);
-	members->set_custom_minimum_size(Size2(0, 50 * EDSCALE));
+	members->set_rect_minimum_size(Size2(0, 50 * EDSCALE));
 	members->set_hide_root(true);
 	members->connect("button_pressed", callable_mp(this, &VisualScriptEditor::_member_button));
 	members->connect("item_edited", callable_mp(this, &VisualScriptEditor::_member_edited));
@@ -4329,7 +4329,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	graph = memnew(GraphEdit);
 	add_child(graph);
-	graph->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	graph->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	graph->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	graph->connect("node_selected", callable_mp(this, &VisualScriptEditor::_node_selected));
 	graph->connect("begin_node_move", callable_mp(this, &VisualScriptEditor::_begin_node_move));
@@ -4366,8 +4366,8 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	// Add Function Dialog.
 	VBoxContainer *function_vb = memnew(VBoxContainer);
-	function_vb->set_v_size_flags(SIZE_EXPAND_FILL);
-	function_vb->set_custom_minimum_size(Size2(450, 300) * EDSCALE);
+	function_vb->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	function_vb->set_rect_minimum_size(Size2(450, 300) * EDSCALE);
 
 	HBoxContainer *func_name_hbox = memnew(HBoxContainer);
 	function_vb->add_child(func_name_hbox);
@@ -4377,7 +4377,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	func_name_hbox->add_child(func_name_label);
 
 	func_name_box = memnew(LineEdit);
-	func_name_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	func_name_box->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	func_name_box->set_placeholder(TTR("function_name"));
 	func_name_box->set_text("");
 	func_name_box->connect("focus_entered", callable_mp(this, &VisualScriptEditor::_deselect_input_names));
@@ -4388,17 +4388,17 @@ VisualScriptEditor::VisualScriptEditor() {
 	function_vb->add_child(memnew(HSeparator));
 
 	Button *add_input_button = memnew(Button);
-	add_input_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	add_input_button->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	add_input_button->set_text(TTR("Add Input"));
 	add_input_button->connect("pressed", callable_mp(this, &VisualScriptEditor::_add_func_input));
 	function_vb->add_child(add_input_button);
 
 	func_input_scroll = memnew(ScrollContainer);
-	func_input_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	func_input_scroll->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	function_vb->add_child(func_input_scroll);
 
 	func_input_vbox = memnew(VBoxContainer);
-	func_input_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	func_input_vbox->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	func_input_scroll->add_child(func_input_vbox);
 
 	function_create_dialog = memnew(ConfirmationDialog);
@@ -4412,7 +4412,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	select_func_text->set_text(TTR("Select or create a function to edit its graph."));
 	select_func_text->set_align(Label::ALIGN_CENTER);
 	select_func_text->set_valign(Label::VALIGN_CENTER);
-	select_func_text->set_h_size_flags(SIZE_EXPAND_FILL);
+	select_func_text->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	add_child(select_func_text);
 
 	hint_text = memnew(Label);

--- a/scene/gui/aspect_ratio_container.cpp
+++ b/scene/gui/aspect_ratio_container.cpp
@@ -74,7 +74,7 @@ void AspectRatioContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
 			bool rtl = is_layout_rtl();
-			Size2 size = get_size();
+			Size2 size = get_rect_size();
 			for (int i = 0; i < get_child_count(); i++) {
 				Control *c = Object::cast_to<Control>(get_child(i));
 				if (!c) {

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -41,7 +41,7 @@ struct _MinSizeCache {
 void BoxContainer::_resort() {
 	/** First pass, determine minimum size AND amount of stretchable elements */
 
-	Size2i new_size = get_size();
+	Size2i new_size = get_rect_size();
 
 	int sep = get_theme_constant("separation"); //,vertical?"VBoxContainer":"HBoxContainer");
 	bool rtl = is_layout_rtl();
@@ -68,17 +68,17 @@ void BoxContainer::_resort() {
 		if (vertical) { /* VERTICAL */
 			stretch_min += size.height;
 			msc.min_size = size.height;
-			msc.will_stretch = c->get_v_size_flags() & SIZE_EXPAND;
+			msc.will_stretch = c->get_size_flags_vertical() & SIZE_EXPAND;
 
 		} else { /* HORIZONTAL */
 			stretch_min += size.width;
 			msc.min_size = size.width;
-			msc.will_stretch = c->get_h_size_flags() & SIZE_EXPAND;
+			msc.will_stretch = c->get_size_flags_horizontal() & SIZE_EXPAND;
 		}
 
 		if (msc.will_stretch) {
 			stretch_avail += msc.min_size;
-			stretch_ratio_total += c->get_stretch_ratio();
+			stretch_ratio_total += c->get_size_flags_stretch_ratio();
 		}
 		msc.final_size = msc.min_size;
 		min_size_cache[c] = msc;
@@ -121,14 +121,14 @@ void BoxContainer::_resort() {
 
 			if (msc.will_stretch) { //wants to stretch
 				//let's see if it can really stretch
-				float final_pixel_size = stretch_avail * c->get_stretch_ratio() / stretch_ratio_total;
+				float final_pixel_size = stretch_avail * c->get_size_flags_stretch_ratio() / stretch_ratio_total;
 				// Add leftover fractional pixels to error accumulator
 				error += final_pixel_size - (int)final_pixel_size;
 				if (final_pixel_size < msc.min_size) {
 					//if available stretching area is too small for widget,
 					//then remove it from stretching area
 					msc.will_stretch = false;
-					stretch_ratio_total -= c->get_stretch_ratio();
+					stretch_ratio_total -= c->get_size_flags_stretch_ratio();
 					refit_successful = false;
 					stretch_avail -= msc.min_size;
 					msc.final_size = msc.min_size;
@@ -318,9 +318,9 @@ Control *BoxContainer::add_spacer(bool p_begin) {
 	c->set_mouse_filter(MOUSE_FILTER_PASS); //allow spacer to pass mouse events
 
 	if (vertical) {
-		c->set_v_size_flags(SIZE_EXPAND_FILL);
+		c->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	} else {
-		c->set_h_size_flags(SIZE_EXPAND_FILL);
+		c->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	}
 
 	add_child(c);
@@ -356,7 +356,7 @@ MarginContainer *VBoxContainer::add_margin_child(const String &p_label, Control 
 	mc->add_child(p_control);
 	add_child(mc);
 	if (p_expand) {
-		mc->set_v_size_flags(SIZE_EXPAND_FILL);
+		mc->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	}
 
 	return mc;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -88,7 +88,7 @@ void Button::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
-			Size2 size = get_size();
+			Size2 size = get_rect_size();
 			Color color;
 			Color color_icon(1, 1, 1, 1);
 
@@ -220,7 +220,7 @@ void Button::_notification(int p_what) {
 				}
 
 				if (expand_icon) {
-					Size2 _size = get_size() - style->get_offset() * 2;
+					Size2 _size = get_rect_size() - style->get_offset() * 2;
 					_size.width -= get_theme_constant("hseparation") + icon_ofs_region;
 					if (!clip_text) {
 						_size.width -= text_buf->get_size().width;

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -71,7 +71,7 @@ bool CenterContainer::is_using_top_left() const {
 
 void CenterContainer::_notification(int p_what) {
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 		for (int i = 0; i < get_child_count(); i++) {
 			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c) {

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -87,11 +87,11 @@ void CheckBox::_notification(int p_what) {
 
 		Vector2 ofs;
 		if (is_layout_rtl()) {
-			ofs.x = get_size().x - sb->get_margin(SIDE_RIGHT) - get_icon_size().width;
+			ofs.x = get_rect_size().x - sb->get_margin(SIDE_RIGHT) - get_icon_size().width;
 		} else {
 			ofs.x = sb->get_margin(SIDE_LEFT);
 		}
-		ofs.y = int((get_size().height - get_icon_size().height) / 2) + get_theme_constant("check_vadjust");
+		ofs.y = int((get_rect_size().height - get_icon_size().height) / 2) + get_theme_constant("check_vadjust");
 
 		if (is_pressed()) {
 			on->draw(ci, ofs);

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -93,9 +93,9 @@ void CheckButton::_notification(int p_what) {
 		if (rtl) {
 			ofs.x = sb->get_margin(SIDE_LEFT);
 		} else {
-			ofs.x = get_size().width - (tex_size.width + sb->get_margin(SIDE_RIGHT));
+			ofs.x = get_rect_size().width - (tex_size.width + sb->get_margin(SIDE_RIGHT));
 		}
-		ofs.y = (get_size().height - tex_size.height) / 2 + get_theme_constant("check_vadjust");
+		ofs.y = (get_rect_size().height - tex_size.height) / 2 + get_theme_constant("check_vadjust");
 
 		if (is_pressed()) {
 			on->draw(ci, ofs);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -301,10 +301,10 @@ void ColorPicker::_update_presets() {
 	//presets should be shown using buttons or something else, this method is not a good idea
 
 	presets_per_row = 10;
-	Size2 size = bt_add_preset->get_size();
+	Size2 size = bt_add_preset->get_rect_size();
 	Size2 preset_size = Size2(MIN(size.width * presets.size(), presets_per_row * size.width), size.height * (Math::ceil((float)presets.size() / presets_per_row)));
-	preset->set_custom_minimum_size(preset_size);
-	preset_container->set_custom_minimum_size(preset_size);
+	preset->set_rect_minimum_size(preset_size);
+	preset_container->set_rect_minimum_size(preset_size);
 	preset->draw_rect(Rect2(Point2(), preset_size), Color(1, 1, 1, 0));
 
 	for (int i = 0; i < presets.size(); i++) {
@@ -459,7 +459,7 @@ void ColorPicker::_update_text_value() {
 }
 
 void ColorPicker::_sample_draw() {
-	const Rect2 r = Rect2(Point2(), Size2(sample->get_size().width, sample->get_size().height * 0.95));
+	const Rect2 r = Rect2(Point2(), Size2(sample->get_rect_size().width, sample->get_rect_size().height * 0.95));
 
 	if (color.a < 1.0) {
 		sample->draw_texture_rect(get_theme_icon("preset_bg", "ColorPicker"), r, true);
@@ -482,15 +482,15 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 		Vector<Color> colors;
 		Vector<Color> colors2;
 		Color col = color;
-		Vector2 center = c->get_size() / 2.0;
+		Vector2 center = c->get_rect_size() / 2.0;
 
 		switch (picker_type) {
 			case SHAPE_HSV_WHEEL: {
 				points.resize(4);
 				colors.resize(4);
 				colors2.resize(4);
-				real_t ring_radius_x = Math_SQRT12 * c->get_size().width * 0.42;
-				real_t ring_radius_y = Math_SQRT12 * c->get_size().height * 0.42;
+				real_t ring_radius_x = Math_SQRT12 * c->get_rect_size().width * 0.42;
+				real_t ring_radius_y = Math_SQRT12 * c->get_rect_size().height * 0.42;
 
 				points.set(0, center - Vector2(ring_radius_x, ring_radius_y));
 				points.set(1, center + Vector2(ring_radius_x, -ring_radius_y));
@@ -519,9 +519,9 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 				colors.resize(4);
 				colors2.resize(4);
 				points.set(0, Vector2());
-				points.set(1, Vector2(c->get_size().x, 0));
-				points.set(2, c->get_size());
-				points.set(3, Vector2(0, c->get_size().y));
+				points.set(1, Vector2(c->get_rect_size().x, 0));
+				points.set(2, c->get_rect_size());
+				points.set(3, Vector2(0, c->get_rect_size().y));
 				colors.set(0, Color(1, 1, 1, 1));
 				colors.set(1, Color(1, 1, 1, 1));
 				colors.set(2, Color(0, 0, 0, 1));
@@ -550,10 +550,10 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 			x = center.x + (center.x * Math::cos(h * Math_TAU) * s) - (cursor->get_width() / 2);
 			y = center.y + (center.y * Math::sin(h * Math_TAU) * s) - (cursor->get_height() / 2);
 		} else {
-			real_t corner_x = (c == wheel_uv) ? center.x - Math_SQRT12 * c->get_size().width * 0.42 : 0;
-			real_t corner_y = (c == wheel_uv) ? center.y - Math_SQRT12 * c->get_size().height * 0.42 : 0;
+			real_t corner_x = (c == wheel_uv) ? center.x - Math_SQRT12 * c->get_rect_size().width * 0.42 : 0;
+			real_t corner_y = (c == wheel_uv) ? center.y - Math_SQRT12 * c->get_rect_size().height * 0.42 : 0;
 
-			Size2 real_size(c->get_size().x - corner_x * 2, c->get_size().y - corner_y * 2);
+			Size2 real_size(c->get_rect_size().x - corner_x * 2, c->get_rect_size().y - corner_y * 2);
 			x = CLAMP(real_size.x * s, 0, real_size.x) + corner_x - (cursor->get_width() / 2);
 			y = CLAMP(real_size.y - real_size.y * v, 0, real_size.y) + corner_y - (cursor->get_height() / 2);
 		}
@@ -574,11 +574,11 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 	} else if (p_which == 1) {
 		if (picker_type == SHAPE_HSV_RECTANGLE) {
 			Ref<Texture2D> hue = get_theme_icon("color_hue", "ColorPicker");
-			c->draw_texture_rect(hue, Rect2(Point2(), c->get_size()));
-			int y = c->get_size().y - c->get_size().y * (1.0 - h);
+			c->draw_texture_rect(hue, Rect2(Point2(), c->get_rect_size()));
+			int y = c->get_rect_size().y - c->get_rect_size().y * (1.0 - h);
 			Color col;
 			col.set_hsv(h, 1, 1);
-			c->draw_line(Point2(0, y), Point2(c->get_size().x, y), col.inverted());
+			c->draw_line(Point2(0, y), Point2(c->get_rect_size().x, y), col.inverted());
 		} else if (picker_type == SHAPE_VHS_CIRCLE) {
 			Vector<Point2> points;
 			Vector<Color> colors;
@@ -587,20 +587,20 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 			points.resize(4);
 			colors.resize(4);
 			points.set(0, Vector2());
-			points.set(1, Vector2(c->get_size().x, 0));
-			points.set(2, c->get_size());
-			points.set(3, Vector2(0, c->get_size().y));
+			points.set(1, Vector2(c->get_rect_size().x, 0));
+			points.set(2, c->get_rect_size());
+			points.set(3, Vector2(0, c->get_rect_size().y));
 			colors.set(0, col);
 			colors.set(1, col);
 			colors.set(2, Color(0, 0, 0));
 			colors.set(3, Color(0, 0, 0));
 			c->draw_polygon(points, colors);
-			int y = c->get_size().y - c->get_size().y * CLAMP(v, 0, 1);
+			int y = c->get_rect_size().y - c->get_rect_size().y * CLAMP(v, 0, 1);
 			col.set_hsv(h, 1, v);
-			c->draw_line(Point2(0, y), Point2(c->get_size().x, y), col.inverted());
+			c->draw_line(Point2(0, y), Point2(c->get_rect_size().x, y), col.inverted());
 		}
 	} else if (p_which == 2) {
-		c->draw_rect(Rect2(Point2(), c->get_size()), Color(1, 1, 1));
+		c->draw_rect(Rect2(Point2(), c->get_rect_size()), Color(1, 1, 1));
 		if (picker_type == SHAPE_VHS_CIRCLE) {
 			circle_mat->set_shader_param("v", v);
 		}
@@ -612,7 +612,7 @@ void ColorPicker::_slider_draw(int p_which) {
 	pos.resize(4);
 	Vector<Color> col;
 	col.resize(4);
-	Size2 size = scroll[p_which]->get_size();
+	Size2 size = scroll[p_which]->get_rect_size();
 	Color left_color;
 	Color right_color;
 #ifdef TOOLS_ENABLED
@@ -636,7 +636,7 @@ void ColorPicker::_slider_draw(int p_which) {
 			if (p_which == 0) {
 				Ref<Texture2D> hue = get_theme_icon("color_hue", "ColorPicker");
 				scroll[p_which]->draw_set_transform(Point2(), -Math_PI / 2, Size2(1.0, 1.0));
-				scroll[p_which]->draw_texture_rect(hue, Rect2(Vector2(margin * -2, 0), Vector2(scroll[p_which]->get_size().x, margin)), false, Color(1, 1, 1), true);
+				scroll[p_which]->draw_texture_rect(hue, Rect2(Vector2(margin * -2, 0), Vector2(scroll[p_which]->get_rect_size().x, margin)), false, Color(1, 1, 1), true);
 				return;
 			}
 			Color s_col;
@@ -675,7 +675,7 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 
 	if (bev.is_valid()) {
 		if (bev->is_pressed() && bev->get_button_index() == MOUSE_BUTTON_LEFT) {
-			Vector2 center = c->get_size() / 2.0;
+			Vector2 center = c->get_rect_size() / 2.0;
 			if (picker_type == SHAPE_VHS_CIRCLE) {
 				real_t dist = center.distance_to(bev->get_position());
 
@@ -687,12 +687,12 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 					return;
 				}
 			} else {
-				real_t corner_x = (c == wheel_uv) ? center.x - Math_SQRT12 * c->get_size().width * 0.42 : 0;
-				real_t corner_y = (c == wheel_uv) ? center.y - Math_SQRT12 * c->get_size().height * 0.42 : 0;
-				Size2 real_size(c->get_size().x - corner_x * 2, c->get_size().y - corner_y * 2);
+				real_t corner_x = (c == wheel_uv) ? center.x - Math_SQRT12 * c->get_rect_size().width * 0.42 : 0;
+				real_t corner_y = (c == wheel_uv) ? center.y - Math_SQRT12 * c->get_rect_size().height * 0.42 : 0;
+				Size2 real_size(c->get_rect_size().x - corner_x * 2, c->get_rect_size().y - corner_y * 2);
 
-				if (bev->get_position().x < corner_x || bev->get_position().x > c->get_size().x - corner_x ||
-						bev->get_position().y < corner_y || bev->get_position().y > c->get_size().y - corner_y) {
+				if (bev->get_position().x < corner_x || bev->get_position().x > c->get_rect_size().x - corner_x ||
+						bev->get_position().y < corner_y || bev->get_position().y > c->get_rect_size().y - corner_y) {
 					{
 						real_t dist = center.distance_to(bev->get_position());
 
@@ -707,11 +707,11 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 				}
 
 				if (!spinning) {
-					real_t x = CLAMP(bev->get_position().x, corner_x, c->get_size().x - corner_x);
-					real_t y = CLAMP(bev->get_position().y, corner_x, c->get_size().y - corner_y);
+					real_t x = CLAMP(bev->get_position().x, corner_x, c->get_rect_size().x - corner_x);
+					real_t y = CLAMP(bev->get_position().y, corner_x, c->get_rect_size().y - corner_y);
 
-					s = (x - c->get_position().x - corner_x) / real_size.x;
-					v = 1.0 - (y - c->get_position().y - corner_y) / real_size.y;
+					s = (x - c->get_rect_position().x - corner_x) / real_size.x;
+					v = 1.0 - (y - c->get_rect_position().y - corner_y) / real_size.y;
 				}
 			}
 			changing_color = true;
@@ -739,7 +739,7 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 			return;
 		}
 
-		Vector2 center = c->get_size() / 2.0;
+		Vector2 center = c->get_rect_size() / 2.0;
 		if (picker_type == SHAPE_VHS_CIRCLE) {
 			real_t dist = center.distance_to(mev->get_position());
 			real_t rad = Math::atan2(mev->get_position().y - center.y, mev->get_position().x - center.x);
@@ -750,12 +750,12 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 				real_t rad = Math::atan2(mev->get_position().y - center.y, mev->get_position().x - center.x);
 				h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
 			} else {
-				real_t corner_x = (c == wheel_uv) ? center.x - Math_SQRT12 * c->get_size().width * 0.42 : 0;
-				real_t corner_y = (c == wheel_uv) ? center.y - Math_SQRT12 * c->get_size().height * 0.42 : 0;
-				Size2 real_size(c->get_size().x - corner_x * 2, c->get_size().y - corner_y * 2);
+				real_t corner_x = (c == wheel_uv) ? center.x - Math_SQRT12 * c->get_rect_size().width * 0.42 : 0;
+				real_t corner_y = (c == wheel_uv) ? center.y - Math_SQRT12 * c->get_rect_size().height * 0.42 : 0;
+				Size2 real_size(c->get_rect_size().x - corner_x * 2, c->get_rect_size().y - corner_y * 2);
 
-				real_t x = CLAMP(mev->get_position().x, corner_x, c->get_size().x - corner_x);
-				real_t y = CLAMP(mev->get_position().y, corner_x, c->get_size().y - corner_y);
+				real_t x = CLAMP(mev->get_position().x, corner_x, c->get_rect_size().x - corner_x);
+				real_t y = CLAMP(mev->get_position().y, corner_x, c->get_rect_size().y - corner_y);
 
 				s = (x - corner_x) / real_size.x;
 				v = 1.0 - (y - corner_y) / real_size.y;
@@ -778,11 +778,11 @@ void ColorPicker::_w_input(const Ref<InputEvent> &p_event) {
 	if (bev.is_valid()) {
 		if (bev->is_pressed() && bev->get_button_index() == MOUSE_BUTTON_LEFT) {
 			changing_color = true;
-			float y = CLAMP((float)bev->get_position().y, 0, w_edit->get_size().height);
+			float y = CLAMP((float)bev->get_position().y, 0, w_edit->get_rect_size().height);
 			if (picker_type == SHAPE_VHS_CIRCLE) {
-				v = 1.0 - (y / w_edit->get_size().height);
+				v = 1.0 - (y / w_edit->get_rect_size().height);
 			} else {
-				h = y / w_edit->get_size().height;
+				h = y / w_edit->get_rect_size().height;
 			}
 		} else {
 			changing_color = false;
@@ -804,11 +804,11 @@ void ColorPicker::_w_input(const Ref<InputEvent> &p_event) {
 		if (!changing_color) {
 			return;
 		}
-		float y = CLAMP((float)mev->get_position().y, 0, w_edit->get_size().height);
+		float y = CLAMP((float)mev->get_position().y, 0, w_edit->get_rect_size().height);
 		if (picker_type == SHAPE_VHS_CIRCLE) {
-			v = 1.0 - (y / w_edit->get_size().height);
+			v = 1.0 - (y / w_edit->get_rect_size().height);
 		} else {
-			h = y / w_edit->get_size().height;
+			h = y / w_edit->get_rect_size().height;
 		}
 		color.set_hsv(h, s, v, color.a);
 		last_hsv = color;
@@ -827,9 +827,9 @@ void ColorPicker::_preset_input(const Ref<InputEvent> &p_event) {
 		int index = 0;
 		if (bev->is_pressed() && bev->get_button_index() == MOUSE_BUTTON_LEFT) {
 			for (int i = 0; i < presets.size(); i++) {
-				int x = (i % presets_per_row) * bt_add_preset->get_size().x;
-				int y = (Math::floor((float)i / presets_per_row)) * bt_add_preset->get_size().y;
-				if (bev->get_position().x > x && bev->get_position().x < x + preset->get_size().x && bev->get_position().y > y && bev->get_position().y < y + preset->get_size().y) {
+				int x = (i % presets_per_row) * bt_add_preset->get_rect_size().x;
+				int y = (Math::floor((float)i / presets_per_row)) * bt_add_preset->get_rect_size().y;
+				if (bev->get_position().x > x && bev->get_position().x < x + preset->get_rect_size().x && bev->get_position().y > y && bev->get_position().y < y + preset->get_rect_size().y) {
 					index = i;
 				}
 			}
@@ -837,7 +837,7 @@ void ColorPicker::_preset_input(const Ref<InputEvent> &p_event) {
 			_update_color();
 			emit_signal("color_changed", color);
 		} else if (bev->is_pressed() && bev->get_button_index() == MOUSE_BUTTON_RIGHT && presets_enabled) {
-			index = bev->get_position().x / (preset->get_size().x / presets.size());
+			index = bev->get_position().x / (preset->get_rect_size().x / presets.size());
 			Color clicked_preset = presets[index];
 			erase_preset(clicked_preset);
 			emit_signal("preset_removed", clicked_preset);
@@ -849,8 +849,8 @@ void ColorPicker::_preset_input(const Ref<InputEvent> &p_event) {
 
 	if (mev.is_valid()) {
 		int index = mev->get_position().x * presets.size();
-		if (preset->get_size().x != 0) {
-			index /= preset->get_size().x;
+		if (preset->get_rect_size().x != 0) {
+			index /= preset->get_rect_size().x;
 		}
 		if (index < 0 || index >= presets.size()) {
 			return;
@@ -903,7 +903,7 @@ void ColorPicker::_screen_pick_pressed() {
 		r->add_child(screen);
 		screen->set_as_top_level(true);
 		screen->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-		screen->set_default_cursor_shape(CURSOR_POINTING_HAND);
+		screen->set_mouse_default_cursor_shape(CURSOR_POINTING_HAND);
 		screen->connect("gui_input", callable_mp(this, &ColorPicker::_screen_input));
 		// It immediately toggles off in the first press otherwise.
 		screen->call_deferred("connect", "hidden", Callable(btn_pick, "set_pressed"), varray(false));
@@ -1018,21 +1018,21 @@ ColorPicker::ColorPicker() :
 		BoxContainer(true) {
 	HBoxContainer *hb_edit = memnew(HBoxContainer);
 	add_child(hb_edit);
-	hb_edit->set_v_size_flags(SIZE_EXPAND_FILL);
+	hb_edit->set_size_flags_vertical(SIZE_EXPAND_FILL);
 
 	hb_edit->add_child(uv_edit);
 	uv_edit->connect("gui_input", callable_mp(this, &ColorPicker::_uv_input), make_binds(uv_edit));
 	uv_edit->set_mouse_filter(MOUSE_FILTER_PASS);
-	uv_edit->set_h_size_flags(SIZE_EXPAND_FILL);
-	uv_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	uv_edit->set_custom_minimum_size(Size2(get_theme_constant("sv_width"), get_theme_constant("sv_height")));
+	uv_edit->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	uv_edit->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	uv_edit->set_rect_minimum_size(Size2(get_theme_constant("sv_width"), get_theme_constant("sv_height")));
 	uv_edit->connect("draw", callable_mp(this, &ColorPicker::_hsv_draw), make_binds(0, uv_edit));
 
 	HBoxContainer *hb_smpl = memnew(HBoxContainer);
 	add_child(hb_smpl);
 
 	hb_smpl->add_child(sample);
-	sample->set_h_size_flags(SIZE_EXPAND_FILL);
+	sample->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	sample->connect("draw", callable_mp(this, &ColorPicker::_sample_draw));
 
 	btn_pick->set_flat(true);
@@ -1048,18 +1048,18 @@ ColorPicker::ColorPicker() :
 
 	VBoxContainer *vbr = memnew(VBoxContainer);
 	add_child(vbr);
-	vbr->set_h_size_flags(SIZE_EXPAND_FILL);
+	vbr->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 	for (int i = 0; i < 4; i++) {
 		HBoxContainer *hbc = memnew(HBoxContainer);
 
 		labels[i] = memnew(Label());
-		labels[i]->set_custom_minimum_size(Size2(get_theme_constant("label_width"), 0));
-		labels[i]->set_v_size_flags(SIZE_SHRINK_CENTER);
+		labels[i]->set_rect_minimum_size(Size2(get_theme_constant("label_width"), 0));
+		labels[i]->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 		hbc->add_child(labels[i]);
 
 		scroll[i] = memnew(HSlider);
-		scroll[i]->set_v_size_flags(SIZE_SHRINK_CENTER);
+		scroll[i]->set_size_flags_vertical(SIZE_SHRINK_CENTER);
 		scroll[i]->set_focus_mode(FOCUS_NONE);
 		hbc->add_child(scroll[i]);
 
@@ -1071,7 +1071,7 @@ ColorPicker::ColorPicker() :
 
 		scroll[i]->set_min(0);
 		scroll[i]->set_page(0);
-		scroll[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		scroll[i]->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 
 		scroll[i]->connect("value_changed", callable_mp(this, &ColorPicker::_value_changed));
 		scroll[i]->connect("draw", callable_mp(this, &ColorPicker::_slider_draw), make_binds(i));
@@ -1097,7 +1097,7 @@ ColorPicker::ColorPicker() :
 	text_type->set_tooltip(TTR("Switch between hexadecimal and code values."));
 	if (Engine::get_singleton()->is_editor_hint()) {
 #ifdef TOOLS_ENABLED
-		text_type->set_custom_minimum_size(Size2(28 * EDSCALE, 0)); // Adjust for the width of the "Script" icon.
+		text_type->set_rect_minimum_size(Size2(28 * EDSCALE, 0)); // Adjust for the width of the "Script" icon.
 #endif
 		text_type->connect("pressed", callable_mp(this, &ColorPicker::_text_type_toggled));
 	} else {
@@ -1106,14 +1106,14 @@ ColorPicker::ColorPicker() :
 	}
 
 	hhb->add_child(c_text);
-	c_text->set_h_size_flags(SIZE_EXPAND_FILL);
+	c_text->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	c_text->connect("text_entered", callable_mp(this, &ColorPicker::_html_entered));
 	c_text->connect("focus_entered", callable_mp(this, &ColorPicker::_focus_enter));
 	c_text->connect("focus_exited", callable_mp(this, &ColorPicker::_html_focus_exit));
 
-	wheel_edit->set_h_size_flags(SIZE_EXPAND_FILL);
-	wheel_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	wheel_edit->set_custom_minimum_size(Size2(get_theme_constant("sv_width"), get_theme_constant("sv_height")));
+	wheel_edit->set_size_flags_horizontal(SIZE_EXPAND_FILL);
+	wheel_edit->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	wheel_edit->set_rect_minimum_size(Size2(get_theme_constant("sv_width"), get_theme_constant("sv_height")));
 	hb_edit->add_child(wheel_edit);
 
 	wheel_mat.instance();
@@ -1144,9 +1144,9 @@ ColorPicker::ColorPicker() :
 	wheel_uv->connect("draw", callable_mp(this, &ColorPicker::_hsv_draw), make_binds(0, wheel_uv));
 
 	hb_edit->add_child(w_edit);
-	w_edit->set_custom_minimum_size(Size2(get_theme_constant("h_width"), 0));
-	w_edit->set_h_size_flags(SIZE_FILL);
-	w_edit->set_v_size_flags(SIZE_EXPAND_FILL);
+	w_edit->set_rect_minimum_size(Size2(get_theme_constant("h_width"), 0));
+	w_edit->set_size_flags_horizontal(SIZE_FILL);
+	w_edit->set_size_flags_vertical(SIZE_EXPAND_FILL);
 	w_edit->connect("gui_input", callable_mp(this, &ColorPicker::_w_input));
 	w_edit->connect("draw", callable_mp(this, &ColorPicker::_hsv_draw), make_binds(1, w_edit));
 
@@ -1158,14 +1158,14 @@ ColorPicker::ColorPicker() :
 
 	add_child(preset_separator);
 
-	preset_container->set_h_size_flags(SIZE_EXPAND_FILL);
+	preset_container->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	add_child(preset_container);
 
 	preset_container->add_child(preset);
 	preset->connect("gui_input", callable_mp(this, &ColorPicker::_preset_input));
 	preset->connect("draw", callable_mp(this, &ColorPicker::_update_presets));
 
-	preset_container2->set_h_size_flags(SIZE_EXPAND_FILL);
+	preset_container2->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	add_child(preset_container2);
 	preset_container2->add_child(bt_add_preset);
 	bt_add_preset->set_tooltip(RTR("Add current color as a preset."));
@@ -1198,13 +1198,13 @@ void ColorPickerButton::pressed() {
 		if (i > 1) {
 			cp_rect.position.y = get_screen_position().y - cp_rect.size.y;
 		} else {
-			cp_rect.position.y = get_screen_position().y + get_size().height;
+			cp_rect.position.y = get_screen_position().y + get_rect_size().height;
 		}
 
 		if (i & 1) {
 			cp_rect.position.x = get_screen_position().x;
 		} else {
-			cp_rect.position.x = get_screen_position().x - MAX(0, (cp_rect.size.x - get_size().x));
+			cp_rect.position.x = get_screen_position().x - MAX(0, (cp_rect.size.x - get_rect_size().x));
 		}
 
 		if (usable_rect.encloses(cp_rect)) {
@@ -1220,7 +1220,7 @@ void ColorPickerButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
 			const Ref<StyleBox> normal = get_theme_stylebox("normal");
-			const Rect2 r = Rect2(normal->get_offset(), get_size() - normal->get_minimum_size());
+			const Rect2 r = Rect2(normal->get_offset(), get_rect_size() - normal->get_minimum_size());
 			draw_texture_rect(Control::get_theme_icon("bg", "ColorPickerButton"), r, true);
 			draw_rect(r, color);
 

--- a/scene/gui/color_rect.cpp
+++ b/scene/gui/color_rect.cpp
@@ -41,7 +41,7 @@ Color ColorRect::get_color() const {
 
 void ColorRect::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
-		draw_rect(Rect2(Point2(), get_size()), color);
+		draw_rect(Rect2(Point2(), get_rect_size()), color);
 	}
 }
 

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -99,22 +99,22 @@ void Container::fit_child_in_rect(Control *p_child, const Rect2 &p_rect) {
 	Size2 minsize = p_child->get_combined_minimum_size();
 	Rect2 r = p_rect;
 
-	if (!(p_child->get_h_size_flags() & SIZE_FILL)) {
+	if (!(p_child->get_size_flags_horizontal() & SIZE_FILL)) {
 		r.size.x = minsize.width;
-		if (p_child->get_h_size_flags() & SIZE_SHRINK_END) {
+		if (p_child->get_size_flags_horizontal() & SIZE_SHRINK_END) {
 			r.position.x += p_rect.size.width - minsize.width;
-		} else if (p_child->get_h_size_flags() & SIZE_SHRINK_CENTER) {
+		} else if (p_child->get_size_flags_horizontal() & SIZE_SHRINK_CENTER) {
 			r.position.x += Math::floor((p_rect.size.x - minsize.width) / 2);
 		} else {
 			r.position.x += 0;
 		}
 	}
 
-	if (!(p_child->get_v_size_flags() & SIZE_FILL)) {
+	if (!(p_child->get_size_flags_vertical() & SIZE_FILL)) {
 		r.size.y = minsize.y;
-		if (p_child->get_v_size_flags() & SIZE_SHRINK_END) {
+		if (p_child->get_size_flags_vertical() & SIZE_SHRINK_END) {
 			r.position.y += p_rect.size.height - minsize.height;
-		} else if (p_child->get_v_size_flags() & SIZE_SHRINK_CENTER) {
+		} else if (p_child->get_size_flags_vertical() & SIZE_SHRINK_CENTER) {
 			r.position.y += Math::floor((p_rect.size.y - minsize.height) / 2);
 		} else {
 			r.position.y += 0;
@@ -122,8 +122,8 @@ void Container::fit_child_in_rect(Control *p_child, const Rect2 &p_rect) {
 	}
 
 	p_child->set_rect(r);
-	p_child->set_rotation(0);
-	p_child->set_scale(Vector2(1, 1));
+	p_child->set_rect_rotation(0);
+	p_child->set_rect_scale(Vector2(1, 1));
 }
 
 void Container::queue_sort() {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -54,9 +54,9 @@
 #ifdef TOOLS_ENABLED
 Dictionary Control::_edit_get_state() const {
 	Dictionary s;
-	s["rotation"] = get_rotation();
-	s["scale"] = get_scale();
-	s["pivot"] = get_pivot_offset();
+	s["rotation"] = get_rect_rotation();
+	s["scale"] = get_rect_scale();
+	s["pivot"] = get_rect_pivot_offset();
 	Array anchors;
 	anchors.push_back(get_anchor(SIDE_LEFT));
 	anchors.push_back(get_anchor(SIDE_TOP));
@@ -78,9 +78,9 @@ void Control::_edit_set_state(const Dictionary &p_state) {
 				  !p_state.has("pivot") || !p_state.has("anchors") || !p_state.has("offsets"));
 	Dictionary state = p_state;
 
-	set_rotation(state["rotation"]);
-	set_scale(state["scale"]);
-	set_pivot_offset(state["pivot"]);
+	set_rect_rotation(state["rotation"]);
+	set_rect_scale(state["scale"]);
+	set_rect_pivot_offset(state["pivot"]);
 	Array anchors = state["anchors"];
 	data.anchor[SIDE_LEFT] = anchors[0];
 	data.anchor[SIDE_TOP] = anchors[1];
@@ -97,19 +97,19 @@ void Control::_edit_set_state(const Dictionary &p_state) {
 void Control::_edit_set_position(const Point2 &p_position) {
 #ifdef TOOLS_ENABLED
 	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint(), "This function can only be used from editor plugins.");
-	set_position(p_position, CanvasItemEditor::get_singleton()->is_anchors_mode_enabled() && Object::cast_to<Control>(data.parent));
+	set_rect_position(p_position, CanvasItemEditor::get_singleton()->is_anchors_mode_enabled() && Object::cast_to<Control>(data.parent));
 #else
 	// Unlikely to happen. TODO: enclose all _edit_ functions into TOOLS_ENABLED
-	set_position(p_position);
+	set_rect_position(p_position);
 #endif
 };
 
 Point2 Control::_edit_get_position() const {
-	return get_position();
+	return get_rect_position();
 };
 
 void Control::_edit_set_scale(const Size2 &p_scale) {
-	set_scale(p_scale);
+	set_rect_scale(p_scale);
 }
 
 Size2 Control::_edit_get_scale() const {
@@ -119,17 +119,17 @@ Size2 Control::_edit_get_scale() const {
 void Control::_edit_set_rect(const Rect2 &p_edit_rect) {
 #ifdef TOOLS_ENABLED
 	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint(), "This function can only be used from editor plugins.");
-	set_position((get_position() + get_transform().basis_xform(p_edit_rect.position)).snapped(Vector2(1, 1)), CanvasItemEditor::get_singleton()->is_anchors_mode_enabled());
-	set_size(p_edit_rect.size.snapped(Vector2(1, 1)), CanvasItemEditor::get_singleton()->is_anchors_mode_enabled());
+	set_rect_position((get_rect_position() + get_transform().basis_xform(p_edit_rect.position)).snapped(Vector2(1, 1)), CanvasItemEditor::get_singleton()->is_anchors_mode_enabled());
+	set_rect_size(p_edit_rect.size.snapped(Vector2(1, 1)), CanvasItemEditor::get_singleton()->is_anchors_mode_enabled());
 #else
 	// Unlikely to happen. TODO: enclose all _edit_ functions into TOOLS_ENABLED
-	set_position((get_position() + get_transform().basis_xform(p_edit_rect.position)).snapped(Vector2(1, 1)));
-	set_size(p_edit_rect.size.snapped(Vector2(1, 1)));
+	set_rect_position((get_rect_position() + get_transform().basis_xform(p_edit_rect.position)).snapped(Vector2(1, 1)));
+	set_rect_size(p_edit_rect.size.snapped(Vector2(1, 1)));
 #endif
 }
 
 Rect2 Control::_edit_get_rect() const {
-	return Rect2(Point2(), get_size());
+	return Rect2(Point2(), get_rect_size());
 }
 
 bool Control::_edit_use_rect() const {
@@ -137,11 +137,11 @@ bool Control::_edit_use_rect() const {
 }
 
 void Control::_edit_set_rotation(real_t p_rotation) {
-	set_rotation(p_rotation);
+	set_rect_rotation(p_rotation);
 }
 
 real_t Control::_edit_get_rotation() const {
-	return get_rotation();
+	return get_rect_rotation();
 }
 
 bool Control::_edit_use_rotation() const {
@@ -149,14 +149,14 @@ bool Control::_edit_use_rotation() const {
 }
 
 void Control::_edit_set_pivot(const Point2 &p_pivot) {
-	Vector2 delta_pivot = p_pivot - get_pivot_offset();
+	Vector2 delta_pivot = p_pivot - get_rect_pivot_offset();
 	Vector2 move = Vector2((cos(data.rotation) - 1.0) * delta_pivot.x - sin(data.rotation) * delta_pivot.y, sin(data.rotation) * delta_pivot.x + (cos(data.rotation) - 1.0) * delta_pivot.y);
-	set_position(get_position() + move);
-	set_pivot_offset(p_pivot);
+	set_rect_position(get_rect_position() + move);
+	set_rect_pivot_offset(p_pivot);
 }
 
 Point2 Control::_edit_get_pivot() const {
-	return get_pivot_offset();
+	return get_rect_pivot_offset();
 }
 
 bool Control::_edit_use_pivot() const {
@@ -168,22 +168,22 @@ Size2 Control::_edit_get_minimum_size() const {
 }
 #endif
 
-void Control::set_custom_minimum_size(const Size2 &p_custom) {
-	if (p_custom == data.custom_minimum_size) {
+void Control::set_rect_minimum_size(const Size2 &p_rect_minimum_size) {
+	if (p_rect_minimum_size == data.rect_minimum_size) {
 		return;
 	}
-	data.custom_minimum_size = p_custom;
+	data.rect_minimum_size = p_rect_minimum_size;
 	minimum_size_changed();
 }
 
-Size2 Control::get_custom_minimum_size() const {
-	return data.custom_minimum_size;
+Size2 Control::get_rect_minimum_size() const {
+	return data.rect_minimum_size;
 }
 
 void Control::_update_minimum_size_cache() {
 	Size2 minsize = get_minimum_size();
-	minsize.x = MAX(minsize.x, data.custom_minimum_size.x);
-	minsize.y = MAX(minsize.y, data.custom_minimum_size.y);
+	minsize.x = MAX(minsize.x, data.rect_minimum_size.x);
+	minsize.y = MAX(minsize.y, data.rect_minimum_size.y);
 
 	bool size_changed = false;
 	if (data.minimum_size_cache != minsize) {
@@ -492,7 +492,7 @@ void Control::remove_child_notify(Node *p_child) {
 
 void Control::_update_canvas_item_transform() {
 	Transform2D xform = _get_internal_transform();
-	xform[2] += get_position();
+	xform[2] += get_rect_position();
 
 	RenderingServer::get_singleton()->canvas_item_set_transform(get_canvas_item(), xform);
 }
@@ -598,7 +598,7 @@ void Control::_notification(int p_notification) {
 		} break;
 		case NOTIFICATION_DRAW: {
 			_update_canvas_item_transform();
-			RenderingServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), !data.disable_visibility_clip, Rect2(Point2(), get_size()));
+			RenderingServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), !data.disable_visibility_clip, Rect2(Point2(), get_rect_size()));
 			RenderingServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), data.clip_contents);
 			//emit_signal(SceneStringNames::get_singleton()->draw);
 
@@ -661,9 +661,9 @@ bool Control::has_point(const Point2 &p_point) const {
 	}
 	/*if (has_stylebox("mask")) {
 		Ref<StyleBox> mask = get_stylebox("mask");
-		return mask->test_mask(p_point,Rect2(Point2(),get_size()));
+		return mask->test_mask(p_point,Rect2(Point2(),get_rect_size()));
 	}*/
-	return Rect2(Point2(), get_size()).has_point(p_point);
+	return Rect2(Point2(), get_rect_size()).has_point(p_point);
 }
 
 void Control::set_drag_forwarding(Control *p_target) {
@@ -1246,9 +1246,9 @@ void Control::_size_changed() {
 	Size2 minimum_size = get_combined_minimum_size();
 
 	if (minimum_size.width > new_size_cache.width) {
-		if (data.h_grow == GROW_DIRECTION_BEGIN) {
+		if (data.grow_horizontal == GROW_DIRECTION_BEGIN) {
 			new_pos_cache.x += new_size_cache.width - minimum_size.width;
-		} else if (data.h_grow == GROW_DIRECTION_BOTH) {
+		} else if (data.grow_horizontal == GROW_DIRECTION_BOTH) {
 			new_pos_cache.x += 0.5 * (new_size_cache.width - minimum_size.width);
 		}
 
@@ -1260,9 +1260,9 @@ void Control::_size_changed() {
 	}
 
 	if (minimum_size.height > new_size_cache.height) {
-		if (data.v_grow == GROW_DIRECTION_BEGIN) {
+		if (data.grow_vertical == GROW_DIRECTION_BEGIN) {
 			new_pos_cache.y += new_size_cache.height - minimum_size.height;
-		} else if (data.v_grow == GROW_DIRECTION_BOTH) {
+		} else if (data.grow_vertical == GROW_DIRECTION_BOTH) {
 			new_pos_cache.y += 0.5 * (new_size_cache.height - minimum_size.height);
 		}
 
@@ -1453,7 +1453,7 @@ void Control::set_offsets_preset(LayoutPreset p_preset, LayoutPresetMode p_resiz
 
 	// Calculate the size if the node is not resized
 	Size2 min_size = get_minimum_size();
-	Size2 new_size = get_size();
+	Size2 new_size = get_rect_size();
 	if (p_resize_mode == PRESET_MODE_MINSIZE || p_resize_mode == PRESET_MODE_KEEP_HEIGHT) {
 		new_size.x = min_size.x;
 	}
@@ -1626,13 +1626,13 @@ Size2 Control::get_end() const {
 	return Size2(data.offset[2], data.offset[3]);
 }
 
-Point2 Control::get_global_position() const {
+Point2 Control::get_rect_global_position() const {
 	return get_global_transform().get_origin();
 }
 
 Point2 Control::get_screen_position() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), Point2());
-	Point2 global_pos = get_global_position();
+	Point2 global_pos = get_rect_global_position();
 	Window *w = Object::cast_to<Window>(get_viewport());
 	if (w && !w->is_embedding_subwindows()) {
 		global_pos += w->get_position();
@@ -1641,18 +1641,18 @@ Point2 Control::get_screen_position() const {
 	return global_pos;
 }
 
-void Control::_set_global_position(const Point2 &p_point) {
-	set_global_position(p_point);
+void Control::_set_rect_global_position(const Point2 &p_point) {
+	set_rect_global_position(p_point);
 }
 
-void Control::set_global_position(const Point2 &p_point, bool p_keep_offsets) {
+void Control::set_rect_global_position(const Point2 &p_point, bool p_keep_offsets) {
 	Transform2D inv;
 
 	if (data.parent_canvas_item) {
 		inv = data.parent_canvas_item->get_global_transform().affine_inverse();
 	}
 
-	set_position(inv.xform(p_point), p_keep_offsets);
+	set_rect_position(inv.xform(p_point), p_keep_offsets);
 }
 
 void Control::_compute_anchors(Rect2 p_rect, const real_t p_offsets[4], real_t (&r_anchors)[4]) {
@@ -1683,11 +1683,11 @@ void Control::_compute_offsets(Rect2 p_rect, const real_t p_anchors[4], real_t (
 	r_offsets[3] = p_rect.position.y + p_rect.size.y - (p_anchors[3] * parent_rect_size.y);
 }
 
-void Control::_set_position(const Size2 &p_point) {
-	set_position(p_point);
+void Control::_set_rect_position(const Size2 &p_point) {
+	set_rect_position(p_point);
 }
 
-void Control::set_position(const Size2 &p_point, bool p_keep_offsets) {
+void Control::set_rect_position(const Size2 &p_point, bool p_keep_offsets) {
 	if (p_keep_offsets) {
 		_compute_anchors(Rect2(p_point, data.size_cache), data.offset, data.anchor);
 	} else {
@@ -1707,16 +1707,16 @@ void Control::set_rect(const Rect2 &p_rect) {
 	}
 }
 
-void Control::_set_size(const Size2 &p_size) {
+void Control::_set_rect_size(const Size2 &p_size) {
 #ifdef DEBUG_ENABLED
 	if (data.size_warning) {
 		WARN_PRINT("Adjusting the size of Control nodes before they are fully initialized is unreliable. Consider deferring it with set_deferred().");
 	}
 #endif
-	set_size(p_size);
+	set_rect_size(p_size);
 }
 
-void Control::set_size(const Size2 &p_size, bool p_keep_offsets) {
+void Control::set_rect_size(const Size2 &p_size, bool p_keep_offsets) {
 	Size2 new_size = p_size;
 	Size2 min = get_combined_minimum_size();
 	if (new_size.x < min.x) {
@@ -1734,22 +1734,22 @@ void Control::set_size(const Size2 &p_size, bool p_keep_offsets) {
 	_size_changed();
 }
 
-Size2 Control::get_position() const {
+Size2 Control::get_rect_position() const {
 	return data.pos_cache;
 }
 
-Size2 Control::get_size() const {
+Size2 Control::get_rect_size() const {
 	return data.size_cache;
 }
 
 Rect2 Control::get_global_rect() const {
-	return Rect2(get_global_position(), get_size());
+	return Rect2(get_rect_global_position(), get_rect_size());
 }
 
 Rect2 Control::get_screen_rect() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), Rect2());
 
-	Rect2 r(get_global_position(), get_size());
+	Rect2 r(get_rect_global_position(), get_rect_size());
 
 	Window *w = Object::cast_to<Window>(get_viewport());
 	if (w && !w->is_embedding_subwindows()) {
@@ -1767,11 +1767,11 @@ Rect2 Control::get_window_rect() const {
 }
 
 Rect2 Control::get_rect() const {
-	return Rect2(get_position(), get_size());
+	return Rect2(get_rect_position(), get_rect_size());
 }
 
 Rect2 Control::get_anchorable_rect() const {
-	return Rect2(Point2(), get_size());
+	return Rect2(Point2(), get_rect_size());
 }
 
 void Control::add_theme_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon) {
@@ -2197,23 +2197,23 @@ Control *Control::make_custom_tooltip(const String &p_text) const {
 	return nullptr;
 }
 
-void Control::set_default_cursor_shape(CursorShape p_shape) {
+void Control::set_mouse_default_cursor_shape(CursorShape p_shape) {
 	ERR_FAIL_INDEX(int(p_shape), CURSOR_MAX);
 
-	data.default_cursor = p_shape;
+	data.mouse_cursor_shape = p_shape;
 }
 
-Control::CursorShape Control::get_default_cursor_shape() const {
-	return data.default_cursor;
+Control::CursorShape Control::get_mouse_default_cursor_shape() const {
+	return data.mouse_cursor_shape;
 }
 
-Control::CursorShape Control::get_cursor_shape(const Point2 &p_pos) const {
-	return data.default_cursor;
+Control::CursorShape Control::get_mouse_cursor_shape(const Point2 &p_pos) const {
+	return data.mouse_cursor_shape;
 }
 
 Transform2D Control::get_transform() const {
 	Transform2D xform = _get_internal_transform();
-	xform[2] += get_position();
+	xform[2] += get_rect_position();
 	return xform;
 }
 
@@ -2287,9 +2287,9 @@ Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
 	Transform2D xform = get_global_transform();
 
 	points[0] = xform.xform(Point2());
-	points[1] = xform.xform(Point2(get_size().x, 0));
-	points[2] = xform.xform(get_size());
-	points[3] = xform.xform(Point2(0, get_size().y));
+	points[1] = xform.xform(Point2(get_rect_size().x, 0));
+	points[2] = xform.xform(get_rect_size());
+	points[3] = xform.xform(Point2(0, get_rect_size().y));
 
 	const Vector2 dir[4] = {
 		Vector2(-1, 0),
@@ -2343,9 +2343,9 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 		Transform2D xform = c->get_global_transform();
 
 		points[0] = xform.xform(Point2());
-		points[1] = xform.xform(Point2(c->get_size().x, 0));
-		points[2] = xform.xform(c->get_size());
-		points[3] = xform.xform(Point2(0, c->get_size().y));
+		points[1] = xform.xform(Point2(c->get_rect_size().x, 0));
+		points[2] = xform.xform(c->get_rect_size());
+		points[3] = xform.xform(Point2(0, c->get_rect_size().y));
 
 		real_t min = 1e7;
 
@@ -2387,27 +2387,27 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 	}
 }
 
-void Control::set_h_size_flags(int p_flags) {
-	if (data.h_size_flags == p_flags) {
+void Control::set_size_flags_horizontal(int p_flags) {
+	if (data.size_flags_horizontal == p_flags) {
 		return;
 	}
-	data.h_size_flags = p_flags;
+	data.size_flags_horizontal = p_flags;
 	emit_signal(SceneStringNames::get_singleton()->size_flags_changed);
 }
 
-int Control::get_h_size_flags() const {
-	return data.h_size_flags;
+int Control::get_size_flags_horizontal() const {
+	return data.size_flags_horizontal;
 }
 
-void Control::set_v_size_flags(int p_flags) {
-	if (data.v_size_flags == p_flags) {
+void Control::set_size_flags_vertical(int p_flags) {
+	if (data.size_flags_vertical == p_flags) {
 		return;
 	}
-	data.v_size_flags = p_flags;
+	data.size_flags_vertical = p_flags;
 	emit_signal(SceneStringNames::get_singleton()->size_flags_changed);
 }
 
-void Control::set_stretch_ratio(real_t p_ratio) {
+void Control::set_size_flags_stretch_ratio(real_t p_ratio) {
 	if (data.expand == p_ratio) {
 		return;
 	}
@@ -2416,7 +2416,7 @@ void Control::set_stretch_ratio(real_t p_ratio) {
 	emit_signal(SceneStringNames::get_singleton()->size_flags_changed);
 }
 
-real_t Control::get_stretch_ratio() const {
+real_t Control::get_size_flags_stretch_ratio() const {
 	return data.expand;
 }
 
@@ -2461,8 +2461,8 @@ void Control::minimum_size_changed() {
 	MessageQueue::get_singleton()->push_call(this, "_update_minimum_size");
 }
 
-int Control::get_v_size_flags() const {
-	return data.v_size_flags;
+int Control::get_size_flags_vertical() const {
+	return data.size_flags_vertical;
 }
 
 void Control::set_mouse_filter(MouseFilter p_filter) {
@@ -2588,22 +2588,22 @@ Vector<Vector2i> Control::structured_text_parser(StructuredTextParser p_node_typ
 	return ret;
 }
 
-void Control::set_rotation(real_t p_radians) {
+void Control::set_rect_rotation(real_t p_radians) {
 	data.rotation = p_radians;
 	update();
 	_notify_transform();
 }
 
-real_t Control::get_rotation() const {
+real_t Control::get_rect_rotation() const {
 	return data.rotation;
 }
 
-void Control::set_rotation_degrees(real_t p_degrees) {
-	set_rotation(Math::deg2rad(p_degrees));
+void Control::set_rect_rotation_degrees(real_t p_degrees) {
+	set_rect_rotation(Math::deg2rad(p_degrees));
 }
 
-real_t Control::get_rotation_degrees() const {
-	return Math::rad2deg(get_rotation());
+real_t Control::get_rect_rotation_degrees() const {
+	return Math::rad2deg(get_rect_rotation());
 }
 
 void Control::_override_changed() {
@@ -2612,17 +2612,17 @@ void Control::_override_changed() {
 	minimum_size_changed(); // overrides are likely to affect minimum size
 }
 
-void Control::set_pivot_offset(const Vector2 &p_pivot) {
+void Control::set_rect_pivot_offset(const Vector2 &p_pivot) {
 	data.pivot_offset = p_pivot;
 	update();
 	_notify_transform();
 }
 
-Vector2 Control::get_pivot_offset() const {
+Vector2 Control::get_rect_pivot_offset() const {
 	return data.pivot_offset;
 }
 
-void Control::set_scale(const Vector2 &p_scale) {
+void Control::set_rect_scale(const Vector2 &p_scale) {
 	data.scale = p_scale;
 	// Avoid having 0 scale values, can lead to errors in physics and rendering.
 	if (data.scale.x == 0) {
@@ -2635,7 +2635,7 @@ void Control::set_scale(const Vector2 &p_scale) {
 	_notify_transform();
 }
 
-Vector2 Control::get_scale() const {
+Vector2 Control::get_rect_scale() const {
 	return data.scale;
 }
 
@@ -2717,35 +2717,35 @@ TypedArray<String> Control::get_configuration_warnings() const {
 	return warnings;
 }
 
-void Control::set_clip_contents(bool p_clip) {
+void Control::set_rect_clip_contents(bool p_clip) {
 	data.clip_contents = p_clip;
 	update();
 }
 
-bool Control::is_clipping_contents() {
+bool Control::is_rect_clipping_contents() {
 	return data.clip_contents;
 }
 
-void Control::set_h_grow_direction(GrowDirection p_direction) {
+void Control::set_grow_horizontal(GrowDirection p_direction) {
 	ERR_FAIL_INDEX((int)p_direction, 3);
 
-	data.h_grow = p_direction;
+	data.grow_horizontal = p_direction;
 	_size_changed();
 }
 
-Control::GrowDirection Control::get_h_grow_direction() const {
-	return data.h_grow;
+Control::GrowDirection Control::get_grow_horizontal() const {
+	return data.grow_horizontal;
 }
 
-void Control::set_v_grow_direction(GrowDirection p_direction) {
+void Control::set_grow_vertical(GrowDirection p_direction) {
 	ERR_FAIL_INDEX((int)p_direction, 3);
 
-	data.v_grow = p_direction;
+	data.grow_vertical = p_direction;
 	_size_changed();
 }
 
-Control::GrowDirection Control::get_v_grow_direction() const {
-	return data.v_grow;
+Control::GrowDirection Control::get_grow_vertical() const {
+	return data.grow_vertical;
 }
 
 void Control::_bind_methods() {
@@ -2765,29 +2765,29 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_anchor_and_offset", "side", "anchor", "offset", "push_opposite_anchor"), &Control::set_anchor_and_offset, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_begin", "position"), &Control::set_begin);
 	ClassDB::bind_method(D_METHOD("set_end", "position"), &Control::set_end);
-	ClassDB::bind_method(D_METHOD("set_position", "position", "keep_offsets"), &Control::set_position, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("_set_position", "position"), &Control::_set_position);
-	ClassDB::bind_method(D_METHOD("set_size", "size", "keep_offsets"), &Control::set_size, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("_set_size", "size"), &Control::_set_size);
-	ClassDB::bind_method(D_METHOD("set_custom_minimum_size", "size"), &Control::set_custom_minimum_size);
-	ClassDB::bind_method(D_METHOD("set_global_position", "position", "keep_offsets"), &Control::set_global_position, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("_set_global_position", "position"), &Control::_set_global_position);
-	ClassDB::bind_method(D_METHOD("set_rotation", "radians"), &Control::set_rotation);
-	ClassDB::bind_method(D_METHOD("set_rotation_degrees", "degrees"), &Control::set_rotation_degrees);
-	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &Control::set_scale);
-	ClassDB::bind_method(D_METHOD("set_pivot_offset", "pivot_offset"), &Control::set_pivot_offset);
+	ClassDB::bind_method(D_METHOD("set_rect_position", "position", "keep_offsets"), &Control::set_rect_position, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("_set_rect_position", "position"), &Control::_set_rect_position);
+	ClassDB::bind_method(D_METHOD("set_rect_size", "size", "keep_offsets"), &Control::set_rect_size, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("_set_rect_size", "size"), &Control::_set_rect_size);
+	ClassDB::bind_method(D_METHOD("set_rect_minimum_size", "size"), &Control::set_rect_minimum_size);
+	ClassDB::bind_method(D_METHOD("set_rect_global_position", "position", "keep_offsets"), &Control::set_rect_global_position, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("_set_rect_global_position", "position"), &Control::_set_rect_global_position);
+	ClassDB::bind_method(D_METHOD("set_rect_rotation", "radians"), &Control::set_rect_rotation);
+	ClassDB::bind_method(D_METHOD("set_rect_rotation_degrees", "degrees"), &Control::set_rect_rotation_degrees);
+	ClassDB::bind_method(D_METHOD("set_rect_scale", "scale"), &Control::set_rect_scale);
+	ClassDB::bind_method(D_METHOD("set_rect_pivot_offset", "pivot_offset"), &Control::set_rect_pivot_offset);
 	ClassDB::bind_method(D_METHOD("get_offset", "offset"), &Control::get_offset);
 	ClassDB::bind_method(D_METHOD("get_begin"), &Control::get_begin);
 	ClassDB::bind_method(D_METHOD("get_end"), &Control::get_end);
-	ClassDB::bind_method(D_METHOD("get_position"), &Control::get_position);
-	ClassDB::bind_method(D_METHOD("get_size"), &Control::get_size);
-	ClassDB::bind_method(D_METHOD("get_rotation"), &Control::get_rotation);
-	ClassDB::bind_method(D_METHOD("get_rotation_degrees"), &Control::get_rotation_degrees);
-	ClassDB::bind_method(D_METHOD("get_scale"), &Control::get_scale);
-	ClassDB::bind_method(D_METHOD("get_pivot_offset"), &Control::get_pivot_offset);
-	ClassDB::bind_method(D_METHOD("get_custom_minimum_size"), &Control::get_custom_minimum_size);
+	ClassDB::bind_method(D_METHOD("get_rect_position"), &Control::get_rect_position);
+	ClassDB::bind_method(D_METHOD("get_rect_size"), &Control::get_rect_size);
+	ClassDB::bind_method(D_METHOD("get_rect_rotation"), &Control::get_rect_rotation);
+	ClassDB::bind_method(D_METHOD("get_rect_rotation_degrees"), &Control::get_rect_rotation_degrees);
+	ClassDB::bind_method(D_METHOD("get_rect_scale"), &Control::get_rect_scale);
+	ClassDB::bind_method(D_METHOD("get_rect_pivot_offset"), &Control::get_rect_pivot_offset);
+	ClassDB::bind_method(D_METHOD("get_rect_minimum_size"), &Control::get_rect_minimum_size);
 	ClassDB::bind_method(D_METHOD("get_parent_area_size"), &Control::get_parent_area_size);
-	ClassDB::bind_method(D_METHOD("get_global_position"), &Control::get_global_position);
+	ClassDB::bind_method(D_METHOD("get_rect_global_position"), &Control::get_rect_global_position);
 	ClassDB::bind_method(D_METHOD("get_rect"), &Control::get_rect);
 	ClassDB::bind_method(D_METHOD("get_global_rect"), &Control::get_global_rect);
 	ClassDB::bind_method(D_METHOD("set_focus_mode", "mode"), &Control::set_focus_mode);
@@ -2799,14 +2799,14 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("find_next_valid_focus"), &Control::find_next_valid_focus);
 	ClassDB::bind_method(D_METHOD("get_focus_owner"), &Control::get_focus_owner);
 
-	ClassDB::bind_method(D_METHOD("set_h_size_flags", "flags"), &Control::set_h_size_flags);
-	ClassDB::bind_method(D_METHOD("get_h_size_flags"), &Control::get_h_size_flags);
+	ClassDB::bind_method(D_METHOD("set_size_flags_horizontal", "flags"), &Control::set_size_flags_horizontal);
+	ClassDB::bind_method(D_METHOD("get_size_flags_horizontal"), &Control::get_size_flags_horizontal);
 
-	ClassDB::bind_method(D_METHOD("set_stretch_ratio", "ratio"), &Control::set_stretch_ratio);
-	ClassDB::bind_method(D_METHOD("get_stretch_ratio"), &Control::get_stretch_ratio);
+	ClassDB::bind_method(D_METHOD("set_size_flags_stretch_ratio", "ratio"), &Control::set_size_flags_stretch_ratio);
+	ClassDB::bind_method(D_METHOD("get_size_flags_stretch_ratio"), &Control::get_size_flags_stretch_ratio);
 
-	ClassDB::bind_method(D_METHOD("set_v_size_flags", "flags"), &Control::set_v_size_flags);
-	ClassDB::bind_method(D_METHOD("get_v_size_flags"), &Control::get_v_size_flags);
+	ClassDB::bind_method(D_METHOD("set_size_flags_vertical", "flags"), &Control::set_size_flags_vertical);
+	ClassDB::bind_method(D_METHOD("get_size_flags_vertical"), &Control::get_size_flags_vertical);
 
 	ClassDB::bind_method(D_METHOD("set_theme", "theme"), &Control::set_theme);
 	ClassDB::bind_method(D_METHOD("get_theme"), &Control::get_theme);
@@ -2848,19 +2848,19 @@ void Control::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_parent_control"), &Control::get_parent_control);
 
-	ClassDB::bind_method(D_METHOD("set_h_grow_direction", "direction"), &Control::set_h_grow_direction);
-	ClassDB::bind_method(D_METHOD("get_h_grow_direction"), &Control::get_h_grow_direction);
+	ClassDB::bind_method(D_METHOD("set_grow_horizontal", "direction"), &Control::set_grow_horizontal);
+	ClassDB::bind_method(D_METHOD("get_grow_horizontal"), &Control::get_grow_horizontal);
 
-	ClassDB::bind_method(D_METHOD("set_v_grow_direction", "direction"), &Control::set_v_grow_direction);
-	ClassDB::bind_method(D_METHOD("get_v_grow_direction"), &Control::get_v_grow_direction);
+	ClassDB::bind_method(D_METHOD("set_grow_vertical", "direction"), &Control::set_grow_vertical);
+	ClassDB::bind_method(D_METHOD("get_grow_vertical"), &Control::get_grow_vertical);
 
 	ClassDB::bind_method(D_METHOD("set_tooltip", "tooltip"), &Control::set_tooltip);
 	ClassDB::bind_method(D_METHOD("get_tooltip", "at_position"), &Control::get_tooltip, DEFVAL(Point2()));
 	ClassDB::bind_method(D_METHOD("_get_tooltip"), &Control::_get_tooltip);
 
-	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Control::set_default_cursor_shape);
-	ClassDB::bind_method(D_METHOD("get_default_cursor_shape"), &Control::get_default_cursor_shape);
-	ClassDB::bind_method(D_METHOD("get_cursor_shape", "position"), &Control::get_cursor_shape, DEFVAL(Point2()));
+	ClassDB::bind_method(D_METHOD("set_mouse_default_cursor_shape", "shape"), &Control::set_mouse_default_cursor_shape);
+	ClassDB::bind_method(D_METHOD("get_mouse_default_cursor_shape"), &Control::get_mouse_default_cursor_shape);
+	ClassDB::bind_method(D_METHOD("get_mouse_cursor_shape", "position"), &Control::get_mouse_cursor_shape, DEFVAL(Point2()));
 
 	ClassDB::bind_method(D_METHOD("set_focus_neighbor", "side", "neighbor"), &Control::set_focus_neighbor);
 	ClassDB::bind_method(D_METHOD("get_focus_neighbor", "side"), &Control::get_focus_neighbor);
@@ -2876,8 +2876,8 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mouse_filter", "filter"), &Control::set_mouse_filter);
 	ClassDB::bind_method(D_METHOD("get_mouse_filter"), &Control::get_mouse_filter);
 
-	ClassDB::bind_method(D_METHOD("set_clip_contents", "enable"), &Control::set_clip_contents);
-	ClassDB::bind_method(D_METHOD("is_clipping_contents"), &Control::is_clipping_contents);
+	ClassDB::bind_method(D_METHOD("set_rect_clip_contents", "enable"), &Control::set_rect_clip_contents);
+	ClassDB::bind_method(D_METHOD("is_rect_clipping_contents"), &Control::is_rect_clipping_contents);
 
 	ClassDB::bind_method(D_METHOD("grab_click_focus"), &Control::grab_click_focus);
 
@@ -2921,25 +2921,25 @@ void Control::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "offset_bottom", PROPERTY_HINT_RANGE, "-4096,4096"), "set_offset", "get_offset", SIDE_BOTTOM);
 
 	ADD_GROUP("Grow Direction", "grow_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "grow_horizontal", PROPERTY_HINT_ENUM, "Begin,End,Both"), "set_h_grow_direction", "get_h_grow_direction");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "grow_vertical", PROPERTY_HINT_ENUM, "Begin,End,Both"), "set_v_grow_direction", "get_v_grow_direction");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "grow_horizontal", PROPERTY_HINT_ENUM, "Begin,End,Both"), "set_grow_horizontal", "get_grow_horizontal");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "grow_vertical", PROPERTY_HINT_ENUM, "Begin,End,Both"), "set_grow_vertical", "get_grow_vertical");
 
 	ADD_GROUP("Layout Direction", "layout_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layout_direction", PROPERTY_HINT_ENUM, "Inherited,Locale,Left-to-right,Right-to-left"), "set_layout_direction", "get_layout_direction");
 
-	ADD_GROUP("Rect", "rect_");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_position", "get_position");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_global_position", PROPERTY_HINT_NONE, "", 0), "_set_global_position", "get_global_position");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_size", "get_size");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_min_size"), "set_custom_minimum_size", "get_custom_minimum_size");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rect_rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_rotation", "get_rotation");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rect_rotation_degrees", PROPERTY_HINT_RANGE, "-360,360,0.1,or_lesser,or_greater"), "set_rotation_degrees", "get_rotation_degrees");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_scale"), "set_scale", "get_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_pivot_offset"), "set_pivot_offset", "get_pivot_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rect_clip_content"), "set_clip_contents", "is_clipping_contents");
+	ADD_GROUP("Rectangle", "rect_");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_rect_position", "get_rect_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_global_position", PROPERTY_HINT_NONE, "", 0), "_set_rect_global_position", "get_rect_global_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_rect_size", "get_rect_size");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_minimum_size"), "set_rect_minimum_size", "get_rect_minimum_size");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rect_rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_rect_rotation", "get_rect_rotation");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rect_rotation_degrees", PROPERTY_HINT_RANGE, "-360,360,0.1,or_lesser,or_greater"), "set_rect_rotation_degrees", "get_rect_rotation_degrees");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_scale"), "set_rect_scale", "get_rect_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "rect_pivot_offset"), "set_rect_pivot_offset", "get_rect_pivot_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rect_clip_contents"), "set_rect_clip_contents", "is_rect_clipping_contents");
 
-	ADD_GROUP("Hint", "hint_");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "hint_tooltip", PROPERTY_HINT_MULTILINE_TEXT), "set_tooltip", "_get_tooltip");
+	ADD_GROUP("Tooltip", "");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "tooltip", PROPERTY_HINT_MULTILINE_TEXT), "set_tooltip", "_get_tooltip");
 
 	ADD_GROUP("Focus", "focus_");
 	ADD_PROPERTYI(PropertyInfo(Variant::NODE_PATH, "focus_neighbor_left", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Control"), "set_focus_neighbor", "get_focus_neighbor", SIDE_LEFT);
@@ -2952,12 +2952,12 @@ void Control::_bind_methods() {
 
 	ADD_GROUP("Mouse", "mouse_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_filter", PROPERTY_HINT_ENUM, "Stop,Pass,Ignore"), "set_mouse_filter", "get_mouse_filter");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_default_cursor_shape", PROPERTY_HINT_ENUM, "Arrow,Ibeam,Pointing hand,Cross,Wait,Busy,Drag,Can drop,Forbidden,Vertical resize,Horizontal resize,Secondary diagonal resize,Main diagonal resize,Move,Vertical split,Horizontal split,Help"), "set_default_cursor_shape", "get_default_cursor_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_default_cursor_shape", PROPERTY_HINT_ENUM, "Arrow,Ibeam,Pointing hand,Cross,Wait,Busy,Drag,Can drop,Forbidden,Vertical resize,Horizontal resize,Secondary diagonal resize,Main diagonal resize,Move,Vertical split,Horizontal split,Help"), "set_mouse_default_cursor_shape", "get_mouse_default_cursor_shape");
 
 	ADD_GROUP("Size Flags", "size_flags_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags_horizontal", PROPERTY_HINT_FLAGS, "Fill,Expand,Shrink Center,Shrink End"), "set_h_size_flags", "get_h_size_flags");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags_vertical", PROPERTY_HINT_FLAGS, "Fill,Expand,Shrink Center,Shrink End"), "set_v_size_flags", "get_v_size_flags");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "size_flags_stretch_ratio", PROPERTY_HINT_RANGE, "0,20,0.01,or_greater"), "set_stretch_ratio", "get_stretch_ratio");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags_horizontal", PROPERTY_HINT_FLAGS, "Fill,Expand,Shrink Center,Shrink End"), "set_size_flags_horizontal", "get_size_flags_horizontal");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags_vertical", PROPERTY_HINT_FLAGS, "Fill,Expand,Shrink Center,Shrink End"), "set_size_flags_vertical", "get_size_flags_vertical");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "size_flags_stretch_ratio", PROPERTY_HINT_RANGE, "0,20,0.01,or_greater"), "set_size_flags_stretch_ratio", "get_size_flags_stretch_ratio");
 	ADD_GROUP("Theme", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, "Theme"), "set_theme", "get_theme");
 	ADD_GROUP("", "");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -174,8 +174,8 @@ private:
 		real_t offset[4] = { 0.0, 0.0, 0.0, 0.0 };
 		real_t anchor[4] = { ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN };
 		FocusMode focus_mode = FOCUS_NONE;
-		GrowDirection h_grow = GROW_DIRECTION_END;
-		GrowDirection v_grow = GROW_DIRECTION_END;
+		GrowDirection grow_horizontal = GROW_DIRECTION_END;
+		GrowDirection grow_vertical = GROW_DIRECTION_END;
 
 		LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
 
@@ -184,10 +184,10 @@ private:
 		Vector2 pivot_offset;
 		bool size_warning = true;
 
-		int h_size_flags = SIZE_FILL;
-		int v_size_flags = SIZE_FILL;
+		int size_flags_horizontal = SIZE_FILL;
+		int size_flags_vertical = SIZE_FILL;
 		real_t expand = 1.0;
-		Point2 custom_minimum_size;
+		Point2 rect_minimum_size;
 
 		MouseFilter mouse_filter = MOUSE_FILTER_STOP;
 
@@ -202,7 +202,7 @@ private:
 		Control *theme_owner = nullptr;
 		Window *theme_owner_window = nullptr;
 		String tooltip;
-		CursorShape default_cursor = CURSOR_ARROW;
+		CursorShape mouse_cursor_shape = CURSOR_ARROW;
 
 		List<Control *>::Element *RI = nullptr;
 
@@ -228,9 +228,9 @@ private:
 	Control *_get_focus_neighbor(Side p_side, int p_count = 0);
 
 	void _set_anchor(Side p_side, real_t p_anchor);
-	void _set_position(const Point2 &p_point);
-	void _set_global_position(const Point2 &p_point);
-	void _set_size(const Size2 &p_size);
+	void _set_rect_position(const Point2 &p_point);
+	void _set_rect_global_position(const Point2 &p_point);
+	void _set_rect_size(const Size2 &p_size);
 
 	void _theme_changed();
 
@@ -349,8 +349,8 @@ public:
 	void set_drag_preview(Control *p_control);
 	void force_drag(const Variant &p_data, Control *p_control);
 
-	void set_custom_minimum_size(const Size2 &p_custom);
-	Size2 get_custom_minimum_size() const;
+	void set_rect_minimum_size(const Size2 &p_rect_minimum_size);
+	Size2 get_rect_minimum_size() const;
 
 	Control *get_parent_control() const;
 
@@ -378,14 +378,14 @@ public:
 	Point2 get_begin() const;
 	Point2 get_end() const;
 
-	void set_position(const Point2 &p_point, bool p_keep_offsets = false);
-	void set_global_position(const Point2 &p_point, bool p_keep_offsets = false);
-	Point2 get_position() const;
-	Point2 get_global_position() const;
+	void set_rect_position(const Point2 &p_point, bool p_keep_offsets = false);
+	void set_rect_global_position(const Point2 &p_point, bool p_keep_offsets = false);
+	Point2 get_rect_position() const;
+	Point2 get_rect_global_position() const;
 	Point2 get_screen_position() const;
 
-	void set_size(const Size2 &p_size, bool p_keep_offsets = false);
-	Size2 get_size() const;
+	void set_rect_size(const Size2 &p_size, bool p_keep_offsets = false);
+	Size2 get_rect_size() const;
 
 	Rect2 get_rect() const;
 	Rect2 get_global_rect() const;
@@ -395,34 +395,34 @@ public:
 
 	void set_rect(const Rect2 &p_rect); // Reset anchors to begin and set rect, for faster container children sorting.
 
-	void set_rotation(real_t p_radians);
-	void set_rotation_degrees(real_t p_degrees);
-	real_t get_rotation() const;
-	real_t get_rotation_degrees() const;
+	void set_rect_rotation(real_t p_radians);
+	void set_rect_rotation_degrees(real_t p_degrees);
+	real_t get_rect_rotation() const;
+	real_t get_rect_rotation_degrees() const;
 
-	void set_h_grow_direction(GrowDirection p_direction);
-	GrowDirection get_h_grow_direction() const;
+	void set_grow_horizontal(GrowDirection p_direction);
+	GrowDirection get_grow_horizontal() const;
 
-	void set_v_grow_direction(GrowDirection p_direction);
-	GrowDirection get_v_grow_direction() const;
+	void set_grow_vertical(GrowDirection p_direction);
+	GrowDirection get_grow_vertical() const;
 
-	void set_pivot_offset(const Vector2 &p_pivot);
-	Vector2 get_pivot_offset() const;
+	void set_rect_pivot_offset(const Vector2 &p_pivot);
+	Vector2 get_rect_pivot_offset() const;
 
-	void set_scale(const Vector2 &p_scale);
-	Vector2 get_scale() const;
+	void set_rect_scale(const Vector2 &p_scale);
+	Vector2 get_rect_scale() const;
 
 	void set_theme(const Ref<Theme> &p_theme);
 	Ref<Theme> get_theme() const;
 
-	void set_h_size_flags(int p_flags);
-	int get_h_size_flags() const;
+	void set_size_flags_horizontal(int p_flags);
+	int get_size_flags_horizontal() const;
 
-	void set_v_size_flags(int p_flags);
-	int get_v_size_flags() const;
+	void set_size_flags_vertical(int p_flags);
+	int get_size_flags_vertical() const;
 
-	void set_stretch_ratio(real_t p_ratio);
-	real_t get_stretch_ratio() const;
+	void set_size_flags_stretch_ratio(real_t p_ratio);
+	real_t get_size_flags_stretch_ratio() const;
 
 	void minimum_size_changed();
 
@@ -495,9 +495,9 @@ public:
 
 	/* CURSOR */
 
-	void set_default_cursor_shape(CursorShape p_shape);
-	CursorShape get_default_cursor_shape() const;
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const;
+	void set_mouse_default_cursor_shape(CursorShape p_shape);
+	CursorShape get_mouse_default_cursor_shape() const;
+	virtual CursorShape get_mouse_cursor_shape(const Point2 &p_pos = Point2i()) const;
 
 	virtual Transform2D get_transform() const override;
 
@@ -514,8 +514,8 @@ public:
 
 	Control *get_root_parent_control() const;
 
-	void set_clip_contents(bool p_clip);
-	bool is_clipping_contents();
+	void set_rect_clip_contents(bool p_clip);
+	bool is_rect_clipping_contents();
 
 	void set_block_minimum_size_adjust(bool p_block);
 	bool is_minimum_size_adjust_blocked() const;

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -185,18 +185,18 @@ void AcceptDialog::_update_child_rects() {
 			continue;
 		}
 
-		c->set_position(cpos);
-		c->set_size(csize);
+		c->set_rect_position(cpos);
+		c->set_rect_size(csize);
 	}
 
 	cpos.y += csize.y + margin;
 	csize.y = hminsize.y;
 
-	hbc->set_position(cpos);
-	hbc->set_size(csize);
+	hbc->set_rect_position(cpos);
+	hbc->set_rect_size(csize);
 
-	bg->set_position(Point2());
-	bg->set_size(size);
+	bg->set_rect_position(Point2());
+	bg->set_rect_size(size);
 }
 
 Size2 AcceptDialog::_get_contents_minimum_size() const {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -962,7 +962,7 @@ FileDialog::FileDialog() {
 	dir = memnew(LineEdit);
 	dir->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
 	hbc->add_child(dir);
-	dir->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	dir->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 
 	refresh = memnew(Button);
 	refresh->set_flat(true);
@@ -1002,12 +1002,12 @@ FileDialog::FileDialog() {
 	file_box->add_child(memnew(Label(TTRC("File:"))));
 	file = memnew(LineEdit);
 	file->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
-	file->set_stretch_ratio(4);
-	file->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	file->set_size_flags_stretch_ratio(4);
+	file->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	file_box->add_child(file);
 	filter = memnew(OptionButton);
-	filter->set_stretch_ratio(3);
-	filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	filter->set_size_flags_stretch_ratio(3);
+	filter->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
 	filter->set_clip_text(true); // too many extensions overflows it
 	file_box->add_child(filter);
 	vbox->add_child(file_box);

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -56,7 +56,7 @@ GradientEdit::GradientEdit() {
 
 int GradientEdit::_get_point_from_pos(int x) {
 	int result = -1;
-	int total_w = get_size().width - get_size().height - SPACING;
+	int total_w = get_rect_size().width - get_rect_size().height - SPACING;
 	float min_distance = 1e20;
 	for (int i = 0; i < points.size(); i++) {
 		//Check if we clicked at point
@@ -77,13 +77,13 @@ void GradientEdit::_show_color_picker() {
 	picker->set_pick_color(points[grabbed].color);
 	Size2 minsize = popup->get_contents_minimum_size();
 	bool show_above = false;
-	if (get_global_position().y + get_size().y + minsize.y > get_viewport_rect().size.y) {
+	if (get_rect_global_position().y + get_rect_size().y + minsize.y > get_viewport_rect().size.y) {
 		show_above = true;
 	}
 	if (show_above) {
 		popup->set_position(get_screen_position() - Vector2(0, minsize.y));
 	} else {
-		popup->set_position(get_screen_position() + Vector2(0, get_size().y));
+		popup->set_position(get_screen_position() + Vector2(0, get_rect_size().y));
 	}
 	popup->popup();
 }
@@ -132,7 +132,7 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		grabbed = _get_point_from_pos(x);
 
 		if (grabbed != -1) {
-			int total_w = get_size().width - get_size().height - SPACING;
+			int total_w = get_rect_size().width - get_rect_size().height - SPACING;
 			Gradient::Point newPoint = points[grabbed];
 			newPoint.offset = CLAMP(x / float(total_w), 0, 1);
 
@@ -154,7 +154,7 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && mb->get_button_index() == 1 && mb->is_pressed()) {
 		update();
 		int x = mb->get_position().x;
-		int total_w = get_size().width - get_size().height - SPACING;
+		int total_w = get_rect_size().width - get_rect_size().height - SPACING;
 
 		//Check if color selector was clicked.
 		if (x > total_w + SPACING) {
@@ -228,7 +228,7 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid() && grabbing) {
-		int total_w = get_size().width - get_size().height - SPACING;
+		int total_w = get_rect_size().width - get_rect_size().height - SPACING;
 
 		int x = mm->get_position().x;
 
@@ -301,14 +301,14 @@ void GradientEdit::_notification(int p_what) {
 		}
 	}
 	if (p_what == NOTIFICATION_DRAW) {
-		int w = get_size().x;
-		int h = get_size().y;
+		int w = get_rect_size().x;
+		int h = get_rect_size().y;
 
 		if (w == 0 || h == 0) {
 			return; //Safety check. We have division by 'h'. And in any case there is nothing to draw with such size
 		}
 
-		int total_w = get_size().width - get_size().height - SPACING;
+		int total_w = get_rect_size().width - get_rect_size().height - SPACING;
 
 		//Draw checker pattern for ramp
 		_draw_checker(0, 0, total_w, h);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -79,7 +79,7 @@ void GraphEditMinimap::update_minimap() {
 	Vector2 graph_size = _get_graph_size();
 
 	camera_position = ge->get_scroll_ofs() - graph_offset;
-	camera_size = ge->get_size();
+	camera_size = ge->get_rect_size();
 
 	Vector2 render_size = _get_render_size();
 	float target_ratio = render_size.x / render_size.y;
@@ -113,7 +113,7 @@ Vector2 GraphEditMinimap::_get_render_size() {
 		return Vector2(0, 0);
 	}
 
-	return get_size() - 2 * minimap_padding;
+	return get_rect_size() - 2 * minimap_padding;
 }
 
 Vector2 GraphEditMinimap::_get_graph_offset() {
@@ -184,8 +184,8 @@ void GraphEditMinimap::_gui_input(const Ref<InputEvent> &p_ev) {
 		if (is_resizing) {
 			// Prevent setting minimap wider than GraphEdit
 			Vector2 new_minimap_size;
-			new_minimap_size.x = MIN(get_size().x - mm->get_relative().x, ge->get_size().x - 2.0 * minimap_padding.x);
-			new_minimap_size.y = MIN(get_size().y - mm->get_relative().y, ge->get_size().y - 2.0 * minimap_padding.y);
+			new_minimap_size.x = MIN(get_rect_size().x - mm->get_relative().x, ge->get_rect_size().x - 2.0 * minimap_padding.x);
+			new_minimap_size.y = MIN(get_rect_size().y - mm->get_relative().y, ge->get_rect_size().y - 2.0 * minimap_padding.y);
 			ge->set_minimap_size(new_minimap_size);
 
 			update();
@@ -289,13 +289,13 @@ void GraphEdit::_update_scroll_offset() {
 
 		Point2 pos = gn->get_position_offset() * zoom;
 		pos -= Point2(h_scroll->get_value(), v_scroll->get_value());
-		gn->set_position(pos);
-		if (gn->get_scale() != Vector2(zoom, zoom)) {
-			gn->set_scale(Vector2(zoom, zoom));
+		gn->set_rect_position(pos);
+		if (gn->get_rect_scale() != Vector2(zoom, zoom)) {
+			gn->set_rect_scale(Vector2(zoom, zoom));
 		}
 	}
 
-	connections_layer->set_position(-Point2(h_scroll->get_value(), v_scroll->get_value()));
+	connections_layer->set_rect_position(-Point2(h_scroll->get_value(), v_scroll->get_value()));
 	set_block_minimum_size_adjust(false);
 	awaiting_scroll_offset_update = false;
 }
@@ -318,16 +318,16 @@ void GraphEdit::_update_scroll() {
 
 		Rect2 r;
 		r.position = gn->get_position_offset() * zoom;
-		r.size = gn->get_size() * zoom;
+		r.size = gn->get_rect_size() * zoom;
 		screen = screen.merge(r);
 	}
 
-	screen.position -= get_size();
-	screen.size += get_size() * 2.0;
+	screen.position -= get_rect_size();
+	screen.size += get_rect_size() * 2.0;
 
 	h_scroll->set_min(screen.position.x);
 	h_scroll->set_max(screen.position.x + screen.size.x);
-	h_scroll->set_page(get_size().x);
+	h_scroll->set_page(get_rect_size().x);
 	if (h_scroll->get_max() - h_scroll->get_min() <= h_scroll->get_page()) {
 		h_scroll->hide();
 	} else {
@@ -336,7 +336,7 @@ void GraphEdit::_update_scroll() {
 
 	v_scroll->set_min(screen.position.y);
 	v_scroll->set_max(screen.position.y + screen.size.y);
-	v_scroll->set_page(get_size().y);
+	v_scroll->set_page(get_rect_size().y);
 
 	if (v_scroll->get_max() - v_scroll->get_min() <= v_scroll->get_page()) {
 		v_scroll->hide();
@@ -408,7 +408,7 @@ void GraphEdit::add_child_notify(Node *p_child) {
 
 	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
-		gn->set_scale(Vector2(zoom, zoom));
+		gn->set_rect_scale(Vector2(zoom, zoom));
 		gn->connect("position_offset_changed", callable_mp(this, &GraphEdit::_graph_node_moved), varray(gn));
 		gn->connect("slot_updated", callable_mp(this, &GraphEdit::_graph_node_slot_updated), varray(gn));
 		gn->connect("raise_request", callable_mp(this, &GraphEdit::_graph_node_raised), varray(gn));
@@ -475,7 +475,7 @@ void GraphEdit::_notification(int p_what) {
 		v_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
 	}
 	if (p_what == NOTIFICATION_DRAW) {
-		draw_style_box(get_theme_stylebox("bg"), Rect2(Point2(), get_size()));
+		draw_style_box(get_theme_stylebox("bg"), Rect2(Point2(), get_rect_size()));
 
 		if (is_using_snap()) {
 			//draw grid
@@ -483,7 +483,7 @@ void GraphEdit::_notification(int p_what) {
 			int snap = get_snap();
 
 			Vector2 offset = get_scroll_ofs() / zoom;
-			Size2 size = get_size() / zoom;
+			Size2 size = get_rect_size() / zoom;
 
 			Point2i from = (offset / float(snap)).floor();
 			Point2i len = (size / float(snap)).floor() + Vector2(1, 1);
@@ -501,7 +501,7 @@ void GraphEdit::_notification(int p_what) {
 				}
 
 				float base_ofs = i * snap * zoom - offset.x * zoom;
-				draw_line(Vector2(base_ofs, 0), Vector2(base_ofs, get_size().height), color);
+				draw_line(Vector2(base_ofs, 0), Vector2(base_ofs, get_rect_size().height), color);
 			}
 
 			for (int i = from.y; i < from.y + len.y; i++) {
@@ -514,7 +514,7 @@ void GraphEdit::_notification(int p_what) {
 				}
 
 				float base_ofs = i * snap * zoom - offset.y * zoom;
-				draw_line(Vector2(0, base_ofs), Vector2(get_size().width, base_ofs), color);
+				draw_line(Vector2(0, base_ofs), Vector2(get_rect_size().width, base_ofs), color);
 			}
 		}
 	}
@@ -536,14 +536,14 @@ bool GraphEdit::_filter_input(const Point2 &p_point) {
 		}
 
 		for (int j = 0; j < gn->get_connection_output_count(); j++) {
-			Vector2 pos = gn->get_connection_output_position(j) + gn->get_position();
+			Vector2 pos = gn->get_connection_output_position(j) + gn->get_rect_position();
 			if (is_in_hot_zone(pos / zoom, p_point / zoom)) {
 				return true;
 			}
 		}
 
 		for (int j = 0; j < gn->get_connection_input_count(); j++) {
-			Vector2 pos = gn->get_connection_input_position(j) + gn->get_position();
+			Vector2 pos = gn->get_connection_input_position(j) + gn->get_rect_position();
 			if (is_in_hot_zone(pos / zoom, p_point / zoom)) {
 				return true;
 			}
@@ -566,7 +566,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 			}
 
 			for (int j = 0; j < gn->get_connection_output_count(); j++) {
-				Vector2 pos = gn->get_connection_output_position(j) + gn->get_position();
+				Vector2 pos = gn->get_connection_output_position(j) + gn->get_rect_position();
 				if (is_in_hot_zone(pos / zoom, click_pos)) {
 					if (valid_left_disconnect_types.has(gn->get_connection_output_type(j))) {
 						//check disconnect
@@ -608,7 +608,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 			}
 
 			for (int j = 0; j < gn->get_connection_input_count(); j++) {
-				Vector2 pos = gn->get_connection_input_position(j) + gn->get_position();
+				Vector2 pos = gn->get_connection_input_position(j) + gn->get_rect_position();
 				if (is_in_hot_zone(pos / zoom, click_pos)) {
 					if (right_disconnects || valid_right_disconnect_types.has(gn->get_connection_input_type(j))) {
 						//check disconnect
@@ -671,7 +671,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 
 				if (!connecting_out) {
 					for (int j = 0; j < gn->get_connection_output_count(); j++) {
-						Vector2 pos = gn->get_connection_output_position(j) + gn->get_position();
+						Vector2 pos = gn->get_connection_output_position(j) + gn->get_rect_position();
 						int type = gn->get_connection_output_type(j);
 						if ((type == connecting_type || valid_connection_types.has(ConnType(type, connecting_type))) && is_in_hot_zone(pos / zoom, mpos)) {
 							connecting_target = true;
@@ -683,7 +683,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 					}
 				} else {
 					for (int j = 0; j < gn->get_connection_input_count(); j++) {
-						Vector2 pos = gn->get_connection_input_position(j) + gn->get_position();
+						Vector2 pos = gn->get_connection_input_position(j) + gn->get_rect_position();
 						int type = gn->get_connection_input_type(j);
 						if ((type == connecting_type || valid_connection_types.has(ConnType(type, connecting_type))) && is_in_hot_zone(pos / zoom, mpos)) {
 							connecting_target = true;
@@ -745,7 +745,7 @@ bool GraphEdit::_check_clickable_control(Control *p_control, const Vector2 &pos)
 			if (!subchild) {
 				continue;
 			}
-			if (_check_clickable_control(subchild, pos - subchild->get_position())) {
+			if (_check_clickable_control(subchild, pos - subchild->get_rect_position())) {
 				return true;
 			}
 		}
@@ -782,7 +782,7 @@ bool GraphEdit::is_in_hot_zone(const Vector2 &pos, const Vector2 &p_mouse_pos) {
 					continue;
 				}
 
-				if (_check_clickable_control(subchild, subpos - subchild->get_position())) {
+				if (_check_clickable_control(subchild, subpos - subchild->get_rect_position())) {
 					return false;
 				}
 			}
@@ -923,7 +923,7 @@ void GraphEdit::_top_layer_draw() {
 		} else {
 			pos = from->get_connection_input_position(connecting_index);
 		}
-		pos += from->get_position();
+		pos += from->get_rect_position();
 
 		Vector2 topos;
 		topos = connecting_to;
@@ -956,7 +956,7 @@ void GraphEdit::_minimap_draw() {
 	minimap->update_minimap();
 
 	// Draw the minimap background.
-	Rect2 minimap_rect = Rect2(Point2(), minimap->get_size());
+	Rect2 minimap_rect = Rect2(Point2(), minimap->get_rect_size());
 	minimap->draw_style_box(minimap->get_theme_stylebox("bg"), minimap_rect);
 
 	Vector2 graph_offset = minimap->_get_graph_offset();
@@ -970,7 +970,7 @@ void GraphEdit::_minimap_draw() {
 		}
 
 		Vector2 node_position = minimap->_convert_from_graph_position(gn->get_position_offset() * zoom - graph_offset) + minimap_offset;
-		Vector2 node_size = minimap->_convert_from_graph_position(gn->get_size() * zoom);
+		Vector2 node_size = minimap->_convert_from_graph_position(gn->get_rect_size() * zoom);
 		Rect2 node_rect = Rect2(node_position, node_size);
 
 		Ref<StyleBoxFlat> sb_minimap = minimap->get_theme_stylebox("node")->duplicate();
@@ -993,7 +993,7 @@ void GraphEdit::_minimap_draw() {
 		}
 
 		Vector2 node_position = minimap->_convert_from_graph_position(gn->get_position_offset() * zoom - graph_offset) + minimap_offset;
-		Vector2 node_size = minimap->_convert_from_graph_position(gn->get_size() * zoom);
+		Vector2 node_size = minimap->_convert_from_graph_position(gn->get_rect_size() * zoom);
 		Rect2 node_rect = Rect2(node_position, node_size);
 
 		Ref<StyleBoxFlat> sb_minimap = minimap->get_theme_stylebox("node")->duplicate();
@@ -1223,7 +1223,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 						continue;
 					}
 
-					if (gn_selected->has_point((b->get_position() - gn_selected->get_position()) / zoom)) {
+					if (gn_selected->has_point((b->get_position() - gn_selected->get_rect_position()) / zoom)) {
 						gn = gn_selected;
 						break;
 					}
@@ -1388,7 +1388,7 @@ void GraphEdit::clear_connections() {
 }
 
 void GraphEdit::set_zoom(float p_zoom) {
-	set_zoom_custom(p_zoom, get_size() / 2);
+	set_zoom_custom(p_zoom, get_rect_size() / 2);
 }
 
 void GraphEdit::set_zoom_custom(float p_zoom, const Vector2 &p_center) {
@@ -1525,8 +1525,8 @@ void GraphEdit::_snap_value_changed(double) {
 }
 
 void GraphEdit::set_minimap_size(Vector2 p_size) {
-	minimap->set_size(p_size);
-	Vector2 minimap_size = minimap->get_size(); // The size might've been adjusted by the minimum size.
+	minimap->set_rect_size(p_size);
+	Vector2 minimap_size = minimap->get_rect_size(); // The size might've been adjusted by the minimum size.
 
 	minimap->set_anchors_preset(Control::PRESET_BOTTOM_RIGHT);
 	minimap->set_offset(Side::SIDE_LEFT, -minimap_size.x - MINIMAP_OFFSET);
@@ -1537,7 +1537,7 @@ void GraphEdit::set_minimap_size(Vector2 p_size) {
 }
 
 Vector2 GraphEdit::get_minimap_size() const {
-	return minimap->get_size();
+	return minimap->get_rect_size();
 }
 
 void GraphEdit::set_minimap_opacity(float p_opacity) {
@@ -1706,7 +1706,7 @@ GraphEdit::GraphEdit() {
 
 	zoom_hb = memnew(HBoxContainer);
 	top_layer->add_child(zoom_hb);
-	zoom_hb->set_position(Vector2(10, 10));
+	zoom_hb->set_rect_position(Vector2(10, 10));
 
 	zoom_minus = memnew(Button);
 	zoom_minus->set_flat(true);
@@ -1763,8 +1763,8 @@ GraphEdit::GraphEdit() {
 	minimap->set_name("_minimap");
 	minimap->set_modulate(Color(1, 1, 1, minimap_opacity));
 	minimap->set_mouse_filter(MOUSE_FILTER_PASS);
-	minimap->set_custom_minimum_size(Vector2(50, 50));
-	minimap->set_size(minimap_size);
+	minimap->set_rect_minimum_size(Vector2(50, 50));
+	minimap->set_rect_size(minimap_size);
 	minimap->set_anchors_preset(Control::PRESET_BOTTOM_RIGHT);
 	minimap->set_offset(Side::SIDE_LEFT, -minimap_size.x - MINIMAP_OFFSET);
 	minimap->set_offset(Side::SIDE_TOP, -minimap_size.y - MINIMAP_OFFSET);
@@ -1772,5 +1772,5 @@ GraphEdit::GraphEdit() {
 	minimap->set_offset(Side::SIDE_BOTTOM, -MINIMAP_OFFSET);
 	minimap->connect("draw", callable_mp(this, &GraphEdit::_minimap_draw));
 
-	set_clip_contents(true);
+	set_rect_clip_contents(true);
 }

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -67,10 +67,10 @@ void GridContainer::_notification(int p_what) {
 					row_minh[row] = ms.height;
 				}
 
-				if (c->get_h_size_flags() & SIZE_EXPAND) {
+				if (c->get_size_flags_horizontal() & SIZE_EXPAND) {
 					col_expanded.insert(col);
 				}
-				if (c->get_v_size_flags() & SIZE_EXPAND) {
+				if (c->get_size_flags_vertical() & SIZE_EXPAND) {
 					row_expanded.insert(row);
 				}
 			}
@@ -81,7 +81,7 @@ void GridContainer::_notification(int p_what) {
 			}
 
 			// Evaluate the remaining space for expanded columns/rows.
-			Size2 remaining_space = get_size();
+			Size2 remaining_space = get_rect_size();
 			for (Map<int, int>::Element *E = col_minw.front(); E; E = E->next()) {
 				if (!col_expanded.has(E->key())) {
 					remaining_space.width -= E->get();
@@ -158,7 +158,7 @@ void GridContainer::_notification(int p_what) {
 
 				if (col == 0) {
 					if (rtl) {
-						col_ofs = get_size().width;
+						col_ofs = get_rect_size().width;
 					} else {
 						col_ofs = 0;
 					}

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -558,7 +558,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 		pos.y += scroll_bar->get_value();
 
 		if (is_layout_rtl()) {
-			pos.x = get_size().width - pos.x;
+			pos.x = get_rect_size().width - pos.x;
 		}
 
 		int closest = -1;
@@ -566,7 +566,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 		for (int i = 0; i < items.size(); i++) {
 			Rect2 rc = items[i].rect_cache;
 			if (i % current_columns == current_columns - 1) {
-				rc.size.width = get_size().width; //not right but works
+				rc.size.width = get_rect_size().width; //not right but works
 			}
 
 			if (rc.has_point(pos)) {
@@ -872,7 +872,7 @@ void ItemList::_notification(int p_what) {
 		scroll_bar->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, bg->get_margin(SIDE_TOP));
 		scroll_bar->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -bg->get_margin(SIDE_BOTTOM));
 
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 
 		int width = size.width - bg->get_minimum_size().width;
 		if (scroll_bar->is_visible()) {
@@ -1301,7 +1301,7 @@ int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 	pos.y += scroll_bar->get_value();
 
 	if (is_layout_rtl()) {
-		pos.x = get_size().width - pos.x;
+		pos.x = get_rect_size().width - pos.x;
 	}
 
 	int closest = -1;
@@ -1310,7 +1310,7 @@ int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 	for (int i = 0; i < items.size(); i++) {
 		Rect2 rc = items[i].rect_cache;
 		if (i % current_columns == current_columns - 1) {
-			rc.size.width = get_size().width - rc.position.x; //make sure you can still select the last item when clicking past the column
+			rc.size.width = get_rect_size().width - rc.position.x; //make sure you can still select the last item when clicking past the column
 		}
 
 		if (rc.has_point(pos)) {
@@ -1339,7 +1339,7 @@ bool ItemList::is_pos_at_end_of_items(const Point2 &p_pos) const {
 	pos.y += scroll_bar->get_value();
 
 	if (is_layout_rtl()) {
-		pos.x = get_size().width - pos.x;
+		pos.x = get_rect_size().width - pos.x;
 	}
 
 	Rect2 endrect = items[items.size() - 1].rect_cache;
@@ -1634,7 +1634,7 @@ ItemList::ItemList() {
 	scroll_bar->connect("value_changed", callable_mp(this, &ItemList::_scroll_changed));
 
 	set_focus_mode(FOCUS_ALL);
-	set_clip_contents(true);
+	set_rect_clip_contents(true);
 }
 
 ItemList::~ItemList() {

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -80,7 +80,7 @@ int Label::get_line_height(int p_line) const {
 
 void Label::_shape() {
 	Ref<StyleBox> style = get_theme_stylebox("normal", "Label");
-	int width = (get_size().width - style->get_minimum_size().width);
+	int width = (get_rect_size().width - style->get_minimum_size().width);
 
 	if (dirty) {
 		TS->shaped_text_clear(text_rid);
@@ -150,7 +150,7 @@ void Label::_update_visible() {
 	int last_line = MIN(lines_rid.size(), lines_visible + lines_skipped);
 	for (int64_t i = lines_skipped; i < last_line; i++) {
 		minsize.height += TS->shaped_text_get_size(lines_rid[i]).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM) + line_spacing;
-		if (minsize.height > (get_size().height - style->get_minimum_size().height + line_spacing)) {
+		if (minsize.height > (get_rect_size().height - style->get_minimum_size().height + line_spacing)) {
 			break;
 		}
 	}
@@ -180,7 +180,7 @@ void Label::_notification(int p_what) {
 		RID ci = get_canvas_item();
 
 		Size2 string_size;
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 		Ref<StyleBox> style = get_theme_stylebox("normal");
 		Ref<Font> font = get_theme_font("font");
 		Color font_color = get_theme_color("font_color");
@@ -192,7 +192,7 @@ void Label::_notification(int p_what) {
 		int shadow_outline_size = get_theme_constant("shadow_outline_size");
 		bool rtl = is_layout_rtl();
 
-		style->draw(ci, Rect2(Point2(0, 0), get_size()));
+		style->draw(ci, Rect2(Point2(0, 0), get_rect_size()));
 
 		float total_h = 0.0;
 		int lines_visible = 0;
@@ -200,7 +200,7 @@ void Label::_notification(int p_what) {
 		// Get number of lines to fit to the height.
 		for (int64_t i = lines_skipped; i < lines_rid.size(); i++) {
 			total_h += TS->shaped_text_get_size(lines_rid[i]).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM) + line_spacing;
-			if (total_h > (get_size().height - style->get_minimum_size().height + line_spacing)) {
+			if (total_h > (get_rect_size().height - style->get_minimum_size().height + line_spacing)) {
 				break;
 			}
 			lines_visible++;
@@ -399,7 +399,7 @@ int Label::get_visible_line_count() const {
 	float total_h = 0.0;
 	for (int64_t i = lines_skipped; i < lines_rid.size(); i++) {
 		total_h += TS->shaped_text_get_size(lines_rid[i]).y + font->get_spacing(Font::SPACING_TOP) + font->get_spacing(Font::SPACING_BOTTOM) + line_spacing;
-		if (total_h > (get_size().height - style->get_minimum_size().height + line_spacing)) {
+		if (total_h > (get_rect_size().height - style->get_minimum_size().height + line_spacing)) {
 			break;
 		}
 		lines_visible++;
@@ -716,7 +716,7 @@ Label::Label(const String &p_text) {
 
 	set_mouse_filter(MOUSE_FILTER_IGNORE);
 	set_text(p_text);
-	set_v_size_flags(SIZE_SHRINK_CENTER);
+	set_size_flags_vertical(SIZE_SHRINK_CENTER);
 }
 
 Label::~Label() {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -348,7 +348,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 		if (context_menu_enabled) {
 			if (k->is_action("ui_menu", true)) {
-				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + get_theme_font("font")->get_height(get_theme_font_size("font_size"))) / 2);
+				Point2 pos = Point2(get_caret_pixel_pos().x, (get_rect_size().y + get_theme_font("font")->get_height(get_theme_font_size("font_size"))) / 2);
 				menu->set_position(get_global_transform().xform(pos));
 				menu->set_size(Vector2(1, 1));
 				_generate_context_menu();
@@ -556,11 +556,11 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 	}
 }
 
-Control::CursorShape LineEdit::get_cursor_shape(const Point2 &p_pos) const {
+Control::CursorShape LineEdit::get_mouse_cursor_shape(const Point2 &p_pos) const {
 	if (!text.is_empty() && is_editable() && _is_over_clear_button(p_pos)) {
 		return CURSOR_ARROW;
 	}
-	return Control::get_cursor_shape(p_pos);
+	return Control::get_mouse_cursor_shape(p_pos);
 }
 
 bool LineEdit::_is_over_clear_button(const Point2 &p_pos) const {
@@ -569,7 +569,7 @@ bool LineEdit::_is_over_clear_button(const Point2 &p_pos) const {
 	}
 	Ref<Texture2D> icon = Control::get_theme_icon("clear");
 	int x_ofs = get_theme_stylebox("normal")->get_offset().x;
-	return p_pos.x > get_size().width - icon->get_width() - x_ofs;
+	return p_pos.x > get_rect_size().width - icon->get_width() - x_ofs;
 }
 
 void LineEdit::_notification(int p_what) {
@@ -619,7 +619,7 @@ void LineEdit::_notification(int p_what) {
 			int width, height;
 			bool rtl = is_layout_rtl();
 
-			Size2 size = get_size();
+			Size2 size = get_rect_size();
 			width = size.width;
 			height = size.height;
 
@@ -854,7 +854,7 @@ void LineEdit::_notification(int p_what) {
 			if (has_focus()) {
 				if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 					DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
-					DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + Point2(using_placeholder ? 0 : x_ofs, y_ofs + TS->shaped_text_get_size(text_rid).y), get_viewport()->get_window_id());
+					DisplayServer::get_singleton()->window_set_ime_position(get_rect_global_position() + Point2(using_placeholder ? 0 : x_ofs, y_ofs + TS->shaped_text_get_size(text_rid).y), get_viewport()->get_window_id());
 				}
 			}
 		} break;
@@ -872,7 +872,7 @@ void LineEdit::_notification(int p_what) {
 			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 				DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
 				Point2 caret_column = Point2(get_caret_column(), 1) * get_minimum_size().height;
-				DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + caret_column, get_viewport()->get_window_id());
+				DisplayServer::get_singleton()->window_set_ime_position(get_rect_global_position() + caret_column, get_viewport()->get_window_id());
 			}
 
 			show_virtual_keyboard();
@@ -1015,7 +1015,7 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 		case ALIGN_FILL:
 		case ALIGN_LEFT: {
 			if (rtl) {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
 			} else {
 				x_ofs = style->get_offset().x;
 			}
@@ -1024,14 +1024,14 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 			if (scroll_offset != 0) {
 				x_ofs = style->get_offset().x;
 			} else {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - (text_width)) / 2);
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - (text_width)) / 2);
 			}
 		} break;
 		case ALIGN_RIGHT: {
 			if (rtl) {
 				x_ofs = style->get_offset().x;
 			} else {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
 			}
 		} break;
 	}
@@ -1042,7 +1042,7 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
 		if (align == ALIGN_CENTER) {
 			if (scroll_offset == 0) {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 			}
 		} else {
 			x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width() - style->get_margin(SIDE_RIGHT));
@@ -1063,7 +1063,7 @@ Vector2i LineEdit::get_caret_pixel_pos() {
 		case ALIGN_FILL:
 		case ALIGN_LEFT: {
 			if (rtl) {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
 			} else {
 				x_ofs = style->get_offset().x;
 			}
@@ -1072,14 +1072,14 @@ Vector2i LineEdit::get_caret_pixel_pos() {
 			if (scroll_offset != 0) {
 				x_ofs = style->get_offset().x;
 			} else {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - (text_width)) / 2);
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - (text_width)) / 2);
 			}
 		} break;
 		case ALIGN_RIGHT: {
 			if (rtl) {
 				x_ofs = style->get_offset().x;
 			} else {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
 			}
 		} break;
 	}
@@ -1090,7 +1090,7 @@ Vector2i LineEdit::get_caret_pixel_pos() {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
 		if (align == ALIGN_CENTER) {
 			if (scroll_offset == 0) {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 			}
 		} else {
 			x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width() - style->get_margin(SIDE_RIGHT));
@@ -1405,7 +1405,7 @@ void LineEdit::set_caret_column(int p_column) {
 		case ALIGN_FILL:
 		case ALIGN_LEFT: {
 			if (rtl) {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
 			} else {
 				x_ofs = style->get_offset().x;
 			}
@@ -1414,26 +1414,26 @@ void LineEdit::set_caret_column(int p_column) {
 			if (scroll_offset != 0) {
 				x_ofs = style->get_offset().x;
 			} else {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - (text_width)) / 2);
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - (text_width)) / 2);
 			}
 		} break;
 		case ALIGN_RIGHT: {
 			if (rtl) {
 				x_ofs = style->get_offset().x;
 			} else {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - style->get_margin(SIDE_RIGHT) - (text_width)));
 			}
 		} break;
 	}
 
-	int ofs_max = get_size().width - style->get_margin(SIDE_RIGHT);
+	int ofs_max = get_rect_size().width - style->get_margin(SIDE_RIGHT);
 	bool using_placeholder = text.is_empty() && ime_text.is_empty();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon("clear") : right_icon;
 		if (align == ALIGN_CENTER) {
 			if (scroll_offset == 0) {
-				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
+				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_rect_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 			}
 		} else {
 			x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width() - style->get_margin(SIDE_RIGHT));
@@ -1938,7 +1938,7 @@ void LineEdit::_shape() {
 void LineEdit::_fit_to_width() {
 	if (align == ALIGN_FILL) {
 		Ref<StyleBox> style = get_theme_stylebox("normal");
-		int t_width = get_size().width - style->get_margin(SIDE_RIGHT) - style->get_margin(SIDE_LEFT);
+		int t_width = get_rect_size().width - style->get_margin(SIDE_RIGHT) - style->get_margin(SIDE_LEFT);
 		bool using_placeholder = text.is_empty() && ime_text.is_empty();
 		bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 		if (right_icon.is_valid() || display_clear_icon) {
@@ -2232,7 +2232,7 @@ LineEdit::LineEdit() {
 
 	deselect();
 	set_focus_mode(FOCUS_ALL);
-	set_default_cursor_shape(CURSOR_IBEAM);
+	set_mouse_default_cursor_shape(CURSOR_IBEAM);
 	set_mouse_filter(MOUSE_FILTER_STOP);
 
 	caret_blink_timer = memnew(Timer);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -216,7 +216,7 @@ public:
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
 
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+	virtual CursorShape get_mouse_cursor_shape(const Point2 &p_pos) const override;
 
 	void menu_option(int p_option);
 	void set_context_menu_enabled(bool p_enable);

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -152,7 +152,7 @@ void LinkButton::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
-			Size2 size = get_size();
+			Size2 size = get_rect_size();
 			Color color;
 			bool do_underline = false;
 
@@ -303,5 +303,5 @@ void LinkButton::_bind_methods() {
 LinkButton::LinkButton() {
 	text_buf.instance();
 	set_focus_mode(FOCUS_NONE);
-	set_default_cursor_shape(CURSOR_POINTING_HAND);
+	set_mouse_default_cursor_shape(CURSOR_POINTING_HAND);
 }

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -73,7 +73,7 @@ void MarginContainer::_notification(int p_what) {
 			int margin_right = get_theme_constant("margin_right");
 			int margin_bottom = get_theme_constant("margin_bottom");
 
-			Size2 s = get_size();
+			Size2 s = get_rect_size();
 
 			for (int i = 0; i < get_child_count(); i++) {
 				Control *c = Object::cast_to<Control>(get_child(i));

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -56,15 +56,15 @@ void MenuButton::_unhandled_key_input(Ref<InputEvent> p_event) {
 }
 
 void MenuButton::pressed() {
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 
 	Point2 gp = get_screen_position();
-	gp.y += get_size().y;
+	gp.y += get_rect_size().y;
 
 	popup->set_position(gp);
 
 	popup->set_size(Size2(size.width, 0));
-	popup->set_parent_rect(Rect2(Point2(gp - popup->get_position()), get_size()));
+	popup->set_parent_rect(Rect2(Point2(gp - popup->get_position()), get_rect_size()));
 	popup->take_mouse_focus();
 	popup->popup();
 }

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -38,7 +38,7 @@ void NinePatchRect::_notification(int p_what) {
 			return;
 		}
 
-		Rect2 rect = Rect2(Point2(), get_size());
+		Rect2 rect = Rect2(Point2(), get_rect_size());
 		Rect2 src_rect = region_rect;
 
 		texture->get_rect_region(rect, src_rect, rect, src_rect);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -75,7 +75,7 @@ void OptionButton::_notification(int p_what) {
 				}
 			}
 
-			Size2 size = get_size();
+			Size2 size = get_rect_size();
 
 			Point2 ofs;
 			if (is_layout_rtl()) {
@@ -115,7 +115,7 @@ void OptionButton::_selected(int p_which) {
 }
 
 void OptionButton::pressed() {
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	popup->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
 	popup->set_size(Size2(size.width, 0));
 	popup->popup();

--- a/scene/gui/panel.cpp
+++ b/scene/gui/panel.cpp
@@ -36,7 +36,7 @@ void Panel::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
 		RID ci = get_canvas_item();
 		Ref<StyleBox> style = mode == MODE_BACKGROUND ? get_theme_stylebox("panel") : get_theme_stylebox("panel_fg");
-		style->draw(ci, Rect2(Point2(), get_size()));
+		style->draw(ci, Rect2(Point2(), get_rect_size()));
 	}
 }
 

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -71,7 +71,7 @@ void PanelContainer::_notification(int p_what) {
 			style = get_theme_stylebox("panel", "PanelContainer");
 		}
 
-		style->draw(ci, Rect2(Point2(), get_size()));
+		style->draw(ci, Rect2(Point2(), get_rect_size()));
 	}
 
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
@@ -83,7 +83,7 @@ void PanelContainer::_notification(int p_what) {
 			style = get_theme_stylebox("panel", "PanelContainer");
 		}
 
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 		Point2 ofs;
 		if (style.is_valid()) {
 			size -= style->get_minimum_size();

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -232,11 +232,11 @@ void PopupPanel::_update_child_rects() {
 		}
 
 		if (c == panel) {
-			c->set_position(Vector2());
-			c->set_size(get_size());
+			c->set_rect_position(Vector2());
+			c->set_rect_size(get_size());
 		} else {
-			c->set_position(cpos);
-			c->set_size(csize);
+			c->set_rect_position(cpos);
+			c->set_rect_size(csize);
 		}
 	}
 }

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -50,7 +50,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 	int hseparation = get_theme_constant("hseparation");
 
 	Size2 minsize = get_theme_stylebox("panel")->get_minimum_size(); // Accounts for margin in the margin container
-	minsize.x += scroll_container->get_v_scrollbar()->get_size().width * 2; // Adds a buffer so that the scrollbar does not render over the top of content
+	minsize.x += scroll_container->get_v_scrollbar()->get_rect_size().width * 2; // Adds a buffer so that the scrollbar does not render over the top of content
 
 	float max_w = 0.0;
 	float icon_w = 0.0;
@@ -146,14 +146,14 @@ void PopupMenu::_scroll_to_item(int p_item) {
 	ERR_FAIL_COND(p_item < 0);
 
 	// Scroll item into view (upwards)
-	if (items[p_item]._ofs_cache < -control->get_position().y) {
-		int amnt_over = items[p_item]._ofs_cache + control->get_position().y;
+	if (items[p_item]._ofs_cache < -control->get_rect_position().y) {
+		int amnt_over = items[p_item]._ofs_cache + control->get_rect_position().y;
 		scroll_container->set_v_scroll(scroll_container->get_v_scroll() + amnt_over);
 	}
 
 	// Scroll item into view (downwards)
-	if (items[p_item]._ofs_cache + items[p_item]._height_cache > -control->get_position().y + scroll_container->get_size().height) {
-		int amnt_over = items[p_item]._ofs_cache + items[p_item]._height_cache + control->get_position().y - scroll_container->get_size().height;
+	if (items[p_item]._ofs_cache + items[p_item]._height_cache > -control->get_rect_position().y + scroll_container->get_rect_size().height) {
+		int amnt_over = items[p_item]._ofs_cache + items[p_item]._height_cache + control->get_rect_position().y - scroll_container->get_rect_size().height;
 		scroll_container->set_v_scroll(scroll_container->get_v_scroll() + amnt_over);
 	}
 }
@@ -178,7 +178,7 @@ int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
 
 		ofs.y += _get_item_height(i);
 
-		if (p_over.y - control->get_position().y < ofs.y) {
+		if (p_over.y - control->get_rect_position().y < ofs.y) {
 			return i;
 		}
 	}
@@ -201,7 +201,7 @@ void PopupMenu::_activate_submenu(int p_over) {
 	Point2 this_pos = get_position();
 	Rect2 this_rect(this_pos, get_size());
 
-	float scroll_offset = control->get_position().y;
+	float scroll_offset = control->get_rect_position().y;
 
 	Point2 submenu_pos;
 	Size2 submenu_size = submenu_popup->get_size();
@@ -236,7 +236,7 @@ void PopupMenu::_activate_submenu(int p_over) {
 		submenu_pum->add_autohide_area(Rect2(this_rect.position.x, this_rect.position.y, this_rect.size.x, items[p_over]._ofs_cache + scroll_offset + style->get_offset().height - vsep / 2));
 
 		// If there is an area below the submenu item, add an autohide area there.
-		if (items[p_over]._ofs_cache + items[p_over]._height_cache + scroll_offset <= control->get_size().height) {
+		if (items[p_over]._ofs_cache + items[p_over]._height_cache + scroll_offset <= control->get_rect_size().height) {
 			int from = items[p_over]._ofs_cache + items[p_over]._height_cache + scroll_offset + vsep / 2 + style->get_offset().height;
 			submenu_pum->add_autohide_area(Rect2(this_rect.position.x, this_rect.position.y + from, this_rect.size.x, this_rect.size.y - from));
 		}
@@ -344,9 +344,9 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 	Rect2 item_clickable_area = scroll_container->get_rect();
 	if (scroll_container->get_v_scrollbar()->is_visible_in_tree()) {
 		if (is_layout_rtl()) {
-			item_clickable_area.position.x += scroll_container->get_v_scrollbar()->get_size().width;
+			item_clickable_area.position.x += scroll_container->get_v_scrollbar()->get_rect_size().width;
 		} else {
-			item_clickable_area.size.width -= scroll_container->get_v_scrollbar()->get_size().width;
+			item_clickable_area.size.width -= scroll_container->get_v_scrollbar()->get_rect_size().width;
 		}
 	}
 
@@ -470,7 +470,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void PopupMenu::_draw_items() {
-	control->set_custom_minimum_size(Size2(0, _get_items_total_height()));
+	control->set_rect_minimum_size(Size2(0, _get_items_total_height()));
 	RID ci = control->get_canvas_item();
 
 	Size2 margin_size;
@@ -506,8 +506,8 @@ void PopupMenu::_draw_items() {
 	Color font_hover_color = get_theme_color("font_hover_color");
 	Color font_separator_color = get_theme_color("font_separator_color");
 
-	float scroll_width = scroll_container->get_v_scrollbar()->is_visible_in_tree() ? scroll_container->get_v_scrollbar()->get_size().width : 0;
-	float display_width = control->get_size().width - scroll_width;
+	float scroll_width = scroll_container->get_v_scrollbar()->is_visible_in_tree() ? scroll_container->get_v_scrollbar()->get_rect_size().width : 0;
+	float display_width = control->get_rect_size().width - scroll_width;
 
 	// Find the widest icon and whether any items have a checkbox, and store the offsets for each.
 	float icon_ofs = 0.0;
@@ -581,7 +581,7 @@ void PopupMenu::_draw_items() {
 		if (items[i].checkable_type) {
 			Texture2D *icon = (items[i].checked ? check[items[i].checkable_type - 1] : uncheck[items[i].checkable_type - 1]).ptr();
 			if (rtl) {
-				icon->draw(ci, Size2(control->get_size().width - item_ofs.x - icon->get_width(), item_ofs.y) + Point2(0, Math::floor((h - icon->get_height()) / 2.0)), icon_color);
+				icon->draw(ci, Size2(control->get_rect_size().width - item_ofs.x - icon->get_width(), item_ofs.y) + Point2(0, Math::floor((h - icon->get_height()) / 2.0)), icon_color);
 			} else {
 				icon->draw(ci, item_ofs + Point2(0, Math::floor((h - icon->get_height()) / 2.0)), icon_color);
 			}
@@ -590,7 +590,7 @@ void PopupMenu::_draw_items() {
 		// Icon
 		if (!items[i].icon.is_null()) {
 			if (rtl) {
-				items[i].icon->draw(ci, Size2(control->get_size().width - item_ofs.x - check_ofs - icon_size.width, item_ofs.y) + Point2(0, Math::floor((h - icon_size.height) / 2.0)), icon_color);
+				items[i].icon->draw(ci, Size2(control->get_rect_size().width - item_ofs.x - check_ofs - icon_size.width, item_ofs.y) + Point2(0, Math::floor((h - icon_size.height) / 2.0)), icon_color);
 			} else {
 				items[i].icon->draw(ci, item_ofs + Size2(check_ofs, 0) + Point2(0, Math::floor((h - icon_size.height) / 2.0)), icon_color);
 			}
@@ -620,7 +620,7 @@ void PopupMenu::_draw_items() {
 		} else {
 			item_ofs.x += icon_ofs + check_ofs;
 			if (rtl) {
-				Vector2 text_pos = Size2(control->get_size().width - items[i].text_buf->get_size().width - item_ofs.x, item_ofs.y) + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
+				Vector2 text_pos = Size2(control->get_rect_size().width - items[i].text_buf->get_size().width - item_ofs.x, item_ofs.y) + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
 				if (outline_size > 0 && font_outline_color.a > 0) {
 					items[i].text_buf->draw_outline(ci, text_pos, outline_size, font_outline_color);
 				}
@@ -659,7 +659,7 @@ void PopupMenu::_draw_items() {
 void PopupMenu::_draw_background() {
 	Ref<StyleBox> style = get_theme_stylebox("panel");
 	RID ci2 = margin_container->get_canvas_item();
-	style->draw(ci2, Rect2(Point2(), margin_container->get_size()));
+	style->draw(ci2, Rect2(Point2(), margin_container->get_rect_size()));
 }
 
 void PopupMenu::_minimum_lifetime_timeout() {
@@ -1695,15 +1695,15 @@ PopupMenu::PopupMenu() {
 
 	// Scroll Container
 	scroll_container = memnew(ScrollContainer);
-	scroll_container->set_clip_contents(true);
+	scroll_container->set_rect_clip_contents(true);
 	margin_container->add_child(scroll_container);
 
 	// The control which will display the items
 	control = memnew(Control);
-	control->set_clip_contents(false);
+	control->set_rect_clip_contents(false);
 	control->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-	control->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	control->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	control->set_size_flags_horizontal(Control::SIZE_EXPAND_FILL);
+	control->set_size_flags_vertical(Control::SIZE_EXPAND_FILL);
 	scroll_container->add_child(control);
 	control->connect("draw", callable_mp(this, &PopupMenu::_draw_items));
 

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -59,22 +59,22 @@ void ProgressBar::_notification(int p_what) {
 		int font_size = get_theme_font_size("font_size");
 		Color font_color = get_theme_color("font_color");
 
-		draw_style_box(bg, Rect2(Point2(), get_size()));
+		draw_style_box(bg, Rect2(Point2(), get_rect_size()));
 		float r = get_as_ratio();
 		int mp = fg->get_minimum_size().width;
-		int p = r * (get_size().width - mp);
+		int p = r * (get_rect_size().width - mp);
 		if (p > 0) {
 			if (is_layout_rtl()) {
-				draw_style_box(fg, Rect2(Point2(p, 0), Size2(fg->get_minimum_size().width, get_size().height)));
+				draw_style_box(fg, Rect2(Point2(p, 0), Size2(fg->get_minimum_size().width, get_rect_size().height)));
 			} else {
-				draw_style_box(fg, Rect2(Point2(0, 0), Size2(p + fg->get_minimum_size().width, get_size().height)));
+				draw_style_box(fg, Rect2(Point2(0, 0), Size2(p + fg->get_minimum_size().width, get_rect_size().height)));
 			}
 		}
 
 		if (percent_visible) {
 			String txt = TS->format_number(itos(int(get_as_ratio() * 100))) + TS->percent_sign();
 			TextLine tl = TextLine(txt, font, font_size);
-			Vector2 text_pos = (Point2(get_size().width - tl.get_size().x, get_size().height - tl.get_size().y) / 2).round();
+			Vector2 text_pos = (Point2(get_rect_size().width - tl.get_size().x, get_rect_size().height - tl.get_size().y) / 2).round();
 			Color font_outline_color = get_theme_color("font_outline_color");
 			int outline_size = get_theme_constant("outline_size");
 			if (outline_size > 0 && font_outline_color.a > 0) {
@@ -102,6 +102,6 @@ void ProgressBar::_bind_methods() {
 }
 
 ProgressBar::ProgressBar() {
-	set_v_size_flags(0);
+	set_size_flags_vertical(0);
 	set_step(0.01);
 }

--- a/scene/gui/reference_rect.cpp
+++ b/scene/gui/reference_rect.cpp
@@ -38,7 +38,7 @@ void ReferenceRect::_notification(int p_what) {
 			return;
 		}
 		if (Engine::get_singleton()->is_editor_hint() || !editor_only) {
-			draw_rect(Rect2(Point2(), get_size()), border_color, false, border_width);
+			draw_rect(Rect2(Point2(), get_rect_size()), border_color, false, border_width);
 		}
 	}
 }

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -137,7 +137,7 @@ RichTextLabel::Item *RichTextLabel::_get_prev_item(Item *p_item, bool p_free) co
 
 Rect2 RichTextLabel::_get_text_rect() {
 	Ref<StyleBox> style = get_theme_stylebox("normal");
-	return Rect2(style->get_offset(), get_size() - style->get_minimum_size());
+	return Rect2(style->get_offset(), get_rect_size() - style->get_minimum_size());
 }
 
 RichTextLabel::Item *RichTextLabel::_get_item_at_pos(RichTextLabel::Item *p_item_from, RichTextLabel::Item *p_item_to, int p_position) {
@@ -702,7 +702,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 	l.text_buf->draw_dropcap(ci, p_ofs + ((rtl) ? Vector2() : Vector2(l.offset.x, 0)), l.dc_color);
 
 	int line_count = 0;
-	Size2 ctrl_size = get_size();
+	Size2 ctrl_size = get_rect_size();
 	// Draw text.
 	for (int line = 0; line < l.text_buf->get_line_count(); line++) {
 		RID rid = l.text_buf->get_line_rid(line);
@@ -1096,7 +1096,7 @@ void RichTextLabel::_find_click(ItemFrame *p_frame, const Point2i &p_click, Item
 		*r_outside = true;
 	}
 
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	Rect2 text_rect = _get_text_rect();
 
 	int vofs = vscroll->get_value();
@@ -1212,7 +1212,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 											crect.size.x = crect.position.x + crect.size.x;
 											crect.position.x = 0;
 										} else {
-											crect.size.x = get_size().x;
+											crect.size.x = get_rect_size().x;
 										}
 									}
 									if (crect.has_point(p_click)) {
@@ -1233,7 +1233,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 				}
 			}
 		}
-		Rect2 rect = Rect2(p_ofs + off - Vector2(0, TS->shaped_text_get_ascent(rid)), Size2(get_size().x, TS->shaped_text_get_size(rid).y));
+		Rect2 rect = Rect2(p_ofs + off - Vector2(0, TS->shaped_text_get_ascent(rid)), Size2(get_rect_size().x, TS->shaped_text_get_size(rid).y));
 
 		if (rect.has_point(p_click) && !table_hit) {
 			char_pos = TS->shaped_text_hit_test_position(rid, p_click.x - rect.position.x);
@@ -1296,7 +1296,7 @@ void RichTextLabel::_scroll_changed(double) {
 void RichTextLabel::_update_scroll() {
 	int total_height = get_content_height();
 
-	bool exceeds = total_height > get_size().height && scroll_active;
+	bool exceeds = total_height > get_rect_size().height && scroll_active;
 
 	if (exceeds != scroll_visible) {
 		if (exceeds) {
@@ -1384,7 +1384,7 @@ void RichTextLabel::_notification(int p_what) {
 
 			RID ci = get_canvas_item();
 
-			Size2 size = get_size();
+			Size2 size = get_rect_size();
 			Rect2 text_rect = _get_text_rect();
 
 			draw_style_box(get_theme_stylebox("normal"), Rect2(Point2(), size));
@@ -1440,7 +1440,7 @@ void RichTextLabel::_notification(int p_what) {
 	}
 }
 
-Control::CursorShape RichTextLabel::get_cursor_shape(const Point2 &p_pos) const {
+Control::CursorShape RichTextLabel::get_mouse_cursor_shape(const Point2 &p_pos) const {
 	if (!underline_meta) {
 		return CURSOR_ARROW;
 	}
@@ -2060,7 +2060,7 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 		}
 
 		// Resize lines without reshaping.
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 		if (fixed_width != -1) {
 			size.width = fixed_width;
 		}
@@ -2095,7 +2095,7 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 	}
 
 	// Shape invalid lines.
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	if (fixed_width != -1) {
 		size.width = fixed_width;
 	}
@@ -4114,7 +4114,7 @@ RichTextLabel::RichTextLabel() {
 	vscroll->set_step(1);
 	vscroll->hide();
 
-	set_clip_contents(true);
+	set_rect_clip_contents(true);
 }
 
 RichTextLabel::~RichTextLabel() {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -519,7 +519,7 @@ public:
 
 	VScrollBar *get_v_scroll() { return vscroll; }
 
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+	virtual CursorShape get_mouse_cursor_shape(const Point2 &p_pos) const override;
 
 	void set_selection_enabled(bool p_enabled);
 	bool is_selection_enabled() const;

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -77,7 +77,7 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
 			double grabber_ofs = get_grabber_offset();
 			double grabber_size = get_grabber_size();
-			double total = orientation == VERTICAL ? get_size().height : get_size().width;
+			double total = orientation == VERTICAL ? get_rect_size().height : get_rect_size().width;
 
 			if (ofs < decr_size) {
 				set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
@@ -155,7 +155,7 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 
 			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
 			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
-			double total = orientation == VERTICAL ? get_size().height : get_size().width;
+			double total = orientation == VERTICAL ? get_rect_size().height : get_rect_size().width;
 
 			HighlightStatus new_hilite;
 
@@ -238,7 +238,7 @@ void ScrollBar::_notification(int p_what) {
 			ofs.y += decr->get_height();
 		}
 
-		Size2 area = get_size();
+		Size2 area = get_rect_size();
 
 		if (orientation == HORIZONTAL) {
 			area.width -= incr->get_width() + decr->get_width();
@@ -259,11 +259,11 @@ void ScrollBar::_notification(int p_what) {
 
 		if (orientation == HORIZONTAL) {
 			grabber_rect.size.width = get_grabber_size();
-			grabber_rect.size.height = get_size().height;
+			grabber_rect.size.height = get_rect_size().height;
 			grabber_rect.position.y = 0;
 			grabber_rect.position.x = get_grabber_offset() + decr->get_width() + bg->get_margin(SIDE_LEFT);
 		} else {
-			grabber_rect.size.width = get_size().width;
+			grabber_rect.size.width = get_rect_size().width;
 			grabber_rect.size.height = get_grabber_size();
 			grabber_rect.position.y = get_grabber_offset() + decr->get_height() + bg->get_margin(SIDE_TOP);
 			grabber_rect.position.x = 0;
@@ -414,7 +414,7 @@ double ScrollBar::get_grabber_size() const {
 double ScrollBar::get_area_size() const {
 	switch (orientation) {
 		case VERTICAL: {
-			double area = get_size().height;
+			double area = get_rect_size().height;
 			area -= get_theme_stylebox("scroll")->get_minimum_size().height;
 			area -= get_theme_icon("increment")->get_height();
 			area -= get_theme_icon("decrement")->get_height();
@@ -422,7 +422,7 @@ double ScrollBar::get_area_size() const {
 			return area;
 		} break;
 		case HORIZONTAL: {
-			double area = get_size().width;
+			double area = get_rect_size().width;
 			area -= get_theme_stylebox("scroll")->get_minimum_size().width;
 			area -= get_theme_icon("increment")->get_width();
 			area -= get_theme_icon("decrement")->get_width();

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -114,7 +114,7 @@ class HScrollBar : public ScrollBar {
 
 public:
 	HScrollBar() :
-			ScrollBar(HORIZONTAL) { set_v_size_flags(0); }
+			ScrollBar(HORIZONTAL) { set_size_flags_vertical(0); }
 };
 
 class VScrollBar : public ScrollBar {
@@ -122,7 +122,7 @@ class VScrollBar : public ScrollBar {
 
 public:
 	VScrollBar() :
-			ScrollBar(VERTICAL) { set_h_size_flags(0); }
+			ScrollBar(VERTICAL) { set_size_flags_horizontal(0); }
 };
 
 #endif

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -248,11 +248,11 @@ void ScrollContainer::_ensure_focused_visible(Control *p_control) {
 		Rect2 other_rect = p_control->get_global_rect();
 		float right_margin = 0.0;
 		if (v_scroll->is_visible()) {
-			right_margin += v_scroll->get_size().x;
+			right_margin += v_scroll->get_rect_size().x;
 		}
 		float bottom_margin = 0.0;
 		if (h_scroll->is_visible()) {
-			bottom_margin += h_scroll->get_size().y;
+			bottom_margin += h_scroll->get_rect_size().y;
 		}
 
 		float diff = MAX(MIN(other_rect.position.y, global_rect.position.y), other_rect.position.y + other_rect.size.y - global_rect.size.y + bottom_margin);
@@ -268,7 +268,7 @@ void ScrollContainer::_ensure_focused_visible(Control *p_control) {
 
 void ScrollContainer::_update_dimensions() {
 	child_max_size = Size2(0, 0);
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	Point2 ofs;
 
 	Ref<StyleBox> sb = get_theme_stylebox("bg");
@@ -300,17 +300,17 @@ void ScrollContainer::_update_dimensions() {
 		child_max_size.y = MAX(child_max_size.y, minsize.y);
 
 		Rect2 r = Rect2(-scroll, minsize);
-		if (!scroll_h || (!h_scroll->is_visible_in_tree() && c->get_h_size_flags() & SIZE_EXPAND)) {
+		if (!scroll_h || (!h_scroll->is_visible_in_tree() && c->get_size_flags_horizontal() & SIZE_EXPAND)) {
 			r.position.x = 0;
-			if (c->get_h_size_flags() & SIZE_EXPAND) {
+			if (c->get_size_flags_horizontal() & SIZE_EXPAND) {
 				r.size.width = MAX(size.width, minsize.width);
 			} else {
 				r.size.width = minsize.width;
 			}
 		}
-		if (!scroll_v || (!v_scroll->is_visible_in_tree() && c->get_v_size_flags() & SIZE_EXPAND)) {
+		if (!scroll_v || (!v_scroll->is_visible_in_tree() && c->get_size_flags_vertical() & SIZE_EXPAND)) {
 			r.position.y = 0;
-			if (c->get_v_size_flags() & SIZE_EXPAND) {
+			if (c->get_size_flags_vertical() & SIZE_EXPAND) {
 				r.size.height = MAX(size.height, minsize.height);
 			} else {
 				r.size.height = minsize.height;
@@ -344,7 +344,7 @@ void ScrollContainer::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_DRAW) {
 		Ref<StyleBox> sb = get_theme_stylebox("bg");
-		draw_style_box(sb, Rect2(Vector2(), get_size()));
+		draw_style_box(sb, Rect2(Vector2(), get_rect_size()));
 
 		update_scrollbars();
 	}
@@ -419,7 +419,7 @@ void ScrollContainer::_notification(int p_what) {
 };
 
 void ScrollContainer::update_scrollbars() {
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	Ref<StyleBox> sb = get_theme_stylebox("bg");
 	size -= sb->get_minimum_size();
 
@@ -626,5 +626,5 @@ ScrollContainer::ScrollContainer() {
 
 	deadzone = GLOBAL_GET("gui/common/default_scroll_deadzone");
 
-	set_clip_contents(true);
+	set_rect_clip_contents(true);
 };

--- a/scene/gui/separator.cpp
+++ b/scene/gui/separator.cpp
@@ -43,7 +43,7 @@ Size2 Separator::get_minimum_size() const {
 void Separator::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			Size2i size = get_size();
+			Size2i size = get_rect_size();
 			Ref<StyleBox> style = get_theme_stylebox("separator");
 			Size2i ssize = style->get_minimum_size() + style->get_center_size();
 

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -62,7 +62,7 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 
 				double grab_width = (double)grabber->get_size().width;
 				double grab_height = (double)grabber->get_size().height;
-				double max = orientation == VERTICAL ? get_size().height - grab_height : get_size().width - grab_width;
+				double max = orientation == VERTICAL ? get_rect_size().height - grab_height : get_rect_size().width - grab_width;
 				if (orientation == VERTICAL) {
 					set_as_ratio(1 - (((double)grab.pos - (grab_height / 2.0)) / max));
 				} else {
@@ -88,7 +88,7 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 
 	if (mm.is_valid()) {
 		if (grab.active) {
-			Size2i size = get_size();
+			Size2i size = get_rect_size();
 			Ref<Texture2D> grabber = get_theme_icon("grabber");
 			float motion = (orientation == VERTICAL ? mm->get_position().y : mm->get_position().x) - grab.pos;
 			if (orientation == VERTICAL) {
@@ -160,7 +160,7 @@ void Slider::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
-			Size2i size = get_size();
+			Size2i size = get_rect_size();
 			Ref<StyleBox> style = get_theme_stylebox("slider");
 			bool highlighted = mouse_inside || has_focus();
 			Ref<StyleBox> grabber_area = get_theme_stylebox(highlighted ? "grabber_area_highlight" : "grabber_area");

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -81,7 +81,7 @@ class HSlider : public Slider {
 
 public:
 	HSlider() :
-			Slider(HORIZONTAL) { set_v_size_flags(0); }
+			Slider(HORIZONTAL) { set_size_flags_vertical(0); }
 };
 
 class VSlider : public Slider {
@@ -89,7 +89,7 @@ class VSlider : public Slider {
 
 public:
 	VSlider() :
-			Slider(VERTICAL) { set_h_size_flags(0); }
+			Slider(VERTICAL) { set_size_flags_horizontal(0); }
 };
 
 #endif // SLIDER_H

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -77,7 +77,7 @@ void SpinBox::_line_edit_input(const Ref<InputEvent> &p_event) {
 
 void SpinBox::_range_click_timeout() {
 	if (!drag.enabled && Input::get_singleton()->is_mouse_button_pressed(MOUSE_BUTTON_LEFT)) {
-		bool up = get_local_mouse_position().y < (get_size().height / 2);
+		bool up = get_local_mouse_position().y < (get_rect_size().height / 2);
 		set_value(get_value() + (up ? get_step() : -get_step()));
 
 		if (range_click_timer->is_one_shot()) {
@@ -109,7 +109,7 @@ void SpinBox::_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid() && mb->is_pressed()) {
-		bool up = mb->get_position().y < (get_size().height / 2);
+		bool up = mb->get_position().y < (get_rect_size().height / 2);
 
 		switch (mb->get_button_index()) {
 			case MOUSE_BUTTON_LEFT: {
@@ -191,7 +191,7 @@ void SpinBox::_notification(int p_what) {
 		_adjust_width_for_icon(updown);
 
 		RID ci = get_canvas_item();
-		Size2i size = get_size();
+		Size2i size = get_rect_size();
 
 		if (is_layout_rtl()) {
 			updown->draw(ci, Point2i(0, (size.height - updown->get_height()) / 2));

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -64,16 +64,16 @@ void SplitContainer::_resort() {
 	// If we have only one element
 	if (!first || !second) {
 		if (first) {
-			fit_child_in_rect(first, Rect2(Point2(), get_size()));
+			fit_child_in_rect(first, Rect2(Point2(), get_rect_size()));
 		} else if (second) {
-			fit_child_in_rect(second, Rect2(Point2(), get_size()));
+			fit_child_in_rect(second, Rect2(Point2(), get_rect_size()));
 		}
 		return;
 	}
 
 	// Determine expanded children
-	bool first_expanded = (vertical ? first->get_v_size_flags() : first->get_h_size_flags()) & SIZE_EXPAND;
-	bool second_expanded = (vertical ? second->get_v_size_flags() : second->get_h_size_flags()) & SIZE_EXPAND;
+	bool first_expanded = (vertical ? first->get_size_flags_vertical() : first->get_size_flags_horizontal()) & SIZE_EXPAND;
+	bool second_expanded = (vertical ? second->get_size_flags_vertical() : second->get_size_flags_horizontal()) & SIZE_EXPAND;
 
 	// Determine the separation between items
 	Ref<Texture2D> g = get_theme_icon("grabber");
@@ -85,12 +85,12 @@ void SplitContainer::_resort() {
 	Size2 ms_second = second->get_combined_minimum_size();
 
 	// Compute the separator position without the split offset
-	float ratio = first->get_stretch_ratio() / (first->get_stretch_ratio() + second->get_stretch_ratio());
+	float ratio = first->get_size_flags_stretch_ratio() / (first->get_size_flags_stretch_ratio() + second->get_size_flags_stretch_ratio());
 	int no_offset_middle_sep = 0;
 	if (first_expanded && second_expanded) {
-		no_offset_middle_sep = get_size()[axis] * ratio - sep / 2;
+		no_offset_middle_sep = get_rect_size()[axis] * ratio - sep / 2;
 	} else if (first_expanded) {
-		no_offset_middle_sep = get_size()[axis] - ms_second[axis] - sep;
+		no_offset_middle_sep = get_rect_size()[axis] - ms_second[axis] - sep;
 	} else {
 		no_offset_middle_sep = ms_first[axis];
 	}
@@ -98,7 +98,7 @@ void SplitContainer::_resort() {
 	// Compute the final middle separation
 	middle_sep = no_offset_middle_sep;
 	if (!collapsed) {
-		int clamped_split_offset = CLAMP(split_offset, ms_first[axis] - no_offset_middle_sep, (get_size()[axis] - ms_second[axis] - sep) - no_offset_middle_sep);
+		int clamped_split_offset = CLAMP(split_offset, ms_first[axis] - no_offset_middle_sep, (get_rect_size()[axis] - ms_second[axis] - sep) - no_offset_middle_sep);
 		middle_sep += clamped_split_offset;
 		if (should_clamp_split_offset) {
 			split_offset = clamped_split_offset;
@@ -108,19 +108,19 @@ void SplitContainer::_resort() {
 	}
 
 	if (vertical) {
-		fit_child_in_rect(first, Rect2(Point2(0, 0), Size2(get_size().width, middle_sep)));
+		fit_child_in_rect(first, Rect2(Point2(0, 0), Size2(get_rect_size().width, middle_sep)));
 		int sofs = middle_sep + sep;
-		fit_child_in_rect(second, Rect2(Point2(0, sofs), Size2(get_size().width, get_size().height - sofs)));
+		fit_child_in_rect(second, Rect2(Point2(0, sofs), Size2(get_rect_size().width, get_rect_size().height - sofs)));
 	} else {
 		if (is_layout_rtl()) {
-			middle_sep = get_size().width - middle_sep - sep;
-			fit_child_in_rect(second, Rect2(Point2(0, 0), Size2(middle_sep, get_size().height)));
+			middle_sep = get_rect_size().width - middle_sep - sep;
+			fit_child_in_rect(second, Rect2(Point2(0, 0), Size2(middle_sep, get_rect_size().height)));
 			int sofs = middle_sep + sep;
-			fit_child_in_rect(first, Rect2(Point2(sofs, 0), Size2(get_size().width - sofs, get_size().height)));
+			fit_child_in_rect(first, Rect2(Point2(sofs, 0), Size2(get_rect_size().width - sofs, get_rect_size().height)));
 		} else {
-			fit_child_in_rect(first, Rect2(Point2(0, 0), Size2(middle_sep, get_size().height)));
+			fit_child_in_rect(first, Rect2(Point2(0, 0), Size2(middle_sep, get_rect_size().height)));
 			int sofs = middle_sep + sep;
-			fit_child_in_rect(second, Rect2(Point2(sofs, 0), Size2(get_size().width - sofs, get_size().height)));
+			fit_child_in_rect(second, Rect2(Point2(sofs, 0), Size2(get_rect_size().width - sofs, get_rect_size().height)));
 		}
 	}
 
@@ -192,7 +192,7 @@ void SplitContainer::_notification(int p_what) {
 
 			int sep = dragger_visibility != DRAGGER_HIDDEN_COLLAPSED ? get_theme_constant("separation") : 0;
 			Ref<Texture2D> tex = get_theme_icon("grabber");
-			Size2 size = get_size();
+			Size2 size = get_rect_size();
 
 			if (vertical) {
 				draw_texture(tex, Point2i((size.x - tex->get_width()) / 2, middle_sep + (sep - tex->get_height()) / 2));
@@ -271,7 +271,7 @@ void SplitContainer::_gui_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
-Control::CursorShape SplitContainer::get_cursor_shape(const Point2 &p_pos) const {
+Control::CursorShape SplitContainer::get_mouse_cursor_shape(const Point2 &p_pos) const {
 	if (dragging) {
 		return (vertical ? CURSOR_VSPLIT : CURSOR_HSPLIT);
 	}
@@ -290,7 +290,7 @@ Control::CursorShape SplitContainer::get_cursor_shape(const Point2 &p_pos) const
 		}
 	}
 
-	return Control::get_cursor_shape(p_pos);
+	return Control::get_mouse_cursor_shape(p_pos);
 }
 
 void SplitContainer::set_split_offset(int p_offset) {

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -75,7 +75,7 @@ public:
 	void set_dragger_visibility(DraggerVisibility p_visibility);
 	DraggerVisibility get_dragger_visibility() const;
 
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
+	virtual CursorShape get_mouse_cursor_shape(const Point2 &p_pos = Point2i()) const override;
 
 	virtual Size2 get_minimum_size() const override;
 

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -80,7 +80,7 @@ void SubViewportContainer::set_stretch_shrink(int p_shrink) {
 			continue;
 		}
 
-		c->set_size(get_size() / shrink);
+		c->set_size(get_rect_size() / shrink);
 	}
 
 	update();
@@ -102,7 +102,7 @@ void SubViewportContainer::_notification(int p_what) {
 				continue;
 			}
 
-			c->set_size(get_size() / shrink);
+			c->set_size(get_rect_size() / shrink);
 		}
 	}
 
@@ -131,7 +131,7 @@ void SubViewportContainer::_notification(int p_what) {
 			}
 
 			if (stretch) {
-				draw_texture_rect(c->get_texture(), Rect2(Vector2(), get_size()));
+				draw_texture_rect(c->get_texture(), Rect2(Vector2(), get_rect_size()));
 			} else {
 				draw_texture_rect(c->get_texture(), Rect2(Vector2(), c->get_size()));
 			}

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -80,7 +80,7 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
 		Point2 pos(mb->get_position().x, mb->get_position().y);
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 
 		// Click must be on tabs in the tab header area.
 		if (pos.y > _get_top_margin()) {
@@ -191,7 +191,7 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mm.is_valid()) {
 		Point2 pos(mm->get_position().x, mm->get_position().y);
-		Size2 size = get_size();
+		Size2 size = get_rect_size();
 
 		// Mouse must be on tabs in the tab header area.
 		if (pos.y > _get_top_margin()) {
@@ -293,7 +293,7 @@ void TabContainer::_notification(int p_what) {
 			Ref<Texture2D> menu = get_theme_icon("menu");
 			Ref<Texture2D> increment = get_theme_icon("increment");
 			Ref<Texture2D> decrement = get_theme_icon("decrement");
-			int header_width = get_size().width - side_margin * 2;
+			int header_width = get_rect_size().width - side_margin * 2;
 
 			// Find the width of the header area.
 			Popup *popup = get_popup();
@@ -328,7 +328,7 @@ void TabContainer::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_DRAW: {
 			RID canvas = get_canvas_item();
-			Size2 size = get_size();
+			Size2 size = get_rect_size();
 			bool rtl = is_layout_rtl();
 
 			// Draw only the tab area if the header is hidden.
@@ -471,7 +471,7 @@ void TabContainer::_notification(int p_what) {
 			if (rtl) {
 				x = 0;
 			} else {
-				x = get_size().width;
+				x = get_rect_size().width;
 			}
 			if (popup) {
 				if (!rtl) {
@@ -929,7 +929,7 @@ int TabContainer::get_tab_idx_at_point(const Point2 &p_point) const {
 		return -1;
 	}
 
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	int button_ofs = 0;
 	int px = p_point.x;
 

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -110,7 +110,7 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 					highlight_arrow = 0;
 				}
 			} else {
-				int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
+				int limit_minus_buttons = get_rect_size().width - incr->get_width() - decr->get_width();
 				if (pos.x > limit_minus_buttons + decr->get_width()) {
 					highlight_arrow = 1;
 				} else if (pos.x > limit_minus_buttons) {
@@ -188,7 +188,7 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 						return;
 					}
 				} else {
-					int limit = get_size().width - incr->get_width() - decr->get_width();
+					int limit = get_rect_size().width - incr->get_width() - decr->get_width();
 					if (pos.x > limit + decr->get_width()) {
 						if (missing_right) {
 							offset++;
@@ -283,10 +283,10 @@ void Tabs::_notification(int p_what) {
 			Color font_outline_color = get_theme_color("font_outline_color");
 			int outline_size = get_theme_constant("outline_size");
 
-			Vector2 size = get_size();
+			Vector2 size = get_rect_size();
 			bool rtl = is_layout_rtl();
 
-			int h = get_size().height;
+			int h = get_rect_size().height;
 			int w = 0;
 			int mw = 0;
 
@@ -296,9 +296,9 @@ void Tabs::_notification(int p_what) {
 			}
 
 			if (tab_align == ALIGN_CENTER) {
-				w = (get_size().width - mw) / 2;
+				w = (get_rect_size().width - mw) / 2;
 			} else if (tab_align == ALIGN_RIGHT) {
-				w = get_size().width - mw;
+				w = get_rect_size().width - mw;
 			}
 
 			if (w < 0) {
@@ -310,8 +310,8 @@ void Tabs::_notification(int p_what) {
 			Ref<Texture2D> incr_hl = get_theme_icon("increment_highlight");
 			Ref<Texture2D> decr_hl = get_theme_icon("decrement_highlight");
 
-			int limit = get_size().width;
-			int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
+			int limit = get_rect_size().width;
+			int limit_minus_buttons = get_rect_size().width - incr->get_width() - decr->get_width();
 
 			missing_right = false;
 
@@ -450,7 +450,7 @@ void Tabs::_notification(int p_what) {
 			}
 
 			if (offset > 0 || missing_right) {
-				int vofs = (get_size().height - incr->get_size().height) / 2;
+				int vofs = (get_rect_size().height - incr->get_size().height) / 2;
 
 				if (rtl) {
 					if (missing_right) {
@@ -673,7 +673,7 @@ void Tabs::_update_cache() {
 	Ref<StyleBox> tab_selected = get_theme_stylebox("tab_selected");
 	Ref<Texture2D> incr = get_theme_icon("increment");
 	Ref<Texture2D> decr = get_theme_icon("decrement");
-	int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
+	int limit_minus_buttons = get_rect_size().width - incr->get_width() - decr->get_width();
 
 	int w = 0;
 	int mw = 0;
@@ -995,8 +995,8 @@ void Tabs::_ensure_no_over_offset() {
 	Ref<Texture2D> incr = get_theme_icon("increment");
 	Ref<Texture2D> decr = get_theme_icon("decrement");
 
-	int limit = get_size().width;
-	int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
+	int limit = get_rect_size().width;
+	int limit_minus_buttons = get_rect_size().width - incr->get_width() - decr->get_width();
 
 	while (offset > 0) {
 		int total_w = 0;
@@ -1035,8 +1035,8 @@ void Tabs::ensure_tab_visible(int p_idx) {
 	int prev_offset = offset;
 	Ref<Texture2D> incr = get_theme_icon("increment");
 	Ref<Texture2D> decr = get_theme_icon("decrement");
-	int limit = get_size().width;
-	int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
+	int limit = get_rect_size().width;
+	int limit_minus_buttons = get_rect_size().width - incr->get_width() - decr->get_width();
 
 	for (int i = offset; i <= p_idx; i++) {
 		int total_w = tabs[i].ofs_cache + tabs[i].size_cache;
@@ -1053,9 +1053,9 @@ void Tabs::ensure_tab_visible(int p_idx) {
 Rect2 Tabs::get_tab_rect(int p_tab) const {
 	ERR_FAIL_INDEX_V(p_tab, tabs.size(), Rect2());
 	if (is_layout_rtl()) {
-		return Rect2(get_size().width - tabs[p_tab].ofs_cache - tabs[p_tab].size_cache, 0, tabs[p_tab].size_cache, get_size().height);
+		return Rect2(get_rect_size().width - tabs[p_tab].ofs_cache - tabs[p_tab].size_cache, 0, tabs[p_tab].size_cache, get_rect_size().height);
 	} else {
-		return Rect2(tabs[p_tab].ofs_cache, 0, tabs[p_tab].size_cache, get_size().height);
+		return Rect2(tabs[p_tab].ofs_cache, 0, tabs[p_tab].size_cache, get_rect_size().height);
 	}
 }
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -293,7 +293,7 @@ void TextEdit::Text::move_gutters(int p_from_line, int p_to_line) {
 ////////////////////////////////////////////////////////////////////////////////
 
 void TextEdit::_update_scrollbars() {
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	Size2 hmin = h_scroll->get_combined_minimum_size();
 	Size2 vmin = v_scroll->get_combined_minimum_size();
 
@@ -383,7 +383,7 @@ void TextEdit::_click_selection_held() {
 Point2 TextEdit::_get_local_mouse_pos() const {
 	Point2 mp = get_local_mouse_position();
 	if (is_layout_rtl()) {
-		mp.x = get_size().width - mp.x;
+		mp.x = get_rect_size().width - mp.x;
 	}
 	return mp;
 }
@@ -481,7 +481,7 @@ void TextEdit::_update_selection_mode_line() {
 void TextEdit::_update_minimap_click() {
 	Point2 mp = _get_local_mouse_pos();
 
-	int xmargin_end = get_size().width - cache.style_normal->get_margin(SIDE_RIGHT);
+	int xmargin_end = get_rect_size().width - cache.style_normal->get_margin(SIDE_RIGHT);
 	if (!dragging_minimap && (mp.x < xmargin_end - minimap_width || mp.y > xmargin_end)) {
 		minimap_clicked = false;
 		return;
@@ -599,7 +599,7 @@ void TextEdit::_notification(int p_what) {
 				}
 			}
 
-			Size2 size = get_size();
+			Size2 size = get_rect_size();
 			bool rtl = is_layout_rtl();
 			if ((!has_focus() && !menu->has_focus()) || !window_has_focus) {
 				draw_caret = false;
@@ -632,7 +632,7 @@ void TextEdit::_notification(int p_what) {
 			Color color = readonly ? cache.font_readonly_color : cache.font_color;
 
 			if (cache.background_color.a > 0.01) {
-				RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2i(), get_size()), cache.background_color);
+				RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2i(), get_rect_size()), cache.background_color);
 			}
 
 			if (line_length_guidelines) {
@@ -970,7 +970,7 @@ void TextEdit::_notification(int p_what) {
 			}
 
 			int top_limit_y = 0;
-			int bottom_limit_y = get_size().height;
+			int bottom_limit_y = get_rect_size().height;
 			if (readonly) {
 				top_limit_y += cache.style_readonly->get_margin(SIDE_TOP);
 				bottom_limit_y -= cache.style_readonly->get_margin(SIDE_BOTTOM);
@@ -1549,15 +1549,15 @@ void TextEdit::_notification(int p_what) {
 				if (rect_left_border_x < 0) {
 					// Anchor the completion panel to the left
 					completion_rect.position.x = 0;
-				} else if (rect_right_border_x > get_size().width) {
+				} else if (rect_right_border_x > get_rect_size().width) {
 					// Anchor the completion panel to the right
-					completion_rect.position.x = get_size().width - total_width;
+					completion_rect.position.x = get_rect_size().width - total_width;
 				} else {
 					// Let the completion panel float with the cursor
 					completion_rect.position.x = rect_left_border_x;
 				}
 
-				if (cursor_pos.y + row_height + total_height > get_size().height && cursor_pos.y > total_height) {
+				if (cursor_pos.y + row_height + total_height > get_rect_size().height && cursor_pos.y > total_height) {
 					// Completion panel above the cursor line
 					completion_rect.position.y = cursor_pos.y - total_height;
 				} else {
@@ -1704,7 +1704,7 @@ void TextEdit::_notification(int p_what) {
 			if (has_focus()) {
 				if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 					DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
-					DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + cursor_pos, get_viewport()->get_window_id());
+					DisplayServer::get_singleton()->window_set_ime_position(get_rect_global_position() + cursor_pos, get_viewport()->get_window_id());
 				}
 			}
 		} break;
@@ -1717,7 +1717,7 @@ void TextEdit::_notification(int p_what) {
 
 			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 				DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
-				DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + _get_cursor_pixel_pos(false), get_viewport()->get_window_id());
+				DisplayServer::get_singleton()->window_set_ime_position(get_rect_global_position() + _get_cursor_pixel_pos(false), get_viewport()->get_window_id());
 			}
 
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
@@ -2864,7 +2864,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 	if (mb.is_valid()) {
 		Vector2i mpos = mb->get_position();
 		if (is_layout_rtl()) {
-			mpos.x = get_size().x - mpos.x;
+			mpos.x = get_rect_size().x - mpos.x;
 		}
 		if (ime_text.length() != 0) {
 			// Ignore mouse clicks in IME input mode.
@@ -3105,7 +3105,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 	if (mm.is_valid()) {
 		Vector2i mpos = mm->get_position();
 		if (is_layout_rtl()) {
-			mpos.x = get_size().x - mpos.x;
+			mpos.x = get_rect_size().x - mpos.x;
 		}
 		if (select_identifiers_enabled) {
 			if (!dragging_minimap && !dragging_selection && mm->get_command() && mm->get_button_mask() == 0) {
@@ -3875,10 +3875,10 @@ Size2 TextEdit::get_minimum_size() const {
 }
 
 int TextEdit::_get_control_height() const {
-	int control_height = get_size().height;
+	int control_height = get_rect_size().height;
 	control_height -= cache.style_normal->get_minimum_size().height;
 	if (h_scroll->is_visible_in_tree()) {
-		control_height -= h_scroll->get_size().height;
+		control_height -= h_scroll->get_rect_size().height;
 	}
 	return control_height;
 }
@@ -3963,7 +3963,7 @@ int TextEdit::get_total_visible_rows() const {
 }
 
 void TextEdit::_update_wrap_at(bool p_force) {
-	int new_wrap_at = get_size().width - cache.style_normal->get_minimum_size().width - gutters_width - gutter_padding;
+	int new_wrap_at = get_rect_size().width - cache.style_normal->get_minimum_size().width - gutters_width - gutter_padding;
 	if (draw_minimap) {
 		new_wrap_at -= minimap_width;
 	}
@@ -4006,7 +4006,7 @@ void TextEdit::adjust_viewport_to_cursor() {
 		set_line_as_last_visible(cur_line, cur_wrap);
 	}
 
-	int visible_width = get_size().width - cache.style_normal->get_minimum_size().width - gutters_width - gutter_padding - cache.minimap_width;
+	int visible_width = get_rect_size().width - cache.style_normal->get_minimum_size().width - gutters_width - gutter_padding - cache.minimap_width;
 	if (v_scroll->is_visible_in_tree()) {
 		visible_width -= v_scroll->get_combined_minimum_size().width;
 	}
@@ -4059,7 +4059,7 @@ void TextEdit::center_viewport_to_cursor() {
 	}
 
 	set_line_as_center_visible(cursor.line, get_cursor_wrap_index());
-	int visible_width = get_size().width - cache.style_normal->get_minimum_size().width - gutters_width - gutter_padding - cache.minimap_width;
+	int visible_width = get_rect_size().width - cache.style_normal->get_minimum_size().width - gutters_width - gutter_padding - cache.minimap_width;
 	if (v_scroll->is_visible_in_tree()) {
 		visible_width -= v_scroll->get_combined_minimum_size().width;
 	}
@@ -4437,7 +4437,7 @@ void TextEdit::insert_text_at_cursor(const String &p_text) {
 	update();
 }
 
-Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
+Control::CursorShape TextEdit::get_mouse_cursor_shape(const Point2 &p_pos) const {
 	if (highlighted_word != String()) {
 		return CURSOR_POINTING_HAND;
 	}
@@ -4467,7 +4467,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 		return CURSOR_ARROW;
 	}
 
-	int xmargin_end = get_size().width - cache.style_normal->get_margin(SIDE_RIGHT);
+	int xmargin_end = get_rect_size().width - cache.style_normal->get_margin(SIDE_RIGHT);
 	if (draw_minimap && p_pos.x > xmargin_end - minimap_width && p_pos.x <= xmargin_end) {
 		return CURSOR_ARROW;
 	}
@@ -4480,7 +4480,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 		}
 	}
 
-	return get_default_cursor_shape();
+	return get_mouse_default_cursor_shape();
 }
 
 void TextEdit::set_text(String p_text) {
@@ -7071,7 +7071,7 @@ TextEdit::TextEdit() {
 	clear();
 	set_focus_mode(FOCUS_ALL);
 	_update_caches();
-	set_default_cursor_shape(CURSOR_IBEAM);
+	set_mouse_default_cursor_shape(CURSOR_IBEAM);
 
 	text.set_indent_size(indent_size);
 	text.clear();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -600,7 +600,7 @@ public:
 		SEARCH_BACKWARDS = 4
 	};
 
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
+	virtual CursorShape get_mouse_cursor_shape(const Point2 &p_pos = Point2i()) const override;
 
 	void _get_mouse_pos(const Point2i &p_mouse, int &r_row, int &r_col) const;
 	void _get_minimap_mouse_row(const Point2i &p_mouse, int &r_row) const;

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -181,19 +181,19 @@ void TextureButton::_notification(int p_what) {
 							size = texdraw->get_size();
 							break;
 						case STRETCH_SCALE:
-							size = get_size();
+							size = get_rect_size();
 							break;
 						case STRETCH_TILE:
-							size = get_size();
+							size = get_rect_size();
 							_tile = true;
 							break;
 						case STRETCH_KEEP_CENTERED:
-							ofs = (get_size() - texdraw->get_size()) / 2;
+							ofs = (get_rect_size() - texdraw->get_size()) / 2;
 							size = texdraw->get_size();
 							break;
 						case STRETCH_KEEP_ASPECT_CENTERED:
 						case STRETCH_KEEP_ASPECT: {
-							Size2 _size = get_size();
+							Size2 _size = get_rect_size();
 							float tex_width = texdraw->get_width() * _size.height / texdraw->get_height();
 							float tex_height = _size.height;
 
@@ -210,7 +210,7 @@ void TextureButton::_notification(int p_what) {
 							size.height = tex_height;
 						} break;
 						case STRETCH_KEEP_ASPECT_COVERED: {
-							size = get_size();
+							size = get_rect_size();
 							Size2 tex_size = texdraw->get_size();
 							Size2 scale_size(size.width / tex_size.width, size.height / tex_size.height);
 							float scale = scale_size.width > scale_size.height ? scale_size.width : scale_size.height;

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -210,7 +210,7 @@ void TextureProgressBar::draw_nine_patch_stretched(const Ref<Texture2D> &p_textu
 	Vector2 bottomright = Vector2(stretch_margin[SIDE_RIGHT], stretch_margin[SIDE_BOTTOM]);
 
 	Rect2 src_rect = Rect2(Point2(), texture_size);
-	Rect2 dst_rect = Rect2(Point2(), get_size());
+	Rect2 dst_rect = Rect2(Point2(), get_rect_size());
 
 	if (p_ratio < 1.0) {
 		// Drawing a partially-filled 9-patch is a little tricky -
@@ -347,7 +347,7 @@ void TextureProgressBar::_notification(int p_what) {
 						case FILL_COUNTER_CLOCKWISE:
 						case FILL_CLOCKWISE_AND_COUNTER_CLOCKWISE: {
 							if (nine_patch_stretch) {
-								s = get_size();
+								s = get_rect_size();
 							}
 
 							float val = get_as_ratio() * rad_max_degrees / 360;
@@ -396,7 +396,7 @@ void TextureProgressBar::_notification(int p_what) {
 								Point2 p;
 
 								if (nine_patch_stretch) {
-									p = get_size();
+									p = get_rect_size();
 								} else {
 									p = progress->get_size();
 								}

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -45,25 +45,25 @@ void TextureRect::_notification(int p_what) {
 
 		switch (stretch_mode) {
 			case STRETCH_SCALE_ON_EXPAND: {
-				size = expand ? get_size() : texture->get_size();
+				size = expand ? get_rect_size() : texture->get_size();
 			} break;
 			case STRETCH_SCALE: {
-				size = get_size();
+				size = get_rect_size();
 			} break;
 			case STRETCH_TILE: {
-				size = get_size();
+				size = get_rect_size();
 				tile = true;
 			} break;
 			case STRETCH_KEEP: {
 				size = texture->get_size();
 			} break;
 			case STRETCH_KEEP_CENTERED: {
-				offset = (get_size() - texture->get_size()) / 2;
+				offset = (get_rect_size() - texture->get_size()) / 2;
 				size = texture->get_size();
 			} break;
 			case STRETCH_KEEP_ASPECT_CENTERED:
 			case STRETCH_KEEP_ASPECT: {
-				size = get_size();
+				size = get_rect_size();
 				int tex_width = texture->get_width() * size.height / texture->get_height();
 				int tex_height = size.height;
 
@@ -81,7 +81,7 @@ void TextureRect::_notification(int p_what) {
 				size.height = tex_height;
 			} break;
 			case STRETCH_KEEP_ASPECT_COVERED: {
-				size = get_size();
+				size = get_rect_size();
 
 				Size2 tex_size = texture->get_size();
 				Size2 scale_size(size.width / tex_size.width, size.height / tex_size.height);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1340,7 +1340,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					//being pressed
 					Point2 od = o;
 					if (rtl) {
-						od.x = get_size().width - od.x - s.x;
+						od.x = get_rect_size().width - od.x - s.x;
 					}
 					cache.button_pressed->draw(get_canvas_item(), Rect2(od, s));
 				}
@@ -1349,7 +1349,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				o += cache.button_pressed->get_offset();
 
 				if (rtl) {
-					o.x = get_size().width - o.x - b->get_width();
+					o.x = get_rect_size().width - o.x - b->get_width();
 				}
 
 				b->draw(ci, o, p_item->cells[i].buttons[j].disabled ? Color(1, 1, 1, 0.5) : p_item->cells[i].buttons[j].color);
@@ -1367,18 +1367,18 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			if (cache.draw_guides) {
 				Rect2 r = cell_rect;
 				if (rtl) {
-					r.position.x = get_size().width - r.position.x - r.size.x;
+					r.position.x = get_rect_size().width - r.position.x - r.size.x;
 				}
 				RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(r.position.x, r.position.y + r.size.height), r.position + r.size, cache.guide_color, 1);
 			}
 
 			if (i == 0) {
 				if (p_item->cells[0].selected && select_mode == SELECT_ROW) {
-					Rect2i row_rect = Rect2i(Point2i(cache.bg->get_margin(SIDE_LEFT), item_rect.position.y), Size2i(get_size().width - cache.bg->get_minimum_size().width, item_rect.size.y));
+					Rect2i row_rect = Rect2i(Point2i(cache.bg->get_margin(SIDE_LEFT), item_rect.position.y), Size2i(get_rect_size().width - cache.bg->get_minimum_size().width, item_rect.size.y));
 					//Rect2 r = Rect2i(row_rect.pos,row_rect.size);
 					//r.grow(cache.selected->get_margin(SIDE_LEFT));
 					if (rtl) {
-						row_rect.position.x = get_size().width - row_rect.position.x - row_rect.size.x;
+						row_rect.position.x = get_rect_size().width - row_rect.position.x - row_rect.size.x;
 					}
 					if (has_focus()) {
 						cache.selected_focus->draw(ci, row_rect);
@@ -1394,7 +1394,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				p_item->set_meta("__focus_rect", Rect2(r.position, r.size));
 
 				if (rtl) {
-					r.position.x = get_size().width - r.position.x - r.size.x;
+					r.position.x = get_rect_size().width - r.position.x - r.size.x;
 				}
 
 				if (p_item->cells[i].selected) {
@@ -1416,7 +1416,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					r.size.x += cache.hseparation;
 				}
 				if (rtl) {
-					r.position.x = get_size().width - r.position.x - r.size.x;
+					r.position.x = get_rect_size().width - r.position.x - r.size.x;
 				}
 				if (p_item->cells[i].custom_bg_outline) {
 					RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), p_item->cells[i].bg_color);
@@ -1432,7 +1432,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				Rect2 r = cell_rect;
 				bool has_parent = p_item->get_children() != nullptr;
 				if (rtl) {
-					r.position.x = get_size().width - r.position.x - r.size.x;
+					r.position.x = get_rect_size().width - r.position.x - r.size.x;
 				}
 
 				if (drop_mode_section == -1 || has_parent || drop_mode_section == 0) {
@@ -1459,7 +1459,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			if (rtl) {
-				item_rect.position.x = get_size().width - item_rect.position.x - item_rect.size.x;
+				item_rect.position.x = get_rect_size().width - item_rect.position.x - item_rect.size.x;
 			}
 
 			Point2i text_pos = item_rect.position;
@@ -1616,7 +1616,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 			if (select_mode == SELECT_MULTI && selected_item == p_item && selected_col == i) {
 				if (is_layout_rtl()) {
-					cell_rect.position.x = get_size().width - cell_rect.position.x - cell_rect.size.x;
+					cell_rect.position.x = get_rect_size().width - cell_rect.position.x - cell_rect.size.x;
 				}
 				if (has_focus()) {
 					cache.cursor->draw(ci, cell_rect);
@@ -1639,7 +1639,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			Point2 apos = p_pos + p_draw_ofs + Point2i(0, (label_h - arrow->get_height()) / 2) - cache.offset;
 
 			if (rtl) {
-				apos.x = get_size().width - apos.x - arrow->get_width();
+				apos.x = get_rect_size().width - apos.x - arrow->get_width();
 			}
 
 			arrow->draw(ci, apos);
@@ -1679,8 +1679,8 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 				if (root_pos.y + line_width >= 0) {
 					if (rtl) {
-						root_pos.x = get_size().width - root_pos.x;
-						parent_pos.x = get_size().width - parent_pos.x;
+						root_pos.x = get_rect_size().width - root_pos.x;
+						parent_pos.x = get_rect_size().width - parent_pos.x;
 					}
 					RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x - Math::floor(line_width / 2), root_pos.y), cache.relationship_line_color, line_width);
 					RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y), Point2i(parent_pos.x, prev_ofs), cache.relationship_line_color, line_width);
@@ -1952,7 +1952,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 				cache.click_id = c.buttons[j].id;
 				cache.click_item = p_item;
 				cache.click_column = col;
-				cache.click_pos = get_global_mouse_position() - get_global_position();
+				cache.click_pos = get_global_mouse_position() - get_rect_global_position();
 				update();
 				//emit_signal("button_pressed");
 				return -1;
@@ -2065,7 +2065,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 					}
 
 					popup_menu->set_size(Size2(col_width, 0));
-					popup_menu->set_position(get_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h) - cache.offset);
+					popup_menu->set_position(get_rect_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h) - cache.offset);
 					popup_menu->popup();
 					popup_edited_item = p_item;
 					popup_edited_item_col = col;
@@ -2125,7 +2125,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 				edited_col = col;
 				bool on_arrow = x > col_width - cache.select_arrow->get_width();
 
-				custom_popup_rect = Rect2i(get_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h - cache.offset.y), Size2(get_column_width(col), item_h));
+				custom_popup_rect = Rect2i(get_rect_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h - cache.offset.y), Size2(get_column_width(col), item_h));
 
 				if (on_arrow || !p_item->cells[col].custom_button) {
 					emit_signal("custom_popup_edited", ((bool)(x >= (col_width - item_h / 2))));
@@ -2147,7 +2147,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 		popup_edited_item = p_item;
 		popup_edited_item_col = col;
 
-		pressing_item_rect = Rect2(get_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs) - cache.offset, Size2(col_width, item_h));
+		pressing_item_rect = Rect2(get_rect_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs) - cache.offset, Size2(col_width, item_h));
 		pressing_for_editor_text = editor_text;
 		pressing_for_editor = true;
 
@@ -2599,7 +2599,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 		Point2 pos = mm->get_position();
 		if (rtl) {
-			pos.x = get_size().width - pos.x;
+			pos.x = get_rect_size().width - pos.x;
 		}
 		pos -= cache.bg->get_offset();
 
@@ -2627,7 +2627,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 		if (root) {
 			Point2 mpos = mm->get_position();
 			if (rtl) {
-				mpos.x = get_size().width - mpos.x;
+				mpos.x = get_rect_size().width - mpos.x;
 			}
 			mpos -= cache.bg->get_offset();
 			mpos.y -= _get_title_button_height();
@@ -2686,7 +2686,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 			if (!range_drag_enabled) {
 				Vector2 cpos = mm->get_position();
 				if (rtl) {
-					cpos.x = get_size().width - cpos.x;
+					cpos.x = get_rect_size().width - cpos.x;
 				}
 				if (cpos.distance_to(pressing_pos) > 2) {
 					range_drag_enabled = true;
@@ -2725,7 +2725,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 			if (b->get_button_index() == MOUSE_BUTTON_LEFT) {
 				Point2 pos = b->get_position();
 				if (rtl) {
-					pos.x = get_size().width - pos.x;
+					pos.x = get_rect_size().width - pos.x;
 				}
 				pos -= cache.bg->get_offset();
 				if (show_column_titles) {
@@ -2760,7 +2760,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 						Rect2 rect = get_selected()->get_meta("__focus_rect");
 						Point2 mpos = b->get_position();
 						if (rtl) {
-							mpos.x = get_size().width - mpos.x;
+							mpos.x = get_rect_size().width - mpos.x;
 						}
 						if (rect.has_point(mpos)) {
 							if (!edit_selected()) {
@@ -2809,7 +2809,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 				Point2 pos = b->get_position();
 				if (rtl) {
-					pos.x = get_size().width - pos.x;
+					pos.x = get_rect_size().width - pos.x;
 				}
 				pos -= bg->get_offset();
 				cache.click_type = Cache::CLICK_NONE;
@@ -2852,7 +2852,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 				if (pressing_for_editor) {
 					pressing_pos = b->get_position();
 					if (rtl) {
-						pressing_pos.x = get_size().width - pressing_pos.x;
+						pressing_pos.x = get_rect_size().width - pressing_pos.x;
 					}
 				}
 
@@ -2953,7 +2953,7 @@ bool Tree::edit_selected() {
 	} else if (c.mode == TreeItem::CELL_MODE_CUSTOM) {
 		edited_item = s;
 		edited_col = col;
-		custom_popup_rect = Rect2i(get_global_position() + rect.position, rect.size);
+		custom_popup_rect = Rect2i(get_rect_global_position() + rect.position, rect.size);
 		emit_signal("custom_popup_edited", false);
 		item_edited(col, s);
 
@@ -2966,7 +2966,7 @@ bool Tree::edit_selected() {
 		}
 
 		popup_menu->set_size(Size2(rect.size.width, 0));
-		popup_menu->set_position(get_global_position() + rect.position + Point2i(0, rect.size.height));
+		popup_menu->set_position(get_rect_global_position() + rect.position + Point2i(0, rect.size.height));
 		popup_menu->popup();
 		popup_edited_item = s;
 		popup_edited_item_col = col;
@@ -2975,7 +2975,7 @@ bool Tree::edit_selected() {
 	} else if (c.mode == TreeItem::CELL_MODE_STRING || c.mode == TreeItem::CELL_MODE_RANGE) {
 		Rect2 popup_rect;
 
-		Vector2 ofs(0, (text_editor->get_size().height - rect.size.height) / 2);
+		Vector2 ofs(0, (text_editor->get_rect_size().height - rect.size.height) / 2);
 
 		Point2i textedpos = get_screen_position() + rect.position - ofs;
 		cache.text_editor_position = textedpos;
@@ -3026,7 +3026,7 @@ Size2 Tree::get_internal_min_size() const {
 }
 
 void Tree::update_scrollbars() {
-	Size2 size = get_size();
+	Size2 size = get_rect_size();
 	int tbh;
 	if (show_column_titles) {
 		tbh = _get_title_button_height();
@@ -3145,20 +3145,20 @@ void Tree::_notification(int p_what) {
 			}
 		}
 
-		Point2 mouse_position = get_viewport()->get_mouse_position() - get_global_position();
+		Point2 mouse_position = get_viewport()->get_mouse_position() - get_rect_global_position();
 		if (scrolling && get_rect().grow(cache.scroll_border).has_point(mouse_position)) {
 			Point2 point;
 
-			if ((ABS(mouse_position.x) < ABS(mouse_position.x - get_size().width)) && (ABS(mouse_position.x) < cache.scroll_border)) {
+			if ((ABS(mouse_position.x) < ABS(mouse_position.x - get_rect_size().width)) && (ABS(mouse_position.x) < cache.scroll_border)) {
 				point.x = mouse_position.x - cache.scroll_border;
-			} else if (ABS(mouse_position.x - get_size().width) < cache.scroll_border) {
-				point.x = mouse_position.x - (get_size().width - cache.scroll_border);
+			} else if (ABS(mouse_position.x - get_rect_size().width) < cache.scroll_border) {
+				point.x = mouse_position.x - (get_rect_size().width - cache.scroll_border);
 			}
 
-			if ((ABS(mouse_position.y) < ABS(mouse_position.y - get_size().height)) && (ABS(mouse_position.y) < cache.scroll_border)) {
+			if ((ABS(mouse_position.y) < ABS(mouse_position.y - get_rect_size().height)) && (ABS(mouse_position.y) < cache.scroll_border)) {
 				point.y = mouse_position.y - cache.scroll_border;
-			} else if (ABS(mouse_position.y - get_size().height) < cache.scroll_border) {
-				point.y = mouse_position.y - (get_size().height - cache.scroll_border);
+			} else if (ABS(mouse_position.y - get_rect_size().height) < cache.scroll_border) {
+				point.y = mouse_position.y - (get_rect_size().height - cache.scroll_border);
 			}
 
 			point *= cache.scroll_speed * get_physics_process_delta_time();
@@ -3180,12 +3180,12 @@ void Tree::_notification(int p_what) {
 
 		Point2 draw_ofs;
 		draw_ofs += bg->get_offset();
-		Size2 draw_size = get_size() - bg->get_minimum_size();
+		Size2 draw_size = get_rect_size() - bg->get_minimum_size();
 
-		bg->draw(ci, Rect2(Point2(), get_size()));
+		bg->draw(ci, Rect2(Point2(), get_rect_size()));
 		if (has_focus()) {
 			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, true);
-			bg_focus->draw(ci, Rect2(Point2(), get_size()));
+			bg_focus->draw(ci, Rect2(Point2(), get_rect_size()));
 			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, false);
 		}
 
@@ -3206,7 +3206,7 @@ void Tree::_notification(int p_what) {
 				Ref<Font> f = cache.tb_font;
 				Rect2 tbrect = Rect2(ofs2 - cache.offset.x, bg->get_margin(SIDE_TOP), get_column_width(i), tbh);
 				if (is_layout_rtl()) {
-					tbrect.position.x = get_size().width - tbrect.size.x - tbrect.position.x;
+					tbrect.position.x = get_rect_size().width - tbrect.size.x - tbrect.position.x;
 				}
 				sb->draw(ci, tbrect);
 				ofs2 += tbrect.size.width;
@@ -3231,13 +3231,13 @@ void Tree::_notification(int p_what) {
 	if (p_what == NOTIFICATION_RESIZED || p_what == NOTIFICATION_TRANSFORM_CHANGED) {
 		if (popup_edited_item != nullptr) {
 			Rect2 rect = popup_edited_item->get_meta("__focus_rect");
-			Vector2 ofs(0, (text_editor->get_size().height - rect.size.height) / 2);
-			Point2i textedpos = get_global_position() + rect.position - ofs;
+			Vector2 ofs(0, (text_editor->get_rect_size().height - rect.size.height) / 2);
+			Point2i textedpos = get_rect_global_position() + rect.position - ofs;
 
 			if (cache.text_editor_position != textedpos) {
 				cache.text_editor_position = textedpos;
-				text_editor->set_position(textedpos);
-				value_editor->set_position(textedpos + Point2i(0, text_editor->get_size().height));
+				text_editor->set_rect_position(textedpos);
+				value_editor->set_rect_position(textedpos + Point2i(0, text_editor->get_rect_size().height));
 			}
 		}
 	}
@@ -3518,7 +3518,7 @@ int Tree::get_column_width(int p_column) const {
 		return columns[p_column].min_width;
 	}
 
-	int expand_area = get_size().width;
+	int expand_area = get_rect_size().width;
 
 	Ref<StyleBox> bg = cache.bg;
 
@@ -3632,7 +3632,7 @@ void Tree::ensure_cursor_is_visible() {
 		return; // Nothing under cursor.
 	}
 
-	const Size2 area_size = get_size() - cache.bg->get_minimum_size();
+	const Size2 area_size = get_rect_size() - cache.bg->get_minimum_size();
 
 	int y_offset = get_item_offset(selected_item);
 	if (y_offset != -1) {
@@ -3689,7 +3689,7 @@ Rect2 Tree::get_item_rect(TreeItem *p_item, int p_column) const {
 
 	if (p_column == -1) {
 		r.position.x = 0;
-		r.size.x = get_size().width;
+		r.size.x = get_rect_size().width;
 	} else {
 		int accum = 0;
 		for (int i = 0; i < p_column; i++) {
@@ -3805,8 +3805,8 @@ void Tree::scroll_to_item(TreeItem *p_item) {
 
 	if (r.position.y <= v_scroll->get_value()) {
 		v_scroll->set_value(r.position.y);
-	} else if (r.position.y + r.size.y + 2 * cache.vseparation > v_scroll->get_value() + get_size().y) {
-		v_scroll->set_value(r.position.y + r.size.y + 2 * cache.vseparation - get_size().y);
+	} else if (r.position.y + r.size.y + 2 * cache.vseparation > v_scroll->get_value() + get_rect_size().y) {
+		v_scroll->set_value(r.position.y + r.size.y + 2 * cache.vseparation - get_rect_size().y);
 	}
 }
 
@@ -3947,7 +3947,7 @@ int Tree::get_column_at_position(const Point2 &p_pos) const {
 	if (root) {
 		Point2 pos = p_pos;
 		if (is_layout_rtl()) {
-			pos.x = get_size().width - pos.x;
+			pos.x = get_rect_size().width - pos.x;
 		}
 		pos -= cache.bg->get_offset();
 		pos.y -= _get_title_button_height();
@@ -3977,7 +3977,7 @@ int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
 	if (root) {
 		Point2 pos = p_pos;
 		if (is_layout_rtl()) {
-			pos.x = get_size().width - pos.x;
+			pos.x = get_rect_size().width - pos.x;
 		}
 		pos -= cache.bg->get_offset();
 		pos.y -= _get_title_button_height();
@@ -4007,7 +4007,7 @@ TreeItem *Tree::get_item_at_position(const Point2 &p_pos) const {
 	if (root) {
 		Point2 pos = p_pos;
 		if (is_layout_rtl()) {
-			pos.x = get_size().width - pos.x;
+			pos.x = get_rect_size().width - pos.x;
 		}
 		pos -= cache.bg->get_offset();
 		pos.y -= _get_title_button_height();
@@ -4297,11 +4297,11 @@ Tree::Tree() {
 	popup_editor_vb->set_anchors_and_offsets_preset(PRESET_WIDE);
 	text_editor = memnew(LineEdit);
 	popup_editor_vb->add_child(text_editor);
-	text_editor->set_v_size_flags(SIZE_EXPAND_FILL);
-	text_editor->set_h_size_flags(SIZE_EXPAND_FILL);
+	text_editor->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	text_editor->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	value_editor = memnew(HSlider);
-	value_editor->set_v_size_flags(SIZE_EXPAND_FILL);
-	value_editor->set_h_size_flags(SIZE_EXPAND_FILL);
+	value_editor->set_size_flags_vertical(SIZE_EXPAND_FILL);
+	value_editor->set_size_flags_horizontal(SIZE_EXPAND_FILL);
 	popup_editor_vb->add_child(value_editor);
 	value_editor->hide();
 
@@ -4326,7 +4326,7 @@ Tree::Tree() {
 
 	set_mouse_filter(MOUSE_FILTER_STOP);
 
-	set_clip_contents(true);
+	set_rect_clip_contents(true);
 }
 
 Tree::~Tree() {

--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -174,7 +174,7 @@ void VideoPlayer::_notification(int p_notification) {
 				return;
 			}
 
-			Size2 s = expand ? get_size() : texture->get_size();
+			Size2 s = expand ? get_rect_size() : texture->get_size();
 			draw_texture_rect(texture, Rect2(Point2(), s), false);
 
 		} break;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2153,7 +2153,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				Vector2 cpos = pos;
 				while (c) {
 					if (gui.mouse_focus_mask != 0 || c->has_point(cpos)) {
-						cursor_shape = c->get_cursor_shape(cpos);
+						cursor_shape = c->get_mouse_cursor_shape(cpos);
 					} else {
 						cursor_shape = Control::CURSOR_ARROW;
 					}
@@ -2185,7 +2185,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 			Control *drag_preview = _gui_get_drag_preview();
 			if (drag_preview) {
-				drag_preview->set_position(mpos);
+				drag_preview->set_rect_position(mpos);
 			}
 
 			gui.drag_mouse_over = over;
@@ -2463,7 +2463,7 @@ void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 		memdelete(drag_preview);
 	}
 	p_control->set_as_top_level(true);
-	p_control->set_position(gui.last_mouse_pos);
+	p_control->set_rect_position(gui.last_mouse_pos);
 	p_base->get_root_parent_control()->add_child(p_control); //add as child of viewport
 	p_control->raise();
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -853,7 +853,7 @@ Size2 Window::_get_contents_minimum_size() const {
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = Object::cast_to<Control>(get_child(i));
 		if (c) {
-			Point2i pos = c->get_position();
+			Point2i pos = c->get_rect_position();
 			Size2i min = c->get_combined_minimum_size();
 
 			max.x = MAX(pos.x + min.x, max.x);

--- a/tests/test_gui.cpp
+++ b/tests/test_gui.cpp
@@ -78,8 +78,8 @@ public:
 
 		Label *label = memnew(Label);
 
-		label->set_position(Point2(80, 90));
-		label->set_size(Point2(170, 80));
+		label->set_rect_position(Point2(80, 90));
+		label->set_rect_size(Point2(170, 80));
 		label->set_align(Label::ALIGN_FILL);
 		label->set_text("There was once upon a time a beautiful unicorn that loved to play with little girls...");
 
@@ -87,8 +87,8 @@ public:
 
 		Button *button = memnew(Button);
 
-		button->set_position(Point2(20, 20));
-		button->set_size(Point2(1, 1));
+		button->set_rect_position(Point2(20, 20));
+		button->set_rect_size(Point2(1, 1));
 		button->set_text("This is a biggie button");
 
 		frame->add_child(button);
@@ -96,8 +96,8 @@ public:
 		Tree *tree = memnew(Tree);
 		tree->set_columns(2);
 
-		tree->set_position(Point2(230, 210));
-		tree->set_size(Point2(150, 250));
+		tree->set_rect_position(Point2(230, 210));
+		tree->set_rect_size(Point2(150, 250));
 
 		TreeItem *item = tree->create_item();
 		item->set_editable(0, true);
@@ -134,15 +134,15 @@ public:
 
 		LineEdit *line_edit = memnew(LineEdit);
 
-		line_edit->set_position(Point2(30, 190));
-		line_edit->set_size(Point2(180, 1));
+		line_edit->set_rect_position(Point2(30, 190));
+		line_edit->set_rect_size(Point2(180, 1));
 
 		frame->add_child(line_edit);
 
 		HScrollBar *hscroll = memnew(HScrollBar);
 
-		hscroll->set_position(Point2(30, 290));
-		hscroll->set_size(Point2(180, 1));
+		hscroll->set_rect_position(Point2(30, 290));
+		hscroll->set_rect_size(Point2(180, 1));
 		hscroll->set_max(10);
 		hscroll->set_page(4);
 
@@ -150,16 +150,16 @@ public:
 
 		SpinBox *spin = memnew(SpinBox);
 
-		spin->set_position(Point2(30, 260));
-		spin->set_size(Point2(120, 1));
+		spin->set_rect_position(Point2(30, 260));
+		spin->set_rect_size(Point2(120, 1));
 
 		frame->add_child(spin);
 		hscroll->share(spin);
 
 		ProgressBar *progress = memnew(ProgressBar);
 
-		progress->set_position(Point2(30, 330));
-		progress->set_size(Point2(120, 1));
+		progress->set_rect_position(Point2(30, 330));
+		progress->set_rect_size(Point2(120, 1));
 
 		frame->add_child(progress);
 		hscroll->share(progress);
@@ -167,8 +167,8 @@ public:
 		MenuButton *menu_button = memnew(MenuButton);
 
 		menu_button->set_text("I'm a menu!");
-		menu_button->set_position(Point2(30, 380));
-		menu_button->set_size(Point2(1, 1));
+		menu_button->set_rect_position(Point2(30, 380));
+		menu_button->set_rect_size(Point2(1, 1));
 
 		frame->add_child(menu_button);
 
@@ -190,15 +190,15 @@ public:
 		options->add_item("Hello, testing");
 		options->add_item("My Dearest");
 
-		options->set_position(Point2(230, 180));
-		options->set_size(Point2(1, 1));
+		options->set_rect_position(Point2(230, 180));
+		options->set_rect_size(Point2(1, 1));
 
 		frame->add_child(options);
 
 		RichTextLabel *richtext = memnew(RichTextLabel);
 
-		richtext->set_position(Point2(600, 210));
-		richtext->set_size(Point2(180, 250));
+		richtext->set_rect_position(Point2(600, 210));
+		richtext->set_rect_size(Point2(180, 250));
 		richtext->set_anchor_and_offset(SIDE_RIGHT, Control::ANCHOR_END, -20);
 
 		frame->add_child(richtext);
@@ -243,22 +243,22 @@ public:
 		tabc->add_child(ctl);
 		label = memnew(Label);
 		label->set_text("Some Label");
-		label->set_position(Point2(20, 20));
+		label->set_rect_position(Point2(20, 20));
 		ctl->add_child(label);
 
 		ctl = memnew(Control);
 		ctl->set_name("tab 3");
 		button = memnew(Button);
 		button->set_text("Some Button");
-		button->set_position(Point2(30, 50));
+		button->set_rect_position(Point2(30, 50));
 		ctl->add_child(button);
 
 		tabc->add_child(ctl);
 
 		frame->add_child(tabc);
 
-		tabc->set_position(Point2(400, 210));
-		tabc->set_size(Point2(180, 250));
+		tabc->set_rect_position(Point2(400, 210));
+		tabc->set_rect_size(Point2(180, 250));
 	}
 };
 


### PR DESCRIPTION
Part of #16863, originally identified by @AlexHolly [here](https://github.com/godotengine/godot/issues/16863#issuecomment-381420942).

Includes renaming some properties to match the getters and setters where appropriate.

Method renames:

Property | Method Before | Method After
-- | -- | --
mouse_default_cursor_shape | set_default_cursor_shape | set_mouse_default_cursor_shape
" | get_default_cursor_shape | get_mouse_default_cursor_shape
-- | get_cursor_shape | get_mouse_cursor_shape
grow_horizontal | set_h_grow_direction | set_grow_horizontal
" | get_h_grow_direction | get_grow_horizontal
grow_vertical | set_v_grow_direction | set_grow_vertical
" | get_v_grow_direction | get_grow_vertical
rect_clip_contents | set_clip_contents | set_rect_clip_contents
" | is_clipping_contents | is_rect_clipping_contents
rect_global_position | set_global_position | set_rect_global_position
" | get_global_position | get_rect_global_position
rect_position | set_position | set_rect_position
" | get_position | get_rect_position
rect_rotation | set_rotation | set_rect_rotation
" | get_rotation | get_rect_rotation
rect_rotation_degrees | set_rotation_degrees | set_rect_rotation_degrees
" | get_rotation_degrees | get_rect_rotation_degrees
rect_minimum_size | set_custom_minimum_size | set_rect_minimum_size
" | get_custom_minimum_size | get_rect_minimum_size
rect_pivot_offset | set_pivot_offset | set_rect_pivot_offset
" | get_pivot_offset | get_rect_pivot_offset
rect_scale | set_scale | set_rect_scale
" | get_scale | get_rect_scale
rect_size | set_size | set_rect_size
" | get_size | get_rect_size
size_flags_horizontal | set_h_size_flags | set_size_flags_horizontal
" | get_h_size_flags | get_size_flags_horizontal
size_flags_stretch_ratio | set_stretch_ratio | set_size_flags_stretch_ratio
" | get_stretch_ratio | get_size_flags_stretch_ratio
size_flags_vertical | set_v_size_flags | set_size_flags_vertical
" | get_v_size_flags | get_size_flags_vertical

Property renames:

Before | After
-- | --
rect_clip_content | rect_clip_contents
rect_min_size | rect_minimum_size
hint_tooltip | tooltip
