### PR TITLE
Add setting for shadow cubemap max size

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1258,6 +1258,9 @@
 		<member name="rendering/quality/shading/force_vertex_shading.mobile" type="bool" setter="" getter="" default="true">
 			Lower-end override for [member rendering/quality/shading/force_vertex_shading] on mobile devices, due to performance concerns or driver support.
 		</member>
+		<member name="rendering/quality/shadow_atlas/cubemap_size" type="int" setter="" getter="" default="512">
+			Size for cubemap into which the shadow is rendered before being copied into the shadow atlas. A higher number can result in higher resolution shadows when used with a higher [member rendering/quality/shadow_atlas/size]. Setting higher than a quarter of the [member rendering/quality/shadow_atlas/size] will not result in a perceptible increase in visual quality.
+		</member>
 		<member name="rendering/quality/shadow_atlas/quadrant_0_subdiv" type="int" setter="" getter="" default="1">
 			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
 		</member>

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -4006,7 +4006,7 @@ void RasterizerSceneGLES2::initialize() {
 
 	// cubemaps for shadows
 	if (storage->config.support_shadow_cubemaps) { //not going to be used
-		int max_shadow_cubemap_sampler_size = CLAMP(int(next_power_of_2(GLOBAL_GET("rendering/quality/shadow_atlas/size")) >> 1), 256, storage->config.max_cubemap_texture_size);
+		int max_shadow_cubemap_sampler_size = MIN(int(GLOBAL_GET("rendering/quality/shadow_atlas/cubemap_size")), storage->config.max_cubemap_texture_size);
 
 		int cube_size = max_shadow_cubemap_sampler_size;
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -5110,7 +5110,7 @@ void RasterizerSceneGLES3::initialize() {
 
 	shadow_atlas_realloc_tolerance_msec = 500;
 
-	int max_shadow_cubemap_sampler_size = CLAMP(int(next_power_of_2(GLOBAL_GET("rendering/quality/shadow_atlas/size")) >> 1), 256, storage->config.max_cubemap_texture_size);
+	int max_shadow_cubemap_sampler_size = MIN(int(GLOBAL_GET("rendering/quality/shadow_atlas/cubemap_size")), storage->config.max_cubemap_texture_size);
 
 	int cube_size = max_shadow_cubemap_sampler_size;
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2409,6 +2409,8 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF_RST("rendering/quality/shadow_atlas/size", 4096);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384"));
+	GLOBAL_DEF_RST("rendering/quality/shadow_atlas/cubemap_size", 512);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/cubemap_size", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/cubemap_size", PROPERTY_HINT_RANGE, "64,16384"));
 	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_0_subdiv", 1);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_1_subdiv", 2);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_2_subdiv", 3);


### PR DESCRIPTION
As discussed in https://github.com/godotengine/godot/issues/48036

This PR allows users to configure max cubemap shadow size. In 3.2 this value was fixed at 512 meaning that there was no improvement in shadow quality for shadow atlases of size 2048 or greater. https://github.com/godotengine/godot/pull/47160 set max cubemap shadow size based on atlas size. This is good for quality, but also meant that shadows are by default rendered with a higher resolution. 

A cap at 512 artificially makes it so that shadows are always low res. For example, a 2048x2048 quadrant (default quadrant size for first light) would use a 512x512 cubemap while a 1024x1024 segment would still use a 512x512 cubemap.

Another thing that 3.2 did funny was request a cubemap that was much to large for a given section. For example, if rendering to an 128x128 section of the atlas, a 256x256 cubemap would be used. This is a huge waste of resolution accordingly, pre-#47160 was using too low of resolution on high-detail shadows and too much resolution on low-detail shadows. 

This PR defaults to making the max cubemap shadow size 512. this matches the visual behaviour of 3.2 but allows users to increase to have higher resolution shadows if they need it at the cost of some performance. 

With this change, high-detail shadows should run the same as in 3.2 while low-detail shadows should look the same and run faster (in theory, in practice the bottleneck is elsewhere)

CC @puchik 