### PR TITLE
Fix `InputMap.action_erase_event()` failing to erase events correctly.

### DIFF
--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -142,7 +142,8 @@ public:
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const;
-	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
+	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const;
+
 	virtual bool is_action_type() const;
 
 	virtual bool accumulate(const Ref<InputEvent> &p_event) { return false; }
@@ -212,6 +213,8 @@ public:
 
 	void set_modifiers_from_event(const InputEventWithModifiers *event);
 
+	uint32_t get_modifiers_mask() const;
+
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
@@ -252,7 +255,7 @@ public:
 	uint32_t get_physical_keycode_with_modifiers() const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const override;
-	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const override;
+	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const override;
 
 	virtual bool is_action_type() const override { return true; }
 
@@ -313,7 +316,9 @@ public:
 	bool is_double_click() const;
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
+
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const override;
+	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const override;
 
 	virtual bool is_action_type() const override { return true; }
 	virtual String as_text() const override;
@@ -373,6 +378,7 @@ public:
 	virtual bool is_pressed() const override;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const override;
+	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const override;
 
 	virtual bool is_action_type() const override { return true; }
 	virtual String as_text() const override;
@@ -401,9 +407,10 @@ public:
 	float get_pressure() const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const override;
-	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const override;
+	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const override;
 
 	virtual bool is_action_type() const override { return true; }
+
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
@@ -491,9 +498,10 @@ public:
 	virtual bool is_action(const StringName &p_action) const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const override;
+	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const override;
 
-	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const override;
 	virtual bool is_action_type() const override { return true; }
+
 	virtual String as_text() const override;
 	virtual String to_string() override;
 

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -130,12 +130,9 @@ List<Ref<InputEvent>>::Element *InputMap::_find_event(Action &p_action, const Re
 	for (List<Ref<InputEvent>>::Element *E = p_action.inputs.front(); E; E = E->next()) {
 		const Ref<InputEvent> e = E->get();
 
-		//if (e.type != Ref<InputEvent>::KEY && e.device != p_event.device) -- unsure about the KEY comparison, why is this here?
-		//	continue;
-
 		int device = e->get_device();
 		if (device == ALL_DEVICES || device == p_event->get_device()) {
-			if (p_exact_match && e->shortcut_match(p_event)) {
+			if (p_exact_match && e->is_match(p_event, true)) {
 				return E;
 			} else if (!p_exact_match && e->action_match(p_event, p_pressed, p_strength, p_raw_strength, p_action.deadzone)) {
 				return E;

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -90,20 +90,23 @@
 				Returns [code]true[/code] if this input event is an echo event (only for events of type [InputEventKey]).
 			</description>
 		</method>
+		<method name="is_match" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="event" type="InputEvent">
+			</argument>
+			<argument index="1" name="exact_match" type="bool" default="true">
+			</argument>
+			<description>
+				Returns [code]true[/code] if the specified [code]event[/code] matches this event. Only valid for action events i.e key ([InputEventKey]), button ([InputEventMouseButton] or [InputEventJoypadButton]), axis [InputEventJoypadMotion] or action ([InputEventAction]) events.
+				If [code]exact_match[/code] is [code]false[/code], it ignores the input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+			</description>
+		</method>
 		<method name="is_pressed" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
 				Returns [code]true[/code] if this input event is pressed. Not relevant for events of type [InputEventMouseMotion] or [InputEventScreenDrag].
-			</description>
-		</method>
-		<method name="shortcut_match" qualifiers="const">
-			<return type="bool">
-			</return>
-			<argument index="0" name="event" type="InputEvent">
-			</argument>
-			<description>
-				Returns [code]true[/code] if the given input event is checking for the same key ([InputEventKey]), button ([InputEventJoypadButton]) or action ([InputEventAction]).
 			</description>
 		</method>
 		<method name="xformed_by" qualifiers="const">

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1709,7 +1709,7 @@ void EditorSettings::set_builtin_action_override(const String &p_name, const Arr
 
 			// Check equality of each event.
 			for (List<Ref<InputEvent>>::Element *E = builtin_events.front(); E; E = E->next()) {
-				if (!E->get()->shortcut_match(p_events[event_idx])) {
+				if (!E->get()->is_match(p_events[event_idx])) {
 					same_as_builtin = false;
 					break;
 				}

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -289,7 +289,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 			event_strings.push_back(I->get()->as_text());
 
 			// Only check if the events have been the same so far - once one fails, we don't need to check any more.
-			if (same_as_defaults && !key_default_events[count]->shortcut_match(I->get())) {
+			if (same_as_defaults && !key_default_events[count]->is_match(I->get())) {
 				same_as_defaults = false;
 			}
 			count++;

--- a/scene/gui/shortcut.cpp
+++ b/scene/gui/shortcut.cpp
@@ -42,7 +42,7 @@ Ref<InputEvent> Shortcut::get_shortcut() const {
 }
 
 bool Shortcut::is_shortcut(const Ref<InputEvent> &p_event) const {
-	return shortcut.is_valid() && shortcut->shortcut_match(p_event);
+	return shortcut.is_valid() && shortcut->is_match(p_event, true);
 }
 
 String Shortcut::get_as_text() const {


### PR DESCRIPTION
Fixes #47965
Fixes #48692

Also fixes modifiers not currently working with `InputEventMouseButton` events.

Breaks compat, because it includes renaming `shortcut_match()` to `is_match()`, which better reflects what the function is now doing.