### PR TITLE
Improved MultiNodeEdit Blendshape Slider Support

### DIFF
--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -167,6 +167,12 @@ void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (List<PLData *>::Element *E = data_list.front(); E; E = E->next()) {
 		if (nc == E->get()->uses) {
 			p_list->push_back(E->get()->info);
+		} else if (E->get()->info.name.begins_with("blend_shapes/")) {
+			// Workaround for the following issue:
+			// If one of the selected MeshInstance nodes is missing a single blend shape,
+			// all the blend shape sliders will disappear in the Inspector because
+			// MultiNodeEdit expects a perfect meta info match.
+			p_list->push_back(E->get()->info);
 		}
 	}
 


### PR DESCRIPTION
Fixes #35934
Recovery of #43574 where I accidently deleted the fork.

Makes Blendshape Sliders in MultiNodeEdit visible in the Inspector even if not all MeshInstances have all the same Blendshapes.

Previously, if one of the selected MeshInstance Nodes was missing a single Blendshape all the Blendshape Sliders would disappear in the Inspector because MultiNodeEdit was expecting a perfect meta info match.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
