### PR TITLE
[3.x] Add autocompletion for method names (`connect()`, `call()`, `call_deferred()` etc.)

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -40,6 +40,10 @@
 #include "core/script_language.h"
 #include "core/translation.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
+#endif
+
 #ifdef DEBUG_ENABLED
 
 struct _ObjectDebugLock {
@@ -2111,6 +2115,23 @@ void ObjectDB::debug_objects(DebugFunc p_func) {
 }
 
 void Object::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+#ifdef TOOLS_ENABLED
+	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
+#else
+	const String quote_style = "\"";
+#endif
+
+	String function = p_function;
+	if (((function == "call" || function == "callv" || function == "call_deferred" || function == "has_method") && p_idx == 0) ||
+			((function == "connect" || function == "disconnect" || function == "is_connected") && p_idx == 2)) {
+		List<MethodInfo> methods;
+		get_method_list(&methods);
+
+		for (int i = 0; i < methods.size(); i++) {
+			const MethodInfo &method_info = methods[i];
+			r_options->push_back(quote_style + method_info.name + quote_style);
+		}
+	}
 }
 
 int ObjectDB::get_object_count() {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Closes https://github.com/godotengine/godot/issues/47940
Only applicable for 3.x (see https://github.com/godotengine/godot/issues/47940#issuecomment-820805247)

https://user-images.githubusercontent.com/50304111/115742571-074a0480-a34e-11eb-9a96-05b3debad32f.mp4
