### PR TITLE
Warn when creating a script with the same name as the parent class

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -238,6 +238,14 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	return "";
 }
 
+String ScriptCreateDialog::_get_class_name() const {
+	if (has_named_classes) {
+		return class_name->get_text();
+	} else {
+		return ProjectSettings::get_singleton()->localize_path(file_path->get_text()).get_file().get_basename();
+	}
+}
+
 void ScriptCreateDialog::_class_name_changed(const String &p_name) {
 	if (_validate_class(class_name->get_text())) {
 		is_class_name_valid = true;
@@ -287,13 +295,7 @@ void ScriptCreateDialog::ok_pressed() {
 }
 
 void ScriptCreateDialog::_create_new() {
-	String cname_param;
-
-	if (has_named_classes) {
-		cname_param = class_name->get_text();
-	} else {
-		cname_param = ProjectSettings::get_singleton()->localize_path(file_path->get_text()).get_file().get_basename();
-	}
+	String cname_param = _get_class_name();
 
 	Ref<Script> scr;
 	if (script_template != "") {
@@ -687,6 +689,10 @@ void ScriptCreateDialog::_update_dialog() {
 
 	builtin_warning_label->set_visible(is_built_in);
 
+	// Check if the script name is the same as the parent class.
+	// This warning isn't relevant if the script is built-in.
+	script_name_warning_label->set_visible(!is_built_in && _get_class_name() == parent_name->get_text());
+
 	if (is_built_in) {
 		get_ok_button()->set_text(TTR("Create"));
 		parent_name->set_editable(true);
@@ -767,6 +773,14 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	vb->add_child(builtin_warning_label);
 	builtin_warning_label->set_autowrap(true);
 	builtin_warning_label->hide();
+
+	script_name_warning_label = memnew(Label);
+	script_name_warning_label->set_text(
+			TTR("Warning: Having the script name be the same as a built-in type is usually not desired."));
+	vb->add_child(script_name_warning_label);
+	script_name_warning_label->add_theme_color_override("font_color", Color(1, 0.85, 0.4));
+	script_name_warning_label->set_autowrap(true);
+	script_name_warning_label->hide();
 
 	status_panel = memnew(PanelContainer);
 	status_panel->set_h_size_flags(Control::SIZE_FILL);

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -50,6 +50,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	Label *error_label;
 	Label *path_error_label;
 	Label *builtin_warning_label;
+	Label *script_name_warning_label;
 	PanelContainer *status_panel;
 	LineEdit *parent_name;
 	Button *parent_browse_button;
@@ -110,6 +111,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool _validate_parent(const String &p_string);
 	bool _validate_class(const String &p_string);
 	String _validate_path(const String &p_path, bool p_file_must_exist);
+	String _get_class_name() const;
 	void _class_name_changed(const String &p_name);
 	void _parent_name_changed(const String &p_parent);
 	void _template_changed(int p_template = 0);


### PR DESCRIPTION
This PR adds a warning when creating a script if the class name is the same as the parent class.

![Screenshot from 2021-04-06 22-46-01](https://user-images.githubusercontent.com/1646875/113803414-7f97af80-972a-11eb-8109-d487f2a230b8.png)

This is most useful for C# users, but it's also relevant for GDScript/VisualScript/GDNative users as well (for those, it's a best practice thing, not a technical limitation, or rather, a technical inconvenience).

For example, let's say that you created this Enemy class in C#, which is a KinematicBody3D:

```cs
public partial class Enemy : KinematicBody3D
```

Then you want to create a class for your player, but you forgot to rename the node to "Player" or similar, and you also forgot to change the name of the file to something other than `KinematicBody3D.cs`. So you get this:

```cs
public partial class KinematicBody3D : Godot.KinematicBody3D
```

The C# script generator has code to handle this case, so it will mark it as extending `Godot.KinematicBody3D`. However, this breaks the `Enemy` class, since now the behavior and variables from the player will show up inside Enemy, since Enemy is now extending `KinematicBody3D` from `KinematicBody3D.cs` instead of `Godot.KinematicBody3D`. To be clear, this is not a hypothetical problem, I've seen this happen to someone in the past.

* One solution would be to make all new scripts `: Godot.Something` instead of `: Something`, however there would still be confusion if someone used `new KinematicBody3D` instead of `new Godot.KinematicBody3D`.

* Also, even if this problem didn't exist (and it doesn't in GDScript etc), I would still recommend as a best practice that people don't name their scripts the same as a built-in type for the sake of clarity.

The solution I've come up with is this PR which will warn users if they try to create a script with the same name as the parent type. Really we would want to check if the class name is the same as any built-in type, but I'm not sure what's the best way to implement that, and checking if it's the same as the parent class will cover the most common cases for this warning.