### PR TITLE
Fix typo in InputEventMIDI string

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1457,7 +1457,7 @@ String InputEventMIDI::as_text() const {
 }
 
 String InputEventMIDI::to_string() {
-	return vformat("InputEvenMIDI: channel=%d, message=%d, pitch=%d, velocity=%d, pressure=%d", channel, message, pitch, velocity, pressure);
+	return vformat("InputEventMIDI: channel=%d, message=%d, pitch=%d, velocity=%d, pressure=%d", channel, message, pitch, velocity, pressure);
 }
 
 void InputEventMIDI::_bind_methods() {


### PR DESCRIPTION
InputEvenMIDI -> InputEventMIDI in to_string() method