### PR TITLE
Implements length() shader function for arrays in structs

### DIFF
--- a/servers/rendering/renderer_rd/shader_compiler_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_compiler_rd.cpp
@@ -1280,6 +1280,9 @@ String ShaderCompilerRD::_dump_node_code(const SL::Node *p_node, int p_level, Ge
 			} else if (mnode->assign_expression != nullptr) {
 				code += "=";
 				code += _dump_node_code(mnode->assign_expression, p_level, r_gen_code, p_actions, p_default_actions, true, false);
+			} else if (mnode->call_expression != nullptr) {
+				code += ".";
+				code += _dump_node_code(mnode->call_expression, p_level, r_gen_code, p_actions, p_default_actions, p_assigning, false);
 			}
 		} break;
 	}

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4301,8 +4301,15 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						}
 						mn->assign_expression = assign_expression;
 					} else if (tk.type == TK_PERIOD) {
-						_set_error("Nested array length() is not yet implemented");
-						return nullptr;
+						completion_class = TAG_ARRAY;
+						p_block->block_tag = SubClassTag::TAG_ARRAY;
+						Node *call_expression = _parse_and_reduce_expression(p_block, p_function_info);
+						p_block->block_tag = SubClassTag::TAG_GLOBAL;
+						if (!call_expression) {
+							return nullptr;
+						}
+						mn->datatype = call_expression->get_datatype();
+						mn->call_expression = call_expression;
 					} else if (tk.type == TK_BRACKET_OPEN) {
 						Node *index_expression = _parse_and_reduce_expression(p_block, p_function_info);
 						if (!index_expression) {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -546,6 +546,7 @@ public:
 		Node *owner = nullptr;
 		Node *index_expression = nullptr;
 		Node *assign_expression = nullptr;
+		Node *call_expression = nullptr;
 		bool has_swizzling_duplicates = false;
 
 		virtual DataType get_datatype() const { return datatype; }


### PR DESCRIPTION
Allow using `length()` on arrays in structs eg:

```
shader_type spatial;

struct Test {
	vec3 t[2];
};

void fragment() {
	Test test = Test({vec3(0, 1, 0), vec3(1, 0, 0)});
	int len = test.t.length();
}

```