### PR TITLE
Add set_pressed_no_signal method to BaseButton

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -39,6 +39,16 @@
 				Returns [code]true[/code] if the mouse has entered the button and has not left it yet.
 			</description>
 		</method>
+		<method name="set_pressed_no_signal">
+			<return type="void">
+			</return>
+			<argument index="0" name="pressed" type="bool">
+			</argument>
+			<description>
+				Changes the [member pressed] state of the button, without emitting [signal toggled]. Use when you just want to change the state of the button without sending the pressed event (e.g. when initializing scene). Only works if [member toggle_mode] is [code]true[/code].
+				[b]Note:[/b] This method doesn't unpress other buttons in [member button_group].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode" default="1">
@@ -60,7 +70,8 @@
 			[b]Note:[/b] This property only affects the button's visual appearance. Signals will be emitted at the same moment regardless of this property's value.
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
-			If [code]true[/code], the button's state is pressed. Means the button is pressed down or toggled (if [member toggle_mode] is active).
+			If [code]true[/code], the button's state is pressed. Means the button is pressed down or toggled (if [member toggle_mode] is active). Only works if [member toggle_mode] is [code]true[/code].
+			[b]Note:[/b] Setting [member pressed] will result in [signal toggled] to be emitted. If you want to change the pressed state without emitting that signal, use [method set_pressed_no_signal].
 		</member>
 		<member name="shortcut" type="Shortcut" setter="set_shortcut" getter="get_shortcut">
 			[Shortcut] associated to the button.

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -226,6 +226,18 @@ void BaseButton::set_pressed(bool p_pressed) {
 	update();
 }
 
+void BaseButton::set_pressed_no_signal(bool p_pressed) {
+	if (!toggle_mode) {
+		return;
+	}
+	if (status.pressed == p_pressed) {
+		return;
+	}
+	status.pressed = p_pressed;
+
+	update();
+}
+
 bool BaseButton::is_pressing() const {
 	return status.press_attempt;
 }
@@ -399,6 +411,7 @@ void BaseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &BaseButton::_unhandled_key_input);
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &BaseButton::set_pressed);
 	ClassDB::bind_method(D_METHOD("is_pressed"), &BaseButton::is_pressed);
+	ClassDB::bind_method(D_METHOD("set_pressed_no_signal", "pressed"), &BaseButton::set_pressed_no_signal);
 	ClassDB::bind_method(D_METHOD("is_hovered"), &BaseButton::is_hovered);
 	ClassDB::bind_method(D_METHOD("set_toggle_mode", "enabled"), &BaseButton::set_toggle_mode);
 	ClassDB::bind_method(D_METHOD("is_toggle_mode"), &BaseButton::is_toggle_mode);

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -98,7 +98,8 @@ public:
 	bool is_pressing() const; ///< return whether button is pressed (toggled in)
 	bool is_hovered() const;
 
-	void set_pressed(bool p_pressed); ///only works in toggle mode
+	void set_pressed(bool p_pressed); // Only works in toggle mode.
+	void set_pressed_no_signal(bool p_pressed);
 	void set_toggle_mode(bool p_on);
 	bool is_toggle_mode() const;
 


### PR DESCRIPTION
Fixes #33422
Fixes #35172
Fixes #33854

I updated the documentation for `pressed`, but changing visual state of the button is still useful. Check #48466 for example - `is_loading_state` was added only because of the unwanted signal emission. We possibly have more similar workarounds in the codebase, which now could be removed by using the new method.