### PR TITLE
Implement reverting to the old color when clicking it in ColorPicker (3.x)

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -393,6 +393,21 @@ void ColorPicker::_update_text_value() {
 	c_text->set_visible(visible);
 }
 
+void ColorPicker::_sample_input(const Ref<InputEvent> &p_event) {
+	const Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+		if (display_old_color) {
+			const Rect2 rect_old = Rect2(Point2(), Size2(uv_edit->get_size().width * 0.5, sample->get_size().height * 0.95));
+			if (rect_old.has_point(mb->get_position())) {
+				// Revert to the old color when left-clicking the old color sample.
+				set_pick_color(old_color);
+				//_update_color();
+				emit_signal("color_changed", color);
+			}
+		}
+	}
+}
+
 void ColorPicker::_sample_draw() {
 	// Covers the right half of the sample if the old color is being displayed,
 	// or the whole sample if it's not being displayed.
@@ -736,6 +751,7 @@ void ColorPicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_text_type_toggled"), &ColorPicker::_text_type_toggled);
 	ClassDB::bind_method(D_METHOD("_add_preset_pressed"), &ColorPicker::_add_preset_pressed);
 	ClassDB::bind_method(D_METHOD("_screen_pick_pressed"), &ColorPicker::_screen_pick_pressed);
+	ClassDB::bind_method(D_METHOD("_sample_input"), &ColorPicker::_sample_input);
 	ClassDB::bind_method(D_METHOD("_sample_draw"), &ColorPicker::_sample_draw);
 	ClassDB::bind_method(D_METHOD("_update_presets"), &ColorPicker::_update_presets);
 	ClassDB::bind_method(D_METHOD("_hsv_draw"), &ColorPicker::_hsv_draw);
@@ -800,6 +816,7 @@ ColorPicker::ColorPicker() :
 	sample = memnew(TextureRect);
 	hb_smpl->add_child(sample);
 	sample->set_h_size_flags(SIZE_EXPAND_FILL);
+	sample->connect("gui_input", this, "_sample_input");
 	sample->connect("draw", this, "_sample_draw");
 
 	btn_pick = memnew(ToolButton);

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -90,6 +90,7 @@ private:
 	void _update_presets();
 	void _update_text_value();
 	void _text_type_toggled();
+	void _sample_input(const Ref<InputEvent> &p_event);
 	void _sample_draw();
 	void _hsv_draw(int p_which, Control *c);
 


### PR DESCRIPTION
`3.x` version of #48618.