### PR TITLE
TileMapEditor Modulate autotile previews

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -573,6 +573,7 @@ void TileMapEditor::_update_palette() {
 		entries2.sort_custom<SwapComparator>();
 
 		Ref<Texture2D> tex = tileset->tile_get_texture(sel_tile);
+		Color modulate = tileset->tile_get_modulate(sel_tile);
 
 		for (int i = 0; i < entries2.size(); i++) {
 			manual_palette->add_item(String());
@@ -588,6 +589,7 @@ void TileMapEditor::_update_palette() {
 				}
 
 				manual_palette->set_item_icon(manual_palette->get_item_count() - 1, tex);
+				manual_palette->set_item_icon_modulate(manual_palette->get_item_count() - 1, modulate);
 			}
 
 			manual_palette->set_item_metadata(manual_palette->get_item_count() - 1, entries2[i]);


### PR DESCRIPTION
Cherry-pickable for `3.3`, `3.x`.

|Before|After|
|-|-|
|![Godot_v3 3-stable_win64_R04TWkvDT7](https://user-images.githubusercontent.com/9283098/116879256-bd500100-ac20-11eb-8661-cab77b1ccec9.png)|![cKC19xvXHV](https://user-images.githubusercontent.com/9283098/116880963-f7ba9d80-ac22-11eb-8a71-34a6fc07d9f0.png)|