### PR TITLE
Array::insert consistent with Pool*Array::insert

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -127,9 +127,9 @@ Error Array::resize(int p_new_size) {
 	return _p->array.resize(p_new_size);
 }
 
-void Array::insert(int p_pos, const Variant &p_value) {
+Error Array::insert(int p_pos, const Variant &p_value) {
 
-	_p->array.insert(p_pos, p_value);
+	return _p->array.insert(p_pos, p_value);
 }
 
 void Array::erase(const Variant &p_value) {

--- a/core/array.h
+++ b/core/array.h
@@ -67,7 +67,7 @@ public:
 	void append_array(const Array &p_array);
 	Error resize(int p_new_size);
 
-	void insert(int p_pos, const Variant &p_value);
+	Error insert(int p_pos, const Variant &p_value);
 	void remove(int p_pos);
 
 	Variant front() const;


### PR DESCRIPTION
There were some inconsistencies with  `Array` and `Pool*Array` that were resolved a few months ago such as exposing new methods. Another difference is the return value of the `insert` function. This change adds an `Error` response to the `Array::insert` function similar to how `Pool*Array` have `Error` on their insert.

master PR here: https://github.com/godotengine/godot/pull/47406