### PR TITLE
pywin32 is no longer necessary for SCons install

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Configuring Python packages
       run: |
         python -c "import sys; print(sys.version)"
-        python -m pip install scons pywin32
+        python -m pip install scons
         python --version
         scons --version
 
@@ -102,7 +102,7 @@ jobs:
     - name: Configuring Python packages
       run: |
         python -c "import sys; print(sys.version)"
-        python -m pip install scons pywin32
+        python -m pip install scons
         python --version
         scons --version
 


### PR DESCRIPTION
As listed in [release notes](https://github.com/SCons/scons/releases/tag/4.1.0) pywin32 is no longer necessary for SCons install. We can also update the documentation as `When compiling with multiple CPU threads, SCons may warn about pywin32 being missing. You can safely ignore this warning.` won't be true anymore.
https://docs.godotengine.org/en/stable/development/compiling/compiling_for_windows.html