### PR TITLE
Fix Camera2D's editor rectangles flicker

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -290,7 +290,15 @@ void Camera2D::_notification(int p_what) {
 				Transform2D inv_transform = get_global_transform().affine_inverse(); // undo global space
 
 				for (int i = 0; i < 4; i++) {
-					draw_line(inv_transform.xform(screen_endpoints[i]), inv_transform.xform(screen_endpoints[(i + 1) % 4]), area_axis_color, area_axis_width);
+					Vector2 from = inv_transform.xform(screen_endpoints[i]);
+					Vector2 to = inv_transform.xform(screen_endpoints[(i + 1) % 4]);
+
+					draw_line(from, to, area_axis_color, area_axis_width);
+
+					// Draw an extra rectangle with line width as one to handle flicker when zoomed out.
+					if (is_current()) {
+						draw_line(from, to, area_axis_color, 1);
+					}
 				}
 			}
 
@@ -313,6 +321,11 @@ void Camera2D::_notification(int p_what) {
 
 				for (int i = 0; i < 4; i++) {
 					draw_line(limit_points[i], limit_points[(i + 1) % 4], limit_drawing_color, limit_drawing_width);
+
+					// Draw an extra rectangle with line width as one to handle flicker when zoomed out.
+					if (is_current()) {
+						draw_line(limit_points[i], limit_points[(i + 1) % 4], limit_drawing_color, 1);
+					}
 				}
 			}
 
@@ -337,7 +350,15 @@ void Camera2D::_notification(int p_what) {
 				Transform2D inv_transform = get_global_transform().affine_inverse(); // undo global space
 
 				for (int i = 0; i < 4; i++) {
-					draw_line(inv_transform.xform(margin_endpoints[i]), inv_transform.xform(margin_endpoints[(i + 1) % 4]), margin_drawing_color, margin_drawing_width);
+					Vector2 from = inv_transform.xform(margin_endpoints[i]);
+					Vector2 to = inv_transform.xform(margin_endpoints[(i + 1) % 4]);
+
+					draw_line(from, to, margin_drawing_color, margin_drawing_width);
+
+					// Draw an extra rectangle with line width as one to handle flicker when zoomed out.
+					if (is_current()) {
+						draw_line(from, to, margin_drawing_color, 3);
+					}
 				}
 			}
 		} break;


### PR DESCRIPTION
Fixes #47542. Except for the screen rectangle, the flicker also happens to the limits rectangle and margin rectangle. The solution is to simply set the line width to one even when the camera is set current. The color contrast between the rectangles at the current and non-current state is increased a bit to compensate the loss of the line width difference. This PR can act as a makeshift solution before some changes are done to the rendering backend about how lines are drawn.

Before:

![camera2d_outline_before](https://user-images.githubusercontent.com/28705694/113472818-21539e00-9498-11eb-9b75-f83a477e18dc.gif)

After:

![camera2d_outline_after](https://user-images.githubusercontent.com/28705694/113472810-1a2c9000-9498-11eb-80c5-de4dd832b542.gif)