### PR TITLE
Fix EditorPropertyResource focus outline being drawn behind the preview

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3254,6 +3254,8 @@ EditorPropertyResource::EditorPropertyResource() {
 	preview->set_offset(SIDE_TOP, 1);
 	preview->set_offset(SIDE_BOTTOM, -1);
 	preview->set_offset(SIDE_RIGHT, -1);
+	// This is required to draw the focus outline in front of the preview, rather than behind.
+	preview->set_draw_behind_parent(true);
 	assign->add_child(preview);
 	assign->connect("gui_input", callable_mp(this, &EditorPropertyResource::_button_input));
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/48579.

This closes https://github.com/godotengine/godot/issues/48575.

## Preview

![image](https://user-images.githubusercontent.com/180032/117569967-72266a00-b0c8-11eb-89dc-b1146615187b.png)
