### PR TITLE
Add buffer orphan / stream options

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1034,6 +1034,22 @@
 			Fix to improve physics jitter, specially on monitors where refresh rate is different than the physics FPS.
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_jitter_fix] instead.
 		</member>
+		<member name="rendering/2d/opengl/batching_send_null" type="int" setter="" getter="" default="0">
+			[b]Experimental[/b] Calls [code]glBufferData[/code] with NULL data prior to uploading batching data. This may not be necessary but can be used for safety.
+			[b]Note:[/b] Use with care. You are advised to leave this as default for exports. A non-default setting that works better on your machine may adversely affect performance for end users.
+		</member>
+		<member name="rendering/2d/opengl/batching_stream" type="int" setter="" getter="" default="0">
+			[b]Experimental[/b] If set to on, uses the [code]GL_STREAM_DRAW[/code] flag for batching buffer uploads. If off, uses the [code]GL_DYNAMIC_DRAW[/code] flag.
+			[b]Note:[/b] Use with care. You are advised to leave this as default for exports. A non-default setting that works better on your machine may adversely affect performance for end users.
+		</member>
+		<member name="rendering/2d/opengl/legacy_orphan_buffers" type="int" setter="" getter="" default="0">
+			[b]Experimental[/b] If set to on, this applies buffer orphaning - [code]glBufferData[/code] is called with NULL data and the full buffer size prior to uploading new data. This can be important to avoid stalling on some hardware.
+			[b]Note:[/b] Use with care. You are advised to leave this as default for exports. A non-default setting that works better on your machine may adversely affect performance for end users.
+		</member>
+		<member name="rendering/2d/opengl/legacy_stream" type="int" setter="" getter="" default="0">
+			[b]Experimental[/b] If set to on, uses the [code]GL_STREAM_DRAW[/code] flag for legacy buffer uploads. If off, uses the [code]GL_DYNAMIC_DRAW[/code] flag.
+			[b]Note:[/b] Use with care. You are advised to leave this as default for exports. A non-default setting that works better on your machine may adversely affect performance for end users.
+		</member>
 		<member name="rendering/2d/options/ninepatch_mode" type="int" setter="" getter="" default="1">
 			Choose between fixed mode where corner scalings are preserved matching the artwork, and scaling mode.
 			Not available in GLES3 when [member rendering/batching/options/use_batching] is off.

