### PR TITLE
[3.x]Fix_VsEditor_drag_in_from_scenetree

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2279,49 +2279,46 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 			ofs = ofs.snapped(Vector2(snap, snap));
 		}
 		ofs /= EDSCALE;
+		drop_pos = ofs;
 
 		undo_redo->create_action(TTR("Add Node(s) From Tree"));
-		int base_id = script->get_available_id();
 
 		if (nodes.size() > 1) {
 			use_node = true;
 		}
 
-		for (int i = 0; i < nodes.size(); i++) {
-			NodePath np = nodes[i];
+		if (use_node) {
+			int base_id = script->get_available_id();
+			for (int i = 0; i < nodes.size(); i++) {
+				NodePath np = nodes[i];
+				Node *node = get_node(np);
+				if (!node) {
+					continue;
+				}
+				Ref<VisualScriptNode> n;
+				if (use_node) {
+					Ref<VisualScriptSceneNode> scene_node;
+					scene_node.instance();
+					scene_node->set_node_path(sn->get_path_to(node));
+					n = scene_node;
+				}
+				undo_redo->add_do_method(script.ptr(), "add_node", default_func, base_id, n, ofs);
+				undo_redo->add_undo_method(script.ptr(), "remove_node", default_func, base_id);
+				base_id++;
+				ofs += Vector2(25, 25);
+			}
+			undo_redo->add_do_method(this, "_update_graph");
+			undo_redo->add_undo_method(this, "_update_graph");
+			undo_redo->commit_action();
+		} else {
+			NodePath np = nodes[0];
 			Node *node = get_node(np);
-			if (!node) {
-				continue;
-			}
-
-			Ref<VisualScriptNode> n;
-
-			if (use_node) {
-				Ref<VisualScriptSceneNode> scene_node;
-				scene_node.instance();
-				scene_node->set_node_path(sn->get_path_to(node));
-				n = scene_node;
-			} else {
-				// ! Doesn't work properly
-				Ref<VisualScriptFunctionCall> call;
-				call.instance();
-				call->set_call_mode(VisualScriptFunctionCall::CALL_MODE_NODE_PATH);
-				call->set_base_path(sn->get_path_to(node));
-				call->set_base_type(node->get_class());
-				n = call;
+			relative_path = sn->get_path_to(node);
+			node_class = node->get_class();
+			if (node) {
 				method_select->select_from_instance(node, "", true, node->get_class());
-				selecting_method_id = base_id;
 			}
-
-			undo_redo->add_do_method(script.ptr(), "add_node", default_func, base_id, n, ofs);
-			undo_redo->add_undo_method(script.ptr(), "remove_node", default_func, base_id);
-
-			base_id++;
-			ofs += Vector2(25, 25);
 		}
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
-		undo_redo->commit_action();
 	}
 
 	if (String(d["type"]) == "obj_property") {
@@ -2442,12 +2439,40 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	}
 }
 
-void VisualScriptEditor::_selected_method(const String &p_method, const String &p_type, const bool p_connecting) {
-	Ref<VisualScriptFunctionCall> vsfc = script->get_node(default_func, selecting_method_id);
-	if (!vsfc.is_valid()) {
-		return;
+void VisualScriptEditor::_selected_method(const String &p_text, const String &p_category, const bool p_connecting) {
+	Ref<VisualScriptNode> vnode;
+
+	if (p_category == String("method")) {
+		Ref<VisualScriptFunctionCall> n;
+		n.instance();
+		n->set_call_mode(VisualScriptFunctionCall::CALL_MODE_NODE_PATH);
+		n->set_base_path(relative_path);
+		n->set_base_type(node_class);
+		n->set_function(p_text);
+		vnode = n;
+	} else if (p_category == String("set")) {
+		Ref<VisualScriptPropertySet> n;
+		n.instance();
+		n->set_call_mode(VisualScriptPropertySet::CALL_MODE_NODE_PATH);
+		n->set_base_path(relative_path);
+		n->set_base_type(node_class);
+		n->set_property(p_text);
+		vnode = n;
+	} else if (p_category == String("get")) {
+		Ref<VisualScriptPropertyGet> n;
+		n.instance();
+		n->set_call_mode(VisualScriptPropertyGet::CALL_MODE_NODE_PATH);
+		n->set_base_path(relative_path);
+		n->set_base_type(node_class);
+		n->set_property(p_text);
+		vnode = n;
 	}
-	vsfc->set_function(p_method);
+	int base_id = script->get_available_id();
+	undo_redo->add_do_method(script.ptr(), "add_node", default_func, base_id, vnode, drop_pos);
+	undo_redo->add_undo_method(script.ptr(), "remove_node", default_func, base_id);
+	undo_redo->add_do_method(this, "_update_graph");
+	undo_redo->add_undo_method(this, "_update_graph");
+	undo_redo->commit_action();
 }
 
 void VisualScriptEditor::_draw_color_over_button(Object *obj, Color p_color) {

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -273,7 +273,9 @@ class VisualScriptEditor : public ScriptEditorBase {
 	void _graph_ofs_changed(const Vector2 &p_ofs);
 	void _comment_node_resized(const Vector2 &p_new_size, int p_node);
 
-	int selecting_method_id;
+	Vector2 drop_pos;
+	NodePath relative_path;
+	String node_class;
 	void _selected_method(const String &p_method, const String &p_type, const bool p_connecting);
 
 	void _draw_color_over_button(Object *obj, Color p_color);

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -646,7 +646,12 @@ void VisualScriptPropertySelector::select_from_instance(Object *p_instance, cons
 	base_type = p_basetype;
 	selected = p_current;
 	type = Variant::NIL;
-	script = 0;
+	Ref<Script> s = p_instance->get_script();
+	if (s.is_null()) {
+		script = 0;
+	} else {
+		script = s->get_instance_id();
+	}
 	properties = false;
 	visual_script_generic = false;
 	instance = p_instance;

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -647,7 +647,7 @@ void VisualScriptPropertySelector::select_from_instance(Object *p_instance, cons
 	selected = p_current;
 	type = Variant::NIL;
 	script = 0;
-	properties = true;
+	properties = false;
 	visual_script_generic = false;
 	instance = p_instance;
 	virtuals_only = false;


### PR DESCRIPTION
Moves the creation of the vs_instances after the decision and allows the creation of set and get propertynodes.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
fix #26717
fix #49146

Moves the creation of the vs_instances after the decision and allows the creation of set and get propertynodes.

<img width="745" alt="VisualScriptEditor_drag_in_scenetree_node_m" src="https://user-images.githubusercontent.com/20573784/120020259-c185f900-bfe9-11eb-94cf-209b952360ed.PNG">

![fix_VsEditor_drag_in_from_scene](https://user-images.githubusercontent.com/20573784/120024413-766ee480-bfef-11eb-93b6-0e2d85c1c675.gif)

Master [PR](https://github.com/godotengine/godot/pull/49172) has updated `undo_redo` thus its one PR
This PR = Cherry-pick for 3.x

Also:
Limit suggestions to useful methods, setters and getters. Other VsNodes are not required from this interaction.
Now includes the attached script of a Node for suggestions. 
