### PR TITLE
Disable the `requestLegacyExternalStorage` attribute when there are no storage permissions

### DIFF
--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -275,13 +275,16 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 	return manifest_activity_text;
 }
 
-String _get_application_tag(const Ref<EditorExportPreset> &p_preset) {
+String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_storage_permission) {
 	bool uses_xr = (int)(p_preset->get("xr_features/xr_mode")) == 1;
-	String manifest_application_text =
+	String manifest_application_text = vformat(
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
 			"        android:allowBackup=\"false\" tools:ignore=\"GoogleAppIndexingWarning\"\n"
+			"        tools:replace=\"android:requestLegacyExternalStorage\" "
+			"        android:requestLegacyExternalStorage=\"%s\"\n"
 			"        android:icon=\"@mipmap/icon\">\n\n"
-			"        <meta-data tools:node=\"remove\" android:name=\"xr_mode_metadata_name\" />\n";
+			"        <meta-data tools:node=\"remove\" android:name=\"xr_mode_metadata_name\" />\n",
+			bool_to_string(p_has_storage_permission));
 
 	if (uses_xr) {
 		manifest_application_text += "        <meta-data tools:node=\"replace\" android:name=\"com.samsung.android.vr.application.mode\" android:value=\"vr_only\" />\n";

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -27,7 +27,8 @@
     <!-- Any tag in this line after android:icon will be erased when doing custom builds. -->
     <!-- If you want to add tags manually, do before it. -->
     <!-- WARNING: This should stay on a single line until the parsing code is improved. See GH-32414. -->
-    <application android:label="@string/godot_project_name_string" android:allowBackup="false" tools:ignore="GoogleAppIndexingWarning" android:icon="@mipmap/icon" >
+    <!-- TODO: Remove the 'requestLegacyExternalStorage' attribute when https://github.com/godotengine/godot/issues/38913 is resolved -->
+    <application android:label="@string/godot_project_name_string" android:allowBackup="false" tools:ignore="GoogleAppIndexingWarning" android:requestLegacyExternalStorage="false" android:icon="@mipmap/icon" >
 
         <!-- Records the version of the Godot editor used for building -->
         <meta-data

--- a/platform/android/java/lib/AndroidManifest.xml
+++ b/platform/android/java/lib/AndroidManifest.xml
@@ -4,8 +4,7 @@
     android:versionCode="1"
     android:versionName="1.0">
 
-    <!-- TODO: Remove the 'requestLegacyExternalStorage' attribute when https://github.com/godotengine/godot/issues/38913 is resolved -->
-    <application android:requestLegacyExternalStorage="true">
+    <application>
 
         <!-- Records the version of the Godot library -->
         <meta-data


### PR DESCRIPTION
Fixes #47910