### PR TITLE
Properly increase line counter when parsing comments

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -151,6 +151,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 						return OK;
 					}
 					if (ch == '\n') {
+						line++;
 						break;
 					}
 				}
@@ -1321,6 +1322,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 					return ERR_FILE_EOF;
 				}
 				if (ch == '\n') {
+					line++;
 					break;
 				}
 			}


### PR DESCRIPTION
Currently the variant parser (e.g. used when reading `project.godot`) skips comments until the end of line, but doesn't increase the line counter when doing so.  This breaks the line offset shown in error messages.

Let's assume the following intentionally broken `project.godot`:
```ini
; Engine configuration file.
; It's best edited using the editor UI and not directly,
; since the parameters that go here are not all obvious.
;
; Format:
;   [section] ; section goes between []
;   param=value ; assign values to parameters

config_version=4

= broken

[application]

# here's the usual contents
```

Listing this project in the Project Manager currently will indicate a parse error on the fourth line (identified as line 3 due to being 0 based):
```txt
ERROR: ConfigFile parse error at .../project.godot:3: Unexpected identifier: 'broken'..
   at: ConfigFile::_parse (core\io\config_file.cpp:284)
```

As you can see above, this actually isn't the third (fourth) line in total. While skipping comments in this file is trivial, it could get tricky in more complex files with multiple comment lines/blocks throughout the file.

After the fix, it correctly reports the tenth (eleventh) line:
```txt
ERROR: ConfigFile parse error at .../project.godot:10: Unexpected identifier: 'broken'..
   at: ConfigFile::_parse (core\io\config_file.cpp:284)
```

I don't really think this is intentional, since it's causing somewhat confusing error messages that won't match the actual file structure. If it actually is, let me know and just disregard this PR.