### PR TITLE
Fix `property_list_changed_notify` causing full inspector rebuild

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2197,10 +2197,14 @@ void EditorInspector::_notification(int p_what) {
 		changing++;
 
 		if (update_tree_pending) {
-			update_tree();
+			for (Map<StringName, List<EditorProperty *>>::Element *E = editor_property_map.front(); E; E = E->next()) {
+				for (List<EditorProperty *>::Element *F = E->value().front(); F; F = F->next()) {
+					F->get()->update_property();
+					F->get()->update_reload_status();
+				}
+			}
 			update_tree_pending = false;
 			pending.clear();
-
 		} else {
 			while (pending.size()) {
 				StringName prop = pending.front()->get();


### PR DESCRIPTION
fixes #44354

Instead of fully rebuilding the inspector only all `EditorProperty`s get updated. This may cause unwanted side effects, if properties get added or removed and relied on `property_list_changed_notify` causing a rebuild. I don't know any use cases for such behaviour. Thinking of it, I may have breaken situations with `_get_property_list`. Tests are welcome.