### PR TITLE
Use `EditorResourcePicker` in the Inspector

### DIFF
--- a/doc/classes/EditorResourcePicker.xml
+++ b/doc/classes/EditorResourcePicker.xml
@@ -4,8 +4,8 @@
 		Godot editor's control for selecting [Resource] type properties.
 	</brief_description>
 	<description>
-		This is a [Control] node similar to the one used in the Inspector dock when editing [Resource]s. It provides options for creating, loading, saving and converting resources.
-		[b]Note:[/b] It does not include an editor for the resource.
+		This [Control] node is used in the editor's Inspector dock to allow editing of [Resource] type properties. It provides options for creating, loading, saving and converting resources. Can be used with [EditorInspectorPlugin] to recreate the same behavior.
+		[b]Note:[/b] This [Control] does not include any editor for the resource, as editing is controlled by the Inspector dock itself or sub-Inspectors.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -51,6 +51,34 @@
 			<description>
 			</description>
 		</method>
+		<method name="handle_menu_selected" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+				This virtual method can be implemented to handle context menu items not handled by default. See [method set_create_options].
+			</description>
+		</method>
+		<method name="set_create_options" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="menu_node" type="Object">
+			</argument>
+			<description>
+				This virtual method is called when updating the context menu of [EditorResourcePicker]. Implement this method to override the "New ..." items with your own options. [code]menu_node[/code] is a reference to the [PopupMenu] node.
+				[b]Note:[/b] Implement [method handle_menu_selected] to handle these custom items.
+			</description>
+		</method>
+		<method name="set_toggle_pressed">
+			<return type="void">
+			</return>
+			<argument index="0" name="pressed" type="bool">
+			</argument>
+			<description>
+				Sets the toggle mode state for the main button. Works only if [member toggle_mode] is set to [code]true[/code].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="base_type" type="String" setter="set_base_type" getter="get_base_type" default="&quot;&quot;">
@@ -61,6 +89,9 @@
 		</member>
 		<member name="edited_resource" type="Resource" setter="set_edited_resource" getter="get_edited_resource">
 			The edited resource value.
+		</member>
+		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" default="false">
+			If [code]true[/code], the main button with the resource preview works in the toggle mode. Use [method set_toggle_pressed] to manually set the state.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/EditorScriptPicker.xml
+++ b/doc/classes/EditorScriptPicker.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorScriptPicker" inherits="EditorResourcePicker" version="4.0">
+	<brief_description>
+		Godot editor's control for selecting the [code]script[/code] property of a [Node].
+	</brief_description>
+	<description>
+		Similar to [EditorResourcePicker] this [Control] node is used in the editor's Inspector dock, but only to edit the [code]script[/code] property of a [Node]. Default options for creating new resources of all possible subtypes are replaced with dedicated buttons that open the "Attach Node Script" dialog. Can be used with [EditorInspectorPlugin] to recreate the same behavior.
+		[b]Note:[/b] You must set the [member script_owner] for the custom context menu items to work.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="script_owner" type="Node" setter="set_script_owner" getter="get_script_owner">
+			The owner [Node] of the script property that holds the edited resource.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EditorSpinSlider" inherits="Range" version="4.0">
 	<brief_description>
+		Godot editor's control for editing numertic values.
 	</brief_description>
 	<description>
+		This [Control] node is used in the editor's Inspector dock to allow editing of numeric values. Can be used with [EditorInspectorPlugin] to recreate the same behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3760,6 +3760,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<EditorFeatureProfile>();
 	ClassDB::register_class<EditorSpinSlider>();
 	ClassDB::register_class<EditorResourcePicker>();
+	ClassDB::register_class<EditorScriptPicker>();
 	ClassDB::register_class<EditorSceneImporterMesh>();
 	ClassDB::register_class<EditorSceneImporterMeshNode3D>();
 

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -33,6 +33,7 @@
 
 #include "editor/create_dialog.h"
 #include "editor/editor_inspector.h"
+#include "editor/editor_resource_picker.h"
 #include "editor/editor_spin_slider.h"
 #include "editor/property_selector.h"
 #include "editor/scene_tree_editor.h"
