### PR TITLE
Fix Tree::get_column_at_position crash

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4334,6 +4334,8 @@ Tree::Tree() {
 	set_mouse_filter(MOUSE_FILTER_STOP);
 
 	set_clip_contents(true);
+
+	update_cache();
 }
 
 Tree::~Tree() {


### PR DESCRIPTION
This PR fixes #48741.

The `get_column_at_position` and `get_drop_section_at_position` methods rely on `cache`. But the cache won't update until the node enters the tree. Thus a null pointer access is triggered if these methods are called before `add_child`.

This PR updates the cache once at the end of the constructor. This approach is also [used](https://github.com/godotengine/godot/blob/c3002c09554b4a398cde09be3788dda3bd5e0503/scene/gui/text_edit.cpp#L7081) by `TextEdit`.

Tested on master(c3002c0955) and 3.x(74174676b8).