### PR TITLE
Fix incorrect skin deduplication when using named binds

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4390,6 +4390,9 @@ bool GLTFDocument::_skins_are_same(const Ref<Skin> skin_a, const Ref<Skin> skin_
 		if (skin_a->get_bind_bone(i) != skin_b->get_bind_bone(i)) {
 			return false;
 		}
+		if (skin_a->get_bind_name(i) != skin_b->get_bind_name(i)) {
+			return false;
+		}
 
 		Transform a_xform = skin_a->get_bind_pose(i);
 		Transform b_xform = skin_b->get_bind_pose(i);


### PR DESCRIPTION
This reduces the number of instances in which this particular "`_skins_are_same`" optimization will take place. It should be safe.

Solves one of the bugs triggered by this case: [NestedSkeletonReproCaseV2Animated.glb](https://cdn.discordapp.com/attachments/714269155523690587/845198106731872306/NestedSkeletonReproCaseV2Animated.glb)

In this case, two nodes are referencing the same mesh, but with a different skin... but the skin has the same IBP matrices, and only differs in bone *names* (the bone indices are -1 because Use Named Binds is enabled by default.

This bug is also present in 3.x and should be backported. Worked on this with @fire 