### PR TITLE
Amend the quit() method description in `SceneTree` to include an exception for iOS

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -207,6 +207,7 @@
 				Quits the application at the end of the current iteration. Argument [code]exit_code[/code] can optionally be given (defaulting to 0) to customize the exit status code.
 				By convention, an exit code of [code]0[/code] indicates success whereas a non-zero exit code indicates an error.
 				For portability reasons, the exit code should be set between 0 and 125 (inclusive).
+				[b]Note:[/b] On iOS this method doesn't work. Instead, as recommended by the iOS Human Interface Guidelines, the user is expected to close apps via the Home button.
 			</description>
 		</method>
 		<method name="reload_current_scene">


### PR DESCRIPTION
Updated the `SceneTree.quit()` method to include a note that on iOS this method won't work as apps are expected to be closed via the Home button, not programmatically.

Resolves: #43655