### PR TITLE
Fix failure in set_primary_interface when parameter is null

### DIFF
--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -311,6 +311,7 @@ Ref<XRInterface> XRServer::get_primary_interface() const {
 };
 
 void XRServer::set_primary_interface(const Ref<XRInterface> &p_primary_interface) {
+	ERR_FAIL_COND(p_primary_interface.is_null());
 	primary_interface = p_primary_interface;
 
 	print_verbose("XR: Primary interface set to: " + primary_interface->get_name());


### PR DESCRIPTION
Fixes #46180

The program would fail if the parameter is passed as null in set_primary_interface because
in the print_verbose, the get_namea) method is called on the parameter and this causes a
failure if the parameter that was passed is null.

Same fix was done in 3.x also and it seems to be present in master too.