### PR TITLE
Add `is_position_in_frustum` to Camera3D

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -55,8 +55,17 @@
 			<argument index="0" name="world_point" type="Vector3">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the given position is behind the camera.
+				Returns [code]true[/code] if the given position is behind the camera (the blue part of the linked diagram). [url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/camera3d_position_frustum.png]See this diagram[/url] for an overview of position query methods.
 				[b]Note:[/b] A position which returns [code]false[/code] may still be outside the camera's field of view.
+			</description>
+		</method>
+		<method name="is_position_in_frustum" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="world_point" type="Vector3">
+			</argument>
+			<description>
+				Returns [code]true[/code] if the given position is inside the camera's frustum (the green part of the linked diagram). [url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/camera3d_position_frustum.png]See this diagram[/url] for an overview of position query methods.
 			</description>
 		</method>
 		<method name="make_current">

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -500,6 +500,7 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_doppler_tracking", "mode"), &Camera3D::set_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_doppler_tracking"), &Camera3D::get_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_frustum"), &Camera3D::get_frustum);
+	ClassDB::bind_method(D_METHOD("is_position_in_frustum", "world_point"), &Camera3D::is_position_in_frustum);
 	ClassDB::bind_method(D_METHOD("get_camera_rid"), &Camera3D::get_camera);
 
 	ClassDB::bind_method(D_METHOD("set_cull_mask_bit", "layer", "enable"), &Camera3D::set_cull_mask_bit);
@@ -621,6 +622,16 @@ Vector<Plane> Camera3D::get_frustum() const {
 	}
 
 	return cm.get_projection_planes(get_camera_transform());
+}
+
+bool Camera3D::is_position_in_frustum(const Vector3 &p_position) const {
+	Vector<Plane> frustum = get_frustum();
+	for (int i = 0; i < frustum.size(); i++) {
+		if (frustum[i].is_point_over(p_position)) {
+			return false;
+		}
+	}
+	return true;
 }
 
 void Camera3D::set_v_offset(float p_offset) {

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -153,6 +153,7 @@ public:
 	bool get_cull_mask_bit(int p_layer) const;
 
 	virtual Vector<Plane> get_frustum() const;
+	bool is_position_in_frustum(const Vector3 &p_position) const;
 
 	void set_environment(const Ref<Environment> &p_environment);
 	Ref<Environment> get_environment() const;


### PR DESCRIPTION
This is a simple helper method that checks if a Vector3 is inside of the Camera3D frustum.

For a Godot project this could technically be worked around in GDScript, but this kind of thing makes sense to be in core. Also, I need this for future editor functionality I'm working on.