### PR TITLE
Unexpose methods and property for binding children to Bones in Skeleton3D

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -22,17 +22,6 @@
 				Adds a bone, with name [code]name[/code]. [method get_bone_count] will become the bone index.
 			</description>
 		</method>
-		<method name="bind_child_node_to_bone">
-			<return type="void">
-			</return>
-			<argument index="0" name="bone_idx" type="int">
-			</argument>
-			<argument index="1" name="node" type="Node">
-			</argument>
-			<description>
-				[i]Deprecated soon.[/i]
-			</description>
-		</method>
 		<method name="bone_transform_to_world_transform">
 			<return type="Transform">
 			</return>
@@ -141,15 +130,6 @@
 			</argument>
 			<description>
 				Returns the rest transform for a bone [code]bone_idx[/code].
-			</description>
-		</method>
-		<method name="get_bound_child_nodes_to_bone" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="bone_idx" type="int">
-			</argument>
-			<description>
-				[i]Deprecated soon.[/i]
 			</description>
 		</method>
 		<method name="is_bone_rest_disabled" qualifiers="const">
@@ -297,17 +277,6 @@
 			</argument>
 			<description>
 				Sets the rest transform for bone [code]bone_idx[/code].
-			</description>
-		</method>
-		<method name="unbind_child_node_from_bone">
-			<return type="void">
-			</return>
-			<argument index="0" name="bone_idx" type="int">
-			</argument>
-			<argument index="1" name="node" type="Node">
-			</argument>
-			<description>
-				[i]Deprecated soon.[/i]
 			</description>
 		</method>
 		<method name="unparent_bone_and_rest">

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -94,20 +94,6 @@ bool Skeleton3D::_set(const StringName &p_path, const Variant &p_value) {
 		set_bone_enabled(which, p_value);
 	} else if (what == "pose") {
 		set_bone_pose(which, p_value);
-	} else if (what == "bound_children") {
-		Array children = p_value;
-
-		if (is_inside_tree()) {
-			bones.write[which].nodes_bound.clear();
-
-			for (int i = 0; i < children.size(); i++) {
-				NodePath npath = children[i];
-				ERR_CONTINUE(npath.operator String() == "");
-				Node *node = get_node(npath);
-				ERR_CONTINUE(!node);
-				bind_child_node_to_bone(which, node);
-			}
-		}
 	} else {
 		return false;
 	}
@@ -137,19 +123,6 @@ bool Skeleton3D::_get(const StringName &p_path, Variant &r_ret) const {
 		r_ret = is_bone_enabled(which);
 	} else if (what == "pose") {
 		r_ret = get_bone_pose(which);
-	} else if (what == "bound_children") {
-		Array children;
-
-		for (const List<ObjectID>::Element *E = bones[which].nodes_bound.front(); E; E = E->next()) {
-			Object *obj = ObjectDB::get_instance(E->get());
-			ERR_CONTINUE(!obj);
-			Node *node = Object::cast_to<Node>(obj);
-			ERR_CONTINUE(!node);
-			NodePath npath = get_path_to(node);
-			children.push_back(npath);
-		}
-
-		r_ret = children;
 	} else {
 		return false;
 	}
@@ -165,7 +138,6 @@ void Skeleton3D::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "rest", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::BOOL, prep + "enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "pose", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
-		p_list->push_back(PropertyInfo(Variant::ARRAY, prep + "bound_children", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	}
 }
 
@@ -911,10 +883,6 @@ void Skeleton3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_bone_disable_rest", "bone_idx", "disable"), &Skeleton3D::set_bone_disable_rest);
 	ClassDB::bind_method(D_METHOD("is_bone_rest_disabled", "bone_idx"), &Skeleton3D::is_bone_rest_disabled);
-
-	ClassDB::bind_method(D_METHOD("bind_child_node_to_bone", "bone_idx", "node"), &Skeleton3D::bind_child_node_to_bone);
-	ClassDB::bind_method(D_METHOD("unbind_child_node_from_bone", "bone_idx", "node"), &Skeleton3D::unbind_child_node_from_bone);
-	ClassDB::bind_method(D_METHOD("get_bound_child_nodes_to_bone", "bone_idx"), &Skeleton3D::_get_bound_child_nodes_to_bone);
 
 	ClassDB::bind_method(D_METHOD("clear_bones"), &Skeleton3D::clear_bones);
 

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -114,18 +114,6 @@ private:
 
 	uint64_t version = 1;
 
-	// bind helpers
-	Array _get_bound_child_nodes_to_bone(int p_bone) const {
-		Array bound;
-		List<Node *> children;
-		get_bound_child_nodes_to_bone(p_bone, &children);
-
-		for (int i = 0; i < children.size(); i++) {
-			bound.push_back(children[i]);
-		}
-		return bound;
-	}
-
 	void _update_process_order();
 
 protected:


### PR DESCRIPTION
These methods have been marked "Deprecated Soon" since 0b806ee0fc9097fa7bda7ac0109191c9c5e0a1ac. They can't be removed, because they are used by `BoneAttachment`, which is what should be used to bind a `Node` to a `Bone`.

Closes https://github.com/godotengine/godot-docs/issues/2177
