### PR TITLE
Display arrow cursor if text is not editable

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -557,7 +557,7 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 }
 
 Control::CursorShape LineEdit::get_cursor_shape(const Point2 &p_pos) const {
-	if (!text.is_empty() && is_editable() && _is_over_clear_button(p_pos)) {
+	if ((!text.is_empty() && is_editable() && _is_over_clear_button(p_pos)) || (!is_editable() && (!is_selecting_enabled() || text.is_empty()))) {
 		return CURSOR_ARROW;
 	}
 	return Control::get_cursor_shape(p_pos);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4450,7 +4450,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 		return CURSOR_POINTING_HAND;
 	}
 
-	if ((completion_active && completion_rect.has_point(p_pos))) {
+	if ((completion_active && completion_rect.has_point(p_pos)) || (is_readonly() && (!is_selecting_enabled() || text.size() == 0))) {
 		return CURSOR_ARROW;
 	}
 


### PR DESCRIPTION
Right now LineEdit/TextEdit will always show the `CURSOR_IBEAM` even if not editable, which is a bit confusing.

For reference:
https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_input_disabled