### PR TITLE
Display a warning dialog when using an old browser version for HTML5

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -597,5 +597,35 @@
 			});
 		}
 	//]]></script>
+	<script type='text/javascript'>
+		// Detect old browser versions and display warning messages.
+
+		const chromeMatch = window.navigator.userAgent.match(/Chrome\/([0-9]+).*$/);
+		if (chromeMatch && chromeMatch.length >= 2) {
+			if (Number(chromeMatch[1]) < 83) {
+				alert(`Warning: Web browser compatibility
+
+You are using an old Chrome version (${chromeMatch[1]}).
+This Chrome version does not support the features required to run Godot projects
+exported to HTML5.
+
+Please update to a newer Chrome version or use a different, up-to-date browser.`);
+			};
+		}
+
+		const firefoxMatch = window.navigator.userAgent.match(/Firefox\/([0-9]+).*$/);
+		if (firefoxMatch && firefoxMatch.length >= 2) {
+			// Allow Firefox 79 ESR (latest package in Debian stable as of April 2021).
+			if (Number(firefoxMatch[1]) < 79) {
+				alert(`Warning: Web browser compatibility
+
+You are using an old Firefox version (${firefoxMatch[1]}).
+This Firefox version does not support the features required to run Godot projects
+exported to HTML5.
+
+Please update to a newer Firefox version or use a different, up-to-date browser.`);
+			};
+		}
+	</script>
 </body>
 </html>

--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -385,5 +385,35 @@ $GODOT_HEAD_INCLUDE
 			}
 		})();
 	//]]></script>
+	<script type='text/javascript'>
+		// Detect old browser versions and display warning messages.
+
+		const chromeMatch = window.navigator.userAgent.match(/Chrome\/([0-9]+).*$/);
+		if (chromeMatch && chromeMatch.length >= 2) {
+			if (Number(chromeMatch[1]) < 83) {
+				alert(`Warning: Web browser compatibility
+
+You are using an old Chrome version (${chromeMatch[1]}).
+This Chrome version does not support the features required to run Godot projects
+exported to HTML5.
+
+Please update to a newer Chrome version or use a different, up-to-date browser.`);
+			};
+		}
+
+		const firefoxMatch = window.navigator.userAgent.match(/Firefox\/([0-9]+).*$/);
+		if (firefoxMatch && firefoxMatch.length >= 2) {
+			// Allow Firefox 79 ESR (latest package in Debian stable as of April 2021).
+			if (Number(firefoxMatch[1]) < 79) {
+				alert(`Warning: Web browser compatibility
+
+You are using an old Firefox version (${firefoxMatch[1]}).
+This Firefox version does not support the features required to run Godot projects
+exported to HTML5.
+
+Please update to a newer Firefox version or use a different, up-to-date browser.`);
+			};
+		}
+	</script>
 </body>
 </html>

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -241,5 +241,35 @@ $GODOT_HEAD_INCLUDE
 			}
 		})();
 	//]]></script>
+	<script type='text/javascript'>
+		// Detect old browser versions and display warning messages.
+
+		const chromeMatch = window.navigator.userAgent.match(/Chrome\/([0-9]+).*$/);
+		if (chromeMatch && chromeMatch.length >= 2) {
+			if (Number(chromeMatch[1]) < 83) {
+				alert(`Warning: Web browser compatibility
+
+You are using an old Chrome version (${chromeMatch[1]}).
+This Chrome version does not support the features required to run Godot projects
+exported to HTML5.
+
+Please update to a newer Chrome version or use a different, up-to-date browser.`);
+			};
+		}
+
+		const firefoxMatch = window.navigator.userAgent.match(/Firefox\/([0-9]+).*$/);
+		if (firefoxMatch && firefoxMatch.length >= 2) {
+			// Allow Firefox 79 ESR (latest package in Debian stable as of April 2021).
+			if (Number(firefoxMatch[1]) < 79) {
+				alert(`Warning: Web browser compatibility
+
+You are using an old Firefox version (${firefoxMatch[1]}).
+This Firefox version does not support the features required to run Godot projects
+exported to HTML5.
+
+Please update to a newer Firefox version or use a different, up-to-date browser.`);
+			};
+		}
+	</script>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to #47919.

Old browser versions don't support the required Web platform features to run Godot exports correctly.

See https://github.com/godotengine/godot/issues/47272.

## TODO

These checks are not essential, but would be nice to have. These can be added in a future PR.

- [ ] Detect and warn for old Safari versions.
- [ ] Detect and warn for EdgeHTML-based Microsoft Edge (since it never supported WebAssembly threads).
- [ ] Detect and warn for Internet Explorer (all versions, since none of them support WebAssembly at all).

## Preview

![image](https://user-images.githubusercontent.com/180032/114901378-06c4e180-9e15-11eb-8c43-a6d9edc879cc.png)