### PR TITLE
[HTML5] Implement WebGL fallback.

### DIFF
--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -71,6 +71,7 @@ extern int godot_js_display_fullscreen_exit();
 extern void godot_js_display_compute_position(int p_x, int p_y, int32_t *r_x, int32_t *r_y);
 extern void godot_js_display_window_title_set(const char *p_text);
 extern void godot_js_display_window_icon_set(const uint8_t *p_ptr, int p_len);
+extern int godot_js_display_has_webgl(int p_version);
 
 // Display clipboard
 extern int godot_js_display_clipboard_set(const char *p_text);

--- a/platform/javascript/js/libs/library_godot_display.js
+++ b/platform/javascript/js/libs/library_godot_display.js
@@ -719,6 +719,17 @@ const GodotDisplay = {
 		GodotRuntime.setHeapValue(r_y, (y - rect.y) * rh, 'i32');
 	},
 
+	godot_js_display_has_webgl__sig: 'ii',
+	godot_js_display_has_webgl: function (p_version) {
+		if (p_version !== 1 && p_version !== 2) {
+			return false;
+		}
+		try {
+			return !!document.createElement('canvas').getContext(p_version === 2 ? 'webgl2' : 'webgl');
+		} catch (e) { /* Not available */ }
+		return false;
+	},
+
 	/*
 	 * Canvas
 	 */


### PR DESCRIPTION
According to project settings, When WebGL2 is not available.
This does nothing in current master, as we have no rendering yet!

See #47659 for the `3.x` implementation that can actually render WebGL/WebGL2.
