### PR TITLE
Fixed Editor Shortcuts revert/edit/clear buttons performing the wrong action

### DIFF
--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -391,9 +391,10 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
+	button_idx = p_idx;
+
 	if (ti->get_metadata(0) == "Common") {
 		// Editing a Built-in action, which can have multiple bindings.
-		button_idx = p_idx;
 		editing_action = true;
 		current_action = ti->get_text(0);
 


### PR DESCRIPTION
For shortcuts not in the 'Common' section, the wrong action was being executed. Fixes part of #47594

Fixes #47743