### PR TITLE
Made default tooltips (non-custom ones) disappear on mouse enter.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1563,6 +1563,9 @@ void Viewport::_gui_show_tooltip() {
 		return;
 	}
 
+	// Popup window which houses the tooltip content.
+	TooltipPanel *panel = memnew(TooltipPanel);
+
 	// Controls can implement `make_custom_tooltip` to provide their own tooltip.
 	// This should be a Control node which will be added as child to a TooltipPanel.
 	Control *base_tooltip = tooltip_owner->make_custom_tooltip(tooltip_text);
@@ -1572,11 +1575,11 @@ void Viewport::_gui_show_tooltip() {
 		gui.tooltip_label = memnew(TooltipLabel);
 		gui.tooltip_label->set_text(tooltip_text);
 		base_tooltip = gui.tooltip_label;
+		panel->connect("mouse_entered", callable_mp(this, &Viewport::_gui_cancel_tooltip));
 	}
 
 	base_tooltip->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 
-	TooltipPanel *panel = memnew(TooltipPanel);
 	panel->set_transient(false);
 	panel->set_flag(Window::FLAG_NO_FOCUS, true);
 	panel->set_wrap_controls(true);


### PR DESCRIPTION
Matches 3.X behaviour, but does not break custom tooltips where mouse interaction is needed. Was quite annoying that tooltips did not automatically disappear when hovering over/past them.

![1eLVdAyCLI](https://user-images.githubusercontent.com/41730826/115998499-e07c1e80-a62a-11eb-88d7-31cf73e6e5c9.gif)
![LJBGNt8nF5](https://user-images.githubusercontent.com/41730826/115998504-e2de7880-a62a-11eb-9753-22c60f0bb605.gif)

Fixes #50571