### PR TITLE
Fix `mouse_over` not dropped when mouse leaves window

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -335,6 +335,7 @@ private:
 		// info used when this is a window
 
 		bool forced_mouse_focus = false; //used for menu buttons
+		bool mouse_in_window = true;
 		bool key_event_accepted = false;
 		Control *mouse_focus = nullptr;
 		Control *last_mouse_focus = nullptr;
@@ -433,6 +434,7 @@ private:
 	void _canvas_layer_add(CanvasLayer *p_canvas_layer);
 	void _canvas_layer_remove(CanvasLayer *p_canvas_layer);
 
+	void _drop_mouse_over();
 	void _drop_mouse_focus();
 	void _drop_physics_mouseover(bool p_paused_only = false);
 


### PR DESCRIPTION
Fixes #46438.

Note: I've added a variable to monitor whether or not the mouse is inside the window, because `NOTIFICATION_WM_MOUSE_ENTER` and `NOTIFICATION_WM_MOUSE_EXIT` events are processed immediately, but other mouse events are queued and processed later. This means a mouse move event received before a mouse exit event may be processed after the mouse exit event resulting in `mouse_over` being set again when it shouldn't.
