### PR TITLE
Add support for contrast-adaptive sharpening in 3D (3.x, GLES3 only)

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1197,6 +1197,9 @@ ProjectSettings::ProjectSettings() {
 	custom_prop_info["physics/2d/thread_model"] = PropertyInfo(Variant::INT, "physics/2d/thread_model", PROPERTY_HINT_ENUM, "Single-Unsafe,Single-Safe,Multi-Threaded");
 	custom_prop_info["rendering/quality/intended_usage/framebuffer_allocation"] = PropertyInfo(Variant::INT, "rendering/quality/intended_usage/framebuffer_allocation", PROPERTY_HINT_ENUM, "2D,2D Without Sampling,3D,3D Without Effects");
 
+	GLOBAL_DEF("rendering/quality/filters/sharpen_intensity", 0.0);
+	custom_prop_info["rendering/quality/filters/sharpen_intensity"] = PropertyInfo(Variant::REAL, "rendering/quality/filters/sharpen_intensity", PROPERTY_HINT_RANGE, "0,1");
+
 	GLOBAL_DEF("debug/settings/profiler/max_functions", 16384);
 	custom_prop_info["debug/settings/profiler/max_functions"] = PropertyInfo(Variant::INT, "debug/settings/profiler/max_functions", PROPERTY_HINT_RANGE, "128,65535,1");
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1219,12 +1219,15 @@
 			Sets the number of MSAA samples to use. MSAA is used to reduce aliasing around the edges of polygons. A higher MSAA value results in smoother edges but can be significantly slower on some hardware.
 			[b]Note:[/b] MSAA is not available on HTML5 export using the GLES2 backend.
 		</member>
+		<member name="rendering/quality/filters/sharpen_intensity" type="float" setter="" getter="" default="0.0">
+			If set to a value greater than [code]0.0[/code], contrast-adaptive sharpening will be applied to the 3D viewport. This has a low performance cost and can be used to recover some of the sharpness lost from using FXAA. Values around [code]0.5[/code] generally give the best results. See also [member rendering/quality/filters/use_fxaa].
+		</member>
 		<member name="rendering/quality/filters/use_debanding" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], uses a fast post-processing filter to make banding significantly less visible. In some cases, debanding may introduce a slightly noticeable dithering pattern. It's recommended to enable debanding only when actually needed since the dithering pattern will make lossless-compressed screenshots larger.
 			[b]Note:[/b] Only available on the GLES3 backend. [member rendering/quality/depth/hdr] must also be [code]true[/code] for debanding to be effective.
 		</member>
 		<member name="rendering/quality/filters/use_fxaa" type="bool" setter="" getter="" default="false">
-			Enables FXAA in the root Viewport. FXAA is a popular screen-space antialiasing method, which is fast but will make the image look blurry, especially at lower resolutions. It can still work relatively well at large resolutions such as 1440p and 4K.
+			Enables FXAA in the root Viewport. FXAA is a popular screen-space antialiasing method, which is fast but will make the image look blurry, especially at lower resolutions. It can still work relatively well at large resolutions such as 1440p and 4K. Some of the lost sharpness can be recovered by enabling contrast-adaptive sharpening (see [member rendering/quality/filters/sharpen_intensity]).
 		</member>
 		<member name="rendering/quality/filters/use_nearest_mipmap_filter" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], uses nearest-neighbor mipmap filtering when using mipmaps (also called "bilinear filtering"), which will result in visible seams appearing between mipmap stages. This may increase performance in mobile as less memory bandwidth is used. If [code]false[/code], linear mipmap filtering (also called "trilinear filtering") is used.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -246,7 +246,7 @@
 			If [code]true[/code], the viewport will disable 3D rendering. For actual disabling use [code]usage[/code].
 		</member>
 		<member name="fxaa" type="bool" setter="set_use_fxaa" getter="get_use_fxaa" default="false">
