### PR TITLE
Emit button_up signal after setting pressed to false.

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -175,10 +175,9 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 				status.hovering = false;
 			}
 		}
-		// pressed state should be correct with button_up signal
-		emit_signal("button_up");
 		status.press_attempt = false;
 		status.pressing_inside = false;
+		emit_signal("button_up");
 	}
 
 	update();


### PR DESCRIPTION
Hey there, I noticed that `button.pressed` is still true when the `button_up` signal is emitted. This means that for listeners of `button_up`, they must wait a frame to understand the true state of the button, or they must propagate some state to represent that "this is a button up event" to ignore button.pressed.

I think this is a mistake in the API. State should be made consistent before signals are emitted such that listeners have a valid scene tree.

A work around for this is to yield a single frame in `button_up` listeners such that the value of pressed is false as you would expect.

I've created pull requests for both master and 3.x to emit the `button_up` signal after the state is fully applied. I think this is more correct, more robust behaviour as it allows listeners to check button.pressed and actually have the correct state.

Here is some example code:
```
extends Button

func _ready():
	self.connect("button_down", self.refresh_button)
	self.connect("button_up", self.refresh_button)
	refresh_button()

func refresh_button():
	self.text = "pressed is: " + str(self.pressed)
```

Before this PR, button.pressed will never be `false` inside of `button_up` nor `button_down`. This is clearly a flaw in the API.

https://user-images.githubusercontent.com/78934401/119916935-b6b46100-bf22-11eb-8346-9bf61721256c.mp4

After this PR, `button.pressed` is `false` in `button_up`, as you would expect.

https://user-images.githubusercontent.com/78934401/119916950-c0d65f80-bf22-11eb-9848-81a4902aef7f.mp4

