### PR TITLE
Implements expandable color ports for Color and Texture's sampling nodes in visual shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -83,6 +83,8 @@ private:
 	List<VisualShader::Connection> connections;
 	bool dirty = false;
 
+	Color vector_expanded_color[3];
+
 protected:
 	static void _bind_methods();
 
@@ -119,6 +121,7 @@ public:
 	void set_expression(VisualShader::Type p_type, int p_node_id, const String &p_expression);
 	int get_constant_index(float p_constant) const;
 	void update_node_size(int p_node_id);
+	void update_theme();
 	VisualShader::Type get_shader_type() const;
 
 	VisualShaderGraphPlugin();
@@ -401,6 +404,7 @@ class VisualShaderEditor : public VBoxContainer {
 	void _remove_output_port(int p_node, int p_port);
 	void _change_output_port_type(int p_type, int p_node, int p_port);
 	void _change_output_port_name(const String &p_text, Object *p_line_edit, int p_node, int p_port);
+	void _expand_output_port(int p_node, int p_port, bool p_expand);
 
 	void _expression_focus_out(Object *code_edit, int p_node);
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -199,6 +199,7 @@ class VisualShaderNode : public Resource {
 	Map<int, Variant> default_input_values;
 	Map<int, bool> connected_input_ports;
 	Map<int, int> connected_output_ports;
+	Map<int, bool> expanded_output_ports;
 
 protected:
 	bool simple_decl = true;
@@ -244,6 +245,13 @@ public:
 	bool is_input_port_connected(int p_port) const;
 	void set_input_port_connected(int p_port, bool p_connected);
 	virtual bool is_generate_input_var(int p_port) const;
+
+	virtual bool is_output_port_expandable(int p_port) const;
+	void _set_output_ports_expanded(const Array &p_data);
+	Array _get_output_ports_expanded() const;
+	void _set_output_port_expanded(int p_port, bool p_expanded);
+	bool _is_output_port_expanded(int p_port) const;
+	int get_expanded_output_port_count() const;
 
 	virtual bool is_code_generated() const;
 	virtual bool is_show_prop_names() const;

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -242,6 +242,13 @@ String VisualShaderNodeColorConstant::get_output_port_name(int p_port) const {
 	return p_port == 0 ? "" : "alpha"; //no output port means the editor will be used as port
 }
 
+bool VisualShaderNodeColorConstant::is_output_port_expandable(int p_port) const {
+	if (p_port == 0) {
+		return true;
+	}
+	return false;
+}
+
 String VisualShaderNodeColorConstant::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String code;
 	code += "\t" + p_output_vars[0] + " = " + vformat("vec3(%.6f, %.6f, %.6f)", constant.r, constant.g, constant.b) + ";\n";
@@ -453,6 +460,13 @@ String VisualShaderNodeTexture::get_output_port_name(int p_port) const {
 		return "depth";
 	}
 	return p_port == 0 ? "rgb" : "alpha";
+}
+
+bool VisualShaderNodeTexture::is_output_port_expandable(int p_port) const {
+	if (p_port == 0) {
+		return true;
+	}
+	return false;
 }
 
 String VisualShaderNodeTexture::get_input_port_default_hint(int p_port) const {
@@ -917,6 +931,13 @@ String VisualShaderNodeSample3D::get_output_port_name(int p_port) const {
 	return p_port == 0 ? "rgb" : "alpha";
 }
 
+bool VisualShaderNodeSample3D::is_output_port_expandable(int p_port) const {
+	if (p_port == 0) {
+		return true;
+	}
+	return false;
+}
+
 String VisualShaderNodeSample3D::get_input_port_default_hint(int p_port) const {
 	if (p_port == 0) {
 		return "default";
@@ -1166,6 +1187,13 @@ VisualShaderNodeCubemap::PortType VisualShaderNodeCubemap::get_output_port_type(
 
 String VisualShaderNodeCubemap::get_output_port_name(int p_port) const {
 	return p_port == 0 ? "rgb" : "alpha";
+}
+
+bool VisualShaderNodeCubemap::is_output_port_expandable(int p_port) const {
+	if (p_port == 0) {
+		return true;
+	}
+	return false;
 }
 
 Vector<VisualShader::DefaultTextureParam> VisualShaderNodeCubemap::get_default_texture_parameters(VisualShader::Type p_type, int p_id) const {

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -163,6 +163,7 @@ public:
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
+	virtual bool is_output_port_expandable(int p_port) const override;
 
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
@@ -275,6 +276,7 @@ public:
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
+	virtual bool is_output_port_expandable(int p_port) const override;
 
 	virtual String get_input_port_default_hint(int p_port) const override;
 
@@ -359,6 +361,7 @@ public:
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
+	virtual bool is_output_port_expandable(int p_port) const override;
 
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
@@ -452,6 +455,7 @@ public:
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
+	virtual bool is_output_port_expandable(int p_port) const override;
 
 	virtual Vector<VisualShader::DefaultTextureParam> get_default_texture_parameters(VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;


### PR DESCRIPTION
`Color` and multiple `Texture` nodes are now able to expand their first output ports to access individual color components of the vector. This eliminates the need to use `VectorDecompose` on them for better usability. 

![color_ports](https://user-images.githubusercontent.com/3036176/119466428-47394880-bd4d-11eb-9591-bf314acb4046.gif)

This enhancement is also implementation of @fire proposal: 

Fixes: https://github.com/godotengine/godot-proposals/issues/884