### PR TITLE
Allow shortcuts to have up to two input events assigned to them.

### DIFF
--- a/doc/classes/Shortcut.xml
+++ b/doc/classes/Shortcut.xml
@@ -13,14 +13,37 @@
 		<method name="get_as_text" qualifiers="const">
 			<return type="String">
 			</return>
+			<argument index="0" name="primary" type="bool" default="true">
+				Returns result for the primary shortcut if [code]true[/code], or secondary shortcut if [code]false[/code].
+			</argument>
 			<description>
 				Returns the shortcut's [InputEvent] as a [String].
+			</description>
+		</method>
+		<method name="get_shortcut" qualifiers="const">
+			<return type="InputEvent">
+			</return>
+			<argument index="0" name="primary" type="bool" default="true">
+				Returns result for the primary shortcut if [code]true[/code], or secondary shortcut if [code]false[/code].
+			</argument>
+			<description>
+				The shortcut's [InputEvent].
+				See also [member primary_shortcut] and member [member secondary_shortcut].
 			</description>
 		</method>
 		<method name="is_shortcut" qualifiers="const">
 			<return type="bool">
 			</return>
 			<argument index="0" name="event" type="InputEvent">
+				The [InputEvent] to check against.
+			</argument>
+			<argument index="1" name="match_either" type="bool" default="true">
+				If [code]true[/code], it will check for matches on both the primary and secondary shortcuts.
+				If [code]false[/code], it will use the third paramter to determine which shorcut to check agaisnt.
+			</argument>
+			<argument index="2" name="primary" type="bool" default="true">
+				This argument is only used if [code]matches_either[/code] is [code]false[/code].
+				Returns result for the primary shortcut if [code]true[/code], or secondary shortcut if [code]false[/code].
 			</argument>
 			<description>
 				Returns [code]true[/code] if the shortcut's [InputEvent] equals [code]event[/code].
@@ -30,13 +53,31 @@
 			<return type="bool">
 			</return>
 			<description>
-				If [code]true[/code], this shortcut is valid.
+				If [code]true[/code], the primary or secondary shortcut is valid.
+			</description>
+		</method>
+		<method name="set_shortcut">
+			<return type="void">
+			</return>
+			<argument index="0" name="event" type="InputEvent">
+				The [InputEvent] to set the shortcut to.
+			</argument>
+			<argument index="1" name="primary" type="bool" default="true">
+				Sets the event for the primary shortcut if [code]true[/code], or secondary shortcut if [code]false[/code].
+			</argument>
+			<description>
+				Sets the shortcut's [InputEvent].
+				See also [member primary_shortcut] and member [member secondary_shortcut].
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="shortcut" type="InputEvent" setter="set_shortcut" getter="get_shortcut">
-			The shortcut's [InputEvent].
+		<member name="primary_shortcut" type="InputEvent" setter="_set_primary_shortcut" getter="_get_primary_shortcut">
+			The primary shortcut's [InputEvent].
+			Generally the [InputEvent] is a keyboard key, though it can be any [InputEvent].
+		</member>
+		<member name="secondary_shortcut" type="InputEvent" setter="_set_secondary_shortcut" getter="_get_secondary_shortcut">
+			The secondary shortcut's [InputEvent].
 			Generally the [InputEvent] is a keyboard key, though it can be any [InputEvent].
 		</member>
 	</members>

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -206,7 +206,7 @@ Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_re
 Variant _EDITOR_GET(const String &p_setting);
 
 #define ED_IS_SHORTCUT(p_name, p_ev) (EditorSettings::get_singleton()->is_shortcut(p_name, p_ev))
-Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p_keycode = 0);
+Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p_keycode = 0, uint32_t p_secondary_keycode = 0);
 Ref<Shortcut> ED_GET_SHORTCUT(const String &p_path);
 
 #endif // EDITOR_SETTINGS_H

