### PR TITLE
Add override keywords to FileAccess and DirAccess derived classes

### DIFF
--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -70,29 +70,29 @@ public:
 
 	Error open_after_magic(Ref<FileAccess> p_base);
 
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual bool is_open() const override; ///< true when file is open
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
-	virtual uint64_t get_length() const; ///< get size of the file
+	virtual void seek(uint64_t p_position) override; ///< seek to a given position
+	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
+	virtual uint64_t get_position() const override; ///< get position in the file
+	virtual uint64_t get_length() const override; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
+	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+	virtual uint8_t get_8() const override; ///< get a byte
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	virtual Error get_error() const; ///< get last error
+	virtual Error get_error() const override; ///< get last error
 
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
+	virtual void flush() override;
+	virtual void store_8(uint8_t p_dest) override; ///< store a byte
 
-	virtual bool file_exists(const String &p_name); ///< return true if a file exists
+	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
 
-	virtual uint64_t _get_modified_time(const String &p_file);
-	virtual uint32_t _get_unix_permissions(const String &p_file);
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions);
+	virtual uint64_t _get_modified_time(const String &p_file) override;
+	virtual uint32_t _get_unix_permissions(const String &p_file) override;
+	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) override;
 
 	FileAccessCompressed() {}
 	virtual ~FileAccessCompressed();

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -60,33 +60,33 @@ public:
 	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true);
 	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
 
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual bool is_open() const override; ///< true when file is open
 
-	virtual String get_path() const; /// returns the path for the current open file
-	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
+	virtual String get_path() const override; /// returns the path for the current open file
+	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
-	virtual uint64_t get_length() const; ///< get size of the file
+	virtual void seek(uint64_t p_position) override; ///< seek to a given position
+	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
+	virtual uint64_t get_position() const override; ///< get position in the file
+	virtual uint64_t get_length() const override; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
+	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+	virtual uint8_t get_8() const override; ///< get a byte
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	virtual Error get_error() const; ///< get last error
+	virtual Error get_error() const override; ///< get last error
 
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
+	virtual void flush() override;
+	virtual void store_8(uint8_t p_dest) override; ///< store a byte
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
-	virtual bool file_exists(const String &p_name); ///< return true if a file exists
+	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
 
-	virtual uint64_t _get_modified_time(const String &p_file);
-	virtual uint32_t _get_unix_permissions(const String &p_file);
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions);
+	virtual uint64_t _get_modified_time(const String &p_file) override;
+	virtual uint32_t _get_unix_permissions(const String &p_file) override;
+	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) override;
 
 	FileAccessEncrypted() {}
 	~FileAccessEncrypted();

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -45,31 +45,31 @@ public:
 	static void cleanup();
 
 	virtual Error open_custom(const uint8_t *p_data, uint64_t p_len); ///< open a file
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual bool is_open() const override; ///< true when file is open
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
-	virtual uint64_t get_length() const; ///< get size of the file
+	virtual void seek(uint64_t p_position) override; ///< seek to a given position
+	virtual void seek_end(int64_t p_position) override; ///< seek from the end of file
+	virtual uint64_t get_position() const override; ///< get position in the file
+	virtual uint64_t get_length() const override; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
+	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
+	virtual uint8_t get_8() const override; ///< get a byte
 
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const; ///< get an array of bytes
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override; ///< get an array of bytes
 
-	virtual Error get_error() const; ///< get last error
+	virtual Error get_error() const override; ///< get last error
 
-	virtual void flush();
-	virtual void store_8(uint8_t p_byte); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
+	virtual void flush() override;
+	virtual void store_8(uint8_t p_byte) override; ///< store a byte
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
-	virtual bool file_exists(const String &p_name); ///< return true if a file exists
+	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
 
