### PR TITLE
Add "process while paused" option to VideoPlayer

### DIFF
--- a/doc/classes/VideoPlayer.xml
+++ b/doc/classes/VideoPlayer.xml
@@ -69,6 +69,9 @@
 		<member name="paused" type="bool" setter="set_paused" getter="is_paused" default="false">
 			If [code]true[/code], the video is paused.
 		</member>
+		<member name="process_while_paused" type="bool" setter="set_process_while_paused" getter="is_processing_while_paused" default="false">
+			If [code]true[/code], continues processing the video stream even when [member paused] is [code]true[/code], this allows to seek to different parts of the video while paused.
+		</member>
 		<member name="stream" type="VideoStream" setter="set_stream" getter="get_stream">
 			The assigned video stream. See description for supported formats.
 		</member>

--- a/scene/gui/video_player.h
+++ b/scene/gui/video_player.h
@@ -60,6 +60,7 @@ class VideoPlayer : public Control {
 	int wait_resampler_limit = 2;
 
 	bool paused = false;
+	bool process_while_paused = false;
 	bool autoplay = false;
 	float volume = 1.0;
 	double last_audio_time = 0.0;
@@ -96,6 +97,9 @@ public:
 
 	void set_paused(bool p_paused);
 	bool is_paused() const;
+
+	void set_process_while_paused(bool p_process_while_paused);
+	bool is_processing_while_paused() const;
 
 	void set_volume(float p_vol);
 	float get_volume() const;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This adds the possibility of seeking to different parts of the video stream while the VideoPlayer is paused, this is particularly useful for custom tools or games that need to seek to a specific location without having the game continue playing from it, which requires some ugly hacks currently (check https://github.com/EIRTeam/godot-videodecoder/blob/master/src/gdnative_videodecoder.c#L904 for the workarounds necessary to make this happen without this feature).