### PR TITLE
Remove alloca from loop and use a single fixed size array declaration

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -366,8 +366,8 @@ Array Array::filter(const Callable &p_callable) const {
 	new_arr.resize(size());
 	int accepted_count = 0;
 
+	const Variant *argptrs[1];
 	for (int i = 0; i < size(); i++) {
-		const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *));
 		argptrs[0] = &get(i);
 
 		Variant result;
@@ -392,8 +392,8 @@ Array Array::map(const Callable &p_callable) const {
 	Array new_arr;
 	new_arr.resize(size());
 
+	const Variant *argptrs[1];
 	for (int i = 0; i < size(); i++) {
-		const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *));
 		argptrs[0] = &get(i);
 
 		Variant result;
@@ -417,8 +417,8 @@ Variant Array::reduce(const Callable &p_callable, const Variant &p_accum) const 
 		start = 1;
 	}
 
+	const Variant *argptrs[2];
 	for (int i = start; i < size(); i++) {
-		const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * 2);
 		argptrs[0] = &ret;
 		argptrs[1] = &get(i);
 


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/?mode=tree&ruleFocus=1508831665988), #38645 introduced `alloca` in a loop. Unlike memory allocated to a variable, which is reused on every iteration, memory allocated by `alloca` is not freed until the calling function returns. Not only does this run the risk of causing a stack overflow, but it neither needs `alloca` nor be inside the loop. First, the memory can be allocated using a standard fixed size array, and second, the array can be reused.

This PR changes the declaration of `argptrs` to a fixed size array of `const Variant` pointers and moves the declaration outside the loop.