### PR TITLE
Fix property selector not displaying certain properties/methods

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3470,6 +3470,9 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 
 				EditorPropertyMember::Type type = EditorPropertyMember::MEMBER_METHOD_OF_BASE_TYPE;
 				switch (p_hint) {
+					case PROPERTY_HINT_METHOD_OF_VARIANT_TYPE:
+						type = EditorPropertyMember::MEMBER_METHOD_OF_VARIANT_TYPE;
+						break;
 					case PROPERTY_HINT_METHOD_OF_BASE_TYPE:
 						type = EditorPropertyMember::MEMBER_METHOD_OF_BASE_TYPE;
 						break;

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -167,7 +167,7 @@ void PropertySelector::_update_search() {
 				continue;
 			}
 
-			if (!(E->get().usage & PROPERTY_USAGE_EDITOR) && !(E->get().usage & PROPERTY_USAGE_SCRIPT_VARIABLE)) {
+			if (!(E->get().usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE)) && (E->get().usage & (PROPERTY_USAGE_GROUP | PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_INTERNAL))) {
 				continue;
 			}
 

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -152,7 +152,7 @@ void VisualScriptPropertySelector::_update_search() {
 				}
 			}
 			for (List<PropertyInfo>::Element *F = props.front(); F; F = F->next()) {
-				if (!(F->get().usage & PROPERTY_USAGE_EDITOR) && !(F->get().usage & PROPERTY_USAGE_SCRIPT_VARIABLE)) {
+				if (!(F->get().usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE)) && (F->get().usage & (PROPERTY_USAGE_GROUP | PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_INTERNAL))) {
 					continue;
 				}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #47837
Fixes #28136

This pull request fixes several issues where PropertySelector was not showing properties/functions that you would reasonably expect to find.

Should be cherry-pickable for 3.3 and 3.x.

<i>Bugsquad edit</i>: + Fixes #49062

---

Update:
Here are screenshots demonstrating these changes. (Shown in 3.x but should be the same in 4.0/master)

<details>
<summary>Property Selector</summary>
Before:

![image](https://user-images.githubusercontent.com/6376721/119894328-7812ac80-bf0a-11eb-8c79-4951bfdcbe99.png)

And after:
![image](https://user-images.githubusercontent.com/6376721/119893073-ef474100-bf08-11eb-8cdd-4bbfa9e4d636.png)
</details>

<details>
<summary>Select method on variant/basic type</summary>
Before:

![image](https://user-images.githubusercontent.com/6376721/119894387-8a8ce600-bf0a-11eb-9dc3-ee6d84281496.png)

And after:
![image](https://user-images.githubusercontent.com/6376721/119893393-4baa6080-bf09-11eb-8c08-427f644d3317.png)
</details>

<details>
<summary>Visual script property selector</summary>
Before:

![image](https://user-images.githubusercontent.com/6376721/119894422-94aee480-bf0a-11eb-8147-14b2a7fe50e0.png)

And after:
![image](https://user-images.githubusercontent.com/6376721/119892970-c8890a80-bf08-11eb-90ce-776db46a86bb.png)
</details>