### PR TITLE
FBX Parser fixes

### DIFF
--- a/modules/fbx/fbx_parser/FBXDocument.h
+++ b/modules/fbx/fbx_parser/FBXDocument.h
@@ -31,6 +31,7 @@
 /** @file  FBXDocument.h
  *  @brief FBX DOM
  */
+
 #ifndef FBX_DOCUMENT_H
 #define FBX_DOCUMENT_H
 
@@ -1099,7 +1100,6 @@ private:
 class Document {
 public:
 	Document(const Parser &parser, const ImportSettings &settings);
-
 	~Document();
 
 	LazyObject *GetObject(uint64_t id) const;
@@ -1202,7 +1202,6 @@ private:
 	void ReadObjects();
 	void ReadPropertyTemplates();
 	void ReadConnections();
-	void ReadGlobalSettings();
 
 private:
 	const ImportSettings &settings;

--- a/modules/fbx/fbx_parser/FBXDocumentUtil.h
+++ b/modules/fbx/fbx_parser/FBXDocumentUtil.h
@@ -125,7 +125,12 @@ const T *ProcessSimpleConnection(const Connection &con,
 
 	// Cast Object to AnimationPlayer for example using safe functions, which return nullptr etc
 	Object *ob = con.SourceObject();
-	ERR_FAIL_COND_V_MSG(!ob, nullptr, "Failed to load object from SourceObject ptr");
+
+	if (!ob) {
+		FBX_CORRUPT;
+		return nullptr;
+	}
+
 	return dynamic_cast<const T *>(ob);
 }
 } // namespace Util

--- a/modules/fbx/fbx_parser/FBXError.cpp
+++ b/modules/fbx/fbx_parser/FBXError.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  FBXParseTools.h                                                      */
+/*  FBXError.cpp                                                         */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,88 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef FBX_PARSE_TOOLS_H
-#define FBX_PARSE_TOOLS_H
-
 #include "FBXError.h"
-#include "core/error/error_macros.h"
-#include "core/string/ustring.h"
 
-#include <stdint.h>
-#include <algorithm>
-#include <locale>
+//
+// Created by Gordon MacPherson on 20/04/2021.
+//
 
-template <class char_t>
-inline bool IsNewLine(char_t c) {
-	return c == '\n' || c == '\r';
-}
-template <class char_t>
-inline bool IsSpace(char_t c) {
-	return (c == (char_t)' ' || c == (char_t)'\t');
-}
-
-template <class char_t>
-inline bool IsSpaceOrNewLine(char_t c) {
-	return IsNewLine(c) || IsSpace(c);
-}
-
-template <class char_t>
-inline bool IsLineEnd(char_t c) {
-	return (c == (char_t)'\r' || c == (char_t)'\n' || c == (char_t)'\0' || c == (char_t)'\f');
-}
-
-// ------------------------------------------------------------------------------------
-// Special version of the function, providing higher accuracy and safety
-// It is mainly used by fast_atof to prevent ugly and unwanted integer overflows.
-// ------------------------------------------------------------------------------------
-inline uint64_t strtoul10_64(const char *in, bool &errored, const char **out = nullptr, unsigned int *max_inout = nullptr) {
-	unsigned int cur = 0;
-	uint64_t value = 0;
-
-	errored = *in < '0' || *in > '9';
-	if (errored) {
-		FBX_CORRUPT;
-		return 0;
-	}
-
-	for (;;) {
-		if (*in < '0' || *in > '9') {
-			break;
-		}
-
-		const uint64_t new_value = (value * (uint64_t)10) + ((uint64_t)(*in - '0'));
-
-		// numeric overflow, we rely on you
-		if (new_value < value) {
-			//WARN_PRINT( "Converting the string \" " + in + " \" into a value resulted in overflow." );
-			return 0;
-		}
-
-		value = new_value;
-
-		++in;
-		++cur;
-
-		if (max_inout && *max_inout == cur) {
-			if (out) { /* skip to end */
-				while (*in >= '0' && *in <= '9') {
-					++in;
-				}
-				*out = in;
-			}
-
-			return value;
-		}
-	}
-	if (out) {
-		*out = in;
-	}
-
-	if (max_inout) {
-		*max_inout = cur;
-	}
-
-	return value;
-}
-
-#endif // FBX_PARSE_TOOLS_H
+thread_local bool FBXError::corrupt = false;

--- a/modules/fbx/fbx_parser/FBXError.h
+++ b/modules/fbx/fbx_parser/FBXError.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  FBXParseTools.h                                                      */
+/*  FBXError.h                                                           */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,88 +28,48 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef FBX_PARSE_TOOLS_H
-#define FBX_PARSE_TOOLS_H
+//
+// Created by Gordon MacPherson on 20/04/2021.
+//
 
