### PR TITLE
Fixed build with SCRIPT_AES256_ENCRYPTION_KEY set

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -18,7 +18,7 @@ if "SCRIPT_AES256_ENCRYPTION_KEY" in os.environ:
         ec_valid = False
     else:
         txt = ""
-        for i in range(len(e) >> 1):
+        for i in range(len(key) >> 1):
             if i > 0:
                 txt += ","
             txts = "0x" + key[i * 2 : i * 2 + 2]


### PR DESCRIPTION
This just fixes an oversight while renaming a variable in #48715. It caused the build to fail.