### PR TITLE
Batching - flip normal map polarity for rects

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -2121,11 +2121,11 @@ bool C_PREAMBLE::_prefill_rect(RasterizerCanvas::Item::CommandRect *rect, FillSt
 
 			// apply to an x axis
 			// the x axis and y axis can be taken directly from the transform (no need to xform identity vectors)
-			Vector2 x_axis(tr.elements[0][0], tr.elements[1][0]);
+			Vector2 x_axis(tr.elements[0][0], tr.elements[0][1]);
 
 			// have to do a y axis to check for scaling flips
 			// this is hassle and extra slowness. We could only allow flips via the flags.
-			Vector2 y_axis(tr.elements[0][1], tr.elements[1][1]);
+			Vector2 y_axis(tr.elements[1][0], tr.elements[1][1]);
 
 			// has the x / y axis flipped due to scaling?
 			float cross = x_axis.cross(y_axis);


### PR DESCRIPTION
An earlier PR #46898 had flipped the rotation basis polarity. This turns out to also need a corresponding flip for the light angles for the lighting to make sense.

Fixes #47276

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
