### PR TITLE
Embree: Forward-port SSE2/x86 fixups from `3.x` branch

### DIFF
--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,9 +1,15 @@
 def can_build(env, platform):
+    # Depends on Embree library, which supports only x86_64 (originally)
+    # and aarch64 (thanks to the embree-aarch64 fork).
+
     if platform == "android":
-        return env["android_arch"] in ["arm64v8", "x86", "x86_64"]
+        return env["android_arch"] in ["arm64v8", "x86_64"]
 
     if platform == "javascript":
         return False  # No SIMD support yet
+
+    if env["bits"] == "32":
+        return False
 
     return True
 

--- a/modules/raycast/lightmap_raycaster.cpp
+++ b/modules/raycast/lightmap_raycaster.cpp
@@ -32,7 +32,9 @@
 
 #include "lightmap_raycaster.h"
 
+#ifdef __SSE2__
 #include <pmmintrin.h>
+#endif
 
 LightmapRaycaster *LightmapRaycasterEmbree::create_embree_raycaster() {
 	return memnew(LightmapRaycasterEmbree);
@@ -171,8 +173,10 @@ void embree_error_handler(void *p_user_data, RTCError p_code, const char *p_str)
 }
 
 LightmapRaycasterEmbree::LightmapRaycasterEmbree() {
+#ifdef __SSE2__
 	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 	_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+#endif
 
 	embree_device = rtcNewDevice(nullptr);
 	rtcSetDeviceErrorFunction(embree_device, &embree_error_handler, nullptr);
@@ -180,8 +184,10 @@ LightmapRaycasterEmbree::LightmapRaycasterEmbree() {
 }
 
 LightmapRaycasterEmbree::~LightmapRaycasterEmbree() {
+#ifdef __SSE2__
 	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
 	_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
+#endif
 
 	if (embree_scene != nullptr) {
 		rtcReleaseScene(embree_scene);


### PR DESCRIPTION
Cherry-picked for `master` from #48483 and #48485.