### PR TITLE
Fix BaseButton.keep_pressed_outside

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -57,7 +57,6 @@
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="keep_pressed_outside" type="bool" setter="set_keep_pressed_outside" getter="is_keep_pressed_outside" default="false">
 			If [code]true[/code], the button stays pressed when moving the cursor outside the button while pressing it.
-			[b]Note:[/b] This property only affects the button's visual appearance. Signals will be emitted at the same moment regardless of this property's value.
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the button's state is pressed. Means the button is pressed down or toggled (if [member toggle_mode] is active).

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -169,14 +169,20 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 	}
 
 	if (!p_event->is_pressed()) {
+		bool cancelPress = false;
 		Ref<InputEventMouseButton> mouse_button = p_event;
 		if (mouse_button.is_valid()) {
 			if (!has_point(mouse_button->get_position())) {
 				status.hovering = false;
+				if (!keep_pressed_outside) {
+				        cancelPress = true;
+				}
 			}
 		}
 		// pressed state should be correct with button_up signal
-		emit_signal("button_up");
+		if (!cancelPress) {
+		        emit_signal("button_up");
+		}
 		status.press_attempt = false;
 		status.pressing_inside = false;
 	}


### PR DESCRIPTION
Issue was described here: https://github.com/godotengine/godot-proposals/issues/2645

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/2645_