### PR TITLE
Fix `OS.find_scancode_from_string()` not working with modifiers

### DIFF
--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -400,17 +400,38 @@ String keycode_get_string(Key p_code) {
 	return codestr;
 }
 
-Key find_keycode(const String &p_code) {
+Key find_keycode(const String &p_codestr) {
+	Key keycode = Key::NONE;
+	Vector<String> code_parts = p_codestr.split("+");
+	if (code_parts.size() < 1) {
+		return keycode;
+	}
+
+	String last_part = code_parts[code_parts.size() - 1];
 	const _KeyCodeText *kct = &_keycodes[0];
 
 	while (kct->text) {
-		if (p_code.nocasecmp_to(kct->text) == 0) {
-			return kct->code;
+		if (last_part.nocasecmp_to(kct->text) == 0) {
+			keycode = kct->code;
+			break;
 		}
 		kct++;
 	}
 
-	return Key::NONE;
+	for (int part = 0; part < code_parts.size() - 1; part++) {
+		String code_part = code_parts[part];
+		if (code_part.nocasecmp_to(find_keycode_name(Key::SHIFT)) == 0) {
+			keycode |= KeyModifierMask::SHIFT;
+		} else if (code_part.nocasecmp_to(find_keycode_name(Key::CTRL)) == 0) {
+			keycode |= KeyModifierMask::CTRL;
+		} else if (code_part.nocasecmp_to(find_keycode_name(Key::META)) == 0) {
+			keycode |= KeyModifierMask::META;
+		} else if (code_part.nocasecmp_to(find_keycode_name(Key::ALT)) == 0) {
+			keycode |= KeyModifierMask::ALT;
+		}
+	}
+
+	return keycode;
 }
 
 const char *find_keycode_name(Key p_keycode) {

--- a/core/os/keyboard.h
+++ b/core/os/keyboard.h
@@ -330,7 +330,7 @@ constexpr KeyModifierMask operator|(KeyModifierMask a, KeyModifierMask b) {
 
 String keycode_get_string(Key p_code);
 bool keycode_has_unicode(Key p_keycode);
-Key find_keycode(const String &p_code);
+Key find_keycode(const String &p_codestr);
 const char *find_keycode_name(Key p_keycode);
 int keycode_get_count();
 int keycode_get_value_by_index(int p_index);


### PR DESCRIPTION
Fixes #17430.

Tested by converting scancodes to strings using `OS.get_scancode_string()` and converting them back again using `OS.find_scancode_from_string()`:
```
65 -> A -> 65
33554498 -> Shift+B -> 33554498
67108931 -> Alt+C -> 67108931
134217796 -> Meta+D -> 134217796
301989958 -> Shift+Control+F -> 301989958
335544389 -> Alt+Control+E -> 335544389
301989959 -> Shift+Control+G -> 301989959
369098824 -> Shift+Alt+Control+H -> 369098824
```
