### PR TITLE
EditorSettings: Look for binding while filtering too

### DIFF
--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -261,10 +261,6 @@ void EditorSettingsDialog::_update_shortcuts() {
 	for (OrderedHashMap<StringName, InputMap::Action>::Element E = action_map.front(); E; E = E.next()) {
 		String action_name = E.key();
 
-		if (!shortcut_filter.is_subsequence_ofi(action_name)) {
-			continue;
-		}
-
 		InputMap::Action action = E.get();
 
 		Array events; // Need to get the list of events into an array so it can be set as metadata on the item.
@@ -297,6 +293,10 @@ void EditorSettingsDialog::_update_shortcuts() {
 
 		// Join the text of the events with a delimiter so they can all be displayed in one cell.
 		String events_display_string = event_strings.is_empty() ? "None" : String("; ").join(event_strings);
+
+		if (!shortcut_filter.is_subsequence_ofi(action_name) && (events_display_string == "None" || !shortcut_filter.is_subsequence_ofi(events_display_string))) {
+			continue;
+		}
 
 		TreeItem *item = shortcuts->create_item(common_section);
 		item->set_text(0, action_name);


### PR DESCRIPTION
Currently we only filter for the action name in the common section while we filter for action name and binding in the other sections.
With this change we find results based on the binding and action name of a common shortcut

Fixes #49294