### PR TITLE
Revert "Show thumbnail for DynamicFont resource", causes occasional deadlock

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -829,25 +829,19 @@ void EditorFontPreviewPlugin::_bind_methods() {
 
 bool EditorFontPreviewPlugin::handles(const String &p_type) const {
 
-	return ClassDB::is_parent_class(p_type, "DynamicFontData") || ClassDB::is_parent_class(p_type, "DynamicFont");
+	return ClassDB::is_parent_class(p_type, "DynamicFontData");
 }
 
 Ref<Texture> EditorFontPreviewPlugin::generate_from_path(const String &p_path, const Size2 &p_size) const {
 
-	Ref<ResourceInteractiveLoader> ril = ResourceLoader::load_interactive(p_path);
-	ril.ptr()->wait();
-	RES res = ril.ptr()->get_resource();
+	Ref<DynamicFontData> SampledFont;
+	SampledFont.instance();
+	SampledFont->set_font_path(p_path);
+
 	Ref<DynamicFont> sampled_font;
-	if (res->is_class("DynamicFont")) {
-		sampled_font = res->duplicate();
-		if (sampled_font->get_outline_color() == Color(1, 1, 1, 1)) {
-			sampled_font->set_outline_color(Color(0, 0, 0, 1));
-		}
-	} else if (res->is_class("DynamicFontData")) {
-		sampled_font.instance();
-		sampled_font->set_font_data(res);
-	}
+	sampled_font.instance();
 	sampled_font->set_size(50);
+	sampled_font->set_font_data(SampledFont);
 
 	String sampled_text = "Abg";
 	Vector2 size = sampled_font->get_string_size(sampled_text);


### PR DESCRIPTION
This reverts commits 9eff8b7007f7604904d5ec87728002d5df3e4760
and a1f63bac0e57b653c452c6b08a72877031d14741.

Despite the attempted fix, some projects would still lock on first open while
attempting to generate thumbnails for a DynamicFont resource used in the main
scene.

So let's revisit this feature once we figure out how to solve the deadlock.

Fixes #42785.

---

The fix doesn't seem to be needed for `master`, at least the affected projects open fine. @bruvzg's refactor of `Font` might have solved this issue incidentally.