### PR TITLE
Tweak Camera2D editor line colors for better visibility

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -270,11 +270,10 @@ void Camera2D::_notification(int p_what) {
 			}
 
 			if (screen_drawing_enabled) {
-				Color area_axis_color(0.5, 0.42, 0.87, 0.63);
+				Color area_axis_color(1, 0.4, 1, 0.63);
 				real_t area_axis_width = 1;
 				if (is_current()) {
 					area_axis_width = 3;
-					area_axis_color.a = 0.83;
 				}
 
 				Transform2D inv_camera_transform = get_camera_transform().affine_inverse();
@@ -295,10 +294,9 @@ void Camera2D::_notification(int p_what) {
 			}
 
 			if (limit_drawing_enabled) {
-				Color limit_drawing_color(1, 1, 0, 0.63);
+				Color limit_drawing_color(1, 1, 0.25, 0.63);
 				real_t limit_drawing_width = 1;
 				if (is_current()) {
-					limit_drawing_color.a = 0.83;
 					limit_drawing_width = 3;
 				}
 
@@ -317,11 +315,10 @@ void Camera2D::_notification(int p_what) {
 			}
 
 			if (margin_drawing_enabled) {
-				Color margin_drawing_color(0, 1, 1, 0.63);
+				Color margin_drawing_color(0.25, 1, 1, 0.63);
 				real_t margin_drawing_width = 1;
 				if (is_current()) {
 					margin_drawing_width = 3;
-					margin_drawing_color.a = 0.83;
 				}
 
 				Transform2D inv_camera_transform = get_camera_transform().affine_inverse();


### PR DESCRIPTION
The new color for screen drawing was chosen to be easier to distinguish from the 2D viewport limits.

This also makes lines less opaque when the Camera2D has the Current property enabled. The increased line width is enough to spot the camera easily, and the increased opacity on top of that felt obnoxious.

Limit and margin lines had their saturation slightly decreased, as "pure" cyan/yellow colors generally don't look good in UI design.

## Preview

### Before

![2021-05-27_06 58 57](https://user-images.githubusercontent.com/180032/119769833-7f5e9980-bebb-11eb-88e3-001f433ab691.png)


### After

![2021-05-27_07 12 58](https://user-images.githubusercontent.com/180032/119769835-7ff73000-bebb-11eb-9cee-6e826207753c.png)


### After (all lines)

![2021-05-27_07 13 27](https://user-images.githubusercontent.com/180032/119769837-7ff73000-bebb-11eb-8ac4-d024e0a14ea8.png)


### After (all lines + Current enabled)

![2021-05-27_07 14 42](https://user-images.githubusercontent.com/180032/119769839-808fc680-bebb-11eb-9a6c-0b4c1ce38aa8.png)