### PR TITLE
Implemented option to allow or disallow AudioStreamPlayer volume override by AnimationTree

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -57,6 +57,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="adjust_when_blending" type="bool" setter="set_adjust_when_blending" getter="get_adjust_when_blending" default="true">
+			If [code]true[/code], the volume will be changed by [AnimationTree] when blending.
+		</member>
 		<member name="autoplay" type="bool" setter="set_autoplay" getter="is_autoplay_enabled" default="false">
 			If [code]true[/code], audio plays when added to scene tree.
 		</member>

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -53,6 +53,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="adjust_when_blending" type="bool" setter="set_adjust_when_blending" getter="get_adjust_when_blending" default="true">
+			If [code]true[/code], the volume will be changed by [AnimationTree] when blending.
+		</member>
 		<member name="area_mask" type="int" setter="set_area_mask" getter="get_area_mask" default="1">
 			Areas in which this sound plays.
 		</member>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -54,6 +54,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="adjust_when_blending" type="bool" setter="set_adjust_when_blending" getter="get_adjust_when_blending" default="true">
+			If [code]true[/code], the volume will be changed by [AnimationTree] when blending.
+		</member>
 		<member name="area_mask" type="int" setter="set_area_mask" getter="get_area_mask" default="1">
 			Areas in which this sound plays.
 		</member>

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -368,6 +368,14 @@ StringName AudioStreamPlayer2D::get_bus() const {
 	return "Master";
 }
 
+void AudioStreamPlayer2D::set_adjust_when_blending(bool p_enable) {
+	adjust_when_blending = p_enable;
+}
+
+bool AudioStreamPlayer2D::get_adjust_when_blending() const {
+	return adjust_when_blending;
+}
+
 void AudioStreamPlayer2D::set_autoplay(bool p_enable) {
 	autoplay = p_enable;
 }
@@ -455,6 +463,9 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_db", "volume_db"), &AudioStreamPlayer2D::set_volume_db);
 	ClassDB::bind_method(D_METHOD("get_volume_db"), &AudioStreamPlayer2D::get_volume_db);
 
+	ClassDB::bind_method(D_METHOD("set_adjust_when_blending", "enable"), &AudioStreamPlayer2D::set_adjust_when_blending);
+	ClassDB::bind_method(D_METHOD("get_adjust_when_blending"), &AudioStreamPlayer2D::get_adjust_when_blending);
+
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer2D::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer2D::get_pitch_scale);
 
@@ -490,6 +501,7 @@ void AudioStreamPlayer2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24"), "set_volume_db", "get_volume_db");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "adjust_when_blending"), "set_adjust_when_blending", "get_adjust_when_blending");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -69,6 +69,7 @@ private:
 	SafeNumeric<float> setplay{ -1.0 };
 
 	float volume_db = 0.0;
+	bool adjust_when_blending = true;
 	float pitch_scale = 1.0;
 	bool autoplay = false;
 	bool stream_paused = false;
@@ -100,6 +101,9 @@ public:
 
 	void set_volume_db(float p_volume);
 	float get_volume_db() const;
+
+	void set_adjust_when_blending(bool p_enable);
+	bool get_adjust_when_blending() const;
 
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -739,6 +739,14 @@ StringName AudioStreamPlayer3D::get_bus() const {
 	return "Master";
 }
 
+void AudioStreamPlayer3D::set_adjust_when_blending(bool p_enable) {
+	adjust_when_blending = p_enable;
+}
+
+bool AudioStreamPlayer3D::get_adjust_when_blending() const {
+	return adjust_when_blending;
+}
+
 void AudioStreamPlayer3D::set_autoplay(bool p_enable) {
 	autoplay = p_enable;
 }
@@ -907,6 +915,9 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_max_db", "max_db"), &AudioStreamPlayer3D::set_max_db);
 	ClassDB::bind_method(D_METHOD("get_max_db"), &AudioStreamPlayer3D::get_max_db);
 
+	ClassDB::bind_method(D_METHOD("set_adjust_when_blending", "enable"), &AudioStreamPlayer3D::set_adjust_when_blending);
+	ClassDB::bind_method(D_METHOD("get_adjust_when_blending"), &AudioStreamPlayer3D::get_adjust_when_blending);
+
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer3D::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer3D::get_pitch_scale);
 
