### PR TITLE
Fixed shader handling of constant expressions in function call

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -891,6 +891,7 @@ private:
 	bool _propagate_function_call_sampler_builtin_reference(StringName p_name, int p_argument, const StringName &p_builtin);
 	bool _validate_varying_assign(ShaderNode::Varying &p_varying, String *r_message);
 	bool _validate_varying_using(ShaderNode::Varying &p_varying, String *r_message);
+	bool _check_node_constness(const Node *p_node) const;
 
 	Node *_parse_expression(BlockNode *p_block, const FunctionInfo &p_function_info);
 	Node *_parse_array_constructor(BlockNode *p_block, const FunctionInfo &p_function_info, DataType p_type, const StringName &p_struct_name, int p_array_size);


### PR DESCRIPTION
Tested shader code:

> shader_type spatial;
> 
> const float global_const_var = log(1.0);
> 
> void fragment() {
> 	const float test1 = log(-1.0 + 1.0);
> 	const float test2 = log(log(1.0));
> 	
> 	float non_const_var = 1.0;
> 	const float const_var = 1.0;
> 	
> 	//const float test3 = log(non_const_var); // INCORRECT - prevent crash
> 	const float test4 = log(const_var);
> 	const float test5 = log(global_const_var);
> 	
> 	float non_const_arr_test[] = {0.0, 1.0, 2.0};
> 	const float const_arr_test[] = {0.0, 1.0, 2.0};
> 	//const float test6 = log(non_const_arr_test[0]); // INCORRECT - prevent crash
> 	const float test7 = log(const_arr_test[0]); 
> }

Fix #48204