### PR TITLE
Remove uses of `auto` for better readability and online code reviews

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -835,7 +835,7 @@ Vector<String> Translation::_get_message_list() const {
 void Translation::_set_messages(const Dictionary &p_messages) {
 	List<Variant> keys;
 	p_messages.get_key_list(&keys);
-	for (auto E = keys.front(); E; E = E->next()) {
+	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
 		translation_map[E->get()] = p_messages[E->get()];
 	}
 }

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -47,14 +47,14 @@ void TranslationPO::print_translation_map() {
 
 	List<StringName> context_l;
 	translation_map.get_key_list(&context_l);
-	for (auto E = context_l.front(); E; E = E->next()) {
+	for (List<StringName>::Element *E = context_l.front(); E; E = E->next()) {
 		StringName ctx = E->get();
 		file->store_line(" ===== Context: " + String::utf8(String(ctx).utf8()) + " ===== ");
 		const HashMap<StringName, Vector<StringName>> &inner_map = translation_map[ctx];
 
 		List<StringName> id_l;
 		inner_map.get_key_list(&id_l);
-		for (auto E2 = id_l.front(); E2; E2 = E2->next()) {
+		for (List<StringName>::Element *E2 = id_l.front(); E2; E2 = E2->next()) {
 			StringName id = E2->get();
 			file->store_line("msgid: " + String::utf8(String(id).utf8()));
 			for (int i = 0; i < inner_map[id].size(); i++) {
@@ -74,7 +74,7 @@ Dictionary TranslationPO::_get_messages() const {
 
 	List<StringName> context_l;
 	translation_map.get_key_list(&context_l);
-	for (auto E = context_l.front(); E; E = E->next()) {
+	for (List<StringName>::Element *E = context_l.front(); E; E = E->next()) {
 		StringName ctx = E->get();
 		const HashMap<StringName, Vector<StringName>> &id_str_map = translation_map[ctx];
 
@@ -82,7 +82,7 @@ Dictionary TranslationPO::_get_messages() const {
 		List<StringName> id_l;
 		id_str_map.get_key_list(&id_l);
 		// Save list of id and strs associated with a context in a temporary dictionary.
-		for (auto E2 = id_l.front(); E2; E2 = E2->next()) {
+		for (List<StringName>::Element *E2 = id_l.front(); E2; E2 = E2->next()) {
 			StringName id = E2->get();
 			d2[id] = id_str_map[id];
 		}
@@ -98,14 +98,14 @@ void TranslationPO::_set_messages(const Dictionary &p_messages) {
 
 	List<Variant> context_l;
 	p_messages.get_key_list(&context_l);
-	for (auto E = context_l.front(); E; E = E->next()) {
+	for (List<Variant>::Element *E = context_l.front(); E; E = E->next()) {
 		StringName ctx = E->get();
 		const Dictionary &id_str_map = p_messages[ctx];
 
 		HashMap<StringName, Vector<StringName>> temp_map;
 		List<Variant> id_l;
 		id_str_map.get_key_list(&id_l);
-		for (auto E2 = id_l.front(); E2; E2 = E2->next()) {
+		for (List<Variant>::Element *E2 = id_l.front(); E2; E2 = E2->next()) {
 			StringName id = E2->get();
 			temp_map[id] = id_str_map[id];
 		}
@@ -121,7 +121,7 @@ Vector<String> TranslationPO::_get_message_list() const {
 	get_message_list(&msgs);
 
 	Vector<String> v;
-	for (auto E = msgs.front(); E; E = E->next()) {
+	for (List<StringName>::Element *E = msgs.front(); E; E = E->next()) {
 		v.push_back(E->get());
 	}
 
@@ -281,7 +281,7 @@ void TranslationPO::get_message_list(List<StringName> *r_messages) const {
 	List<StringName> context_l;
 	translation_map.get_key_list(&context_l);
 
-	for (auto E = context_l.front(); E; E = E->next()) {
+	for (List<StringName>::Element *E = context_l.front(); E; E = E->next()) {
 		if (String(E->get()) != "") {
 			continue;
 		}
@@ -289,7 +289,7 @@ void TranslationPO::get_message_list(List<StringName> *r_messages) const {
 		List<StringName> msgid_l;
 		translation_map[E->get()].get_key_list(&msgid_l);
 
-		for (auto E2 = msgid_l.front(); E2; E2 = E2->next()) {
+		for (List<StringName>::Element *E2 = msgid_l.front(); E2; E2 = E2->next()) {
 			r_messages->push_back(E2->get());
 		}
 	}
@@ -300,7 +300,7 @@ int TranslationPO::get_message_count() const {
 	translation_map.get_key_list(&context_l);
 
 	int count = 0;
-	for (auto E = context_l.front(); E; E = E->next()) {
+	for (List<StringName>::Element *E = context_l.front(); E; E = E->next()) {
 		count += translation_map[E->get()].size();
 	}
 	return count;

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -105,7 +105,7 @@ void EditorTranslationParser::get_recognized_extensions(List<String> *r_extensio
 	for (int i = 0; i < temp.size(); i++) {
 		extensions.insert(temp[i]);
 	}
-	for (auto E = extensions.front(); E; E = E->next()) {
+	for (Set<String>::Element *E = extensions.front(); E; E = E->next()) {
 		r_extensions->push_back(E->get());
 	}
 }

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -39,7 +39,7 @@ POTGenerator *POTGenerator::singleton = nullptr;
 
 #ifdef DEBUG_POT
 void POTGenerator::_print_all_translation_strings() {
-	for (auto E = all_translation_strings.front(); E; E = E.next()) {
+	for (OrderedHashMap<String, Vector<POTGenerator::MsgidData>>::Element E = all_translation_strings.front(); E; E = E.next()) {
 		Vector<MsgidData> v_md = all_translation_strings[E.key()];
 		for (int i = 0; i < v_md.size(); i++) {
 			print_line("++++++");

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -277,7 +277,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		}
 
 		Ref<Texture2D> icon_temp;
-		auto signal_temp = BUTTON_SIGNALS;
+		SceneTreeEditorButton signal_temp = BUTTON_SIGNALS;
 		if (num_connections >= 1 && num_groups >= 1) {
 			icon_temp = get_theme_icon("SignalsAndGroups", "EditorIcons");
 		} else if (num_connections >= 1) {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -43,7 +43,7 @@ class SceneTreeEditor : public Control {
 
 	EditorSelection *editor_selection;
 
-	enum {
+	enum SceneTreeEditorButton {
 		BUTTON_SUBSCENE = 0,
 		BUTTON_VISIBILITY = 1,
 		BUTTON_SCRIPT = 2,

--- a/modules/fbx/fbx_parser/FBXMaterial.cpp
+++ b/modules/fbx/fbx_parser/FBXMaterial.cpp
@@ -325,7 +325,7 @@ Video::Video(uint64_t id, const ElementPtr element, const Document &doc, const s
 					DOMError("embedded content is not surrounded by quotation marks", element);
 				} else {
 					size_t targetLength = 0;
-					auto numTokens = Content->Tokens().size();
+					const size_t numTokens = Content->Tokens().size();
 					// First time compute size (it could be large like 64Gb and it is good to allocate it once)
 					for (uint32_t tokenIdx = 0; tokenIdx < numTokens; ++tokenIdx) {
 						const Token *dataToken = GetRequiredToken(Content, tokenIdx);

--- a/modules/fbx/fbx_parser/FBXParser.h
+++ b/modules/fbx/fbx_parser/FBXParser.h
@@ -160,7 +160,7 @@ public:
 	}
 
 	ElementPtr FindElementCaseInsensitive(const std::string &elementName) const {
-		for (auto element = elements.begin(); element != elements.end(); ++element) {
+		for (FBXDocParser::ElementMap::const_iterator element = elements.begin(); element != elements.end(); ++element) {
 			if (element->first.compare(elementName)) {
 				return element->second;
 			}

--- a/modules/fbx/fbx_parser/FBXUtil.cpp
+++ b/modules/fbx/fbx_parser/FBXUtil.cpp
@@ -121,7 +121,7 @@ static const uint8_t base64DecodeTable[128] = {
 };
 
 uint8_t DecodeBase64(char ch) {
-	const auto idx = static_cast<uint8_t>(ch);
+	const uint8_t idx = static_cast<uint8_t>(ch);
 	if (idx > 127) {
 		return 255;
 	}

--- a/modules/gdnavigation/gd_navigation_server.cpp
+++ b/modules/gdnavigation/gd_navigation_server.cpp
@@ -122,7 +122,7 @@ GdNavigationServer::~GdNavigationServer() {
 }
 
 void GdNavigationServer::add_command(SetCommand *command) const {
-	auto mut_this = const_cast<GdNavigationServer *>(this);
+	GdNavigationServer *mut_this = const_cast<GdNavigationServer *>(this);
 	{
 		MutexLock lock(commands_mutex);
 		mut_this->commands.push_back(command);
@@ -130,7 +130,7 @@ void GdNavigationServer::add_command(SetCommand *command) const {
 }
 
 RID GdNavigationServer::map_create() const {
-	auto mut_this = const_cast<GdNavigationServer *>(this);
+	GdNavigationServer *mut_this = const_cast<GdNavigationServer *>(this);
 	MutexLock lock(mut_this->operations_mutex);
 	NavMap *space = memnew(NavMap);
 	RID rid = map_owner.make_rid(space);
@@ -240,7 +240,7 @@ RID GdNavigationServer::map_get_closest_point_owner(RID p_map, const Vector3 &p_
 }
 
 RID GdNavigationServer::region_create() const {
-	auto mut_this = const_cast<GdNavigationServer *>(this);
+	GdNavigationServer *mut_this = const_cast<GdNavigationServer *>(this);
 	MutexLock lock(mut_this->operations_mutex);
 	NavRegion *reg = memnew(NavRegion);
 	RID rid = region_owner.make_rid(reg);
@@ -330,7 +330,7 @@ Vector3 GdNavigationServer::region_get_connection_pathway_end(RID p_region, int 
 }
 
 RID GdNavigationServer::agent_create() const {
-	auto mut_this = const_cast<GdNavigationServer *>(this);
+	GdNavigationServer *mut_this = const_cast<GdNavigationServer *>(this);
 	MutexLock lock(mut_this->operations_mutex);
 	RvoAgent *agent = memnew(RvoAgent());
 	RID rid = agent_owner.make_rid(agent);
@@ -504,7 +504,7 @@ COMMAND_1(free, RID, p_object) {
 }
 
 void GdNavigationServer::set_active(bool p_active) const {
-	auto mut_this = const_cast<GdNavigationServer *>(this);
+	GdNavigationServer *mut_this = const_cast<GdNavigationServer *>(this);
 	MutexLock lock(mut_this->operations_mutex);
 	mut_this->active = p_active;
 }

--- a/modules/gdnavigation/nav_map.cpp
+++ b/modules/gdnavigation/nav_map.cpp
@@ -168,7 +168,7 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 				const Vector3 new_entry = Geometry3D::get_closest_point_to_segment(least_cost_poly->entry, pathway);
 				const float new_distance = least_cost_poly->entry.distance_to(new_entry) + least_cost_poly->traveled_distance;
 
-				auto it = std::find(
+				const std::vector<gd::NavigationPoly>::iterator it = std::find(
 						navigation_polys.begin(),
 						navigation_polys.end(),
 						gd::NavigationPoly(connection.polygon));
@@ -504,7 +504,7 @@ void NavMap::add_region(NavRegion *p_region) {
 }
 
 void NavMap::remove_region(NavRegion *p_region) {
-	std::vector<NavRegion *>::iterator it = std::find(regions.begin(), regions.end(), p_region);
+	const std::vector<NavRegion *>::iterator it = std::find(regions.begin(), regions.end(), p_region);
 	if (it != regions.end()) {
 		regions.erase(it);
 		regenerate_links = true;
@@ -524,7 +524,7 @@ void NavMap::add_agent(RvoAgent *agent) {
 
 void NavMap::remove_agent(RvoAgent *agent) {
 	remove_agent_as_controlled(agent);
-	auto it = std::find(agents.begin(), agents.end(), agent);
+	const std::vector<RvoAgent *>::iterator it = std::find(agents.begin(), agents.end(), agent);
 	if (it != agents.end()) {
 		agents.erase(it);
 		agents_dirty = true;
@@ -540,7 +540,7 @@ void NavMap::set_agent_as_controlled(RvoAgent *agent) {
 }
 
 void NavMap::remove_agent_as_controlled(RvoAgent *agent) {
-	auto it = std::find(controlled_agents.begin(), controlled_agents.end(), agent);
+	const std::vector<RvoAgent *>::iterator it = std::find(controlled_agents.begin(), controlled_agents.end(), agent);
 	if (it != controlled_agents.end()) {
 		controlled_agents.erase(it);
 	}

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -441,7 +441,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		result.output = get_text_for_status(result.status) + "\n";
 
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
-		for (auto *E = errors.front(); E; E = E->next()) {
+		for (const List<GDScriptParser::ParserError>::Element *E = errors.front(); E; E = E->next()) {
 			result.output += E->get().message + "\n"; // TODO: line, column?
 			break; // Only the first error since the following might be cascading.
 		}
@@ -460,7 +460,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		result.output = get_text_for_status(result.status) + "\n";
 
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
-		for (auto *E = errors.front(); E; E = E->next()) {
+		for (const List<GDScriptParser::ParserError>::Element *E = errors.front(); E; E = E->next()) {
 			result.output += E->get().message + "\n"; // TODO: line, column?
 			break; // Only the first error since the following might be cascading.
 		}

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2016,7 +2016,7 @@ void CSharpInstance::connect_event_signals() {
 		StringName signal_name = event_signal.field->get_name();
 
 		// TODO: Use pooling for ManagedCallable instances.
-		auto event_signal_callable = memnew(EventSignalCallable(owner, &event_signal));
+		EventSignalCallable *event_signal_callable = memnew(EventSignalCallable(owner, &event_signal));
 
 		Callable callable(event_signal_callable);
 		connected_event_signals.push_back(callable);
@@ -2027,7 +2027,7 @@ void CSharpInstance::connect_event_signals() {
 void CSharpInstance::disconnect_event_signals() {
 	for (const List<Callable>::Element *E = connected_event_signals.front(); E; E = E->next()) {
 		const Callable &callable = E->get();
-		auto event_signal_callable = static_cast<const EventSignalCallable *>(callable.get_custom());
+		const EventSignalCallable *event_signal_callable = static_cast<const EventSignalCallable *>(callable.get_custom());
 		owner->disconnect(event_signal_callable->get_signal(), callable);
 	}
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -119,11 +119,11 @@ void gd_mono_profiler_init() {
 
 	const String env_var_name = "MONO_ENV_OPTIONS";
 	if (OS::get_singleton()->has_environment(env_var_name)) {
-		const auto mono_env_ops = OS::get_singleton()->get_environment(env_var_name);
+		const String mono_env_ops = OS::get_singleton()->get_environment(env_var_name);
 		// Usually MONO_ENV_OPTIONS looks like:   --profile=jb:prof=timeline,ctl=remote,host=127.0.0.1:55467
 		const String prefix = "--profile=";
 		if (mono_env_ops.begins_with(prefix)) {
-			const auto ops = mono_env_ops.substr(prefix.length(), mono_env_ops.length());
+			const String ops = mono_env_ops.substr(prefix.length(), mono_env_ops.length());
 			mono_profiler_load(ops.utf8());
 		}
 	}


### PR DESCRIPTION
[The current code style guidelines forbid the use of `auto`.](https://github.com/godotengine/godot-docs/pull/3668)

Some uses of `auto` are still present, such as in UWP code (which can't be currently tested) and macros (where removing `auto` isn't easy).

There are further code style changes that need to be made (there are some camelCase variables), but these changes should be made separately.

**Note:** The use of `auto` is not up for debate here – it's already been [discussed at length](https://github.com/godotengine/godot/issues/9694) :slightly_smiling_face: