### PR TITLE
Prevents TextureUniform in visual shaders from conversion to constant

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2627,7 +2627,7 @@ void VisualShaderEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 						selected_constants.insert(id);
 					}
 					VisualShaderNodeUniform *uniform_node = Object::cast_to<VisualShaderNodeUniform>(node.ptr());
-					if (uniform_node != nullptr) {
+					if (uniform_node != nullptr && uniform_node->is_convertible_to_constant()) {
 						selected_uniforms.insert(id);
 					}
 				}

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -421,6 +421,7 @@ public:
 	bool is_global_code_generated() const;
 
 	virtual bool is_qualifier_supported(Qualifier p_qual) const = 0;
+	virtual bool is_convertible_to_constant() const = 0;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 	virtual String get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const override;

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -3744,6 +3744,10 @@ bool VisualShaderNodeFloatUniform::is_qualifier_supported(Qualifier p_qual) cons
 	return true; // all qualifiers are supported
 }
 
+bool VisualShaderNodeFloatUniform::is_convertible_to_constant() const {
+	return true; // conversion is allowed
+}
+
 Vector<StringName> VisualShaderNodeFloatUniform::get_editable_properties() const {
 	Vector<StringName> props = VisualShaderNodeUniform::get_editable_properties();
 	props.push_back("hint");
@@ -3911,6 +3915,10 @@ bool VisualShaderNodeIntUniform::is_qualifier_supported(Qualifier p_qual) const 
 	return true; // all qualifiers are supported
 }
 
+bool VisualShaderNodeIntUniform::is_convertible_to_constant() const {
+	return true; // conversion is allowed
+}
+
 Vector<StringName> VisualShaderNodeIntUniform::get_editable_properties() const {
 	Vector<StringName> props = VisualShaderNodeUniform::get_editable_properties();
 	props.push_back("hint");
@@ -4019,6 +4027,10 @@ bool VisualShaderNodeBooleanUniform::is_qualifier_supported(Qualifier p_qual) co
 	return true; // all qualifiers are supported
 }
 
+bool VisualShaderNodeBooleanUniform::is_convertible_to_constant() const {
+	return true; // conversion is allowed
+}
+
 Vector<StringName> VisualShaderNodeBooleanUniform::get_editable_properties() const {
 	Vector<StringName> props = VisualShaderNodeUniform::get_editable_properties();
 	props.push_back("default_value_enabled");
@@ -4111,6 +4123,10 @@ void VisualShaderNodeColorUniform::_bind_methods() {
 
 bool VisualShaderNodeColorUniform::is_qualifier_supported(Qualifier p_qual) const {
 	return true; // all qualifiers are supported
+}
+
+bool VisualShaderNodeColorUniform::is_convertible_to_constant() const {
+	return true; // conversion is allowed
 }
 
 Vector<StringName> VisualShaderNodeColorUniform::get_editable_properties() const {
@@ -4207,6 +4223,10 @@ bool VisualShaderNodeVec3Uniform::is_use_prop_slots() const {
 
 bool VisualShaderNodeVec3Uniform::is_qualifier_supported(Qualifier p_qual) const {
 	return true; // all qualifiers are supported
+}
+
+bool VisualShaderNodeVec3Uniform::is_convertible_to_constant() const {
+	return true; // conversion is allowed
 }
 
 Vector<StringName> VisualShaderNodeVec3Uniform::get_editable_properties() const {
@@ -4307,6 +4327,10 @@ bool VisualShaderNodeTransformUniform::is_use_prop_slots() const {
 
 bool VisualShaderNodeTransformUniform::is_qualifier_supported(Qualifier p_qual) const {
 	return true; // all qualifiers are supported
+}
+
+bool VisualShaderNodeTransformUniform::is_convertible_to_constant() const {
+	return true; // conversion is allowed
 }
 
 Vector<StringName> VisualShaderNodeTransformUniform::get_editable_properties() const {
@@ -4492,6 +4516,10 @@ bool VisualShaderNodeTextureUniform::is_qualifier_supported(Qualifier p_qual) co
 			return false;
 	}
 	return false;
+}
+
+bool VisualShaderNodeTextureUniform::is_convertible_to_constant() const {
+	return false; // conversion is not allowed
 }
 
 VisualShaderNodeTextureUniform::VisualShaderNodeTextureUniform() {

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1574,6 +1574,7 @@ public:
 	float get_default_value() const;
 
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+	bool is_convertible_to_constant() const override;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 
@@ -1639,6 +1640,7 @@ public:
 	int get_default_value() const;
 
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+	bool is_convertible_to_constant() const override;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 
@@ -1683,6 +1685,7 @@ public:
 	bool get_default_value() const;
 
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+	bool is_convertible_to_constant() const override;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 
@@ -1724,6 +1727,7 @@ public:
 	Color get_default_value() const;
 
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+	bool is_convertible_to_constant() const override;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 
@@ -1766,6 +1770,7 @@ public:
 	Vector3 get_default_value() const;
 
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+	bool is_convertible_to_constant() const override;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 
@@ -1808,6 +1813,7 @@ public:
 	Transform get_default_value() const;
 
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+	bool is_convertible_to_constant() const override;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 
@@ -1865,6 +1871,7 @@ public:
 	ColorDefault get_color_default() const;
 
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+	bool is_convertible_to_constant() const override;
 
 	VisualShaderNodeTextureUniform();
 };


### PR DESCRIPTION
I think It's meaningless since texture uniform cannot be transformed to constant in any way, and currently, it throws an error.

This change just removes this option from that menu (for that node and all its derivatives):
![image](https://user-images.githubusercontent.com/3036176/113508298-e6b13a80-9557-11eb-90a9-262863ed0164.png)
