### PR TITLE
Make LineEdit underlines thinner in the editor theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -960,11 +960,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> style_line_edit = style_widget->duplicate();
 	// Add a bottom line to make LineEdits more visible, especially in sectioned inspectors
 	// such as the Project Settings.
-	style_line_edit->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
+	style_line_edit->set_border_width(SIDE_BOTTOM, Math::round(EDSCALE));
 	style_line_edit->set_border_color(dark_color_2);
-	// Don't round the bottom corner to make the line look sharper.
-	style_tab_selected->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-	style_tab_selected->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+	// Don't round the bottom corners to make the line look sharper.
+	style_line_edit->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+	style_line_edit->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
 	Ref<StyleBoxFlat> style_line_edit_disabled = style_line_edit->duplicate();
 	style_line_edit_disabled->set_border_color(disabled_color);


### PR DESCRIPTION
This also fixes a typo in the code that disables the bottom rounded corners.

**Note:** Not cherry-pickable to the `3.x` branch as this only pertains to the new editor theme.

## Preview

### Before

![2021-05-08_23 45 08](https://user-images.githubusercontent.com/180032/117554425-d8bf6f80-b057-11eb-9403-676cf2dd06e8.png)

### After

![2021-05-08_23 46 15](https://user-images.githubusercontent.com/180032/117554426-d9580600-b057-11eb-983c-8ee9017cd387.png)

### Alternative (not included in this PR)

Alternatively, we may want to keep the rounded corners at the bottom while making underlines thinner. It would look like this:

![image](https://user-images.githubusercontent.com/180032/117554464-38b61600-b058-11eb-869f-937c67931874.png)