### PR TITLE
gltf: Fix mesh nodes which are also bones.

### DIFF
--- a/modules/gltf/doc_classes/GLTFNode.xml
+++ b/modules/gltf/doc_classes/GLTFNode.xml
@@ -13,8 +13,6 @@
 		</member>
 		<member name="children" type="PackedInt32Array" setter="set_children" getter="get_children" default="PackedInt32Array(  )">
 		</member>
-		<member name="fake_joint_parent" type="int" setter="set_fake_joint_parent" getter="get_fake_joint_parent" default="-1">
-		</member>
 		<member name="height" type="int" setter="set_height" getter="get_height" default="-1">
 		</member>
 		<member name="joint" type="bool" setter="set_joint" getter="get_joint" default="false">

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -260,11 +260,12 @@ private:
 	Error _serialize_animations(Ref<GLTFState> state);
 	BoneAttachment3D *_generate_bone_attachment(Ref<GLTFState> state,
 			Skeleton3D *skeleton,
-			const GLTFNodeIndex node_index);
+			const GLTFNodeIndex node_index,
+			const GLTFNodeIndex bone_index);
 	EditorSceneImporterMeshNode3D *_generate_mesh_instance(Ref<GLTFState> state, Node *scene_parent, const GLTFNodeIndex node_index);
 	Camera3D *_generate_camera(Ref<GLTFState> state, Node *scene_parent,
 			const GLTFNodeIndex node_index);
-	Light3D *_generate_light(Ref<GLTFState> state, Node *scene_parent, const GLTFNodeIndex node_index);
+	Node3D *_generate_light(Ref<GLTFState> state, Node *scene_parent, const GLTFNodeIndex node_index);
 	Node3D *_generate_spatial(Ref<GLTFState> state, Node *scene_parent,
 			const GLTFNodeIndex node_index);
 	void _assign_scene_names(Ref<GLTFState> state);
@@ -365,6 +366,7 @@ public:
 	void _generate_scene_node(Ref<GLTFState> state, Node *scene_parent,
 			Node3D *scene_root,
 			const GLTFNodeIndex node_index);
+	void _generate_skeleton_bone_node(Ref<GLTFState> state, Node *scene_parent, Node3D *scene_root, const GLTFNodeIndex node_index);
 	void _import_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			const GLTFAnimationIndex index, const int bake_fps);
 	GLTFMeshIndex _convert_mesh_instance(Ref<GLTFState> state,

--- a/modules/gltf/gltf_node.cpp
+++ b/modules/gltf/gltf_node.cpp
@@ -55,8 +55,6 @@ void GLTFNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &GLTFNode::set_scale);
 	ClassDB::bind_method(D_METHOD("get_children"), &GLTFNode::get_children);
 	ClassDB::bind_method(D_METHOD("set_children", "children"), &GLTFNode::set_children);
-	ClassDB::bind_method(D_METHOD("get_fake_joint_parent"), &GLTFNode::get_fake_joint_parent);
-	ClassDB::bind_method(D_METHOD("set_fake_joint_parent", "fake_joint_parent"), &GLTFNode::set_fake_joint_parent);
 	ClassDB::bind_method(D_METHOD("get_light"), &GLTFNode::get_light);
 	ClassDB::bind_method(D_METHOD("set_light", "light"), &GLTFNode::set_light);
 
@@ -72,7 +70,6 @@ void GLTFNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::QUAT, "rotation"), "set_rotation", "get_rotation"); // Quat
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale"), "set_scale", "get_scale"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "children"), "set_children", "get_children"); // Vector<int>
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "fake_joint_parent"), "set_fake_joint_parent", "get_fake_joint_parent"); // GLTFNodeIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light"), "set_light", "get_light"); // GLTFLightIndex
 }
 
@@ -170,14 +167,6 @@ Vector<int> GLTFNode::get_children() {
 
 void GLTFNode::set_children(Vector<int> p_children) {
 	children = p_children;
-}
-
-GLTFNodeIndex GLTFNode::get_fake_joint_parent() {
-	return fake_joint_parent;
-}
-
-void GLTFNode::set_fake_joint_parent(GLTFNodeIndex p_fake_joint_parent) {
-	fake_joint_parent = p_fake_joint_parent;
 }
 
 GLTFLightIndex GLTFNode::get_light() {

--- a/modules/gltf/gltf_node.h
+++ b/modules/gltf/gltf_node.h
@@ -53,7 +53,6 @@ private:
 	Quat rotation;
 	Vector3 scale = Vector3(1, 1, 1);
 	Vector<int> children;
-	GLTFNodeIndex fake_joint_parent = -1;
 	GLTFLightIndex light = -1;
 
 protected:
@@ -95,9 +94,6 @@ public:
 
 	Vector<int> get_children();
 	void set_children(Vector<int> p_children);
-
-	GLTFNodeIndex get_fake_joint_parent();
-	void set_fake_joint_parent(GLTFNodeIndex p_fake_joint_parent);
 
 	GLTFLightIndex get_light();
 	void set_light(GLTFLightIndex p_light);


### PR DESCRIPTION
This resolves these errors related to skinned meshes with mesh nodes as bones:
```
ERROR: Condition "mi == nullptr" is true.
   at: GLTFDocument::_process_mesh_instances (modules\gltf\gltf_document.cpp:5969)
ERROR: Condition "sk == nullptr" is true.
   at: GLTFDocument::_import_animation (modules\gltf\gltf_document.cpp:5648)
```

I filed an issue specifically for what this PR solves at #49118
It affects both 3.x and master.


in the following glTF documents:
[NestedSkeletonReproCaseV2Animated.glb](https://cdn.discordapp.com/attachments/714269155523690587/845198106731872306/NestedSkeletonReproCaseV2Animated.glb)
[MeshSkinnedToItselfAndOthersV2.glb](https://cdn.discordapp.com/attachments/714269155523690587/845088321687257148/MeshSkinnedToItselfAndOthersV2.glb)
[NestedSkeletonReproV3.glb](https://cdn.discordapp.com/attachments/714269155523690587/845079080361000960/NestedSkeletonReproV3.glb)

However, it does not resolve the problems in the following glTF document. More extensive work will need to be done on models causing the `ERROR: glTF: Generating scene detected direct parented Skeletons` error:
[DirectParentedSkeletons.glb](https://cdn.discordapp.com/attachments/714269155523690587/845192845640204298/DirectParentedSkeletons.glb)
The following assume the more useful error messages implemented by #48912:
```
ERROR: glTF: Generating scene detected direct parented Skeletons
   at: (modules\gltf\gltf_document.cpp:5441)
ERROR: glTF: Generating scene detected direct parented Skeletons
   at: (modules\gltf\gltf_document.cpp:5441)
ERROR: glTF: Generating scene detected direct parented Skeletons
   at: (modules\gltf\gltf_document.cpp:5441)
ERROR: Unable to cast node 13 of type Skeleton3D to EditorSceneImporterMeshNode3D
   at: (modules\gltf\gltf_document.cpp:5987)
ERROR: Unable to find node 32
   at: (modules\gltf\gltf_document.cpp:5984)
```

Despite any reservations you may have about the usefulness of having mesh nodes as bones, The above glTF documents are conformant and can be generated from the UniGLTF unity plugin, and I have confirmed that this issue existed in the wild (in at least one model being sold for real money). Also, these models are confirmed to work in Blender, three.js (Don McCurty), Unity (UniGLTF) and Windows 3D Viewer.

I think we should test these fixes heavily. We don't want to break any working models. CC @fire 