-	virtual uint64_t _get_modified_time(const String &p_file) { return 0; }
-	virtual uint32_t _get_unix_permissions(const String &p_file) { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) { return FAILED; }
+	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
+	virtual uint32_t _get_unix_permissions(const String &p_file) override { return 0; }
+	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) override { return FAILED; }
 
 	FileAccessMemory() {}
 };

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -132,29 +132,29 @@ public:
 		RESPONSE_GET_MODTIME,
 	};
 
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual bool is_open() const override; ///< true when file is open
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
-	virtual uint64_t get_length() const; ///< get size of the file
+	virtual void seek(uint64_t p_position) override; ///< seek to a given position
+	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
+	virtual uint64_t get_position() const override; ///< get position in the file
+	virtual uint64_t get_length() const override; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
+	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+	virtual uint8_t get_8() const override; ///< get a byte
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	virtual Error get_error() const; ///< get last error
+	virtual Error get_error() const override; ///< get last error
 
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
+	virtual void flush() override;
+	virtual void store_8(uint8_t p_dest) override; ///< store a byte
 
-	virtual bool file_exists(const String &p_path); ///< return true if a file exists
+	virtual bool file_exists(const String &p_path) override; ///< return true if a file exists
 
-	virtual uint64_t _get_modified_time(const String &p_file);
-	virtual uint32_t _get_unix_permissions(const String &p_file);
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions);
+	virtual uint64_t _get_modified_time(const String &p_file) override;
+	virtual uint32_t _get_unix_permissions(const String &p_file) override;
+	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) override;
 
 	static void configure();
 

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -148,35 +148,35 @@ class FileAccessPack : public FileAccess {
 	uint64_t off;
 
 	Ref<FileAccess> f;
-	virtual Error _open(const String &p_path, int p_mode_flags);
-	virtual uint64_t _get_modified_time(const String &p_file) { return 0; }
-	virtual uint32_t _get_unix_permissions(const String &p_file) { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) { return FAILED; }
+	virtual Error _open(const String &p_path, int p_mode_flags) override;
+	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
+	virtual uint32_t _get_unix_permissions(const String &p_file) override { return 0; }
+	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) override { return FAILED; }
 
 public:
-	virtual bool is_open() const;
+	virtual bool is_open() const override;
 
-	virtual void seek(uint64_t p_position);
-	virtual void seek_end(int64_t p_position = 0);
-	virtual uint64_t get_position() const;
-	virtual uint64_t get_length() const;
+	virtual void seek(uint64_t p_position) override;
+	virtual void seek_end(int64_t p_position = 0) override;
+	virtual uint64_t get_position() const override;
+	virtual uint64_t get_length() const override;
 
-	virtual bool eof_reached() const;
+	virtual bool eof_reached() const override;
 
-	virtual uint8_t get_8() const;
+	virtual uint8_t get_8() const override;
 
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	virtual void set_big_endian(bool p_big_endian);
+	virtual void set_big_endian(bool p_big_endian) override;
 
-	virtual Error get_error() const;
+	virtual Error get_error() const override;
 
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest);
+	virtual void flush() override;
+	virtual void store_8(uint8_t p_dest) override;
 
-	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length);
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override;
 
