### PR TITLE
GDScript: Fix inner classes and preloaded scripts as types

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3248,7 +3248,9 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::CallNode *p_source
 
 		for (const MethodInfo &E : methods) {
 			if (E.name == p_function) {
-				return function_signature_from_info(E, r_return_type, r_par_types, r_default_arg_count, r_static, r_vararg);
+				function_signature_from_info(E, r_return_type, r_par_types, r_default_arg_count, r_static, r_vararg);
+				r_static = Variant::is_builtin_method_static(p_base_type.builtin_type, function_name);
+				return true;
 			}
 		}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3229,7 +3229,7 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_property(const PropertyInfo
 	return result;
 }
 
-bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, GDScriptParser::DataType p_base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg) {
+bool GDScriptAnalyzer::get_function_signature(GDScriptParser::CallNode *p_source, GDScriptParser::DataType p_base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg) {
 	r_static = false;
 	r_vararg = false;
 	r_default_arg_count = 0;
@@ -3255,7 +3255,7 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, GD
 		return false;
 	}
 
-	bool is_constructor = p_base_type.is_meta_type && p_function == "new";
+	bool is_constructor = (p_base_type.is_meta_type || (p_source->callee && p_source->callee->type == GDScriptParser::Node::IDENTIFIER)) && p_function == StaticCString::create("new");
 	if (is_constructor) {
 		function_name = "_init";
 		r_static = true;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -30,6 +30,7 @@
 
 #include "gdscript_analyzer.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
@@ -3335,7 +3336,11 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::CallNode *p_source
 
 	MethodInfo info;
 	if (ClassDB::get_method_info(base_native, function_name, &info)) {
-		return function_signature_from_info(info, r_return_type, r_par_types, r_default_arg_count, r_static, r_vararg);
+		bool valid = function_signature_from_info(info, r_return_type, r_par_types, r_default_arg_count, r_static, r_vararg);
+		if (valid && Engine::get_singleton()->has_singleton(base_native)) {
+			r_static = true;
+		}
+		return valid;
 	}
 
 	return false;

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -99,7 +99,7 @@ class GDScriptAnalyzer {
 	GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type) const;
 	GDScriptParser::DataType type_from_property(const PropertyInfo &p_property) const;
 	GDScriptParser::DataType make_global_class_meta_type(const StringName &p_class_name, const GDScriptParser::Node *p_source);
-	bool get_function_signature(GDScriptParser::Node *p_source, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);
+	bool get_function_signature(GDScriptParser::CallNode *p_source, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);
 	bool function_signature_from_info(const MethodInfo &p_info, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);
 	bool validate_call_arg(const List<GDScriptParser::DataType> &p_par_types, int p_default_args_count, bool p_is_vararg, const GDScriptParser::CallNode *p_call);
 	bool validate_call_arg(const MethodInfo &p_method, const GDScriptParser::CallNode *p_call);

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -126,8 +126,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 						names.pop_back();
 					}
 					result.kind = GDScriptDataType::GDSCRIPT;
-					result.script_type_ref = script;
-					result.script_type = result.script_type_ref.ptr();
+					result.script_type = script.ptr();
 					result.native_type = script->get_instance_base_type();
 				} else {
 					result.kind = GDScriptDataType::GDSCRIPT;

--- a/modules/gdscript/tests/scripts/analyzer/features/call_static_builtin_function.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/call_static_builtin_function.gd
@@ -1,0 +1,3 @@
+func test():
+	print(Color.html_is_valid("00ffff"))
+	print("OK")

--- a/modules/gdscript/tests/scripts/analyzer/features/call_static_builtin_function.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/call_static_builtin_function.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+True
+OK

--- a/modules/gdscript/tests/scripts/analyzer/features/gdscript_to_preload.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/gdscript_to_preload.gd
@@ -1,0 +1,5 @@
+func test():
+	pass
+
+func something():
+	return "OK"

--- a/modules/gdscript/tests/scripts/analyzer/features/gdscript_to_preload.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/gdscript_to_preload.out
@@ -1,0 +1,1 @@
+GDTEST_OK

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_class_as_return_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_class_as_return_type.gd
@@ -1,0 +1,11 @@
+class InnerClass:
+	var val := "OK"
+	static func create_instance() -> InnerClass:
+		return new()
+
+func create_inner_instance() -> InnerClass:
+	return InnerClass.create_instance()
+
+func test():
+	var instance = create_inner_instance()
+	print(instance.val)

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_class_as_return_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_class_as_return_type.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+OK

--- a/modules/gdscript/tests/scripts/analyzer/features/use_preload_script_as_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/use_preload_script_as_type.gd
@@ -1,0 +1,5 @@
+const preloaded : GDScript = preload("gdscript_to_preload.gd")
+
+func test():
+	var preloaded_instance: preloaded = preloaded.new()
+	print(preloaded_instance.something())

--- a/modules/gdscript/tests/scripts/analyzer/features/use_preload_script_as_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/use_preload_script_as_type.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+OK


### PR DESCRIPTION
Fix #47063