### PR TITLE
Calculate the mouse focus inverse transform only when needed

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1739,7 +1739,7 @@ Control *Viewport::_gui_find_control(const Point2 &p_global) {
 			xform = sw->get_canvas_transform();
 		}
 
-		Control *ret = _gui_find_control_at_pos(sw, p_global, xform, gui.focus_inv_xform);
+		Control *ret = _gui_find_control_at_pos(sw, p_global, xform);
 		if (ret) {
 			return ret;
 		}
@@ -1748,7 +1748,7 @@ Control *Viewport::_gui_find_control(const Point2 &p_global) {
 	return nullptr;
 }
 
-Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform, Transform2D &r_inv_xform) {
+Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform) {
 	if (Object::cast_to<Viewport>(p_node)) {
 		return nullptr;
 	}
@@ -1773,7 +1773,7 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 				continue;
 			}
 
-			Control *ret = _gui_find_control_at_pos(ci, p_global, matrix, r_inv_xform);
+			Control *ret = _gui_find_control_at_pos(ci, p_global, matrix);
 			if (ret) {
 				return ret;
 			}
@@ -1791,7 +1791,6 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 
 	Control *drag_preview = _gui_get_drag_preview();
 	if (!drag_preview || (c != drag_preview && !drag_preview->is_a_parent_of(c))) {
-		r_inv_xform = matrix;
 		return c;
 	}
 
@@ -1842,7 +1841,6 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		Point2 mpos = mb->get_position();
 		gui.last_mouse_pos = mpos;
 		if (mb->is_pressed()) {
-			Size2 pos = mpos;
 			if (gui.mouse_focus_mask) {
 				//do not steal mouse focus and stuff while a focus mask exists
 				gui.mouse_focus_mask |= 1 << (mb->get_button_index() - 1); //add the button to the mask
@@ -1861,7 +1859,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					parent_xform=data.parent_canvas_item->get_global_transform();
 				*/
 
-				gui.mouse_focus = _gui_find_control(pos);
+				gui.mouse_focus = _gui_find_control(mpos);
 				gui.last_mouse_focus = gui.mouse_focus;
 
 				if (!gui.mouse_focus) {
@@ -1878,11 +1876,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 
 			mb = mb->xformed_by(Transform2D()); // make a copy of the event
-
-			mb->set_global_position(pos);
-
-			pos = gui.focus_inv_xform.xform(pos);
-
+			Point2 pos = gui.mouse_focus->get_global_transform_with_canvas().affine_inverse().xform(mpos);
 			mb->set_position(pos);
 
 #ifdef DEBUG_ENABLED
@@ -1970,11 +1964,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				return;
 			}
 
-			Size2 pos = mpos;
-
 			mb = mb->xformed_by(Transform2D()); //make a copy
-			mb->set_global_position(pos);
-			pos = gui.focus_inv_xform.xform(pos);
+			Point2 pos = gui.mouse_focus->get_global_transform_with_canvas().affine_inverse().xform(mpos);
 			mb->set_position(pos);
 
 			Control *mouse_focus = gui.mouse_focus;
@@ -2298,17 +2289,13 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 	Ref<InputEventScreenTouch> touch_event = p_event;
 	if (touch_event.is_valid()) {
-		Size2 pos = touch_event->get_position();
+		Point2 pos = touch_event->get_position();
 		if (touch_event->is_pressed()) {
 			Control *over = _gui_find_control(pos);
 			if (over) {
 				if (over->can_process()) {
 					touch_event = touch_event->xformed_by(Transform2D()); //make a copy
-					if (over == gui.mouse_focus) {
-						pos = gui.focus_inv_xform.xform(pos);
-					} else {
-						pos = over->get_global_transform_with_canvas().affine_inverse().xform(pos);
-					}
+					pos = over->get_global_transform_with_canvas().affine_inverse().xform(pos);
 					touch_event->set_position(pos);
 					_gui_call_input(over, touch_event);
 				}
@@ -2318,8 +2305,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		} else if (touch_event->get_index() == 0 && gui.last_mouse_focus) {
 			if (gui.last_mouse_focus->can_process()) {
 				touch_event = touch_event->xformed_by(Transform2D()); //make a copy
-				touch_event->set_position(gui.focus_inv_xform.xform(pos));
-
+				pos = gui.last_mouse_focus->get_global_transform_with_canvas().affine_inverse().xform(pos);
+				touch_event->set_position(pos);
 				_gui_call_input(gui.last_mouse_focus, touch_event);
 			}
 			set_input_as_handled();
@@ -2339,11 +2326,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (over) {
 			if (over->can_process()) {
 				gesture_event = gesture_event->xformed_by(Transform2D()); //make a copy
-				if (over == gui.mouse_focus) {
-					pos = gui.focus_inv_xform.xform(pos);
-				} else {
-					pos = over->get_global_transform_with_canvas().affine_inverse().xform(pos);
-				}
+				pos = over->get_global_transform_with_canvas().affine_inverse().xform(pos);
 				gesture_event->set_position(pos);
 				_gui_call_input(over, gesture_event);
 			}
@@ -2691,7 +2674,6 @@ void Viewport::_post_gui_grab_click_focus() {
 		}
 
 		gui.mouse_focus = focus_grabber;
-		gui.focus_inv_xform = gui.mouse_focus->get_global_transform_with_canvas().affine_inverse();
 		click = gui.mouse_focus->get_global_transform_with_canvas().affine_inverse().xform(gui.last_mouse_pos);
 
 		for (int i = 0; i < 3; i++) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -363,7 +363,6 @@ private:
 		ObjectID drag_preview_id;
 		float tooltip_timer = -1.0;
 		float tooltip_delay = 0.0;
-		Transform2D focus_inv_xform;
 		bool roots_order_dirty = false;
 		List<Control *> roots;
 		int canvas_sort_index = 0; //for sorting items with canvas as root
@@ -393,7 +392,7 @@ private:
 
 	void _gui_sort_roots();
 	Control *_gui_find_control(const Point2 &p_global);
-	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform, Transform2D &r_inv_xform);
+	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform);
 
 	void _gui_input_event(Ref<InputEvent> p_event);
 


### PR DESCRIPTION
Currently, `gui.focus_inv_xform` is used to determine the location of an event within a `Control`. `Viewport::_gui_find_control()` has the side-effect of updating `gui.focus_inv_xform`. This would be fine if `_gui_find_control()` was just used to assign `gui.mouse_focus`, but it's not. The result is, when a mouse button release event happens, sometimes `gui.focus_inv_xform` does not provide the location of the event inside the `Control` where the mouse button press event happened.

Instead of calculating the `mouse_focus`'s `Control`'s inverse transform every time `_gui_find_control()` is called and storing the result for later use, this PR calculates the required inverse transform only when it is needed. This will not only prevent the wrong inverse transform sometimes being used, but should result in better performance too.

Fixes #41585.
