### PR TITLE
Rename EditorPropertyTransform to EditorPropertyTransform3D

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2078,7 +2078,7 @@ EditorPropertyBasis::EditorPropertyBasis() {
 
 ///////////////////// TRANSFORM /////////////////////////
 
-void EditorPropertyTransform::_value_changed(double val, const String &p_name) {
+void EditorPropertyTransform3D::_value_changed(double val, const String &p_name) {
 	if (setting) {
 		return;
 	}
@@ -2100,11 +2100,11 @@ void EditorPropertyTransform::_value_changed(double val, const String &p_name) {
 	emit_changed(get_edited_property(), p, p_name);
 }
 
-void EditorPropertyTransform::update_property() {
+void EditorPropertyTransform3D::update_property() {
 	update_using_transform(get_edited_object()->get(get_edited_property()));
 }
 
-void EditorPropertyTransform::update_using_transform(Transform3D p_transform) {
+void EditorPropertyTransform3D::update_using_transform(Transform3D p_transform) {
 	setting = true;
 	spin[0]->set_value(p_transform.basis[0][0]);
 	spin[1]->set_value(p_transform.basis[1][0]);
@@ -2121,7 +2121,7 @@ void EditorPropertyTransform::update_using_transform(Transform3D p_transform) {
 	setting = false;
 }
 
-void EditorPropertyTransform::_notification(int p_what) {
+void EditorPropertyTransform3D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
 		Color base = get_theme_color("accent_color", "Editor");
 		for (int i = 0; i < 12; i++) {
@@ -2132,10 +2132,10 @@ void EditorPropertyTransform::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyTransform::_bind_methods() {
+void EditorPropertyTransform3D::_bind_methods() {
 }
 
-void EditorPropertyTransform::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
+void EditorPropertyTransform3D::setup(double p_min, double p_max, double p_step, bool p_no_slider) {
 	for (int i = 0; i < 12; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
@@ -2146,7 +2146,7 @@ void EditorPropertyTransform::setup(double p_min, double p_max, double p_step, b
 	}
 }
 
-EditorPropertyTransform::EditorPropertyTransform() {
+EditorPropertyTransform3D::EditorPropertyTransform3D() {
 	GridContainer *g = memnew(GridContainer);
 	g->set_columns(3);
 	add_child(g);
@@ -2159,7 +2159,7 @@ EditorPropertyTransform::EditorPropertyTransform() {
 		g->add_child(spin[i]);
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
-		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyTransform::_value_changed), varray(desc[i]));
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyTransform3D::_value_changed), varray(desc[i]));
 	}
 	set_bottom_editor(g);
 	setting = false;
@@ -3108,7 +3108,7 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			add_property_editor(p_path, editor);
 		} break;
 		case Variant::TRANSFORM3D: {
-			EditorPropertyTransform *editor = memnew(EditorPropertyTransform);
+			EditorPropertyTransform3D *editor = memnew(EditorPropertyTransform3D);
 			double min = -65535, max = 65535, step = default_float_step;
 			bool hide_slider = true;
 

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -529,8 +529,8 @@ public:
 	EditorPropertyBasis();
 };
 
-class EditorPropertyTransform : public EditorProperty {
-	GDCLASS(EditorPropertyTransform, EditorProperty);
+class EditorPropertyTransform3D : public EditorProperty {
+	GDCLASS(EditorPropertyTransform3D, EditorProperty);
 	EditorSpinSlider *spin[12];
 	bool setting;
 	void _value_changed(double p_val, const String &p_name);
@@ -543,7 +543,7 @@ public:
 	virtual void update_property() override;
 	virtual void update_using_transform(Transform3D p_transform);
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider);
-	EditorPropertyTransform();
+	EditorPropertyTransform3D();
 };
 
 class EditorPropertyColor : public EditorProperty {

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -869,7 +869,7 @@ void EditorPropertyDictionary::update_property() {
 
 				} break;
 				case Variant::TRANSFORM3D: {
-					EditorPropertyTransform *editor = memnew(EditorPropertyTransform);
+					EditorPropertyTransform3D *editor = memnew(EditorPropertyTransform3D);
 					editor->setup(-100000, 100000, 0.001, true);
 					prop = editor;
 

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -95,7 +95,7 @@ void BoneTransformEditor::create_editors() {
 	section->get_vbox()->add_child(transform_section);
 
 	// Transform/Matrix property
-	transform_property = memnew(EditorPropertyTransform());
+	transform_property = memnew(EditorPropertyTransform3D());
 	transform_property->setup(-10000, 10000, 0.001f, true);
 	transform_property->set_label("Transform");
 	transform_property->set_use_folding(true);

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -41,7 +41,7 @@ class PhysicalBone3D;
 class Skeleton3DEditorPlugin;
 class Button;
 class CheckBox;
-class EditorPropertyTransform;
+class EditorPropertyTransform3D;
 class EditorPropertyVector3;
 
 class BoneTransformEditor : public VBoxContainer {
@@ -53,7 +53,7 @@ class BoneTransformEditor : public VBoxContainer {
 	EditorPropertyVector3 *rotation_property = nullptr;
 	EditorPropertyVector3 *scale_property = nullptr;
 	EditorInspectorSection *transform_section = nullptr;
-	EditorPropertyTransform *transform_property = nullptr;
+	EditorPropertyTransform3D *transform_property = nullptr;
 
 	Rect2 background_rects[5];
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4689,7 +4689,7 @@ Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_par
 		if (Object::cast_to<EditorPropertyResource>(prop)) {
 			Object::cast_to<EditorPropertyResource>(prop)->set_use_sub_inspector(false);
 			prop->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-		} else if (Object::cast_to<EditorPropertyTransform>(prop) || Object::cast_to<EditorPropertyVector3>(prop)) {
+		} else if (Object::cast_to<EditorPropertyTransform3D>(prop) || Object::cast_to<EditorPropertyVector3>(prop)) {
 			prop->set_custom_minimum_size(Size2(250 * EDSCALE, 0));
 		} else if (Object::cast_to<EditorPropertyFloat>(prop)) {
 			prop->set_custom_minimum_size(Size2(100 * EDSCALE, 0));


### PR DESCRIPTION
Follow-up to #38430. I noticed this while rebasing another PR on top of #38430's merge commit.