### PR TITLE
Port changes to the "raycast" module build files from 3.x

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -131,6 +131,11 @@ Comment: doctest
 Copyright: 2016-2020, Viktor Kirilov
 License: Expat
 
+Files: ./thirdparty/embree-aarch64/
+Comment: Embree-aarch64
+Copyright: 2009-2021 Intel Corporation
+License: Apache-2.0
+
 Files: ./thirdparty/enet/
 Comment: ENet
 Copyright: 2002-2020, Lee Salzman

--- a/SConstruct
+++ b/SConstruct
@@ -145,6 +145,7 @@ opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise e
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_bullet", "Use the built-in Bullet library", True))
 opts.Add(BoolVariable("builtin_certs", "Use the built-in SSL certificates bundles", True))
+opts.Add(BoolVariable("builtin_embree", "Use the built-in Embree library", True))
 opts.Add(BoolVariable("builtin_enet", "Use the built-in ENet library", True))
 opts.Add(BoolVariable("builtin_freetype", "Use the built-in FreeType library", True))
 opts.Add(BoolVariable("builtin_glslang", "Use the built-in glslang library", True))

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -3,84 +3,101 @@
 Import("env")
 Import("env_modules")
 
-embree_src = [
-    "common/sys/sysinfo.cpp",
-    "common/sys/alloc.cpp",
-    "common/sys/filename.cpp",
-    "common/sys/library.cpp",
-    "common/sys/thread.cpp",
-    "common/sys/string.cpp",
-    "common/sys/regression.cpp",
-    "common/sys/mutex.cpp",
-    "common/sys/condition.cpp",
-    "common/sys/barrier.cpp",
-    "common/math/constants.cpp",
-    "common/simd/sse.cpp",
-    "common/lexers/stringstream.cpp",
-    "common/lexers/tokenstream.cpp",
-    "common/tasking/taskschedulerinternal.cpp",
-    "common/algorithms/parallel_for.cpp",
-    "common/algorithms/parallel_reduce.cpp",
-    "common/algorithms/parallel_prefix_sum.cpp",
-    "common/algorithms/parallel_for_for.cpp",
-    "common/algorithms/parallel_for_for_prefix_sum.cpp",
-    "common/algorithms/parallel_partition.cpp",
-    "common/algorithms/parallel_sort.cpp",
-    "common/algorithms/parallel_set.cpp",
-    "common/algorithms/parallel_map.cpp",
-    "common/algorithms/parallel_filter.cpp",
-    "kernels/common/device.cpp",
-    "kernels/common/stat.cpp",
-    "kernels/common/acceln.cpp",
-    "kernels/common/accelset.cpp",
-    "kernels/common/state.cpp",
-    "kernels/common/rtcore.cpp",
-    "kernels/common/rtcore_builder.cpp",
-    "kernels/common/scene.cpp",
-    "kernels/common/alloc.cpp",
-    "kernels/common/geometry.cpp",
-    "kernels/common/scene_triangle_mesh.cpp",
-    "kernels/geometry/primitive4.cpp",
-    "kernels/builders/primrefgen.cpp",
-    "kernels/bvh/bvh.cpp",
-    "kernels/bvh/bvh_statistics.cpp",
-    "kernels/bvh/bvh4_factory.cpp",
-    "kernels/bvh/bvh8_factory.cpp",
-    "kernels/bvh/bvh_collider.cpp",
-    "kernels/bvh/bvh_rotate.cpp",
-    "kernels/bvh/bvh_refit.cpp",
-    "kernels/bvh/bvh_builder.cpp",
-    "kernels/bvh/bvh_builder_morton.cpp",
-    "kernels/bvh/bvh_builder_sah.cpp",
-    "kernels/bvh/bvh_builder_sah_spatial.cpp",
-    "kernels/bvh/bvh_builder_sah_mb.cpp",
-    "kernels/bvh/bvh_builder_twolevel.cpp",
-    "kernels/bvh/bvh_intersector1_bvh4.cpp",
-]
-
-embree_dir = "#thirdparty/embree-aarch64/"
-
-env_embree = env_modules.Clone()
-embree_sources = [embree_dir + file for file in embree_src]
-env_embree.Prepend(CPPPATH=[embree_dir, embree_dir + "include"])
-env_embree.Append(CPPFLAGS=["-DEMBREE_TARGET_SSE2", "-DEMBREE_LOWEST_ISA", "-DTASKING_INTERNAL", "-DNDEBUG"])
-
-if not env_embree.msvc:
-    env_embree.Append(CPPFLAGS=["-msse2", "-mxsave"])
-    if env["platform"] == "windows":
-        env_embree.Append(CPPFLAGS=["-mstackrealign"])
-
-if env["platform"] == "windows":
-    if env.msvc:
-        env.Append(LINKFLAGS=["psapi.lib"])
-        env_embree.Append(CPPFLAGS=["-D__SSE2__", "-D__SSE__"])
-    else:
-        env.Append(LIBS=["psapi"])
-
-env_embree.disable_warnings()
-env_embree.add_source_files(env.modules_sources, embree_sources)
-
 env_raycast = env_modules.Clone()
