### PR TITLE
[macOS] Enable code signing by default, use ad-hoc signature if no identity specified.

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -155,7 +155,7 @@ void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/microphone_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need to use the microphone"), ""));
 
 #ifdef OSX_ENABLED
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/enable"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/enable"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/identity", PROPERTY_HINT_PLACEHOLDER_TEXT, "Type: Name (ID)"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/timestamp"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/hardened_runtime"), true));
@@ -487,7 +487,11 @@ Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_prese
 	}
 
 	args.push_back("-s");
-	args.push_back(p_preset->get("codesign/identity"));
+	if (p_preset->get("codesign/identity") == "") {
+		args.push_back("-");
+	} else {
+		args.push_back(p_preset->get("codesign/identity"));
+	}
 
 	args.push_back("-v"); /* provide some more feedback */
 
@@ -1060,12 +1064,6 @@ bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset
 	}
 
 	bool sign_enabled = p_preset->get("codesign/enable");
-	if (sign_enabled) {
-		if (p_preset->get("codesign/identity") == "") {
-			err += TTR("Codesign: identity not specified.") + "\n";
-			valid = false;
-		}
-	}
 	bool noto_enabled = p_preset->get("notarization/enable");
 	if (noto_enabled) {
 		if (!sign_enabled) {


### PR DESCRIPTION
- Enables export code signing by default.
- Allow ad-hoc signing if no identity is provided.