### PR TITLE
GDNative: Fix size mismatch on 32-bit platforms for Signal and Callable

### DIFF
--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -44,9 +44,9 @@ class CallableCustom;
 // is required. It is designed for the standard case (object and method)
 // but can be optimized or customized.
 
+// Enforce 16 bytes with `alignas` to avoid arch-specific alignment issues on x86 vs armv7.
 class Callable {
-	//needs to be max 16 bytes in 64 bits
-	StringName method;
+	alignas(8) StringName method;
 	union {
 		uint64_t object = 0;
 		CallableCustom *custom;
@@ -138,8 +138,9 @@ public:
 // be put inside a Variant, but it is not
 // used by the engine itself.
 
+// Enforce 16 bytes with `alignas` to avoid arch-specific alignment issues on x86 vs armv7.
 class Signal {
-	StringName name;
+	alignas(8) StringName name;
 	ObjectID object;
 
 public:

--- a/modules/gdnative/include/gdnative/callable.h
+++ b/modules/gdnative/include/gdnative/callable.h
@@ -37,6 +37,7 @@ extern "C" {
 
 #include <stdint.h>
 
+// Alignment hardcoded in `core/variant/callable.h`.
 #define GODOT_CALLABLE_SIZE (16)
 
 #ifndef GODOT_CORE_API_GODOT_CALLABLE_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/signal.h
+++ b/modules/gdnative/include/gdnative/signal.h
@@ -37,6 +37,7 @@ extern "C" {
 
 #include <stdint.h>
 
+// Alignment hardcoded in `core/variant/callable.h`.
 #define GODOT_SIGNAL_SIZE (16)
 
 #ifndef GODOT_CORE_API_GODOT_SIGNAL_TYPE_DEFINED


### PR DESCRIPTION
Fixes #48645.

I dehardcoded the size similarly to what was done in #38779 for other types. `Signal` and `Callable` are both a `StringName` (pointer) and `uint64_t`.