### PR TITLE
Rename the audio `FFT_Size` enum to `FFTSize` for consistency

### DIFF
--- a/doc/classes/AudioEffectPitchShift.xml
+++ b/doc/classes/AudioEffectPitchShift.xml
@@ -12,7 +12,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="fft_size" type="int" setter="set_fft_size" getter="get_fft_size" enum="AudioEffectPitchShift.FFT_Size" default="3">
+		<member name="fft_size" type="int" setter="set_fft_size" getter="get_fft_size" enum="AudioEffectPitchShift.FFTSize" default="3">
 		</member>
 		<member name="oversampling" type="int" setter="set_oversampling" getter="get_oversampling" default="4">
 		</member>
@@ -21,18 +21,18 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="FFT_SIZE_256" value="0" enum="FFT_Size">
+		<constant name="FFT_SIZE_256" value="0" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_512" value="1" enum="FFT_Size">
+		<constant name="FFT_SIZE_512" value="1" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_1024" value="2" enum="FFT_Size">
+		<constant name="FFT_SIZE_1024" value="2" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_2048" value="3" enum="FFT_Size">
+		<constant name="FFT_SIZE_2048" value="3" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_4096" value="4" enum="FFT_Size">
+		<constant name="FFT_SIZE_4096" value="4" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_MAX" value="5" enum="FFT_Size">
-			Represents the size of the [enum FFT_Size] enum.
+		<constant name="FFT_SIZE_MAX" value="5" enum="FFTSize">
+			Represents the size of the [enum FFTSize] enum.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/AudioEffectSpectrumAnalyzer.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzer.xml
@@ -11,24 +11,24 @@
 	<members>
 		<member name="buffer_length" type="float" setter="set_buffer_length" getter="get_buffer_length" default="2.0">
 		</member>
-		<member name="fft_size" type="int" setter="set_fft_size" getter="get_fft_size" enum="AudioEffectSpectrumAnalyzer.FFT_Size" default="2">
+		<member name="fft_size" type="int" setter="set_fft_size" getter="get_fft_size" enum="AudioEffectSpectrumAnalyzer.FFTSize" default="2">
 		</member>
 		<member name="tap_back_pos" type="float" setter="set_tap_back_pos" getter="get_tap_back_pos" default="0.01">
 		</member>
 	</members>
 	<constants>
-		<constant name="FFT_SIZE_256" value="0" enum="FFT_Size">
+		<constant name="FFT_SIZE_256" value="0" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_512" value="1" enum="FFT_Size">
+		<constant name="FFT_SIZE_512" value="1" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_1024" value="2" enum="FFT_Size">
+		<constant name="FFT_SIZE_1024" value="2" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_2048" value="3" enum="FFT_Size">
+		<constant name="FFT_SIZE_2048" value="3" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_4096" value="4" enum="FFT_Size">
+		<constant name="FFT_SIZE_4096" value="4" enum="FFTSize">
 		</constant>
-		<constant name="FFT_SIZE_MAX" value="5" enum="FFT_Size">
-			Represents the size of the [enum FFT_Size] enum.
+		<constant name="FFT_SIZE_MAX" value="5" enum="FFTSize">
+			Represents the size of the [enum FFTSize] enum.
 		</constant>
 	</constants>
 </class>

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -326,12 +326,12 @@ int AudioEffectPitchShift::get_oversampling() const {
 	return oversampling;
 }
 
-void AudioEffectPitchShift::set_fft_size(FFT_Size p_fft_size) {
+void AudioEffectPitchShift::set_fft_size(FFTSize p_fft_size) {
 	ERR_FAIL_INDEX(p_fft_size, FFT_SIZE_MAX);
 	fft_size = p_fft_size;
 }
 
-AudioEffectPitchShift::FFT_Size AudioEffectPitchShift::get_fft_size() const {
+AudioEffectPitchShift::FFTSize AudioEffectPitchShift::get_fft_size() const {
 	return fft_size;
 }
 

--- a/servers/audio/effects/audio_effect_pitch_shift.h
+++ b/servers/audio/effects/audio_effect_pitch_shift.h
@@ -89,7 +89,7 @@ class AudioEffectPitchShift : public AudioEffect {
 public:
 	friend class AudioEffectPitchShiftInstance;
 
-	enum FFT_Size {
+	enum FFTSize {
 		FFT_SIZE_256,
 		FFT_SIZE_512,
 		FFT_SIZE_1024,
@@ -100,7 +100,7 @@ public:
 
 	float pitch_scale;
 	int oversampling;
-	FFT_Size fft_size;
+	FFTSize fft_size;
 	float wet;
 	float dry;
 	bool filter;
@@ -117,12 +117,12 @@ public:
 	void set_oversampling(int p_oversampling);
 	int get_oversampling() const;
 
-	void set_fft_size(FFT_Size);
-	FFT_Size get_fft_size() const;
+	void set_fft_size(FFTSize);
+	FFTSize get_fft_size() const;
 
 	AudioEffectPitchShift();
 };
 
-VARIANT_ENUM_CAST(AudioEffectPitchShift::FFT_Size);
+VARIANT_ENUM_CAST(AudioEffectPitchShift::FFTSize);
 
 #endif // AUDIO_EFFECT_PITCH_SHIFT_H

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -245,12 +245,12 @@ float AudioEffectSpectrumAnalyzer::get_tap_back_pos() const {
 	return tapback_pos;
 }
 
-void AudioEffectSpectrumAnalyzer::set_fft_size(FFT_Size p_fft_size) {
+void AudioEffectSpectrumAnalyzer::set_fft_size(FFTSize p_fft_size) {
 	ERR_FAIL_INDEX(p_fft_size, FFT_SIZE_MAX);
 	fft_size = p_fft_size;
 }
 
-AudioEffectSpectrumAnalyzer::FFT_Size AudioEffectSpectrumAnalyzer::get_fft_size() const {
+AudioEffectSpectrumAnalyzer::FFTSize AudioEffectSpectrumAnalyzer::get_fft_size() const {
 	return fft_size;
 }
 

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.h
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.h
@@ -71,7 +71,7 @@ class AudioEffectSpectrumAnalyzer : public AudioEffect {
 	GDCLASS(AudioEffectSpectrumAnalyzer, AudioEffect);
 
 public:
-	enum FFT_Size {
+	enum FFTSize {
 		FFT_SIZE_256,
 		FFT_SIZE_512,
 		FFT_SIZE_1024,
@@ -84,7 +84,7 @@ public:
 	friend class AudioEffectSpectrumAnalyzerInstance;
 	float buffer_length;
 	float tapback_pos;
-	FFT_Size fft_size;
+	FFTSize fft_size;
 
 protected:
 	static void _bind_methods();
@@ -96,12 +96,12 @@ public:
 	void set_tap_back_pos(float p_seconds);
 	float get_tap_back_pos() const;
 
-	void set_fft_size(FFT_Size);
-	FFT_Size get_fft_size() const;
+	void set_fft_size(FFTSize);
+	FFTSize get_fft_size() const;
 
 	AudioEffectSpectrumAnalyzer();
 };
 
-VARIANT_ENUM_CAST(AudioEffectSpectrumAnalyzer::FFT_Size);
+VARIANT_ENUM_CAST(AudioEffectSpectrumAnalyzer::FFTSize);
 
 #endif // AUDIO_EFFECT_SPECTRUM_ANALYZER_H


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/37700.

I noticed this while working on https://github.com/godotengine/godot/pull/48681.