### PR TITLE
Tweak highlight color in the editor Find in Files dialog

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -763,8 +763,10 @@ void FindInFilesPanel::draw_result_text(Object *item_obj, Rect2 rect) {
 	match_rect.position.y += 1 * EDSCALE;
 	match_rect.size.y -= 2 * EDSCALE;
 
-	_results_display->draw_rect(match_rect, Color(0, 0, 0, 0.5));
-	// Text is drawn by Tree already
+	// Use the inverted accent color to help match rectangles stand out even on the currently selected line.
+	_results_display->draw_rect(match_rect, get_theme_color("accent_color", "Editor").inverted() * Color(1, 1, 1, 0.5));
+
+	// Text is drawn by Tree already.
 }
 
 void FindInFilesPanel::_on_item_edited() {


### PR DESCRIPTION
The new color is more visible against dark backgrounds.

## Preview

***Note:** The selected line highlight is too strong because it's drawn twice. This bug is unrelated to this PR.*

### Dark theme

![image](https://user-images.githubusercontent.com/180032/118379837-efc50b00-b5dd-11eb-85d5-6bf6372d8fe7.png)

### Light theme

![image](https://user-images.githubusercontent.com/180032/118379851-05d2cb80-b5de-11eb-8e5c-99896aed5a4e.png)

