### PR TITLE
Import: Cleanup and optimize etcpak compression method 

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -186,7 +186,8 @@
 			<return type="int" enum="Error">
 			</return>
 			<description>
-				Decompresses the image if it is compressed. Returns an error if decompress function is not available.
+				Decompresses the image if it is VRAM compressed in a supported format. Returns [constant OK] if the format is supported, otherwise [constant ERR_UNAVAILABLE].
+				[b]Note:[/b] The following formats can be decompressed: DXT, RGTC, BPTC, PVRTC1. The formats ETC1 and ETC2 are not supported.
 			</description>
 		</method>
 		<method name="detect_alpha" qualifiers="const">

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  image_etcpak.cpp                                                     */
+/*  image_compress_etcpak.cpp                                            */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,21 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "image_etcpak.h"
+#include "image_compress_etcpak.h"
 
-#include "core/os/copymem.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
 #include "thirdparty/etcpak/ProcessDxtc.hpp"
 #include "thirdparty/etcpak/ProcessRGB.hpp"
 
-// thresholds for the early compression-mode decision scheme in QuickETC2
-// which can be changed by the option -e
-float ecmd_threshold[3] = { 0.03f, 0.09f, 0.38f };
-
-EtcpakType _determine_etc_type(Image::UsedChannels p_source) {
-	switch (p_source) {
+EtcpakType _determine_etc_type(Image::UsedChannels p_channels) {
+	switch (p_channels) {
 		case Image::USED_CHANNELS_L:
 			return EtcpakType::ETCPAK_TYPE_ETC1;
 		case Image::USED_CHANNELS_LA:
@@ -60,8 +55,8 @@ EtcpakType _determine_etc_type(Image::UsedChannels p_source) {
 	}
 }
 
-EtcpakType _determine_dxt_type(Image::UsedChannels p_source) {
-	switch (p_source) {
+EtcpakType _determine_dxt_type(Image::UsedChannels p_channels) {
+	switch (p_channels) {
 		case Image::USED_CHANNELS_L:
 			return EtcpakType::ETCPAK_TYPE_DXT1;
 		case Image::USED_CHANNELS_LA:
@@ -78,93 +73,112 @@ EtcpakType _determine_dxt_type(Image::UsedChannels p_source) {
 			return EtcpakType::ETCPAK_TYPE_DXT5;
 	}
 }
-void _compress_etc2(Image *p_img, float p_lossy_quality, Image::UsedChannels p_source) {
-	EtcpakType type = _determine_etc_type(p_source);
-	_compress_etcpak(type, p_img, p_lossy_quality, false, p_source);
-}
-void _compress_bc(Image *p_img, float p_lossy_quality, Image::UsedChannels p_source) {
-	EtcpakType type = _determine_dxt_type(p_source);
-	_compress_etcpak(type, p_img, p_lossy_quality, false, p_source);
-}
-void _compress_etc1(Image *p_img, float p_lossy_quality) {
-	_compress_etcpak(EtcpakType::ETCPAK_TYPE_ETC1, p_img, p_lossy_quality, true, Image::USED_CHANNELS_RGB);
+
+void _compress_etc1(Image *r_img, float p_lossy_quality) {
+	_compress_etcpak(EtcpakType::ETCPAK_TYPE_ETC1, r_img, p_lossy_quality);
 }
 
-void _compress_etcpak(EtcpakType p_compresstype, Image *p_img, float p_lossy_quality, bool force_etc1_format, Image::UsedChannels p_channels) {
-	uint64_t t = OS::get_singleton()->get_ticks_msec();
-	Image::Format img_format = p_img->get_format();
+void _compress_etc2(Image *r_img, float p_lossy_quality, Image::UsedChannels p_channels) {
+	EtcpakType type = _determine_etc_type(p_channels);
+	_compress_etcpak(type, r_img, p_lossy_quality);
+}
 
+void _compress_bc(Image *r_img, float p_lossy_quality, Image::UsedChannels p_channels) {
+	EtcpakType type = _determine_dxt_type(p_channels);
+	_compress_etcpak(type, r_img, p_lossy_quality);
+}
+
+void _compress_etcpak(EtcpakType p_compresstype, Image *r_img, float p_lossy_quality) {
+	uint64_t start_time = OS::get_singleton()->get_ticks_msec();
+
+	// TODO: See how to handle lossy quality.
+
+	Image::Format img_format = r_img->get_format();
 	if (img_format >= Image::FORMAT_DXT1) {
-		return; //do not compress, already compressed
+		return; // Do not compress, already compressed.
 	}
-
 	if (img_format > Image::FORMAT_RGBA8) {
 		// TODO: we should be able to handle FORMAT_RGBA4444 and FORMAT_RGBA5551 eventually
 		return;
 	}
 
-	Image::Format format = Image::FORMAT_RGBA8;
-	if (p_img->get_format() != Image::FORMAT_RGBA8) {
-		p_img->convert(Image::FORMAT_RGBA8);
+	// Use RGBA8 to convert.
+	if (img_format != Image::FORMAT_RGBA8) {
+		r_img->convert(Image::FORMAT_RGBA8);
 	}
-	if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC1 || force_etc1_format) {
-		format = Image::FORMAT_ETC;
+
+	// Determine output format based on Etcpak type.
+	Image::Format target_format = Image::FORMAT_RGBA8;
+	if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC1) {
+		target_format = Image::FORMAT_ETC;
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2) {
-		format = Image::FORMAT_ETC2_RGB8;
+		target_format = Image::FORMAT_ETC2_RGB8;
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_RA_AS_RG) {
-		format = Image::FORMAT_ETC2_RA_AS_RG;
-		p_img->convert_rg_to_ra_rgba8();
+		target_format = Image::FORMAT_ETC2_RA_AS_RG;
+		r_img->convert_rg_to_ra_rgba8();
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_ALPHA) {
-		format = Image::FORMAT_ETC2_RGBA8;
+		target_format = Image::FORMAT_ETC2_RGBA8;
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_DXT1) {
-		format = Image::FORMAT_DXT1;
+		target_format = Image::FORMAT_DXT1;
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_DXT5_RA_AS_RG) {
-		format = Image::FORMAT_DXT5_RA_AS_RG;
-		p_img->convert_rg_to_ra_rgba8();
+		target_format = Image::FORMAT_DXT5_RA_AS_RG;
+		r_img->convert_rg_to_ra_rgba8();
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_DXT5) {
-		format = Image::FORMAT_DXT5;
+		target_format = Image::FORMAT_DXT5;
 	} else {
-		ERR_FAIL();
+		ERR_FAIL_MSG("Invalid or unsupported Etcpak compression format.");
 	}
 
-	const bool mipmap = p_img->has_mipmaps();
-	print_verbose("Encoding format: " + Image::get_format_name(format));
+	// Compress image data and (if required) mipmaps.
 
-	Ref<Image> new_img;
-	new_img.instance();
-	new_img->create(p_img->get_width(), p_img->get_height(), mipmap, format);
-	Vector<uint8_t> data = new_img->get_data();
-	uint8_t *wr = data.ptrw();
+	const bool mipmaps = r_img->has_mipmaps();
+	const int width = r_img->get_width();
+	const int height = r_img->get_height();
+	const uint8_t *src_read = r_img->get_data().ptr();
 
-	Ref<Image> image = p_img->duplicate();
-	int mmc = 1 + (mipmap ? Image::get_image_required_mipmaps(new_img->get_width(), new_img->get_height(), format) : 0);
-	for (int i = 0; i < mmc; i++) {
-		int ofs, size, mip_w, mip_h;
-		new_img->get_mipmap_offset_size_and_dimensions(i, ofs, size, mip_w, mip_h);
+	print_verbose(vformat("ETCPAK: Encoding image size %dx%d to format %s.", width, height, Image::get_format_name(target_format)));
+
+	int dest_size = Image::get_image_data_size(width, height, target_format, mipmaps);
+	Vector<uint8_t> dest_data;
+	dest_data.resize(dest_size);
+	uint8_t *dest_write = dest_data.ptrw();
+
+	int mip_count = mipmaps ? Image::get_image_required_mipmaps(width, height, target_format) : 0;
+
+	for (int i = 0; i < mip_count + 1; i++) {
+		// Get write mip metrics for target image.
+		int mip_w, mip_h;
+		int mip_ofs = Image::get_image_mipmap_offset_and_dimensions(width, height, target_format, i, mip_w, mip_h);
+		// Ensure that mip offset is a multiple of 8 (etcpak expects uint64_t pointer).
+		ERR_FAIL_COND(mip_ofs % 8 != 0);
+		uint64_t *dest_mip_write = (uint64_t *)&dest_write[mip_ofs];
+
+		// Block size. Align stride to multiple of 4 (RGBA8).
 		mip_w = (mip_w + 3) & ~3;
 		mip_h = (mip_h + 3) & ~3;
-		Vector<uint8_t> dst_data;
-		dst_data.resize(size);
-		int mipmap_ofs = image->get_mipmap_offset(i);
+		const uint32_t blocks = mip_w * mip_h / 16;
 
-		const uint32_t *image_read = (const uint32_t *)&image->get_data().ptr()[mipmap_ofs];
-		uint64_t *dst_write = (uint64_t *)dst_data.ptrw();
-		if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC1 || force_etc1_format) {
-			CompressEtc1RgbDither(image_read, dst_write, mip_w * mip_h / 16, mip_w);
+		// Get mip data from source image for reading.
+		int src_mip_ofs = r_img->get_mipmap_offset(i);
+		const uint32_t *src_mip_read = (const uint32_t *)&src_read[src_mip_ofs];
+
+		if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC1) {
+			CompressEtc1RgbDither(src_mip_read, dest_mip_write, blocks, mip_w);
 		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2 || p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_RA_AS_RG) {
-			CompressEtc2Rgb(image_read, dst_write, mip_w * mip_h / 16, mip_w);
+			CompressEtc2Rgb(src_mip_read, dest_mip_write, blocks, mip_w);
 		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_ALPHA) {
-			CompressEtc2Rgba(image_read, dst_write, mip_w * mip_h / 16, mip_w);
-		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_DXT5 || p_compresstype == EtcpakType::ETCPAK_TYPE_DXT5_RA_AS_RG) {
-			CompressDxt5(image_read, dst_write, mip_w * mip_h / 16, mip_w);
+			CompressEtc2Rgba(src_mip_read, dest_mip_write, blocks, mip_w);
 		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_DXT1) {
-			CompressDxt1Dither(image_read, dst_write, mip_w * mip_h / 16, mip_w);
+			CompressDxt1Dither(src_mip_read, dest_mip_write, blocks, mip_w);
+		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_DXT5 || p_compresstype == EtcpakType::ETCPAK_TYPE_DXT5_RA_AS_RG) {
+			CompressDxt5(src_mip_read, dest_mip_write, blocks, mip_w);
 		} else {
-			ERR_FAIL();
+			ERR_FAIL_MSG("Invalid or unsupported Etcpak compression format.");
 		}
-		copymem(&wr[ofs], dst_data.ptr(), size);
 	}
-	p_img->create(new_img->get_width(), new_img->get_height(), mipmap, format, data);
 
-	print_verbose(vformat("ETCPAK encode took %s ms.", rtos(OS::get_singleton()->get_ticks_msec() - t)));
+	// Replace original image with compressed one.
+	r_img->create(width, height, mipmaps, target_format, dest_data);
+
+	print_verbose(vformat("ETCPAK encode took %s ms.", rtos(OS::get_singleton()->get_ticks_msec() - start_time)));
 }

--- a/modules/etcpak/image_compress_etcpak.h
+++ b/modules/etcpak/image_compress_etcpak.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  image_compress_squish.h                                              */
+/*  image_compress_etcpak.h                                              */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,11 +28,25 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef IMAGE_COMPRESS_SQUISH_H
-#define IMAGE_COMPRESS_SQUISH_H
+#ifndef IMAGE_COMPRESS_ETCPAK_H
+#define IMAGE_COMPRESS_ETCPAK_H
 
 #include "core/io/image.h"
 
-void image_decompress_squish(Image *p_image);
+enum class EtcpakType {
+	ETCPAK_TYPE_ETC1,
+	ETCPAK_TYPE_ETC2,
+	ETCPAK_TYPE_ETC2_ALPHA,
+	ETCPAK_TYPE_ETC2_RA_AS_RG,
+	ETCPAK_TYPE_DXT1,
+	ETCPAK_TYPE_DXT5,
+	ETCPAK_TYPE_DXT5_RA_AS_RG,
+};
 
-#endif // IMAGE_COMPRESS_SQUISH_H
+void _compress_etc1(Image *r_img, float p_lossy_quality);
+void _compress_etc2(Image *r_img, float p_lossy_quality, Image::UsedChannels p_channels);
+void _compress_bc(Image *r_img, float p_lossy_quality, Image::UsedChannels p_channels);
+
+void _compress_etcpak(EtcpakType p_compresstype, Image *r_img, float p_lossy_quality);
+
+#endif // IMAGE_COMPRESS_ETCPAK_H

--- a/modules/etcpak/register_types.cpp
+++ b/modules/etcpak/register_types.cpp
@@ -30,7 +30,7 @@
 
 #include "register_types.h"
 
-#include "image_etcpak.h"
+#include "image_compress_etcpak.h"
 
 void register_etcpak_types() {
 	Image::_image_compress_etc1_func = _compress_etc1;

--- a/modules/etcpak/register_types.h
+++ b/modules/etcpak/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ETCPAK_REGISTER_TYPES_H
+#define ETCPAK_REGISTER_TYPES_H
+
 void register_etcpak_types();
 void unregister_etcpak_types();
+
+#endif // ETCPAK_REGISTER_TYPES_H

--- a/modules/squish/image_decompress_squish.h
+++ b/modules/squish/image_decompress_squish.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  image_compress_squish.cpp                                            */
+/*  image_decompress_squish.h                                            */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,51 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "image_compress_squish.h"
+#ifndef IMAGE_DECOMPRESS_SQUISH_H
+#define IMAGE_DECOMPRESS_SQUISH_H
 
-#include <squish.h>
+#include "core/io/image.h"
 
-void image_decompress_squish(Image *p_image) {
-	int w = p_image->get_width();
-	int h = p_image->get_height();
+void image_decompress_squish(Image *p_image);
 
-	Image::Format target_format = Image::FORMAT_RGBA8;
-	Vector<uint8_t> data;
-	int target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
-	int mm_count = p_image->get_mipmap_count();
-	data.resize(target_size);
-
-	const uint8_t *rb = p_image->get_data().ptr();
-	uint8_t *wb = data.ptrw();
-
-	int squish_flags = Image::FORMAT_MAX;
-	if (p_image->get_format() == Image::FORMAT_DXT1) {
-		squish_flags = squish::kDxt1;
-	} else if (p_image->get_format() == Image::FORMAT_DXT3) {
-		squish_flags = squish::kDxt3;
-	} else if (p_image->get_format() == Image::FORMAT_DXT5 || p_image->get_format() == Image::FORMAT_DXT5_RA_AS_RG) {
-		squish_flags = squish::kDxt5;
-	} else if (p_image->get_format() == Image::FORMAT_RGTC_R) {
-		squish_flags = squish::kBc4;
-	} else if (p_image->get_format() == Image::FORMAT_RGTC_RG) {
-		squish_flags = squish::kBc5;
-	} else {
-		ERR_FAIL_MSG("Squish: Can't decompress unknown format: " + itos(p_image->get_format()) + ".");
-		return;
-	}
-
-	for (int i = 0; i <= mm_count; i++) {
-		int src_ofs = 0, mipmap_size = 0, mipmap_w = 0, mipmap_h = 0;
-		p_image->get_mipmap_offset_size_and_dimensions(i, src_ofs, mipmap_size, mipmap_w, mipmap_h);
-		int dst_ofs = Image::get_image_mipmap_offset(p_image->get_width(), p_image->get_height(), target_format, i);
-		squish::DecompressImage(&wb[dst_ofs], w, h, &rb[src_ofs], squish_flags);
-		w >>= 1;
-		h >>= 1;
-	}
-
-	p_image->create(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
-
-	if (p_image->get_format() == Image::FORMAT_DXT5_RA_AS_RG) {
-		p_image->convert_ra_rgba8_to_rg();
-	}
-}
+#endif // IMAGE_DECOMPRESS_SQUISH_H

--- a/modules/squish/register_types.cpp
+++ b/modules/squish/register_types.cpp
@@ -29,7 +29,8 @@
 /*************************************************************************/
 
 #include "register_types.h"
-#include "image_compress_squish.h"
+
+#include "image_decompress_squish.h"
 
 void register_squish_types() {
 	Image::_image_decompress_bc = image_decompress_squish;

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -101,6 +101,7 @@ Files extracted from upstream source:
   ```
 - `AUTHORS.txt` and `LICENSE.txt`
 
+
 ## fonts
 
 - `NotoSans*.ttf`, `NotoNaskhArabicUI_Regular.ttf`:


### PR DESCRIPTION
Avoid unnecessary allocation of temporary buffers for each mip, and redundant
Image `create` where we can assign the pointer directly.
Also renames variable and reorders code for clarity.

Clarify that squish is now only used for decompression.

Documented which formats can be decompressed in Image.

Follow-up to #47370.

## Notes

### Lossy quality

etcpak doesn't provide any options for configuring the quality. Reading the [upstream README](https://github.com/wolfpld/etcpak), it says:

> etcpak is an extremely fast Ericsson Texture Compression and S3 Texture Compression (DXT1/DXT5) utility. Currently it's best suited for rapid assets preparation during development, when graphics quality is not a concern, but it's also used in production builds of applications used by millions of people.

i.e. it's not geared towards perfect quality, but then that's also aligned with our default lossy import with quality 0.7. That means that if some users eventually want higher quality, we might need to provide another way to encode their assets (possibly via a thirdparty plugin).

But it also states:

> [Why there's no image quality metrics? / Quality comparison.](https://i.imgur.com/FxlmUOF.png)

And the image comparison does look fairly good to my untrained eye.

So now that we import ETC/ETC2 and S3TC through an importer that has no configurable quality settings, maybe we should consider removing the `lossy_quality` option?

The PVRTC importer we use also doesn't handle `lossy_quality`, so only cvtt handles it for BPTC.

### Decompression

etcpak does provide support for decode ETC, ETC2, DXT1, and DXT5.

It's not part of the minimal `Process*` code we extracted from the library, but part of the `BlockData.cpp` which depends on etcpak's own Bitmap representation and everything else: task scheduler, modified libpng, etc.

https://github.com/wolfpld/etcpak/blob/1dc7b300453ae3d20cc43d906c89bcfcd8854cd3/BlockData.cpp#L694-L711

We could likely extract only the relevant `Decode*Part` methods and hook them with our own `Image` bitmap representation: https://github.com/wolfpld/etcpak/blob/1dc7b300453ae3d20cc43d906c89bcfcd8854cd3/BlockData.cpp#L723-L857

That would require either some copy-paste work which makes it harder to sync with upstream, or splitting the upstream `BlockData.cpp` into two files (one part with only the byte decoding, and another part with the higher level Bitmap stuff) and have them agree to merge it.

That would allow use to drop Squish (used to decode DXT) and add decoding support for ETC1/ETC2.