### PR TITLE
Add the button pressed to some signals in Tree

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -353,10 +353,11 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="button_pressed">
+		<signal name="button_clicked">
 			<argument index="0" name="item" type="TreeItem" />
 			<argument index="1" name="column" type="int" />
 			<argument index="2" name="id" type="int" />
+			<argument index="3" name="mouse_button_index" type="int" />
 			<description>
 				Emitted when a button on the tree was pressed (see [method TreeItem.add_button]).
 			</description>
@@ -379,22 +380,23 @@
 				Emitted when a column's title is pressed.
 			</description>
 		</signal>
+		<signal name="custom_item_clicked">
+			<argument index="0" name="mouse_button_index" type="int" />
+			<description>
+				Emitted when an item with [constant TreeItem.CELL_MODE_CUSTOM] is clicked with a mouse button.
+			</description>
+		</signal>
 		<signal name="custom_popup_edited">
 			<argument index="0" name="arrow_clicked" type="bool" />
 			<description>
 				Emitted when a cell with the [constant TreeItem.CELL_MODE_CUSTOM] is clicked to be edited.
 			</description>
 		</signal>
-		<signal name="empty_rmb">
+		<signal name="empty_clicked">
 			<argument index="0" name="position" type="Vector2" />
+			<argument index="1" name="mouse_button_index" type="int" />
 			<description>
-				Emitted when the right mouse button is pressed in the empty space of the tree.
-			</description>
-		</signal>
-		<signal name="empty_tree_rmb_selected">
-			<argument index="0" name="position" type="Vector2" />
-			<description>
-				Emitted when the right mouse button is pressed if right mouse button selection is active and the tree is empty.
+				Emitted when a mouse button is clicked in the empty space of the tree.
 			</description>
 		</signal>
 		<signal name="item_activated">
@@ -423,15 +425,11 @@
 				Emitted when an item is edited.
 			</description>
 		</signal>
-		<signal name="item_rmb_edited">
-			<description>
-				Emitted when an item is edited using the right mouse button.
-			</description>
-		</signal>
-		<signal name="item_rmb_selected">
+		<signal name="item_mouse_selected">
 			<argument index="0" name="position" type="Vector2" />
+			<argument index="1" name="mouse_button_index" type="int" />
 			<description>
-				Emitted when an item is selected with the right mouse button.
+				Emitted when an item is selected with a mouse button.
 			</description>
 		</signal>
 		<signal name="item_selected">

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -868,7 +868,11 @@ void ActionMapEditor::_action_edited() {
 	}
 }
 
