### PR TITLE
Fix CSG Path Polygon cache being removed after connect

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1741,7 +1741,6 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 			path_cache->connect("tree_exited", callable_mp(this, &CSGPolygon3D::_path_exited));
 			path_cache->connect("curve_changed", callable_mp(this, &CSGPolygon3D::_path_changed));
-			path_cache = nullptr;
 		}
 		curve = path->get_curve();
 		if (curve.is_null()) {


### PR DESCRIPTION
fixes #30229 
supersedes #37714

I recreated the fix done in #37714 as we encountered the error yesterday in production and the original PR seems to be abandoned