### PR TITLE
Refactor import hints parser

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -68,6 +68,10 @@ bool is_symbol(char32_t c) {
 	return c != '_' && ((c >= '!' && c <= '/') || (c >= ':' && c <= '@') || (c >= '[' && c <= '`') || (c >= '{' && c <= '~') || c == '\t' || c == ' ');
 }
 
+bool is_alpha(char32_t c) {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
 bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end) {
 	const String &s = p_s;
 	int beg = CLAMP(p_col, 0, s.length());

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -535,6 +535,7 @@ String RTR(const String &p_text, const String &p_context = "");
 String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
 
 bool is_symbol(char32_t c);
+bool is_alpha(char32_t c);
 bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end);
 
 _FORCE_INLINE_ void sarray_add_str(Vector<String> &arr) {

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -118,6 +118,40 @@ class ResourceImporterScene : public ResourceImporter {
 		MESH_OVERRIDE_DISABLE,
 	};
 
+	enum NodeHint {
+		NODE_HINT_NONE,
+		NODE_HINT_NO_IMPORT,
+		NODE_HINT_COLLISION,
+		NODE_HINT_CONVEX_COLLISION,
+		NODE_HINT_COLLISION_ONLY,
+		NODE_HINT_CONVEX_COLLISION_ONLY,
+		NODE_HINT_RIGID,
+		NODE_HINT_NAVMESH,
+		NODE_HINT_MAX,
+	};
+
+	enum MaterialHint {
+		MATERIAL_HINT_NONE,
+		MATERIAL_HINT_ALPHA,
+		MATERIAL_HINT_VERTEX_COLOR,
+		MATERIAL_HINT_MAX,
+	};
+
+	enum AnimationHint {
+		ANIMATION_HINT_NONE,
+		ANIMATION_HINT_LOOPS,
+		ANIMATION_HINT_LOOP,
+		ANIMATION_HINT_CYCLE,
+		ANIMATION_HINT_MAX,
+	};
+
+	static String _import_hint_string(NodeHint p_hint);
+	static String _import_hint_string(MaterialHint p_hint);
+	static String _import_hint_string(AnimationHint p_hint);
+
+	template <class T>
+	static T _parse_import_hint(String &p_name, T p_max);
+
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
 	void _generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<uint8_t> &r_dst_lightmap_cache);
 	void _add_shapes(Node *p_node, const List<Ref<Shape3D>> &p_shapes);


### PR DESCRIPTION
In this PR, I reworked the parsing of import hints. Here is what I did:

* Material import hints only worked in the following order: `-alpha` `-vcol`. This is a bug. I replaced the parsing with a loop and the order is no longer important.
* Replaced `_fixstr` and `_teststr`, which contained duplicate code, with `_parse_hint` that changes passed name and returns the obtained hint.
* Enhanced the hints detection algorithm. Now it finds a hint and make sure that there are no letters around it. Supersedes #43563.
* Now the hints are enums and they are parsed only once, which speeds up the import. Also, all import hints are now in one place.