### PR TITLE
[3.x] Tell rpc target method/property when node is not found

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -200,8 +200,6 @@ void MultiplayerAPI::_process_packet(int p_from, const uint8_t *p_packet, int p_
 
 			Node *node = _process_get_node(p_from, p_packet, p_packet_len);
 
-			ERR_FAIL_COND_MSG(node == nullptr, "Invalid packet received. Requested node was not found.");
-
 			// Detect cstring end.
 			int len_end = 5;
 			for (; len_end < p_packet_len; len_end++) {
@@ -213,6 +211,8 @@ void MultiplayerAPI::_process_packet(int p_from, const uint8_t *p_packet, int p_
 			ERR_FAIL_COND_MSG(len_end >= p_packet_len, "Invalid packet received. Size too small.");
 
 			StringName name = String::utf8((const char *)&p_packet[5]);
+
+			ERR_FAIL_COND_MSG(node == nullptr, "Invalid packet received. Requested node was not found. Target property/method: " + name);
 
 			if (packet_type == NETWORK_COMMAND_REMOTE_CALL) {
 				_process_rpc(node, name, p_from, p_packet, p_packet_len, len_end + 1);


### PR DESCRIPTION
When working with RPC calls, I sometimes get node not found errors that are caused by my code. However they are not obvious to debug as you only get the failed node name and not the call/set target.

There seems to be some more going on in 4.0 as only an id is sent and the API tries to get the target then. A similar functionality would be nice, but is most likely not possible, because the target is target is fetched on the node script. We could print the id, but idk how helpful that is :D