### PR TITLE
Add the ability to hide `ScrollContainer`'s scrollbars

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -39,11 +39,17 @@
 		<member name="scroll_horizontal_enabled" type="bool" setter="set_enable_h_scroll" getter="is_h_scroll_enabled" default="true">
 			If [code]true[/code], enables horizontal scrolling.
 		</member>
+		<member name="scroll_horizontal_visible" type="bool" setter="set_h_scroll_visible" getter="is_h_scroll_visible" default="true">
+			If [code]false[/code], hides the horizontal scrollbar.
+		</member>
 		<member name="scroll_vertical" type="int" setter="set_v_scroll" getter="get_v_scroll" default="0">
 			The current vertical scroll value.
 		</member>
 		<member name="scroll_vertical_enabled" type="bool" setter="set_enable_v_scroll" getter="is_v_scroll_enabled" default="true">
 			If [code]true[/code], enables vertical scrolling.
+		</member>
+		<member name="scroll_vertical_visible" type="bool" setter="set_v_scroll_visible" getter="is_v_scroll_visible" default="true">
+			If [code]false[/code], hides the vertical scrollbar.
 		</member>
 	</members>
 	<signals>

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -42,7 +42,6 @@ class ScrollContainer : public Container {
 	VScrollBar *v_scroll;
 
 	Size2 child_max_size;
-	Size2 scroll;
 
 	void update_scrollbars();
 
@@ -50,15 +49,16 @@ class ScrollContainer : public Container {
 	Vector2 drag_accum;
 	Vector2 drag_from;
 	Vector2 last_drag_accum;
-	float last_drag_time = 0.0;
-	float time_since_motion = 0.0;
+	float time_since_motion = 0.0f;
 	bool drag_touching = false;
 	bool drag_touching_deaccel = false;
-	bool click_handled = false;
 	bool beyond_deadzone = false;
 
 	bool scroll_h = true;
 	bool scroll_v = true;
+
+	bool h_scroll_visible = true;
+	bool v_scroll_visible = true;
 
 	int deadzone = 0;
 	bool follow_focus = false;
@@ -80,17 +80,23 @@ protected:
 	void _ensure_focused_visible(Control *p_node);
 
 public:
-	int get_v_scroll() const;
-	void set_v_scroll(int p_pos);
-
-	int get_h_scroll() const;
 	void set_h_scroll(int p_pos);
+	int get_h_scroll() const;
+
+	void set_v_scroll(int p_pos);
+	int get_v_scroll() const;
 
 	void set_enable_h_scroll(bool p_enable);
 	bool is_h_scroll_enabled() const;
 
 	void set_enable_v_scroll(bool p_enable);
 	bool is_v_scroll_enabled() const;
+
+	void set_h_scroll_visible(bool p_visible);
+	bool is_h_scroll_visible() const;
+
+	void set_v_scroll_visible(bool p_visible);
+	bool is_v_scroll_visible() const;
 
 	int get_deadzone() const;
 	void set_deadzone(int p_deadzone);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

https://user-images.githubusercontent.com/50304111/115481068-0196d680-a209-11eb-9d2d-875eacd8333f.mp4

I was originally doing this primarily to hide the scrollbars in `GraphEdit` (because they're unnecessary, especially with the new minimap, neither blender (edit: blender sort of has them but they only appear if you move your mouse near them and they behave a little different) or unity's visual editors use scrollbars) because I assumed it inherited `ScrollContainer`, turns out it doesn't, whoops.

I figured it'd still be useful for a fair number of people, as [this question](https://godotengine.org/qa/25082/how-to-hide-the-scrollcontainers-scrollbar) on godot Q&A has +9 votes

Resolves half of https://github.com/godotengine/godot-proposals/issues/810