### PR TITLE
Fixed usage of proxy textures on GLES2 sky

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2815,6 +2815,8 @@ void RasterizerSceneGLES2::_draw_sky(RasterizerStorageGLES2::Sky *p_sky, const C
 	RasterizerStorageGLES2::Texture *tex = storage->texture_owner.getornull(p_sky->panorama);
 	ERR_FAIL_COND(!tex);
 
+	tex = tex->get_ptr(); //resolve for proxies
+
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(tex->target, tex->tex_id);
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1162,6 +1162,8 @@ void RasterizerStorageGLES2::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 		ERR_FAIL_COND(!texture);
 	}
 
+	texture = texture->get_ptr(); //resolve for proxies
+
 	// glBindVertexArray(0) and more
 	{
 		glBindBuffer(GL_ARRAY_BUFFER, 0);


### PR DESCRIPTION
The GLES2 sky rasterizer was missing a resolver for proxy textures like GLES3 does, and so this fixes it, so now ViewportTexture/ProxyTexture for PanoramaSky works as expected.