### PR TITLE
Use Bullet's convex hull computer in place of QuickHull when available.

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -30,10 +30,13 @@
 
 #include "geometry_3d.h"
 
+#include "core/math/quick_hull.h"
 #include "core/string/print_string.h"
 
 #include "thirdparty/misc/clipper.hpp"
 #include "thirdparty/misc/polypartition.h"
+
+Geometry3D::ConvexHullFunc Geometry3D::convex_hull_function = nullptr;
 
 void Geometry3D::MeshData::optimize_vertices() {
 	Map<int, int> vtx_remap;
@@ -759,6 +762,13 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 	}
 
 	return mesh;
+}
+
+Error Geometry3D::build_convex_hull(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_mesh) {
+	if (!convex_hull_function) {
+		return QuickHull::build(p_points, r_mesh);
+	}
+	return convex_hull_function(p_points, r_mesh);
 }
 
 Vector<Plane> Geometry3D::build_box_planes(const Vector3 &p_extents) {

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -646,6 +646,7 @@ public:
 	};
 
 	static MeshData build_convex_mesh(const Vector<Plane> &p_planes);
+	static Error build_convex_hull(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_mesh);
 	static Vector<Plane> build_sphere_planes(real_t p_radius, int p_lats, int p_lons, Vector3::Axis p_axis = Vector3::AXIS_Z);
 	static Vector<Plane> build_box_planes(const Vector3 &p_extents);
 	static Vector<Plane> build_cylinder_planes(real_t p_radius, real_t p_height, int p_sides, Vector3::Axis p_axis = Vector3::AXIS_Z);
@@ -916,6 +917,9 @@ public:
 		n.y += n.y >= 0 ? -t : t;
 		return n.normalized();
 	}
+
+	typedef Error (*ConvexHullFunc)(const Vector<Vector3> &, Geometry3D::MeshData &);
+	static ConvexHullFunc convex_hull_function;
 };
 
 #endif // GEOMETRY_3D_H

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -32,7 +32,6 @@
 
 #include "core/math/geometry_2d.h"
 #include "core/math/geometry_3d.h"
-#include "core/math/quick_hull.h"
 #include "scene/3d/audio_stream_player_3d.h"
 #include "scene/3d/baked_lightmap.h"
 #include "scene/3d/collision_polygon_3d.h"
