### PR TITLE
Fix accessing scene tree without checking: MeshInstance3D::create_debug_tangents, GIProbe::bake

### DIFF
--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -454,7 +454,7 @@ void GIProbe::bake(Node *p_from_node, bool p_create_visual_debug) {
 		mmi->set_multimesh(baker.create_debug_multimesh());
 		add_child(mmi);
 #ifdef TOOLS_ENABLED
-		if (get_tree()->get_edited_scene_root() == this) {
+		if (is_inside_tree() && get_tree()->get_edited_scene_root() == this) {
 			mmi->set_owner(this);
 		} else {
 			mmi->set_owner(get_owner());

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -427,7 +427,7 @@ void MeshInstance3D::create_debug_tangents() {
 		add_child(mi);
 #ifdef TOOLS_ENABLED
 
-		if (this == get_tree()->get_edited_scene_root()) {
+		if (is_inside_tree() && this == get_tree()->get_edited_scene_root()) {
 			mi->set_owner(this);
 		} else {
 			mi->set_owner(get_owner());


### PR DESCRIPTION
Fixes #48755.
Fixes similar issue when executing `GIProbe.new().bake(self, true)`.
Cherry-pickable `3.x`, `3.3`.