### PR TITLE
Buffered access to log output

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -226,6 +226,21 @@ String Engine::get_shader_cache_path() const {
 	return shader_cache_path;
 }
 
+void Engine::set_buffered_logger(BufferedSingletonLogger *p_logger) {
+	buffered_log = p_logger;
+	buffered_log_active = true;
+}
+
+Array Engine::get_log_buffer() {
+	ERR_FAIL_COND_V_MSG(!buffered_log_active, Array(), "The project setting \"logging/buffered_logging/enable_buffered_logging\" must be `true` to get the buffered output log.");
+	return buffered_log->flush_message_buffer();
+}
+
+Array Engine::get_error_buffer() {
+	ERR_FAIL_COND_V_MSG(!buffered_log_active, Array(), "The project setting \"logging/buffered_logging/enable_buffered_logging\" must be `true` to get the buffered error log.");
+	return buffered_log->flush_error_buffer();
+}
+
 Engine *Engine::singleton = nullptr;
 
 Engine *Engine::get_singleton() {

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -31,6 +31,8 @@
 #ifndef ENGINE_H
 #define ENGINE_H
 
+#include "core/config/project_settings.h"
+#include "core/io/logger.h"
 #include "core/os/main_loop.h"
 #include "core/string/ustring.h"
 #include "core/templates/list.h"
@@ -70,6 +72,9 @@ private:
 	Map<StringName, Object *> singleton_ptrs;
 
 	bool editor_hint = false;
+
+	BufferedSingletonLogger *buffered_log = nullptr;
+	bool buffered_log_active = false;
 
 	static Engine *singleton;
 
@@ -132,6 +137,10 @@ public:
 
 	bool is_abort_on_gpu_errors_enabled() const;
 	bool is_validation_layers_enabled() const;
+
+	Array get_log_buffer();
+	Array get_error_buffer();
+	void set_buffered_logger(BufferedSingletonLogger *p_logger);
 
 	Engine();
 	virtual ~Engine() {}

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2181,6 +2181,14 @@ bool Engine::is_editor_hint() const {
 	return ::Engine::get_singleton()->is_editor_hint();
 }
 
+Array Engine::get_log_buffer() const {
+	return ::Engine::get_singleton()->get_log_buffer();
+}
+
+Array Engine::get_error_buffer() const {
+	return ::Engine::get_singleton()->get_error_buffer();
+}
+
 void Engine::set_print_error_messages(bool p_enabled) {
 	::Engine::get_singleton()->set_print_error_messages(p_enabled);
 }
@@ -2232,6 +2240,11 @@ void Engine::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "target_fps"), "set_target_fps", "get_target_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_scale"), "set_time_scale", "get_time_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "physics_jitter_fix"), "set_physics_jitter_fix", "get_physics_jitter_fix");
+
+	ADD_SIGNAL(MethodInfo("log_message", PropertyInfo(Variant::INT, "buffered_messages")));
+	ADD_SIGNAL(MethodInfo("error_message", PropertyInfo(Variant::INT, "buffered_messages")));
+	ClassDB::bind_method(D_METHOD("get_log_buffer"), &Engine::get_log_buffer);
+	ClassDB::bind_method(D_METHOD("get_error_buffer"), &Engine::get_error_buffer);
 }
 
 Engine *Engine::singleton = nullptr;

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -648,6 +648,9 @@ public:
 	void set_print_error_messages(bool p_enabled);
 	bool is_printing_error_messages() const;
 
+	Array get_log_buffer() const;
+	Array get_error_buffer() const;
+
 	Engine() { singleton = this; }
 };
 

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -275,3 +275,95 @@ CompositeLogger::~CompositeLogger() {
 		memdelete(loggers[i]);
 	}
 }
