### PR TITLE
Add checks for __SSE2__ in the lightmap raycaster

### DIFF
--- a/modules/raycast/lightmap_raycaster.cpp
+++ b/modules/raycast/lightmap_raycaster.cpp
@@ -30,7 +30,9 @@
 
 #include "lightmap_raycaster.h"
 
+#ifdef __SSE2__
 #include <pmmintrin.h>
+#endif
 
 LightmapRaycaster *LightmapRaycasterEmbree::create_embree_raycaster() {
 	return memnew(LightmapRaycasterEmbree);
@@ -180,8 +182,10 @@ void embree_error_handler(void *p_user_data, RTCError p_code, const char *p_str)
 }
 
 LightmapRaycasterEmbree::LightmapRaycasterEmbree() {
+#ifdef __SSE2__
 	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 	_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+#endif
 
 	embree_device = rtcNewDevice(nullptr);
 	rtcSetDeviceErrorFunction(embree_device, &embree_error_handler, nullptr);
@@ -189,8 +193,10 @@ LightmapRaycasterEmbree::LightmapRaycasterEmbree() {
 }
 
 LightmapRaycasterEmbree::~LightmapRaycasterEmbree() {
+#ifdef __SSE2__
 	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
 	_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
+#endif
 
 	if (embree_scene != nullptr) {
 		rtcReleaseScene(embree_scene);


### PR DESCRIPTION
Add checks for `__SSE2__` in the lightmap raycaster because it was causing build issues on platforms using SSE2NEON.
