### PR TITLE
Add description to `EditorPlugin.remove_export_plugin`

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -580,6 +580,7 @@
 			<argument index="0" name="plugin" type="EditorExportPlugin">
 			</argument>
 			<description>
+				Removes an existing export plugin. Export plugins are used when the project is being exported. See [EditorExportPlugin] for more information.
 			</description>
 		</method>
 		<method name="remove_import_plugin">


### PR DESCRIPTION
This description was missing.
