### PR TITLE
Fix RigidBody3D.get_inverse_inertia_tensor() crash

### DIFF
--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -43,17 +43,20 @@ public:
 		v->type = p_type;
 
 		switch (p_type) {
-			case Variant::AABB:
-				init_aabb(v);
+			case Variant::STRING:
+				init_string(v);
 				break;
 			case Variant::TRANSFORM2D:
 				init_transform2d(v);
 				break;
+			case Variant::AABB:
+				init_aabb(v);
+				break;
+			case Variant::BASIS:
+				init_basis(v);
+				break;
 			case Variant::TRANSFORM:
 				init_transform(v);
-				break;
-			case Variant::STRING:
-				init_string(v);
 				break;
 			case Variant::STRING_NAME:
 				init_string_name(v);
@@ -192,6 +195,10 @@ public:
 		v->type = GetTypeInfo<T>::VARIANT_TYPE;
 	}
 
+	// Should be in the same order as Variant::Type for consistency.
+	// Those primitive and vector types don't need an `init_` method:
+	// Nil, bool, float, Vector2/i, Rect2/i, Vector3/i, Plane, Quat, Color, RID.
+	// Object is a special case, handled via `object_assign_null`.
 	_FORCE_INLINE_ static void init_string(Variant *v) {
 		memnew_placement(v->_data._mem, String);
 		v->type = Variant::STRING;

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -103,7 +103,7 @@
 				[b]Note:[/b] The result of this test is not immediate after moving objects. For performance, list of collisions is updated once per frame and before the physics step. Consider using signals instead.
 			</description>
 		</method>
-		<method name="get_inverse_inertia_tensor">
+		<method name="get_inverse_inertia_tensor" qualifiers="const">
 			<return type="Basis">
 			</return>
 			<description>

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -511,7 +511,7 @@ Vector3 RigidBody3D::get_angular_velocity() const {
 	return angular_velocity;
 }
 
-Basis RigidBody3D::get_inverse_inertia_tensor() {
+Basis RigidBody3D::get_inverse_inertia_tensor() const {
 	return inverse_inertia_tensor;
 }
 

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -181,7 +181,7 @@ public:
 	void set_angular_velocity(const Vector3 &p_velocity);
 	Vector3 get_angular_velocity() const override;
 
-	Basis get_inverse_inertia_tensor();
+	Basis get_inverse_inertia_tensor() const;
 
 	void set_gravity_scale(real_t p_gravity_scale);
 	real_t get_gravity_scale() const;


### PR DESCRIPTION
Fix #46282

Also I assume method get_inverse_inertia_tensor should be const
