### PR TITLE
Fix ragdoll simulation when parent was readded to scene

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1958,6 +1958,8 @@ void PhysicalBone3D::_notification(int p_what) {
 			if (parent_skeleton) {
 				if (-1 != bone_id) {
 					parent_skeleton->unbind_physical_bone_from_bone(bone_id);
+					parent_skeleton->unbind_child_node_from_bone(bone_id, this);
+					bone_id = -1;
 				}
 			}
 			parent_skeleton = nullptr;


### PR DESCRIPTION
This PR fixes #48705, also applies to the 3.x branch.

The `PhysicalBone`'s `bone_id` was kept when exiting the tree. But when entering the tree, rebind and setup of the bone only happen if `bone_id` should be changed. Also, it does not make sense to keep the `bone_id` because the `PhysicalBone` may be added to a different `Skeleton` afterward.