### PR TITLE
Make all file access 64-bit (`uint64_t`)

### DIFF
--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -390,8 +390,8 @@ public:
 
 	void seek(int64_t p_position); // Seek to a given position.
 	void seek_end(int64_t p_position = 0); // Seek from the end of file.
-	int64_t get_position() const; // Get position in the file.
-	int64_t get_len() const; // Get size of the file.
+	uint64_t get_position() const; // Get position in the file.
+	uint64_t get_len() const; // Get size of the file.
 
 	bool eof_reached() const; // Reading passed EOF.
 
@@ -406,7 +406,7 @@ public:
 
 	Variant get_var(bool p_allow_objects = false) const;
 
-	Vector<uint8_t> get_buffer(int p_length) const; // Get an array of bytes.
+	Vector<uint8_t> get_buffer(int64_t p_length) const; // Get an array of bytes.
 	String get_line() const;
 	Vector<String> get_csv_line(const String &p_delim = ",") const;
 	String get_as_text() const;
@@ -486,7 +486,7 @@ public:
 	bool file_exists(String p_file);
 	bool dir_exists(String p_dir);
 
-	int get_space_left();
+	uint64_t get_space_left();
 
 	Error copy(String p_from, String p_to);
 	Error rename(String p_from, String p_to);

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -32,7 +32,7 @@
 
 #include "core/string/print_string.h"
 
