### PR TITLE
Expose editor scale to the plugin API

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -48,6 +48,14 @@
 				[b]Note:[/b] This returns the main editor control containing the whole editor, not the 2D or 3D viewports specifically.
 			</description>
 		</method>
+		<method name="get_editor_scale" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				Returns the actual scale of the editor UI ([code]1.0[/code] being 100% scale). This can be used to adjust position and dimensions of the UI added by plugins.
+				[b]Note:[/b] This value is set via the [code]interface/editor/display_scale[/code] and [code]interface/editor/custom_display_scale[/code] editor settings. Editor must be restarted for changes to be properly applied.
+			</description>
+		</method>
 		<method name="get_editor_settings">
 			<return type="EditorSettings">
 			</return>

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -262,6 +262,10 @@ Control *EditorInterface::get_base_control() {
 	return EditorNode::get_singleton()->get_gui_base();
 }
 
+float EditorInterface::get_editor_scale() const {
+	return EDSCALE;
+}
+
 void EditorInterface::set_plugin_enabled(const String &p_plugin, bool p_enabled) {
 	EditorNode::get_singleton()->set_addon_plugin_enabled(p_plugin, p_enabled, true);
 }
@@ -306,6 +310,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
 	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);
 	ClassDB::bind_method(D_METHOD("get_base_control"), &EditorInterface::get_base_control);
+	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
 	ClassDB::bind_method(D_METHOD("edit_resource", "resource"), &EditorInterface::edit_resource);
 	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath"), &EditorInterface::open_scene_from_path);
 	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -100,6 +100,7 @@ public:
 	FileSystemDock *get_file_system_dock();
 
 	Control *get_base_control();
+	float get_editor_scale() const;
 
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;


### PR DESCRIPTION
Based on feedback from plugin developers it seems that it's a requirement to have access to the actual scale value to make consistent and good looking plugin UI. While it is possible to read the setting, when it's set to `Auto` values are calculated internally in a way that is not accessible to the scripting API. This exposes a method that gives direct access to reading `EDSCALE` value.

It's a method and not a property because, AFAIK, we cannot do readonly properties currently and setting this value is definitely not something that can be exposed either.