### PR TITLE
Cleanup vulkan capabilities check and add multiview check

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -7844,6 +7844,10 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 		device_capabilities.subgroup_size = subgroup_capabilities.size;
 		device_capabilities.subgroup_in_shaders = subgroup_capabilities.supported_stages_flags_rd();
 		device_capabilities.subgroup_operations = subgroup_capabilities.supported_operations_flags_rd();
+
+		// get info about further features
+		VulkanContext::MultiviewCapabilities multiview_capabilies = p_context->get_multiview_capabilities();
+		device_capabilities.supports_multiview = multiview_capabilies.is_supported && multiview_capabilies.max_view_count > 1;
 	}
 
 	context = p_context;

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -54,6 +54,12 @@ public:
 		String supported_operations_desc() const;
 	};
 
+	struct MultiviewCapabilities {
+		bool is_supported;
+		int32_t max_view_count;
+		int32_t max_instance_count;
+	};
+
 private:
 	enum {
 		MAX_EXTENSIONS = 128,
@@ -75,6 +81,7 @@ private:
 	uint32_t vulkan_major = 1;
 	uint32_t vulkan_minor = 0;
 	SubgroupCapabilities subgroup_capabilities;
+	MultiviewCapabilities multiview_capabilities;
 
 	String device_vendor;
 	String device_name;
@@ -227,6 +234,7 @@ public:
 	uint32_t get_vulkan_major() const { return vulkan_major; };
 	uint32_t get_vulkan_minor() const { return vulkan_minor; };
 	SubgroupCapabilities get_subgroup_capabilities() const { return subgroup_capabilities; };
+	MultiviewCapabilities get_multiview_capabilities() const { return multiview_capabilities; };
 
 	VkDevice get_device();
 	VkPhysicalDevice get_physical_device();

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -93,10 +93,14 @@ public:
 		DeviceFamily device_family = DEVICE_UNKNOWN;
 		uint32_t version_major = 1.0;
 		uint32_t version_minor = 0.0;
+
 		// subgroup capabilities
 		uint32_t subgroup_size = 0;
 		uint32_t subgroup_in_shaders = 0; // Set flags using SHADER_STAGE_VERTEX_BIT, SHADER_STAGE_FRAGMENT_BIT, etc.
 		uint32_t subgroup_operations = 0; // Set flags, using SubgroupOperations
+
+		// features
+		bool supports_multiview = false; // If true this device supports multiview options
 	};
 
 	typedef Vector<uint8_t> (*ShaderCompileFunction)(ShaderStage p_stage, const String &p_source_code, ShaderLanguage p_language, String *r_error, const Capabilities *p_capabilities);


### PR DESCRIPTION
While working on #48207 I cleaned up the checking code in the Vulkan driver for subgroups and made sure output was only logged when `release_debug` or `debug` was being used as it's overkill in `release`. 

As the multiview work will probably takes some weeks if not months to complete just extracted the relevant changes into a separate PR that we may want to merge in already.