### PR TITLE
Make tree item dragging not affected by touch dragging

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3106,7 +3106,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					drag_accum = 0;
 					//last_drag_accum=0;
 					drag_from = v_scroll->get_value();
-					drag_touching = !DisplayServer::get_singleton()->screen_is_touchscreen(DisplayServer::get_singleton()->window_get_current_screen(get_viewport()->get_window_id()));
+					drag_touching = DisplayServer::get_singleton()->screen_is_touchscreen(DisplayServer::get_singleton()->window_get_current_screen(get_viewport()->get_window_id()));
 					drag_touching_deaccel = false;
 					if (drag_touching) {
 						set_physics_process_internal(true);


### PR DESCRIPTION
Fixes #49240.
*Bugsquad edit:* Fixes #39087.
![tree_drag_2](https://user-images.githubusercontent.com/28705694/120325994-d086e700-c31a-11eb-8118-83da8b7365f2.gif)

However, it seems `DisplayServer::get_singleton()->screen_is_touchscreen()` doesn't return the expected value when I enable `emulate_touch_from_mouse`. As a result, the fix disables touch dragging on tree item. I don't know if this function returns the right value on a physical device with touch screen as mobile export is not available for now.