### PR TITLE
Batching - Don't join items with invalid shaders

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1356,6 +1356,12 @@ bool RasterizerCanvasGLES2::try_join_item(Item *p_ci, RenderItemState &r_ris, bo
 		if (material_ptr) {
 			shader_ptr = material_ptr->shader;
 
+			// special case, if the user has made an error in the shader code
+			if (shader_ptr && !shader_ptr->valid) {
+				join = false;
+				r_batch_break = true;
+			}
+
 			if (shader_ptr && shader_ptr->mode != VS::SHADER_CANVAS_ITEM) {
 				shader_ptr = NULL; // not a canvas item shader, don't use.
 			}

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1754,6 +1754,12 @@ bool RasterizerCanvasGLES3::try_join_item(Item *p_ci, RenderItemState &r_ris, bo
 		if (material_ptr) {
 			shader_ptr = material_ptr->shader;
 
+			// special case, if the user has made an error in the shader code
+			if (shader_ptr && !shader_ptr->valid) {
+				join = false;
+				r_batch_break = true;
+			}
+
 			if (shader_ptr && shader_ptr->mode != VS::SHADER_CANVAS_ITEM) {
 				shader_ptr = NULL; // not a canvas item shader, don't use.
 			}


### PR DESCRIPTION
When users create an invalid shader, the `shader->valid` flag is set to false. Batching previously assumes that shaders are valid, and this can result in primitives with invalid shader being joined, causing visual errors.

This PR prevents joining items that have invalid shaders.

Fixes #47995 (error with invalid shaders mentioned in #46896)
May fix- #47981

## Notes
* I'm not entirely clear how broken shaders are currently handled in the legacy renderer. It appears they are set to invalid, but the previous valid state of the shader is still used (whether this is intended, or a historical accident I don't know).
* This PR fixes a situation where these 'half valid' shaders can produce strange results as a result of being joined.
* This is very much an editor only 'panic mode', and should not occur in a shipped project.
* This will need someone else to test whether this fixes- #47981 because I can't seem to replicate it.
* This should be a fairly safe PR, but equally I'm not sure this bug should be a blocker for 3.3 stable, as it seems fairly rare, and only occurs with broken shaders.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
