### PR TITLE
Fix stack overflow in setter

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2014,6 +2014,8 @@ Error GDScriptCompiler::_parse_setter_getter(GDScript *p_script, const GDScriptP
 		func_name = "@" + p_variable->identifier->name + "_getter";
 	}
 
+	codegen.function_name = func_name;
+
 	GDScriptDataType return_type;
 	if (p_is_setter) {
 		return_type.has_type = true;


### PR DESCRIPTION
Closes #47662
where a Stack overflow happens in the setter.

Currently, if a variable has a setter, every occurrence of its assignments are replaced by the setter, even in its own setter method, thus creating a stack overflow error where the setter method is calling itself recursively.
The `is_in_setter = setter_function == codegen.function_name;` should detect if the assignement happens in its setter or not, but codegen.function_name is undefined.

This fix fills the codegen.function_name, thus avoiding the bug.
