### PR TITLE
Fix TextEdit selection drawing behing minimap

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1187,7 +1187,8 @@ void TextEdit::_notification(int p_what) {
 							if (rect.position.x < xmargin_beg) {
 								rect.size.x -= (xmargin_beg - rect.position.x);
 								rect.position.x = xmargin_beg;
-							} else if (rect.position.x + rect.size.x > xmargin_end) {
+							}
+							if (rect.position.x + rect.size.x > xmargin_end) {
 								rect.size.x = xmargin_end - rect.position.x;
 							}
 							draw_rect(rect, cache.selection_color, true);


### PR DESCRIPTION
Fixed the selection drawing behind the minimap.

With RTL changes, closes #15732