### PR TITLE
Rename `BaseButton` signals to avoid name conflict and reflect event

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -9,17 +9,17 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_pressed" qualifiers="virtual">
+		<method name="_clicked" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				Called when the button is pressed. If you need to know the button's pressed state (and [member toggle_mode] is active), use [method _toggled] instead.
+				Called when the button is clicked.
 			</description>
 		</method>
 		<method name="_toggled" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="button_pressed" type="bool" />
 			<description>
-				Called when the button is toggled (only if [member toggle_mode] is active).
+				If [member toggle_mode] is [code]true[/code], called when the button is toggled.
 			</description>
 		</method>
 		<method name="get_draw_mode" qualifiers="const">
@@ -38,7 +38,7 @@
 			<return type="void" />
 			<argument index="0" name="pressed" type="bool" />
 			<description>
-				Changes the [member pressed] state of the button, without emitting [signal toggled]. Use when you just want to change the state of the button without sending the pressed event (e.g. when initializing scene). Only works if [member toggle_mode] is [code]true[/code].
+				Changes the [member pressed] state of the button, without emitting [signal button_toggled]. Use when you just want to change the state of the button without sending the pressed event (e.g. when initializing scene). Only works if [member toggle_mode] is [code]true[/code].
 				[b]Note:[/b] This method doesn't unpress other buttons in [member button_group].
 			</description>
 		</method>
@@ -64,7 +64,7 @@
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the button's state is pressed. Means the button is pressed down or toggled (if [member toggle_mode] is active). Only works if [member toggle_mode] is [code]true[/code].
-			[b]Note:[/b] Setting [member pressed] will result in [signal toggled] to be emitted. If you want to change the pressed state without emitting that signal, use [method set_pressed_no_signal].
+			[b]Note:[/b] Setting [member pressed] will result in [signal button_toggled] to be emitted. If you want to change the pressed state without emitting that signal, use [method set_pressed_no_signal].
 		</member>
 		<member name="shortcut" type="Shortcut" setter="set_shortcut" getter="get_shortcut">
 			[Shortcut] associated to the button.
@@ -76,30 +76,30 @@
 			If [code]true[/code], the button will add information about its shortcut in the tooltip.
 		</member>
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" default="false">
-			If [code]true[/code], the button is in toggle mode. Makes the button flip state between pressed and unpressed each time its area is clicked.
+			If [code]true[/code], the button is in toggle mode. Makes the button flip state between pressed and released each time it's clicked.
 		</member>
 	</members>
 	<signals>
-		<signal name="button_down">
+		<signal name="button_clicked">
 			<description>
-				Emitted when the button starts being held down.
+				Emitted when the button is clicked.
+				If [member action_mode] is [constant ACTION_MODE_BUTTON_PRESS], emitted with [signal button_pressed]. If [member action_mode] is [constant ACTION_MODE_BUTTON_RELEASE], emitted with [signal button_released] if the mouse is still over the button.
 			</description>
 		</signal>
-		<signal name="button_up">
+		<signal name="button_pressed">
 			<description>
-				Emitted when the button stops being held down.
+				Emitted when the button starts being pressed.
 			</description>
 		</signal>
-		<signal name="pressed">
+		<signal name="button_released">
 			<description>
-				Emitted when the button is toggled or pressed. This is on [signal button_down] if [member action_mode] is [constant ACTION_MODE_BUTTON_PRESS] and on [signal button_up] otherwise.
-				If you need to know the button's pressed state (and [member toggle_mode] is active), use [signal toggled] instead.
+				Emitted when the button is released.
 			</description>
 		</signal>
-		<signal name="toggled">
+		<signal name="button_toggled">
 			<argument index="0" name="button_pressed" type="bool" />
 			<description>
-				Emitted when the button was just toggled between pressed and normal states (only if [member toggle_mode] is active). The new state is contained in the [code]button_pressed[/code] argument.
+				If [member toggle_mode] is [code]true[/code], emitted whenever the button is clicked. The new state is contained in the [code]button_pressed[/code] argument.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -5,16 +5,16 @@
 	</brief_description>
 	<description>
 		Button is the standard themed button. It can contain text and an icon, and will display them according to the current [Theme].
-		[b]Example of creating a button and assigning an action when pressed by code:[/b]
+		[b]Example of creating a button and assigning an action when clicked by code:[/b]
 		[codeblocks]
 		[gdscript]
 		func _ready():
 		    var button = Button.new()
 		    button.text = "Click me"
-		    button.connect("pressed", self, "_button_pressed")
+		    button.connect("button_clicked", self, "_button_clicked")
 		    add_child(button)
 
-		func _button_pressed():
+		func _button_clicked():
 		    print("Hello world!")
 		[/gdscript]
 		[csharp]
@@ -22,11 +22,11 @@
 		{
 		    var button = new Button();
 		    button.Text = "Click me";
-		    button.Connect("pressed", this, nameof(ButtonPressed));
+		    button.Connect("button_clicked", this, nameof(ButtonClicked));
 		    AddChild(button);
 		}
 
-		private void ButtonPressed()
+		private void ButtonClicked()
 		{
 		    GD.Print("Hello world!");
 		}

--- a/doc/classes/ButtonGroup.xml
+++ b/doc/classes/ButtonGroup.xml
@@ -27,10 +27,10 @@
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" override="true" default="true" />
 	</members>
 	<signals>
-		<signal name="pressed">
+		<signal name="button_clicked">
 			<argument index="0" name="button" type="Object" />
 			<description>
-				Emitted when one of the buttons of the group is pressed.
+				Emitted when one of the buttons of the group is clicked.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/ConfirmationDialog.xml
+++ b/doc/classes/ConfirmationDialog.xml
@@ -8,10 +8,10 @@
 		To get cancel action, you can use:
 		[codeblocks]
 		[gdscript]
-		get_cancel().connect("pressed", self, "cancelled")
+		get_cancel().connect("button_clicked", self, "cancelled")
 		[/gdscript]
 		[csharp]
-		GetCancel().Connect("pressed", this, nameof(Cancelled));
+		GetCancel().Connect("button_clicked", this, nameof(Cancelled));
 		[/csharp]
 		[/codeblocks]
 	</description>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -162,9 +162,9 @@
 				[gdscript]
 				func _ready():
 				    var button = Button.new()
-				    # `button_down` here is a Signal object, and we thus call the Signal.connect() method,
+				    # `button_pressed` here is a Signal object, and we thus call the Signal.connect() method,
 				    # not Object.connect(). See discussion below for a more in-depth overview of the API.
-				    button.button_down.connect(_on_button_down)
+				    button.button_pressed.connect(_on_button_pressed)
 
 				    # This assumes that a `Player` class exists which defines a `hit` signal.
 				    var player = Player.new()
@@ -172,8 +172,8 @@
 				    # returns a new Callable with the parameter binds.
 				    player.hit.connect(_on_player_hit.bind("sword", 100))
 
-				func _on_button_down():
-				    print("Button down!")
+				func _on_button_pressed():
+				    print("Button pressed!")
 
 				func _on_player_hit(weapon_type, damage):
 				    print("Hit with weapon %s for %d damage." % [weapon_type, damage])
@@ -183,7 +183,7 @@
 				{
 				    var button = new Button();
 				    // C# supports passing signals as events, so we can use this idiomatic construct:
-				    button.ButtonDown += OnButtonDown;
+				    button.ButtonPressed += OnButtonPressed;
 
 				    // This assumes that a `Player` class exists which defines a `Hit` signal.
 				    var player = new Player();
@@ -191,9 +191,9 @@
 				    player.Hit.Connect(OnPlayerHit, new Godot.Collections.Array {"sword", 100 });
 				}
 
-				private void OnButtonDown()
+				private void OnButtonPressed()
 				{
-				    GD.Print("Button down!");
+				    GD.Print("Button pressed!");
 				}
 
 				private void OnPlayerHit(string weaponType, int damage)
@@ -209,40 +209,40 @@
 				func _ready():
 				    var button = Button.new()
 				    # Option 1: Object.connect() with an implicit Callable for the defined function.
-				    button.connect("button_down", _on_button_down)
+				    button.connect("button_pressed", _on_button_pressed)
 				    # Option 2: Object.connect() with a constructed Callable using a target object and method name.
-				    button.connect("button_down", Callable(self, "_on_button_down"))
+				    button.connect("button_pressed", Callable(self, "_on_button_pressed"))
 				    # Option 3: Signal.connect() with an implicit Callable for the defined function.
-				    button.button_down.connect(_on_button_down)
+				    button.button_pressed.connect(_on_button_pressed)
 				    # Option 4: Signal.connect() with a constructed Callable using a target object and method name.
-				    button.button_down.connect(Callable(self, "_on_button_down"))
+				    button.button_pressed.connect(Callable(self, "_on_button_pressed"))
 
-				func _on_button_down():
-				    print("Button down!")
+				func _on_button_pressed():
+				    print("Button pressed!")
 				[/gdscript]
 				[csharp]
 				public override void _Ready()
 				{
 				    var button = new Button();
 				    // Option 1: Object.Connect() with an implicit Callable for the defined function.
-				    button.Connect("button_down", OnButtonDown);
+				    button.Connect("button_pressed", OnButtonPressed);
 				    // Option 2: Object.connect() with a constructed Callable using a target object and method name.
-				    button.Connect("button_down", new Callable(self, nameof(OnButtonDown)));
+				    button.Connect("button_pressed", new Callable(self, nameof(OnButtonPressed)));
 				    // Option 3: Signal.connect() with an implicit Callable for the defined function.
-				    button.ButtonDown.Connect(OnButtonDown);
+				    button.ButtonPressed.Connect(OnButtonPressed);
 				    // Option 3b: In C#, we can use signals as events and connect with this more idiomatic syntax:
-				    button.ButtonDown += OnButtonDown;
+				    button.ButtonPressed += OnButtonPressed;
 				    // Option 4: Signal.connect() with a constructed Callable using a target object and method name.
-				    button.ButtonDown.Connect(new Callable(self, nameof(OnButtonDown)));
+				    button.ButtonPressed.Connect(new Callable(self, nameof(OnButtonPressed)));
 				}
 
-				private void OnButtonDown()
+				private void OnButtonPressed()
 				{
-				    GD.Print("Button down!");
+				    GD.Print("Button pressed!");
 				}
 				[/csharp]
 				[/codeblocks]
-				While all options have the same outcome ([code]button[/code]'s [signal BaseButton.button_down] signal will be connected to [code]_on_button_down[/code]), option 3 offers the best validation: it will throw a compile-time error if either the [code]button_down[/code] signal or the [code]_on_button_down[/code] callable are undefined. On the other hand, option 2 only relies on string names and will only be able to validate either names at runtime: it will throw a runtime error if [code]"button_down"[/code] doesn't correspond to a signal, or if [code]"_on_button_down"[/code] is not a registered method in the object [code]self[/code]. The main reason for using options 1, 2, or 4 would be if you actually need to use strings (e.g. to connect signals programmatically based on strings read from a configuration file). Otherwise, option 3 is the recommended (and fastest) method.
+				While all options have the same outcome ([code]button[/code]'s [signal BaseButton.button_pressed] signal will be connected to [code]_on_button_pressed[/code]), option 3 offers the best validation: it will throw a compile-time error if either the [code]button_pressed[/code] signal or the [code]_on_button_pressed[/code] callable are undefined. On the other hand, option 2 only relies on string names and will only be able to validate either names at runtime: it will throw a runtime error if [code]"button_pressed"[/code] doesn't correspond to a signal, or if [code]"_on_button_pressed"[/code] is not a registered method in the object [code]self[/code]. The main reason for using options 1, 2, or 4 would be if you actually need to use strings (e.g. to connect signals programmatically based on strings read from a configuration file). Otherwise, option 3 is the recommended (and fastest) method.
 				[b]Parameter bindings and passing:[/b]
 				For legacy or language-specific reasons, there are also several ways to bind parameters to signals. One can pass a [code]binds[/code] [Array] to [method Object.connect] or [method Signal.connect], or use the recommended [method Callable.bind] method to create a new callable from an existing one, with the given parameter binds.
 				One can also pass additional parameters when emitting the signal with [method emit_signal]. The examples below show the relationship between those two types of parameters.

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -689,7 +689,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	for (int i = 0; i < MOD_MAX; i++) {
 		String name = mods[i];
 		mod_checkboxes[i] = memnew(CheckBox);
-		mod_checkboxes[i]->connect("toggled", callable_mp(this, &InputEventConfigurationDialog::_mod_toggled), varray(i));
+		mod_checkboxes[i]->connect("button_toggled", callable_mp(this, &InputEventConfigurationDialog::_mod_toggled), varray(i));
 		mod_checkboxes[i]->set_text(name);
 		mod_container->add_child(mod_checkboxes[i]);
 	}
@@ -697,7 +697,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	mod_container->add_child(memnew(VSeparator));
 
 	store_command_checkbox = memnew(CheckBox);
-	store_command_checkbox->connect("toggled", callable_mp(this, &InputEventConfigurationDialog::_store_command_toggled));
+	store_command_checkbox->connect("button_toggled", callable_mp(this, &InputEventConfigurationDialog::_store_command_toggled));
 	store_command_checkbox->set_pressed(true);
 	store_command_checkbox->set_text(TTR("Store Command"));
 #ifdef APPLE_STYLE_KEYS
@@ -715,7 +715,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	physical_key_checkbox = memnew(CheckBox);
 	physical_key_checkbox->set_text(TTR("Use Physical Keycode"));
 	physical_key_checkbox->set_tooltip(TTR("Stores the physical position of the key on the keyboard rather than the key's value. Used for compatibility with non-latin layouts.\nThis should generally be enabled for most game shortcuts, but not in non-game applications."));
-	physical_key_checkbox->connect("toggled", callable_mp(this, &InputEventConfigurationDialog::_physical_keycode_toggled));
+	physical_key_checkbox->connect("button_toggled", callable_mp(this, &InputEventConfigurationDialog::_physical_keycode_toggled));
 	physical_key_checkbox->hide();
 	additional_options_container->add_child(physical_key_checkbox);
 
@@ -1127,7 +1127,7 @@ ActionMapEditor::ActionMapEditor() {
 	show_builtin_actions_checkbutton = memnew(CheckButton);
 	show_builtin_actions_checkbutton->set_pressed(false);
 	show_builtin_actions_checkbutton->set_text(TTR("Show Built-in Actions"));
-	show_builtin_actions_checkbutton->connect("toggled", callable_mp(this, &ActionMapEditor::set_show_builtin_actions));
+	show_builtin_actions_checkbutton->connect("button_toggled", callable_mp(this, &ActionMapEditor::set_show_builtin_actions));
 	top_hbox->add_child(show_builtin_actions_checkbutton);
 
 	// Adding Action line edit + button
@@ -1143,7 +1143,7 @@ ActionMapEditor::ActionMapEditor() {
 
 	Button *add_button = memnew(Button);
 	add_button->set_text(TTR("Add"));
-	add_button->connect("pressed", callable_mp(this, &ActionMapEditor::_add_action_pressed));
+	add_button->connect("button_clicked", callable_mp(this, &ActionMapEditor::_add_action_pressed));
 	add_hbox->add_child(add_button);
 
 	main_vbox->add_child(add_hbox);

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1181,7 +1181,7 @@ AnimationBezierTrackEdit::AnimationBezierTrackEdit() {
 	set_clip_contents(true);
 
 	close_button = memnew(Button);
-	close_button->connect("pressed", Callable(this, SNAME("emit_signal")), varray(SNAME("close_request")));
+	close_button->connect("button_clicked", Callable(this, SNAME("emit_signal")), varray(SNAME("close_request")));
 	close_button->set_text(TTR("Close"));
 
 	right_column = memnew(VBoxContainer);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1916,7 +1916,7 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	loop = memnew(Button);
 	loop->set_flat(true);
 	loop->set_tooltip(TTR("Animation Looping"));
-	loop->connect("pressed", callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
+	loop->connect("button_clicked", callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
 	loop->set_toggle_mode(true);
 	len_hb->add_child(loop);
 	add_child(len_hb);
@@ -6067,14 +6067,14 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	imported_anim_warning = memnew(Button);
 	imported_anim_warning->hide();
 	imported_anim_warning->set_tooltip(TTR("Warning: Editing imported animation"));
-	imported_anim_warning->connect("pressed", callable_mp(this, &AnimationTrackEditor::_show_imported_anim_warning));
+	imported_anim_warning->connect("button_clicked", callable_mp(this, &AnimationTrackEditor::_show_imported_anim_warning));
 	bottom_hb->add_child(imported_anim_warning);
 
 	bottom_hb->add_spacer();
 
 	selected_filter = memnew(Button);
 	selected_filter->set_flat(true);
-	selected_filter->connect("pressed", callable_mp(this, &AnimationTrackEditor::_view_group_toggle)); // Same function works the same.
+	selected_filter->connect("button_clicked", callable_mp(this, &AnimationTrackEditor::_view_group_toggle)); // Same function works the same.
 	selected_filter->set_toggle_mode(true);
 	selected_filter->set_tooltip(TTR("Only show tracks from nodes selected in tree."));
 
@@ -6082,7 +6082,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	view_group = memnew(Button);
 	view_group->set_flat(true);
-	view_group->connect("pressed", callable_mp(this, &AnimationTrackEditor::_view_group_toggle));
+	view_group->connect("button_clicked", callable_mp(this, &AnimationTrackEditor::_view_group_toggle));
 	view_group->set_toggle_mode(true);
 	view_group->set_tooltip(TTR("Group tracks by node or display them as plain list."));
 
@@ -6293,7 +6293,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	Button *select_all_button = memnew(Button);
 	select_all_button->set_text(TTR("Select All/None"));
-	select_all_button->connect("pressed", callable_mp(this, &AnimationTrackEditor::_select_all_tracks_for_copy));
+	select_all_button->connect("button_clicked", callable_mp(this, &AnimationTrackEditor::_select_all_tracks_for_copy));
 	track_vbox->add_child(select_all_button);
 
 	track_copy_select = memnew(Tree);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -658,25 +658,25 @@ FindReplaceBar::FindReplaceBar() {
 	find_prev->set_flat(true);
 	hbc_button_search->add_child(find_prev);
 	find_prev->set_focus_mode(FOCUS_NONE);
-	find_prev->connect("pressed", callable_mp(this, &FindReplaceBar::search_prev));
+	find_prev->connect("button_clicked", callable_mp(this, &FindReplaceBar::search_prev));
 
 	find_next = memnew(Button);
 	find_next->set_flat(true);
 	hbc_button_search->add_child(find_next);
 	find_next->set_focus_mode(FOCUS_NONE);
-	find_next->connect("pressed", callable_mp(this, &FindReplaceBar::search_next));
+	find_next->connect("button_clicked", callable_mp(this, &FindReplaceBar::search_next));
 
 	case_sensitive = memnew(CheckBox);
 	hbc_option_search->add_child(case_sensitive);
 	case_sensitive->set_text(TTR("Match Case"));
 	case_sensitive->set_focus_mode(FOCUS_NONE);
-	case_sensitive->connect("toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
+	case_sensitive->connect("button_toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
 
 	whole_words = memnew(CheckBox);
 	hbc_option_search->add_child(whole_words);
 	whole_words->set_text(TTR("Whole Words"));
 	whole_words->set_focus_mode(FOCUS_NONE);
-	whole_words->connect("toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
+	whole_words->connect("button_toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
 
 	// replace toolbar
 	replace_text = memnew(LineEdit);
@@ -687,23 +687,23 @@ FindReplaceBar::FindReplaceBar() {
 	replace = memnew(Button);
 	hbc_button_replace->add_child(replace);
 	replace->set_text(TTR("Replace"));
-	replace->connect("pressed", callable_mp(this, &FindReplaceBar::_replace));
+	replace->connect("button_clicked", callable_mp(this, &FindReplaceBar::_replace));
 
 	replace_all = memnew(Button);
 	hbc_button_replace->add_child(replace_all);
 	replace_all->set_text(TTR("Replace All"));
-	replace_all->connect("pressed", callable_mp(this, &FindReplaceBar::_replace_all));
+	replace_all->connect("button_clicked", callable_mp(this, &FindReplaceBar::_replace_all));
 
 	selection_only = memnew(CheckBox);
 	hbc_option_replace->add_child(selection_only);
 	selection_only->set_text(TTR("Selection Only"));
 	selection_only->set_focus_mode(FOCUS_NONE);
-	selection_only->connect("toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
+	selection_only->connect("button_toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
 
 	hide_button = memnew(TextureButton);
 	add_child(hide_button);
 	hide_button->set_focus_mode(FOCUS_NONE);
-	hide_button->connect("pressed", callable_mp(this, &FindReplaceBar::_hide_bar));
+	hide_button->connect("button_clicked", callable_mp(this, &FindReplaceBar::_hide_bar));
 	hide_button->set_v_size_flags(SIZE_SHRINK_CENTER);
 }
 
@@ -1846,7 +1846,7 @@ CodeTextEditor::CodeTextEditor() {
 
 	toggle_scripts_button = memnew(Button);
 	toggle_scripts_button->set_flat(true);
-	toggle_scripts_button->connect("pressed", callable_mp(this, &CodeTextEditor::_toggle_scripts_pressed));
+	toggle_scripts_button->connect("button_clicked", callable_mp(this, &CodeTextEditor::_toggle_scripts_pressed));
 	status_bar->add_child(toggle_scripts_button);
 	toggle_scripts_button->hide();
 
@@ -1869,7 +1869,7 @@ CodeTextEditor::CodeTextEditor() {
 	status_bar->add_child(error_button);
 	error_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	error_button->set_default_cursor_shape(CURSOR_POINTING_HAND);
-	error_button->connect("pressed", callable_mp(this, &CodeTextEditor::_error_button_pressed));
+	error_button->connect("button_clicked", callable_mp(this, &CodeTextEditor::_error_button_pressed));
 	error_button->set_tooltip(TTR("Errors"));
 
 	error_button->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
@@ -1885,7 +1885,7 @@ CodeTextEditor::CodeTextEditor() {
 	status_bar->add_child(warning_button);
 	warning_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	warning_button->set_default_cursor_shape(CURSOR_POINTING_HAND);
-	warning_button->connect("pressed", callable_mp(this, &CodeTextEditor::_warning_button_pressed));
+	warning_button->connect("button_clicked", callable_mp(this, &CodeTextEditor::_warning_button_pressed));
 	warning_button->set_tooltip(TTR("Warnings"));
 
 	warning_button->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor")));

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -453,12 +453,12 @@ ConnectDialog::ConnectDialog() {
 	Button *add_bind = memnew(Button);
 	add_bind->set_text(TTR("Add"));
 	add_bind_hb->add_child(add_bind);
-	add_bind->connect("pressed", callable_mp(this, &ConnectDialog::_add_bind));
+	add_bind->connect("button_clicked", callable_mp(this, &ConnectDialog::_add_bind));
 
 	Button *del_bind = memnew(Button);
 	del_bind->set_text(TTR("Remove"));
 	add_bind_hb->add_child(del_bind);
-	del_bind->connect("pressed", callable_mp(this, &ConnectDialog::_remove_bind));
+	del_bind->connect("button_clicked", callable_mp(this, &ConnectDialog::_remove_bind));
 
 	vbc_right->add_margin_child(TTR("Add Extra Call Argument:"), add_bind_hb);
 
@@ -477,7 +477,7 @@ ConnectDialog::ConnectDialog() {
 	advanced = memnew(CheckButton);
 	dstm_hb->add_child(advanced);
 	advanced->set_text(TTR("Advanced"));
-	advanced->connect("pressed", callable_mp(this, &ConnectDialog::_advanced_pressed));
+	advanced->connect("button_clicked", callable_mp(this, &ConnectDialog::_advanced_pressed));
 
 	deferred = memnew(CheckBox);
 	deferred->set_h_size_flags(0);
@@ -1099,7 +1099,7 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	vbc->add_child(hb);
 	hb->add_spacer();
 	hb->add_child(connect_button);
-	connect_button->connect("pressed", callable_mp(this, &ConnectionsDock::_connect_pressed));
+	connect_button->connect("button_clicked", callable_mp(this, &ConnectionsDock::_connect_pressed));
 
 	connect_dialog = memnew(ConnectDialog);
 	add_child(connect_dialog);

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -719,7 +719,7 @@ CreateDialog::CreateDialog() {
 	favorite = memnew(Button);
 	favorite->set_toggle_mode(true);
 	favorite->set_tooltip(TTR("(Un)favorite selected item."));
-	favorite->connect("pressed", callable_mp(this, &CreateDialog::_favorite_toggled));
+	favorite->connect("button_clicked", callable_mp(this, &CreateDialog::_favorite_toggled));
 	search_hb->add_child(favorite);
 	vbc->add_margin_child(TTR("Search:"), search_hb);
 

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -991,7 +991,7 @@ DebugAdapterProtocol::DebugAdapterProtocol() {
 	reset_ids();
 
 	EditorNode *node = EditorNode::get_singleton();
-	node->get_pause_button()->connect("pressed", callable_mp(this, &DebugAdapterProtocol::on_debug_paused));
+	node->get_pause_button()->connect("button_clicked", callable_mp(this, &DebugAdapterProtocol::on_debug_paused));
 
 	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
 	debugger_node->connect("breakpoint_toggled", callable_mp(this, &DebugAdapterProtocol::on_debug_breakpoint_toggled));

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -84,7 +84,7 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	EditorNode *editor = EditorNode::get_singleton();
 	editor->get_undo_redo()->set_method_notify_callback(_method_changeds, this);
 	editor->get_undo_redo()->set_property_notify_callback(_property_changeds, this);
-	editor->get_pause_button()->connect("pressed", callable_mp(this, &EditorDebuggerNode::_paused));
+	editor->get_pause_button()->connect("button_clicked", callable_mp(this, &EditorDebuggerNode::_paused));
 }
 
 ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {

--- a/editor/debugger/editor_network_profiler.cpp
+++ b/editor/debugger/editor_network_profiler.cpp
@@ -132,12 +132,12 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
-	activate->connect("pressed", callable_mp(this, &EditorNetworkProfiler::_activate_pressed));
+	activate->connect("button_clicked", callable_mp(this, &EditorNetworkProfiler::_activate_pressed));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
-	clear_button->connect("pressed", callable_mp(this, &EditorNetworkProfiler::_clear_pressed));
+	clear_button->connect("button_clicked", callable_mp(this, &EditorNetworkProfiler::_clear_pressed));
 	hb->add_child(clear_button);
 
 	hb->add_spacer();

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -576,12 +576,12 @@ EditorProfiler::EditorProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
-	activate->connect("pressed", callable_mp(this, &EditorProfiler::_activate_pressed));
+	activate->connect("button_clicked", callable_mp(this, &EditorProfiler::_activate_pressed));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
-	clear_button->connect("pressed", callable_mp(this, &EditorProfiler::_clear_pressed));
+	clear_button->connect("button_clicked", callable_mp(this, &EditorProfiler::_clear_pressed));
 	clear_button->set_disabled(true);
 	hb->add_child(clear_button);
 

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -723,12 +723,12 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
-	activate->connect("pressed", callable_mp(this, &EditorVisualProfiler::_activate_pressed));
+	activate->connect("button_clicked", callable_mp(this, &EditorVisualProfiler::_activate_pressed));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
-	clear_button->connect("pressed", callable_mp(this, &EditorVisualProfiler::_clear_pressed));
+	clear_button->connect("button_clicked", callable_mp(this, &EditorVisualProfiler::_clear_pressed));
 	hb->add_child(clear_button);
 
 	hb->add_child(memnew(Label(TTR("Measure:"))));
@@ -743,11 +743,11 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	frame_relative = memnew(CheckBox(TTR("Fit to Frame")));
 	frame_relative->set_pressed(true);
 	hb->add_child(frame_relative);
-	frame_relative->connect("pressed", callable_mp(this, &EditorVisualProfiler::_update_plot));
+	frame_relative->connect("button_clicked", callable_mp(this, &EditorVisualProfiler::_update_plot));
 	linked = memnew(CheckBox(TTR("Linked")));
 	linked->set_pressed(true);
 	hb->add_child(linked);
-	linked->connect("pressed", callable_mp(this, &EditorVisualProfiler::_update_plot));
+	linked->connect("button_clicked", callable_mp(this, &EditorVisualProfiler::_update_plot));
 
 	hb->add_spacer();
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -784,8 +784,8 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			next->set_icon(get_theme_icon(SNAME("DebugNext"), SNAME("EditorIcons")));
 			dobreak->set_icon(get_theme_icon(SNAME("Pause"), SNAME("EditorIcons")));
 			docontinue->set_icon(get_theme_icon(SNAME("DebugContinue"), SNAME("EditorIcons")));
-			le_set->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_live_edit_set));
-			le_clear->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_live_edit_clear));
+			le_set->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::_live_edit_set));
+			le_clear->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::_live_edit_clear));
 			error_tree->connect("item_selected", callable_mp(this, &ScriptEditorDebugger::_error_selected));
 			error_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_error_activated));
 			vmem_refresh->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
@@ -1602,7 +1602,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		skip_breakpoints->set_flat(true);
 		hbc->add_child(skip_breakpoints);
 		skip_breakpoints->set_tooltip(TTR("Skip Breakpoints"));
-		skip_breakpoints->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_skip_breakpoints));
+		skip_breakpoints->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::debug_skip_breakpoints));
 
 		hbc->add_child(memnew(VSeparator));
 
@@ -1610,7 +1610,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		copy->set_flat(true);
 		hbc->add_child(copy);
 		copy->set_tooltip(TTR("Copy Error"));
-		copy->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_copy));
+		copy->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::debug_copy));
 
 		hbc->add_child(memnew(VSeparator));
 
@@ -1619,14 +1619,14 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		hbc->add_child(step);
 		step->set_tooltip(TTR("Step Into"));
 		step->set_shortcut(ED_GET_SHORTCUT("debugger/step_into"));
-		step->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_step));
+		step->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::debug_step));
 
 		next = memnew(Button);
 		next->set_flat(true);
 		hbc->add_child(next);
 		next->set_tooltip(TTR("Step Over"));
 		next->set_shortcut(ED_GET_SHORTCUT("debugger/step_over"));
-		next->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_next));
+		next->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::debug_next));
 
 		hbc->add_child(memnew(VSeparator));
 
@@ -1635,14 +1635,14 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		hbc->add_child(dobreak);
 		dobreak->set_tooltip(TTR("Break"));
 		dobreak->set_shortcut(ED_GET_SHORTCUT("debugger/break"));
-		dobreak->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_break));
+		dobreak->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::debug_break));
 
 		docontinue = memnew(Button);
 		docontinue->set_flat(true);
 		hbc->add_child(docontinue);
 		docontinue->set_tooltip(TTR("Continue"));
 		docontinue->set_shortcut(ED_GET_SHORTCUT("debugger/continue"));
-		docontinue->connect("pressed", callable_mp(this, &ScriptEditorDebugger::debug_continue));
+		docontinue->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::debug_continue));
 
 		HSplitContainer *sc = memnew(HSplitContainer);
 		vbc->add_child(sc);
@@ -1679,13 +1679,13 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		expand_all_button = memnew(Button);
 		expand_all_button->set_text(TTR("Expand All"));
 		expand_all_button->set_disabled(true);
-		expand_all_button->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_expand_errors_list));
+		expand_all_button->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::_expand_errors_list));
 		error_hbox->add_child(expand_all_button);
 
 		collapse_all_button = memnew(Button);
 		collapse_all_button->set_text(TTR("Collapse All"));
 		collapse_all_button->set_disabled(true);
-		collapse_all_button->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_collapse_errors_list));
+		collapse_all_button->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::_collapse_errors_list));
 		error_hbox->add_child(collapse_all_button);
 
 		Control *space = memnew(Control);
@@ -1696,7 +1696,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		clear_button->set_text(TTR("Clear"));
 		clear_button->set_h_size_flags(0);
 		clear_button->set_disabled(true);
-		clear_button->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_clear_errors_list));
+		clear_button->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::_clear_errors_list));
 		error_hbox->add_child(clear_button);
 
 		error_tree = memnew(Tree);
@@ -1777,8 +1777,8 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		vmem_export->set_tooltip(TTR("Export list to a CSV file"));
 		vmem_hb->add_child(vmem_export);
 		vmem_vb->add_child(vmem_hb);
-		vmem_refresh->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_video_mem_request));
-		vmem_export->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_video_mem_export));
+		vmem_refresh->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::_video_mem_request));
+		vmem_export->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::_video_mem_export));
 
 		VBoxContainer *vmmc = memnew(VBoxContainer);
 		vmem_tree = memnew(Tree);
@@ -1844,7 +1844,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		HBoxContainer *buttons = memnew(HBoxContainer);
 
 		export_csv = memnew(Button(TTR("Export measures as CSV")));
-		export_csv->connect("pressed", callable_mp(this, &ScriptEditorDebugger::_export_csv));
+		export_csv->connect("button_clicked", callable_mp(this, &ScriptEditorDebugger::_export_csv));
 		buttons->add_child(export_csv);
 
 		misc->add_child(buttons);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -249,7 +249,7 @@ DependencyEditor::DependencyEditor() {
 	hbc->add_spacer();
 	fixdeps = memnew(Button(TTR("Fix Broken")));
 	hbc->add_child(fixdeps);
-	fixdeps->connect("pressed", callable_mp(this, &DependencyEditor::_fix_all));
+	fixdeps->connect("button_clicked", callable_mp(this, &DependencyEditor::_fix_all));
 
 	vb->add_child(hbc);
 

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -149,7 +149,7 @@ EditorAbout::EditorAbout() {
 	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
 	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
 	version_btn->set_tooltip(TTR("Click to copy."));
-	version_btn->connect("pressed", callable_mp(this, &EditorAbout::_version_button_pressed));
+	version_btn->connect("button_clicked", callable_mp(this, &EditorAbout::_version_button_pressed));
 	version_info_vbc->add_child(version_btn);
 
 	Label *about_text = memnew(Label);

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -781,21 +781,21 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	solo->set_toggle_mode(true);
 	solo->set_tooltip(TTR("Solo"));
 	solo->set_focus_mode(FOCUS_NONE);
-	solo->connect("pressed", callable_mp(this, &EditorAudioBus::_solo_toggled));
+	solo->connect("button_clicked", callable_mp(this, &EditorAudioBus::_solo_toggled));
 	hbc->add_child(solo);
 	mute = memnew(Button);
 	mute->set_flat(true);
 	mute->set_toggle_mode(true);
 	mute->set_tooltip(TTR("Mute"));
 	mute->set_focus_mode(FOCUS_NONE);
-	mute->connect("pressed", callable_mp(this, &EditorAudioBus::_mute_toggled));
+	mute->connect("button_clicked", callable_mp(this, &EditorAudioBus::_mute_toggled));
 	hbc->add_child(mute);
 	bypass = memnew(Button);
 	bypass->set_flat(true);
 	bypass->set_toggle_mode(true);
 	bypass->set_tooltip(TTR("Bypass"));
 	bypass->set_focus_mode(FOCUS_NONE);
-	bypass->connect("pressed", callable_mp(this, &EditorAudioBus::_bypass_toggled));
+	bypass->connect("button_clicked", callable_mp(this, &EditorAudioBus::_bypass_toggled));
 	hbc->add_child(bypass);
 	hbc->add_spacer();
 
@@ -1265,7 +1265,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	top_hb->add_child(add);
 	add->set_text(TTR("Add Bus"));
 	add->set_tooltip(TTR("Add a new Audio Bus to this layout."));
-	add->connect("pressed", callable_mp(this, &EditorAudioBuses::_add_bus));
+	add->connect("button_clicked", callable_mp(this, &EditorAudioBuses::_add_bus));
 
 	VSeparator *separator = memnew(VSeparator);
 	top_hb->add_child(separator);
@@ -1274,25 +1274,25 @@ EditorAudioBuses::EditorAudioBuses() {
 	load->set_text(TTR("Load"));
 	load->set_tooltip(TTR("Load an existing Bus Layout."));
 	top_hb->add_child(load);
-	load->connect("pressed", callable_mp(this, &EditorAudioBuses::_load_layout));
+	load->connect("button_clicked", callable_mp(this, &EditorAudioBuses::_load_layout));
 
 	save_as = memnew(Button);
 	save_as->set_text(TTR("Save As"));
 	save_as->set_tooltip(TTR("Save this Bus Layout to a file."));
 	top_hb->add_child(save_as);
-	save_as->connect("pressed", callable_mp(this, &EditorAudioBuses::_save_as_layout));
+	save_as->connect("button_clicked", callable_mp(this, &EditorAudioBuses::_save_as_layout));
 
 	_default = memnew(Button);
 	_default->set_text(TTR("Load Default"));
 	_default->set_tooltip(TTR("Load the default Bus Layout."));
 	top_hb->add_child(_default);
-	_default->connect("pressed", callable_mp(this, &EditorAudioBuses::_load_default_layout));
+	_default->connect("button_clicked", callable_mp(this, &EditorAudioBuses::_load_default_layout));
 
 	_new = memnew(Button);
 	_new->set_text(TTR("Create"));
 	_new->set_tooltip(TTR("Create a new Bus Layout."));
 	top_hb->add_child(_new);
-	_new->connect("pressed", callable_mp(this, &EditorAudioBuses::_new_layout));
+	_new->connect("button_clicked", callable_mp(this, &EditorAudioBuses::_new_layout));
 
 	bus_scroll = memnew(ScrollContainer);
 	bus_scroll->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -853,7 +853,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	browse_button = memnew(Button);
 	hbc->add_child(browse_button);
-	browse_button->connect("pressed", callable_mp(this, &EditorAutoloadSettings::_browse_autoload_add_path));
+	browse_button->connect("button_clicked", callable_mp(this, &EditorAutoloadSettings::_browse_autoload_add_path));
 
 	file_dialog = memnew(EditorFileDialog);
 	hbc->add_child(file_dialog);
@@ -877,7 +877,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	add_autoload = memnew(Button);
 	add_autoload->set_text(TTR("Add"));
-	add_autoload->connect("pressed", callable_mp(this, &EditorAutoloadSettings::_autoload_add));
+	add_autoload->connect("button_clicked", callable_mp(this, &EditorAutoloadSettings::_autoload_add));
 	// The button will be enabled once a valid name is entered (either automatically or manually).
 	add_autoload->set_disabled(true);
 	hbc->add_child(add_autoload);

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -184,7 +184,7 @@ EditorDirDialog::EditorDirDialog() {
 	tree->connect("item_activated", callable_mp(this, &EditorDirDialog::_item_activated));
 
 	makedir = add_button(TTR("Create Folder"), DisplayServer::get_singleton()->get_swap_cancel_ok(), "makedir");
-	makedir->connect("pressed", callable_mp(this, &EditorDirDialog::_make_dir));
+	makedir->connect("button_clicked", callable_mp(this, &EditorDirDialog::_make_dir));
 
 	makedialog = memnew(ConfirmationDialog);
 	makedialog->set_title(TTR("Create Folder"));

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -865,7 +865,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	profile_actions[PROFILE_CLEAR] = memnew(Button(TTR("Reset to Default")));
 	name_hbc->add_child(profile_actions[PROFILE_CLEAR]);
 	profile_actions[PROFILE_CLEAR]->set_disabled(true);
-	profile_actions[PROFILE_CLEAR]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_CLEAR));
+	profile_actions[PROFILE_CLEAR]->connect("button_clicked", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_CLEAR));
 
 	main_vbc->add_margin_child(TTR("Current Profile:"), name_hbc);
 
@@ -879,12 +879,12 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 
 	profile_actions[PROFILE_NEW] = memnew(Button(TTR("Create Profile")));
 	profiles_hbc->add_child(profile_actions[PROFILE_NEW]);
-	profile_actions[PROFILE_NEW]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_NEW));
+	profile_actions[PROFILE_NEW]->connect("button_clicked", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_NEW));
 
 	profile_actions[PROFILE_ERASE] = memnew(Button(TTR("Remove Profile")));
 	profiles_hbc->add_child(profile_actions[PROFILE_ERASE]);
 	profile_actions[PROFILE_ERASE]->set_disabled(true);
