### PR TITLE
Batching - fix item_batch_flags stale state

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -2560,6 +2560,13 @@ PREAMBLE(void)::render_joined_item_commands(const BItemJoined &p_bij, Rasterizer
 		bdata.fvf = RasterizerStorageCommon::FVF_LARGE;
 	}
 
+	// make sure the jointed item flags state is up to date, as it is read indirectly in
+	// a couple of places from the state rather than from the joined item.
+	// we could alternatively make sure to only read directly from the joined item
+	// during the render, but it is probably more bug future proof to make sure both
+	// are up to date.
+	bdata.joined_item_batch_flags = p_bij.flags;
+
 	// in the special case of custom shaders that read from VERTEX (i.e. vertex position)
 	// we want to disable software transform of extra matrix
 	if (bdata.joined_item_batch_flags & RasterizerStorageCommon::PREVENT_VERTEX_BAKING) {


### PR DESCRIPTION
Fixes `bdata.joined_item_batch_flags` not being kept up to date during the rendering pass.

The batch flags for a joined item were stored in a state variable `bdata.joined_item_batch_flags` during the `try_join_item` phase. This was then stored into each joined item (`p_bij.flags`).

During the rendering phase however, this meant that while the joined item flags were correct, the state variable contained stale data from the last item in the `try_join_item` phase. This caused problems because this was incorrectly read from the state in the render pass in a couple of places.

To fix this I have made sure the state is up to date in the render phase. Alternatively I could have fixed the two places to read from the joined item directly, but this was an easy bug to miss, and the same mistake could have been made again in future, so keeping both up to date seems the most sensible approach.

Fixes #48981

## Notes
* The bug in the linked issue was caused by reading here:
`render_joined_item_commands`:
```
	if (bdata.joined_item_batch_flags & RasterizerStorageCommon::PREVENT_VERTEX_BAKING) {
		fill_state.extra_matrix_sent = true;
	}
```
Which caused the extra transform matrix to get out of sync.

Bugs could also have occurred due to incorrect reading here:
`flush_render_batches`:
```
			// only check whether to convert if there are quads (prevent divide by zero)
			// and we haven't decided to prevent color baking (due to e.g. MODULATE
			// being used in a shader)
			if (bdata.total_quads && !(bdata.joined_item_batch_flags & RasterizerStorageCommon::PREVENT_COLOR_BAKING)) {
```