### PR TITLE
Fix broken tangents in vulkan rendering server on godot 4

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -422,7 +422,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 					value |= CLAMP(int((src[i * 4 + 0] * 0.5 + 0.5) * 1023.0), 0, 1023);
 					value |= CLAMP(int((src[i * 4 + 1] * 0.5 + 0.5) * 1023.0), 0, 1023) << 10;
 					value |= CLAMP(int((src[i * 4 + 2] * 0.5 + 0.5) * 1023.0), 0, 1023) << 20;
-					value |= CLAMP(int((src[i * 4 + 3] * 0.5 + 0.5) * 3.0), 0, 3) << 30;
+					value |= CLAMP(int((src[i * 4 + 3] * 0.5 + 0.5) * 1023.0), 0, 1023) << 30;
 
 					memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], &value, 4);
 				}


### PR DESCRIPTION
Fix an issue with broken tangents on rendering server since redux can't copy and paste his own code rightly.

https://github.com/godotengine/godot/blob/70f5972905a5ea6916e9aab909f9a34b963f67b1/servers/rendering_server.cpp#L423

Related issue:
https://github.com/godotengine/godot/issues/48279#issuecomment-828833771


This PR is part of a larger PR which deals with the issues of tangent and normal generations up to the representation in the shader. This is part 2. Each part is an independent part and solves an independent problem.
https://github.com/godotengine/godot/pull/48340

