### PR TITLE
Expose NodeDock and its children

### DIFF
--- a/doc/classes/ConnectionsDock.xml
+++ b/doc/classes/ConnectionsDock.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ConnectionsDock" inherits="VBoxContainer" version="4.0">
+	<brief_description>
+		The connection control in the Node dock.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_connection_tree">
+			<return type="Tree" />
+			<description>
+				Returns the [code]tree[/code] where signal connections are listed.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -84,6 +84,12 @@
 				Returns the editor's [EditorInspector] instance.
 			</description>
 		</method>
+		<method name="get_node_dock">
+			<return type="NodeDock" />
+			<description>
+				Returns the editor's [NodeDock] instance.
+			</description>
+		</method>
 		<method name="get_open_scenes" qualifiers="const">
 			<return type="Array" />
 			<description>

--- a/doc/classes/GroupsEditor.xml
+++ b/doc/classes/GroupsEditor.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GroupsEditor" inherits="VBoxContainer" version="4.0">
+	<brief_description>
+		The group control in the [code]Node[/code] dock.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_groups_tree">
+			<return type="Tree" />
+			<description>
+				Returns the [code]tree[/code] where groups are listed.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/NodeDock.xml
+++ b/doc/classes/NodeDock.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NodeDock" inherits="VBoxContainer" version="4.0">
+	<brief_description>
+		The Node dock.
+	</brief_description>
+	<description>
+		The Node dock shows some [Node] specific properties through tabs. A plugin can add new tabs or get the built-in ones.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_control">
+			<return type="Button" />
+			<argument index="0" name="control" type="Control" />
+			<argument index="1" name="title" type="String" />
+			<description>
+				Adds a control (together with Signals and Groups). Returns a reference to the button added. It's up to you to update your control when the selected node changed (use the [signal node_changed] signal for that). When your plugin is deactivated, make sure to remove your custom control with [method remove_control] and free it with [method Node.queue_free].
+			</description>
+		</method>
+		<method name="remove_control">
+			<return type="void" />
+			<argument index="0" name="control" type="Control" />
+			<description>
+				Removes the control and frees the button. You have to manually [method Node.queue_free] the control.
+			</description>
+		</method>
+		<method name="show_control">
+			<return type="void" />
+			<argument index="0" name="control" type="Control" />
+			<description>
+				Shows the given tab and replace the current tab.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="node_changed">
+			<argument index="0" name="node" type="Node" />
+			<description>
+				Emitted when the showed node changes.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -159,7 +159,7 @@ class ConnectionsDock : public VBoxContainer {
 		DISCONNECT
 	};
 
-	Node *selectedNode;
+	Node *selected_node;
 	ConnectionsDockTree *tree;
 	EditorNode *editor;
 
@@ -172,6 +172,8 @@ class ConnectionsDock : public VBoxContainer {
 	LineEdit *search_box;
 
 	Map<StringName, Map<StringName, String>> descr_cache;
+
+	void _update_tree();
 
 	void _filter_changed(const String &p_text);
 
@@ -201,7 +203,8 @@ protected:
 public:
 	void set_undoredo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; }
 	void set_node(Node *p_node);
