### PR TITLE
Add PackedDataContainer data pointer check for non nullable

### DIFF
--- a/core/io/packed_data_container.cpp
+++ b/core/io/packed_data_container.cpp
@@ -123,6 +123,7 @@ Variant PackedDataContainer::_get_at_ofs(uint32_t p_ofs, const uint8_t *p_buf, b
 
 uint32_t PackedDataContainer::_type_at_ofs(uint32_t p_ofs) const {
 	const uint8_t *rd = data.ptr();
+	ERR_FAIL_COND_V(!rd, 0);
 	const uint8_t *r = &rd[p_ofs];
 	uint32_t type = decode_uint32(r);
 
@@ -149,6 +150,10 @@ int PackedDataContainer::_size(uint32_t p_ofs) const {
 
 Variant PackedDataContainer::_key_at_ofs(uint32_t p_ofs, const Variant &p_key, bool &err) const {
 	const uint8_t *rd = data.ptr();
+	if (!rd) {
+		err = true;
+		ERR_FAIL_COND_V(!rd, Variant());
+	}
 	const uint8_t *r = &rd[p_ofs];
 	uint32_t type = decode_uint32(r);
 


### PR DESCRIPTION
Fixes #46019.

In this class is 4 calls of data.read - two of them has been already protected, there are two more which one now have checking.