### PR TITLE
Add editor singletons to expose more editor UI components

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -617,8 +617,8 @@ void ConnectionsDock::_connect(ConnectDialog::ConnectionData cToMake) {
 	undo_redo->add_undo_method(source, "disconnect", cToMake.signal, c);
 	undo_redo->add_do_method(this, "update_tree");
 	undo_redo->add_undo_method(this, "update_tree");
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); //to force redraw of scene tree
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); //to force redraw of scene tree
+	undo_redo->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -638,8 +638,8 @@ void ConnectionsDock::_disconnect(TreeItem &item) {
 	undo_redo->add_undo_method(selectedNode, "connect", c.signal, Callable(c.target, c.method), c.binds, c.flags);
 	undo_redo->add_do_method(this, "update_tree");
 	undo_redo->add_undo_method(this, "update_tree");
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
+	undo_redo->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -669,8 +669,8 @@ void ConnectionsDock::_disconnect_all() {
 
 	undo_redo->add_do_method(this, "update_tree");
 	undo_redo->add_undo_method(this, "update_tree");
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -39,13 +39,16 @@
 #include "editor/editor_inspector.h"
 #include "editor/scene_tree_editor.h"
 #include "scene/gui/button.h"
+#include "scene/gui/check_box.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/tree.h"
 
+class EditorNode;
 class PopupMenu;
 class ConnectDialogBinds;
 

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -38,6 +38,8 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/tree.h"
 
+class EditorHelpBit;
+
 class CreateDialog : public ConfirmationDialog {
 	GDCLASS(CreateDialog, ConfirmationDialog);
 

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -75,8 +75,8 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	remote_scene_tree = memnew(EditorDebuggerTree);
 	remote_scene_tree->connect("object_selected", callable_mp(this, &EditorDebuggerNode::_remote_object_requested));
 	remote_scene_tree->connect("save_node", callable_mp(this, &EditorDebuggerNode::_save_node_requested));
-	EditorNode::get_singleton()->get_scene_tree_dock()->add_remote_tree_editor(remote_scene_tree);
-	EditorNode::get_singleton()->get_scene_tree_dock()->connect("remote_tree_selected", callable_mp(this, &EditorDebuggerNode::request_remote_tree));
+	EditorDocks::get_singleton()->get_scene_tree_dock()->add_remote_tree_editor(remote_scene_tree);
+	EditorDocks::get_singleton()->get_scene_tree_dock()->connect("remote_tree_selected", callable_mp(this, &EditorDebuggerNode::request_remote_tree));
 
 	remote_scene_tree_timeout = EDITOR_DEF("debugger/remote_scene_tree_refresh_interval", 1.0);
 	inspect_edited_object_timeout = EDITOR_DEF("debugger/remote_inspect_refresh_interval", 0.2);
@@ -320,10 +320,10 @@ void EditorDebuggerNode::_notification(int p_what) {
 		// Switch to remote tree view if so desired.
 		auto_switch_remote_scene_tree = (bool)EditorSettings::get_singleton()->get("debugger/auto_switch_to_remote_scene_tree");
 		if (auto_switch_remote_scene_tree) {
-			EditorNode::get_singleton()->get_scene_tree_dock()->show_remote_tree();
+			EditorDocks::get_singleton()->get_scene_tree_dock()->show_remote_tree();
 		}
 		// Good to go.
-		EditorNode::get_singleton()->get_scene_tree_dock()->show_tab_buttons();
+		EditorDocks::get_singleton()->get_scene_tree_dock()->show_tab_buttons();
 		debugger->set_editor_remote_tree(remote_scene_tree);
 		debugger->start(server->take_connection());
 		// Send breakpoints.
@@ -349,8 +349,8 @@ void EditorDebuggerNode::_debugger_stopped(int p_id) {
 	if (!found) {
 		EditorNode::get_singleton()->get_pause_button()->set_pressed(false);
 		EditorNode::get_singleton()->get_pause_button()->set_disabled(true);
-		EditorNode::get_singleton()->get_scene_tree_dock()->hide_remote_tree();
-		EditorNode::get_singleton()->get_scene_tree_dock()->hide_tab_buttons();
+		EditorDocks::get_singleton()->get_scene_tree_dock()->hide_remote_tree();
+		EditorDocks::get_singleton()->get_scene_tree_dock()->hide_tab_buttons();
 		EditorNode::get_singleton()->notify_all_debug_sessions_exited();
 	}
 }

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -161,8 +161,9 @@ void EditorDebuggerNode::_bind_methods() {
 	ClassDB::bind_method("live_debug_reparent_node", &EditorDebuggerNode::live_debug_reparent_node);
 
 	ADD_SIGNAL(MethodInfo("goto_script_line"));
-	ADD_SIGNAL(MethodInfo("set_execution", PropertyInfo("script"), PropertyInfo(Variant::INT, "line")));
-	ADD_SIGNAL(MethodInfo("clear_execution", PropertyInfo("script")));
+
+	ADD_SIGNAL(MethodInfo("set_execution", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script"), PropertyInfo(Variant::INT, "line")));
+	ADD_SIGNAL(MethodInfo("clear_execution", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("breaked", PropertyInfo(Variant::BOOL, "reallydid"), PropertyInfo(Variant::BOOL, "can_debug")));
 }
 

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -128,7 +128,7 @@ void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position) {
 void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int p_debugger) {
 	updating_scene_tree = true;
 	const String last_path = get_selected_path();
-	const String filter = EditorNode::get_singleton()->get_scene_tree_dock()->get_filter();
+	const String filter = EditorDocks::get_singleton()->get_scene_tree_dock()->get_filter();
 	bool filter_changed = filter != last_filter;
 	TreeItem *scroll_item = nullptr;
 

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -205,7 +205,6 @@ bool DocTools::has_doc(const String &p_class_name) {
 static Variant get_documentation_default_value(const StringName &p_class_name, const StringName &p_property_name, bool &r_default_value_valid) {
 	Variant default_value = Variant();
 	r_default_value_valid = false;
-
 	if (ClassDB::can_instance(p_class_name)) {
 		default_value = ClassDB::class_get_default_property_value(p_class_name, p_property_name, &r_default_value_valid);
 	} else {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1018,7 +1018,8 @@ void EditorAudioBuses::_update_buses() {
 
 EditorAudioBuses *EditorAudioBuses::register_editor() {
 	EditorAudioBuses *audio_buses = memnew(EditorAudioBuses);
-	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Audio"), audio_buses);
+	EditorBottomPanels::get_singleton()->add_control(TTR("Audio"), audio_buses);
+	EditorBottomPanels::get_singleton()->set_audio_panel(audio_buses);
 	return audio_buses;
 }
 

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1176,7 +1176,7 @@ void EditorAudioBuses::_server_save() {
 }
 
 void EditorAudioBuses::_select_layout() {
-	EditorNode::get_singleton()->get_filesystem_dock()->select_file(edited_path);
+	EditorDocks::get_singleton()->get_filesystem_dock()->select_file(edited_path);
 }
 
 void EditorAudioBuses::_save_as_layout() {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3749,6 +3749,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_virtual_class<EditorInterface>();
 	ClassDB::register_virtual_class<EditorDocks>();
 	ClassDB::register_virtual_class<EditorBottomPanels>();
+	ClassDB::register_virtual_class<EditorWorkspaces>();
 	ClassDB::register_class<EditorExportPlugin>();
 	ClassDB::register_class<EditorResourceConversionPlugin>();
 	ClassDB::register_class<EditorSceneImporter>();
@@ -6748,6 +6749,9 @@ EditorNode::EditorNode() {
 	EditorBottomPanels::get_singleton()->set_output_panel(log);
 	add_child(editor_bottom_panels);
 
+	EditorWorkspaces *editor_workspaces = memnew(EditorWorkspaces(this));
+	add_child(editor_workspaces);
+
 	//plugin stuff
 
 	add_editor_plugin(memnew(DebuggerEditorPlugin(this, debug_menu)));
@@ -6786,7 +6790,7 @@ EditorNode::EditorNode() {
 	TextEditor::register_editor();
 
 	if (StreamPeerSSL::is_available()) {
-		add_editor_plugin(memnew(AssetLibraryEditorPlugin(this)));
+		add_editor_plugin(memnew(AssetLibraryEditorPlugin));
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -94,6 +94,7 @@
 #include "editor/editor_translation_parser.h"
 #include "editor/export_template_manager.h"
 #include "editor/filesystem_dock.h"
+#include "editor/find_in_files.h"
 #include "editor/import/editor_import_collada.h"
 #include "editor/import/resource_importer_bitmask.h"
 #include "editor/import/resource_importer_csv_translation.h"
@@ -3730,31 +3731,62 @@ void EditorNode::register_editor_types() {
 
 	ClassDB::register_class<EditorPaths>();
 	ClassDB::register_class<EditorPlugin>();
+	ClassDB::register_class<EditorScript>();
+
+	ClassDB::register_virtual_class<EditorInterface>();
+	ClassDB::register_virtual_class<EditorDocks>();
+	ClassDB::register_virtual_class<EditorBottomPanels>();
+	ClassDB::register_virtual_class<EditorWorkspaces>();
+	ClassDB::register_virtual_class<EditorPluginInterfaces>();
+
+	ClassDB::register_virtual_class<SceneTreeDock>();
+	ClassDB::register_virtual_class<NodeDock>();
+	ClassDB::register_virtual_class<ConnectionsDock>();
+	ClassDB::register_virtual_class<InspectorDock>();
+	ClassDB::register_virtual_class<ImportDock>();
+	ClassDB::register_virtual_class<FileSystemDock>();
+
+	ClassDB::register_virtual_class<EditorAudioBuses>();
+	ClassDB::register_virtual_class<EditorLog>();
+	ClassDB::register_virtual_class<AnimationPlayerEditor>();
+	ClassDB::register_virtual_class<AnimationTreeEditor>();
+	ClassDB::register_virtual_class<EditorDebuggerNode>();
+	ClassDB::register_virtual_class<ResourcePreloaderEditor>();
+	ClassDB::register_virtual_class<FindInFilesPanel>();
+	ClassDB::register_virtual_class<ShaderEditor>();
+	ClassDB::register_virtual_class<ShaderFileEditor>();
+	ClassDB::register_virtual_class<SpriteFramesEditor>();
+	ClassDB::register_virtual_class<TextureRegionEditor>();
+	ClassDB::register_virtual_class<ThemeEditor>();
+	ClassDB::register_virtual_class<TileSetEditor>();
+	ClassDB::register_virtual_class<VisualShaderEditor>();
+
+	ClassDB::register_virtual_class<CanvasItemEditor>();
+	ClassDB::register_virtual_class<Node3DEditor>();
+	ClassDB::register_virtual_class<ScriptEditor>();
+	ClassDB::register_virtual_class<EditorAssetLibrary>();
+
 	ClassDB::register_class<EditorTranslationParserPlugin>();
 	ClassDB::register_class<EditorImportPlugin>();
-	ClassDB::register_class<EditorScript>();
+	ClassDB::register_class<EditorExportPlugin>();
+	ClassDB::register_class<EditorNode3DGizmoPlugin>();
+	ClassDB::register_class<EditorInspectorPlugin>();
+	ClassDB::register_class<EditorSceneImporter>();
+	ClassDB::register_class<EditorDebuggerPlugin>();
+
 	ClassDB::register_class<EditorSelection>();
 	ClassDB::register_class<EditorFileDialog>();
 	ClassDB::register_virtual_class<EditorSettings>();
 	ClassDB::register_class<EditorNode3DGizmo>();
-	ClassDB::register_class<EditorNode3DGizmoPlugin>();
 	ClassDB::register_virtual_class<EditorResourcePreview>();
 	ClassDB::register_class<EditorResourcePreviewGenerator>();
 	ClassDB::register_virtual_class<EditorFileSystem>();
 	ClassDB::register_class<EditorFileSystemDirectory>();
 	ClassDB::register_class<EditorVCSInterface>();
-	ClassDB::register_virtual_class<ScriptEditor>();
 	ClassDB::register_virtual_class<ScriptEditorBase>();
 	ClassDB::register_class<EditorSyntaxHighlighter>();
-	ClassDB::register_virtual_class<EditorInterface>();
-	ClassDB::register_virtual_class<EditorDocks>();
-	ClassDB::register_virtual_class<EditorBottomPanels>();
-	ClassDB::register_virtual_class<EditorWorkspaces>();
-	ClassDB::register_class<EditorExportPlugin>();
 	ClassDB::register_class<EditorResourceConversionPlugin>();
-	ClassDB::register_class<EditorSceneImporter>();
 	ClassDB::register_class<EditorInspector>();
-	ClassDB::register_class<EditorInspectorPlugin>();
 	ClassDB::register_class<EditorProperty>();
 	ClassDB::register_class<AnimationTrackEditPlugin>();
 	ClassDB::register_class<ScriptCreateDialog>();
@@ -3764,14 +3796,11 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<EditorScriptPicker>();
 	ClassDB::register_class<EditorSceneImporterMesh>();
 	ClassDB::register_class<EditorSceneImporterMeshNode3D>();
-
-	ClassDB::register_virtual_class<FileSystemDock>();
-	ClassDB::register_virtual_class<SceneTreeDock>();
+	ClassDB::register_virtual_class<SceneTreeEditor>();
 
 	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?
 	ClassDB::register_class<EditorScenePostImport>();
 	//ClassDB::register_type<EditorImportExport>();
-	ClassDB::register_class<EditorDebuggerPlugin>();
 }
 
 void EditorNode::unregister_editor_types() {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3738,6 +3738,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_virtual_class<EditorBottomPanels>();
 	ClassDB::register_virtual_class<EditorWorkspaces>();
 	ClassDB::register_virtual_class<EditorPluginInterfaces>();
+	ClassDB::register_virtual_class<EditorTopBars>();
 
 	ClassDB::register_virtual_class<SceneTreeDock>();
 	ClassDB::register_virtual_class<NodeDock>();
@@ -6780,6 +6781,12 @@ EditorNode::EditorNode() {
 
 	EditorWorkspaces *editor_workspaces = memnew(EditorWorkspaces(this));
 	add_child(editor_workspaces);
+
+	EditorTopBars *editor_top_bars = memnew(EditorTopBars(this));
+	editor_top_bars->main_menu_bar = left_menu_hb;
+	editor_top_bars->workspaces_bar = main_editor_button_vb;
+	editor_top_bars->playtest_bar = play_hb;
+	editor_top_bars->video_driver_bar = right_menu_hb;
 
 	//plugin stuff
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -414,7 +414,7 @@ void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
 			_scene_tab_changed(next_tab);
 		}
 		if (ED_IS_SHORTCUT("editor/filter_files", p_event)) {
-			filesystem_dock->focus_on_filter();
+			EditorDocks::get_singleton()->get_filesystem_dock()->focus_on_filter();
 		}
 
 		if (ED_IS_SHORTCUT("editor/editor_2d", p_event)) {
@@ -1069,7 +1069,7 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 		return ERR_FILE_MISSING_DEPENDENCIES;
 	}
 
-	inspector_dock->edit_resource(res);
+	EditorDocks::get_singleton()->get_inspector_dock()->edit_resource(res);
 	return OK;
 }
 
@@ -1970,9 +1970,9 @@ void EditorNode::edit_item(Object *p_object) {
 void EditorNode::push_item(Object *p_object, const String &p_property, bool p_inspector_only) {
 	if (!p_object) {
 		get_inspector()->edit(nullptr);
-		node_dock->set_node(nullptr);
-		scene_tree_dock->set_selected(nullptr);
-		inspector_dock->update(nullptr);
+		EditorDocks::get_singleton()->get_node_dock()->set_node(nullptr);
+		EditorDocks::get_singleton()->get_scene_tree_dock()->set_selected(nullptr);
+		EditorDocks::get_singleton()->get_inspector_dock()->update(nullptr);
 		_display_top_editors(false);
 		return;
 	}
@@ -2037,10 +2037,10 @@ void EditorNode::_edit_current() {
 	this->current = current_obj;
 
 	if (!current_obj) {
-		scene_tree_dock->set_selected(nullptr);
+		EditorDocks::get_singleton()->get_scene_tree_dock()->set_selected(nullptr);
 		get_inspector()->edit(nullptr);
-		node_dock->set_node(nullptr);
-		inspector_dock->update(nullptr);
+		EditorDocks::get_singleton()->get_node_dock()->set_node(nullptr);
+		EditorDocks::get_singleton()->get_inspector_dock()->update(nullptr);
 
 		_display_top_editors(false);
 
@@ -2060,10 +2060,10 @@ void EditorNode::_edit_current() {
 		Resource *current_res = Object::cast_to<Resource>(current_obj);
 		ERR_FAIL_COND(!current_res);
 		get_inspector()->edit(current_res);
-		scene_tree_dock->set_selected(nullptr);
-		node_dock->set_node(nullptr);
-		inspector_dock->update(nullptr);
-		EditorNode::get_singleton()->get_import_dock()->set_edit_path(current_res->get_path());
+		EditorDocks::get_singleton()->get_scene_tree_dock()->set_selected(nullptr);
+		EditorDocks::get_singleton()->get_node_dock()->set_node(nullptr);
+		EditorDocks::get_singleton()->get_inspector_dock()->update(nullptr);
+		EditorDocks::get_singleton()->get_import_dock()->set_edit_path(current_res->get_path());
 
 		int subr_idx = current_res->get_path().find("::");
 		if (subr_idx != -1) {
@@ -2086,13 +2086,13 @@ void EditorNode::_edit_current() {
 
 		get_inspector()->edit(current_node);
 		if (current_node->is_inside_tree()) {
-			node_dock->set_node(current_node);
-			scene_tree_dock->set_selected(current_node);
-			inspector_dock->update(current_node);
+			EditorDocks::get_singleton()->get_node_dock()->set_node(current_node);
+			EditorDocks::get_singleton()->get_scene_tree_dock()->set_selected(current_node);
+			EditorDocks::get_singleton()->get_inspector_dock()->update(current_node);
 		} else {
-			node_dock->set_node(nullptr);
-			scene_tree_dock->set_selected(nullptr);
-			inspector_dock->update(nullptr);
+			EditorDocks::get_singleton()->get_node_dock()->set_node(nullptr);
+			EditorDocks::get_singleton()->get_scene_tree_dock()->set_selected(nullptr);
+			EditorDocks::get_singleton()->get_inspector_dock()->update(nullptr);
 		}
 
 		if (get_edited_scene() && get_edited_scene()->get_filename() != String()) {
@@ -2132,9 +2132,9 @@ void EditorNode::_edit_current() {
 		}
 
 		get_inspector()->edit(current_obj);
-		node_dock->set_node(nullptr);
-		scene_tree_dock->set_selected(selected_node);
-		inspector_dock->update(nullptr);
+		EditorDocks::get_singleton()->get_node_dock()->set_node(nullptr);
+		EditorDocks::get_singleton()->get_scene_tree_dock()->set_selected(selected_node);
+		EditorDocks::get_singleton()->get_inspector_dock()->update(nullptr);
 	}
 
 	if (current_obj == prev_inspected_object) {
@@ -2142,7 +2142,7 @@ void EditorNode::_edit_current() {
 		get_inspector()->update_tree();
 	}
 
-	inspector_dock->set_warning(editable_warning);
+	EditorDocks::get_singleton()->get_inspector_dock()->set_warning(editable_warning);
 
 	if (get_inspector()->is_capitalize_paths_enabled() != capitalize) {
 		get_inspector()->set_enable_capitalize_paths(capitalize);
@@ -2215,8 +2215,8 @@ void EditorNode::_edit_current() {
 		}
 	}
 
-	inspector_dock->update(current_obj);
-	inspector_dock->update_keying();
+	EditorDocks::get_singleton()->get_inspector_dock()->update(current_obj);
+	EditorDocks::get_singleton()->get_inspector_dock()->update_keying();
 }
 
 void EditorNode::_run(bool p_current, const String &p_custom) {
@@ -2669,7 +2669,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_SHOW_IN_FILESYSTEM: {
 			String path = editor_data.get_scene_path(editor_data.get_edited_scene());
 			if (path != String()) {
-				filesystem_dock->navigate_to_path(path);
+				EditorDocks::get_singleton()->get_filesystem_dock()->navigate_to_path(path);
 			}
 		} break;
 
@@ -3252,7 +3252,7 @@ void EditorNode::set_edited_scene(Node *p_scene) {
 	if (Object::cast_to<Popup>(p_scene)) {
 		Object::cast_to<Popup>(p_scene)->show(); //show popups
 	}
-	scene_tree_dock->set_edited_scene(p_scene);
+	EditorDocks::get_singleton()->get_scene_tree_dock()->set_edited_scene(p_scene);
 	if (get_tree()) {
 		get_tree()->set_edited_scene_root(p_scene);
 	}
@@ -3277,10 +3277,10 @@ int EditorNode::_get_current_main_editor() {
 Dictionary EditorNode::_get_main_scene_state() {
 	Dictionary state;
 	state["main_tab"] = _get_current_main_editor();
-	state["scene_tree_offset"] = scene_tree_dock->get_tree_editor()->get_scene_tree()->get_vscroll_bar()->get_value();
+	state["scene_tree_offset"] = EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor()->get_scene_tree()->get_vscroll_bar()->get_value();
 	state["property_edit_offset"] = get_inspector()->get_scroll_offset();
 	state["saved_version"] = saved_version;
-	state["node_filter"] = scene_tree_dock->get_filter();
+	state["node_filter"] = EditorDocks::get_singleton()->get_scene_tree_dock()->get_filter();
 	return state;
 }
 
@@ -3322,14 +3322,14 @@ void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
 	}
 
 	if (p_state.has("scene_tree_offset")) {
-		scene_tree_dock->get_tree_editor()->get_scene_tree()->get_vscroll_bar()->set_value(p_state["scene_tree_offset"]);
+		EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor()->get_scene_tree()->get_vscroll_bar()->set_value(p_state["scene_tree_offset"]);
 	}
 	if (p_state.has("property_edit_offset")) {
 		get_inspector()->set_scroll_offset(p_state["property_edit_offset"]);
 	}
 
 	if (p_state.has("node_filter")) {
-		scene_tree_dock->set_filter(p_state["node_filter"]);
+		EditorDocks::get_singleton()->get_scene_tree_dock()->set_filter(p_state["node_filter"]);
 	}
 
 	//this should only happen at the very end
@@ -3384,7 +3384,7 @@ void EditorNode::set_current_scene(int p_idx) {
 		Object::cast_to<Popup>(new_scene)->show(); //show popups
 	}
 
-	scene_tree_dock->set_edited_scene(new_scene);
+	EditorDocks::get_singleton()->get_scene_tree_dock()->set_edited_scene(new_scene);
 	if (get_tree()) {
 		get_tree()->set_edited_scene_root(new_scene);
 	}
@@ -3564,7 +3564,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	prev_scene->set_disabled(previous_scenes.size() == 0);
 	opening_prev = false;
-	scene_tree_dock->set_selected(new_scene);
+	EditorDocks::get_singleton()->get_scene_tree_dock()->set_selected(new_scene);
 
 	EditorDebuggerNode::get_singleton()->update_live_edit_root();
 
@@ -3589,27 +3589,11 @@ void EditorNode::open_request(const String &p_path) {
 }
 
 void EditorNode::request_instance_scene(const String &p_path) {
-	scene_tree_dock->instance(p_path);
+	EditorDocks::get_singleton()->get_scene_tree_dock()->instance(p_path);
 }
 
 void EditorNode::request_instance_scenes(const Vector<String> &p_files) {
-	scene_tree_dock->instance_scenes(p_files);
-}
-
-ImportDock *EditorNode::get_import_dock() {
-	return import_dock;
-}
-
-FileSystemDock *EditorNode::get_filesystem_dock() {
-	return filesystem_dock;
-}
-
-SceneTreeDock *EditorNode::get_scene_tree_dock() {
-	return scene_tree_dock;
-}
-
-InspectorDock *EditorNode::get_inspector_dock() {
-	return inspector_dock;
+	EditorDocks::get_singleton()->get_scene_tree_dock()->instance_scenes(p_files);
 }
 
 void EditorNode::_inherit_request(String p_file) {
@@ -3763,6 +3747,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_virtual_class<ScriptEditorBase>();
 	ClassDB::register_class<EditorSyntaxHighlighter>();
 	ClassDB::register_virtual_class<EditorInterface>();
+	ClassDB::register_virtual_class<EditorDocks>();
 	ClassDB::register_class<EditorExportPlugin>();
 	ClassDB::register_class<EditorResourceConversionPlugin>();
 	ClassDB::register_class<EditorSceneImporter>();
@@ -4383,10 +4368,10 @@ void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String &p
 		}
 	}
 
-	p_layout->set_value(p_section, "dock_filesystem_split", filesystem_dock->get_split_offset());
-	p_layout->set_value(p_section, "dock_filesystem_display_mode", filesystem_dock->get_display_mode());
-	p_layout->set_value(p_section, "dock_filesystem_file_sort", filesystem_dock->get_file_sort());
-	p_layout->set_value(p_section, "dock_filesystem_file_list_display_mode", filesystem_dock->get_file_list_display_mode());
+	p_layout->set_value(p_section, "dock_filesystem_split", EditorDocks::get_singleton()->get_filesystem_dock()->get_split_offset());
+	p_layout->set_value(p_section, "dock_filesystem_display_mode", EditorDocks::get_singleton()->get_filesystem_dock()->get_display_mode());
+	p_layout->set_value(p_section, "dock_filesystem_file_sort", EditorDocks::get_singleton()->get_filesystem_dock()->get_file_sort());
+	p_layout->set_value(p_section, "dock_filesystem_file_list_display_mode", EditorDocks::get_singleton()->get_filesystem_dock()->get_file_list_display_mode());
 
 	for (int i = 0; i < vsplits.size(); i++) {
 		if (vsplits[i]->is_visible_in_tree()) {
@@ -4572,22 +4557,22 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String 
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_split")) {
 		int fs_split_ofs = p_layout->get_value(p_section, "dock_filesystem_split");
-		filesystem_dock->set_split_offset(fs_split_ofs);
+		EditorDocks::get_singleton()->get_filesystem_dock()->set_split_offset(fs_split_ofs);
 	}
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_display_mode")) {
 		FileSystemDock::DisplayMode dock_filesystem_display_mode = FileSystemDock::DisplayMode(int(p_layout->get_value(p_section, "dock_filesystem_display_mode")));
-		filesystem_dock->set_display_mode(dock_filesystem_display_mode);
+		EditorDocks::get_singleton()->get_filesystem_dock()->set_display_mode(dock_filesystem_display_mode);
 	}
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_file_sort")) {
 		FileSystemDock::FileSortOption dock_filesystem_file_sort = FileSystemDock::FileSortOption(int(p_layout->get_value(p_section, "dock_filesystem_file_sort")));
-		filesystem_dock->set_file_sort(dock_filesystem_file_sort);
+		EditorDocks::get_singleton()->get_filesystem_dock()->set_file_sort(dock_filesystem_file_sort);
 	}
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_file_list_display_mode")) {
 		FileSystemDock::FileListDisplayMode dock_filesystem_file_list_display_mode = FileSystemDock::FileListDisplayMode(int(p_layout->get_value(p_section, "dock_filesystem_file_list_display_mode")));
-		filesystem_dock->set_file_list_display_mode(dock_filesystem_file_list_display_mode);
+		EditorDocks::get_singleton()->get_filesystem_dock()->set_file_list_display_mode(dock_filesystem_file_list_display_mode);
 	}
 
 	for (int i = 0; i < vsplits.size(); i++) {
@@ -4805,7 +4790,7 @@ void EditorNode::_layout_menu_option(int p_id) {
 void EditorNode::_scene_tab_script_edited(int p_tab) {
 	Ref<Script> script = editor_data.get_scene_root_script(p_tab);
 	if (script.is_valid()) {
-		inspector_dock->edit_resource(script);
+		EditorDocks::get_singleton()->get_inspector_dock()->edit_resource(script);
 	}
 }
 
@@ -5260,7 +5245,7 @@ void EditorNode::_global_menu_new_window(const Variant &p_tag) {
 }
 
 void EditorNode::_dropped_files(const Vector<String> &p_files, int p_screen) {
-	String to_path = ProjectSettings::get_singleton()->globalize_path(get_filesystem_dock()->get_selected_path());
+	String to_path = ProjectSettings::get_singleton()->globalize_path(EditorDocks::get_singleton()->get_filesystem_dock()->get_selected_path());
 
 	_add_dropped_files_recursive(p_files, to_path);
 
@@ -5488,15 +5473,15 @@ void EditorNode::_resource_loaded(RES p_resource, const String &p_path) {
 
 void EditorNode::_feature_profile_changed() {
 	Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
-	TabContainer *import_tabs = cast_to<TabContainer>(import_dock->get_parent());
-	TabContainer *node_tabs = cast_to<TabContainer>(node_dock->get_parent());
-	TabContainer *fs_tabs = cast_to<TabContainer>(filesystem_dock->get_parent());
+	TabContainer *import_tabs = cast_to<TabContainer>(EditorDocks::get_singleton()->get_import_dock()->get_parent());
+	TabContainer *node_tabs = cast_to<TabContainer>(EditorDocks::get_singleton()->get_node_dock()->get_parent());
+	TabContainer *fs_tabs = cast_to<TabContainer>(EditorDocks::get_singleton()->get_filesystem_dock()->get_parent());
 	if (profile.is_valid()) {
-		node_tabs->set_tab_hidden(node_dock->get_index(), profile->is_feature_disabled(EditorFeatureProfile::FEATURE_NODE_DOCK));
+		node_tabs->set_tab_hidden(EditorDocks::get_singleton()->get_node_dock()->get_index(), profile->is_feature_disabled(EditorFeatureProfile::FEATURE_NODE_DOCK));
 		// The Import dock is useless without the FileSystem dock. Ensure the configuration is valid.
 		bool fs_dock_disabled = profile->is_feature_disabled(EditorFeatureProfile::FEATURE_FILESYSTEM_DOCK);
-		fs_tabs->set_tab_hidden(filesystem_dock->get_index(), fs_dock_disabled);
-		import_tabs->set_tab_hidden(import_dock->get_index(), fs_dock_disabled || profile->is_feature_disabled(EditorFeatureProfile::FEATURE_IMPORT_DOCK));
+		fs_tabs->set_tab_hidden(EditorDocks::get_singleton()->get_filesystem_dock()->get_index(), fs_dock_disabled);
+		import_tabs->set_tab_hidden(EditorDocks::get_singleton()->get_import_dock()->get_index(), fs_dock_disabled || profile->is_feature_disabled(EditorFeatureProfile::FEATURE_IMPORT_DOCK));
 
 		main_editor_buttons[EDITOR_3D]->set_visible(!profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D));
 		main_editor_buttons[EDITOR_SCRIPT]->set_visible(!profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCRIPT));
@@ -5509,12 +5494,12 @@ void EditorNode::_feature_profile_changed() {
 			_editor_select(EDITOR_2D);
 		}
 	} else {
-		import_tabs->set_tab_hidden(import_dock->get_index(), false);
-		node_tabs->set_tab_hidden(node_dock->get_index(), false);
-		fs_tabs->set_tab_hidden(filesystem_dock->get_index(), false);
-		import_dock->set_visible(true);
-		node_dock->set_visible(true);
-		filesystem_dock->set_visible(true);
+		import_tabs->set_tab_hidden(EditorDocks::get_singleton()->get_import_dock()->get_index(), false);
+		node_tabs->set_tab_hidden(EditorDocks::get_singleton()->get_node_dock()->get_index(), false);
+		fs_tabs->set_tab_hidden(EditorDocks::get_singleton()->get_filesystem_dock()->get_index(), false);
+		EditorDocks::get_singleton()->get_import_dock()->set_visible(true);
+		EditorDocks::get_singleton()->get_node_dock()->set_visible(true);
+		EditorDocks::get_singleton()->get_filesystem_dock()->set_visible(true);
 		main_editor_buttons[EDITOR_3D]->set_visible(true);
 		main_editor_buttons[EDITOR_SCRIPT]->set_visible(true);
 		if (StreamPeerSSL::is_available()) {
@@ -6536,12 +6521,12 @@ EditorNode::EditorNode() {
 
 	// Instantiate and place editor docks
 
-	scene_tree_dock = memnew(SceneTreeDock(this, scene_root, editor_selection, editor_data));
-	inspector_dock = memnew(InspectorDock(this, editor_data));
-	import_dock = memnew(ImportDock);
-	node_dock = memnew(NodeDock);
+	SceneTreeDock *scene_tree_dock = memnew(SceneTreeDock(this, scene_root, editor_selection, editor_data));
+	InspectorDock *inspector_dock = memnew(InspectorDock(this, editor_data));
+	ImportDock *import_dock = memnew(ImportDock);
+	NodeDock *node_dock = memnew(NodeDock);
 
-	filesystem_dock = memnew(FileSystemDock(this));
+	FileSystemDock *filesystem_dock = memnew(FileSystemDock(this));
 	filesystem_dock->connect("inherit", callable_mp(this, &EditorNode::_inherit_request));
 	filesystem_dock->connect("instance", callable_mp(this, &EditorNode::_instance_request));
 	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_docks));
@@ -6742,6 +6727,20 @@ EditorNode::EditorNode() {
 
 	preview_gen = memnew(AudioStreamPreviewGenerator);
 	add_child(preview_gen);
+
+	// Initialize singletons before adding plugins
+
+	EditorInterface *editor_interface = memnew(EditorInterface);
+	add_child(editor_interface);
+	EditorDocks *editor_docks = memnew(EditorDocks);
+	add_child(editor_docks);
+	editor_docks->scene_tree_dock = scene_tree_dock;
+	editor_docks->filesystem_dock = filesystem_dock;
+	editor_docks->node_dock = node_dock;
+	//	editor_docks->connection_dock = node_dock->connections;
+	editor_docks->inspector_dock = inspector_dock;
+	editor_docks->import_dock = import_dock;
+
 	//plugin stuff
 
 	add_editor_plugin(memnew(DebuggerEditorPlugin(this, debug_menu)));
@@ -6784,11 +6783,6 @@ EditorNode::EditorNode() {
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
-
-	//add interface before adding plugins
-
-	editor_interface = memnew(EditorInterface);
-	add_child(editor_interface);
 
 	//more visually meaningful to have this later
 	raise_bottom_panel_item(AnimationPlayerEditor::singleton);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3739,6 +3739,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_virtual_class<EditorWorkspaces>();
 	ClassDB::register_virtual_class<EditorPluginInterfaces>();
 	ClassDB::register_virtual_class<EditorTopBars>();
+	ClassDB::register_virtual_class<EditorScenes>();
 
 	ClassDB::register_virtual_class<SceneTreeDock>();
 	ClassDB::register_virtual_class<NodeDock>();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3748,6 +3748,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<EditorSyntaxHighlighter>();
 	ClassDB::register_virtual_class<EditorInterface>();
 	ClassDB::register_virtual_class<EditorDocks>();
+	ClassDB::register_virtual_class<EditorBottomPanels>();
 	ClassDB::register_class<EditorExportPlugin>();
 	ClassDB::register_class<EditorResourceConversionPlugin>();
 	ClassDB::register_class<EditorSceneImporter>();
@@ -3764,6 +3765,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<EditorSceneImporterMeshNode3D>();
 
 	ClassDB::register_virtual_class<FileSystemDock>();
+	ClassDB::register_virtual_class<SceneTreeDock>();
 
 	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?
 	ClassDB::register_class<EditorScenePostImport>();
@@ -6730,9 +6732,10 @@ EditorNode::EditorNode() {
 
 	// Initialize singletons before adding plugins
 
-	EditorInterface *editor_interface = memnew(EditorInterface);
+	EditorInterface *editor_interface = memnew(EditorInterface(this));
 	add_child(editor_interface);
-	EditorDocks *editor_docks = memnew(EditorDocks);
+
+	EditorDocks *editor_docks = memnew(EditorDocks(this));
 	add_child(editor_docks);
 	editor_docks->scene_tree_dock = scene_tree_dock;
 	editor_docks->filesystem_dock = filesystem_dock;
@@ -6740,6 +6743,10 @@ EditorNode::EditorNode() {
 	//	editor_docks->connection_dock = node_dock->connections;
 	editor_docks->inspector_dock = inspector_dock;
 	editor_docks->import_dock = import_dock;
+
+	EditorBottomPanels *editor_bottom_panels = memnew(EditorBottomPanels(this));
+	EditorBottomPanels::get_singleton()->set_output_panel(log);
+	add_child(editor_bottom_panels);
 
 	//plugin stuff
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -684,10 +684,9 @@ public:
 	EditorPluginList *get_editor_plugins_over() { return editor_plugins_over; }
 	EditorPluginList *get_editor_plugins_force_over() { return editor_plugins_force_over; }
 	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
-	EditorInspector *get_inspector() { return EditorDocks::get_singleton()->get_inspector_dock()->get_inspector(); }
-	Container *get_inspector_dock_addon_area() { return EditorDocks::get_singleton()->get_inspector_dock()->get_addon_area(); }
-	ScriptCreateDialog *get_script_create_dialog() { return EditorDocks::get_singleton()->get_scene_tree_dock()->get_script_create_dialog(); }
-
+	EditorInspector *get_inspector() { return EditorDocks::singleton->inspector_dock->get_inspector(); }
+	Container *get_inspector_dock_addon_area() { return EditorDocks::singleton->inspector_dock->get_addon_area(); }
+	ScriptCreateDialog *get_script_create_dialog() { return EditorDocks::singleton->scene_tree_dock->get_script_create_dialog(); }
 	ProjectSettingsEditor *get_project_settings() { return project_settings; }
 
 	static void add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed = false);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -37,6 +37,7 @@
 #include "editor/editor_folding.h"
 #include "editor/editor_native_shader_source_visualizer.h"
 #include "editor/editor_run.h"
+#include "editor/editor_singletons.h"
 #include "editor/inspector_dock.h"
 #include "editor/property_editor.h"
 #include "editor/scene_tree_dock.h"
@@ -61,16 +62,15 @@ class EditorFileServer;
 class EditorInspector;
 class EditorLayoutsDialog;
 class EditorLog;
-class EditorPlugin;
 class EditorPluginList;
 class EditorQuickOpen;
 class EditorResourcePreview;
 class EditorRunNative;
 class EditorSettingsDialog;
 class ExportTemplateManager;
+class FileDialog;
 class FileSystemDock;
 class HSplitContainer;
-class ImportDock;
 class MenuButton;
 class NodeDock;
 class OrphanResourcesDialog;
@@ -288,11 +288,6 @@ private:
 	Ref<Theme> theme;
 
 	PopupMenu *recent_scenes;
-	SceneTreeDock *scene_tree_dock;
-	InspectorDock *inspector_dock;
-	NodeDock *node_dock;
-	ImportDock *import_dock;
-	FileSystemDock *filesystem_dock;
 	EditorRunNative *run_native;
 
 	ConfirmationDialog *confirmation;
@@ -432,8 +427,6 @@ private:
 	ConfirmationDialog *disk_changed;
 
 	void _bottom_panel_raise_toggled(bool);
-
-	EditorInterface *editor_interface;
 
 	void _bottom_panel_switch(bool p_enable, int p_idx);
 
@@ -691,9 +684,9 @@ public:
 	EditorPluginList *get_editor_plugins_over() { return editor_plugins_over; }
 	EditorPluginList *get_editor_plugins_force_over() { return editor_plugins_force_over; }
 	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
-	EditorInspector *get_inspector() { return inspector_dock->get_inspector(); }
-	Container *get_inspector_dock_addon_area() { return inspector_dock->get_addon_area(); }
-	ScriptCreateDialog *get_script_create_dialog() { return scene_tree_dock->get_script_create_dialog(); }
+	EditorInspector *get_inspector() { return EditorDocks::get_singleton()->get_inspector_dock()->get_inspector(); }
+	Container *get_inspector_dock_addon_area() { return EditorDocks::get_singleton()->get_inspector_dock()->get_addon_area(); }
+	ScriptCreateDialog *get_script_create_dialog() { return EditorDocks::get_singleton()->get_scene_tree_dock()->get_script_create_dialog(); }
 
 	ProjectSettingsEditor *get_project_settings() { return project_settings; }
 
@@ -717,8 +710,8 @@ public:
 	bool is_addon_plugin_enabled(const String &p_addon) const;
 
 	void edit_node(Node *p_node);
-	void edit_resource(const Ref<Resource> &p_resource) { inspector_dock->edit_resource(p_resource); };
-	void open_resource(const String &p_type) { inspector_dock->open_resource(p_type); };
+	void edit_resource(const Ref<Resource> &p_resource) { EditorDocks::get_singleton()->get_inspector_dock()->edit_resource(p_resource); };
+	void open_resource(const String &p_type) { EditorDocks::get_singleton()->get_inspector_dock()->open_resource(p_type); };
 
 	void save_resource_in_path(const Ref<Resource> &p_resource, const String &p_path);
 	void save_resource(const Ref<Resource> &p_resource);
@@ -770,10 +763,6 @@ public:
 
 	void request_instance_scene(const String &p_path);
 	void request_instance_scenes(const Vector<String> &p_files);
-	FileSystemDock *get_filesystem_dock();
-	ImportDock *get_import_dock();
-	SceneTreeDock *get_scene_tree_dock();
-	InspectorDock *get_inspector_dock();
 	static UndoRedo *get_undo_redo() { return &singleton->editor_data.get_undo_redo(); }
 
 	EditorSelection *get_editor_selection() { return editor_selection; }
@@ -861,7 +850,7 @@ public:
 
 	void edit_current() { _edit_current(); };
 
-	void update_keying() const { inspector_dock->update_keying(); };
+	void update_keying() const { EditorDocks::get_singleton()->get_inspector_dock()->update_keying(); };
 	bool has_scenes_in_session();
 
 	int execute_and_show_output(const String &p_title, const String &p_path, const List<String> &p_arguments, bool p_close_on_ok = true, bool p_close_on_errors = false);

--- a/editor/editor_path.h
+++ b/editor/editor_path.h
@@ -34,6 +34,8 @@
 #include "editor_data.h"
 #include "scene/gui/menu_button.h"
 
+class EditorHistory;
+
 class EditorPath : public MenuButton {
 	GDCLASS(EditorPath, MenuButton);
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -30,337 +30,12 @@
 
 #include "editor_plugin.h"
 
-#include "editor/editor_export.h"
 #include "editor/editor_node.h"
-#include "editor/editor_paths.h"
-#include "editor/editor_settings.h"
-#include "editor/filesystem_dock.h"
+#include "editor/editor_singletons.h"
+#include "editor/plugins/canvas_item_editor_plugin.h"
+#include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/project_settings_editor.h"
-#include "editor_resource_preview.h"
-#include "main/main.h"
-#include "plugins/canvas_item_editor_plugin.h"
-#include "plugins/node_3d_editor_plugin.h"
-#include "scene/3d/camera_3d.h"
-#include "scene/gui/popup_menu.h"
-#include "servers/rendering_server.h"
 
-Array EditorInterface::_make_mesh_previews(const Array &p_meshes, int p_preview_size) {
-	Vector<Ref<Mesh>> meshes;
-
-	for (int i = 0; i < p_meshes.size(); i++) {
-		meshes.push_back(p_meshes[i]);
-	}
-
-	Vector<Ref<Texture2D>> textures = make_mesh_previews(meshes, nullptr, p_preview_size);
-	Array ret;
-	for (int i = 0; i < textures.size(); i++) {
-		ret.push_back(textures[i]);
-	}
-
-	return ret;
-}
-
-Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform> *p_transforms, int p_preview_size) {
-	int size = p_preview_size;
-
-	RID scenario = RS::get_singleton()->scenario_create();
-
-	RID viewport = RS::get_singleton()->viewport_create();
-	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_ALWAYS);
-	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
-	RS::get_singleton()->viewport_set_size(viewport, size, size);
-	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
-	RS::get_singleton()->viewport_set_active(viewport, true);
-	RID viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
-
-	RID camera = RS::get_singleton()->camera_create();
-	RS::get_singleton()->viewport_attach_camera(viewport, camera);
-
-	RID light = RS::get_singleton()->directional_light_create();
-	RID light_instance = RS::get_singleton()->instance_create2(light, scenario);
-
-	RID light2 = RS::get_singleton()->directional_light_create();
-	RS::get_singleton()->light_set_color(light2, Color(0.7, 0.7, 0.7));
-	RID light_instance2 = RS::get_singleton()->instance_create2(light2, scenario);
-
-	EditorProgress ep("mlib", TTR("Creating Mesh Previews"), p_meshes.size());
-
-	Vector<Ref<Texture2D>> textures;
-
-	for (int i = 0; i < p_meshes.size(); i++) {
-		Ref<Mesh> mesh = p_meshes[i];
-		if (!mesh.is_valid()) {
-			textures.push_back(Ref<Texture2D>());
-			continue;
-		}
-
-		Transform mesh_xform;
-		if (p_transforms != nullptr) {
-			mesh_xform = (*p_transforms)[i];
-		}
-
-		RID inst = RS::get_singleton()->instance_create2(mesh->get_rid(), scenario);
-		RS::get_singleton()->instance_set_transform(inst, mesh_xform);
-
-		AABB aabb = mesh->get_aabb();
-		Vector3 ofs = aabb.position + aabb.size * 0.5;
-		aabb.position -= ofs;
-		Transform xform;
-		xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math_PI / 6);
-		xform.basis = Basis().rotated(Vector3(1, 0, 0), Math_PI / 6) * xform.basis;
-		AABB rot_aabb = xform.xform(aabb);
-		float m = MAX(rot_aabb.size.x, rot_aabb.size.y) * 0.5;
-		if (m == 0) {
-			textures.push_back(Ref<Texture2D>());
-			continue;
-		}
-		xform.origin = -xform.basis.xform(ofs); //-ofs*m;
-		xform.origin.z -= rot_aabb.size.z * 2;
-		xform.invert();
-		xform = mesh_xform * xform;
-
-		RS::get_singleton()->camera_set_transform(camera, xform * Transform(Basis(), Vector3(0, 0, 3)));
-		RS::get_singleton()->camera_set_orthogonal(camera, m * 2, 0.01, 1000.0);
-
-		RS::get_singleton()->instance_set_transform(light_instance, xform * Transform().looking_at(Vector3(-2, -1, -1), Vector3(0, 1, 0)));
-		RS::get_singleton()->instance_set_transform(light_instance2, xform * Transform().looking_at(Vector3(+1, -1, -2), Vector3(0, 1, 0)));
-
-		ep.step(TTR("Thumbnail..."), i);
-		Main::iteration();
-		Main::iteration();
-		Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
-		ERR_CONTINUE(!img.is_valid() || img->is_empty());
-		Ref<ImageTexture> it(memnew(ImageTexture));
-		it->create_from_image(img);
-
-		RS::get_singleton()->free(inst);
-
-		textures.push_back(it);
-	}
-
-	RS::get_singleton()->free(viewport);
-	RS::get_singleton()->free(light);
-	RS::get_singleton()->free(light_instance);
-	RS::get_singleton()->free(light2);
-	RS::get_singleton()->free(light_instance2);
-	RS::get_singleton()->free(camera);
-	RS::get_singleton()->free(scenario);
-
-	return textures;
-}
-
-void EditorInterface::set_main_screen_editor(const String &p_name) {
-	EditorNode::get_singleton()->select_editor_by_name(p_name);
-}
-
-Control *EditorInterface::get_editor_main_control() {
-	return EditorNode::get_singleton()->get_main_control();
-}
-
-void EditorInterface::edit_resource(const Ref<Resource> &p_resource) {
-	EditorNode::get_singleton()->edit_resource(p_resource);
-}
-
-void EditorInterface::edit_node(Node *p_node) {
-	EditorNode::get_singleton()->edit_node(p_node);
-}
-
-void EditorInterface::open_scene_from_path(const String &scene_path) {
-	if (EditorNode::get_singleton()->is_changing_scene()) {
-		return;
-	}
-
-	EditorNode::get_singleton()->open_request(scene_path);
-}
-
-void EditorInterface::reload_scene_from_path(const String &scene_path) {
-	if (EditorNode::get_singleton()->is_changing_scene()) {
-		return;
-	}
-
-	EditorNode::get_singleton()->reload_scene(scene_path);
-}
-
-void EditorInterface::play_main_scene() {
-	EditorNode::get_singleton()->run_play();
-}
-
-void EditorInterface::play_current_scene() {
-	EditorNode::get_singleton()->run_play_current();
-}
-
-void EditorInterface::play_custom_scene(const String &scene_path) {
-	EditorNode::get_singleton()->run_play_custom(scene_path);
-}
-
-void EditorInterface::stop_playing_scene() {
-	EditorNode::get_singleton()->run_stop();
-}
-
-bool EditorInterface::is_playing_scene() const {
-	return EditorNode::get_singleton()->is_run_playing();
-}
-
-String EditorInterface::get_playing_scene() const {
-	return EditorNode::get_singleton()->get_run_playing_scene();
-}
-
-Node *EditorInterface::get_edited_scene_root() {
-	return EditorNode::get_singleton()->get_edited_scene();
-}
-
-Array EditorInterface::get_open_scenes() const {
-	Array ret;
-	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
-
-	int scns_amount = scenes.size();
-	for (int idx_scn = 0; idx_scn < scns_amount; idx_scn++) {
-		if (scenes[idx_scn].root == nullptr) {
-			continue;
-		}
-		ret.push_back(scenes[idx_scn].root->get_filename());
-	}
-	return ret;
-}
-
-ScriptEditor *EditorInterface::get_script_editor() {
-	return ScriptEditor::get_singleton();
-}
-
-void EditorInterface::select_file(const String &p_file) {
-	EditorNode::get_singleton()->get_filesystem_dock()->select_file(p_file);
-}
-
-String EditorInterface::get_selected_path() const {
-	return EditorNode::get_singleton()->get_filesystem_dock()->get_selected_path();
-}
-
-String EditorInterface::get_current_path() const {
-	return EditorNode::get_singleton()->get_filesystem_dock()->get_current_path();
-}
-
-void EditorInterface::inspect_object(Object *p_obj, const String &p_for_property, bool p_inspector_only) {
-	EditorNode::get_singleton()->push_item(p_obj, p_for_property, p_inspector_only);
-}
-
-EditorFileSystem *EditorInterface::get_resource_file_system() {
-	return EditorFileSystem::get_singleton();
-}
-
-FileSystemDock *EditorInterface::get_file_system_dock() {
-	return EditorNode::get_singleton()->get_filesystem_dock();
-}
-
-EditorSelection *EditorInterface::get_selection() {
-	return EditorNode::get_singleton()->get_editor_selection();
-}
-
-Ref<EditorSettings> EditorInterface::get_editor_settings() {
-	return EditorSettings::get_singleton();
-}
-EditorPaths *EditorInterface::get_editor_paths() {
-	return EditorPaths::get_singleton();
-}
-
-EditorResourcePreview *EditorInterface::get_resource_previewer() {
-	return EditorResourcePreview::get_singleton();
-}
-
-Control *EditorInterface::get_base_control() {
-	return EditorNode::get_singleton()->get_gui_base();
-}
-
-float EditorInterface::get_editor_scale() const {
-	return EDSCALE;
-}
-
-void EditorInterface::set_plugin_enabled(const String &p_plugin, bool p_enabled) {
-	EditorNode::get_singleton()->set_addon_plugin_enabled(p_plugin, p_enabled, true);
-}
-
-bool EditorInterface::is_plugin_enabled(const String &p_plugin) const {
-	return EditorNode::get_singleton()->is_addon_plugin_enabled(p_plugin);
-}
-
-EditorInspector *EditorInterface::get_inspector() const {
-	return EditorNode::get_singleton()->get_inspector();
-}
-
-Error EditorInterface::save_scene() {
-	if (!get_edited_scene_root()) {
-		return ERR_CANT_CREATE;
-	}
-	if (get_edited_scene_root()->get_filename() == String()) {
-		return ERR_CANT_CREATE;
-	}
-
-	save_scene_as(get_edited_scene_root()->get_filename());
-	return OK;
-}
-
-void EditorInterface::save_scene_as(const String &p_scene, bool p_with_preview) {
-	EditorNode::get_singleton()->save_scene_to_path(p_scene, p_with_preview);
-}
-
-void EditorInterface::set_distraction_free_mode(bool p_enter) {
-	EditorNode::get_singleton()->set_distraction_free_mode(p_enter);
-}
-
-bool EditorInterface::is_distraction_free_mode_enabled() const {
-	return EditorNode::get_singleton()->is_distraction_free_mode_enabled();
-}
-
-EditorInterface *EditorInterface::singleton = nullptr;
-
-void EditorInterface::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("inspect_object", "object", "for_property", "inspector_only"), &EditorInterface::inspect_object, DEFVAL(String()), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
-	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
-	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);
-	ClassDB::bind_method(D_METHOD("get_base_control"), &EditorInterface::get_base_control);
-	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
-	ClassDB::bind_method(D_METHOD("edit_resource", "resource"), &EditorInterface::edit_resource);
-	ClassDB::bind_method(D_METHOD("edit_node", "node"), &EditorInterface::edit_node);
-	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath"), &EditorInterface::open_scene_from_path);
-	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
-	ClassDB::bind_method(D_METHOD("play_main_scene"), &EditorInterface::play_main_scene);
-	ClassDB::bind_method(D_METHOD("play_current_scene"), &EditorInterface::play_current_scene);
-	ClassDB::bind_method(D_METHOD("play_custom_scene", "scene_filepath"), &EditorInterface::play_custom_scene);
-	ClassDB::bind_method(D_METHOD("stop_playing_scene"), &EditorInterface::stop_playing_scene);
-	ClassDB::bind_method(D_METHOD("is_playing_scene"), &EditorInterface::is_playing_scene);
-	ClassDB::bind_method(D_METHOD("get_playing_scene"), &EditorInterface::get_playing_scene);
-	ClassDB::bind_method(D_METHOD("get_open_scenes"), &EditorInterface::get_open_scenes);
-	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root);
-	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
-	ClassDB::bind_method(D_METHOD("get_resource_filesystem"), &EditorInterface::get_resource_file_system);
-	ClassDB::bind_method(D_METHOD("get_editor_main_control"), &EditorInterface::get_editor_main_control);
-	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
-	ClassDB::bind_method(D_METHOD("select_file", "file"), &EditorInterface::select_file);
-	ClassDB::bind_method(D_METHOD("get_selected_path"), &EditorInterface::get_selected_path);
-	ClassDB::bind_method(D_METHOD("get_current_path"), &EditorInterface::get_current_path);
-	ClassDB::bind_method(D_METHOD("get_file_system_dock"), &EditorInterface::get_file_system_dock);
-	ClassDB::bind_method(D_METHOD("get_editor_paths"), &EditorInterface::get_editor_paths);
-
-	ClassDB::bind_method(D_METHOD("set_plugin_enabled", "plugin", "enabled"), &EditorInterface::set_plugin_enabled);
-	ClassDB::bind_method(D_METHOD("is_plugin_enabled", "plugin"), &EditorInterface::is_plugin_enabled);
-
-	ClassDB::bind_method(D_METHOD("get_inspector"), &EditorInterface::get_inspector);
-
-	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);
-	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));
-
-	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
-	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);
-	ClassDB::bind_method(D_METHOD("is_distraction_free_mode_enabled"), &EditorInterface::is_distraction_free_mode_enabled);
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
-}
-
-EditorInterface::EditorInterface() {
-	singleton = this;
-}
-
-///////////////////////////////////////////
 void EditorPlugin::add_custom_type(const String &p_type, const String &p_base, const Ref<Script> &p_script, const Ref<Texture2D> &p_icon) {
 	EditorNode::get_editor_data().add_custom_type(p_type, p_base, p_script, p_icon);
 }
@@ -708,14 +383,6 @@ bool EditorPlugin::get_remove_list(List<Node *> *p_list) {
 void EditorPlugin::restore_global_state() {}
 void EditorPlugin::save_global_state() {}
 
-void EditorPlugin::add_undo_redo_inspector_hook_callback(Callable p_callable) {
-	EditorNode::get_singleton()->get_editor_data().add_undo_redo_inspector_hook_callback(p_callable);
-}
-
-void EditorPlugin::remove_undo_redo_inspector_hook_callback(Callable p_callable) {
-	EditorNode::get_singleton()->get_editor_data().remove_undo_redo_inspector_hook_callback(p_callable);
-}
-
 void EditorPlugin::add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
 	EditorTranslationParser::get_singleton()->add_parser(p_parser, EditorTranslationParser::CUSTOM);
 }
@@ -829,6 +496,10 @@ EditorInterface *EditorPlugin::get_editor_interface() {
 	return EditorInterface::get_singleton();
 }
 
+EditorDocks *EditorPlugin::get_editor_docks() {
+	return EditorDocks::get_singleton();
+}
+
 ScriptCreateDialog *EditorPlugin::get_script_create_dialog() {
 	return EditorNode::get_singleton()->get_script_create_dialog();
 }
@@ -875,8 +546,6 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("hide_bottom_panel"), &EditorPlugin::hide_bottom_panel);
 
 	ClassDB::bind_method(D_METHOD("get_undo_redo"), &EditorPlugin::_get_undo_redo);
-	ClassDB::bind_method(D_METHOD("add_undo_redo_inspector_hook_callback", "callable"), &EditorPlugin::add_undo_redo_inspector_hook_callback);
-	ClassDB::bind_method(D_METHOD("remove_undo_redo_inspector_hook_callback", "callable"), &EditorPlugin::remove_undo_redo_inspector_hook_callback);
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);
 	ClassDB::bind_method(D_METHOD("add_translation_parser_plugin", "parser"), &EditorPlugin::add_translation_parser_plugin);
 	ClassDB::bind_method(D_METHOD("remove_translation_parser_plugin", "parser"), &EditorPlugin::remove_translation_parser_plugin);
@@ -894,6 +563,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_force_draw_over_forwarding_enabled"), &EditorPlugin::set_force_draw_over_forwarding_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
+	ClassDB::bind_method(D_METHOD("get_editor_docks"), &EditorPlugin::get_editor_docks);
 	ClassDB::bind_method(D_METHOD("get_script_create_dialog"), &EditorPlugin::get_script_create_dialog);
 	ClassDB::bind_method(D_METHOD("add_debugger_plugin", "script"), &EditorPlugin::add_debugger_plugin);
 	ClassDB::bind_method(D_METHOD("remove_debugger_plugin", "script"), &EditorPlugin::remove_debugger_plugin);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -363,56 +363,6 @@ bool EditorPlugin::get_remove_list(List<Node *> *p_list) {
 void EditorPlugin::restore_global_state() {}
 void EditorPlugin::save_global_state() {}
 
-void EditorPlugin::add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
-	EditorTranslationParser::get_singleton()->add_parser(p_parser, EditorTranslationParser::CUSTOM);
-}
-
-void EditorPlugin::remove_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
-	EditorTranslationParser::get_singleton()->remove_parser(p_parser, EditorTranslationParser::CUSTOM);
-}
-
-void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
-	ResourceFormatImporter::get_singleton()->add_importer(p_importer);
-	EditorFileSystem::get_singleton()->call_deferred("scan");
-}
-
-void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
-	ResourceFormatImporter::get_singleton()->remove_importer(p_importer);
-	EditorFileSystem::get_singleton()->call_deferred("scan");
-}
-
-void EditorPlugin::add_export_plugin(const Ref<EditorExportPlugin> &p_exporter) {
-	EditorExport::get_singleton()->add_export_plugin(p_exporter);
-}
-
-void EditorPlugin::remove_export_plugin(const Ref<EditorExportPlugin> &p_exporter) {
-	EditorExport::get_singleton()->remove_export_plugin(p_exporter);
-}
-
-void EditorPlugin::add_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
-	Node3DEditor::get_singleton()->add_gizmo_plugin(p_gizmo_plugin);
-}
-
-void EditorPlugin::remove_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
-	Node3DEditor::get_singleton()->remove_gizmo_plugin(p_gizmo_plugin);
-}
-
-void EditorPlugin::add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
-	EditorInspector::add_inspector_plugin(p_plugin);
-}
-
-void EditorPlugin::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
-	EditorInspector::remove_inspector_plugin(p_plugin);
-}
-
-void EditorPlugin::add_scene_import_plugin(const Ref<EditorSceneImporter> &p_importer) {
-	ResourceImporterScene::get_singleton()->add_importer(p_importer);
-}
-
-void EditorPlugin::remove_scene_import_plugin(const Ref<EditorSceneImporter> &p_importer) {
-	ResourceImporterScene::get_singleton()->remove_importer(p_importer);
-}
-
 int find(const PackedStringArray &a, const String &v) {
 	const String *r = a.ptr();
 	for (int j = 0; j < a.size(); ++j) {
@@ -480,14 +430,6 @@ ScriptCreateDialog *EditorPlugin::get_script_create_dialog() {
 	return EditorNode::get_singleton()->get_script_create_dialog();
 }
 
-void EditorPlugin::add_debugger_plugin(const Ref<Script> &p_script) {
-	EditorDebuggerNode::get_singleton()->add_debugger_plugin(p_script);
-}
-
-void EditorPlugin::remove_debugger_plugin(const Ref<Script> &p_script) {
-	EditorDebuggerNode::get_singleton()->remove_debugger_plugin(p_script);
-}
-
 void EditorPlugin::_editor_project_settings_changed() {
 	emit_signal("project_settings_changed");
 }
@@ -516,18 +458,6 @@ void EditorPlugin::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_undo_redo"), &EditorPlugin::_get_undo_redo);
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);
-	ClassDB::bind_method(D_METHOD("add_translation_parser_plugin", "parser"), &EditorPlugin::add_translation_parser_plugin);
-	ClassDB::bind_method(D_METHOD("remove_translation_parser_plugin", "parser"), &EditorPlugin::remove_translation_parser_plugin);
-	ClassDB::bind_method(D_METHOD("add_import_plugin", "importer"), &EditorPlugin::add_import_plugin);
-	ClassDB::bind_method(D_METHOD("remove_import_plugin", "importer"), &EditorPlugin::remove_import_plugin);
-	ClassDB::bind_method(D_METHOD("add_scene_import_plugin", "scene_importer"), &EditorPlugin::add_scene_import_plugin);
-	ClassDB::bind_method(D_METHOD("remove_scene_import_plugin", "scene_importer"), &EditorPlugin::remove_scene_import_plugin);
-	ClassDB::bind_method(D_METHOD("add_export_plugin", "plugin"), &EditorPlugin::add_export_plugin);
-	ClassDB::bind_method(D_METHOD("remove_export_plugin", "plugin"), &EditorPlugin::remove_export_plugin);
-	ClassDB::bind_method(D_METHOD("add_spatial_gizmo_plugin", "plugin"), &EditorPlugin::add_spatial_gizmo_plugin);
-	ClassDB::bind_method(D_METHOD("remove_spatial_gizmo_plugin", "plugin"), &EditorPlugin::remove_spatial_gizmo_plugin);
-	ClassDB::bind_method(D_METHOD("add_inspector_plugin", "plugin"), &EditorPlugin::add_inspector_plugin);
-	ClassDB::bind_method(D_METHOD("remove_inspector_plugin", "plugin"), &EditorPlugin::remove_inspector_plugin);
 	ClassDB::bind_method(D_METHOD("set_input_event_forwarding_always_enabled"), &EditorPlugin::set_input_event_forwarding_always_enabled);
 	ClassDB::bind_method(D_METHOD("set_force_draw_over_forwarding_enabled"), &EditorPlugin::set_force_draw_over_forwarding_enabled);
 
@@ -535,8 +465,6 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_docks"), &EditorPlugin::get_editor_docks);
 	ClassDB::bind_method(D_METHOD("get_editor_bottom_panels"), &EditorPlugin::get_editor_bottom_panels);
 	ClassDB::bind_method(D_METHOD("get_script_create_dialog"), &EditorPlugin::get_script_create_dialog);
-	ClassDB::bind_method(D_METHOD("add_debugger_plugin", "script"), &EditorPlugin::add_debugger_plugin);
-	ClassDB::bind_method(D_METHOD("remove_debugger_plugin", "script"), &EditorPlugin::remove_debugger_plugin);
 
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_canvas_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -159,21 +159,6 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 	}
 }
 
-void EditorPlugin::add_tool_menu_item(const String &p_name, const Callable &p_callable) {
-	EditorNode::get_singleton()->add_tool_menu_item(p_name, p_callable);
-}
-
-void EditorPlugin::add_tool_submenu_item(const String &p_name, Object *p_submenu) {
-	ERR_FAIL_NULL(p_submenu);
-	PopupMenu *submenu = Object::cast_to<PopupMenu>(p_submenu);
-	ERR_FAIL_NULL(submenu);
-	EditorNode::get_singleton()->add_tool_submenu_item(p_name, submenu);
-}
-
-void EditorPlugin::remove_tool_menu_item(const String &p_name) {
-	EditorNode::get_singleton()->remove_tool_menu_item(p_name);
-}
-
 void EditorPlugin::set_input_event_forwarding_always_enabled() {
 	input_event_forwarding_always_enabled = true;
 	EditorPluginList *always_input_forwarding_list = EditorNode::get_singleton()->get_editor_plugins_force_input_forwarding();
@@ -453,9 +438,6 @@ void EditorPlugin::_notification(int p_what) {
 void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_control_to_container", "container", "control"), &EditorPlugin::add_control_to_container);
 	ClassDB::bind_method(D_METHOD("remove_control_from_container", "container", "control"), &EditorPlugin::remove_control_from_container);
-	ClassDB::bind_method(D_METHOD("add_tool_menu_item", "name", "callable"), &EditorPlugin::add_tool_menu_item);
-	ClassDB::bind_method(D_METHOD("add_tool_submenu_item", "name", "submenu"), &EditorPlugin::add_tool_submenu_item);
-	ClassDB::bind_method(D_METHOD("remove_tool_menu_item", "name"), &EditorPlugin::remove_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("add_custom_type", "type", "base", "script", "icon"), &EditorPlugin::add_custom_type);
 	ClassDB::bind_method(D_METHOD("remove_custom_type", "type"), &EditorPlugin::remove_custom_type);
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -426,6 +426,14 @@ EditorBottomPanels *EditorPlugin::get_editor_bottom_panels() {
 	return EditorBottomPanels::get_singleton();
 }
 
+EditorPluginInterfaces *EditorPlugin::get_editor_plugin_interfaces() {
+	return EditorPluginInterfaces::get_singleton();
+}
+
+EditorTopBars *EditorPlugin::get_editor_top_bars() {
+	return EditorTopBars::get_singleton();
+}
+
 ScriptCreateDialog *EditorPlugin::get_script_create_dialog() {
 	return EditorNode::get_singleton()->get_script_create_dialog();
 }
@@ -464,6 +472,9 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
 	ClassDB::bind_method(D_METHOD("get_editor_docks"), &EditorPlugin::get_editor_docks);
 	ClassDB::bind_method(D_METHOD("get_editor_bottom_panels"), &EditorPlugin::get_editor_bottom_panels);
+	ClassDB::bind_method(D_METHOD("get_editor_plugin_interfaces"), &EditorPlugin::get_editor_plugin_interfaces);
+	ClassDB::bind_method(D_METHOD("get_editor_top_bars"), &EditorPlugin::get_editor_top_bars);
+
 	ClassDB::bind_method(D_METHOD("get_script_create_dialog"), &EditorPlugin::get_script_create_dialog);
 
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -52,26 +52,6 @@ void EditorPlugin::remove_autoload_singleton(const String &p_name) {
 	EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_remove(p_name);
 }
 
-Button *EditorPlugin::add_control_to_bottom_panel(Control *p_control, const String &p_title) {
-	ERR_FAIL_NULL_V(p_control, nullptr);
-	return EditorNode::get_singleton()->add_bottom_panel_item(p_title, p_control);
-}
-
-void EditorPlugin::add_control_to_dock(DockSlot p_slot, Control *p_control) {
-	ERR_FAIL_NULL(p_control);
-	EditorNode::get_singleton()->add_control_to_dock(EditorNode::DockSlot(p_slot), p_control);
-}
-
-void EditorPlugin::remove_control_from_docks(Control *p_control) {
-	ERR_FAIL_NULL(p_control);
-	EditorNode::get_singleton()->remove_control_from_dock(p_control);
-}
-
-void EditorPlugin::remove_control_from_bottom_panel(Control *p_control) {
-	ERR_FAIL_NULL(p_control);
-	EditorNode::get_singleton()->remove_bottom_panel_item(p_control);
-}
-
 void EditorPlugin::add_control_to_container(CustomControlContainer p_location, Control *p_control) {
 	ERR_FAIL_NULL(p_control);
 
@@ -484,20 +464,16 @@ void EditorPlugin::queue_save_layout() {
 	EditorNode::get_singleton()->save_layout();
 }
 
-void EditorPlugin::make_bottom_panel_item_visible(Control *p_item) {
-	EditorNode::get_singleton()->make_bottom_panel_item_visible(p_item);
-}
-
-void EditorPlugin::hide_bottom_panel() {
-	EditorNode::get_singleton()->hide_bottom_panel();
-}
-
 EditorInterface *EditorPlugin::get_editor_interface() {
 	return EditorInterface::get_singleton();
 }
 
 EditorDocks *EditorPlugin::get_editor_docks() {
 	return EditorDocks::get_singleton();
+}
+
+EditorBottomPanels *EditorPlugin::get_editor_bottom_panels() {
+	return EditorBottomPanels::get_singleton();
 }
 
 ScriptCreateDialog *EditorPlugin::get_script_create_dialog() {
@@ -526,10 +502,6 @@ void EditorPlugin::_notification(int p_what) {
 
 void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_control_to_container", "container", "control"), &EditorPlugin::add_control_to_container);
-	ClassDB::bind_method(D_METHOD("add_control_to_bottom_panel", "control", "title"), &EditorPlugin::add_control_to_bottom_panel);
-	ClassDB::bind_method(D_METHOD("add_control_to_dock", "slot", "control"), &EditorPlugin::add_control_to_dock);
-	ClassDB::bind_method(D_METHOD("remove_control_from_docks", "control"), &EditorPlugin::remove_control_from_docks);
-	ClassDB::bind_method(D_METHOD("remove_control_from_bottom_panel", "control"), &EditorPlugin::remove_control_from_bottom_panel);
 	ClassDB::bind_method(D_METHOD("remove_control_from_container", "container", "control"), &EditorPlugin::remove_control_from_container);
 	ClassDB::bind_method(D_METHOD("add_tool_menu_item", "name", "callable"), &EditorPlugin::add_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("add_tool_submenu_item", "name", "submenu"), &EditorPlugin::add_tool_submenu_item);
@@ -541,9 +513,6 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_autoload_singleton", "name"), &EditorPlugin::remove_autoload_singleton);
 
 	ClassDB::bind_method(D_METHOD("update_overlays"), &EditorPlugin::update_overlays);
-
-	ClassDB::bind_method(D_METHOD("make_bottom_panel_item_visible", "item"), &EditorPlugin::make_bottom_panel_item_visible);
-	ClassDB::bind_method(D_METHOD("hide_bottom_panel"), &EditorPlugin::hide_bottom_panel);
 
 	ClassDB::bind_method(D_METHOD("get_undo_redo"), &EditorPlugin::_get_undo_redo);
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);
@@ -564,6 +533,7 @@ void EditorPlugin::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
 	ClassDB::bind_method(D_METHOD("get_editor_docks"), &EditorPlugin::get_editor_docks);
+	ClassDB::bind_method(D_METHOD("get_editor_bottom_panels"), &EditorPlugin::get_editor_bottom_panels);
 	ClassDB::bind_method(D_METHOD("get_script_create_dialog"), &EditorPlugin::get_script_create_dialog);
 	ClassDB::bind_method(D_METHOD("add_debugger_plugin", "script"), &EditorPlugin::add_debugger_plugin);
 	ClassDB::bind_method(D_METHOD("remove_debugger_plugin", "script"), &EditorPlugin::remove_debugger_plugin);
@@ -610,16 +580,6 @@ void EditorPlugin::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONTAINER_PROPERTY_EDITOR_BOTTOM);
 	BIND_ENUM_CONSTANT(CONTAINER_PROJECT_SETTING_TAB_LEFT);
 	BIND_ENUM_CONSTANT(CONTAINER_PROJECT_SETTING_TAB_RIGHT);
-
-	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_UL);
-	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_BL);
-	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_UR);
-	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_BR);
-	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_UL);
-	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_BL);
-	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_UR);
-	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_BR);
-	BIND_ENUM_CONSTANT(DOCK_SLOT_MAX);
 }
 
 EditorPluginCreateFunc EditorPlugins::creation_funcs[MAX_CREATE_FUNCS];

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -141,6 +141,7 @@ public:
 	EditorBottomPanels *get_editor_bottom_panels();
 	EditorWorkspaces *get_editor_workspaces();
 	EditorPluginInterfaces *get_editor_plugin_interfaces();
+	EditorTopBars *get_editor_top_bars();
 
 	ScriptCreateDialog *get_script_create_dialog();
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -34,7 +34,9 @@
 #include "core/io/config_file.h"
 #include "core/object/undo_redo.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/editor_export.h"
 #include "editor/editor_inspector.h"
+#include "editor/editor_singletons.h"
 #include "editor/editor_translation_parser.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_scene.h"
@@ -43,87 +45,13 @@
 #include "scene/resources/texture.h"
 
 class EditorNode;
-class Node3D;
-class Camera3D;
-class EditorSelection;
-class EditorExport;
-class EditorSettings;
-class EditorImportPlugin;
-class EditorExportPlugin;
+class EditorInterface;
+class EditorDocks;
 class EditorNode3DGizmoPlugin;
-class EditorResourcePreview;
-class EditorFileSystem;
-class EditorToolAddons;
-class EditorPaths;
-class FileSystemDock;
-class ScriptEditor;
-
-class EditorInterface : public Node {
-	GDCLASS(EditorInterface, Node);
-
-protected:
-	static void _bind_methods();
-	static EditorInterface *singleton;
-
-	Array _make_mesh_previews(const Array &p_meshes, int p_preview_size);
-
-public:
-	static EditorInterface *get_singleton() { return singleton; }
-
-	Control *get_editor_main_control();
-	void edit_resource(const Ref<Resource> &p_resource);
-	void edit_node(Node *p_node);
-	void open_scene_from_path(const String &scene_path);
-	void reload_scene_from_path(const String &scene_path);
-
-	void play_main_scene();
-	void play_current_scene();
-	void play_custom_scene(const String &scene_path);
-	void stop_playing_scene();
-	bool is_playing_scene() const;
-	String get_playing_scene() const;
-
-	Node *get_edited_scene_root();
-	Array get_open_scenes() const;
-	ScriptEditor *get_script_editor();
-
-	void select_file(const String &p_file);
-	String get_selected_path() const;
-	String get_current_path() const;
-
-	void inspect_object(Object *p_obj, const String &p_for_property = String(), bool p_inspector_only = false);
-
-	EditorSelection *get_selection();
-	//EditorImportExport *get_import_export();
-	Ref<EditorSettings> get_editor_settings();
-	EditorPaths *get_editor_paths();
-	EditorResourcePreview *get_resource_previewer();
-	EditorFileSystem *get_resource_file_system();
-
-	FileSystemDock *get_file_system_dock();
-
-	Control *get_base_control();
-	float get_editor_scale() const;
-
-	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
-	bool is_plugin_enabled(const String &p_plugin) const;
-
-	EditorInspector *get_inspector() const;
-
-	Error save_scene();
-	void save_scene_as(const String &p_scene, bool p_with_preview = true);
-
-	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform> *p_transforms, int p_preview_size);
-
-	void set_main_screen_editor(const String &p_name);
-	void set_distraction_free_mode(bool p_enter);
-	bool is_distraction_free_mode_enabled() const;
-
-	EditorInterface();
-};
 
 class EditorPlugin : public Node {
 	GDCLASS(EditorPlugin, Node);
+
 	friend class EditorData;
 	UndoRedo *undo_redo = nullptr;
 
@@ -225,10 +153,8 @@ public:
 	virtual bool build(); // builds with external tools. Returns true if safe to continue running scene.
 
 	EditorInterface *get_editor_interface();
+	EditorDocks *get_editor_docks();
 	ScriptCreateDialog *get_script_create_dialog();
-
-	void add_undo_redo_inspector_hook_callback(Callable p_callable);
-	void remove_undo_redo_inspector_hook_callback(Callable p_callable);
 
 	int update_overlays() const;
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -89,26 +89,10 @@ public:
 		CONTAINER_PROJECT_SETTING_TAB_RIGHT,
 	};
 
-	enum DockSlot {
-		DOCK_SLOT_LEFT_UL,
-		DOCK_SLOT_LEFT_BL,
-		DOCK_SLOT_LEFT_UR,
-		DOCK_SLOT_LEFT_BR,
-		DOCK_SLOT_RIGHT_UL,
-		DOCK_SLOT_RIGHT_BL,
-		DOCK_SLOT_RIGHT_UR,
-		DOCK_SLOT_RIGHT_BR,
-		DOCK_SLOT_MAX
-	};
-
 	//TODO: send a resource for editing to the editor node?
 
 	void add_control_to_container(CustomControlContainer p_location, Control *p_control);
 	void remove_control_from_container(CustomControlContainer p_location, Control *p_control);
-	Button *add_control_to_bottom_panel(Control *p_control, const String &p_title);
-	void add_control_to_dock(DockSlot p_slot, Control *p_control);
-	void remove_control_from_docks(Control *p_control);
-	void remove_control_from_bottom_panel(Control *p_control);
 
 	void add_tool_menu_item(const String &p_name, const Callable &p_callable);
 	void add_tool_submenu_item(const String &p_name, Object *p_submenu);
@@ -154,14 +138,12 @@ public:
 
 	EditorInterface *get_editor_interface();
 	EditorDocks *get_editor_docks();
+	EditorBottomPanels *get_editor_bottom_panels();
 	ScriptCreateDialog *get_script_create_dialog();
 
 	int update_overlays() const;
 
 	void queue_save_layout();
-
-	void make_bottom_panel_item_visible(Control *p_item);
-	void hide_bottom_panel();
 
 	virtual void restore_global_state();
 	virtual void save_global_state();
@@ -198,7 +180,6 @@ public:
 };
 
 VARIANT_ENUM_CAST(EditorPlugin::CustomControlContainer);
-VARIANT_ENUM_CAST(EditorPlugin::DockSlot);
 
 typedef EditorPlugin *(*EditorPluginCreateFunc)(EditorNode *);
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -140,6 +140,7 @@ public:
 	EditorDocks *get_editor_docks();
 	EditorBottomPanels *get_editor_bottom_panels();
 	EditorWorkspaces *get_editor_workspaces();
+	EditorPluginInterfaces *get_editor_plugin_interfaces();
 
 	ScriptCreateDialog *get_script_create_dialog();
 
@@ -150,29 +151,8 @@ public:
 	virtual void restore_global_state();
 	virtual void save_global_state();
 
-	void add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser);
-	void remove_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser);
-
-	void add_import_plugin(const Ref<EditorImportPlugin> &p_importer);
-	void remove_import_plugin(const Ref<EditorImportPlugin> &p_importer);
-
-	void add_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
-	void remove_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
-
-	void add_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
-	void remove_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
-
-	void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
-	void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
-
-	void add_scene_import_plugin(const Ref<EditorSceneImporter> &p_importer);
-	void remove_scene_import_plugin(const Ref<EditorSceneImporter> &p_importer);
-
 	void add_autoload_singleton(const String &p_name, const String &p_path);
 	void remove_autoload_singleton(const String &p_name);
