### PR TITLE
Add a "keep" import mode to keep files as-is and export them.

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -295,6 +295,9 @@ Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) 
 	return OK;
 }
 
+void ConfigFile::clear() {
+	values.clear();
+}
 void ConfigFile::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_value", "section", "key", "value"), &ConfigFile::set_value);
 	ClassDB::bind_method(D_METHOD("get_value", "section", "key", "default"), &ConfigFile::get_value, DEFVAL(Variant()));
@@ -317,4 +320,6 @@ void ConfigFile::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("save_encrypted", "path", "key"), &ConfigFile::save_encrypted);
 	ClassDB::bind_method(D_METHOD("save_encrypted_pass", "path", "password"), &ConfigFile::save_encrypted_pass);
+
+	ClassDB::bind_method(D_METHOD("clear"), &ConfigFile::clear);
 }

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -68,6 +68,8 @@ public:
 	Error load(const String &p_path);
 	Error parse(const String &p_data);
 
+	void clear();
+
 	Error load_encrypted(const String &p_path, const Vector<uint8_t> &p_key);
 	Error load_encrypted_pass(const String &p_path, const String &p_pass);
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -874,6 +874,20 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				continue;
 			}
 
+			String importer_type = config->get_value("remap", "importer");
+
+			if (importer_type == "keep") {
+				//just keep file as-is
+				Vector<uint8_t> array = FileAccess::get_file_as_array(path);
+				err = p_func(p_udata, path, array, idx, total, enc_in_filters, enc_ex_filters, key);
+
+				if (err != OK) {
+					return err;
+				}
+
+				continue;
+			}
+
 			List<String> remaps;
 			config->get_section_keys("remap", &remaps);
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -405,6 +405,10 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 
 	memdelete(f);
 
+	if (importer_name == "keep") {
+		return false; //keep mode, do not reimport
+	}
+
 	Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
 
 	if (importer->get_format_version() > version) {
@@ -1532,6 +1536,10 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		source_file_options[p_files[i]] = Map<StringName, Variant>();
 		importer_name = file_importer_name;
 
+		if (importer_name == "keep") {
+			continue; //do nothing
+		}
+
 		Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
 		ERR_FAIL_COND_V(!importer.is_valid(), ERR_FILE_CORRUPT);
 		List<ResourceImporter::ImportOption> options;
@@ -1553,6 +1561,10 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		}
 
 		base_paths[p_files[i]] = ResourceFormatImporter::get_singleton()->get_import_base_path(p_files[i]);
+	}
+
+	if (importer_name == "keep") {
+		return OK; // (do nothing)
 	}
 
 	ERR_FAIL_COND_V(importer_name == String(), ERR_UNCONFIGURED);
@@ -1700,7 +1712,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 						params[E->get()] = cf->get_value("params", E->get());
 					}
 				}
-				if (p_custom_importer != String() && cf->has_section("remap")) {
+				if (p_custom_importer == String() && cf->has_section("remap")) {
 					importer_name = cf->get_value("remap", "importer");
 				}
 			}
@@ -1710,6 +1722,16 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 		late_added_files.insert(p_file); //imported files do not call update_file(), but just in case..
 	}
 
+	if (importer_name == "keep") {
+		//keep files, do nothing.
+		fs->files[cpos]->modified_time = FileAccess::get_modified_time(p_file);
+		fs->files[cpos]->import_modified_time = FileAccess::get_modified_time(p_file + ".import");
+		fs->files[cpos]->deps.clear();
+		fs->files[cpos]->type = "";
+		fs->files[cpos]->import_valid = false;
+		EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
+		return;
+	}
 	Ref<ResourceImporter> importer;
 	bool load_default = false;
 	//find the importer


### PR DESCRIPTION
Just choose this mode, and the file will not be imported (but it will be exported as-is).

![image](https://user-images.githubusercontent.com/6265307/112049184-0c891900-8b2e-11eb-9d51-e090fcbdb3bf.png)

Cherry picking for 3.x should e relatively easy.

Fixes #38957.
Fixes #47061.