### PR TITLE
Rename Animation TYPE_TRANSFORM to TYPE_TRANSFORM3D

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -727,8 +727,8 @@
 		<constant name="TYPE_VALUE" value="0" enum="TrackType">
 			Value tracks set values in node properties, but only those which can be Interpolated.
 		</constant>
-		<constant name="TYPE_TRANSFORM" value="1" enum="TrackType">
-			Transform tracks are used to change node local transforms or skeleton pose bones. Transitions are interpolated.
+		<constant name="TYPE_TRANSFORM3D" value="1" enum="TrackType">
+			Transform3D tracks are used to change node local transforms or skeleton pose bones of 3D nodes. Transitions are interpolated.
 		</constant>
 		<constant name="TYPE_METHOD" value="2" enum="TrackType">
 			Method tracks call functions with given arguments per key.

--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -24,7 +24,7 @@
 			<return type="Transform3D">
 			</return>
 			<description>
-				Retrieve the motion of the [member root_motion_track] as a [Transform3D] that can be used elsewhere. If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_TRANSFORM], returns an identity transformation.
+				Retrieve the motion of the [member root_motion_track] as a [Transform3D] that can be used elsewhere. If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_TRANSFORM3D], returns an identity transformation.
 			</description>
 		</method>
 		<method name="rename_parameter">
@@ -50,7 +50,7 @@
 		</member>
 		<member name="root_motion_track" type="NodePath" setter="set_root_motion_track" getter="get_root_motion_track" default="NodePath(&quot;&quot;)">
 			The path to the Animation track used for root motion. Paths must be valid scene-tree paths to a node, and must be specified starting from the parent node of the node that will reproduce the animation. To specify a track that controls properties or bones, append its name after the path, separated by [code]":"[/code]. For example, [code]"character/skeleton:ankle"[/code] or [code]"character/mesh:transform/local"[/code].
