### PR TITLE
Added support for scripts reporting multiple errors to ScriptTextEditor

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -268,6 +268,12 @@ public:
 		String message;
 	};
 
+	struct ScriptError {
+		int line = -1;
+		int column = -1;
+		String message;
+	};
+
 	void get_core_type_words(List<String> *p_core_type_words) const;
 	virtual void get_reserved_words(List<String> *p_words) const = 0;
 	virtual bool is_control_flow_keyword(String p_string) const = 0;
@@ -276,7 +282,7 @@ public:
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const = 0;
 	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) {}
 	virtual bool is_using_templates() { return false; }
-	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = nullptr, List<Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const = 0;
+	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptError> *r_errors = nullptr, List<Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const = 0;
 	virtual String validate_path(const String &p_path) const { return ""; }
 	virtual Script *create_script() const = 0;
 	virtual bool has_named_classes() const = 0;

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1612,15 +1612,19 @@ void CodeTextEditor::validate_script() {
 	idle->start();
 }
 
-void CodeTextEditor::_warning_label_gui_input(const Ref<InputEvent> &p_event) {
-	Ref<InputEventMouseButton> mb = p_event;
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MOUSE_BUTTON_LEFT) {
-		_warning_button_pressed();
-	}
+void CodeTextEditor::_error_button_pressed() {
+	_set_show_errors_panel(!is_errors_panel_opened);
+	_set_show_warnings_panel(false);
 }
 
 void CodeTextEditor::_warning_button_pressed() {
 	_set_show_warnings_panel(!is_warnings_panel_opened);
+	_set_show_errors_panel(false);
+}
+
+void CodeTextEditor::_set_show_errors_panel(bool p_show) {
+	is_errors_panel_opened = p_show;
+	emit_signal("show_errors_panel", p_show);
 }
 
 void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
@@ -1653,6 +1657,7 @@ void CodeTextEditor::_notification(int p_what) {
 			_update_font();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
+			error_button->set_icon(get_theme_icon("StatusError", "EditorIcons"));
 			warning_button->set_icon(get_theme_icon("NodeWarning", "EditorIcons"));
 			add_theme_constant_override("separation", 4 * EDSCALE);
 		} break;
@@ -1667,11 +1672,18 @@ void CodeTextEditor::_notification(int p_what) {
 	}
 }
 
-void CodeTextEditor::set_warning_nb(int p_warning_nb) {
-	warning_count_label->set_text(itos(p_warning_nb));
-	warning_count_label->set_visible(p_warning_nb > 0);
-	warning_button->set_visible(p_warning_nb > 0);
-	if (!p_warning_nb) {
+void CodeTextEditor::set_error_count(int p_error_count) {
+	error_button->set_text(itos(p_error_count));
+	error_button->set_visible(p_error_count > 0);
+	if (!p_error_count) {
+		_set_show_errors_panel(false);
+	}
+}
+
+void CodeTextEditor::set_warning_count(int p_warning_count) {
+	warning_button->set_text(itos(p_warning_count));
+	warning_button->set_visible(p_warning_count > 0);
+	if (!p_warning_count) {
 		_set_show_warnings_panel(false);
 	}
 }
@@ -1738,6 +1750,7 @@ void CodeTextEditor::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("validate_script"));
 	ADD_SIGNAL(MethodInfo("load_theme_settings"));
+	ADD_SIGNAL(MethodInfo("show_errors_panel"));
 	ADD_SIGNAL(MethodInfo("show_warnings_panel"));
 }
 
@@ -1835,6 +1848,22 @@ CodeTextEditor::CodeTextEditor() {
 	error->set_mouse_filter(MOUSE_FILTER_STOP);
 	error->connect("gui_input", callable_mp(this, &CodeTextEditor::_error_pressed));
 
+	// Errors
+	error_button = memnew(Button);
+	error_button->set_flat(true);
+	status_bar->add_child(error_button);
+	error_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
+	error_button->set_default_cursor_shape(CURSOR_POINTING_HAND);
+	error_button->connect("pressed", callable_mp(this, &CodeTextEditor::_error_button_pressed));
+	error_button->set_tooltip(TTR("Errors"));
+
+	error_button->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("error_color", "Editor"));
+	error_button->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
+	error_button->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
+
+	is_errors_panel_opened = false;
+	set_error_count(0);
+
 	// Warnings
 	warning_button = memnew(Button);
 	warning_button->set_flat(true);
