### PR TITLE
Fix infinite loop when guessing argument type from parent class

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1745,8 +1745,8 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 								return true;
 							}
 						}
-						base_type = base_type.class_type->base_type;
 					}
+					base_type = base_type.class_type->base_type;
 					break;
 				case GDScriptParser::DataType::NATIVE: {
 					if (id_type.is_set() && !id_type.is_variant()) {


### PR DESCRIPTION
Closes #44281

This PR fixes an infinite loop that happen in gdscript_editor.cpp when, during validation, the code is guessing a method's argument type. 

If the parent class does not have the same method name, the code should then try the parent's parent and so on, until finding it or not, but it does not, leading to the infinite loop.
