### PR TITLE
Allow selecting frames by holding down the mouse in SpriteFrames editor

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -87,6 +87,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	Button *split_sheet_zoom_in;
 	EditorFileDialog *file_split_sheet;
 	Set<int> frames_selected;
+	Set<int> frames_toggled_by_mouse_hover;
 	int last_frame_selected;
 
 	float scale_ratio;


### PR DESCRIPTION
This complements the existing (Ctrl +) Shift + Left mouse button multiple frame (de)selection.

This closes https://github.com/godotengine/godot-proposals/issues/2252.

**Testing project:** [test_sprite_frames_editor.zip](https://github.com/godotengine/godot/files/6292286/test_sprite_frames_editor.zip)

## Preview

https://user-images.githubusercontent.com/180032/114313622-72e2d500-9af7-11eb-96cc-bde96c65d28d.mp4

