### PR TITLE
Check OptimizedTranslation generate p_from is valid

### DIFF
--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -46,6 +46,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 	// This method compresses a Translation instance.
 	// Right now, it doesn't handle context or plurals, so Translation subclasses using plurals or context (i.e TranslationPO) shouldn't be compressed.
 #ifdef TOOLS_ENABLED
+	ERR_FAIL_COND(p_from.is_null());
 	List<StringName> keys;
 	p_from->get_message_list(&keys);
 


### PR DESCRIPTION
Fixes #46001.

In this example aa is not valid reference for Ref<Translation> in this way we got null-value at p_from.

```
var aa = BoxShape.new()
PHashTranslation.new().generate(aa)
```
