### PR TITLE
Windows: Disable ASLR protection w/ MinGW, it breaks Mono

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -397,7 +397,7 @@ def configure_mingw(env):
     ## Compile flags
 
     env.Append(CCFLAGS=["-mwindows"])
-    env.Append(LINKFLAGS=["-Wl,--nxcompat", "-Wl,--dynamicbase"])
+    env.Append(LINKFLAGS=["-Wl,--nxcompat"])  # DEP protection. Not enabling ASLR for now, Mono crashes.
     env.Append(CPPDEFINES=["WINDOWS_ENABLED", "OPENGL_ENABLED", "WASAPI_ENABLED", "WINMIDI_ENABLED"])
     env.Append(CPPDEFINES=[("WINVER", env["target_win_version"]), ("_WIN32_WINNT", env["target_win_version"])])
     env.Append(


### PR DESCRIPTION
We might be able to make it work by building Mono itself with
ASLR protection too, but there might still be issues when loading
e.g. GDNative DLLs built without ASLR protection.

In the short term this is not a goal, but we can reconsider later
what is actually needed for ASLR protection to work and keep things
user-friendly.

---

To clarify the issue, an official Mono build with MinGW-GCC ended up crashing on Windows, even without Mandatory ASLR enabled. We haven't investigated in depth why but it's likely to be because Mono isn't built with ASLR support, or possibly because the MinGW/binutils version we use doesn't support it properly yet.

I think this will mean reopening #47256, I'll test to be sure, but official builds will likely crash again with Mandatory ASLR.
I think #47219 might still be fixed though by the rest of the changes in #47368, right?

Will make a MinGW build for both standard and Mono flavors to validate this PR.