### PR TITLE
Ensure ConvexPolygonShape3D support count variable is initialised

### DIFF
--- a/servers/physics_3d/shape_3d_sw.cpp
+++ b/servers/physics_3d/shape_3d_sw.cpp
@@ -891,6 +891,9 @@ void ConvexPolygonShape3DSW::get_supports(const Vector3 &p_normal, int p_max, Ve
 	const Vector3 *vertices = mesh.vertices.ptr();
 	int vc = mesh.vertices.size();
 
+	r_amount = 0;
+	ERR_FAIL_COND_MSG(vc == 0, "Convex polygon shape has no vertices.");
+
 	//find vertex first
 	real_t max = 0;
 	int vtx = 0;


### PR DESCRIPTION
Also adds an error when the ConvexPolygonShape3D doesn't have any vertices.

Fixes #47438
