### PR TITLE
set StartupWMClass in linux `.desktop` file

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.desktop
+++ b/misc/dist/linux/org.godotengine.Godot.desktop
@@ -9,3 +9,4 @@ PrefersNonDefaultGPU=true
 Type=Application
 MimeType=application/x-godot-project;
 Categories=Development;IDE;
+StartupWMClass=Godot


### PR DESCRIPTION
this allows linux app launchers and docks to correctly associate the godot project selector & editor windows with the icon used to launch godot.
it prevents this problem specifically: https://askubuntu.com/questions/1144214/why-does-my-custom-launcher-file-create-two-icons-on-the-launcher-bar