+
+BufferedSingletonLogger::BufferedSingletonLogger(int p_buffer_size) {
+	buffer_size = p_buffer_size;
+}
+
+BufferedSingletonLogger::~BufferedSingletonLogger() {
+}
+
+Array BufferedSingletonLogger::flush_message_buffer() {
+	Array return_array = message_buffer.duplicate();
+	message_buffer.clear();
+	return return_array;
+}
+
+Array BufferedSingletonLogger::flush_error_buffer() {
+	Array return_array = error_buffer.duplicate();
+	error_buffer.clear();
+	return return_array;
+}
+
+void BufferedSingletonLogger::logv(const char *p_format, va_list p_list, bool p_err) {
+	const int static_buf_size = 512;
+	char static_buf[static_buf_size];
+	char *buf = static_buf;
+	va_list list_copy;
+	va_copy(list_copy, p_list);
+	int len = vsnprintf(buf, static_buf_size, p_format, p_list);
+	if (len >= static_buf_size) {
+		buf = (char *)Memory::alloc_static(len + 1);
+		vsnprintf(buf, len + 1, p_format, list_copy);
+	}
+	va_end(list_copy);
+	String new_message = String(buf);
+	if (message_buffer.size() >= buffer_size) {
+		message_buffer.pop_front();
+		message_buffer.pop_front();
+		message_buffer.push_back(new_message);
+		WARN_PRINT("Maximum size of buffered log has been exceeded. Discarding log messages.");
+	} else {
+		message_buffer.push_back(new_message);
+	}
+
+	if (len >= static_buf_size) {
+		Memory::free_static(buf);
+	}
+
+	if (Engine::get_singleton()->has_singleton("Engine")) {
+		Engine::get_singleton()->get_singleton_object("Engine")->emit_signal("log_message", message_buffer.size());
+	}
+}
+
+void BufferedSingletonLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type) {
+	const char *error_type = "ERROR";
+	switch (p_type) {
+		case ERR_ERROR:
+			error_type = "ERROR";
+			break;
+		case ERR_WARNING:
+			error_type = "WARNING";
+			break;
+		case ERR_SCRIPT:
+			error_type = "SCRIPT ERROR";
+			break;
+		case ERR_SHADER:
+			error_type = "SHADER ERROR";
+			break;
+		default:
+			error_type = "UNKNOWN ERROR TYPE";
+			break;
+	}
+
+	Dictionary error_message = Dictionary();
+	error_message["type"] = String(error_type);
+	error_message["function"] = String(p_function);
+	error_message["file"] = String(p_file);
+	error_message["line"] = itos(p_line);
+	error_message["code"] = String(p_code);
+	error_message["rationale"] = String(p_rationale);
+
+	if (error_buffer.size() >= buffer_size) {
+		error_buffer.pop_front();
+		error_buffer.pop_front();
+		error_buffer.push_back(error_message);
+		WARN_PRINT("Maximum size of buffered error log has been exceeded. Discarding error messages.");
+	} else {
+		error_buffer.push_back(error_message);
+	}
+
+	if (Engine::get_singleton()->has_singleton("Engine")) {
+		Engine::get_singleton()->get_singleton_object("Engine")->emit_signal("error_message", error_buffer.size());
+	}
+}

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -110,4 +110,23 @@ public:
 	virtual ~CompositeLogger();
 };
 
+/**
+ * Writes messages to a buffer that can be accessed from the Engine singleton.
+ */
+class BufferedSingletonLogger : public Logger {
+	Array message_buffer;
+	Array error_buffer;
+	int buffer_size;
+
+public:
+	BufferedSingletonLogger(int p_buffer_size = 100);
+
+	virtual void logv(const char *p_format, va_list p_list, bool p_err) _PRINTF_FORMAT_ATTRIBUTE_2_0;
+	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type = ERR_ERROR);
+	Array flush_message_buffer();
+	Array flush_error_buffer();
+
+	virtual ~BufferedSingletonLogger();
+};
+
 #endif // LOGGER_H

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -34,6 +34,14 @@
 				{[code]platinum_sponsors[/code], [code]gold_sponsors[/code], [code]silver_sponsors[/code], [code]bronze_sponsors[/code], [code]mini_sponsors[/code], [code]gold_donors[/code], [code]silver_donors[/code], [code]bronze_donors[/code]}
 			</description>
 		</method>
+		<method name="get_error_buffer" qualifiers="const">
+			<return type="Array">
+			</return>
+			<description>
+				Returns an array of [Dictionary] elements with the standard error logging stream. The error buffer is automatically cleared after calling [method get_error_buffer]. See also [method get_log_buffer].
+				[b]Note:[/b] This method will return an empty array if [member ProjectSettings.logging/buffered_logging/enable_buffered_logging] is [code]false[/code], which is the default.
+			</description>
+		</method>
 		<method name="get_frames_drawn">
 			<return type="int" />
 			<description>
