### PR TITLE
Fix `EditorSpinSlider` not resetting the mouse position correctly when freed

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -448,6 +448,7 @@ void EditorSpinSlider::_notification(int p_what) {
 			if (grabbing_spinner) {
 				grabber->hide();
 				Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+				Input::get_singleton()->warp_mouse(grabbing_spinner_mouse_pos);
 				grabbing_spinner = false;
 				grabbing_spinner_attempt = false;
 			}


### PR DESCRIPTION
This especially important in 3.x and 3.2 as seen in #44354.

<i>Bugsquad edit</i>: Fix #44354.