### PR TITLE
Fix face area calculation in SoftBody 3D

### DIFF
--- a/servers/physics_3d/soft_body_3d_sw.cpp
+++ b/servers/physics_3d/soft_body_3d_sw.cpp
@@ -243,7 +243,7 @@ void SoftBody3DSW::update_area() {
 		const Vector3 a = x1 - x0;
 		const Vector3 b = x2 - x0;
 		const Vector3 cr = vec3_cross(a, b);
-		face.ra = cr.length();
+		face.ra = 0.5 * cr.length();
 	}
 
 	// Node area.


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixed face area calculation in `soft_body_3d_sw.cpp`, which was off by a factor of 0.5: https://github.com/godotengine/godot/blob/49511d439124ab5a71defd22639737f45bd0ff70/servers/physics_3d/soft_body_3d_sw.cpp#L246

_bugsquad edit:_ Fixes: #47962 