### PR TITLE
Allow warning-ignore in the same line as the respective warning

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8769,7 +8769,7 @@ Error GDScriptParser::_parse(const String &p_base_path) {
 		GDScriptWarning &w = E->get();
 		int skip_index = -1;
 		for (int i = 0; i < warning_skips.size(); i++) {
-			if (warning_skips[i].first >= w.line) {
+			if (warning_skips[i].first > w.line) {
 				break;
 			}
 			skip_index = i;


### PR DESCRIPTION
This patch allows putting `warning-ignore` comments in the same line as the respective warning itself.

```gdscript
# warning-ignore: return_value_discarded
connect("tree_entered", self, "_tree_entered")

# This works now, too
connect("tree_entered", self, "_tree_entered")  # warning-ignore: return_value_discarded
```

I can't think of any particular reason the latter shouldn't be allowed.
It should be up to the programmer to decide where to put their comments.
Personally, and I'm sure I'm not the only one, I find the latter more readable as it doesn't visually interrupt the actual code.

I took a look at the source and saw that this fix only requires a `>=` to be changed to `>`, so this is a very simple fix for slightly more flexibility.
As for the master branch, I couldn't find any code related to honoring `warning-ignore` at all, so this fix is only for 3.x versions.
