### PR TITLE
Rename LineEdit getters and setters to match property names

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -12,34 +12,25 @@
 		- [kbd]Ctrl + Z[/kbd]: Undo
 		- [kbd]Ctrl + ~[/kbd]: Swap input direction.
 		- [kbd]Ctrl + Shift + Z[/kbd]: Redo
-		- [kbd]Ctrl + U[/kbd]: Delete text from the cursor position to the beginning of the line
-		- [kbd]Ctrl + K[/kbd]: Delete text from the cursor position to the end of the line
+		- [kbd]Ctrl + U[/kbd]: Delete text from the caret position to the beginning of the line
+		- [kbd]Ctrl + K[/kbd]: Delete text from the caret position to the end of the line
 		- [kbd]Ctrl + A[/kbd]: Select all text
-		- [kbd]Up Arrow[/kbd]/[kbd]Down Arrow[/kbd]: Move the cursor to the beginning/end of the line
+		- [kbd]Up Arrow[/kbd]/[kbd]Down Arrow[/kbd]: Move the caret to the beginning/end of the line
 		On macOS, some extra keyboard shortcuts are available:
-		- [kbd]Ctrl + F[/kbd]: Same as [kbd]Right Arrow[/kbd], move the cursor one character right
-		- [kbd]Ctrl + B[/kbd]: Same as [kbd]Left Arrow[/kbd], move the cursor one character left
-		- [kbd]Ctrl + P[/kbd]: Same as [kbd]Up Arrow[/kbd], move the cursor to the previous line
-		- [kbd]Ctrl + N[/kbd]: Same as [kbd]Down Arrow[/kbd], move the cursor to the next line
-		- [kbd]Ctrl + D[/kbd]: Same as [kbd]Delete[/kbd], delete the character on the right side of cursor
-		- [kbd]Ctrl + H[/kbd]: Same as [kbd]Backspace[/kbd], delete the character on the left side of the cursor
-		- [kbd]Ctrl + A[/kbd]: Same as [kbd]Home[/kbd], move the cursor to the beginning of the line
-		- [kbd]Ctrl + E[/kbd]: Same as [kbd]End[/kbd], move the cursor to the end of the line
-		- [kbd]Cmd + Left Arrow[/kbd]: Same as [kbd]Home[/kbd], move the cursor to the beginning of the line
-		- [kbd]Cmd + Right Arrow[/kbd]: Same as [kbd]End[/kbd], move the cursor to the end of the line
+		- [kbd]Ctrl + F[/kbd]: Same as [kbd]Right Arrow[/kbd], move the caret one character right
+		- [kbd]Ctrl + B[/kbd]: Same as [kbd]Left Arrow[/kbd], move the caret one character left
+		- [kbd]Ctrl + P[/kbd]: Same as [kbd]Up Arrow[/kbd], move the caret to the previous line
+		- [kbd]Ctrl + N[/kbd]: Same as [kbd]Down Arrow[/kbd], move the caret to the next line
+		- [kbd]Ctrl + D[/kbd]: Same as [kbd]Delete[/kbd], delete the character on the right side of caret
+		- [kbd]Ctrl + H[/kbd]: Same as [kbd]Backspace[/kbd], delete the character on the left side of the caret
+		- [kbd]Ctrl + A[/kbd]: Same as [kbd]Home[/kbd], move the caret to the beginning of the line
+		- [kbd]Ctrl + E[/kbd]: Same as [kbd]End[/kbd], move the caret to the end of the line
+		- [kbd]Cmd + Left Arrow[/kbd]: Same as [kbd]Home[/kbd], move the caret to the beginning of the line
+		- [kbd]Cmd + Right Arrow[/kbd]: Same as [kbd]End[/kbd], move the caret to the end of the line
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="append_at_cursor">
-			<return type="void">
-			</return>
-			<argument index="0" name="text" type="String">
-			</argument>
-			<description>
-				Adds [code]text[/code] after the cursor. If the resulting value is longer than [member max_length], nothing happens.
-			</description>
-		</method>
 		<method name="clear">
 			<return type="void">
 			</return>
@@ -54,11 +45,11 @@
 				Removes all OpenType features.
 			</description>
 		</method>
-		<method name="delete_char_at_cursor">
+		<method name="delete_char_at_caret">
 			<return type="void">
 			</return>
 			<description>
-				Deletes one character at the cursor's current position (equivalent to pressing [kbd]Delete[/kbd]).
+				Deletes one character at the caret's current position (equivalent to pressing [kbd]Delete[/kbd]).
 			</description>
 		</method>
 		<method name="delete_text">
@@ -99,7 +90,16 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the scroll offset due to [member caret_position], as a number of characters.
+				Returns the scroll offset due to [member caret_column], as a number of characters.
+			</description>
+		</method>
+		<method name="insert_text_at_caret">
+			<return type="void">
+			</return>
+			<argument index="0" name="text" type="String">
+			</argument>
+			<description>
+				Inserts [code]text[/code] at the caret. If the resulting value is longer than [member max_length], nothing happens.
 			</description>
 		</method>
 		<method name="menu_option">
@@ -159,20 +159,20 @@
 		<member name="align" type="int" setter="set_align" getter="get_align" enum="LineEdit.Align" default="0">
 			Text alignment as defined in the [enum Align] enum.
 		</member>
-		<member name="caret_blink" type="bool" setter="cursor_set_blink_enabled" getter="cursor_get_blink_enabled" default="false">
-			If [code]true[/code], the caret (visual cursor) blinks.
+		<member name="caret_blink" type="bool" setter="set_caret_blink_enabled" getter="is_caret_blink_enabled" default="false">
+			If [code]true[/code], the caret (text cursor) blinks.
 		</member>
-		<member name="caret_blink_speed" type="float" setter="cursor_set_blink_speed" getter="cursor_get_blink_speed" default="0.65">
+		<member name="caret_blink_speed" type="float" setter="set_caret_blink_speed" getter="get_caret_blink_speed" default="0.65">
 			Duration (in seconds) of a caret's blinking cycle.
 		</member>
-		<member name="caret_force_displayed" type="bool" setter="cursor_set_force_displayed" getter="cursor_get_force_displayed" default="false">
+		<member name="caret_column" type="int" setter="set_caret_column" getter="get_caret_column" default="0">
+			The caret's column position inside the [LineEdit]. When set, the text may scroll to accommodate it.
 		</member>
-		<member name="caret_mid_grapheme" type="bool" setter="set_mid_grapheme_caret_enabled" getter="get_mid_grapheme_caret_enabled" default="false">
+		<member name="caret_force_displayed" type="bool" setter="set_caret_force_displayed" getter="is_caret_force_displayed" default="false">
+		</member>
+		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="false">
 			Allow moving caret, selecting and removing the individual composite character components.
 			Note: [kbd]Backspace[/kbd] is always removing individual composite character components.
-		</member>
-		<member name="caret_position" type="int" setter="set_cursor_position" getter="get_cursor_position" default="0">
-			The cursor's position inside the [LineEdit]. When set, the text may scroll to accommodate it.
 		</member>
 		<member name="clear_button_enabled" type="bool" setter="set_clear_button_enabled" getter="is_clear_button_enabled" default="false">
 			If [code]true[/code], the [LineEdit] will show a clear button if [code]text[/code] is not empty, which can be used to clear the text quickly.
@@ -186,7 +186,7 @@
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
 			If [code]false[/code], existing text cannot be modified and new text cannot be added.
 		</member>
-		<member name="expand_to_text_length" type="bool" setter="set_expand_to_text_length" getter="get_expand_to_text_length" default="false">
+		<member name="expand_to_text_length" type="bool" setter="set_expand_to_text_length_enabled" getter="is_expand_to_text_length_enabled" default="false">
 			If [code]true[/code], the [LineEdit] width will increase to stay longer than the [member text]. It will [b]not[/b] compress if the [member text] is shortened.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
@@ -276,7 +276,7 @@
 			Copies the selected text.
 		</constant>
 		<constant name="MENU_PASTE" value="2" enum="MenuItems">