-	profile_actions[PROFILE_ERASE]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_ERASE));
+	profile_actions[PROFILE_ERASE]->connect("button_clicked", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_ERASE));
 
 	main_vbc->add_margin_child(TTR("Available Profiles:"), profiles_hbc);
 
@@ -893,18 +893,18 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	profile_actions[PROFILE_SET] = memnew(Button(TTR("Make Current")));
 	current_profile_hbc->add_child(profile_actions[PROFILE_SET]);
 	profile_actions[PROFILE_SET]->set_disabled(true);
-	profile_actions[PROFILE_SET]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_SET));
+	profile_actions[PROFILE_SET]->connect("button_clicked", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_SET));
 
 	current_profile_hbc->add_child(memnew(VSeparator));
 
 	profile_actions[PROFILE_IMPORT] = memnew(Button(TTR("Import")));
 	current_profile_hbc->add_child(profile_actions[PROFILE_IMPORT]);
-	profile_actions[PROFILE_IMPORT]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_IMPORT));
+	profile_actions[PROFILE_IMPORT]->connect("button_clicked", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_IMPORT));
 
 	profile_actions[PROFILE_EXPORT] = memnew(Button(TTR("Export")));
 	current_profile_hbc->add_child(profile_actions[PROFILE_EXPORT]);
 	profile_actions[PROFILE_EXPORT]->set_disabled(true);
-	profile_actions[PROFILE_EXPORT]->connect("pressed", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_EXPORT));
+	profile_actions[PROFILE_EXPORT]->connect("button_clicked", callable_mp(this, &EditorFeatureProfileManager::_profile_action), varray(PROFILE_EXPORT));
 
 	main_vbc->add_child(current_profile_hbc);
 

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1505,9 +1505,9 @@ EditorFileDialog::EditorFileDialog() {
 	pathhb->add_child(dir_next);
 	pathhb->add_child(dir_up);
 
-	dir_prev->connect("pressed", callable_mp(this, &EditorFileDialog::_go_back));
-	dir_next->connect("pressed", callable_mp(this, &EditorFileDialog::_go_forward));
-	dir_up->connect("pressed", callable_mp(this, &EditorFileDialog::_go_up));
+	dir_prev->connect("button_clicked", callable_mp(this, &EditorFileDialog::_go_back));
+	dir_next->connect("button_clicked", callable_mp(this, &EditorFileDialog::_go_forward));
+	dir_up->connect("button_clicked", callable_mp(this, &EditorFileDialog::_go_up));
 
 	Label *l = memnew(Label(TTR("Path:")));
 	l->set_theme_type_variation("HeaderSmall");
@@ -1524,14 +1524,14 @@ EditorFileDialog::EditorFileDialog() {
 	refresh = memnew(Button);
 	refresh->set_flat(true);
 	refresh->set_tooltip(TTR("Refresh files."));
-	refresh->connect("pressed", callable_mp(this, &EditorFileDialog::update_file_list));
+	refresh->connect("button_clicked", callable_mp(this, &EditorFileDialog::update_file_list));
 	pathhb->add_child(refresh);
 
 	favorite = memnew(Button);
 	favorite->set_flat(true);
 	favorite->set_toggle_mode(true);
 	favorite->set_tooltip(TTR("(Un)favorite current folder."));
-	favorite->connect("pressed", callable_mp(this, &EditorFileDialog::_favorite_pressed));
+	favorite->connect("button_clicked", callable_mp(this, &EditorFileDialog::_favorite_pressed));
 	pathhb->add_child(favorite);
 
 	show_hidden = memnew(Button);
@@ -1539,7 +1539,7 @@ EditorFileDialog::EditorFileDialog() {
 	show_hidden->set_toggle_mode(true);
 	show_hidden->set_pressed(is_showing_hidden_files());
 	show_hidden->set_tooltip(TTR("Toggle the visibility of hidden files."));
-	show_hidden->connect("toggled", callable_mp(this, &EditorFileDialog::set_show_hidden_files));
+	show_hidden->connect("button_toggled", callable_mp(this, &EditorFileDialog::set_show_hidden_files));
 	pathhb->add_child(show_hidden);
 
 	pathhb->add_child(memnew(VSeparator));
@@ -1549,7 +1549,7 @@ EditorFileDialog::EditorFileDialog() {
 
 	mode_thumbnails = memnew(Button);
 	mode_thumbnails->set_flat(true);
-	mode_thumbnails->connect("pressed", callable_mp(this, &EditorFileDialog::set_display_mode), varray(DISPLAY_THUMBNAILS));
+	mode_thumbnails->connect("button_clicked", callable_mp(this, &EditorFileDialog::set_display_mode), varray(DISPLAY_THUMBNAILS));
 	mode_thumbnails->set_toggle_mode(true);
 	mode_thumbnails->set_pressed(display_mode == DISPLAY_THUMBNAILS);
 	mode_thumbnails->set_button_group(view_mode_group);
@@ -1558,7 +1558,7 @@ EditorFileDialog::EditorFileDialog() {
 
 	mode_list = memnew(Button);
 	mode_list->set_flat(true);
-	mode_list->connect("pressed", callable_mp(this, &EditorFileDialog::set_display_mode), varray(DISPLAY_LIST));
+	mode_list->connect("button_clicked", callable_mp(this, &EditorFileDialog::set_display_mode), varray(DISPLAY_LIST));
 	mode_list->set_toggle_mode(true);
 	mode_list->set_pressed(display_mode == DISPLAY_LIST);
 	mode_list->set_button_group(view_mode_group);
@@ -1574,7 +1574,7 @@ EditorFileDialog::EditorFileDialog() {
 
 	makedir = memnew(Button);
 	makedir->set_text(TTR("Create Folder"));
-	makedir->connect("pressed", callable_mp(this, &EditorFileDialog::_make_dir));
+	makedir->connect("button_clicked", callable_mp(this, &EditorFileDialog::_make_dir));
 	pathhb->add_child(makedir);
 
 	list_hb = memnew(HSplitContainer);
@@ -1601,11 +1601,11 @@ EditorFileDialog::EditorFileDialog() {
 	fav_up = memnew(Button);
 	fav_up->set_flat(true);
 	fav_hb->add_child(fav_up);
-	fav_up->connect("pressed", callable_mp(this, &EditorFileDialog::_favorite_move_up));
+	fav_up->connect("button_clicked", callable_mp(this, &EditorFileDialog::_favorite_move_up));
 	fav_down = memnew(Button);
 	fav_down->set_flat(true);
 	fav_hb->add_child(fav_down);
-	fav_down->connect("pressed", callable_mp(this, &EditorFileDialog::_favorite_move_down));
+	fav_down->connect("button_clicked", callable_mp(this, &EditorFileDialog::_favorite_move_down));
 
 	favorites = memnew(ItemList);
 	fav_vb->add_child(favorites);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1793,7 +1793,7 @@ EditorHelp::EditorHelp() {
 
 	toggle_scripts_button = memnew(Button);
 	toggle_scripts_button->set_flat(true);
-	toggle_scripts_button->connect("pressed", callable_mp(this, &EditorHelp::_toggle_scripts_pressed));
+	toggle_scripts_button->connect("button_clicked", callable_mp(this, &EditorHelp::_toggle_scripts_pressed));
 	status_bar->add_child(toggle_scripts_button);
 
 	class_desc->set_selection_enabled(true);
@@ -1887,13 +1887,13 @@ FindBar::FindBar() {
 	find_prev->set_flat(true);
 	add_child(find_prev);
 	find_prev->set_focus_mode(FOCUS_NONE);
-	find_prev->connect("pressed", callable_mp(this, &FindBar::search_prev));
+	find_prev->connect("button_clicked", callable_mp(this, &FindBar::search_prev));
 
 	find_next = memnew(Button);
 	find_next->set_flat(true);
 	add_child(find_next);
 	find_next->set_focus_mode(FOCUS_NONE);
-	find_next->connect("pressed", callable_mp(this, &FindBar::search_next));
+	find_next->connect("button_clicked", callable_mp(this, &FindBar::search_next));
 
 	Control *space = memnew(Control);
 	add_child(space);
@@ -1904,7 +1904,7 @@ FindBar::FindBar() {
 	hide_button->set_focus_mode(FOCUS_NONE);
 	hide_button->set_expand(true);
 	hide_button->set_stretch_mode(TextureButton::STRETCH_KEEP_CENTERED);
-	hide_button->connect("pressed", callable_mp(this, &FindBar::_hide_bar));
+	hide_button->connect("button_clicked", callable_mp(this, &FindBar::_hide_bar));
 }
 
 void FindBar::popup_search() {

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -206,7 +206,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	case_sensitive_button = memnew(Button);
 	case_sensitive_button->set_flat(true);
 	case_sensitive_button->set_tooltip(TTR("Case Sensitive"));
-	case_sensitive_button->connect("pressed", callable_mp(this, &EditorHelpSearch::_update_results));
+	case_sensitive_button->connect("button_clicked", callable_mp(this, &EditorHelpSearch::_update_results));
 	case_sensitive_button->set_toggle_mode(true);
 	case_sensitive_button->set_focus_mode(Control::FOCUS_NONE);
 	hbox->add_child(case_sensitive_button);
@@ -214,7 +214,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	hierarchy_button = memnew(Button);
 	hierarchy_button->set_flat(true);
 	hierarchy_button->set_tooltip(TTR("Show Hierarchy"));
-	hierarchy_button->connect("pressed", callable_mp(this, &EditorHelpSearch::_update_results));
+	hierarchy_button->connect("button_clicked", callable_mp(this, &EditorHelpSearch::_update_results));
 	hierarchy_button->set_toggle_mode(true);
 	hierarchy_button->set_pressed(true);
 	hierarchy_button->set_focus_mode(Control::FOCUS_NONE);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2084,7 +2084,7 @@ EditorInspectorArray::EditorInspectorArray() {
 	add_button = memnew(Button);
 	add_button->set_text(TTR("Add Element"));
 	add_button->set_text_align(Button::ALIGN_CENTER);
-	add_button->connect("pressed", callable_mp(this, &EditorInspectorArray::_add_button_pressed));
+	add_button->connect("button_clicked", callable_mp(this, &EditorInspectorArray::_add_button_pressed));
 	vbox->add_child(add_button);
 
 	hbox_pagination = memnew(HBoxContainer);
@@ -2094,12 +2094,12 @@ EditorInspectorArray::EditorInspectorArray() {
 
 	first_page_button = memnew(Button);
 	first_page_button->set_flat(true);
-	first_page_button->connect("pressed", callable_mp(this, &EditorInspectorArray::_first_page_button_pressed));
+	first_page_button->connect("button_clicked", callable_mp(this, &EditorInspectorArray::_first_page_button_pressed));
 	hbox_pagination->add_child(first_page_button);
 
 	prev_page_button = memnew(Button);
 	prev_page_button->set_flat(true);
-	prev_page_button->connect("pressed", callable_mp(this, &EditorInspectorArray::_prev_page_button_pressed));
+	prev_page_button->connect("button_clicked", callable_mp(this, &EditorInspectorArray::_prev_page_button_pressed));
 	hbox_pagination->add_child(prev_page_button);
 
 	page_line_edit = memnew(LineEdit);
@@ -2111,12 +2111,12 @@ EditorInspectorArray::EditorInspectorArray() {
 	hbox_pagination->add_child(page_count_label);
 	next_page_button = memnew(Button);
 	next_page_button->set_flat(true);
-	next_page_button->connect("pressed", callable_mp(this, &EditorInspectorArray::_next_page_button_pressed));
+	next_page_button->connect("button_clicked", callable_mp(this, &EditorInspectorArray::_next_page_button_pressed));
 	hbox_pagination->add_child(next_page_button);
 
 	last_page_button = memnew(Button);
 	last_page_button->set_flat(true);
-	last_page_button->connect("pressed", callable_mp(this, &EditorInspectorArray::_last_page_button_pressed));
+	last_page_button->connect("button_clicked", callable_mp(this, &EditorInspectorArray::_last_page_button_pressed));
 	hbox_pagination->add_child(last_page_button);
 
 	control_dropping = memnew(Control);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -368,7 +368,7 @@ EditorLog::EditorLog() {
 	clear_button->set_focus_mode(FOCUS_NONE);
 	clear_button->set_shortcut(ED_SHORTCUT("editor/clear_output", TTR("Clear Output"), KeyModifierMask::CMD | KeyModifierMask::SHIFT | Key::K));
 	clear_button->set_shortcut_context(this);
-	clear_button->connect("pressed", callable_mp(this, &EditorLog::_clear_request));
+	clear_button->connect("button_clicked", callable_mp(this, &EditorLog::_clear_request));
 	hb_tools->add_child(clear_button);
 
 	// Copy.
@@ -377,7 +377,7 @@ EditorLog::EditorLog() {
 	copy_button->set_focus_mode(FOCUS_NONE);
 	copy_button->set_shortcut(ED_SHORTCUT("editor/copy_output", TTR("Copy Selection"), KeyModifierMask::CMD | Key::C));
 	copy_button->set_shortcut_context(this);
-	copy_button->connect("pressed", callable_mp(this, &EditorLog::_copy_request));
+	copy_button->connect("button_clicked", callable_mp(this, &EditorLog::_copy_request));
 	hb_tools->add_child(copy_button);
 
 	// A second hbox to make a 2x2 grid of buttons.
@@ -392,7 +392,7 @@ EditorLog::EditorLog() {
 	collapse_button->set_tooltip(TTR("Collapse duplicate messages into one log entry. Shows number of occurrences."));
 	collapse_button->set_toggle_mode(true);
 	collapse_button->set_pressed(false);
-	collapse_button->connect("toggled", callable_mp(this, &EditorLog::_set_collapse));
+	collapse_button->connect("button_toggled", callable_mp(this, &EditorLog::_set_collapse));
 	hb_tools2->add_child(collapse_button);
 
 	// Show Search.
@@ -403,7 +403,7 @@ EditorLog::EditorLog() {
 	show_search_button->set_pressed(true);
 	show_search_button->set_shortcut(ED_SHORTCUT("editor/open_search", TTR("Focus Search/Filter Bar"), KeyModifierMask::CMD | Key::F));
 	show_search_button->set_shortcut_context(this);
-	show_search_button->connect("toggled", callable_mp(this, &EditorLog::_set_search_visible));
+	show_search_button->connect("button_toggled", callable_mp(this, &EditorLog::_set_search_visible));
 	hb_tools2->add_child(show_search_button);
 
 	// Message Type Filters.

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -88,7 +88,7 @@ private:
 			toggle_button->add_theme_color_override("icon_color_pressed", Color(1, 1, 1, 1));
 			toggle_button->set_focus_mode(FOCUS_NONE);
 			// When toggled call the callback and pass the MessageType this button is for.
-			toggle_button->connect("toggled", p_toggled_callback, varray(type));
+			toggle_button->connect("button_toggled", p_toggled_callback, varray(type));
 		}
 
 		int get_message_count() {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3163,7 +3163,7 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 		Button *tb = memnew(Button);
 		tb->set_flat(true);
 		tb->set_toggle_mode(true);
-		tb->connect("pressed", callable_mp(singleton, &EditorNode::_editor_select), varray(singleton->main_editor_buttons.size()));
+		tb->connect("button_clicked", callable_mp(singleton, &EditorNode::_editor_select), varray(singleton->main_editor_buttons.size()));
 		tb->set_name(p_editor->get_name());
 		tb->set_text(p_editor->get_name());
 
@@ -5117,7 +5117,7 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item) {
 	Button *tb = memnew(Button);
 	tb->set_flat(true);
-	tb->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch), varray(bottom_panel_items.size()));
+	tb->connect("button_toggled", callable_mp(this, &EditorNode::_bottom_panel_switch), varray(bottom_panel_items.size()));
 	tb->set_text(p_text);
 	tb->set_toggle_mode(true);
 	tb->set_focus_mode(Control::FOCUS_NONE);
@@ -5163,8 +5163,8 @@ void EditorNode::raise_bottom_panel_item(Control *p_item) {
 	}
 
 	for (int i = 0; i < bottom_panel_items.size(); i++) {
-		bottom_panel_items[i].button->disconnect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch));
-		bottom_panel_items[i].button->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch), varray(i));
+		bottom_panel_items[i].button->disconnect("button_toggled", callable_mp(this, &EditorNode::_bottom_panel_switch));
+		bottom_panel_items[i].button->connect("button_toggled", callable_mp(this, &EditorNode::_bottom_panel_switch), varray(i));
 	}
 }
 
@@ -5183,8 +5183,8 @@ void EditorNode::remove_bottom_panel_item(Control *p_item) {
 	}
 
 	for (int i = 0; i < bottom_panel_items.size(); i++) {
-		bottom_panel_items[i].button->disconnect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch));
-		bottom_panel_items[i].button->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch), varray(i));
+		bottom_panel_items[i].button->disconnect("button_toggled", callable_mp(this, &EditorNode::_bottom_panel_switch));
+		bottom_panel_items[i].button->connect("button_toggled", callable_mp(this, &EditorNode::_bottom_panel_switch), varray(i));
 	}
 }
 
@@ -6152,7 +6152,7 @@ EditorNode::EditorNode() {
 		dock_tab_move_left->set_icon(theme->get_icon("Back", "EditorIcons"));
 	}
 	dock_tab_move_left->set_focus_mode(Control::FOCUS_NONE);
-	dock_tab_move_left->connect("pressed", callable_mp(this, &EditorNode::_dock_move_left));
+	dock_tab_move_left->connect("button_clicked", callable_mp(this, &EditorNode::_dock_move_left));
 	dock_hb->add_child(dock_tab_move_left);
 
 	Label *dock_label = memnew(Label);
@@ -6169,7 +6169,7 @@ EditorNode::EditorNode() {
 		dock_tab_move_right->set_icon(theme->get_icon("Forward", "EditorIcons"));
 	}
 	dock_tab_move_right->set_focus_mode(Control::FOCUS_NONE);
-	dock_tab_move_right->connect("pressed", callable_mp(this, &EditorNode::_dock_move_right));
+	dock_tab_move_right->connect("button_clicked", callable_mp(this, &EditorNode::_dock_move_right));
 
 	dock_hb->add_child(dock_tab_move_right);
 	dock_vb->add_child(dock_hb);
@@ -6186,7 +6186,7 @@ EditorNode::EditorNode() {
 	dock_float->set_text(TTR("Make Floating"));
 	dock_float->set_focus_mode(Control::FOCUS_NONE);
 	dock_float->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
-	dock_float->connect("pressed", callable_mp(this, &EditorNode::_dock_make_float));
+	dock_float->connect("button_clicked", callable_mp(this, &EditorNode::_dock_make_float));
 
 	dock_vb->add_child(dock_float);
 
@@ -6266,7 +6266,7 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_OVERRIDE("editor/distraction_free_mode", "macos", KeyModifierMask::CMD | KeyModifierMask::CTRL | Key::D);
 	distraction_free->set_shortcut(ED_GET_SHORTCUT("editor/distraction_free_mode"));
 	distraction_free->set_tooltip(TTR("Toggle distraction-free mode."));
-	distraction_free->connect("pressed", callable_mp(this, &EditorNode::_toggle_distraction_free_mode));
+	distraction_free->connect("button_clicked", callable_mp(this, &EditorNode::_toggle_distraction_free_mode));
 	distraction_free->set_icon(gui_base->get_theme_icon(SNAME("DistractionFree"), SNAME("EditorIcons")));
 	distraction_free->set_toggle_mode(true);
 
@@ -6277,7 +6277,7 @@ EditorNode::EditorNode() {
 	scene_tab_add->set_tooltip(TTR("Add a new scene."));
 	scene_tab_add->set_icon(gui_base->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 	scene_tab_add->add_theme_color_override("icon_normal_color", Color(0.6f, 0.6f, 0.6f, 0.8f));
-	scene_tab_add->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_NEW_SCENE));
+	scene_tab_add->connect("button_clicked", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_NEW_SCENE));
 
 	scene_root_parent = memnew(PanelContainer);
 	scene_root_parent->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
@@ -6313,7 +6313,7 @@ EditorNode::EditorNode() {
 	prev_scene->set_icon(gui_base->get_theme_icon(SNAME("PrevScene"), SNAME("EditorIcons")));
 	prev_scene->set_tooltip(TTR("Go to previously opened scene."));
 	prev_scene->set_disabled(true);
-	prev_scene->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_OPEN_PREV));
+	prev_scene->connect("button_clicked", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_OPEN_PREV));
 	gui_base->add_child(prev_scene);
 	prev_scene->set_position(Point2(3, 24));
 	prev_scene->hide();
@@ -6562,7 +6562,7 @@ EditorNode::EditorNode() {
 	play_button->set_toggle_mode(true);
 	play_button->set_icon(gui_base->get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
 	play_button->set_focus_mode(Control::FOCUS_NONE);
-	play_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY));
+	play_button->connect("button_clicked", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY));
 	play_button->set_tooltip(TTR("Play the project."));
 
 	ED_SHORTCUT_AND_COMMAND("editor/play", TTR("Play"), Key::F5);
@@ -6587,7 +6587,7 @@ EditorNode::EditorNode() {
 	play_hb->add_child(stop_button);
 	stop_button->set_focus_mode(Control::FOCUS_NONE);
 	stop_button->set_icon(gui_base->get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
-	stop_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_STOP));
+	stop_button->connect("button_clicked", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_STOP));
 	stop_button->set_tooltip(TTR("Stop the scene."));
 	stop_button->set_disabled(true);
 
@@ -6605,7 +6605,7 @@ EditorNode::EditorNode() {
 	play_scene_button->set_toggle_mode(true);
 	play_scene_button->set_focus_mode(Control::FOCUS_NONE);
 	play_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayScene"), SNAME("EditorIcons")));
-	play_scene_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY_SCENE));
+	play_scene_button->connect("button_clicked", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY_SCENE));
 	play_scene_button->set_tooltip(TTR("Play the edited scene."));
 
 	ED_SHORTCUT_AND_COMMAND("editor/play_scene", TTR("Play Scene"), Key::F6);
@@ -6618,7 +6618,7 @@ EditorNode::EditorNode() {
 	play_custom_scene_button->set_toggle_mode(true);
 	play_custom_scene_button->set_focus_mode(Control::FOCUS_NONE);
 	play_custom_scene_button->set_icon(gui_base->get_theme_icon(SNAME("PlayCustom"), SNAME("EditorIcons")));
-	play_custom_scene_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY_CUSTOM_SCENE));
+	play_custom_scene_button->connect("button_clicked", callable_mp(this, &EditorNode::_menu_option), make_binds(RUN_PLAY_CUSTOM_SCENE));
 	play_custom_scene_button->set_tooltip(TTR("Play custom scene"));
 
 	ED_SHORTCUT_AND_COMMAND("editor/play_custom_scene", TTR("Play Custom Scene"), KeyModifierMask::CMD | KeyModifierMask::SHIFT | Key::F5);
@@ -6798,7 +6798,7 @@ EditorNode::EditorNode() {
 	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
 	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
 	version_btn->set_tooltip(TTR("Click to copy."));
-	version_btn->connect("pressed", callable_mp(this, &EditorNode::_version_button_pressed));
+	version_btn->connect("button_clicked", callable_mp(this, &EditorNode::_version_button_pressed));
 	version_info_vbc->add_child(version_btn);
 
 	// Add a dummy control node for horizontal spacing.
@@ -6814,7 +6814,7 @@ EditorNode::EditorNode() {
 	bottom_panel_hb->add_child(bottom_panel_raise);
 	bottom_panel_raise->hide();
 	bottom_panel_raise->set_toggle_mode(true);
-	bottom_panel_raise->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_raise_toggled));
+	bottom_panel_raise->connect("button_toggled", callable_mp(this, &EditorNode::_bottom_panel_raise_toggled));
 
 	log = memnew(EditorLog);
 	Button *output_button = add_bottom_panel_item(TTR("Output"), log);
