### PR TITLE
Fix editor constantly redrawing when freelook is active with still camera

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -344,7 +344,7 @@ void Node3DEditorViewport::_update_camera(float p_interp_delta) {
 		equal = false;
 	}
 
-	if (!equal || p_interp_delta == 0 || is_freelook_active() || is_orthogonal != orthogonal) {
+	if (!equal || p_interp_delta == 0 || is_orthogonal != orthogonal) {
 		camera->set_global_transform(to_camera_transform(camera_cursor));
 
 		if (orthogonal) {


### PR DESCRIPTION
The editor only needs to redraw when the camera is moving.

This helps preserve battery life on laptops when using freelook, especially with the toggle mode (<kbd>Shift + F</kbd>). I couldn't notice any side effects to removing the condition, but I recommend having other people test this too. You can check whether the editor is redrawing by enabling **Show Update Spinner** in the Editor Settings.