### PR TITLE
Fix error in the console: `double free or corruption (!prev)` at exit of GDnative C++ application

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1759,6 +1759,8 @@ void NativeScriptLanguage::unregister_script(NativeScript *script) {
 						C->get().destroy_func.free_func(C->get().destroy_func.method_data);
 					}
 				}
+
+				library_classes.erase(script->lib_path);
 			}
 
 			Map<String, Ref<GDNative>>::Element *G = library_gdnatives.find(script->lib_path);


### PR DESCRIPTION
Should resolve #47607.

