### PR TITLE
Fix color properties of particle nodes/material

### DIFF
--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -152,7 +152,7 @@
 			Each particle's initial color. If [member texture] is defined, it will be multiplied by this color.
 		</member>
 		<member name="color_ramp" type="Gradient" setter="set_color_ramp" getter="get_color_ramp">
-			Each particle's color will vary along this [Gradient].
+			Each particle's color will vary along this [Gradient] (multiplied with [member color]).
 		</member>
 		<member name="damping" type="float" setter="set_param" getter="get_param" default="0.0">
 			The rate at which particles lose velocity.

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -148,10 +148,10 @@
 			Animation speed randomness ratio.
 		</member>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
-			Unused for 3D particles.
+			Each particle's initial color. To have particle display color in a [BaseMaterial3D] make sure to set [member BaseMaterial3D.vertex_color_use_as_albedo] to [code]true[/code].
 		</member>
 		<member name="color_ramp" type="Gradient" setter="set_color_ramp" getter="get_color_ramp">
-			Unused for 3D particles.
+			Each particle's color will vary along this [GradientTexture] over its lifetime (multiplied with [member color]).
 		</member>
 		<member name="damping" type="float" setter="set_param" getter="get_param" default="0.0">
 			The rate at which particles lose velocity.

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -145,7 +145,7 @@
 			Each particle's initial color. If the [GPUParticles2D]'s [code]texture[/code] is defined, it will be multiplied by this color. To have particle display color in a [BaseMaterial3D] make sure to set [member BaseMaterial3D.vertex_color_use_as_albedo] to [code]true[/code].
 		</member>
 		<member name="color_ramp" type="Texture2D" setter="set_color_ramp" getter="get_color_ramp">
-			Each particle's color will vary along this [GradientTexture].
+			Each particle's color will vary along this [GradientTexture] over its lifetime (multiplied with [member color]).
 		</member>
 		<member name="damping" type="float" setter="set_param" getter="get_param" default="0.0">
 			The rate at which particles lose velocity.

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -463,10 +463,6 @@ Vector2 CPUParticles2D::get_gravity() const {
 }
 
 void CPUParticles2D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "color" && color_ramp.is_valid()) {
-		property.usage = PROPERTY_USAGE_NONE;
-	}
-
 	if (property.name == "emission_sphere_radius" && emission_shape != EMISSION_SHAPE_SPHERE) {
 		property.usage = PROPERTY_USAGE_NONE;
 	}

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -434,10 +434,6 @@ Vector3 CPUParticles3D::get_gravity() const {
 }
 
 void CPUParticles3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "color" && color_ramp.is_valid()) {
-		property.usage = PROPERTY_USAGE_NONE;
-	}
-
 	if (property.name == "emission_sphere_radius" && emission_shape != EMISSION_SHAPE_SPHERE) {
 		property.usage = PROPERTY_USAGE_NONE;
 	}

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -569,7 +569,7 @@ void ParticlesMaterial::_update_shader() {
 	code += "			vec4(1.250, -1.050, -0.203, 0.0),\n";
 	code += "			vec4(0.000, 0.000, 0.000, 0.0)) * hue_rot_s;\n";
 	if (color_ramp.is_valid()) {
-		code += "	COLOR = hue_rot_mat * textureLod(color_ramp, vec2(tv, 0.0), 0.0);\n";
+		code += "	COLOR = hue_rot_mat * textureLod(color_ramp, vec2(tv, 0.0), 0.0) * color_value;\n";
 	} else {
 		code += "	COLOR = hue_rot_mat * color_value;\n";
 	}
@@ -1040,10 +1040,6 @@ RID ParticlesMaterial::get_shader_rid() const {
 }
 
 void ParticlesMaterial::_validate_property(PropertyInfo &property) const {
-	if (property.name == "color" && color_ramp.is_valid()) {
-		property.usage = PROPERTY_USAGE_NONE;
-	}
-
 	if (property.name == "emission_sphere_radius" && emission_shape != EMISSION_SHAPE_SPHERE) {
 		property.usage = PROPERTY_USAGE_NONE;
 	}


### PR DESCRIPTION
This PR fixes the color properties of CPUParticles2D/CPUParticles3D as well as ParticleMaterial, which would close #48506.
It contains the following changes:
- Fix color property getting hidden when a colorramp is added although the final color is determined by both (multiplication) in CPUParticles2D/CPUParticles3D
- Changed the behavior of ParticlesMaterial for consistency to match with CPUParticles2D/CPUParticles3D (color property stays visible and final color is computed as: color*colorramp)
- Updated documentation and replaced the hint "Unused for 3D particles." for the color properties in CPUParticles3D since this wasn't true in the first place (same behavior as with ParticleMaterial, the color properties are accesible in the shader/mesh material)

As #48506 was opened for 3.3 this could be backported if desired.