### PR TITLE
Re-add "no-exceptions" for export templates builds with ICU.

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -258,8 +258,10 @@ def configure(env):
     env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++abi/include"])
 
     # Disable exceptions and rtti on non-tools (template) builds
-    if env["tools"] or env["builtin_icu"]:
+    if env["tools"]:
         env.Append(CXXFLAGS=["-frtti"])
+    elif env["builtin_icu"]:
+        env.Append(CXXFLAGS=["-frtti", "-fno-exceptions"])
     else:
         env.Append(CXXFLAGS=["-fno-rtti", "-fno-exceptions"])
         # Don't use dynamic_cast, necessary with no-rtti.

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -95,8 +95,9 @@ def configure(env):
         if env["initial_memory"] < 64:
             print("Editor build requires at least 64MiB of initial memory. Forcing it.")
             env["initial_memory"] = 64
-    elif env["builtin_icu"]:
         env.Append(CCFLAGS=["-frtti"])
+    elif env["builtin_icu"]:
+        env.Append(CCFLAGS=["-fno-exceptions", "-frtti"])
     else:
         # Disable exceptions and rtti on non-tools (template) builds
         # These flags help keep the file size down.


### PR DESCRIPTION
ICU requires only RTTI, exceptions and STL are not used. 

> We continue to not use the Standard Template Library (STL) in ICU library code because its design causes a lot of code bloat. More importantly:
>
>    - Exceptions: STL classes and algorithms throw exceptions. ICU does not throw exceptions, and ICU code is not exception-safe.
>    - Memory management: STL uses default new/delete, or Allocator parameters which create different types; they throw out-of-memory exceptions. ICU memory allocation is customizable and must not throw exceptions.
>    - Non-polymorphic: For APIs, STL classes are also problematic because different template specializations create different types. For example, some systems use custom string classes (different allocators, different strategies for buffer sharing vs. copying), and ICU should be able to interface with most of them.
>
>We have started to use compiler-provided Run-Time Type Information (RTTI) in ICU 4.6. It is now required for building ICU, and encouraged for using ICU where RTTI is needed.

https://github.com/unicode-org/icu/blob/main/docs/userguide/dev/codingguidelines.md