### PR TITLE
[3.x] Check for empty ConcavePolygonShape2D before checking for intersection

### DIFF
--- a/servers/physics_2d/shape_2d_sw.cpp
+++ b/servers/physics_2d/shape_2d_sw.cpp
@@ -743,6 +743,9 @@ bool ConcavePolygonShape2DSW::contains_point(const Vector2 &p_point) const {
 
 bool ConcavePolygonShape2DSW::intersect_segment(const Vector2 &p_begin, const Vector2 &p_end, Vector2 &r_point, Vector2 &r_normal) const {
 
+	if (segments.size() == 0 || points.size() == 0)
+		return false;
+
 	uint32_t *stack = (uint32_t *)alloca(sizeof(int) * bvh_depth);
 
 	enum {


### PR DESCRIPTION
3.x version of #47678.
