### PR TITLE
[macOS, 4.x] Prefer .app bundle icon over the default one.

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -305,6 +305,11 @@ String OS::get_bundle_resource_dir() const {
 	return ".";
 }
 
+// Path to macOS .app bundle embedded icon
+String OS::get_bundle_icon_path() const {
+	return String();
+}
+
 // OS specific path for user://
 String OS::get_user_data_dir() const {
 	return ".";

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -250,6 +250,7 @@ public:
 	virtual String get_config_path() const;
 	virtual String get_cache_path() const;
 	virtual String get_bundle_resource_dir() const;
+	virtual String get_bundle_icon_path() const;
 
 	virtual String get_user_data_dir() const;
 	virtual String get_resource_dir() const;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1696,8 +1696,10 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		}
 
 #ifdef TOOLS_ENABLED
-		Ref<Image> icon = memnew(Image(app_icon_png));
-		DisplayServer::get_singleton()->set_icon(icon);
+		if (OS::get_singleton()->get_bundle_icon_path().is_empty()) {
+			Ref<Image> icon = memnew(Image(app_icon_png));
+			DisplayServer::get_singleton()->set_icon(icon);
+		}
 #endif
 	}
 
@@ -2391,7 +2393,7 @@ bool Main::start() {
 #endif
 	}
 
-	if (!hasicon) {
+	if (!hasicon && OS::get_singleton()->get_bundle_icon_path().is_empty()) {
 		Ref<Image> icon = memnew(Image(app_icon_png));
 		DisplayServer::get_singleton()->set_icon(icon);
 	}

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -80,6 +80,7 @@ public:
 	virtual String get_data_path() const override;
 	virtual String get_cache_path() const override;
 	virtual String get_bundle_resource_dir() const override;
+	virtual String get_bundle_icon_path() const override;
 	virtual String get_godot_dir_name() const override;
 
 	virtual String get_system_dir(SystemDir p_dir) const override;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -216,14 +216,26 @@ String OS_OSX::get_cache_path() const {
 }
 
 String OS_OSX::get_bundle_resource_dir() const {
-	NSBundle *main = [NSBundle mainBundle];
-	NSString *resourcePath = [main resourcePath];
-
-	char *utfs = strdup([resourcePath UTF8String]);
 	String ret;
-	ret.parse_utf8(utfs);
-	free(utfs);
 
+	NSBundle *main = [NSBundle mainBundle];
+	if (main) {
+		NSString *resourcePath = [main resourcePath];
+		ret.parse_utf8([resourcePath UTF8String]);
+	}
+	return ret;
+}
+
+String OS_OSX::get_bundle_icon_path() const {
+	String ret;
+
+	NSBundle *main = [NSBundle mainBundle];
+	if (main) {
+		NSString *iconPath = [[main infoDictionary] objectForKey:@"CFBundleIconFile"];
+		if (iconPath) {
+			ret.parse_utf8([iconPath UTF8String]);
+		}
+	}
 	return ret;
 }
 


### PR DESCRIPTION
Load default (embedded `png`) only when there's no icon (`icns` file) in the app bundle, or running standalone executable. This allows users to change the editor icon without rebuilding it. See https://github.com/godotengine/godot-proposals/issues/1616