### PR TITLE
Allow basic user data backup on Android

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -857,6 +857,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 		int xr_mode_index = p_preset->get("xr_features/xr_mode");
 
+		bool backup_allowed = p_preset->get("user_data_backup/allow");
+
 		Vector<String> perms;
 		// Write permissions into the perms variable.
 		_get_permissions(p_preset, p_give_internet, perms);
@@ -947,6 +949,10 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 							} else {
 								string_table.write[attr_value] = version_name;
 							}
+						}
+
+						if (tname == "application" && attrname == "allowBackup") {
+							encode_uint32(backup_allowed, &p_manifest.write[iofs + 16]);
 						}
 
 						if (tname == "instrumentation" && attrname == "targetPackage") {
@@ -1683,6 +1689,8 @@ public:
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_normal"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_large"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_xlarge"), true));
+
+		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "user_data_backup/allow"), false));
 
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "command_line/extra_args"), ""));
 

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -258,10 +258,11 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 }
 
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset) {
-	String manifest_application_text =
+	String manifest_application_text = vformat(
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
-			"        android:allowBackup=\"false\" tools:ignore=\"GoogleAppIndexingWarning\"\n"
-			"        android:icon=\"@mipmap/icon\">\n\n";
+			"        android:allowBackup=\"%s\" tools:ignore=\"GoogleAppIndexingWarning\"\n"
+			"        android:icon=\"@mipmap/icon\">\n\n",
+			bool_to_string(p_preset->get("user_data_backup/allow")));
 
 	manifest_application_text += _get_activity_tag(p_preset);
 	manifest_application_text += "    </application>\n";


### PR DESCRIPTION
This adds an export option to enable the most basic modality of automatic backup of user data (basically, an export preset flag that maps to `<application android:allowBackup="" ...>`; see https://developer.android.com/guide/topics/data/autobackup).

Projects that store device or session specific data that shouldn't be backed up, shouldn't use it, as explained in the above guide. They would need an evolution of this feature where there would be additional settings for white-listing which files to allow backup for.

However, this basic setting already helps projects that just store gameplay data and save them from the burden of implementing game services or something like that just to get user data backed up and restored on reinstall (on the same or another device).

**NOTE:** Version for 3.x submitted as #49070.