### PR TITLE
Improve command line `--print-fps` display

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2537,10 +2537,10 @@ bool Main::iteration() {
 	if (frame > 1000000) {
 		if (editor || project_manager) {
 			if (print_fps) {
-				print_line("Editor FPS: " + itos(frames));
+				print_line(vformat("Editor FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(1)));
 			}
 		} else if (GLOBAL_GET("debug/settings/stdout/print_fps") || print_fps) {
-			print_line("Game FPS: " + itos(frames));
+			print_line(vformat("Project FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(1)));
 		}
 
 		Engine::get_singleton()->_fps = frames;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/47733.

- Display the frame time in addition to FPS.
  - Frame time is a more objective measurement in comparison to FPS, but FPS is more familiar to people less acquainted with profiling.
- Rename "Game" to "Project" for the project FPS printing line.

I've also experimented with printing the project FPS with leading indentation to distinguish it from editor FPS when the output is intertwined, but I decided not to include it in this PR. (We can't print both on the same line because they're printed from separate processes at a separate time.)
Here's what it looked like (disregard the incorrect mspf rounding, which I fixed in this PR):

```
Editor FPS: 22 (45.0 mspf)
                                Project FPS: 143 (6.0 mspf)
Editor FPS: 22 (45.0 mspf)
                                Project FPS: 144 (6.0 mspf)
Editor FPS: 20 (50.0 mspf)
                                Project FPS: 144 (6.0 mspf)
Editor FPS: 25 (40.0 mspf)
```