### PR TITLE
Fix JSONParseResult error property type

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2377,7 +2377,7 @@ void JSONParseResult::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_error_line", "error_line"), &JSONParseResult::set_error_line);
 	ClassDB::bind_method(D_METHOD("set_result", "result"), &JSONParseResult::set_result);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "error", PROPERTY_HINT_NONE, "Error", PROPERTY_USAGE_CLASS_IS_ENUM), "set_error", "get_error");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "error", PROPERTY_HINT_NONE, "Error", PROPERTY_USAGE_CLASS_IS_ENUM), "set_error", "get_error");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "error_string"), "set_error_string", "get_error_string");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "error_line"), "set_error_line", "get_error_line");
 	ADD_PROPERTY(PropertyInfo(Variant::NIL, "result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "set_result", "get_result");


### PR DESCRIPTION
The registered type of JSONParseResult::error was Variant::OBJECT. This conflicts with the documentation, which describes error as being an integer belonging to the Error enum. This resulted in the editor throwing out parse errors when trying to perform any operation between the error property and an integer, even including other members of the Error enum.

By changing the type of the error property to Variant::INT, the expected behavior is achieved. The error property is still recognized as an Error enum (and still gets relevant auto-complete as a result), but can now be operated with other integer types.

I didn't update the PropertyHint of the property, since that didn't seem relevant for JSONParseResult.

Fixes #48684
