### PR TITLE
Tweak lightmapper warning message to mention Rosetta emulation on macOS

### DIFF
--- a/editor/plugins/baked_lightmap_editor_plugin.cpp
+++ b/editor/plugins/baked_lightmap_editor_plugin.cpp
@@ -70,7 +70,11 @@ void BakedLightmapEditorPlugin::_bake_select_file(const String &p_file) {
 				EditorNode::get_singleton()->show_warning(TTR("Some mesh is invalid. Make sure the UV2 channel values are contained within the [0.0,1.0] square region."));
 				break;
 			case BakedLightmap::BAKE_ERROR_NO_LIGHTMAPPER:
-				EditorNode::get_singleton()->show_warning(TTR("Godot editor was built without ray tracing support, lightmaps can't be baked."));
+#ifdef OSX_ENABLED
+				EditorNode::get_singleton()->show_warning(TTR("Godot editor was built without ray tracing support; lightmaps can't be baked.\nIf you are using an Apple Silicon-based Mac, try forcing Rosetta emulation on Godot.app in the application settings\nthen restart the editor."));
+#else
+				EditorNode::get_singleton()->show_warning(TTR("Godot editor was built without ray tracing support; lightmaps can't be baked."));
+#endif
 				break;
 			default: {
 			}


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/48082.