### PR TITLE
Fix usage of String.left()

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -939,7 +939,7 @@ const char32_t *String::get_data() const {
 }
 
 void String::erase(int p_pos, int p_chars) {
-	*this = left(p_pos) + substr(p_pos + p_chars, length() - ((p_pos + p_chars)));
+	*this = left(MAX(p_pos, 0)) + substr(p_pos + p_chars, length() - ((p_pos + p_chars)));
 }
 
 String String::capitalize() const {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1824,7 +1824,13 @@ void EditorInspector::update_tree() {
 			}
 		}
 
-		String path = basename.left(basename.rfind("/"));
+		String path;
+		{
+			int idx = basename.rfind("/");
+			if (idx > -1) {
+				path = basename.left(idx);
+			}
+		}
 
 		if (use_filter && filter != "") {
 			String cat = path;


### PR DESCRIPTION
#36180 changed behavior of negative arguments in `left()`. Previously it would return empty string. Some code relied on that behavior, so this PR fixes it.

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/48951.