### PR TITLE
Use Option+Cmd+Left/Right for script editor history navigation on macOS

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3402,8 +3402,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/show_in_file_system", TTR("Show in FileSystem")), SHOW_IN_FILE_SYSTEM);
 	file_menu->get_popup()->add_separator();
 
+#ifdef APPLE_STYLE_KEYS
+	// Alt + Left/Alt + Right conflict with TextEdit shortcuts on macOS, so we have to use different keys by default.
+	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/history_previous", TTR("History Previous"), KEY_MASK_ALT | KEY_MASK_META | KEY_LEFT), WINDOW_PREV);
+	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/history_next", TTR("History Next"), KEY_MASK_ALT | KEY_MASK_META | KEY_RIGHT), WINDOW_NEXT);
+#else
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/history_previous", TTR("History Previous"), KEY_MASK_ALT | KEY_LEFT), WINDOW_PREV);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/history_next", TTR("History Next"), KEY_MASK_ALT | KEY_RIGHT), WINDOW_NEXT);
+#endif
 	file_menu->get_popup()->add_separator();
 
 	file_menu->get_popup()->add_submenu_item(TTR("Theme"), "Theme", FILE_THEME);


### PR DESCRIPTION
The default shortcuts were conflicting with TextEdit shortcuts on macOS.

**Note that I haven't tested this.** I'd like someone on macOS to test this to make sure it works as expected.

This can be trivially cherry-picked to the `3.x` branch.

This closes https://github.com/godotengine/godot/issues/44858.