### PR TITLE
Fix json dump and print of circular structure

### DIFF
--- a/core/io/json.h
+++ b/core/io/json.h
@@ -62,7 +62,7 @@ class JSON {
 
 	static const char *tk_name[TK_MAX];
 
-	static String _print_var(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, bool p_full_precision = false);
+	static String _print_var(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, Set<const void *> &p_markers, bool p_full_precision = false);
 
 	static Error _get_token(const char32_t *p_str, int &index, int p_len, Token &r_token, int &line, String &r_err_str);
 	static Error _parse_value(Variant &value, Token &token, const char32_t *p_str, int &index, int p_len, int &line, String &r_err_str);

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1698,6 +1698,7 @@ String Variant::stringify(List<const void *> &stack) const {
 			}
 			str += "}";
 
+			stack.erase(d.id());
 			return str;
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
@@ -1801,6 +1802,7 @@ String Variant::stringify(List<const void *> &stack) const {
 			}
 
 			str += "]";
+			stack.erase(arr.id());
 			return str;
 
 		} break;


### PR DESCRIPTION
This fixes #48289, also applies to 3.x (`core/variant/variant.cpp` → `core/variant.cpp`).

When the parameter of `JSON.print` contains circular structure, an error will now be printed and the dictionary / array will be stringified into `"{...}"` / `"[...]"` to help debugging while keeping the output valid JSON.

```gdscript
var d = {1: 1, 2: 2, 3: 3}
d[1] = d
# {1:{...}, 2:2, 3:3}
print(d)
# ERROR: _print_var: Converting circular structure to JSON.
#    At: core/io/json.cpp:103.
# {"1":"{...}","2":2,"3":3}
print(JSON.print(d))  # 3.2 to_json(d)
```

The `print` function treated any repeated element as circular structure even if they are not nested. This is also fixed:

```gdscript
var x = ['a', 'b', 'c']
var y = [1, 2, 3]
var z = [x, y, x, y]

# before: [[a, b, c], [1, 2, 3], [...], [...]]
# after:  [[a, b, c], [1, 2, 3], [a, b, c], [1, 2, 3]]
print(z)
```