### PR TITLE
Use double when setting the default step size

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3282,7 +3282,7 @@ void EditorInspectorDefaultPlugin::parse_begin(Object *p_object) {
 }
 
 bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide) {
-	float default_float_step = EDITOR_GET("interface/inspector/default_float_step");
+	double default_float_step = EDITOR_GET("interface/inspector/default_float_step");
 
 	switch (p_type) {
 		// atomic types

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1472,7 +1472,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 				Vector3 ray_pos = _get_ray_pos(m->get_position());
 				Vector3 ray = _get_ray(m->get_position());
-				float snap = EDITOR_GET("interface/inspector/default_float_step");
+				double snap = EDITOR_GET("interface/inspector/default_float_step");
 				int snap_step_decimals = Math::range_step_decimals(snap);
 
 				switch (_edit.mode) {
@@ -1766,7 +1766,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						Vector3 y_axis = (click - _edit.center).normalized();
 						Vector3 x_axis = plane.normal.cross(y_axis).normalized();
 
-						float angle = Math::atan2(x_axis.dot(intersection - _edit.center), y_axis.dot(intersection - _edit.center));
+						double angle = Math::atan2(x_axis.dot(intersection - _edit.center), y_axis.dot(intersection - _edit.center));
 
 						if (_edit.snap || spatial_editor->is_snap_enabled()) {
 							snap = spatial_editor->get_rotate_snap();


### PR DESCRIPTION
Fixes #47390

Confirmed this bug is present in 3.2 and current master branch. 

Prior to change:
![Godot3 2_example](https://user-images.githubusercontent.com/80655527/112716539-36cb3580-8ea4-11eb-9482-23f93301e6ff.png)
![precision_error](https://user-images.githubusercontent.com/80655527/112716533-3337ae80-8ea4-11eb-9812-56efeecb9dd6.png)


After change:
![godot_fix](https://user-images.githubusercontent.com/80655527/112715526-e81a9d00-8e9d-11eb-89b5-c929dd02225c.png)
![fixed_100](https://user-images.githubusercontent.com/80655527/112716542-3af75300-8ea4-11eb-8f3e-009bd78b6432.png)


