### PR TITLE
Fix small issues with capitalization in the new TileMap editor

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -575,7 +575,7 @@ TileAtlasView::TileAtlasView() {
 
 	// Base tiles.
 	Label *base_tile_label = memnew(Label);
-	base_tile_label->set_text(TTR("Base tiles"));
+	base_tile_label->set_text(TTR("Base Tiles"));
 	base_tile_label->set_align(Label::ALIGN_CENTER);
 	left_vbox->add_child(base_tile_label);
 
@@ -623,7 +623,7 @@ TileAtlasView::TileAtlasView() {
 
 	// Alternative tiles.
 	Label *alternative_tiles_label = memnew(Label);
-	alternative_tiles_label->set_text(TTR("Alternative tiles"));
+	alternative_tiles_label->set_text(TTR("Alternative Tiles"));
 	alternative_tiles_label->set_align(Label::ALIGN_CENTER);
 	right_vbox->add_child(alternative_tiles_label);
 

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -154,10 +154,10 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 			if (texture.is_valid()) {
 				sources_list->add_item(vformat("%s - (id:%d)", texture->get_path().get_file(), source_id), texture);
 			} else {
-				sources_list->add_item(vformat("No texture atlas source - (id:%d)", source_id), missing_texture_texture);
+				sources_list->add_item(vformat("No Texture Atlas Source - (id:%d)", source_id), missing_texture_texture);
 			}
 		} else {
-			sources_list->add_item(vformat("Unknown type source - (id:%d)", source_id), missing_texture_texture);
+			sources_list->add_item(vformat("Unknown Type Source - (id:%d)", source_id), missing_texture_texture);
 		}
 		sources_list->set_item_metadata(i, source_id);
 	}
@@ -1671,7 +1671,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	// Random tile checkbox.
 	random_tile_checkbox = memnew(CheckBox);
 	random_tile_checkbox->set_flat(true);
-	random_tile_checkbox->set_text(TTR("Place random tile"));
+	random_tile_checkbox->set_text(TTR("Place Random Tile"));
 	random_tile_checkbox->connect("toggled", callable_mp(this, &TileMapEditorTilesPlugin::_on_random_tile_checkbox_toggled));
 	tools_settings->add_child(random_tile_checkbox);
 
@@ -2798,15 +2798,15 @@ void TileMapEditorTerrainsPlugin::_update_terrains_tree() {
 		String matches;
 		if (tile_set->get_terrain_set_mode(terrain_set_index) == TileSet::TERRAIN_MODE_MATCH_CORNERS_AND_SIDES) {
 			terrain_set_tree_item->set_icon(0, get_theme_icon("TerrainMatchCornersAndSides", "EditorIcons"));
-			matches = String(TTR("Matches corners and sides"));
+			matches = String(TTR("Matches Corners and Sides"));
 		} else if (tile_set->get_terrain_set_mode(terrain_set_index) == TileSet::TERRAIN_MODE_MATCH_CORNERS) {
 			terrain_set_tree_item->set_icon(0, get_theme_icon("TerrainMatchCorners", "EditorIcons"));
-			matches = String(TTR("Matches corners only"));
+			matches = String(TTR("Matches Corners Only"));
 		} else {
 			terrain_set_tree_item->set_icon(0, get_theme_icon("TerrainMatchSides", "EditorIcons"));
-			matches = String(TTR("Matches sides only"));
+			matches = String(TTR("Matches Sides Only"));
 		}
-		terrain_set_tree_item->set_text(0, vformat("Terrain set %d (%s)", terrain_set_index, matches));
+		terrain_set_tree_item->set_text(0, vformat("Terrain Set %d (%s)", terrain_set_index, matches));
 		terrain_set_tree_item->set_selectable(0, false);
 
 		for (int terrain_index = 0; terrain_index < tile_set->get_terrains_count(terrain_set_index); terrain_index++) {

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1669,7 +1669,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	// Tile inspector.
 	tile_inspector_label = memnew(Label);
-	tile_inspector_label->set_text(TTR("Tile properties:"));
+	tile_inspector_label->set_text(TTR("Tile Properties:"));
 	tile_inspector_label->hide();
 	middle_vbox_container->add_child(tile_inspector_label);
 
@@ -1686,7 +1686,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	// Atlas source inspector.
 	atlas_source_inspector_label = memnew(Label);
-	atlas_source_inspector_label->set_text(TTR("Atlas properties:"));
+	atlas_source_inspector_label->set_text(TTR("Atlas Properties:"));
 	middle_vbox_container->add_child(atlas_source_inspector_label);
 
 	atlas_source_proxy_object = memnew(TileSetAtlasSourceProxyObject());
@@ -1724,7 +1724,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tool_select_button->set_toggle_mode(true);
 	tool_select_button->set_pressed(true);
 	tool_select_button->set_button_group(tools_button_group);
-	tool_select_button->set_tooltip(TTR("Select tiles"));
+	tool_select_button->set_tooltip(TTR("Select tiles."));
 	tool_select_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_fix_selected_and_hovered_tiles));
 	tool_select_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_id_label));
 	tool_select_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_inspector));