@@ -599,64 +600,26 @@ public:
 class EditorPropertyResource : public EditorProperty {
 	GDCLASS(EditorPropertyResource, EditorProperty);
 
-	enum MenuOption {
-		OBJ_MENU_LOAD = 0,
-		OBJ_MENU_EDIT = 1,
-		OBJ_MENU_CLEAR = 2,
-		OBJ_MENU_MAKE_UNIQUE = 3,
-		OBJ_MENU_SAVE = 4,
-		OBJ_MENU_COPY = 5,
-		OBJ_MENU_PASTE = 6,
-		OBJ_MENU_NEW_SCRIPT = 7,
-		OBJ_MENU_EXTEND_SCRIPT = 8,
-		OBJ_MENU_SHOW_IN_FILE_SYSTEM = 9,
-		TYPE_BASE_ID = 100,
-		CONVERT_BASE_ID = 1000
+	EditorResourcePicker *resource_picker = nullptr;
+	SceneTreeDialog *scene_tree = nullptr;
 
-	};
+	bool use_sub_inspector = false;
+	EditorInspector *sub_inspector = nullptr;
+	VBoxContainer *sub_inspector_vbox = nullptr;
+	bool updating_theme = false;
+	bool opened_editor = false;
 
-	Button *assign;
-	TextureRect *preview;
-	Button *edit;
-	PopupMenu *menu;
-	EditorFileDialog *file;
-	Vector<String> inheritors_array;
-	EditorInspector *sub_inspector;
-	VBoxContainer *sub_inspector_vbox;
+	void _resource_selected(const RES &p_resource);
+	void _resource_changed(const RES &p_resource);
 
-	bool use_sub_inspector;
-	bool dropping;
-	String base_type;
-
-	SceneTreeDialog *scene_tree;
-
-	void _file_selected(const String &p_path);
-	void _menu_option(int p_which);
-	void _resource_preview(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, ObjectID p_obj);
-	void _resource_selected();
 	void _viewport_selected(const NodePath &p_path);
-
-	void _update_menu_items();
-
-	void _update_menu();
 
 	void _sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool);
 	void _sub_inspector_resource_selected(const RES &p_resource, const String &p_property);
 	void _sub_inspector_object_id_selected(int p_id);
 
-	void _button_draw();
-	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
-	bool _is_drop_valid(const Dictionary &p_drag_data) const;
-	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
-	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
-
-	void _button_input(const Ref<InputEvent> &p_event);
 	void _open_editor_pressed();
 	void _fold_other_editors(Object *p_self);
-
-	bool opened_editor;
-
-	bool updating_theme = false;
 	void _update_property_bg();
 
 protected:
@@ -665,7 +628,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(const String &p_base_type);
+	void setup(Object *p_object, const String &p_path, const String &p_base_type);
 
 	void collapse_all_folding() override;
 	void expand_all_folding() override;

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -902,7 +902,7 @@ void EditorPropertyDictionary::update_property() {
 
 					} else {
 						EditorPropertyResource *editor = memnew(EditorPropertyResource);
-						editor->setup("Resource");
+						editor->setup(object.ptr(), prop_name, "Resource");
 						prop = editor;
 					}
 

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -98,13 +98,44 @@ public:
 	void set_base_type(const String &p_base_type);
 	String get_base_type() const;
 	Vector<String> get_allowed_types() const;
+
 	void set_edited_resource(RES p_resource);
 	RES get_edited_resource();
+
+	void set_toggle_mode(bool p_enable);
+	bool is_toggle_mode() const;
+	void set_toggle_pressed(bool p_pressed);
 
 	void set_editable(bool p_editable);
 	bool is_editable() const;
 
+	virtual void set_create_options(Object *p_menu_node);
+	virtual bool handle_menu_selected(int p_which);
+
 	EditorResourcePicker();
+};
+
+class EditorScriptPicker : public EditorResourcePicker {
+	GDCLASS(EditorScriptPicker, EditorResourcePicker);
+
+	enum ExtraMenuOption {
+		OBJ_MENU_NEW_SCRIPT = 10,
+		OBJ_MENU_EXTEND_SCRIPT = 11
+	};
+
+	Node *script_owner = nullptr;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual void set_create_options(Object *p_menu_node) override;
+	virtual bool handle_menu_selected(int p_which) override;
+
+	void set_script_owner(Node *p_owner);
+	Node *get_script_owner() const;
+
+	EditorScriptPicker();
 };
 
 #endif // EDITOR_RESOURCE_PICKER_H


### PR DESCRIPTION
Closes #48797, follow-up to #47260. This also exposes additional properties and methods on `EditorResourcePicker` as well as introduces a derivative class `EditorScriptPicker` (available in the scripting API) that's different from the parent class in that it replaces "New ..." options with special "New Script"/"Extend Script" actions. They open the "Attach Script" dialog, as before.

Special behavior for `ViewportTexture`s was left in the EditorProperty wrapper as it's too specific to the Inspector. I also have concerns about warnings that try to prevent the creation of invalid `ViewportTexture`s (when no scene or node is involved and therefore it's impossible to attach it anywhere). These warnings and checks are pretty much superficial and can be easily side-stepped by users by accident or by misunderstanding them. Therefore I think those need to be removed from here and rethought, reimplemented in a more encompassing way. But, alas, I have no idea on what that way may be, so I've tried to keep them as close to the old behavior as possible.