### PR TITLE
Add `INT32_MIN`, `INT32_MAX`, `INT64_MIN`, `INT64_MAX` constants

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -401,6 +401,18 @@ Error Expression::_get_token(Token &r_token) {
 					} else if (id == "NAN") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = Math_NAN;
+					} else if (id == "INT32_MIN") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = INT32_MIN;
+					} else if (id == "INT32_MAX") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = INT32_MAX;
+					} else if (id == "INT64_MIN") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = INT64_MIN;
+					} else if (id == "INT64_MAX") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = INT64_MAX;
 					} else if (id == "not") {
 						r_token.type = TK_OP_NOT;
 					} else if (id == "or") {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1744,6 +1744,10 @@ void GDScriptLanguage::init() {
 	_add_global(StaticCString::create("TAU"), Math_TAU);
 	_add_global(StaticCString::create("INF"), Math_INF);
 	_add_global(StaticCString::create("NAN"), Math_NAN);
+	_add_global(StaticCString::create("INT32_MIN"), INT32_MIN);
+	_add_global(StaticCString::create("INT32_MAX"), INT32_MAX);
+	_add_global(StaticCString::create("INT64_MIN"), INT64_MIN);
+	_add_global(StaticCString::create("INT64_MAX"), INT64_MAX);
 
 	//populate native classes
 
@@ -2083,6 +2087,10 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		"TAU",
 		"INF",
 		"NAN",
+		"INT32_MIN",
+		"INT32_MAX",
+		"INT64_MIN",
+		"INT64_MAX",
 		"self",
 		"true",
 		"void",

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -458,6 +458,26 @@ void GDScriptLanguage::get_public_constants(List<Pair<String, Variant>> *p_const
 	nan.first = "NAN";
 	nan.second = Math_NAN;
 	p_constants->push_back(nan);
+
+	Pair<String, Variant> int32_min;
+	int32_min.first = "INT32_MIN";
+	int32_min.second = INT32_MIN;
+	p_constants->push_back(int32_min);
+
+	Pair<String, Variant> int32_max;
+	int32_max.first = "INT32_MAX";
+	int32_max.second = INT32_MAX;
+	p_constants->push_back(int32_max);
+
+	Pair<String, Variant> int64_min;
+	int64_min.first = "INT64_MIN";
+	int64_min.second = INT64_MIN;
+	p_constants->push_back(int64_min);
+
+	Pair<String, Variant> int64_max;
+	int64_max.first = "INT64_MAX";
+	int64_max.second = INT64_MAX;
+	p_constants->push_back(int64_max);
 }
 
 String GDScriptLanguage::make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const {
@@ -1035,7 +1055,8 @@ static void _find_identifiers(GDScriptParser::CompletionContext &p_context, bool
 	}
 
 	static const char *_keywords[] = {
-		"false", "PI", "TAU", "INF", "NAN", "self", "true", "breakpoint", "tool", "super",
+		"false", "PI", "TAU", "INF", "NAN", "INT32_MIN", "INT32_MAX", "INT64_MIN", "INT64_MAX",
+		"self", "true", "breakpoint", "tool", "super",
 		"break", "continue", "pass", "return",
 		nullptr
 	};
@@ -2954,7 +2975,7 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 		return OK;
 	}
 
-	if ("PI" == p_symbol || "TAU" == p_symbol || "INF" == p_symbol || "NAN" == p_symbol) {
+	if ("PI" == p_symbol || "TAU" == p_symbol || "INF" == p_symbol || "NAN" == p_symbol || "INT32_MIN" == p_symbol || "INT32_MAX" == p_symbol || "INT64_MIN" == p_symbol || "INT64_MAX" == p_symbol) {
 		r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_CONSTANT;
 		r_result.class_name = "@GDScript";
 		r_result.class_member = p_symbol;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2077,6 +2077,18 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_builtin_constant(Expressio
 		case GDScriptTokenizer::Token::CONST_NAN:
 			constant->value = Math_NAN;
 			break;
+		case GDScriptTokenizer::Token::CONST_INT32_MIN:
+			constant->value = INT32_MIN;
+			break;
+		case GDScriptTokenizer::Token::CONST_INT32_MAX:
+			constant->value = INT32_MAX;
+			break;
+		case GDScriptTokenizer::Token::CONST_INT64_MIN:
+			constant->value = INT64_MIN;
+			break;
+		case GDScriptTokenizer::Token::CONST_INT64_MAX:
+			constant->value = INT64_MAX;
+			break;
 		default:
 			return nullptr; // Unreachable.
 	}
@@ -3056,6 +3068,10 @@ GDScriptParser::ParseRule *GDScriptParser::get_rule(GDScriptTokenizer::Token::Ty
 		{ &GDScriptParser::parse_builtin_constant,			nullptr,                                        PREC_NONE }, // CONST_TAU,
 		{ &GDScriptParser::parse_builtin_constant,			nullptr,                                        PREC_NONE }, // CONST_INF,
 		{ &GDScriptParser::parse_builtin_constant,			nullptr,                                        PREC_NONE }, // CONST_NAN,
+		{ &GDScriptParser::parse_builtin_constant,			nullptr,                                        PREC_NONE }, // CONST_INT32_MIN,
+		{ &GDScriptParser::parse_builtin_constant,			nullptr,                                        PREC_NONE }, // CONST_INT32_MAX,
+		{ &GDScriptParser::parse_builtin_constant,			nullptr,                                        PREC_NONE }, // CONST_INT64_MIN,
+		{ &GDScriptParser::parse_builtin_constant,			nullptr,                                        PREC_NONE }, // CONST_INT64_MAX,
 		// Error message improvement
 		{ nullptr,                                          nullptr,                                        PREC_NONE }, // VCS_CONFLICT_MARKER,
 		{ nullptr,                                          nullptr,                                        PREC_NONE }, // BACKTICK,

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -139,6 +139,10 @@ static const char *token_names[] = {
 	"TAU", // CONST_TAU,
 	"INF", // CONST_INF,
 	"NaN", // CONST_NAN,
+	"int32 minimum", // CONST_INT32_MIN,
+	"int32 maximum", // CONST_INT32_MAX,
+	"int64 minimum", // CONST_INT64_MIN,
+	"int64 maximum", // CONST_INT64_MAX,
 	// Error message improvement
 	"VCS conflict marker", // VCS_CONFLICT_MARKER,
 	"`", // BACKTICK,
@@ -451,65 +455,69 @@ GDScriptTokenizer::Token GDScriptTokenizer::annotation() {
 }
 
 GDScriptTokenizer::Token GDScriptTokenizer::potential_identifier() {
-#define KEYWORDS(KEYWORD_GROUP, KEYWORD)     \
-	KEYWORD_GROUP('a')                       \
-	KEYWORD("as", Token::AS)                 \
-	KEYWORD("and", Token::AND)               \
-	KEYWORD("assert", Token::ASSERT)         \
-	KEYWORD("await", Token::AWAIT)           \
-	KEYWORD_GROUP('b')                       \
-	KEYWORD("break", Token::BREAK)           \
-	KEYWORD("breakpoint", Token::BREAKPOINT) \
-	KEYWORD_GROUP('c')                       \
-	KEYWORD("class", Token::CLASS)           \
-	KEYWORD("class_name", Token::CLASS_NAME) \
-	KEYWORD("const", Token::CONST)           \
-	KEYWORD("continue", Token::CONTINUE)     \
-	KEYWORD_GROUP('e')                       \
-	KEYWORD("elif", Token::ELIF)             \
-	KEYWORD("else", Token::ELSE)             \
-	KEYWORD("enum", Token::ENUM)             \
-	KEYWORD("extends", Token::EXTENDS)       \
-	KEYWORD_GROUP('f')                       \
-	KEYWORD("for", Token::FOR)               \
-	KEYWORD("func", Token::FUNC)             \
-	KEYWORD_GROUP('i')                       \
-	KEYWORD("if", Token::IF)                 \
-	KEYWORD("in", Token::IN)                 \
-	KEYWORD("is", Token::IS)                 \
-	KEYWORD_GROUP('m')                       \
-	KEYWORD("match", Token::MATCH)           \
-	KEYWORD_GROUP('n')                       \
-	KEYWORD("namespace", Token::NAMESPACE)   \
-	KEYWORD("not", Token::NOT)               \
-	KEYWORD_GROUP('o')                       \
-	KEYWORD("or", Token::OR)                 \
-	KEYWORD_GROUP('p')                       \
-	KEYWORD("pass", Token::PASS)             \
-	KEYWORD("preload", Token::PRELOAD)       \
-	KEYWORD_GROUP('r')                       \
-	KEYWORD("return", Token::RETURN)         \
-	KEYWORD_GROUP('s')                       \
-	KEYWORD("self", Token::SELF)             \
-	KEYWORD("signal", Token::SIGNAL)         \
-	KEYWORD("static", Token::STATIC)         \
-	KEYWORD("super", Token::SUPER)           \
-	KEYWORD_GROUP('t')                       \
-	KEYWORD("trait", Token::TRAIT)           \
-	KEYWORD_GROUP('v')                       \
-	KEYWORD("var", Token::VAR)               \
-	KEYWORD("void", Token::VOID)             \
-	KEYWORD_GROUP('w')                       \
-	KEYWORD("while", Token::WHILE)           \
-	KEYWORD_GROUP('y')                       \
-	KEYWORD("yield", Token::YIELD)           \
-	KEYWORD_GROUP('I')                       \
-	KEYWORD("INF", Token::CONST_INF)         \
-	KEYWORD_GROUP('N')                       \
-	KEYWORD("NAN", Token::CONST_NAN)         \
-	KEYWORD_GROUP('P')                       \
-	KEYWORD("PI", Token::CONST_PI)           \
-	KEYWORD_GROUP('T')                       \
+#define KEYWORDS(KEYWORD_GROUP, KEYWORD)         \
+	KEYWORD_GROUP('a')                           \
+	KEYWORD("as", Token::AS)                     \
+	KEYWORD("and", Token::AND)                   \
+	KEYWORD("assert", Token::ASSERT)             \
+	KEYWORD("await", Token::AWAIT)               \
+	KEYWORD_GROUP('b')                           \
+	KEYWORD("break", Token::BREAK)               \
+	KEYWORD("breakpoint", Token::BREAKPOINT)     \
+	KEYWORD_GROUP('c')                           \
+	KEYWORD("class", Token::CLASS)               \
+	KEYWORD("class_name", Token::CLASS_NAME)     \
+	KEYWORD("const", Token::CONST)               \
+	KEYWORD("continue", Token::CONTINUE)         \
+	KEYWORD_GROUP('e')                           \
+	KEYWORD("elif", Token::ELIF)                 \
+	KEYWORD("else", Token::ELSE)                 \
+	KEYWORD("enum", Token::ENUM)                 \
+	KEYWORD("extends", Token::EXTENDS)           \
+	KEYWORD_GROUP('f')                           \
+	KEYWORD("for", Token::FOR)                   \
+	KEYWORD("func", Token::FUNC)                 \
+	KEYWORD_GROUP('i')                           \
+	KEYWORD("if", Token::IF)                     \
+	KEYWORD("in", Token::IN)                     \
+	KEYWORD("is", Token::IS)                     \
+	KEYWORD_GROUP('m')                           \
+	KEYWORD("match", Token::MATCH)               \
+	KEYWORD_GROUP('n')                           \
+	KEYWORD("namespace", Token::NAMESPACE)       \
+	KEYWORD("not", Token::NOT)                   \
+	KEYWORD_GROUP('o')                           \
+	KEYWORD("or", Token::OR)                     \
+	KEYWORD_GROUP('p')                           \
+	KEYWORD("pass", Token::PASS)                 \
+	KEYWORD("preload", Token::PRELOAD)           \
+	KEYWORD_GROUP('r')                           \
+	KEYWORD("return", Token::RETURN)             \
+	KEYWORD_GROUP('s')                           \
+	KEYWORD("self", Token::SELF)                 \
+	KEYWORD("signal", Token::SIGNAL)             \
+	KEYWORD("static", Token::STATIC)             \
+	KEYWORD("super", Token::SUPER)               \
+	KEYWORD_GROUP('t')                           \
+	KEYWORD("trait", Token::TRAIT)               \
+	KEYWORD_GROUP('v')                           \
+	KEYWORD("var", Token::VAR)                   \
+	KEYWORD("void", Token::VOID)                 \
+	KEYWORD_GROUP('w')                           \
+	KEYWORD("while", Token::WHILE)               \
+	KEYWORD_GROUP('y')                           \
+	KEYWORD("yield", Token::YIELD)               \
+	KEYWORD_GROUP('I')                           \
+	KEYWORD("INF", Token::CONST_INF)             \
+	KEYWORD("INT32_MIN", Token::CONST_INT32_MIN) \
+	KEYWORD("INT32_MAX", Token::CONST_INT32_MAX) \
+	KEYWORD("INT64_MIN", Token::CONST_INT64_MIN) \
+	KEYWORD("INT64_MAX", Token::CONST_INT64_MAX) \
+	KEYWORD_GROUP('N')                           \
+	KEYWORD("NAN", Token::CONST_NAN)             \
+	KEYWORD_GROUP('P')                           \
+	KEYWORD("PI", Token::CONST_PI)               \
+	KEYWORD_GROUP('T')                           \
 	KEYWORD("TAU", Token::CONST_TAU)
 
 #define MIN_KEYWORD_LENGTH 2

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -150,6 +150,10 @@ public:
 			CONST_TAU,
 			CONST_INF,
 			CONST_NAN,
+			CONST_INT32_MIN,
+			CONST_INT32_MAX,
+			CONST_INT64_MIN,
+			CONST_INT64_MAX,
 			// Error message improvement
 			VCS_CONFLICT_MARKER,
 			BACKTICK,

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -530,6 +530,18 @@ Error VisualScriptExpression::_get_token(Token &r_token) {
 					} else if (id == "NAN") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = Math_NAN;
+					} else if (id == "INT32_MIN") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = INT32_MIN;
+					} else if (id == "INT32_MAX") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = INT32_MAX;
+					} else if (id == "INT64_MIN") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = INT64_MIN;
+					} else if (id == "INT64_MAX") {
+						r_token.type = TK_CONSTANT;
+						r_token.value = INT64_MAX;
 					} else if (id == "not") {
 						r_token.type = TK_OP_NOT;
 					} else if (id == "or") {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2099,6 +2099,9 @@ VisualScriptBasicTypeConstant::VisualScriptBasicTypeConstant() {
 ////////////////MATHCONSTANT///////////
 //////////////////////////////////////////
 
+// `INT32_MIN`, `INT32_MAX`, `INT64_MIN`, `INT64_MAX` are missing because they
+// require integer types (only `double`s can currently be returned).
+// Use a VisualScriptExpression if you need those integer constants.
 const char *VisualScriptMathConstant::const_name[MATH_CONSTANT_MAX] = {
 	"One",
 	"PI",


### PR DESCRIPTION
These are available in GDScript, Expression and VisualScript expressions.
Since both PackedInt32Array and PackedInt64Array are exposed to GDScript, it makes sense to have constants for both 32-bit and 64-bit integers.

These constants aren't available in VisualScript Math constant nodes because it can only return `double`s, not integers.

This closes https://github.com/godotengine/godot-proposals/issues/2411. This PR can be remade for the `3.x` branch if desired.

<details>
<summary>Testing code</summary>

```gdscript
print(INT32_MIN)
print(INT32_MAX)
print(INT64_MIN)
print(INT64_MAX)

print()
print(-INT32_MIN)
print(-INT32_MAX)
print(-INT64_MIN)
print(-INT64_MAX)

print()
print(2 * INT32_MIN)
print(2 * INT32_MAX)
print(2 * INT64_MIN)
print(2 * INT64_MAX)

print()
var exp = Expression.new()
exp.parse("INT64_MAX")
print(exp.execute())
```

Should print:

```
-2147483648
2147483647
-9223372036854775808
9223372036854775807

2147483648
-2147483647
-9223372036854775808
-9223372036854775807

-4294967296
4294967294
0
-2

9223372036854775807
```
</details>