### PR TITLE
[Net] Fix bogus FileAccessNetwork deconstructor.

### DIFF
--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -487,7 +487,6 @@ FileAccessNetwork::~FileAccessNetwork() {
 
 	FileAccessNetworkClient *nc = FileAccessNetworkClient::singleton;
 	nc->lock_mutex();
-	id = nc->last_id++;
 	nc->accesses.erase(id);
 	nc->unlock_mutex();
 }


### PR DESCRIPTION
Now correctly erases old instances.
The code will likely need overhaul anyway to be usable.
It doesn't apply to editor runs, there's a bunch of inconsistencies on how to clients are handled, and I don't really understand why multiple instances are created for a single client/server.

Fixes #48326 .