### PR TITLE
Create ColorPicker shaders statically

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -84,6 +84,57 @@ void ColorPicker::_notification(int p_what) {
 	}
 }
 
+Ref<Shader> ColorPicker::wheel_shader;
+Ref<Shader> ColorPicker::circle_shader;
+
+void ColorPicker::init_shaders() {
+	wheel_shader.instance();
+	wheel_shader->set_code(
+			"shader_type canvas_item;"
+			"const float TAU = 6.28318530718;"
+			"void fragment() {"
+			"	float x = UV.x - 0.5;"
+			"	float y = UV.y - 0.5;"
+			"	float a = atan(y, x);"
+			"	x += 0.001;"
+			"	y += 0.001;"
+			"	float b = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > 0.42);"
+			"	x -= 0.002;"
+			"	float b2 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > 0.42);"
+			"	y -= 0.002;"
+			"	float b3 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > 0.42);"
+			"	x += 0.002;"
+			"	float b4 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > 0.42);"
+			"	COLOR = vec4(clamp((abs(fract(((a - TAU) / TAU) + vec3(3.0, 2.0, 1.0) / 3.0) * 6.0 - 3.0) - 1.0), 0.0, 1.0), (b + b2 + b3 + b4) / 4.00);"
+			"}");
+
+	circle_shader.instance();
+	circle_shader->set_code(
+			"shader_type canvas_item;"
+			"const float TAU = 6.28318530718;"
+			"uniform float v = 1.0;"
+			"void fragment() {"
+			"	float x = UV.x - 0.5;"
+			"	float y = UV.y - 0.5;"
+			"	float a = atan(y, x);"
+			"	x += 0.001;"
+			"	y += 0.001;"
+			"	float b = float(sqrt(x * x + y * y) < 0.5);"
+			"	x -= 0.002;"
+			"	float b2 = float(sqrt(x * x + y * y) < 0.5);"
+			"	y -= 0.002;"
+			"	float b3 = float(sqrt(x * x + y * y) < 0.5);"
+			"	x += 0.002;"
+			"	float b4 = float(sqrt(x * x + y * y) < 0.5);"
+			"	COLOR = vec4(mix(vec3(1.0), clamp(abs(fract(vec3((a - TAU) / TAU) + vec3(1.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - vec3(3.0)) - vec3(1.0), 0.0, 1.0), ((float(sqrt(x * x + y * y)) * 2.0)) / 1.0) * vec3(v), (b + b2 + b3 + b4) / 4.00);"
+			"}");
+}
+
+void ColorPicker::finish_shaders() {
+	wheel_shader.unref();
+	circle_shader.unref();
+}
+
 void ColorPicker::set_focus_on_line_edit() {
 	c_text->call_deferred("grab_focus");
 }
@@ -1165,14 +1216,8 @@ ColorPicker::ColorPicker() :
 	hb_edit->add_child(wheel_edit);
 
 	wheel_mat.instance();
-	circle_mat.instance();
-
-	Ref<Shader> wheel_shader(memnew(Shader));
-	wheel_shader->set_code("shader_type canvas_item;const float TAU=6.28318530718;void fragment(){float x=UV.x-0.5;float y=UV.y-0.5;float a=atan(y,x);x+=0.001;y+=0.001;float b=float(sqrt(x*x+y*y)<0.5)*float(sqrt(x*x+y*y)>0.42);x-=0.002;float b2=float(sqrt(x*x+y*y)<0.5)*float(sqrt(x*x+y*y)>0.42);y-=0.002;float b3=float(sqrt(x*x+y*y)<0.5)*float(sqrt(x*x+y*y)>0.42);x+=0.002;float b4=float(sqrt(x*x+y*y)<0.5)*float(sqrt(x*x+y*y)>0.42);COLOR=vec4(clamp((abs(fract(((a-TAU)/TAU)+vec3(3.0,2.0,1.0)/3.0)*6.0-3.0)-1.0),0.0,1.0),(b+b2+b3+b4)/4.00);}");
 	wheel_mat->set_shader(wheel_shader);
-
-	Ref<Shader> circle_shader(memnew(Shader));
-	circle_shader->set_code("shader_type canvas_item;const float TAU=6.28318530718;uniform float v=1.0;void fragment(){float x=UV.x-0.5;float y=UV.y-0.5;float a=atan(y,x);x+=0.001;y+=0.001;float b=float(sqrt(x*x+y*y)<0.5);x-=0.002;float b2=float(sqrt(x*x+y*y)<0.5);y-=0.002;float b3=float(sqrt(x*x+y*y)<0.5);x+=0.002;float b4=float(sqrt(x*x+y*y)<0.5);COLOR=vec4(mix(vec3(1.0),clamp(abs(fract(vec3((a-TAU)/TAU)+vec3(1.0,2.0/3.0,1.0/3.0))*6.0-vec3(3.0))-vec3(1.0),0.0,1.0),((float(sqrt(x*x+y*y))*2.0))/1.0)*vec3(v),(b+b2+b3+b4)/4.00);}");
+	circle_mat.instance();
 	circle_mat->set_shader(circle_shader);
 
 	MarginContainer *wheel_margin(memnew(MarginContainer));

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -56,6 +56,9 @@ public:
 	};
 
 private:
+	static Ref<Shader> wheel_shader;
+	static Ref<Shader> circle_shader;
+
 	Control *screen = nullptr;
 	Control *uv_edit = memnew(Control);
 	Control *w_edit = memnew(Control);
@@ -128,6 +131,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	static void init_shaders();
+	static void finish_shaders();
+
 	void set_edit_alpha(bool p_show);
 	bool is_editing_alpha() const;
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -979,6 +979,7 @@ void register_scene_types() {
 	// Always make the default theme to avoid invalid default font/icon/style in the given theme.
 	if (RenderingServer::get_singleton()) {
 		make_default_theme(default_theme_hidpi, font);
+		ColorPicker::init_shaders(); // RenderingServer needs to exist for this to succeed.
 	}
 
 	if (theme_path != String()) {
@@ -1035,5 +1036,6 @@ void unregister_scene_types() {
 
 	ParticlesMaterial::finish_shaders();
 	CanvasItemMaterial::finish_shaders();
+	ColorPicker::finish_shaders();
 	SceneStringNames::free();
 }


### PR DESCRIPTION
As discovered by @pycbouh, the recent inspector slowdows were introduced by #46340. Turns out that each ColorPicker was compiling shaders when it was created, which was terribly slow.

This PR moves the shader compilation to a static method, so it's done only once.