### PR TITLE
Fix String.right(count) not returning the last count characters of a string

### DIFF
--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -183,7 +183,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 						print_line("Error: Unknown option " + key);
 					} else {
 						// Allow explicit tab character
-						String value = key_value.right(value_pos + 1).replace("\\t", "\t");
+						String value = key_value.substr(value_pos + 1).replace("\\t", "\t");
 
 						options[key] = value;
 					}
@@ -348,7 +348,7 @@ Pair<String, int> LocalDebugger::to_breakpoint(const String &p_line) {
 	}
 
 	breakpoint.first = script_debugger->breakpoint_find_source(breakpoint_part.left(last_colon).strip_edges());
-	breakpoint.second = breakpoint_part.right(last_colon).strip_edges().to_int();
+	breakpoint.second = breakpoint_part.substr(last_colon).strip_edges().to_int();
 
 	return breakpoint;
 }

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1262,16 +1262,16 @@ void Input::parse_mapping(String p_mapping) {
 			} else if (output[0] == '-') {
 				output_range = NEGATIVE_HALF_AXIS;
 			}
-			output = output.right(1);
+			output = output.substr(1);
 		}
 
 		JoyAxisRange input_range = FULL_AXIS;
 		if (input[0] == '+') {
 			input_range = POSITIVE_HALF_AXIS;
-			input = input.right(1);
+			input = input.substr(1);
 		} else if (input[0] == '-') {
 			input_range = NEGATIVE_HALF_AXIS;
-			input = input.right(1);
+			input = input.substr(1);
 		}
 		bool invert_axis = false;
 		if (input[input.length() - 1] == '~') {
@@ -1299,11 +1299,11 @@ void Input::parse_mapping(String p_mapping) {
 		switch (input[0]) {
 			case 'b':
 				binding.inputType = TYPE_BUTTON;
-				binding.input.button = input.right(1).to_int();
+				binding.input.button = input.substr(1).to_int();
 				break;
 			case 'a':
 				binding.inputType = TYPE_AXIS;
-				binding.input.axis.axis = input.right(1).to_int();
+				binding.input.axis.axis = input.substr(1).to_int();
 				binding.input.axis.range = input_range;
 				binding.input.axis.invert = invert_axis;
 				break;
@@ -1312,7 +1312,7 @@ void Input::parse_mapping(String p_mapping) {
 						String(entry[idx] + "\nInvalid hat input: " + input));
 				binding.inputType = TYPE_HAT;
 				binding.input.hat.hat = input.substr(1, 1).to_int();
-				binding.input.hat.hat_mask = static_cast<HatMask>(input.right(3).to_int());
+				binding.input.hat.hat_mask = static_cast<HatMask>(input.substr(3).to_int());
 				break;
 			default:
 				ERR_CONTINUE_MSG(true, String(entry[idx] + "\nUnrecognised input string: " + input));

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -868,7 +868,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 				continue;
 			}
 
-			String l = res_remaps[i].right(split + 1).strip_edges();
+			String l = res_remaps[i].substr(split + 1).strip_edges();
 			if (l == locale) { // Exact match.
 				new_path = res_remaps[i].left(split);
 				break;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3317,14 +3317,14 @@ String String::format(const Variant &values, String placeholder) const {
 				if (value_arr.size() == 2) {
 					Variant v_key = value_arr[0];
 					String key = v_key;
-					if (key.left(1) == "\"" && key.right(key.length() - 1) == "\"") {
+					if (key.left(1) == "\"" && key.right(1) == "\"") {
 						key = key.substr(1, key.length() - 2);
 					}
 
 					Variant v_val = value_arr[1];
 					String val = v_val;
 
-					if (val.left(1) == "\"" && val.right(val.length() - 1) == "\"") {
+					if (val.left(1) == "\"" && val.right(1) == "\"") {
 						val = val.substr(1, val.length() - 2);
 					}
 
@@ -3336,7 +3336,7 @@ String String::format(const Variant &values, String placeholder) const {
 				Variant v_val = values_arr[i];
 				String val = v_val;
 
-				if (val.left(1) == "\"" && val.right(val.length() - 1) == "\"") {
+				if (val.left(1) == "\"" && val.right(1) == "\"") {
 					val = val.substr(1, val.length() - 2);
 				}
 
@@ -3356,11 +3356,11 @@ String String::format(const Variant &values, String placeholder) const {
 			String key = E->get();
 			String val = d[E->get()];
 
-			if (key.left(1) == "\"" && key.right(key.length() - 1) == "\"") {
+			if (key.left(1) == "\"" && key.right(1) == "\"") {
 				key = key.substr(1, key.length() - 2);
 			}
 
-			if (val.left(1) == "\"" && val.right(val.length() - 1) == "\"") {
+			if (val.left(1) == "\"" && val.right(1) == "\"") {
 				val = val.substr(1, val.length() - 2);
 			}
 
@@ -3463,28 +3463,28 @@ String String::repeat(int p_count) const {
 	return new_string;
 }
 
-String String::left(int p_pos) const {
-	if (p_pos <= 0) {
+String String::left(int p_count) const {
+	if (p_count <= 0) {
 		return "";
 	}
 
-	if (p_pos >= length()) {
+	if (p_count >= length()) {
 		return *this;
 	}
 
-	return substr(0, p_pos);
+	return substr(0, p_count);
 }
 
-String String::right(int p_pos) const {
-	if (p_pos >= length()) {
-		return "";
-	}
-
-	if (p_pos <= 0) {
+String String::right(int p_count) const {
+	if (p_count >= length()) {
 		return *this;
 	}
 
-	return substr(p_pos, (length() - p_pos));
+	if (p_count <= 0) {
+		return "";
+	}
+
+	return substr(length() - p_count);
 }
 
 char32_t String::unicode_at(int p_idx) const {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -356,8 +356,8 @@ public:
 	int count(const String &p_string, int p_from = 0, int p_to = 0) const;
 	int countn(const String &p_string, int p_from = 0, int p_to = 0) const;
 
-	String left(int p_pos) const;
-	String right(int p_pos) const;
+	String left(int p_count) const;
+	String right(int p_count) const;
 	String dedent() const;
 	String strip_edges(bool left = true, bool right = true) const;
 	String strip_escapes() const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1058,8 +1058,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, to_upper, sarray(), varray());
 	bind_method(String, to_lower, sarray(), varray());
 
-	bind_method(String, left, sarray("position"), varray());
-	bind_method(String, right, sarray("position"), varray());
+	bind_method(String, left, sarray("count"), varray());
+	bind_method(String, right, sarray("count"), varray());
 
 	bind_method(String, strip_edges, sarray("left", "right"), varray(true, true));
 	bind_method(String, strip_escapes, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -394,10 +394,10 @@
 		<method name="left" qualifiers="const">
 			<return type="String">
 			</return>
-			<argument index="0" name="position" type="int">
+			<argument index="0" name="count" type="int">
 			</argument>
 			<description>
-				Returns a number of characters from the left of the string.
+				Returns the first [code]count[/code] characters from the beginning of the string. Equivalent to [code]substr(0, count)[/code].
 			</description>
 		</method>
 		<method name="length" qualifiers="const">
@@ -669,7 +669,7 @@
 			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
-				Returns the right side of the string from a given position.
+				Returns the last [code]count[/code] characters from the end of the string. Equivalent to [code]substr(length() - count)[/code].
 			</description>
 		</method>
 		<method name="rpad" qualifiers="const">

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -198,7 +198,7 @@ String DirAccessWindows::get_current_dir(bool p_include_drive) {
 		if (_get_root_string() == "") {
 			int p = current_dir.find(":");
 			if (p != -1) {
-				return current_dir.right(p + 1);
+				return current_dir.substr(p + 1);
 			}
 		}
 		return current_dir;

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1008,7 +1008,7 @@ void CodeTextEditor::convert_indent_to_spaces() {
 				if (cursor_line == i && cursor_column > j) {
 					cursor_column += indent_size - 1;
 				}
-				line = line.left(j) + indent + line.right(j + 1);
+				line = line.left(j) + indent + line.substr(j + 1);
 			}
 			j++;
 		}
@@ -1052,7 +1052,7 @@ void CodeTextEditor::convert_indent_to_tabs() {
 					if (cursor_line == i && cursor_column > j) {
 						cursor_column -= indent_size;
 					}
-					line = line.left(j - indent_size) + "\t" + line.right(j + 1);
+					line = line.left(j - indent_size) + "\t" + line.substr(j + 1);
 					j = 0;
 					space_count = -1;
 				}
@@ -1110,7 +1110,7 @@ void CodeTextEditor::convert_case(CaseStyle p_case) {
 			new_line = text_editor->get_line(i).left(begin_col) + new_line;
 		}
 		if (i == end) {
-			new_line = new_line + text_editor->get_line(i).right(end_col);
+			new_line = new_line + text_editor->get_line(i).substr(end_col);
 		}
 		text_editor->set_line(i, new_line);
 	}

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -475,7 +475,7 @@ void EditorHelp::_update_doc() {
 			String linktxt = (cd.tutorials[i].title.is_empty()) ? link : DTR(cd.tutorials[i].title);
 			const int seppos = linktxt.find("//");
 			if (seppos != -1) {
-				linktxt = link.right(seppos + 2);
+				linktxt = link.substr(seppos + 2);
 			}
 
 			class_desc->push_color(symbol_color);

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -333,7 +333,7 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 				for (int i = 0; i < class_doc.methods.size(); i++) {
 					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.methods[i].name : class_doc.methods[i].name.to_lower();
 					if (method_name.find(term) > -1 ||
-							(term.begins_with(".") && method_name.begins_with(term.right(1))) ||
+							(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
 							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
 							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
 						match.methods.push_back(const_cast<DocData::MethodDoc *>(&class_doc.methods[i]));

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1805,12 +1805,12 @@ void EditorInspector::update_tree() {
 			basename = group + "/" + basename;
 		}
 
-		String name = (basename.find("/") != -1) ? basename.right(basename.rfind("/") + 1) : basename;
+		String name = (basename.find("/") != -1) ? basename.substr(basename.rfind("/") + 1) : basename;
 
 		if (capitalize_paths) {
 			int dot = name.find(".");
 			if (dot != -1) {
-				String ov = name.right(dot);
+				String ov = name.substr(dot);
 				name = name.substr(0, dot);
 				name = name.capitalize();
 				name += ov;

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -530,7 +530,7 @@ void FindInFilesDialog::_on_replace_text_entered(String text) {
 void FindInFilesDialog::_on_folder_selected(String path) {
 	int i = path.find("://");
 	if (i != -1) {
-		path = path.right(i + 3);
+		path = path.substr(i + 3);
 	}
 	_folder_line_edit->set_text(path);
 }
@@ -932,7 +932,7 @@ void FindInFilesPanel::apply_replaces_in_file(String fpath, const Vector<Result>
 			continue;
 		}
 
-		line = line.left(repl_begin) + new_text + line.right(repl_end);
+		line = line.left(repl_begin) + new_text + line.substr(repl_end);
 		// keep an offset in case there are successive replaces in the same line
 		offset += new_text.length() - (repl_end - repl_begin);
 	}

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -3432,7 +3432,7 @@ bool TilesetEditorContext::_set(const StringName &p_name, const Variant &p_value
 		tileset_editor->_set_snap_sep(snap);
 		return true;
 	} else if (p_name.operator String().left(5) == "tile_") {
-		String name2 = p_name.operator String().right(5);
+		String name2 = p_name.operator String().substr(5);
 		bool v = false;
 
 		if (tileset_editor->get_current_tile() < 0 || tileset.is_null()) {
@@ -3496,7 +3496,7 @@ bool TilesetEditorContext::_get(const StringName &p_name, Variant &r_ret) const 
 		r_ret = tileset_editor->snap_separation;
 		v = true;
 	} else if (name.left(5) == "tile_") {
-		name = name.right(5);
+		name = name.substr(5);
 
 		if (tileset_editor->get_current_tile() < 0 || tileset.is_null()) {
 			return false;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2121,8 +2121,8 @@ void ProjectManager::_run_project_confirm() {
 		const String &selected = selected_list[i].project_key;
 		String path = EditorSettings::get_singleton()->get("projects/" + selected);
 
-		// `.right(6)` on `IMPORTED_FILES_PATH` strips away the leading "res://".
-		if (!DirAccess::exists(path.plus_file(ProjectSettings::IMPORTED_FILES_PATH.right(6)))) {
+		// `.substr(6)` on `IMPORTED_FILES_PATH` strips away the leading "res://".
+		if (!DirAccess::exists(path.plus_file(ProjectSettings::IMPORTED_FILES_PATH.substr(6)))) {
 			run_error_diag->set_text(TTR("Can't run project: Assets need to be imported.\nPlease edit the project to trigger the initial import."));
 			run_error_diag->popup_centered();
 			continue;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2897,7 +2897,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				StringName parent = ClassDB::get_parent_class(class_name);
 				if (parent != StringName()) {
 					if (String(parent).begins_with("_")) {
-						base_type.native_type = String(parent).right(1);
+						base_type.native_type = String(parent).substr(1);
 					} else {
 						base_type.native_type = parent;
 					}
@@ -3090,7 +3090,7 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 
 							// proxy class remove the underscore.
 							if (r_result.class_name.begins_with("_")) {
-								r_result.class_name = r_result.class_name.right(1);
+								r_result.class_name = r_result.class_name.substr(1);
 							}
 							return OK;
 						}

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -664,7 +664,7 @@ static Vector<uint8_t> _parse_base64_uri(const String &uri) {
 	int start = uri.find(",");
 	ERR_FAIL_COND_V(start == -1, Vector<uint8_t>());
 
-	CharString substr = uri.right(start + 1).ascii();
+	CharString substr = uri.substr(start + 1).ascii();
 
 	int strlen = substr.length();
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -69,7 +69,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 			tile_set_tile_mode(id, AUTO_TILE);
 		}
 	} else if (what.left(9) == "autotile/") {
-		what = what.right(9);
+		what = what.substr(9);
 		if (what == "bitmask_mode") {
 			autotile_set_bitmask_mode(id, (BitmaskMode)((int)p_value));
 		} else if (what == "icon_coordinate") {
@@ -235,7 +235,7 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (what == "tile_mode") {
 		r_ret = tile_get_tile_mode(id);
 	} else if (what.left(9) == "autotile/") {
-		what = what.right(9);
+		what = what.substr(9);
 		if (what == "bitmask_mode") {
 			r_ret = autotile_get_bitmask_mode(id);
 		} else if (what == "icon_coordinate") {

--- a/tests/test_string.h
+++ b/tests/test_string.h
@@ -1240,8 +1240,7 @@ TEST_CASE("[String] Trim") {
 
 TEST_CASE("[String] Right/Left") {
 	String s = "aaaTestbbb";
-	//                ^
-	CHECK(s.right(6) == "tbbb");
+	CHECK(s.right(6) == "estbbb");
 	CHECK(s.left(6) == "aaaTes");
 }
 


### PR DESCRIPTION
As originally identified by @KoBeWi [here](https://github.com/godotengine/godot/issues/16863#issuecomment-419635744), `String.right(count)` doesn't behave as expected. Instead of returning the last `count` characters of a string, it currently behaves like `String.substr(position)`. This PR modifies the behaviour of `String.right(count)` to return the last `count` characters of a string i.e. `String.substr(length() - count)`.

Part of #16863.
