### PR TITLE
Fix crash when trying to save with no scenes and scripts open

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2281,8 +2281,7 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 
 void ScriptEditor::save_current_script() {
 	ScriptEditorBase *current = _get_current_editor();
-
-	if (_test_script_times_on_disk()) {
+	if (!current || _test_script_times_on_disk()) {
 		return;
 	}
 


### PR DESCRIPTION
This bug was introduced by https://github.com/godotengine/godot/pull/48578. Adding a null check fixes the crash while preserving the expected behavior.

This crash could occur when attempting to save project settings when no scenes or scripts are open (which is common in a brand new project).