### PR TITLE
Remove duplicate orientation settings in the iOS export preset

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -426,6 +426,27 @@ OS::ScreenOrientation OS::get_screen_orientation() const {
 	return (OS::ScreenOrientation)_orientation;
 }
 
+// Internal helper function that returns the screen orientation enum value from a string
+// (generally coming from the Project Settings).
+// This is required to keep compatibility with existing projects.
+OS::ScreenOrientation OS::get_screen_orientation_from_string(const String &p_orientation) const {
+	if (p_orientation == "portrait") {
+		return OS::SCREEN_PORTRAIT;
+	} else if (p_orientation == "reverse_landscape") {
+		return OS::SCREEN_REVERSE_LANDSCAPE;
+	} else if (p_orientation == "reverse_portrait") {
+		return OS::SCREEN_REVERSE_PORTRAIT;
+	} else if (p_orientation == "sensor_landscape") {
+		return OS::SCREEN_SENSOR_LANDSCAPE;
+	} else if (p_orientation == "sensor_portrait") {
+		return OS::SCREEN_SENSOR_PORTRAIT;
+	} else if (p_orientation == "sensor") {
+		return OS::SCREEN_SENSOR;
+	}
+
+	return OS::SCREEN_LANDSCAPE;
+}
+
 void OS::ensure_user_data_dir() {
 	String dd = get_user_data_dir();
 	DirAccess *da = DirAccess::open(dd);

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -471,6 +471,7 @@ public:
 
 	virtual void set_screen_orientation(ScreenOrientation p_orientation);
 	virtual ScreenOrientation get_screen_orientation() const;
+	ScreenOrientation get_screen_orientation_from_string(const String &p_orientation) const;
 
 	virtual void enable_for_stealing_focus(ProcessID pid) {}
 	virtual void move_window_to_foreground() {}

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -464,7 +464,8 @@
 			If [code]true[/code], keeps the screen on (even in case of inactivity), so the screensaver does not take over. Works on desktop and mobile platforms.
 		</member>
 		<member name="display/window/handheld/orientation" type="String" setter="" getter="" default="&quot;landscape&quot;">
-			Default orientation on mobile devices.
+			The default screen orientation to use on mobile devices.
+			[b]Note:[/b] When set to a portrait orientation, this project setting does not flip the project resolution's width and height automatically. Instead, you have to set [member display/window/size/width] and [member display/window/size/height] accordingly.
 		</member>
 		<member name="display/window/ios/hide_home_indicator" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the home indicator is hidden automatically. This only affects iOS devices without a physical home button.

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -855,7 +855,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		int version_code = p_preset->get("version/code");
 		String package_name = p_preset->get("package/unique_name");
 
-		const int screen_orientation = _get_android_orientation_value(_get_screen_orientation());
+		const int screen_orientation = _get_android_orientation_value(
+				OS::get_singleton()->get_screen_orientation_from_string(GLOBAL_GET("display/window/handheld/orientation")));
 
 		bool min_gles3 = ProjectSettings::get_singleton()->get("rendering/quality/driver/driver_name") == "GLES3" &&
 						 !ProjectSettings::get_singleton()->get("rendering/quality/driver/fallback_to_gles2");

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -44,28 +44,6 @@ const String godot_project_name_xml_string = R"(<?xml version="1.0" encoding="ut
 </resources>
 )";
 
