### PR TITLE
Make sure `Tabs` reflect theme changes

### DIFF
--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -256,6 +256,7 @@ void Tabs::_notification(int p_what) {
 			_update_cache();
 			update();
 		} break;
+		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			for (int i = 0; i < tabs.size(); ++i) {
 				_shape(i);


### PR DESCRIPTION
Theme changes can affect the font and font size used, which `Tabs` only update on demand.
I think this only happens in `master` and only in `Tabs` (`TabContainer` seems to already handle theme changes).

Example:

![image](https://user-images.githubusercontent.com/11782833/120808550-d9153280-c551-11eb-8c9f-f679d541e0d0.png)

First tab was added before the node entered the tree, so before the theme was available.