### PR TITLE
[3.x] Add a get_as_bulk_array method to multimesh

### DIFF
--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -68,6 +68,15 @@
 				[Transform] is stored as 12 floats, [Transform2D] is stored as 8 floats, [code]COLOR_8BIT[/code] / [code]CUSTOM_DATA_8BIT[/code] is stored as 1 float (4 bytes as is) and [code]COLOR_FLOAT[/code] / [code]CUSTOM_DATA_FLOAT[/code] is stored as 4 floats.
 			</description>
 		</method>
+		<method name="get_as_bulk_array">
+			<return type="PoolRealArray">
+			</return>
+			<description>
+				Gets all data related to the instances in one go. Note that this will cause stalls in multithreaded environments.
+				All data is packed in one large float array. An array may look like this: Transform for instance 1, color data for instance 1, custom data for instance 1, transform for instance 2, color data for instance 2, etc...
+				[Transform] is stored as 12 floats, [Transform2D] is stored as 8 floats, [code]COLOR_8BIT[/code] / [code]CUSTOM_DATA_8BIT[/code] is stored as 1 float (4 bytes as is) and [code]COLOR_FLOAT[/code] / [code]CUSTOM_DATA_FLOAT[/code] is stored as 4 floats.
+			</description>
+		</method>
 		<method name="set_instance_color">
 			<return type="void">
 			</return>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -2966,9 +2966,18 @@
 			</argument>
 			<description>
 				Sets all data related to the instances in one go. This is especially useful when loading the data from disk or preparing the data from GDNative.
-
 				All data is packed in one large float array. An array may look like this: Transform for instance 1, color data for instance 1, custom data for instance 1, transform for instance 2, color data for instance 2, etc.
-
+				[Transform] is stored as 12 floats, [Transform2D] is stored as 8 floats, [code]COLOR_8BIT[/code] / [code]CUSTOM_DATA_8BIT[/code] is stored as 1 float (4 bytes as is) and [code]COLOR_FLOAT[/code] / [code]CUSTOM_DATA_FLOAT[/code] is stored as 4 floats.
+			</description>
+		</method>
+		<method name="multimesh_get_as_bulk_array">
+			<return type="PoolRealArray">
+			</return>
+			<argument index="0" name="multimesh" type="RID">
+			</argument>
+			<description>
+				Gets all data related to the instances in one go. Note that this will cause stalls in multithreaded environments.
+				All data is packed in one large float array. An array may look like this: Transform for instance 1, color data for instance 1, custom data for instance 1, transform for instance 2, color data for instance 2, etc.
 				[Transform] is stored as 12 floats, [Transform2D] is stored as 8 floats, [code]COLOR_8BIT[/code] / [code]CUSTOM_DATA_8BIT[/code] is stored as 1 float (4 bytes as is) and [code]COLOR_FLOAT[/code] / [code]CUSTOM_DATA_FLOAT[/code] is stored as 4 floats.
 			</description>
 		</method>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -440,6 +440,7 @@ public:
 	Color multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const { return Color(); }
 
 	void multimesh_set_as_bulk_array(RID p_multimesh, const PoolVector<float> &p_array) {}
+	PoolVector<float> multimesh_get_as_bulk_array(RID p_multimesh) const { return PoolVector<float>(); }
 
 	void multimesh_set_visible_instances(RID p_multimesh, int p_visible) {}
 	int multimesh_get_visible_instances(RID p_multimesh) const { return 0; }

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -3410,6 +3410,23 @@ void RasterizerStorageGLES2::multimesh_set_as_bulk_array(RID p_multimesh, const 
 	}
 }
 
+PoolVector<float> RasterizerStorageGLES2::multimesh_get_as_bulk_array(RID p_multimesh) const {
+	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, PoolVector<float>());
+	ERR_FAIL_COND_V(!multimesh->data.ptr(), PoolVector<float>());
+
+	int dsize = multimesh->data.size();
+
+	ERR_FAIL_COND_V(dsize <= 0, PoolVector<float>());
+
+	PoolVector<float> ret;
+	ret.resize(dsize);
+	PoolVector<float>::Write w = ret.write();
+	copymem(w.ptr(), multimesh->data.ptr(), dsize);
+
+	return ret;
+}
+
 void RasterizerStorageGLES2::multimesh_set_visible_instances(RID p_multimesh, int p_visible) {
 	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);
 	ERR_FAIL_COND(!multimesh);

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -829,6 +829,7 @@ public:
 	virtual Color multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const;
 
 	virtual void multimesh_set_as_bulk_array(RID p_multimesh, const PoolVector<float> &p_array);
+	virtual PoolVector<float> multimesh_get_as_bulk_array(RID p_multimesh) const;
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible);
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5069,6 +5069,23 @@ void RasterizerStorageGLES3::multimesh_set_as_bulk_array(RID p_multimesh, const 
 	}
 }
 
