### PR TITLE
Add tangents and normals generation by smoothing for SurfaceTool

### DIFF
--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -115,6 +115,10 @@ bool Vector3::is_equal_approx(const Vector3 &p_v) const {
 	return Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y) && Math::is_equal_approx(z, p_v.z);
 }
 
+bool Vector3::is_equal_approx_tolerance(const Vector3 &p_v, real_t tolerance) const {
+	return Math::is_equal_approx(x, p_v.x, tolerance) && Math::is_equal_approx(y, p_v.y, tolerance) && Math::is_equal_approx(z, p_v.z, tolerance);
+}
+
 Vector3::operator String() const {
 	return (rtos(x) + ", " + rtos(y) + ", " + rtos(z));
 }

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -54,6 +54,22 @@ struct Vector3 {
 		real_t coord[3] = { 0 };
 	};
 
+	Vector3 min(const Vector3 &p_vector3) const {
+		return Vector3(MIN(x, p_vector3.x), MIN(y, p_vector3.y), MIN(z, p_vector3.z));
+	}
+
+	Vector3 max(const Vector3 &p_vector3) const {
+		return Vector3(MAX(x, p_vector3.x), MAX(y, p_vector3.y), MAX(z, p_vector3.z));
+	}
+
+	bool is_inf() const {
+		return Math::is_inf(x) || Math::is_inf(y) || Math::is_inf(z);
+	}
+
+	bool is_nan() const {
+		return Math::is_nan(x) || Math::is_nan(y) || Math::is_nan(z);
+	}
+
 	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
 		return coord[p_axis];
 	}
@@ -118,6 +134,7 @@ struct Vector3 {
 	_FORCE_INLINE_ Vector3 reflect(const Vector3 &p_normal) const;
 
 	bool is_equal_approx(const Vector3 &p_v) const;
+	bool is_equal_approx_tolerance(const Vector3 &p_v, real_t tolerance) const;
 
 	/* Operators */
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1416,6 +1416,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3, normalized, sarray(), varray());
 	bind_method(Vector3, is_normalized, sarray(), varray());
 	bind_method(Vector3, is_equal_approx, sarray("to"), varray());
+	bind_method(Vector3, is_equal_approx_tolerance, sarray("to", "tolerance"), varray());
 	bind_method(Vector3, inverse, sarray(), varray());
 	bind_method(Vector3, snapped, sarray("step"), varray());
 	bind_method(Vector3, rotated, sarray("by_axis", "phi"), varray());

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -201,6 +201,10 @@ struct VariantUtilityFunctions {
 		return Math::is_equal_approx(x, y);
 	}
 
+	static inline bool is_equal_approx_tolerance(double x, double y, double tolerance) {
+		return Math::is_equal_approx(x, y, tolerance);
+	}
+
 	static inline bool is_zero_approx(double x) {
 		return Math::is_zero_approx(x);
 	}
