### PR TITLE
Support for 3D sync to physics

### DIFF
--- a/doc/classes/StaticBody3D.xml
+++ b/doc/classes/StaticBody3D.xml
@@ -32,6 +32,9 @@
 			The physics material override for the body.
 			If a material is assigned to this property, it will be used instead of any other physics material, such as an inherited one.
 		</member>
+		<member name="sync_to_physics" type="bool" setter="set_sync_to_physics" getter="is_sync_to_physics_enabled" default="false">
+			If [code]true[/code] and [member kinematic_motion] is enabled, the body's movement will be synchronized to the physics frame. This is useful when animating movement via [AnimationPlayer], for example on moving platforms. Do [b]not[/b] use together with [method PhysicsBody3D.move_and_collide].
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -77,6 +77,10 @@ void CollisionObject3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
+			if (only_update_transform_changes) {
+				return;
+			}
+
 			if (area) {
 				PhysicsServer3D::get_singleton()->area_set_transform(rid, get_global_transform());
 			} else {
@@ -282,6 +286,14 @@ void CollisionObject3D::set_body_mode(PhysicsServer3D::BodyMode p_mode) {
 	}
 
 	PhysicsServer3D::get_singleton()->body_set_mode(rid, p_mode);
+}
+
+void CollisionObject3D::set_only_update_transform_changes(bool p_enable) {
+	only_update_transform_changes = p_enable;
+}
+
+bool CollisionObject3D::is_only_update_transform_changes_enabled() const {
+	return only_update_transform_changes;
 }
 
 void CollisionObject3D::_update_pickable() {

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -74,6 +74,8 @@ private:
 
 	Map<uint32_t, ShapeData> shapes;
 
+	bool only_update_transform_changes = false; // This is used for sync to physics.
+
 	bool capture_input_on_drag = false;
 	bool ray_pickable = true;
 
@@ -106,6 +108,9 @@ protected:
 	virtual void _mouse_exit();
 
 	void set_body_mode(PhysicsServer3D::BodyMode p_mode);
+
+	void set_only_update_transform_changes(bool p_enable);
+	bool is_only_update_transform_changes_enabled() const;
 
 public:
 	void set_collision_layer(uint32_t p_layer);

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -82,12 +82,15 @@ class StaticBody3D : public PhysicsBody3D {
 	Ref<PhysicsMaterial> physics_material_override;
 
 	bool kinematic_motion = false;
+	bool sync_to_physics = false;
+
+	Transform3D last_valid_transform;
+
+	void _direct_state_changed(Object *p_state);
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-
-	void _direct_state_changed(Object *p_state);
 
 public:
 	void set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override);
@@ -102,6 +105,8 @@ public:
 	virtual Vector3 get_linear_velocity() const override;
 	virtual Vector3 get_angular_velocity() const override;
 
+	virtual TypedArray<String> get_configuration_warnings() const override;
+
 	StaticBody3D();
 
 private:
@@ -111,6 +116,9 @@ private:
 
 	void set_kinematic_motion_enabled(bool p_enabled);
 	bool is_kinematic_motion_enabled() const;
+
+	void set_sync_to_physics(bool p_enable);
+	bool is_sync_to_physics_enabled() const;
 };
 
 class RigidBody3D : public PhysicsBody3D {
@@ -251,7 +259,7 @@ public:
 	void apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position = Vector3());
 	void apply_torque_impulse(const Vector3 &p_impulse);
 
-	TypedArray<String> get_configuration_warnings() const override;
+	virtual TypedArray<String> get_configuration_warnings() const override;
 
 	RigidBody3D();
 	~RigidBody3D();


### PR DESCRIPTION
Same implementation as in 2D, based on the code from PR #49327.

Closes https://github.com/godotengine/godot-proposals/issues/961.
Fixes #36334