### PR TITLE
Remove mention of community-driven and mention feature PRs may not be accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Windows), mobile platforms (Android, iOS), as well as Web-based platforms
 (HTML5) and
 [consoles](https://docs.godotengine.org/en/latest/tutorials/platform/consoles.html).
 
-## Free, open source and community-driven
+## Free and open source
 
 Godot is completely free and open source under the very permissive MIT license.
 No strings attached, no royalties, nothing. The users' games are theirs, down
 to the last line of engine code. Godot's development is fully independent and
-community-driven, empowering users to help shape their engine to match their
+open source, empowering users to help shape their engine to match their
 expectations. It is supported by the [Software Freedom Conservancy](https://sfconservancy.org/)
 not-for-profit.
 
@@ -53,6 +53,10 @@ To get in touch with the engine developers, the best way is to join the
 [Godot Contributors Chat](https://chat.godotengine.org).
 
 To get started contributing to the project, see the [contributing guide](CONTRIBUTING.md).
+
+Please note that a feature PR that a maintainer did not ask for or approve in
+advance will often not be accepted. Ultimately, Godot's maintainers will decide
+whether or not a feature will be merged, and there is no compromise.
 
 ## Documentation and demos
 


### PR DESCRIPTION
This brings the README in line with Godot's actual policy as stated by @reduz.

Citation for removing community-driven: https://twitter.com/reduzio/status/1376855473283010562

Citation for 1st added sentence: https://twitter.com/reduzio/status/1376749654495399944

Citation for 2nd added sentence: https://twitter.com/reduzio/status/1376745492713967616

Most of the words in this PR are quoting @reduz verbatim with his clarifications of the policy on Twitter.

The README should reflect Godot's policy, not go against it. Doing otherwise is confusing for contributors. Stating Godot is community-driven is misleading at best, so it shouldn't be in the README. Most people will read "community" as "the whole community of users and developers", not "the community of core developers".

I am legitimately interested in improving this README (and other documents). This was not done in bad faith.