### PR TITLE
Add WebSocketMultiplayerPeer _incoming_packets check bound

### DIFF
--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -99,6 +99,8 @@ Error WebSocketMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buff
 		_current_packet.data = nullptr;
 	}
 
+	ERR_FAIL_COND_V(_incoming_packets.size() == 0, ERR_UNAVAILABLE);
+
 	_current_packet = _incoming_packets.front()->get();
 	_incoming_packets.pop_front();
 


### PR DESCRIPTION
Fixes #46096.
Analog for 3.x [PR](https://github.com/godotengine/godot/pull/48330)

Code for reproduction

```
func _ready():
	var q_WebSocketServer : WebSocketServer = WebSocketServer.new()
	q_WebSocketServer.listen(2222, PoolStringArray([]), true)
	q_WebSocketServer.get_var(false) # now here is no crash
```
