### PR TITLE
[3.x] Use Bullet's convex hull computer in place of QuickHull when available.

### DIFF
--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -30,6 +30,7 @@
 
 #include "geometry.h"
 
+#include "core/math/quick_hull.h"
 #include "core/print_string.h"
 
 #include "thirdparty/misc/clipper.hpp"
@@ -38,6 +39,8 @@
 #include "thirdparty/stb_rect_pack/stb_rect_pack.h"
 
 #define SCALE_FACTOR 100000.0 // Based on CMP_EPSILON.
+
+Geometry::ConvexHullFunc Geometry::convex_hull_function = NULL;
 
 // This implementation is very inefficient, commenting unless bugs happen. See the other one.
 /*
@@ -860,6 +863,13 @@ Geometry::MeshData Geometry::build_convex_mesh(const PoolVector<Plane> &p_planes
 	}
 
 	return mesh;
+}
+
+Error Geometry::build_convex_hull(const Vector<Vector3> &p_points, Geometry::MeshData &r_mesh) {
+	if (!convex_hull_function) {
+		return QuickHull::build(p_points, r_mesh);
+	}
+	return convex_hull_function(p_points, r_mesh);
 }
 
 PoolVector<Plane> Geometry::build_box_planes(const Vector3 &p_extents) {

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -1037,6 +1037,7 @@ public:
 	static Vector<Vector<Vector2> > decompose_polygon_in_convex(Vector<Point2> polygon);
 
 	static MeshData build_convex_mesh(const PoolVector<Plane> &p_planes);
+	static Error build_convex_hull(const Vector<Vector3> &p_points, MeshData &r_mesh);
 	static PoolVector<Plane> build_sphere_planes(real_t p_radius, int p_lats, int p_lons, Vector3::Axis p_axis = Vector3::AXIS_Z);
 	static PoolVector<Plane> build_box_planes(const Vector3 &p_extents);
 	static PoolVector<Plane> build_cylinder_planes(real_t p_radius, real_t p_height, int p_sides, Vector3::Axis p_axis = Vector3::AXIS_Z);
@@ -1052,6 +1053,9 @@ public:
 	static Vector<PackRectsResult> partial_pack_rects(const Vector<Vector2i> &p_sizes, const Size2i &p_atlas_size);
 
 	static Vector<Vector3> compute_convex_mesh_points(const Plane *p_planes, int p_plane_count);
+
+	typedef Error (*ConvexHullFunc)(const Vector<Vector3> &, MeshData &);
+	static ConvexHullFunc convex_hull_function;
 
 private:
 	static Vector<Vector<Point2> > _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open = false);

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -31,7 +31,6 @@
 #include "spatial_editor_gizmos.h"
 
 #include "core/math/geometry.h"
-#include "core/math/quick_hull.h"
 #include "scene/3d/audio_stream_player_3d.h"
 #include "scene/3d/baked_lightmap.h"
 #include "scene/3d/collision_polygon.h"
@@ -3671,7 +3670,7 @@ void CollisionShapeSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 
 			Vector<Vector3> varr = Variant(points);
 			Geometry::MeshData md;
-			Error err = QuickHull::build(varr, md);
+			Error err = Geometry::build_convex_hull(varr, md);
 			if (err == OK) {
 				Vector<Vector3> points2;
 				points2.resize(md.edges.size() * 2);

--- a/main/tests/test_physics.cpp
+++ b/main/tests/test_physics.cpp
@@ -32,7 +32,6 @@
 
 #include "core/map.h"
 #include "core/math/math_funcs.h"
-#include "core/math/quick_hull.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/print_string.h"
@@ -176,7 +175,7 @@ protected:
 
 		RID convex_mesh = vs->mesh_create();
 		Geometry::MeshData convex_data = Geometry::build_convex_mesh(convex_planes);
-		QuickHull::build(convex_data.vertices, convex_data);
+		Geometry::build_convex_hull(convex_data.vertices, convex_data);
 		vs->mesh_add_surface_from_mesh_data(convex_mesh, convex_data);
 
 		type_mesh_map[PhysicsServer::SHAPE_CONVEX_POLYGON] = convex_mesh;

--- a/main/tests/test_render.cpp
+++ b/main/tests/test_render.cpp
@@ -31,7 +31,6 @@
 #include "test_render.h"
 
 #include "core/math/math_funcs.h"
-#include "core/math/quick_hull.h"
 #include "core/os/keyboard.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
@@ -121,7 +120,7 @@ public:
 		vts.push_back(Vector3(-1, -1, -1));
 
 		Geometry::MeshData md;
-		Error err = QuickHull::build(vts, md);
+		Error err = Geometry::build_convex_hull(vts, md);
 		print_line("ERR: " + itos(err));
 		test_cube = vs->mesh_create();
 		vs->mesh_add_surface_from_mesh_data(test_cube, md);

--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -29,7 +29,6 @@
 /*************************************************************************/
 
 #include "navigation_mesh_generator.h"
-#include "core/math/quick_hull.h"
 #include "core/os/thread.h"
 #include "editor/editor_settings.h"
 #include "scene/3d/collision_shape.h"
@@ -217,7 +216,7 @@ void EditorNavigationMeshGenerator::_parse_geometry(Transform p_accumulated_tran
 						Vector<Vector3> varr = Variant(convex_polygon->get_points());
 						Geometry::MeshData md;
 
-						Error err = QuickHull::build(varr, md);
+						Error err = Geometry::build_convex_hull(varr, md);
 
 						if (err == OK) {
 							PoolVector3Array faces;

--- a/scene/resources/convex_polygon_shape.cpp
+++ b/scene/resources/convex_polygon_shape.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 #include "convex_polygon_shape.h"
-#include "core/math/quick_hull.h"
+#include "core/math/geometry.h"
 #include "servers/physics_server.h"
 
 Vector<Vector3> ConvexPolygonShape::get_debug_mesh_lines() {
@@ -40,7 +40,7 @@ Vector<Vector3> ConvexPolygonShape::get_debug_mesh_lines() {
 
 		Vector<Vector3> varr = Variant(points);
 		Geometry::MeshData md;
-		Error err = QuickHull::build(varr, md);
+		Error err = Geometry::build_convex_hull(varr, md);
 		if (err == OK) {
 			Vector<Vector3> lines;
 			lines.resize(md.edges.size() * 2);

--- a/servers/physics/shape_sw.cpp
+++ b/servers/physics/shape_sw.cpp
@@ -31,7 +31,6 @@
 #include "shape_sw.h"
 
 #include "core/math/geometry.h"
-#include "core/math/quick_hull.h"
 #include "core/sort_array.h"
 
 #define _EDGE_IS_VALID_SUPPORT_THRESHOLD 0.0002
@@ -1149,9 +1148,9 @@ Vector3 ConvexPolygonShapeSW::get_moment_of_inertia(real_t p_mass) const {
 
 void ConvexPolygonShapeSW::_setup(const Vector<Vector3> &p_vertices) {
 
-	Error err = QuickHull::build(p_vertices, mesh);
+	Error err = Geometry::build_convex_hull(p_vertices, mesh);
 	if (err != OK)
-		ERR_PRINT("Failed to build QuickHull");
+		ERR_PRINT("Failed to build convex hull");
 
 	AABB _aabb;
 


### PR DESCRIPTION
Fixes #45946, maybe more.