### PR TITLE
Dist: Add macOS entitlements files for editor code signing

### DIFF
--- a/misc/dist/osx/editor.entitlements
+++ b/misc/dist/osx/editor.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+ <key>com.apple.security.device.audio-input</key>
+ <true/>
+ <key>com.apple.security.device.camera</key>
+ <true/>
+ <key>com.apple.security.cs.disable-library-validation</key>
+ <true/>
+</dict>
+</plist>

--- a/misc/dist/osx/editor_mono.entitlements
+++ b/misc/dist/osx/editor_mono.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+ <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+ <true/>
+ <key>com.apple.security.cs.allow-jit</key>
+ <true/>
+ <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+ <true/>
+ <key>com.apple.security.cs.disable-library-validation</key>
+ <true/>
+ <key>com.apple.security.device.audio-input</key>
+ <true/>
+ <key>com.apple.security.device.camera</key>
+ <true/>
+</dict>
+</plist>


### PR DESCRIPTION
These are the entitlements we define for official macOS editor builds since
Godot 3.3.

Users making custom builds of the engine can use those files with `codesign` to
sign their own builds. E.g.:
```
codesign --force --timestamp \
  --options=runtime --entitlements editor.entitlements \
  -s <your key> -v osx_template.app
```

---

Note: Now that there's a `misc/dist/osx` folder, I'd like to move `misc/dist/osx_tools.app` and `misc/dist/osx_template.app` to `misc/dist/osx/*.app`. But I don't want to change this in the `3.3` and `3.x` branches to avoid breaking user scripts, and I don't want to change it in `master` now since the updated `latest` docs would also confuse users... so I'll do it closer to the 4.0 release.