### PR TITLE
Add a menu action to open C++ source on GitHub in the editor debugger

### DIFF
--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -74,6 +74,11 @@ private:
 		PROFILER_SCRIPTS_SERVERS
 	};
 
+	enum Actions {
+		ACTION_COPY_ERROR,
+		ACTION_OPEN_SOURCE,
+	};
+
 	AcceptDialog *msgdialog;
 
 	LineEdit *clicked_ctrl;


### PR DESCRIPTION
This helps user find back the source code where the error/warning was emitted from.

I've tested this both with engine-emitted errors and user-emitted errors (`push_error()` in GDScript), and it seems to work successfully so far.

## Preview

*The action brings you to `https://github.com/godotengine/godot/blob/0ee744ff5f3cf045a2699aa4111de3200b9d70be/core/variant/variant_utility.cpp#L597`.*

![image](https://user-images.githubusercontent.com/180032/115129937-fbc3aa00-9fea-11eb-9165-a4c293534b8a.png)