### PR TITLE
Tweak the name for new animations in the editor

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -304,7 +304,7 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 
 void AnimationPlayerEditor::_animation_new() {
 	int count = 1;
-	String base = TTR("New Anim");
+	String base = "new_animation";
 	String current_library_name = "";
 	if (animation->has_selectable_items()) {
 		String current_animation_name = animation->get_item_text(animation->get_selected());
@@ -317,7 +317,7 @@ void AnimationPlayerEditor::_animation_new() {
 	while (true) {
 		String attempt = base;
 		if (count > 1) {
-			attempt += " (" + itos(count) + ")";
+			attempt += vformat("_%d", count);
 		}
 		if (player->has_animation(attempt_prefix + attempt)) {
 			count++;

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -756,11 +756,11 @@ void SpriteFramesEditor::_animation_name_edited() {
 }
 
 void SpriteFramesEditor::_animation_add() {
-	String name = "New Anim";
+	String name = "new_animation";
 	int counter = 0;
 	while (frames->has_animation(name)) {
 		counter++;
-		name = "New Anim " + itos(counter);
+		name = vformat("new_animation_%d", counter);
 	}
 
 	List<Node *> nodes;


### PR DESCRIPTION
- Use snake_case to "suggest" the naming that fits the Godot style guide.
- Fully spell out "new_animation" since both editors can fit it in full.
- Don't internationalize the new animation name to have consistent behavior between both editors.
  - Since the recommendation is to follow snake_case, special characters should also be avoided in the name to make animations easier to refer to in code.

This is technically not a breaking change because it only impacts the name of animations added via the editor (not by code). However, it can break user expectations for those who are used to naming their animations *Like This*. Due to this, I'm not sure if this should be cherry-picked to the `3.x` branch (apart of the translation consistency fix).