### PR TITLE
FBX: Fix first bone getting unnecessary '_1' suffix

### DIFF
--- a/modules/fbx/data/fbx_skeleton.cpp
+++ b/modules/fbx/data/fbx_skeleton.cpp
@@ -69,7 +69,7 @@ void FBXSkeleton::init_skeleton(const ImportState &state) {
 			// Make sure the bone name is unique.
 			const String bone_name = bone->bone_name;
 			int same_name_count = 0;
-			for (int y = x; y < skeleton_bone_count; y++) {
+			for (int y = x + 1; y < skeleton_bone_count; y++) {
 				Ref<FBXBone> other_bone = skeleton_bones[y];
 				if (other_bone.is_valid()) {
 					if (other_bone->bone_name == bone_name) {


### PR DESCRIPTION
Fixes #43820.

Extracted from #46525 which is still WIP.