### PR TITLE
HTML5: Fix link to documentation on editor template

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -239,7 +239,7 @@
 				<br />
 				<button class="btn" onclick="clearPersistence()" style="margin-bottom: 1.5rem">Clear persistent data</button>
 				<br />
-				<a href="https://docs.godotengine.org/en/3.3/tutorials/editor/using_the_web_editor.html">Web editor documentation</a>
+				<a href="https://docs.godotengine.org/en/3.3/getting_started/editor/using_the_web_editor.html">Web editor documentation</a>
 			</div>
 		</div>
 		<div id="tab-editor" style="display: none;">


### PR DESCRIPTION
Not needed in the `master` branch which already has a correct link for the `latest` docs.

Fixed manually in the 3.3 RC 7 page: https://editor.godotengine.org/releases/3.3.rc7/