### PR TITLE
Fixed possible crash in `DynamicBVH::optimize_incremental`

### DIFF
--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -312,8 +312,11 @@ void DynamicBVH::optimize_incremental(int passes) {
 	if (passes < 0) {
 		passes = total_leaves;
 	}
-	if (bvh_root && (passes > 0)) {
+	if (passes > 0) {
 		do {
+			if (!bvh_root) {
+				break;
+			}
 			Node *node = bvh_root;
 			unsigned bit = 0;
 			while (node->is_internal()) {


### PR DESCRIPTION
I found this crash while experimenting with rendering.
bvh_root may change in update function and set to null which causes a crash by calling on the null pointer(on the next iteration).