### PR TITLE
Scene: Remove unused `mesh_materials` StringNames

### DIFF
--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -190,10 +190,6 @@ SceneStringNames::SceneStringNames() {
 
 	_default = StaticCString::create("default");
 
-	for (int i = 0; i < MAX_MATERIALS; i++) {
-		mesh_materials[i] = "material/" + itos(i);
-	}
-
 	_window_group = StaticCString::create("_window_group");
 	_window_input = StaticCString::create("_window_input");
 	window_input = StaticCString::create("window_input");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -216,10 +216,6 @@ public:
 	StringName use_in_baked_light;
 	StringName use_dynamic_gi;
 #endif
-	enum {
-		MAX_MATERIALS = 32
-	};
-	StringName mesh_materials[MAX_MATERIALS];
 };
 
 #endif // SCENE_STRING_NAMES_H


### PR DESCRIPTION
They were added in 8be2fabbe5cd846bac5e5a38e55f3fb70e73f2da (2.1 era) but
were likely a first attempt that didn't get unused in the end.