### PR TITLE
[3.x] Fix Array.max() navigating to @GDScript.max()

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3342,15 +3342,6 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 		}
 	}
 
-	for (int i = 0; i < GDScriptFunctions::FUNC_MAX; i++) {
-		if (GDScriptFunctions::get_func_name(GDScriptFunctions::Function(i)) == p_symbol) {
-			r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_METHOD;
-			r_result.class_name = "@GDScript";
-			r_result.class_member = p_symbol;
-			return OK;
-		}
-	}
-
 	if ("PI" == p_symbol || "TAU" == p_symbol || "INF" == p_symbol || "NAN" == p_symbol) {
 		r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_CONSTANT;
 		r_result.class_name = "@GDScript";
@@ -3563,6 +3554,16 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 			}
 		} break;
 		default: {
+		}
+	}
+
+	for (int i = 0; i < GDScriptFunctions::FUNC_MAX; i++) {
+		// this has to get run after parsing because otherwise functions like Array.max() will trigger it
+		if (GDScriptFunctions::get_func_name(GDScriptFunctions::Function(i)) == p_symbol) {
+			r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_METHOD;
+			r_result.class_name = "@GDScript";
+			r_result.class_member = p_symbol;
+			return OK;
 		}
 	}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes https://github.com/godotengine/godot/issues/48113, supersedes https://github.com/godotengine/godot/pull/48119 because apparently these changes are only relevant to 3.x