-	virtual bool file_exists(const String &p_name);
+	virtual bool file_exists(const String &p_name) override;
 
 	FileAccessPack(const String &p_path, const PackedData::PackedFile &p_file);
 };

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -217,33 +217,33 @@ class DirAccessPack : public DirAccess {
 	PackedData::PackedDir *_find_dir(String p_dir);
 
 public:
-	virtual Error list_dir_begin();
-	virtual String get_next();
-	virtual bool current_is_dir() const;
-	virtual bool current_is_hidden() const;
-	virtual void list_dir_end();
+	virtual Error list_dir_begin() override;
+	virtual String get_next() override;
+	virtual bool current_is_dir() const override;
+	virtual bool current_is_hidden() const override;
+	virtual void list_dir_end() override;
 
-	virtual int get_drive_count();
-	virtual String get_drive(int p_drive);
+	virtual int get_drive_count() override;
+	virtual String get_drive(int p_drive) override;
 
-	virtual Error change_dir(String p_dir);
-	virtual String get_current_dir(bool p_include_drive = true) const;
+	virtual Error change_dir(String p_dir) override;
+	virtual String get_current_dir(bool p_include_drive = true) const override;
 
-	virtual bool file_exists(String p_file);
-	virtual bool dir_exists(String p_dir);
+	virtual bool file_exists(String p_file) override;
+	virtual bool dir_exists(String p_dir) override;
 
-	virtual Error make_dir(String p_dir);
+	virtual Error make_dir(String p_dir) override;
 
-	virtual Error rename(String p_from, String p_to);
-	virtual Error remove(String p_name);
+	virtual Error rename(String p_from, String p_to) override;
+	virtual Error remove(String p_name) override;
 
-	uint64_t get_space_left();
+	uint64_t get_space_left() override;
 
-	virtual bool is_link(String p_file) { return false; }
-	virtual String read_link(String p_file) { return p_file; }
-	virtual Error create_link(String p_source, String p_target) { return FAILED; }
+	virtual bool is_link(String p_file) override { return false; }
+	virtual String read_link(String p_file) override { return p_file; }
+	virtual Error create_link(String p_source, String p_target) override { return FAILED; }
 
-	virtual String get_filesystem_type() const;
+	virtual String get_filesystem_type() const override;
 
 	DirAccessPack();
 };

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -85,29 +85,29 @@ class FileAccessZip : public FileAccess {
 	void _close();
 
 public:
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual bool is_open() const override; ///< true when file is open
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
-	virtual uint64_t get_length() const; ///< get size of the file
+	virtual void seek(uint64_t p_position) override; ///< seek to a given position
+	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
+	virtual uint64_t get_position() const override; ///< get position in the file
+	virtual uint64_t get_length() const override; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
+	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+	virtual uint8_t get_8() const override; ///< get a byte
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	virtual Error get_error() const; ///< get last error
+	virtual Error get_error() const override; ///< get last error
 
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
+	virtual void flush() override;
+	virtual void store_8(uint8_t p_dest) override; ///< store a byte
 
-	virtual bool file_exists(const String &p_name); ///< return true if a file exists
+	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
 
-	virtual uint64_t _get_modified_time(const String &p_file) { return 0; } // todo
-	virtual uint32_t _get_unix_permissions(const String &p_file) { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) { return FAILED; }
+	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; } // todo
+	virtual uint32_t _get_unix_permissions(const String &p_file) override { return 0; }
+	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) override { return FAILED; }
 
 	FileAccessZip(const String &p_path, const PackedData::PackedFile &p_file);
 	~FileAccessZip();

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -52,39 +52,39 @@ protected:
 	virtual bool is_hidden(const String &p_name);
 
 public:
-	virtual Error list_dir_begin(); ///< This starts dir listing
-	virtual String get_next();
-	virtual bool current_is_dir() const;
-	virtual bool current_is_hidden() const;
+	virtual Error list_dir_begin() override; ///< This starts dir listing
+	virtual String get_next() override;
+	virtual bool current_is_dir() const override;
+	virtual bool current_is_hidden() const override;
 
-	virtual void list_dir_end(); ///<
+	virtual void list_dir_end() override; ///<
 
-	virtual int get_drive_count();
-	virtual String get_drive(int p_drive);
-	virtual int get_current_drive();
-	virtual bool drives_are_shortcuts();
+	virtual int get_drive_count() override;
+	virtual String get_drive(int p_drive) override;
+	virtual int get_current_drive() override;
+	virtual bool drives_are_shortcuts() override;
 
-	virtual Error change_dir(String p_dir); ///< can be relative or absolute, return false on success
-	virtual String get_current_dir(bool p_include_drive = true) const; ///< return current dir location
-	virtual Error make_dir(String p_dir);
+	virtual Error change_dir(String p_dir) override; ///< can be relative or absolute, return false on success
+	virtual String get_current_dir(bool p_include_drive = true) const override; ///< return current dir location
+	virtual Error make_dir(String p_dir) override;
 
-	virtual bool file_exists(String p_file);
-	virtual bool dir_exists(String p_dir);
-	virtual bool is_readable(String p_dir);
-	virtual bool is_writable(String p_dir);
+	virtual bool file_exists(String p_file) override;
+	virtual bool dir_exists(String p_dir) override;
+	virtual bool is_readable(String p_dir) override;
+	virtual bool is_writable(String p_dir) override;
 
 	virtual uint64_t get_modified_time(String p_file);
 
-	virtual Error rename(String p_path, String p_new_path);
-	virtual Error remove(String p_path);
+	virtual Error rename(String p_path, String p_new_path) override;
+	virtual Error remove(String p_path) override;
 
-	virtual bool is_link(String p_file);
-	virtual String read_link(String p_file);
-	virtual Error create_link(String p_source, String p_target);
+	virtual bool is_link(String p_file) override;
+	virtual String read_link(String p_file) override;
+	virtual Error create_link(String p_source, String p_target) override;
 
