### PR TITLE
Re-bind posmod, use int64_t instead of int

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -218,8 +218,8 @@ public:
 		return value;
 	}
 
-	static _ALWAYS_INLINE_ int posmod(int p_x, int p_y) {
-		int value = p_x % p_y;
+	static _ALWAYS_INLINE_ int64_t posmod(int64_t p_x, int64_t p_y) {
+		int64_t value = p_x % p_y;
 		if ((value < 0 && p_y > 0) || (value > 0 && p_y < 0)) {
 			value += p_y;
 		}

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -93,6 +93,10 @@ struct VariantUtilityFunctions {
 		return Math::fposmod(b, r);
 	}
 
+	static inline int64_t posmod(int64_t b, int64_t r) {
+		return Math::posmod(b, r);
+	}
+
 	static inline double floor(double x) {
 		return Math::floor(x);
 	}
@@ -1154,6 +1158,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(sqrt, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(fmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(fposmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(posmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(floor, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(ceil, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(round, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -652,6 +652,31 @@
 				Converts a 2D point expressed in the polar coordinate system (a distance from the origin [code]r[/code] and an angle [code]th[/code]) to the cartesian coordinate system (X and Y axis).
 			</description>
 		</method>
+		<method name="posmod">
+			<return type="int">
+			</return>
+			<argument index="0" name="x" type="int">
+			</argument>
+			<argument index="1" name="y" type="int">
+			</argument>
+			<description>
+				Returns the integer modulus of [code]x/y[/code] that wraps equally in positive and negative.
+				[codeblock]
+				for i in range(-3, 4):
+				    print("%2d %2d %2d" % [i, i % 3, posmod(i, 3)])
+				[/codeblock]
+				Produces:
+				[codeblock]
+				-3  0  0
+				-2 -2  1
+				-1 -1  2
+				0  0  0
+				1  1  1
+				2  2  2
+				3  0  0
+				[/codeblock]
+			</description>
+		</method>
 		<method name="pow">
 			<return type="float">
 			</return>

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -723,7 +723,7 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 		case VisualScriptBuiltinFunc::MATH_POSMOD: {
 			VALIDATE_ARG_NUM(0);
 			VALIDATE_ARG_NUM(1);
-			*r_return = Math::posmod((int)*p_inputs[0], (int)*p_inputs[1]);
+			*r_return = Math::posmod((int64_t)*p_inputs[0], (int64_t)*p_inputs[1]);
 		} break;
 		case VisualScriptBuiltinFunc::MATH_FLOOR: {
 			VALIDATE_ARG_NUM(0);


### PR DESCRIPTION
Fixes #48420, fixes #48421.

The binding was missed when moving GDScript built-in to Global Scope it seems. (Unless you left it out on purpose @vnen @reduz? *Edit:* vnen says it was likely an oversight.)

Co-authored-by: @kleonc (forward port of #48429)