### PR TITLE
allow variant construction in expressions

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -410,6 +410,14 @@ Error Expression::_get_token(Token &r_token) {
 					} else if (id == "self") {
 						r_token.type = TK_SELF;
 					} else {
+						for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+							if (id == Variant::get_type_name(Variant::Type(i))) {
+								r_token.type = TK_BASIC_TYPE;
+								r_token.value = i;
+								return OK;
+							}
+						}
+
 						if (Variant::has_utility_function(id)) {
 							r_token.type = TK_BUILTIN_FUNC;
 							r_token.value = id;


### PR DESCRIPTION
This code has been removed here: 
https://github.com/godotengine/godot/commit/5288ff538d75d2ddab257a9e1e40050c9b8fa1cb#diff-38f5f835b7be8d6d97fcdc68ee97e34c8161292e7ca9bb55c80ee4c399a4f3d5L1095

previously (godot-3.2) evaluating an expression like "Vector2(0, 0)" would return the Vector2 as Variant, after I ported my project to godot-4.0 this stopped working. 

You can also notice that the `TK_BASIC_TYPE`-token is available in the switch case, but nowhere is it ever assigned, so in its current state the `TK_BASIC_TYPE` can not be constructed.

We can also see that the same code is used for `visual_script_expression.cpp` 
https://github.com/godotengine/godot/blob/cd05653e308c2263e23debd45211c48af134040d/modules/visual_script/visual_script_expression.cpp#L544
which is not removed there.