### PR TITLE
Separate underscore from grapheme punctuation to enable doubleclick and caret jump over snakecase variables in editor

### DIFF
--- a/modules/gdnative/include/text/godot_text.h
+++ b/modules/gdnative/include/text/godot_text.h
@@ -150,7 +150,7 @@ typedef struct {
 	godot_packed_glyph_array (*shaped_text_sort_logical)(void *, godot_rid *);
 	godot_packed_vector2i_array (*shaped_text_get_line_breaks_adv)(void *, godot_rid *, godot_packed_float32_array *, int, bool, uint8_t);
 	godot_packed_vector2i_array (*shaped_text_get_line_breaks)(void *, godot_rid *, float, int, uint8_t);
-	godot_packed_vector2i_array (*shaped_text_get_word_breaks)(void *, godot_rid *);
+	godot_packed_vector2i_array (*shaped_text_get_word_breaks)(void *, godot_rid *, int);
 	godot_array (*shaped_text_get_objects)(void *, godot_rid *);
 	godot_rect2 (*shaped_text_get_object_rect)(void *, godot_rid *, const godot_variant *);
 	godot_vector2 (*shaped_text_get_size)(void *, godot_rid *);

--- a/modules/gdnative/text/text_server_gdnative.cpp
+++ b/modules/gdnative/text/text_server_gdnative.cpp
@@ -555,15 +555,15 @@ Vector<Vector2i> TextServerGDNative::shaped_text_get_line_breaks(RID p_shaped, f
 	}
 }
 
