### PR TITLE
Add utility methods to Theme, improve error messages and documentation

### DIFF
--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -84,6 +84,19 @@
 				Clears [StyleBox] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
+		<method name="clear_theme_item">
+			<return type="void">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Clears the theme item of [code]data_type[/code] at [code]name[/code] if the theme has [code]node_type[/code].
+			</description>
+		</method>
 		<method name="copy_default_theme">
 			<return type="void">
 			</return>
@@ -194,6 +207,13 @@
 				Returns all the font sizes as a [PackedStringArray] filled with each font size name, for use in [method get_font_size], if the theme has [code]node_type[/code].
 			</description>
 		</method>
+		<method name="get_font_size_type_list" qualifiers="const">
+			<return type="PackedStringArray">
+			</return>
+			<description>
+				Returns all the font size types as a [PackedStringArray] filled with unique type names, for use in [method get_font_size] and/or [method get_font_size_list].
+			</description>
+		</method>
 		<method name="get_font_type_list" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
@@ -255,6 +275,41 @@
 			</return>
 			<description>
 				Returns all the [StyleBox] types as a [PackedStringArray] filled with unique type names, for use in [method get_stylebox] and/or [method get_stylebox_list].
+			</description>
+		</method>
+		<method name="get_theme_item" qualifiers="const">
+			<return type="StyleBox">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Returns the theme item of [code]data_type[/code] at [code]name[/code] if the theme has [code]node_type[/code].
+				Valid [code]name[/code]s may be found using [method get_theme_item_list] or a data type specific method. Valid [code]node_type[/code]s may be found using [method get_theme_item_type_list] or a data type specific method.
+			</description>
+		</method>
+		<method name="get_theme_item_list" qualifiers="const">
+			<return type="PackedStringArray">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="node_type" type="String">
+			</argument>
+			<description>
+				Returns all the theme items of [code]data_type[/code] as a [PackedStringArray] filled with each theme items's name, for use in [method get_theme_item] or a data type specific method, if the theme has [code]node_type[/code].
+				Valid [code]node_type[/code]s may be found using [method get_theme_item_type_list] or a data type specific method.
+			</description>
+		</method>
+		<method name="get_theme_item_type_list" qualifiers="const">
+			<return type="PackedStringArray">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<description>
+				Returns all the theme items of [code]data_type[/code] types as a [PackedStringArray] filled with unique type names, for use in [method get_theme_item], [method get_theme_item_list] or data type specific methods.
 			</description>
 		</method>
 		<method name="get_type_list" qualifiers="const">
@@ -336,6 +391,113 @@
 				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
