### PR TITLE
GDScript: Fix crash caused by uninitialized temp stack slots

### DIFF
--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -496,6 +496,8 @@ private:
 	Vector<GDScriptDataType> argument_types;
 	GDScriptDataType return_type;
 
+	Map<int, Variant::Type> temporary_slots;
+
 #ifdef TOOLS_ENABLED
 	Vector<StringName> arg_names;
 	Vector<Variant> default_arg_values;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -152,6 +152,44 @@ String GDScriptFunction::_get_call_error(const Callable::CallError &p_err, const
 	return err_text;
 }
 
+void (*type_init_function_table[])(Variant *) = {
+	nullptr, // NIL (shouldn't be called).
+	&VariantInitializer<bool>::init, // BOOL.
+	&VariantInitializer<int64_t>::init, // INT.
+	&VariantInitializer<double>::init, // FLOAT.
+	&VariantInitializer<String>::init, // STRING.
+	&VariantInitializer<Vector2>::init, // VECTOR2.
+	&VariantInitializer<Vector2i>::init, // VECTOR2I.
+	&VariantInitializer<Rect2>::init, // RECT2.
+	&VariantInitializer<Rect2i>::init, // RECT2I.
+	&VariantInitializer<Vector3>::init, // VECTOR3.
+	&VariantInitializer<Vector3i>::init, // VECTOR3I.
+	&VariantInitializer<Transform2D>::init, // TRANSFORM2D.
+	&VariantInitializer<Plane>::init, // PLANE.
+	&VariantInitializer<Quat>::init, // QUAT.
+	&VariantInitializer<AABB>::init, // AABB.
+	&VariantInitializer<Basis>::init, // BASIS.
+	&VariantInitializer<Transform>::init, // TRANSFORM.
+	&VariantInitializer<Color>::init, // COLOR.
+	&VariantInitializer<StringName>::init, // STRING_NAME.
+	&VariantInitializer<NodePath>::init, // NODE_PATH.
+	&VariantInitializer<RID>::init, // RID.
+	&VariantTypeAdjust<Object *>::adjust, // OBJECT.
+	&VariantInitializer<Callable>::init, // CALLABLE.
+	&VariantInitializer<Signal>::init, // SIGNAL.
+	&VariantInitializer<Dictionary>::init, // DICTIONARY.
+	&VariantInitializer<Array>::init, // ARRAY.
+	&VariantInitializer<PackedByteArray>::init, // PACKED_BYTE_ARRAY.
+	&VariantInitializer<PackedInt32Array>::init, // PACKED_INT32_ARRAY.
+	&VariantInitializer<PackedInt64Array>::init, // PACKED_INT64_ARRAY.
+	&VariantInitializer<PackedFloat32Array>::init, // PACKED_FLOAT32_ARRAY.
+	&VariantInitializer<PackedFloat64Array>::init, // PACKED_FLOAT64_ARRAY.
+	&VariantInitializer<PackedStringArray>::init, // PACKED_STRING_ARRAY.
+	&VariantInitializer<PackedVector2Array>::init, // PACKED_VECTOR2_ARRAY.
+	&VariantInitializer<PackedVector3Array>::init, // PACKED_VECTOR3_ARRAY.
+	&VariantInitializer<PackedColorArray>::init, // PACKED_COLOR_ARRAY.
+};
+
 #if defined(__GNUC__)
 #define OPCODES_TABLE                                \
 	static const void *switch_table_ops[] = {        \
@@ -490,6 +528,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	}
 
 	memnew_placement(&stack[ADDR_STACK_CLASS], Variant(script));
+
+	for (const Map<int, Variant::Type>::Element *E = temporary_slots.front(); E; E = E->next()) {
+		type_init_function_table[E->get()](&stack[E->key()]);
+	}
 
 	String err_text;
 


### PR DESCRIPTION
This adds initialization to every typed temporary stack slot at the beginning of the function call instead of emitting instructions, since those might be in a conditional branch and not be called.

Fix #48215