### PR TITLE
[3.x] Update all properties when a property is changed

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -262,7 +262,6 @@ class EditorInspector : public ScrollContainer {
 	//map use to cache the instanced editors
 	Map<StringName, List<EditorProperty *>> editor_property_map;
 	List<EditorInspectorSection *> sections;
-	Set<StringName> pending;
 
 	void _clear();
 	Object *object;
@@ -279,6 +278,7 @@ class EditorInspector : public ScrollContainer {
 	bool use_folding;
 	int changing;
 	bool update_all_pending;
+	bool update_properties;
 	bool read_only;
 	bool keying;
 	bool sub_inspector;


### PR DESCRIPTION
This fixes issues where `property_list_changed_notify` was
previously used to update properties from tool scripts and causing update problems, because of the full tree rebuild.
Calling said function is not longer necessary for that case.

This is an alternative approach to #49032.
Fixes #37464
Resolves #44354, because `property_list_changed_notify` is not longer necessary in that case

This is only relevant in 3.x as 4.0 polls. (Although there is still the old logic present as well. Why though?)