### PR TITLE
[Net] Fix socket poll timeout on Windows.

### DIFF
--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -446,7 +446,7 @@ Error NetSocketPosix::poll(PollType p_type, int p_timeout) const {
 	FD_ZERO(&wr);
 	FD_ZERO(&ex);
 	FD_SET(_sock, &ex);
-	struct timeval timeout = { p_timeout, 0 };
+	struct timeval timeout = { p_timeout / 1000, (p_timeout % 1000) * 1000 };
 	// For blocking operation, pass nullptr  timeout pointer to select.
 	struct timeval *tp = nullptr;
 	if (p_timeout >= 0) {


### PR DESCRIPTION
Now correctly computes the timeout value in milliseconds.

Fixes #48195