### PR TITLE
Add type_traits include for `std::is_trivially_destructible`

### DIFF
--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -36,6 +36,7 @@
 #if !defined(NO_THREADS)
 
 #include <atomic>
+#include <type_traits>
 
 // Design goals for these classes:
 // - No automatic conversions or arithmetic operators,


### PR DESCRIPTION
Fixes this error with GCC 5:
```
./core/safe_refcount.h:54:16: error: 'is_trivially_destructible' is not a member of 'std'
  static_assert(std::is_trivially_destructible<std::atomic<m_type> >::value, "");
                ^
```

GCC 5 isn't supported in the `master` branch but it's relevant for `3.x`, and we might as well include what we use to ensure it's correct.