### PR TITLE
Fix crash on null object in ClassDB.get_property() and set_property() (Fix #47573)

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1095,6 +1095,8 @@ bool ClassDB::get_property_info(StringName p_class, StringName p_property, Prope
 }
 
 bool ClassDB::set_property(Object *p_object, const StringName &p_property, const Variant &p_value, bool *r_valid) {
+	ERR_FAIL_NULL_V(p_object, false);
+
 	ClassInfo *type = classes.getptr(p_object->get_class_name());
 	ClassInfo *check = type;
 	while (check) {
@@ -1142,6 +1144,8 @@ bool ClassDB::set_property(Object *p_object, const StringName &p_property, const
 }
 
 bool ClassDB::get_property(Object *p_object, const StringName &p_property, Variant &r_value) {
+	ERR_FAIL_NULL_V(p_object, false);
+
 	ClassInfo *type = classes.getptr(p_object->get_class_name());
 	ClassInfo *check = type;
 	while (check) {


### PR DESCRIPTION
Fix #47573

### Issue fixed : 

Crash on 
ClassDB.class_get_property(null,"") or ClassDB.class_set_property(null,"","")

### Fix proposal : 

Adding ERR_FAIL_NULL_V check in  ClassDB::set_property() and ClassDB::get_property()