### PR TITLE
[3.x] Fix crashes with CollisionObject debug shapes

### DIFF
--- a/scene/3d/collision_object.h
+++ b/scene/3d/collision_object.h
@@ -69,6 +69,7 @@ class CollisionObject : public Spatial {
 	bool ray_pickable;
 
 	Set<uint32_t> debug_shapes_to_update;
+	int debug_shape_count = 0;
 
 	void _update_pickable();
 
@@ -85,6 +86,7 @@ protected:
 	virtual void _mouse_exit();
 
 	void _update_debug_shapes();
+	void _clear_debug_shapes();
 
 public:
 	uint32_t create_shape_owner(Object *p_owner);


### PR DESCRIPTION
`MeshInstance` nodes added as child nodes for `CollisionObject` debug shapes can be invalidated while deleting the collision object (child nodes are deleted first), which caused accesses to invalid memory in `shape_owner_remove_shape` that lead to random crashes.

Also optimized accesses to shapes to avoid copy-on-write on each iteration.

Regression from #46397

3.x backport of #47848