### PR TITLE
Fix failure in set_primary_interface when parameter is null

### DIFF
--- a/servers/arvr_server.cpp
+++ b/servers/arvr_server.cpp
@@ -318,6 +318,7 @@ Ref<ARVRInterface> ARVRServer::get_primary_interface() const {
 };
 
 void ARVRServer::set_primary_interface(const Ref<ARVRInterface> &p_primary_interface) {
+	ERR_FAIL_COND(p_primary_interface.is_null());
 	primary_interface = p_primary_interface;
 
 	print_verbose("ARVR: Primary interface set to: " + primary_interface->get_name());


### PR DESCRIPTION
Fixes #46180 

The program would fail if the parameter is passed as null in set_primary_interface because 
in the print_verbose, the get_namea) method is called on the parameter and this causes a 
failure if the parameter that was passed is null.

While I am not 100% sure this does fix the issue #46180, as I am new to contributing to godot,
it does fix a failure that would happen if the parameter is passed as null.
And regarding the failure, don't know if the problem was only this call on a null parameter 
or that the problem was that the parameter was null in the first place. 
I need a confirmation on this and I might look more into it.

Note: I also see this issue being present in master. If it's confirmed that this is the fix, I will make 
another pull request in master also because there ARVR was renamed to XR.