### PR TITLE
Make the focus outline translucent for editor viewports

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -582,6 +582,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Focus
 	theme->set_stylebox("Focus", "EditorStyles", style_widget_focus);
+	// Use a less opaque color to be less distracting for the 2D and 3D editor viewports.
+	Ref<StyleBoxFlat> style_widget_focus_viewport = style_widget_focus->duplicate();
+	style_widget_focus_viewport->set_border_color(accent_color * Color(1, 1, 1, 0.5));
+	theme->set_stylebox("FocusViewport", "EditorStyles", style_widget_focus_viewport);
 
 	// Menu
 	Ref<StyleBoxFlat> style_menu = style_widget->duplicate();

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2655,7 +2655,7 @@ void CanvasItemEditor::_draw_percentage_at_position(float p_value, Point2 p_posi
 void CanvasItemEditor::_draw_focus() {
 	// Draw the focus around the base viewport
 	if (viewport->has_focus()) {
-		get_theme_stylebox(SNAME("Focus"), SNAME("EditorStyles"))->draw(viewport->get_canvas_item(), Rect2(Point2(), viewport->get_size()));
+		get_theme_stylebox(SNAME("FocusViewport"), SNAME("EditorStyles"))->draw(viewport->get_canvas_item(), Rect2(Point2(), viewport->get_size()));
 	}
 }
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2871,7 +2871,7 @@ void Node3DEditorViewport::_draw() {
 	if (surface->has_focus()) {
 		Size2 size = surface->get_size();
 		Rect2 r = Rect2(Point2(), size);
-		get_theme_stylebox(SNAME("Focus"), SNAME("EditorStyles"))->draw(surface->get_canvas_item(), r);
+		get_theme_stylebox(SNAME("FocusViewport"), SNAME("EditorStyles"))->draw(surface->get_canvas_item(), r);
 	}
 
 	if (cursor.region_select) {


### PR DESCRIPTION
This makes the focus outline less distracting on the 2D and 3D editor viewports. We still need to keep this outline visible as it's the only way the user can see if their key presses will go to the viewport (for actions like Focus Selection). [Originally requested on Twitter.](https://twitter.com/Larssteenhoff/status/1391129270454476802)

**Note:** Not cherry-pickable to the `3.x` branch as this only pertains to the new editor theme.

## Preview

***Note:** These screenshots are taken at the smallest possible window size. Remember that the focus outline becomes less distracting at larger screen sizes, since it takes up a lower portion of the window.*

### Before

![Before](https://user-images.githubusercontent.com/180032/117556509-02819200-b06a-11eb-9659-733d6d66ffa8.png)

### After

![After](https://user-images.githubusercontent.com/180032/117556507-01e8fb80-b06a-11eb-8086-bfa3d58caf92.png)