### PR TITLE
CI: Upgrade Emscripten to 2.0.15 (same as official standard builds)

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -6,7 +6,7 @@ env:
   GODOT_BASE_BRANCH: 3.x
   SCONSFLAGS: platform=javascript verbose=yes warnings=all werror=yes debug_symbols=no --jobs=2
   SCONS_CACHE_LIMIT: 4096
-  EM_VERSION: 1.39.20
+  EM_VERSION: 2.0.15
   EM_CACHE_FOLDER: 'emsdk-cache'
 
 jobs:


### PR DESCRIPTION
We still use Emscripten 1.39.9 for official Mono builds so ideally we want to test
against an old Emscripten version to ensure we don't break compatibility.

But then google-closure-compiler-linux broke compatibility for us and is not properly
pinned, so we need to use a more recent version for now to fix CI.

Cf. https://github.com/emscripten-core/emsdk/issues/802