### PR TITLE
[3.x] Make posmod use int64_t instead of int

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -199,8 +199,8 @@ public:
 		value += 0.0;
 		return value;
 	}
-	static _ALWAYS_INLINE_ int posmod(int p_x, int p_y) {
-		int value = p_x % p_y;
+	static _ALWAYS_INLINE_ int64_t posmod(int64_t p_x, int64_t p_y) {
+		int64_t value = p_x % p_y;
 		if ((value < 0 && p_y > 0) || (value > 0 && p_y < 0)) {
 			value += p_y;
 		}

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -250,7 +250,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 			VALIDATE_ARG_COUNT(2);
 			VALIDATE_ARG_NUM(0);
 			VALIDATE_ARG_NUM(1);
-			r_ret = Math::posmod((int)*p_args[0], (int)*p_args[1]);
+			r_ret = Math::posmod((int64_t)*p_args[0], (int64_t)*p_args[1]);
 		} break;
 		case MATH_FLOOR: {
 			VALIDATE_ARG_COUNT(1);

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -760,7 +760,7 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 
 			VALIDATE_ARG_NUM(0);
 			VALIDATE_ARG_NUM(1);
-			*r_return = Math::posmod((int)*p_inputs[0], (int)*p_inputs[1]);
+			*r_return = Math::posmod((int64_t)*p_inputs[0], (int64_t)*p_inputs[1]);
 		} break;
 		case VisualScriptBuiltinFunc::MATH_FLOOR: {
 


### PR DESCRIPTION
Fixes #48420, fixes #48421. Cherry-pickable for `3.3`.

Needs a separate version for `master` because the code handling calling from GDScript is different. I'm not really sure what needs to be done in there thus I'm leaving it for someone else.