### PR TITLE
Improve crash handler message display

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -32,6 +32,8 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
+#include "core/version.h"
+#include "core/version_hash.gen.h"
 #include "main/main.h"
 
 #ifdef DEBUG_ENABLED
@@ -61,12 +63,19 @@ static void handle_crash(int sig) {
 	}
 
 	// Dump the backtrace to stderr with a message to the user
+	fprintf(stderr, "\n================================================================\n");
 	fprintf(stderr, "%s: Program crashed with signal %d\n", __FUNCTION__, sig);
 
 	if (OS::get_singleton()->get_main_loop()) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
 	}
 
+	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
+	if (String(VERSION_HASH).length() != 0) {
+		fprintf(stderr, "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n");
+	} else {
+		fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
+	}
 	fprintf(stderr, "Dumping the backtrace. %s\n", msg.utf8().get_data());
 	char **strings = backtrace_symbols(bt_buffer, size);
 	if (strings) {
@@ -115,6 +124,7 @@ static void handle_crash(int sig) {
 		free(strings);
 	}
 	fprintf(stderr, "-- END OF BACKTRACE --\n");
+	fprintf(stderr, "================================================================\n");
 
 	// Abort to pass the error to the OS
 	abort();

--- a/platform/osx/crash_handler_osx.mm
+++ b/platform/osx/crash_handler_osx.mm
@@ -32,6 +32,8 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
+#include "core/version.h"
+#include "core/version_hash.gen.h"
 #include "main/main.h"
 
 #include <string.h>
@@ -85,11 +87,18 @@ static void handle_crash(int sig) {
 	}
 
 	// Dump the backtrace to stderr with a message to the user
+	fprintf(stderr, "\n================================================================\n");
 	fprintf(stderr, "%s: Program crashed with signal %d\n", __FUNCTION__, sig);
 
 	if (OS::get_singleton()->get_main_loop())
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
 
+	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
+	if (String(VERSION_HASH).length() != 0) {
+		fprintf(stderr, "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n");
+	} else {
+		fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
+	}
 	fprintf(stderr, "Dumping the backtrace. %s\n", msg.utf8().get_data());
 	char **strings = backtrace_symbols(bt_buffer, size);
 	if (strings) {
@@ -148,6 +157,7 @@ static void handle_crash(int sig) {
 		free(strings);
 	}
 	fprintf(stderr, "-- END OF BACKTRACE --\n");
+	fprintf(stderr, "================================================================\n");
 
 	// Abort to pass the error to the OS
 	abort();

--- a/platform/windows/crash_handler_windows.cpp
+++ b/platform/windows/crash_handler_windows.cpp
@@ -32,6 +32,8 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
+#include "core/version.h"
+#include "core/version_hash.gen.h"
 #include "main/main.h"
 
 #ifdef CRASH_HANDLER_EXCEPTION
@@ -127,6 +129,7 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 		return EXCEPTION_CONTINUE_SEARCH;
 	}
 
+	fprintf(stderr, "\n================================================================\n");
 	fprintf(stderr, "%s: Program crashed\n", __FUNCTION__);
 
 	if (OS::get_singleton()->get_main_loop())
@@ -175,6 +178,12 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 		msg = proj_settings->get("debug/settings/crash_handler/message");
 	}
 
+	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
+	if (String(VERSION_HASH).length() != 0) {
+		fprintf(stderr, "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n");
+	} else {
+		fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
+	}
 	fprintf(stderr, "Dumping the backtrace. %s\n", msg.utf8().get_data());
 
 	int n = 0;
@@ -200,6 +209,7 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	} while (frame.AddrReturn.Offset != 0 && n < 256);
 
 	fprintf(stderr, "-- END OF BACKTRACE --\n");
+	fprintf(stderr, "================================================================\n");
 
 	SymCleanup(process);
 


### PR DESCRIPTION
Can be merged independently of https://github.com/godotengine/godot/pull/33505.

- State the Godot version and full hash in the backtrace.
  - Knowing the exact hash is important because source code backtraces depend on the source code version to be accurate.
- Add decoration around the crash backtrace, both to make it stand out from other messages and help the user figure out what they should copy.

I got the idea to implement this while looking at the comments here: https://github.com/godotengine/godot/issues/47732#issuecomment-817558712

## Preview

### Before

```
ERROR: Testing crash handler with CRASH_NOW_MSG
   at: ProjectManager (editor/project_manager.cpp:2379)
handle_crash: Program crashed with signal 4
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /lib64/libc.so.6(+0x3da60) [0x7fa094eeaa60] (??:0)
[2] ProjectManager::ProjectManager() (/home/hugo/Documents/Git/godotengine/godot/editor/project_manager.cpp:2379)
[3] Main::start() (/home/hugo/Documents/Git/godotengine/godot/main/main.cpp:2363)
[4] bin/godot.linuxbsd.tools.64.llvm(main+0x1b2) [0x4765822] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/godot_linuxbsd.cpp:57)
[5] /lib64/libc.so.6(__libc_start_main+0xf2) [0x7fa094ed51e2] (??:0)
[6] bin/godot.linuxbsd.tools.64.llvm(_start+0x2e) [0x47655ae] (??:?)
-- END OF BACKTRACE --
[1]    100306 IOT instruction (core dumped)  bin/godot.linuxbsd.tools.64.llvm
```

### After

```
ERROR: Testing crash handler with CRASH_NOW_MSG
   at: ProjectManager (editor/project_manager.cpp:2379)

================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v4.0.dev.custom_build (4e8b67a0d186e39a8e64366ac05a2d6a3df0c2ff)
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /lib64/libc.so.6(+0x3da60) [0x7f30fc2e7a60] (??:0)
[2] ProjectManager::ProjectManager() (/home/hugo/Documents/Git/godotengine/godot/editor/project_manager.cpp:2379)
[3] Main::start() (/home/hugo/Documents/Git/godotengine/godot/main/main.cpp:2363)
[4] bin/godot.linuxbsd.tools.64.llvm(main+0x1b2) [0x4765822] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/godot_linuxbsd.cpp:57)
[5] /lib64/libc.so.6(__libc_start_main+0xf2) [0x7f30fc2d21e2] (??:0)
[6] bin/godot.linuxbsd.tools.64.llvm(_start+0x2e) [0x47655ae] (??:?)
-- END OF BACKTRACE --
================================================================
[1]    95589 IOT instruction (core dumped)  bin/godot.linuxbsd.tools.64.llvm
```