### PR TITLE
Rename Vector2 Perpendicular to Orthogonal in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -519,7 +519,7 @@ namespace Godot
         /// compared to the original, with the same length.
         /// </summary>
         /// <returns>The perpendicular vector.</returns>
-        public Vector2 Perpendicular()
+        public Vector2 Orthogonal()
         {
             return new Vector2(y, -x);
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -248,13 +248,13 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns a vector rotated 90 degrees counter-clockwise
+        /// Returns a perpendicular vector rotated 90 degrees counter-clockwise
         /// compared to the original, with the same length.
         /// </summary>
         /// <returns>The perpendicular vector.</returns>
-        public Vector2 Perpendicular()
+        public Vector2i Orthogonal()
         {
-            return new Vector2(y, -x);
+            return new Vector2i(y, -x);
         }
 
         // Constants


### PR DESCRIPTION
For consistency with #44149. I had previously [committed](https://github.com/godotengine/godot/pull/40218) the rename of "Tangent" to "Perpendicular" before it was decided that "tangent" should be "orthogonal", so this changes "Perpendicular" to "Orthogonal" to be consistent with core's "orthogonal". This PR also fixes a bug where Vector2i's method was returning Vector2 (non-i).