-			Pastes the clipboard text over the selected text (or at the cursor's position).
+			Pastes the clipboard text over the selected text (or at the caret's position).
 			Non-printable escape characters are automatically stripped from the OS clipboard via [method String.strip_escapes].
 		</constant>
 		<constant name="MENU_CLEAR" value="3" enum="MenuItems">
@@ -359,6 +359,9 @@
 		</constant>
 	</constants>
 	<theme_items>
+		<theme_item name="caret_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+			Color of the [LineEdit]'s caret (text cursor).
+		</theme_item>
 		<theme_item name="clear" type="Texture2D">
 			Texture for the clear button. See [member clear_button_enabled].
 		</theme_item>
@@ -367,9 +370,6 @@
 		</theme_item>
 		<theme_item name="clear_button_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
 			Color used for the clear button when it's pressed.
-		</theme_item>
-		<theme_item name="cursor_color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
-			Color of the [LineEdit]'s visual cursor (caret).
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
 			Background used when [LineEdit] has GUI focus.

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2734,7 +2734,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		path_popup->set_size(path_rect.size);
 		path_popup->popup();
 		path->grab_focus();
-		path->set_cursor_position(path->get_text().length());
+		path->set_caret_column(path->get_text().length());
 		clicking_on_name = false;
 	}
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -488,10 +488,10 @@ void FindReplaceBar::_show_search(bool p_focus_replace, bool p_show_only) {
 	if (!get_search_text().is_empty()) {
 		if (p_focus_replace) {
 			replace_text->select_all();
-			replace_text->set_cursor_position(replace_text->get_text().length());
+			replace_text->set_caret_column(replace_text->get_text().length());
 		} else {
 			search_text->select_all();
-			search_text->set_cursor_position(search_text->get_text().length());
+			search_text->set_caret_column(search_text->get_text().length());
 		}
 
 		results_count = -1;

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1801,7 +1801,7 @@ void FindBar::popup_search() {
 
 	if (!search_text->get_text().is_empty()) {
 		search_text->select_all();
-		search_text->set_cursor_position(search_text->get_text().length());
+		search_text->set_caret_column(search_text->get_text().length());
 		if (grabbed_focus) {
 			_search();
 		}

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -963,7 +963,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("read_only", "LineEdit", font_disabled_color);
 	theme->set_color("font_color", "LineEdit", font_color);
 	theme->set_color("font_selected_color", "LineEdit", mono_color);
-	theme->set_color("cursor_color", "LineEdit", font_color);
+	theme->set_color("caret_color", "LineEdit", font_color);
 	theme->set_color("selection_color", "LineEdit", selection_color);
 	theme->set_color("clear_button_color", "LineEdit", font_color);
 	theme->set_color("clear_button_color_pressed", "LineEdit", accent_color);

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -698,7 +698,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 		max_value->set_step(0.01);
 
 		label_value = memnew(LineEdit);
-		label_value->set_expand_to_text_length(true);
+		label_value->set_expand_to_text_length_enabled(true);
 
 		// now add
 

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -942,7 +942,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 		left_vbox->add_spacer();
 		label_y = memnew(LineEdit);
 		left_vbox->add_child(label_y);
-		label_y->set_expand_to_text_length(true);
+		label_y->set_expand_to_text_length_enabled(true);
 		left_vbox->add_spacer();
 		min_y_value = memnew(SpinBox);
 		left_vbox->add_child(min_y_value);
@@ -978,7 +978,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 		bottom_vbox->add_spacer();
 		label_x = memnew(LineEdit);
 		bottom_vbox->add_child(label_x);
-		label_x->set_expand_to_text_length(true);
+		label_x->set_expand_to_text_length_enabled(true);
 		bottom_vbox->add_spacer();
 		max_x_value = memnew(SpinBox);
 		bottom_vbox->add_child(max_x_value);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -136,7 +136,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 		if (String(E->get()) != "output") {
 			LineEdit *name = memnew(LineEdit);
 			name->set_text(E->get());
-			name->set_expand_to_text_length(true);
+			name->set_expand_to_text_length_enabled(true);
 			node->add_child(name);
 			node->set_slot(0, false, 0, Color(), true, 0, get_theme_color("font_color", "Label"));
 			name->connect("text_entered", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed), varray(agnode), CONNECT_DEFERRED);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3671,7 +3671,7 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	comment_title_change_popup = memnew(PopupPanel);
 	comment_title_change_edit = memnew(LineEdit);
-	comment_title_change_edit->set_expand_to_text_length(true);
+	comment_title_change_edit->set_expand_to_text_length_enabled(true);
 	comment_title_change_edit->connect("text_changed", callable_mp(this, &VisualShaderEditor::_comment_title_text_changed));
 	comment_title_change_edit->connect("text_entered", callable_mp(this, &VisualShaderEditor::_comment_title_text_entered));
 	comment_title_change_popup->add_child(comment_title_change_edit);

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -632,7 +632,7 @@ void RenameDialog::_insert_text(String text) {
 
 	if (_is_main_field(focus_owner)) {
 		focus_owner->selection_delete();
-		focus_owner->append_at_cursor(text);
+		focus_owner->insert_text_at_caret(text);
 		_update_preview();
 	}
 }

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -87,8 +87,8 @@ void ScriptCreateDialog::_path_hbox_sorted() {
 
 		// First set cursor to the end of line to scroll LineEdit view
 		// to the right and then set the actual cursor position.
-		file_path->set_cursor_position(file_path->get_text().length());
-		file_path->set_cursor_position(filename_start_pos);
+		file_path->set_caret_column(file_path->get_text().length());
+		file_path->set_caret_column(filename_start_pos);
 
 		file_path->grab_focus();
 	}
@@ -557,7 +557,7 @@ void ScriptCreateDialog::_file_selected(const String &p_file) {
 		String filename = p.get_file().get_basename();
 		int select_start = p.rfind(filename);
 		file_path->select(select_start, select_start + filename.length());
-		file_path->set_cursor_position(select_start + filename.length());
+		file_path->set_caret_column(select_start + filename.length());
 		file_path->grab_focus();
 	}
 }

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -710,7 +710,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			has_gnode_text = true;
 			LineEdit *line_edit = memnew(LineEdit);
 			line_edit->set_text(node->get_text());
-			line_edit->set_expand_to_text_length(true);
+			line_edit->set_expand_to_text_length_enabled(true);
 			line_edit->add_theme_font_override("font", get_theme_font("source", "EditorFonts"));
 			gnode->add_child(line_edit);
 			line_edit->connect("text_changed", callable_mp(this, &VisualScriptEditor::_expression_text_changed), varray(E->get()));
@@ -843,7 +843,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 						hbc->add_child(name_box);
 						name_box->set_custom_minimum_size(Size2(60 * EDSCALE, 0));
 						name_box->set_text(left_name);
-						name_box->set_expand_to_text_length(true);
+						name_box->set_expand_to_text_length_enabled(true);
 						name_box->connect("resized", callable_mp(this, &VisualScriptEditor::_update_node_size), varray(E->get()));
 						name_box->connect("focus_exited", callable_mp(this, &VisualScriptEditor::_port_name_focus_out), varray(name_box, E->get(), i, true));
 					} else {
@@ -938,7 +938,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 						hbc->add_child(name_box);
 						name_box->set_custom_minimum_size(Size2(60 * EDSCALE, 0));
 						name_box->set_text(right_name);
-						name_box->set_expand_to_text_length(true);
+						name_box->set_expand_to_text_length_enabled(true);
 						name_box->connect("resized", callable_mp(this, &VisualScriptEditor::_update_node_size), varray(E->get()));
 						name_box->connect("focus_exited", callable_mp(this, &VisualScriptEditor::_port_name_focus_out), varray(name_box, E->get(), i, false));
 					} else {
@@ -4322,7 +4322,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	function_name_box = memnew(LineEdit);
 	function_name_edit->add_child(function_name_box);
 	function_name_box->connect("gui_input", callable_mp(this, &VisualScriptEditor::_fn_name_box_input));
-	function_name_box->set_expand_to_text_length(true);
+	function_name_box->set_expand_to_text_length_enabled(true);
 	add_child(function_name_edit);
 
 	///       Actual Graph          ///

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -51,13 +51,13 @@ void LineEdit::_swap_current_input_direction() {
 	} else {
 		input_direction = TEXT_DIRECTION_LTR;
 	}
-	set_cursor_position(get_cursor_position());
+	set_caret_column(get_caret_column());
 	update();
 }
 
-void LineEdit::_move_cursor_left(bool p_select, bool p_move_by_word) {
+void LineEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
 	if (selection.enabled && !p_select) {
-		set_cursor_position(selection.begin);
+		set_caret_column(selection.begin);
 		deselect();
 		return;
 	}
@@ -65,7 +65,7 @@ void LineEdit::_move_cursor_left(bool p_select, bool p_move_by_word) {
 	shift_selection_check_pre(p_select);
 
 	if (p_move_by_word) {
-		int cc = cursor_pos;
+		int cc = caret_column;
 
 		Vector<Vector2i> words = TS->shaped_text_get_word_breaks(text_rid);
 		for (int i = words.size() - 1; i >= 0; i--) {
@@ -75,21 +75,21 @@ void LineEdit::_move_cursor_left(bool p_select, bool p_move_by_word) {
 			}
 		}
 
-		set_cursor_position(cc);
+		set_caret_column(cc);
 	} else {
-		if (mid_grapheme_caret_enabled) {
-			set_cursor_position(get_cursor_position() - 1);
+		if (caret_mid_grapheme_enabled) {
+			set_caret_column(get_caret_column() - 1);
 		} else {
-			set_cursor_position(TS->shaped_text_prev_grapheme_pos(text_rid, get_cursor_position()));
+			set_caret_column(TS->shaped_text_prev_grapheme_pos(text_rid, get_caret_column()));
 		}
 	}
 
 	shift_selection_check_post(p_select);
 }
 
-void LineEdit::_move_cursor_right(bool p_select, bool p_move_by_word) {
+void LineEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
 	if (selection.enabled && !p_select) {
-		set_cursor_position(selection.end);
+		set_caret_column(selection.end);
 		deselect();
 		return;
 	}
@@ -97,7 +97,7 @@ void LineEdit::_move_cursor_right(bool p_select, bool p_move_by_word) {
 	shift_selection_check_pre(p_select);
 
 	if (p_move_by_word) {
-		int cc = cursor_pos;
+		int cc = caret_column;
 
 		Vector<Vector2i> words = TS->shaped_text_get_word_breaks(text_rid);
 		for (int i = 0; i < words.size(); i++) {
@@ -107,27 +107,27 @@ void LineEdit::_move_cursor_right(bool p_select, bool p_move_by_word) {
 			}
 		}
 
-		set_cursor_position(cc);
+		set_caret_column(cc);
 	} else {
-		if (mid_grapheme_caret_enabled) {
-			set_cursor_position(get_cursor_position() + 1);
+		if (caret_mid_grapheme_enabled) {
+			set_caret_column(get_caret_column() + 1);
 		} else {
-			set_cursor_position(TS->shaped_text_next_grapheme_pos(text_rid, get_cursor_position()));
+			set_caret_column(TS->shaped_text_next_grapheme_pos(text_rid, get_caret_column()));
 		}
 	}
 
 	shift_selection_check_post(p_select);
 }
 
-void LineEdit::_move_cursor_start(bool p_select) {
+void LineEdit::_move_caret_start(bool p_select) {
 	shift_selection_check_pre(p_select);
-	set_cursor_position(0);
+	set_caret_column(0);
 	shift_selection_check_post(p_select);
 }
 
-void LineEdit::_move_cursor_end(bool p_select) {
+void LineEdit::_move_caret_end(bool p_select) {
 	shift_selection_check_pre(p_select);
-	set_cursor_position(text.length());
+	set_caret_column(text.length());
 	shift_selection_check_post(p_select);
 }
 
@@ -138,7 +138,7 @@ void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
 
 	if (p_all_to_left) {
 		deselect();
-		text = text.substr(0, cursor_pos);
+		text = text.substr(0, caret_column);
 		_text_changed();
 		return;
 	}
@@ -149,7 +149,7 @@ void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
 	}
 
 	if (p_word) {
-		int cc = cursor_pos;
+		int cc = caret_column;
 
 		Vector<Vector2i> words = TS->shaped_text_get_word_breaks(text_rid);
 		for (int i = words.size() - 1; i >= 0; i--) {
@@ -158,9 +158,9 @@ void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
 			}
 		}
 
-		delete_text(cc, cursor_pos);
+		delete_text(cc, caret_column);
 
-		set_cursor_position(cc);
+		set_caret_column(cc);
 	} else {
 		delete_char();
 	}
@@ -173,9 +173,9 @@ void LineEdit::_delete(bool p_word, bool p_all_to_right) {
 
 	if (p_all_to_right) {
 		deselect();
-		text = text.substr(cursor_pos, text.length() - cursor_pos);
+		text = text.substr(caret_column, text.length() - caret_column);
 		_shape();
-		set_cursor_position(0);
+		set_caret_column(0);
 		_text_changed();
 		return;
 	}
@@ -187,12 +187,12 @@ void LineEdit::_delete(bool p_word, bool p_all_to_right) {
 
 	int text_len = text.length();
 
-	if (cursor_pos == text_len) {
+	if (caret_column == text_len) {
 		return; // Nothing to do.
 	}
 
 	if (p_word) {
-		int cc = cursor_pos;
+		int cc = caret_column;
 		Vector<Vector2i> words = TS->shaped_text_get_word_breaks(text_rid);
 		for (int i = 0; i < words.size(); i++) {
 			if (words[i].y > cc) {
@@ -201,15 +201,15 @@ void LineEdit::_delete(bool p_word, bool p_all_to_right) {
 			}
 		}
 
-		delete_text(cursor_pos, cc);
+		delete_text(caret_column, cc);
 	} else {
-		if (mid_grapheme_caret_enabled) {
-			set_cursor_position(cursor_pos + 1);
+		if (caret_mid_grapheme_enabled) {
+			set_caret_column(caret_column + 1);
 			delete_char();
 		} else {
-			int cc = cursor_pos;
-			set_cursor_position(TS->shaped_text_next_grapheme_pos(text_rid, cursor_pos));
-			delete_text(cc, cursor_pos);
+			int cc = caret_column;
+			set_caret_column(TS->shaped_text_next_grapheme_pos(text_rid, caret_column));
+			delete_text(cc, caret_column);
 		}
 	}
 }
@@ -250,10 +250,10 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 			shift_selection_check_pre(b->get_shift());
 
-			set_cursor_at_pixel_pos(b->get_position().x);
+			set_caret_at_pixel_pos(b->get_position().x);
 
 			if (b->get_shift()) {
-				selection_fill_at_cursor();
+				selection_fill_at_caret();
 				selection.creating = true;
 
 			} else {
@@ -265,18 +265,18 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 						selection.end = text.length();
 						selection.doubleclick = true;
 						selection.last_dblclk = 0;
-						cursor_pos = selection.begin;
+						caret_column = selection.begin;
 					} else if (b->is_doubleclick()) {
 						// Double-click select word.
 						Vector<Vector2i> words = TS->shaped_text_get_word_breaks(text_rid);
 						for (int i = 0; i < words.size(); i++) {
-							if (words[i].x < cursor_pos && words[i].y > cursor_pos) {
+							if (words[i].x < caret_column && words[i].y > caret_column) {
 								selection.enabled = true;
 								selection.begin = words[i].x;
 								selection.end = words[i].y;
 								selection.doubleclick = true;
 								selection.last_dblclk = OS::get_singleton()->get_ticks_msec();
-								cursor_pos = selection.end;
+								caret_column = selection.end;
 								break;
 							}
 						}
@@ -285,9 +285,9 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 				selection.drag_attempt = false;
 
-				if ((cursor_pos < selection.begin) || (cursor_pos > selection.end) || !selection.enabled) {
+				if ((caret_column < selection.begin) || (caret_column > selection.end) || !selection.enabled) {
 					deselect();
-					selection.cursor_start = cursor_pos;
+					selection.start_column = caret_column;
 					selection.creating = true;
 				} else if (selection.enabled) {
 					selection.drag_attempt = true;
@@ -331,8 +331,8 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 		if (m->get_button_mask() & MOUSE_BUTTON_LEFT) {
 			if (selection.creating) {
-				set_cursor_at_pixel_pos(m->get_position().x);
-				selection_fill_at_cursor();
+				set_caret_at_pixel_pos(m->get_position().x);
+				selection_fill_at_caret();
 			}
 		}
 	}
@@ -346,7 +346,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 		if (context_menu_enabled) {
 			if (k->is_action("ui_menu", true)) {
-				Point2 pos = Point2(get_cursor_pixel_pos().x, (get_size().y + get_theme_font("font")->get_height(get_theme_font_size("font_size"))) / 2);
+				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + get_theme_font("font")->get_height(get_theme_font_size("font_size"))) / 2);
 				menu->set_position(get_global_transform().xform(pos));
 				menu->set_size(Vector2(1, 1));
 				_generate_context_menu();
@@ -445,34 +445,34 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 		k->set_shift(false);
 
 		if (k->is_action("ui_text_caret_word_left", true)) {
-			_move_cursor_left(shift_pressed, true);
+			_move_caret_left(shift_pressed, true);
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_text_caret_left", true)) {
-			_move_cursor_left(shift_pressed);
+			_move_caret_left(shift_pressed);
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_text_caret_word_right", true)) {
-			_move_cursor_right(shift_pressed, true);
+			_move_caret_right(shift_pressed, true);
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_text_caret_right", true)) {
-			_move_cursor_right(shift_pressed, false);
+			_move_caret_right(shift_pressed, false);
 			accept_event();
 			return;
 		}
 
 		// Up = Home, Down = End
 		if (k->is_action("ui_text_caret_up", true) || k->is_action("ui_text_caret_line_start", true) || k->is_action("ui_text_caret_page_up", true)) {
-			_move_cursor_start(shift_pressed);
+			_move_caret_start(shift_pressed);
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_text_caret_down", true) || k->is_action("ui_text_caret_line_end", true) || k->is_action("ui_text_caret_page_down", true)) {
-			_move_cursor_end(shift_pressed);
+			_move_caret_end(shift_pressed);
 			accept_event();
 			return;
 		}
@@ -495,7 +495,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 			selection_delete();
 			char32_t ucodestr[2] = { (char32_t)k->get_unicode(), 0 };
 			int prev_len = text.length();
-			append_at_cursor(ucodestr);
+			insert_text_at_caret(ucodestr);
 			if (text.length() != prev_len) {
 				_text_changed();
 			}
@@ -542,15 +542,15 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 	Control::drop_data(p_point, p_data);
 
 	if (p_data.get_type() == Variant::STRING) {
-		set_cursor_at_pixel_pos(p_point.x);
+		set_caret_at_pixel_pos(p_point.x);
 		int selected = selection.end - selection.begin;
 
 		text.erase(selection.begin, selected);
 		_shape();
 
-		append_at_cursor(p_data);
-		selection.begin = cursor_pos - selected;
-		selection.end = cursor_pos;
+		insert_text_at_caret(p_data);
+		selection.begin = caret_column - selected;
+		selection.end = caret_column;
 	}
 }
 
@@ -575,8 +575,8 @@ void LineEdit::_notification(int p_what) {
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_ENTER_TREE: {
 			if (Engine::get_singleton()->is_editor_hint() && !get_tree()->is_node_being_edited(this)) {
-				cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
-				cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
+				set_caret_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
+				set_caret_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
 
 				if (!EditorSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed))) {
 					EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed));
@@ -587,7 +587,7 @@ void LineEdit::_notification(int p_what) {
 		case NOTIFICATION_RESIZED: {
 			_fit_to_width();
 			scroll_offset = 0;
-			set_cursor_position(get_cursor_position());
+			set_caret_column(get_caret_column());
 		} break;
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
@@ -674,7 +674,7 @@ void LineEdit::_notification(int p_what) {
 			Color selection_color = get_theme_color("selection_color");
 			Color font_color = is_editable() ? get_theme_color("font_color") : get_theme_color("font_uneditable_color");
 			Color font_selected_color = get_theme_color("font_selected_color");
-			Color cursor_color = get_theme_color("cursor_color");
+			Color caret_color = get_theme_color("caret_color");
 
 			// Draw placeholder color.
 			if (using_placeholder) {
@@ -778,7 +778,7 @@ void LineEdit::_notification(int p_what) {
 					// Normal caret.
 					Rect2 l_caret, t_caret;
 					TextServer::Direction l_dir, t_dir;
-					TS->shaped_text_get_carets(text_rid, cursor_pos, l_caret, l_dir, t_caret, t_dir);
+					TS->shaped_text_get_carets(text_rid, caret_column, l_caret, l_dir, t_caret, t_dir);
 
 					if (l_caret == Rect2() && t_caret == Rect2()) {
 						// No carets, add one at the start.
@@ -791,28 +791,28 @@ void LineEdit::_notification(int p_what) {
 							l_dir = TextServer::DIRECTION_LTR;
 							l_caret = Rect2(Vector2(x_ofs, y), Size2(caret_width, h));
 						}
-						RenderingServer::get_singleton()->canvas_item_add_rect(ci, l_caret, cursor_color);
+						RenderingServer::get_singleton()->canvas_item_add_rect(ci, l_caret, caret_color);
 					} else {
 						if (l_caret != Rect2() && l_dir == TextServer::DIRECTION_AUTO) {
 							// Draw extra marker on top of mid caret.
 							Rect2 trect = Rect2(l_caret.position.x - 3 * caret_width, l_caret.position.y, 6 * caret_width, caret_width);
 							trect.position += ofs;
-							RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, cursor_color);
+							RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
 						}
 
 						l_caret.position += ofs;
 						l_caret.size.x = caret_width;
-						RenderingServer::get_singleton()->canvas_item_add_rect(ci, l_caret, cursor_color);
+						RenderingServer::get_singleton()->canvas_item_add_rect(ci, l_caret, caret_color);
 
 						t_caret.position += ofs;
 						t_caret.size.x = caret_width;
 
-						RenderingServer::get_singleton()->canvas_item_add_rect(ci, t_caret, cursor_color);
+						RenderingServer::get_singleton()->canvas_item_add_rect(ci, t_caret, caret_color);
 					}
 				} else {
 					{
 						// IME intermediate text range.
-						Vector<Vector2> sel = TS->shaped_text_get_selection(text_rid, cursor_pos, cursor_pos + ime_text.length());
+						Vector<Vector2> sel = TS->shaped_text_get_selection(text_rid, caret_column, caret_column + ime_text.length());
 						for (int i = 0; i < sel.size(); i++) {
 							Rect2 rect = Rect2(sel[i].x + ofs.x, ofs.y, sel[i].y - sel[i].x, text_height);
 							if (rect.position.x + rect.size.x <= x_ofs || rect.position.x > ofs_max) {
@@ -825,12 +825,12 @@ void LineEdit::_notification(int p_what) {
 								rect.size.x = ofs_max - rect.position.x;
 							}
 							rect.size.y = caret_width;
-							RenderingServer::get_singleton()->canvas_item_add_rect(ci, rect, cursor_color);
+							RenderingServer::get_singleton()->canvas_item_add_rect(ci, rect, caret_color);
 						}
 					}
 					{
 						// IME caret.
-						Vector<Vector2> sel = TS->shaped_text_get_selection(text_rid, cursor_pos + ime_selection.x, cursor_pos + ime_selection.x + ime_selection.y);
+						Vector<Vector2> sel = TS->shaped_text_get_selection(text_rid, caret_column + ime_selection.x, caret_column + ime_selection.x + ime_selection.y);
 						for (int i = 0; i < sel.size(); i++) {
 							Rect2 rect = Rect2(sel[i].x + ofs.x, ofs.y, sel[i].y - sel[i].x, text_height);
 							if (rect.position.x + rect.size.x <= x_ofs || rect.position.x > ofs_max) {
@@ -843,7 +843,7 @@ void LineEdit::_notification(int p_what) {
 								rect.size.x = ofs_max - rect.position.x;
 							}
 							rect.size.y = caret_width * 3;
-							RenderingServer::get_singleton()->canvas_item_add_rect(ci, rect, cursor_color);
+							RenderingServer::get_singleton()->canvas_item_add_rect(ci, rect, caret_color);
 						}
 					}
 				}
@@ -869,8 +869,8 @@ void LineEdit::_notification(int p_what) {
 
 			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 				DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
-				Point2 cursor_pos = Point2(get_cursor_position(), 1) * get_minimum_size().height;
-				DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + cursor_pos, get_viewport()->get_window_id());
+				Point2 caret_column = Point2(get_caret_column(), 1) * get_minimum_size().height;
+				DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + caret_column, get_viewport()->get_window_id());
 			}
 
 			show_virtual_keyboard();
@@ -887,7 +887,7 @@ void LineEdit::_notification(int p_what) {
 			ime_text = "";
 			ime_selection = Point2();
 			_shape();
-			set_cursor_position(cursor_pos); // Update scroll_offset
+			set_caret_column(caret_column); // Update scroll_offset
 
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
 				DisplayServer::get_singleton()->virtual_keyboard_hide();
@@ -899,7 +899,7 @@ void LineEdit::_notification(int p_what) {
 				ime_text = DisplayServer::get_singleton()->ime_get_text();
 				ime_selection = DisplayServer::get_singleton()->ime_get_selection();
 				_shape();
-				set_cursor_position(cursor_pos); // Update scroll_offset
+				set_caret_column(caret_column); // Update scroll_offset
 
 				update();
 			}
@@ -933,7 +933,7 @@ void LineEdit::paste_text() {
 		if (selection.enabled) {
 			selection_delete();
 		}
-		append_at_cursor(paste_buffer);
+		insert_text_at_caret(paste_buffer);
 
 		if (!text_changed_dirty) {
 			if (is_inside_tree() && text.length() != prev_len) {
@@ -961,7 +961,7 @@ void LineEdit::undo() {
 	TextOperation op = undo_stack_pos->get();
 	text = op.text;
 	scroll_offset = op.scroll_offset;
-	set_cursor_position(op.cursor_pos);
+	set_caret_column(op.caret_column);
 
 	_shape();
 	_emit_text_change();
@@ -982,7 +982,7 @@ void LineEdit::redo() {
 	TextOperation op = undo_stack_pos->get();
 	text = op.text;
 	scroll_offset = op.scroll_offset;
-	set_cursor_position(op.cursor_pos);
+	set_caret_column(op.caret_column);
 
 	_shape();
 	_emit_text_change();
@@ -990,7 +990,7 @@ void LineEdit::redo() {
 
 void LineEdit::shift_selection_check_pre(bool p_shift) {
 	if (!selection.enabled && p_shift) {
-		selection.cursor_start = cursor_pos;
+		selection.start_column = caret_column;
 	}
 	if (!p_shift) {
 		deselect();
@@ -999,11 +999,11 @@ void LineEdit::shift_selection_check_pre(bool p_shift) {
 
 void LineEdit::shift_selection_check_post(bool p_shift) {
 	if (p_shift) {
-		selection_fill_at_cursor();
+		selection_fill_at_caret();
 	}
 }
 
-void LineEdit::set_cursor_at_pixel_pos(int p_x) {
+void LineEdit::set_caret_at_pixel_pos(int p_x) {
 	Ref<StyleBox> style = get_theme_stylebox("normal");
 	bool rtl = is_layout_rtl();
 
@@ -1048,10 +1048,10 @@ void LineEdit::set_cursor_at_pixel_pos(int p_x) {
 	}
 
 	int ofs = TS->shaped_text_hit_test_position(text_rid, p_x - x_ofs - scroll_offset);
-	set_cursor_position(ofs);
+	set_caret_column(ofs);
 }
 
-Vector2i LineEdit::get_cursor_pixel_pos() {
+Vector2i LineEdit::get_caret_pixel_pos() {
 	Ref<StyleBox> style = get_theme_stylebox("normal");
 	bool rtl = is_layout_rtl();
 
@@ -1100,9 +1100,9 @@ Vector2i LineEdit::get_cursor_pixel_pos() {
 	TextServer::Direction l_dir, t_dir;
 	// Get position of the start of caret.
 	if (ime_text.length() != 0 && ime_selection.x != 0) {
-		TS->shaped_text_get_carets(text_rid, cursor_pos + ime_selection.x, l_caret, l_dir, t_caret, t_dir);
+		TS->shaped_text_get_carets(text_rid, caret_column + ime_selection.x, l_caret, l_dir, t_caret, t_dir);
 	} else {
-		TS->shaped_text_get_carets(text_rid, cursor_pos, l_caret, l_dir, t_caret, t_dir);
+		TS->shaped_text_get_carets(text_rid, caret_column, l_caret, l_dir, t_caret, t_dir);
 	}
 
 	if ((l_caret != Rect2() && (l_dir == TextServer::DIRECTION_AUTO || l_dir == (TextServer::Direction)input_direction)) || (t_caret == Rect2())) {
@@ -1114,9 +1114,9 @@ Vector2i LineEdit::get_cursor_pixel_pos() {
 	// Get position of the end of caret.
 	if (ime_text.length() != 0) {
 		if (ime_selection.y != 0) {
-			TS->shaped_text_get_carets(text_rid, cursor_pos + ime_selection.x + ime_selection.y, l_caret, l_dir, t_caret, t_dir);
+			TS->shaped_text_get_carets(text_rid, caret_column + ime_selection.x + ime_selection.y, l_caret, l_dir, t_caret, t_dir);
 		} else {
-			TS->shaped_text_get_carets(text_rid, cursor_pos + ime_text.size(), l_caret, l_dir, t_caret, t_dir);
+			TS->shaped_text_get_carets(text_rid, caret_column + ime_text.size(), l_caret, l_dir, t_caret, t_dir);
 		}
 		if ((l_caret != Rect2() && (l_dir == TextServer::DIRECTION_AUTO || l_dir == (TextServer::Direction)input_direction)) || (t_caret == Rect2())) {
 			ret.y = x_ofs + l_caret.position.x + scroll_offset;
@@ -1130,19 +1130,19 @@ Vector2i LineEdit::get_cursor_pixel_pos() {
 	return ret;
 }
 
-void LineEdit::set_mid_grapheme_caret_enabled(const bool p_enabled) {
-	mid_grapheme_caret_enabled = p_enabled;
+void LineEdit::set_caret_mid_grapheme_enabled(const bool p_enabled) {
+	caret_mid_grapheme_enabled = p_enabled;
 }
 
-bool LineEdit::get_mid_grapheme_caret_enabled() const {
-	return mid_grapheme_caret_enabled;
+bool LineEdit::is_caret_mid_grapheme_enabled() const {
+	return caret_mid_grapheme_enabled;
 }
 
-bool LineEdit::cursor_get_blink_enabled() const {
+bool LineEdit::is_caret_blink_enabled() const {
 	return caret_blink_enabled;
 }
 
-void LineEdit::cursor_set_blink_enabled(const bool p_enabled) {
+void LineEdit::set_caret_blink_enabled(const bool p_enabled) {
 	caret_blink_enabled = p_enabled;
 
 	if (has_focus() || caret_force_displayed) {
@@ -1160,21 +1160,21 @@ void LineEdit::cursor_set_blink_enabled(const bool p_enabled) {
 	notify_property_list_changed();
 }
 
-bool LineEdit::cursor_get_force_displayed() const {
+bool LineEdit::is_caret_force_displayed() const {
 	return caret_force_displayed;
 }
 
-void LineEdit::cursor_set_force_displayed(const bool p_enabled) {
+void LineEdit::set_caret_force_displayed(const bool p_enabled) {
 	caret_force_displayed = p_enabled;
-	cursor_set_blink_enabled(caret_blink_enabled);
+	set_caret_blink_enabled(caret_blink_enabled);
 	update();
 }
 
-float LineEdit::cursor_get_blink_speed() const {
+float LineEdit::get_caret_blink_speed() const {
 	return caret_blink_timer->get_wait_time();
 }
 
-void LineEdit::cursor_set_blink_speed(const float p_speed) {
+void LineEdit::set_caret_blink_speed(const float p_speed) {
 	ERR_FAIL_COND(p_speed <= 0);
 	caret_blink_timer->set_wait_time(p_speed);
 }
@@ -1198,14 +1198,14 @@ void LineEdit::_toggle_draw_caret() {
 }
 
 void LineEdit::delete_char() {
-	if ((text.length() <= 0) || (cursor_pos == 0)) {
+	if ((text.length() <= 0) || (caret_column == 0)) {
 		return;
 	}
 
-	text.erase(cursor_pos - 1, 1);
+	text.erase(caret_column - 1, 1);
 	_shape();
 
-	set_cursor_position(get_cursor_position() - 1);
+	set_caret_column(get_caret_column() - 1);
 
 	_text_changed();
 }
@@ -1217,10 +1217,10 @@ void LineEdit::delete_text(int p_from_column, int p_to_column) {
 	text.erase(p_from_column, p_to_column - p_from_column);
 	_shape();
 
-	cursor_pos -= CLAMP(cursor_pos - p_from_column, 0, p_to_column - p_from_column);
+	caret_column -= CLAMP(caret_column - p_from_column, 0, p_to_column - p_from_column);
 
-	if (cursor_pos >= text.length()) {
-		cursor_pos = text.length();
+	if (caret_column >= text.length()) {
+		caret_column = text.length();
 	}
 
 	if (!text_changed_dirty) {
@@ -1233,11 +1233,11 @@ void LineEdit::delete_text(int p_from_column, int p_to_column) {
 
 void LineEdit::set_text(String p_text) {
 	clear_internal();
-	append_at_cursor(p_text);
+	insert_text_at_caret(p_text);
 	_create_undo_state();
 
 	update();
-	cursor_pos = 0;
+	caret_column = 0;
 	scroll_offset = 0;
 }
 
@@ -1347,7 +1347,7 @@ void LineEdit::show_virtual_keyboard() {
 		if (selection.enabled) {
 			DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), false, max_length, selection.begin, selection.end);
 		} else {
-			DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), false, max_length, cursor_pos);
+			DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), false, max_length, caret_column);
 		}
 	}
 }
@@ -1376,16 +1376,16 @@ float LineEdit::get_placeholder_alpha() const {
 	return placeholder_alpha;
 }
 
-void LineEdit::set_cursor_position(int p_pos) {
-	if (p_pos > (int)text.length()) {
-		p_pos = text.length();
+void LineEdit::set_caret_column(int p_column) {
+	if (p_column > (int)text.length()) {
+		p_column = text.length();
 	}
 
-	if (p_pos < 0) {
-		p_pos = 0;
+	if (p_column < 0) {
+		p_column = 0;
 	}
 
-	cursor_pos = p_pos;
+	caret_column = p_column;
 
 	// Fit to window.
 
@@ -1440,7 +1440,7 @@ void LineEdit::set_cursor_position(int p_pos) {
 	}
 
 	// Note: Use two coordinates to fit IME input range.
-	Vector2i primary_catret_offset = get_cursor_pixel_pos();
+	Vector2i primary_catret_offset = get_caret_pixel_pos();
 
 	if (MIN(primary_catret_offset.x, primary_catret_offset.y) <= x_ofs) {
 		scroll_offset += (x_ofs - MIN(primary_catret_offset.x, primary_catret_offset.y));
@@ -1452,8 +1452,8 @@ void LineEdit::set_cursor_position(int p_pos) {
 	update();
 }
 
-int LineEdit::get_cursor_position() const {
-	return cursor_pos;
+int LineEdit::get_caret_column() const {
+	return caret_column;
 }
 
 void LineEdit::set_scroll_offset(int p_pos) {
@@ -1467,17 +1467,17 @@ int LineEdit::get_scroll_offset() const {
 	return scroll_offset;
 }
 
-void LineEdit::append_at_cursor(String p_text) {
+void LineEdit::insert_text_at_caret(String p_text) {
 	if ((max_length <= 0) || (text.length() + p_text.length() <= max_length)) {
-		String pre = text.substr(0, cursor_pos);
-		String post = text.substr(cursor_pos, text.length() - cursor_pos);
+		String pre = text.substr(0, caret_column);
+		String post = text.substr(caret_column, text.length() - caret_column);
 		text = pre + p_text + post;
 		_shape();
-		TextServer::Direction dir = TS->shaped_text_get_dominant_direciton_in_range(text_rid, cursor_pos, cursor_pos + p_text.length());
+		TextServer::Direction dir = TS->shaped_text_get_dominant_direciton_in_range(text_rid, caret_column, caret_column + p_text.length());
 		if (dir != TextServer::DIRECTION_AUTO) {
 			input_direction = (TextDirection)dir;
 		}
-		set_cursor_position(cursor_pos + p_text.length());
+		set_caret_column(caret_column + p_text.length());
 	} else {
 		emit_signal("text_change_rejected");
 	}
@@ -1486,7 +1486,7 @@ void LineEdit::append_at_cursor(String p_text) {
 void LineEdit::clear_internal() {
 	deselect();
 	_clear_undo_stack();
-	cursor_pos = 0;
+	caret_column = 0;
 	scroll_offset = 0;
 	undo_text = "";
 	text = "";
@@ -1506,7 +1506,7 @@ Size2 LineEdit::get_minimum_size() const {
 	min_size.width = get_theme_constant("minimum_character_width") * em_space_size;
 
 	if (expand_to_text_length) {
-		// Add a space because some fonts are too exact, and because cursor needs a bit more when at the end.
+		// Add a space because some fonts are too exact, and because caret needs a bit more when at the end.
 		min_size.width = MAX(min_size.width, full_width + em_space_size);
 	}
 
@@ -1527,7 +1527,7 @@ Size2 LineEdit::get_minimum_size() const {
 void LineEdit::deselect() {
 	selection.begin = 0;
 	selection.end = 0;
-	selection.cursor_start = 0;
+	selection.start_column = 0;
 	selection.enabled = false;
 	selection.creating = false;
 	selection.doubleclick = false;
@@ -1552,13 +1552,13 @@ int LineEdit::get_max_length() const {
 	return max_length;
 }
 
-void LineEdit::selection_fill_at_cursor() {
+void LineEdit::selection_fill_at_caret() {
 	if (!selecting_enabled) {
 		return;
 	}
 
-	selection.begin = cursor_pos;
-	selection.end = selection.cursor_start;
+	selection.begin = caret_column;
+	selection.end = selection.start_column;
 
 	if (selection.end < selection.begin) {
 		int aux = selection.end;
@@ -1715,82 +1715,82 @@ void LineEdit::menu_option(int p_option) {
 		} break;
 		case MENU_INSERT_LRM: {
 			if (editable) {
-				append_at_cursor(String::chr(0x200E));
+				insert_text_at_caret(String::chr(0x200E));
 			}
 		} break;
 		case MENU_INSERT_RLM: {
 			if (editable) {
-				append_at_cursor(String::chr(0x200F));
+				insert_text_at_caret(String::chr(0x200F));
 			}
 		} break;
 		case MENU_INSERT_LRE: {
 			if (editable) {
-				append_at_cursor(String::chr(0x202A));
+				insert_text_at_caret(String::chr(0x202A));
 			}
 		} break;
 		case MENU_INSERT_RLE: {
 			if (editable) {
-				append_at_cursor(String::chr(0x202B));
+				insert_text_at_caret(String::chr(0x202B));
 			}
 		} break;
 		case MENU_INSERT_LRO: {
 			if (editable) {
-				append_at_cursor(String::chr(0x202D));
+				insert_text_at_caret(String::chr(0x202D));
 			}
 		} break;
 		case MENU_INSERT_RLO: {
 			if (editable) {
-				append_at_cursor(String::chr(0x202E));
+				insert_text_at_caret(String::chr(0x202E));
 			}
 		} break;
 		case MENU_INSERT_PDF: {
 			if (editable) {
-				append_at_cursor(String::chr(0x202C));
+				insert_text_at_caret(String::chr(0x202C));
 			}
 		} break;
 		case MENU_INSERT_ALM: {
 			if (editable) {
-				append_at_cursor(String::chr(0x061C));
+				insert_text_at_caret(String::chr(0x061C));
 			}
 		} break;
 		case MENU_INSERT_LRI: {
 			if (editable) {
-				append_at_cursor(String::chr(0x2066));
+				insert_text_at_caret(String::chr(0x2066));
 			}
 		} break;
 		case MENU_INSERT_RLI: {
 			if (editable) {
-				append_at_cursor(String::chr(0x2067));
+				insert_text_at_caret(String::chr(0x2067));
 			}
 		} break;
 		case MENU_INSERT_FSI: {
 			if (editable) {
-				append_at_cursor(String::chr(0x2068));
+				insert_text_at_caret(String::chr(0x2068));
 			}
 		} break;
 		case MENU_INSERT_PDI: {
 			if (editable) {
-				append_at_cursor(String::chr(0x2069));
+				insert_text_at_caret(String::chr(0x2069));
 			}
 		} break;
 		case MENU_INSERT_ZWJ: {
 			if (editable) {
-				append_at_cursor(String::chr(0x200D));
+				insert_text_at_caret(String::chr(0x200D));
 			}
 		} break;
 		case MENU_INSERT_ZWNJ: {
 			if (editable) {
-				append_at_cursor(String::chr(0x200C));
+				insert_text_at_caret(String::chr(0x200C));
 			}
 		} break;
 		case MENU_INSERT_WJ: {
 			if (editable) {
-				append_at_cursor(String::chr(0x2060));
+				insert_text_at_caret(String::chr(0x2060));
 			}
 		} break;
 		case MENU_INSERT_SHY: {
 			if (editable) {
-				append_at_cursor(String::chr(0x00AD));
+				insert_text_at_caret(String::chr(0x00AD));
 			}
 		}
 	}
@@ -1810,18 +1810,18 @@ PopupMenu *LineEdit::get_menu() const {
 
 void LineEdit::_editor_settings_changed() {
 #ifdef TOOLS_ENABLED
-	cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
-	cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
+	set_caret_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
+	set_caret_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
 #endif
 }
 
-void LineEdit::set_expand_to_text_length(bool p_enabled) {
+void LineEdit::set_expand_to_text_length_enabled(bool p_enabled) {
 	expand_to_text_length = p_enabled;
 	minimum_size_changed();
-	set_cursor_position(cursor_pos);
+	set_caret_column(caret_column);
 }
 
-bool LineEdit::get_expand_to_text_length() const {
+bool LineEdit::is_expand_to_text_length_enabled() const {
 	return expand_to_text_length;
 }
 
@@ -1906,7 +1906,7 @@ void LineEdit::_shape() {
 		t = secret_character.repeat(text.length() + ime_text.length());
 	} else {
 		if (ime_text.length() > 0) {
-			t = text.substr(0, cursor_pos) + ime_text + text.substr(cursor_pos, text.length());
+			t = text.substr(0, caret_column) + ime_text + text.substr(caret_column, text.length());
 		} else {
 			t = text;
 		}
@@ -1971,7 +1971,7 @@ void LineEdit::_clear_undo_stack() {
 void LineEdit::_create_undo_state() {
 	TextOperation op;
 	op.text = text;
-	op.cursor_pos = cursor_pos;
+	op.caret_column = caret_column;
 	op.scroll_offset = scroll_offset;
 	undo_stack.push_back(op);
 }
@@ -2116,23 +2116,23 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_placeholder"), &LineEdit::get_placeholder);
 	ClassDB::bind_method(D_METHOD("set_placeholder_alpha", "alpha"), &LineEdit::set_placeholder_alpha);
 	ClassDB::bind_method(D_METHOD("get_placeholder_alpha"), &LineEdit::get_placeholder_alpha);
-	ClassDB::bind_method(D_METHOD("set_cursor_position", "position"), &LineEdit::set_cursor_position);
-	ClassDB::bind_method(D_METHOD("get_cursor_position"), &LineEdit::get_cursor_position);
+	ClassDB::bind_method(D_METHOD("set_caret_column", "position"), &LineEdit::set_caret_column);
+	ClassDB::bind_method(D_METHOD("get_caret_column"), &LineEdit::get_caret_column);
 	ClassDB::bind_method(D_METHOD("get_scroll_offset"), &LineEdit::get_scroll_offset);
-	ClassDB::bind_method(D_METHOD("set_expand_to_text_length", "enabled"), &LineEdit::set_expand_to_text_length);
-	ClassDB::bind_method(D_METHOD("get_expand_to_text_length"), &LineEdit::get_expand_to_text_length);
-	ClassDB::bind_method(D_METHOD("cursor_set_blink_enabled", "enabled"), &LineEdit::cursor_set_blink_enabled);
-	ClassDB::bind_method(D_METHOD("cursor_get_blink_enabled"), &LineEdit::cursor_get_blink_enabled);
-	ClassDB::bind_method(D_METHOD("set_mid_grapheme_caret_enabled", "enabled"), &LineEdit::set_mid_grapheme_caret_enabled);
-	ClassDB::bind_method(D_METHOD("get_mid_grapheme_caret_enabled"), &LineEdit::get_mid_grapheme_caret_enabled);
-	ClassDB::bind_method(D_METHOD("cursor_set_force_displayed", "enabled"), &LineEdit::cursor_set_force_displayed);
-	ClassDB::bind_method(D_METHOD("cursor_get_force_displayed"), &LineEdit::cursor_get_force_displayed);
-	ClassDB::bind_method(D_METHOD("cursor_set_blink_speed", "blink_speed"), &LineEdit::cursor_set_blink_speed);
-	ClassDB::bind_method(D_METHOD("cursor_get_blink_speed"), &LineEdit::cursor_get_blink_speed);
+	ClassDB::bind_method(D_METHOD("set_expand_to_text_length_enabled", "enabled"), &LineEdit::set_expand_to_text_length_enabled);
+	ClassDB::bind_method(D_METHOD("is_expand_to_text_length_enabled"), &LineEdit::is_expand_to_text_length_enabled);
+	ClassDB::bind_method(D_METHOD("set_caret_blink_enabled", "enabled"), &LineEdit::set_caret_blink_enabled);
+	ClassDB::bind_method(D_METHOD("is_caret_blink_enabled"), &LineEdit::is_caret_blink_enabled);
+	ClassDB::bind_method(D_METHOD("set_caret_mid_grapheme_enabled", "enabled"), &LineEdit::set_caret_mid_grapheme_enabled);
+	ClassDB::bind_method(D_METHOD("is_caret_mid_grapheme_enabled"), &LineEdit::is_caret_mid_grapheme_enabled);
+	ClassDB::bind_method(D_METHOD("set_caret_force_displayed", "enabled"), &LineEdit::set_caret_force_displayed);
+	ClassDB::bind_method(D_METHOD("is_caret_force_displayed"), &LineEdit::is_caret_force_displayed);
+	ClassDB::bind_method(D_METHOD("set_caret_blink_speed", "blink_speed"), &LineEdit::set_caret_blink_speed);
+	ClassDB::bind_method(D_METHOD("get_caret_blink_speed"), &LineEdit::get_caret_blink_speed);
 	ClassDB::bind_method(D_METHOD("set_max_length", "chars"), &LineEdit::set_max_length);
 	ClassDB::bind_method(D_METHOD("get_max_length"), &LineEdit::get_max_length);
-	ClassDB::bind_method(D_METHOD("append_at_cursor", "text"), &LineEdit::append_at_cursor);
-	ClassDB::bind_method(D_METHOD("delete_char_at_cursor"), &LineEdit::delete_char);
+	ClassDB::bind_method(D_METHOD("insert_text_at_caret", "text"), &LineEdit::insert_text_at_caret);
+	ClassDB::bind_method(D_METHOD("delete_char_at_caret"), &LineEdit::delete_char);
 	ClassDB::bind_method(D_METHOD("delete_text", "from_column", "to_column"), &LineEdit::delete_text);
 	ClassDB::bind_method(D_METHOD("set_editable", "enabled"), &LineEdit::set_editable);
 	ClassDB::bind_method(D_METHOD("is_editable"), &LineEdit::is_editable);
@@ -2200,7 +2200,7 @@ void LineEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "secret"), "set_secret", "is_secret");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "secret_character"), "set_secret_character", "get_secret_character");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand_to_text_length"), "set_expand_to_text_length", "get_expand_to_text_length");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand_to_text_length"), "set_expand_to_text_length_enabled", "is_expand_to_text_length_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "context_menu_enabled"), "set_context_menu_enabled", "is_context_menu_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "virtual_keyboard_enabled"), "set_virtual_keyboard_enabled", "is_virtual_keyboard_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clear_button_enabled"), "set_clear_button_enabled", "is_clear_button_enabled");
@@ -2217,11 +2217,11 @@ void LineEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "placeholder_text"), "set_placeholder", "get_placeholder");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "placeholder_alpha", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_placeholder_alpha", "get_placeholder_alpha");
 	ADD_GROUP("Caret", "caret_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_blink"), "cursor_set_blink_enabled", "cursor_get_blink_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "caret_blink_speed", PROPERTY_HINT_RANGE, "0.1,10,0.01"), "cursor_set_blink_speed", "cursor_get_blink_speed");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "caret_position"), "set_cursor_position", "get_cursor_position");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_force_displayed"), "cursor_set_force_displayed", "cursor_get_force_displayed");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_mid_grapheme"), "set_mid_grapheme_caret_enabled", "get_mid_grapheme_caret_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_blink"), "set_caret_blink_enabled", "is_caret_blink_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "caret_blink_speed", PROPERTY_HINT_RANGE, "0.1,10,0.01"), "set_caret_blink_speed", "get_caret_blink_speed");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "caret_column"), "set_caret_column", "get_caret_column");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_force_displayed"), "set_caret_force_displayed", "is_caret_force_displayed");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_mid_grapheme"), "set_caret_mid_grapheme_enabled", "is_caret_mid_grapheme_enabled");
 }
 
 LineEdit::LineEdit() {
@@ -2237,7 +2237,7 @@ LineEdit::LineEdit() {
 	add_child(caret_blink_timer);
 	caret_blink_timer->set_wait_time(0.65);
 	caret_blink_timer->connect("timeout", callable_mp(this, &LineEdit::_toggle_draw_caret));
-	cursor_set_blink_enabled(false);
+	set_caret_blink_enabled(false);
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -103,9 +103,9 @@ private:
 	PopupMenu *menu_dir = nullptr;
 	PopupMenu *menu_ctl = nullptr;
 
-	bool mid_grapheme_caret_enabled = false;
+	bool caret_mid_grapheme_enabled = false;
 
-	int cursor_pos = 0;
+	int caret_column = 0;
 	int scroll_offset = 0;
 	int max_length = 0; // 0 for no maximum.
 
@@ -131,7 +131,7 @@ private:
 	struct Selection {
 		int begin = 0;
 		int end = 0;
-		int cursor_start = 0;
+		int start_column = 0;
 		bool enabled = false;
 		bool creating = false;
 		bool doubleclick = false;
@@ -140,7 +140,7 @@ private:
 	} selection;
 
 	struct TextOperation {
-		int cursor_pos = 0;
+		int caret_column = 0;
 		int scroll_offset = 0;
 		int cached_width = 0;
 		String text;
@@ -175,12 +175,12 @@ private:
 	void shift_selection_check_pre(bool);
 	void shift_selection_check_post(bool);
 
-	void selection_fill_at_cursor();
+	void selection_fill_at_caret();
 	void set_scroll_offset(int p_pos);
 	int get_scroll_offset() const;
 
-	void set_cursor_at_pixel_pos(int p_x);
-	Vector2i get_cursor_pixel_pos();
+	void set_caret_at_pixel_pos(int p_x);
+	Vector2i get_caret_pixel_pos();
 
 	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();
@@ -191,10 +191,10 @@ private:
 	void _editor_settings_changed();
 
 	void _swap_current_input_direction();
-	void _move_cursor_left(bool p_select, bool p_move_by_word = false);
-	void _move_cursor_right(bool p_select, bool p_move_by_word = false);
-	void _move_cursor_start(bool p_select);
-	void _move_cursor_end(bool p_select);
+	void _move_caret_left(bool p_select, bool p_move_by_word = false);
+	void _move_caret_right(bool p_select, bool p_move_by_word = false);
+	void _move_caret_start(bool p_select);
+	void _move_caret_end(bool p_select);
 	void _backspace(bool p_word = false, bool p_all_to_left = false);
 	void _delete(bool p_word = false, bool p_all_to_right = false);
 
@@ -259,26 +259,26 @@ public:
 	void set_placeholder_alpha(float p_alpha);
 	float get_placeholder_alpha() const;
 
-	void set_cursor_position(int p_pos);
-	int get_cursor_position() const;
+	void set_caret_column(int p_column);
+	int get_caret_column() const;
 
 	void set_max_length(int p_max_length);
 	int get_max_length() const;
 
-	void append_at_cursor(String p_text);
+	void insert_text_at_caret(String p_text);
 	void clear();
 
-	void set_mid_grapheme_caret_enabled(const bool p_enabled);
-	bool get_mid_grapheme_caret_enabled() const;
+	void set_caret_mid_grapheme_enabled(const bool p_enabled);
+	bool is_caret_mid_grapheme_enabled() const;
 
-	bool cursor_get_blink_enabled() const;
-	void cursor_set_blink_enabled(const bool p_enabled);
+	bool is_caret_blink_enabled() const;
+	void set_caret_blink_enabled(const bool p_enabled);
 
-	float cursor_get_blink_speed() const;
-	void cursor_set_blink_speed(const float p_speed);
+	float get_caret_blink_speed() const;
+	void set_caret_blink_speed(const float p_speed);
 
-	bool cursor_get_force_displayed() const;
-	void cursor_set_force_displayed(const bool p_enabled);
+	void set_caret_force_displayed(const bool p_enabled);
+	bool is_caret_force_displayed() const;
 
 	void copy_text();
 	void cut_text();
@@ -297,8 +297,8 @@ public:
 
 	virtual Size2 get_minimum_size() const override;
 
-	void set_expand_to_text_length(bool p_enabled);
-	bool get_expand_to_text_length() const;
+	void set_expand_to_text_length_enabled(bool p_enabled);
+	bool is_expand_to_text_length_enabled() const;
 
 	void set_clear_button_enabled(bool p_enabled);
 	bool is_clear_button_enabled() const;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -438,7 +438,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_selected_color", "LineEdit", Color(0, 0, 0));
 	theme->set_color("font_uneditable_color", "LineEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
 	theme->set_color("font_outline_color", "LineEdit", Color(1, 1, 1));
-	theme->set_color("cursor_color", "LineEdit", control_font_hover_color);
+	theme->set_color("caret_color", "LineEdit", control_font_hover_color);
 	theme->set_color("selection_color", "LineEdit", control_selection_color);
 	theme->set_color("clear_button_color", "LineEdit", control_font_color);
 	theme->set_color("clear_button_color_pressed", "LineEdit", control_font_pressed_color);


### PR DESCRIPTION
Part of #16863.

As originally identified by @AlexHolly in #16116, `LineEdit`'s `caret_*` properties getters and setters are misnamed. This PR renames those getters and setters to match the property names. In addition, for consistency, it renames a few other methods and the documentation to refer to caret instead of cursor too.

Methods renamed:

Old Property | New Property | Old Method Name | New Method Name
-- | -- | -- | --
| |  | append_at_cursor | insert_text_at_caret
| |  | delete_char_at_cursor | delete_char_at_caret
caret_blink |  | cursor_set_blink_enabled | set_caret_blink_enabled
" |  | cursor_get_blink_enabled | is_caret_blink_enabled
caret_blink_speed |  | cursor_set_blink_speed | set_caret_blink_speed
" | | cursor_get_blink_speed | get_caret_blink_speed
caret_force_displayed | | cursor_set_force_displayed | set_caret_force_displayed
" | | cursor_get_force_displayed | is_caret_force_displayed
caret_position | caret_column | set_cursor_column | set_caret_column
" | | get_cursor_position | get_caret_column
expand_to_text_length | | set_expand_to_text_length | set_expand_to_text_length_enabled
" | | get_expand_to_text_length | is_expand_to_text_length_enabled
caret_mid_grapheme | | set_mid_grapheme_caret_enabled | set_caret_mid_grapheme_enabled
" | | get_mid_grapheme_caret_enabled | is_caret_mid_grapheme_enabled