### PR TITLE
Fix Bullet Physics Server

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1248,6 +1248,9 @@
 			The default angular damp in 3D.
 			[b]Note:[/b] Good values are in the range [code]0[/code] to [code]1[/code]. At value [code]0[/code] objects will keep moving with the same velocity. Values greater than [code]1[/code] will aim to reduce the velocity to [code]0[/code] in less than a second e.g. a value of [code]2[/code] will aim to reduce the velocity to [code]0[/code] in half a second. A value equal to or greater than the physics frame rate ([member ProjectSettings.physics/common/physics_fps], [code]60[/code] by default) will bring the object to a stop in one iteration.
 		</member>
+		<member name="physics/3d/active_soft_world" type="bool" setter="" getter="" default="true">
+			Sets whether the 3D physics world will be created with support for [SoftBody] physics. Only applies to the Bullet physics engine.
+		</member>
 		<member name="physics/3d/default_gravity" type="float" setter="" getter="" default="9.8">
 			The default gravity strength in 3D.
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity at runtime, use the following code sample:

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1249,7 +1249,7 @@
 			[b]Note:[/b] Good values are in the range [code]0[/code] to [code]1[/code]. At value [code]0[/code] objects will keep moving with the same velocity. Values greater than [code]1[/code] will aim to reduce the velocity to [code]0[/code] in less than a second e.g. a value of [code]2[/code] will aim to reduce the velocity to [code]0[/code] in half a second. A value equal to or greater than the physics frame rate ([member ProjectSettings.physics/common/physics_fps], [code]60[/code] by default) will bring the object to a stop in one iteration.
 		</member>
 		<member name="physics/3d/active_soft_world" type="bool" setter="" getter="" default="true">
-			Sets whether the 3D physics world will be created with support for [SoftBody] physics. Only applies to the Bullet physics engine.
+			Sets whether the 3D physics world will be created with support for [SoftBody3D] physics. Only applies to the Bullet physics engine.
 		</member>
 		<member name="physics/3d/default_gravity" type="float" setter="" getter="" default="9.8">
 			The default gravity strength in 3D.

--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -59,8 +59,9 @@ AreaBullet::AreaBullet() :
 
 AreaBullet::~AreaBullet() {
 	// signal are handled by godot, so just clear without notify
+
 	for (int i = overlappingObjects.size() - 1; 0 <= i; --i) {
-		overlappingObjects[i].object->on_exit_area(this);
+		overlappingObjects.write[i].object->on_exit_area(this);
 	}
 }
 

--- a/modules/bullet/area_bullet.h
+++ b/modules/bullet/area_bullet.h
@@ -85,6 +85,7 @@ private:
 	btGhostObject *btGhost = nullptr;
 	Vector<OverlappingObjectData> overlappingObjects;
 	bool monitorable = true;
+	int priority = 0;
 
 	PhysicsServer3D::AreaSpaceOverrideMode spOv_mode = PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED;
 	bool spOv_gravityPoint = false;
@@ -138,6 +139,9 @@ public:
 
 	_FORCE_INLINE_ void set_spOv_priority(int p_priority) { spOv_priority = p_priority; }
 	_FORCE_INLINE_ int get_spOv_priority() { return spOv_priority; }
+
+	_FORCE_INLINE_ void set_priority(int p_priority) { priority = p_priority; }
+	_FORCE_INLINE_ int get_priority() const { return priority; }
 
 	virtual void main_shape_changed();
 	virtual void reload_body();

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -81,10 +81,9 @@
 void BulletPhysicsServer3D::_bind_methods() {
 	//ClassDB::bind_method(D_METHOD("DoTest"), &BulletPhysicsServer3D::DoTest);
 }
-BulletPhysicsServer3D *BulletPhysicsServer3D::singletonbullet = nullptr;
+
 BulletPhysicsServer3D::BulletPhysicsServer3D(bool p_using_threads) {
 	using_threads = p_using_threads;
-	singletonbullet = this;
 	active = true;
 	doing_sync = false;
 };
