### PR TITLE
Use a more specific type for AcceptDialog register_text_enter

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -49,7 +49,7 @@
 		<method name="register_text_enter">
 			<return type="void">
 			</return>
-			<argument index="0" name="line_edit" type="Node">
+			<argument index="0" name="line_edit" type="Control">
 			</argument>
 			<description>
 				Registers a [LineEdit] in the dialog. When the enter key is pressed, the dialog will be accepted.

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -155,7 +155,7 @@ bool AcceptDialog::has_autowrap() {
 	return label->has_autowrap();
 }
 
-void AcceptDialog::register_text_enter(Node *p_line_edit) {
+void AcceptDialog::register_text_enter(Control *p_line_edit) {
 	ERR_FAIL_NULL(p_line_edit);
 	LineEdit *line_edit = Object::cast_to<LineEdit>(p_line_edit);
 	if (line_edit) {

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -77,7 +77,7 @@ public:
 	Label *get_label() { return label; }
 	static void set_swap_cancel_ok(bool p_swap);
 
-	void register_text_enter(Node *p_line_edit);
+	void register_text_enter(Control *p_line_edit);
 
 	Button *get_ok_button() { return ok; }
 	Button *add_button(const String &p_text, bool p_right = false, const String &p_action = "");


### PR DESCRIPTION
Both `Node` and `Control` are bindable due to the available operators, so we can be more specific than `Node` here.

This breaks compatibility for typed languages, such as C#.