### PR TITLE
Fix AudioServer Crash when no buses present

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -246,6 +246,7 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 		init_channels_and_buffers();
 	}
 
+	ERR_FAIL_COND_MSG(buses.is_empty() && todo, "AudioServer bus count is less than 1.");
 	while (todo) {
 		if (to_mix == 0) {
 			_mix_step();


### PR DESCRIPTION
`AudioServer::_driver_process` implicitly expects at least 1 bus to be present (the master). The default constructor does not setup any buses, leading to a crash. 

The issue is not present in the engine code as it calls `init()` shortly after, but is a problem when an `AudioServer` is created separately.

https://github.com/godotengine/godot/blob/db90ab86b94eb59eb296d574c279e40e57c2f99b/main/main.cpp#L1609-L1610

I suppose the alternate fix is to call `set_bus_count(1)` in the default constructor itself.

Closes #45972
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
