### PR TITLE
OSX: Clarify min version requirement (10.12) in Info.plist

### DIFF
--- a/misc/dist/osx_template.app/Contents/Info.plist
+++ b/misc/dist/osx_template.app/Contents/Info.plist
@@ -37,11 +37,11 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9</string>
+	<string>10.12</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.9</string>
+		<string>10.12</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	$highres

--- a/misc/dist/osx_tools.app/Contents/Info.plist
+++ b/misc/dist/osx_tools.app/Contents/Info.plist
@@ -39,11 +39,11 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9</string>
+	<string>10.12</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.9</string>
+		<string>10.12</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>


### PR DESCRIPTION
The min requirement was upped by #45618 to have proper support for C++14.

Related to #48222.

Not needed in `master`, the min version was already increased in the `Info.plist`s there.