### PR TITLE
Generate error if RegEx offset is negative

### DIFF
--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -194,6 +194,7 @@ Error RegEx::compile(const String &p_pattern) {
 
 Ref<RegExMatch> RegEx::search(const String &p_subject, int p_offset, int p_end) const {
 	ERR_FAIL_COND_V(!is_valid(), nullptr);
+	ERR_FAIL_COND_V_MSG(p_offset < 0, nullptr, "RegEx search offset must be >= 0");
 
 	Ref<RegExMatch> result = memnew(RegExMatch);
 
@@ -258,6 +259,8 @@ Ref<RegExMatch> RegEx::search(const String &p_subject, int p_offset, int p_end) 
 }
 
 Array RegEx::search_all(const String &p_subject, int p_offset, int p_end) const {
+	ERR_FAIL_COND_V_MSG(p_offset < 0, Array(), "RegEx search offset must be >= 0");
+
 	int last_end = -1;
 	Array result;
 	Ref<RegExMatch> match = search(p_subject, p_offset, p_end);
@@ -274,6 +277,7 @@ Array RegEx::search_all(const String &p_subject, int p_offset, int p_end) const 
 
 String RegEx::sub(const String &p_subject, const String &p_replacement, bool p_all, int p_offset, int p_end) const {
 	ERR_FAIL_COND_V(!is_valid(), String());
+	ERR_FAIL_COND_V_MSG(p_offset < 0, String(), "RegEx sub offset must be >= 0");
 
 	// safety_zone is the number of chars we allocate in addition to the number of chars expected in order to
 	// guard against the PCRE API writing one additional \0 at the end. PCRE's API docs are unclear on whether

--- a/modules/regex/tests/test_regex.h
+++ b/modules/regex/tests/test_regex.h
@@ -130,16 +130,6 @@ TEST_CASE("[RegEx] Empty Pattern") {
 	CHECK(re.is_valid());
 }
 
-TEST_CASE("[RegEx] Invalid offset") {
-	const String s = "Godot";
-
-	RegEx re("o");
-	REQUIRE(re.is_valid());
-	CHECK(re.search(s, -1) == nullptr);
-	CHECK(re.search_all(s, -1).size() == 0);
-	CHECK(re.sub(s, "", true, -1) == "");
-}
-
 TEST_CASE("[RegEx] Invalid end position") {
 	const String s = "Godot";
 


### PR DESCRIPTION
Currently, if a negative offset is used, `RegEx` may result in undefined behaviour:
```
modules/regex/regex.cpp:212:41: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'size_t' (aka 'unsigned long') changed the value to 18446744073709551615 (64-bit, unsigned)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior modules/regex/regex.cpp:212:41 in 
thirdparty/pcre2/src/pcre2_match.c:6130:34: runtime error: addition of unsigned offset to 0x60400033f5e0 overflowed to 0x60400033f5dc
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior thirdparty/pcre2/src/pcre2_match.c:6130:34 in 
modules/regex/regex.cpp:307:46: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'size_t' (aka 'unsigned long') changed the value to 18446744073709551615 (64-bit, unsigned)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior modules/regex/regex.cpp:307:46 in 
```
This PR generates an error if a negative offset is passed to `RegEx`'s [`search()`](https://docs.godotengine.org/en/stable/classes/class_regex.html#class-regex-method-search), [`search_all()`](https://docs.godotengine.org/en/stable/classes/class_regex.html#class-regex-method-search-all) or [`sub()`](https://docs.godotengine.org/en/stable/classes/class_regex.html#class-regex-method-sub) methods.
