### PR TITLE
Fix crash caused by null parameter passed to CameraServer.add_feed()

### DIFF
--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -99,6 +99,8 @@ Ref<CameraFeed> CameraServer::get_feed_by_id(int p_id) {
 };
 
 void CameraServer::add_feed(const Ref<CameraFeed> &p_feed) {
+	ERR_FAIL_COND(p_feed.is_null());
+
 	// add our feed
 	feeds.push_back(p_feed);
 


### PR DESCRIPTION
Fixes #46181

CameraServer.add_feed() takes a CameraFeed object type as parameter.
Passing in another type of data while binding the method it will make
that parameter null.
Added a check for null which returns from function and does not make the
engine crash anymore.

Important note: the issue was for 3.x but I noticed in master this is also the case 
and I know that it's best to pull request to master and then cherry pick to 3.x 
(I will also do that one if this is merged). I was not able to test on master because 
I can't run the engine compiled for master for some reason but the change is small 
enough to not affect it in a bad way even if the issue is not reproducible in 4.0 
(if someone could confirm the issue is still present there, that would be great). 