### PR TITLE
Fix crash on debug shapes update if CollisionObject is not in tree

### DIFF
--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -212,6 +212,11 @@ void CollisionObject::_shape_changed(const Ref<Shape> &p_shape) {
 }
 
 void CollisionObject::_update_debug_shapes() {
+	if (!is_inside_tree()) {
+		debug_shapes_to_update.clear();
+		return;
+	}
+
 	for (Set<uint32_t>::Element *shapedata_idx = debug_shapes_to_update.front(); shapedata_idx; shapedata_idx = shapedata_idx->next()) {
 		if (shapes.has(shapedata_idx->get())) {
 			ShapeData &shapedata = shapes[shapedata_idx->get()];

--- a/scene/resources/concave_polygon_shape.cpp
+++ b/scene/resources/concave_polygon_shape.cpp
@@ -66,6 +66,7 @@ void ConcavePolygonShape::_update_shape() {
 
 void ConcavePolygonShape::set_faces(const PoolVector<Vector3> &p_faces) {
 	PhysicsServer::get_singleton()->shape_set_data(get_shape(), p_faces);
+	_update_shape();
 	notify_change_to_owners();
 }
 


### PR DESCRIPTION
3.x version of #48973

Fixes #48866
Fixes #48281 by calling `_update_shape()` when the concave shape changes. 

See [this comment](https://github.com/godotengine/godot/issues/48866#issuecomment-845472246) for an explanation of why this is needed.



<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