@@ -1176,6 +1180,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(is_inf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(is_equal_approx, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(is_equal_approx_tolerance, sarray("a", "b", "tolerance"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(is_zero_approx, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(ease, sarray("x", "curve"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -410,6 +410,21 @@
 				Infinity values of the same sign are considered equal.
 			</description>
 		</method>
+		<method name="is_equal_approx_tolerance">
+			<return type="bool">
+			</return>
+			<argument index="0" name="a" type="float">
+			</argument>
+			<argument index="1" name="b" type="float">
+			</argument>
+			<argument index="2" name="tolerance" type="float">
+			</argument>
+			<description>
+				Returns [code]true[/code] if [code]a[/code] and [code]b[/code] are approximately equal to each other by using [code]tolerance[/code] as tolerance.
+				Here, approximately equal means that [code]a[/code] and [code]b[/code] are within a small internal epsilon of each other, which scales with the magnitude of the numbers.
+				Infinity values of the same sign are considered equal.
+			</description>
+		</method>
 		<method name="is_inf">
 			<return type="bool">
 			</return>
@@ -1713,8 +1728,7 @@
 		<constant name="KEY_LESS" value="60" enum="Key">
 			&lt; key.
 		</constant>
-		<constant name="KEY_EQUAL" value="61" enum="Key">
-			= key.
+		<constant name="KEY_EQUAL" value="61" enum="Key"> = key.
 		</constant>
 		<constant name="KEY_GREATER" value="62" enum="Key">
 			&gt; key.

--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -168,6 +168,27 @@
 				[b]Note:[/b] [method generate_normals] only works if the primitive type to be set to [constant Mesh.PRIMITIVE_TRIANGLES].
 			</description>
 		</method>
+		<method name="generate_normals_smoothed">
+			<return type="void">
+			</return>
+			<argument index="0" name="flip" type="bool" default="false">
+			</argument>
+			<argument index="1" name="smoothingAngle" type="float" default="175">
+			</argument>
+			<description>
+				Generates normals from vertices by smoothing so you do not have to do it manually. If [code]flip[/code] is [code]true[/code], the resulting normals will be inverted. [method generate_normals] should be called [i]after[/i] generating geometry and [i]before[/i] committing the mesh using [method commit] or [method commit_to_arrays].
+				[b]Note:[/b] [method generate_normals_smoothed] only works if the primitive type to be set to [constant Mesh.PRIMITIVE_TRIANGLES]. [code]smoothingAngle[/code] is the radius in degrees to determine the smoothing angle.
+			</description>
+		</method>
+		<method name="generate_tangents_smoothed">
+			<return type="void">
+			</return>
+			<argument index="0" name="smoothingAngle" type="float" default="45">
+			</argument>
+			<description>
+				Generates a tangent vector for each vertex by using a smoothing angle. Requires that each vertex have UVs and normals set already. [code]smoothingAngle[/code] is the radius in degrees to determine the smoothing angle.
+			</description>
+		</method>
 		<method name="generate_tangents">
 			<return type="void">
 			</return>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -174,6 +174,17 @@
 				Returns [code]true[/code] if this vector and [code]v[/code] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
 			</description>
 		</method>
+		<method name="is_equal_approx_tolerance" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="to" type="Vector3">
+			</argument>
+			<argument index="1" name="tolerance" type="float">
+			</argument>
+			<description>
+				Returns [code]true[/code] if this vector and [code]v[/code] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component and using a tolerance parameter.
+			</description>
+		</method>
 		<method name="is_normalized" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -167,6 +167,9 @@ public:
 	void deindex();
 	void generate_normals(bool p_flip = false);
 	void generate_tangents();
+	void generate_normals_smoothed(bool p_flip, float smoothingAngle = 175.0f);
+	void generate_tangents_smoothed(float smoothingAngle = 45.0f);
+	void find_vertices(const Vector3 &position, float epsilon, Vector<int> &result);
 
 	void optimize_indices_for_cache();
 	float get_max_axis_length() const;


### PR DESCRIPTION
This PR extends the SurfaceTool by two new methods which make it possible to generate "Normals" and "Tangents" faster than usual and to smooth them. Which brings more details and is a common practice in 3D applications (such as Blender).

To compare the classic methods against the extensions:

- **test generate_normals_smoothed**
- Generated normals for mesh in 6 ms (758 vertices, 3924 indices)
- **test generate_tangents_smoothed**
- Generated tangents for mesh in 7 ms (758 vertices, 3924 indices)
- **test generate_normals**
- Generated normals for mesh (old) in 10 ms (758 vertices, 3924 indices)
- **test generate_tangents**
- Generated tangents for mesh (old) in 15 ms (758 vertices, 3924 indices)

In addition, the long outdated third party tool "mikktspace" becomes superfluous. It should therefore be considered whether the standard methods (generate_normals and generate_tangents) are replaced by the new methods.

This PR is part of a larger PR which deals with the issues of tangent and normal generations up to the representation in the shader. This is part 1. Each part is an independent part and solves an independent problem.


Example image:

![image](https://user-images.githubusercontent.com/76991284/116769900-ebc2b600-aa3f-11eb-847f-6640a1221ce5.png)
![image](https://user-images.githubusercontent.com/76991284/116769959-5673f180-aa40-11eb-803e-3ba55c815f88.png)

