### PR TITLE
Fix crash on importing empty .fbx file (3.x Backport)

### DIFF
--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -104,6 +104,9 @@ Node *EditorSceneImporterFBX::import_scene(const String &p_path, uint32_t p_flag
 
 		bool is_binary = false;
 		data.resize(f->get_len());
+
+		ERR_FAIL_COND_V(data.size() < 64, NULL);
+
 		f->get_buffer(data.write().ptr(), data.size());
 		PoolByteArray fbx_header;
 		fbx_header.resize(64);


### PR DESCRIPTION
Fixes this crash when an empty .fbx file is placed in the project.
Backport of #47717

CC @RevoluPowered 
```
CrashHandlerException: Program crashed
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[0] EditorSceneImporterFBX::import_scene (S:\repo\godot-3.x-pr\modules\fbx\editor_scene_importer_fbx.cpp:111)
[1] EditorSceneImporterFBX::import_scene (S:\repo\godot-3.x-pr\modules\fbx\editor_scene_importer_fbx.cpp:111)
[2] ResourceImporterScene::import (S:\repo\godot-3.x-pr\editor\import\resource_importer_scene.cpp:1317)
[3] EditorFileSystem::_reimport_file (S:\repo\godot-3.x-pr\editor\editor_file_system.cpp:1813)
[4] EditorFileSystem::reimport_files (S:\repo\godot-3.x-pr\editor\editor_file_system.cpp:2012)
[5] EditorFileSystem::_update_scan_actions (S:\repo\godot-3.x-pr\editor\editor_file_system.cpp:599)
[6] EditorFileSystem::_notification (S:\repo\godot-3.x-pr\editor\editor_file_system.cpp:1155)
[7] EditorFileSystem::_notificationv (S:\repo\godot-3.x-pr\editor\editor_file_system.h:110)
[8] Object::notification (S:\repo\godot-3.x-pr\core\object.cpp:931)
[9] SceneTree::_notify_group_pause (S:\repo\godot-3.x-pr\scene\main\scene_tree.cpp:995)
[10] SceneTree::idle (S:\repo\godot-3.x-pr\scene\main\scene_tree.cpp:530)
[11] Main::iteration (S:\repo\godot-3.x-pr\main\main.cpp:2123)
[12] OS_Windows::run (S:\repo\godot-3.x-pr\platform\windows\os_windows.cpp:3440)
[13] widechar_main (S:\repo\godot-3.x-pr\platform\windows\godot_windows.cpp:162)
[14] _main (S:\repo\godot-3.x-pr\platform\windows\godot_windows.cpp:184)
[15] main (S:\repo\godot-3.x-pr\platform\windows\godot_windows.cpp:196)
[16] __scrt_common_main_seh (D:\agent\_work\9\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[17] BaseThreadInitThunk
-- END OF BACKTRACE --
```