### PR TITLE
Fix "Filter Files" shortcut by merging duplicate functions

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1985,20 +1985,6 @@ void FileSystemDock::_resource_created() {
 	editor->save_resource_as(RES(r), fpath);
 }
 
-void FileSystemDock::_focus_current_search_box() {
-	LineEdit *current_search_box = nullptr;
-	if (display_mode == DISPLAY_MODE_TREE_ONLY) {
-		current_search_box = tree_search_box;
-	} else if (display_mode == DISPLAY_MODE_SPLIT) {
-		current_search_box = file_list_search_box;
-	}
-
-	if (current_search_box) {
-		current_search_box->grab_focus();
-		current_search_box->select_all();
-	}
-}
-
 void FileSystemDock::_search_changed(const String &p_text, const Control *p_from) {
 	if (searched_string.length() == 0) {
 		// Register the uncollapsed paths before they change.
@@ -2040,7 +2026,17 @@ void FileSystemDock::fix_dependencies(const String &p_for_file) {
 }
 
 void FileSystemDock::focus_on_filter() {
-	file_list_search_box->grab_focus();
+	LineEdit *current_search_box = nullptr;
+	if (display_mode == DISPLAY_MODE_TREE_ONLY) {
+		current_search_box = tree_search_box;
+	} else if (display_mode == DISPLAY_MODE_SPLIT) {
+		current_search_box = file_list_search_box;
+	}
+
+	if (current_search_box) {
+		current_search_box->grab_focus();
+		current_search_box->select_all();
+	}
 }
 
 void FileSystemDock::set_file_list_display_mode(FileListDisplayMode p_mode) {
@@ -2590,7 +2586,7 @@ void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
 		} else if (ED_IS_SHORTCUT("filesystem_dock/rename", p_event)) {
 			_tree_rmb_option(FILE_RENAME);
 		} else if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
-			_focus_current_search_box();
+			focus_on_filter();
 		} else {
 			return;
 		}
@@ -2611,7 +2607,7 @@ void FileSystemDock::_file_list_gui_input(Ref<InputEvent> p_event) {
 		} else if (ED_IS_SHORTCUT("filesystem_dock/rename", p_event)) {
 			_file_list_rmb_option(FILE_RENAME);
 		} else if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
-			_focus_current_search_box();
+			focus_on_filter();
 		} else {
 			return;
 		}

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -253,7 +253,6 @@ private:
 
 	void _toggle_split_mode(bool p_active);
 
-	void _focus_current_search_box();
 	void _search_changed(const String &p_text, const Control *p_from);
 
 	MenuButton *_create_file_menu_button();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

There's a "Filter Files..." shortcut which selects filter bar inside of filesystem_dock globally. This fixes an issue where the shortcut only works when filesystem is in split mode by merging two duplicate functions, one which didn't focus on the correct filter bar when not in split mode