### PR TITLE
Registering Global Script Classes under Mono

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1454,6 +1454,41 @@ Map<Object *, CSharpScriptBinding>::Element *CSharpLanguage::insert_script_bindi
 	return script_bindings.insert(p_object, p_script_binding);
 }
 
+bool CSharpLanguage::handles_global_class_type(const String &p_type) const {
+	return p_type == "CSharpScript";
+}
+
+String CSharpLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const {
+	if (!p_path.is_empty()) {
+		Ref<CSharpScript> script = ResourceLoader::load(p_path, "CSharpScript");
+
+		if (script.is_valid()) {
+			GDMonoClass *top = script->script_class;
+
+			if (top && top != script->native) {
+				MonoClass *parent_mono_class = mono_class_get_parent(top->get_mono_ptr());
+
+				if (r_base_type && parent_mono_class) {
+					*r_base_type = String::utf8(mono_class_get_name(parent_mono_class));
+				}
+
+				if (r_icon_path) {
+					*r_icon_path = script->get_script_class_icon_path();
+				}
+
+				return String(top->get_name());
+			}
+		}
+		if (r_base_type) {
+			*r_base_type = String();
+		}
+		if (r_icon_path) {
+			*r_icon_path = String();
+		}
+	}
+	return String();
+}
+
 void CSharpLanguage::free_instance_binding_data(void *p_data) {
 	if (GDMono::get_singleton() == nullptr) {
 #ifdef DEBUG_ENABLED

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -129,6 +129,7 @@ private:
 
 	String source;
 	StringName name;
+	String _icon_path;
 
 	SelfList<CSharpScript> script_list = this;
 
@@ -201,6 +202,14 @@ public:
 	bool has_source_code() const override;
 	String get_source_code() const override;
 	void set_source_code(const String &p_code) override;
+
+	String get_script_class_name() const {
+		return name;
+	}
+
+	String get_script_class_icon_path() const {
+		return _icon_path;
+	}
 
 #ifdef TOOLS_ENABLED
 	virtual const Vector<DocData::ClassDoc> &get_documentation() const override {
@@ -533,6 +542,8 @@ public:
 	void free_instance_binding_data(void *p_data) override;
 	void refcount_incremented_instance_binding(Object *p_object) override;
 	bool refcount_decremented_instance_binding(Object *p_object) override;
+	virtual bool handles_global_class_type(const String &p_type) const;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const;
 
 	Map<Object *, CSharpScriptBinding>::Element *insert_script_binding(Object *p_object, const CSharpScriptBinding &p_script_binding);
 	bool setup_csharp_script_binding(CSharpScriptBinding &r_script_binding, Object *p_object);


### PR DESCRIPTION
Registering Editor Plugins, Custom Resources and CustomNodes to _global_script_classes like in all other Scripting Languages (GD, Native..).

This PR is neccesary to create as example Custom Nodes from type "VisualShaderNodeCustom" to use them inside the Visual Editor under Mono. The reason is because the Visual Shadar Editor is doing a lookup for custom nodes by the attribute "to _global_script_classes" of the "project.godot" file. This pr is also usefull for godot 3.

Example:

C# Script for VisualShaderNodeCustom
![image](https://user-images.githubusercontent.com/76991284/115482912-07fc7100-a250-11eb-9aa6-de025eefe222.png)
Visual Shader Node List
![image](https://user-images.githubusercontent.com/76991284/115482821-d2f01e80-a24f-11eb-908f-f8e7ea19f7d2.png)
VisualShaderNodeCustom attached to the Visual Editor
![image](https://user-images.githubusercontent.com/76991284/115482828-d8e5ff80-a24f-11eb-9ea8-8f0dd7912dc3.png)
Project file with Extensions written in C#
![image](https://user-images.githubusercontent.com/76991284/115482852-e307fe00-a24f-11eb-963f-9e4bc4f74746.png)

This PR is not related to any other 

Btw this issue fix also a problem with custom resources which binded under mono to an export array.