### PR TITLE
BVH - thread safety option

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1336,6 +1336,10 @@
 		<member name="rendering/threads/thread_model" type="int" setter="" getter="" default="1">
 			Thread model for rendering. Rendering on a thread can vastly improve performance, but synchronizing to the main thread can cause a bit more jitter.
 		</member>
+		<member name="rendering/threads/thread_safe_bvh" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], a thread safe version of BVH (bounding volume hierarchy) will be used in rendering and Godot physics.
+			Try enabling this option if you see any visual anomalies in 3D (such as incorrect object visibility).
+		</member>
 		<member name="rendering/vram_compression/import_bptc" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the texture importer will import VRAM-compressed textures using the BPTC algorithm. This texture compression algorithm is only supported on desktop platforms, and only when using the GLES3 renderer.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1108,6 +1108,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	if (rtm == -1) {
 		rtm = GLOBAL_DEF("rendering/threads/thread_model", OS::RENDER_THREAD_SAFE);
 	}
+	GLOBAL_DEF("rendering/threads/thread_safe_bvh", false);
 
 	if (rtm >= 0 && rtm < 3) {
 #ifdef NO_THREADS

--- a/servers/physics/broad_phase_bvh.cpp
+++ b/servers/physics/broad_phase_bvh.cpp
@@ -109,6 +109,7 @@ BroadPhaseSW *BroadPhaseBVH::_create() {
 }
 
 BroadPhaseBVH::BroadPhaseBVH() {
+	bvh.params_set_thread_safe(GLOBAL_GET("rendering/threads/thread_safe_bvh"));
 	bvh.set_pair_callback(_pair_callback, this);
 	bvh.set_unpair_callback(_unpair_callback, this);
 	pair_callback = nullptr;

--- a/servers/physics_2d/broad_phase_2d_bvh.cpp
+++ b/servers/physics_2d/broad_phase_2d_bvh.cpp
@@ -106,6 +106,7 @@ BroadPhase2DSW *BroadPhase2DBVH::_create() {
 }
 
 BroadPhase2DBVH::BroadPhase2DBVH() {
+	bvh.params_set_thread_safe(GLOBAL_GET("rendering/threads/thread_safe_bvh"));
 	bvh.set_pair_callback(_pair_callback, this);
 	bvh.set_unpair_callback(_unpair_callback, this);
 	pair_callback = nullptr;

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -97,6 +97,11 @@ void VisualServerScene::camera_set_use_vertical_aspect(RID p_camera, bool p_enab
 }
 
 /* SPATIAL PARTITIONING */
+
+VisualServerScene::SpatialPartitioningScene_BVH::SpatialPartitioningScene_BVH() {
+	_bvh.params_set_thread_safe(GLOBAL_GET("rendering/threads/thread_safe_bvh"));
+}
+
 VisualServerScene::SpatialPartitionID VisualServerScene::SpatialPartitioningScene_BVH::create(Instance *p_userdata, const AABB &p_aabb, int p_subindex, bool p_pairable, uint32_t p_pairable_type, uint32_t p_pairable_mask) {
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
 	// we are relying on this instance to be valid in order to pass

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -163,6 +163,7 @@ public:
 		BVH_Manager<Instance, true, 256> _bvh;
 
 	public:
+		SpatialPartitioningScene_BVH();
 		SpatialPartitionID create(Instance *p_userdata, const AABB &p_aabb = AABB(), int p_subindex = 0, bool p_pairable = false, uint32_t p_pairable_type = 0, uint32_t p_pairable_mask = 1);
 		void erase(SpatialPartitionID p_handle);
 		void move(SpatialPartitionID p_handle, const AABB &p_aabb);


### PR DESCRIPTION
Added optional thread safe version through template argument and runtime switch, that wraps access with a mutex.

Related to #48749
Related to #48790

This temporarily also adds a project setting to turn on and off use of the mutex to hopefully allow us to test whether the bug is to do with threading. The project setting is `rendering/threads/thread_safe_bvh` and defaults to off.

On suggestion from @pouleyKetchoupp I've also added a `try_lock` so it should print a warning if it detects a contended situation (which would indicate that thread safety was needed).

## Notes
* As I can't replicate the BVH bug on my machine I've made this PR to try and fix / track down the source of the bug
* I don't seem to get any significant slowdown with `thread_safe_bvh` on my linux system. It could be that uncontended mutexes are very cheap on my system, although I can't vouch for this on other platforms.
* We could also use other alternatives to a mutex, I'm not an expert in this area so would welcome any improvements.
* Using the `try_lock` I can't seem to get a contended lock on my system with the project from the issue (or any other). So hopefully the bug is something simpler, and we won't need to use a mutex in production. It still needs testing on windows, or by someone who can reproduce the bug.
* As the render bvh and the physics bvh are in servers, hopefully the existing thread protection will prevent problems, but this PR should help us find out whether this is the case.

## Update
The default value for the `thread_safe_bvh` is now off (if we introduce it set to on, we may never find out whether thread safety was the cause of the problems).

It now operates on both the rendering BVH, and the physics BVHs for 3d and 2d. The project setting name is still the same. I'm unsure a little about having it still as `rendering/threads/thread_safe_bvh` for this reason, but there doesn't seem to be a sensible section to put it into. It may well be a temporary setting - if we discover that thread safety is required, we should probably leave it on in all cases and remove the option, and vice versa if it is not the cause of the bug.

## Instructions for Testers
* You can download the builds to try, from the section at the bottom of this PR thread that says 'All checks have passed' with a green arrow. If you click on show all checks, choose the section for your platform, you are taken to a page where you can download the artifact (build) from a button / listbox in the top right corner.
* Be sure to try the build with and without the `rendering/threads/thread_safe_bvh` set to on. Please post here whether it fixes the visual bugs with either `thread_safe_bvh` switched on or off, and especially whether you see an error / warning message `Info : multithread BVH access detected (benign)`.