### PR TITLE
Set and update the path of the `ViewportTexture` of a `Viewport`

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -492,10 +492,17 @@ void Viewport::_notification(int p_what) {
 			}
 #endif
 
+			default_texture->set_viewport_path_in_scene(get_path());
+
 			// Enable processing for tooltips, collision debugging, physics object picking, etc.
 			set_process_internal(true);
 			set_physics_process_internal(true);
 
+		} break;
+		case NOTIFICATION_PARENTED: {
+			if (is_inside_tree()) {
+				default_texture->set_viewport_path_in_scene(get_path());
+			}
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			_gui_cancel_tooltip();


### PR DESCRIPTION
The `viewport_path` property of `Viewport`'s `ViewportTextures` is empty because the path isn't being set. This can cause problems in some cases. This PR set's the path as soon as the Viewport enters the tree, and when the path changes.

Related: #46631

**Steps to reproduce the issue:**
Create a viewport and print the path of it's texture:
`print(get_texture().viewport_path))` -> prints `""`, even though the path is something like `/root/Main/Viewport`.