### PR TITLE
[3.x] Expose get_debug_mesh in Shape to scripting API

### DIFF
--- a/doc/classes/Shape.xml
+++ b/doc/classes/Shape.xml
@@ -10,6 +10,13 @@
 		<link>https://docs.godotengine.org/en/3.3/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_debug_mesh">
+			<return type="ArrayMesh">
+			</return>
+			<description>
+				Returns the [ArrayMesh] used to draw the debug collision for this [Shape].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.04">

--- a/scene/resources/shape.cpp
+++ b/scene/resources/shape.cpp
@@ -106,6 +106,8 @@ void Shape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &Shape::set_margin);
 	ClassDB::bind_method(D_METHOD("get_margin"), &Shape::get_margin);
 
+	ClassDB::bind_method(D_METHOD("get_debug_mesh"), &Shape::get_debug_mesh);
+
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "margin", PROPERTY_HINT_RANGE, "0.001,10,0.001"), "set_margin", "get_margin");
 }
 


### PR DESCRIPTION
3.x backport of #48315.

Will be needed after #48175 is cherry-picked to 3.3/3.4, since the debug mesh node won't be available anymore.
