### PR TITLE
String::format leave passed values untouched

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3382,16 +3382,9 @@ String String::format(const Variant &values, String placeholder) const {
 				if (value_arr.size() == 2) {
 					Variant v_key = value_arr[0];
 					String key = v_key;
-					if (key.left(1) == "\"" && key.right(1) == "\"") {
-						key = key.substr(1, key.length() - 2);
-					}
 
 					Variant v_val = value_arr[1];
 					String val = v_val;
-
-					if (val.left(1) == "\"" && val.right(1) == "\"") {
-						val = val.substr(1, val.length() - 2);
-					}
 
 					new_string = new_string.replace(placeholder.replace("_", key), val);
 				} else {
@@ -3400,10 +3393,6 @@ String String::format(const Variant &values, String placeholder) const {
 			} else { //Array structure ["RobotGuy","Logis","rookie"]
 				Variant v_val = values_arr[i];
 				String val = v_val;
-
-				if (val.left(1) == "\"" && val.right(1) == "\"") {
-					val = val.substr(1, val.length() - 2);
-				}
 
 				if (placeholder.find("_") > -1) {
 					new_string = new_string.replace(placeholder.replace("_", i_as_str), val);
@@ -3420,14 +3409,6 @@ String String::format(const Variant &values, String placeholder) const {
 		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
 			String key = E->get();
 			String val = d[E->get()];
-
-			if (key.left(1) == "\"" && key.right(1) == "\"") {
-				key = key.substr(1, key.length() - 2);
-			}
-
-			if (val.left(1) == "\"" && val.right(1) == "\"") {
-				val = val.substr(1, val.length() - 2);
-			}
 
 			new_string = new_string.replace(placeholder.replace("_", key), val);
 		}


### PR DESCRIPTION
For some reason since the initial implementation of ``String::format`` the key and value will get modified if it starts
and end with double quotation marks. As far as I see there is no real reason in why that's the case.

I also looked at the usages of format in the code base and didn't saw any obvious reason for why that's the case.

---

Fixes #49262

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
