### PR TITLE
embree: Allow building against system library on Linux

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -151,6 +151,7 @@ opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise e
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_bullet", "Use the built-in Bullet library", True))
 opts.Add(BoolVariable("builtin_certs", "Use the built-in SSL certificates bundles", True))
+opts.Add(BoolVariable("builtin_embree", "Use the built-in Embree library", True))
 opts.Add(BoolVariable("builtin_enet", "Use the built-in ENet library", True))
 opts.Add(BoolVariable("builtin_freetype", "Use the built-in FreeType library", True))
 opts.Add(BoolVariable("builtin_libogg", "Use the built-in libogg library", True))

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -3,92 +3,97 @@
 Import("env")
 Import("env_modules")
 
-embree_src = [
-    "common/sys/sysinfo.cpp",
-    "common/sys/alloc.cpp",
-    "common/sys/filename.cpp",
-    "common/sys/library.cpp",
-    "common/sys/thread.cpp",
-    "common/sys/string.cpp",
-    "common/sys/regression.cpp",
-    "common/sys/mutex.cpp",
-    "common/sys/condition.cpp",
-    "common/sys/barrier.cpp",
-    "common/math/constants.cpp",
-    "common/simd/sse.cpp",
-    "common/lexers/stringstream.cpp",
-    "common/lexers/tokenstream.cpp",
-    "common/tasking/taskschedulerinternal.cpp",
-    "common/algorithms/parallel_for.cpp",
-    "common/algorithms/parallel_reduce.cpp",
-    "common/algorithms/parallel_prefix_sum.cpp",
-    "common/algorithms/parallel_for_for.cpp",
-    "common/algorithms/parallel_for_for_prefix_sum.cpp",
-    "common/algorithms/parallel_partition.cpp",
-    "common/algorithms/parallel_sort.cpp",
-    "common/algorithms/parallel_set.cpp",
-    "common/algorithms/parallel_map.cpp",
-    "common/algorithms/parallel_filter.cpp",
-    "kernels/common/device.cpp",
-    "kernels/common/stat.cpp",
-    "kernels/common/acceln.cpp",
-    "kernels/common/accelset.cpp",
-    "kernels/common/state.cpp",
-    "kernels/common/rtcore.cpp",
-    "kernels/common/rtcore_builder.cpp",
-    "kernels/common/scene.cpp",
-    "kernels/common/alloc.cpp",
-    "kernels/common/geometry.cpp",
-    "kernels/common/scene_triangle_mesh.cpp",
-    "kernels/geometry/primitive4.cpp",
-    "kernels/builders/primrefgen.cpp",
-    "kernels/bvh/bvh.cpp",
-    "kernels/bvh/bvh_statistics.cpp",
-    "kernels/bvh/bvh4_factory.cpp",
-    "kernels/bvh/bvh8_factory.cpp",
-    "kernels/bvh/bvh_collider.cpp",
-    "kernels/bvh/bvh_rotate.cpp",
-    "kernels/bvh/bvh_refit.cpp",
-    "kernels/bvh/bvh_builder.cpp",
-    "kernels/bvh/bvh_builder_morton.cpp",
-    "kernels/bvh/bvh_builder_sah.cpp",
-    "kernels/bvh/bvh_builder_sah_spatial.cpp",
-    "kernels/bvh/bvh_builder_sah_mb.cpp",
-    "kernels/bvh/bvh_builder_twolevel.cpp",
-    "kernels/bvh/bvh_intersector1_bvh4.cpp",
-]
-
-embree_dir = "#thirdparty/embree/"
-
-env_embree = env_modules.Clone()
-embree_sources = [embree_dir + file for file in embree_src]
-env_embree.Prepend(CPPPATH=[embree_dir, embree_dir + "include"])
-env_embree.Append(
-    CPPFLAGS=[
-        "-DEMBREE_TARGET_SSE2",
-        "-DEMBREE_LOWEST_ISA",
-        "-DTASKING_INTERNAL",
-        "-DNDEBUG",
-        "-D__SSE2__",
-        "-D__SSE__",
-    ]
-)
-
-if not env_embree.msvc:
-    env_embree.Append(CPPFLAGS=["-msse2", "-mxsave"])
-    if env["platform"] == "windows":
-        env_embree.Append(CPPFLAGS=["-mstackrealign"])
-
-if env["platform"] == "windows":
-    if env.msvc:
-        env.Append(LINKFLAGS=["psapi.lib"])
-    else:
-        env.Append(LIBS=["psapi"])
-
-env_embree.disable_warnings()
-env_embree.add_source_files(env.modules_sources, embree_sources)
-
 env_raycast = env_modules.Clone()
