### PR TITLE
Fix for SkeletonIK not working correctly with 0 interpolation and incorrectly rotating with animation

### DIFF
--- a/scene/3d/skeleton_ik_3d.h
+++ b/scene/3d/skeleton_ik_3d.h
@@ -118,6 +118,8 @@ public:
 	static void set_goal(Task *p_task, const Transform &p_goal);
 	static void make_goal(Task *p_task, const Transform &p_inverse_transf, real_t blending_delta);
 	static void solve(Task *p_task, real_t blending_delta, bool override_tip_basis, bool p_use_magnet, const Vector3 &p_magnet_position);
+
+	static void _update_chain(const Skeleton3D *p_skeleton, ChainItem *p_chain_item);
 };
 
 class SkeletonIK3D : public Node {


### PR DESCRIPTION
Should close #47381

I know for sure this PR closes the issue with `0` interpolation not working correctly. I'm fairly confident that it will also fix the animation issue, as I removed a function that I thought was unnecessary but I think its removal was causing the issue.