### PR TITLE
Use bold font for categories and brighten sections in the editor inspectors

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1098,7 +1098,7 @@ void EditorInspectorPlugin::_bind_methods() {
 void EditorInspectorCategory::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
 		draw_rect(Rect2(Vector2(), get_size()), bg_color);
-		Ref<Font> font = get_theme_font("font", "Tree");
+		Ref<Font> font = get_theme_font("bold", "EditorFonts");
 		int font_size = get_theme_font_size("font_size", "Tree");
 
 		int hs = get_theme_constant("hseparation", "Tree");
@@ -1144,7 +1144,7 @@ Control *EditorInspectorCategory::make_custom_tooltip(const String &p_text) cons
 }
 
 Size2 EditorInspectorCategory::get_minimum_size() const {
-	Ref<Font> font = get_theme_font("font", "Tree");
+	Ref<Font> font = get_theme_font("bold", "EditorFonts");
 	int font_size = get_theme_font_size("font_size", "Tree");
 
 	Size2 ms;
@@ -1252,7 +1252,7 @@ void EditorInspectorSection::_notification(int p_what) {
 		draw_rect(Rect2(Vector2(), Vector2(get_size().width, h)), bg_color);
 
 		const int arrow_margin = 3;
-		Color color = get_theme_color("font_color", "Tree");
+		Color color = get_theme_color("highlighted_font_color", "Editor");
 		float text_width = get_size().width - Math::round((16 + arrow_margin) * EDSCALE);
 		draw_string(font, Point2(rtl ? 0 : Math::round((16 + arrow_margin) * EDSCALE), font->get_ascent(font_size) + (h - font->get_height(font_size)) / 2).floor(), label, rtl ? HALIGN_RIGHT : HALIGN_LEFT, text_width, font_size, color);
 

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -251,6 +251,7 @@ void SectionedInspector::update_category_list() {
 		for (int i = 0; i < sc; i++) {
 			TreeItem *parent = section_map[metasection];
 			parent->set_custom_bg_color(0, get_theme_color("prop_subsection", "Editor"));
+			parent->set_custom_color(0, get_theme_color("highlighted_font_color", "Editor"));
 
 			if (i > 0) {
 				metasection += "/" + sectionarr[i];


### PR DESCRIPTION
This makes categories and sections stand out more.

Inspired by [this mockup](https://www.reddit.com/r/godot/comments/nhsqug/ui_rewamp_just_for_fun_what_do_you_think/). Thanks seppoday for providing this mockup!

## Preview

**Note:** PR was amended to not use bold for sections, only for categories. Instead, section titles are now brighter.

| Before | After |
|--------|-------|
| ![No bold titles](https://user-images.githubusercontent.com/180032/119210539-f277a280-baac-11eb-91e0-1de6e2652147.png) | ![Bold titles](https://user-images.githubusercontent.com/180032/119240352-433fd780-bb4f-11eb-9966-2373cad83857.png) |