### PR TITLE
Fix canvas rect bound calculation

### DIFF
--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1043,7 +1043,6 @@ public:
 
 				if (found_xform) {
 					r = xf.xform(r);
-					found_xform = false;
 				}
 
 				if (first) {


### PR DESCRIPTION
It turns out the calculation of the bounding rect for canvas items has a nasty bug. When a transform is applied (especially in a custom draw), in the renderer this extra matrix is applied to all later commands in the canvas item. However in the calculation of the bound, the transform is only applied to the first command following the transform.

This PR fixes this inconsistency.

Fixes #49156

## Notes
* Amazingly, this bug has existed since at least 3.1, possibly a lot further back. It may not have been noticed as people use custom drawing a lot less than the default canvas types.
* Have tested on a few projects, seems to work fine. More testing welcome though.
* It may be needed in Godot 4.x also.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
