### PR TITLE
TextureRegionEditor Fix not updating on editing region with autoslice cached

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -937,7 +937,6 @@ void TextureRegionEditor::_edit_region() {
 	if (cache_map.has(texture->get_rid())) {
 		autoslice_cache = cache_map[texture->get_rid()];
 		autoslice_is_dirty = false;
-		return;
 	} else {
 		if (is_visible() && snap_mode == SNAP_AUTOSLICE) {
 			_update_autoslice();


### PR DESCRIPTION
If texture's autoslicing was already cached neither the region's rect was updated nor redrawing was triggered.

Fixes #49233.
Cherry-pickable `3.x`, `3.3`.