@@ -4121,7 +4120,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		if (points.size() > 3) {
 			Vector<Vector3> varr = Variant(points);
 			Geometry3D::MeshData md;
-			Error err = QuickHull::build(varr, md);
+			Error err = Geometry3D::build_convex_hull(varr, md);
 			if (err == OK) {
 				Vector<Vector3> points2;
 				points2.resize(md.edges.size() * 2);

--- a/modules/gdnavigation/navigation_mesh_generator.cpp
+++ b/modules/gdnavigation/navigation_mesh_generator.cpp
@@ -32,7 +32,6 @@
 
 #include "navigation_mesh_generator.h"
 
-#include "core/math/quick_hull.h"
 #include "core/os/thread.h"
 #include "scene/3d/collision_shape_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -220,7 +219,7 @@ void NavigationMeshGenerator::_parse_geometry(Transform p_accumulated_transform,
 						Vector<Vector3> varr = Variant(convex_polygon->get_points());
 						Geometry3D::MeshData md;
 
-						Error err = QuickHull::build(varr, md);
+						Error err = Geometry3D::build_convex_hull(varr, md);
 
 						if (err == OK) {
 							PackedVector3Array faces;

--- a/modules/vhacd/register_types.cpp
+++ b/modules/vhacd/register_types.cpp
@@ -29,7 +29,9 @@
 /*************************************************************************/
 
 #include "register_types.h"
+#include "core/math/geometry_3d.h"
 #include "scene/resources/mesh.h"
+#include "thirdparty/vhacd/inc/btConvexHullComputer.h"
 #include "thirdparty/vhacd/public/VHACD.h"
 
 static Vector<Vector<Face3>> convex_decompose(const Vector<Face3> &p_faces) {
@@ -78,10 +80,61 @@ static Vector<Vector<Face3>> convex_decompose(const Vector<Face3> &p_faces) {
 	return ret;
 }
 
+static Error convex_hull(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_mesh) {
+	// build the convex hull using the convex hull computer from bullet.
+	// simply copies the data over to Godot's types
+
+	r_mesh = Geometry3D::MeshData(); // clear
+
+	if (p_points.size() == 0) {
+		return FAILED; // matches QuickHull
+	}
+
+	VHACD::btConvexHullComputer ch;
+	ch.compute(&p_points.ptr()[0][0], sizeof(p_points.ptr()[0]), p_points.size(), -1.0, -1.0);
+
+	r_mesh.vertices.resize(ch.vertices.size());
+	for (int i = 0; i < ch.vertices.size(); i++) {
+		r_mesh.vertices.write[i].x = ch.vertices[i].getX();
+		r_mesh.vertices.write[i].y = ch.vertices[i].getY();
+		r_mesh.vertices.write[i].z = ch.vertices[i].getZ();
+	}
+
+	r_mesh.edges.resize(ch.edges.size());
+	for (int i = 0; i < ch.edges.size(); i++) {
+		r_mesh.edges.write[i].a = (&ch.edges[i])->getSourceVertex();
+		r_mesh.edges.write[i].b = (&ch.edges[i])->getTargetVertex();
+	}
+
+	r_mesh.faces.resize(ch.faces.size());
+	for (int i = 0; i < ch.faces.size(); i++) {
+		const VHACD::btConvexHullComputer::Edge *e_start = &ch.edges[ch.faces[i]];
+		const VHACD::btConvexHullComputer::Edge *e = e_start;
+		Geometry3D::MeshData::Face &face = r_mesh.faces.write[i];
+
+		do {
+			face.indices.push_back(e->getTargetVertex());
+
+			e = e->getNextEdgeOfFace();
+		} while (e != e_start);
+
+		// compute normal
+		if (face.indices.size() >= 3) {
+			face.plane = Plane(r_mesh.vertices[face.indices[0]], r_mesh.vertices[face.indices[2]], r_mesh.vertices[face.indices[1]]);
+		} else {
+			WARN_PRINT("Too few vertices per face.");
+		}
+	}
+
+	return OK;
+}
+
 void register_vhacd_types() {
 	Mesh::convex_composition_function = convex_decompose;
+	Geometry3D::convex_hull_function = convex_hull;
 }
 
 void unregister_vhacd_types() {
 	Mesh::convex_composition_function = nullptr;
+	Geometry3D::convex_hull_function = nullptr;
 }

--- a/scene/resources/convex_polygon_shape_3d.cpp
+++ b/scene/resources/convex_polygon_shape_3d.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 #include "convex_polygon_shape_3d.h"
-#include "core/math/quick_hull.h"
+#include "core/math/geometry_3d.h"
 #include "servers/physics_server_3d.h"
 
 Vector<Vector3> ConvexPolygonShape3D::get_debug_mesh_lines() const {
@@ -38,7 +38,7 @@ Vector<Vector3> ConvexPolygonShape3D::get_debug_mesh_lines() const {
 	if (points.size() > 3) {
 		Vector<Vector3> varr = Variant(points);
 		Geometry3D::MeshData md;
-		Error err = QuickHull::build(varr, md);
+		Error err = Geometry3D::build_convex_hull(varr, md);
 		if (err == OK) {
 			Vector<Vector3> lines;
 			lines.resize(md.edges.size() * 2);

--- a/servers/physics_3d/shape_3d_sw.cpp
+++ b/servers/physics_3d/shape_3d_sw.cpp
@@ -31,7 +31,6 @@
 #include "shape_3d_sw.h"
 
 #include "core/math/geometry_3d.h"
-#include "core/math/quick_hull.h"
 #include "core/templates/sort_array.h"
 
 #define _EDGE_IS_VALID_SUPPORT_THRESHOLD 0.0002
@@ -1068,9 +1067,9 @@ Vector3 ConvexPolygonShape3DSW::get_moment_of_inertia(real_t p_mass) const {
 }
 
 void ConvexPolygonShape3DSW::_setup(const Vector<Vector3> &p_vertices) {
-	Error err = QuickHull::build(p_vertices, mesh);
+	Error err = Geometry3D::build_convex_hull(p_vertices, mesh);
 	if (err != OK) {
-		ERR_PRINT("Failed to build QuickHull");
+		ERR_PRINT("Failed to build convex hull");
 	}
 
 	AABB _aabb;

--- a/tests/test_physics_3d.cpp
+++ b/tests/test_physics_3d.cpp
@@ -31,7 +31,6 @@
 #include "test_physics_3d.h"
 
 #include "core/math/math_funcs.h"
-#include "core/math/quick_hull.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
@@ -173,7 +172,7 @@ protected:
 
 		RID convex_mesh = vs->mesh_create();
 		Geometry3D::MeshData convex_data = Geometry3D::build_convex_mesh(convex_planes);
-		QuickHull::build(convex_data.vertices, convex_data);
+		Geometry3D::build_convex_hull(convex_data.vertices, convex_data);
 		vs->mesh_add_surface_from_mesh_data(convex_mesh, convex_data);
 
 		type_mesh_map[PhysicsServer3D::SHAPE_CONVEX_POLYGON] = convex_mesh;

--- a/tests/test_render.cpp
+++ b/tests/test_render.cpp
@@ -31,7 +31,6 @@
 #include "test_render.h"
 
 #include "core/math/math_funcs.h"
-#include "core/math/quick_hull.h"
 #include "core/os/keyboard.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
@@ -118,7 +117,7 @@ public:
 		vts.push_back(Vector3(-1, -1, -1));
 
 		Geometry3D::MeshData md;
-		Error err = QuickHull::build(vts, md);
+		Error err = Geometry3D::build_convex_hull(vts, md);
 		print_line("ERR: " + itos(err));
 		test_cube = vs->mesh_create();
 		vs->mesh_add_surface_from_mesh_data(test_cube, md);


### PR DESCRIPTION
Fixes #45946, maybe more.

Now against master.
Uses QuickHull if vhacd is unavailable.