### PR TITLE
Android: Remove `-fno-integrated-as`, it can break arm64v8 build

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -250,7 +250,7 @@ def configure(env):
     env["RANLIB"] = tools_path + "/ranlib"
     env["AS"] = tools_path + "/as"
 
-    common_opts = ["-fno-integrated-as", "-gcc-toolchain", gcc_toolchain_path]
+    common_opts = ["-gcc-toolchain", gcc_toolchain_path]
 
     # Compile flags
 


### PR DESCRIPTION
We found that this flag causes this error on PR #48812 which does not add any
fancy inline assembly:
```
/tmp/tile_set-ce236a.s: Assembler messages:
/tmp/tile_set-ce236a.s:34676: Error: selected processor does not support `bfc x0,#32,#32'
clang++: error: assembler command failed with exit code 1 (use -v to see invocation)
```

That flag is mentioned in various errors related to assembler failures on
arm64v8 with Clang from the Android NDK.

It was added in Godot in #6958 when migrating from GCC to Clang, and is indeed
referenced in the NDK's Clang migration guide:
https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md

> Especially for ARM and ARM64, Clang is much stricter about assembler rules
> than GCC/GAS. Use `-fno-integrated-as` if Clang reports errors in inline
> assembly or assembly files that you don't wish to modernize.

We don't get those errors nowadays so it seems the flag is no longer needed.

---

I'll do a test round for `master` and `3.3` on all Android architectures to be safe.