-	virtual uint64_t get_space_left();
+	virtual uint64_t get_space_left() override;
 
-	virtual String get_filesystem_type() const;
+	virtual String get_filesystem_type() const override;
 
 	DirAccessUnix();
 	~DirAccessUnix();

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -54,33 +54,33 @@ class FileAccessUnix : public FileAccess {
 public:
 	static CloseNotificationFunc close_notification_func;
 
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual bool is_open() const override; ///< true when file is open
 
-	virtual String get_path() const; /// returns the path for the current open file
-	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
+	virtual String get_path() const override; /// returns the path for the current open file
+	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
-	virtual uint64_t get_length() const; ///< get size of the file
+	virtual void seek(uint64_t p_position) override; ///< seek to a given position
+	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
+	virtual uint64_t get_position() const override; ///< get position in the file
+	virtual uint64_t get_length() const override; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
+	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+	virtual uint8_t get_8() const override; ///< get a byte
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	virtual Error get_error() const; ///< get last error
+	virtual Error get_error() const override; ///< get last error
 
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
+	virtual void flush() override;
+	virtual void store_8(uint8_t p_dest) override; ///< store a byte
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
-	virtual bool file_exists(const String &p_path); ///< return true if a file exists
+	virtual bool file_exists(const String &p_path) override; ///< return true if a file exists
 
-	virtual uint64_t _get_modified_time(const String &p_file);
-	virtual uint32_t _get_unix_permissions(const String &p_file);
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions);
+	virtual uint64_t _get_modified_time(const String &p_file) override;
+	virtual uint32_t _get_unix_permissions(const String &p_file) override;
+	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) override;
 
 	FileAccessUnix() {}
 	virtual ~FileAccessUnix();

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -54,33 +54,33 @@ class DirAccessWindows : public DirAccess {
 	bool _cishidden = false;
 
 public:
-	virtual Error list_dir_begin(); ///< This starts dir listing
-	virtual String get_next();
-	virtual bool current_is_dir() const;
-	virtual bool current_is_hidden() const;
-	virtual void list_dir_end(); ///<
+	virtual Error list_dir_begin() override; ///< This starts dir listing
+	virtual String get_next() override;
+	virtual bool current_is_dir() const override;
+	virtual bool current_is_hidden() const override;
+	virtual void list_dir_end() override; ///<
 
-	virtual int get_drive_count();
-	virtual String get_drive(int p_drive);
+	virtual int get_drive_count() override;
+	virtual String get_drive(int p_drive) override;
 
-	virtual Error change_dir(String p_dir); ///< can be relative or absolute, return false on success
-	virtual String get_current_dir(bool p_include_drive = true) const; ///< return current dir location
+	virtual Error change_dir(String p_dir) override; ///< can be relative or absolute, return false on success
+	virtual String get_current_dir(bool p_include_drive = true) const override; ///< return current dir location
 
-	virtual bool file_exists(String p_file);
-	virtual bool dir_exists(String p_dir);
+	virtual bool file_exists(String p_file) override;
+	virtual bool dir_exists(String p_dir) override;
 
-	virtual Error make_dir(String p_dir);
+	virtual Error make_dir(String p_dir) override;
 
-	virtual Error rename(String p_path, String p_new_path);
-	virtual Error remove(String p_path);
+	virtual Error rename(String p_path, String p_new_path) override;
+	virtual Error remove(String p_path) override;
 
-	virtual bool is_link(String p_file) { return false; };
-	virtual String read_link(String p_file) { return p_file; };
-	virtual Error create_link(String p_source, String p_target) { return FAILED; };
+	virtual bool is_link(String p_file) override { return false; };
+	virtual String read_link(String p_file) override { return p_file; };
+	virtual Error create_link(String p_source, String p_target) override { return FAILED; };
 
-	uint64_t get_space_left();
+	uint64_t get_space_left() override;
 
-	virtual String get_filesystem_type() const;
+	virtual String get_filesystem_type() const override;
 
 	DirAccessWindows();
 	~DirAccessWindows();

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -51,33 +51,33 @@ class FileAccessWindows : public FileAccess {
 	void _close();
 
 public:
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual bool is_open() const override; ///< true when file is open
 
-	virtual String get_path() const; /// returns the path for the current open file
-	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
+	virtual String get_path() const override; /// returns the path for the current open file
+	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
-	virtual uint64_t get_length() const; ///< get size of the file
+	virtual void seek(uint64_t p_position) override; ///< seek to a given position
+	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
+	virtual uint64_t get_position() const override; ///< get position in the file
+	virtual uint64_t get_length() const override; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
+	virtual bool eof_reached() const override; ///< reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+	virtual uint8_t get_8() const override; ///< get a byte
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	virtual Error get_error() const; ///< get last error
+	virtual Error get_error() const override; ///< get last error
 
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
+	virtual void flush() override;
+	virtual void store_8(uint8_t p_dest) override; ///< store a byte
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
-	virtual bool file_exists(const String &p_name); ///< return true if a file exists
+	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
 
-	uint64_t _get_modified_time(const String &p_file);
-	virtual uint32_t _get_unix_permissions(const String &p_file);
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions);
+	uint64_t _get_modified_time(const String &p_file) override;
+	virtual uint32_t _get_unix_permissions(const String &p_file) override;
+	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) override;
 
 	FileAccessWindows() {}
 	virtual ~FileAccessWindows();

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -49,34 +49,34 @@ class FileAccessAndroid : public FileAccess {
 public:
 	static AAssetManager *asset_manager;
 
-	virtual Error _open(const String &p_path, int p_mode_flags); // open a file
-	virtual bool is_open() const; // true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags) override; // open a file
+	virtual bool is_open() const override; // true when file is open
 
 	/// returns the path for the current open file
-	virtual String get_path() const;
+	virtual String get_path() const override;
 	/// returns the absolute path for the current open file
-	virtual String get_path_absolute() const;
+	virtual String get_path_absolute() const override;
 
-	virtual void seek(uint64_t p_position); // seek to a given position
-	virtual void seek_end(int64_t p_position = 0); // seek from the end of file
-	virtual uint64_t get_position() const; // get position in the file
-	virtual uint64_t get_length() const; // get size of the file
+	virtual void seek(uint64_t p_position) override; // seek to a given position
+	virtual void seek_end(int64_t p_position = 0) override; // seek from the end of file
+	virtual uint64_t get_position() const override; // get position in the file
+	virtual uint64_t get_length() const override; // get size of the file
 
-	virtual bool eof_reached() const; // reading passed EOF
+	virtual bool eof_reached() const override; // reading passed EOF
 
-	virtual uint8_t get_8() const; // get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+	virtual uint8_t get_8() const override; // get a byte
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	virtual Error get_error() const; // get last error
+	virtual Error get_error() const override; // get last error
 
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest); // store a byte
+	virtual void flush() override;
+	virtual void store_8(uint8_t p_dest) override; // store a byte
 
