### PR TITLE
Document that `File.open_compressed()` can only open files saved by Godot

### DIFF
--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -275,6 +275,7 @@
 			</argument>
 			<description>
 				Opens a compressed file for reading or writing.
+				[b]Note:[/b] [method open_compressed] can only read files that were saved by Godot, not third-party compression formats. See [url=https://github.com/godotengine/godot/issues/28999]GitHub issue #28999[/url] for a workaround.
 			</description>
 		</method>
 		<method name="open_encrypted">


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/28999#issuecomment-578539416. I'd like to list the workaround directly in the class reference, but the code sample needs to be adapted into something easily reusable.