### PR TITLE
[Doc] Remove reference to UNIX sockets in StreamPeer.

### DIFF
--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -4,7 +4,7 @@
 		Abstraction and base class for stream-based protocols.
 	</brief_description>
 	<description>
-		StreamPeer is an abstraction and base class for stream-based protocols (such as TCP or UNIX sockets). It provides an API for sending and receiving data through streams as raw data or strings.
+		StreamPeer is an abstraction and base class for stream-based protocols (such as TCP). It provides an API for sending and receiving data through streams as raw data or strings.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
That class can be used as a base to implement them, but there is no actual implementation for it in Godot.

See #48862