### PR TITLE
doc: Mark LargeTexture as deprecated (removed in 4.0)

### DIFF
--- a/doc/classes/LargeTexture.xml
+++ b/doc/classes/LargeTexture.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="LargeTexture" inherits="Texture" version="3.4">
 	<brief_description>
-		A [Texture] capable of storing many smaller textures with offsets.
+		[i]Deprecated.[/i] A [Texture] capable of storing many smaller textures with offsets.
 	</brief_description>
 	<description>
-		A [Texture] capable of storing many smaller textures with offsets.
+		[i]Deprecated (will be removed in Godot 4.0).[/i] A [Texture] capable of storing many smaller textures with offsets.
 		You can dynamically add pieces ([Texture]s) to this [LargeTexture] using different offsets.
 	</description>
 	<tutorials>


### PR DESCRIPTION
Cf. https://github.com/godotengine/godot/pull/48269.

Not adding an actual `WARN_DEPRECATED` message as those tend to annoy users more than inform them, when they do use the class successfully in their project. Since this class can only be used from code, it can be assumed that new users would check the class reference and see the warning there.