@@ -56,6 +64,14 @@
 			<return type="String" />
 			<description>
 				Returns Godot license text.
+			</description>
+		</method>
+		<method name="get_log_buffer" qualifiers="const">
+			<return type="Array">
+			</return>
+			<description>
+				Returns an array of [Dictionary] elements with the standard output logging stream. The log buffer is automatically cleared after calling [method get_log_buffer]. See also [method get_error_buffer].
+				[b]Note:[/b] This method will return an empty array if [member ProjectSettings.logging/buffered_logging/enable_buffered_logging] is [code]false[/code], which is the default.
 			</description>
 		</method>
 		<method name="get_main_loop" qualifiers="const">
@@ -168,6 +184,24 @@
 			Controls how fast or slow the in-game clock ticks versus the real life one. It defaults to 1.0. A value of 2.0 means the game moves twice as fast as real life, whilst a value of 0.5 means the game moves at half the regular speed.
 		</member>
 	</members>
+	<signals>
+		<signal name="error_message">
+			<argument index="0" name="buffered_messages" type="int">
+			</argument>
+			<description>
+				Emitted when a message is printed to the standard output logging stream. See also [signal log_message].
+				[b]Note:[/b] This signal is only emitted if [member ProjectSettings.logging/buffered_logging/enable_buffered_logging] is [code]true[/code], which is not the default.
+			</description>
+		</signal>
+		<signal name="log_message">
+			<argument index="0" name="buffered_messages" type="int">
+			</argument>
+			<description>
+				Emitted when a message is printed to the standard error logging stream. See also [signal error_message].
+				[b]Note:[/b] This signal is only emitted if [member ProjectSettings.logging/buffered_logging/enable_buffered_logging] is [code]true[/code], which is not the default.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1287,6 +1287,15 @@
 		<member name="layer_names/3d_render/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D render layer 9. If left empty, the layer will display as "Layer 9".
 		</member>
+		<member name="logging/buffered_logging/buffer_size" type="int" setter="" getter="" default="100">
+			The buffer size to use when [member logging/buffered_logging/enable_buffered_logging] is enabled. This value is defined in number of [i]messages[/i] printed, not the number of lines or characters.
+		</member>
+		<member name="logging/buffered_logging/enable_buffered_logging" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], allows retrieving standard output and error logging streams using [method Engine.get_log_buffer], [method Engine.get_error_buffer], [signal Engine.log_message], and [signal Engine.error_message]. For example, this can be used to display built-in messages in an in-game console.
+			[b]Note:[/b] The buffer has a limited size which is configured by [member logging/buffered_logging/buffer_size].
+		</member>
+		<member name="memory/limits/command_queue/multithreading_queue_size_kb" type="int" setter="" getter="" default="256">
+		</member>
 		<member name="memory/limits/message_queue/max_size_kb" type="int" setter="" getter="" default="4096">
 			Godot uses a message queue to defer some function calls. If you run out of space on it (you will see an error), you can increase the size here.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1168,6 +1168,15 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->add_logger(memnew(RotatedFileLogger(base_path, max_files)));
 	}
 
+	GLOBAL_DEF("logging/buffered_logging/enable_buffered_logging", false);
+	GLOBAL_DEF("logging/buffered_logging/buffer_size", 100);
+	if (!project_manager && !editor && GLOBAL_GET("logging/buffered_logging/enable_buffered_logging")) {
+		int buffer_size = GLOBAL_GET("logging/buffered_logging/buffer_size");
+		BufferedSingletonLogger *buffer_logger = memnew(BufferedSingletonLogger(buffer_size));
+		OS::get_singleton()->add_logger(buffer_logger);
+		Engine::get_singleton()->set_buffered_logger(buffer_logger);
+	}
+
 	if (main_args.size() == 0 && String(GLOBAL_GET("application/run/main_scene")) == "") {
 #ifdef TOOLS_ENABLED
 		if (!editor && !project_manager) {


### PR DESCRIPTION
This is an attempt at implementing the feature proposed in https://github.com/godotengine/godot-proposals/issues/536 as we need this for a project

Added support for buffered log access from game scripts. This can be enabled from the project settings.

The log buffer can be accessed from the Engine singleton, via the `get_log_buffer()` method. The Engine singleton will also emit a signal when a new message is logged.

If messages are not handled a warning will be logged when the buffer is full (and some log messages in the buffer will be deleted).

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/536.*