### PR TITLE
[4.x] Fix canvas rect bound calculation

### DIFF
--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -420,7 +420,6 @@ public:
 
 				if (found_xform) {
 					r = xf.xform(r);
-					found_xform = false;
 				}
 
 				if (first) {


### PR DESCRIPTION
It turns out the calculation of the bounding rect for canvas items has a nasty bug. When a transform is applied (especially in a custom draw), in the renderer this extra matrix is applied to all later commands in the canvas item. However in the calculation of the bound, the transform is only applied to the first command following the transform.

This PR fixes this inconsistency.

Version of #49160 for Godot 4.x.

## Notes
* This could do with testing in Godot 4, but it should work the same as in 3.x, providing the vulkan renderer has not changed the behaviour of transform commands.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
