### PR TITLE
Allow to change the Stop shortcut used at runtime

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -258,6 +258,11 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		}
 	}
 
+	// Pass the debugger stop shortcut to the running instance(s).
+	String shortcut;
+	VariantWriter::write_to_string(ED_GET_SHORTCUT("editor/stop"), shortcut);
+	OS::get_singleton()->set_environment("__GODOT_EDITOR_STOP_SHORTCUT__", shortcut);
+
 	printf("Running: %s", exec.utf8().get_data());
 	for (const String &E : args) {
 		printf(" %s", E.utf8().get_data());

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -32,7 +32,9 @@
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
+#include "core/input/shortcut.h"
 #include "core/string/translation.h"
+#include "core/variant/variant_parser.h"
 #include "scene/gui/control.h"
 #include "scene/scene_string_names.h"
 #include "scene/theme/theme_db.h"
@@ -1034,9 +1036,31 @@ bool Window::_can_consume_input_events() const {
 
 void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	if (EngineDebugger::is_active()) {
-		// Quit from game window using F8.
+		// Quit from game window using the stop shortcut (F8 by default).
+		// The custom shortcut is provided via environment variable when running from the editor.
+		if (debugger_stop_shortcut.is_null()) {
+			String shortcut_str = OS::get_singleton()->get_environment("__GODOT_EDITOR_STOP_SHORTCUT__");
+			if (!shortcut_str.is_empty()) {
+				Variant shortcut_var;
+
+				VariantParser::StreamString ss;
+				ss.s = shortcut_str;
+
+				String errs;
+				int line;
+				VariantParser::parse(&ss, shortcut_var, errs, line);
+				debugger_stop_shortcut = shortcut_var;
+			}
+
+			if (debugger_stop_shortcut.is_null()) {
+				// Define a default shortcut if it wasn't provided or is invalid.
+				debugger_stop_shortcut.instantiate();
+				debugger_stop_shortcut->set_events({ (Variant)InputEventKey::create_reference(Key::F8) });
+			}
+		}
+
 		Ref<InputEventKey> k = p_ev;
-		if (k.is_valid() && k->is_pressed() && !k->is_echo() && k->get_keycode() == Key::F8) {
+		if (k.is_valid() && k->is_pressed() && !k->is_echo() && debugger_stop_shortcut->matches_event(k)) {
 			EngineDebugger::get_singleton()->send_message("request_quit", Array());
 		}
 	}

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -35,6 +35,7 @@
 
 class Control;
 class Font;
+class Shortcut;
 class StyleBox;
 class Theme;
 
@@ -150,6 +151,8 @@ private:
 	void _rect_changed_callback(const Rect2i &p_callback);
 	void _event_callback(DisplayServer::WindowEvent p_event);
 	virtual bool _can_consume_input_events() const override;
+
+	Ref<Shortcut> debugger_stop_shortcut;
 
 protected:
 	Viewport *_get_embedder() const;


### PR DESCRIPTION
Fixes #23929

Here's how it works:
1. User plays a scene
2. Editor will serialize the `editor/stop` shortcut to a string using VariantWriter
3. The shortcut string is sent as an environment variable `__EDITOR_STOP_SHORTCUT__`
5. In runtime when EngineDebugger is active, Window will check if `debugger_stop_shortcut` variable is valid
6. If it's not, it will try to get the shortcut evnironment variable and use VariantParser to get a shortcut
7. If it fails, a default F8 shortcut is created
8. Window will check if the pressed event matches the shortcut