### PR TITLE
Fix VisibilityEnabler to work with AnimationTree [4.x]

### DIFF
--- a/scene/3d/visibility_notifier_3d.cpp
+++ b/scene/3d/visibility_notifier_3d.cpp
@@ -34,6 +34,7 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/physics_body_3d.h"
 #include "scene/animation/animation_player.h"
+#include "scene/animation/animation_tree.h"
 #include "scene/scene_string_names.h"
 
 void VisibilityNotifier3D::_enter_camera(Camera3D *p_camera) {
@@ -151,6 +152,13 @@ void VisibilityEnabler3D::_find_nodes(Node *p_node) {
 		}
 	}
 
+	{
+		AnimationTree *at = Object::cast_to<AnimationTree>(p_node);
+		if (at) {
+			add = true;
+		}
+	}
+
 	if (add) {
 		p_node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &VisibilityEnabler3D::_node_removed), varray(p_node), CONNECT_ONESHOT);
 		nodes[p_node] = meta;
@@ -213,6 +221,11 @@ void VisibilityEnabler3D::_change_node_state(Node *p_node, bool p_enabled) {
 
 		if (ap) {
 			ap->set_active(p_enabled);
+		} else {
+			AnimationTree *at = Object::cast_to<AnimationTree>(p_node);
+			if (at) {
+				at->set_active(p_enabled);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Although the visibility enabler worked to turn on and off AnimationPlayer as it enters and exits the view frustum, this was of little use as bones animation and especially software skinning still take place driven by the AnimationTree node.

This PR adds the ability to turn on and off AnimationTree nodes as they enter or exit the view frustum, which achieves the intention of switching off expensive animation processing.

Godot 4 version of #49341

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
