### PR TITLE
Implement LSP didSave notification and rename request

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -310,6 +310,7 @@ public:
 		Ref<Script> script;
 		String class_name;
 		String class_member;
+		String class_path;
 		int location;
 	};
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2799,6 +2799,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					if (base_type.class_type->has_member(p_symbol)) {
 						r_result.type = ScriptLanguage::LookupResult::RESULT_SCRIPT_LOCATION;
 						r_result.location = base_type.class_type->get_member(p_symbol).get_line();
+						r_result.class_path = base_type.script_path;
 						return OK;
 					}
 					base_type = base_type.class_type->base_type;

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -42,10 +42,12 @@ void GDScriptTextDocument::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("didOpen"), &GDScriptTextDocument::didOpen);
 	ClassDB::bind_method(D_METHOD("didClose"), &GDScriptTextDocument::didClose);
 	ClassDB::bind_method(D_METHOD("didChange"), &GDScriptTextDocument::didChange);
+	ClassDB::bind_method(D_METHOD("didSave"), &GDScriptTextDocument::didSave);
 	ClassDB::bind_method(D_METHOD("nativeSymbol"), &GDScriptTextDocument::nativeSymbol);
 	ClassDB::bind_method(D_METHOD("documentSymbol"), &GDScriptTextDocument::documentSymbol);
 	ClassDB::bind_method(D_METHOD("completion"), &GDScriptTextDocument::completion);
 	ClassDB::bind_method(D_METHOD("resolve"), &GDScriptTextDocument::resolve);
+	ClassDB::bind_method(D_METHOD("rename"), &GDScriptTextDocument::rename);
 	ClassDB::bind_method(D_METHOD("foldingRange"), &GDScriptTextDocument::foldingRange);
 	ClassDB::bind_method(D_METHOD("codeLens"), &GDScriptTextDocument::codeLens);
 	ClassDB::bind_method(D_METHOD("documentLink"), &GDScriptTextDocument::documentLink);
@@ -77,6 +79,20 @@ void GDScriptTextDocument::didChange(const Variant &p_param) {
 		doc.text = evt.text;
 	}
 	sync_script_content(doc.uri, doc.text);
+}
+
+void GDScriptTextDocument::didSave(const Variant &p_param) {
+	lsp::TextDocumentItem doc = load_document_item(p_param);
+	Dictionary dict = p_param;
+	String text = dict["text"];
+
+	sync_script_content(doc.uri, text);
+
+	/*String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(doc.uri);
+
+	Ref<GDScript> script = ResourceLoader::load(path);
+	script->load_source_code(path);
+	script->reload(true);*/
 }
 
 lsp::TextDocumentItem GDScriptTextDocument::load_document_item(const Variant &p_param) {
@@ -214,6 +230,14 @@ Array GDScriptTextDocument::completion(const Dictionary &p_params) {
 		}
 	}
 	return arr;
+}
+
+Dictionary GDScriptTextDocument::rename(const Dictionary &p_params) {
+	lsp::TextDocumentPositionParams params;
+	params.load(p_params);
+	String new_name = p_params["newName"];
+
+	return GDScriptLanguageProtocol::get_singleton()->get_workspace()->rename(params, new_name);
 }
 
 Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
