### PR TITLE
[HTML5] Fix WM notifications not being called.

### DIFF
--- a/platform/javascript/js/libs/library_godot_display.js
+++ b/platform/javascript/js/libs/library_godot_display.js
@@ -858,7 +858,7 @@ const GodotDisplay = {
 		const notif = [p_enter, p_exit, p_in, p_out];
 		['mouseover', 'mouseleave', 'focus', 'blur'].forEach(function (evt_name, idx) {
 			GodotDisplayListeners.add(canvas, evt_name, function () {
-				func.bind(null, notif[idx]);
+				func(notif[idx]);
 			}, true);
 		});
 	},


### PR DESCRIPTION
Regression from the library refactoring, binding and not calling is pretty useless 'o_o.

Fixes #47417.