### PR TITLE
Improve the `Engine.editor_hint` property documentation

### DIFF
--- a/doc/classes/AStar.xml
+++ b/doc/classes/AStar.xml
@@ -289,7 +289,7 @@
 			</argument>
 			<description>
 				Returns an array with the points that are in the path found by AStar between the given points. The array is ordered from the starting point to the ending point of the path.
-				[b]Note:[/b] This method is not thread-safe. If called from a [Thread], it will return an empty [PackedVector2Array] and will print an error message.
+				[b]Note:[/b] This method is not thread-safe. If called from a [Thread], it will return an empty [PackedVector3Array] and will print an error message.
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -156,7 +156,15 @@
 	</methods>
 	<members>
 		<member name="editor_hint" type="bool" setter="set_editor_hint" getter="is_editor_hint" default="true">
-			If [code]true[/code], it is running inside the editor. Useful for tool scripts.
+			If [code]true[/code], the script is currently running inside the editor. This is useful for [code]@tool[/code] scripts to conditionally draw editor helpers, or prevent accidentally running "game" code that would affect the scene state while in the editor:
+			[codeblock]
+			if Engine.editor_hint:
+			    draw_gizmos()
+			else:
+			    simulate_physics()
+			[/codeblock]
+			See [url=https://docs.godotengine.org/en/latest/tutorials/plugins/running_code_in_the_editor.html]Running code in the editor[/url] in the documentation for more information.
+			[b]Note:[/b] To detect whether the script is run from an editor [i]build[/i] (e.g. when pressing [kbd]F5[/kbd]), use [method OS.has_feature] with the [code]"editor"[/code] argument instead. [code]OS.has_feature("editor")[/code] will evaluate to [code]true[/code] both when the code is running in the editor and when running the project from the editor, but it will evaluate to [code]false[/code] when the code is run from an exported project.
 		</member>
 		<member name="iterations_per_second" type="int" setter="set_iterations_per_second" getter="get_iterations_per_second" default="60">
 			The number of fixed iterations per second. This controls how often physics simulation and [method Node._physics_process] methods are run. This value should generally always be set to [code]60[/code] or above, as Godot doesn't interpolate the physics step. As a result, values lower than [code]60[/code] will look stuttery. This value can be increased to make input more reactive or work around tunneling issues, but keep in mind doing so will increase CPU usage.


### PR DESCRIPTION
**Note when cherry-picking to `3.x`:** Replace `@tool` with `tool` and replace the documentation URL with `https://docs.godotengine.org/en/stable/tutorials/misc/running_code_in_the_editor.html`.

This also includes a typo fix in `doc/classes/AStar.xml`.