### PR TITLE
[RichTextLabel] Fix not updating fonts when parent theme changes

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -959,16 +959,13 @@ void RichTextLabel::_notification(int p_what) {
 			update();
 
 		} break;
+		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
 			if (bbcode != "") {
 				set_bbcode(bbcode);
 			}
 
 			main->first_invalid_line = 0; //invalidate ALL
-			update();
-
-		} break;
-		case NOTIFICATION_THEME_CHANGED: {
 			update();
 
 		} break;


### PR DESCRIPTION
Fixes #49089

----

Analog to what we're already doing in master branch since #42595 we"re now updating the 
RichTextLabel items when we receive a theme changed notification.

We should also consider cherry picking this into the 3.3 branch.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
