### PR TITLE
Fixed issue in SkeletonIK leading to some root bones being twisted incorrectly

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -91,6 +91,15 @@
 				Returns the overall transform of the specified bone, with respect to the skeleton. Being relative to the skeleton frame, this is not the actual "global" transform of the bone.
 			</description>
 		</method>
+		<method name="get_bone_global_pose_no_override" qualifiers="const">
+			<return type="Transform">
+			</return>
+			<argument index="0" name="bone_idx" type="int">
+			</argument>
+			<description>
+				Returns the overall transform of the specified bone, with respect to the skeleton, but without any global pose overrides. Being relative to the skeleton frame, this is not the actual "global" transform of the bone.
+			</description>
+		</method>
 		<method name="get_bone_name" qualifiers="const">
 			<return type="String">
 			</return>

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -83,6 +83,7 @@ private:
 
 		Transform pose;
 		Transform pose_global;
+		Transform pose_global_no_override;
 
 		bool custom_pose_enable = false;
 		Transform custom_pose;
@@ -160,6 +161,7 @@ public:
 	void set_bone_rest(int p_bone, const Transform &p_rest);
 	Transform get_bone_rest(int p_bone) const;
 	Transform get_bone_global_pose(int p_bone) const;
+	Transform get_bone_global_pose_no_override(int p_bone) const;
 
 	void clear_bones_global_pose_override();
 	void set_bone_global_pose_override(int p_bone, const Transform &p_pose, float p_amount, bool p_persistent = false);

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -246,7 +246,7 @@ void FabrikInverseKinematic::make_goal(Task *p_task, const Transform &p_inverse_
 		p_task->end_effectors.write[0].goal_transform = p_inverse_transf * p_task->goal_global_transform;
 	} else {
 		// End effector in local transform
-		const Transform end_effector_pose(p_task->skeleton->get_bone_global_pose(p_task->end_effectors[0].tip_bone));
+		const Transform end_effector_pose(p_task->skeleton->get_bone_global_pose_no_override(p_task->end_effectors[0].tip_bone));
 
 		// Update the end_effector (local transform) by blending with current pose
 		p_task->end_effectors.write[0].goal_transform = end_effector_pose.interpolate_with(p_inverse_transf * p_task->goal_global_transform, blending_delta);
@@ -270,18 +270,7 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 		return; // Skip solving
 	}
 
-	p_task->skeleton->set_bone_global_pose_override(p_task->chain.chain_root.bone, Transform(), 0.0, true);
-
-	if (p_task->chain.middle_chain_item) {
-		p_task->skeleton->set_bone_global_pose_override(p_task->chain.middle_chain_item->bone, Transform(), 0.0, true);
-	}
-
-	for (int i = 0; i < p_task->chain.tips.size(); i += 1) {
-		p_task->skeleton->set_bone_global_pose_override(p_task->chain.tips[i].chain_item->bone, Transform(), 0.0, true);
-	}
-
-	// Update the transforms to their global poses
-	// (Needed to sync IK with animation)
+	// Update the initial root transform so its synced with any animation changes
 	_update_chain(p_task->skeleton, &p_task->chain.chain_root);
 
 	make_goal(p_task, p_task->skeleton->get_global_transform().affine_inverse(), blending_delta);
@@ -298,48 +287,22 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 		Transform new_bone_pose(ci->initial_transform);
 		new_bone_pose.origin = ci->current_pos;
 