@@ -1525,8 +1524,6 @@ void BulletPhysicsServer3D::init() {
 }
 
 void BulletPhysicsServer3D::step(real_t p_deltaTime) {
-#ifndef _3D_DISABLED
-
 	if (!active) {
 		return;
 	}
@@ -1537,8 +1534,6 @@ void BulletPhysicsServer3D::step(real_t p_deltaTime) {
 		SpaceBullet *space = (SpaceBullet *)E->get();
 		space->step(p_deltaTime);
 	}
-
-#endif
 }
 
 void BulletPhysicsServer3D::flush_queries() {

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -216,7 +216,7 @@ real_t BulletPhysicsServer3D::space_get_param(RID p_space, SpaceParameter p_para
 PhysicsDirectSpaceState3D *BulletPhysicsServer3D::space_get_direct_state(RID p_space) {
 	SpaceBullet *space = space_owner.getornull(p_space);
 	ERR_FAIL_COND_V(!space, nullptr);
-	ERR_FAIL_COND_V_MSG((using_threads && !doing_sync) || space->is_locked(), nullptr, "Space state is inaccessible right now, wait for iteration or physics process notification.");
+	ERR_FAIL_COND_V_MSG(using_threads && !doing_sync, nullptr, "Space state is inaccessible right now, wait for iteration or physics process notification.");
 
 	return space->get_direct_state();
 }
@@ -848,7 +848,6 @@ PhysicsDirectBodyState3D *BulletPhysicsServer3D::body_get_direct_state(RID p_bod
 
 	RigidBodyBullet *body = rigid_body_owner.getornull(p_body);
 	ERR_FAIL_COND_V(!body, nullptr);
-	ERR_FAIL_COND_V_MSG(body->get_space()->is_locked(), nullptr, "Body state is inaccessible right now, wait for iteration or physics process notification.");
 
 	return BulletPhysicsDirectBodyState3D::get_singleton(body);
 }

--- a/modules/bullet/cone_twist_joint_bullet.h
+++ b/modules/bullet/cone_twist_joint_bullet.h
@@ -45,7 +45,7 @@ class ConeTwistJointBullet : public JointBullet {
 public:
 	ConeTwistJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Transform &rbAFrame, const Transform &rbBFrame);
 
-	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_CONE_TWIST; }
+	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JointType::JOINT_TYPE_CONE_TWIST; }
 
 	void set_param(PhysicsServer3D::ConeTwistJointParam p_param, real_t p_value);
 	real_t get_param(PhysicsServer3D::ConeTwistJointParam p_param) const;

--- a/modules/bullet/config.py
+++ b/modules/bullet/config.py
@@ -1,6 +1,5 @@
 def can_build(env, platform):
-    # API Changed and bullet is disabled at the moment
-    return False
+    return True
 
 
 def configure(env):

--- a/modules/bullet/constraint_bullet.cpp
+++ b/modules/bullet/constraint_bullet.cpp
@@ -49,7 +49,9 @@ void ConstraintBullet::set_space(SpaceBullet *p_space) {
 }
 
 void ConstraintBullet::destroy_internal_constraint() {
-	space->remove_constraint(this);
+	if (space) {
+		space->remove_constraint(this);
+	}
 }
 
 void ConstraintBullet::disable_collisions_between_bodies(const bool p_disabled) {

--- a/modules/bullet/generic_6dof_joint_bullet.h
+++ b/modules/bullet/generic_6dof_joint_bullet.h
@@ -50,7 +50,7 @@ class Generic6DOFJointBullet : public JointBullet {
 public:
 	Generic6DOFJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Transform &frameInA, const Transform &frameInB);
 
-	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_6DOF; }
+	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_TYPE_6DOF; }
 
 	Transform getFrameOffsetA() const;
 	Transform getFrameOffsetB() const;

--- a/modules/bullet/hinge_joint_bullet.h
+++ b/modules/bullet/hinge_joint_bullet.h
@@ -44,7 +44,9 @@ public:
 	HingeJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Transform &frameA, const Transform &frameB);
 	HingeJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Vector3 &pivotInA, const Vector3 &pivotInB, const Vector3 &axisInA, const Vector3 &axisInB);
 
-	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_HINGE; }
+	virtual PhysicsServer3D::JointType get_type() const {
+		return PhysicsServer3D::JointType::JOINT_TYPE_HINGE;
+	}
 
 	real_t get_hinge_angle();
 

