### PR TITLE
Check for the use of an empty shape in Bullet Kinematic collisions

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -1235,6 +1235,10 @@ bool SpaceBullet::recover_from_penetration(RigidBodyBullet *p_body, const btTran
 			continue;
 		}
 
+		if (kin_shape.shape->getShapeType() == EMPTY_SHAPE_PROXYTYPE) {
+			continue;
+		}
+
 		btTransform shape_transform = p_body_position * kin_shape.transform;
 		shape_transform.getOrigin() += r_delta_recover_movement;
 


### PR DESCRIPTION
If a user attempts to use a malformed mesh as a `ConvexPolygonShape` on a Bullet `KinematicBody`, an empty shape is created instead. This PR checks for and skips these empty shapes when doing kinematic collisions to ensure the Bullet physics engine doesn't crash later.

Fixes #47437.

As Bullet is not currently working on `master` I cannot test it there, but I have tested a cherry-pick of this commit on 3.x, so it's safe to cherry-pick there.

Note: There is already:
1. An error telling a user that the malformed mesh could not be used to create a `ConvexPolygon`:
```
ERROR: decompose_polygon_in_convex: Convex decomposing failed!
   At: core/math/geometry.cpp:705.
```
2. A warning telling the user that a `ConvexPolygonShape` is not supported with `KinematicBody`
```
WARNING: copyAllOwnerShapes: This shape is not supported to be kinematic!
   At: modules/bullet/rigid_body_bullet.cpp:243.
```
This PR just prevents a crash should those errors and warnings be ignored.