### PR TITLE
Display the mouse coordinates in the 2D editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -240,6 +240,9 @@ private:
 	Map<Control *, Timer *> popup_temporarily_timers;
 
 	Label *warning_child_of_container;
+	Label *mouse_position;
+	Timer *mouse_position_debounce;
+	Vector2 viewport_mouse_position;
 	VBoxContainer *info_overlay;
 
 	Transform2D transform;
@@ -446,6 +449,7 @@ private:
 	void _add_node_pressed(int p_result);
 	void _node_created(Node *p_node);
 	void _reset_create_position();
+	void _update_mouse_position_label();
 
 	UndoRedo *undo_redo;
 	bool _build_bones_list(Node *p_node);


### PR DESCRIPTION
The label is only updated when the mouse has stopped moving (using debouncing, not throttling).
This is because updating the label every time the mouse moves would cause the editor to redraw continuously, making it use a lot of power for no good reason. I think preserving battery life on laptops is more important than showing mouse coordinates in real-time :slightly_smiling_face:

I can add an editor setting to hide the mouse coordinates if desired.

This feature was originally requested in https://github.com/godotengine/godot/issues/6224.

## Preview

https://user-images.githubusercontent.com/180032/114599532-85921100-9c93-11eb-95a6-041d11a2422e.mp4