### PR TITLE
Fixes #48178: WebXR broken when built with Emscripten 2.0.13 or later

### DIFF
--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -71,10 +71,8 @@ const GodotWebXR = {
 			// enabled or disabled. When using the WebXR API Emulator, this
 			// gets picked up automatically, however, in the Oculus Browser
 			// on the Quest, we need to pause and resume the main loop.
-			Browser.pauseAsyncCallbacks();
 			Browser.mainLoop.pause();
 			window.setTimeout(function () {
-				Browser.resumeAsyncCallbacks();
 				Browser.mainLoop.resume();
 			}, 0);
 		},


### PR DESCRIPTION
Fixes #48178 

I tested this with Godot 3.3, built with Emscripten 2.0.15, both in debug mode and release (with the Closure compiler). It worked with my WebXR demo, and the example project from the issue.

This should cleanly cherry-pick to the `3.3` branch.