### PR TITLE
Improve the editor window title for better usability

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -376,14 +376,16 @@ void EditorNode::_version_control_menu_option(int p_idx) {
 }
 
 void EditorNode::_update_title() {
-	String appname = ProjectSettings::get_singleton()->get("application/config/name");
-	String title = appname.is_empty() ? String(VERSION_FULL_NAME) : String(VERSION_NAME + String(" - ") + appname);
-	String edited = editor_data.get_edited_scene_root() ? editor_data.get_edited_scene_root()->get_filename() : String();
+	const String appname = ProjectSettings::get_singleton()->get("application/config/name");
+	String title = (appname.is_empty() ? "Unnamed Project" : appname) + String(" - ") + VERSION_NAME;
+	const String edited = editor_data.get_edited_scene_root() ? editor_data.get_edited_scene_root()->get_filename() : String();
 	if (!edited.is_empty()) {
-		title += " - " + String(edited.get_file());
+		// Display the edited scene name before the program name so that it can be seen in the OS task bar.
+		title = vformat("%s - %s", edited.get_file(), title);
 	}
 	if (unsaved_cache) {
-		title += " (*)";
+		// Display the "modified" mark before anything else so that it can always be seen in the OS task bar.
+		title = vformat("(*) %s", title);
 	}
 
 	DisplayServer::get_singleton()->window_set_title(title);


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51972.

- Display the scene name, then the project name, then "Godot Engine".
- Display the "modified" mark before anything else.

Both of these changes ensure important, project-specific elements can always be seen in the task bar which may truncate strings due to its low per-item width.

- Use "Unnamed Project" if the project has no name (similar to the Project Manager).

## Preview

*Both screenshots show the same scene being edited with a "modified" marker in the KDE task bar.*

### Before

![2021-04-06_19 28 06](https://user-images.githubusercontent.com/180032/113753630-9a5c2b00-970e-11eb-834c-2fd1679179c3.png)

### After

![2021-04-06_19 27 37](https://user-images.githubusercontent.com/180032/113753634-9af4c180-970e-11eb-9b99-2f31d71ba093.png)
