### PR TITLE
Fix bold fonts on GraphNode's in the editor

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1310,6 +1310,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("resizer", "GraphNode", theme->get_icon("GuiResizer", "EditorIcons"));
 	theme->set_icon("port", "GraphNode", theme->get_icon("GuiGraphNodePort", "EditorIcons"));
 
+	theme->set_font("title_font", "GraphNode", theme->get_font("title", "EditorFonts"));
+
 	// GridContainer
 	theme->set_constant("vseparation", "GridContainer", Math::round(widget_default_margin.y - 2 * EDSCALE));
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -413,6 +413,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			node->add_child(comment_label);
 			comment_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 			comment_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+			comment_label->add_theme_font_override("font", VisualShaderEditor::get_singleton()->get_theme_font("main", "EditorFonts"));
 			comment_label->set_text(comment_node->get_description());
 		}
 	}
@@ -672,12 +673,14 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					Label *label = memnew(Label);
 					label->set_text(name_left);
 					label->add_theme_style_override("normal", label_style); //more compact
+					label->add_theme_font_override("font", VisualShaderEditor::get_singleton()->get_theme_font("main", "EditorFonts"));
 					hb->add_child(label);
 
 					if (vsnode->get_input_port_default_hint(i) != "" && !port_left_used) {
 						Label *hint_label = memnew(Label);
 						hint_label->set_text("[" + vsnode->get_input_port_default_hint(i) + "]");
 						hint_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color("font_readonly_color", "TextEdit"));
+						hint_label->add_theme_font_override("font", VisualShaderEditor::get_singleton()->get_theme_font("main", "EditorFonts"));
 						hint_label->add_theme_style_override("normal", label_style);
 						hb->add_child(hint_label);
 					}
@@ -718,6 +721,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					Label *label = memnew(Label);
 					label->set_text(name_right);
 					label->add_theme_style_override("normal", label_style); //more compact
+					label->add_theme_font_override("font", VisualShaderEditor::get_singleton()->get_theme_font("main", "EditorFonts"));
 					hb->add_child(label);
 				}
 			}
@@ -805,6 +809,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	if (error != String()) {
 		Label *error_label = memnew(Label);
 		error_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color("error_color", "Editor"));
+		error_label->add_theme_font_size_override("font_size", VisualShaderEditor::get_singleton()->get_theme_font_size("status_source_size", "EditorFonts"));
+		error_label->add_theme_font_override("font", VisualShaderEditor::get_singleton()->get_theme_font("status_source", "EditorFonts"));
 		error_label->set_text(error);
 		node->add_child(error_label);
 	}
@@ -4613,6 +4619,7 @@ public:
 			prop_name_str = prop_name_str.capitalize() + ":";
 			prop_name->set_text(prop_name_str);
 			prop_name->set_visible(false);
+			prop_name->add_theme_font_override("font", get_theme_font("main", "EditorFonts"));
 			hbox->add_child(prop_name);
 			prop_names.push_back(prop_name);
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -853,7 +853,9 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					hbc->add_child(rmbtn);
 					rmbtn->connect("pressed", callable_mp(this, &VisualScriptEditor::_remove_input_port), varray(E->get(), i), CONNECT_DEFERRED);
 				} else {
-					hbc->add_child(memnew(Label(left_name)));
+					Label *label = memnew(Label(left_name));
+					hbc->add_child(label);
+					label->add_theme_font_override("font", get_theme_font("main", "EditorFonts"));
 				}
 
 				if (left_type != Variant::NIL && !script->is_input_value_port_connected(E->get(), i)) {
@@ -932,7 +934,9 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 						hbc->add_child(memnew(Label(right_name)));
 					}
 				} else {
-					hbc->add_child(memnew(Label(right_name)));
+					Label *label = memnew(Label(right_name));
+					hbc->add_child(label);
+					label->add_theme_font_override("font", get_theme_font("main", "EditorFonts"));
 				}
 
 				Ref<Texture2D> t;
@@ -4340,6 +4344,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	Label *base_lbl = memnew(Label);
 	base_lbl->set_text(TTR("Change Base Type:") + " ");
+	base_lbl->add_theme_font_override("font", get_theme_font("main", "EditorFonts"));
 	graph_hbc->add_child(base_lbl);
 
 	base_type_select = memnew(Button);


### PR DESCRIPTION
I think currently (after the #49148) GraphNode's in VisualShaders and VisualScripts are looking incorrectly:

![image](https://user-images.githubusercontent.com/3036176/120620130-5747db00-c465-11eb-867a-11347ab67ae6.png)

I think the bold font should be assigned to node's captions instead, and use standart (main) font for the ports and other stuff. So I've changed it to:

![image](https://user-images.githubusercontent.com/3036176/120620254-76466d00-c465-11eb-939e-252391ce3c87.png)
