### PR TITLE
[3.x] Add ability to automatically choose a joystick button or axis...

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1743,9 +1743,12 @@ void ProjectSettingsEditor::_joypad_capture_timeout() {
 		for (int i = 0; i < JOY_AXIS_MAX; i++) {
 			float axisValue = Input::get_singleton()->get_joy_axis(_get_current_device(), i);
 			if (ABS(axisValue - _last_axis_reading[i]) > 0.1f) {
-				if (axisValue < -0.75f) {
+				// Only choose the axis if it has been pushed almost all the way through.
+				const float axis_threshold = 0.75;
+				
+				if (axisValue < -axis_threshold) {
 					device_index->select(i * 2);
-				} else if (axisValue > 0.75f) {
+				} else if (axisValue > axis_threshold) {
 					device_index->select(i * 2 + 1);
 				}
 			}

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1743,9 +1743,11 @@ void ProjectSettingsEditor::_joypad_capture_timeout() {
 		for (int i = 0; i < JOY_AXIS_MAX; i++) {
 			float axisValue = Input::get_singleton()->get_joy_axis(_get_current_device(), i);
 			if (ABS(axisValue - _last_axis_reading[i]) > 0.1f) {
-				if (axisValue < -0.75f) {
+				// Only choose the axis if it has been pushed almost all the way through.
+				const float axis_threshold = 0.75;
+				if (axisValue < -axis_threshold) {
 					device_index->select(i * 2);
-				} else if (axisValue > 0.75f) {
+				} else if (axisValue > axis_threshold) {
 					device_index->select(i * 2 + 1);
 				}
 			}

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -124,6 +124,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _action_adds(String);
 	void _action_add();
 	void _device_input_add();
+	void _device_input_cancel();
 
 	void _item_checked(const String &p_item, bool p_check);
 	void _action_selected();
@@ -178,6 +179,11 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _editor_restart_request();
 	void _editor_restart();
 	void _editor_restart_close();
+
+	Timer *joypad_capture_timer;
+	void _joypad_capture_timeout();
+	CheckButton *capture_button;
+	void _capture_button_toggled(bool pressed);
 
 protected:
 	void _unhandled_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
... when modifying a project's input settings

![image](https://user-images.githubusercontent.com/2986044/113438765-3a385280-93b7-11eb-8a47-2a1079caf397.png)

If you click the CheckButton "capture", you can then wiggle a joystick (or press a button) and the selection will automatically change to that axis (or button).