### PR TITLE
Fixed_VisualScriptFunctionCall_ReturnHint

### DIFF
--- a/modules/visual_script/doc_classes/VisualScriptCustomNode.xml
+++ b/modules/visual_script/doc_classes/VisualScriptCustomNode.xml
@@ -48,6 +48,24 @@
 				Return the specified input port's type. See the [enum Variant.Type] values.
 			</description>
 		</method>
+		<method name="_get_input_value_port_hint" qualifiers="virtual">
+			<return type="int">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Return the specified input port's hint. See the [enum @GlobalScope.PropertyHint] hints.
+			</description>
+		</method>
+		<method name="_get_input_value_port_hint_string" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Return the specified input port's hint_string.
+			</description>
+		</method>
 		<method name="_get_output_sequence_port_count" qualifiers="virtual">
 			<return type="int">
 			</return>
@@ -77,7 +95,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the specified output's name.
+				Return the specified output ports name.
 			</description>
 		</method>
 		<method name="_get_output_value_port_type" qualifiers="virtual">
@@ -86,7 +104,25 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Return the specified output's type. See the [enum Variant.Type] values.
+				Return the specified output ports type. See the [enum Variant.Type] values.
+			</description>
+		</method>
+		<method name="_get_output_value_port_hint" qualifiers="virtual">
+			<return type="int">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Return the specified output ports hint. See the [enum @GlobalScope.PropertyHint] hints.
+			</description>
+		</method>
+		<method name="_get_output_value_port_hint_string" qualifiers="virtual">
+			<return type="String">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Return the specified output ports hint_string.
 			</description>
 		</method>
 		<method name="_get_text" qualifiers="virtual">

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -231,15 +231,12 @@ PropertyInfo VisualScriptFunctionCall::get_output_value_port_info(int p_idx) con
 
 		PropertyInfo ret;
 
-		/*MethodBind *mb = ClassDB::get_method(_get_base_type(),function);
+		MethodBind *mb = ClassDB::get_method(_get_base_type(), function);
 		if (mb) {
-
-			ret = mb->get_argument_info(-1);
-		} else {*/
-
-		ret = method_cache.return_val;
-
-		//}
+			ret = mb->get_return_info();
+		} else {
+			ret = method_cache.return_val;
+		}
 
 		if (call_mode == CALL_MODE_INSTANCE) {
 			ret.name = "return";

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2742,9 +2742,6 @@ PropertyInfo VisualScriptCustomNode::get_input_value_port_info(int p_idx) const 
 	if (get_script_instance() && get_script_instance()->has_method("_get_input_value_port_hint_string")) {
 		info.hint_string = get_script_instance()->call("_get_input_value_port_hint_string", p_idx);
 	}
-	if (get_script_instance() && get_script_instance()->has_method("_get_input_value_port_usage")) {
-		info.usage = uint32_t(int(get_script_instance()->call("_get_input_value_port_usage", p_idx)));
-	}
 	return info;
 }
 
@@ -2761,9 +2758,6 @@ PropertyInfo VisualScriptCustomNode::get_output_value_port_info(int p_idx) const
 	}
 	if (get_script_instance() && get_script_instance()->has_method("_get_output_value_port_hint_string")) {
 		info.hint_string = get_script_instance()->call("_get_output_value_port_hint_string", p_idx);
-	}
-	if (get_script_instance() && get_script_instance()->has_method("_get_output_value_port_usage")) {
-		info.usage = uint32_t(int(get_script_instance()->call("_get_output_value_port_usage", p_idx)));
 	}
 	return info;
 }
@@ -2909,16 +2903,12 @@ void VisualScriptCustomNode::_bind_methods() {
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_input_value_port_type", PropertyInfo(Variant::INT, "idx")));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_input_value_port_name", PropertyInfo(Variant::INT, "idx")));
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_input_value_port_hint", PropertyInfo(Variant::INT, "idx")));
-	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_input_value_hint_string", PropertyInfo(Variant::INT, "idx")));
-	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_input_value_port_usage", PropertyInfo(Variant::INT, "idx")));
-	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_input_value_class_name", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_input_value_port_hint_string", PropertyInfo(Variant::INT, "idx")));
 
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_output_value_port_type", PropertyInfo(Variant::INT, "idx")));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_output_value_port_name", PropertyInfo(Variant::INT, "idx")));
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_output_value_port_hint", PropertyInfo(Variant::INT, "idx")));
-	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_output_value_hint_string", PropertyInfo(Variant::INT, "idx")));
-	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_output_value_port_usage", PropertyInfo(Variant::INT, "idx")));
-	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_output_value_class_name", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_output_value_port_hint_string", PropertyInfo(Variant::INT, "idx")));
 
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_caption"));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_text"));

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2736,6 +2736,15 @@ PropertyInfo VisualScriptCustomNode::get_input_value_port_info(int p_idx) const 
 	if (get_script_instance() && get_script_instance()->has_method("_get_input_value_port_name")) {
 		info.name = get_script_instance()->call("_get_input_value_port_name", p_idx);
 	}
