### PR TITLE
Return error when decompressing empty PackedByteArray

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -611,6 +611,9 @@ struct _VariantCall {
 		if (buffer_size <= 0) {
 			ERR_FAIL_V_MSG(decompressed, "Decompression buffer size must be greater than zero.");
 		}
+		if (p_instance->size() == 0) {
+			ERR_FAIL_V_MSG(decompressed, "Compressed buffer size must be greater than zero.");
+		}
 
 		decompressed.resize(buffer_size);
 		int result = Compression::decompress(decompressed.ptrw(), buffer_size, p_instance->ptr(), p_instance->size(), mode);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This should fix #49006 . I'm creating PRs to `3.x` and `master` separately because `PoolByteArray` was renamed to `PackedByteArray` in 4.0.