### PR TITLE
Fix `EditorPropertyEasing` capturing drag events originated outside of it

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -951,7 +951,7 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 
 	const Ref<InputEventMouseMotion> mm = p_ev;
 
-	if (mm.is_valid() && mm->get_button_mask() & MOUSE_BUTTON_MASK_LEFT) {
+	if (dragging && mm.is_valid() && mm->get_button_mask() & MOUSE_BUTTON_MASK_LEFT) {
 		float rel = mm->get_relative().x;
 		if (rel == 0) {
 			return;


### PR DESCRIPTION
Fixes #21912. `EditorPropertyEasing` was capturing mouse drag events even if that drag didn't originate from it. This issue affects built-in properties, such as easing and attenuation in audio resources and nodes, as well any custom export properties with `PROPERTY_HINT_EXP_EASING`.