-	void update_tree();
+
+	Tree *get_connection_tree();
 
 	ConnectionsDock(EditorNode *p_editor = nullptr);
 	~ConnectionsDock();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3820,6 +3820,9 @@ void EditorNode::register_editor_types() {
 	GDREGISTER_CLASS(EditorSceneImporterMeshNode3D);
 
 	GDREGISTER_VIRTUAL_CLASS(FileSystemDock);
+	GDREGISTER_VIRTUAL_CLASS(NodeDock);
+	GDREGISTER_VIRTUAL_CLASS(ConnectionsDock);
+	GDREGISTER_VIRTUAL_CLASS(GroupsEditor);
 
 	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?
 	GDREGISTER_CLASS(EditorScenePostImport);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
 #include "editor/filesystem_dock.h"
+#include "editor/node_dock.h"
 #include "editor/project_settings_editor.h"
 #include "editor_resource_preview.h"
 #include "main/main.h"
@@ -251,6 +252,10 @@ FileSystemDock *EditorInterface::get_file_system_dock() {
 	return EditorNode::get_singleton()->get_filesystem_dock();
 }
 
+NodeDock *EditorInterface::get_node_dock() {
+	return NodeDock::singleton;
+}
+
 EditorSelection *EditorInterface::get_selection() {
 	return EditorNode::get_singleton()->get_editor_selection();
 }
@@ -343,6 +348,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_selected_path"), &EditorInterface::get_selected_path);
 	ClassDB::bind_method(D_METHOD("get_current_path"), &EditorInterface::get_current_path);
 	ClassDB::bind_method(D_METHOD("get_file_system_dock"), &EditorInterface::get_file_system_dock);
+	ClassDB::bind_method(D_METHOD("get_node_dock"), &EditorInterface::get_node_dock);
 	ClassDB::bind_method(D_METHOD("get_editor_paths"), &EditorInterface::get_editor_paths);
 	ClassDB::bind_method(D_METHOD("get_command_palette"), &EditorInterface::get_command_palette);
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -58,6 +58,7 @@ class EditorToolAddons;
 class EditorPaths;
 class FileSystemDock;
 class ScriptEditor;
+class NodeDock;
 
 class EditorInterface : public Node {
 	GDCLASS(EditorInterface, Node);
@@ -104,6 +105,7 @@ public:
 	EditorFileSystem *get_resource_file_system();
 
 	FileSystemDock *get_file_system_dock();
+	NodeDock *get_node_dock();
 
 	Control *get_base_control();
 	float get_editor_scale() const;

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -402,6 +402,8 @@ void GroupDialog::_bind_methods() {
 
 	ClassDB::bind_method("_rename_group_item", &GroupDialog::_rename_group_item);
 
+	ClassDB::bind_method("_group_selected", &GroupDialog::_group_selected);
+
 	ADD_SIGNAL(MethodInfo("group_edited"));
 }
 
@@ -570,8 +572,8 @@ void GroupsEditor::_add_group(const String &p_group) {
 
 	undo_redo->add_do_method(node, "add_to_group", name, true);
 	undo_redo->add_undo_method(node, "remove_from_group", name);
-	undo_redo->add_do_method(this, "update_tree");
-	undo_redo->add_undo_method(this, "update_tree");
+	undo_redo->add_do_method(this, "_update_tree");
+	undo_redo->add_undo_method(this, "_update_tree");
 
 	// To force redraw of scene tree.
 	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
@@ -598,8 +600,8 @@ void GroupsEditor::_remove_group(Object *p_item, int p_column, int p_id) {
 
 	undo_redo->add_do_method(node, "remove_from_group", name);
 	undo_redo->add_undo_method(node, "add_to_group", name, true);
-	undo_redo->add_do_method(this, "update_tree");
-	undo_redo->add_undo_method(this, "update_tree");
+	undo_redo->add_do_method(this, "_update_tree");
+	undo_redo->add_undo_method(this, "_update_tree");
 
 	// To force redraw of scene tree.
 	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
@@ -614,7 +616,7 @@ struct _GroupInfoComparator {
 	}
 };
 
-void GroupsEditor::update_tree() {
+void GroupsEditor::_update_tree() {
 	tree->clear();
 
 	if (!node) {
@@ -662,7 +664,13 @@ void GroupsEditor::update_tree() {
 
 void GroupsEditor::set_current(Node *p_node) {
 	node = p_node;
-	update_tree();
+	if (is_visible_in_tree()) {
+		_update_tree();
+	}
+}
+
+Tree *GroupsEditor::get_groups_tree() {
+	return tree;
 }
 
 void GroupsEditor::_show_group_dialog() {
@@ -671,7 +679,9 @@ void GroupsEditor::_show_group_dialog() {
 }
 
 void GroupsEditor::_bind_methods() {
-	ClassDB::bind_method("update_tree", &GroupsEditor::update_tree);
+	ClassDB::bind_method("_update_tree", &GroupsEditor::_update_tree);
+
+	ClassDB::bind_method("get_groups_tree", &GroupsEditor::get_groups_tree);
 }
 
 GroupsEditor::GroupsEditor() {
@@ -682,7 +692,7 @@ GroupsEditor::GroupsEditor() {
 	group_dialog = memnew(GroupDialog);
 
 	add_child(group_dialog);
-	group_dialog->connect("group_edited", callable_mp(this, &GroupsEditor::update_tree));
+	group_dialog->connect("group_edited", callable_mp(this, &GroupsEditor::_update_tree));
 
 	Button *group_dialog_button = memnew(Button);
 	group_dialog_button->set_text(TTR("Manage Groups"));

--- a/editor/groups_editor.h
+++ b/editor/groups_editor.h
@@ -114,7 +114,7 @@ class GroupsEditor : public VBoxContainer {
 
 	UndoRedo *undo_redo;
 
-	void update_tree();
+	void _update_tree();
 	void _add_group(const String &p_group = "");
 	void _remove_group(Object *p_item, int p_column, int p_id);
 	void _close();
@@ -127,6 +127,8 @@ protected:
 public:
 	void set_undo_redo(UndoRedo *p_undoredo) { undo_redo = p_undoredo; }
 	void set_current(Node *p_node);
+
+	Tree *get_groups_tree();
 
 	GroupsEditor();
 	~GroupsEditor();

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -33,53 +33,133 @@
 #include "editor_node.h"
 #include "editor_scale.h"
 
-void NodeDock::show_groups() {
-	groups_button->set_pressed(true);
-	connections_button->set_pressed(false);
-	groups->show();
-	connections->hide();
-}
+void NodeDock::_set_current(bool p_enable, int p_idx) {
+	ERR_FAIL_INDEX(p_idx, mode_items.size());
 
-void NodeDock::show_connections() {
-	groups_button->set_pressed(false);
-	connections_button->set_pressed(true);
-	groups->hide();
-	connections->show();
+	if (mode_items[p_idx].control->is_visible() == p_enable) {
+		return;
+	}
+
+	if (p_idx != current_idx) {
+		mode_items[current_idx].control->hide();
+		mode_items[current_idx].button->set_pressed(false);
+		mode_items[p_idx].control->show();
+		mode_items[p_idx].button->set_pressed(true);
+		current_idx = p_idx;
+
+		set_node(current_node);
+	} else if (!p_enable) {
+		// Toggle event, not a switch
+		mode_items[current_idx].button->set_pressed(true);
+	}
 }
 
 void NodeDock::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_control", "control", "title"), &NodeDock::add_control);
+	ClassDB::bind_method(D_METHOD("remove_control", "control"), &NodeDock::remove_control);
+	ClassDB::bind_method(D_METHOD("show_control", "control"), &NodeDock::show_control);
+
+	ADD_SIGNAL(MethodInfo("node_changed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 }
 
 void NodeDock::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		connections_button->set_icon(get_theme_icon(SNAME("Signals"), SNAME("EditorIcons")));
-		groups_button->set_icon(get_theme_icon(SNAME("Groups"), SNAME("EditorIcons")));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED:
+			connections_button->set_icon(get_theme_icon(SNAME("Signals"), SNAME("EditorIcons")));
+			groups_button->set_icon(get_theme_icon(SNAME("Groups"), SNAME("EditorIcons")));
+			break;
 	}
 }
 
 NodeDock *NodeDock::singleton = nullptr;
 
 void NodeDock::update_lists() {
-	connections->update_tree();
+	emit_signal("node_changed", current_node);
+}
+
+ConnectionsDock *NodeDock::get_connections_dock() {
+	return connections;
+}
+
+GroupsEditor *NodeDock::get_group_editor() {
+	return groups;
+}
+
+Button *NodeDock::add_control(Control *p_control, const String &p_title) {
+	Button *mb = memnew(Button);
+	mb->set_flat(true);
+	mb->connect("toggled", callable_mp(this, &NodeDock::_set_current), varray(mode_items.size()));
+	mb->set_text(p_title);
+	mb->set_toggle_mode(true);
+	mb->set_pressed(false);
+	mb->set_h_size_flags(SIZE_EXPAND_FILL);
+	mb->set_clip_text(true);
+
+	mode_container->add_child(mb);
+	add_child(p_control);
+	p_control->hide();
+	p_control->set_v_size_flags(SIZE_EXPAND_FILL);
+
+	ModeItem item;
+	item.button = mb;
+	item.control = p_control;
+	mode_items.push_back(item);
+
+	return mb;
+}
+
+void NodeDock::remove_control(Control *p_control) {
+	for (int i = 0; i < mode_items.size(); i++) {
+		if (mode_items[i].control == p_control) {
+			remove_child(mode_items[i].control);
+			mode_container->remove_child(mode_items[i].button);
+			memdelete(mode_items[i].button);
+			mode_items.remove(i);
+
+			if (mode_items.is_empty()) {
+				// This is not a good state.
+				current_idx = 0;
+				set_node(nullptr);
+			} else {
+				_set_current(true, MIN(i, mode_items.size()));
+			}
+			break;
+		}
+	}
+
+	for (int i = 0; i < mode_items.size(); i++) {
+		mode_items[i].button->disconnect("toggled", callable_mp(this, &NodeDock::_set_current));
+		mode_items[i].button->connect("toggled", callable_mp(this, &NodeDock::_set_current), varray(i));
+	}
+}
+
+void NodeDock::show_control(Control *p_control) {
+	for (int i = 0; i < mode_items.size(); i++) {
+		if (mode_items[i].control == p_control) {
+			_set_current(true, i);
+			return;
+		}
+	}
+	ERR_FAIL_MSG(vformat("Control is not a %s's tab.", get_class()));
 }
 
 void NodeDock::set_node(Node *p_node) {
-	connections->set_node(p_node);
-	groups->set_current(p_node);
-
+	current_node = p_node;
 	if (p_node) {
-		if (connections_button->is_pressed()) {
-			connections->show();
-		} else {
-			groups->show();
-		}
-
-		mode_hb->show();
+		mode_container->show();
 		select_a_node->hide();
+
+		ERR_FAIL_COND_MSG(!mode_items.size(), "No modes found.");
+		mode_items[current_idx].control->show();
+		mode_items[current_idx].button->set_pressed(true);
+		emit_signal("node_changed", p_node);
 	} else {
-		connections->hide();
-		groups->hide();
-		mode_hb->hide();
+		if (mode_items.size() != 0) {
+			mode_items[current_idx].button->set_pressed(false);
+			mode_items[current_idx].control->hide();
+		}
+		mode_container->hide();
 		select_a_node->show();
 	}
 }
@@ -88,41 +168,20 @@ NodeDock::NodeDock() {
 	singleton = this;
 
 	set_name("Node");
-	mode_hb = memnew(HBoxContainer);
-	add_child(mode_hb);
-	mode_hb->hide();
-
-	connections_button = memnew(Button);
-	connections_button->set_flat(true);
-	connections_button->set_text(TTR("Signals"));
-	connections_button->set_toggle_mode(true);
-	connections_button->set_pressed(true);
-	connections_button->set_h_size_flags(SIZE_EXPAND_FILL);
-	connections_button->set_clip_text(true);
-	mode_hb->add_child(connections_button);
-	connections_button->connect("pressed", callable_mp(this, &NodeDock::show_connections));
-
-	groups_button = memnew(Button);
-	groups_button->set_flat(true);
-	groups_button->set_text(TTR("Groups"));
-	groups_button->set_toggle_mode(true);
-	groups_button->set_pressed(false);
-	groups_button->set_h_size_flags(SIZE_EXPAND_FILL);
-	groups_button->set_clip_text(true);
-	mode_hb->add_child(groups_button);
-	groups_button->connect("pressed", callable_mp(this, &NodeDock::show_groups));
+	mode_container = memnew(GridContainer);
+	mode_container->set_columns(2);
+	add_child(mode_container);
+	mode_container->hide();
 
 	connections = memnew(ConnectionsDock(EditorNode::get_singleton()));
 	connections->set_undoredo(EditorNode::get_undo_redo());
-	add_child(connections);
-	connections->set_v_size_flags(SIZE_EXPAND_FILL);
-	connections->hide();
+	connections_button = add_control(connections, TTR("Connections"));
+	connect("node_changed", callable_mp(connections, &ConnectionsDock::set_node));
 
 	groups = memnew(GroupsEditor);
 	groups->set_undo_redo(EditorNode::get_undo_redo());
-	add_child(groups);
-	groups->set_v_size_flags(SIZE_EXPAND_FILL);
-	groups->hide();
+	groups_button = add_control(groups, TTR("Groups"));
+	connect("node_changed", callable_mp(groups, &GroupsEditor::set_current));
 
 	select_a_node = memnew(Label);
 	select_a_node->set_text(TTR("Select a single node to edit its signals and groups."));

--- a/editor/node_dock.h
+++ b/editor/node_dock.h
@@ -37,15 +37,25 @@
 class NodeDock : public VBoxContainer {
 	GDCLASS(NodeDock, VBoxContainer);
 
+	struct ModeItem {
+		Control *control = nullptr;
+		Button *button = nullptr;
+	};
+
+	int current_idx = 0;
+	Vector<ModeItem> mode_items;
+
+	Node *current_node = nullptr;
+
+	GridContainer *mode_container;
 	Button *connections_button;
 	Button *groups_button;
 
 	ConnectionsDock *connections;
 	GroupsEditor *groups;
-
-	HBoxContainer *mode_hb;
-
 	Label *select_a_node;
+
+	void _set_current(bool p_toggled, int p_idx);
 
 protected:
 	static void _bind_methods();
@@ -54,12 +64,18 @@ protected:
 public:
 	static NodeDock *singleton;
 
+	void update_lists();
+
+	// Getters
+	ConnectionsDock *get_connections_dock();
+	GroupsEditor *get_group_editor();
+
+	// Modifiers
 	void set_node(Node *p_node);
 
-	void show_groups();
-	void show_connections();
-
-	void update_lists();
+	Button *add_control(Control *p_control, const String &p_title);
+	void remove_control(Control *p_control);
+	void show_control(Control *p_control);
 
 	NodeDock();
 };

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -134,7 +134,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		set_selected(n);
 
 		NodeDock::singleton->get_parent()->call("set_current_tab", NodeDock::singleton->get_index());
-		NodeDock::singleton->show_connections();
+		NodeDock::singleton->show_control(NodeDock::singleton->get_connections_dock());
 
 	} else if (p_id == BUTTON_GROUPS) {
 		editor_selection->clear();
@@ -143,7 +143,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		set_selected(n);
 
 		NodeDock::singleton->get_parent()->call("set_current_tab", NodeDock::singleton->get_index());
-		NodeDock::singleton->show_groups();
+		NodeDock::singleton->show_control(NodeDock::singleton->get_group_editor());
 	}
 }
 


### PR DESCRIPTION
Part of godotengine/godot-proposals#2537
Indipendent from #47520

Expose NodeDock, ConnectionDock and GroupsEditor. NodeDock was refactored to allow an arbitrary number of tabs that can be added by plugins (no more show_* methods).
ConnectionDock and GroupsEditor exposes their main subcomponents (both trees). Dialogs are not exposed.
Also, I did some little unrelated changes (including a bugfix).

Docs for newly exposed classes are added, but I'm not sure about the quality of them, especially the descriptions. 
IMO the brief description should state what component is and where it is, and the description should explain in short how it is structured and how a plugin can modify it.