-env_raycast.Prepend(CPPPATH=[embree_dir, embree_dir + "include", embree_dir + "common"])
 
+# Thirdparty source files
+
+if env["builtin_embree"]:
+    thirdparty_dir = "#thirdparty/embree/"
+
+    embree_src = [
+        "common/sys/sysinfo.cpp",
+        "common/sys/alloc.cpp",
+        "common/sys/filename.cpp",
+        "common/sys/library.cpp",
+        "common/sys/thread.cpp",
+        "common/sys/string.cpp",
+        "common/sys/regression.cpp",
+        "common/sys/mutex.cpp",
+        "common/sys/condition.cpp",
+        "common/sys/barrier.cpp",
+        "common/math/constants.cpp",
+        "common/simd/sse.cpp",
+        "common/lexers/stringstream.cpp",
+        "common/lexers/tokenstream.cpp",
+        "common/tasking/taskschedulerinternal.cpp",
+        "common/algorithms/parallel_for.cpp",
+        "common/algorithms/parallel_reduce.cpp",
+        "common/algorithms/parallel_prefix_sum.cpp",
+        "common/algorithms/parallel_for_for.cpp",
+        "common/algorithms/parallel_for_for_prefix_sum.cpp",
+        "common/algorithms/parallel_partition.cpp",
+        "common/algorithms/parallel_sort.cpp",
+        "common/algorithms/parallel_set.cpp",
+        "common/algorithms/parallel_map.cpp",
+        "common/algorithms/parallel_filter.cpp",
+        "kernels/common/device.cpp",
+        "kernels/common/stat.cpp",
+        "kernels/common/acceln.cpp",
+        "kernels/common/accelset.cpp",
+        "kernels/common/state.cpp",
+        "kernels/common/rtcore.cpp",
+        "kernels/common/rtcore_builder.cpp",
+        "kernels/common/scene.cpp",
+        "kernels/common/alloc.cpp",
+        "kernels/common/geometry.cpp",
+        "kernels/common/scene_triangle_mesh.cpp",
+        "kernels/geometry/primitive4.cpp",
+        "kernels/builders/primrefgen.cpp",
+        "kernels/bvh/bvh.cpp",
+        "kernels/bvh/bvh_statistics.cpp",
+        "kernels/bvh/bvh4_factory.cpp",
+        "kernels/bvh/bvh8_factory.cpp",
+        "kernels/bvh/bvh_collider.cpp",
+        "kernels/bvh/bvh_rotate.cpp",
+        "kernels/bvh/bvh_refit.cpp",
+        "kernels/bvh/bvh_builder.cpp",
+        "kernels/bvh/bvh_builder_morton.cpp",
+        "kernels/bvh/bvh_builder_sah.cpp",
+        "kernels/bvh/bvh_builder_sah_spatial.cpp",
+        "kernels/bvh/bvh_builder_sah_mb.cpp",
+        "kernels/bvh/bvh_builder_twolevel.cpp",
+        "kernels/bvh/bvh_intersector1_bvh4.cpp",
+    ]
+
+    thirdparty_sources = [thirdparty_dir + file for file in embree_src]
+
+    env_raycast.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "include"])
+    env_raycast.Append(
+        CPPDEFINES=[
+            "EMBREE_TARGET_SSE2",
+            "EMBREE_LOWEST_ISA",
+            "TASKING_INTERNAL",
+            "NDEBUG",
+            "__SSE2__",
+            "__SSE__",
+        ]
+    )
+
+    if not env.msvc:
+        env_raycast.Append(CPPFLAGS=["-msse2", "-mxsave"])
+        if env["platform"] == "windows":
+            env_raycast.Append(CPPFLAGS=["-mstackrealign"])
+
+    if env["platform"] == "windows":
+        if env.msvc:
+            env.Append(LINKFLAGS=["psapi.lib"])
+        else:
+            env.Append(LIBS=["psapi"])
+
+    env_thirdparty = env_raycast.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+
+
+# Godot source files
 env_raycast.add_source_files(env.modules_sources, "*.cpp")

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -310,6 +310,10 @@ def configure(env):
     if not env["builtin_pcre2"]:
         env.ParseConfig("pkg-config libpcre2-32 --cflags --libs")
 
+    if not env["builtin_embree"]:
+        # No pkgconfig file so far, hardcode expected lib name.
+        env.Append(LIBS=["embree3"])
+
     ## Flags
 
     if os.system("pkg-config --exists alsa") == 0:  # 0 means found


### PR DESCRIPTION
Tested on my distro Mageia, I could successfully link against system-packaged `lib64embree3-devel-3.12.1-1.mga8` which seems to be the same version we vendor (and our patches are only for Windows/MinGW support).