### PR TITLE
fbx: Fix include for zlib that broke unbundling

### DIFF
--- a/modules/fbx/SCsub
+++ b/modules/fbx/SCsub
@@ -8,6 +8,9 @@ env_fbx = env_modules.Clone()
 # Make includes relative to the folder path specified here so our includes are clean
 env_fbx.Prepend(CPPPATH=["#modules/fbx/"])
 
+if env["builtin_zlib"]:
+    env_fbx.Prepend(CPPPATH=["#thirdparty/zlib/"])
+
 # Godot's own source files
 env_fbx.add_source_files(env.modules_sources, "tools/*.cpp")
 env_fbx.add_source_files(env.modules_sources, "data/*.cpp")

--- a/modules/fbx/fbx_parser/FBXParser.cpp
+++ b/modules/fbx/fbx_parser/FBXParser.cpp
@@ -74,8 +74,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *  @brief Implementation of the FBX parser and the rudimentary DOM that we use
  */
 
-#include "thirdparty/zlib/zlib.h"
 #include <stdlib.h> /* strtol */
+#include <zlib.h>
 
 #include "ByteSwapper.h"
 #include "FBXParseTools.h"


### PR DESCRIPTION
It's possible to link against system zlib on Linux, so we should use system paths.