### PR TITLE
add method name to profiler tooltip

### DIFF
--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -401,7 +401,7 @@ void EditorProfiler::_update_frame() {
 			item->set_metadata(1, it.script);
 			item->set_metadata(2, it.line);
 			item->set_text_align(2, TreeItem::ALIGN_RIGHT);
-			item->set_tooltip(0, it.script + ":" + itos(it.line));
+			item->set_tooltip(0, it.name + "\n" + it.script + ":" + itos(it.line));
 
 			float time = dtime == DISPLAY_SELF_TIME ? it.self : it.total;
 


### PR DESCRIPTION
Show the method name of an item in the profiler, and move the normal contents
(file path and line number) to a second line.

This is useful for long method names, since they otherwise get cut off.

Fixes #48835

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
