### PR TITLE
Rename Project Settings, Display, Window width and height, and test_width and test_height settings to match their function

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -488,7 +488,7 @@
 		</member>
 		<member name="display/window/handheld/orientation" type="int" setter="" getter="" default="0">
 			The default screen orientation to use on mobile devices. See [enum DisplayServer.ScreenOrientation] for possible values.
-			[b]Note:[/b] When set to a portrait orientation, this project setting does not flip the project resolution's width and height automatically. Instead, you have to set [member display/window/size/width] and [member display/window/size/height] accordingly.
+			[b]Note:[/b] When set to a portrait orientation, this project setting does not flip the project resolution's width and height automatically. Instead, you have to set [member display/window/size/viewport_width] and [member display/window/size/viewport_height] accordingly.
 		</member>
 		<member name="display/window/ios/hide_home_indicator" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the home indicator is hidden automatically. This only affects iOS devices without a physical home button.
@@ -506,21 +506,23 @@
 			Regardless of the platform, enabling fullscreen will change the window size to match the monitor's size. Therefore, make sure your project supports [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] when enabling fullscreen mode.
 			[b]Note:[/b] This setting is ignored on iOS, Android, and HTML5.
 		</member>
-		<member name="display/window/size/height" type="int" setter="" getter="" default="600">
-			Sets the game's main viewport height. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
-		</member>
 		<member name="display/window/size/resizable" type="bool" setter="" getter="" default="true">
 			Allows the window to be resizable by default.
 			[b]Note:[/b] This setting is ignored on iOS and Android.
 		</member>
-		<member name="display/window/size/test_height" type="int" setter="" getter="" default="0">
-			If greater than zero, overrides the window height when running the game. Useful for testing stretch modes.
+		<member name="display/window/size/viewport_height" type="int" setter="" getter="" default="600">
+			Sets the game's main viewport height. On desktop platforms, this is also the initial window height.
 		</member>
-		<member name="display/window/size/test_width" type="int" setter="" getter="" default="0">
-			If greater than zero, overrides the window width when running the game. Useful for testing stretch modes.
+		<member name="display/window/size/viewport_width" type="int" setter="" getter="" default="1024">
+			Sets the game's main viewport width. On desktop platforms, this is also the initial window width.
 		</member>
