### PR TITLE
Add GPS functionality for Android

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -121,6 +121,10 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_accelerometer"), &Input::get_accelerometer);
 	ClassDB::bind_method(D_METHOD("get_magnetometer"), &Input::get_magnetometer);
 	ClassDB::bind_method(D_METHOD("get_gyroscope"), &Input::get_gyroscope);
+	ClassDB::bind_method(D_METHOD("start_gps_tracker", "time_ms", "distance"), &Input::start_gps_tracker);
+	ClassDB::bind_method(D_METHOD("stop_gps_tracker"), &Input::stop_gps_tracker);
+	ClassDB::bind_method(D_METHOD("get_location"), &Input::get_location);
+	ClassDB::bind_method(D_METHOD("get_altitude"), &Input::get_altitude);
 	ClassDB::bind_method(D_METHOD("get_last_mouse_speed"), &Input::get_last_mouse_speed);
 	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &Input::get_mouse_button_mask);
 	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &Input::set_mouse_mode);
@@ -460,6 +464,24 @@ Vector3 Input::get_gyroscope() const {
 	return gyroscope;
 }
 
+void Input::start_gps_tracker(int p_time_ms, int p_distance) {
+	OS::get_singleton()->start_gps_tracker(p_time_ms, p_distance);
+}
+
+void Input::stop_gps_tracker() {
+	OS::get_singleton()->stop_gps_tracker();
+}
+
+Vector2 Input::get_location() const {
+	_THREAD_SAFE_METHOD_
+	return location;
+}
+
+float Input::get_altitude() const {
+	_THREAD_SAFE_METHOD_
+	return altitude;
+}
+
 void Input::parse_input_event(const Ref<InputEvent> &p_event) {
 	_parse_input_event_impl(p_event, false);
 }
@@ -698,6 +720,18 @@ void Input::set_gyroscope(const Vector3 &p_gyroscope) {
 	_THREAD_SAFE_METHOD_
 
 	gyroscope = p_gyroscope;
+}
+
+void Input::set_location(const Vector2 &p_location) {
+	_THREAD_SAFE_METHOD_
+
+	location = p_location;
+}
+
+void Input::set_altitude(float p_altitude) {
+	_THREAD_SAFE_METHOD_
+
+	altitude = p_altitude;
 }
 
 void Input::set_mouse_position(const Point2 &p_posf) {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -109,6 +109,8 @@ private:
 	Vector3 accelerometer;
 	Vector3 magnetometer;
 	Vector3 gyroscope;
+	Vector2 location;
+	float altitude;
 	Vector2 mouse_pos;
 	int64_t mouse_window = 0;
 
@@ -285,6 +287,11 @@ public:
 	Vector3 get_magnetometer() const;
 	Vector3 get_gyroscope() const;
 
+	void start_gps_tracker(int p_time_ms = 10000, int p_distance = 10);
+	void stop_gps_tracker();
+	Vector2 get_location() const;
+	float get_altitude() const;
+
 	Point2 get_mouse_position() const;
 	Point2 get_last_mouse_speed() const;
 	int get_mouse_button_mask() const;
@@ -298,6 +305,8 @@ public:
 	void set_accelerometer(const Vector3 &p_accel);
 	void set_magnetometer(const Vector3 &p_magnetometer);
 	void set_gyroscope(const Vector3 &p_gyroscope);
+	void set_location(const Vector2 &p_location);
+	void set_altitude(float p_altitude);
 	void set_joy_axis(int p_device, int p_axis, float p_value);
 
 	void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration = 0);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -532,6 +532,14 @@ void OS::add_frame_delay(bool p_can_draw) {
 	}
 }
 
+void OS::start_gps_tracker(int p_time_ms, int p_distance) {
+	WARN_PRINT("start_gps_tracker only works with Android");
+}
+
+void OS::stop_gps_tracker() {
+	WARN_PRINT("stop_gps_tracker only works with Android");
+}
+
 OS::OS() {
 	singleton = this;
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -296,6 +296,10 @@ public:
 	virtual Vector<String> get_granted_permissions() const { return Vector<String>(); }
 
 	virtual void process_and_drop_events() {}
+
+	virtual void start_gps_tracker(int p_time_ms, int p_distance);
+	virtual void stop_gps_tracker();
+
 	OS();
 	virtual ~OS();
 };

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -76,6 +76,14 @@
 				Returns a value between 0 and 1 representing the intensity of the given action. In a joypad, for example, the further away the axis (analog sticks or L2, R2 triggers) is from the dead zone, the closer the value will be to 1. If the action is mapped to a control that has no axis as the keyboard, the value returned will be 0 or 1.
 			</description>
 		</method>
+		<method name="get_altitude" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				If a GPS tracker is running, returns the device's altitude above the WGS84 ellipsoid.
+				[b]Note:[/b] This method only works on Android.
+			</description>
+		</method>
 		<method name="get_axis" qualifiers="const">
 			<return type="float">
 			</return>
