### PR TITLE
Fix race condition on `script_binding` in C#

### DIFF
--- a/modules/mono/mono_gd/gd_mono_internals.cpp
+++ b/modules/mono/mono_gd/gd_mono_internals.cpp
@@ -91,7 +91,11 @@ void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 		// The object was just created, no script instance binding should have been attached
 		CRASH_COND(unmanaged->has_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index()));
 
-		void *data = (void *)CSharpLanguage::get_singleton()->insert_script_binding(unmanaged, script_binding);
+		void *data;
+		{
+			MutexLock lock(CSharpLanguage::get_singleton()->get_language_bind_mutex());
+			data = (void *)CSharpLanguage::get_singleton()->insert_script_binding(unmanaged, script_binding);
+		}
 
 		// Should be thread safe because the object was just created and nothing else should be referencing it
 		unmanaged->set_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index(), data);


### PR DESCRIPTION
Fixes #37652, replicates changes from #43889 into `master` branch. Protects the script binding map in the C# scripting system from getting corrupted during multithreaded allocation.