### PR TITLE
[3.x] update_bitmask_region() error changed to be informative

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -477,7 +477,7 @@ void TileSet::tile_set_tile_mode(int p_id, TileMode p_tile_mode) {
 
 TileSet::TileMode TileSet::tile_get_tile_mode(int p_id) const {
 
-	ERR_FAIL_COND_V_MSG(!tile_map.has(p_id), SINGLE_TILE, "Cannot assign tileslot for the cell value.");
+	ERR_FAIL_COND_V_MSG(!tile_map.has(p_id), SINGLE_TILE, "Found no tilemap at the given tile value.");
 	return tile_map[p_id].tile_mode;
 }
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -477,7 +477,7 @@ void TileSet::tile_set_tile_mode(int p_id, TileMode p_tile_mode) {
 
 TileSet::TileMode TileSet::tile_get_tile_mode(int p_id) const {
 
-	ERR_FAIL_COND_V(!tile_map.has(p_id), SINGLE_TILE);
+	ERR_FAIL_COND_V_MSG(!tile_map.has(p_id), SINGLE_TILE, "Cannot assign tileslot for the cell value.");
 	return tile_map[p_id].tile_mode;
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
When executing:

```
extends TileMap

func _ready():
	set_cell(0, 0, 1)
	update_bitmask_region()
```
returns, ``` !tile_map.has(p_id)" is true. Returned: SINGLE_TILE ```
The error returned isn't clear as to what the problem is. Updated the error message to a custom error message for clarity.

Fix #47313