### PR TITLE
[3.x] Add a V-Sync editor setting

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -541,6 +541,8 @@ void EditorNode::_notification(int p_what) {
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			OS::get_singleton()->set_use_vsync(bool(EDITOR_GET("interface/editor/use_vsync")));
+
 			scene_tabs->set_tab_close_display_policy((bool(EDITOR_GET("interface/scene_tabs/always_show_close_button")) ? Tabs::CLOSE_BUTTON_SHOW_ALWAYS : Tabs::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
 			theme = create_editor_theme(theme_base->get_theme());
 
@@ -5871,6 +5873,8 @@ EditorNode::EditorNode() {
 		EditorSettings::create();
 
 	FileAccess::set_backup_save(EDITOR_GET("filesystem/on_save/safe_save_on_backup_then_rename"));
+
+	OS::get_singleton()->set_use_vsync(bool(EDITOR_GET("interface/editor/use_vsync")));
 
 	{
 		int display_scale = EditorSettings::get_singleton()->get("interface/editor/display_scale");

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -361,6 +361,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/code_font", "");
 	hints["interface/editor/code_font"] = PropertyInfo(Variant::STRING, "interface/editor/code_font", PROPERTY_HINT_GLOBAL_FILE, "*.ttf,*.otf", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/editor/dim_editor_on_dialog_popup", true);
+	_initial_set("interface/editor/use_vsync", true);
 	_initial_set("interface/editor/low_processor_mode_sleep_usec", 6900); // ~144 FPS
 	hints["interface/editor/low_processor_mode_sleep_usec"] = PropertyInfo(Variant::REAL, "interface/editor/low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "1,100000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/unfocused_low_processor_mode_sleep_usec", 50000); // 20 FPS

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1086,7 +1086,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", false);
 	}
 
-	video_mode.use_vsync = GLOBAL_DEF_RST("display/window/vsync/use_vsync", true);
+	video_mode.use_vsync = GLOBAL_DEF("display/window/vsync/use_vsync", true);
 	OS::get_singleton()->_use_vsync = video_mode.use_vsync;
 
 	if (!saw_vsync_via_compositor_override) {


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/48364.

The editor setting makes it possible to tweak V-Sync status independently of the project setting.

Use cases:

- Decrease input lag and increase editor responsiveness when editing a project that has V-Sync enabled.
- Avoid tearing when editing a project that has V-Sync disabled.

Inspired by https://github.com/godotengine/godot/pull/20916, but the default behavior is now to have V-Sync enabled.