### PR TITLE
Show colored rects for autocompletion of Color constants in functions

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -741,6 +741,7 @@ static void _find_identifiers_in_suite(const GDScriptParser::SuiteNode *p_suite,
 		ScriptCodeCompletionOption option;
 		if (p_suite->locals[i].type == GDScriptParser::SuiteNode::Local::CONSTANT) {
 			option = ScriptCodeCompletionOption(p_suite->locals[i].name, ScriptCodeCompletionOption::KIND_CONSTANT);
+			option.default_value = p_suite->locals[i].constant->initializer->reduced_value;
 		} else {
 			option = ScriptCodeCompletionOption(p_suite->locals[i].name, ScriptCodeCompletionOption::KIND_VARIABLE);
 		}


### PR DESCRIPTION
Continuation of #43026, currently, it doesn't show.

Afterwards:
![image](https://user-images.githubusercontent.com/3036176/118806833-36518880-b8b0-11eb-9db1-33b021d0dda5.png)