### PR TITLE
Importer - Fix crash & Fix FBX mesh names

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -477,7 +477,7 @@ SceneImportSettings *SceneImportSettings::get_singleton() {
 void SceneImportSettings::_select(Tree *p_from, String p_type, String p_id) {
 	selecting = true;
 
-	if (p_type == "Node") {
+	if (p_type == "Node" && node_map.has(p_id)) {
 		node_selected->hide(); //always hide just in case
 		mesh_preview->hide();
 		if (Object::cast_to<Node3D>(scene)) {
@@ -516,7 +516,7 @@ void SceneImportSettings::_select(Tree *p_from, String p_type, String p_id) {
 				scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_NODE;
 			}
 		}
-	} else if (p_type == "Animation") {
+	} else if (p_type == "Animation" && animation_map.has(p_id)) {
 		node_selected->hide(); //always hide just in case
 		mesh_preview->hide();
 		if (Object::cast_to<Node3D>(scene)) {
@@ -529,13 +529,18 @@ void SceneImportSettings::_select(Tree *p_from, String p_type, String p_id) {
 
 		scene_import_settings_data->settings = &ad.settings;
 		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION;
-	} else if (p_type == "Mesh") {
+	} else if (p_type == "Mesh" && mesh_map.has(p_id)) {
 		node_selected->hide();
 		if (Object::cast_to<Node3D>(scene)) {
 			Object::cast_to<Node3D>(scene)->hide();
 		}
 
 		MeshData &md = mesh_map[p_id];
+
+		if (md.mesh_node == nullptr) {
+			return;
+		}
+
 		if (p_from != mesh_tree) {
 			md.mesh_node->uncollapse_tree();
 			md.mesh_node->select(0);
@@ -554,7 +559,8 @@ void SceneImportSettings::_select(Tree *p_from, String p_type, String p_id) {
 
 		scene_import_settings_data->settings = &md.settings;
 		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MESH;
-	} else if (p_type == "Material") {
+
+	} else if (p_type == "Material" && material_map.has(p_id)) {
 		node_selected->hide();
 		if (Object::cast_to<Node3D>(scene)) {
 			Object::cast_to<Node3D>(scene)->hide();

--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -106,10 +106,10 @@ class SceneImportSettings : public ConfirmationDialog {
 	Map<String, MaterialData> material_map;
 
 	struct MeshData {
-		bool has_import_id;
+		bool has_import_id = false;
 		Ref<Mesh> mesh;
-		TreeItem *scene_node;
-		TreeItem *mesh_node;
+		TreeItem *scene_node = nullptr;
+		TreeItem *mesh_node = nullptr;
 
 		float cam_rot_x = -Math_PI / 4;
 		float cam_rot_y = -Math_PI / 4;

--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -398,6 +398,8 @@ EditorSceneImporterMeshNode3D *FBXMeshData::create_fbx_mesh(const ImportState &s
 
 	EditorSceneImporterMeshNode3D *godot_mesh = memnew(EditorSceneImporterMeshNode3D);
 	godot_mesh->set_mesh(mesh);
+	godot_mesh->set_name(ImportUtils::FBXNodeToName(model->Name()));
+	mesh->set_name(ImportUtils::FBXNodeToName(model->Name()));
 	return godot_mesh;
 }
 


### PR DESCRIPTION
Mesh was crashing when I clicked it in the UI without a name.
<img width="354" alt="Screenshot 2021-03-24 at 01 19 05" src="https://user-images.githubusercontent.com/748770/112243037-c83c6c80-8c44-11eb-9c4e-8cd29ffc5e2f.png">

It was a missing name, but there was a null check missing too, so I fixed this along with some nullptr things, that clang debugger pointed out to me.

<img width="354" alt="Screenshot 2021-03-24 at 02 02 16" src="https://user-images.githubusercontent.com/748770/112243147-fcb02880-8c44-11eb-901a-fd3ccf9083d4.png">

I really like the new import dialog.
