### PR TITLE
Add TileMap grid editor settings.

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -704,6 +704,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/2d/scroll_to_pan", false);
 	_initial_set("editors/2d/pan_speed", 20);
 
+	// Tiles editor
+	_initial_set("editors/tiles_editor/display_grid", true);
+	_initial_set("editors/tiles_editor/grid_color", Color(1.0, 0.5, 0.2, 0.5));
+
 	// Polygon editor
 	_initial_set("editors/poly_editor/point_grab_radius", 8);
 	_initial_set("editors/poly_editor/show_previous_outline", true);

--- a/editor/icons/Grid.svg
+++ b/editor/icons/Grid.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m1 1v2 10 2h2 12v-2-12h-12zm2 2h2v2h-2zm4 0h2v2h-2zm4 0h2v2h-2zm-8 4h2v2h-2zm4 0h2v2h-2zm4 0h2v2h-2zm-8 4h2v2h-2zm4 0h2v2h-2zm4 0h2v2h-2z" fill="#8da5f3" fill-opacity=".98824"/></svg>
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m1 1v14h14v-14zm1.9999999 2h2v2h-2zm4 0h2v2h-2zm4.0000001 0h2v2h-2zm-8.0000001 4.0000004h2v2h-2zm4 0h2v2h-2zm4.0000001 0h2v2h-2zm-8.0000001 3.9999996h2v2h-2zm4 0h2v2h-2zm4.0000001 0h2v2h-2z" fill="#e0e0e0"/></svg>

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -39,6 +39,7 @@
 #include "scene/gui/texture_rect.h"
 
 #include "editor/editor_scale.h"
+#include "editor/editor_settings.h"
 
 void TileAtlasView::_gui_input(const Ref<InputEvent> &p_event) {
 	bool ctrl = Input::get_singleton()->is_key_pressed(KEY_CTRL);
@@ -316,6 +317,7 @@ void TileAtlasView::_draw_base_tiles_dark() {
 
 void TileAtlasView::_draw_base_tiles_shape_grid() {
 	// Draw the shapes.
+	Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
 	Vector2i tile_shape_size = tile_set->get_tile_size();
 	for (int i = 0; i < tile_set_atlas_source->get_tiles_count(); i++) {
 		Vector2i tile_id = tile_set_atlas_source->get_tile_id(i);
@@ -324,7 +326,7 @@ void TileAtlasView::_draw_base_tiles_shape_grid() {
 		Vector2 origin = texture_region.position + (texture_region.size - tile_shape_size) / 2 + in_tile_base_offset;
 
 		// Draw only if the tile shape fits in the texture region
-		tile_set->draw_tile_shape(base_tiles_shape_grid, Rect2(origin, tile_shape_size), Color(1.0, 0.5, 0.2, 0.8));
+		tile_set->draw_tile_shape(base_tiles_shape_grid, Rect2(origin, tile_shape_size), grid_color);
 	}
 }
 

--- a/editor/plugins/tiles/tile_map_editor.h
+++ b/editor/plugins/tiles/tile_map_editor.h
@@ -82,6 +82,9 @@ private:
 	void _on_random_tile_checkbox_toggled(bool p_pressed);
 	void _on_scattering_spinbox_changed(double p_value);
 
+	Button *toggle_grid_button;
+	void _on_grid_toggled(bool p_pressed);
+
 	void _update_toolbar();
 
 	///// Tilemap editing. /////

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1178,6 +1178,10 @@ Array TileSetAtlasSourceEditor::_get_selection_as_array() {
 }
 
 void TileSetAtlasSourceEditor::_tile_atlas_control_draw() {
+	// Colors.
+	Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
+	Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
+
 	// Draw the selected tile.
 	if (tools_button_group->get_pressed_button() == tool_select_button) {
 		for (Set<TileSelection>::Element *E = selection.front(); E; E = E->next()) {
@@ -1185,7 +1189,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_draw() {
 			if (selected.alternative == 0) {
 				// Draw the rect.
 				Rect2 region = tile_set_atlas_source->get_tile_texture_region(selected.tile);
-				tile_atlas_control->draw_rect(region, Color(0.2, 0.2, 1.0), false);
+				tile_atlas_control->draw_rect(region, selection_color, false);
 			}
 		}
 
@@ -1234,7 +1238,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_draw() {
 
 		Color color = Color(0.0, 0.0, 0.0);
 		if (drag_type == DRAG_TYPE_RECT_SELECT) {
-			color = Color(0.5, 0.5, 1.0);
+			color = selection_color.lightened(0.2);
 		}
 
 		Set<Vector2i> to_paint;
@@ -1393,6 +1397,9 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_mouse_exited() {
 }
 
 void TileSetAtlasSourceEditor::_tile_alternatives_control_draw() {
+	Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
+	Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
+
 	// Update the hovered alternative tile.
 	if (tools_button_group->get_pressed_button() == tool_select_button) {
 		// Draw hovered tile.
@@ -1410,7 +1417,7 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_draw() {
 			if (selected.alternative >= 1) {
 				Rect2i rect = tile_atlas_view->get_alternative_tile_rect(selected.tile, selected.alternative);
 				if (rect != Rect2i()) {
-					alternative_tiles_control->draw_rect(rect, Color(0.2, 0.2, 1.0), false);
+					alternative_tiles_control->draw_rect(rect, selection_color, false);
 				}
 			}
 		}

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -202,6 +202,7 @@ TilesEditor::TilesEditor(EditorNode *p_editor) {
 
 	// Toolbar.
 	HBoxContainer *toolbar = memnew(HBoxContainer);
+	toolbar->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_child(toolbar);
 
 	// Switch button.


### PR DESCRIPTION
Adds setting to show/hide display the TileMap grid and change its color.
Also modifies the Grid editor icon to remove its uneeded blue color (it is only used in the polygon2D editor, not as a a node).