### PR TITLE
Fix triplanar mapping for AO on Godot 4

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -672,7 +672,7 @@ void BaseMaterial3D::_update_shader() {
 		code += "uniform sampler2D texture_flowmap : hint_aniso," + texfilter_str + ";\n";
 	}
 	if (features[FEATURE_AMBIENT_OCCLUSION]) {
-		code += "uniform sampler2D texture_ambient_occlusion : hint_white;\n";
+		code += "uniform sampler2D texture_ambient_occlusion : hint_white, " + texfilter_str + ";\n";
 		code += "uniform vec4 ao_texture_channel;\n";
 		code += "uniform float ao_light_affect;\n";
 	}


### PR DESCRIPTION
Fixing a issue with triplanar mapping on ambient occlusion.
![image](https://user-images.githubusercontent.com/76991284/115977547-97b85d00-a579-11eb-89cd-caf25035912c.png)

Fixes https://github.com/godotengine/godot/issues/47460
