### PR TITLE
Fix C# tool script displaying exported variables in the wrong order

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1614,8 +1614,8 @@ void CSharpInstance::get_properties_state_for_reloading(List<Pair<StringName, Va
 
 void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 
-	for (Map<StringName, PropertyInfo>::Element *E = script->member_info.front(); E; E = E->next()) {
-		p_properties->push_back(E->value());
+	for (const List<StringName>::Element *E = script->member_order.front(); E; E = E->next()) {
+		p_properties->push_back(script->member_info[E->get()]);
 	}
 
 	// Call _get_property_list
@@ -2234,6 +2234,7 @@ void CSharpScript::_update_member_info_no_exports() {
 		exports_invalidated = false;
 
 		member_info.clear();
+		member_order.clear();
 
 		GDMonoClass *top = script_class;
 
@@ -2250,6 +2251,7 @@ void CSharpScript::_update_member_info_no_exports() {
 					StringName member_name = field->get_name();
 
 					member_info[member_name] = prop_info;
+					member_order.push_front(member_name);
 					exported_members_cache.push_front(prop_info);
 					exported_members_defval_cache[member_name] = Variant();
 				}
@@ -2264,6 +2266,7 @@ void CSharpScript::_update_member_info_no_exports() {
 					StringName member_name = property->get_name();
 
 					member_info[member_name] = prop_info;
+					member_order.push_front(member_name);
 					exported_members_cache.push_front(prop_info);
 					exported_members_defval_cache[member_name] = Variant();
 				}
@@ -2297,6 +2300,7 @@ bool CSharpScript::_update_exports() {
 		changed = true;
 
 		member_info.clear();
+		member_order.clear();
 
 #ifdef TOOLS_ENABLED
 		MonoObject *tmp_object = nullptr;
@@ -2357,6 +2361,7 @@ bool CSharpScript::_update_exports() {
 					StringName member_name = field->get_name();
 
 					member_info[member_name] = prop_info;
+					member_order.push_front(member_name);
 
 					if (exported) {
 #ifdef TOOLS_ENABLED
@@ -2385,6 +2390,7 @@ bool CSharpScript::_update_exports() {
 					StringName member_name = property->get_name();
 
 					member_info[member_name] = prop_info;
+					member_order.push_front(member_name);
 
 					if (exported) {
 #ifdef TOOLS_ENABLED
@@ -3302,8 +3308,8 @@ Ref<Script> CSharpScript::get_base_script() const {
 
 void CSharpScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 
-	for (Map<StringName, PropertyInfo>::Element *E = member_info.front(); E; E = E->next()) {
-		p_list->push_back(E->value());
+	for (const List<StringName>::Element *E = member_order.front(); E; E = E->next()) {
+		p_list->push_back(member_info[E->get()]);
 	}
 }
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -130,6 +130,7 @@ class CSharpScript : public Script {
 #endif
 
 	Map<StringName, PropertyInfo> member_info;
+	List<StringName> member_order;
 
 	void _clear();
 


### PR DESCRIPTION
Hello all, first time contributor here :)

Previously, exported variables in a C# tool script would not appear in
the order they were exported within the inspector upon rebuilding the
project solution. The potential cause of this problem is that the
CSharpInstance::get_property_list method was iterating through
the member_info Map member variable to populate the p_properties
list argument.

Maps typically do not give guarantees about the ordering of elements
and I think that Godot's implementation of Map may also shuffle elements
around.

My proposed solution is to add a new list within the CSharpScript
class that contains the keys of the member_info Map in the order
they were inserted. This list is cleared and gets new elements
whenever the member_info Map is cleared or updated.

This fix causes exported variables in C# tools scripts to appear
in the order they were exported within the inspector after rebuilding
the project solution just like regular C# scripts.

Fixes #47465

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
