### PR TITLE
[3.3] Fix PhysicalBone gizmo not showing

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -3056,7 +3056,7 @@ String CollisionObjectGizmoPlugin::get_name() const {
 }
 
 int CollisionObjectGizmoPlugin::get_priority() const {
-	return -1;
+	return -2;
 }
 
 void CollisionObjectGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {


### PR DESCRIPTION
The new CollisionObject gizmo used for custom shapes was used with higher priority due to alphabetical order and was preventing physical bones from being displayed in the editor.

Fixes #47188 (regression from #46397)
3.x backport of #47263