### PR TITLE
Improve xr gdnative

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -3243,6 +3243,25 @@ bool RenderingDeviceVulkan::texture_is_format_supported_for_usage(DataFormat p_f
 	return true;
 }
 
+// for now to get access to VkImage
+uint64_t RenderingDeviceVulkan::texture_get_vulkan_image(const RID p_texture) {
+	_THREAD_SAFE_METHOD_
+
+	Texture *tex = texture_owner.getornull(p_texture);
+	ERR_FAIL_NULL_V(tex, 0);
+
+	return (uint64_t)tex->image;
+}
+
+uint32_t RenderingDeviceVulkan::texture_get_vulkan_image_format(const RID p_texture) {
+	_THREAD_SAFE_METHOD_
+
+	Texture *tex = texture_owner.getornull(p_texture);
+	ERR_FAIL_NULL_V(tex, 0);
+
+	return vulkan_formats[tex->format];
+}
+
 /********************/
 /**** ATTACHMENT ****/
 /********************/
@@ -7010,7 +7029,7 @@ Error RenderingDeviceVulkan::_draw_list_allocate(const Rect2i &p_viewport, uint3
 				VkCommandPoolCreateInfo cmd_pool_info;
 				cmd_pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
 				cmd_pool_info.pNext = nullptr;
-				cmd_pool_info.queueFamilyIndex = context->get_graphics_queue();
+				cmd_pool_info.queueFamilyIndex = context->get_graphics_queue_family_index();
 				cmd_pool_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 
 				VkResult res = vkCreateCommandPool(device, &cmd_pool_info, nullptr, &split_draw_list_allocators.write[i].command_pool);
@@ -8263,7 +8282,7 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 			VkCommandPoolCreateInfo cmd_pool_info;
 			cmd_pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
 			cmd_pool_info.pNext = nullptr;
-			cmd_pool_info.queueFamilyIndex = p_context->get_graphics_queue();
+			cmd_pool_info.queueFamilyIndex = p_context->get_graphics_queue_family_index();
 			cmd_pool_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 
 			VkResult res = vkCreateCommandPool(device, &cmd_pool_info, nullptr, &frames[i].command_pool);
@@ -8667,4 +8686,24 @@ RenderingDeviceVulkan::~RenderingDeviceVulkan() {
 		finalize();
 		context->local_device_free(local_device);
 	}
+}
+
+void *RenderingDeviceVulkan::get_vulkan_device() {
+	return context->get_device();
+}
+
+void *RenderingDeviceVulkan::get_vulkan_physical_device() {
+	return context->get_physical_device();
+}
+
+void *RenderingDeviceVulkan::get_vulkan_instance() {
+	return context->get_instance();
+}
+
+void *RenderingDeviceVulkan::get_vulkan_queue() {
+	return context->get_graphics_queue();
+}
+
+uint32_t RenderingDeviceVulkan::get_vulkan_queue_family_index() {
+	return context->get_graphics_queue_family_index();
 }

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1035,6 +1035,10 @@ public:
 	virtual Error texture_clear(RID p_texture, const Color &p_color, uint32_t p_base_mipmap, uint32_t p_mipmaps, uint32_t p_base_layer, uint32_t p_layers, uint32_t p_post_barrier = BARRIER_MASK_ALL);
 	virtual Error texture_resolve_multisample(RID p_from_texture, RID p_to_texture, uint32_t p_post_barrier = BARRIER_MASK_ALL);
 
+	// for now to get access to VkImage
+	virtual uint64_t texture_get_vulkan_image(const RID p_texture);
+	virtual uint32_t texture_get_vulkan_image_format(const RID p_texture);
+
 	/*********************/
 	/**** FRAMEBUFFER ****/
 	/*********************/
@@ -1208,6 +1212,13 @@ public:
 
 	RenderingDeviceVulkan();
 	~RenderingDeviceVulkan();
+
+	// TODO this needs to be solved differently but for now to get things to work..
+	virtual void *get_vulkan_device();
+	virtual void *get_vulkan_physical_device();
+	virtual void *get_vulkan_instance();
+	virtual void *get_vulkan_queue();
+	virtual uint32_t get_vulkan_queue_family_index();
 };
 
 #endif // RENDERING_DEVICE_VULKAN_H

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -1995,11 +1995,19 @@ VkPhysicalDevice VulkanContext::get_physical_device() {
 	return gpu;
 }
 
