### PR TITLE
Dont Change Hovering during Control Focus Events

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -96,17 +96,14 @@ void BaseButton::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_FOCUS_ENTER) {
-		status.hovering = true;
 		update();
 	}
 
 	if (p_what == NOTIFICATION_FOCUS_EXIT) {
 		if (status.press_attempt) {
 			status.press_attempt = false;
-			status.hovering = false;
 			update();
 		} else if (status.hovering) {
-			status.hovering = false;
 			update();
 		}
 	}


### PR DESCRIPTION
I've talked with a few people on the chat about this. @Calinou  and @vnen 

This PR removes the alteration of `hovering` during Focus Enter and Focus Exit events. The alteration of `hovering` during Focus Enter and Exit events causes inconsistency in the UI. This PR makes the Hover and Focus styles more clear in their purpose and improves the consistency of the usage of those styles.

I've tested and am using this on our projects.

backport to 3.x: https://github.com/godotengine/godot/pull/47281

When a Node is focused, it renders with its Hover stylebox and its Focus stylebox. If the node is then then Hovered and UnHovered, the Hover stylebox is removed and replaced with a Normal stylebox. This is inconsistent. It is more logical and intuitive if Hover and Focus are treated as 2 independent mechanisms.

Before:
![before_focushover](https://user-images.githubusercontent.com/78934401/112081578-7cf16380-8b49-11eb-90ec-d56e4f6ce7e8.gif)

After:
![after_focushover](https://user-images.githubusercontent.com/78934401/112081585-7f53bd80-8b49-11eb-8d91-b708fffc326a.gif)

*Bugsquad edit:* Fixes #29326.