### PR TITLE
[3.x] Return error when decompressing empty PoolByteArray

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -631,6 +631,10 @@ struct _VariantCall {
 			r_ret = decompressed;
 			ERR_FAIL_MSG("Decompression buffer size must be greater than zero.");
 		}
+		if (ba->size() == 0) {
+			r_ret = decompressed;
+			ERR_FAIL_MSG("Compressed buffer size must be greater than zero.");
+		}
 
 		decompressed.resize(buffer_size);
 		int result = Compression::decompress(decompressed.write().ptr(), buffer_size, ba->read().ptr(), ba->size(), mode);


### PR DESCRIPTION
This should fix #49006 . I'm creating PRs to `3.x` and `master` separately because `PoolByteArray` was renamed to `PackedByteArray` in 4.0.

*Bugsquad edit:* `master` PR: #49073