@@ -1736,7 +1736,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tool_add_remove_button->set_flat(true);
 	tool_add_remove_button->set_toggle_mode(true);
 	tool_add_remove_button->set_button_group(tools_button_group);
-	tool_add_remove_button->set_tooltip(TTR("Add/Remove tiles tool (use the shift key to create big tiles)"));
+	tool_add_remove_button->set_tooltip(TTR("Add/Remove tiles tool (use the shift key to create big tiles)."));
 	tool_add_remove_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_fix_selected_and_hovered_tiles));
 	tool_add_remove_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_id_label));
 	tool_add_remove_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_inspector));
@@ -1748,7 +1748,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tool_add_remove_rect_button->set_flat(true);
 	tool_add_remove_rect_button->set_toggle_mode(true);
 	tool_add_remove_rect_button->set_button_group(tools_button_group);
-	tool_add_remove_rect_button->set_tooltip(TTR("Add/Remove tiles rectangle tool (use the shift key to create big tiles)"));
+	tool_add_remove_rect_button->set_tooltip(TTR("Add/Remove tiles rectangle tool (use the shift key to create big tiles)."));
 	tool_add_remove_rect_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_fix_selected_and_hovered_tiles));
 	tool_add_remove_rect_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_id_label));
 	tool_add_remove_rect_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_update_tile_inspector));
@@ -1775,10 +1775,10 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	tool_advanced_menu_buttom = memnew(MenuButton);
 	tool_advanced_menu_buttom->set_flat(true);
-	tool_advanced_menu_buttom->get_popup()->add_item(TTR("Cleanup tiles outside texture"), ADVANCED_CLEANUP_TILES_OUTSIDE_TEXTURE);
+	tool_advanced_menu_buttom->get_popup()->add_item(TTR("Cleanup Tiles Outside Texture"), ADVANCED_CLEANUP_TILES_OUTSIDE_TEXTURE);
 	tool_advanced_menu_buttom->get_popup()->set_item_disabled(0, true);
-	tool_advanced_menu_buttom->get_popup()->add_item(TTR("Create tiles in non-transparent texture regions."), ADVANCED_AUTO_CREATE_TILES);
-	tool_advanced_menu_buttom->get_popup()->add_item(TTR("Remove tiles in fully transparent texture regions."), ADVANCED_AUTO_REMOVE_TILES);
+	tool_advanced_menu_buttom->get_popup()->add_item(TTR("Create Tiles in Non-Transparent Texture Regions"), ADVANCED_AUTO_CREATE_TILES);
+	tool_advanced_menu_buttom->get_popup()->add_item(TTR("Remove Tiles in Fully Transparent Texture Regions"), ADVANCED_AUTO_REMOVE_TILES);
 	tool_advanced_menu_buttom->get_popup()->connect("id_pressed", callable_mp(this, &TileSetAtlasSourceEditor::_menu_option));
 	toolbox->add_child(tool_advanced_menu_buttom);
 


### PR DESCRIPTION
Just some small touch-ups in capitalization/periods for better consistency with the rest of the editor.