### PR TITLE
Deterministic constraint map in Godot Physics solver

### DIFF
--- a/servers/physics_2d/area_2d_sw.h
+++ b/servers/physics_2d/area_2d_sw.h
@@ -34,11 +34,9 @@
 #include "collision_object_2d_sw.h"
 #include "core/templates/self_list.h"
 #include "servers/physics_server_2d.h"
-//#include "servers/physics_3d/query_sw.h"
 
 class Space2DSW;
 class Body2DSW;
-class Constraint2DSW;
 
 class Area2DSW : public CollisionObject2DSW {
 	PhysicsServer2D::AreaSpaceOverrideMode space_override_mode;
@@ -94,17 +92,10 @@ class Area2DSW : public CollisionObject2DSW {
 	Map<BodyKey, BodyState> monitored_bodies;
 	Map<BodyKey, BodyState> monitored_areas;
 
-	//virtual void shape_changed_notify(Shape2DSW *p_shape);
-	//virtual void shape_deleted_notify(Shape2DSW *p_shape);
-	Set<Constraint2DSW *> constraints;
-
 	virtual void _shapes_changed();
 	void _queue_monitor_update();
 
 public:
-	//_FORCE_INLINE_ const Matrix32& get_inverse_transform() const { return inverse_transform; }
-	//_FORCE_INLINE_ SpaceSW* get_owner() { return owner; }
-
 	void set_monitor_callback(ObjectID p_id, const StringName &p_method);
 	_FORCE_INLINE_ bool has_monitor_callback() const { return monitor_callback_id.is_valid(); }
 
@@ -146,11 +137,6 @@ public:
 
 	_FORCE_INLINE_ void set_priority(int p_priority) { priority = p_priority; }
 	_FORCE_INLINE_ int get_priority() const { return priority; }
-
-	_FORCE_INLINE_ void add_constraint(Constraint2DSW *p_constraint) { constraints.insert(p_constraint); }
-	_FORCE_INLINE_ void remove_constraint(Constraint2DSW *p_constraint) { constraints.erase(p_constraint); }
-	_FORCE_INLINE_ const Set<Constraint2DSW *> &get_constraints() const { return constraints; }
-	_FORCE_INLINE_ void clear_constraints() { constraints.clear(); }
 
 	void set_monitorable(bool p_monitorable);
 	_FORCE_INLINE_ bool is_monitorable() const { return monitorable; }

--- a/servers/physics_2d/area_pair_2d_sw.cpp
+++ b/servers/physics_2d/area_pair_2d_sw.cpp
@@ -89,7 +89,7 @@ AreaPair2DSW::AreaPair2DSW(Body2DSW *p_body, int p_body_shape, Area2DSW *p_area,
 	area = p_area;
 	body_shape = p_body_shape;
 	area_shape = p_area_shape;
-	body->add_constraint(this, 0);
+	body->add_constraint(this);
 	area->add_constraint(this);
 	if (p_body->get_mode() == PhysicsServer2D::BODY_MODE_KINEMATIC) { //need to be active to process pair
 		p_body->set_active(true);
@@ -105,7 +105,7 @@ AreaPair2DSW::~AreaPair2DSW() {
 			area->remove_body_from_query(body, body_shape, area_shape);
 		}
 	}
-	body->remove_constraint(this, 0);
+	body->remove_constraint(this);
 	area->remove_constraint(this);
 }
 

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -541,22 +541,24 @@ void Body2DSW::integrate_velocities(real_t p_step) {
 }
 
 void Body2DSW::wakeup_neighbours() {
-	for (List<Pair<Constraint2DSW *, int>>::Element *E = constraint_list.front(); E; E = E->next()) {
-		const Constraint2DSW *c = E->get().first;
-		Body2DSW **n = c->get_body_ptr();
-		int bc = c->get_body_count();
+	for (const CollisionObject2DSW::T_ConstraintMap::Element *E = get_constraint_map().front(); E; E = E->next()) {
+		const Constraint2DSW *constraint = E->get();
 
-		for (int i = 0; i < bc; i++) {
-			if (i == E->get().second) {
-				continue;
-			}
-			Body2DSW *b = n[i];
-			if (b->mode != PhysicsServer2D::BODY_MODE_RIGID) {
+		Body2DSW **bodies = constraint->get_body_ptr();
+		int body_count = constraint->get_body_count();
+		for (int i = 0; i < body_count; i++) {
+			Body2DSW *body = bodies[i];
+
+			if (body == this) {
 				continue;
 			}
 
-			if (!b->is_active()) {
-				b->set_active(true);
+			if (body->mode != PhysicsServer2D::BODY_MODE_RIGID) {
+				continue;
+			}
+
+			if (!body->is_active()) {
+				body->set_active(true);
 			}
 		}
 	}

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -33,11 +33,7 @@
 
 #include "area_2d_sw.h"
 #include "collision_object_2d_sw.h"
-#include "core/templates/list.h"
-#include "core/templates/pair.h"
 #include "core/templates/vset.h"
-
-class Constraint2DSW;
 
 class Body2DSW : public CollisionObject2DSW {
 	PhysicsServer2D::BodyMode mode;
@@ -84,8 +80,6 @@ class Body2DSW : public CollisionObject2DSW {
 	void _update_inertia();
 	virtual void _shapes_changed();
 	Transform2D new_transform;
-
-	List<Pair<Constraint2DSW *, int>> constraint_list;
 
 	struct AreaCMP {
 		Area2DSW *area;
@@ -171,11 +165,6 @@ public:
 
 	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
 	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }
-
-	_FORCE_INLINE_ void add_constraint(Constraint2DSW *p_constraint, int p_pos) { constraint_list.push_back({ p_constraint, p_pos }); }
-	_FORCE_INLINE_ void remove_constraint(Constraint2DSW *p_constraint, int p_pos) { constraint_list.erase({ p_constraint, p_pos }); }
-	const List<Pair<Constraint2DSW *, int>> &get_constraint_list() const { return constraint_list; }
-	_FORCE_INLINE_ void clear_constraint_list() { constraint_list.clear(); }
 
 	_FORCE_INLINE_ void set_omit_force_integration(bool p_omit_force_integration) { omit_force_integration = p_omit_force_integration; }
 	_FORCE_INLINE_ bool get_omit_force_integration() const { return omit_force_integration; }

--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -534,11 +534,11 @@ BodyPair2DSW::BodyPair2DSW(Body2DSW *p_A, int p_shape_A, Body2DSW *p_B, int p_sh
 	shape_A = p_shape_A;
 	shape_B = p_shape_B;
 	space = A->get_space();
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 BodyPair2DSW::~BodyPair2DSW() {
-	A->remove_constraint(this, 0);
-	B->remove_constraint(this, 1);
+	A->remove_constraint(this);
+	B->remove_constraint(this);
 }

--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -32,6 +32,8 @@
 #define COLLISION_OBJECT_2D_SW_H
 
 #include "broad_phase_2d_sw.h"
+#include "constraint_2d_sw.h"
+#include "core/templates/map.h"
 #include "core/templates/self_list.h"
 #include "servers/physics_server_2d.h"
 #include "shape_2d_sw.h"
@@ -44,6 +46,8 @@ public:
 		TYPE_AREA,
 		TYPE_BODY
 	};
+
+	typedef Map<uint32_t, Constraint2DSW *> T_ConstraintMap;
 
 private:
 	Type type;
@@ -76,6 +80,8 @@ private:
 	uint32_t collision_mask;
 	uint32_t collision_layer;
 	bool _static;
+
+	T_ConstraintMap constraint_map;
 
 	SelfList<CollisionObject2DSW> pending_shape_update_list;
 
@@ -182,6 +188,11 @@ public:
 
 	void remove_shape(Shape2DSW *p_shape);
 	void remove_shape(int p_index);
+
+	_FORCE_INLINE_ void add_constraint(Constraint2DSW *p_constraint) { constraint_map.insert(p_constraint->get_constraint_id(), p_constraint); }
+	_FORCE_INLINE_ void remove_constraint(Constraint2DSW *p_constraint) { constraint_map.erase(p_constraint->get_constraint_id()); }
+	const T_ConstraintMap &get_constraint_map() const { return constraint_map; }
+	_FORCE_INLINE_ void clear_constraint_map() { constraint_map.clear(); }
 
 	virtual void set_space(Space2DSW *p_space) = 0;
 

--- a/servers/physics_2d/constraint_2d_sw.cpp
+++ b/servers/physics_2d/constraint_2d_sw.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  constraint_2d_sw.h                                                   */
+/*  constraint_2d_sw.cpp                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,55 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CONSTRAINT_2D_SW_H
-#define CONSTRAINT_2D_SW_H
+#include "constraint_2d_sw.h"
 
-#include "core/math/math_defs.h"
-#include "core/templates/rid.h"
-#include "core/templates/safe_refcount.h"
-
-class Body2DSW;
-
-class Constraint2DSW {
-	Body2DSW **_body_ptr;
-	int _body_count;
-	uint64_t island_step;
-	bool disabled_collisions_between_bodies;
-
-	RID self;
-
-	static SafeNumeric<uint32_t> constraint_id_counter;
-	uint32_t constraint_id = 0;
-
-protected:
-	Constraint2DSW(Body2DSW **p_body_ptr = nullptr, int p_body_count = 0) {
-		_body_ptr = p_body_ptr;
-		_body_count = p_body_count;
-		island_step = 0;
-		disabled_collisions_between_bodies = true;
-		constraint_id = constraint_id_counter.increment();
-	}
-
-public:
-	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }
-	_FORCE_INLINE_ RID get_self() const { return self; }
-
-	_FORCE_INLINE_ uint32_t get_constraint_id() const { return constraint_id; }
-
-	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
-	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }
-
-	_FORCE_INLINE_ Body2DSW **get_body_ptr() const { return _body_ptr; }
-	_FORCE_INLINE_ int get_body_count() const { return _body_count; }
-
-	_FORCE_INLINE_ void disable_collisions_between_bodies(const bool p_disabled) { disabled_collisions_between_bodies = p_disabled; }
-	_FORCE_INLINE_ bool is_disabled_collisions_between_bodies() const { return disabled_collisions_between_bodies; }
-
-	virtual bool setup(real_t p_step) = 0;
-	virtual bool pre_solve(real_t p_step) = 0;
-	virtual void solve(real_t p_step) = 0;
-
-	virtual ~Constraint2DSW() {}
-};
-
-#endif // CONSTRAINT_2D_SW_H
+SafeNumeric<uint32_t> Constraint2DSW::constraint_id_counter;

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -215,9 +215,9 @@ PinJoint2DSW::PinJoint2DSW(const Vector2 &p_pos, Body2DSW *p_body_a, Body2DSW *p
 
 	softness = 0;
 
-	p_body_a->add_constraint(this, 0);
+	p_body_a->add_constraint(this);
 	if (p_body_b) {
-		p_body_b->add_constraint(this, 1);
+		p_body_b->add_constraint(this);
 	}
 }
 
@@ -370,8 +370,8 @@ GrooveJoint2DSW::GrooveJoint2DSW(const Vector2 &p_a_groove1, const Vector2 &p_a_
 	B_anchor = B->get_inv_transform().xform(p_b_anchor);
 	A_groove_normal = -(A_groove_2 - A_groove_1).normalized().orthogonal();
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 //////////////////////////////////////////////
@@ -482,6 +482,6 @@ DampedSpringJoint2DSW::DampedSpringJoint2DSW(const Vector2 &p_anchor_a, const Ve
 	stiffness = 20;
 	damping = 1.5;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }

--- a/servers/physics_2d/joints_2d_sw.h
+++ b/servers/physics_2d/joints_2d_sw.h
@@ -70,7 +70,7 @@ public:
 		for (int i = 0; i < get_body_count(); i++) {
 			Body2DSW *body = get_body_ptr()[i];
 			if (body) {
-				body->remove_constraint(this, i);
+				body->remove_constraint(this);
 			}
 		}
 	};

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -304,7 +304,7 @@ void PhysicsServer2DSW::area_set_space(RID p_area, RID p_space) {
 		return; //pointless
 	}
 
-	area->clear_constraints();
+	area->clear_constraint_map();
 	area->set_space(space);
 };
 
@@ -548,7 +548,7 @@ void PhysicsServer2DSW::body_set_space(RID p_body, RID p_space) {
 		return; //pointless
 	}
 
-	body->clear_constraint_list();
+	body->clear_constraint_map();
 	body->set_space(space);
 };
 

--- a/servers/physics_3d/area_3d_sw.h
+++ b/servers/physics_3d/area_3d_sw.h
@@ -34,11 +34,9 @@
 #include "collision_object_3d_sw.h"
 #include "core/templates/self_list.h"
 #include "servers/physics_server_3d.h"
-//#include "servers/physics_3d/query_sw.h"
 
 class Space3DSW;
 class Body3DSW;
-class Constraint3DSW;
 
 class Area3DSW : public CollisionObject3DSW {
 	PhysicsServer3D::AreaSpaceOverrideMode space_override_mode;
@@ -94,18 +92,10 @@ class Area3DSW : public CollisionObject3DSW {
 	Map<BodyKey, BodyState> monitored_bodies;
 	Map<BodyKey, BodyState> monitored_areas;
 
-	//virtual void shape_changed_notify(ShapeSW *p_shape);
-	//virtual void shape_deleted_notify(ShapeSW *p_shape);
-
-	Set<Constraint3DSW *> constraints;
-
 	virtual void _shapes_changed();
 	void _queue_monitor_update();
 
 public:
-	//_FORCE_INLINE_ const Transform& get_inverse_transform() const { return inverse_transform; }
-	//_FORCE_INLINE_ SpaceSW* get_owner() { return owner; }
-
 	void set_monitor_callback(ObjectID p_id, const StringName &p_method);
 	_FORCE_INLINE_ bool has_monitor_callback() const { return monitor_callback_id.is_valid(); }
 
@@ -147,11 +137,6 @@ public:
 
 	_FORCE_INLINE_ void set_priority(int p_priority) { priority = p_priority; }
 	_FORCE_INLINE_ int get_priority() const { return priority; }
-
-	_FORCE_INLINE_ void add_constraint(Constraint3DSW *p_constraint) { constraints.insert(p_constraint); }
-	_FORCE_INLINE_ void remove_constraint(Constraint3DSW *p_constraint) { constraints.erase(p_constraint); }
-	_FORCE_INLINE_ const Set<Constraint3DSW *> &get_constraints() const { return constraints; }
-	_FORCE_INLINE_ void clear_constraints() { constraints.clear(); }
 
 	void set_monitorable(bool p_monitorable);
 	_FORCE_INLINE_ bool is_monitorable() const { return monitorable; }

--- a/servers/physics_3d/area_pair_3d_sw.cpp
+++ b/servers/physics_3d/area_pair_3d_sw.cpp
@@ -89,7 +89,7 @@ AreaPair3DSW::AreaPair3DSW(Body3DSW *p_body, int p_body_shape, Area3DSW *p_area,
 	area = p_area;
 	body_shape = p_body_shape;
 	area_shape = p_area_shape;
-	body->add_constraint(this, 0);
+	body->add_constraint(this);
 	area->add_constraint(this);
 	if (p_body->get_mode() == PhysicsServer3D::BODY_MODE_KINEMATIC) {
 		p_body->set_active(true);

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -644,22 +644,23 @@ void BodySW::simulate_motion(const Transform& p_xform,real_t p_step) {
 */
 
 void Body3DSW::wakeup_neighbours() {
-	for (Map<Constraint3DSW *, int>::Element *E = constraint_map.front(); E; E = E->next()) {
-		const Constraint3DSW *c = E->key();
-		Body3DSW **n = c->get_body_ptr();
-		int bc = c->get_body_count();
+	for (const CollisionObject3DSW::T_ConstraintMap::Element *E = get_constraint_map().front(); E; E = E->next()) {
+		const Constraint3DSW *constraint = E->get();
 
-		for (int i = 0; i < bc; i++) {
-			if (i == E->get()) {
-				continue;
-			}
-			Body3DSW *b = n[i];
-			if (b->mode != PhysicsServer3D::BODY_MODE_RIGID) {
+		Body3DSW **bodies = constraint->get_body_ptr();
+		int body_count = constraint->get_body_count();
+		for (int i = 0; i < body_count; i++) {
+			Body3DSW *body = bodies[i];
+			if (body == this) {
 				continue;
 			}
 
-			if (!b->is_active()) {
-				b->set_active(true);
+			if (body->mode != PhysicsServer3D::BODY_MODE_RIGID) {
+				continue;
+			}
+
+			if (!body->is_active()) {
+				body->set_active(true);
 			}
 		}
 	}

--- a/servers/physics_3d/body_3d_sw.h
+++ b/servers/physics_3d/body_3d_sw.h
@@ -35,8 +35,6 @@
 #include "collision_object_3d_sw.h"
 #include "core/templates/vset.h"
 
-class Constraint3DSW;
-
 class Body3DSW : public CollisionObject3DSW {
 	PhysicsServer3D::BodyMode mode;
 
@@ -94,8 +92,6 @@ class Body3DSW : public CollisionObject3DSW {
 	void _update_inertia();
 	virtual void _shapes_changed();
 	Transform new_transform;
-
-	Map<Constraint3DSW *, int> constraint_map;
 
 	struct AreaCMP {
 		Area3DSW *area;
@@ -185,11 +181,6 @@ public:
 
 	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
 	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }
-
-	_FORCE_INLINE_ void add_constraint(Constraint3DSW *p_constraint, int p_pos) { constraint_map[p_constraint] = p_pos; }
-	_FORCE_INLINE_ void remove_constraint(Constraint3DSW *p_constraint) { constraint_map.erase(p_constraint); }
-	const Map<Constraint3DSW *, int> &get_constraint_map() const { return constraint_map; }
-	_FORCE_INLINE_ void clear_constraint_map() { constraint_map.clear(); }
 
 	_FORCE_INLINE_ void set_omit_force_integration(bool p_omit_force_integration) { omit_force_integration = p_omit_force_integration; }
 	_FORCE_INLINE_ bool get_omit_force_integration() const { return omit_force_integration; }

--- a/servers/physics_3d/body_pair_3d_sw.cpp
+++ b/servers/physics_3d/body_pair_3d_sw.cpp
@@ -517,8 +517,8 @@ BodyPair3DSW::BodyPair3DSW(Body3DSW *p_A, int p_shape_A, Body3DSW *p_B, int p_sh
 	shape_A = p_shape_A;
 	shape_B = p_shape_B;
 	space = A->get_space();
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 BodyPair3DSW::~BodyPair3DSW() {
@@ -849,7 +849,7 @@ BodySoftBodyPair3DSW::BodySoftBodyPair3DSW(Body3DSW *p_A, int p_shape_A, SoftBod
 	soft_body = p_B;
 	body_shape = p_shape_A;
 	space = p_A->get_space();
-	body->add_constraint(this, 0);
+	body->add_constraint(this);
 	soft_body->add_constraint(this);
 }
 

--- a/servers/physics_3d/collision_object_3d_sw.h
+++ b/servers/physics_3d/collision_object_3d_sw.h
@@ -32,6 +32,8 @@
 #define COLLISION_OBJECT_SW_H
 
 #include "broad_phase_3d_sw.h"
+#include "constraint_3d_sw.h"
+#include "core/templates/map.h"
 #include "core/templates/self_list.h"
 #include "servers/physics_server_3d.h"
 #include "shape_3d_sw.h"
@@ -51,6 +53,8 @@ public:
 		TYPE_BODY,
 		TYPE_SOFT_BODY,
 	};
+
+	typedef Map<uint32_t, Constraint3DSW *> T_ConstraintMap;
 
 private:
 	Type type;
@@ -76,6 +80,8 @@ private:
 	Transform transform;
 	Transform inv_transform;
 	bool _static;
+
+	T_ConstraintMap constraint_map;
 
 	SelfList<CollisionObject3DSW> pending_shape_update_list;
 
@@ -161,6 +167,11 @@ public:
 
 	void remove_shape(Shape3DSW *p_shape);
 	void remove_shape(int p_index);
+
+	_FORCE_INLINE_ void add_constraint(Constraint3DSW *p_constraint) { constraint_map.insert(p_constraint->get_constraint_id(), p_constraint); }
+	_FORCE_INLINE_ void remove_constraint(Constraint3DSW *p_constraint) { constraint_map.erase(p_constraint->get_constraint_id()); }
+	const T_ConstraintMap &get_constraint_map() const { return constraint_map; }
+	_FORCE_INLINE_ void clear_constraint_map() { constraint_map.clear(); }
 
 	virtual void set_space(Space3DSW *p_space) = 0;
 

--- a/servers/physics_3d/constraint_3d_sw.cpp
+++ b/servers/physics_3d/constraint_3d_sw.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  constraint_2d_sw.h                                                   */
+/*  constraint_3d_sw.cpp                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,55 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CONSTRAINT_2D_SW_H
-#define CONSTRAINT_2D_SW_H
+#include "constraint_3d_sw.h"
 
-#include "core/math/math_defs.h"
-#include "core/templates/rid.h"
-#include "core/templates/safe_refcount.h"
-
-class Body2DSW;
-
-class Constraint2DSW {
-	Body2DSW **_body_ptr;
-	int _body_count;
-	uint64_t island_step;
-	bool disabled_collisions_between_bodies;
-
-	RID self;
-
-	static SafeNumeric<uint32_t> constraint_id_counter;
-	uint32_t constraint_id = 0;
-
-protected:
-	Constraint2DSW(Body2DSW **p_body_ptr = nullptr, int p_body_count = 0) {
-		_body_ptr = p_body_ptr;
-		_body_count = p_body_count;
-		island_step = 0;
-		disabled_collisions_between_bodies = true;
-		constraint_id = constraint_id_counter.increment();
-	}
-
-public:
-	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }
-	_FORCE_INLINE_ RID get_self() const { return self; }
-
-	_FORCE_INLINE_ uint32_t get_constraint_id() const { return constraint_id; }
-
-	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
-	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }
-
-	_FORCE_INLINE_ Body2DSW **get_body_ptr() const { return _body_ptr; }
-	_FORCE_INLINE_ int get_body_count() const { return _body_count; }
-
-	_FORCE_INLINE_ void disable_collisions_between_bodies(const bool p_disabled) { disabled_collisions_between_bodies = p_disabled; }
-	_FORCE_INLINE_ bool is_disabled_collisions_between_bodies() const { return disabled_collisions_between_bodies; }
-
-	virtual bool setup(real_t p_step) = 0;
-	virtual bool pre_solve(real_t p_step) = 0;
-	virtual void solve(real_t p_step) = 0;
-
-	virtual ~Constraint2DSW() {}
-};
-
-#endif // CONSTRAINT_2D_SW_H
+SafeNumeric<uint32_t> Constraint3DSW::constraint_id_counter;

--- a/servers/physics_3d/constraint_3d_sw.h
+++ b/servers/physics_3d/constraint_3d_sw.h
@@ -31,6 +31,10 @@
 #ifndef CONSTRAINT_SW_H
 #define CONSTRAINT_SW_H
 
+#include "core/math/math_defs.h"
+#include "core/templates/rid.h"
+#include "core/templates/safe_refcount.h"
+
 class Body3DSW;
 class SoftBody3DSW;
 
@@ -43,6 +47,9 @@ class Constraint3DSW {
 
 	RID self;
 
+	static SafeNumeric<uint32_t> constraint_id_counter;
+	uint32_t constraint_id = 0;
+
 protected:
 	Constraint3DSW(Body3DSW **p_body_ptr = nullptr, int p_body_count = 0) {
 		_body_ptr = p_body_ptr;
@@ -50,11 +57,14 @@ protected:
 		island_step = 0;
 		priority = 1;
 		disabled_collisions_between_bodies = true;
+		constraint_id = constraint_id_counter.increment();
 	}
 
 public:
 	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }
 	_FORCE_INLINE_ RID get_self() const { return self; }
+
+	_FORCE_INLINE_ uint32_t get_constraint_id() const { return constraint_id; }
 
 	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
 	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }

--- a/servers/physics_3d/joints/cone_twist_joint_3d_sw.cpp
+++ b/servers/physics_3d/joints/cone_twist_joint_3d_sw.cpp
@@ -102,8 +102,8 @@ ConeTwistJoint3DSW::ConeTwistJoint3DSW(Body3DSW *rbA, Body3DSW *rbB, const Trans
 	m_solveTwistLimit = false;
 	m_solveSwingLimit = false;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 
 	m_appliedImpulse = 0;
 }

--- a/servers/physics_3d/joints/generic_6dof_joint_3d_sw.cpp
+++ b/servers/physics_3d/joints/generic_6dof_joint_3d_sw.cpp
@@ -226,8 +226,8 @@ Generic6DOFJoint3DSW::Generic6DOFJoint3DSW(Body3DSW *rbA, Body3DSW *rbB, const T
 		m_useLinearReferenceFrameA(useLinearReferenceFrameA) {
 	A = rbA;
 	B = rbB;
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 void Generic6DOFJoint3DSW::calculateAngleInfo() {

--- a/servers/physics_3d/joints/hinge_joint_3d_sw.cpp
+++ b/servers/physics_3d/joints/hinge_joint_3d_sw.cpp
@@ -94,8 +94,8 @@ HingeJoint3DSW::HingeJoint3DSW(Body3DSW *rbA, Body3DSW *rbB, const Transform &fr
 	m_angularOnly = false;
 	m_enableAngularMotor = false;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 HingeJoint3DSW::HingeJoint3DSW(Body3DSW *rbA, Body3DSW *rbB, const Vector3 &pivotInA, const Vector3 &pivotInB,
@@ -150,8 +150,8 @@ HingeJoint3DSW::HingeJoint3DSW(Body3DSW *rbA, Body3DSW *rbB, const Vector3 &pivo
 	m_angularOnly = false;
 	m_enableAngularMotor = false;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 bool HingeJoint3DSW::setup(real_t p_step) {

--- a/servers/physics_3d/joints/pin_joint_3d_sw.cpp
+++ b/servers/physics_3d/joints/pin_joint_3d_sw.cpp
@@ -176,8 +176,8 @@ PinJoint3DSW::PinJoint3DSW(Body3DSW *p_body_a, const Vector3 &p_pos_a, Body3DSW 
 	m_impulseClamp = 0;
 	m_appliedImpulse = 0;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 PinJoint3DSW::~PinJoint3DSW() {

--- a/servers/physics_3d/joints/slider_joint_3d_sw.cpp
+++ b/servers/physics_3d/joints/slider_joint_3d_sw.cpp
@@ -118,8 +118,8 @@ SliderJoint3DSW::SliderJoint3DSW(Body3DSW *rbA, Body3DSW *rbB, const Transform &
 	A = rbA;
 	B = rbB;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 
 	initParams();
 } // SliderJointSW::SliderJointSW()

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -234,7 +234,7 @@ void PhysicsServer3DSW::area_set_space(RID p_area, RID p_space) {
 		return; //pointless
 	}
 
-	area->clear_constraints();
+	area->clear_constraint_map();
 	area->set_space(space);
 };
 

--- a/servers/physics_3d/soft_body_3d_sw.h
+++ b/servers/physics_3d/soft_body_3d_sw.h
@@ -37,11 +37,8 @@
 #include "core/math/dynamic_bvh.h"
 #include "core/math/vector3.h"
 #include "core/templates/local_vector.h"
-#include "core/templates/set.h"
 #include "core/templates/vset.h"
 #include "scene/resources/mesh.h"
-
-class Constraint3DSW;
 
 class SoftBody3DSW : public CollisionObject3DSW {
 	Ref<Mesh> soft_mesh;
@@ -102,8 +99,6 @@ class SoftBody3DSW : public CollisionObject3DSW {
 
 	SelfList<SoftBody3DSW> active_list;
 
-	Set<Constraint3DSW *> constraints;
-
 	VSet<RID> exceptions;
 
 	uint64_t island_step = 0;
@@ -115,11 +110,6 @@ public:
 
 	void set_state(PhysicsServer3D::BodyState p_state, const Variant &p_variant);
 	Variant get_state(PhysicsServer3D::BodyState p_state) const;
-
-	_FORCE_INLINE_ void add_constraint(Constraint3DSW *p_constraint) { constraints.insert(p_constraint); }
-	_FORCE_INLINE_ void remove_constraint(Constraint3DSW *p_constraint) { constraints.erase(p_constraint); }
-	_FORCE_INLINE_ const Set<Constraint3DSW *> &get_constraints() const { return constraints; }
-	_FORCE_INLINE_ void clear_constraints() { constraints.clear(); }
 
 	_FORCE_INLINE_ void add_exception(const RID &p_exception) { exceptions.insert(p_exception); }
 	_FORCE_INLINE_ void remove_exception(const RID &p_exception) { exceptions.erase(p_exception); }


### PR DESCRIPTION
This PR iterates on #44112 by @jordo, which made 2D physics more deterministic. This PR changes the container from a `List` back to a `Map` because it was causing a drop in performance, and applies the same change to all types of physics objects (areas, rigid bodies, soft bodies) in both 2D and 3D physics.

Fixes #48303

Detailed list of changes:
- Common constraint map in CollisionObjectSW instead of separate containers for rigid body, soft body, area
- Removed index in rigid body constraints (it was only used to test bodies from a constraint against a specific body)
- Added incremental constraint id as key in constraint map (instead of pointer) to help with determinism
- In 2D, this system replaces the previous `List` implementation which was making the solver slower (by 30% in some cases)

@jordo: Could you please test again with your project on 4.0 to make sure it still works for you?
With your previous PR, I wasn't seeing any change in determinism in either 3.x or 4.0 (I had tested in debug only).
With this one, I can see a difference in the 3.x version (debug and release_debug) but not in 4.0.
There must be something happening with my compiler that might need more investigation later, but I'd like to make sure there's at least no regression.

Test project:
[physics-2d.zip](https://github.com/godotengine/godot/files/5667459/physics-2d.zip)