### PR TITLE
Fix negative arguments not allowed in @export_range

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -572,7 +572,20 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 
 				// Apply annotations.
 				for (List<GDScriptParser::AnnotationNode *>::Element *E = member.variable->annotations.front(); E; E = E->next()) {
-					E->get()->apply(parser, member.variable);
+					GDScriptParser::AnnotationNode *annotation = E->get();
+
+					String hint_string;
+					for (int j = 0; j < annotation->arguments.size(); j++) {
+						if (j > 0) {
+							hint_string += ",";
+						}
+						GDScriptParser::ExpressionNode *expression = annotation->arguments[j];
+						reduce_expression(expression);
+						hint_string += String(expression->reduced_value);
+					}
+					member.variable->export_info.hint_string = hint_string;
+
+					annotation->apply(parser, member.variable);
 				}
 			} break;
 			case GDScriptParser::ClassNode::Member::CONSTANT: {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -319,7 +319,6 @@ public:
 	struct AnnotationNode : public Node {
 		StringName name;
 		Vector<ExpressionNode *> arguments;
-		Vector<Variant> resolved_arguments;
 
 		AnnotationInfo *info = nullptr;
 


### PR DESCRIPTION
This is a proposal PR that do fix #41183, however, I am not sure if it respect the code architecture.

The issue is about negative arguments not accepted in @export_range.

First change is to make it pass GDScriptParser::validate_annotation_arguments, by adding a new case for UNARY_OPERATOR.

Second change, to computer hint_string, I wanted to make use of `reduce_expression` available, not in the parser, but in gdscript_analyzer.cpp, so the hint_string calculation was moved from parser to analyzer.

Finally, `resolve_arguments` was also removed since:
1) computed by gdscript_parser which seems cannot treat the UNARY_OPERATOR expression node
2) and redundant for caching with ExpressionNode which already contains a `reduced_value` (I may be wrong here)