+PoolVector<float> RasterizerStorageGLES3::multimesh_get_as_bulk_array(RID p_multimesh) const {
+	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, PoolVector<float>());
+	ERR_FAIL_COND_V(!multimesh->data.ptr(), PoolVector<float>());
+
+	int dsize = multimesh->data.size();
+
+	ERR_FAIL_COND_V(dsize <= 0, PoolVector<float>());
+
+	PoolVector<float> ret;
+	ret.resize(dsize);
+	PoolVector<float>::Write w = ret.write();
+	copymem(w.ptr(), multimesh->data.ptr(), dsize);
+
+	return ret;
+}
+
 void RasterizerStorageGLES3::multimesh_set_visible_instances(RID p_multimesh, int p_visible) {
 
 	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -863,6 +863,7 @@ public:
 	virtual Color multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const;
 
 	virtual void multimesh_set_as_bulk_array(RID p_multimesh, const PoolVector<float> &p_array);
+	virtual PoolVector<float> multimesh_get_as_bulk_array(RID p_multimesh) const;
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible);
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const;

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -268,6 +268,11 @@ void MultiMesh::set_as_bulk_array(const PoolVector<float> &p_array) {
 	VisualServer::get_singleton()->multimesh_set_as_bulk_array(multimesh, p_array);
 }
 
+PoolVector<float> MultiMesh::get_as_bulk_array() {
+
+	return VisualServer::get_singleton()->multimesh_get_as_bulk_array(multimesh);
+}
+
 AABB MultiMesh::get_aabb() const {
 
 	return VisualServer::get_singleton()->multimesh_get_aabb(multimesh);
@@ -334,6 +339,7 @@ void MultiMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_instance_custom_data", "instance", "custom_data"), &MultiMesh::set_instance_custom_data);
 	ClassDB::bind_method(D_METHOD("get_instance_custom_data", "instance"), &MultiMesh::get_instance_custom_data);
 	ClassDB::bind_method(D_METHOD("set_as_bulk_array", "array"), &MultiMesh::set_as_bulk_array);
+	ClassDB::bind_method(D_METHOD("get_as_bulk_array"), &MultiMesh::get_as_bulk_array);
 	ClassDB::bind_method(D_METHOD("get_aabb"), &MultiMesh::get_aabb);
 
 	ClassDB::bind_method(D_METHOD("_set_transform_array"), &MultiMesh::_set_transform_array);

--- a/scene/resources/multimesh.h
+++ b/scene/resources/multimesh.h
@@ -112,6 +112,7 @@ public:
 	Color get_instance_custom_data(int p_instance) const;
 
 	void set_as_bulk_array(const PoolVector<float> &p_array);
+	PoolVector<float> get_as_bulk_array();
 
 	virtual AABB get_aabb() const;
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -335,6 +335,7 @@ public:
 	virtual Color multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const = 0;
 
 	virtual void multimesh_set_as_bulk_array(RID p_multimesh, const PoolVector<float> &p_array) = 0;
+	virtual PoolVector<float> multimesh_get_as_bulk_array(RID p_multimesh) const = 0;
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible) = 0;
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -269,6 +269,7 @@ public:
 	BIND2RC(Color, multimesh_instance_get_custom_data, RID, int)
 
 	BIND2(multimesh_set_as_bulk_array, RID, const PoolVector<float> &)
+	BIND1RC(PoolVector<float>, multimesh_get_as_bulk_array, RID)
 
 	BIND2(multimesh_set_visible_instances, RID, int)
 	BIND1RC(int, multimesh_get_visible_instances, RID)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -206,6 +206,7 @@ public:
 	FUNC2RC(Color, multimesh_instance_get_custom_data, RID, int)
 
 	FUNC2(multimesh_set_as_bulk_array, RID, const PoolVector<float> &)
+	FUNC1RC(PoolVector<float>, multimesh_get_as_bulk_array, RID)
 
 	FUNC2(multimesh_set_visible_instances, RID, int)
 	FUNC1RC(int, multimesh_get_visible_instances, RID)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1734,6 +1734,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("multimesh_set_visible_instances", "multimesh", "visible"), &VisualServer::multimesh_set_visible_instances);
 	ClassDB::bind_method(D_METHOD("multimesh_get_visible_instances", "multimesh"), &VisualServer::multimesh_get_visible_instances);
 	ClassDB::bind_method(D_METHOD("multimesh_set_as_bulk_array", "multimesh", "array"), &VisualServer::multimesh_set_as_bulk_array);
+	ClassDB::bind_method(D_METHOD("multimesh_get_as_bulk_array", "multimesh"), &VisualServer::multimesh_get_as_bulk_array);
 #ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("immediate_create"), &VisualServer::immediate_create);
 	ClassDB::bind_method(D_METHOD("immediate_begin", "immediate", "primitive", "texture"), &VisualServer::immediate_begin, DEFVAL(RID()));

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -369,6 +369,7 @@ public:
 	virtual Color multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const = 0;
 
 	virtual void multimesh_set_as_bulk_array(RID p_multimesh, const PoolVector<float> &p_array) = 0;
+	virtual PoolVector<float> multimesh_get_as_bulk_array(RID p_multimesh) const = 0;
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible) = 0;
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const = 0;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Added a `get_as_bulk_array` method to multimesh.

Neither `get` nor `set` of bulk arrays for multimeshes exists in 4.0/master right now so I don't think it can be implemented for those and cherry picked down.

Closes #47158 
