### PR TITLE
Fixed editor log collapsing of duplicate messages not working

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -234,7 +234,9 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 
 	if (p_replace_previous) {
 		// Remove last line if replacing, as it will be replace by the next added line.
-		log->remove_line(log->get_line_count() - 1);
+		// Why - 2? RichTextLabel is weird. When you add a line, it also adds a NEW line, which is null,
+		// but it still counts as a line. So if you remove the last line (count - 1) you are actually removing nothing...
+		log->remove_line(log->get_line_count() - 2);
 		log->increment_line_count();
 	}
 


### PR DESCRIPTION
Closes #48930

The internals of Rich Text Label is pretty confusing to me so I apologise for the faffing about with this editor log stuff. I hope this is the last of it.

![K0UzDMdzv5](https://user-images.githubusercontent.com/41730826/119229624-43929f80-bb5c-11eb-91a3-21fd24984a7c.gif)
