### PR TITLE
[HTML5] Markup cleanup, replace single quotes by double quotes

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<html lang="en">
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html xmlns='http://www.w3.org/1999/xhtml' lang='' xml:lang=''>
+<html lang="">
 <head>
-	<meta charset='utf-8' />
-	<meta name='viewport' content='width=device-width, user-scalable=no' />
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, user-scalable=no" />
 	<title>$GODOT_PROJECT_NAME</title>
-	<style type='text/css'>
+	<style type="text/css">
 
 		body {
 			touch-action: none;
@@ -114,13 +114,13 @@
 $GODOT_HEAD_INCLUDE
 </head>
 <body>
-	<canvas id='canvas'>
+	<canvas id="canvas">
 		HTML5 canvas appears to be unsupported in the current browser.<br />
 		Please try updating or use a different browser.
 	</canvas>
-	<div id='status'>
-		<div id='status-progress' style='display: none;' oncontextmenu='event.preventDefault();'><div id ='status-progress-inner'></div></div>
-		<div id='status-indeterminate' style='display: none;' oncontextmenu='event.preventDefault();'>
+	<div id="status">
+		<div id="status-progress" style="display: none;" oncontextmenu="event.preventDefault();"><div id="status-progress-inner"></div></div>
+		<div id="status-indeterminate" style="display: none;" oncontextmenu="event.preventDefault();">
 			<div></div>
 			<div></div>
 			<div></div>
@@ -130,11 +130,11 @@ $GODOT_HEAD_INCLUDE
 			<div></div>
 			<div></div>
 		</div>
-		<div id='status-notice' class='godot' style='display: none;'></div>
+		<div id="status-notice" class="godot" style="display: none;"></div>
 	</div>
 
-	<script type='text/javascript' src='$GODOT_URL'></script>
-	<script type='text/javascript'>//<![CDATA[
+	<script type="text/javascript" src="$GODOT_URL"></script>
+	<script type="text/javascript">//<![CDATA[
 
 		const GODOT_CONFIG = $GODOT_CONFIG;
 		var engine = new Engine(GODOT_CONFIG);


### PR DESCRIPTION
Small markup cleanup for the HTML 5 export.

Should be cherry-pickable for 3.4 if I'm not mistaken.