### PR TITLE
Document `Resource.duplicate()` only copying exported variables' values

### DIFF
--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -27,6 +27,7 @@
 			<description>
 				Duplicates the resource, returning a new resource. By default, sub-resources are shared between resource copies for efficiency. This can be changed by passing [code]true[/code] to the [code]subresources[/code] argument which will copy the subresources.
 				[b]Note:[/b] If [code]subresources[/code] is [code]true[/code], this method will only perform a shallow copy. Nested resources within subresources will not be duplicated and will still be shared.
+				[b]Note:[/b] When duplicating a resource, only [code]export[/code]ed properties are copied. Other properties will be set to their default value in the new resource.
 			</description>
 		</method>
 		<method name="emit_changed">


### PR DESCRIPTION
I'm fairly sure there's an issue about this on the main repository, but I can't find it right now.

**Note:** I didn't check whether this behavior is still true in `master`.

This closes https://github.com/godotengine/godot-docs/issues/4947.