### PR TITLE
Fixed inspector not updating anchor

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -88,6 +88,10 @@ void Control::_edit_set_state(const Dictionary &p_state) {
 	data.margin[MARGIN_RIGHT] = margins[2];
 	data.margin[MARGIN_BOTTOM] = margins[3];
 	_size_changed();
+	_change_notify("anchor_left");
+	_change_notify("anchor_right");
+	_change_notify("anchor_top");
+	_change_notify("anchor_bottom");
 }
 
 void Control::_edit_set_position(const Point2 &p_position) {


### PR DESCRIPTION
Fixes #49004
**Before:**
The change in preset-layout was taking place. But the respective changes in `anchor` were not being notified to the inspector.

**After:**
`_change_notify("anchor_<left/right/top/bottom>")` was added to the setter of `anchor` and `margin` properties.
This fixes the bug.    
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
