### PR TITLE
Mouse pointer reappears at same spot

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -70,6 +70,7 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 					grabbing_spinner_dist_cache = 0;
 					pre_grab_value = get_value();
 					grabbing_spinner = false;
+					grabbing_spinner_mouse_pos = get_global_mouse_position();
 				}
 			} else {
 				if (grabbing_spinner_attempt) {


### PR DESCRIPTION
This fixes #48971 

**Before changes:**
After grabbing and dragging a numeric field, mouse pointer is teleported to top-left.

**After changes:**
After grabbing and dragging a numeric field, mouse pointer reappears at the same point from where it vanished.
Edit: After incorporating the changes suggested by @EricEzaM, the mouse pointer should now reappear at the spot from where the user grabbed and started dragging.

Note: This PR does not affect the grab and drag behaviour of Spin Sliders. The problem does not exist with Spin Sliders.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
