### PR TITLE
Fix misformatted documentation from recent PRs

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -328,13 +328,6 @@
 				[b]Note:[/b] On large arrays, this method will be slower if the inserted element is close to the beginning of the array (index 0). This is because all elements placed after the newly inserted element have to be reindexed.
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -472,6 +465,13 @@
 			</argument>
 			<description>
 				Resizes the array to contain a different number of elements. If the array size is smaller, elements are cleared, if bigger, new elements are [code]null[/code].
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="rfind" qualifiers="const">

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -128,6 +128,16 @@
 				Will regenerate normal maps for the [ArrayMesh].
 			</description>
 		</method>
+		<method name="set_blend_shape_name">
+			<return type="void">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<argument index="1" name="name" type="StringName">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="surface_find_by_name" qualifiers="const">
 			<return type="int">
 			</return>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -157,13 +157,6 @@
 				Inserts a new element at a given position in the array. The position must be valid, or at the end of the array ([code]idx == size()[/code]).
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -228,6 +221,13 @@
 			</argument>
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -79,13 +79,6 @@
 				Inserts a new element at a given position in the array. The position must be valid, or at the end of the array ([code]idx == size()[/code]).
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -150,6 +143,13 @@
 			</argument>
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -80,13 +80,6 @@
 				Inserts a new element at a given position in the array. The position must be valid, or at the end of the array ([code]idx == size()[/code]).
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -143,6 +136,13 @@
 			</argument>
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -80,13 +80,6 @@
 				Inserts a new element at a given position in the array. The position must be valid, or at the end of the array ([code]idx == size()[/code]).
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -151,6 +144,13 @@
 			</argument>
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -80,13 +80,6 @@
 				Inserts a new integer at a given position in the array. The position must be valid, or at the end of the array ([code]idx == size()[/code]).
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -151,6 +144,13 @@
 			</argument>
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -80,13 +80,6 @@
 				Inserts a new integer at a given position in the array. The position must be valid, or at the end of the array ([code]idx == size()[/code]).
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -151,6 +144,13 @@
 			</argument>
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -80,13 +80,6 @@
 				Inserts a new element at a given position in the array. The position must be valid, or at the end of the array ([code]idx == size()[/code]).
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -151,6 +144,13 @@
 			</argument>
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -80,13 +80,6 @@
 				Inserts a new element at a given position in the array. The position must be valid, or at the end of the array ([code]idx == size()[/code]).
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -159,6 +152,13 @@
 			</argument>
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -79,13 +79,6 @@
 				Inserts a new element at a given position in the array. The position must be valid, or at the end of the array ([code]idx == size()[/code]).
 			</description>
 		</method>
-		<method name="reverse">
-			<return type="void">
-			</return>
-			<description>
-				Reverses the order of the elements in the array.
-			</description>
-		</method>
 		<method name="is_empty" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -158,6 +151,13 @@
 			</argument>
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="reverse">
+			<return type="void">
+			</return>
+			<description>
+				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -245,6 +245,16 @@
 				[b]Note[/b]: The pose transform needs to be in bone space. Use [method world_transform_to_bone_transform] to convert a world transform, like one you can get from a [Node3D], to bone space.
 			</description>
 		</method>
+		<method name="set_bone_name">
+			<return type="void">
+			</return>
+			<argument index="0" name="bone_idx" type="int">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_bone_parent">
 			<return type="void">
 			</return>

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -63,18 +63,18 @@
 				Draws a part of the texture using a [CanvasItem] with the [RenderingServer] API.
 			</description>
 		</method>
-		<method name="get_image" qualifiers="const">
-			<return type="Image">
-			</return>
-			<description>
-				Returns an [Image] that is a copy of data from this [Texture2D]. [Image]s can be accessed and manipulated directly.
-			</description>
-		</method>
 		<method name="get_height" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
 				Returns the texture height.
+			</description>
+		</method>
+		<method name="get_image" qualifiers="const">
+			<return type="Image">
+			</return>
+			<description>
+				Returns an [Image] that is a copy of data from this [Texture2D]. [Image]s can be accessed and manipulated directly.
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">


### PR DESCRIPTION
After several recent PRs (#47435, #42827, #46991) some class reference docs were misformatted which caused `doctool` to produce unnecessary diffs. This resolves this.

Only parts related to #42827 can be backported (ArrayMesh and Skeleton3D) when #42827 itself is backported. Though, it actually lacks documentation now.