### PR TITLE
Fix macOS build with all sanitizers enabled.

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -156,7 +156,7 @@ def configure(env):
             if env["use_llvm"]:
                 env.Append(
                     CCFLAGS=[
-                        "-fsanitize=nullability-return,nullability-arg,function,nullability-assign,implicit-integer-sign-change,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation"
+                        "-fsanitize=nullability-return,nullability-arg,function,nullability-assign,implicit-integer-sign-change"
                     ]
                 )
             else:

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -35,7 +35,6 @@ def get_opts():
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
         BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN)", False),
-        BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN)", False),
         BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN)", False),
     ]
 
@@ -132,7 +131,7 @@ def configure(env):
         env["AS"] = basecmd + "as"
         env.Append(CPPDEFINES=["__MACPORTS__"])  # hack to fix libvpx MM256_BROADCASTSI128_SI256 define
 
-    if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"]:
+    if env["use_ubsan"] or env["use_asan"] or env["use_tsan"]:
         env.extra_suffix += "s"
 
         if env["use_ubsan"]:
@@ -142,22 +141,11 @@ def configure(env):
                 ]
             )
             env.Append(LINKFLAGS=["-fsanitize=undefined"])
-            if env["use_llvm"]:
-                env.Append(
-                    CCFLAGS=[
-                        "-fsanitize=nullability-return,nullability-arg,function,nullability-assign,implicit-integer-sign-change,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation"
-                    ]
-                )
-            else:
-                env.Append(CCFLAGS=["-fsanitize=bounds-strict"])
+            env.Append(CCFLAGS=["-fsanitize=nullability-return,nullability-arg,function,nullability-assign"])
 
         if env["use_asan"]:
             env.Append(CCFLAGS=["-fsanitize=address,pointer-subtract,pointer-compare"])
             env.Append(LINKFLAGS=["-fsanitize=address"])
-
-        if env["use_lsan"]:
-            env.Append(CCFLAGS=["-fsanitize=leak"])
-            env.Append(LINKFLAGS=["-fsanitize=leak"])
 
         if env["use_tsan"]:
             env.Append(CCFLAGS=["-fsanitize=thread"])

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -113,7 +113,7 @@ def configure(env):
             if env["use_llvm"]:
                 env.Append(
                     CCFLAGS=[
-                        "-fsanitize=nullability-return,nullability-arg,function,nullability-assign,implicit-integer-sign-change,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation"
+                        "-fsanitize=nullability-return,nullability-arg,function,nullability-assign,implicit-integer-sign-change"
                     ]
                 )
             else:


### PR DESCRIPTION
Some sanitizer flag fixes for macOS (#40924 follow-up).

- There's no `use_llvm` environment variable, macOS build is LLVM only.
- `-fsanitize=leak` is not supported as standalone flag (it is integrated into address sanitizer, see: https://clang.llvm.org/docs/LeakSanitizer.html).
- `-fsanitize=implicit-integer-sign-change` is not supported.

Also removes `implicit-signed-integer-truncation` and `implicit-unsigned-integer-truncation`.