### PR TITLE
SCons: Abort if SCRIPT_AES256_ENCRYPTION_KEY is invalid

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -12,25 +12,28 @@ import os
 
 txt = "0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0"
 if "SCRIPT_AES256_ENCRYPTION_KEY" in os.environ:
-    e = os.environ["SCRIPT_AES256_ENCRYPTION_KEY"]
-    txt = ""
+    key = os.environ["SCRIPT_AES256_ENCRYPTION_KEY"]
     ec_valid = True
-    if len(e) != 64:
+    if len(key) != 64:
         ec_valid = False
     else:
-
+        txt = ""
         for i in range(len(e) >> 1):
             if i > 0:
                 txt += ","
-            txts = "0x" + e[i * 2 : i * 2 + 2]
+            txts = "0x" + key[i * 2 : i * 2 + 2]
             try:
                 int(txts, 16)
             except Exception:
                 ec_valid = False
             txt += txts
     if not ec_valid:
-        txt = "0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0"
-        print("Invalid AES256 encryption key, not 64 bits hex: " + e)
+        print("Error: Invalid AES256 encryption key, not 64 hexadecimal characters: '" + key + "'.")
+        print(
+            "Unset 'SCRIPT_AES256_ENCRYPTION_KEY' in your environment "
+            "or make sure that it contains exactly 64 hexadecimal characters."
+        )
+        Exit(255)
 
 # NOTE: It is safe to generate this file here, since this is still executed serially
 with open("script_encryption_key.gen.cpp", "w") as f:


### PR DESCRIPTION
Helps users figure out that something is wrong if they did define this
environment variable and it turns out being ignored.