### PR TITLE
added _change_notify in Control::set_scale to fix issue #48936

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2586,6 +2586,7 @@ void Control::set_scale(const Vector2 &p_scale) {
 	}
 	update();
 	_notify_transform();
+	_change_notify("rect_scale");
 }
 Vector2 Control::get_scale() const {
 	return data.scale;


### PR DESCRIPTION
`Control::set_scale` appeared to be missing `_change_notify("rect_scale");`, which prevented the inspector from receiving updates as controls were scaled.  
this adds the `_change_notify` line to match `Control::set_pivot_offset`, `Control::set_rotation`, etc.

should not apply to 4.0+ :
> Since [`change_notify()` was removed in favor of polling in the `master` branch](https://github.com/godotengine/godot/pull/45879), this issue is likely only present in the `3.x` branch.
thank you Calinou

<I>Bugsquad edit</i>: Fix #48936