### PR TITLE
[3.x]Fixed VisualScriptYield node so resume is possible

### DIFF
--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -117,7 +117,7 @@ public:
 			int ret = STEP_YIELD_BIT;
 			switch (mode) {
 				case VisualScriptYield::YIELD_RETURN:
-					ret = STEP_EXIT_FUNCTION_BIT;
+					ret = STEP_YIELD_BIT;
 					break; //return the yield
 				case VisualScriptYield::YIELD_FRAME:
 					state->connect_to_signal(tree, "idle_frame", Array());


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Honestly I do not understand why the yield node would ever return STEP_EXIT_FUNCTION_BIT. as a sequence option.
Now it sends STEP_YIELD_BIT like all other Yield nodes

I tested this by using the [Godot example](https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_basics.html?highlight=yield#coroutines-with-yield).
The Yield with return would need a separate node.

![image](https://user-images.githubusercontent.com/20573784/118000277-f46f9200-b345-11eb-923f-58f18e89b1de.png)


PS: My Apology's for creating a pull from 3.x In Master Visual script does not seem to work.
