### PR TITLE
Added metadata for TreeItem buttons

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -537,6 +537,20 @@ void TreeItem::add_button(int p_column, const Ref<Texture> &p_button, int p_id, 
 	_changed_notify(p_column);
 }
 
+void TreeItem::set_button_metadata(int p_column, int p_idx, const Variant &p_meta) {
+
+	ERR_FAIL_INDEX(p_column, cells.size());
+	ERR_FAIL_INDEX(p_column, cells[p_column].buttons.size());
+	cells.write[p_column].buttons.write[p_idx].meta = p_meta;
+}
+
+Variant TreeItem::get_button_metadata(int p_column, int p_idx) const {
+
+	ERR_FAIL_INDEX_V(p_column, cells.size(), Variant());
+	ERR_FAIL_INDEX_V(p_idx, cells[p_column].buttons.size(), Variant());
+	return cells[p_column].buttons[p_idx].meta;
+}
+
 int TreeItem::get_button_count(int p_column) const {
 
 	ERR_FAIL_INDEX_V(p_column, cells.size(), -1);
@@ -840,6 +854,8 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_custom_set_as_button", "column"), &TreeItem::is_custom_set_as_button);
 
 	ClassDB::bind_method(D_METHOD("add_button", "column", "button", "button_idx", "disabled", "tooltip"), &TreeItem::add_button, DEFVAL(-1), DEFVAL(false), DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("set_button_metadata", "column", "button_idx", "meta"), &TreeItem::set_button_metadata);
+	ClassDB::bind_method(D_METHOD("get_button_metadata", "column", "button_idx"), &TreeItem::get_button_metadata);
 	ClassDB::bind_method(D_METHOD("get_button_count", "column"), &TreeItem::get_button_count);
 	ClassDB::bind_method(D_METHOD("get_button_tooltip", "column", "button_idx"), &TreeItem::get_button_tooltip);
 	ClassDB::bind_method(D_METHOD("get_button", "column", "button_idx"), &TreeItem::get_button);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -100,6 +100,7 @@ private:
 			Ref<Texture> texture;
 			Color color;
 			String tooltip;
+			Variant meta;
 			Button() {
 				id = 0;
 				disabled = false;
@@ -202,6 +203,8 @@ public:
 	int get_icon_max_width(int p_column) const;
 
 	void add_button(int p_column, const Ref<Texture> &p_button, int p_id = -1, bool p_disabled = false, const String &p_tooltip = "");
+	void set_button_metadata(int p_column, int p_idx, const Variant &p_meta);
+	Variant get_button_metadata(int p_column, int p_idx) const;
 	int get_button_count(int p_column) const;
 	String get_button_tooltip(int p_column, int p_idx) const;
 	Ref<Texture> get_button(int p_column, int p_idx) const;


### PR DESCRIPTION
TreeItem buttons are displayed from left to right but we normally want buttons to be displayed right to left : 

Example:
![image](https://user-images.githubusercontent.com/40196601/112714970-837f3280-8edd-11eb-9e0b-b91bd469626b.png)

For "main" TreeItem, the visibility button will be index 1 while for "background" TreeItem, the same button will be index 0.

So when we use tree with multiselect and we want to multiclick a button the easy way is to add a metadata to pass for example the name of a method.