### PR TITLE
Fix display of programmatically created value in remote inspector

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -367,7 +367,7 @@ void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 
 		PropertyHint hint = pi.hint;
 		String hint_string = pi.hint_string;
-		if (!res.is_null()) {
+		if (!res.is_null() && !res->get_path().is_empty()) {
 			var = res->get_path();
 		} else { //only send information that can be sent..
 			int len = 0; //test how big is this to encode


### PR DESCRIPTION
`4.0` version of #44657.

Can anyone confirm the fix with a minimal reproduction project?