### PR TITLE
[3.x] Give bone attachments in the GLTF importer stable and proper names, and deduplicate.

### DIFF
--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -424,7 +424,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 	Error _parse_lights(GLTFState &state);
 	Error _parse_animations(GLTFState &state);
 
-	BoneAttachment *_generate_bone_attachment(GLTFState &state, Skeleton *skeleton, const GLTFNodeIndex node_index);
+	BoneAttachment *_get_or_make_bone_attachment(GLTFState &state, Skeleton *skeleton, Spatial *scene_root, const GLTFNodeIndex node_index);
 	MeshInstance *_generate_mesh_instance(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);
 	Camera *_generate_camera(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);
 	Light *_generate_light(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);


### PR DESCRIPTION
If an object is parented to a bone (not via skinning, but actually parented), a BoneAttachment node is generated on import.
These nodes are simply named _BoneAttachment_, _BoneAttachment1_, _BoneAttachment2_, ...
If the gltf model file is updated, the order of these bone attachments can change, which will break inherited scenes.
Also, if multiple objects are parented to the same bone, a BoneAttachment node is generated for each of them, which makes the scene tree unnecessarily messy.

This commit only generates one BoneAttachent node per bone, and names them after the bone.
This ensures, that model files can be updated without breaking inherited scenes.

Backward compatibility is broken by this (if a model is reimported, the BoneAttachments will have different names), but it was already broken between 3.2.3 and 3.x, so I assume this is fine.
(In 3.2.3, the BoneAttachments were named _BoneAttachment_, _BoneAttachment 1_, _BoneAttachment 2_, ... - In 3.x there is no _space_ in the name.)
Therefore I'd be happy if we can get this into 3.3, in order to avoid breaking compatibility twice.