### PR TITLE
Add header property to labels, revert non headers to regular font.

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -81,6 +81,9 @@
 		<member name="clip_text" type="bool" setter="set_clip_text" getter="is_clipping_text" default="false">
 			If [code]true[/code], the Label only shows the text that fits inside its bounding rectangle. It also lets you scale the node down freely.
 		</member>
+		<member name="header_mode" type="int" setter="set_header_mode" getter="get_header_mode" enum="Label.HeaderMode" default="0">
+			It is possible to use a preset header size for labels, which is useful when designing user interfaces. Check the respective theme properties for which font and size will be used for each.
+		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>
@@ -142,6 +145,14 @@
 		<constant name="VALIGN_FILL" value="3" enum="VAlign">
 			Align the whole text by spreading the rows.
 		</constant>
+		<constant name="HEADER_DISABLED" value="0" enum="HeaderMode">
+		</constant>
+		<constant name="HEADER_SMALL" value="1" enum="HeaderMode">
+		</constant>
+		<constant name="HEADER_MEDIUM" value="2" enum="HeaderMode">
+		</constant>
+		<constant name="HEADER_LARGE" value="3" enum="HeaderMode">
+		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="font" type="Font">
@@ -149,6 +160,18 @@
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Default text [Color] of the [Label].
+		</theme_item>
+		<theme_item name="font_header_large" type="Font">
+		</theme_item>
+		<theme_item name="font_header_large_size" type="int">
+		</theme_item>
+		<theme_item name="font_header_medium" type="Font">
+		</theme_item>
+		<theme_item name="font_header_medium_size" type="int">
+		</theme_item>
+		<theme_item name="font_header_small" type="Font">
+		</theme_item>
+		<theme_item name="font_header_small_size" type="int">
 		</theme_item>
 		<theme_item name="font_outline_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The tint of [Font]'s outline.

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -631,6 +631,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	additional_options_container->hide();
 
 	Label *opts_label = memnew(Label);
+	opts_label->set_header_mode(Label::HEADER_SMALL);
 	opts_label->set_text("Additional Options");
 	additional_options_container->add_child(opts_label);
 
@@ -639,6 +640,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	device_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	Label *device_label = memnew(Label);
+	device_label->set_header_mode(Label::HEADER_SMALL);
 	device_label->set_text("Device:");
 	device_container->add_child(device_label);
 
@@ -858,6 +860,7 @@ Variant ActionMapEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 
 	String name = selected->get_text(0);
 	Label *label = memnew(Label(name));
+	label->set_header_mode(Label::HEADER_SMALL);
 	label->set_modulate(Color(1, 1, 1, 1.0f));
 	action_tree->set_drag_preview(label);
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1698,6 +1698,8 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		VBoxContainer *vmem_vb = memnew(VBoxContainer);
 		HBoxContainer *vmem_hb = memnew(HBoxContainer);
 		Label *vmlb = memnew(Label(TTR("List of Video Memory Usage by Resource:") + " "));
