### PR TITLE
Make it possible to copy the Godot version identifier by clicking it (3.x)

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -37,6 +37,9 @@
 #include "core/version.h"
 #include "core/version_hash.gen.h"
 
+// The metadata key used to store and retrieve the version text to copy to the clipboard.
+static const String META_TEXT_TO_COPY = "text_to_copy";
+
 void EditorAbout::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
@@ -57,7 +60,12 @@ void EditorAbout::_license_tree_selected() {
 	_tpl_text->set_text(selected->get_metadata(0));
 }
 
+void EditorAbout::_version_button_pressed() {
+	OS::get_singleton()->set_clipboard(version_btn->get_meta(META_TEXT_TO_COPY));
+}
+
 void EditorAbout::_bind_methods() {
+	ClassDB::bind_method("_version_button_pressed", &EditorAbout::_version_button_pressed);
 	ClassDB::bind_method(D_METHOD("_license_tree_selected"), &EditorAbout::_license_tree_selected);
 }
 
@@ -119,16 +127,32 @@ EditorAbout::EditorAbout() {
 	_logo = memnew(TextureRect);
 	hbc->add_child(_logo);
 
+	VBoxContainer *version_info_vbc = memnew(VBoxContainer);
+
+	// Add a dummy control node for spacing.
+	Control *v_spacer = memnew(Control);
+	version_info_vbc->add_child(v_spacer);
+
+	version_btn = memnew(LinkButton);
 	String hash = String(VERSION_HASH);
-	if (hash.length() != 0)
+	if (hash.length() != 0) {
 		hash = "." + hash.left(9);
+	}
+	version_btn->set_text(VERSION_FULL_NAME + hash);
+	// Set the text to copy in metadata as it slightly differs from the button's text.
+	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
+	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+	version_btn->set_tooltip(TTR("Click to copy."));
+	version_btn->connect("pressed", this, "_version_button_pressed");
+	version_info_vbc->add_child(version_btn);
 
 	Label *about_text = memnew(Label);
 	about_text->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
-	about_text->set_text(VERSION_FULL_NAME + hash +
-						 String::utf8("\n\xc2\xa9 2007-2021 Juan Linietsky, Ariel Manzur.\n\xc2\xa9 2014-2021 ") +
+	about_text->set_text(String::utf8("\xc2\xa9 2007-2021 Juan Linietsky, Ariel Manzur.\n\xc2\xa9 2014-2021 ") +
 						 TTR("Godot Engine contributors") + "\n");
-	hbc->add_child(about_text);
+	version_info_vbc->add_child(about_text);
+
+	hbc->add_child(version_info_vbc);
 
 	TabContainer *tc = memnew(TabContainer);
 	tc->set_custom_minimum_size(Size2(950, 400) * EDSCALE);

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -34,6 +34,7 @@
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
+#include "scene/gui/link_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
@@ -53,8 +54,10 @@ class EditorAbout : public AcceptDialog {
 
 private:
 	void _license_tree_selected();
+	void _version_button_pressed();
 	ScrollContainer *_populate_list(const String &p_name, const List<String> &p_sections, const char *const *const p_src[], const int p_flag_single_column = 0);
 
+	LinkButton *version_btn;
 	Tree *_tpl_tree;
 	RichTextLabel *_license_text;
 	RichTextLabel *_tpl_text;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -47,12 +47,14 @@
 #include "core/project_settings.h"
 #include "core/translation.h"
 #include "core/version.h"
+#include "core/version_hash.gen.h"
 #include "main/input_default.h"
 #include "main/main.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/file_dialog.h"
+#include "scene/gui/link_button.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/panel_container.h"
@@ -172,6 +174,9 @@
 #include <stdlib.h>
 
 EditorNode *EditorNode::singleton = NULL;
+
+// The metadata key used to store and retrieve the version text to copy to the clipboard.
+static const String META_TEXT_TO_COPY = "text_to_copy";
 
 void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vector<String> &r_filenames) {
 	// Keep track of a list of "index sets," i.e. sets of indices
@@ -874,6 +879,10 @@ void EditorNode::_reload_project_settings() {
 }
 
 void EditorNode::_vp_resized() {
+}
+
+void EditorNode::_version_button_pressed() {
+	OS::get_singleton()->set_clipboard(version_btn->get_meta(META_TEXT_TO_COPY));
 }
 
 void EditorNode::_node_renamed() {
@@ -5342,6 +5351,7 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("_close_messages", &EditorNode::_close_messages);
 	ClassDB::bind_method("_show_messages", &EditorNode::_show_messages);
 	ClassDB::bind_method("_vp_resized", &EditorNode::_vp_resized);
+	ClassDB::bind_method("_version_button_pressed", &EditorNode::_version_button_pressed);
 	ClassDB::bind_method("_quick_opened", &EditorNode::_quick_opened);
 	ClassDB::bind_method("_quick_run", &EditorNode::_quick_run);
 
@@ -6440,11 +6450,31 @@ EditorNode::EditorNode() {
 	bottom_panel_hb_editors->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	bottom_panel_hb->add_child(bottom_panel_hb_editors);
 
-	version_label = memnew(Label);
-	version_label->set_text(VERSION_FULL_CONFIG);
+	VBoxContainer *version_info_vbc = memnew(VBoxContainer);
+	bottom_panel_hb->add_child(version_info_vbc);
+
+	// Add a dummy control node for vertical spacing.
+	Control *v_spacer = memnew(Control);
+	version_info_vbc->add_child(v_spacer);
+
+	version_btn = memnew(LinkButton);
+	version_btn->set_text(VERSION_FULL_CONFIG);
+	String hash = String(VERSION_HASH);
+	if (hash.length() != 0) {
+		hash = "." + hash.left(9);
+	}
+	// Set the text to copy in metadata as it slightly differs from the button's text.
+	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
 	// Fade out the version label to be less prominent, but still readable
-	version_label->set_self_modulate(Color(1, 1, 1, 0.6));
-	bottom_panel_hb->add_child(version_label);
+	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
+	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+	version_btn->set_tooltip(TTR("Click to copy."));
+	version_btn->connect("pressed", this, "_version_button_pressed");
+	version_info_vbc->add_child(version_btn);
+
+	// Add a dummy control node for horizontal spacing.
+	Control *h_spacer = memnew(Control);
+	bottom_panel_hb->add_child(h_spacer);
 
 	bottom_panel_raise = memnew(ToolButton);
 	bottom_panel_raise->set_icon(gui_base->get_icon("ExpandBottomDock", "EditorIcons"));

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -38,6 +38,7 @@
 #include "editor/inspector_dock.h"
 #include "editor/property_editor.h"
 #include "editor/scene_tree_dock.h"
+#include "scene/gui/link_button.h"
 
 typedef void (*EditorNodeInitCallback)();
 typedef void (*EditorPluginInitializeCallback)();
@@ -424,7 +425,7 @@ private:
 	HBoxContainer *bottom_panel_hb;
 	HBoxContainer *bottom_panel_hb_editors;
 	VBoxContainer *bottom_panel_vb;
-	Label *version_label;
+	LinkButton *version_btn;
 	ToolButton *bottom_panel_raise;
 
 	Tree *disk_changed_list;
@@ -478,6 +479,7 @@ private:
 	void _close_messages();
 	void _show_messages();
 	void _vp_resized();
+	void _version_button_pressed();
 
 	int _save_external_resources();
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2303,6 +2303,7 @@ void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_erase_project_confirm", &ProjectManager::_erase_project_confirm);
 	ClassDB::bind_method("_erase_missing_projects_confirm", &ProjectManager::_erase_missing_projects_confirm);
 	ClassDB::bind_method("_show_about", &ProjectManager::_show_about);
+	ClassDB::bind_method("_version_button_pressed", &ProjectManager::_version_button_pressed);
 	ClassDB::bind_method("_language_selected", &ProjectManager::_language_selected);
 	ClassDB::bind_method("_restart_confirm", &ProjectManager::_restart_confirm);
 	ClassDB::bind_method("_on_order_option_changed", &ProjectManager::_on_order_option_changed);
@@ -2321,6 +2322,10 @@ void ProjectManager::_bind_methods() {
 void ProjectManager::_open_asset_library() {
 	asset_library->disable_community_support();
 	tabs->set_current_tab(1);
+}
+
+void ProjectManager::_version_button_pressed() {
+	OS::get_singleton()->set_clipboard(version_btn->get_text());
 }
 
 ProjectManager::ProjectManager() {
@@ -2562,16 +2567,30 @@ ProjectManager::ProjectManager() {
 	settings_hb->set_alignment(BoxContainer::ALIGN_END);
 	settings_hb->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
 
-	Label *version_label = memnew(Label);
+	// A VBoxContainer that contains a dummy Control node to adjust the LinkButton's vertical position.
+	VBoxContainer *spacer_vb = memnew(VBoxContainer);
+	settings_hb->add_child(spacer_vb);
+
+	Control *v_spacer = memnew(Control);
+	spacer_vb->add_child(v_spacer);
+
+	version_btn = memnew(LinkButton);
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0) {
 		hash = "." + hash.left(9);
 	}
-	version_label->set_text("v" VERSION_FULL_BUILD "" + hash);
-	// Fade out the version label to be less prominent, but still readable
-	version_label->set_self_modulate(Color(1, 1, 1, 0.6));
-	version_label->set_align(Label::ALIGN_CENTER);
-	settings_hb->add_child(version_label);
+	version_btn->set_text("v" VERSION_FULL_BUILD + hash);
+	// Fade the version label to be less prominent, but still readable.
+	version_btn->set_self_modulate(Color(1, 1, 1, 0.6));
+	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+	version_btn->set_tooltip(TTR("Click to copy."));
+	version_btn->connect("pressed", this, "_version_button_pressed");
+	spacer_vb->add_child(version_btn);
+
+	// Add a small horizontal spacer between the version and language buttons
+	// to distinguish them.
+	Control *h_spacer = memnew(Control);
+	settings_hb->add_child(h_spacer);
 
 	language_btn = memnew(OptionButton);
 	language_btn->set_flat(true);

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -77,6 +77,7 @@ class ProjectManager : public Control {
 	TabContainer *tabs;
 	ProjectList *_project_list;
 
+	LinkButton *version_btn;
 	OptionButton *language_btn;
 	Control *gui_base;
 
@@ -118,6 +119,7 @@ class ProjectManager : public Control {
 	void _files_dropped(PoolStringArray p_files, int p_screen);
 	void _scan_multiple_folders(PoolStringArray p_files);
 
+	void _version_button_pressed();
 	void _on_order_option_changed();
 	void _on_filter_option_changed();
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/35375.

This closes #24317.