### PR TITLE
[Net] ENet non-relaying server now process broadcasts.

### DIFF
--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -362,7 +362,10 @@ void NetworkedMultiplayerENet::poll() {
 							// To myself and only myself
 							incoming_packets.push_back(packet);
 						} else if (!server_relay) {
-							// No other destination is allowed when server is not relaying
+							// When relaying is disabled, other destinations will only be processed by the server.
+							if (target == 0 || target < -1) {
+								incoming_packets.push_back(packet);
+							}
 							continue;
 						} else if (target == 0) {
 							// Re-send to everyone but sender :|


### PR DESCRIPTION
Setting `server_relay = false` prevents the server from letting clients communicate with each other, but without this fix, the server would also ignore broadcast packets.

With this change, the server still does not relay messages to other clients, but will correctly process broadcast messages (and "exclusive" messages) as if they were directed to just the server.

Closes #38030 (superseded)
Fixes #37996 .

Can be cherry picked to `3.4`.
I'd avoid cherry-picking to `3.3` as it does change the behaviour a bit (but I don't have a strong opinion against it).