### PR TITLE
Fix @export and prevent non-exportable References from being exported.

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2282,9 +2282,10 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 					}
 					prop_info.hint = export_info.hint;
 					prop_info.hint_string = export_info.hint_string;
-					prop_info.usage = export_info.usage;
+					prop_info.usage = export_info.usage | PROPERTY_USAGE_SCRIPT_VARIABLE;
+				} else {
+					prop_info.usage = PROPERTY_USAGE_SCRIPT_VARIABLE;
 				}
-				prop_info.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
 #ifdef TOOLS_ENABLED
 				p_script->doc_variables[name] = variable->doc_description;
 #endif


### PR DESCRIPTION
Addresses issue #48224 related to @export affecting all properties and non-Resource reference types being saved to .res files.

cc @vnen 
Reverts a part of #47131 commit 160c260

This may break enum export. I do not know enough about enums to understand why this change would affect it, but that is the commit this reverts.

*Bugsquad edit:* fixes #48224.