### PR TITLE
Handle portrait mode monitors in the automatic editor scale detection

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5684,15 +5684,17 @@ EditorNode::EditorNode() {
 				editor_set_scale(DisplayServer::get_singleton()->screen_get_max_scale());
 #else
 				const int screen = DisplayServer::get_singleton()->window_get_current_screen();
+				// Use the smallest dimension to use a correct display scale on portait displays.
+				const int smallest_dimension = MIN(DisplayServer::get_singleton()->screen_get_size(screen).x, DisplayServer::get_singleton()->screen_get_size(screen).y);
 				float scale;
-				if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && DisplayServer::get_singleton()->screen_get_size(screen).y >= 1400) {
+				if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && smallest_dimension >= 1400) {
 					// hiDPI display.
 					scale = 2.0;
-				} else if (DisplayServer::get_singleton()->screen_get_size(screen).y >= 1700) {
+				} else if (smallest_dimension >= 1700) {
 					// Likely a hiDPI display, but we aren't certain due to the returned DPI.
 					// Use an intermediate scale to handle this situation.
 					scale = 1.5;
-				} else if (DisplayServer::get_singleton()->screen_get_size(screen).y <= 800) {
+				} else if (smallest_dimension <= 800) {
 					// Small loDPI display. Use a smaller display scale so that editor elements fit more easily.
 					// Icons won't look great, but this is better than having editor elements overflow from its window.
 					scale = 0.75;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -379,15 +379,17 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	float scale = DisplayServer::get_singleton()->screen_get_max_scale();
 #else
 	const int screen = DisplayServer::get_singleton()->window_get_current_screen();
+	// Use the smallest dimension to use a correct display scale on portait displays.
+	const int smallest_dimension = MIN(DisplayServer::get_singleton()->screen_get_size(screen).x, DisplayServer::get_singleton()->screen_get_size(screen).y);
 	float scale;
-	if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && DisplayServer::get_singleton()->screen_get_size(screen).y >= 1400) {
+	if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && smallest_dimension >= 1400) {
 		// hiDPI display.
 		scale = 2.0;
-	} else if (DisplayServer::get_singleton()->screen_get_size(screen).y >= 1700) {
+	} else if (smallest_dimension <= 1700) {
 		// Likely a hiDPI display, but we aren't certain due to the returned DPI.
 		// Use an intermediate scale to handle this situation.
 		scale = 1.5;
-	} else if (DisplayServer::get_singleton()->screen_get_size(screen).y <= 800) {
+	} else if (smallest_dimension <= 800) {
 		// Small loDPI display. Use a smaller display scale so that editor elements fit more easily.
 		// Icons won't look great, but this is better than having editor elements overflow from its window.
 		scale = 0.75;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2403,15 +2403,17 @@ ProjectManager::ProjectManager() {
 				editor_set_scale(DisplayServer::get_singleton()->screen_get_max_scale());
 #else
 				const int screen = DisplayServer::get_singleton()->window_get_current_screen();
+				// Use the smallest dimension to use a correct display scale on portait displays.
+				const int smallest_dimension = MIN(DisplayServer::get_singleton()->screen_get_size(screen).x, DisplayServer::get_singleton()->screen_get_size(screen).y);
 				float scale;
-				if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && DisplayServer::get_singleton()->screen_get_size(screen).y >= 1400) {
+				if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && smallest_dimension >= 1400) {
 					// hiDPI display.
 					scale = 2.0;
-				} else if (DisplayServer::get_singleton()->screen_get_size(screen).y >= 1700) {
+				} else if (smallest_dimension >= 1700) {
 					// Likely a hiDPI display, but we aren't certain due to the returned DPI.
 					// Use an intermediate scale to handle this situation.
 					scale = 1.5;
-				} else if (DisplayServer::get_singleton()->screen_get_size(screen).y <= 800) {
+				} else if (smallest_dimension <= 800) {
 					// Small loDPI display. Use a smaller display scale so that editor elements fit more easily.
 					// Icons won't look great, but this is better than having editor elements overflow from its window.
 					scale = 0.75;


### PR DESCRIPTION
Using the smallest dimension of the width and height makes it possible to support both landscape and portrait monitors.

This closes https://github.com/godotengine/godot/issues/48585.