### PR TITLE
Fix NavigationAgent2D not emitting "target_reached" Signal reliably

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -100,12 +100,7 @@ void NavigationAgent2D::_notification(int p_what) {
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (agent_parent) {
 				NavigationServer2D::get_singleton()->agent_set_position(agent, agent_parent->get_global_transform().get_origin());
-				if (!target_reached) {
-					if (distance_to_target() < target_desired_distance) {
-						emit_signal("target_reached");
-						target_reached = true;
-					}
-				}
+				_check_distance_to_target();
 			}
 		} break;
 	}
@@ -301,17 +296,21 @@ void NavigationAgent2D::update_navigation() {
 		while (o.distance_to(navigation_path[nav_path_index]) < target_desired_distance) {
 			nav_path_index += 1;
 			if (nav_path_index == navigation_path.size()) {
-				if (!target_reached) {
-					if (distance_to_target() < target_desired_distance) {
-						emit_signal("target_reached");
-						target_reached = true;
-					}
-				}
+				_check_distance_to_target();
 				nav_path_index -= 1;
 				navigation_finished = true;
 				emit_signal("navigation_finished");
 				break;
 			}
+		}
+	}
+}
+
+void NavigationAgent2D::_check_distance_to_target() {
+	if (!target_reached) {
+		if (distance_to_target() < target_desired_distance) {
+			emit_signal("target_reached");
+			target_reached = true;
 		}
 	}
 }

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -301,6 +301,12 @@ void NavigationAgent2D::update_navigation() {
 		while (o.distance_to(navigation_path[nav_path_index]) < target_desired_distance) {
 			nav_path_index += 1;
 			if (nav_path_index == navigation_path.size()) {
+				if (!target_reached) {
+					if (distance_to_target() < target_desired_distance) {
+						emit_signal("target_reached");
+						target_reached = true;
+					}
+				}
 				nav_path_index -= 1;
 				navigation_finished = true;
 				emit_signal("navigation_finished");

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -140,6 +140,7 @@ public:
 
 private:
 	void update_navigation();
+	void _check_distance_to_target();
 };
 
 #endif


### PR DESCRIPTION
2D version of #47959

NavigationAgent2D did only check distance to target on the slow physics tickrate. This created situations where a fast moving agent on high framerate would not emit the "target_reached" signal when it would immediatly move to the next target on completing the current navigation path (even if standing right on top the target position).

Now whenever the NavigationAgent2D completes a path follow and the "navigation_finished" signal is emitted a target distance checks is performed to also emit "target_reached" if distance to target is small enough.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
