### PR TITLE
Batching - fallback for 2d skinning with unrigged polys.

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -1881,17 +1881,23 @@ PREAMBLE(bool)::_software_skin_poly(RasterizerCanvas::Item::CommandPolygon *p_po
 			}
 		}
 
-		// software transform with combined matrix?
-		if (p_fill_state.transform_mode != TM_NONE) {
-			for (int n = 0; n < num_verts; n++) {
-				Vector2 &dst_pos = pTemps[n];
-				_software_transform_vertex(dst_pos, p_fill_state.transform_combined);
-			}
-		}
-
 	} // if bone format matches
 	else {
-		// not supported
+		// not rigged properly, just copy the verts directly
+		for (int n = 0; n < num_verts; n++) {
+			const Vector2 &src_pos = p_poly->points[n];
+			Vector2 &dst_pos = pTemps[n];
+
+			dst_pos = src_pos;
+		}
+	}
+
+	// software transform with combined matrix?
+	if (p_fill_state.transform_mode != TM_NONE) {
+		for (int n = 0; n < num_verts; n++) {
+			Vector2 &dst_pos = pTemps[n];
+			_software_transform_vertex(dst_pos, p_fill_state.transform_combined);
+		}
 	}
 
 	// output to the batch verts


### PR DESCRIPTION
In the legacy renderer unrigged polys would display with no transform applied, whereas the software skinning didn't deal with these at all (outputted them with position zero). This PR simply copies the source to destination verts and replicates the legacy behaviour.

Fixes #48641

## Notes
* I think this is fine, I tried a variety of situations and couldn't break it (but of course welcome more testing)
* We could alternatively instead of copying the vertices just not enter the software skinning function, but this keeps the same path so may be slightly preferable, performance difference is likely to be negligible and unrigged polys are unlikely to be used in production.
* I wanted to check whether there was a situation where some vertices were assigned a bone and some not, but this appears not to happen. As far as I can see they are all rigged, or none at all, which makes the fix nice and easy.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