@@ -6843,7 +6843,7 @@ EditorNode::EditorNode() {
 	custom_build_manage_templates = memnew(ConfirmationDialog);
 	custom_build_manage_templates->set_text(TTR("Android build template is missing, please install relevant templates."));
 	custom_build_manage_templates->get_ok_button()->set_text(TTR("Manage Templates"));
-	custom_build_manage_templates->add_button(TTR("Install from file"))->connect("pressed", callable_mp(this, &EditorNode::_menu_option), varray(SETTINGS_INSTALL_ANDROID_BUILD_TEMPLATE));
+	custom_build_manage_templates->add_button(TTR("Install from file"))->connect("button_clicked", callable_mp(this, &EditorNode::_menu_option), varray(SETTINGS_INSTALL_ANDROID_BUILD_TEMPLATE));
 	custom_build_manage_templates->connect("confirmed", callable_mp(this, &EditorNode::_menu_option), varray(SETTINGS_MANAGE_EXPORT_TEMPLATES));
 	gui_base->add_child(custom_build_manage_templates);
 

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -185,7 +185,7 @@ void EditorPath::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			connect("pressed", callable_mp(this, &EditorPath::_show_popup));
+			connect("button_clicked", callable_mp(this, &EditorPath::_show_popup));
 		} break;
 	}
 }

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -197,10 +197,10 @@ EditorPluginSettings::EditorPluginSettings() {
 	title_hb->add_child(l);
 	title_hb->add_spacer();
 	create_plugin = memnew(Button(TTR("Create")));
-	create_plugin->connect("pressed", callable_mp(this, &EditorPluginSettings::_create_clicked));
+	create_plugin->connect("button_clicked", callable_mp(this, &EditorPluginSettings::_create_clicked));
 	title_hb->add_child(create_plugin);
 	update_list = memnew(Button(TTR("Update")));
-	update_list->connect("pressed", callable_mp(this, &EditorPluginSettings::update_plugins));
+	update_list->connect("button_clicked", callable_mp(this, &EditorPluginSettings::update_plugins));
 	title_hb->add_child(update_list);
 	add_child(title_hb);
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -184,7 +184,7 @@ EditorPropertyMultilineText::EditorPropertyMultilineText() {
 	text->set_h_size_flags(SIZE_EXPAND_FILL);
 	open_big_text = memnew(Button);
 	open_big_text->set_flat(true);
-	open_big_text->connect("pressed", callable_mp(this, &EditorPropertyMultilineText::_open_big_text));
+	open_big_text->connect("button_clicked", callable_mp(this, &EditorPropertyMultilineText::_open_big_text));
 	hb->add_child(open_big_text);
 	big_text_dialog = nullptr;
 	big_text = nullptr;
@@ -319,7 +319,7 @@ EditorPropertyTextEnum::EditorPropertyTextEnum() {
 	edit_button->set_flat(true);
 	edit_button->hide();
 	default_layout->add_child(edit_button);
-	edit_button->connect("pressed", callable_mp(this, &EditorPropertyTextEnum::_edit_custom_value));
+	edit_button->connect("button_clicked", callable_mp(this, &EditorPropertyTextEnum::_edit_custom_value));
 
 	custom_value_edit = memnew(LineEdit);
 	custom_value_edit->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -329,12 +329,12 @@ EditorPropertyTextEnum::EditorPropertyTextEnum() {
 	accept_button = memnew(Button);
 	accept_button->set_flat(true);
 	edit_custom_layout->add_child(accept_button);
-	accept_button->connect("pressed", callable_mp(this, &EditorPropertyTextEnum::_custom_value_accepted));
+	accept_button->connect("button_clicked", callable_mp(this, &EditorPropertyTextEnum::_custom_value_accepted));
 
 	cancel_button = memnew(Button);
 	cancel_button->set_flat(true);
 	edit_custom_layout->add_child(cancel_button);
-	cancel_button->connect("pressed", callable_mp(this, &EditorPropertyTextEnum::_custom_value_cancelled));
+	cancel_button->connect("button_clicked", callable_mp(this, &EditorPropertyTextEnum::_custom_value_cancelled));
 
 	add_focusable(option_button);
 	add_focusable(edit_button);
@@ -434,7 +434,7 @@ EditorPropertyPath::EditorPropertyPath() {
 	path_hb->add_child(path_edit);
 	add_focusable(path);
 	dialog = nullptr;
-	path_edit->connect("pressed", callable_mp(this, &EditorPropertyPath::_path_pressed));
+	path_edit->connect("button_clicked", callable_mp(this, &EditorPropertyPath::_path_pressed));
 	folder = false;
 	global = false;
 	save_mode = false;
@@ -478,7 +478,7 @@ EditorPropertyClassName::EditorPropertyClassName() {
 	add_child(property);
 	add_focusable(property);
 	property->set_text(selected_type);
-	property->connect("pressed", callable_mp(this, &EditorPropertyClassName::_property_selected));
+	property->connect("button_clicked", callable_mp(this, &EditorPropertyClassName::_property_selected));
 	dialog = memnew(CreateDialog);
 	dialog->set_base_type(base_type);
 	dialog->connect("create", callable_mp(this, &EditorPropertyClassName::_dialog_created));
@@ -583,7 +583,7 @@ EditorPropertyMember::EditorPropertyMember() {
 	property->set_clip_text(true);
 	add_child(property);
 	add_focusable(property);
-	property->connect("pressed", callable_mp(this, &EditorPropertyMember::_property_select));
+	property->connect("button_clicked", callable_mp(this, &EditorPropertyMember::_property_select));
 }
 
 ///////////////////// CHECK /////////////////////////
@@ -610,7 +610,7 @@ EditorPropertyCheck::EditorPropertyCheck() {
 	checkbox->set_text(TTR("On"));
 	add_child(checkbox);
 	add_focusable(checkbox);
-	checkbox->connect("pressed", callable_mp(this, &EditorPropertyCheck::_checkbox_pressed));
+	checkbox->connect("button_clicked", callable_mp(this, &EditorPropertyCheck::_checkbox_pressed));
 }
 
 ///////////////////// ENUM /////////////////////////
@@ -710,7 +710,7 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 			CheckBox *cb = memnew(CheckBox);
 			cb->set_text(option);
 			cb->set_clip_text(true);
-			cb->connect("pressed", callable_mp(this, &EditorPropertyFlags::_flag_toggled));
+			cb->connect("button_clicked", callable_mp(this, &EditorPropertyFlags::_flag_toggled));
 			add_focusable(cb);
 			vbox->add_child(cb);
 			flags.push_back(cb);
@@ -1116,7 +1116,7 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	button = memnew(Button);
 	button->set_toggle_mode(true);
 	button->set_text("...");
-	button->connect("pressed", callable_mp(this, &EditorPropertyLayers::_button_pressed));
+	button->connect("button_clicked", callable_mp(this, &EditorPropertyLayers::_button_pressed));
 	hb->add_child(button);
 
 	set_bottom_editor(hb);
@@ -1213,7 +1213,7 @@ EditorPropertyObjectID::EditorPropertyObjectID() {
 	edit = memnew(Button);
 	add_child(edit);
 	add_focusable(edit);
-	edit->connect("pressed", callable_mp(this, &EditorPropertyObjectID::_edit_pressed));
+	edit->connect("button_clicked", callable_mp(this, &EditorPropertyObjectID::_edit_pressed));
 }
 
 ///////////////////// FLOAT /////////////////////////
@@ -2789,12 +2789,12 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 	assign->set_flat(true);
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
-	assign->connect("pressed", callable_mp(this, &EditorPropertyNodePath::_node_assign));
+	assign->connect("button_clicked", callable_mp(this, &EditorPropertyNodePath::_node_assign));
 	hbc->add_child(assign);
 
 	clear = memnew(Button);
 	clear->set_flat(true);
-	clear->connect("pressed", callable_mp(this, &EditorPropertyNodePath::_node_clear));
+	clear->connect("button_clicked", callable_mp(this, &EditorPropertyNodePath::_node_clear));
 	hbc->add_child(clear);
 	use_path_from_scene_root = false;
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -349,8 +349,8 @@ void EditorPropertyArray::update_property() {
 			reorder_button->set_icon(get_theme_icon(SNAME("TripleBar"), SNAME("EditorIcons")));
 			reorder_button->set_default_cursor_shape(Control::CURSOR_MOVE);
 			reorder_button->connect("gui_input", callable_mp(this, &EditorPropertyArray::_reorder_button_gui_input));
-			reorder_button->connect("button_down", callable_mp(this, &EditorPropertyArray::_reorder_button_down), varray(i + offset));
-			reorder_button->connect("button_up", callable_mp(this, &EditorPropertyArray::_reorder_button_up));
+			reorder_button->connect("button_pressed", callable_mp(this, &EditorPropertyArray::_reorder_button_pressed), varray(i + offset));
+			reorder_button->connect("button_released", callable_mp(this, &EditorPropertyArray::_reorder_button_released));
 			hbox->add_child(reorder_button);
 
 			String prop_name = "indices/" + itos(i + offset);
@@ -385,11 +385,11 @@ void EditorPropertyArray::update_property() {
 				Button *edit = memnew(Button);
 				edit->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 				hbox->add_child(edit);
-				edit->connect("pressed", callable_mp(this, &EditorPropertyArray::_change_type), varray(edit, i + offset));
+				edit->connect("button_clicked", callable_mp(this, &EditorPropertyArray::_change_type), varray(edit, i + offset));
 			} else {
 				Button *remove = memnew(Button);
 				remove->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
-				remove->connect("pressed", callable_mp(this, &EditorPropertyArray::_remove_pressed), varray(i + offset));
+				remove->connect("button_clicked", callable_mp(this, &EditorPropertyArray::_remove_pressed), varray(i + offset));
 				hbox->add_child(remove);
 			}
 
@@ -632,7 +632,7 @@ void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_eve
 	}
 }
 
-void EditorPropertyArray::_reorder_button_down(int p_index) {
+void EditorPropertyArray::_reorder_button_pressed(int p_index) {
 	reorder_from_index = p_index;
 	reorder_to_index = p_index;
 	reorder_selected_element_hbox = Object::cast_to<HBoxContainer>(vbox->get_child(p_index % page_length + 2));
@@ -642,7 +642,7 @@ void EditorPropertyArray::_reorder_button_down(int p_index) {
 	Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
 }
 
-void EditorPropertyArray::_reorder_button_up() {
+void EditorPropertyArray::_reorder_button_released() {
 	if (reorder_from_index != reorder_to_index) {
 		// Move the element.
 		Variant array = object->get_array();
@@ -678,7 +678,7 @@ EditorPropertyArray::EditorPropertyArray() {
 	edit = memnew(Button);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
-	edit->connect("pressed", callable_mp(this, &EditorPropertyArray::_edit_pressed));
+	edit->connect("button_clicked", callable_mp(this, &EditorPropertyArray::_edit_pressed));
 	edit->set_toggle_mode(true);
 	edit->set_drag_forwarding(this);
 	edit->connect("draw", callable_mp(this, &EditorPropertyArray::_button_draw));
@@ -1114,14 +1114,14 @@ void EditorPropertyDictionary::update_property() {
 			Button *edit = memnew(Button);
 			edit->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 			hbox->add_child(edit);
-			edit->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_change_type), varray(edit, change_index));
+			edit->connect("button_clicked", callable_mp(this, &EditorPropertyDictionary::_change_type), varray(edit, change_index));
 
 			prop->update_property();
 
 			if (i == amount + 1) {
 				Button *butt_add_item = memnew(Button);
 				butt_add_item->set_text(TTR("Add Key/Value Pair"));
-				butt_add_item->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_add_key_value));
+				butt_add_item->connect("button_clicked", callable_mp(this, &EditorPropertyDictionary::_add_key_value));
 				add_vbox->add_child(butt_add_item);
 			}
 		}
@@ -1173,7 +1173,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	edit = memnew(Button);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
-	edit->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_edit_pressed));
+	edit->connect("button_clicked", callable_mp(this, &EditorPropertyDictionary::_edit_pressed));
 	edit->set_toggle_mode(true);
 	add_child(edit);
 	add_focusable(edit);

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -119,8 +119,8 @@ class EditorPropertyArray : public EditorProperty {
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 	void _reorder_button_gui_input(const Ref<InputEvent> &p_event);
-	void _reorder_button_down(int p_index);
-	void _reorder_button_up();
+	void _reorder_button_pressed(int p_index);
+	void _reorder_button_released();
 
 protected:
 	static void _bind_methods();

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -845,7 +845,7 @@ EditorResourcePicker::EditorResourcePicker() {
 	assign_button->set_clip_text(true);
 	assign_button->set_drag_forwarding(this);
 	add_child(assign_button);
-	assign_button->connect("pressed", callable_mp(this, &EditorResourcePicker::_resource_selected));
+	assign_button->connect("button_clicked", callable_mp(this, &EditorResourcePicker::_resource_selected));
 	assign_button->connect("draw", callable_mp(this, &EditorResourcePicker::_button_draw));
 	assign_button->connect("gui_input", callable_mp(this, &EditorResourcePicker::_button_input));
 
@@ -860,7 +860,7 @@ EditorResourcePicker::EditorResourcePicker() {
 	edit_button = memnew(Button);
 	edit_button->set_flat(true);
 	edit_button->set_toggle_mode(true);
-	edit_button->connect("pressed", callable_mp(this, &EditorResourcePicker::_update_menu));
+	edit_button->connect("button_clicked", callable_mp(this, &EditorResourcePicker::_update_menu));
 	add_child(edit_button);
 	edit_button->connect("gui_input", callable_mp(this, &EditorResourcePicker::_button_input));
 }

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -53,7 +53,7 @@ void EditorRunNative::_notification(int p_what) {
 					small_icon->create_from_image(im);
 					MenuButton *mb = memnew(MenuButton);
 					mb->get_popup()->connect("id_pressed", callable_mp(this, &EditorRunNative::run_native), varray(i));
-					mb->connect("pressed", callable_mp(this, &EditorRunNative::run_native), varray(-1, i));
+					mb->connect("button_clicked", callable_mp(this, &EditorRunNative::run_native), varray(-1, i));
 					mb->set_icon(small_icon);
 					add_child(mb);
 					menus[i] = mb;

--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -365,7 +365,7 @@ Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_
 		Button *close_button = memnew(Button);
 		close_button->set_flat(true);
 		close_button->set_icon(get_theme_icon("Close", "EditorIcons"));
-		close_button->connect("pressed", callable_bind(callable_mp(this, &EditorToaster::close), panel));
+		close_button->connect("button_clicked", callable_bind(callable_mp(this, &EditorToaster::close), panel));
 		hbox_container->add_child(close_button);
 	}
 
@@ -485,8 +485,8 @@ EditorToaster::EditorToaster() {
 	// Main button.
 	main_button = memnew(Button);
 	main_button->set_flat(true);
-	main_button->connect("pressed", callable_mp(this, &EditorToaster::_set_notifications_enabled), varray(true));
-	main_button->connect("pressed", callable_mp(this, &EditorToaster::_repop_old));
+	main_button->connect("button_clicked", callable_mp(this, &EditorToaster::_set_notifications_enabled), varray(true));
+	main_button->connect("button_clicked", callable_mp(this, &EditorToaster::_repop_old));
 	main_button->connect("draw", callable_mp(this, &EditorToaster::_draw_button));
 	add_child(main_button);
 
@@ -498,7 +498,7 @@ EditorToaster::EditorToaster() {
 
 	disable_notifications_button = memnew(Button);
 	disable_notifications_button->set_flat(true);
-	disable_notifications_button->connect("pressed", callable_mp(this, &EditorToaster::_set_notifications_enabled), varray(false));
+	disable_notifications_button->connect("button_clicked", callable_mp(this, &EditorToaster::_set_notifications_enabled), varray(false));
 	disable_notifications_panel->add_child(disable_notifications_button);
 
 	// Other

--- a/editor/editor_zoom_widget.cpp
+++ b/editor/editor_zoom_widget.cpp
@@ -168,7 +168,7 @@ EditorZoomWidget::EditorZoomWidget() {
 	zoom_minus = memnew(Button);
 	zoom_minus->set_flat(true);
 	add_child(zoom_minus);
-	zoom_minus->connect("pressed", callable_mp(this, &EditorZoomWidget::_button_zoom_minus));
+	zoom_minus->connect("button_clicked", callable_mp(this, &EditorZoomWidget::_button_zoom_minus));
 	zoom_minus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_minus", TTR("Zoom Out"), KeyModifierMask::CMD | Key::MINUS));
 	zoom_minus->set_shortcut_context(this);
 	zoom_minus->set_focus_mode(FOCUS_NONE);
@@ -179,7 +179,7 @@ EditorZoomWidget::EditorZoomWidget() {
 	zoom_reset->add_theme_constant_override("outline_size", 1);
 	zoom_reset->add_theme_color_override("font_outline_color", Color(0, 0, 0));
 	zoom_reset->add_theme_color_override("font_color", Color(1, 1, 1));
-	zoom_reset->connect("pressed", callable_mp(this, &EditorZoomWidget::_button_zoom_reset));
+	zoom_reset->connect("button_clicked", callable_mp(this, &EditorZoomWidget::_button_zoom_reset));
 	zoom_reset->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_reset", TTR("Zoom Reset"), KeyModifierMask::CMD | Key::KEY_0));
 	zoom_reset->set_shortcut_context(this);
 	zoom_reset->set_focus_mode(FOCUS_NONE);
@@ -190,7 +190,7 @@ EditorZoomWidget::EditorZoomWidget() {
 	zoom_plus = memnew(Button);
 	zoom_plus->set_flat(true);
 	add_child(zoom_plus);
-	zoom_plus->connect("pressed", callable_mp(this, &EditorZoomWidget::_button_zoom_plus));
+	zoom_plus->connect("button_clicked", callable_mp(this, &EditorZoomWidget::_button_zoom_plus));
 	zoom_plus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_plus", TTR("Zoom In"), KeyModifierMask::CMD | Key::EQUAL)); // Usually direct access key for PLUS
 	zoom_plus->set_shortcut_context(this);
 	zoom_plus->set_focus_mode(FOCUS_NONE);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -853,13 +853,13 @@ ExportTemplateManager::ExportTemplateManager() {
 	current_open_button->set_text(TTR("Open Folder"));
 	current_open_button->set_tooltip(TTR("Open the folder containing installed templates for the current version."));
 	current_installed_hb->add_child(current_open_button);
-	current_open_button->connect("pressed", callable_mp(this, &ExportTemplateManager::_open_template_folder), varray(VERSION_FULL_CONFIG));
+	current_open_button->connect("button_clicked", callable_mp(this, &ExportTemplateManager::_open_template_folder), varray(VERSION_FULL_CONFIG));
 
 	current_uninstall_button = memnew(Button);
 	current_uninstall_button->set_text(TTR("Uninstall"));
 	current_uninstall_button->set_tooltip(TTR("Uninstall templates for the current version."));
 	current_installed_hb->add_child(current_uninstall_button);
-	current_uninstall_button->connect("pressed", callable_mp(this, &ExportTemplateManager::_uninstall_template), varray(VERSION_FULL_CONFIG));
+	current_uninstall_button->connect("button_clicked", callable_mp(this, &ExportTemplateManager::_uninstall_template), varray(VERSION_FULL_CONFIG));
 
 	main_vb->add_child(memnew(HSeparator));
 
@@ -900,7 +900,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	download_current_button->set_text(TTR("Download and Install"));
 	download_current_button->set_tooltip(TTR("Download and install templates for the current version from the best possible mirror."));
 	download_install_hb->add_child(download_current_button);
-	download_current_button->connect("pressed", callable_mp(this, &ExportTemplateManager::_download_current));
+	download_current_button->connect("button_clicked", callable_mp(this, &ExportTemplateManager::_download_current));
 
 	// Update downloads buttons to prevent unsupported downloads.
 	if (!downloads_available) {
@@ -916,7 +916,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	install_file_button->set_text(TTR("Install from File"));
 	install_file_button->set_tooltip(TTR("Install templates from a local file."));
 	install_file_hb->add_child(install_file_button);
-	install_file_button->connect("pressed", callable_mp(this, &ExportTemplateManager::_install_file));
+	install_file_button->connect("button_clicked", callable_mp(this, &ExportTemplateManager::_install_file));
 
 	// Templates are being downloaded; buttons unavailable.
 	download_progress_hb = memnew(HBoxContainer);
@@ -941,7 +941,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	download_cancel_button->set_text(TTR("Cancel"));
 	download_cancel_button->set_tooltip(TTR("Cancel the download of the templates."));
 	download_progress_hb->add_child(download_cancel_button);
-	download_cancel_button->connect("pressed", callable_mp(this, &ExportTemplateManager::_cancel_template_download));
+	download_cancel_button->connect("button_clicked", callable_mp(this, &ExportTemplateManager::_cancel_template_download));
 
 	download_templates = memnew(HTTPRequest);
 	install_templates_hb->add_child(download_templates);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -339,11 +339,11 @@ void FileSystemDock::_notification(int p_what) {
 
 			button_reload->set_icon(get_theme_icon(SNAME("Reload"), ei));
 			button_toggle_display_mode->set_icon(get_theme_icon(SNAME("Panels2"), ei));
-			button_file_list_display_mode->connect("pressed", callable_mp(this, &FileSystemDock::_toggle_file_display));
+			button_file_list_display_mode->connect("button_clicked", callable_mp(this, &FileSystemDock::_toggle_file_display));
 
 			files->connect("item_activated", callable_mp(this, &FileSystemDock::_file_list_activate_file));
-			button_hist_next->connect("pressed", callable_mp(this, &FileSystemDock::_fw_history));
-			button_hist_prev->connect("pressed", callable_mp(this, &FileSystemDock::_bw_history));
+			button_hist_next->connect("button_clicked", callable_mp(this, &FileSystemDock::_fw_history));
+			button_hist_prev->connect("button_clicked", callable_mp(this, &FileSystemDock::_bw_history));
 
 			tree_search_box->set_right_icon(get_theme_icon(SNAME("Search"), ei));
 			tree_search_box->set_clear_button_enabled(true);
@@ -2829,7 +2829,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	toolbar_hbc->add_child(current_path);
 
 	button_reload = memnew(Button);
-	button_reload->connect("pressed", callable_mp(this, &FileSystemDock::_rescan));
+	button_reload->connect("button_clicked", callable_mp(this, &FileSystemDock::_rescan));
 	button_reload->set_focus_mode(FOCUS_NONE);
 	button_reload->set_tooltip(TTR("Re-Scan Filesystem"));
 	button_reload->hide();
@@ -2837,7 +2837,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 
 	button_toggle_display_mode = memnew(Button);
 	button_toggle_display_mode->set_toggle_mode(true);
-	button_toggle_display_mode->connect("toggled", callable_mp(this, &FileSystemDock::_toggle_split_mode));
+	button_toggle_display_mode->connect("button_toggled", callable_mp(this, &FileSystemDock::_toggle_split_mode));
 	button_toggle_display_mode->set_focus_mode(FOCUS_NONE);
 	button_toggle_display_mode->set_tooltip(TTR("Toggle Split Mode"));
 	button_toggle_display_mode->set_flat(true);

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -364,7 +364,7 @@ FindInFilesDialog::FindInFilesDialog() {
 
 		Button *folder_button = memnew(Button);
 		folder_button->set_text("...");
-		folder_button->connect("pressed", callable_mp(this, &FindInFilesDialog::_on_folder_button_pressed));
+		folder_button->connect("button_clicked", callable_mp(this, &FindInFilesDialog::_on_folder_button_pressed));
 		hbc->add_child(folder_button);
 
 		_folder_dialog = memnew(FileDialog);
@@ -587,13 +587,13 @@ FindInFilesPanel::FindInFilesPanel() {
 
 		_refresh_button = memnew(Button);
 		_refresh_button->set_text(TTR("Refresh"));
-		_refresh_button->connect("pressed", callable_mp(this, &FindInFilesPanel::_on_refresh_button_clicked));
+		_refresh_button->connect("button_clicked", callable_mp(this, &FindInFilesPanel::_on_refresh_button_clicked));
 		_refresh_button->hide();
 		hbc->add_child(_refresh_button);
 
 		_cancel_button = memnew(Button);
 		_cancel_button->set_text(TTR("Cancel"));
-		_cancel_button->connect("pressed", callable_mp(this, &FindInFilesPanel::_on_cancel_button_clicked));
+		_cancel_button->connect("button_clicked", callable_mp(this, &FindInFilesPanel::_on_cancel_button_clicked));
 		_cancel_button->hide();
 		hbc->add_child(_cancel_button);
 
@@ -628,7 +628,7 @@ FindInFilesPanel::FindInFilesPanel() {
 
 		_replace_all_button = memnew(Button);
 		_replace_all_button->set_text(TTR("Replace all (no undo)"));
-		_replace_all_button->connect("pressed", callable_mp(this, &FindInFilesPanel::_on_replace_all_clicked));
+		_replace_all_button->connect("button_clicked", callable_mp(this, &FindInFilesPanel::_on_replace_all_clicked));
 		_replace_container->add_child(_replace_all_button);
 
 		_replace_container->hide();

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -460,7 +460,7 @@ GroupDialog::GroupDialog() {
 	Button *add_group_button = memnew(Button);
 	add_group_button->set_text(TTR("Add"));
 	chbc->add_child(add_group_button);
-	add_group_button->connect("pressed", callable_mp(this, &GroupDialog::_add_group_pressed), varray(String()));
+	add_group_button->connect("button_clicked", callable_mp(this, &GroupDialog::_add_group_pressed), varray(String()));
 
 	VBoxContainer *vbc_add = memnew(VBoxContainer);
 	hbc->add_child(vbc_add);
@@ -498,7 +498,7 @@ GroupDialog::GroupDialog() {
 	add_button = memnew(Button);
 	add_button->set_flat(true);
 	add_button->set_text(TTR("Add"));
-	add_button->connect("pressed", callable_mp(this, &GroupDialog::_add_pressed));
+	add_button->connect("button_clicked", callable_mp(this, &GroupDialog::_add_pressed));
 
 	vbc_buttons->add_child(add_button);
 	vbc_buttons->add_spacer();
@@ -508,7 +508,7 @@ GroupDialog::GroupDialog() {
 	remove_button = memnew(Button);
 	remove_button->set_flat(true);
 	remove_button->set_text(TTR("Remove"));
-	remove_button->connect("pressed", callable_mp(this, &GroupDialog::_removed_pressed));
+	remove_button->connect("button_clicked", callable_mp(this, &GroupDialog::_removed_pressed));
 
 	vbc_buttons->add_child(remove_button);
 
@@ -701,7 +701,7 @@ GroupsEditor::GroupsEditor() {
 	Button *group_dialog_button = memnew(Button);
 	group_dialog_button->set_text(TTR("Manage Groups"));
 	vbc->add_child(group_dialog_button);
-	group_dialog_button->connect("pressed", callable_mp(this, &GroupsEditor::_show_group_dialog));
+	group_dialog_button->connect("button_clicked", callable_mp(this, &GroupsEditor::_show_group_dialog));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	vbc->add_child(hbc);
@@ -714,7 +714,7 @@ GroupsEditor::GroupsEditor() {
 	add = memnew(Button);
 	add->set_text(TTR("Add"));
 	hbc->add_child(add);
-	add->connect("pressed", callable_mp(this, &GroupsEditor::_add_group), varray(String()));
+	add->connect("button_clicked", callable_mp(this, &GroupsEditor::_add_group), varray(String()));
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);

--- a/editor/import/dynamicfont_import_settings.cpp
+++ b/editor/import/dynamicfont_import_settings.cpp
@@ -1702,7 +1702,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	page2_hb_vars->add_child(add_var);
 	add_var->set_tooltip(TTR("Add configuration"));
 	add_var->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
-	add_var->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_variation_add));
+	add_var->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_variation_add));
 
 	vars_list = memnew(Tree);
 	page2_side_vb->add_child(vars_list);
@@ -1772,12 +1772,12 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	Button *btn_fill = memnew(Button);
 	text_hb->add_child(btn_fill);
 	btn_fill->set_text(TTR("Shape text and add glyphs"));
-	btn_fill->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_glyph_text_selected));
+	btn_fill->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_glyph_text_selected));
 
 	Button *btn_clear = memnew(Button);
 	text_hb->add_child(btn_clear);
 	btn_clear->set_text(TTR("Clear glyph list"));
-	btn_clear->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_glyph_clear));
+	btn_clear->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_glyph_clear));
 
 	// Page 4 layout: Character map
 	VBoxContainer *page4_vb = memnew(VBoxContainer);
@@ -1854,7 +1854,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	hb_lang->add_child(add_lang);
 	add_lang->set_tooltip(TTR("Add language override"));
 	add_lang->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
-	add_lang->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_lang_add));
+	add_lang->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_lang_add));
 
 	lang_list = memnew(Tree);
 	page5_vb->add_child(lang_list);
@@ -1882,7 +1882,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	hb_script->add_child(add_script);
 	add_script->set_tooltip(TTR("Add script override"));
 	add_script->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
-	add_script->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_script_add));
+	add_script->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_script_add));
 
 	script_list = memnew(Tree);
 	page5_vb->add_child(script_list);

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -195,7 +195,7 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 	reset_defaults = memnew(Button);
 	reset_defaults->set_text(TTR("Reset to Defaults"));
 	reset_defaults->set_disabled(true);
-	reset_defaults->connect("pressed", callable_mp(this, &ImportDefaultsEditor::_reset));
+	reset_defaults->connect("button_clicked", callable_mp(this, &ImportDefaultsEditor::_reset));
 	hb->add_child(reset_defaults);
 	add_child(hb);
 	inspector = memnew(EditorInspector);
@@ -204,7 +204,7 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 	CenterContainer *cc = memnew(CenterContainer);
 	save_defaults = memnew(Button);
 	save_defaults->set_text(TTR("Save"));
-	save_defaults->connect("pressed", callable_mp(this, &ImportDefaultsEditor::_save));
+	save_defaults->connect("button_clicked", callable_mp(this, &ImportDefaultsEditor::_save));
 	cc->add_child(save_defaults);
 	add_child(cc);
 

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -628,7 +628,7 @@ ImportDock::ImportDock() {
 	import = memnew(Button);
 	import->set_text(TTR("Reimport"));
 	import->set_disabled(true);
-	import->connect("pressed", callable_mp(this, &ImportDock::_reimport_attempt));
+	import->connect("button_clicked", callable_mp(this, &ImportDock::_reimport_attempt));
 	if (!DisplayServer::get_singleton()->get_swap_cancel_ok()) {
 		advanced_spacer = hb->add_spacer();
 		advanced = memnew(Button);
@@ -648,7 +648,7 @@ ImportDock::ImportDock() {
 
 	advanced->hide();
 	advanced_spacer->hide();
-	advanced->connect("pressed", callable_mp(this, &ImportDock::_advanced_options));
+	advanced->connect("button_clicked", callable_mp(this, &ImportDock::_advanced_options));
 
 	reimport_confirm = memnew(ConfirmationDialog);
 	reimport_confirm->get_ok_button()->set_text(TTR("Save Scenes, Re-Import, and Restart"));

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -575,7 +575,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	resource_new_button->set_tooltip(TTR("Create a new resource in memory and edit it."));
 	resource_new_button->set_icon(get_theme_icon(SNAME("New"), SNAME("EditorIcons")));
 	general_options_hb->add_child(resource_new_button);
-	resource_new_button->connect("pressed", callable_mp(this, &InspectorDock::_new_resource));
+	resource_new_button->connect("button_clicked", callable_mp(this, &InspectorDock::_new_resource));
 	resource_new_button->set_focus_mode(Control::FOCUS_NONE);
 
 	resource_load_button = memnew(Button);
@@ -583,7 +583,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	resource_load_button->set_tooltip(TTR("Load an existing resource from disk and edit it."));
 	resource_load_button->set_icon(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")));
 	general_options_hb->add_child(resource_load_button);
-	resource_load_button->connect("pressed", callable_mp(this, &InspectorDock::_open_resource_selector));
+	resource_load_button->connect("button_clicked", callable_mp(this, &InspectorDock::_open_resource_selector));
 	resource_load_button->set_focus_mode(Control::FOCUS_NONE);
 
 	resource_save_button = memnew(MenuButton);
@@ -621,7 +621,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	}
 	backward_button->set_tooltip(TTR("Go to the previous edited object in history."));
 	backward_button->set_disabled(true);
-	backward_button->connect("pressed", callable_mp(this, &InspectorDock::_edit_back));
+	backward_button->connect("button_clicked", callable_mp(this, &InspectorDock::_edit_back));
 
 	forward_button = memnew(Button);
 	forward_button->set_flat(true);
@@ -633,7 +633,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	}
 	forward_button->set_tooltip(TTR("Go to the next edited object in history."));
 	forward_button->set_disabled(true);
-	forward_button->connect("pressed", callable_mp(this, &InspectorDock::_edit_forward));
+	forward_button->connect("button_clicked", callable_mp(this, &InspectorDock::_edit_forward));
 
 	history_menu = memnew(MenuButton);
 	history_menu->set_tooltip(TTR("History of recently edited objects."));
@@ -655,7 +655,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	open_docs_button->set_icon(get_theme_icon(SNAME("HelpSearch"), SNAME("EditorIcons")));
 	open_docs_button->set_shortcut(ED_SHORTCUT("property_editor/open_help", TTR("Open Documentation")));
 	subresource_hb->add_child(open_docs_button);
-	open_docs_button->connect("pressed", callable_mp(this, &InspectorDock::_menu_option), varray(OBJECT_REQUEST_HELP));
+	open_docs_button->connect("button_clicked", callable_mp(this, &InspectorDock::_menu_option), varray(OBJECT_REQUEST_HELP));
 
 	new_resource_dialog = memnew(CreateDialog);
 	editor->get_gui_base()->add_child(new_resource_dialog);
@@ -686,7 +686,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	warning->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 	warning->set_clip_text(true);
 	warning->hide();
-	warning->connect("pressed", callable_mp(this, &InspectorDock::_warning_pressed));
+	warning->connect("button_clicked", callable_mp(this, &InspectorDock::_warning_pressed));
 
 	unique_resources_confirmation = memnew(ConfirmationDialog);
 	add_child(unique_resources_confirmation);

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -658,7 +658,7 @@ LocalizationEditor::LocalizationEditor() {
 		tvb->add_child(thb);
 
 		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect("pressed", callable_mp(this, &LocalizationEditor::_translation_file_open));
+		addtr->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_file_open));
 		thb->add_child(addtr);
 
 		VBoxContainer *tmc = memnew(VBoxContainer);
@@ -688,7 +688,7 @@ LocalizationEditor::LocalizationEditor() {
 		tvb->add_child(thb);
 
 		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect("pressed", callable_mp(this, &LocalizationEditor::_translation_res_file_open));
+		addtr->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_res_file_open));
 		thb->add_child(addtr);
 
 		VBoxContainer *tmc = memnew(VBoxContainer);
@@ -714,7 +714,7 @@ LocalizationEditor::LocalizationEditor() {
 		tvb->add_child(thb);
 
 		addtr = memnew(Button(TTR("Add...")));
-		addtr->connect("pressed", callable_mp(this, &LocalizationEditor::_translation_res_option_file_open));
+		addtr->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_res_option_file_open));
 		translation_res_option_add_button = addtr;
 		thb->add_child(addtr);
 
@@ -782,11 +782,11 @@ LocalizationEditor::LocalizationEditor() {
 		tvb->add_child(thb);
 
 		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect("pressed", callable_mp(this, &LocalizationEditor::_pot_file_open));
+		addtr->connect("button_clicked", callable_mp(this, &LocalizationEditor::_pot_file_open));
 		thb->add_child(addtr);
 
 		Button *generate = memnew(Button(TTR("Generate POT")));
-		generate->connect("pressed", callable_mp(this, &LocalizationEditor::_pot_generate_open));
+		generate->connect("button_clicked", callable_mp(this, &LocalizationEditor::_pot_generate_open));
 		thb->add_child(generate);
 
 		VBoxContainer *tmc = memnew(VBoxContainer);

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -100,7 +100,7 @@ NodeDock::NodeDock() {
 	connections_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	connections_button->set_clip_text(true);
 	mode_hb->add_child(connections_button);
-	connections_button->connect("pressed", callable_mp(this, &NodeDock::show_connections));
+	connections_button->connect("button_clicked", callable_mp(this, &NodeDock::show_connections));
 
 	groups_button = memnew(Button);
 	groups_button->set_flat(true);
@@ -110,7 +110,7 @@ NodeDock::NodeDock() {
 	groups_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	groups_button->set_clip_text(true);
 	mode_hb->add_child(groups_button);
-	groups_button->connect("pressed", callable_mp(this, &NodeDock::show_groups));
+	groups_button->connect("button_clicked", callable_mp(this, &NodeDock::show_groups));
 
 	connections = memnew(ConnectionsDock(EditorNode::get_singleton()));
 	connections->set_undoredo(EditorNode::get_undo_redo());

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -194,7 +194,7 @@ void PluginConfigDialog::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_READY: {
 			connect("confirmed", callable_mp(this, &PluginConfigDialog::_on_confirmed));
-			get_cancel_button()->connect("pressed", callable_mp(this, &PluginConfigDialog::_on_cancelled));
+			get_cancel_button()->connect("button_clicked", callable_mp(this, &PluginConfigDialog::_on_cancelled));
 		} break;
 	}
 }

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -707,19 +707,19 @@ AbstractPolygon2DEditor::AbstractPolygon2DEditor(EditorNode *p_editor, bool p_wi
 	button_create = memnew(Button);
 	button_create->set_flat(true);
 	add_child(button_create);
-	button_create->connect("pressed", callable_mp(this, &AbstractPolygon2DEditor::_menu_option), varray(MODE_CREATE));
+	button_create->connect("button_clicked", callable_mp(this, &AbstractPolygon2DEditor::_menu_option), varray(MODE_CREATE));
 	button_create->set_toggle_mode(true);
 
 	button_edit = memnew(Button);
 	button_edit->set_flat(true);
 	add_child(button_edit);
-	button_edit->connect("pressed", callable_mp(this, &AbstractPolygon2DEditor::_menu_option), varray(MODE_EDIT));
+	button_edit->connect("button_clicked", callable_mp(this, &AbstractPolygon2DEditor::_menu_option), varray(MODE_EDIT));
 	button_edit->set_toggle_mode(true);
 
 	button_delete = memnew(Button);
 	button_delete->set_flat(true);
 	add_child(button_delete);
-	button_delete->connect("pressed", callable_mp(this, &AbstractPolygon2DEditor::_menu_option), varray(MODE_DELETE));
+	button_delete->connect("button_clicked", callable_mp(this, &AbstractPolygon2DEditor::_menu_option), varray(MODE_DELETE));
 	button_delete->set_toggle_mode(true);
 
 	create_resource = memnew(ConfirmationDialog);

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -603,7 +603,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	top_hb->add_child(tool_blend);
 	tool_blend->set_pressed(true);
 	tool_blend->set_tooltip(TTR("Set the blending position within the space"));
-	tool_blend->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch), varray(3));
+	tool_blend->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch), varray(3));
 
 	tool_select = memnew(Button);
 	tool_select->set_flat(true);
@@ -611,7 +611,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	tool_select->set_button_group(bg);
 	top_hb->add_child(tool_select);
 	tool_select->set_tooltip(TTR("Select and move points, create points with RMB."));
-	tool_select->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch), varray(0));
+	tool_select->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch), varray(0));
 
 	tool_create = memnew(Button);
 	tool_create->set_flat(true);
@@ -619,7 +619,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	tool_create->set_button_group(bg);
 	top_hb->add_child(tool_create);
 	tool_create->set_tooltip(TTR("Create points."));
-	tool_create->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch), varray(1));
+	tool_create->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch), varray(1));
 
 	tool_erase_sep = memnew(VSeparator);
 	top_hb->add_child(tool_erase_sep);
@@ -627,7 +627,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	tool_erase->set_flat(true);
 	top_hb->add_child(tool_erase);
 	tool_erase->set_tooltip(TTR("Erase points."));
-	tool_erase->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_erase_selected));
+	tool_erase->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_erase_selected));
 
 	top_hb->add_child(memnew(VSeparator));
 
@@ -637,7 +637,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	top_hb->add_child(snap);
 	snap->set_pressed(true);
 	snap->set_tooltip(TTR("Enable snap and show grid."));
-	snap->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_snap_toggled));
+	snap->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_snap_toggled));
 
 	snap_value = memnew(SpinBox);
 	top_hb->add_child(snap_value);
@@ -660,7 +660,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
 	open_editor->set_text(TTR("Open Editor"));
-	open_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_open_editor), varray(), CONNECT_DEFERRED);
+	open_editor->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_open_editor), varray(), CONNECT_DEFERRED);
 
 	edit_hb->hide();
 	open_editor->hide();

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -822,7 +822,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hb->add_child(tool_blend);
 	tool_blend->set_pressed(true);
 	tool_blend->set_tooltip(TTR("Set the blending position within the space"));
-	tool_blend->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(3));
+	tool_blend->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(3));
 
 	tool_select = memnew(Button);
 	tool_select->set_flat(true);
@@ -830,7 +830,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_select->set_button_group(bg);
 	top_hb->add_child(tool_select);
 	tool_select->set_tooltip(TTR("Select and move points, create points with RMB."));
-	tool_select->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(0));
+	tool_select->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(0));
 
 	tool_create = memnew(Button);
 	tool_create->set_flat(true);
@@ -838,7 +838,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_create->set_button_group(bg);
 	top_hb->add_child(tool_create);
 	tool_create->set_tooltip(TTR("Create points."));
-	tool_create->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(1));
+	tool_create->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(1));
 
 	tool_triangle = memnew(Button);
 	tool_triangle->set_flat(true);
@@ -846,7 +846,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_triangle->set_button_group(bg);
 	top_hb->add_child(tool_triangle);
 	tool_triangle->set_tooltip(TTR("Create triangles by connecting points."));
-	tool_triangle->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(2));
+	tool_triangle->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch), varray(2));
 
 	tool_erase_sep = memnew(VSeparator);
 	top_hb->add_child(tool_erase_sep);
@@ -854,7 +854,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_erase->set_flat(true);
 	top_hb->add_child(tool_erase);
 	tool_erase->set_tooltip(TTR("Erase points and triangles."));
-	tool_erase->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_erase_selected));
+	tool_erase->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_erase_selected));
 	tool_erase->set_disabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
@@ -862,7 +862,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	auto_triangles = memnew(Button);
 	auto_triangles->set_flat(true);
 	top_hb->add_child(auto_triangles);
-	auto_triangles->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled));
+	auto_triangles->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled));
 	auto_triangles->set_toggle_mode(true);
 	auto_triangles->set_tooltip(TTR("Generate blend triangles automatically (instead of manually)"));
 
@@ -874,7 +874,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hb->add_child(snap);
 	snap->set_pressed(true);
 	snap->set_tooltip(TTR("Enable snap and show grid."));
-	snap->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_snap_toggled));
+	snap->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_snap_toggled));
 
 	snap_x = memnew(SpinBox);
 	top_hb->add_child(snap_x);
@@ -916,7 +916,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
 	open_editor->set_text(TTR("Open Editor"));
-	open_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_open_editor), varray(), CONNECT_DEFERRED);
+	open_editor->connect("button_clicked", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_open_editor), varray(), CONNECT_DEFERRED);
 	edit_hb->hide();
 	open_editor->hide();
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -184,7 +184,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			open_in_editor->set_text(TTR("Open Editor"));
 			open_in_editor->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 			node->add_child(open_in_editor);
-			open_in_editor->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_open_in_editor), varray(E), CONNECT_DEFERRED);
+			open_in_editor->connect("button_clicked", callable_mp(this, &AnimationNodeBlendTreeEditor::_open_in_editor), varray(E), CONNECT_DEFERRED);
 			open_in_editor->set_h_size_flags(SIZE_SHRINK_CENTER);
 		}
 
@@ -194,7 +194,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			edit_filters->set_text(TTR("Edit Filters"));
 			edit_filters->set_icon(get_theme_icon(SNAME("AnimationFilter"), SNAME("EditorIcons")));
 			node->add_child(edit_filters);
-			edit_filters->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_edit_filters), varray(E), CONNECT_DEFERRED);
+			edit_filters->connect("button_clicked", callable_mp(this, &AnimationNodeBlendTreeEditor::_edit_filters), varray(E), CONNECT_DEFERRED);
 			edit_filters->set_h_size_flags(SIZE_SHRINK_CENTER);
 		}
 
@@ -977,7 +977,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 
 	filter_enabled = memnew(CheckBox);
 	filter_enabled->set_text(TTR("Enable Filtering"));
-	filter_enabled->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_filter_toggled));
+	filter_enabled->connect("button_clicked", callable_mp(this, &AnimationNodeBlendTreeEditor::_filter_toggled));
 	filter_vbox->add_child(filter_enabled);
 
 	filters = memnew(Tree);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1619,7 +1619,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	onion_toggle->set_flat(true);
 	onion_toggle->set_toggle_mode(true);
 	onion_toggle->set_tooltip(TTR("Enable Onion Skinning"));
-	onion_toggle->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_onion_skinning_menu), varray(ONION_SKINNING_ENABLE));
+	onion_toggle->connect("button_clicked", callable_mp(this, &AnimationPlayerEditor::_onion_skinning_menu), varray(ONION_SKINNING_ENABLE));
 	hb->add_child(onion_toggle);
 
 	onion_skinning = memnew(MenuButton);
