### PR TITLE
Add Vector2.from_angle() method

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -34,6 +34,10 @@ real_t Vector2::angle() const {
 	return Math::atan2(y, x);
 }
 
+Vector2 Vector2::from_angle(const real_t p_angle) {
+	return Vector2(Math::cos(p_angle), Math::sin(p_angle));
+}
+
 real_t Vector2::length() const {
 	return Math::sqrt(x * x + y * y);
 }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -147,6 +147,7 @@ struct Vector2 {
 	bool operator>=(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y >= p_vec2.y) : (x > p_vec2.x); }
 
 	real_t angle() const;
+	static Vector2 from_angle(const real_t p_angle);
 
 	_FORCE_INLINE_ Vector2 abs() const {
 		return Vector2(Math::abs(x), Math::abs(y));

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1502,6 +1502,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2, clamp, sarray("min", "max"), varray());
 	bind_method(Vector2, snapped, sarray("step"), varray());
 
+	bind_static_method(Vector2, from_angle, sarray("angle"), varray());
+
 	/* Vector2i */
 
 	bind_method(Vector2i, aspect, sarray(), varray());

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -155,6 +155,18 @@
 				Returns the vector with all components rounded down (towards negative infinity).
 			</description>
 		</method>
+		<method name="from_angle" qualifiers="static">
+			<return type="Vector2" />
+			<argument index="0" name="angle" type="float" />
+			<description>
+				Creates a unit [Vector2] rotated to the given [code]angle[/code] in radians. This is equivalent to doing [code]Vector2(cos(angle), sin(angle))[/code] or [code]Vector2.RIGHT.rotated(angle)[/code].
+				[codeblock]
+				print(Vector2.from_angle(0)) # Prints (1, 0).
+				print(Vector2(1, 0).angle()) # Prints 0, which is the angle used above.
+				print(Vector2.from_angle(PI / 2)) # Prints (0, 1).
+				[/codeblock]
+			</description>
+		</method>
 		<method name="is_equal_approx" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="to" type="Vector2" />

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -603,6 +603,17 @@ namespace Godot
             y = v.y;
         }
 
+        /// <summary>
+        /// Creates a unit Vector2 rotated to the given angle. This is equivalent to doing
+        /// `Vector2(Mathf.Cos(angle), Mathf.Sin(angle))` or `Vector2.Right.Rotated(angle)`.
+        /// </summary>
+        /// <param name="angle">Angle of the vector, in radians.</param>
+        /// <returns>The resulting vector.</returns>
+        public static Vector2 FromAngle(real_t angle)
+        {
+            return new Vector2(Mathf.Cos(angle), Mathf.Sin(angle));
+        }
+
         public static Vector2 operator +(Vector2 left, Vector2 right)
         {
             left.x += right.x;


### PR DESCRIPTION
Resolves 2D part of https://github.com/godotengine/godot-proposals/issues/1719 (someone wanted Vector3 equivalent, but it probably requires some more math so meh)

With this you can do
```
Vector2.from_angle(PI/2)
```
and it will return `Vector2(0, 1)`

(or at least it would if static functions weren't bugged, see #48238)