### PR TITLE
Fix logic for showing tilemap debug collision

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -327,7 +327,7 @@
 			The light mask assigned to all light occluders in the TileMap. The TileSet's light occluders will cast shadows only from Light2D(s) that have the same light mask(s).
 		</member>
 		<member name="show_collision" type="bool" setter="set_show_collision" getter="is_show_collision_enabled" default="false">
-			If [code]true[/code], collision shapes are shown in the editor and at run-time. Requires [b]Visible Collision Shapes[/b] to be enabled in the [b]Debug[/b] menu for collision shapes to be visible at run-time.
+			If [code]true[/code], collision shapes are visible in the editor. Doesn't affect collision shapes visibility at runtime. To show collision shapes at runtime, enable [b]Visible Collision Shapes[/b] in the [b]Debug[/b] menu instead.
 		</member>
 		<member name="tile_set" type="TileSet" setter="set_tileset" getter="get_tileset">
 			The assigned [TileSet].

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -328,10 +328,17 @@ void TileMap::update_dirty_quadrants() {
 	Color debug_collision_color;
 	Color debug_navigation_color;
 
-	bool debug_shapes = show_collision && (Engine::get_singleton()->is_editor_hint() || (st && st->is_debugging_collisions_hint()));
+	bool debug_shapes = false;
+	if (st) {
+		if (Engine::get_singleton()->is_editor_hint()) {
+			debug_shapes = show_collision;
+		} else {
+			debug_shapes = st->is_debugging_collisions_hint();
+		}
 
-	if (debug_shapes) {
-		debug_collision_color = st->get_debug_collisions_color();
+		if (debug_shapes) {
+			debug_collision_color = st->get_debug_collisions_color();
+		}
 	}
 
 	bool debug_navigation = st && st->is_debugging_navigation_hint();


### PR DESCRIPTION
**In editor:** only when `show_collision` property is enabled
**In game:** only when `Visible collision shapes` is enabled in `Debug` menu

3.x version based on discussion in #48631 (see https://github.com/godotengine/godot/issues/48631#issuecomment-847154224)
Master version is done in #49024
