### PR TITLE
Replace `get_settings_dir` with `get_config_dir` when fetching configuration paths

### DIFF
--- a/doc/classes/EditorPaths.xml
+++ b/doc/classes/EditorPaths.xml
@@ -31,12 +31,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_settings_dir" qualifiers="const">
-			<return type="String">
-			</return>
-			<description>
-			</description>
-		</method>
 		<method name="is_self_contained" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2754,7 +2754,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			OS::get_singleton()->shell_open(String("file://") + EditorPaths::get_singleton()->get_data_dir());
 		} break;
 		case SETTINGS_EDITOR_CONFIG_FOLDER: {
-			OS::get_singleton()->shell_open(String("file://") + EditorPaths::get_singleton()->get_settings_dir());
+			OS::get_singleton()->shell_open(String("file://") + EditorPaths::get_singleton()->get_config_dir());
 		} break;
 		case SETTINGS_MANAGE_EXPORT_TEMPLATES: {
 			export_template_manager->popup_manager();

--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -38,9 +38,6 @@ bool EditorPaths::are_paths_valid() const {
 	return paths_valid;
 }
 
-String EditorPaths::get_settings_dir() const {
-	return settings_dir;
-}
 String EditorPaths::get_data_dir() const {
 	return data_dir;
 }
@@ -67,7 +64,6 @@ void EditorPaths::free() {
 }
 
 void EditorPaths::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_settings_dir"), &EditorPaths::get_settings_dir);
 	ClassDB::bind_method(D_METHOD("get_data_dir"), &EditorPaths::get_data_dir);
 	ClassDB::bind_method(D_METHOD("get_config_dir"), &EditorPaths::get_config_dir);
 	ClassDB::bind_method(D_METHOD("get_cache_dir"), &EditorPaths::get_cache_dir);

--- a/editor/editor_paths.h
+++ b/editor/editor_paths.h
@@ -37,7 +37,6 @@ class EditorPaths : public Object {
 	GDCLASS(EditorPaths, Object)
 
 	bool paths_valid = false;
-	String settings_dir;
 	String data_dir; //editor data dir
 	String config_dir; //editor config dir
 	String cache_dir; //editor cache dir
@@ -52,7 +51,6 @@ protected:
 public:
 	bool are_paths_valid() const;
 
-	String get_settings_dir() const;
 	String get_data_dir() const;
 	String get_config_dir() const;
 	String get_cache_dir() const;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1264,11 +1264,11 @@ String EditorSettings::get_project_settings_dir() const {
 }
 
 String EditorSettings::get_text_editor_themes_dir() const {
-	return EditorPaths::get_singleton()->get_settings_dir().plus_file("text_editor_themes");
+	return EditorPaths::get_singleton()->get_config_dir().plus_file("text_editor_themes");
 }
 
 String EditorSettings::get_script_templates_dir() const {
-	return EditorPaths::get_singleton()->get_settings_dir().plus_file("script_templates");
+	return EditorPaths::get_singleton()->get_config_dir().plus_file("script_templates");
 }
 
 String EditorSettings::get_project_script_templates_dir() const {
@@ -1278,7 +1278,7 @@ String EditorSettings::get_project_script_templates_dir() const {
 // Cache directory
 
 String EditorSettings::get_feature_profiles_dir() const {
-	return EditorPaths::get_singleton()->get_settings_dir().plus_file("feature_profiles");
+	return EditorPaths::get_singleton()->get_config_dir().plus_file("feature_profiles");
 }
 
 // Metadata
@@ -1505,7 +1505,7 @@ Vector<String> EditorSettings::get_script_templates(const String &p_extension, c
 }
 
 String EditorSettings::get_editor_layouts_config() const {
-	return EditorPaths::get_singleton()->get_settings_dir().plus_file("editor_layouts.cfg");
+	return EditorPaths::get_singleton()->get_config_dir().plus_file("editor_layouts.cfg");
 }
 
 // Shortcuts


### PR DESCRIPTION
Fixes #49257. This issue was also appearing with other things, like script templates (if you try to create a new GDScript script without this fix you won't get any templates suggested).

This regression happened in #49050 as editor paths were refactored. According to @reduz `get_settings_dir` is outdated and `get_config_dir` should be used instead (they are equivalent — `settings_dir` used to point to the same directory, and after #49050 it wasn't set anymore, hence this issue).