### PR TITLE
Handle having no sinks in the PulseAudio driver.

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -89,7 +89,7 @@ class AudioDriverPulseAudio : public AudioDriver {
 	Error capture_init_device();
 	void capture_finish_device();
 
-	void detect_channels(bool capture = false);
+	Error detect_channels(bool capture = false);
 
 	static void thread_func(void *p_udata);
 


### PR DESCRIPTION
Also make PulseAudio errors more verbose.

This fixes #48677. It handles starting with no sinks connected, enables automatically connecting to a new sink, and handles all sinks being disconnected.