+VkInstance VulkanContext::get_instance() {
+	return inst;
+}
+
 int VulkanContext::get_swapchain_image_count() const {
 	return swapchainImageCount;
 }
 
-uint32_t VulkanContext::get_graphics_queue() const {
+VkQueue VulkanContext::get_graphics_queue() const {
+	return graphics_queue;
+}
+
+uint32_t VulkanContext::get_graphics_queue_family_index() const {
 	return graphics_queue_family_index;
 }
 

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -228,7 +228,7 @@ protected:
 
 	Error _get_preferred_validation_layers(uint32_t *count, const char *const **names);
 
-	VkInstance _get_instance() {
+	VkInstance _get_instance() { // replace with get_instance?
 		return inst;
 	}
 
@@ -240,8 +240,10 @@ public:
 
 	VkDevice get_device();
 	VkPhysicalDevice get_physical_device();
+	VkInstance get_instance();
 	int get_swapchain_image_count() const;
-	uint32_t get_graphics_queue() const;
+	VkQueue get_graphics_queue() const;
+	uint32_t get_graphics_queue_family_index() const;
 
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);
 	int window_get_width(DisplayServer::WindowID p_window = 0);

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -5051,8 +5051,8 @@
 			"name": "xr",
 			"type": "XR",
 			"version": {
-				"major": 1,
-				"minor": 1
+				"major": 4,
+				"minor": 0
 			},
 			"next": null,
 			"api": [
@@ -5063,6 +5063,74 @@
 						[
 							"const godot_xr_interface_gdnative *",
 							"p_interface"
+						]
+					]
+				},
+				{
+					"name": "godot_xr_set_interface",
+					"return_type": "void",
+					"arguments": [
+						[
+							"godot_object *",
+							"p_xr_interface"
+						],
+						[
+							"const godot_xr_interface_gdnative *",
+							"p_gdn_interface"
+						]
+					]
+				},
+				{
+					"name": "godot_xr_blit_layer",
+					"return_type": "void",
+					"arguments": [
+						[
+							"void *",
+							"p_blit_to_screen"
+						],
+						[
+							"const godot_rid *",
+							"p_render_target"
+						],
+						[
+							"const godot_rect2 *",
+							"p_src_rect"
+						],
+						[
+							"const godot_rect2 *",
+							"p_dest_rect"
+						],
+						[
+							"godot_int",
+							"p_layer"
+						]
+					]
+				},
+				{
+					"name": "godot_xr_get_vulkan_data",
+					"return_type": "bool",
+					"arguments": [
+						[
+							"godot_xr_vulkan_data *",
+							"p_vulkan_data"
+						]
+					]
+				},
+				{
+					"name": "godot_xr_get_image_data",
+					"return_type": "bool",
+					"arguments": [
+						[
+							"const godot_rid *",
+							"p_vulkan_data"
+						],
+						[
+							"uint64_t *",
+							"p_texture_id"
+						],
+						[
+							"uint32_t *",
+							"p_format"
 						]
 					]
 				},

