### PR TITLE
[3.x] Fix Skeleton.clear_bones_global_pose_override() not resetting global_bone_overrides properly

### DIFF
--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -383,6 +383,7 @@ void Skeleton::_notification(int p_what) {
 void Skeleton::clear_bones_global_pose_override() {
 	for (int i = 0; i < bones.size(); i += 1) {
 		bones.write[i].global_pose_override_amount = 0;
+		bones.write[i].global_pose_override_reset = true;
 	}
 	_make_dirty();
 }


### PR DESCRIPTION
Godot 3.x version of #47923

fixes #47850 as SkeletonIK is currently the only Node that uses said function to reset bones.

When SkeletonIK was first introduced it was enough to set the interpolation value for the IK to zero (what the function does) to disable it. With the later introduced global_bone_override persistent flag this was no longer enough and the IK pose stayed frozen even at zero interpolation value until the persistent flag is lifted through other means.


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
