### PR TITLE
Automatically detect joystick buttons and axis changes when editing t…

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1700,7 +1700,8 @@ void ProjectSettingsEditor::_toggle_search_bar(bool p_pressed) {
 		search_box->clear();
 		search_bar->hide();
 		add_prop_bar->show();
-	}
+	}<<<<<<< HEAD
+
 }
 
 void ProjectSettingsEditor::set_plugins_page() {
@@ -1748,7 +1749,7 @@ void ProjectSettingsEditor::_input_map_helper_timer_timeout() {
                device_index->select(i * 2 + 1);
             }
          }
-         _last_axis_reading[i] = axisValue;comm
+         _last_axis_reading[i] = axisValue;
       }
       return;
    }

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -32,6 +32,7 @@
 
 #include "core/global_constants.h"
 #include "core/input_map.h"
+#include "core/os/input.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
 #include "core/translation.h"
@@ -81,6 +82,8 @@ static const char *_axis_names[JOY_AXIS_MAX * 2] = {
 	"", " (L2)",
 	"", " (R2)"
 };
+
+float _last_axis_reading[JOY_AXIS_MAX] = { 0.0f };
 
 void ProjectSettingsEditor::_unhandled_input(const Ref<InputEvent> &p_event) {
 
@@ -259,6 +262,8 @@ void ProjectSettingsEditor::_device_input_add() {
 	Dictionary action = old_val.duplicate();
 	Array events = action["events"];
 
+   input_map_helper_timer->stop();
+
 	switch (add_type) {
 
 		case INPUT_MOUSE_BUTTON: {
@@ -344,6 +349,10 @@ void ProjectSettingsEditor::_device_input_add() {
 	undo_redo->commit_action();
 
 	_show_last_added(ie, name);
+}
+
+void ProjectSettingsEditor::_device_input_cancel() {
+   input_map_helper_timer->stop();
 }
 
 void ProjectSettingsEditor::_set_current_device(int i_device) {
@@ -519,6 +528,10 @@ void ProjectSettingsEditor::_add_item(int p_item, Ref<InputEvent> p_exiting_even
 				_set_current_device(0);
 				device_input->get_ok()->set_text(TTR("Add"));
 			}
+         for (int i = 0; i < JOY_AXIS_MAX; ++i) {
+            _last_axis_reading[i] = Input::get_singleton()->get_joy_axis(_get_current_device(), i);
+         }
+         input_map_helper_timer->start();
 
 		} break;
 		case INPUT_JOY_BUTTON: {
@@ -541,6 +554,7 @@ void ProjectSettingsEditor::_add_item(int p_item, Ref<InputEvent> p_exiting_even
 				_set_current_device(0);
 				device_input->get_ok()->set_text(TTR("Add"));
 			}
+         input_map_helper_timer->start();
 
 		} break;
 		default: {
@@ -1713,6 +1727,33 @@ void ProjectSettingsEditor::_editor_restart_close() {
 	restart_container->hide();
 }
 
+void ProjectSettingsEditor::_input_map_helper_timer_timeout() {
+   if (add_type == INPUT_JOY_BUTTON) {
+      for (int i = 0; i < JOY_BUTTON_MAX; i++) {
+         if (Input::get_singleton()->is_joy_button_pressed(_get_current_device(), i)) {
+            device_index->select(i);
+            break;
+         }
+      }
+      return;
+	}
+   else if (add_type == INPUT_JOY_MOTION) {
+      for (int i = 0; i < JOY_AXIS_MAX; i++) {
+         float axisValue = Input::get_singleton()->get_joy_axis(_get_current_device(), i);
+         if (ABS(axisValue - _last_axis_reading[i]) > 0.1f) {
+            if (axisValue < -0.75f) {
+               device_index->select(i * 2);
+            }
+            else if (axisValue > 0.75f) {
+               device_index->select(i * 2 + 1);
+            }
+         }
+         _last_axis_reading[i] = axisValue;
+      }
+      return;
+   }
+}
+
 void ProjectSettingsEditor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_unhandled_input"), &ProjectSettingsEditor::_unhandled_input);
@@ -1761,6 +1802,10 @@ void ProjectSettingsEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_editor_restart_request"), &ProjectSettingsEditor::_editor_restart_request);
 	ClassDB::bind_method(D_METHOD("_editor_restart"), &ProjectSettingsEditor::_editor_restart);
 	ClassDB::bind_method(D_METHOD("_editor_restart_close"), &ProjectSettingsEditor::_editor_restart_close);
+
+
+	ClassDB::bind_method(D_METHOD("_input_map_helper_timer_timeout"), &ProjectSettingsEditor::_input_map_helper_timer_timeout);
+	ClassDB::bind_method(D_METHOD("_device_input_cancel"), &ProjectSettingsEditor::_device_input_cancel);
 
 	ClassDB::bind_method(D_METHOD("get_tabs"), &ProjectSettingsEditor::get_tabs);
 
@@ -1955,6 +2000,13 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	press_a_key->set_focus_mode(FOCUS_ALL);
 	add_child(press_a_key);
 
+	input_map_helper_timer = memnew(Timer);
+	add_child(input_map_helper_timer);
+	input_map_helper_timer->set_one_shot(false);
+	input_map_helper_timer->set_wait_time(.1);
+	input_map_helper_timer->connect("timeout", this, "_input_map_helper_timer_timeout");
+
+
 	l = memnew(Label);
 	l->set_text(TTR("Press a Key..."));
 	l->set_anchors_and_margins_preset(Control::PRESET_WIDE);
@@ -1971,6 +2023,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	add_child(device_input);
 	device_input->get_ok()->set_text(TTR("Add"));
 	device_input->connect("confirmed", this, "_device_input_add");
+   device_input->get_cancel()->connect("pressed", this, "_device_input_cancel");
 
 	hbc = memnew(HBoxContainer);
 	device_input->add_child(hbc);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1700,7 +1700,7 @@ void ProjectSettingsEditor::_toggle_search_bar(bool p_pressed) {
 		search_box->clear();
 		search_bar->hide();
 		add_prop_bar->show();
-	}<<<<<<< HEAD
+	}
 
 }
 

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -124,6 +124,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _action_adds(String);
 	void _action_add();
 	void _device_input_add();
+   void _device_input_cancel();
 
 	void _item_checked(const String &p_item, bool p_check);
 	void _action_selected();
@@ -179,6 +180,8 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _editor_restart();
 	void _editor_restart_close();
 
+	void _input_map_helper_timer_timeout();
+
 protected:
 	void _unhandled_input(const Ref<InputEvent> &p_event);
 	void _notification(int p_what);
@@ -187,6 +190,8 @@ protected:
 	int _get_current_device();
 	void _set_current_device(int i_device);
 	String _get_device_string(int i_device);
+
+	Timer *input_map_helper_timer;
 
 public:
 	void add_translation(const String &p_translation);


### PR DESCRIPTION
This code is useful when setting up your project's inputs. If you add a new joystick button or joystick axis entry to an action, when the dialog comes up for you to select the button or axis, if you press a button or move an axis on your joystick the dropdown menu selection will automatically change to that button or axis. 