### PR TITLE
[3.x] Draw triangles for HeightMapShape debug collision

### DIFF
--- a/scene/resources/height_map_shape.cpp
+++ b/scene/resources/height_map_shape.cpp
@@ -45,7 +45,7 @@ Vector<Vector3> HeightMapShape::get_debug_mesh_lines() {
 		PoolRealArray::Read r = map_data.read();
 
 		// reserve some memory for our points..
-		points.resize(((map_width - 1) * map_depth * 2) + (map_width * (map_depth - 1) * 2));
+		points.resize(((map_width - 1) * map_depth * 2) + (map_width * (map_depth - 1) * 2) + (map_width - 1) * (map_depth - 1) * 2);
 
 		// now set our points
 		int r_offset = 0;
@@ -63,6 +63,11 @@ Vector<Vector3> HeightMapShape::get_debug_mesh_lines() {
 
 				if (d != map_depth - 1) {
 					points.write[w_offset++] = height;
+					points.write[w_offset++] = Vector3(height.x, r[r_offset + map_width - 1], height.z + 1.0);
+				}
+
+				if ((w != map_width - 1) && (d != map_depth - 1)) {
+					points.write[w_offset++] = Vector3(height.x + 1.0, r[r_offset], height.z);
 					points.write[w_offset++] = Vector3(height.x, r[r_offset + map_width - 1], height.z + 1.0);
 				}
 


### PR DESCRIPTION
Helps with ambiguous cases where it's not possible to tell which diagonal is used for collision in quads.

Before (can't tell if it's convex or concave):
<img src="https://user-images.githubusercontent.com/1075032/112403545-d5506e80-8ccb-11eb-91c2-9fc764574a81.png" width="200" />

After (added edge for clarification):
<img src="https://user-images.githubusercontent.com/1075032/112403584-ebf6c580-8ccb-11eb-9ed5-830b9d87f1b5.png" width="200" />

3.x backport of #47345