### PR TITLE
Rename "Move to Recycle Bin" back to "Delete" on Windows

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2756,10 +2756,13 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	ED_SHORTCUT("filesystem_dock/duplicate", TTR("Duplicate..."), KEY_MASK_CMD | KEY_D);
 
 #if defined(WINDOWS_ENABLED)
-	// TRANSLATORS: This string is only used on Windows, as it refers to the system trash
-	// as "Recycle Bin" instead of "Trash". Make sure to use the translation of "Recycle Bin"
-	// recommended by Microsoft for the target language.
-	ED_SHORTCUT("filesystem_dock/delete", TTR("Move to Recycle Bin"), KEY_DELETE);
+	// Note that the "Delete" action is actually responsible for moving files
+	// to "Recycle Bin" by default instead of deleting files altogether, so we
+	// use "Delete" term here rather than more explicit "Move to Recycle Bin",
+	// otherwise this will break user expectations in terms of discoverability.
+	// Once Microsoft decides to rename it to "Move to Recycle Bin", then it's
+	// safe to rename it in Godot as well.
+	ED_SHORTCUT("filesystem_dock/delete", TTR("Delete"), KEY_DELETE);
 #elif defined(OSX_ENABLED)
 	// TRANSLATORS: This string is only used on macOS, as it refers to the system trash
 	// as "Bin" instead of "Trash". Make sure to use the translation of "Bin"


### PR DESCRIPTION
Closes godotengine/godot-proposals#2463.

As it was in `3.2.3-stable`:

![image](https://user-images.githubusercontent.com/17108460/113327134-3eb32b80-9323-11eb-80ec-575ec0a5aa34.png)

I'm fine if this PR is postponed until `3.3-stable` is released if you'd like to gather more feedback from the general public, as most users have not even stumbled upon this yet. But according to the number of 👍 on the proposal linked, I think it makes sense to merge this regardless, since it's already the case in current `3.2.3-stable` version, and it was like that throughout existence of Godot on Windows).

In `3.3-rc`, it's actually "Move to Trash" by the way, and `master` has "Move to Recycle Bin", which is needlessly explicit, and does not always move files to Recycle Bin according to #47106...

Also note that translators won't have to translate the new name either, since "Delete" string is already translated.


