### PR TITLE
Rename the `.shader` file extension to `.gdshader`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1103,7 +1103,7 @@ ProjectSettings::ProjectSettings() {
 	if (Engine::get_singleton()->has_singleton("GodotSharp")) {
 		extensions.push_back("cs");
 	}
-	extensions.push_back("shader");
+	extensions.push_back("gdshader");
 
 	GLOBAL_DEF("editor/script/search_in_file_extensions", extensions);
 	custom_prop_info["editor/script/search_in_file_extensions"] = PropertyInfo(Variant::PACKED_STRING_ARRAY, "editor/script/search_in_file_extensions");

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -137,7 +137,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 		extension_guess["atlastex"] = tree->get_theme_icon("AtlasTexture", "EditorIcons");
 		extension_guess["scn"] = tree->get_theme_icon("PackedScene", "EditorIcons");
 		extension_guess["tscn"] = tree->get_theme_icon("PackedScene", "EditorIcons");
-		extension_guess["shader"] = tree->get_theme_icon("Shader", "EditorIcons");
+		extension_guess["gdshader"] = tree->get_theme_icon("Shader", "EditorIcons");
 		extension_guess["gd"] = tree->get_theme_icon("GDScript", "EditorIcons");
 		extension_guess["vs"] = tree->get_theme_icon("VisualScript", "EditorIcons");
 	}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3172,7 +3172,7 @@ void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_numb
 	if (ResourceLoader::exists(fpath)) {
 		RES res = ResourceLoader::load(fpath);
 
-		if (fpath.get_extension() == "shader") {
+		if (fpath.get_extension() == "gdshader") {
 			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));
 			shader_editor->edit(res.ptr());
 			shader_editor->make_visible(true);

--- a/misc/dist/linux/org.godotengine.Godot.xml
+++ b/misc/dist/linux/org.godotengine.Godot.xml
@@ -21,6 +21,12 @@
     <glob pattern="*.escn"/>
   </mime-type>
 
+  <mime-type type="application/x-godot-shader">
+    <comment>Godot Engine shader</comment>
+    <icon name="x-godot-shader" />
+    <glob pattern="*.gdshader"/>
+  </mime-type>
+
   <mime-type type="application/x-gdscript">
     <comment>GDScript script</comment>
     <icon name="x-gdscript" />

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -184,7 +184,7 @@ RES ResourceFormatLoaderShader::load(const String &p_path, const String &p_origi
 }
 
 void ResourceFormatLoaderShader::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("shader");
+	p_extensions->push_back("gdshader");
 }
 
 bool ResourceFormatLoaderShader::handles_type(const String &p_type) const {
@@ -193,7 +193,7 @@ bool ResourceFormatLoaderShader::handles_type(const String &p_type) const {
 
 String ResourceFormatLoaderShader::get_resource_type(const String &p_path) const {
 	String el = p_path.get_extension().to_lower();
-	if (el == "shader") {
+	if (el == "gdshader") {
 		return "Shader";
 	}
 	return "";
@@ -224,7 +224,7 @@ Error ResourceFormatSaverShader::save(const String &p_path, const RES &p_resourc
 void ResourceFormatSaverShader::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
 	if (const Shader *shader = Object::cast_to<Shader>(*p_resource)) {
 		if (shader->is_text_shader()) {
-			p_extensions->push_back("shader");
+			p_extensions->push_back("gdshader");
 		}
 	}
 }


### PR DESCRIPTION
This lets third-party software recognize Godot shaders more easily, without relying on guesswork since the `.shader` extension is generic.

Existing `.shader` files will have to be renamed to `.gdshader` to be recognized by Godot again.

This closes https://github.com/godotengine/godot-proposals/issues/2488.