### PR TITLE
Always have a name for gltf2 mesh, material and skins.

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -554,10 +554,10 @@ Error GLTFDocument::_parse_scenes(Ref<GLTFState> state) {
 			state->root_nodes.push_back(nodes[j]);
 		}
 
-		if (s.has("name") && s["name"] != "") {
+		if (s.has("name") && !String(s["name"]).is_empty() && !((String)s["name"]).begins_with("Scene")) {
 			state->scene_name = _gen_unique_name(state, s["name"]);
 		} else {
-			state->scene_name = _gen_unique_name(state, "Scene");
+			state->scene_name = _gen_unique_name(state, state->filename);
 		}
 	}
 
@@ -2449,6 +2449,12 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> state) {
 		const Dictionary &extras = d.has("extras") ? (Dictionary)d["extras"] : Dictionary();
 		Ref<EditorSceneImporterMesh> import_mesh;
 		import_mesh.instance();
+		String mesh_name = "mesh";
+		if (d.has("name") && !String(d["name"]).is_empty()) {
+			mesh_name = d["name"];
+		}
+		import_mesh->set_name(_gen_unique_name(state, vformat("%s_%s", state->scene_name, mesh_name)));
+
 		for (int j = 0; j < primitives.size(); j++) {
 			Dictionary p = primitives[j];
 
@@ -3343,8 +3349,10 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> state) {
 
 		Ref<StandardMaterial3D> material;
 		material.instance();
-		if (d.has("name")) {
+		if (d.has("name") && !String(d["name"]).is_empty()) {
 			material->set_name(d["name"]);
+		} else {
+			material->set_name(vformat("material_%s", itos(i)));
 		}
 		material->set_flag(BaseMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 		Dictionary pbr_spec_gloss_extensions;
@@ -3881,8 +3889,10 @@ Error GLTFDocument::_parse_skins(Ref<GLTFState> state) {
 			state->nodes.write[node]->joint = true;
 		}
 
-		if (d.has("name")) {
+		if (d.has("name") && !String(d["name"]).is_empty()) {
 			skin->set_name(d["name"]);
+		} else {
+			skin->set_name(vformat("skin_%s", itos(i)));
 		}
 
 		if (d.has("skeleton")) {
@@ -6355,6 +6365,9 @@ Error GLTFDocument::parse(Ref<GLTFState> state, String p_path, bool p_read_binar
 			return FAILED;
 	}
 	f->close();
+
+	// get file's name, use for scene name if none
+	state->filename = p_path.get_file().get_slice(".", 0);
 
 	ERR_FAIL_COND_V(!state->json.has("asset"), Error::FAILED);
 

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -53,6 +53,7 @@ class GLTFState : public Resource {
 	friend class GLTFDocument;
 	friend class PackedSceneGLTF;
 
+	String filename;
 	Dictionary json;
 	int major_version = 0;
 	int minor_version = 0;


### PR DESCRIPTION
Co-authored-by: @Lcbx

Always have names for gltf2 meshes in the new import dialog.

Can you try?

Related to https://github.com/godotengine/godot/pull/46783. See also https://github.com/godotengine/godot/pull/47312.