### PR TITLE
Fix create physical bone when up vector is collinear to child origin

### DIFF
--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -416,8 +416,14 @@ PhysicalBone3D *Skeleton3DEditor::create_physical_bone(int bone_id, int bone_chi
 	capsule_transform.basis = Basis(Vector3(1, 0, 0), Vector3(0, 0, 1), Vector3(0, -1, 0));
 	bone_shape->set_transform(capsule_transform);
 
+	/// Get an up vector not collinear with child rest origin
+	Vector3 up = Vector3(0, 1, 0);
+	if (up.cross(child_rest.origin).is_equal_approx(Vector3())) {
+		up = Vector3(0, 0, 1);
+	}
+
 	Transform3D body_transform;
-	body_transform.basis = Basis::looking_at(child_rest.origin);
+	body_transform.basis = Basis::looking_at(child_rest.origin, up);
 	body_transform.origin = body_transform.basis.xform(Vector3(0, 0, -half_height));
 
 	Transform3D joint_transform;


### PR DESCRIPTION
Fix issue #39757 but for Godot 4.0

When generating physical bone, `set_look_at` is used to change the bone direction.

`body_transform.set_look_at(Vector3(0, 0, 0), child_rest.origin);`

However, if the vector child_rest.origin is collinear with the default up vector =Vector3(0, 1, 0), the cross product cannot generate a third vector (with length > 0) and `set_look_at` fails.
In order to avoid this issue, we first compute an up vector not collinear:
```
/// Get an up vector not collinear with child rest origin
Vector3 up = Vector3(0, 1, 0);
if (up.cross(child_rest.origin).length() == 0) {
	up = Vector3(0, 0, 1);
}
```

And then use it

```
body_transform.set_look_at(Vector3(0, 0, 0), child_rest.origin, up);
```

Please find a reproduction project for Godot 4.0 at https://github.com/godotengine/godot/issues/39757#issuecomment-829595289

*Bugsquad edit:*
- Fixes #39757