### PR TITLE
[HTML5] Fix target_fps when window loses focus.

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -567,10 +567,17 @@ public:
 	void particles_set_use_local_coordinates(RID p_particles, bool p_enable) override {}
 	void particles_set_process_material(RID p_particles, RID p_material) override {}
 	void particles_set_fixed_fps(RID p_particles, int p_fps) override {}
+	void particles_set_interpolate(RID p_particles, bool p_enable) override {}
 	void particles_set_fractional_delta(RID p_particles, bool p_enable) override {}
 	void particles_set_subemitter(RID p_particles, RID p_subemitter_particles) override {}
-	void particles_set_view_axis(RID p_particles, const Vector3 &p_axis) override {}
+	void particles_set_view_axis(RID p_particles, const Vector3 &p_axis, const Vector3 &p_up_axis) override {}
 	void particles_set_collision_base_size(RID p_particles, float p_size) override {}
+
+	void particles_set_transform_align(RID p_particles, RS::ParticlesTransformAlign p_transform_align) override {}
+
+	void particles_set_trails(RID p_particles, bool p_enable, float p_length) override {}
+	void particles_set_trail_bind_poses(RID p_particles, const Vector<Transform> &p_bind_poses) override {}
+
 	void particles_restart(RID p_particles) override {}
 
 	void particles_set_draw_order(RID p_particles, RS::ParticlesDrawOrder p_order) override {}

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -66,6 +66,11 @@ void main_loop_callback() {
 
 	int target_fps = Engine::get_singleton()->get_target_fps();
 	if (target_fps > 0) {
+		if (current_ticks - target_ticks > 1000000) {
+			// When the window loses focus, we stop getting updates and accumulate delay.
+			// For this reason, if the difference is too big, we reset target ticks to the current ticks.
+			target_ticks = current_ticks;
+		}
 		target_ticks += (uint64_t)(1000000 / target_fps);
 	}
 	if (os->main_loop_iterate()) {


### PR DESCRIPTION
We don't get updates when the window is unfocused/minimized, so we must detect the situation where the counted ticks start drifting away resulting in more frames drawn than needed.
This commit adds a check to ensure that the target ticks do not drift away more than one second.

Fixes #48061

(the first commit is the usual `RasterizerDummy` fix, the second commit should be cherry-pickable).