@@ -1844,20 +1873,12 @@ CodeTextEditor::CodeTextEditor() {
 	warning_button->connect("pressed", callable_mp(this, &CodeTextEditor::_warning_button_pressed));
 	warning_button->set_tooltip(TTR("Warnings"));
 
-	warning_count_label = memnew(Label);
-	status_bar->add_child(warning_count_label);
-	warning_count_label->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
-	warning_count_label->set_align(Label::ALIGN_RIGHT);
-	warning_count_label->set_default_cursor_shape(CURSOR_POINTING_HAND);
-	warning_count_label->set_mouse_filter(MOUSE_FILTER_STOP);
-	warning_count_label->set_tooltip(TTR("Warnings"));
-	warning_count_label->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("warning_color", "Editor"));
-	warning_count_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
-	warning_count_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
-	warning_count_label->connect("gui_input", callable_mp(this, &CodeTextEditor::_warning_label_gui_input));
+	warning_button->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color("warning_color", "Editor"));
+	warning_button->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("status_source", "EditorFonts"));
+	warning_button->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size("status_source_size", "EditorFonts"));
 
 	is_warnings_panel_opened = false;
-	set_warning_nb(0);
+	set_warning_count(0);
 
 	// Line and column
 	line_and_col_txt = memnew(Label);

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -145,8 +145,8 @@ class CodeTextEditor : public VBoxContainer {
 	HBoxContainer *status_bar;
 
 	Button *toggle_scripts_button;
+	Button *error_button;
 	Button *warning_button;
-	Label *warning_count_label;
 
 	Label *line_and_col_txt;
 
@@ -184,8 +184,9 @@ class CodeTextEditor : public VBoxContainer {
 	CodeTextEditorCodeCompleteFunc code_complete_func;
 	void *code_complete_ud;
 
-	void _warning_label_gui_input(const Ref<InputEvent> &p_event);
+	void _error_button_pressed();
 	void _warning_button_pressed();
+	void _set_show_errors_panel(bool p_show);
 	void _set_show_warnings_panel(bool p_show);
 	void _error_pressed(const Ref<InputEvent> &p_event);
 
@@ -205,6 +206,7 @@ protected:
 	static void _bind_methods();
 
 	bool is_warnings_panel_opened;
+	bool is_errors_panel_opened;
 
 public:
 	void trim_trailing_whitespace();
@@ -238,7 +240,8 @@ public:
 	Variant get_edit_state();
 	void set_edit_state(const Variant &p_state);
 
-	void set_warning_nb(int p_warning_nb);
+	void set_error_count(int p_error_count);
+	void set_warning_count(int p_warning_count);
 
 	void update_editor_settings();
 	void set_error(const String &p_error);

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -55,6 +55,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 
 	CodeTextEditor *code_editor = nullptr;
 	RichTextLabel *warnings_panel = nullptr;
+	RichTextLabel *errors_panel = nullptr;
 
 	Ref<Script> script;
 	bool script_is_valid = false;
@@ -161,7 +162,9 @@ protected:
 
 	void _load_theme_settings();
 	void _set_theme_for_script();
+	void _show_errors_panel(bool p_show);
 	void _show_warnings_panel(bool p_show);
+	void _error_clicked(Variant p_line);
 	void _warning_clicked(Variant p_line);
 
 	void _notification(int p_what);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -240,7 +240,7 @@ void ShaderTextEditor::_validate_script() {
 		warnings.sort_custom<WarningsComparator>();
 		_update_warning_panel();
 	} else {
-		set_warning_nb(0);
+		set_warning_count(0);
 	}
 	emit_signal("script_changed");
 }
@@ -280,7 +280,7 @@ void ShaderTextEditor::_update_warning_panel() {
 	}
 	warnings_panel->pop(); // Table.
 
-	set_warning_nb(warning_count);
+	set_warning_count(warning_count);
 }
 
 void ShaderTextEditor::_bind_methods() {

--- a/modules/gdnative/include/pluginscript/godot_pluginscript.h
+++ b/modules/gdnative/include/pluginscript/godot_pluginscript.h
@@ -132,7 +132,7 @@ typedef struct {
 	godot_bool can_inherit_from_file;
 
 	godot_string (*get_template_source_code)(godot_pluginscript_language_data *p_data, const godot_string *p_class_name, const godot_string *p_base_class_name);
-	godot_bool (*validate)(godot_pluginscript_language_data *p_data, const godot_string *p_script, int *r_line_error, int *r_col_error, godot_string *r_test_error, const godot_string *p_path, godot_packed_string_array *r_functions);
+	godot_bool (*validate)(godot_pluginscript_language_data *p_data, const godot_string *p_script, const godot_string *p_path, godot_packed_string_array *r_functions, godot_array *r_errors); // errors = Array of Dictionary with "line", "column", "message" keys
 	int (*find_function)(godot_pluginscript_language_data *p_data, const godot_string *p_function, const godot_string *p_code); // Can be nullptr
 	godot_string (*make_function)(godot_pluginscript_language_data *p_data, const godot_string *p_class, const godot_string *p_name, const godot_packed_string_array *p_args);
 	godot_error (*complete_code)(godot_pluginscript_language_data *p_data, const godot_string *p_code, const godot_string *p_path, godot_object *p_owner, godot_array *r_options, godot_bool *r_force, godot_string *r_call_hint);

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1035,7 +1035,7 @@ Ref<Script> NativeScriptLanguage::get_template(const String &p_class_name, const
 	return Ref<NativeScript>(s);
 }
 
-bool NativeScriptLanguage::validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path, List<String> *r_functions, List<ScriptLanguage::Warning> *r_warnings, Set<int> *r_safe_lines) const {
+bool NativeScriptLanguage::validate(const String &p_script, const String &p_path, List<String> *r_functions, List<ScriptLanguage::ScriptError> *r_errors, List<ScriptLanguage::Warning> *r_warnings, Set<int> *r_safe_lines) const {
 	return true;
 }
 

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -317,7 +317,7 @@ public:
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const;
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;
-	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path, List<String> *r_functions, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
+	virtual bool validate(const String &p_script, const String &p_path, List<String> *r_functions, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
 	virtual bool supports_builtin_mode() const;

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -112,19 +112,28 @@ Ref<Script> PluginScriptLanguage::get_template(const String &p_class_name, const
 	return script;
 }
 
-bool PluginScriptLanguage::validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path, List<String> *r_functions, List<ScriptLanguage::Warning> *r_warnings, Set<int> *r_safe_lines) const {
+bool PluginScriptLanguage::validate(const String &p_script, const String &p_path, List<String> *r_functions, List<ScriptLanguage::ScriptError> *r_errors, List<ScriptLanguage::Warning> *r_warnings, Set<int> *r_safe_lines) const {
 	PackedStringArray functions;
+	Array errors;
 	if (_desc.validate) {
 		bool ret = _desc.validate(
 				_data,
 				(godot_string *)&p_script,
-				&r_line_error,
-				&r_col_error,
-				(godot_string *)&r_test_error,
 				(godot_string *)&p_path,
-				(godot_packed_string_array *)&functions);
+				(godot_packed_string_array *)&functions,
+				(godot_array *)&errors);
 		for (int i = 0; i < functions.size(); i++) {
 			r_functions->push_back(functions[i]);
+		}
+		if (r_errors) {
+			for (int i = 0; i < errors.size(); i++) {
+				Dictionary error = errors[i];
+				ScriptLanguage::ScriptError e;
+				e.line = error["line"];
+				e.column = error["column"];
+				e.message = error["message"];
+				r_errors->push_back(e);
+			}
 		}
 		return ret;
 	}

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -75,7 +75,7 @@ public:
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const;
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;
-	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
+	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
 	virtual bool supports_builtin_mode() const;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -447,7 +447,7 @@ public:
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;
 	virtual bool is_using_templates();
 	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script);
-	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
+	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
 	virtual bool supports_builtin_mode() const;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -455,9 +455,8 @@ public:
 	Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const override;
 	bool is_using_templates() override;
 	void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) override;
-	/* TODO */ bool validate(const String &p_script, int &r_line_error, int &r_col_error,
-			String &r_test_error, const String &p_path, List<String> *r_functions,
-			List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const override {
+	/* TODO */ bool validate(const String &p_script, const String &p_path, List<String> *r_functions,
+			List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const override {
 		return true;
 	}
 	String validate_path(const String &p_path) const override;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2276,7 +2276,7 @@ void VisualScriptLanguage::make_template(const String &p_class_name, const Strin
 	script->set_instance_base_type(p_base_class_name);
 }
 
-bool VisualScriptLanguage::validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path, List<String> *r_functions, List<ScriptLanguage::Warning> *r_warnings, Set<int> *r_safe_lines) const {
+bool VisualScriptLanguage::validate(const String &p_script, const String &p_path, List<String> *r_functions, List<ScriptLanguage::ScriptError> *r_errors, List<ScriptLanguage::Warning> *r_warnings, Set<int> *r_safe_lines) const {
 	return false;
 }
 

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -571,7 +571,7 @@ public:
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;
 	virtual bool is_using_templates();
 	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script);
-	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
+	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, Set<int> *r_safe_lines = nullptr) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
 	virtual bool supports_builtin_mode() const;


### PR DESCRIPTION
Scripts can now report multiple errors to the scripting editor in the engine. UI elements were added to support multiple errors.

I can't find a ticket for this but it is known to be a common request. Since the ability was added in GDScript, it's time to bring it into the Godot UI.

This required changes to `Native` and `Plugin`-script code so that needs to be checked too.

**Preview:**
![image](https://user-images.githubusercontent.com/41730826/118586067-709e2580-b7dd-11eb-9dd2-d16f74298e2e.png)

**Notes**
The error button next to the warning button can be clicked to toggle the panel of errors.
The label above the panel shows the first error detected... This is for backwards compatibility reasons mainly (e.g. the shader editor doe not support multiple errors), but also helpful as a quick reference as to what the error is, until something like the below can be implemented (in another PR):
![image](https://user-images.githubusercontent.com/41730826/118585428-34b69080-b7dc-11eb-80de-7c653fa907cb.png)

Code simplifications were made. For example, the warning button used a button (icon only) and a label to display the number of errors... which is redundant. The error count is set in the button text now, and the warning `Label` could be removed.