### PR TITLE
Remove extra separator in scenetree dock menu

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2624,7 +2624,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			}
 		}
 
-		if (add_separator) {
+		if (add_separator && profile_allow_editing) {
 			menu->add_separator();
 		}
 	}


### PR DESCRIPTION
Removes an extra separator when Scene Tree Editing is disabled. Discussed in #48518

Before:
![Screenshot from 2021-05-06 16-04-14](https://user-images.githubusercontent.com/57882701/117368752-f2af5580-ae91-11eb-942a-3a97f294f7b3.png)

After:
![Screenshot from 2021-05-06 17-38-05](https://user-images.githubusercontent.com/57882701/117368765-f80ca000-ae91-11eb-8bf0-edacf4e568ad.png)

After with Scene Tree Editing enabled:
![Screenshot from 2021-05-06 17-38-33](https://user-images.githubusercontent.com/57882701/117368799-00fd7180-ae92-11eb-8222-7eb577d1beb0.png)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