-void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_mode, int p_block_size) {
+void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_mode, uint32_t p_block_size) {
 	magic = p_magic.ascii().get_data();
 	if (magic.length() > 4) {
 		magic = magic.substr(0, 4);
@@ -67,10 +67,10 @@ Error FileAccessCompressed::open_after_magic(FileAccess *p_base) {
 		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Can't open compressed file '" + p_base->get_path() + "' with block size 0, it is corrupted.");
 	}
 	read_total = f->get_32();
-	int bc = (read_total / block_size) + 1;
-	int acc_ofs = f->get_position() + bc * 4;
-	int max_bs = 0;
-	for (int i = 0; i < bc; i++) {
+	uint32_t bc = (read_total / block_size) + 1;
+	uint64_t acc_ofs = f->get_position() + bc * 4;
+	uint32_t max_bs = 0;
+	for (uint32_t i = 0; i < bc; i++) {
 		ReadBlock rb;
 		rb.offset = acc_ofs;
 		rb.csize = f->get_32();
@@ -148,15 +148,15 @@ void FileAccessCompressed::close() {
 		f->store_32(cmode); //write compression mode 4
 		f->store_32(block_size); //write block size 4
 		f->store_32(write_max); //max amount of data written 4
-		int bc = (write_max / block_size) + 1;
+		uint32_t bc = (write_max / block_size) + 1;
 
-		for (int i = 0; i < bc; i++) {
+		for (uint32_t i = 0; i < bc; i++) {
 			f->store_32(0); //compressed sizes, will update later
 		}
 
 		Vector<int> block_sizes;
-		for (int i = 0; i < bc; i++) {
-			int bl = i == (bc - 1) ? write_max % block_size : block_size;
+		for (uint32_t i = 0; i < bc; i++) {
+			uint32_t bl = i == (bc - 1) ? write_max % block_size : block_size;
 			uint8_t *bp = &write_ptr[i * block_size];
 
 			Vector<uint8_t> cblock;
@@ -168,7 +168,7 @@ void FileAccessCompressed::close() {
 		}
 
 		f->seek(16); //ok write block sizes
-		for (int i = 0; i < bc; i++) {
+		for (uint32_t i = 0; i < bc; i++) {
 			f->store_32(block_sizes[i]);
 		}
 		f->seek_end();
@@ -190,8 +190,9 @@ bool FileAccessCompressed::is_open() const {
 	return f != nullptr;
 }
 
-void FileAccessCompressed::seek(size_t p_position) {
+void FileAccessCompressed::seek(uint64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
+
 	if (writing) {
 		ERR_FAIL_COND(p_position > write_max);
 
@@ -204,7 +205,7 @@ void FileAccessCompressed::seek(size_t p_position) {
 		} else {
 			at_end = false;
 			read_eof = false;
-			int block_idx = p_position / block_size;
+			uint32_t block_idx = p_position / block_size;
 			if (block_idx != read_block) {
 				read_block = block_idx;
 				f->seek(read_blocks[read_block].offset);
@@ -227,7 +228,7 @@ void FileAccessCompressed::seek_end(int64_t p_position) {
 	}
 }
 
-size_t FileAccessCompressed::get_position() const {
+uint64_t FileAccessCompressed::get_position() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	if (writing) {
 		return write_pos;
@@ -236,7 +237,7 @@ size_t FileAccessCompressed::get_position() const {
 	}
 }
 
-size_t FileAccessCompressed::get_len() const {
+uint64_t FileAccessCompressed::get_len() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	if (writing) {
 		return write_max;
@@ -285,9 +286,8 @@ uint8_t FileAccessCompressed::get_8() const {
 	return ret;
 }
 
-int FileAccessCompressed::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessCompressed::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V_MSG(!f, -1, "File must be opened before use.");
 	ERR_FAIL_COND_V_MSG(writing, -1, "File has not been opened in read mode.");
 
@@ -296,7 +296,7 @@ int FileAccessCompressed::get_buffer(uint8_t *p_dst, int p_length) const {
 		return 0;
 	}
 
-	for (int i = 0; i < p_length; i++) {
+	for (uint64_t i = 0; i < p_length; i++) {
 		p_dst[i] = read_ptr[read_pos];
 		read_pos++;
 		if (read_pos >= read_block_size) {

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -37,34 +37,34 @@
 class FileAccessCompressed : public FileAccess {
 	Compression::Mode cmode = Compression::MODE_ZSTD;
 	bool writing = false;
-	uint32_t write_pos = 0;
+	uint64_t write_pos = 0;
 	uint8_t *write_ptr = nullptr;
 	uint32_t write_buffer_size = 0;
-	uint32_t write_max = 0;
+	uint64_t write_max = 0;
 	uint32_t block_size = 0;
 	mutable bool read_eof = false;
 	mutable bool at_end = false;
 
 	struct ReadBlock {
-		int csize;
-		int offset;
+		uint32_t csize;
+		uint64_t offset;
 	};
 
 	mutable Vector<uint8_t> comp_buffer;
 	uint8_t *read_ptr = nullptr;
-	mutable int read_block = 0;
-	int read_block_count = 0;
-	mutable int read_block_size = 0;
-	mutable int read_pos = 0;
+	mutable uint32_t read_block = 0;
+	uint32_t read_block_count = 0;
+	mutable uint32_t read_block_size = 0;
+	mutable uint64_t read_pos = 0;
 	Vector<ReadBlock> read_blocks;
-	uint32_t read_total = 0;
+	uint64_t read_total = 0;
 
 	String magic = "GCMP";
 	mutable Vector<uint8_t> buffer;
 	FileAccess *f = nullptr;
 
 public:
-	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, int p_block_size = 4096);
+	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, uint32_t p_block_size = 4096);
 
 	Error open_after_magic(FileAccess *p_base);
 
@@ -72,15 +72,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -70,13 +70,13 @@ Error FileAccessEncrypted::open_and_parse(FileAccess *p_base, const Vector<uint8
 
 		base = p_base->get_position();
 		ERR_FAIL_COND_V(p_base->get_len() < base + length, ERR_FILE_CORRUPT);
-		uint32_t ds = length;
+		uint64_t ds = length;
 		if (ds % 16) {
 			ds += 16 - (ds % 16);
 		}
 		data.resize(ds);
 
-		uint32_t blen = p_base->get_buffer(data.ptrw(), ds);
+		uint64_t blen = p_base->get_buffer(data.ptrw(), ds);
 		ERR_FAIL_COND_V(blen != ds, ERR_FILE_CORRUPT);
 
 		{
@@ -141,7 +141,7 @@ void FileAccessEncrypted::release() {
 void FileAccessEncrypted::_release() {
 	if (writing) {
 		Vector<uint8_t> compressed;
-		size_t len = data.size();
+		uint64_t len = data.size();
 		if (len % 16) {
 			len += 16 - (len % 16);
 		}
@@ -198,9 +198,9 @@ String FileAccessEncrypted::get_path_absolute() const {
 	}
 }
 
-void FileAccessEncrypted::seek(size_t p_position) {
-	if (p_position > (size_t)data.size()) {
-		p_position = data.size();
+void FileAccessEncrypted::seek(uint64_t p_position) {
+	if (p_position > get_len()) {
+		p_position = get_len();
 	}
 
 	pos = p_position;
@@ -208,14 +208,14 @@ void FileAccessEncrypted::seek(size_t p_position) {
 }
 
 void FileAccessEncrypted::seek_end(int64_t p_position) {
-	seek(data.size() + p_position);
+	seek(get_len() + p_position);
 }
 
-size_t FileAccessEncrypted::get_position() const {
+uint64_t FileAccessEncrypted::get_position() const {
 	return pos;
 }
 
-size_t FileAccessEncrypted::get_len() const {
+uint64_t FileAccessEncrypted::get_len() const {
 	return data.size();
 }
 
@@ -225,7 +225,7 @@ bool FileAccessEncrypted::eof_reached() const {
 
 uint8_t FileAccessEncrypted::get_8() const {
 	ERR_FAIL_COND_V_MSG(writing, 0, "File has not been opened in read mode.");
-	if (pos >= data.size()) {
+	if (pos >= get_len()) {
 		eofed = true;
 		return 0;
 	}
@@ -235,13 +235,12 @@ uint8_t FileAccessEncrypted::get_8() const {
 	return b;
 }
 
-int FileAccessEncrypted::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessEncrypted::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V_MSG(writing, -1, "File has not been opened in read mode.");
 
-	int to_copy = MIN(p_length, data.size() - pos);
-	for (int i = 0; i < to_copy; i++) {
+	uint64_t to_copy = MIN(p_length, get_len() - pos);
+	for (uint64_t i = 0; i < to_copy; i++) {
 		p_dst[i] = data[pos++];
 	}
 
@@ -256,16 +255,16 @@ Error FileAccessEncrypted::get_error() const {
 	return eofed ? ERR_FILE_EOF : OK;
 }
 
-void FileAccessEncrypted::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccessEncrypted::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND_MSG(!writing, "File has not been opened in write mode.");
 
-	if (pos < data.size()) {
-		for (int i = 0; i < p_length; i++) {
+	if (pos < get_len()) {
+		for (uint64_t i = 0; i < p_length; i++) {
 			store_8(p_src[i]);
 		}
-	} else if (pos == data.size()) {
+	} else if (pos == get_len()) {
 		data.resize(pos + p_length);
-		for (int i = 0; i < p_length; i++) {
+		for (uint64_t i = 0; i < p_length; i++) {
 			data.write[pos + i] = p_src[i];
 		}
 		pos += p_length;
@@ -281,10 +280,10 @@ void FileAccessEncrypted::flush() {
 void FileAccessEncrypted::store_8(uint8_t p_dest) {
 	ERR_FAIL_COND_MSG(!writing, "File has not been opened in write mode.");
 
-	if (pos < data.size()) {
+	if (pos < get_len()) {
 		data.write[pos] = p_dest;
 		pos++;
-	} else if (pos == data.size()) {
+	} else if (pos == get_len()) {
 		data.push_back(p_dest);
 		pos++;
 	}

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -47,10 +47,10 @@ private:
 	Vector<uint8_t> key;
 	bool writing = false;
 	FileAccess *file = nullptr;
-	size_t base = 0;
-	size_t length = 0;
+	uint64_t base = 0;
+	uint64_t length = 0;
 	Vector<uint8_t> data;
-	mutable int pos = 0;
+	mutable uint64_t pos = 0;
 	mutable bool eofed = false;
 	bool use_magic = true;
 
@@ -68,21 +68,21 @@ public:
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -71,7 +71,7 @@ bool FileAccessMemory::file_exists(const String &p_name) {
 	return files && (files->find(name) != nullptr);
 }
 
-Error FileAccessMemory::open_custom(const uint8_t *p_data, int p_len) {
+Error FileAccessMemory::open_custom(const uint8_t *p_data, uint64_t p_len) {
 	data = (uint8_t *)p_data;
 	length = p_len;
 	pos = 0;
@@ -102,7 +102,7 @@ bool FileAccessMemory::is_open() const {
 	return data != nullptr;
 }
 
-void FileAccessMemory::seek(size_t p_position) {
+void FileAccessMemory::seek(uint64_t p_position) {
 	ERR_FAIL_COND(!data);
 	pos = p_position;
 }
@@ -112,12 +112,12 @@ void FileAccessMemory::seek_end(int64_t p_position) {
 	pos = length + p_position;
 }
 
-size_t FileAccessMemory::get_position() const {
+uint64_t FileAccessMemory::get_position() const {
 	ERR_FAIL_COND_V(!data, 0);
 	return pos;
 }
 
-size_t FileAccessMemory::get_len() const {
+uint64_t FileAccessMemory::get_len() const {
 	ERR_FAIL_COND_V(!data, 0);
 	return length;
 }
@@ -136,13 +136,12 @@ uint8_t FileAccessMemory::get_8() const {
 	return ret;
 }
 
-int FileAccessMemory::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessMemory::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V(!data, -1);
 
-	int left = length - pos;
-	int read = MIN(p_length, left);
+	uint64_t left = length - pos;
+	uint64_t read = MIN(p_length, left);
 
 	if (read < p_length) {
 		WARN_PRINT("Reading less data than requested");
@@ -168,9 +167,9 @@ void FileAccessMemory::store_8(uint8_t p_byte) {
 	data[pos++] = p_byte;
 }
 
-void FileAccessMemory::store_buffer(const uint8_t *p_src, int p_length) {
-	int left = length - pos;
-	int write = MIN(p_length, left);
+void FileAccessMemory::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	uint64_t left = length - pos;
+	uint64_t write = MIN(p_length, left);
 	if (write < p_length) {
 		WARN_PRINT("Writing less data than requested");
 	}

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -35,8 +35,8 @@
 
 class FileAccessMemory : public FileAccess {
 	uint8_t *data = nullptr;
-	int length = 0;
-	mutable int pos = 0;
+	uint64_t length = 0;
+	mutable uint64_t pos = 0;
 
 	static FileAccess *create();
 
@@ -44,27 +44,27 @@ public:
 	static void register_file(String p_name, Vector<uint8_t> p_data);
 	static void cleanup();
 
-	virtual Error open_custom(const uint8_t *p_data, int p_len); ///< open a file
+	virtual Error open_custom(const uint8_t *p_data, uint64_t p_len); ///< open a file
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
 
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const; ///< get an array of bytes
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const; ///< get an array of bytes
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_byte); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -126,7 +126,7 @@ void FileAccessNetworkClient::_thread_func() {
 				if (status != OK) {
 					fa->_respond(0, Error(status));
 				} else {
-					uint64_t len = get_64();
+					int64_t len = get_64();
 					fa->_respond(len, Error(status));
 				}
 
@@ -135,7 +135,7 @@ void FileAccessNetworkClient::_thread_func() {
 			} break;
 			case FileAccessNetwork::RESPONSE_DATA: {
 				int64_t offset = get_64();
-				uint32_t len = get_32();
+				int32_t len = get_32();
 
 				Vector<uint8_t> block;
 				block.resize(len);
@@ -219,13 +219,13 @@ FileAccessNetworkClient::~FileAccessNetworkClient() {
 	thread.wait_to_finish();
 }
 
-void FileAccessNetwork::_set_block(int p_offset, const Vector<uint8_t> &p_block) {
-	int page = p_offset / page_size;
+void FileAccessNetwork::_set_block(uint64_t p_offset, const Vector<uint8_t> &p_block) {
+	int32_t page = p_offset / page_size;
 	ERR_FAIL_INDEX(page, pages.size());
 	if (page < pages.size() - 1) {
 		ERR_FAIL_COND(p_block.size() != page_size);
 	} else {
-		ERR_FAIL_COND((p_block.size() != (int)(total_size % page_size)));
+		ERR_FAIL_COND((uint64_t)p_block.size() != total_size % page_size);
 	}
 
 	{
@@ -240,7 +240,7 @@ void FileAccessNetwork::_set_block(int p_offset, const Vector<uint8_t> &p_block)
 	}
 }
 
-void FileAccessNetwork::_respond(size_t p_len, Error p_status) {
+void FileAccessNetwork::_respond(uint64_t p_len, Error p_status) {
 	DEBUG_PRINT("GOT RESPONSE - len: " + itos(p_len) + " status: " + itos(p_status));
 	response = p_status;
 	if (response != OK) {
@@ -248,7 +248,7 @@ void FileAccessNetwork::_respond(size_t p_len, Error p_status) {
 	}
 	opened = true;
 	total_size = p_len;
-	int pc = ((total_size - 1) / page_size) + 1;
+	int32_t pc = ((total_size - 1) / page_size) + 1;
 	pages.resize(pc);
 }
 
@@ -307,8 +307,9 @@ bool FileAccessNetwork::is_open() const {
 	return opened;
 }
 
-void FileAccessNetwork::seek(size_t p_position) {
+void FileAccessNetwork::seek(uint64_t p_position) {
 	ERR_FAIL_COND_MSG(!opened, "File must be opened before use.");
+
 	eof_flag = p_position > total_size;
 
 	if (p_position >= total_size) {
@@ -322,12 +323,12 @@ void FileAccessNetwork::seek_end(int64_t p_position) {
 	seek(total_size + p_position);
 }
 
-size_t FileAccessNetwork::get_position() const {
+uint64_t FileAccessNetwork::get_position() const {
 	ERR_FAIL_COND_V_MSG(!opened, 0, "File must be opened before use.");
 	return pos;
 }
 
-size_t FileAccessNetwork::get_len() const {
+uint64_t FileAccessNetwork::get_len() const {
 	ERR_FAIL_COND_V_MSG(!opened, 0, "File must be opened before use.");
 	return total_size;
 }
@@ -343,7 +344,7 @@ uint8_t FileAccessNetwork::get_8() const {
 	return v;
 }
 
-void FileAccessNetwork::_queue_page(int p_page) const {
+void FileAccessNetwork::_queue_page(int32_t p_page) const {
 	if (p_page >= pages.size()) {
 		return;
 	}
@@ -354,7 +355,7 @@ void FileAccessNetwork::_queue_page(int p_page) const {
 
 			FileAccessNetworkClient::BlockRequest br;
 			br.id = id;
-			br.offset = size_t(p_page) * page_size;
+			br.offset = (uint64_t)p_page * page_size;
 			br.size = page_size;
 			nc->block_requests.push_back(br);
 			pages.write[p_page].queued = true;
@@ -365,11 +366,9 @@ void FileAccessNetwork::_queue_page(int p_page) const {
 	}
 }
 
-int FileAccessNetwork::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessNetwork::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 
-	//bool eof=false;
 	if (pos + p_length > total_size) {
 		eof_flag = true;
 	}
@@ -377,18 +376,16 @@ int FileAccessNetwork::get_buffer(uint8_t *p_dst, int p_length) const {
 		p_length = total_size - pos;
 	}
 
-	//FileAccessNetworkClient *nc = FileAccessNetworkClient::singleton;
-
 	uint8_t *buff = last_page_buff;
 
-	for (int i = 0; i < p_length; i++) {
-		int page = pos / page_size;
+	for (uint64_t i = 0; i < p_length; i++) {
+		int32_t page = pos / page_size;
 
 		if (page != last_page) {
 			buffer_mutex.lock();
 			if (pages[page].buffer.is_empty()) {
 				waiting_on_page = page;
-				for (int j = 0; j < read_ahead; j++) {
+				for (int32_t j = 0; j < read_ahead; j++) {
 					_queue_page(page + j);
 				}
 				buffer_mutex.unlock();
@@ -396,10 +393,9 @@ int FileAccessNetwork::get_buffer(uint8_t *p_dst, int p_length) const {
 				page_sem.wait();
 				DEBUG_PRINT("done");
 			} else {
-				for (int j = 0; j < read_ahead; j++) {
+				for (int32_t j = 0; j < read_ahead; j++) {
 					_queue_page(page + j);
 				}
-				//queue pages
 				buffer_mutex.unlock();
 			}
 

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -40,9 +40,9 @@ class FileAccessNetwork;
 
 class FileAccessNetworkClient {
 	struct BlockRequest {
-		int id;
+		int32_t id;
 		uint64_t offset;
-		int size;
+		int32_t size;
 	};
 
 	List<BlockRequest> block_requests;
@@ -54,17 +54,17 @@ class FileAccessNetworkClient {
 	Mutex blockrequest_mutex;
 	Map<int, FileAccessNetwork *> accesses;
 	Ref<StreamPeerTCP> client;
-	int last_id = 0;
-	int lockcount = 0;
+	int32_t last_id = 0;
+	int32_t lockcount = 0;
 
 	Vector<uint8_t> block;
 
 	void _thread_func();
 	static void _thread_func(void *s);
 
-	void put_32(int p_32);
+	void put_32(int32_t p_32);
 	void put_64(int64_t p_64);
-	int get_32();
+	int32_t get_32();
 	int64_t get_64();
 	void lock_mutex();
 	void unlock_mutex();
@@ -86,15 +86,15 @@ class FileAccessNetwork : public FileAccess {
 	Semaphore page_sem;
 	Mutex buffer_mutex;
 	bool opened = false;
-	size_t total_size;
-	mutable size_t pos = 0;
-	int id;
+	uint64_t total_size;
+	mutable uint64_t pos = 0;
+	int32_t id;
 	mutable bool eof_flag = false;
-	mutable int last_page = -1;
+	mutable int32_t last_page = -1;
 	mutable uint8_t *last_page_buff = nullptr;
 
-	int page_size;
-	int read_ahead;
+	int32_t page_size;
+	int32_t read_ahead;
 
 	mutable int waiting_on_page = -1;
 
@@ -110,9 +110,9 @@ class FileAccessNetwork : public FileAccess {
 
 	uint64_t exists_modtime;
 	friend class FileAccessNetworkClient;
-	void _queue_page(int p_page) const;
-	void _respond(size_t p_len, Error p_status);
-	void _set_block(int p_offset, const Vector<uint8_t> &p_block);
+	void _queue_page(int32_t p_page) const;
+	void _respond(uint64_t p_len, Error p_status);
+	void _set_block(uint64_t p_offset, const Vector<uint8_t> &p_block);
 
 public:
 	enum Command {
@@ -134,15 +134,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -36,7 +36,7 @@
 
 #include <stdio.h>
 
-Error PackedData::add_pack(const String &p_path, bool p_replace_files, size_t p_offset) {
+Error PackedData::add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) {
 	for (int i = 0; i < sources.size(); i++) {
 		if (sources[i]->try_open_pack(p_path, p_replace_files, p_offset)) {
 			return OK;
@@ -46,17 +46,16 @@ Error PackedData::add_pack(const String &p_path, bool p_replace_files, size_t p_
 	return ERR_FILE_UNRECOGNIZED;
 }
 
-void PackedData::add_path(const String &pkg_path, const String &path, uint64_t ofs, uint64_t size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted) {
-	PathMD5 pmd5(path.md5_buffer());
-	//printf("adding path %s, %lli, %lli\n", path.utf8().get_data(), pmd5.a, pmd5.b);
+void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted) {
+	PathMD5 pmd5(p_path.md5_buffer());
 
 	bool exists = files.has(pmd5);
 
 	PackedFile pf;
 	pf.encrypted = p_encrypted;
-	pf.pack = pkg_path;
-	pf.offset = ofs;
-	pf.size = size;
+	pf.pack = p_pkg_path;
+	pf.offset = p_ofs;
+	pf.size = p_size;
 	for (int i = 0; i < 16; i++) {
 		pf.md5[i] = p_md5[i];
 	}
@@ -68,7 +67,7 @@ void PackedData::add_path(const String &pkg_path, const String &path, uint64_t o
 
 	if (!exists) {
 		//search for dir
-		String p = path.replace_first("res://", "");
+		String p = p_path.replace_first("res://", "");
 		PackedDir *cd = root;
 
 		if (p.find("/") != -1) { //in a subdir
@@ -87,7 +86,7 @@ void PackedData::add_path(const String &pkg_path, const String &path, uint64_t o
 				}
 			}
 		}
-		String filename = path.get_file();
+		String filename = p_path.get_file();
 		// Don't add as a file if the path points to a directory
 		if (!filename.is_empty()) {
 			cd->files.insert(filename);
@@ -126,7 +125,7 @@ PackedData::~PackedData() {
 
 //////////////////////////////////////////////////////////////////
 
-bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset) {
+bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f) {
 		return false;
@@ -261,7 +260,7 @@ bool FileAccessPack::is_open() const {
 	return f->is_open();
 }
 
-void FileAccessPack::seek(size_t p_position) {
+void FileAccessPack::seek(uint64_t p_position) {
 	if (p_position > pf.size) {
 		eof = true;
 	} else {
@@ -276,11 +275,11 @@ void FileAccessPack::seek_end(int64_t p_position) {
 	seek(pf.size + p_position);
 }
 
-size_t FileAccessPack::get_position() const {
+uint64_t FileAccessPack::get_position() const {
 	return pos;
 }
 
-size_t FileAccessPack::get_len() const {
+uint64_t FileAccessPack::get_len() const {
 	return pf.size;
 }
 
@@ -298,18 +297,17 @@ uint8_t FileAccessPack::get_8() const {
 	return f->get_8();
 }
 
-int FileAccessPack::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessPack::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 
 	if (eof) {
 		return 0;
 	}
 
-	uint64_t to_read = p_length;
+	int64_t to_read = p_length;
 	if (to_read + pos > pf.size) {
 		eof = true;
-		to_read = int64_t(pf.size) - int64_t(pos);
+		to_read = (int64_t)pf.size - (int64_t)pos;
 	}
 
 	pos += p_length;
@@ -342,7 +340,7 @@ void FileAccessPack::store_8(uint8_t p_dest) {
 	ERR_FAIL();
 }
 
-void FileAccessPack::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccessPack::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL();
 }
 
@@ -549,7 +547,7 @@ Error DirAccessPack::remove(String p_name) {
 	return ERR_UNAVAILABLE;
 }
 
-size_t DirAccessPack::get_space_left() {
+uint64_t DirAccessPack::get_space_left() {
 	return 0;
 }
 

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -112,13 +112,13 @@ private:
 
 public:
 	void add_pack_source(PackSource *p_source);
-	void add_path(const String &pkg_path, const String &path, uint64_t ofs, uint64_t size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted = false); // for PackSource
+	void add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted = false); // for PackSource
 
 	void set_disabled(bool p_disabled) { disabled = p_disabled; }
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
 
 	static PackedData *get_singleton() { return singleton; }
-	Error add_pack(const String &p_path, bool p_replace_files, size_t p_offset);
+	Error add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
 
 	_FORCE_INLINE_ FileAccess *try_open_path(const String &p_path);
 	_FORCE_INLINE_ bool has_path(const String &p_path);
@@ -132,21 +132,21 @@ public:
 
 class PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset) = 0;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) = 0;
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file) = 0;
 	virtual ~PackSource() {}
 };
 
 class PackedSourcePCK : public PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
 	virtual FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 };
 
 class FileAccessPack : public FileAccess {
 	PackedData::PackedFile pf;
 
-	mutable size_t pos;
+	mutable uint64_t pos;
 	mutable bool eof;
 	uint64_t off;
 
@@ -160,16 +160,16 @@ public:
 	virtual void close();
 	virtual bool is_open() const;
 
-	virtual void seek(size_t p_position);
+	virtual void seek(uint64_t p_position);
 	virtual void seek_end(int64_t p_position = 0);
-	virtual size_t get_position() const;
-	virtual size_t get_len() const;
+	virtual uint64_t get_position() const;
+	virtual uint64_t get_len() const;
 
 	virtual bool eof_reached() const;
 
 	virtual uint8_t get_8() const;
 
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual void set_endian_swap(bool p_swap);
 
@@ -178,7 +178,7 @@ public:
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest);
 
-	virtual void store_buffer(const uint8_t *p_src, int p_length);
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length);
 
 	virtual bool file_exists(const String &p_name);
 
@@ -243,7 +243,7 @@ public:
 	virtual Error rename(String p_from, String p_to);
 	virtual Error remove(String p_name);
 
-	size_t get_space_left();
+	uint64_t get_space_left();
 
 	virtual String get_filesystem_type() const;
 

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -67,7 +67,7 @@ public:
 
 	bool file_exists(String p_name) const;
 
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, size_t p_offset);
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
 	FileAccess *get_file(const String &p_path, PackedData::PackedFile *p_file);
 
 	static ZipArchive *get_singleton();
@@ -87,20 +87,21 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
+
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 
 	virtual uint64_t _get_modified_time(const String &p_file) { return 0; } // todo

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -236,7 +236,7 @@ Error PCKPacker::flush(bool p_verbose) {
 		}
 
 		while (to_write > 0) {
-			int read = src->get_buffer(buf, MIN(to_write, buf_max));
+			uint64_t read = src->get_buffer(buf, MIN(to_write, buf_max));
 			ftmp->store_buffer(buf, read);
 			to_write -= read;
 		}

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1157,8 +1157,8 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 
 	save_ustring(fw, get_ustring(f)); //type
 
-	size_t md_ofs = f->get_position();
-	size_t importmd_ofs = f->get_64();
+	uint64_t md_ofs = f->get_position();
+	uint64_t importmd_ofs = f->get_64();
 	fw->store_64(0); //metadata offset
 
 	for (int i = 0; i < 14; i++) {

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -68,7 +68,7 @@ long zipio_tell(voidpf opaque, voidpf stream) {
 long zipio_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 	FileAccess *f = *(FileAccess **)opaque;
 
-	int pos = offset;
+	uint64_t pos = offset;
 	switch (origin) {
 		case ZLIB_FILEFUNC_SEEK_CUR:
 			pos = f->get_position() + offset;

--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -87,7 +87,7 @@ public:
 	virtual bool is_readable(String p_dir) { return true; };
 	virtual bool is_writable(String p_dir) { return true; };
 	static bool exists(String p_dir);
-	virtual size_t get_space_left() = 0;
+	virtual uint64_t get_space_left() = 0;
 
 	Error copy_dir(String p_from, String p_to, int p_chmod_flags = -1);
 	virtual Error copy(String p_from, String p_to, int p_chmod_flags = -1);

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -367,10 +367,10 @@ Vector<String> FileAccess::get_csv_line(const String &p_delim) const {
 	return strings;
 }
 
-int FileAccess::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccess::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
-	int i = 0;
+
+	uint64_t i = 0;
 	for (i = 0; i < p_length && !eof_reached(); i++) {
 		p_dst[i] = get_8();
 	}
@@ -380,11 +380,11 @@ int FileAccess::get_buffer(uint8_t *p_dst, int p_length) const {
 
 String FileAccess::get_as_utf8_string() const {
 	Vector<uint8_t> sourcef;
-	int len = get_len();
+	uint64_t len = get_len();
 	sourcef.resize(len + 1);
 
 	uint8_t *w = sourcef.ptrw();
-	int r = get_buffer(w, len);
+	uint64_t r = get_buffer(w, len);
 	ERR_FAIL_COND_V(r != len, String());
 	w[len] = 0;
 
@@ -550,8 +550,8 @@ void FileAccess::store_csv_line(const Vector<String> &p_values, const String &p_
 	store_line(line);
 }
 
-void FileAccess::store_buffer(const uint8_t *p_src, int p_length) {
-	for (int i = 0; i < p_length; i++) {
+void FileAccess::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	for (uint64_t i = 0; i < p_length; i++) {
 		store_8(p_src[i]);
 	}
 }
@@ -601,7 +601,7 @@ String FileAccess::get_md5(const String &p_file) {
 	unsigned char step[32768];
 
 	while (true) {
-		int br = f->get_buffer(step, 32768);
+		uint64_t br = f->get_buffer(step, 32768);
 		if (br > 0) {
 			ctx.update(step, br);
 		}
@@ -629,7 +629,7 @@ String FileAccess::get_multiple_md5(const Vector<String> &p_file) {
 		unsigned char step[32768];
 
 		while (true) {
-			int br = f->get_buffer(step, 32768);
+			uint64_t br = f->get_buffer(step, 32768);
 			if (br > 0) {
 				ctx.update(step, br);
 			}
@@ -658,7 +658,7 @@ String FileAccess::get_sha256(const String &p_file) {
 	unsigned char step[32768];
 
 	while (true) {
-		int br = f->get_buffer(step, 32768);
+		uint64_t br = f->get_buffer(step, 32768);
 		if (br > 0) {
 			ctx.update(step, br);
 		}

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -93,10 +93,10 @@ public:
 	virtual String get_path() const { return ""; } /// returns the path for the current open file
 	virtual String get_path_absolute() const { return ""; } /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position) = 0; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) = 0; ///< seek from the end of file
-	virtual size_t get_position() const = 0; ///< get position in the file
-	virtual size_t get_len() const = 0; ///< get size of the file
+	virtual void seek(uint64_t p_position) = 0; ///< seek to a given position
+	virtual void seek_end(int64_t p_position = 0) = 0; ///< seek from the end of file with negative offset
+	virtual uint64_t get_position() const = 0; ///< get position in the file
+	virtual uint64_t get_len() const = 0; ///< get size of the file
 
 	virtual bool eof_reached() const = 0; ///< reading passed EOF
 
@@ -109,7 +109,7 @@ public:
 	virtual double get_double() const;
 	virtual real_t get_real() const;
 
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const; ///< get an array of bytes
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const; ///< get an array of bytes
 	virtual String get_line() const;
 	virtual String get_token() const;
 	virtual Vector<String> get_csv_line(const String &p_delim = ",") const;
@@ -142,7 +142,7 @@ public:
 	virtual void store_pascal_string(const String &p_string);
 	virtual String get_pascal_string();
 
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name) = 0; ///< return true if a file exists
 

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -37,7 +37,7 @@
 #include <string.h>
 
 Error ImageLoaderPNG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
-	const size_t buffer_size = f->get_len();
+	const uint64_t buffer_size = f->get_len();
 	Vector<uint8_t> file_buffer;
 	Error err = file_buffer.resize(buffer_size);
 	if (err) {

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -406,7 +406,7 @@ Error DirAccessUnix::remove(String p_path) {
 	}
 }
 
-size_t DirAccessUnix::get_space_left() {
+uint64_t DirAccessUnix::get_space_left() {
 #ifndef NO_STATVFS
 	struct statvfs vfs;
 	if (statvfs(current_dir.utf8().get_data(), &vfs) != 0) {

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -79,7 +79,7 @@ public:
 	virtual Error rename(String p_path, String p_new_path);
 	virtual Error remove(String p_path);
 
-	virtual size_t get_space_left();
+	virtual uint64_t get_space_left();
 
 	virtual String get_filesystem_type() const;
 

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -184,11 +184,11 @@ String FileAccessUnix::get_path_absolute() const {
 	return path;
 }
 
-void FileAccessUnix::seek(size_t p_position) {
+void FileAccessUnix::seek(uint64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	last_error = OK;
-	if (fseek(f, p_position, SEEK_SET)) {
+	if (fseeko(f, p_position, SEEK_SET)) {
 		check_errors();
 	}
 }
@@ -196,15 +196,15 @@ void FileAccessUnix::seek(size_t p_position) {
 void FileAccessUnix::seek_end(int64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
-	if (fseek(f, p_position, SEEK_END)) {
+	if (fseeko(f, p_position, SEEK_END)) {
 		check_errors();
 	}
 }
 
-size_t FileAccessUnix::get_position() const {
+uint64_t FileAccessUnix::get_position() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 
-	long pos = ftell(f);
+	int64_t pos = ftello(f);
 	if (pos < 0) {
 		check_errors();
 		ERR_FAIL_V(0);
@@ -212,15 +212,15 @@ size_t FileAccessUnix::get_position() const {
 	return pos;
 }
 
-size_t FileAccessUnix::get_len() const {
+uint64_t FileAccessUnix::get_len() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 
-	long pos = ftell(f);
+	int64_t pos = ftello(f);
 	ERR_FAIL_COND_V(pos < 0, 0);
-	ERR_FAIL_COND_V(fseek(f, 0, SEEK_END), 0);
-	long size = ftell(f);
+	ERR_FAIL_COND_V(fseeko(f, 0, SEEK_END), 0);
+	int64_t size = ftello(f);
 	ERR_FAIL_COND_V(size < 0, 0);
-	ERR_FAIL_COND_V(fseek(f, pos, SEEK_SET), 0);
+	ERR_FAIL_COND_V(fseeko(f, pos, SEEK_SET), 0);
 
 	return size;
 }
@@ -239,11 +239,11 @@ uint8_t FileAccessUnix::get_8() const {
 	return b;
 }
 
-int FileAccessUnix::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessUnix::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 	ERR_FAIL_COND_V_MSG(!f, -1, "File must be opened before use.");
-	int read = fread(p_dst, 1, p_length, f);
+
+	uint64_t read = fread(p_dst, 1, p_length, f);
 	check_errors();
 	return read;
 };
@@ -262,10 +262,10 @@ void FileAccessUnix::store_8(uint8_t p_dest) {
 	ERR_FAIL_COND(fwrite(&p_dest, 1, 1, f) != 1);
 }
 
-void FileAccessUnix::store_buffer(const uint8_t *p_src, int p_length) {
+void FileAccessUnix::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	ERR_FAIL_COND(!p_src);
-	ERR_FAIL_COND((int)fwrite(p_src, 1, p_length, f) != p_length);
+	ERR_FAIL_COND(fwrite(p_src, 1, p_length, f) != p_length);
 }
 
 bool FileAccessUnix::file_exists(const String &p_path) {

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -61,21 +61,21 @@ public:
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_path); ///< return true if a file exists
 

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -325,14 +325,15 @@ FileType DirAccessWindows::get_file_type(const String& p_file) const {
 }
 
 */
-size_t DirAccessWindows::get_space_left() {
+
+uint64_t DirAccessWindows::get_space_left() {
 	uint64_t bytes = 0;
 	if (!GetDiskFreeSpaceEx(nullptr, (PULARGE_INTEGER)&bytes, nullptr, nullptr)) {
 		return 0;
 	}
 
 	//this is either 0 or a value in bytes.
-	return (size_t)bytes;
+	return bytes;
 }
 
 String DirAccessWindows::get_filesystem_type() const {

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -78,8 +78,7 @@ public:
 	virtual Error rename(String p_path, String p_new_path);
 	virtual Error remove(String p_path);
 
-	//virtual FileType get_file_type() const;
-	size_t get_space_left();
+	uint64_t get_space_left();
 
 	virtual String get_filesystem_type() const;
 

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -56,21 +56,21 @@ public:
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1222,12 +1222,12 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 	}
 
 	for (int i = 0; i < pd.file_ofs.size(); i++) {
-		int string_len = pd.file_ofs[i].path_utf8.length();
-		int pad = _get_pad(4, string_len);
+		uint32_t string_len = pd.file_ofs[i].path_utf8.length();
+		uint32_t pad = _get_pad(4, string_len);
 
 		fhead->store_32(string_len + pad);
 		fhead->store_buffer((const uint8_t *)pd.file_ofs[i].path_utf8.get_data(), string_len);
-		for (int j = 0; j < pad; j++) {
+		for (uint32_t j = 0; j < pad; j++) {
 			fhead->store_8(0);
 		}
 
@@ -1269,8 +1269,8 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 	uint8_t buf[bufsize];
 
 	while (true) {
-		int got = ftmp->get_buffer(buf, bufsize);
-		if (got <= 0) {
+		uint64_t got = ftmp->get_buffer(buf, bufsize);
+		if (got == 0) {
 			break;
 		}
 		f->store_buffer(buf, got);
@@ -1280,13 +1280,13 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 
 	if (p_embed) {
 		// Ensure embedded data ends at a 64-bit multiple
-		int64_t embed_end = f->get_position() - embed_pos + 12;
-		int pad = embed_end % 8;
-		for (int i = 0; i < pad; i++) {
+		uint64_t embed_end = f->get_position() - embed_pos + 12;
+		uint64_t pad = embed_end % 8;
+		for (uint64_t i = 0; i < pad; i++) {
 			f->store_8(0);
 		}
 
-		int64_t pck_size = f->get_position() - pck_start_pos;
+		uint64_t pck_size = f->get_position() - pck_start_pos;
 		f->store_64(pck_size);
 		f->store_32(PACK_HEADER_MAGIC);
 

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -230,8 +230,7 @@ void EditorFileServer::_subthread_start(void *s) {
 				cd->files[id]->seek(offset);
 				Vector<uint8_t> buf;
 				buf.resize(blocklen);
-				int read = cd->files[id]->get_buffer(buf.ptrw(), blocklen);
-				ERR_CONTINUE(read < 0);
+				uint32_t read = cd->files[id]->get_buffer(buf.ptrw(), blocklen);
 
 				print_verbose("GET BLOCK - offset: " + itos(offset) + ", blocklen: " + itos(blocklen));
 

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -75,7 +75,7 @@ Error ResourceImporterImage::import(const String &p_source_file, const String &p
 
 	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, "Cannot open file from path '" + p_source_file + "'.");
 
-	size_t len = f->get_len();
+	uint64_t len = f->get_len();
 
 	Vector<uint8_t> data;
 	data.resize(len);

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -441,10 +441,10 @@ Error PluginScript::load_source_code(const String &p_path) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot open file '" + p_path + "'.");
 
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	uint8_t *w = sourcef.ptrw();
-	int r = f->get_buffer(w, len);
+	uint64_t r = f->get_buffer(w, len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -47,11 +47,7 @@ godot_int GDAPI godot_videodecoder_file_read(void *ptr, uint8_t *buf, int buf_si
 
 	// if file exists
 	if (file) {
-		long bytes_read = file->get_buffer(buf, buf_size);
-		// No bytes to read => EOF
-		if (bytes_read == 0) {
-			return 0;
-		}
+		int64_t bytes_read = file->get_buffer(buf, buf_size);
 		return bytes_read;
 	}
 	return -1;
@@ -62,41 +58,35 @@ int64_t GDAPI godot_videodecoder_file_seek(void *ptr, int64_t pos, int whence) {
 	FileAccess *file = reinterpret_cast<FileAccess *>(ptr);
 
 	if (file) {
-		size_t len = file->get_len();
+		int64_t len = file->get_len();
 		switch (whence) {
 			case SEEK_SET: {
-				// Just for explicitness
-				size_t new_pos = static_cast<size_t>(pos);
-				if (new_pos > len) {
+				if (pos > len) {
 					return -1;
 				}
-				file->seek(new_pos);
-				pos = static_cast<int64_t>(file->get_position());
-				return pos;
+				file->seek(pos);
+				return file->get_position();
 			} break;
 			case SEEK_CUR: {
 				// Just in case it doesn't exist
-				if (pos < 0 && (size_t)-pos > file->get_position()) {
+				if (pos < 0 && -pos > (int64_t)file->get_position()) {
 					return -1;
 				}
-				pos = pos + static_cast<int>(file->get_position());
-				file->seek(pos);
-				pos = static_cast<int64_t>(file->get_position());
-				return pos;
+				file->seek(file->get_position() + pos);
+				return file->get_position();
 			} break;
 			case SEEK_END: {
 				// Just in case something goes wrong
-				if ((size_t)-pos > len) {
+				if (-pos > len) {
 					return -1;
 				}
 				file->seek_end(pos);
-				pos = static_cast<int64_t>(file->get_position());
-				return pos;
+				return file->get_position();
 			} break;
 			default: {
 				// Only 4 possible options, hence default = AVSEEK_SIZE
 				// Asks to return the length of file
-				return static_cast<int64_t>(len);
+				return len;
 			} break;
 		}
 	}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1045,10 +1045,10 @@ Error GDScript::load_source_code(const String &p_path) {
 		ERR_FAIL_COND_V(err, err);
 	}
 
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	uint8_t *w = sourcef.ptrw();
-	int r = f->get_buffer(w, len);
+	uint64_t r = f->get_buffer(w, len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -153,9 +153,9 @@ String GDScriptCache::get_source_code(const String &p_path) {
 		ERR_FAIL_COND_V(err, "");
 	}
 
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	source_file.resize(len + 1);
-	int r = f->get_buffer(source_file.ptrw(), len);
+	uint64_t r = f->get_buffer(source_file.ptrw(), len);
 	f->close();
 	ERR_FAIL_COND_V(r != len, "");
 	source_file.write[len] = 0;

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -215,7 +215,7 @@ void test(TestType p_type) {
 	init_language(fa->get_path_absolute().get_base_dir());
 
 	Vector<uint8_t> buf;
-	int flen = fa->get_len();
+	uint64_t flen = fa->get_len();
 	buf.resize(fa->get_len() + 1);
 	fa->get_buffer(buf.ptrw(), flen);
 	buf.write[flen] = 0;

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -105,7 +105,7 @@ Error jpeg_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 
 Error ImageLoaderJPG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 	Vector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	uint64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -58,7 +58,7 @@ Error CryptoKeyMbedTLS::load(String p_path, bool p_public_only) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(!f, ERR_INVALID_PARAMETER, "Cannot open CryptoKeyMbedTLS file '" + p_path + "'.");
 
-	int flen = f->get_len();
+	uint64_t flen = f->get_len();
 	out.resize(flen + 1);
 	f->get_buffer(out.ptrw(), flen);
 	out.write[flen] = 0; // string terminator
@@ -146,7 +146,7 @@ Error X509CertificateMbedTLS::load(String p_path) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(!f, ERR_INVALID_PARAMETER, "Cannot open X509CertificateMbedTLS file '" + p_path + "'.");
 
-	int flen = f->get_len();
+	uint64_t flen = f->get_len();
 	out.resize(flen + 1);
 	f->get_buffer(out.ptrw(), flen);
 	out.write[flen] = 0; // string terminator

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -79,7 +79,7 @@ Error ResourceImporterMP3::import(const String &p_source_file, const String &p_s
 
 	ERR_FAIL_COND_V(!f, ERR_CANT_OPEN);
 
-	size_t len = f->get_len();
+	uint64_t len = f->get_len();
 
 	Vector<uint8_t> data;
 	data.resize(len);

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -170,10 +170,10 @@ Error read_all_file_utf8(const String &p_path, String &r_content) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot open file '" + p_path + "'.");
 
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	uint8_t *w = sourcef.ptrw();
-	int r = f->get_buffer(w, len);
+	uint64_t r = f->get_buffer(w, len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
@@ -79,7 +79,7 @@ Error ResourceImporterOGGVorbis::import(const String &p_source_file, const Strin
 
 	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, "Cannot open file '" + p_source_file + "'.");
 
-	size_t len = f->get_len();
+	uint64_t len = f->get_len();
 
 	Vector<uint8_t> data;
 	data.resize(len);

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -140,7 +140,7 @@ Error ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, const char *p
 }
 
 Error ImageLoaderSVG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
-	uint32_t size = f->get_len();
+	uint64_t size = f->get_len();
 	Vector<uint8_t> src_image;
 	src_image.resize(size + 1);
 	uint8_t *src_w = src_image.ptrw();

--- a/modules/text_server_adv/dynamic_font_adv.cpp
+++ b/modules/text_server_adv/dynamic_font_adv.cpp
@@ -66,7 +66,7 @@ DynamicFontDataAdvanced::DataAtSize *DynamicFontDataAdvanced::get_data_for_size(
 					ERR_FAIL_V_MSG(nullptr, "Cannot open font file '" + font_path + "'.");
 				}
 
-				size_t len = f->get_len();
+				uint64_t len = f->get_len();
 				font_mem_cache.resize(len);
 				f->get_buffer(font_mem_cache.ptrw(), len);
 				font_mem = font_mem_cache.ptr();

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -181,7 +181,7 @@ bool TextServerAdvanced::load_support_data(const String &p_filename) {
 		UErrorCode err = U_ZERO_ERROR;
 
 		// ICU data found.
-		size_t len = f->get_len();
+		uint64_t len = f->get_len();
 		icu_data = (uint8_t *)memalloc(len);
 		f->get_buffer(icu_data, len);
 		f->close();

--- a/modules/text_server_fb/dynamic_font_fb.cpp
+++ b/modules/text_server_fb/dynamic_font_fb.cpp
@@ -65,7 +65,7 @@ DynamicFontDataFallback::DataAtSize *DynamicFontDataFallback::get_data_for_size(
 					ERR_FAIL_V_MSG(nullptr, "Cannot open font file '" + font_path + "'.");
 				}
 
-				size_t len = f->get_len();
+				uint64_t len = f->get_len();
 				font_mem_cache.resize(len);
 				f->get_buffer(font_mem_cache.ptrw(), len);
 				font_mem = font_mem_cache.ptr();

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -226,9 +226,9 @@ Error ImageLoaderTGA::convert_to_image(Ref<Image> p_image, const uint8_t *p_buff
 
 Error ImageLoaderTGA::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 	Vector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	uint64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
-	ERR_FAIL_COND_V(src_image_len < (int)sizeof(tga_header_s), ERR_FILE_CORRUPT);
+	ERR_FAIL_COND_V(src_image_len < (int64_t)sizeof(tga_header_s), ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 
 	Error err = OK;

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -58,7 +58,7 @@ int VideoStreamPlaybackTheora::buffer_data() {
 
 #else
 
-	int bytes = file->get_buffer((uint8_t *)buffer, 4096);
+	uint64_t bytes = file->get_buffer((uint8_t *)buffer, 4096);
 	ogg_sync_wrote(&oy, bytes);
 	return (bytes);
 
@@ -176,7 +176,7 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 	thread_eof = false;
 	//pre-fill buffer
 	int to_read = ring_buffer.space_left();
-	int read = file->get_buffer(read_buffer.ptr(), to_read);
+	uint64_t read = file->get_buffer(read_buffer.ptr(), to_read);
 	ring_buffer.write(read_buffer.ptr(), read);
 
 	thread.start(_streaming_thread, this);
@@ -632,8 +632,8 @@ void VideoStreamPlaybackTheora::_streaming_thread(void *ud) {
 		//just fill back the buffer
 		if (!vs->thread_eof) {
 			int to_read = vs->ring_buffer.space_left();
-			if (to_read) {
-				int read = vs->file->get_buffer(vs->read_buffer.ptr(), to_read);
+			if (to_read > 0) {
+				uint64_t read = vs->file->get_buffer(vs->read_buffer.ptr(), to_read);
 				vs->ring_buffer.write(vs->read_buffer.ptr(), read);
 				vs->thread_eof = vs->file->eof_reached();
 			}

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -37,7 +37,7 @@
 
 Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 	Vector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	uint64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -62,10 +62,10 @@ public:
 
 	virtual int Read(long long pos, long len, unsigned char *buf) {
 		if (file) {
-			if (file->get_position() != (size_t)pos) {
+			if (file->get_position() != (uint64_t)pos) {
 				file->seek(pos);
 			}
-			if (file->get_buffer(buf, len) == len) {
+			if (file->get_buffer(buf, len) == (uint64_t)len) {
 				return 0;
 			}
 		}
@@ -74,7 +74,7 @@ public:
 
 	virtual int Length(long long *total, long long *available) {
 		if (file) {
-			const size_t len = file->get_len();
+			const uint64_t len = file->get_len();
 			if (total) {
 				*total = len;
 			}

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -147,7 +147,7 @@ static Ref<Image> _webp_mem_loader_func(const uint8_t *p_png, int p_size) {
 
 Error ImageLoaderWEBP::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
 	Vector<uint8_t> src_image;
-	int src_image_len = f->get_len();
+	uint64_t src_image_len = f->get_len();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
 	src_image.resize(src_image_len);
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -285,6 +285,9 @@ def configure(env):
     )
     env.Append(CPPDEFINES=["NO_STATVFS", "GLES_ENABLED"])
 
+    if get_platform(env["ndk_platform"]) >= 24:
+        env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
+
     env["neon_enabled"] = False
     if env["android_arch"] == "x86":
         target_opts = ["-target", "i686-none-linux-android"]

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -201,8 +201,7 @@ String DirAccessJAndroid::get_filesystem_type() const {
 	return "APK";
 }
 
-//FileType get_file_type() const;
-size_t DirAccessJAndroid::get_space_left() {
+uint64_t DirAccessJAndroid::get_space_left() {
 	return 0;
 }
 

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -76,8 +76,7 @@ public:
 
 	virtual String get_filesystem_type() const;
 
-	//virtual FileType get_file_type() const;
-	size_t get_space_left();
+	uint64_t get_space_left();
 
 	static void setup(jobject p_io);
 

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -71,8 +71,9 @@ bool FileAccessAndroid::is_open() const {
 	return a != nullptr;
 }
 
-void FileAccessAndroid::seek(size_t p_position) {
+void FileAccessAndroid::seek(uint64_t p_position) {
 	ERR_FAIL_COND(!a);
+
 	AAsset_seek(a, p_position, SEEK_SET);
 	pos = p_position;
 	if (pos > len) {
@@ -89,11 +90,11 @@ void FileAccessAndroid::seek_end(int64_t p_position) {
 	pos = len + p_position;
 }
 
-size_t FileAccessAndroid::get_position() const {
+uint64_t FileAccessAndroid::get_position() const {
 	return pos;
 }
 
-size_t FileAccessAndroid::get_len() const {
+uint64_t FileAccessAndroid::get_len() const {
 	return len;
 }
 
@@ -113,11 +114,10 @@ uint8_t FileAccessAndroid::get_8() const {
 	return byte;
 }
 
-int FileAccessAndroid::get_buffer(uint8_t *p_dst, int p_length) const {
+uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(p_length < 0, -1);
 
-	off_t r = AAsset_read(a, p_dst, p_length);
+	int r = AAsset_read(a, p_dst, p_length);
 
 	if (pos + p_length > len) {
 		eof = true;

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -40,8 +40,8 @@
 class FileAccessAndroid : public FileAccess {
 	static FileAccess *create_android();
 	mutable AAsset *a = nullptr;
-	mutable size_t len = 0;
-	mutable size_t pos = 0;
+	mutable uint64_t len = 0;
+	mutable uint64_t pos = 0;
 	mutable bool eof = false;
 
 public:
@@ -51,15 +51,15 @@ public:
 	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(size_t p_position); ///< seek to a given position
+	virtual void seek(uint64_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_position() const; ///< get position in the file
-	virtual size_t get_len() const; ///< get size of the file
+	virtual uint64_t get_position() const; ///< get position in the file
+	virtual uint64_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF
 
 	virtual uint8_t get_8() const; ///< get a byte
-	virtual int get_buffer(uint8_t *p_dst, int p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
 	virtual Error get_error() const; ///< get last error
 

--- a/platform/javascript/api/javascript_tools_editor_plugin.cpp
+++ b/platform/javascript/api/javascript_tools_editor_plugin.cpp
@@ -79,7 +79,7 @@ void JavaScriptToolsEditorPlugin::_zip_file(String p_path, String p_base_path, z
 		return;
 	}
 	Vector<uint8_t> data;
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	data.resize(len);
 	f->get_buffer(data.ptrw(), len);
 	f->close();

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -170,8 +170,8 @@ public:
 
 		while (true) {
 			uint8_t bytes[4096];
-			int read = f->get_buffer(bytes, 4096);
-			if (read < 1) {
+			uint64_t read = f->get_buffer(bytes, 4096);
+			if (read == 0) {
 				break;
 			}
 			err = peer->put_data(bytes, read);

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -363,6 +363,7 @@ def configure(env):
 
     env.Prepend(CPPPATH=["#platform/linuxbsd"])
     env.Append(CPPDEFINES=["X11_ENABLED", "UNIX_ENABLED"])
+    env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
 
     env.Append(CPPDEFINES=["VULKAN_ENABLED"])
     if not env["builtin_vulkan"]:

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -3467,7 +3467,7 @@ void DisplayServerOSX::set_native_icon(const String &p_filename) {
 	ERR_FAIL_COND(!f);
 
 	Vector<uint8_t> data;
-	uint32_t len = f->get_len();
+	uint64_t len = f->get_len();
 	data.resize(len);
 	f->get_buffer((uint8_t *)&data.write[0], len);
 	memdelete(f);

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -312,7 +312,7 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
 			}
 
 			int ofs = data.size();
-			uint32_t len = f->get_len();
+			uint64_t len = f->get_len();
 			data.resize(data.size() + len + 8);
 			f->get_buffer(&data.write[ofs + 8], len);
 			memdelete(f);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -978,7 +978,7 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 	}
 
 	wf->store_32(0); //string table size, will not be in use
-	size_t ext_res_count_pos = wf->get_position();
+	uint64_t ext_res_count_pos = wf->get_position();
 
 	wf->store_32(0); //zero ext resources, still parsing them
 
@@ -1041,7 +1041,7 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 
 	//now, save resources to a separate file, for now
 
-	size_t sub_res_count_pos = wf->get_position();
+	uint64_t sub_res_count_pos = wf->get_position();
 	wf->store_32(0); //zero sub resources, still parsing them
 
 	String temp_file = p_path + ".temp";
@@ -1050,8 +1050,8 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 		return ERR_CANT_OPEN;
 	}
 
-	Vector<size_t> local_offsets;
-	Vector<size_t> local_pointers_pos;
+	Vector<uint64_t> local_offsets;
+	Vector<uint64_t> local_pointers_pos;
 
 	while (next_tag.name == "sub_resource" || next_tag.name == "resource") {
 		String type;
@@ -1089,7 +1089,7 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 		wf->store_64(0); //temp local offset
 
 		bs_save_unicode_string(wf2, type);
-		size_t propcount_ofs = wf2->get_position();
+		uint64_t propcount_ofs = wf2->get_position();
 		wf2->store_32(0);
 
 		int prop_count = 0;
@@ -1159,7 +1159,7 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 
 		local_offsets.push_back(wf2->get_position());
 		bs_save_unicode_string(wf2, "PackedScene");
-		size_t propcount_ofs = wf2->get_position();
+		uint64_t propcount_ofs = wf2->get_position();
 		wf2->store_32(0);
 
 		int prop_count = 0;
@@ -1185,7 +1185,7 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 
 	wf2->close();
 
-	size_t offset_from = wf->get_position();
+	uint64_t offset_from = wf->get_position();
 	wf->seek(sub_res_count_pos); //plus one because the saved one
 	wf->store_32(local_offsets.size());
 

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -55,10 +55,10 @@ Error TextFile::load_text(const String &p_path) {
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot open TextFile '" + p_path + "'.");
 
-	int len = f->get_len();
+	uint64_t len = f->get_len();
 	sourcef.resize(len + 1);
 	uint8_t *w = sourcef.ptrw();
-	int r = f->get_buffer(w, len);
+	uint64_t r = f->get_buffer(w, len);
 	f->close();
 	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -335,7 +335,7 @@ Ref<Image> StreamTexture2D::load_image_from_file(FileAccess *f, int p_size_limit
 
 		//mipmaps need to be read independently, they will be later combined
 		Vector<Ref<Image>> mipmap_images;
-		int total_size = 0;
+		uint64_t total_size = 0;
 
 		bool first = true;
 

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -529,7 +529,7 @@ MainLoop *test() {
 	ERR_FAIL_COND_V_MSG(!fa, nullptr, "Could not open file: " + test);
 
 	Vector<uint8_t> buf;
-	int flen = fa->get_len();
+	uint64_t flen = fa->get_len();
 	buf.resize(fa->get_len() + 1);
 	fa->get_buffer(buf.ptrw(), flen);
 	buf.write[flen] = 0;


### PR DESCRIPTION
Forward port of #47254 to `master`. Draft for now as I haven't tested the changes yet, nor done a full pass to check potential type mismatches on calls to `get_buffer()` and similar.

---

This changes the types of a big number of variables.

General rules:
- Using `uint64_t` in general. We also considered `int64_t` but eventually
  settled on keeping it unsigned, which is also closer to what one would expect
  with `size_t`/`off_t`.
- We only keep `int64_t` for `seek_end` (takes a negative offset from the end)
  and for the `Variant` bindings, since `Variant::INT` is `int64_t`. This means
  we only need to guard against passing negative values in `core_bind.cpp`.
- Using `uint32_t` integers for concepts not needing such a huge range, like
  pages, blocks, etc.

In addition:
- Improve usage of integer types in some related places; namely, `DirAccess`,
  core binds.

Note:
- On Windows, `_ftelli64` reports invalid values when using 32-bit MinGW with
  version < 8.0. This was an upstream bug fixed in 8.0. It breaks support for
  big files on 32-bit Windows builds made with that toolchain. We might add a
  workaround.

Fixes #44363.
Fixes godotengine/godot-proposals#400.