### PR TITLE
Fix opening scene (.tscn) via FileSystem

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -967,7 +967,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 				ResourceImporterScene::get_singleton()->get_recognized_extensions(&importer_exts);
 				String extension = fpath.get_extension();
 				for (List<String>::Element *E = importer_exts.front(); E; E = E->next()) {
-					if (extension.nocasecmp_to(E->get())) {
+					if (extension.nocasecmp_to(E->get()) == 0) {
 						is_imported = true;
 						break;
 					}


### PR DESCRIPTION
https://github.com/godotengine/godot/issues/47303 still persists

Error opening scene - when opening a .tscn file ("PackedScene") in the FileSystem tab.

Since "tscn" is alphabetically greater than all of : "dae", "escn", "fbx", "glb", "gltf", and "obj",
is_imported will always be set to true, and the for loop will always break on the first iteration.

I believe the if statement is meant to check for equal strings. 

Maybe Fixes: https://github.com/godotengine/godot/issues/47303