### PR TITLE
Add flag to stop printing to stdout/stderr

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -106,10 +106,18 @@ void OS::add_logger(Logger *p_logger) {
 }
 
 void OS::print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, Logger::ErrorType p_type) {
+	if (!_stderr_enabled) {
+		return;
+	}
+
 	_logger->log_error(p_function, p_file, p_line, p_code, p_rationale, p_type);
 }
 
 void OS::print(const char *p_format, ...) {
+	if (!_stdout_enabled) {
+		return;
+	}
+
 	va_list argp;
 	va_start(argp, p_format);
 
@@ -119,6 +127,10 @@ void OS::print(const char *p_format, ...) {
 }
 
 void OS::printerr(const char *p_format, ...) {
+	if (!_stderr_enabled) {
+		return;
+	}
+
 	va_list argp;
 	va_start(argp, p_format);
 
@@ -161,6 +173,22 @@ bool OS::is_stdout_verbose() const {
 
 bool OS::is_stdout_debug_enabled() const {
 	return _debug_stdout;
+}
+
+bool OS::is_stdout_enabled() const {
+	return _stdout_enabled;
+}
+
+bool OS::is_stderr_enabled() const {
+	return _stderr_enabled;
+}
+
+void OS::set_stdout_enabled(bool p_enabled) {
+	_stdout_enabled = p_enabled;
+}
+
+void OS::set_stderr_enabled(bool p_enabled) {
+	_stderr_enabled = p_enabled;
 }
 
 void OS::dump_memory_to_file(const char *p_file) {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -60,6 +60,8 @@ class OS {
 	bool _allow_layered = false;
 	bool _use_vsync;
 	bool _vsync_via_compositor;
+	bool _stdout_enabled = true;
+	bool _stderr_enabled = true;
 
 	char *last_error;
 
@@ -218,6 +220,11 @@ public:
 
 	bool is_stdout_verbose() const;
 	bool is_stdout_debug_enabled() const;
+
+	bool is_stdout_enabled() const;
+	bool is_stderr_enabled() const;
+	void set_stdout_enabled(bool p_enabled);
+	void set_stderr_enabled(bool p_enabled);
 
 	virtual void disable_crash_handler() {}
 	virtual bool is_disable_crash_handler() const { return false; }


### PR DESCRIPTION
This allows the terminal output to be suppressed but still be captured by print/error handlers. Which is useful for a GDScript test suite (cf. #41074).
