### PR TITLE
Fix normals of PrismMesh

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -1133,7 +1133,7 @@ void PrismMesh::_create_mesh_array(Array &p_arr) const {
 	Vector3 normal_left, normal_right;
 
 	normal_left = Vector3(-size.y, size.x * left_to_right, 0.0);
-	normal_right = Vector3(size.y, size.x * left_to_right, 0.0);
+	normal_right = Vector3(size.y, size.x * (1.0 - left_to_right), 0.0);
 	normal_left.normalize();
 	normal_right.normalize();
 


### PR DESCRIPTION
Fixes #48774.

This also seems to be broken in 4.0 so I'm making a PR for master.