+		<method name="has_theme_item" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Returns [code]true[/code] if a theme item of [code]data_type[/code] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
+			</description>
+		</method>
+		<method name="rename_color">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="StringName">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Renames the [Color] at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_constant">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="StringName">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Renames the constant at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_font">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="StringName">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Renames the [Font] at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_font_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="StringName">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Renames the font size [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_icon">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="StringName">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Renames the icon at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_stylebox">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="StringName">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Renames [StyleBox] at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_theme_item">
+			<return type="void">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="old_name" type="StringName">
+			</argument>
+			<argument index="2" name="name" type="StringName">
+			</argument>
+			<argument index="3" name="node_type" type="StringName">
+			</argument>
+			<description>
+				Renames the theme item of [code]data_type[/code] at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
 		<method name="set_color">
 			<return type="void">
 			</return>
@@ -347,7 +509,7 @@
 			</argument>
 			<description>
 				Sets the theme's [Color] to [code]color[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 		<method name="set_constant">
@@ -361,7 +523,7 @@
 			</argument>
 			<description>
 				Sets the theme's constant to [code]constant[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 		<method name="set_font">
@@ -375,7 +537,7 @@
 			</argument>
 			<description>
 				Sets the theme's [Font] to [code]font[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 		<method name="set_font_size">
@@ -389,7 +551,7 @@
 			</argument>
 			<description>
 				Sets the theme's font size to [code]font_size[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 		<method name="set_icon">
@@ -403,7 +565,7 @@
 			</argument>
 			<description>
 				Sets the theme's icon [Texture2D] to [code]texture[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 		<method name="set_stylebox">
@@ -417,7 +579,24 @@
 			</argument>
 			<description>
 				Sets theme's [StyleBox] to [code]stylebox[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
+			</description>
+		</method>
+		<method name="set_theme_item">
+			<return type="void">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<argument index="2" name="node_type" type="StringName">
+			</argument>
+			<argument index="3" name="value" type="Variant">
+			</argument>
+			<description>
+				Sets the theme item of [code]data_type[/code] to [code]value[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the [code]value[/code] type does not match [code]data_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 	</methods>
@@ -430,5 +609,26 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="DATA_TYPE_COLOR" value="0" enum="DataType">
+			Theme's [Color] item type.
+		</constant>
+		<constant name="DATA_TYPE_CONSTANT" value="1" enum="DataType">
+			Theme's constant item type.
+		</constant>
+		<constant name="DATA_TYPE_FONT" value="2" enum="DataType">
+			Theme's [Font] item type.
+		</constant>
+		<constant name="DATA_TYPE_FONT_SIZE" value="3" enum="DataType">
+			Theme's font size item type.
+		</constant>
+		<constant name="DATA_TYPE_ICON" value="4" enum="DataType">
+			Theme's icon [Texture2D] item type.
+		</constant>
+		<constant name="DATA_TYPE_STYLEBOX" value="5" enum="DataType">
+			Theme's [StyleBox] item type.
+		</constant>
+		<constant name="DATA_TYPE_MAX" value="6" enum="DataType">
+			Maximum value for the DataType enum.
+		</constant>
 	</constants>
 </class>

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -141,6 +141,21 @@ Vector<String> Theme::_get_font_size_list(const String &p_node_type) const {
 	return ilret;
 }
 
+Vector<String> Theme::_get_font_size_type_list() const {
+	Vector<String> ilret;
+	List<StringName> il;
+
+	get_font_size_type_list(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	String *w = ilret.ptrw();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
 Vector<String> Theme::_get_color_list(const String &p_node_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
@@ -199,6 +214,48 @@ Vector<String> Theme::_get_constant_type_list() const {
 		w[i] = E->get();
 	}
 	return ilret;
+}
+
+Vector<String> Theme::_get_theme_item_list(DataType p_data_type, const String &p_node_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return _get_color_list(p_node_type);
+		case DATA_TYPE_CONSTANT:
+			return _get_constant_list(p_node_type);
+		case DATA_TYPE_FONT:
+			return _get_font_list(p_node_type);
+		case DATA_TYPE_FONT_SIZE:
+			return _get_font_size_list(p_node_type);
+		case DATA_TYPE_ICON:
+			return _get_icon_list(p_node_type);
+		case DATA_TYPE_STYLEBOX:
+			return _get_stylebox_list(p_node_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return Vector<String>();
+}
+
+Vector<String> Theme::_get_theme_item_type_list(DataType p_data_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return _get_color_type_list();
+		case DATA_TYPE_CONSTANT:
+			return _get_constant_type_list();
+		case DATA_TYPE_FONT:
+			return _get_font_type_list();
+		case DATA_TYPE_FONT_SIZE:
+			return _get_font_size_type_list();
+		case DATA_TYPE_ICON:
+			return _get_icon_type_list();
+		case DATA_TYPE_STYLEBOX:
+			return _get_stylebox_type_list();
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return Vector<String>();
 }
 
 Vector<String> Theme::_get_type_list() const {
@@ -421,8 +478,6 @@ void Theme::set_default_font_size(int p_font_size) {
 }
 
 void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture2D> &p_icon) {
-	//ERR_FAIL_COND(p_icon.is_null());
-
 	bool new_value = !icon_map.has(p_node_type) || !icon_map[p_node_type].has(p_name);
 
 	if (icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
@@ -453,9 +508,21 @@ bool Theme::has_icon(const StringName &p_name, const StringName &p_node_type) co
 	return (icon_map.has(p_node_type) && icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid());
 }
 
+void Theme::rename_icon(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!icon_map.has(p_node_type), "Cannot rename the icon '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(icon_map[p_node_type].has(p_name), "Cannot rename the icon '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!icon_map[p_node_type].has(p_old_name), "Cannot rename the icon '" + String(p_old_name) + "' because it does not exist.");
+
+	icon_map[p_node_type][p_name] = icon_map[p_node_type][p_old_name];
+	icon_map[p_node_type].erase(p_old_name);
+
+	notify_property_list_changed();
+	emit_changed();
+}
+
 void Theme::clear_icon(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!icon_map.has(p_node_type));
-	ERR_FAIL_COND(!icon_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!icon_map.has(p_node_type), "Cannot clear the icon '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!icon_map[p_node_type].has(p_name), "Cannot clear the icon '" + String(p_name) + "' because it does not exist.");
 
 	if (icon_map[p_node_type][p_name].is_valid()) {
 		icon_map[p_node_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
@@ -481,6 +548,10 @@ void Theme::get_icon_list(StringName p_node_type, List<StringName> *p_list) cons
 	}
 }
 
+void Theme::add_icon_type(const StringName &p_node_type) {
+	icon_map[p_node_type] = HashMap<StringName, Ref<Texture2D>>();
+}
+
 void Theme::get_icon_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
@@ -491,8 +562,6 @@ void Theme::get_icon_type_list(List<StringName> *p_list) const {
 }
 
 void Theme::set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style) {
-	//ERR_FAIL_COND(p_style.is_null());
-
 	bool new_value = !style_map.has(p_node_type) || !style_map[p_node_type].has(p_name);
 
 	if (style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid()) {
@@ -523,9 +592,21 @@ bool Theme::has_stylebox(const StringName &p_name, const StringName &p_node_type
 	return (style_map.has(p_node_type) && style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid());
 }
 
+void Theme::rename_stylebox(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!style_map.has(p_node_type), "Cannot rename the stylebox '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(style_map[p_node_type].has(p_name), "Cannot rename the stylebox '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!style_map[p_node_type].has(p_old_name), "Cannot rename the stylebox '" + String(p_old_name) + "' because it does not exist.");
+
+	style_map[p_node_type][p_name] = style_map[p_node_type][p_old_name];
+	style_map[p_node_type].erase(p_old_name);
+
+	notify_property_list_changed();
+	emit_changed();
+}
+
 void Theme::clear_stylebox(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!style_map.has(p_node_type));
-	ERR_FAIL_COND(!style_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!style_map.has(p_node_type), "Cannot clear the stylebox '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!style_map[p_node_type].has(p_name), "Cannot clear the stylebox '" + String(p_name) + "' because it does not exist.");
 
 	if (style_map[p_node_type][p_name].is_valid()) {
 		style_map[p_node_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
@@ -551,6 +632,10 @@ void Theme::get_stylebox_list(StringName p_node_type, List<StringName> *p_list) 
 	}
 }
 
+void Theme::add_stylebox_type(const StringName &p_node_type) {
+	style_map[p_node_type] = HashMap<StringName, Ref<StyleBox>>();
+}
+
 void Theme::get_stylebox_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
@@ -561,8 +646,6 @@ void Theme::get_stylebox_type_list(List<StringName> *p_list) const {
 }
 
 void Theme::set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font) {
-	//ERR_FAIL_COND(p_font.is_null());
-
 	bool new_value = !font_map.has(p_node_type) || !font_map[p_node_type].has(p_name);
 
 	if (font_map[p_node_type][p_name].is_valid()) {
@@ -595,9 +678,21 @@ bool Theme::has_font(const StringName &p_name, const StringName &p_node_type) co
 	return ((font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid()) || default_theme_font.is_valid());
 }
 
+void Theme::rename_font(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!font_map.has(p_node_type), "Cannot rename the font '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(font_map[p_node_type].has(p_name), "Cannot rename the font '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!font_map[p_node_type].has(p_old_name), "Cannot rename the font '" + String(p_old_name) + "' because it does not exist.");
+
+	font_map[p_node_type][p_name] = font_map[p_node_type][p_old_name];
+	font_map[p_node_type].erase(p_old_name);
+
+	notify_property_list_changed();
+	emit_changed();
+}
+
 void Theme::clear_font(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!font_map.has(p_node_type));
-	ERR_FAIL_COND(!font_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!font_map.has(p_node_type), "Cannot clear the font '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!font_map[p_node_type].has(p_name), "Cannot clear the font '" + String(p_name) + "' because it does not exist.");
 
 	if (font_map[p_node_type][p_name].is_valid()) {
 		font_map[p_node_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
@@ -620,6 +715,10 @@ void Theme::get_font_list(StringName p_node_type, List<StringName> *p_list) cons
 	while ((key = font_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
+}
+
+void Theme::add_font_type(const StringName &p_node_type) {
+	font_map[p_node_type] = HashMap<StringName, Ref<Font>>();
 }
 
 void Theme::get_font_type_list(List<StringName> *p_list) const {
@@ -656,9 +755,21 @@ bool Theme::has_font_size(const StringName &p_name, const StringName &p_node_typ
 	return ((font_size_map.has(p_node_type) && font_size_map[p_node_type].has(p_name) && (font_size_map[p_node_type][p_name] > 0)) || (default_theme_font_size > 0));
 }
 
+void Theme::rename_font_size(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!font_size_map.has(p_node_type), "Cannot rename the font size '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(font_size_map[p_node_type].has(p_name), "Cannot rename the font size '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!font_size_map[p_node_type].has(p_old_name), "Cannot rename the font size '" + String(p_old_name) + "' because it does not exist.");
+
+	font_size_map[p_node_type][p_name] = font_size_map[p_node_type][p_old_name];
+	font_size_map[p_node_type].erase(p_old_name);
+
+	notify_property_list_changed();
+	emit_changed();
+}
+
 void Theme::clear_font_size(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!font_size_map.has(p_node_type));
-	ERR_FAIL_COND(!font_size_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!font_size_map.has(p_node_type), "Cannot clear the font size '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!font_size_map[p_node_type].has(p_name), "Cannot clear the font size '" + String(p_name) + "' because it does not exist.");
 
 	font_size_map[p_node_type].erase(p_name);
 	notify_property_list_changed();
@@ -675,6 +786,19 @@ void Theme::get_font_size_list(StringName p_node_type, List<StringName> *p_list)
 	const StringName *key = nullptr;
 
 	while ((key = font_size_map[p_node_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::add_font_size_type(const StringName &p_node_type) {
+	font_size_map[p_node_type] = HashMap<StringName, int>();
+}
+
+void Theme::get_font_size_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = font_size_map.next(key))) {
 		p_list->push_back(*key);
 	}
 }
@@ -702,9 +826,21 @@ bool Theme::has_color(const StringName &p_name, const StringName &p_node_type) c
 	return (color_map.has(p_node_type) && color_map[p_node_type].has(p_name));
 }
 
+void Theme::rename_color(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!color_map.has(p_node_type), "Cannot rename the color '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(color_map[p_node_type].has(p_name), "Cannot rename the color '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!color_map[p_node_type].has(p_old_name), "Cannot rename the color '" + String(p_old_name) + "' because it does not exist.");
+
+	color_map[p_node_type][p_name] = color_map[p_node_type][p_old_name];
+	color_map[p_node_type].erase(p_old_name);
+
+	notify_property_list_changed();
+	emit_changed();
+}
+
 void Theme::clear_color(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!color_map.has(p_node_type));
-	ERR_FAIL_COND(!color_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!color_map.has(p_node_type), "Cannot clear the color '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!color_map[p_node_type].has(p_name), "Cannot clear the color '" + String(p_name) + "' because it does not exist.");
 
 	color_map[p_node_type].erase(p_name);
 	notify_property_list_changed();
@@ -723,6 +859,10 @@ void Theme::get_color_list(StringName p_node_type, List<StringName> *p_list) con
 	while ((key = color_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
+}
+
+void Theme::add_color_type(const StringName &p_node_type) {
+	color_map[p_node_type] = HashMap<StringName, Color>();
 }
 
 void Theme::get_color_type_list(List<StringName> *p_list) const {
@@ -756,9 +896,21 @@ bool Theme::has_constant(const StringName &p_name, const StringName &p_node_type
 	return (constant_map.has(p_node_type) && constant_map[p_node_type].has(p_name));
 }
 
+void Theme::rename_constant(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!constant_map.has(p_node_type), "Cannot rename the constant '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(constant_map[p_node_type].has(p_name), "Cannot rename the constant '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!constant_map[p_node_type].has(p_old_name), "Cannot rename the constant '" + String(p_old_name) + "' because it does not exist.");
+
+	constant_map[p_node_type][p_name] = constant_map[p_node_type][p_old_name];
+	constant_map[p_node_type].erase(p_old_name);
+
+	notify_property_list_changed();
+	emit_changed();
+}
+
 void Theme::clear_constant(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!constant_map.has(p_node_type));
-	ERR_FAIL_COND(!constant_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!constant_map.has(p_node_type), "Cannot clear the constant '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!constant_map[p_node_type].has(p_name), "Cannot clear the constant '" + String(p_name) + "' because it does not exist.");
 
 	constant_map[p_node_type].erase(p_name);
 	notify_property_list_changed();
@@ -779,12 +931,226 @@ void Theme::get_constant_list(StringName p_node_type, List<StringName> *p_list) 
 	}
 }
 
+void Theme::add_constant_type(const StringName &p_node_type) {
+	constant_map[p_node_type] = HashMap<StringName, int>();
+}
+
 void Theme::get_constant_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
 	const StringName *key = nullptr;
 	while ((key = constant_map.next(key))) {
 		p_list->push_back(*key);
+	}
+}
+
+void Theme::set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type, const Variant &p_value) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::COLOR, "Theme item's data type (Color) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Color color_value = p_value;
+			set_color(p_name, p_node_type, color_value);
+		} break;
+		case DATA_TYPE_CONSTANT: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::INT, "Theme item's data type (int) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			int constant_value = p_value;
+			set_constant(p_name, p_node_type, constant_value);
+		} break;
+		case DATA_TYPE_FONT: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<Font> font_value = Object::cast_to<Font>(p_value.get_validated_object());
+			set_font(p_name, p_node_type, font_value);
+		} break;
+		case DATA_TYPE_FONT_SIZE: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::INT, "Theme item's data type (int) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			int font_size_value = p_value;
+			set_font_size(p_name, p_node_type, font_size_value);
+		} break;
+		case DATA_TYPE_ICON: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<Texture2D> icon_value = Object::cast_to<Texture2D>(p_value.get_validated_object());
+			set_icon(p_name, p_node_type, icon_value);
+		} break;
+		case DATA_TYPE_STYLEBOX: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<StyleBox> stylebox_value = Object::cast_to<StyleBox>(p_value.get_validated_object());
+			set_stylebox(p_name, p_node_type, stylebox_value);
+		} break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+Variant Theme::get_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return get_color(p_name, p_node_type);
+		case DATA_TYPE_CONSTANT:
+			return get_constant(p_name, p_node_type);
+		case DATA_TYPE_FONT:
+			return get_font(p_name, p_node_type);
+		case DATA_TYPE_FONT_SIZE:
+			return get_font_size(p_name, p_node_type);
+		case DATA_TYPE_ICON:
+			return get_icon(p_name, p_node_type);
+		case DATA_TYPE_STYLEBOX:
+			return get_stylebox(p_name, p_node_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return Variant();
+}
+
+bool Theme::has_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return has_color(p_name, p_node_type);
+		case DATA_TYPE_CONSTANT:
+			return has_constant(p_name, p_node_type);
+		case DATA_TYPE_FONT:
+			return has_font(p_name, p_node_type);
+		case DATA_TYPE_FONT_SIZE:
+			return has_font_size(p_name, p_node_type);
+		case DATA_TYPE_ICON:
+			return has_icon(p_name, p_node_type);
+		case DATA_TYPE_STYLEBOX:
+			return has_stylebox(p_name, p_node_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return false;
+}
+
+void Theme::rename_theme_item(DataType p_data_type, const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			rename_color(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			rename_constant(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_FONT:
+			rename_font(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			rename_font_size(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_ICON:
+			rename_icon(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			rename_stylebox(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::clear_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			clear_color(p_name, p_node_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			clear_constant(p_name, p_node_type);
+			break;
+		case DATA_TYPE_FONT:
+			clear_font(p_name, p_node_type);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			clear_font_size(p_name, p_node_type);
+			break;
+		case DATA_TYPE_ICON:
+			clear_icon(p_name, p_node_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			clear_stylebox(p_name, p_node_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::get_theme_item_list(DataType p_data_type, StringName p_node_type, List<StringName> *p_list) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			get_color_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_CONSTANT:
+			get_constant_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_FONT:
+			get_font_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			get_font_size_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_ICON:
+			get_icon_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			get_stylebox_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::add_theme_item_type(DataType p_data_type, const StringName &p_node_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			add_color_type(p_node_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			add_constant_type(p_node_type);
+			break;
+		case DATA_TYPE_FONT:
+			add_font_type(p_node_type);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			add_font_size_type(p_node_type);
+			break;
+		case DATA_TYPE_ICON:
+			add_icon_type(p_node_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			add_stylebox_type(p_node_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::get_theme_item_type_list(DataType p_data_type, List<StringName> *p_list) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			get_color_type_list(p_list);
+			break;
+		case DATA_TYPE_CONSTANT:
+			get_constant_type_list(p_list);
+			break;
+		case DATA_TYPE_FONT:
+			get_font_type_list(p_list);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			get_font_size_type_list(p_list);
+			break;
+		case DATA_TYPE_ICON:
+			get_icon_type_list(p_list);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			get_stylebox_type_list(p_list);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
 	}
 }
 
@@ -847,11 +1213,10 @@ void Theme::copy_default_theme() {
 void Theme::copy_theme(const Ref<Theme> &p_other) {
 	if (p_other.is_null()) {
 		clear();
-
 		return;
 	}
 
-	//these need reconnecting, so add normally
+	// These items need reconnecting, so add them normally.
 	{
 		const StringName *K = nullptr;
 		while ((K = p_other->icon_map.next(K))) {
@@ -882,8 +1247,8 @@ void Theme::copy_theme(const Ref<Theme> &p_other) {
 		}
 	}
 
-	//these are ok to just copy
-
+	// These items can be simply copied.
+	font_size_map = p_other->font_size_map;
 	color_map = p_other->color_map;
 	constant_map = p_other->constant_map;
 
@@ -937,6 +1302,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_icon", "name", "node_type", "texture"), &Theme::set_icon);
 	ClassDB::bind_method(D_METHOD("get_icon", "name", "node_type"), &Theme::get_icon);
 	ClassDB::bind_method(D_METHOD("has_icon", "name", "node_type"), &Theme::has_icon);
+	ClassDB::bind_method(D_METHOD("rename_icon", "old_name", "name", "node_type"), &Theme::rename_icon);
 	ClassDB::bind_method(D_METHOD("clear_icon", "name", "node_type"), &Theme::clear_icon);
 	ClassDB::bind_method(D_METHOD("get_icon_list", "node_type"), &Theme::_get_icon_list);
 	ClassDB::bind_method(D_METHOD("get_icon_type_list"), &Theme::_get_icon_type_list);
@@ -944,6 +1310,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stylebox", "name", "node_type", "texture"), &Theme::set_stylebox);
 	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "node_type"), &Theme::get_stylebox);
 	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "node_type"), &Theme::has_stylebox);
+	ClassDB::bind_method(D_METHOD("rename_stylebox", "old_name", "name", "node_type"), &Theme::rename_stylebox);
 	ClassDB::bind_method(D_METHOD("clear_stylebox", "name", "node_type"), &Theme::clear_stylebox);
 	ClassDB::bind_method(D_METHOD("get_stylebox_list", "node_type"), &Theme::_get_stylebox_list);
 	ClassDB::bind_method(D_METHOD("get_stylebox_type_list"), &Theme::_get_stylebox_type_list);
@@ -951,6 +1318,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_font", "name", "node_type", "font"), &Theme::set_font);
 	ClassDB::bind_method(D_METHOD("get_font", "name", "node_type"), &Theme::get_font);
 	ClassDB::bind_method(D_METHOD("has_font", "name", "node_type"), &Theme::has_font);
+	ClassDB::bind_method(D_METHOD("rename_font", "old_name", "name", "node_type"), &Theme::rename_font);
 	ClassDB::bind_method(D_METHOD("clear_font", "name", "node_type"), &Theme::clear_font);
 	ClassDB::bind_method(D_METHOD("get_font_list", "node_type"), &Theme::_get_font_list);
 	ClassDB::bind_method(D_METHOD("get_font_type_list"), &Theme::_get_font_type_list);
@@ -958,12 +1326,15 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_font_size", "name", "node_type", "font_size"), &Theme::set_font_size);
 	ClassDB::bind_method(D_METHOD("get_font_size", "name", "node_type"), &Theme::get_font_size);
 	ClassDB::bind_method(D_METHOD("has_font_size", "name", "node_type"), &Theme::has_font_size);
+	ClassDB::bind_method(D_METHOD("rename_font_size", "old_name", "name", "node_type"), &Theme::rename_font_size);
 	ClassDB::bind_method(D_METHOD("clear_font_size", "name", "node_type"), &Theme::clear_font_size);
 	ClassDB::bind_method(D_METHOD("get_font_size_list", "node_type"), &Theme::_get_font_size_list);
+	ClassDB::bind_method(D_METHOD("get_font_size_type_list"), &Theme::_get_font_size_type_list);
 
 	ClassDB::bind_method(D_METHOD("set_color", "name", "node_type", "color"), &Theme::set_color);
 	ClassDB::bind_method(D_METHOD("get_color", "name", "node_type"), &Theme::get_color);
 	ClassDB::bind_method(D_METHOD("has_color", "name", "node_type"), &Theme::has_color);
+	ClassDB::bind_method(D_METHOD("rename_color", "old_name", "name", "node_type"), &Theme::rename_color);
 	ClassDB::bind_method(D_METHOD("clear_color", "name", "node_type"), &Theme::clear_color);
 	ClassDB::bind_method(D_METHOD("get_color_list", "node_type"), &Theme::_get_color_list);
 	ClassDB::bind_method(D_METHOD("get_color_type_list"), &Theme::_get_color_type_list);
@@ -971,6 +1342,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_constant", "name", "node_type", "constant"), &Theme::set_constant);
 	ClassDB::bind_method(D_METHOD("get_constant", "name", "node_type"), &Theme::get_constant);
 	ClassDB::bind_method(D_METHOD("has_constant", "name", "node_type"), &Theme::has_constant);
+	ClassDB::bind_method(D_METHOD("rename_constant", "old_name", "name", "node_type"), &Theme::rename_constant);
 	ClassDB::bind_method(D_METHOD("clear_constant", "name", "node_type"), &Theme::clear_constant);
 	ClassDB::bind_method(D_METHOD("get_constant_list", "node_type"), &Theme::_get_constant_list);
 	ClassDB::bind_method(D_METHOD("get_constant_type_list"), &Theme::_get_constant_type_list);
@@ -983,6 +1355,14 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_default_font_size", "font_size"), &Theme::set_default_theme_font_size);
 	ClassDB::bind_method(D_METHOD("get_default_font_size"), &Theme::get_default_theme_font_size);
 
+	ClassDB::bind_method(D_METHOD("set_theme_item", "data_type", "name", "node_type", "value"), &Theme::set_theme_item);
+	ClassDB::bind_method(D_METHOD("get_theme_item", "data_type", "name", "node_type"), &Theme::get_theme_item);
+	ClassDB::bind_method(D_METHOD("has_theme_item", "data_type", "name", "node_type"), &Theme::has_theme_item);
+	ClassDB::bind_method(D_METHOD("rename_theme_item", "data_type", "old_name", "name", "node_type"), &Theme::rename_theme_item);
+	ClassDB::bind_method(D_METHOD("clear_theme_item", "data_type", "name", "node_type"), &Theme::clear_theme_item);
+	ClassDB::bind_method(D_METHOD("get_theme_item_list", "data_type", "node_type"), &Theme::_get_theme_item_list);
+	ClassDB::bind_method(D_METHOD("get_theme_item_type_list", "data_type"), &Theme::_get_theme_item_type_list);
+
 	ClassDB::bind_method(D_METHOD("get_type_list"), &Theme::_get_type_list);
 
 	ClassDB::bind_method("copy_default_theme", &Theme::copy_default_theme);
@@ -990,6 +1370,14 @@ void Theme::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "default_font", PROPERTY_HINT_RESOURCE_TYPE, "Font"), "set_default_font", "get_default_font");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "default_font_size"), "set_default_font_size", "get_default_font_size");
+
+	BIND_ENUM_CONSTANT(DATA_TYPE_ICON);
+	BIND_ENUM_CONSTANT(DATA_TYPE_STYLEBOX);
+	BIND_ENUM_CONSTANT(DATA_TYPE_FONT);
+	BIND_ENUM_CONSTANT(DATA_TYPE_FONT_SIZE);
+	BIND_ENUM_CONSTANT(DATA_TYPE_COLOR);
+	BIND_ENUM_CONSTANT(DATA_TYPE_CONSTANT);
+	BIND_ENUM_CONSTANT(DATA_TYPE_MAX);
 }
 
 Theme::Theme() {

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -41,6 +41,18 @@ class Theme : public Resource {
 	GDCLASS(Theme, Resource);
 	RES_BASE_EXTENSION("theme");
 
+public:
+	enum DataType {
+		DATA_TYPE_COLOR,
+		DATA_TYPE_CONSTANT,
+		DATA_TYPE_FONT,
+		DATA_TYPE_FONT_SIZE,
+		DATA_TYPE_ICON,
+		DATA_TYPE_STYLEBOX,
+		DATA_TYPE_MAX
+	};
+
+private:
 	void _emit_theme_changed();
 
 	HashMap<StringName, HashMap<StringName, Ref<Texture2D>>> icon_map;
@@ -57,10 +69,14 @@ class Theme : public Resource {
 	Vector<String> _get_font_list(const String &p_node_type) const;
 	Vector<String> _get_font_type_list() const;
 	Vector<String> _get_font_size_list(const String &p_node_type) const;
+	Vector<String> _get_font_size_type_list() const;
 	Vector<String> _get_color_list(const String &p_node_type) const;
 	Vector<String> _get_color_type_list() const;
 	Vector<String> _get_constant_list(const String &p_node_type) const;
 	Vector<String> _get_constant_type_list() const;
+
+	Vector<String> _get_theme_item_list(DataType p_data_type, const String &p_node_type) const;
+	Vector<String> _get_theme_item_type_list(DataType p_data_type) const;
 	Vector<String> _get_type_list() const;
 
 protected:
@@ -103,43 +119,65 @@ public:
 	void set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_icon(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_icon(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_icon(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_icon(const StringName &p_name, const StringName &p_node_type);
 	void get_icon_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_icon_type(const StringName &p_node_type);
 	void get_icon_type_list(List<StringName> *p_list) const;
 
 	void set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style);
 	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_stylebox(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_stylebox(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_stylebox(const StringName &p_name, const StringName &p_node_type);
 	void get_stylebox_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_stylebox_type(const StringName &p_node_type);
 	void get_stylebox_type_list(List<StringName> *p_list) const;
 
 	void set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font);
 	Ref<Font> get_font(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_font(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_font(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_font(const StringName &p_name, const StringName &p_node_type);
 	void get_font_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_font_type(const StringName &p_node_type);
 	void get_font_type_list(List<StringName> *p_list) const;
 
 	void set_font_size(const StringName &p_name, const StringName &p_node_type, int p_font_size);
 	int get_font_size(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_font_size(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_font_size(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_font_size(const StringName &p_name, const StringName &p_node_type);
 	void get_font_size_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_font_size_type(const StringName &p_node_type);
+	void get_font_size_type_list(List<StringName> *p_list) const;
 
 	void set_color(const StringName &p_name, const StringName &p_node_type, const Color &p_color);
 	Color get_color(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_color(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_color(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_color(const StringName &p_name, const StringName &p_node_type);
 	void get_color_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_color_type(const StringName &p_node_type);
 	void get_color_type_list(List<StringName> *p_list) const;
 
 	void set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant);
 	int get_constant(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_constant(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_constant(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_constant(const StringName &p_name, const StringName &p_node_type);
 	void get_constant_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_constant_type(const StringName &p_node_type);
 	void get_constant_type_list(List<StringName> *p_list) const;
+
+	void set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type, const Variant &p_value);
+	Variant get_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) const;
+	bool has_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) const;
+	void rename_theme_item(DataType p_data_type, const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
+	void clear_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type);
+	void get_theme_item_list(DataType p_data_type, StringName p_node_type, List<StringName> *p_list) const;
+	void add_theme_item_type(DataType p_data_type, const StringName &p_node_type);
+	void get_theme_item_type_list(DataType p_data_type, List<StringName> *p_list) const;
 
 	void get_type_list(List<StringName> *p_list) const;
 
@@ -150,5 +188,7 @@ public:
 	Theme();
 	~Theme();
 };
+
+VARIANT_ENUM_CAST(Theme::DataType);
 
 #endif


### PR DESCRIPTION
This adds several utility methods that can be used to replace a lot of boilerplate code mentioned in https://github.com/godotengine/godot/pull/46593#issuecomment-792306683. While mostly useful internally, users can find them handy as well, especially plugin developers. So I've exposed them.

This PR also includes all theme additions from #46593 and #46808, so that they can be tested and merged separately (and those PRs can then be rebased).

This should be portable to `3.x`, likely even cherrypickable.

-----

* Added missing `get_font_size_type_list()` method.
* Added `rename_X()` methods for renaming theme items.
* Added `add_X_type()` method for creating empty theme item types; *these methods are not exposed to the API to prevent confusion from users thinking calling them is necessary, when in fact all `set_X` methods implicitly create types*.
* Added `DataType` enum and `VERB_theme_item_X()` methods to perform all the same tasks as are available for individual item types but without hardcoding all the function names.