### PR TITLE
Added GraphNode missing setters.

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -40,7 +40,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the color of the input connection [code]idx[/code].
+				Returns the [Color] of the input connection [code]idx[/code].
 			</description>
 		</method>
 		<method name="get_connection_input_count">
@@ -74,7 +74,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the color of the output connection [code]idx[/code].
+				Returns the [Color] of the output connection [code]idx[/code].
 			</description>
 		</method>
 		<method name="get_connection_output_count">
@@ -117,7 +117,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the color set to [code]idx[/code] left (input) slot.
+				Returns the left (input) [Color] of the slot [code]idx[/code].
 			</description>
 		</method>
 		<method name="get_slot_color_right" qualifiers="const">
@@ -126,7 +126,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the color set to [code]idx[/code] right (output) slot.
+				Returns the right (output) [Color] of the slot [code]idx[/code].
 			</description>
 		</method>
 		<method name="get_slot_type_left" qualifiers="const">
@@ -135,7 +135,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the (integer) type of left (input) [code]idx[/code] slot.
+				Returns the left (input) type of the slot [code]idx[/code].
 			</description>
 		</method>
 		<method name="get_slot_type_right" qualifiers="const">
@@ -144,7 +144,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the (integer) type of right (output) [code]idx[/code] slot.
+				Returns the right (output) type of the slot [code]idx[/code].
 			</description>
 		</method>
 		<method name="is_slot_enabled_left" qualifiers="const">
@@ -153,7 +153,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if left (input) slot [code]idx[/code] is enabled, [code]false[/code] otherwise.
+				Returns [code]true[/code] if left (input) side of the slot [code]idx[/code] is enabled.
 			</description>
 		</method>
 		<method name="is_slot_enabled_right" qualifiers="const">
@@ -162,7 +162,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if right (output) slot [code]idx[/code] is enabled, [code]false[/code] otherwise.
+				Returns [code]true[/code] if right (output) side of the slot [code]idx[/code] is enabled.
 			</description>
 		</method>
 		<method name="set_opentype_feature">
@@ -204,6 +204,73 @@
 				[code]color_left[/code]/[code]right[/code] is the tint of the port's icon on this side.
 				[code]custom_left[/code]/[code]right[/code] is a custom texture for this side's port.
 				[b]Note:[/b] This method only sets properties of the slot. To create the slot, add a [Control]-derived child to the GraphNode.
