### PR TITLE
Do not change scene on save when debugging

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -526,6 +526,10 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 }
 
 void SceneTreeEditor::_node_renamed(Node *p_node) {
+	if (!get_scene_node()->is_ancestor_of(p_node)) {
+		return;
+	}
+
 	emit_signal("node_renamed");
 
 	if (!tree_dirty) {


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/33409
Fix https://github.com/godotengine/godot/issues/47861

Aka: Do not update scene tree dock when node edited outside of it

It would be **incredible** to get this in 3.3, but seeing as we're already in RC8 that is unlikely. Just saying this would save dozens of peoples' sanity when they're already in their most dangerous place: **debugging**

---

Reproduction (Thanks for suggesting, KoBeWi)
- Add this code to any node:
```py
  func _process(delta):
  	pass
  ```

- Start debugging scene
- Select any canvas item in the scene
- Switch back to script tab
- Save