### PR TITLE
curvetexture and gradientexture default to 64 as a size

### DIFF
--- a/doc/classes/CurveTexture.xml
+++ b/doc/classes/CurveTexture.xml
@@ -14,7 +14,7 @@
 		<member name="curve" type="Curve" setter="set_curve" getter="get_curve">
 			The [code]curve[/code] rendered onto the texture.
 		</member>
-		<member name="width" type="int" setter="set_width" getter="get_width" default="2048">
+		<member name="width" type="int" setter="set_width" getter="get_width" default="64">
 			The width of the texture.
 		</member>
 	</members>

--- a/doc/classes/GradientTexture.xml
+++ b/doc/classes/GradientTexture.xml
@@ -14,7 +14,7 @@
 		<member name="gradient" type="Gradient" setter="set_gradient" getter="get_gradient">
 			The [Gradient] that will be used to fill the texture.
 		</member>
-		<member name="width" type="int" setter="set_width" getter="get_width" default="2048">
+		<member name="width" type="int" setter="set_width" getter="get_width" default="64">
 			The number of color samples that will be obtained from the [Gradient].
 		</member>
 	</members>

--- a/modules/gltf/doc_classes/GLTFTexture.xml
+++ b/modules/gltf/doc_classes/GLTFTexture.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="src_image" type="int" setter="set_src_image" getter="get_src_image" default="212600976">
+		<member name="src_image" type="int" setter="set_src_image" getter="get_src_image" default="0">
 		</member>
 	</members>
 	<constants>

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -644,7 +644,7 @@ class CurveTexture : public Texture2D {
 private:
 	mutable RID _texture;
 	Ref<Curve> _curve;
-	int _width = 2048;
+	int _width = 64;
 
 	void _update();
 
@@ -697,7 +697,7 @@ private:
 	Ref<Gradient> gradient;
 	bool update_pending = false;
 	RID texture;
-	int width = 2048;
+	int width = 64;
 
 	void _queue_update();
 	void _update();


### PR DESCRIPTION
I don't see a good reason why we should default to 2k for a curve or a gradient.
In most of my particles i use curves and gradients with a width of 64 with no clear loss of precision.

FAIR DISCLAIMER: Most of my particle don't live past a second. We can also default to something like 128 or 256, but 2k still seems too much, considering also that the texture is already interploated through filtering.
