### PR TITLE
Allow to get list of non object methods

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2045,7 +2045,26 @@ bool ClassDB::is_class_enabled(StringName p_class) const {
 	return ::ClassDB::is_class_enabled(p_class);
 }
 
+Array ClassDB::get_variant_method_list(Variant::Type p_type) const {
+	List<MethodInfo> methods;
+	Variant::get_method_list_by_type(&methods, p_type);
+	Array ret;
+
+	for (const MethodInfo &E : methods) {
+#ifdef DEBUG_METHODS_ENABLED
+		ret.push_back(E.operator Dictionary());
+#else
+		Dictionary dict;
+		dict["name"] = E.name;
+		ret.push_back(dict);
+#endif
+	}
+
+	return ret;
+}
+
 void ClassDB::_bind_methods() {
+	::ClassDB::bind_method(D_METHOD("get_variant_method_list", "type"), &ClassDB::get_variant_method_list);
 	::ClassDB::bind_method(D_METHOD("get_class_list"), &ClassDB::get_class_list);
 	::ClassDB::bind_method(D_METHOD("get_inheriters_from_class", "class"), &ClassDB::get_inheriters_from_class);
 	::ClassDB::bind_method(D_METHOD("get_parent_class", "class"), &ClassDB::get_parent_class);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -606,7 +606,9 @@ public:
 
 	bool has_method(StringName p_class, StringName p_method, bool p_no_inheritance = false) const;
 
+
 	TypedArray<Dictionary> get_method_list(StringName p_class, bool p_no_inheritance = false) const;
+	Array get_variant_method_list(Variant::Type p_type) const;
 
 	PackedStringArray get_integer_constant_list(const StringName &p_class, bool p_no_inheritance = false) const;
 	bool has_integer_constant(const StringName &p_class, const StringName &p_name) const;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -601,6 +601,8 @@ public:
 	static String get_call_error_text(Object *p_base, const StringName &p_method, const Variant **p_argptrs, int p_argcount, const Callable::CallError &ce);
 	static String get_callable_error_text(const Callable &p_callable, const Variant **p_argptrs, int p_argcount, const Callable::CallError &ce);
 
+	static void get_method_list_by_type(List<MethodInfo> *p_list, Variant::Type p_type);
+
 	//dynamic (includes Object)
 	void get_method_list(List<MethodInfo> *p_list) const;
 	bool has_method(const StringName &p_method) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1248,6 +1248,51 @@ uint32_t Variant::get_builtin_method_hash(Variant::Type p_type, const StringName
 	return hash_fmix32(hash);
 }
 
+void Variant::get_method_list_by_type(List<MethodInfo> *p_list, Variant::Type p_type) {
+	ERR_FAIL_INDEX(p_type, Variant::VARIANT_MAX);
+	for (const StringName &E : builtin_method_names[p_type]) {
+		const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(E);
+		ERR_CONTINUE(!method);
+
+		MethodInfo mi;
+		mi.name = E;
+
+		//return type
+		if (method->has_return_type) {
+			mi.return_val.type = method->return_type;
+			if (mi.return_val.type == Variant::NIL) {
+				mi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+			}
+		}
+
+		if (method->is_const) {
+			mi.flags |= METHOD_FLAG_CONST;
+		}
+		if (method->is_vararg) {
+			mi.flags |= METHOD_FLAG_VARARG;
+		}
+		if (method->is_static) {
+			mi.flags |= METHOD_FLAG_STATIC;
+		}
+		for (int i = 0; i < method->argument_count; i++) {
+			PropertyInfo pi;
+#ifdef DEBUG_METHODS_ENABLED
+			pi.name = method->argument_names[i];
+#else
+			pi.name = "arg" + itos(i + 1);
+#endif
+			pi.type = method->get_argument_type(i);
+			if (pi.type == Variant::NIL) {
+				pi.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+			}
+			mi.arguments.push_back(pi);
+		}
+
+		mi.default_arguments = method->default_arguments;
+		p_list->push_back(mi);
+	}
+}
+
 void Variant::get_method_list(List<MethodInfo> *p_list) const {
 	if (type == OBJECT) {
 		Object *obj = get_validated_object();
@@ -1255,47 +1300,7 @@ void Variant::get_method_list(List<MethodInfo> *p_list) const {
 			obj->get_method_list(p_list);
 		}
 	} else {
-		for (const StringName &E : builtin_method_names[type]) {
-			const VariantBuiltInMethodInfo *method = builtin_method_info[type].lookup_ptr(E);
-			ERR_CONTINUE(!method);
-
-			MethodInfo mi;
-			mi.name = E;
-
-			//return type
-			if (method->has_return_type) {
-				mi.return_val.type = method->return_type;
-				if (mi.return_val.type == Variant::NIL) {
-					mi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
-				}
-			}
-
-			if (method->is_const) {
-				mi.flags |= METHOD_FLAG_CONST;
-			}
-			if (method->is_vararg) {
-				mi.flags |= METHOD_FLAG_VARARG;
-			}
-			if (method->is_static) {
-				mi.flags |= METHOD_FLAG_STATIC;
-			}
-			for (int i = 0; i < method->argument_count; i++) {
-				PropertyInfo pi;
-#ifdef DEBUG_METHODS_ENABLED
-				pi.name = method->argument_names[i];
-#else
-				pi.name = "arg" + itos(i + 1);
-#endif
-				pi.type = method->get_argument_type(i);
-				if (pi.type == Variant::NIL) {
-					pi.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
-				}
-				mi.arguments.push_back(pi);
-			}
-
-			mi.default_arguments = method->default_arguments;
-			p_list->push_back(mi);
-		}
+		Variant::get_method_list_by_type(p_list, type);
 	}
 }
 

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -169,6 +169,13 @@
 				Returns the parent class of [param class].
 			</description>
 		</method>
+		<method name="get_variant_method_list" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="type" type="int" enum="Variant.Type" />
+			<description>
+				Returns an array of methods of built-in [code]class[/code] like [code]String[/code] or [code]Vector2[/code].
+			</description>
+		</method>
 		<method name="instantiate" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="class" type="StringName" />


### PR DESCRIPTION
1/3 of https://github.com/godotengine/godot-proposals/issues/2344

This allow to get list of e.g. String methods by using:
```
ClassDB.get_variant_method_list(TYPE_STRING)
```
`_ClassDB::get_variant_method_list` is almost 1:1 copy of `_ClassDB::get_method_list`
also  
`Variant::get_method_list_by_type` is just extracted code from `Variant::get_method_list` to be able not duplicate same code.

~`get_non_object_methods_list` isn't the best name, so it should be renamed to something better~