-		// The root bone needs to be rotated differently so it isn't frozen in place.
-		if (ci == &p_task->chain.chain_root && !ci->children.is_empty()) {
-			new_bone_pose = new_bone_pose.looking_at(ci->children[0].current_pos);
-			const Vector3 bone_rest_dir = p_task->skeleton->get_bone_rest(ci->children[0].bone).origin.normalized().abs();
-			const Vector3 bone_rest_dir_abs = bone_rest_dir.abs();
-			if (bone_rest_dir_abs.x > bone_rest_dir_abs.y && bone_rest_dir_abs.x > bone_rest_dir_abs.z) {
-				if (bone_rest_dir.x < 0) {
-					new_bone_pose.basis.rotate_local(Vector3(0, 1, 0), -Math_PI / 2.0f);
-				} else {
-					new_bone_pose.basis.rotate_local(Vector3(0, 1, 0), Math_PI / 2.0f);
-				}
-			} else if (bone_rest_dir_abs.y > bone_rest_dir_abs.x && bone_rest_dir_abs.y > bone_rest_dir_abs.z) {
-				if (bone_rest_dir.y < 0) {
-					new_bone_pose.basis.rotate_local(Vector3(1, 0, 0), Math_PI / 2.0f);
-				} else {
-					new_bone_pose.basis.rotate_local(Vector3(1, 0, 0), -Math_PI / 2.0f);
-				}
-			} else {
-				if (bone_rest_dir.z < 0) {
-					// Do nothing!
-				} else {
-					new_bone_pose.basis.rotate_local(Vector3(0, 0, 1), Math_PI);
-				}
+		if (!ci->children.is_empty()) {
+			/// Rotate basis
+			const Vector3 initial_ori((ci->children[0].initial_transform.origin - ci->initial_transform.origin).normalized());
+			const Vector3 rot_axis(initial_ori.cross(ci->current_ori).normalized());
+
+			if (rot_axis[0] != 0 && rot_axis[1] != 0 && rot_axis[2] != 0) {
+				const real_t rot_angle(Math::acos(CLAMP(initial_ori.dot(ci->current_ori), -1, 1)));
+				new_bone_pose.basis.rotate(rot_axis, rot_angle);
 			}
+
 		} else {
-			if (!ci->children.is_empty()) {
-				/// Rotate basis
-				const Vector3 initial_ori((ci->children[0].initial_transform.origin - ci->initial_transform.origin).normalized());
-				const Vector3 rot_axis(initial_ori.cross(ci->current_ori).normalized());
-
-				if (rot_axis[0] != 0 && rot_axis[1] != 0 && rot_axis[2] != 0) {
-					const real_t rot_angle(Math::acos(CLAMP(initial_ori.dot(ci->current_ori), -1, 1)));
-					new_bone_pose.basis.rotate(rot_axis, rot_angle);
-				}
-
+			// Set target orientation to tip
+			if (override_tip_basis) {
+				new_bone_pose.basis = p_task->chain.tips[0].end_effector->goal_transform.basis;
 			} else {
-				// Set target orientation to tip
-				if (override_tip_basis) {
-					new_bone_pose.basis = p_task->chain.tips[0].end_effector->goal_transform.basis;
-				} else {
-					new_bone_pose.basis = new_bone_pose.basis * p_task->chain.tips[0].end_effector->goal_transform.basis;
-				}
+				new_bone_pose.basis = new_bone_pose.basis * p_task->chain.tips[0].end_effector->goal_transform.basis;
 			}
 		}
 
@@ -362,7 +325,7 @@ void FabrikInverseKinematic::_update_chain(const Skeleton3D *p_sk, ChainItem *p_
 		return;
 	}
 
-	p_chain_item->initial_transform = p_sk->get_bone_global_pose(p_chain_item->bone);
+	p_chain_item->initial_transform = p_sk->get_bone_global_pose_no_override(p_chain_item->bone);
 	p_chain_item->current_pos = p_chain_item->initial_transform.origin;
 
 	ChainItem *items = p_chain_item->children.ptrw();


### PR DESCRIPTION
Should close #48078 and close #47803 - at least I think it should.

I still have the issue where in Godot 4.0 I am unable to see meshes, but the bone gizmo seems to no longer be twisted. I tested the minimum replication projects in both of the linked issues, as well as some other projects, and the gizmos seem to be in the correct rotation.

The issue seems to be two fold: the first problem was that I was incorrectly making both of the Vector3s I was using for directions absolute, making it where bones with -Z as the forward vector would be incorrectly parsed as +Z as the forward direction. The other issue was that LookAt was using a up direction of +Y, so for bones with a forward bone direction on the Z axis, up is now +X.

That said, this **needs testing** to make sure the visuals are correct! It could be the rotation is off by an increment of 90 degrees, in which case I would be unable to see it in the bone gizmo. Help testing this PR to make sure it actually fixes the issues linked would be greatly appreciated!
