### PR TITLE
Fix `CSGMesh` undo not refreshing gizmo

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -880,7 +880,7 @@ void CSGMesh3D::set_mesh(const Ref<Mesh> &p_mesh) {
 		mesh->connect("changed", callable_mp(this, &CSGMesh3D::_mesh_changed));
 	}
 
-	_make_dirty();
+	_mesh_changed();
 }
 
 Ref<Mesh> CSGMesh3D::get_mesh() {


### PR DESCRIPTION
As identified [here](https://github.com/godotengine/godot/issues/46610#issue-820710590), when undoing the selected `Mesh` in a `CSGMesh`, the gizmo is not fully removed. This PR ensures that the gizmo is updated when the assigned `Mesh` of an existing `CSGMesh` is changed.
