### PR TITLE
[3.x] Fix issue causing the response callback to be invoked with the invalid `requestCode`

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
@@ -64,30 +64,27 @@ public abstract class FullScreenGodotApp extends FragmentActivity implements God
 
 	@Override
 	public void onNewIntent(Intent intent) {
+		super.onNewIntent(intent);
 		if (godotFragment != null) {
 			godotFragment.onNewIntent(intent);
-		} else {
-			super.onNewIntent(intent);
 		}
 	}
 
 	@CallSuper
 	@Override
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
 		if (godotFragment != null) {
 			godotFragment.onActivityResult(requestCode, resultCode, data);
-		} else {
-			super.onActivityResult(requestCode, resultCode, data);
 		}
 	}
 
 	@CallSuper
 	@Override
 	public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+		super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 		if (godotFragment != null) {
 			godotFragment.onRequestPermissionsResult(requestCode, permissions, grantResults);
-		} else {
-			super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 		}
 	}
 


### PR DESCRIPTION
Fixes #47073
