### PR TITLE
Enable unit testing in MSVC when tests=yes is supplied

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -646,6 +646,9 @@ def generate_vs_project(env, num_jobs):
                 "-j%s" % num_jobs,
             ]
 
+            if env["tests"]:
+                common_build_postfix.append("tests=yes")
+
             if env["custom_modules"]:
                 common_build_postfix.append("custom_modules=%s" % env["custom_modules"])
 
@@ -658,6 +661,8 @@ def generate_vs_project(env, num_jobs):
         add_to_vs_project(env, env.modules_sources)
         add_to_vs_project(env, env.scene_sources)
         add_to_vs_project(env, env.servers_sources)
+        if env["tests"]:
+            add_to_vs_project(env, env.tests_sources)
         add_to_vs_project(env, env.editor_sources)
 
         for header in glob_recursive("**/*.h"):


### PR DESCRIPTION
I noticed that tests weren't enabled in MSVC even when tests=yes was supplied to scons. After some digging through the scons files it seems that some things were missing that was needed to enable testing in MSVC. 
- The NMake build command would not get the test=yes command appended to its command-line arguments.
- The Preprocessor definition TESTS_ENABLED was not set, which enables compilation of the correct main.
- The test sources (*.cpp file) were not added to the vs project sources.

With these changes, I was able to build the project and run the unit tests using the command line argument --test. Additionally, I was able to run the tests using Resharper's unit testing dialogue in visual studio (it seems that the built-in unit test dialogue does not support doctest). 

Some unit tests are ignored, but running them manually seems to work, so I am not entirely sure why they are skipped when run from the Resharper tool.

![UnitTestsRunning](https://user-images.githubusercontent.com/5877844/112146467-e457f380-8bdb-11eb-8e89-eef5fafedc19.jpg)