-			If the track has type [constant Animation.TYPE_TRANSFORM], the transformation will be cancelled visually, and the animation will appear to stay in place.
+			If the track has type [constant Animation.TYPE_TRANSFORM3D], the transformation will be cancelled visually, and the animation will appear to stay in place.
 		</member>
 		<member name="tree_root" type="AnimationNode" setter="set_tree_root" getter="get_tree_root">
 			The root animation node of this [AnimationTree]. See [AnimationNode].

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -165,7 +165,7 @@ public:
 		}
 
 		switch (animation->track_get_type(track)) {
-			case Animation::TYPE_TRANSFORM: {
+			case Animation::TYPE_TRANSFORM3D: {
 				Dictionary d_old = animation->track_get_key_value(track, key);
 				Dictionary d_new = d_old.duplicate();
 				d_new[p_name] = p_value;
@@ -412,7 +412,7 @@ public:
 		}
 
 		switch (animation->track_get_type(track)) {
-			case Animation::TYPE_TRANSFORM: {
+			case Animation::TYPE_TRANSFORM3D: {
 				Dictionary d = animation->track_get_key_value(track, key);
 				ERR_FAIL_COND_V(!d.has(name), false);
 				r_ret = d[p_name];
@@ -523,7 +523,7 @@ public:
 		}
 
 		switch (animation->track_get_type(track)) {
-			case Animation::TYPE_TRANSFORM: {
+			case Animation::TYPE_TRANSFORM3D: {
 				p_list->push_back(PropertyInfo(Variant::VECTOR3, "location"));
 				p_list->push_back(PropertyInfo(Variant::QUAT, "rotation"));
 				p_list->push_back(PropertyInfo(Variant::VECTOR3, "scale"));
@@ -781,7 +781,7 @@ public:
 				}
 
 				switch (animation->track_get_type(track)) {
-					case Animation::TYPE_TRANSFORM: {
+					case Animation::TYPE_TRANSFORM3D: {
 						Dictionary d_old = animation->track_get_key_value(track, key);
 						Dictionary d_new = d_old.duplicate();
 						d_new[p_name] = p_value;
@@ -1012,7 +1012,7 @@ public:
 				}
 
 				switch (animation->track_get_type(track)) {
-					case Animation::TYPE_TRANSFORM: {
+					case Animation::TYPE_TRANSFORM3D: {
 						Dictionary d = animation->track_get_key_value(track, key);
 						ERR_FAIL_COND_V(!d.has(name), false);
 						r_ret = d[p_name];
@@ -1162,7 +1162,7 @@ public:
 
 		if (same_track_type) {
 			switch (animation->track_get_type(first_track)) {
-				case Animation::TYPE_TRANSFORM: {
+				case Animation::TYPE_TRANSFORM3D: {
 					p_list->push_back(PropertyInfo(Variant::VECTOR3, "location"));
 					p_list->push_back(PropertyInfo(Variant::QUAT, "rotation"));
 					p_list->push_back(PropertyInfo(Variant::VECTOR3, "scale"));
@@ -2007,7 +2007,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				interp_mode_rect.position.y = int(get_size().height - icon->get_height()) / 2;
 				interp_mode_rect.size = icon->get_size();
 
-				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM) {
+				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM3D) {
 					draw_texture(icon, interp_mode_rect.position);
 				}
 				//make it easier to click
@@ -2017,7 +2017,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				ofs += icon->get_width() + hsep;
 				interp_mode_rect.size.x += hsep;
 
-				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM) {
+				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM3D) {
 					draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
 					interp_mode_rect.size.x += down_icon->get_width();
 				} else {
@@ -2040,7 +2040,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				loop_mode_rect.position.y = int(get_size().height - icon->get_height()) / 2;
 				loop_mode_rect.size = icon->get_size();
 
-				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM) {
+				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM3D) {
 					draw_texture(icon, loop_mode_rect.position);
 				}
 
@@ -2050,7 +2050,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				ofs += icon->get_width() + hsep;
 				loop_mode_rect.size.x += hsep;
 
-				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM) {
+				if (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_TRANSFORM3D) {
 					draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
 					loop_mode_rect.size.x += down_icon->get_width();
 				} else {
@@ -2441,7 +2441,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 		if (key_idx != -1) {
 			String text = TTR("Time (s): ") + rtos(animation->track_get_key_time(track, key_idx)) + "\n";
 			switch (animation->track_get_type(track)) {
-				case Animation::TYPE_TRANSFORM: {
+				case Animation::TYPE_TRANSFORM3D: {
 					Dictionary d = animation->track_get_key_value(track, key_idx);
 					if (d.has("location")) {
 						text += "Pos: " + String(d["location"]) + "\n";
@@ -3310,7 +3310,7 @@ static bool track_type_is_resettable(Animation::TrackType p_type) {
 			[[fallthrough]];
 		case Animation::TYPE_BEZIER:
 			[[fallthrough]];
-		case Animation::TYPE_TRANSFORM:
+		case Animation::TYPE_TRANSFORM3D:
 			return true;
 		default:
 			return false;
@@ -3479,7 +3479,7 @@ void AnimationTrackEditor::insert_transform_key(Node3D *p_node, const String &p_
 	int track_idx = -1;
 
 	for (int i = 0; i < animation->get_track_count(); i++) {
-		if (animation->track_get_type(i) != Animation::TYPE_TRANSFORM) {
+		if (animation->track_get_type(i) != Animation::TYPE_TRANSFORM3D) {
 			continue;
 		}
 		if (animation->track_get_path(i) != np) {
@@ -3496,7 +3496,7 @@ void AnimationTrackEditor::insert_transform_key(Node3D *p_node, const String &p_
 	id.path = np;
 	id.track_idx = track_idx;
 	id.value = p_xform;
-	id.type = Animation::TYPE_TRANSFORM;
+	id.type = Animation::TYPE_TRANSFORM3D;
 	id.query = "node '" + p_node->get_name() + "'";
 	id.advance = false;
 
@@ -3945,7 +3945,7 @@ AnimationTrackEditor::TrackIndices AnimationTrackEditor::_confirm_insert(InsertD
 			value = p_id.value;
 
 		} break;
-		case Animation::TYPE_TRANSFORM: {
+		case Animation::TYPE_TRANSFORM3D: {
 			Transform3D tr = p_id.value;
 			Dictionary d;
 			d["location"] = tr.origin;
@@ -4368,8 +4368,8 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 	ERR_FAIL_COND(!node);
 	NodePath path_to = root->get_path_to(node);
 
-	if (adding_track_type == Animation::TYPE_TRANSFORM && !node->is_class("Node3D")) {
-		EditorNode::get_singleton()->show_warning(TTR("Transform tracks only apply to 3D-based nodes."));
+	if (adding_track_type == Animation::TYPE_TRANSFORM3D && !node->is_class("Node3D")) {
+		EditorNode::get_singleton()->show_warning(TTR("Transform3D tracks only apply to 3D-based nodes."));
 		return;
 	}
 
@@ -4379,7 +4379,7 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 			prop_selector->set_type_filter(Vector<Variant::Type>());
 			prop_selector->select_property_from_instance(node);
 		} break;
-		case Animation::TYPE_TRANSFORM:
+		case Animation::TYPE_TRANSFORM3D:
 		case Animation::TYPE_METHOD: {
 			undo_redo->create_action(TTR("Add Track"));
 			undo_redo->add_do_method(animation.ptr(), "add_track", adding_track_type);
@@ -4548,7 +4548,7 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 	}
 
 	switch (animation->track_get_type(p_track)) {
-		case Animation::TYPE_TRANSFORM: {
+		case Animation::TYPE_TRANSFORM3D: {
 			if (!root->has_node(animation->track_get_path(p_track))) {
 				EditorNode::get_singleton()->show_warning(TTR("Track path is invalid, so can't add a key."));
 				return;
@@ -5182,7 +5182,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				}
 
 				switch (animation->track_get_type(i)) {
-					case Animation::TYPE_TRANSFORM:
+					case Animation::TYPE_TRANSFORM3D:
 						text += " (Transform)";
 						break;
 					case Animation::TYPE_METHOD:

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1461,7 +1461,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 			continue;
 		}
 
-		animation->add_track(Animation::TYPE_TRANSFORM);
+		animation->add_track(Animation::TYPE_TRANSFORM3D);
 		int track = animation->get_track_count() - 1;
 		animation->track_set_path(track, path);
 		animation->track_set_imported(track, true); //helps merging later
@@ -1584,7 +1584,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 				continue;
 			}
 
-			animation->add_track(Animation::TYPE_TRANSFORM);
+			animation->add_track(Animation::TYPE_TRANSFORM3D);
 			int track = animation->get_track_count() - 1;
 			animation->track_set_path(track, path);
 			animation->track_set_imported(track, true); //helps merging later

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -856,7 +856,7 @@ void ResourceImporterScene::_create_clips(AnimationPlayer *anim, const Array &p_
 						new_anim->track_set_path(dtrack, default_anim->track_get_path(j));
 
 						if (kt > (from + 0.01) && k > 0) {
-							if (default_anim->track_get_type(j) == Animation::TYPE_TRANSFORM) {
+							if (default_anim->track_get_type(j) == Animation::TYPE_TRANSFORM3D) {
 								Quat q;
 								Vector3 p;
 								Vector3 s;
@@ -870,7 +870,7 @@ void ResourceImporterScene::_create_clips(AnimationPlayer *anim, const Array &p_
 						}
 					}
 
-					if (default_anim->track_get_type(j) == Animation::TYPE_TRANSFORM) {
+					if (default_anim->track_get_type(j) == Animation::TYPE_TRANSFORM3D) {
 						Quat q;
 						Vector3 p;
 						Vector3 s;
@@ -884,7 +884,7 @@ void ResourceImporterScene::_create_clips(AnimationPlayer *anim, const Array &p_
 				}
 
 				if (dtrack != -1 && kt >= to) {
-					if (default_anim->track_get_type(j) == Animation::TYPE_TRANSFORM) {
+					if (default_anim->track_get_type(j) == Animation::TYPE_TRANSFORM3D) {
 						Quat q;
 						Vector3 p;
 						Vector3 s;
@@ -902,7 +902,7 @@ void ResourceImporterScene::_create_clips(AnimationPlayer *anim, const Array &p_
 				new_anim->add_track(default_anim->track_get_type(j));
 				dtrack = new_anim->get_track_count() - 1;
 				new_anim->track_set_path(dtrack, default_anim->track_get_path(j));
-				if (default_anim->track_get_type(j) == Animation::TYPE_TRANSFORM) {
+				if (default_anim->track_get_type(j) == Animation::TYPE_TRANSFORM3D) {
 					Quat q;
 					Vector3 p;
 					Vector3 s;

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -1011,7 +1011,7 @@ Node3D *EditorSceneImporterFBX::_generate_scene(
 						// track count is 5.
 						// next track id is 5.
 						const uint64_t target_id = track->key();
-						int track_idx = animation->add_track(Animation::TYPE_TRANSFORM);
+						int track_idx = animation->add_track(Animation::TYPE_TRANSFORM3D);
 
 						// animation->track_set_path(track_idx, node_path);
 						Ref<FBXBone> bone;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5673,7 +5673,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 		if ((track.rotation_track.values.size() || track.translation_track.values.size() || track.scale_track.values.size()) && !transform_affects_skinned_mesh_instance) {
 			//make transform track
 			int track_idx = animation->get_track_count();
-			animation->add_track(Animation::TYPE_TRANSFORM);
+			animation->add_track(Animation::TYPE_TRANSFORM3D);
 			animation->track_set_path(track_idx, transform_node_path);
 			//first determine animation length
 
@@ -6020,7 +6020,7 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 		times.write[key_i] = p_animation->track_get_key_time(p_track_i, key_i);
 	}
 	const float BAKE_FPS = 30.0f;
-	if (track_type == Animation::TYPE_TRANSFORM) {
+	if (track_type == Animation::TYPE_TRANSFORM3D) {
 		p_track.translation_track.times = times;
 		p_track.translation_track.interpolation = gltf_interpolation;
 		p_track.rotation_track.times = times;

--- a/scene/animation/animation_cache.cpp
+++ b/scene/animation/animation_cache.cpp
@@ -80,10 +80,10 @@ void AnimationCache::_update_cache() {
 
 		Ref<Resource> res;
 
-		if (animation->track_get_type(i) == Animation::TYPE_TRANSFORM) {
+		if (animation->track_get_type(i) == Animation::TYPE_TRANSFORM3D) {
 			if (np.get_subname_count() > 1) {
 				path_cache.push_back(Path());
-				ERR_CONTINUE_MSG(animation->track_get_type(i) == Animation::TYPE_TRANSFORM, "Transform tracks can't have a subpath '" + np + "'.");
+				ERR_CONTINUE_MSG(animation->track_get_type(i) == Animation::TYPE_TRANSFORM3D, "Transform tracks can't have a subpath '" + np + "'.");
 			}
 
 			Node3D *sp = Object::cast_to<Node3D>(node);
@@ -231,7 +231,7 @@ void AnimationCache::set_all(float p_time, float p_delta) {
 	int tc = animation->get_track_count();
 	for (int i = 0; i < tc; i++) {
 		switch (animation->track_get_type(i)) {
-			case Animation::TYPE_TRANSFORM: {
+			case Animation::TYPE_TRANSFORM3D: {
 				Vector3 loc, scale;
 				Quat rot;
 				animation->transform_track_interpolate(i, p_time, &loc, &rot, &scale);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -279,7 +279,7 @@ void AnimationPlayer::_ensure_node_caches(AnimationData *p_anim, Node *p_root_ov
 		p_anim->node_cache[i]->node = child;
 		p_anim->node_cache[i]->resource = resource;
 		p_anim->node_cache[i]->node_2d = Object::cast_to<Node2D>(child);
-		if (a->track_get_type(i) == Animation::TYPE_TRANSFORM) {
+		if (a->track_get_type(i) == Animation::TYPE_TRANSFORM3D) {
 			// special cases and caches for transform tracks
 
 			// cache spatial
@@ -366,7 +366,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 		}
 
 		switch (a->track_get_type(i)) {
-			case Animation::TYPE_TRANSFORM: {
+			case Animation::TYPE_TRANSFORM3D: {
 				if (!nc->spatial) {
 					continue;
 				}

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -581,7 +581,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 						track = track_value;
 
 					} break;
-					case Animation::TYPE_TRANSFORM: {
+					case Animation::TYPE_TRANSFORM3D: {
 						Node3D *spatial = Object::cast_to<Node3D>(child);
 
 						if (!spatial) {
@@ -844,7 +844,7 @@ void AnimationTree::_process_graph(float p_delta) {
 				}
 
 				switch (track->type) {
-					case Animation::TYPE_TRANSFORM: {
+					case Animation::TYPE_TRANSFORM3D: {
 						TrackCacheTransform *t = static_cast<TrackCacheTransform *>(track);
 
 						if (track->root_motion) {
@@ -1188,7 +1188,7 @@ void AnimationTree::_process_graph(float p_delta) {
 			}
 
 			switch (track->type) {
-				case Animation::TYPE_TRANSFORM: {
+				case Animation::TYPE_TRANSFORM3D: {
 					TrackCacheTransform *t = static_cast<TrackCacheTransform *>(track);
 
 					Transform3D xform;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -193,7 +193,7 @@ private:
 		Vector3 scale;
 
 		TrackCacheTransform() {
-			type = Animation::TYPE_TRANSFORM;
+			type = Animation::TYPE_TRANSFORM3D;
 		}
 	};
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -43,8 +43,8 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 		if (tracks.size() == track && what == "type") {
 			String type = p_value;
 
-			if (type == "transform") {
-				add_track(TYPE_TRANSFORM);
+			if (type == "transform" || type == "transform3d") {
+				add_track(TYPE_TRANSFORM3D);
 			} else if (type == "value") {
 				add_track(TYPE_VALUE);
 			} else if (type == "method") {
@@ -75,7 +75,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (what == "enabled") {
 			track_set_enabled(track, p_value);
 		} else if (what == "keys" || what == "key_values") {
-			if (track_get_type(track) == TYPE_TRANSFORM) {
+			if (track_get_type(track) == TYPE_TRANSFORM3D) {
 				TransformTrack *tt = static_cast<TransformTrack *>(tracks[track]);
 				Vector<float> values = p_value;
 				int vcount = values.size();
@@ -318,7 +318,7 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 		ERR_FAIL_INDEX_V(track, tracks.size(), false);
 		if (what == "type") {
 			switch (track_get_type(track)) {
-				case TYPE_TRANSFORM:
+				case TYPE_TRANSFORM3D:
 					r_ret = "transform";
 					break;
 				case TYPE_VALUE:
@@ -351,7 +351,7 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 		} else if (what == "enabled") {
 			r_ret = track_is_enabled(track);
 		} else if (what == "keys") {
-			if (track_get_type(track) == TYPE_TRANSFORM) {
+			if (track_get_type(track) == TYPE_TRANSFORM3D) {
 				Vector<float> keys;
 				int kk = track_get_key_count(track);
 				keys.resize(kk * 12);
@@ -590,7 +590,7 @@ int Animation::add_track(TrackType p_type, int p_at_pos) {
 	}
 
 	switch (p_type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = memnew(TransformTrack);
 			tracks.insert(p_at_pos, tt);
 		} break;
@@ -628,7 +628,7 @@ void Animation::remove_track(int p_track) {
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			_clear(tt->transforms);
 
@@ -671,7 +671,7 @@ int Animation::get_track_count() const {
 }
 
 Animation::TrackType Animation::track_get_type(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), TYPE_TRANSFORM);
+	ERR_FAIL_INDEX_V(p_track, tracks.size(), TYPE_TRANSFORM3D);
 	return tracks[p_track]->type;
 }
 
@@ -778,7 +778,7 @@ Error Animation::transform_track_get_key(int p_track, int p_key, Vector3 *r_loc,
 	Track *t = tracks[p_track];
 
 	TransformTrack *tt = static_cast<TransformTrack *>(t);
-	ERR_FAIL_COND_V(t->type != TYPE_TRANSFORM, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(t->type != TYPE_TRANSFORM3D, ERR_INVALID_PARAMETER);
 	ERR_FAIL_INDEX_V(p_key, tt->transforms.size(), ERR_INVALID_PARAMETER);
 
 	if (r_loc) {
@@ -797,7 +797,7 @@ Error Animation::transform_track_get_key(int p_track, int p_key, Vector3 *r_loc,
 int Animation::transform_track_insert_key(int p_track, float p_time, const Vector3 &p_loc, const Quat &p_rot, const Vector3 &p_scale) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
-	ERR_FAIL_COND_V(t->type != TYPE_TRANSFORM, -1);
+	ERR_FAIL_COND_V(t->type != TYPE_TRANSFORM3D, -1);
 
 	TransformTrack *tt = static_cast<TransformTrack *>(t);
 
@@ -823,7 +823,7 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			ERR_FAIL_INDEX(p_idx, tt->transforms.size());
 			tt->transforms.remove(p_idx);
@@ -869,7 +869,7 @@ int Animation::track_find_key(int p_track, float p_time, bool p_exact) const {
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			int k = _find(tt->transforms, p_time);
 			if (k < 0 || k >= tt->transforms.size()) {
@@ -951,7 +951,7 @@ void Animation::track_insert_key(int p_track, float p_time, const Variant &p_key
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			Dictionary d = p_key;
 			Vector3 loc;
 			if (d.has("location")) {
@@ -1053,7 +1053,7 @@ int Animation::track_get_key_count(int p_track) const {
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			return tt->transforms.size();
 		} break;
@@ -1088,7 +1088,7 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			ERR_FAIL_INDEX_V(p_key_idx, tt->transforms.size(), Variant());
 
@@ -1156,7 +1156,7 @@ float Animation::track_get_key_time(int p_track, int p_key_idx) const {
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			ERR_FAIL_INDEX_V(p_key_idx, tt->transforms.size(), -1);
 			return tt->transforms[p_key_idx].time;
@@ -1201,7 +1201,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, float p_time) {
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, tt->transforms.size());
 			TKey<TransformKey> key = tt->transforms[p_key_idx];
@@ -1265,7 +1265,7 @@ float Animation::track_get_key_transition(int p_track, int p_key_idx) const {
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			ERR_FAIL_INDEX_V(p_key_idx, tt->transforms.size(), -1);
 			return tt->transforms[p_key_idx].transition;
@@ -1301,7 +1301,7 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, tt->transforms.size());
 
@@ -1384,7 +1384,7 @@ void Animation::track_set_key_transition(int p_track, int p_key_idx, float p_tra
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, tt->transforms.size());
 			tt->transforms.write[p_key_idx].transition = p_transition;
@@ -1731,7 +1731,7 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, float p_time, Interpola
 Error Animation::transform_track_interpolate(int p_track, float p_time, Vector3 *r_loc, Quat *r_rot, Vector3 *r_scale) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
-	ERR_FAIL_COND_V(t->type != TYPE_TRANSFORM, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(t->type != TYPE_TRANSFORM3D, ERR_INVALID_PARAMETER);
 
 	TransformTrack *tt = static_cast<TransformTrack *>(t);
 
@@ -1932,7 +1932,7 @@ void Animation::track_get_key_indices_in_range(int p_track, float p_time, float 
 			// handle loop by splitting
 
 			switch (t->type) {
-				case TYPE_TRANSFORM: {
+				case TYPE_TRANSFORM3D: {
 					const TransformTrack *tt = static_cast<const TransformTrack *>(t);
 					_track_get_key_indices_in_range(tt->transforms, from_time, length, p_indices);
 					_track_get_key_indices_in_range(tt->transforms, 0, to_time, p_indices);
@@ -1988,7 +1988,7 @@ void Animation::track_get_key_indices_in_range(int p_track, float p_time, float 
 	}
 
 	switch (t->type) {
-		case TYPE_TRANSFORM: {
+		case TYPE_TRANSFORM3D: {
 			const TransformTrack *tt = static_cast<const TransformTrack *>(t);
 			_track_get_key_indices_in_range(tt->transforms, from_time, to_time, p_indices);
 
@@ -2681,7 +2681,7 @@ void Animation::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("tracks_changed"));
 
 	BIND_ENUM_CONSTANT(TYPE_VALUE);
-	BIND_ENUM_CONSTANT(TYPE_TRANSFORM);
+	BIND_ENUM_CONSTANT(TYPE_TRANSFORM3D);
 	BIND_ENUM_CONSTANT(TYPE_METHOD);
 	BIND_ENUM_CONSTANT(TYPE_BEZIER);
 	BIND_ENUM_CONSTANT(TYPE_AUDIO);
@@ -2877,7 +2877,7 @@ bool Animation::_transform_track_optimize_key(const TKey<TransformKey> &t0, cons
 
 void Animation::_transform_track_optimize(int p_idx, float p_allowed_linear_err, float p_allowed_angular_err, float p_max_optimizable_angle) {
 	ERR_FAIL_INDEX(p_idx, tracks.size());
-	ERR_FAIL_COND(tracks[p_idx]->type != TYPE_TRANSFORM);
+	ERR_FAIL_COND(tracks[p_idx]->type != TYPE_TRANSFORM3D);
 	TransformTrack *tt = static_cast<TransformTrack *>(tracks[p_idx]);
 	bool prev_erased = false;
 	TKey<TransformKey> first_erased;
@@ -2917,7 +2917,7 @@ void Animation::_transform_track_optimize(int p_idx, float p_allowed_linear_err,
 
 void Animation::optimize(float p_allowed_linear_err, float p_allowed_angular_err, float p_max_optimizable_angle) {
 	for (int i = 0; i < tracks.size(); i++) {
-		if (tracks[i]->type == TYPE_TRANSFORM) {
+		if (tracks[i]->type == TYPE_TRANSFORM3D) {
 			_transform_track_optimize(i, p_allowed_linear_err, p_allowed_angular_err, p_max_optimizable_angle);
 		}
 	}

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -42,7 +42,7 @@ class Animation : public Resource {
 public:
 	enum TrackType {
 		TYPE_VALUE, ///< Set a value in a property, can be interpolated.
-		TYPE_TRANSFORM, ///< Transform a node or a bone.
+		TYPE_TRANSFORM3D, ///< Transform a node or a bone.
 		TYPE_METHOD, ///< Call any method on a specific node.
 		TYPE_BEZIER, ///< Bezier curve
 		TYPE_AUDIO,
@@ -97,7 +97,7 @@ private:
 	struct TransformTrack : public Track {
 		Vector<TKey<TransformKey>> transforms;
 
-		TransformTrack() { type = TYPE_TRANSFORM; }
+		TransformTrack() { type = TYPE_TRANSFORM3D; }
 	};
 
 	/* PROPERTY VALUE TRACK */


### PR DESCRIPTION
Follow-up to #38430. I noticed this while rebasing another PR on top of #38430's merge commit.

I'm not against having 2D transform animations or anything, but the current logic is hard-coded to work with 3D, ex:

```cpp
if (adding_track_type == Animation::TYPE_TRANSFORM && !node->is_class("Node3D")) {
	EditorNode::get_singleton()->show_warning(TTR("Transform tracks only apply to 3D-based nodes."));
	return;
}
```