### PR TITLE
Fixed crash in Editor Settings shortcuts UI

### DIFF
--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -270,16 +270,17 @@ void EditorSettingsDialog::_update_shortcuts() {
 		Array events; // Need to get the list of events into an array so it can be set as metadata on the item.
 		Vector<String> event_strings;
 
-		List<Ref<InputEvent>> defaults = InputMap::get_singleton()->get_builtins().find(action_name).value();
-		// Remove all non-key events from the defaults.
-		for (List<Ref<InputEvent>>::Element *I = defaults.front(); I; I = I->next()) {
+		List<Ref<InputEvent>> all_default_events = InputMap::get_singleton()->get_builtins().find(action_name).value();
+		List<Ref<InputEventKey>> key_default_events;
+		// Remove all non-key events from the defaults. Only check keys, since we are in the editor.
+		for (List<Ref<InputEvent>>::Element *I = all_default_events.front(); I; I = I->next()) {
 			Ref<InputEventKey> k = I->get();
-			if (k.is_null()) {
-				I->erase();
+			if (k.is_valid()) {
+				key_default_events.push_back(k);
 			}
 		}
 
-		bool same_as_defaults = defaults.size() == action.inputs.size(); // Initially this is set to just whether the arrays are equal. Later we check the events if needed.
+		bool same_as_defaults = key_default_events.size() == action.inputs.size(); // Initially this is set to just whether the arrays are equal. Later we check the events if needed.
 
 		int count = 0;
 		for (List<Ref<InputEvent>>::Element *I = action.inputs.front(); I; I = I->next()) {
@@ -288,12 +289,8 @@ void EditorSettingsDialog::_update_shortcuts() {
 			event_strings.push_back(I->get()->as_text());
 
 			// Only check if the events have been the same so far - once one fails, we don't need to check any more.
-			if (same_as_defaults) {
-				Ref<InputEventKey> k = defaults[count];
-				// Only check keys, since we are in the editor.
-				if (k.is_valid() && !defaults[count]->shortcut_match(I->get())) {
-					same_as_defaults = false;
-				}
+			if (same_as_defaults && !key_default_events[count]->shortcut_match(I->get())) {
+				same_as_defaults = false;
 			}
 			count++;
 		}


### PR DESCRIPTION
Closes #48417

CC @qarmin I was not getting that crash for some reason... How did you get it? It doesnt seem it would be a platform thing (im on Windows)