-			Enables fast approximate antialiasing. FXAA is a popular screen-space antialiasing method, which is fast but will make the image look blurry, especially at lower resolutions. It can still work relatively well at large resolutions such as 1440p and 4K.
+			Enables fast approximate antialiasing. FXAA is a popular screen-space antialiasing method, which is fast but will make the image look blurry, especially at lower resolutions. It can still work relatively well at large resolutions such as 1440p and 4K. Some of the lost sharpness can be recovered by enabling contrast-adaptive sharpening (see [member sharpen_intensity]).
 		</member>
 		<member name="global_canvas_transform" type="Transform2D" setter="set_global_canvas_transform" getter="get_global_canvas_transform">
 			The global canvas transform of the viewport. The canvas transform is relative to this.
@@ -303,6 +303,9 @@
 		<member name="shadow_atlas_size" type="int" setter="set_shadow_atlas_size" getter="get_shadow_atlas_size" default="0">
 			The shadow atlas' resolution (used for omni and spot lights). The value will be rounded up to the nearest power of 2.
 			[b]Note:[/b] If this is set to 0, shadows won't be visible. Since user-created viewports default to a value of 0, this value must be set above 0 manually.
+		</member>
+		<member name="sharpen_intensity" type="float" setter="set_sharpen_intensity" getter="get_sharpen_intensity" default="0.0">
+			If set to a value greater than [code]0.0[/code], contrast-adaptive sharpening will be applied to the 3D viewport. This has a low performance cost and can be used to recover some of the sharpness lost from using FXAA. Values around [code]0.5[/code] generally give the best results. See also [member fxaa].
 		</member>
 		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2( 0, 0 )">
 			The width and height of viewport.

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -4198,6 +4198,17 @@
 				Sets the size of the shadow atlas's images (used for omni and spot lights). The value will be rounded up to the nearest power of 2.
 			</description>
 		</method>
+		<method name="viewport_set_sharpen_intensity">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="intensity" type="float">
+			</argument>
+			<description>
+				Sets the sharpening [code]intensity[/code] for the [code]viewport[/code]. If set to a value greater than [code]0.0[/code], contrast-adaptive sharpening will be applied to the 3D viewport. This has a low performance cost and can be used to recover some of the sharpness lost from using FXAA. Values around [code]0.5[/code] generally give the best results. See also [method viewport_set_use_fxaa].
+			</description>
+		</method>
 		<method name="viewport_set_size">
 			<return type="void">
 			</return>
@@ -4275,7 +4286,7 @@
 			<argument index="1" name="fxaa" type="bool">
 			</argument>
 			<description>
-				Enables fast approximate antialiasing for this viewport. FXAA is a popular screen-space antialiasing method, which is fast but will make the image look blurry, especially at lower resolutions. It can still work relatively well at large resolutions such as 1440p and 4K.
+				Enables fast approximate antialiasing for this viewport. FXAA is a popular screen-space antialiasing method, which is fast but will make the image look blurry, especially at lower resolutions. It can still work relatively well at large resolutions such as 1440p and 4K. Some of the lost sharpness can be recovered by enabling contrast-adaptive sharpening (see [method viewport_set_sharpen_intensity]).
 			</description>
 		</method>
 		<method name="viewport_set_vflip">

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -706,6 +706,7 @@ public:
 	void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa) {}
 	void render_target_set_use_fxaa(RID p_render_target, bool p_fxaa) {}
 	void render_target_set_use_debanding(RID p_render_target, bool p_debanding) {}
+	void render_target_set_sharpen_intensity(RID p_render_target, float p_intensity) {}
 
 	/* CANVAS SHADOW */
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5366,10 +5366,21 @@ void RasterizerStorageGLES2::render_target_set_use_debanding(RID p_render_target
 	ERR_FAIL_COND(!rt);
 
 	if (p_debanding) {
-		WARN_PRINT_ONCE("Debanding is not supported in the GLES2 backend. Switch to the GLES3 backend and make sure HDR is enabled.");
+		WARN_PRINT_ONCE("Debanding is not supported in the GLES2 backend. To use debanding, switch to the GLES3 backend and make sure HDR is enabled.");
 	}
 
 	rt->use_debanding = p_debanding;
+}
+
+void RasterizerStorageGLES2::render_target_set_sharpen_intensity(RID p_render_target, float p_intensity) {
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	if (p_intensity >= 0.001) {
+		WARN_PRINT_ONCE("Sharpening is not supported in the GLES2 backend. To use sharpening, switch to the GLES3 backend.");
+	}
+
+	rt->sharpen_intensity = p_intensity;
 }
 
 /* CANVAS SHADOW */

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1232,6 +1232,7 @@ public:
 
 		bool use_fxaa;
 		bool use_debanding;
