### PR TITLE
GodotPhysics: Avoid NaNs when calculating inertias for bodies without mass/area

### DIFF
--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -65,16 +65,18 @@ void Body3DSW::update_inertias() {
 			// We have to recompute the center of mass.
 			center_of_mass_local.zero();
 
-			for (int i = 0; i < get_shape_count(); i++) {
-				real_t area = get_shape_area(i);
+			if (total_area != 0.0) {
+				for (int i = 0; i < get_shape_count(); i++) {
+					real_t area = get_shape_area(i);
 
-				real_t mass = area * this->mass / total_area;
+					real_t mass = area * this->mass / total_area;
 
-				// NOTE: we assume that the shape origin is also its center of mass.
-				center_of_mass_local += mass * get_shape_transform(i).origin;
+					// NOTE: we assume that the shape origin is also its center of mass.
+					center_of_mass_local += mass * get_shape_transform(i).origin;
+				}
+
+				center_of_mass_local /= mass;
 			}
-
-			center_of_mass_local /= mass;
 
 			// Recompute the inertia tensor.
 			Basis inertia_tensor;
@@ -86,11 +88,14 @@ void Body3DSW::update_inertias() {
 					continue;
 				}
 
+				real_t area = get_shape_area(i);
+				if (area == 0.0) {
+					continue;
+				}
+
 				inertia_set = true;
 
 				const Shape3DSW *shape = get_shape(i);
-
-				real_t area = get_shape_area(i);
 
 				real_t mass = area * this->mass / total_area;
 


### PR DESCRIPTION
This PR fixes #49176 (which also occurs on 4.0 branch) by avoiding division by zero when calculating inertia for bodies with attached colliders without area/mass (RayCast shape). 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
