### PR TITLE
Fix VisualScriptFunctionState connect to null object crash (Fix #47572)

### DIFF
--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2252,6 +2252,7 @@ Variant VisualScriptFunctionState::_signal_callback(const Variant **p_args, int 
 }
 
 void VisualScriptFunctionState::connect_to_signal(Object *p_obj, const String &p_signal, Array p_binds) {
+	ERR_FAIL_NULL(p_obj);
 	Vector<Variant> binds;
 	for (int i = 0; i < p_binds.size(); i++) {
 		binds.push_back(p_binds[i]);


### PR DESCRIPTION
Fix #47572 

### Issue fixed :

Crash executing ```VisualScriptFunctionState.new().connect_to_signal(null,".",[])```

### Fix proposal : 

Adding a ```ERR_FAIL_NULL()``` check on object parameter in ```VisualScriptFunctionState::connect_to_signal()```