### PR TITLE
Add a FPS limit applied when the project window is unfocused or minimized

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -271,6 +271,14 @@
 		<member name="application/run/main_scene" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to the main scene file that will be loaded when the project runs.
 		</member>
+		<member name="application/run/max_fps_when_unfocused" type="int" setter="" getter="" default="10">
+			If set to a value above [code]0[/code], applies a FPS limit while the project window is unfocused. The default value is optimized to reduce power usage while the project window is unfocused at the cost of smoothness. Since minimizing the window will consider the window as unfocused, this FPS limit also applies when the project window is minimized.
+			Set [member debug/settings/fps/force_fps] to value above [code]0[/code] to apply a FPS limit while the window is focused.
+			[b]Note:[/b] Changes to this setting will be applied when the window is unfocused for the next time.
+		</member>
+		<member name="application/run/max_fps_when_unfocused.editor" type="int" setter="" getter="" default="0">
+			Editor override to avoid interfering with profiling tools when running the project from the editor. The default value disables the FPS limit when the project window is unfocused.
+		</member>
 		<member name="audio/buses/channel_disable_threshold_db" type="float" setter="" getter="" default="-60.0">
 			Audio buses will disable automatically when sound goes below a given dB threshold for a given time. This saves CPU as effects assigned to that bus will no longer do any processing.
 		</member>
@@ -431,9 +439,10 @@
 			Message to be displayed before the backtrace when the engine crashes.
 		</member>
 		<member name="debug/settings/fps/force_fps" type="int" setter="" getter="" default="0">
-			Maximum number of frames per second allowed. The actual number of frames per second may still be below this value if the game is lagging.
-			If [member display/window/vsync/vsync_mode] is set to [code]Enabled[/code] or [code]Adaptive[/code], it takes precedence and the forced FPS number cannot exceed the monitor's refresh rate. See also [member physics/common/physics_ticks_per_second].
+			If set to a value above [code]0[/code], limits the maximum number of frames per second allowed. The actual number of frames per second may still be below this value if the game is lagging. See also [member physics/common/physics_ticks_per_second].
+			If [member display/window/vsync/vsync_mode] is set to [code]Enabled[/code] or [code]Adaptive[/code], it takes precedence and the forced FPS number cannot exceed the monitor's refresh rate.
 			This setting is therefore mostly relevant for lowering the maximum FPS below VSync, e.g. to perform non-real-time rendering of static frames, or test the project under lag conditions.
+			See also [member application/run/max_fps_when_unfocused], which limits FPS when the project window is unfocused (and is enabled by default).
 			[b]Note:[/b] This property is only read when the project starts. To change the rendering FPS cap at runtime, set [member Engine.target_fps] instead.
 		</member>
 		<member name="debug/settings/gdscript/max_call_stack" type="int" setter="" getter="" default="1024">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1477,6 +1477,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					PROPERTY_HINT_RANGE,
 					"0,33200,1,or_greater")); // No negative numbers
 
+	GLOBAL_DEF("application/run/max_fps_when_unfocused", 10);
+	ProjectSettings::get_singleton()->set_custom_property_info("application/run/max_fps_when_unfocused",
+			PropertyInfo(Variant::INT,
+					"application/run/max_fps_when_unfocused",
+					PROPERTY_HINT_RANGE,
+					"0,120,1,or_greater")); // No negative numbers
+	// Disable FPS limit when unfocused when the project is run from the editor.
+	// This avoids interfering with performance profilers.
+	GLOBAL_DEF("application/run/max_fps_when_unfocused.editor", 0);
+
 	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
 	GLOBAL_DEF("input_devices/pointing/ios/touch_delay", 0.150);
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -612,14 +612,34 @@ void SceneTree::_notification(int p_notification) {
 				get_root()->propagate_notification(p_notification);
 			}
 		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_IN: {
+			// If the unfocused FPS limit is set to 0, don't restore it at all. Otherwise,
+			// an user-applied FPS limit would be set back to the `force_fps` value when the project window is refocused.
+			if (!Engine::get_singleton()->is_editor_hint() && int(GLOBAL_GET("application/run/max_fps_when_unfocused")) >= 1) {
+				// Restore the previous FPS limit.
+				Engine::get_singleton()->set_target_fps(previous_target_fps);
+			}
+
+			get_root()->propagate_notification(p_notification);
+		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			// If the unfocused FPS limit is set to 0, don't apply it at all. Otherwise,
+			// an user-applied FPS limit would be removed while the project window is unfocused.
+			if (!Engine::get_singleton()->is_editor_hint() && int(GLOBAL_GET("application/run/max_fps_when_unfocused")) >= 1) {
+				// Apply a FPS limit to reduce power usage while the window is unfocused
+				// (or minimized, since the window is considered to be unfocused when minimized).
+				previous_target_fps = Engine::get_singleton()->get_target_fps();
+				Engine::get_singleton()->set_target_fps(int(GLOBAL_GET("application/run/max_fps_when_unfocused")));
+			}
+
+			get_root()->propagate_notification(p_notification);
+		} break;
 		case NOTIFICATION_OS_MEMORY_WARNING:
 		case NOTIFICATION_OS_IME_UPDATE:
 		case NOTIFICATION_WM_ABOUT:
 		case NOTIFICATION_CRASH:
 		case NOTIFICATION_APPLICATION_RESUMED:
-		case NOTIFICATION_APPLICATION_PAUSED:
-		case NOTIFICATION_APPLICATION_FOCUS_IN:
-		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+		case NOTIFICATION_APPLICATION_PAUSED: {
 			get_root()->propagate_notification(p_notification); //pass these to nodes, since they are mirrored
 		} break;
 
@@ -1322,6 +1342,8 @@ SceneTree::SceneTree() {
 	GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
 
 	Math::randomize();
+
+	previous_target_fps = GLOBAL_GET("debug/settings/fps/force_fps");
 
 	// Create with mainloop.
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -113,6 +113,7 @@ private:
 	StringName node_renamed_name = "node_renamed";
 
 	int64_t current_frame = 0;
+	int previous_target_fps = 0;
 	int node_count = 0;
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
This helps decrease power usage while the project window is unfocused or minimized.

The default FPS limit is 10[^1]. It can be disabled by setting the `application/run/max_fps_when_unfocused` project setting to 0.
The FPS limit is disabled by default when running the project from the editor to avoid interfering with profiling tools.

This closes https://github.com/godotengine/godot-proposals/issues/2001 and closes https://github.com/godotengine/godot/issues/19741.

[^1]: I've decided to go with 10 instead of 20, because 20 doesn't result in sufficient power savings on low-end machines that already struggle with rendering projects at 30-40 FPS.

This PR can be remade for the `3.x` branch if we reach an agreement on it.

**Testing project:** [test_fps_limit.zip](https://github.com/godotengine/godot/files/6292835/test_fps_limit.zip)