### PR TITLE
Allow negative contrast values in the editor theme settings

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -444,8 +444,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/theme/base_color"] = PropertyInfo(Variant::COLOR, "interface/theme/base_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/theme/accent_color", Color(0.41, 0.61, 0.91));
 	hints["interface/theme/accent_color"] = PropertyInfo(Variant::COLOR, "interface/theme/accent_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
-	_initial_set("interface/theme/contrast", 0.25);
-	hints["interface/theme/contrast"] = PropertyInfo(Variant::FLOAT, "interface/theme/contrast", PROPERTY_HINT_RANGE, "0.01, 1, 0.01");
+	_initial_set("interface/theme/contrast", 0.3);
+	hints["interface/theme/contrast"] = PropertyInfo(Variant::FLOAT, "interface/theme/contrast", PROPERTY_HINT_RANGE, "-1, 1, 0.01");
 	_initial_set("interface/theme/icon_saturation", 1.0);
 	hints["interface/theme/icon_saturation"] = PropertyInfo(Variant::FLOAT, "interface/theme/icon_saturation", PROPERTY_HINT_RANGE, "0,2,0.01", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/theme/relationship_line_opacity", 0.1);


### PR DESCRIPTION
`master` version of #48540.

When using a negative contrast value, the base color will be lightened to create the derivative colors instead of being darkened.

This can lead to better-looking themes, especially for light themes.

I also fixed the default theme contrast value not matching the new default.

See https://github.com/godotengine/godot/issues/48477#issuecomment-834343944.

## Preview

### Light theme

![Light theme](https://user-images.githubusercontent.com/180032/117457868-f4d4eb00-af49-11eb-928a-f57533b1024a.png)

### Custom theme based on Light theme with base color set to `#ddd` and contrast to `-0.08`

![Custom theme](https://user-images.githubusercontent.com/180032/117457832-ed154680-af49-11eb-9672-8e261fd3b813.png)