@@ -1646,7 +1646,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	pin->set_toggle_mode(true);
 	pin->set_tooltip(TTR("Pin AnimationPlayer"));
 	hb->add_child(pin);
-	pin->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_pin_pressed));
+	pin->connect("button_clicked", callable_mp(this, &AnimationPlayerEditor::_pin_pressed));
 
 	file = memnew(EditorFileDialog);
 	add_child(file);
@@ -1688,13 +1688,13 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	blend_editor.tree->connect("item_edited", callable_mp(this, &AnimationPlayerEditor::_blend_edited));
 
-	autoplay->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_autoplay_pressed));
+	autoplay->connect("button_clicked", callable_mp(this, &AnimationPlayerEditor::_autoplay_pressed));
 	autoplay->set_toggle_mode(true);
-	play->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_play_pressed));
-	play_from->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_play_from_pressed));
-	play_bw->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_play_bw_pressed));
-	play_bw_from->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_play_bw_from_pressed));
-	stop->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_stop_pressed));
+	play->connect("button_clicked", callable_mp(this, &AnimationPlayerEditor::_play_pressed));
+	play_from->connect("button_clicked", callable_mp(this, &AnimationPlayerEditor::_play_from_pressed));
+	play_bw->connect("button_clicked", callable_mp(this, &AnimationPlayerEditor::_play_bw_pressed));
+	play_bw_from->connect("button_clicked", callable_mp(this, &AnimationPlayerEditor::_play_bw_from_pressed));
+	stop->connect("button_clicked", callable_mp(this, &AnimationPlayerEditor::_stop_pressed));
 
 	animation->connect("item_selected", callable_mp(this, &AnimationPlayerEditor::_animation_selected));
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1222,7 +1222,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_select->set_button_group(bg);
 	tool_select->set_pressed(true);
 	tool_select->set_tooltip(TTR("Select and move nodes.\nRMB to add new nodes.\nShift+LMB to create connections."));
-	tool_select->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
+	tool_select->connect("button_clicked", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
 
 	tool_create = memnew(Button);
 	tool_create->set_flat(true);
@@ -1230,7 +1230,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	tool_create->set_tooltip(TTR("Create new nodes."));
-	tool_create->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
+	tool_create->connect("button_clicked", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
 
 	tool_connect = memnew(Button);
 	tool_connect->set_flat(true);
@@ -1238,7 +1238,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_connect->set_toggle_mode(true);
 	tool_connect->set_button_group(bg);
 	tool_connect->set_tooltip(TTR("Connect nodes."));
-	tool_connect->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
+	tool_connect->connect("button_clicked", callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), varray(), CONNECT_DEFERRED);
 
 	tool_erase_hb = memnew(HBoxContainer);
 	top_hb->add_child(tool_erase_hb);
@@ -1247,7 +1247,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_erase->set_flat(true);
 	tool_erase->set_tooltip(TTR("Remove selected node or transition."));
 	tool_erase_hb->add_child(tool_erase);
-	tool_erase->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_erase_selected));
+	tool_erase->connect("button_clicked", callable_mp(this, &AnimationNodeStateMachineEditor::_erase_selected));
 	tool_erase->set_disabled(true);
 
 	tool_erase_hb->add_child(memnew(VSeparator));
@@ -1256,14 +1256,14 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_autoplay->set_flat(true);
 	tool_autoplay->set_tooltip(TTR("Toggle autoplay this animation on start, restart or seek to zero."));
 	tool_erase_hb->add_child(tool_autoplay);
-	tool_autoplay->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_autoplay_selected));
+	tool_autoplay->connect("button_clicked", callable_mp(this, &AnimationNodeStateMachineEditor::_autoplay_selected));
 	tool_autoplay->set_disabled(true);
 
 	tool_end = memnew(Button);
 	tool_end->set_flat(true);
 	tool_end->set_tooltip(TTR("Set the end animation. This is useful for sub-transitions."));
 	tool_erase_hb->add_child(tool_end);
-	tool_end->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_end_selected));
+	tool_end->connect("button_clicked", callable_mp(this, &AnimationNodeStateMachineEditor::_end_selected));
 	tool_end->set_disabled(true);
 
 	top_hb->add_child(memnew(VSeparator));

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -84,7 +84,7 @@ void AnimationTreeEditor::_update_path() {
 	b->set_button_group(group);
 	b->set_pressed(true);
 	b->set_focus_mode(FOCUS_NONE);
-	b->connect("pressed", callable_mp(this, &AnimationTreeEditor::_path_button_pressed), varray(-1));
+	b->connect("button_clicked", callable_mp(this, &AnimationTreeEditor::_path_button_pressed), varray(-1));
 	path_hb->add_child(b);
 	for (int i = 0; i < button_path.size(); i++) {
 		b = memnew(Button);
@@ -94,7 +94,7 @@ void AnimationTreeEditor::_update_path() {
 		path_hb->add_child(b);
 		b->set_pressed(true);
 		b->set_focus_mode(FOCUS_NONE);
-		b->connect("pressed", callable_mp(this, &AnimationTreeEditor::_path_button_pressed), varray(i));
+		b->connect("button_clicked", callable_mp(this, &AnimationTreeEditor::_path_button_pressed), varray(i));
 	}
 }
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -101,7 +101,7 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 	icon = memnew(TextureButton);
 	icon->set_custom_minimum_size(Size2(64, 64) * EDSCALE);
 	icon->set_default_cursor_shape(CURSOR_POINTING_HAND);
-	icon->connect("pressed", callable_mp(this, &EditorAssetLibraryItem::_asset_clicked));
+	icon->connect("button_clicked", callable_mp(this, &EditorAssetLibraryItem::_asset_clicked));
 
 	hb->add_child(icon);
 
@@ -112,17 +112,17 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 
 	title = memnew(LinkButton);
 	title->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	title->connect("pressed", callable_mp(this, &EditorAssetLibraryItem::_asset_clicked));
+	title->connect("button_clicked", callable_mp(this, &EditorAssetLibraryItem::_asset_clicked));
 	vb->add_child(title);
 
 	category = memnew(LinkButton);
 	category->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	category->connect("pressed", callable_mp(this, &EditorAssetLibraryItem::_category_clicked));
+	category->connect("button_clicked", callable_mp(this, &EditorAssetLibraryItem::_category_clicked));
 	vb->add_child(category);
 
 	author = memnew(LinkButton);
 	author->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	author->connect("pressed", callable_mp(this, &EditorAssetLibraryItem::_author_clicked));
+	author->connect("button_clicked", callable_mp(this, &EditorAssetLibraryItem::_author_clicked));
 	vb->add_child(author);
 
 	price = memnew(Label);
@@ -242,7 +242,7 @@ void EditorAssetLibraryItemDescription::add_preview(int p_id, bool p_video, cons
 	preview.button = memnew(Button);
 	preview.button->set_icon(previews->get_theme_icon(SNAME("ThumbnailWait"), SNAME("EditorIcons")));
 	preview.button->set_toggle_mode(true);
-	preview.button->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDescription::_preview_click), varray(p_id));
+	preview.button->connect("button_clicked", callable_mp(this, &EditorAssetLibraryItemDescription::_preview_click), varray(p_id));
 	preview_hb->add_child(preview.button);
 	if (!p_video) {
 		preview.image = previews->get_theme_icon(SNAME("ThumbnailWait"), SNAME("EditorIcons"));
@@ -499,7 +499,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	title->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	dismiss = memnew(TextureButton);
-	dismiss->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDownload::_close));
+	dismiss->connect("button_clicked", callable_mp(this, &EditorAssetLibraryItemDownload::_close));
 	title_hb->add_child(dismiss);
 
 	title->set_clip_text(true);
@@ -519,11 +519,11 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	install = memnew(Button);
 	install->set_text(TTR("Install..."));
 	install->set_disabled(true);
-	install->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDownload::_install));
+	install->connect("button_clicked", callable_mp(this, &EditorAssetLibraryItemDownload::_install));
 
 	retry = memnew(Button);
 	retry->set_text(TTR("Retry"));
-	retry->connect("pressed", callable_mp(this, &EditorAssetLibraryItemDownload::_make_request));
+	retry->connect("button_clicked", callable_mp(this, &EditorAssetLibraryItemDownload::_make_request));
 	// Only show the Retry button in case of a failure.
 	retry->hide();
 
@@ -977,7 +977,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *first = memnew(Button);
 	first->set_text(TTR("First"));
 	if (p_page != 0) {
-		first->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(0));
+		first->connect("button_clicked", callable_mp(this, &EditorAssetLibrary::_search), varray(0));
 	} else {
 		first->set_disabled(true);
 		first->set_focus_mode(Control::FOCUS_NONE);
@@ -987,7 +987,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *prev = memnew(Button);
 	prev->set_text(TTR("Previous"));
 	if (p_page > 0) {
-		prev->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(p_page - 1));
+		prev->connect("button_clicked", callable_mp(this, &EditorAssetLibrary::_search), varray(p_page - 1));
 	} else {
 		prev->set_disabled(true);
 		prev->set_focus_mode(Control::FOCUS_NONE);
@@ -1008,7 +1008,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 			Button *current = memnew(Button);
 			// Add padding to make page number buttons easier to click.
 			current->set_text(vformat(" %d ", i + 1));
-			current->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(i));
+			current->connect("button_clicked", callable_mp(this, &EditorAssetLibrary::_search), varray(i));
 
 			hbc->add_child(current);
 		}
@@ -1017,7 +1017,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *next = memnew(Button);
 	next->set_text(TTR("Next"));
 	if (p_page < p_page_count - 1) {
-		next->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(p_page + 1));
+		next->connect("button_clicked", callable_mp(this, &EditorAssetLibrary::_search), varray(p_page + 1));
 	} else {
 		next->set_disabled(true);
 		next->set_focus_mode(Control::FOCUS_NONE);
@@ -1028,7 +1028,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *last = memnew(Button);
 	last->set_text(TTR("Last"));
 	if (p_page != p_page_count - 1) {
-		last->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), varray(p_page_count - 1));
+		last->connect("button_clicked", callable_mp(this, &EditorAssetLibrary::_search), varray(p_page_count - 1));
 	} else {
 		last->set_disabled(true);
 		last->set_focus_mode(Control::FOCUS_NONE);
@@ -1364,12 +1364,12 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	Button *open_asset = memnew(Button);
 	open_asset->set_text(TTR("Import..."));
 	search_hb->add_child(open_asset);
-	open_asset->connect("pressed", callable_mp(this, &EditorAssetLibrary::_asset_open));
+	open_asset->connect("button_clicked", callable_mp(this, &EditorAssetLibrary::_asset_open));
 
 	Button *plugins = memnew(Button);
 	plugins->set_text(TTR("Plugins..."));
 	search_hb->add_child(plugins);
-	plugins->connect("pressed", callable_mp(this, &EditorAssetLibrary::_manage_plugins));
+	plugins->connect("button_clicked", callable_mp(this, &EditorAssetLibrary::_manage_plugins));
 
 	if (p_templates_only) {
 		open_asset->hide();

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -231,14 +231,14 @@ AudioStreamEditor::AudioStreamEditor() {
 	_play_button->set_flat(true);
 	hbox->add_child(_play_button);
 	_play_button->set_focus_mode(Control::FOCUS_NONE);
-	_play_button->connect("pressed", callable_mp(this, &AudioStreamEditor::_play));
+	_play_button->connect("button_clicked", callable_mp(this, &AudioStreamEditor::_play));
 	_play_button->set_shortcut(ED_SHORTCUT("inspector/audio_preview_play_pause", TTR("Audio Preview Play/Pause"), Key::SPACE));
 
 	_stop_button = memnew(Button);
 	_stop_button->set_flat(true);
 	hbox->add_child(_stop_button);
 	_stop_button->set_focus_mode(Control::FOCUS_NONE);
-	_stop_button->connect("pressed", callable_mp(this, &AudioStreamEditor::_stop));
+	_stop_button->connect("button_clicked", callable_mp(this, &AudioStreamEditor::_stop));
 
 	_current_label = memnew(Label);
 	_current_label->set_align(Label::ALIGN_RIGHT);

--- a/editor/plugins/camera_3d_editor_plugin.cpp
+++ b/editor/plugins/camera_3d_editor_plugin.cpp
@@ -75,7 +75,7 @@ Camera3DEditor::Camera3DEditor() {
 	preview->set_offset(SIDE_RIGHT, 0);
 	preview->set_offset(SIDE_TOP, 0);
 	preview->set_offset(SIDE_BOTTOM, 10);
-	preview->connect("pressed", callable_mp(this, &Camera3DEditor::_pressed));
+	preview->connect("button_clicked", callable_mp(this, &Camera3DEditor::_pressed));
 }
 
 void Camera3DEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5263,7 +5263,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	select_button->set_flat(true);
 	hb->add_child(select_button);
 	select_button->set_toggle_mode(true);
-	select_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_SELECT));
+	select_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_SELECT));
 	select_button->set_pressed(true);
 	select_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/select_mode", TTR("Select Mode"), Key::Q));
 	select_button->set_shortcut_context(this);
@@ -5275,7 +5275,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	move_button->set_flat(true);
 	hb->add_child(move_button);
 	move_button->set_toggle_mode(true);
-	move_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_MOVE));
+	move_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_MOVE));
 	move_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/move_mode", TTR("Move Mode"), Key::W));
 	move_button->set_shortcut_context(this);
 	move_button->set_tooltip(TTR("Move Mode"));
@@ -5284,7 +5284,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	rotate_button->set_flat(true);
 	hb->add_child(rotate_button);
 	rotate_button->set_toggle_mode(true);
-	rotate_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_ROTATE));
+	rotate_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_ROTATE));
 	rotate_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/rotate_mode", TTR("Rotate Mode"), Key::E));
 	rotate_button->set_shortcut_context(this);
 	rotate_button->set_tooltip(TTR("Rotate Mode"));
@@ -5293,7 +5293,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	scale_button->set_flat(true);
 	hb->add_child(scale_button);
 	scale_button->set_toggle_mode(true);
-	scale_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_SCALE));
+	scale_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_SCALE));
 	scale_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/scale_mode", TTR("Scale Mode"), Key::S));
 	scale_button->set_shortcut_context(this);
 	scale_button->set_tooltip(TTR("Scale Mode"));
@@ -5304,21 +5304,21 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	list_select_button->set_flat(true);
 	hb->add_child(list_select_button);
 	list_select_button->set_toggle_mode(true);
-	list_select_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_LIST_SELECT));
+	list_select_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_LIST_SELECT));
 	list_select_button->set_tooltip(TTR("Show list of selectable nodes at position clicked."));
 
 	pivot_button = memnew(Button);
 	pivot_button->set_flat(true);
 	hb->add_child(pivot_button);
 	pivot_button->set_toggle_mode(true);
-	pivot_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_EDIT_PIVOT));
+	pivot_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_EDIT_PIVOT));
 	pivot_button->set_tooltip(TTR("Click to change object's rotation pivot."));
 
 	pan_button = memnew(Button);
 	pan_button->set_flat(true);
 	hb->add_child(pan_button);
 	pan_button->set_toggle_mode(true);
-	pan_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_PAN));
+	pan_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_PAN));
 	pan_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/pan_mode", TTR("Pan Mode"), Key::G));
 	pan_button->set_shortcut_context(this);
 	pan_button->set_tooltip(TTR("You can also use Pan View shortcut (Space by default) to pan in any mode."));
@@ -5327,7 +5327,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	ruler_button->set_flat(true);
 	hb->add_child(ruler_button);
 	ruler_button->set_toggle_mode(true);
-	ruler_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_RULER));
+	ruler_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_button_tool_select), make_binds(TOOL_RULER));
 	ruler_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/ruler_mode", TTR("Ruler Mode"), Key::R));
 	ruler_button->set_shortcut_context(this);
 	ruler_button->set_tooltip(TTR("Ruler Mode"));
@@ -5338,7 +5338,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	smart_snap_button->set_flat(true);
 	hb->add_child(smart_snap_button);
 	smart_snap_button->set_toggle_mode(true);
-	smart_snap_button->connect("toggled", callable_mp(this, &CanvasItemEditor::_button_toggle_smart_snap));
+	smart_snap_button->connect("button_toggled", callable_mp(this, &CanvasItemEditor::_button_toggle_smart_snap));
 	smart_snap_button->set_tooltip(TTR("Toggle smart snapping."));
 	smart_snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_smart_snap", TTR("Use Smart Snap"), KeyModifierMask::SHIFT | Key::S));
 	smart_snap_button->set_shortcut_context(this);
@@ -5347,7 +5347,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	grid_snap_button->set_flat(true);
 	hb->add_child(grid_snap_button);
 	grid_snap_button->set_toggle_mode(true);
-	grid_snap_button->connect("toggled", callable_mp(this, &CanvasItemEditor::_button_toggle_grid_snap));
+	grid_snap_button->connect("button_toggled", callable_mp(this, &CanvasItemEditor::_button_toggle_grid_snap));
 	grid_snap_button->set_tooltip(TTR("Toggle grid snapping."));
 	grid_snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_grid_snap", TTR("Use Grid Snap"), KeyModifierMask::SHIFT | Key::G));
 	grid_snap_button->set_shortcut_context(this);
@@ -5389,7 +5389,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	lock_button->set_flat(true);
 	hb->add_child(lock_button);
 
-	lock_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(LOCK_SELECTED));
+	lock_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(LOCK_SELECTED));
 	lock_button->set_tooltip(TTR("Lock selected node, preventing selection and movement."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
 	lock_button->set_shortcut(ED_SHORTCUT("editor/lock_selected_nodes", TTR("Lock Selected Node(s)"), KeyModifierMask::CMD | Key::L));
@@ -5397,7 +5397,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	unlock_button = memnew(Button);
 	unlock_button->set_flat(true);
 	hb->add_child(unlock_button);
-	unlock_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(UNLOCK_SELECTED));
+	unlock_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(UNLOCK_SELECTED));
 	unlock_button->set_tooltip(TTR("Unlock selected node, allowing selection and movement."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
 	unlock_button->set_shortcut(ED_SHORTCUT("editor/unlock_selected_nodes", TTR("Unlock Selected Node(s)"), KeyModifierMask::CMD | KeyModifierMask::SHIFT | Key::L));
@@ -5405,7 +5405,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	group_button = memnew(Button);
 	group_button->set_flat(true);
 	hb->add_child(group_button);
-	group_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(GROUP_SELECTED));
+	group_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(GROUP_SELECTED));
 	group_button->set_tooltip(TTR("Makes sure the object's children are not selectable."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
 	group_button->set_shortcut(ED_SHORTCUT("editor/group_selected_nodes", TTR("Group Selected Node(s)"), KeyModifierMask::CMD | Key::G));
@@ -5413,7 +5413,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	ungroup_button = memnew(Button);
 	ungroup_button->set_flat(true);
 	hb->add_child(ungroup_button);
-	ungroup_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(UNGROUP_SELECTED));
+	ungroup_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(UNGROUP_SELECTED));
 	ungroup_button->set_tooltip(TTR("Restores the object's children's ability to be selected."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
 	ungroup_button->set_shortcut(ED_SHORTCUT("editor/ungroup_selected_nodes", TTR("Ungroup Selected Node(s)"), KeyModifierMask::CMD | KeyModifierMask::SHIFT | Key::G));
@@ -5438,7 +5438,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	override_camera_button = memnew(Button);
 	override_camera_button->set_flat(true);
 	hb->add_child(override_camera_button);
-	override_camera_button->connect("toggled", callable_mp(this, &CanvasItemEditor::_button_override_camera));
+	override_camera_button->connect("button_toggled", callable_mp(this, &CanvasItemEditor::_button_override_camera));
 	override_camera_button->set_toggle_mode(true);
 	override_camera_button->set_disabled(true);
 	_update_override_camera_button(false);
@@ -5501,7 +5501,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	hbc_context_menu->add_child(anchor_mode_button);
 	anchor_mode_button->set_toggle_mode(true);
 	anchor_mode_button->hide();
-	anchor_mode_button->connect("toggled", callable_mp(this, &CanvasItemEditor::_button_toggle_anchor_mode));
+	anchor_mode_button->connect("button_toggled", callable_mp(this, &CanvasItemEditor::_button_toggle_anchor_mode));
 
 	animation_hb = memnew(HBoxContainer);
 	hbc_context_menu->add_child(animation_hb);
@@ -5513,7 +5513,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	key_loc_button->set_toggle_mode(true);
 	key_loc_button->set_pressed(true);
 	key_loc_button->set_focus_mode(FOCUS_NONE);
-	key_loc_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_POS));
+	key_loc_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_POS));
 	key_loc_button->set_tooltip(TTR("Translation mask for inserting keys."));
 	animation_hb->add_child(key_loc_button);
 
@@ -5522,7 +5522,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	key_rot_button->set_toggle_mode(true);
 	key_rot_button->set_pressed(true);
 	key_rot_button->set_focus_mode(FOCUS_NONE);
-	key_rot_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_ROT));
+	key_rot_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_ROT));
 	key_rot_button->set_tooltip(TTR("Rotation mask for inserting keys."));
 	animation_hb->add_child(key_rot_button);
 
@@ -5530,14 +5530,14 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	key_scale_button->set_flat(true);
 	key_scale_button->set_toggle_mode(true);
 	key_scale_button->set_focus_mode(FOCUS_NONE);
-	key_scale_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_SCALE));
+	key_scale_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_SCALE));
 	key_scale_button->set_tooltip(TTR("Scale mask for inserting keys."));
 	animation_hb->add_child(key_scale_button);
 
 	key_insert_button = memnew(Button);
 	key_insert_button->set_flat(true);
 	key_insert_button->set_focus_mode(FOCUS_NONE);
-	key_insert_button->connect("pressed", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_KEY));
+	key_insert_button->connect("button_clicked", callable_mp(this, &CanvasItemEditor::_popup_callback), varray(ANIM_INSERT_KEY));
 	key_insert_button->set_tooltip(TTR("Insert keys (based on mask)."));
 	key_insert_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/anim_insert_key", TTR("Insert Key"), Key::INSERT));
 	key_insert_button->set_shortcut_context(this);
@@ -6121,7 +6121,7 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 		CheckBox *check = memnew(CheckBox);
 		btn_group->add_child(check);
 		check->set_text(texture_node_types[i]);
-		check->connect("button_down", callable_mp(this, &CanvasItemEditorViewport::_on_select_type), varray(check));
+		check->connect("button_pressed", callable_mp(this, &CanvasItemEditorViewport::_on_select_type), varray(check));
 		check->set_button_group(button_group);
 	}
 

