### PR TITLE
Enable `contact_monitor` in RigidBody by default

### DIFF
--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -134,10 +134,10 @@
 			If [code]true[/code], the body can enter sleep mode when there is no movement. See [member sleeping].
 			[b]Note:[/b] A RigidBody2D will never enter sleep mode automatically if its [member mode] is [constant MODE_CHARACTER]. It can still be put to sleep manually by setting its [member sleeping] property to [code]true[/code].
 		</member>
-		<member name="contact_monitor" type="bool" setter="set_contact_monitor" getter="is_contact_monitor_enabled" default="false">
-			If [code]true[/code], the body will emit signals when it collides with another RigidBody2D. See also [member contacts_reported].
+		<member name="contact_monitor" type="bool" setter="set_contact_monitor" getter="is_contact_monitor_enabled" default="true">
+			If [code]true[/code], the body will emit signals when it collides with another RigidBody2D. If you don't need information about contacts, set this to [code]false[/code] to improve performance when using a large amount of RigidBodies. See also [member contacts_reported].
 		</member>
-		<member name="contacts_reported" type="int" setter="set_max_contacts_reported" getter="get_max_contacts_reported" default="0">
+		<member name="contacts_reported" type="int" setter="set_max_contacts_reported" getter="get_max_contacts_reported" default="1">
 			The maximum number of contacts that will be recorded. Requires [member contact_monitor] to be set to [code]true[/code].
 			[b]Note:[/b] The number of contacts is different from the number of collisions. Collisions between parallel edges will result in two contacts (one at each end).
 		</member>

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -161,10 +161,10 @@
 			If [code]true[/code], the body can enter sleep mode when there is no movement. See [member sleeping].
 			[b]Note:[/b] A RigidBody3D will never enter sleep mode automatically if its [member mode] is [constant MODE_CHARACTER]. It can still be put to sleep manually by setting its [member sleeping] property to [code]true[/code].
 		</member>
-		<member name="contact_monitor" type="bool" setter="set_contact_monitor" getter="is_contact_monitor_enabled" default="false">
-			If [code]true[/code], the RigidBody3D will emit signals when it collides with another RigidBody3D. See also [member contacts_reported].
+		<member name="contact_monitor" type="bool" setter="set_contact_monitor" getter="is_contact_monitor_enabled" default="true">
+			If [code]true[/code], the RigidBody3D will emit signals when it collides with another RigidBody3D. If you don't need information about contacts, set this to [code]false[/code] to improve performance when using a large amount of RigidBodies. See also [member contacts_reported].
 		</member>
-		<member name="contacts_reported" type="int" setter="set_max_contacts_reported" getter="get_max_contacts_reported" default="0">
+		<member name="contacts_reported" type="int" setter="set_max_contacts_reported" getter="get_max_contacts_reported" default="1">
 			The maximum number of contacts that will be recorded. Requires [member contact_monitor] to be set to [code]true[/code].
 			[b]Note:[/b] The number of contacts is different from the number of collisions. Collisions between parallel edges will result in two contacts (one at each end), and collisions between parallel faces will result in four contacts (one at each corner).
 		</member>

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -839,6 +839,10 @@ void RigidBody2D::_bind_methods() {
 RigidBody2D::RigidBody2D() :
 		PhysicsBody2D(PhysicsServer2D::BODY_MODE_RIGID) {
 	PhysicsServer2D::get_singleton()->body_set_force_integration_callback(get_rid(), this, "_direct_state_changed");
+	// Enable the contact monitor by default.
+	// This has a small performance impact, but it results in better usability, especially for beginners.
+	// The user will need to increase `max_contacts_reported` above 0 to get information about contacts.
+	set_contact_monitor(true);
 }
 
 RigidBody2D::~RigidBody2D() {

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -130,7 +130,7 @@ private:
 	real_t angular_velocity = 0.0;
 	bool sleeping = false;
 
-	int max_contacts_reported = 0;
+	int max_contacts_reported = 1;
 
 	bool custom_integrator = false;
 

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -827,6 +827,10 @@ void RigidBody3D::_bind_methods() {
 RigidBody3D::RigidBody3D() :
 		PhysicsBody3D(PhysicsServer3D::BODY_MODE_RIGID) {
 	PhysicsServer3D::get_singleton()->body_set_force_integration_callback(get_rid(), this, "_direct_state_changed");
+	// Enable the contact monitor by default.
+	// This has a small performance impact, but it results in better usability, especially for beginners.
+	// The user will need to increase `max_contacts_reported` above 0 to get information about contacts.
+	set_contact_monitor(true);
 }
 
 RigidBody3D::~RigidBody3D() {

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -128,7 +128,7 @@ protected:
 	bool sleeping = false;
 	bool ccd = false;
 
-	int max_contacts_reported = 0;
+	int max_contacts_reported = 1;
 
 	bool custom_integrator = false;
 


### PR DESCRIPTION
This results in better usability out of the box at a small performance cost.

`max_contacts_reported` was also increased to 1 by default to make the contact monitor useful out of the box.

This closes https://github.com/godotengine/godot-proposals/issues/1019.