### PR TITLE
Style: Apply selected clang-tidy checks

### DIFF
--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -157,8 +157,9 @@ RES ResourceFormatLoaderCrypto::load(const String &p_path, const String &p_origi
 		return key;
 	} else if (el == "pub") {
 		CryptoKey *key = CryptoKey::create();
-		if (key)
+		if (key) {
 			key->load(p_path, true);
+		}
 		return key;
 	}
 	return nullptr;

--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -61,7 +61,7 @@ DynamicBVH::Node *DynamicBVH::_create_node_with_volume(Node *p_parent, const Vol
 void DynamicBVH::_insert_leaf(Node *p_root, Node *p_leaf) {
 	if (!bvh_root) {
 		bvh_root = p_leaf;
-		p_leaf->parent = 0;
+		p_leaf->parent = nullptr;
 	} else {
 		if (!p_root->is_leaf()) {
 			do {
@@ -71,7 +71,7 @@ void DynamicBVH::_insert_leaf(Node *p_root, Node *p_leaf) {
 			} while (!p_root->is_leaf());
 		}
 		Node *prev = p_root->parent;
-		Node *node = _create_node_with_volume(prev, p_leaf->volume.merge(p_root->volume), 0);
+		Node *node = _create_node_with_volume(prev, p_leaf->volume.merge(p_root->volume), nullptr);
 		if (prev) {
 			prev->childs[p_root->get_index_in_parent()] = node;
 			node->childs[0] = p_root;
@@ -85,7 +85,7 @@ void DynamicBVH::_insert_leaf(Node *p_root, Node *p_leaf) {
 					break;
 				}
 				node = prev;
-			} while (0 != (prev = node->parent));
+			} while (nullptr != (prev = node->parent));
 		} else {
 			node->childs[0] = p_root;
 			p_root->parent = node;
@@ -98,8 +98,8 @@ void DynamicBVH::_insert_leaf(Node *p_root, Node *p_leaf) {
 
 DynamicBVH::Node *DynamicBVH::_remove_leaf(Node *leaf) {
 	if (leaf == bvh_root) {
-		bvh_root = 0;
-		return (0);
+		bvh_root = nullptr;
+		return (nullptr);
 	} else {
 		Node *parent = leaf->parent;
 		Node *prev = parent->parent;
@@ -119,7 +119,7 @@ DynamicBVH::Node *DynamicBVH::_remove_leaf(Node *leaf) {
 			return (prev ? prev : bvh_root);
 		} else {
 			bvh_root = sibling;
-			sibling->parent = 0;
+			sibling->parent = nullptr;
 			_delete_node(parent);
 			return (bvh_root);
 		}

--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -113,8 +113,9 @@ DynamicBVH::Node *DynamicBVH::_remove_leaf(Node *leaf) {
 				prev->volume = prev->childs[0]->volume.merge(prev->childs[1]->volume);
 				if (pb.is_not_equal_to(prev->volume)) {
 					prev = prev->parent;
-				} else
+				} else {
 					break;
+				}
 			}
 			return (prev ? prev : bvh_root);
 		} else {
@@ -262,10 +263,11 @@ DynamicBVH::Node *DynamicBVH::_node_sort(Node *n, Node *&r) {
 		Node *s = p->childs[j];
 		Node *q = p->parent;
 		ERR_FAIL_COND_V(n != p->childs[i], nullptr);
-		if (q)
+		if (q) {
 			q->childs[p->get_index_in_parent()] = n;
-		else
+		} else {
 			r = n;
+		}
 		s->parent = n;
 		p->parent = n;
 		n->parent = q;
@@ -307,8 +309,9 @@ void DynamicBVH::optimize_top_down(int bu_threshold) {
 }
 
 void DynamicBVH::optimize_incremental(int passes) {
-	if (passes < 0)
+	if (passes < 0) {
 		passes = total_leaves;
+	}
 	if (bvh_root && (passes > 0)) {
 		do {
 			Node *node = bvh_root;
@@ -345,8 +348,9 @@ void DynamicBVH::_update(Node *leaf, int lookahead) {
 			for (int i = 0; (i < lookahead) && root->parent; ++i) {
 				root = root->parent;
 			}
-		} else
+		} else {
 			root = bvh_root;
+		}
 	}
 	_insert_leaf(root, leaf);
 }
@@ -370,8 +374,9 @@ bool DynamicBVH::update(const ID &p_id, const AABB &p_box) {
 			for (int i = 0; (i < lkhd) && base->parent; ++i) {
 				base = base->parent;
 			}
-		} else
+		} else {
 			base = bvh_root;
+		}
 	}
 	leaf->volume = volume;
 	_insert_leaf(base, leaf);

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -278,7 +278,7 @@ private:
 public:
 	// Methods
 	void clear();
-	bool is_empty() const { return (0 == bvh_root); }
+	bool is_empty() const { return (nullptr == bvh_root); }
 	void optimize_bottom_up();
 	void optimize_top_down(int bu_threshold = 128);
 	void optimize_incremental(int passes);

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -87,14 +87,16 @@ private:
 		_FORCE_INLINE_ Volume merge(const Volume &b) const {
 			Volume r;
 			for (int i = 0; i < 3; ++i) {
-				if (min[i] < b.min[i])
+				if (min[i] < b.min[i]) {
 					r.min[i] = min[i];
-				else
+				} else {
 					r.min[i] = b.min[i];
-				if (max[i] > b.max[i])
+				}
+				if (max[i] > b.max[i]) {
 					r.max[i] = max[i];
-				else
+				} else {
 					r.max[i] = b.max[i];
+				}
 			}
 			return r;
 		}
@@ -202,10 +204,11 @@ private:
 
 		//
 		int count_leaves() const {
-			if (is_internal())
+			if (is_internal()) {
 				return childs[0]->count_leaves() + childs[1]->count_leaves();
-			else
+			} else {
 				return (1);
+			}
 		}
 
 		bool is_left_of_axis(const Vector3 &org, const Vector3 &axis) const {
@@ -254,24 +257,30 @@ private:
 		tymin = (bounds[raySign[1]].y - rayFrom.y) * rayInvDirection.y;
 		tymax = (bounds[1 - raySign[1]].y - rayFrom.y) * rayInvDirection.y;
 
-		if ((tmin > tymax) || (tymin > tmax))
+		if ((tmin > tymax) || (tymin > tmax)) {
 			return false;
+		}
 
-		if (tymin > tmin)
+		if (tymin > tmin) {
 			tmin = tymin;
+		}
 
-		if (tymax < tmax)
+		if (tymax < tmax) {
 			tmax = tymax;
+		}
 
 		tzmin = (bounds[raySign[2]].z - rayFrom.z) * rayInvDirection.z;
 		tzmax = (bounds[1 - raySign[2]].z - rayFrom.z) * rayInvDirection.z;
 
-		if ((tmin > tzmax) || (tzmin > tmax))
+		if ((tmin > tzmax) || (tzmin > tmax)) {
 			return false;
-		if (tzmin > tmin)
+		}
+		if (tzmin > tmin) {
 			tmin = tzmin;
-		if (tzmax < tmax)
+		}
+		if (tzmax < tmax) {
 			tmax = tzmax;
+		}
 		return ((tmin < lambda_max) && (tmax > lambda_min));
 	}
 

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -891,8 +891,9 @@ struct VariantIndexedSetGet_Array {
 	static void ptr_get(const void *base, int64_t index, void *member) {
 		/* avoid ptrconvert for performance*/
 		const Array &v = *reinterpret_cast<const Array *>(base);
-		if (index < 0)
+		if (index < 0) {
 			index += v.size();
+		}
 		OOB_TEST(index, v.size());
 		PtrToArg<Variant>::encode(v[index], member);
 	}
@@ -925,8 +926,9 @@ struct VariantIndexedSetGet_Array {
 	static void ptr_set(void *base, int64_t index, const void *member) {
 		/* avoid ptrconvert for performance*/
 		Array &v = *reinterpret_cast<Array *>(base);
-		if (index < 0)
+		if (index < 0) {
 			index += v.size();
+		}
 		OOB_TEST(index, v.size());
 		v.set(index, PtrToArg<Variant>::convert(member));
 	}

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -505,7 +505,7 @@ Error VulkanContext::_check_capabilities() {
 	if (func != nullptr) {
 		VkPhysicalDeviceSubgroupProperties subgroupProperties;
 		subgroupProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES;
-		subgroupProperties.pNext = NULL;
+		subgroupProperties.pNext = nullptr;
 
 		VkPhysicalDeviceProperties2 physicalDeviceProperties;
 		physicalDeviceProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2570,9 +2570,9 @@ void EditorInspector::_update_script_class_properties(const Object &p_object, Li
 	}
 
 	// Script Variables -> to insert: NodeC..B..A -> bottom (insert_here)
-	List<PropertyInfo>::Element *script_variables = NULL;
-	List<PropertyInfo>::Element *bottom = NULL;
-	List<PropertyInfo>::Element *insert_here = NULL;
+	List<PropertyInfo>::Element *script_variables = nullptr;
+	List<PropertyInfo>::Element *bottom = nullptr;
+	List<PropertyInfo>::Element *insert_here = nullptr;
 	for (List<PropertyInfo>::Element *E = r_list.front(); E; E = E->next()) {
 		PropertyInfo &pi = E->get();
 		if (pi.name != "Script Variables") {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1379,7 +1379,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 		// which would result in an invalid texture.
 		if (c3d == 0 && c2d == 0) {
 			img.instance();
-			img->create(1, 1, 0, Image::FORMAT_RGB8);
+			img->create(1, 1, false, Image::FORMAT_RGB8);
 		} else if (c3d < c2d) {
 			Ref<ViewportTexture> viewport_texture = scene_root->get_texture();
 			if (viewport_texture->get_width() > 0 && viewport_texture->get_height() > 0) {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -649,14 +649,16 @@ public:
 				Color color = get_theme_color("highlight_color", "Editor");
 				for (int i = 0; i < 2; i++) {
 					Point2 ofs(4, vofs);
-					if (i == 1)
+					if (i == 1) {
 						ofs.y += bsize + 1;
+					}
 
 					ofs += rect.position;
 					for (int j = 0; j < 10; j++) {
 						Point2 o = ofs + Point2(j * (bsize + 1), 0);
-						if (j >= 5)
+						if (j >= 5) {
 							o.x += 1;
+						}
 
 						const int idx = i * 10 + j;
 						const bool on = value & (1 << idx);

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -38,8 +38,9 @@
 EditorTranslationParser *EditorTranslationParser::singleton = nullptr;
 
 Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) {
-	if (!get_script_instance())
+	if (!get_script_instance()) {
 		return ERR_UNAVAILABLE;
+	}
 
 	if (get_script_instance()->has_method("parse_file")) {
 		Array ids;
@@ -70,8 +71,9 @@ Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<Str
 }
 
 void EditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
-	if (!get_script_instance())
+	if (!get_script_instance()) {
 		return;
+	}
 
 	if (get_script_instance()->has_method("get_recognized_extensions")) {
 		Array extensions = get_script_instance()->call("get_recognized_extensions");

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2621,8 +2621,9 @@ void FileSystemDock::_get_imported_files(const String &p_path, Vector<String> &f
 }
 
 void FileSystemDock::_update_import_dock() {
-	if (!import_dock_needs_update)
+	if (!import_dock_needs_update) {
 		return;
+	}
 
 	// List selected.
 	Vector<String> selected;
@@ -2633,8 +2634,9 @@ void FileSystemDock::_update_import_dock() {
 	} else {
 		// Use the file list.
 		for (int i = 0; i < files->get_item_count(); i++) {
-			if (!files->is_selected(i))
+			if (!files->is_selected(i)) {
 				continue;
+			}
 
 			selected.push_back(files->get_item_metadata(i));
 		}

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1688,7 +1688,7 @@ Node *EditorSceneImporterCollada::import_scene(const String &p_path, uint32_t p_
 	state.use_mesh_builtin_materials = true;
 	state.bake_fps = p_bake_fps;
 
-	Error err = state.load(p_path, flags, p_flags & EditorSceneImporter::IMPORT_GENERATE_TANGENT_ARRAYS, 0);
+	Error err = state.load(p_path, flags, p_flags & EditorSceneImporter::IMPORT_GENERATE_TANGENT_ARRAYS, false);
 
 	if (r_err) {
 		*r_err = err;

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -427,7 +427,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, int p_bake_fps, List<String> *r_missing_deps, Error *r_err) {
 	List<Ref<Mesh>> meshes;
 
-	Error err = _parse_obj(p_path, meshes, false, p_flags & IMPORT_GENERATE_TANGENT_ARRAYS, 0, Vector3(1, 1, 1), Vector3(0, 0, 0), r_missing_deps);
+	Error err = _parse_obj(p_path, meshes, false, p_flags & IMPORT_GENERATE_TANGENT_ARRAYS, false, Vector3(1, 1, 1), Vector3(0, 0, 0), r_missing_deps);
 
 	if (err != OK) {
 		if (r_err) {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -167,16 +167,18 @@ void BoneTransformEditor::_notification(int p_what) {
 }
 
 void BoneTransformEditor::_value_changed(const double p_value) {
-	if (updating)
+	if (updating) {
 		return;
+	}
 
 	Transform tform = compute_transform_from_vector3s();
 	_change_transform(tform);
 }
 
 void BoneTransformEditor::_value_changed_vector3(const String p_property_name, const Vector3 p_vector, const StringName p_edited_property_name, const bool p_boolean) {
-	if (updating)
+	if (updating) {
 		return;
+	}
 	Transform tform = compute_transform_from_vector3s();
 	_change_transform(tform);
 }
@@ -194,8 +196,9 @@ Transform BoneTransformEditor::compute_transform_from_vector3s() const {
 }
 
 void BoneTransformEditor::_value_changed_transform(const String p_property_name, const Transform p_transform, const StringName p_edited_property_name, const bool p_boolean) {
-	if (updating)
+	if (updating) {
 		return;
+	}
 	_change_transform(p_transform);
 }
 
@@ -222,11 +225,13 @@ void BoneTransformEditor::update_enabled_checkbox() {
 }
 
 void BoneTransformEditor::_update_properties() {
-	if (updating)
+	if (updating) {
 		return;
+	}
 
-	if (skeleton == nullptr)
+	if (skeleton == nullptr) {
 		return;
+	}
 
 	updating = true;
 
@@ -235,11 +240,13 @@ void BoneTransformEditor::_update_properties() {
 }
 
 void BoneTransformEditor::_update_custom_pose_properties() {
-	if (updating)
+	if (updating) {
 		return;
+	}
 
-	if (skeleton == nullptr)
+	if (skeleton == nullptr) {
 		return;
+	}
 
 	updating = true;
 
@@ -287,14 +294,16 @@ void BoneTransformEditor::set_toggle_enabled(const bool p_enabled) {
 }
 
 void BoneTransformEditor::_key_button_pressed() {
-	if (skeleton == nullptr)
+	if (skeleton == nullptr) {
 		return;
+	}
 
 	const BoneId bone_id = property.get_slicec('/', 1).to_int();
 	const String name = skeleton->get_bone_name(bone_id);
 
-	if (name.is_empty())
+	if (name.is_empty()) {
 		return;
+	}
 
 	// Need to normalize the basis before you key it
 	Transform tform = compute_transform_from_vector3s();
@@ -405,8 +414,9 @@ PhysicalBone3D *Skeleton3DEditor::create_physical_bone(int bone_id, int bone_chi
 Variant Skeleton3DEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 	TreeItem *selected = joint_tree->get_selected();
 
-	if (!selected)
+	if (!selected) {
 		return Variant();
+	}
 
 	Ref<Texture> icon = selected->get_icon(0);
 
@@ -431,27 +441,32 @@ Variant Skeleton3DEditor::get_drag_data_fw(const Point2 &p_point, Control *p_fro
 
 bool Skeleton3DEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
 	TreeItem *target = joint_tree->get_item_at_position(p_point);
-	if (!target)
+	if (!target) {
 		return false;
+	}
 
 	const String path = target->get_metadata(0);
-	if (!path.begins_with("bones/"))
+	if (!path.begins_with("bones/")) {
 		return false;
+	}
 
 	TreeItem *selected = Object::cast_to<TreeItem>(Dictionary(p_data)["node"]);
-	if (target == selected)
+	if (target == selected) {
 		return false;
+	}
 
 	const String path2 = target->get_metadata(0);
-	if (!path2.begins_with("bones/"))
+	if (!path2.begins_with("bones/")) {
 		return false;
+	}
 
 	return true;
 }
 
 void Skeleton3DEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	if (!can_drop_data_fw(p_point, p_data, p_from))
+	if (!can_drop_data_fw(p_point, p_data, p_from)) {
 		return;
+	}
 
 	TreeItem *target = joint_tree->get_item_at_position(p_point);
 	TreeItem *selected = Object::cast_to<TreeItem>(Dictionary(p_data)["node"]);
@@ -510,19 +525,23 @@ void Skeleton3DEditor::_joint_tree_rmb_select(const Vector2 &p_pos) {
 }
 
 void Skeleton3DEditor::_update_properties() {
-	if (rest_editor)
+	if (rest_editor) {
 		rest_editor->_update_properties();
-	if (pose_editor)
+	}
+	if (pose_editor) {
 		pose_editor->_update_properties();
-	if (custom_pose_editor)
+	}
+	if (custom_pose_editor) {
 		custom_pose_editor->_update_custom_pose_properties();
+	}
 }
 
 void Skeleton3DEditor::update_joint_tree() {
 	joint_tree->clear();
 
-	if (skeleton == nullptr)
+	if (skeleton == nullptr) {
 		return;
+	}
 
 	TreeItem *root = joint_tree->create_item();
 

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -67,7 +67,7 @@ private:
 		VisualShader::Type type = VisualShader::Type::TYPE_MAX;
 		VisualShaderNode *visual_node = nullptr;
 		GraphNode *graph_node = nullptr;
-		bool preview_visible = 0;
+		bool preview_visible = false;
 		int preview_pos = 0;
 		Map<int, InputPort> input_ports;
 		Map<int, Port> output_ports;

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -260,8 +260,9 @@ T EditorSceneImporterFBX::_interpolate_track(const Vector<float> &p_times, const
 	//could use binary search, worth it?
 	int idx = -1;
 	for (int i = 0; i < p_times.size(); i++) {
-		if (p_times[i] > p_time)
+		if (p_times[i] > p_time) {
 			break;
+		}
 		idx++;
 	}
 
@@ -610,8 +611,9 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 				for (const FBXDocParser::Geometry *mesh : geometry) {
 					print_verbose("[doc] [" + itos(mesh->ID()) + "] mesh: " + fbx_node->node_name);
 
-					if (mesh == nullptr)
+					if (mesh == nullptr) {
 						continue;
+					}
 
 					const FBXDocParser::MeshGeometry *mesh_geometry = dynamic_cast<const FBXDocParser::MeshGeometry *>(mesh);
 					if (mesh_geometry) {

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -94,7 +94,7 @@ Node3D *EditorSceneImporterFBX::import_scene(const String &p_path, uint32_t p_fl
 	Error err;
 	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ, &err);
 
-	ERR_FAIL_COND_V(!f, NULL);
+	ERR_FAIL_COND_V(!f, nullptr);
 
 	{
 		PackedByteArray data;
@@ -334,7 +334,7 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 	ImportState state;
 	state.is_blender_fbx = p_is_blender_fbx;
 	state.path = p_path;
-	state.animation_player = NULL;
+	state.animation_player = nullptr;
 
 	// create new root node for scene
 	Node3D *scene_root = memnew(Node3D);

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -628,7 +628,7 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 						mesh_data_precached->mesh_node = fbx_node;
 
 						// mesh node, mesh id
-						mesh_node = mesh_data_precached->create_fbx_mesh(state, mesh_geometry, fbx_node->fbx_model, 0);
+						mesh_node = mesh_data_precached->create_fbx_mesh(state, mesh_geometry, fbx_node->fbx_model, false);
 						if (!state.MeshNodes.has(mesh_id)) {
 							state.MeshNodes.insert(mesh_id, fbx_node);
 						}

--- a/modules/fbx/editor_scene_importer_fbx.h
+++ b/modules/fbx/editor_scene_importer_fbx.h
@@ -128,7 +128,7 @@ public:
 
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual uint32_t get_import_flags() const override;
-	virtual Node3D *import_scene(const String &p_path, uint32_t p_flags, int p_bake_fps, List<String> *r_missing_deps, Error *r_err = NULL) override;
+	virtual Node3D *import_scene(const String &p_path, uint32_t p_flags, int p_bake_fps, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 };
 
 #endif // TOOLS_ENABLED

--- a/modules/fbx/fbx_parser/ByteSwapper.h
+++ b/modules/fbx/fbx_parser/ByteSwapper.h
@@ -264,8 +264,9 @@ struct Getter {
 		le = !le;
 		if (le) {
 			ByteSwapper<T, (sizeof(T) > 1 ? true : false)>()(inout);
-		} else
+		} else {
 			ByteSwapper<T, false>()(inout);
+		}
 	}
 };
 

--- a/modules/fbx/fbx_parser/FBXAnimation.cpp
+++ b/modules/fbx/fbx_parser/FBXAnimation.cpp
@@ -130,7 +130,7 @@ AnimationCurve::~AnimationCurve() {
 AnimationCurveNode::AnimationCurveNode(uint64_t id, const ElementPtr element, const std::string &name,
 		const Document &doc, const char *const *target_prop_whitelist /*= NULL*/,
 		size_t whitelist_size /*= 0*/) :
-		Object(id, element, name), target(), doc(doc) {
+		Object(id, element, name), doc(doc) {
 	const ScopePtr sc = GetRequiredScope(element);
 
 	// find target node

--- a/modules/fbx/fbx_parser/FBXDocument.cpp
+++ b/modules/fbx/fbx_parser/FBXDocument.cpp
@@ -93,7 +93,7 @@ using namespace Util;
 
 // ------------------------------------------------------------------------------------------------
 LazyObject::LazyObject(uint64_t id, const ElementPtr element, const Document &doc) :
-		doc(doc), element(element), id(id), flags() {
+		doc(doc), element(element), id(id) {
 	// empty
 }
 
@@ -252,7 +252,7 @@ FileGlobalSettings::~FileGlobalSettings() {
 
 // ------------------------------------------------------------------------------------------------
 Document::Document(const Parser &parser, const ImportSettings &settings) :
-		settings(settings), parser(parser), SafeToImport(false) {
+		settings(settings), parser(parser) {
 	// Cannot use array default initialization syntax because vc8 fails on it
 	for (unsigned int &timeStamp : creationTimeStamp) {
 		timeStamp = 0;

--- a/modules/fbx/fbx_parser/FBXDocument.h
+++ b/modules/fbx/fbx_parser/FBXDocument.h
@@ -670,7 +670,7 @@ public:
 
 	uint8_t *RelinquishContent() {
 		uint8_t *ptr = content;
-		content = 0;
+		content = nullptr;
 		return ptr;
 	}
 

--- a/modules/fbx/fbx_parser/FBXImportSettings.h
+++ b/modules/fbx/fbx_parser/FBXImportSettings.h
@@ -80,60 +80,52 @@ namespace FBXDocParser {
 
 /** FBX import settings, parts of which are publicly accessible via their corresponding AI_CONFIG constants */
 struct ImportSettings {
-	ImportSettings() :
-			strictMode(true), readAllLayers(true), readAllMaterials(true), readMaterials(true), readTextures(true), readCameras(true), readLights(true), readAnimations(true), readWeights(true), preservePivots(true), optimizeEmptyAnimationCurves(true), useLegacyEmbeddedTextureNaming(false), removeEmptyBones(true), convertToMeters(false) {
-		// empty
-	}
-
 	/** enable strict mode:
      *   - only accept fbx 2012, 2013 files
      *   - on the slightest error, give up.
      *
      *  Basically, strict mode means that the fbx file will actually
-     *  be validated. Strict mode is off by default. */
-	bool strictMode;
+     *  be validated.*/
+	bool strictMode = true;
 
 	/** specifies whether all geometry layers are read and scanned for
       * usable data channels. The FBX spec indicates that many readers
       * will only read the first channel and that this is in some way
       * the recommended way- in reality, however, it happens a lot that
-      * vertex data is spread among multiple layers. The default
-      * value for this option is true.*/
-	bool readAllLayers;
+      * vertex data is spread among multiple layers.*/
+	bool readAllLayers = true;
 
 	/** specifies whether all materials are read, or only those that
      *  are referenced by at least one mesh. Reading all materials
      *  may make FBX reading a lot slower since all objects
-     *  need to be processed .
-     *  This bit is ignored unless readMaterials=true*/
-	bool readAllMaterials;
+     *  need to be processed.
+     *  This bit is ignored unless readMaterials=true.*/
+	bool readAllMaterials = true;
 
 	/** import materials (true) or skip them and assign a default
-     *  material. The default value is true.*/
-	bool readMaterials;
+     *  material.*/
+	bool readMaterials = true;
 
-	/** import embedded textures? Default value is true.*/
-	bool readTextures;
+	/** import embedded textures?*/
+	bool readTextures = true;
 
-	/** import cameras? Default value is true.*/
-	bool readCameras;
+	/** import cameras?*/
+	bool readCameras = true;
 
-	/** import light sources? Default value is true.*/
-	bool readLights;
+	/** import light sources?*/
+	bool readLights = true;
 
 	/** import animations (i.e. animation curves, the node
-     *  skeleton is always imported). Default value is true. */
-	bool readAnimations;
+     *  skeleton is always imported).*/
+	bool readAnimations = true;
 
-	/** read bones (vertex weights and deform info).
-     *  Default value is true. */
-	bool readWeights;
+	/** read bones (vertex weights and deform info).*/
+	bool readWeights = true;
 
 	/** preserve transformation pivots and offsets. Since these can
      *  not directly be represented in assimp, additional dummy
      *  nodes will be generated. Note that settings this to false
-     *  can make animation import a lot slower. The default value
-     *  is true.
+     *  can make animation import a lot slower.
      *
      *  The naming scheme for the generated nodes is:
      *    <OriginalName>_$AssimpFbx$_<TransformName>
@@ -149,24 +141,21 @@ struct ImportSettings {
      *    Scaling
      *    Rotation
      **/
-	bool preservePivots;
+	bool preservePivots = true;
 
 	/** do not import animation curves that specify a constant
-     *  values matching the corresponding node transformation.
-     *  The default value is true. */
-	bool optimizeEmptyAnimationCurves;
+     *  values matching the corresponding node transformation.*/
+	bool optimizeEmptyAnimationCurves = true;
 
-	/** use legacy naming for embedded textures eg: (*0, *1, *2)
-    */
-	bool useLegacyEmbeddedTextureNaming;
+	/** use legacy naming for embedded textures eg: (*0, *1, *2).*/
+	bool useLegacyEmbeddedTextureNaming = false;
 
-	/** Empty bones shall be removed
-    */
-	bool removeEmptyBones;
+	/** Empty bones shall be removed.*/
+	bool removeEmptyBones = true;
 
-	/** Set to true to perform a conversion from cm to meter after the import
-    */
-	bool convertToMeters;
+	/** Set to true to perform a conversion from cm to meter after
+	 *  the import.*/
+	bool convertToMeters = false;
 };
 } // namespace FBXDocParser
 

--- a/modules/fbx/fbx_parser/FBXMaterial.cpp
+++ b/modules/fbx/fbx_parser/FBXMaterial.cpp
@@ -267,10 +267,10 @@ LayeredTexture::LayeredTexture(uint64_t id, const ElementPtr element, const Docu
 	ElementPtr BlendModes = sc->GetElement("BlendModes");
 	ElementPtr Alphas = sc->GetElement("Alphas");
 
-	if (BlendModes != 0) {
+	if (BlendModes != nullptr) {
 		blendMode = (BlendMode)ParseTokenAsInt(GetRequiredToken(BlendModes, 0));
 	}
-	if (Alphas != 0) {
+	if (Alphas != nullptr) {
 		alpha = ParseTokenAsFloat(GetRequiredToken(Alphas, 0));
 	}
 }

--- a/modules/fbx/fbx_parser/FBXMaterial.cpp
+++ b/modules/fbx/fbx_parser/FBXMaterial.cpp
@@ -171,7 +171,7 @@ Material::~Material() {
 
 // ------------------------------------------------------------------------------------------------
 Texture::Texture(uint64_t id, const ElementPtr element, const Document &doc, const std::string &name) :
-		Object(id, element, name), uvScaling(1.0f, 1.0f), media(nullptr) {
+		Object(id, element, name), uvScaling(1.0f, 1.0f) {
 	const ScopePtr sc = GetRequiredScope(element);
 
 	const ElementPtr Type = sc->GetElement("Type");
@@ -297,7 +297,7 @@ void LayeredTexture::fillTexture(const Document &doc) {
 
 // ------------------------------------------------------------------------------------------------
 Video::Video(uint64_t id, const ElementPtr element, const Document &doc, const std::string &name) :
-		Object(id, element, name), contentLength(0), content(0) {
+		Object(id, element, name) {
 	const ScopePtr sc = GetRequiredScope(element);
 
 	const ElementPtr Type = sc->GetElement("Type");

--- a/modules/fbx/fbx_parser/FBXMeshGeometry.cpp
+++ b/modules/fbx/fbx_parser/FBXMeshGeometry.cpp
@@ -88,7 +88,7 @@ using namespace Util;
 
 // ------------------------------------------------------------------------------------------------
 Geometry::Geometry(uint64_t id, const ElementPtr element, const std::string &name, const Document &doc) :
-		Object(id, element, name), skin() {
+		Object(id, element, name) {
 	const std::vector<const Connection *> &conns = doc.GetConnectionsByDestinationSequenced(ID(), "Deformer");
 	for (const Connection *con : conns) {
 		const Skin *sk = ProcessSimpleConnection<Skin>(*con, false, "Skin -> Geometry", element);

--- a/modules/fbx/fbx_parser/FBXParseTools.h
+++ b/modules/fbx/fbx_parser/FBXParseTools.h
@@ -61,7 +61,7 @@ inline bool IsLineEnd(char_t c) {
 // Special version of the function, providing higher accuracy and safety
 // It is mainly used by fast_atof to prevent ugly and unwanted integer overflows.
 // ------------------------------------------------------------------------------------
-inline uint64_t strtoul10_64(const char *in, bool &errored, const char **out = 0, unsigned int *max_inout = 0) {
+inline uint64_t strtoul10_64(const char *in, bool &errored, const char **out = nullptr, unsigned int *max_inout = nullptr) {
 	unsigned int cur = 0;
 	uint64_t value = 0;
 

--- a/modules/fbx/fbx_parser/FBXParser.cpp
+++ b/modules/fbx/fbx_parser/FBXParser.cpp
@@ -216,7 +216,7 @@ Scope::~Scope() {
 
 // ------------------------------------------------------------------------------------------------
 Parser::Parser(const TokenList &tokens, bool is_binary) :
-		tokens(tokens), last(), current(), cursor(tokens.begin()), is_binary(is_binary) {
+		tokens(tokens), cursor(tokens.begin()), is_binary(is_binary) {
 	root = new_Scope(*this, true);
 	scopes.push_back(root);
 }

--- a/modules/fbx/fbx_parser/FBXProperties.cpp
+++ b/modules/fbx/fbx_parser/FBXProperties.cpp
@@ -215,8 +215,9 @@ DirectPropertyMap PropertyTable::GetUnparsedProperties() const {
 	// Loop through all the lazy properties (which is all the properties)
 	for (const LazyPropertyMap::value_type &element : lazyProps) {
 		// Skip parsed properties
-		if (props.end() != props.find(element.first))
+		if (props.end() != props.find(element.first)) {
 			continue;
+		}
 
 		// Read the element's value.
 		// Wrap the naked pointer (since the call site is required to acquire ownership)
@@ -224,8 +225,9 @@ DirectPropertyMap PropertyTable::GetUnparsedProperties() const {
 		Property *prop = ReadTypedProperty(element.second);
 
 		// Element could not be read. Skip it.
-		if (!prop)
+		if (!prop) {
 			continue;
+		}
 
 		// Add to result
 		result[element.first] = prop;

--- a/modules/fbx/fbx_parser/FBXProperties.cpp
+++ b/modules/fbx/fbx_parser/FBXProperties.cpp
@@ -145,8 +145,7 @@ std::string PeekPropertyName(const Element &element) {
 } // namespace
 
 // ------------------------------------------------------------------------------------------------
-PropertyTable::PropertyTable() :
-		templateProps(), element() {
+PropertyTable::PropertyTable() {
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/modules/fbx/fbx_parser/FBXUtil.cpp
+++ b/modules/fbx/fbx_parser/FBXUtil.cpp
@@ -122,8 +122,9 @@ static const uint8_t base64DecodeTable[128] = {
 
 uint8_t DecodeBase64(char ch) {
 	const auto idx = static_cast<uint8_t>(ch);
-	if (idx > 127)
+	if (idx > 127) {
 		return 255;
+	}
 	return base64DecodeTable[idx];
 }
 
@@ -211,8 +212,9 @@ std::string EncodeBase64(const char *data, size_t length) {
 		EncodeByteBlock(&finalBytes[0], encoded_string, iEncodedByte);
 
 		// add '=' at the end
-		for (size_t i = 0; i < 4 * extraBytes / 3; i++)
+		for (size_t i = 0; i < 4 * extraBytes / 3; i++) {
 			encoded_string[encodedBytes - i - 1] = '=';
+		}
 	}
 	return encoded_string;
 }

--- a/modules/fbx/tools/validation_tools.h
+++ b/modules/fbx/tools/validation_tools.h
@@ -65,8 +65,9 @@ protected:
 			Error err;
 			FileAccess *file = FileAccess::open(path, FileAccess::WRITE, &err);
 			if (!file || err) {
-				if (file)
+				if (file) {
 					memdelete(file);
+				}
 				print_error("ValidationTracker Error - failed to create file - path: %s\n" + path);
 				return;
 			}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2301,7 +2301,7 @@ GDScriptLanguage::~GDScriptLanguage() {
 		script->unreference();
 	}
 
-	singleton = NULL;
+	singleton = nullptr;
 }
 
 void GDScriptLanguage::add_orphan_subclass(const String &p_qualified_name, const ObjectID &p_subclass) {

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -163,64 +163,72 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	}
 
 	int get_constant_pos(const Variant &p_constant) {
-		if (constant_map.has(p_constant))
+		if (constant_map.has(p_constant)) {
 			return constant_map[p_constant];
+		}
 		int pos = constant_map.size();
 		constant_map[p_constant] = pos;
 		return pos;
 	}
 
 	int get_operation_pos(const Variant::ValidatedOperatorEvaluator p_operation) {
-		if (operator_func_map.has(p_operation))
+		if (operator_func_map.has(p_operation)) {
 			return operator_func_map[p_operation];
+		}
 		int pos = operator_func_map.size();
 		operator_func_map[p_operation] = pos;
 		return pos;
 	}
 
 	int get_setter_pos(const Variant::ValidatedSetter p_setter) {
-		if (setters_map.has(p_setter))
+		if (setters_map.has(p_setter)) {
 			return setters_map[p_setter];
+		}
 		int pos = setters_map.size();
 		setters_map[p_setter] = pos;
 		return pos;
 	}
 
 	int get_getter_pos(const Variant::ValidatedGetter p_getter) {
-		if (getters_map.has(p_getter))
+		if (getters_map.has(p_getter)) {
 			return getters_map[p_getter];
+		}
 		int pos = getters_map.size();
 		getters_map[p_getter] = pos;
 		return pos;
 	}
 
 	int get_keyed_setter_pos(const Variant::ValidatedKeyedSetter p_keyed_setter) {
-		if (keyed_setters_map.has(p_keyed_setter))
+		if (keyed_setters_map.has(p_keyed_setter)) {
 			return keyed_setters_map[p_keyed_setter];
+		}
 		int pos = keyed_setters_map.size();
 		keyed_setters_map[p_keyed_setter] = pos;
 		return pos;
 	}
 
 	int get_keyed_getter_pos(const Variant::ValidatedKeyedGetter p_keyed_getter) {
-		if (keyed_getters_map.has(p_keyed_getter))
+		if (keyed_getters_map.has(p_keyed_getter)) {
 			return keyed_getters_map[p_keyed_getter];
+		}
 		int pos = keyed_getters_map.size();
 		keyed_getters_map[p_keyed_getter] = pos;
 		return pos;
 	}
 
 	int get_indexed_setter_pos(const Variant::ValidatedIndexedSetter p_indexed_setter) {
-		if (indexed_setters_map.has(p_indexed_setter))
+		if (indexed_setters_map.has(p_indexed_setter)) {
 			return indexed_setters_map[p_indexed_setter];
+		}
 		int pos = indexed_setters_map.size();
 		indexed_setters_map[p_indexed_setter] = pos;
 		return pos;
 	}
 
 	int get_indexed_getter_pos(const Variant::ValidatedIndexedGetter p_indexed_getter) {
-		if (indexed_getters_map.has(p_indexed_getter))
+		if (indexed_getters_map.has(p_indexed_getter)) {
 			return indexed_getters_map[p_indexed_getter];
+		}
 		int pos = indexed_getters_map.size();
 		indexed_getters_map[p_indexed_getter] = pos;
 		return pos;
@@ -272,8 +280,9 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	}
 
 	void alloc_stack(int p_level) {
-		if (p_level >= stack_max)
+		if (p_level >= stack_max) {
 			stack_max = p_level + 1;
+		}
 	}
 
 	int increase_stack() {
@@ -283,8 +292,9 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	}
 
 	void alloc_ptrcall(int p_params) {
-		if (p_params >= ptrcall_max)
+		if (p_params >= ptrcall_max) {
 			ptrcall_max = p_params;
+		}
 	}
 
 	int address_of(const Address &p_address) {

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -393,8 +393,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				text += Variant::get_type_name(t) + "(";
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(i + 1);
 				}
 				text += ")";
@@ -410,8 +411,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				text += "<unkown type>(";
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(i + 1);
 				}
 				text += ")";
@@ -425,8 +427,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += " = [";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 
@@ -458,8 +461,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += " = [";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 
@@ -474,8 +478,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += " = {";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i * 2 + 0);
 					text += ": ";
 					text += DADDR(1 + i * 2 + 1);
@@ -509,8 +514,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "(";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 				text += ")";
@@ -539,8 +545,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "(";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 				text += ")";
@@ -559,8 +566,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "(";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 				text += ")";
@@ -636,8 +644,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "(";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 				text += ")";
@@ -654,8 +663,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "(";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 				text += ")";
@@ -672,8 +682,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "(";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 				text += ")";
@@ -690,8 +701,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "(";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 				text += ")";
@@ -708,8 +720,9 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "(";
 
 				for (int i = 0; i < argc; i++) {
-					if (i > 0)
+					if (i > 0) {
 						text += ", ";
+					}
 					text += DADDR(1 + i);
 				}
 				text += ")";

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1037,7 +1037,7 @@ static void _find_identifiers(GDScriptParser::CompletionContext &p_context, bool
 	static const char *_keywords[] = {
 		"false", "PI", "TAU", "INF", "NAN", "self", "true", "breakpoint", "tool", "super",
 		"break", "continue", "pass", "return",
-		0
+		nullptr
 	};
 
 	const char **kw = _keywords;
@@ -1050,7 +1050,7 @@ static void _find_identifiers(GDScriptParser::CompletionContext &p_context, bool
 	static const char *_keywords_with_space[] = {
 		"and", "in", "not", "or", "as", "class", "extends", "is", "func", "signal", "await",
 		"const", "enum", "static", "var", "if", "elif", "else", "for", "match", "while",
-		0
+		nullptr
 	};
 
 	const char **kws = _keywords_with_space;
@@ -1063,7 +1063,7 @@ static void _find_identifiers(GDScriptParser::CompletionContext &p_context, bool
 
 	static const char *_keywords_with_args[] = {
 		"assert", "preload",
-		0
+		nullptr
 	};
 
 	const char **kwa = _keywords_with_args;
@@ -2892,7 +2892,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					v = v_ref;
 				} else {
 					Callable::CallError err;
-					Variant::construct(base_type.builtin_type, v, NULL, 0, err);
+					Variant::construct(base_type.builtin_type, v, nullptr, 0, err);
 					if (err.error != Callable::CallError::CALL_OK) {
 						break;
 					}

--- a/modules/gltf/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor_scene_importer_gltf.h
@@ -64,8 +64,8 @@ public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			int p_bake_fps,
-			List<String> *r_missing_deps = NULL,
-			Error *r_err = NULL) override;
+			List<String> *r_missing_deps = nullptr,
+			Error *r_err = nullptr) override;
 	virtual Ref<Animation> import_animation(const String &p_path,
 			uint32_t p_flags, int p_bake_fps) override;
 };
@@ -80,7 +80,7 @@ protected:
 public:
 	virtual void save_scene(Node *p_node, const String &p_path, const String &p_src_path,
 			uint32_t p_flags, int p_bake_fps,
-			List<String> *r_missing_deps, Error *r_err = NULL);
+			List<String> *r_missing_deps, Error *r_err = nullptr);
 	virtual void _build_parent_hierachy(Ref<GLTFState> state);
 	virtual Error export_gltf(Node *p_root, String p_path, int32_t p_flags = 0,
 			real_t p_bake_fps = 1000.0f);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -940,22 +940,29 @@ String GLTFDocument::_get_accessor_type_name(const GLTFDocument::GLTFType p_type
 }
 
 GLTFDocument::GLTFType GLTFDocument::_get_type_from_str(const String &p_string) {
-	if (p_string == "SCALAR")
+	if (p_string == "SCALAR") {
 		return GLTFDocument::TYPE_SCALAR;
+	}
 
-	if (p_string == "VEC2")
+	if (p_string == "VEC2") {
 		return GLTFDocument::TYPE_VEC2;
-	if (p_string == "VEC3")
+	}
+	if (p_string == "VEC3") {
 		return GLTFDocument::TYPE_VEC3;
-	if (p_string == "VEC4")
+	}
+	if (p_string == "VEC4") {
 		return GLTFDocument::TYPE_VEC4;
+	}
 
-	if (p_string == "MAT2")
+	if (p_string == "MAT2") {
 		return GLTFDocument::TYPE_MAT2;
-	if (p_string == "MAT3")
+	}
+	if (p_string == "MAT3") {
 		return GLTFDocument::TYPE_MAT3;
-	if (p_string == "MAT4")
+	}
+	if (p_string == "MAT4") {
 		return GLTFDocument::TYPE_MAT4;
+	}
 
 	ERR_FAIL_V(GLTFDocument::TYPE_SCALAR);
 }
@@ -1434,8 +1441,9 @@ Vector<double> GLTFDocument::_decode_accessor(Ref<GLTFState> state, const GLTFAc
 		ERR_FAIL_INDEX_V(a->buffer_view, state->buffer_views.size(), Vector<double>());
 
 		const Error err = _decode_buffer_view(state, dst, a->buffer_view, skip_every, skip_bytes, element_size, a->count, a->type, component_count, a->component_type, component_size, a->normalized, a->byte_offset, p_for_vertex);
-		if (err != OK)
+		if (err != OK) {
 			return Vector<double>();
+		}
 	} else {
 		//fill with zeros, as bufferview is not defined.
 		for (int i = 0; i < (a->count * component_count); i++) {
@@ -1450,14 +1458,16 @@ Vector<double> GLTFDocument::_decode_accessor(Ref<GLTFState> state, const GLTFAc
 		const int indices_component_size = _get_component_type_size(a->sparse_indices_component_type);
 
 		Error err = _decode_buffer_view(state, indices.ptrw(), a->sparse_indices_buffer_view, 0, 0, indices_component_size, a->sparse_count, TYPE_SCALAR, 1, a->sparse_indices_component_type, indices_component_size, false, a->sparse_indices_byte_offset, false);
-		if (err != OK)
+		if (err != OK) {
 			return Vector<double>();
+		}
 
 		Vector<double> data;
 		data.resize(component_count * a->sparse_count);
 		err = _decode_buffer_view(state, data.ptrw(), a->sparse_values_buffer_view, skip_every, skip_bytes, element_size, a->sparse_count, a->type, component_count, a->component_type, component_size, a->normalized, a->sparse_values_byte_offset, p_for_vertex);
-		if (err != OK)
+		if (err != OK) {
 			return Vector<double>();
+		}
 
 		for (int i = 0; i < indices.size(); i++) {
 			const int write_offset = int(indices[i]) * component_count;
@@ -1528,8 +1538,9 @@ Vector<int> GLTFDocument::_decode_accessor_as_ints(Ref<GLTFState> state, const G
 	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<int> ret;
 
-	if (attribs.size() == 0)
+	if (attribs.size() == 0) {
 		return ret;
+	}
 
 	const double *attribs_ptr = attribs.ptr();
 	const int ret_size = attribs.size();
@@ -1546,8 +1557,9 @@ Vector<float> GLTFDocument::_decode_accessor_as_floats(Ref<GLTFState> state, con
 	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<float> ret;
 
-	if (attribs.size() == 0)
+	if (attribs.size() == 0) {
 		return ret;
+	}
 
 	const double *attribs_ptr = attribs.ptr();
 	const int ret_size = attribs.size();
@@ -1820,8 +1832,9 @@ Vector<Vector2> GLTFDocument::_decode_accessor_as_vec2(Ref<GLTFState> state, con
 	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Vector2> ret;
 
-	if (attribs.size() == 0)
+	if (attribs.size() == 0) {
 		return ret;
+	}
 
 	ERR_FAIL_COND_V(attribs.size() % 2 != 0, ret);
 	const double *attribs_ptr = attribs.ptr();
@@ -1998,8 +2011,9 @@ Vector<Vector3> GLTFDocument::_decode_accessor_as_vec3(Ref<GLTFState> state, con
 	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Vector3> ret;
 
-	if (attribs.size() == 0)
+	if (attribs.size() == 0) {
 		return ret;
+	}
 
 	ERR_FAIL_COND_V(attribs.size() % 3 != 0, ret);
 	const double *attribs_ptr = attribs.ptr();
@@ -2017,8 +2031,9 @@ Vector<Color> GLTFDocument::_decode_accessor_as_color(Ref<GLTFState> state, cons
 	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Color> ret;
 
-	if (attribs.size() == 0)
+	if (attribs.size() == 0) {
 		return ret;
+	}
 
 	const int type = state->accessors[p_accessor]->type;
 	ERR_FAIL_COND_V(!(type == TYPE_VEC3 || type == TYPE_VEC4), ret);
@@ -2042,8 +2057,9 @@ Vector<Quat> GLTFDocument::_decode_accessor_as_quat(Ref<GLTFState> state, const 
 	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Quat> ret;
 
-	if (attribs.size() == 0)
+	if (attribs.size() == 0) {
 		return ret;
+	}
 
 	ERR_FAIL_COND_V(attribs.size() % 4 != 0, ret);
 	const double *attribs_ptr = attribs.ptr();
@@ -2060,8 +2076,9 @@ Vector<Transform2D> GLTFDocument::_decode_accessor_as_xform2d(Ref<GLTFState> sta
 	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Transform2D> ret;
 
-	if (attribs.size() == 0)
+	if (attribs.size() == 0) {
 		return ret;
+	}
 
 	ERR_FAIL_COND_V(attribs.size() % 4 != 0, ret);
 	ret.resize(attribs.size() / 4);
@@ -2076,8 +2093,9 @@ Vector<Basis> GLTFDocument::_decode_accessor_as_basis(Ref<GLTFState> state, cons
 	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Basis> ret;
 
-	if (attribs.size() == 0)
+	if (attribs.size() == 0) {
 		return ret;
+	}
 
 	ERR_FAIL_COND_V(attribs.size() % 9 != 0, ret);
 	ret.resize(attribs.size() / 9);
@@ -2093,8 +2111,9 @@ Vector<Transform> GLTFDocument::_decode_accessor_as_xform(Ref<GLTFState> state, 
 	const Vector<double> attribs = _decode_accessor(state, p_accessor, p_for_vertex);
 	Vector<Transform> ret;
 
-	if (attribs.size() == 0)
+	if (attribs.size() == 0) {
 		return ret;
+	}
 
 	ERR_FAIL_COND_V(attribs.size() % 16 != 0, ret);
 	ret.resize(attribs.size() / 16);
@@ -3046,8 +3065,9 @@ Error GLTFDocument::_serialize_textures(Ref<GLTFState> state) {
 }
 
 Error GLTFDocument::_parse_textures(Ref<GLTFState> state) {
-	if (!state->json.has("textures"))
+	if (!state->json.has("textures")) {
 		return OK;
+	}
 
 	const Array &textures = state->json["textures"];
 	for (GLTFTextureIndex i = 0; i < textures.size(); i++) {
@@ -3340,8 +3360,9 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> state) {
 }
 
 Error GLTFDocument::_parse_materials(Ref<GLTFState> state) {
-	if (!state->json.has("materials"))
+	if (!state->json.has("materials")) {
 		return OK;
+	}
 
 	const Array &materials = state->json["materials"];
 	for (GLTFMaterialIndex i = 0; i < materials.size(); i++) {
@@ -3858,8 +3879,9 @@ Error GLTFDocument::_verify_skin(Ref<GLTFState> state, Ref<GLTFSkin> skin) {
 }
 
 Error GLTFDocument::_parse_skins(Ref<GLTFState> state) {
-	if (!state->json.has("skins"))
+	if (!state->json.has("skins")) {
 		return OK;
+	}
 
 	const Array &skins = state->json["skins"];
 
@@ -4108,8 +4130,9 @@ Error GLTFDocument::_reparent_to_fake_joint(Ref<GLTFState> state, Ref<GLTFSkelet
 	state->nodes.push_back(fake_joint);
 
 	// We better not be a joint, or we messed up in our logic
-	if (node->joint)
+	if (node->joint) {
 		return FAILED;
+	}
 
 	fake_joint->translation = node->translation;
 	fake_joint->rotation = node->rotation;
@@ -4528,8 +4551,9 @@ Error GLTFDocument::_parse_lights(Ref<GLTFState> state) {
 }
 
 Error GLTFDocument::_parse_cameras(Ref<GLTFState> state) {
-	if (!state->json.has("cameras"))
+	if (!state->json.has("cameras")) {
 		return OK;
+	}
 
 	const Array cameras = state->json["cameras"];
 
@@ -4730,8 +4754,9 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 }
 
 Error GLTFDocument::_parse_animations(Ref<GLTFState> state) {
-	if (!state->json.has("animations"))
+	if (!state->json.has("animations")) {
 		return OK;
+	}
 
 	const Array &animations = state->json["animations"];
 
@@ -4741,8 +4766,9 @@ Error GLTFDocument::_parse_animations(Ref<GLTFState> state) {
 		Ref<GLTFAnimation> animation;
 		animation.instance();
 
-		if (!d.has("channels") || !d.has("samplers"))
+		if (!d.has("channels") || !d.has("samplers")) {
 			continue;
+		}
 
 		Array channels = d["channels"];
 		Array samplers = d["samplers"];
@@ -4757,8 +4783,9 @@ Error GLTFDocument::_parse_animations(Ref<GLTFState> state) {
 
 		for (int j = 0; j < channels.size(); j++) {
 			const Dictionary &c = channels[j];
-			if (!c.has("target"))
+			if (!c.has("target")) {
 				continue;
+			}
 
 			const Dictionary &t = c["target"];
 			if (!t.has("node") || !t.has("path")) {
@@ -4868,8 +4895,9 @@ void GLTFDocument::_assign_scene_names(Ref<GLTFState> state) {
 		Ref<GLTFNode> n = state->nodes[i];
 
 		// Any joints get unique names generated when the skeleton is made, unique to the skeleton
-		if (n->skeleton >= 0)
+		if (n->skeleton >= 0) {
 			continue;
+		}
 
 		if (n->get_name().is_empty()) {
 			if (n->mesh >= 0) {
@@ -5515,8 +5543,9 @@ T GLTFDocument::_interpolate_track(const Vector<float> &p_times, const Vector<T>
 	//could use binary search, worth it?
 	int idx = -1;
 	for (int i = 0; i < p_times.size(); i++) {
-		if (p_times[i] > p_time)
+		if (p_times[i] > p_time) {
 			break;
+		}
 		idx++;
 	}
 
@@ -6356,13 +6385,15 @@ Error GLTFDocument::parse(Ref<GLTFState> state, String p_path, bool p_read_binar
 		//binary file
 		//text file
 		err = _parse_glb(p_path, state);
-		if (err)
+		if (err) {
 			return FAILED;
+		}
 	} else {
 		//text file
 		err = _parse_json(p_path, state);
-		if (err)
+		if (err) {
 			return FAILED;
+		}
 	}
 	f->close();
 
@@ -6382,68 +6413,81 @@ Error GLTFDocument::parse(Ref<GLTFState> state, String p_path, bool p_read_binar
 
 	/* STEP 0 PARSE SCENE */
 	err = _parse_scenes(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 1 PARSE NODES */
 	err = _parse_nodes(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 2 PARSE BUFFERS */
 	err = _parse_buffers(state, p_path.get_base_dir());
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 3 PARSE BUFFER VIEWS */
 	err = _parse_buffer_views(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 4 PARSE ACCESSORS */
 	err = _parse_accessors(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 5 PARSE IMAGES */
 	err = _parse_images(state, p_path.get_base_dir());
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 6 PARSE TEXTURES */
 	err = _parse_textures(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 7 PARSE TEXTURES */
 	err = _parse_materials(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 9 PARSE SKINS */
 	err = _parse_skins(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 10 DETERMINE SKELETONS */
 	err = _determine_skeletons(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 11 CREATE SKELETONS */
 	err = _create_skeletons(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 12 CREATE SKINS */
 	err = _create_skins(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 13 PARSE MESHES (we have enough info now) */
 	err = _parse_meshes(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 14 PARSE LIGHTS */
 	err = _parse_lights(state);
@@ -6453,13 +6497,15 @@ Error GLTFDocument::parse(Ref<GLTFState> state, String p_path, bool p_read_binar
 
 	/* STEP 15 PARSE CAMERAS */
 	err = _parse_cameras(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 16 PARSE ANIMATIONS */
 	err = _parse_animations(state);
-	if (err != OK)
+	if (err != OK) {
 		return Error::FAILED;
+	}
 
 	/* STEP 17 ASSIGN SCENE NAMES */
 	_assign_scene_names(state);

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -99,8 +99,9 @@ float AudioStreamPlaybackMP3::get_playback_position() const {
 }
 
 void AudioStreamPlaybackMP3::seek(float p_time) {
-	if (!active)
+	if (!active) {
 		return;
+	}
 
 	if (p_time >= mp3_stream->get_length()) {
 		p_time = 0;

--- a/modules/text_server_adv/dynamic_font_adv.cpp
+++ b/modules/text_server_adv/dynamic_font_adv.cpp
@@ -231,7 +231,7 @@ Dictionary DynamicFontDataAdvanced::get_feature_list() const {
 
 	Dictionary out;
 	// Read feature flags.
-	unsigned int count = hb_ot_layout_table_get_feature_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GSUB, 0, NULL, NULL);
+	unsigned int count = hb_ot_layout_table_get_feature_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GSUB, 0, nullptr, nullptr);
 	if (count != 0) {
 		hb_tag_t *feature_tags = (hb_tag_t *)memalloc(count * sizeof(hb_tag_t));
 		hb_ot_layout_table_get_feature_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GSUB, 0, &count, feature_tags);
@@ -240,7 +240,7 @@ Dictionary DynamicFontDataAdvanced::get_feature_list() const {
 		}
 		memfree(feature_tags);
 	}
-	count = hb_ot_layout_table_get_feature_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GPOS, 0, NULL, NULL);
+	count = hb_ot_layout_table_get_feature_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GPOS, 0, nullptr, nullptr);
 	if (count != 0) {
 		hb_tag_t *feature_tags = (hb_tag_t *)memalloc(count * sizeof(hb_tag_t));
 		hb_ot_layout_table_get_feature_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GPOS, 0, &count, feature_tags);
@@ -639,7 +639,7 @@ bool DynamicFontDataAdvanced::is_script_supported(uint32_t p_script) const {
 	DataAtSize *fds = const_cast<DynamicFontDataAdvanced *>(this)->get_data_for_size(base_size);
 	ERR_FAIL_COND_V(fds == nullptr, false);
 
-	unsigned int count = hb_ot_layout_table_get_script_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GSUB, 0, NULL, NULL);
+	unsigned int count = hb_ot_layout_table_get_script_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GSUB, 0, nullptr, nullptr);
 	if (count != 0) {
 		hb_tag_t *script_tags = (hb_tag_t *)memalloc(count * sizeof(hb_tag_t));
 		hb_ot_layout_table_get_script_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GSUB, 0, &count, script_tags);
@@ -651,7 +651,7 @@ bool DynamicFontDataAdvanced::is_script_supported(uint32_t p_script) const {
 		}
 		memfree(script_tags);
 	}
-	count = hb_ot_layout_table_get_script_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GPOS, 0, NULL, NULL);
+	count = hb_ot_layout_table_get_script_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GPOS, 0, nullptr, nullptr);
 	if (count != 0) {
 		hb_tag_t *script_tags = (hb_tag_t *)memalloc(count * sizeof(hb_tag_t));
 		hb_ot_layout_table_get_script_tags(hb_font_get_face(fds->hb_handle), HB_OT_TAG_GPOS, 0, &count, script_tags);

--- a/modules/text_server_adv/script_iterator.cpp
+++ b/modules/text_server_adv/script_iterator.cpp
@@ -75,10 +75,12 @@ ScriptIterator::ScriptIterator(const String &p_string, int p_start, int p_length
 					while (paren_sp >= 0 && paren_stack[paren_sp].pair_index != paired_ch) {
 						paren_sp -= 1;
 					}
-					if (paren_sp < start_sp)
+					if (paren_sp < start_sp) {
 						start_sp = paren_sp;
-					if (paren_sp >= 0)
+					}
+					if (paren_sp >= 0) {
 						sc = paren_stack[paren_sp].script_code;
+					}
 				}
 			}
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1832,8 +1832,9 @@ _FORCE_INLINE_ int _generate_kashida_justification_opportunies(const String &p_d
 				}
 			}
 		}
-		if (!is_transparent(c))
+		if (!is_transparent(c)) {
 			pc = c;
+		}
 		i++;
 	}
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2050,12 +2050,12 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 
 				instance->id = F->get();
 				instance->input_port_count = node->get_input_value_port_count();
-				instance->input_ports = NULL;
+				instance->input_ports = nullptr;
 				instance->output_port_count = node->get_output_value_port_count();
-				instance->output_ports = NULL;
+				instance->output_ports = nullptr;
 				instance->sequence_output_count = node->get_output_sequence_port_count();
 				instance->sequence_index = function.node_count++;
-				instance->sequence_outputs = NULL;
+				instance->sequence_outputs = nullptr;
 				instance->pass_idx = -1;
 
 				if (instance->input_port_count) {
@@ -2075,7 +2075,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				if (instance->sequence_output_count) {
 					instance->sequence_outputs = memnew_arr(VisualScriptNodeInstance *, instance->sequence_output_count);
 					for (int i = 0; i < instance->sequence_output_count; i++) {
-						instance->sequence_outputs[i] = NULL; // If it remains null, flow ends here.
+						instance->sequence_outputs[i] = nullptr; // If it remains null, flow ends here.
 					}
 				}
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -784,8 +784,9 @@ ScriptInstance *VisualScript::instance_create(Object *p_this) {
 		variables.get_key_list(&keys);
 
 		for (const List<StringName>::Element *E = keys.front(); E; E = E->next()) {
-			if (!variables[E->get()]._export)
+			if (!variables[E->get()]._export) {
 				continue;
+			}
 
 			PropertyInfo p = variables[E->get()].info;
 			p.name = String(E->get());
@@ -2085,10 +2086,11 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 
 					StringName var_name;
 
-					if (Object::cast_to<VisualScriptLocalVar>(*node))
+					if (Object::cast_to<VisualScriptLocalVar>(*node)) {
 						var_name = String(Object::cast_to<VisualScriptLocalVar>(*node)->get_var_name()).strip_edges();
-					else
+					} else {
 						var_name = String(Object::cast_to<VisualScriptLocalVarSet>(*node)->get_var_name()).strip_edges();
+					}
 
 					if (!local_var_indices.has(var_name)) {
 						local_var_indices[var_name] = function.max_stack;

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3017,9 +3017,9 @@ void VisualScriptEditor::_graph_connect_to_empty(const String &p_from, int p_fro
 	if (!vsn.is_valid()) {
 		return;
 	}
-	if (vsn->get_output_value_port_count())
-
+	if (vsn->get_output_value_port_count()) {
 		port_action_pos = p_release_pos;
+	}
 
 	if (p_from_slot < vsn->get_output_sequence_port_count()) {
 		port_action_node = p_from.to_int();

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -2484,7 +2484,7 @@ public:
 			_clear_assets_directory();
 			if (!apk_expansion) {
 				print_verbose("Exporting project files..");
-				err = export_project_files(p_preset, rename_and_store_file_in_gradle_project, NULL, ignore_so_file);
+				err = export_project_files(p_preset, rename_and_store_file_in_gradle_project, nullptr, ignore_so_file);
 				if (err != OK) {
 					EditorNode::add_io_error("Could not export project files to gradle project\n");
 					return err;
@@ -2813,11 +2813,11 @@ public:
 		zipOpenNewFileInZip(unaligned_apk,
 				"assets/_cl_",
 				&zipfi,
-				NULL,
+				nullptr,
 				0,
-				NULL,
+				nullptr,
 				0,
-				NULL,
+				nullptr,
 				0, // No compress (little size gain and potentially slower startup)
 				Z_DEFAULT_COMPRESSION);
 		zipWriteInFileInZip(unaligned_apk, command_line_flags.ptr(), command_line_flags.size());

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -2262,8 +2262,9 @@ public:
 				CharString command_line_argument = command_line_strings[i].utf8();
 				int base = r_command_line_flags.size();
 				int length = command_line_argument.length();
-				if (length == 0)
+				if (length == 0) {
 					continue;
+				}
 				r_command_line_flags.resize(base + 4 + length);
 				encode_uint32(length, &r_command_line_flags.write[base]);
 				copymem(&r_command_line_flags.write[base + 4], command_line_argument.ptr(), length);
@@ -2615,10 +2616,11 @@ public:
 		}
 		// This is the start of the Legacy build system
 		print_verbose("Starting legacy build system..");
-		if (p_debug)
+		if (p_debug) {
 			src_apk = p_preset->get("custom_template/debug");
-		else
+		} else {
 			src_apk = p_preset->get("custom_template/release");
+		}
 		src_apk = src_apk.strip_edges();
 		if (src_apk == "") {
 			if (p_debug) {

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -47,20 +47,21 @@ const String godot_project_name_xml_string = R"(<?xml version="1.0" encoding="ut
 DisplayServer::ScreenOrientation _get_screen_orientation() {
 	String orientation_settings = ProjectSettings::get_singleton()->get("display/window/handheld/orientation");
 	DisplayServer::ScreenOrientation screen_orientation;
-	if (orientation_settings == "portrait")
+	if (orientation_settings == "portrait") {
 		screen_orientation = DisplayServer::SCREEN_PORTRAIT;
-	else if (orientation_settings == "reverse_landscape")
+	} else if (orientation_settings == "reverse_landscape") {
 		screen_orientation = DisplayServer::SCREEN_REVERSE_LANDSCAPE;
-	else if (orientation_settings == "reverse_portrait")
+	} else if (orientation_settings == "reverse_portrait") {
 		screen_orientation = DisplayServer::SCREEN_REVERSE_PORTRAIT;
-	else if (orientation_settings == "sensor_landscape")
+	} else if (orientation_settings == "sensor_landscape") {
 		screen_orientation = DisplayServer::SCREEN_SENSOR_LANDSCAPE;
-	else if (orientation_settings == "sensor_portrait")
+	} else if (orientation_settings == "sensor_portrait") {
 		screen_orientation = DisplayServer::SCREEN_SENSOR_PORTRAIT;
-	else if (orientation_settings == "sensor")
+	} else if (orientation_settings == "sensor") {
 		screen_orientation = DisplayServer::SCREEN_SENSOR;
-	else
+	} else {
 		screen_orientation = DisplayServer::SCREEN_LANDSCAPE;
+	}
 
 	return screen_orientation;
 }

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -550,7 +550,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 		if (f) {
 			file_sizes[pck_path.get_file()] = (uint64_t)f->get_len();
 			memdelete(f);
-			f = NULL;
+			f = nullptr;
 		}
 		_fix_html(html, p_preset, p_path.get_file().get_basename(), p_debug, p_flags, shared_objects, file_sizes);
 		f = FileAccess::open(p_path, FileAccess::WRITE);

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -2012,7 +2012,7 @@ int DisplayServerX11::keyboard_get_layout_count() const {
 		XkbGetNames(x11_display, XkbSymbolsNameMask, kbd);
 
 		const Atom *groups = kbd->names->groups;
-		if (kbd->ctrls != NULL) {
+		if (kbd->ctrls != nullptr) {
 			_group_count = kbd->ctrls->num_groups;
 		} else {
 			while (_group_count < XkbNumKbdGroups && groups[_group_count] != None) {
@@ -2046,7 +2046,7 @@ String DisplayServerX11::keyboard_get_layout_language(int p_index) const {
 
 		int _group_count = 0;
 		const Atom *groups = kbd->names->groups;
-		if (kbd->ctrls != NULL) {
+		if (kbd->ctrls != nullptr) {
 			_group_count = kbd->ctrls->num_groups;
 		} else {
 			while (_group_count < XkbNumKbdGroups && groups[_group_count] != None) {
@@ -2085,7 +2085,7 @@ String DisplayServerX11::keyboard_get_layout_name(int p_index) const {
 
 		int _group_count = 0;
 		const Atom *groups = kbd->names->groups;
-		if (kbd->ctrls != NULL) {
+		if (kbd->ctrls != nullptr) {
 			_group_count = kbd->ctrls->num_groups;
 		} else {
 			while (_group_count < XkbNumKbdGroups && groups[_group_count] != None) {
@@ -2684,7 +2684,7 @@ bool DisplayServerX11::_wait_for_events() const {
 	tv.tv_sec = 1;
 
 	// Wait for next event or timeout.
-	int num_ready_fds = select(x11_fd + 1, &in_fds, NULL, NULL, &tv);
+	int num_ready_fds = select(x11_fd + 1, &in_fds, nullptr, nullptr, &tv);
 
 	if (num_ready_fds > 0) {
 		// Event received.

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -178,7 +178,7 @@ void JoypadLinux::monitor_joypads(udev *p_udev) {
 			   select() ensured that this will not block. */
 			dev = udev_monitor_receive_device(mon);
 
-			if (dev && udev_device_get_devnode(dev) != 0) {
+			if (dev && udev_device_get_devnode(dev) != nullptr) {
 				MutexLock lock(joy_mutex);
 				String action = udev_device_get_action(dev);
 				const char *devnode = udev_device_get_devnode(dev);
@@ -212,7 +212,7 @@ void JoypadLinux::monitor_joypads() {
 				struct dirent *current;
 				char fname[64];
 
-				while ((current = readdir(input_directory)) != NULL) {
+				while ((current = readdir(input_directory)) != nullptr) {
 					if (strncmp(current->d_name, "event", 5) != 0) {
 						continue;
 					}

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -185,10 +185,11 @@ void JoypadLinux::monitor_joypads(udev *p_udev) {
 				if (devnode) {
 					String devnode_str = devnode;
 					if (devnode_str.find(ignore_str) == -1) {
-						if (action == "add")
+						if (action == "add") {
 							open_joypad(devnode);
-						else if (String(action) == "remove")
+						} else if (String(action) == "remove") {
 							close_joypad(get_joy_from_path(devnode));
+						}
 					}
 				}
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -203,8 +203,8 @@ class AnimatedSprite3D : public SpriteBase3D {
 
 	float timeout = 0.0;
 
-	bool hflip = 1;
-	bool vflip = 1;
+	bool hflip = true;
+	bool vflip = true;
 
 	Color modulate;
 

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -454,7 +454,7 @@ void HTTPRequest::_request_done(int p_status, int p_code, const PackedStringArra
 		is_compressed = false;
 	}
 
-	const PackedByteArray *data = NULL;
+	const PackedByteArray *data = nullptr;
 
 	if (accept_gzip && is_compressed && p_data.size() > 0) {
 		// Decompress request body

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1968,8 +1968,9 @@ Node *Node::get_deepest_editable_node(Node *p_start_node) const {
 	Node *node = p_start_node;
 
 	while (iterated_item->get_owner() && iterated_item->get_owner() != this) {
-		if (!is_editable_instance(iterated_item->get_owner()))
+		if (!is_editable_instance(iterated_item->get_owner())) {
 			node = iterated_item->get_owner();
+		}
 
 		iterated_item = iterated_item->get_owner();
 	}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3228,8 +3228,9 @@ Viewport::ScreenSpaceAA Viewport::get_screen_space_aa() const {
 }
 
 void Viewport::set_use_debanding(bool p_use_debanding) {
-	if (use_debanding == p_use_debanding)
+	if (use_debanding == p_use_debanding) {
 		return;
+	}
 	use_debanding = p_use_debanding;
 	RS::get_singleton()->viewport_set_use_debanding(viewport, p_use_debanding);
 }

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -620,11 +620,13 @@ int TextParagraph::hit_test(const Point2 &p_coords) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	Vector2 ofs;
 	if (TS->shaped_text_get_orientation(rid) == TextServer::ORIENTATION_HORIZONTAL) {
-		if (ofs.y < 0)
+		if (ofs.y < 0) {
 			return 0;
+		}
 	} else {
-		if (ofs.x < 0)
+		if (ofs.x < 0) {
 			return 0;
+		}
 	}
 	for (int i = 0; i < lines.size(); i++) {
 		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -4660,16 +4660,18 @@ String VisualShaderNodeTexture2DArrayUniform::generate_global(Shader::Mode p_mod
 
 	switch (texture_type) {
 		case TYPE_DATA:
-			if (color_default == COLOR_DEFAULT_BLACK)
+			if (color_default == COLOR_DEFAULT_BLACK) {
 				code += " : hint_black;\n";
-			else
+			} else {
 				code += ";\n";
+			}
 			break;
 		case TYPE_COLOR:
-			if (color_default == COLOR_DEFAULT_BLACK)
+			if (color_default == COLOR_DEFAULT_BLACK) {
 				code += " : hint_black_albedo;\n";
-			else
+			} else {
 				code += " : hint_albedo;\n";
+			}
 			break;
 		case TYPE_NORMAL_MAP:
 			code += " : hint_normal;\n";
@@ -4728,16 +4730,18 @@ String VisualShaderNodeTexture3DUniform::generate_global(Shader::Mode p_mode, Vi
 
 	switch (texture_type) {
 		case TYPE_DATA:
-			if (color_default == COLOR_DEFAULT_BLACK)
+			if (color_default == COLOR_DEFAULT_BLACK) {
 				code += " : hint_black;\n";
-			else
+			} else {
 				code += ";\n";
+			}
 			break;
 		case TYPE_COLOR:
-			if (color_default == COLOR_DEFAULT_BLACK)
+			if (color_default == COLOR_DEFAULT_BLACK) {
 				code += " : hint_black_albedo;\n";
-			else
+			} else {
 				code += " : hint_albedo;\n";
+			}
 			break;
 		case TYPE_NORMAL_MAP:
 			code += " : hint_normal;\n";

--- a/servers/physics_3d/step_3d_sw.cpp
+++ b/servers/physics_3d/step_3d_sw.cpp
@@ -232,7 +232,7 @@ void Step3DSW::step(Space3DSW *p_space, real_t p_delta, int p_iterations) {
 			if (c->get_island_step() == _step)
 				continue;
 			c->set_island_step(_step);
-			c->set_island_next(NULL);
+			c->set_island_next(nullptr);
 			c->set_island_list_next(constraint_island_list);
 			constraint_island_list = c;
 		}

--- a/servers/physics_3d/step_3d_sw.cpp
+++ b/servers/physics_3d/step_3d_sw.cpp
@@ -229,8 +229,9 @@ void Step3DSW::step(Space3DSW *p_space, real_t p_delta, int p_iterations) {
 	while (sb) {
 		for (const Set<Constraint3DSW *>::Element *E = sb->self()->get_constraints().front(); E; E = E->next()) {
 			Constraint3DSW *c = E->get();
-			if (c->get_island_step() == _step)
+			if (c->get_island_step() == _step) {
 				continue;
+			}
 			c->set_island_step(_step);
 			c->set_island_next(nullptr);
 			c->set_island_list_next(constraint_island_list);

--- a/servers/rendering/renderer_rd/renderer_scene_render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward_clustered.cpp
@@ -3022,8 +3022,9 @@ void RendererSceneRenderForwardClustered::_geometry_instance_update(GeometryInst
 
 			for (int j = 0; j < draw_passes; j++) {
 				RID mesh = storage->particles_get_draw_pass_mesh(ginstance->data->base, j);
-				if (!mesh.is_valid())
+				if (!mesh.is_valid()) {
 					continue;
+				}
 
 				const RID *materials = nullptr;
 				uint32_t surface_count;

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -4692,10 +4692,11 @@ void RendererStorageRD::update_particles() {
 
 		if (particles->clear && particles->pre_process_time > 0.0) {
 			float frame_time;
-			if (particles->fixed_fps > 0)
+			if (particles->fixed_fps > 0) {
 				frame_time = 1.0 / particles->fixed_fps;
-			else
+			} else {
 				frame_time = 1.0 / 30.0;
+			}
 
 			float todo = particles->pre_process_time;
 
@@ -4731,10 +4732,11 @@ void RendererStorageRD::update_particles() {
 			particles->frame_remainder = todo;
 
 		} else {
-			if (zero_time_scale)
+			if (zero_time_scale) {
 				_particles_process(particles, 0.0);
-			else
+			} else {
 				_particles_process(particles, RendererCompositorRD::singleton->get_frame_delta_time());
+			}
 		}
 
 		//copy particles to instance buffer

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -691,21 +691,21 @@ private:
 	};
 
 	struct Particles {
-		bool inactive;
-		float inactive_time;
-		bool emitting;
-		bool one_shot;
-		int amount;
-		float lifetime;
-		float pre_process_time;
-		float explosiveness;
-		float randomness;
-		bool restart_request;
-		AABB custom_aabb;
-		bool use_local_coords;
+		bool inactive = true;
+		float inactive_time = 0.0;
+		bool emitting = false;
+		bool one_shot = false;
+		int amount = 0;
+		float lifetime = 1.0;
+		float pre_process_time = 0.0;
+		float explosiveness = 0.0;
+		float randomness = 0.0;
+		bool restart_request = false;
+		AABB custom_aabb = AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8));
+		bool use_local_coords = true;
 		RID process_material;
 
-		RS::ParticlesDrawOrder draw_order;
+		RS::ParticlesDrawOrder draw_order = RS::PARTICLES_DRAW_ORDER_INDEX;
 
 		Vector<RID> draw_passes;
 
@@ -730,21 +730,21 @@ private:
 
 		RID sub_emitter;
 
-		float phase;
-		float prev_phase;
-		uint64_t prev_ticks;
-		uint32_t random_seed;
+		float phase = 0.0;
+		float prev_phase = 0.0;
+		uint64_t prev_ticks = 0;
+		uint32_t random_seed = 0;
 
-		uint32_t cycle_number;
+		uint32_t cycle_number = 0;
 
-		float speed_scale;
+		float speed_scale = 1.0;
 
-		int fixed_fps;
-		bool fractional_delta;
-		float frame_remainder;
-		float collision_base_size;
+		int fixed_fps = 0;
+		bool fractional_delta = false;
+		float frame_remainder = 0;
+		float collision_base_size = 0.01;
 
-		bool clear;
+		bool clear = true;
 
 		bool force_sub_emit = false;
 
@@ -756,31 +756,6 @@ private:
 		RID emission_storage_buffer;
 
 		Set<RID> collisions;
-
-		Particles() :
-				inactive(true),
-				inactive_time(0.0),
-				emitting(false),
-				one_shot(false),
-				amount(0),
-				lifetime(1.0),
-				pre_process_time(0.0),
-				explosiveness(0.0),
-				randomness(0.0),
-				restart_request(false),
-				custom_aabb(AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8))),
-				use_local_coords(true),
-				draw_order(RS::PARTICLES_DRAW_ORDER_INDEX),
-				prev_ticks(0),
-				random_seed(0),
-				cycle_number(0),
-				speed_scale(1.0),
-				fixed_fps(0),
-				fractional_delta(false),
-				frame_remainder(0),
-				collision_base_size(0.01),
-				clear(true) {
-		}
 
 		Dependency dependency;
 

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -6825,7 +6825,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 										} else {
 											_set_tkpos(pos2);
 
-											Node *n = _parse_and_reduce_expression(NULL, FunctionInfo());
+											Node *n = _parse_and_reduce_expression(nullptr, FunctionInfo());
 											if (!n || n->type != Node::TYPE_CONSTANT || n->get_datatype() != TYPE_INT) {
 												_set_error("Expected single integer constant > 0");
 												return ERR_PARSE_ERROR;
@@ -6906,7 +6906,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 
 								if (tk.type == TK_PARENTHESIS_OPEN || curly) { // initialization
 									while (true) {
-										Node *n = _parse_and_reduce_expression(NULL, FunctionInfo());
+										Node *n = _parse_and_reduce_expression(nullptr, FunctionInfo());
 										if (!n) {
 											return ERR_PARSE_ERROR;
 										}
@@ -6961,7 +6961,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 								constant.initializer = static_cast<ConstantNode *>(expr);
 							} else {
 								//variable created with assignment! must parse an expression
-								Node *expr = _parse_and_reduce_expression(NULL, FunctionInfo());
+								Node *expr = _parse_and_reduce_expression(nullptr, FunctionInfo());
 								if (!expr)
 									return ERR_PARSE_ERROR;
 								if (expr->type == Node::TYPE_OPERATOR && ((OperatorNode *)expr)->op == OP_CALL) {

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -6932,10 +6932,11 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 											decl.initializer.push_back(n);
 											break;
 										} else {
-											if (curly)
+											if (curly) {
 												_set_error("Expected '}' or ','");
-											else
+											} else {
 												_set_error("Expected ')' or ','");
+											}
 											return ERR_PARSE_ERROR;
 										}
 									}
@@ -6962,8 +6963,9 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 							} else {
 								//variable created with assignment! must parse an expression
 								Node *expr = _parse_and_reduce_expression(nullptr, FunctionInfo());
-								if (!expr)
+								if (!expr) {
 									return ERR_PARSE_ERROR;
+								}
 								if (expr->type == Node::TYPE_OPERATOR && ((OperatorNode *)expr)->op == OP_CALL) {
 									_set_error("Expected constant expression after '='");
 									return ERR_PARSE_ERROR;


### PR DESCRIPTION
Applies changes from our `.clang-tidy` config with `/usr/share/clang/run-clang-tidy.py -fix`. Note that to keep them in separate commits I edited `.clang-tidy` to apply checks one by one (could also be done from command line but didn't bother looking it up).

Still a painful process as:
- Can't figure out a way to make `clang-tidy` properly ignore `thirdparty`
- It's buggy and does stuff like `bool some_member = false = false;` or `if (cond) { {` which need to be reviewed and fixed manually.