### PR TITLE
Fixed missing sequence port in VisualScript seed()

### DIFF
--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -132,6 +132,7 @@ bool VisualScriptBuiltinFunc::has_input_sequence_port() const {
 		case TEXT_PRINT:
 		case TEXT_PRINTERR:
 		case TEXT_PRINTRAW:
+		case MATH_SEED:
 			return true;
 		default:
 			return false;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Bug fix if there is no [output port](https://github.com/godotengine/godot/blob/871d067aa9f988e69b860887cceebd243011da06/modules/visual_script/visual_script_builtin_funcs.cpp#L225) a sequence port is needed to run the VS_Node

Image Godot 3.3.0 stable
![image](https://user-images.githubusercontent.com/20573784/117550078-7c9c2180-b03e-11eb-805e-a5383fb14c1e.png)

![image](https://user-images.githubusercontent.com/20573784/117550247-95f19d80-b03f-11eb-98b6-7efad2e1c6e4.png)

