### PR TITLE
Automatically display the installer after downloading an asset

### DIFF
--- a/editor/editor_asset_installer.h
+++ b/editor/editor_asset_installer.h
@@ -37,7 +37,9 @@ class EditorAssetInstaller : public ConfirmationDialog {
 	GDCLASS(EditorAssetInstaller, ConfirmationDialog);
 
 	Tree *tree;
+	Label *asset_contents;
 	String package_path;
+	String asset_name;
 	AcceptDialog *error;
 	Map<String, TreeItem *> status_map;
 	bool updating;
@@ -51,6 +53,10 @@ protected:
 
 public:
 	void open(const String &p_path, int p_depth = 0);
+
+	void set_asset_name(const String &p_asset_name);
+	String get_asset_name() const;
+
 	EditorAssetInstaller();
 };
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -369,6 +369,9 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 	progress->set_modulate(Color(0, 0, 0, 0));
 
 	set_process(false);
+
+	// Automatically prompt for installation once the download is completed.
+	_install();
 }
 
 void EditorAssetLibraryItemDownload::configure(const String &p_title, int p_asset_id, const Ref<Texture2D> &p_preview, const String &p_download_url, const String &p_sha256_hash) {
@@ -456,6 +459,7 @@ void EditorAssetLibraryItemDownload::_install() {
 		return;
 	}
 
+	asset_installer->set_asset_name(title->get_text());
 	asset_installer->open(file, 1);
 }
 
@@ -1296,6 +1300,7 @@ void EditorAssetLibrary::_asset_file_selected(const String &p_file) {
 	}
 
 	asset_installer = memnew(EditorAssetInstaller);
+	asset_installer->set_asset_name(p_file.get_basename());
 	add_child(asset_installer);
 	asset_installer->open(p_file);
 }


### PR DESCRIPTION
- To make things easier to follow, display the asset name in confirmation dialogs.

This reduces the number of clicks required to install an asset.

## Preview

![image](https://user-images.githubusercontent.com/180032/113738385-22d2cf80-96ff-11eb-9651-d33328570448.png)

![image](https://user-images.githubusercontent.com/180032/125267384-08fce600-e307-11eb-8acc-a9285efc2823.png)
