### PR TITLE
Amend `Popup` class description

### DIFF
--- a/doc/classes/Popup.xml
+++ b/doc/classes/Popup.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Popup is a base [Control] used to show dialogs and popups. It's a subwindow and modal by default (see [Control]) and has helpers for custom popup behavior.
+		[b]Note:[/b] An open Popup window is focus-capturing.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Amend the `Popup` class description to have a note mentioning that popup windows are focus-capturing when open.

Resolves: #49116
