### PR TITLE
RichTextLabel: fix font extra spacing and style box size usage.

### DIFF
--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -289,6 +289,20 @@
 				Returns the size of the bounding box of the paragraph.
 			</description>
 		</method>
+		<method name="get_spacing_bottom" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns extra spacing at the bottom of the line. See [member Font.extra_spacing_bottom].
+			</description>
+		</method>
+		<method name="get_spacing_top" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns extra spacing at the top of the line. See [member Font.extra_spacing_top].
+			</description>
+		</method>
 		<method name="hit_test" qualifiers="const">
 			<return type="int">
 			</return>

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -760,7 +760,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 
 		//draw_rect(Rect2(p_ofs + off, TS->shaped_text_get_size(rid)), Color(1,0,0), false, 2); //DEBUG_RECTS
 
-		off.y += TS->shaped_text_get_ascent(rid);
+		off.y += TS->shaped_text_get_ascent(rid) + l.text_buf->get_spacing_top();
 		// Draw inlined objects.
 		Array objects = TS->shaped_text_get_objects(rid);
 		for (int i = 0; i < objects.size(); i++) {
@@ -1079,7 +1079,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 				off.x += glyphs[i].advance;
 			}
 		}
-		off.y += TS->shaped_text_get_descent(rid);
+		off.y += TS->shaped_text_get_descent(rid) + l.text_buf->get_spacing_bottom();
 	}
 
 	return line_count;
@@ -1174,7 +1174,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 			} break;
 		}
 
-		off.y += TS->shaped_text_get_ascent(rid);
+		off.y += TS->shaped_text_get_ascent(rid) + l.text_buf->get_spacing_top();
 
 		Array objects = TS->shaped_text_get_objects(rid);
 		for (int i = 0; i < objects.size(); i++) {
@@ -1238,7 +1238,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 		if (rect.has_point(p_click) && !table_hit) {
 			char_pos = TS->shaped_text_hit_test_position(rid, p_click.x - rect.position.x);
 		}
-		off.y += TS->shaped_text_get_descent(rid);
+		off.y += TS->shaped_text_get_descent(rid) + l.text_buf->get_spacing_bottom();
 	}
 
 	if (char_pos >= 0) {
@@ -3999,14 +3999,16 @@ void RichTextLabel::set_fixed_size_to_width(int p_width) {
 }
 
 Size2 RichTextLabel::get_minimum_size() const {
-	Size2 size(0, 0);
+	Ref<StyleBox> style = get_theme_stylebox("normal");
+	Size2 size = style->get_minimum_size();
+
 	if (fixed_width != -1) {
-		size.x = fixed_width;
+		size.x += fixed_width;
 	}
 
 	if (fixed_width != -1 || fit_content_height) {
 		const_cast<RichTextLabel *>(this)->_validate_line_caches(main);
-		size.y = get_content_height();
+		size.y += get_content_height();
 	}
 
 	return size;

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -98,6 +98,9 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_line_underline_position", "line"), &TextParagraph::get_line_underline_position);
 	ClassDB::bind_method(D_METHOD("get_line_underline_thickness", "line"), &TextParagraph::get_line_underline_thickness);
 
+	ClassDB::bind_method(D_METHOD("get_spacing_top"), &TextParagraph::get_spacing_top);
+	ClassDB::bind_method(D_METHOD("get_spacing_bottom"), &TextParagraph::get_spacing_bottom);
+
 	ClassDB::bind_method(D_METHOD("get_dropcap_size"), &TextParagraph::get_dropcap_size);
 	ClassDB::bind_method(D_METHOD("get_dropcap_lines"), &TextParagraph::get_dropcap_lines);
 
@@ -264,6 +267,14 @@ bool TextParagraph::add_string(const String &p_text, const Ref<Font> &p_fonts, i
 	spacing_bottom = p_fonts->get_spacing(Font::SPACING_BOTTOM);
 	dirty_lines = true;
 	return res;
+}
+
+int TextParagraph::get_spacing_top() const {
+	return spacing_top;
+}
+
+int TextParagraph::get_spacing_bottom() const {
+	return spacing_bottom;
 }
 
 void TextParagraph::_set_bidi_override(const Array &p_override) {

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -116,6 +116,9 @@ public:
 	float get_line_underline_position(int p_line) const;
 	float get_line_underline_thickness(int p_line) const;
 
+	int get_spacing_top() const;
+	int get_spacing_bottom() const;
+
 	Size2 get_dropcap_size() const;
 	int get_dropcap_lines() const;
 


### PR DESCRIPTION
- Use extra font spacing in the RichTextLabel line height calculation.
- Use stylebox size in the minimum size calculation.

Fixes #47377