-Vector<Vector2i> TextServerGDNative::shaped_text_get_word_breaks(RID p_shaped) const {
+Vector<Vector2i> TextServerGDNative::shaped_text_get_word_breaks(RID p_shaped, int p_grapheme_flags) const {
 	ERR_FAIL_COND_V(interface == nullptr, Vector<Vector2i>());
 	if (interface->shaped_text_get_word_breaks != nullptr) {
-		godot_packed_vector2i_array result = interface->shaped_text_get_word_breaks(data, (godot_rid *)&p_shaped);
+		godot_packed_vector2i_array result = interface->shaped_text_get_word_breaks(data, (godot_rid *)&p_shaped, p_grapheme_flags);
 		Vector<Vector2i> breaks = *(Vector<Vector2i> *)&result;
 		godot_packed_vector2i_array_destroy(&result);
 		return breaks;
 	} else {
-		return TextServer::shaped_text_get_word_breaks(p_shaped);
+		return TextServer::shaped_text_get_word_breaks(p_shaped, p_grapheme_flags);
 	}
 }
 

--- a/modules/gdnative/text/text_server_gdnative.h
+++ b/modules/gdnative/text/text_server_gdnative.h
@@ -178,7 +178,7 @@ public:
 	virtual Vector<Glyph> shaped_text_sort_logical(RID p_shaped) override;
 	virtual Vector<Vector2i> shaped_text_get_line_breaks_adv(RID p_shaped, const Vector<float> &p_width, int p_start = 0, bool p_once = true, uint8_t /*TextBreakFlag*/ p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const override;
 	virtual Vector<Vector2i> shaped_text_get_line_breaks(RID p_shaped, float p_width, int p_start = 0, uint8_t p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const override;
-	virtual Vector<Vector2i> shaped_text_get_word_breaks(RID p_shaped) const override;
+	virtual Vector<Vector2i> shaped_text_get_word_breaks(RID p_shaped, int p_grapheme_flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION) const override;
 	virtual Array shaped_text_get_objects(RID p_shaped) const override;
 	virtual Rect2 shaped_text_get_object_rect(RID p_shaped, Variant p_key) const override;
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -129,6 +129,10 @@ _FORCE_INLINE_ bool is_linebreak(char32_t p_char) {
 	return (p_char >= 0x000a && p_char <= 0x000d) || (p_char == 0x0085) || (p_char == 0x2028) || (p_char == 0x2029);
 }
 
+_FORCE_INLINE_ bool is_underscore(char32_t p_char) {
+	return (p_char == 0x005F);
+}
+
 /*************************************************************************/
 
 String TextServerAdvanced::interface_name = "ICU / HarfBuzz / Graphite";
@@ -1883,7 +1887,10 @@ bool TextServerAdvanced::shaped_text_update_breaks(RID p_shaped) {
 			if (is_whitespace(c)) {
 				sd_glyphs[i].flags |= GRAPHEME_IS_SPACE;
 			}
-			if (u_ispunct(c)) {
+			if (is_underscore(c)) {
+				sd_glyphs[i].flags |= GRAPHEME_IS_UNDERSCORE;
+			}
+			if (u_ispunct(c) && c != 0x005F) {
 				sd_glyphs[i].flags |= GRAPHEME_IS_PUNCTUATION;
 			}
 			if (breaks.has(sd->glyphs[i].start)) {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -46,7 +46,11 @@ _FORCE_INLINE_ bool is_linebreak(char32_t p_char) {
 }
 
 _FORCE_INLINE_ bool is_punct(char32_t p_char) {
-	return (p_char >= 0x0020 && p_char <= 0x002F) || (p_char >= 0x003A && p_char <= 0x0040) || (p_char >= 0x005B && p_char <= 0x0060) || (p_char >= 0x007B && p_char <= 0x007E) || (p_char >= 0x2000 && p_char <= 0x206F) || (p_char >= 0x3000 && p_char <= 0x303F);
+	return (p_char >= 0x0020 && p_char <= 0x002F) || (p_char >= 0x003A && p_char <= 0x0040) || (p_char >= 0x005B && p_char <= 0x005E) || (p_char == 0x0060) || (p_char >= 0x007B && p_char <= 0x007E) || (p_char >= 0x2000 && p_char <= 0x206F) || (p_char >= 0x3000 && p_char <= 0x303F);
+}
+
+_FORCE_INLINE_ bool is_underscore(char32_t p_char) {
+	return (p_char == 0x005F);
 }
 
 /*************************************************************************/
@@ -1107,6 +1111,9 @@ bool TextServerFallback::shaped_text_update_breaks(RID p_shaped) {
 			char32_t c = sd->text[sd->glyphs[i].start];
 			if (is_punct(c)) {
 				sd->glyphs.write[i].flags |= GRAPHEME_IS_PUNCTUATION;
+			}
+			if (is_underscore(c)) {
+				sd->glyphs.write[i].flags |= GRAPHEME_IS_UNDERSCORE;
 			}
 			if (is_whitespace(c) && !is_linebreak(c)) {
 				sd->glyphs.write[i].flags |= GRAPHEME_IS_SPACE;

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -712,7 +712,7 @@ Vector<Vector2i> TextServer::shaped_text_get_line_breaks(RID p_shaped, float p_w
 	return lines;
 }
 
-Vector<Vector2i> TextServer::shaped_text_get_word_breaks(RID p_shaped) const {
+Vector<Vector2i> TextServer::shaped_text_get_word_breaks(RID p_shaped, int p_grapheme_flags) const {
 	Vector<Vector2i> words;
 
 	const_cast<TextServer *>(this)->shaped_text_update_justification_ops(p_shaped);
@@ -726,7 +726,7 @@ Vector<Vector2i> TextServer::shaped_text_get_word_breaks(RID p_shaped) const {
 
 	for (int i = 0; i < l_size; i++) {
 		if (l_gl[i].count > 0) {
-			if (((l_gl[i].flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE) || ((l_gl[i].flags & GRAPHEME_IS_PUNCTUATION) == GRAPHEME_IS_PUNCTUATION)) {
+			if ((l_gl[i].flags & p_grapheme_flags) != 0) {
 				words.push_back(Vector2i(word_start, l_gl[i].start));
 				word_start = l_gl[i].end;
 			}

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -87,7 +87,8 @@ public:
 		GRAPHEME_IS_BREAK_SOFT = 1 << 5, // Is line break (optional break, e.g. space).
 		GRAPHEME_IS_TAB = 1 << 6, // Is tab or vertical tab.
 		GRAPHEME_IS_ELONGATION = 1 << 7, // Elongation (e.g. kashida), glyph can be duplicated or truncated to fit line to width.
-		GRAPHEME_IS_PUNCTUATION = 1 << 8 // Punctuation (can be used as word break, but not line break or justifiction).
+		GRAPHEME_IS_PUNCTUATION = 1 << 8, // Punctuation, except underscore (can be used as word break, but not line break or justifiction).
+		GRAPHEME_IS_UNDERSCORE = 1 << 9, // Underscore (can be used as word break).
 	};
 
 	enum Hinting {
@@ -354,10 +355,9 @@ public:
 
 	virtual Vector<Vector2i> shaped_text_get_line_breaks_adv(RID p_shaped, const Vector<float> &p_width, int p_start = 0, bool p_once = true, uint8_t /*TextBreakFlag*/ p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const;
 	virtual Vector<Vector2i> shaped_text_get_line_breaks(RID p_shaped, float p_width, int p_start = 0, uint8_t /*TextBreakFlag*/ p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const;
-	virtual Vector<Vector2i> shaped_text_get_word_breaks(RID p_shaped) const;
+	virtual Vector<Vector2i> shaped_text_get_word_breaks(RID p_shaped, int p_grapheme_flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION) const;
 
 	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint8_t p_clip_flags) = 0;
-
 	virtual Array shaped_text_get_objects(RID p_shaped) const = 0;
 	virtual Rect2 shaped_text_get_object_rect(RID p_shaped, Variant p_key) const = 0;
 


### PR DESCRIPTION
Separate underscore from grapheme punctuation to enable doubleclick and caret jump over snakecase variables in editor.

I noticed that due to commit 06ae77a the method "shaped_text_get_word_breaks" now breaks on underscores (aka _ ), which means that a doubleclick on the editor window on a snake_case variable with_underscores_like_this will only select part of it (word by word split by the underscores) instead of the whole variable. The same thing also happens on ctrl+arrows to move the caret right or left. This is different from how godot 3.2, VSCode and other IDEs handle snake_case doubleclick and caret movement.

I mentioned this in 46524 and also patched my fork of godot with this code to have it do what I expected: to select the entire snake_case variables with doubleclick and skip the entire variable on ctrl+arrow by splitting underscores from the GRAPHEME_IS_PUNCTUATION logic, and created a new enum entry GRAPHEME_IS_UNDERSCORE and added this as a parameter to shaped_text_get_word_breaks so that the method can be reused if someone wishes for a different logic.

Hopefully this is good enough for the master godot repository, but I am happy to know if a different solution is better. 


*Bugsquad edit:* Fixes #46456, fixes #46380.