### PR TITLE
Fix issue causing the response callback to be invoked with the invalid `requestCode`

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
@@ -34,7 +34,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.KeyEvent;
 
-import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
@@ -63,30 +62,9 @@ public abstract class FullScreenGodotApp extends FragmentActivity implements God
 
 	@Override
 	public void onNewIntent(Intent intent) {
+		super.onNewIntent(intent);
 		if (godotFragment != null) {
 			godotFragment.onNewIntent(intent);
-		} else {
-			super.onNewIntent(intent);
-		}
-	}
-
-	@CallSuper
-	@Override
-	public void onActivityResult(int requestCode, int resultCode, Intent data) {
-		if (godotFragment != null) {
-			godotFragment.onActivityResult(requestCode, resultCode, data);
-		} else {
-			super.onActivityResult(requestCode, resultCode, data);
-		}
-	}
-
-	@CallSuper
-	@Override
-	public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-		if (godotFragment != null) {
-			godotFragment.onRequestPermissionsResult(requestCode, permissions, grantResults);
-		} else {
-			super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 		}
 	}
 


### PR DESCRIPTION
In addition, this deprecates support for forwarding callbacks from Godot's parent activity.

Fixes #47073