### PR TITLE
Keep custom editor theme when changing editor settings

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -628,7 +628,7 @@ void EditorNode::_notification(int p_what) {
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			scene_tabs->set_tab_close_display_policy((bool(EDITOR_GET("interface/scene_tabs/always_show_close_button")) ? Tabs::CLOSE_BUTTON_SHOW_ALWAYS : Tabs::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
-			theme = create_editor_theme(theme_base->get_theme());
+			theme = create_custom_theme(theme_base->get_theme());
 
 			theme_base->set_theme(theme);
 			gui_base->set_theme(theme);


### PR DESCRIPTION
Currently whenever the editor settings are changed in any way, the theme is reset to the default one and an editor restart is required to bring the custom theme back.