-#include "FBXError.h"
-#include "core/error/error_macros.h"
-#include "core/string/ustring.h"
+#ifndef FBX_ERROR_H
+#define FBX_ERROR_H
 
-#include <stdint.h>
-#include <algorithm>
-#include <locale>
+#include "core/string/print_string.h"
 
-template <class char_t>
-inline bool IsNewLine(char_t c) {
-	return c == '\n' || c == '\r';
-}
-template <class char_t>
-inline bool IsSpace(char_t c) {
-	return (c == (char_t)' ' || c == (char_t)'\t');
-}
+#define FBX_ERROR_DETECTED FBXError::IsCorrupt()
+#define IF_FBX_IS_CORRUPT_RETURN \
+	if (FBXError::IsCorrupt()) { \
+		return;                  \
+	}
+#define IS_FBX_CORRUPT FBXError::IsCorrupt()
+#define FBX_CORRUPT FBXError::SetCorrupt()
 
-template <class char_t>
-inline bool IsSpaceOrNewLine(char_t c) {
-	return IsNewLine(c) || IsSpace(c);
-}
+#define FBX_CORRUPT_ERROR_PTR \
+	FBX_CORRUPT;              \
+	return nullptr;
 
-template <class char_t>
-inline bool IsLineEnd(char_t c) {
-	return (c == (char_t)'\r' || c == (char_t)'\n' || c == (char_t)'\0' || c == (char_t)'\f');
-}
-
-// ------------------------------------------------------------------------------------
-// Special version of the function, providing higher accuracy and safety
-// It is mainly used by fast_atof to prevent ugly and unwanted integer overflows.
-// ------------------------------------------------------------------------------------
-inline uint64_t strtoul10_64(const char *in, bool &errored, const char **out = nullptr, unsigned int *max_inout = nullptr) {
-	unsigned int cur = 0;
-	uint64_t value = 0;
-
-	errored = *in < '0' || *in > '9';
-	if (errored) {
-		FBX_CORRUPT;
-		return 0;
+#define FBX_CORRUPT_ERROR_BOOL \
+	if (IS_FBX_CORRUPT) {      \
+		return false;          \
 	}
 
-	for (;;) {
-		if (*in < '0' || *in > '9') {
-			break;
-		}
-
-		const uint64_t new_value = (value * (uint64_t)10) + ((uint64_t)(*in - '0'));
-
-		// numeric overflow, we rely on you
-		if (new_value < value) {
-			//WARN_PRINT( "Converting the string \" " + in + " \" into a value resulted in overflow." );
-			return 0;
-		}
-
-		value = new_value;
-
-		++in;
-		++cur;
-
-		if (max_inout && *max_inout == cur) {
-			if (out) { /* skip to end */
-				while (*in >= '0' && *in <= '9') {
-					++in;
-				}
-				*out = in;
-			}
-
-			return value;
-		}
-	}
-	if (out) {
-		*out = in;
+struct FBXError {
+	static bool IsCorrupt() {
+		return FBXError::corrupt;
 	}
 
-	if (max_inout) {
-		*max_inout = cur;
+	static void ClearCorrupt() {
+		FBXError::corrupt = false;
 	}
 
-	return value;
-}
+	static void SetCorrupt() {
+		print_error("FBX Document was found to be corrupt, we have decided to stop all operations");
+		FBXError::corrupt = true;
+	}
 
-#endif // FBX_PARSE_TOOLS_H
+	// NOTE: thread local should be required, but may crash since godot is not in the same static lib
+	thread_local static bool corrupt;
+};
+
+#endif // FBX_ERROR_H

--- a/modules/fbx/fbx_parser/FBXModel.cpp
+++ b/modules/fbx/fbx_parser/FBXModel.cpp
@@ -87,18 +87,20 @@ using namespace Util;
 Model::Model(uint64_t id, const ElementPtr element, const Document &doc, const std::string &name) :
 		Object(id, element, name), shading("Y") {
 	const ScopePtr sc = GetRequiredScope(element);
+	IF_FBX_IS_CORRUPT_RETURN;
 	const ElementPtr Shading = sc->GetElement("Shading");
 	const ElementPtr Culling = sc->GetElement("Culling");
-
+	IF_FBX_IS_CORRUPT_RETURN;
 	if (Shading) {
 		shading = GetRequiredToken(Shading, 0)->StringContents();
 	}
-
+	IF_FBX_IS_CORRUPT_RETURN;
 	if (Culling) {
 		culling = ParseTokenAsString(GetRequiredToken(Culling, 0));
 	}
-
+	IF_FBX_IS_CORRUPT_RETURN;
 	ResolveLinks(element, doc);
+	IF_FBX_IS_CORRUPT_RETURN;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -159,6 +161,10 @@ void Model::ResolveLinks(const ElementPtr element, const Document &doc) {
 // ------------------------------------------------------------------------------------------------
 bool Model::IsNull() const {
 	const std::vector<const NodeAttribute *> &attrs = GetAttributes();
+	if (IS_FBX_CORRUPT) {
+		return true;
+	}
+
 	for (const NodeAttribute *att : attrs) {
 		const Null *null_tag = dynamic_cast<const Null *>(att);
 		if (null_tag) {

--- a/modules/fbx/fbx_parser/FBXNodeAttribute.cpp
+++ b/modules/fbx/fbx_parser/FBXNodeAttribute.cpp
@@ -99,15 +99,15 @@ CameraSwitcher::CameraSwitcher(uint64_t id, const ElementPtr element, const Docu
 	const ElementPtr CameraId = sc->GetElement("CameraId");
 	const ElementPtr CameraName = sc->GetElement("CameraName");
 	const ElementPtr CameraIndexName = sc->GetElement("CameraIndexName");
-
+	IF_FBX_IS_CORRUPT_RETURN;
 	if (CameraId) {
 		cameraId = ParseTokenAsInt(GetRequiredToken(CameraId, 0));
 	}
-
+	IF_FBX_IS_CORRUPT_RETURN;
 	if (CameraName) {
 		cameraName = GetRequiredToken(CameraName, 0)->StringContents();
 	}
-
+	IF_FBX_IS_CORRUPT_RETURN;
 	if (CameraIndexName && CameraIndexName->Tokens().size()) {
 		cameraIndexName = GetRequiredToken(CameraIndexName, 0)->StringContents();
 	}

--- a/modules/fbx/fbx_parser/FBXPose.cpp
+++ b/modules/fbx/fbx_parser/FBXPose.cpp
@@ -88,6 +88,7 @@ FbxPose::FbxPose(uint64_t id, const ElementPtr element, const Document &doc, con
 	//const std::string &classname = ParseTokenAsString(GetRequiredToken(element, 2));
 
 	const ElementCollection &PoseNodes = sc->GetCollection("PoseNode");
+	IF_FBX_IS_CORRUPT_RETURN;
 	for (ElementMap::const_iterator it = PoseNodes.first; it != PoseNodes.second; ++it) {
 		std::string entry_name = (*it).first;
 		ElementPtr some_element = (*it).second;
@@ -98,6 +99,9 @@ FbxPose::FbxPose(uint64_t id, const ElementPtr element, const Document &doc, con
 
 // ------------------------------------------------------------------------------------------------
 FbxPose::~FbxPose() {
+	for (FbxPoseNode *x : pose_nodes) {
+		delete x;
+	}
 	pose_nodes.clear();
 	// empty
 }

--- a/modules/fbx/fbx_parser/FBXTokenizer.cpp
+++ b/modules/fbx/fbx_parser/FBXTokenizer.cpp
@@ -124,16 +124,22 @@ void ProcessDataToken(TokenList &output_tokens, const char *&start, const char *
 
 			if (!in_double_quotes && IsSpaceOrNewLine(*c)) {
 				TokenizeError("unexpected whitespace in token", line, column);
+				FBX_CORRUPT;
+				return;
 			}
 		}
 
 		if (in_double_quotes) {
 			TokenizeError("non-terminated double quotes", line, column);
+			FBX_CORRUPT;
+			return;
 		}
 
 		output_tokens.push_back(new_Token(start, end + 1, type, line, column));
 	} else if (must_have_token) {
 		TokenizeError("unexpected character, expected data token", line, column);
+		FBX_CORRUPT;
+		return;
 	}
 
 	start = end = nullptr;
@@ -185,6 +191,7 @@ void Tokenize(TokenList &output_tokens, const char *input, size_t length, bool &
 			case '\"':
 				if (token_begin) {
 					TokenizeError("unexpected double-quote", line, column);
+					FBX_CORRUPT;
 					corrupt = true;
 					return;
 				}


### PR DESCRIPTION
This will prevent a bunch of crashes, but definitely still contains a few.

- Prevents invalid files from being loaded
- Fixes global file properties not being loaded correctly or at all
- Fixes regression in UnitScale not being imported
- Prevents crashing by exiting parser in many more cases
- Fixes 2 test files provided by @qarmin
- Fixes token conversion to data being able to crash
- Fixes GetRequiredScope/GetRequiredToken crashing


I think this contains a good start for the places to catch errors in the FBX parser.

TODO:
- [x] check if MSVC compiler will crash with thread_local like it did for doctest due to /MT flag on the static lib.
- [x] make sure all parser types use the IF_FBX_IS_CORRUPT_RETURN logic 
- [x] get more corrupt files from @qarmin 
- [x] Blender FBX files have the wrong vertex weight data and index count in them this will block skinned FBX meshes until the bug is fixed or the case is handled with a check, this is a good thing though it means we found the source of an issue we have with blender fbx files.