### PR TITLE
Add option to exclude addons in Quick Open dialog

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -489,6 +489,9 @@
 			- [b]Thumbnails[/b] takes more space, but displays dynamic resource thumbnails, making resources easier to preview without having to open them.
 			- [b]List[/b] is more compact but doesn't display dynamic resource thumbnails. Instead, it displays static icons based on the file extension.
 		</member>
+		<member name="filesystem/file_dialog/quick_open_exclude_addons" type="bool" setter="" getter="">
+			If [code]true[/code], files in the [code]res://addons[/code] folder will not be listed in Quick Open dialogs.
+		</member>
 		<member name="filesystem/file_dialog/show_hidden_files" type="bool" setter="" getter="">
 			If [code]true[/code], display hidden files in the editor's file dialogs. Files that have names starting with [code].[/code] are considered hidden (e.g. [code].hidden_file[/code]).
 		</member>

--- a/editor/editor_quick_open.cpp
+++ b/editor/editor_quick_open.cpp
@@ -32,7 +32,10 @@
 
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
+#include "editor/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+
+static const String addons_directory = "addons";
 
 Rect2i EditorQuickOpen::prev_rect = Rect2i();
 bool EditorQuickOpen::was_showed = false;
@@ -65,6 +68,8 @@ void EditorQuickOpen::_build_search_cache(EditorFileSystemDirectory *p_efsd) {
 		_build_search_cache(p_efsd->get_subdir(i));
 	}
 
+	const bool skip_addons = (bool)EDITOR_GET("filesystem/file_dialog/quick_open_exclude_addons");
+
 	Vector<String> base_types = base_type.split(",");
 	for (int i = 0; i < p_efsd->get_file_count(); i++) {
 		String file = p_efsd->get_file_path(i);
@@ -75,7 +80,9 @@ void EditorQuickOpen::_build_search_cache(EditorFileSystemDirectory *p_efsd) {
 		// Iterate all possible base types.
 		for (String &parent_type : base_types) {
 			if (ClassDB::is_parent_class(engine_type, parent_type) || EditorNode::get_editor_data().script_class_is_parent(script_type, parent_type)) {
-				files.push_back(file.substr(6, file.length()));
+				if (!skip_addons || !file.substr(6).begins_with(addons_directory + "/")) {
+					files.push_back(file.substr(6));
+				}
 
 				// Store refs to used icons.
 				String ext = file.get_extension();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -516,6 +516,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// File dialog
 	_initial_set("filesystem/file_dialog/show_hidden_files", false);
+	_initial_set("filesystem/file_dialog/quick_open_exclude_addons", false);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "filesystem/file_dialog/display_mode", 0, "Thumbnails,List")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/file_dialog/thumbnail_size", 64, "32,128,16")
 


### PR DESCRIPTION
One of the features requested in https://github.com/godotengine/godot-proposals/issues/25.
A video with the feature working in 3.3:

https://user-images.githubusercontent.com/29497869/113396134-49110c00-939b-11eb-8230-f7e4698d2ab6.mp4



<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
