### PR TITLE
Let var2str display StringName with correct sigil

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1516,7 +1516,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 		case Variant::STRING_NAME: {
 			String str = p_variant;
 
-			str = "@\"" + str.c_escape() + "\"";
+			str = "&\"" + str.c_escape() + "\"";
 			p_store_string_func(p_store_string_ud, str);
 
 		} break;

--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -22,7 +22,7 @@
 		<method name="play">
 			<return type="void">
 			</return>
-			<argument index="0" name="anim" type="StringName" default="@&quot;&quot;">
+			<argument index="0" name="anim" type="StringName" default="&amp;&quot;&quot;">
 			</argument>
 			<argument index="1" name="backwards" type="bool" default="false">
 			</argument>
@@ -39,7 +39,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="@&quot;default&quot;">
+		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="&amp;&quot;default&quot;">
 			The current animation from the [code]frames[/code] resource. If this value changes, the [code]frame[/code] counter is reset.
 		</member>
 		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -20,7 +20,7 @@
 		<method name="play">
 			<return type="void">
 			</return>
-			<argument index="0" name="anim" type="StringName" default="@&quot;&quot;">
+			<argument index="0" name="anim" type="StringName" default="&amp;&quot;&quot;">
 			</argument>
 			<description>
 				Plays the animation named [code]anim[/code]. If no [code]anim[/code] is provided, the current animation is played.
@@ -35,7 +35,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="@&quot;default&quot;">
+		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="&amp;&quot;default&quot;">
 			The current animation from the [code]frames[/code] resource. If this value changes, the [code]frame[/code] counter is reset.
 		</member>
 		<member name="frame" type="int" setter="set_frame" getter="get_frame" default="0">

--- a/doc/classes/AnimationNodeAnimation.xml
+++ b/doc/classes/AnimationNodeAnimation.xml
@@ -14,7 +14,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="@&quot;&quot;">
+		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="&amp;&quot;&quot;">
 			Animation to use as an output. It is one of the animations provided by [member AnimationTree.anim_player].
 		</member>
 	</members>

