### PR TITLE
Implementing blit shader with versions

### DIFF
--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -59,7 +59,22 @@ public:
 	struct BlitToScreen {
 		RID render_target;
 		Rect2i rect;
-		//lens distorted parameters for VR should go here
+
+		struct {
+			bool use_layer = false;
+			uint32_t layer = 0;
+		} multi_view;
+
+		struct {
+			//lens distorted parameters for VR
+			bool apply = false;
+			Vector2 eye_center;
+			float k1 = 0.0;
+			float k2 = 0.0;
+
+			float upscale = 1.0;
+			float aspect_ratio = 1.0;
+		} lens_distortion;
 	};
 
 	virtual void prepare_for_blitting_render_targets() = 0;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -38,6 +38,7 @@
 #include "servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h"
 #include "servers/rendering/renderer_rd/renderer_canvas_render_rd.h"
 #include "servers/rendering/renderer_rd/renderer_storage_rd.h"
+#include "servers/rendering/renderer_rd/shaders/blit.glsl.gen.h"
 
 class RendererCompositorRD : public RendererCompositor {
 protected:
@@ -45,11 +46,35 @@ protected:
 	RendererStorageRD *storage;
 	RendererSceneRenderRD *scene;
 
-	RID copy_viewports_rd_shader;
-	RID copy_viewports_rd_pipeline;
-	RID copy_viewports_rd_index_buffer;
-	RID copy_viewports_rd_array;
-	RID copy_viewports_sampler;
+	enum BlitMode {
+		BLIT_MODE_NORMAL,
+		BLIT_MODE_USE_LAYER,
+		BLIT_MODE_LENS,
+		BLIT_MODE_MAX
+	};
+
+	struct BlitPushConstant {
+		float rect[4];
+
+		float eye_center[2];
+		float k1;
+		float k2;
+
+		float upscale;
+		float aspect_ratio;
+		uint32_t layer;
+		uint32_t pad1;
+	};
+
+	struct Blit {
+		BlitPushConstant push_constant;
+		BlitShaderRD shader;
+		RID shader_version;
+		RID pipelines[BLIT_MODE_MAX];
+		RID index_buffer;
+		RID array;
+		RID sampler;
+	} blit;
 
 	Map<RID, RID> render_target_descriptors;
 

--- a/servers/rendering/renderer_rd/shaders/blit.glsl
+++ b/servers/rendering/renderer_rd/shaders/blit.glsl
@@ -1,0 +1,95 @@
+#[vertex]
+
+#version 450
+
+#VERSION_DEFINES
+
+layout(push_constant, binding = 0, std140) uniform Pos {
+	vec4 dst_rect;
+
+	vec2 eye_center;
+	float k1;
+	float k2;
+
+	float upscale;
+	float aspect_ratio;
+	uint layer;
+	uint pad1;
+}
+data;
+
+layout(location = 0) out vec2 uv;
+
+void main() {
+	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
+	uv = base_arr[gl_VertexIndex];
+	vec2 vtx = data.dst_rect.xy + uv * data.dst_rect.zw;
+	gl_Position = vec4(vtx * 2.0 - 1.0, 0.0, 1.0);
+}
+
+#[fragment]
+
+#version 450
+
+#VERSION_DEFINES
+
+layout(push_constant, binding = 0, std140) uniform Pos {
+	vec4 dst_rect;
+
+	vec2 eye_center;
+	float k1;
+	float k2;
+
+	float upscale;
+	float aspect_ratio;
+	uint layer;
+	uint pad1;
+}
+data;
+
+layout(location = 0) in vec2 uv;
+
+layout(location = 0) out vec4 color;
+
+#ifdef USE_LAYER
+layout(binding = 0) uniform sampler2DArray src_rt;
+#else
+layout(binding = 0) uniform sampler2D src_rt;
+#endif
+
+void main() {
+#ifdef APPLY_LENS_DISTORTION
+	vec2 coords = uv * 2.0 - 1.0;
+	vec2 offset = coords - data.eye_center;
+
+	// take aspect ratio into account
+	offset.y /= data.aspect_ratio;
+
+	// distort
+	vec2 offset_sq = offset * offset;
+	float radius_sq = offset_sq.x + offset_sq.y;
+	float radius_s4 = radius_sq * radius_sq;
+	float distortion_scale = 1.0 + (data.k1 * radius_sq) + (data.k2 * radius_s4);
+	offset *= distortion_scale;
+
+	// reapply aspect ratio
+	offset.y *= data.aspect_ratio;
+
+	// add our eye center back in
+	coords = offset + data.eye_center;
+	coords /= data.upscale;
+
+	// and check our color
+	if (coords.x < -1.0 || coords.y < -1.0 || coords.x > 1.0 || coords.y > 1.0) {
+		color = vec4(0.0, 0.0, 0.0, 1.0);
+	} else {
+		// layer is always used here
+		coords = (coords + vec2(1.0)) / vec2(2.0);
+		color = texture(src_rt, vec3(coords, data.layer));
+	}
+#elif defined(USE_LAYER)
+	color = texture(src_rt, vec3(uv, data.layer));
+#else
+	color = texture(src_rt, uv);
+#endif
+}


### PR DESCRIPTION
The current shader logic that copies viewports onto the display is currently a hard coded shader in `RendererCompositorRD`.
Changing this to a `blit.glsl` implementations so we can implement different versions for layers and lens distortion.

There are now 3 versions of the blit shader possible:
- the default one which just copies the contents of the viewport on screen as is to the defined rectangle
- a version that reads from a specific layer in a texture array (needed for stereo buffers, see multiview PR)
- a version that also applies lens distortion, note that right now it assumes it is used with layer support. 