@@ -170,6 +178,14 @@
 			</return>
 			<description>
 				Returns the mouse speed for the last time the cursor was moved, and this until the next frame where the mouse moves. This means that even if the mouse is not moving, this function will still return the value of the last motion.
+			</description>
+		</method>
+		<method name="get_location" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<description>
+				If a GPS tracker is running, returns the device's latitude and longitude.
+				[b]Note:[/b] This method only works on Android.
 			</description>
 		</method>
 		<method name="get_magnetometer" qualifiers="const">
@@ -381,6 +397,19 @@
 				Input accumulation is enabled by default. It can be disabled to get slightly more precise/reactive input at the cost of increased CPU usage. In applications where drawing freehand lines is required, input accumulation should generally be disabled while the user is drawing the line to get results that closely follow the actual input.
 			</description>
 		</method>
+		<method name="start_gps_tracker">
+			<return type="void">
+			</return>
+			<argument index="0" name="time_ms" type="int">
+			</argument>
+			<argument index="1" name="distance" type="int">
+			</argument>
+			<description>
+				Starts a GPS tracker, which is necessary for calling [code]get_location()[/code] and [code]get_altitude[/code]. The minimum time between location updates is given by [code]time_ms[/code]. [code]distance[/code] specifies the minimum distance in meters the device has to move before a new location fix is provided. Note that these parameters do not ensure an update every [code]time_ms[/code] milliseconds, as that is device-dependent.
+				If a GPS tracker is already running, calling this method again will restart it using the new time and distance parameters.
+				[b]Note:[/b] This method only works on Android.
+			</description>
+		</method>
 		<method name="start_joy_vibration">
 			<return type="void">
 			</return>
@@ -395,6 +424,14 @@
 			<description>
 				Starts to vibrate the joypad. Joypads usually come with two rumble motors, a strong and a weak one. [code]weak_magnitude[/code] is the strength of the weak motor (between 0 and 1) and [code]strong_magnitude[/code] is the strength of the strong motor (between 0 and 1). [code]duration[/code] is the duration of the effect in seconds (a duration of 0 will try to play the vibration indefinitely).
 				[b]Note:[/b] Not every hardware is compatible with long effect durations; it is recommended to restart an effect if it has to be played for more than a few seconds.
+			</description>
+		</method>
+		<method name="stop_gps_tracker">
+			<return type="void">
+			</return>
+			<description>
+				Stops the GPS tracker if running.
+				[b]Note:[/b] This method only works on Android.
 			</description>
 		</method>
 		<method name="stop_joy_vibration">

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -825,6 +825,14 @@ void DisplayServerAndroid::process_gyroscope(const Vector3 &p_gyroscope) {
 	Input::get_singleton()->set_gyroscope(p_gyroscope);
 }
 
