### PR TITLE
Display a matrix for Node2D and don't display a duplicate origin

### DIFF
--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -115,7 +115,7 @@
 		</member>
 		<member name="skew" type="float" setter="set_skew" getter="get_skew" default="0.0">
 		</member>
-		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform">
+		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			Local [Transform2D].
 		</member>
 		<member name="y_sort_enabled" type="bool" setter="set_y_sort_enabled" getter="is_y_sort_enabled" default="false">

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -255,6 +255,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="basis" type="Basis" setter="set_basis" getter="get_basis" default="Basis(1, 0, 0, 0, 1, 0, 0, 0, 1)">
+			Local space [Basis] of this node, with respect to the parent node. This is the same as [code]transform.basis[/code].
+		</member>
 		<member name="global_transform" type="Transform3D" setter="set_global_transform" getter="get_global_transform">
 			World3D space (global) [Transform3D] of this node.
 		</member>

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2268,7 +2268,7 @@ void EditorPropertyTransform2D::setup(double p_min, double p_max, double p_step,
 	}
 }
 
-EditorPropertyTransform2D::EditorPropertyTransform2D() {
+EditorPropertyTransform2D::EditorPropertyTransform2D(bool p_include_origin) {
 	GridContainer *g = memnew(GridContainer);
 	g->set_columns(2);
 	add_child(g);
@@ -2278,7 +2278,9 @@ EditorPropertyTransform2D::EditorPropertyTransform2D() {
 		spin[i] = memnew(EditorSpinSlider);
 		spin[i]->set_label(desc[i]);
 		spin[i]->set_flat(true);
-		g->add_child(spin[i]);
+		if (p_include_origin || i < 4) {
+			g->add_child(spin[i]);
+		}
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyTransform2D::_value_changed), varray(desc[i]));
@@ -3285,7 +3287,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 
 		} break;
 		case Variant::TRANSFORM2D: {
-			EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D);
+			EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D(p_usage != PROPERTY_USAGE_EDITOR));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
 			return editor;

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -531,7 +531,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyTransform2D();
+	EditorPropertyTransform2D(bool p_include_origin = true);
 };
 
 class EditorPropertyBasis : public EditorProperty {

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -421,11 +421,13 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rotation", PROPERTY_HINT_RANGE, "-360,360,0.1,or_lesser,or_greater,radians"), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "scale"), "set_scale", "get_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "skew", PROPERTY_HINT_RANGE, "-89.9,89.9,0.1,radians"), "set_skew", "get_skew");
-	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_transform", "get_transform");
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_position", "get_global_position");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_rotation", "get_global_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_scale", "get_global_scale");
+
+	ADD_GROUP("Raw Matrix", "");
+	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_transform", "get_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "global_transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_transform", "get_global_transform");
 
 	ADD_GROUP("Ordering", "");

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -220,6 +220,15 @@ void Node3D::_notification(int p_what) {
 	}
 }
 
+void Node3D::set_basis(const Basis &p_basis) {
+	data.local_transform = Transform3D(p_basis, data.local_transform.origin);
+	data.dirty |= DIRTY_VECTORS;
+	_propagate_transform_changed(this);
+	if (data.notify_local_transform) {
+		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+	}
+}
+
 void Node3D::set_transform(const Transform3D &p_transform) {
 	data.local_transform = p_transform;
 	data.dirty |= DIRTY_VECTORS;
@@ -236,6 +245,14 @@ void Node3D::set_global_transform(const Transform3D &p_transform) {
 					  p_transform;
 
 	set_transform(xform);
+}
+
+Basis Node3D::get_basis() const {
+	if (data.dirty & DIRTY_LOCAL) {
+		_update_local_transform();
+	}
+
+	return data.local_transform.basis;
 }
 
 Transform3D Node3D::get_transform() const {
@@ -765,7 +782,9 @@ NodePath Node3D::get_visibility_parent() const {
 }
 
 void Node3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_transform", "local"), &Node3D::set_transform);
+	ClassDB::bind_method(D_METHOD("set_basis", "basis"), &Node3D::set_basis);
+	ClassDB::bind_method(D_METHOD("get_basis"), &Node3D::get_basis);
+	ClassDB::bind_method(D_METHOD("set_transform", "transform"), &Node3D::set_transform);
 	ClassDB::bind_method(D_METHOD("get_transform"), &Node3D::get_transform);
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &Node3D::set_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &Node3D::get_position);
@@ -838,8 +857,12 @@ void Node3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation", PROPERTY_HINT_RANGE, "-360,360,0.1,or_lesser,or_greater,radians", PROPERTY_USAGE_EDITOR), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_scale", "get_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "top_level"), "set_as_top_level", "is_set_as_top_level");
-	ADD_GROUP("Matrix", "");
-	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "transform", PROPERTY_HINT_NONE, ""), "set_transform", "get_transform");
+
+	ADD_GROUP("Raw Matrix", "");
+	// No need to display the full Transform, we already have the translation above.
+	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_transform", "get_transform");
+	ADD_PROPERTY(PropertyInfo(Variant::BASIS, "basis", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_basis", "get_basis");
+
 	ADD_GROUP("Visibility", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "visibility_parent", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "GeometryInstance3D"), "set_visibility_parent", "get_visibility_parent");

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -136,9 +136,11 @@ public:
 	Vector3 get_rotation() const;
 	Vector3 get_scale() const;
 
+	void set_basis(const Basis &p_basis);
 	void set_transform(const Transform3D &p_transform);
 	void set_global_transform(const Transform3D &p_transform);
 
+	Basis get_basis() const;
 	Transform3D get_transform() const;
 	Transform3D get_global_transform() const;
 


### PR DESCRIPTION
This is a subset of #32068 because it's taking a long time to be merged and some have asked for a smaller PR.

This PR only changes the code for Node2D and Node3D, without changing the inspector code. For 2D, the matrix is displayed, while previously it just wasn't displayed at all. For 3D, "Matrix" is now "Raw Matrix", and it displays the Basis instead of Transform.

Before/after pic (left is before, right is after):

![Untitled](https://user-images.githubusercontent.com/1646875/113534311-5a763600-959e-11eb-9457-4671a261eb8e.png)