### PR TITLE
Tweak the default project path to use a dedicated folder in Documents

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -195,7 +195,8 @@ void ProjectDialog::_validate_path() {
 	String home_dir = OS::get_singleton()->get_environment("HOME");
 #endif
 	String documents_dir = OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
-	if (target_path == home_dir || target_path == documents_dir) {
+	String default_dir = String(EditorSettings::get_singleton()->get("filesystem/directories/default_project_path"));
+	if (target_path == home_dir || target_path == documents_dir || target_path == default_dir) {
 		_set_message(TTRC("You cannot save a project at the selected path. Please create a subfolder or choose a new path."), MESSAGE_ERROR, target_path_input_type);
 		return;
 	}

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -648,9 +648,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_PLACEHOLDER_TEXT, "filesystem/external_programs/terminal_emulator_flags", "", "Call flags with placeholder: {directory}.");
 
 	// Directories
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/autoscan_project_path", "", "")
-	const String fs_dir_default_project_path = OS::get_singleton()->has_environment("HOME") ? OS::get_singleton()->get_environment("HOME") : OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
-	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/default_project_path", fs_dir_default_project_path, "")
+	// Set the default directory as both the autoscan project path and default project path,
+	// so that projects can be dropped onto it and detected automatically.
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/autoscan_project_path", OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS).path_join("Godot"), "");
+	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/default_project_path", OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS).path_join("Godot"), "");
 
 	// On save
 	_initial_set("filesystem/on_save/compress_binary_resources", true);


### PR DESCRIPTION
- Set the autoscan path to match the default project path. This way, projects can be manually extracted to it and detected on launch.
- Disallow creating new projects at the root of the default project path to avoid clutter. Instead, projects must be created in subfolders.

One downside is that a `$HOME/Documents/Godot` folder will be created even if the user never creates any projects in it. However, I believe it encourages better organization (it's something I always do personally), so I'd say the tradeoff is worth it. This tradeoff is also shared by other software such as Premiere Pro, so we wouldn't be the only software to do this.

## Preview

![image](https://user-images.githubusercontent.com/180032/114023535-4c146c80-9873-11eb-8484-4628241ffddf.png)

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/13914