### PR TITLE
Export gltf2 normal textures correctly.

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3293,6 +3293,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> state) {
 				}
 				img->decompress();
 				img->convert(Image::FORMAT_RGBA8);
+				img->convert_ra_rgba8_to_rg();
 				for (int32_t y = 0; y < img->get_height(); y++) {
 					for (int32_t x = 0; x < img->get_width(); x++) {
 						Color c = img->get_pixel(x, y);


### PR DESCRIPTION
The gltf2 exported image for normals was red and alpha. This converts it to r and g so that I can process it.

Edited:

This is a series of patches to get gltf2 export better.

Not cherry pickable to 3.x since exporting requires work in a different pr.