### PR TITLE
Fix `PointLight2D.set_texture` crash

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -7268,6 +7268,7 @@ RS::InstanceType RendererStorageRD::get_base_type(RID p_rid) const {
 
 void RendererStorageRD::texture_add_to_decal_atlas(RID p_texture, bool p_panorama_to_dp) {
 	if (!decal_atlas.textures.has(p_texture)) {
+		ERR_FAIL_COND(texture_owner.getornull(p_texture) == nullptr);
 		DecalAtlas::Texture t;
 		t.users = 1;
 		t.panorama_to_dp_users = p_panorama_to_dp ? 1 : 0;


### PR DESCRIPTION
The program mentioned in the related issue crashes in `RendererStorageRD::_update_decal_atlas()` because the `RID` corresponding to the texture is deemed invalid:
https://github.com/godotengine/godot/blob/0bef220f0a7abd5c3b29f9ddbc95e8a7ecf822df/servers/rendering/renderer_rd/renderer_storage_rd.cpp#L7329

This happens because the `RID` is associated with a different owner, i.e. `canvas_texture_owner`, not `texture_owner`:
https://github.com/godotengine/godot/blob/0bef220f0a7abd5c3b29f9ddbc95e8a7ecf822df/servers/rendering/renderer_rd/renderer_storage_rd.cpp#L1235-L1237

The proposed fix checks the RID for validity before adding the corresponding texture to the `decal_atlas`. I'm not very familiar with the newer rendering code, so apologies in advance if this is not the best fix.

Closes #46828

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
