### PR TITLE
Fixed implementation of RichTextLabel remove_line(), which fixed issues in EditorLog.

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -234,10 +234,9 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 
 	if (p_replace_previous) {
 		// Remove last line if replacing, as it will be replace by the next added line.
-		// Why - 2? RichTextLabel is weird. When you add a line, it also adds a NEW line, which is null,
+		// Why "- 2"? RichTextLabel is weird. When you add a line with add_newline(), it also adds an element to the list of lines which is null/blank,
 		// but it still counts as a line. So if you remove the last line (count - 1) you are actually removing nothing...
-		log->remove_line(log->get_line_count() - 2);
-		log->increment_line_count();
+		log->remove_line(log->get_paragraph_count() - 2);
 	}
 
 	switch (p_message.type) {
@@ -271,13 +270,14 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	}
 
 	log->add_text(p_message.text);
-	log->add_newline();
 
 	// Need to use pop() to exit out of the RichTextLabels current "push" stack.
 	// We only "push" in the above switch when message type != STD, so only pop when that is the case.
 	if (p_message.type != MSG_TYPE_STD) {
 		log->pop();
 	}
+
+	log->add_newline();
 }
 
 void EditorLog::_set_filter_active(bool p_active, MessageType p_message_type) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2232,18 +2232,22 @@ void RichTextLabel::_remove_item(Item *p_item, const int p_line, const int p_sub
 	int size = p_item->subitems.size();
 	if (size == 0) {
 		p_item->parent->subitems.erase(p_item);
+		// If a newline was erased, all lines AFTER the newline need to be decremented.
 		if (p_item->type == ITEM_NEWLINE) {
 			current_frame->lines.remove(p_line);
-			for (int i = p_subitem_line; i < current->subitems.size(); i++) {
-				if (current->subitems[i]->line > 0) {
+			for (int i = 0; i < current->subitems.size(); i++) {
+				if (current->subitems[i]->line > p_subitem_line) {
 					current->subitems[i]->line--;
 				}
 			}
 		}
 	} else {
+		// First, remove all child items for the provided item.
 		for (int i = 0; i < size; i++) {
 			_remove_item(p_item->subitems.front()->get(), p_line, p_subitem_line);
 		}
+		// Then remove the provided item itself.
+		p_item->parent->subitems.erase(p_item);
 	}
 }
 
@@ -2303,21 +2307,23 @@ bool RichTextLabel::remove_line(const int p_line) {
 		return false;
 	}
 
-	int i = 0;
-	while (i < current->subitems.size() && current->subitems[i]->line < p_line) {
-		i++;
-	}
-
-	bool was_newline = false;
-	while (i < current->subitems.size()) {
-		was_newline = current->subitems[i]->type == ITEM_NEWLINE;
-		_remove_item(current->subitems[i], current->subitems[i]->line, p_line);
-		if (was_newline) {
-			break;
+	// Remove all subitems with the same line as that provided.
+	Vector<int> subitem_indices_to_remove;
+	for (int i = 0; i < current->subitems.size(); i++) {
+		if (current->subitems[i]->line == p_line) {
+			subitem_indices_to_remove.push_back(i);
 		}
 	}
 
-	if (!was_newline) {
+	bool had_newline = false;
+	// Reverse for loop to remove items from the end first.
+	for (int i = subitem_indices_to_remove.size() - 1; i >= 0; i--) {
+		int subitem_idx = subitem_indices_to_remove[i];
+		had_newline = had_newline || current->subitems[subitem_idx]->type == ITEM_NEWLINE;
+		_remove_item(current->subitems[subitem_idx], current->subitems[subitem_idx]->line, p_line);
+	}
+
+	if (!had_newline) {
 		current_frame->lines.remove(p_line);
 		if (current_frame->lines.size() == 0) {
 			current_frame->lines.resize(1);
@@ -2329,6 +2335,7 @@ bool RichTextLabel::remove_line(const int p_line) {
 	}
 
 	main->first_invalid_line = 0; // p_line ???
+	update();
 
 	return true;
 }
@@ -2611,14 +2618,6 @@ void RichTextLabel::pop() {
 		current_frame = static_cast<ItemFrame *>(current)->parent_frame;
 	}
 	current = current->parent;
-}
-
-// Creates a new line without adding an ItemNewline to the previous line.
-// Useful when wanting to calling remove_line and add a new line immediately after.
-void RichTextLabel::increment_line_count() {
-	_validate_line_caches(main);
-	current_frame->lines.resize(current_frame->lines.size() + 1);
-	_invalidate_current_line(current_frame);
 }
 
 void RichTextLabel::clear() {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -483,8 +483,6 @@ public:
 	void push_cell();
 	void pop();
 
-	void increment_line_count();
-
 	void clear();
 
 	void set_offset(int p_pixel);


### PR DESCRIPTION
There were some issues in RichTextLabel `remove_line()` method, where items were not correctly removed, and line decremending for items in later lines was not correctly done.

This also fixed several headaches with EditorLog, which relied on the `remove_line()` method for collapsing of duplicate messages.

I added some comments which should help clarify some of the logic for the next person to look at this code.

Fixes #49030

See #49030 for the code which I used for the below samples. Essentially the spacebar just calls `remove_line(get_line_count() - 1)`, which should remove the last line of the rich text label. I also tested the update with code which removes lines from the middle of a set of lines and it worked as expected.

Note the "Before" was even more broken because an `update()` was not triggered on `remove_line()` - for the below "Before" showcase I added a manual call to `update()` in the GDScript code. 

## BEFORE

https://user-images.githubusercontent.com/41730826/119494471-aeceb280-bda4-11eb-96ac-81a119f18697.mp4

## AFTER

https://user-images.githubusercontent.com/41730826/119494492-b4c49380-bda4-11eb-994a-a4621f957a74.mp4

## Editor Log AFTER

https://user-images.githubusercontent.com/41730826/119494422-a2e2f080-bda4-11eb-957b-e339ee36cde8.mp4

CC @KoBeWi I hope you can stop submitting reports about EditorLog now... 😂