### PR TITLE
Fail gracefully when a mesh fails to import.

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5978,13 +5978,15 @@ void GLTFDocument::_process_mesh_instances(Ref<GLTFState> state, Node *scene_roo
 			const GLTFSkinIndex skin_i = node->skin;
 
 			Map<GLTFNodeIndex, Node *>::Element *mi_element = state->scene_nodes.find(node_i);
+			ERR_CONTINUE_MSG(mi_element == nullptr, vformat("Unable to find node %d", node_i));
+
 			EditorSceneImporterMeshNode3D *mi = Object::cast_to<EditorSceneImporterMeshNode3D>(mi_element->get());
-			ERR_FAIL_COND(mi == nullptr);
+			ERR_CONTINUE_MSG(mi == nullptr, vformat("Unable to cast node %d of type %s to EditorSceneImporterMeshNode3D", node_i, mi_element->get()->get_class_name()));
 
 			const GLTFSkeletonIndex skel_i = state->skins.write[node->skin]->skeleton;
 			Ref<GLTFSkeleton> gltf_skeleton = state->skeletons.write[skel_i];
 			Skeleton3D *skeleton = gltf_skeleton->godot_skeleton;
-			ERR_FAIL_COND(skeleton == nullptr);
+			ERR_CONTINUE_MSG(skeleton == nullptr, vformat("Unable to find Skeleton for node %d skin %d", node_i, skin_i));
 
 			mi->get_parent()->remove_child(mi);
 			skeleton->add_child(mi);


### PR DESCRIPTION
When a mesh instance is processed that triggers an error in `_process_mesh_instances`, it causes the function to abort early and leaves many meshes with unassigned skeletons or skins.

This patch uses `ERR_CONTINUE_MSG` instead of `ERR_FAIL_COND` within the for loop.

Here are some valid glTF meshes which trigger errors at present in Godot (PRs pending):
[DirectParentedSkeletons.glb](https://cdn.discordapp.com/attachments/714269155523690587/845192845640204298/DirectParentedSkeletons.glb)

[NestedSkeletonReproCaseV2Animated.glb](https://cdn.discordapp.com/attachments/714269155523690587/845198106731872306/NestedSkeletonReproCaseV2Animated.glb)

While I recognize that this patch is handling a failure case that ideally would never hapen, the point is it allows for maintaining consistent behavior even when there are bugs or invalid gltf nodes. Leaving ERR_FAIL here will cause a sort of undefined behavior (for example, skinned meshes arbitrarily not parented to their skeletons).

Worked with @fire on debugging this