### PR TITLE
[3.x] ScrollContainer: Expose `_ensure_focused_visible` to the scripting API and rename it to `ensure_control_visible`

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -9,6 +9,15 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="ensure_control_visible">
+			<return type="void">
+			</return>
+			<argument index="0" name="control" type="Control">
+			</argument>
+			<description>
+				Ensures the given [code]control[/code] is visible (must be a direct or indirect child of the ScrollContainer). Used by [member follow_focus].
+			</description>
+		</method>
 		<method name="get_h_scrollbar">
 			<return type="HScrollBar">
 			</return>

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1428,16 +1428,7 @@ Vector<ProjectList::Item> ProjectList::get_selected_projects() const {
 
 void ProjectList::ensure_project_visible(int p_index) {
 	const Item &item = _projects[p_index];
-
-	int item_top = item.control->get_position().y;
-	int item_bottom = item.control->get_position().y + item.control->get_size().y;
-
-	if (item_top < get_v_scroll()) {
-		set_v_scroll(item_top);
-
-	} else if (item_bottom > get_v_scroll() + get_size().y) {
-		set_v_scroll(item_bottom - get_size().y);
-	}
+	ensure_control_visible(item.control);
 }
 
 int ProjectList::get_single_selected_index() const {

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -69,13 +69,13 @@ protected:
 	Size2 get_minimum_size() const;
 
 	void _gui_input(const Ref<InputEvent> &p_gui_input);
+	void _gui_focus_changed(Control *p_control);
 	void _notification(int p_what);
 
 	void _scroll_moved(float);
 	static void _bind_methods();
 
 	void _update_scrollbar_position();
-	void _ensure_focused_visible(Control *p_node);
 
 public:
 	int get_v_scroll() const;
@@ -98,6 +98,7 @@ public:
 
 	HScrollBar *get_h_scrollbar();
 	VScrollBar *get_v_scrollbar();
+	void ensure_control_visible(Control *p_control);
 
 	virtual bool clips_input() const;
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
3.x version of https://github.com/godotengine/godot/pull/48770