### PR TITLE
[3.x] Fix Blendshapes exploding on skinned Mesh replacement

### DIFF
--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -149,6 +149,12 @@ void MeshInstance::set_mesh(const Ref<Mesh> &p_mesh) {
 		set_base(RID());
 	}
 
+	if (blend_shape_tracks.size() > 0) {
+		for (const Map<StringName, BlendShapeTrack>::Element *E = blend_shape_tracks.front(); E; E = E->next()) {
+			VisualServer::get_singleton()->instance_set_blend_shape_weight(get_instance(), E->get().idx, E->get().value);
+		}
+	}
+
 	update_gizmo();
 
 	_change_notify();


### PR DESCRIPTION
Fixes #37854

Previously when a MeshInstance Mesh with Blendshapes was loaded or replaced on an animated Skeleton at runtime it could cause an unrepairable Mesh explosion on the next frame up to an entire (VisualServer) crash under bad circumstances.

Now when a Mesh is set or replaced any available Blendshape on the new Mesh is reset to default blendvalues AFTER updating Skin and Material Surfaces.

Issue was that only Skeleton Skins and Material Surfaces were updated on Mesh changes. Existing old blendvalues for the MeshInstance on the VisualServer could set the new Mesh off to a corrupted blending state.

In my tests all Blendshape related runtime loading and replacement crashes in Godot 3.x are 100% gone with this change (... and they hunted all my projects for months if not years now).

Godot 4.x had similar issues a few months back when blendshapes were first added back in. I have no blendshape test setup rightnow that runs on Godot 4.x and will keep it in mind for later.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
