### PR TITLE
Android: Upgrade buildTools from 30.0.1 to 30.0.3

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -3,7 +3,7 @@ ext.versions = [
     compileSdk         : 29,
     minSdk             : 18,
     targetSdk          : 29,
-    buildTools         : '30.0.1',
+    buildTools         : '30.0.3',
     supportCoreUtils   : '1.0.0',
     kotlinVersion      : '1.4.10',
     v4Support          : '1.0.0',


### PR DESCRIPTION
It seems 30.0.1 had issues with compatibility with JDK 8 and 11,
which appear to be solved in 30.0.3 as per godotengine/godot-docs#4796.

Goes together with https://github.com/godotengine/godot-docs/pull/4873.