### PR TITLE
Fix doc theme not changing when its changed via settings

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1593,7 +1593,7 @@ void EditorHelp::_notification(int p_what) {
 			_update_doc();
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			if (is_visible_in_tree()) {
+			if (is_inside_tree()) {
 				_class_desc_resized();
 			}
 		} break;


### PR DESCRIPTION
When multiple doc help pages are opened their themes sometimes do not change after the user changes the global theme. Demo: ![doc_bug](https://user-images.githubusercontent.com/3036176/114300677-29c85c00-9aca-11eb-8436-301521b51519.gif)

