### PR TITLE
Fix `Directory::get_space_left()` result on macOS and Linux.

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -460,7 +460,7 @@ uint64_t DirAccessUnix::get_space_left() {
 		return 0;
 	};
 
-	return vfs.f_bfree * vfs.f_bsize;
+	return (uint64_t)vfs.f_bavail * (uint64_t)vfs.f_frsize;
 #else
 	// FIXME: Implement this.
 	return 0;


### PR DESCRIPTION
- Use `fragme_size` instead of `block_size` as base unit.
- Use "free space for unprivileged users" instead of "total free space" (which corresponds to the Windows implementation and value shown by `df` and `mc` and some other Linux file managers).

Tested on macOS 11.4, Ubuntu 21.04 (x86-64), Mageia 8 (x86-64 and i586) with different file systems.

Fixes #47262