-env_raycast.Prepend(CPPPATH=[embree_dir, embree_dir + "include", embree_dir + "common"])
 
-env_raycast.add_source_files(env.modules_sources, "*.cpp")
+# Thirdparty source files
+
+thirdparty_obj = []
+
+if env["builtin_embree"]:
+    thirdparty_dir = "#thirdparty/embree-aarch64/"
+
+    embree_src = [
+        "common/sys/sysinfo.cpp",
+        "common/sys/alloc.cpp",
+        "common/sys/filename.cpp",
+        "common/sys/library.cpp",
+        "common/sys/thread.cpp",
+        "common/sys/string.cpp",
+        "common/sys/regression.cpp",
+        "common/sys/mutex.cpp",
+        "common/sys/condition.cpp",
+        "common/sys/barrier.cpp",
+        "common/math/constants.cpp",
+        "common/simd/sse.cpp",
+        "common/lexers/stringstream.cpp",
+        "common/lexers/tokenstream.cpp",
+        "common/tasking/taskschedulerinternal.cpp",
+        "common/algorithms/parallel_for.cpp",
+        "common/algorithms/parallel_reduce.cpp",
+        "common/algorithms/parallel_prefix_sum.cpp",
+        "common/algorithms/parallel_for_for.cpp",
+        "common/algorithms/parallel_for_for_prefix_sum.cpp",
+        "common/algorithms/parallel_partition.cpp",
+        "common/algorithms/parallel_sort.cpp",
+        "common/algorithms/parallel_set.cpp",
+        "common/algorithms/parallel_map.cpp",
+        "common/algorithms/parallel_filter.cpp",
+        "kernels/common/device.cpp",
+        "kernels/common/stat.cpp",
+        "kernels/common/acceln.cpp",
+        "kernels/common/accelset.cpp",
+        "kernels/common/state.cpp",
+        "kernels/common/rtcore.cpp",
+        "kernels/common/rtcore_builder.cpp",
+        "kernels/common/scene.cpp",
+        "kernels/common/alloc.cpp",
+        "kernels/common/geometry.cpp",
+        "kernels/common/scene_triangle_mesh.cpp",
+        "kernels/geometry/primitive4.cpp",
+        "kernels/builders/primrefgen.cpp",
+        "kernels/bvh/bvh.cpp",
+        "kernels/bvh/bvh_statistics.cpp",
+        "kernels/bvh/bvh4_factory.cpp",
+        "kernels/bvh/bvh8_factory.cpp",
+        "kernels/bvh/bvh_collider.cpp",
+        "kernels/bvh/bvh_rotate.cpp",
+        "kernels/bvh/bvh_refit.cpp",
+        "kernels/bvh/bvh_builder.cpp",
+        "kernels/bvh/bvh_builder_morton.cpp",
+        "kernels/bvh/bvh_builder_sah.cpp",
+        "kernels/bvh/bvh_builder_sah_spatial.cpp",
+        "kernels/bvh/bvh_builder_sah_mb.cpp",
+        "kernels/bvh/bvh_builder_twolevel.cpp",
+        "kernels/bvh/bvh_intersector1_bvh4.cpp",
+    ]
+
+    thirdparty_sources = [thirdparty_dir + file for file in embree_src]
+
+    env_raycast.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "include"])
+    env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2", "EMBREE_LOWEST_ISA", "TASKING_INTERNAL", "NDEBUG"])
+
+    if not env.msvc:
+        if env["arch"] in ["x86", "x86_64"]:
+            env_raycast.Append(CPPFLAGS=["-msse2", "-mxsave"])
+
+        if env["platform"] == "windows":
+            env_raycast.Append(CPPFLAGS=["-mstackrealign"])
+
+    if env["platform"] == "windows":
+        if env.msvc:
+            env.Append(LINKFLAGS=["psapi.lib"])
+            env_raycast.Append(CPPDEFINES=["__SSE2__", "__SSE__"])
+        else:
+            env.Append(LIBS=["psapi"])
+
+    env_thirdparty = env_raycast.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env.modules_sources += thirdparty_obj
+
+
+# Godot source files
+
+module_obj = []
+
+env_raycast.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -325,6 +325,10 @@ def configure(env):
     if not env["builtin_pcre2"]:
         env.ParseConfig("pkg-config libpcre2-32 --cflags --libs")
 
+    if not env["builtin_embree"]:
+        # No pkgconfig file so far, hardcode expected lib name.
+        env.Append(LIBS=["embree3"])
+
     ## Flags
 
     if os.system("pkg-config --exists alsa") == 0:  # 0 means found


### PR DESCRIPTION
Bring some changes to the `raycast` build system from 3.x, mainly the ability to build against system Embree library.