### PR TITLE
Expose ImportDock and its children

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -78,6 +78,12 @@
 				Returns the editor's [FileSystemDock] instance.
 			</description>
 		</method>
+		<method name="get_import_dock">
+			<return type="ImportDock" />
+			<description>
+				Returns the editor's [ImportDock] instance.
+			</description>
+		</method>
 		<method name="get_inspector" qualifiers="const">
 			<return type="EditorInspector" />
 			<description>

--- a/doc/classes/ImportDock.xml
+++ b/doc/classes/ImportDock.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ImportDock" inherits="VBoxContainer" version="4.0">
+	<brief_description>
+		The Import dock.
+	</brief_description>
+	<description>
+		The Import dock shows import settings for one or more files through an [EditorInspector].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_edited_paths">
+			<return type="Array" />
+			<description>
+				Returns the paths currently edited.
+			</description>
+		</method>
+		<method name="get_editor_inspector">
+			<return type="EditorInspector" />
+			<description>
+				Returns the [EditorInspector] where import settings are listed.
+			</description>
+		</method>
+		<method name="set_edited_paths">
+			<return type="void" />
+			<argument index="0" name="paths" type="PackedStringArray" />
+			<description>
+				Sets the current edited paths and replace the old ones.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="edited_paths_changed">
+			<description>
+				Emitted when the edited paths changes.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2102,7 +2102,10 @@ void EditorNode::_edit_current() {
 		scene_tree_dock->set_selected(nullptr);
 		node_dock->set_node(nullptr);
 		inspector_dock->update(nullptr);
-		EditorNode::get_singleton()->get_import_dock()->set_edit_path(current_res->get_path());
+
+		Vector<String> edit_paths;
+		edit_paths.push_back(current_res->get_path());
+		EditorNode::get_singleton()->get_import_dock()->set_edited_paths(edit_paths);
 
 		int subr_idx = current_res->get_path().find("::");
 		if (subr_idx != -1) {
@@ -3822,6 +3825,7 @@ void EditorNode::register_editor_types() {
 	GDREGISTER_CLASS(EditorSceneImporterMeshNode3D);
 
 	GDREGISTER_VIRTUAL_CLASS(FileSystemDock);
+	GDREGISTER_VIRTUAL_CLASS(ImportDock);
 
 	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?
 	GDREGISTER_CLASS(EditorScenePostImport);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
 #include "editor/filesystem_dock.h"
+#include "editor/import_dock.h"
 #include "editor/project_settings_editor.h"
 #include "editor_resource_preview.h"
 #include "main/main.h"
@@ -251,6 +252,10 @@ FileSystemDock *EditorInterface::get_file_system_dock() {
 	return EditorNode::get_singleton()->get_filesystem_dock();
 }
 
+ImportDock *EditorInterface::get_import_dock() {
+	return EditorNode::get_singleton()->get_import_dock();
+}
+
 EditorSelection *EditorInterface::get_selection() {
 	return EditorNode::get_singleton()->get_editor_selection();
 }
@@ -343,6 +348,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_selected_path"), &EditorInterface::get_selected_path);
 	ClassDB::bind_method(D_METHOD("get_current_path"), &EditorInterface::get_current_path);
 	ClassDB::bind_method(D_METHOD("get_file_system_dock"), &EditorInterface::get_file_system_dock);
+	ClassDB::bind_method(D_METHOD("get_import_dock"), &EditorInterface::get_import_dock);
 	ClassDB::bind_method(D_METHOD("get_editor_paths"), &EditorInterface::get_editor_paths);
 	ClassDB::bind_method(D_METHOD("get_command_palette"), &EditorInterface::get_command_palette);
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -57,6 +57,7 @@ class EditorFileSystem;
 class EditorToolAddons;
 class EditorPaths;
 class FileSystemDock;
+class ImportDock;
 class ScriptEditor;
 
 class EditorInterface : public Node {
@@ -104,6 +105,7 @@ public:
 	EditorFileSystem *get_resource_file_system();
 
 	FileSystemDock *get_file_system_dock();
+	ImportDock *get_import_dock();
 
 	Control *get_base_control();
 	float get_editor_scale() const;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2689,13 +2689,7 @@ void FileSystemDock::_update_import_dock() {
 		imports.push_back(fpath);
 	}
 
-	if (imports.size() == 0) {
-		EditorNode::get_singleton()->get_import_dock()->clear();
-	} else if (imports.size() == 1) {
-		EditorNode::get_singleton()->get_import_dock()->set_edit_path(imports[0]);
-	} else {
-		EditorNode::get_singleton()->get_import_dock()->set_edit_multiple_paths(imports);
-	}
+	EditorNode::get_singleton()->get_import_dock()->set_edited_paths(imports);
 
 	import_dock_needs_update = false;
 }

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -50,6 +50,7 @@ class ImportDock : public VBoxContainer {
 	MenuButton *preset;
 	EditorInspector *import_opts;
 
+	Vector<String> current_paths;
 	List<PropertyInfo> properties;
 	Map<StringName, Variant> property_values;
 
@@ -72,6 +73,8 @@ class ImportDock : public VBoxContainer {
 	void _reimport_and_restart();
 	void _reimport();
 
+	void _set_single_edit_path(const String &p_path);
+
 	void _advanced_options();
 	enum {
 		ITEM_SET_AS_DEFAULT = 100,
@@ -84,9 +87,12 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void set_edit_path(const String &p_path);
-	void set_edit_multiple_paths(const Vector<String> &p_paths);
 	void initialize_import_options() const;
+
+	EditorInspector *get_editor_inspector();
+	Array get_edited_paths();
+
+	void set_edited_paths(const Vector<String> &p_paths);
 	void clear();
 
 	ImportDock();


### PR DESCRIPTION
Part of godotengine/godot-proposals#2537
Indipendent from #47520

Expose ImportDock, including a bunch of method for interacting with it.

Considerations for docs are the same of #47767.