### PR TITLE
[4.x] Fix available Blendshapes not displayed in Mesh Resource Inspector

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1109,6 +1109,15 @@ void ArrayMesh::_get_property_list(List<PropertyInfo> *p_list) const {
 		return;
 	}
 
+	if (blend_shapes.size()) {
+		String available_blendshapes("");
+		for (int blendshape_inx = 0; blendshape_inx < get_blend_shape_count(); blendshape_inx++) {
+			if (blendshape_inx > 0)
+				available_blendshapes += ",";
+			available_blendshapes += get_blend_shape_name(blendshape_inx);
+		}
+		p_list->push_back(PropertyInfo(Variant::INT, "available_blendshapes", PROPERTY_HINT_ENUM, available_blendshapes, PROPERTY_USAGE_EDITOR));
+	}
 	for (int i = 0; i < surfaces.size(); i++) {
 		p_list->push_back(PropertyInfo(Variant::STRING, "surface_" + itos(i + 1) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 		if (surfaces[i].is_2d) {


### PR DESCRIPTION
Godot 4.x version of #47927 since Godot 3.x had legacy properties inside block.

Available Blendshapes stored in a Mesh Resource are now displayed as a (read-only) enum property in Editor Inspector.

Previously to see available blendshapes on Mesh Resources users had to take extra steps and load Mesh Resources on MeshInstance nodes. Since Blendshapes and their names are already stored inside Mesh Resource files this seemed to be an oversight.


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