-	virtual bool file_exists(const String &p_path); // return true if a file exists
+	virtual bool file_exists(const String &p_path) override; // return true if a file exists
 
-	virtual uint64_t _get_modified_time(const String &p_file) { return 0; }
-	virtual uint32_t _get_unix_permissions(const String &p_file) { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) { return FAILED; }
+	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
+	virtual uint32_t _get_unix_permissions(const String &p_file) override { return 0; }
+	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) override { return FAILED; }
 
 	~FileAccessAndroid();
 };

--- a/platform/macos/dir_access_macos.h
+++ b/platform/macos/dir_access_macos.h
@@ -43,12 +43,12 @@
 
 class DirAccessMacOS : public DirAccessUnix {
 protected:
-	virtual String fix_unicode_name(const char *p_name) const;
+	virtual String fix_unicode_name(const char *p_name) const override;
 
-	virtual int get_drive_count();
-	virtual String get_drive(int p_drive);
+	virtual int get_drive_count() override;
+	virtual String get_drive(int p_drive) override;
 
-	virtual bool is_hidden(const String &p_name);
+	virtual bool is_hidden(const String &p_name) override;
 };
 
 #endif // UNIX ENABLED || LIBC_FILEIO_ENABLED


### PR DESCRIPTION
Adds missing `override` keyword to `FileAccess` and `DirAccess` derived classes' overridden methods.
