### PR TITLE
Linux: Don't attempt linking embree3 on non-tools, link it for headless too

### DIFF
--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -222,6 +222,13 @@ def configure(env):
     if not env["builtin_pcre2"]:
         env.ParseConfig("pkg-config libpcre2-32 --cflags --libs")
 
+    # Embree is only compatible with x86_64. Yet another unreliable hack that will break
+    # cross-compilation, this will really need to be handle better. Thankfully only affects
+    # people who disable builtin_embree (likely distro packagers).
+    if env["tools"] and not env["builtin_embree"] and (is64 and platform.machine() == "x86_64"):
+        # No pkgconfig file so far, hardcode expected lib name.
+        env.Append(LIBS=["embree3"])
+
     ## Flags
 
     # Linkflags below this line should typically stay the last ones

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -313,7 +313,7 @@ def configure(env):
     # Embree is only compatible with x86_64. Yet another unreliable hack that will break
     # cross-compilation, this will really need to be handle better. Thankfully only affects
     # people who disable builtin_embree (likely distro packagers).
-    if not env["builtin_embree"] and (is64 and platform.machine() == "x86_64"):
+    if env["tools"] and not env["builtin_embree"] and (is64 and platform.machine() == "x86_64"):
         # No pkgconfig file so far, hardcode expected lib name.
         env.Append(LIBS=["embree3"])
 


### PR DESCRIPTION
`tech_debt++`, that's what we get for not taking the time to cleanup all this
and do it right...

Follow-up to #48073 and #48102.

This time I'll wait to have a successful distro build before merging.

![help](https://media.giphy.com/media/vX9WcCiWwUF7G/giphy.gif)