### PR TITLE
Fix ColorPicker's RGB bars are show in RAW mode and other

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -115,19 +115,22 @@ void ColorPicker::_update_controls() {
 
 	if (raw_mode_enabled) {
 		for (int i = 0; i < 3; i++) {
-			scroll[i]->add_theme_icon_override("grabber", Ref<Texture2D>());
-			scroll[i]->add_theme_icon_override("grabber_highlight", Ref<Texture2D>());
-			scroll[i]->add_theme_style_override("slider", Ref<StyleBox>());
-			scroll[i]->add_theme_style_override("grabber_area", Ref<StyleBox>());
-			scroll[i]->add_theme_style_override("grabber_area_highlight", Ref<StyleBox>());
+			scroll[i]->remove_theme_icon_override("grabber");
+			scroll[i]->remove_theme_icon_override("grabber_highlight");
+			scroll[i]->remove_theme_style_override("slider");
+			scroll[i]->remove_theme_style_override("grabber_area");
+			scroll[i]->remove_theme_style_override("grabber_area_highlight");
 		}
 	} else {
-		for (int i = 0; i < 3; i++) {
-			scroll[i]->add_theme_icon_override("grabber", get_theme_icon("bar_arrow"));
-			scroll[i]->add_theme_icon_override("grabber_highlight", get_theme_icon("bar_arrow"));
-			scroll[i]->add_theme_style_override("slider", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
-			scroll[i]->add_theme_style_override("grabber_area", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
-			scroll[i]->add_theme_style_override("grabber_area_highlight", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
+		Ref<StyleBoxEmpty> style_box_empty(memnew(StyleBoxEmpty));
+		Ref<Texture2D> bar_arrow = get_theme_icon("bar_arrow");
+
+		for (int i = 0; i < 4; i++) {
+			scroll[i]->add_theme_icon_override("grabber", bar_arrow);
+			scroll[i]->add_theme_icon_override("grabber_highlight", bar_arrow);
+			scroll[i]->add_theme_style_override("slider", style_box_empty);
+			scroll[i]->add_theme_style_override("grabber_area", style_box_empty);
+			scroll[i]->add_theme_style_override("grabber_area_highlight", style_box_empty);
 		}
 	}
 
@@ -887,12 +890,8 @@ ColorPicker::ColorPicker() :
 
 		vbr->add_child(hbc);
 	}
+
 	labels[3]->set_text("A");
-	scroll[3]->add_theme_icon_override("grabber", get_theme_icon("bar_arrow"));
-	scroll[3]->add_theme_icon_override("grabber_highlight", get_theme_icon("bar_arrow"));
-	scroll[3]->add_theme_style_override("slider", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
-	scroll[3]->add_theme_style_override("grabber_area", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
-	scroll[3]->add_theme_style_override("grabber_area_highlight", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
 
 	HBoxContainer *hhb = memnew(HBoxContainer);
 	vbr->add_child(hhb);


### PR DESCRIPTION
Fix RGB bars that shouldn't show in RAW mode. And the problem with the Alpha bar when the editor scale was changed.

I noticed this issue in https://github.com/godotengine/godot/commit/1075943cc54266eefd85b1829c282e09d19ef491. Maybe after #47252 was merged.

<details><summary>Images</summary><p>

![image](https://user-images.githubusercontent.com/13400398/113858625-25502a80-97ce-11eb-9fc4-be17e2abfda5.png)
![image](https://user-images.githubusercontent.com/13400398/113858744-4add3400-97ce-11eb-89a5-ccc999432a4f.png)

</p></details>

<details><summary>Images</summary><p>

![image](https://user-images.githubusercontent.com/13400398/113858673-339e4680-97ce-11eb-854a-0ec5d1bd9577.png)
![image](https://user-images.githubusercontent.com/13400398/113859525-3483a800-97cf-11eb-896a-4285bc8047f6.png)

</p></details>

I'm really not sure that why it needs to override a theme every `_update_control` called. But it really fixes the issue.
