### PR TITLE
Make ColorPicker button text and tooltips appear in exported projects

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -847,7 +847,7 @@ ColorPicker::ColorPicker() :
 	btn_pick->set_flat(true);
 	hb_smpl->add_child(btn_pick);
 	btn_pick->set_toggle_mode(true);
-	btn_pick->set_tooltip(TTR("Pick a color from the editor window."));
+	btn_pick->set_tooltip(RTR("Pick a color from the editor window."));
 	btn_pick->connect("pressed", callable_mp(this, &ColorPicker::_screen_pick_pressed));
 
 	VBoxContainer *vbl = memnew(VBoxContainer);
@@ -899,12 +899,12 @@ ColorPicker::ColorPicker() :
 
 	btn_hsv = memnew(CheckButton);
 	hhb->add_child(btn_hsv);
-	btn_hsv->set_text(TTR("HSV"));
+	btn_hsv->set_text(RTR("HSV"));
 	btn_hsv->connect("toggled", callable_mp(this, &ColorPicker::set_hsv_mode));
 
 	btn_raw = memnew(CheckButton);
 	hhb->add_child(btn_raw);
-	btn_raw->set_text(TTR("Raw"));
+	btn_raw->set_text(RTR("Raw"));
 	btn_raw->connect("toggled", callable_mp(this, &ColorPicker::set_raw_mode));
 
 	text_type = memnew(Button);
@@ -950,7 +950,7 @@ ColorPicker::ColorPicker() :
 	add_child(preset_container2);
 	bt_add_preset = memnew(Button);
 	preset_container2->add_child(bt_add_preset);
-	bt_add_preset->set_tooltip(TTR("Add current color as a preset."));
+	bt_add_preset->set_tooltip(RTR("Add current color as a preset."));
 	bt_add_preset->connect("pressed", callable_mp(this, &ColorPicker::_add_preset_pressed));
 }
 


### PR DESCRIPTION
Fixes #35693.

As in the issue, I also observed this while using Pixelorama. It would be nice to cherry-pick this to 3.x so Pixelorama can pick up the change.

### Bug:
![export-bug](https://user-images.githubusercontent.com/3495802/113315256-156ead00-92db-11eb-809f-6fac28e00070.png)

### Fix:
![export-fix](https://user-images.githubusercontent.com/3495802/113315278-1a336100-92db-11eb-9167-b91140ac3163.png)