+void DisplayServerAndroid::process_location(const Vector2 &p_location) {
+	Input::get_singleton()->set_location(p_location);
+}
+
+void DisplayServerAndroid::process_altitude(float p_altitude) {
+	Input::get_singleton()->set_altitude(p_altitude);
+}
+
 void DisplayServerAndroid::mouse_set_mode(MouseMode p_mode) {
 	if (mouse_mode == p_mode) {
 		return;

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -172,6 +172,8 @@ public:
 	void process_gravity(const Vector3 &p_gravity);
 	void process_magnetometer(const Vector3 &p_magnetometer);
 	void process_gyroscope(const Vector3 &p_gyroscope);
+	void process_location(const Vector2 &p_location);
+	void process_altitude(float p_altitude);
 	void process_touch(int p_event, int p_pointer, const Vector<TouchPos> &p_points);
 	void process_hover(int p_type, Point2 p_pos);
 	void process_mouse_event(int input_device, int event_action, int event_android_buttons_mask, Point2 event_pos, float event_vertical_factor = 0, float event_horizontal_factor = 0);

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
@@ -138,6 +138,16 @@ public class GodotLib {
 	public static native void gyroscope(float x, float y, float z);
 
 	/**
+	 * Forward location from the main thread to the GL thread.
+	 */
+	public static native void location(float lat, float lng);
+
+	/**
+	 * Forward altitude from the main thread to the GL thread.
+	 */
+	public static native void altitude(float alt);
+
+	/**
 	 * Forward regular key events from the main thread to the GL thread.
 	 */
 	public static native void key(int p_keycode, int p_scancode, int p_unicode_char, boolean p_pressed);

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -68,6 +68,8 @@ static Vector3 accelerometer;
 static Vector3 gravity;
 static Vector3 magnetometer;
 static Vector3 gyroscope;
+static Vector2 location;
+static float altitude;
 
 extern "C" {
 
@@ -230,6 +232,8 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jcl
 	DisplayServerAndroid::get_singleton()->process_gravity(gravity);
 	DisplayServerAndroid::get_singleton()->process_magnetometer(magnetometer);
 	DisplayServerAndroid::get_singleton()->process_gyroscope(gyroscope);
+	DisplayServerAndroid::get_singleton()->process_location(location);
+	DisplayServerAndroid::get_singleton()->process_altitude(altitude);
 
 	if (os_android->main_loop_iterate()) {
 		godot_java->force_quit(env);
@@ -368,6 +372,14 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnetometer(JNIEnv *
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gyroscope(JNIEnv *env, jclass clazz, jfloat x, jfloat y, jfloat z) {
 	gyroscope = Vector3(x, y, z);
+}
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_location(JNIEnv *env, jclass clazz, jfloat lat, jfloat lng) {
+	location = Vector2(lat, lng);
+}
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_altitude(JNIEnv *env, jclass clazz, jfloat alt) {
+	altitude = alt;
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusin(JNIEnv *env, jclass clazz) {

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -61,6 +61,8 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_accelerometer(JNIEnv 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gravity(JNIEnv *env, jclass clazz, jfloat x, jfloat y, jfloat z);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnetometer(JNIEnv *env, jclass clazz, jfloat x, jfloat y, jfloat z);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gyroscope(JNIEnv *env, jclass clazz, jfloat x, jfloat y, jfloat z);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_location(JNIEnv *env, jclass clazz, jfloat lat, jfloat lng);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_altitude(JNIEnv *env, jclass clazz, jfloat alt);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusin(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusout(JNIEnv *env, jclass clazz);
 JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getGlobal(JNIEnv *env, jclass clazz, jstring path);

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -76,6 +76,8 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_get_input_fallback_mapping = p_env->GetMethodID(godot_class, "getInputFallbackMapping", "()Ljava/lang/String;");
 	_on_godot_setup_completed = p_env->GetMethodID(godot_class, "onGodotSetupCompleted", "()V");
 	_on_godot_main_loop_started = p_env->GetMethodID(godot_class, "onGodotMainLoopStarted", "()V");
+	_start_gps_tracker = p_env->GetMethodID(godot_class, "startGpsTracker", "(II)V");
+	_stop_gps_tracker = p_env->GetMethodID(godot_class, "stopGpsTracker", "()V");
 
 	// get some Activity method pointers...
 	_get_class_loader = p_env->GetMethodID(activity_class, "getClassLoader", "()Ljava/lang/ClassLoader;");
@@ -329,5 +331,23 @@ void GodotJavaWrapper::vibrate(int p_duration_ms) {
 		ERR_FAIL_COND(env == nullptr);
 
 		env->CallVoidMethod(godot_instance, _vibrate, p_duration_ms);
+	}
+}
+
+void GodotJavaWrapper::start_gps_tracker(int p_time_ms, int p_distance) {
+	if (_start_gps_tracker) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+
+		env->CallVoidMethod(godot_instance, _start_gps_tracker, p_time_ms, p_distance);
+	}
+}
+
+void GodotJavaWrapper::stop_gps_tracker() {
+	if (_stop_gps_tracker) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND(env == nullptr);
+
+		env->CallVoidMethod(godot_instance, _stop_gps_tracker);
 	}
 }

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -68,6 +68,8 @@ private:
 	jmethodID _get_input_fallback_mapping = 0;
 	jmethodID _on_godot_setup_completed = 0;
 	jmethodID _on_godot_main_loop_started = 0;
+	jmethodID _start_gps_tracker = 0;
+	jmethodID _stop_gps_tracker = 0;
 	jmethodID _get_class_loader = 0;
 
 public:
@@ -99,6 +101,8 @@ public:
 	jobject get_surface();
 	bool is_activity_resumed();
 	void vibrate(int p_duration_ms);
+	void start_gps_tracker(int p_time_ms, int p_distance);
+	void stop_gps_tracker();
 	String get_input_fallback_mapping();
 };
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -275,6 +275,14 @@ void OS_Android::vibrate_handheld(int p_duration_ms) {
 	godot_java->vibrate(p_duration_ms);
 }
 
+void OS_Android::start_gps_tracker(int p_time_ms, int p_distance) {
+	godot_java->start_gps_tracker(p_time_ms, p_distance);
+}
+
+void OS_Android::stop_gps_tracker() {
+	godot_java->stop_gps_tracker();
+}
+
 bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 	if (p_feature == "mobile") {
 		return true;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -121,6 +121,9 @@ public:
 
 	void vibrate_handheld(int p_duration_ms) override;
 
+	virtual void start_gps_tracker(int p_time_ms, int p_distance) override;
+	virtual void stop_gps_tracker() override;
+
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
 	OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion);
 	~OS_Android();


### PR DESCRIPTION
This adds four GPS-related functions to the Input singleton:
- start_gps_tracker() where the user specifies the minimum frequency of location fixes and the minimum distance that the device has to move in order to get a location update (for battery saving reasons)
- stop_gps_tracker()
- get_locatino() which gives a Lat/Long Vector2 of the location
- get_altitude() which gives a float representing altitude above the WGS84 ellipsoid