### PR TITLE
[3.x] Separate set.h from map.h

### DIFF
--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -36,6 +36,7 @@
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
 #include "core/print_string.h"
+#include "core/set.h"
 
 // Godot's packed file magic header ("GDPC" in ASCII).
 #define PACK_HEADER_MAGIC 0x43504447

--- a/core/map.h
+++ b/core/map.h
@@ -32,7 +32,7 @@
 #define MAP_H
 
 #include "core/error_macros.h"
-#include "core/set.h"
+#include "core/os/memory.h"
 
 // based on the very nice implementation of rb-trees by:
 // https://web.archive.org/web/20120507164830/http://web.mit.edu/~emin/www/source_code/red_black_tree/index.html


### PR DESCRIPTION
Removes "unused" include for `set.h` in `map.h` and adds proper header file instead. The only place in Godot where data structure from `set.h` is used is `file_access_pack.h` and it should be included explicitly. In all other cases we are forcing preprocessor to concatenate unused code from `set.h` everywhere `map.h` is included.

*Edit:* `3.x` version of #47886.