### PR TITLE
Change ARVRPositionalTracker to a reference (3.x)

### DIFF
--- a/doc/classes/ARVRPositionalTracker.xml
+++ b/doc/classes/ARVRPositionalTracker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="ARVRPositionalTracker" inherits="Object" version="3.3">
+<class name="ARVRPositionalTracker" inherits="Reference" version="3.3">
 	<brief_description>
 		A tracked object.
 	</brief_description>

--- a/doc/classes/ARVRServer.xml
+++ b/doc/classes/ARVRServer.xml
@@ -10,6 +10,24 @@
 		<link>https://docs.godotengine.org/en/3.3/tutorials/vr/index.html</link>
 	</tutorials>
 	<methods>
+		<method name="add_interface">
+			<return type="void">
+			</return>
+			<argument index="0" name="interface" type="ARVRInterface">
+			</argument>
+			<description>
+				Registers an [ARVRInterface] object.
+			</description>
+		</method>
+		<method name="add_tracker">
+			<return type="void">
+			</return>
+			<argument index="0" name="tracker" type="ARVRPositionalTracker">
+			</argument>
+			<description>
+				Registers a new [ARVRPositionalTracker] that tracks a spatial location in real space.
+			</description>
+		</method>
 		<method name="center_on_hmd">
 			<return type="void">
 			</return>
@@ -24,6 +42,15 @@
 				This method allows you to center your tracker on the location of the HMD. It will take the current location of the HMD and use that to adjust all your tracking data; in essence, realigning the real world to your player's current position in the game world.
 				For this method to produce usable results, tracking information must be available. This often takes a few frames after starting your game.
 				You should call this method after a few seconds have passed. For instance, when the user requests a realignment of the display holding a designated button on a controller for a short period of time, or when implementing a teleport mechanism.
+			</description>
+		</method>
+		<method name="clear_primary_interface_if">
+			<return type="void">
+			</return>
+			<argument index="0" name="interface" type="ARVRInterface">
+			</argument>
+			<description>
+				Clears our current primary interface if it is set to the provided interface.
 			</description>
 		</method>
 		<method name="find_interface" qualifiers="const">
@@ -107,6 +134,24 @@
 			</return>
 			<description>
 				Returns the number of trackers currently registered.
+			</description>
+		</method>
+		<method name="remove_interface">
+			<return type="void">
+			</return>
+			<argument index="0" name="interface" type="ARVRInterface">
+			</argument>
+			<description>
+				Removes this interface.
+			</description>
+		</method>
+		<method name="remove_tracker">
+			<return type="void">
+			</return>
+			<argument index="0" name="tracker" type="ARVRPositionalTracker">
+			</argument>
+			<description>
+				Removes this positional tracker.
 			</description>
 		</method>
 	</methods>