--- a/editor/settings_config_dialog.h
+++ b/editor/settings_config_dialog.h
@@ -54,12 +54,14 @@ class EditorSettingsDialog : public AcceptDialog {
 	SectionedInspector *inspector;
 
 	enum ShortcutButton {
-		SHORTCUT_EDIT,
-		SHORTCUT_ERASE,
-		SHORTCUT_REVERT
+		SHORTCUT_EDIT = 1 << 0,
+		SHORTCUT_ERASE = 1 << 1,
+		SHORTCUT_REVERT = 1 << 2,
+		SHORTCUT_SECONDARY_MASK = 1 << 3,
+		SHORTCUT_ACTION_MASK = ((1 << 3) - 1)
 	};
 
-	int button_idx;
+	int button_id;
 	int current_action_event_index = -1;
 	bool editing_action = false;
 	String current_action;
@@ -75,6 +77,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	Tree *shortcuts;
 	InputEventConfigurationDialog *shortcut_editor;
 	String shortcut_being_edited;
+	bool editing_primary_shortcut;
 
 	virtual void cancel_pressed() override;
 	virtual void ok_pressed() override;

--- a/scene/gui/shortcut.cpp
+++ b/scene/gui/shortcut.cpp
@@ -32,41 +32,76 @@
 
 #include "core/os/keyboard.h"
 
-void Shortcut::set_shortcut(const Ref<InputEvent> &p_shortcut) {
-	shortcut = p_shortcut;
+void Shortcut::set_shortcut(const Ref<InputEvent> &p_shortcut, bool p_primary) {
+	if (p_primary) {
+		primary_shortcut = p_shortcut;
+	} else {
+		secondary_shortcut = p_shortcut;
+	}
 	emit_changed();
 }
 
-Ref<InputEvent> Shortcut::get_shortcut() const {
-	return shortcut;
+Ref<InputEvent> Shortcut::get_shortcut(bool p_primary) const {
+	return p_primary ? primary_shortcut : secondary_shortcut;
 }
 
-bool Shortcut::is_shortcut(const Ref<InputEvent> &p_event) const {
-	return shortcut.is_valid() && shortcut->shortcut_match(p_event);
+bool Shortcut::is_shortcut(const Ref<InputEvent> &p_event, bool p_match_either, bool p_primary) const {
+	bool primary_match = (primary_shortcut.is_valid() && primary_shortcut->shortcut_match(p_event));
+	bool secondary_match = (secondary_shortcut.is_valid() && secondary_shortcut->shortcut_match(p_event));
+
+	if (p_match_either) {
+		return primary_match || secondary_match;
+	} else {
+		return p_primary ? primary_match : secondary_match;
+	}
 }
 
-String Shortcut::get_as_text() const {
-	if (shortcut.is_valid()) {
-		return shortcut->as_text();
+String Shortcut::get_as_text(bool p_primary) const {
+	if (p_primary && primary_shortcut.is_valid()) {
+		return primary_shortcut->as_text();
+	} else if (!p_primary && secondary_shortcut.is_valid()) {
+		return secondary_shortcut->as_text();
 	} else {
 		return "None";
 	}
 }
 
 bool Shortcut::is_valid() const {
-	return shortcut.is_valid();
+	return primary_shortcut.is_valid() || secondary_shortcut.is_valid();
+}
+
+Ref<InputEvent> Shortcut::_get_primary_shortcut() {
+	return get_shortcut();
+}
+
+void Shortcut::_set_primary_shortcut(const Ref<InputEvent> &p_shortcut) {
+	set_shortcut(p_shortcut);
+}
+
+Ref<InputEvent> Shortcut::_get_secondary_shortcut() {
+	return get_shortcut(false);
+}
+
+void Shortcut::_set_secondary_shortcut(const Ref<InputEvent> &p_shortcut) {
+	set_shortcut(p_shortcut, false);
 }
 
 void Shortcut::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_shortcut", "event"), &Shortcut::set_shortcut);
-	ClassDB::bind_method(D_METHOD("get_shortcut"), &Shortcut::get_shortcut);
+	ClassDB::bind_method(D_METHOD("set_shortcut", "event", "primary"), &Shortcut::set_shortcut, true);
+	ClassDB::bind_method(D_METHOD("get_shortcut", "primary"), &Shortcut::get_shortcut, true);
 
 	ClassDB::bind_method(D_METHOD("is_valid"), &Shortcut::is_valid);
 
-	ClassDB::bind_method(D_METHOD("is_shortcut", "event"), &Shortcut::is_shortcut);
-	ClassDB::bind_method(D_METHOD("get_as_text"), &Shortcut::get_as_text);
+	ClassDB::bind_method(D_METHOD("is_shortcut", "event", "match_either", "primary"), &Shortcut::is_shortcut, true, true);
+	ClassDB::bind_method(D_METHOD("get_as_text", "primary"), &Shortcut::get_as_text, true);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), "set_shortcut", "get_shortcut");
+	ClassDB::bind_method(D_METHOD("_get_primary_shortcut"), &Shortcut::_get_primary_shortcut);
+	ClassDB::bind_method(D_METHOD("_set_primary_shortcut", "event"), &Shortcut::_set_primary_shortcut);
+	ClassDB::bind_method(D_METHOD("_get_secondary_shortcut"), &Shortcut::_get_secondary_shortcut);
+	ClassDB::bind_method(D_METHOD("_set_secondary_shortcut", "event"), &Shortcut::_set_secondary_shortcut);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "primary_shortcut", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), "_set_primary_shortcut", "_get_primary_shortcut");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "secondary_shortcut", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), "_set_secondary_shortcut", "_get_secondary_shortcut");
 }
 
 Shortcut::Shortcut() {

--- a/scene/gui/shortcut.h
+++ b/scene/gui/shortcut.h
@@ -37,18 +37,24 @@
 class Shortcut : public Resource {
 	GDCLASS(Shortcut, Resource);
 
-	Ref<InputEvent> shortcut;
+	Ref<InputEvent> primary_shortcut, secondary_shortcut;
+
+	Ref<InputEvent> _get_primary_shortcut();
+	void _set_primary_shortcut(const Ref<InputEvent> &p_shortcut);
+
+	Ref<InputEvent> _get_secondary_shortcut();
+	void _set_secondary_shortcut(const Ref<InputEvent> &p_shortcut);
 
 protected:
 	static void _bind_methods();
 
 public:
-	void set_shortcut(const Ref<InputEvent> &p_shortcut);
-	Ref<InputEvent> get_shortcut() const;
-	bool is_shortcut(const Ref<InputEvent> &p_event) const;
+	void set_shortcut(const Ref<InputEvent> &p_shortcut, bool p_primary = true);
+	Ref<InputEvent> get_shortcut(bool p_primary = true) const;
+	bool is_shortcut(const Ref<InputEvent> &p_event, bool p_match_either = true, bool p_primary = true) const;
 	bool is_valid() const;
 
-	String get_as_text() const;
+	String get_as_text(bool p_primary = true) const;
 
 	Shortcut();
 };


### PR DESCRIPTION
This allows primary and secondary events for shortcuts, allowing up to 2 input events to be set for shortcuts.

This is partially in an effort to stop having shortcuts hardcoded into the engine (e.g. #47929). However, it does bring parity with other engines such as UE4 which do allow a primary and secondary shortcut binding for all actions.

- Configurable through editor settings.
- Exposed to scripting and shortcut resources (e.g. Shortcut.tres), so usable by users in their projects.
- Serialisation of shortcuts to the editor settings file has been changed to support saving primary and secondary shortcuts. It is backwards compatible with the current saving system (via a conversion on startup to the new format).
- Shortcut API has been update to allow getting/setting/checking of both the primary and secondary shortcuts. This is via a method argument `p_primary`. The default parameters for these methods have been designed such that it is fully backwards compatible.
- Documentation for `Shortcut` updated.

Supersedes / closes #47929

![image](https://user-images.githubusercontent.com/41730826/115168425-310cec80-a0fe-11eb-9766-4901f8dbefa4.png)
![image](https://user-images.githubusercontent.com/41730826/115168450-42ee8f80-a0fe-11eb-9f0a-48b88bb82427.png)
