### PR TITLE
Rename TextEdit getters and setters to match property names

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -26,11 +26,11 @@
 				Returns if the given line is foldable, that is, it has indented lines right below it.
 			</description>
 		</method>
-		<method name="center_viewport_to_cursor">
+		<method name="center_viewport_at_caret">
 			<return type="void">
 			</return>
 			<description>
-				Centers the viewport on the line the editing cursor is at. This also resets the [member scroll_horizontal] value to [code]0[/code].
+				Centers the viewport on the line the caret is at. This also resets the [member scroll_horizontal] value to [code]0[/code].
 			</description>
 		</method>
 		<method name="clear_opentype_features">
@@ -52,49 +52,6 @@
 			</return>
 			<description>
 				Copy's the current text selection.
-			</description>
-		</method>
-		<method name="cursor_get_column" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-				Returns the column the editing cursor is at.
-			</description>
-		</method>
-		<method name="cursor_get_line" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-				Returns the line the editing cursor is at.
-			</description>
-		</method>
-		<method name="cursor_set_column">
-			<return type="void">
-			</return>
-			<argument index="0" name="column" type="int">
-			</argument>
-			<argument index="1" name="adjust_viewport" type="bool" default="true">
-			</argument>
-			<description>
-				Moves the cursor at the specified [code]column[/code] index.
-				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the cursor position after the move occurs.
-			</description>
-		</method>
-		<method name="cursor_set_line">
-			<return type="void">
-			</return>
-			<argument index="0" name="line" type="int">
-			</argument>
-			<argument index="1" name="adjust_viewport" type="bool" default="true">
-			</argument>
-			<argument index="2" name="can_be_hidden" type="bool" default="true">
-			</argument>
-			<argument index="3" name="wrap_index" type="int" default="0">
-			</argument>
-			<description>
-				Moves the cursor at the specified [code]line[/code] index.
-				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the cursor position after the move occurs.
-				If [code]can_be_hidden[/code] is set to [code]true[/code], the specified [code]line[/code] can be hidden using [method set_line_as_hidden].
 			</description>
 		</method>
 		<method name="cut">
@@ -125,6 +82,20 @@
 			</argument>
 			<description>
 				Folds the given line, if possible (see [method can_fold]).
+			</description>
+		</method>
+		<method name="get_caret_column" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the column the caret (text cursor) is at.
+			</description>
+		</method>
+		<method name="get_caret_line" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the line the caret (text cursor) is at.
 			</description>
 		</method>
 		<method name="get_gutter_count" qualifiers="const">
@@ -282,20 +253,20 @@
 				Returns the selection end line.
 			</description>
 		</method>
-		<method name="get_word_under_cursor" qualifiers="const">
+		<method name="get_word_at_caret" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
-				Returns a [String] text with the word under the caret (text cursor) location.
+				Returns a [String] text with the word at the caret position.
 			</description>
 		</method>
-		<method name="insert_text_at_cursor">
+		<method name="insert_text_at_caret">
 			<return type="void">
 			</return>
 			<argument index="0" name="text" type="String">
 			</argument>
 			<description>
-				Insert the specified text at the cursor position.
+				Insert the specified text at the caret position.
 			</description>
 		</method>
 		<method name="is_folded" qualifiers="const">
@@ -444,6 +415,35 @@
 			<description>
 				Select all the text.
 				If [member selecting_enabled] is [code]false[/code], no selection will occur.
+			</description>
+		</method>
+		<method name="set_caret_column">
+			<return type="void">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<argument index="1" name="adjust_viewport" type="bool" default="true">
+			</argument>
+			<description>
+				Moves the caret to the specified [code]column[/code].
+				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the caret position after the move occurs.
+			</description>
+		</method>
+		<method name="set_caret_line">
+			<return type="void">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="adjust_viewport" type="bool" default="true">
+			</argument>
+			<argument index="2" name="can_be_hidden" type="bool" default="true">
+			</argument>
+			<argument index="3" name="wrap_index" type="int" default="0">
+			</argument>
+			<description>
+				Moves the caret to the specified [code]line[/code].
+				If [code]adjust_viewport[/code] is set to [code]true[/code], the viewport will center at the caret position after the move occurs.
+				If [code]can_be_hidden[/code] is set to [code]true[/code], the specified [code]line[/code] can be hidden using [method set_line_as_hidden].
 			</description>
 		</method>
 		<method name="set_gutter_clickable">
@@ -657,23 +657,23 @@
 		</method>
 	</methods>
 	<members>
-		<member name="caret_blink" type="bool" setter="cursor_set_blink_enabled" getter="cursor_get_blink_enabled" default="false">
-			If [code]true[/code], the caret (visual cursor) blinks.
+		<member name="caret_blink" type="bool" setter="set_caret_blink_enabled" getter="is_caret_blink_enabled" default="false">
+			If [code]true[/code], the caret (text cursor) blinks.
 		</member>
-		<member name="caret_blink_speed" type="float" setter="cursor_set_blink_speed" getter="cursor_get_blink_speed" default="0.65">
+		<member name="caret_blink_speed" type="float" setter="set_caret_blink_speed" getter="get_caret_blink_speed" default="0.65">
 			Duration (in seconds) of a caret's blinking cycle.
 		</member>
-		<member name="caret_block_mode" type="bool" setter="cursor_set_block_mode" getter="cursor_is_block_mode" default="false">
+		<member name="caret_block_mode" type="bool" setter="set_caret_block_mode_enabled" getter="is_caret_block_mode_enabled" default="false">
 			If [code]true[/code], the caret displays as a rectangle.
 			If [code]false[/code], the caret displays as a bar.
 		</member>
-		<member name="caret_mid_grapheme" type="bool" setter="set_mid_grapheme_caret_enabled" getter="get_mid_grapheme_caret_enabled" default="false">
+		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="false">
 			Allow moving caret, selecting and removing the individual composite character components.
 			Note: [kbd]Backspace[/kbd] is always removing individual composite character components.
 		</member>
-		<member name="caret_moving_by_right_click" type="bool" setter="set_right_click_moves_caret" getter="is_right_click_moving_caret" default="true">
-			If [code]true[/code], a right-click moves the cursor at the mouse position before displaying the context menu.
-			If [code]false[/code], the context menu disregards mouse location.
+		<member name="caret_moves_with_right_click" type="bool" setter="set_caret_moves_with_right_click_enabled" getter="is_caret_moves_with_right_click_enabled" default="true">
+			If [code]true[/code], a right-click moves the caret to the mouse position before displaying the context menu.
+			If [code]false[/code], the context menu disregards the mouse location.
 		</member>
 		<member name="context_menu_enabled" type="bool" setter="set_context_menu_enabled" getter="is_context_menu_enabled" default="true">
 			If [code]true[/code], a right-click displays the context menu.
@@ -695,7 +695,7 @@
 			If [code]true[/code], all occurrences of the selected text will be highlighted.
 		</member>
 		<member name="highlight_current_line" type="bool" setter="set_highlight_current_line" getter="is_highlight_current_line_enabled" default="false">
-			If [code]true[/code], the line containing the cursor is highlighted.
+			If [code]true[/code], the line containing the caret (text cursor) is highlighted.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
@@ -755,9 +755,9 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="cursor_changed">
+		<signal name="caret_changed">
 			<description>
-				Emitted when the cursor changes.
+				Emitted when the caret changes.
 			</description>
 		</signal>
 		<signal name="gutter_added">
@@ -843,7 +843,7 @@
 			Copies the selected text.
 		</constant>
 		<constant name="MENU_PASTE" value="2" enum="MenuItems">
