### PR TITLE
Add RPC support to Callable

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -54,6 +54,20 @@ void Callable::call(const Variant **p_arguments, int p_argcount, Variant &r_retu
 	}
 }
 
+void Callable::rpc(int p_id, const Variant **p_arguments, int p_argcount, CallError &r_call_error) const {
+	if (is_null()) {
+		r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
+		r_call_error.argument = 0;
+		r_call_error.expected = 0;
+	} else if (!is_custom()) {
+		r_call_error.error = CallError::CALL_ERROR_INVALID_METHOD;
+		r_call_error.argument = 0;
+		r_call_error.expected = 0;
+	} else {
+		custom->rpc(p_id, p_arguments, p_argcount, r_call_error);
+	}
+}
+
 Callable Callable::bind(const Variant **p_arguments, int p_argcount) const {
 	Vector<Variant> args;
 	args.resize(p_argcount);
@@ -281,6 +295,12 @@ Callable::~Callable() {
 			memdelete(custom);
 		}
 	}
+}
+
+void CallableCustom::rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const {
+	r_call_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+	r_call_error.argument = 0;
+	r_call_error.expected = 0;
 }
 
 const Callable *CallableCustom::get_base_comparator() const {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -70,6 +70,8 @@ public:
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, CallError &r_call_error) const;
 	void call_deferred(const Variant **p_arguments, int p_argcount) const;
 
+	void rpc(int p_id, const Variant **p_arguments, int p_argcount, CallError &r_call_error) const;
+
 	_FORCE_INLINE_ bool is_null() const {
 		return method == StringName() && object == 0;
 	}
@@ -124,6 +126,7 @@ public:
 	virtual CompareLessFunc get_compare_less_func() const = 0;
 	virtual ObjectID get_object() const = 0; //must always be able to provide an object
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const = 0;
+	virtual void rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const;
 	virtual const Callable *get_base_comparator() const;
 
 	CallableCustom();

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -151,6 +151,22 @@
 				Returns [code]true[/code] if both [Callable]s invoke the same custom target.
 			</description>
 		</method>
+		<method name="rpc" qualifiers="vararg const">
+			<return type="void">
+			</return>
+			<description>
+				Perform an RPC (Remote Procedure Call). This is used for multiplayer and is normally not available unless the function being called has been marked as [i]RPC[/i]. Calling it on unsupported functions will result in an error.
+			</description>
+		</method>
+		<method name="rpc_id" qualifiers="vararg const">
+			<return type="void">
+			</return>
+			<argument index="0" name="peer_id" type="int">
+			</argument>
+			<description>
+				Perform an RPC (Remote Procedure Call) on a specific peer ID (see multiplayer documentation for reference). This is used for multiplayer and is normally not available unless the function being called has been marked as [i]RPC[/i]. Calling it on unsupported functions will result in an error.
+			</description>
+		</method>
 		<method name="unbind" qualifiers="const">
 			<return type="Callable">
 			</return>


### PR DESCRIPTION
* Up to each scripting language to implement this whenever possible
* If not supported for the function, it will just error when you try to call

Idea is that instead of:

```GDScript
object.rpc("funcname",args)
```
you can do

```GDScript
object.funcname.rpc(args)
```
![image](https://user-images.githubusercontent.com/6265307/116933315-c1d4e380-ac39-11eb-9c7d-1f9053c90c84.png)

After merged, @vnen needs to implement support for this in GDScript properly.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
