### PR TITLE
Remove plugin from enabled plugins, if there is an error

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -460,6 +460,7 @@ private:
 	void _update_file_menu_closed();
 
 	void _on_plugin_ready(Object *p_script, const String &p_activate_name);
+	void _remove_plugin_from_enabled(const String &p_name);
 
 	void _fs_changed();
 	void _resources_reimported(const Vector<String> &p_resources);


### PR DESCRIPTION
Resolves [Issue #48441](https://github.com/godotengine/godot/issues/48441). At startup, if there is an error compiling a plugin script, the script will now be removed from enabled plugins. This will cease error messages appearing on startup.