--- a/modules/gdnative/include/xr/godot_xr.h
+++ b/modules/gdnative/include/xr/godot_xr.h
@@ -48,7 +48,7 @@ typedef struct {
 	godot_gdnative_api_version version; /* version of our API */
 	void *(*constructor)(godot_object *);
 	void (*destructor)(void *);
-	godot_string (*get_name)(const void *);
+	void (*get_name)(const void *, godot_string *);
 	godot_int (*get_capabilities)(const void *);
 	godot_bool (*get_anchor_detection_is_enabled)(const void *);
 	void (*set_anchor_detection_is_enabled)(void *, godot_bool);
@@ -59,9 +59,9 @@ typedef struct {
 	godot_vector2 (*get_render_targetsize)(const void *);
 
 	godot_transform3d (*get_camera_transform)(void *);
-	godot_transform3d (*get_transform_for_view)(void *, godot_int, godot_transform3d *);
+	godot_transform3d (*get_transform_for_view)(void *, godot_int, const godot_transform3d *);
 	void (*fill_projection_for_view)(void *, godot_real_t *, godot_int, godot_real_t, godot_real_t, godot_real_t);
-	void (*commit_views)(void *, godot_rid *, godot_rect2 *);
+	void (*commit_views)(void *, void *, const godot_rid *, godot_rect2 *);
 
 	void (*process)(void *);
 	void (*notification)(void *, godot_int);
@@ -73,17 +73,33 @@ typedef struct {
 	godot_int (*get_external_depth_for_eye)(void *, godot_int);
 } godot_xr_interface_gdnative;
 
+// register our callback struct
 void GDAPI godot_xr_register_interface(const godot_xr_interface_gdnative *p_interface);
+void GDAPI godot_xr_set_interface(godot_object *p_xr_interface, const godot_xr_interface_gdnative *p_gdn_interface);
 
-// helper functions to access XRServer data
+// help functions for rendering
+void GDAPI godot_xr_blit_layer(void *p_blit_to_screen, const godot_rid *p_render_target, const godot_rect2 *p_src_rect, const godot_rect2 *p_dest_rect, godot_int p_layer);
+
+typedef struct {
+	void *device;
+	void *physical_device;
+	void *instance;
+	void *queue;
+	uint32_t queue_family_index;
+} godot_xr_vulkan_data;
+
+bool GDAPI godot_xr_get_vulkan_data(godot_xr_vulkan_data *p_vulkan_data);
+bool GDAPI godot_xr_get_image_data(const godot_rid *p_render_target, uint64_t *p_texture_id, uint32_t *p_format);
+
+// helper functions to access XRServer data (deprecated)
 godot_real_t GDAPI godot_xr_get_worldscale();
 godot_transform3d GDAPI godot_xr_get_reference_frame();
 
-// helper functions for rendering
+// helper functions for rendering (deprecated)
 void GDAPI godot_xr_blit(godot_int p_eye, godot_rid *p_render_target, godot_rect2 *p_rect);
 godot_int GDAPI godot_xr_get_texid(godot_rid *p_render_target);
 
-// helper functions for updating XR controllers
+// helper functions for updating XR controllers (deprecated)
 godot_int GDAPI godot_xr_add_controller(char *p_device_name, godot_int p_hand, godot_bool p_tracks_orientation, godot_bool p_tracks_position);
 void GDAPI godot_xr_remove_controller(godot_int p_controller_id);
 void GDAPI godot_xr_set_controller_transform(godot_int p_controller_id, godot_transform3d *p_transform, godot_bool p_tracks_orientation, godot_bool p_tracks_position);

--- a/modules/gdnative/xr/xr_interface_gdnative.h
+++ b/modules/gdnative/xr/xr_interface_gdnative.h
@@ -58,7 +58,7 @@ public:
 
 	void set_interface(const godot_xr_interface_gdnative *p_interface);
 
-	virtual StringName get_name() const override;
+	virtual String get_name() const override;
 	virtual int get_capabilities() const override;
 
 	virtual bool is_initialized() const override;
@@ -82,7 +82,7 @@ public:
 	// and a CameraMatrix version to XRServer
 	virtual CameraMatrix get_projection_for_view(uint32_t p_view, real_t p_aspect, real_t p_z_near, real_t p_z_far) override;
 
-	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) override;
+	virtual Vector<BlitToScreen> commit_views(const RID p_render_target, const Rect2 &p_screen_rect) override;
 
 	virtual void process() override;
 	virtual void notification(int p_what) override;

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -35,7 +35,7 @@
 #include "servers/display_server.h"
 #include "servers/rendering/rendering_server_globals.h"
 
-StringName MobileVRInterface::get_name() const {
+String MobileVRInterface::get_name() const {
 	return "Native mobile";
 };
 
@@ -454,7 +454,7 @@ void MobileVRInterface::commit_for_eye(XRInterface::Eyes p_eye, RID p_render_tar
 	eye_center.y = 0.0;
 }
 
-Vector<BlitToScreen> MobileVRInterface::commit_views(RID p_render_target, const Rect2 &p_screen_rect) {
+Vector<BlitToScreen> MobileVRInterface::commit_views(const RID p_render_target, const Rect2 &p_screen_rect) {
 	_THREAD_SAFE_METHOD_
 
 	Vector<BlitToScreen> blit_to_screen;
@@ -476,16 +476,16 @@ Vector<BlitToScreen> MobileVRInterface::commit_views(RID p_render_target, const 
 	blit.lens_distortion.aspect_ratio = aspect;
 
 	// left eye
-	blit.rect = p_screen_rect;
-	blit.rect.size.width *= 0.5;
+	blit.dest_rect = p_screen_rect;
+	blit.dest_rect.size.width *= 0.5;
 	blit.multi_view.layer = 0;
 	blit.lens_distortion.eye_center.x = ((-intraocular_dist / 2.0) + (display_width / 4.0)) / (display_width / 2.0);
 	blit_to_screen.push_back(blit);
 
 	// right eye
-	blit.rect = p_screen_rect;
-	blit.rect.size.width *= 0.5;
-	blit.rect.position.x = blit.rect.size.width;
+	blit.dest_rect = p_screen_rect;
+	blit.dest_rect.size.width *= 0.5;
+	blit.dest_rect.position.x = blit.dest_rect.size.width;
 	blit.multi_view.layer = 1;
 	blit.lens_distortion.eye_center.x = ((intraocular_dist / 2.0) - (display_width / 4.0)) / (display_width / 2.0);
 	blit_to_screen.push_back(blit);

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -130,7 +130,7 @@ public:
 	void set_k2(const real_t p_k2);
 	real_t get_k2() const;
 
-	virtual StringName get_name() const override;
+	virtual String get_name() const override;
 	virtual int get_capabilities() const override;
 
 	virtual bool is_initialized() const override;
@@ -142,7 +142,7 @@ public:
 	virtual Transform3D get_camera_transform() override;
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
 	virtual CameraMatrix get_projection_for_view(uint32_t p_view, real_t p_aspect, real_t p_z_near, real_t p_z_far) override;
-	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) override;
+	virtual Vector<BlitToScreen> commit_views(const RID p_render_target, const Rect2 &p_screen_rect) override;
 
 	virtual void process() override;
 	virtual void notification(int p_what) override {}

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -194,7 +194,7 @@ PackedVector3Array WebXRInterfaceJS::get_bounds_geometry() const {
 	return ret;
 }
 
-StringName WebXRInterfaceJS::get_name() const {
+String WebXRInterfaceJS::get_name() const {
 	return "WebXR";
 };
 

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -75,7 +75,7 @@ public:
 	virtual String get_visibility_state() const override;
 	virtual PackedVector3Array get_bounds_geometry() const override;
 
-	virtual StringName get_name() const override;
+	virtual String get_name() const override;
 	virtual int get_capabilities() const override;
 
 	virtual bool is_initialized() const override;

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -637,6 +637,7 @@ public:
 	void render_target_set_position(RID p_render_target, int p_x, int p_y) override {}
 	void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) override {}
 	RID render_target_get_texture(RID p_render_target) override { return RID(); }
+	RID render_target_get_color(RID p_render_target) override { return RID(); }
 	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) override {}
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) override {}
 	bool render_target_was_used(RID p_render_target) override { return false; }

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -41,7 +41,8 @@
 class RendererSceneRender;
 struct BlitToScreen {
 	RID render_target;
-	Rect2i rect;
+	Rect2 src_rect = Rect2(0.0, 0.0, 1.0, 1.0);
+	Rect2i dest_rect;
 
 	struct {
 		bool use_layer = false;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -65,10 +65,14 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 		RD::get_singleton()->draw_list_bind_index_array(draw_list, blit.array);
 		RD::get_singleton()->draw_list_bind_uniform_set(draw_list, render_target_descriptors[rd_texture], 0);
 
-		blit.push_constant.rect[0] = p_render_targets[i].rect.position.x / screen_size.width;
-		blit.push_constant.rect[1] = p_render_targets[i].rect.position.y / screen_size.height;
-		blit.push_constant.rect[2] = p_render_targets[i].rect.size.width / screen_size.width;
-		blit.push_constant.rect[3] = p_render_targets[i].rect.size.height / screen_size.height;
+		blit.push_constant.src_rect[0] = p_render_targets[i].src_rect.position.x;
+		blit.push_constant.src_rect[1] = p_render_targets[i].src_rect.position.y;
+		blit.push_constant.src_rect[2] = p_render_targets[i].src_rect.size.width;
+		blit.push_constant.src_rect[3] = p_render_targets[i].src_rect.size.height;
+		blit.push_constant.dst_rect[0] = p_render_targets[i].dest_rect.position.x / screen_size.width;
+		blit.push_constant.dst_rect[1] = p_render_targets[i].dest_rect.position.y / screen_size.height;
+		blit.push_constant.dst_rect[2] = p_render_targets[i].dest_rect.size.width / screen_size.width;
+		blit.push_constant.dst_rect[3] = p_render_targets[i].dest_rect.size.height / screen_size.height;
 		blit.push_constant.layer = p_render_targets[i].multi_view.layer;
 		blit.push_constant.eye_center[0] = p_render_targets[i].lens_distortion.eye_center.x;
 		blit.push_constant.eye_center[1] = p_render_targets[i].lens_distortion.eye_center.y;
@@ -204,10 +208,14 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 	RD::get_singleton()->draw_list_bind_index_array(draw_list, blit.array);
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uset, 0);
 
-	blit.push_constant.rect[0] = screenrect.position.x;
-	blit.push_constant.rect[1] = screenrect.position.y;
-	blit.push_constant.rect[2] = screenrect.size.width;
-	blit.push_constant.rect[3] = screenrect.size.height;
+	blit.push_constant.src_rect[0] = 0.0;
+	blit.push_constant.src_rect[1] = 0.0;
+	blit.push_constant.src_rect[2] = 1.0;
+	blit.push_constant.src_rect[3] = 1.0;
+	blit.push_constant.dst_rect[0] = screenrect.position.x;
+	blit.push_constant.dst_rect[1] = screenrect.position.y;
+	blit.push_constant.dst_rect[2] = screenrect.size.width;
+	blit.push_constant.dst_rect[3] = screenrect.size.height;
 	blit.push_constant.layer = 0;
 	blit.push_constant.eye_center[0] = 0;
 	blit.push_constant.eye_center[1] = 0;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -55,7 +55,8 @@ protected:
 	};
 
 	struct BlitPushConstant {
-		float rect[4];
+		float src_rect[4];
+		float dst_rect[4];
 
 		float eye_center[2];
 		float k1;

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -7105,6 +7105,13 @@ RID RendererStorageRD::render_target_get_texture(RID p_render_target) {
 	return rt->texture;
 }
 
+RID RendererStorageRD::render_target_get_color(RID p_render_target) {
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND_V(!rt, RID());
+
+	return rt->color;
+}
+
 void RendererStorageRD::render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) {
 }
 

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -2288,6 +2288,7 @@ public:
 	void render_target_set_position(RID p_render_target, int p_x, int p_y);
 	void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count);
 	RID render_target_get_texture(RID p_render_target);
+	RID render_target_get_color(RID p_render_target);
 	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id);
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value);
 	bool render_target_was_used(RID p_render_target);