+		float sharpen_intensity;
 
 		RID texture;
 
@@ -1254,6 +1255,7 @@ public:
 				msaa(VS::VIEWPORT_MSAA_DISABLED),
 				use_fxaa(false),
 				use_debanding(false),
+				sharpen_intensity(0.0),
 				used_dof_blur_near(false),
 				mip_maps_allocated(false) {
 			for (int i = 0; i < RENDER_TARGET_FLAG_MAX; ++i) {
@@ -1281,6 +1283,7 @@ public:
 	virtual void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa);
 	virtual void render_target_set_use_fxaa(RID p_render_target, bool p_fxaa);
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_debanding);
+	virtual void render_target_set_sharpen_intensity(RID p_render_target, float p_intensity);
 
 	/* CANVAS SHADOW */
 

--- a/drivers/gles2/shaders/tonemap.glsl
+++ b/drivers/gles2/shaders/tonemap.glsl
@@ -98,6 +98,10 @@ uniform vec3 bcs;
 uniform vec2 pixel_size;
 #endif
 
+#ifdef USE_SHARPENING
+uniform float sharpen_intensity;
+#endif
+
 #ifdef USE_COLOR_CORRECTION
 uniform sampler2D color_correction; //texunit:1
 #endif

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -7446,6 +7446,13 @@ void RasterizerStorageGLES3::render_target_set_use_debanding(RID p_render_target
 	rt->use_debanding = p_debanding;
 }
 
