### PR TITLE
Use less blur for distant directional shadow splits

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -1479,62 +1479,78 @@ void main() {
 				} else { //no soft shadows
 
 					vec4 pssm_coord;
+					float blur_factor;
+
 					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 0)
 
 						pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
+						blur_factor = 1.0;
 					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 1)
 
 						pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
+						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
 					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 2)
 
 						pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
-
+						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
 					} else {
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 3)
 
 						pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
+						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
 					}
 
 					pssm_coord /= pssm_coord.w;
 
-					shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
+					shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * blur_factor, pssm_coord);
 
 					if (directional_lights.data[i].blend_splits) {
 						float pssm_blend;
+						float blur_factor2;
 
 						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
 							vec4 v = vec4(vertex, 1.0);
 							BIAS_FUNC(v, 1)
 							pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 							pssm_blend = smoothstep(0.0, directional_lights.data[i].shadow_split_offsets.x, depth_z);
+							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
 						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
 							vec4 v = vec4(vertex, 1.0);
 							BIAS_FUNC(v, 2)
 							pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 							pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x, directional_lights.data[i].shadow_split_offsets.y, depth_z);
+							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
 						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
 							vec4 v = vec4(vertex, 1.0);
 							BIAS_FUNC(v, 3)
 							pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
 							pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y, directional_lights.data[i].shadow_split_offsets.z, depth_z);
+							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
+							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
 						} else {
 							pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
+							blur_factor2 = 1.0;
 						}
 
 						pssm_coord /= pssm_coord.w;
 
-						float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
+						float shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * blur_factor2, pssm_coord);
 						shadow = mix(shadow, shadow2, pssm_blend);
 					}
 				}


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/60186.

This makes the transition between shadow splits less noticeable, specially when the expensive Blend Splits property is disabled. In many scenarios, you no longer need to enable Blend Splits to get good directional shadow appearance.

~~From empirical benchmarking, this seems to have a small performance cost (average 160.6 FPS over 5 screenshots instead of 163.8 FPS). I'm not sure if this is introduced by benchmarking. It's not very scientific since I carried this out from the editor and its fluctuating frame time information.~~
**Edit:** Further testing didn't reveal any performance difference.

This closes https://github.com/godotengine/godot-proposals/issues/2729.

**Note:** Not cherry-pickable to the `3.x` branch, since this relies on the per-light shadow blur feature found in the new Vulkan renderer.

`3.x` equivalent of this PR (doesn't work with Blend Splits enabled yet): https://github.com/Calinou/godot/tree/directional-shadow-distant-split-lower-blur-3.x

## TODO

- [x] Don't hardcode the blur factors. Instead, calculate them based on the effective "share".
  - By default, the multipliers would be:
    - `1.0` for the first split.
    - `0.5` for the second split.
    - `0.2` for the third split.
    - `0.1` for the fourth (and last) split.
  - These multipliers should change automatically when the split offsets are adjusted in the DirectionalLight.
- [x] Adapt the mobile renderer shader code as well.

## Preview

***Note:** GI and ambient lighting was disabled to make the difference in shadow rendering more obvious.*

### Before

*Distant shadows have less detail. There is a noticeable "cut" between splits near the lamp posts in the middle of the image.*

![Old shadows](https://user-images.githubusercontent.com/180032/118413757-2f086000-b6a1-11eb-8307-7d4bd18437a4.png)

### After

*Distant shadows keep a similar level of detail. Despite Blend Splits being disabled, the cut between splits is now much less noticeable.*

![New shadows](https://user-images.githubusercontent.com/180032/118413754-2d3e9c80-b6a1-11eb-9816-010ef5d9dc27.png)