### PR TITLE
[HTML5] Make debug server more maintainable, better icon export.

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset='utf-8' />
 	<meta name='viewport' content='width=device-width, user-scalable=no' />
-	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
 	<title>$GODOT_PROJECT_NAME</title>
 	<style type='text/css'>
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#include "core/io/image_loader.h"
 #include "core/io/json.h"
 #include "core/io/tcp_server.h"
 #include "core/io/zip_io.h"
@@ -282,11 +283,16 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 	config["fileSizes"] = p_file_sizes;
 	const String str_config = JSON::print(config);
 
+	String head_include;
+	if (p_preset->get("html/export_icon")) {
+		head_include += "<link id='-gd-engine-icon' rel='icon' type='image/png' href='" + p_name + ".icon.png' />\n";
+	}
+	head_include += static_cast<String>(p_preset->get("html/head_include"));
 	for (int i = 0; i < lines.size(); i++) {
 		String current_line = lines[i];
 		current_line = current_line.replace("$GODOT_URL", p_name + ".js");
 		current_line = current_line.replace("$GODOT_PROJECT_NAME", ProjectSettings::get_singleton()->get_setting("application/config/name"));
-		current_line = current_line.replace("$GODOT_HEAD_INCLUDE", p_preset->get("html/head_include"));
+		current_line = current_line.replace("$GODOT_HEAD_INCLUDE", head_include);
 		current_line = current_line.replace("$GODOT_CONFIG", str_config);
 		str_export += current_line + "\n";
 	}
@@ -328,6 +334,7 @@ void EditorExportPlatformJavaScript::get_export_options(List<ExportOption> *r_op
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_desktop"), true)); // S3TC
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_mobile"), false)); // ETC or ETC2, depending on renderer
 
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/export_icon"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/custom_html_shell", PROPERTY_HINT_FILE, "*.html"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/head_include", PROPERTY_HINT_MULTILINE_TEXT), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "html/canvas_resize_policy", PROPERTY_HINT_ENUM, "None,Project,Adaptive"), 2));
@@ -400,6 +407,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 	String custom_debug = p_preset->get("custom_template/debug");
 	String custom_release = p_preset->get("custom_template/release");
 	String custom_html = p_preset->get("html/custom_html_shell");
+	bool export_icon = p_preset->get("html/export_icon");
 
 	String template_path = p_debug ? custom_debug : custom_release;
 
@@ -545,7 +553,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 	const String splash_path = String(GLOBAL_GET("application/boot_splash/image")).strip_edges();
 	if (!splash_path.is_empty()) {
 		splash.instance();
-		const Error err = splash->load(splash_path);
+		const Error err = ImageLoader::load_image(splash_path, splash);
 		if (err) {
 			EditorNode::get_singleton()->show_warning(TTR("Could not read boot splash image file:") + "\n" + splash_path + "\n" + TTR("Using default boot splash image."));
 			splash.unref();
@@ -562,18 +570,21 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 
 	// Save a favicon that can be accessed without waiting for the project to finish loading.
 	// This way, the favicon can be displayed immediately when loading the page.
-	Ref<Image> favicon;
-	const String favicon_path = String(GLOBAL_GET("application/config/icon")).strip_edges();
-	if (!favicon_path.is_empty()) {
-		favicon.instance();
-		const Error err = favicon->load(favicon_path);
-		if (err) {
-			favicon.unref();
+	if (export_icon) {
+		Ref<Image> favicon;
+		const String favicon_path = String(GLOBAL_GET("application/config/icon")).strip_edges();
+		if (!favicon_path.is_empty()) {
+			favicon.instance();
+			const Error err = ImageLoader::load_image(favicon_path, favicon);
+			if (err) {
+				favicon.unref();
+			}
 		}
-	}
 
-	if (favicon.is_valid()) {
-		const String favicon_png_path = p_path.get_base_dir().plus_file("favicon.png");
+		if (favicon.is_null()) {
+			favicon = EditorNode::get_singleton()->get_editor_theme()->get_icon("DefaultProjectIcon", "EditorIcons")->get_image();
+		}
+		const String favicon_png_path = p_path.get_base_dir().plus_file(p_path.get_file().get_basename() + ".icon.png");
 		if (favicon->save_png(favicon_png_path) != OK) {
 			EditorNode::get_singleton()->show_warning(TTR("Could not write file:") + "\n" + favicon_png_path);
 			return ERR_FILE_CANT_WRITE;
@@ -643,7 +654,7 @@ Error EditorExportPlatformJavaScript::run(const Ref<EditorExportPreset> &p_prese
 		DirAccess::remove_file_or_error(basepath + ".png");
 		DirAccess::remove_file_or_error(basepath + ".side.wasm");
 		DirAccess::remove_file_or_error(basepath + ".wasm");
-		DirAccess::remove_file_or_error(dest.plus_file("favicon.png"));
+		DirAccess::remove_file_or_error(basepath + ".icon.png");
 		return err;
 	}
 


### PR DESCRIPTION
In this PR:

- Debug HttpServer now runs in `web` cache subdir.
  Serving all files in that folder and using a known list of mime types. Makes it easy to add more exported files, while still playing safe.

- Optional icon generation, use export name for it.
  We used to only generate the favicon if it was specified in the user project settings, now it's optional, will export it to `NAME.icon.png`, (falling back to the default project icon if none is set in project settings), and the `<link>` tag is added using the `$HEAD_INCLUDE` instead of being hardcoded in the template.

There is a `3.x` version here: https://github.com/Faless/godot/tree/js/3.x_http_server_refactor
Likely `3.4` material, since I don't want to break anything in the long awaited `3.3` :) .