-			Pastes the clipboard text over the selected text (or at the cursor's position).
+			Pastes the clipboard text over the selected text (or at the caret's position).
 		</constant>
 		<constant name="MENU_CLEAR" value="3" enum="MenuItems">
 			Erases the whole [TextEdit] text.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -687,6 +687,9 @@
 		<member name="draw_tabs" type="bool" setter="set_draw_tabs" getter="is_drawing_tabs" default="false">
 			If [code]true[/code], the "tab" character will have a visible representation.
 		</member>
+		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
+			If [code]false[/code], existing text cannot be modified and new text cannot be added.
+		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="hiding_enabled" type="bool" setter="set_hiding_enabled" getter="is_hiding_enabled" default="false">
 			If [code]true[/code], all lines that have been set to hidden by [method set_line_as_hidden], will not be visible.
@@ -709,9 +712,6 @@
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="1" />
 		<member name="override_selected_font_color" type="bool" setter="set_override_selected_font_color" getter="is_overriding_selected_font_color" default="false">
 			If [code]true[/code], custom [code]font_selected_color[/code] will be used for selected text.
-		</member>
-		<member name="readonly" type="bool" setter="set_readonly" getter="is_readonly" default="false">
-			If [code]true[/code], read-only mode is enabled. Existing text cannot be modified and new text cannot be added.
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			If there is a horizontal scrollbar this determines the current horizontal scroll value in pixels.
@@ -989,7 +989,7 @@
 			The size of the text outline.
 		</theme_item>
 		<theme_item name="read_only" type="StyleBox">
-			Sets the [StyleBox] of this [TextEdit] when [member readonly] is enabled.
+			Sets the [StyleBox] of this [TextEdit] when [member editable] is [code]false[/code].
 		</theme_item>
 		<theme_item name="selection_color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
 			Sets the highlight [Color] of text selections.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -43,7 +43,7 @@
 void GotoLineDialog::popup_find_line(CodeEdit *p_edit) {
 	text_editor = p_edit;
 
-	line->set_text(itos(text_editor->cursor_get_line()));
+	line->set_text(itos(text_editor->get_caret_line()));
 	line->select_all();
 	popup_centered(Size2(180, 80) * EDSCALE);
 	line->grab_focus();
@@ -58,7 +58,7 @@ void GotoLineDialog::ok_pressed() {
 		return;
 	}
 	text_editor->unfold_line(get_line() - 1);
-	text_editor->cursor_set_line(get_line() - 1);
+	text_editor->set_caret_line(get_line() - 1);
 	hide();
 }
 
@@ -142,11 +142,11 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 	bool found = text_editor->search(text, p_flags, p_from_line, p_from_col, line, col);
 
 	if (found) {
-		if (!preserve_cursor && !is_selection_only()) {
+		if (!preserve_caret && !is_selection_only()) {
 			text_editor->unfold_line(line);
-			text_editor->cursor_set_line(line, false);
-			text_editor->cursor_set_column(col + text.length(), false);
-			text_editor->center_viewport_to_cursor();
+			text_editor->set_caret_line(line, false);
+			text_editor->set_caret_column(col + text.length(), false);
+			text_editor->center_viewport_at_caret();
 			text_editor->select(line, col, line, col + text.length());
 		}
 
@@ -185,8 +185,8 @@ void FindReplaceBar::_replace() {
 
 	text_editor->begin_complex_operation();
 	if (selection_enabled && is_selection_only()) { // To restrict search_current() to selected region
-		text_editor->cursor_set_line(selection_begin.width);
-		text_editor->cursor_set_column(selection_begin.height);
+		text_editor->set_caret_line(selection_begin.width);
+		text_editor->set_caret_column(selection_begin.height);
 	}
 
 	if (search_current()) {
@@ -197,13 +197,13 @@ void FindReplaceBar::_replace() {
 			Point2i match_from(result_line, result_col);
 			Point2i match_to(result_line, result_col + search_text_len);
 			if (!(match_from < selection_begin || match_to > selection_end)) {
-				text_editor->insert_text_at_cursor(replace_text);
+				text_editor->insert_text_at_caret(replace_text);
 				if (match_to.x == selection_end.x) { // Adjust selection bounds if necessary
 					selection_end.y += replace_text.length() - search_text_len;
 				}
 			}
 		} else {
-			text_editor->insert_text_at_cursor(replace_text);
+			text_editor->insert_text_at_caret(replace_text);
 		}
 	}
 	text_editor->end_complex_operation();
@@ -220,7 +220,7 @@ void FindReplaceBar::_replace() {
 void FindReplaceBar::_replace_all() {
 	text_editor->disconnect("text_changed", callable_mp(this, &FindReplaceBar::_editor_text_changed));
 	// Line as x so it gets priority in comparison, column as y.
-	Point2i orig_cursor(text_editor->cursor_get_line(), text_editor->cursor_get_column());
+	Point2i orig_caret(text_editor->get_caret_line(), text_editor->get_caret_column());
 	Point2i prev_match = Point2(-1, -1);
 
 	bool selection_enabled = text_editor->is_selection_active();
@@ -232,8 +232,8 @@ void FindReplaceBar::_replace_all() {
 
 	int vsval = text_editor->get_v_scroll();
 
-	text_editor->cursor_set_line(0);
-	text_editor->cursor_set_column(0);
+	text_editor->set_caret_line(0);
+	text_editor->set_caret_column(0);
 
 	String replace_text = get_replace_text();
 	int search_text_len = get_search_text().length();
@@ -245,8 +245,8 @@ void FindReplaceBar::_replace_all() {
 	text_editor->begin_complex_operation();
 
 	if (selection_enabled && is_selection_only()) {
-		text_editor->cursor_set_line(selection_begin.width);
-		text_editor->cursor_set_column(selection_begin.height);
+		text_editor->set_caret_line(selection_begin.width);
+		text_editor->set_caret_column(selection_begin.height);
 	}
 	if (search_current()) {
 		do {
@@ -269,14 +269,14 @@ void FindReplaceBar::_replace_all() {
 				}
 
 				// Replace but adjust selection bounds.
-				text_editor->insert_text_at_cursor(replace_text);
+				text_editor->insert_text_at_caret(replace_text);
 				if (match_to.x == selection_end.x) {
 					selection_end.y += replace_text.length() - search_text_len;
 				}
 
 			} else {
 				// Just replace.
-				text_editor->insert_text_at_cursor(replace_text);
+				text_editor->insert_text_at_caret(replace_text);
 			}
 
 			rc++;
@@ -287,9 +287,9 @@ void FindReplaceBar::_replace_all() {
 
 	replace_all_mode = false;
 
-	// Restore editor state (selection, cursor, scroll).
-	text_editor->cursor_set_line(orig_cursor.x);
-	text_editor->cursor_set_column(orig_cursor.y);
+	// Restore editor state (selection, caret, scroll).
+	text_editor->set_caret_line(orig_caret.x);
+	text_editor->set_caret_column(orig_caret.y);
 
 	if (selection_enabled && is_selection_only()) {
 		// Reselect.
@@ -307,8 +307,8 @@ void FindReplaceBar::_replace_all() {
 }
 
 void FindReplaceBar::_get_search_from(int &r_line, int &r_col) {
-	r_line = text_editor->cursor_get_line();
-	r_col = text_editor->cursor_get_column();
+	r_line = text_editor->get_caret_line();
+	r_col = text_editor->get_caret_column();
 
 	if (text_editor->is_selection_active() && is_selection_only()) {
 		return;
@@ -528,9 +528,9 @@ void FindReplaceBar::_search_options_changed(bool p_pressed) {
 void FindReplaceBar::_editor_text_changed() {
 	results_count = -1;
 	if (is_visible_in_tree()) {
-		preserve_cursor = true;
+		preserve_caret = true;
 		search_current();
-		preserve_cursor = false;
+		preserve_caret = false;
 	}
 }
 
@@ -601,7 +601,7 @@ void FindReplaceBar::_bind_methods() {
 FindReplaceBar::FindReplaceBar() {
 	results_count = -1;
 	replace_all_mode = false;
-	preserve_cursor = false;
+	preserve_caret = false;
 
 	vbc_lineedit = memnew(VBoxContainer);
 	add_child(vbc_lineedit);
@@ -783,10 +783,10 @@ void CodeTextEditor::_reset_zoom() {
 }
 
 void CodeTextEditor::_line_col_changed() {
-	String line = text_editor->get_line(text_editor->cursor_get_line());
+	String line = text_editor->get_line(text_editor->get_caret_line());
 
 	int positional_column = 0;
-	for (int i = 0; i < text_editor->cursor_get_column(); i++) {
+	for (int i = 0; i < text_editor->get_caret_column(); i++) {
 		if (line[i] == '\t') {
 			positional_column += text_editor->get_indent_size(); //tab size
 		} else {
@@ -796,7 +796,7 @@ void CodeTextEditor::_line_col_changed() {
 
 	StringBuilder sb;
 	sb.append("(");
-	sb.append(itos(text_editor->cursor_get_line() + 1).lpad(3));
+	sb.append(itos(text_editor->get_caret_line() + 1).lpad(3));
 	sb.append(",");
 	sb.append(itos(positional_column + 1).lpad(3));
 	sb.append(")");
@@ -931,10 +931,10 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_show_line_length_guidelines(EditorSettings::get_singleton()->get("text_editor/appearance/show_line_length_guidelines"));
 	text_editor->set_line_length_guideline_soft_column(EditorSettings::get_singleton()->get("text_editor/appearance/line_length_guideline_soft_column"));
 	text_editor->set_line_length_guideline_hard_column(EditorSettings::get_singleton()->get("text_editor/appearance/line_length_guideline_hard_column"));
-	text_editor->set_scroll_pass_end_of_file(EditorSettings::get_singleton()->get("text_editor/cursor/scroll_past_end_of_file"));
-	text_editor->cursor_set_block_mode(EditorSettings::get_singleton()->get("text_editor/cursor/block_caret"));
-	text_editor->cursor_set_blink_enabled(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink"));
-	text_editor->cursor_set_blink_speed(EditorSettings::get_singleton()->get("text_editor/cursor/caret_blink_speed"));
+	text_editor->set_scroll_pass_end_of_file(EditorSettings::get_singleton()->get("text_editor/caret/scroll_past_end_of_file"));
+	text_editor->set_caret_block_mode_enabled(EditorSettings::get_singleton()->get("text_editor/caret/block_mode_enabled"));
+	text_editor->set_caret_blink_enabled(EditorSettings::get_singleton()->get("text_editor/caret/blink_enabled"));
+	text_editor->set_caret_blink_speed(EditorSettings::get_singleton()->get("text_editor/caret/blink_speed"));
 	text_editor->set_auto_brace_completion(EditorSettings::get_singleton()->get("text_editor/completion/auto_brace_complete"));
 }
 
@@ -991,8 +991,8 @@ void CodeTextEditor::convert_indent_to_spaces() {
 		indent += " ";
 	}
 
-	int cursor_line = text_editor->cursor_get_line();
-	int cursor_column = text_editor->cursor_get_column();
+	int caret_line = text_editor->get_caret_line();
+	int caret_column = text_editor->get_caret_column();
 
 	bool changed_indentation = false;
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
@@ -1009,8 +1009,8 @@ void CodeTextEditor::convert_indent_to_spaces() {
 					text_editor->begin_complex_operation();
 					changed_indentation = true;
 				}
-				if (cursor_line == i && cursor_column > j) {
-					cursor_column += indent_size - 1;
+				if (caret_line == i && caret_column > j) {
+					caret_column += indent_size - 1;
 				}
 				line = line.left(j) + indent + line.right(j + 1);
 			}
@@ -1021,7 +1021,7 @@ void CodeTextEditor::convert_indent_to_spaces() {
 		}
 	}
 	if (changed_indentation) {
-		text_editor->cursor_set_column(cursor_column);
+		text_editor->set_caret_column(caret_column);
 		text_editor->end_complex_operation();
 		text_editor->update();
 	}
@@ -1031,8 +1031,8 @@ void CodeTextEditor::convert_indent_to_tabs() {
 	int indent_size = EditorSettings::get_singleton()->get("text_editor/indent/size");
 	indent_size -= 1;
 
-	int cursor_line = text_editor->cursor_get_line();
-	int cursor_column = text_editor->cursor_get_column();
+	int caret_line = text_editor->get_caret_line();
+	int caret_column = text_editor->get_caret_column();
 
 	bool changed_indentation = false;
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
@@ -1053,8 +1053,8 @@ void CodeTextEditor::convert_indent_to_tabs() {
 						text_editor->begin_complex_operation();
 						changed_indentation = true;
 					}
-					if (cursor_line == i && cursor_column > j) {
-						cursor_column -= indent_size;
+					if (caret_line == i && caret_column > j) {
+						caret_column -= indent_size;
 					}
 					line = line.left(j - indent_size) + "\t" + line.right(j + 1);
 					j = 0;
@@ -1070,7 +1070,7 @@ void CodeTextEditor::convert_indent_to_tabs() {
 		}
 	}
 	if (changed_indentation) {
-		text_editor->cursor_set_column(cursor_column);
+		text_editor->set_caret_column(caret_column);
 		text_editor->end_complex_operation();
 		text_editor->update();
 	}
@@ -1128,7 +1128,7 @@ void CodeTextEditor::move_lines_up() {
 		int from_col = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
 		int to_column = text_editor->get_selection_to_column();
-		int cursor_line = text_editor->cursor_get_line();
+		int caret_line = text_editor->get_caret_line();
 
 		for (int i = from_line; i <= to_line; i++) {
 			int line_id = i;
@@ -1142,15 +1142,15 @@ void CodeTextEditor::move_lines_up() {
 			text_editor->unfold_line(next_id);
 
 			text_editor->swap_lines(line_id, next_id);
-			text_editor->cursor_set_line(next_id);
+			text_editor->set_caret_line(next_id);
 		}
 		int from_line_up = from_line > 0 ? from_line - 1 : from_line;
 		int to_line_up = to_line > 0 ? to_line - 1 : to_line;
-		int cursor_line_up = cursor_line > 0 ? cursor_line - 1 : cursor_line;
+		int caret_line_up = caret_line > 0 ? caret_line - 1 : caret_line;
 		text_editor->select(from_line_up, from_col, to_line_up, to_column);
-		text_editor->cursor_set_line(cursor_line_up);
+		text_editor->set_caret_line(caret_line_up);
 	} else {
-		int line_id = text_editor->cursor_get_line();
+		int line_id = text_editor->get_caret_line();
 		int next_id = line_id - 1;
 
 		if (line_id == 0 || next_id < 0) {
@@ -1161,7 +1161,7 @@ void CodeTextEditor::move_lines_up() {
 		text_editor->unfold_line(next_id);
 
 		text_editor->swap_lines(line_id, next_id);
-		text_editor->cursor_set_line(next_id);
+		text_editor->set_caret_line(next_id);
 	}
 	text_editor->end_complex_operation();
 	text_editor->update();
@@ -1174,7 +1174,7 @@ void CodeTextEditor::move_lines_down() {
 		int from_col = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
 		int to_column = text_editor->get_selection_to_column();
-		int cursor_line = text_editor->cursor_get_line();
+		int caret_line = text_editor->get_caret_line();
 
 		for (int i = to_line; i >= from_line; i--) {
 			int line_id = i;
@@ -1188,15 +1188,15 @@ void CodeTextEditor::move_lines_down() {
 			text_editor->unfold_line(next_id);
 
 			text_editor->swap_lines(line_id, next_id);
-			text_editor->cursor_set_line(next_id);
+			text_editor->set_caret_line(next_id);
 		}
 		int from_line_down = from_line < text_editor->get_line_count() ? from_line + 1 : from_line;
 		int to_line_down = to_line < text_editor->get_line_count() ? to_line + 1 : to_line;
-		int cursor_line_down = cursor_line < text_editor->get_line_count() ? cursor_line + 1 : cursor_line;
+		int caret_line_down = caret_line < text_editor->get_line_count() ? caret_line + 1 : caret_line;
 		text_editor->select(from_line_down, from_col, to_line_down, to_column);
-		text_editor->cursor_set_line(cursor_line_down);
+		text_editor->set_caret_line(caret_line_down);
 	} else {
-		int line_id = text_editor->cursor_get_line();
+		int line_id = text_editor->get_caret_line();
 		int next_id = line_id + 1;
 
 		if (line_id == text_editor->get_line_count() - 1 || next_id > text_editor->get_line_count()) {
@@ -1207,7 +1207,7 @@ void CodeTextEditor::move_lines_down() {
 		text_editor->unfold_line(next_id);
 
 		text_editor->swap_lines(line_id, next_id);
-		text_editor->cursor_set_line(next_id);
+		text_editor->set_caret_line(next_id);
 	}
 	text_editor->end_complex_operation();
 	text_editor->update();
@@ -1218,12 +1218,12 @@ void CodeTextEditor::_delete_line(int p_line) {
 	// so `begin_complex_operation` is omitted here
 	text_editor->set_line(p_line, "");
 	if (p_line == 0 && text_editor->get_line_count() > 1) {
-		text_editor->cursor_set_line(1);
-		text_editor->cursor_set_column(0);
+		text_editor->set_caret_line(1);
+		text_editor->set_caret_column(0);
 	}
-	text_editor->backspace_at_cursor();
+	text_editor->backspace_at_caret();
 	text_editor->unfold_line(p_line);
-	text_editor->cursor_set_line(p_line);
+	text_editor->set_caret_line(p_line);
 }
 
 void CodeTextEditor::delete_lines() {
@@ -1233,42 +1233,42 @@ void CodeTextEditor::delete_lines() {
 		int from_line = text_editor->get_selection_from_line();
 		int count = Math::abs(to_line - from_line) + 1;
 
-		text_editor->cursor_set_line(from_line, false);
+		text_editor->set_caret_line(from_line, false);
 		for (int i = 0; i < count; i++) {
 			_delete_line(from_line);
 		}
 		text_editor->deselect();
 	} else {
-		_delete_line(text_editor->cursor_get_line());
+		_delete_line(text_editor->get_caret_line());
 	}
 	text_editor->end_complex_operation();
 }
 
 void CodeTextEditor::clone_lines_down() {
-	const int cursor_column = text_editor->cursor_get_column();
-	int from_line = text_editor->cursor_get_line();
-	int to_line = text_editor->cursor_get_line();
+	const int caret_column = text_editor->get_caret_column();
+	int from_line = text_editor->get_caret_line();
+	int to_line = text_editor->get_caret_line();
 	int from_column = 0;
 	int to_column = 0;
-	int cursor_new_line = to_line + 1;
-	int cursor_new_column = text_editor->cursor_get_column();
+	int caret_new_line = to_line + 1;
+	int caret_new_column = text_editor->get_caret_column();
 	String new_text = "\n" + text_editor->get_line(from_line);
 	bool selection_active = false;
 
-	text_editor->cursor_set_column(text_editor->get_line(from_line).length());
+	text_editor->set_caret_column(text_editor->get_line(from_line).length());
 	if (text_editor->is_selection_active()) {
 		from_column = text_editor->get_selection_from_column();
 		to_column = text_editor->get_selection_to_column();
 
 		from_line = text_editor->get_selection_from_line();
 		to_line = text_editor->get_selection_to_line();
-		cursor_new_line = to_line + text_editor->cursor_get_line() - from_line;
-		cursor_new_column = to_column == cursor_column ? 2 * to_column - from_column : to_column;
+		caret_new_line = to_line + text_editor->get_caret_line() - from_line;
+		caret_new_column = to_column == caret_column ? 2 * to_column - from_column : to_column;
 		new_text = text_editor->get_selection_text();
 		selection_active = true;
 
-		text_editor->cursor_set_line(to_line);
-		text_editor->cursor_set_column(to_column);
+		text_editor->set_caret_line(to_line);
+		text_editor->set_caret_column(to_column);
 	}
 
 	text_editor->begin_complex_operation();
@@ -1277,9 +1277,9 @@ void CodeTextEditor::clone_lines_down() {
 		text_editor->unfold_line(i);
 	}
 	text_editor->deselect();
-	text_editor->insert_text_at_cursor(new_text);
-	text_editor->cursor_set_line(cursor_new_line);
-	text_editor->cursor_set_column(cursor_new_column);
+	text_editor->insert_text_at_caret(new_text);
+	text_editor->set_caret_line(caret_new_line);
+	text_editor->set_caret_column(caret_new_column);
 	if (selection_active) {
 		text_editor->select(to_line, to_column, 2 * to_line - from_line, to_line == from_line ? 2 * to_column - from_column : to_column);
 	}
@@ -1300,7 +1300,7 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		}
 
 		int col_to = text_editor->get_selection_to_column();
-		int cursor_pos = text_editor->cursor_get_column();
+		int caret_pos = text_editor->get_caret_column();
 
 		// Check if all lines in the selected block are commented.
 		bool is_commented = true;
@@ -1325,31 +1325,31 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 			text_editor->set_line(i, line_text);
 		}
 
-		// Adjust selection & cursor position.
+		// Adjust selection & caret position.
 		int offset = (is_commented ? -1 : 1) * delimiter.length();
 		int col_from = text_editor->get_selection_from_column() > 0 ? text_editor->get_selection_from_column() + offset : 0;
 
-		if (is_commented && text_editor->cursor_get_column() == text_editor->get_line(text_editor->cursor_get_line()).length() + 1) {
-			cursor_pos += 1;
+		if (is_commented && text_editor->get_caret_column() == text_editor->get_line(text_editor->get_caret_line()).length() + 1) {
+			caret_pos += 1;
 		}
 
 		if (text_editor->get_selection_to_column() != 0 && col_to != text_editor->get_line(text_editor->get_selection_to_line()).length() + 1) {
 			col_to += offset;
 		}
 
-		if (text_editor->cursor_get_column() != 0) {
-			cursor_pos += offset;
+		if (text_editor->get_caret_column() != 0) {
+			caret_pos += offset;
 		}
 
 		text_editor->select(begin, col_from, text_editor->get_selection_to_line(), col_to);
-		text_editor->cursor_set_column(cursor_pos);
+		text_editor->set_caret_column(caret_pos);
 
 	} else {
-		int begin = text_editor->cursor_get_line();
+		int begin = text_editor->get_caret_line();
 		String line_text = text_editor->get_line(begin);
 		int delimiter_length = delimiter.length();
 
-		int col = text_editor->cursor_get_column();
+		int col = text_editor->get_caret_column();
 		if (line_text.begins_with(delimiter)) {
 			line_text = line_text.substr(delimiter_length, line_text.length());
 			col -= delimiter_length;
@@ -1359,7 +1359,7 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		}
 
 		text_editor->set_line(begin, line_text);
-		text_editor->cursor_set_column(col);
+		text_editor->set_caret_column(col);
 	}
 	text_editor->end_complex_operation();
 	text_editor->update();
@@ -1368,19 +1368,19 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 void CodeTextEditor::goto_line(int p_line) {
 	text_editor->deselect();
 	text_editor->unfold_line(p_line);
-	text_editor->call_deferred("cursor_set_line", p_line);
+	text_editor->call_deferred("set_caret_line", p_line);
 }
 
 void CodeTextEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
 	text_editor->unfold_line(p_line);
-	text_editor->call_deferred("cursor_set_line", p_line);
-	text_editor->call_deferred("cursor_set_column", p_begin);
+	text_editor->call_deferred("set_caret_line", p_line);
+	text_editor->call_deferred("set_caret_column", p_begin);
 	text_editor->select(p_line, p_begin, p_line, p_end);
 }
 
 void CodeTextEditor::goto_line_centered(int p_line) {
 	goto_line(p_line);
-	text_editor->call_deferred("center_viewport_to_cursor");
+	text_editor->call_deferred("center_viewport_at_caret");
 }
 
 void CodeTextEditor::set_executing_line(int p_line) {
@@ -1396,8 +1396,8 @@ Variant CodeTextEditor::get_edit_state() {
 
 	state["scroll_position"] = text_editor->get_v_scroll();
 	state["h_scroll_position"] = text_editor->get_h_scroll();
-	state["column"] = text_editor->cursor_get_column();
-	state["row"] = text_editor->cursor_get_line();
+	state["column"] = text_editor->get_caret_column();
+	state["row"] = text_editor->get_caret_line();
 
 	state["selection"] = get_text_editor()->is_selection_active();
 	if (get_text_editor()->is_selection_active()) {
@@ -1421,8 +1421,8 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 	Dictionary state = p_state;
 
 	/* update the row first as it sets the column to 0 */
-	text_editor->cursor_set_line(state["row"]);
-	text_editor->cursor_set_column(state["column"]);
+	text_editor->set_caret_line(state["row"]);
+	text_editor->set_caret_column(state["column"]);
 	text_editor->set_v_scroll(state["scroll_position"]);
 	text_editor->set_h_scroll(state["h_scroll_position"]);
 
@@ -1468,9 +1468,9 @@ void CodeTextEditor::set_error_pos(int p_line, int p_column) {
 
 void CodeTextEditor::goto_error() {
 	if (error->get_text() != "") {
-		text_editor->cursor_set_line(error_line);
-		text_editor->cursor_set_column(error_column);
-		text_editor->center_viewport_to_cursor();
+		text_editor->set_caret_line(error_line);
+		text_editor->set_caret_column(error_column);
+		text_editor->center_viewport_at_caret();
 	}
 }
 
@@ -1618,7 +1618,7 @@ void CodeTextEditor::set_warning_nb(int p_warning_nb) {
 }
 
 void CodeTextEditor::toggle_bookmark() {
-	int line = text_editor->cursor_get_line();
+	int line = text_editor->get_caret_line();
 	text_editor->set_line_as_bookmarked(line, !text_editor->is_line_bookmarked(line));
 }
 
@@ -1628,18 +1628,18 @@ void CodeTextEditor::goto_next_bookmark() {
 		return;
 	}
 
-	int line = text_editor->cursor_get_line();
+	int line = text_editor->get_caret_line();
 	if (line >= (int)bmarks[bmarks.size() - 1]) {
 		text_editor->unfold_line(bmarks[0]);
-		text_editor->cursor_set_line(bmarks[0]);
-		text_editor->center_viewport_to_cursor();
+		text_editor->set_caret_line(bmarks[0]);
+		text_editor->center_viewport_at_caret();
 	} else {
 		for (int i = 0; i < bmarks.size(); i++) {
 			int bmark_line = bmarks[i];
 			if (bmark_line > line) {
 				text_editor->unfold_line(bmark_line);
-				text_editor->cursor_set_line(bmark_line);
-				text_editor->center_viewport_to_cursor();
+				text_editor->set_caret_line(bmark_line);
+				text_editor->center_viewport_at_caret();
 				return;
 			}
 		}
@@ -1652,18 +1652,18 @@ void CodeTextEditor::goto_prev_bookmark() {
 		return;
 	}
 
-	int line = text_editor->cursor_get_line();
+	int line = text_editor->get_caret_line();
 	if (line <= (int)bmarks[0]) {
 		text_editor->unfold_line(bmarks[bmarks.size() - 1]);
-		text_editor->cursor_set_line(bmarks[bmarks.size() - 1]);
-		text_editor->center_viewport_to_cursor();
+		text_editor->set_caret_line(bmarks[bmarks.size() - 1]);
+		text_editor->center_viewport_at_caret();
 	} else {
 		for (int i = bmarks.size(); i >= 0; i--) {
 			int bmark_line = bmarks[i];
 			if (bmark_line < line) {
 				text_editor->unfold_line(bmark_line);
-				text_editor->cursor_set_line(bmark_line);
-				text_editor->center_viewport_to_cursor();
+				text_editor->set_caret_line(bmark_line);
+				text_editor->center_viewport_at_caret();
 				return;
 			}
 		}
@@ -1819,7 +1819,7 @@ CodeTextEditor::CodeTextEditor() {
 	line_and_col_txt->set_mouse_filter(MOUSE_FILTER_STOP);
 
 	text_editor->connect("gui_input", callable_mp(this, &CodeTextEditor::_text_editor_gui_input));
-	text_editor->connect("cursor_changed", callable_mp(this, &CodeTextEditor::_line_col_changed));
+	text_editor->connect("caret_changed", callable_mp(this, &CodeTextEditor::_line_col_changed));
 	text_editor->connect("text_changed", callable_mp(this, &CodeTextEditor::_text_changed));
 	text_editor->connect("request_completion", callable_mp(this, &CodeTextEditor::_complete_request));
 	Vector<String> cs;

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -84,7 +84,7 @@ class FindReplaceBar : public HBoxContainer {
 	int results_count;
 
 	bool replace_all_mode;
-	bool preserve_cursor;
+	bool preserve_caret;
 
 	void _get_search_from(int &r_line, int &r_col);
 	void _update_results_count();

--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -51,7 +51,7 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 		versions->add_child(vtab);
 		for (int j = 0; j < nsc.versions[i].stages.size(); j++) {
 			TextEdit *vtext = memnew(TextEdit);
-			vtext->set_readonly(true);
+			vtext->set_editable(false);
 			vtext->set_name(nsc.versions[i].stages[j].name);
 			vtext->set_text(nsc.versions[i].stages[j].code);
 			vtext->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -557,13 +557,13 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/tools/create_signal_callbacks", true);
 	_initial_set("text_editor/tools/sort_members_outline_alphabetically", false);
 
-	// Cursor
-	_initial_set("text_editor/cursor/scroll_past_end_of_file", false);
-	_initial_set("text_editor/cursor/block_caret", false);
-	_initial_set("text_editor/cursor/caret_blink", true);
-	_initial_set("text_editor/cursor/caret_blink_speed", 0.5);
-	hints["text_editor/cursor/caret_blink_speed"] = PropertyInfo(Variant::FLOAT, "text_editor/cursor/caret_blink_speed", PROPERTY_HINT_RANGE, "0.1, 10, 0.01");
-	_initial_set("text_editor/cursor/right_click_moves_caret", true);
+	// Caret
+	_initial_set("text_editor/caret/scroll_past_end_of_file", false);
+	_initial_set("text_editor/caret/block_mode_enabled", false);
+	_initial_set("text_editor/caret/blink_enabled", true);
+	_initial_set("text_editor/caret/blink_speed", 0.5);
+	hints["text_editor/caret/blink_speed"] = PropertyInfo(Variant::FLOAT, "text_editor/caret/blink_speed", PROPERTY_HINT_RANGE, "0.1, 10, 0.01");
+	_initial_set("text_editor/caret/moves_with_right_click", true);
 
 	// Completion
 	_initial_set("text_editor/completion/idle_parse_delay", 2.0);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -292,7 +292,7 @@ void ScriptTextEditor::_show_warnings_panel(bool p_show) {
 
 void ScriptTextEditor::_warning_clicked(Variant p_line) {
 	if (p_line.get_type() == Variant::INT) {
-		code_editor->get_text_editor()->cursor_set_line(p_line.operator int64_t());
+		code_editor->get_text_editor()->set_caret_line(p_line.operator int64_t());
 	} else if (p_line.get_type() == Variant::DICTIONARY) {
 		Dictionary meta = p_line.operator Dictionary();
 		code_editor->get_text_editor()->insert_at("# warning-ignore:" + meta["code"].operator String(), meta["line"].operator int64_t() - 1);
@@ -304,14 +304,14 @@ void ScriptTextEditor::reload_text() {
 	ERR_FAIL_COND(script.is_null());
 
 	CodeEdit *te = code_editor->get_text_editor();
-	int column = te->cursor_get_column();
-	int row = te->cursor_get_line();
+	int column = te->get_caret_column();
+	int row = te->get_caret_line();
 	int h = te->get_h_scroll();
 	int v = te->get_v_scroll();
 
 	te->set_text(script->get_source_code());
-	te->cursor_set_line(row);
-	te->cursor_set_column(column);
+	te->set_caret_line(row);
+	te->set_caret_column(column);
 	te->set_h_scroll(h);
 	te->set_v_scroll(v);
 
@@ -329,12 +329,12 @@ void ScriptTextEditor::add_callback(const String &p_function, PackedStringArray 
 		pos = code_editor->get_text_editor()->get_line_count() + 2;
 		String func = script->get_language()->make_function("", p_function, p_args);
 		//code=code+func;
-		code_editor->get_text_editor()->cursor_set_line(pos + 1);
-		code_editor->get_text_editor()->cursor_set_column(1000000); //none shall be that big
-		code_editor->get_text_editor()->insert_text_at_cursor("\n\n" + func);
+		code_editor->get_text_editor()->set_caret_line(pos + 1);
+		code_editor->get_text_editor()->set_caret_column(1000000); //none shall be that big
+		code_editor->get_text_editor()->insert_text_at_caret("\n\n" + func);
 	}
-	code_editor->get_text_editor()->cursor_set_line(pos);
-	code_editor->get_text_editor()->cursor_set_column(1);
+	code_editor->get_text_editor()->set_caret_line(pos);
+	code_editor->get_text_editor()->set_caret_column(1);
 }
 
 bool ScriptTextEditor::show_members_overview() {
@@ -1082,7 +1082,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			code_editor->clone_lines_down();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
-			tx->toggle_fold_line(tx->cursor_get_line());
+			tx->toggle_fold_line(tx->get_caret_line());
 			tx->update();
 		} break;
 		case EDIT_FOLD_ALL_LINES: {
@@ -1170,7 +1170,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			}
 
 			code_editor->get_text_editor()->begin_complex_operation(); //prevents creating a two-step undo
-			code_editor->get_text_editor()->insert_text_at_cursor(String("\n").join(results));
+			code_editor->get_text_editor()->insert_text_at_caret(String("\n").join(results));
 			code_editor->get_text_editor()->end_complex_operation();
 		} break;
 		case SEARCH_FIND: {
@@ -1217,7 +1217,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			code_editor->remove_all_bookmarks();
 		} break;
 		case DEBUG_TOGGLE_BREAKPOINT: {
-			int line = tx->cursor_get_line();
+			int line = tx->get_caret_line();
 			bool dobreak = !tx->is_line_breakpointed(line);
 			tx->set_line_as_breakpoint(line, dobreak);
 			EditorDebuggerNode::get_singleton()->set_breakpoint(script->get_path(), line + 1, dobreak);
@@ -1238,20 +1238,20 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
-			int line = tx->cursor_get_line();
+			int line = tx->get_caret_line();
 
 			// wrap around
 			if (line >= (int)bpoints[bpoints.size() - 1]) {
 				tx->unfold_line(bpoints[0]);
-				tx->cursor_set_line(bpoints[0]);
-				tx->center_viewport_to_cursor();
+				tx->set_caret_line(bpoints[0]);
+				tx->center_viewport_at_caret();
 			} else {
 				for (int i = 0; i < bpoints.size(); i++) {
 					int bline = bpoints[i];
 					if (bline > line) {
 						tx->unfold_line(bline);
-						tx->cursor_set_line(bline);
-						tx->center_viewport_to_cursor();
+						tx->set_caret_line(bline);
+						tx->center_viewport_at_caret();
 						return;
 					}
 				}
@@ -1264,19 +1264,19 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
-			int line = tx->cursor_get_line();
+			int line = tx->get_caret_line();
 			// wrap around
 			if (line <= (int)bpoints[0]) {
 				tx->unfold_line(bpoints[bpoints.size() - 1]);
-				tx->cursor_set_line(bpoints[bpoints.size() - 1]);
-				tx->center_viewport_to_cursor();
+				tx->set_caret_line(bpoints[bpoints.size() - 1]);
+				tx->center_viewport_at_caret();
 			} else {
 				for (int i = bpoints.size(); i >= 0; i--) {
 					int bline = bpoints[i];
 					if (bline < line) {
 						tx->unfold_line(bline);
-						tx->cursor_set_line(bline);
-						tx->center_viewport_to_cursor();
+						tx->set_caret_line(bline);
+						tx->center_viewport_at_caret();
 						return;
 					}
 				}
@@ -1286,19 +1286,19 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		case HELP_CONTEXTUAL: {
 			String text = tx->get_selection_text();
 			if (text == "") {
-				text = tx->get_word_under_cursor();
+				text = tx->get_word_at_caret();
 			}
 			if (text != "") {
 				emit_signal("request_help", text);
 			}
 		} break;
 		case LOOKUP_SYMBOL: {
-			String text = tx->get_word_under_cursor();
+			String text = tx->get_word_at_caret();
 			if (text == "") {
 				text = tx->get_selection_text();
 			}
 			if (text != "") {
-				_lookup_symbol(text, tx->cursor_get_line(), tx->cursor_get_column());
+				_lookup_symbol(text, tx->get_caret_line(), tx->get_caret_column());
 			}
 		} break;
 	}
@@ -1457,9 +1457,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			return;
 		}
 
-		te->cursor_set_line(row);
-		te->cursor_set_column(col);
-		te->insert_text_at_cursor(res->get_path());
+		te->set_caret_line(row);
+		te->set_caret_column(col);
+		te->insert_text_at_caret(res->get_path());
 	}
 
 	if (d.has("type") && (String(d["type"]) == "files" || String(d["type"]) == "files_and_dirs")) {
@@ -1473,9 +1473,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			text_to_drop += "\"" + String(files[i]).c_escape() + "\"";
 		}
 
-		te->cursor_set_line(row);
-		te->cursor_set_column(col);
-		te->insert_text_at_cursor(text_to_drop);
+		te->set_caret_line(row);
+		te->set_caret_column(col);
+		te->insert_text_at_caret(text_to_drop);
 	}
 
 	if (d.has("type") && String(d["type"]) == "nodes") {
@@ -1503,9 +1503,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			text_to_drop += "\"" + path.c_escape() + "\"";
 		}
 
-		te->cursor_set_line(row);
-		te->cursor_set_column(col);
-		te->insert_text_at_cursor(text_to_drop);
+		te->set_caret_line(row);
+		te->set_caret_column(col);
+		te->insert_text_at_caret(text_to_drop);
 	}
 }
 
@@ -1520,7 +1520,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		local_pos = mb->get_global_position() - tx->get_global_position();
 		create_menu = true;
 	} else if (k.is_valid() && k->get_keycode() == KEY_MENU) {
-		local_pos = tx->_get_cursor_pixel_pos();
+		local_pos = tx->_get_caret_pixel_pos();
 		create_menu = true;
 	}
 
@@ -1528,8 +1528,8 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		int col, row;
 		tx->_get_mouse_pos(local_pos, row, col);
 
-		tx->set_right_click_moves_caret(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
-		if (tx->is_right_click_moving_caret()) {
+		tx->set_caret_moves_with_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/caret/moves_with_right_click"));
+		if (tx->is_caret_moves_with_right_click_enabled()) {
 			if (tx->is_selection_active()) {
 				int from_line = tx->get_selection_from_line();
 				int to_line = tx->get_selection_to_line();
@@ -1542,14 +1542,14 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 				}
 			}
 			if (!tx->is_selection_active()) {
-				tx->cursor_set_line(row, true, false);
-				tx->cursor_set_column(col);
+				tx->set_caret_line(row, true, false);
+				tx->set_caret_column(col);
 			}
 		}
 
 		String word_at_pos = tx->get_word_at_pos(local_pos);
 		if (word_at_pos == "") {
-			word_at_pos = tx->get_word_under_cursor();
+			word_at_pos = tx->get_word_at_caret();
 		}
 		if (word_at_pos == "") {
 			word_at_pos = tx->get_selection_text();

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -66,14 +66,14 @@ void ShaderTextEditor::reload_text() {
 	ERR_FAIL_COND(shader.is_null());
 
 	CodeEdit *te = get_text_editor();
-	int column = te->cursor_get_column();
-	int row = te->cursor_get_line();
+	int column = te->get_caret_column();
+	int row = te->get_caret_line();
 	int h = te->get_h_scroll();
 	int v = te->get_v_scroll();
 
 	te->set_text(shader->get_code());
-	te->cursor_set_line(row);
-	te->cursor_set_column(column);
+	te->set_caret_line(row);
+	te->set_caret_column(column);
 	te->set_h_scroll(h);
 	te->set_v_scroll(v);
 
@@ -464,9 +464,9 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			int col, row;
 			CodeEdit *tx = shader_editor->get_text_editor();
 			tx->_get_mouse_pos(mb->get_global_position() - tx->get_global_position(), row, col);
-			tx->set_right_click_moves_caret(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
+			tx->set_caret_moves_with_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/caret/moves_with_right_click"));
 
-			if (tx->is_right_click_moving_caret()) {
+			if (tx->is_caret_moves_with_right_click_enabled()) {
 				if (tx->is_selection_active()) {
 					int from_line = tx->get_selection_from_line();
 					int to_line = tx->get_selection_to_line();
@@ -479,8 +479,8 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					}
 				}
 				if (!tx->is_selection_active()) {
-					tx->cursor_set_line(row, true, false);
-					tx->cursor_set_column(col);
+					tx->set_caret_line(row, true, false);
+					tx->set_caret_column(col);
 				}
 			}
 			_make_context_menu(tx->is_selection_active(), get_local_mouse_position());
@@ -490,7 +490,7 @@ void ShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	Ref<InputEventKey> k = ev;
 	if (k.is_valid() && k->is_pressed() && k->get_keycode() == KEY_MENU) {
 		CodeEdit *tx = shader_editor->get_text_editor();
-		_make_context_menu(tx->is_selection_active(), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->_get_cursor_pixel_pos()));
+		_make_context_menu(tx->is_selection_active(), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->_get_caret_pixel_pos()));
 		context_menu->grab_focus();
 	}
 }

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -179,14 +179,14 @@ void TextEditor::reload_text() {
 	ERR_FAIL_COND(text_file.is_null());
 
 	CodeEdit *te = code_editor->get_text_editor();
-	int column = te->cursor_get_column();
-	int row = te->cursor_get_line();
+	int column = te->get_caret_column();
+	int row = te->get_caret_line();
 	int h = te->get_h_scroll();
 	int v = te->get_v_scroll();
 
 	te->set_text(text_file->get_text());
-	te->cursor_set_line(row);
-	te->cursor_set_column(column);
+	te->set_caret_line(row);
+	te->set_caret_column(column);
 	te->set_h_scroll(h);
 	te->set_v_scroll(v);
 
@@ -375,7 +375,7 @@ void TextEditor::_edit_option(int p_op) {
 			code_editor->clone_lines_down();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
-			tx->toggle_fold_line(tx->cursor_get_line());
+			tx->toggle_fold_line(tx->get_caret_line());
 			tx->update();
 		} break;
 		case EDIT_FOLD_ALL_LINES: {
@@ -474,11 +474,11 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			CodeEdit *tx = code_editor->get_text_editor();
 			tx->_get_mouse_pos(mb->get_global_position() - tx->get_global_position(), row, col);
 
-			tx->set_right_click_moves_caret(EditorSettings::get_singleton()->get("text_editor/cursor/right_click_moves_caret"));
+			tx->set_caret_moves_with_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/caret/moves_with_right_click"));
 			bool can_fold = tx->can_fold(row);
 			bool is_folded = tx->is_folded(row);
 
-			if (tx->is_right_click_moving_caret()) {
+			if (tx->is_caret_moves_with_right_click_enabled()) {
 				if (tx->is_selection_active()) {
 					int from_line = tx->get_selection_from_line();
 					int to_line = tx->get_selection_to_line();
@@ -491,8 +491,8 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					}
 				}
 				if (!tx->is_selection_active()) {
-					tx->cursor_set_line(row, true, false);
-					tx->cursor_set_column(col);
+					tx->set_caret_line(row, true, false);
+					tx->set_caret_column(col);
 				}
 			}
 
@@ -505,8 +505,8 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	Ref<InputEventKey> k = ev;
 	if (k.is_valid() && k->is_pressed() && k->get_keycode() == KEY_MENU) {
 		CodeEdit *tx = code_editor->get_text_editor();
-		int line = tx->cursor_get_line();
-		_make_context_menu(tx->is_selection_active(), tx->can_fold(line), tx->is_folded(line), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->_get_cursor_pixel_pos()));
+		int line = tx->get_caret_line();
+		_make_context_menu(tx->is_selection_active(), tx->can_fold(line), tx->is_folded(line), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->_get_caret_pixel_pos()));
 		context_menu->grab_focus();
 	}
 }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3608,7 +3608,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	preview_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	preview_text->set_syntax_highlighter(syntax_highlighter);
 	preview_text->set_draw_line_numbers(true);
-	preview_text->set_readonly(true);
+	preview_text->set_editable(false);
 
 	error_text = memnew(Label);
 	preview_vbox->add_child(error_text);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -345,8 +345,8 @@ void CodeEdit::_gutter_clicked(int p_line, int p_gutter) {
 	if (p_gutter == line_number_gutter) {
 		set_selection_mode(TextEdit::SelectionMode::SELECTION_MODE_LINE, p_line, 0);
 		select(p_line, 0, p_line + 1, 0);
-		cursor_set_line(p_line + 1);
-		cursor_set_column(0);
+		set_caret_line(p_line + 1);
+		set_caret_column(0);
 		return;
 	}
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -577,8 +577,8 @@ void LineEdit::_notification(int p_what) {
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_ENTER_TREE: {
 			if (Engine::get_singleton()->is_editor_hint() && !get_tree()->is_node_being_edited(this)) {
-				set_caret_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
-				set_caret_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
+				set_caret_blink_enabled(EDITOR_DEF("text_editor/caret/blink_enabled", false));
+				set_caret_blink_speed(EDITOR_DEF("text_editor/caret/blink_speed", 0.65));
 
 				if (!EditorSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed))) {
 					EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed));
@@ -1812,8 +1812,8 @@ PopupMenu *LineEdit::get_menu() const {
 
 void LineEdit::_editor_settings_changed() {
 #ifdef TOOLS_ENABLED
-	set_caret_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
-	set_caret_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
+	set_caret_blink_enabled(EDITOR_DEF("text_editor/caret/blink_enabled", false));
+	set_caret_blink_speed(EDITOR_DEF("text_editor/caret/blink_speed", 0.65));
 #endif
 }
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -169,14 +169,14 @@ private:
 		bool is_line_gutter_clickable(int p_line, int p_gutter) const { return text[p_line].gutters[p_gutter].clickable; }
 	};
 
-	struct Cursor {
+	struct Caret {
 		int last_fit_x = 0;
 		int line = 0;
-		int column = 0; ///< cursor
+		int column = 0;
 		int x_ofs = 0;
 		int line_ofs = 0;
 		int wrap_ofs = 0;
-	} cursor;
+	} caret;
 
 	struct Selection {
 		SelectionMode selecting_mode = SelectionMode::SELECTION_MODE_NONE;
@@ -276,9 +276,9 @@ private:
 	bool caret_blink_enabled = false;
 	bool draw_caret = true;
 	bool window_has_focus = true;
-	bool block_caret = false;
-	bool right_click_moves_caret = true;
-	bool mid_grapheme_caret_enabled = false;
+	bool caret_block_mode = false;
+	bool caret_moves_with_right_click = true;
+	bool caret_mid_grapheme_enabled = false;
 
 	bool wrap_enabled = false;
 	int wrap_at = 0;
@@ -289,7 +289,7 @@ private:
 	bool draw_tabs = false;
 	bool draw_spaces = false;
 	bool override_selected_font_color = false;
-	bool cursor_changed_dirty = false;
+	bool caret_changed_dirty = false;
 	bool text_changed_dirty = false;
 	bool undo_enabled = true;
 	bool line_length_guidelines = false;
@@ -359,12 +359,12 @@ private:
 
 	int _get_minimap_visible_rows() const;
 
-	void update_cursor_wrap_offset();
+	void update_caret_wrap_offset();
 	void _update_wrap_at(bool p_force = false);
 	bool line_wraps(int line) const;
 	int times_line_wraps(int line) const;
 	Vector<String> get_wrap_rows_text(int p_line) const;
-	int get_cursor_wrap_index() const;
+	int get_caret_wrap_index() const;
 	int get_line_wrap_index_at_col(int p_line, int p_column) const;
 	int get_char_count();
 
@@ -381,7 +381,7 @@ private:
 	int get_char_pos_for_line(int p_px, int p_line, int p_wrap_index = 0) const;
 	int get_column_x_offset_for_line(int p_char, int p_line) const;
 
-	void adjust_viewport_to_cursor();
+	void adjust_viewport_to_caret();
 	double get_scroll_line_diff() const;
 	void _scroll_moved(double);
 	void _update_scrollbars();
@@ -414,8 +414,8 @@ private:
 	void _toggle_draw_caret();
 
 	void _update_caches();
-	void _cursor_changed_emit();
-	void _text_changed_emit();
+	void _emit_caret_changed();
+	void _emit_text_changed();
 
 	void _push_current_op();
 
@@ -447,19 +447,19 @@ private:
 	void _new_line(bool p_split_current = true, bool p_above = false);
 	void _indent_right();
 	void _indent_left();
-	void _move_cursor_left(bool p_select, bool p_move_by_word = false);
-	void _move_cursor_right(bool p_select, bool p_move_by_word = false);
-	void _move_cursor_up(bool p_select);
-	void _move_cursor_down(bool p_select);
-	void _move_cursor_to_line_start(bool p_select);
-	void _move_cursor_to_line_end(bool p_select);
-	void _move_cursor_page_up(bool p_select);
-	void _move_cursor_page_down(bool p_select);
+	void _move_caret_left(bool p_select, bool p_move_by_word = false);
+	void _move_caret_right(bool p_select, bool p_move_by_word = false);
+	void _move_caret_up(bool p_select);
+	void _move_caret_down(bool p_select);
+	void _move_caret_to_line_start(bool p_select);
+	void _move_caret_to_line_end(bool p_select);
+	void _move_caret_page_up(bool p_select);
+	void _move_caret_page_down(bool p_select);
 	void _backspace(bool p_word = false, bool p_all_to_left = false);
 	void _delete(bool p_word = false, bool p_all_to_right = false);
 	void _delete_selection();
-	void _move_cursor_document_start(bool p_select);
-	void _move_cursor_document_end(bool p_select);
+	void _move_caret_document_start(bool p_select);
+	void _move_caret_document_end(bool p_select);
 	void _handle_unicode_character(uint32_t unicode, bool p_had_selection, bool p_update_auto_complete);
 
 protected:
@@ -502,7 +502,7 @@ protected:
 
 	void _insert_text(int p_line, int p_char, const String &p_text, int *r_end_line = nullptr, int *r_end_char = nullptr);
 	void _remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
-	void _insert_text_at_cursor(const String &p_text);
+	void _insert_text_at_caret(const String &p_text);
 	void _gui_input(const Ref<InputEvent> &p_gui_input);
 	void _notification(int p_what);
 
@@ -634,7 +634,7 @@ public:
 
 	void set_highlighted_word(const String &new_word);
 	void set_text(String p_text);
-	void insert_text_at_cursor(const String &p_text);
+	void insert_text_at_caret(const String &p_text);
 	void insert_at(const String &p_text, int at);
 	int get_line_count() const;
 	void set_line_as_marked(int p_line, bool p_marked);
@@ -658,7 +658,7 @@ public:
 	String get_line(int line) const;
 	void set_line(int line, String new_text);
 	int get_row_height() const;
-	void backspace_at_cursor();
+	void backspace_at_caret();
 
 	void indent_selected_lines_left();
 	void indent_selected_lines_right();
@@ -682,29 +682,29 @@ public:
 	}
 	void set_auto_indent(bool p_auto_indent);
 
-	void center_viewport_to_cursor();
+	void center_viewport_at_caret();
 
-	void set_mid_grapheme_caret_enabled(const bool p_enabled);
-	bool get_mid_grapheme_caret_enabled() const;
+	void set_caret_mid_grapheme_enabled(const bool p_enabled);
+	bool is_caret_mid_grapheme_enabled() const;
 
-	void cursor_set_column(int p_col, bool p_adjust_viewport = true);
-	void cursor_set_line(int p_row, bool p_adjust_viewport = true, bool p_can_be_hidden = true, int p_wrap_index = 0);
+	void set_caret_column(int p_col, bool p_adjust_viewport = true);
+	void set_caret_line(int p_row, bool p_adjust_viewport = true, bool p_can_be_hidden = true, int p_wrap_index = 0);
 
-	int cursor_get_column() const;
-	int cursor_get_line() const;
-	Vector2i _get_cursor_pixel_pos(bool p_adjust_viewport = true);
+	int get_caret_column() const;
+	int get_caret_line() const;
+	Vector2i _get_caret_pixel_pos(bool p_adjust_viewport = true);
 
-	bool cursor_get_blink_enabled() const;
-	void cursor_set_blink_enabled(const bool p_enabled);
+	void set_caret_blink_enabled(const bool p_enabled);
+	bool is_caret_blink_enabled() const;
 
-	float cursor_get_blink_speed() const;
-	void cursor_set_blink_speed(const float p_speed);
+	void set_caret_blink_speed(const float p_speed);
+	float get_caret_blink_speed() const;
 
-	void cursor_set_block_mode(const bool p_enable);
-	bool cursor_is_block_mode() const;
+	void set_caret_block_mode_enabled(const bool p_enable);
+	bool is_caret_block_mode_enabled() const;
 
-	void set_right_click_moves_caret(bool p_enable);
-	bool is_right_click_moving_caret() const;
+	void set_caret_moves_with_right_click_enabled(bool p_enable);
+	bool is_caret_moves_with_right_click_enabled() const;
 
 	SelectionMode get_selection_mode() const;
 	void set_selection_mode(SelectionMode p_mode, int p_line = -1, int p_column = -1);
@@ -743,7 +743,7 @@ public:
 	int get_selection_to_column() const;
 	String get_selection_text() const;
 
-	String get_word_under_cursor() const;
+	String get_word_at_caret() const;
 	String get_word_at_pos(const Vector2 &p_pos) const;
 
 	bool search(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column, int &r_line, int &r_column) const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -267,7 +267,7 @@ private:
 	uint32_t saved_version = 0;
 
 	int max_chars = 0;
-	bool readonly = true; // Initialise to opposite first, so we get past the early-out in set_readonly.
+	bool editable = false; // Initialise to opposite first, so we get past the early-out in set_editable.
 	bool indent_using_spaces = false;
 	int indent_size = 4;
 	String space_indent = "    ";
@@ -711,8 +711,8 @@ public:
 	int get_selection_line() const;
 	int get_selection_column() const;
 
-	void set_readonly(bool p_readonly);
-	bool is_readonly() const;
+	void set_editable(bool p_editable);
+	bool is_editable() const;
 
 	void set_max_chars(int p_max_chars);
 	int get_max_chars() const;


### PR DESCRIPTION
Part of #16863, and the `TextEdit` sister PR to the `LineEdit` PR #47448.

Similar to `LineEdit`, TextEdit's caret_* properties getters and setters are also misnamed. This PR renames those getters and setters to match the property names. In addition, for consistency, it renames the other caret methods, signals, the editor settings and the documentation to refer to caret instead of cursor too.

**Methods renamed:**

Property | Old Method Name | New Method Name
 -- | -- | --
| | center_viewport_to_cursor | center_viewport_at_caret
| | cursor_get_column | get_caret_column
| | cursor_get_line | get_caret_line
| | cursor_set_column | set_caret_column
| | cursor_set_line | set_caret_line
| | get_word_under_cursor | get_word_at_caret
| | insert_text_at_cursor | insert_text_at_caret
caret_blink | cursor_set_blink_enabled | set_caret_blink_enabled
" | cursor_get_blink_enabled | is_caret_blink_enabled
caret_blink_speed | cursor_set_blink_speed | set_caret_blink_speed
" | cursor_get_blink_speed | get_caret_blink_speed
caret_block_mode | cursor_set_block_mode | set_caret_block_mode_enabled
" | cursor_is_block_mode | is_caret_block_mode_enabled
caret_mid_grapheme | set_mid_grapheme_caret_enabled | set_caret_mid_grapheme_enabled
" | get_mid_grapheme_caret_enabled | is_caret_mid_grapheme_enabled
caret_moving_by_right_click -> caret_moves_with_right_click | set_right_click_moves_caret | set_caret_moves_with_right_click_enabled
" | is_right_click_moving_caret | is_caret_moves_with_right_click_enabled

Old Signal | New Signal
-- | --
cursor_changed | caret_changed

**Editor Settings renamed:**
Old Setting | New Setting
-- | --
text_editor/cursor/scroll_past_end_of_file | text_editor/caret/scroll_past_end_of_file
text_editor/cursor/block_caret | text_editor/caret/block_mode_enabled
text_editor/cursor/caret_blink | text_editor/caret/blink_enabled
text_editor/cursor/caret_blink_speed | text_editor/caret/blink_speed

Finally, the property `readonly` has also been renamed to `editable` to make it consistent with `LineEdit`. I've kept this as a separate commit, because it also reverses the functionality.