@@ -406,7 +430,11 @@ GDScriptTextDocument::~GDScriptTextDocument() {
 void GDScriptTextDocument::sync_script_content(const String &p_path, const String &p_content) {
 	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(p_path);
 	GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_script(path, p_content);
+
 	EditorFileSystem::get_singleton()->update_file(path);
+	Ref<GDScript> script = ResourceLoader::load(path);
+	script->load_source_code(path);
+	script->reload(true);
 }
 
 void GDScriptTextDocument::show_native_symbol_in_editor(const String &p_symbol_id) {

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -45,6 +45,7 @@ protected:
 	void didOpen(const Variant &p_param);
 	void didClose(const Variant &p_param);
 	void didChange(const Variant &p_param);
+	void didSave(const Variant &p_param);
 
 	void sync_script_content(const String &p_path, const String &p_content);
 	void show_native_symbol_in_editor(const String &p_symbol_id);
@@ -61,6 +62,7 @@ public:
 	Array documentSymbol(const Dictionary &p_params);
 	Array completion(const Dictionary &p_params);
 	Dictionary resolve(const Dictionary &p_params);
+	Dictionary rename(const Dictionary &p_params);
 	Array foldingRange(const Dictionary &p_params);
 	Array codeLens(const Dictionary &p_params);
 	Array documentLink(const Dictionary &p_params);

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -116,6 +116,36 @@ const lsp::DocumentSymbol *GDScriptWorkspace::get_script_symbol(const String &p_
 	return nullptr;
 }
 
+const lsp::DocumentSymbol *GDScriptWorkspace::get_parameter_symbol(const lsp::DocumentSymbol *p_parent, const String &symbol_identifier) {
+	for (int i = 0; i < p_parent->children.size(); ++i) {
+		const lsp::DocumentSymbol *parameter_symbol = &p_parent->children[i];
+		if (!parameter_symbol->detail.is_empty() && parameter_symbol->name == symbol_identifier) {
+			return parameter_symbol;
+		}
+	}
+
+	return nullptr;
+}
+
+const lsp::DocumentSymbol *GDScriptWorkspace::get_local_symbol(const ExtendGDScriptParser *p_parser, const String &p_symbol_identifier) {
+	const lsp::DocumentSymbol *class_symbol = &p_parser->get_symbols();
+
+	for (int i = 0; i < class_symbol->children.size(); ++i) {
+		if (class_symbol->children[i].kind == lsp::SymbolKind::Function || class_symbol->children[i].kind == lsp::SymbolKind::Class) {
+			const lsp::DocumentSymbol *function_symbol = &class_symbol->children[i];
+
+			for (int l = 0; l < function_symbol->children.size(); ++l) {
+				const lsp::DocumentSymbol *local = &function_symbol->children[l];
+				if (!local->detail.is_empty() && local->name == p_symbol_identifier) {
+					return local;
+				}
+			}
+		}
+	}
+
+	return nullptr;
+}
+
 void GDScriptWorkspace::reload_all_workspace_scripts() {
 	List<String> paths;
 	list_script_files("res://", paths);
@@ -351,6 +381,50 @@ Error GDScriptWorkspace::parse_script(const String &p_path, const String &p_cont
 	return err;
 }
 
+Dictionary GDScriptWorkspace::rename(const lsp::TextDocumentPositionParams &p_doc_pos, const String &new_name) {
+	Error err;
+	String path = get_file_path(p_doc_pos.textDocument.uri);
+
+	lsp::WorkspaceEdit edit;
+
+	List<String> paths;
+	list_script_files("res://", paths);
+
+	const lsp::DocumentSymbol *reference_symbol = resolve_symbol(p_doc_pos);
+	if (reference_symbol) {
+		String identifier = reference_symbol->name;
+
+		for (List<String>::Element *PE = paths.front(); PE; PE = PE->next()) {
+			PackedStringArray content = FileAccess::get_file_as_string(PE->get(), &err).split("\n");
+			for (int i = 0; i < content.size(); ++i) {
+				String line = content[i];
+
+				int character = line.find(identifier);
+				while (character > -1) {
+					lsp::TextDocumentPositionParams params;
+
+					lsp::TextDocumentIdentifier text_doc;
+					text_doc.uri = get_file_uri(PE->get());
+
+					params.textDocument = text_doc;
+					params.position.line = i;
+					params.position.character = character;
+
+					const lsp::DocumentSymbol *other_symbol = resolve_symbol(params);
+
+					if (other_symbol == reference_symbol) {
+						edit.add_change(text_doc.uri, i, character, character + identifier.length(), new_name);
+					}
+
+					character = line.find(identifier, character + 1);
+				}
+			}
+		}
+	}
+
+	return edit.to_json();
+}
+
 Error GDScriptWorkspace::parse_local_script(const String &p_path) {
 	Error err;
 	String content = FileAccess::get_file_as_string(p_path, &err);
@@ -479,10 +553,16 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 						String target_script_path = path;
 						if (!ret.script.is_null()) {
 							target_script_path = ret.script->get_path();
+						} else if (!ret.class_path.is_empty()) {
+							target_script_path = ret.class_path;
 						}
 
 						if (const ExtendGDScriptParser *target_parser = get_parse_result(target_script_path)) {
 							symbol = target_parser->get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(ret.location));
+
+							if (symbol && symbol->kind == lsp::SymbolKind::Function && symbol->name != symbol_identifier) {
+								symbol = get_parameter_symbol(symbol, symbol_identifier);
+							}
 						}
 
 					} else {
@@ -494,6 +574,10 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 					}
 				} else {
 					symbol = parser->get_member_symbol(symbol_identifier);
+
+					if (!symbol) {
+						symbol = get_local_symbol(parser, symbol_identifier);
+					}
 				}
 			}
 		}

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -52,6 +52,8 @@ protected:
 
 	const lsp::DocumentSymbol *get_native_symbol(const String &p_class, const String &p_member = "") const;
 	const lsp::DocumentSymbol *get_script_symbol(const String &p_path) const;
+	const lsp::DocumentSymbol *get_parameter_symbol(const lsp::DocumentSymbol *p_parent, const String &symbol_identifier);
+	const lsp::DocumentSymbol *get_local_symbol(const ExtendGDScriptParser *p_parser, const String &p_symbol_identifier);
 
 	void reload_all_workspace_scripts();
 
@@ -90,6 +92,7 @@ public:
 	Dictionary generate_script_api(const String &p_path);
 	Error resolve_signature(const lsp::TextDocumentPositionParams &p_doc_pos, lsp::SignatureHelp &r_signature);
 	void did_delete_files(const Dictionary &p_params);
+	Dictionary rename(const lsp::TextDocumentPositionParams &p_doc_pos, const String &new_name);
 
 	GDScriptWorkspace();
 	~GDScriptWorkspace();


### PR DESCRIPTION
This is a companion to #48616, but for 4.0. Fixes #47609. This implements the `textDocument/rename` request for the language server to find symbols such as function names, variables, properties, signals and otherwise, and rename them wherever they match the original symbol.

As a companion, this also adds the `textDocument/didSave` notification. This is because, by the time the text changes are received by the client, none of the variables have been renamed internally, which results in error. But saving the scripts will re-trigger a parsing of all changed scripts and thus find the new property names.

Also fixes #50510 by reloading the script resource's internal state.