### PR TITLE
[3.x]  Dont Change Hovering during Control Focus Events

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -98,8 +98,6 @@ void BaseButton::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_FOCUS_ENTER) {
-
-		status.hovering = true;
 		update();
 	}
 
@@ -107,10 +105,8 @@ void BaseButton::_notification(int p_what) {
 
 		if (status.press_attempt) {
 			status.press_attempt = false;
-			status.hovering = false;
 			update();
 		} else if (status.hovering) {
-			status.hovering = false;
 			update();
 		}
 	}


### PR DESCRIPTION
3.x backport version of: https://github.com/godotengine/godot/pull/47280

I've talked with a few people on the chat about this. @Calinou and @vnen

This PR removes the alteration of hovering during Focus Enter and Focus Exit events. The alteration of hovering during Focus Enter and Exit events causes inconsistency in the UI. This PR makes the Hover and Focus styles more clear in their purpose and improves the consistency of the usage of those styles.