### PR TITLE
Adds proxy support for HTTPClient

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -49,6 +49,14 @@ HTTPClient *HTTPClient::create() {
 	return nullptr;
 }
 
+void HTTPClient::set_http_proxy(const String &p_host, int p_port) {
+	WARN_PRINT("HTTP proxy feature is not available");
+}
+
+void HTTPClient::set_https_proxy(const String &p_host, int p_port) {
+	WARN_PRINT("HTTPS proxy feature is not available");
+}
+
 Error HTTPClient::_request_raw(Method p_method, const String &p_url, const Vector<String> &p_headers, const Vector<uint8_t> &p_body) {
 	int size = p_body.size();
 	return request(p_method, p_url, p_headers, size > 0 ? p_body.ptr() : nullptr, size);
@@ -141,6 +149,9 @@ void HTTPClient::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_status"), &HTTPClient::get_status);
 	ClassDB::bind_method(D_METHOD("poll"), &HTTPClient::poll);
+
+	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPClient::set_http_proxy);
+	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPClient::set_https_proxy);
 
 	ClassDB::bind_method(D_METHOD("query_string_from_dict", "fields"), &HTTPClient::query_string_from_dict);
 

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -192,6 +192,10 @@ public:
 
 	virtual Error poll() = 0;
 
+	// Use empty string or -1 to unset
+	virtual void set_http_proxy(const String &p_host, int p_port);
+	virtual void set_https_proxy(const String &p_host, int p_port);
+
 	HTTPClient() {}
 	virtual ~HTTPClient() {}
 };

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -38,8 +38,14 @@ private:
 	Status status = STATUS_DISCONNECTED;
 	IP::ResolverID resolving = IP::RESOLVER_INVALID_ID;
 	Array ip_candidates;
-	int conn_port = -1;
+	int conn_port = -1; // Server to make requests to
 	String conn_host;
+	int server_port = -1; // Server to connect to (might be a proxy server)
+	String server_host;
+	int http_proxy_port = -1; // Proxy server for http requests
+	String http_proxy_host;
+	int https_proxy_port = -1; // Proxy server for https requests
+	String https_proxy_host;
 	bool ssl = false;
 	bool ssl_verify_host = false;
 	bool blocking = false;
@@ -58,6 +64,7 @@ private:
 
 	Ref<StreamPeerTCP> tcp_connection;
 	Ref<StreamPeer> connection;
+	Ref<HTTPClientTCP> proxy_client; // Negotiate with proxy server
 
 	int response_num = 0;
 	Vector<String> response_headers;
@@ -87,6 +94,8 @@ public:
 	void set_read_chunk_size(int p_size) override;
 	int get_read_chunk_size() const override;
 	Error poll() override;
+	void set_http_proxy(const String &p_host, int p_port) override;
+	void set_https_proxy(const String &p_host, int p_port) override;
 	HTTPClientTCP();
 };
 

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -173,6 +173,24 @@
 				Sends the body data raw, as a byte array and does not encode it in any way.
 			</description>
 		</method>
+		<method name="set_http_proxy">
+			<return type="void" />
+			<argument index="0" name="host" type="String" />
+			<argument index="1" name="port" type="int" />
+			<description>
+				Sets the proxy server for HTTP requests.
+				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+			</description>
+		</method>
+		<method name="set_https_proxy">
+			<return type="void" />
+			<argument index="0" name="host" type="String" />
+			<argument index="1" name="port" type="int" />
+			<description>
+				Sets the proxy server for HTTPS requests.
+				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="blocking_mode_enabled" type="bool" setter="set_blocking_mode" getter="is_blocking_mode_enabled" default="false">


### PR DESCRIPTION
This PR adds HTTP(s) proxy support for `HTTPClient`.

* `core/io/http_client.{h,cpp}`:
    * Added `set_http{,s}_proxy(host, port)` methods to set/unset proxy. They are not pure virtual functions, the default implementation does nothing and emits warnings about proxy not implemented.
* `core/io/http_client_tcp.{h,cpp}`:
    * what HTTP proxy does:
        1. connect to proxy server instead of target server
        2. use full URL in request line
    * what HTTPS proxy does:
        1. connect to proxy server instead of target server
        2. send a `CONNECT` request to setup the tunnel to target server
        3. do SSL handshakes and other things as usual
