### PR TITLE
[3.x] C#: Fix `double` casting in wasm m2n trampolines

### DIFF
--- a/modules/mono/mono_gd/gd_mono_wasm_m2n.h
+++ b/modules/mono/mono_gd/gd_mono_wasm_m2n.h
@@ -201,7 +201,7 @@ struct m2n_arg_cast_helper<T, 'F'> {
 template <typename T>
 struct m2n_arg_cast_helper<T, 'D'> {
 	static T cast(Mono_InterpMethodArguments *p_margs, size_t p_idx) {
-		return (T)(size_t)p_margs->fargs[p_idx];
+		return (T)p_margs->fargs[p_idx];
 	}
 };
 


### PR DESCRIPTION
The trampolines were casting double to `size_t` (likely a copy-paste mistake), so the value was getting truncated.

Fixes #47898
