### PR TITLE
Fix Closing Running Game, still shows remote and local tabs

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -209,7 +209,7 @@ void EditorDebuggerNode::stop() {
 	// Also close all debugging sessions.
 	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
 		if (dbg->is_session_active()) {
-			dbg->stop();
+			dbg->_stop_and_notify();
 		}
 	});
 	_break_state_changed();


### PR DESCRIPTION
Fixing an issue with "Closing Running Game, still shows remote and local tabs".

To reproduce the error, just starting and game and use the "stop button" to close the game, the remote tree will not be disabled because the notifier will not be triggered.

![image](https://user-images.githubusercontent.com/76991284/115668987-11690480-a348-11eb-8968-1c8e3cfab785.png)


Related to this issue: https://github.com/godotengine/godot/issues/47643