### PR TITLE
Made Editor Log buttons save their state, per project.

### DIFF
--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -72,11 +72,11 @@ private:
 	private:
 		// Force usage of set method since it has functionality built-in.
 		int message_count = 0;
+		bool active = true;
 
 	public:
 		MessageType type;
 		Button *toggle_button = nullptr;
-		bool active = true;
 
 		void initialize_button(const String &p_tooltip, Callable p_toggled_callback) {
 			toggle_button = memnew(Button);
@@ -98,6 +98,15 @@ private:
 		void set_message_count(int p_count) {
 			message_count = p_count;
 			toggle_button->set_text(itos(message_count));
+		}
+
+		bool is_active() {
+			return active;
+		}
+
+		void set_active(bool p_active) {
+			toggle_button->set_pressed(p_active);
+			active = p_active;
 		}
 
 		LogFilter(MessageType p_type) :
@@ -124,6 +133,9 @@ private:
 	// Warnings or Errors are encounetered.
 	Button *tool_button;
 
+	bool is_loading_state = false; // Used to disable saving requests while loading (some signals from buttons will try trigger a save, which happens during loading).
+	Timer *save_state_timer;
+
 	static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, ErrorHandlerType p_type);
 
 	ErrorHandlerList eh;
@@ -146,6 +158,10 @@ private:
 	void _reset_message_counts();
 
 	void _set_collapse(bool p_collapse);
+
+	void _start_state_save_timer();
+	void _save_state();
+	void _load_state();
 
 protected:
 	static void _bind_methods();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4362,6 +4362,8 @@ void EditorNode::_save_docks() {
 	}
 	Ref<ConfigFile> config;
 	config.instance();
+	// Load and amend existing config if it exists.
+	config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 
 	_save_docks_to_config(config, "docks");
 	_save_open_scenes_to_config(config, "EditorNode");


### PR DESCRIPTION
Closes #48445

State is saved in `res://.godot/editor_layout.cfg`, which is the same as the editor docks layout, per project. This seems to be the most appropriate place to save it. A slight logic change was required in `EditorNode` so that the file is not overwritten every time it is saved, since now the file is read and written to from somewhere other than the one `EditorNode` method.

The state of all 4 filter buttons and the collapse state is saved:
![image](https://user-images.githubusercontent.com/41730826/117087152-ff4c8480-ad91-11eb-9636-45ee11673f6b.png)

A timer is used to delay the save, as is done in other places in the editor, so that rapid changes to the state do not spam saving the config file.

CC @KoBeWi 