### PR TITLE
Overhaul inertial scrolling +fixes

### DIFF
--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -46,14 +46,12 @@ class ScrollContainer : public Container {
 
 	void update_scrollbars();
 
-	Vector2 drag_speed;
-	Vector2 drag_accum;
-	Vector2 drag_from;
-	Vector2 last_drag_accum;
+	Vector2 drag_speed = Vector2();
+	Vector2 drag_accum = Vector2();
+	Vector2 drag_from = Vector2();
 	float last_drag_time = 0.0;
-	float time_since_motion = 0.0;
 	bool drag_touching = false;
-	bool drag_touching_deaccel = false;
+	bool animating = false;
 	bool click_handled = false;
 	bool beyond_deadzone = false;
 
@@ -63,7 +61,24 @@ class ScrollContainer : public Container {
 	int deadzone = 0;
 	bool follow_focus = false;
 
+	bool always_smoothed;
+	float scroll_step;
+
+	float smooth_scroll_duration_button;
+	float inertial_scroll_duration_touch;
+	float inertial_scroll_duration_current;
+
+	float inertial_time_left;
+	Vector2 expected_scroll_value;
+	Vector2 inertial_start;
+	Vector2 inertial_target;
+
 	void _cancel_drag();
+	void _button_scroll(bool horizontal, float amount);
+	void _start_inertial_scroll();
+
+	void _check_expected_scroll();
+	void _update_expected_scroll();
 
 protected:
 	Size2 get_minimum_size() const override;
@@ -95,8 +110,14 @@ public:
 	int get_deadzone() const;
 	void set_deadzone(int p_deadzone);
 
+	float get_scroll_step() const;
+	void set_scroll_step(float p_step);
+
 	bool is_following_focus() const;
 	void set_follow_focus(bool p_follow);
+
+	bool is_always_smoothed() const;
+	void set_always_smoothed(bool p_smoothed);
 
 	HScrollBar *get_h_scrollbar();
 	VScrollBar *get_v_scrollbar();


### PR DESCRIPTION
This is a fix to a previous pull request I made, which ended up getting mangled due to a botched rebase. The original description is as follows:

## Summary
I made quite a few changes, however all are interlocked so they can't really be split to multiple branches.
I tried to be as thorough as possible with the description below, however, in short: 
- Scroll behaves much nicer on mobile
- A bunch of options have been added

## List of Changes
- New options have been added to project settings under a new gui>scroll section
- Completely rewrote inertial scrolling on touch. This fixes various issues, and make things far more consistent.
     - Various issues involving scroll_deadzone are now fixed. (Resolves godotengine/godot#45402)
     - Inertial scroll now decelerates quadratically instead of linear. This is more accurate to real-life friction, more consistent with other mobile applications, and subjectively feels better. It also fixes an issue where deceleration would be far too much on scaled nodes or windows.
     - The amount of inertia can be configured in project settings  (gui>scroll>intertial_scroll_duration_touch)
- Added a scroll_step parameter. When scrolling with the mouse wheel, each notch will scroll by one page * scroll_step. The default is 1/8, which is the same as the previously hard-coded behavior.
     - The default value of scroll_step can be set in project settings (gui>scroll>default_scroll_step)
- When focus is within a scroll container, ui_page_up and ui_page_down input actions will now work as expected. (Previously they did nothing)
- Added a scroll_smooth parameter. This will enable Windows 10 - style smooth scrolling when scrolling using the mouse wheel, page up & down, or with follow_focus
     - The default value of scroll_smooth can be set in project settings (gui>scroll>default_scroll_smoothed)
     - The duration of the smooth scrolling animation can be set in project settings (gui>scroll>smooth_scroll_duration_button)


## Changes to default behavior
I have done my best to make these changes without breaking compatibility or changing default behavior. By default only the following are changed:
- The default focus mode of a scroll_container is not CLICK instead of NONE. This is required for page up & down to work. It can manually be changed back to NONE, which revert page up & down to doing nothing, unless a child element is focused.
- Inertial scrolling will always use the new, fixed physics.
- The default_scroll_deadzone project setting is now under gui>scroll instead of gui>common
All other new functionality requires settings to be manually changed by the user.

## Context
Tested with:
 - 3.2.3:
     - Windows (in editor, exported debug, exported release)
     - Android (debug, release, custom build)
 - 4.0.dev:
     - Windows (in editor, debug)
     - Android (debug)

I previously submitted a similar pull request that only fixed bugs, however I closed it in favor of this one. This pull fixes all of the bugs fixed by the first one and more, by fixing the underlying issues.
This pull request *does not* include documentation for the new options. If/once it is merged to master, I will submit a second pull with new documentation added.
I have a 3.2 compatible version ready if desired

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/5386.*

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
