### PR TITLE
Port code examples to C# (V)

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -33,8 +33,8 @@
 		[/gdscript]
 		[csharp]
 		// Array concatenation is not possible with C# arrays, but is with Godot.Collections.Array.
-		var array1 = new Godot.Collections.Array("One", 2);
-		var array2 = new Godot.Collections.Array(3, "Four");
+		var array1 = new Godot.Collections.Array{"One", 2};
+		var array2 = new Godot.Collections.Array{3, "Four"};
 		GD.Print(array1 + array2); // Prints [One, 2, 3, Four]
 		[/csharp]
 		[/codeblocks]
@@ -294,14 +294,14 @@
 				[gdscript]
 				# Will evaluate to `true`.
 				if 2 in [2, 4, 6, 8]:
-				    print("Containes!")
+				    print("Contains!")
 				[/gdscript]
 				[csharp]
 				// As there is no "in" keyword in C#, you have to use Contains
 				var array = new Godot.Collections.Array{2, 4, 6, 8};
 				if (array.Contains(2))
 				{
-				    GD.Print("Containes!");
+				    GD.Print("Contains!");
 				}
 				[/csharp]
 				[/codeblocks]

--- a/doc/classes/Variant.xml
+++ b/doc/classes/Variant.xml
@@ -5,20 +5,30 @@
 	</brief_description>
 	<description>
 		In computer programming, a Variant class is a class that is designed to store a variety of other types. Dynamic programming languages like PHP, Lua, JavaScript and GDScript like to use them to store variables' data on the backend. With these Variants, properties are able to change value types freely.
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var foo = 2 # foo is dynamically an integer
 		foo = "Now foo is a string!"
 		foo = Reference.new() # foo is an Object
 		var bar: int = 2 # bar is a statically typed integer.
 		# bar = "Uh oh! I can't make static variables become a different type!"
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		// ... but C# is statically typed. Once a variable has a type it cannot be changed. However you can use the var keyword in methods to let the compiler decide the type automatically.
+		var foo = 2; // Foo is a 32-bit integer (int). Be cautious, integers in GDScript are 64-bit and the direct C# equivalent is "long".
+		// foo = "foo was and will always be an integer. It cannot be turned into a string!";
+		var boo = "Boo is a string!";
+		var ref = new Reference(); // var is especially useful when used together with a constructor.
+		[/csharp]
+		[/codeblocks]
 		Godot tracks all scripting API variables within Variants. Without even realizing it, you use Variants all the time. When a particular language enforces its own rules for keeping data typed, then that language is applying its own custom logic over the base Variant scripting API.
 		- GDScript automatically wrap values in them. It keeps all data in plain Variants by default and then optionally enforces custom static typing rules on variable types.
 		- VisualScript tracks properties inside Variants as well, but it also uses static typing. The GUI interface enforces that properties have a particular type that doesn't change over time.
 		- C# is statically typed, but uses the Mono [code]object[/code] type in place of Godot's Variant class when it needs to represent a dynamic value. [code]object[/code] is the Mono runtime's equivalent of the same concept.
 		- The statically-typed language NativeScript C++ does not define a built-in Variant-like class. Godot's GDNative bindings provide their own godot::Variant class for users; Any point at which the C++ code starts interacting with the Godot runtime is a place where you might have to start wrapping data inside Variant objects.
 		The global [method @GlobalScope.typeof] function returns the enumerated value of the Variant type stored in the current variable (see [enum Variant.Type]).
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var foo = 2
 		match typeof(foo):
 		    TYPE_NIL:
@@ -32,7 +42,19 @@
 		        # Note also that there is not yet any way to get a script's `class_name` string easily.
 		        # To fetch that value, you need to dig deeply into a hidden ProjectSettings setting: an Array of Dictionaries called "_global_script_classes".
 		        # Open your project.godot file to see it up close.
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		int foo = 2;
+		if (foo == null)
+		{
+		    GD.Print("foo is null");
+		}
+		if (foo is int)
+		{
+		    GD.Print("foo is an integer");
+		}
+		[/csharp]
+		[/codeblocks]
 		A Variant takes up only 20 bytes and can store almost any engine datatype inside of it. Variants are rarely used to hold information for long periods of time. Instead, they are used mainly for communication, editing, serialization and moving data around.
 		Godot has specifically invested in making its Variant class as flexible as possible; so much so that it is used for a multitude of operations to facilitate communication between all of Godot's systems.
 		A Variant:

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -81,10 +81,16 @@
 			<description>
 				Returns the viewport's texture.
 				[b]Note:[/b] Due to the way OpenGL works, the resulting [ViewportTexture] is flipped vertically. You can use [method Image.flip_y] on the result of [method Texture2D.get_image] to flip it back, for example:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var img = get_viewport().get_texture().get_image()
 				img.flip_y()
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Image img = GetViewport().GetTexture().GetImage();
+				img.FlipY();
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_viewport_rid" qualifiers="const">


### PR DESCRIPTION
Includes:
 * Variant
 * Viewport

and two fixes in Array that were pointed out in #40978
VisualScript classes are skipped on purpose.
That is the final commit of the inital code porting to C#. 🥳 

I am unsure about the Variant codeblocks. The first one would always be `Uh oh!` and the second idk. Is that possbile? I know that C# has good reflection, but I guess it doesn't use the Godot Variant.
`Object.get_class()`doesn't seem to exist in C#.