--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -10,7 +10,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="advance_condition" type="StringName" setter="set_advance_condition" getter="get_advance_condition" default="@&quot;&quot;">
+		<member name="advance_condition" type="StringName" setter="set_advance_condition" getter="get_advance_condition" default="&amp;&quot;&quot;">
 			Turn on auto advance when this condition is set. The provided name will become a boolean parameter on the [AnimationTree] that can be controlled from code (see [url=https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html#controlling-from-code][/url]). For example, if [member AnimationTree.tree_root] is an [AnimationNodeStateMachine] and [member advance_condition] is set to [code]"idle"[/code]:
 			[codeblocks]
 			[gdscript]

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -54,7 +54,7 @@
 			The rate at which objects stop spinning in this area. Represents the angular velocity lost per second.
 			See [member ProjectSettings.physics/2d/default_angular_damp] for more details about damping.
 		</member>
-		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="@&quot;Master&quot;">
+		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="&amp;&quot;Master&quot;">
 			The name of the area's audio bus.
 		</member>
 		<member name="audio_bus_override" type="bool" setter="set_audio_bus_override" getter="is_overriding_audio_bus" default="false">

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -52,7 +52,7 @@
 			The rate at which objects stop spinning in this area. Represents the angular velocity lost per second.
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
-		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="@&quot;Master&quot;">
+		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="&amp;&quot;Master&quot;">
 			The name of the area's audio bus.
 		</member>
 		<member name="audio_bus_override" type="bool" setter="set_audio_bus_override" getter="is_overriding_audio_bus" default="false">
@@ -89,7 +89,7 @@
 		<member name="reverb_bus_enable" type="bool" setter="set_use_reverb_bus" getter="is_using_reverb_bus" default="false">
 			If [code]true[/code], the area applies reverb to its associated audio.
 		</member>
-		<member name="reverb_bus_name" type="StringName" setter="set_reverb_bus" getter="get_reverb_bus" default="@&quot;Master&quot;">
+		<member name="reverb_bus_name" type="StringName" setter="set_reverb_bus" getter="get_reverb_bus" default="&amp;&quot;Master&quot;">
 			The reverb bus name to use for this area's associated audio.
 		</member>
 		<member name="reverb_bus_uniformity" type="float" setter="set_reverb_uniformity" getter="get_reverb_uniformity" default="0.0">

--- a/doc/classes/AudioEffectCompressor.xml
+++ b/doc/classes/AudioEffectCompressor.xml
@@ -32,7 +32,7 @@
 		<member name="release_ms" type="float" setter="set_release_ms" getter="get_release_ms" default="250.0">
 			Compressor's delay time to stop reducing the signal after the signal level falls below the threshold, in milliseconds. Value can range from 20 to 2000.
 		</member>
-		<member name="sidechain" type="StringName" setter="set_sidechain" getter="get_sidechain" default="@&quot;&quot;">
+		<member name="sidechain" type="StringName" setter="set_sidechain" getter="get_sidechain" default="&amp;&quot;&quot;">
 			Reduce the sound level using another audio bus for threshold detection.
 		</member>
 		<member name="threshold" type="float" setter="set_threshold" getter="get_threshold" default="0.0">

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -60,7 +60,7 @@
 		<member name="autoplay" type="bool" setter="set_autoplay" getter="is_autoplay_enabled" default="false">
 			If [code]true[/code], audio plays when added to scene tree.
 		</member>
-		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="@&quot;Master&quot;">
+		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="&amp;&quot;Master&quot;">
 			Bus on which this audio is playing.
 		</member>
 		<member name="mix_target" type="int" setter="set_mix_target" getter="get_mix_target" enum="AudioStreamPlayer.MixTarget" default="0">

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -62,7 +62,7 @@
 		<member name="autoplay" type="bool" setter="set_autoplay" getter="is_autoplay_enabled" default="false">
 			If [code]true[/code], audio plays when added to scene tree.
 		</member>
-		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="@&quot;Master&quot;">
+		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="&amp;&quot;Master&quot;">
 			Bus on which this audio is playing.
 		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="2000.0">

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -69,7 +69,7 @@
 		<member name="autoplay" type="bool" setter="set_autoplay" getter="is_autoplay_enabled" default="false">
 			If [code]true[/code], audio plays when the AudioStreamPlayer3D node is added to scene tree.
 		</member>
-		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="@&quot;Master&quot;">
+		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="&amp;&quot;Master&quot;">
 			The bus on which this audio is playing.
 		</member>
 		<member name="doppler_tracking" type="int" setter="set_doppler_tracking" getter="get_doppler_tracking" enum="AudioStreamPlayer3D.DopplerTracking" default="0">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1175,7 +1175,7 @@
 		<member name="theme" type="Theme" setter="set_theme" getter="get_theme">
 			The [Theme] resource this node and all its [Control] children use. If a child node has its own [Theme] resource set, theme items are merged with child's definitions having higher priority.
 		</member>
-		<member name="theme_custom_type" type="StringName" setter="set_theme_custom_type" getter="get_theme_custom_type" default="@&quot;&quot;">
+		<member name="theme_custom_type" type="StringName" setter="set_theme_custom_type" getter="get_theme_custom_type" default="&amp;&quot;&quot;">
 			The type name used by this [Control] to look up its own theme items. By default, the class name of the node is used (e.g. [code]Button[/code] for the [Button] control), as well as the class names of all parent classes (in order of inheritance). Setting this property gives the highest priority to the type of the specified name, then falls back on the class names.
 			[b]Note:[/b] To look up [Control]'s own items use various [code]get_theme_*[/code] methods without specifying [code]theme_type[/code].
 			[b]Note:[/b] Theme items are looked for in the tree order, from branch to root, where each [Control] node is checked for its [member theme] property. The earliest match against any type/class name is returned. The project-level Theme and the default Theme are checked last.

--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -25,7 +25,7 @@
 			</argument>
 			<argument index="1" name="value" type="Variant">
 			</argument>
-			<argument index="2" name="field" type="StringName" default="@&quot;&quot;">
+			<argument index="2" name="field" type="StringName" default="&amp;&quot;&quot;">
 			</argument>
 			<argument index="3" name="changing" type="bool" default="false">
 			</argument>

--- a/doc/classes/InputEventAction.xml
+++ b/doc/classes/InputEventAction.xml
@@ -14,7 +14,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="action" type="StringName" setter="set_action" getter="get_action" default="@&quot;&quot;">
+		<member name="action" type="StringName" setter="set_action" getter="get_action" default="&amp;&quot;&quot;">
 			The action's name. Actions are accessed via this [String].
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">

--- a/doc/classes/RDShaderFile.xml
+++ b/doc/classes/RDShaderFile.xml
@@ -10,7 +10,7 @@
 		<method name="get_bytecode" qualifiers="const">
 			<return type="RDShaderBytecode">
 			</return>
-			<argument index="0" name="version" type="StringName" default="@&quot;&quot;">
+			<argument index="0" name="version" type="StringName" default="&amp;&quot;&quot;">
 			</argument>
 			<description>
 			</description>
@@ -26,7 +26,7 @@
 			</return>
 			<argument index="0" name="bytecode" type="RDShaderBytecode">
 			</argument>
-			<argument index="1" name="version" type="StringName" default="@&quot;&quot;">
+			<argument index="1" name="version" type="StringName" default="&amp;&quot;&quot;">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/SkeletonIK3D.xml
+++ b/doc/classes/SkeletonIK3D.xml
@@ -46,13 +46,13 @@
 		</member>
 		<member name="override_tip_basis" type="bool" setter="set_override_tip_basis" getter="is_override_tip_basis" default="true">
 		</member>
-		<member name="root_bone" type="StringName" setter="set_root_bone" getter="get_root_bone" default="@&quot;&quot;">
+		<member name="root_bone" type="StringName" setter="set_root_bone" getter="get_root_bone" default="&amp;&quot;&quot;">
 		</member>
 		<member name="target" type="Transform3D" setter="set_target_transform" getter="get_target_transform" default="Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 		</member>
 		<member name="target_node" type="NodePath" setter="set_target_node" getter="get_target_node" default="NodePath(&quot;&quot;)">
 		</member>
-		<member name="tip_bone" type="StringName" setter="set_tip_bone" getter="get_tip_bone" default="@&quot;&quot;">
+		<member name="tip_bone" type="StringName" setter="set_tip_bone" getter="get_tip_bone" default="&amp;&quot;&quot;">
 		</member>
 		<member name="use_magnet" type="bool" setter="set_use_magnet" getter="is_using_magnet" default="false">
 		</member>

--- a/doc/classes/VideoPlayer.xml
+++ b/doc/classes/VideoPlayer.xml
@@ -60,7 +60,7 @@
 		<member name="buffering_msec" type="int" setter="set_buffering_msec" getter="get_buffering_msec" default="500">
 			Amount of time in milliseconds to store in buffer while playing.
 		</member>
-		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="@&quot;Master&quot;">
+		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="&amp;&quot;Master&quot;">
 			Audio bus to use for sound playback.
 		</member>
 		<member name="expand" type="bool" setter="set_expand" getter="has_expand" default="true">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -340,7 +340,7 @@
 		</member>
 		<member name="theme" type="Theme" setter="set_theme" getter="get_theme">
 		</member>
-		<member name="theme_custom_type" type="StringName" setter="set_theme_custom_type" getter="get_theme_custom_type" default="@&quot;&quot;">
+		<member name="theme_custom_type" type="StringName" setter="set_theme_custom_type" getter="get_theme_custom_type" default="&amp;&quot;&quot;">
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;&quot;">
 		</member>

--- a/modules/visual_script/doc_classes/VisualScriptClassConstant.xml
+++ b/modules/visual_script/doc_classes/VisualScriptClassConstant.xml
@@ -15,10 +15,10 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="@&quot;Object&quot;">
+		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="&amp;&quot;Object&quot;">
 			The constant's parent class.
 		</member>
-		<member name="constant" type="StringName" setter="set_class_constant" getter="get_class_constant" default="@&quot;&quot;">
+		<member name="constant" type="StringName" setter="set_class_constant" getter="get_class_constant" default="&amp;&quot;&quot;">
 			The constant to return. See the given class for its available constants.
 		</member>
 	</members>

--- a/modules/visual_script/doc_classes/VisualScriptEmitSignal.xml
+++ b/modules/visual_script/doc_classes/VisualScriptEmitSignal.xml
@@ -15,7 +15,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="signal" type="StringName" setter="set_signal" getter="get_signal" default="@&quot;&quot;">
+		<member name="signal" type="StringName" setter="set_signal" getter="get_signal" default="&amp;&quot;&quot;">
 			The signal to emit.
 		</member>
 	</members>

--- a/modules/visual_script/doc_classes/VisualScriptFunctionCall.xml
+++ b/modules/visual_script/doc_classes/VisualScriptFunctionCall.xml
@@ -11,13 +11,13 @@
 	<members>
 		<member name="base_script" type="String" setter="set_base_script" getter="get_base_script">
 		</member>
-		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="@&quot;Object&quot;">
+		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="&amp;&quot;Object&quot;">
 		</member>
 		<member name="basic_type" type="int" setter="set_basic_type" getter="get_basic_type" enum="Variant.Type">
 		</member>
 		<member name="call_mode" type="int" setter="set_call_mode" getter="get_call_mode" enum="VisualScriptFunctionCall.CallMode" default="0">
 		</member>
-		<member name="function" type="StringName" setter="set_function" getter="get_function" default="@&quot;&quot;">
+		<member name="function" type="StringName" setter="set_function" getter="get_function" default="&amp;&quot;&quot;">
 		</member>
 		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path">
 		</member>

--- a/modules/visual_script/doc_classes/VisualScriptInputAction.xml
+++ b/modules/visual_script/doc_classes/VisualScriptInputAction.xml
@@ -9,7 +9,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="action" type="StringName" setter="set_action_name" getter="get_action_name" default="@&quot;&quot;">
+		<member name="action" type="StringName" setter="set_action_name" getter="get_action_name" default="&amp;&quot;&quot;">
 		</member>
 		<member name="mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="VisualScriptInputAction.Mode" default="0">
 		</member>

--- a/modules/visual_script/doc_classes/VisualScriptLocalVar.xml
+++ b/modules/visual_script/doc_classes/VisualScriptLocalVar.xml
@@ -18,7 +18,7 @@
 		<member name="type" type="int" setter="set_var_type" getter="get_var_type" enum="Variant.Type" default="0">
 			The local variable's type.
 		</member>
-		<member name="var_name" type="StringName" setter="set_var_name" getter="get_var_name" default="@&quot;new_local&quot;">
+		<member name="var_name" type="StringName" setter="set_var_name" getter="get_var_name" default="&amp;&quot;new_local&quot;">
 			The local variable's name.
 		</member>
 	</members>

--- a/modules/visual_script/doc_classes/VisualScriptLocalVarSet.xml
+++ b/modules/visual_script/doc_classes/VisualScriptLocalVarSet.xml
@@ -20,7 +20,7 @@
 		<member name="type" type="int" setter="set_var_type" getter="get_var_type" enum="Variant.Type" default="0">
 			The local variable's type.
 		</member>
-		<member name="var_name" type="StringName" setter="set_var_name" getter="get_var_name" default="@&quot;new_local&quot;">
+		<member name="var_name" type="StringName" setter="set_var_name" getter="get_var_name" default="&amp;&quot;new_local&quot;">
 			The local variable's name.
 		</member>
 	</members>

--- a/modules/visual_script/doc_classes/VisualScriptPropertyGet.xml
+++ b/modules/visual_script/doc_classes/VisualScriptPropertyGet.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="base_script" type="String" setter="set_base_script" getter="get_base_script">
 		</member>
-		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="@&quot;Object&quot;">
+		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="&amp;&quot;Object&quot;">
 		</member>
 		<member name="basic_type" type="int" setter="set_basic_type" getter="get_basic_type" enum="Variant.Type">
 		</member>
@@ -19,7 +19,7 @@
 		</member>
 		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path">
 		</member>
-		<member name="property" type="StringName" setter="set_property" getter="get_property" default="@&quot;&quot;">
+		<member name="property" type="StringName" setter="set_property" getter="get_property" default="&amp;&quot;&quot;">
 		</member>
 		<member name="set_mode" type="int" setter="set_call_mode" getter="get_call_mode" enum="VisualScriptPropertyGet.CallMode" default="0">
 		</member>

--- a/modules/visual_script/doc_classes/VisualScriptPropertySet.xml
+++ b/modules/visual_script/doc_classes/VisualScriptPropertySet.xml
@@ -13,7 +13,7 @@
 		</member>
 		<member name="base_script" type="String" setter="set_base_script" getter="get_base_script">
 		</member>
-		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="@&quot;Object&quot;">
+		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="&amp;&quot;Object&quot;">
 		</member>
 		<member name="basic_type" type="int" setter="set_basic_type" getter="get_basic_type" enum="Variant.Type">
 		</member>
@@ -21,7 +21,7 @@
 		</member>
 		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path">
 		</member>
-		<member name="property" type="StringName" setter="set_property" getter="get_property" default="@&quot;&quot;">
+		<member name="property" type="StringName" setter="set_property" getter="get_property" default="&amp;&quot;&quot;">
 		</member>
 		<member name="set_mode" type="int" setter="set_call_mode" getter="get_call_mode" enum="VisualScriptPropertySet.CallMode" default="0">
 		</member>

--- a/modules/visual_script/doc_classes/VisualScriptTypeCast.xml
+++ b/modules/visual_script/doc_classes/VisualScriptTypeCast.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="base_script" type="String" setter="set_base_script" getter="get_base_script" default="&quot;&quot;">
 		</member>
-		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="@&quot;Object&quot;">
+		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="&amp;&quot;Object&quot;">
 		</member>
 	</members>
 	<constants>

--- a/modules/visual_script/doc_classes/VisualScriptVariableGet.xml
+++ b/modules/visual_script/doc_classes/VisualScriptVariableGet.xml
@@ -15,7 +15,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="var_name" type="StringName" setter="set_variable" getter="get_variable" default="@&quot;&quot;">
+		<member name="var_name" type="StringName" setter="set_variable" getter="get_variable" default="&amp;&quot;&quot;">
 			The variable's name.
 		</member>
 	</members>

--- a/modules/visual_script/doc_classes/VisualScriptVariableSet.xml
+++ b/modules/visual_script/doc_classes/VisualScriptVariableSet.xml
@@ -16,7 +16,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="var_name" type="StringName" setter="set_variable" getter="get_variable" default="@&quot;&quot;">
+		<member name="var_name" type="StringName" setter="set_variable" getter="get_variable" default="&amp;&quot;&quot;">
 			The variable's name.
 		</member>
 	</members>

--- a/modules/visual_script/doc_classes/VisualScriptYieldSignal.xml
+++ b/modules/visual_script/doc_classes/VisualScriptYieldSignal.xml
@@ -9,13 +9,13 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="@&quot;Object&quot;">
+		<member name="base_type" type="StringName" setter="set_base_type" getter="get_base_type" default="&amp;&quot;Object&quot;">
 		</member>
 		<member name="call_mode" type="int" setter="set_call_mode" getter="get_call_mode" enum="VisualScriptYieldSignal.CallMode" default="0">
 		</member>
 		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path">
 		</member>
-		<member name="signal" type="StringName" setter="set_signal" getter="get_signal" default="@&quot;&quot;">
+		<member name="signal" type="StringName" setter="set_signal" getter="get_signal" default="&amp;&quot;&quot;">
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
[Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_basics.html?#literals) shows that `@"string"` literals don't exist anymore. but `var2str(&"AStringName")` prints `@"AStringName"`.
This PR fixes `var2str()`'s output to match the new sigil for `StringName`s.