### PR TITLE
Made the file system on the Bottom next to the output tab for convenience.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6375,7 +6375,7 @@ EditorNode::EditorNode() {
 	import_dock = memnew(ImportDock);
 	node_dock = memnew(NodeDock);
 
-	filesystem_dock = memnew(FileSystemDock(this));
+	filesystem_dock = memnew(FileSystemDock(this, false));
 	filesystem_dock->connect("inherit", this, "_inherit_request");
 	filesystem_dock->connect("instance", this, "_instance_request");
 	filesystem_dock->connect("display_mode_changed", this, "_save_docks");
@@ -6485,6 +6485,13 @@ EditorNode::EditorNode() {
 	bottom_panel_raise->hide();
 	bottom_panel_raise->set_toggle_mode(true);
 	bottom_panel_raise->connect("toggled", this, "_bottom_panel_raise_toggled");
+
+	FileSystemDock* fs_d = memnew(FileSystemDock(this, true));
+	fs_d->connect("inherit", this, "_inherit_request");
+	fs_d->connect("instance", this, "_instance_request");
+	fs_d->connect("display_mode_changed", this, "_save_docks");
+
+	add_bottom_panel_item(TTR("File System"), fs_d);
 
 	log = memnew(EditorLog);
 	ToolButton *output_button = add_bottom_panel_item(TTR("Output"), log);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -96,9 +96,11 @@ private:
 		FOLDER_COLLAPSE_ALL,
 	};
 
+	bool is_lower_dock;
+
 	VBoxContainer *scanning_vb;
 	ProgressBar *scanning_progress;
-	VSplitContainer *split_box;
+	SplitContainer *split_box;
 	VBoxContainer *file_list_vb;
 
 	EditorNode *editor;
@@ -304,7 +306,7 @@ public:
 	void set_file_list_display_mode(FileListDisplayMode p_mode);
 	FileListDisplayMode get_file_list_display_mode() { return file_list_display_mode; };
 
-	FileSystemDock(EditorNode *p_editor);
+	FileSystemDock(EditorNode *p_editor, bool dock_lower = false);
 	~FileSystemDock();
 };
 


### PR DESCRIPTION

![GodotBottomFileSystem](https://user-images.githubusercontent.com/62818641/117224481-0dc08d80-adde-11eb-95b0-443026c58f58.PNG)

Just a convenience commit. No need to include, code isn't great but still a nice little feature. Maybe not the best way to implement it and can definitely be improved, I've just wanted this for a while so I just did it myself. having the file system in the sides of the screen is just too inconvenient for me.