### PR TITLE
Upgrade visual script function call return autocomplete m

### DIFF
--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -132,6 +132,7 @@ bool VisualScriptBuiltinFunc::has_input_sequence_port() const {
 		case TEXT_PRINT:
 		case TEXT_PRINTERR:
 		case TEXT_PRINTRAW:
+		case MATH_SEED:
 			return true;
 		default:
 			return false;

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -132,7 +132,6 @@ bool VisualScriptBuiltinFunc::has_input_sequence_port() const {
 		case TEXT_PRINT:
 		case TEXT_PRINTERR:
 		case TEXT_PRINTRAW:
-		case MATH_SEED:
 			return true;
 		default:
 			return false;

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -232,14 +232,12 @@ PropertyInfo VisualScriptFunctionCall::get_output_value_port_info(int p_idx) con
 
 		PropertyInfo ret;
 
-		/*MethodBind *mb = ClassDB::get_method(_get_base_type(),function);
+		MethodBind *mb = ClassDB::get_method(_get_base_type(), function);
 		if (mb) {
-			ret = mb->get_argument_info(-1);
-		} else {*/
-
-		ret = method_cache.return_val;
-
-		//}
+			ret = mb->get_return_info();
+		} else {
+			ret = method_cache.return_val;
+		}
 
 		if (call_mode == CALL_MODE_INSTANCE) {
 			ret.name = "return";

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -1727,7 +1727,7 @@ PropertyInfo VisualScriptPropertyGet::get_output_value_port_info(int p_idx) cons
 	ClassDB::get_property_list(_get_base_type(), &props, false);
 	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 		if (E->get().name == property) {
-			return PropertyInfo(E->get().type, "value." + String(index));
+			return PropertyInfo(E->get().type, "value." + String(index), E->get().hint, E->get().hint_string);
 		}
 	}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

De-comment and fix the output port hint for VisualScriptFunctionCall

Brach 3.x: https://github.com/godotengine/godot/pull/48901