### PR TITLE
Fix crash on GDNative API json generator exit.

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -41,6 +41,8 @@
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 
+#include "main/main.h"
+
 #include "scene/main/scene_tree.h"
 #include "scene/resources/resource_format_text.h"
 
@@ -1248,6 +1250,7 @@ void NativeScriptLanguage::init() {
 		if (generate_c_api(E->next()->get()) != OK) {
 			ERR_PRINT("Failed to generate C API\n");
 		}
+		Main::cleanup(true);
 		exit(0);
 	}
 
@@ -1257,6 +1260,7 @@ void NativeScriptLanguage::init() {
 		if (generate_c_builtin_api(E->next()->get()) != OK) {
 			ERR_PRINT("Failed to generate C builtin API\n");
 		}
+		Main::cleanup(true);
 		exit(0);
 	}
 #endif


### PR DESCRIPTION
Fixes #48020

Relevant for 3.x (3.x code have only the first `if` with `exit(0);`, but it is exactly same).

*Bugsquad edit:* Fixes #36582.
