### PR TITLE
Fix crash on debug shapes update if CollisionObject3D is not in tree

### DIFF
--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -215,6 +215,11 @@ void CollisionObject3D::_shape_changed(const Ref<Shape3D> &p_shape) {
 }
 
 void CollisionObject3D::_update_debug_shapes() {
+	if (!is_inside_tree()) {
+		debug_shapes_to_update.clear();
+		return;
+	}
+
 	for (Set<uint32_t>::Element *shapedata_idx = debug_shapes_to_update.front(); shapedata_idx; shapedata_idx = shapedata_idx->next()) {
 		if (shapes.has(shapedata_idx->get())) {
 			ShapeData &shapedata = shapes[shapedata_idx->get()];


### PR DESCRIPTION
Fixes #48866

See [this comment](https://github.com/godotengine/godot/issues/48866#issuecomment-845472246) for an explanation of why this is needed.
