### PR TITLE
Use global scope round method for rounding

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -275,8 +275,8 @@ public:
 	static _ALWAYS_INLINE_ double db2linear(double p_db) { return Math::exp(p_db * 0.11512925464970228420089957273422); }
 	static _ALWAYS_INLINE_ float db2linear(float p_db) { return Math::exp(p_db * 0.11512925464970228420089957273422); }
 
-	static _ALWAYS_INLINE_ double round(double p_val) { return (p_val >= 0) ? Math::floor(p_val + 0.5) : -Math::floor(-p_val + 0.5); }
-	static _ALWAYS_INLINE_ float round(float p_val) { return (p_val >= 0) ? Math::floor(p_val + 0.5) : -Math::floor(-p_val + 0.5); }
+	static _ALWAYS_INLINE_ double round(double p_val) { return ::round(p_val); }
+	static _ALWAYS_INLINE_ float round(float p_val) { return ::roundf(p_val); }
 
 	static _ALWAYS_INLINE_ int64_t wrapi(int64_t value, int64_t min, int64_t max) {
 		int64_t range = max - min;


### PR DESCRIPTION
Fixes #48841. I'm curious as to why the old implementation existed, my only guess is for historical reasons if some platforms didn't have `::round`. We should test if this compiles everywhere, the CI checks should take care of this. If it compiles then the behavior should be good. Test code:

```gdscript
func _ready():
	var x = 4503599627370497.0
	print(x)
	print(round(x))
	print(floor(x))
```

Output with this PR:

```
4503599627370497
4503599627370497
4503599627370497
```