### PR TITLE
[3.x] SpriteFramesEditor Add animation searchbox

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -36,6 +36,7 @@
 #include "scene/2d/animated_sprite.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/file_dialog.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
@@ -68,6 +69,7 @@ class SpriteFramesEditor : public HSplitContainer {
 
 	ToolButton *new_anim;
 	ToolButton *remove_anim;
+	LineEdit *anim_search_box;
 
 	Tree *animations;
 	SpinBox *anim_speed;
@@ -132,6 +134,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _animation_add();
 	void _animation_remove();
 	void _animation_remove_confirmed();
+	void _animation_search_text_changed(const String &p_text);
 	void _animation_loop_changed();
 	void _animation_fps_changed(double p_value);
 


### PR DESCRIPTION
(~will do `master` version after this is approved~) `master` version: #49488

Closes https://github.com/godotengine/godot-proposals/issues/2681. Made searchbox toggleable so it won't take any vertical space if not needed.

|before|after|
|-|-|
|![R3Nxn5k37W](https://user-images.githubusercontent.com/9283098/120486551-771fc600-c3b5-11eb-9a1b-766d39e19797.png)|![aQjtrYwE0v](https://user-images.githubusercontent.com/9283098/120486205-1c866a00-c3b5-11eb-94bb-debcea2ce618.gif)|

---

Do I need to add added strings somewhere (for translations)?
