### PR TITLE
Add Header theme type to editor labels

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -631,6 +631,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	additional_options_container->hide();
 
 	Label *opts_label = memnew(Label);
+	opts_label->set_theme_custom_type("Header");
 	opts_label->set_text("Additional Options");
 	additional_options_container->add_child(opts_label);
 
@@ -639,6 +640,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	device_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	Label *device_label = memnew(Label);
+	device_label->set_theme_custom_type("Header");
 	device_label->set_text("Device:");
 	device_container->add_child(device_label);
 
@@ -858,6 +860,7 @@ Variant ActionMapEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 
 	String name = selected->get_text(0);
 	Label *label = memnew(Label(name));
+	label->set_theme_custom_type("Header");
 	label->set_modulate(Color(1, 1, 1, 1.0f));
 	action_tree->set_drag_preview(label);
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1698,6 +1698,8 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		VBoxContainer *vmem_vb = memnew(VBoxContainer);
 		HBoxContainer *vmem_hb = memnew(HBoxContainer);
 		Label *vmlb = memnew(Label(TTR("List of Video Memory Usage by Resource:") + " "));
+		vmlb->set_theme_custom_type("Header");
+
 		vmlb->set_h_size_flags(SIZE_EXPAND_FILL);
 		vmem_hb->add_child(vmlb);
 		vmem_hb->add_child(memnew(Label(TTR("Total:") + " ")));

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -232,6 +232,8 @@ DependencyEditor::DependencyEditor() {
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	Label *label = memnew(Label(TTR("Dependencies:")));
+	label->set_theme_custom_type("Header");
+
 	hbc->add_child(label);
 	hbc->add_spacer();
 	fixdeps = memnew(Button(TTR("Fix Broken")));

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -92,6 +92,7 @@ ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<St
 		const char *const *names_ptr = p_src[i];
 		if (*names_ptr) {
 			Label *lbl = memnew(Label);
+			lbl->set_theme_custom_type("Header");
 			lbl->set_text(p_sections[i]);
 			vbc->add_child(lbl);
 

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1507,7 +1507,9 @@ EditorFileDialog::EditorFileDialog() {
 	dir_next->connect("pressed", callable_mp(this, &EditorFileDialog::_go_forward));
 	dir_up->connect("pressed", callable_mp(this, &EditorFileDialog::_go_up));
 
-	pathhb->add_child(memnew(Label(TTR("Path:"))));
+	Label *l = memnew(Label(TTR("Path:")));
+	l->set_theme_custom_type("Header");
+	pathhb->add_child(l);
 
 	drives_container = memnew(HBoxContainer);
 	pathhb->add_child(drives_container);
@@ -1588,7 +1590,11 @@ EditorFileDialog::EditorFileDialog() {
 	fav_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	HBoxContainer *fav_hb = memnew(HBoxContainer);
 	fav_vb->add_child(fav_hb);
-	fav_hb->add_child(memnew(Label(TTR("Favorites:"))));
+
+	l = memnew(Label(TTR("Favorites:")));
+	l->set_theme_custom_type("Header");
+	fav_hb->add_child(l);
+
 	fav_hb->add_spacer();
 	fav_up = memnew(Button);
 	fav_up->set_flat(true);
@@ -1623,7 +1629,10 @@ EditorFileDialog::EditorFileDialog() {
 
 	VBoxContainer *list_vb = memnew(VBoxContainer);
 	list_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	list_vb->add_child(memnew(Label(TTR("Directories & Files:"))));
+
+	l = memnew(Label(TTR("Directories & Files:")));
+	l->set_theme_custom_type("Header");
+	list_vb->add_child(l);
 	preview_hb->add_child(list_vb);
 
 	// Item (files and folders) list with context menu.
@@ -1650,7 +1659,11 @@ EditorFileDialog::EditorFileDialog() {
 	preview_vb->hide();
 
 	file_box = memnew(HBoxContainer);
-	file_box->add_child(memnew(Label(TTR("File:"))));
+
+	l = memnew(Label(TTR("File:")));
+	l->set_theme_custom_type("Header");
+	file_box->add_child(l);
+
 	file = memnew(LineEdit);
 	file->set_structured_text_bidi_override(Control::STRUCTURED_TEXT_FILE);
 	file->set_stretch_ratio(4);

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -319,7 +319,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	p_theme->set_font_size("main_button_font_size", "EditorFonts", default_font_size + 1 * EDSCALE);
 	p_theme->set_font("main_button_font", "EditorFonts", df_bold);
 
-	p_theme->set_font("font", "Label", df_bold);
+	p_theme->set_font("font", "Label", df);
+	p_theme->set_font("font", "Header", df_bold);
+	p_theme->set_font_size("font", "Header", default_font_size);
 
 	// Documentation fonts
 	MAKE_SOURCE_FONT(df_code);

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -192,7 +192,9 @@ EditorPluginSettings::EditorPluginSettings() {
 	add_child(plugin_config_dialog);
 
 	HBoxContainer *title_hb = memnew(HBoxContainer);
-	title_hb->add_child(memnew(Label(TTR("Installed Plugins:"))));
+	Label *l = memnew(Label(TTR("Installed Plugins:")));
+	l->set_theme_custom_type("Header");
+	title_hb->add_child(l);
 	title_hb->add_spacer();
 	create_plugin = memnew(Button(TTR("Create")));
 	create_plugin->connect("pressed", callable_mp(this, &EditorPluginSettings::_create_clicked));

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -814,6 +814,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	main_vb->add_child(current_hb);
 
 	Label *current_label = memnew(Label);
+	current_label->set_theme_custom_type("Header");
 	current_label->set_text(TTR("Current Version:"));
 	current_hb->add_child(current_label);
 
@@ -823,6 +824,8 @@ ExportTemplateManager::ExportTemplateManager() {
 	// Current version statuses.
 	// Status: Current version is missing.
 	current_missing_label = memnew(Label);
+	current_missing_label->set_theme_custom_type("Header");
+
 	current_missing_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	current_missing_label->set_align(Label::ALIGN_RIGHT);
 	current_missing_label->set_text(TTR("Export templates are missing. Download them or install from a file."));
@@ -830,6 +833,7 @@ ExportTemplateManager::ExportTemplateManager() {
 
 	// Status: Current version is installed.
 	current_installed_label = memnew(Label);
+	current_installed_label->set_theme_custom_type("Header");
 	current_installed_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	current_installed_label->set_align(Label::ALIGN_RIGHT);
 	current_installed_label->set_text(TTR("Export templates are installed and ready to be used."));
@@ -949,6 +953,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	HBoxContainer *installed_versions_hb = memnew(HBoxContainer);
 	main_vb->add_child(installed_versions_hb);
 	Label *installed_label = memnew(Label);
+	installed_label->set_theme_custom_type("Header");
 	installed_label->set_text(TTR("Other Installed Versions:"));
 	installed_versions_hb->add_child(installed_label);
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -424,6 +424,8 @@ GroupDialog::GroupDialog() {
 	vbc_left->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	Label *group_title = memnew(Label);
+	group_title->set_theme_custom_type("Header");
+
 	group_title->set_text(TTR("Groups"));
 	vbc_left->add_child(group_title);
 
@@ -458,6 +460,8 @@ GroupDialog::GroupDialog() {
 	vbc_add->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	Label *out_of_group_title = memnew(Label);
+	out_of_group_title->set_theme_custom_type("Header");
+
 	out_of_group_title->set_text(TTR("Nodes Not in Group"));
 	vbc_add->add_child(out_of_group_title);
 
@@ -506,6 +510,8 @@ GroupDialog::GroupDialog() {
 	vbc_remove->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	Label *in_group_title = memnew(Label);
+	in_group_title->set_theme_custom_type("Header");
+
 	in_group_title->set_text(TTR("Nodes in Group"));
 	vbc_remove->add_child(in_group_title);
 
@@ -528,6 +534,8 @@ GroupDialog::GroupDialog() {
 	remove_filter->connect("text_changed", callable_mp(this, &GroupDialog::_remove_filter_changed));
 
 	group_empty = memnew(Label());
+	group_empty->set_theme_custom_type("Header");
+
 	group_empty->set_text(TTR("Empty groups will be automatically removed."));
 	group_empty->set_valign(Label::VALIGN_CENTER);
 	group_empty->set_align(Label::ALIGN_CENTER);

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -656,7 +656,9 @@ LocalizationEditor::LocalizationEditor() {
 		translations->add_child(tvb);
 
 		HBoxContainer *thb = memnew(HBoxContainer);
-		thb->add_child(memnew(Label(TTR("Translations:"))));
+		Label *l = memnew(Label(TTR("Translations:")));
+		l->set_theme_custom_type("Header");
+		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
@@ -684,7 +686,9 @@ LocalizationEditor::LocalizationEditor() {
 		translations->add_child(tvb);
 
 		HBoxContainer *thb = memnew(HBoxContainer);
-		thb->add_child(memnew(Label(TTR("Resources:"))));
+		Label *l = memnew(Label(TTR("Resources:")));
+		l->set_theme_custom_type("Header");
+		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
@@ -708,7 +712,9 @@ LocalizationEditor::LocalizationEditor() {
 		add_child(translation_res_file_open_dialog);
 
 		thb = memnew(HBoxContainer);
-		thb->add_child(memnew(Label(TTR("Remaps by Locale:"))));
+		l = memnew(Label(TTR("Remaps by Locale:")));
+		l->set_theme_custom_type("Header");
+		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 
@@ -756,7 +762,9 @@ LocalizationEditor::LocalizationEditor() {
 		translation_locale_filter_mode->connect("item_selected", callable_mp(this, &LocalizationEditor::_translation_filter_mode_changed));
 		tmc->add_margin_child(TTR("Filter mode:"), translation_locale_filter_mode);
 
-		tmc->add_child(memnew(Label(TTR("Locales:"))));
+		Label *l = memnew(Label(TTR("Locales:")));
+		l->set_theme_custom_type("Header");
+		tmc->add_child(l);
 		translation_filter = memnew(Tree);
 		translation_filter->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		translation_filter->set_columns(1);
@@ -770,7 +778,9 @@ LocalizationEditor::LocalizationEditor() {
 		translations->add_child(tvb);
 
 		HBoxContainer *thb = memnew(HBoxContainer);
-		thb->add_child(memnew(Label(TTR("Files with translation strings:"))));
+		Label *l = memnew(Label(TTR("Files with translation strings:")));
+		l->set_theme_custom_type("Header");
+		thb->add_child(l);
 		thb->add_spacer();
 		tvb->add_child(thb);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7080,6 +7080,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 		sun_vb->hide();
 
 		sun_title = memnew(Label);
+		sun_title->set_theme_custom_type("Header");
 		sun_vb->add_child(sun_title);
 		sun_title->set_text(TTR("Preview Sun"));
 		sun_title->set_align(Label::ALIGN_CENTER);
@@ -7141,6 +7142,8 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 		environ_vb->hide();
 
 		environ_title = memnew(Label);
+		environ_title->set_theme_custom_type("Header");
+
 		environ_vb->add_child(environ_title);
 		environ_title->set_text(TTR("Preview Environment"));
 		environ_title->set_align(Label::ALIGN_CENTER);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1954,7 +1954,9 @@ ThemeEditor::ThemeEditor() {
 	HBoxContainer *top_menu = memnew(HBoxContainer);
 	add_child(top_menu);
 
-	top_menu->add_child(memnew(Label(TTR("Preview:"))));
+	Label *l = memnew(Label(TTR("Preview:")));
+	l->set_theme_custom_type("Header");
+	top_menu->add_child(l);
 	top_menu->add_spacer(false);
 
 	theme_edit_button = memnew(Button);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1005,8 +1005,11 @@ ProjectExportDialog::ProjectExportDialog() {
 	preset_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbox->add_child(preset_vb);
 
+	Label *l = memnew(Label(TTR("Presets")));
+	l->set_theme_custom_type("Header");
+
 	HBoxContainer *preset_hb = memnew(HBoxContainer);
-	preset_hb->add_child(memnew(Label(TTR("Presets"))));
+	preset_hb->add_child(l);
 	preset_hb->add_spacer();
 	preset_vb->add_child(preset_hb);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1209,7 +1209,9 @@ void SceneTreeDock::_notification(int p_what) {
 			HBoxContainer *top_row = memnew(HBoxContainer);
 			top_row->set_name("NodeShortcutsTopRow");
 			top_row->set_h_size_flags(SIZE_EXPAND_FILL);
-			top_row->add_child(memnew(Label(TTR("Create Root Node:"))));
+			Label *l = memnew(Label(TTR("Create Root Node:")));
+			l->set_theme_custom_type("Header");
+			top_row->add_child(l);
 			top_row->add_spacer();
 
 			Button *node_shortcuts_toggle = memnew(Button);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1165,6 +1165,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 
 	if (p_label) {
 		Label *label = memnew(Label);
+		label->set_theme_custom_type("Header");
 		label->set_position(Point2(10, 0));
 		label->set_text(TTR("Scene Tree (Nodes):"));
 

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -349,6 +349,7 @@ void BoxContainer::_bind_methods() {
 
 MarginContainer *VBoxContainer::add_margin_child(const String &p_label, Control *p_control, bool p_expand) {
 	Label *l = memnew(Label);
+	l->set_theme_custom_type("Header");
 	l->set_text(p_label);
 	add_child(l);
 	MarginContainer *mc = memnew(MarginContainer);


### PR DESCRIPTION
This is the same as #49336, but without adding any new API (consider this a counter-PR xd).

The addition of `header_mode` to Label created some controversies, to name a few:
- literally no user ever asked about this feature (at least not formally)
- it's already perfectly possible to do, especially with newly added variable font sizes
- the PR added 3 header modes. Not only this is arbitrary number, it uses only one of them

We should add headers to the editor, but we don't need a new property for this. And users don't need it either, otherwise someone would've already proposed it.