### PR TITLE
[3.x] Make all file access 64-bit (take 2)

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1900,18 +1900,21 @@ String _File::get_path_absolute() const {
 
 void _File::seek(int64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
+	ERR_FAIL_COND_MSG(p_position < 0, "Seek position must be a positive integer.");
 	f->seek(p_position);
 }
+
 void _File::seek_end(int64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	f->seek_end(p_position);
 }
-int64_t _File::get_position() const {
+
+uint64_t _File::get_position() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_position();
 }
 
-int64_t _File::get_len() const {
+uint64_t _File::get_len() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	return f->get_len();
 }
@@ -1951,7 +1954,7 @@ real_t _File::get_real() const {
 	return f->get_real();
 }
 
-PoolVector<uint8_t> _File::get_buffer(int p_length) const {
+PoolVector<uint8_t> _File::get_buffer(int64_t p_length) const {
 	PoolVector<uint8_t> data;
 	ERR_FAIL_COND_V_MSG(!f, data, "File must be opened before use.");
 
@@ -1964,7 +1967,7 @@ PoolVector<uint8_t> _File::get_buffer(int p_length) const {
 	ERR_FAIL_COND_V_MSG(err != OK, data, "Can't resize data to " + itos(p_length) + " elements.");
 
 	PoolVector<uint8_t>::Write w = data.write();
-	int len = f->get_buffer(&w[0], p_length);
+	int64_t len = f->get_buffer(&w[0], p_length);
 	ERR_FAIL_COND_V(len < 0, PoolVector<uint8_t>());
 
 	w.release();
@@ -1980,7 +1983,7 @@ String _File::get_as_text() const {
 	ERR_FAIL_COND_V_MSG(!f, String(), "File must be opened before use.");
 
 	String text;
-	size_t original_pos = f->get_position();
+	uint64_t original_pos = f->get_position();
 	f->seek(0);
 
 	String l = get_line();
@@ -2103,7 +2106,7 @@ void _File::store_csv_line(const Vector<String> &p_values, const String &p_delim
 void _File::store_buffer(const PoolVector<uint8_t> &p_buffer) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
-	int len = p_buffer.size();
+	uint64_t len = p_buffer.size();
 	if (len == 0) {
 		return;
 	}
@@ -2341,9 +2344,9 @@ bool _Directory::dir_exists(String p_dir) {
 	}
 }
 
-int _Directory::get_space_left() {
+uint64_t _Directory::get_space_left() {
 	ERR_FAIL_COND_V_MSG(!d, 0, "Directory must be opened before use.");
-	return d->get_space_left() / 1024 * 1024; //return value in megabytes, given binding is int
+	return d->get_space_left() / 1024 * 1024; // Truncate to closest MiB.
 }
 
 Error _Directory::copy(String p_from, String p_to) {

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -516,8 +516,8 @@ public:
 
 	void seek(int64_t p_position); // Seek to a given position.
 	void seek_end(int64_t p_position = 0); // Seek from the end of file.
-	int64_t get_position() const; // Get position in the file.
-	int64_t get_len() const; // Get size of the file.
+	uint64_t get_position() const; // Get position in the file.
+	uint64_t get_len() const; // Get size of the file.
 
 	bool eof_reached() const; // Reading passed EOF.
 
@@ -532,7 +532,7 @@ public:
 
 	Variant get_var(bool p_allow_objects = false) const;
 
-	PoolVector<uint8_t> get_buffer(int p_length) const; // Get an array of bytes.
+	PoolVector<uint8_t> get_buffer(int64_t p_length) const; // Get an array of bytes.
 	String get_line() const;
 	Vector<String> get_csv_line(const String &p_delim = ",") const;
 	String get_as_text() const;
@@ -609,7 +609,7 @@ public:
 	bool file_exists(String p_file);
 	bool dir_exists(String p_dir);
 
-	int get_space_left();
+	uint64_t get_space_left();
 
 	Error copy(String p_from, String p_to);
 	Error rename(String p_from, String p_to);

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -32,7 +32,7 @@
 
 #include "core/print_string.h"
 
-void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_mode, int p_block_size) {
+void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_mode, uint32_t p_block_size) {
 	magic = p_magic.ascii().get_data();
 	if (magic.length() > 4) {
 		magic = magic.substr(0, 4);
@@ -67,10 +67,10 @@ Error FileAccessCompressed::open_after_magic(FileAccess *p_base) {
 		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Can't open compressed file '" + p_base->get_path() + "' with block size 0, it is corrupted.");
 	}
 	read_total = f->get_32();
-	int bc = (read_total / block_size) + 1;
-	int acc_ofs = f->get_position() + bc * 4;
-	int max_bs = 0;
-	for (int i = 0; i < bc; i++) {
+	uint32_t bc = (read_total / block_size) + 1;
+	uint64_t acc_ofs = f->get_position() + bc * 4;
+	uint32_t max_bs = 0;
+	for (uint32_t i = 0; i < bc; i++) {
 		ReadBlock rb;
 		rb.offset = acc_ofs;
 		rb.csize = f->get_32();
@@ -147,15 +147,15 @@ void FileAccessCompressed::close() {
 		f->store_32(cmode); //write compression mode 4
 		f->store_32(block_size); //write block size 4
 		f->store_32(write_max); //max amount of data written 4
-		int bc = (write_max / block_size) + 1;
+		uint32_t bc = (write_max / block_size) + 1;
 
-		for (int i = 0; i < bc; i++) {
+		for (uint32_t i = 0; i < bc; i++) {
 			f->store_32(0); //compressed sizes, will update later
 		}
 
 		Vector<int> block_sizes;
-		for (int i = 0; i < bc; i++) {
-			int bl = i == (bc - 1) ? write_max % block_size : block_size;
+		for (uint32_t i = 0; i < bc; i++) {
+			uint32_t bl = i == (bc - 1) ? write_max % block_size : block_size;
 			uint8_t *bp = &write_ptr[i * block_size];
 
 			Vector<uint8_t> cblock;
@@ -167,7 +167,7 @@ void FileAccessCompressed::close() {
 		}
 
 		f->seek(16); //ok write block sizes
-		for (int i = 0; i < bc; i++) {
+		for (uint32_t i = 0; i < bc; i++) {
 			f->store_32(block_sizes[i]);
 		}
 		f->seek_end();
@@ -189,8 +189,9 @@ bool FileAccessCompressed::is_open() const {
 	return f != nullptr;
 }
 
-void FileAccessCompressed::seek(size_t p_position) {
+void FileAccessCompressed::seek(uint64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
+
 	if (writing) {
 		ERR_FAIL_COND(p_position > write_max);
 
@@ -203,7 +204,7 @@ void FileAccessCompressed::seek(size_t p_position) {
 		} else {
 			at_end = false;
 			read_eof = false;
-			int block_idx = p_position / block_size;
+			uint32_t block_idx = p_position / block_size;
 			if (block_idx != read_block) {
 				read_block = block_idx;
 				f->seek(read_blocks[read_block].offset);
@@ -225,7 +226,8 @@ void FileAccessCompressed::seek_end(int64_t p_position) {
 		seek(read_total + p_position);
 	}
 }
-size_t FileAccessCompressed::get_position() const {
+
+uint64_t FileAccessCompressed::get_position() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	if (writing) {
 		return write_pos;
@@ -233,7 +235,8 @@ size_t FileAccessCompressed::get_position() const {
 		return read_block * block_size + read_pos;
 	}
 }
-size_t FileAccessCompressed::get_len() const {
+
+uint64_t FileAccessCompressed::get_len() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	if (writing) {
 		return write_max;
@@ -281,9 +284,9 @@ uint8_t FileAccessCompressed::get_8() const {
 
 	return ret;
 }
-int FileAccessCompressed::get_buffer(uint8_t *p_dst, int p_length) const {
+
+uint64_t FileAccessCompressed::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V_MSG(!f, -1, "File must be opened before use.");
 	ERR_FAIL_COND_V_MSG(writing, -1, "File has not been opened in read mode.");
 
@@ -292,7 +295,7 @@ int FileAccessCompressed::get_buffer(uint8_t *p_dst, int p_length) const {
 		return 0;
 	}
 
-	for (int i = 0; i < p_length; i++) {
+	for (uint64_t i = 0; i < p_length; i++) {
 		p_dst[i] = read_ptr[read_pos];
 		read_pos++;
 		if (read_pos >= read_block_size) {

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -37,34 +37,34 @@
 class FileAccessCompressed : public FileAccess {
 	Compression::Mode cmode;
 	bool writing;
-	uint32_t write_pos;
+	uint64_t write_pos;
 	uint8_t *write_ptr;
 	uint32_t write_buffer_size;
-	uint32_t write_max;
+	uint64_t write_max;
 	uint32_t block_size;
 	mutable bool read_eof;
 	mutable bool at_end;
 
 	struct ReadBlock {
-		int csize;
-		int offset;
+		uint32_t csize;
+		uint64_t offset;
 	};
 
 	mutable Vector<uint8_t> comp_buffer;
 	uint8_t *read_ptr;
-	mutable int read_block;
-	int read_block_count;
-	mutable int read_block_size;
-	mutable int read_pos;
+	mutable uint32_t read_block;
+	uint32_t read_block_count;
+	mutable uint32_t read_block_size;
+	mutable uint64_t read_pos;
 	Vector<ReadBlock> read_blocks;
-	uint32_t read_total;
+	uint64_t read_total;
 
 	String magic;
 	mutable Vector<uint8_t> buffer;
 	FileAccess *f;
 
 public:
-	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, int p_block_size = 4096);
+	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, uint32_t p_block_size = 4096);
 
 	Error open_after_magic(FileAccess *p_base);
 
@@ -72,15 +72,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -67,20 +67,20 @@ Error FileAccessEncrypted::open_and_parse(FileAccess *p_base, const Vector<uint8
 		length = p_base->get_64();
 		base = p_base->get_position();
 		ERR_FAIL_COND_V(p_base->get_len() < base + length, ERR_FILE_CORRUPT);
-		uint32_t ds = length;
+		uint64_t ds = length;
 		if (ds % 16) {
 			ds += 16 - (ds % 16);
 		}
 
 		data.resize(ds);
 
-		uint32_t blen = p_base->get_buffer(data.ptrw(), ds);
+		uint64_t blen = p_base->get_buffer(data.ptrw(), ds);
 		ERR_FAIL_COND_V(blen != ds, ERR_FILE_CORRUPT);
 
 		CryptoCore::AESContext ctx;
 		ctx.set_decode_key(key.ptrw(), 256);
 
-		for (size_t i = 0; i < ds; i += 16) {
+		for (uint64_t i = 0; i < ds; i += 16) {
 			ctx.decrypt_ecb(&data.write[i], &data.write[i]);
 		}
 
@@ -119,7 +119,7 @@ void FileAccessEncrypted::close() {
 
 	if (writing) {
 		Vector<uint8_t> compressed;
-		size_t len = data.size();
+		uint64_t len = data.size();
 		if (len % 16) {
 			len += 16 - (len % 16);
 		}
@@ -136,7 +136,7 @@ void FileAccessEncrypted::close() {
 		CryptoCore::AESContext ctx;
 		ctx.set_encode_key(key.ptrw(), 256);
 
-		for (size_t i = 0; i < len; i += 16) {
+		for (uint64_t i = 0; i < len; i += 16) {
 			ctx.encrypt_ecb(&compressed.write[i], &compressed.write[i]);
 		}
 
@@ -180,9 +180,9 @@ String FileAccessEncrypted::get_path_absolute() const {
 	}
 }
 
-void FileAccessEncrypted::seek(size_t p_position) {
-	if (p_position > (size_t)data.size()) {
-		p_position = data.size();
+void FileAccessEncrypted::seek(uint64_t p_position) {
+	if (p_position > get_len()) {
+		p_position = get_len();
 	}
 
 	pos = p_position;
@@ -190,12 +190,14 @@ void FileAccessEncrypted::seek(size_t p_position) {
 }
 
 void FileAccessEncrypted::seek_end(int64_t p_position) {
-	seek(data.size() + p_position);
+	seek(get_len() + p_position);
 }
-size_t FileAccessEncrypted::get_position() const {
+
+uint64_t FileAccessEncrypted::get_position() const {
 	return pos;
 }
-size_t FileAccessEncrypted::get_len() const {
+
+uint64_t FileAccessEncrypted::get_len() const {
 	return data.size();
 }
 
@@ -205,7 +207,7 @@ bool FileAccessEncrypted::eof_reached() const {
 
 uint8_t FileAccessEncrypted::get_8() const {
 	ERR_FAIL_COND_V_MSG(writing, 0, "File has not been opened in read mode.");
-	if (pos >= data.size()) {
+	if (pos >= get_len()) {
 		eofed = true;
 		return 0;
 	}
@@ -215,13 +217,12 @@ uint8_t FileAccessEncrypted::get_8() const {
 	return b;
 }
 
-int FileAccessEncrypted::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessEncrypted::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V_MSG(writing, -1, "File has not been opened in read mode.");
 
-	int to_copy = MIN(p_length, data.size() - pos);
-	for (int i = 0; i < to_copy; i++) {
+	uint64_t to_copy = MIN(p_length, get_len() - pos);
+	for (uint64_t i = 0; i < to_copy; i++) {
 		p_dst[i] = data[pos++];
 	}
 
@@ -236,16 +237,16 @@ Error FileAccessEncrypted::get_error() const {
 	return eofed ? ERR_FILE_EOF : OK;
 }
 
-void FileAccessEncrypted::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccessEncrypted::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND_MSG(!writing, "File has not been opened in write mode.");
 
-	if (pos < data.size()) {
-		for (int i = 0; i < p_length; i++) {
+	if (pos < get_len()) {
+		for (uint64_t i = 0; i < p_length; i++) {
 			store_8(p_src[i]);
 		}
-	} else if (pos == data.size()) {
+	} else if (pos == get_len()) {
 		data.resize(pos + p_length);
-		for (int i = 0; i < p_length; i++) {
+		for (uint64_t i = 0; i < p_length; i++) {
 			data.write[pos + i] = p_src[i];
 		}
 		pos += p_length;
@@ -261,10 +262,10 @@ void FileAccessEncrypted::flush() {
 void FileAccessEncrypted::store_8(uint8_t p_dest) {
 	ERR_FAIL_COND_MSG(!writing, "File has not been opened in write mode.");
 
-	if (pos < data.size()) {
+	if (pos < get_len()) {
 		data.write[pos] = p_dest;
 		pos++;
-	} else if (pos == data.size()) {
+	} else if (pos == get_len()) {
 		data.push_back(p_dest);
 		pos++;
 	}

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -46,10 +46,10 @@ private:
 	Vector<uint8_t> key;
 	bool writing;
 	FileAccess *file;
-	size_t base;
-	size_t length;
+	uint64_t base;
+	uint64_t length;
 	Vector<uint8_t> data;
-	mutable int pos;
+	mutable uint64_t pos;
 	mutable bool eofed;
 
 public:
@@ -63,21 +63,21 @@ public:
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -71,7 +71,7 @@ bool FileAccessMemory::file_exists(const String &p_name) {
 	return files && (files->find(name) != nullptr);
 }
 
-Error FileAccessMemory::open_custom(const uint8_t *p_data, int p_len) {
+Error FileAccessMemory::open_custom(const uint8_t *p_data, uint64_t p_len) {
 	data = (uint8_t *)p_data;
 	length = p_len;
 	pos = 0;
@@ -102,7 +102,7 @@ bool FileAccessMemory::is_open() const {
 	return data != nullptr;
 }
 
-void FileAccessMemory::seek(size_t p_position) {
+void FileAccessMemory::seek(uint64_t p_position) {
 	ERR_FAIL_COND(!data);
 	pos = p_position;
 }
@@ -112,12 +112,12 @@ void FileAccessMemory::seek_end(int64_t p_position) {
 	pos = length + p_position;
 }
 
-size_t FileAccessMemory::get_position() const {
+uint64_t FileAccessMemory::get_position() const {
 	ERR_FAIL_COND_V(!data, 0);
 	return pos;
 }
 
-size_t FileAccessMemory::get_len() const {
+uint64_t FileAccessMemory::get_len() const {
 	ERR_FAIL_COND_V(!data, 0);
 	return length;
 }
@@ -136,17 +136,16 @@ uint8_t FileAccessMemory::get_8() const {
 	return ret;
 }
 
-int FileAccessMemory::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessMemory::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V(!data, -1);
 
-	int left = length - pos;
-	int read = MIN(p_length, left);
+	uint64_t left = length - pos;
+	uint64_t read = MIN(p_length, left);
 
 	if (read < p_length) {
 		WARN_PRINT("Reading less data than requested");
-	};
+	}
 
 	memcpy(p_dst, &data[pos], read);
 	pos += p_length;
@@ -168,9 +167,9 @@ void FileAccessMemory::store_8(uint8_t p_byte) {
 	data[pos++] = p_byte;
 }
 
-void FileAccessMemory::store_buffer(const uint8_t *p_src, int p_length) {
-	int left = length - pos;
-	int write = MIN(p_length, left);
+void FileAccessMemory::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	uint64_t left = length - pos;
+	uint64_t write = MIN(p_length, left);
 	if (write < p_length) {
 		WARN_PRINT("Writing less data than requested");
 	}

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -35,8 +35,8 @@
 
 class FileAccessMemory : public FileAccess {
 	uint8_t *data;
-	int length;
-	mutable int pos;
+	uint64_t length;
+	mutable uint64_t pos;
 
 	static FileAccess *create();
 
@@ -44,27 +44,27 @@ public:
 	static void register_file(String p_name, Vector<uint8_t> p_data);
 	static void cleanup();
 
-	virtual Error open_custom(const uint8_t *p_data, int p_len); ///< open a file
+	virtual Error open_custom(const uint8_t *p_data, uint64_t p_len); ///< open a file
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
 
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const; ///< get an array of bytes
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const; ///< get an array of bytes
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_byte); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -40,9 +40,9 @@ class FileAccessNetwork;
 
 class FileAccessNetworkClient {
 	struct BlockRequest {
-		int id;
+		int32_t id;
 		uint64_t offset;
-		int size;
+		int32_t size;
 	};
 
 	List<BlockRequest> block_requests;
@@ -54,16 +54,16 @@ class FileAccessNetworkClient {
 	Mutex blockrequest_mutex;
 	Map<int, FileAccessNetwork *> accesses;
 	Ref<StreamPeerTCP> client;
-	int last_id;
+	int32_t last_id;
 
 	Vector<uint8_t> block;
 
 	void _thread_func();
 	static void _thread_func(void *s);
 
-	void put_32(int p_32);
+	void put_32(int32_t p_32);
 	void put_64(int64_t p_64);
-	int get_32();
+	int32_t get_32();
 	int64_t get_64();
 	int lockcount;
 	void lock_mutex();
@@ -86,18 +86,17 @@ class FileAccessNetwork : public FileAccess {
 	Semaphore page_sem;
 	Mutex buffer_mutex;
 	bool opened;
-	size_t total_size;
-	mutable size_t pos;
-	int id;
+	uint64_t total_size;
+	mutable uint64_t pos;
+	int32_t id;
 	mutable bool eof_flag;
-	mutable int last_page;
+	mutable int32_t last_page;
 	mutable uint8_t *last_page_buff;
 
-	int page_size;
-	int read_ahead;
+	int32_t page_size;
+	int32_t read_ahead;
 
 	mutable int waiting_on_page;
-	mutable int last_activity_val;
 	struct Page {
 		int activity;
 		bool queued;
@@ -114,9 +113,9 @@ class FileAccessNetwork : public FileAccess {
 
 	uint64_t exists_modtime;
 	friend class FileAccessNetworkClient;
-	void _queue_page(int p_page) const;
-	void _respond(size_t p_len, Error p_status);
-	void _set_block(int p_offset, const Vector<uint8_t> &p_block);
+	void _queue_page(int32_t p_page) const;
+	void _respond(uint64_t p_len, Error p_status);
+	void _set_block(uint64_t p_offset, const Vector<uint8_t> &p_block);
 
 public:
 	enum Command {
@@ -138,15 +137,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -97,7 +97,6 @@ private:
 	Vector<PackSource *> sources;
 
 	PackedDir *root;
-	//Map<String,PackedDir*> dirs;
 
 	static PackedData *singleton;
 	bool disabled;
@@ -106,13 +105,13 @@ private:
 
 public:
 	void add_pack_source(PackSource *p_source);
-	void add_path(const String &pkg_path, const String &path, uint64_t ofs, uint64_t size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files); // for PackSource
+	void add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files); // for PackSource
 
 	void set_disabled(bool p_disabled) { disabled = p_disabled; }
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
 
 	static PackedData *get_singleton() { return singleton; }
-	Error add_pack(const String &p_path, bool p_replace_files, size_t p_offset);
+	Error add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
 
 	_FORCE_INLINE_ FileAccess *try_open_path(const String &p_path);
 	_FORCE_INLINE_ bool has_path(const String &p_path);
@@ -126,21 +125,21 @@ public:
 
 class PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset) = 0;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) = 0;
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file) = 0;
 	virtual ~PackSource() {}
 };
 
 class PackedSourcePCK : public PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 };
 
 class FileAccessPack : public FileAccess {
 	PackedData::PackedFile pf;
 
-	mutable size_t pos;
+	mutable uint64_t pos;
 	mutable bool eof;
 
 	FileAccess *f;
@@ -153,16 +152,16 @@ public:
 	virtual void close();
 	virtual bool is_open() const;
 
-	virtual void seek(size_t p_position);
+	virtual void seek(uint64_t p_position);
 	virtual void seek_end(int64_t p_position = 0);
-	virtual size_t get_position() const;
-	virtual size_t get_len() const;
+	virtual uint64_t get_position() const;
+	virtual uint64_t get_len() const;
 
 	virtual bool eof_reached() const;
 
 	virtual uint8_t get_8() const;
 
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual void set_endian_swap(bool p_swap);
 
@@ -171,7 +170,7 @@ public:
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest);
 
-	virtual void store_buffer(const uint8_t *p_src, int p_length);
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length);
 
 	virtual bool file_exists(const String &p_name);
 
@@ -236,7 +235,7 @@ public:
 	virtual Error rename(String p_from, String p_to);
 	virtual Error remove(String p_name);
 
-	size_t get_space_left();
+	uint64_t get_space_left();
 
 	virtual String get_filesystem_type() const;
 

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -67,7 +67,7 @@ static long godot_tell(voidpf opaque, voidpf stream) {
 static long godot_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 	FileAccess *f = (FileAccess *)stream;
 
-	int pos = offset;
+	uint64_t pos = offset;
 	switch (origin) {
 		case ZLIB_FILEFUNC_SEEK_CUR:
 			pos = f->get_position() + offset;
@@ -145,7 +145,7 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 	return pkg;
 }
 
-bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset = 0) {
+bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset = 0) {
 	//printf("opening zip pack %ls, %i, %i\n", p_name.c_str(), p_name.extension().nocasecmp_to("zip"), p_name.extension().nocasecmp_to("pcz"));
 	// load with offset feature only supported for PCK files
 	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Invalid PCK data. Note that loading files with a non-zero offset isn't supported with ZIP archives.");
@@ -267,8 +267,9 @@ bool FileAccessZip::is_open() const {
 	return zfile != nullptr;
 }
 
-void FileAccessZip::seek(size_t p_position) {
+void FileAccessZip::seek(uint64_t p_position) {
 	ERR_FAIL_COND(!zfile);
+
 	unzSeekCurrentFile(zfile, p_position);
 }
 
@@ -277,12 +278,12 @@ void FileAccessZip::seek_end(int64_t p_position) {
 	unzSeekCurrentFile(zfile, get_len() + p_position);
 }
 
-size_t FileAccessZip::get_position() const {
+uint64_t FileAccessZip::get_position() const {
 	ERR_FAIL_COND_V(!zfile, 0);
 	return unztell(zfile);
 }
 
-size_t FileAccessZip::get_len() const {
+uint64_t FileAccessZip::get_len() const {
 	ERR_FAIL_COND_V(!zfile, 0);
 	return file_info.uncompressed_size;
 }
@@ -299,17 +300,17 @@ uint8_t FileAccessZip::get_8() const {
 	return ret;
 }
 
-int FileAccessZip::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessZip::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V(!zfile, -1);
+
 	at_eof = unzeof(zfile);
 	if (at_eof) {
 		return 0;
 	}
-	int read = unzReadCurrentFile(zfile, p_dst, p_length);
+	int64_t read = unzReadCurrentFile(zfile, p_dst, p_length);
 	ERR_FAIL_COND_V(read < 0, read);
-	if (read < p_length) {
+	if ((uint64_t)read < p_length) {
 		at_eof = true;
 	}
 	return read;

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -71,7 +71,7 @@ public:
 
 	bool file_exists(String p_name) const;
 
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
 	FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 
 	static ZipArchive *get_singleton();
@@ -91,20 +91,21 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
+
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 
 	virtual uint64_t _get_modified_time(const String &p_file) { return 0; } // todo

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -138,7 +138,7 @@ Error PCKPacker::flush(bool p_verbose) {
 		FileAccess *src = FileAccess::open(files[i].src_path, FileAccess::READ);
 		uint64_t to_write = files[i].size;
 		while (to_write > 0) {
-			int read = src->get_buffer(buf, MIN(to_write, buf_max));
+			uint64_t read = src->get_buffer(buf, MIN(to_write, buf_max));
 			file->store_buffer(buf, read);
 			to_write -= read;
 		};

--- a/core/io/pck_packer.h
+++ b/core/io/pck_packer.h
@@ -46,7 +46,7 @@ class PCKPacker : public Reference {
 	struct File {
 		String path;
 		String src_path;
-		int size;
+		uint64_t size;
 		uint64_t offset_offset;
 	};
 	Vector<File> files;

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1106,8 +1106,8 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 
 	save_ustring(fw, get_ustring(f)); //type
 
-	size_t md_ofs = f->get_position();
-	size_t importmd_ofs = f->get_64();
+	uint64_t md_ofs = f->get_position();
+	uint64_t importmd_ofs = f->get_64();
 	fw->store_64(0); //metadata offset
 
 	for (int i = 0; i < 14; i++) {

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -68,7 +68,7 @@ long zipio_tell(voidpf opaque, voidpf stream) {
 long zipio_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 	FileAccess *f = *(FileAccess **)opaque;
 
-	int pos = offset;
+	uint64_t pos = offset;
 	switch (origin) {
 		case ZLIB_FILEFUNC_SEEK_CUR:
 			pos = f->get_position() + offset;

--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -87,7 +87,7 @@ public:
 	virtual bool file_exists(String p_file) = 0;
 	virtual bool dir_exists(String p_dir) = 0;
 	static bool exists(String p_dir);
-	virtual size_t get_space_left() = 0;
+	virtual uint64_t get_space_left() = 0;
 
 	Error copy_dir(String p_from, String p_to, int p_chmod_flags = -1);
 	virtual Error copy(String p_from, String p_to, int p_chmod_flags = -1);

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -366,10 +366,10 @@ Vector<String> FileAccess::get_csv_line(const String &p_delim) const {
 	return strings;
 }
 
-int FileAccess::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccess::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
-	int i = 0;
+
+	uint64_t i = 0;
 	for (i = 0; i < p_length && !eof_reached(); i++) {
 		p_dst[i] = get_8();
 	}
@@ -379,11 +379,11 @@ int FileAccess::get_buffer(uint8_t *p_dst, int p_length) const {
 
 String FileAccess::get_as_utf8_string() const {
 	PoolVector<uint8_t> sourcef;
-	int len = get_len();
+	uint64_t len = get_len();
 	sourcef.resize(len + 1);
 
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = get_buffer(w.ptr(), len);
+	uint64_t r = get_buffer(w.ptr(), len);
 	ERR_FAIL_COND_V(r != len, String());
 	w[len] = 0;
 
@@ -547,8 +547,8 @@ void FileAccess::store_csv_line(const Vector<String> &p_values, const String &p_
 	store_line(line);
 }
 
-void FileAccess::store_buffer(const uint8_t *p_src, int p_length) {
-	for (int i = 0; i < p_length; i++) {
+void FileAccess::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	for (uint64_t i = 0; i < p_length; i++) {
 		store_8(p_src[i]);
 	}
 }
@@ -598,7 +598,7 @@ String FileAccess::get_md5(const String &p_file) {
 	unsigned char step[32768];
 
 	while (true) {
-		int br = f->get_buffer(step, 32768);
+		uint64_t br = f->get_buffer(step, 32768);
 		if (br > 0) {
 			ctx.update(step, br);
 		}
@@ -626,7 +626,7 @@ String FileAccess::get_multiple_md5(const Vector<String> &p_file) {
 		unsigned char step[32768];
 
 		while (true) {
-			int br = f->get_buffer(step, 32768);
+			uint64_t br = f->get_buffer(step, 32768);
 			if (br > 0) {
 				ctx.update(step, br);
 			}
@@ -655,7 +655,7 @@ String FileAccess::get_sha256(const String &p_file) {
 	unsigned char step[32768];
 
 	while (true) {
-		int br = f->get_buffer(step, 32768);
+		uint64_t br = f->get_buffer(step, 32768);
 		if (br > 0) {
 			ctx.update(step, br);
 		}

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -94,10 +94,10 @@ public:
 	virtual String get_path() const { return ""; } /// returns the path for the current open file
 	virtual String get_path_absolute() const { return ""; } /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position) = 0; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) = 0; ///< seek from the end of file
-	virtual size_t get_position() const = 0; ///< get position in the file
-	virtual size_t get_len() const = 0; ///< get size of the file
+	virtual void seek(uint64_t p_position) = 0; ///< seek to a given position
+	virtual void seek_end(int64_t p_position = 0) = 0; ///< seek from the end of file with negative offset
+	virtual uint64_t get_position() const = 0; ///< get position in the file
+	virtual uint64_t get_len() const = 0; ///< get size of the file
 
 	virtual bool eof_reached() const = 0; ///< reading passed EOF
 
@@ -110,7 +110,7 @@ public:
 	virtual double get_double() const;
 	virtual real_t get_real() const;
 
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const; ///< get an array of bytes
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const; ///< get an array of bytes
 	virtual String get_line() const;
 	virtual String get_token() const;
 	virtual Vector<String> get_csv_line(const String &p_delim = ",") const;
@@ -143,7 +143,7 @@ public:
 	virtual void store_pascal_string(const String &p_string);
 	virtual String get_pascal_string();
 
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name) = 0; ///< return true if a file exists
 

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -37,7 +37,7 @@
 #include <string.h>
 
 Error ImageLoaderPNG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
-	const size_t buffer_size = f->get_len();
+	const uint64_t buffer_size = f->get_len();
 	PoolVector<uint8_t> file_buffer;
 	Error err = file_buffer.resize(buffer_size);
 	if (err) {

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -382,7 +382,7 @@ Error DirAccessUnix::remove(String p_path) {
 	}
 }
 
-size_t DirAccessUnix::get_space_left() {
+uint64_t DirAccessUnix::get_space_left() {
 #ifndef NO_STATVFS
 	struct statvfs vfs;
 	if (statvfs(current_dir.utf8().get_data(), &vfs) != 0) {

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -77,7 +77,7 @@ public:
 	virtual Error rename(String p_path, String p_new_path);
 	virtual Error remove(String p_path);
 
-	virtual size_t get_space_left();
+	virtual uint64_t get_space_left();
 
 	virtual String get_filesystem_type() const;
 

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -184,11 +184,11 @@ String FileAccessUnix::get_path_absolute() const {
 	return path;
 }
 
-void FileAccessUnix::seek(size_t p_position) {
+void FileAccessUnix::seek(uint64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	last_error = OK;
-	if (fseek(f, p_position, SEEK_SET)) {
+	if (fseeko(f, p_position, SEEK_SET)) {
 		check_errors();
 	}
 }
@@ -196,15 +196,15 @@ void FileAccessUnix::seek(size_t p_position) {
 void FileAccessUnix::seek_end(int64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
-	if (fseek(f, p_position, SEEK_END)) {
+	if (fseeko(f, p_position, SEEK_END)) {
 		check_errors();
 	}
 }
 
-size_t FileAccessUnix::get_position() const {
+uint64_t FileAccessUnix::get_position() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 
-	long pos = ftell(f);
+	int64_t pos = ftello(f);
 	if (pos < 0) {
 		check_errors();
 		ERR_FAIL_V(0);
@@ -212,15 +212,15 @@ size_t FileAccessUnix::get_position() const {
 	return pos;
 }
 
-size_t FileAccessUnix::get_len() const {
+uint64_t FileAccessUnix::get_len() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 
-	long pos = ftell(f);
+	int64_t pos = ftello(f);
 	ERR_FAIL_COND_V(pos < 0, 0);
-	ERR_FAIL_COND_V(fseek(f, 0, SEEK_END), 0);
-	long size = ftell(f);
+	ERR_FAIL_COND_V(fseeko(f, 0, SEEK_END), 0);
+	int64_t size = ftello(f);
 	ERR_FAIL_COND_V(size < 0, 0);
-	ERR_FAIL_COND_V(fseek(f, pos, SEEK_SET), 0);
+	ERR_FAIL_COND_V(fseeko(f, pos, SEEK_SET), 0);
 
 	return size;
 }
@@ -239,11 +239,11 @@ uint8_t FileAccessUnix::get_8() const {
 	return b;
 }
 
-int FileAccessUnix::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessUnix::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V_MSG(!f, -1, "File must be opened before use.");
-	int read = fread(p_dst, 1, p_length, f);
+
+	uint64_t read = fread(p_dst, 1, p_length, f);
 	check_errors();
 	return read;
 };
@@ -262,10 +262,10 @@ void FileAccessUnix::store_8(uint8_t p_dest) {
 	ERR_FAIL_COND(fwrite(&p_dest, 1, 1, f) != 1);
 }
 
-void FileAccessUnix::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccessUnix::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	ERR_FAIL_COND(!p_src);
-	ERR_FAIL_COND((int)fwrite(p_src, 1, p_length, f) != p_length);
+	ERR_FAIL_COND(fwrite(p_src, 1, p_length, f) != p_length);
 }
 
 bool FileAccessUnix::file_exists(const String &p_path) {

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -61,21 +61,21 @@ public:
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_path); ///< return true if a file exists
 

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -325,13 +325,14 @@ FileType DirAccessWindows::get_file_type(const String& p_file) const {
 	return (attr&FILE_ATTRIBUTE_DIRECTORY)?FILE_TYPE_
 }
 */
-size_t DirAccessWindows::get_space_left() {
+
+uint64_t DirAccessWindows::get_space_left() {
 	uint64_t bytes = 0;
 	if (!GetDiskFreeSpaceEx(NULL, (PULARGE_INTEGER)&bytes, NULL, NULL))
 		return 0;
 
 	//this is either 0 or a value in bytes.
-	return (size_t)bytes;
+	return bytes;
 }
 
 String DirAccessWindows::get_filesystem_type() const {

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -79,8 +79,7 @@ public:
 	virtual Error rename(String p_path, String p_new_path);
 	virtual Error remove(String p_path);
 
-	//virtual FileType get_file_type() const;
-	size_t get_space_left();
+	uint64_t get_space_left();
 
 	virtual String get_filesystem_type() const;
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -188,34 +188,38 @@ String FileAccessWindows::get_path_absolute() const {
 bool FileAccessWindows::is_open() const {
 	return (f != NULL);
 }
-void FileAccessWindows::seek(size_t p_position) {
+
+void FileAccessWindows::seek(uint64_t p_position) {
 	ERR_FAIL_COND(!f);
+
 	last_error = OK;
-	if (fseek(f, p_position, SEEK_SET))
+	if (_fseeki64(f, p_position, SEEK_SET))
 		check_errors();
 	prev_op = 0;
 }
+
 void FileAccessWindows::seek_end(int64_t p_position) {
 	ERR_FAIL_COND(!f);
-	if (fseek(f, p_position, SEEK_END))
+	if (_fseeki64(f, p_position, SEEK_END))
 		check_errors();
 	prev_op = 0;
 }
-size_t FileAccessWindows::get_position() const {
-	size_t aux_position = 0;
-	aux_position = ftell(f);
-	if (!aux_position) {
+
+uint64_t FileAccessWindows::get_position() const {
+	int64_t aux_position = _ftelli64(f);
+	if (aux_position < 0) {
 		check_errors();
-	};
+	}
 	return aux_position;
 }
-size_t FileAccessWindows::get_len() const {
+
+uint64_t FileAccessWindows::get_len() const {
 	ERR_FAIL_COND_V(!f, 0);
 
-	size_t pos = get_position();
-	fseek(f, 0, SEEK_END);
-	int size = get_position();
-	fseek(f, pos, SEEK_SET);
+	uint64_t pos = get_position();
+	_fseeki64(f, 0, SEEK_END);
+	uint64_t size = get_position();
+	_fseeki64(f, pos, SEEK_SET);
 
 	return size;
 }
@@ -242,17 +246,17 @@ uint8_t FileAccessWindows::get_8() const {
 	return b;
 }
 
-int FileAccessWindows::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessWindows::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V(!f, -1);
+
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == WRITE) {
 			fflush(f);
 		}
 		prev_op = READ;
 	}
-	int read = fread(p_dst, 1, p_length, f);
+	uint64_t read = fread(p_dst, 1, p_length, f);
 	check_errors();
 	return read;
 };
@@ -281,7 +285,7 @@ void FileAccessWindows::store_8(uint8_t p_dest) {
 	fwrite(&p_dest, 1, 1, f);
 }
 
-void FileAccessWindows::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccessWindows::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND(!f);
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == READ) {

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -56,21 +56,21 @@ public:
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1029,12 +1029,12 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 	int header_padding = _get_pad(PCK_PADDING, header_size);
 
 	for (int i = 0; i < pd.file_ofs.size(); i++) {
-		int string_len = pd.file_ofs[i].path_utf8.length();
-		int pad = _get_pad(4, string_len);
+		uint32_t string_len = pd.file_ofs[i].path_utf8.length();
+		uint32_t pad = _get_pad(4, string_len);
 
 		f->store_32(string_len + pad);
 		f->store_buffer((const uint8_t *)pd.file_ofs[i].path_utf8.get_data(), string_len);
-		for (int j = 0; j < pad; j++) {
+		for (uint32_t j = 0; j < pad; j++) {
 			f->store_8(0);
 		}
 
@@ -1060,8 +1060,8 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 	uint8_t buf[bufsize];
 
 	while (true) {
-		int got = ftmp->get_buffer(buf, bufsize);
-		if (got <= 0) {
+		uint64_t got = ftmp->get_buffer(buf, bufsize);
+		if (got == 0) {
 			break;
 		}
 		f->store_buffer(buf, got);
@@ -1071,13 +1071,13 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 
 	if (p_embed) {
 		// Ensure embedded data ends at a 64-bit multiple
-		int64_t embed_end = f->get_position() - embed_pos + 12;
-		int pad = embed_end % 8;
-		for (int i = 0; i < pad; i++) {
+		uint64_t embed_end = f->get_position() - embed_pos + 12;
+		uint64_t pad = embed_end % 8;
+		for (uint64_t i = 0; i < pad; i++) {
 			f->store_8(0);
 		}
 
-		int64_t pck_size = f->get_position() - pck_start_pos;
+		uint64_t pck_size = f->get_position() - pck_start_pos;
 		f->store_64(pck_size);
 		f->store_32(PACK_HEADER_MAGIC);
 

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -229,8 +229,7 @@ void EditorFileServer::_subthread_start(void *s) {
 				cd->files[id]->seek(offset);
 				Vector<uint8_t> buf;
 				buf.resize(blocklen);
-				int read = cd->files[id]->get_buffer(buf.ptrw(), blocklen);
-				ERR_CONTINUE(read < 0);
+				uint32_t read = cd->files[id]->get_buffer(buf.ptrw(), blocklen);
 
 				print_verbose("GET BLOCK - offset: " + itos(offset) + ", blocklen: " + itos(blocklen));
 

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -73,7 +73,7 @@ Error ResourceImporterImage::import(const String &p_source_file, const String &p
 
 	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, "Cannot open file from path '" + p_source_file + "'.");
 
-	size_t len = f->get_len();
+	uint64_t len = f->get_len();
 
 	Vector<uint8_t> data;
 	data.resize(len);

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1357,7 +1357,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		String cache_file_path = base_path.plus_file(file_id + ".unwrap_cache");
 
 		int *cache_data = nullptr;
-		unsigned int cache_size = 0;
+		uint64_t cache_size = 0;
 
 		if (FileAccess::exists(cache_file_path)) {
 			Error err2;
@@ -1366,7 +1366,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 			if (!err2) {
 				cache_size = file->get_len();
 				cache_data = (int *)memalloc(cache_size);
-				file->get_buffer((unsigned char *)cache_data, cache_size);
+				file->get_buffer((uint8_t *)cache_data, cache_size);
 			}
 
 			if (file) {

--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -899,7 +899,7 @@ MainLoop *test(TestType p_type) {
 	ERR_FAIL_COND_V_MSG(!fa, nullptr, "Could not open file: " + test);
 
 	Vector<uint8_t> buf;
-	int flen = fa->get_len();
+	uint64_t flen = fa->get_len();
 	buf.resize(fa->get_len() + 1);
 	fa->get_buffer(buf.ptrw(), flen);
 	buf.write[flen] = 0;

--- a/main/tests/test_math.cpp
+++ b/main/tests/test_math.cpp
@@ -487,7 +487,7 @@ MainLoop *test() {
 	ERR_FAIL_COND_V_MSG(!fa, nullptr, "Could not open file: " + test);
 
 	Vector<uint8_t> buf;
-	int flen = fa->get_len();
+	uint64_t flen = fa->get_len();
 	buf.resize(fa->get_len() + 1);
 	fa->get_buffer(buf.ptrw(), flen);
 	buf.write[flen] = 0;

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -412,10 +412,10 @@ Error PluginScript::load_source_code(const String &p_path) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot open file '" + p_path + "'.");
 
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = f->get_buffer(w.ptr(), len);
+	uint64_t r = f->get_buffer(w.ptr(), len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -47,11 +47,7 @@ godot_int GDAPI godot_videodecoder_file_read(void *ptr, uint8_t *buf, int buf_si
 
 	// if file exists
 	if (file) {
-		long bytes_read = file->get_buffer(buf, buf_size);
-		// No bytes to read => EOF
-		if (bytes_read == 0) {
-			return 0;
-		}
+		int64_t bytes_read = file->get_buffer(buf, buf_size);
 		return bytes_read;
 	}
 	return -1;
@@ -62,41 +58,35 @@ int64_t GDAPI godot_videodecoder_file_seek(void *ptr, int64_t pos, int whence) {
 	FileAccess *file = reinterpret_cast<FileAccess *>(ptr);
 
 	if (file) {
-		size_t len = file->get_len();
+		int64_t len = file->get_len();
 		switch (whence) {
 			case SEEK_SET: {
-				// Just for explicitness
-				size_t new_pos = static_cast<size_t>(pos);
-				if (new_pos > len) {
+				if (pos > len) {
 					return -1;
 				}
-				file->seek(new_pos);
-				pos = static_cast<int64_t>(file->get_position());
-				return pos;
+				file->seek(pos);
+				return file->get_position();
 			} break;
 			case SEEK_CUR: {
 				// Just in case it doesn't exist
-				if (pos < 0 && (size_t)-pos > file->get_position()) {
+				if (pos < 0 && -pos > (int64_t)file->get_position()) {
 					return -1;
 				}
-				pos = pos + static_cast<int>(file->get_position());
-				file->seek(pos);
-				pos = static_cast<int64_t>(file->get_position());
-				return pos;
+				file->seek(file->get_position() + pos);
+				return file->get_position();
 			} break;
 			case SEEK_END: {
 				// Just in case something goes wrong
-				if ((size_t)-pos > len) {
+				if (-pos > len) {
 					return -1;
 				}
 				file->seek_end(pos);
-				pos = static_cast<int64_t>(file->get_position());
-				return pos;
+				return file->get_position();
 			} break;
 			default: {
 				// Only 4 possible options, hence default = AVSEEK_SIZE
 				// Asks to return the length of file
-				return static_cast<int64_t>(len);
+				return len;
 			} break;
 		}
 	}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -771,10 +771,10 @@ Error GDScript::load_source_code(const String &p_path) {
 		ERR_FAIL_COND_V(err, err);
 	}
 
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = f->get_buffer(w.ptr(), len);
+	uint64_t r = f->get_buffer(w.ptr(), len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -106,7 +106,7 @@ Error jpeg_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 
 Error ImageLoaderJPG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 	PoolVector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	uint64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -57,7 +57,7 @@ Error CryptoKeyMbedTLS::load(String p_path, bool p_public_only) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(!f, ERR_INVALID_PARAMETER, "Cannot open CryptoKeyMbedTLS file '" + p_path + "'.");
 
-	int flen = f->get_len();
+	uint64_t flen = f->get_len();
 	out.resize(flen + 1);
 	{
 		PoolByteArray::Write w = out.write();
@@ -148,7 +148,7 @@ Error X509CertificateMbedTLS::load(String p_path) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(!f, ERR_INVALID_PARAMETER, "Cannot open X509CertificateMbedTLS file '" + p_path + "'.");
 
-	int flen = f->get_len();
+	uint64_t flen = f->get_len();
 	out.resize(flen + 1);
 	{
 		PoolByteArray::Write w = out.write();

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -79,7 +79,7 @@ Error ResourceImporterMP3::import(const String &p_source_file, const String &p_s
 
 	ERR_FAIL_COND_V(!f, ERR_CANT_OPEN);
 
-	size_t len = f->get_len();
+	uint64_t len = f->get_len();
 
 	PoolVector<uint8_t> data;
 	data.resize(len);

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -166,10 +166,10 @@ Error read_all_file_utf8(const String &p_path, String &r_content) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot open file '" + p_path + "'.");
 
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = f->get_buffer(w.ptr(), len);
+	uint64_t r = f->get_buffer(w.ptr(), len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
@@ -77,7 +77,7 @@ Error ResourceImporterOGGVorbis::import(const String &p_source_file, const Strin
 
 	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, "Cannot open file '" + p_source_file + "'.");
 
-	size_t len = f->get_len();
+	uint64_t len = f->get_len();
 
 	PoolVector<uint8_t> data;
 	data.resize(len);

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -141,7 +141,7 @@ Error ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, const char *p
 }
 
 Error ImageLoaderSVG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
-	uint32_t size = f->get_len();
+	uint64_t size = f->get_len();
 	PoolVector<uint8_t> src_image;
 	src_image.resize(size + 1);
 	PoolVector<uint8_t>::Write src_w = src_image.write();

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -228,9 +228,9 @@ Error ImageLoaderTGA::convert_to_image(Ref<Image> p_image, const uint8_t *p_buff
 
 Error ImageLoaderTGA::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 	PoolVector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	uint64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
-	ERR_FAIL_COND_V(src_image_len < (int)sizeof(tga_header_s), ERR_FILE_CORRUPT);
+	ERR_FAIL_COND_V(src_image_len < (int64_t)sizeof(tga_header_s), ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 
 	Error err = OK;

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -58,7 +58,7 @@ int VideoStreamPlaybackTheora::buffer_data() {
 
 #else
 
-	int bytes = file->get_buffer((uint8_t *)buffer, 4096);
+	uint64_t bytes = file->get_buffer((uint8_t *)buffer, 4096);
 	ogg_sync_wrote(&oy, bytes);
 	return (bytes);
 
@@ -176,7 +176,7 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 	thread_eof = false;
 	//pre-fill buffer
 	int to_read = ring_buffer.space_left();
-	int read = file->get_buffer(read_buffer.ptr(), to_read);
+	uint64_t read = file->get_buffer(read_buffer.ptr(), to_read);
 	ring_buffer.write(read_buffer.ptr(), read);
 
 	thread.start(_streaming_thread, this);
@@ -631,8 +631,8 @@ void VideoStreamPlaybackTheora::_streaming_thread(void *ud) {
 		//just fill back the buffer
 		if (!vs->thread_eof) {
 			int to_read = vs->ring_buffer.space_left();
-			if (to_read) {
-				int read = vs->file->get_buffer(vs->read_buffer.ptr(), to_read);
+			if (to_read > 0) {
+				uint64_t read = vs->file->get_buffer(vs->read_buffer.ptr(), to_read);
 				vs->ring_buffer.write(vs->read_buffer.ptr(), read);
 				vs->thread_eof = vs->file->eof_reached();
 			}

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -37,7 +37,7 @@
 
 Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 	PoolVector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	uint64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -62,10 +62,10 @@ public:
 
 	virtual int Read(long long pos, long len, unsigned char *buf) {
 		if (file) {
-			if (file->get_position() != (size_t)pos) {
+			if (file->get_position() != (uint64_t)pos) {
 				file->seek(pos);
 			}
-			if (file->get_buffer(buf, len) == len) {
+			if (file->get_buffer(buf, len) == (uint64_t)len) {
 				return 0;
 			}
 		}
@@ -74,7 +74,7 @@ public:
 
 	virtual int Length(long long *total, long long *available) {
 		if (file) {
-			const size_t len = file->get_len();
+			const uint64_t len = file->get_len();
 			if (total) {
 				*total = len;
 			}

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -150,7 +150,7 @@ static Ref<Image> _webp_mem_loader_func(const uint8_t *p_png, int p_size) {
 
 Error ImageLoaderWEBP::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 	PoolVector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	uint64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -278,6 +278,9 @@ def configure(env):
     )
     env.Append(CPPDEFINES=["NO_STATVFS", "GLES_ENABLED"])
 
+    if get_platform(env["ndk_platform"]) >= 24:
+        env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
+
     env["neon_enabled"] = False
     if env["android_arch"] == "x86":
         target_opts = ["-target", "i686-none-linux-android"]

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -201,8 +201,7 @@ String DirAccessJAndroid::get_filesystem_type() const {
 	return "APK";
 }
 
-//FileType get_file_type() const;
-size_t DirAccessJAndroid::get_space_left() {
+uint64_t DirAccessJAndroid::get_space_left() {
 	return 0;
 }
 

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -76,8 +76,7 @@ public:
 
 	virtual String get_filesystem_type() const;
 
-	//virtual FileType get_file_type() const;
-	size_t get_space_left();
+	uint64_t get_space_left();
 
 	static void setup(jobject p_io);
 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -2339,7 +2339,7 @@ public:
 								text = text.to_upper(); //just in case
 
 								String end_marker = "//CHUNK_" + text + "_END";
-								size_t pos = f->get_position();
+								uint64_t pos = f->get_position();
 								bool found = false;
 								while (!f->eof_reached()) {
 									l = f->get_line();
@@ -2378,7 +2378,7 @@ public:
 								text = text.to_upper(); //just in case
 
 								String end_marker = "//DIR_" + text + "_END";
-								size_t pos = f->get_position();
+								uint64_t pos = f->get_position();
 								bool found = false;
 								while (!f->eof_reached()) {
 									l = f->get_line();
@@ -2448,7 +2448,7 @@ public:
 								text = text.to_upper(); //just in case
 
 								String end_marker = "<!--CHUNK_" + text + "_END-->";
-								size_t pos = f->get_position();
+								uint64_t pos = f->get_position();
 								bool found = false;
 								while (!f->eof_reached()) {
 									l = f->get_line();

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -72,8 +72,9 @@ bool FileAccessAndroid::is_open() const {
 	return a != NULL;
 }
 
-void FileAccessAndroid::seek(size_t p_position) {
+void FileAccessAndroid::seek(uint64_t p_position) {
 	ERR_FAIL_COND(!a);
+
 	AAsset_seek(a, p_position, SEEK_SET);
 	pos = p_position;
 	if (pos > len) {
@@ -90,11 +91,11 @@ void FileAccessAndroid::seek_end(int64_t p_position) {
 	pos = len + p_position;
 }
 
-size_t FileAccessAndroid::get_position() const {
+uint64_t FileAccessAndroid::get_position() const {
 	return pos;
 }
 
-size_t FileAccessAndroid::get_len() const {
+uint64_t FileAccessAndroid::get_len() const {
 	return len;
 }
 
@@ -114,11 +115,10 @@ uint8_t FileAccessAndroid::get_8() const {
 	return byte;
 }
 
-int FileAccessAndroid::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 
-	off_t r = AAsset_read(a, p_dst, p_length);
+	int r = AAsset_read(a, p_dst, p_length);
 
 	if (pos + p_length > len) {
 		eof = true;

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -40,8 +40,8 @@
 class FileAccessAndroid : public FileAccess {
 	static FileAccess *create_android();
 	mutable AAsset *a;
-	mutable size_t len;
-	mutable size_t pos;
+	mutable uint64_t len;
+	mutable uint64_t pos;
 	mutable bool eof;
 
 public:
@@ -51,15 +51,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/platform/javascript/api/javascript_tools_editor_plugin.cpp
+++ b/platform/javascript/api/javascript_tools_editor_plugin.cpp
@@ -84,7 +84,7 @@ void JavaScriptToolsEditorPlugin::_zip_file(String p_path, String p_base_path, z
 		return;
 	}
 	Vector<uint8_t> data;
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	data.resize(len);
 	f->get_buffer(data.ptrw(), len);
 	f->close();

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -170,8 +170,8 @@ public:
 
 		while (true) {
 			uint8_t bytes[4096];
-			int read = f->get_buffer(bytes, 4096);
-			if (read < 1) {
+			uint64_t read = f->get_buffer(bytes, 4096);
+			if (read == 0) {
 				break;
 			}
 			err = peer->put_data(bytes, read);

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -284,7 +284,7 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
 			}
 
 			int ofs = data.size();
-			uint32_t len = f->get_len();
+			uint64_t len = f->get_len();
 			data.resize(data.size() + len + 8);
 			f->get_buffer(&data.write[ofs + 8], len);
 			memdelete(f);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -2181,7 +2181,7 @@ void OS_OSX::set_native_icon(const String &p_filename) {
 	ERR_FAIL_COND(!f);
 
 	Vector<uint8_t> data;
-	uint32_t len = f->get_len();
+	uint64_t len = f->get_len();
 	data.resize(len);
 	f->get_buffer((uint8_t *)&data.write[0], len);
 	memdelete(f);

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -350,7 +350,7 @@ def configure(env):
         env.ParseConfig("pkg-config zlib --cflags --libs")
 
     env.Prepend(CPPPATH=["#platform/x11"])
-    env.Append(CPPDEFINES=["X11_ENABLED", "UNIX_ENABLED", "OPENGL_ENABLED", "GLES_ENABLED"])
+    env.Append(CPPDEFINES=["X11_ENABLED", "UNIX_ENABLED", "OPENGL_ENABLED", "GLES_ENABLED", ("_FILE_OFFSET_BITS", 64)])
     env.Append(LIBS=["GL", "pthread"])
 
     if platform.system() == "Linux":

--- a/platform/x11/power_x11.cpp
+++ b/platform/x11/power_x11.cpp
@@ -78,16 +78,12 @@ FileAccessRef PowerX11::open_power_file(const char *base, const char *node, cons
 }
 
 bool PowerX11::read_power_file(const char *base, const char *node, const char *key, char *buf, size_t buflen) {
-	ssize_t br = 0;
 	FileAccessRef fd = open_power_file(base, node, key);
 	if (!fd) {
 		return false;
 	}
-	br = fd->get_buffer(reinterpret_cast<uint8_t *>(buf), buflen - 1);
+	uint64_t br = fd->get_buffer(reinterpret_cast<uint8_t *>(buf), buflen - 1);
 	fd->close();
-	if (br < 0) {
-		return false;
-	}
 	buf[br] = '\0'; // null-terminate the string
 	return true;
 }
@@ -340,18 +336,13 @@ bool PowerX11::GetPowerInfo_Linux_proc_apm() {
 	char buf[128];
 	char *ptr = &buf[0];
 	char *str = nullptr;
-	ssize_t br;
 
 	if (!fd) {
 		return false; /* can't use this interface. */
 	}
 
-	br = fd->get_buffer(reinterpret_cast<uint8_t *>(buf), sizeof(buf) - 1);
+	uint64_t br = fd->get_buffer(reinterpret_cast<uint8_t *>(buf), sizeof(buf) - 1);
 	fd->close();
-
-	if (br < 0) {
-		return false;
-	}
 
 	buf[br] = '\0'; /* null-terminate the string. */
 	if (!next_string(&ptr, &str)) { /* driver version */

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -120,7 +120,7 @@ Error DynamicFontAtSize::_load() {
 			ERR_FAIL_V_MSG(ERR_CANT_OPEN, "Cannot open font file '" + font->font_path + "'.");
 		}
 
-		size_t len = f->get_len();
+		uint64_t len = f->get_len();
 		font->_fontdata = Vector<uint8_t>();
 		font->_fontdata.resize(len);
 		f->get_buffer(font->_fontdata.ptrw(), len);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -896,7 +896,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 	}
 
 	wf->store_32(0); //string table size, will not be in use
-	size_t ext_res_count_pos = wf->get_position();
+	uint64_t ext_res_count_pos = wf->get_position();
 
 	wf->store_32(0); //zero ext resources, still parsing them
 
@@ -959,7 +959,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 
 	//now, save resources to a separate file, for now
 
-	size_t sub_res_count_pos = wf->get_position();
+	uint64_t sub_res_count_pos = wf->get_position();
 	wf->store_32(0); //zero sub resources, still parsing them
 
 	String temp_file = p_path + ".temp";
@@ -968,8 +968,8 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 		return ERR_CANT_OPEN;
 	}
 
-	Vector<size_t> local_offsets;
-	Vector<size_t> local_pointers_pos;
+	Vector<uint64_t> local_offsets;
+	Vector<uint64_t> local_pointers_pos;
 
 	while (next_tag.name == "sub_resource" || next_tag.name == "resource") {
 		String type;
@@ -1007,7 +1007,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 		wf->store_64(0); //temp local offset
 
 		bs_save_unicode_string(wf2, type);
-		size_t propcount_ofs = wf2->get_position();
+		uint64_t propcount_ofs = wf2->get_position();
 		wf2->store_32(0);
 
 		int prop_count = 0;
@@ -1077,7 +1077,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 
 		local_offsets.push_back(wf2->get_position());
 		bs_save_unicode_string(wf2, "PackedScene");
-		size_t propcount_ofs = wf2->get_position();
+		uint64_t propcount_ofs = wf2->get_position();
 		wf2->store_32(0);
 
 		int prop_count = 0;
@@ -1103,7 +1103,7 @@ Error ResourceInteractiveLoaderText::save_as_binary(FileAccess *p_f, const Strin
 
 	wf2->close();
 
-	size_t offset_from = wf->get_position();
+	uint64_t offset_from = wf->get_position();
 	wf->seek(sub_res_count_pos); //plus one because the saved one
 	wf->store_32(local_offsets.size());
 

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -55,10 +55,10 @@ Error TextFile::load_text(const String &p_path) {
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot open TextFile '" + p_path + "'.");
 
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	PoolVector<uint8_t>::Write w = sourcef.write();
-	int r = f->get_buffer(w.ptr(), len);
+	uint64_t r = f->get_buffer(w.ptr(), len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -539,7 +539,7 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &tw_
 
 		//mipmaps need to be read independently, they will be later combined
 		Vector<Ref<Image>> mipmap_images;
-		int total_size = 0;
+		uint64_t total_size = 0;
 
 		for (uint32_t i = 0; i < mipmaps; i++) {
 			if (i) {
@@ -624,7 +624,7 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &tw_
 			int sh = th;
 
 			int mipmaps2 = Image::get_image_required_mipmaps(tw, th, format);
-			int total_size = Image::get_image_data_size(tw, th, format, true);
+			uint64_t total_size = Image::get_image_data_size(tw, th, format, true);
 			int idx = 0;
 
 			while (mipmaps2 > 1 && p_size_limit > 0 && (sw > p_size_limit || sh > p_size_limit)) {
@@ -648,12 +648,12 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &tw_
 
 			{
 				PoolVector<uint8_t>::Write w = img_data.write();
-				int bytes = f->get_buffer(w.ptr(), total_size - ofs);
+				uint64_t bytes = f->get_buffer(w.ptr(), total_size - ofs);
 				//print_line("requested read: " + itos(total_size - ofs) + " but got: " + itos(bytes));
 
 				memdelete(f);
 
-				int expected = total_size - ofs;
+				uint64_t expected = total_size - ofs;
 				if (bytes < expected) {
 					//this is a compatibility workaround for older format, which saved less mipmaps2. It is still recommended the image is reimported.
 					memset(w.ptr() + bytes, 0, (expected - bytes));
@@ -2225,14 +2225,14 @@ Error TextureLayered::load(const String &p_path) {
 		} else {
 			//look for regular format
 			bool mipmaps = (flags & Texture::FLAG_MIPMAPS);
-			int total_size = Image::get_image_data_size(tw, th, format, mipmaps);
+			uint64_t total_size = Image::get_image_data_size(tw, th, format, mipmaps);
 
 			PoolVector<uint8_t> img_data;
 			img_data.resize(total_size);
 
 			{
 				PoolVector<uint8_t>::Write w = img_data.write();
-				int bytes = f->get_buffer(w.ptr(), total_size);
+				uint64_t bytes = f->get_buffer(w.ptr(), total_size);
 				if (bytes != total_size) {
 					f->close();
 					memdelete(f);


### PR DESCRIPTION
This is a redo of #27247 from @RandomShaper, as a draft as I intend to do some changes.

Opening against `3.x` for now as several users need support for PCK files above 2.1 GB, so they can backport this to their custom 3.3 builds. We'll probably target 3.4 for this though as it's a fairly big change, coming a bit too late for 3.3. We could consider cherry-picking for 3.3.x depending on how it goes.
This will of course be forward-ported to `master` once ready.

Fixes #44363.
Fixes https://github.com/godotengine/godot-proposals/issues/400.

Some changes I plan to make after discussion with @reduz and others in @godotengine/core:

- It would be better to standardize on `uint64_t` instead of `int64_t` in the `FileAccess` API. That's closer to `size_t` / `off_t` and should be good for all these operations.
- The `File` bindings should use `int64_t` where relevant to validate that input is unsigned (as the Variant binding system only has signed ints).
- I'd revert the `Directory::get_space_left()` change to bytes instead of MiB as it breaks compat. We can consider doing it for 4.0 but it shouldn't really be in the PR.

I'll make changes as a separate commit for review.

---

This changes the types of a big number of variables.

General rules:
- Using `int64_t` in general. With 64-bit we no longer need to use unsigned type. That matches `Variant` better and avoids akward casts. Checks for negative numbers are performed where they don't make sense (seek, read/write buffer size).
- Previous point means no more `size_t` for file size/offsets.
- Not worrying about `FileAccess::get_64/store_64` working with unsigneds. I haven't found any place where conversion to unsigned will cause trouble and saves us from having to add `get/store_64_signed` or similar.
- Using `int32_t` integers for concepts not needing such a huge range, like pages, blocks, etc.

In addition:
- Improve usage of integer types in some related places; namely, `DirAccess`, core binds.
- The binding for `Directory::get_space_left()` tried to return the size in MiB, but the expression was missing parentheses, so the `1024 * 1024` is removed and it keeps working as usual, returning bytes.