### PR TITLE
Improve axis awareness and visibility for Position2D and Position3D

### DIFF
--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -1541,19 +1541,46 @@ Position3DGizmoPlugin::Position3DGizmoPlugin() {
 	cursor_points = Vector<Vector3>();
 
 	Vector<Color> cursor_colors;
-	float cs = 0.25;
+	const float cs = 0.25;
+	// Add more points to create a "hard stop" in the color gradient.
 	cursor_points.push_back(Vector3(+cs, 0, 0));
+	cursor_points.push_back(Vector3());
+	cursor_points.push_back(Vector3());
 	cursor_points.push_back(Vector3(-cs, 0, 0));
+
 	cursor_points.push_back(Vector3(0, +cs, 0));
+	cursor_points.push_back(Vector3());
+	cursor_points.push_back(Vector3());
 	cursor_points.push_back(Vector3(0, -cs, 0));
+
 	cursor_points.push_back(Vector3(0, 0, +cs));
+	cursor_points.push_back(Vector3());
+	cursor_points.push_back(Vector3());
 	cursor_points.push_back(Vector3(0, 0, -cs));
-	cursor_colors.push_back(EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_x_color", "Editor"));
-	cursor_colors.push_back(EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_x_color", "Editor"));
-	cursor_colors.push_back(EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_y_color", "Editor"));
-	cursor_colors.push_back(EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_y_color", "Editor"));
-	cursor_colors.push_back(EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_z_color", "Editor"));
-	cursor_colors.push_back(EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_z_color", "Editor"));
+
+	// Use the axis color which is brighter for the positive axis.
+	// Use a darkened axis color for the negative axis.
+	// This makes it possible to see in which direction the Position3D node is rotated
+	// (which can be important depending on how it's used).
+	const Color color_x = EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_x_color", "Editor");
+	cursor_colors.push_back(color_x);
+	cursor_colors.push_back(color_x);
+	// FIXME: Use less strong darkening factor once GH-48573 is fixed.
+	// The current darkening factor compensates for lines being too bright in the 3D editor.
+	cursor_colors.push_back(color_x.lerp(Color(0, 0, 0), 0.75));
+	cursor_colors.push_back(color_x.lerp(Color(0, 0, 0), 0.75));
+
+	const Color color_y = EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_y_color", "Editor");
+	cursor_colors.push_back(color_y);
+	cursor_colors.push_back(color_y);
+	cursor_colors.push_back(color_y.lerp(Color(0, 0, 0), 0.75));
+	cursor_colors.push_back(color_y.lerp(Color(0, 0, 0), 0.75));
+
+	const Color color_z = EditorNode::get_singleton()->get_gui_base()->get_theme_color("axis_z_color", "Editor");
+	cursor_colors.push_back(color_z);
+	cursor_colors.push_back(color_z);
+	cursor_colors.push_back(color_z.lerp(Color(0, 0, 0), 0.75));
+	cursor_colors.push_back(color_z.lerp(Color(0, 0, 0), 0.75));
 
 	Ref<StandardMaterial3D> mat = memnew(StandardMaterial3D);
 	mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -36,10 +36,41 @@
 const real_t DEFAULT_GIZMO_EXTENTS = 10.0;
 
 void Position2D::_draw_cross() {
-	real_t extents = get_gizmo_extents();
-	// Colors taken from `axis_x_color` and `axis_y_color` (defined in `editor/editor_themes.cpp`)
-	draw_line(Point2(-extents, 0), Point2(+extents, 0), Color(0.96, 0.20, 0.32));
-	draw_line(Point2(0, -extents), Point2(0, +extents), Color(0.53, 0.84, 0.01));
+	const real_t extents = get_gizmo_extents();
+
+	// Add more points to create a "hard stop" in the color gradient.
+	PackedVector2Array points_x;
+	points_x.push_back(Point2(+extents, 0));
+	points_x.push_back(Point2());
+	points_x.push_back(Point2());
+	points_x.push_back(Point2(-extents, 0));
+
+	PackedVector2Array points_y;
+	points_y.push_back(Point2(0, +extents));
+	points_y.push_back(Point2());
+	points_y.push_back(Point2());
+	points_y.push_back(Point2(0, -extents));
+
+	// Use the axis color which is brighter for the positive axis.
+	// Use a darkened axis color for the negative axis.
+	// This makes it possible to see in which direction the Position3D node is rotated
+	// (which can be important depending on how it's used).
+	// Axis colors are taken from `axis_x_color` and `axis_y_color` (defined in `editor/editor_themes.cpp`).
+	PackedColorArray colors_x;
+	const Color color_x = Color(0.96, 0.20, 0.32);
+	colors_x.push_back(color_x);
+	colors_x.push_back(color_x);
+	colors_x.push_back(color_x.lerp(Color(0, 0, 0), 0.5));
+	colors_x.push_back(color_x.lerp(Color(0, 0, 0), 0.5));
+	draw_multiline_colors(points_x, colors_x);
+
+	PackedColorArray colors_y;
+	const Color color_y = Color(0.53, 0.84, 0.01);
+	colors_y.push_back(color_y);
+	colors_y.push_back(color_y);
+	colors_y.push_back(color_y.lerp(Color(0, 0, 0), 0.5));
+	colors_y.push_back(color_y.lerp(Color(0, 0, 0), 0.5));
+	draw_multiline_colors(points_y, colors_y);
 }
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Previously, it was impossible to see which axis a Position node pointed towards. However, this can be important information depending on how the Position node is used in game logic.

## Preview

### 2D

| Before | After |
|--------|-------|
| ![2021-05-27_08 24 28](https://user-images.githubusercontent.com/180032/119776903-cea9c780-bec5-11eb-862d-02fce53caddc.png) | ![image](https://user-images.githubusercontent.com/180032/119894202-97c2c880-bf3c-11eb-9ee5-7c033cc1a6a3.png) |

### 3D

| Before | After |
|--------|-------|
| ![2021-05-27_08 22 03](https://user-images.githubusercontent.com/180032/119776875-c3ef3280-bec5-11eb-8516-0738cf50982b.png) | ![image](https://user-images.githubusercontent.com/180032/120014064-e1192380-bfe1-11eb-959f-fb3bd10b0643.png) |

<details>
<summary>Old version with smooth gradient</summary>

### 2D

| Before | After |
|--------|-------|
| ![2021-05-27_08 24 28](https://user-images.githubusercontent.com/180032/119776903-cea9c780-bec5-11eb-862d-02fce53caddc.png) | ![2021-05-27_08 28 47](https://user-images.githubusercontent.com/180032/119776904-cf425e00-bec5-11eb-8afb-5b71e4b73fe8.png) |

### 3D

| Before | After |
|--------|-------|
| ![2021-05-27_08 22 03](https://user-images.githubusercontent.com/180032/119776875-c3ef3280-bec5-11eb-8516-0738cf50982b.png) | ![2021-05-27_08 22 37](https://user-images.githubusercontent.com/180032/119776887-c782b980-bec5-11eb-8b51-89f79bfb7cfa.png) |

As a bonus, mixed-background visibility is improved:

![2021-05-27_08 23 17](https://user-images.githubusercontent.com/180032/119776969-e41ef180-bec5-11eb-8f3b-3d42b121bba0.png)
</details>