### PR TITLE
Add comment highlighting to script thumbnails

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -504,6 +504,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 	Color keyword_color = EditorSettings::get_singleton()->get("text_editor/highlighting/keyword_color");
 	Color text_color = EditorSettings::get_singleton()->get("text_editor/highlighting/text_color");
 	Color symbol_color = EditorSettings::get_singleton()->get("text_editor/highlighting/symbol_color");
+	Color comment_color = EditorSettings::get_singleton()->get("text_editor/highlighting/comment_color");
 
 	if (bg_color.a == 0) {
 		bg_color = Color(0, 0, 0, 0);
@@ -523,33 +524,42 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 
 	bool prev_is_text = false;
 	bool in_keyword = false;
+	bool in_comment = false;
 	for (int i = 0; i < code.length(); i++) {
 		char32_t c = code[i];
 		if (c > 32) {
 			if (col < thumbnail_size) {
 				Color color = text_color;
 
-				if (c != '_' && ((c >= '!' && c <= '/') || (c >= ':' && c <= '@') || (c >= '[' && c <= '`') || (c >= '{' && c <= '~') || c == '\t')) {
-					//make symbol a little visible
-					color = symbol_color;
-					in_keyword = false;
-				} else if (!prev_is_text && _is_text_char(c)) {
-					int pos = i;
-
-					while (_is_text_char(code[pos])) {
-						pos++;
-					}
-					String word = code.substr(i, pos - i);
-					if (keywords.has(word)) {
-						in_keyword = true;
-					}
-
-				} else if (!_is_text_char(c)) {
-					in_keyword = false;
+				if (c == '#') {
+					in_comment = true;
 				}
 
-				if (in_keyword) {
-					color = keyword_color;
+				if (in_comment) {
+					color = comment_color;
+				} else {
+					if (c != '_' && ((c >= '!' && c <= '/') || (c >= ':' && c <= '@') || (c >= '[' && c <= '`') || (c >= '{' && c <= '~') || c == '\t')) {
+						//make symbol a little visible
+						color = symbol_color;
+						in_keyword = false;
+					} else if (!prev_is_text && _is_text_char(c)) {
+						int pos = i;
+
+						while (_is_text_char(code[pos])) {
+							pos++;
+						}
+						String word = code.substr(i, pos - i);
+						if (keywords.has(word)) {
+							in_keyword = true;
+						}
+
+					} else if (!_is_text_char(c)) {
+						in_keyword = false;
+					}
+
+					if (in_keyword) {
+						color = keyword_color;
+					}
 				}
 
 				Color ul = color;
@@ -559,11 +569,14 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 
 				prev_is_text = _is_text_char(c);
 			}
+			col++;
 		} else {
 			prev_is_text = false;
 			in_keyword = false;
 
 			if (c == '\n') {
+				in_comment = false;
+
 				col = x0;
 				line++;
 				if (line >= available_height / 2) {
@@ -571,9 +584,10 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 				}
 			} else if (c == '\t') {
 				col += 3;
+			} else {
+				col++;
 			}
 		}
-		col++;
 	}
 
 	post_process_preview(img);


### PR DESCRIPTION
This PR makes so that comments are properly highlighted in script thumbnails, and also fixes a bug that causes all lines after the first to be one pixel to the right. Note that this will only affect newly generated thumbnails.

**Before / After:**
![preview](https://user-images.githubusercontent.com/30739239/116833700-37916e80-abaa-11eb-9f46-1c37e0c72258.png)

Fixes #19057.