-		<member name="display/window/size/width" type="int" setter="" getter="" default="1024">
-			Sets the game's main viewport width. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
+		<member name="display/window/size/window_height_override" type="int" setter="" getter="" default="0">
+			On desktop platforms, sets the game's initial window height.
+			[b]Note:[/b] By default, or when set to 0, the initial window height is the [member display/window/size/viewport_height]. This setting is ignored on iOS, Android, and HTML5.
+		</member>
+		<member name="display/window/size/window_width_override" type="int" setter="" getter="" default="0">
+			On desktop platforms, sets the game's initial window width.
+			[b]Note:[/b] By default, or when set to 0, the initial window width is the viewport [member display/window/size/viewport_width]. This setting is ignored on iOS, Android, and HTML5.
 		</member>
 		<member name="display/window/vsync/vsync_mode" type="int" setter="" getter="" default="1">
 			Sets the VSync mode for the main game window.

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -98,15 +98,15 @@ Error EditorRun::run(const String &p_scene) {
 	screen_rect.position = DisplayServer::get_singleton()->screen_get_position(screen);
 	screen_rect.size = DisplayServer::get_singleton()->screen_get_size(screen);
 
-	Size2 desired_size;
-	desired_size.x = ProjectSettings::get_singleton()->get("display/window/size/width");
-	desired_size.y = ProjectSettings::get_singleton()->get("display/window/size/height");
+	Size2 window_size;
+	window_size.x = ProjectSettings::get_singleton()->get("display/window/size/viewport_width");
+	window_size.y = ProjectSettings::get_singleton()->get("display/window/size/viewport_height");
 
-	Size2 test_size;
-	test_size.x = ProjectSettings::get_singleton()->get("display/window/size/test_width");
-	test_size.y = ProjectSettings::get_singleton()->get("display/window/size/test_height");
-	if (test_size.x > 0 && test_size.y > 0) {
-		desired_size = test_size;
+	Size2 desired_size;
+	desired_size.x = ProjectSettings::get_singleton()->get("display/window/size/window_width_override");
+	desired_size.y = ProjectSettings::get_singleton()->get("display/window/size/window_height_override");
+	if (desired_size.x > 0 && desired_size.y > 0) {
+		window_size = desired_size;
 	}
 
 	int window_placement = EditorSettings::get_singleton()->get("run/window_placement/rect");
@@ -136,7 +136,7 @@ Error EditorRun::run(const String &p_scene) {
 			args.push_back(itos(screen_rect.position.x) + "," + itos(screen_rect.position.y));
 		} break;
 		case 1: { // centered
-			Vector2 pos = (screen_rect.position) + ((screen_rect.size - desired_size) / 2).floor();
+			Vector2 pos = (screen_rect.position) + ((screen_rect.size - window_size) / 2).floor();
 			args.push_back("--position");
 			args.push_back(itos(pos.x) + "," + itos(pos.y));
 		} break;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3508,7 +3508,7 @@ void CanvasItemEditor::_draw_axis() {
 
 		Color area_axis_color = EditorSettings::get_singleton()->get("editors/2d/viewport_border_color");
 
-		Size2 screen_size = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+		Size2 screen_size = Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 
 		Vector2 screen_endpoints[4] = {
 			transform.xform(Vector2(0, 0)),
@@ -4001,7 +4001,7 @@ void CanvasItemEditor::_update_scrollbars() {
 	Size2 vmin = v_scroll->get_minimum_size();
 
 	// Get the visible frame.
-	Size2 screen_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+	Size2 screen_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 	Rect2 local_rect = Rect2(Point2(), viewport->get_size() - Size2(vmin.width, hmin.height));
 
 	// Calculate scrollable area.

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3061,7 +3061,7 @@ void Node3DEditorViewport::_draw() {
 				Math::round(2 * EDSCALE));
 	}
 	if (previewing) {
-		Size2 ss = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+		Size2 ss = Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 		float aspect = ss.aspect();
 		Size2 s = get_size();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1302,47 +1302,47 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// always convert to lower case for consistency in the code
 	rendering_driver = rendering_driver.to_lower();
 
-	GLOBAL_DEF_BASIC("display/window/size/width", 1024);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/width",
-			PropertyInfo(Variant::INT, "display/window/size/width",
+	GLOBAL_DEF_BASIC("display/window/size/viewport_width", 1024);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/viewport_width",
+			PropertyInfo(Variant::INT, "display/window/size/viewport_width",
 					PROPERTY_HINT_RANGE,
 					"0,7680,or_greater")); // 8K resolution
-	GLOBAL_DEF_BASIC("display/window/size/height", 600);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/height",
-			PropertyInfo(Variant::INT, "display/window/size/height",
+	GLOBAL_DEF_BASIC("display/window/size/viewport_height", 600);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/viewport_height",
+			PropertyInfo(Variant::INT, "display/window/size/viewport_height",
 					PROPERTY_HINT_RANGE,
 					"0,4320,or_greater")); // 8K resolution
 	GLOBAL_DEF_BASIC("display/window/size/resizable", true);
 	GLOBAL_DEF_BASIC("display/window/size/borderless", false);
 	GLOBAL_DEF_BASIC("display/window/size/fullscreen", false);
 	GLOBAL_DEF("display/window/size/always_on_top", false);
-	GLOBAL_DEF("display/window/size/test_width", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_width",
+	GLOBAL_DEF("display/window/size/window_width_override", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/window_width_override",
 			PropertyInfo(Variant::INT,
-					"display/window/size/test_width",
+					"display/window/size/window_width_override",
 					PROPERTY_HINT_RANGE,
 					"0,7680,or_greater")); // 8K resolution
-	GLOBAL_DEF("display/window/size/test_height", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_height",
+	GLOBAL_DEF("display/window/size/window_height_override", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/window_height_override",
 			PropertyInfo(Variant::INT,
-					"display/window/size/test_height",
+					"display/window/size/window_height_override",
 					PROPERTY_HINT_RANGE,
 					"0,4320,or_greater")); // 8K resolution
 
 	if (use_custom_res) {
 		if (!force_res) {
-			window_size.width = GLOBAL_GET("display/window/size/width");
-			window_size.height = GLOBAL_GET("display/window/size/height");
+			window_size.width = GLOBAL_GET("display/window/size/viewport_width");
+			window_size.height = GLOBAL_GET("display/window/size/viewport_height");
 
-			if (globals->has_setting("display/window/size/test_width") &&
-					globals->has_setting("display/window/size/test_height")) {
-				int tw = globals->get("display/window/size/test_width");
-				if (tw > 0) {
-					window_size.width = tw;
+			if (globals->has_setting("display/window/size/window_width_override") &&
+					globals->has_setting("display/window/size/window_height_override")) {
+				int desired_width = globals->get("display/window/size/window_width_override");
+				if (desired_width > 0) {
+					window_size.width = desired_width;
 				}
-				int th = globals->get("display/window/size/test_height");
-				if (th > 0) {
-					window_size.height = th;
+				int desired_height = globals->get("display/window/size/window_height_override");
+				if (desired_height > 0) {
+					window_size.height = desired_height;
 				}
 			}
 		}
@@ -2337,8 +2337,8 @@ bool Main::start() {
 
 			String stretch_mode = GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
 			String stretch_aspect = GLOBAL_DEF_BASIC("display/window/stretch/aspect", "keep");
-			Size2i stretch_size = Size2i(GLOBAL_DEF_BASIC("display/window/size/width", 0),
-					GLOBAL_DEF_BASIC("display/window/size/height", 0));
+			Size2i stretch_size = Size2i(GLOBAL_DEF_BASIC("display/window/size/viewport_width", 0),
+					GLOBAL_DEF_BASIC("display/window/size/viewport_height", 0));
 			real_t stretch_scale = GLOBAL_DEF_BASIC("display/window/stretch/scale", 1.0);
 
 			Window::ContentScaleMode cs_sm = Window::CONTENT_SCALE_MODE_DISABLED;

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1514,7 +1514,7 @@ String EditorExportPlatformAndroid::load_splash_refs(Ref<Image> &splash_image, R
 	}
 
 	if (scale_splash) {
-		Size2 screen_size = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+		Size2 screen_size = Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 		int width, height;
 		if (screen_size.width > screen_size.height) {
 			// scale horizontally

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -530,7 +530,7 @@ Point2 Camera2D::get_camera_screen_center() const {
 Size2 Camera2D::_get_camera_screen_size() const {
 	// special case if the camera2D is in the root viewport
 	if (Engine::get_singleton()->is_editor_hint() && get_viewport()->get_parent_viewport() == get_tree()->get_root()) {
-		return Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+		return Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 	}
 	return get_viewport_rect().size;
 }

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1296,7 +1296,7 @@ Rect2 Control::get_parent_anchorable_rect() const {
 #ifdef TOOLS_ENABLED
 		Node *edited_root = get_tree()->get_edited_scene_root();
 		if (edited_root && (this == edited_root || edited_root->is_ancestor_of(this))) {
-			parent_rect.size = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+			parent_rect.size = Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 		} else {
 			parent_rect = get_viewport()->get_visible_rect();
 		}


### PR DESCRIPTION
As originally identified by @leonkrause [here](https://github.com/godotengine/godot/issues/16863#issuecomment-412308210), the Project Settings `display/window/size/test_width` and `test_height` should be renamed to `window_width` and `window_height` to reflect their function. To avoid confusion, this PR also renames `display/window/size/width` and `height` to `viewport_width` and `viewport_height` to reflect their function too.

Part of #16863
