### PR TITLE
Changed SkeletonIK3D to clear bone overrides when stopping

### DIFF
--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -270,7 +270,6 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 		return; // Skip solving
 	}
 
-	// This line below is part of the problem - removing it fixes the issue with BoneAttachment nodes...
 	p_task->skeleton->set_bone_global_pose_override(p_task->chain.chain_root.bone, Transform(), 0.0, true);
 
 	if (p_task->chain.middle_chain_item) {
@@ -567,6 +566,9 @@ void SkeletonIK3D::start(bool p_one_time) {
 
 void SkeletonIK3D::stop() {
 	set_process_internal(false);
+	if (skeleton) {
+		skeleton->clear_bones_global_pose_override();
+	}
 }
 
 Transform SkeletonIK3D::_get_target_transform() {


### PR DESCRIPTION
Fixes #47850 in the projected I tested on. The project I tested with is not the same sample project, but I was able to get the same bug in my testing and this PR makes the bug no longer appear.

Previously the `stop` function simply stops the IK from executing by setting the internal process to false, which doesn't clear the global pose overrides. Now when `stop` is called, the `clear_bones_global_pose_override` function is called and this resets the bones.

This should be able to be cherry picked in Godot 3.x, but if not, let me know and I can make a 3.x version.