### PR TITLE
NodePath: Remove unimplemented `get_parent()` method

### DIFF
--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -66,8 +66,6 @@ public:
 
 	void prepend_period();
 
-	NodePath get_parent() const;
-
 	_FORCE_INLINE_ uint32_t hash() const {
 		if (!data) {
 			return 0;


### PR DESCRIPTION
Fixes #48100.

Could be implemented fairly easily but since nobody asked for it in the past 7 years, I agree with @kleonc that we don't need to.