### PR TITLE
Make platform feature tag names lowercase

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -317,36 +317,36 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
     { "ui_text_dedent",                                TTRC("Dedent") },
     { "ui_text_backspace",                             TTRC("Backspace") },
     { "ui_text_backspace_word",                        TTRC("Backspace Word") },
-    { "ui_text_backspace_word.OSX",                    TTRC("Backspace Word") },
+    { "ui_text_backspace_word.osx",                    TTRC("Backspace Word") },
     { "ui_text_backspace_all_to_left",                 TTRC("Backspace all to Left") },
-    { "ui_text_backspace_all_to_left.OSX",             TTRC("Backspace all to Left") },
+    { "ui_text_backspace_all_to_left.osx",             TTRC("Backspace all to Left") },
     { "ui_text_delete",                                TTRC("Delete") },
     { "ui_text_delete_word",                           TTRC("Delete Word") },
-    { "ui_text_delete_word.OSX",                       TTRC("Delete Word") },
+    { "ui_text_delete_word.osx",                       TTRC("Delete Word") },
     { "ui_text_delete_all_to_right",                   TTRC("Delete all to Right") },
-    { "ui_text_delete_all_to_right.OSX",               TTRC("Delete all to Right") },
+    { "ui_text_delete_all_to_right.osx",               TTRC("Delete all to Right") },
     { "ui_text_caret_left",                            TTRC("Caret Left") },
     { "ui_text_caret_word_left",                       TTRC("Caret Word Left") },
-    { "ui_text_caret_word_left.OSX",                   TTRC("Caret Word Left") },
+    { "ui_text_caret_word_left.osx",                   TTRC("Caret Word Left") },
     { "ui_text_caret_right",                           TTRC("Caret Right") },
     { "ui_text_caret_word_right",                      TTRC("Caret Word Right") },
-    { "ui_text_caret_word_right.OSX",                  TTRC("Caret Word Right") },
+    { "ui_text_caret_word_right.osx",                  TTRC("Caret Word Right") },
     { "ui_text_caret_up",                              TTRC("Caret Up") },
     { "ui_text_caret_down",                            TTRC("Caret Down") },
     { "ui_text_caret_line_start",                      TTRC("Caret Line Start") },
-    { "ui_text_caret_line_start.OSX",                  TTRC("Caret Line Start") },
+    { "ui_text_caret_line_start.osx",                  TTRC("Caret Line Start") },
     { "ui_text_caret_line_end",                        TTRC("Caret Line End") },
-    { "ui_text_caret_line_end.OSX",                    TTRC("Caret Line End") },
+    { "ui_text_caret_line_end.osx",                    TTRC("Caret Line End") },
     { "ui_text_caret_page_up",                         TTRC("Caret Page Up") },
     { "ui_text_caret_page_down",                       TTRC("Caret Page Down") },
     { "ui_text_caret_document_start",                  TTRC("Caret Document Start") },
-    { "ui_text_caret_document_start.OSX",              TTRC("Caret Document Start") },
+    { "ui_text_caret_document_start.osx",              TTRC("Caret Document Start") },
     { "ui_text_caret_document_end",                    TTRC("Caret Document End") },
-    { "ui_text_caret_document_end.OSX",                TTRC("Caret Document End") },
+    { "ui_text_caret_document_end.osx",                TTRC("Caret Document End") },
     { "ui_text_scroll_up",                             TTRC("Scroll Up") },
-    { "ui_text_scroll_up.OSX",                         TTRC("Scroll Up") },
+    { "ui_text_scroll_up.osx",                         TTRC("Scroll Up") },
     { "ui_text_scroll_down",                           TTRC("Scroll Down") },
-    { "ui_text_scroll_down.OSX",                       TTRC("Scroll Down") },
+    { "ui_text_scroll_down.osx",                       TTRC("Scroll Down") },
     { "ui_text_select_all",                            TTRC("Select All") },
     { "ui_text_select_word_under_caret",               TTRC("Select Word Under Caret") },
     { "ui_text_toggle_insert_mode",                    TTRC("Toggle Insert Mode") },
