### PR TITLE
Fix reloading of csharpscripts that have orphaned references awaiting gc

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2727,6 +2727,7 @@ void CSharpScript::_clear() {
 
 	tool = false;
 	valid = false;
+	reload_invalidated = false;
 
 	base = NULL;
 	native = NULL;
@@ -2840,6 +2841,7 @@ void CSharpScript::initialize_for_managed_type(Ref<CSharpScript> p_script, GDMon
 
 	p_script->valid = true;
 	p_script->tool = p_script->script_class->has_attribute(CACHED_CLASS(ToolAttribute));
+	p_script->reload_invalidated = false;
 
 	if (!p_script->tool) {
 		GDMonoClass *nesting_class = p_script->script_class->get_nesting_class();
@@ -3151,20 +3153,10 @@ MethodInfo CSharpScript::get_method_info(const StringName &p_method) const {
 
 Error CSharpScript::reload(bool p_keep_state) {
 
-	bool has_instances = false;
-	{
-		MutexLock lock(CSharpLanguage::get_singleton()->script_instances_mutex);
-		for (Set<Object *>::Element *F = instances.front(); F; F = F->next()) {
-			Reference *obj = Object::cast_to<Reference>(F->get());
-			if (obj->reference_get_count() > 1) {
-				// we only care about a refcount > 1, since orphaned instances awaiting GC retain a count of 1
-				has_instances = true;
-				break;
-			}
-		}
+	if (reload_invalidated) {
+		return OK;
 	}
-
-	ERR_FAIL_COND_V(!p_keep_state && has_instances, ERR_ALREADY_IN_USE);
+	reload_invalidated = true; /* In the case of C#, reload doesn't really do any script reloading. That's done separately via domain reloading. */
 
 	GD_MONO_SCOPE_THREAD_ATTACH;
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -75,6 +75,7 @@ class CSharpScript : public Script {
 
 	bool tool;
 	bool valid;
+	bool reload_invalidated;
 
 	bool builtin;
 


### PR DESCRIPTION
Fix for #48590

Successfully tested in release_debug & debug on 3.3 in several multi-hour long editor-sessions, mostly porting, building and debugging procedural content generation through C# tool-/editorscripts.

I contribute this for 3.3 and not 3.x/master bc my focus and alloted qa time is on stable. The commit itself is simple and should be easily moved/cherrypicked.
