### PR TITLE
Rename `String.is_abs_path()` to `String.is_absolute_path()`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -62,7 +62,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 	}
 
 	if (p_path.begins_with("res://") || p_path.begins_with("user://") ||
-			(p_path.is_abs_path() && !p_path.begins_with(resource_path))) {
+			(p_path.is_absolute_path() && !p_path.begins_with(resource_path))) {
 		return p_path.simplify_path();
 	}
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3786,7 +3786,7 @@ String String::humanize_size(uint64_t p_size) {
 	return String::num(p_size / divisor).pad_decimals(digits) + " " + prefixes[prefix_idx];
 }
 
-bool String::is_abs_path() const {
+bool String::is_absolute_path() const {
 	if (length() > 1) {
 		return (operator[](0) == '/' || operator[](0) == '\\' || find(":/") != -1 || find(":\\") != -1);
 	} else if ((length()) == 1) {
@@ -4396,7 +4396,7 @@ bool String::is_resource_file() const {
 }
 
 bool String::is_rel_path() const {
-	return !is_abs_path();
+	return !is_absolute_path();
 }
 
 String String::get_base_dir() const {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -397,7 +397,7 @@ public:
 	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 
 	// path functions
-	bool is_abs_path() const;
+	bool is_absolute_path() const;
 	bool is_rel_path() const;
 	bool is_resource_file() const;
 	String path_to(const String &p_path) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1365,7 +1365,7 @@ static void _register_variant_builtin_methods() {
 	// FIXME: Static function, not sure how to bind
 	//bind_method(String, humanize_size, sarray("size"), varray());
 
-	bind_method(String, is_abs_path, sarray(), varray());
+	bind_method(String, is_absolute_path, sarray(), varray());
 	bind_method(String, is_rel_path, sarray(), varray());
 	bind_method(String, get_base_dir, sarray(), varray());
 	bind_method(String, get_file, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -275,7 +275,7 @@
 				Returns a copy of the string with the substring [code]what[/code] inserted at the given position.
 			</description>
 		</method>
-		<method name="is_abs_path" qualifiers="const">
+		<method name="is_absolute_path" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -208,7 +208,7 @@ String DirAccessWindows::get_current_dir(bool p_include_drive) {
 bool DirAccessWindows::file_exists(String p_file) {
 	GLOBAL_LOCK_FUNCTION
 
-	if (!p_file.is_abs_path()) {
+	if (!p_file.is_absolute_path()) {
 		p_file = get_current_dir().plus_file(p_file);
 	}
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -151,7 +151,7 @@ void EditorExportPreset::set_export_path(const String &p_path) {
 	export_path = p_path;
 	/* NOTE(SonerSound): if there is a need to implement a PropertyHint that specifically indicates a relative path,
 	 * this should be removed. */
-	if (export_path.is_abs_path()) {
+	if (export_path.is_absolute_path()) {
 		String res_path = OS::get_singleton()->get_resource_dir();
 		export_path = res_path.path_to_file(export_path);
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -770,7 +770,7 @@ void EditorNode::_resources_changed(const Vector<String> &p_resources) {
 		if (!res->editor_can_reload_from_file()) {
 			continue;
 		}
-		if (!res->get_path().is_resource_file() && !res->get_path().is_abs_path()) {
+		if (!res->get_path().is_resource_file() && !res->get_path().is_absolute_path()) {
 			continue;
 		}
 		if (!FileAccess::exists(res->get_path())) {

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -126,7 +126,7 @@ static Error _parse_material_library(const String &p_path, Map<String, Ref<Stand
 
 			String p = l.replace("map_Kd", "").replace("\\", "/").strip_edges();
 			String path;
-			if (p.is_abs_path()) {
+			if (p.is_absolute_path()) {
 				path = p;
 			} else {
 				path = base_path.plus_file(p);
@@ -146,7 +146,7 @@ static Error _parse_material_library(const String &p_path, Map<String, Ref<Stand
 
 			String p = l.replace("map_Ks", "").replace("\\", "/").strip_edges();
 			String path;
-			if (p.is_abs_path()) {
+			if (p.is_absolute_path()) {
 				path = p;
 			} else {
 				path = base_path.plus_file(p);
@@ -166,7 +166,7 @@ static Error _parse_material_library(const String &p_path, Map<String, Ref<Stand
 
 			String p = l.replace("map_Ns", "").replace("\\", "/").strip_edges();
 			String path;
-			if (p.is_abs_path()) {
+			if (p.is_absolute_path()) {
 				path = p;
 			} else {
 				path = base_path.plus_file(p);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2169,7 +2169,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 	if (err == OK) {
 		const GDScriptParser::ClassNode *c = parser.get_tree();
 		if (r_icon_path) {
-			if (c->icon_path.is_empty() || c->icon_path.is_abs_path()) {
+			if (c->icon_path.is_empty() || c->icon_path.is_absolute_path()) {
 				*r_icon_path = c->icon_path;
 			} else if (c->icon_path.is_rel_path()) {
 				*r_icon_path = p_path.get_base_dir().plus_file(c->icon_path).simplify_path();

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -80,7 +80,7 @@ String cwd() {
 }
 
 String abspath(const String &p_path) {
-	if (p_path.is_abs_path()) {
+	if (p_path.is_absolute_path()) {
 		return p_path.simplify_path();
 	} else {
 		return path::join(path::cwd(), p_path).simplify_path();

--- a/platform/android/plugin/godot_plugin_config.h
+++ b/platform/android/plugin/godot_plugin_config.h
@@ -102,7 +102,7 @@ struct PluginConfigAndroid {
 static inline String resolve_local_dependency_path(String plugin_config_dir, String dependency_path) {
 	String absolute_path;
 	if (!dependency_path.is_empty()) {
-		if (dependency_path.is_abs_path()) {
+		if (dependency_path.is_absolute_path()) {
 			absolute_path = ProjectSettings::get_singleton()->globalize_path(dependency_path);
 		} else {
 			absolute_path = plugin_config_dir.plus_file(dependency_path);

--- a/platform/iphone/plugin/godot_plugin_config.h
+++ b/platform/iphone/plugin/godot_plugin_config.h
@@ -104,7 +104,7 @@ static inline String resolve_local_dependency_path(String plugin_config_dir, Str
 		return absolute_path;
 	}
 
-	if (dependency_path.is_abs_path()) {
+	if (dependency_path.is_absolute_path()) {
 		return dependency_path;
 	}
 
@@ -121,7 +121,7 @@ static inline String resolve_system_dependency_path(String dependency_path) {
 		return absolute_path;
 	}
 
-	if (dependency_path.is_abs_path()) {
+	if (dependency_path.is_absolute_path()) {
 		return dependency_path;
 	}
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -166,7 +166,7 @@ bool OS_LinuxBSD::_check_internal_feature_support(const String &p_feature) {
 
 String OS_LinuxBSD::get_config_path() const {
 	if (has_environment("XDG_CONFIG_HOME")) {
-		if (get_environment("XDG_CONFIG_HOME").is_abs_path()) {
+		if (get_environment("XDG_CONFIG_HOME").is_absolute_path()) {
 			return get_environment("XDG_CONFIG_HOME");
 		} else {
 			WARN_PRINT_ONCE("`XDG_CONFIG_HOME` is a relative path. Ignoring its value and falling back to `$HOME/.config` or `.` per the XDG Base Directory specification.");
@@ -181,7 +181,7 @@ String OS_LinuxBSD::get_config_path() const {
 
 String OS_LinuxBSD::get_data_path() const {
 	if (has_environment("XDG_DATA_HOME")) {
-		if (get_environment("XDG_DATA_HOME").is_abs_path()) {
+		if (get_environment("XDG_DATA_HOME").is_absolute_path()) {
 			return get_environment("XDG_DATA_HOME");
 		} else {
 			WARN_PRINT_ONCE("`XDG_DATA_HOME` is a relative path. Ignoring its value and falling back to `$HOME/.local/share` or `get_config_path()` per the XDG Base Directory specification.");
@@ -196,7 +196,7 @@ String OS_LinuxBSD::get_data_path() const {
 
 String OS_LinuxBSD::get_cache_path() const {
 	if (has_environment("XDG_CACHE_HOME")) {
-		if (get_environment("XDG_CACHE_HOME").is_abs_path()) {
+		if (get_environment("XDG_CACHE_HOME").is_absolute_path()) {
 			return get_environment("XDG_CACHE_HOME");
 		} else {
 			WARN_PRINT_ONCE("`XDG_CACHE_HOME` is a relative path. Ignoring its value and falling back to `$HOME/.cache` or `get_config_path()` per the XDG Base Directory specification.");

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -190,7 +190,7 @@ MainLoop *OS_OSX::get_main_loop() const {
 String OS_OSX::get_config_path() const {
 	// The XDG Base Directory specification technically only applies on Linux/*BSD, but it doesn't hurt to support it on macOS as well.
 	if (has_environment("XDG_CONFIG_HOME")) {
-		if (get_environment("XDG_CONFIG_HOME").is_abs_path()) {
+		if (get_environment("XDG_CONFIG_HOME").is_absolute_path()) {
 			return get_environment("XDG_CONFIG_HOME");
 		} else {
 			WARN_PRINT_ONCE("`XDG_CONFIG_HOME` is a relative path. Ignoring its value and falling back to `$HOME/Library/Application Support` or `.` per the XDG Base Directory specification.");
@@ -205,7 +205,7 @@ String OS_OSX::get_config_path() const {
 String OS_OSX::get_data_path() const {
 	// The XDG Base Directory specification technically only applies on Linux/*BSD, but it doesn't hurt to support it on macOS as well.
 	if (has_environment("XDG_DATA_HOME")) {
-		if (get_environment("XDG_DATA_HOME").is_abs_path()) {
+		if (get_environment("XDG_DATA_HOME").is_absolute_path()) {
 			return get_environment("XDG_DATA_HOME");
 		} else {
 			WARN_PRINT_ONCE("`XDG_DATA_HOME` is a relative path. Ignoring its value and falling back to `get_config_path()` per the XDG Base Directory specification.");
@@ -217,7 +217,7 @@ String OS_OSX::get_data_path() const {
 String OS_OSX::get_cache_path() const {
 	// The XDG Base Directory specification technically only applies on Linux/*BSD, but it doesn't hurt to support it on macOS as well.
 	if (has_environment("XDG_CACHE_HOME")) {
-		if (get_environment("XDG_CACHE_HOME").is_abs_path()) {
+		if (get_environment("XDG_CACHE_HOME").is_absolute_path()) {
 			return get_environment("XDG_CACHE_HOME");
 		} else {
 			WARN_PRINT_ONCE("`XDG_CACHE_HOME` is a relative path. Ignoring its value and falling back to `$HOME/Libary/Caches` or `get_config_path()` per the XDG Base Directory specification.");

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -633,7 +633,7 @@ MainLoop *OS_Windows::get_main_loop() const {
 String OS_Windows::get_config_path() const {
 	// The XDG Base Directory specification technically only applies on Linux/*BSD, but it doesn't hurt to support it on Windows as well.
 	if (has_environment("XDG_CONFIG_HOME")) {
-		if (get_environment("XDG_CONFIG_HOME").is_abs_path()) {
+		if (get_environment("XDG_CONFIG_HOME").is_absolute_path()) {
 			return get_environment("XDG_CONFIG_HOME");
 		} else {
 			WARN_PRINT_ONCE("`XDG_CONFIG_HOME` is a relative path. Ignoring its value and falling back to `%APPDATA%` or `.` per the XDG Base Directory specification.");
@@ -648,7 +648,7 @@ String OS_Windows::get_config_path() const {
 String OS_Windows::get_data_path() const {
 	// The XDG Base Directory specification technically only applies on Linux/*BSD, but it doesn't hurt to support it on Windows as well.
 	if (has_environment("XDG_DATA_HOME")) {
-		if (get_environment("XDG_DATA_HOME").is_abs_path()) {
+		if (get_environment("XDG_DATA_HOME").is_absolute_path()) {
 			return get_environment("XDG_DATA_HOME");
 		} else {
 			WARN_PRINT_ONCE("`XDG_DATA_HOME` is a relative path. Ignoring its value and falling back to `get_config_path()` per the XDG Base Directory specification.");
@@ -660,7 +660,7 @@ String OS_Windows::get_data_path() const {
 String OS_Windows::get_cache_path() const {
 	// The XDG Base Directory specification technically only applies on Linux/*BSD, but it doesn't hurt to support it on Windows as well.
 	if (has_environment("XDG_CACHE_HOME")) {
-		if (get_environment("XDG_CACHE_HOME").is_abs_path()) {
+		if (get_environment("XDG_CACHE_HOME").is_absolute_path()) {
 			return get_environment("XDG_CACHE_HOME");
 		} else {
 			WARN_PRINT_ONCE("`XDG_CACHE_HOME` is a relative path. Ignoring its value and falling back to `%TEMP%` or `get_config_path()` per the XDG Base Directory specification.");

--- a/tests/test_string.h
+++ b/tests/test_string.h
@@ -1130,7 +1130,7 @@ TEST_CASE("[String] Path functions") {
 		CHECK(String(path[i]).get_basename() == base_name[i]);
 		CHECK(String(path[i]).get_extension() == ext[i]);
 		CHECK(String(path[i]).get_file() == file[i]);
-		CHECK(String(path[i]).is_abs_path() == abs[i]);
+		CHECK(String(path[i]).is_absolute_path() == abs[i]);
 		CHECK(String(path[i]).is_rel_path() != abs[i]);
 		CHECK(String(path[i]).simplify_path().get_base_dir().plus_file(file[i]) == String(path[i]).simplify_path());
 	}


### PR DESCRIPTION
This is more consistent with `NodePath.is_absolute()`.

See https://github.com/godotengine/godot/issues/16863#issuecomment-845276240.