-
-	void add_debugger_plugin(const Ref<Script> &p_script);
-	void remove_debugger_plugin(const Ref<Script> &p_script);
 
 	void enable_plugin();
 	void disable_plugin();

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -139,6 +139,8 @@ public:
 	EditorInterface *get_editor_interface();
 	EditorDocks *get_editor_docks();
 	EditorBottomPanels *get_editor_bottom_panels();
+	EditorWorkspaces *get_editor_workspaces();
+
 	ScriptCreateDialog *get_script_create_dialog();
 
 	int update_overlays() const;

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -94,10 +94,6 @@ public:
 	void add_control_to_container(CustomControlContainer p_location, Control *p_control);
 	void remove_control_from_container(CustomControlContainer p_location, Control *p_control);
 
-	void add_tool_menu_item(const String &p_name, const Callable &p_callable);
-	void add_tool_submenu_item(const String &p_name, Object *p_submenu);
-	void remove_tool_menu_item(const String &p_name);
-
 	void set_input_event_forwarding_always_enabled();
 	bool is_input_event_forwarding_always_enabled() { return input_event_forwarding_always_enabled; }
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -303,7 +303,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 		} break;
 
 		case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {
-			FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
+			FileSystemDock *file_system_dock = EditorDocks::get_singleton()->get_filesystem_dock();
 			file_system_dock->navigate_to_path(edited_resource->get_path());
 
 			// Ensure that the FileSystem dock is visible.
@@ -829,14 +829,14 @@ bool EditorScriptPicker::handle_menu_selected(int p_which) {
 	switch (p_which) {
 		case OBJ_MENU_NEW_SCRIPT: {
 			if (script_owner) {
-				EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(script_owner, false);
+				EditorDocks::get_singleton()->get_scene_tree_dock()->open_script_dialog(script_owner, false);
 			}
 			return true;
 		}
 
 		case OBJ_MENU_EXTEND_SCRIPT: {
 			if (script_owner) {
-				EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(script_owner, true);
+				EditorDocks::get_singleton()->get_scene_tree_dock()->open_script_dialog(script_owner, true);
 			}
 			return true;
 		}

--- a/editor/editor_singletons.cpp
+++ b/editor/editor_singletons.cpp
@@ -1,0 +1,379 @@
+/*************************************************************************/
+/*  editor_singletons.cpp                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor_singletons.h"
+
+#include "editor/editor_node.h"
+#include "editor/import_dock.h"
+#include "editor/node_dock.h"
+#include "main/main.h"
+
+Array EditorInterface::_make_mesh_previews(const Array &p_meshes, int p_preview_size) {
+	Vector<Ref<Mesh>> meshes;
+
+	for (int i = 0; i < p_meshes.size(); i++) {
+		meshes.push_back(p_meshes[i]);
+	}
+
+	Vector<Ref<Texture2D>> textures = make_mesh_previews(meshes, nullptr, p_preview_size);
+	Array ret;
+	for (int i = 0; i < textures.size(); i++) {
+		ret.push_back(textures[i]);
+	}
+
+	return ret;
+}
+
+Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform> *p_transforms, int p_preview_size) {
+	int size = p_preview_size;
+
+	RID scenario = RS::get_singleton()->scenario_create();
+
+	RID viewport = RS::get_singleton()->viewport_create();
+	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_ALWAYS);
+	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
+	RS::get_singleton()->viewport_set_size(viewport, size, size);
+	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
+	RS::get_singleton()->viewport_set_active(viewport, true);
+	RID viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
+
+	RID camera = RS::get_singleton()->camera_create();
+	RS::get_singleton()->viewport_attach_camera(viewport, camera);
+
+	RID light = RS::get_singleton()->directional_light_create();
+	RID light_instance = RS::get_singleton()->instance_create2(light, scenario);
+
+	RID light2 = RS::get_singleton()->directional_light_create();
+	RS::get_singleton()->light_set_color(light2, Color(0.7, 0.7, 0.7));
+	RID light_instance2 = RS::get_singleton()->instance_create2(light2, scenario);
+
+	EditorProgress ep("mlib", TTR("Creating Mesh Previews"), p_meshes.size());
+
+	Vector<Ref<Texture2D>> textures;
+
+	for (int i = 0; i < p_meshes.size(); i++) {
+		Ref<Mesh> mesh = p_meshes[i];
+		if (!mesh.is_valid()) {
+			textures.push_back(Ref<Texture2D>());
+			continue;
+		}
+
+		Transform mesh_xform;
+		if (p_transforms != nullptr) {
+			mesh_xform = (*p_transforms)[i];
+		}
+
+		RID inst = RS::get_singleton()->instance_create2(mesh->get_rid(), scenario);
+		RS::get_singleton()->instance_set_transform(inst, mesh_xform);
+
+		AABB aabb = mesh->get_aabb();
+		Vector3 ofs = aabb.position + aabb.size * 0.5;
+		aabb.position -= ofs;
+		Transform xform;
+		xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math_PI / 6);
+		xform.basis = Basis().rotated(Vector3(1, 0, 0), Math_PI / 6) * xform.basis;
+		AABB rot_aabb = xform.xform(aabb);
+		float m = MAX(rot_aabb.size.x, rot_aabb.size.y) * 0.5;
+		if (m == 0) {
+			textures.push_back(Ref<Texture2D>());
+			continue;
+		}
+		xform.origin = -xform.basis.xform(ofs); //-ofs*m;
+		xform.origin.z -= rot_aabb.size.z * 2;
+		xform.invert();
+		xform = mesh_xform * xform;
+
+		RS::get_singleton()->camera_set_transform(camera, xform * Transform(Basis(), Vector3(0, 0, 3)));
+		RS::get_singleton()->camera_set_orthogonal(camera, m * 2, 0.01, 1000.0);
+
+		RS::get_singleton()->instance_set_transform(light_instance, xform * Transform().looking_at(Vector3(-2, -1, -1), Vector3(0, 1, 0)));
+		RS::get_singleton()->instance_set_transform(light_instance2, xform * Transform().looking_at(Vector3(+1, -1, -2), Vector3(0, 1, 0)));
+
+		ep.step(TTR("Thumbnail..."), i);
+		Main::iteration();
+		Main::iteration();
+		Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
+		ERR_CONTINUE(!img.is_valid() || img->is_empty());
+		Ref<ImageTexture> it(memnew(ImageTexture));
+		it->create_from_image(img);
+
+		RS::get_singleton()->free(inst);
+
+		textures.push_back(it);
+	}
+
+	RS::get_singleton()->free(viewport);
+	RS::get_singleton()->free(light);
+	RS::get_singleton()->free(light_instance);
+	RS::get_singleton()->free(light2);
+	RS::get_singleton()->free(light_instance2);
+	RS::get_singleton()->free(camera);
+	RS::get_singleton()->free(scenario);
+
+	return textures;
+}
+
+void EditorInterface::set_main_screen_editor(const String &p_name) {
+	EditorNode::get_singleton()->select_editor_by_name(p_name);
+}
+
+Control *EditorInterface::get_editor_main_control() {
+	return EditorNode::get_singleton()->get_main_control();
+}
+
+void EditorInterface::edit_resource(const Ref<Resource> &p_resource) {
+	EditorNode::get_singleton()->edit_resource(p_resource);
+}
+
+void EditorInterface::open_scene_from_path(const String &scene_path) {
+	if (EditorNode::get_singleton()->is_changing_scene()) {
+		return;
+	}
+
+	EditorNode::get_singleton()->open_request(scene_path);
+}
+
+void EditorInterface::reload_scene_from_path(const String &scene_path) {
+	if (EditorNode::get_singleton()->is_changing_scene()) {
+		return;
+	}
+
+	EditorNode::get_singleton()->reload_scene(scene_path);
+}
+
+void EditorInterface::play_main_scene() {
+	EditorNode::get_singleton()->run_play();
+}
+
+void EditorInterface::play_current_scene() {
+	EditorNode::get_singleton()->run_play_current();
+}
+
+void EditorInterface::play_custom_scene(const String &scene_path) {
+	EditorNode::get_singleton()->run_play_custom(scene_path);
+}
+
+void EditorInterface::stop_playing_scene() {
+	EditorNode::get_singleton()->run_stop();
+}
+
+bool EditorInterface::is_playing_scene() const {
+	return EditorNode::get_singleton()->is_run_playing();
+}
+
+String EditorInterface::get_playing_scene() const {
+	return EditorNode::get_singleton()->get_run_playing_scene();
+}
+
+Node *EditorInterface::get_edited_scene_root() {
+	return EditorNode::get_singleton()->get_edited_scene();
+}
+
+Array EditorInterface::get_open_scenes() const {
+	Array ret;
+	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
+
+	int scns_amount = scenes.size();
+	for (int idx_scn = 0; idx_scn < scns_amount; idx_scn++) {
+		if (scenes[idx_scn].root == nullptr) {
+			continue;
+		}
+		ret.push_back(scenes[idx_scn].root->get_filename());
+	}
+	return ret;
+}
+
+ScriptEditor *EditorInterface::get_script_editor() {
+	return ScriptEditor::get_singleton();
+}
+
+void EditorInterface::select_file(const String &p_file) {
+	EditorDocks::get_singleton()->get_filesystem_dock()->select_file(p_file);
+}
+
+String EditorInterface::get_selected_path() const {
+	return EditorDocks::get_singleton()->get_filesystem_dock()->get_selected_path();
+}
+
+String EditorInterface::get_current_path() const {
+	return EditorDocks::get_singleton()->get_filesystem_dock()->get_current_path();
+}
+
+void EditorInterface::inspect_object(Object *p_obj, const String &p_for_property, bool p_inspector_only) {
+	EditorNode::get_singleton()->push_item(p_obj, p_for_property, p_inspector_only);
+}
+
+EditorFileSystem *EditorInterface::get_resource_file_system() {
+	return EditorFileSystem::get_singleton();
+}
+
+EditorSelection *EditorInterface::get_selection() {
+	return EditorNode::get_singleton()->get_editor_selection();
+}
+
+Ref<EditorSettings> EditorInterface::get_editor_settings() {
+	return EditorSettings::get_singleton();
+}
+
+EditorResourcePreview *EditorInterface::get_resource_previewer() {
+	return EditorResourcePreview::get_singleton();
+}
+
+Control *EditorInterface::get_base_control() {
+	return EditorNode::get_singleton()->get_gui_base();
+}
+
+float EditorInterface::get_editor_scale() const {
+	return EDSCALE;
+}
+
+void EditorInterface::set_plugin_enabled(const String &p_plugin, bool p_enabled) {
+	EditorNode::get_singleton()->set_addon_plugin_enabled(p_plugin, p_enabled, true);
+}
+
+bool EditorInterface::is_plugin_enabled(const String &p_plugin) const {
+	return EditorNode::get_singleton()->is_addon_plugin_enabled(p_plugin);
+}
+
+EditorInspector *EditorInterface::get_inspector() const {
+	return EditorNode::get_singleton()->get_inspector();
+}
+
+Error EditorInterface::save_scene() {
+	if (!get_edited_scene_root()) {
+		return ERR_CANT_CREATE;
+	}
+	if (get_edited_scene_root()->get_filename() == String()) {
+		return ERR_CANT_CREATE;
+	}
+
+	save_scene_as(get_edited_scene_root()->get_filename());
+	return OK;
+}
+
+void EditorInterface::save_scene_as(const String &p_scene, bool p_with_preview) {
+	EditorNode::get_singleton()->save_scene_to_path(p_scene, p_with_preview);
+}
+
+void EditorInterface::set_distraction_free_mode(bool p_enter) {
+	EditorNode::get_singleton()->set_distraction_free_mode(p_enter);
+}
+
+bool EditorInterface::is_distraction_free_mode_enabled() const {
+	return EditorNode::get_singleton()->is_distraction_free_mode_enabled();
+}
+
+EditorInterface *EditorInterface::singleton = nullptr;
+
+void EditorInterface::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("inspect_object", "object", "for_property", "inspector_only"), &EditorInterface::inspect_object, DEFVAL(String()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
+	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
+	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);
+	ClassDB::bind_method(D_METHOD("get_base_control"), &EditorInterface::get_base_control);
+	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
+	ClassDB::bind_method(D_METHOD("edit_resource", "resource"), &EditorInterface::edit_resource);
+	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath"), &EditorInterface::open_scene_from_path);
+	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
+	ClassDB::bind_method(D_METHOD("play_main_scene"), &EditorInterface::play_main_scene);
+	ClassDB::bind_method(D_METHOD("play_current_scene"), &EditorInterface::play_current_scene);
+	ClassDB::bind_method(D_METHOD("play_custom_scene", "scene_filepath"), &EditorInterface::play_custom_scene);
+	ClassDB::bind_method(D_METHOD("stop_playing_scene"), &EditorInterface::stop_playing_scene);
+	ClassDB::bind_method(D_METHOD("is_playing_scene"), &EditorInterface::is_playing_scene);
+	ClassDB::bind_method(D_METHOD("get_playing_scene"), &EditorInterface::get_playing_scene);
+	ClassDB::bind_method(D_METHOD("get_open_scenes"), &EditorInterface::get_open_scenes);
+	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root);
+	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
+	ClassDB::bind_method(D_METHOD("get_resource_filesystem"), &EditorInterface::get_resource_file_system);
+	ClassDB::bind_method(D_METHOD("get_editor_main_control"), &EditorInterface::get_editor_main_control);
+	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
+	ClassDB::bind_method(D_METHOD("select_file", "file"), &EditorInterface::select_file);
+	ClassDB::bind_method(D_METHOD("get_selected_path"), &EditorInterface::get_selected_path);
+	ClassDB::bind_method(D_METHOD("get_current_path"), &EditorInterface::get_current_path);
+
+	ClassDB::bind_method(D_METHOD("set_plugin_enabled", "plugin", "enabled"), &EditorInterface::set_plugin_enabled);
+	ClassDB::bind_method(D_METHOD("is_plugin_enabled", "plugin"), &EditorInterface::is_plugin_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_inspector"), &EditorInterface::get_inspector);
+
+	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);
+	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));
+
+	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
+	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);
+	ClassDB::bind_method(D_METHOD("is_distraction_free_mode_enabled"), &EditorInterface::is_distraction_free_mode_enabled);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
+}
+
+EditorInterface::EditorInterface() {
+	singleton = this;
+}
+
+///////////////////////////////////////////
+
+SceneTreeDock *EditorDocks::get_scene_tree_dock() {
+	return scene_tree_dock;
+}
+
+FileSystemDock *EditorDocks::get_filesystem_dock() {
+	return filesystem_dock;
+}
+
+NodeDock *EditorDocks::get_node_dock() {
+	return node_dock;
+}
+
+ConnectionsDock *EditorDocks::get_connection_dock() {
+	return connection_dock;
+}
+
+InspectorDock *EditorDocks::get_inspector_dock() {
+	return inspector_dock;
+}
+
+ImportDock *EditorDocks::get_import_dock() {
+	return import_dock;
+}
+
+void EditorDocks::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_scene_tree_dock"), &EditorDocks::get_scene_tree_dock);
+	ClassDB::bind_method(D_METHOD("get_filesystem_dock"), &EditorDocks::get_filesystem_dock);
+	ClassDB::bind_method(D_METHOD("get_node_dock"), &EditorDocks::get_node_dock);
+	ClassDB::bind_method(D_METHOD("get_connection_dock"), &EditorDocks::get_connection_dock);
+	ClassDB::bind_method(D_METHOD("get_inspector_dock"), &EditorDocks::get_inspector_dock);
+	ClassDB::bind_method(D_METHOD("get_import_dock"), &EditorDocks::get_import_dock);
+}
+
+EditorDocks *EditorDocks::singleton = nullptr;
+
+EditorDocks::EditorDocks() {
+	singleton = this;
+}

--- a/editor/editor_singletons.cpp
+++ b/editor/editor_singletons.cpp
@@ -646,6 +646,10 @@ EditorAssetLibrary *EditorWorkspaces::get_asset_library_workspace() {
 	return asset_library_workspace;
 }
 
+EditorPlugin *EditorWorkspaces::get_current_workspace() {
+	return editor->get_editor_plugin_screen();
+}
+
 void EditorWorkspaces::add_control(Control *p_control) {
 	ERR_FAIL_NULL(p_control);
 	ERR_FAIL_COND(p_control->get_parent());
@@ -744,5 +748,32 @@ void EditorPluginInterfaces::_bind_methods() {
 EditorPluginInterfaces *EditorPluginInterfaces::singleton = nullptr;
 
 EditorPluginInterfaces::EditorPluginInterfaces() {
+	singleton = this;
+}
+
+///////////////////////////////////////////
+
+HBoxContainer *EditorTopBars::get_main_menu_bar() {
+	return main_menu_bar;
+}
+
+HBoxContainer *EditorTopBars::get_workspaces_bar() {
+	return workspaces_bar;
+}
+
+HBoxContainer *EditorTopBars::get_playtest_bar() {
+	return playtest_bar;
+}
+
+void EditorTopBars::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_main_menu_bar"), &EditorTopBars::get_main_menu_bar);
+	ClassDB::bind_method(D_METHOD("get_workspaces_bar"), &EditorTopBars::get_workspaces_bar);
+	ClassDB::bind_method(D_METHOD("get_playtest_bar"), &EditorTopBars::get_playtest_bar);
+}
+
+EditorTopBars *EditorTopBars::singleton = nullptr;
+
+EditorTopBars::EditorTopBars(EditorNode *p_editor) {
+	editor = p_editor;
 	singleton = this;
 }

--- a/editor/editor_singletons.cpp
+++ b/editor/editor_singletons.cpp
@@ -663,7 +663,7 @@ void EditorWorkspaces::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_script_workspace"), &EditorWorkspaces::get_script_workspace);
 	ClassDB::bind_method(D_METHOD("get_asset_library_workspace"), &EditorWorkspaces::get_asset_library_workspace);
 
-	ClassDB::bind_method(D_METHOD("add_control", "title", "control"), &EditorWorkspaces::add_control);
+	ClassDB::bind_method(D_METHOD("add_control", "control"), &EditorWorkspaces::add_control);
 	ClassDB::bind_method(D_METHOD("remove_control", "control"), &EditorWorkspaces::remove_control);
 }
 
@@ -672,4 +672,77 @@ EditorWorkspaces *EditorWorkspaces::singleton = nullptr;
 EditorWorkspaces::EditorWorkspaces(EditorNode *p_editor) {
 	singleton = this;
 	editor = p_editor;
+}
+
+///////////////////////////////////////////
+
+void EditorPluginInterfaces::add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
+	EditorTranslationParser::get_singleton()->add_parser(p_parser, EditorTranslationParser::CUSTOM);
+}
+
+void EditorPluginInterfaces::remove_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
+	EditorTranslationParser::get_singleton()->remove_parser(p_parser, EditorTranslationParser::CUSTOM);
+}
+
+void EditorPluginInterfaces::add_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
+	ResourceFormatImporter::get_singleton()->add_importer(p_importer);
+	EditorFileSystem::get_singleton()->call_deferred("scan");
+}
+
+void EditorPluginInterfaces::remove_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
+	ResourceFormatImporter::get_singleton()->remove_importer(p_importer);
+	EditorFileSystem::get_singleton()->call_deferred("scan");
+}
+
+void EditorPluginInterfaces::add_export_plugin(const Ref<EditorExportPlugin> &p_exporter) {
+	EditorExport::get_singleton()->add_export_plugin(p_exporter);
+}
+
+void EditorPluginInterfaces::remove_export_plugin(const Ref<EditorExportPlugin> &p_exporter) {
+	EditorExport::get_singleton()->remove_export_plugin(p_exporter);
+}
+
+void EditorPluginInterfaces::add_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
+	EditorWorkspaces::singleton->node_3d_workspace->add_gizmo_plugin(p_gizmo_plugin);
+}
+
+void EditorPluginInterfaces::remove_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
+	EditorWorkspaces::singleton->node_3d_workspace->remove_gizmo_plugin(p_gizmo_plugin);
+}
+
+void EditorPluginInterfaces::add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
+	EditorInspector::add_inspector_plugin(p_plugin);
+}
+
+void EditorPluginInterfaces::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
+	EditorInspector::remove_inspector_plugin(p_plugin);
+}
+
+void EditorPluginInterfaces::add_scene_import_plugin(const Ref<EditorSceneImporter> &p_importer) {
+	ResourceImporterScene::get_singleton()->add_importer(p_importer);
+}
+
+void EditorPluginInterfaces::remove_scene_import_plugin(const Ref<EditorSceneImporter> &p_importer) {
+	ResourceImporterScene::get_singleton()->remove_importer(p_importer);
+}
+
+void EditorPluginInterfaces::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_translation_parser_plugin", "parser"), &EditorPluginInterfaces::add_translation_parser_plugin);
+	ClassDB::bind_method(D_METHOD("remove_translation_parser_plugin", "parser"), &EditorPluginInterfaces::remove_translation_parser_plugin);
+	ClassDB::bind_method(D_METHOD("add_import_plugin", "importer"), &EditorPluginInterfaces::add_import_plugin);
+	ClassDB::bind_method(D_METHOD("remove_import_plugin", "importer"), &EditorPluginInterfaces::remove_import_plugin);
+	ClassDB::bind_method(D_METHOD("add_scene_import_plugin", "scene_importer"), &EditorPluginInterfaces::add_scene_import_plugin);
+	ClassDB::bind_method(D_METHOD("remove_scene_import_plugin", "scene_importer"), &EditorPluginInterfaces::remove_scene_import_plugin);
+	ClassDB::bind_method(D_METHOD("add_export_plugin", "plugin"), &EditorPluginInterfaces::add_export_plugin);
+	ClassDB::bind_method(D_METHOD("remove_export_plugin", "plugin"), &EditorPluginInterfaces::remove_export_plugin);
+	ClassDB::bind_method(D_METHOD("add_spatial_gizmo_plugin", "plugin"), &EditorPluginInterfaces::add_spatial_gizmo_plugin);
+	ClassDB::bind_method(D_METHOD("remove_spatial_gizmo_plugin", "plugin"), &EditorPluginInterfaces::remove_spatial_gizmo_plugin);
+	ClassDB::bind_method(D_METHOD("add_inspector_plugin", "plugin"), &EditorPluginInterfaces::add_inspector_plugin);
+	ClassDB::bind_method(D_METHOD("remove_inspector_plugin", "plugin"), &EditorPluginInterfaces::remove_inspector_plugin);
+}
+
+EditorPluginInterfaces *EditorPluginInterfaces::singleton = nullptr;
+
+EditorPluginInterfaces::EditorPluginInterfaces() {
+	singleton = this;
 }

--- a/editor/editor_singletons.cpp
+++ b/editor/editor_singletons.cpp
@@ -31,8 +31,24 @@
 #include "editor_singletons.h"
 
 #include "editor/editor_node.h"
+#include "editor/editor_log.h"
+#include "editor/editor_audio_buses.h"
+#include "editor/find_in_files.h"
+#include "editor/filesystem_dock.h"
 #include "editor/import_dock.h"
 #include "editor/node_dock.h"
+#include "editor/plugins/animation_player_editor_plugin.h"
+#include "editor/plugins/animation_tree_editor_plugin.h"
+#include "editor/plugins/editor_debugger_plugin.h"
+#include "editor/plugins/resource_preloader_editor_plugin.h"
+#include "editor/plugins/shader_editor_plugin.h"
+#include "editor/plugins/shader_file_editor_plugin.h"
+#include "editor/plugins/sprite_frames_editor_plugin.h"
+#include "editor/plugins/texture_region_editor_plugin.h"
+#include "editor/plugins/theme_editor_plugin.h"
+#include "editor/plugins/tile_set_editor_plugin.h"
+#include "editor/plugins/visual_shader_editor_plugin.h"
+
 #include "main/main.h"
 
 Array EditorInterface::_make_mesh_previews(const Array &p_meshes, int p_preview_size) {
@@ -141,59 +157,59 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 }
 
 void EditorInterface::set_main_screen_editor(const String &p_name) {
-	EditorNode::get_singleton()->select_editor_by_name(p_name);
+	editor->select_editor_by_name(p_name);
 }
 
 Control *EditorInterface::get_editor_main_control() {
-	return EditorNode::get_singleton()->get_main_control();
+	return editor->get_main_control();
 }
 
 void EditorInterface::edit_resource(const Ref<Resource> &p_resource) {
-	EditorNode::get_singleton()->edit_resource(p_resource);
+	editor->edit_resource(p_resource);
 }
 
 void EditorInterface::open_scene_from_path(const String &scene_path) {
-	if (EditorNode::get_singleton()->is_changing_scene()) {
+	if (editor->is_changing_scene()) {
 		return;
 	}
 
-	EditorNode::get_singleton()->open_request(scene_path);
+	editor->open_request(scene_path);
 }
 
 void EditorInterface::reload_scene_from_path(const String &scene_path) {
-	if (EditorNode::get_singleton()->is_changing_scene()) {
+	if (editor->is_changing_scene()) {
 		return;
 	}
 
-	EditorNode::get_singleton()->reload_scene(scene_path);
+	editor->reload_scene(scene_path);
 }
 
 void EditorInterface::play_main_scene() {
-	EditorNode::get_singleton()->run_play();
+	editor->run_play();
 }
 
 void EditorInterface::play_current_scene() {
-	EditorNode::get_singleton()->run_play_current();
+	editor->run_play_current();
 }
 
 void EditorInterface::play_custom_scene(const String &scene_path) {
-	EditorNode::get_singleton()->run_play_custom(scene_path);
+	editor->run_play_custom(scene_path);
 }
 
 void EditorInterface::stop_playing_scene() {
-	EditorNode::get_singleton()->run_stop();
+	editor->run_stop();
 }
 
 bool EditorInterface::is_playing_scene() const {
-	return EditorNode::get_singleton()->is_run_playing();
+	return editor->is_run_playing();
 }
 
 String EditorInterface::get_playing_scene() const {
-	return EditorNode::get_singleton()->get_run_playing_scene();
+	return editor->get_run_playing_scene();
 }
 
 Node *EditorInterface::get_edited_scene_root() {
-	return EditorNode::get_singleton()->get_edited_scene();
+	return editor->get_edited_scene();
 }
 
 Array EditorInterface::get_open_scenes() const {
@@ -227,7 +243,7 @@ String EditorInterface::get_current_path() const {
 }
 
 void EditorInterface::inspect_object(Object *p_obj, const String &p_for_property, bool p_inspector_only) {
-	EditorNode::get_singleton()->push_item(p_obj, p_for_property, p_inspector_only);
+	editor->push_item(p_obj, p_for_property, p_inspector_only);
 }
 
 EditorFileSystem *EditorInterface::get_resource_file_system() {
@@ -235,7 +251,7 @@ EditorFileSystem *EditorInterface::get_resource_file_system() {
 }
 
 EditorSelection *EditorInterface::get_selection() {
-	return EditorNode::get_singleton()->get_editor_selection();
+	return editor->get_editor_selection();
 }
 
 Ref<EditorSettings> EditorInterface::get_editor_settings() {
@@ -247,7 +263,7 @@ EditorResourcePreview *EditorInterface::get_resource_previewer() {
 }
 
 Control *EditorInterface::get_base_control() {
-	return EditorNode::get_singleton()->get_gui_base();
+	return editor->get_gui_base();
 }
 
 float EditorInterface::get_editor_scale() const {
@@ -255,15 +271,15 @@ float EditorInterface::get_editor_scale() const {
 }
 
 void EditorInterface::set_plugin_enabled(const String &p_plugin, bool p_enabled) {
-	EditorNode::get_singleton()->set_addon_plugin_enabled(p_plugin, p_enabled, true);
+	editor->set_addon_plugin_enabled(p_plugin, p_enabled, true);
 }
 
 bool EditorInterface::is_plugin_enabled(const String &p_plugin) const {
-	return EditorNode::get_singleton()->is_addon_plugin_enabled(p_plugin);
+	return editor->is_addon_plugin_enabled(p_plugin);
 }
 
 EditorInspector *EditorInterface::get_inspector() const {
-	return EditorNode::get_singleton()->get_inspector();
+	return editor->get_inspector();
 }
 
 Error EditorInterface::save_scene() {
@@ -279,15 +295,15 @@ Error EditorInterface::save_scene() {
 }
 
 void EditorInterface::save_scene_as(const String &p_scene, bool p_with_preview) {
-	EditorNode::get_singleton()->save_scene_to_path(p_scene, p_with_preview);
+	editor->save_scene_to_path(p_scene, p_with_preview);
 }
 
 void EditorInterface::set_distraction_free_mode(bool p_enter) {
-	EditorNode::get_singleton()->set_distraction_free_mode(p_enter);
+	editor->set_distraction_free_mode(p_enter);
 }
 
 bool EditorInterface::is_distraction_free_mode_enabled() const {
-	return EditorNode::get_singleton()->is_distraction_free_mode_enabled();
+	return editor->is_distraction_free_mode_enabled();
 }
 
 EditorInterface *EditorInterface::singleton = nullptr;
@@ -333,8 +349,9 @@ void EditorInterface::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
 }
 
-EditorInterface::EditorInterface() {
+EditorInterface::EditorInterface(EditorNode *p_editor) {
 	singleton = this;
+	editor = p_editor;
 }
 
 ///////////////////////////////////////////
@@ -363,6 +380,16 @@ ImportDock *EditorDocks::get_import_dock() {
 	return import_dock;
 }
 
+void EditorDocks::add_control(DockSlot p_slot, Control *p_control) {
+	ERR_FAIL_NULL(p_control);
+	editor->add_control_to_dock(EditorNode::DockSlot(p_slot), p_control);
+}
+
+void EditorDocks::remove_control(Control *p_control) {
+	ERR_FAIL_NULL(p_control);
+	editor->remove_control_from_dock(p_control);
+}
+
 void EditorDocks::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_scene_tree_dock"), &EditorDocks::get_scene_tree_dock);
 	ClassDB::bind_method(D_METHOD("get_filesystem_dock"), &EditorDocks::get_filesystem_dock);
@@ -370,10 +397,214 @@ void EditorDocks::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_connection_dock"), &EditorDocks::get_connection_dock);
 	ClassDB::bind_method(D_METHOD("get_inspector_dock"), &EditorDocks::get_inspector_dock);
 	ClassDB::bind_method(D_METHOD("get_import_dock"), &EditorDocks::get_import_dock);
+
+	ClassDB::bind_method(D_METHOD("add_control", "slot", "control"), &EditorDocks::add_control);
+	ClassDB::bind_method(D_METHOD("remove_control", "control"), &EditorDocks::remove_control);
+
+	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_UL);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_BL);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_UR);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_BR);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_UL);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_BL);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_UR);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_BR);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_MAX);
+}
+
+void EditorDocks::set_version_control_dock(VBoxContainer *p_dock) {
+	ERR_FAIL_COND(!version_control_dock);
+	version_control_dock = p_dock;
 }
 
 EditorDocks *EditorDocks::singleton = nullptr;
 
-EditorDocks::EditorDocks() {
+EditorDocks::EditorDocks(EditorNode *p_editor) {
 	singleton = this;
+	editor = p_editor;
+}
+
+///////////////////////////////////////////
+
+void EditorBottomPanels::set_output_panel(EditorLog *p_panel) {
+	ERR_FAIL_COND(output_panel);
+	output_panel = p_panel;
+}
+
+void EditorBottomPanels::set_audio_panel(EditorAudioBuses *p_panel) {
+	ERR_FAIL_COND(audio_panel);
+	audio_panel = p_panel;
+}
+
+void EditorBottomPanels::set_animation_panel(AnimationPlayerEditor *p_panel) {
+	ERR_FAIL_COND(animation_panel);
+	animation_panel = p_panel;
+}
+
+void EditorBottomPanels::set_animation_tree_panel(AnimationTreeEditor *p_panel) {
+	ERR_FAIL_COND(animation_tree_panel);
+	animation_tree_panel = p_panel;
+}
+
+void EditorBottomPanels::set_debugger_panel(EditorDebuggerNode *p_panel) {
+	ERR_FAIL_COND(debugger_panel);
+	debugger_panel = p_panel;
+}
+
+void EditorBottomPanels::set_resource_preloader_panel(ResourcePreloaderEditor *p_panel) {
+	ERR_FAIL_COND(resource_preloader_panel);
+	resource_preloader_panel = p_panel;
+}
+
+void EditorBottomPanels::set_find_in_files_panel(FindInFilesPanel *p_panel) {
+	ERR_FAIL_COND(find_in_files_panel);
+	find_in_files_panel = p_panel;
+}
+
+void EditorBottomPanels::set_shader_panel(ShaderEditor *p_panel) {
+	ERR_FAIL_COND(shader_panel);
+	shader_panel = p_panel;
+}
+
+void EditorBottomPanels::set_shader_file_panel(ShaderFileEditor *p_panel) {
+	ERR_FAIL_COND(shader_file_panel);
+	shader_file_panel = p_panel;
+}
+
+void EditorBottomPanels::set_sprite_frames_panel(SpriteFramesEditor *p_panel) {
+	ERR_FAIL_COND(sprite_frames_panel);
+	sprite_frames_panel = p_panel;
+}
+
+void EditorBottomPanels::set_texture_region_panel(TextureRegionEditor *p_panel) {
+	ERR_FAIL_COND(texture_region_panel);
+	texture_region_panel = p_panel;
+}
+
+void EditorBottomPanels::set_theme_panel(ThemeEditor *p_panel) {
+	ERR_FAIL_COND(theme_panel);
+	theme_panel = p_panel;
+}
+
+void EditorBottomPanels::set_tileset_panel(TileSetEditor *p_panel) {
+	ERR_FAIL_COND(tileset_panel);
+	tileset_panel = p_panel;
+}
+
+void EditorBottomPanels::set_version_control_panel(PanelContainer *p_panel) {
+	ERR_FAIL_COND(version_control_panel);
+	version_control_panel = p_panel;
+}
+
+void EditorBottomPanels::set_visual_shader_panel(VisualShaderEditor *p_panel) {
+	ERR_FAIL_COND(visual_shader_panel);
+	visual_shader_panel = p_panel;
+}
+
+EditorLog *EditorBottomPanels::get_output_panel() {
+	return output_panel;
+}
+
+EditorAudioBuses *EditorBottomPanels::get_audio_panel() {
+	return audio_panel;
+}
+
+AnimationPlayerEditor *EditorBottomPanels::get_animation_panel() {
+	return animation_panel;
+}
+
+AnimationTreeEditor *EditorBottomPanels::get_animation_tree_panel() {
+	return animation_tree_panel;
+}
+
+EditorDebuggerNode *EditorBottomPanels::get_debugger_panel() {
+	return debugger_panel;
+}
+
+ResourcePreloaderEditor *EditorBottomPanels::get_resource_preloader_panel() {
+	return resource_preloader_panel;
+}
+
+FindInFilesPanel *EditorBottomPanels::get_find_in_files_panel() {
+	return find_in_files_panel;
+}
+
+ShaderEditor *EditorBottomPanels::get_shader_panel() {
+	return shader_panel;
+}
+
+ShaderFileEditor *EditorBottomPanels::get_shader_file_panel() {
+	return shader_file_panel;
+}
+
+SpriteFramesEditor *EditorBottomPanels::get_sprite_frames_panel() {
+	return sprite_frames_panel;
+}
+
+TextureRegionEditor *EditorBottomPanels::get_texture_region_panel() {
+	return texture_region_panel;
+}
+
+ThemeEditor *EditorBottomPanels::get_theme_panel() {
+	return theme_panel;
+}
+
+TileSetEditor *EditorBottomPanels::get_tileset_panel() {
+	return tileset_panel;
+}
+
+PanelContainer *EditorBottomPanels::get_version_control_panel() {
+	return version_control_panel;
+}
+
+VisualShaderEditor *EditorBottomPanels::get_visual_shader_panel() {
+	return visual_shader_panel;
+}
+
+Button *EditorBottomPanels::add_control(const String p_title, Control *p_control) {
+	ERR_FAIL_NULL_V(p_control, nullptr);
+	return editor->add_bottom_panel_item(p_title, p_control);
+}
+
+void EditorBottomPanels::remove_control(Control *p_control) {
+	ERR_FAIL_NULL(p_control);
+	editor->remove_bottom_panel_item(p_control);
+}
+
+void EditorBottomPanels::make_bottom_panel_item_visible(Control *p_item) {
+	editor->make_bottom_panel_item_visible(p_item);
+}
+
+void EditorBottomPanels::hide_bottom_panel() {
+	editor->hide_bottom_panel();
+}
+
+void EditorBottomPanels::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_output_panel"), &EditorBottomPanels::get_output_panel);
+	ClassDB::bind_method(D_METHOD("get_audio_panel"), &EditorBottomPanels::get_audio_panel);
+	ClassDB::bind_method(D_METHOD("get_animation_panel"), &EditorBottomPanels::get_animation_panel);
+	ClassDB::bind_method(D_METHOD("get_animation_tree_panel"), &EditorBottomPanels::get_animation_tree_panel);
+	ClassDB::bind_method(D_METHOD("get_debugger_panel"), &EditorBottomPanels::get_debugger_panel);
+	ClassDB::bind_method(D_METHOD("get_resource_preloader_panel"), &EditorBottomPanels::get_resource_preloader_panel);
+	ClassDB::bind_method(D_METHOD("get_find_in_files_panel"), &EditorBottomPanels::get_find_in_files_panel);
+	ClassDB::bind_method(D_METHOD("get_shader_panel"), &EditorBottomPanels::get_shader_panel);
+	ClassDB::bind_method(D_METHOD("get_sprite_frames_panel"), &EditorBottomPanels::get_sprite_frames_panel);
+	ClassDB::bind_method(D_METHOD("get_texture_region_panel"), &EditorBottomPanels::get_texture_region_panel);
+	ClassDB::bind_method(D_METHOD("get_theme_panel"), &EditorBottomPanels::get_theme_panel);
+	ClassDB::bind_method(D_METHOD("get_tileset_panel"), &EditorBottomPanels::get_tileset_panel);
+	ClassDB::bind_method(D_METHOD("get_version_control_panel"), &EditorBottomPanels::get_version_control_panel);
+	ClassDB::bind_method(D_METHOD("get_visual_shader_panel"), &EditorBottomPanels::get_visual_shader_panel);
+
+	ClassDB::bind_method(D_METHOD("add_control", "title", "control"), &EditorBottomPanels::add_control);
+	ClassDB::bind_method(D_METHOD("remove_control", "control"), &EditorBottomPanels::remove_control);
+
+	ClassDB::bind_method(D_METHOD("make_bottom_panel_item_visible", "control"), &EditorBottomPanels::make_bottom_panel_item_visible);
+	ClassDB::bind_method(D_METHOD("hide_bottom_panel"), &EditorBottomPanels::hide_bottom_panel);
+}
+
+EditorBottomPanels *EditorBottomPanels::singleton = nullptr;
+
+EditorBottomPanels::EditorBottomPanels(EditorNode *p_editor) {
+	singleton = this;
+	editor = p_editor;
 }

--- a/editor/editor_singletons.cpp
+++ b/editor/editor_singletons.cpp
@@ -765,10 +765,30 @@ HBoxContainer *EditorTopBars::get_playtest_bar() {
 	return playtest_bar;
 }
 
+void EditorTopBars::add_tool_menu_item(const String &p_name, const Callable &p_callable) {
+	editor->add_tool_menu_item(p_name, p_callable);
+}
+
+void EditorTopBars::add_tool_submenu_item(const String &p_name, Object *p_submenu) {
+	ERR_FAIL_NULL(p_submenu);
+	PopupMenu *submenu = Object::cast_to<PopupMenu>(p_submenu);
+	ERR_FAIL_NULL(submenu);
+	editor->add_tool_submenu_item(p_name, submenu);
+}
+
+void EditorTopBars::remove_tool_menu_item(const String &p_name) {
+	editor->remove_tool_menu_item(p_name);
+}
+
 void EditorTopBars::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_main_menu_bar"), &EditorTopBars::get_main_menu_bar);
 	ClassDB::bind_method(D_METHOD("get_workspaces_bar"), &EditorTopBars::get_workspaces_bar);
 	ClassDB::bind_method(D_METHOD("get_playtest_bar"), &EditorTopBars::get_playtest_bar);
+
+	ClassDB::bind_method(D_METHOD("add_tool_menu_item", "name", "callable"), &EditorTopBars::add_tool_menu_item);
+	ClassDB::bind_method(D_METHOD("add_tool_submenu_item", "name", "submenu"), &EditorTopBars::add_tool_submenu_item);
+	ClassDB::bind_method(D_METHOD("remove_tool_menu_item", "name"), &EditorTopBars::remove_tool_menu_item);
+
 }
 
 EditorTopBars *EditorTopBars::singleton = nullptr;

--- a/editor/editor_singletons.cpp
+++ b/editor/editor_singletons.cpp
@@ -30,17 +30,21 @@
 
 #include "editor_singletons.h"
 
-#include "editor/editor_node.h"
-#include "editor/editor_log.h"
 #include "editor/editor_audio_buses.h"
-#include "editor/find_in_files.h"
+#include "editor/editor_log.h"
+#include "editor/editor_node.h"
 #include "editor/filesystem_dock.h"
+#include "editor/find_in_files.h"
 #include "editor/import_dock.h"
 #include "editor/node_dock.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
+#include "editor/plugins/asset_library_editor_plugin.h"
+#include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/editor_debugger_plugin.h"
+#include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/plugins/resource_preloader_editor_plugin.h"
+#include "editor/plugins/script_editor_plugin.h"
 #include "editor/plugins/shader_editor_plugin.h"
 #include "editor/plugins/shader_file_editor_plugin.h"
 #include "editor/plugins/sprite_frames_editor_plugin.h"
@@ -226,10 +230,6 @@ Array EditorInterface::get_open_scenes() const {
 	return ret;
 }
 
-ScriptEditor *EditorInterface::get_script_editor() {
-	return ScriptEditor::get_singleton();
-}
-
 void EditorInterface::select_file(const String &p_file) {
 	EditorDocks::get_singleton()->get_filesystem_dock()->select_file(p_file);
 }
@@ -312,7 +312,6 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("inspect_object", "object", "for_property", "inspector_only"), &EditorInterface::inspect_object, DEFVAL(String()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
-	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);
 	ClassDB::bind_method(D_METHOD("get_base_control"), &EditorInterface::get_base_control);
 	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
 	ClassDB::bind_method(D_METHOD("edit_resource", "resource"), &EditorInterface::edit_resource);
@@ -605,6 +604,72 @@ void EditorBottomPanels::_bind_methods() {
 EditorBottomPanels *EditorBottomPanels::singleton = nullptr;
 
 EditorBottomPanels::EditorBottomPanels(EditorNode *p_editor) {
+	singleton = this;
+	editor = p_editor;
+}
+
+///////////////////////////////////////////
+
+void EditorWorkspaces::set_canvas_item_workspace(CanvasItemEditor *p_panel) {
+	ERR_FAIL_COND(canvas_item_workspace);
+	canvas_item_workspace = p_panel;
+}
+
+void EditorWorkspaces::set_node_3d_workspace(Node3DEditor *p_panel) {
+	ERR_FAIL_COND(node_3d_workspace);
+	node_3d_workspace = p_panel;
+}
+
+void EditorWorkspaces::set_script_workspace(ScriptEditor *p_panel) {
+	ERR_FAIL_COND(script_workspace);
+	script_workspace = p_panel;
+}
+
+void EditorWorkspaces::set_asset_library_workspace(EditorAssetLibrary *p_panel) {
+	ERR_FAIL_COND(asset_library_workspace);
+	asset_library_workspace = p_panel;
+}
+
+CanvasItemEditor *EditorWorkspaces::get_canvas_item_workspace() {
+	return canvas_item_workspace;
+}
+
+Node3DEditor *EditorWorkspaces::get_node_3d_workspace() {
+	return node_3d_workspace;
+}
+
+ScriptEditor *EditorWorkspaces::get_script_workspace() {
+	return script_workspace;
+}
+
+EditorAssetLibrary *EditorWorkspaces::get_asset_library_workspace() {
+	return asset_library_workspace;
+}
+
+void EditorWorkspaces::add_control(Control *p_control) {
+	ERR_FAIL_NULL(p_control);
+	ERR_FAIL_COND(p_control->get_parent());
+	editor->get_main_control()->add_child(p_control);
+}
+
+void EditorWorkspaces::remove_control(Control *p_control) {
+	ERR_FAIL_COND(p_control->get_parent() != editor->get_main_control());
+	p_control->get_parent()->remove_child(p_control);
+}
+
+void EditorWorkspaces::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_canvas_item_workspace"), &EditorWorkspaces::get_canvas_item_workspace);
+	ClassDB::bind_method(D_METHOD("get_node_3d_workspace"), &EditorWorkspaces::get_node_3d_workspace);
+	ClassDB::bind_method(D_METHOD("get_script_workspace"), &EditorWorkspaces::get_script_workspace);
+	ClassDB::bind_method(D_METHOD("get_asset_library_workspace"), &EditorWorkspaces::get_asset_library_workspace);
+
+	ClassDB::bind_method(D_METHOD("add_control", "title", "control"), &EditorWorkspaces::add_control);
+	ClassDB::bind_method(D_METHOD("remove_control", "control"), &EditorWorkspaces::remove_control);
+}
+
+EditorWorkspaces *EditorWorkspaces::singleton = nullptr;
+
+EditorWorkspaces::EditorWorkspaces(EditorNode *p_editor) {
 	singleton = this;
 	editor = p_editor;
 }

--- a/editor/editor_singletons.h
+++ b/editor/editor_singletons.h
@@ -39,7 +39,6 @@
 #include "scene/main/node.h"
 
 class EditorNode;
-class EditorData;
 class EditorSelection;
 class EditorSettings;
 
@@ -265,6 +264,8 @@ class EditorAssetLibrary;
 class EditorWorkspaces : public Node {
 	GDCLASS(EditorWorkspaces, Node);
 
+	friend class EditorPluginInterfaces;
+
 	EditorNode *editor;
 
 	CanvasItemEditor *canvas_item_workspace = nullptr;
@@ -296,6 +297,46 @@ public:
 	void remove_control(Control *p_control);
 
 	EditorWorkspaces(EditorNode *p_editor);
+};
+
+class EditorTranslationParserPlugin;
+class EditorImportPlugin;
+class EditorExportPlugin;
+class EditorNode3DGizmoPlugin;
+class EditorSceneImporter;
+
+class EditorPluginInterfaces : public Node {
+	GDCLASS(EditorPluginInterfaces, Node);
+
+protected:
+	static void _bind_methods();
+	static EditorPluginInterfaces *singleton;
+
+public:
+	static EditorPluginInterfaces *get_singleton() { return singleton; }
+
+	void add_debugger_plugin(const Ref<Script> &p_script);
+	void remove_debugger_plugin(const Ref<Script> &p_script);
+
+	void add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser);
+	void remove_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser);
+
+	void add_import_plugin(const Ref<EditorImportPlugin> &p_importer);
+	void remove_import_plugin(const Ref<EditorImportPlugin> &p_importer);
+
+	void add_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
+	void remove_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
+
+	void add_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
+	void remove_spatial_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin);
+
+	void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
+	void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
+
+	void add_scene_import_plugin(const Ref<EditorSceneImporter> &p_importer);
+	void remove_scene_import_plugin(const Ref<EditorSceneImporter> &p_importer);
+
+	EditorPluginInterfaces();
 };
 
 #endif // EDITOR_SINGLETONS_H

--- a/editor/editor_singletons.h
+++ b/editor/editor_singletons.h
@@ -1,0 +1,148 @@
+/*************************************************************************/
+/*  editor_singletons.h                                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef EDITOR_SINGLETONS_H
+#define EDITOR_SINGLETONS_H
+
+#include "editor/editor_resource_preview.h"
+//#include "editor/scene_tree_dock.h"
+//#include "editor/inspector_dock.h"
+//#include "editor/node_dock.h"
+#include "editor/editor_file_system.h"
+#include "editor/editor_inspector.h"
+#include "editor/filesystem_dock.h"
+#include "scene/main/node.h"
+
+class ScriptEditor;
+
+class SceneTreeDock;
+class NodeDock;
+class ConnectionsDock;
+class InspectorDock;
+class ImportDock;
+class FileSystemDock;
+
+class EditorData;
+class EditorSelection;
+class EditorSettings;
+
+class EditorInterface : public Node {
+	GDCLASS(EditorInterface, Node);
+
+protected:
+	static void _bind_methods();
+	static EditorInterface *singleton;
+
+	Array _make_mesh_previews(const Array &p_meshes, int p_preview_size);
+
+public:
+	static EditorInterface *get_singleton() { return singleton; }
+
+	Control *get_editor_main_control();
+	void edit_resource(const Ref<Resource> &p_resource);
+	void open_scene_from_path(const String &scene_path);
+	void reload_scene_from_path(const String &scene_path);
+
+	void play_main_scene();
+	void play_current_scene();
+	void play_custom_scene(const String &scene_path);
+	void stop_playing_scene();
+	bool is_playing_scene() const;
+	String get_playing_scene() const;
+
+	Node *get_edited_scene_root();
+	Array get_open_scenes() const;
+	ScriptEditor *get_script_editor();
+
+	void select_file(const String &p_file);
+	String get_selected_path() const;
+	String get_current_path() const;
+
+	void inspect_object(Object *p_obj, const String &p_for_property = String(), bool p_inspector_only = false);
+
+	EditorSelection *get_selection();
+	//EditorImportExport *get_import_export();
+	Ref<EditorSettings> get_editor_settings();
+	EditorResourcePreview *get_resource_previewer();
+	EditorFileSystem *get_resource_file_system();
+
+	Control *get_base_control();
+	float get_editor_scale() const;
+
+	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
+	bool is_plugin_enabled(const String &p_plugin) const;
+
+	EditorInspector *get_inspector() const;
+
+	Error save_scene();
+	void save_scene_as(const String &p_scene, bool p_with_preview = true);
+
+	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform> *p_transforms, int p_preview_size);
+
+	void set_main_screen_editor(const String &p_name);
+	void set_distraction_free_mode(bool p_enter);
+	bool is_distraction_free_mode_enabled() const;
+
+	EditorInterface();
+};
+
+class EditorDocks : public Node {
+	GDCLASS(EditorDocks, Node);
+
+	friend class EditorNode;
+
+	SceneTreeDock *scene_tree_dock = nullptr;
+	FileSystemDock *filesystem_dock = nullptr;
+	NodeDock *node_dock = nullptr;
+	ConnectionsDock *connection_dock = nullptr;
+	InspectorDock *inspector_dock = nullptr;
+	ImportDock *import_dock = nullptr;
+
+protected:
+	static void _bind_methods();
+	static EditorDocks *singleton;
+
+public:
+	static EditorDocks *get_singleton() { return singleton; }
+
+	SceneTreeDock *get_scene_tree_dock();
+	FileSystemDock *get_filesystem_dock();
+	NodeDock *get_node_dock();
+	ConnectionsDock *get_connection_dock();
+	InspectorDock *get_inspector_dock();
+	ImportDock *get_import_dock();
+
+	void add_dock(String p_name, Control p_control);
+	void remove_dock(String p_name);
+
+	EditorDocks();
+};
+
+#endif // EDITOR_SINGLETONS_H

--- a/editor/editor_singletons.h
+++ b/editor/editor_singletons.h
@@ -358,9 +358,16 @@ protected:
 
 public:
 	static EditorTopBars *get_singleton() { return singleton; }
+
+	// Getters
 	HBoxContainer *get_main_menu_bar();
 	HBoxContainer *get_workspaces_bar();
 	HBoxContainer *get_playtest_bar();
+
+	// Modifiers
+	void add_tool_menu_item(const String &p_name, const Callable &p_callable);
+	void add_tool_submenu_item(const String &p_name, Object *p_submenu);
+	void remove_tool_menu_item(const String &p_name);
 
 	EditorTopBars(EditorNode *p_editor);
 };

--- a/editor/editor_singletons.h
+++ b/editor/editor_singletons.h
@@ -38,30 +38,6 @@
 #include "scene/gui/panel_container.h"
 #include "scene/main/node.h"
 
-class ScriptEditor;
-
-class SceneTreeDock;
-class NodeDock;
-class ConnectionsDock;
-class InspectorDock;
-class ImportDock;
-class FileSystemDock;
-
-class EditorAudioBuses;
-class EditorLog;
-class AnimationPlayerEditor;
-class AnimationTreeEditor;
-class EditorDebuggerNode;
-class ResourcePreloaderEditor;
-class FindInFilesPanel;
-class ShaderEditor;
-class ShaderFileEditor;
-class SpriteFramesEditor;
-class TextureRegionEditor;
-class ThemeEditor;
-class TileSetEditor;
-class VisualShaderEditor;
-
 class EditorNode;
 class EditorData;
 class EditorSelection;
@@ -95,7 +71,6 @@ public:
 
 	Node *get_edited_scene_root();
 	Array get_open_scenes() const;
-	ScriptEditor *get_script_editor();
 
 	void select_file(const String &p_file);
 	String get_selected_path() const;
@@ -129,10 +104,15 @@ public:
 	EditorInterface(EditorNode *p_editor);
 };
 
+class SceneTreeDock;
+class NodeDock;
+class ConnectionsDock;
+class InspectorDock;
+class ImportDock;
+class FileSystemDock;
+
 class EditorDocks : public Node {
 	GDCLASS(EditorDocks, Node);
-
-	EditorNode *editor;
 
 public:
 	enum DockSlot {
@@ -150,7 +130,9 @@ public:
 private:
 	friend class EditorNode;
 
-	// Editor node added
+	EditorNode *editor;
+
+	// EditorNode added
 	SceneTreeDock *scene_tree_dock = nullptr;
 	FileSystemDock *filesystem_dock = nullptr;
 	NodeDock *node_dock = nullptr;
@@ -188,6 +170,21 @@ public:
 };
 
 VARIANT_ENUM_CAST(EditorDocks::DockSlot);
+
+class EditorAudioBuses;
+class EditorLog;
+class AnimationPlayerEditor;
+class AnimationTreeEditor;
+class EditorDebuggerNode;
+class ResourcePreloaderEditor;
+class FindInFilesPanel;
+class ShaderEditor;
+class ShaderFileEditor;
+class SpriteFramesEditor;
+class TextureRegionEditor;
+class ThemeEditor;
+class TileSetEditor;
+class VisualShaderEditor;
 
 class EditorBottomPanels : public Node {
 	GDCLASS(EditorBottomPanels, Node);
@@ -258,6 +255,47 @@ public:
 	void hide_bottom_panel();
 
 	EditorBottomPanels(EditorNode *p_editor);
+};
+
+class CanvasItemEditor;
+class Node3DEditor;
+class ScriptEditor;
+class EditorAssetLibrary;
+
+class EditorWorkspaces : public Node {
+	GDCLASS(EditorWorkspaces, Node);
+
+	EditorNode *editor;
+
+	CanvasItemEditor *canvas_item_workspace = nullptr;
+	Node3DEditor *node_3d_workspace = nullptr;
+	ScriptEditor *script_workspace = nullptr;
+	EditorAssetLibrary *asset_library_workspace = nullptr;
+
+protected:
+	static void _bind_methods();
+	static EditorWorkspaces *singleton;
+
+public:
+	static EditorWorkspaces *get_singleton() { return singleton; }
+
+	// Internal setters
+	void set_canvas_item_workspace(CanvasItemEditor *p_panel);
+	void set_node_3d_workspace(Node3DEditor *p_panel);
+	void set_script_workspace(ScriptEditor *p_panel);
+	void set_asset_library_workspace(EditorAssetLibrary *p_panel);
+
+	// Getters
+	CanvasItemEditor *get_canvas_item_workspace();
+	Node3DEditor *get_node_3d_workspace();
+	ScriptEditor *get_script_workspace();
+	EditorAssetLibrary *get_asset_library_workspace();
+
+	// Modifiers
+	void add_control(Control *p_control);
+	void remove_control(Control *p_control);
+
+	EditorWorkspaces(EditorNode *p_editor);
 };
 
 #endif // EDITOR_SINGLETONS_H

--- a/editor/editor_singletons.h
+++ b/editor/editor_singletons.h
@@ -39,6 +39,7 @@
 #include "scene/main/node.h"
 
 class EditorNode;
+class EditorPlugin;
 class EditorSelection;
 class EditorSettings;
 
@@ -82,7 +83,6 @@ public:
 	Ref<EditorSettings> get_editor_settings();
 	EditorResourcePreview *get_resource_previewer();
 	EditorFileSystem *get_resource_file_system();
-
 	Control *get_base_control();
 	float get_editor_scale() const;
 
@@ -291,6 +291,7 @@ public:
 	Node3DEditor *get_node_3d_workspace();
 	ScriptEditor *get_script_workspace();
 	EditorAssetLibrary *get_asset_library_workspace();
+	EditorPlugin *get_current_workspace();
 
 	// Modifiers
 	void add_control(Control *p_control);
@@ -337,6 +338,31 @@ public:
 	void remove_scene_import_plugin(const Ref<EditorSceneImporter> &p_importer);
 
 	EditorPluginInterfaces();
+};
+
+class EditorTopBars : public Node {
+	GDCLASS(EditorTopBars, Node);
+
+	friend class EditorNode;
+
+	EditorNode *editor;
+
+	HBoxContainer *main_menu_bar = nullptr;
+	HBoxContainer *workspaces_bar = nullptr;
+	HBoxContainer *playtest_bar = nullptr;
+	HBoxContainer *video_driver_bar = nullptr;
+
+protected:
+	static void _bind_methods();
+	static EditorTopBars *singleton;
+
+public:
+	static EditorTopBars *get_singleton() { return singleton; }
+	HBoxContainer *get_main_menu_bar();
+	HBoxContainer *get_workspaces_bar();
+	HBoxContainer *get_playtest_bar();
+
+	EditorTopBars(EditorNode *p_editor);
 };
 
 #endif // EDITOR_SINGLETONS_H

--- a/editor/editor_singletons.h
+++ b/editor/editor_singletons.h
@@ -59,18 +59,9 @@ public:
 
 	Control *get_editor_main_control();
 	void edit_resource(const Ref<Resource> &p_resource);
+	void edit_node(Node *p_node);
 	void open_scene_from_path(const String &scene_path);
 	void reload_scene_from_path(const String &scene_path);
-
-	void play_main_scene();
-	void play_current_scene();
-	void play_custom_scene(const String &scene_path);
-	void stop_playing_scene();
-	bool is_playing_scene() const;
-	String get_playing_scene() const;
-
-	Node *get_edited_scene_root();
-	Array get_open_scenes() const;
 
 	void select_file(const String &p_file);
 	String get_selected_path() const;
@@ -90,9 +81,6 @@ public:
 	bool is_plugin_enabled(const String &p_plugin) const;
 
 	EditorInspector *get_inspector() const;
-
-	Error save_scene();
-	void save_scene_as(const String &p_scene, bool p_with_preview = true);
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform> *p_transforms, int p_preview_size);
 
@@ -370,6 +358,34 @@ public:
 	void remove_tool_menu_item(const String &p_name);
 
 	EditorTopBars(EditorNode *p_editor);
+};
+
+class EditorScenes : public Node {
+	GDCLASS(EditorScenes, Node);
+
+	EditorNode *editor;
+
+protected:
+	static void _bind_methods();
+	static EditorScenes *singleton;
+
+public:
+	static EditorScenes *get_singleton() { return singleton; }
+
+	void play_main_scene();
+	void play_current_scene();
+	void play_custom_scene(const String &scene_path);
+	void stop_playing_scene();
+	bool is_playing_scene() const;
+	String get_playing_scene() const;
+
+	Node *get_edited_scene_root();
+	Array get_open_scenes() const;
+
+	Error save_scene();
+	void save_scene_as(const String &p_scene, bool p_with_preview = true);
+
+	EditorScenes(EditorNode *p_editor);
 };
 
 #endif // EDITOR_SINGLETONS_H

--- a/editor/editor_singletons.h
+++ b/editor/editor_singletons.h
@@ -31,13 +31,11 @@
 #ifndef EDITOR_SINGLETONS_H
 #define EDITOR_SINGLETONS_H
 
-#include "editor/editor_resource_preview.h"
-//#include "editor/scene_tree_dock.h"
-//#include "editor/inspector_dock.h"
-//#include "editor/node_dock.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_inspector.h"
-#include "editor/filesystem_dock.h"
+#include "editor/editor_resource_preview.h"
+#include "scene/gui/button.h"
+#include "scene/gui/panel_container.h"
 #include "scene/main/node.h"
 
 class ScriptEditor;
@@ -49,12 +47,30 @@ class InspectorDock;
 class ImportDock;
 class FileSystemDock;
 
+class EditorAudioBuses;
+class EditorLog;
+class AnimationPlayerEditor;
+class AnimationTreeEditor;
+class EditorDebuggerNode;
+class ResourcePreloaderEditor;
+class FindInFilesPanel;
+class ShaderEditor;
+class ShaderFileEditor;
+class SpriteFramesEditor;
+class TextureRegionEditor;
+class ThemeEditor;
+class TileSetEditor;
+class VisualShaderEditor;
+
+class EditorNode;
 class EditorData;
 class EditorSelection;
 class EditorSettings;
 
 class EditorInterface : public Node {
 	GDCLASS(EditorInterface, Node);
+
+	EditorNode *editor;
 
 protected:
 	static void _bind_methods();
@@ -110,20 +126,40 @@ public:
 	void set_distraction_free_mode(bool p_enter);
 	bool is_distraction_free_mode_enabled() const;
 
-	EditorInterface();
+	EditorInterface(EditorNode *p_editor);
 };
 
 class EditorDocks : public Node {
 	GDCLASS(EditorDocks, Node);
 
+	EditorNode *editor;
+
+public:
+	enum DockSlot {
+		DOCK_SLOT_LEFT_UL,
+		DOCK_SLOT_LEFT_BL,
+		DOCK_SLOT_LEFT_UR,
+		DOCK_SLOT_LEFT_BR,
+		DOCK_SLOT_RIGHT_UL,
+		DOCK_SLOT_RIGHT_BL,
+		DOCK_SLOT_RIGHT_UR,
+		DOCK_SLOT_RIGHT_BR,
+		DOCK_SLOT_MAX
+	};
+
+private:
 	friend class EditorNode;
 
+	// Editor node added
 	SceneTreeDock *scene_tree_dock = nullptr;
 	FileSystemDock *filesystem_dock = nullptr;
 	NodeDock *node_dock = nullptr;
 	ConnectionsDock *connection_dock = nullptr;
 	InspectorDock *inspector_dock = nullptr;
 	ImportDock *import_dock = nullptr;
+
+	// Plugin added
+	VBoxContainer *version_control_dock = nullptr;
 
 protected:
 	static void _bind_methods();
@@ -132,17 +168,96 @@ protected:
 public:
 	static EditorDocks *get_singleton() { return singleton; }
 
+	// Internal setters
+	void set_version_control_dock(VBoxContainer *p_dock);
+
+	// Getters
 	SceneTreeDock *get_scene_tree_dock();
 	FileSystemDock *get_filesystem_dock();
 	NodeDock *get_node_dock();
 	ConnectionsDock *get_connection_dock();
 	InspectorDock *get_inspector_dock();
 	ImportDock *get_import_dock();
+	VBoxContainer *get_version_control_dock();
 
-	void add_dock(String p_name, Control p_control);
-	void remove_dock(String p_name);
+	// Modifiers
+	void add_control(DockSlot p_slot, Control *p_control);
+	void remove_control(Control *p_control);
 
-	EditorDocks();
+	EditorDocks(EditorNode *p_editor);
+};
+
+VARIANT_ENUM_CAST(EditorDocks::DockSlot);
+
+class EditorBottomPanels : public Node {
+	GDCLASS(EditorBottomPanels, Node);
+
+	EditorNode *editor;
+
+	EditorLog *output_panel = nullptr;
+	EditorAudioBuses *audio_panel = nullptr;
+	AnimationPlayerEditor *animation_panel = nullptr;
+	AnimationTreeEditor *animation_tree_panel = nullptr;
+	EditorDebuggerNode *debugger_panel = nullptr;
+	ResourcePreloaderEditor *resource_preloader_panel = nullptr;
+	FindInFilesPanel *find_in_files_panel = nullptr;
+	ShaderEditor *shader_panel = nullptr;
+	ShaderFileEditor *shader_file_panel = nullptr;
+	SpriteFramesEditor *sprite_frames_panel = nullptr;
+	TextureRegionEditor *texture_region_panel = nullptr;
+	ThemeEditor *theme_panel = nullptr;
+	TileSetEditor *tileset_panel = nullptr;
+	PanelContainer *version_control_panel = nullptr;
+	VisualShaderEditor *visual_shader_panel = nullptr;
+
+protected:
+	static void _bind_methods();
+	static EditorBottomPanels *singleton;
+
+public:
+	static EditorBottomPanels *get_singleton() { return singleton; }
+
+	// Internal setters
+	void set_output_panel(EditorLog *p_panel);
+	void set_audio_panel(EditorAudioBuses *p_panel);
+	void set_animation_panel(AnimationPlayerEditor *p_panel);
+	void set_animation_tree_panel(AnimationTreeEditor *p_panel);
+	void set_debugger_panel(EditorDebuggerNode *p_panel);
+	void set_resource_preloader_panel(ResourcePreloaderEditor *p_panel);
+	void set_find_in_files_panel(FindInFilesPanel *p_panel);
+	void set_shader_panel(ShaderEditor *p_panel);
+	void set_shader_file_panel(ShaderFileEditor *p_panel);
+	void set_sprite_frames_panel(SpriteFramesEditor *p_panel);
+	void set_texture_region_panel(TextureRegionEditor *p_panel);
+	void set_theme_panel(ThemeEditor *p_panel);
+	void set_tileset_panel(TileSetEditor *p_panel);
+	void set_version_control_panel(PanelContainer *p_panel);
+	void set_visual_shader_panel(VisualShaderEditor *p_panel);
+
+	// Getters
+	EditorLog *get_output_panel();
+	EditorAudioBuses *get_audio_panel();
+	AnimationPlayerEditor *get_animation_panel();
+	AnimationTreeEditor *get_animation_tree_panel();
+	EditorDebuggerNode *get_debugger_panel();
+	ResourcePreloaderEditor *get_resource_preloader_panel();
+	FindInFilesPanel *get_find_in_files_panel();
+	ShaderEditor *get_shader_panel();
+	ShaderFileEditor *get_shader_file_panel();
+	SpriteFramesEditor *get_sprite_frames_panel();
+	TextureRegionEditor *get_texture_region_panel();
+	ThemeEditor *get_theme_panel();
+	TileSetEditor *get_tileset_panel();
+	PanelContainer *get_version_control_panel();
+	VisualShaderEditor *get_visual_shader_panel();
+
+	// Modifiers
+	Button *add_control(const String p_title, Control *p_control);
+	void remove_control(Control *p_control);
+	void make_bottom_panel_item_visible(Control *p_item);
+	void hide_bottom_panel();
+
+	EditorBottomPanels(EditorNode *p_editor);
 };
 
 #endif // EDITOR_SINGLETONS_H

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2697,11 +2697,11 @@ void FileSystemDock::_update_import_dock() {
 	}
 
 	if (imports.size() == 0) {
-		EditorNode::get_singleton()->get_import_dock()->clear();
+		EditorDocks::get_singleton()->get_import_dock()->clear();
 	} else if (imports.size() == 1) {
-		EditorNode::get_singleton()->get_import_dock()->set_edit_path(imports[0]);
+		EditorDocks::get_singleton()->get_import_dock()->set_edit_path(imports[0]);
 	} else {
-		EditorNode::get_singleton()->get_import_dock()->set_edit_multiple_paths(imports);
+		EditorDocks::get_singleton()->get_import_dock()->set_edit_multiple_paths(imports);
 	}
 
 	import_dock_needs_update = false;

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -144,8 +144,8 @@ void GroupDialog::_add_pressed() {
 	undo_redo->add_undo_method(this, "emit_signal", "group_edited");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -173,8 +173,8 @@ void GroupDialog::_removed_pressed() {
 	undo_redo->add_undo_method(this, "emit_signal", "group_edited");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -331,8 +331,8 @@ void GroupDialog::_delete_group_pressed(Object *p_item, int p_column, int p_id) 
 	undo_redo->add_undo_method(this, "emit_signal", "group_edited");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -567,8 +567,8 @@ void GroupsEditor::_add_group(const String &p_group) {
 	undo_redo->add_undo_method(this, "update_tree");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 
@@ -595,8 +595,8 @@ void GroupsEditor::_remove_group(Object *p_item, int p_column, int p_id) {
 	undo_redo->add_undo_method(this, "update_tree");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -57,8 +57,6 @@ void NodeDock::_notification(int p_what) {
 	}
 }
 
-NodeDock *NodeDock::singleton = nullptr;
-
 void NodeDock::update_lists() {
 	connections->update_tree();
 }
@@ -85,8 +83,6 @@ void NodeDock::set_node(Node *p_node) {
 }
 
 NodeDock::NodeDock() {
-	singleton = this;
-
 	set_name("Node");
 	mode_hb = memnew(HBoxContainer);
 	add_child(mode_hb);

--- a/editor/node_dock.h
+++ b/editor/node_dock.h
@@ -52,8 +52,6 @@ protected:
 	void _notification(int p_what);
 
 public:
-	static NodeDock *singleton;
-
 	void set_node(Node *p_node);
 
 	void show_groups();

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1479,7 +1479,7 @@ void AnimationPlayerEditor::_stop_onion_skinning() {
 }
 
 void AnimationPlayerEditor::_pin_pressed() {
-	EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->update_tree();
+	EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor()->update_tree();
 }
 
 void AnimationPlayerEditor::_bind_methods() {

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -673,7 +673,7 @@ void AnimationPlayerEditor::set_state(const Dictionary &p_state) {
 		if (Object::cast_to<AnimationPlayer>(n) && EditorNode::get_singleton()->get_editor_selection()->is_selected(n)) {
 			player = Object::cast_to<AnimationPlayer>(n);
 			_update_player();
-			editor->make_bottom_panel_item_visible(this);
+			EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(this);
 			set_process(true);
 			ensure_visibility();
 
@@ -1783,7 +1783,7 @@ bool AnimationPlayerEditorPlugin::handles(Object *p_object) const {
 
 void AnimationPlayerEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		editor->make_bottom_panel_item_visible(anim_editor);
+		EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(anim_editor);
 		anim_editor->set_process(true);
 		anim_editor->ensure_visibility();
 	}
@@ -1793,7 +1793,8 @@ AnimationPlayerEditorPlugin::AnimationPlayerEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	anim_editor = memnew(AnimationPlayerEditor(editor, this));
 	anim_editor->set_undo_redo(EditorNode::get_undo_redo());
-	editor->add_bottom_panel_item(TTR("Animation"), anim_editor);
+	EditorBottomPanels::get_singleton()->add_control(TTR("Animation"), anim_editor);
+	EditorBottomPanels::get_singleton()->set_animation_panel(anim_editor);
 }
 
 AnimationPlayerEditorPlugin::~AnimationPlayerEditorPlugin() {

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -258,11 +258,11 @@ void AnimationTreeEditorPlugin::make_visible(bool p_visible) {
 		//editor->hide_animation_player_editors();
 		//editor->animation_panel_make_visible(true);
 		button->show();
-		editor->make_bottom_panel_item_visible(anim_tree_editor);
+		EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(anim_tree_editor);
 		anim_tree_editor->set_process(true);
 	} else {
 		if (anim_tree_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorBottomPanels::get_singleton()->hide_bottom_panel();
 		}
 		button->hide();
 		anim_tree_editor->set_process(false);
@@ -274,7 +274,8 @@ AnimationTreeEditorPlugin::AnimationTreeEditorPlugin(EditorNode *p_node) {
 	anim_tree_editor = memnew(AnimationTreeEditor);
 	anim_tree_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
 
-	button = editor->add_bottom_panel_item(TTR("AnimationTree"), anim_tree_editor);
+	button = EditorBottomPanels::get_singleton()->add_control(TTR("AnimationTree"), anim_tree_editor);
+	EditorBottomPanels::get_singleton()->set_animation_tree_panel(anim_tree_editor);
 	button->hide();
 }
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1526,11 +1526,11 @@ void AssetLibraryEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-AssetLibraryEditorPlugin::AssetLibraryEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+AssetLibraryEditorPlugin::AssetLibraryEditorPlugin() {
 	addon_library = memnew(EditorAssetLibrary);
 	addon_library->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_main_control()->add_child(addon_library);
+	EditorWorkspaces::get_singleton()->add_control(addon_library);
+	EditorWorkspaces::get_singleton()->set_asset_library_workspace(addon_library);
 	addon_library->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	addon_library->hide();
 }

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -311,7 +311,6 @@ class AssetLibraryEditorPlugin : public EditorPlugin {
 	GDCLASS(AssetLibraryEditorPlugin, EditorPlugin);
 
 	EditorAssetLibrary *addon_library;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "AssetLib"; }
@@ -323,7 +322,7 @@ public:
 	//virtual Dictionary get_state() const;
 	//virtual void set_state(const Dictionary& p_state);
 
-	AssetLibraryEditorPlugin(EditorNode *p_node);
+	AssetLibraryEditorPlugin();
 	~AssetLibraryEditorPlugin();
 };
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1033,9 +1033,9 @@ void CanvasItemEditor::_selection_menu_hide() {
 
 void CanvasItemEditor::_add_node_pressed(int p_result) {
 	if (p_result == AddNodeOption::ADD_NODE) {
-		editor->get_scene_tree_dock()->open_add_child_dialog();
+		EditorDocks::get_singleton()->get_scene_tree_dock()->open_add_child_dialog();
 	} else if (p_result == AddNodeOption::ADD_INSTANCE) {
-		editor->get_scene_tree_dock()->open_instance_child_dialog();
+		EditorDocks::get_singleton()->get_scene_tree_dock()->open_instance_child_dialog();
 	}
 }
 
@@ -5684,8 +5684,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	editor_selection->connect("selection_changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
 	editor_selection->connect("selection_changed", callable_mp(this, &CanvasItemEditor::_selection_changed));
 
-	editor->get_scene_tree_dock()->connect("node_created", callable_mp(this, &CanvasItemEditor::_node_created));
-	editor->get_scene_tree_dock()->connect("add_node_used", callable_mp(this, &CanvasItemEditor::_reset_create_position));
+	EditorDocks::get_singleton()->get_scene_tree_dock()->connect("node_created", callable_mp(this, &CanvasItemEditor::_node_created));
+	EditorDocks::get_singleton()->get_scene_tree_dock()->connect("add_node_used", callable_mp(this, &CanvasItemEditor::_reset_create_position));
 
 	editor->call_deferred("connect", "play_pressed", Callable(this, "_update_override_camera_button"), make_binds(true));
 	editor->call_deferred("connect", "stop_pressed", Callable(this, "_update_override_camera_button"), make_binds(false));
@@ -6083,8 +6083,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	add_node_menu = memnew(PopupMenu);
 	add_child(add_node_menu);
-	add_node_menu->add_icon_item(editor->get_scene_tree_dock()->get_theme_icon("Add", "EditorIcons"), TTR("Add Node Here"));
-	add_node_menu->add_icon_item(editor->get_scene_tree_dock()->get_theme_icon("Instance", "EditorIcons"), TTR("Instance Scene Here"));
+	add_node_menu->add_icon_item(EditorDocks::get_singleton()->get_scene_tree_dock()->get_theme_icon("Add", "EditorIcons"), TTR("Add Node Here"));
+	add_node_menu->add_icon_item(EditorDocks::get_singleton()->get_scene_tree_dock()->get_theme_icon("Instance", "EditorIcons"), TTR("Instance Scene Here"));
 	add_node_menu->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_add_node_pressed));
 
 	multiply_grid_step_shortcut = ED_SHORTCUT("canvas_item_editor/multiply_grid_step", TTR("Multiply grid step by 2"), KEY_KP_MULTIPLY);
@@ -6561,7 +6561,7 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 
 	target_node = nullptr;
 	editor = p_node;
-	editor_data = editor->get_scene_tree_dock()->get_editor_data();
+	editor_data = EditorDocks::get_singleton()->get_scene_tree_dock()->get_editor_data();
 	canvas_item_editor = p_canvas_item_editor;
 	preview_node = memnew(Node2D);
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6136,7 +6136,8 @@ CanvasItemEditorPlugin::CanvasItemEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	canvas_item_editor = memnew(CanvasItemEditor(editor));
 	canvas_item_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_main_control()->add_child(canvas_item_editor);
+	EditorWorkspaces::get_singleton()->add_control(canvas_item_editor);
+	EditorWorkspaces::get_singleton()->set_canvas_item_workspace(canvas_item_editor);
 	canvas_item_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	canvas_item_editor->hide();
 }

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -51,7 +51,8 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(EditorNode *p_editor, MenuButton *p_d
 	file_server = memnew(EditorFileServer);
 
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
-	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
+	Button *db = EditorBottomPanels::get_singleton()->add_control(TTR("Debugger"), debugger);
+	EditorBottomPanels::get_singleton()->set_debugger_panel(debugger);
 	debugger->set_tool_button(db);
 
 	// Main editor debug menu.

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -86,9 +86,9 @@ void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles2D"));
-			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", particles, cpu_particles, true, false);
+			ur->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock(), "replace_node", particles, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
-			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, particles, false, false);
+			ur->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, particles, false, false);
 			ur->add_undo_reference(particles);
 			ur->commit_action();
 

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -267,9 +267,9 @@ void GPUParticles3DEditor::_menu_option(int p_option) {
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles3D"));
-			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, cpu_particles, true, false);
+			ur->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock(), "replace_node", node, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
-			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, node, false, false);
+			ur->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, node, false, false);
 			ur->add_undo_reference(node);
 			ur->commit_action();
 

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -93,5 +93,5 @@ void EditorInspectorPluginGradient::parse_begin(Object *p_object) {
 GradientEditorPlugin::GradientEditorPlugin(EditorNode *p_node) {
 	Ref<EditorInspectorPluginGradient> plugin;
 	plugin.instance();
-	add_inspector_plugin(plugin);
+	EditorPluginInterfaces::get_singleton()->add_inspector_plugin(plugin);
 }

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -234,7 +234,7 @@ EditorInspectorPluginMaterial::EditorInspectorPluginMaterial() {
 MaterialEditorPlugin::MaterialEditorPlugin(EditorNode *p_node) {
 	Ref<EditorInspectorPluginMaterial> plugin;
 	plugin.instance();
-	add_inspector_plugin(plugin);
+	EditorPluginInterfaces::get_singleton()->add_inspector_plugin(plugin);
 }
 
 String StandardMaterial3DConversionPlugin::converts_to() const {

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -183,5 +183,5 @@ void EditorInspectorPluginMesh::parse_begin(Object *p_object) {
 MeshEditorPlugin::MeshEditorPlugin(EditorNode *p_node) {
 	Ref<EditorInspectorPluginMesh> plugin;
 	plugin.instance();
-	add_inspector_plugin(plugin);
+	EditorPluginInterfaces::get_singleton()->add_inspector_plugin(plugin);
 }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7335,8 +7335,8 @@ Node3DEditorPlugin::Node3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	spatial_editor = memnew(Node3DEditor(p_node));
 	spatial_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_main_control()->add_child(spatial_editor);
-
+	EditorWorkspaces::get_singleton()->add_control(spatial_editor);
+	EditorWorkspaces::get_singleton()->set_node_3d_workspace(spatial_editor);
 	spatial_editor->hide();
 	spatial_editor->connect("transform_key_request", Callable(EditorDocks::get_singleton()->get_inspector_dock(), "_transform_keyed"));
 }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2411,7 +2411,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		_update_freelook(delta);
 
-		Node *scene_root = editor->get_scene_tree_dock()->get_editor_data()->get_edited_scene_root();
+		Node *scene_root = EditorDocks::get_singleton()->get_scene_tree_dock()->get_editor_data()->get_edited_scene_root();
 		if (previewing_cinema && scene_root != nullptr) {
 			Camera3D *cam = scene_root->get_viewport()->get_camera();
 			if (cam != nullptr && cam != previewing) {
@@ -3960,7 +3960,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 
 	index = p_index;
 	editor = p_editor;
-	editor_data = editor->get_scene_tree_dock()->get_editor_data();
+	editor_data = EditorDocks::get_singleton()->get_scene_tree_dock()->get_editor_data();
 	editor_selection = editor->get_editor_selection();
 	undo_redo = editor->get_undo_redo();
 
@@ -6281,7 +6281,7 @@ void Node3DEditor::_notification(int p_what) {
 
 		get_tree()->connect("node_removed", callable_mp(this, &Node3DEditor::_node_removed));
 		get_tree()->connect("node_added", callable_mp(this, &Node3DEditor::_node_added));
-		EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->connect("node_changed", callable_mp(this, &Node3DEditor::_refresh_menu_icons));
+		EditorDocks::get_singleton()->get_scene_tree_dock()->get_tree_editor()->connect("node_changed", callable_mp(this, &Node3DEditor::_refresh_menu_icons));
 		editor_selection->connect("selection_changed", callable_mp(this, &Node3DEditor::_refresh_menu_icons));
 
 		editor->connect("stop_pressed", callable_mp(this, &Node3DEditor::_update_camera_override_button), make_binds(false));
@@ -7338,7 +7338,7 @@ Node3DEditorPlugin::Node3DEditorPlugin(EditorNode *p_node) {
 	editor->get_main_control()->add_child(spatial_editor);
 
 	spatial_editor->hide();
-	spatial_editor->connect("transform_key_request", Callable(editor->get_inspector_dock(), "_transform_keyed"));
+	spatial_editor->connect("transform_key_request", Callable(EditorDocks::get_singleton()->get_inspector_dock(), "_transform_keyed"));
 }
 
 Node3DEditorPlugin::~Node3DEditorPlugin() {

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -404,11 +404,11 @@ void ResourcePreloaderEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		//preloader_editor->show();
 		button->show();
-		editor->make_bottom_panel_item_visible(preloader_editor);
+		EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(preloader_editor);
 		//preloader_editor->set_process(true);
 	} else {
 		if (preloader_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorBottomPanels::get_singleton()->hide_bottom_panel();
 		}
 		button->hide();
 		//preloader_editor->hide();
@@ -421,7 +421,8 @@ ResourcePreloaderEditorPlugin::ResourcePreloaderEditorPlugin(EditorNode *p_node)
 	preloader_editor = memnew(ResourcePreloaderEditor);
 	preloader_editor->set_custom_minimum_size(Size2(0, 250) * EDSCALE);
 
-	button = editor->add_bottom_panel_item(TTR("ResourcePreloader"), preloader_editor);
+	button = EditorBottomPanels::get_singleton()->add_control(TTR("ResourcePreloader"), preloader_editor);
+	EditorBottomPanels::get_singleton()->set_resource_preloader_panel(preloader_editor);
 	button->hide();
 
 	//preloader_editor->set_anchor( MARGIN_TOP, Control::ANCHOR_END);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1530,7 +1530,7 @@ void ScriptEditor::_notification(int p_what) {
 				find_in_files_button->show();
 			} else {
 				if (find_in_files->is_visible_in_tree()) {
-					editor->hide_bottom_panel();
+					EditorBottomPanels::get_singleton()->hide_bottom_panel();
 				}
 				find_in_files_button->hide();
 			}
@@ -3234,7 +3234,7 @@ void ScriptEditor::_start_find_in_files(bool with_replace) {
 	find_in_files->set_replace_text(find_in_files_dialog->get_replace_text());
 	find_in_files->start_search();
 
-	editor->make_bottom_panel_item_visible(find_in_files);
+	EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(find_in_files);
 }
 
 void ScriptEditor::_on_find_in_files_modified_files(PackedStringArray paths) {
@@ -3571,7 +3571,8 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	find_in_files_dialog->connect(FindInFilesDialog::SIGNAL_REPLACE_REQUESTED, callable_mp(this, &ScriptEditor::_start_find_in_files), varray(true));
 	add_child(find_in_files_dialog);
 	find_in_files = memnew(FindInFilesPanel);
-	find_in_files_button = editor->add_bottom_panel_item(TTR("Search Results"), find_in_files);
+	find_in_files_button = EditorBottomPanels::get_singleton()->add_control(TTR("Search Results"), find_in_files);
+	EditorBottomPanels::get_singleton()->set_find_in_files_panel(find_in_files);
 	find_in_files->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	find_in_files->connect(FindInFilesPanel::SIGNAL_RESULT_SELECTED, callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
 	find_in_files->connect(FindInFilesPanel::SIGNAL_FILES_MODIFIED, callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1341,7 +1341,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				const RES script = current->get_edited_resource();
 				const String path = script->get_path();
 				if (!path.is_empty()) {
-					FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
+					FileSystemDock *file_system_dock = EditorDocks::get_singleton()->get_filesystem_dock();
 					file_system_dock->navigate_to_path(path);
 					// Ensure that the FileSystem dock is visible.
 					TabContainer *tab_container = (TabContainer *)file_system_dock->get_parent_control();
@@ -1470,7 +1470,7 @@ void ScriptEditor::_notification(int p_what) {
 			editor->connect("stop_pressed", callable_mp(this, &ScriptEditor::_editor_stop));
 			editor->connect("script_add_function_request", callable_mp(this, &ScriptEditor::_add_callback));
 			editor->connect("resource_saved", callable_mp(this, &ScriptEditor::_res_saved_callback));
-			editor->get_filesystem_dock()->connect("file_removed", callable_mp(this, &ScriptEditor::_file_removed));
+			EditorDocks::get_singleton()->get_filesystem_dock()->connect("file_removed", callable_mp(this, &ScriptEditor::_file_removed));
 			script_list->connect("item_selected", callable_mp(this, &ScriptEditor::_script_selected));
 
 			members_overview->connect("item_selected", callable_mp(this, &ScriptEditor::_members_overview_selected));
@@ -1512,7 +1512,7 @@ void ScriptEditor::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 			get_tree()->connect("tree_changed", callable_mp(this, &ScriptEditor::_tree_changed));
-			editor->get_inspector_dock()->connect("request_help", callable_mp(this, &ScriptEditor::_help_class_open));
+			EditorDocks::get_singleton()->get_inspector_dock()->connect("request_help", callable_mp(this, &ScriptEditor::_help_class_open));
 			editor->connect("request_help_search", callable_mp(this, &ScriptEditor::_help_search));
 		} break;
 
@@ -3168,7 +3168,7 @@ void ScriptEditor::register_create_script_editor_function(CreateScriptEditorFunc
 }
 
 void ScriptEditor::_script_changed() {
-	NodeDock::singleton->update_lists();
+	EditorDocks::get_singleton()->get_node_dock()->update_lists();
 }
 
 void ScriptEditor::_on_find_in_files_requested(String text) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3676,7 +3676,8 @@ void ScriptEditorPlugin::edited_scene_changed() {
 ScriptEditorPlugin::ScriptEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	script_editor = memnew(ScriptEditor(p_node));
-	editor->get_main_control()->add_child(script_editor);
+	EditorWorkspaces::get_singleton()->add_control(script_editor);
+	EditorWorkspaces::get_singleton()->set_script_workspace(script_editor);
 	script_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	script_editor->hide();

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -172,6 +172,7 @@ public:
 
 typedef ScriptEditorBase *(*CreateScriptEditorFunc)(const RES &p_resource);
 
+class EditorNode;
 class EditorScriptCodeCompletionCache;
 class FindInFilesDialog;
 class FindInFilesPanel;

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -798,12 +798,12 @@ bool ShaderEditorPlugin::handles(Object *p_object) const {
 void ShaderEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		editor->make_bottom_panel_item_visible(shader_editor);
+		EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(shader_editor);
 
 	} else {
 		button->hide();
 		if (shader_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorBottomPanels::get_singleton()->hide_bottom_panel();
 		}
 		shader_editor->apply_shaders();
 	}
@@ -826,7 +826,8 @@ ShaderEditorPlugin::ShaderEditorPlugin(EditorNode *p_node) {
 	shader_editor = memnew(ShaderEditor(p_node));
 
 	shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
-	button = editor->add_bottom_panel_item(TTR("Shader"), shader_editor);
+	button = EditorBottomPanels::get_singleton()->add_control(TTR("Shader"), shader_editor);
+	EditorBottomPanels::get_singleton()->set_shader_panel(shader_editor);
 	button->hide();
 
 	_2d = false;

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -301,12 +301,12 @@ bool ShaderFileEditorPlugin::handles(Object *p_object) const {
 void ShaderFileEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		editor->make_bottom_panel_item_visible(shader_editor);
+		EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(shader_editor);
 
 	} else {
 		button->hide();
 		if (shader_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorBottomPanels::get_singleton()->hide_bottom_panel();
 		}
 	}
 }
@@ -316,7 +316,8 @@ ShaderFileEditorPlugin::ShaderFileEditorPlugin(EditorNode *p_node) {
 	shader_editor = memnew(ShaderFileEditor(p_node));
 
 	shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
-	button = editor->add_bottom_panel_item(TTR("ShaderFile"), shader_editor);
+	button = EditorBottomPanels::get_singleton()->add_control(TTR("ShaderFile"), shader_editor);
+	EditorBottomPanels::get_singleton()->set_shader_file_panel(shader_editor);
 	button->hide();
 }
 

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -337,9 +337,9 @@ void Sprite2DEditor::_convert_to_mesh_2d_node() {
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Convert to Mesh2D"));
-	ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, mesh_instance, true, false);
+	ur->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock(), "replace_node", node, mesh_instance, true, false);
 	ur->add_do_reference(mesh_instance);
-	ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", mesh_instance, node, false, false);
+	ur->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock(), "replace_node", mesh_instance, node, false, false);
 	ur->add_undo_reference(node);
 	ur->commit_action();
 }
@@ -395,9 +395,9 @@ void Sprite2DEditor::_convert_to_polygon_2d_node() {
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Convert to Polygon2D"));
-	ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, polygon_2d_instance, true, false);
+	ur->add_do_method(EditorDocks::get_singleton()->get_scene_tree_dock(), "replace_node", node, polygon_2d_instance, true, false);
 	ur->add_do_reference(polygon_2d_instance);
-	ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", polygon_2d_instance, node, false, false);
+	ur->add_undo_method(EditorDocks::get_singleton()->get_scene_tree_dock(), "replace_node", polygon_2d_instance, node, false, false);
 	ur->add_undo_reference(node);
 	ur->commit_action();
 }

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1279,11 +1279,11 @@ bool SpriteFramesEditorPlugin::handles(Object *p_object) const {
 void SpriteFramesEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		editor->make_bottom_panel_item_visible(frames_editor);
+		EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(frames_editor);
 	} else {
 		button->hide();
 		if (frames_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorBottomPanels::get_singleton()->hide_bottom_panel();
 		}
 	}
 }
@@ -1292,7 +1292,8 @@ SpriteFramesEditorPlugin::SpriteFramesEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	frames_editor = memnew(SpriteFramesEditor);
 	frames_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
-	button = editor->add_bottom_panel_item(TTR("SpriteFrames"), frames_editor);
+	button = EditorBottomPanels::get_singleton()->add_control(TTR("SpriteFrames"), frames_editor);
+	EditorBottomPanels::get_singleton()->set_sprite_frames_panel(frames_editor);
 	button->hide();
 }
 

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -94,5 +94,5 @@ StyleBoxPreview::StyleBoxPreview() {
 StyleBoxEditorPlugin::StyleBoxEditorPlugin(EditorNode *p_node) {
 	Ref<EditorInspectorPluginStyleBox> inspector_plugin;
 	inspector_plugin.instance();
-	add_inspector_plugin(inspector_plugin);
+	EditorPluginInterfaces::get_singleton()->add_inspector_plugin(inspector_plugin);
 }

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -208,5 +208,5 @@ void EditorInspectorPlugin3DTexture::parse_begin(Object *p_object) {
 Texture3DEditorPlugin::Texture3DEditorPlugin(EditorNode *p_node) {
 	Ref<EditorInspectorPlugin3DTexture> plugin;
 	plugin.instance();
-	add_inspector_plugin(plugin);
+	EditorPluginInterfaces::get_singleton()->add_inspector_plugin(plugin);
 }

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -161,5 +161,5 @@ void EditorInspectorPluginTexture::parse_begin(Object *p_object) {
 TextureEditorPlugin::TextureEditorPlugin(EditorNode *p_node) {
 	Ref<EditorInspectorPluginTexture> plugin;
 	plugin.instance();
-	add_inspector_plugin(plugin);
+	EditorPluginInterfaces::get_singleton()->add_inspector_plugin(plugin);
 }

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -272,5 +272,5 @@ void EditorInspectorPluginLayeredTexture::parse_begin(Object *p_object) {
 TextureLayeredEditorPlugin::TextureLayeredEditorPlugin(EditorNode *p_node) {
 	Ref<EditorInspectorPluginLayeredTexture> plugin;
 	plugin.instance();
-	add_inspector_plugin(plugin);
+	EditorPluginInterfaces::get_singleton()->add_inspector_plugin(plugin);
 }

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -1116,11 +1116,11 @@ void TextureRegionEditorPlugin::make_visible(bool p_visible) {
 		texture_region_button->show();
 		bool is_node_configured = region_editor->is_stylebox() || region_editor->is_atlas_texture() || region_editor->is_ninepatch() || (region_editor->get_sprite() && region_editor->get_sprite()->is_region_enabled()) || (region_editor->get_sprite_3d() && region_editor->get_sprite_3d()->is_region_enabled());
 		if ((is_node_configured && !manually_hidden) || texture_region_button->is_pressed()) {
-			editor->make_bottom_panel_item_visible(region_editor);
+			EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(region_editor);
 		}
 	} else {
 		if (region_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorBottomPanels::get_singleton()->hide_bottom_panel();
 			manually_hidden = false;
 		}
 		texture_region_button->hide();
@@ -1178,6 +1178,7 @@ TextureRegionEditorPlugin::TextureRegionEditorPlugin(EditorNode *p_node) {
 	region_editor->hide();
 	region_editor->connect("visibility_changed", callable_mp(this, &TextureRegionEditorPlugin::_editor_visiblity_changed));
 
-	texture_region_button = p_node->add_bottom_panel_item(TTR("TextureRegion"), region_editor);
+	texture_region_button = EditorBottomPanels::get_singleton()->add_control(TTR("TextureRegion"), region_editor);
+	EditorBottomPanels::get_singleton()->set_texture_region_panel(region_editor);
 	texture_region_button->hide();
 }

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2166,11 +2166,11 @@ void ThemeEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		theme_editor->set_process(true);
 		button->show();
-		editor->make_bottom_panel_item_visible(theme_editor);
+		EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(theme_editor);
 	} else {
 		theme_editor->set_process(false);
 		if (theme_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorBottomPanels::get_singleton()->hide_bottom_panel();
 		}
 
 		button->hide();
@@ -2182,6 +2182,7 @@ ThemeEditorPlugin::ThemeEditorPlugin(EditorNode *p_node) {
 	theme_editor = memnew(ThemeEditor);
 	theme_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 
-	button = editor->add_bottom_panel_item(TTR("Theme"), theme_editor);
+	button = EditorBottomPanels::get_singleton()->add_control(TTR("Theme"), theme_editor);
+	EditorBottomPanels::get_singleton()->set_theme_panel(theme_editor);
 	button->hide();
 }

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -294,11 +294,13 @@ void VersionControlEditorPlugin::_update_commit_button() {
 
 void VersionControlEditorPlugin::register_editor() {
 	if (!EditorVCSInterface::get_singleton()) {
-		EditorNode::get_singleton()->add_control_to_dock(EditorNode::DOCK_SLOT_RIGHT_UL, version_commit_dock);
+		EditorDocks::get_singleton()->add_control(EditorDocks::DOCK_SLOT_LEFT_UL, version_commit_dock);
+		EditorDocks::get_singleton()->set_version_control_dock(version_commit_dock);
 		TabContainer *dock_vbc = (TabContainer *)version_commit_dock->get_parent_control();
 		dock_vbc->set_tab_title(version_commit_dock->get_index(), TTR("Commit"));
 
-		Button *vc = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Version Control"), version_control_dock);
+		Button *vc = EditorBottomPanels::get_singleton()->add_control(TTR("Version Control"), version_control_dock);
+		EditorBottomPanels::get_singleton()->set_version_control_panel(version_control_dock);
 		set_version_control_tool_button(vc);
 	}
 }

--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -70,6 +70,7 @@ private:
 	HashMap<ChangeType, String> change_type_to_strings;
 	HashMap<ChangeType, Color> change_type_to_color;
 
+	// TODO: create a dedicated class
 	VBoxContainer *version_commit_dock;
 	VBoxContainer *commit_box_vbc;
 	HSplitContainer *stage_tools;

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3632,7 +3632,7 @@ void VisualShaderEditor::_visibility_changed() {
 void VisualShaderEditor::_bind_methods() {
 	ClassDB::bind_method("_update_graph", &VisualShaderEditor::_update_graph);
 	ClassDB::bind_method("_update_options_menu", &VisualShaderEditor::_update_options_menu);
-	ClassDB::bind_method("_add_node", &VisualShaderEditor::_add_node);
+	//ClassDB::bind_method("_add_node", &VisualShaderEditor::_add_node);
 	ClassDB::bind_method("_node_changed", &VisualShaderEditor::_node_changed);
 	ClassDB::bind_method("_input_select_item", &VisualShaderEditor::_input_select_item);
 	ClassDB::bind_method("_uniform_select_item", &VisualShaderEditor::_uniform_select_item);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4402,13 +4402,13 @@ void VisualShaderEditorPlugin::make_visible(bool p_visible) {
 		//editor->hide_animation_player_editors();
 		//editor->animation_panel_make_visible(true);
 		button->show();
-		editor->make_bottom_panel_item_visible(visual_shader_editor);
+		EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(visual_shader_editor);
 		visual_shader_editor->update_custom_nodes();
 		visual_shader_editor->set_process_input(true);
 		//visual_shader_editor->set_process(true);
 	} else {
 		if (visual_shader_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorBottomPanels::get_singleton()->hide_bottom_panel();
 		}
 		button->hide();
 		visual_shader_editor->set_process_input(false);
@@ -4421,7 +4421,8 @@ VisualShaderEditorPlugin::VisualShaderEditorPlugin(EditorNode *p_node) {
 	visual_shader_editor = memnew(VisualShaderEditor);
 	visual_shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
 
-	button = editor->add_bottom_panel_item(TTR("VisualShader"), visual_shader_editor);
+	button = EditorBottomPanels::get_singleton()->add_control(TTR("VisualShader"), visual_shader_editor);
+	EditorBottomPanels::get_singleton()->set_visual_shader_panel(visual_shader_editor);
 	button->hide();
 }
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -219,19 +219,19 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 				} break;
 				case OBJ_MENU_NEW_SCRIPT: {
 					if (Object::cast_to<Node>(owner)) {
-						EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(owner), false);
+						EditorDocks::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(owner), false);
 					}
 
 				} break;
 				case OBJ_MENU_EXTEND_SCRIPT: {
 					if (Object::cast_to<Node>(owner)) {
-						EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(owner), true);
+						EditorDocks::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(owner), true);
 					}
 
 				} break;
 				case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {
 					RES r = v;
-					FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
+					FileSystemDock *file_system_dock = EditorDocks::get_singleton()->get_filesystem_dock();
 					file_system_dock->navigate_to_path(r->get_path());
 					// Ensure that the FileSystem dock is visible.
 					TabContainer *tab_container = (TabContainer *)file_system_dock->get_parent_control();
@@ -1254,7 +1254,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 				if (owner->is_class("Node") && (v.get_type() == Variant::NODE_PATH) && Object::cast_to<Node>(owner)->has_node(v)) {
 					Node *target_node = Object::cast_to<Node>(owner)->get_node(v);
 					EditorNode::get_singleton()->get_editor_selection()->clear();
-					EditorNode::get_singleton()->get_scene_tree_dock()->set_selected(target_node);
+					EditorDocks::get_singleton()->get_scene_tree_dock()->set_selected(target_node);
 				}
 
 				hide();

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -35,6 +35,8 @@
 #include "editor_help.h"
 #include "scene/gui/rich_text_label.h"
 
+class EditorHelpBit;
+
 class PropertySelector : public ConfirmationDialog {
 	GDCLASS(PropertySelector, ConfirmationDialog);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2019,7 +2019,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 	// Fixes the EditorHistory from still offering deleted notes
 	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
 	editor_history->cleanup_history();
-	EditorNode::get_singleton()->get_inspector_dock()->call("_prepare_history");
+	EditorDocks::get_singleton()->get_inspector_dock()->call("_prepare_history");
 }
 
 void SceneTreeDock::_update_script_button() {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -49,6 +49,7 @@
 #include "scene_tree_editor.h"
 
 class EditorNode;
+class EditorData;
 
 class SceneTreeDock : public VBoxContainer {
 	GDCLASS(SceneTreeDock, VBoxContainer);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -134,8 +134,9 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 
 		set_selected(n);
 
-		NodeDock::singleton->get_parent()->call("set_current_tab", NodeDock::singleton->get_index());
-		NodeDock::singleton->show_connections();
+		EditorDocks::get_singleton()->get_node_dock()->get_parent()->call(
+				"set_current_tab", EditorDocks::get_singleton()->get_node_dock()->get_index());
+		EditorDocks::get_singleton()->get_node_dock()->show_connections();
 
 	} else if (p_id == BUTTON_GROUPS) {
 		editor_selection->clear();
@@ -143,8 +144,9 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 
 		set_selected(n);
 
-		NodeDock::singleton->get_parent()->call("set_current_tab", NodeDock::singleton->get_index());
-		NodeDock::singleton->show_groups();
+		EditorDocks::get_singleton()->get_node_dock()->get_parent()->call(
+				"set_current_tab", EditorDocks::get_singleton()->get_node_dock()->get_index());
+		EditorDocks::get_singleton()->get_node_dock()->show_groups();
 	}
 }
 

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -38,6 +38,8 @@
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tree.h"
 
+class EditorSelection;
+
 class SceneTreeEditor : public Control {
 	GDCLASS(SceneTreeEditor, Control);
 

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -398,7 +398,7 @@ bool GDNativeLibraryEditorPlugin::handles(Object *p_node) const {
 void GDNativeLibraryEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		EditorNode::get_singleton()->make_bottom_panel_item_visible(library_editor);
+		EditorBottomPanels::get_singleton()->make_bottom_panel_item_visible(library_editor);
 
 	} else {
 		if (library_editor->is_visible_in_tree()) {
@@ -411,7 +411,7 @@ void GDNativeLibraryEditorPlugin::make_visible(bool p_visible) {
 GDNativeLibraryEditorPlugin::GDNativeLibraryEditorPlugin(EditorNode *p_node) {
 	library_editor = memnew(GDNativeLibraryEditor);
 	library_editor->set_custom_minimum_size(Size2(0, 250 * EDSCALE));
-	button = p_node->add_bottom_panel_item(TTR("GDNativeLibrary"), library_editor);
+	button = EditorBottomPanels::get_singleton()->add_control(TTR("GDNativeLibrary"), library_editor);
 	button->hide();
 }
 

--- a/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
@@ -61,7 +61,7 @@ SceneExporterGLTFPlugin::SceneExporterGLTFPlugin(EditorNode *p_node) {
 	file_export_lib->add_filter("*.gltf");
 	file_export_lib->set_title(TTR("Export Mesh GLTF2"));
 	String gltf_scene_name = TTR("Export GLTF...");
-	add_tool_menu_item(gltf_scene_name, callable_mp(this, &SceneExporterGLTFPlugin::convert_scene_to_gltf2));
+	EditorTopBars::get_singleton()->add_tool_menu_item(gltf_scene_name, callable_mp(this, &SceneExporterGLTFPlugin::convert_scene_to_gltf2));
 }
 
 void SceneExporterGLTFPlugin::_gltf2_dialog_action(String p_file) {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1197,7 +1197,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 	// FIXME: Hack to refresh editor in order to display new properties and signals. See if there is a better alternative.
 	if (Engine::get_singleton()->is_editor_hint()) {
 		EditorNode::get_singleton()->get_inspector()->update_tree();
-		NodeDock::singleton->update_lists();
+		EditorDocks::get_singleton()->get_node_dock()->update_lists();
 	}
 #endif
 }


### PR DESCRIPTION
Part of godotengine/godot-proposals#2537

This PR exposes every editor component (only the main ones, not subcomponents) through dedicated singletons.
The naming scheme follows [this section](https://docs.godotengine.org/en/latest/community/contributing/docs_writing_guidelines.html#common-vocabulary-to-use-in-godot-s-documentation), including the use of "workspace" instead of "main screen".

I took the opportunity to move some methods from EditorPlugin and EditorInterface to dedicated singletons to clean up that classes. As I pointed out in godotengine/godot-proposals#2537, the Godot editor is too big and complex to expose its API mostly through 2 classes.

Singletons:

- [x] EditorDocks
- [x] EditorBottomPanels
- [x] EditorWorkspaces
- [x] EditorTopBars
- [x] EditorPluginInterfaces (I don't like this name)
- [x] EditorScenes (may require a better name)
- [x] EditorInterface

Notes for reviewers: 
- Since this is going to be a big PR, I'd be verbose with commits and squash them when this became stable enough.
- Docs are not done yet because I prefer that we agree on the new API.