### PR TITLE
[WIP] Initialize all members with in-class field initializers (`core`)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,modernize-redundant-void-arg,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-nullptr,readability-braces-around-statements'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,cppcoreguidelines-pro-type-member-init,modernize-redundant-void-arg,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-nullptr,readability-braces-around-statements'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
@@ -13,6 +13,10 @@ CheckOptions:
   - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
     value:           '1'
   - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    value:           '1'
+  - key:             cppcoreguidelines-pro-type-member-init.UseAssignment
     value:           '1'
   - key:             google-readability-function-size.StatementThreshold
     value:           '800'

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -247,8 +247,8 @@ bool ProjectSettings::_get(const StringName &p_name, Variant &r_ret) const {
 struct _VCSort {
 	String name;
 	Variant::Type type;
-	int order;
-	int flags;
+	int order = 0;
+	int flags = 0;
 
 	bool operator<(const _VCSort &p_vcs) const { return order == p_vcs.order ? name < p_vcs.name : order < p_vcs.order; }
 };

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -451,7 +451,8 @@ Dictionary _OS::get_datetime_from_unix_time(int64_t unix_time_val) const {
 	OS::Date date;
 	OS::Time time;
 
-	long dayclock, dayno;
+	long dayclock = 0;
+	long dayno = 0;
 	int year = EPOCH_YR;
 
 	if (unix_time_val >= 0) {

--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -40,7 +40,7 @@ struct _CoreConstant {
 	StringName enum_name;
 	bool ignore_value_in_docs = false;
 #endif
-	const char *name;
+	const char *name = nullptr;
 	int value = 0;
 
 	_CoreConstant() {}

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -84,7 +84,7 @@ struct LocalDebugger::ScriptsProfiler {
 			}
 		}
 
-		SortArray<ScriptLanguage::ProfilingInfo, ProfileInfoSort> sort;
+		SortArray<ScriptLanguage::ProfilingInfo, ProfileInfoSort> sort{};
 		sort.sort(pinfo.ptrw(), ofs);
 
 		// compute total script frame time

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -231,7 +231,7 @@ struct RemoteDebugger::ScriptsProfiler {
 			ptrs.write[i] = &info.write[i];
 		}
 
-		SortArray<ScriptLanguage::ProfilingInfo *, ProfileInfoSort> sa;
+		SortArray<ScriptLanguage::ProfilingInfo *, ProfileInfoSort> sa{};
 		sa.sort(ptrs.ptrw(), ofs);
 
 		int to_send = MIN(ofs, max_frame_functions);

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -216,8 +216,6 @@ void Input::SpeedTrack::reset() {
 }
 
 Input::SpeedTrack::SpeedTrack() {
-	min_ref_frame = 0.1;
-	max_ref_frame = 0.3;
 	reset();
 }
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -92,8 +92,8 @@ public:
 	};
 
 	struct JoyAxisValue {
-		int min;
-		float value;
+		int min = 0;
+		float value = 0.0;
 	};
 
 	typedef void (*EventDispatchFunc)(const Ref<InputEvent> &p_event);
@@ -104,7 +104,6 @@ private:
 	Set<int> keys_pressed;
 	Set<int> joy_buttons_pressed;
 	Map<int, float> _joy_axis;
-	//Map<StringName,int> custom_action_press;
 	Vector3 gravity;
 	Vector3 accelerometer;
 	Vector3 magnetometer;
@@ -113,12 +112,12 @@ private:
 	int64_t mouse_window = 0;
 
 	struct Action {
-		uint64_t physics_frame;
-		uint64_t process_frame;
-		bool pressed;
-		bool exact;
-		float strength;
-		float raw_strength;
+		uint64_t physics_frame = 0;
+		uint64_t process_frame = 0;
+		bool pressed = false;
+		bool exact = false;
+		float strength = 0.0;
+		float raw_strength = 0.0;
 	};
 
 	Map<StringName, Action> action_state;
@@ -130,12 +129,12 @@ private:
 	int mouse_from_touch_index = -1;
 
 	struct SpeedTrack {
-		uint64_t last_tick;
+		uint64_t last_tick = 0;
 		Vector2 speed;
 		Vector2 accum;
-		float accum_t;
-		float min_ref_frame;
-		float max_ref_frame;
+		float accum_t = 0.0;
+		float min_ref_frame = 0.1;
+		float max_ref_frame = 0.3;
 
 		void update(const Vector2 &p_delta_p);
 		void reset();
@@ -147,7 +146,7 @@ private:
 		StringName uid;
 		bool connected = false;
 		bool last_buttons[JOY_BUTTON_MAX] = { false };
-		float last_axis[JOY_AXIS_MAX] = { 0.0f };
+		float last_axis[JOY_AXIS_MAX] = { 0.0 };
 		int last_hat = HAT_MASK_CENTER;
 		int mapping = -1;
 		int hat_current = 0;
@@ -174,15 +173,15 @@ private:
 	};
 
 	struct JoyEvent {
-		int type;
-		int index;
-		float value;
+		JoyType type = TYPE_MAX;
+		int index = 0;
+		float value = 0.0;
 	};
 
 	struct JoyBinding {
-		JoyType inputType;
+		JoyType inputType = TYPE_MAX;
 		union {
-			int button;
+			int button = 0;
 
 			struct {
 				int axis;
@@ -194,18 +193,16 @@ private:
 				int hat;
 				HatMask hat_mask;
 			} hat;
-
 		} input;
 
-		JoyType outputType;
+		JoyType outputType = TYPE_MAX;
 		union {
-			JoyButton button;
+			JoyButton button = JOY_BUTTON_MAX;
 
 			struct {
 				JoyAxis axis;
 				JoyAxisRange range;
 			} axis;
-
 		} output;
 	};
 
@@ -242,10 +239,10 @@ private:
 
 protected:
 	struct VibrationInfo {
-		float weak_magnitude;
-		float strong_magnitude;
-		float duration; // Duration in seconds
-		uint64_t timestamp;
+		float weak_magnitude = 0.0;
+		float strong_magnitude = 0.0;
+		float duration = 0.0; // Duration in seconds
+		uint64_t timestamp = 0;
 	};
 
 	Map<int, VibrationInfo> joy_vibration;

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -175,10 +175,9 @@ class InputEventWithModifiers : public InputEventFromWindow {
 	bool alt = false;
 #ifdef APPLE_STYLE_KEYS
 	union {
-		bool command;
-		bool meta = false; //< windows/mac key
+		bool command = false;
+		bool meta; //< windows/mac key
 	};
-
 	bool control = false;
 #else
 	union {
@@ -269,7 +268,6 @@ class InputEventMouse : public InputEventWithModifiers {
 	GDCLASS(InputEventMouse, InputEventWithModifiers);
 
 	int button_mask = 0;
-
 	Vector2 pos;
 	Vector2 global_pos;
 
@@ -292,7 +290,7 @@ public:
 class InputEventMouseButton : public InputEventMouse {
 	GDCLASS(InputEventMouseButton, InputEventMouse);
 
-	float factor = 1;
+	float factor = 1.0;
 	int button_index = 0;
 	bool pressed = false; //otherwise released
 	bool doubleclick = false; //last even less than doubleclick time
@@ -327,7 +325,7 @@ class InputEventMouseMotion : public InputEventMouse {
 	GDCLASS(InputEventMouseMotion, InputEventMouse);
 
 	Vector2 tilt;
-	float pressure = 0;
+	float pressure = 0.0;
 	Vector2 relative;
 	Vector2 speed;
 
@@ -358,8 +356,9 @@ public:
 
 class InputEventJoypadMotion : public InputEvent {
 	GDCLASS(InputEventJoypadMotion, InputEvent);
+
 	int axis = 0; ///< Joypad axis
-	float axis_value = 0; ///< -1 to 1
+	float axis_value = 0.0; ///< -1 to 1
 
 protected:
 	static void _bind_methods();
@@ -387,7 +386,8 @@ class InputEventJoypadButton : public InputEvent {
 
 	int button_index = 0;
 	bool pressed = false;
-	float pressure = 0; //0 to 1
+	float pressure = 0.0; //0 to 1
+
 protected:
 	static void _bind_methods();
 
@@ -415,6 +415,7 @@ public:
 
 class InputEventScreenTouch : public InputEventFromWindow {
 	GDCLASS(InputEventScreenTouch, InputEventFromWindow);
+
 	int index = 0;
 	Vector2 pos;
 	bool pressed = false;
@@ -441,6 +442,7 @@ public:
 
 class InputEventScreenDrag : public InputEventFromWindow {
 	GDCLASS(InputEventScreenDrag, InputEventFromWindow);
+
 	int index = 0;
 	Vector2 pos;
 	Vector2 relative;
@@ -474,7 +476,7 @@ class InputEventAction : public InputEvent {
 
 	StringName action;
 	bool pressed = false;
-	float strength = 1.0f;
+	float strength = 1.0;
 
 protected:
 	static void _bind_methods();
@@ -516,6 +518,7 @@ public:
 
 class InputEventMagnifyGesture : public InputEventGesture {
 	GDCLASS(InputEventMagnifyGesture, InputEventGesture);
+
 	real_t factor = 1.0;
 
 protected:

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -39,6 +39,8 @@
 class InputMap : public Object {
 	GDCLASS(InputMap, Object);
 
+	static InputMap *singleton;
+
 public:
 	/**
 	* A special value used to signify that a given Action can be triggered by any device
@@ -46,14 +48,12 @@ public:
 	static int ALL_DEVICES;
 
 	struct Action {
-		int id;
-		float deadzone;
+		int id = 0;
+		float deadzone = 0.0;
 		List<Ref<InputEvent>> inputs;
 	};
 
 private:
-	static InputMap *singleton;
-
 	mutable OrderedHashMap<StringName, Action> input_map;
 	OrderedHashMap<String, List<Ref<InputEvent>>> default_builtin_cache;
 

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -46,8 +46,8 @@ class FileAccessCompressed : public FileAccess {
 	mutable bool at_end = false;
 
 	struct ReadBlock {
-		int csize;
-		int offset;
+		int csize = 0;
+		int offset = 0;
 	};
 
 	mutable Vector<uint8_t> comp_buffer;

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -39,10 +39,14 @@
 class FileAccessNetwork;
 
 class FileAccessNetworkClient {
+	friend class FileAccessNetwork;
+
+	static FileAccessNetworkClient *singleton;
+
 	struct BlockRequest {
-		int id;
-		uint64_t offset;
-		int size;
+		int id = 0;
+		uint64_t offset = 0;
+		int size = 0;
 	};
 
 	List<BlockRequest> block_requests;
@@ -69,9 +73,6 @@ class FileAccessNetworkClient {
 	void lock_mutex();
 	void unlock_mutex();
 
-	friend class FileAccessNetwork;
-	static FileAccessNetworkClient *singleton;
-
 public:
 	static FileAccessNetworkClient *get_singleton() { return singleton; }
 
@@ -82,19 +83,21 @@ public:
 };
 
 class FileAccessNetwork : public FileAccess {
+	friend class FileAccessNetworkClient;
+
 	Semaphore sem;
 	Semaphore page_sem;
 	Mutex buffer_mutex;
 	bool opened = false;
-	size_t total_size;
+	size_t total_size = 0;
 	mutable size_t pos = 0;
-	int id;
+	int id = 0;
 	mutable bool eof_flag = false;
 	mutable int last_page = -1;
 	mutable uint8_t *last_page_buff = nullptr;
 
-	int page_size;
-	int read_ahead;
+	int page_size = 0;
+	int read_ahead = 0;
 
 	mutable int waiting_on_page = -1;
 
@@ -106,10 +109,10 @@ class FileAccessNetwork : public FileAccess {
 
 	mutable Vector<Page> pages;
 
-	mutable Error response;
+	mutable Error response = FAILED;
 
-	uint64_t exists_modtime;
-	friend class FileAccessNetworkClient;
+	uint64_t exists_modtime = 0;
+
 	void _queue_page(int p_page) const;
 	void _respond(size_t p_len, Error p_status);
 	void _set_block(int p_offset, const Vector<uint8_t> &p_block);

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -57,14 +57,16 @@ class PackedData {
 	friend class DirAccessPack;
 	friend class PackSource;
 
+	static PackedData *singleton;
+
 public:
 	struct PackedFile {
 		String pack;
-		uint64_t offset; //if offset is ZERO, the file was ERASED
-		uint64_t size;
-		uint8_t md5[16];
-		PackSource *src;
-		bool encrypted;
+		uint64_t offset = 0; //if offset is ZERO, the file was ERASED
+		uint64_t size = 0;
+		uint8_t md5[16]{};
+		PackSource *src = nullptr;
+		bool encrypted = false;
 	};
 
 private:
@@ -99,12 +101,8 @@ private:
 	};
 
 	Map<PathMD5, PackedFile> files;
-
 	Vector<PackSource *> sources;
-
-	PackedDir *root;
-
-	static PackedData *singleton;
+	PackedDir *root = nullptr;
 	bool disabled = false;
 
 	void _free_packed_dirs(PackedDir *p_dir);
@@ -145,11 +143,12 @@ public:
 class FileAccessPack : public FileAccess {
 	PackedData::PackedFile pf;
 
-	mutable size_t pos;
-	mutable bool eof;
-	uint64_t off;
+	mutable size_t pos = 0;
+	mutable bool eof = false;
+	uint64_t off = 0;
 
-	FileAccess *f;
+	FileAccess *f = nullptr;
+
 	virtual Error _open(const String &p_path, int p_mode_flags);
 	virtual uint64_t _get_modified_time(const String &p_file) { return 0; }
 	virtual uint32_t _get_unix_permissions(const String &p_file) { return 0; }
@@ -213,7 +212,7 @@ bool PackedData::has_directory(const String &p_path) {
 }
 
 class DirAccessPack : public DirAccess {
-	PackedData::PackedDir *current;
+	PackedData::PackedDir *current = nullptr;
 
 	List<String> list_dirs;
 	List<String> list_files;

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -44,7 +44,7 @@ class ZipArchive : public PackSource {
 public:
 	struct File {
 		int package = -1;
-		unz_file_pos file_pos;
+		unz_file_pos file_pos{};
 		File() {}
 	};
 
@@ -78,9 +78,9 @@ public:
 
 class FileAccessZip : public FileAccess {
 	unzFile zfile = nullptr;
-	unz_file_info64 file_info;
+	unz_file_info64 file_info{};
 
-	mutable bool at_eof;
+	mutable bool at_eof = false;
 
 public:
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -43,7 +43,7 @@ struct _IP_ResolverPrivate {
 		SafeNumeric<IP::ResolverStatus> status;
 		IP_Address response;
 		String hostname;
-		IP::Type type;
+		IP::Type type = IP::TYPE_NONE;
 
 		void clear() {
 			status.set(IP::RESOLVER_STATUS_NONE);
@@ -72,8 +72,7 @@ struct _IP_ResolverPrivate {
 	Semaphore sem;
 
 	Thread thread;
-	//Semaphore* semaphore;
-	bool thread_abort;
+	bool thread_abort = false;
 
 	void resolve_queues() {
 		for (int i = 0; i < IP::RESOLVER_MAX_QUERIES; i++) {

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -67,6 +67,7 @@ private:
 
 protected:
 	static IP *singleton;
+
 	static void _bind_methods();
 
 	virtual IP_Address _resolve_hostname(const String &p_hostname, Type p_type = TYPE_ANY) = 0;

--- a/core/io/ip_address.h
+++ b/core/io/ip_address.h
@@ -36,20 +36,19 @@
 struct IP_Address {
 private:
 	union {
-		uint8_t field8[16];
+		uint8_t field8[16]{};
 		uint16_t field16[8];
 		uint32_t field32[4];
 	};
 
-	bool valid;
-	bool wildcard;
+	bool valid = false;
+	bool wildcard = false;
 
 protected:
 	void _parse_ipv6(const String &p_string);
 	void _parse_ipv4(const String &p_string, int p_start, uint8_t *p_ret);
 
 public:
-	//operator Variant() const;
 	bool operator==(const IP_Address &p_ip) const {
 		if (p_ip.valid != valid) {
 			return false;
@@ -91,6 +90,7 @@ public:
 	void set_ipv6(const uint8_t *p_buf);
 
 	operator String() const;
+
 	IP_Address(const String &p_string);
 	IP_Address(uint32_t p_a, uint32_t p_b, uint32_t p_c, uint32_t p_d, bool is_v6 = false);
 	IP_Address() { clear(); }

--- a/core/io/marshalls.h
+++ b/core/io/marshalls.h
@@ -42,12 +42,12 @@
 
 union MarshallFloat {
 	uint32_t i; ///< int
-	float f; ///< float
+	float f = 0.0; ///< float
 };
 
 union MarshallDouble {
 	uint64_t l; ///< long long
-	double d; ///< double
+	double d = 0.0; ///< double
 };
 
 static inline unsigned int encode_uint16(uint16_t p_uint, uint8_t *p_arr) {

--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -41,7 +41,7 @@ private:
 	//path sent caches
 	struct PathSentCache {
 		Map<int, bool> confirmed_peers;
-		int id;
+		int id = 0;
 	};
 
 	//path get caches
@@ -59,7 +59,7 @@ private:
 	Set<int> connected_peers;
 	HashMap<NodePath, PathSentCache> path_send_cache;
 	Map<int, PathGetCache> path_get_cache;
-	int last_send_cache_id;
+	int last_send_cache_id = 0;
 	Vector<uint8_t> packet_cache;
 	Node *root_node = nullptr;
 	bool allow_object_decoding = false;

--- a/core/io/packed_data_container.h
+++ b/core/io/packed_data_container.h
@@ -36,13 +36,15 @@
 class PackedDataContainer : public Resource {
 	GDCLASS(PackedDataContainer, Resource);
 
+	friend class PackedDataContainerRef;
+
 	enum {
 		TYPE_DICT = 0xFFFFFFFF,
 		TYPE_ARRAY = 0xFFFFFFFE,
 	};
 
 	struct DictKey {
-		uint32_t hash;
+		uint32_t hash = 0;
 		Variant key;
 		bool operator<(const DictKey &p_key) const { return hash < p_key.hash; }
 	};
@@ -60,7 +62,6 @@ class PackedDataContainer : public Resource {
 	Variant _iter_next(const Array &p_iter);
 	Variant _iter_get(const Variant &p_iter);
 
-	friend class PackedDataContainerRef;
 	Variant _key_at_ofs(uint32_t p_ofs, const Variant &p_key, bool &err) const;
 	Variant _get_at_ofs(uint32_t p_ofs, const uint8_t *p_buf, bool &err) const;
 	uint32_t _type_at_ofs(uint32_t p_ofs) const;
@@ -84,6 +85,7 @@ class PackedDataContainerRef : public Reference {
 	GDCLASS(PackedDataContainerRef, Reference);
 
 	friend class PackedDataContainer;
+
 	uint32_t offset = 0;
 	Ref<PackedDataContainer> from;
 

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -46,8 +46,8 @@ protected:
 	};
 
 	RingBuffer<uint8_t> rb;
-	uint8_t recv_buffer[PACKET_BUFFER_SIZE];
-	uint8_t packet_buffer[PACKET_BUFFER_SIZE];
+	uint8_t recv_buffer[PACKET_BUFFER_SIZE]; // NOLINT - No init for performance.
+	uint8_t packet_buffer[PACKET_BUFFER_SIZE]; // NOLINT - No init for performance.
 	IP_Address packet_ip;
 	int packet_port = 0;
 	int queue_count = 0;

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -36,6 +36,8 @@
 #include "core/os/file_access.h"
 
 class ResourceLoaderBinary {
+	friend class ResourceFormatLoaderBinary;
+
 	bool translation_remapped = false;
 	String local_path;
 	String res_path;
@@ -52,8 +54,6 @@ class ResourceLoaderBinary {
 
 	Vector<StringName> string_map;
 
-	StringName _get_string();
-
 	struct ExtResource {
 		String path;
 		String type;
@@ -66,25 +66,23 @@ class ResourceLoaderBinary {
 
 	struct IntResource {
 		String path;
-		uint64_t offset;
+		uint64_t offset = 0;
 	};
 
 	Vector<IntResource> internal_resources;
 	Map<String, RES> internal_index_cache;
-
-	String get_unicode_string();
-	void _advance_padding(uint32_t p_len);
 
 	Map<String, String> remaps;
 	Error error = OK;
 
 	ResourceFormatLoader::CacheMode cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE;
 
-	friend class ResourceFormatLoaderBinary;
-
-	Error parse_variant(Variant &r_v);
-
 	Map<String, RES> dependency_cache;
+
+	StringName _get_string();
+	String get_unicode_string();
+	void _advance_padding(uint32_t p_len);
+	Error parse_variant(Variant &r_v);
 
 public:
 	void set_local_path(const String &p_local_path);
@@ -116,12 +114,12 @@ class ResourceFormatSaverBinaryInstance {
 	String local_path;
 	String path;
 
-	bool relative_paths;
-	bool bundle_resources;
-	bool skip_editor;
-	bool big_endian;
-	bool takeover_paths;
-	FileAccess *f;
+	bool relative_paths = false;
+	bool bundle_resources = false;
+	bool skip_editor = false;
+	bool big_endian = false;
+	bool takeover_paths = false;
+	FileAccess *f = nullptr;
 	String magic;
 	Set<RES> resource_set;
 
@@ -139,7 +137,7 @@ class ResourceFormatSaverBinaryInstance {
 	List<RES> saved_resources;
 
 	struct Property {
-		int name_idx;
+		int name_idx = 0;
 		Variant value;
 		PropertyInfo pi;
 	};

--- a/core/io/udp_server.h
+++ b/core/io/udp_server.h
@@ -43,7 +43,7 @@ protected:
 	};
 
 	struct Peer {
-		PacketPeerUDP *peer;
+		PacketPeerUDP *peer = nullptr;
 		IP_Address ip;
 		uint16_t port = 0;
 
@@ -51,7 +51,7 @@ protected:
 			return (ip == p_other.ip && port == p_other.port);
 		}
 	};
-	uint8_t recv_buffer[PACKET_BUFFER_SIZE];
+	uint8_t recv_buffer[PACKET_BUFFER_SIZE]; // NOLINT - No init for performance.
 
 	int bind_port = 0;
 	IP_Address bind_address;

--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -335,7 +335,7 @@ bool AStar::_solve(Point *begin_point, Point *end_point) {
 	bool found_route = false;
 
 	Vector<Point *> open_list;
-	SortArray<Point *, SortPoints> sorter;
+	SortArray<Point *, SortPoints> sorter{};
 
 	begin_point->g_score = 0;
 	begin_point->f_score = _estimate_cost(begin_point->id, end_point->id);
@@ -799,7 +799,7 @@ bool AStar2D::_solve(AStar::Point *begin_point, AStar::Point *end_point) {
 	bool found_route = false;
 
 	Vector<AStar::Point *> open_list;
-	SortArray<AStar::Point *, AStar::SortPoints> sorter;
+	SortArray<AStar::Point *, AStar::SortPoints> sorter{};
 
 	begin_point->g_score = 0;
 	begin_point->f_score = _estimate_cost(begin_point->id, end_point->id);

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -42,14 +42,13 @@
 
 class AStar : public Reference {
 	GDCLASS(AStar, Reference);
+
 	friend class AStar2D;
 
 	struct Point {
-		Point() {}
-
 		int id = 0;
 		Vector3 pos;
-		real_t weight_scale = 0;
+		real_t weight_scale = 0.0;
 		bool enabled = false;
 
 		OAHashMap<int, Point *> neighbours = 4u;
@@ -57,10 +56,12 @@ class AStar : public Reference {
 
 		// Used for pathfinding.
 		Point *prev_point = nullptr;
-		real_t g_score = 0;
-		real_t f_score = 0;
+		real_t g_score = 0.0;
+		real_t f_score = 0.0;
 		uint64_t open_pass = 0;
 		uint64_t closed_pass = 0;
+
+		Point() {}
 	};
 
 	struct SortPoints {
@@ -159,6 +160,7 @@ public:
 
 class AStar2D : public Reference {
 	GDCLASS(AStar2D, Reference);
+
 	AStar astar;
 
 	bool _solve(AStar::Point *begin_point, AStar::Point *end_point);

--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -38,7 +38,7 @@ static inline float undenormalise(volatile float f) {
 	union {
 		uint32_t i;
 		float f;
-	} v;
+	} v{};
 
 	v.f = f;
 
@@ -52,7 +52,8 @@ static const float AUDIO_MIN_PEAK_DB = -200.0f; // linear2db(AUDIO_PEAK_OFFSET)
 
 struct AudioFrame {
 	//left and right samples
-	float l, r;
+	float l = 0.0;
+	float r = 0.0;
 
 	_ALWAYS_INLINE_ const float &operator[](int idx) const { return idx == 0 ? l : r; }
 	_ALWAYS_INLINE_ float &operator[](int idx) { return idx == 0 ? l : r; }

--- a/core/math/camera_matrix.h
+++ b/core/math/camera_matrix.h
@@ -44,7 +44,7 @@ struct CameraMatrix {
 		PLANE_BOTTOM
 	};
 
-	real_t matrix[4][4];
+	real_t matrix[4][4]{};
 
 	float determinant() const;
 	void set_identity();

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -42,7 +42,7 @@ struct Color {
 			float b;
 			float a;
 		};
-		float components[4] = { 0, 0, 0, 1.0 };
+		float components[4] = { 0.0, 0.0, 0.0, 1.0 };
 	};
 
 	uint32_t to_rgba32() const;

--- a/core/math/color_names.inc
+++ b/core/math/color_names.inc
@@ -5,7 +5,7 @@
 // this is not used as often as for more performance to make sense
 
 struct NamedColor {
-	const char *name;
+	const char *name = nullptr;
 	Color color;
 };
 

--- a/core/math/delaunay_2d.h
+++ b/core/math/delaunay_2d.h
@@ -36,7 +36,7 @@
 class Delaunay2D {
 public:
 	struct Triangle {
-		int points[3];
+		int points[3]{};
 		bool bad = false;
 		Triangle() {}
 		Triangle(int p_a, int p_b, int p_c) {
@@ -47,7 +47,7 @@ public:
 	};
 
 	struct Edge {
-		int edge[2];
+		int edge[2]{};
 		bool bad = false;
 		Edge() {}
 		Edge(int p_a, int p_b) {

--- a/core/math/disjoint_set.h
+++ b/core/math/disjoint_set.h
@@ -42,7 +42,7 @@
 template <typename T, class C = Comparator<T>, class AL = DefaultAllocator>
 class DisjointSet {
 	struct Element {
-		T object;
+		T object = 0;
 		Element *parent = nullptr;
 		int rank = 0;
 	};

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -182,7 +182,7 @@ private:
 		Volume volume;
 		Node *parent = nullptr;
 		union {
-			Node *childs[2];
+			Node *childs[2]{};
 			void *data;
 		};
 
@@ -193,6 +193,7 @@ private:
 			ERR_FAIL_COND_V(!parent, 0);
 			return (parent->childs[1] == this) ? 1 : 0;
 		}
+
 		void get_max_depth(int depth, int &maxdepth) {
 			if (is_internal()) {
 				childs[0]->get_max_depth(depth + 1, maxdepth);
@@ -202,7 +203,6 @@ private:
 			}
 		}
 
-		//
 		int count_leaves() const {
 			if (is_internal()) {
 				return childs[0]->count_leaves() + childs[1]->count_leaves();
@@ -215,10 +215,7 @@ private:
 			return axis.dot(volume.get_center() - org) <= 0;
 		}
 
-		Node() {
-			childs[0] = nullptr;
-			childs[1] = nullptr;
-		}
+		Node() {}
 	};
 
 	PagedAllocator<Node> node_allocator;
@@ -416,6 +413,7 @@ void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Ve
 		}
 	} while (depth > 0);
 }
+
 template <class QueryResult>
 void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResult &r_result) {
 	if (!bvh_root) {

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -74,14 +74,14 @@ Vector<Vector<Vector2>> Geometry2D::decompose_polygon_in_convex(Vector<Point2> p
 struct _AtlasWorkRect {
 	Size2i s;
 	Point2i p;
-	int idx;
+	int idx = 0;
 	_FORCE_INLINE_ bool operator<(const _AtlasWorkRect &p_r) const { return s.width > p_r.s.width; };
 };
 
 struct _AtlasWorkRectResult {
 	Vector<_AtlasWorkRect> result;
-	int max_w;
-	int max_h;
+	int max_w = 0;
+	int max_h = 0;
 };
 
 void Geometry2D::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_result, Size2i &r_size) {

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -635,7 +635,8 @@ public:
 		Vector<Face> faces;
 
 		struct Edge {
-			int a, b;
+			int a = 0;
+			int b = 0;
 		};
 
 		Vector<Edge> edges;

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -113,7 +113,7 @@ public:
 		union {
 			uint64_t u;
 			double f;
-		} ieee754;
+		} ieee754{};
 		ieee754.f = p_val;
 		// (unsigned)(0x7ff0000000000001 >> 32) : 0x7ff00000
 		return ((((unsigned)(ieee754.u >> 32) & 0x7fffffff) + ((unsigned)ieee754.u != 0)) > 0x7ff00000);
@@ -129,7 +129,7 @@ public:
 		union {
 			uint32_t u;
 			float f;
-		} ieee754;
+		} ieee754{};
 		ieee754.f = p_val;
 		// -----------------------------------
 		// (single-precision floating-point)
@@ -153,7 +153,7 @@ public:
 		union {
 			uint64_t u;
 			double f;
-		} ieee754;
+		} ieee754{};
 		ieee754.f = p_val;
 		return ((unsigned)(ieee754.u >> 32) & 0x7fffffff) == 0x7ff00000 &&
 			   ((unsigned)ieee754.u == 0);
@@ -170,7 +170,7 @@ public:
 		union {
 			uint32_t u;
 			float f;
-		} ieee754;
+		} ieee754{};
 		ieee754.f = p_val;
 		return (ieee754.u & 0x7fffffff) == 0x7f800000;
 #else
@@ -338,7 +338,7 @@ public:
 		union {
 			float f;
 			uint32_t i;
-		} u;
+		} u{};
 
 		u.f = g;
 		u.i &= 2147483647u;
@@ -349,7 +349,7 @@ public:
 		union {
 			double d;
 			uint64_t i;
-		} u;
+		} u{};
 		u.d = g;
 		u.i &= (uint64_t)9223372036854775807ll;
 		return u.d;
@@ -414,7 +414,7 @@ public:
 		union {
 			uint32_t u32;
 			float f32;
-		} u;
+		} u{};
 
 		u.u32 = halfbits_to_floatbits(*h);
 		return u.f32;
@@ -428,7 +428,7 @@ public:
 		union {
 			float fv;
 			uint32_t ui;
-		} ci;
+		} ci{};
 		ci.fv = f;
 
 		uint32_t x = ci.ui;

--- a/core/math/octree.h
+++ b/core/math/octree.h
@@ -73,7 +73,7 @@ private:
 				OctreeElementID A;
 				OctreeElementID B;
 			};
-			uint64_t key;
+			uint64_t key = 0;
 		};
 
 		_FORCE_INLINE_ bool operator<(const PairKey &p_pair) const {
@@ -134,8 +134,8 @@ private:
 		List<PairData *, AL> pair_list;
 
 		struct OctantOwner {
-			Octant *octant;
-			typename List<Element *, AL>::Element *E;
+			Octant *octant = nullptr;
+			typename List<Element *, AL>::Element *E = nullptr;
 		}; // an element can be in max 8 octants
 
 		List<OctantOwner, AL> octant_owners;
@@ -144,11 +144,13 @@ private:
 	};
 
 	struct PairData {
-		int refcount;
-		bool intersect;
-		Element *A, *B;
-		void *ud;
-		typename List<PairData *, AL>::Element *eA, *eB;
+		int refcount = 0;
+		bool intersect = false;
+		Element *A = nullptr;
+		Element *B = nullptr;
+		void *ud = nullptr;
+		typename List<PairData *, AL>::Element *eA = nullptr;
+		typename List<PairData *, AL>::Element *eB = nullptr;
 	};
 
 	typedef Map<OctreeElementID, Element, Comparator<OctreeElementID>, AL> ElementMap;
@@ -161,13 +163,13 @@ private:
 	void *pair_callback_userdata;
 	void *unpair_callback_userdata;
 
-	OctreeElementID last_element_id;
-	uint64_t pass;
+	OctreeElementID last_element_id = 0;
+	uint64_t pass = 0;
 
-	real_t unit_size;
-	Octant *root;
-	int octant_count;
-	int pair_count;
+	real_t unit_size = 0.0;
+	Octant *root = nullptr;
+	int octant_count = 0;
+	int pair_count = 0;
 
 	_FORCE_INLINE_ void _pair_check(PairData *p_pair) {
 		bool intersect = p_pair->A->aabb.intersects_inclusive(p_pair->B->aabb);
@@ -294,14 +296,14 @@ private:
 	void _unpair_element(Element *p_element, Octant *p_octant);
 
 	struct _CullConvexData {
-		const Plane *planes;
-		int plane_count;
-		const Vector3 *points;
-		int point_count;
-		T **result_array;
-		int *result_idx;
-		int result_max;
-		uint32_t mask;
+		const Plane *planes = nullptr;
+		int plane_count = 0;
+		const Vector3 *points = nullptr;
+		int point_count = 0;
+		T **result_array = nullptr;
+		int *result_idx = nullptr;
+		int result_max = 0;
+		uint32_t mask = 0;
 	};
 
 	void _cull_convex(Octant *p_octant, _CullConvexData *p_cull);

--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -61,8 +61,8 @@ static int __bsr_clz32(uint32_t x) {
 
 class RandomPCG {
 	pcg32_random_t pcg;
-	uint64_t current_seed; // The seed the current generator state started from.
-	uint64_t current_inc;
+	uint64_t current_seed = 0; // The seed the current generator state started from.
+	uint64_t current_inc = 0;
 
 public:
 	static const uint64_t DEFAULT_SEED = 12047754176567800795U;

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -53,17 +53,17 @@ int TriangleMesh::_create_bvh(BVH *p_bvh, BVH **p_bb, int p_from, int p_size, in
 
 	switch (li) {
 		case Vector3::AXIS_X: {
-			SortArray<BVH *, BVHCmpX> sort_x;
+			SortArray<BVH *, BVHCmpX> sort_x{};
 			sort_x.nth_element(0, p_size, p_size / 2, &p_bb[p_from]);
 			//sort_x.sort(&p_bb[p_from],p_size);
 		} break;
 		case Vector3::AXIS_Y: {
-			SortArray<BVH *, BVHCmpY> sort_y;
+			SortArray<BVH *, BVHCmpY> sort_y{};
 			sort_y.nth_element(0, p_size, p_size / 2, &p_bb[p_from]);
 			//sort_y.sort(&p_bb[p_from],p_size);
 		} break;
 		case Vector3::AXIS_Z: {
-			SortArray<BVH *, BVHCmpZ> sort_z;
+			SortArray<BVH *, BVHCmpZ> sort_z{};
 			sort_z.nth_element(0, p_size, p_size / 2, &p_bb[p_from]);
 			//sort_z.sort(&p_bb[p_from],p_size);
 

--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -39,7 +39,7 @@ class TriangleMesh : public Reference {
 
 	struct Triangle {
 		Vector3 normal;
-		int indices[3];
+		int indices[3]{};
 	};
 
 	Vector<Triangle> triangles;
@@ -48,11 +48,15 @@ class TriangleMesh : public Reference {
 	struct BVH {
 		AABB aabb;
 		Vector3 center; //used for sorting
-		int left;
-		int right;
+		int left = 0;
+		int right = 0;
 
-		int face_index;
+		int face_index = 0;
 	};
+
+	Vector<BVH> bvh;
+	int max_depth = 0;
+	bool valid = false;
 
 	struct BVHCmpX {
 		bool operator()(const BVH *p_left, const BVH *p_right) const {
@@ -72,10 +76,6 @@ class TriangleMesh : public Reference {
 	};
 
 	int _create_bvh(BVH *p_bvh, BVH **p_bb, int p_from, int p_size, int p_depth, int &max_depth, int &max_alloc);
-
-	Vector<BVH> bvh;
-	int max_depth;
-	bool valid;
 
 public:
 	bool is_valid() const;

--- a/core/object/callable_method_pointer.h
+++ b/core/object/callable_method_pointer.h
@@ -39,9 +39,9 @@
 #include "core/variant/callable.h"
 
 class CallableCustomMethodPointerBase : public CallableCustom {
-	uint32_t *comp_ptr;
-	uint32_t comp_size;
-	uint32_t h;
+	uint32_t *comp_ptr = nullptr;
+	uint32_t comp_size = 0;
+	uint32_t h = 0;
 #ifdef DEBUG_METHODS_ENABLED
 	const char *text = "";
 #endif

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -102,12 +102,12 @@ public:
 
 public:
 	struct PropertySetGet {
-		int index;
+		int index = 0;
 		StringName setter;
 		StringName getter;
-		MethodBind *_setptr;
-		MethodBind *_getptr;
-		Variant::Type type;
+		MethodBind *_setptr = nullptr;
+		MethodBind *_getptr = nullptr;
+		Variant::Type type = Variant::NIL;
 	};
 
 	struct ClassInfo {

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -37,6 +37,8 @@
 class MessageQueue {
 	_THREAD_SAFE_CLASS_
 
+	static MessageQueue *singleton;
+
 	enum {
 		DEFAULT_QUEUE_SIZE_KB = 4096
 	};
@@ -52,23 +54,21 @@ class MessageQueue {
 
 	struct Message {
 		Callable callable;
-		int16_t type;
+		int16_t type = 0;
 		union {
-			int16_t notification;
+			int16_t notification = 0;
 			int16_t args;
 		};
 	};
 
-	uint8_t *buffer;
+	uint8_t *buffer = nullptr;
 	uint32_t buffer_end = 0;
 	uint32_t buffer_max_used = 0;
-	uint32_t buffer_size;
-
-	void _call_function(const Callable &p_callable, const Variant *p_args, int p_argcount, bool p_show_error);
-
-	static MessageQueue *singleton;
+	uint32_t buffer_size = 0;
 
 	bool flushing = false;
+
+	void _call_function(const Callable &p_callable, const Variant *p_args, int p_argcount, bool p_show_error);
 
 public:
 	static MessageQueue *get_singleton();

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -198,7 +198,7 @@ Array convert_property_list(const List<PropertyInfo> *p_list);
 struct MethodInfo {
 	String name;
 	PropertyInfo return_val;
-	uint32_t flags; // NOLINT - prevent clang-tidy to assign method_bind.h constant here, it should stay in .cpp.
+	uint32_t flags = 0;
 	int id = 0;
 	List<PropertyInfo> arguments;
 	Vector<Variant> default_arguments;
@@ -231,12 +231,6 @@ struct MethodInfo {
 	MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4);
 	MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4, const PropertyInfo &p_param5);
 };
-
-// old cast_to
-//if ( is_type(T::get_class_static()) )
-//return static_cast<T*>(this);
-////else
-//return nullptr;
 
 /*
    the following is an incomprehensible blob of hacks and workarounds to compensate for many of the fallencies in C++. As a plus, this macro pretty much alone defines the object model.
@@ -490,7 +484,7 @@ private:
 	friend class Reference;
 	bool type_is_reference = false;
 	SafeNumeric<uint32_t> instance_binding_count;
-	void *_script_instance_bindings[MAX_SCRIPT_INSTANCE_BINDINGS];
+	void *_script_instance_bindings[MAX_SCRIPT_INSTANCE_BINDINGS]{};
 
 	Object(bool p_reference);
 
@@ -744,7 +738,7 @@ class ObjectDB {
 		uint64_t validator : OBJECTDB_VALIDATOR_BITS;
 		uint64_t next_free : OBJECTDB_SLOT_MAX_COUNT_BITS;
 		uint64_t is_reference : 1;
-		Object *object;
+		Object *object = nullptr;
 	};
 
 	static SpinLock spin_lock;

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
+ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES]{};
 int ScriptServer::_language_count = 0;
 
 bool ScriptServer::scripting_enabled = true;

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -294,9 +294,11 @@ public:
 
 	/* EDITOR FUNCTIONS */
 	struct Warning {
-		int start_line = -1, end_line = -1;
-		int leftmost_column = -1, rightmost_column = -1;
-		int code;
+		int start_line = -1;
+		int end_line = -1;
+		int leftmost_column = -1;
+		int rightmost_column = -1;
+		int code = 0;
 		String string_code;
 		String message;
 	};
@@ -332,11 +334,11 @@ public:
 			RESULT_CLASS_ENUM,
 			RESULT_CLASS_TBD_GLOBALSCOPE
 		};
-		Type type;
+		Type type = RESULT_SCRIPT_LOCATION;
 		Ref<Script> script;
 		String class_name;
 		String class_member;
-		int location;
+		int location = 0;
 	};
 
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) { return ERR_UNAVAILABLE; }
@@ -356,7 +358,7 @@ public:
 	struct StackInfo {
 		String file;
 		String func;
-		int line;
+		int line = 0;
 	};
 
 	virtual String debug_get_error() const = 0;
@@ -382,9 +384,9 @@ public:
 
 	struct ProfilingInfo {
 		StringName signature;
-		uint64_t call_count;
-		uint64_t total_time;
-		uint64_t self_time;
+		uint64_t call_count = 0;
+		uint64_t total_time = 0;
+		uint64_t self_time = 0;
 	};
 
 	virtual void profiling_start() = 0;
@@ -409,11 +411,11 @@ public:
 extern uint8_t script_encryption_key[32];
 
 class PlaceHolderScriptInstance : public ScriptInstance {
-	Object *owner;
+	Object *owner = nullptr;
 	List<PropertyInfo> properties;
 	Map<StringName, Variant> values;
 	Map<StringName, Variant> constants;
-	ScriptLanguage *language;
+	ScriptLanguage *language = nullptr;
 	Ref<Script> script;
 
 public:

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -60,7 +60,7 @@ private:
 			TYPE_REFERENCE
 		};
 
-		Type type;
+		Type type = TYPE_METHOD;
 		Ref<Reference> ref;
 		ObjectID object;
 		StringName name;
@@ -71,7 +71,7 @@ private:
 		String name;
 		List<Operation> do_ops;
 		List<Operation> undo_ops;
-		uint64_t last_tick;
+		uint64_t last_tick = 0;
 	};
 
 	Vector<Action> actions;
@@ -80,6 +80,7 @@ private:
 	MergeMode merge_mode = MERGE_DISABLE;
 	bool merging = false;
 	uint64_t version = 1;
+	int committing = 0;
 
 	void _pop_history_tail();
 	void _process_operation_list(List<Operation>::Element *E);
@@ -93,8 +94,6 @@ private:
 
 	MethodNotifyCallback method_callback = nullptr;
 	PropertyNotifyCallback property_callback = nullptr;
-
-	int committing = 0;
 
 protected:
 	static void _bind_methods();

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -45,6 +45,7 @@
 class OS {
 	static OS *singleton;
 	static uint64_t target_ticks;
+
 	String _execpath;
 	List<String> _cmdline;
 	bool _keep_screen_on = true; // set default value to true, because this had been true before godot 2.0.
@@ -55,15 +56,15 @@ class OS {
 	String _local_clipboard;
 	bool _no_window = false;
 	int _exit_code = EXIT_FAILURE; // unexpected exit is marked as failure
-	int _orientation;
+	int _orientation = 0;
 	bool _allow_hidpi = false;
 	bool _allow_layered = false;
-	bool _use_vsync;
-	bool _vsync_via_compositor;
+	bool _use_vsync = false;
+	bool _vsync_via_compositor = false;
 	bool _stdout_enabled = true;
 	bool _stderr_enabled = true;
 
-	char *last_error;
+	char *last_error = nullptr;
 
 	CompositeLogger *_logger = nullptr;
 
@@ -186,21 +187,21 @@ public:
 	};
 
 	struct Date {
-		int year;
-		Month month;
-		int day;
-		Weekday weekday;
-		bool dst;
+		int year = 0;
+		Month month = MONTH_JANUARY;
+		int day = 0;
+		Weekday weekday = DAY_SUNDAY;
+		bool dst = false;
 	};
 
 	struct Time {
-		int hour;
-		int min;
-		int sec;
+		int hour = 0;
+		int min = 0;
+		int sec = 0;
 	};
 
 	struct TimeZoneInfo {
-		int bias;
+		int bias = 0;
 		String name;
 	};
 
@@ -296,6 +297,7 @@ public:
 	virtual Vector<String> get_granted_permissions() const { return Vector<String>(); }
 
 	virtual void process_and_drop_events() {}
+
 	OS();
 	virtual ~OS();
 };

--- a/core/os/pool_allocator.h
+++ b/core/os/pool_allocator.h
@@ -76,26 +76,27 @@ private:
 	typedef int EntryArrayPos;
 	typedef int EntryIndicesPos;
 
-	Entry *entry_array;
-	int *entry_indices;
-	int entry_max;
-	int entry_count;
+	Entry *entry_array = nullptr;
+	int *entry_indices = nullptr;
+	int entry_max = 0;
+	int entry_count = 0;
 
-	uint8_t *pool;
-	void *mem_ptr;
-	int pool_size;
+	uint8_t *pool = nullptr;
+	void *mem_ptr = nullptr;
+	int pool_size = 0;
 
-	int free_mem;
-	int free_mem_peak;
+	int free_mem = 0;
+	int free_mem_peak = 0;
 
-	unsigned int check_count;
-	int align;
+	unsigned int check_count = 0;
+	int align = 0;
 
-	bool needs_locking;
+	bool needs_locking = false;
 
 	inline int entry_end(const Entry &p_entry) const {
 		return p_entry.pos + aligned(p_entry.len);
 	}
+
 	inline int aligned(int p_size) const {
 		int rem = p_size % align;
 		if (rem) {

--- a/core/os/threaded_array_processor.h
+++ b/core/os/threaded_array_processor.h
@@ -39,11 +39,11 @@
 
 template <class C, class U>
 struct ThreadArrayProcessData {
-	uint32_t elements;
+	uint32_t elements = 0;
 	SafeNumeric<uint32_t> index;
-	C *instance;
-	U userdata;
-	void (C::*method)(uint32_t, U);
+	C *instance = nullptr;
+	U userdata = nullptr;
+	void (C::*method)(uint32_t, U){};
 
 	void process(uint32_t p_index) {
 		(instance->*method)(p_index, userdata);

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -40,15 +40,15 @@ class NodePath {
 		Vector<StringName> path;
 		Vector<StringName> subpath;
 		StringName concatenated_subpath;
-		bool absolute;
-		bool has_slashes;
-		mutable bool hash_cache_valid;
-		mutable uint32_t hash_cache;
+		bool absolute = false;
+		bool has_slashes = false;
+		mutable bool hash_cache_valid = false;
+		mutable uint32_t hash_cache = 0;
 	};
 
 	mutable Data *data = nullptr;
-	void unref();
 
+	void unref();
 	void _update_hash_cache() const;
 
 public:

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -37,9 +37,9 @@ extern "C" {
 }
 
 struct CompressedString {
-	int orig_len;
+	int orig_len = 0;
 	CharString compressed;
-	int offset;
+	int offset = 0;
 };
 
 void OptimizedTranslation::generate(const Ref<Translation> &p_from) {

--- a/core/string/string_buffer.h
+++ b/core/string/string_buffer.h
@@ -35,7 +35,7 @@
 
 template <int SHORT_BUFFER_SIZE = 64>
 class StringBuffer {
-	char32_t short_buffer[SHORT_BUFFER_SIZE];
+	char32_t short_buffer[SHORT_BUFFER_SIZE]; // NOLINT - No init for performance.
 	String buffer;
 	int string_length = 0;
 

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -38,7 +38,7 @@
 class Main;
 
 struct StaticCString {
-	const char *ptr;
+	const char *ptr = nullptr;
 	static StaticCString create(const char *p_ptr);
 };
 
@@ -53,7 +53,6 @@ class StringName {
 		SafeRefCount refcount;
 		const char *cname = nullptr;
 		String name;
-
 		String get_name() const { return cname ? String(cname) : name; }
 		int idx = 0;
 		uint32_t hash = 0;
@@ -67,7 +66,7 @@ class StringName {
 	_Data *_data = nullptr;
 
 	union _HashUnion {
-		_Data *ptr;
+		_Data *ptr = nullptr;
 		uint32_t hash;
 	};
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -170,8 +170,8 @@ protected:
 /*************************************************************************/
 
 struct StrRange {
-	const char32_t *c_str;
-	int len;
+	const char32_t *c_str = nullptr;
+	int len = 0;
 
 	StrRange(const char32_t *p_c_str = nullptr, int p_len = 0) {
 		c_str = p_c_str;

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -309,7 +309,7 @@ class CommandQueueMT {
 	};
 
 	struct SyncCommand : public CommandBase {
-		SyncSemaphore *sync_sem;
+		SyncSemaphore *sync_sem = nullptr;
 
 		virtual void post() {
 			sync_sem->sem.post();

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -89,7 +89,7 @@ static inline uint32_t hash_djb2_one_float(double p_in, uint32_t p_prev = 5381) 
 	union {
 		double d;
 		uint64_t i;
-	} u;
+	} u{};
 
 	// Normalize +/- 0.0 and NaN values so they hash the same.
 	if (p_in == 0.0f) {
@@ -118,7 +118,7 @@ static inline uint64_t hash_djb2_one_float_64(double p_in, uint64_t p_prev = 538
 	union {
 		double d;
 		uint64_t i;
-	} u;
+	} u{};
 
 	// Normalize +/- 0.0 and NaN values so they hash the same.
 	if (p_in == 0.0f) {
@@ -141,7 +141,7 @@ static inline uint64_t make_uint64_t(T p_in) {
 	union {
 		T t;
 		uint64_t _u64;
-	} _u;
+	} _u{};
 	_u._u64 = 0; // in case p_in is smaller
 
 	_u.t = p_in;

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -640,7 +640,7 @@ public:
 			idx++;
 		}
 
-		SortArray<Element *, AuxiliaryComparator<C>> sort;
+		SortArray<Element *, AuxiliaryComparator<C>> sort{};
 		sort.sort(aux_buffer, s);
 
 		_data->first = aux_buffer[0];

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -194,7 +194,7 @@ public:
 			return;
 		}
 
-		SortArray<T, C> sorter;
+		SortArray<T, C> sorter{};
 		sorter.sort(data, len);
 	}
 

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -304,21 +304,17 @@ public:
 	}
 
 	struct Iterator {
-		bool valid;
-
-		const TKey *key;
-		TValue *value;
-
-	private:
-		uint32_t pos;
 		friend class OAHashMap;
+
+		bool valid = false;
+		const TKey *key = nullptr;
+		TValue *value = nullptr;
+		uint32_t pos = 0;
 	};
 
 	Iterator iter() const {
 		Iterator it;
-
 		it.valid = true;
-		it.pos = 0;
 
 		return next_iter(it);
 	}
@@ -329,10 +325,7 @@ public:
 		}
 
 		Iterator it;
-		it.valid = false;
 		it.pos = p_iter.pos;
-		it.key = nullptr;
-		it.value = nullptr;
 
 		for (uint32_t i = it.pos; i < capacity; i++) {
 			it.pos = i + 1;

--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -38,7 +38,7 @@ class RingBuffer {
 	Vector<T> data;
 	int read_pos = 0;
 	int write_pos = 0;
-	int size_mask;
+	int size_mask = 0;
 
 	inline int inc(int &p_var, int p_size) const {
 		int ret = p_var;

--- a/core/templates/thread_work_pool.h
+++ b/core/templates/thread_work_pool.h
@@ -38,7 +38,7 @@
 #include <atomic>
 
 class ThreadWorkPool {
-	std::atomic<uint32_t> index;
+	std::atomic<uint32_t> index{};
 
 	struct BaseWork {
 		std::atomic<uint32_t> *index = nullptr;
@@ -49,9 +49,9 @@ class ThreadWorkPool {
 
 	template <class C, class M, class U>
 	struct Work : public BaseWork {
-		C *instance;
-		M method;
-		U userdata;
+		C *instance = nullptr;
+		M method{};
+		U userdata = nullptr;
 		virtual void work() {
 			while (true) {
 				uint32_t work_index = index->fetch_add(1, std::memory_order_relaxed);
@@ -67,8 +67,8 @@ class ThreadWorkPool {
 		Thread thread;
 		Semaphore start;
 		Semaphore completed;
-		std::atomic<bool> exit;
-		BaseWork *work;
+		std::atomic<bool> exit{};
+		BaseWork *work = nullptr;
 	};
 
 	ThreadData *threads = nullptr;

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -104,7 +104,7 @@ public:
 		}
 
 		T *data = ptrw();
-		SortArray<T, C> sorter;
+		SortArray<T, C> sorter{};
 		sorter.sort(data, len);
 	}
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -641,20 +641,20 @@ struct _VariantCall {
 _VariantCall::ConstantData *_VariantCall::constant_data = nullptr;
 
 struct VariantBuiltInMethodInfo {
-	void (*call)(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error);
-	Variant::ValidatedBuiltInMethod validated_call;
-	Variant::PTRBuiltInMethod ptrcall;
+	void (*call)(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) = nullptr;
+	Variant::ValidatedBuiltInMethod validated_call = nullptr;
+	Variant::PTRBuiltInMethod ptrcall = nullptr;
 
 	Vector<Variant> default_arguments;
 	Vector<String> argument_names;
 
-	bool is_const;
-	bool is_static;
-	bool has_return_type;
-	bool is_vararg;
+	bool is_const = false;
+	bool is_static = false;
+	bool has_return_type = false;
+	bool is_vararg = false;
 	Variant::Type return_type;
-	int argument_count;
-	Variant::Type (*get_argument_type)(int p_arg);
+	int argument_count = 0;
+	Variant::Type (*get_argument_type)(int p_arg) = nullptr;
 };
 
 typedef OAHashMap<StringName, VariantBuiltInMethodInfo> BuiltinMethodMap;

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -567,11 +567,11 @@ public:
 };
 
 struct VariantConstructData {
-	void (*construct)(Variant &r_base, const Variant **p_args, Callable::CallError &r_error);
-	Variant::ValidatedConstructor validated_construct;
-	Variant::PTRConstructor ptr_construct;
-	Variant::Type (*get_argument_type)(int);
-	int argument_count;
+	void (*construct)(Variant &r_base, const Variant **p_args, Callable::CallError &r_error) = nullptr;
+	Variant::ValidatedConstructor validated_construct = nullptr;
+	Variant::PTRConstructor ptr_construct = nullptr;
+	Variant::Type (*get_argument_type)(int) = nullptr;
+	int argument_count = 0;
 	Vector<String> arg_names;
 };
 

--- a/core/variant/variant_parser.h
+++ b/core/variant/variant_parser.h
@@ -73,9 +73,9 @@ public:
 
 	struct ResourceParser {
 		void *userdata = nullptr;
-		ParseResourceFunc func;
-		ParseResourceFunc ext_func;
-		ParseResourceFunc sub_func;
+		ParseResourceFunc func = nullptr;
+		ParseResourceFunc ext_func = nullptr;
+		ParseResourceFunc sub_func = nullptr;
 	};
 
 	enum TokenType {

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -306,13 +306,13 @@ SETGET_NUMBER_STRUCT_FUNC(Color, double, s, set_s, get_s)
 SETGET_NUMBER_STRUCT_FUNC(Color, double, v, set_v, get_v)
 
 struct VariantSetterGetterInfo {
-	void (*setter)(Variant *base, const Variant *value, bool &valid);
-	void (*getter)(const Variant *base, Variant *value);
-	Variant::ValidatedSetter validated_setter;
-	Variant::ValidatedGetter validated_getter;
-	Variant::PTRSetter ptr_setter;
-	Variant::PTRGetter ptr_getter;
-	Variant::Type member_type;
+	void (*setter)(Variant *base, const Variant *value, bool &valid) = nullptr;
+	void (*getter)(const Variant *base, Variant *value) = nullptr;
+	Variant::ValidatedSetter validated_setter = nullptr;
+	Variant::ValidatedGetter validated_getter = nullptr;
+	Variant::PTRSetter ptr_setter = nullptr;
+	Variant::PTRGetter ptr_getter = nullptr;
+	Variant::Type member_type = Variant::NIL;
 };
 
 static LocalVector<VariantSetterGetterInfo> variant_setters_getters[Variant::VARIANT_MAX];
@@ -994,18 +994,18 @@ INDEXED_SETGET_STRUCT_TYPED(PackedColorArray, Color)
 INDEXED_SETGET_STRUCT_DICT(Dictionary)
 
 struct VariantIndexedSetterGetterInfo {
-	void (*setter)(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob);
-	void (*getter)(const Variant *base, int64_t index, Variant *value, bool *oob);
+	void (*setter)(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) = nullptr;
+	void (*getter)(const Variant *base, int64_t index, Variant *value, bool *oob) = nullptr;
 
-	Variant::ValidatedIndexedSetter validated_setter;
-	Variant::ValidatedIndexedGetter validated_getter;
+	Variant::ValidatedIndexedSetter validated_setter = nullptr;
+	Variant::ValidatedIndexedGetter validated_getter = nullptr;
 
-	Variant::PTRIndexedSetter ptr_setter;
-	Variant::PTRIndexedGetter ptr_getter;
+	Variant::PTRIndexedSetter ptr_setter = nullptr;
+	Variant::PTRIndexedGetter ptr_getter = nullptr;
 
-	uint64_t (*get_indexed_size)(const Variant *base);
+	uint64_t (*get_indexed_size)(const Variant *base) = nullptr;
 
-	Variant::Type index_type;
+	Variant::Type index_type = Variant::NIL;
 
 	bool valid = false;
 };
@@ -1205,13 +1205,13 @@ struct VariantKeyedSetGetObject {
 };
 
 struct VariantKeyedSetterGetterInfo {
-	Variant::ValidatedKeyedSetter validated_setter;
-	Variant::ValidatedKeyedGetter validated_getter;
-	Variant::ValidatedKeyedChecker validated_checker;
+	Variant::ValidatedKeyedSetter validated_setter = nullptr;
+	Variant::ValidatedKeyedGetter validated_getter = nullptr;
+	Variant::ValidatedKeyedChecker validated_checker = nullptr;
 
-	Variant::PTRKeyedSetter ptr_setter;
-	Variant::PTRKeyedGetter ptr_getter;
-	Variant::PTRKeyedChecker ptr_checker;
+	Variant::PTRKeyedSetter ptr_setter = nullptr;
+	Variant::PTRKeyedGetter ptr_getter = nullptr;
+	Variant::PTRKeyedChecker ptr_checker = nullptr;
 
 	bool valid = false;
 };

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1091,16 +1091,16 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
 struct VariantUtilityFunctionInfo {
-	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-	Variant::ValidatedUtilityFunction validated_call_utility;
-	Variant::PTRUtilityFunction ptr_call_utility;
+	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) = nullptr;
+	Variant::ValidatedUtilityFunction validated_call_utility = nullptr;
+	Variant::PTRUtilityFunction ptr_call_utility = nullptr;
 	Vector<String> argnames;
-	bool is_vararg;
-	bool returns_value;
-	int argcount;
-	Variant::Type (*get_arg_type)(int);
-	Variant::Type return_type;
-	Variant::UtilityFunctionType type;
+	bool is_vararg = false;
+	bool returns_value = false;
+	int argcount = 0;
+	Variant::Type (*get_arg_type)(int) = nullptr;
+	Variant::Type return_type = Variant::NIL;
+	Variant::UtilityFunctionType type = Variant::UTILITY_FUNC_TYPE_GENERAL;
 };
 
 static OAHashMap<StringName, VariantUtilityFunctionInfo> utility_function_table;

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -473,18 +473,18 @@ DisplayServerAndroid::~DisplayServerAndroid() {
 
 void DisplayServerAndroid::process_joy_event(DisplayServerAndroid::JoypadEvent p_event) {
 	switch (p_event.type) {
-		case JOY_EVENT_BUTTON:
+		case JOY_EVENT_BUTTON: {
 			Input::get_singleton()->joy_button(p_event.device, p_event.index, p_event.pressed);
-			break;
-		case JOY_EVENT_AXIS:
+		} break;
+		case JOY_EVENT_AXIS: {
 			Input::JoyAxisValue value;
 			value.min = -1;
 			value.value = p_event.value;
 			Input::get_singleton()->joy_axis(p_event.device, p_event.index, value);
-			break;
-		case JOY_EVENT_HAT:
+		} break;
+		case JOY_EVENT_HAT: {
 			Input::get_singleton()->joy_hat(p_event.device, p_event.hat);
-			break;
+		} break;
 		default:
 			return;
 	}


### PR DESCRIPTION
Done in part using clang-tidy 12's `cppcoreguidelines-pro-type-member-init`
check, though it made a lot of invalid changes (such as initializing multiple
members of a union), so I had to review all files manually, and did further
changes where I saw non-static uninitialized fields.

---

Extracted from #47723 and with a few extra hours of manual cleanup and review.


## Notes

There are a few things we need to decide how we want to solve them (if at all):

### 1. Initializing unions

We use a number of unions in the core, either to be able to repurpose a chunk of memory for different users, or to have aliases for a given memory chunk (possibly with different types and I guess some conversion done).

This seems to be [undefined behavior](https://en.cppreference.com/w/cpp/language/union) which we rely extensively upon (most prominently in `Variant::_data`, see below), so I guess it's UB which happens to be implemented in a convenient way everywhere?

Either, we have things like this:
```cpp
struct Color {
...
	union {
		struct {
			float r;
			float g;
			float b;
			float a;
		};
		float components[4] = { 0.0, 0.0, 0.0, 1.0 };
	};
```
```cpp
struct Vector2i {
...
	union {
		int32_t x = 0;
		int32_t width;
	};
```
```cpp
class StringName {
...
	union _HashUnion {
		_Data *ptr = nullptr;
		uint32_t hash;
	};
```

`clang-tidy` complains about those being uninitialized, yet I don't see what would be a valid way to initialize them (value initializing several union members is invalid).

It seems like *instances* of anonymous unions can be value-initialized like this:
```cpp
		union {
			uint64_t u;
			double f;
		} ieee754{};
		ieee754.f = p_val;
```
What this does to `u` and `f`, I have no idea.

### 2. `Variant::_data`

The most pathological case for the above is `Variant::_data`:

```cpp
class Variant {
...
	union {
		bool _bool;
		int64_t _int;
		double _float;
		Transform2D *_transform2d;
		::AABB *_aabb;
		Basis *_basis;
		Transform *_transform;
		PackedArrayRefBase *packed_array;
		void *_ptr; //generic pointer
		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)];
	} _data alignas(8);
```

What can we do here? Leave it as is and keep passing uninitialized Variants around, or zeroize `_mem`?

`clang-tidy` spouts *tons* of warnings about this (basically on every single it processes which uses Variants, i.e. the whole codebase).