### PR TITLE
Obtain supported Vulkan API

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -7834,6 +7834,18 @@ void RenderingDeviceVulkan::_flush(bool p_current_frame) {
 }
 
 void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_device) {
+	// get our device capabilities
+	{
+		device_capabilities.version_major = p_context->get_vulkan_major();
+		device_capabilities.version_minor = p_context->get_vulkan_minor();
+
+		// get info about subgroups
+		VulkanContext::SubgroupCapabilities subgroup_capabilities = p_context->get_subgroup_capabilities();
+		device_capabilities.subgroup_size = subgroup_capabilities.size;
+		device_capabilities.subgroup_in_shaders = subgroup_capabilities.supported_stages_flags_rd();
+		device_capabilities.subgroup_operations = subgroup_capabilities.supported_operations_flags_rd();
+	}
+
 	context = p_context;
 	device = p_context->get_device();
 	if (p_local_device) {
@@ -8253,6 +8265,7 @@ RenderingDevice *RenderingDeviceVulkan::create_local_device() {
 }
 
 RenderingDeviceVulkan::RenderingDeviceVulkan() {
+	device_capabilities.device_family = DEVICE_VULKAN;
 }
 
 RenderingDeviceVulkan::~RenderingDeviceVulkan() {

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -41,6 +41,20 @@
 #include <vulkan/vulkan.h>
 
 class VulkanContext {
+public:
+	struct SubgroupCapabilities {
+		uint32_t size;
+		VkShaderStageFlags supportedStages;
+		VkSubgroupFeatureFlags supportedOperations;
+		VkBool32 quadOperationsInAllStages;
+
+		uint32_t supported_stages_flags_rd() const;
+		String supported_stages_desc() const;
+		uint32_t supported_operations_flags_rd() const;
+		String supported_operations_desc() const;
+	};
+
+private:
 	enum {
 		MAX_EXTENSIONS = 128,
 		MAX_LAYERS = 64,
@@ -56,6 +70,11 @@ class VulkanContext {
 	VkDevice device = VK_NULL_HANDLE;
 	bool device_initialized = false;
 	bool inst_initialized = false;
+
+	// Vulkan 1.0 doesn't return version info so we assume this by default until we know otherwise
+	uint32_t vulkan_major = 1;
+	uint32_t vulkan_minor = 0;
+	SubgroupCapabilities subgroup_capabilities;
 
 	String device_vendor;
 	String device_name;
@@ -150,8 +169,10 @@ class VulkanContext {
 
 	VkDebugUtilsMessengerEXT dbg_messenger = VK_NULL_HANDLE;
 
+	Error _obtain_vulkan_version();
 	Error _create_validation_layers();
 	Error _initialize_extensions();
+	Error _check_capabilities();
 
 	VkBool32 _check_layers(uint32_t check_count, const char **check_names, uint32_t layer_count, VkLayerProperties *layers);
 	static VKAPI_ATTR VkBool32 VKAPI_CALL _debug_messenger_callback(
@@ -186,6 +207,10 @@ protected:
 	}
 
 public:
+	uint32_t get_vulkan_major() const { return vulkan_major; };
+	uint32_t get_vulkan_minor() const { return vulkan_minor; };
+	SubgroupCapabilities get_subgroup_capabilities() const { return subgroup_capabilities; };
+
 	VkDevice get_device();
 	VkPhysicalDevice get_physical_device();
 	int get_swapchain_image_count() const;

--- a/modules/glslang/register_types.cpp
+++ b/modules/glslang/register_types.cpp
@@ -37,7 +37,7 @@
 #include <glslang/Include/Types.h>
 #include <glslang/Public/ShaderLang.h>
 
-static Vector<uint8_t> _compile_shader_glsl(RenderingDevice::ShaderStage p_stage, const String &p_source_code, RenderingDevice::ShaderLanguage p_language, String *r_error) {
+static Vector<uint8_t> _compile_shader_glsl(RenderingDevice::ShaderStage p_stage, const String &p_source_code, RenderingDevice::ShaderLanguage p_language, String *r_error, const RenderingDevice::Capabilities *p_capabilities) {
 	Vector<uint8_t> ret;
 
 	ERR_FAIL_COND_V(p_language == RenderingDevice::SHADER_LANGUAGE_HLSL, ret);
@@ -52,9 +52,27 @@ static Vector<uint8_t> _compile_shader_glsl(RenderingDevice::ShaderStage p_stage
 
 	int ClientInputSemanticsVersion = 100; // maps to, say, #define VULKAN 100
 
-	glslang::EShTargetClientVersion VulkanClientVersion = glslang::EShTargetVulkan_1_0;
-	glslang::EShTargetLanguageVersion TargetVersion = glslang::EShTargetSpv_1_3;
+	glslang::EShTargetClientVersion ClientVersion = glslang::EShTargetVulkan_1_2;
+	glslang::EShTargetLanguageVersion TargetVersion = glslang::EShTargetSpv_1_5;
 	glslang::TShader::ForbidIncluder includer;
+
+	if (p_capabilities->device_family == RenderingDevice::DeviceFamily::DEVICE_VULKAN) {
+		if (p_capabilities->version_major == 1 && p_capabilities->version_minor == 0) {
+			ClientVersion = glslang::EShTargetVulkan_1_0;
+			TargetVersion = glslang::EShTargetSpv_1_0;
+		} else if (p_capabilities->version_major == 1 && p_capabilities->version_minor == 1) {
+			ClientVersion = glslang::EShTargetVulkan_1_1;
+			TargetVersion = glslang::EShTargetSpv_1_3;
+		} else {
+			// use defaults
+		}
+	} else {
+		// once we support other backends we'll need to do something here
+		if (r_error) {
+			(*r_error) = "GLSLANG - Unsupported device family";
+		}
+		return ret;
+	}
 
 	glslang::TShader shader(stages[p_stage]);
 	CharString cs = p_source_code.ascii();
@@ -62,7 +80,7 @@ static Vector<uint8_t> _compile_shader_glsl(RenderingDevice::ShaderStage p_stage
 
 	shader.setStrings(&cs_strings, 1);
 	shader.setEnvInput(glslang::EShSourceGlsl, stages[p_stage], glslang::EShClientVulkan, ClientInputSemanticsVersion);
-	shader.setEnvClient(glslang::EShClientVulkan, VulkanClientVersion);
+	shader.setEnvClient(glslang::EShClientVulkan, ClientVersion);
 	shader.setEnvTarget(glslang::EShTargetSpv, TargetVersion);
 
 	EShMessages messages = (EShMessages)(EShMsgSpvRules | EShMsgVulkanRules);

--- a/servers/rendering/renderer_rd/shaders/cluster_render.glsl
+++ b/servers/rendering/renderer_rd/shaders/cluster_render.glsl
@@ -65,7 +65,7 @@ void main() {
 
 VERSION_DEFINES
 
-#if defined(GL_KHR_shader_subgroup_ballot) && defined(GL_KHR_shader_subgroup_arithmetic) && defined(GL_KHR_shader_subgroup_vote)
+#if defined(has_GL_KHR_shader_subgroup_ballot) && defined(has_GL_KHR_shader_subgroup_arithmetic) && defined(has_GL_KHR_shader_subgroup_vote)
 
 #extension GL_KHR_shader_subgroup_ballot : enable
 #extension GL_KHR_shader_subgroup_arithmetic : enable

--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered_inc.glsl
@@ -3,7 +3,7 @@
 
 #define MAX_GI_PROBES 8
 
-#if defined(GL_KHR_shader_subgroup_ballot) && defined(GL_KHR_shader_subgroup_arithmetic)
+#if defined(has_GL_KHR_shader_subgroup_ballot) && defined(has_GL_KHR_shader_subgroup_arithmetic)
 
 #extension GL_KHR_shader_subgroup_ballot : enable
 #extension GL_KHR_shader_subgroup_arithmetic : enable

--- a/servers/rendering/renderer_rd/shaders/volumetric_fog.glsl
+++ b/servers/rendering/renderer_rd/shaders/volumetric_fog.glsl
@@ -5,10 +5,10 @@
 VERSION_DEFINES
 
 /* Do not use subgroups here, seems there is not much advantage and causes glitches
+#if defined(has_GL_KHR_shader_subgroup_ballot) && defined(has_GL_KHR_shader_subgroup_arithmetic)
 #extension GL_KHR_shader_subgroup_ballot: enable
 #extension GL_KHR_shader_subgroup_arithmetic: enable
 
-#if defined(GL_KHR_shader_subgroup_ballot) && defined(GL_KHR_shader_subgroup_arithmetic)
 #define USE_SUBGROUPS
 #endif
 */

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -59,7 +59,7 @@ Vector<uint8_t> RenderingDevice::shader_compile_from_source(ShaderStage p_stage,
 
 	ERR_FAIL_COND_V(!compile_function, Vector<uint8_t>());
 
-	return compile_function(p_stage, p_source_code, p_language, r_error);
+	return compile_function(p_stage, p_source_code, p_language, r_error, &device_capabilities);
 }
 
 RID RenderingDevice::_texture_create(const Ref<RDTextureFormat> &p_format, const Ref<RDTextureView> &p_view, const TypedArray<PackedByteArray> &p_data) {


### PR DESCRIPTION
Adding code to obtain the supported Vulkan version from our Vulkan drivers. This so we can switch what we actually use and prevent resulting crashes.

The problem here is that the required function `vkEnumerateInstanceVersion` is not available in Vulkan 1.0 and is not present in the include files on Android. 
So we need to take the long way around, obtain the function pointer (if this does not exist it means Vulkan 1.0), if it does exist we can call it and parse our version number.

Seems to correctly return `1.2.162` on my Windows machines and `1.1.0` on my Moto G Android phone. 

See https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkApplicationInfo.html#_description for more info

Also adding in support for `vkGetPhysicalDeviceProperties2` to get info about our subgroup capabilities according to:
https://www.khronos.org/blog/vulkan-subgroup-tutorial