### PR TITLE
Check PHashTranslation generate p_from is valid

### DIFF
--- a/core/compressed_translation.cpp
+++ b/core/compressed_translation.cpp
@@ -45,6 +45,7 @@ struct _PHashTranslationCmp {
 
 void PHashTranslation::generate(const Ref<Translation> &p_from) {
 #ifdef TOOLS_ENABLED
+	ERR_FAIL_COND(p_from.is_null());
 	List<StringName> keys;
 	p_from->get_message_list(&keys);
 


### PR DESCRIPTION
Fixes #46001.

In this example **aa** is not valid reference for `Ref<Translation>` in this way we got null-value at **p_from**.
```
var aa = BoxShape.new()
PHashTranslation.new().generate(aa)
```