### PR TITLE
Rename File's `endian_swap` to `big_endian`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1226,7 +1226,7 @@ Error _File::open(const String &p_path, ModeFlags p_mode_flags) {
 	Error err;
 	f = FileAccess::open(p_path, p_mode_flags, &err);
 	if (f) {
-		f->set_endian_swap(eswap);
+		f->set_big_endian(big_endian);
 	}
 	return err;
 }
@@ -1382,15 +1382,15 @@ Vector<String> _File::get_csv_line(const String &p_delim) const {
  * These flags get reset to false (little endian) on each open
  */
 
-void _File::set_endian_swap(bool p_swap) {
-	eswap = p_swap;
+void _File::set_big_endian(bool p_big_endian) {
+	big_endian = p_big_endian;
 	if (f) {
-		f->set_endian_swap(p_swap);
+		f->set_big_endian(p_big_endian);
 	}
 }
 
-bool _File::get_endian_swap() {
-	return eswap;
+bool _File::is_big_endian() {
+	return big_endian;
 }
 
 Error _File::get_error() const {
@@ -1552,8 +1552,8 @@ void _File::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_as_text"), &_File::get_as_text);
 	ClassDB::bind_method(D_METHOD("get_md5", "path"), &_File::get_md5);
 	ClassDB::bind_method(D_METHOD("get_sha256", "path"), &_File::get_sha256);
-	ClassDB::bind_method(D_METHOD("get_endian_swap"), &_File::get_endian_swap);
-	ClassDB::bind_method(D_METHOD("set_endian_swap", "enable"), &_File::set_endian_swap);
+	ClassDB::bind_method(D_METHOD("is_big_endian"), &_File::is_big_endian);
+	ClassDB::bind_method(D_METHOD("set_big_endian", "big_endian"), &_File::set_big_endian);
 	ClassDB::bind_method(D_METHOD("get_error"), &_File::get_error);
 	ClassDB::bind_method(D_METHOD("get_var", "allow_objects"), &_File::get_var, DEFVAL(false));
 
@@ -1576,7 +1576,7 @@ void _File::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("file_exists", "path"), &_File::file_exists);
 	ClassDB::bind_method(D_METHOD("get_modified_time", "file"), &_File::get_modified_time);
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "endian_swap"), "set_endian_swap", "get_endian_swap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "big_endian"), "set_big_endian", "is_big_endian");
 
 	BIND_ENUM_CONSTANT(READ);
 	BIND_ENUM_CONSTANT(WRITE);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -356,7 +356,7 @@ class _File : public Reference {
 	GDCLASS(_File, Reference);
 
 	FileAccess *f = nullptr;
-	bool eswap = false;
+	bool big_endian = false;
 
 protected:
 	static void _bind_methods();
@@ -413,13 +413,13 @@ public:
 	String get_md5(const String &p_path) const;
 	String get_sha256(const String &p_path) const;
 
-	/* Use this for files WRITTEN in _big_ endian machines (ie, amiga/mac).
+	/*
+	 * Use this for files WRITTEN in _big_ endian machines (ie, amiga/mac).
 	 * It's not about the current CPU type but file formats.
-	 * This flags get reset to false (little endian) on each open.
+	 * This flag gets reset to `false` (little endian) on each open.
 	 */
-
-	void set_endian_swap(bool p_swap);
-	bool get_endian_swap();
+	void set_big_endian(bool p_big_endian);
+	bool is_big_endian();
 
 	Error get_error() const; // Get last error.
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -320,9 +320,9 @@ uint64_t FileAccessPack::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	return to_read;
 }
 
-void FileAccessPack::set_endian_swap(bool p_swap) {
-	FileAccess::set_endian_swap(p_swap);
-	f->set_endian_swap(p_swap);
+void FileAccessPack::set_big_endian(bool p_big_endian) {
+	FileAccess::set_big_endian(p_big_endian);
+	f->set_big_endian(p_big_endian);
 }
 
 Error FileAccessPack::get_error() const {

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -171,7 +171,7 @@ public:
 
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
-	virtual void set_endian_swap(bool p_swap);
+	virtual void set_big_endian(bool p_big_endian);
 
 	virtual Error get_error() const;
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -851,7 +851,7 @@ void ResourceLoaderBinary::open(FileAccess *p_f) {
 	bool big_endian = f->get_32();
 	bool use_real64 = f->get_32();
 
-	f->set_endian_swap(big_endian != 0); //read big endian if saved as big endian
+	f->set_big_endian(big_endian != 0); //read big endian if saved as big endian
 
 	uint32_t ver_major = f->get_32();
 	uint32_t ver_minor = f->get_32();
@@ -948,7 +948,7 @@ String ResourceLoaderBinary::recognize(FileAccess *p_f) {
 	bool big_endian = f->get_32();
 	f->get_32(); // use_real64
 
-	f->set_endian_swap(big_endian != 0); //read big endian if saved as big endian
+	f->set_big_endian(big_endian != 0); //read big endian if saved as big endian
 
 	uint32_t ver_major = f->get_32();
 	f->get_32(); // ver_minor
@@ -1097,13 +1097,13 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	bool big_endian = f->get_32();
 	bool use_real64 = f->get_32();
 
-	f->set_endian_swap(big_endian != 0); //read big endian if saved as big endian
+	f->set_big_endian(big_endian != 0); //read big endian if saved as big endian
 #ifdef BIG_ENDIAN_ENABLED
 	fw->store_32(!big_endian);
 #else
 	fw->store_32(big_endian);
 #endif
-	fw->set_endian_swap(big_endian != 0);
+	fw->set_big_endian(big_endian != 0);
 	fw->store_32(use_real64); //use real64
 
 	uint32_t ver_major = f->get_32();
@@ -1798,7 +1798,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 
 	if (big_endian) {
 		f->store_32(1);
-		f->set_endian_swap(true);
+		f->set_big_endian(true);
 	} else {
 		f->store_32(0);
 	}

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -108,8 +108,8 @@ Array StreamPeer::_get_partial_data(int p_bytes) {
 	return ret;
 }
 
-void StreamPeer::set_big_endian(bool p_enable) {
-	big_endian = p_enable;
+void StreamPeer::set_big_endian(bool p_big_endian) {
+	big_endian = p_big_endian;
 }
 
 bool StreamPeer::is_big_endian_enabled() const {

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -58,7 +58,7 @@ public:
 
 	virtual int get_available_bytes() const = 0;
 
-	void set_big_endian(bool p_enable);
+	void set_big_endian(bool p_big_endian);
 	bool is_big_endian_enabled() const;
 
 	void put_8(int8_t p_val);

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -164,7 +164,7 @@ uint16_t FileAccess::get_16() const {
 	a = get_8();
 	b = get_8();
 
-	if (endian_swap) {
+	if (big_endian) {
 		SWAP(a, b);
 	}
 
@@ -182,7 +182,7 @@ uint32_t FileAccess::get_32() const {
 	a = get_16();
 	b = get_16();
 
-	if (endian_swap) {
+	if (big_endian) {
 		SWAP(a, b);
 	}
 
@@ -200,7 +200,7 @@ uint64_t FileAccess::get_64() const {
 	a = get_32();
 	b = get_32();
 
-	if (endian_swap) {
+	if (big_endian) {
 		SWAP(a, b);
 	}
 
@@ -401,7 +401,7 @@ void FileAccess::store_16(uint16_t p_dest) {
 	a = p_dest & 0xFF;
 	b = p_dest >> 8;
 
-	if (endian_swap) {
+	if (big_endian) {
 		SWAP(a, b);
 	}
 
@@ -415,7 +415,7 @@ void FileAccess::store_32(uint32_t p_dest) {
 	a = p_dest & 0xFFFF;
 	b = p_dest >> 16;
 
-	if (endian_swap) {
+	if (big_endian) {
 		SWAP(a, b);
 	}
 
@@ -429,7 +429,7 @@ void FileAccess::store_64(uint64_t p_dest) {
 	a = p_dest & 0xFFFFFFFF;
 	b = p_dest >> 32;
 
-	if (endian_swap) {
+	if (big_endian) {
 		SWAP(a, b);
 	}
 

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -52,7 +52,7 @@ public:
 	typedef void (*FileCloseFailNotify)(const String &);
 
 	typedef FileAccess *(*CreateFunc)();
-	bool endian_swap = false;
+	bool big_endian = false;
 	bool real_is_double = false;
 
 	virtual uint32_t _get_unix_permissions(const String &p_file) = 0;
@@ -115,13 +115,13 @@ public:
 	virtual Vector<String> get_csv_line(const String &p_delim = ",") const;
 	virtual String get_as_utf8_string() const;
 
-	/**< use this for files WRITTEN in _big_ endian machines (ie, amiga/mac)
+	/**
+	 * Use this for files WRITTEN in _big_ endian machines (ie, amiga/mac)
 	 * It's not about the current CPU type but file formats.
-	 * this flags get reset to false (little endian) on each open
+	 * This flag gets reset to `false` (little endian) on each open.
 	 */
-
-	virtual void set_endian_swap(bool p_swap) { endian_swap = p_swap; }
-	inline bool get_endian_swap() const { return endian_swap; }
+	virtual void set_big_endian(bool p_big_endian) { big_endian = p_big_endian; }
+	inline bool is_big_endian() const { return big_endian; }
 
 	virtual Error get_error() const = 0; ///< get last error
 

--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -490,10 +490,10 @@
 		</method>
 	</methods>
 	<members>
-		<member name="endian_swap" type="bool" setter="set_endian_swap" getter="get_endian_swap" default="false">
+		<member name="big_endian" type="bool" setter="set_big_endian" getter="is_big_endian" default="false">
 			If [code]true[/code], the file is read with big-endian [url=https://en.wikipedia.org/wiki/Endianness]endianness[/url]. If [code]false[/code], the file is read with little-endian endianness. If in doubt, leave this to [code]false[/code] as most files are written with little-endian endianness.
-			[b]Note:[/b] [member endian_swap] is only about the file format, not the CPU type. The CPU endianness doesn't affect the default endianness for files written.
-			[b]Note:[/b] This is always reset to [code]false[/code] whenever you open the file. Therefore, you must set [member endian_swap] [i]after[/i] opening the file, not before.
+			[b]Note:[/b] [member big_endian] is only about the file format, not the CPU type. The CPU endianness doesn't affect the default endianness for files written.
+			[b]Note:[/b] This is always reset to [code]false[/code] whenever you open the file. Therefore, you must set [member big_endian] [i]after[/i] opening the file, not before.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ResourceSaver.xml
+++ b/doc/classes/ResourceSaver.xml
@@ -49,7 +49,7 @@
 			Do not save editor-specific metadata (identified by their [code]__editor[/code] prefix).
 		</constant>
 		<constant name="FLAG_SAVE_BIG_ENDIAN" value="16" enum="SaverFlags">
-			Save as big endian (see [member File.endian_swap]).
+			Save as big endian (see [member File.big_endian]).
 		</constant>
 		<constant name="FLAG_COMPRESS" value="32" enum="SaverFlags">
 			Compress the resource on save using [constant File.COMPRESSION_ZSTD]. Only available for binary resource types.


### PR DESCRIPTION
This new name is more consistent with ResourceSaver and StreamPeer.

See https://github.com/godotengine/godot/issues/16863#issuecomment-844633192.