### PR TITLE
makerst: Fix generation of overridden properties in child classes

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -437,7 +437,7 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
         for property_def in class_def.properties.values():
             type_rst = property_def.type_name.to_rst(state)
             default = property_def.default_value
-            if property_def.overridden:
+            if default is not None and property_def.overridden:
                 ml.append((type_rst, property_def.name, default + " *(parent override)*"))
             else:
                 ref = ":ref:`{0}<class_{1}_property_{0}>`".format(property_def.name, class_name)


### PR DESCRIPTION
Closes #47661.

Note that there's no class in Godot which exposes this issue currently (and may not in the future according to #39479 which is exclusive to Godot 4.x). All this PR does is to prevent an error from happening which I've stumbled upon in [Goost](https://github.com/goostengine/goost) while generating the online class reference. If you think further enhancement are needed, I can do them.
