### PR TITLE
[master] C#: Fix `double` casting in wasm m2n trampolines

### DIFF
--- a/modules/mono/mono_gd/gd_mono_wasm_m2n.h
+++ b/modules/mono/mono_gd/gd_mono_wasm_m2n.h
@@ -176,7 +176,7 @@ T m2n_arg_cast(Mono_InterpMethodArguments *p_margs, size_t p_idx) {
 	} else if constexpr (cookie == 'F') {
 		return *reinterpret_cast<float *>(&p_margs->fargs[fidx(p_idx)]);
 	} else if constexpr (cookie == 'D') {
-		return (T)(size_t)p_margs->fargs[p_idx];
+		return (T)p_margs->fargs[p_idx];
 	}
 }
 


### PR DESCRIPTION
Port of #47968 to the master branch. The trampolines may be removed from the master branch in the future as they likely won't be needed anymore after some changes I'll commit soon. Still I prefer to fix this here as well.
