### PR TITLE
SCons: Don't pass -msse2 to MSVC for Embree

### DIFF
--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -67,7 +67,6 @@ env_embree.Append(
     CPPFLAGS=[
         "-DEMBREE_TARGET_SSE2",
         "-DEMBREE_LOWEST_ISA",
-        "-msse2",
         "-DTASKING_INTERNAL",
         "-DNDEBUG",
         "-D__SSE2__",
@@ -76,7 +75,7 @@ env_embree.Append(
 )
 
 if not env_embree.msvc:
-    env_embree.Append(CPPFLAGS=["-mxsave"])
+    env_embree.Append(CPPFLAGS=["-msse2", "-mxsave"])
     if env["platform"] == "windows":
         env_embree.Append(CPPFLAGS=["-mstackrealign"])
 


### PR DESCRIPTION
This is a flag only supported by GCC/Clang.