### PR TITLE
Merge Tiles Editor setting category with the existing Tile Map category

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -705,8 +705,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/2d/pan_speed", 20);
 
 	// Tiles editor
-	_initial_set("editors/tiles_editor/display_grid", true);
-	_initial_set("editors/tiles_editor/grid_color", Color(1.0, 0.5, 0.2, 0.5));
+	_initial_set("editors/tile_map/display_grid", true);
+	_initial_set("editors/tile_map/grid_color", Color(1.0, 0.5, 0.2, 0.5));
 
 	// Polygon editor
 	_initial_set("editors/poly_editor/point_grab_radius", 8);

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -317,7 +317,7 @@ void TileAtlasView::_draw_base_tiles_dark() {
 
 void TileAtlasView::_draw_base_tiles_shape_grid() {
 	// Draw the shapes.
-	Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
+	Color grid_color = EditorSettings::get_singleton()->get("editors/tile_map/grid_color");
 	Vector2i tile_shape_size = tile_set->get_tile_size();
 	for (int i = 0; i < tile_set_atlas_source->get_tiles_count(); i++) {
 		Vector2i tile_id = tile_set_atlas_source->get_tile_id(i);

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -60,13 +60,13 @@ void TileMapEditorTilesPlugin::_notification(int p_what) {
 
 			missing_atlas_texture_icon = get_theme_icon("TileSet", "EditorIcons");
 
-			toggle_grid_button->set_pressed(EditorSettings::get_singleton()->get("editors/tiles_editor/display_grid"));
+			toggle_grid_button->set_pressed(EditorSettings::get_singleton()->get("editors/tile_map/display_grid"));
 			break;
 		case NOTIFICATION_VISIBILITY_CHANGED:
 			_stop_dragging();
 			break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED:
-			toggle_grid_button->set_pressed(EditorSettings::get_singleton()->get("editors/tiles_editor/display_grid"));
+			toggle_grid_button->set_pressed(EditorSettings::get_singleton()->get("editors/tile_map/display_grid"));
 			break;
 	}
 }
@@ -86,7 +86,7 @@ void TileMapEditorTilesPlugin::_on_scattering_spinbox_changed(double p_value) {
 }
 
 void TileMapEditorTilesPlugin::_on_grid_toggled(bool p_pressed) {
-	EditorSettings::get_singleton()->set("editors/tiles_editor/display_grid", p_pressed);
+	EditorSettings::get_singleton()->set("editors/tile_map/display_grid", p_pressed);
 }
 
 void TileMapEditorTilesPlugin::_update_toolbar() {
@@ -616,7 +616,7 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 		if (drag_type == DRAG_TYPE_MOVE || (drag_type == DRAG_TYPE_SELECT && !Input::get_singleton()->is_key_pressed(KEY_CTRL) && !Input::get_singleton()->is_key_pressed(KEY_SHIFT))) {
 			// Do nothing
 		} else {
-			Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
+			Color grid_color = EditorSettings::get_singleton()->get("editors/tile_map/grid_color");
 			Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
 			tile_map->draw_cells_outline(p_overlay, tile_map_selection, selection_color, xform);
 		}
@@ -717,9 +717,9 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 			const int fading = 5;
 
 			// Draw the lines of the grid behind the preview.
-			bool display_grid = EditorSettings::get_singleton()->get("editors/tiles_editor/display_grid");
+			bool display_grid = EditorSettings::get_singleton()->get("editors/tile_map/display_grid");
 			if (display_grid) {
-				Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
+				Color grid_color = EditorSettings::get_singleton()->get("editors/tile_map/grid_color");
 				if (drawn_grid_rect.size.x > 0 && drawn_grid_rect.size.y > 0) {
 					drawn_grid_rect = drawn_grid_rect.grow(fading);
 					for (int x = drawn_grid_rect.position.x; x < (drawn_grid_rect.position.x + drawn_grid_rect.size.x); x++) {
@@ -1437,7 +1437,7 @@ void TileMapEditorTilesPlugin::_tile_atlas_control_draw() {
 	}
 
 	// Draw the selection.
-	Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
+	Color grid_color = EditorSettings::get_singleton()->get("editors/tile_map/grid_color");
 	Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
 	for (Set<TileMapCell>::Element *E = tile_set_selection.front(); E; E = E->next()) {
 		if (E->get().source_id == source_id && E->get().alternative_tile == 0) {
@@ -3460,9 +3460,9 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 	}
 
 	// Draw the grid.
-	bool display_grid = EditorSettings::get_singleton()->get("editors/tiles_editor/display_grid");
+	bool display_grid = EditorSettings::get_singleton()->get("editors/tile_map/display_grid");
 	if (display_grid) {
-		Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
+		Color grid_color = EditorSettings::get_singleton()->get("editors/tile_map/grid_color");
 		for (int x = displayed_rect.position.x; x < (displayed_rect.position.x + displayed_rect.size.x); x++) {
 			for (int y = displayed_rect.position.y; y < (displayed_rect.position.y + displayed_rect.size.y); y++) {
 				Vector2i pos_in_rect = Vector2i(x, y) - displayed_rect.position;

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1179,7 +1179,7 @@ Array TileSetAtlasSourceEditor::_get_selection_as_array() {
 
 void TileSetAtlasSourceEditor::_tile_atlas_control_draw() {
 	// Colors.
-	Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
+	Color grid_color = EditorSettings::get_singleton()->get("editors/tile_map/grid_color");
 	Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
 
 	// Draw the selected tile.
@@ -1397,7 +1397,7 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_mouse_exited() {
 }
 
 void TileSetAtlasSourceEditor::_tile_alternatives_control_draw() {
-	Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
+	Color grid_color = EditorSettings::get_singleton()->get("editors/tile_map/grid_color");
 	Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);
 
 	// Update the hovered alternative tile.


### PR DESCRIPTION
The new category (added with the TileSet/TileMap rework) was redundant with the existing Tile Map (`tile_map/...`) setting category.

**Note:** Not cherry-pickable to the `3.x` branch since this is only relevant with the TileSet/TileMap rework.