### PR TITLE
Rename the bundled text editor themes for consistency with themes

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -503,12 +503,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* Text editor */
 
 	// Theme
-	_initial_set("text_editor/theme/color_theme", "Adaptive");
-	hints["text_editor/theme/color_theme"] = PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, "Adaptive,Default,Custom");
+	_initial_set("text_editor/theme/color_theme", "Default");
+	hints["text_editor/theme/color_theme"] = PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, "Default,Godot 2,Custom");
 	_initial_set("text_editor/theme/line_spacing", 6);
 	hints["text_editor/theme/line_spacing"] = PropertyInfo(Variant::INT, "text_editor/theme/line_spacing", PROPERTY_HINT_RANGE, "0,50,1");
 
-	_load_default_text_editor_theme();
+	_load_godot2_text_editor_theme();
 
 	// Highlighting
 	_initial_set("text_editor/highlighting/highlight_all_occurrences", true);
@@ -786,9 +786,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	};
 }
 
-void EditorSettings::_load_default_text_editor_theme() {
-	bool dark_theme = is_dark_theme();
-
+void EditorSettings::_load_godot2_text_editor_theme() {
+	// Godot 2 is only a dark theme; it doesn't have a light theme counterpart.
 	_initial_set("text_editor/highlighting/symbol_color", Color(0.73, 0.87, 1.0));
 	_initial_set("text_editor/highlighting/keyword_color", Color(1.0, 1.0, 0.7));
 	_initial_set("text_editor/highlighting/control_flow_keyword_color", Color(1.0, 0.85, 0.7));
@@ -797,7 +796,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 	_initial_set("text_editor/highlighting/user_type_color", Color(0.42, 0.67, 0.93));
 	_initial_set("text_editor/highlighting/comment_color", Color(0.4, 0.4, 0.4));
 	_initial_set("text_editor/highlighting/string_color", Color(0.94, 0.43, 0.75));
-	_initial_set("text_editor/highlighting/background_color", dark_theme ? Color(0.0, 0.0, 0.0, 0.23) : Color(0.2, 0.23, 0.31));
+	_initial_set("text_editor/highlighting/background_color", Color(0.13, 0.12, 0.15));
 	_initial_set("text_editor/highlighting/completion_background_color", Color(0.17, 0.16, 0.2));
 	_initial_set("text_editor/highlighting/completion_selected_color", Color(0.26, 0.26, 0.27));
 	_initial_set("text_editor/highlighting/completion_existing_color", Color(0.13, 0.87, 0.87, 0.87));
@@ -847,7 +846,7 @@ bool EditorSettings::_save_text_editor_theme(String p_file) {
 }
 
 bool EditorSettings::_is_default_text_editor_theme(String p_theme_name) {
-	return p_theme_name == "default" || p_theme_name == "adaptive" || p_theme_name == "custom";
+	return p_theme_name == "default" || p_theme_name == "godot 2" || p_theme_name == "custom";
 }
 
 static Dictionary _get_builtin_script_templates() {
@@ -1436,7 +1435,7 @@ bool EditorSettings::is_dark_theme() {
 }
 
 void EditorSettings::list_text_editor_themes() {
-	String themes = "Adaptive,Default,Custom";
+	String themes = "Default,Godot 2,Custom";
 
 	DirAccess *d = DirAccess::open(get_text_editor_themes_dir());
 	if (d) {
@@ -1464,8 +1463,8 @@ void EditorSettings::load_text_editor_theme() {
 	String p_file = get("text_editor/theme/color_theme");
 
 	if (_is_default_text_editor_theme(p_file.get_file().to_lower())) {
-		if (p_file == "Default") {
-			_load_default_text_editor_theme();
+		if (p_file == "Godot 2") {
+			_load_godot2_text_editor_theme();
 		}
 		return; // sorry for "Settings changed" console spam
 	}

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -108,7 +108,7 @@ private:
 	void _add_property_info_bind(const Dictionary &p_info);
 
 	void _load_defaults(Ref<ConfigFile> p_extra_config = Ref<ConfigFile>());
-	void _load_default_text_editor_theme();
+	void _load_godot2_text_editor_theme();
 	bool _save_text_editor_theme(String p_file);
 	bool _is_default_text_editor_theme(String p_theme_name);
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1384,7 +1384,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	EditorSettings *setting = EditorSettings::get_singleton();
 	String text_editor_color_theme = setting->get("text_editor/theme/color_theme");
-	if (text_editor_color_theme == "Adaptive") {
+	if (text_editor_color_theme == "Default") {
 		setting->set_initial_value("text_editor/highlighting/symbol_color", symbol_color, true);
 		setting->set_initial_value("text_editor/highlighting/keyword_color", keyword_color, true);
 		setting->set_initial_value("text_editor/highlighting/control_flow_keyword_color", control_flow_keyword_color, true);
@@ -1420,7 +1420,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		setting->set_initial_value("text_editor/highlighting/code_folding_color", code_folding_color, true);
 		setting->set_initial_value("text_editor/highlighting/search_result_color", search_result_color, true);
 		setting->set_initial_value("text_editor/highlighting/search_result_border_color", search_result_border_color, true);
-	} else if (text_editor_color_theme == "Default") {
+	} else if (text_editor_color_theme == "Godot 2") {
 		setting->load_text_editor_theme();
 	}
 

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -546,7 +546,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	}
 
 	const String text_edit_color_theme = EditorSettings::get_singleton()->get("text_editor/theme/color_theme");
-	const bool default_theme = text_edit_color_theme == "Default";
+	const bool default_theme = text_edit_color_theme == "Godot 2";
 
 	if (default_theme || EditorSettings::get_singleton()->is_dark_theme()) {
 		function_definition_color = Color(0.4, 0.9, 1.0);
@@ -558,7 +558,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 
 	EDITOR_DEF("text_editor/highlighting/gdscript/function_definition_color", function_definition_color);
 	EDITOR_DEF("text_editor/highlighting/gdscript/node_path_color", node_path_color);
-	if (text_edit_color_theme == "Adaptive" || default_theme) {
+	if (text_edit_color_theme == "Default" || default_theme) {
 		EditorSettings::get_singleton()->set_initial_value(
 				"text_editor/highlighting/gdscript/function_definition_color",
 				function_definition_color,


### PR DESCRIPTION
The Adaptive text editor theme is the default, and has therefore been renamed Default for consistency with the Default theme preset. It keeps its automatic dark/light switch status.

The Default text editor theme was actually a legacy Godot 2-style theme, so it has been renamed to Godot 2 to match the theme preset. Its background color has been changed to be a constant opaque color, since the new editor theme made the theme look less good on a translucent background. The previous background color on light theme also lacked contrast.

This breaks compatibility in a minor way since people using the "Default" (now "Godot 2") theme preset may see their theme switch automatically back to the "Adaptive" (now "Default") theme preset. This could technically be cherry-picked to the `3.x` branch, but I don't think it's worth the risk.

## Preview

*New background color for the Godot 2 text editor theme. Pictured below with the Godot 2 editor theme preset.*

![image](https://user-images.githubusercontent.com/180032/119792723-37993b80-bed6-11eb-8741-e28d12f363af.png)