### PR TITLE
Fixes missing descriptions in Visual Script search window when adding nodes

### DIFF
--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -469,10 +469,11 @@ void VisualScriptPropertySelector::_item_selected() {
 
 		at_class = ClassDB::get_parent_class_nocheck(at_class);
 	}
-	Map<String, DocData::ClassDoc>::Element *T = dd->class_list.find(class_type);
+	Vector<String> functions = name.rsplit("/", false);
+	at_class = functions.size() > 3 ? functions[functions.size() - 2] : class_type;
+	Map<String, DocData::ClassDoc>::Element *T = dd->class_list.find(at_class);
 	if (T) {
 		for (int i = 0; i < T->get().methods.size(); i++) {
-			Vector<String> functions = name.rsplit("/", false, 1);
 			if (T->get().methods[i].name == functions[functions.size() - 1]) {
 				text = DTR(T->get().methods[i].description);
 			}


### PR DESCRIPTION
Fixes #48699

**Issue:** When the search window is opened to add nodes in visual script by "right-clicking" on the canvas, some of the functions(found in methods of `Vector2`, `String`, `Array` etc.) would not have their descriptions showing. But when the search window is opened by dragging connection out of the data port of a node, the functions that weren't showing descriptions previously, will have descriptions now. _Kindly see the issue mentioned above for more details_

This PR is for master branch, but the issue is presented in 3.x as well!

_Before the fix, these descriptions would not show_
![Screenshot (251)](https://user-images.githubusercontent.com/41969735/122076078-30e84f00-ce18-11eb-9f36-87ec8ff7ca22.png)



