### PR TITLE
Fix negative arguments not allowed in @export_range

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1326,6 +1326,8 @@ GDScriptTokenizer::Token GDScriptTokenizer::scan() {
 			if (_peek() == '=') {
 				_advance();
 				return make_token(Token::PLUS_EQUAL);
+			} else if (_is_digit(_peek())) {
+				return number();
 			} else {
 				return make_token(Token::PLUS);
 			}
@@ -1336,6 +1338,8 @@ GDScriptTokenizer::Token GDScriptTokenizer::scan() {
 			} else if (_peek() == '>') {
 				_advance();
 				return make_token(Token::FORWARD_ARROW);
+			} else if (_is_digit(_peek())) {
+				return number();
 			} else {
 				return make_token(Token::MINUS);
 			}


### PR DESCRIPTION
Closes #41183

In the GDScript tokenizer, when detecting a + (plus) or - (minus), it will peek the following character and if it is a digit, the whole expression will be treated as a number (LITERAL), instead of an UNARY_OP (minus) containing a LITERAL.
