### PR TITLE
Fix trimming text input in Find in Files 

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -125,6 +125,9 @@ void FindInFiles::start() {
 		return;
 	}
 
+	if (_whole_words) {
+		_pattern = _pattern.strip_edges();
+	}
 	// Init search
 	_current_dir = "";
 	PackedStringArray init_folder;
@@ -420,8 +423,7 @@ void FindInFilesDialog::set_find_in_files_mode(FindInFilesMode p_mode) {
 }
 
 String FindInFilesDialog::get_search_text() const {
-	String text = _search_text_line_edit->get_text();
-	return text.strip_edges();
+	return _search_text_line_edit->get_text();
 }
 
 String FindInFilesDialog::get_replace_text() const {
@@ -721,7 +723,9 @@ void FindInFilesPanel::_on_result_found(String fpath, int line_number, int begin
 
 	// Trim result item line
 	int old_text_size = text.size();
-	text = text.strip_edges(true, false);
+	if (_finder->is_whole_words()) {
+		text = text.strip_edges(true, false);
+	}
 	int chars_removed = old_text_size - text.size();
 	String start = vformat("%3s: ", line_number);
 


### PR DESCRIPTION
find_in_files.cpp previous had a number of calls to strip_edges() this caused a bug where, even if "whole words" was not selected, the search would not preserve white-space.

As noted by @cptchuckles in #48464 it seems to create an erroneous assumption of what the user wants to find. Instead of just listening to the user.

This merge fixes that issue while also maintaining the functionality of the "whole words" option by only stripping the whitespace edges of search queries *if* that box is checked.

Fixes #48464 