### PR TITLE
Wrap description TextEdit of plugin config dialog

### DIFF
--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -214,6 +214,7 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	desc_edit = memnew(TextEdit);
 	desc_edit->set_custom_minimum_size(Size2(400, 80) * EDSCALE);
+	desc_edit->set_wrap_enabled(true);
 	grid->add_child(desc_edit);
 
 	Label *author_lb = memnew(Label);


### PR DESCRIPTION
This PR enables wrapping of the TextEdit for plugin description in PluginConfigDialog. So that only the vertical scrollbar will appear.

Before:
![Before](https://user-images.githubusercontent.com/372476/120184170-41f36680-c243-11eb-90ac-a39b97e62875.png)

After:
![After](https://user-images.githubusercontent.com/372476/120184176-43bd2a00-c243-11eb-9540-a843e221e6e6.png)

This also applies to the 3.x branch.