### PR TITLE
Expose get_debug_mesh in Shape3D to scripting API

### DIFF
--- a/doc/classes/Shape3D.xml
+++ b/doc/classes/Shape3D.xml
@@ -10,6 +10,13 @@
 		<link title="Physics introduction">https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_debug_mesh">
+			<return type="ArrayMesh">
+			</return>
+			<description>
+				Returns the [ArrayMesh] used to draw the debug collision for this [Shape3D].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.04">

--- a/scene/resources/shape_3d.cpp
+++ b/scene/resources/shape_3d.cpp
@@ -102,6 +102,8 @@ void Shape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &Shape3D::set_margin);
 	ClassDB::bind_method(D_METHOD("get_margin"), &Shape3D::get_margin);
 
+	ClassDB::bind_method(D_METHOD("get_debug_mesh"), &Shape3D::get_debug_mesh);
+
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0.001,10,0.001"), "set_margin", "get_margin");
 }
 


### PR DESCRIPTION
Can be useful for custom drawing of physics shapes without having to add a collision object node to the tree.

Avoids hacks like this one (in this case, drawing a shape used in a query, not attached to a node):
https://github.com/godotengine/godot-demo-projects/blob/2ce76ff4e5abfa352a5bca4de9b1214567579b8d/3d/physics_tests/test.gd#L48-L70

Can be replaced with:
```
func add_shape(shape, transform, color):
	var debug_mesh = shape.get_debug_mesh()
	
	var mesh_instance = MeshInstance.new()
	mesh_instance.transform = transform
	mesh_instance.mesh = debug_mesh
	
	var material = SpatialMaterial.new()
	material.flags_unshaded = true
	material.albedo_color = color
	mesh_instance.material_override = material
	
	add_child(mesh_instance)
	_drawn_nodes.push_back(mesh_instance)
```

This change will also be needed after #48175 is merged, since the debug mesh node won't be available anymore.