### PR TITLE
BitMask::create Don't request more memory than needed when size is a multiply of 8

### DIFF
--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -38,7 +38,7 @@ void BitMap::create(const Size2 &p_size) {
 
 	width = p_size.width;
 	height = p_size.height;
-	bitmask.resize(((width * height) / 8) + 1);
+	bitmask.resize((((width * height) - 1) / 8) + 1);
 	memset(bitmask.ptrw(), 0, bitmask.size());
 }
 


### PR DESCRIPTION
Partially fixes #48545 (more details in [this comment](https://github.com/godotengine/godot/issues/48545#issuecomment-835283680)).
Cherry-pickable.