### PR TITLE
Fix crash caused by null parameter passed to CameraServer.add_feed()

### DIFF
--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -99,6 +99,8 @@ Ref<CameraFeed> CameraServer::get_feed_by_id(int p_id) {
 };
 
 void CameraServer::add_feed(const Ref<CameraFeed> &p_feed) {
+	ERR_FAIL_COND(p_feed.is_null());
+
 	// add our feed
 	feeds.push_back(p_feed);
 


### PR DESCRIPTION
Fixes #46181

CameraServer.add_feed() takes a CameraFeed object type as parameter.
Passing in another type of data while binding the method it will make
tha parameter null.
Added a check for null which returns from function and does not make the
engine crash anymore.

(cherry picked from commit c158a63a8af668eac20ed303b1f8c02b6831a983)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
