### PR TITLE
[3.x] CPU lightmapper environment energy fixes.

### DIFF
--- a/modules/raycast/lightmap_raycaster.cpp
+++ b/modules/raycast/lightmap_raycaster.cpp
@@ -30,12 +30,7 @@
 
 #include "lightmap_raycaster.h"
 
-// From Embree.
-#include <math/vec2.h>
-#include <math/vec3.h>
-#include <xmmintrin.h>
-
-using namespace embree;
+#include <pmmintrin.h>
 
 LightmapRaycaster *LightmapRaycasterEmbree::create_embree_raycaster() {
 	return memnew(LightmapRaycasterEmbree);
@@ -135,23 +130,22 @@ void LightmapRaycasterEmbree::add_mesh(const Vector<Vector3> &p_vertices, const 
 
 	ERR_FAIL_COND(vertex_count % 3 != 0);
 	ERR_FAIL_COND(vertex_count != p_uv2s.size());
+	ERR_FAIL_COND(!p_normals.empty() && vertex_count != p_normals.size());
 
-	Vec3fa *embree_vertices = (Vec3fa *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT3, sizeof(Vec3fa), vertex_count);
-	Vec2fa *embree_light_uvs = (Vec2fa *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX_ATTRIBUTE, 0, RTC_FORMAT_FLOAT2, sizeof(Vec2fa), vertex_count);
+	Vector3 *embree_vertices = (Vector3 *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT3, sizeof(Vector3), vertex_count);
+	copymem(embree_vertices, p_vertices.ptr(), sizeof(Vector3) * vertex_count);
+
+	Vector2 *embree_light_uvs = (Vector2 *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX_ATTRIBUTE, 0, RTC_FORMAT_FLOAT2, sizeof(Vector2), vertex_count);
+	copymem(embree_light_uvs, p_uv2s.ptr(), sizeof(Vector2) * vertex_count);
+
 	uint32_t *embree_triangles = (uint32_t *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_INDEX, 0, RTC_FORMAT_UINT3, sizeof(uint32_t) * 3, vertex_count / 3);
-
-	Vec3fa *embree_normals = nullptr;
-	if (!p_normals.empty()) {
-		embree_normals = (Vec3fa *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX_ATTRIBUTE, 1, RTC_FORMAT_FLOAT3, sizeof(Vec3fa), vertex_count);
+	for (int i = 0; i < vertex_count; i++) {
+		embree_triangles[i] = i;
 	}
 
-	for (int i = 0; i < vertex_count; i++) {
-		embree_vertices[i] = Vec3fa(p_vertices[i].x, p_vertices[i].y, p_vertices[i].z);
-		embree_light_uvs[i] = Vec2fa(p_uv2s[i].x, p_uv2s[i].y);
-		if (embree_normals != nullptr) {
-			embree_normals[i] = Vec3fa(p_normals[i].x, p_normals[i].y, p_normals[i].z);
-		}
-		embree_triangles[i] = i;
+	if (!p_normals.empty()) {
+		Vector3 *embree_normals = (Vector3 *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX_ATTRIBUTE, 1, RTC_FORMAT_FLOAT3, sizeof(Vector3), vertex_count);
+		copymem(embree_normals, p_normals.ptr(), sizeof(Vector3) * vertex_count);
 	}
 
 	rtcCommitGeometry(embree_mesh);

--- a/scene/3d/baked_lightmap.h
+++ b/scene/3d/baked_lightmap.h
@@ -187,7 +187,7 @@ private:
 	void _clear_lightmaps();
 
 	void _get_material_images(const MeshesFound &p_found_mesh, Lightmapper::MeshData &r_mesh_data, Vector<Ref<Texture> > &r_albedo_textures, Vector<Ref<Texture> > &r_emission_textures);
-	Ref<Image> _get_irradiance_from_sky(Ref<Sky> p_sky, Vector2i p_size);
+	Ref<Image> _get_irradiance_from_sky(Ref<Sky> p_sky, float p_energy, Vector2i p_size);
 	Ref<Image> _get_irradiance_map(Ref<Environment> p_env, Vector2i p_size);
 	void _find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound> &meshes, Vector<LightsFound> &lights);
 	Vector2i _compute_lightmap_size(const MeshesFound &p_mesh);

--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -390,8 +390,8 @@ ProceduralSky::TextureSize ProceduralSky::get_texture_size() const {
 	return texture_size;
 }
 
-Ref<Image> ProceduralSky::get_panorama() const {
-	return panorama;
+Ref<Image> ProceduralSky::get_data() const {
+	return panorama->duplicate();
 }
 
 RID ProceduralSky::get_rid() const {

--- a/scene/resources/sky.h
+++ b/scene/resources/sky.h
@@ -190,7 +190,7 @@ public:
 	void set_texture_size(TextureSize p_size);
 	TextureSize get_texture_size() const;
 
-	Ref<Image> get_panorama() const;
+	Ref<Image> get_data() const;
 
 	virtual RID get_rid() const;
 


### PR DESCRIPTION
* Better handling of the scene's environment energy in the lightmapper bakes. Fixes #47785.
* Fixed a bug where `ProceduralSky::get_panorama()` returned a reference instead of a copy.
* Removed includes to Embree's internal header files. Should allow for linking against system-packaged Embree, see #48073.