### PR TITLE
Check cache_parent_physical_bone when rebuilding parent cache

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -698,7 +698,7 @@ void Skeleton3D::_rebuild_physical_bones_cache() {
 	const int b_size = bones.size();
 	for (int i = 0; i < b_size; ++i) {
 		PhysicalBone3D *parent_pb = _get_physical_bone_parent(i);
-		if (parent_pb != bones[i].physical_bone) {
+		if (parent_pb != bones[i].cache_parent_physical_bone) {
 			bones.write[i].cache_parent_physical_bone = parent_pb;
 			if (bones[i].physical_bone) {
 				bones[i].physical_bone->_on_bone_parent_changed();


### PR DESCRIPTION
When updating the parent bone cache, checking whether the parent bone equals itself makes no sense. I believe this is a typo that existed for quite a long time.  CC @AndreaCatania 

This PR also applies to the `3.x` branch. It helps to solve the strange offset of last `PhysicalBone` after fixing the bone ID (see #48705). The `master` branch does not have this offset because the joint is always reloaded at the end of `ENTER_TREE` after the multithread refactoring.