### PR TITLE
Fix_VsEditor_drag_in_from_scenetree

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2432,7 +2432,6 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 }
 
 void VisualScriptEditor::_selected_method(const String &p_text, const String &p_category, const bool p_connecting) {
-
 	Ref<VisualScriptNode> vnode;
 
 	if (p_category == String("method")) {

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2295,7 +2295,6 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				}
 				undo_redo->add_do_method(script.ptr(), "add_node", base_id, n, ofs);
 				undo_redo->add_undo_method(script.ptr(), "remove_node", base_id);
-				print_error(ofs);
 				base_id++;
 				ofs += Vector2(25, 25);
 			}

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -269,7 +269,9 @@ class VisualScriptEditor : public ScriptEditorBase {
 	void _graph_ofs_changed(const Vector2 &p_ofs);
 	void _comment_node_resized(const Vector2 &p_new_size, int p_node);
 
-	int selecting_method_id;
+	Vector2 drop_pos;
+	NodePath relative_path;
+	String node_class;
 	void _selected_method(const String &p_method, const String &p_type, const bool p_connecting);
 
 	void _draw_color_over_button(Object *obj, Color p_color);

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -269,39 +269,41 @@ void VisualScriptPropertySelector::_update_search() {
 			memdelete(category); //old category was unused
 		}
 	}
-	if (properties) {
-		if (!seq_connect && !visual_script_generic) {
-			get_visual_node_names("flow_control/type_cast", Set<String>(), found, root, search_box);
-			get_visual_node_names("functions/built_in/print", Set<String>(), found, root, search_box);
-			get_visual_node_names("functions/by_type/" + Variant::get_type_name(type), Set<String>(), found, root, search_box);
-			get_visual_node_names("functions/deconstruct/" + Variant::get_type_name(type), Set<String>(), found, root, search_box);
-			get_visual_node_names("operators/compare/", Set<String>(), found, root, search_box);
-			if (type == Variant::INT) {
-				get_visual_node_names("operators/bitwise/", Set<String>(), found, root, search_box);
-			}
-			if (type == Variant::BOOL) {
-				get_visual_node_names("operators/logic/", Set<String>(), found, root, search_box);
-			}
-			if (type == Variant::BOOL || type == Variant::INT || type == Variant::FLOAT || type == Variant::VECTOR2 || type == Variant::VECTOR3) {
-				get_visual_node_names("operators/math/", Set<String>(), found, root, search_box);
+	if (!visual_script_import) {
+		if (properties) {
+			if (!seq_connect && !visual_script_generic) {
+				get_visual_node_names("flow_control/type_cast", Set<String>(), found, root, search_box);
+				get_visual_node_names("functions/built_in/print", Set<String>(), found, root, search_box);
+				get_visual_node_names("functions/by_type/" + Variant::get_type_name(type), Set<String>(), found, root, search_box);
+				get_visual_node_names("functions/deconstruct/" + Variant::get_type_name(type), Set<String>(), found, root, search_box);
+				get_visual_node_names("operators/compare/", Set<String>(), found, root, search_box);
+				if (type == Variant::INT) {
+					get_visual_node_names("operators/bitwise/", Set<String>(), found, root, search_box);
+				}
+				if (type == Variant::BOOL) {
+					get_visual_node_names("operators/logic/", Set<String>(), found, root, search_box);
+				}
+				if (type == Variant::BOOL || type == Variant::INT || type == Variant::FLOAT || type == Variant::VECTOR2 || type == Variant::VECTOR3) {
+					get_visual_node_names("operators/math/", Set<String>(), found, root, search_box);
+				}
 			}
 		}
-	}
 
-	if (seq_connect && !visual_script_generic) {
-		String text = search_box->get_text();
-		create_visualscript_item(String("VisualScriptCondition"), root, text, String("Condition"));
-		create_visualscript_item(String("VisualScriptSwitch"), root, text, String("Switch"));
-		create_visualscript_item(String("VisualScriptSequence"), root, text, String("Sequence"));
-		create_visualscript_item(String("VisualScriptIterator"), root, text, String("Iterator"));
-		create_visualscript_item(String("VisualScriptWhile"), root, text, String("While"));
-		create_visualscript_item(String("VisualScriptReturn"), root, text, String("Return"));
-		get_visual_node_names("flow_control/type_cast", Set<String>(), found, root, search_box);
-		get_visual_node_names("functions/built_in/print", Set<String>(), found, root, search_box);
-	}
+		if (seq_connect && !visual_script_generic) {
+			String text = search_box->get_text();
+			create_visualscript_item(String("VisualScriptCondition"), root, text, String("Condition"));
+			create_visualscript_item(String("VisualScriptSwitch"), root, text, String("Switch"));
+			create_visualscript_item(String("VisualScriptSequence"), root, text, String("Sequence"));
+			create_visualscript_item(String("VisualScriptIterator"), root, text, String("Iterator"));
+			create_visualscript_item(String("VisualScriptWhile"), root, text, String("While"));
+			create_visualscript_item(String("VisualScriptReturn"), root, text, String("Return"));
+			get_visual_node_names("flow_control/type_cast", Set<String>(), found, root, search_box);
+			get_visual_node_names("functions/built_in/print", Set<String>(), found, root, search_box);
+		}
 
-	if ((properties || seq_connect) && visual_script_generic) {
-		get_visual_node_names("", Set<String>(), found, root, search_box);
+		if ((properties || seq_connect) && visual_script_generic) {
+			get_visual_node_names("", Set<String>(), found, root, search_box);
+		}
 	}
 
 	TreeItem *selected_item = search_options->search_item_text(search_box->get_text());
@@ -649,6 +651,14 @@ void VisualScriptPropertySelector::select_from_instance(Object *p_instance, cons
 	base_type = p_basetype;
 	selected = p_current;
 	type = Variant::NIL;
+	Ref<Script> s = p_instance->get_script();
+	if (s.is_null()) {
+		uint64_t id0 = 0;
+		script = id0;
+	} else {
+		script = s->get_instance_id();
+	}
+	visual_script_import = true;
 	properties = true;
 	visual_script_generic = false;
 	instance = p_instance;

--- a/modules/visual_script/visual_script_property_selector.h
+++ b/modules/visual_script/visual_script_property_selector.h
@@ -55,6 +55,7 @@ class VisualScriptPropertySelector : public ConfirmationDialog {
 	EditorHelpBit *help_bit;
 
 	bool properties;
+	bool visual_script_import;
 	bool visual_script_generic;
 	bool connecting;
 	String selected;


### PR DESCRIPTION
Moves the creation of the vs_instances after the decision and allows the creation of set and get propertynodes.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fix #26717
fix #49146

Moves the creation of the vs_instances after the decision and allows the creation of set and get propertynodes.

<img width="745" alt="VisualScriptEditor_drag_in_scenetree_node_m" src="https://user-images.githubusercontent.com/20573784/120020259-c185f900-bfe9-11eb-94cf-209b952360ed.PNG">

![fix_VsEditor_drag_in_from_scene](https://user-images.githubusercontent.com/20573784/120024413-766ee480-bfef-11eb-93b6-0e2d85c1c675.gif)

Tested on Master and 3.x
For cherry-pick 3.x I will make a extra [PR](https://github.com/godotengine/godot/pull/49184)
3.x requires 1 more argument on for lines. 

Also:
Limit suggestions to useful methods, setters and getters. Other VsNodes are not required from this interaction.
Now includes the attached script of a Node for suggestions.