### PR TITLE
Separate set.h from map.h

### DIFF
--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -36,6 +36,7 @@
 #include "core/string/print_string.h"
 #include "core/templates/list.h"
 #include "core/templates/map.h"
+#include "core/templates/set.h"
 
 // Godot's packed file magic header ("GDPC" in ASCII).
 #define PACK_HEADER_MAGIC 0x43504447

--- a/core/templates/map.h
+++ b/core/templates/map.h
@@ -32,7 +32,7 @@
 #define MAP_H
 
 #include "core/error/error_macros.h"
-#include "core/templates/set.h"
+#include "core/os/memory.h"
 
 // based on the very nice implementation of rb-trees by:
 // https://web.archive.org/web/20120507164830/http://web.mit.edu/~emin/www/source_code/red_black_tree/index.html


### PR DESCRIPTION
Removes "unused" include for `set.h` in `map.h` and adds proper header file instead. The only place in Godot where data structure from `set.h` is used is `file_access_pack.h` and it should be included explicitly. In all other cases we are forcing preprocessor to concatenate unused code from `set.h` everywhere `map.h` is included.