### PR TITLE
Fix `_File::get_buffer` length always set to p_length

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1334,7 +1334,7 @@ Vector<uint8_t> _File::get_buffer(int p_length) const {
 	ERR_FAIL_COND_V(len < 0, Vector<uint8_t>());
 
 	if (len < p_length) {
-		data.resize(p_length);
+		data.resize(len);
 	}
 
 	return data;


### PR DESCRIPTION
supersedes #47810 as I forgot to check out onto a new branch. 🤦 