### PR TITLE
Fixed ui_accept (spacebar + return) accepting auto-completion options.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3261,7 +3261,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				accept_event();
 				return;
 			}
-			if (k->is_action("ui_accept", true) || k->is_action("ui_text_completion_accept", true)) {
+			if (k->is_action("ui_text_completion_accept", true)) {
 				_confirm_completion();
 				accept_event();
 				return;


### PR DESCRIPTION
Fixes the issue outlined in comment: https://github.com/godotengine/godot/pull/43663#issuecomment-812778678