### PR TITLE
Removed optimization causing Dictionary indexing to use named get.

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -680,7 +680,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				name = subscript->attribute->name;
 				named = true;
 			} else {
-				if (subscript->index->type == GDScriptParser::Node::LITERAL && static_cast<const GDScriptParser::LiteralNode *>(subscript->index)->value.get_type() == Variant::STRING) {
+				if (subscript->index->type == GDScriptParser::Node::LITERAL && static_cast<const GDScriptParser::LiteralNode *>(subscript->index)->value.get_type() == Variant::STRING_NAME) {
 					// Also, somehow, named (speed up anyway).
 					name = static_cast<const GDScriptParser::LiteralNode *>(subscript->index)->value;
 					named = true;


### PR DESCRIPTION
Fixes #44241

Test project with script code can be found in that issue, and this fix can be verified against that example.

This removes what claims to be an optimization, but the optimization uses "named get" instead of "keyed get" or "indexed get" for this purpose. @vnen may want to look at re-adding this optimization correctly in the future.

cc @vnen @reduz 