### PR TITLE
Rename "Singleton" to "Global Variable" in the AutoLoad editor

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -882,15 +882,16 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	tree->set_column_title(0, TTR("Name"));
 	tree->set_column_expand(0, true);
-	tree->set_column_min_width(0, 100);
+	tree->set_column_min_width(0, 100 * EDSCALE);
 
 	tree->set_column_title(1, TTR("Path"));
 	tree->set_column_expand(1, true);
-	tree->set_column_min_width(1, 100);
+	tree->set_column_min_width(1, 100 * EDSCALE);
 
-	tree->set_column_title(2, TTR("Singleton"));
+	tree->set_column_title(2, TTR("Global Variable"));
 	tree->set_column_expand(2, false);
-	tree->set_column_min_width(2, 80 * EDSCALE);
+	// Reserve enough space for translations of "Global Variable" which may be longer.
+	tree->set_column_min_width(2, 150 * EDSCALE);
 
 	tree->set_column_expand(3, false);
 	tree->set_column_min_width(3, 120 * EDSCALE);


### PR DESCRIPTION
The name "Singleton" was misleading because Godot does not actually enforce a singleton pattern for autoloads. They can be instanced multiple times.

"Global Variable" makes it more obvious that all the checkbox does is expose the AutoLoad with a global variable for easy access.

This closes https://github.com/godotengine/godot-proposals/issues/1649.

## Preview

![image](https://user-images.githubusercontent.com/180032/117697771-23112f80-b1c3-11eb-849c-8626ecd266de.png)