--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -320,7 +320,8 @@ godot_int GDAPI godot_arvr_add_controller(char *p_device_name, godot_int p_hand,
 	InputDefault *input = (InputDefault *)Input::get_singleton();
 	ERR_FAIL_NULL_V(input, 0);
 
-	ARVRPositionalTracker *new_tracker = memnew(ARVRPositionalTracker);
+	Ref<ARVRPositionalTracker> new_tracker;
+	new_tracker.instance();
 	new_tracker->set_name(p_device_name);
 	new_tracker->set_type(ARVRServer::TRACKER_CONTROLLER);
 	if (p_hand == 1) {
@@ -359,8 +360,8 @@ void GDAPI godot_arvr_remove_controller(godot_int p_controller_id) {
 	InputDefault *input = (InputDefault *)Input::get_singleton();
 	ERR_FAIL_NULL(input);
 
-	ARVRPositionalTracker *remove_tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
-	if (remove_tracker != NULL) {
+	Ref<ARVRPositionalTracker> remove_tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+	if (remove_tracker.is_valid()) {
 		// unset our joystick if applicable
 		int joyid = remove_tracker->get_joy_id();
 		if (joyid != -1) {
@@ -370,7 +371,7 @@ void GDAPI godot_arvr_remove_controller(godot_int p_controller_id) {
 
 		// remove our tracker from our server
 		arvr_server->remove_tracker(remove_tracker);
-		memdelete(remove_tracker);
+		remove_tracker.unref();
 	}
 }
 
@@ -378,8 +379,8 @@ void GDAPI godot_arvr_set_controller_transform(godot_int p_controller_id, godot_
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL(arvr_server);
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
-	if (tracker != NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+	if (tracker.is_valid()) {
 		Transform *transform = (Transform *)p_transform;
 		if (p_tracks_orientation) {
 			tracker->set_orientation(transform->basis);
@@ -397,8 +398,8 @@ void GDAPI godot_arvr_set_controller_button(godot_int p_controller_id, godot_int
 	InputDefault *input = (InputDefault *)Input::get_singleton();
 	ERR_FAIL_NULL(input);
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
-	if (tracker != NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+	if (tracker.is_valid()) {
 		int joyid = tracker->get_joy_id();
 		if (joyid != -1) {
 			input->joy_button(joyid, p_button, p_is_pressed);
@@ -413,8 +414,8 @@ void GDAPI godot_arvr_set_controller_axis(godot_int p_controller_id, godot_int p
 	InputDefault *input = (InputDefault *)Input::get_singleton();
 	ERR_FAIL_NULL(input);
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
-	if (tracker != NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+	if (tracker.is_valid()) {
 		int joyid = tracker->get_joy_id();
 		if (joyid != -1) {
 			InputDefault::JoyAxis jx;
@@ -429,8 +430,8 @@ godot_real GDAPI godot_arvr_get_controller_rumble(godot_int p_controller_id) {
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL_V(arvr_server, 0.0);
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
-	if (tracker != NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+	if (tracker.is_valid()) {
 		return tracker->get_rumble();
 	}
 

--- a/modules/webxr/webxr_interface.h
+++ b/modules/webxr/webxr_interface.h
@@ -57,7 +57,7 @@ public:
 	virtual void set_requested_reference_space_types(String p_requested_reference_space_types) = 0;
 	virtual String get_requested_reference_space_types() const = 0;
 	virtual String get_reference_space_type() const = 0;
-	virtual ARVRPositionalTracker *get_controller(int p_controller_id) const = 0;
+	virtual Ref<ARVRPositionalTracker> get_controller(int p_controller_id) const = 0;
 	virtual String get_visibility_state() const = 0;
 	virtual PoolVector3Array get_bounds_geometry() const = 0;
 };

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -162,7 +162,7 @@ String WebXRInterfaceJS::get_reference_space_type() const {
 	return reference_space_type;
 }
 
-ARVRPositionalTracker *WebXRInterfaceJS::get_controller(int p_controller_id) const {
+Ref<ARVRPositionalTracker> WebXRInterfaceJS::get_controller(int p_controller_id) const {
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL_V(arvr_server, nullptr);
 
@@ -382,10 +382,10 @@ void WebXRInterfaceJS::_update_tracker(int p_controller_id) {
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL(arvr_server);
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id + 1);
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id + 1);
 	if (godot_webxr_is_controller_connected(p_controller_id)) {
-		if (tracker == nullptr) {
-			tracker = memnew(ARVRPositionalTracker);
+		if (tracker.is_null()) {
+			tracker.instance();
 			tracker->set_type(ARVRServer::TRACKER_CONTROLLER);
 			// Controller id's 0 and 1 are always the left and right hands.
 			if (p_controller_id < 2) {
@@ -425,7 +425,7 @@ void WebXRInterfaceJS::_update_tracker(int p_controller_id) {
 			}
 			free(axes);
 		}
-	} else if (tracker) {
+	} else if (tracker.is_valid()) {
 		arvr_server->remove_tracker(tracker);
 	}
 }

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -71,7 +71,7 @@ public:
 	virtual String get_requested_reference_space_types() const;
 	void _set_reference_space_type(String p_reference_space_type);
 	virtual String get_reference_space_type() const;
-	virtual ARVRPositionalTracker *get_controller(int p_controller_id) const;
+	virtual Ref<ARVRPositionalTracker> get_controller(int p_controller_id) const;
 	virtual String get_visibility_state() const;
 	virtual PoolVector3Array get_bounds_geometry() const;
 

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -195,8 +195,8 @@ void ARVRController::_notification(int p_what) {
 			ERR_FAIL_NULL(arvr_server);
 
 			// find the tracker for our controller
-			ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
-			if (tracker == NULL) {
+			Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
+			if (!tracker.is_valid()) {
 				// this controller is currently turned off
 				is_active = false;
 				button_states = 0;
@@ -282,8 +282,8 @@ String ARVRController::get_controller_name(void) const {
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL_V(arvr_server, String());
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
-	if (tracker == NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
+	if (!tracker.is_valid()) {
 		return String("Not connected");
 	};
 
@@ -295,8 +295,8 @@ int ARVRController::get_joystick_id() const {
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL_V(arvr_server, 0);
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
-	if (tracker == NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
+	if (!tracker.is_valid()) {
 		// No tracker? no joystick id... (0 is our first joystick)
 		return -1;
 	};
@@ -327,8 +327,8 @@ real_t ARVRController::get_rumble() const {
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL_V(arvr_server, 0.0);
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
-	if (tracker == NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
+	if (!tracker.is_valid()) {
 		return 0.0;
 	};
 
@@ -340,8 +340,8 @@ void ARVRController::set_rumble(real_t p_rumble) {
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL(arvr_server);
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
-	if (tracker != NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
+	if (tracker.is_valid()) {
 		tracker->set_rumble(p_rumble);
 	};
 };
@@ -359,8 +359,8 @@ ARVRPositionalTracker::TrackerHand ARVRController::get_hand() const {
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL_V(arvr_server, ARVRPositionalTracker::TRACKER_HAND_UNKNOWN);
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
-	if (tracker == NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
+	if (!tracker.is_valid()) {
 		return ARVRPositionalTracker::TRACKER_HAND_UNKNOWN;
 	};
 
@@ -417,8 +417,8 @@ void ARVRAnchor::_notification(int p_what) {
 			ERR_FAIL_NULL(arvr_server);
 
 			// find the tracker for our anchor
-			ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_ANCHOR, anchor_id);
-			if (tracker == NULL) {
+			Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_ANCHOR, anchor_id);
+			if (!tracker.is_valid()) {
 				// this anchor is currently not available
 				is_active = false;
 			} else {
@@ -489,8 +489,8 @@ String ARVRAnchor::get_anchor_name(void) const {
 	ARVRServer *arvr_server = ARVRServer::get_singleton();
 	ERR_FAIL_NULL_V(arvr_server, String());
 
-	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_ANCHOR, anchor_id);
-	if (tracker == NULL) {
+	Ref<ARVRPositionalTracker> tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_ANCHOR, anchor_id);
+	if (!tracker.is_valid()) {
 		return String("Not connected");
 	};
 

--- a/servers/arvr/arvr_positional_tracker.h
+++ b/servers/arvr/arvr_positional_tracker.h
@@ -43,8 +43,8 @@
 	This is where potentially additional AR/VR interfaces may be active as there are AR/VR SDKs that solely deal with positional tracking.
 */
 
-class ARVRPositionalTracker : public Object {
-	GDCLASS(ARVRPositionalTracker, Object);
+class ARVRPositionalTracker : public Reference {
+	GDCLASS(ARVRPositionalTracker, Reference);
 	_THREAD_SAFE_CLASS_
 
 public:

--- a/servers/arvr_server.cpp
+++ b/servers/arvr_server.cpp
@@ -48,12 +48,17 @@ void ARVRServer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "world_scale"), "set_world_scale", "get_world_scale");
 
+	ClassDB::bind_method(D_METHOD("add_interface", "interface"), &ARVRServer::add_interface);
+	ClassDB::bind_method(D_METHOD("clear_primary_interface_if", "interface"), &ARVRServer::clear_primary_interface_if);
 	ClassDB::bind_method(D_METHOD("get_interface_count"), &ARVRServer::get_interface_count);
+	ClassDB::bind_method(D_METHOD("remove_interface", "interface"), &ARVRServer::remove_interface);
 	ClassDB::bind_method(D_METHOD("get_interface", "idx"), &ARVRServer::get_interface);
 	ClassDB::bind_method(D_METHOD("get_interfaces"), &ARVRServer::get_interfaces);
 	ClassDB::bind_method(D_METHOD("find_interface", "name"), &ARVRServer::find_interface);
 	ClassDB::bind_method(D_METHOD("get_tracker_count"), &ARVRServer::get_tracker_count);
 	ClassDB::bind_method(D_METHOD("get_tracker", "idx"), &ARVRServer::get_tracker);
+	ClassDB::bind_method(D_METHOD("add_tracker", "tracker"), &ARVRServer::add_tracker);
+	ClassDB::bind_method(D_METHOD("remove_tracker", "tracker"), &ARVRServer::remove_tracker);
 
 	ClassDB::bind_method(D_METHOD("get_primary_interface"), &ARVRServer::get_primary_interface);
 	ClassDB::bind_method(D_METHOD("set_primary_interface", "interface"), &ARVRServer::set_primary_interface);
@@ -265,15 +270,15 @@ int ARVRServer::get_free_tracker_id_for_type(TrackerType p_tracker_type) {
 	return tracker_id;
 };
 
-void ARVRServer::add_tracker(ARVRPositionalTracker *p_tracker) {
-	ERR_FAIL_NULL(p_tracker);
+void ARVRServer::add_tracker(Ref<ARVRPositionalTracker> p_tracker) {
+	ERR_FAIL_COND(p_tracker.is_null());
 
 	trackers.push_back(p_tracker);
 	emit_signal("tracker_added", p_tracker->get_name(), p_tracker->get_type(), p_tracker->get_tracker_id());
 };
 
-void ARVRServer::remove_tracker(ARVRPositionalTracker *p_tracker) {
-	ERR_FAIL_NULL(p_tracker);
+void ARVRServer::remove_tracker(Ref<ARVRPositionalTracker> p_tracker) {
+	ERR_FAIL_COND(p_tracker.is_null());
 
 	int idx = -1;
 	for (int i = 0; i < trackers.size(); i++) {
@@ -295,14 +300,14 @@ int ARVRServer::get_tracker_count() const {
 	return trackers.size();
 };
 
-ARVRPositionalTracker *ARVRServer::get_tracker(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, trackers.size(), NULL);
+Ref<ARVRPositionalTracker> ARVRServer::get_tracker(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, trackers.size(), Ref<ARVRPositionalTracker>());
 
 	return trackers[p_index];
 };
 
-ARVRPositionalTracker *ARVRServer::find_by_type_and_id(TrackerType p_tracker_type, int p_tracker_id) const {
-	ERR_FAIL_COND_V(p_tracker_id == 0, NULL);
+Ref<ARVRPositionalTracker> ARVRServer::find_by_type_and_id(TrackerType p_tracker_type, int p_tracker_id) const {
+	ERR_FAIL_COND_V(p_tracker_id == 0, Ref<ARVRPositionalTracker>());
 
 	for (int i = 0; i < trackers.size(); i++) {
 		if (trackers[i]->get_type() == p_tracker_type && trackers[i]->get_tracker_id() == p_tracker_id) {
@@ -310,7 +315,7 @@ ARVRPositionalTracker *ARVRServer::find_by_type_and_id(TrackerType p_tracker_typ
 		};
 	};
 
-	return NULL;
+	return Ref<ARVRPositionalTracker>();
 };
 
 Ref<ARVRInterface> ARVRServer::get_primary_interface() const {

--- a/servers/arvr_server.h
+++ b/servers/arvr_server.h
@@ -77,7 +77,7 @@ public:
 
 private:
 	Vector<Ref<ARVRInterface> > interfaces;
-	Vector<ARVRPositionalTracker *> trackers;
+	Vector<Ref<ARVRPositionalTracker> > trackers;
 
 	Ref<ARVRInterface> primary_interface; /* we'll identify one interface as primary, this will be used by our viewports */
 
@@ -167,11 +167,11 @@ public:
 	*/
 	bool is_tracker_id_in_use_for_type(TrackerType p_tracker_type, int p_tracker_id) const;
 	int get_free_tracker_id_for_type(TrackerType p_tracker_type);
-	void add_tracker(ARVRPositionalTracker *p_tracker);
-	void remove_tracker(ARVRPositionalTracker *p_tracker);
+	void add_tracker(Ref<ARVRPositionalTracker> p_tracker);
+	void remove_tracker(Ref<ARVRPositionalTracker> p_tracker);
 	int get_tracker_count() const;
-	ARVRPositionalTracker *get_tracker(int p_index) const;
-	ARVRPositionalTracker *find_by_type_and_id(TrackerType p_tracker_type, int p_tracker_id) const;
+	Ref<ARVRPositionalTracker> get_tracker(int p_index) const;
+	Ref<ARVRPositionalTracker> find_by_type_and_id(TrackerType p_tracker_type, int p_tracker_id) const;
 
 	uint64_t get_last_process_usec();
 	uint64_t get_last_commit_usec();


### PR DESCRIPTION
Change `ARVRPositionalTracker` to a reference and better expose it to GDNative

These changes were originally wrapped up in #41026 but thought it would be a good idea to split them into their own PR. It also fixes a few things with the original implementation.

I will also be submitting this for master in a minute.

This changes `ARVRPositionalTracker` to be subclassed from Reference instead of Object and exposes more functions to classdb so the positional tracker can be maintained from any ARVR GDNative plugin. 

This will eventually lead to retiring a few of the ARVR api calls in GDNative as we can just extend tracks as needed. 