--- a/editor/plugins/collision_polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_3d_editor_plugin.cpp
@@ -502,13 +502,13 @@ CollisionPolygon3DEditor::CollisionPolygon3DEditor(EditorNode *p_editor) {
 	button_create = memnew(Button);
 	button_create->set_flat(true);
 	add_child(button_create);
-	button_create->connect("pressed", callable_mp(this, &CollisionPolygon3DEditor::_menu_option), varray(MODE_CREATE));
+	button_create->connect("button_clicked", callable_mp(this, &CollisionPolygon3DEditor::_menu_option), varray(MODE_CREATE));
 	button_create->set_toggle_mode(true);
 
 	button_edit = memnew(Button);
 	button_edit->set_flat(true);
 	add_child(button_edit);
-	button_edit->connect("pressed", callable_mp(this, &CollisionPolygon3DEditor::_menu_option), varray(MODE_EDIT));
+	button_edit->connect("button_clicked", callable_mp(this, &CollisionPolygon3DEditor::_menu_option), varray(MODE_EDIT));
 	button_edit->set_toggle_mode(true);
 
 	mode = MODE_EDIT;

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -176,7 +176,7 @@ GPUParticlesCollisionSDFEditorPlugin::GPUParticlesCollisionSDFEditorPlugin(Edito
 	bake->set_flat(true);
 	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake SDF"));
-	bake->connect("pressed", callable_mp(this, &GPUParticlesCollisionSDFEditorPlugin::_bake));
+	bake->connect("button_clicked", callable_mp(this, &GPUParticlesCollisionSDFEditorPlugin::_bake));
 	bake_hb->add_child(bake);
 	bake_info = memnew(Label);
 	bake_info->set_h_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -125,7 +125,7 @@ void EditorInspectorPluginGradient::parse_begin(Object *p_object) {
 
 	add_custom_control(gradient_tools_hbox);
 
-	reverse_btn->connect("pressed", callable_mp(this, &EditorInspectorPluginGradient::_reverse_button_pressed));
+	reverse_btn->connect("button_clicked", callable_mp(this, &EditorInspectorPluginGradient::_reverse_button_pressed));
 	reverse_btn->set_tooltip(TTR("Reverse/mirror gradient."));
 }
 

--- a/editor/plugins/input_event_editor_plugin.cpp
+++ b/editor/plugins/input_event_editor_plugin.cpp
@@ -87,7 +87,7 @@ InputEventConfigContainer::InputEventConfigContainer() {
 
 	open_config_button = memnew(Button);
 	open_config_button->set_text(TTR("Configure"));
-	open_config_button->connect("pressed", callable_mp(this, &InputEventConfigContainer::_configure_pressed));
+	open_config_button->connect("button_clicked", callable_mp(this, &InputEventConfigContainer::_configure_pressed));
 	hb->add_child(open_config_button);
 
 	input_event_text = memnew(Label);

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -122,7 +122,7 @@ LightmapGIEditorPlugin::LightmapGIEditorPlugin(EditorNode *p_node) {
 	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake Lightmaps"));
 	bake->hide();
-	bake->connect("pressed", Callable(this, "_bake"));
+	bake->connect("button_clicked", Callable(this, "_bake"));
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, bake);
 	lightmap = nullptr;
 

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -165,13 +165,13 @@ MaterialEditor::MaterialEditor() {
 	sphere_switch->set_toggle_mode(true);
 	sphere_switch->set_pressed(true);
 	vb_shape->add_child(sphere_switch);
-	sphere_switch->connect("pressed", callable_mp(this, &MaterialEditor::_button_pressed), varray(sphere_switch));
+	sphere_switch->connect("button_clicked", callable_mp(this, &MaterialEditor::_button_pressed), varray(sphere_switch));
 
 	box_switch = memnew(TextureButton);
 	box_switch->set_toggle_mode(true);
 	box_switch->set_pressed(false);
 	vb_shape->add_child(box_switch);
-	box_switch->connect("pressed", callable_mp(this, &MaterialEditor::_button_pressed), varray(box_switch));
+	box_switch->connect("button_clicked", callable_mp(this, &MaterialEditor::_button_pressed), varray(box_switch));
 
 	hb->add_spacer();
 
@@ -181,12 +181,12 @@ MaterialEditor::MaterialEditor() {
 	light_1_switch = memnew(TextureButton);
 	light_1_switch->set_toggle_mode(true);
 	vb_light->add_child(light_1_switch);
-	light_1_switch->connect("pressed", callable_mp(this, &MaterialEditor::_button_pressed), varray(light_1_switch));
+	light_1_switch->connect("button_clicked", callable_mp(this, &MaterialEditor::_button_pressed), varray(light_1_switch));
 
 	light_2_switch = memnew(TextureButton);
 	light_2_switch->set_toggle_mode(true);
 	vb_light->add_child(light_2_switch);
-	light_2_switch->connect("pressed", callable_mp(this, &MaterialEditor::_button_pressed), varray(light_2_switch));
+	light_2_switch->connect("button_clicked", callable_mp(this, &MaterialEditor::_button_pressed), varray(light_2_switch));
 
 	first_enter = true;
 

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -145,12 +145,12 @@ MeshEditor::MeshEditor() {
 	light_1_switch = memnew(TextureButton);
 	light_1_switch->set_toggle_mode(true);
 	vb_light->add_child(light_1_switch);
-	light_1_switch->connect("pressed", callable_mp(this, &MeshEditor::_button_pressed), varray(light_1_switch));
+	light_1_switch->connect("button_clicked", callable_mp(this, &MeshEditor::_button_pressed), varray(light_1_switch));
 
 	light_2_switch = memnew(TextureButton);
 	light_2_switch->set_toggle_mode(true);
 	vb_light->add_child(light_2_switch);
-	light_2_switch->connect("pressed", callable_mp(this, &MeshEditor::_button_pressed), varray(light_2_switch));
+	light_2_switch->connect("button_clicked", callable_mp(this, &MeshEditor::_button_pressed), varray(light_2_switch));
 
 	first_enter = true;
 

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -283,12 +283,12 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 	editor = p_editor;
 	cd_remove = memnew(ConfirmationDialog);
 	add_child(cd_remove);
-	cd_remove->get_ok_button()->connect("pressed", callable_mp(this, &MeshLibraryEditor::_menu_remove_confirm));
+	cd_remove->get_ok_button()->connect("button_clicked", callable_mp(this, &MeshLibraryEditor::_menu_remove_confirm));
 	cd_update = memnew(ConfirmationDialog);
 	add_child(cd_update);
 	cd_update->get_ok_button()->set_text("Apply without Transforms");
-	cd_update->get_ok_button()->connect("pressed", callable_mp(this, &MeshLibraryEditor::_menu_update_confirm), varray(false));
-	cd_update->add_button("Apply with Transforms")->connect("pressed", callable_mp(this, &MeshLibraryEditor::_menu_update_confirm), varray(true));
+	cd_update->get_ok_button()->connect("button_clicked", callable_mp(this, &MeshLibraryEditor::_menu_update_confirm), varray(false));
+	cd_update->add_button("Apply with Transforms")->connect("button_clicked", callable_mp(this, &MeshLibraryEditor::_menu_update_confirm), varray(true));
 }
 
 void MeshLibraryEditorPlugin::edit(Object *p_node) {

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -289,7 +289,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	Button *b = memnew(Button);
 	hbc->add_child(b);
 	b->set_text("..");
-	b->connect("pressed", callable_mp(this, &MultiMeshEditor::_browse), make_binds(false));
+	b->connect("button_clicked", callable_mp(this, &MultiMeshEditor::_browse), make_binds(false));
 
 	vbc->add_margin_child(TTR("Target Surface:"), hbc);
 
@@ -301,7 +301,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	hbc->add_child(b);
 	b->set_text("..");
 	vbc->add_margin_child(TTR("Source Mesh:"), hbc);
-	b->connect("pressed", callable_mp(this, &MultiMeshEditor::_browse), make_binds(true));
+	b->connect("button_clicked", callable_mp(this, &MultiMeshEditor::_browse), make_binds(true));
 
 	populate_axis = memnew(OptionButton);
 	populate_axis->add_item(TTR("X-Axis"));
@@ -347,7 +347,7 @@ MultiMeshEditor::MultiMeshEditor() {
 
 	populate_dialog->get_ok_button()->set_text(TTR("Populate"));
 
-	populate_dialog->get_ok_button()->connect("pressed", callable_mp(this, &MultiMeshEditor::_populate));
+	populate_dialog->get_ok_button()->connect("button_clicked", callable_mp(this, &MultiMeshEditor::_populate));
 	std = memnew(SceneTreeDialog);
 	populate_dialog->add_child(std);
 	std->connect("selected", callable_mp(this, &MultiMeshEditor::_browsed));

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3486,10 +3486,10 @@ void Node3DEditorViewport::_set_auto_orthogonal() {
 }
 
 void Node3DEditorViewport::_preview_exited_scene() {
-	preview_camera->disconnect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	preview_camera->disconnect("button_toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
 	preview_camera->set_pressed(false);
 	_toggle_camera_preview(false);
-	preview_camera->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	preview_camera->connect("button_toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
 	view_menu->show();
 }
 
@@ -3813,7 +3813,7 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 	}
 
 	if (preview_camera->is_connected("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview))) {
-		preview_camera->disconnect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+		preview_camera->disconnect("button_toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
 	}
 	if (p_state.has("previewing")) {
 		Node *pv = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["previewing"]);
@@ -3826,7 +3826,7 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 			preview_camera->show();
 		}
 	}
-	preview_camera->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	preview_camera->connect("button_toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
 }
 
 Dictionary Node3DEditorViewport::get_state() const {
@@ -4409,7 +4409,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	vbox->add_child(preview_camera);
 	preview_camera->set_h_size_flags(0);
 	preview_camera->hide();
-	preview_camera->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	preview_camera->connect("button_toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
 	previewing = nullptr;
 	gizmo_scale = 1.0;
 
@@ -7240,7 +7240,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SELECT]->set_flat(true);
 	tool_button[TOOL_MODE_SELECT]->set_pressed(true);
 	button_binds.write[0] = MENU_TOOL_SELECT;
-	tool_button[TOOL_MODE_SELECT]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
+	tool_button[TOOL_MODE_SELECT]->connect("button_clicked", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_SELECT]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_select", TTR("Select Mode"), Key::Q));
 	tool_button[TOOL_MODE_SELECT]->set_shortcut_context(this);
 	tool_button[TOOL_MODE_SELECT]->set_tooltip(keycode_get_string((Key)KeyModifierMask::CMD) + TTR("Drag: Rotate selected node around pivot.") + "\n" + TTR("Alt+RMB: Show list of all nodes at position clicked, including locked."));
@@ -7251,7 +7251,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_MOVE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_MOVE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_MOVE;
-	tool_button[TOOL_MODE_MOVE]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
+	tool_button[TOOL_MODE_MOVE]->connect("button_clicked", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_MOVE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_move", TTR("Move Mode"), Key::W));
 	tool_button[TOOL_MODE_MOVE]->set_shortcut_context(this);
 
@@ -7260,7 +7260,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_ROTATE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_ROTATE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_ROTATE;
-	tool_button[TOOL_MODE_ROTATE]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
+	tool_button[TOOL_MODE_ROTATE]->connect("button_clicked", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_ROTATE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_rotate", TTR("Rotate Mode"), Key::E));
 	tool_button[TOOL_MODE_ROTATE]->set_shortcut_context(this);
 
@@ -7269,7 +7269,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SCALE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_SCALE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_SCALE;
-	tool_button[TOOL_MODE_SCALE]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
+	tool_button[TOOL_MODE_SCALE]->connect("button_clicked", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_SCALE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_scale", TTR("Scale Mode"), Key::R));
 	tool_button[TOOL_MODE_SCALE]->set_shortcut_context(this);
 
@@ -7280,14 +7280,14 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_LIST_SELECT]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_LIST_SELECT;
-	tool_button[TOOL_MODE_LIST_SELECT]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
+	tool_button[TOOL_MODE_LIST_SELECT]->connect("button_clicked", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_tooltip(TTR("Show list of selectable nodes at position clicked."));
 
 	tool_button[TOOL_LOCK_SELECTED] = memnew(Button);
 	hbc_menu->add_child(tool_button[TOOL_LOCK_SELECTED]);
 	tool_button[TOOL_LOCK_SELECTED]->set_flat(true);
 	button_binds.write[0] = MENU_LOCK_SELECTED;
-	tool_button[TOOL_LOCK_SELECTED]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
+	tool_button[TOOL_LOCK_SELECTED]->connect("button_clicked", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_LOCK_SELECTED]->set_tooltip(TTR("Lock selected node, preventing selection and movement."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
 	tool_button[TOOL_LOCK_SELECTED]->set_shortcut(ED_SHORTCUT("editor/lock_selected_nodes", TTR("Lock Selected Node(s)"), KeyModifierMask::CMD | Key::L));
@@ -7296,7 +7296,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(tool_button[TOOL_UNLOCK_SELECTED]);
 	tool_button[TOOL_UNLOCK_SELECTED]->set_flat(true);
 	button_binds.write[0] = MENU_UNLOCK_SELECTED;
-	tool_button[TOOL_UNLOCK_SELECTED]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
+	tool_button[TOOL_UNLOCK_SELECTED]->connect("button_clicked", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_UNLOCK_SELECTED]->set_tooltip(TTR("Unlock selected node, allowing selection and movement."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
 	tool_button[TOOL_UNLOCK_SELECTED]->set_shortcut(ED_SHORTCUT("editor/unlock_selected_nodes", TTR("Unlock Selected Node(s)"), KeyModifierMask::CMD | KeyModifierMask::SHIFT | Key::L));
@@ -7305,7 +7305,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(tool_button[TOOL_GROUP_SELECTED]);
 	tool_button[TOOL_GROUP_SELECTED]->set_flat(true);
 	button_binds.write[0] = MENU_GROUP_SELECTED;
-	tool_button[TOOL_GROUP_SELECTED]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
+	tool_button[TOOL_GROUP_SELECTED]->connect("button_clicked", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_GROUP_SELECTED]->set_tooltip(TTR("Makes sure the object's children are not selectable."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
 	tool_button[TOOL_GROUP_SELECTED]->set_shortcut(ED_SHORTCUT("editor/group_selected_nodes", TTR("Group Selected Node(s)"), KeyModifierMask::CMD | Key::G));
@@ -7314,7 +7314,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(tool_button[TOOL_UNGROUP_SELECTED]);
 	tool_button[TOOL_UNGROUP_SELECTED]->set_flat(true);
 	button_binds.write[0] = MENU_UNGROUP_SELECTED;
-	tool_button[TOOL_UNGROUP_SELECTED]->connect("pressed", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
+	tool_button[TOOL_UNGROUP_SELECTED]->connect("button_clicked", callable_mp(this, &Node3DEditor::_menu_item_pressed), button_binds);
 	tool_button[TOOL_UNGROUP_SELECTED]->set_tooltip(TTR("Restores the object's children's ability to be selected."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
 	tool_button[TOOL_UNGROUP_SELECTED]->set_shortcut(ED_SHORTCUT("editor/ungroup_selected_nodes", TTR("Ungroup Selected Node(s)"), KeyModifierMask::CMD | KeyModifierMask::SHIFT | Key::G));
@@ -7326,7 +7326,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_LOCAL_COORDS;
-	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect("toggled", callable_mp(this, &Node3DEditor::_menu_item_toggled), button_binds);
+	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect("button_toggled", callable_mp(this, &Node3DEditor::_menu_item_toggled), button_binds);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_shortcut(ED_SHORTCUT("spatial_editor/local_coords", TTR("Use Local Space"), Key::T));
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_shortcut_context(this);
 
@@ -7335,7 +7335,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_USE_SNAP;
-	tool_option_button[TOOL_OPT_USE_SNAP]->connect("toggled", callable_mp(this, &Node3DEditor::_menu_item_toggled), button_binds);
+	tool_option_button[TOOL_OPT_USE_SNAP]->connect("button_toggled", callable_mp(this, &Node3DEditor::_menu_item_toggled), button_binds);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_shortcut(ED_SHORTCUT("spatial_editor/snap", TTR("Use Snap"), Key::Y));
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_shortcut_context(this);
 
@@ -7347,7 +7347,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->set_flat(true);
 	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->set_disabled(true);
 	button_binds.write[0] = MENU_TOOL_OVERRIDE_CAMERA;
-	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->connect("toggled", callable_mp(this, &Node3DEditor::_menu_item_toggled), button_binds);
+	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->connect("button_toggled", callable_mp(this, &Node3DEditor::_menu_item_toggled), button_binds);
 	_update_camera_override_button(false);
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -7355,7 +7355,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	sun_button->set_tooltip(TTR("Toggle preview sunlight.\nIf a DirectionalLight3D node is added to the scene, preview sunlight is disabled."));
 	sun_button->set_toggle_mode(true);
 	sun_button->set_flat(true);
-	sun_button->connect("pressed", callable_mp(this, &Node3DEditor::_update_preview_environment), varray(), CONNECT_DEFERRED);
+	sun_button->connect("button_clicked", callable_mp(this, &Node3DEditor::_update_preview_environment), varray(), CONNECT_DEFERRED);
 	sun_button->set_disabled(true);
 
 	hbc_menu->add_child(sun_button);
@@ -7364,7 +7364,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	environ_button->set_tooltip(TTR("Toggle preview environment.\nIf a WorldEnvironment node is added to the scene, preview environment is disabled."));
 	environ_button->set_toggle_mode(true);
 	environ_button->set_flat(true);
-	environ_button->connect("pressed", callable_mp(this, &Node3DEditor::_update_preview_environment), varray(), CONNECT_DEFERRED);
+	environ_button->connect("button_clicked", callable_mp(this, &Node3DEditor::_update_preview_environment), varray(), CONNECT_DEFERRED);
 	environ_button->set_disabled(true);
 
 	hbc_menu->add_child(environ_button);
@@ -7372,7 +7372,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	sun_environ_settings = memnew(Button);
 	sun_environ_settings->set_tooltip(TTR("Edit Sun and Environment settings."));
 	sun_environ_settings->set_flat(true);
-	sun_environ_settings->connect("pressed", callable_mp(this, &Node3DEditor::_sun_environ_settings_pressed));
+	sun_environ_settings->connect("button_clicked", callable_mp(this, &Node3DEditor::_sun_environ_settings_pressed));
 
 	hbc_menu->add_child(sun_environ_settings);
 
@@ -7503,7 +7503,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	snap_dialog->set_title(TTR("Snap Settings"));
 	add_child(snap_dialog);
 	snap_dialog->connect("confirmed", callable_mp(this, &Node3DEditor::_snap_changed));
-	snap_dialog->get_cancel_button()->connect("pressed", callable_mp(this, &Node3DEditor::_snap_update));
+	snap_dialog->get_cancel_button()->connect("button_clicked", callable_mp(this, &Node3DEditor::_snap_update));
 
 	VBoxContainer *snap_dialog_vbc = memnew(VBoxContainer);
 	snap_dialog->add_child(snap_dialog_vbc);
@@ -7726,7 +7726,7 @@ void fragment() {
 		sun_add_to_scene = memnew(Button);
 		sun_add_to_scene->set_text(TTR("Add Sun to Scene"));
 		sun_add_to_scene->set_tooltip(TTR("Adds a DirectionalLight3D node matching the preview sun settings to the current scene.\nHold Shift while clicking to also add the preview environment to the current scene."));
-		sun_add_to_scene->connect("pressed", callable_mp(this, &Node3DEditor::_add_sun_to_scene), varray(false));
+		sun_add_to_scene->connect("button_clicked", callable_mp(this, &Node3DEditor::_add_sun_to_scene), varray(false));
 		sun_vb->add_spacer();
 		sun_vb->add_child(sun_add_to_scene);
 
@@ -7771,29 +7771,29 @@ void fragment() {
 		environ_ao_button = memnew(Button);
 		environ_ao_button->set_text(TTR("AO"));
 		environ_ao_button->set_toggle_mode(true);
-		environ_ao_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), varray(), CONNECT_DEFERRED);
+		environ_ao_button->connect("button_clicked", callable_mp(this, &Node3DEditor::_preview_settings_changed), varray(), CONNECT_DEFERRED);
 		fx_vb->add_child(environ_ao_button);
 		environ_glow_button = memnew(Button);
 		environ_glow_button->set_text(TTR("Glow"));
 		environ_glow_button->set_toggle_mode(true);
-		environ_glow_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), varray(), CONNECT_DEFERRED);
+		environ_glow_button->connect("button_clicked", callable_mp(this, &Node3DEditor::_preview_settings_changed), varray(), CONNECT_DEFERRED);
 		fx_vb->add_child(environ_glow_button);
 		environ_tonemap_button = memnew(Button);
 		environ_tonemap_button->set_text(TTR("Tonemap"));
 		environ_tonemap_button->set_toggle_mode(true);
-		environ_tonemap_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), varray(), CONNECT_DEFERRED);
+		environ_tonemap_button->connect("button_clicked", callable_mp(this, &Node3DEditor::_preview_settings_changed), varray(), CONNECT_DEFERRED);
 		fx_vb->add_child(environ_tonemap_button);
 		environ_gi_button = memnew(Button);
 		environ_gi_button->set_text(TTR("GI"));
 		environ_gi_button->set_toggle_mode(true);
-		environ_gi_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), varray(), CONNECT_DEFERRED);
+		environ_gi_button->connect("button_clicked", callable_mp(this, &Node3DEditor::_preview_settings_changed), varray(), CONNECT_DEFERRED);
 		fx_vb->add_child(environ_gi_button);
 		environ_vb->add_margin_child(TTR("Post Process"), fx_vb);
 
 		environ_add_to_scene = memnew(Button);
 		environ_add_to_scene->set_text(TTR("Add Environment to Scene"));
 		environ_add_to_scene->set_tooltip(TTR("Adds a WorldEnvironment node matching the preview environment settings to the current scene.\nHold Shift while clicking to also add the preview sun to the current scene."));
-		environ_add_to_scene->connect("pressed", callable_mp(this, &Node3DEditor::_add_environment_to_scene), varray(false));
+		environ_add_to_scene->connect("button_clicked", callable_mp(this, &Node3DEditor::_add_environment_to_scene), varray(false));
 		environ_vb->add_spacer();
 		environ_vb->add_child(environ_add_to_scene);
 

--- a/editor/plugins/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.cpp
@@ -101,7 +101,7 @@ OccluderInstance3DEditorPlugin::OccluderInstance3DEditorPlugin(EditorNode *p_nod
 	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake Occluders"));
 	bake->hide();
-	bake->connect("pressed", Callable(this, "_bake"));
+	bake->connect("button_clicked", Callable(this, "_bake"));
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, bake);
 	occluder_instance = nullptr;
 

--- a/editor/plugins/ot_features_plugin.cpp
+++ b/editor/plugins/ot_features_plugin.cpp
@@ -87,7 +87,7 @@ OpenTypeFeaturesEditor::OpenTypeFeaturesEditor() {
 	button->set_flat(true);
 	bc->add_child(button);
 
-	button->connect("pressed", callable_mp(this, &OpenTypeFeaturesEditor::_remove_feature));
+	button->connect("button_clicked", callable_mp(this, &OpenTypeFeaturesEditor::_remove_feature));
 
 	setting = false;
 }
@@ -172,7 +172,7 @@ OpenTypeFeaturesAdd::OpenTypeFeaturesAdd() {
 	button->set_tooltip(RTR("Add feature..."));
 	add_child(button);
 
-	button->connect("pressed", callable_mp(this, &OpenTypeFeaturesAdd::_features_menu));
+	button->connect("button_clicked", callable_mp(this, &OpenTypeFeaturesAdd::_features_menu));
 	menu->connect("id_pressed", callable_mp(this, &OpenTypeFeaturesAdd::_add_feature));
 	menu_cv->connect("id_pressed", callable_mp(this, &OpenTypeFeaturesAdd::_add_feature));
 	menu_ss->connect("id_pressed", callable_mp(this, &OpenTypeFeaturesAdd::_add_feature));

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -538,7 +538,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	curve_edit->set_toggle_mode(true);
 	curve_edit->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit->set_tooltip(TTR("Select Points") + "\n" + TTR("Shift+Drag: Select Control Points") + "\n" + keycode_get_string((Key)KeyModifierMask::CMD) + TTR("Click: Add Point") + "\n" + TTR("Left Click: Split Segment (in curve)") + "\n" + TTR("Right Click: Delete Point"));
-	curve_edit->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_EDIT));
+	curve_edit->connect("button_clicked", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_EDIT));
 	base_hb->add_child(curve_edit);
 	curve_edit_curve = memnew(Button);
 	curve_edit_curve->set_flat(true);
@@ -546,7 +546,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	curve_edit_curve->set_toggle_mode(true);
 	curve_edit_curve->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit_curve->set_tooltip(TTR("Select Control Points (Shift+Drag)"));
-	curve_edit_curve->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_EDIT_CURVE));
+	curve_edit_curve->connect("button_clicked", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_EDIT_CURVE));
 	base_hb->add_child(curve_edit_curve);
 	curve_create = memnew(Button);
 	curve_create->set_flat(true);
@@ -554,7 +554,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	curve_create->set_toggle_mode(true);
 	curve_create->set_focus_mode(Control::FOCUS_NONE);
 	curve_create->set_tooltip(TTR("Add Point (in empty space)"));
-	curve_create->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_CREATE));
+	curve_create->connect("button_clicked", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_CREATE));
 	base_hb->add_child(curve_create);
 	curve_del = memnew(Button);
 	curve_del->set_flat(true);
@@ -562,14 +562,14 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	curve_del->set_toggle_mode(true);
 	curve_del->set_focus_mode(Control::FOCUS_NONE);
 	curve_del->set_tooltip(TTR("Delete Point"));
-	curve_del->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_DELETE));
+	curve_del->connect("button_clicked", callable_mp(this, &Path2DEditor::_mode_selected), varray(MODE_DELETE));
 	base_hb->add_child(curve_del);
 	curve_close = memnew(Button);
 	curve_close->set_flat(true);
 	curve_close->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CurveClose"), SNAME("EditorIcons")));
 	curve_close->set_focus_mode(Control::FOCUS_NONE);
 	curve_close->set_tooltip(TTR("Close Curve"));
-	curve_close->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected), varray(ACTION_CLOSE));
+	curve_close->connect("button_clicked", callable_mp(this, &Path2DEditor::_mode_selected), varray(ACTION_CLOSE));
 	base_hb->add_child(curve_close);
 
 	PopupMenu *menu;

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -541,10 +541,10 @@ void Path3DEditorPlugin::_handle_option_pressed(int p_option) {
 
 void Path3DEditorPlugin::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		curve_create->connect("pressed", callable_mp(this, &Path3DEditorPlugin::_mode_changed), make_binds(0));
-		curve_edit->connect("pressed", callable_mp(this, &Path3DEditorPlugin::_mode_changed), make_binds(1));
-		curve_del->connect("pressed", callable_mp(this, &Path3DEditorPlugin::_mode_changed), make_binds(2));
-		curve_close->connect("pressed", callable_mp(this, &Path3DEditorPlugin::_close_curve));
+		curve_create->connect("button_clicked", callable_mp(this, &Path3DEditorPlugin::_mode_changed), make_binds(0));
+		curve_edit->connect("button_clicked", callable_mp(this, &Path3DEditorPlugin::_mode_changed), make_binds(1));
+		curve_del->connect("button_clicked", callable_mp(this, &Path3DEditorPlugin::_mode_changed), make_binds(2));
+		curve_close->connect("button_clicked", callable_mp(this, &Path3DEditorPlugin::_close_curve));
 	}
 }
 

--- a/editor/plugins/physical_bone_3d_editor_plugin.cpp
+++ b/editor/plugins/physical_bone_3d_editor_plugin.cpp
@@ -63,7 +63,7 @@ PhysicalBone3DEditor::PhysicalBone3DEditor(EditorNode *p_editor) :
 	button_transform_joint->set_text(TTR("Move Joint"));
 	button_transform_joint->set_icon(Node3DEditor::get_singleton()->get_theme_icon(SNAME("PhysicalBone3D"), SNAME("EditorIcons")));
 	button_transform_joint->set_toggle_mode(true);
-	button_transform_joint->connect("toggled", callable_mp(this, &PhysicalBone3DEditor::_on_toggle_button_transform_joint));
+	button_transform_joint->connect("button_toggled", callable_mp(this, &PhysicalBone3DEditor::_on_toggle_button_transform_joint));
 
 	hide();
 }

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -183,7 +183,7 @@ void Polygon2DEditor::_update_bone_list() {
 			cb->set_pressed(true);
 		}
 
-		cb->connect("pressed", callable_mp(this, &Polygon2DEditor::_bone_paint_selected), varray(i));
+		cb->connect("button_clicked", callable_mp(this, &Polygon2DEditor::_bone_paint_selected), varray(i));
 	}
 
 	uv_edit_draw->update();
@@ -1219,7 +1219,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	button_uv->set_flat(true);
 	add_child(button_uv);
 	button_uv->set_tooltip(TTR("Open Polygon 2D UV editor."));
-	button_uv->connect("pressed", callable_mp(this, &Polygon2DEditor::_menu_option), varray(MODE_EDIT_UV));
+	button_uv->connect("button_clicked", callable_mp(this, &Polygon2DEditor::_menu_option), varray(MODE_EDIT_UV));
 
 	uv_mode = UV_MODE_EDIT_POINT;
 	uv_edit = memnew(AcceptDialog);
@@ -1257,10 +1257,10 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_edit_mode[2]->set_button_group(uv_edit_group);
 	uv_edit_mode[3]->set_button_group(uv_edit_group);
 
-	uv_edit_mode[0]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(0));
-	uv_edit_mode[1]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(1));
-	uv_edit_mode[2]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(2));
-	uv_edit_mode[3]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(3));
+	uv_edit_mode[0]->connect("button_clicked", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(0));
+	uv_edit_mode[1]->connect("button_clicked", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(1));
+	uv_edit_mode[2]->connect("button_clicked", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(2));
+	uv_edit_mode[3]->connect("button_clicked", callable_mp(this, &Polygon2DEditor::_uv_edit_mode_select), varray(3));
 
 	uv_mode_hb->add_child(memnew(VSeparator));
 
@@ -1270,7 +1270,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 		uv_button[i]->set_flat(true);
 		uv_button[i]->set_toggle_mode(true);
 		uv_mode_hb->add_child(uv_button[i]);
-		uv_button[i]->connect("pressed", callable_mp(this, &Polygon2DEditor::_uv_mode), varray(i));
+		uv_button[i]->connect("button_clicked", callable_mp(this, &Polygon2DEditor::_uv_mode), varray(i));
 		uv_button[i]->set_focus_mode(FOCUS_NONE);
 	}
 
@@ -1350,7 +1350,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	b_snap_enable->set_toggle_mode(true);
 	b_snap_enable->set_pressed(use_snap);
 	b_snap_enable->set_tooltip(TTR("Enable Snap"));
-	b_snap_enable->connect("toggled", callable_mp(this, &Polygon2DEditor::_set_use_snap));
+	b_snap_enable->connect("button_toggled", callable_mp(this, &Polygon2DEditor::_set_use_snap));
 
 	b_snap_grid = memnew(Button);
 	b_snap_grid->set_flat(true);
@@ -1360,7 +1360,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	b_snap_grid->set_toggle_mode(true);
 	b_snap_grid->set_pressed(snap_show_grid);
 	b_snap_grid->set_tooltip(TTR("Show Grid"));
-	b_snap_grid->connect("toggled", callable_mp(this, &Polygon2DEditor::_set_show_grid));
+	b_snap_grid->connect("button_toggled", callable_mp(this, &Polygon2DEditor::_set_show_grid));
 
 	grid_settings = memnew(AcceptDialog);
 	grid_settings->set_title(TTR("Configure Grid:"));
@@ -1438,7 +1438,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sync_bones = memnew(Button(TTR("Sync Bones to Polygon")));
 	bone_scroll_main_vb->add_child(sync_bones);
 	sync_bones->set_h_size_flags(0);
-	sync_bones->connect("pressed", callable_mp(this, &Polygon2DEditor::_sync_bones));
+	sync_bones->connect("button_clicked", callable_mp(this, &Polygon2DEditor::_sync_bones));
 	uv_main_hsc->add_child(bone_scroll_main_vb);
 	bone_scroll = memnew(ScrollContainer);
 	bone_scroll->set_v_scroll(true);

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -377,8 +377,8 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	dialog = memnew(AcceptDialog);
 	add_child(dialog);
 
-	load->connect("pressed", callable_mp(this, &ResourcePreloaderEditor::_load_pressed));
-	paste->connect("pressed", callable_mp(this, &ResourcePreloaderEditor::_paste_pressed));
+	load->connect("button_clicked", callable_mp(this, &ResourcePreloaderEditor::_load_pressed));
+	paste->connect("button_clicked", callable_mp(this, &ResourcePreloaderEditor::_paste_pressed));
 	file->connect("files_selected", callable_mp(this, &ResourcePreloaderEditor::_files_load_request));
 	tree->connect("item_edited", callable_mp(this, &ResourcePreloaderEditor::_item_edited));
 	loading_scene = false;

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -248,11 +248,11 @@ EditorPropertyRootMotion::EditorPropertyRootMotion() {
 	assign = memnew(Button);
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
-	assign->connect("pressed", callable_mp(this, &EditorPropertyRootMotion::_node_assign));
+	assign->connect("button_clicked", callable_mp(this, &EditorPropertyRootMotion::_node_assign));
 	hbc->add_child(assign);
 
 	clear = memnew(Button);
-	clear->connect("pressed", callable_mp(this, &EditorPropertyRootMotion::_node_clear));
+	clear->connect("button_clicked", callable_mp(this, &EditorPropertyRootMotion::_node_clear));
 	hbc->add_child(clear);
 
 	filter_dialog = memnew(ConfirmationDialog);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3633,7 +3633,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	members_overview_alphabeta_sort_button->set_tooltip(TTR("Toggle alphabetical sorting of the method list."));
 	members_overview_alphabeta_sort_button->set_toggle_mode(true);
 	members_overview_alphabeta_sort_button->set_pressed(EditorSettings::get_singleton()->get("text_editor/script_list/sort_members_outline_alphabetically"));
-	members_overview_alphabeta_sort_button->connect("toggled", callable_mp(this, &ScriptEditor::_toggle_members_overview_alpha_sort));
+	members_overview_alphabeta_sort_button->connect("button_toggled", callable_mp(this, &ScriptEditor::_toggle_members_overview_alpha_sort));
 
 	buttons_hbox->add_child(members_overview_alphabeta_sort_button);
 
@@ -3773,14 +3773,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	site_search = memnew(Button);
 	site_search->set_flat(true);
 	site_search->set_text(TTR("Online Docs"));
-	site_search->connect("pressed", callable_mp(this, &ScriptEditor::_menu_option), varray(SEARCH_WEBSITE));
+	site_search->connect("button_clicked", callable_mp(this, &ScriptEditor::_menu_option), varray(SEARCH_WEBSITE));
 	menu_hb->add_child(site_search);
 	site_search->set_tooltip(TTR("Open Godot online documentation."));
 
 	help_search = memnew(Button);
 	help_search->set_flat(true);
 	help_search->set_text(TTR("Search Help"));
-	help_search->connect("pressed", callable_mp(this, &ScriptEditor::_menu_option), varray(SEARCH_HELP));
+	help_search->connect("button_clicked", callable_mp(this, &ScriptEditor::_menu_option), varray(SEARCH_HELP));
 	menu_hb->add_child(help_search);
 	help_search->set_tooltip(TTR("Search the reference documentation."));
 
@@ -3788,14 +3788,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	script_back = memnew(Button);
 	script_back->set_flat(true);
-	script_back->connect("pressed", callable_mp(this, &ScriptEditor::_history_back));
+	script_back->connect("button_clicked", callable_mp(this, &ScriptEditor::_history_back));
 	menu_hb->add_child(script_back);
 	script_back->set_disabled(true);
 	script_back->set_tooltip(TTR("Go to previous edited document."));
 
 	script_forward = memnew(Button);
 	script_forward->set_flat(true);
-	script_forward->connect("pressed", callable_mp(this, &ScriptEditor::_history_forward));
+	script_forward->connect("button_clicked", callable_mp(this, &ScriptEditor::_history_forward));
 	menu_hb->add_child(script_forward);
 	script_forward->set_disabled(true);
 	script_forward->set_tooltip(TTR("Go to next edited document."));

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -280,7 +280,7 @@ ShaderFileEditor::ShaderFileEditor(EditorNode *p_node) {
 		stage_hb->add_child(button);
 		stages[i] = button;
 		button->set_button_group(bg);
-		button->connect("pressed", callable_mp(this, &ShaderFileEditor::_version_selected), varray(i));
+		button->connect("button_clicked", callable_mp(this, &ShaderFileEditor::_version_selected), varray(i));
 	}
 
 	error_text = memnew(RichTextLabel);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -637,7 +637,7 @@ void Skeleton3DEditor::create_editors() {
 	edit_mode_button->set_toggle_mode(true);
 	edit_mode_button->set_focus_mode(FOCUS_NONE);
 	edit_mode_button->set_tooltip(TTR("Edit Mode\nShow buttons on joints."));
-	edit_mode_button->connect("toggled", callable_mp(this, &Skeleton3DEditor::edit_mode_toggled));
+	edit_mode_button->connect("button_toggled", callable_mp(this, &Skeleton3DEditor::edit_mode_toggled));
 
 	edit_mode = false;
 
@@ -679,7 +679,7 @@ void Skeleton3DEditor::create_editors() {
 	key_insert_button = memnew(Button);
 	key_insert_button->set_flat(true);
 	key_insert_button->set_focus_mode(FOCUS_NONE);
-	key_insert_button->connect("pressed", callable_mp(this, &Skeleton3DEditor::insert_keys), varray(false));
+	key_insert_button->connect("button_clicked", callable_mp(this, &Skeleton3DEditor::insert_keys), varray(false));
 	key_insert_button->set_tooltip(TTR("Insert key of bone poses already exist track."));
 	key_insert_button->set_shortcut(ED_SHORTCUT("skeleton_3d_editor/insert_key_to_existing_tracks", TTR("Insert Key (Existing Tracks)"), Key::INSERT));
 	animation_hb->add_child(key_insert_button);
@@ -687,7 +687,7 @@ void Skeleton3DEditor::create_editors() {
 	key_insert_all_button = memnew(Button);
 	key_insert_all_button->set_flat(true);
 	key_insert_all_button->set_focus_mode(FOCUS_NONE);
-	key_insert_all_button->connect("pressed", callable_mp(this, &Skeleton3DEditor::insert_keys), varray(true));
+	key_insert_all_button->connect("button_clicked", callable_mp(this, &Skeleton3DEditor::insert_keys), varray(true));
 	key_insert_all_button->set_tooltip(TTR("Insert key of all bone poses."));
 	key_insert_all_button->set_shortcut(ED_SHORTCUT("skeleton_3d_editor/insert_key_of_all_bones", TTR("Insert Key (All Bones)"), KeyModifierMask::CMD + Key::INSERT));
 	animation_hb->add_child(key_insert_all_button);

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
@@ -87,7 +87,7 @@ SkeletonIK3DEditorPlugin::SkeletonIK3DEditorPlugin(EditorNode *p_node) {
 	play_btn->set_text(TTR("Play IK"));
 	play_btn->set_toggle_mode(true);
 	play_btn->hide();
-	play_btn->connect("pressed", callable_mp(this, &SkeletonIK3DEditorPlugin::_play));
+	play_btn->connect("button_clicked", callable_mp(this, &SkeletonIK3DEditorPlugin::_play));
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, play_btn);
 	skeleton_ik = nullptr;
 }

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -561,7 +561,7 @@ Sprite2DEditor::Sprite2DEditor() {
 	hb->add_spacer();
 	update_preview = memnew(Button);
 	update_preview->set_text(TTR("Update Preview"));
-	update_preview->connect("pressed", callable_mp(this, &Sprite2DEditor::_update_mesh_data));
+	update_preview->connect("button_clicked", callable_mp(this, &Sprite2DEditor::_update_mesh_data));
 	hb->add_child(update_preview);
 	vb->add_margin_child(TTR("Settings:"), hb);
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1037,13 +1037,13 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	new_anim->set_flat(true);
 	new_anim->set_tooltip(TTR("New Animation"));
 	hbc_animlist->add_child(new_anim);
-	new_anim->connect("pressed", callable_mp(this, &SpriteFramesEditor::_animation_add));
+	new_anim->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_animation_add));
 
 	remove_anim = memnew(Button);
 	remove_anim->set_flat(true);
 	remove_anim->set_tooltip(TTR("Remove Animation"));
 	hbc_animlist->add_child(remove_anim);
-	remove_anim->connect("pressed", callable_mp(this, &SpriteFramesEditor::_animation_remove));
+	remove_anim->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_animation_remove));
 
 	animations = memnew(Tree);
 	sub_vb->add_child(animations);
@@ -1068,7 +1068,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	anim_loop = memnew(CheckButton);
 	anim_loop->set_text(TTR("Loop"));
 	vbc_animlist->add_child(anim_loop);
-	anim_loop->connect("pressed", callable_mp(this, &SpriteFramesEditor::_animation_loop_changed));
+	anim_loop->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_animation_loop_changed));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
@@ -1134,19 +1134,19 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	hbc->add_spacer();
 
 	zoom_out = memnew(Button);
-	zoom_out->connect("pressed", callable_mp(this, &SpriteFramesEditor::_zoom_out));
+	zoom_out->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_zoom_out));
 	zoom_out->set_flat(true);
 	zoom_out->set_tooltip(TTR("Zoom Out"));
 	hbc->add_child(zoom_out);
 
 	zoom_reset = memnew(Button);
-	zoom_reset->connect("pressed", callable_mp(this, &SpriteFramesEditor::_zoom_reset));
+	zoom_reset->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_zoom_reset));
 	zoom_reset->set_flat(true);
 	zoom_reset->set_tooltip(TTR("Zoom Reset"));
 	hbc->add_child(zoom_reset);
 
 	zoom_in = memnew(Button);
-	zoom_in->connect("pressed", callable_mp(this, &SpriteFramesEditor::_zoom_in));
+	zoom_in->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_zoom_in));
 	zoom_in->set_flat(true);
 	zoom_in->set_tooltip(TTR("Zoom In"));
 	hbc->add_child(zoom_in);
@@ -1169,15 +1169,15 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	dialog = memnew(AcceptDialog);
 	add_child(dialog);
 
-	load->connect("pressed", callable_mp(this, &SpriteFramesEditor::_load_pressed));
-	load_sheet->connect("pressed", callable_mp(this, &SpriteFramesEditor::_open_sprite_sheet));
-	_delete->connect("pressed", callable_mp(this, &SpriteFramesEditor::_delete_pressed));
-	copy->connect("pressed", callable_mp(this, &SpriteFramesEditor::_copy_pressed));
-	paste->connect("pressed", callable_mp(this, &SpriteFramesEditor::_paste_pressed));
-	empty->connect("pressed", callable_mp(this, &SpriteFramesEditor::_empty_pressed));
-	empty2->connect("pressed", callable_mp(this, &SpriteFramesEditor::_empty2_pressed));
-	move_up->connect("pressed", callable_mp(this, &SpriteFramesEditor::_up_pressed));
-	move_down->connect("pressed", callable_mp(this, &SpriteFramesEditor::_down_pressed));
+	load->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_load_pressed));
+	load_sheet->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_open_sprite_sheet));
+	_delete->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_delete_pressed));
+	copy->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_copy_pressed));
+	paste->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_paste_pressed));
+	empty->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_empty_pressed));
+	empty2->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_empty2_pressed));
+	move_up->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_up_pressed));
+	move_down->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_down_pressed));
 	file->connect("files_selected", callable_mp(this, &SpriteFramesEditor::_file_load_request), make_binds(-1));
 	loading_scene = false;
 	sel = -1;
@@ -1221,7 +1221,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	Button *select_clear_all = memnew(Button);
 	select_clear_all->set_text(TTR("Select/Clear All Frames"));
-	select_clear_all->connect("pressed", callable_mp(this, &SpriteFramesEditor::_sheet_select_clear_all_frames));
+	select_clear_all->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_sheet_select_clear_all_frames));
 	split_sheet_hb->add_child(select_clear_all);
 
 	split_sheet_vb->add_child(split_sheet_hb);
@@ -1261,21 +1261,21 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_zoom_out->set_flat(true);
 	split_sheet_zoom_out->set_focus_mode(FOCUS_NONE);
 	split_sheet_zoom_out->set_tooltip(TTR("Zoom Out"));
-	split_sheet_zoom_out->connect("pressed", callable_mp(this, &SpriteFramesEditor::_sheet_zoom_out));
+	split_sheet_zoom_out->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_sheet_zoom_out));
 	split_sheet_zoom_hb->add_child(split_sheet_zoom_out);
 
 	split_sheet_zoom_reset = memnew(Button);
 	split_sheet_zoom_reset->set_flat(true);
 	split_sheet_zoom_reset->set_focus_mode(FOCUS_NONE);
 	split_sheet_zoom_reset->set_tooltip(TTR("Zoom Reset"));
-	split_sheet_zoom_reset->connect("pressed", callable_mp(this, &SpriteFramesEditor::_sheet_zoom_reset));
+	split_sheet_zoom_reset->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_sheet_zoom_reset));
 	split_sheet_zoom_hb->add_child(split_sheet_zoom_reset);
 
 	split_sheet_zoom_in = memnew(Button);
 	split_sheet_zoom_in->set_flat(true);
 	split_sheet_zoom_in->set_focus_mode(FOCUS_NONE);
 	split_sheet_zoom_in->set_tooltip(TTR("Zoom In"));
-	split_sheet_zoom_in->connect("pressed", callable_mp(this, &SpriteFramesEditor::_sheet_zoom_in));
+	split_sheet_zoom_in->connect("button_clicked", callable_mp(this, &SpriteFramesEditor::_sheet_zoom_in));
 	split_sheet_zoom_hb->add_child(split_sheet_zoom_in);
 
 	file_split_sheet = memnew(EditorFileDialog);

--- a/editor/plugins/text_control_editor_plugin.cpp
+++ b/editor/plugins/text_control_editor_plugin.cpp
@@ -344,7 +344,7 @@ TextControlEditor::TextControlEditor() {
 	clear_formatting->set_flat(true);
 	clear_formatting->set_tooltip(TTR("Clear Formatting"));
 	add_child(clear_formatting);
-	clear_formatting->connect("pressed", callable_mp(this, &TextControlEditor::_clear_formatting));
+	clear_formatting->connect("button_clicked", callable_mp(this, &TextControlEditor::_clear_formatting));
 }
 
 /*************************************************************************/

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -1078,19 +1078,19 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	zoom_out = memnew(Button);
 	zoom_out->set_flat(true);
 	zoom_out->set_tooltip(TTR("Zoom Out"));
-	zoom_out->connect("pressed", callable_mp(this, &TextureRegionEditor::_zoom_out));
+	zoom_out->connect("button_clicked", callable_mp(this, &TextureRegionEditor::_zoom_out));
 	zoom_hb->add_child(zoom_out);
 
 	zoom_reset = memnew(Button);
 	zoom_reset->set_flat(true);
 	zoom_reset->set_tooltip(TTR("Zoom Reset"));
-	zoom_reset->connect("pressed", callable_mp(this, &TextureRegionEditor::_zoom_reset));
+	zoom_reset->connect("button_clicked", callable_mp(this, &TextureRegionEditor::_zoom_reset));
 	zoom_hb->add_child(zoom_reset);
 
 	zoom_in = memnew(Button);
 	zoom_in->set_flat(true);
 	zoom_in->set_tooltip(TTR("Zoom In"));
