### PR TITLE
Add the About dialog to the project manager (3.x)

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -44,13 +44,12 @@ void EditorAbout::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 
-			Control *base = EditorNode::get_singleton()->get_gui_base();
-			Ref<Font> font = base->get_font("source", "EditorFonts");
+			Ref<Font> font = get_font("source", "EditorFonts");
 			_tpl_text->add_font_override("normal_font", font);
 			_tpl_text->add_constant_override("line_separation", 6 * EDSCALE);
 			_license_text->add_font_override("normal_font", font);
 			_license_text->add_constant_override("line_separation", 6 * EDSCALE);
-			_logo->set_texture(base->get_icon("Logo", "EditorIcons"));
+			_logo->set_texture(get_icon("Logo", "EditorIcons"));
 		} break;
 	}
 }

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -44,6 +44,10 @@
 
 #include "editor_scale.h"
 
+/**
+ * NOTE: Do not assume the EditorNode singleton to be available in this class' methods.
+ * EditorAbout is also used from the project manager where EditorNode isn't initialized.
+ */
 class EditorAbout : public AcceptDialog {
 
 	GDCLASS(EditorAbout, AcceptDialog);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1835,6 +1835,10 @@ void ProjectManager::_notification(int p_what) {
 
 			_dim_window();
 		} break;
+		case NOTIFICATION_WM_ABOUT: {
+
+			_show_about();
+		} break;
 	}
 }
 
@@ -2283,6 +2287,11 @@ void ProjectManager::_erase_missing_projects() {
 	erase_missing_ask->popup_centered_minsize();
 }
 
+void ProjectManager::_show_about() {
+
+	about->popup_centered(Size2(780, 500) * EDSCALE);
+}
+
 void ProjectManager::_language_selected(int p_id) {
 
 	String lang = language_btn->get_item_metadata(p_id);
@@ -2393,6 +2402,7 @@ void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_erase_missing_projects", &ProjectManager::_erase_missing_projects);
 	ClassDB::bind_method("_erase_project_confirm", &ProjectManager::_erase_project_confirm);
 	ClassDB::bind_method("_erase_missing_projects_confirm", &ProjectManager::_erase_missing_projects_confirm);
+	ClassDB::bind_method("_show_about", &ProjectManager::_show_about);
 	ClassDB::bind_method("_language_selected", &ProjectManager::_language_selected);
 	ClassDB::bind_method("_restart_confirm", &ProjectManager::_restart_confirm);
 	ClassDB::bind_method("_on_order_option_changed", &ProjectManager::_on_order_option_changed);
@@ -2505,7 +2515,7 @@ ProjectManager::ProjectManager() {
 	String cp;
 	cp += 0xA9;
 	// TRANSLATORS: This refers to the application where users manage their Godot projects.
-	OS::get_singleton()->set_window_title(VERSION_NAME + String(" - ") + TTR("Project Manager") + " - " + cp + " 2007-2021 Juan Linietsky, Ariel Manzur & Godot Contributors");
+	OS::get_singleton()->set_window_title(VERSION_NAME + String(" - ") + TTR("Project Manager"));
 
 	Control *center_box = memnew(Control);
 	center_box->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -2634,6 +2644,11 @@ ProjectManager::ProjectManager() {
 	erase_missing_btn = erase_missing;
 
 	tree_vb->add_spacer();
+
+	about_btn = memnew(Button);
+	about_btn->set_text(TTR("About"));
+	about_btn->connect("pressed", this, "_show_about");
+	tree_vb->add_child(about_btn);
 
 	if (StreamPeerSSL::is_available()) {
 		asset_library = memnew(EditorAssetLibrary(true));
@@ -2774,6 +2789,9 @@ ProjectManager::ProjectManager() {
 	open_templates->get_ok()->set_text(TTR("Open Asset Library"));
 	open_templates->connect("confirmed", this, "_open_asset_library");
 	add_child(open_templates);
+
+	about = memnew(EditorAbout);
+	add_child(about);
 }
 
 ProjectManager::~ProjectManager() {

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -31,6 +31,7 @@
 #ifndef PROJECT_MANAGER_H
 #define PROJECT_MANAGER_H
 
+#include "editor/editor_about.h"
 #include "editor/plugins/asset_library_editor_plugin.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/file_dialog.h"
@@ -51,6 +52,7 @@ class ProjectManager : public Control {
 	Button *open_btn;
 	Button *rename_btn;
 	Button *run_btn;
+	Button *about_btn;
 
 	EditorAssetLibrary *asset_library;
 
@@ -67,6 +69,7 @@ class ProjectManager : public Control {
 	ConfirmationDialog *multi_scan_ask;
 	ConfirmationDialog *ask_update_settings;
 	ConfirmationDialog *open_templates;
+	EditorAbout *about;
 	AcceptDialog *run_error_diag;
 	AcceptDialog *dialog_error;
 	ProjectDialog *npdialog;
@@ -93,6 +96,7 @@ class ProjectManager : public Control {
 	void _erase_missing_projects();
 	void _erase_project_confirm();
 	void _erase_missing_projects_confirm();
+	void _show_about();
 	void _update_project_buttons();
 	void _language_selected(int p_id);
 	void _restart_confirm();


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/47710.

The About button is located in the bottom-right corner of the project manager.

This allows removing the copyright notice from the window title (which looked a bit ugly in comparison to other applications).