### PR TITLE
Update CSGMesh3D's documentation to explain how vertex normals are used

### DIFF
--- a/modules/csg/doc_classes/CSGMesh3D.xml
+++ b/modules/csg/doc_classes/CSGMesh3D.xml
@@ -16,6 +16,7 @@
 		</member>
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
 			The [Mesh] resource to use as a CSG shape.
+			[b]Note:[/b] When using an [ArrayMesh], avoid meshes with vertex normals unless a flat shader is required. By default, CSGMesh will ignore the mesh's vertex normals and use a smooth shader calculated using the faces' normals. If a flat shader is required, ensure that all faces' vertex normals are parallel.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Closes #24111.
