### PR TITLE
Scroll faster when holding Alt in TextEdit (and script editor)

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		TextEdit is meant for editing large, multiline text. It also has facilities for editing code, such as syntax highlighting support and multiple levels of undo/redo.
+		[b]Note:[/b] When holding down [kbd]Alt[/kbd], the vertical scroll wheel will scroll 5 times as fast as it would normally do. This also works in the Godot script editor.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -714,10 +715,10 @@
 			If [code]true[/code], read-only mode is enabled. Existing text cannot be modified and new text cannot be added.
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
-			If there is a horizontal scrollbar this determines the current horizontal scroll value in pixels.
+			If there is a horizontal scrollbar, this determines the current horizontal scroll value in pixels.
 		</member>
 		<member name="scroll_vertical" type="float" setter="set_v_scroll" getter="get_v_scroll" default="0.0">
-			If there is a vertical scrollbar this determines the current vertical scroll value in line numbers, starting at 0 for the top line.
+			If there is a vertical scrollbar, this determines the current vertical scroll value in line numbers, starting at 0 for the top line.
 		</member>
 		<member name="selecting_enabled" type="bool" setter="set_selecting_enabled" getter="is_selecting_enabled" default="true">
 			If [code]true[/code], text can be selected.

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2917,14 +2917,22 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (mb->get_button_index() == MOUSE_BUTTON_WHEEL_UP && !mb->get_command()) {
 				if (mb->get_shift()) {
 					h_scroll->set_value(h_scroll->get_value() - (100 * mb->get_factor()));
+				} else if (mb->get_alt()) {
+					// Scroll 5 times as fast as normal (like in Visual Studio Code).
+					_scroll_up(15 * mb->get_factor());
 				} else if (v_scroll->is_visible()) {
+					// Scroll 3 lines.
 					_scroll_up(3 * mb->get_factor());
 				}
 			}
 			if (mb->get_button_index() == MOUSE_BUTTON_WHEEL_DOWN && !mb->get_command()) {
 				if (mb->get_shift()) {
 					h_scroll->set_value(h_scroll->get_value() + (100 * mb->get_factor()));
+				} else if (mb->get_alt()) {
+					// Scroll 5 times as fast as normal (like in Visual Studio Code).
+					_scroll_down(15 * mb->get_factor());
 				} else if (v_scroll->is_visible()) {
+					// Scroll 3 lines.
 					_scroll_down(3 * mb->get_factor());
 				}
 			}


### PR DESCRIPTION
This feature is inspired by a similar feature found in Visual Studio Code.
A 5× speed modifier is applied when holding down <kbd>Alt</kbd>, letting you spare your mouse wheel :slightly_smiling_face: 

Note that I didn't expose a property to disable this behavior, but if you disable scrolling somehow or mark scroll events as handled in your script, it should be ignored anyway.