### PR TITLE
Add a subtle background to editor scrollbars

### DIFF
--- a/editor/icons/GuiScrollBg.svg
+++ b/editor/icons/GuiScrollBg.svg
@@ -1,1 +1,1 @@
-<svg height="12" viewBox="0 0 12 11.999999" width="12" xmlns="http://www.w3.org/2000/svg"/>
+<svg height="12" viewBox="0 0 12 11.999999" width="12" xmlns="http://www.w3.org/2000/svg"><circle cx="6" cy="6" fill="#fff" fill-opacity=".082353" r="2"/></svg>

--- a/editor/icons/GuiScrollGrabber.svg
+++ b/editor/icons/GuiScrollGrabber.svg
@@ -1,1 +1,1 @@
-<svg height="12" viewBox="0 0 12 11.999999" width="12" xmlns="http://www.w3.org/2000/svg"><circle cx="6" cy="6" fill="#fff" fill-opacity=".27451" r="2"/></svg>
+<svg height="12" viewBox="0 0 12 11.999999" width="12" xmlns="http://www.w3.org/2000/svg"><circle cx="6" cy="6" fill="#fff" fill-opacity=".294118" r="3"/></svg>


### PR DESCRIPTION
This makes it possible to see whether a scrollbar grabber is at the top or at the bottom of a scrollbar. Also, if a scrollable area is very large, this makes it easier to notice that the area can be scrolled (since the grabber is proportionally very small).

The scrollbar grabbers were also made thicker and slightly more opaque for better visibility, especially in peripheral vision.

This can be merged independently of https://github.com/godotengine/godot/pull/45607.

## Preview

### Before

![Before](https://user-images.githubusercontent.com/180032/113525139-89e36d80-95b3-11eb-9a4b-cde165eac94b.png)

### After

![After](https://user-images.githubusercontent.com/180032/113525141-8b149a80-95b3-11eb-94d4-5d9a6c80ed48.png)