### PR TITLE
Fix EditorExportPlugin  _export_begin and _export_end  functions not being called when exporting UWP 

### DIFF
--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1177,6 +1177,8 @@ public:
 	}
 
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override {
+		ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+
 		String src_appx;
 
 		EditorProgress ep("export", "Exporting for UWP", 7, true);


### PR DESCRIPTION
in uwp's version of export.cpp create a ExportNotifier object so that EditorExportPlugin _export_begin and _export_end functions will be called as documentated.

Fixes #47875