### PR TITLE
Fix the previous tab and next tab editor shortcuts being ignored

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -515,6 +515,7 @@ private:
 
 	bool convert_old;
 
+	void _input(const Ref<InputEvent> &p_event);
 	void _unhandled_input(const Ref<InputEvent> &p_event);
 
 	static void _load_error_notify(void *p_ud, const String &p_text);


### PR DESCRIPTION
This makes <kbd>Ctrl + Tab</kbd> and <kbd>Ctrl + Shift + Tab</kbd> switch scene tabs in the editor as expected.

This should be cherry-picked to the `3.x` branch after 3.3 is released, since the feature didn't work in 3.2.x either from my testing.

This closes https://github.com/godotengine/godot/issues/8799.