### PR TITLE
Move FindReplaceBar out of CodeTextEditor

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -57,6 +57,8 @@ public:
 	GotoLineDialog();
 };
 
+class CodeTextEditor;
+
 class FindReplaceBar : public HBoxContainer {
 	GDCLASS(FindReplaceBar, HBoxContainer);
 
@@ -77,6 +79,7 @@ class FindReplaceBar : public HBoxContainer {
 	HBoxContainer *hbc_button_replace;
 	HBoxContainer *hbc_option_replace;
 
+	CodeTextEditor *base_text_editor = nullptr;
 	CodeEdit *text_editor;
 
 	int result_line;
@@ -120,7 +123,7 @@ public:
 	bool is_selection_only() const;
 	void set_error(const String &p_label);
 
-	void set_text_edit(CodeEdit *p_text_edit);
+	void set_text_edit(CodeTextEditor *p_text_editor);
 
 	void popup_search(bool p_show_only = false);
 	void popup_replace();
@@ -138,7 +141,7 @@ class CodeTextEditor : public VBoxContainer {
 	GDCLASS(CodeTextEditor, VBoxContainer);
 
 	CodeEdit *text_editor;
-	FindReplaceBar *find_replace_bar;
+	FindReplaceBar *find_replace_bar = nullptr;
 	HBoxContainer *status_bar;
 
 	Button *toggle_scripts_button;
@@ -243,6 +246,8 @@ public:
 	void update_line_and_column() { _line_col_changed(); }
 	CodeEdit *get_text_editor() { return text_editor; }
 	FindReplaceBar *get_find_replace_bar() { return find_replace_bar; }
+	void set_find_replace_bar(FindReplaceBar *p_bar);
+	void remove_find_replace_bar();
 	virtual void apply_code() {}
 	void goto_error();
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1640,10 +1640,13 @@ void ScriptEditor::ensure_select_current() {
 		ScriptEditorBase *se = _get_current_editor();
 		if (se) {
 			se->enable_editor();
+			se->set_find_replace_bar(find_replace_bar);
 
 			if (!grab_focus_block && is_visible_in_tree()) {
 				se->ensure_focus();
 			}
+		} else {
+			find_replace_bar->hide();
 		}
 	}
 
@@ -3377,11 +3380,19 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	help_overview->set_custom_minimum_size(Size2(0, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
 	help_overview->set_v_size_flags(SIZE_EXPAND_FILL);
 
+	VBoxContainer *code_editor_container = memnew(VBoxContainer);
+	script_split->add_child(code_editor_container);
+
 	tab_container = memnew(TabContainer);
 	tab_container->set_tabs_visible(false);
 	tab_container->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
-	script_split->add_child(tab_container);
+	code_editor_container->add_child(tab_container);
 	tab_container->set_h_size_flags(SIZE_EXPAND_FILL);
+	tab_container->set_v_size_flags(SIZE_EXPAND_FILL);
+
+	find_replace_bar = memnew(FindReplaceBar);
+	code_editor_container->add_child(find_replace_bar);
+	find_replace_bar->hide();
 
 	ED_SHORTCUT("script_editor/window_sort", TTR("Sort"));
 	ED_SHORTCUT("script_editor/window_move_up", TTR("Move Up"), KEY_MASK_SHIFT | KEY_MASK_ALT | KEY_UP);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -162,6 +162,7 @@ public:
 	virtual void set_tooltip_request_func(String p_method, Object *p_obj) = 0;
 	virtual Control *get_edit_menu() = 0;
 	virtual void clear_edit_menu() = 0;
+	virtual void set_find_replace_bar(FindReplaceBar *p_bar) = 0;
 
 	virtual Control *get_base_editor() const = 0;
 
@@ -270,6 +271,7 @@ class ScriptEditor : public PanelContainer {
 	ConfirmationDialog *erase_tab_confirm;
 	ScriptCreateDialog *script_create_dialog;
 	Button *scripts_visible;
+	FindReplaceBar *find_replace_bar;
 
 	String current_theme;
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1358,6 +1358,10 @@ void ScriptTextEditor::clear_edit_menu() {
 	memdelete(edit_hb);
 }
 
+void ScriptTextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {
+	code_editor->set_find_replace_bar(p_bar);
+}
+
 void ScriptTextEditor::reload(bool p_soft) {
 	CodeEdit *te = code_editor->get_text_editor();
 	Ref<Script> scr = script;

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -233,6 +233,8 @@ public:
 
 	Control *get_edit_menu() override;
 	virtual void clear_edit_menu() override;
+	virtual void set_find_replace_bar(FindReplaceBar *p_bar) override;
+
 	static void register_editor();
 
 	virtual Control *get_base_editor() const override;

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -751,6 +751,11 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	editor_box->set_v_size_flags(SIZE_EXPAND_FILL);
 	editor_box->add_child(shader_editor);
 
+	FindReplaceBar *bar = memnew(FindReplaceBar);
+	main_container->add_child(bar);
+	bar->hide();
+	shader_editor->set_find_replace_bar(bar);
+
 	warnings_panel = memnew(RichTextLabel);
 	warnings_panel->set_custom_minimum_size(Size2(0, 100 * EDSCALE));
 	warnings_panel->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -281,6 +281,10 @@ void TextEditor::clear_edit_menu() {
 	memdelete(edit_hb);
 }
 
+void TextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {
+	code_editor->set_find_replace_bar(p_bar);
+}
+
 void TextEditor::_edit_option(int p_op) {
 	CodeEdit *tx = code_editor->get_text_editor();
 

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -139,6 +139,7 @@ public:
 
 	virtual Control *get_edit_menu() override;
 	virtual void clear_edit_menu() override;
+	virtual void set_find_replace_bar(FindReplaceBar *p_bar) override;
 
 	virtual void validate() override;
 

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -317,6 +317,7 @@ public:
 	virtual void set_tooltip_request_func(String p_method, Object *p_obj) override;
 	virtual Control *get_edit_menu() override;
 	virtual void clear_edit_menu() override;
+	virtual void set_find_replace_bar(FindReplaceBar *p_bar) override { p_bar->hide(); }; // Not needed here.
 	virtual bool can_lose_focus_on_node_selection() override { return false; }
 	virtual void validate() override;
 


### PR DESCRIPTION
Second attempt to fix #27003 (after failed #28793)

Script Editor is a TabContainer with hidden tabs, containing ScriptEditorBases that use CodeTextEditor internally. Previously each of them had their own FindReplaceBar, so when switching between scripts you'd lose your search context. Each script had its own search texts, state of checkboxes etc.

This PR removed FindReplaceBar from CodeTextEditor. It's now part of ScriptEditorPlugin, which means there is only one bar. It required minimal changes, CodeTextEditor still has variable for FindReplaceBar, but now it's set externally whenever an editor is switched.

The side-effect is that search bar is now below status bar:
![sidefx](https://chat.godotengine.org/file-upload/T8dBKGkEshA3WutK7/Clipboard%20-%202%20czerwca%202021%2023:28)
One way for fixing this would be moving status bar to be part of FindReplaceBar, but that increases the complexity of changes **a lot** and could be done later if ever.

There seems to be some issue with F3 not working when the search bar is focused, not sure why :/