### PR TITLE
[HTML5] Disable body_size in fetch.

### DIFF
--- a/platform/javascript/js/engine/preloader.js
+++ b/platform/javascript/js/engine/preloader.js
@@ -1,22 +1,5 @@
 const Preloader = /** @constructor */ function () { // eslint-disable-line no-unused-vars
 	function getTrackedResponse(response, load_status) {
-		let clen = 0;
-		let compressed = false;
-		response.headers.forEach(function (value, header) {
-			const h = header.toLowerCase().trim();
-			// We can't accurately compute compressed stream length.
-			if (h === 'content-encoding') {
-				compressed = true;
-			} else if (h === 'content-length') {
-				const length = parseInt(value, 10);
-				if (!Number.isNaN(length) && length > 0) {
-					clen = length;
-				}
-			}
-		});
-		if (!compressed && clen) {
-			load_status.total = clen;
-		}
 		function onloadprogress(reader, controller) {
 			return reader.read().then(function (result) {
 				if (load_status.done) {

--- a/platform/javascript/js/libs/library_godot_fetch.js
+++ b/platform/javascript/js/libs/library_godot_fetch.js
@@ -49,25 +49,14 @@ const GodotFetch = {
 			if (!obj) {
 				return;
 			}
-			let size = -1;
-			let compressed = false;
 			let chunked = false;
 			response.headers.forEach(function (value, header) {
 				const v = value.toLowerCase().trim();
 				const h = header.toLowerCase().trim();
-				if (h === 'content-encoding') {
-					compressed = true;
-					size = -1;
-				} else if (h === 'content-length') {
-					const len = Number.parseInt(value, 10);
-					if (!Number.isNaN(len) && !compressed) {
-						size = len;
-					}
-				} else if (h === 'transfer-encoding' && v === 'chunked') {
+				if (h === 'transfer-encoding' && v === 'chunked') {
 					chunked = true;
 				}
 			});
-			obj.bodySize = size;
 			obj.status = response.status;
 			obj.response = response;
 			obj.reader = response.body.getReader();


### PR DESCRIPTION
We were using `Content-Length` from the server when `Content-Encoding`
was not set (i.e. response was not compressed).

Sadly, in CORS requests accessing headers is restricted, and while
`Content-Length` is enabled by default, `Content-Encoding` is not.

This results in the impossibility of knowing if the content was
compressed, unless the server explicitly enabled the encoding header
via `Access-Control-Expose-Headers`.

To keep maximum compatibility we must disable `body_size` completely.

Fixes https://github.com/heroiclabs/nakama-godot/issues/66

Allowed headers: https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header