### PR TITLE
Add colors to TextureRegion editor guide lines

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -410,9 +410,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("box_selection_fill_color", "Editor", accent_color * Color(1, 1, 1, 0.3));
 	theme->set_color("box_selection_stroke_color", "Editor", accent_color * Color(1, 1, 1, 0.8));
 
-	theme->set_color("axis_x_color", "Editor", Color(0.96, 0.20, 0.32));
-	theme->set_color("axis_y_color", "Editor", Color(0.53, 0.84, 0.01));
-	theme->set_color("axis_z_color", "Editor", Color(0.16, 0.55, 0.96));
+	const Color axis_x_color = Color(0.96, 0.20, 0.32);
+	const Color axis_y_color = Color(0.53, 0.84, 0.01);
+	const Color axis_z_color = Color(0.16, 0.55, 0.96);
+
+	theme->set_color("axis_x_color", "Editor", axis_x_color);
+	theme->set_color("axis_y_color", "Editor", axis_y_color);
+	theme->set_color("axis_z_color", "Editor", axis_z_color);
 
 	theme->set_color("font_color", "Editor", font_color);
 	theme->set_color("highlighted_font_color", "Editor", font_hover_color);
@@ -1285,6 +1289,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("picker_cursor", "ColorPicker", theme->get_icon("PickerCursor", "EditorIcons"));
 
 	theme->set_icon("bg", "ColorPickerButton", theme->get_icon("GuiMiniCheckerboard", "EditorIcons"));
+
+	// Texture Region Editor
+	theme->set_color("base_line_color", "TextureRegionEditor", mono_color);
+	theme->set_color("v_line_color", "TextureRegionEditor", axis_x_color);
+	theme->set_color("h_line_color", "TextureRegionEditor", axis_y_color);
 
 	// Information on 3D viewport
 	Ref<StyleBoxFlat> style_info_3d_viewport = style_default->duplicate();

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -40,21 +40,21 @@
 	@author Mariano Suligoy
 */
 
-void draw_margin_line(Control *edit_draw, Vector2 from, Vector2 to) {
-	Vector2 line = (to - from).normalized() * 10;
+void draw_margin_line(Control *edit_draw, Vector2 from, Vector2 to, Color line_color, int line_factor) {
+	Vector2 line = (to - from).normalized() * line_factor;
 
 	// Draw a translucent background line to make the foreground line visible on any background.
 	edit_draw->draw_line(
 			from,
 			to,
-			EditorNode::get_singleton()->get_theme_base()->get_theme_color("mono_color", "Editor").inverted() * Color(1, 1, 1, 0.5),
+			EditorNode::get_singleton()->get_theme_base()->get_theme_color("base_line_color", "TextureRegionEditor").inverted() * Color(1, 1, 1, 0.5),
 			Math::round(2 * EDSCALE));
 
 	while ((to - from).length_squared() > 200) {
 		edit_draw->draw_line(
 				from,
 				from + line,
-				EditorNode::get_singleton()->get_theme_base()->get_theme_color("mono_color", "Editor"),
+				line_color,
 				Math::round(2 * EDSCALE));
 
 		from += line * 2;
@@ -175,7 +175,9 @@ void TextureRegionEditor::_region_draw() {
 		mtx.basis_xform(raw_endpoints[2]),
 		mtx.basis_xform(raw_endpoints[3])
 	};
-	Color color = get_theme_color("mono_color", "Editor");
+
+	Color h_line_color = EditorNode::get_singleton()->get_theme_base()->get_theme_color("h_line_color", "TextureRegionEditor");
+	Color v_line_color = EditorNode::get_singleton()->get_theme_base()->get_theme_color("v_line_color", "TextureRegionEditor");
 	for (int i = 0; i < 4; i++) {
 		int prev = (i + 3) % 4;
 		int next = (i + 1) % 4;
@@ -183,7 +185,12 @@ void TextureRegionEditor::_region_draw() {
 		Vector2 ofs = ((endpoints[i] - endpoints[prev]).normalized() + ((endpoints[i] - endpoints[next]).normalized())).normalized();
 		ofs *= Math_SQRT2 * (select_handle->get_size().width / 2);
 
-		edit_draw->draw_line(endpoints[i] - draw_ofs * draw_zoom, endpoints[next] - draw_ofs * draw_zoom, color, 2);
+		Color line_color = (i % 2 ? v_line_color : h_line_color);
+		if (i == 0 || i == 3) {
+			line_color = line_color.lightened(0.54);
+		}
+
+		edit_draw->draw_line(endpoints[i] - draw_ofs * draw_zoom, endpoints[next] - draw_ofs * draw_zoom, line_color, 2);
 
 		if (snap_mode != SNAP_AUTOSLICE) {
 			edit_draw->draw_texture(select_handle, (endpoints[i] + ofs - (select_handle->get_size() / 2)).floor() - draw_ofs * draw_zoom);
@@ -256,10 +263,10 @@ void TextureRegionEditor::_region_draw() {
 			-mtx.basis_xform(Vector2(margins[3], 0)) + Vector2(endpoints[2].x - draw_ofs.x * draw_zoom, 0)
 		};
 
-		draw_margin_line(edit_draw, pos[0], pos[0] + Vector2(edit_draw->get_size().x, 0));
-		draw_margin_line(edit_draw, pos[1], pos[1] + Vector2(edit_draw->get_size().x, 0));
-		draw_margin_line(edit_draw, pos[2], pos[2] + Vector2(0, edit_draw->get_size().y));
-		draw_margin_line(edit_draw, pos[3], pos[3] + Vector2(0, edit_draw->get_size().y));
+		draw_margin_line(edit_draw, pos[0], pos[0] + Vector2(edit_draw->get_size().x, 0), h_line_color.lightened(0.54), 7);
+		draw_margin_line(edit_draw, pos[1], pos[1] + Vector2(edit_draw->get_size().x, 0), h_line_color, 10);
+		draw_margin_line(edit_draw, pos[2], pos[2] + Vector2(0, edit_draw->get_size().y), v_line_color.lightened(0.54), 7);
+		draw_margin_line(edit_draw, pos[3], pos[3] + Vector2(0, edit_draw->get_size().y), v_line_color, 10);
 	}
 }
 


### PR DESCRIPTION
Currently TextureRegion editor allows guide lines to be swapped, so that left line is to the right of the right one and top line is to the bottom of the bottom line. This can happen accidentally and quite easily as you drag to draw the shape for the region. Due to the use of only a single, white color the problem is impossible to determine at a glance. It is only evident that something is wrong from the fact that the resulting texture is broken:

[Here's how it looks now](https://user-images.githubusercontent.com/11782833/114308785-a3be0c80-9aed-11eb-8982-3863660ffb2a.png)

This PR adds color to horizontal and vertical guide lines, matching X and Y axis colors, with top and left lines being a bit lighter than their counterparts. The colors from the dashed guides much the colors of the region box, so this can hopefully demonstrate the user where exactly the problem lies and help them to quickly fix it.

[Here's how it may look](https://user-images.githubusercontent.com/11782833/114308828-d10aba80-9aed-11eb-96c0-01f991a89a7a.png)

-----
*Edit: Made "begin" and "end" lines use different length dashes as proposed, see below.*

~This may still provide a challenge for colorblind folk. To that end I can propose making dashed lines use different dash lengths. Or maybe there is some other solution. But as the current state of the editor is not colorblind friendly anyway, this can be fixed with a later PR with a bit more thought put into it.~