### PR TITLE
[3.x] Android: Remove non-functional native video OS methods

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -475,23 +475,20 @@ int OS::get_processor_count() const {
 
 Error OS::native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track) {
 	return FAILED;
-};
+}
 
 bool OS::native_video_is_playing() const {
 	return false;
-};
+}
 
-void OS::native_video_pause(){
+void OS::native_video_pause() {
+}
 
-};
+void OS::native_video_unpause() {
+}
 
-void OS::native_video_unpause(){
-
-};
-
-void OS::native_video_stop(){
-
-};
+void OS::native_video_stop() {
+}
 
 void OS::set_mouse_mode(MouseMode p_mode) {
 }

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -807,7 +807,7 @@
 			</return>
 			<description>
 				Returns [code]true[/code] if native video is playing.
-				[b]Note:[/b] This method is implemented on Android and iOS.
+				[b]Note:[/b] This method is only implemented on iOS.
 			</description>
 		</method>
 		<method name="native_video_pause">
@@ -815,7 +815,7 @@
 			</return>
 			<description>
 				Pauses native video playback.
-				[b]Note:[/b] This method is implemented on Android and iOS.
+				[b]Note:[/b] This method is only implemented on iOS.
 			</description>
 		</method>
 		<method name="native_video_play">
@@ -831,7 +831,7 @@
 			</argument>
 			<description>
 				Plays native video from the specified path, at the given volume and with audio and subtitle tracks.
-				[b]Note:[/b] This method is implemented on Android and iOS, and the current Android implementation does not support the [code]volume[/code], [code]audio_track[/code] and [code]subtitle_track[/code] options.
+				[b]Note:[/b] This method is only implemented on iOS.
 			</description>
 		</method>
 		<method name="native_video_stop">
@@ -839,7 +839,7 @@
 			</return>
 			<description>
 				Stops native video playback.
-				[b]Note:[/b] This method is implemented on Android and iOS.
+				[b]Note:[/b] This method is implemented on iOS.
 			</description>
 		</method>
 		<method name="native_video_unpause">
@@ -847,7 +847,7 @@
 			</return>
 			<description>
 				Resumes native video playback.
-				[b]Note:[/b] This method is implemented on Android and iOS.
+				[b]Note:[/b] This method is implemented on iOS.
 			</description>
 		</method>
 		<method name="open_midi_inputs">

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -536,40 +536,6 @@ public class GodotIO {
 		edit = _edit;
 	}
 
-	public void playVideo(String p_path) {
-		Uri filePath = Uri.parse(p_path);
-		mediaPlayer = new MediaPlayer();
-
-		try {
-			mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
-			mediaPlayer.setDataSource(activity.getApplicationContext(), filePath);
-			mediaPlayer.prepare();
-			mediaPlayer.start();
-		} catch (IOException e) {
-			System.out.println("IOError while playing video");
-		}
-	}
-
-	public boolean isVideoPlaying() {
-		if (mediaPlayer != null) {
-			return mediaPlayer.isPlaying();
-		}
-		return false;
-	}
-
-	public void pauseVideo() {
-		if (mediaPlayer != null) {
-			mediaPlayer.pause();
-		}
-	}
-
-	public void stopVideo() {
-		if (mediaPlayer != null) {
-			mediaPlayer.release();
-			mediaPlayer = null;
-		}
-	}
-
 	public static final int SYSTEM_DIR_DESKTOP = 0;
 	public static final int SYSTEM_DIR_DCIM = 1;
 	public static final int SYSTEM_DIR_DOCUMENTS = 2;

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -59,10 +59,6 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 		_set_screen_orientation = p_env->GetMethodID(cls, "setScreenOrientation", "(I)V");
 		_get_screen_orientation = p_env->GetMethodID(cls, "getScreenOrientation", "()I");
 		_get_system_dir = p_env->GetMethodID(cls, "getSystemDir", "(I)Ljava/lang/String;");
-		_play_video = p_env->GetMethodID(cls, "playVideo", "(Ljava/lang/String;)V");
-		_is_video_playing = p_env->GetMethodID(cls, "isVideoPlaying", "()Z");
-		_pause_video = p_env->GetMethodID(cls, "pauseVideo", "()V");
-		_stop_video = p_env->GetMethodID(cls, "stopVideo", "()V");
 	}
 }
 
@@ -200,33 +196,6 @@ String GodotIOJavaWrapper::get_system_dir(int p_dir) {
 		return jstring_to_string(s, env);
 	} else {
 		return String(".");
-	}
-}
-
-void GodotIOJavaWrapper::play_video(const String &p_path) {
-	// Why is this not here?!?!
-}
-
-bool GodotIOJavaWrapper::is_video_playing() {
-	if (_is_video_playing) {
-		JNIEnv *env = get_jni_env();
-		return env->CallBooleanMethod(godot_io_instance, _is_video_playing);
-	} else {
-		return false;
-	}
-}
-
-void GodotIOJavaWrapper::pause_video() {
-	if (_pause_video) {
-		JNIEnv *env = get_jni_env();
-		env->CallVoidMethod(godot_io_instance, _pause_video);
-	}
-}
-
-void GodotIOJavaWrapper::stop_video() {
-	if (_stop_video) {
-		JNIEnv *env = get_jni_env();
-		env->CallVoidMethod(godot_io_instance, _stop_video);
 	}
 }
 

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -57,10 +57,6 @@ private:
 	jmethodID _set_screen_orientation = 0;
 	jmethodID _get_screen_orientation = 0;
 	jmethodID _get_system_dir = 0;
-	jmethodID _play_video = 0;
-	jmethodID _is_video_playing = 0;
-	jmethodID _pause_video = 0;
-	jmethodID _stop_video = 0;
 
 public:
 	GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instance);
@@ -83,10 +79,6 @@ public:
 	void set_screen_orientation(int p_orient);
 	int get_screen_orientation() const;
 	String get_system_dir(int p_dir);
-	void play_video(const String &p_path);
-	bool is_video_playing();
-	void pause_video();
-	void stop_video();
 };
 
 #endif /* !JAVA_GODOT_IO_WRAPPER_H */

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -798,27 +798,8 @@ String OS_Android::get_unique_id() const {
 	return OS::get_unique_id();
 }
 
-Error OS_Android::native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track) {
-	// FIXME: Add support for volume, audio and subtitle tracks
-
-	godot_io_java->play_video(p_path);
-	return OK;
-}
-
-bool OS_Android::native_video_is_playing() const {
-	return godot_io_java->is_video_playing();
-}
-
-void OS_Android::native_video_pause() {
-	godot_io_java->pause_video();
-}
-
 String OS_Android::get_system_dir(SystemDir p_dir) const {
 	return godot_io_java->get_system_dir(p_dir);
-}
-
-void OS_Android::native_video_stop() {
-	godot_io_java->stop_video();
 }
 
 void OS_Android::set_context_is_16_bits(bool p_is_16) {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -212,11 +212,6 @@ public:
 	void process_event(Ref<InputEvent> p_event);
 	void init_video_mode(int p_video_width, int p_video_height);
 
-	virtual Error native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track);
-	virtual bool native_video_is_playing() const;
-	virtual void native_video_pause();
-	virtual void native_video_stop();
-
 	virtual bool is_joy_known(int p_device);
 	virtual String get_joy_guid(int p_device) const;
 	void joy_connection_changed(int p_device, bool p_connected, String p_name);


### PR DESCRIPTION
Those methods are only properly implemented for iOS.

Supersedes #43811.