### PR TITLE
[3.x] Reset touch emulated mouse on press release.

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -380,6 +380,22 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 				}
 
 				_parse_input_event_impl(button_event, true);
+
+				// Reseting mouse position on release
+				// if we are emulating mouse from touch
+				if (!st->is_pressed()) {
+					Vector2 reset_position = Vector2(-1, -1);
+
+					Ref<InputEventMouseMotion> reset_mouse_event;
+					reset_mouse_event.instance();
+
+					reset_mouse_event->set_device(InputEvent::DEVICE_ID_TOUCH_MOUSE);
+					reset_mouse_event->set_position(reset_position);
+					reset_mouse_event->set_global_position(reset_position);
+					reset_mouse_event->set_button_mask(0);
+
+					_parse_input_event_impl(reset_mouse_event, true);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Same as #48065 for `3.x`

Fixes https://github.com/godotengine/godot/issues/47903

Sends a mouse motion event to move mouse to `(-1, -1)` position when touch is released.

Might require more testing especially for desktops with touch support or applications with multitouch support.
Since more testing is needed to ensure everything works correctly and hovering issue being present on older versions (`3.2.1`, `3.2.3`) this probably shouldn't be merged into 3.3