### PR TITLE
Add `get_base_editor` to `ScriptEditorBase`

### DIFF
--- a/doc/classes/ScriptEditorBase.xml
+++ b/doc/classes/ScriptEditorBase.xml
@@ -18,6 +18,13 @@
 				Adds a [EditorSyntaxHighlighter] to the open script.
 			</description>
 		</method>
+		<method name="get_base_editor" qualifiers="const">
+			<return type="Control">
+			</return>
+			<description>
+				Returns the underlying [Control] used for editing scripts. This can be either [CodeEdit] (for text scripts) or [GraphEdit] (for visual scripts).
+			</description>
+		</method>
 	</methods>
 	<signals>
 		<signal name="edited_script_changed">

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -218,6 +218,8 @@ Ref<EditorSyntaxHighlighter> EditorPlainTextSyntaxHighlighter::_create() const {
 /*** SCRIPT EDITOR ****/
 
 void ScriptEditorBase::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_base_editor"), &ScriptEditorBase::get_base_editor);
+
 	ADD_SIGNAL(MethodInfo("name_changed"));
 	ADD_SIGNAL(MethodInfo("edited_script_changed"));
 	ADD_SIGNAL(MethodInfo("request_help", PropertyInfo(Variant::STRING, "topic")));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -163,6 +163,8 @@ public:
 	virtual Control *get_edit_menu() = 0;
 	virtual void clear_edit_menu() = 0;
 
+	virtual Control *get_base_editor() const = 0;
+
 	virtual void validate() = 0;
 
 	ScriptEditorBase() {}

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1402,6 +1402,10 @@ void ScriptTextEditor::set_tooltip_request_func(String p_method, Object *p_obj) 
 void ScriptTextEditor::set_debugger_active(bool p_active) {
 }
 
+Control *ScriptTextEditor::get_base_editor() const {
+	return code_editor->get_text_editor();
+}
+
 Variant ScriptTextEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 	return Variant();
 }

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -233,6 +233,8 @@ public:
 	virtual void clear_edit_menu() override;
 	static void register_editor();
 
+	virtual Control *get_base_editor() const override;
+
 	virtual void validate() override;
 
 	ScriptTextEditor();

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -171,6 +171,10 @@ void TextEditor::add_callback(const String &p_function, PackedStringArray p_args
 void TextEditor::set_debugger_active(bool p_active) {
 }
 
+Control *TextEditor::get_base_editor() const {
+	return code_editor->get_text_editor();
+}
+
 Array TextEditor::get_breakpoints() {
 	return Array();
 }

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -142,6 +142,8 @@ public:
 
 	virtual void validate() override;
 
+	virtual Control *get_base_editor() const override;
+
 	static void register_editor();
 
 	TextEditor();

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2710,6 +2710,10 @@ void VisualScriptEditor::set_debugger_active(bool p_active) {
 	}
 }
 
+Control *VisualScriptEditor::get_base_editor() const {
+	return graph;
+}
+
 void VisualScriptEditor::set_tooltip_request_func(String p_method, Object *p_obj) {
 }
 

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -320,6 +320,8 @@ public:
 	virtual bool can_lose_focus_on_node_selection() override { return false; }
 	virtual void validate() override;
 
+	virtual Control *get_base_editor() const override;
+
 	static void register_editor();
 
 	static void free_clipboard();


### PR DESCRIPTION
Fixes godotengine/godot-proposals#2278
I picked this proposal because I want to do [this](https://godotforums.org/discussion/26131/how-to-get-script-editor-current-line).
