### PR TITLE
Fix swapped front/rear directions in viewport rotation control.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -85,10 +85,10 @@ void ViewportRotationControl::_notification(int p_what) {
 		axis_menu_options.clear();
 		axis_menu_options.push_back(Node3DEditorViewport::VIEW_RIGHT);
 		axis_menu_options.push_back(Node3DEditorViewport::VIEW_TOP);
-		axis_menu_options.push_back(Node3DEditorViewport::VIEW_FRONT);
+		axis_menu_options.push_back(Node3DEditorViewport::VIEW_REAR);
 		axis_menu_options.push_back(Node3DEditorViewport::VIEW_LEFT);
 		axis_menu_options.push_back(Node3DEditorViewport::VIEW_BOTTOM);
-		axis_menu_options.push_back(Node3DEditorViewport::VIEW_REAR);
+		axis_menu_options.push_back(Node3DEditorViewport::VIEW_FRONT);
 
 		axis_colors.clear();
 		axis_colors.push_back(get_theme_color("axis_x_color", "Editor"));


### PR DESCRIPTION
Fixes #48832. 

As reported in the issue, +Z and -Z axes were inverted in the `ViewportRotationControl`, probably because they were not updated in  #45669.

This should make all the axes consistent between the rotation control and the menu options and shortcuts. Supersedes #48859.