### PR TITLE
Fix use of Error its uninitialised and resolves importers being broken

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1302,7 +1302,7 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file) {
 
 	ERR_FAIL_COND_V(!importer.is_valid(), nullptr);
 
-	Error err;
+	Error err = OK;
 	Node *scene = importer->import_scene(p_source_file, EditorSceneImporter::IMPORT_ANIMATION | EditorSceneImporter::IMPORT_GENERATE_TANGENT_ARRAYS, 15, nullptr, &err);
 	if (!scene || err != OK) {
 		return nullptr;


### PR DESCRIPTION
Fixes importers not being able to open up when you click the scene

The problem:
```Error err;```

The solution
```Error err = OK;```

we could possibly make a fix or do a scan for these kinds of bugs

*Bugsquad edit:* fixes #47303.