### PR TITLE
Allow selecting multiple files in the editor translation/remap dialogs (3.x)

### DIFF
--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -139,16 +139,16 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _copy_to_platform(int p_which);
 
 	void _translation_file_open();
-	void _translation_add(const String &p_path);
+	void _translation_add(const PoolStringArray &p_paths);
 	void _translation_delete(Object *p_item, int p_column, int p_button);
 	void _update_translations();
 
 	void _translation_res_file_open();
-	void _translation_res_add(const String &p_path);
+	void _translation_res_add(const PoolStringArray &p_paths);
 	void _translation_res_delete(Object *p_item, int p_column, int p_button);
 	void _translation_res_select();
 	void _translation_res_option_file_open();
-	void _translation_res_option_add(const String &p_path);
+	void _translation_res_option_add(const PoolStringArray &p_paths);
 	void _translation_res_option_changed();
 	void _translation_res_option_delete(Object *p_item, int p_column, int p_button);
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/44786.

This makes it faster to add several translations.

The undo/redo messages were also tweaked to give better context.