### PR TITLE
[3.x] CI: Add `--doctool` check to find missing classref updates

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -208,3 +208,11 @@ jobs:
           echo "----- Run and test project -----"
           DRI_PRIME=0 xvfb-run bin/godot.x11.tools.64s 30 --video-driver GLES3 --audio-driver Dummy --path test_project 2>&1 | tee sanitizers_log.txt || true
           misc/scripts/check_ci_log.py sanitizers_log.txt
+
+      # Check class reference
+      - name: Check for class reference updates
+        run: |
+          echo "Running --doctool to see if this changes the public API without updating the documentation."
+          echo -e "If a diff is shown, it means that your code/doc changes are incomplete and you should update the class reference with --doctool.\n\n"
+          DRI_PRIME=0 xvfb-run bin/godot.x11.tools.64s --doctool . 2>&1 > /dev/null || true
+          git diff --color --exit-code


### PR DESCRIPTION
This will enforce that PRs properly sync the class reference templates to match
their changes to the public API, and help notice binding bugs in the process
(e.g. missing enum bindings, unexpected API changes or missing argument names).

This should also serve as a reminder to contributors that their changes impact
the scripting API and might warrant actually filling the descriptions for the
new methods/properties/etc.

Backport of #48410 (doesn't need SwiftShader, lavapipe works fine for GLES3).

---

Added the test to the sanitizers build as it doesn't use Mono, and in `3.x` it's too tiresome to preserve the Mono-specific project settings which are removed by non-Mono `--doctool` runs.