### PR TITLE
Fix PhysicalBone gizmo not showing

### DIFF
--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -3531,7 +3531,7 @@ String CollisionObject3DGizmoPlugin::get_gizmo_name() const {
 }
 
 int CollisionObject3DGizmoPlugin::get_priority() const {
-	return -1;
+	return -2;
 }
 
 void CollisionObject3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {


### PR DESCRIPTION
The new CollisionObject gizmo used for custom shapes was used with higher priority due to alphabetical order and was preventing physical bones from being displayed in the editor.

Fixes #47188 (regression from #45783)