### PR TITLE
Fix `script_class` null access when reloading a deleted C# script

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -875,6 +875,13 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 	// As scripts are going to be reloaded, must proceed without locking here
 
 	for (Ref<CSharpScript> &script : scripts) {
+		// If someone removes a script from a node, deletes the script, builds, adds a script to the
+		// same node, then builds again, the script might have no path and also no script_class. In
+		// that case, we can't (and don't need to) reload it.
+		if (script->get_path().is_empty() && !script->script_class) {
+			continue;
+		}
+
 		to_reload.push_back(script);
 
 		if (script->get_path().is_empty()) {


### PR DESCRIPTION
If `script->script_class` is null, `script->script_class->get_name_for_lookup()` a few lines down hits a null access. I added a condition for this specific case that `continue`s, instead.

Fixes https://github.com/godotengine/godot/issues/46974 (repro details inside)
Also repros in `3.x`. Here's a cherry-pick on `3.x`, if it seems worth taking: https://github.com/31/godot/commit/68765de464df55dc452e8401f028ac82a6366744