### PR TITLE
Create CollisionObject3D debug shapes using RS 

### DIFF
--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -48,7 +48,7 @@ class CollisionObject3D : public Node3D {
 		Object *owner = nullptr;
 		Transform xform;
 		struct ShapeBase {
-			Node *debug_shape = nullptr;
+			RID debug_shape;
 			Ref<Shape3D> shape;
 			int index = 0;
 		};
@@ -65,24 +65,29 @@ class CollisionObject3D : public Node3D {
 	bool ray_pickable = true;
 
 	Set<uint32_t> debug_shapes_to_update;
-	int debug_shape_count = 0;
+	int debug_shapes_count = 0;
+	Transform debug_shape_old_transform;
 
 	void _update_pickable();
 
+	bool _are_collision_shapes_visible();
 	void _update_shape_data(uint32_t p_owner);
+	void _shape_changed(Ref<Shape3D> p_shape);
+	void _update_debug_shapes();
+	void _clear_debug_shapes();
 
 protected:
 	CollisionObject3D(RID p_rid, bool p_area);
 
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	void _on_transform_changed();
+
 	friend class Viewport;
 	virtual void _input_event(Node *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);
 	virtual void _mouse_enter();
 	virtual void _mouse_exit();
-
-	void _update_debug_shapes();
-	void _clear_debug_shapes();
 
 public:
 	void set_collision_layer(uint32_t p_layer);

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -161,12 +161,10 @@ void CollisionShape3D::set_shape(const Ref<Shape3D> &p_shape) {
 	}
 	if (!shape.is_null()) {
 		shape->unregister_owner(this);
-		shape->disconnect("changed", callable_mp(this, &CollisionShape3D::_shape_changed));
 	}
 	shape = p_shape;
 	if (!shape.is_null()) {
 		shape->register_owner(this);
-		shape->connect("changed", callable_mp(this, &CollisionShape3D::_shape_changed));
 	}
 	update_gizmo();
 	if (parent) {
@@ -176,8 +174,9 @@ void CollisionShape3D::set_shape(const Ref<Shape3D> &p_shape) {
 		}
 	}
 
-	if (is_inside_tree()) {
-		_shape_changed();
+	if (is_inside_tree() && parent) {
+		// If this is a heightfield shape our center may have changed
+		_update_in_shape_owner(true);
 	}
 	update_configuration_warnings();
 }
@@ -208,11 +207,4 @@ CollisionShape3D::~CollisionShape3D() {
 		shape->unregister_owner(this);
 	}
 	//RenderingServer::get_singleton()->free(indicator);
-}
-
-void CollisionShape3D::_shape_changed() {
-	// If this is a heightfield shape our center may have changed
-	if (parent) {
-		_update_in_shape_owner(true);
-	}
 }

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -47,8 +47,6 @@ class CollisionShape3D : public Node3D {
 	bool disabled = false;
 
 protected:
-	void _shape_changed();
-
 	void _update_in_shape_owner(bool p_xform_only = false);
 
 protected:

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -292,6 +292,7 @@ void RigidBody3D::_direct_state_changed(Object *p_state) {
 		get_script_instance()->call("_integrate_forces", state);
 	}
 	set_ignore_transform_notification(false);
+	_on_transform_changed();
 
 	if (contact_monitor) {
 		contact_monitor->locked = true;
@@ -1985,6 +1986,7 @@ void PhysicalBone3D::_direct_state_changed(Object *p_state) {
 	set_ignore_transform_notification(true);
 	set_global_transform(global_transform);
 	set_ignore_transform_notification(false);
+	_on_transform_changed();
 
 	// Update skeleton
 	if (parent_skeleton) {


### PR DESCRIPTION
Fixes #48085, fixes #48281

In #45783, I added the possibility to show debug shapes directly in CollisionObject3D. To be conservative (and because it's my first PR), I displayed debug shapes using MeshInstances, as it was done in CollisionShape3D. This unfortunately came with some drawbacks and one of them was described in #48085.

In this PR I replace MeshInstances with direct calls to RenderingServer.
~When I test this, the debug shape disappears when the Shape3D resource changes and reappears only when I change the transform.~ *EDIT*: fixed
 ~Since I'm not sure if it is my fault or a RS bug, I want to backport it to 3.x soon to see if the same issue appears.~ 

~*EDIT*: I have backported this and the issue doesn't happen, so it's a RS bug.~
*EDIT 2*: See [this comment](https://github.com/godotengine/godot/pull/48175#pullrequestreview-645745811)

*Bugsquad edit:* test scenes here: [CollisionObject_debug_meshes.zip](https://github.com/godotengine/godot/files/6420042/CollisionObject_debug_meshes.zip)