+		vmlb->set_header_mode(Label::HEADER_SMALL);
+
 		vmlb->set_h_size_flags(SIZE_EXPAND_FILL);
 		vmem_hb->add_child(vmlb);
 		vmem_hb->add_child(memnew(Label(TTR("Total:") + " ")));

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -232,6 +232,8 @@ DependencyEditor::DependencyEditor() {
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	Label *label = memnew(Label(TTR("Dependencies:")));
+	label->set_header_mode(Label::HEADER_SMALL);
+
 	hbc->add_child(label);
 	hbc->add_spacer();
 	fixdeps = memnew(Button(TTR("Fix Broken")));

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -92,6 +92,7 @@ ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<St
 		const char *const *names_ptr = p_src[i];
 		if (*names_ptr) {
 			Label *lbl = memnew(Label);
+			lbl->set_header_mode(Label::HEADER_SMALL);
 			lbl->set_text(p_sections[i]);
 			vbc->add_child(lbl);
 

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1507,7 +1507,9 @@ EditorFileDialog::EditorFileDialog() {
 	dir_next->connect("pressed", callable_mp(this, &EditorFileDialog::_go_forward));
 	dir_up->connect("pressed", callable_mp(this, &EditorFileDialog::_go_up));
 
-	pathhb->add_child(memnew(Label(TTR("Path:"))));
+	Label *l = memnew(Label(TTR("Path:")));
+	l->set_header_mode(Label::HEADER_SMALL);
+	pathhb->add_child(l);
 
 	drives_container = memnew(HBoxContainer);
 	pathhb->add_child(drives_container);
@@ -1588,7 +1590,11 @@ EditorFileDialog::EditorFileDialog() {
 	fav_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	HBoxContainer *fav_hb = memnew(HBoxContainer);
 	fav_vb->add_child(fav_hb);
-	fav_hb->add_child(memnew(Label(TTR("Favorites:"))));
+
+	l = memnew(Label(TTR("Favorites:")));
+	l->set_header_mode(Label::HEADER_SMALL);
+	fav_hb->add_child(l);
+
 	fav_hb->add_spacer();
 	fav_up = memnew(Button);
 	fav_up->set_flat(true);
@@ -1623,7 +1629,10 @@ EditorFileDialog::EditorFileDialog() {
 
 	VBoxContainer *list_vb = memnew(VBoxContainer);
 	list_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	list_vb->add_child(memnew(Label(TTR("Directories & Files:"))));
+
+	l = memnew(Label(TTR("Directories & Files:")));
+	l->set_header_mode(Label::HEADER_SMALL);
+	list_vb->add_child(l);
 	preview_hb->add_child(list_vb);
 
 	// Item (files and folders) list with context menu.
@@ -1650,7 +1659,11 @@ EditorFileDialog::EditorFileDialog() {
 	preview_vb->hide();
 
 	file_box = memnew(HBoxContainer);
-	file_box->add_child(memnew(Label(TTR("File:"))));
+
+	l = memnew(Label(TTR("File:")));
+	l->set_header_mode(Label::HEADER_SMALL);
+	file_box->add_child(l);
+
 	file = memnew(LineEdit);
 	file->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
 	file->set_stretch_ratio(4);

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -319,7 +319,13 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	p_theme->set_font_size("main_button_font_size", "EditorFonts", default_font_size + 1 * EDSCALE);
 	p_theme->set_font("main_button_font", "EditorFonts", df_bold);
 
-	p_theme->set_font("font", "Label", df_bold);
+	p_theme->set_font("font", "Label", df);
+	p_theme->set_font("font_header_small", "Label", df_bold);
+	p_theme->set_font_size("font_header_small_size", "Label", default_font_size);
+	p_theme->set_font("font_header_medium", "Label", df_bold);
+	p_theme->set_font_size("font_header_medium_size", "Label", default_font_size + 1 * EDSCALE);
+	p_theme->set_font("font_header_large", "Label", df_bold);
+	p_theme->set_font_size("font_header_large_size", "Label", default_font_size + 3 * EDSCALE);
 
 	// Documentation fonts
 	MAKE_SOURCE_FONT(df_code);

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -192,7 +192,9 @@ EditorPluginSettings::EditorPluginSettings() {
 	add_child(plugin_config_dialog);
 
 	HBoxContainer *title_hb = memnew(HBoxContainer);
-	title_hb->add_child(memnew(Label(TTR("Installed Plugins:"))));
+	Label *l = memnew(Label(TTR("Installed Plugins:")));
+	l->set_header_mode(Label::HEADER_SMALL);
+	title_hb->add_child(l);
 	title_hb->add_spacer();
 	create_plugin = memnew(Button(TTR("Create")));
 	create_plugin->connect("pressed", callable_mp(this, &EditorPluginSettings::_create_clicked));

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -814,6 +814,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	main_vb->add_child(current_hb);
 
 	Label *current_label = memnew(Label);
+	current_label->set_header_mode(Label::HEADER_SMALL);
 	current_label->set_text(TTR("Current Version:"));
 	current_hb->add_child(current_label);
 
@@ -823,6 +824,8 @@ ExportTemplateManager::ExportTemplateManager() {
 	// Current version statuses.
 	// Status: Current version is missing.
 	current_missing_label = memnew(Label);
+	current_missing_label->set_header_mode(Label::HEADER_SMALL);
+
 	current_missing_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	current_missing_label->set_align(Label::ALIGN_RIGHT);
 	current_missing_label->set_text(TTR("Export templates are missing. Download them or install from a file."));
@@ -830,6 +833,7 @@ ExportTemplateManager::ExportTemplateManager() {
 
 	// Status: Current version is installed.
 	current_installed_label = memnew(Label);
+	current_installed_label->set_header_mode(Label::HEADER_SMALL);
 	current_installed_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	current_installed_label->set_align(Label::ALIGN_RIGHT);
 	current_installed_label->set_text(TTR("Export templates are installed and ready to be used."));
@@ -949,6 +953,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	HBoxContainer *installed_versions_hb = memnew(HBoxContainer);
 	main_vb->add_child(installed_versions_hb);
 	Label *installed_label = memnew(Label);
+	installed_label->set_header_mode(Label::HEADER_SMALL);
 	installed_label->set_text(TTR("Other Installed Versions:"));
 	installed_versions_hb->add_child(installed_label);
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -424,6 +424,8 @@ GroupDialog::GroupDialog() {
 	vbc_left->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	Label *group_title = memnew(Label);
+	group_title->set_header_mode(Label::HEADER_SMALL);
+
 	group_title->set_text(TTR("Groups"));
 	vbc_left->add_child(group_title);
 
@@ -458,6 +460,8 @@ GroupDialog::GroupDialog() {
 	vbc_add->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	Label *out_of_group_title = memnew(Label);
+	out_of_group_title->set_header_mode(Label::HEADER_SMALL);
+
 	out_of_group_title->set_text(TTR("Nodes Not in Group"));
 	vbc_add->add_child(out_of_group_title);
 
@@ -506,6 +510,8 @@ GroupDialog::GroupDialog() {
 	vbc_remove->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	Label *in_group_title = memnew(Label);
+	in_group_title->set_header_mode(Label::HEADER_SMALL);
+
 	in_group_title->set_text(TTR("Nodes in Group"));
 	vbc_remove->add_child(in_group_title);
 
@@ -528,6 +534,8 @@ GroupDialog::GroupDialog() {
 	remove_filter->connect("text_changed", callable_mp(this, &GroupDialog::_remove_filter_changed));
 
 	group_empty = memnew(Label());
+	group_empty->set_header_mode(Label::HEADER_SMALL);
+
 	group_empty->set_text(TTR("Empty groups will be automatically removed."));
 	group_empty->set_valign(Label::VALIGN_CENTER);
 	group_empty->set_align(Label::ALIGN_CENTER);

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -656,7 +656,9 @@ LocalizationEditor::LocalizationEditor() {
 		translations->add_child(tvb);
 
 		HBoxContainer *thb = memnew(HBoxContainer);
-		thb->add_child(memnew(Label(TTR("Translations:"))));
+		Label *l = memnew(Label(TTR("Translations:")));
+		l->set_header_mode(Label::HEADER_SMALL);
+		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
@@ -684,7 +686,9 @@ LocalizationEditor::LocalizationEditor() {
 		translations->add_child(tvb);
 
 		HBoxContainer *thb = memnew(HBoxContainer);
-		thb->add_child(memnew(Label(TTR("Resources:"))));
+		Label *l = memnew(Label(TTR("Resources:")));
+		l->set_header_mode(Label::HEADER_SMALL);
+		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
@@ -708,7 +712,9 @@ LocalizationEditor::LocalizationEditor() {
 		add_child(translation_res_file_open_dialog);
 
 		thb = memnew(HBoxContainer);
-		thb->add_child(memnew(Label(TTR("Remaps by Locale:"))));
+		l = memnew(Label(TTR("Remaps by Locale:")));
+		l->set_header_mode(Label::HEADER_SMALL);
+		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
@@ -756,7 +762,9 @@ LocalizationEditor::LocalizationEditor() {
 		translation_locale_filter_mode->connect("item_selected", callable_mp(this, &LocalizationEditor::_translation_filter_mode_changed));
 		tmc->add_margin_child(TTR("Filter mode:"), translation_locale_filter_mode);
 
-		tmc->add_child(memnew(Label(TTR("Locales:"))));
+		Label *l = memnew(Label(TTR("Locales:")));
+		l->set_header_mode(Label::HEADER_SMALL);
+		tmc->add_child(l);
 		translation_filter = memnew(Tree);
 		translation_filter->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		translation_filter->set_columns(1);
@@ -770,7 +778,9 @@ LocalizationEditor::LocalizationEditor() {
 		translations->add_child(tvb);
 
 		HBoxContainer *thb = memnew(HBoxContainer);
-		thb->add_child(memnew(Label(TTR("Files with translation strings:"))));
+		Label *l = memnew(Label(TTR("Files with translation strings:")));
+		l->set_header_mode(Label::HEADER_SMALL);
+		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7080,6 +7080,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 		sun_vb->hide();
 
 		sun_title = memnew(Label);
+		sun_title->set_header_mode(Label::HEADER_SMALL);
 		sun_vb->add_child(sun_title);
 		sun_title->set_text(TTR("Preview Sun"));
 		sun_title->set_align(Label::ALIGN_CENTER);
@@ -7141,6 +7142,8 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 		environ_vb->hide();
 
 		environ_title = memnew(Label);
+		environ_title->set_header_mode(Label::HEADER_SMALL);
+
 		environ_vb->add_child(environ_title);
 		environ_title->set_text(TTR("Preview Environment"));
 		environ_title->set_align(Label::ALIGN_CENTER);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1954,7 +1954,9 @@ ThemeEditor::ThemeEditor() {
 	HBoxContainer *top_menu = memnew(HBoxContainer);
 	add_child(top_menu);
 
-	top_menu->add_child(memnew(Label(TTR("Preview:"))));
+	Label *l = memnew(Label(TTR("Preview:")));
+	l->set_header_mode(Label::HEADER_SMALL);
+	top_menu->add_child(l);
 	top_menu->add_spacer(false);
 
 	theme_edit_button = memnew(Button);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1006,7 +1006,10 @@ ProjectExportDialog::ProjectExportDialog() {
 	hbox->add_child(preset_vb);
 
 	HBoxContainer *preset_hb = memnew(HBoxContainer);
-	preset_hb->add_child(memnew(Label(TTR("Presets"))));
+	Label *l = memnew(Label(TTR("Presets")));
+	l->set_header_mode(Label::HEADER_SMALL);
+	preset_hb->add_child(l);
+
 	preset_hb->add_spacer();
 	preset_vb->add_child(preset_hb);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1209,7 +1209,9 @@ void SceneTreeDock::_notification(int p_what) {
 			HBoxContainer *top_row = memnew(HBoxContainer);
 			top_row->set_name("NodeShortcutsTopRow");
 			top_row->set_h_size_flags(SIZE_EXPAND_FILL);
-			top_row->add_child(memnew(Label(TTR("Create Root Node:"))));
+			Label *l = memnew(Label(TTR("Create Root Node:")));
+			l->set_header_mode(Label::HEADER_SMALL);
+			top_row->add_child(l);
 			top_row->add_spacer();
 
 			Button *node_shortcuts_toggle = memnew(Button);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1165,6 +1165,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 
 	if (p_label) {
 		Label *label = memnew(Label);
+		label->set_header_mode(Label::HEADER_SMALL);
 		label->set_position(Point2(10, 0));
 		label->set_text(TTR("Scene Tree (Nodes):"));
 

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -349,6 +349,7 @@ void BoxContainer::_bind_methods() {
 
 MarginContainer *VBoxContainer::add_margin_child(const String &p_label, Control *p_control, bool p_expand) {
 	Label *l = memnew(Label);
+	l->set_header_mode(Label::HEADER_SMALL);
 	l->set_text(p_label);
 	add_child(l);
 	MarginContainer *mc = memnew(MarginContainer);

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -51,6 +51,13 @@ public:
 		VALIGN_FILL
 	};
 
+	enum HeaderMode {
+		HEADER_DISABLED,
+		HEADER_SMALL,
+		HEADER_MEDIUM,
+		HEADER_LARGE,
+	};
+
 private:
 	Align align = ALIGN_LEFT;
 	VAlign valign = VALIGN_TOP;
@@ -60,6 +67,7 @@ private:
 	bool clip = false;
 	Size2 minsize;
 	bool uppercase = false;
+	HeaderMode header_mode = HEADER_DISABLED;
 
 	bool lines_dirty = true;
 	bool dirty = true;
@@ -80,6 +88,9 @@ private:
 
 	void _update_visible();
 	void _shape();
+
+	Ref<Font> _get_font() const;
+	int _get_font_size() const;
 
 protected:
 	void _notification(int p_what);
@@ -144,11 +155,15 @@ public:
 	int get_line_count() const;
 	int get_visible_line_count() const;
 
+	void set_header_mode(HeaderMode p_mode);
+	HeaderMode get_header_mode() const;
+
 	Label(const String &p_text = String());
 	~Label();
 };
 
 VARIANT_ENUM_CAST(Label::Align);
 VARIANT_ENUM_CAST(Label::VAlign);
+VARIANT_ENUM_CAST(Label::HeaderMode);
 
 #endif

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -380,6 +380,13 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font("font", "Label", Ref<Font>());
 	theme->set_font_size("font_size", "Label", -1);
 
+	theme->set_font("font_header_small", "Label", Ref<Font>());
+	theme->set_font_size("font_header_small_size", "Label", -1);
+	theme->set_font("font_header_medium", "Label", Ref<Font>());
+	theme->set_font_size("font_header_medium_size", "Label", -1);
+	theme->set_font("font_header_large", "Label", Ref<Font>());
+	theme->set_font_size("font_header_large_size", "Label", -1);
+
 	theme->set_color("font_color", "Label", Color(1, 1, 1));
 	theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
 	theme->set_color("font_outline_color", "Label", Color(1, 1, 1));


### PR DESCRIPTION
* When designing UIs, labels are often be used as headers to give section names.
* This PR makes it possible to do so where relevant.
* Labels are also non-bold again by default, only bold when marked as headers.

This PR should fix all the problems of bold fonts where they should not be, I have been checking one by one all the usages.

The header size can be chosen from presets (Small, Medium, Large). This allows for creating modern UIs with Godot with reusable preset sizes more efficiently, as per these examples which use multiple header sizes:
![image](https://user-images.githubusercontent.com/6265307/120899286-4df57480-c605-11eb-8601-c485ad83042e.png)
![image](https://user-images.githubusercontent.com/6265307/120899452-38cd1580-c606-11eb-81de-e16431ca699e.png)
![image](https://user-images.githubusercontent.com/6265307/120899481-54d0b700-c606-11eb-809e-5b9bb0f44be3.png)

and should work as a base for ourselves for modernizing Godot UI.

Godot never supported this in the past because our font support was limited, but this is a common feature of modern UIs and the fact we now support variable font sizes properly is main the reason for it.

**Q:**  Why not a workaround using theme overrides or theme custom types?
**A:**  After checking several applications, headers with multiple sizes are an integral part of modern ones, and are thoroughly used across user interfaces (see examples above). Given this is a very commonly used feature, it should be core and not a workaround (workarounds are designed for corner cases). Additionally, it is common for non-programmers to build user interfaces in game development teams, so having the ability to do this easily (without resorting to code or having to remember strings) is important.