### PR TITLE
Ensure RigidBodies only interact with Bodies with layers in their mask

### DIFF
--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -398,12 +398,12 @@ bool BodyPair2DSW::pre_solve(real_t p_step) {
 		c.rA = global_A;
 		c.rB = global_B - offset_B;
 
-		if (A->can_report_contacts()) {
+		if (A->can_report_contacts() && B->mask_has_layer(A)) {
 			Vector2 crB(-B->get_angular_velocity() * c.rB.y, B->get_angular_velocity() * c.rB.x);
 			A->add_contact(global_A + offset_A, -c.normal, depth, shape_A, global_B + offset_A, shape_B, B->get_instance_id(), B->get_self(), crB + B->get_linear_velocity());
 		}
 
-		if (B->can_report_contacts()) {
+		if (B->can_report_contacts() && A->mask_has_layer(B)) {
 			Vector2 crA(-A->get_angular_velocity() * c.rA.y, A->get_angular_velocity() * c.rA.x);
 			B->add_contact(global_B + offset_A, c.normal, depth, shape_B, global_A + offset_A, shape_A, A->get_instance_id(), A->get_self(), crA + A->get_linear_velocity());
 		}
@@ -436,10 +436,10 @@ bool BodyPair2DSW::pre_solve(real_t p_step) {
 			// Apply normal + friction impulse
 			Vector2 P = c.acc_normal_impulse * c.normal + c.acc_tangent_impulse * tangent;
 
-			if (dynamic_A) {
+			if (dynamic_A && A->mask_has_layer(B)) {
 				A->apply_impulse(-P, c.rA);
 			}
-			if (dynamic_B) {
+			if (dynamic_B && B->mask_has_layer(A)) {
 				B->apply_impulse(P, c.rB);
 			}
 		}
@@ -493,10 +493,10 @@ void BodyPair2DSW::solve(real_t p_step) {
 
 		Vector2 jb = c.normal * (c.acc_bias_impulse - jbnOld);
 
-		if (dynamic_A) {
+		if (dynamic_A && A->mask_has_layer(B)) {
 			A->apply_bias_impulse(-jb, c.rA);
 		}
-		if (dynamic_B) {
+		if (dynamic_B && B->mask_has_layer(A)) {
 			B->apply_bias_impulse(jb, c.rB);
 		}
 
@@ -513,10 +513,10 @@ void BodyPair2DSW::solve(real_t p_step) {
 
 		Vector2 j = c.normal * (c.acc_normal_impulse - jnOld) + tangent * (c.acc_tangent_impulse - jtOld);
 
-		if (dynamic_A) {
+		if (dynamic_A && A->mask_has_layer(B)) {
 			A->apply_impulse(-j, c.rA);
 		}
-		if (dynamic_B) {
+		if (dynamic_B && B->mask_has_layer(A)) {
 			B->apply_impulse(j, c.rB);
 		}
 	}

--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -186,8 +186,8 @@ public:
 	void set_pickable(bool p_pickable) { pickable = p_pickable; }
 	_FORCE_INLINE_ bool is_pickable() const { return pickable; }
 
-	_FORCE_INLINE_ bool layer_in_mask(CollisionObject2DSW *p_other) const {
-		return collision_layer & p_other->collision_mask;
+	_FORCE_INLINE_ bool mask_has_layer(CollisionObject2DSW *p_other) const {
+		return collision_mask & p_other->collision_layer;
 	}
 
 	_FORCE_INLINE_ bool interacts_with(CollisionObject2DSW *p_other) const {

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -508,7 +508,7 @@ int Space2DSW::_cull_aabb_for_body(Body2DSW *p_body, const Rect2 &p_aabb) {
 			keep = false;
 		} else if (intersection_query_results[i]->get_type() == CollisionObject2DSW::TYPE_AREA) {
 			keep = false;
-		} else if (!p_body->layer_in_mask(static_cast<Body2DSW *>(intersection_query_results[i]))) {
+		} else if (!p_body->mask_has_layer(static_cast<Body2DSW *>(intersection_query_results[i]))) {
 			keep = false;
 		} else if (static_cast<Body2DSW *>(intersection_query_results[i])->has_exception(p_body->get_self()) || p_body->has_exception(intersection_query_results[i]->get_self())) {
 			keep = false;

--- a/servers/physics_3d/body_pair_3d_sw.cpp
+++ b/servers/physics_3d/body_pair_3d_sw.cpp
@@ -320,12 +320,12 @@ bool BodyPair3DSW::pre_solve(real_t p_step) {
 
 		// contact query reporting...
 
-		if (A->can_report_contacts()) {
+		if (A->can_report_contacts() && B->mask_has_layer(A)) {
 			Vector3 crA = A->get_angular_velocity().cross(c.rA) + A->get_linear_velocity();
 			A->add_contact(global_A, -c.normal, depth, shape_A, global_B, shape_B, B->get_instance_id(), B->get_self(), crA);
 		}
 
-		if (B->can_report_contacts()) {
+		if (B->can_report_contacts() && A->mask_has_layer(B)) {
 			Vector3 crB = B->get_angular_velocity().cross(c.rB) + B->get_linear_velocity();
 			B->add_contact(global_B, c.normal, depth, shape_B, global_A, shape_A, A->get_instance_id(), A->get_self(), crB);
 		}
@@ -349,10 +349,10 @@ bool BodyPair3DSW::pre_solve(real_t p_step) {
 		c.depth = depth;
 
 		Vector3 j_vec = c.normal * c.acc_normal_impulse + c.acc_tangent_impulse;
-		if (dynamic_A) {
+		if (dynamic_A && A->mask_has_layer(B)) {
 			A->apply_impulse(-j_vec, c.rA + A->get_center_of_mass());
 		}
-		if (dynamic_B) {
+		if (dynamic_B && B->mask_has_layer(A)) {
 			B->apply_impulse(j_vec, c.rB + B->get_center_of_mass());
 		}
 		c.acc_bias_impulse = 0;
@@ -401,10 +401,10 @@ void BodyPair3DSW::solve(real_t p_step) {
 
 			Vector3 jb = c.normal * (c.acc_bias_impulse - jbnOld);
 
-			if (dynamic_A) {
+			if (dynamic_A && A->mask_has_layer(B)) {
 				A->apply_bias_impulse(-jb, c.rA + A->get_center_of_mass(), max_bias_av);
 			}
-			if (dynamic_B) {
+			if (dynamic_B && B->mask_has_layer(A)) {
 				B->apply_bias_impulse(jb, c.rB + B->get_center_of_mass(), max_bias_av);
 			}
 
@@ -421,10 +421,10 @@ void BodyPair3DSW::solve(real_t p_step) {
 
 				Vector3 jb_com = c.normal * (c.acc_bias_impulse_center_of_mass - jbnOld_com);
 
-				if (dynamic_A) {
+				if (dynamic_A && A->mask_has_layer(B)) {
 					A->apply_bias_impulse(-jb_com, A->get_center_of_mass(), 0.0f);
 				}
-				if (dynamic_B) {
+				if (dynamic_B && B->mask_has_layer(A)) {
 					B->apply_bias_impulse(jb_com, B->get_center_of_mass(), 0.0f);
 				}
 			}
@@ -446,10 +446,10 @@ void BodyPair3DSW::solve(real_t p_step) {
 
 			Vector3 j = c.normal * (c.acc_normal_impulse - jnOld);
 
-			if (dynamic_A) {
+			if (dynamic_A && A->mask_has_layer(B)) {
 				A->apply_impulse(-j, c.rA + A->get_center_of_mass());
 			}
-			if (dynamic_B) {
+			if (dynamic_B && B->mask_has_layer(A)) {
 				B->apply_impulse(j, c.rB + B->get_center_of_mass());
 			}
 
@@ -493,10 +493,10 @@ void BodyPair3DSW::solve(real_t p_step) {
 
 			jt = c.acc_tangent_impulse - jtOld;
 
-			if (dynamic_A) {
+			if (dynamic_A && A->mask_has_layer(B)) {
 				A->apply_impulse(-jt, c.rA + A->get_center_of_mass());
 			}
-			if (dynamic_B) {
+			if (dynamic_B && B->mask_has_layer(A)) {
 				B->apply_impulse(jt, c.rB + B->get_center_of_mass());
 			}
 

--- a/servers/physics_3d/collision_object_3d_sw.h
+++ b/servers/physics_3d/collision_object_3d_sw.h
@@ -166,8 +166,8 @@ public:
 	}
 	_FORCE_INLINE_ uint32_t get_collision_mask() const { return collision_mask; }
 
-	_FORCE_INLINE_ bool layer_in_mask(CollisionObject3DSW *p_other) const {
-		return collision_layer & p_other->collision_mask;
+	_FORCE_INLINE_ bool mask_has_layer(CollisionObject3DSW *p_other) const {
+		return collision_mask & p_other->collision_layer;
 	}
 
 	_FORCE_INLINE_ bool interacts_with(CollisionObject3DSW *p_other) const {

--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -549,7 +549,7 @@ int Space3DSW::_cull_aabb_for_body(Body3DSW *p_body, const AABB &p_aabb) {
 			keep = false;
 		} else if (intersection_query_results[i]->get_type() == CollisionObject3DSW::TYPE_SOFT_BODY) {
 			keep = false;
-		} else if (!p_body->layer_in_mask(static_cast<Body3DSW *>(intersection_query_results[i]))) {
+		} else if (!p_body->mask_has_layer(static_cast<Body3DSW *>(intersection_query_results[i]))) {
 			keep = false;
 		} else if (static_cast<Body3DSW *>(intersection_query_results[i])->has_exception(p_body->get_self()) || p_body->has_exception(intersection_query_results[i]->get_self())) {
 			keep = false;


### PR DESCRIPTION
The `RigidBody` sister PR to #42268 (`Area`s) and #42641 (`KinematicBody`s).

Currently, when a `RigidBody` collides with another `CollisionObject` the `collision_layer`->`collision_mask` combination is checked both ways. This results in unintended and unwanted collisions.

This PR ensures that `RigidBody`s only collide with `CollisionObjects` that have one of the `RigidBody`'s `collision_layer` bits in the other `CollisionObject`'s `collision_mask`. It fixes both 2D and 3D Godot physics.

Note: Unlike #42268 and #42641, this PR does not apply the same fix to Bullet physics.

The final part of https://github.com/godotengine/godot-proposals/issues/2775.