@@ -516,14 +516,14 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_BACKSPACE | KEY_MASK_ALT));
-	default_builtin_cache.insert("ui_text_backspace_word.OSX", inputs);
+	default_builtin_cache.insert("ui_text_backspace_word.osx", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	default_builtin_cache.insert("ui_text_backspace_all_to_left", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_BACKSPACE | KEY_MASK_CMD));
-	default_builtin_cache.insert("ui_text_backspace_all_to_left.OSX", inputs);
+	default_builtin_cache.insert("ui_text_backspace_all_to_left.osx", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_DELETE));
@@ -535,14 +535,14 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_DELETE | KEY_MASK_ALT));
-	default_builtin_cache.insert("ui_text_delete_word.OSX", inputs);
+	default_builtin_cache.insert("ui_text_delete_word.osx", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	default_builtin_cache.insert("ui_text_delete_all_to_right", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_DELETE | KEY_MASK_CMD));
-	default_builtin_cache.insert("ui_text_delete_all_to_right.OSX", inputs);
+	default_builtin_cache.insert("ui_text_delete_all_to_right.osx", inputs);
 
 	// Text Caret Movement Left/Right
 
@@ -556,7 +556,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_LEFT | KEY_MASK_ALT));
-	default_builtin_cache.insert("ui_text_caret_word_left.OSX", inputs);
+	default_builtin_cache.insert("ui_text_caret_word_left.osx", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_RIGHT));
@@ -568,7 +568,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_RIGHT | KEY_MASK_ALT));
-	default_builtin_cache.insert("ui_text_caret_word_right.OSX", inputs);
+	default_builtin_cache.insert("ui_text_caret_word_right.osx", inputs);
 
 	// Text Caret Movement Up/Down
 
@@ -589,7 +589,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_A | KEY_MASK_CTRL));
 	inputs.push_back(InputEventKey::create_reference(KEY_LEFT | KEY_MASK_CMD));
-	default_builtin_cache.insert("ui_text_caret_line_start.OSX", inputs);
+	default_builtin_cache.insert("ui_text_caret_line_start.osx", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_END));
@@ -598,7 +598,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_E | KEY_MASK_CTRL));
 	inputs.push_back(InputEventKey::create_reference(KEY_RIGHT | KEY_MASK_CMD));
-	default_builtin_cache.insert("ui_text_caret_line_end.OSX", inputs);
+	default_builtin_cache.insert("ui_text_caret_line_end.osx", inputs);
 
 	// Text Caret Movement Page Up/Down
 
@@ -618,7 +618,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_UP | KEY_MASK_CMD));
-	default_builtin_cache.insert("ui_text_caret_document_start.OSX", inputs);
+	default_builtin_cache.insert("ui_text_caret_document_start.osx", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_END | KEY_MASK_CMD));
@@ -626,7 +626,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_DOWN | KEY_MASK_CMD));
-	default_builtin_cache.insert("ui_text_caret_document_end.OSX", inputs);
+	default_builtin_cache.insert("ui_text_caret_document_end.osx", inputs);
 
 	// Text Scrolling
 
@@ -636,7 +636,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_UP | KEY_MASK_CMD | KEY_MASK_ALT));
-	default_builtin_cache.insert("ui_text_scroll_up.OSX", inputs);
+	default_builtin_cache.insert("ui_text_scroll_up.osx", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_DOWN | KEY_MASK_CMD));
@@ -644,7 +644,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_DOWN | KEY_MASK_CMD | KEY_MASK_ALT));
-	default_builtin_cache.insert("ui_text_scroll_down.OSX", inputs);
+	default_builtin_cache.insert("ui_text_scroll_down.osx", inputs);
 
 	// Text Misc
 
