### PR TITLE
Fix type argument in is_builtin which was treated as an address

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -391,7 +391,7 @@ void GDScriptByteCodeGenerator::write_type_test(const Address &p_target, const A
 }
 
 void GDScriptByteCodeGenerator::write_type_test_builtin(const Address &p_target, const Address &p_source, Variant::Type p_type) {
-	append(GDScriptFunction::OPCODE_IS_BUILTIN, 3);
+	append(GDScriptFunction::OPCODE_IS_BUILTIN, 2);
 	append(p_source);
 	append(p_target);
 	append(p_type);


### PR DESCRIPTION
Closes #47777

The bug happens with the IS_BUILTIN operator (example: `myVar is RID`)

When gdscript_vm.cpp was reading the bytecode, the third argument  p_type (RID in the example) was treated as an argument address but in fact was Variant::Type.
By changing the code generator, only p_source and p_target are treated as variant address, and p_type is treated further down in gdscript_vm.cpp:
`Variant::Type var_type = (Variant::Type)_code_ptr[ip + 3];`