--- a/servers/rendering/renderer_rd/shaders/blit.glsl
+++ b/servers/rendering/renderer_rd/shaders/blit.glsl
@@ -5,6 +5,7 @@
 #VERSION_DEFINES
 
 layout(push_constant, binding = 0, std140) uniform Pos {
+	vec4 src_rect;
 	vec4 dst_rect;
 
 	vec2 eye_center;
@@ -22,8 +23,8 @@ layout(location = 0) out vec2 uv;
 
 void main() {
 	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
-	uv = base_arr[gl_VertexIndex];
-	vec2 vtx = data.dst_rect.xy + uv * data.dst_rect.zw;
+	uv = data.src_rect.xy + base_arr[gl_VertexIndex] * data.src_rect.zw;
+	vec2 vtx = data.dst_rect.xy + base_arr[gl_VertexIndex] * data.dst_rect.zw;
 	gl_Position = vec4(vtx * 2.0 - 1.0, 0.0, 1.0);
 }
 
@@ -34,6 +35,7 @@ void main() {
 #VERSION_DEFINES
 
 layout(push_constant, binding = 0, std140) uniform Pos {
+	vec4 src_rect;
 	vec4 dst_rect;
 
 	vec2 eye_center;

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -575,6 +575,7 @@ public:
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y) = 0;
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) = 0;
 	virtual RID render_target_get_texture(RID p_render_target) = 0;
+	virtual RID render_target_get_color(RID p_render_target) = 0;
 	virtual void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) = 0;
 	virtual void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) = 0;
 	virtual bool render_target_was_used(RID p_render_target) = 0;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -587,10 +587,10 @@ void RendererViewport::draw_viewports() {
 				BlitToScreen blit;
 				blit.render_target = vp->render_target;
 				if (vp->viewport_to_screen_rect != Rect2()) {
-					blit.rect = vp->viewport_to_screen_rect;
+					blit.dest_rect = vp->viewport_to_screen_rect;
 				} else {
-					blit.rect.position = Vector2();
-					blit.rect.size = vp->size;
+					blit.dest_rect.position = Vector2();
+					blit.dest_rect.size = vp->size;
 				}
 
 				if (!blit_to_screen_list.has(vp->viewport_to_screen)) {

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -499,6 +499,10 @@ public:
 	virtual Error texture_clear(RID p_texture, const Color &p_color, uint32_t p_base_mipmap, uint32_t p_mipmaps, uint32_t p_base_layer, uint32_t p_layers, uint32_t p_post_barrier = BARRIER_MASK_ALL) = 0;
 	virtual Error texture_resolve_multisample(RID p_from_texture, RID p_to_texture, uint32_t p_post_barrier = BARRIER_MASK_ALL) = 0;
 
+	// for now to get access to VkImage
+	virtual uint64_t texture_get_vulkan_image(const RID p_texture) = 0;
+	virtual uint32_t texture_get_vulkan_image_format(const RID p_texture) = 0;
+
 	/*********************/
 	/**** FRAMEBUFFER ****/
 	/*********************/
@@ -1150,6 +1154,13 @@ public:
 
 	static RenderingDevice *get_singleton();
 	RenderingDevice();
+
+	// TODO this needs to be solved differently but for now to get things to work..
+	virtual void *get_vulkan_device() { return nullptr; };
+	virtual void *get_vulkan_physical_device() { return nullptr; };
+	virtual void *get_vulkan_instance() { return nullptr; };
+	virtual void *get_vulkan_queue() { return nullptr; };
+	virtual uint32_t get_vulkan_queue_family_index() { return 0; };
 
 protected:
 	//binders to script API

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -79,7 +79,7 @@ void XRInterface::_bind_methods() {
 	BIND_ENUM_CONSTANT(XR_NOT_TRACKING);
 };
 
-StringName XRInterface::get_name() const {
+String XRInterface::get_name() const {
 	return "Unknown";
 };
 

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -84,7 +84,7 @@ protected:
 
 public:
 	/** general interface information **/
-	virtual StringName get_name() const;
+	virtual String get_name() const;
 	virtual int get_capabilities() const = 0;
 
 	bool is_primary();
@@ -113,7 +113,7 @@ public:
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) = 0; /* get each views transform */
 	virtual CameraMatrix get_projection_for_view(uint32_t p_view, real_t p_aspect, real_t p_z_near, real_t p_z_far) = 0; /* get each view projection matrix */
 
-	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) = 0; /* commit rendered views to the XR interface */
+	virtual Vector<BlitToScreen> commit_views(const RID p_render_target, const Rect2 &p_screen_rect) = 0; /* commit rendered views to the XR interface */
 
 	virtual void process() = 0;
 	virtual void notification(int p_what) = 0;


### PR DESCRIPTION
Depends on #48207

This PR adds additional changes to XRInterfaceGDNative and related structures to enable writing XR plugins for Godot 4.

Breaking changes (some of these I'm still working on, some coming from 48207):
- Output now based on Vulkan renderer using `commit_views`
- `is_stereo` was replaced by `get_view_count`
- `get_name` now has String as parameter, not return value
- `godot_xr_get_worldscale` will be removed (use `XRServer`)
- 'godot_xr_get_reference_frame` will be removed (use `XRServer`)
- `godot_xr_*_controller*` will be removed (use `XRPositionalTracker`)

Currently deprecated but will be re-introduced in another form:
- `get_external_texture_for_eye`
- `get_external_depth_for_eye`
- 'commit_for_eye' (maybe, depends on the requirements of the OpenGL backend)
