### PR TITLE
Fix Script editor completion doesn't suggest members of a script for type hints

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2983,8 +2983,17 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 							base_type.has_type = false;
 						}
 					} break;
-					case GDScriptParser::DataType::SCRIPT:
 					case GDScriptParser::DataType::GDSCRIPT: {
+						Ref<GDScript> scr = base_type.script_type;
+						if (scr.is_valid()) {
+							for (const Map<StringName, Ref<GDScript>>::Element *E = scr->get_subclasses().front(); E; E = E->next()) {
+								ScriptCodeCompletionOption option(E->key().operator String(), ScriptCodeCompletionOption::KIND_CLASS);
+								options.insert(option.display, option);
+							}
+						}
+						FALLTHROUGH;
+					}
+					case GDScriptParser::DataType::SCRIPT: {
 						Ref<Script> scr = base_type.script_type;
 						if (scr.is_valid()) {
 							Map<StringName, Variant> constants;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -5786,6 +5786,7 @@ bool GDScriptParser::_parse_type(DataType &r_type, bool p_can_be_void) {
 					can_index = false;
 					tokenizer->advance();
 				} break;
+				case GDScriptTokenizer::TK_CURSOR:
 				case GDScriptTokenizer::TK_IDENTIFIER: {
 					if (can_index) {
 						_set_error("Unexpected identifier.");


### PR DESCRIPTION
Fix #47720 
result:
![example](https://user-images.githubusercontent.com/56381255/114200907-3cd31300-9988-11eb-842a-f169c3098162.png)