### PR TITLE
Fixed changing enabled classes resetting folding in editor features.

### DIFF
--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -60,6 +60,8 @@ private:
 	Set<StringName> disabled_editors;
 	Map<StringName, Set<StringName>> disabled_properties;
 
+	Set<StringName> collapsed_classes;
+
 	bool features_disabled[FEATURE_MAX];
 	static const char *feature_names[FEATURE_MAX];
 	static const char *feature_identifiers[FEATURE_MAX];
@@ -79,6 +81,9 @@ public:
 	void set_disable_class_property(const StringName &p_class, const StringName &p_property, bool p_disabled);
 	bool is_class_property_disabled(const StringName &p_class, const StringName &p_property) const;
 	bool has_class_properties_disabled(const StringName &p_class) const;
+
+	void set_item_collapsed(const StringName &p_class, bool p_collapsed);
+	bool is_item_collapsed(const StringName &p_class) const;
 
 	void set_disable_feature(Feature p_feature, bool p_disable);
 	bool is_feature_disabled(Feature p_feature) const;
@@ -151,6 +156,7 @@ class EditorFeatureProfileManager : public AcceptDialog {
 
 	void _class_list_item_selected();
 	void _class_list_item_edited();
+	void _class_list_item_collapsed(Object *p_item);
 	void _property_item_edited();
 	void _save_and_update();
 


### PR DESCRIPTION
Fixes #49040
When using the Manage Editor Features dialog, enabling/disabling a class would reset the folding structure to the initial state.

I fixed it by connecting to the Tree's "item_collapsed" from EditorFeatureProfileManager and using it to store the collapsed items classnames. Then, during the rebuilding of the tree I use that information to make sure the treeItem is correctly collapsed.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
