### PR TITLE
Add a warning on using directory to access of imported files

### DIFF
--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -6,6 +6,7 @@
 	<description>
 		Directory type. It is used to manage directories and their content (not restricted to the project folder).
 		When creating a new [Directory], it must be explicitly opened using [method open] before most methods can be used. However, [method file_exists] and [method dir_exists] can be used without opening a directory. If so, they use a path relative to [code]res://[/code].
+		[b]Note:[/b] Many resources types are imported (e.g. textures or sound files), and their source asset will not be included in the exported game, as only the imported version is used. Use [ResourceLoader] to access imported resources.
 		Here is an example on how to iterate through the files of a directory:
 		[codeblocks]
 		[gdscript]


### PR DESCRIPTION
Adds a note to the directory class reference that it should not be used to access imported files. I took and slightly changed the warning from the file class reference. Closes https://github.com/godotengine/godot-docs/issues/4680 and closes https://github.com/godotengine/godot-docs/issues/2280