+void RasterizerStorageGLES3::render_target_set_sharpen_intensity(RID p_render_target, float p_intensity) {
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	rt->sharpen_intensity = p_intensity;
+}
+
 /* CANVAS SHADOW */
 
 RID RasterizerStorageGLES3::canvas_light_shadow_buffer_create(int p_width) {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1383,6 +1383,7 @@ public:
 		VS::ViewportMSAA msaa;
 		bool use_fxaa;
 		bool use_debanding;
+		float sharpen_intensity;
 
 		RID texture;
 
@@ -1395,7 +1396,8 @@ public:
 				used_in_frame(false),
 				msaa(VS::VIEWPORT_MSAA_DISABLED),
 				use_fxaa(false),
-				use_debanding(false) {
+				use_debanding(false),
+				sharpen_intensity(0.0) {
 			exposure.fbo = 0;
 			buffers.fbo = 0;
 			external.fbo = 0;
@@ -1426,6 +1428,7 @@ public:
 	virtual void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa);
 	virtual void render_target_set_use_fxaa(RID p_render_target, bool p_fxaa);
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_debanding);
+	virtual void render_target_set_sharpen_intensity(RID p_render_target, float p_intensity);
 
 	/* CANVAS SHADOW */
 

--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -52,6 +52,10 @@ uniform vec3 bcs;
 uniform vec2 pixel_size;
 #endif
 
+#ifdef USE_SHARPENING
+uniform float sharpen_intensity;
+#endif
+
 #ifdef USE_COLOR_CORRECTION
 uniform sampler2D color_correction; //texunit:3
 #endif
@@ -323,6 +327,54 @@ vec3 screen_space_dither(vec2 frag_coord) {
 	return (dither.rgb - 0.5) / 255.0;
 }
 
+// Adapted from https://github.com/DadSchoorse/vkBasalt/blob/b929505ba71dea21d6c32a5a59f2d241592b30c4/src/shader/cas.frag.glsl
+// (MIT license).
+vec3 apply_cas(vec3 color, vec2 uv_interp, float sharpen_intensity) {
+	// Fetch a 3x3 neighborhood around the pixel 'e',
+	//  a b c
+	//  d(e)f
+	//  g h i
+	vec3 a = textureLodOffset(source, uv_interp, 0.0, ivec2(-1, -1)).rgb;
+	vec3 b = textureLodOffset(source, uv_interp, 0.0, ivec2(0, -1)).rgb;
+	vec3 c = textureLodOffset(source, uv_interp, 0.0, ivec2(1, -1)).rgb;
+	vec3 d = textureLodOffset(source, uv_interp, 0.0, ivec2(-1, 0)).rgb;
+	vec3 e = color.rgb;
+	vec3 f = textureLodOffset(source, uv_interp, 0.0, ivec2(1, 0)).rgb;
+	vec3 g = textureLodOffset(source, uv_interp, 0.0, ivec2(-1, 1)).rgb;
+	vec3 h = textureLodOffset(source, uv_interp, 0.0, ivec2(0, 1)).rgb;
+	vec3 i = textureLodOffset(source, uv_interp, 0.0, ivec2(1, 1)).rgb;
+
+	// Soft min and max.
+	//  a b c             b
+	//  d e f * 0.5  +  d e f * 0.5
+	//  g h i             h
+	// These are 2.0x bigger (factored out the extra multiply).
+	vec3 min_rgb = min(min(min(d, e), min(f, b)), h);
+	vec3 min_rgb2 = min(min(min(min_rgb, a), min(g, c)), i);
+	min_rgb += min_rgb2;
+
+	vec3 max_rgb = max(max(max(d, e), max(f, b)), h);
+	vec3 max_rgb2 = max(max(max(max_rgb, a), max(g, c)), i);
+	max_rgb += max_rgb2;
+
+	// Smooth minimum distance to signal limit divided by smooth max.
+	vec3 rcp_max_rgb = vec3(1.0) / max_rgb;
+	vec3 amp_rgb = clamp((min(min_rgb, 2.0 - max_rgb) * rcp_max_rgb), 0.0, 1.0);
+
+	// Shaping amount of sharpening.
+	amp_rgb = inversesqrt(amp_rgb);
+	float peak = 8.0 - 3.0 * sharpen_intensity;
+	vec3 w_rgb = -vec3(1) / (amp_rgb * peak);
+	vec3 rcp_weight_rgb = vec3(1.0) / (1.0 + 4.0 * w_rgb);
+
+	//                          0 w 0
+	//  Filter shape:           w 1 w
+	//                          0 w 0
+	vec3 window = b + d + f + h;
+
+	return max(vec3(0.0), (window * w_rgb + e) * rcp_weight_rgb);
+}
+
 void main() {
 	vec3 color = textureLod(source, uv_interp, 0.0f).rgb;
 
@@ -338,6 +390,12 @@ void main() {
 #ifdef USE_FXAA
 	// FXAA must be applied before tonemapping.
 	color = apply_fxaa(color, full_exposure, uv_interp, pixel_size);
+#endif
+
+#ifdef USE_SHARPENING
+	// CAS gives best results when applied after tonemapping, but `source` isn't tonemapped.
+	// As a workaround, apply CAS before tonemapping so that the image still has a correct appearance when tonemapped.
+	color = apply_cas(color, uv_interp, sharpen_intensity);
 #endif
 
 #ifdef USE_DEBANDING

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2441,6 +2441,9 @@ void SpatialEditorViewport::_notification(int p_what) {
 		bool use_debanding = ProjectSettings::get_singleton()->get("rendering/quality/filters/use_debanding");
 		viewport->set_use_debanding(use_debanding);
 
+		float sharpen_intensity = ProjectSettings::get_singleton()->get("rendering/quality/filters/sharpen_intensity");
+		viewport->set_sharpen_intensity(sharpen_intensity);
+
 		bool hdr = ProjectSettings::get_singleton()->get("rendering/quality/depth/hdr");
 		viewport->set_hdr(hdr);
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2062,6 +2062,9 @@ SceneTree::SceneTree() {
 	const bool use_debanding = GLOBAL_DEF("rendering/quality/filters/use_debanding", false);
 	root->set_use_debanding(use_debanding);
 
+	const float sharpen_intensity = GLOBAL_GET("rendering/quality/filters/sharpen_intensity");
+	root->set_sharpen_intensity(sharpen_intensity);
+
 	GLOBAL_DEF_RST("rendering/quality/depth/hdr", true);
 	GLOBAL_DEF("rendering/quality/depth/hdr.mobile", false);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2988,6 +2988,18 @@ bool Viewport::get_use_debanding() const {
 	return use_debanding;
 }
 
+void Viewport::set_sharpen_intensity(float p_intensity) {
+	if (p_intensity == sharpen_intensity) {
+		return;
+	}
+	sharpen_intensity = p_intensity;
+	VS::get_singleton()->viewport_set_sharpen_intensity(viewport, sharpen_intensity);
+}
+
+float Viewport::get_sharpen_intensity() const {
+	return sharpen_intensity;
+}
+
 void Viewport::set_hdr(bool p_hdr) {
 	if (hdr == p_hdr) {
 		return;
@@ -3120,6 +3132,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_debanding", "enable"), &Viewport::set_use_debanding);
 	ClassDB::bind_method(D_METHOD("get_use_debanding"), &Viewport::get_use_debanding);
 
+	ClassDB::bind_method(D_METHOD("set_sharpen_intensity", "intensity"), &Viewport::set_sharpen_intensity);
+	ClassDB::bind_method(D_METHOD("get_sharpen_intensity"), &Viewport::get_sharpen_intensity);
+
 	ClassDB::bind_method(D_METHOD("set_hdr", "enable"), &Viewport::set_hdr);
 	ClassDB::bind_method(D_METHOD("get_hdr"), &Viewport::get_hdr);
 
@@ -3212,6 +3227,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "msaa", PROPERTY_HINT_ENUM, "Disabled,2x,4x,8x,16x,AndroidVR 2x,AndroidVR 4x"), "set_msaa", "get_msaa");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fxaa"), "set_use_fxaa", "get_use_fxaa");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debanding"), "set_use_debanding", "get_use_debanding");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "sharpen_intensity"), "set_sharpen_intensity", "get_sharpen_intensity");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hdr"), "set_hdr", "get_hdr");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_3d"), "set_disable_3d", "is_3d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_3d_linear"), "set_keep_3d_linear", "get_keep_3d_linear");
@@ -3371,6 +3387,7 @@ Viewport::Viewport() {
 	msaa = MSAA_DISABLED;
 	use_fxaa = false;
 	use_debanding = false;
+	sharpen_intensity = 0.0;
 	hdr = true;
 
 	usage = USAGE_3D;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -281,6 +281,7 @@ private:
 	MSAA msaa;
 	bool use_fxaa;
 	bool use_debanding;
+	float sharpen_intensity;
 	bool hdr;
 
 	Ref<ViewportTexture> default_texture;
@@ -501,6 +502,9 @@ public:
 
 	void set_use_debanding(bool p_debanding);
 	bool get_use_debanding() const;
+
+	void set_sharpen_intensity(float p_intensity);
+	float get_sharpen_intensity() const;
 
 	void set_hdr(bool p_hdr);
 	bool get_hdr() const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -577,6 +577,7 @@ public:
 	virtual void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa) = 0;
 	virtual void render_target_set_use_fxaa(RID p_render_target, bool p_fxaa) = 0;
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_debanding) = 0;
+	virtual void render_target_set_sharpen_intensity(RID p_render_target, float p_intensity) = 0;
 
 	/* CANVAS SHADOW */
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -488,6 +488,7 @@ public:
 	BIND2(viewport_set_msaa, RID, ViewportMSAA)
 	BIND2(viewport_set_use_fxaa, RID, bool)
 	BIND2(viewport_set_use_debanding, RID, bool)
