### PR TITLE
Fix window resizing after minimization on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2566,6 +2566,8 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					windows[window_id].preserve_window_size = false;
 					window_set_size(Size2(windows[window_id].width, windows[window_id].height), window_id);
 				}
+			} else {
+				windows[window_id].preserve_window_size = true;
 			}
 
 			if (!windows[window_id].rect_changed_callback.is_null()) {


### PR DESCRIPTION
Fixes #47482. Result:

![window_resize_fix](https://user-images.githubusercontent.com/28705694/112987133-f403a900-9194-11eb-8193-3b6ddbeec712.gif)
