### PR TITLE
Hide row for altering custom settings in non-advanced mode

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -74,8 +74,13 @@ void ProjectSettingsEditor::_setting_edited(const String &p_name) {
 	queue_save();
 }
 
+void ProjectSettingsEditor::_update_advanced(bool p_is_advanced) {
+	custom_properties->set_visible(p_is_advanced);
+}
+
 void ProjectSettingsEditor::_advanced_toggled(bool p_button_pressed) {
 	EditorSettings::get_singleton()->set_project_metadata("project_settings", "advanced_mode", p_button_pressed);
+	_update_advanced(p_button_pressed);
 	general_settings_inspector->set_restrict_to_basic_settings(!p_button_pressed);
 }
 
@@ -584,35 +589,35 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	advanced->connect("toggled", callable_mp(this, &ProjectSettingsEditor::_advanced_toggled));
 	search_bar->add_child(advanced);
 
-	HBoxContainer *header = memnew(HBoxContainer);
-	general_editor->add_child(header);
+	custom_properties = memnew(HBoxContainer);
+	general_editor->add_child(custom_properties);
 
 	property_box = memnew(LineEdit);
 	property_box->set_placeholder(TTR("Select a Setting or Type its Name"));
 	property_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	property_box->connect("text_changed", callable_mp(this, &ProjectSettingsEditor::_property_box_changed));
-	header->add_child(property_box);
+	custom_properties->add_child(property_box);
 
 	feature_box = memnew(OptionButton);
 	feature_box->set_custom_minimum_size(Size2(120, 0) * EDSCALE);
 	feature_box->connect("item_selected", callable_mp(this, &ProjectSettingsEditor::_feature_selected));
-	header->add_child(feature_box);
+	custom_properties->add_child(feature_box);
 
 	type_box = memnew(OptionButton);
 	type_box->set_custom_minimum_size(Size2(120, 0) * EDSCALE);
-	header->add_child(type_box);
+	custom_properties->add_child(type_box);
 
 	add_button = memnew(Button);
 	add_button->set_text(TTR("Add"));
 	add_button->set_disabled(true);
 	add_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_add_setting));
-	header->add_child(add_button);
+	custom_properties->add_child(add_button);
 
 	del_button = memnew(Button);
 	del_button->set_text(TTR("Delete"));
 	del_button->set_disabled(true);
 	del_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_delete_setting));
-	header->add_child(del_button);
+	custom_properties->add_child(del_button);
 
 	general_settings_inspector = memnew(SectionedInspector);
 	general_settings_inspector->get_inspector()->set_undo_redo(EditorNode::get_singleton()->get_undo_redo());
@@ -693,6 +698,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		advanced->set_pressed(true);
 	}
 
+	_update_advanced(use_advanced);
 	general_settings_inspector->set_restrict_to_basic_settings(!use_advanced);
 
 	import_defaults_editor = memnew(ImportDefaultsEditor);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -61,6 +61,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	LineEdit *search_box = nullptr;
 	CheckButton *advanced = nullptr;
 
+	HBoxContainer *custom_properties = nullptr;
 	LineEdit *property_box = nullptr;
 	OptionButton *feature_box = nullptr;
 	OptionButton *type_box = nullptr;
@@ -77,6 +78,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	UndoRedo *undo_redo = nullptr;
 
 	void _advanced_toggled(bool p_button_pressed);
+	void _update_advanced(bool p_is_advanced);
 	void _property_box_changed(const String &p_text);
 	void _update_property_box();
 	void _feature_selected(int p_index);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2723 (see: https://github.com/godotengine/godot-proposals/issues/2723#issuecomment-841684108)

When advanced settings is disabled you're still able to add custom settings even though they only appear in advanced mode, which is confusing.

Hiding the row for altering custom settings when not in advanced mode used to happen until #45716, the reason for not hiding the row was so that you can still copy them. Copying settings names seems like an advanced concept that should probably be behind advanced mode though. It also takes up vertical space just for one box to copy from.

https://user-images.githubusercontent.com/12120644/119398125-1b628800-bca5-11eb-99f6-e2479af1e76c.mp4

