### PR TITLE
CI: Add `--doctool` check to find missing classref updates

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -70,6 +70,23 @@ jobs:
         run: |
           ./bin/godot.linuxbsd.opt.tools.64 --test
 
+      # Download, unzip and setup SwiftShader library [d4550ab8d3f]
+      - name: Download SwiftShader
+        run: |
+          wget https://github.com/qarmin/gtk_library_store/releases/download/3.24.0/swiftshader.zip
+          unzip swiftshader.zip
+          rm swiftshader.zip
+          curr="$(pwd)/libvk_swiftshader.so"
+          sed -i "s|PATH_TO_CHANGE|$curr|" vk_swiftshader_icd.json
+
+      # Check class reference
+      - name: Check for class reference updates
+        run: |
+          echo "Running --doctool to see if this changes the public API without updating the documentation."
+          echo -e "If a diff is shown, it means that your code/doc changes are incomplete and you should update the class reference with --doctool.\n\n"
+          VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run bin/godot.linuxbsd.opt.tools.64 --doctool . 2>&1 > /dev/null || true
+          git diff --color --exit-code
+
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ github.job }}


### PR DESCRIPTION
This will enforce that PRs properly sync the class reference templates to match
their changes to the public API, and help notice binding bugs in the process
(e.g. missing enum bindings, unexpected API changes or missing argument names).

This should also serve as a reminder to contributors that their changes impact
the scripting API and might warrant actually filling the descriptions for the
new methods/properties/etc.

---

Thanks to @qarmin for doing all the work necessary to be able to run Godot Vulkan with a software renderer (for now SwiftShader, though Mesa's lavapipe should now become functional too for Godot in the next Mesa release).

Note: I intentionally merged a PR with a known missing `--doctool` run to see if this PR actually works as expected.