### PR TITLE
Adds a pressed signal to ButtonGroup

### DIFF
--- a/doc/classes/ButtonGroup.xml
+++ b/doc/classes/ButtonGroup.xml
@@ -28,6 +28,15 @@
 	<members>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" override="true" default="true" />
 	</members>
+	<signals>
+		<signal name="pressed">
+			<argument index="0" name="button" type="Object">
+			</argument>
+			<description>
+				Emitted when one of the buttons of the group is pressed.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -155,6 +155,9 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 				}
 				status.pressed = !status.pressed;
 				_unpress_group();
+				if (button_group.is_valid()) {
+					button_group->emit_signal("pressed", this);
+				}
 				_toggled(status.pressed);
 				_pressed();
 			}
@@ -218,6 +221,9 @@ void BaseButton::set_pressed(bool p_pressed) {
 
 	if (p_pressed) {
 		_unpress_group();
+		if (button_group.is_valid()) {
+			button_group->emit_signal("pressed", this);
+		}
 	}
 	_toggled(status.pressed);
 
@@ -487,6 +493,7 @@ BaseButton *ButtonGroup::get_pressed_button() {
 void ButtonGroup::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pressed_button"), &ButtonGroup::get_pressed_button);
 	ClassDB::bind_method(D_METHOD("get_buttons"), &ButtonGroup::_get_buttons);
+	ADD_SIGNAL(MethodInfo("pressed", PropertyInfo(Variant::OBJECT, "button")));
 }
 
 ButtonGroup::ButtonGroup() {


### PR DESCRIPTION
A simple QoL improvement we discussed with reduz some time ago. This adds a "pressed" signal to the ButtonGroup resource. 

Often a ButtonGroup is used for mutually exclusive tools (in a toolbar), so you usually need a single callback where you check with `ButtonGroup.get_pressed_button()` which button is pressed.

However, until now, the callback needed to be registered to every single button in the group, while it's more convenient to register the callback once to the ButtonGroup instead. This is what this PR implements.

It could likely be backported.

Edit: closes https://github.com/godotengine/godot/issues/22839