-OS::ScreenOrientation _get_screen_orientation() {
-	String orientation_settings = ProjectSettings::get_singleton()->get("display/window/handheld/orientation");
-	OS::ScreenOrientation screen_orientation;
-	if (orientation_settings == "portrait") {
-		screen_orientation = OS::SCREEN_PORTRAIT;
-	} else if (orientation_settings == "reverse_landscape") {
-		screen_orientation = OS::SCREEN_REVERSE_LANDSCAPE;
-	} else if (orientation_settings == "reverse_portrait") {
-		screen_orientation = OS::SCREEN_REVERSE_PORTRAIT;
-	} else if (orientation_settings == "sensor_landscape") {
-		screen_orientation = OS::SCREEN_SENSOR_LANDSCAPE;
-	} else if (orientation_settings == "sensor_portrait") {
-		screen_orientation = OS::SCREEN_SENSOR_PORTRAIT;
-	} else if (orientation_settings == "sensor") {
-		screen_orientation = OS::SCREEN_SENSOR;
-	} else {
-		screen_orientation = OS::SCREEN_LANDSCAPE;
-	}
-
-	return screen_orientation;
-}
-
 int _get_android_orientation_value(OS::ScreenOrientation screen_orientation) {
 	switch (screen_orientation) {
 		case OS::SCREEN_PORTRAIT:
@@ -272,7 +250,8 @@ String _get_instrumentation_tag(const Ref<EditorExportPreset> &p_preset) {
 
 String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 	bool uses_xr = (int)(p_preset->get("xr_features/xr_mode")) == 1;
-	String orientation = _get_android_orientation_label(_get_screen_orientation());
+	String orientation = _get_android_orientation_label(
+			OS::get_singleton()->get_screen_orientation_from_string(GLOBAL_GET("display/window/handheld/orientation")));
 	String manifest_activity_text = vformat(
 			"        <activity android:name=\"com.godot.game.GodotApp\" "
 			"tools:replace=\"android:screenOrientation\" "

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -378,11 +378,6 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/microphone_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need to use the microphone"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/photolibrary_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need access to the photo library"), ""));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/portrait"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/landscape_left"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/landscape_right"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/portrait_upside_down"), true));
-
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "required_icons/iphone_120x120", PROPERTY_HINT_FILE, "*.png"), "")); // Home screen on iPhone/iPod Touch with retina display
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "required_icons/ipad_76x76", PROPERTY_HINT_FILE, "*.png"), "")); // Home screen on iPad
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "required_icons/app_store_1024x1024", PROPERTY_HINT_FILE, "*.png"), "")); // App Store
@@ -497,18 +492,39 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 			strnew += lines[i].replace("$required_device_capabilities", capabilities);
 		} else if (lines[i].find("$interface_orientations") != -1) {
 			String orientations;
+			const OS::ScreenOrientation screen_orientation =
+					OS::get_singleton()->get_screen_orientation_from_string(GLOBAL_GET("display/window/handheld/orientation"));
 
-			if ((bool)p_preset->get("orientation/portrait")) {
-				orientations += "<string>UIInterfaceOrientationPortrait</string>\n";
-			}
-			if ((bool)p_preset->get("orientation/landscape_left")) {
-				orientations += "<string>UIInterfaceOrientationLandscapeLeft</string>\n";
-			}
-			if ((bool)p_preset->get("orientation/landscape_right")) {
-				orientations += "<string>UIInterfaceOrientationLandscapeRight</string>\n";
-			}
-			if ((bool)p_preset->get("orientation/portrait_upside_down")) {
-				orientations += "<string>UIInterfaceOrientationPortraitUpsideDown</string>\n";
+			switch (screen_orientation) {
+				case OS::SCREEN_LANDSCAPE:
+					orientations += "<string>UIInterfaceOrientationLandscapeLeft</string>\n";
+					break;
+				case OS::SCREEN_PORTRAIT:
+					orientations += "<string>UIInterfaceOrientationPortrait</string>\n";
+					break;
+				case OS::SCREEN_REVERSE_LANDSCAPE:
+					orientations += "<string>UIInterfaceOrientationLandscapeRight</string>\n";
+					break;
+				case OS::SCREEN_REVERSE_PORTRAIT:
+					orientations += "<string>UIInterfaceOrientationPortraitUpsideDown</string>\n";
+					break;
+				case OS::SCREEN_SENSOR_LANDSCAPE:
+					// Allow both landscape orientations depending on sensor direction.
+					orientations += "<string>UIInterfaceOrientationLandscapeLeft</string>\n";
+					orientations += "<string>UIInterfaceOrientationLandscapeRight</string>\n";
+					break;
+				case OS::SCREEN_SENSOR_PORTRAIT:
+					// Allow both portrait orientations depending on sensor direction.
+					orientations += "<string>UIInterfaceOrientationPortrait</string>\n";
+					orientations += "<string>UIInterfaceOrientationPortraitUpsideDown</string>\n";
+					break;
+				case OS::SCREEN_SENSOR:
+					// Allow all screen orientations depending on sensor direction.
+					orientations += "<string>UIInterfaceOrientationLandscapeLeft</string>\n";
+					orientations += "<string>UIInterfaceOrientationLandscapeRight</string>\n";
+					orientations += "<string>UIInterfaceOrientationPortrait</string>\n";
+					orientations += "<string>UIInterfaceOrientationPortraitUpsideDown</string>\n";
+					break;
 			}
 
 			strnew += lines[i].replace("$interface_orientations", orientations);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/48939 (backwards compatible).

The screen orientation is now sourced from the Project Settings like it is done for Android already.

See https://github.com/godotengine/godot/issues/45422.