### PR TITLE
Fix Callable crash on freed objects

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -50,6 +50,15 @@ void Callable::call(const Variant **p_arguments, int p_argcount, Variant &r_retu
 		custom->call(p_arguments, p_argcount, r_return_value, r_call_error);
 	} else {
 		Object *obj = ObjectDB::get_instance(ObjectID(object));
+#ifdef DEBUG_ENABLED
+		if (!obj) {
+			r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
+			r_call_error.argument = 0;
+			r_call_error.expected = 0;
+			r_return_value = Variant();
+			return;
+		}
+#endif
 		r_return_value = obj->call(method, p_arguments, p_argcount, r_call_error);
 	}
 }

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -257,6 +257,7 @@ bool GDScriptTestRunner::make_tests() {
 
 	ERR_FAIL_COND_V_MSG(err != OK, false, "Could not open specified test directory.");
 
+	source_dir = dir->get_current_dir() + "/"; // Make it absolute path.
 	return make_tests_for_dir(dir->get_current_dir());
 }
 
@@ -361,11 +362,9 @@ void GDScriptTest::error_handler(void *p_this, const char *p_function, const cha
 			break;
 	}
 
-	builder.append("\n>> ");
+	builder.append("\n>> on function: ");
 	builder.append(p_function);
-	builder.append("\n>> ");
-	builder.append(p_function);
-	builder.append("\n>> ");
+	builder.append("()\n>> ");
 	builder.append(String(p_file).trim_prefix(self->base_dir));
 	builder.append("\n>> ");
 	builder.append(itos(p_line));

--- a/modules/gdscript/tests/scripts/runtime/errors/callable_call_after_free_object.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/callable_call_after_free_object.gd
@@ -1,0 +1,5 @@
+func test():
+	var node := Node.new()
+	var inside_tree = node.is_inside_tree
+	node.free()
+	inside_tree.call()

--- a/modules/gdscript/tests/scripts/runtime/errors/callable_call_after_free_object.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/callable_call_after_free_object.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> runtime/errors/callable_call_after_free_object.gd
+>> 5
+>> Attempt to call function 'null::is_inside_tree (Callable)' on a null instance.


### PR DESCRIPTION
Also added a fix to the GDScript test runner so I could add a proper test for this case.

Fix #48353