### PR TITLE
Make several actions in the Inspector dock more obvious

### DIFF
--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -59,13 +59,38 @@ void EditorPath::_add_children_to_popup(Object *p_obj, int p_depth) {
 
 		Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(obj);
 
-		int index = get_popup()->get_item_count();
-		get_popup()->add_icon_item(icon, E->get().name.capitalize(), objects.size());
-		get_popup()->set_item_h_offset(index, p_depth * 10 * EDSCALE);
+		String proper_name = "";
+		Vector<String> name_parts = E->get().name.split("/");
+
+		for (int i = 0; i < name_parts.size(); i++) {
+			if (i > 0) {
+				proper_name += " > ";
+			}
+			proper_name += name_parts[i].capitalize();
+		}
+
+		int index = sub_objects_menu->get_item_count();
+		sub_objects_menu->add_icon_item(icon, proper_name, objects.size());
+		sub_objects_menu->set_item_h_offset(index, p_depth * 10 * EDSCALE);
 		objects.push_back(obj->get_instance_id());
 
 		_add_children_to_popup(obj, p_depth + 1);
 	}
+}
+
+void EditorPath::_show_popup() {
+	sub_objects_menu->clear();
+
+	Size2 size = get_size();
+	Point2 gp = get_screen_position();
+	gp.y += size.y;
+
+	sub_objects_menu->set_position(gp);
+	sub_objects_menu->set_size(Size2(size.width, 1));
+	sub_objects_menu->set_parent_rect(Rect2(Point2(gp - sub_objects_menu->get_position()), size));
+
+	sub_objects_menu->take_mouse_focus();
+	sub_objects_menu->popup();
 }
 
 void EditorPath::_about_to_show() {
@@ -75,13 +100,11 @@ void EditorPath::_about_to_show() {
 	}
 
 	objects.clear();
-	get_popup()->clear();
-	get_popup()->set_size(Size2(get_size().width, 1));
 
 	_add_children_to_popup(obj);
-	if (get_popup()->get_item_count() == 0) {
-		get_popup()->add_item(TTR("No sub-resources found."));
-		get_popup()->set_item_disabled(0, true);
+	if (sub_objects_menu->get_item_count() == 0) {
+		sub_objects_menu->add_item(TTR("No sub-resources found."));
+		sub_objects_menu->set_item_disabled(0, true);
 	}
 }
 
@@ -94,7 +117,7 @@ void EditorPath::update_path() {
 
 		Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(obj);
 		if (icon.is_valid()) {
-			set_icon(icon);
+			current_object_icon->set_texture(icon);
 		}
 
 		if (i == history->get_path_size() - 1) {
@@ -120,10 +143,24 @@ void EditorPath::update_path() {
 				name = obj->get_class();
 			}
 
-			set_text(" " + name); // An extra space so the text is not too close of the icon.
+			current_object_label->set_text(" " + name); // An extra space so the text is not too close of the icon.
 			set_tooltip(obj->get_class());
 		}
 	}
+}
+
+void EditorPath::clear_path() {
+	set_disabled(true);
+	set_tooltip("");
+
+	current_object_label->set_text("");
+	current_object_icon->set_texture(nullptr);
+	sub_objects_icon->set_visible(false);
+}
+
+void EditorPath::enable_path() {
+	set_disabled(false);
+	sub_objects_icon->set_visible(true);
 }
 
 void EditorPath::_id_pressed(int p_idx) {
@@ -139,8 +176,16 @@ void EditorPath::_id_pressed(int p_idx) {
 
 void EditorPath::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			update_path();
+
+			sub_objects_icon->set_texture(get_theme_icon("select_arrow", "Tree"));
+			current_object_label->add_theme_font_override("font", get_theme_font("main", "EditorFonts"));
+		} break;
+
+		case NOTIFICATION_READY: {
+			connect("pressed", callable_mp(this, &EditorPath::_show_popup));
 		} break;
 	}
 }
