### PR TITLE
[3.x] SCons: Add explicit dependencies on thirdparty code in cloned env

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -40,6 +40,9 @@ with open("script_encryption_key.gen.cpp", "w") as f:
 
 
 # Add required thirdparty code.
+
+thirdparty_obj = []
+
 env_thirdparty = env.Clone()
 env_thirdparty.disable_warnings()
 
@@ -57,7 +60,7 @@ thirdparty_misc_sources = [
     "clipper.cpp",
 ]
 thirdparty_misc_sources = [thirdparty_misc_dir + file for file in thirdparty_misc_sources]
-env_thirdparty.add_source_files(env.core_sources, thirdparty_misc_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_misc_sources)
 
 # Zlib library, can be unbundled
 if env["builtin_zlib"]:
@@ -83,7 +86,7 @@ if env["builtin_zlib"]:
     if env["target"] == "debug":
         env_thirdparty.Append(CPPDEFINES=["ZLIB_DEBUG"])
 
-    env_thirdparty.add_source_files(env.core_sources, thirdparty_zlib_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_zlib_sources)
 
 # Minizip library, could be unbundled in theory
 # However, our version has some custom modifications, so it won't compile with the system one
@@ -94,7 +97,7 @@ thirdparty_minizip_sources = [
     "zip.c",
 ]
 thirdparty_minizip_sources = [thirdparty_minizip_dir + file for file in thirdparty_minizip_sources]
-env_thirdparty.add_source_files(env.core_sources, thirdparty_minizip_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_minizip_sources)
 
 # Zstd library, can be unbundled in theory
 # though we currently use some private symbols
@@ -136,10 +139,14 @@ if env["builtin_zstd"]:
     # Also needed in main env includes will trigger warnings
     env.Append(CPPDEFINES=["ZSTD_STATIC_LINKING_ONLY"])
 
-    env_thirdparty.add_source_files(env.core_sources, thirdparty_zstd_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_zstd_sources)
 
 
-# Godot's own sources
+env.core_sources += thirdparty_obj
+
+
+# Godot source files
+
 env.add_source_files(env.core_sources, "*.cpp")
 
 # Certificates
@@ -185,3 +192,6 @@ SConscript("bind/SCsub")
 # Build it all as a library
 lib = env.add_library("core", env.core_sources)
 env.Prepend(LIBS=[lib])
+
+# Needed to force rebuilding the core files when the thirdparty code is updated.
+env.Depends(lib, thirdparty_obj)

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -6,6 +6,7 @@ env_crypto = env.Clone()
 
 is_builtin = env["builtin_mbedtls"]
 has_module = env["module_mbedtls_enabled"]
+thirdparty_obj = []
 
 if is_builtin or not has_module:
     # Use our headers for builtin or if the module is not going to be compiled.
@@ -35,6 +36,16 @@ if not has_module:
         "godot_core_mbedtls_platform.c",
     ]
     thirdparty_mbedtls_sources = [thirdparty_mbedtls_dir + file for file in thirdparty_mbedtls_sources]
-    env_thirdparty.add_source_files(env.core_sources, thirdparty_mbedtls_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_mbedtls_sources)
+    env.core_sources += thirdparty_obj
 
-env_crypto.add_source_files(env.core_sources, "*.cpp")
+
+# Godot source files
+
+core_obj = []
+
+env_crypto.add_source_files(core_obj, "*.cpp")
+env.core_sources += core_obj
+
+# Needed to force rebuilding the core files when the thirdparty library is updated.
+env.Depends(core_obj, thirdparty_obj)

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -2,6 +2,8 @@
 
 Import("env")
 
+thirdparty_obj = []
+
 if env["platform"] in ["haiku", "osx", "windows", "x11"]:
     # Thirdparty source files
     thirdparty_dir = "#thirdparty/glad/"
@@ -17,7 +19,16 @@ if env["platform"] in ["haiku", "osx", "windows", "x11"]:
 
     env_thirdparty = env.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.drivers_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.drivers_sources += thirdparty_obj
+
 
 # Godot source files
