### PR TITLE
Fix corrupt scene when export var has setter

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -811,6 +811,7 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_allow_proper
 
 	VariableNode *variable = alloc_node<VariableNode>();
 	variable->identifier = parse_identifier();
+	variable->export_info.name = variable->identifier->name;
 
 	if (match(GDScriptTokenizer::Token::COLON)) {
 		if (check(GDScriptTokenizer::Token::NEWLINE)) {
@@ -859,8 +860,6 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_allow_proper
 	}
 
 	end_statement("variable declaration");
-
-	variable->export_info.name = variable->identifier->name;
 
 	return variable;
 }


### PR DESCRIPTION
Closes #45357

Where after saving a scene can generate an empty property name in .tscn, making it corrupted, for instance:

```
[node name="BallLight" type="Node3D"]
script = ExtResource( 2 )
 = null
```

The issue is caused when an @export variable has a setter, such as:
```
@export var isOn: bool = false:
	set(val):
		isOn = val
```