### PR TITLE
Use key enum instead of plain integers for input code

### DIFF
--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -104,9 +104,6 @@ static Vector<_CoreConstant> _global_constants;
 
 #endif
 
-VARIANT_ENUM_CAST(Key);
-VARIANT_ENUM_CAST(KeyModifierMask);
-
 void register_global_constants() {
 	BIND_CORE_ENUM_CONSTANT(SIDE_LEFT);
 	BIND_CORE_ENUM_CONSTANT(SIDE_TOP);

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -221,7 +221,7 @@ Input::SpeedTrack::SpeedTrack() {
 	reset();
 }
 
-bool Input::is_key_pressed(int p_keycode) const {
+bool Input::is_key_pressed(Key p_keycode) const {
 	_THREAD_SAFE_METHOD_
 	return keys_pressed.has(p_keycode);
 }

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -33,6 +33,7 @@
 
 #include "core/input/input_event.h"
 #include "core/object/object.h"
+#include "core/os/keyboard.h"
 #include "core/os/thread_safe.h"
 
 class Input : public Object {
@@ -244,7 +245,7 @@ public:
 
 	static Input *get_singleton();
 
-	bool is_key_pressed(int p_keycode) const;
+	bool is_key_pressed(Key p_keycode) const;
 	bool is_mouse_button_pressed(MouseButton p_button) const;
 	bool is_joy_button_pressed(int p_device, JoyButton p_button) const;
 	bool is_action_pressed(const StringName &p_action, bool p_exact = false) const;

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -307,21 +307,21 @@ bool InputEventKey::is_pressed() const {
 	return pressed;
 }
 
-void InputEventKey::set_keycode(uint32_t p_keycode) {
+void InputEventKey::set_keycode(Key p_keycode) {
 	keycode = p_keycode;
 	emit_changed();
 }
 
-uint32_t InputEventKey::get_keycode() const {
+Key InputEventKey::get_keycode() const {
 	return keycode;
 }
 
-void InputEventKey::set_physical_keycode(uint32_t p_keycode) {
+void InputEventKey::set_physical_keycode(Key p_keycode) {
 	physical_keycode = p_keycode;
 	emit_changed();
 }
 
-uint32_t InputEventKey::get_physical_keycode() const {
+Key InputEventKey::get_physical_keycode() const {
 	return physical_keycode;
 }
 
@@ -387,7 +387,7 @@ String InputEventKey::to_string() {
 	return vformat("InputEventKey: keycode=%s, mods=%s, physical=%s, pressed=%s, echo=%s", kc, mods, physical, p, e);
 }
 
-Ref<InputEventKey> InputEventKey::create_reference(uint32_t p_keycode) {
+Ref<InputEventKey> InputEventKey::create_reference(Key p_keycode) {
 	Ref<InputEventKey> ie;
 	ie.instantiate();
 	ie->set_keycode(p_keycode & KEY_CODE_MASK);

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -34,6 +34,7 @@
 #include "core/input/input_enums.h"
 #include "core/io/resource.h"
 #include "core/math/transform_2d.h"
+#include "core/os/keyboard.h"
 #include "core/string/ustring.h"
 #include "core/typedefs.h"
 
@@ -163,8 +164,8 @@ class InputEventKey : public InputEventWithModifiers {
 
 	bool pressed = false; /// otherwise release
 
-	uint32_t keycode = 0; ///< check keyboard.h , KeyCode enum, without modifier masks
-	uint32_t physical_keycode = 0;
+	Key keycode = KEY_NONE; // Key enum, without modifier masks.
+	Key physical_keycode = KEY_NONE;
 	uint32_t unicode = 0; ///unicode
 
 	bool echo = false; /// true if this is an echo key
@@ -176,11 +177,11 @@ public:
 	void set_pressed(bool p_pressed);
 	virtual bool is_pressed() const override;
 
-	void set_keycode(uint32_t p_keycode);
-	uint32_t get_keycode() const;
+	void set_keycode(Key p_keycode);
+	Key get_keycode() const;
 
-	void set_physical_keycode(uint32_t p_keycode);
-	uint32_t get_physical_keycode() const;
+	void set_physical_keycode(Key p_keycode);
+	Key get_physical_keycode() const;
 
 	void set_unicode(uint32_t p_unicode);
 	uint32_t get_unicode() const;
@@ -199,7 +200,7 @@ public:
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
-	static Ref<InputEventKey> create_reference(uint32_t p_keycode_with_modifier_masks);
+	static Ref<InputEventKey> create_reference(Key p_keycode_with_modifier_masks);
 
 	InputEventKey() {}
 };

--- a/core/os/keyboard.h
+++ b/core/os/keyboard.h
@@ -46,6 +46,7 @@ enum {
 };
 
 enum Key {
+	KEY_NONE = 0,
 	/* CURSOR/FUNCTION/BROWSER/MULTIMEDIA/MISC KEYS */
 	KEY_ESCAPE = SPKEY | 0x01,
 	KEY_TAB = SPKEY | 0x02,
@@ -313,6 +314,52 @@ enum KeyModifierMask {
 	KEY_MASK_GROUP_SWITCH = (1 << 30)
 	// bit 31 can't be used because variant uses regular 32 bits int as datatype
 };
+
+// To avoid having unnecessary operators, only define the ones that are needed.
+
+inline Key operator-(uint32_t a, Key b) {
+	return (Key)(a - (uint32_t)b);
+}
+
+inline Key &operator-=(Key &a, int b) {
+	return (Key &)((int &)a -= b);
+}
+
+inline Key operator+(Key a, Key b) {
+	return (Key)((int)a - (int)b);
+}
+
+inline Key &operator|=(Key &a, Key b) {
+	return (Key &)((int &)a |= (int)b);
+}
+
+inline Key &operator|=(Key &a, KeyModifierMask b) {
+	return (Key &)((int &)a |= (int)b);
+}
+
+inline Key operator|(Key a, KeyModifierMask b) {
+	return (Key)((int)a | (int)b);
+}
+
+inline Key operator&(Key a, KeyModifierMask b) {
+	return (Key)((int)a & (int)b);
+}
+
+inline Key operator+(KeyModifierMask a, Key b) {
+	return (Key)((int)a + (int)b);
+}
+
+inline Key operator|(KeyModifierMask a, Key b) {
+	return (Key)((int)a | (int)b);
+}
+
+inline KeyModifierMask operator+(KeyModifierMask a, KeyModifierMask b) {
+	return (KeyModifierMask)((int)a + (int)b);
+}
+
+inline KeyModifierMask operator|(KeyModifierMask a, KeyModifierMask b) {
+	return (KeyModifierMask)((int)a | (int)b);
+}
 
 String keycode_get_string(uint32_t p_code);
 bool keycode_has_unicode(uint32_t p_keycode);

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -33,6 +33,7 @@
 
 #include "core/input/input_enums.h"
 #include "core/object/object.h"
+#include "core/os/keyboard.h"
 #include "core/templates/list.h"
 #include "core/templates/simple_type.h"
 #include "core/typedefs.h"
@@ -96,6 +97,8 @@ VARIANT_ENUM_CAST(HatDir);
 VARIANT_ENUM_CAST(HatMask);
 VARIANT_ENUM_CAST(JoyAxis);
 VARIANT_ENUM_CAST(JoyButton);
+VARIANT_ENUM_CAST(Key);
+VARIANT_ENUM_CAST(KeyModifierMask);
 VARIANT_ENUM_CAST(MIDIMessage);
 VARIANT_ENUM_CAST(MouseButton);
 VARIANT_ENUM_CAST(Orientation);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -217,7 +217,7 @@
 		</method>
 		<method name="is_key_pressed" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="keycode" type="int" />
+			<argument index="0" name="keycode" type="int" enum="Key" />
 			<description>
 				Returns [code]true[/code] if you are pressing the key in the current keyboard layout. You can pass a [enum Key] constant.
 			</description>

--- a/doc/classes/InputEventKey.xml
+++ b/doc/classes/InputEventKey.xml
@@ -29,11 +29,11 @@
 		<member name="echo" type="bool" setter="set_echo" getter="is_echo" default="false">
 			If [code]true[/code], the key was already pressed before this event. It means the user is holding the key down.
 		</member>
-		<member name="keycode" type="int" setter="set_keycode" getter="get_keycode" default="0">
+		<member name="keycode" type="int" setter="set_keycode" getter="get_keycode" enum="Key" default="0">
 			The key keycode, which corresponds to one of the [enum Key] constants. Represent key in the current keyboard layout.
 			To get a human-readable representation of the [InputEventKey], use [code]OS.get_keycode_string(event.keycode)[/code] where [code]event[/code] is the [InputEventKey].
 		</member>
-		<member name="physical_keycode" type="int" setter="set_physical_keycode" getter="get_physical_keycode" default="0">
+		<member name="physical_keycode" type="int" setter="set_physical_keycode" getter="get_physical_keycode" enum="Key" default="0">
 			Key physical keycode, which corresponds to one of the [enum Key] constants. Represent the physical location of a key on the 101/102-key US QWERTY keyboard.
 			To get a human-readable representation of the [InputEventKey], use [code]OS.get_keycode_string(event.keycode)[/code] where [code]event[/code] is the [InputEventKey].
 		</member>

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -249,10 +249,10 @@ void InputEventConfigurationDialog::_listen_window_input(const Ref<InputEvent> &
 		// Maintain physical keycode option state
 		if (physical_key_checkbox->is_pressed()) {
 			k->set_physical_keycode(k->get_keycode());
-			k->set_keycode(0);
+			k->set_keycode(KEY_NONE);
 		} else {
-			k->set_keycode(k->get_physical_keycode());
-			k->set_physical_keycode(0);
+			k->set_keycode((Key)k->get_physical_keycode());
+			k->set_physical_keycode(KEY_NONE);
 		}
 	}
 
@@ -435,10 +435,10 @@ void InputEventConfigurationDialog::_physical_keycode_toggled(bool p_checked) {
 
 	if (p_checked) {
 		k->set_physical_keycode(k->get_keycode());
-		k->set_keycode(0);
+		k->set_keycode(KEY_NONE);
 	} else {
-		k->set_keycode(k->get_physical_keycode());
-		k->set_physical_keycode(0);
+		k->set_keycode((Key)k->get_physical_keycode());
+		k->set_physical_keycode(KEY_NONE);
 	}
 
 	_set_event(k);
@@ -452,20 +452,20 @@ void InputEventConfigurationDialog::_input_list_item_selected() {
 		return;
 	}
 
-	int input_type = selected->get_parent()->get_meta("__type");
+	InputEventConfigurationDialog::InputType input_type = (InputEventConfigurationDialog::InputType)(int)selected->get_parent()->get_meta("__type");
 
 	switch (input_type) {
 		case InputEventConfigurationDialog::INPUT_KEY: {
-			int kc = selected->get_meta("__keycode");
+			Key keycode = (Key)(int)selected->get_meta("__keycode");
 			Ref<InputEventKey> k;
 			k.instantiate();
 
 			if (physical_key_checkbox->is_pressed()) {
-				k->set_physical_keycode(kc);
-				k->set_keycode(0);
+				k->set_physical_keycode(keycode);
+				k->set_keycode(KEY_NONE);
 			} else {
-				k->set_physical_keycode(0);
-				k->set_keycode(kc);
+				k->set_physical_keycode(KEY_NONE);
+				k->set_keycode(keycode);
 			}
 
 			// Maintain modifier state from checkboxes
@@ -479,10 +479,10 @@ void InputEventConfigurationDialog::_input_list_item_selected() {
 			_set_event(k);
 		} break;
 		case InputEventConfigurationDialog::INPUT_MOUSE_BUTTON: {
-			int idx = selected->get_meta("__index");
+			MouseButton idx = (MouseButton)(int)selected->get_meta("__index");
 			Ref<InputEventMouseButton> mb;
 			mb.instantiate();
-			mb->set_button_index((MouseButton)idx);
+			mb->set_button_index(idx);
 			// Maintain modifier state from checkboxes
 			mb->set_alt_pressed(mod_checkboxes[MOD_ALT]->is_pressed());
 			mb->set_shift_pressed(mod_checkboxes[MOD_SHIFT]->is_pressed());
@@ -494,22 +494,20 @@ void InputEventConfigurationDialog::_input_list_item_selected() {
 			_set_event(mb);
 		} break;
 		case InputEventConfigurationDialog::INPUT_JOY_BUTTON: {
-			int idx = selected->get_meta("__index");
-			Ref<InputEventJoypadButton> jb = InputEventJoypadButton::create_reference((JoyButton)idx);
+			JoyButton idx = (JoyButton)(int)selected->get_meta("__index");
+			Ref<InputEventJoypadButton> jb = InputEventJoypadButton::create_reference(idx);
 			_set_event(jb);
 		} break;
 		case InputEventConfigurationDialog::INPUT_JOY_MOTION: {
-			int axis = selected->get_meta("__axis");
+			JoyAxis axis = (JoyAxis)(int)selected->get_meta("__axis");
 			int value = selected->get_meta("__value");
 
 			Ref<InputEventJoypadMotion> jm;
 			jm.instantiate();
-			jm->set_axis((JoyAxis)axis);
+			jm->set_axis(axis);
 			jm->set_axis_value(value);
 			_set_event(jm);
 		} break;
-		default:
-			break;
 	}
 }
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5759,6 +5759,8 @@ void AnimationTrackEditor::_pick_track_filter_input(const Ref<InputEvent> &p_ie)
 				pick_track->get_scene_tree()->get_scene_tree()->call("_gui_input", k);
 				pick_track->get_filter_line_edit()->accept_event();
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -359,6 +359,8 @@ void CreateDialog::_sbox_input(const Ref<InputEvent> &p_ie) {
 				search_options->call("_gui_input", k);
 				search_box->accept_event();
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -153,6 +153,8 @@ void EditorCommandPalette::_sbox_input(const Ref<InputEvent> &p_ie) {
 			case KEY_PAGEDOWN: {
 				search_options->call("_gui_input", k);
 			} break;
+			default:
+				break;
 		}
 	}
 }
@@ -289,7 +291,7 @@ EditorCommandPalette::EditorCommandPalette() {
 	set_hide_on_ok(false);
 }
 
-Ref<Shortcut> ED_SHORTCUT_AND_COMMAND(const String &p_path, const String &p_name, uint32_t p_keycode, String p_command_name) {
+Ref<Shortcut> ED_SHORTCUT_AND_COMMAND(const String &p_path, const String &p_name, Key p_keycode, String p_command_name) {
 	if (p_command_name.is_empty()) {
 		p_command_name = p_name;
 	}

--- a/editor/editor_command_palette.h
+++ b/editor/editor_command_palette.h
@@ -90,6 +90,6 @@ public:
 	static EditorCommandPalette *get_singleton();
 };
 
-Ref<Shortcut> ED_SHORTCUT_AND_COMMAND(const String &p_path, const String &p_name, uint32_t p_keycode = 0, String p_command = "");
+Ref<Shortcut> ED_SHORTCUT_AND_COMMAND(const String &p_path, const String &p_name, Key p_keycode = KEY_NONE, String p_command = "");
 
 #endif //EDITOR_COMMAND_PALETTE_H

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -74,6 +74,8 @@ void EditorHelpSearch::_search_box_gui_input(const Ref<InputEvent> &p_event) {
 				results_tree->call("_gui_input", key);
 				search_box->accept_event();
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -58,6 +58,8 @@ void EditorLayoutsDialog::_line_gui_input(const Ref<InputEvent> &p_event) {
 				hide();
 				set_input_as_handled();
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6301,7 +6301,7 @@ EditorNode::EditorNode() {
 
 	p = project_menu->get_popup();
 
-	p->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/project_settings", TTR("Project Settings..."), 0, TTR("Project Settings")), RUN_SETTINGS);
+	p->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/project_settings", TTR("Project Settings..."), KEY_NONE, TTR("Project Settings")), RUN_SETTINGS);
 	p->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 
 	vcs_actions_menu = VersionControlEditorPlugin::get_singleton()->get_version_control_actions_panel();
@@ -6314,7 +6314,7 @@ EditorNode::EditorNode() {
 	vcs_actions_menu->add_item(TTR("Shut Down Version Control"), RUN_VCS_SHUT_DOWN);
 
 	p->add_separator();
-	p->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/export", TTR("Export..."), 0, TTR("Export")), FILE_EXPORT_PROJECT);
+	p->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/export", TTR("Export..."), KEY_NONE, TTR("Export")), FILE_EXPORT_PROJECT);
 	p->add_item(TTR("Install Android Build Template..."), FILE_INSTALL_ANDROID_SOURCE);
 	p->add_item(TTR("Open Project Data Folder"), RUN_PROJECT_DATA_FOLDER);
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1519,7 +1519,7 @@ Ref<Shortcut> ED_GET_SHORTCUT(const String &p_path) {
 	return sc;
 }
 
-Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p_keycode) {
+Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, Key p_keycode) {
 #ifdef OSX_ENABLED
 	// Use Cmd+Backspace as a general replacement for Delete shortcuts on macOS
 	if (p_keycode == KEY_DELETE) {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -200,7 +200,7 @@ Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_re
 Variant _EDITOR_GET(const String &p_setting);
 
 #define ED_IS_SHORTCUT(p_name, p_ev) (EditorSettings::get_singleton()->is_shortcut(p_name, p_ev))
-Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p_keycode = 0);
+Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, Key p_keycode = KEY_NONE);
 Ref<Shortcut> ED_GET_SHORTCUT(const String &p_path);
 
 #endif // EDITOR_SETTINGS_H

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1246,6 +1246,8 @@ void AnimationPlayerEditor::_unhandled_key_input(const Ref<InputEvent> &p_ev) {
 				}
 				accept_event();
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2457,7 +2457,7 @@ static bool is_shortcut_pressed(const String &p_path) {
 		return false;
 	}
 	const Input &input = *Input::get_singleton();
-	int keycode = k->get_keycode();
+	Key keycode = k->get_keycode();
 	return input.is_key_pressed(keycode);
 }
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1925,12 +1925,12 @@ void ScriptTextEditor::register_editor() {
 	// Leave these at zero, same can be accomplished with tab/shift-tab, including selection.
 	// The next/previous in history shortcut in this case makes a lot more sense.
 
-	ED_SHORTCUT("script_text_editor/indent_left", TTR("Indent Left"), 0);
-	ED_SHORTCUT("script_text_editor/indent_right", TTR("Indent Right"), 0);
+	ED_SHORTCUT("script_text_editor/indent_left", TTR("Indent Left"), KEY_NONE);
+	ED_SHORTCUT("script_text_editor/indent_right", TTR("Indent Right"), KEY_NONE);
 	ED_SHORTCUT("script_text_editor/toggle_comment", TTR("Toggle Comment"), KEY_MASK_CMD | KEY_K);
 	ED_SHORTCUT("script_text_editor/toggle_fold_line", TTR("Fold/Unfold Line"), KEY_MASK_ALT | KEY_F);
-	ED_SHORTCUT("script_text_editor/fold_all_lines", TTR("Fold All Lines"), 0);
-	ED_SHORTCUT("script_text_editor/unfold_all_lines", TTR("Unfold All Lines"), 0);
+	ED_SHORTCUT("script_text_editor/fold_all_lines", TTR("Fold All Lines"), KEY_NONE);
+	ED_SHORTCUT("script_text_editor/unfold_all_lines", TTR("Unfold All Lines"), KEY_NONE);
 #ifdef OSX_ENABLED
 	ED_SHORTCUT("script_text_editor/duplicate_selection", TTR("Duplicate Selection"), KEY_MASK_SHIFT | KEY_MASK_CMD | KEY_C);
 #else
@@ -1965,7 +1965,7 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT("script_text_editor/toggle_bookmark", TTR("Toggle Bookmark"), KEY_MASK_CMD | KEY_MASK_ALT | KEY_B);
 	ED_SHORTCUT("script_text_editor/goto_next_bookmark", TTR("Go to Next Bookmark"), KEY_MASK_CMD | KEY_B);
 	ED_SHORTCUT("script_text_editor/goto_previous_bookmark", TTR("Go to Previous Bookmark"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_B);
-	ED_SHORTCUT("script_text_editor/remove_all_bookmarks", TTR("Remove All Bookmarks"), 0);
+	ED_SHORTCUT("script_text_editor/remove_all_bookmarks", TTR("Remove All Bookmarks"), KEY_NONE);
 
 #ifdef OSX_ENABLED
 	ED_SHORTCUT("script_text_editor/goto_function", TTR("Go to Function..."), KEY_MASK_CTRL | KEY_MASK_CMD | KEY_J);

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -330,7 +330,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					for (const Rect2 &E : autoslice_cache) {
 						if (E.has_point(point)) {
 							rect = E;
-							if (Input::get_singleton()->is_key_pressed(KEY_CTRL) && !(Input::get_singleton()->is_key_pressed(KEY_SHIFT | KEY_ALT))) {
+							if (Input::get_singleton()->is_key_pressed(KEY_CTRL) && !(Input::get_singleton()->is_key_pressed(Key(KEY_SHIFT | KEY_ALT)))) {
 								Rect2 r;
 								if (node_sprite) {
 									r = node_sprite->get_region_rect();

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1721,6 +1721,8 @@ void ThemeItemEditorDialog::_edit_theme_item_gui_input(const Ref<InputEvent> &p_
 				edit_theme_item_dialog->hide();
 				edit_theme_item_dialog->set_input_as_handled();
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -67,6 +67,8 @@ void PropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 				current->select(0);
 
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -190,6 +190,8 @@ void EditorQuickOpen::_sbox_input(const Ref<InputEvent> &p_ie) {
 					current->set_as_cursor(0);
 				}
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -74,6 +74,8 @@ void VisualScriptPropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 				current->select(0);
 
 			} break;
+			default:
+				break;
 		}
 	}
 }

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -538,8 +538,8 @@ void DisplayServerAndroid::process_key_event(int p_keycode, int p_scancode, int 
 		meta_mem = p_pressed;
 	}
 
-	ev->set_keycode(keycode);
-	ev->set_physical_keycode(phy_keycode);
+	ev->set_keycode((Key)keycode);
+	ev->set_physical_keycode((Key)phy_keycode);
 	ev->set_unicode(val);
 	ev->set_pressed(p_pressed);
 

--- a/platform/iphone/display_server_iphone.h
+++ b/platform/iphone/display_server_iphone.h
@@ -105,7 +105,7 @@ public:
 
 	// MARK: Keyboard
 
-	void key(uint32_t p_key, bool p_pressed);
+	void key(Key p_key, bool p_pressed);
 
 	// MARK: Motion
 

--- a/platform/iphone/display_server_iphone.mm
+++ b/platform/iphone/display_server_iphone.mm
@@ -254,7 +254,7 @@ void DisplayServerIPhone::touches_cancelled(int p_idx) {
 
 // MARK: Keyboard
 
-void DisplayServerIPhone::key(uint32_t p_key, bool p_pressed) {
+void DisplayServerIPhone::key(Key p_key, bool p_pressed) {
 	Ref<InputEventKey> ev;
 	ev.instantiate();
 	ev->set_echo(false);

--- a/platform/iphone/keyboard_input_view.mm
+++ b/platform/iphone/keyboard_input_view.mm
@@ -138,8 +138,8 @@
 				break;
 		}
 
-		DisplayServerIPhone::get_singleton()->key(character, true);
-		DisplayServerIPhone::get_singleton()->key(character, false);
+		DisplayServerIPhone::get_singleton()->key((Key)character, true);
+		DisplayServerIPhone::get_singleton()->key((Key)character, false);
 	}
 }
 

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -172,7 +172,7 @@ EM_BOOL DisplayServerJavaScript::keyup_callback(int p_event_type, const Emscript
 	Ref<InputEventKey> ev = setup_key_event(p_event);
 	ev->set_pressed(false);
 	Input::get_singleton()->parse_input_event(ev);
-	return ev->get_keycode() != KEY_UNKNOWN && ev->get_keycode() != 0;
+	return ev->get_keycode() != KEY_UNKNOWN && ev->get_keycode() != (Key)0;
 }
 
 // Mouse

--- a/platform/javascript/dom_keys.inc
+++ b/platform/javascript/dom_keys.inc
@@ -31,7 +31,7 @@
 #include "core/os/keyboard.h"
 
 // See https://w3c.github.io/uievents-code/#code-value-tables
-int dom_code2godot_scancode(EM_UTF8 const p_code[32], EM_UTF8 const p_key[32], bool p_physical) {
+Key dom_code2godot_scancode(EM_UTF8 const p_code[32], EM_UTF8 const p_key[32], bool p_physical) {
 #define DOM2GODOT(p_str, p_godot_code)                                         \
 	if (memcmp((const void *)p_str, (void *)p_code, strlen(p_str) + 1) == 0) { \
 		return KEY_##p_godot_code;                                             \
@@ -79,7 +79,7 @@ int dom_code2godot_scancode(EM_UTF8 const p_code[32], EM_UTF8 const p_key[32], b
 			if (b0 > 0x60 && b0 < 0x7B) { // Lowercase ASCII.
 				b0 -= 32;
 			}
-			return b0;
+			return (Key)b0;
 		}
 
 #define _U_2BYTES_MASK 0xE0
@@ -88,11 +88,11 @@ int dom_code2godot_scancode(EM_UTF8 const p_code[32], EM_UTF8 const p_key[32], b
 		if (b2 == 0 && (b0 & _U_2BYTES_MASK) == _U_2BYTES) { // 2-bytes utf8, only known latin.
 			uint32_t key = ((b0 & ~_U_2BYTES_MASK) << 6) | (b1 & 0x3F);
 			if (key >= 0xA0 && key <= 0xDF) {
-				return key;
+				return (Key)key;
 			}
 			if (key >= 0xE0 && key <= 0xFF) { // Lowercase known latin.
 				key -= 0x20;
-				return key;
+				return (Key)key;
 			}
 		}
 #undef _U_2BYTES_MASK

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -2207,7 +2207,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 
 		if (status == XLookupChars) {
 			bool keypress = xkeyevent->type == KeyPress;
-			unsigned int keycode = KeyMappingX11::get_keycode(keysym_keycode);
+			Key keycode = KeyMappingX11::get_keycode(keysym_keycode);
 			unsigned int physical_keycode = KeyMappingX11::get_scancode(xkeyevent->keycode);
 
 			if (keycode >= 'a' && keycode <= 'z') {
@@ -2224,7 +2224,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 				}
 
 				if (keycode == 0) {
-					keycode = physical_keycode;
+					keycode = (Key)physical_keycode;
 				}
 
 				_get_key_modifier_state(xkeyevent->state, k);
@@ -2236,7 +2236,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 
 				k->set_keycode(keycode);
 
-				k->set_physical_keycode(physical_keycode);
+				k->set_physical_keycode((Key)physical_keycode);
 
 				k->set_echo(false);
 
@@ -2271,7 +2271,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 	// KeyMappingX11 just translated the X11 keysym to a PIGUI
 	// keysym, so it works in all platforms the same.
 
-	unsigned int keycode = KeyMappingX11::get_keycode(keysym_keycode);
+	Key keycode = KeyMappingX11::get_keycode(keysym_keycode);
 	unsigned int physical_keycode = KeyMappingX11::get_scancode(xkeyevent->keycode);
 
 	/* Phase 3, obtain a unicode character from the keysym */
@@ -2292,12 +2292,12 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 
 	bool keypress = xkeyevent->type == KeyPress;
 
-	if (physical_keycode == 0 && keycode == 0 && unicode == 0) {
+	if (physical_keycode == 0 && keycode == KEY_NONE && unicode == 0) {
 		return;
 	}
 
-	if (keycode == 0) {
-		keycode = physical_keycode;
+	if (keycode == KEY_NONE) {
+		keycode = (Key)physical_keycode;
 	}
 
 	/* Phase 5, determine modifier mask */
@@ -2360,11 +2360,11 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 	k->set_pressed(keypress);
 
 	if (keycode >= 'a' && keycode <= 'z') {
-		keycode -= 'a' - 'A';
+		keycode -= int('a' - 'A');
 	}
 
 	k->set_keycode(keycode);
-	k->set_physical_keycode(physical_keycode);
+	k->set_physical_keycode((Key)physical_keycode);
 	k->set_unicode(unicode);
 	k->set_echo(p_echo);
 

--- a/platform/linuxbsd/key_mapping_x11.cpp
+++ b/platform/linuxbsd/key_mapping_x11.cpp
@@ -34,7 +34,7 @@
 
 struct _XTranslatePair {
 	KeySym keysym;
-	unsigned int keycode;
+	Key keycode;
 };
 
 static _XTranslatePair _xkeysym_to_keycode[] = {
@@ -176,7 +176,7 @@ static _XTranslatePair _xkeysym_to_keycode[] = {
 	{ XF86XK_LaunchC, KEY_LAUNCHE },
 	{ XF86XK_LaunchD, KEY_LAUNCHF },
 
-	{ 0, 0 }
+	{ 0, KEY_NONE }
 };
 
 struct _TranslatePair {
@@ -309,11 +309,11 @@ unsigned int KeyMappingX11::get_scancode(unsigned int p_code) {
 	return keycode;
 }
 
-unsigned int KeyMappingX11::get_keycode(KeySym p_keysym) {
+Key KeyMappingX11::get_keycode(KeySym p_keysym) {
 	// kinda bruteforce.. could optimize.
 
 	if (p_keysym < 0x100) { // Latin 1, maps 1-1
-		return p_keysym;
+		return (Key)p_keysym;
 	}
 
 	// look for special key
@@ -323,14 +323,14 @@ unsigned int KeyMappingX11::get_keycode(KeySym p_keysym) {
 		}
 	}
 
-	return 0;
+	return KEY_NONE;
 }
 
-KeySym KeyMappingX11::get_keysym(unsigned int p_code) {
+KeySym KeyMappingX11::get_keysym(Key p_code) {
 	// kinda bruteforce.. could optimize.
 
 	if (p_code < 0x100) { // Latin 1, maps 1-1
-		return p_code;
+		return (KeySym)p_code;
 	}
 
 	// look for special key
@@ -340,7 +340,7 @@ KeySym KeyMappingX11::get_keysym(unsigned int p_code) {
 		}
 	}
 
-	return 0;
+	return (KeySym)KEY_NONE;
 }
 
 /***** UNICODE CONVERSION ******/

--- a/platform/linuxbsd/key_mapping_x11.h
+++ b/platform/linuxbsd/key_mapping_x11.h
@@ -44,9 +44,9 @@ class KeyMappingX11 {
 	KeyMappingX11() {}
 
 public:
-	static unsigned int get_keycode(KeySym p_keysym);
+	static Key get_keycode(KeySym p_keysym);
 	static unsigned int get_scancode(unsigned int p_code);
-	static KeySym get_keysym(unsigned int p_code);
+	static KeySym get_keysym(Key p_code);
 	static unsigned int get_unicode_from_keysym(KeySym p_keysym);
 	static KeySym get_keysym_from_unicode(unsigned int p_unicode);
 };

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -85,7 +85,7 @@ public:
 		bool pressed = false;
 		bool echo = false;
 		bool raw = false;
-		uint32_t keycode = 0;
+		Key keycode = KEY_NONE;
 		uint32_t physical_keycode = 0;
 		uint32_t unicode = 0;
 	};

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -585,7 +585,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 		ke.pressed = true;
 		ke.echo = false;
 		ke.raw = false; // IME input event
-		ke.keycode = 0;
+		ke.keycode = KEY_NONE;
 		ke.physical_keycode = 0;
 		ke.unicode = codepoint;
 
@@ -928,9 +928,9 @@ static bool isNumpadKey(unsigned int key) {
 
 // Translates a OS X keycode to a Godot keycode
 //
-static int translateKey(unsigned int key) {
+static Key translateKey(unsigned int key) {
 	// Keyboard symbol translation table
-	static const unsigned int table[128] = {
+	static const Key table[128] = {
 		/* 00 */ KEY_A,
 		/* 01 */ KEY_S,
 		/* 02 */ KEY_D,
@@ -1070,7 +1070,7 @@ static int translateKey(unsigned int key) {
 
 struct _KeyCodeMap {
 	UniChar kchar;
-	int kcode;
+	Key kcode;
 };
 
 static const _KeyCodeMap _keycodes[55] = {
@@ -1131,7 +1131,7 @@ static const _KeyCodeMap _keycodes[55] = {
 	{ '/', KEY_SLASH }
 };
 
-static int remapKey(unsigned int key, unsigned int state) {
+static Key remapKey(unsigned int key, unsigned int state) {
 	if (isNumpadKey(key)) {
 		return translateKey(key);
 	}
@@ -3271,7 +3271,7 @@ void DisplayServerOSX::_process_key_events() {
 			k->set_pressed(ke.pressed);
 			k->set_echo(ke.echo);
 			k->set_keycode(ke.keycode);
-			k->set_physical_keycode(ke.physical_keycode);
+			k->set_physical_keycode((Key)ke.physical_keycode);
 			k->set_unicode(ke.unicode);
 
 			_push_input(k);
@@ -3284,8 +3284,8 @@ void DisplayServerOSX::_process_key_events() {
 				_get_key_modifier_state(ke.osx_state, k);
 				k->set_pressed(ke.pressed);
 				k->set_echo(ke.echo);
-				k->set_keycode(0);
-				k->set_physical_keycode(0);
+				k->set_keycode(KEY_NONE);
+				k->set_physical_keycode(KEY_NONE);
 				k->set_unicode(ke.unicode);
 
 				_push_input(k);
@@ -3298,7 +3298,7 @@ void DisplayServerOSX::_process_key_events() {
 				k->set_pressed(ke.pressed);
 				k->set_echo(ke.echo);
 				k->set_keycode(ke.keycode);
-				k->set_physical_keycode(ke.physical_keycode);
+				k->set_physical_keycode((Key)ke.physical_keycode);
 
 				if (i + 1 < key_event_pos && key_event_buffer[i + 1].keycode == 0) {
 					k->set_unicode(key_event_buffer[i + 1].unicode);

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -566,7 +566,7 @@ void OS_UWP::process_key_events() {
 		key_event->set_ctrl_pressed(kev.control);
 		key_event->set_echo(kev.echo);
 		key_event->set_keycode(kev.keycode);
-		key_event->set_physical_keycode(kev.physical_keycode);
+		key_event->set_physical_keycode((Key)kev.physical_keycode);
 		key_event->set_unicode(kev.unicode);
 		key_event->set_pressed(kev.pressed);
 

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -58,7 +58,7 @@ public:
 		bool alt = false, shift = false, control = false;
 		MessageType type = KEY_EVENT_MESSAGE;
 		bool pressed = false;
-		unsigned int keycode = 0;
+		Key keycode = KEY_NONE;
 		unsigned int physical_keycode = 0;
 		unsigned int unicode = 0;
 		bool echo = false;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2855,8 +2855,8 @@ void DisplayServerWindows::_process_key_events() {
 					k->set_ctrl_pressed(ke.control);
 					k->set_meta_pressed(ke.meta);
 					k->set_pressed(true);
-					k->set_keycode(KeyMappingWindows::get_keysym(ke.wParam));
-					k->set_physical_keycode(KeyMappingWindows::get_scansym((ke.lParam >> 16) & 0xFF, ke.lParam & (1 << 24)));
+					k->set_keycode((Key)KeyMappingWindows::get_keysym(ke.wParam));
+					k->set_physical_keycode((Key)(KeyMappingWindows::get_scansym((ke.lParam >> 16) & 0xFF, ke.lParam & (1 << 24))));
 					k->set_unicode(unicode);
 					if (k->get_unicode() && gr_mem) {
 						k->set_alt_pressed(false);
@@ -2888,10 +2888,10 @@ void DisplayServerWindows::_process_key_events() {
 					// Special case for Numpad Enter key
 					k->set_keycode(KEY_KP_ENTER);
 				} else {
-					k->set_keycode(KeyMappingWindows::get_keysym(ke.wParam));
+					k->set_keycode((Key)KeyMappingWindows::get_keysym(ke.wParam));
 				}
 
-				k->set_physical_keycode(KeyMappingWindows::get_scansym((ke.lParam >> 16) & 0xFF, ke.lParam & (1 << 24)));
+				k->set_physical_keycode((Key)(KeyMappingWindows::get_scansym((ke.lParam >> 16) & 0xFF, ke.lParam & (1 << 24))));
 
 				if (i + 1 < key_event_pos && key_event_buffer[i + 1].uMsg == WM_CHAR) {
 					char32_t unicode = key_event_buffer[i + 1].wParam;

--- a/platform/windows/key_mapping_windows.cpp
+++ b/platform/windows/key_mapping_windows.cpp
@@ -365,6 +365,8 @@ unsigned int KeyMappingWindows::get_scansym(unsigned int p_code, bool p_extended
 			case KEY_CAPSLOCK: {
 				keycode = KEY_KP_ADD;
 			} break;
+			default:
+				break;
 		}
 	} else {
 		switch (keycode) {
@@ -404,6 +406,8 @@ unsigned int KeyMappingWindows::get_scansym(unsigned int p_code, bool p_extended
 			case KEY_PRINT: {
 				keycode = KEY_KP_MULTIPLY;
 			} break;
+			default:
+				break;
 		}
 	}
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1274,13 +1274,13 @@ int PopupMenu::get_item_count() const {
 }
 
 bool PopupMenu::activate_item_by_event(const Ref<InputEvent> &p_event, bool p_for_global_only) {
-	uint32_t code = 0;
+	Key code = KEY_NONE;
 	Ref<InputEventKey> k = p_event;
 
 	if (k.is_valid()) {
 		code = k->get_keycode();
-		if (code == 0) {
-			code = k->get_unicode();
+		if (code == KEY_NONE) {
+			code = (Key)k->get_unicode();
 		}
 		if (k->is_ctrl_pressed()) {
 			code |= KEY_MASK_CTRL;


### PR DESCRIPTION
This PR is a follow-up to #38054 and #49281 and is a revival/salvage of #27450. Making these methods semantically use the enums is good for readability, it makes things more explicit, and it is much more friendly to languages with strongly typed enums such as C#.

Noteworthy things:

* For the most part, this is the kind of change where if it compiles, it works. Extensive testing was not done on all platforms (many of which I am not able to test), but would be appreciated.

* Web and UWP aren't compiled by CI right now because they're unavailable. I did my best to look over the code, but they may require slight tweaking when re-enabled later (worst case scenario, just add a few casts).

* It seems that the members of `key_mapping_windows.cpp`'s `_WinTranslatePair` are backwards, as are the members of `key_mapping_x11.cpp`'s `_TranslatePair`, but not X11's `_XTranslatePair`, and `android_keys_utils.h`'s `_WinTranslatePair` is also backwards. I would assume that `keycode` would be populated with members from the `Key` enum, and `keysym` would be populated with members from `KeySym`, but for `_TranslatePair` and `_WinTranslatePair`, the `keysym` variable is what contains members from the `Key` enum, instead of `keycode`. For this PR, I played it safe and didn't touch these, so the members are still `unsigned int` and in the same order etc.