### PR TITLE
Add note that for _gui_input(event) event position is relative to the control origin

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -137,6 +137,7 @@
 				* control is obstructed by another [Control] on top of it, which doesn't have [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
 				* control's parent has [member mouse_filter] set to [constant MOUSE_FILTER_STOP] or has accepted the event;
 				* it happens outside the parent's rectangle and the parent has either [member rect_clip_content] enabled.
+				[b]Note:[/b] Event position is relative to the control origin.
 			</description>
 		</method>
 		<method name="_has_point" qualifiers="virtual const">


### PR DESCRIPTION
Does what the title says. Closes https://github.com/godotengine/godot-docs/issues/4433