### PR TITLE
Fix duplicate close file when deconstructing ZipArchive

### DIFF
--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -226,9 +226,7 @@ ZipArchive::ZipArchive() {
 
 ZipArchive::~ZipArchive() {
 	for (int i = 0; i < packages.size(); i++) {
-		FileAccess *f = (FileAccess *)unzGetOpaque(packages[i].zfile);
 		unzClose(packages[i].zfile);
-		memdelete(f);
 	}
 
 	packages.clear();


### PR DESCRIPTION
Fixes #49012 