### PR TITLE
Use a non-zero default size for SubViewports

### DIFF
--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -25,7 +25,7 @@
 		<member name="render_target_update_mode" type="int" setter="set_update_mode" getter="get_update_mode" enum="SubViewport.UpdateMode" default="2">
 			The update mode when the sub-viewport is used as a render target.
 		</member>
-		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i( 0, 0 )">
+		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i( 512, 512 )">
 			The width and height of the sub-viewport.
 		</member>
 		<member name="size_2d_override" type="Vector2i" setter="set_size_2d_override" getter="get_size_2d_override" default="Vector2i( 0, 0 )">

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -231,7 +231,7 @@ private:
 	Transform2D global_canvas_transform;
 	Transform2D stretch_transform;
 
-	Size2i size;
+	Size2i size = Size2i(512, 512);
 	Size2i size_2d_override;
 	bool size_allocated = false;
 	bool use_xr = false;


### PR DESCRIPTION
This makes viewports visible out of the box. While it's very unlikely that anyone is relying on zero-sized viewports, this is technically a breaking change.

This closes https://github.com/godotengine/godot/issues/19247 (see https://github.com/godotengine/godot/issues/19247#issuecomment-572704161).