-	zoom_in->connect("pressed", callable_mp(this, &TextureRegionEditor::_zoom_in));
+	zoom_in->connect("button_clicked", callable_mp(this, &TextureRegionEditor::_zoom_in));
 	zoom_hb->add_child(zoom_in);
 
 	vscroll = memnew(VScrollBar);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1120,15 +1120,15 @@ ThemeItemImportTree::ThemeItemImportTree() {
 		select_all_items_button->set_flat(true);
 		select_all_items_button->set_tooltip(select_all_items_tooltip);
 		button_set->add_child(select_all_items_button);
-		select_all_items_button->connect("pressed", callable_mp(this, &ThemeItemImportTree::_select_all_data_type_pressed), varray(i));
+		select_all_items_button->connect("button_clicked", callable_mp(this, &ThemeItemImportTree::_select_all_data_type_pressed), varray(i));
 		select_full_items_button->set_flat(true);
 		select_full_items_button->set_tooltip(select_full_items_tooltip);
 		button_set->add_child(select_full_items_button);
-		select_full_items_button->connect("pressed", callable_mp(this, &ThemeItemImportTree::_select_full_data_type_pressed), varray(i));
+		select_full_items_button->connect("button_clicked", callable_mp(this, &ThemeItemImportTree::_select_full_data_type_pressed), varray(i));
 		deselect_all_items_button->set_flat(true);
 		deselect_all_items_button->set_tooltip(deselect_all_items_tooltip);
 		button_set->add_child(deselect_all_items_button);
-		deselect_all_items_button->connect("pressed", callable_mp(this, &ThemeItemImportTree::_deselect_all_data_type_pressed), varray(i));
+		deselect_all_items_button->connect("button_clicked", callable_mp(this, &ThemeItemImportTree::_deselect_all_data_type_pressed), varray(i));
 
 		total_selected_items_label->set_align(Label::ALIGN_RIGHT);
 		total_selected_items_label->hide();
@@ -1159,12 +1159,12 @@ ThemeItemImportTree::ThemeItemImportTree() {
 	import_collapse_types_button->set_flat(true);
 	import_collapse_types_button->set_tooltip(TTR("Collapse types."));
 	import_buttons->add_child(import_collapse_types_button);
-	import_collapse_types_button->connect("pressed", callable_mp(this, &ThemeItemImportTree::_toggle_type_items), varray(true));
+	import_collapse_types_button->connect("button_clicked", callable_mp(this, &ThemeItemImportTree::_toggle_type_items), varray(true));
 	import_expand_types_button = memnew(Button);
 	import_expand_types_button->set_flat(true);
 	import_expand_types_button->set_tooltip(TTR("Expand types."));
 	import_buttons->add_child(import_expand_types_button);
-	import_expand_types_button->connect("pressed", callable_mp(this, &ThemeItemImportTree::_toggle_type_items), varray(false));
+	import_expand_types_button->connect("button_clicked", callable_mp(this, &ThemeItemImportTree::_toggle_type_items), varray(false));
 
 	import_buttons->add_child(memnew(VSeparator));
 
@@ -1173,26 +1173,26 @@ ThemeItemImportTree::ThemeItemImportTree() {
 	import_select_all_button->set_text(TTR("Select All"));
 	import_select_all_button->set_tooltip(TTR("Select all Theme items."));
 	import_buttons->add_child(import_select_all_button);
-	import_select_all_button->connect("pressed", callable_mp(this, &ThemeItemImportTree::_select_all_items_pressed));
+	import_select_all_button->connect("button_clicked", callable_mp(this, &ThemeItemImportTree::_select_all_items_pressed));
 	import_select_full_button = memnew(Button);
 	import_select_full_button->set_flat(true);
 	import_select_full_button->set_text(TTR("Select With Data"));
 	import_select_full_button->set_tooltip(TTR("Select all Theme items with item data."));
 	import_buttons->add_child(import_select_full_button);
-	import_select_full_button->connect("pressed", callable_mp(this, &ThemeItemImportTree::_select_full_items_pressed));
+	import_select_full_button->connect("button_clicked", callable_mp(this, &ThemeItemImportTree::_select_full_items_pressed));
 	import_deselect_all_button = memnew(Button);
 	import_deselect_all_button->set_flat(true);
 	import_deselect_all_button->set_text(TTR("Deselect All"));
 	import_deselect_all_button->set_tooltip(TTR("Deselect all Theme items."));
 	import_buttons->add_child(import_deselect_all_button);
-	import_deselect_all_button->connect("pressed", callable_mp(this, &ThemeItemImportTree::_deselect_all_items_pressed));
+	import_deselect_all_button->connect("button_clicked", callable_mp(this, &ThemeItemImportTree::_deselect_all_items_pressed));
 
 	import_buttons->add_spacer();
 
 	Button *import_add_selected_button = memnew(Button);
 	import_add_selected_button->set_text(TTR("Import Selected"));
 	import_buttons->add_child(import_add_selected_button);
-	import_add_selected_button->connect("pressed", callable_mp(this, &ThemeItemImportTree::_import_selected));
+	import_add_selected_button->connect("button_clicked", callable_mp(this, &ThemeItemImportTree::_import_selected));
 }
 
 void ThemeItemEditorDialog::ok_pressed() {
@@ -1817,7 +1817,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	Button *edit_add_type_button = memnew(Button);
 	edit_add_type_button->set_text(TTR("Add"));
 	edit_add_type_hb->add_child(edit_add_type_button);
-	edit_add_type_button->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_add_theme_type), varray(""));
+	edit_add_type_button->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_add_theme_type), varray(""));
 
 	VBoxContainer *edit_items_vb = memnew(VBoxContainer);
 	edit_items_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1835,42 +1835,42 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	edit_items_add_color->set_flat(true);
 	edit_items_add_color->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_add_color);
-	edit_items_add_color->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_COLOR));
+	edit_items_add_color->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_COLOR));
 
 	edit_items_add_constant = memnew(Button);
 	edit_items_add_constant->set_tooltip(TTR("Add Constant Item"));
 	edit_items_add_constant->set_flat(true);
 	edit_items_add_constant->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_add_constant);
-	edit_items_add_constant->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_CONSTANT));
+	edit_items_add_constant->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_CONSTANT));
 
 	edit_items_add_font = memnew(Button);
 	edit_items_add_font->set_tooltip(TTR("Add Font Item"));
 	edit_items_add_font->set_flat(true);
 	edit_items_add_font->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_add_font);
-	edit_items_add_font->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_FONT));
+	edit_items_add_font->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_FONT));
 
 	edit_items_add_font_size = memnew(Button);
 	edit_items_add_font_size->set_tooltip(TTR("Add Font Size Item"));
 	edit_items_add_font_size->set_flat(true);
 	edit_items_add_font_size->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_add_font_size);
-	edit_items_add_font_size->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_FONT_SIZE));
+	edit_items_add_font_size->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_FONT_SIZE));
 
 	edit_items_add_icon = memnew(Button);
 	edit_items_add_icon->set_tooltip(TTR("Add Icon Item"));
 	edit_items_add_icon->set_flat(true);
 	edit_items_add_icon->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_add_icon);
-	edit_items_add_icon->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_ICON));
+	edit_items_add_icon->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_ICON));
 
 	edit_items_add_stylebox = memnew(Button);
 	edit_items_add_stylebox->set_tooltip(TTR("Add StyleBox Item"));
 	edit_items_add_stylebox->set_flat(true);
 	edit_items_add_stylebox->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_add_stylebox);
-	edit_items_add_stylebox->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_STYLEBOX));
+	edit_items_add_stylebox->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog), varray(Theme::DATA_TYPE_STYLEBOX));
 
 	edit_items_toolbar->add_child(memnew(VSeparator));
 
@@ -1883,21 +1883,21 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	edit_items_remove_class->set_flat(true);
 	edit_items_remove_class->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_remove_class);
-	edit_items_remove_class->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_remove_class_items));
+	edit_items_remove_class->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_remove_class_items));
 
 	edit_items_remove_custom = memnew(Button);
 	edit_items_remove_custom->set_tooltip(TTR("Remove Custom Items"));
 	edit_items_remove_custom->set_flat(true);
 	edit_items_remove_custom->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_remove_custom);
-	edit_items_remove_custom->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_remove_custom_items));
+	edit_items_remove_custom->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_remove_custom_items));
 
 	edit_items_remove_all = memnew(Button);
 	edit_items_remove_all->set_tooltip(TTR("Remove All Items"));
 	edit_items_remove_all->set_flat(true);
 	edit_items_remove_all->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_remove_all);
-	edit_items_remove_all->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_remove_all_items));
+	edit_items_remove_all->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_remove_all_items));
 
 	edit_items_tree = memnew(Tree);
 	edit_items_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1961,7 +1961,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog() {
 	import_another_file_hb->add_child(import_another_theme_value);
 	import_another_theme_button = memnew(Button);
 	import_another_file_hb->add_child(import_another_theme_button);
-	import_another_theme_button->connect("pressed", callable_mp(this, &ThemeItemEditorDialog::_open_select_another_theme));
+	import_another_theme_button->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_open_select_another_theme));
 
 	import_another_theme_dialog = memnew(EditorFileDialog);
 	import_another_theme_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
@@ -2128,7 +2128,7 @@ VBoxContainer *ThemeTypeEditor::_create_item_list(Theme::DataType p_data_type) {
 	Button *item_add_button = memnew(Button);
 	item_add_button->set_text(TTR("Add"));
 	item_add_hb->add_child(item_add_button);
-	item_add_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_add_cbk), varray(p_data_type, item_add_edit));
+	item_add_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_item_add_cbk), varray(p_data_type, item_add_edit));
 
 	return items_list;
 }
@@ -2279,21 +2279,21 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		item_rename_button->set_tooltip(TTR("Rename Item"));
 		item_rename_button->set_flat(true);
 		item_name_container->add_child(item_rename_button);
-		item_rename_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_rename_cbk), varray(p_data_type, p_item_name, item_name_container));
+		item_rename_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_item_rename_cbk), varray(p_data_type, p_item_name, item_name_container));
 
 		Button *item_remove_button = memnew(Button);
 		item_remove_button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 		item_remove_button->set_tooltip(TTR("Remove Item"));
 		item_remove_button->set_flat(true);
 		item_name_container->add_child(item_remove_button);
-		item_remove_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_remove_cbk), varray(p_data_type, p_item_name));
+		item_remove_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_item_remove_cbk), varray(p_data_type, p_item_name));
 
 		Button *item_rename_confirm_button = memnew(Button);
 		item_rename_confirm_button->set_icon(get_theme_icon(SNAME("ImportCheck"), SNAME("EditorIcons")));
 		item_rename_confirm_button->set_tooltip(TTR("Confirm Item Rename"));
 		item_rename_confirm_button->set_flat(true);
 		item_name_container->add_child(item_rename_confirm_button);
-		item_rename_confirm_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_rename_confirmed), varray(p_data_type, p_item_name, item_name_container));
+		item_rename_confirm_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_item_rename_confirmed), varray(p_data_type, p_item_name, item_name_container));
 		item_rename_confirm_button->hide();
 
 		Button *item_rename_cancel_button = memnew(Button);
@@ -2301,7 +2301,7 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		item_rename_cancel_button->set_tooltip(TTR("Cancel Item Rename"));
 		item_rename_cancel_button->set_flat(true);
 		item_name_container->add_child(item_rename_cancel_button);
-		item_rename_cancel_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_rename_canceled), varray(p_data_type, p_item_name, item_name_container));
+		item_rename_cancel_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_item_rename_canceled), varray(p_data_type, p_item_name, item_name_container));
 		item_rename_cancel_button->hide();
 	} else {
 		item_name->add_theme_color_override("font_color", get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
@@ -2311,7 +2311,7 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		item_override_button->set_tooltip(TTR("Override Item"));
 		item_override_button->set_flat(true);
 		item_name_container->add_child(item_override_button);
-		item_override_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_override_cbk), varray(p_data_type, p_item_name));
+		item_override_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_item_override_cbk), varray(p_data_type, p_item_name));
 	}
 
 	return item_control;
@@ -2519,7 +2519,7 @@ void ThemeTypeEditor::_update_type_items() {
 			pin_leader_button->set_icon(get_theme_icon(SNAME("Pin"), SNAME("EditorIcons")));
 			pin_leader_button->set_tooltip(TTR("Unpin this StyleBox as a main style."));
 			item_control->add_child(pin_leader_button);
-			pin_leader_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_unpin_leading_stylebox));
+			pin_leader_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_unpin_leading_stylebox));
 
 			item_control->add_child(item_editor);
 
@@ -2564,7 +2564,7 @@ void ThemeTypeEditor::_update_type_items() {
 				pin_leader_button->set_icon(get_theme_icon(SNAME("Pin"), SNAME("EditorIcons")));
 				pin_leader_button->set_tooltip(TTR("Pin this StyleBox as a main style. Editing its properties will update the same properties in all other StyleBoxes of this type."));
 				item_control->add_child(pin_leader_button);
-				pin_leader_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_pin_leading_stylebox), varray(item_editor, E.key()));
+				pin_leader_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_pin_leading_stylebox), varray(item_editor, E.key()));
 			} else {
 				if (Theme::get_default()->has_stylebox(E.key(), edited_type)) {
 					item_editor->set_edited_resource(Theme::get_default()->get_stylebox(E.key(), edited_type));
@@ -3063,7 +3063,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	add_type_button = memnew(Button);
 	add_type_button->set_tooltip(TTR("Add a type from a list of available types or create a new one."));
 	type_list_hb->add_child(add_type_button);
-	add_type_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_add_type_button_cbk));
+	add_type_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_add_type_button_cbk));
 
 	HBoxContainer *type_controls = memnew(HBoxContainer);
 	main_vb->add_child(type_controls);
@@ -3074,14 +3074,14 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	show_default_items_button->set_tooltip(TTR("Show default type items alongside items that have been overridden."));
 	show_default_items_button->set_pressed(true);
 	type_controls->add_child(show_default_items_button);
-	show_default_items_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_update_type_items));
+	show_default_items_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_update_type_items));
 
 	Button *add_default_items_button = memnew(Button);
 	add_default_items_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_default_items_button->set_text(TTR("Override All"));
 	add_default_items_button->set_tooltip(TTR("Override all default type items."));
 	type_controls->add_child(add_default_items_button);
-	add_default_items_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_add_default_type_items));
+	add_default_items_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_add_default_type_items));
 
 	data_type_tabs = memnew(TabContainer);
 	main_vb->add_child(data_type_tabs);
@@ -3125,7 +3125,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	type_variation_button = memnew(Button);
 	type_variation_hb->add_child(type_variation_button);
 	type_variation_button->set_tooltip(TTR("Select the variation base type from a list of available types."));
-	type_variation_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_add_type_variation_cbk));
+	type_variation_button->connect("button_clicked", callable_mp(this, &ThemeTypeEditor::_add_type_variation_cbk));
 
 	type_variation_locked = memnew(Label);
 	type_variation_vb->add_child(type_variation_locked);
@@ -3290,13 +3290,13 @@ ThemeEditor::ThemeEditor() {
 	Button *theme_save_button = memnew(Button);
 	theme_save_button->set_text(TTR("Save"));
 	theme_save_button->set_flat(true);
-	theme_save_button->connect("pressed", callable_mp(this, &ThemeEditor::_theme_save_button_cbk), varray(false));
+	theme_save_button->connect("button_clicked", callable_mp(this, &ThemeEditor::_theme_save_button_cbk), varray(false));
 	top_menu->add_child(theme_save_button);
 
 	Button *theme_save_as_button = memnew(Button);
 	theme_save_as_button->set_text(TTR("Save As..."));
 	theme_save_as_button->set_flat(true);
-	theme_save_as_button->connect("pressed", callable_mp(this, &ThemeEditor::_theme_save_button_cbk), varray(true));
+	theme_save_as_button->connect("button_clicked", callable_mp(this, &ThemeEditor::_theme_save_button_cbk), varray(true));
 	top_menu->add_child(theme_save_as_button);
 
 	top_menu->add_child(memnew(VSeparator));
@@ -3305,7 +3305,7 @@ ThemeEditor::ThemeEditor() {
 	theme_edit_button->set_text(TTR("Manage Items..."));
 	theme_edit_button->set_tooltip(TTR("Add, remove, organize and import Theme items."));
 	theme_edit_button->set_flat(true);
-	theme_edit_button->connect("pressed", callable_mp(this, &ThemeEditor::_theme_edit_button_cbk));
+	theme_edit_button->connect("button_clicked", callable_mp(this, &ThemeEditor::_theme_edit_button_cbk));
 	top_menu->add_child(theme_edit_button);
 
 	theme_edit_dialog = memnew(ThemeItemEditorDialog);
@@ -3340,7 +3340,7 @@ ThemeEditor::ThemeEditor() {
 	add_preview_button = memnew(Button);
 	add_preview_button->set_text(TTR("Add Preview"));
 	add_preview_button_hb->add_child(add_preview_button);
-	add_preview_button->connect("pressed", callable_mp(this, &ThemeEditor::_add_preview_button_cbk));
+	add_preview_button->connect("button_clicked", callable_mp(this, &ThemeEditor::_add_preview_button_cbk));
 
 	DefaultThemeEditorPreview *default_preview_tab = memnew(DefaultThemeEditorPreview);
 	preview_tabs_content->add_child(default_preview_tab);

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -216,7 +216,7 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	picker_button->set_flat(true);
 	picker_button->set_toggle_mode(true);
 	picker_button->set_tooltip(TTR("Toggle the control picker, allowing to visually select control types for edit."));
-	picker_button->connect("pressed", callable_mp(this, &ThemeEditorPreview::_picker_button_cbk));
+	picker_button->connect("button_clicked", callable_mp(this, &ThemeEditorPreview::_picker_button_cbk));
 
 	MarginContainer *preview_body = memnew(MarginContainer);
 	preview_body->set_custom_minimum_size(Size2(480, 0) * EDSCALE);
@@ -499,5 +499,5 @@ SceneThemeEditorPreview::SceneThemeEditorPreview() {
 	reload_scene_button->set_flat(true);
 	reload_scene_button->set_tooltip(TTR("Reload the scene to reflect its most actual state."));
 	preview_toolbar->add_child(reload_scene_button);
-	reload_scene_button->connect("pressed", callable_mp(this, &SceneThemeEditorPreview::_reload_scene));
+	reload_scene_button->connect("button_clicked", callable_mp(this, &SceneThemeEditorPreview::_reload_scene));
 }

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -578,7 +578,7 @@ TileAtlasView::TileAtlasView() {
 	button_center_view = memnew(Button);
 	button_center_view->set_icon(get_theme_icon(SNAME("CenterView"), SNAME("EditorIcons")));
 	button_center_view->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT, Control::PRESET_MODE_MINSIZE, 5);
-	button_center_view->connect("pressed", callable_mp(this, &TileAtlasView::_center_view));
+	button_center_view->connect("button_clicked", callable_mp(this, &TileAtlasView::_center_view));
 	button_center_view->set_flat(true);
 	button_center_view->set_disabled(true);
 	button_center_view->set_tooltip(TTR("Center View"));

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -820,7 +820,7 @@ GenericTilePolygonEditor::GenericTilePolygonEditor() {
 	button_center_view = memnew(Button);
 	button_center_view->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("CenterView"), SNAME("EditorIcons")));
 	button_center_view->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT, Control::PRESET_MODE_MINSIZE, 5);
-	button_center_view->connect("pressed", callable_mp(this, &GenericTilePolygonEditor::_center_view));
+	button_center_view->connect("button_clicked", callable_mp(this, &GenericTilePolygonEditor::_center_view));
 	button_center_view->set_flat(true);
 	button_center_view->set_disabled(true);
 	root->add_child(button_center_view);

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -1980,7 +1980,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	select_tool_button->set_toggle_mode(true);
 	select_tool_button->set_button_group(tool_buttons_group);
 	select_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/selection_tool", "Selection", Key::S));
-	select_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
+	select_tool_button->connect("button_clicked", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(select_tool_button);
 
 	paint_tool_button = memnew(Button);
@@ -1989,7 +1989,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	paint_tool_button->set_button_group(tool_buttons_group);
 	paint_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/paint_tool", "Paint", Key::D));
 	paint_tool_button->set_tooltip(TTR("Shift: Draw line.") + "\n" + TTR("Shift+Ctrl: Draw rectangle."));
-	paint_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
+	paint_tool_button->connect("button_clicked", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(paint_tool_button);
 
 	line_tool_button = memnew(Button);
@@ -1997,7 +1997,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	line_tool_button->set_toggle_mode(true);
 	line_tool_button->set_button_group(tool_buttons_group);
 	line_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/line_tool", "Line", Key::L));
-	line_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
+	line_tool_button->connect("button_clicked", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(line_tool_button);
 
 	rect_tool_button = memnew(Button);
@@ -2005,7 +2005,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	rect_tool_button->set_toggle_mode(true);
 	rect_tool_button->set_button_group(tool_buttons_group);
 	rect_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/rect_tool", "Rect", Key::R));
-	rect_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
+	rect_tool_button->connect("button_clicked", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(rect_tool_button);
 
 	bucket_tool_button = memnew(Button);
@@ -2013,7 +2013,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	bucket_tool_button->set_toggle_mode(true);
 	bucket_tool_button->set_button_group(tool_buttons_group);
 	bucket_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/bucket_tool", "Bucket", Key::B));
-	bucket_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
+	bucket_tool_button->connect("button_clicked", callable_mp(this, &TileMapEditorTilesPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(bucket_tool_button);
 	toolbar->add_child(tilemap_tiles_tools_buttons);
 
@@ -2030,7 +2030,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	picker_button->set_toggle_mode(true);
 	picker_button->set_shortcut(ED_SHORTCUT("tiles_editor/picker", "Picker", Key::P));
 	picker_button->set_tooltip(TTR("Alternatively hold Ctrl with other tools to pick tile."));
-	picker_button->connect("pressed", callable_mp(CanvasItemEditor::get_singleton(), &CanvasItemEditor::update_viewport));
+	picker_button->connect("button_clicked", callable_mp(CanvasItemEditor::get_singleton(), &CanvasItemEditor::update_viewport));
 	tools_settings->add_child(picker_button);
 
 	// Erase button.
@@ -2039,7 +2039,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	erase_button->set_toggle_mode(true);
 	erase_button->set_shortcut(ED_SHORTCUT("tiles_editor/eraser", "Eraser", Key::E));
 	erase_button->set_tooltip(TTR("Alternatively use RMB to erase tiles."));
-	erase_button->connect("pressed", callable_mp(CanvasItemEditor::get_singleton(), &CanvasItemEditor::update_viewport));
+	erase_button->connect("button_clicked", callable_mp(CanvasItemEditor::get_singleton(), &CanvasItemEditor::update_viewport));
 	tools_settings->add_child(erase_button);
 
 	// Separator 2.
@@ -2057,7 +2057,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	random_tile_checkbox = memnew(CheckBox);
 	random_tile_checkbox->set_flat(true);
 	random_tile_checkbox->set_text(TTR("Place Random Tile"));
-	random_tile_checkbox->connect("toggled", callable_mp(this, &TileMapEditorTilesPlugin::_on_random_tile_checkbox_toggled));
+	random_tile_checkbox->connect("button_toggled", callable_mp(this, &TileMapEditorTilesPlugin::_on_random_tile_checkbox_toggled));
 	tools_settings->add_child(random_tile_checkbox);
 
 	// Random tile scattering.
@@ -3231,7 +3231,7 @@ TileMapEditorTerrainsPlugin::TileMapEditorTerrainsPlugin() {
 	paint_tool_button->set_button_group(tool_buttons_group);
 	paint_tool_button->set_pressed(true);
 	paint_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/paint_tool", "Paint", Key::D));
-	paint_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTerrainsPlugin::_update_toolbar));
+	paint_tool_button->connect("button_clicked", callable_mp(this, &TileMapEditorTerrainsPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(paint_tool_button);
 
 	line_tool_button = memnew(Button);
@@ -3239,7 +3239,7 @@ TileMapEditorTerrainsPlugin::TileMapEditorTerrainsPlugin() {
 	line_tool_button->set_toggle_mode(true);
 	line_tool_button->set_button_group(tool_buttons_group);
 	line_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/line_tool", "Line", Key::L));
-	line_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTerrainsPlugin::_update_toolbar));
+	line_tool_button->connect("button_clicked", callable_mp(this, &TileMapEditorTerrainsPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(line_tool_button);
 
 	rect_tool_button = memnew(Button);
@@ -3247,7 +3247,7 @@ TileMapEditorTerrainsPlugin::TileMapEditorTerrainsPlugin() {
 	rect_tool_button->set_toggle_mode(true);
 	rect_tool_button->set_button_group(tool_buttons_group);
 	rect_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/rect_tool", "Rect", Key::R));
-	rect_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTerrainsPlugin::_update_toolbar));
+	rect_tool_button->connect("button_clicked", callable_mp(this, &TileMapEditorTerrainsPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(rect_tool_button);
 
 	bucket_tool_button = memnew(Button);
@@ -3255,7 +3255,7 @@ TileMapEditorTerrainsPlugin::TileMapEditorTerrainsPlugin() {
 	bucket_tool_button->set_toggle_mode(true);
 	bucket_tool_button->set_button_group(tool_buttons_group);
 	bucket_tool_button->set_shortcut(ED_SHORTCUT("tiles_editor/bucket_tool", "Bucket", Key::B));
-	bucket_tool_button->connect("pressed", callable_mp(this, &TileMapEditorTerrainsPlugin::_update_toolbar));
+	bucket_tool_button->connect("button_clicked", callable_mp(this, &TileMapEditorTerrainsPlugin::_update_toolbar));
 	tilemap_tiles_tools_buttons->add_child(bucket_tool_button);
 
 	toolbar->add_child(tilemap_tiles_tools_buttons);
@@ -3272,7 +3272,7 @@ TileMapEditorTerrainsPlugin::TileMapEditorTerrainsPlugin() {
 	picker_button->set_flat(true);
 	picker_button->set_toggle_mode(true);
 	picker_button->set_shortcut(ED_SHORTCUT("tiles_editor/picker", "Picker", Key::P));
-	picker_button->connect("pressed", callable_mp(CanvasItemEditor::get_singleton(), &CanvasItemEditor::update_viewport));
+	picker_button->connect("button_clicked", callable_mp(CanvasItemEditor::get_singleton(), &CanvasItemEditor::update_viewport));
 	tools_settings->add_child(picker_button);
 
 	// Erase button.
@@ -3280,7 +3280,7 @@ TileMapEditorTerrainsPlugin::TileMapEditorTerrainsPlugin() {
 	erase_button->set_flat(true);
 	erase_button->set_toggle_mode(true);
 	erase_button->set_shortcut(ED_SHORTCUT("tiles_editor/eraser", "Eraser", Key::E));
-	erase_button->connect("pressed", callable_mp(CanvasItemEditor::get_singleton(), &CanvasItemEditor::update_viewport));
+	erase_button->connect("button_clicked", callable_mp(CanvasItemEditor::get_singleton(), &CanvasItemEditor::update_viewport));
 	tools_settings->add_child(erase_button);
 
 	// Separator 2.
@@ -3946,7 +3946,7 @@ TileMapEditor::TileMapEditor() {
 	layers_selection_button = memnew(Button);
 	layers_selection_button->set_toggle_mode(true);
 	layers_selection_button->connect("draw", callable_mp(this, &TileMapEditor::_layers_selection_button_draw));
-	layers_selection_button->connect("pressed", callable_mp(this, &TileMapEditor::_layers_selection_button_pressed));
+	layers_selection_button->connect("button_clicked", callable_mp(this, &TileMapEditor::_layers_selection_button_pressed));
 	layers_selection_button->connect("hidden", callable_mp((Window *)layers_selection_popup, &Popup::hide));
 	layers_selection_button->set_tooltip(TTR("Tile Map Layer"));
 	layers_selection_button->add_child(layers_selection_popup);
@@ -3956,7 +3956,7 @@ TileMapEditor::TileMapEditor() {
 	toogle_highlight_selected_layer_button->set_flat(true);
 	toogle_highlight_selected_layer_button->set_toggle_mode(true);
 	toogle_highlight_selected_layer_button->set_pressed(true);
-	toogle_highlight_selected_layer_button->connect("pressed", callable_mp(this, &TileMapEditor::_update_layers_selection));
+	toogle_highlight_selected_layer_button->connect("button_clicked", callable_mp(this, &TileMapEditor::_update_layers_selection));
 	toogle_highlight_selected_layer_button->set_tooltip(TTR("Highlight Selected TileMap Layer"));
 	tile_map_toolbar->add_child(toogle_highlight_selected_layer_button);
 
@@ -3967,7 +3967,7 @@ TileMapEditor::TileMapEditor() {
 	toggle_grid_button->set_flat(true);
 	toggle_grid_button->set_toggle_mode(true);
 	toggle_grid_button->set_tooltip(TTR("Toggle grid visibility."));
-	toggle_grid_button->connect("toggled", callable_mp(this, &TileMapEditor::_on_grid_toggled));
+	toggle_grid_button->connect("button_toggled", callable_mp(this, &TileMapEditor::_on_grid_toggled));
 	tile_map_toolbar->add_child(toggle_grid_button);
 
 	// Advanced settings menu button.

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
@@ -445,7 +445,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	Button *add_button = memnew(Button);
 	add_button->set_text(TTR("Add"));
 	add_button->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
-	add_button->connect("pressed", callable_mp(this, &TileProxiesManagerDialog::_add_button_pressed));
+	add_button->connect("button_clicked", callable_mp(this, &TileProxiesManagerDialog::_add_button_pressed));
 	vbox_container->add_child(add_button);
 
 	h_separator = memnew(HSeparator);
@@ -462,13 +462,13 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	Button *clear_invalid_button = memnew(Button);
 	clear_invalid_button->set_text(TTR("Clear Invalid"));
 	clear_invalid_button->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
-	clear_invalid_button->connect("pressed", callable_mp(this, &TileProxiesManagerDialog::_clear_invalid_button_pressed));
+	clear_invalid_button->connect("button_clicked", callable_mp(this, &TileProxiesManagerDialog::_clear_invalid_button_pressed));
 	hboxcontainer->add_child(clear_invalid_button);
 
 	Button *clear_all_button = memnew(Button);
 	clear_all_button->set_text(TTR("Clear All"));
 	clear_all_button->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
-	clear_all_button->connect("pressed", callable_mp(this, &TileProxiesManagerDialog::_clear_all_button_pressed));
+	clear_all_button->connect("button_clicked", callable_mp(this, &TileProxiesManagerDialog::_clear_all_button_pressed));
 	hboxcontainer->add_child(clear_all_button);
 
 	h_separator = memnew(HSeparator);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -911,8 +911,8 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 			button->add_theme_style_override("normal", memnew(StyleBoxEmpty));
 			button->add_theme_style_override("hover", memnew(StyleBoxEmpty));
 			button->add_theme_style_override("focus", memnew(StyleBoxEmpty));
-			button->add_theme_style_override("pressed", memnew(StyleBoxEmpty));
-			button->connect("pressed", callable_mp(tile_set_atlas_source, &TileSetAtlasSource::create_alternative_tile), varray(tile_id, TileSetSource::INVALID_TILE_ALTERNATIVE));
+			button->add_theme_style_override("button_clicked", memnew(StyleBoxEmpty));
+			button->connect("button_clicked", callable_mp(tile_set_atlas_source, &TileSetAtlasSource::create_alternative_tile), varray(tile_id, TileSetSource::INVALID_TILE_ALTERNATIVE));
 			button->set_rect(Rect2(Vector2(pos.x, pos.y + (y_increment - texture_region_base_size.y) / 2.0), Vector2(texture_region_base_size_min, texture_region_base_size_min)));
 			button->set_expand_icon(true);
 
@@ -2359,7 +2359,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	tile_data_editor_dropdown_button = memnew(Button);
 	tile_data_editor_dropdown_button->connect("draw", callable_mp(this, &TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_draw));
-	tile_data_editor_dropdown_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_pressed));
+	tile_data_editor_dropdown_button->connect("button_clicked", callable_mp(this, &TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_pressed));
 	middle_vbox_container->add_child(tile_data_editor_dropdown_button);
 	tile_data_editor_dropdown_button->add_child(tile_data_editors_popup);
 
@@ -2406,14 +2406,14 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	// -- Toolbox --
 	tools_button_group.instantiate();
-	tools_button_group->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_fix_selected_and_hovered_tiles).unbind(1));
-	tools_button_group->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_id_label).unbind(1));
-	tools_button_group->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_atlas_source_inspector).unbind(1));
-	tools_button_group->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_inspector).unbind(1));
-	tools_button_group->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_data_editors).unbind(1));
-	tools_button_group->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_current_tile_data_editor).unbind(1));
-	tools_button_group->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_atlas_view).unbind(1));
-	tools_button_group->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_toolbar).unbind(1));
+	tools_button_group->connect("button_clicked", callable_mp(this, &TileSetAtlasSourceEditor::_update_fix_selected_and_hovered_tiles).unbind(1));
+	tools_button_group->connect("button_clicked", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_id_label).unbind(1));
+	tools_button_group->connect("button_clicked", callable_mp(this, &TileSetAtlasSourceEditor::_update_atlas_source_inspector).unbind(1));
+	tools_button_group->connect("button_clicked", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_inspector).unbind(1));
+	tools_button_group->connect("button_clicked", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_data_editors).unbind(1));
+	tools_button_group->connect("button_clicked", callable_mp(this, &TileSetAtlasSourceEditor::_update_current_tile_data_editor).unbind(1));
+	tools_button_group->connect("button_clicked", callable_mp(this, &TileSetAtlasSourceEditor::_update_atlas_view).unbind(1));
+	tools_button_group->connect("button_clicked", callable_mp(this, &TileSetAtlasSourceEditor::_update_toolbar).unbind(1));
 
 	toolbox = memnew(HBoxContainer);
 	right_panel->add_child(toolbox);

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -688,7 +688,7 @@ TileSetEditor::TileSetEditor() {
 	sources_delete_button = memnew(Button);
 	sources_delete_button->set_flat(true);
 	sources_delete_button->set_disabled(true);
-	sources_delete_button->connect("pressed", callable_mp(this, &TileSetEditor::_source_delete_pressed));
+	sources_delete_button->connect("button_clicked", callable_mp(this, &TileSetEditor::_source_delete_pressed));
 	sources_bottom_actions->add_child(sources_delete_button);
 
 	sources_add_button = memnew(MenuButton);

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -517,13 +517,13 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 
 	scene_tile_add_button = memnew(Button);
 	scene_tile_add_button->set_flat(true);
-	scene_tile_add_button->connect("pressed", callable_mp(this, &TileSetScenesCollectionSourceEditor::_source_add_pressed));
+	scene_tile_add_button->connect("button_clicked", callable_mp(this, &TileSetScenesCollectionSourceEditor::_source_add_pressed));
 	scenes_bottom_actions->add_child(scene_tile_add_button);
 
 	scene_tile_delete_button = memnew(Button);
 	scene_tile_delete_button->set_flat(true);
 	scene_tile_delete_button->set_disabled(true);
-	scene_tile_delete_button->connect("pressed", callable_mp(this, &TileSetScenesCollectionSourceEditor::_source_delete_pressed));
+	scene_tile_delete_button->connect("button_clicked", callable_mp(this, &TileSetScenesCollectionSourceEditor::_source_delete_pressed));
 	scenes_bottom_actions->add_child(scene_tile_delete_button);
 }
 

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -399,7 +399,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	metadata_selection->add_item("None", (int)EditorVCSInterface::VCSMetadata::NONE);
 	metadata_selection->add_item("Git", (int)EditorVCSInterface::VCSMetadata::GIT);
 	metadata_selection->select((int)EditorVCSInterface::VCSMetadata::GIT);
-	metadata_dialog->get_ok_button()->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_create_vcs_metadata_files));
+	metadata_dialog->get_ok_button()->connect("button_clicked", callable_mp(this, &VersionControlEditorPlugin::_create_vcs_metadata_files));
 	metadata_hb->add_child(metadata_selection);
 	metadata_vb->add_child(metadata_hb);
 	l = memnew(Label);
@@ -440,7 +440,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	set_up_init_button = memnew(Button);
 	set_up_init_button->set_text(TTR("Initialize"));
-	set_up_init_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_initialize_vcs));
+	set_up_init_button->connect("button_clicked", callable_mp(this, &VersionControlEditorPlugin::_initialize_vcs));
 	set_up_vbc->add_child(set_up_init_button);
 
 	version_commit_dock = memnew(VBoxContainer);
@@ -465,7 +465,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	refresh_button->set_tooltip(TTR("Detect new changes"));
 	refresh_button->set_text(TTR("Refresh"));
 	refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
-	refresh_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area));
+	refresh_button->connect("button_clicked", callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area));
 	stage_tools->add_child(refresh_button);
 
 	stage_files = memnew(Tree);
@@ -502,12 +502,12 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	stage_selected_button = memnew(Button);
 	stage_selected_button->set_h_size_flags(Button::SIZE_EXPAND_FILL);
 	stage_selected_button->set_text(TTR("Stage Selected"));
-	stage_selected_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_stage_selected));
+	stage_selected_button->connect("button_clicked", callable_mp(this, &VersionControlEditorPlugin::_stage_selected));
 	stage_buttons->add_child(stage_selected_button);
 
 	stage_all_button = memnew(Button);
 	stage_all_button->set_text(TTR("Stage All"));
-	stage_all_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_stage_all));
+	stage_all_button->connect("button_clicked", callable_mp(this, &VersionControlEditorPlugin::_stage_all));
 	stage_buttons->add_child(stage_all_button);
 
 	commit_box_vbc->add_child(memnew(HSeparator));
@@ -526,7 +526,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	commit_button = memnew(Button);
 	commit_button->set_text(TTR("Commit Changes"));
 	commit_button->set_disabled(true);
-	commit_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_send_commit_msg));
+	commit_button->connect("button_clicked", callable_mp(this, &VersionControlEditorPlugin::_send_commit_msg));
 	commit_box_vbc->add_child(commit_button);
 
 	commit_status = memnew(Label);
@@ -561,7 +561,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	diff_refresh_button = memnew(Button);
 	diff_refresh_button->set_tooltip(TTR("Detect changes in file diff"));
 	diff_refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
-	diff_refresh_button->connect("pressed", callable_mp(this, &VersionControlEditorPlugin::_refresh_file_diff));
+	diff_refresh_button->connect("button_clicked", callable_mp(this, &VersionControlEditorPlugin::_refresh_file_diff));
 	diff_hbc->add_child(diff_refresh_button);
 
 	diff = memnew(RichTextLabel);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -514,7 +514,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 				register_default_input_button(p_id, 0, button);
 				custom_editor->move_child(button, 0);
 