--- a/modules/bullet/joint_bullet.cpp
+++ b/modules/bullet/joint_bullet.cpp
@@ -37,6 +37,8 @@
 */
 
 JointBullet::JointBullet() :
-		ConstraintBullet() {}
+		ConstraintBullet() {
+}
 
-JointBullet::~JointBullet() {}
+JointBullet::~JointBullet() {
+}

--- a/modules/bullet/joint_bullet.h
+++ b/modules/bullet/joint_bullet.h
@@ -46,6 +46,10 @@ public:
 	JointBullet();
 	virtual ~JointBullet();
 
-	virtual PhysicsServer3D::JointType get_type() const = 0;
+	void copy_settings_from(JointBullet *p_joint) {
+		set_self(p_joint->get_self());
+	}
+
+	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_TYPE_MAX; }
 };
 #endif

--- a/modules/bullet/pin_joint_bullet.h
+++ b/modules/bullet/pin_joint_bullet.h
@@ -46,7 +46,7 @@ public:
 	PinJointBullet(RigidBodyBullet *p_body_a, const Vector3 &p_pos_a, RigidBodyBullet *p_body_b, const Vector3 &p_pos_b);
 	~PinJointBullet();
 
-	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_PIN; }
+	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JointType::JOINT_TYPE_PIN; }
 
 	void set_param(PhysicsServer3D::PinJointParam p_param, real_t p_value);
 	real_t get_param(PhysicsServer3D::PinJointParam p_param) const;

