### PR TITLE
Check if input marked handled before processing additional CollisionObjects

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -819,6 +819,9 @@ void Viewport::_process_picking() {
 					sorter.sort(res, rc);
 				}
 				for (int i = 0; i < rc; i++) {
+					if (is_input_handled()) {
+						break;
+					}
 					if (res[i].collider_id.is_valid() && res[i].collider) {
 						CollisionObject2D *co = Object::cast_to<CollisionObject2D>(res[i].collider);
 						if (co && co->can_process()) {


### PR DESCRIPTION
Currently, when processing picking, all `CollisionObject2D`s under the mouse pointer are processed regardless of whether or not `set_input_as_handled()` was called. This PR checks whether `set_input_as_handled()` has been called before processing additional `CollisionObject2D`s.

Fixes #48788
