### PR TITLE
[2.1] LineEdit crash on delete_text

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -870,6 +870,15 @@ void LineEdit::delete_char() {
 
 void LineEdit::delete_text(int p_from_column, int p_to_column) {
 
+	p_from_column = MAX(0, p_from_column);
+	p_to_column = MIN(p_to_column, text.size());
+
+	if (p_from_column >= p_to_column) {
+
+		// Nothing to do
+		return;
+	}
+	
 	undo_text = text;
 
 	if (text.size() > 0) {


### PR DESCRIPTION
Got that really annoying exception while making some experiment with LineEdit.
I think this fix is important for 2.1, since it crashes the engine.

```
ERROR: operator[]: SEVERE: Index p_index out of size (size()).
   At: core/vector.h:137.
handle_crash: Program crashed with signal 11
Dumping the backtrace. Please include this when reporting the bug on https://support.binogure-studio.com/
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x3bd60) [0x7fa77f2abd60] (??:0)
[2] LineEdit::delete_text(int, int) (??:0)
[3] LineEdit::selection_delete() (??:0)
[4] LineEdit::_input_event(InputEvent) (??:0)
[5] MethodBind1<InputEvent>::call(Object*, Variant const**, int, Variant::CallError&) (??:0)
[6] Object::call_multilevel(StringName const&, Variant const**, int) (??:0)
[7] Object::call_multilevel(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (??:0)
[8] Viewport::_gui_input_event(InputEvent) (??:0)
[9] Viewport::input(InputEvent const&) (??:0)
[10] Viewport::_vp_input(InputEvent const&) (??:0)
[11] MethodBind1<InputEvent const&>::call(Object*, Variant const**, int, Variant::CallError&) (??:0)
[12] Object::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[13] Object::call(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (??:0)
[14] SceneTree::call_group(unsigned int, StringName const&, StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (??:0)
[15] SceneTree::input_event(InputEvent const&) (??:0)
[16] InputDefault::parse_input_event(InputEvent const&) (??:0)
[17] OS_X11::handle_key_event(XKeyEvent*, bool) (??:0)
[18] OS_X11::process_xevents() (??:0)
[19] OS_X11::run() (??:0)
[20] godot(main+0xa6) [0xc828dc] (??:0)
[21] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xea) [0x7fa77f296d0a] (??:0)
[22] godot(_start+0x2a) [0xc8275a] (??:0)
-- END OF BACKTRACE --
```

This bug has already been fixed in v3.2 and master ( https://github.com/godotengine/godot/commit/24b3bf06375ff408fce82e698f264e32913d237c ). Haven't tried to reproduce it in 3.1 or 3.0 sorry.
