### PR TITLE
Fix CONNECT_REFERENCE_COUNTED

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1355,7 +1355,7 @@ void Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 
 	if (!p_force) {
 		slot->reference_count--; // by default is zero, if it was not referenced it will go below it
-		if (slot->reference_count >= 0) {
+		if (slot->reference_count > 0) {
 			return;
 		}
 	}


### PR DESCRIPTION
`CONNECT_REFERENCE_COUNTED` requires 1 more `disconnect` call than `connect` calls. The PR fixes this behavior.

Minimal reproduction project:

[TestConnect.zip](https://github.com/godotengine/godot/files/6217692/TestConnect.zip)

_(just try to uncomment line 14)_

Closes #44584.