### PR TITLE
Array::insert consistent with Pool*Array::insert

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -202,9 +202,9 @@ Error Array::resize(int p_new_size) {
 	return _p->array.resize(p_new_size);
 }
 
-void Array::insert(int p_pos, const Variant &p_value) {
-	ERR_FAIL_COND(!_p->typed.validate(p_value, "insert"));
-	_p->array.insert(p_pos, p_value);
+Error Array::insert(int p_pos, const Variant &p_value) {
+	ERR_FAIL_COND_V(!_p->typed.validate(p_value, "insert"), ERR_INVALID_PARAMETER);
+	return _p->array.insert(p_pos, p_value);
 }
 
 void Array::erase(const Variant &p_value) {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -72,7 +72,7 @@ public:
 	void append_array(const Array &p_array);
 	Error resize(int p_new_size);
 
-	void insert(int p_pos, const Variant &p_value);
+	Error insert(int p_pos, const Variant &p_value);
 	void remove(int p_pos);
 
 	Variant front() const;


### PR DESCRIPTION
There were some inconsistencies with  `Array` and `Pool*Array` that were resolved a few month sago such as exposing new methods. Another difference is the return value of the `insert` function. This change adds an `Error` response to the `Array::insert` function similar to how `Pool*Array` have `Error` on their insert..