-env.add_source_files(env.drivers_sources, "*.cpp")
+
+driver_obj = []
+
+env.add_source_files(driver_obj, "*.cpp")
+env.drivers_sources += driver_obj
+
+# Needed to force rebuilding the driver files when the thirdparty code is updated.
+env.Depends(driver_obj, thirdparty_obj)

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -5,6 +5,9 @@ Import("env")
 env_png = env.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_libpng"]:
     thirdparty_dir = "#thirdparty/libpng/"
     thirdparty_sources = [
@@ -41,7 +44,7 @@ if env["builtin_libpng"]:
 
     env_thirdparty = env_png.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.drivers_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 
     if use_neon:
         env_neon = env_thirdparty.Clone()
@@ -52,9 +55,17 @@ if env["builtin_libpng"]:
         neon_sources.append(env_neon.Object(thirdparty_dir + "/arm/filter_neon_intrinsics.c"))
         neon_sources.append(env_neon.Object(thirdparty_dir + "/arm/filter_neon.S"))
         neon_sources.append(env_neon.Object(thirdparty_dir + "/arm/palette_neon_intrinsics.c"))
-        env.drivers_sources += neon_sources
+        thirdparty_obj += neon_sources
+
+    env.drivers_sources += thirdparty_obj
+
 
 # Godot source files
-env_png.add_source_files(env.drivers_sources, "*.cpp")
 
-Export("env")
+driver_obj = []
+
+env_png.add_source_files(driver_obj, "*.cpp")
+env.drivers_sources += driver_obj
+
+# Needed to force rebuilding the driver files when the thirdparty library is updated.
+env.Depends(driver_obj, thirdparty_obj)

--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -7,6 +7,8 @@ env_bullet = env_modules.Clone()
 
 # Thirdparty source files
 
+thirdparty_obj = []
+
 if env["builtin_bullet"]:
     # Build only version 2 for now (as of 2.89)
     # Sync file list with relevant upstream CMakeLists.txt for each folder.
@@ -207,8 +209,16 @@ if env["builtin_bullet"]:
 
     env_thirdparty = env_bullet.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
 
 
 # Godot source files
-env_bullet.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_bullet.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/cvtt/SCsub
+++ b/modules/cvtt/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_cvtt = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 thirdparty_dir = "#thirdparty/cvtt/"
 thirdparty_sources = ["ConvectionKernels.cpp"]
 
@@ -15,7 +18,15 @@ env_cvtt.Prepend(CPPPATH=[thirdparty_dir])
 
 env_thirdparty = env_cvtt.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
 # Godot source files
-env_cvtt.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_cvtt.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/denoise/SCsub
+++ b/modules/denoise/SCsub
@@ -8,6 +8,9 @@ Import("env_modules")
 env_oidn = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 thirdparty_dir = "#thirdparty/oidn/"
 thirdparty_sources = [
     "core/api.cpp",
@@ -106,7 +109,8 @@ env_oidn.Append(
 
 env_thirdparty = env_oidn.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
 if env["platform"] == "windows" and not env.msvc:
     env_thirdparty.Append(CPPFLAGS=["-mstackrealign"])
@@ -117,5 +121,13 @@ weights_out_path = thirdparty_dir + "weights/rtlightmap_hdr.gen.cpp"
 env_thirdparty.Depends(weights_out_path, weights_in_path)
 env_thirdparty.CommandNoCache(weights_out_path, weights_in_path, resource_to_cpp.tza_to_cpp)
 
-env_oidn.add_source_files(env.modules_sources, "denoise_wrapper.cpp")
-env_modules.add_source_files(env.modules_sources, ["register_types.cpp", "lightmap_denoiser.cpp"])
+# Godot source files
+
+module_obj = []
+
+env_oidn.add_source_files(module_obj, "denoise_wrapper.cpp")
+env_modules.add_source_files(module_obj, ["register_types.cpp", "lightmap_denoiser.cpp"])
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -7,6 +7,8 @@ env_enet = env_modules.Clone()
 
 # Thirdparty source files
 
+thirdparty_obj = []
+
 if env["builtin_enet"]:
     thirdparty_dir = "#thirdparty/enet/"
     thirdparty_sources = [
@@ -26,6 +28,16 @@ if env["builtin_enet"]:
 
     env_thirdparty = env_enet.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
 
-env_enet.add_source_files(env.modules_sources, "*.cpp")
+
+# Godot source files
+
+module_obj = []
+
+env_enet.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/etc/SCsub
+++ b/modules/etc/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_etc = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 # Not unbundled so far since not widespread as shared library
 thirdparty_dir = "#thirdparty/etc2comp/"
 thirdparty_sources = [
@@ -31,7 +34,15 @@ env_etc.Prepend(CPPPATH=[thirdparty_dir])
 
 env_thirdparty = env_etc.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
 # Godot source files
-env_etc.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_etc.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -8,6 +8,9 @@ from compat import isbasestring
 env_freetype = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_freetype"]:
     thirdparty_dir = "#thirdparty/freetype/"
     thirdparty_sources = [
@@ -86,6 +89,7 @@ if env["builtin_freetype"]:
     env_thirdparty = env_freetype.Clone()
     env_thirdparty.disable_warnings()
     lib = env_thirdparty.add_library("freetype_builtin", thirdparty_sources)
+    thirdparty_obj += lib
 
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
@@ -100,7 +104,16 @@ if env["builtin_freetype"]:
     if not inserted:
         env.Append(LIBS=[lib])
 
+
 # Godot source files
-env_freetype.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_freetype.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
 # Used in scene/, needs to be in main env
 env.Append(CPPDEFINES=["FREETYPE_ENABLED"])
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_jpg = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 # Not unbundled for now as they are not commonly available as shared library
 thirdparty_dir = "#thirdparty/jpeg-compressor/"
 thirdparty_sources = [
@@ -17,7 +20,15 @@ env_jpg.Prepend(CPPPATH=[thirdparty_dir])
 
 env_thirdparty = env_jpg.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
-# Godot's own source files
-env_jpg.add_source_files(env.modules_sources, "*.cpp")
+# Godot source files
+
+module_obj = []
+
+env_jpg.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -5,8 +5,11 @@ Import("env_modules")
 
 env_mbed_tls = env_modules.Clone()
 
+# Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_mbedtls"]:
-    # Thirdparty source files
     thirdparty_sources = [
         "aes.c",
         "aesni.c",
@@ -96,7 +99,17 @@ if env["builtin_mbedtls"]:
 
     env_thirdparty = env_mbed_tls.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
 
-# Module sources
-env_mbed_tls.add_source_files(env.modules_sources, "*.cpp")
+
+# Godot source files
+
+module_obj = []
+
+env_mbed_tls.add_source_files(module_obj, "*.cpp")
+
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/ogg/SCsub
+++ b/modules/ogg/SCsub
@@ -9,6 +9,9 @@ Import("env_modules")
 env_ogg = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_libogg"]:
     thirdparty_dir = "#thirdparty/libogg/"
     thirdparty_sources = [
@@ -21,7 +24,16 @@ if env["builtin_libogg"]:
 
     env_thirdparty = env_ogg.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
+
 
 # Godot source files
-env_ogg.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_ogg.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/opensimplex/SCsub
+++ b/modules/opensimplex/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_opensimplex = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 thirdparty_dir = "#thirdparty/misc/"
 thirdparty_sources = [
     "open-simplex-noise.c",
@@ -16,7 +19,15 @@ env_opensimplex.Prepend(CPPPATH=[thirdparty_dir])
 
 env_thirdparty = env_opensimplex.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
-# Godot's own source files
-env_opensimplex.add_source_files(env.modules_sources, "*.cpp")
+# Godot source files
+
+module_obj = []
+
+env_opensimplex.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -10,6 +10,10 @@ Import("env_modules")
 env_opus = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
+# Thirdparty source files
 if env["builtin_opus"]:
     thirdparty_dir = "#thirdparty/opus/"
 
@@ -233,7 +237,16 @@ if env["builtin_opus"]:
 
     env_thirdparty = env_opus.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
 
-# Module files
-env_opus.add_source_files(env.modules_sources, "register_types.cpp")
+
+# Godot source files
+
+module_obj = []
+
+env_opus.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/pvr/SCsub
+++ b/modules/pvr/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_pvr = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 # Not unbundled so far since not widespread as shared library
 thirdparty_dir = "#thirdparty/pvrtccompressor/"
 thirdparty_sources = [
@@ -21,7 +24,15 @@ env_pvr.Prepend(CPPPATH=[thirdparty_dir])
 
 env_thirdparty = env_pvr.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
 # Godot source files
-env_pvr.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_pvr.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -7,6 +7,8 @@ env_raycast = env_modules.Clone()
 
 # Thirdparty source files
 
+thirdparty_obj = []
+
 if env["builtin_embree"]:
     thirdparty_dir = "#thirdparty/embree/"
 
@@ -92,8 +94,16 @@ if env["builtin_embree"]:
 
     env_thirdparty = env_raycast.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
 
 
 # Godot source files
-env_raycast.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_raycast.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/recast/SCsub
+++ b/modules/recast/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_recast = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_recast"]:
     thirdparty_dir = "#thirdparty/recastnavigation/Recast/"
     thirdparty_sources = [
@@ -27,7 +30,15 @@ if env["builtin_recast"]:
 
     env_thirdparty = env_recast.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
 
 # Godot source files
-env_recast.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_recast.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -5,6 +5,10 @@ Import("env_modules")
 
 env_regex = env_modules.Clone()
 
+# Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_pcre2"]:
     thirdparty_dir = "#thirdparty/pcre2/src/"
     thirdparty_flags = ["PCRE2_STATIC", "HAVE_CONFIG_H", "SUPPORT_UNICODE"]
@@ -52,11 +56,21 @@ if env["builtin_pcre2"]:
         env_pcre2 = env_regex.Clone()
         env_pcre2.disable_warnings()
         env_pcre2["OBJSUFFIX"] = "_" + width + env_pcre2["OBJSUFFIX"]
-        env_pcre2.add_source_files(env.modules_sources, thirdparty_sources)
         env_pcre2.Append(CPPDEFINES=[("PCRE2_CODE_UNIT_WIDTH", width)])
+        env_pcre2.add_source_files(thirdparty_obj, thirdparty_sources)
+        env.modules_sources += thirdparty_obj
 
     pcre2_builtin("16")
     pcre2_builtin("32")
 
+
+# Godot source files
+
+module_obj = []
+
 env_regex.Append(CPPDEFINES=[("PCRE2_CODE_UNIT_WIDTH", 0)])
-env_regex.add_source_files(env.modules_sources, "*.cpp")
+env_regex.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/squish/SCsub
+++ b/modules/squish/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_squish = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_squish"]:
     thirdparty_dir = "#thirdparty/squish/"
     thirdparty_sources = [
@@ -26,7 +29,16 @@ if env["builtin_squish"]:
 
     env_thirdparty = env_squish.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
+
 
 # Godot source files
-env_squish.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_squish.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/stb_vorbis/SCsub
+++ b/modules/stb_vorbis/SCsub
@@ -6,11 +6,22 @@ Import("env_modules")
 env_stb_vorbis = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 thirdparty_sources = ["#thirdparty/misc/stb_vorbis.c"]
 
 env_thirdparty = env_stb_vorbis.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
-# Godot's own source files
-env_stb_vorbis.add_source_files(env.modules_sources, "*.cpp")
+# Godot source files
+
+module_obj = []
+
+env_stb_vorbis.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_svg = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 thirdparty_dir = "#thirdparty/nanosvg/"
 thirdparty_sources = ["nanosvg.cc"]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
@@ -18,7 +21,15 @@ env.Append(CPPDEFINES=["SVG_ENABLED"])
 
 env_thirdparty = env_svg.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
-# Godot's own source files
-env_svg.add_source_files(env.modules_sources, "*.cpp")
+# Godot source files
+
+module_obj = []
+
+env_svg.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_theora = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_libtheora"]:
     thirdparty_dir = "#thirdparty/libtheora/"
     thirdparty_sources = [
@@ -80,7 +83,16 @@ if env["builtin_libtheora"]:
 
     env_thirdparty = env_theora.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
+
 
 # Godot source files
-env_theora.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_theora.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -7,6 +7,8 @@ env_upnp = env_modules.Clone()
 
 # Thirdparty source files
 
+thirdparty_obj = []
+
 if env["builtin_miniupnpc"]:
     thirdparty_dir = "#thirdparty/miniupnpc/"
     thirdparty_sources = [
@@ -32,7 +34,16 @@ if env["builtin_miniupnpc"]:
 
     env_thirdparty = env_upnp.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
+
 
 # Godot source files
-env_upnp.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_upnp.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/vhacd/SCsub
+++ b/modules/vhacd/SCsub
@@ -7,6 +7,8 @@ env_vhacd = env_modules.Clone()
 
 # Thirdparty source files
 
+thirdparty_obj = []
+
 thirdparty_dir = "#thirdparty/vhacd/"
 
 thirdparty_sources = [
@@ -24,10 +26,19 @@ thirdparty_sources = [
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_vhacd.Prepend(CPPPATH=[thirdparty_dir + "/inc"])
+env_vhacd.Prepend(CPPPATH=[thirdparty_dir + "inc"])
 
 env_thirdparty = env_vhacd.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
-env_vhacd.add_source_files(env.modules_sources, "*.cpp")
+# Godot source files
+
+module_obj = []
+
+env_vhacd.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -8,9 +8,10 @@ Import("env_modules")
 
 env_vorbis = env_modules.Clone()
 
-stub = True
-
 # Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_libvorbis"]:
     thirdparty_dir = "#thirdparty/libvorbis/"
     thirdparty_sources = [
@@ -51,7 +52,16 @@ if env["builtin_libvorbis"]:
 
     env_thirdparty = env_vorbis.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
 
-# Module files
-env_vorbis.add_source_files(env.modules_sources, "register_types.cpp")
+
+# Godot source files
+
+module_obj = []
+
+env_vorbis.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/webm/SCsub
+++ b/modules/webm/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_webm = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 thirdparty_dir = "#thirdparty/libsimplewebm/"
 thirdparty_sources = [
     "libwebm/mkvparser/mkvparser.cc",
@@ -31,7 +34,15 @@ if env["builtin_libvpx"]:
 
 env_thirdparty = env_webm.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
 
 # Godot source files
-env_webm.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_webm.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_webp = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_libwebp"]:
     thirdparty_dir = "#thirdparty/libwebp/"
     thirdparty_sources = [
@@ -130,7 +133,16 @@ if env["builtin_libwebp"]:
 
     env_thirdparty = env_webp.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
+
 
 # Godot source files
-env_webp.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_webp.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/webrtc/SCsub
+++ b/modules/webrtc/SCsub
@@ -3,8 +3,6 @@
 Import("env")
 Import("env_modules")
 
-# Thirdparty source files
-
 env_webrtc = env_modules.Clone()
 use_gdnative = env_webrtc["module_gdnative_enabled"]
 

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -5,28 +5,44 @@ Import("env_modules")
 
 env_ws = env_modules.Clone()
 
+thirdparty_obj = []
+
 if env["platform"] == "javascript":
     # Our JavaScript/C++ interface.
     env.AddJSLibraries(["library_godot_websocket.js"])
+
 elif env["builtin_wslay"]:
     # Thirdparty source files
-    wslay_dir = "#thirdparty/wslay/"
-    wslay_sources = [
+    thirdparty_dir = "#thirdparty/wslay/"
+    thirdparty_sources = [
         "wslay_net.c",
         "wslay_event.c",
         "wslay_queue.c",
         "wslay_stack.c",
         "wslay_frame.c",
     ]
-    wslay_sources = [wslay_dir + s for s in wslay_sources]
-    env_ws.Prepend(CPPPATH=[wslay_dir + "includes/"])
+    thirdparty_sources = [thirdparty_dir + s for s in thirdparty_sources]
+
+    env_ws.Prepend(CPPPATH=[thirdparty_dir + "includes/"])
     env_ws.Append(CPPDEFINES=["HAVE_CONFIG_H"])
+
     if env["platform"] == "windows" or env["platform"] == "uwp":
         env_ws.Append(CPPDEFINES=["HAVE_WINSOCK2_H"])
     else:
         env_ws.Append(CPPDEFINES=["HAVE_NETINET_IN_H"])
-    env_wslay = env_ws.Clone()
-    env_wslay.disable_warnings()
-    env_wslay.add_source_files(env.modules_sources, wslay_sources)
 
-env_ws.add_source_files(env.modules_sources, "*.cpp")
+    env_thirdparty = env_ws.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
+
+
+# Godot source files
+
+module_obj = []
+
+env_ws.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_xatlas_unwrap = env_modules.Clone()
 
 # Thirdparty source files
+
+thirdparty_obj = []
+
 if env["builtin_xatlas"]:
     thirdparty_dir = "#thirdparty/xatlas/"
     thirdparty_sources = [
@@ -17,7 +20,16 @@ if env["builtin_xatlas"]:
 
     env_thirdparty = env_xatlas_unwrap.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
+
 
 # Godot source files
-env_xatlas_unwrap.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_xatlas_unwrap.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -28,9 +28,13 @@ for x in android_files:
 
 env_thirdparty = env_android.Clone()
 env_thirdparty.disable_warnings()
-android_objects.append(env_thirdparty.SharedObject("#thirdparty/misc/ifaddrs-android.cc"))
+thirdparty_obj = env_thirdparty.SharedObject("#thirdparty/misc/ifaddrs-android.cc")
+android_objects.append(thirdparty_obj)
 
 lib = env_android.add_shared_library("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
+
+# Needed to force rebuilding the platform files when the thirdparty code is updated.
+env.Depends(lib, thirdparty_obj)
 
 lib_arch_dir = ""
 if env["android_arch"] == "armv7":

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -4,23 +4,8 @@ Import("env")
 
 env.scene_sources = []
 
-# Thirdparty code
-thirdparty_dir = "#thirdparty/misc/"
-thirdparty_sources = [
-    # C++ sources
-    "easing_equations.cpp",
-    # C sources
-    "mikktspace.c",
-]
-thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-
-env_thirdparty = env.Clone()
-env_thirdparty.disable_warnings()
-env_thirdparty.add_source_files(env.scene_sources, thirdparty_sources)
-
-# Godot's own sources
+# Godot source files
 env.add_source_files(env.scene_sources, "*.cpp")
-
 
 # Chain load SCsubs
 SConscript("main/SCsub")
@@ -31,7 +16,6 @@ SConscript("animation/SCsub")
 SConscript("audio/SCsub")
 SConscript("resources/SCsub")
 SConscript("debugger/SCsub")
-
 
 # Build it all as a library
 lib = env.add_library("scene", env.scene_sources)

--- a/scene/animation/SCsub
+++ b/scene/animation/SCsub
@@ -2,4 +2,23 @@
 
 Import("env")
 
-env.add_source_files(env.scene_sources, "*.cpp")
+# Thirdparty code
+
+thirdparty_obj = []
+
+thirdparty_sources = "#thirdparty/misc/easing_equations.cpp"
+
+env_thirdparty = env.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.scene_sources += thirdparty_obj
+
+# Godot source files
+
+scene_obj = []
+
+env.add_source_files(scene_obj, "*.cpp")
+env.scene_sources += scene_obj
+
+# Needed to force rebuilding the scene files when the thirdparty code is updated.
+env.Depends(scene_obj, thirdparty_obj)

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -2,6 +2,25 @@
 
 Import("env")
 
-env.add_source_files(env.scene_sources, "*.cpp")
+# Thirdparty code
+
+thirdparty_obj = []
+
+thirdparty_sources = "#thirdparty/misc/mikktspace.c"
+
+env_thirdparty = env.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.scene_sources += thirdparty_obj
+
+# Godot source files
+
+scene_obj = []
+
+env.add_source_files(scene_obj, "*.cpp")
+env.scene_sources += scene_obj
+
+# Needed to force rebuilding the scene files when the thirdparty code is updated.
+env.Depends(scene_obj, thirdparty_obj)
 
 SConscript("default_theme/SCsub")

--- a/servers/camera/SCsub
+++ b/servers/camera/SCsub
@@ -3,5 +3,3 @@
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")
-
-Export("env")


### PR DESCRIPTION
Since we clone the environments to build thirdparty code, we don't get an
explicit dependency on the build objects produced by that environment.

So when we update thirdparty code, Godot code using it is not necessarily
rebuilt (I think it is for changed headers, but not for changed .c/.cpp files),
which can lead to an invalid compilation output (linking old Godot .o files
with a newer, potentially ABI breaking version of thirdparty code).

This was only seen as really problematic with bullet updates (leading to
crashes when rebuilding Godot after a bullet update without cleaning .o files),
but it's safer to fix it everywhere, even if it's a LOT of hacky boilerplate.

(cherry picked from commit c7b53c03ae7f7feb45a6023ee5cf764025ebb5e1)