### PR TITLE
Gltf export blend shape

### DIFF
--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -71,6 +71,9 @@ class GLTFDocument : public Resource {
 	friend class GLTFSkin;
 	friend class GLTFSkeleton;
 
+private:
+	const float BAKE_FPS = 30.0f;
+
 public:
 	const int32_t JOINT_GROUP_SIZE = 4;
 	enum GLTFType {


### PR DESCRIPTION
Work on gltf export.

Fixes: https://github.com/godotengine/godot/issues/47121

## GLTF Export blend shape notes from Lyuma



This code is invalid:

                            Color tangent;
                            tangent.r = tarr[(i * 4) + 0];
                            tangent.g = tarr[(i * 4) + 1];
                            tangent.b = tarr[(i * 4) + 2];
                            tangent.a = tarr[(i * 4) + 3];
                            Vector3 vec3;
                            vec3.x = tarr[(i * 4) + 0];
                            vec3.y = tarr[(i * 4) + 1];
                            vec3.z = tarr[(i * 4) + 2];
                            vec3 *= tarr[(i * 4) + 3] * -1;
                        }


If TANGENT is encoded as vec3, the w component should be dropped, not multiplied.


This code has a bug:

                    Vector<Vector3> narr = array_morph[Mesh::ARRAY_NORMAL];
                    if (varr.size()) {
                        t["NORMAL"] = _encode_accessor_as_vec3(state, narr, true);
                    }

Should be if(narr.size()) {



Line 6262: If we encounter another :blend_shapes/ track for a mesh whose blend shapes we have already exported, we must avoid exporting the blend shapes for that mesh a second time.

keyframes should be capped at a constant * the original number of keyframes. for example, min of 1.0 / BAKE_FPS and (total length / (10 * number of keyframes))


We should check if tracks are linear and avoid the complicated baking cases.

```
blend shape A   ..      . .    .
blend shape O   .    . .   .   .
->
output          ..   . .. ..   .
```

Line 6358: change to if key_count == 0: Why two zeros? I think we should do only one key
```
                weight.times.push_back(0.0f);
                weight.times.push_back(0.0f);
                weight.values.push_back(0.0f);
                weight.values.push_back(0.0f);
                track.weight_tracks.push_back(weight);
```