### PR TITLE
Android: Fix get_buffer false positive on empty dest buffer

### DIFF
--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -114,7 +114,7 @@ uint8_t FileAccessAndroid::get_8() const {
 }
 
 int FileAccessAndroid::get_buffer(uint8_t *p_dst, int p_length) const {
-	ERR_FAIL_COND_V(!p_dst, -1);
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(p_length < 0, -1);
 
 	off_t r = AAsset_read(a, p_dst, p_length);


### PR DESCRIPTION
Follow-up to #46810, this was missed in #47079 when fixing the issue
for other platforms.

Fixes #48135.