### PR TITLE
[3.x] Fix crash when using get_available_chars with invalid DynamicFontData

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -256,6 +256,10 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 }
 
 String DynamicFontAtSize::get_available_chars() const {
+	if (!valid) {
+		return "";
+	}
+
 	String chars;
 
 	FT_UInt gindex;


### PR DESCRIPTION
The crash was caused by using an invalid `face` handle.

This PR returns an empty string if the data is invalid without logging it with `ERR_FAIL_COND_V` because this is how `DynamicFontAtSize::get_char_size` and `DynamicFontAtSize::draw_char` handles the scenario. (There is already an error when the initialization fails in `DynamicFontAtSize::_load`.)

https://github.com/godotengine/godot/blob/4396ee18af03ec77e94fff0a007d88c1e886ca1d/scene/resources/dynamic_font.cpp#L283-L286

https://github.com/godotengine/godot/blob/4396ee18af03ec77e94fff0a007d88c1e886ca1d/scene/resources/dynamic_font.cpp#L239-L242

`get_available_chars` no longer exists after the TextServer rewrite on master, so this PR targets the 3.x branch.

Fixes #46118.
