### PR TITLE
Add a keyboard shortcut to select the word under cursor in TextEdit

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -353,6 +353,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
     { "ui_text_scroll_down",                           TTRC("Scroll Down") },
     { "ui_text_scroll_down.OSX",                       TTRC("Scroll Down") },
     { "ui_text_select_all",                            TTRC("Select All") },
+    { "ui_text_select_word_under_caret",              TTRC("Select Word Under Caret") },
     { "ui_text_toggle_insert_mode",                    TTRC("Toggle Insert Mode") },
     { "ui_graph_duplicate",                            TTRC("Duplicate Nodes") },
     { "ui_graph_delete",                               TTRC("Delete Nodes") },
@@ -649,6 +650,10 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_A | KEY_MASK_CMD));
 	default_builtin_cache.insert("ui_text_select_all", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(KEY_D | KEY_MASK_CMD));
+	default_builtin_cache.insert("ui_text_select_word_under_caret", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_INSERT));

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -732,6 +732,10 @@
 		</member>
 		<member name="input/ui_text_select_all" type="Dictionary" setter="" getter="">
 		</member>
+		<member name="input/ui_text_select_word_under_caret" type="Dictionary" setter="" getter="">
+			If no selection is currently active, selects the word currently under the caret in text fields. If a selection is currently active, deselects the current selection.
+			[b]Note:[/b] Currently, this is only implemented in [TextEdit], not [LineEdit].
+		</member>
 		<member name="input/ui_text_toggle_insert_mode" type="Dictionary" setter="" getter="">
 		</member>
 		<member name="input/ui_undo" type="Dictionary" setter="" getter="">

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1896,7 +1896,7 @@ void ScriptTextEditor::register_editor() {
 #ifdef OSX_ENABLED
 	ED_SHORTCUT("script_text_editor/clone_down", TTR("Clone Down"), KEY_MASK_SHIFT | KEY_MASK_CMD | KEY_C);
 #else
-	ED_SHORTCUT("script_text_editor/clone_down", TTR("Clone Down"), KEY_MASK_CMD | KEY_D);
+	ED_SHORTCUT("script_text_editor/clone_down", TTR("Clone Down"), KEY_MASK_SHIFT | KEY_MASK_CMD | KEY_D);
 #endif
 	ED_SHORTCUT("script_text_editor/evaluate_selection", TTR("Evaluate Selection"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_E);
 	ED_SHORTCUT("script_text_editor/trim_trailing_whitespace", TTR("Trim Trailing Whitespace"), KEY_MASK_CMD | KEY_MASK_ALT | KEY_T);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -731,6 +731,7 @@ public:
 	void copy();
 	void paste();
 	void select_all();
+	void select_word_under_caret();
 	void select(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
 	void deselect();
 	void swap_lines(int line1, int line2);


### PR DESCRIPTION
You can use this shortcut to quickly replace a word in a script. It works in a way similar to Visual Studio Code's <kbd>Ctrl + D</kbd> shortcut, although it can't select multiple words due to support for multiple cursors not being implemented yet.

This also acts as a general-purpose "deselect" shortcut since pressing it a second time will deselect text.

This is available both in the script editor and in TextEdit fields in use, both in the editor and projects.

The Duplicate Line script editor shortcut was moved to <kbd>Ctrl + Shift + D</kbd> since it conflicts with the new shortcut (<kbd>Ctrl + D</kbd>). The rationale for doing so is that Duplicate Line is a less commonly used action, and its behavior can be replicated by copying and pasting the current line anyway. (With no selection active, the whole line will be copied.)

The feature isn't implemented in LineEdit yet, but it's likely to be feasible there as well (perhaps for a future PR).

This closes https://github.com/godotengine/godot-proposals/issues/2134.

## Preview

*While visible, the mouse isn't used here at any point in time.*

https://user-images.githubusercontent.com/180032/118371117-5e3ca580-b5ab-11eb-8692-efedbaab3b96.mp4