### PR TITLE
Use snake_case by default for filenames

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2467,7 +2467,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				file->add_filter("*." + extensions[i] + " ; " + extensions[i].to_upper());
 			}
 
-			if (scene->get_filename() != "") {
+			if (!scene->get_filename().is_empty()) {
 				String path = scene->get_filename();
 				file->set_current_path(path);
 				if (extensions.size()) {
@@ -2476,13 +2476,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 						file->set_current_path(path.replacen("." + ext, "." + extensions.front()->get()));
 					}
 				}
-			} else {
-				String existing;
-				if (extensions.size()) {
-					String root_name(scene->get_name());
-					existing = root_name + "." + extensions.front()->get().to_lower();
-				}
-				file->set_current_path(existing);
+			} else if (extensions.size()) {
+				const String root_name = String(scene->get_name()).camelcase_to_underscore();
+				file->set_current_path(root_name + "." + extensions.front()->get().to_lower());
 			}
 			file->popup_file_dialog();
 			file->set_title(TTR("Save Scene As..."));


### PR DESCRIPTION
The guideline from #3694 states that `snake_case` should be used for filenames. But the automatically-chosen names currently don't follow this guideline. @Calinou mentioned that this should be changed in the editor code itself.