### PR TITLE
Don't use the abbrevation "Sep." in UI text

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -1042,7 +1042,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	hb_grid->add_child(sb_step_y);
 
 	hb_grid->add_child(memnew(VSeparator));
-	hb_grid->add_child(memnew(Label(TTR("Sep.:"))));
+	hb_grid->add_child(memnew(Label(TTR("Separation:"))));
 
 	sb_sep_x = memnew(SpinBox);
 	sb_sep_x->set_min(0);

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -278,7 +278,7 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	test_menu_button->get_popup()->add_radio_check_item(TTR("Radio Item"));
 	test_menu_button->get_popup()->add_radio_check_item(TTR("Checked Radio Item"));
 	test_menu_button->get_popup()->set_item_checked(7, true);
-	test_menu_button->get_popup()->add_separator(TTR("Named Sep."));
+	test_menu_button->get_popup()->add_separator(TTR("Named Separator"));
 
 	PopupMenu *test_submenu = memnew(PopupMenu);
 	test_menu_button->get_popup()->add_child(test_submenu);


### PR DESCRIPTION
This PR expands the abbrevation "Sep." to "Separator" and "Separation" accordingly in UI texts.

As explained in https://github.com/godotengine/godot-proposals/issues/2551 , the "Sep." causes confusions to translators and Weblate, and probably end users.

This also applies to the 3.x branch.