### PR TITLE
Fix VisibilityEnabler to work with AnimationTree

### DIFF
--- a/scene/3d/visibility_notifier.cpp
+++ b/scene/3d/visibility_notifier.cpp
@@ -34,6 +34,8 @@
 #include "scene/3d/camera.h"
 #include "scene/3d/physics_body.h"
 #include "scene/animation/animation_player.h"
+#include "scene/animation/animation_tree.h"
+#include "scene/animation/animation_tree_player.h"
 #include "scene/scene_string_names.h"
 
 void VisibilityNotifier::_enter_camera(Camera *p_camera) {
@@ -146,11 +148,8 @@ void VisibilityEnabler::_find_nodes(Node *p_node) {
 		}
 	}
 
-	{
-		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
-		if (ap) {
-			add = true;
-		}
+	if (Object::cast_to<AnimationPlayer>(p_node) || Object::cast_to<AnimationTree>(p_node) || Object::cast_to<AnimationTreePlayer>(p_node)) {
+		add = true;
 	}
 
 	if (add) {
@@ -212,9 +211,18 @@ void VisibilityEnabler::_change_node_state(Node *p_node, bool p_enabled) {
 
 	if (enabler[ENABLER_PAUSE_ANIMATIONS]) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
-
 		if (ap) {
 			ap->set_active(p_enabled);
+		} else {
+			AnimationTree *at = Object::cast_to<AnimationTree>(p_node);
+			if (at) {
+				at->set_active(p_enabled);
+			} else {
+				AnimationTreePlayer *atp = Object::cast_to<AnimationTreePlayer>(p_node);
+				if (atp) {
+					atp->set_active(p_enabled);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Although the visibility enabler worked to turn on and off AnimationPlayer as it enters and exits the view frustum, this was of little use as bones animation and especially software skinning still take place driven by the AnimationTree node.

This PR adds the ability to turn on and off AnimationTree, and AnimationTreePlayer nodes as they enter or exit the view frustum, which achieves the intention of switching off expensive animation processing.

## Notes
* Noticed when working on the rooms & portals PR that the VisibilityEnabler didn't seem to work as intended. However decided this could be done independently as a separate PR as it should speed up games that use VisibilityEnabler irrespective of use of portals.
* This is especially important to use with software skinning, because unlike hardware skinning, software skinning is processed entirely irrespective of whether the object is in the view frustum, unless you use this fixed VisibilityEnabler.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
