### PR TITLE
[3.3] Fix thread_local, tls, ASLR, and DEP with MingW

### DIFF
--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -66,7 +66,6 @@ private:
 	static uint64_t _thread_id_hash(const std::thread::id &p_t);
 
 	ID id = _thread_id_hash(std::thread::id());
-	static thread_local ID caller_id;
 	std::thread thread;
 
 	static void callback(Thread *p_self, const Settings &p_settings, Thread::Callback p_callback, void *p_userdata);
@@ -87,7 +86,7 @@ public:
 #if !defined(NO_THREADS)
 	_FORCE_INLINE_ ID get_id() const { return id; }
 	// get the ID of the caller thread
-	_FORCE_INLINE_ static ID get_caller_id() { return caller_id; }
+	static ID get_caller_id();
 	// get the ID of the main thread
 	_FORCE_INLINE_ static ID get_main_id() { return main_thread_id; }
 
@@ -98,7 +97,6 @@ public:
 	///< waits until thread is finished, and deallocates it.
 	void wait_to_finish();
 
-	Thread();
 	~Thread();
 #else
 	_FORCE_INLINE_ ID get_id() const { return 0; }

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -397,6 +397,7 @@ def configure_mingw(env):
     ## Compile flags
 
     env.Append(CCFLAGS=["-mwindows"])
+    env.Append(LINKFLAGS=["-Wl,--nxcompat", "-Wl,--dynamicbase"])
     env.Append(CPPDEFINES=["WINDOWS_ENABLED", "OPENGL_ENABLED", "WASAPI_ENABLED", "WINMIDI_ENABLED"])
     env.Append(CPPDEFINES=[("WINVER", env["target_win_version"]), ("_WIN32_WINNT", env["target_win_version"])])
     env.Append(

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -135,7 +135,7 @@ char *wc_to_utf8(const wchar_t *wc) {
 	return ubuf;
 }
 
-int widechar_main(int argc, wchar_t **argv) {
+__declspec(dllexport) int widechar_main(int argc, wchar_t **argv) {
 
 	OS_Windows os(NULL);
 
@@ -169,7 +169,7 @@ int widechar_main(int argc, wchar_t **argv) {
 	return os.get_exit_code();
 };
 
-int _main() {
+__declspec(dllexport) int _main() {
 	LPWSTR *wc_argv;
 	int argc;
 	int result;
@@ -187,7 +187,7 @@ int _main() {
 	return result;
 }
 
-int main(int _argc, char **_argv) {
+__declspec(dllexport) int main(int _argc, char **_argv) {
 	// _argc and _argv are ignored
 	// we are going to use the WideChar version of them instead
 


### PR DESCRIPTION
This commit changes the way Thread::caller_id works. By moving caller_id
to the .cpp file we make sure that the TLS variable doesn't get
relocated twice causing a crash. Since we build with LTO for release
builds (and everyone should be doing that anyway) there is no extra
overhead from the non-static method. We do do an extra bool check now
there but I don't think this will add much in the way of overhead.

This check cannot be avoided if we still want to be able to cache the
thread ID hash, as we had to move the setter because of limitations of
the WinRT platform. The original workaround for this was in #46813 but
this has some unintended consequences. Specifically; threads that never
create a Thread object will always return 0 in Thread::get_caller_id()
which caused a regression. For instance the editor now freezes when
importing large textures. This PR also addresses that.

Additionally we now enable ASLR support when building with MingW, this
includes a workaround for MingW. MingW refuses to create an appropriate
relocation table if no symbols are exported. So we just export the
various main() functions in godot_windows.cpp.

While ASLR support isn't criticial for Godot, previous versions of Godot
just happened to work with a dynamic base 'by accident' and some users
run Godot this way. After the thread change the .tls section now needs
relocations to make this work. By enabling ASLR at build-time we create
these relocations and people who forced ALSR on previously will now get
a working Godot again.

This fixes #47256 and fixes #47219

This is the 3.x version of this PR. For master a different approach is
possible which I will make in the coming days.