### PR TITLE
GDScript: Fix temporary value not released when used as a dictionary key

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -966,6 +966,9 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				} else {
 					gen->write_set(prev_base, key, assigned);
 				}
+				if (key.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
+				}
 				if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
 					gen->pop_temporary();
 				}


### PR DESCRIPTION
Closes #48346

When compiling GDScript, the code generating the assignment value to a dictionary never released the key, especially when the key is a temporary value from an expression
This commit adds the necessary code to do the release.

The error in console logs `Leaving block with non-zero temporary variables: 1` do disappear and the assignment do still works after testing, but the change need to be confirmed by an expert first.
