### PR TITLE
add OpenBSD to OS_LinuxBSD::get_name()

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -116,6 +116,8 @@ String OS_LinuxBSD::get_name() const {
 	return "FreeBSD";
 #elif defined(__NetBSD__)
 	return "NetBSD";
+#elif defined(__OpenBSD__)
+	return "OpenBSD";
 #else
 	return "BSD";
 #endif


### PR DESCRIPTION
as per title, I found this while looking for #48938, and thought it would be nice to have the os properly detected :)