### PR TITLE
Fix Quat multiplication

### DIFF
--- a/core/math/quat.cpp
+++ b/core/math/quat.cpp
@@ -55,10 +55,13 @@ Vector3 Quat::get_euler_yxz() const {
 }
 
 void Quat::operator*=(const Quat &p_q) {
-	x = w * p_q.x + x * p_q.w + y * p_q.z - z * p_q.y;
-	y = w * p_q.y + y * p_q.w + z * p_q.x - x * p_q.z;
-	z = w * p_q.z + z * p_q.w + x * p_q.y - y * p_q.x;
+	real_t xx = w * p_q.x + x * p_q.w + y * p_q.z - z * p_q.y;
+	real_t yy = w * p_q.y + y * p_q.w + z * p_q.x - x * p_q.z;
+	real_t zz = w * p_q.z + z * p_q.w + x * p_q.y - y * p_q.x;
 	w = w * p_q.w - x * p_q.x - y * p_q.y - z * p_q.z;
+	x = xx;
+	y = yy;
+	z = zz;
 }
 
 Quat Quat::operator*(const Quat &p_q) const {


### PR DESCRIPTION
x, y, z values were updated too early

Edit:
Could be related Fixes: #47439
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