--- a/drivers/gles2/rasterizer_canvas_base_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_base_gles2.cpp
@@ -947,11 +947,18 @@ void RasterizerCanvasBaseGLES2::draw_lens_distortion_rect(const Rect2 &p_rect, f
 
 void RasterizerCanvasBaseGLES2::initialize() {
 
-	bool flag_stream = false;
-	if (flag_stream)
-		_buffer_upload_usage_flag = GL_STREAM_DRAW;
-	else
-		_buffer_upload_usage_flag = GL_DYNAMIC_DRAW;
+	int flag_stream_mode = GLOBAL_GET("rendering/2d/opengl/legacy_stream");
+	switch (flag_stream_mode) {
+		default: {
+			_buffer_upload_usage_flag = GL_STREAM_DRAW;
+		} break;
+		case 1: {
+			_buffer_upload_usage_flag = GL_DYNAMIC_DRAW;
+		} break;
+		case 2: {
+			_buffer_upload_usage_flag = GL_STREAM_DRAW;
+		} break;
+	}
 
 	// quad buffer
 	{

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -6420,6 +6420,19 @@ void RasterizerStorageGLES2::initialize() {
 	GLOBAL_DEF_RST("rendering/quality/lightmapping/use_bicubic_sampling", true);
 	GLOBAL_DEF_RST("rendering/quality/lightmapping/use_bicubic_sampling.mobile", false);
 	config.use_lightmap_filter_bicubic = GLOBAL_GET("rendering/quality/lightmapping/use_bicubic_sampling");
+
+	int orphan_mode = GLOBAL_GET("rendering/2d/opengl/legacy_orphan_buffers");
+	switch (orphan_mode) {
+		default: {
+			config.should_orphan = true;
+		} break;
+		case 1: {
+			config.should_orphan = false;
+		} break;
+		case 2: {
+			config.should_orphan = true;
+		} break;
+	}
 }
 
 void RasterizerStorageGLES2::finalize() {

--- a/drivers/gles3/rasterizer_canvas_base_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_base_gles3.cpp
@@ -1137,11 +1137,17 @@ void RasterizerCanvasBaseGLES3::draw_window_margins(int *black_margin, RID *blac
 
 void RasterizerCanvasBaseGLES3::initialize() {
 
-	bool flag_stream = false;
-	if (flag_stream) {
-		_buffer_upload_usage_flag = GL_STREAM_DRAW;
-	} else {
-		_buffer_upload_usage_flag = GL_DYNAMIC_DRAW;
+	int flag_stream_mode = GLOBAL_GET("rendering/2d/opengl/legacy_stream");
+	switch (flag_stream_mode) {
+		default: {
+			_buffer_upload_usage_flag = GL_STREAM_DRAW;
+		} break;
+		case 1: {
+			_buffer_upload_usage_flag = GL_DYNAMIC_DRAW;
+		} break;
+		case 2: {
+			_buffer_upload_usage_flag = GL_STREAM_DRAW;
+		} break;
 	}
 
 	{

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5105,11 +5105,13 @@ void RasterizerStorageGLES3::update_dirty_multimeshes() {
 
 			glBindBuffer(GL_ARRAY_BUFFER, multimesh->buffer);
 			uint32_t buffer_size = multimesh->data.size() * sizeof(float);
-			if (config.should_orphan) {
-				glBufferData(GL_ARRAY_BUFFER, buffer_size, multimesh->data.ptr(), GL_DYNAMIC_DRAW);
-			} else {
-				glBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, multimesh->data.ptr());
-			}
+
+			// this could potentially have a project setting for API options as with 2d
+			// if (config.should_orphan) {
+			glBufferData(GL_ARRAY_BUFFER, buffer_size, multimesh->data.ptr(), GL_DYNAMIC_DRAW);
+			//	} else {
+			//	glBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, multimesh->data.ptr());
+			//	}
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 		}
 
@@ -8651,6 +8653,19 @@ void RasterizerStorageGLES3::initialize() {
 				config.use_depth_prepass = false;
 			}
 		}
+	}
+
+	int orphan_mode = GLOBAL_GET("rendering/2d/opengl/legacy_orphan_buffers");
+	switch (orphan_mode) {
+		default: {
+			config.should_orphan = true;
+		} break;
+		case 1: {
+			config.should_orphan = false;
+		} break;
+		case 2: {
+			config.should_orphan = true;
+		} break;
 	}
 }
 

--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -1007,6 +1007,33 @@ PREAMBLE(void)::batch_initialize() {
 	bdata.settings_use_software_skinning = GLOBAL_GET("rendering/2d/options/use_software_skinning");
 	bdata.settings_ninepatch_mode = GLOBAL_GET("rendering/2d/options/ninepatch_mode");
 
+	// allow user to override the api usage techniques using project settings
+	int send_null_mode = GLOBAL_GET("rendering/2d/opengl/batching_send_null");
+	switch (send_null_mode) {
+		default: {
+			bdata.buffer_mode_batch_upload_send_null = true;
+		} break;
+		case 1: {
+			bdata.buffer_mode_batch_upload_send_null = false;
+		} break;
+		case 2: {
+			bdata.buffer_mode_batch_upload_send_null = true;
+		} break;
+	}
+
+	int stream_mode = GLOBAL_GET("rendering/2d/opengl/batching_stream");
+	switch (stream_mode) {
+		default: {
+			bdata.buffer_mode_batch_upload_flag_stream = false;
+		} break;
+		case 1: {
+			bdata.buffer_mode_batch_upload_flag_stream = false;
+		} break;
+		case 2: {
+			bdata.buffer_mode_batch_upload_flag_stream = true;
+		} break;
+	}
+
 	// alternatively only enable uv contract if pixel snap in use,
 	// but with this enable bool, it should not be necessary
 	bdata.settings_uv_contract = GLOBAL_GET("rendering/batching/precision/uv_contract");

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2454,6 +2454,15 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF_RST("rendering/2d/options/ninepatch_mode", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/options/ninepatch_mode", PropertyInfo(Variant::INT, "rendering/2d/options/ninepatch_mode", PROPERTY_HINT_ENUM, "Fixed,Scaling"));
 
+	GLOBAL_DEF_RST("rendering/2d/opengl/batching_send_null", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/opengl/batching_send_null", PropertyInfo(Variant::INT, "rendering/2d/opengl/batching_send_null", PROPERTY_HINT_ENUM, "Default (On),Off,On"));
+	GLOBAL_DEF_RST("rendering/2d/opengl/batching_stream", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/opengl/batching_stream", PropertyInfo(Variant::INT, "rendering/2d/opengl/batching_stream", PROPERTY_HINT_ENUM, "Default (Off),Off,On"));
+	GLOBAL_DEF_RST("rendering/2d/opengl/legacy_orphan_buffers", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/opengl/legacy_orphan_buffers", PropertyInfo(Variant::INT, "rendering/2d/opengl/legacy_orphan_buffers", PROPERTY_HINT_ENUM, "Default (On),Off,On"));
+	GLOBAL_DEF_RST("rendering/2d/opengl/legacy_stream", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/opengl/legacy_stream", PropertyInfo(Variant::INT, "rendering/2d/opengl/legacy_stream", PROPERTY_HINT_ENUM, "Default (On),Off,On"));
+
 	GLOBAL_DEF("rendering/batching/options/use_batching", true);
 	GLOBAL_DEF_RST("rendering/batching/options/use_batching_in_editor", true);
 	GLOBAL_DEF("rendering/batching/options/single_rect_fallback", false);


### PR DESCRIPTION
Allows users to override default API usage, in order to get best performance on different platforms.

Ideally we would like to treat all OpenGL devices in a similar fashion, but unfortunately it seems as if the best way to use OpenGL with dynamic buffers (particularly for 2d) seems to vary on different hardware / OS / drivers.

This PR reintroduces 4 project settings to allow the user to override default settings (potentially for each platform using the project settings overrides).

![orphan_settings](https://user-images.githubusercontent.com/21999379/114594438-2927f500-9c85-11eb-958f-b8785145db33.png)

Each is settable to Default, Off or On. Having an explicit default setting allows us to improve the defaults in later releases as we gain more user feedback.

Related to #47833, #47824

### About

Without having access to a large number of devices, we have relied on limited feedback from users. We currently believe that buffer orphaning is especially useful on mobile. It may not make much difference on most desktops, however having it on, or off, may prove better or worse on some platforms, especially Mac. It is possible some Macs may suffer stalls with orphaning on, and some with orphaning off. This makes it problematic to set a default for that platform.

### Defaults
The previous defaults for Godot were to use orphaning only when `GLES_OVER_GL` was not set. We did have complaints of low performance on Macs, so have been using orphaning in all cases through the 3.3 betas. Some users are still reporting low performance that can be fixed by not using orphaning.

As we do not have the information to make a hardware database as yet, the best we can offer for now is to set the default that works in what appears to be the majority of cases (as defined by user feedback), and leave the options to set it to custom values in project settings. The consequence of users being able to override these defaults is that this will affect their exports, and they may expect what works on their machine will also work for others (which may not be the case). So we will have to make this very clear in the documentation, that changing the defaults should be done with care.

As to the default we should use for orphaning, I really have no idea. On the whole I get the impression we've had better feedback for results with orphaning defaulting to on in all cases, but we can equally well set it to the same logic we used in earlier versions (selecting by GLES_OVER_GL). These settings were exposed in some of the earlier betas, but unfortunately very few people tried them and gave feedback.

### Flags
As with orphaning, GL offers a choice, either DYNAMIC or STREAM flags, without making clear which would be best. Some users have reported better performance using STREAM flag. This flag is selectable in this PR.

See https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBufferData.xhtml for more info on flags. We use GL_DYNAMIC_DRAW (default), or GL_STREAM_DRAW if stream is switched on in the project setting. The docs are confusing. We update a buffer multiple times, and use it once per update. According to the docs we should therefore be using DYNAMIC:

> DYNAMIC
The data store contents will be modified repeatedly and used many times.
STREAM
The data store contents will be modified once and used at most a few times.

_However_, they also suggest elsewhere using stream flag with buffer orphaning, and I have a sneaking suspicion we should be changing to using this as the default:
https://www.khronos.org/opengl/wiki/Buffer_Object_Streaming

We have used DYNAMIC up till now, and had no feedback on the use of STREAM. In addition, it seems possible that some drivers detect your usage pattern and make a sensible decision irrespective of what flags you set here, there often doesn't seem to be a lot of difference. But it may be important to get right on some small set of hardware.

At this late stage for 3.3, it seems safer to keep the current default, see if we can get some feedback from the custom settings, and try STREAM as a default for one of the betas for the next Godot version.

It may turn out that we should use STREAM with orphaning, and DYNAMIC when not using orphaning.

### Other options
There are some other options for dynamic buffers - such as glMapBuffer. This is only available in core in GLES3, and via an extension in GLES2. We haven't tried this - it may be better or worse on some hardware, adding to the choice difficulty. You would *hope* that all implementations would have a decent implementation for the more basic calls. But that may or may not be the case.

Another option is the use of multiple buffers round robin style, however in our case it may not be possible because we reuse buffers multiple times per frame and rely on buffer renaming / sensible buffer handling from the driver.

## Notes
* I haven't written class reference yet, hopefully I'll get some feedback on the PR and how we should approach this area, I'm happy to change approach / welcome ideas
* Without the facilities to do systematic testing over a range of devices, this is a very difficult area, as we are mostly relying on anecdotal evidence and guesswork(!)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
