### PR TITLE
Fix PrimitiveMesh surface being unavailable immediately after creation

### DIFF
--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -55,10 +55,6 @@ private:
 	Ref<Material> material;
 	bool flip_faces = false;
 
-	// make sure we do an update after we've finished constructing our object
-	mutable bool pending_request = true;
-	void _update() const;
-
 protected:
 	// assume primitive triangles as the type, correct for all but one and it will change this :)
 	Mesh::PrimitiveType primitive_type = Mesh::PRIMITIVE_TRIANGLES;
@@ -66,7 +62,7 @@ protected:
 	static void _bind_methods();
 
 	virtual void _create_mesh_array(Array &p_arr) const = 0;
-	void _request_update();
+	void _update() const;
 
 public:
 	virtual int get_surface_count() const override;


### PR DESCRIPTION
Fixes #46610.

Makes calls to `PrimitiveMesh::_update()` wait until the `RenderingServer` has finished creating the surface before returning.

Also removes the variable `pending_request`, which was unnecessarily delaying the initial call to `update()` until the first call to access the new `PrimitiveMesh`.
