### PR TITLE
Fixed window_can_draw of DisplayServerWindows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1119,7 +1119,7 @@ bool DisplayServerWindows::window_can_draw(WindowID p_window) const {
 
 	ERR_FAIL_COND_V(!windows.has(p_window), false);
 	const WindowData &wd = windows[p_window];
-	return wd.minimized;
+	return !wd.minimized;
 }
 
 bool DisplayServerWindows::can_any_window_draw() const {


### PR DESCRIPTION
This fixes a small typo in DisplayServerWindows, which is essential for PR #48622.