-				button->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_edit_port_default_input), varray(button, p_id, 0));
+				button->connect("button_clicked", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_edit_port_default_input), varray(button, p_id, 0));
 				if (default_value.get_type() != Variant::NIL) {
 					set_input_port_default_value(p_type, p_id, 0, default_value);
 				} else {
@@ -533,7 +533,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 			register_output_port(p_id, 0, preview);
 
-			preview->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_preview_select_port), varray(p_id, 0), CONNECT_DEFERRED);
+			preview->connect("button_clicked", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_preview_select_port), varray(p_id, 0), CONNECT_DEFERRED);
 			custom_editor->add_child(preview);
 
 			if (vsnode->get_output_port_for_preview() >= 0) {
@@ -625,14 +625,14 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 			Button *add_input_btn = memnew(Button);
 			add_input_btn->set_text(TTR("Add Input"));
-			add_input_btn->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_add_input_port), varray(p_id, group_node->get_free_input_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, input_port_name), CONNECT_DEFERRED);
+			add_input_btn->connect("button_clicked", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_add_input_port), varray(p_id, group_node->get_free_input_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, input_port_name), CONNECT_DEFERRED);
 			hb2->add_child(add_input_btn);
 
 			hb2->add_spacer();
 
 			Button *add_output_btn = memnew(Button);
 			add_output_btn->set_text(TTR("Add Output"));
-			add_output_btn->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_add_output_port), varray(p_id, group_node->get_free_output_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, output_port_name), CONNECT_DEFERRED);
+			add_output_btn->connect("button_clicked", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_add_output_port), varray(p_id, group_node->get_free_output_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, output_port_name), CONNECT_DEFERRED);
 			hb2->add_child(add_output_btn);
 
 			node->add_child(hb2);
@@ -705,7 +705,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		Button *button = memnew(Button);
 		hb->add_child(button);
 		register_default_input_button(p_id, i, button);
-		button->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_edit_port_default_input), varray(button, p_id, i));
+		button->connect("button_clicked", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_edit_port_default_input), varray(button, p_id, i));
 		if (default_value.get_type() != Variant::NIL) { // only a label
 			set_input_port_default_value(p_type, p_id, i, default_value);
 		} else {
@@ -741,7 +741,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					Button *remove_btn = memnew(Button);
 					remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
-					remove_btn->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_remove_input_port), varray(p_id, i), CONNECT_DEFERRED);
+					remove_btn->connect("button_clicked", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_remove_input_port), varray(p_id, i), CONNECT_DEFERRED);
 					hb->add_child(remove_btn);
 				} else {
 					Label *label = memnew(Label);
@@ -768,7 +768,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					Button *remove_btn = memnew(Button);
 					remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
-					remove_btn->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_remove_output_port), varray(p_id, i), CONNECT_DEFERRED);
+					remove_btn->connect("button_clicked", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_remove_output_port), varray(p_id, i), CONNECT_DEFERRED);
 					hb->add_child(remove_btn);
 
 					LineEdit *name_box = memnew(LineEdit);
@@ -806,7 +806,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 				expand->set_pressed_texture(VisualShaderEditor::get_singleton()->get_theme_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")));
 				expand->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 				expand->set_pressed(vsnode->_is_output_port_expanded(i));
-				expand->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_expand_output_port), varray(p_id, i, !vsnode->_is_output_port_expanded(i)), CONNECT_DEFERRED);
+				expand->connect("button_clicked", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_expand_output_port), varray(p_id, i, !vsnode->_is_output_port_expanded(i)), CONNECT_DEFERRED);
 				hb->add_child(expand);
 			}
 			if (vsnode->has_output_port_preview(i) && port_right != VisualShaderNode::PORT_TYPE_TRANSFORM && port_right != VisualShaderNode::PORT_TYPE_SAMPLER) {
@@ -818,7 +818,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 				register_output_port(p_id, j, preview);
 
-				preview->connect("pressed", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_preview_select_port), varray(p_id, j), CONNECT_DEFERRED);
+				preview->connect("button_clicked", callable_mp(VisualShaderEditor::get_singleton(), &VisualShaderEditor::_preview_select_port), varray(p_id, j), CONNECT_DEFERRED);
 				hb->add_child(preview);
 			}
 		}
@@ -4076,7 +4076,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	custom_mode_box->set_text(TTR("Custom"));
 	custom_mode_box->set_pressed(false);
 	custom_mode_box->set_visible(false);
-	custom_mode_box->connect("toggled", callable_mp(this, &VisualShaderEditor::_custom_mode_toggled));
+	custom_mode_box->connect("button_toggled", callable_mp(this, &VisualShaderEditor::_custom_mode_toggled));
 
 	edit_type_standard = memnew(OptionButton);
 	edit_type_standard->add_item(TTR("Vertex"));
@@ -4120,14 +4120,14 @@ VisualShaderEditor::VisualShaderEditor() {
 	graph->get_zoom_hbox()->add_child(add_node);
 	add_node->set_text(TTR("Add Node..."));
 	graph->get_zoom_hbox()->move_child(add_node, 0);
-	add_node->connect("pressed", callable_mp(this, &VisualShaderEditor::_show_members_dialog), varray(false, VisualShaderNode::PORT_TYPE_MAX, VisualShaderNode::PORT_TYPE_MAX));
+	add_node->connect("button_clicked", callable_mp(this, &VisualShaderEditor::_show_members_dialog), varray(false, VisualShaderNode::PORT_TYPE_MAX, VisualShaderNode::PORT_TYPE_MAX));
 
 	preview_shader = memnew(Button);
 	preview_shader->set_flat(true);
 	preview_shader->set_toggle_mode(true);
 	preview_shader->set_tooltip(TTR("Show generated shader code."));
 	graph->get_zoom_hbox()->add_child(preview_shader);
-	preview_shader->connect("pressed", callable_mp(this, &VisualShaderEditor::_show_preview_text));
+	preview_shader->connect("button_clicked", callable_mp(this, &VisualShaderEditor::_show_preview_text));
 
 	///////////////////////////////////////
 	// PREVIEW WINDOW
@@ -4240,7 +4240,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	members_dialog->set_exclusive(false);
 	members_dialog->add_child(members_vb);
 	members_dialog->get_ok_button()->set_text(TTR("Create"));
-	members_dialog->get_ok_button()->connect("pressed", callable_mp(this, &VisualShaderEditor::_member_create));
+	members_dialog->get_ok_button()->connect("button_clicked", callable_mp(this, &VisualShaderEditor::_member_create));
 	members_dialog->get_ok_button()->set_disabled(true);
 	members_dialog->connect("cancelled", callable_mp(this, &VisualShaderEditor::_member_cancel));
 	add_child(members_dialog);
@@ -4278,7 +4278,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	Button *comment_desc_confirm_button = memnew(Button);
 	comment_desc_confirm_button->set_text(TTR("OK"));
 	comment_desc_vbox->add_child(comment_desc_confirm_button);
-	comment_desc_confirm_button->connect("pressed", callable_mp(this, &VisualShaderEditor::_comment_desc_confirm));
+	comment_desc_confirm_button->connect("button_clicked", callable_mp(this, &VisualShaderEditor::_comment_desc_confirm));
 	add_child(comment_desc_change_popup);
 
 	///////////////////////////////////////

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -145,7 +145,7 @@ VoxelGIEditorPlugin::VoxelGIEditorPlugin(EditorNode *p_node) {
 	bake->set_flat(true);
 	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake GI Probe"));
-	bake->connect("pressed", callable_mp(this, &VoxelGIEditorPlugin::_bake));
+	bake->connect("button_clicked", callable_mp(this, &VoxelGIEditorPlugin::_bake));
 	bake_hb->add_child(bake);
 	bake_info = memnew(Label);
 	bake_info->set_h_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -247,5 +247,5 @@ ProgressDialog::ProgressDialog() {
 	cancel_hb->add_child(cancel);
 	cancel->set_text(TTR("Cancel"));
 	cancel_hb->add_spacer();
-	cancel->connect("pressed", callable_mp(this, &ProgressDialog::_cancel_pressed));
+	cancel->connect("button_clicked", callable_mp(this, &ProgressDialog::_cancel_pressed));
 }

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1042,11 +1042,11 @@ ProjectExportDialog::ProjectExportDialog() {
 	duplicate_preset = memnew(Button);
 	duplicate_preset->set_flat(true);
 	preset_hb->add_child(duplicate_preset);
-	duplicate_preset->connect("pressed", callable_mp(this, &ProjectExportDialog::_duplicate_preset));
+	duplicate_preset->connect("button_clicked", callable_mp(this, &ProjectExportDialog::_duplicate_preset));
 	delete_preset = memnew(Button);
 	delete_preset->set_flat(true);
 	preset_hb->add_child(delete_preset);
-	delete_preset->connect("pressed", callable_mp(this, &ProjectExportDialog::_delete_preset));
+	delete_preset->connect("button_clicked", callable_mp(this, &ProjectExportDialog::_delete_preset));
 
 	// Preset settings.
 
@@ -1060,7 +1060,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	runnable = memnew(CheckButton);
 	runnable->set_text(TTR("Runnable"));
 	runnable->set_tooltip(TTR("If checked, the preset will be available for use in one-click deploy.\nOnly one preset per platform may be marked as runnable."));
-	runnable->connect("pressed", callable_mp(this, &ProjectExportDialog::_runnable_pressed));
+	runnable->connect("button_clicked", callable_mp(this, &ProjectExportDialog::_runnable_pressed));
 	settings_vb->add_child(runnable);
 
 	export_path = memnew(EditorPropertyPath);
@@ -1151,12 +1151,12 @@ ProjectExportDialog::ProjectExportDialog() {
 	sec_vb->set_name(TTR("Encryption"));
 
 	enc_pck = memnew(CheckButton);
-	enc_pck->connect("toggled", callable_mp(this, &ProjectExportDialog::_enc_pck_changed));
+	enc_pck->connect("button_toggled", callable_mp(this, &ProjectExportDialog::_enc_pck_changed));
 	enc_pck->set_text(TTR("Encrypt Exported PCK"));
 	sec_vb->add_child(enc_pck);
 
 	enc_directory = memnew(CheckButton);
-	enc_directory->connect("toggled", callable_mp(this, &ProjectExportDialog::_enc_directory_changed));
+	enc_directory->connect("button_toggled", callable_mp(this, &ProjectExportDialog::_enc_directory_changed));
 	enc_directory->set_text(TTR("Encrypt Index (File Names and Info)"));
 	sec_vb->add_child(enc_directory);
 
@@ -1187,7 +1187,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	LinkButton *sec_more_info = memnew(LinkButton);
 	sec_more_info->set_text(TTR("More Info..."));
-	sec_more_info->connect("pressed", callable_mp(this, &ProjectExportDialog::_open_key_help_link));
+	sec_more_info->connect("button_clicked", callable_mp(this, &ProjectExportDialog::_open_key_help_link));
 	sec_vb->add_child(sec_more_info);
 
 	sections->connect("tab_changed", callable_mp(this, &ProjectExportDialog::_tab_changed));
@@ -1216,7 +1216,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	get_cancel_button()->set_text(TTR("Close"));
 	get_ok_button()->set_text(TTR("Export PCK/ZIP..."));
 	export_button = add_button(TTR("Export Project..."), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "export");
-	export_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_export_project));
+	export_button->connect("button_clicked", callable_mp(this, &ProjectExportDialog::_export_project));
 	// Disable initially before we select a valid preset
 	export_button->set_disabled(true);
 	get_ok_button()->set_disabled(true);
@@ -1231,7 +1231,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_all_dialog->connect("custom_action", callable_mp(this, &ProjectExportDialog::_export_all_dialog_action));
 
 	export_all_button = add_button(TTR("Export All..."), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "export");
-	export_all_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_export_all_dialog));
+	export_all_button->connect("button_clicked", callable_mp(this, &ProjectExportDialog::_export_all_dialog));
 	export_all_button->set_disabled(true);
 
 	export_pck_zip = memnew(EditorFileDialog);
@@ -1266,7 +1266,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	download_templates->set_text(TTR("Manage Export Templates"));
 	download_templates->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	export_templates_error->add_child(download_templates);
-	download_templates->connect("pressed", callable_mp(this, &ProjectExportDialog::_open_export_template_manager));
+	download_templates->connect("button_clicked", callable_mp(this, &ProjectExportDialog::_open_export_template_manager));
 
 	export_project = memnew(EditorFileDialog);
 	export_project->set_access(EditorFileDialog::ACCESS_FILESYSTEM);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -472,7 +472,7 @@ private:
 						ConfirmationDialog *cd = memnew(ConfirmationDialog);
 						cd->set_title(TTR("Warning: This folder is not empty"));
 						cd->set_text(TTR("You are about to create a Godot project in a non-empty folder.\nThe entire contents of this folder will be imported as project resources!\n\nAre you sure you wish to continue?"));
-						cd->get_ok_button()->connect("pressed", callable_mp(this, &ProjectDialog::_nonempty_confirmation_ok_pressed));
+						cd->get_ok_button()->connect("button_clicked", callable_mp(this, &ProjectDialog::_nonempty_confirmation_ok_pressed));
 						get_parent()->add_child(cd);
 						cd->popup_centered();
 						cd->grab_focus();
@@ -819,7 +819,7 @@ public:
 		create_dir = memnew(Button);
 		pnhb->add_child(create_dir);
 		create_dir->set_text(TTR("Create Folder"));
-		create_dir->connect("pressed", callable_mp(this, &ProjectDialog::_create_folder));
+		create_dir->connect("button_clicked", callable_mp(this, &ProjectDialog::_create_folder));
 
 		path_container = memnew(VBoxContainer);
 		vb->add_child(path_container);
@@ -858,7 +858,7 @@ public:
 
 		browse = memnew(Button);
 		browse->set_text(TTR("Browse"));
-		browse->connect("pressed", callable_mp(this, &ProjectDialog::_browse_path));
+		browse->connect("button_clicked", callable_mp(this, &ProjectDialog::_browse_path));
 		pphb->add_child(browse);
 
 		// install status icon
@@ -868,7 +868,7 @@ public:
 
 		install_browse = memnew(Button);
 		install_browse->set_text(TTR("Browse"));
-		install_browse->connect("pressed", callable_mp(this, &ProjectDialog::_browse_install_path));
+		install_browse->connect("button_clicked", callable_mp(this, &ProjectDialog::_browse_install_path));
 		iphb->add_child(install_browse);
 
 		msg = memnew(Label);
@@ -1385,7 +1385,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	favorite->set_normal_texture(favorite_icon);
 	// This makes the project's "hover" style display correctly when hovering the favorite icon.
 	favorite->set_mouse_filter(MOUSE_FILTER_PASS);
-	favorite->connect("pressed", callable_mp(this, &ProjectList::_favorite_pressed), varray(hb));
+	favorite->connect("button_clicked", callable_mp(this, &ProjectList::_favorite_pressed), varray(hb));
 	favorite_box->add_child(favorite);
 	favorite_box->set_alignment(BoxContainer::ALIGN_CENTER);
 	hb->add_child(favorite_box);
@@ -1458,7 +1458,7 @@ void ProjectList::create_project_item_control(int p_index) {
 		path_hb->add_child(show);
 
 		if (!item.missing) {
-			show->connect("pressed", callable_mp(this, &ProjectList::_show_project), varray(item.path));
+			show->connect("button_clicked", callable_mp(this, &ProjectList::_show_project), varray(item.path));
 			show->set_tooltip(TTR("Show in File Manager"));
 		} else {
 			show->set_tooltip(TTR("Error: Project is missing on the filesystem."));
@@ -2425,8 +2425,8 @@ void ProjectManager::_files_dropped(PackedStringArray p_files, int p_screen) {
 			memdelete(dir);
 		}
 		if (confirm) {
-			multi_scan_ask->get_ok_button()->disconnect("pressed", callable_mp(this, &ProjectManager::_scan_multiple_folders));
-			multi_scan_ask->get_ok_button()->connect("pressed", callable_mp(this, &ProjectManager::_scan_multiple_folders), varray(folders));
+			multi_scan_ask->get_ok_button()->disconnect("button_clicked", callable_mp(this, &ProjectManager::_scan_multiple_folders));
+			multi_scan_ask->get_ok_button()->connect("button_clicked", callable_mp(this, &ProjectManager::_scan_multiple_folders), varray(folders));
 			multi_scan_ask->set_text(
 					vformat(TTR("Are you sure to scan %s folders for existing Godot projects?\nThis could take a while."), folders.size()));
 			multi_scan_ask->popup_centered();
@@ -2634,19 +2634,19 @@ ProjectManager::ProjectManager() {
 		Button *create = memnew(Button);
 		create->set_text(TTR("New Project"));
 		create->set_shortcut(ED_SHORTCUT("project_manager/new_project", TTR("New Project"), KeyModifierMask::CMD | Key::N));
-		create->connect("pressed", callable_mp(this, &ProjectManager::_new_project));
+		create->connect("button_clicked", callable_mp(this, &ProjectManager::_new_project));
 		tree_vb->add_child(create);
 
 		Button *import = memnew(Button);
 		import->set_text(TTR("Import"));
 		import->set_shortcut(ED_SHORTCUT("project_manager/import_project", TTR("Import Project"), KeyModifierMask::CMD | Key::I));
-		import->connect("pressed", callable_mp(this, &ProjectManager::_import_project));
+		import->connect("button_clicked", callable_mp(this, &ProjectManager::_import_project));
 		tree_vb->add_child(import);
 
 		Button *scan = memnew(Button);
 		scan->set_text(TTR("Scan"));
 		scan->set_shortcut(ED_SHORTCUT("project_manager/scan_projects", TTR("Scan Projects"), KeyModifierMask::CMD | Key::S));
-		scan->connect("pressed", callable_mp(this, &ProjectManager::_scan_projects));
+		scan->connect("button_clicked", callable_mp(this, &ProjectManager::_scan_projects));
 		tree_vb->add_child(scan);
 
 		tree_vb->add_child(memnew(HSeparator));
@@ -2654,38 +2654,38 @@ ProjectManager::ProjectManager() {
 		open_btn = memnew(Button);
 		open_btn->set_text(TTR("Edit"));
 		open_btn->set_shortcut(ED_SHORTCUT("project_manager/edit_project", TTR("Edit Project"), KeyModifierMask::CMD | Key::E));
-		open_btn->connect("pressed", callable_mp(this, &ProjectManager::_open_selected_projects_ask));
+		open_btn->connect("button_clicked", callable_mp(this, &ProjectManager::_open_selected_projects_ask));
 		tree_vb->add_child(open_btn);
 
 		run_btn = memnew(Button);
 		run_btn->set_text(TTR("Run"));
 		run_btn->set_shortcut(ED_SHORTCUT("project_manager/run_project", TTR("Run Project"), KeyModifierMask::CMD | Key::R));
-		run_btn->connect("pressed", callable_mp(this, &ProjectManager::_run_project));
+		run_btn->connect("button_clicked", callable_mp(this, &ProjectManager::_run_project));
 		tree_vb->add_child(run_btn);
 
 		rename_btn = memnew(Button);
 		rename_btn->set_text(TTR("Rename"));
 		// The F2 shortcut isn't overridden with Enter on macOS as Enter is already used to edit a project.
 		rename_btn->set_shortcut(ED_SHORTCUT("project_manager/rename_project", TTR("Rename Project"), Key::F2));
-		rename_btn->connect("pressed", callable_mp(this, &ProjectManager::_rename_project));
+		rename_btn->connect("button_clicked", callable_mp(this, &ProjectManager::_rename_project));
 		tree_vb->add_child(rename_btn);
 
 		erase_btn = memnew(Button);
 		erase_btn->set_text(TTR("Remove"));
 		erase_btn->set_shortcut(ED_SHORTCUT("project_manager/remove_project", TTR("Remove Project"), Key::KEY_DELETE));
-		erase_btn->connect("pressed", callable_mp(this, &ProjectManager::_erase_project));
+		erase_btn->connect("button_clicked", callable_mp(this, &ProjectManager::_erase_project));
 		tree_vb->add_child(erase_btn);
 
 		erase_missing_btn = memnew(Button);
 		erase_missing_btn->set_text(TTR("Remove Missing"));
-		erase_missing_btn->connect("pressed", callable_mp(this, &ProjectManager::_erase_missing_projects));
+		erase_missing_btn->connect("button_clicked", callable_mp(this, &ProjectManager::_erase_missing_projects));
 		tree_vb->add_child(erase_missing_btn);
 
 		tree_vb->add_spacer();
 
 		about_btn = memnew(Button);
 		about_btn->set_text(TTR("About"));
-		about_btn->connect("pressed", callable_mp(this, &ProjectManager::_show_about));
+		about_btn->connect("button_clicked", callable_mp(this, &ProjectManager::_show_about));
 		tree_vb->add_child(about_btn);
 	}
 
@@ -2713,7 +2713,7 @@ ProjectManager::ProjectManager() {
 		version_btn->set_self_modulate(Color(1, 1, 1, 0.6));
 		version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
 		version_btn->set_tooltip(TTR("Click to copy."));
-		version_btn->connect("pressed", callable_mp(this, &ProjectManager::_version_button_pressed));
+		version_btn->connect("button_clicked", callable_mp(this, &ProjectManager::_version_button_pressed));
 		spacer_vb->add_child(version_btn);
 
 		// Add a small horizontal spacer between the version and language buttons
@@ -2767,7 +2767,7 @@ ProjectManager::ProjectManager() {
 		// Dialogs
 		language_restart_ask = memnew(ConfirmationDialog);
 		language_restart_ask->get_ok_button()->set_text(TTR("Restart Now"));
-		language_restart_ask->get_ok_button()->connect("pressed", callable_mp(this, &ProjectManager::_restart_confirm));
+		language_restart_ask->get_ok_button()->connect("button_clicked", callable_mp(this, &ProjectManager::_restart_confirm));
 		language_restart_ask->get_cancel_button()->set_text(TTR("Continue"));
 		add_child(language_restart_ask);
 
@@ -2781,12 +2781,12 @@ ProjectManager::ProjectManager() {
 
 		erase_missing_ask = memnew(ConfirmationDialog);
 		erase_missing_ask->get_ok_button()->set_text(TTR("Remove All"));
-		erase_missing_ask->get_ok_button()->connect("pressed", callable_mp(this, &ProjectManager::_erase_missing_projects_confirm));
+		erase_missing_ask->get_ok_button()->connect("button_clicked", callable_mp(this, &ProjectManager::_erase_missing_projects_confirm));
 		add_child(erase_missing_ask);
 
 		erase_ask = memnew(ConfirmationDialog);
 		erase_ask->get_ok_button()->set_text(TTR("Remove"));
-		erase_ask->get_ok_button()->connect("pressed", callable_mp(this, &ProjectManager::_erase_project_confirm));
+		erase_ask->get_ok_button()->connect("button_clicked", callable_mp(this, &ProjectManager::_erase_project_confirm));
 		add_child(erase_ask);
 
 		VBoxContainer *erase_ask_vb = memnew(VBoxContainer);
@@ -2801,12 +2801,12 @@ ProjectManager::ProjectManager() {
 
 		multi_open_ask = memnew(ConfirmationDialog);
 		multi_open_ask->get_ok_button()->set_text(TTR("Edit"));
-		multi_open_ask->get_ok_button()->connect("pressed", callable_mp(this, &ProjectManager::_open_selected_projects));
+		multi_open_ask->get_ok_button()->connect("button_clicked", callable_mp(this, &ProjectManager::_open_selected_projects));
 		add_child(multi_open_ask);
 
 		multi_run_ask = memnew(ConfirmationDialog);
 		multi_run_ask->get_ok_button()->set_text(TTR("Run"));
-		multi_run_ask->get_ok_button()->connect("pressed", callable_mp(this, &ProjectManager::_run_project_confirm));
+		multi_run_ask->get_ok_button()->connect("button_clicked", callable_mp(this, &ProjectManager::_run_project_confirm));
 		add_child(multi_run_ask);
 
 		multi_scan_ask = memnew(ConfirmationDialog);
@@ -2814,7 +2814,7 @@ ProjectManager::ProjectManager() {
 		add_child(multi_scan_ask);
 
 		ask_update_settings = memnew(ConfirmationDialog);
-		ask_update_settings->get_ok_button()->connect("pressed", callable_mp(this, &ProjectManager::_confirm_update_settings));
+		ask_update_settings->get_ok_button()->connect("button_clicked", callable_mp(this, &ProjectManager::_confirm_update_settings));
 		add_child(ask_update_settings);
 
 		npdialog = memnew(ProjectDialog);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -533,7 +533,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	advanced = memnew(CheckButton);
 	advanced->set_text(TTR("Advanced Settings"));
-	advanced->connect("toggled", callable_mp(this, &ProjectSettingsEditor::_advanced_toggled));
+	advanced->connect("button_toggled", callable_mp(this, &ProjectSettingsEditor::_advanced_toggled));
 	search_bar->add_child(advanced);
 
 	HBoxContainer *header = memnew(HBoxContainer);
@@ -565,13 +565,13 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	add_button = memnew(Button);
 	add_button->set_text(TTR("Add"));
 	add_button->set_disabled(true);
-	add_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_add_setting));
+	add_button->connect("button_clicked", callable_mp(this, &ProjectSettingsEditor::_add_setting));
 	header->add_child(add_button);
 
 	del_button = memnew(Button);
 	del_button->set_text(TTR("Delete"));
 	del_button->set_disabled(true);
-	del_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_delete_setting));
+	del_button->connect("button_clicked", callable_mp(this, &ProjectSettingsEditor::_delete_setting));
 	header->add_child(del_button);
 
 	inspector = memnew(SectionedInspector);
@@ -600,13 +600,13 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	restart_hb->add_spacer();
 
 	Button *restart_button = memnew(Button);
-	restart_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_editor_restart));
+	restart_button->connect("button_clicked", callable_mp(this, &ProjectSettingsEditor::_editor_restart));
 	restart_hb->add_child(restart_button);
 	restart_button->set_text(TTR("Save & Restart"));
 
 	restart_close_button = memnew(Button);
 	restart_close_button->set_flat(true);
-	restart_close_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_editor_restart_close));
+	restart_close_button->connect("button_clicked", callable_mp(this, &ProjectSettingsEditor::_editor_restart_close));
 	restart_hb->add_child(restart_close_button);
 
 	action_map = memnew(ActionMapEditor);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -1799,7 +1799,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		checks20[i]->set_focus_mode(Control::FOCUS_NONE);
 		checks20gc->add_child(checks20[i]);
 		checks20[i]->hide();
-		checks20[i]->connect("pressed", callable_mp(this, &CustomPropertyEditor::_action_pressed), make_binds(i));
+		checks20[i]->connect("button_clicked", callable_mp(this, &CustomPropertyEditor::_action_pressed), make_binds(i));
 		checks20[i]->set_tooltip(vformat(TTR("Bit %d, val %d."), i, 1 << i));
 	}
 
@@ -1872,7 +1872,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		action_hboxes->add_child(action_buttons[i]);
 		Vector<Variant> binds;
 		binds.push_back(i);
-		action_buttons[i]->connect("pressed", callable_mp(this, &CustomPropertyEditor::_action_pressed), binds);
+		action_buttons[i]->connect("button_clicked", callable_mp(this, &CustomPropertyEditor::_action_pressed), binds);
 	}
 
 	create_dialog = nullptr;

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -140,7 +140,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_name->set_text("NAME");
 	but_insert_name->set_tooltip(String("${NAME}\n") + TTR("Node name."));
 	but_insert_name->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_name->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${NAME}"));
+	but_insert_name->connect("button_clicked", callable_mp(this, &RenameDialog::_insert_text), make_binds("${NAME}"));
 	but_insert_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_name);
 
@@ -150,7 +150,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_parent->set_text("PARENT");
 	but_insert_parent->set_tooltip(String("${PARENT}\n") + TTR("Node's parent name, if available."));
 	but_insert_parent->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_parent->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${PARENT}"));
+	but_insert_parent->connect("button_clicked", callable_mp(this, &RenameDialog::_insert_text), make_binds("${PARENT}"));
 	but_insert_parent->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_parent);
 
@@ -160,7 +160,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_type->set_text("TYPE");
 	but_insert_type->set_tooltip(String("${TYPE}\n") + TTR("Node type."));
 	but_insert_type->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_type->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${TYPE}"));
+	but_insert_type->connect("button_clicked", callable_mp(this, &RenameDialog::_insert_text), make_binds("${TYPE}"));
 	but_insert_type->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_type);
 
@@ -170,7 +170,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_scene->set_text("SCENE");
 	but_insert_scene->set_tooltip(String("${SCENE}\n") + TTR("Current scene name."));
 	but_insert_scene->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_scene->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${SCENE}"));
+	but_insert_scene->connect("button_clicked", callable_mp(this, &RenameDialog::_insert_text), make_binds("${SCENE}"));
 	but_insert_scene->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_scene);
 
@@ -180,7 +180,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_root->set_text("ROOT");
 	but_insert_root->set_tooltip(String("${ROOT}\n") + TTR("Root node name."));
 	but_insert_root->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_root->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${ROOT}"));
+	but_insert_root->connect("button_clicked", callable_mp(this, &RenameDialog::_insert_text), make_binds("${ROOT}"));
 	but_insert_root->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_root);
 
@@ -190,7 +190,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_count->set_text("COUNTER");
 	but_insert_count->set_tooltip(String("${COUNTER}\n") + TTR("Sequential integer counter.\nCompare counter options."));
 	but_insert_count->set_focus_mode(Control::FOCUS_NONE);
-	but_insert_count->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${COUNTER}"));
+	but_insert_count->connect("button_clicked", callable_mp(this, &RenameDialog::_insert_text), make_binds("${COUNTER}"));
 	but_insert_count->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_count);
 
@@ -297,7 +297,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	// ---- Connections
 
-	cbut_collapse_features->connect("toggled", callable_mp(this, &RenameDialog::_features_toggled));
+	cbut_collapse_features->connect("button_toggled", callable_mp(this, &RenameDialog::_features_toggled));
 
 	// Substitute Buttons
 
@@ -321,11 +321,11 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	spn_count_padding->connect("value_changed", callable_mp(this, &RenameDialog::_update_preview_int));
 	opt_style->connect("item_selected", callable_mp(this, &RenameDialog::_update_preview_int));
 	opt_case->connect("item_selected", callable_mp(this, &RenameDialog::_update_preview_int));
-	cbut_substitute->connect("pressed", callable_mp(this, &RenameDialog::_update_preview), varray(""));
-	cbut_regex->connect("pressed", callable_mp(this, &RenameDialog::_update_preview), varray(""));
-	cbut_process->connect("pressed", callable_mp(this, &RenameDialog::_update_preview), varray(""));
+	cbut_substitute->connect("button_clicked", callable_mp(this, &RenameDialog::_update_preview), varray(""));
+	cbut_regex->connect("button_clicked", callable_mp(this, &RenameDialog::_update_preview), varray(""));
+	cbut_process->connect("button_clicked", callable_mp(this, &RenameDialog::_update_preview), varray(""));
 
-	but_reset->connect("pressed", callable_mp(this, &RenameDialog::reset));
+	but_reset->connect("button_clicked", callable_mp(this, &RenameDialog::reset));
 
 	reset();
 	_features_toggled(false);

--- a/editor/reparent_dialog.cpp
+++ b/editor/reparent_dialog.cpp
@@ -85,7 +85,7 @@ ReparentDialog::ReparentDialog() {
 
 	//vbc->add_margin_child("Options:",node_only);
 
-	//cancel->connect("pressed", this,"_cancel");
+	//cancel->connect("button_clicked", this,"_cancel");
 
 	get_ok_button()->set_text(TTR("Reparent"));
 }

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1247,7 +1247,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts_toggle->set_tooltip(TTR("Switch to Favorite Nodes"));
 			node_shortcuts_toggle->set_pressed(EDITOR_GET("_use_favorites_root_selection"));
 			node_shortcuts_toggle->set_anchors_and_offsets_preset(Control::PRESET_CENTER_RIGHT);
-			node_shortcuts_toggle->connect("pressed", callable_mp(this, &SceneTreeDock::_update_create_root_dialog));
+			node_shortcuts_toggle->connect("button_clicked", callable_mp(this, &SceneTreeDock::_update_create_root_dialog));
 			top_row->add_child(node_shortcuts_toggle);
 
 			create_root_dialog->add_child(top_row);
@@ -1263,19 +1263,19 @@ void SceneTreeDock::_notification(int p_what) {
 			beginner_node_shortcuts->add_child(button_2d);
 			button_2d->set_text(TTR("2D Scene"));
 			button_2d->set_icon(get_theme_icon(SNAME("Node2D"), SNAME("EditorIcons")));
-			button_2d->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_2D_SCENE, false));
+			button_2d->connect("button_clicked", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_2D_SCENE, false));
 
 			button_3d = memnew(Button);
 			beginner_node_shortcuts->add_child(button_3d);
 			button_3d->set_text(TTR("3D Scene"));
 			button_3d->set_icon(get_theme_icon(SNAME("Node3D"), SNAME("EditorIcons")));
-			button_3d->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_3D_SCENE, false));
+			button_3d->connect("button_clicked", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_3D_SCENE, false));
 
 			button_ui = memnew(Button);
 			beginner_node_shortcuts->add_child(button_ui);
 			button_ui->set_text(TTR("User Interface"));
 			button_ui->set_icon(get_theme_icon(SNAME("Control"), SNAME("EditorIcons")));
-			button_ui->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_USER_INTERFACE, false));
+			button_ui->connect("button_clicked", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_CREATE_USER_INTERFACE, false));
 
 			VBoxContainer *favorite_node_shortcuts = memnew(VBoxContainer);
 			favorite_node_shortcuts->set_name("FavoriteNodeShortcuts");
@@ -1285,7 +1285,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts->add_child(button_custom);
 			button_custom->set_text(TTR("Other Node"));
 			button_custom->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-			button_custom->connect("pressed", callable_bind(callable_mp(this, &SceneTreeDock::_tool_selected), TOOL_NEW, false));
+			button_custom->connect("button_clicked", callable_bind(callable_mp(this, &SceneTreeDock::_tool_selected), TOOL_NEW, false));
 
 			node_shortcuts->add_spacer();
 			create_root_dialog->add_child(node_shortcuts);
@@ -3075,7 +3075,7 @@ void SceneTreeDock::_update_create_root_dialog() {
 						name = ScriptServer::get_global_class_native_base(name);
 					}
 					button->set_icon(EditorNode::get_singleton()->get_class_icon(name));
-					button->connect("pressed", callable_mp(this, &SceneTreeDock::_favorite_root_selected), make_binds(l));
+					button->connect("button_clicked", callable_mp(this, &SceneTreeDock::_favorite_root_selected), make_binds(l));
 				}
 			}
 
@@ -3258,14 +3258,14 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	button_add = memnew(Button);
 	button_add->set_flat(true);
-	button_add->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_NEW, false));
+	button_add->connect("button_clicked", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_NEW, false));
 	button_add->set_tooltip(TTR("Add/Create a New Node."));
 	button_add->set_shortcut(ED_GET_SHORTCUT("scene_tree/add_child_node"));
 	filter_hbc->add_child(button_add);
 
 	button_instance = memnew(Button);
 	button_instance->set_flat(true);
-	button_instance->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_INSTANTIATE, false));
+	button_instance->connect("button_clicked", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_INSTANTIATE, false));
 	button_instance->set_tooltip(TTR("Instantiate a scene file as a Node. Creates an inherited scene if no root node exists."));
 	button_instance->set_shortcut(ED_GET_SHORTCUT("scene_tree/instance_scene"));
 	filter_hbc->add_child(button_instance);
@@ -3280,7 +3280,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	button_create_script = memnew(Button);
 	button_create_script->set_flat(true);
-	button_create_script->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_ATTACH_SCRIPT, false));
+	button_create_script->connect("button_clicked", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_ATTACH_SCRIPT, false));
 	button_create_script->set_tooltip(TTR("Attach a new or existing script to the selected node."));
 	button_create_script->set_shortcut(ED_GET_SHORTCUT("scene_tree/attach_script"));
 	filter_hbc->add_child(button_create_script);
@@ -3288,7 +3288,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	button_detach_script = memnew(Button);
 	button_detach_script->set_flat(true);
-	button_detach_script->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_DETACH_SCRIPT, false));
+	button_detach_script->connect("button_clicked", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_DETACH_SCRIPT, false));
 	button_detach_script->set_tooltip(TTR("Detach the script from the selected node."));
 	button_detach_script->set_shortcut(ED_GET_SHORTCUT("scene_tree/detach_script"));
 	filter_hbc->add_child(button_detach_script);