* `doc/classes/HTTPClient.xml`: added corresponding doc for new methods

Some notes:

* Common HTTP proxy servers can send requests to different target servers. This implementation always closes and reconnects to the proxy server for each `connect_to_host()` since simple HTTP connections are seldom used nowadays and reusing the connection complicates the code.
* Only proxy servers that uses HTTP protocol are supported (i.e. no HTTP-on-HTTPS or HTTPS-on-HTTPS). It's hard to find such proxy servers.
* Basic authentication is not currently implemented.

<details>
<summary>Here is a messy test code.</summary>

```gdscript
extends SceneTree

func _init():
    var err = 0
    var http = HTTPClient.new() # Create the Client.

    http.set_http_proxy("localhost", 8123)
    http.set_https_proxy("127.0.0.1", 8123)

    print("----- http with proxy -----")
    err = http.connect_to_host("httpbin.org", -1, false) # Connect to host/port.
    assert(err == OK) # Make sure connection was OK.
    await do_http(http)
    http.close()

    print("----- https with proxy -----")
    err = http.connect_to_host("httpbin.org", -1, true) # Connect to host/port.
    assert(err == OK) # Make sure connection was OK.
    await do_http(http)
    http.close()

    http.set_http_proxy("127.0.0.1", -1)
    http.set_https_proxy("127.0.0.1", -1)

    print("----- http without proxy -----")
    err = http.connect_to_host("httpbin.org", -1, false) # Connect to host/port.
    assert(err == OK) # Make sure connection was OK.
    await do_http(http)
    http.close()

    print("----- https without proxy -----")
    err = http.connect_to_host("httpbin.org", -1, true) # Connect to host/port.
    assert(err == OK) # Make sure connection was OK.
    await do_http(http)
    http.close()

    quit()


func do_http(http):
    var err = 0
    # Wait until resolved and connected.
    while http.get_status() == HTTPClient.STATUS_CONNECTING or http.get_status() == HTTPClient.STATUS_RESOLVING:
        http.poll()
        print("Connecting...")
        if not OS.has_feature("web"):
            OS.delay_msec(500)
        else:
            await (Engine.get_main_loop().idle_frame)

    assert(http.get_status() == HTTPClient.STATUS_CONNECTED) # Could not connect

    # Some headers
    var headers = [
        "User-Agent: Pirulo/1.0 (Godot)",
        "Accept: */*"
    ]

    err = http.request(HTTPClient.METHOD_GET, "/get", headers) # Request a page from the site (this one was chunked..)
    assert(err == OK) # Make sure all is OK.

    while http.get_status() == HTTPClient.STATUS_REQUESTING:
        # Keep polling for as long as the request is being processed.
        http.poll()
        print("Requesting...")
        if not OS.has_feature("web"):
            OS.delay_msec(500)
        else:
            # Synchronous HTTP requests are not supported on the web,
            # so wait for the next main loop iteration.
            await (Engine.get_main_loop().idle_frame)

    assert(http.get_status() == HTTPClient.STATUS_BODY or http.get_status() == HTTPClient.STATUS_CONNECTED) # Make sure request finished well.

    print("response? ", http.has_response()) # Site might not have a response.

    if http.has_response():
        # If there is a response...

        headers = http.get_response_headers_as_dictionary() # Get response headers.
        print("code: ", http.get_response_code()) # Show response code.
        print("**headers:\\n", headers) # Show headers.

        # Getting the HTTP Body

        if http.is_response_chunked():
            # Does it use chunks?
            print("Response is Chunked!")
        else:
            # Or just plain Content-Length
            var bl = http.get_response_body_length()
            print("Response Length: ", bl)

        # This method works for both anyway

        var rb = PackedByteArray() # Array that will hold the data.

        while http.get_status() == HTTPClient.STATUS_BODY:
            # Get a chunk.
            var chunk = http.read_response_body_chunk()
            if chunk.size() == 0:
                if not OS.has_feature("web"):
                    # Got nothing, wait for buffers to fill a bit.
                    OS.delay_usec(1000)
                else:
                    await (Engine.get_main_loop().idle_frame)
            else:
                rb = rb + chunk # Append to read buffer.
            # While there is body left to be read
            http.poll()
        # Done!

        print("bytes got: ", rb.size())
        var text = rb.get_string_from_ascii()
        print("Text: ", text)
```

</details>