### PR TITLE
Fix overflow in export template manager

### DIFF
--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -136,6 +136,8 @@ void ExportTemplateManager::_update_template_list() {
 
 		installed_vb->add_child(hbc);
 	}
+
+	_fix_size();
 }
 
 void ExportTemplateManager::_download_template(const String &p_version) {


### PR DESCRIPTION
Fix #48826

----

Fixes the possible overflow of buttons after downloading the current export template with using custom fonts or custom font size by calling the _fix_size function of the popup after updating the template list.

This bug is not present in the master branch.