### PR TITLE
Fix crash on importing empty .fbx file

### DIFF
--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -104,6 +104,9 @@ Node3D *EditorSceneImporterFBX::import_scene(const String &p_path, uint32_t p_fl
 
 		bool is_binary = false;
 		data.resize(f->get_len());
+
+		ERR_FAIL_COND_V(data.size() < 64, NULL);
+
 		f->get_buffer(data.ptrw(), data.size());
 		PackedByteArray fbx_header;
 		fbx_header.resize(64);


### PR DESCRIPTION
Fixes this crash when an empty .fbx file is placed in the project.
CC @RevoluPowered 
```
CrashHandlerException: Program crashed
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[0] EditorSceneImporterFBX::import_scene (S:\repo\godot-pr-pr\modules\fbx\editor_scene_importer_fbx.cpp:111)
[1] ResourceImporterScene::import (S:\repo\godot-pr-pr\editor\import\resource_importer_scene.cpp:1366)
[2] EditorFileSystem::_reimport_file (S:\repo\godot-pr-pr\editor\editor_file_system.cpp:1779)
[3] EditorFileSystem::reimport_files (S:\repo\godot-pr-pr\editor\editor_file_system.cpp:1976)
[4] EditorFileSystem::_update_scan_actions (S:\repo\godot-pr-pr\editor\editor_file_system.cpp:582)
[5] EditorFileSystem::_notification (S:\repo\godot-pr-pr\editor\editor_file_system.cpp:1124)
[6] EditorFileSystem::_notificationv (S:\repo\godot-pr-pr\editor\editor_file_system.h:108)
[7] Object::notification (S:\repo\godot-pr-pr\core\object\object.cpp:795)
[8] SceneTree::_notify_group_pause (S:\repo\godot-pr-pr\scene\main\scene_tree.cpp:811)
[9] SceneTree::process (S:\repo\godot-pr-pr\scene\main\scene_tree.cpp:443)
[10] Main::iteration (S:\repo\godot-pr-pr\main\main.cpp:2495)
[11] OS_Windows::run (S:\repo\godot-pr-pr\platform\windows\os_windows.cpp:622)
[12] widechar_main (S:\repo\godot-pr-pr\platform\windows\godot_windows.cpp:163)
[13] _main (S:\repo\godot-pr-pr\platform\windows\godot_windows.cpp:185)
[14] main (S:\repo\godot-pr-pr\platform\windows\godot_windows.cpp:199)
[15] __scrt_common_main_seh (D:\agent\_work\9\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[16] BaseThreadInitThunk
-- END OF BACKTRACE --
```