@@ -702,11 +702,11 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 void InputMap::load_default() {
 	OrderedHashMap<String, List<Ref<InputEvent>>> builtins = get_builtins();
 
-	// List of Builtins which have an override for OSX.
+	// List of Builtins which have an override for macOS.
 	Vector<String> osx_builtins;
 	for (OrderedHashMap<String, List<Ref<InputEvent>>>::Element E = builtins.front(); E; E = E.next()) {
-		if (String(E.key()).ends_with(".OSX")) {
-			// Strip .OSX from name: some_input_name.OSX -> some_input_name
+		if (String(E.key()).ends_with(".osx")) {
+			// Strip .osx from name: some_input_name.osx -> some_input_name
 			osx_builtins.push_back(String(E.key()).split(".")[0]);
 		}
 	}
@@ -717,13 +717,13 @@ void InputMap::load_default() {
 		String override_for = fullname.split(".").size() > 1 ? fullname.split(".")[1] : "";
 
 #ifdef APPLE_STYLE_KEYS
-		if (osx_builtins.has(name) && override_for != "OSX") {
-			// Name has osx builtin but this particular one is for non-osx systems - so skip.
+		if (osx_builtins.has(name) && override_for != "osx") {
+			// Name has `osx` builtin but this particular one is for non-macOS systems - so skip.
 			continue;
 		}
 #else
-		if (override_for == "OSX") {
-			// Override for OSX - not needed on non-osx platforms.
+		if (override_for == "osx") {
+			// Override for macOS - not needed on non-macOS platforms.
 			continue;
 		}
 #endif

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -357,9 +357,17 @@ void OS::set_has_server_feature_callback(HasServerFeatureCallback p_callback) {
 }
 
 bool OS::has_feature(const String &p_feature) {
-	if (p_feature == get_name()) {
+	// Feature tags are always lowercase for consistency.
+	if (p_feature == get_name().to_lower()) {
 		return true;
 	}
+
+	// Catch-all `linuxbsd` feature tag that matches on both Linux and BSD.
+	// This is the one exposed in the project settings dialog.
+	if (p_feature == "linuxbsd" && (get_name() == "Linux" || get_name() == "FreeBSD" || get_name() == "NetBSD" || get_name() == "OpenBSD" || get_name() == "BSD")) {
+		return true;
+	}
+
 #ifdef DEBUG_ENABLED
 	if (p_feature == "debug") {
 		return true;

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -625,19 +625,19 @@
 		</member>
 		<member name="input/ui_text_backspace_all_to_left" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_backspace_all_to_left.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_backspace_all_to_left.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_backspace_word" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_backspace_word.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_backspace_word.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_caret_document_end" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_caret_document_end.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_caret_document_end.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_caret_document_start" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_caret_document_start.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_caret_document_start.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_caret_down" type="Dictionary" setter="" getter="">
 		</member>
@@ -645,11 +645,11 @@
 		</member>
 		<member name="input/ui_text_caret_line_end" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_caret_line_end.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_caret_line_end.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_caret_line_start" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_caret_line_start.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_caret_line_start.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_caret_page_down" type="Dictionary" setter="" getter="">
 		</member>
@@ -661,11 +661,11 @@
 		</member>
 		<member name="input/ui_text_caret_word_left" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_caret_word_left.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_caret_word_left.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_caret_word_right" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_caret_word_right.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_caret_word_right.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_completion_accept" type="Dictionary" setter="" getter="">
 		</member>
@@ -679,11 +679,11 @@
 		</member>
 		<member name="input/ui_text_delete_all_to_right" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_delete_all_to_right.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_delete_all_to_right.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_delete_word" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_delete_word.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_delete_word.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_indent" type="Dictionary" setter="" getter="">
 		</member>
@@ -695,11 +695,11 @@
 		</member>
 		<member name="input/ui_text_scroll_down" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_scroll_down.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_scroll_down.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_scroll_up" type="Dictionary" setter="" getter="">
 		</member>
-		<member name="input/ui_text_scroll_up.OSX" type="Dictionary" setter="" getter="">
+		<member name="input/ui_text_scroll_up.osx" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_text_select_all" type="Dictionary" setter="" getter="">
 		</member>
@@ -726,7 +726,7 @@
 		<member name="input_devices/pen_tablet/driver" type="String" setter="" getter="">
 			Specifies the tablet driver to use. If left empty, the default driver will be used.
 		</member>
-		<member name="input_devices/pen_tablet/driver.Windows" type="String" setter="" getter="">
+		<member name="input_devices/pen_tablet/driver.windows" type="String" setter="" getter="">
 			Override for [member input_devices/pen_tablet/driver] on Windows.
 		</member>
 		<member name="input_devices/pointing/emulate_mouse_from_touch" type="bool" setter="" getter="" default="true">

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1948,7 +1948,7 @@ void EditorExportPlatformPC::set_debug_32(const String &p_file) {
 void EditorExportPlatformPC::get_platform_features(List<String> *r_features) {
 	r_features->push_back("pc"); //all pcs support "pc"
 	r_features->push_back("s3tc"); //all pcs support "s3tc" compression
-	r_features->push_back(get_os_name()); //OS name is a feature
+	r_features->push_back(get_os_name().to_lower()); //OS name is a feature
 }
 
 void EditorExportPlatformPC::resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -222,7 +222,6 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 	presets.insert("standalone");
 	presets.insert("32");
 	presets.insert("64");
-	presets.insert("Server"); // Not available as an export platform yet, so it needs to be added manually
 
 	EditorExport *ee = EditorExport::get_singleton();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1559,8 +1559,8 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	{
 		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver", "");
-		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver.Windows", "");
-		ProjectSettings::get_singleton()->set_custom_property_info("input_devices/pen_tablet/driver.Windows", PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.Windows", PROPERTY_HINT_ENUM, "wintab,winink"));
+		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver.windows", "");
+		ProjectSettings::get_singleton()->set_custom_property_info("input_devices/pen_tablet/driver.windows", PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.windows", PROPERTY_HINT_ENUM, "wintab,winink"));
 	}
 
 	if (tablet_driver == "") { // specified in project.godot

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2937,7 +2937,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 
 void EditorExportPlatformAndroid::get_platform_features(List<String> *r_features) {
 	r_features->push_back("mobile");
-	r_features->push_back("Android");
+	r_features->push_back("android");
 }
 
 void EditorExportPlatformAndroid::resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) {

--- a/platform/iphone/export/export_plugin.h
+++ b/platform/iphone/export/export_plugin.h
@@ -204,7 +204,7 @@ public:
 
 	virtual void get_platform_features(List<String> *r_features) override {
 		r_features->push_back("mobile");
-		r_features->push_back("iOS");
+		r_features->push_back("ios");
 	}
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) override {

--- a/platform/javascript/export/export_plugin.h
+++ b/platform/javascript/export/export_plugin.h
@@ -134,7 +134,7 @@ public:
 
 	virtual void get_platform_features(List<String> *r_features) override {
 		r_features->push_back("web");
-		r_features->push_back(get_os_name());
+		r_features->push_back(get_os_name().to_lower());
 	}
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) override {

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -137,12 +137,12 @@ int OS_JavaScript::get_processor_count() const {
 }
 
 bool OS_JavaScript::_check_internal_feature_support(const String &p_feature) {
-	if (p_feature == "HTML5" || p_feature == "web") {
+	if (p_feature == "html5" || p_feature == "web") {
 		return true;
 	}
 
 #ifdef JAVASCRIPT_EVAL_ENABLED
-	if (p_feature == "JavaScript") {
+	if (p_feature == "javascript") {
 		return true;
 	}
 #endif

--- a/platform/linuxbsd/export/export.cpp
+++ b/platform/linuxbsd/export/export.cpp
@@ -53,7 +53,7 @@ void register_linuxbsd_exporter() {
 	platform->set_debug_32("linux_x11_32_debug");
 	platform->set_release_64("linux_x11_64_release");
 	platform->set_debug_64("linux_x11_64_debug");
-	platform->set_os_name("X11");
+	platform->set_os_name("LinuxBSD");
 	platform->set_chmod_flags(0755);
 	platform->set_fixup_embedded_pck_func(&fixup_embedded_pck);
 

--- a/platform/osx/export/export_plugin.h
+++ b/platform/osx/export/export_plugin.h
@@ -115,7 +115,7 @@ public:
 	virtual void get_platform_features(List<String> *r_features) override {
 		r_features->push_back("pc");
 		r_features->push_back("s3tc");
-		r_features->push_back("macOS");
+		r_features->push_back("macos");
 	}
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) override {

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -485,7 +485,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 
 void EditorExportPlatformUWP::get_platform_features(List<String> *r_features) {
 	r_features->push_back("pc");
-	r_features->push_back("UWP");
+	r_features->push_back("uwp");
 }
 
 void EditorExportPlatformUWP::resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) {


### PR DESCRIPTION
Feature tag names are still case-sensitive, but this makes built-in feature tags more consistent.

- `Windows` -> `windows`
- `OSX` -> `osx`
- `Linux` -> `linux` (also applies to FreeBSD, NetBSD, and BSD)
- `Android` -> `android`
- `iOS` -> `ios`
- `HTML5` -> `html5`
- `JavaScript` -> `javascript`
- `UWP` -> `uwp`
- `Server` -> `server`

This also hides the "X11" feature tag in the project settings editor's override list and adds Linux and BSD manually. Ideally, this should be fixed properly but I don't know how to do it right now. I think we should have a single `linuxbsd` feature tag as there's not much reason to have separate feature tags for Linux and *BSD.

This closes https://github.com/godotengine/godot-proposals/issues/2492.

## Preview

Using `print(ProjectSettings.get_setting("application/config/hello"))` will display `hello from Linux` on Linux, and `hello world` on all other platforms.

*The correct name to use is `linux`, the others are present just for testing.*

![image](https://user-images.githubusercontent.com/180032/112649966-3a7e9e00-8e4b-11eb-8018-8c2c50ad5bdb.png)
