### PR TITLE
Hide renderer selection dropdown in the editor as it's not implemented

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6466,8 +6466,8 @@ EditorNode::EditorNode() {
 	video_driver->connect("item_selected", callable_mp(this, &EditorNode::_video_driver_selected));
 	video_driver->add_theme_font_override("font", gui_base->get_theme_font("bold", "EditorFonts"));
 	video_driver->add_theme_font_size_override("font_size", gui_base->get_theme_font_size("bold_size", "EditorFonts"));
-	// TODO re-enable when GLES2 is ported
-	video_driver->set_disabled(true);
+	// TODO: Show again when OpenGL is ported.
+	video_driver->set_visible(false);
 	right_menu_hb->add_child(video_driver);
 
 #ifndef _MSC_VER


### PR DESCRIPTION
It will take at least a few months until an [OpenGL renderer](https://github.com/godotengine/godot/pull/44399) is merged for the `master` branch.

## Preview

### Before

*Notice the arrow on the right.*

![image](https://user-images.githubusercontent.com/180032/112514328-7a834980-8d95-11eb-81be-b185ffb1a62d.png)

### After

![image](https://user-images.githubusercontent.com/180032/112514179-56c00380-8d95-11eb-956f-0914082a78e2.png)
