### PR TITLE
Remove high radiance sizes from the editor due to issues on specific GPUs

### DIFF
--- a/doc/classes/Sky.xml
+++ b/doc/classes/Sky.xml
@@ -14,7 +14,7 @@
 		<member name="radiance_size" type="int" setter="set_radiance_size" getter="get_radiance_size" enum="Sky.RadianceSize" default="2">
 			The [Sky]'s radiance map size. The higher the radiance map size, the more detailed the lighting from the [Sky] will be.
 			See [enum RadianceSize] constants for values.
-			[b]Note:[/b] Some hardware will have trouble with higher radiance sizes, especially [constant RADIANCE_SIZE_512] and above. Only use such high values on high-end hardware.
+			[b]Note:[/b] You will only benefit from high radiance sizes if you have perfectly sharp reflective surfaces in your project and are not using [ReflectionProbe]s or [GIProbe]s. For most projects, keeping [member radiance_size] to the default value is the best compromise between visuals and performance. Be careful when using high radiance size values as these can cause crashes on low-end GPUs.
 		</member>
 	</members>
 	<constants>
@@ -35,9 +35,11 @@
 		</constant>
 		<constant name="RADIANCE_SIZE_1024" value="5" enum="RadianceSize">
 			Radiance texture size is 1024×1024 pixels.
+			[b]Note:[/b] [constant RADIANCE_SIZE_1024] is not exposed in the inspector as it is known to cause GPU hangs on certain systems.
 		</constant>
 		<constant name="RADIANCE_SIZE_2048" value="6" enum="RadianceSize">
 			Radiance texture size is 2048×2048 pixels.
+			[b]Note:[/b] [constant RADIANCE_SIZE_2048] is not exposed in the inspector as it is known to cause GPU hangs on certain systems.
 		</constant>
 		<constant name="RADIANCE_SIZE_MAX" value="7" enum="RadianceSize">
 			Represents the size of the [enum RadianceSize] enum.

--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -47,7 +47,8 @@ void Sky::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_radiance_size", "size"), &Sky::set_radiance_size);
 	ClassDB::bind_method(D_METHOD("get_radiance_size"), &Sky::get_radiance_size);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "radiance_size", PROPERTY_HINT_ENUM, "32,64,128,256,512,1024,2048"), "set_radiance_size", "get_radiance_size");
+	// Don't expose 1024 and 2048 in the property hint as these sizes will cause GPU hangs on many systems.
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "radiance_size", PROPERTY_HINT_ENUM, "32,64,128,256,512"), "set_radiance_size", "get_radiance_size");
 
 	BIND_ENUM_CONSTANT(RADIANCE_SIZE_32);
 	BIND_ENUM_CONSTANT(RADIANCE_SIZE_64);


### PR DESCRIPTION
These values can still be set by code, but are no longer presented in the editor.

See https://github.com/godotengine/godot/issues/35552.