### PR TITLE
Print a warning when importing a repeating NPOT texture in a GLES2 project

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -393,6 +393,21 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 	int tex_flags = 0;
 	if (repeat > 0) {
 		tex_flags |= Texture::FLAG_REPEAT;
+
+		const bool min_gles3 = GLOBAL_GET("rendering/quality/driver/driver_name") == "GLES3" &&
+							   !GLOBAL_GET("rendering/quality/driver/fallback_to_gles2");
+		if (!min_gles3 && !image->is_size_po2()) {
+			// The project can be run using GLES2. GLES2 does not guarantee that
+			// repeating textures with a non-power-of-two size will be displayed
+			// without artifacts (due to upscaling to the nearest power of 2).
+			if (GLOBAL_GET("rendering/quality/driver/fallback_to_gles2")) {
+				WARN_PRINT(vformat("%s: Imported a repeating texture with a size of %dx%d, but the project is configured to allow falling back to GLES2.\nNon-power-of-2 repeating textures may not display correctly on some platforms such as HTML5. This is because GLES2 does not mandate support for non-power-of-2 repeating textures.",
+						p_source_file, image->get_width(), image->get_height()));
+			} else {
+				WARN_PRINT(vformat("%s: Imported a repeating texture with a size of %dx%d, but the project is configured to use GLES2.\nNon-power-of-2 repeating textures may not display correctly on some platforms such as HTML5. This is because GLES2 does not mandate support for non-power-of-2 repeating textures.",
+						p_source_file, image->get_width(), image->get_height()));
+			}
+		}
 	}
 	if (repeat == 2) {
 		tex_flags |= Texture::FLAG_MIRRORED_REPEAT;


### PR DESCRIPTION
Repeating NPOT textures are not guaranteed to be displayed correctly in GLES2, since the specification does not mandate support for it. The warning is displayed for both repeating and mirrored repeating textures.

The warning is also displayed in GLES3 projects that are configured to allow falling back to GLES2.

This closes https://github.com/godotengine/godot/issues/48807.

**Testing project:** [test_npot.zip](https://github.com/godotengine/godot/files/6503271/test_npot.zip)

## Questions

- Should there be a project setting to disable this warning? It's only displayed when initially importing a texture or reimporting it, so I don't think it's that intrusive.
- Should the warning be extended to non-repeating textures?
- Could the wording be improved?