### PR TITLE
Fix drawing boxselection on GraphEdit

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1123,7 +1123,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 				}
 				gn->set_selected(box_selection_mode_additive);
 			} else {
-				bool select = (previus_selected.find(gn) != nullptr);
+				bool select = (previous_selected.find(gn) != nullptr);
 				if (gn->is_selected() && !select) {
 					emit_signal("node_deselected", gn);
 				} else if (!gn->is_selected() && select) {
@@ -1148,7 +1148,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 						continue;
 					}
 
-					bool select = (previus_selected.find(gn) != nullptr);
+					bool select = (previous_selected.find(gn) != nullptr);
 					if (gn->is_selected() && !select) {
 						emit_signal("node_deselected", gn);
 					} else if (!gn->is_selected() && select) {
@@ -1273,29 +1273,29 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 				box_selecting_from = b->get_position();
 				if (b->get_control()) {
 					box_selection_mode_additive = true;
-					previus_selected.clear();
+					previous_selected.clear();
 					for (int i = get_child_count() - 1; i >= 0; i--) {
 						GraphNode *gn2 = Object::cast_to<GraphNode>(get_child(i));
 						if (!gn2 || !gn2->is_selected()) {
 							continue;
 						}
 
-						previus_selected.push_back(gn2);
+						previous_selected.push_back(gn2);
 					}
 				} else if (b->get_shift()) {
 					box_selection_mode_additive = false;
-					previus_selected.clear();
+					previous_selected.clear();
 					for (int i = get_child_count() - 1; i >= 0; i--) {
 						GraphNode *gn2 = Object::cast_to<GraphNode>(get_child(i));
 						if (!gn2 || !gn2->is_selected()) {
 							continue;
 						}
 
-						previus_selected.push_back(gn2);
+						previous_selected.push_back(gn2);
 					}
 				} else {
 					box_selection_mode_additive = true;
-					previus_selected.clear();
+					previous_selected.clear();
 					for (int i = get_child_count() - 1; i >= 0; i--) {
 						GraphNode *gn2 = Object::cast_to<GraphNode>(get_child(i));
 						if (!gn2) {
@@ -1313,7 +1313,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 		if (b->get_button_index() == BUTTON_LEFT && !b->is_pressed() && box_selecting) {
 			box_selecting = false;
 			box_selecting_rect = Rect2();
-			previus_selected.clear();
+			previous_selected.clear();
 			top_layer->update();
 			minimap->update();
 		}

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1312,6 +1312,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 		if (b->get_button_index() == BUTTON_LEFT && !b->is_pressed() && box_selecting) {
 			box_selecting = false;
+			box_selecting_rect = Rect2();
 			previus_selected.clear();
 			top_layer->update();
 			minimap->update();

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -150,7 +150,7 @@ private:
 	Point2 box_selecting_from;
 	Point2 box_selecting_to;
 	Rect2 box_selecting_rect;
-	List<GraphNode *> previus_selected;
+	List<GraphNode *> previous_selected;
 
 	bool setting_scroll_ofs = false;
 	bool right_disconnects = false;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Box selection is drawn with previous area at mouse press when one or more GraphNode is connected.
![graphedit_boxselection](https://user-images.githubusercontent.com/8281454/112418690-527ff000-8d6d-11eb-9835-5a1d5dc57a60.gif)
