### PR TITLE
RichTextLabel: On custom effect change, parse bbcode only if it's enabled and not empty.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3756,7 +3756,9 @@ void RichTextLabel::set_effects(const Vector<Variant> &effects) {
 		custom_effects.push_back(effect);
 	}
 
-	parse_bbcode(bbcode);
+	if ((bbcode != "") && use_bbcode) {
+		parse_bbcode(bbcode);
+	}
 }
 
 Vector<Variant> RichTextLabel::get_effects() {
@@ -3773,7 +3775,9 @@ void RichTextLabel::install_effect(const Variant effect) {
 
 	if (rteffect.is_valid()) {
 		custom_effects.push_back(effect);
-		parse_bbcode(bbcode);
+		if ((bbcode != "") && use_bbcode) {
+			parse_bbcode(bbcode);
+		}
 	}
 }
 


### PR DESCRIPTION
Prevents overwriting `text` by the empty bbcode.

Fixes #47471

*Note: #47471 is not reproducible on 3.2 (probably difference in resource loading), but it's still relevant when, `custom_effects` is set from the code.*