### PR TITLE
Fix AnimatedTexture inconsistency when setting frame

### DIFF
--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -46,7 +46,7 @@
 	</methods>
 	<members>
 		<member name="current_frame" type="int" setter="set_current_frame" getter="get_current_frame">
-			Sets the currently visible frame of the texture.
+			Sets the currently visible frame of the texture. Setting this frame while playing resets the current frame time, so the newly selected frame plays for its whole configured frame duration.
 		</member>
 		<member name="frames" type="int" setter="set_frames" getter="get_frames" default="1">
 			Number of frames to use in the animation. While you can create the frames independently with [method set_frame_texture], you need to set this value for the animation to take new frames into account. The maximum number of frames is [constant MAX_FRAMES].

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2704,6 +2704,7 @@ void AnimatedTexture::set_current_frame(int p_frame) {
 	RWLockWrite r(rw_lock);
 
 	current_frame = p_frame;
+	time = 0;
 }
 
 int AnimatedTexture::get_current_frame() const {


### PR DESCRIPTION
Pull Request to fixing the bug stated in issue #49078 for unexpected behaviour when setting current frame in AnimatedTextures

Accidentally broke last pull request #49097

Fix #49078
