### PR TITLE
Expose set_surface_material and set_editable_instance methods

### DIFF
--- a/editor/import/scene_importer_mesh.cpp
+++ b/editor/import/scene_importer_mesh.cpp
@@ -803,6 +803,7 @@ void EditorSceneImporterMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_surface_lod_size", "surface_idx", "lod_idx"), &EditorSceneImporterMesh::get_surface_lod_size);
 	ClassDB::bind_method(D_METHOD("get_surface_lod_indices", "surface_idx", "lod_idx"), &EditorSceneImporterMesh::get_surface_lod_indices);
 	ClassDB::bind_method(D_METHOD("get_surface_material", "surface_idx"), &EditorSceneImporterMesh::get_surface_material);
+	ClassDB::bind_method(D_METHOD("set_surface_material", "surface_idx", "material"), &EditorSceneImporterMesh::set_surface_material);
 
 	ClassDB::bind_method(D_METHOD("get_mesh"), &EditorSceneImporterMesh::get_mesh);
 	ClassDB::bind_method(D_METHOD("clear"), &EditorSceneImporterMesh::clear);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2761,6 +2761,8 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_scene_instance_load_placeholder", "load_placeholder"), &Node::set_scene_instance_load_placeholder);
 	ClassDB::bind_method(D_METHOD("get_scene_instance_load_placeholder"), &Node::get_scene_instance_load_placeholder);
+	ClassDB::bind_method(D_METHOD("set_editable_instance", "node", "is_editable"), &Node::set_editable_instance);
+	ClassDB::bind_method(D_METHOD("is_editable_instance", "node"), &Node::is_editable_instance);
 
 	ClassDB::bind_method(D_METHOD("get_viewport"), &Node::get_viewport);
 


### PR DESCRIPTION
These two methods are required for a custom importer I am building.

`set_surface_material` was available on MeshInstance3D but not on EditorSceneImportMesh. Having this method available allows importer scripts to mutate the materials (for example, swap a StandardMaterial3D to a custom ShaderMaterial.

`set_editable_instance` is the best way to make an importer which includes scene references to another file. In my case, I had to create a scene which references a .glb file and adds BoneAttachment / extensions to it. Instancing an editable scene seems like a logical way to do this, but this function is required in GDScript.