### PR TITLE
Display the old color in ColorPicker for easier comparison (3.x)

### DIFF
--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -71,6 +71,8 @@ private:
 	int presets_per_row;
 
 	Color color;
+	Color old_color;
+	bool display_old_color = false;
 	bool raw_mode_enabled;
 	bool hsv_mode_enabled;
 	bool deferred_mode_enabled;
@@ -112,6 +114,10 @@ public:
 	void _set_pick_color(const Color &p_color, bool p_update_sliders);
 	void set_pick_color(const Color &p_color);
 	Color get_pick_color() const;
+	void set_old_color(const Color &p_color);
+
+	void set_display_old_color(bool p_enabled);
+	bool is_displaying_old_color() const;
 
 	void add_preset(const Color &p_color);
 	void erase_preset(const Color &p_color);
@@ -145,6 +151,7 @@ class ColorPickerButton : public Button {
 	Color color;
 	bool edit_alpha;
 
+	void _about_to_show();
 	void _color_changed(const Color &p_color);
 	void _modal_closed();
 


### PR DESCRIPTION
`3.x` version of #34840.

This only affects ColorPickerButton nodes that spawn a ColorPicker, not standalone ColorPickers.

## Preview

![image](https://user-images.githubusercontent.com/180032/117669314-0c5cdf80-b1a7-11eb-8808-d0e8f984d6cc.png)
