### PR TITLE
Check for valid DynamicFontData before duplicate in Editor

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -830,7 +830,9 @@ Ref<Texture> EditorFontPreviewPlugin::generate_from_path(const String &p_path, c
 	sampled_font.instance();
 	if (res->is_class("DynamicFont")) {
 		Ref<DynamicFont> font = res;
-		sampled_font->set_font_data(font->get_font_data()->duplicate());
+		if (font->get_font_data().is_valid()) {
+			sampled_font->set_font_data(font->get_font_data()->duplicate());
+		}
 		for (int i = 0; i < font->get_fallback_count(); i++) {
 			sampled_font->add_fallback(font->get_fallback(i)->duplicate());
 		}


### PR DESCRIPTION
Proposed fix for issue #48674

Adds a check for valid DynamicFontData before attempting to duplicate it when creating the Editor preview.

This is a re-submission of pull request #48675 due to issues with the forked repository

*Bugsquad edit:* fixes #48674