### PR TITLE
[macOS, sandbox] Add export option to embed and sign helper executables.

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -49,6 +49,7 @@
 				[/codeblocks]
 				See [method execute] if you wish to run an external command and retrieve the results.
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
+				[b]Note:[/b] On macOS, sandboxed applications are limited to run only embedded helper executables, specified during export.
 			</description>
 		</method>
 		<method name="delay_msec" qualifiers="const">
@@ -119,6 +120,7 @@
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
+				[b]Note:[/b] On macOS, sandboxed applications are limited to run only embedded helper executables, specified during export.
 			</description>
 		</method>
 		<method name="find_keycode_from_string" qualifiers="const">


### PR DESCRIPTION
- Adds export option to embed helper executables.
- Adds notes to the `OS.execute` and `OS.create_process` method documentation.

<img width="1034" alt="macos_helpers" src="https://user-images.githubusercontent.com/7645683/113150887-341e6680-923d-11eb-8181-3c47e2dc1c42.png">

macOS sandboxed apps are limited to run only "helper executables" embedded into the app bundle, and signed with special [sandbox entitlement keys](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW15).