### PR TITLE
Fix broken NavigationAgent3D collision avoidance callbacks

### DIFF
--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -34,6 +34,8 @@
 #include "servers/navigation_server_3d.h"
 
 void NavigationAgent3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationAgent3D::get_rid);
+
 	ClassDB::bind_method(D_METHOD("set_target_desired_distance", "desired_distance"), &NavigationAgent3D::set_target_desired_distance);
 	ClassDB::bind_method(D_METHOD("get_target_desired_distance"), &NavigationAgent3D::get_target_desired_distance);
 
@@ -95,8 +97,11 @@ void NavigationAgent3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			agent_parent = Object::cast_to<Node3D>(get_parent());
-
-			NavigationServer3D::get_singleton()->agent_set_callback(agent, this, "_avoidance_done");
+			if (agent_parent != nullptr) {
+				// place agent on navigation map first or else the RVO agent callback creation fails silently later
+				NavigationServer3D::get_singleton()->agent_set_map(get_rid(), agent_parent->get_world_3d()->get_navigation_map());
+				NavigationServer3D::get_singleton()->agent_set_callback(agent, this, "_avoidance_done");
+			}
 			set_physics_process_internal(true);
 		} break;
 		case NOTIFICATION_EXIT_TREE: {


### PR DESCRIPTION
Fixes #47337
Fixes #39692

Fix broken NavigationAgent3D collision avoidance callbacks.

Collision avoidance is broken and this is only a mini pr in advance cause it is important to make it testable again for larger fixes.

The callbacks are responsible for the `safe_velocity` signal received by the agents. The dispatched callbacks by the RVO agent would all fail silently if the NavigationAgent3D was not registered on a navigation map before calling the agent_set_callback function.

Now all agents are placed on the default navigation map for the agents parent node so they work by default and can be customized later by the user. This pr also exposes the `NavigationAgent3D.get_rid()` function for scripting cause the agent RID is required by many `NavigationServer3D` queries, e.g. to change agent map or create new callbacks after changes.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
