### PR TITLE
Fix C# file extension not appearing in Search in File Extensions default

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1099,9 +1099,9 @@ ProjectSettings::ProjectSettings() {
 
 	PackedStringArray extensions = PackedStringArray();
 	extensions.push_back("gd");
-	if (Engine::get_singleton()->has_singleton("GodotSharp")) {
-		extensions.push_back("cs");
-	}
+#ifdef MODULE_MONO_ENABLED
+	extensions.push_back("cs");
+#endif
 	extensions.push_back("shader");
 
 	GLOBAL_DEF("editor/run/main_run_args", "");


### PR DESCRIPTION
I'm not sure if this is a proper fix, but it seems the code path isn't being triggered correctly according to the proposal.

This closes https://github.com/godotengine/godot-proposals/issues/2766.