### PR TITLE
lightmapper: Disable build if raycast module can't build

### DIFF
--- a/modules/lightmapper_cpu/config.py
+++ b/modules/lightmapper_cpu/config.py
@@ -1,5 +1,28 @@
 def can_build(env, platform):
-    return env["tools"] and env["module_raycast_enabled"]
+    if not env["tools"] or not env["module_raycast_enabled"]:
+        return False
+
+    # Depends on raycast module (embree), but we can't have access to the result of
+    # `can_build()` for that module, so we need to duplicate that code as a short-term
+    # solution.
+
+    # Embree requires at least SSE2 to be available, so 32-bit and ARM64 builds are
+    # not supported.
+    # It's also only relevant for tools build and desktop platforms,
+    # as doing lightmap generation on Android or HTML5 would be a bit far-fetched.
+    supported_platform = platform in ["x11", "osx", "windows", "server"]
+    supported_bits = env["bits"] == "64"
+    supported_arch = env["arch"] != "arm64"
+
+    # Hack to disable on Linux arm64. This won't work well for cross-compilation (checks
+    # host, not target) and would need a more thorough fix by refactoring our arch and
+    # bits-handling code.
+    from platform import machine
+
+    if platform == "x11" and machine() != "x86_64":
+        supported_arch = False
+
+    return supported_platform and supported_bits and supported_arch
 
 
 def configure(env):

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -310,7 +310,10 @@ def configure(env):
     if not env["builtin_pcre2"]:
         env.ParseConfig("pkg-config libpcre2-32 --cflags --libs")
 
-    if not env["builtin_embree"]:
+    # Embree is only compatible with x86_64. Yet another unreliable hack that will break
+    # cross-compilation, this will really need to be handle better. Thankfully only affects
+    # people who disable builtin_embree (likely distro packagers).
+    if not env["builtin_embree"] and (is64 and platform.machine() == "x86_64"):
         # No pkgconfig file so far, hardcode expected lib name.
         env.Append(LIBS=["embree3"])
 


### PR DESCRIPTION
We need to propagate the hacky checks from the raycast config to the
lightmapper config, as the failure of a `can_build()` check is not notified to
other modules (which might even be checked further depending on the processing
order in SConstruct).

A more thorough fix would be to change SConstruct to do two loops on modules:
one to check `can_build()` and disable modules which can't build, then another
one to rechecked `can_build()` with the new lineup and do further config.
But there would be more risk for regressions than with this ad hoc hack.

Similar story for the `platform/x11/detect.py` change... oh my eyes :(