### PR TITLE
GUI: Support for multi touch in _gui_input

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1454,8 +1454,6 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				gui.mouse_focus_mask |= mouse_button_to_mask(mb->get_button_index());
 			} else {
 				gui.mouse_focus = gui_find_control(pos);
-				gui.last_mouse_focus = gui.mouse_focus;
-
 				if (!gui.mouse_focus) {
 					gui.mouse_focus_mask = MouseButton::NONE;
 					return;
@@ -1884,19 +1882,24 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					}
 					touch_event->set_position(pos);
 					stopped = _gui_call_input(over, touch_event);
+					_gui_set_touch_focus(touch_event->get_index(), over);
 				}
 				if (stopped) {
 					set_input_as_handled();
 				}
 				return;
 			}
-		} else if (touch_event->get_index() == 0 && gui.last_mouse_focus) {
+		} else {
+			Control *last_control = _gui_get_touch_focus(touch_event->get_index());
 			bool stopped = false;
-			if (gui.last_mouse_focus->can_process()) {
-				touch_event = touch_event->xformed_by(Transform2D()); // Make a copy.
-				touch_event->set_position(gui.focus_inv_xform.xform(pos));
-
-				stopped = _gui_call_input(gui.last_mouse_focus, touch_event);
+			if (last_control && last_control->can_process()) {
+				touch_event = touch_event->xformed_by(Transform2D()); // Make a copy
+				if (last_control == gui.mouse_focus) {
+					touch_event->set_position(gui.focus_inv_xform.xform(pos));
+				} else {
+					touch_event->set_position(last_control->get_global_transform_with_canvas().affine_inverse().xform(pos));
+				}
+				stopped = _gui_call_input(last_control, touch_event);
 			}
 			if (stopped) {
 				set_input_as_handled();
@@ -1935,7 +1938,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 	Ref<InputEventScreenDrag> drag_event = p_event;
 	if (drag_event.is_valid()) {
-		Control *over = gui.mouse_focus;
+		Control *over = _gui_get_touch_focus(drag_event->get_index());
 		if (!over) {
 			over = gui_find_control(drag_event->get_position());
 		}
@@ -2144,8 +2147,9 @@ void Viewport::_gui_remove_control(Control *p_control) {
 		gui.forced_mouse_focus = false;
 		gui.mouse_focus_mask = MouseButton::NONE;
 	}
-	if (gui.last_mouse_focus == p_control) {
-		gui.last_mouse_focus = nullptr;
+	int index = _gui_has_touch_focus(p_control);
+	if (index != -1) {
+		_gui_clear_touch_focus(index);
 	}
 	if (gui.key_focus == p_control) {
 		gui.key_focus = nullptr;
@@ -3139,6 +3143,47 @@ Viewport::SDFScale Viewport::get_sdf_scale() const {
 
 Transform2D Viewport::get_screen_transform() const {
 	return _get_input_pre_xform().affine_inverse() * get_final_transform();
+}
+
+void Viewport::_gui_set_touch_focus(int p_index, Control *p_control) {
+	for (int i = 0; i < gui.touch_focuses.size(); i++) {
+		if (gui.touch_focuses[i].index == p_index) {
+			gui.touch_focuses.write[i].control = p_control;
+			return;
+		}
+	}
+
+	TouchFocus state;
+	state.index = p_index;
+	state.control = p_control;
+	gui.touch_focuses.push_back(state);
+}
+
+void Viewport::_gui_clear_touch_focus(int p_index) {
+	for (int i = 0; i < gui.touch_focuses.size(); i++) {
+		if (gui.touch_focuses[i].index == p_index) {
+			gui.touch_focuses.remove_at(i);
+			return;
+		}
+	}
+}
+
+Control *Viewport::_gui_get_touch_focus(int p_index) {
+	for (int i = 0; i < gui.touch_focuses.size(); i++) {
+		if (gui.touch_focuses[i].index == p_index) {
+			return gui.touch_focuses[i].control;
+		}
+	}
+	return nullptr;
+}
+
+int Viewport::_gui_has_touch_focus(Control *p_control) {
+	for (int i = 0; i < gui.touch_focuses.size(); i++) {
+		if (gui.touch_focuses[i].control == p_control) {
+			return gui.touch_focuses[i].index;
+		}
+	}
+	return -1;
 }
 
 #ifndef _3D_DISABLED

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -333,6 +333,11 @@ private:
 		RID canvas_item;
 	};
 
+	struct TouchFocus {
+		int index;
+		Control *control;
+	};
+
 	struct GUI {
 		// info used when this is a window
 
@@ -340,7 +345,6 @@ private:
 		bool mouse_in_viewport = true;
 		bool key_event_accepted = false;
 		Control *mouse_focus = nullptr;
-		Control *last_mouse_focus = nullptr;
 		Control *mouse_click_grabber = nullptr;
 		MouseButton mouse_focus_mask = MouseButton::NONE;
 		Control *key_focus = nullptr;
@@ -364,6 +368,8 @@ private:
 		int canvas_sort_index = 0; //for sorting items with canvas as root
 		bool dragging = false;
 		bool drag_successful = false;
+		Vector<TouchFocus> touch_focuses;
+
 		bool embed_subwindows_hint = false;
 
 		Window *subwindow_focused = nullptr;
@@ -388,6 +394,11 @@ private:
 
 	void _gui_sort_roots();
 	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform, Transform2D &r_inv_xform);
+
+	void _gui_set_touch_focus(int p_index, Control *p_control);
+	void _gui_clear_touch_focus(int p_index);
+	Control *_gui_get_touch_focus(int p_index);
+	int _gui_has_touch_focus(Control *p_control);
 
 	void _gui_input_event(Ref<InputEvent> p_event);
 	void _gui_cleanup_internal_state(Ref<InputEvent> p_event);


### PR DESCRIPTION
This is a forward port of #34383, which was created by @NoFr1ends and who I've made co-author of the commit.

Enables multi-touch `InputEventScreenTouch` and `InputEventScreenDrag` events in the GUI by storing the `Control` associated with each touch index.

Note: This only enables multi-touch support in the GUI i.e. it does not solve #24589. Only `InputEventMouseButton` events (which are generated from `InputEventScreenTouch` events when the "Emulate Mouse From Touch" setting is on -- the default) will trigger `BaseButton` `button_down` and `button_up` events in the button; so with "Emulate Mouse From Touch" on, only the first touch will trigger a `BaseButton` pressed event, and nothing when it's off.

Fixes #29525
Fixes #62597