### PR TITLE
Clarify that get_unix_time() returns seconds

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -355,7 +355,7 @@
 			<return type="float">
 			</return>
 			<description>
-				Returns the current UNIX epoch timestamp.
+				Returns the current UNIX epoch timestamp in seconds.
 				[b]Important:[/b] This is the system clock that the user can manully set. [b]Never use[/b] this method for precise time calculation since its results are also subject to automatic adjustments by the operating system. [b]Always use[/b] [method get_ticks_usec] or [method get_ticks_msec] for precise time calculation instead, since they are guaranteed to be monotonic (i.e. never decrease).
 			</description>
 		</method>


### PR DESCRIPTION
I've been implementing IAPs for a mobile game and apparently Google Billing uses milliseconds for purchase timestamp. So I felt like our timestamp needs some clarification too.