### PR TITLE
fix wrong encoding format in uri_encode

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3772,9 +3772,9 @@ String String::uri_encode() const {
 		} else {
 			char h_Val[3];
 #if defined(__GNUC__) || defined(_MSC_VER)
-			snprintf(h_Val, 3, "%hhX", ord);
+			snprintf(h_Val, 3, "%02hhX", ord);
 #else
-			sprintf(h_Val, "%hhX", ord);
+			sprintf(h_Val, "%02hhX", ord);
 #endif
 			res += "%";
 			res += h_Val;


### PR DESCRIPTION
This should fix the wrong encoding format mentioned in  #47475. It explicitly wants the hex number to be aligned to two digits, if it is too small, it just adds null. I tested it with reproduce function given in the issue, and it worked.

*Bugsquad edit:* fixes #47475.