### PR TITLE
Fix zip_root not being defined when importing by drag&drop

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -100,7 +100,6 @@ private:
 	FileDialog *fdialog_install;
 	String zip_path;
 	String zip_title;
-	String zip_root;
 	AcceptDialog *dialog_error;
 	String fav_dir;
 
@@ -201,9 +200,7 @@ private:
 						char fname[16384];
 						ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
 
-						String fname_str = String(fname);
-						if (fname_str.ends_with("project.godot")) {
-							zip_root = fname_str.substr(0, fname_str.rfind("project.godot"));
+						if (String(fname).ends_with("project.godot")) {
 							break;
 						}
 
@@ -524,7 +521,24 @@ private:
 						return;
 					}
 
+					// Find the zip_root
+					String zip_root;
 					int ret = unzGoToFirstFile(pkg);
+					while (ret == UNZ_OK) {
+						unz_file_info info;
+						char fname[16384];
+						unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
+
+						String name = fname;
+						if (name.ends_with("project.godot")) {
+							zip_root = name.substr(0, name.rfind("project.godot"));
+							break;
+						}
+
+						ret = unzGoToNextFile(pkg);
+					}
+
+					ret = unzGoToFirstFile(pkg);
 
 					Vector<String> failed_files;
 


### PR DESCRIPTION
Moved the code to find the zip's root to the install process. Before, it was just under a function (`_test_path`) that isn't called on every scenario possible *(most notably when drag&dropping ZIP files)*

Fixes #48845