+				Individual properties can be set using one of the [code]set_slot_*[/code] methods. You must enable at least one side of the slot to do so.
+			</description>
+		</method>
+		<method name="set_slot_color_left">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="color_left" type="Color">
+			</argument>
+			<description>
+				Sets the [Color] of the left (input) side of the slot [code]idx[/code] to [code]color_left[/code].
+			</description>
+		</method>
+		<method name="set_slot_color_right">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="color_right" type="Color">
+			</argument>
+			<description>
+				Sets the [Color] of the right (output) side of the slot [code]idx[/code] to [code]color_right[/code].
+			</description>
+		</method>
+		<method name="set_slot_enabled_left">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="enable_left" type="bool">
+			</argument>
+			<description>
+				Toggles the left (input) side of the slot [code]idx[/code]. If [code]enable_left[/code] is [code]true[/code], a port will appear on the left side and the slot will be able to be connected from this side.
+			</description>
+		</method>
+		<method name="set_slot_enabled_right">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="enable_right" type="bool">
+			</argument>
+			<description>
+				Toggles the right (output) side of the slot [code]idx[/code]. If [code]enable_right[/code] is [code]true[/code], a port will appear on the right side and the slot will be able to be connected from this side.
+			</description>
+		</method>
+		<method name="set_slot_type_left">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="type_left" type="int">
+			</argument>
+			<description>
+				Sets the left (input) type of the slot [code]idx[/code] to [code]type_left[/code].
+			</description>
+		</method>
+		<method name="set_slot_type_right">
+			<return type="void">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="type_right" type="int">
+			</argument>
+			<description>
+				Sets the right (output) type of the slot [code]idx[/code] to [code]type_right[/code].
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -459,7 +459,7 @@ void GraphNode::_shape() {
 }
 
 void GraphNode::set_slot(int p_idx, bool p_enable_left, int p_type_left, const Color &p_color_left, bool p_enable_right, int p_type_right, const Color &p_color_right, const Ref<Texture2D> &p_custom_left, const Ref<Texture2D> &p_custom_right) {
-	ERR_FAIL_COND(p_idx < 0);
+	ERR_FAIL_COND_MSG(p_idx < 0, vformat("Cannot set slot with p_idx (%d) lesser than zero.", p_idx));
 
 	if (!p_enable_left && p_type_left == 0 && p_color_left == Color(1, 1, 1, 1) &&
 			!p_enable_right && p_type_right == 0 && p_color_right == Color(1, 1, 1, 1) &&
@@ -503,11 +503,41 @@ bool GraphNode::is_slot_enabled_left(int p_idx) const {
 	return slot_info[p_idx].enable_left;
 }
 
+void GraphNode::set_slot_enabled_left(int p_idx, bool p_enable_left) {
+	ERR_FAIL_COND_MSG(p_idx < 0, vformat("Cannot set enable_left for the slot with p_idx (%d) lesser than zero.", p_idx));
+
+	slot_info[p_idx].enable_left = p_enable_left;
+	update();
+	connpos_dirty = true;
+
+	emit_signal("slot_updated", p_idx);
+}
+
+void GraphNode::set_slot_type_left(int p_idx, int p_type_left) {
+	ERR_FAIL_COND_MSG(!slot_info.has(p_idx), vformat("Cannot set type_left for the slot '%d' because it hasn't been enabled.", p_idx));
+
+	slot_info[p_idx].type_left = p_type_left;
+	update();
+	connpos_dirty = true;
+
+	emit_signal("slot_updated", p_idx);
+}
+
 int GraphNode::get_slot_type_left(int p_idx) const {
 	if (!slot_info.has(p_idx)) {
 		return 0;
 	}
 	return slot_info[p_idx].type_left;
+}
+
+void GraphNode::set_slot_color_left(int p_idx, const Color &p_color_left) {
+	ERR_FAIL_COND_MSG(!slot_info.has(p_idx), vformat("Cannot set color_left for the slot '%d' because it hasn't been enabled.", p_idx));
+
+	slot_info[p_idx].color_left = p_color_left;
+	update();
+	connpos_dirty = true;
+
+	emit_signal("slot_updated", p_idx);
 }
 
 Color GraphNode::get_slot_color_left(int p_idx) const {
@@ -524,11 +554,41 @@ bool GraphNode::is_slot_enabled_right(int p_idx) const {
 	return slot_info[p_idx].enable_right;
 }
 
+void GraphNode::set_slot_enabled_right(int p_idx, bool p_enable_right) {
+	ERR_FAIL_COND_MSG(p_idx < 0, vformat("Cannot set enable_right for the slot with p_idx (%d) lesser than zero.", p_idx));
+
+	slot_info[p_idx].enable_right = p_enable_right;
+	update();
+	connpos_dirty = true;
+
+	emit_signal("slot_updated", p_idx);
+}
+
+void GraphNode::set_slot_type_right(int p_idx, int p_type_right) {
+	ERR_FAIL_COND_MSG(!slot_info.has(p_idx), vformat("Cannot set type_right for the slot '%d' because it hasn't been enabled.", p_idx));
+
+	slot_info[p_idx].type_right = p_type_right;
+	update();
+	connpos_dirty = true;
+
+	emit_signal("slot_updated", p_idx);
+}
+
 int GraphNode::get_slot_type_right(int p_idx) const {
 	if (!slot_info.has(p_idx)) {
 		return 0;
 	}
 	return slot_info[p_idx].type_right;
+}
+
+void GraphNode::set_slot_color_right(int p_idx, const Color &p_color_right) {
+	ERR_FAIL_COND_MSG(!slot_info.has(p_idx), vformat("Cannot set color_right for the slot '%d' because it hasn't been enabled.", p_idx));
+
+	slot_info[p_idx].color_right = p_color_right;
+	update();
+	connpos_dirty = true;
+
+	emit_signal("slot_updated", p_idx);
 }
 
 Color GraphNode::get_slot_color_right(int p_idx) const {
@@ -891,11 +951,23 @@ void GraphNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_slot", "idx", "enable_left", "type_left", "color_left", "enable_right", "type_right", "color_right", "custom_left", "custom_right"), &GraphNode::set_slot, DEFVAL(Ref<Texture2D>()), DEFVAL(Ref<Texture2D>()));
 	ClassDB::bind_method(D_METHOD("clear_slot", "idx"), &GraphNode::clear_slot);
 	ClassDB::bind_method(D_METHOD("clear_all_slots"), &GraphNode::clear_all_slots);
+
 	ClassDB::bind_method(D_METHOD("is_slot_enabled_left", "idx"), &GraphNode::is_slot_enabled_left);
+	ClassDB::bind_method(D_METHOD("set_slot_enabled_left", "idx", "enable_left"), &GraphNode::set_slot_enabled_left);
+
+	ClassDB::bind_method(D_METHOD("set_slot_type_left", "idx", "type_left"), &GraphNode::set_slot_type_left);
 	ClassDB::bind_method(D_METHOD("get_slot_type_left", "idx"), &GraphNode::get_slot_type_left);
+
+	ClassDB::bind_method(D_METHOD("set_slot_color_left", "idx", "color_left"), &GraphNode::set_slot_color_left);
 	ClassDB::bind_method(D_METHOD("get_slot_color_left", "idx"), &GraphNode::get_slot_color_left);
+
 	ClassDB::bind_method(D_METHOD("is_slot_enabled_right", "idx"), &GraphNode::is_slot_enabled_right);
+	ClassDB::bind_method(D_METHOD("set_slot_enabled_right", "idx", "enable_right"), &GraphNode::set_slot_enabled_right);
+
+	ClassDB::bind_method(D_METHOD("set_slot_type_right", "idx", "type_right"), &GraphNode::set_slot_type_right);
 	ClassDB::bind_method(D_METHOD("get_slot_type_right", "idx"), &GraphNode::get_slot_type_right);
+
+	ClassDB::bind_method(D_METHOD("set_slot_color_right", "idx", "color_right"), &GraphNode::set_slot_color_right);
 	ClassDB::bind_method(D_METHOD("get_slot_color_right", "idx"), &GraphNode::get_slot_color_right);
 
 	ClassDB::bind_method(D_METHOD("set_position_offset", "offset"), &GraphNode::set_position_offset);

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -113,11 +113,23 @@ public:
 	void set_slot(int p_idx, bool p_enable_left, int p_type_left, const Color &p_color_left, bool p_enable_right, int p_type_right, const Color &p_color_right, const Ref<Texture2D> &p_custom_left = Ref<Texture2D>(), const Ref<Texture2D> &p_custom_right = Ref<Texture2D>());
 	void clear_slot(int p_idx);
 	void clear_all_slots();
+
 	bool is_slot_enabled_left(int p_idx) const;
+	void set_slot_enabled_left(int p_idx, bool p_enable_left);
+
+	void set_slot_type_left(int p_idx, int p_type_left);
 	int get_slot_type_left(int p_idx) const;
+
+	void set_slot_color_left(int p_idx, const Color &p_color_left);
 	Color get_slot_color_left(int p_idx) const;
+
 	bool is_slot_enabled_right(int p_idx) const;
+	void set_slot_enabled_right(int p_idx, bool p_enable_right);
+
+	void set_slot_type_right(int p_idx, int p_type_right);
 	int get_slot_type_right(int p_idx) const;
+
+	void set_slot_color_right(int p_idx, const Color &p_color_right);
 	Color get_slot_color_right(int p_idx) const;
 
 	void set_title(const String &p_title);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Previous PR had git issues,this has everything squashed.

As of now, in order to set even a single property of a GraphNode slot, you have to use the
`set_slot(int p_idx, bool p_enable_left, int p_type_left, const Color &p_color_left, bool p_enable_right, int p_type_right, const Color &p_color_right, const Ref<Texture2D> &p_custom_left = Ref<Texture2D>(), const Ref<Texture2D> &p_custom_right = Ref<Texture2D>());`

,that means if you want to change a single property, say p_enable_left, of p_idx =0, you have to at least use,
`set_slot(0, true, 0, Color.white, false, 0, Color.green)`.
Say,When you have selected a color already in the editor,you need to pass that color again in this function.
			

So,Added Some setters to GraphNode, which allows to directly set the values of different slots.

Probably Fixes some of https://github.com/godotengine/godot-proposals/issues/2212, as it mentions there to add similiar functions.

Update:New Screenshot
![graph](https://user-images.githubusercontent.com/17506575/118123032-61049280-b413-11eb-878d-a4629bd5e689.png)