@@ -965,6 +976,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "attenuation_model", PROPERTY_HINT_ENUM, "Inverse,Inverse Square,Log,Disabled"), "set_attenuation_model", "get_attenuation_model");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unit_db", PROPERTY_HINT_RANGE, "-80,80"), "set_unit_db", "get_unit_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unit_size", PROPERTY_HINT_RANGE, "0.1,100,0.01,or_greater"), "set_unit_size", "get_unit_size");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "adjust_when_blending"), "set_adjust_when_blending", "get_adjust_when_blending");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_db", PROPERTY_HINT_RANGE, "-24,6"), "set_max_db", "get_max_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_playing", "is_playing");

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -100,6 +100,7 @@ private:
 	float unit_db = 0.0;
 	float unit_size = 10.0;
 	float max_db = 3.0;
+	bool adjust_when_blending = true;
 	float pitch_scale = 1.0;
 	bool autoplay = false;
 	bool stream_paused = false;
@@ -151,6 +152,9 @@ public:
 
 	void set_max_db(float p_boost);
 	float get_max_db() const;
+
+	void set_adjust_when_blending(bool p_enable);
+	bool get_adjust_when_blending() const;
 
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1103,11 +1103,13 @@ void AnimationTree::_process_graph(float p_delta) {
 							}
 						}
 
-						float db = Math::linear2db(MAX(blend, 0.00001));
-						if (t->object->has_method("set_unit_db")) {
-							t->object->call("set_unit_db", db);
-						} else {
-							t->object->call("set_volume_db", db);
+						if (t->object->call("get_adjust_when_blending")) {
+							float db = Math::linear2db(MAX(blend, 0.00001));
+							if (t->object->has_method("set_unit_db")) {
+								t->object->call("set_unit_db", db);
+							} else {
+								t->object->call("set_volume_db", db);
+							}
 						}
 					} break;
 					case Animation::TYPE_ANIMATION: {

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -293,6 +293,14 @@ StringName AudioStreamPlayer::get_bus() const {
 	return "Master";
 }
 
+void AudioStreamPlayer::set_adjust_when_blending(bool p_enable) {
+	adjust_when_blending = p_enable;
+}
+
+bool AudioStreamPlayer::get_adjust_when_blending() const {
+	return adjust_when_blending;
+}
+
 void AudioStreamPlayer::set_autoplay(bool p_enable) {
 	autoplay = p_enable;
 }
@@ -362,6 +370,9 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_db", "volume_db"), &AudioStreamPlayer::set_volume_db);
 	ClassDB::bind_method(D_METHOD("get_volume_db"), &AudioStreamPlayer::get_volume_db);
 
+	ClassDB::bind_method(D_METHOD("set_adjust_when_blending", "enable"), &AudioStreamPlayer::set_adjust_when_blending);
+	ClassDB::bind_method(D_METHOD("get_adjust_when_blending"), &AudioStreamPlayer::get_adjust_when_blending);
+
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer::get_pitch_scale);
 
@@ -391,6 +402,7 @@ void AudioStreamPlayer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24"), "set_volume_db", "get_volume_db");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "adjust_when_blending"), "set_adjust_when_blending", "get_adjust_when_blending");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -60,6 +60,7 @@ private:
 	float mix_volume_db = 0.0;
 	float pitch_scale = 1.0;
 	float volume_db = 0.0;
+	bool adjust_when_blending = true;
 	bool autoplay = false;
 	bool stream_paused = false;
 	bool stream_paused_fade = false;
@@ -88,6 +89,9 @@ public:
 
 	void set_volume_db(float p_volume);
 	float get_volume_db() const;
+
+	void set_adjust_when_blending(bool p_enable);
+	bool get_adjust_when_blending() const;
 
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;


### PR DESCRIPTION
https://www.youtube.com/watch?v=0ztTcX7Z-Do

In a `BlendTree`, `AudioTrack` will change the volume of the `AudioStreamPlayer` implicitly when blending. This is useful for damping sounds like footsteps, but it can be a problem if you want to play sound effects with `NodeOneshot`, or if you are controlling the volume externally. So I added an option to the `AudioStreamPlayer` to allow or disallow the `BlendTree` to change the volume.

I've named the option _"Adjust When Blending"_ for now, but I couldn't think of a short and clear name to represent this feature, so it's possible to discuss naming it something like _"Controlled By Blending"_, _"Overrided By Animation Tree"_ or e.t.c.

Slightly related #48526

[volume_blend_test.zip](https://github.com/godotengine/godot/files/6545246/volume_blend_test.zip)

