### PR TITLE
Add methods to vector2i for consistency with vector2

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -257,3 +257,49 @@ bool Vector2i::operator==(const Vector2i &p_vec2) const {
 bool Vector2i::operator!=(const Vector2i &p_vec2) const {
 	return x != p_vec2.x || y != p_vec2.y;
 }
+
+real_t Vector2i::angle() const {
+	return Math::atan2((real_t)y, (real_t)x);
+}
+
+real_t Vector2i::angle_to(const Vector2i &p_vector2i) const {
+	return Math::atan2((real_t)cross(p_vector2i), (real_t)dot(p_vector2i));
+}
+
+real_t Vector2i::angle_to_point(const Vector2i &p_vector2i) const {
+	return Math::atan2((real_t)y - p_vector2i.y, (real_t)x - p_vector2i.x);
+}
+
+int Vector2i::cross(const Vector2i &p_other) const {
+	return x * p_other.y - y * p_other.x;
+}
+
+real_t Vector2i::distance_to(const Vector2i &p_vector2i) const {
+	return Math::sqrt((real_t)distance_squared_to(p_vector2i));
+}
+
+int Vector2i::distance_squared_to(const Vector2i &p_vector2i) const {
+	return (x - p_vector2i.x) * (x - p_vector2i.x) + (y - p_vector2i.y) * (y - p_vector2i.y);
+}
+
+int Vector2i::dot(const Vector2i &p_other) const {
+	return x * p_other.x + y * p_other.y;
+}
+
+real_t Vector2i::length() const {
+	return Math::sqrt((real_t)length_squared());
+}
+
+int Vector2i::length_squared() const {
+	return x * x + y * y;
+}
+
+Vector2i Vector2i::posmodv(const Vector2i &p_modv) const {
+	return Vector2(Math::posmod(x, p_modv.x), Math::posmod(y, p_modv.y));
+}
+
+Vector2i Vector2i::snapped(const Vector2i &p_step) const {
+	return Vector2(
+			Math::snapped(x, p_step.x),
+			Math::snapped(y, p_step.y));
+}

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -311,6 +311,22 @@ struct Vector2i {
 	Vector2i sign() const { return Vector2i(SGN(x), SGN(y)); }
 	Vector2i abs() const { return Vector2i(ABS(x), ABS(y)); }
 
+	real_t angle() const;
+	real_t angle_to(const Vector2i &p_vector2i) const;
+	real_t angle_to_point(const Vector2i &p_vector2i) const;
+	int cross(const Vector2i &p_other) const;
+	real_t distance_to(const Vector2i &p_vector2i) const;
+	int distance_squared_to(const Vector2i &p_vector2i) const;
+	int dot(const Vector2i &p_other) const;
+	real_t length() const;
+	int length_squared() const;
+	Vector2i posmodv(const Vector2i &p_modv) const;
+	Vector2i snapped(const Vector2i &p_by) const;
+
+	Vector2i orthogonal() const {
+		return Vector2i(y, -x);
+	}
+
 	operator String() const { return String::num(x) + ", " + String::num(y); }
 
 	operator Vector2() const { return Vector2(x, y); }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1168,6 +1168,18 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2i, aspect, sarray(), varray());
 	bind_method(Vector2i, sign, sarray(), varray());
 	bind_method(Vector2i, abs, sarray(), varray());
+	bind_method(Vector2i, angle, sarray(), varray());
+	bind_method(Vector2i, angle_to, sarray("to"), varray());
+	bind_method(Vector2i, angle_to_point, sarray("to"), varray());
+	bind_method(Vector2i, dot, sarray("with"), varray());
+	bind_method(Vector2i, orthogonal, sarray(), varray());
+	bind_method(Vector2i, posmodv, sarray("modv"), varray());
+	bind_method(Vector2i, distance_to, sarray("to"), varray());
+	bind_method(Vector2i, distance_squared_to, sarray("to"), varray());
+	bind_method(Vector2i, length, sarray(), varray());
+	bind_method(Vector2i, length_squared, sarray(), varray());
+	bind_method(Vector2i, cross, sarray("with"), varray());
+	bind_method(Vector2i, snapped, sarray("step"), varray());
 
 	/* Rect2 */
 


### PR DESCRIPTION
Implements the Vector2i side of proposal # [2297](https://github.com/godotengine/godot-proposals/issues/2297) by adding the following methods to Vector2i that already exist in Vector2 and exposing them to GDScript:

angle
angle_to
angle_to_point
cross
distance_to
distance_squared_to
dot
length
length_squared
posmodv
snapped

These methods were chosen based on discussions in proposal https://github.com/godotengine/godot-proposals/issues/2297

Below is a project that I used for testing.

[Vector2iTest.zip](https://github.com/godotengine/godot/files/6261106/Vector2iTest.zip)


If this PR is accepted then I will start work on the Vector3i portion of this.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
