### PR TITLE
Fix GDScript variables addresses getting mixed

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -778,6 +778,10 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							gen->pop_temporary();
 						}
 					}
+
+					if (operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						gen->pop_temporary();
+					}
 				} break;
 				default: {
 					GDScriptCodeGenerator::Address left_operand = _parse_expression(codegen, r_error, binary->left_operand);


### PR DESCRIPTION
Fix a GDScript bug where different variables' addresses get the same value (#47603).

When trying to parse the expression `if node is Node2D:`, an unexpected shift in variable address happen which results in var i and var j to share the same address.
Adding the missing `pop_temporary` code block for GDScriptCodeGenerator::Address operand (l. 765) fix this unexpected shift.


*Bugsquad edit:* Fixes #47603.