### PR TITLE
Remove repeat from forward mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -363,10 +363,9 @@ protected:
 	};
 
 	struct RenderElementInfo {
-		uint32_t repeat : 22;
 		uint32_t uses_lightmap : 1;
 		uint32_t lod_index : 8;
-		uint32_t reserved : 1; // was uses_forward_gi but we don't use that here
+		uint32_t reserved : 23;
 	};
 
 	template <PassMode p_pass_mode>


### PR DESCRIPTION
The clustered renderer has an optimization where using mesh instances with the same mesh they can be rendered in a single draw call. This does not work in the mobile renderer as only a single position can be stored in the push constant.  Had to remove this logic from the mobile renderer.

Fixes #48424 
