### PR TITLE
Improvements for UndoRedo class

### DIFF
--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -247,7 +247,7 @@ bool UndoRedo::has_uncommitted_action() const {
 	return action_level > 0;
 }
 
-void UndoRedo::commit_action() {
+void UndoRedo::commit_action(bool p_apply_redo) {
 
 	ERR_FAIL_COND(action_level <= 0);
 	action_level--;
@@ -260,7 +260,13 @@ void UndoRedo::commit_action() {
 	}
 
 	committing++;
-	redo(); // perform action
+	if (p_apply_redo) {
+		redo(); // perform action
+	} else {
+		current_action++;
+		version++;
+		emit_signal("version_changed");
+	}
 	committing--;
 	if (callback && actions.size() > 0) {
 		callback(callback_ud, actions[actions.size() - 1].name);
@@ -525,7 +531,7 @@ Variant UndoRedo::_add_undo_method(const Variant **p_args, int p_argcount, Varia
 void UndoRedo::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("create_action", "name", "merge_mode"), &UndoRedo::create_action, DEFVAL(MERGE_DISABLE));
-	ClassDB::bind_method(D_METHOD("commit_action"), &UndoRedo::commit_action);
+	ClassDB::bind_method(D_METHOD("commit_action", "apply_redo"), &UndoRedo::commit_action, DEFVAL(true));
 	// FIXME: Typo in "commiting", fix in 4.0 when breaking compat.
 	ClassDB::bind_method(D_METHOD("is_commiting_action"), &UndoRedo::is_committing_action);
 	ClassDB::bind_method(D_METHOD("has_uncommitted_action"), &UndoRedo::has_uncommitted_action);

--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -380,6 +380,17 @@ String UndoRedo::get_current_action_name() const {
 	return actions[current_action].name;
 }
 
+int UndoRedo::get_action_count() const {
+
+	return current_action + 1;
+}
+
+String UndoRedo::get_action_name(int p_idx) const {
+
+	ERR_FAIL_COND_V(p_idx > current_action, "");
+	return actions[p_idx].name;
+}
+
 bool UndoRedo::has_undo() {
 
 	return current_action >= 0;
@@ -542,6 +553,8 @@ void UndoRedo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_undo_reference", "object"), &UndoRedo::add_undo_reference);
 	ClassDB::bind_method(D_METHOD("clear_history", "increase_version"), &UndoRedo::clear_history, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_current_action_name"), &UndoRedo::get_current_action_name);
+	ClassDB::bind_method(D_METHOD("get_action_count"), &UndoRedo::get_action_count);
+	ClassDB::bind_method(D_METHOD("get_action_name", "idx"), &UndoRedo::get_action_name);
 	ClassDB::bind_method(D_METHOD("has_undo"), &UndoRedo::has_undo);
 	ClassDB::bind_method(D_METHOD("has_redo"), &UndoRedo::has_redo);
 	ClassDB::bind_method(D_METHOD("get_version"), &UndoRedo::get_version);

--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -112,7 +112,7 @@ public:
 
 	bool has_uncommitted_action() const;
 	bool is_committing_action() const;
-	void commit_action();
+	void commit_action(bool p_apply_redo = true);
 
 	bool redo();
 	bool undo();

--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -110,6 +110,7 @@ public:
 	void add_do_reference(Object *p_object);
 	void add_undo_reference(Object *p_object);
 
+	bool has_uncommitted_action() const;
 	bool is_committing_action() const;
 	void commit_action();
 

--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -117,6 +117,8 @@ public:
 	bool redo();
 	bool undo();
 	String get_current_action_name() const;
+	int get_action_count() const;
+	String get_action_name(int p_idx) const;
 	void clear_history(bool p_increase_version = true);
 
 	bool has_undo();


### PR DESCRIPTION
Added some improvements for UndoRedo class :

- Added `has_uncommitted_action()` method to check if there is an uncommitted action.
- Added `get_action_count()` and `get_action_name()` methods to make additionnal checks. (For example, if you need to check for a specific panel if there still are some unmodified inputs when undo)
- Added `apply_redo` optional parameter for `commit_action` to be able to have a different function for do() and redo().