### PR TITLE
Upgrade the autocomplete for VisualScriptFunctionCall.

### DIFF
--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -231,15 +231,12 @@ PropertyInfo VisualScriptFunctionCall::get_output_value_port_info(int p_idx) con
 
 		PropertyInfo ret;
 
-		/*MethodBind *mb = ClassDB::get_method(_get_base_type(),function);
+		MethodBind *mb = ClassDB::get_method(_get_base_type(), function);
 		if (mb) {
-
-			ret = mb->get_argument_info(-1);
-		} else {*/
-
-		ret = method_cache.return_val;
-
-		//}
+			ret = mb->get_return_info();
+		} else {
+			ret = method_cache.return_val;
+		}
 
 		if (call_mode == CALL_MODE_INSTANCE) {
 			ret.name = "return";


### PR DESCRIPTION
When dragging out return value.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

De-comment and fix the output port hint for VisualScriptFunctionCall
