### PR TITLE
Fix changing theme coloring for error label in VisualShader editor

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2949,9 +2949,6 @@ void VisualShaderEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
 		highend_label->set_modulate(get_theme_color("vulkan_color", "Editor"));
 
-		error_panel->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
-		error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
-
 		node_filter->set_right_icon(Control::get_theme_icon("Search", "EditorIcons"));
 
 		preview_shader->set_icon(Control::get_theme_icon("Shader", "EditorIcons"));
@@ -2992,9 +2989,10 @@ void VisualShaderEditor::_notification(int p_what) {
 			preview_text->add_comment_delimiter("/*", "*/", false);
 			preview_text->add_comment_delimiter("//", "", true);
 
-			error_text->add_theme_font_override("font", get_theme_font("status_source", "EditorFonts"));
-			error_text->add_theme_font_size_override("font_size", get_theme_font_size("status_source_size", "EditorFonts"));
-			error_text->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
+			error_panel->add_theme_style_override("panel", get_theme_stylebox("panel", "Panel"));
+			error_label->add_theme_font_override("font", get_theme_font("status_source", "EditorFonts"));
+			error_label->add_theme_font_size_override("font_size", get_theme_font_size("status_source_size", "EditorFonts"));
+			error_label->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));
 		}
 
 		tools->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon("Tools", "EditorIcons"));
@@ -3610,13 +3608,13 @@ void VisualShaderEditor::_update_preview() {
 	if (err != OK) {
 		Color error_line_color = EDITOR_GET("text_editor/highlighting/mark_color");
 		preview_text->set_line_background_color(sl.get_error_line() - 1, error_line_color);
-		error_text->set_visible(true);
+		error_panel->show();
 
 		String text = "error(" + itos(sl.get_error_line()) + "): " + sl.get_error_text();
-		error_text->set_text(text);
+		error_label->set_text(text);
 		shader_error = true;
 	} else {
-		error_text->set_visible(false);
+		error_panel->hide();
 		shader_error = false;
 	}
 }
@@ -3778,6 +3776,7 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	preview_vbox = memnew(VBoxContainer);
 	preview_window->add_child(preview_vbox);
+	preview_vbox->add_theme_constant_override("separation", 0);
 
 	preview_text = memnew(CodeEdit);
 	syntax_highlighter.instance();
@@ -3787,10 +3786,13 @@ VisualShaderEditor::VisualShaderEditor() {
 	preview_text->set_draw_line_numbers(true);
 	preview_text->set_readonly(true);
 
-	error_text = memnew(Label);
-	preview_vbox->add_child(error_text);
-	error_text->set_autowrap(true);
-	error_text->set_visible(false);
+	error_panel = memnew(PanelContainer);
+	preview_vbox->add_child(error_panel);
+	error_panel->set_visible(false);
+
+	error_label = memnew(Label);
+	error_panel->add_child(error_label);
+	error_label->set_autowrap(true);
 
 	///////////////////////////////////////
 	// POPUP MENU
@@ -4370,13 +4372,6 @@ VisualShaderEditor::VisualShaderEditor() {
 	/////////////////////////////////////////////////////////////////////
 
 	_update_options_menu();
-
-	error_panel = memnew(PanelContainer);
-	add_child(error_panel);
-	error_label = memnew(Label);
-	error_panel->add_child(error_label);
-	error_label->set_text("eh");
-	error_panel->hide();
 
 	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -146,16 +146,14 @@ class VisualShaderEditor : public VBoxContainer {
 	OptionButton *edit_type_particles;
 	OptionButton *edit_type_sky;
 
-	PanelContainer *error_panel;
-	Label *error_label;
-
 	bool pending_update_preview;
 	bool shader_error;
 	Window *preview_window;
 	VBoxContainer *preview_vbox;
 	CodeEdit *preview_text;
 	Ref<CodeHighlighter> syntax_highlighter;
-	Label *error_text;
+	PanelContainer *error_panel;
+	Label *error_label;
 
 	UndoRedo *undo_redo;
 	Point2 saved_node_pos;


### PR DESCRIPTION
Fix:
![image](https://user-images.githubusercontent.com/3036176/120608152-8ce6c700-c459-11eb-98e1-604092e15ac4.png)
+also removed redundant (not used) old error label.
