### PR TITLE
Fix property warning when updating inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2469,7 +2469,7 @@ void EditorInspector::_notification(int p_what) {
 		}
 		if (refresh_countdown > 0) {
 			refresh_countdown -= get_process_delta_time();
-			if (refresh_countdown <= 0) {
+			if (refresh_countdown <= 0 && !update_tree_pending) {
 				for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
 					for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
 						if (!E->get()->is_cache_valid()) {


### PR DESCRIPTION
Fixes #46289

The warning came from here:
https://github.com/godotengine/godot/blob/f47c285f678345f5fde6937deb8bd740589beb83/editor/editor_inspector.cpp#L2473-L2481
Now, I don't 100% understand this code, but my assumed cause of the bug is that the inspector was pending update (and presumably the properties were invalid at this time), but the update happened after a cache check on the properties was run. `is_cache_valid()` eventually triggered a warning, because the property didn't exist.

This could potentially be fixed by re-arranging the code, but the change I did is safer.