-void ActionMapEditor::_tree_button_pressed(Object *p_item, int p_column, int p_id) {
+void ActionMapEditor::_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	ItemButton option = (ItemButton)p_id;
 
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
@@ -926,7 +930,7 @@ void ActionMapEditor::_tree_item_activated() {
 		return;
 	}
 
-	_tree_button_pressed(item, 2, BUTTON_EDIT_EVENT);
+	_tree_button_pressed(item, 2, BUTTON_EDIT_EVENT, MouseButton::LEFT);
 }
 
 void ActionMapEditor::set_show_builtin_actions(bool p_show) {
@@ -1249,7 +1253,7 @@ ActionMapEditor::ActionMapEditor() {
 	action_tree->set_column_custom_minimum_width(2, 50 * EDSCALE);
 	action_tree->connect("item_edited", callable_mp(this, &ActionMapEditor::_action_edited));
 	action_tree->connect("item_activated", callable_mp(this, &ActionMapEditor::_tree_item_activated));
-	action_tree->connect("button_pressed", callable_mp(this, &ActionMapEditor::_tree_button_pressed));
+	action_tree->connect("button_clicked", callable_mp(this, &ActionMapEditor::_tree_button_pressed));
 	main_vbox->add_child(action_tree);
 
 	action_tree->set_drag_forwarding(this);

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -182,7 +182,7 @@ private:
 	void _add_action(const String &p_name);
 	void _action_edited();
 
-	void _tree_button_pressed(Object *p_item, int p_column, int p_id);
+	void _tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _tree_item_activated();
 	void _search_term_updated(const String &p_search_term);
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -864,7 +864,11 @@ void ConnectionsDock::_handle_slot_menu_option(int p_option) {
 	}
 }
 
-void ConnectionsDock::_rmb_pressed(Vector2 p_position) {
+void ConnectionsDock::_rmb_pressed(Vector2 p_position, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
+
 	TreeItem *item = tree->get_selected();
 
 	if (!item) {
@@ -1166,7 +1170,7 @@ ConnectionsDock::ConnectionsDock() {
 	connect_dialog->connect("connected", callable_mp(this, &ConnectionsDock::_make_or_edit_connection));
 	tree->connect("item_selected", callable_mp(this, &ConnectionsDock::_tree_item_selected));
 	tree->connect("item_activated", callable_mp(this, &ConnectionsDock::_tree_item_activated));
-	tree->connect("item_rmb_selected", callable_mp(this, &ConnectionsDock::_rmb_pressed));
+	tree->connect("item_mouse_selected", callable_mp(this, &ConnectionsDock::_rmb_pressed));
 
 	add_theme_constant_override("separation", 3 * EDSCALE);
 

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -216,7 +216,7 @@ class ConnectionsDock : public VBoxContainer {
 
 	void _handle_signal_menu_option(int p_option);
 	void _handle_slot_menu_option(int p_option);
-	void _rmb_pressed(Vector2 p_position);
+	void _rmb_pressed(Vector2 p_position, MouseButton p_button);
 	void _close();
 
 protected:

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -57,7 +57,7 @@ void EditorDebuggerTree::_notification(int p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
 			connect("cell_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_selected));
 			connect("item_collapsed", callable_mp(this, &EditorDebuggerTree::_scene_tree_folded));
-			connect("item_rmb_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_rmb_selected));
+			connect("item_mouse_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_rmb_selected));
 		} break;
 	}
 }
@@ -100,7 +100,11 @@ void EditorDebuggerTree::_scene_tree_folded(Object *p_obj) {
 	}
 }
 
-void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position) {
+void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
+
 	TreeItem *item = get_item_at_position(p_position);
 	if (!item) {
 		return;

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -56,7 +56,7 @@ private:
 	String _get_path(TreeItem *p_item);
 	void _scene_tree_folded(Object *p_obj);
 	void _scene_tree_selected();
-	void _scene_tree_rmb_selected(const Vector2 &p_position);
+	void _scene_tree_rmb_selected(const Vector2 &p_position, MouseButton p_button);
 	void _item_menu_id_pressed(int p_option);
 	void _file_selected(const String &p_file);
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1472,7 +1472,11 @@ void ScriptEditorDebugger::_clear_errors_list() {
 	clear_button->set_disabled(true);
 }
 
-void ScriptEditorDebugger::_breakpoints_item_rmb_selected(const Vector2 &p_pos) {
+void ScriptEditorDebugger::_breakpoints_item_rmb_selected(const Vector2 &p_pos, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
+
 	breakpoints_menu->clear();
 	breakpoints_menu->set_size(Size2(1, 1));
 
@@ -1490,7 +1494,11 @@ void ScriptEditorDebugger::_breakpoints_item_rmb_selected(const Vector2 &p_pos) 
 }
 
 // Right click on specific file(s) or folder(s).
-void ScriptEditorDebugger::_error_tree_item_rmb_selected(const Vector2 &p_pos) {
+void ScriptEditorDebugger::_error_tree_item_rmb_selected(const Vector2 &p_pos, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
+
 	item_menu->clear();
 	item_menu->reset_size();
 
@@ -1780,7 +1788,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		breakpoints_tree->set_allow_reselect(true);
 		breakpoints_tree->set_allow_rmb_select(true);
 		breakpoints_tree->set_hide_root(true);
-		breakpoints_tree->connect("item_rmb_selected", callable_mp(this, &ScriptEditorDebugger::_breakpoints_item_rmb_selected));
+		breakpoints_tree->connect("item_mouse_selected", callable_mp(this, &ScriptEditorDebugger::_breakpoints_item_rmb_selected));
 		breakpoints_tree->create_item();
 
 		parent_sc->add_child(breakpoints_tree);
@@ -1835,7 +1843,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		error_tree->set_hide_root(true);
 		error_tree->set_v_size_flags(SIZE_EXPAND_FILL);
 		error_tree->set_allow_rmb_select(true);
-		error_tree->connect("item_rmb_selected", callable_mp(this, &ScriptEditorDebugger::_error_tree_item_rmb_selected));
+		error_tree->connect("item_mouse_selected", callable_mp(this, &ScriptEditorDebugger::_error_tree_item_rmb_selected));
 		errors_tab->add_child(error_tree);
 
 		item_menu = memnew(PopupMenu);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -201,8 +201,8 @@ private:
 
 	void _clear_errors_list();
 
-	void _breakpoints_item_rmb_selected(const Vector2 &p_pos);
-	void _error_tree_item_rmb_selected(const Vector2 &p_pos);
+	void _breakpoints_item_rmb_selected(const Vector2 &p_pos, MouseButton p_button);
+	void _error_tree_item_rmb_selected(const Vector2 &p_pos, MouseButton p_button);
 	void _item_menu_id_pressed(int p_option);
 	void _tab_changed(int p_tab);
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -49,7 +49,10 @@ void DependencyEditor::_searched(const String &p_path) {
 	_update_file();
 }
 
-void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button) {
+void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button, MouseButton p_mouse_button) {
+	if (p_mouse_button != MouseButton::LEFT) {
+		return;
+	}
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	replacing = ti->get_text(1);
 
@@ -242,7 +245,7 @@ DependencyEditor::DependencyEditor() {
 	tree->set_column_clip_content(1, true);
 	tree->set_column_expand_ratio(1, 1);
 	tree->set_hide_root(true);
-	tree->connect("button_pressed", callable_mp(this, &DependencyEditor::_load_pressed));
+	tree->connect("button_clicked", callable_mp(this, &DependencyEditor::_load_pressed));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	Label *label = memnew(Label(TTR("Dependencies:")));
@@ -761,7 +764,10 @@ void OrphanResourcesDialog::_delete_confirm() {
 	refresh();
 }
 
-void OrphanResourcesDialog::_button_pressed(Object *p_item, int p_column, int p_id) {
+void OrphanResourcesDialog::_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 
 	String path = ti->get_metadata(0);
@@ -796,5 +802,5 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 	files->set_column_title(1, TTR("Owns"));
 	files->set_hide_root(true);
 	vbc->add_margin_child(TTR("Resources Without Explicit Ownership:"), files, true);
-	files->connect("button_pressed", callable_mp(this, &OrphanResourcesDialog::_button_pressed));
+	files->connect("button_clicked", callable_mp(this, &OrphanResourcesDialog::_button_pressed));
 }

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -54,7 +54,7 @@ class DependencyEditor : public AcceptDialog {
 	void _fix_and_find(EditorFileSystemDirectory *efsd, HashMap<String, HashMap<String, String>> &candidates);
 
 	void _searched(const String &p_path);
-	void _load_pressed(Object *p_item, int p_cell, int p_button);
+	void _load_pressed(Object *p_item, int p_cell, int p_button, MouseButton p_mouse_button);
 	void _fix_all();
 	void _update_list();
 
@@ -166,7 +166,7 @@ class OrphanResourcesDialog : public ConfirmationDialog {
 	List<String> paths;
 	void _find_to_delete(TreeItem *p_item, List<String> &paths);
 	void _delete_confirm();
-	void _button_pressed(Object *p_item, int p_column, int p_id);
+	void _button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
 	void refresh();
 	static void _bind_methods();

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -739,7 +739,11 @@ void EditorAudioBus::_delete_effect_pressed(int p_option) {
 	ur->commit_action();
 }
 
-void EditorAudioBus::_effect_rmb(const Vector2 &p_pos) {
+void EditorAudioBus::_effect_rmb(const Vector2 &p_pos, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
+
 	TreeItem *item = effects->get_selected();
 	if (!item) {
 		return;
@@ -897,7 +901,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	effects->connect("cell_selected", callable_mp(this, &EditorAudioBus::_effect_selected));
 	effects->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
 	effects->set_drag_forwarding(this);
-	effects->connect("item_rmb_selected", callable_mp(this, &EditorAudioBus::_effect_rmb));
+	effects->connect("item_mouse_selected", callable_mp(this, &EditorAudioBus::_effect_rmb));
 	effects->set_allow_rmb_select(true);
 	effects->set_focus_mode(FOCUS_CLICK);
 	effects->set_allow_reselect(true);

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -108,7 +108,7 @@ class EditorAudioBus : public PanelContainer {
 	void _effect_add(int p_which);
 	void _effect_selected();
 	void _delete_effect_pressed(int p_option);
-	void _effect_rmb(const Vector2 &p_pos);
+	void _effect_rmb(const Vector2 &p_pos, MouseButton p_button);
 	void _update_visible_channels();
 
 	virtual Variant get_drag_data(const Point2 &p_point) override;

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -280,7 +280,10 @@ void EditorAutoloadSettings::_autoload_edited() {
 	updating_autoload = false;
 }
 
-void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_column, int p_button) {
+void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button) {
+	if (p_mouse_button != MouseButton::LEFT) {
+		return;
+	}
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 
 	String name = "autoload/" + ti->get_text(0);
@@ -950,7 +953,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	tree->connect("cell_selected", callable_mp(this, &EditorAutoloadSettings::_autoload_selected));
 	tree->connect("item_edited", callable_mp(this, &EditorAutoloadSettings::_autoload_edited));
-	tree->connect("button_pressed", callable_mp(this, &EditorAutoloadSettings::_autoload_button_pressed));
+	tree->connect("button_clicked", callable_mp(this, &EditorAutoloadSettings::_autoload_button_pressed));
 	tree->connect("item_activated", callable_mp(this, &EditorAutoloadSettings::_autoload_activated));
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -81,7 +81,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 	void _autoload_add();
 	void _autoload_selected();
 	void _autoload_edited();
-	void _autoload_button_pressed(Object *p_item, int p_column, int p_button);
+	void _autoload_button_pressed(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 	void _autoload_activated();
 	void _autoload_path_text_changed(const String p_path);
 	void _autoload_text_submitted(const String p_name);

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -46,7 +46,7 @@ void EditorPluginSettings::_notification(int p_what) {
 
 		case Node::NOTIFICATION_READY: {
 			plugin_config_dialog->connect("plugin_ready", Callable(EditorNode::get_singleton(), "_on_plugin_ready"));
-			plugin_list->connect("button_pressed", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
+			plugin_list->connect("button_clicked", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
 		} break;
 	}
 }
@@ -146,7 +146,10 @@ void EditorPluginSettings::_create_clicked() {
 	plugin_config_dialog->popup_centered();
 }
 
-void EditorPluginSettings::_cell_button_pressed(Object *p_item, int p_column, int p_id) {
+void EditorPluginSettings::_cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	if (!item) {
 		return;

--- a/editor/editor_plugin_settings.h
+++ b/editor/editor_plugin_settings.h
@@ -50,7 +50,7 @@ class EditorPluginSettings : public VBoxContainer {
 
 	void _plugin_activity_changed();
 	void _create_clicked();
-	void _cell_button_pressed(Object *p_item, int p_column, int p_id);
+	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
 	static Vector<String> _get_plugins(const String &p_dir);
 

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -475,7 +475,10 @@ void EditorSettingsDialog::_update_shortcuts() {
 	}
 }
 
-void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column, int p_idx) {
+void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND_MSG(!ti, "Object passed is not a TreeItem");
 
@@ -748,7 +751,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcuts->set_column_titles_visible(true);
 	shortcuts->set_column_title(0, TTR("Name"));
 	shortcuts->set_column_title(1, TTR("Binding"));
-	shortcuts->connect("button_pressed", callable_mp(this, &EditorSettingsDialog::_shortcut_button_pressed));
+	shortcuts->connect("button_clicked", callable_mp(this, &EditorSettingsDialog::_shortcut_button_pressed));
 	shortcuts->connect("item_activated", callable_mp(this, &EditorSettingsDialog::_shortcut_cell_double_clicked));
 	tab_shortcuts->add_child(shortcuts);
 

--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -103,7 +103,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	void _filter_shortcuts(const String &p_filter);
 
 	void _update_shortcuts();
-	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx);
+	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button = MouseButton::LEFT);
 	void _shortcut_cell_double_clicked();
 
 	void _builtin_action_popup_index_pressed(int p_index);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -593,7 +593,10 @@ void ExportTemplateManager::_mirror_options_button_cbk(int p_id) {
 	}
 }
 
-void ExportTemplateManager::_installed_table_button_cbk(Object *p_item, int p_column, int p_id) {
+void ExportTemplateManager::_installed_table_button_cbk(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	if (!ti) {
 		return;
@@ -975,7 +978,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	installed_table->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
 	installed_table->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	main_vb->add_child(installed_table);
-	installed_table->connect("button_pressed", callable_mp(this, &ExportTemplateManager::_installed_table_button_cbk));
+	installed_table->connect("button_clicked", callable_mp(this, &ExportTemplateManager::_installed_table_button_cbk));
 
 	// Dialogs.
 	uninstall_confirm = memnew(ConfirmationDialog);

--- a/editor/export_template_manager.h
+++ b/editor/export_template_manager.h
@@ -109,7 +109,7 @@ class ExportTemplateManager : public AcceptDialog {
 
 	String _get_selected_mirror() const;
 	void _mirror_options_button_cbk(int p_id);
-	void _installed_table_button_cbk(Object *p_item, int p_column, int p_id);
+	void _installed_table_button_cbk(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
 	void _open_template_folder(const String &p_version);
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2592,7 +2592,10 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 	}
 }
 
-void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
+void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
 	// Right click is pressed in the tree.
 	Vector<String> paths = _tree_get_selected(false);
 
@@ -2615,7 +2618,10 @@ void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
 	}
 }
 
-void FileSystemDock::_tree_rmb_empty(const Vector2 &p_pos) {
+void FileSystemDock::_tree_empty_click(const Vector2 &p_pos, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
 	// Right click is pressed in the empty space of the tree.
 	path = "res://";
 	tree_popup->clear();
@@ -3106,8 +3112,8 @@ FileSystemDock::FileSystemDock() {
 
 	tree->connect("item_activated", callable_mp(this, &FileSystemDock::_tree_activate_file));
 	tree->connect("multi_selected", callable_mp(this, &FileSystemDock::_tree_multi_selected));
-	tree->connect("item_rmb_selected", callable_mp(this, &FileSystemDock::_tree_rmb_select));
-	tree->connect("empty_rmb", callable_mp(this, &FileSystemDock::_tree_rmb_empty));
+	tree->connect("item_mouse_selected", callable_mp(this, &FileSystemDock::_tree_rmb_select));
+	tree->connect("empty_clicked", callable_mp(this, &FileSystemDock::_tree_empty_click));
 	tree->connect("nothing_selected", callable_mp(this, &FileSystemDock::_tree_empty_selected));
 	tree->connect("gui_input", callable_mp(this, &FileSystemDock::_tree_gui_input));
 	tree->connect("mouse_exited", callable_mp(this, &FileSystemDock::_tree_mouse_exited));

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -258,10 +258,10 @@ private:
 	void _file_sort_popup(int p_id);
 
 	void _file_and_folders_fill_popup(PopupMenu *p_popup, Vector<String> p_paths, bool p_display_path_dependent_options = true);
-	void _tree_rmb_select(const Vector2 &p_pos);
-	void _tree_rmb_empty(const Vector2 &p_pos);
+	void _tree_rmb_select(const Vector2 &p_pos, MouseButton p_button);
 	void _file_list_item_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _file_list_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
+	void _tree_empty_click(const Vector2 &p_pos, MouseButton p_button);
 	void _tree_empty_selected();
 
 	struct FileInfo {

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -303,7 +303,11 @@ void GroupDialog::_load_groups(Node *p_current) {
 	}
 }
 
-void GroupDialog::_modify_group_pressed(Object *p_item, int p_column, int p_id) {
+void GroupDialog::_modify_group_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	if (!ti) {
 		return;
@@ -453,7 +457,7 @@ GroupDialog::GroupDialog() {
 	groups->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	groups->add_theme_constant_override("draw_guides", 1);
 	groups->connect("item_selected", callable_mp(this, &GroupDialog::_group_selected));
-	groups->connect("button_pressed", callable_mp(this, &GroupDialog::_modify_group_pressed));
+	groups->connect("button_clicked", callable_mp(this, &GroupDialog::_modify_group_pressed));
 	groups->connect("item_edited", callable_mp(this, &GroupDialog::_group_renamed));
 
 	HBoxContainer *chbc = memnew(HBoxContainer);
@@ -600,7 +604,11 @@ void GroupsEditor::_add_group(const String &p_group) {
 	undo_redo->commit_action();
 }
 
-void GroupsEditor::_modify_group(Object *p_item, int p_column, int p_id) {
+void GroupsEditor::_modify_group(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	if (!node) {
 		return;
 	}
@@ -735,7 +743,7 @@ GroupsEditor::GroupsEditor() {
 	tree->set_hide_root(true);
 	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vbc->add_child(tree);
-	tree->connect("button_pressed", callable_mp(this, &GroupsEditor::_modify_group));
+	tree->connect("button_clicked", callable_mp(this, &GroupsEditor::_modify_group));
 	tree->add_theme_constant_override("draw_guides", 1);
 	add_theme_constant_override("separation", 3 * EDSCALE);
 

--- a/editor/groups_editor.h
+++ b/editor/groups_editor.h
@@ -84,7 +84,7 @@ class GroupDialog : public AcceptDialog {
 	void _rename_group_item(const String &p_old_name, const String &p_new_name);
 
 	void _add_group(String p_name);
-	void _modify_group_pressed(Object *p_item, int p_column, int p_id);
+	void _modify_group_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _delete_group_item(const String &p_name);
 
 	bool _can_edit(Node *p_node, String p_group);
@@ -123,7 +123,7 @@ class GroupsEditor : public VBoxContainer {
 
 	void update_tree();
 	void _add_group(const String &p_group = "");
-	void _modify_group(Object *p_item, int p_column, int p_id);
+	void _modify_group(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _group_name_changed(const String &p_new_text);
 
 	void _show_group_dialog();

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -547,7 +547,11 @@ void DynamicFontImportSettings::_variation_selected() {
 	}
 }
 
-void DynamicFontImportSettings::_variation_remove(Object *p_item, int p_column, int p_id) {
+void DynamicFontImportSettings::_variation_remove(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *vars_item = (TreeItem *)p_item;
 	ERR_FAIL_NULL(vars_item);
 
@@ -832,7 +836,11 @@ void DynamicFontImportSettings::_lang_add_item(const String &p_locale) {
 	lang_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 }
 
-void DynamicFontImportSettings::_lang_remove(Object *p_item, int p_column, int p_id) {
+void DynamicFontImportSettings::_lang_remove(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *lang_item = (TreeItem *)p_item;
 	ERR_FAIL_NULL(lang_item);
 
@@ -864,7 +872,11 @@ void DynamicFontImportSettings::_ot_add_item(int p_option) {
 	ot_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 }
 
-void DynamicFontImportSettings::_ot_remove(Object *p_item, int p_column, int p_id) {
+void DynamicFontImportSettings::_ot_remove(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *ot_item = (TreeItem *)p_item;
 	ERR_FAIL_NULL(ot_item);
 
@@ -891,7 +903,11 @@ void DynamicFontImportSettings::_script_add_item(int p_option) {
 	script_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 }
 
-void DynamicFontImportSettings::_script_remove(Object *p_item, int p_column, int p_id) {
+void DynamicFontImportSettings::_script_remove(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *script_item = (TreeItem *)p_item;
 	ERR_FAIL_NULL(script_item);
 
@@ -1487,7 +1503,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	vars_list->set_column_expand(1, false);
 	vars_list->set_column_custom_minimum_width(1, 50 * EDSCALE);
 	vars_list->connect("item_selected", callable_mp(this, &DynamicFontImportSettings::_variation_selected));
-	vars_list->connect("button_pressed", callable_mp(this, &DynamicFontImportSettings::_variation_remove));
+	vars_list->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_variation_remove));
 	vars_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	inspector_vars = memnew(EditorInspector);
@@ -1639,7 +1655,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	lang_list->set_column_custom_minimum_width(1, 80 * EDSCALE);
 	lang_list->set_column_expand(2, false);
 	lang_list->set_column_custom_minimum_width(2, 50 * EDSCALE);
-	lang_list->connect("button_pressed", callable_mp(this, &DynamicFontImportSettings::_lang_remove));
+	lang_list->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_lang_remove));
 	lang_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	HBoxContainer *hb_script = memnew(HBoxContainer);
@@ -1667,7 +1683,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	script_list->set_column_custom_minimum_width(1, 80 * EDSCALE);
 	script_list->set_column_expand(2, false);
 	script_list->set_column_custom_minimum_width(2, 50 * EDSCALE);
-	script_list->connect("button_pressed", callable_mp(this, &DynamicFontImportSettings::_script_remove));
+	script_list->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_script_remove));
 	script_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	HBoxContainer *hb_ot = memnew(HBoxContainer);
@@ -1695,7 +1711,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	ot_list->set_column_custom_minimum_width(1, 80 * EDSCALE);
 	ot_list->set_column_expand(2, false);
 	ot_list->set_column_custom_minimum_width(2, 50 * EDSCALE);
-	ot_list->connect("button_pressed", callable_mp(this, &DynamicFontImportSettings::_ot_remove));
+	ot_list->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_ot_remove));
 	ot_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	// Common

--- a/editor/import/dynamic_font_import_settings.h
+++ b/editor/import/dynamic_font_import_settings.h
@@ -91,7 +91,7 @@ class DynamicFontImportSettings : public ConfirmationDialog {
 
 	void _variation_add();
 	void _variation_selected();
-	void _variation_remove(Object *p_item, int p_column, int p_id);
+	void _variation_remove(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _variation_changed(const String &p_edited_property);
 	void _variations_validate();
 
@@ -145,15 +145,15 @@ class DynamicFontImportSettings : public ConfirmationDialog {
 
 	void _lang_add();
 	void _lang_add_item(const String &p_locale);
-	void _lang_remove(Object *p_item, int p_column, int p_id);
+	void _lang_remove(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
 	void _script_add();
 	void _script_add_item(int p_option);
-	void _script_remove(Object *p_item, int p_column, int p_id);
+	void _script_remove(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
 	void _ot_add();
 	void _ot_add_item(int p_option);
-	void _ot_remove(Object *p_item, int p_column, int p_id);
+	void _ot_remove(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
 	// Common
 

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -969,7 +969,11 @@ void SceneImportSettings::_save_path_changed(const String &p_path) {
 	}
 }
 
-void SceneImportSettings::_browse_save_callback(Object *p_item, int p_column, int p_id) {
+void SceneImportSettings::_browse_save_callback(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 
 	String path = item->get_text(1);
@@ -1331,7 +1335,7 @@ SceneImportSettings::SceneImportSettings() {
 	add_child(external_paths);
 	external_path_tree = memnew(Tree);
 	external_paths->add_child(external_path_tree);
-	external_path_tree->connect("button_pressed", callable_mp(this, &SceneImportSettings::_browse_save_callback));
+	external_path_tree->connect("button_clicked", callable_mp(this, &SceneImportSettings::_browse_save_callback));
 	external_paths->connect("confirmed", callable_mp(this, &SceneImportSettings::_save_dir_confirm));
 	external_path_tree->set_columns(3);
 	external_path_tree->set_column_titles_visible(true);

--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -182,7 +182,7 @@ class SceneImportSettings : public ConfirmationDialog {
 
 	TreeItem *save_path_item = nullptr;
 	void _save_path_changed(const String &p_path);
-	void _browse_save_callback(Object *p_item, int p_column, int p_id);
+	void _browse_save_callback(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _save_dir_confirm();
 
 	Dictionary base_subresource_settings;

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -42,8 +42,8 @@
 void LocalizationEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			translation_list->connect("button_pressed", callable_mp(this, &LocalizationEditor::_translation_delete));
-			translation_pot_list->connect("button_pressed", callable_mp(this, &LocalizationEditor::_pot_delete));
+			translation_list->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_delete));
+			translation_pot_list->connect("button_clicked", callable_mp(this, &LocalizationEditor::_pot_delete));
 
 			List<String> tfn;
 			ResourceLoader::get_recognized_extensions_for_type("Translation", &tfn);
@@ -93,7 +93,11 @@ void LocalizationEditor::_translation_file_open() {
 	translation_file_open->popup_file_dialog();
 }
 
-void LocalizationEditor::_translation_delete(Object *p_item, int p_column, int p_button) {
+void LocalizationEditor::_translation_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button) {
+	if (p_mouse_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
@@ -239,8 +243,12 @@ void LocalizationEditor::_translation_res_option_changed() {
 	updating_translations = false;
 }
 
-void LocalizationEditor::_translation_res_delete(Object *p_item, int p_column, int p_button) {
+void LocalizationEditor::_translation_res_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button) {
 	if (updating_translations) {
+		return;
+	}
+
+	if (p_mouse_button != MouseButton::LEFT) {
 		return;
 	}
 
@@ -267,8 +275,12 @@ void LocalizationEditor::_translation_res_delete(Object *p_item, int p_column, i
 	undo_redo->commit_action();
 }
 
-void LocalizationEditor::_translation_res_option_delete(Object *p_item, int p_column, int p_button) {
+void LocalizationEditor::_translation_res_option_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button) {
 	if (updating_translations) {
+		return;
+	}
+
+	if (p_mouse_button != MouseButton::LEFT) {
 		return;
 	}
 
@@ -320,7 +332,11 @@ void LocalizationEditor::_pot_add(const PackedStringArray &p_paths) {
 	undo_redo->commit_action();
 }
 
-void LocalizationEditor::_pot_delete(Object *p_item, int p_column, int p_button) {
+void LocalizationEditor::_pot_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button) {
+	if (p_mouse_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
@@ -536,7 +552,7 @@ LocalizationEditor::LocalizationEditor() {
 		translation_remap = memnew(Tree);
 		translation_remap->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		translation_remap->connect("cell_selected", callable_mp(this, &LocalizationEditor::_translation_res_select));
-		translation_remap->connect("button_pressed", callable_mp(this, &LocalizationEditor::_translation_res_delete));
+		translation_remap->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_res_delete));
 		tmc->add_child(translation_remap);
 
 		translation_res_file_open_dialog = memnew(EditorFileDialog);
@@ -572,7 +588,7 @@ LocalizationEditor::LocalizationEditor() {
 		translation_remap_options->set_column_clip_content(1, false);
 		translation_remap_options->set_column_custom_minimum_width(1, 250);
 		translation_remap_options->connect("item_edited", callable_mp(this, &LocalizationEditor::_translation_res_option_changed));
-		translation_remap_options->connect("button_pressed", callable_mp(this, &LocalizationEditor::_translation_res_option_delete));
+		translation_remap_options->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_res_option_delete));
 		translation_remap_options->connect("custom_popup_edited", callable_mp(this, &LocalizationEditor::_translation_res_option_popup));
 		tmc->add_child(translation_remap_options);
 

--- a/editor/localization_editor.h
+++ b/editor/localization_editor.h
@@ -61,21 +61,21 @@ class LocalizationEditor : public VBoxContainer {
 
 	void _translation_file_open();
 	void _translation_add(const PackedStringArray &p_paths);
-	void _translation_delete(Object *p_item, int p_column, int p_button);
+	void _translation_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 
 	void _translation_res_file_open();
 	void _translation_res_add(const PackedStringArray &p_paths);
-	void _translation_res_delete(Object *p_item, int p_column, int p_button);
+	void _translation_res_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 	void _translation_res_select();
 	void _translation_res_option_file_open();
 	void _translation_res_option_add(const PackedStringArray &p_paths);
 	void _translation_res_option_changed();
-	void _translation_res_option_delete(Object *p_item, int p_column, int p_button);
+	void _translation_res_option_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 	void _translation_res_option_popup(bool p_arrow_clicked);
 	void _translation_res_option_selected(const String &p_locale);
 
 	void _pot_add(const PackedStringArray &p_paths);
-	void _pot_delete(Object *p_item, int p_column, int p_button);
+	void _pot_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 	void _pot_file_open();
 	void _pot_generate_open();
 	void _pot_generate(const String &p_file);

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -673,7 +673,7 @@ AnimationLibraryEditor::AnimationLibraryEditor() {
 	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	tree->connect("item_edited", callable_mp(this, &AnimationLibraryEditor::_item_renamed));
-	tree->connect("button_pressed", callable_mp(this, &AnimationLibraryEditor::_button_pressed));
+	tree->connect("button_clicked", callable_mp(this, &AnimationLibraryEditor::_button_pressed));
 
 	file_popup = memnew(PopupMenu);
 	add_child(file_popup);

--- a/editor/plugins/replication_editor_plugin.cpp
+++ b/editor/plugins/replication_editor_plugin.cpp
@@ -81,7 +81,7 @@ ReplicationEditor::ReplicationEditor() {
 	tree->set_column_expand(2, false);
 	tree->set_column_expand(3, false);
 	tree->create_item();
-	tree->connect("button_pressed", callable_mp(this, &ReplicationEditor::_tree_button_pressed));
+	tree->connect("button_clicked", callable_mp(this, &ReplicationEditor::_tree_button_pressed));
 	tree->connect("item_edited", callable_mp(this, &ReplicationEditor::_tree_item_edited));
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	vb->add_child(tree);
@@ -167,7 +167,11 @@ void ReplicationEditor::_tree_item_edited() {
 	undo_redo->commit_action();
 }
 
-void ReplicationEditor::_tree_button_pressed(Object *p_item, int p_column, int p_id) {
+void ReplicationEditor::_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	if (!ti) {
 		return;

--- a/editor/plugins/replication_editor_plugin.h
+++ b/editor/plugins/replication_editor_plugin.h
@@ -58,7 +58,7 @@ private:
 
 	void _add_pressed();
 	void _tree_item_edited();
-	void _tree_button_pressed(Object *p_item, int p_column, int p_id);
+	void _tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _update_checked(const NodePath &p_prop, int p_column, bool p_checked);
 	void _update_config();
 	void _dialog_closed(bool p_confirmed);

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -213,7 +213,11 @@ void ResourcePreloaderEditor::_update_library() {
 	//player->add_resource("default",resource);
 }
 
-void ResourcePreloaderEditor::_cell_button_pressed(Object *p_item, int p_column, int p_id) {
+void ResourcePreloaderEditor::_cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!item);
 
@@ -359,7 +363,7 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	add_child(file);
 
 	tree = memnew(Tree);
-	tree->connect("button_pressed", callable_mp(this, &ResourcePreloaderEditor::_cell_button_pressed));
+	tree->connect("button_clicked", callable_mp(this, &ResourcePreloaderEditor::_cell_button_pressed));
 	tree->set_columns(2);
 	tree->set_column_expand_ratio(0, 2);
 	tree->set_column_clip_content(0, true);

--- a/editor/plugins/resource_preloader_editor_plugin.h
+++ b/editor/plugins/resource_preloader_editor_plugin.h
@@ -63,7 +63,7 @@ class ResourcePreloaderEditor : public PanelContainer {
 	void _paste_pressed();
 	void _remove_resource(const String &p_to_remove);
 	void _update_library();
-	void _cell_button_pressed(Object *p_item, int p_column, int p_id);
+	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _item_edited();
 
 	UndoRedo *undo_redo = nullptr;

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -569,7 +569,7 @@ void Skeleton3DEditor::_joint_tree_selection_changed() {
 }
 
 // May be not used with single select mode.
-void Skeleton3DEditor::_joint_tree_rmb_select(const Vector2 &p_pos) {
+void Skeleton3DEditor::_joint_tree_rmb_select(const Vector2 &p_pos, MouseButton p_button) {
 }
 
 void Skeleton3DEditor::_update_properties() {
@@ -766,7 +766,7 @@ void Skeleton3DEditor::_notification(int p_what) {
 			update_joint_tree();
 			update_editors();
 			joint_tree->connect("item_selected", callable_mp(this, &Skeleton3DEditor::_joint_tree_selection_changed));
-			joint_tree->connect("item_rmb_selected", callable_mp(this, &Skeleton3DEditor::_joint_tree_rmb_select));
+			joint_tree->connect("item_mouse_selected", callable_mp(this, &Skeleton3DEditor::_joint_tree_rmb_select));
 #ifdef TOOLS_ENABLED
 			skeleton->connect("pose_updated", callable_mp(this, &Skeleton3DEditor::_draw_gizmo));
 			skeleton->connect("pose_updated", callable_mp(this, &Skeleton3DEditor::_update_properties));

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -181,7 +181,7 @@ class Skeleton3DEditor : public VBoxContainer {
 	void _draw_handles();
 
 	void _joint_tree_selection_changed();
-	void _joint_tree_rmb_select(const Vector2 &p_pos);
+	void _joint_tree_rmb_select(const Vector2 &p_pos, MouseButton p_button);
 	void _update_properties();
 
 	void _subgizmo_selection_change();

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1287,7 +1287,11 @@ void ThemeItemEditorDialog::_edited_type_selected() {
 	_update_edit_item_tree(selected_type);
 }
 
-void ThemeItemEditorDialog::_edited_type_button_pressed(Object *p_item, int p_column, int p_id) {
+void ThemeItemEditorDialog::_edited_type_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	if (!item) {
 		return;
@@ -1461,7 +1465,11 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 	}
 }
 
-void ThemeItemEditorDialog::_item_tree_button_pressed(Object *p_item, int p_column, int p_id) {
+void ThemeItemEditorDialog::_item_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	if (!item) {
 		return;
@@ -1909,7 +1917,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	edit_type_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	edit_dialog_side_vb->add_child(edit_type_list);
 	edit_type_list->connect("item_selected", callable_mp(this, &ThemeItemEditorDialog::_edited_type_selected));
-	edit_type_list->connect("button_pressed", callable_mp(this, &ThemeItemEditorDialog::_edited_type_button_pressed));
+	edit_type_list->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_edited_type_button_pressed));
 
 	Label *edit_add_type_label = memnew(Label);
 	edit_add_type_label->set_text(TTR("Add Type:"));
@@ -2011,7 +2019,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	edit_items_tree->set_hide_root(true);
 	edit_items_tree->set_columns(1);
 	edit_items_vb->add_child(edit_items_tree);
-	edit_items_tree->connect("button_pressed", callable_mp(this, &ThemeItemEditorDialog::_item_tree_button_pressed));
+	edit_items_tree->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_item_tree_button_pressed));
 
 	edit_items_message = memnew(Label);
 	edit_items_message->set_anchors_and_offsets_preset(Control::PRESET_WIDE);

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -249,10 +249,10 @@ class ThemeItemEditorDialog : public AcceptDialog {
 	void _dialog_about_to_show();
 	void _update_edit_types();
 	void _edited_type_selected();
-	void _edited_type_button_pressed(Object *p_item, int p_column, int p_id);
+	void _edited_type_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
 	void _update_edit_item_tree(String p_item_type);
-	void _item_tree_button_pressed(Object *p_item, int p_column, int p_id);
+	void _item_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
 	void _add_theme_type(const String &p_new_text);
 	void _add_theme_item(Theme::DataType p_data_type, String p_item_name, String p_item_type);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -49,7 +49,11 @@ Node *SceneTreeEditor::get_scene_node() {
 	return get_tree()->get_edited_scene_root();
 }
 
-void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_id) {
+void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_button != MouseButton::LEFT) {
+		return;
+	}
+
 	if (connect_to_script_mode) {
 		return; //don't do anything in this mode
 	}
@@ -1166,7 +1170,17 @@ void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 	}
 }
 
-void SceneTreeEditor::_rmb_select(const Vector2 &p_pos) {
+void SceneTreeEditor::_empty_clicked(const Vector2 &p_pos, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
+	_rmb_select(p_pos);
+}
+
+void SceneTreeEditor::_rmb_select(const Vector2 &p_pos, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
 	emit_signal(SNAME("rmb_pressed"), tree->get_screen_position() + p_pos);
 }
 
@@ -1251,14 +1265,14 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	tree->set_drag_forwarding(this);
 	if (p_can_rename) {
 		tree->set_allow_rmb_select(true);
-		tree->connect("item_rmb_selected", callable_mp(this, &SceneTreeEditor::_rmb_select));
-		tree->connect("empty_tree_rmb_selected", callable_mp(this, &SceneTreeEditor::_rmb_select));
+		tree->connect("item_mouse_selected", callable_mp(this, &SceneTreeEditor::_rmb_select));
+		tree->connect("empty_clicked", callable_mp(this, &SceneTreeEditor::_empty_clicked));
 	}
 
 	tree->connect("cell_selected", callable_mp(this, &SceneTreeEditor::_selected_changed));
 	tree->connect("item_edited", callable_mp(this, &SceneTreeEditor::_renamed));
 	tree->connect("multi_selected", callable_mp(this, &SceneTreeEditor::_cell_multi_selected));
-	tree->connect("button_pressed", callable_mp(this, &SceneTreeEditor::_cell_button_pressed));
+	tree->connect("button_clicked", callable_mp(this, &SceneTreeEditor::_cell_button_pressed));
 	tree->connect("nothing_selected", callable_mp(this, &SceneTreeEditor::_deselect_items));
 
 	error = memnew(AcceptDialog);

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -107,7 +107,7 @@ class SceneTreeEditor : public Control {
 	bool pending_test_update = false;
 	static void _bind_methods();
 
-	void _cell_button_pressed(Object *p_item, int p_column, int p_id);
+	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _toggle_visible(Node *p_node);
 	void _cell_multi_selected(Object *p_object, int p_cell, bool p_selected);
 	void _update_selection(TreeItem *item);
@@ -122,7 +122,8 @@ class SceneTreeEditor : public Control {
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
-	void _rmb_select(const Vector2 &p_pos);
+	void _empty_clicked(const Vector2 &p_pos, MouseButton p_button);
+	void _rmb_select(const Vector2 &p_pos, MouseButton p_button = MouseButton::RIGHT);
 
 	void _warning_changed(Node *p_for_node);
 

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -1440,7 +1440,11 @@ void VisualScriptEditor::_deselect_input_names() {
 	}
 }
 
-void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_button) {
+void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button) {
+	if (p_mouse_button != MouseButton::LEFT) {
+		return;
+	}
+
 	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 
 	TreeItem *root = members->get_root();
@@ -4352,7 +4356,11 @@ void VisualScriptEditor::_get_ends(int p_node, const List<VisualScript::Sequence
 	}
 }
 
-void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
+void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos, MouseButton p_button) {
+	if (p_button != MouseButton::RIGHT) {
+		return;
+	}
+
 	TreeItem *ti = members->get_selected();
 	ERR_FAIL_COND(!ti);
 
@@ -4553,11 +4561,11 @@ VisualScriptEditor::VisualScriptEditor() {
 	members_section->add_margin_child(TTR("Members:"), members, true);
 	members->set_custom_minimum_size(Size2(0, 50 * EDSCALE));
 	members->set_hide_root(true);
-	members->connect("button_pressed", callable_mp(this, &VisualScriptEditor::_member_button));
+	members->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_member_button));
 	members->connect("item_edited", callable_mp(this, &VisualScriptEditor::_member_edited));
 	members->connect("cell_selected", callable_mp(this, &VisualScriptEditor::_member_selected), varray(), CONNECT_DEFERRED);
 	members->connect("gui_input", callable_mp(this, &VisualScriptEditor::_members_gui_input));
-	members->connect("item_rmb_selected", callable_mp(this, &VisualScriptEditor::_member_rmb_selected));
+	members->connect("item_mouse_selected", callable_mp(this, &VisualScriptEditor::_member_rmb_selected));
 	members->set_allow_rmb_select(true);
 	members->set_allow_reselect(true);
 	members->set_hide_folding(true);

--- a/modules/visual_script/editor/visual_script_editor.h
+++ b/modules/visual_script/editor/visual_script_editor.h
@@ -226,7 +226,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	void _update_available_nodes();
 
-	void _member_button(Object *p_item, int p_column, int p_button);
+	void _member_button(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 
 	void _expression_text_changed(const String &p_text, int p_id);
 	void _add_input_port(int p_id);
@@ -289,7 +289,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	VisualScriptNode::TypeGuess _guess_output_type(int p_port_action_node, int p_port_action_output, RBSet<int> &p_visited_nodes);
 
-	void _member_rmb_selected(const Vector2 &p_pos);
+	void _member_rmb_selected(const Vector2 &p_pos, MouseButton p_button);
 	void _member_option(int p_option);
 
 	void _toggle_scripts_pressed();

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -466,7 +466,7 @@ private:
 
 	void _notification(int p_what);
 
-	void item_edited(int p_column, TreeItem *p_item, bool p_lmb = true);
+	void item_edited(int p_column, TreeItem *p_item, MouseButton p_mouse_index = MouseButton::NONE);
 	void item_changed(int p_column, TreeItem *p_item);
 	void item_selected(int p_column, TreeItem *p_item);
 	void item_deselected(int p_column, TreeItem *p_item);


### PR DESCRIPTION
Supersedes #46588
Based on [this comment](https://github.com/godotengine/godot/pull/46588#issuecomment-803377510)

This PR replaces most `rmb` (some can't be changed easily due to dependencies with key events) signals with a `mouse_button_index` parameter.

Changes:

- `button_pressed(TreeItem item, int column, int id)` -> `button_clicked(int mouse_button_index, TreeItem item, int column, int id)`
- `empty_rmb(Vector2 position)` -> `empty_clicked(Vector2 position, int mouse_button_index)`
- `empty_tree_rmb_selected(Vector2 position)` -> `void`
- `item_rmb_edited()` -> `custom_item_clicked(int mouse_button_index)`
- `item_rmb_selected(Vector2 position)` -> `item_mouse_selected(Vector2 position, int mouse_button_index)`

~~Note: I prefer to wait a review on the signal changes before changing the affected editor code (and fix docs).~~ 
EDIT: The signals names were adapted as requested (to be consistent with #59720 changes), and the `empty_tree_rmb_selected` signal was removed, as discussed [here](https://github.com/godotengine/godot/pull/59720#issuecomment-1092864254).