### PR TITLE
Fix crashes with CollisionObject3D debug shapes

### DIFF
--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -62,6 +62,7 @@ class CollisionObject3D : public Node3D {
 	bool ray_pickable = true;
 
 	Set<uint32_t> debug_shapes_to_update;
+	int debug_shape_count = 0;
 
 	void _update_pickable();
 
@@ -78,6 +79,7 @@ protected:
 	virtual void _mouse_exit();
 
 	void _update_debug_shapes();
+	void _clear_debug_shapes();
 
 public:
 	uint32_t create_shape_owner(Object *p_owner);


### PR DESCRIPTION
`MeshInstance` nodes added as child nodes for `CollisionObject3D` debug shapes can be invalidated while deleting the collision object (child nodes are deleted first), which caused accesses to invalid memory in `shape_owner_remove_shape` that lead to random crashes.

Also optimized accesses to shapes to avoid copy-on-write on each iteration.

Regression from #45783
