### PR TITLE
Fixed cut/copy/paste visibility

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2587,14 +2587,16 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		}
 	}
 
-	if (profile_allow_script_editing) {
+	if (profile_allow_editing) {
 		menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/cut_node"), TOOL_CUT);
 		menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/copy_node"), TOOL_COPY);
 		if (selection.size() == 1 && !node_clipboard.is_empty()) {
 			menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/paste_node"), TOOL_PASTE);
 		}
 		menu->add_separator();
+	}
 
+	if (profile_allow_script_editing) {
 		bool add_separator = false;
 
 		if (full_selection.size() == 1) {


### PR DESCRIPTION
Fixes #48514 by moving the visibility of these buttons into their own if statement that depends on if scene tree editing is allowed. Previously it was under the script editing setting which is unexpected as it works with nodes and the scene tree.

Scene Tree Editing Disabled:
![Screenshot from 2021-05-06 16-04-14](https://user-images.githubusercontent.com/57882701/117359002-d5c05580-ae84-11eb-9fb3-bf0b96cb4610.png)

Scene Tree Editing Enabled:
![Screenshot from 2021-05-06 16-04-53](https://user-images.githubusercontent.com/57882701/117359017-d9ec7300-ae84-11eb-8c90-1552af820d4f.png)


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
