### PR TITLE
Fix Transform2D and Transform3D scaled and rotated methods

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -215,34 +215,50 @@ Transform2D Transform2D::operator*(const Transform2D &p_transform) const {
 	return t;
 }
 
-Transform2D Transform2D::scaled(const Size2 &p_scale) const {
-	Transform2D copy = *this;
-	copy.scale(p_scale);
-	return copy;
+Transform2D Transform2D::translated(const Vector2 &p_offset) const {
+	Transform2D result = *this;
+	result[2].x = tdotx(p_offset);
+	result[2].y = tdoty(p_offset);
+	return result;
 }
 
-Transform2D Transform2D::basis_scaled(const Size2 &p_scale) const {
-	Transform2D copy = *this;
-	copy.scale_basis(p_scale);
-	return copy;
+Transform2D Transform2D::pre_translated(const Vector2 &p_offset) const {
+	Transform2D result = *this;
+	result[2] += p_offset;
+	return result;
+}
+
+Transform2D Transform2D::scaled(const Size2 &p_scale) const {
+	Transform2D result = *this;
+	result[0] *= p_scale.x;
+	result[1] *= p_scale.y;
+	return result;
+}
+
+Transform2D Transform2D::pre_scaled(const Size2 &p_scale) const {
+	Transform2D result = *this;
+	result[0] *= p_scale;
+	result[1] *= p_scale;
+	result[2] *= p_scale;
+	return result;
+}
+
+Transform2D Transform2D::rotated(const real_t p_radians) const {
+	Transform2D result = *this;
+	result *= Transform2D(p_radians, Vector2());
+	return result;
+}
+
+Transform2D Transform2D::pre_rotated(const real_t p_radians) const {
+	Transform2D result = Transform2D(p_radians, Vector2());
+	result *= *this;
+	return result;
 }
 
 Transform2D Transform2D::untranslated() const {
-	Transform2D copy = *this;
-	copy.elements[2] = Vector2();
-	return copy;
-}
-
-Transform2D Transform2D::translated(const Vector2 &p_offset) const {
-	Transform2D copy = *this;
-	copy.translate(p_offset);
-	return copy;
-}
-
-Transform2D Transform2D::rotated(const real_t p_phi) const {
-	Transform2D copy = *this;
-	copy.rotate(p_phi);
-	return copy;
+	Transform2D result = *this;
+	result.elements[2] = Vector2();
+	return result;
 }
 
 real_t Transform2D::basis_determinant() const {

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -89,10 +89,12 @@ struct _NO_DISCARD_ Transform2D {
 	_FORCE_INLINE_ const Vector2 &get_origin() const { return elements[2]; }
 	_FORCE_INLINE_ void set_origin(const Vector2 &p_origin) { elements[2] = p_origin; }
 
-	Transform2D scaled(const Size2 &p_scale) const;
-	Transform2D basis_scaled(const Size2 &p_scale) const;
 	Transform2D translated(const Vector2 &p_offset) const;
-	Transform2D rotated(const real_t p_phi) const;
+	Transform2D pre_translated(const Vector2 &p_offset) const;
+	Transform2D scaled(const Size2 &p_scale) const;
+	Transform2D pre_scaled(const Size2 &p_scale) const;
+	Transform2D rotated(const real_t p_radians) const;
+	Transform2D pre_rotated(const real_t p_radians) const;
 
 	Transform2D untranslated() const;
 

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -61,10 +61,6 @@ void Transform3D::rotate(const Vector3 &p_axis, real_t p_phi) {
 	*this = rotated(p_axis, p_phi);
 }
 
-Transform3D Transform3D::rotated(const Vector3 &p_axis, real_t p_phi) const {
-	return Transform3D(Basis(p_axis, p_phi), Vector3()) * (*this);
-}
-
 void Transform3D::rotate_basis(const Vector3 &p_axis, real_t p_phi) {
 	basis.rotate(p_axis, p_phi);
 }
@@ -113,12 +109,6 @@ void Transform3D::scale(const Vector3 &p_scale) {
 	origin *= p_scale;
 }
 
-Transform3D Transform3D::scaled(const Vector3 &p_scale) const {
-	Transform3D t = *this;
-	t.scale(p_scale);
-	return t;
-}
-
 void Transform3D::scale_basis(const Vector3 &p_scale) {
 	basis.scale(p_scale);
 }
@@ -133,10 +123,47 @@ void Transform3D::translate(const Vector3 &p_translation) {
 	}
 }
 
-Transform3D Transform3D::translated(const Vector3 &p_translation) const {
-	Transform3D t = *this;
-	t.translate(p_translation);
-	return t;
+Transform3D Transform3D::translated(const Vector3 &p_offset) const {
+	Transform3D result = *this;
+	result.origin.x += basis[0].dot(p_offset);
+	result.origin.y += basis[1].dot(p_offset);
+	result.origin.z += basis[2].dot(p_offset);
+	return result;
+}
+
+Transform3D Transform3D::pre_translated(const Vector3 &p_offset) const {
+	Transform3D result = *this;
+	result.origin += p_offset;
+	return result;
+}
+
+Transform3D Transform3D::scaled(const Vector3 &p_scale) const {
+	Transform3D result = *this;
+	result.basis[0] *= p_scale;
+	result.basis[1] *= p_scale;
+	result.basis[2] *= p_scale;
+	return result;
+}
+
+Transform3D Transform3D::pre_scaled(const Vector3 &p_scale) const {
+	Transform3D result = *this;
+	result.basis[0] *= p_scale.x;
+	result.basis[1] *= p_scale.y;
+	result.basis[2] *= p_scale.z;
+	result.origin *= p_scale;
+	return result;
+}
+
+Transform3D Transform3D::rotated(const Vector3 &p_axis, real_t p_radians) const {
+	Transform3D result = *this;
+	result *= Transform3D(Basis(p_axis, p_radians), Vector3());
+	return result;
+}
+
+Transform3D Transform3D::pre_rotated(const Vector3 &p_axis, real_t p_radians) const {
+	Transform3D result(Basis(p_axis, p_radians), Vector3());
+	result *= *this;
+	return result;
 }
 
 void Transform3D::orthonormalize() {

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -46,8 +46,6 @@ public:
 	void affine_invert();
 	Transform3D affine_inverse() const;
 
-	Transform3D rotated(const Vector3 &p_axis, real_t p_phi) const;
-
 	void rotate(const Vector3 &p_axis, real_t p_phi);
 	void rotate_basis(const Vector3 &p_axis, real_t p_phi);
 
@@ -55,11 +53,16 @@ public:
 	Transform3D looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0)) const;
 
 	void scale(const Vector3 &p_scale);
-	Transform3D scaled(const Vector3 &p_scale) const;
 	void scale_basis(const Vector3 &p_scale);
 	void translate(real_t p_tx, real_t p_ty, real_t p_tz);
 	void translate(const Vector3 &p_translation);
+
 	Transform3D translated(const Vector3 &p_translation) const;
+	Transform3D pre_translated(const Vector3 &p_translation) const;
+	Transform3D scaled(const Vector3 &p_scale) const;
+	Transform3D pre_scaled(const Vector3 &p_scale) const;
+	Transform3D rotated(const Vector3 &p_axis, real_t p_radians) const;
+	Transform3D pre_rotated(const Vector3 &p_axis, real_t p_radians) const;
 
 	const Basis &get_basis() const { return basis; }
 	void set_basis(const Basis &p_basis) { basis = p_basis; }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1720,9 +1720,12 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform2D, get_scale, sarray(), varray());
 	bind_method(Transform2D, get_skew, sarray(), varray());
 	bind_method(Transform2D, orthonormalized, sarray(), varray());
-	bind_method(Transform2D, rotated, sarray("phi"), varray());
+	bind_method(Transform2D, rotated, sarray("radians"), varray());
+	bind_method(Transform2D, pre_rotated, sarray("radians"), varray());
 	bind_method(Transform2D, scaled, sarray("scale"), varray());
+	bind_method(Transform2D, pre_scaled, sarray("scale"), varray());
 	bind_method(Transform2D, translated, sarray("offset"), varray());
+	bind_method(Transform2D, pre_translated, sarray("offset"), varray());
 	bind_method(Transform2D, basis_xform, sarray("v"), varray());
 	bind_method(Transform2D, basis_xform_inv, sarray("v"), varray());
 	bind_method(Transform2D, interpolate_with, sarray("xform", "weight"), varray());
@@ -1785,9 +1788,12 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform3D, inverse, sarray(), varray());
 	bind_method(Transform3D, affine_inverse, sarray(), varray());
 	bind_method(Transform3D, orthonormalized, sarray(), varray());
-	bind_method(Transform3D, rotated, sarray("axis", "phi"), varray());
+	bind_method(Transform3D, rotated, sarray("axis", "radians"), varray());
+	bind_method(Transform3D, pre_rotated, sarray("axis", "radians"), varray());
 	bind_method(Transform3D, scaled, sarray("scale"), varray());
+	bind_method(Transform3D, pre_scaled, sarray("scale"), varray());
 	bind_method(Transform3D, translated, sarray("offset"), varray());
+	bind_method(Transform3D, pre_translated, sarray("offset"), varray());
 	bind_method(Transform3D, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
 	bind_method(Transform3D, sphere_interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, interpolate_with, sarray("xform", "weight"), varray());

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -137,18 +137,44 @@
 				Returns the transform with the basis orthogonal (90 degrees), and normalized axis vectors (scale of 1 or -1).
 			</description>
 		</method>
+		<method name="pre_rotated" qualifiers="const">
+			<return type="Transform2D" />
+			<argument index="0" name="radians" type="float" />
+			<description>
+				Returns the transform rotated by the given angle (in radians) in the parent's reference frame.
+				[b]Note[/b]: To peform the rotation in the local reference frame, use [method rotated].
+			</description>
+		</method>
+		<method name="pre_scaled" qualifiers="const">
+			<return type="Transform2D" />
+			<argument index="0" name="scale" type="Vector2" />
+			<description>
+				Returns the transform scaled by the given scale factor in the parent's reference frame.
+				[b]Note[/b]: To peform the scaling in the local reference frame, use [method scaled].
+			</description>
+		</method>
+		<method name="pre_translated" qualifiers="const">
+			<return type="Transform2D" />
+			<argument index="0" name="offset" type="Vector2" />
+			<description>
+				Returns the transform translated by the given offset in the parent's reference frame.
+				[b]Note[/b]: To peform the translation in the local reference frame, use [method translated].
+			</description>
+		</method>
 		<method name="rotated" qualifiers="const">
 			<return type="Transform2D" />
-			<argument index="0" name="phi" type="float" />
+			<argument index="0" name="radians" type="float" />
 			<description>
-				Rotates the transform by the given angle (in radians), using matrix multiplication.
+				Returns the transform rotated by the given angle (in radians).
+				[b]Note[/b]: The rotation is performed in the local reference frame. To peform the rotation in the parent's reference frame, use [method pre_rotated].
 			</description>
 		</method>
 		<method name="scaled" qualifiers="const">
 			<return type="Transform2D" />
 			<argument index="0" name="scale" type="Vector2" />
 			<description>
-				Scales the transform by the given scale factor, using matrix multiplication.
+				Returns the transform scaled by the given scale factor.
+				[b]Note[/b]: The scaling is performed in the local reference frame. To peform the scaling in the parent's reference frame, use [method pre_scaled].
 			</description>
 		</method>
 		<method name="set_rotation">
@@ -176,8 +202,8 @@
 			<return type="Transform2D" />
 			<argument index="0" name="offset" type="Vector2" />
 			<description>
-				Translates the transform by the given offset, relative to the transform's basis vectors.
-				Unlike [method rotated] and [method scaled], this does not use matrix multiplication.
+				Returns the transform translated by the given offset.
+				[b]Note[/b]: The translation is performed in the local reference frame. To peform the translation in the parent's reference frame, use [method pre_translated].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -91,19 +91,46 @@
 				Returns the transform with the basis orthogonal (90 degrees), and normalized axis vectors (scale of 1 or -1).
 			</description>
 		</method>
+		<method name="pre_rotated" qualifiers="const">
+			<return type="Transform3D" />
+			<argument index="0" name="axis" type="Vector3" />
+			<argument index="1" name="radians" type="float" />
+			<description>
+				Returns the transform rotated around the given axis by the given angle (in radians) in the parent's reference frame. The axis must be a normalized vector.
+				[b]Note[/b]: To peform the rotation in the local reference frame, use [method rotated].
+			</description>
+		</method>
+		<method name="pre_scaled" qualifiers="const">
+			<return type="Transform3D" />
+			<argument index="0" name="scale" type="Vector3" />
+			<description>
+				Returns the transform scaled by the given scale factor in the parent's reference frame.
+				[b]Note[/b]: To peform the scaling in the local reference frame, use [method scaled].
+			</description>
+		</method>
+		<method name="pre_translated" qualifiers="const">
+			<return type="Transform3D" />
+			<argument index="0" name="offset" type="Vector3" />
+			<description>
+				Returns the transform translated by the given offset in the parent's reference frame.
+				[b]Note[/b]: To peform the translation in the local reference frame, use [method translated].
+			</description>
+		</method>
 		<method name="rotated" qualifiers="const">
 			<return type="Transform3D" />
 			<argument index="0" name="axis" type="Vector3" />
-			<argument index="1" name="phi" type="float" />
+			<argument index="1" name="radians" type="float" />
 			<description>
-				Rotates the transform around the given axis by the given angle (in radians), using matrix multiplication. The axis must be a normalized vector.
+				Returns the transform rotated around the given axis by the given angle (in radians). The axis must be a normalized vector.
+				[b]Note[/b]: The rotation is performed in the local reference frame. To peform the rotation in the parent's reference frame, use [method pre_rotated].
 			</description>
 		</method>
 		<method name="scaled" qualifiers="const">
 			<return type="Transform3D" />
 			<argument index="0" name="scale" type="Vector3" />
 			<description>
-				Scales basis and origin of the transform by the given scale factor, using matrix multiplication.
+				Returns the transform scaled by the given scale factor.
+				[b]Note[/b]: The scaling is performed in the local reference frame. To peform the scaling in the parent's reference frame, use [method pre_scaled].
 			</description>
 		</method>
 		<method name="sphere_interpolate_with" qualifiers="const">
@@ -118,8 +145,8 @@
 			<return type="Transform3D" />
 			<argument index="0" name="offset" type="Vector3" />
 			<description>
-				Translates the transform by the given offset, relative to the transform's basis vectors.
-				Unlike [method rotated] and [method scaled], this does not use matrix multiplication.
+				Returns the transform translated by the given offset.
+				[b]Note[/b]: The translation is performed in the local reference frame. To peform the translation in the parent's reference frame, use [method pre_translated].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Currently, `Transform` and `Transform2D`'s `scaled()` and `rotated()` methods are performed in the parent reference frame (i.e. left matrix multiplication). This may make sense from a mathematical point of view, but it's not intuitive from the user's point of view, who expects the transform to take place in the local reference frame. Furthermore, it prevents these methods from being chained. To make it even more confusing, the `translated()` method does the intuitive transform in the local reference frame (i.e. right matrix multiplication). The result is, there is currently no simply way to recreate an editor's `Transfrom`'s `Translation`, `Rotation` and `Scale` using a series of `translated()`, `rotated()` and `scaled()` methods.

This PR makes the `scaled()` and `rotated()` perform a local transformation (i.e. right matrix multiplication) so they behave the same way as `translated()`. This not only makes them more intuitive, but it allows them to be chained.

Below are 2D and 3D demo projects showing how, with this PR, an object's `Translation`, `Rotation` and `Scale` can be easily recreated using chained `translated()`, `rotated()` and `scaled()` methods e.g.:
```
	var xform = Transform.IDENTITY
	xform = xform.translated(Vector3(-1.5, 0, 0))
	xform = xform.rotated(Vector3(0, 0, 1), deg2rad(20))
	xform = xform.scaled(Vector3(1, 1.5, 1))
	transform = xform
```
[2DTransforms.zip](https://github.com/godotengine/godot/files/6489711/2DTransforms.zip)
[3DTransforms.zip](https://github.com/godotengine/godot/files/6489713/3DTransforms.zip)

Properly fixes #34329
Closes https://github.com/godotengine/godot-proposals/issues/1336
