### PR TITLE
Fix viewport not updating mouse pos on click.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1830,6 +1830,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		Control *over = nullptr;
 
 		Point2 mpos = mb->get_position();
+		gui.last_mouse_pos = mpos;
 		if (mb->is_pressed()) {
 			Size2 pos = mpos;
 			if (gui.mouse_focus_mask) {


### PR DESCRIPTION
Closes #47594 and possibly others, unknown. See further discussion there. Thanks to @Bhu1-V for the investigation which led to this fix.

The value of `gui.last_mouse_pos` is now updated on click and not just on mouse movement. This caused issues where you clicked onto viewport 1 from viewport 2 without giving viewport 1 focus and mouse movement first. It impacted the shortcuts editor, but is now fixed as shown below.

![d4gNHoFJkl](https://user-images.githubusercontent.com/41730826/115993994-8e320200-a618-11eb-9f8d-7d0d4cb00d6c.gif)
