### PR TITLE
Fixed typecasting in Dictionary's key

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -74,10 +74,16 @@ Variant Dictionary::get_value_at_index(int p_index) const {
 }
 
 Variant &Dictionary::operator[](const Variant &p_key) {
+	if (p_key.get_type() == Variant::STRING_NAME) {
+		return _p->variant_map[p_key.operator String()];
+	}
 	return _p->variant_map[p_key];
 }
 
 const Variant &Dictionary::operator[](const Variant &p_key) const {
+	if (p_key.get_type() == Variant::STRING_NAME) {
+		return _p->variant_map[p_key.operator String()];
+	}
 	return _p->variant_map[p_key];
 }
 


### PR DESCRIPTION
This PR is an extension of #48515.

First, `Dictionary`'s key is `Variant` type; in 3.2, `StringName` type was cast to `String` type in `Variant.cpp`, but not so in 4.0.

Then, that problem is [causing a bug in editor](https://github.com/godotengine/godot/pull/48515), so to fix it, this PR will try to cast `StringName` type that is a `Dictionary`'s key to `String` type. If there is a case where it would be better not to use `String` type, it is debatable.