+	BIND2(viewport_set_sharpen_intensity, RID, float)
 	BIND2(viewport_set_hdr, RID, bool)
 	BIND2(viewport_set_usage, RID, ViewportUsage)
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -630,6 +630,13 @@ void VisualServerViewport::viewport_set_use_debanding(RID p_viewport, bool p_deb
 	VSG::storage->render_target_set_use_debanding(viewport->render_target, p_debanding);
 }
 
+void VisualServerViewport::viewport_set_sharpen_intensity(RID p_viewport, float p_intensity) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+
+	VSG::storage->render_target_set_sharpen_intensity(viewport->render_target, p_intensity);
+}
+
 void VisualServerViewport::viewport_set_hdr(RID p_viewport, bool p_enabled) {
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -188,6 +188,7 @@ public:
 	void viewport_set_msaa(RID p_viewport, VS::ViewportMSAA p_msaa);
 	void viewport_set_use_fxaa(RID p_viewport, bool p_fxaa);
 	void viewport_set_use_debanding(RID p_viewport, bool p_debanding);
+	void viewport_set_sharpen_intensity(RID p_viewport, float p_intensity);
 	void viewport_set_hdr(RID p_viewport, bool p_enabled);
 	void viewport_set_usage(RID p_viewport, VS::ViewportUsage p_usage);
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -416,6 +416,7 @@ public:
 	FUNC2(viewport_set_msaa, RID, ViewportMSAA)
 	FUNC2(viewport_set_use_fxaa, RID, bool)
 	FUNC2(viewport_set_use_debanding, RID, bool)
+	FUNC2(viewport_set_sharpen_intensity, RID, float)
 	FUNC2(viewport_set_hdr, RID, bool)
 	FUNC2(viewport_set_usage, RID, ViewportUsage)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1753,6 +1753,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_msaa", "viewport", "msaa"), &VisualServer::viewport_set_msaa);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_fxaa", "viewport", "fxaa"), &VisualServer::viewport_set_use_fxaa);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_debanding", "viewport", "debanding"), &VisualServer::viewport_set_use_debanding);
