### PR TITLE
Make 2D list tool show locked nodes for consistency

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2447,7 +2447,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 			// Popup the selection menu list
 			Point2 click = transform.affine_inverse().xform(b->get_position());
 
-			_get_canvas_items_at_pos(click, selection_results, b->is_alt_pressed() && tool != TOOL_LIST_SELECT);
+			_get_canvas_items_at_pos(click, selection_results, true);
 
 			if (selection_results.size() == 1) {
 				CanvasItem *item = selection_results[0].item;


### PR DESCRIPTION
When using list tool in 2D, locked nodes do not show up in the list. However, when pressing alt & right click with the select tool in 2D, it does show locked nodes. Also, when in 3D using the list tool or alt & right click in select tool also shows up locked nodes. This makes the 2D list tool show locked nodes for consistency with the others.

Old behavior:

https://user-images.githubusercontent.com/12120644/120791611-69c42200-c502-11eb-8816-2627d2f45e84.mp4

Alternative PR that hides locked nodes in all instead: #49306