### PR TITLE
[3.x] Fix RichTextLabel auto-wrapping on CJK texts

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -393,11 +393,17 @@ void Label::regenerate_word_cache() {
 			current = String::char_uppercase(current);
 		}
 
-		// ranges taken from http://www.unicodemap.org/
+		// ranges taken from https://en.wikipedia.org/wiki/Plane_(Unicode)
 		// if your language is not well supported, consider helping improve
 		// the unicode support in Godot.
-		bool separatable = (current >= 0x2E08 && current <= 0xFAFF) || (current >= 0xFE30 && current <= 0xFE4F);
-		//current>=33 && (current < 65||current >90) && (current<97||current>122) && (current<48||current>57);
+		bool separatable = (current >= 0x2E08 && current <= 0x9FFF) || // CJK scripts and symbols.
+						   (current >= 0xAC00 && current <= 0xD7FF) || // Hangul Syllables and Hangul Jamo Extended-B.
+						   (current >= 0xF900 && current <= 0xFAFF) || // CJK Compatibility Ideographs.
+						   (current >= 0xFE30 && current <= 0xFE4F) || // CJK Compatibility Forms.
+						   (current >= 0xFF65 && current <= 0xFF9F) || // Halfwidth forms of katakana
+						   (current >= 0xFFA0 && current <= 0xFFDC) || // Halfwidth forms of compatibility jamo characters for Hangul
+						   (current >= 0x20000 && current <= 0x2FA1F) || // CJK Unified Ideographs Extension B ~ F and CJK Compatibility Ideographs Supplement.
+						   (current >= 0x30000 && current <= 0x3134F); // CJK Unified Ideographs Extension G.
 		bool insert_newline = false;
 		real_t char_width = 0;
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -386,12 +386,14 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 					l.char_count += text->text.length();
 				}
 
+				bool just_breaked_in_middle = false;
 				rchar = 0;
 				FontDrawer drawer(font, Color(1, 1, 1));
 				while (*c) {
 					int end = 0;
 					int w = 0;
 					int fw = 0;
+					bool was_separatable = false;
 
 					lh = 0;
 
@@ -409,6 +411,25 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 						if (end > 0 && w + cw + begin > p_width) {
 							break; //don't allow lines longer than assigned width
 						}
+
+						// For info about the unicode range, see Label::regenerate_word_cache.
+						const CharType current = c[end];
+						const bool separatable = (current >= 0x2E08 && current <= 0x9FFF) || // CJK scripts and symbols.
+												 (current >= 0xAC00 && current <= 0xD7FF) || // Hangul Syllables and Hangul Jamo Extended-B.
+												 (current >= 0xF900 && current <= 0xFAFF) || // CJK Compatibility Ideographs.
+												 (current >= 0xFE30 && current <= 0xFE4F) || // CJK Compatibility Forms.
+												 (current >= 0xFF65 && current <= 0xFF9F) || // Halfwidth forms of katakana
+												 (current >= 0xFFA0 && current <= 0xFFDC) || // Halfwidth forms of compatibility jamo characters for Hangul
+												 (current >= 0x20000 && current <= 0x2FA1F) || // CJK Unified Ideographs Extension B ~ F and CJK Compatibility Ideographs Supplement.
+												 (current >= 0x30000 && current <= 0x3134F); // CJK Unified Ideographs Extension G.
+						const bool long_separatable = separatable && (wofs - backtrack + w + cw > p_width);
+						const bool separation_changed = end > 0 && was_separatable != separatable;
+						if (!just_breaked_in_middle && (long_separatable || separation_changed)) {
+							just_breaked_in_middle = true;
+							break;
+						}
+						was_separatable = separatable;
+						just_breaked_in_middle = false;
 
 						w += cw;
 						fw += cw;


### PR DESCRIPTION
This PR fixes #21482.

There is still 1 px difference between when they wrap the last character after this fix. This is becauses `Label` autowraps if the text chunk width >= frame width, while `RichTextLabel` autowraps if text chunk width > frame width. I think this is not related to the original issue and worth a dedicated PR if desired.

Complex Text Layout on the `master` branch is the proper way to solve the wrapping problem, but it seems that it won't be backported.

This PR also supersedes #45290. I also added a fix to solve the issue mentioned in https://github.com/godotengine/godot/pull/45290#issuecomment-762410458, allowing word breaking on CJK and non-CJK edge. I'll revert this additional fix if it should be a separate PR.

---

Before:  (there is unexpected linebreak after "Hopefully, ", and "should" wraps after "sh")
![before](https://user-images.githubusercontent.com/372476/121187636-dc365880-c89a-11eb-84f5-1fad36fbd8c9.png)

After:
![after](https://user-images.githubusercontent.com/372476/121187640-dd678580-c89a-11eb-83ec-e42e95757cdc.png)

