### PR TITLE
Added Billboard Node to Visual Shaders

### DIFF
--- a/doc/classes/VisualShaderNodeBillboard.xml
+++ b/doc/classes/VisualShaderNodeBillboard.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisualShaderNodeBillboard" inherits="VisualShaderNode" version="4.0">
+	<brief_description>
+		A node that controls how the object faces the camera to be used within the visual shader graph.
+	</brief_description>
+	<description>
+		The output port of this node needs to be connected to [code]Model View Matrix[/code] port of [VisualShaderNodeOutput].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="billboard_type" type="int" setter="set_billboard_type" getter="get_billboard_type" enum="VisualShaderNodeBillboard.BillboardType" default="1">
+			Controls how the object faces the camera. See [enum BillboardType].
+		</member>
+		<member name="keep_scale" type="bool" setter="set_keep_scale_enabled" getter="is_keep_scale_enabled" default="false">
+			If [code]true[/code], the shader will keep the scale set for the mesh. Otherwise, the scale is lost when billboarding.
+		</member>
+	</members>
+	<constants>
+		<constant name="BILLBOARD_TYPE_DISABLED" value="0" enum="BillboardType">
+			Billboarding is disabled and the node does nothing.
+		</constant>
+		<constant name="BILLBOARD_TYPE_ENABLED" value="1" enum="BillboardType">
+			A standard billboarding algorithm is enabled.
+		</constant>
+		<constant name="BILLBOARD_TYPE_FIXED_Y" value="2" enum="BillboardType">
+			A billboarding algorithm to rotate around Y-axis is enabled.
+		</constant>
+		<constant name="BILLBOARD_TYPE_PARTICLES" value="3" enum="BillboardType">
+			A billboarding algorithm designed to use on particles is enabled.
+		</constant>
+		<constant name="BILLBOARD_TYPE_MAX" value="4" enum="BillboardType">
+			Represents the size of the [enum BillboardType] enum.
+		</constant>
+	</constants>
+</class>

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4260,6 +4260,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	add_options.push_back(AddOption("TransformDecompose", "Transform", "Composition", "VisualShaderNodeTransformDecompose", TTR("Decomposes transform to four vectors.")));
 
 	add_options.push_back(AddOption("Determinant", "Transform", "Functions", "VisualShaderNodeDeterminant", TTR("Calculates the determinant of a transform."), -1, VisualShaderNode::PORT_TYPE_SCALAR));
+	add_options.push_back(AddOption("GetBillboardMatrix", "Transform", "Functions", "VisualShaderNodeBillboard", TTR("Calculates how the object should face the camera to be applied on Model View Matrix output port for 3D objects."), -1, VisualShaderNode::PORT_TYPE_TRANSFORM, TYPE_FLAGS_VERTEX, Shader::MODE_SPATIAL));
 	add_options.push_back(AddOption("Inverse", "Transform", "Functions", "VisualShaderNodeTransformFunc", TTR("Calculates the inverse of a transform."), VisualShaderNodeTransformFunc::FUNC_INVERSE, VisualShaderNode::PORT_TYPE_TRANSFORM));
 	add_options.push_back(AddOption("Transpose", "Transform", "Functions", "VisualShaderNodeTransformFunc", TTR("Calculates the transpose of a transform."), VisualShaderNodeTransformFunc::FUNC_TRANSPOSE, VisualShaderNode::PORT_TYPE_TRANSFORM));
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -597,6 +597,7 @@ void register_scene_types() {
 	ClassDB::register_class<VisualShaderNodeIs>();
 	ClassDB::register_class<VisualShaderNodeCompare>();
 	ClassDB::register_class<VisualShaderNodeMultiplyAdd>();
+	ClassDB::register_class<VisualShaderNodeBillboard>();
 
 	ClassDB::register_class<VisualShaderNodeSDFToScreenUV>();
 	ClassDB::register_class<VisualShaderNodeScreenUVToSDF>();

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -203,6 +203,8 @@ class VisualShaderNode : public Resource {
 
 protected:
 	bool simple_decl = true;
+	bool disabled = false;
+
 	static void _bind_methods();
 
 public:
@@ -256,6 +258,9 @@ public:
 	virtual bool is_code_generated() const;
 	virtual bool is_show_prop_names() const;
 	virtual bool is_use_prop_slots() const;
+
+	bool is_disabled() const;
+	void set_disabled(bool p_disabled = true);
 
 	virtual Vector<StringName> get_editable_properties() const;
 

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -2217,4 +2217,51 @@ public:
 
 VARIANT_ENUM_CAST(VisualShaderNodeMultiplyAdd::OpType)
 
+class VisualShaderNodeBillboard : public VisualShaderNode {
+	GDCLASS(VisualShaderNodeBillboard, VisualShaderNode);
+
+public:
+	enum BillboardType {
+		BILLBOARD_TYPE_DISABLED,
+		BILLBOARD_TYPE_ENABLED,
+		BILLBOARD_TYPE_FIXED_Y,
+		BILLBOARD_TYPE_PARTICLES,
+		BILLBOARD_TYPE_MAX,
+	};
+
+protected:
+	BillboardType billboard_type = BILLBOARD_TYPE_ENABLED;
+	bool keep_scale = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual String get_caption() const override;
+
+	virtual int get_input_port_count() const override;
+	virtual PortType get_input_port_type(int p_port) const override;
+	virtual String get_input_port_name(int p_port) const override;
+
+	virtual int get_output_port_count() const override;
+	virtual PortType get_output_port_type(int p_port) const override;
+	virtual String get_output_port_name(int p_port) const override;
+
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
+
+	virtual bool is_show_prop_names() const override;
+
+	void set_billboard_type(BillboardType p_billboard_type);
+	BillboardType get_billboard_type() const;
+
+	void set_keep_scale_enabled(bool p_enabled);
+	bool is_keep_scale_enabled() const;
+
+	virtual Vector<StringName> get_editable_properties() const override;
+
+	VisualShaderNodeBillboard();
+};
+
+VARIANT_ENUM_CAST(VisualShaderNodeBillboard::BillboardType)
+
 #endif // VISUAL_SHADER_NODES_H


### PR DESCRIPTION
Users requested me to do that...

![vs_billboard](https://user-images.githubusercontent.com/3036176/119936329-a9828b00-bf91-11eb-8746-fd818c0258e6.gif)

This will add a `VisualShaderNodeBillboard` node which returns transform and a new ModelViewMatrix port for output (of Node3D/Vertex) where this new node can be connected.