+	ClassDB::bind_method(D_METHOD("viewport_set_sharpen_intensity", "viewport", "intensity"), &VisualServer::viewport_set_sharpen_intensity);
 	ClassDB::bind_method(D_METHOD("viewport_set_hdr", "viewport", "enabled"), &VisualServer::viewport_set_hdr);
 	ClassDB::bind_method(D_METHOD("viewport_set_usage", "viewport", "usage"), &VisualServer::viewport_set_usage);
 	ClassDB::bind_method(D_METHOD("viewport_get_render_info", "viewport", "info"), &VisualServer::viewport_get_render_info);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -683,6 +683,7 @@ public:
 	virtual void viewport_set_msaa(RID p_viewport, ViewportMSAA p_msaa) = 0;
 	virtual void viewport_set_use_fxaa(RID p_viewport, bool p_fxaa) = 0;
 	virtual void viewport_set_use_debanding(RID p_viewport, bool p_debanding) = 0;
+	virtual void viewport_set_sharpen_intensity(RID p_viewport, float p_intensity) = 0;
 
 	enum ViewportUsage {
 		VIEWPORT_USAGE_2D,


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/47401.

This is an older, easier to implement variant of CAS as a pure fragment shader. It doesn't support upscaling, but we won't make use of it (at least for now).

The sharpening intensity can be adjusted on a per-Viewport basis. For the root viewport, it can be adjusted in the Project Settings.

Since `textureLodOffset()` isn't available in GLES2, there is no way to support contrast-adaptive sharpening in GLES2.

## Preview

*FXAA is enabled on both screenshots.*

[Slider comparison](https://imgsli.com/NDY0OTM)

### Sharpening disabled

![Disabled](https://user-images.githubusercontent.com/180032/112730037-8440b480-8f2f-11eb-958b-90cb14aec35c.png)

### Sharpening enabled (intensity 1.0)

![Enabled](https://user-images.githubusercontent.com/180032/112730035-8276f100-8f2f-11eb-85aa-c7ffdbae5761.png)