### PR TITLE
Fix some uwp capabilities not being added to AppxManifest.xml

### DIFF
--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -812,21 +812,21 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		String capabilities_elements = "";
 		const char **basic = uwp_capabilities;
 		while (*basic) {
-			if ((bool)p_preset->get("capabilities/" + String(*basic))) {
+			if ((bool)p_preset->get("capabilities/" + String(*basic).camelcase_to_underscore(false))) {
 				capabilities_elements += "    <Capability Name=\"" + String(*basic) + "\" />\n";
 			}
 			basic++;
 		}
 		const char **uap = uwp_uap_capabilities;
 		while (*uap) {
-			if ((bool)p_preset->get("capabilities/" + String(*uap))) {
+			if ((bool)p_preset->get("capabilities/" + String(*uap).camelcase_to_underscore(false))) {
 				capabilities_elements += "    <uap:Capability Name=\"" + String(*uap) + "\" />\n";
 			}
 			uap++;
 		}
 		const char **device = uwp_device_capabilities;
 		while (*device) {
-			if ((bool)p_preset->get("capabilities/" + String(*device))) {
+			if ((bool)p_preset->get("capabilities/" + String(*device).camelcase_to_underscore(false))) {
 				capabilities_elements += "    <DeviceCapability Name=\"" + String(*device) + "\" />\n";
 			}
 			device++;

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -832,7 +832,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 			device++;
 		}
 
-		if (!((bool)p_preset->get("capabilities/internetClient")) && p_give_internet) {
+		if (!((bool)p_preset->get("capabilities/internet_Client")) && p_give_internet) {
 			capabilities_elements += "    <Capability Name=\"internetClient\" />\n";
 		}
 


### PR DESCRIPTION
In UWP Export Options any capabilities consisting of more then 1 word was not inserted into the generated AppxManifest.xml.

This was a mixup between the Windows format being camelCase like internetClient and godot options being underscore like internet_Client

Fixed by checking options for underscore version

Fixes #47900

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
