### PR TITLE
etcpak: Fix handling of pthread naming API for Linux and MinGW

### DIFF
--- a/thirdparty/etcpak/System.cpp
+++ b/thirdparty/etcpak/System.cpp
@@ -2,7 +2,6 @@
 #ifdef _WIN32
 #  include <windows.h>
 #else
-#  include <pthread.h>
 #  include <unistd.h>
 #endif
 
@@ -62,7 +61,5 @@ void System::SetThreadName( std::thread& thread, const char* name )
     __except(EXCEPTION_EXECUTE_HANDLER)
     {
     }
-#elif !defined(__APPLE__)
-    pthread_setname_np( thread.native_handle(), name );
 #endif
 }

--- a/thirdparty/etcpak/patches/pthread-setname.patch
+++ b/thirdparty/etcpak/patches/pthread-setname.patch
@@ -1,0 +1,66 @@
+diff --git a/thirdparty/etcpak/System.cpp b/thirdparty/etcpak/System.cpp
+index 1383d0ecd0..041f2676e8 100644
+--- a/thirdparty/etcpak/System.cpp
++++ b/thirdparty/etcpak/System.cpp
+@@ -2,7 +2,6 @@
+ #ifdef _WIN32
+ #  include <windows.h>
+ #else
+-#  include <pthread.h>
+ #  include <unistd.h>
+ #endif
+ 
+@@ -35,7 +34,7 @@ unsigned int System::CPUCores()
+ 
+ void System::SetThreadName( std::thread& thread, const char* name )
+ {
+-#ifdef _WIN32
++#ifdef _MSC_VER
+     const DWORD MS_VC_EXCEPTION=0x406D1388;
+ 
+ #  pragma pack( push, 8 )
+@@ -62,7 +61,5 @@ void System::SetThreadName( std::thread& thread, const char* name )
+     __except(EXCEPTION_EXECUTE_HANDLER)
+     {
+     }
+-#elif !defined(__APPLE__)
+-    pthread_setname_np( thread.native_handle(), name );
+ #endif
+ }
+diff --git a/thirdparty/etcpak/TaskDispatch.cpp b/thirdparty/etcpak/TaskDispatch.cpp
+index 7287da4de2..b1ba17953b 100644
+--- a/thirdparty/etcpak/TaskDispatch.cpp
++++ b/thirdparty/etcpak/TaskDispatch.cpp
+@@ -1,5 +1,8 @@
+ #include <assert.h>
+ #include <stdio.h>
++#ifndef _MSC_VER
++#include <pthread.h>
++#endif
+ 
+ #include "Debug.hpp"
+ #include "System.hpp"
+@@ -22,15 +25,19 @@ TaskDispatch::TaskDispatch( size_t workers )
+     {
+         char tmp[16];
+         sprintf( tmp, "Worker %zu", i );
+-#ifdef __APPLE__
++#ifdef _MSC_VER
++        auto worker = std::thread( [this]{ Worker(); } );
++        System::SetThreadName( worker, tmp );
++#else // Using pthread.
+         auto worker = std::thread( [this, tmp]{
++#ifdef __APPLE__
+             pthread_setname_np( tmp );
++#else // Linux or MinGW.
++            pthread_setname_np( pthread_self(), tmp );
++#endif
+             Worker();
+         } );
+-#else
+-        auto worker = std::thread( [this]{ Worker(); } );
+ #endif
+-        System::SetThreadName( worker, tmp );
+         m_workers.emplace_back( std::move( worker ) );
+     }
+ 

--- a/thirdparty/etcpak/patches/windows-mingw-bswap.patch
+++ b/thirdparty/etcpak/patches/windows-mingw-bswap.patch
@@ -48,16 +48,3 @@ index 220d5c55e2..9dc5a78b67 100644
  #endif
  
  #ifndef _bswap
-diff --git a/thirdparty/etcpak/System.cpp b/thirdparty/etcpak/System.cpp
-index 1383d0ecd0..a09b289cb2 100644
---- a/thirdparty/etcpak/System.cpp
-+++ b/thirdparty/etcpak/System.cpp
-@@ -35,7 +35,7 @@ unsigned int System::CPUCores()
- 
- void System::SetThreadName( std::thread& thread, const char* name )
- {
--#ifdef _WIN32
-+#ifdef _MSC_VER
-     const DWORD MS_VC_EXCEPTION=0x406D1388;
- 
- #  pragma pack( push, 8 )


### PR DESCRIPTION
For MinGW this is tricky to do as a two-step process like it was implemented,
as `std:thread:native_handle()` is implementation-defined and depending on
the MinGW distribution, it may or may not be a pthread handle.

With mingw-gcc as packaged in Linux distros with pthread support it worked
fine, but with llvm-mingw it was problematic.

Setting the name in the thread directly as done for Apple platforms is simpler
and works fine.

Fixes https://github.com/godotengine/godot/pull/47370#issuecomment-818427939.

Builds fine with this patch against https://github.com/mstorsjo/llvm-mingw/releases/tag/20201020 (`llvm-mingw-20201020-ucrt-ubuntu-18.04.tar.xz`).