### PR TITLE
Display a dialog for HTML5 performance issues when using Firefox + Linux

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -597,5 +597,21 @@
 			});
 		}
 	//]]></script>
+	<script type='text/javascript'>
+		if (
+			localStorage.getItem('firefoxLinuxWarningDismissed') === null
+			&& window.navigator.platform.match(/Linux/)
+			&& window.navigator.userAgent.match(/Firefox/)
+		) {
+			alert(`Warning: Possible low performance
+
+Firefox has notoriously poor WebGL performance on Linux compared to other platforms,
+unless you are using EGL (which is only possible on Wayland).
+
+Consider using a Chromium-based browser for better rendering performance.
+This dialog will only appear once.`);
+			localStorage.setItem('firefoxLinuxWarningDismissed', true);
+		}
+	</script>
 </body>
 </html>

--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -385,5 +385,21 @@ $GODOT_HEAD_INCLUDE
 			}
 		})();
 	//]]></script>
+	<script type='text/javascript'>
+		if (
+			localStorage.getItem('firefoxLinuxWarningDismissed') === null
+			&& window.navigator.platform.match(/Linux/)
+			&& window.navigator.userAgent.match(/Firefox/)
+		) {
+			alert(`Warning: Possible low performance
+
+Firefox has notoriously poor WebGL performance on Linux compared to other platforms,
+unless you are using EGL (which is only possible on Wayland).
+
+Consider using a Chromium-based browser for better rendering performance.
+This dialog will only appear once.`);
+			localStorage.setItem('firefoxLinuxWarningDismissed', true);
+		}
+	</script>
 </body>
 </html>

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -241,5 +241,21 @@ $GODOT_HEAD_INCLUDE
 			}
 		})();
 	//]]></script>
+	<script type='text/javascript'>
+		if (
+			localStorage.getItem('firefoxLinuxWarningDismissed') === null
+			&& window.navigator.platform.match(/Linux/)
+			&& window.navigator.userAgent.match(/Firefox/)
+		) {
+			alert(`Warning: Possible low performance
+
+Firefox has notoriously poor WebGL performance on Linux compared to other platforms,
+unless you are using EGL (which is only possible on Wayland).
+
+Consider using a Chromium-based browser for better rendering performance.
+This dialog will only appear once.`);
+			localStorage.setItem('firefoxLinuxWarningDismissed', true);
+		}
+	</script>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-docs/pull/4628.

There is no way to work around this issue on the developer's side.

This dialog only appears once per project (or for the web editor).

## Preview

![image](https://user-images.githubusercontent.com/180032/114875254-67e0bb00-9dfd-11eb-81bf-95793ce210f0.png)