### PR TITLE
[3.3] fix gltf importer regression from b032067e42c03, causing different BoneAttachment names

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -165,7 +165,7 @@ String EditorSceneImporterGLTF::_gen_unique_name(GLTFState &state, const String 
 		name = s_name;
 
 		if (index > 1) {
-			name += itos(index);
+			name += " " + itos(index);
 		}
 		if (!state.unique_names.has(name)) {
 			break;


### PR DESCRIPTION
in https://github.com/godotengine/godot/commit/b032067e42c03f9da860c0fe7ea4d40a33c467c8/editor/import/editor_scene_importer_gltf.cpp in line 174, the space had been removed.
This causes BoneAttachments (and perhaps other nodes) to have different names, which breaks inherited scenes.

The underlying issue of the names being unstable remains and is addressed in #47270, but probably won't make it into 3.3.