### PR TITLE
ProjectSettingsEditor: Make "Type" OptionButton item ids match corresponding Variant::Type enum values

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -102,10 +102,9 @@ void ProjectSettingsEditor::_add_setting() {
 	String setting = _get_setting_name();
 
 	// Initialize the property with the default value for the given type.
-	// The type list starts at 1 (as we exclude Nil), so add 1 to the selected value.
 	Callable::CallError ce;
 	Variant value;
-	Variant::construct(Variant::Type(type->get_selected() + 1), value, nullptr, 0, ce);
+	Variant::construct(Variant::Type(type->get_selected_id()), value, nullptr, 0, ce);
 
 	undo_redo->create_action(TTR("Add Project Setting"));
 	undo_redo->add_do_property(ps, setting, value);
@@ -584,7 +583,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 			// There's no point in adding Nil types, and Object types
 			// can't be serialized correctly in the project settings.
 			if (i != Variant::NIL && i != Variant::OBJECT) {
-				type->add_item(Variant::get_type_name(Variant::Type(i)));
+				type->add_item(Variant::get_type_name(Variant::Type(i)), i);
 			}
 		}
 


### PR DESCRIPTION
Fixes #48045.
Cherry-pickable for `3.x`.