### PR TITLE
[3.x] Create CollisionObject debug shapes using VS

### DIFF
--- a/scene/3d/collision_object.h
+++ b/scene/3d/collision_object.h
@@ -48,7 +48,7 @@ class CollisionObject : public Spatial {
 		Object *owner;
 		Transform xform;
 		struct ShapeBase {
-			Node *debug_shape = nullptr;
+			RID debug_shape;
 			Ref<Shape> shape;
 			int index;
 		};
@@ -70,11 +70,16 @@ class CollisionObject : public Spatial {
 	bool ray_pickable;
 
 	Set<uint32_t> debug_shapes_to_update;
-	int debug_shape_count = 0;
+	int debug_shapes_count = 0;
+	Transform debug_shape_old_transform;
 
 	void _update_pickable();
 
+	bool _are_collision_shapes_visible();
 	void _update_shape_data(uint32_t p_owner);
+	void _shape_changed(const Ref<Shape> &p_shape);
+	void _update_debug_shapes();
+	void _clear_debug_shapes();
 
 protected:
 	CollisionObject(RID p_rid, bool p_area);
@@ -86,8 +91,7 @@ protected:
 	virtual void _mouse_enter();
 	virtual void _mouse_exit();
 
-	void _update_debug_shapes();
-	void _clear_debug_shapes();
+	void _on_transform_changed();
 
 public:
 	void set_collision_layer(uint32_t p_layer);

--- a/scene/3d/collision_shape.h
+++ b/scene/3d/collision_shape.h
@@ -47,8 +47,6 @@ class CollisionShape : public Spatial {
 	bool disabled;
 
 protected:
-	void _shape_changed();
-
 	void _update_in_shape_owner(bool p_xform_only = false);
 
 protected:

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -367,6 +367,7 @@ void RigidBody::_direct_state_changed(Object *p_state) {
 		get_script_instance()->call("_integrate_forces", state);
 	}
 	set_ignore_transform_notification(false);
+	_on_transform_changed();
 
 	if (contact_monitor) {
 		contact_monitor->locked = true;
@@ -2101,6 +2102,7 @@ void PhysicalBone::_direct_state_changed(Object *p_state) {
 	set_ignore_transform_notification(true);
 	set_global_transform(global_transform);
 	set_ignore_transform_notification(false);
+	_on_transform_changed();
 
 	// Update skeleton
 	if (parent_skeleton) {


### PR DESCRIPTION
Backport of #48175.

EDIT: **Does not** fix #48281 because ConcavePolygonShape in 3.x doesn't emit "changed" when the `faces` property changes.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
