### PR TITLE
Updates script list colors after theme is changed

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1503,6 +1503,9 @@ void ScriptEditor::_notification(int p_what) {
 			filename->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox("normal", "LineEdit"));
 
 			recent_scripts->set_as_minsize();
+
+			_update_script_colors();
+			_update_script_names();
 		} break;
 
 		case NOTIFICATION_READY: {


### PR DESCRIPTION
I've detected and fixed incorrect theme changing for script list:

![script_list_bug](https://user-images.githubusercontent.com/3036176/118926619-49646700-b949-11eb-877f-a66ea840a2c0.gif)