@@ -150,8 +195,35 @@ void EditorPath::_bind_methods() {
 
 EditorPath::EditorPath(EditorHistory *p_history) {
 	history = p_history;
-	set_clip_text(true);
-	set_text_align(ALIGN_LEFT);
-	get_popup()->connect("about_to_popup", callable_mp(this, &EditorPath::_about_to_show));
-	get_popup()->connect("id_pressed", callable_mp(this, &EditorPath::_id_pressed));
+
+	MarginContainer *main_mc = memnew(MarginContainer);
+	main_mc->set_anchors_and_offsets_preset(PRESET_WIDE);
+	main_mc->add_theme_constant_override("margin_left", 4 * EDSCALE);
+	main_mc->add_theme_constant_override("margin_right", 6 * EDSCALE);
+	add_child(main_mc);
+
+	HBoxContainer *main_hb = memnew(HBoxContainer);
+	main_mc->add_child(main_hb);
+
+	current_object_icon = memnew(TextureRect);
+	current_object_icon->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
+	main_hb->add_child(current_object_icon);
+
+	current_object_label = memnew(Label);
+	current_object_label->set_clip_text(true);
+	current_object_label->set_align(Label::ALIGN_LEFT);
+	current_object_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	main_hb->add_child(current_object_label);
+
+	sub_objects_icon = memnew(TextureRect);
+	sub_objects_icon->set_visible(false);
+	sub_objects_icon->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
+	main_hb->add_child(sub_objects_icon);
+
+	sub_objects_menu = memnew(PopupMenu);
+	add_child(sub_objects_menu);
+	sub_objects_menu->connect("about_to_popup", callable_mp(this, &EditorPath::_about_to_show));
+	sub_objects_menu->connect("id_pressed", callable_mp(this, &EditorPath::_id_pressed));
+
+	set_tooltip(TTR("Open a list of sub-resources."));
 }

--- a/editor/editor_path.h
+++ b/editor/editor_path.h
@@ -32,16 +32,24 @@
 #define EDITOR_PATH_H
 
 #include "editor_data.h"
-#include "scene/gui/menu_button.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/popup_menu.h"
 
-class EditorPath : public MenuButton {
-	GDCLASS(EditorPath, MenuButton);
+class EditorPath : public Button {
+	GDCLASS(EditorPath, Button);
 
 	EditorHistory *history;
+
+	TextureRect *current_object_icon;
+	Label *current_object_label;
+	TextureRect *sub_objects_icon;
+	PopupMenu *sub_objects_menu;
 
 	Vector<ObjectID> objects;
 	EditorPath();
 
+	void _show_popup();
 	void _id_pressed(int p_idx);
 	void _about_to_show();
 	void _add_children_to_popup(Object *p_obj, int p_depth = 0);
@@ -52,6 +60,8 @@ protected:
 
 public:
 	void update_path();
+	void clear_path();
+	void enable_path();
 
 	EditorPath(EditorHistory *p_history);
 };

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -81,9 +81,11 @@ class InspectorDock : public VBoxContainer {
 	Button *resource_new_button;
 	Button *resource_load_button;
 	MenuButton *resource_save_button;
+	MenuButton *resource_extra_button;
 	MenuButton *history_menu;
 	LineEdit *search;
 
+	Button *open_docs_button;
 	MenuButton *object_menu;
 	EditorPath *editor_path;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2047, and also adjusts the looks of the top part of the Inspector dock to make other actions available more obvious.

![godot windows tools 64_2021-06-04_02-07-00](https://user-images.githubusercontent.com/11782833/120723179-ebec2080-c4d9-11eb-9ac9-2c437a1bd278.png)
*[Original version](https://user-images.githubusercontent.com/11782833/118374473-ea0efb80-b5c4-11eb-8601-1d85d203f594.png)*

Here it is in action:

https://user-images.githubusercontent.com/11782833/120723078-b0e9ed00-c4d9-11eb-955e-b38067f837ed.mp4

*[Original version](https://user-images.githubusercontent.com/11782833/118374477-ee3b1900-b5c4-11eb-8aee-53546076326f.mp4)*

1. Clickability of the current object's name was made obvious, with a non-flat button design and an arrow at the right end.
2. Extra tools menu was reorganized to only include things that make sense for properties, as the button was called "Object properties" and we have a better place for object-specific actions at the top. The button itself was moved next to the properties filter.
3. Therefore object-specific actions were added to the topmost bar; and "Save"/"Save as" was removed from the context menu because it already exists in the topmost bar.
4. Several names, tooltips and texts were adjusted to better reflect their actions. 
5. The list of sub-resources had its name capitalization logic improved.
6. ~The `PopupMenu` for sub-resources was made a bit shorter than full width to give user an ability to see and click the dock underneath. Especially important for huge sub-resource holders, [like themes](https://user-images.githubusercontent.com/11782833/118375306-a2d73980-b5c9-11eb-904e-98c82cfbcada.png).~ This change was reverted (but still present in the clip; so imagine the popup at the button's width when you watch it).

-----
Should be possible to cherrypick this to the stable branch.