### PR TITLE
Enable single-window mode by default on Linux to workaround NVIDIA bug

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -426,7 +426,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/editor/unfocused_low_processor_mode_sleep_usec"] = PropertyInfo(Variant::FLOAT, "interface/editor/unfocused_low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "1,100000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/separate_distraction_mode", false);
 	_initial_set("interface/editor/automatically_open_screenshots", true);
+#ifdef X11_ENABLED
+	// Work around NVIDIA proprietary driver bug that causes frequent X11 freezes (GH-41614).
+	_initial_set("interface/editor/single_window_mode", true);
+#else
 	_initial_set("interface/editor/single_window_mode", false);
+#endif
 	hints["interface/editor/single_window_mode"] = PropertyInfo(Variant::BOOL, "interface/editor/single_window_mode", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/hide_console_window", false);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2085,9 +2085,11 @@ bool Main::start() {
 		}
 #endif
 
-		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", false);
+		// Work around NVIDIA proprietary driver bug that causes frequent X11 freezes (GH-41614).
+		GLOBAL_DEF("display/window/subwindows/embed_subwindows.Linux", true);
+		const bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", false);
 
-		if (single_window || (!project_manager && !editor && embed_subwindows)) {
+		if (single_window || (!editor && embed_subwindows)) {
 			sml->get_root()->set_embed_subwindows_hint(true);
 		}
 		ResourceLoader::add_custom_loaders();


### PR DESCRIPTION
- Single-window mode is always enabled in the project manager on Linux, since the single-window mode editor setting can't be read at the time the project manager starts. Previously, you had to pass `--single-window` to the project manager to avoid freezes when creating a new project (unless you were really careful with your mouse cursor).

See https://github.com/godotengine/godot/issues/41614. That issue gets a lot of duplicate reports, and we aren't close to getting a fix (it's a few weeks away at best, and might not be done in time for alpha1).