### PR TITLE
Add description To "hide_bottom_panel()" method In `EditorPlugin`

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -512,6 +512,7 @@
 			<return type="void">
 			</return>
 			<description>
+				Minimizes the bottom panel.
 			</description>
 		</method>
 		<method name="make_bottom_panel_item_visible">


### PR DESCRIPTION
This description was missing from the documentation. Based on some simple testing I've done, this function simply minimizes the bottom panel in the editor whenever it's called.