### PR TITLE
Improve compiler version extraction

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -409,14 +409,27 @@ if selected_platform in platform_list:
         env.Prepend(CCFLAGS=["/std:c++17"])
 
     # Enforce our minimal compiler version requirements
-    cc_version = methods.get_compiler_version(env) or [-1, -1]
-    cc_version_major = cc_version[0]
-    cc_version_minor = cc_version[1]
+    cc_version = methods.get_compiler_version(env) or {
+        "major": None,
+        "minor": None,
+        "patch": None,
+        "metadata1": None,
+        "metadata2": None,
+        "date": None,
+    }
+    cc_version_major = int(cc_version["major"] or -1)
+    cc_version_minor = int(cc_version["minor"] or -1)
+    cc_version_metadata1 = cc_version["metadata1"] or ""
 
     if methods.using_gcc(env):
+        if cc_version_major == -1:
+            print(
+                "Couldn't detect compiler version, skipping version checks. "
+                "Build may fail if the compiler doesn't support C++17 fully."
+            )
         # GCC 8 before 8.4 has a regression in the support of guaranteed copy elision
         # which causes a build failure: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86521
-        if cc_version_major == 8 and cc_version_minor < 4:
+        elif cc_version_major == 8 and cc_version_minor < 4:
             print(
                 "Detected GCC 8 version < 8.4, which is not supported due to a "
                 "regression in its C++17 guaranteed copy elision support. Use a "
@@ -432,10 +445,23 @@ if selected_platform in platform_list:
                 "SCons command line."
             )
             Exit(255)
+        elif cc_version_metadata1 == "win32":
+            print(
+                "Detected mingw version is not using posix threads. Only posix "
+                "version of mingw is supported. "
+                'Use "update-alternatives --config <platform>-w64-mingw32-[gcc|g++]" '
+                "to switch to posix threads."
+            )
+            Exit(255)
     elif methods.using_clang(env):
+        if cc_version_major == -1:
+            print(
+                "Couldn't detect compiler version, skipping version checks. "
+                "Build may fail if the compiler doesn't support C++17 fully."
+            )
         # Apple LLVM versions differ from upstream LLVM version \o/, compare
         # in https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
-        if env["platform"] == "osx" or env["platform"] == "iphone":
+        elif env["platform"] == "osx" or env["platform"] == "iphone":
             vanilla = methods.is_vanilla_clang(env)
             if vanilla and cc_version_major < 6:
                 print(

--- a/methods.py
+++ b/methods.py
@@ -787,9 +787,18 @@ def get_compiler_version(env):
             return None
     else:  # TODO: Implement for MSVC
         return None
-    match = re.search("[0-9]+\.[0-9.]+", version)
+    match = re.search(
+        "(?:(?<=version )|(?<=\) )|(?<=^))"
+        "(?P<major>\d+)"
+        "(?:\.(?P<minor>\d*))?"
+        "(?:\.(?P<patch>\d*))?"
+        "(?:-(?P<metadata1>[0-9a-zA-Z-]*))?"
+        "(?:\+(?P<metadata2>[0-9a-zA-Z-]*))?"
+        "(?: (?P<date>[0-9]{8}|[0-9]{6})(?![0-9a-zA-Z]))?",
+        version,
+    )
     if match is not None:
-        return list(map(int, match.group().split(".")))
+        return match.groupdict()
     else:
         return None
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch, and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
With this pr the compiler version checking improved in a way where only the major version is mandatory and along with the major field we can extract minor, patch, two alphanumeric fields and a date, so more sophisticated version checks are possible. The accepted string is `1.2.3-abc+def 20210531` where any field can be omitted except the major version. I hope this enough to cover the version numbers for a long time.

I have tested it with many distro's compiler version strings (Debian, Ubuntu, Arch, Fedora) but I may have missed something, so please have a look at the pattern [here](https://regex101.com/r/M5c88N/1).

Fixes: #48815