--- a/modules/bullet/register_types.cpp
+++ b/modules/bullet/register_types.cpp
@@ -33,6 +33,7 @@
 #include "bullet_physics_server.h"
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "servers/physics_3d/physics_server_3d_wrap_mt.h"
 
 /**
 	@author AndreaCatania
@@ -40,17 +41,18 @@
 
 #ifndef _3D_DISABLED
 PhysicsServer3D *_createBulletPhysicsCallback() {
-	return memnew(BulletPhysicsServer3D);
+	bool using_threads = GLOBAL_GET("physics/3d/run_on_thread");
+	PhysicsServer3D *physics_server = memnew(BulletPhysicsServer3D(using_threads));
+	return memnew(PhysicsServer3DWrapMT(physics_server, using_threads));
 }
 #endif
 
 void register_bullet_types() {
 #ifndef _3D_DISABLED
+	GLOBAL_DEF("physics/3d/active_soft_world", true);
+
 	PhysicsServer3DManager::register_server("Bullet", &_createBulletPhysicsCallback);
 	PhysicsServer3DManager::set_default_server("Bullet", 1);
-
-	GLOBAL_DEF("physics/3d/active_soft_world", true);
-	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/active_soft_world", PropertyInfo(Variant::BOOL, "physics/3d/active_soft_world"));
 #endif
 }
 

--- a/modules/bullet/slider_joint_bullet.h
+++ b/modules/bullet/slider_joint_bullet.h
@@ -46,7 +46,7 @@ public:
 	/// Reference frame is A
 	SliderJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Transform &frameInA, const Transform &frameInB);
 
-	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_SLIDER; }
+	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JointType::JOINT_TYPE_SLIDER; }
 
 	const RigidBodyBullet *getRigidBodyA() const;
 	const RigidBodyBullet *getRigidBodyB() const;

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -123,7 +123,7 @@ int BulletPhysicsDirectSpaceState::intersect_shape(const RID &p_shape, const Tra
 		return 0;
 	}
 
-	ShapeBullet *shape = BulletPhysicsServer3D::singletonbullet->shape_owner.getornull(p_shape);
+	ShapeBullet *shape = space->get_physics_server()->shape_owner.getornull(p_shape);
 	ERR_FAIL_COND_V(!shape, 0);
 
 	btCollisionShape *btShape = shape->create_bt_shape(p_xform.basis.get_scale_abs(), p_margin);
@@ -159,7 +159,7 @@ bool BulletPhysicsDirectSpaceState::cast_motion(const RID &p_shape, const Transf
 	btVector3 bt_motion;
 	G_TO_B(p_motion, bt_motion);
 
-	ShapeBullet *shape = BulletPhysicsServer3D::singletonbullet->shape_owner.getornull(p_shape);
+	ShapeBullet *shape = space->get_physics_server()->shape_owner.getornull(p_shape);
 	ERR_FAIL_COND_V(!shape, false);
 
 	btCollisionShape *btShape = shape->create_bt_shape(p_xform.basis.get_scale(), p_margin);
@@ -219,7 +219,7 @@ bool BulletPhysicsDirectSpaceState::collide_shape(RID p_shape, const Transform &
 	if (p_result_max <= 0) {
 		return false;
 	}
-	ShapeBullet *shape = BulletPhysicsServer3D::singletonbullet->shape_owner.getornull(p_shape);
+	ShapeBullet *shape = space->get_physics_server()->shape_owner.getornull(p_shape);
 
 	ERR_FAIL_COND_V(!shape, false);
 
@@ -252,7 +252,7 @@ bool BulletPhysicsDirectSpaceState::collide_shape(RID p_shape, const Transform &
 }
 
 bool BulletPhysicsDirectSpaceState::rest_info(RID p_shape, const Transform &p_shape_xform, real_t p_margin, ShapeRestInfo *r_info, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
-	ShapeBullet *shape = BulletPhysicsServer3D::singletonbullet->shape_owner.getornull(p_shape);
+	ShapeBullet *shape = space->get_physics_server()->shape_owner.getornull(p_shape);
 	ERR_FAIL_COND_V(!shape, false);
 
 	btCollisionShape *btShape = shape->create_bt_shape(p_shape_xform.basis.get_scale_abs(), p_margin);
@@ -290,7 +290,7 @@ bool BulletPhysicsDirectSpaceState::rest_info(RID p_shape, const Transform &p_sh
 }
 
 Vector3 BulletPhysicsDirectSpaceState::get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const {
-	RigidCollisionObjectBullet *rigid_object = BulletPhysicsServer3D::singletonbullet->get_rigid_collision_object(p_object);
+	RigidCollisionObjectBullet *rigid_object = space->get_physics_server()->get_rigid_collision_object(p_object);
 
 	ERR_FAIL_COND_V(!rigid_object, Vector3());
 

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -64,8 +64,6 @@ BulletPhysicsDirectSpaceState::BulletPhysicsDirectSpaceState(SpaceBullet *p_spac
 }
 
 int BulletPhysicsDirectSpaceState::intersect_point(const Vector3 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
-	ERR_FAIL_COND_V(space->locked, false);
-
 	if (p_result_max <= 0) {
 		return 0;
 	}
@@ -89,8 +87,6 @@ int BulletPhysicsDirectSpaceState::intersect_point(const Vector3 &p_point, Shape
 }
 
 bool BulletPhysicsDirectSpaceState::intersect_ray(const Vector3 &p_from, const Vector3 &p_to, RayResult &r_result, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas, bool p_pick_ray) {
-	ERR_FAIL_COND_V(space->locked, false);
-
 	btVector3 btVec_from;
 	btVector3 btVec_to;
 
@@ -353,17 +349,6 @@ SpaceBullet::SpaceBullet() {
 	direct_access->space = this;
 }
 
-void SpaceBullet::lock() {
-	locked = true;
-}
-
-void SpaceBullet::unlock() {
-	locked = false;
-}
-
-bool SpaceBullet::is_locked() const {
-	return locked;
-}
 SpaceBullet::~SpaceBullet() {
 	memdelete(direct_access);
 	destroy_world();

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -109,7 +109,6 @@ class SpaceBullet : public RIDBullet {
 	real_t angular_damp = 0.0;
 
 	Vector<AreaBullet *> areas;
-	bool locked = false;
 	Vector<Vector3> contactDebug;
 	int contactDebugCount = 0;
 	real_t delta_time = 0.;
@@ -121,10 +120,6 @@ public:
 	void flush_queries();
 	real_t get_delta_time() { return delta_time; }
 	void step(real_t p_delta_time);
-
-	bool is_locked() const;
-	void lock();
-	void unlock();
 
 	_FORCE_INLINE_ btBroadphaseInterface *get_broadphase() const { return broadphase; }
 	_FORCE_INLINE_ btDefaultCollisionConfiguration *get_collision_configuration() const { return collisionConfiguration; }

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -70,10 +70,8 @@ extern ContactAddedCallback gContactAddedCallback;
 class BulletPhysicsDirectSpaceState : public PhysicsDirectSpaceState3D {
 	GDCLASS(BulletPhysicsDirectSpaceState, PhysicsDirectSpaceState3D);
 
-private:
-	SpaceBullet *space;
-
 public:
+	SpaceBullet *space;
 	BulletPhysicsDirectSpaceState(SpaceBullet *p_space);
 
 	virtual int intersect_point(const Vector3 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_areas = false) override;
@@ -87,6 +85,9 @@ public:
 };
 
 class SpaceBullet : public RIDBullet {
+	RID static_global_body;
+	AreaBullet *area = nullptr;
+
 	friend class AreaBullet;
 	friend void onBulletTickCallback(btDynamicsWorld *world, btScalar timeStep);
 	friend class BulletPhysicsDirectSpaceState;
@@ -111,7 +112,7 @@ class SpaceBullet : public RIDBullet {
 	real_t angular_damp = 0.0;
 
 	Vector<AreaBullet *> areas;
-
+	bool locked = false;
 	Vector<Vector3> contactDebug;
 	int contactDebugCount = 0;
 	real_t delta_time = 0.;
@@ -124,6 +125,10 @@ public:
 	real_t get_delta_time() { return delta_time; }
 	void step(real_t p_delta_time);
 
+	bool is_locked() const;
+	void lock();
+	void unlock();
+
 	_FORCE_INLINE_ btBroadphaseInterface *get_broadphase() const { return broadphase; }
 	_FORCE_INLINE_ btDefaultCollisionConfiguration *get_collision_configuration() const { return collisionConfiguration; }
 	_FORCE_INLINE_ btCollisionDispatcher *get_dispatcher() const { return dispatcher; }
@@ -131,6 +136,12 @@ public:
 	_FORCE_INLINE_ btDiscreteDynamicsWorld *get_dynamic_world() const { return dynamicsWorld; }
 	_FORCE_INLINE_ btSoftBodyWorldInfo *get_soft_body_world_info() const { return soft_body_world_info; }
 	_FORCE_INLINE_ bool is_using_soft_world() { return soft_body_world_info; }
+
+	void set_default_area(AreaBullet *p_area) { area = p_area; }
+	AreaBullet *get_default_area() const { return area; }
+
+	void set_static_global_body(RID p_body) { static_global_body = p_body; }
+	RID get_static_global_body() { return static_global_body; }
 
 	/// Used to set some parameters to Bullet world
 	/// @param p_param:

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -85,9 +85,6 @@ public:
 };
 
 class SpaceBullet : public RIDBullet {
-	RID static_global_body;
-	AreaBullet *area = nullptr;
-
 	friend class AreaBullet;
 	friend void onBulletTickCallback(btDynamicsWorld *world, btScalar timeStep);
 	friend class BulletPhysicsDirectSpaceState;
@@ -136,12 +133,6 @@ public:
 	_FORCE_INLINE_ btDiscreteDynamicsWorld *get_dynamic_world() const { return dynamicsWorld; }
 	_FORCE_INLINE_ btSoftBodyWorldInfo *get_soft_body_world_info() const { return soft_body_world_info; }
 	_FORCE_INLINE_ bool is_using_soft_world() { return soft_body_world_info; }
-
-	void set_default_area(AreaBullet *p_area) { area = p_area; }
-	AreaBullet *get_default_area() const { return area; }
-
-	void set_static_global_body(RID p_body) { static_global_body = p_body; }
-	RID get_static_global_body() { return static_global_body; }
 
 	/// Used to set some parameters to Bullet world
 	/// @param p_param:


### PR DESCRIPTION
Bullet2 physics compatibility for to new rendering server api in godot 4. Only small changes were necessary.

![image](https://user-images.githubusercontent.com/76991284/113055336-c590c880-91aa-11eb-9ff6-f831799ea302.png)

Next step: PhysX Integration (in progress)