+	if (get_script_instance() && get_script_instance()->has_method("_get_input_value_port_hint")) {
+		info.hint = PropertyHint(int(get_script_instance()->call("_get_input_value_port_hint", p_idx)));
+	}
+	if (get_script_instance() && get_script_instance()->has_method("_get_input_value_port_hint_string")) {
+		info.hint_string = get_script_instance()->call("_get_input_value_port_hint_string", p_idx);
+	}
+	if (get_script_instance() && get_script_instance()->has_method("_get_input_value_port_usage")) {
+		info.usage = uint32_t(int(get_script_instance()->call("_get_input_value_port_usage", p_idx)));
+	}
 	return info;
 }
 
@@ -2747,8 +2756,36 @@ PropertyInfo VisualScriptCustomNode::get_output_value_port_info(int p_idx) const
 	if (get_script_instance() && get_script_instance()->has_method("_get_output_value_port_name")) {
 		info.name = get_script_instance()->call("_get_output_value_port_name", p_idx);
 	}
+	if (get_script_instance() && get_script_instance()->has_method("_get_output_value_port_hint")) {
+		info.hint = PropertyHint(int(get_script_instance()->call("_get_output_value_port_hint", p_idx)));
+	}
+	if (get_script_instance() && get_script_instance()->has_method("_get_output_value_port_hint_string")) {
+		info.hint_string = get_script_instance()->call("_get_output_value_port_hint_string", p_idx);
+	}
+	if (get_script_instance() && get_script_instance()->has_method("_get_output_value_port_usage")) {
+		info.usage = uint32_t(int(get_script_instance()->call("_get_output_value_port_usage", p_idx)));
+	}
 	return info;
 }
+
+VisualScriptCustomNode::TypeGuess VisualScriptCustomNode::guess_output_type(TypeGuess *p_inputs, int p_output) const {
+	TypeGuess tg;
+	PropertyInfo pi = VisualScriptCustomNode::get_output_value_port_info(p_output);
+	tg.type = pi.type;
+	if (pi.type == Variant::OBJECT) {
+		if (pi.hint == PROPERTY_HINT_RESOURCE_TYPE) {
+			if (pi.hint_string.is_resource_file()) {
+				tg.script = ResourceLoader::load(pi.hint_string);
+			} else if (ClassDB::class_exists(pi.hint_string)) {
+				printf("Hint_string");
+				tg.gdclass = pi.hint_string;
+			} 
+		}
+	}
+	return tg;
+}
+
+
 
 String VisualScriptCustomNode::get_caption() const {
 	if (get_script_instance() && get_script_instance()->has_method("_get_caption")) {
@@ -2871,9 +2908,17 @@ void VisualScriptCustomNode::_bind_methods() {
 
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_input_value_port_type", PropertyInfo(Variant::INT, "idx")));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_input_value_port_name", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_input_value_port_hint", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_input_value_hint_string", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_input_value_port_usage", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_input_value_class_name", PropertyInfo(Variant::INT, "idx")));
 
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_output_value_port_type", PropertyInfo(Variant::INT, "idx")));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_output_value_port_name", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_output_value_port_hint", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_output_value_hint_string", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_output_value_port_usage", PropertyInfo(Variant::INT, "idx")));
+	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_output_value_class_name", PropertyInfo(Variant::INT, "idx")));
 
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_caption"));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_text"));

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2779,8 +2779,6 @@ VisualScriptCustomNode::TypeGuess VisualScriptCustomNode::guess_output_type(Type
 	return tg;
 }
 
-
-
 String VisualScriptCustomNode::get_caption() const {
 	if (get_script_instance() && get_script_instance()->has_method("_get_caption")) {
 		return get_script_instance()->call("_get_caption");

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -790,6 +790,8 @@ public:
 
 	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
 
+	virtual TypeGuess guess_output_type(TypeGuess *p_inputs, int p_output) const;
+
 	void _script_changed();
 
 	VisualScriptCustomNode();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Expose the minimal of new virtual methods to give the Node creator all tools needed to create full type hints for input and output ports.

Improves the default guess_output_type() for VisualScriptCustomNode class.

Fixes [issues/2692]( https://github.com/godotengine/godot-proposals/issues/2692)

PS: When developing I have started to (re)create a advanced subcall pluggin as a fix by itself and as a test of the functionality