### PR TITLE
Only create InputEventMouseMotion event on Windows if mouse moves

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2103,7 +2103,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					mm->set_relative(Vector2(mm->get_position() - Vector2(old_x, old_y)));
 					old_x = mm->get_position().x;
 					old_y = mm->get_position().y;
-					if (windows[window_id].window_has_focus)
+					if (windows[window_id].window_has_focus && mm->get_relative() != Vector2())
 						Input::get_singleton()->accumulate_input_event(mm);
 				}
 				return 0;
@@ -2249,7 +2249,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			mm->set_relative(Vector2(mm->get_position() - Vector2(old_x, old_y)));
 			old_x = mm->get_position().x;
 			old_y = mm->get_position().y;
-			if (windows[window_id].window_has_focus) {
+			if (windows[window_id].window_has_focus && mm->get_relative() != Vector2()) {
 				Input::get_singleton()->accumulate_input_event(mm);
 			}
 
@@ -2354,7 +2354,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			mm->set_relative(Vector2(mm->get_position() - Vector2(old_x, old_y)));
 			old_x = mm->get_position().x;
 			old_y = mm->get_position().y;
-			if (windows[window_id].window_has_focus)
+			if (windows[window_id].window_has_focus && mm->get_relative() != Vector2())
 				Input::get_singleton()->accumulate_input_event(mm);
 
 		} break;


### PR DESCRIPTION
In Windows, a window can receive `WM_MOUSEMOVE` events even if the mouse coordinates don't change, _"For example, if the cursor is positioned over a window, and the user hides the window, the window receives WM_MOUSEMOVE messages even if the mouse did not move."_[[1](https://docs.microsoft.com/en-us/windows/win32/learnwin32/mouse-movement)]. Similarly, `WM_MOUSEMOVE` events are received when a mouse button is released. This results in unexpected `InputEventMouseMotion` events being generated: see #20357.

This PR checks to see if the mouse actually moved before adding an `InputEventMouseMotion` event. Since this was fixed for `WM_INPUT` for when `mouse_mode` is `MOUSE_MODE_CAPTURED` in #22368, this PR applies 33dd2c8de to the the WM_MOUSEMOVE and WM_POINTERUPDATE Windows events as well as the Wacom WT_PACKET event. 

Fixes #20357.
