### PR TITLE
Improve the layout and texts of the Editor Feature Profiles dialog

### DIFF
--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -34,6 +34,7 @@
 #include "core/object/reference.h"
 #include "core/os/file_access.h"
 #include "editor/editor_file_dialog.h"
+#include "editor_help.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/separator.h"
@@ -64,6 +65,7 @@ private:
 
 	bool features_disabled[FEATURE_MAX];
 	static const char *feature_names[FEATURE_MAX];
+	static const char *feature_descriptions[FEATURE_MAX];
 	static const char *feature_identifiers[FEATURE_MAX];
 
 	String _get_feature_name(Feature p_feature) { return get_feature_name(p_feature); }
@@ -92,6 +94,7 @@ public:
 	Error load_from_file(const String &p_path);
 
 	static String get_feature_name(Feature p_feature);
+	static String get_feature_description(Feature p_feature);
 
 	EditorFeatureProfile();
 };
@@ -129,6 +132,7 @@ class EditorFeatureProfileManager : public AcceptDialog {
 	Tree *class_list;
 	VBoxContainer *property_list_vbc;
 	Tree *property_list;
+	EditorHelpBit *description_bit;
 	Label *no_profile_selected_help;
 
 	EditorFileDialog *import_profiles;


### PR DESCRIPTION
After interacting with this dialog a bit I've noticed that some texts don't really make sense (e.g. sections called "Enabled X", when it was a list of all X where only items with selected checkboxes were enabled) or don't convey the intention well for a user. The layout is also pretty rough, with buttons that don't really have any order and therefore are harder to work with.

I've rearranged some elements to better group them together, and changed some titles and labels to be clearer and nicer.

![godot windows tools 64_2021-05-06_22-13-32](https://user-images.githubusercontent.com/11782833/117354980-aa585d80-aeba-11eb-9ec9-41d9860f27f8.png)
[Current layout, for comparison](https://user-images.githubusercontent.com/11782833/117354924-9876ba80-aeba-11eb-9d7d-d737f77cf0f2.png)

As evident from the screenshot above I've also considered that it would be beneficial to have some sort of description here to let users know what exactly they enable and disable. I've provided descriptions for the main features, and for the nodes and resources I've used documentation data.

![godot windows tools 64_2021-05-06_22-13-46](https://user-images.githubusercontent.com/11782833/117355159-dd025600-aeba-11eb-9683-06706621aaf6.png)

More screenshots:
* Some nodes don't have properties, and before there was an empty branch for them. This is now fixed, [no empty branch](https://user-images.githubusercontent.com/11782833/117355260-04f1b980-aebb-11eb-8662-33e57dc057b3.png).
* [Most descriptions fit nicely](https://user-images.githubusercontent.com/11782833/117355341-1fc42e00-aebb-11eb-9d21-ca821dd84fc4.png), and for some edge cases [we have a nice scroll](https://user-images.githubusercontent.com/11782833/117355390-3074a400-aebb-11eb-9572-14a1a603401a.png). All docs are properly parsed and interactive, by the way.
* [Create](https://user-images.githubusercontent.com/11782833/117355472-497d5500-aebb-11eb-8ab8-f6ef2826333a.png) and [Remove](https://user-images.githubusercontent.com/11782833/117355478-4b471880-aebb-11eb-99ff-e5b46cc4e492.png) profile dialogs were also slightly improved.

-----
If this is controversial I am prepared to open a proposal, but I think this is a pretty straightforward uplift + a little usability feature.