### PR TITLE
[3.x] Deterministic constraint map in Godot Physics solver

### DIFF
--- a/servers/physics/area_pair_sw.cpp
+++ b/servers/physics/area_pair_sw.cpp
@@ -73,7 +73,7 @@ AreaPairSW::AreaPairSW(BodySW *p_body, int p_body_shape, AreaSW *p_area, int p_a
 	body_shape = p_body_shape;
 	area_shape = p_area_shape;
 	colliding = false;
-	body->add_constraint(this, 0);
+	body->add_constraint(this);
 	area->add_constraint(this);
 	if (p_body->get_mode() == PhysicsServer::BODY_MODE_KINEMATIC) {
 		p_body->set_active(true);

--- a/servers/physics/area_sw.h
+++ b/servers/physics/area_sw.h
@@ -34,11 +34,9 @@
 #include "collision_object_sw.h"
 #include "core/self_list.h"
 #include "servers/physics_server.h"
-//#include "servers/physics/query_sw.h"
 
 class SpaceSW;
 class BodySW;
-class ConstraintSW;
 
 class AreaSW : public CollisionObjectSW {
 	PhysicsServer::AreaSpaceOverrideMode space_override_mode;
@@ -94,18 +92,10 @@ class AreaSW : public CollisionObjectSW {
 	Map<BodyKey, BodyState> monitored_bodies;
 	Map<BodyKey, BodyState> monitored_areas;
 
-	//virtual void shape_changed_notify(ShapeSW *p_shape);
-	//virtual void shape_deleted_notify(ShapeSW *p_shape);
-
-	Set<ConstraintSW *> constraints;
-
 	virtual void _shapes_changed();
 	void _queue_monitor_update();
 
 public:
-	//_FORCE_INLINE_ const Transform& get_inverse_transform() const { return inverse_transform; }
-	//_FORCE_INLINE_ SpaceSW* get_owner() { return owner; }
-
 	void set_monitor_callback(ObjectID p_id, const StringName &p_method);
 	_FORCE_INLINE_ bool has_monitor_callback() const { return monitor_callback_id; }
 
@@ -147,11 +137,6 @@ public:
 
 	_FORCE_INLINE_ void set_priority(int p_priority) { priority = p_priority; }
 	_FORCE_INLINE_ int get_priority() const { return priority; }
-
-	_FORCE_INLINE_ void add_constraint(ConstraintSW *p_constraint) { constraints.insert(p_constraint); }
-	_FORCE_INLINE_ void remove_constraint(ConstraintSW *p_constraint) { constraints.erase(p_constraint); }
-	_FORCE_INLINE_ const Set<ConstraintSW *> &get_constraints() const { return constraints; }
-	_FORCE_INLINE_ void clear_constraints() { constraints.clear(); }
 
 	void set_monitorable(bool p_monitorable);
 	_FORCE_INLINE_ bool is_monitorable() const { return monitorable; }

--- a/servers/physics/body_pair_sw.cpp
+++ b/servers/physics/body_pair_sw.cpp
@@ -462,8 +462,8 @@ BodyPairSW::BodyPairSW(BodySW *p_A, int p_shape_A, BodySW *p_B, int p_shape_B) :
 	shape_A = p_shape_A;
 	shape_B = p_shape_B;
 	space = A->get_space();
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 	contact_count = 0;
 	collided = false;
 }

--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -665,22 +665,24 @@ void BodySW::simulate_motion(const Transform& p_xform,real_t p_step) {
 */
 
 void BodySW::wakeup_neighbours() {
-	for (Map<ConstraintSW *, int>::Element *E = constraint_map.front(); E; E = E->next()) {
-		const ConstraintSW *c = E->key();
-		BodySW **n = c->get_body_ptr();
-		int bc = c->get_body_count();
+	for (const CollisionObjectSW::T_ConstraintMap::Element *E = get_constraint_map().front(); E; E = E->next()) {
+		ConstraintSW *constraint = E->get();
 
-		for (int i = 0; i < bc; i++) {
-			if (i == E->get()) {
-				continue;
-			}
-			BodySW *b = n[i];
-			if (b->mode != PhysicsServer::BODY_MODE_RIGID) {
+		BodySW **bodies = constraint->get_body_ptr();
+		int body_count = constraint->get_body_count();
+		for (int i = 0; i < body_count; i++) {
+			BodySW *body = bodies[i];
+
+			if (body == this) {
 				continue;
 			}
 
-			if (!b->is_active()) {
-				b->set_active(true);
+			if (body->mode != PhysicsServer::BODY_MODE_RIGID) {
+				continue;
+			}
+
+			if (!body->is_active()) {
+				body->set_active(true);
 			}
 		}
 	}

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -35,8 +35,6 @@
 #include "collision_object_sw.h"
 #include "core/vset.h"
 
-class ConstraintSW;
-
 class BodySW : public CollisionObjectSW {
 	PhysicsServer::BodyMode mode;
 
@@ -94,8 +92,6 @@ class BodySW : public CollisionObjectSW {
 	void _update_inertia();
 	virtual void _shapes_changed();
 	Transform new_transform;
-
-	Map<ConstraintSW *, int> constraint_map;
 
 	struct AreaCMP {
 		AreaSW *area;
@@ -194,11 +190,6 @@ public:
 
 	_FORCE_INLINE_ BodySW *get_island_list_next() const { return island_list_next; }
 	_FORCE_INLINE_ void set_island_list_next(BodySW *p_next) { island_list_next = p_next; }
-
-	_FORCE_INLINE_ void add_constraint(ConstraintSW *p_constraint, int p_pos) { constraint_map[p_constraint] = p_pos; }
-	_FORCE_INLINE_ void remove_constraint(ConstraintSW *p_constraint) { constraint_map.erase(p_constraint); }
-	const Map<ConstraintSW *, int> &get_constraint_map() const { return constraint_map; }
-	_FORCE_INLINE_ void clear_constraint_map() { constraint_map.clear(); }
 
 	_FORCE_INLINE_ void set_omit_force_integration(bool p_omit_force_integration) { omit_force_integration = p_omit_force_integration; }
 	_FORCE_INLINE_ bool get_omit_force_integration() const { return omit_force_integration; }

--- a/servers/physics/collision_object_sw.h
+++ b/servers/physics/collision_object_sw.h
@@ -32,6 +32,8 @@
 #define COLLISION_OBJECT_SW_H
 
 #include "broad_phase_sw.h"
+#include "constraint_sw.h"
+#include "core/map.h"
 #include "core/self_list.h"
 #include "servers/physics_server.h"
 #include "shape_sw.h"
@@ -50,6 +52,8 @@ public:
 		TYPE_AREA,
 		TYPE_BODY
 	};
+
+	typedef Map<uint32_t, ConstraintSW *> T_ConstraintMap;
 
 private:
 	Type type;
@@ -75,6 +79,8 @@ private:
 	Transform transform;
 	Transform inv_transform;
 	bool _static;
+
+	T_ConstraintMap constraint_map;
 
 	SelfList<CollisionObjectSW> pending_shape_update_list;
 
@@ -160,6 +166,11 @@ public:
 
 	void remove_shape(ShapeSW *p_shape);
 	void remove_shape(int p_index);
+
+	_FORCE_INLINE_ void add_constraint(ConstraintSW *p_constraint) { constraint_map.insert(p_constraint->get_constraint_id(), p_constraint); }
+	_FORCE_INLINE_ void remove_constraint(ConstraintSW *p_constraint) { constraint_map.erase(p_constraint->get_constraint_id()); }
+	const T_ConstraintMap &get_constraint_map() const { return constraint_map; }
+	_FORCE_INLINE_ void clear_constraint_map() { constraint_map.clear(); }
 
 	virtual void set_space(SpaceSW *p_space) = 0;
 

--- a/servers/physics/constraint_sw.cpp
+++ b/servers/physics/constraint_sw.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  constraint_2d_sw.h                                                   */
+/*  constraint_sw.cpp                                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,62 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CONSTRAINT_2D_SW_H
-#define CONSTRAINT_2D_SW_H
+#include "constraint_sw.h"
 
-#include "core/math/math_defs.h"
-#include "core/rid.h"
-#include "core/safe_refcount.h"
-
-class Body2DSW;
-
-class Constraint2DSW : public RID_Data {
-	Body2DSW **_body_ptr;
-	int _body_count;
-	uint64_t island_step;
-	Constraint2DSW *island_next;
-	Constraint2DSW *island_list_next;
-	bool disabled_collisions_between_bodies;
-
-	RID self;
-
-	static SafeNumeric<uint32_t> constraint_id_counter;
-	uint32_t constraint_id = 0;
-
-protected:
-	Constraint2DSW(Body2DSW **p_body_ptr = nullptr, int p_body_count = 0) {
-		_body_ptr = p_body_ptr;
-		_body_count = p_body_count;
-		island_step = 0;
-		disabled_collisions_between_bodies = true;
-		constraint_id = constraint_id_counter.increment();
-	}
-
-public:
-	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }
-	_FORCE_INLINE_ RID get_self() const { return self; }
-
-	_FORCE_INLINE_ uint32_t get_constraint_id() const { return constraint_id; }
-
-	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
-	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }
-
-	_FORCE_INLINE_ Constraint2DSW *get_island_next() const { return island_next; }
-	_FORCE_INLINE_ void set_island_next(Constraint2DSW *p_next) { island_next = p_next; }
-
-	_FORCE_INLINE_ Constraint2DSW *get_island_list_next() const { return island_list_next; }
-	_FORCE_INLINE_ void set_island_list_next(Constraint2DSW *p_next) { island_list_next = p_next; }
-
-	_FORCE_INLINE_ Body2DSW **get_body_ptr() const { return _body_ptr; }
-	_FORCE_INLINE_ int get_body_count() const { return _body_count; }
-
-	_FORCE_INLINE_ void disable_collisions_between_bodies(const bool p_disabled) { disabled_collisions_between_bodies = p_disabled; }
-	_FORCE_INLINE_ bool is_disabled_collisions_between_bodies() const { return disabled_collisions_between_bodies; }
-
-	virtual bool setup(real_t p_step) = 0;
-	virtual void solve(real_t p_step) = 0;
-
-	virtual ~Constraint2DSW() {}
-};
-
-#endif // CONSTRAINT_2D_SW_H
+SafeNumeric<uint32_t> ConstraintSW::constraint_id_counter;

--- a/servers/physics/constraint_sw.h
+++ b/servers/physics/constraint_sw.h
@@ -31,7 +31,11 @@
 #ifndef CONSTRAINT_SW_H
 #define CONSTRAINT_SW_H
 
-#include "body_sw.h"
+#include "core/math/math_defs.h"
+#include "core/rid.h"
+#include "core/safe_refcount.h"
+
+class BodySW;
 
 class ConstraintSW : public RID_Data {
 	BodySW **_body_ptr;
@@ -44,6 +48,9 @@ class ConstraintSW : public RID_Data {
 
 	RID self;
 
+	static SafeNumeric<uint32_t> constraint_id_counter;
+	uint32_t constraint_id = 0;
+
 protected:
 	ConstraintSW(BodySW **p_body_ptr = nullptr, int p_body_count = 0) {
 		_body_ptr = p_body_ptr;
@@ -51,11 +58,14 @@ protected:
 		island_step = 0;
 		priority = 1;
 		disabled_collisions_between_bodies = true;
+		constraint_id = constraint_id_counter.increment();
 	}
 
 public:
 	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }
 	_FORCE_INLINE_ RID get_self() const { return self; }
+
+	_FORCE_INLINE_ uint32_t get_constraint_id() const { return constraint_id; }
 
 	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
 	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }

--- a/servers/physics/joints/cone_twist_joint_sw.cpp
+++ b/servers/physics/joints/cone_twist_joint_sw.cpp
@@ -102,8 +102,8 @@ ConeTwistJointSW::ConeTwistJointSW(BodySW *rbA, BodySW *rbB, const Transform &rb
 	m_solveTwistLimit = false;
 	m_solveSwingLimit = false;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 
 	m_appliedImpulse = 0;
 }

--- a/servers/physics/joints/generic_6dof_joint_sw.cpp
+++ b/servers/physics/joints/generic_6dof_joint_sw.cpp
@@ -217,8 +217,8 @@ Generic6DOFJointSW::Generic6DOFJointSW(BodySW *rbA, BodySW *rbB, const Transform
 		m_useLinearReferenceFrameA(useLinearReferenceFrameA) {
 	A = rbA;
 	B = rbB;
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 void Generic6DOFJointSW::calculateAngleInfo() {

--- a/servers/physics/joints/hinge_joint_sw.cpp
+++ b/servers/physics/joints/hinge_joint_sw.cpp
@@ -94,8 +94,8 @@ HingeJointSW::HingeJointSW(BodySW *rbA, BodySW *rbB, const Transform &frameA, co
 	m_angularOnly = false;
 	m_enableAngularMotor = false;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 HingeJointSW::HingeJointSW(BodySW *rbA, BodySW *rbB, const Vector3 &pivotInA, const Vector3 &pivotInB,
@@ -150,8 +150,8 @@ HingeJointSW::HingeJointSW(BodySW *rbA, BodySW *rbB, const Vector3 &pivotInA, co
 	m_angularOnly = false;
 	m_enableAngularMotor = false;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 bool HingeJointSW::setup(real_t p_step) {

--- a/servers/physics/joints/pin_joint_sw.cpp
+++ b/servers/physics/joints/pin_joint_sw.cpp
@@ -169,8 +169,8 @@ PinJointSW::PinJointSW(BodySW *p_body_a, const Vector3 &p_pos_a, BodySW *p_body_
 	m_impulseClamp = 0;
 	m_appliedImpulse = 0;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 PinJointSW::~PinJointSW() {

--- a/servers/physics/joints/slider_joint_sw.cpp
+++ b/servers/physics/joints/slider_joint_sw.cpp
@@ -119,8 +119,8 @@ SliderJointSW::SliderJointSW(BodySW *rbA, BodySW *rbB, const Transform &frameInA
 	A = rbA;
 	B = rbB;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 
 	initParams();
 } // SliderJointSW::SliderJointSW()

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -220,7 +220,7 @@ void PhysicsServerSW::area_set_space(RID p_area, RID p_space) {
 		return; //pointless
 	}
 
-	area->clear_constraints();
+	area->clear_constraint_map();
 	area->set_space(space);
 };
 

--- a/servers/physics/step_sw.cpp
+++ b/servers/physics/step_sw.cpp
@@ -38,24 +38,30 @@ void StepSW::_populate_island(BodySW *p_body, BodySW **p_island, ConstraintSW **
 	p_body->set_island_next(*p_island);
 	*p_island = p_body;
 
-	for (Map<ConstraintSW *, int>::Element *E = p_body->get_constraint_map().front(); E; E = E->next()) {
-		ConstraintSW *c = (ConstraintSW *)E->key();
-		if (c->get_island_step() == _step) {
-			continue; //already processed
+	for (const CollisionObjectSW::T_ConstraintMap::Element *E = p_body->get_constraint_map().front(); E; E = E->next()) {
+		ConstraintSW *constraint = E->get();
+		if (constraint->get_island_step() == _step) {
+			continue; // Already processed.
 		}
-		c->set_island_step(_step);
-		c->set_island_next(*p_constraint_island);
-		*p_constraint_island = c;
 
-		for (int i = 0; i < c->get_body_count(); i++) {
-			if (i == E->get()) {
-				continue;
+		constraint->set_island_step(_step);
+		constraint->set_island_next(*p_constraint_island);
+		*p_constraint_island = constraint;
+
+		BodySW **bodies = constraint->get_body_ptr();
+		int body_count = constraint->get_body_count();
+		for (int i = 0; i < body_count; i++) {
+			BodySW *other_body = bodies[i];
+
+			if (other_body->get_island_step() == _step) {
+				continue; // Already processed (can be this body).
 			}
-			BodySW *b = c->get_body_ptr()[i];
-			if (b->get_island_step() == _step || b->get_mode() == PhysicsServer::BODY_MODE_STATIC || b->get_mode() == PhysicsServer::BODY_MODE_KINEMATIC) {
-				continue; //no go
+
+			if (other_body->get_mode() <= PhysicsServer::BODY_MODE_KINEMATIC) {
+				continue; // Only dynamic bodies connect islands.
 			}
-			_populate_island(c->get_body_ptr()[i], p_island, p_constraint_island);
+
+			_populate_island(other_body, p_island, p_constraint_island);
 		}
 	}
 }
@@ -201,15 +207,15 @@ void StepSW::step(SpaceSW *p_space, real_t p_delta, int p_iterations) {
 	const SelfList<AreaSW>::List &aml = p_space->get_moved_area_list();
 
 	while (aml.first()) {
-		for (const Set<ConstraintSW *>::Element *E = aml.first()->self()->get_constraints().front(); E; E = E->next()) {
-			ConstraintSW *c = E->get();
-			if (c->get_island_step() == _step) {
+		for (const CollisionObjectSW::T_ConstraintMap::Element *E = aml.first()->self()->get_constraint_map().front(); E; E = E->next()) {
+			ConstraintSW *constraint = E->get();
+			if (constraint->get_island_step() == _step) {
 				continue;
 			}
-			c->set_island_step(_step);
-			c->set_island_next(nullptr);
-			c->set_island_list_next(constraint_island_list);
-			constraint_island_list = c;
+			constraint->set_island_step(_step);
+			constraint->set_island_next(nullptr);
+			constraint->set_island_list_next(constraint_island_list);
+			constraint_island_list = constraint;
 		}
 		p_space->area_remove_from_moved_list((SelfList<AreaSW> *)aml.first()); //faster to remove here
 	}

--- a/servers/physics_2d/area_2d_sw.h
+++ b/servers/physics_2d/area_2d_sw.h
@@ -34,11 +34,9 @@
 #include "collision_object_2d_sw.h"
 #include "core/self_list.h"
 #include "servers/physics_2d_server.h"
-//#include "servers/physics/query_sw.h"
 
 class Space2DSW;
 class Body2DSW;
-class Constraint2DSW;
 
 class Area2DSW : public CollisionObject2DSW {
 	Physics2DServer::AreaSpaceOverrideMode space_override_mode;
@@ -94,17 +92,10 @@ class Area2DSW : public CollisionObject2DSW {
 	Map<BodyKey, BodyState> monitored_bodies;
 	Map<BodyKey, BodyState> monitored_areas;
 
-	//virtual void shape_changed_notify(Shape2DSW *p_shape);
-	//virtual void shape_deleted_notify(Shape2DSW *p_shape);
-	Set<Constraint2DSW *> constraints;
-
 	virtual void _shapes_changed();
 	void _queue_monitor_update();
 
 public:
-	//_FORCE_INLINE_ const Matrix32& get_inverse_transform() const { return inverse_transform; }
-	//_FORCE_INLINE_ SpaceSW* get_owner() { return owner; }
-
 	void set_monitor_callback(ObjectID p_id, const StringName &p_method);
 	_FORCE_INLINE_ bool has_monitor_callback() const { return monitor_callback_id; }
 
@@ -146,11 +137,6 @@ public:
 
 	_FORCE_INLINE_ void set_priority(int p_priority) { priority = p_priority; }
 	_FORCE_INLINE_ int get_priority() const { return priority; }
-
-	_FORCE_INLINE_ void add_constraint(Constraint2DSW *p_constraint) { constraints.insert(p_constraint); }
-	_FORCE_INLINE_ void remove_constraint(Constraint2DSW *p_constraint) { constraints.erase(p_constraint); }
-	_FORCE_INLINE_ const Set<Constraint2DSW *> &get_constraints() const { return constraints; }
-	_FORCE_INLINE_ void clear_constraints() { constraints.clear(); }
 
 	void set_monitorable(bool p_monitorable);
 	_FORCE_INLINE_ bool is_monitorable() const { return monitorable; }

--- a/servers/physics_2d/area_pair_2d_sw.cpp
+++ b/servers/physics_2d/area_pair_2d_sw.cpp
@@ -73,7 +73,7 @@ AreaPair2DSW::AreaPair2DSW(Body2DSW *p_body, int p_body_shape, Area2DSW *p_area,
 	body_shape = p_body_shape;
 	area_shape = p_area_shape;
 	colliding = false;
-	body->add_constraint(this, 0);
+	body->add_constraint(this);
 	area->add_constraint(this);
 	if (p_body->get_mode() == Physics2DServer::BODY_MODE_KINEMATIC) { //need to be active to process pair
 		p_body->set_active(true);

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -560,22 +560,24 @@ void Body2DSW::integrate_velocities(real_t p_step) {
 }
 
 void Body2DSW::wakeup_neighbours() {
-	for (Map<Constraint2DSW *, int>::Element *E = constraint_map.front(); E; E = E->next()) {
-		const Constraint2DSW *c = E->key();
-		Body2DSW **n = c->get_body_ptr();
-		int bc = c->get_body_count();
+	for (const CollisionObject2DSW::T_ConstraintMap::Element *E = get_constraint_map().front(); E; E = E->next()) {
+		const Constraint2DSW *constraint = E->get();
 
-		for (int i = 0; i < bc; i++) {
-			if (i == E->get()) {
-				continue;
-			}
-			Body2DSW *b = n[i];
-			if (b->mode != Physics2DServer::BODY_MODE_RIGID) {
+		Body2DSW **bodies = constraint->get_body_ptr();
+		int body_count = constraint->get_body_count();
+		for (int i = 0; i < body_count; i++) {
+			Body2DSW *body = bodies[i];
+
+			if (body == this) {
 				continue;
 			}
 
-			if (!b->is_active()) {
-				b->set_active(true);
+			if (body->mode != Physics2DServer::BODY_MODE_RIGID) {
+				continue;
+			}
+
+			if (!body->is_active()) {
+				body->set_active(true);
 			}
 		}
 	}

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -35,8 +35,6 @@
 #include "collision_object_2d_sw.h"
 #include "core/vset.h"
 
-class Constraint2DSW;
-
 class Body2DSW : public CollisionObject2DSW {
 	Physics2DServer::BodyMode mode;
 
@@ -82,8 +80,6 @@ class Body2DSW : public CollisionObject2DSW {
 	void _update_inertia();
 	virtual void _shapes_changed();
 	Transform2D new_transform;
-
-	Map<Constraint2DSW *, int> constraint_map;
 
 	struct AreaCMP {
 		Area2DSW *area;
@@ -178,11 +174,6 @@ public:
 
 	_FORCE_INLINE_ Body2DSW *get_island_list_next() const { return island_list_next; }
 	_FORCE_INLINE_ void set_island_list_next(Body2DSW *p_next) { island_list_next = p_next; }
-
-	_FORCE_INLINE_ void add_constraint(Constraint2DSW *p_constraint, int p_pos) { constraint_map[p_constraint] = p_pos; }
-	_FORCE_INLINE_ void remove_constraint(Constraint2DSW *p_constraint) { constraint_map.erase(p_constraint); }
-	const Map<Constraint2DSW *, int> &get_constraint_map() const { return constraint_map; }
-	_FORCE_INLINE_ void clear_constraint_map() { constraint_map.clear(); }
 
 	_FORCE_INLINE_ void set_omit_force_integration(bool p_omit_force_integration) { omit_force_integration = p_omit_force_integration; }
 	_FORCE_INLINE_ bool get_omit_force_integration() const { return omit_force_integration; }

--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -500,8 +500,8 @@ BodyPair2DSW::BodyPair2DSW(Body2DSW *p_A, int p_shape_A, Body2DSW *p_B, int p_sh
 	shape_A = p_shape_A;
 	shape_B = p_shape_B;
 	space = A->get_space();
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 	contact_count = 0;
 	collided = false;
 	oneway_disabled = false;

--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -32,6 +32,8 @@
 #define COLLISION_OBJECT_2D_SW_H
 
 #include "broad_phase_2d_sw.h"
+#include "constraint_2d_sw.h"
+#include "core/map.h"
 #include "core/self_list.h"
 #include "servers/physics_2d_server.h"
 #include "shape_2d_sw.h"
@@ -44,6 +46,8 @@ public:
 		TYPE_AREA,
 		TYPE_BODY
 	};
+
+	typedef Map<uint32_t, Constraint2DSW *> T_ConstraintMap;
 
 private:
 	Type type;
@@ -76,6 +80,8 @@ private:
 	uint32_t collision_mask;
 	uint32_t collision_layer;
 	bool _static;
+
+	T_ConstraintMap constraint_map;
 
 	SelfList<CollisionObject2DSW> pending_shape_update_list;
 
@@ -182,6 +188,11 @@ public:
 
 	void remove_shape(Shape2DSW *p_shape);
 	void remove_shape(int p_index);
+
+	_FORCE_INLINE_ void add_constraint(Constraint2DSW *p_constraint) { constraint_map.insert(p_constraint->get_constraint_id(), p_constraint); }
+	_FORCE_INLINE_ void remove_constraint(Constraint2DSW *p_constraint) { constraint_map.erase(p_constraint->get_constraint_id()); }
+	const T_ConstraintMap &get_constraint_map() const { return constraint_map; }
+	_FORCE_INLINE_ void clear_constraint_map() { constraint_map.clear(); }
 
 	virtual void set_space(Space2DSW *p_space) = 0;
 

--- a/servers/physics_2d/constraint_2d_sw.cpp
+++ b/servers/physics_2d/constraint_2d_sw.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  constraint_2d_sw.h                                                   */
+/*  constraint_2d_sw.cpp                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,62 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CONSTRAINT_2D_SW_H
-#define CONSTRAINT_2D_SW_H
+#include "constraint_2d_sw.h"
 
-#include "core/math/math_defs.h"
-#include "core/rid.h"
-#include "core/safe_refcount.h"
-
-class Body2DSW;
-
-class Constraint2DSW : public RID_Data {
-	Body2DSW **_body_ptr;
-	int _body_count;
-	uint64_t island_step;
-	Constraint2DSW *island_next;
-	Constraint2DSW *island_list_next;
-	bool disabled_collisions_between_bodies;
-
-	RID self;
-
-	static SafeNumeric<uint32_t> constraint_id_counter;
-	uint32_t constraint_id = 0;
-
-protected:
-	Constraint2DSW(Body2DSW **p_body_ptr = nullptr, int p_body_count = 0) {
-		_body_ptr = p_body_ptr;
-		_body_count = p_body_count;
-		island_step = 0;
-		disabled_collisions_between_bodies = true;
-		constraint_id = constraint_id_counter.increment();
-	}
-
-public:
-	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }
-	_FORCE_INLINE_ RID get_self() const { return self; }
-
-	_FORCE_INLINE_ uint32_t get_constraint_id() const { return constraint_id; }
-
-	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
-	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }
-
-	_FORCE_INLINE_ Constraint2DSW *get_island_next() const { return island_next; }
-	_FORCE_INLINE_ void set_island_next(Constraint2DSW *p_next) { island_next = p_next; }
-
-	_FORCE_INLINE_ Constraint2DSW *get_island_list_next() const { return island_list_next; }
-	_FORCE_INLINE_ void set_island_list_next(Constraint2DSW *p_next) { island_list_next = p_next; }
-
-	_FORCE_INLINE_ Body2DSW **get_body_ptr() const { return _body_ptr; }
-	_FORCE_INLINE_ int get_body_count() const { return _body_count; }
-
-	_FORCE_INLINE_ void disable_collisions_between_bodies(const bool p_disabled) { disabled_collisions_between_bodies = p_disabled; }
-	_FORCE_INLINE_ bool is_disabled_collisions_between_bodies() const { return disabled_collisions_between_bodies; }
-
-	virtual bool setup(real_t p_step) = 0;
-	virtual void solve(real_t p_step) = 0;
-
-	virtual ~Constraint2DSW() {}
-};
-
-#endif // CONSTRAINT_2D_SW_H
+SafeNumeric<uint32_t> Constraint2DSW::constraint_id_counter;

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -196,9 +196,9 @@ PinJoint2DSW::PinJoint2DSW(const Vector2 &p_pos, Body2DSW *p_body_a, Body2DSW *p
 
 	softness = 0;
 
-	p_body_a->add_constraint(this, 0);
+	p_body_a->add_constraint(this);
 	if (p_body_b) {
-		p_body_b->add_constraint(this, 1);
+		p_body_b->add_constraint(this);
 	}
 }
 
@@ -343,8 +343,8 @@ GrooveJoint2DSW::GrooveJoint2DSW(const Vector2 &p_a_groove1, const Vector2 &p_a_
 	B_anchor = B->get_inv_transform().xform(p_b_anchor);
 	A_groove_normal = -(A_groove_2 - A_groove_1).normalized().tangent();
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 GrooveJoint2DSW::~GrooveJoint2DSW() {
@@ -444,8 +444,8 @@ DampedSpringJoint2DSW::DampedSpringJoint2DSW(const Vector2 &p_anchor_a, const Ve
 	stiffness = 20;
 	damping = 1.5;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	A->add_constraint(this);
+	B->add_constraint(this);
 }
 
 DampedSpringJoint2DSW::~DampedSpringJoint2DSW() {

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -299,7 +299,7 @@ void Physics2DServerSW::area_set_space(RID p_area, RID p_space) {
 		return; //pointless
 	}
 
-	area->clear_constraints();
+	area->clear_constraint_map();
 	area->set_space(space);
 };
 


### PR DESCRIPTION
3.x backport of #48497

Makes the physics solver more deterministic for all types of physics objects (areas, rigid bodies, soft bodies) in both 2D and 3D physics.

This PR iterates on #44112 by @jordo, which made 2D physics more deterministic, but it doesn't require #44112 to be ported to the 3.x branch.