### PR TITLE
Fix 3D selection box size for Node3D

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3660,9 +3660,9 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos) const 
 AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, bool p_exclude_top_level_transform) {
 	AABB bounds;
 
-	const MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(p_parent);
-	if (mesh_instance) {
-		bounds = mesh_instance->get_aabb();
+	const VisualInstance3D *visual_instance = Object::cast_to<VisualInstance3D>(p_parent);
+	if (visual_instance) {
+		bounds = visual_instance->get_aabb();
 	}
 
 	for (int i = 0; i < p_parent->get_child_count(); i++) {


### PR DESCRIPTION
When calculating the bounding box for `Node3D` nodes, only AABB of child `MeshInstance3D` nodes are considered. So the size of selection box may be different from selecting child nodes directly (which uses the AABB of any `VisualInstance3D`).

https://github.com/godotengine/godot/blob/d540875bc0b2c436c2fae1ce410801db074437d9/editor/plugins/node_3d_editor_plugin.cpp#L2445-L2446

For example, selecting the parent `Node3D` node of `CSGPolygon` shows a default small selection box:

![before](https://user-images.githubusercontent.com/372476/114295775-e4ac2600-9ad9-11eb-82ed-fd2226bb4132.png)

after this PR, the selection box is the same size of selecting the `CSGPolygon` node directly:

![after](https://user-images.githubusercontent.com/372476/114295790-f7bef600-9ad9-11eb-8633-1d07f1ea5e23.png)

p.s. This also applies to the 3.x branch (7a9c14e276)