### PR TITLE
Rename tabs in the project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2490,7 +2490,7 @@ ProjectManager::ProjectManager() {
 	tabs->connect("tab_changed", callable_mp(this, &ProjectManager::_on_tab_changed));
 
 	HBoxContainer *projects_hb = memnew(HBoxContainer);
-	projects_hb->set_name(TTR("Projects"));
+	projects_hb->set_name(TTR("Local Projects"));
 	tabs->add_child(projects_hb);
 
 	{
@@ -2672,7 +2672,7 @@ ProjectManager::ProjectManager() {
 
 	if (StreamPeerSSL::is_available()) {
 		asset_library = memnew(EditorAssetLibrary(true));
-		asset_library->set_name(TTR("Templates"));
+		asset_library->set_name(TTR("Asset Library Projects"));
 		tabs->add_child(asset_library);
 		asset_library->connect("install_asset", callable_mp(this, &ProjectManager::_install_project));
 	} else {


### PR DESCRIPTION
In the Discord discussion today, it was mentioned that the Godot Asset Library is not very visible to users.

* One of the problems is that the tab in the project manager is called "Templates". People may ignore "Templates" because they don't have any templates already and they don't realize it's a tab for downloading new projects from the Godot Asset Library. This PR renames it to "Asset Library Projects", which should be more discoverable.
* Another thing is that really both tabs are about projects, it's just that the "Projects" tab is for local projects, and "Templates" is for downloading new projects to install locally. Therefore, I renamed "Projects" to "Local Projects".

Preview:

![Screenshot from 2021-04-13 17-41-10](https://user-images.githubusercontent.com/1646875/114624960-8a4cca00-9c7f-11eb-97b8-7d98c4be2d13.png)

This is not super vital, but it's also a very simple change, so I marked it as cherry-pick for 3.3.
