### PR TITLE
Fix some warnings raised by GCC-11.1

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2211,7 +2211,7 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 					if (err) {
 						return err;
 					}
-					if (base.is_null() && !base->is_valid()) {
+					if (base.is_null() || !base->is_valid()) {
 						return ERR_COMPILATION_FAILED;
 					}
 				}

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -490,7 +490,7 @@ Image::Format StreamTexture2D::get_format() const {
 	return format;
 }
 
-Error StreamTexture2D::_load_data(const String &p_path, int &tw, int &th, int &tw_custom, int &th_custom, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit) {
+Error StreamTexture2D::_load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit) {
 	alpha_cache.unref();
 
 	ERR_FAIL_COND_V(image.is_null(), ERR_INVALID_PARAMETER);
@@ -511,8 +511,8 @@ Error StreamTexture2D::_load_data(const String &p_path, int &tw, int &th, int &t
 		memdelete(f);
 		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Stream texture file is too new.");
 	}
-	tw_custom = f->get_32();
-	th_custom = f->get_32();
+	r_width = f->get_32();
+	r_height = f->get_32();
 	uint32_t df = f->get_32(); //data format
 
 	//skip reserved
@@ -551,7 +551,7 @@ Error StreamTexture2D::_load_data(const String &p_path, int &tw, int &th, int &t
 }
 
 Error StreamTexture2D::load(const String &p_path) {
-	int lw, lh, lwc, lhc;
+	int lw, lh;
 	Ref<Image> image;
 	image.instance();
 
@@ -560,7 +560,7 @@ Error StreamTexture2D::load(const String &p_path) {
 	bool request_roughness;
 	int mipmap_limit;
 
-	Error err = _load_data(p_path, lw, lh, lwc, lhc, image, request_3d, request_normal, request_roughness, mipmap_limit);
+	Error err = _load_data(p_path, lw, lh, image, request_3d, request_normal, request_roughness, mipmap_limit);
 	if (err) {
 		return err;
 	}
@@ -571,12 +571,12 @@ Error StreamTexture2D::load(const String &p_path) {
 	} else {
 		texture = RS::get_singleton()->texture_2d_create(image);
 	}
-	if (lwc || lhc) {
-		RS::get_singleton()->texture_set_size_override(texture, lwc, lhc);
+	if (lw || lh) {
+		RS::get_singleton()->texture_set_size_override(texture, lw, lh);
 	}
 
-	w = lwc ? lwc : lw;
-	h = lhc ? lhc : lh;
+	w = lw;
+	h = lh;
 	path_to_file = p_path;
 	format = image->get_format();
 

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -158,7 +158,7 @@ public:
 	};
 
 private:
-	Error _load_data(const String &p_path, int &tw, int &th, int &tw_custom, int &th_custom, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit = 0);
+	Error _load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit = 0);
 	String path_to_file;
 	mutable RID texture;
 	Image::Format format = Image::FORMAT_MAX;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1164,6 +1164,9 @@ void AudioServer::set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout) {
 				Bus::Effect bfx;
 				bfx.effect = fx;
 				bfx.enabled = p_bus_layout->buses[i].effects[j].enabled;
+#if DEBUG_ENABLED
+				bfx.prof_time = 0;
+#endif
 				bus->effects.push_back(bfx);
 			}
 		}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -121,24 +121,27 @@ int test_main(int argc, char *argv[]) {
 			test_args.push_back(arg);
 		}
 	}
-	// Convert Godot command line arguments back to standard arguments.
-	char **doctest_args = new char *[test_args.size()];
-	for (int x = 0; x < test_args.size(); x++) {
-		// Operation to convert Godot string to non wchar string.
-		CharString cs = test_args[x].utf8();
-		const char *str = cs.get_data();
-		// Allocate the string copy.
-		doctest_args[x] = new char[strlen(str) + 1];
-		// Copy this into memory.
-		memcpy(doctest_args[x], str, strlen(str) + 1);
-	}
 
-	test_context.applyCommandLine(test_args.size(), doctest_args);
+	if (test_args.size() > 0) {
+		// Convert Godot command line arguments back to standard arguments.
+		char **doctest_args = new char *[test_args.size()];
+		for (int x = 0; x < test_args.size(); x++) {
+			// Operation to convert Godot string to non wchar string.
+			CharString cs = test_args[x].utf8();
+			const char *str = cs.get_data();
+			// Allocate the string copy.
+			doctest_args[x] = new char[strlen(str) + 1];
+			// Copy this into memory.
+			memcpy(doctest_args[x], str, strlen(str) + 1);
+		}
 
-	for (int x = 0; x < test_args.size(); x++) {
-		delete[] doctest_args[x];
+		test_context.applyCommandLine(test_args.size(), doctest_args);
+
+		for (int x = 0; x < test_args.size(); x++) {
+			delete[] doctest_args[x];
+		}
+		delete[] doctest_args;
 	}
-	delete[] doctest_args;
 
 	return test_context.run();
 }


### PR DESCRIPTION
Fixes for some issues that previous GCC versions were missing. 

Most of them are straight-forward, but it would be nice to get @reduz to review the changes to `StreamTexture2D`, since I'm not really sure if this is the correct fix. I removed the unused `int &tw` and `int &th` parameters, because they don't seem to be stored in the file format anymore, but it is possible the correct fix is to keep the parameters and actually store the values in the file.