@@ -3296,7 +3296,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	button_tree_menu = memnew(Button);
 	button_tree_menu->set_flat(true);
-	button_tree_menu->connect("pressed", callable_mp(this, &SceneTreeDock::_open_tree_menu));
+	button_tree_menu->connect("button_clicked", callable_mp(this, &SceneTreeDock::_open_tree_menu));
 	filter_hbc->add_child(button_tree_menu);
 
 	button_hb = memnew(HBoxContainer);
@@ -3309,7 +3309,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	edit_remote->set_text(TTR("Remote"));
 	edit_remote->set_toggle_mode(true);
 	edit_remote->set_tooltip(TTR("If selected, the Remote scene tree dock will cause the project to stutter every time it updates.\nSwitch back to the Local scene tree dock to improve performance."));
-	edit_remote->connect("pressed", callable_mp(this, &SceneTreeDock::_remote_tree_selected));
+	edit_remote->connect("button_clicked", callable_mp(this, &SceneTreeDock::_remote_tree_selected));
 
 	edit_local = memnew(Button);
 	edit_local->set_flat(true);
@@ -3318,7 +3318,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	edit_local->set_text(TTR("Local"));
 	edit_local->set_toggle_mode(true);
 	edit_local->set_pressed(true);
-	edit_local->connect("pressed", callable_mp(this, &SceneTreeDock::_local_tree_selected));
+	edit_local->connect("button_clicked", callable_mp(this, &SceneTreeDock::_local_tree_selected));
 
 	remote_tree = nullptr;
 	button_hb->hide();

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -832,10 +832,10 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	parent_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hb->add_child(parent_name);
 	parent_search_button = memnew(Button);
-	parent_search_button->connect("pressed", callable_mp(this, &ScriptCreateDialog::_browse_class_in_tree));
+	parent_search_button->connect("button_clicked", callable_mp(this, &ScriptCreateDialog::_browse_class_in_tree));
 	hb->add_child(parent_search_button);
 	parent_browse_button = memnew(Button);
-	parent_browse_button->connect("pressed", callable_mp(this, &ScriptCreateDialog::_browse_path), varray(true, false));
+	parent_browse_button->connect("button_clicked", callable_mp(this, &ScriptCreateDialog::_browse_path), varray(true, false));
 	hb->add_child(parent_browse_button);
 	gc->add_child(memnew(Label(TTR("Inherits:"))));
 	gc->add_child(hb);
@@ -860,7 +860,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	internal = memnew(CheckBox);
 	internal->set_text(TTR("On"));
-	internal->connect("pressed", callable_mp(this, &ScriptCreateDialog::_built_in_pressed));
+	internal->connect("button_clicked", callable_mp(this, &ScriptCreateDialog::_built_in_pressed));
 	gc->add_child(memnew(Label(TTR("Built-in Script:"))));
 	gc->add_child(internal);
 
@@ -873,7 +873,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	file_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hb->add_child(file_path);
 	path_button = memnew(Button);
-	path_button->connect("pressed", callable_mp(this, &ScriptCreateDialog::_browse_path), varray(false, true));
+	path_button->connect("button_clicked", callable_mp(this, &ScriptCreateDialog::_browse_path), varray(false, true));
 	hb->add_child(path_button);
 	Label *label = memnew(Label(TTR("Path:")));
 	gc->add_child(label);

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -662,12 +662,12 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	restart_hb->add_child(restart_label);
 	restart_hb->add_spacer();
 	Button *restart_button = memnew(Button);
-	restart_button->connect("pressed", callable_mp(this, &EditorSettingsDialog::_editor_restart));
+	restart_button->connect("button_clicked", callable_mp(this, &EditorSettingsDialog::_editor_restart));
 	restart_hb->add_child(restart_button);
 	restart_button->set_text(TTR("Save & Restart"));
 	restart_close_button = memnew(Button);
 	restart_close_button->set_flat(true);
-	restart_close_button->connect("pressed", callable_mp(this, &EditorSettingsDialog::_editor_restart_close));
+	restart_close_button->connect("button_clicked", callable_mp(this, &EditorSettingsDialog::_editor_restart_close));
 	restart_hb->add_child(restart_close_button);
 	restart_container->hide();
 

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -597,7 +597,7 @@ ShaderCreateDialog::ShaderCreateDialog() {
 
 	internal = memnew(CheckBox);
 	internal->set_text(TTR("On"));
-	internal->connect("toggled", callable_mp(this, &ShaderCreateDialog::_built_in_toggled));
+	internal->connect("button_toggled", callable_mp(this, &ShaderCreateDialog::_built_in_toggled));
 	gc->add_child(memnew(Label(TTR("Built-in Shader:"))));
 	gc->add_child(internal);
 
@@ -611,7 +611,7 @@ ShaderCreateDialog::ShaderCreateDialog() {
 	file_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hb->add_child(file_path);
 	path_button = memnew(Button);
-	path_button->connect("pressed", callable_mp(this, &ShaderCreateDialog::_browse_path));
+	path_button->connect("button_clicked", callable_mp(this, &ShaderCreateDialog::_browse_path));
 	hb->add_child(path_button);
 	gc->add_child(memnew(Label(TTR("Path:"))));
 	gc->add_child(hb);

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -465,7 +465,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 
 	variable_add = memnew(Button(TTR("Add")));
 	add_menu_hb->add_child(variable_add);
-	variable_add->connect("pressed", callable_mp(this, &ShaderGlobalsEditor::_variable_added));
+	variable_add->connect("button_clicked", callable_mp(this, &ShaderGlobalsEditor::_variable_added));
 
 	inspector = memnew(EditorInspector);
 	inspector->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -381,7 +381,7 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 	new_architecture_dialog->add_child(new_architecture_input);
 	//	new_architecture_dialog->set_custom_minimum_size(Vector2(300, 80) * EDSCALE);
 	new_architecture_input->set_anchors_and_offsets_preset(PRESET_HCENTER_WIDE, PRESET_MODE_MINSIZE, 5 * EDSCALE);
-	new_architecture_dialog->get_ok_button()->connect("pressed", callable_mp(this, &GDNativeLibraryEditor::_on_create_new_entry));
+	new_architecture_dialog->get_ok_button()->connect("button_clicked", callable_mp(this, &GDNativeLibraryEditor::_on_create_new_entry));
 }
 
 void GDNativeLibraryEditorPlugin::edit(Object *p_node) {

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1252,7 +1252,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	mode_thumbnail->set_pressed(true);
 	mode_thumbnail->set_icon(p_editor->get_gui_base()->get_theme_icon(SNAME("FileThumbnail"), SNAME("EditorIcons")));
 	hb->add_child(mode_thumbnail);
-	mode_thumbnail->connect("pressed", callable_mp(this, &GridMapEditor::_set_display_mode), varray(DISPLAY_THUMBNAIL));
+	mode_thumbnail->connect("button_clicked", callable_mp(this, &GridMapEditor::_set_display_mode), varray(DISPLAY_THUMBNAIL));
 
 	mode_list = memnew(Button);
 	mode_list->set_flat(true);
@@ -1260,7 +1260,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	mode_list->set_pressed(false);
 	mode_list->set_icon(p_editor->get_gui_base()->get_theme_icon(SNAME("FileList"), SNAME("EditorIcons")));
 	hb->add_child(mode_list);
-	mode_list->connect("pressed", callable_mp(this, &GridMapEditor::_set_display_mode), varray(DISPLAY_LIST));
+	mode_list->connect("button_clicked", callable_mp(this, &GridMapEditor::_set_display_mode), varray(DISPLAY_LIST));
 
 	size_slider = memnew(HSlider);
 	size_slider->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -150,7 +150,7 @@ namespace GodotTools.Build
                 Pressed = true,
                 FocusMode = FocusModeEnum.None
             };
-            _errorsBtn.Toggled += ErrorsToggled;
+            _errorsBtn.ButtonToggled += ErrorsToggled;
             toolBarHBox.AddChild(_errorsBtn);
 
             _warningsBtn = new Button
@@ -162,7 +162,7 @@ namespace GodotTools.Build
                 Pressed = true,
                 FocusMode = FocusModeEnum.None
             };
-            _warningsBtn.Toggled += WarningsToggled;
+            _warningsBtn.ButtonToggled += WarningsToggled;
             toolBarHBox.AddChild(_warningsBtn);
 
             _viewLogBtn = new Button
@@ -172,7 +172,7 @@ namespace GodotTools.Build
                 Pressed = true,
                 FocusMode = FocusModeEnum.None
             };
-            _viewLogBtn.Toggled += ViewLogToggled;
+            _viewLogBtn.ButtonToggled += ViewLogToggled;
             toolBarHBox.AddChild(_viewLogBtn);
 
             BuildOutputView = new BuildOutputView();

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -156,7 +156,7 @@ namespace GodotTools
             }
         }
 
-        private void BuildSolutionPressed()
+        private void BuildSolutionClicked()
         {
             if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
             {
@@ -428,7 +428,7 @@ namespace GodotTools
                 Shortcut = buildSolutionShortcut,
                 ShortcutInTooltip = true
             };
-            _toolBarBuildButton.PressedSignal += BuildSolutionPressed;
+            _toolBarBuildButton.ButtonClicked += BuildSolutionClicked;
             AddControlToContainer(CustomControlContainer.Toolbar, _toolBarBuildButton);
 
             if (File.Exists(GodotSharpDirs.ProjectSlnPath) && File.Exists(GodotSharpDirs.ProjectCsProjPath))

--- a/modules/navigation/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/navigation_mesh_editor_plugin.cpp
@@ -100,14 +100,14 @@ NavigationMeshEditor::NavigationMeshEditor() {
 	bake_hbox->add_child(button_bake);
 	button_bake->set_toggle_mode(true);
 	button_bake->set_text(TTR("Bake NavMesh"));
-	button_bake->connect("pressed", callable_mp(this, &NavigationMeshEditor::_bake_pressed));
+	button_bake->connect("button_clicked", callable_mp(this, &NavigationMeshEditor::_bake_pressed));
 
 	button_reset = memnew(Button);
 	button_reset->set_flat(true);
 	bake_hbox->add_child(button_reset);
 	// No button text, we only use a revert icon which is set when entering the tree.
 	button_reset->set_tooltip(TTR("Clear the navigation mesh."));
-	button_reset->connect("pressed", callable_mp(this, &NavigationMeshEditor::_clear_pressed));
+	button_reset->connect("button_clicked", callable_mp(this, &NavigationMeshEditor::_clear_pressed));
 
 	bake_info = memnew(Label);
 	bake_hbox->add_child(bake_info);

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -694,7 +694,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				Button *btn = memnew(Button);
 				btn->set_text(TTR("Add Input Port"));
 				hbnc->add_child(btn);
-				btn->connect("pressed", callable_mp(this, &VisualScriptEditor::_add_input_port), varray(E), CONNECT_DEFERRED);
+				btn->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_add_input_port), varray(E), CONNECT_DEFERRED);
 			}
 			if (nd_list->is_output_port_editable()) {
 				if (nd_list->is_input_port_editable()) {
@@ -704,7 +704,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				Button *btn = memnew(Button);
 				btn->set_text(TTR("Add Output Port"));
 				hbnc->add_child(btn);
-				btn->connect("pressed", callable_mp(this, &VisualScriptEditor::_add_output_port), varray(E), CONNECT_DEFERRED);
+				btn->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_add_output_port), varray(E), CONNECT_DEFERRED);
 			}
 			gnode->add_child(hbnc);
 		} else if (Object::cast_to<VisualScriptExpression>(node.ptr())) {
@@ -853,7 +853,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					Button *rmbtn = memnew(Button);
 					rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					hbc->add_child(rmbtn);
-					rmbtn->connect("pressed", callable_mp(this, &VisualScriptEditor::_remove_input_port), varray(E, i), CONNECT_DEFERRED);
+					rmbtn->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_remove_input_port), varray(E, i), CONNECT_DEFERRED);
 				} else {
 					hbc->add_child(memnew(Label(left_name)));
 				}
@@ -885,7 +885,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					} else {
 						button->set_text(value);
 					}
-					button->connect("pressed", callable_mp(this, &VisualScriptEditor::_default_value_edited), varray(button, E, i));
+					button->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_default_value_edited), varray(button, E, i));
 					hbc2->add_child(button);
 				}
 			} else {
@@ -909,7 +909,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					Button *rmbtn = memnew(Button);
 					rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					hbc->add_child(rmbtn);
-					rmbtn->connect("pressed", callable_mp(this, &VisualScriptEditor::_remove_output_port), varray(E, i), CONNECT_DEFERRED);
+					rmbtn->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_remove_output_port), varray(E, i), CONNECT_DEFERRED);
 
 					if (nd_list->is_output_port_type_editable()) {
 						OptionButton *opbtn = memnew(OptionButton);
@@ -1408,7 +1408,7 @@ void VisualScriptEditor::_add_func_input() {
 	func_input_vbox->add_child(hbox);
 	hbox->set_meta("id", hbox->get_index());
 
-	delete_button->connect("pressed", callable_mp(this, &VisualScriptEditor::_remove_func_input), varray(hbox));
+	delete_button->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_remove_func_input), varray(hbox));
 
 	name_box->select_all();
 	name_box->grab_focus();
@@ -4350,7 +4350,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	CheckButton *tool_script_check = memnew(CheckButton);
 	tool_script_check->set_text(TTR("Make Tool:"));
 	members_section->add_child(tool_script_check);
-	tool_script_check->connect("pressed", callable_mp(this, &VisualScriptEditor::_toggle_tool_script));
+	tool_script_check->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_toggle_tool_script));
 
 	///       Members        ///
 
@@ -4406,7 +4406,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	toggle_scripts_button = memnew(Button);
 	toggle_scripts_button->set_flat(true);
-	toggle_scripts_button->connect("pressed", callable_mp(this, &VisualScriptEditor::_toggle_scripts_pressed));
+	toggle_scripts_button->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_toggle_scripts_pressed));
 	status_bar->add_child(toggle_scripts_button);
 
 	/// Add Buttons to Top Bar/Zoom bar.
@@ -4417,18 +4417,18 @@ VisualScriptEditor::VisualScriptEditor() {
 	graph_hbc->add_child(base_lbl);
 
 	base_type_select = memnew(Button);
-	base_type_select->connect("pressed", callable_mp(this, &VisualScriptEditor::_change_base_type));
+	base_type_select->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_change_base_type));
 	graph_hbc->add_child(base_type_select);
 
 	Button *add_nds = memnew(Button);
 	add_nds->set_text(TTR("Add Nodes..."));
 	graph_hbc->add_child(add_nds);
-	add_nds->connect("pressed", callable_mp(this, &VisualScriptEditor::_add_node_dialog));
+	add_nds->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_add_node_dialog));
 
 	Button *fn_btn = memnew(Button);
 	fn_btn->set_text(TTR("Add Function..."));
 	graph_hbc->add_child(fn_btn);
-	fn_btn->connect("pressed", callable_mp(this, &VisualScriptEditor::_create_function_dialog));
+	fn_btn->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_create_function_dialog));
 
 	// Add Function Dialog.
 	VBoxContainer *function_vb = memnew(VBoxContainer);
@@ -4456,7 +4456,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	Button *add_input_button = memnew(Button);
 	add_input_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_input_button->set_text(TTR("Add Input"));
-	add_input_button->connect("pressed", callable_mp(this, &VisualScriptEditor::_add_func_input));
+	add_input_button->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_add_func_input));
 	function_vb->add_child(add_input_button);
 
 	func_input_scroll = memnew(ScrollContainer);
@@ -4471,7 +4471,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	function_create_dialog->set_title(TTR("Create Function"));
 	function_create_dialog->add_child(function_vb);
 	function_create_dialog->get_ok_button()->set_text(TTR("Create"));
-	function_create_dialog->get_ok_button()->connect("pressed", callable_mp(this, &VisualScriptEditor::_create_function));
+	function_create_dialog->get_ok_button()->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_create_function));
 	add_child(function_create_dialog);
 
 	select_func_text = memnew(Label);
@@ -4551,7 +4551,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	new_connect_node_select = memnew(VisualScriptPropertySelector);
 	add_child(new_connect_node_select);
 	new_connect_node_select->connect("selected", callable_mp(this, &VisualScriptEditor::_selected_connect_node));
-	new_connect_node_select->get_cancel_button()->connect("pressed", callable_mp(this, &VisualScriptEditor::_cancel_connect_node));
+	new_connect_node_select->get_cancel_button()->connect("button_clicked", callable_mp(this, &VisualScriptEditor::_cancel_connect_node));
 
 	new_virtual_method_select = memnew(VisualScriptPropertySelector);
 	add_child(new_virtual_method_select);

--- a/modules/webxr/doc_classes/WebXRInterface.xml
+++ b/modules/webxr/doc_classes/WebXRInterface.xml
@@ -18,7 +18,7 @@
 		func _ready():
 		    # We assume this node has a button as a child.
 		    # This button is for the user to consent to entering immersive VR mode.
-		    $Button.connect("pressed", self, "_on_Button_pressed")
+		    $Button.connect("button_clicked", self, "_on_button_clicked")
 
 		    webxr_interface = XRServer.find_interface("WebXR")
 		    if webxr_interface:
@@ -38,7 +38,7 @@
 		    if session_mode == 'immersive-vr':
 		        vr_supported = supported
 
-		func _on_Button_pressed():
+		func _on_button_clicked():
 		    if not vr_supported:
 		        OS.alert("Your browser doesn't support VR")
 		        return

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -120,23 +120,23 @@ void BaseButton::_notification(int p_what) {
 	}
 }
 
-void BaseButton::_pressed() {
-	GDVIRTUAL_CALL(_pressed);
-	pressed();
-	emit_signal(SNAME("pressed"));
+void BaseButton::_clicked() {
+	GDVIRTUAL_CALL(_clicked);
+	clicked();
+	emit_signal(SNAME("button_clicked"));
 }
 
 void BaseButton::_toggled(bool p_pressed) {
 	GDVIRTUAL_CALL(_toggled, p_pressed);
 	toggled(p_pressed);
-	emit_signal(SNAME("toggled"), p_pressed);
+	emit_signal(SNAME("button_toggled"), p_pressed);
 }
 
 void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 	if (p_event->is_pressed()) {
 		status.press_attempt = true;
 		status.pressing_inside = true;
-		emit_signal(SNAME("button_down"));
+		emit_signal(SNAME("button_pressed"));
 	}
 
 	if (status.press_attempt && status.pressing_inside) {
@@ -153,14 +153,14 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 				status.pressed = !status.pressed;
 				_unpress_group();
 				if (button_group.is_valid()) {
-					button_group->emit_signal(SNAME("pressed"), this);
+					button_group->emit_signal(SNAME("button_clicked"), this);
 				}
 				_toggled(status.pressed);
-				_pressed();
+				_clicked();
 			}
 		} else {
 			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
-				_pressed();
+				_clicked();
 			}
 		}
 	}
@@ -174,13 +174,13 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		}
 		status.press_attempt = false;
 		status.pressing_inside = false;
-		emit_signal(SNAME("button_up"));
+		emit_signal(SNAME("button_released"));
 	}
 
 	update();
 }
 
-void BaseButton::pressed() {
+void BaseButton::clicked() {
 }
 
 void BaseButton::toggled(bool p_pressed) {
@@ -218,7 +218,7 @@ void BaseButton::set_pressed(bool p_pressed) {
 	if (p_pressed) {
 		_unpress_group();
 		if (button_group.is_valid()) {
-			button_group->emit_signal(SNAME("pressed"), this);
+			button_group->emit_signal(SNAME("button_clicked"), this);
 		}
 	}
 	_toggled(status.pressed);
@@ -284,13 +284,13 @@ BaseButton::DrawMode BaseButton::get_draw_mode() const {
 	return DRAW_NORMAL;
 }
 
-void BaseButton::set_toggle_mode(bool p_on) {
+void BaseButton::set_toggle_mode(bool p_pressed) {
 	// Make sure to set 'pressed' to false if we are not in toggle mode
-	if (!p_on) {
+	if (!p_pressed) {
 		set_pressed(false);
 	}
 
-	toggle_mode = p_on;
+	toggle_mode = p_pressed;
 }
 
 bool BaseButton::is_toggle_mode() const {
@@ -434,13 +434,13 @@ void BaseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shortcut_context", "node"), &BaseButton::set_shortcut_context);
 	ClassDB::bind_method(D_METHOD("get_shortcut_context"), &BaseButton::get_shortcut_context);
 
-	GDVIRTUAL_BIND(_pressed);
+	GDVIRTUAL_BIND(_clicked);
 	GDVIRTUAL_BIND(_toggled, "button_pressed");
 
-	ADD_SIGNAL(MethodInfo("pressed"));
-	ADD_SIGNAL(MethodInfo("button_up"));
-	ADD_SIGNAL(MethodInfo("button_down"));
-	ADD_SIGNAL(MethodInfo("toggled", PropertyInfo(Variant::BOOL, "button_pressed")));
+	ADD_SIGNAL(MethodInfo("button_clicked"));
+	ADD_SIGNAL(MethodInfo("button_pressed"));
+	ADD_SIGNAL(MethodInfo("button_released"));
+	ADD_SIGNAL(MethodInfo("button_toggled", PropertyInfo(Variant::BOOL, "button_pressed")));
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_in_tooltip"), "set_shortcut_in_tooltip", "is_shortcut_in_tooltip_enabled");
@@ -500,7 +500,7 @@ BaseButton *ButtonGroup::get_pressed_button() {
 void ButtonGroup::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pressed_button"), &ButtonGroup::get_pressed_button);
 	ClassDB::bind_method(D_METHOD("get_buttons"), &ButtonGroup::_get_buttons);
-	ADD_SIGNAL(MethodInfo("pressed", PropertyInfo(Variant::OBJECT, "button")));
+	ADD_SIGNAL(MethodInfo("button_clicked", PropertyInfo(Variant::OBJECT, "button")));
 }
 
 ButtonGroup::ButtonGroup() {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -66,13 +66,13 @@ private:
 	Ref<ButtonGroup> button_group;
 
 	void _unpress_group();
-	void _pressed();
+	void _clicked();
 	void _toggled(bool p_pressed);
 
 	void on_action_event(Ref<InputEvent> p_event);
 
 protected:
-	virtual void pressed();
+	virtual void clicked();
 	virtual void toggled(bool p_pressed);
 	static void _bind_methods();
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
@@ -81,7 +81,7 @@ protected:
 
 	bool _is_focus_owner_in_shorcut_context() const;
 
-	GDVIRTUAL0(_pressed)
+	GDVIRTUAL0(_clicked)
 	GDVIRTUAL1(_toggled, bool)
 
 public:
@@ -103,7 +103,7 @@ public:
 
 	void set_pressed(bool p_pressed); // Only works in toggle mode.
 	void set_pressed_no_signal(bool p_pressed);
-	void set_toggle_mode(bool p_on);
+	void set_toggle_mode(bool p_pressed);
 	bool is_toggle_mode() const;
 
 	void set_shortcut_in_tooltip(bool p_on);

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -153,7 +153,7 @@ void Button::_notification(int p_what) {
 					if (rtl && has_theme_stylebox(SNAME("pressed_mirrored"))) {
 						style = get_theme_stylebox(SNAME("pressed_mirrored"));
 					} else {
-						style = get_theme_stylebox(SNAME("pressed"));
+						style = get_theme_stylebox(SNAME("button_clicked"));
 					}
 
 					if (!flat) {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1167,7 +1167,7 @@ ColorPicker::ColorPicker() :
 	hb_smpl->add_child(btn_pick);
 	btn_pick->set_toggle_mode(true);
 	btn_pick->set_tooltip(RTR("Pick a color from the editor window."));
-	btn_pick->connect("pressed", callable_mp(this, &ColorPicker::_screen_pick_pressed));
+	btn_pick->connect("button_clicked", callable_mp(this, &ColorPicker::_screen_pick_pressed));
 
 	VBoxContainer *vbl = memnew(VBoxContainer);
 	add_child(vbl, false, INTERNAL_MODE_FRONT);
@@ -1214,17 +1214,17 @@ ColorPicker::ColorPicker() :
 
 	hhb->add_child(btn_hsv);
 	btn_hsv->set_text(RTR("HSV"));
-	btn_hsv->connect("toggled", callable_mp(this, &ColorPicker::set_hsv_mode));
+	btn_hsv->connect("button_toggled", callable_mp(this, &ColorPicker::set_hsv_mode));
 
 	hhb->add_child(btn_raw);
 	btn_raw->set_text(RTR("Raw"));
-	btn_raw->connect("toggled", callable_mp(this, &ColorPicker::set_raw_mode));
+	btn_raw->connect("button_toggled", callable_mp(this, &ColorPicker::set_raw_mode));
 
 	hhb->add_child(text_type);
 	text_type->set_text("#");
 	text_type->set_tooltip(TTR("Switch between hexadecimal and code values."));
 	if (Engine::get_singleton()->is_editor_hint()) {
-		text_type->connect("pressed", callable_mp(this, &ColorPicker::_text_type_toggled));
+		text_type->connect("button_clicked", callable_mp(this, &ColorPicker::_text_type_toggled));
 	} else {
 		text_type->set_flat(true);
 		text_type->set_mouse_filter(MOUSE_FILTER_IGNORE);
@@ -1276,7 +1276,7 @@ ColorPicker::ColorPicker() :
 
 	btn_add_preset->set_icon_align(Button::ALIGN_CENTER);
 	btn_add_preset->set_tooltip(RTR("Add current color as a preset."));
-	btn_add_preset->connect("pressed", callable_mp(this, &ColorPicker::_add_preset_pressed));
+	btn_add_preset->connect("button_clicked", callable_mp(this, &ColorPicker::_add_preset_pressed));
 	preset_container->add_child(btn_add_preset);
 }
 
@@ -1300,7 +1300,7 @@ void ColorPickerButton::_modal_closed() {
 	set_pressed(false);
 }
 
-void ColorPickerButton::pressed() {
+void ColorPickerButton::clicked() {
 	_update_picker();
 
 	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -213,7 +213,7 @@ class ColorPickerButton : public Button {
 	void _color_changed(const Color &p_color);
 	void _modal_closed();
 
-	virtual void pressed() override;
+	virtual void clicked() override;
 
 	void _update_picker();
 

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -243,7 +243,7 @@ Button *AcceptDialog::add_button(const String &p_text, bool p_right, const Strin
 	}
 
 	if (p_action != "") {
-		button->connect("pressed", callable_mp(this, &AcceptDialog::_custom_action), varray(p_action));
+		button->connect("button_clicked", callable_mp(this, &AcceptDialog::_custom_action), varray(p_action));
 	}
 
 	return button;
@@ -255,7 +255,7 @@ Button *AcceptDialog::add_cancel_button(const String &p_cancel) {
 		c = TTRC("Cancel");
 	}
 	Button *b = swap_cancel_ok ? add_button(c, true) : add_button(c);
-	b->connect("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed));
+	b->connect("button_clicked", callable_mp(this, &AcceptDialog::_cancel_pressed));
 	return b;
 }
 
@@ -273,11 +273,11 @@ void AcceptDialog::remove_button(Control *p_button) {
 	}
 	hbc->remove_child(button);
 
-	if (button->is_connected("pressed", callable_mp(this, &AcceptDialog::_custom_action))) {
-		button->disconnect("pressed", callable_mp(this, &AcceptDialog::_custom_action));
+	if (button->is_connected("button_clicked", callable_mp(this, &AcceptDialog::_custom_action))) {
+		button->disconnect("button_clicked", callable_mp(this, &AcceptDialog::_custom_action));
 	}
-	if (button->is_connected("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed))) {
-		button->disconnect("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed));
+	if (button->is_connected("button_clicked", callable_mp(this, &AcceptDialog::_cancel_pressed))) {
+		button->disconnect("button_clicked", callable_mp(this, &AcceptDialog::_cancel_pressed));
 	}
 }
 
@@ -340,7 +340,7 @@ AcceptDialog::AcceptDialog() {
 	hbc->add_child(ok);
 	hbc->add_spacer();
 
-	ok->connect("pressed", callable_mp(this, &AcceptDialog::_ok_pressed));
+	ok->connect("button_clicked", callable_mp(this, &AcceptDialog::_ok_pressed));
 
 	set_title(TTRC("Alert!"));
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -950,9 +950,9 @@ FileDialog::FileDialog() {
 	hbc->add_child(dir_prev);
 	hbc->add_child(dir_next);
 	hbc->add_child(dir_up);
-	dir_prev->connect("pressed", callable_mp(this, &FileDialog::_go_back));
-	dir_next->connect("pressed", callable_mp(this, &FileDialog::_go_forward));
-	dir_up->connect("pressed", callable_mp(this, &FileDialog::_go_up));
+	dir_prev->connect("button_clicked", callable_mp(this, &FileDialog::_go_back));
+	dir_next->connect("button_clicked", callable_mp(this, &FileDialog::_go_forward));
+	dir_up->connect("button_clicked", callable_mp(this, &FileDialog::_go_up));
 
 	hbc->add_child(memnew(Label(TTRC("Path:"))));
 
@@ -971,7 +971,7 @@ FileDialog::FileDialog() {
 	refresh = memnew(Button);
 	refresh->set_flat(true);
 	refresh->set_tooltip(TTRC("Refresh files."));
-	refresh->connect("pressed", callable_mp(this, &FileDialog::update_file_list));
+	refresh->connect("button_clicked", callable_mp(this, &FileDialog::update_file_list));
 	hbc->add_child(refresh);
 
 	show_hidden = memnew(Button);
@@ -979,7 +979,7 @@ FileDialog::FileDialog() {
 	show_hidden->set_toggle_mode(true);
 	show_hidden->set_pressed(is_showing_hidden_files());
 	show_hidden->set_tooltip(TTRC("Toggle the visibility of hidden files."));
-	show_hidden->connect("toggled", callable_mp(this, &FileDialog::set_show_hidden_files));
+	show_hidden->connect("button_toggled", callable_mp(this, &FileDialog::set_show_hidden_files));
 	hbc->add_child(show_hidden);
 
 	shortcuts_container = memnew(HBoxContainer);
@@ -987,7 +987,7 @@ FileDialog::FileDialog() {
 
 	makedir = memnew(Button);
 	makedir->set_text(TTRC("Create Folder"));
-	makedir->connect("pressed", callable_mp(this, &FileDialog::_make_dir));
+	makedir->connect("button_clicked", callable_mp(this, &FileDialog::_make_dir));
 	hbc->add_child(makedir);
 	vbox->add_child(hbc);
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2320,28 +2320,28 @@ GraphEdit::GraphEdit() {
 	zoom_minus->set_flat(true);
 	zoom_hb->add_child(zoom_minus);
 	zoom_minus->set_tooltip(RTR("Zoom Out"));
-	zoom_minus->connect("pressed", callable_mp(this, &GraphEdit::_zoom_minus));
+	zoom_minus->connect("button_clicked", callable_mp(this, &GraphEdit::_zoom_minus));
 	zoom_minus->set_focus_mode(FOCUS_NONE);
 
 	zoom_reset = memnew(Button);
 	zoom_reset->set_flat(true);
 	zoom_hb->add_child(zoom_reset);
 	zoom_reset->set_tooltip(RTR("Zoom Reset"));
-	zoom_reset->connect("pressed", callable_mp(this, &GraphEdit::_zoom_reset));
+	zoom_reset->connect("button_clicked", callable_mp(this, &GraphEdit::_zoom_reset));
 	zoom_reset->set_focus_mode(FOCUS_NONE);
 
 	zoom_plus = memnew(Button);
 	zoom_plus->set_flat(true);
 	zoom_hb->add_child(zoom_plus);
 	zoom_plus->set_tooltip(RTR("Zoom In"));
-	zoom_plus->connect("pressed", callable_mp(this, &GraphEdit::_zoom_plus));
+	zoom_plus->connect("button_clicked", callable_mp(this, &GraphEdit::_zoom_plus));
 	zoom_plus->set_focus_mode(FOCUS_NONE);
 
 	snap_button = memnew(Button);
 	snap_button->set_flat(true);
 	snap_button->set_toggle_mode(true);
 	snap_button->set_tooltip(RTR("Enable snap and show grid."));
-	snap_button->connect("pressed", callable_mp(this, &GraphEdit::_snap_toggled));
+	snap_button->connect("button_clicked", callable_mp(this, &GraphEdit::_snap_toggled));
 	snap_button->set_pressed(true);
 	snap_button->set_focus_mode(FOCUS_NONE);
 	zoom_hb->add_child(snap_button);
@@ -2358,7 +2358,7 @@ GraphEdit::GraphEdit() {
 	minimap_button->set_flat(true);
 	minimap_button->set_toggle_mode(true);
 	minimap_button->set_tooltip(RTR("Enable grid minimap."));
-	minimap_button->connect("pressed", callable_mp(this, &GraphEdit::_minimap_toggled));
+	minimap_button->connect("button_clicked", callable_mp(this, &GraphEdit::_minimap_toggled));
 	minimap_button->set_pressed(true);
 	minimap_button->set_focus_mode(FOCUS_NONE);
 	zoom_hb->add_child(minimap_button);
@@ -2367,7 +2367,7 @@ GraphEdit::GraphEdit() {
 	layout_button->set_flat(true);
 	zoom_hb->add_child(layout_button);
 	layout_button->set_tooltip(RTR("Arrange nodes."));
-	layout_button->connect("pressed", callable_mp(this, &GraphEdit::arrange_nodes));
+	layout_button->connect("button_clicked", callable_mp(this, &GraphEdit::arrange_nodes));
 	layout_button->set_focus_mode(FOCUS_NONE);
 
 	Vector2 minimap_size = Vector2(240, 160);

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -85,7 +85,7 @@ void MenuButton::_popup_visibility_changed(bool p_visible) {
 	}
 }
 
-void MenuButton::pressed() {
+void MenuButton::clicked() {
 	emit_signal(SNAME("about_to_popup"));
 	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
 
@@ -142,7 +142,7 @@ void MenuButton::_notification(int p_what) {
 			if (menu_btn_other && menu_btn_other != this && menu_btn_other->is_switch_on_hover() && !menu_btn_other->is_disabled() &&
 					(get_parent()->is_ancestor_of(menu_btn_other) || menu_btn_other->get_parent()->is_ancestor_of(popup))) {
 				popup->hide();
-				menu_btn_other->pressed();
+				menu_btn_other->clicked();
 			}
 		} break;
 	}

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -37,7 +37,6 @@
 class MenuButton : public Button {
 	GDCLASS(MenuButton, Button);
 
-	bool clicked = false;
 	bool switch_on_hover = false;
 	bool disable_shortcuts = false;
 	PopupMenu *popup;
@@ -57,7 +56,7 @@ protected:
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 
 public:
-	virtual void pressed() override;
+	virtual void clicked() override;
 
 	PopupMenu *get_popup() const;
 	void set_switch_on_hover(bool p_enabled);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -118,7 +118,7 @@ void OptionButton::_selected(int p_which) {
 	_select(p_which, true);
 }
 
-void OptionButton::pressed() {
+void OptionButton::clicked() {
 	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
 	popup->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
 	popup->set_size(Size2(size.width, 0));

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -48,7 +48,7 @@ class OptionButton : public Button {
 	Array _get_items() const;
 	void _set_items(const Array &p_items);
 
-	virtual void pressed() override;
+	virtual void clicked() override;
 
 protected:
 	Size2 get_minimum_size() const override;

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -177,7 +177,7 @@ SceneStringNames::SceneStringNames() {
 	_mouse_shape_enter = StaticCString::create("_mouse_shape_enter");
 	_mouse_shape_exit = StaticCString::create("_mouse_shape_exit");
 
-	_pressed = StaticCString::create("_pressed");
+	_clicked = StaticCString::create("_clicked");
 	_toggled = StaticCString::create("_toggled");
 
 	frame_changed = StaticCString::create("frame_changed");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -126,7 +126,7 @@ public:
 	StringName _unhandled_input;
 	StringName _unhandled_key_input;
 
-	StringName _pressed;
+	StringName _clicked;
 	StringName _toggled;
 
 	StringName _update_scroll;


### PR DESCRIPTION
Currently, `BaseButton` has a name conflict between the property called `pressed` and a signal called `pressed`. This PR renames the signal `pressed` to `button_clicked` to reflect the event that emits this signal. Also, for consistency, renames the `pressed()` and `_pressed()` methods to `clicked()` and `_clicked()` respectively. Finally, to better reflect their events, `button_down` is renamed `button_pressed` and `button_up` is renamed `button_released` to match the names used in `Action Mode`.