### PR TITLE
Fixed changing screen orientation on Android

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -196,7 +196,7 @@ void DisplayServerAndroid::window_set_input_text_callback(const Callable &p_call
 }
 
 void DisplayServerAndroid::window_set_rect_changed_callback(const Callable &p_callable, DisplayServer::WindowID p_window) {
-	// Not supported on Android.
+	rect_changed_callback = p_callable;
 }
 
 void DisplayServerAndroid::window_set_drop_files_callback(const Callable &p_callable, DisplayServer::WindowID p_window) {
@@ -387,6 +387,19 @@ void DisplayServerAndroid::reset_window() {
 		}
 	}
 #endif
+}
+
+void DisplayServerAndroid::notify_surface_changed(int p_width, int p_height) {
+	if (rect_changed_callback.is_null()) {
+		return;
+	}
+
+	const Variant size = Rect2i(0, 0, p_width, p_height);
+	const Variant *sizep = &size;
+	Variant ret;
+	Callable::CallError ce;
+
+	rect_changed_callback.call(reinterpret_cast<const Variant **>(&sizep), 1, ret, ce);
 }
 
 DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, DisplayServer::WindowMode p_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error) {

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -112,6 +112,7 @@ private:
 	Callable window_event_callback;
 	Callable input_event_callback;
 	Callable input_text_callback;
+	Callable rect_changed_callback;
 
 	void _window_callback(const Callable &p_callable, const Variant &p_arg) const;
 
@@ -215,6 +216,7 @@ public:
 	static void register_android_driver();
 
 	void reset_window();
+	void notify_surface_changed(int p_width, int p_height);
 
 	virtual Point2i mouse_get_position() const;
 	virtual int mouse_get_button_state() const;

--- a/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkThread.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkThread.kt
@@ -61,6 +61,7 @@ internal class VkThread(private val vkSurfaceView: VkSurfaceView, private val vk
 	private var rendererInitialized = false
 	private var rendererResumed = false
 	private var resumed = false
+	private var surfaceChanged = false
 	private var hasSurface = false
 	private var width = 0
 	private var height = 0
@@ -141,8 +142,10 @@ internal class VkThread(private val vkSurfaceView: VkSurfaceView, private val vk
 	fun onSurfaceChanged(width: Int, height: Int) {
 		lock.withLock {
 			hasSurface = true
+			surfaceChanged = true;
 			this.width = width
 			this.height = height
+
 			lockCondition.signalAll()
 		}
 	}
@@ -188,8 +191,11 @@ internal class VkThread(private val vkSurfaceView: VkSurfaceView, private val vk
 									rendererInitialized = true
 									vkRenderer.onVkSurfaceCreated(vkSurfaceView.holder.surface)
 								}
+							}
 
+							if (surfaceChanged) {
 								vkRenderer.onVkSurfaceChanged(vkSurfaceView.holder.surface, width, height)
+								surfaceChanged = false
 							}
 
 							// Break out of the loop so drawing can occur without holding onto the lock.

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -173,6 +173,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, j
 				os_android->set_native_window(native_window);
 
 				DisplayServerAndroid::get_singleton()->reset_window();
+				DisplayServerAndroid::get_singleton()->notify_surface_changed(p_width, p_height);
 			}
 		}
 	}


### PR DESCRIPTION
**What was broken**
The main Android thread wasn't notifying the engine about screen orientation changes. Android still was rotating screen but the engine was rendering the scene like there was no rotation, which was causing the surface to be stretched and wrongly orientated. Below is the video demonstrating the problem.
[video](https://youtu.be/Y1J5CWC6tBU)

**Fix**
`VkThread.onSurfaceChanged()` now calls `VkRenderer.onVkSurfaceChanged()` upon changing the screen orientation, which resets the window (by calling `DisplayServerAndroid.reset_window()`). Resetting the window is not enough though. All framebuffers need to be invalidated and recreated. This happens through the new method `DisplayServerAndroid.notify_surface_changed()`, which mimics the behavior from the Windows' build. Here is the video of the screen orientation with the applied fix.
[video](https://youtu.be/QRoJ4CAAagY)