### PR TITLE
Refactor main.cpp setup

### DIFF
--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -34,10 +34,10 @@
 #include "core/string/string_name.h"
 
 class CoreStringNames {
-	friend void register_core_types();
-	friend void unregister_core_types();
-
+	friend void register_core();
 	static void create() { singleton = memnew(CoreStringNames); }
+
+	friend void unregister_core();
 	static void free() {
 		memdelete(singleton);
 		singleton = nullptr;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -754,13 +754,13 @@ class ObjectDB {
 	static uint64_t validator_counter;
 
 	friend class Object;
-	friend void unregister_core_types();
+	friend void unregister_core();
 	static void cleanup();
 
 	static ObjectID add_instance(Object *p_object);
 	static void remove_instance(Object *p_object);
 
-	friend void register_core_types();
+	friend void register_core();
 	static void setup();
 
 public:

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -364,7 +364,7 @@ String OS::get_model_name() const {
 	return "GenericDevice";
 }
 
-void OS::set_cmdline(const char *p_execpath, const List<String> &p_args) {
+void OS::set_cmdline(const String p_execpath, const List<String> &p_args) {
 	_execpath = p_execpath;
 	_cmdline = p_args;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -103,7 +103,7 @@ protected:
 	virtual void finalize() = 0;
 	virtual void finalize_core() = 0;
 
-	virtual void set_cmdline(const char *p_execpath, const List<String> &p_args);
+	virtual void set_cmdline(const String p_execpath, const List<String> &p_args);
 
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
 

--- a/core/register_core_types.h
+++ b/core/register_core_types.h
@@ -31,9 +31,11 @@
 #ifndef REGISTER_CORE_TYPES_H
 #define REGISTER_CORE_TYPES_H
 
+void register_core();
 void register_core_types();
-void register_core_settings();
 void register_core_singletons();
+
 void unregister_core_types();
+void unregister_core();
 
 #endif // REGISTER_CORE_TYPES_H

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -72,8 +72,8 @@ class StringName {
 	};
 
 	void unref();
-	friend void register_core_types();
-	friend void unregister_core_types();
+	friend void register_core();
+	friend void unregister_core();
 	friend class Main;
 	static Mutex mutex;
 	static void setup();

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -238,6 +238,8 @@
 		<member name="application/boot_splash/use_filter" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], applies linear filtering when scaling the image (recommended for high resolution artwork). If [code]false[/code], uses nearest-neighbor interpolation (recommended for pixel art).
 		</member>
+		<member name="application/config/auto_accept_quit" type="bool" setter="" getter="" default="true">
+		</member>
 		<member name="application/config/custom_user_dir_name" type="String" setter="" getter="" default="&quot;&quot;">
 			This user directory is used for storing persistent data ([code]user://[/code] filesystem). If left empty, [code]user://[/code] resolves to a project-specific folder in Godot's own configuration folder (see [method OS.get_user_data_dir]). If a custom directory name is defined, this name will be used instead and appended to the system-specific user data directory (same parent folder as the Godot configuration folder documented in [method OS.get_user_data_dir]).
 			The [member application/config/use_custom_user_dir] setting must be enabled for this to take effect.
@@ -249,7 +251,6 @@
 			Icon used for the project, set when project loads. Exporters will also use this icon when possible.
 		</member>
 		<member name="application/config/macos_native_icon" type="String" setter="" getter="" default="&quot;&quot;">
-			Icon set in [code].icns[/code] format used on macOS to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
 		</member>
 		<member name="application/config/name" type="String" setter="" getter="" default="&quot;&quot;">
 			The project's name. It is used both by the Project Manager and by exporters. The project name can be translated by translating its value in localization files. The window title will be set to match the project name automatically on startup.
@@ -258,6 +259,8 @@
 		<member name="application/config/project_settings_override" type="String" setter="" getter="" default="&quot;&quot;">
 			Specifies a file to override project settings. For example: [code]user://custom_settings.cfg[/code]. See "Overriding" in the [ProjectSettings] class description at the top for more information.
 			[b]Note:[/b] Regardless of this setting's value, [code]res://override.cfg[/code] will still be read to override the project settings.
+		</member>
+		<member name="application/config/quit_on_go_back" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="application/config/use_custom_user_dir" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the project will save user data to its own user directory (see [member application/config/custom_user_dir_name]). This setting is only effective on desktop platforms. A name must be set in the [member application/config/custom_user_dir_name] setting for this to take effect. If [code]false[/code], the project will save user data to [code](OS user data directory)/Godot/app_userdata/(project name)[/code].
@@ -289,6 +292,8 @@
 		</member>
 		<member name="application/run/low_processor_mode_sleep_usec" type="int" setter="" getter="" default="6900">
 			Amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage.
+		</member>
+		<member name="application/run/main_loop_type" type="String" setter="" getter="" default="&quot;SceneTree&quot;">
 		</member>
 		<member name="application/run/main_scene" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to the main scene file that will be loaded when the project runs.
@@ -501,6 +506,10 @@
 		<member name="display/window/ios/hide_home_indicator" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the home indicator is hidden automatically. This only affects iOS devices without a physical home button.
 		</member>
+		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="display/window/per_pixel_transparency/enabled" type="bool" setter="" getter="" default="false">
+		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="" default="false">
 			Forces the main window to be always on top.
 			[b]Note:[/b] This setting is ignored on iOS, Android, and HTML5.
@@ -529,6 +538,14 @@
 		</member>
 		<member name="display/window/size/width" type="int" setter="" getter="" default="1024">
 			Sets the game's main viewport width. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
+		</member>
+		<member name="display/window/stretch/aspect" type="String" setter="" getter="" default="&quot;ignore&quot;">
+		</member>
+		<member name="display/window/stretch/mode" type="String" setter="" getter="" default="&quot;disabled&quot;">
+		</member>
+		<member name="display/window/stretch/shrink" type="float" setter="" getter="" default="1.0">
+		</member>
+		<member name="display/window/subwindows/embed_subwindows" type="bool" setter="" getter="" default="false">
 		</member>
 		<member name="display/window/vsync/use_vsync" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables vertical synchronization. This eliminates tearing that may appear in moving scenes, at the cost of higher input latency and stuttering at lower framerates. If [code]false[/code], vertical synchronization will be disabled, however, many platforms will enforce it regardless (such as mobile platforms and HTML5).
@@ -560,10 +577,14 @@
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.
 		</member>
+		<member name="gui/common/snap_controls_to_pixels" type="bool" setter="" getter="" default="true">
+		</member>
 		<member name="gui/common/swap_cancel_ok" type="bool" setter="" getter="">
 			If [code]true[/code], swaps Cancel and OK buttons in dialogs on Windows and UWP to follow interface conventions.
 		</member>
 		<member name="gui/common/text_edit_undo_stack_max_size" type="int" setter="" getter="" default="1024">
+		</member>
+		<member name="gui/fonts/dynamic_fonts/use_oversampling" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="gui/theme/custom" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to a custom [Theme] resource file to use for the project ([code]theme[/code] or generic [code]tres[/code]/[code]res[/code] extension).
@@ -1571,6 +1592,10 @@
 		</member>
 		<member name="rendering/shadows/shadows/soft_shadow_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/shadows/shadows/soft_shadow_quality] on mobile devices, due to performance concerns or driver support.
+		</member>
+		<member name="rendering/textures/canvas_textures/default_texture_filter" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="rendering/textures/canvas_textures/default_texture_repeat" type="int" setter="" getter="" default="0">
 		</member>
 		<member name="rendering/textures/default_filters/anisotropic_filtering_level" type="int" setter="" getter="" default="2">
 			Sets the maximum number of samples to take when using anisotropic filtering on textures (as a power of two). A higher sample count will result in sharper textures at oblique angles, but is more expensive to compute. A value of [code]0[/code] forcibly disables anisotropic filtering, even on materials where it is enabled.

--- a/drivers/register_driver_types.cpp
+++ b/drivers/register_driver_types.cpp
@@ -52,9 +52,3 @@ void unregister_core_driver_types() {
 	ResourceSaver::remove_resource_format_saver(resource_saver_png);
 	resource_saver_png.unref();
 }
-
-void register_driver_types() {
-}
-
-void unregister_driver_types() {
-}

--- a/drivers/register_driver_types.h
+++ b/drivers/register_driver_types.h
@@ -34,7 +34,4 @@
 void register_core_driver_types();
 void unregister_core_driver_types();
 
-void register_driver_types();
-void unregister_driver_types();
-
 #endif

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5687,10 +5687,6 @@ EditorNode::EditorNode() {
 	script_distraction = false;
 
 	TranslationServer::get_singleton()->set_enabled(false);
-	// load settings
-	if (!EditorSettings::get_singleton()) {
-		EditorSettings::create();
-	}
 
 	FileAccess::set_backup_save(EDITOR_GET("filesystem/on_save/safe_save_on_backup_then_rename"));
 

--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -129,7 +129,7 @@ EditorPaths::EditorPaths(bool p_for_project_mamanger) {
 
 		// Validate/create cache dir
 
-		if (dir->change_dir(EditorPaths::get_singleton()->get_cache_dir()) != OK) {
+		if (dir->change_dir(cache_dir) != OK) {
 			dir->make_dir_recursive(cache_dir);
 			if (dir->change_dir(cache_dir) != OK) {
 				ERR_PRINT("Cannot create cache directory!");

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -44,6 +44,7 @@
 #include "editor_scale.h"
 #include "editor_settings.h"
 #include "editor_themes.h"
+#include "progress_dialog.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/margin_container.h"
@@ -2389,11 +2390,6 @@ void ProjectManager::_version_button_pressed() {
 }
 
 ProjectManager::ProjectManager() {
-	// load settings
-	if (!EditorSettings::get_singleton()) {
-		EditorSettings::create();
-	}
-
 	EditorSettings::get_singleton()->set_optimize_save(false); //just write settings as they came
 
 	{
@@ -2469,6 +2465,9 @@ ProjectManager::ProjectManager() {
 	set_theme(create_custom_theme());
 
 	set_anchors_and_offsets_preset(Control::PRESET_WIDE);
+
+	ProgressDialog *progress_dialog = memnew(ProgressDialog);
+	add_child(progress_dialog);
 
 	Panel *panel = memnew(Panel);
 	add_child(panel);

--- a/main/application_configuration.cpp
+++ b/main/application_configuration.cpp
@@ -1,0 +1,672 @@
+/*************************************************************************/
+/*  application_configuration.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "application_configuration.h"
+
+#include "core/config/project_settings.h"
+#include "core/os/dir_access.h"
+#include "core/templates/list.h"
+#include "core/version.h"
+#include "core/version_hash.gen.h"
+#include "servers/audio_server.h"
+#include "servers/display_server.h"
+#include "servers/text_server.h"
+
+void print_help(const char *p_exec_path);
+
+// Moves the iterator if the next argument is a parameter.
+#define EAT_PARAMETER                                                                                                                     \
+	if (!I || !is_parameter(I->get())) {                                                                                                  \
+		OS::get_singleton()->printerr("Missing parameter for argument '%s'.\nUse --help for more information.\n", arg.utf8().get_data()); \
+		return ERR_INVALID_PARAMETER;                                                                                                     \
+	}                                                                                                                                     \
+	param = I->get();                                                                                                                     \
+	I = I->next();
+
+// Prints a predefined message.
+#define EXIT_COND(m_cond, m_msg)                                                                                                                                                  \
+	if (m_cond) {                                                                                                                                                                 \
+		OS::get_singleton()->printerr("Invalid parameter '%s' for argument '%s'. %s\nUse --help for more information.\n", param.utf8().get_data(), arg.utf8().get_data(), m_msg); \
+		return ERR_INVALID_PARAMETER;                                                                                                                                             \
+	}
+
+static String clean_argument(const char *arg) {
+	return String::utf8(arg).strip_edges().replace("%20", " ");
+}
+
+bool is_parameter(const String &arg) {
+	return arg.length() > 0 && arg[0] != '-';
+}
+
+String get_full_version_string() {
+	String hash = String(VERSION_HASH);
+	if (hash.length() != 0) {
+		hash = "." + hash.left(9);
+	}
+	return String(VERSION_FULL_BUILD) + hash;
+}
+
+String get_program_string() {
+	return String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE);
+}
+
+Error parse_configuration(const char *exec_path, int argc, char *argv[], ApplicationConfiguration &r_config) {
+	r_config.exec_path = exec_path;
+
+	List<String> args;
+	for (int i = 0; i < argc; i++) {
+		args.push_back(clean_argument(argv[i]));
+	}
+
+	bool file_specified = false;
+
+	// Step through the list of arguments, filling in the configuration
+	// as requested. An argument can have multiple required or optional
+	// parameters. All parameters for an argument are handled within a
+	// single loop iteration, so that at the end of iteration the list
+	// iterator points to the next argument.
+	List<String>::Element *I = args.front();
+	while (I) {
+		const String arg = I->get();
+		I = I->next();
+		String param;
+
+#ifdef OSX_ENABLED
+		// Ignore the process serial number argument passed by macOS Gatekeeper.
+		// Otherwise, Godot would try to open a non-existent project on the first start and abort.
+		if (arg.begins_with("-psn_")) {
+			continue;
+		}
+#endif
+
+		if (arg == "--") {
+			// Pass the remaining arguments to the project.
+			while (I) {
+				r_config.user_args.push_back(I->get());
+				I = I->next();
+			}
+		} else if (is_parameter(arg) && !file_specified) {
+			file_specified = true;
+
+			if (arg.ends_with("project.godot")) {
+#ifdef TOOLS_ENABLED
+				if (r_config.application_type == ApplicationType::PROJECT) {
+					r_config.application_type = ApplicationType::EDITOR;
+				}
+#endif
+				String directory = arg.get_base_dir();
+
+				if (OS::get_singleton()->set_cwd(directory) != OK) {
+					r_config.project_path = directory;
+				}
+			} else if (arg.ends_with(".scn") ||
+					   arg.ends_with(".tscn") ||
+					   arg.ends_with(".escn") ||
+					   arg.ends_with(".res") ||
+					   arg.ends_with(".tres")) {
+				// Only consider the argument to be a scene path if it ends with
+				// a file extension associated with Godot scenes. This makes it possible
+				// for projects to parse command-line arguments for custom CLI arguments
+				// or other file extensions without trouble. This can be used to implement
+				// "drag-and-drop onto executable" logic, which can prove helpful
+				// for non-game applications.
+				r_config.scene_path = arg;
+			}
+		} else if (arg == "-s" || arg == "--script") {
+			EAT_PARAMETER;
+			r_config.script_path = param;
+			r_config.application_type = ApplicationType::SCRIPT;
+
+			if (I && I->get() == "--check-only") {
+				r_config.selected_tool = StandaloneTool::VALIDATE_SCRIPT;
+				r_config.run_tool = true;
+				I = I->next();
+			}
+		} else if (arg == "--path") {
+			EAT_PARAMETER;
+
+			if (OS::get_singleton()->set_cwd(param) != OK) {
+				r_config.project_path = param; //use project_path instead
+			}
+		} else if (arg == "--main-pack") {
+			EAT_PARAMETER;
+			r_config.main_pack = param;
+		} else if (arg == "-h" || arg == "--help" || arg == "/?") {
+			print_help(exec_path);
+			return ERR_INVALID_PARAMETER;
+		} else if (arg == "--version") {
+			print_line(get_full_version_string());
+			return ERR_INVALID_PARAMETER;
+		} else if (arg == "-v" || arg == "--verbose") {
+			r_config.output_verbosity = OutputVerbosity::VERBOSE;
+		} else if (arg == "--quiet") {
+			r_config.output_verbosity = OutputVerbosity::QUIET;
+		} else if (arg == "--audio-driver") {
+			EAT_PARAMETER;
+
+			const int audio_driver_count = AudioDriverManager::get_driver_count();
+
+			for (int i = 0; i < audio_driver_count; i++) {
+				if (param == AudioDriverManager::get_driver(i)->get_name()) {
+					r_config.audio_driver_index = i;
+					break;
+				}
+			}
+
+			if (r_config.audio_driver_index < 0) {
+				OS::get_singleton()->printerr("Unknown audio driver '%s'. Choose one of: ", param.utf8().get_data());
+				print_audio_drivers();
+				return ERR_INVALID_PARAMETER;
+			}
+		} else if (arg == "--text-driver") {
+			EAT_PARAMETER;
+
+			const int text_interface_count = TextServerManager::get_interface_count();
+			for (int i = 0; i < text_interface_count; i++) {
+				if (param == TextServerManager::get_interface_name(i)) {
+					r_config.text_driver_index = i;
+					break;
+				}
+			}
+
+			if (r_config.text_driver_index < 0) {
+				OS::get_singleton()->printerr("Unknown text interface '%s'.", param.utf8().get_data());
+				return ERR_INVALID_PARAMETER;
+			}
+		} else if (arg == "--display-driver") {
+			EAT_PARAMETER;
+
+			const int display_driver_count = DisplayServer::get_create_function_count();
+
+			for (int i = 0; i < display_driver_count; i++) {
+				if (param == DisplayServer::get_create_function_name(i)) {
+					r_config.display_driver_index = i;
+					break;
+				}
+			}
+
+			if (r_config.display_driver_index < 0) {
+				OS::get_singleton()->print("Unknown display driver '%s'. Choose one of: ", param.utf8().get_data());
+				print_display_drivers();
+				return ERR_INVALID_PARAMETER;
+			}
+#ifndef SERVER_ENABLED // Display options
+		} else if (arg == "--tablet-driver") {
+			EAT_PARAMETER;
+			r_config.tablet_driver_name = param;
+		} else if (arg == "-f" || arg == "--fullscreen") {
+			r_config.window_mode = DisplayServer::WindowMode::WINDOW_MODE_FULLSCREEN;
+			r_config.forced_window_mode = true;
+		} else if (arg == "-m" || arg == "--maximized") {
+			r_config.window_mode = DisplayServer::WindowMode::WINDOW_MODE_MAXIMIZED;
+			r_config.forced_window_mode = true;
+		} else if (arg == "-w" || arg == "--windowed") {
+			r_config.window_mode = DisplayServer::WindowMode::WINDOW_MODE_WINDOWED;
+			r_config.forced_window_mode = true;
+		} else if (arg == "-t" || arg == "--always-on-top") {
+			r_config.window_flags |= DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP;
+		} else if (arg == "--no-window") {
+			r_config.no_window_mode = true;
+		} else if (arg == "--single-window") {
+			r_config.single_window = true;
+		} else if (arg == "--low-dpi") {
+			r_config.allow_hidpi = false;
+		} else if (arg == "--enable-vsync-via-compositor") {
+			r_config.override_vsync_via_compositor_value = true;
+			r_config.window_vsync_via_compositor = true;
+		} else if (arg == "--disable-vsync-via-compositor") {
+			r_config.override_vsync_via_compositor_value = true;
+			r_config.window_vsync_via_compositor = false;
+#ifdef DEBUG_ENABLED
+		} else if (arg == "--gpu-abort") {
+			r_config.abort_on_gpu_errors = true;
+#endif // DEBUG_ENABLED
+		} else if (arg == "--resolution") {
+			EAT_PARAMETER;
+			EXIT_COND(param.find("x") == -1, "Resolution should be e.g. 600x400.");
+
+			int w = param.get_slice("x", 0).to_int();
+			int h = param.get_slice("x", 1).to_int();
+			EXIT_COND(w <= 0 || h <= 0, "Width and height should be greater than 0.");
+
+			r_config.window_size = Size2i(w, h);
+			r_config.forced_window_size = true;
+		} else if (arg == "--position") {
+			EAT_PARAMETER;
+			EXIT_COND(param.find(",") == -1, "Position should be e.g. 100,200.");
+
+			int x = param.get_slice(",", 0).to_int();
+			int y = param.get_slice(",", 1).to_int();
+
+			r_config.window_position = Point2(x, y);
+#endif // !SERVER_ENABLED
+		} else if (arg == "-l" || arg == "--language") {
+			EAT_PARAMETER;
+			r_config.locale = param;
+		} else if (arg == "--remote-fs") {
+			EAT_PARAMETER;
+			if (param.find(":") != -1) {
+				r_config.remote_filesystem_address = param.get_slicec(':', 0);
+				r_config.remote_filesystem_port = param.get_slicec(':', 1).to_int();
+			} else {
+				r_config.remote_filesystem_address = param;
+				r_config.remote_filesystem_port = 6010;
+			}
+		} else if (arg == "--remote-fs-password") {
+			EAT_PARAMETER;
+			r_config.remote_filesystem_password = param;
+		} else if (arg == "--render-thread") {
+			EAT_PARAMETER;
+			if (param == "safe") {
+				r_config.render_thread_mode = OS::RENDER_THREAD_SAFE;
+			} else if (param == "unsafe") {
+				r_config.render_thread_mode = OS::RENDER_THREAD_UNSAFE;
+			} else if (param == "separate") {
+				r_config.render_thread_mode = OS::RENDER_SEPARATE_THREAD;
+			} else {
+				EXIT_COND(true, "Invalid parameter for argument '%s'. It should be 'safe', 'unsafe' or 'separate'");
+			}
+		} else if (arg == "-u" || arg == "--upwards") {
+			r_config.scan_folders_upwards = true;
+		} else if (arg == "-q" || arg == "--quit") {
+			r_config.auto_quit = true;
+		} else if (arg == "-d" || arg == "--debug") {
+			r_config.debug_uri = "local://";
+			r_config.debug_output = true;
+		} else if (arg == "-b" || arg == "--breakpoints") {
+			EAT_PARAMETER;
+			r_config.breakpoints = param.split(",");
+		} else if (arg == "--skip-breakpoints") {
+			r_config.skip_breakpoints = true;
+		} else if (arg == "--profiling") {
+			r_config.enable_debug_profiler = true;
+		} else if (arg == "--profile-gpu") {
+			r_config.enable_gpu_profiler = true;
+		} else if (arg == "--vk-layers") {
+			r_config.use_validation_layers = true;
+		} else if (arg == "--disable-crash-handler") {
+			r_config.disable_crash_handler = true;
+		} else if (arg == "--allow_focus_steal_pid") {
+			EAT_PARAMETER;
+			r_config.allow_focus_steal_pid = param.to_int();
+		} else if (arg == "--disable-render-loop") {
+			r_config.disable_render_loop = true;
+#if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
+		} else if (arg == "--debug-collisions") {
+			r_config.enable_debug_collisions = true;
+		} else if (arg == "--debug-navigation") {
+			r_config.enable_debug_navigation = true;
+#endif
+		} else if (arg == "--frame-delay") {
+			EAT_PARAMETER;
+			r_config.frame_delay = param.to_int();
+		} else if (arg == "--time-scale") {
+			EAT_PARAMETER;
+			r_config.time_scale = param.to_float();
+		} else if (arg == "--fixed-fps") {
+			EAT_PARAMETER;
+			r_config.fixed_fps = param.to_int();
+		} else if (arg == "--print-fps") {
+			r_config.print_fps = true;
+		} else if (arg == "--remote-debug") {
+			EAT_PARAMETER;
+			ERR_FAIL_COND_V_MSG((param.find("://") == -1), ERR_INVALID_PARAMETER, "Invalid debug host address, it should be of the form <protocol>://<host/IP>:<port>.");
+
+			r_config.debug_uri = param;
+#ifdef TOOLS_ENABLED
+		} else if (arg == "-e" || arg == "--editor") {
+			r_config.application_type = ApplicationType::EDITOR;
+			r_config.main_args.push_back(arg);
+		} else if (arg == "-p" || arg == "--project-manager") {
+			r_config.application_type = ApplicationType::PROJECT_MANAGER;
+		} else if (arg == "--build-solutions") {
+			r_config.auto_build_solutions = true;
+			r_config.application_type = ApplicationType::EDITOR;
+		} else if (arg == "--export") {
+			EAT_PARAMETER;
+			r_config.export_config.preset = param;
+
+			EAT_PARAMETER;
+			r_config.export_config.path = param;
+
+			r_config.main_args.push_back(arg);
+			r_config.selected_tool = StandaloneTool::EXPORT;
+
+			// Export has multiple optional flags, and they can appear in any order.
+			Vector<String> flag_candidates;
+			if (I) {
+				flag_candidates.push_back(I->get());
+				if (I->next()) {
+					flag_candidates.push_back(I->next()->get());
+				}
+			}
+
+			for (int i = 0; i < flag_candidates.size(); i++) {
+				bool valid_flag = true;
+				if (flag_candidates[i] == "--export-debug") {
+					r_config.export_config.debug_build = true;
+				} else if (flag_candidates[i] == "--export-pack") {
+					r_config.export_config.pack_only = true;
+				} else {
+					valid_flag = false;
+				}
+
+				if (valid_flag) {
+					I = I->next();
+				}
+			}
+		} else if (arg == "--doctool") {
+			r_config.selected_tool = StandaloneTool::DOC_TOOL;
+			r_config.run_tool = true;
+
+			r_config.doc_tool_path = "."; // Assume current directory if no path is given.
+			r_config.doc_base_types = true;
+
+			// DocTool has multiple optional parameters, but they are ordered.
+			if (I) {
+				param = I->get();
+
+				if (is_parameter(param)) {
+					r_config.doc_tool_path = param;
+
+					if (!I->next()) {
+						continue;
+					}
+
+					param = I->next()->get();
+				}
+
+				if (param == "--no-docbase") {
+					r_config.doc_base_types = false;
+				}
+			}
+#ifdef DEBUG_METHODS_ENABLED
+		} else if (arg == "--gdnative-generate-json-api" || arg == "--gdnative-generate-json-builtin-api") {
+			// Register as an editor instance to use low-end fallback if relevant.
+			r_config.application_type = ApplicationType::EDITOR;
+
+			// We still pass it to the main arguments since the argument handling itself is not done in this function
+			r_config.main_args.push_back(arg);
+#endif // DEBUG_METHODS_ENABLED
+#endif // TOOLS_ENABLED
+		} else {
+			r_config.main_args.push_back(arg);
+		}
+	}
+
+	return OK;
+}
+
+Error finalize_configuration(ApplicationConfiguration &r_config) {
+	// Window configuration
+	{
+		if (r_config.application_type != ApplicationType::PROJECT_MANAGER && r_config.application_type != ApplicationType::EDITOR) {
+			if (!r_config.forced_window_size) {
+#ifdef TOOLS_ENABLED
+				r_config.window_size.width = GLOBAL_GET("display/window/size/test_width");
+				r_config.window_size.height = GLOBAL_GET("display/window/size/test_height");
+
+				if (r_config.window_size == Size2i()) {
+					r_config.window_size.width = GLOBAL_GET("display/window/size/width");
+					r_config.window_size.height = GLOBAL_GET("display/window/size/height");
+				}
+#else
+				r_config.window_size.width = GLOBAL_GET("display/window/size/width");
+				r_config.window_size.height = GLOBAL_GET("display/window/size/height");
+#endif // TOOLS_ENABLED
+			}
+
+			if (!bool(GLOBAL_GET("display/window/size/resizable"))) {
+				r_config.window_flags |= DisplayServer::WINDOW_FLAG_RESIZE_DISABLED_BIT;
+			}
+			if (bool(GLOBAL_GET("display/window/size/borderless"))) {
+				r_config.window_flags |= DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
+			}
+			if (bool(GLOBAL_GET("display/window/size/always_on_top"))) {
+				r_config.window_flags |= DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP_BIT;
+			}
+			if (bool(GLOBAL_GET("display/window/size/fullscreen"))) {
+				r_config.window_mode = DisplayServer::WINDOW_MODE_FULLSCREEN;
+			}
+		}
+
+#ifdef TOOLS_ENABLED
+		if (r_config.run_tool) {
+			r_config.no_window_mode = true;
+		}
+
+		if (r_config.application_type == ApplicationType::EDITOR && !r_config.forced_window_mode) {
+			r_config.window_mode = DisplayServer::WINDOW_MODE_MAXIMIZED;
+		}
+#endif // TOOLS_ENABLED
+	}
+
+	if ((r_config.application_type == ApplicationType::EDITOR || r_config.application_type == ApplicationType::PROJECT) && r_config.scene_path == "") {
+		r_config.scene_path = String(GLOBAL_GET("application/run/main_scene"));
+
+		// Only fail if running the projecct.
+		bool should_fail = (r_config.application_type == ApplicationType::PROJECT && r_config.scene_path == "");
+		ERR_FAIL_COND_V_MSG(should_fail, ERR_INVALID_PARAMETER, vformat("Can't run project '%s': no main scene defined.\n", r_config.project_path.utf8().get_data()));
+	}
+
+#ifdef TOOLS_ENABLED
+	if (r_config.export_config.preset != "") {
+		r_config.scene_path = ""; // Do not load anything.
+	}
+
+	if (r_config.doc_tool_path != "") {
+		DirAccessRef da = DirAccess::open(r_config.doc_tool_path);
+		ERR_FAIL_COND_V_MSG(!da, ERR_INVALID_PARAMETER, "Argument supplied to --doctool must be a valid directory path.");
+	}
+#endif // TOOLS_ENABLED
+
+	if (!r_config.override_vsync_via_compositor_value) {
+		// If one of the command line options to enable/disable vsync via the
+		// window compositor ("--enable-vsync-via-compositor" or
+		// "--disable-vsync-via-compositor") was present then it overrides the
+		// project setting.
+		r_config.window_vsync_via_compositor = GLOBAL_GET("display/window/vsync/vsync_via_compositor");
+	}
+
+#ifdef NO_THREADS
+	r_config.render_thread_mode = OS::RENDER_THREAD_UNSAFE; // No threads available on this platform.
+#else
+#ifdef TOOLS_ENABLED
+	if (r_config.application_type == ApplicationType::EDITOR) {
+		r_config.render_thread_mode = OS::RENDER_THREAD_SAFE;
+	}
+#endif // TOOLS_ENABLED
+#endif // NO_THREADS
+
+	return OK;
+}
+
+void print_audio_drivers() {
+	const int audio_driver_count = AudioDriverManager::get_driver_count();
+	if (audio_driver_count == 0) {
+		OS::get_singleton()->print("[].\n");
+		return;
+	}
+
+	OS::get_singleton()->print("['%s'", AudioDriverManager::get_driver(0)->get_name());
+	if (audio_driver_count > 1) {
+		for (int i = 1; i < audio_driver_count - 1; i++) {
+			OS::get_singleton()->print(", '%s'", AudioDriverManager::get_driver(i)->get_name());
+		}
+
+		OS::get_singleton()->print(" and '%s'", AudioDriverManager::get_driver(audio_driver_count - 1)->get_name());
+	}
+	OS::get_singleton()->print("].\n");
+}
+
+void print_display_drivers() {
+	const int display_driver_count = DisplayServer::get_create_function_count();
+	if (display_driver_count == 0) {
+		OS::get_singleton()->print("[].\n");
+		return;
+	}
+
+	OS::get_singleton()->print("['%s'", DisplayServer::get_create_function_name(0));
+	if (display_driver_count > 1) {
+		for (int i = 1; i < display_driver_count; i++) {
+			OS::get_singleton()->print(", '%s'", DisplayServer::get_create_function_name(i));
+		}
+	}
+	OS::get_singleton()->print("].\n");
+}
+
+void print_display_and_rendering_drivers() {
+	const int display_driver_count = DisplayServer::get_create_function_count();
+	if (display_driver_count == 0) {
+		OS::get_singleton()->print("[].\n");
+		return;
+	}
+
+	for (int i = 0; i < display_driver_count; i++) {
+		if (i > 0) {
+			OS::get_singleton()->print(", ");
+		}
+		OS::get_singleton()->print("['%s' (", DisplayServer::get_create_function_name(i));
+		Vector<String> rd = DisplayServer::get_create_function_rendering_drivers(i);
+		for (int j = 0; j < rd.size(); j++) {
+			if (j > 0) {
+				OS::get_singleton()->print(", ");
+			}
+			OS::get_singleton()->print("'%s'", rd[j].utf8().get_data());
+		}
+		OS::get_singleton()->print(")");
+	}
+	OS::get_singleton()->print("].\n");
+}
+
+void print_help(const char *p_exec_path) {
+	print_line(get_program_string());
+	OS::get_singleton()->print("Free and open source software under the terms of the MIT license.\n");
+	OS::get_singleton()->print("(c) 2007-2021 Juan Linietsky, Ariel Manzur.\n");
+	OS::get_singleton()->print("(c) 2014-2021 Godot Engine contributors.\n");
+	OS::get_singleton()->print("\n");
+	OS::get_singleton()->print("Usage: %s [options] [path to scene or 'project.godot' file]\n", p_exec_path);
+	OS::get_singleton()->print("\n");
+
+	OS::get_singleton()->print("General options:\n");
+	OS::get_singleton()->print("  -h, --help                                   Display this help message and exit.\n");
+	OS::get_singleton()->print("  --version                                    Display the version string and exit.\n");
+	OS::get_singleton()->print("  -v, --verbose                                Use verbose stdout mode.\n");
+	OS::get_singleton()->print("  --quiet                                      Quiet mode, silences stdout messages. Errors are still displayed.\n");
+	OS::get_singleton()->print("  --                                           Pass every following argument to the project. \n");
+	OS::get_singleton()->print("\n");
+
+	OS::get_singleton()->print("Run options:\n");
+#ifdef TOOLS_ENABLED
+	OS::get_singleton()->print("  -e, --editor                                 Start the editor instead of running the scene.\n");
+	OS::get_singleton()->print("  -p, --project-manager                        Start the project manager, even if a project is auto-detected.\n");
+#endif
+	OS::get_singleton()->print("  -q, --quit                                   Quit after the first main loop iteration.\n");
+	OS::get_singleton()->print("  -l, --language <locale>                      Use a specific locale (<locale> being a two-letter code).\n");
+	OS::get_singleton()->print("  --path <directory>                           Path to a project (<directory> must contain a 'project.godot' file).\n");
+	OS::get_singleton()->print("  -u, --upwards                                Scan folders upwards for project.godot file.\n");
+	OS::get_singleton()->print("  --main-pack <file>                           Path to a pack (.pck) file to load.\n");
+	OS::get_singleton()->print("  --render-thread <mode>                       Render thread mode ('unsafe', 'safe', 'separate').\n");
+	OS::get_singleton()->print("  --remote-fs <address>                        Remote filesystem (<host/IP>[:<port>] address).\n");
+	OS::get_singleton()->print("  --remote-fs-password <password>              Password for remote filesystem.\n");
+
+	OS::get_singleton()->print("  --audio-driver <driver>                      Choose audio driver: ");
+	print_audio_drivers();
+
+	OS::get_singleton()->print("  --display-driver <driver>                    Choose display driver: ");
+	print_display_and_rendering_drivers();
+
+	OS::get_singleton()->print("  --rendering-driver <driver>                  Rendering driver (depends on display driver).\n");
+	OS::get_singleton()->print("  --text-driver <driver>                       Text driver (Fonts, BiDi, shaping)\n");
+	OS::get_singleton()->print("\n");
+
+#ifndef SERVER_ENABLED
+	OS::get_singleton()->print("Display options:\n");
+	OS::get_singleton()->print("  -f, --fullscreen                             Request fullscreen mode.\n");
+	OS::get_singleton()->print("  -m, --maximized                              Request a maximized window.\n");
+	OS::get_singleton()->print("  -w, --windowed                               Request windowed mode.\n");
+	OS::get_singleton()->print("  -t, --always-on-top                          Request an always-on-top window.\n");
+	OS::get_singleton()->print("  --resolution <W>x<H>                         Request window resolution. Format: WxH (e.g. 600x400).\n");
+	OS::get_singleton()->print("  --position <X>,<Y>                           Request window position. Format: X,Y (e.g. 100,200).\n");
+	OS::get_singleton()->print("  --low-dpi                                    Force low-DPI mode (macOS and Windows only).\n");
+	OS::get_singleton()->print("  --no-window                                  Disable window creation (Currently not implemented).\n");
+	OS::get_singleton()->print("  --enable-vsync-via-compositor                When vsync is enabled, vsync via the OS' window compositor (Windows only).\n");
+	OS::get_singleton()->print("  --disable-vsync-via-compositor               Disable vsync via the OS' window compositor (Windows only).\n");
+	OS::get_singleton()->print("  --single-window                              Use a single window (no separate subwindows).\n");
+	OS::get_singleton()->print("  --tablet-driver                              Pen tablet input driver.\n");
+	OS::get_singleton()->print("\n");
+#endif
+
+	OS::get_singleton()->print("Debug options:\n"); //set implementation-specific option. The following options are available:
+	OS::get_singleton()->print("  -d, --debug                                  Debug (local stdout debugger).\n");
+	OS::get_singleton()->print("  -b, --breakpoints                            Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
+	OS::get_singleton()->print("  --profiling                                  Enable profiling in the script debugger.\n");
+	OS::get_singleton()->print("  --vk-layers                                  Enable Vulkan Validation layers for debugging.\n");
+#if DEBUG_ENABLED
+	OS::get_singleton()->print("  --gpu-abort                                  Abort on GPU errors (usually validation layer errors), may help see the problem if your system freezes.\n");
+#endif
+	OS::get_singleton()->print("  --remote-debug <uri>                         Remote debug (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007).\n");
+#if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
+	OS::get_singleton()->print("  --debug-collisions                           Show collision shapes when running the scene.\n");
+	OS::get_singleton()->print("  --debug-navigation                           Show navigation polygons when running the scene.\n");
+#endif
+	OS::get_singleton()->print("  --frame-delay <ms>                           Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
+	OS::get_singleton()->print("  --time-scale <scale>                         Force time scale (higher values are faster, 1.0 is normal speed).\n");
+	OS::get_singleton()->print("  --disable-render-loop                        Disable render loop so rendering only occurs when called explicitly from script.\n");
+	OS::get_singleton()->print("  --disable-crash-handler                      Disable crash handler when supported by the platform code.\n");
+	OS::get_singleton()->print("  --fixed-fps <fps>                            Force a fixed number of frames per second. This setting disables real-time synchronization.\n");
+	OS::get_singleton()->print("  --print-fps                                  Print the frames per second to the stdout.\n");
+	OS::get_singleton()->print("  --profile-gpu                                Show a simple profile of the tasks that took more time during frame rendering.\n");
+	OS::get_singleton()->print("\n");
+
+	OS::get_singleton()->print("Standalone tools:\n");
+	OS::get_singleton()->print("  -s, --script <path> [--check-only]           Run a script (must inherit from MainLoop). Append --check-only to only parse the script for errors.\n");
+#ifdef TOOLS_ENABLED
+	OS::get_singleton()->print("  --export <preset> <path> [parameter]         Export the project using the given preset and matching release template. The preset name\n");
+	OS::get_singleton()->print("                                               should match one defined in export_presets.cfg. <path> should be absolute or relative to\n");
+	OS::get_singleton()->print("                                               the project directory, and include the filename for the binary (e.g. 'builds/game.exe').\n");
+	OS::get_singleton()->print("                                               The target directory should exist.\n");
+	OS::get_singleton()->print("                                               Optional parameters: --export-debug   Use debug template.\n");
+	OS::get_singleton()->print("                                                                    --export-pack    Only export the game pack. The <path> extension\n");
+	OS::get_singleton()->print("											   determines whether it will be in PCK or ZIP format.\n");
+	OS::get_singleton()->print("  --doctool [<path>] [--no-docbase]            Dump the engine API reference to the given <path> (defaults to current dir), merging if\n");
+	OS::get_singleton()->print("                                               existing files are found. Append --no-docbase to disallow dumping the base types.\n");
+	OS::get_singleton()->print("  --build-solutions                            Build the scripting solutions (e.g. for C# projects). Implies --editor and requires a valid project to edit.\n");
+#ifdef DEBUG_METHODS_ENABLED
+	OS::get_singleton()->print("  --gdnative-generate-json-api <path>          Generate JSON dump of the Godot API for GDNative bindings and save it on the file specified in <path>.\n");
+	OS::get_singleton()->print("  --gdnative-generate-json-builtin-api <path>  Generate JSON dump of the Godot API of the builtin Variant types and utility functions\n");
+	OS::get_singleton()->print("                                               for GDNative bindings and save it on the file specified in <path>.\n");
+#endif
+#ifdef TESTS_ENABLED
+	OS::get_singleton()->print("  --test [--help]                              Run unit tests. Use --test --help for more information.\n");
+#endif
+#endif
+	OS::get_singleton()->print("\n");
+}

--- a/main/application_configuration.h
+++ b/main/application_configuration.h
@@ -1,0 +1,153 @@
+/*************************************************************************/
+/*  application_configuration.h                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef APPLICATION_CONFIGURATION_H
+#define APPLICATION_CONFIGURATION_H
+
+#include "../core/error/error_list.h"
+#include "servers/display_server.h"
+
+enum class ApplicationType {
+	PROJECT,
+	SCRIPT,
+	EDITOR,
+	PROJECT_MANAGER,
+};
+
+enum class StandaloneTool {
+	DOC_TOOL,
+	EXPORT,
+	VALIDATE_SCRIPT
+};
+
+enum class OutputVerbosity {
+	NORMAL,
+	QUIET,
+	VERBOSE
+};
+
+typedef struct ExportConfiguration {
+	String preset = "";
+	String path = "";
+	bool debug_build = false;
+	bool pack_only = false;
+} ExportConfiguration;
+
+typedef struct ApplicationConfiguration {
+	ApplicationType application_type = ApplicationType::PROJECT;
+	String scene_path = "";
+
+	String project_path = ".";
+	String main_pack = "";
+	bool scan_folders_upwards = false;
+
+	String script_path;
+
+	// Tools
+	bool run_tool = false;
+	StandaloneTool selected_tool;
+
+#ifdef TOOLS_ENABLED
+	String doc_tool_path = "";
+	bool doc_base_types = true;
+
+	ExportConfiguration export_config;
+
+	bool auto_build_solutions;
+#endif
+
+	bool auto_quit = false;
+
+	// Drivers
+	int display_driver_index = -1;
+	int audio_driver_index = -1;
+	int text_driver_index = -1;
+	String tablet_driver_name;
+
+	// Display
+	bool single_window = false;
+	bool init_always_on_top;
+	bool allow_hidpi = true;
+	bool no_window_mode = false;
+
+	bool use_vsync = false;
+	bool window_vsync_via_compositor = false;
+	bool saw_vsync_via_compositor_override = false;
+	bool override_vsync_via_compositor_value = false;
+
+	DisplayServer::WindowMode window_mode = DisplayServer::WindowMode::WINDOW_MODE_WINDOWED;
+	bool forced_window_mode = false;
+	uint32_t window_flags = 0;
+	Point2 window_position;
+	Size2i window_size = Size2i(1024, 600);
+	bool forced_window_size = false;
+
+	// Debug
+	bool debug_output = false;
+	String debug_uri = "";
+	PackedStringArray breakpoints;
+	bool skip_breakpoints = false;
+	bool enable_debug_collisions = false;
+	bool enable_debug_navigation = false;
+	bool enable_debug_profiler = false;
+	bool enable_gpu_profiler = false;
+	bool disable_crash_handler = false;
+	bool disable_render_loop = false;
+	bool use_validation_layers = false;
+	bool abort_on_gpu_errors = false;
+
+	bool print_fps = false;
+	int fixed_fps = -1;
+	OutputVerbosity output_verbosity = OutputVerbosity::NORMAL;
+
+	String remote_filesystem_address;
+	String remote_filesystem_password;
+	int remote_filesystem_port;
+
+	OS::RenderThreadMode render_thread_mode;
+	double time_scale = 1;
+	int frame_delay = 0;
+	String locale;
+
+	OS::ProcessID allow_focus_steal_pid = -1; // Not exposed to user.
+
+	String exec_path;
+	List<String> main_args;
+	List<String> user_args;
+} ApplicationConfiguration;
+
+void print_audio_drivers();
+void print_display_drivers();
+
+Error parse_configuration(const char *exec_path, int argc, char *argv[], ApplicationConfiguration &r_configuration);
+Error finalize_configuration(ApplicationConfiguration &r_configuration);
+
+String get_program_string();
+#endif // APPLICATION_CONFIGURATION_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -30,6 +30,7 @@
 
 #include "main.h"
 
+#include "application_configuration.h"
 #include "core/config/project_settings.h"
 #include "core/core_string_names.h"
 #include "core/crypto/crypto.h"
@@ -58,7 +59,6 @@
 #include "modules/modules_enabled.gen.h"
 #include "modules/register_module_types.h"
 #include "platform/register_platform_apis.h"
-#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/register_scene_types.h"
 #include "scene/resources/packed_scene.h"
@@ -74,180 +74,66 @@
 #include "servers/text_server.h"
 #include "servers/xr_server.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "editor/project_manager.h"
+#include "standalone_tools.h"
+#endif
+
 #ifdef TESTS_ENABLED
 #include "tests/test_main.h"
 #endif
 
-#ifdef TOOLS_ENABLED
-
-#include "editor/doc_data_class_path.gen.h"
-#include "editor/doc_tools.h"
-#include "editor/editor_node.h"
-#include "editor/editor_settings.h"
-#include "editor/progress_dialog.h"
-#include "editor/project_manager.h"
-
-#endif
-
-/* Static members */
-
-// Singletons
-
+/* Singletons */
 // Initialized in setup()
 static Engine *engine = nullptr;
-static ProjectSettings *globals = nullptr;
+static ProjectSettings *project_settings = nullptr;
 static Input *input = nullptr;
 static InputMap *input_map = nullptr;
 static TranslationServer *translation_server = nullptr;
 static Performance *performance = nullptr;
 static PackedData *packed_data = nullptr;
+static FileAccessNetworkClient *file_access_network_client = nullptr;
+static MessageQueue *message_queue = nullptr;
 #ifdef MINIZIP_ENABLED
 static ZipArchive *zip_packed_data = nullptr;
 #endif
-static FileAccessNetworkClient *file_access_network_client = nullptr;
-static MessageQueue *message_queue = nullptr;
 
-// Initialized in setup2()
+// Initialized in finish_setup()
 static AudioServer *audio_server = nullptr;
 static DisplayServer *display_server = nullptr;
 static RenderingServer *rendering_server = nullptr;
 static CameraServer *camera_server = nullptr;
 static XRServer *xr_server = nullptr;
-static TextServerManager *tsman = nullptr;
-static PhysicsServer3D *physics_server = nullptr;
-static PhysicsServer2D *physics_2d_server = nullptr;
+static TextServerManager *text_server_manager = nullptr;
+static PhysicsServer3D *physics_server_3d = nullptr;
+static PhysicsServer2D *physics_server_2d = nullptr;
 static NavigationServer3D *navigation_server = nullptr;
 static NavigationServer2D *navigation_2d_server = nullptr;
-// We error out if setup2() doesn't turn this true
-static bool _start_success = false;
 
-// Drivers
+static ApplicationConfiguration configuration;
+static bool is_tool_application;
 
-String tablet_driver = "";
-String text_driver = "";
+// We error out if finish_setup() doesn't turn this true
+static bool _setup_completed = false;
 
-static int text_driver_idx = -1;
-static int display_driver_idx = -1;
-static int audio_driver_idx = -1;
+// Everything the main loop needs to know about frame timings
+static MainTimerSync main_timer_sync;
+static uint64_t last_ticks = 0;
+static uint32_t frames = 0;
+static uint32_t frame = 0;
+static bool force_redraw_requested = false;
+static int iterating = 0;
 
-// Engine config/tools
+// For performance metrics.
+static uint64_t physics_process_max = 0;
+static uint64_t process_max = 0;
 
-static bool single_window = false;
-static bool editor = false;
-static bool project_manager = false;
-static String locale;
-static bool show_help = false;
-static bool auto_quit = false;
-static OS::ProcessID allow_focus_steal_pid = 0;
-#ifdef TOOLS_ENABLED
-static bool auto_build_solutions = false;
-#endif
-
-// Display
-
-static DisplayServer::WindowMode window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
-static DisplayServer::ScreenOrientation window_orientation = DisplayServer::SCREEN_LANDSCAPE;
-static uint32_t window_flags = 0;
-static Size2i window_size = Size2i(1024, 600);
-static bool window_vsync_via_compositor = false;
-
-static int init_screen = -1;
-static bool init_fullscreen = false;
-static bool init_maximized = false;
-static bool init_windowed = false;
-static bool init_always_on_top = false;
-static bool init_use_custom_pos = false;
-static Vector2 init_custom_pos;
-static bool force_lowdpi = false;
-
-// Debug
-
-static bool use_debug_profiler = false;
-#ifdef DEBUG_ENABLED
-static bool debug_collisions = false;
-static bool debug_navigation = false;
-#endif
-static int frame_delay = 0;
-static bool disable_render_loop = false;
-static int fixed_fps = -1;
-static bool print_fps = false;
-
-bool profile_gpu = false;
-
-/* Helper methods */
-
-// Used by Mono module, should likely be registered in Engine singleton instead
-// FIXME: This is also not 100% accurate, `project_manager` is only true when it was requested,
-// but not if e.g. we fail to load and project and fallback to the manager.
-bool Main::is_project_manager() {
-	return project_manager;
-}
-
-static String unescape_cmdline(const String &p_str) {
-	return p_str.replace("%20", " ");
-}
-
-static String get_full_version_string() {
-	String hash = String(VERSION_HASH);
-	if (hash.length() != 0) {
-		hash = "." + hash.left(9);
-	}
-	return String(VERSION_FULL_BUILD) + hash;
-}
-
-// FIXME: Could maybe be moved to PhysicsServer3DManager and PhysicsServer2DManager directly
-// to have less code in main.cpp.
-void initialize_physics() {
-	/// 3D Physics Server
-	physics_server = PhysicsServer3DManager::new_server(
-			ProjectSettings::get_singleton()->get(PhysicsServer3DManager::setting_property_name));
-	if (!physics_server) {
-		// Physics server not found, Use the default physics
-		physics_server = PhysicsServer3DManager::new_default_server();
-	}
-	ERR_FAIL_COND(!physics_server);
-	physics_server->init();
-
-	/// 2D Physics server
-	physics_2d_server = PhysicsServer2DManager::new_server(
-			ProjectSettings::get_singleton()->get(PhysicsServer2DManager::setting_property_name));
-	if (!physics_2d_server) {
-		// Physics server not found, Use the default physics
-		physics_2d_server = PhysicsServer2DManager::new_default_server();
-	}
-	ERR_FAIL_COND(!physics_2d_server);
-	physics_2d_server->init();
-}
-
-void finalize_physics() {
-	physics_server->finish();
-	memdelete(physics_server);
-
-	physics_2d_server->finish();
-	memdelete(physics_2d_server);
-}
-
-void finalize_display() {
-	rendering_server->finish();
-	memdelete(rendering_server);
-
-	memdelete(display_server);
-}
-
-void initialize_navigation_server() {
-	ERR_FAIL_COND(navigation_server != nullptr);
-
-	navigation_server = NavigationServer3DManager::new_default_server();
-	navigation_2d_server = memnew(NavigationServer2D);
-}
-
-void finalize_navigation_server() {
-	memdelete(navigation_server);
-	navigation_server = nullptr;
-
-	memdelete(navigation_2d_server);
-	navigation_2d_server = nullptr;
-}
+// TODO: these methods can't be defined in main.h, because including scene_tree.h
+// conflicts with Window on X11.
+SceneTree *create_scene_tree(MainLoop *p_main_loop);
+MainLoop *create_main_loop(const String &p_main_loop_type);
 
 //#define DEBUG_INIT
 #ifdef DEBUG_INIT
@@ -256,240 +142,19 @@ void finalize_navigation_server() {
 #define MAIN_PRINT(m_txt)
 #endif
 
-void Main::print_help(const char *p_binary) {
-	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
-	OS::get_singleton()->print("Free and open source software under the terms of the MIT license.\n");
-	OS::get_singleton()->print("(c) 2007-2021 Juan Linietsky, Ariel Manzur.\n");
-	OS::get_singleton()->print("(c) 2014-2021 Godot Engine contributors.\n");
-	OS::get_singleton()->print("\n");
-	OS::get_singleton()->print("Usage: %s [options] [path to scene or 'project.godot' file]\n", p_binary);
-	OS::get_singleton()->print("\n");
-
-	OS::get_singleton()->print("General options:\n");
-	OS::get_singleton()->print("  -h, --help                                   Display this help message.\n");
-	OS::get_singleton()->print("  --version                                    Display the version string.\n");
-	OS::get_singleton()->print("  -v, --verbose                                Use verbose stdout mode.\n");
-	OS::get_singleton()->print("  --quiet                                      Quiet mode, silences stdout messages. Errors are still displayed.\n");
-	OS::get_singleton()->print("\n");
-
-	OS::get_singleton()->print("Run options:\n");
-#ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  -e, --editor                                 Start the editor instead of running the scene.\n");
-	OS::get_singleton()->print("  -p, --project-manager                        Start the project manager, even if a project is auto-detected.\n");
-#endif
-	OS::get_singleton()->print("  -q, --quit                                   Quit after the first iteration.\n");
-	OS::get_singleton()->print("  -l, --language <locale>                      Use a specific locale (<locale> being a two-letter code).\n");
-	OS::get_singleton()->print("  --path <directory>                           Path to a project (<directory> must contain a 'project.godot' file).\n");
-	OS::get_singleton()->print("  -u, --upwards                                Scan folders upwards for project.godot file.\n");
-	OS::get_singleton()->print("  --main-pack <file>                           Path to a pack (.pck) file to load.\n");
-	OS::get_singleton()->print("  --render-thread <mode>                       Render thread mode ('unsafe', 'safe', 'separate').\n");
-	OS::get_singleton()->print("  --remote-fs <address>                        Remote filesystem (<host/IP>[:<port>] address).\n");
-	OS::get_singleton()->print("  --remote-fs-password <password>              Password for remote filesystem.\n");
-
-	OS::get_singleton()->print("  --audio-driver <driver>                      Audio driver [");
-	for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
-		if (i > 0) {
-			OS::get_singleton()->print(", ");
-		}
-		OS::get_singleton()->print("'%s'", AudioDriverManager::get_driver(i)->get_name());
-	}
-	OS::get_singleton()->print("].\n");
-
-	OS::get_singleton()->print("  --display-driver <driver>                    Display driver (and rendering driver) [");
-	for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
-		if (i > 0) {
-			OS::get_singleton()->print(", ");
-		}
-		OS::get_singleton()->print("'%s' (", DisplayServer::get_create_function_name(i));
-		Vector<String> rd = DisplayServer::get_create_function_rendering_drivers(i);
-		for (int j = 0; j < rd.size(); j++) {
-			if (j > 0) {
-				OS::get_singleton()->print(", ");
-			}
-			OS::get_singleton()->print("'%s'", rd[j].utf8().get_data());
-		}
-		OS::get_singleton()->print(")");
-	}
-	OS::get_singleton()->print("].\n");
-
-	OS::get_singleton()->print("  --rendering-driver <driver>                  Rendering driver (depends on display driver).\n");
-
-	OS::get_singleton()->print("  --text-driver <driver>                       Text driver (Fonts, BiDi, shaping)\n");
-
-	OS::get_singleton()->print("\n");
-
-#ifndef SERVER_ENABLED
-	OS::get_singleton()->print("Display options:\n");
-	OS::get_singleton()->print("  -f, --fullscreen                             Request fullscreen mode.\n");
-	OS::get_singleton()->print("  -m, --maximized                              Request a maximized window.\n");
-	OS::get_singleton()->print("  -w, --windowed                               Request windowed mode.\n");
-	OS::get_singleton()->print("  -t, --always-on-top                          Request an always-on-top window.\n");
-	OS::get_singleton()->print("  --resolution <W>x<H>                         Request window resolution.\n");
-	OS::get_singleton()->print("  --position <X>,<Y>                           Request window position.\n");
-	OS::get_singleton()->print("  --low-dpi                                    Force low-DPI mode (macOS and Windows only).\n");
-	OS::get_singleton()->print("  --no-window                                  Disable window creation (Windows only). Useful together with --script.\n");
-	OS::get_singleton()->print("  --enable-vsync-via-compositor                When vsync is enabled, vsync via the OS' window compositor (Windows only).\n");
-	OS::get_singleton()->print("  --disable-vsync-via-compositor               Disable vsync via the OS' window compositor (Windows only).\n");
-	OS::get_singleton()->print("  --single-window                              Use a single window (no separate subwindows).\n");
-	OS::get_singleton()->print("  --tablet-driver                              Pen tablet input driver.\n");
-	OS::get_singleton()->print("\n");
-#endif
-
-	OS::get_singleton()->print("Debug options:\n");
-	OS::get_singleton()->print("  -d, --debug                                  Debug (local stdout debugger).\n");
-	OS::get_singleton()->print("  -b, --breakpoints                            Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
-	OS::get_singleton()->print("  --profiling                                  Enable profiling in the script debugger.\n");
-	OS::get_singleton()->print("  --vk-layers                                  Enable Vulkan Validation layers for debugging.\n");
-#if DEBUG_ENABLED
-	OS::get_singleton()->print("  --gpu-abort                                  Abort on GPU errors (usually validation layer errors), may help see the problem if your system freezes.\n");
-#endif
-	OS::get_singleton()->print("  --remote-debug <uri>                         Remote debug (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007).\n");
-#if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
-	OS::get_singleton()->print("  --debug-collisions                           Show collision shapes when running the scene.\n");
-	OS::get_singleton()->print("  --debug-navigation                           Show navigation polygons when running the scene.\n");
-#endif
-	OS::get_singleton()->print("  --frame-delay <ms>                           Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
-	OS::get_singleton()->print("  --time-scale <scale>                         Force time scale (higher values are faster, 1.0 is normal speed).\n");
-	OS::get_singleton()->print("  --disable-render-loop                        Disable render loop so rendering only occurs when called explicitly from script.\n");
-	OS::get_singleton()->print("  --disable-crash-handler                      Disable crash handler when supported by the platform code.\n");
-	OS::get_singleton()->print("  --fixed-fps <fps>                            Force a fixed number of frames per second. This setting disables real-time synchronization.\n");
-	OS::get_singleton()->print("  --print-fps                                  Print the frames per second to the stdout.\n");
-	OS::get_singleton()->print("  --profile-gpu                                Show a simple profile of the tasks that took more time during frame rendering.\n");
-	OS::get_singleton()->print("\n");
-
-	OS::get_singleton()->print("Standalone tools:\n");
-	OS::get_singleton()->print("  -s, --script <script>                        Run a script.\n");
-	OS::get_singleton()->print("  --check-only                                 Only parse for errors and quit (use with --script).\n");
-#ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  --export <preset> <path>                     Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.cfg.\n");
-	OS::get_singleton()->print("                                               <path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe'). The target directory should exist.\n");
-	OS::get_singleton()->print("  --export-debug <preset> <path>               Same as --export, but using the debug template.\n");
-	OS::get_singleton()->print("  --export-pack <preset> <path>                Same as --export, but only export the game pack for the given preset. The <path> extension determines whether it will be in PCK or ZIP format.\n");
-	OS::get_singleton()->print("  --doctool [<path>]                           Dump the engine API reference to the given <path> (defaults to current dir) in XML format, merging if existing files are found.\n");
-	OS::get_singleton()->print("  --no-docbase                                 Disallow dumping the base types (used with --doctool).\n");
-	OS::get_singleton()->print("  --build-solutions                            Build the scripting solutions (e.g. for C# projects). Implies --editor and requires a valid project to edit.\n");
-#ifdef DEBUG_METHODS_ENABLED
-	OS::get_singleton()->print("  --gdnative-generate-json-api <path>          Generate JSON dump of the Godot API for GDNative bindings and save it on the file specified in <path>.\n");
-	OS::get_singleton()->print("  --gdnative-generate-json-builtin-api <path>  Generate JSON dump of the Godot API of the builtin Variant types and utility functions for GDNative bindings and save it on the file specified in <path>.\n");
-#endif
-#ifdef TESTS_ENABLED
-	OS::get_singleton()->print("  --test [--help]                              Run unit tests. Use --test --help for more information.\n");
-#endif
-#endif
-	OS::get_singleton()->print("\n");
-}
-
-#ifdef TESTS_ENABLED
-// The order is the same as in `Main::setup()`, only core and some editor types
-// are initialized here. This also combines `Main::setup2()` initialization.
-Error Main::test_setup() {
-	OS::get_singleton()->initialize();
-
-	engine = memnew(Engine);
-
-	register_core_types();
-	register_core_driver_types();
-
-	packed_data = memnew(PackedData);
-
-	globals = memnew(ProjectSettings);
-
-	GLOBAL_DEF("debug/settings/crash_handler/message",
-			String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
-
-	translation_server = memnew(TranslationServer);
-
-	// From `Main::setup2()`.
-	preregister_module_types();
-	preregister_server_types();
-
-	register_core_singletons();
-
-	register_server_types();
-
-	translation_server->setup(); //register translations, load them, etc.
-	if (locale != "") {
-		translation_server->set_locale(locale);
-	}
-	translation_server->load_translations();
-	ResourceLoader::load_translation_remaps(); //load remaps for resources
-
-	ResourceLoader::load_path_remaps();
-
-	register_scene_types();
-
-#ifdef TOOLS_ENABLED
-	ClassDB::set_current_api(ClassDB::API_EDITOR);
-	EditorNode::register_editor_types();
-
-	ClassDB::set_current_api(ClassDB::API_CORE);
-#endif
-	register_platform_apis();
-
-	register_module_types();
-	register_driver_types();
-
-	ClassDB::set_current_api(ClassDB::API_NONE);
-
-	_start_success = true;
-
-	return OK;
-}
-// The order is the same as in `Main::cleanup()`.
-void Main::test_cleanup() {
-	ERR_FAIL_COND(!_start_success);
-
-	EngineDebugger::deinitialize();
-
-	ResourceLoader::remove_custom_loaders();
-	ResourceSaver::remove_custom_savers();
-
-#ifdef TOOLS_ENABLED
-	EditorNode::unregister_editor_types();
-#endif
-	unregister_driver_types();
-	unregister_module_types();
-	unregister_platform_apis();
-	unregister_scene_types();
-	unregister_server_types();
-
-	OS::get_singleton()->finalize();
-
-	if (translation_server) {
-		memdelete(translation_server);
-	}
-	if (globals) {
-		memdelete(globals);
-	}
-	if (packed_data) {
-		memdelete(packed_data);
-	}
-	if (engine) {
-		memdelete(engine);
-	}
-
-	unregister_core_driver_types();
-	unregister_core_types();
-
-	OS::get_singleton()->finalize_core();
-}
-#endif
-
-int Main::test_entrypoint(int argc, char *argv[], bool &tests_need_run) {
+int Main::test_entrypoint(int argc, char *argv[], bool &finished) {
 #ifdef TESTS_ENABLED
 	for (int x = 0; x < argc; x++) {
 		if ((strncmp(argv[x], "--test", 6) == 0) && (strlen(argv[x]) == 6)) {
-			tests_need_run = true;
-			// TODO: need to come up with different test contexts.
-			// Not every test requires high-level functionality like `ClassDB`.
+			finished = true;
 			test_setup();
 			int status = test_main(argc, argv);
 			test_cleanup();
 			return status;
 		}
 	}
-#endif
-	tests_need_run = false;
+#endif // TESTS_ENABLED
+	finished = false;
 	return 0;
 }
 
@@ -499,1922 +164,162 @@ int Main::test_entrypoint(int argc, char *argv[], bool &tests_need_run) {
  * To fully understand engine init, one should therefore start from the platform's main and
  * see how it calls into the Main class' methods.
  *
- * The initialization is typically done in 3 steps (with the setup2 step triggered either
+ * The initialization is typically done in 3 steps (with the finish_setup step triggered either
  * automatically by setup, or manually in the platform's main).
  *
- * - setup(execpath, argc, argv, p_second_phase) is the main entry point for all platforms,
- *   responsible for the initialization of all low level singletons and core types, and parsing
- *   command line arguments to configure things accordingly.
- *   If p_second_phase is true, it will chain into setup2() (default behaviour). This is
+ * - setup(exec_path, argc, argv, p_finish_setup) is the main entry point for all platforms,
+ *   responsible for the initialization of all low level singletons and core types according
+ *   to command line arguments.
+ *   If <p_finish_setup> is true, it will chain into finish_setup() (default behaviour). This is
  *   disabled on some platforms (Android, iOS, UWP) which trigger the second step in their
  *   own time.
  *
- * - setup2(p_main_tid_override) registers high level servers and singletons, displays the
+ * - p_finish_setup(p_main_tid_override) registers high level servers and singletons, displays the
  *   boot splash, then registers higher level types (scene, editor, etc.).
  *
- * - start() is the last step and that's where command line tools can run, or the main loop
- *   can be created eventually and the project settings put into action. That's also where
- *   the editor node is created, if relevant.
- *   start() does it own argument parsing for a subset of the command line arguments described
- *   in help, it's a bit messy and should be globalized with the setup() parsing somehow.
+ * - start() is the last step and either creates a main loop, or runs a standalone tool.
  */
-
-Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_phase) {
+Error Main::setup(const char *exec_path, int argc, char *argv[], bool p_finish_setup) {
 	OS::get_singleton()->initialize();
 
-	engine = memnew(Engine);
-
-	MAIN_PRINT("Main: Initialize CORE");
-
-	register_core_types();
-	register_core_driver_types();
-
-	MAIN_PRINT("Main: Initialize Globals");
-
-	input_map = memnew(InputMap);
-	globals = memnew(ProjectSettings);
-
-	register_core_settings(); //here globals are present
-
-	translation_server = memnew(TranslationServer);
-	performance = memnew(Performance);
-	ClassDB::register_class<Performance>();
-	engine->add_singleton(Engine::Singleton("Performance", performance));
-
-	// Only flush stdout in debug builds by default, as spamming `print()` will
-	// decrease performance if this is enabled.
-	GLOBAL_DEF_RST("application/run/flush_stdout_on_print", false);
-	GLOBAL_DEF_RST("application/run/flush_stdout_on_print.debug", true);
-
-	GLOBAL_DEF("debug/settings/crash_handler/message",
-			String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
-
 	MAIN_PRINT("Main: Parse CMDLine");
-
-	/* argument parsing and main creation */
-	List<String> args;
-	List<String> main_args;
-
-	for (int i = 0; i < argc; i++) {
-		args.push_back(String::utf8(argv[i]));
+	Error error = parse_configuration(exec_path, argc, argv, configuration);
+	if (error != OK) {
+		deinitialize_early(false);
+		return error;
 	}
 
-	List<String>::Element *I = args.front();
-
-	I = args.front();
-
-	while (I) {
-		I->get() = unescape_cmdline(I->get().strip_edges());
-		I = I->next();
-	}
-
-	I = args.front();
-
-	String display_driver = "";
-	String audio_driver = "";
-	String project_path = ".";
-	bool upwards = false;
-	String debug_uri = "";
-	bool skip_breakpoints = false;
-	String main_pack;
-	bool quiet_stdout = false;
-	int rtm = -1;
-
-	String remotefs;
-	String remotefs_pass;
-
-	Vector<String> breakpoints;
-	bool use_custom_res = true;
-	bool force_res = false;
-	bool saw_vsync_via_compositor_override = false;
-#ifdef TOOLS_ENABLED
-	bool found_project = false;
-#endif
-	bool use_vsync = false;
-
-	packed_data = PackedData::get_singleton();
-	if (!packed_data) {
+	MAIN_PRINT("Main: Setup Core");
+	// Create necessary core singletons for the following steps.
+	{
+		engine = memnew(Engine);
+		register_core();
+		input_map = memnew(InputMap);
+		project_settings = memnew(ProjectSettings);
 		packed_data = memnew(PackedData);
 	}
 
-#ifdef MINIZIP_ENABLED
-
-	//XXX: always get_singleton() == 0x0
-	zip_packed_data = ZipArchive::get_singleton();
-	//TODO: remove this temporary fix
-	if (!zip_packed_data) {
-		zip_packed_data = memnew(ZipArchive);
+	error = load_project_settings();
+	if (error != OK) {
+		deinitialize_early();
+		return error;
 	}
 
-	packed_data->add_pack_source(zip_packed_data);
-#endif
-
-	I = args.front();
-	while (I) {
-#ifdef OSX_ENABLED
-		// Ignore the process serial number argument passed by macOS Gatekeeper.
-		// Otherwise, Godot would try to open a non-existent project on the first start and abort.
-		if (I->get().begins_with("-psn_")) {
-			I = I->next();
-			continue;
-		}
-#endif
-
-		List<String>::Element *N = I->next();
-
-		if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
-
-			show_help = true;
-			goto error;
-
-		} else if (I->get() == "--version") {
-			print_line(get_full_version_string());
-			goto error;
-
-		} else if (I->get() == "-v" || I->get() == "--verbose") { // verbose output
-
-			OS::get_singleton()->_verbose_stdout = true;
-		} else if (I->get() == "--quiet") { // quieter output
-
-			quiet_stdout = true;
-
-		} else if (I->get() == "--audio-driver") { // audio driver
-
-			if (I->next()) {
-				audio_driver = I->next()->get();
-
-				bool found = false;
-				for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
-					if (audio_driver == AudioDriverManager::get_driver(i)->get_name()) {
-						found = true;
-					}
-				}
-
-				if (!found) {
-					OS::get_singleton()->print("Unknown audio driver '%s', aborting.\nValid options are ",
-							audio_driver.utf8().get_data());
-
-					for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
-						if (i == AudioDriverManager::get_driver_count() - 1) {
-							OS::get_singleton()->print(" and ");
-						} else if (i != 0) {
-							OS::get_singleton()->print(", ");
-						}
-
-						OS::get_singleton()->print("'%s'", AudioDriverManager::get_driver(i)->get_name());
-					}
-
-					OS::get_singleton()->print(".\n");
-
-					goto error;
-				}
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing audio driver argument, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--text-driver") {
-			if (I->next()) {
-				text_driver = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing text driver argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--display-driver") { // force video driver
-
-			if (I->next()) {
-				display_driver = I->next()->get();
-
-				bool found = false;
-				for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
-					if (display_driver == DisplayServer::get_create_function_name(i)) {
-						found = true;
-					}
-				}
-
-				if (!found) {
-					OS::get_singleton()->print("Unknown display driver '%s', aborting.\nValid options are ",
-							display_driver.utf8().get_data());
-
-					for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
-						if (i == DisplayServer::get_create_function_count() - 1) {
-							OS::get_singleton()->print(" and ");
-						} else if (i != 0) {
-							OS::get_singleton()->print(", ");
-						}
-
-						OS::get_singleton()->print("'%s'", DisplayServer::get_create_function_name(i));
-					}
-
-					OS::get_singleton()->print(".\n");
-
-					goto error;
-				}
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing video driver argument, aborting.\n");
-				goto error;
-			}
-#ifndef SERVER_ENABLED
-		} else if (I->get() == "-f" || I->get() == "--fullscreen") { // force fullscreen
-
-			init_fullscreen = true;
-		} else if (I->get() == "-m" || I->get() == "--maximized") { // force maximized window
-
-			init_maximized = true;
-			window_mode = DisplayServer::WINDOW_MODE_MAXIMIZED;
-
-		} else if (I->get() == "-w" || I->get() == "--windowed") { // force windowed window
-
-			init_windowed = true;
-		} else if (I->get() == "--vk-layers") {
-			Engine::singleton->use_validation_layers = true;
-#ifdef DEBUG_ENABLED
-		} else if (I->get() == "--gpu-abort") {
-			Engine::singleton->abort_on_gpu_errors = true;
-#endif
-		} else if (I->get() == "--tablet-driver") {
-			if (I->next()) {
-				tablet_driver = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing tablet driver argument, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--single-window") { // force single window
-
-			single_window = true;
-		} else if (I->get() == "-t" || I->get() == "--always-on-top") { // force always-on-top window
-
-			init_always_on_top = true;
-		} else if (I->get() == "--resolution") { // force resolution
-
-			if (I->next()) {
-				String vm = I->next()->get();
-
-				if (vm.find("x") == -1) { // invalid parameter format
-
-					OS::get_singleton()->print("Invalid resolution '%s', it should be e.g. '1280x720'.\n",
-							vm.utf8().get_data());
-					goto error;
-				}
-
-				int w = vm.get_slice("x", 0).to_int();
-				int h = vm.get_slice("x", 1).to_int();
-
-				if (w <= 0 || h <= 0) {
-					OS::get_singleton()->print("Invalid resolution '%s', width and height must be above 0.\n",
-							vm.utf8().get_data());
-					goto error;
-				}
-
-				window_size.width = w;
-				window_size.height = h;
-				force_res = true;
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing resolution argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--position") { // set window position
-
-			if (I->next()) {
-				String vm = I->next()->get();
-
-				if (vm.find(",") == -1) { // invalid parameter format
-
-					OS::get_singleton()->print("Invalid position '%s', it should be e.g. '80,128'.\n",
-							vm.utf8().get_data());
-					goto error;
-				}
-
-				int x = vm.get_slice(",", 0).to_int();
-				int y = vm.get_slice(",", 1).to_int();
-
-				init_custom_pos = Point2(x, y);
-				init_use_custom_pos = true;
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing position argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--low-dpi") { // force low DPI (macOS only)
-
-			force_lowdpi = true;
-		} else if (I->get() == "--no-window") { // disable window creation (Windows only)
-
-			OS::get_singleton()->set_no_window_mode(true);
-		} else if (I->get() == "--enable-vsync-via-compositor") {
-			window_vsync_via_compositor = true;
-			saw_vsync_via_compositor_override = true;
-		} else if (I->get() == "--disable-vsync-via-compositor") {
-			window_vsync_via_compositor = false;
-			saw_vsync_via_compositor_override = true;
-#endif
-		} else if (I->get() == "--profiling") { // enable profiling
-
-			use_debug_profiler = true;
-
-		} else if (I->get() == "-l" || I->get() == "--language") { // language
-
-			if (I->next()) {
-				locale = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing language argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--remote-fs") { // remote filesystem
-
-			if (I->next()) {
-				remotefs = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing remote filesystem address, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--remote-fs-password") { // remote filesystem password
-
-			if (I->next()) {
-				remotefs_pass = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing remote filesystem password, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--render-thread") { // render thread mode
-
-			if (I->next()) {
-				if (I->next()->get() == "safe") {
-					rtm = OS::RENDER_THREAD_SAFE;
-				} else if (I->next()->get() == "unsafe") {
-					rtm = OS::RENDER_THREAD_UNSAFE;
-				} else if (I->next()->get() == "separate") {
-					rtm = OS::RENDER_SEPARATE_THREAD;
-				}
-
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing render thread mode argument, aborting.\n");
-				goto error;
-			}
-#ifdef TOOLS_ENABLED
-		} else if (I->get() == "-e" || I->get() == "--editor") { // starts editor
-
-			editor = true;
-		} else if (I->get() == "-p" || I->get() == "--project-manager") { // starts project manager
-
-			project_manager = true;
-		} else if (I->get() == "--build-solutions") { // Build the scripting solution such C#
-
-			auto_build_solutions = true;
-			editor = true;
-#ifdef DEBUG_METHODS_ENABLED
-		} else if (I->get() == "--gdnative-generate-json-api" || I->get() == "--gdnative-generate-json-builtin-api") {
-			// Register as an editor instance to use low-end fallback if relevant.
-			editor = true;
-
-			// We still pass it to the main arguments since the argument handling itself is not done in this function
-			main_args.push_back(I->get());
-#endif
-		} else if (I->get() == "--export" || I->get() == "--export-debug" ||
-				   I->get() == "--export-pack") { // Export project
-
-			editor = true;
-			main_args.push_back(I->get());
-#endif
-		} else if (I->get() == "--path") { // set path of project to start or edit
-
-			if (I->next()) {
-				String p = I->next()->get();
-				if (OS::get_singleton()->set_cwd(p) == OK) {
-					//nothing
-				} else {
-					project_path = I->next()->get(); //use project_path instead
-				}
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing relative or absolute path, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "-u" || I->get() == "--upwards") { // scan folders upwards
-			upwards = true;
-		} else if (I->get() == "-q" || I->get() == "--quit") { // Auto quit at the end of the first main loop iteration
-			auto_quit = true;
-		} else if (I->get().ends_with("project.godot")) {
-			String path;
-			String file = I->get();
-			int sep = MAX(file.rfind("/"), file.rfind("\\"));
-			if (sep == -1) {
-				path = ".";
-			} else {
-				path = file.substr(0, sep);
-			}
-			if (OS::get_singleton()->set_cwd(path) == OK) {
-				// path already specified, don't override
-			} else {
-				project_path = path;
-			}
-#ifdef TOOLS_ENABLED
-			editor = true;
-#endif
-		} else if (I->get() == "-b" || I->get() == "--breakpoints") { // add breakpoints
-
-			if (I->next()) {
-				String bplist = I->next()->get();
-				breakpoints = bplist.split(",");
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing list of breakpoints, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--frame-delay") { // force frame delay
-
-			if (I->next()) {
-				frame_delay = I->next()->get().to_int();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing frame delay argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--time-scale") { // force time scale
-
-			if (I->next()) {
-				Engine::get_singleton()->set_time_scale(I->next()->get().to_float());
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing time scale argument, aborting.\n");
-				goto error;
-			}
-
-		} else if (I->get() == "--main-pack") {
-			if (I->next()) {
-				main_pack = I->next()->get();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing path to main pack file, aborting.\n");
-				goto error;
-			};
-
-		} else if (I->get() == "-d" || I->get() == "--debug") {
-			debug_uri = "local://";
-			OS::get_singleton()->_debug_stdout = true;
-#if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
-		} else if (I->get() == "--debug-collisions") {
-			debug_collisions = true;
-		} else if (I->get() == "--debug-navigation") {
-			debug_navigation = true;
-#endif
-		} else if (I->get() == "--remote-debug") {
-			if (I->next()) {
-				debug_uri = I->next()->get();
-				if (debug_uri.find("://") == -1) { // wrong address
-					OS::get_singleton()->print(
-							"Invalid debug host address, it should be of the form <protocol>://<host/IP>:<port>.\n");
-					goto error;
-				}
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing remote debug host address, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--allow_focus_steal_pid") { // not exposed to user
-			if (I->next()) {
-				allow_focus_steal_pid = I->next()->get().to_int();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--disable-render-loop") {
-			disable_render_loop = true;
-		} else if (I->get() == "--fixed-fps") {
-			if (I->next()) {
-				fixed_fps = I->next()->get().to_int();
-				N = I->next()->next();
-			} else {
-				OS::get_singleton()->print("Missing fixed-fps argument, aborting.\n");
-				goto error;
-			}
-		} else if (I->get() == "--print-fps") {
-			print_fps = true;
-		} else if (I->get() == "--profile-gpu") {
-			profile_gpu = true;
-		} else if (I->get() == "--disable-crash-handler") {
-			OS::get_singleton()->disable_crash_handler();
-		} else if (I->get() == "--skip-breakpoints") {
-			skip_breakpoints = true;
-		} else {
-			main_args.push_back(I->get());
-		}
-
-		I = N;
+	print_line(get_program_string());
+
+	// Validate and manually adjust the configuration.
+	finalize_configuration(configuration);
+	if (error != OK) {
+		deinitialize_early();
+		return error;
 	}
 
-#ifdef TOOLS_ENABLED
-	if (editor && project_manager) {
-		OS::get_singleton()->print(
-				"Error: Command line arguments implied opening both editor and project manager, which is not possible. Aborting.\n");
-		goto error;
-	}
-#endif
+	MAIN_PRINT("Main: Initialize Core");
+	initialize_core();
 
-	// Network file system needs to be configured before globals, since globals are based on the
-	// 'project.godot' file which will only be available through the network if this is enabled
-	FileAccessNetwork::configure();
-	if (remotefs != "") {
-		file_access_network_client = memnew(FileAccessNetworkClient);
-		int port;
-		if (remotefs.find(":") != -1) {
-			port = remotefs.get_slicec(':', 1).to_int();
-			remotefs = remotefs.get_slicec(':', 0);
-		} else {
-			port = 6010;
-		}
-
-		Error err = file_access_network_client->connect(remotefs, port, remotefs_pass);
-		if (err) {
-			OS::get_singleton()->printerr("Could not connect to remotefs: %s:%i.\n", remotefs.utf8().get_data(), port);
-			goto error;
-		}
-
-		FileAccess::make_default<FileAccessNetwork>(FileAccess::ACCESS_RESOURCES);
-	}
-
-	if (globals->setup(project_path, main_pack, upwards) == OK) {
-#ifdef TOOLS_ENABLED
-		found_project = true;
-#endif
-	} else {
-#ifdef TOOLS_ENABLED
-		editor = false;
-#else
-		const String error_msg = "Error: Couldn't load project data at path \"" + project_path + "\". Is the .pck file missing?\nIf you've renamed the executable, the associated .pck file should also be renamed to match the executable's name (without the extension).\n";
-		OS::get_singleton()->print("%s", error_msg.ascii().get_data());
-		DisplayServer::get_singleton()->alert(error_msg);
-
-		goto error;
-#endif
-	}
-
-	// Initialize user data dir.
-	OS::get_singleton()->ensure_user_data_dir();
-
-	GLOBAL_DEF("memory/limits/multithreaded_server/rid_pool_prealloc", 60);
-	ProjectSettings::get_singleton()->set_custom_property_info("memory/limits/multithreaded_server/rid_pool_prealloc",
-			PropertyInfo(Variant::INT,
-					"memory/limits/multithreaded_server/rid_pool_prealloc",
-					PROPERTY_HINT_RANGE,
-					"0,500,1")); // No negative and limit to 500 due to crashes
-	GLOBAL_DEF("network/limits/debugger/max_chars_per_second", 32768);
-	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_chars_per_second",
-			PropertyInfo(Variant::INT,
-					"network/limits/debugger/max_chars_per_second",
-					PROPERTY_HINT_RANGE,
-					"0, 4096, 1, or_greater"));
-	GLOBAL_DEF("network/limits/debugger/max_queued_messages", 2048);
-	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_queued_messages",
-			PropertyInfo(Variant::INT,
-					"network/limits/debugger/max_queued_messages",
-					PROPERTY_HINT_RANGE,
-					"0, 8192, 1, or_greater"));
-	GLOBAL_DEF("network/limits/debugger/max_errors_per_second", 400);
-	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_errors_per_second",
-			PropertyInfo(Variant::INT,
-					"network/limits/debugger/max_errors_per_second",
-					PROPERTY_HINT_RANGE,
-					"0, 200, 1, or_greater"));
-	GLOBAL_DEF("network/limits/debugger/max_warnings_per_second", 400);
-	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_warnings_per_second",
-			PropertyInfo(Variant::INT,
-					"network/limits/debugger/max_warnings_per_second",
-					PROPERTY_HINT_RANGE,
-					"0, 200, 1, or_greater"));
-
-	EngineDebugger::initialize(debug_uri, skip_breakpoints, breakpoints);
-
-#ifdef TOOLS_ENABLED
-	if (editor) {
-		packed_data->set_disabled(true);
-		globals->set_disable_feature_overrides(true);
-	}
-#endif
-
-#ifdef TOOLS_ENABLED
-	if (editor) {
-		Engine::get_singleton()->set_editor_hint(true);
-		main_args.push_back("--editor");
-		if (!init_windowed) {
-			init_maximized = true;
-			window_mode = DisplayServer::WINDOW_MODE_MAXIMIZED;
-		}
-	}
-
-	if (!project_manager && !editor) {
-		// Determine if the project manager should be requested
-		project_manager = main_args.size() == 0 && !found_project;
-	}
-#endif
-
-	GLOBAL_DEF("debug/file_logging/enable_file_logging", false);
-	// Only file logging by default on desktop platforms as logs can't be
-	// accessed easily on mobile/Web platforms (if at all).
-	// This also prevents logs from being created for the editor instance, as feature tags
-	// are disabled while in the editor (even if they should logically apply).
-	GLOBAL_DEF("debug/file_logging/enable_file_logging.pc", true);
-	GLOBAL_DEF("debug/file_logging/log_path", "user://logs/godot.log");
-	GLOBAL_DEF("debug/file_logging/max_log_files", 5);
-	ProjectSettings::get_singleton()->set_custom_property_info("debug/file_logging/max_log_files",
-			PropertyInfo(Variant::INT,
-					"debug/file_logging/max_log_files",
-					PROPERTY_HINT_RANGE,
-					"0,20,1,or_greater")); //no negative numbers
-	if (!project_manager && !editor && FileAccess::get_create_func(FileAccess::ACCESS_USERDATA) &&
-			GLOBAL_GET("debug/file_logging/enable_file_logging")) {
-		// Don't create logs for the project manager as they would be written to
-		// the current working directory, which is inconvenient.
-		String base_path = GLOBAL_GET("debug/file_logging/log_path");
-		int max_files = GLOBAL_GET("debug/file_logging/max_log_files");
-		OS::get_singleton()->add_logger(memnew(RotatedFileLogger(base_path, max_files)));
-	}
-
-	if (main_args.size() == 0 && String(GLOBAL_GET("application/run/main_scene")) == "") {
-#ifdef TOOLS_ENABLED
-		if (!editor && !project_manager) {
-#endif
-			OS::get_singleton()->print("Error: Can't run project: no main scene defined.\n");
-			goto error;
-#ifdef TOOLS_ENABLED
-		}
-#endif
-	}
-
-	if (editor || project_manager) {
-		Engine::get_singleton()->set_editor_hint(true);
-		use_custom_res = false;
-		input_map->load_default(); //keys for editor
-	} else {
-		input_map->load_from_project_settings(); //keys for game
-	}
-
-	if (bool(ProjectSettings::get_singleton()->get("application/run/disable_stdout"))) {
-		quiet_stdout = true;
-	}
-	if (bool(ProjectSettings::get_singleton()->get("application/run/disable_stderr"))) {
-		_print_error_enabled = false;
-	};
-
-	if (quiet_stdout) {
-		_print_line_enabled = false;
-	}
-
-	Logger::set_flush_stdout_on_print(ProjectSettings::get_singleton()->get("application/run/flush_stdout_on_print"));
-
-	OS::get_singleton()->set_cmdline(execpath, main_args);
-
-	GLOBAL_DEF("rendering/driver/driver_name", "Vulkan");
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/driver/driver_name",
-			PropertyInfo(Variant::STRING,
-					"rendering/driver/driver_name",
-					PROPERTY_HINT_ENUM, "Vulkan"));
-	if (display_driver == "") {
-		display_driver = GLOBAL_GET("rendering/driver/driver_name");
-	}
-
-	GLOBAL_DEF_BASIC("display/window/size/width", 1024);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/width",
-			PropertyInfo(Variant::INT, "display/window/size/width",
-					PROPERTY_HINT_RANGE,
-					"0,7680,or_greater")); // 8K resolution
-	GLOBAL_DEF_BASIC("display/window/size/height", 600);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/height",
-			PropertyInfo(Variant::INT, "display/window/size/height",
-					PROPERTY_HINT_RANGE,
-					"0,4320,or_greater")); // 8K resolution
-	GLOBAL_DEF_BASIC("display/window/size/resizable", true);
-	GLOBAL_DEF_BASIC("display/window/size/borderless", false);
-	GLOBAL_DEF_BASIC("display/window/size/fullscreen", false);
-	GLOBAL_DEF("display/window/size/always_on_top", false);
-	GLOBAL_DEF("display/window/size/test_width", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_width",
-			PropertyInfo(Variant::INT,
-					"display/window/size/test_width",
-					PROPERTY_HINT_RANGE,
-					"0,7680,or_greater")); // 8K resolution
-	GLOBAL_DEF("display/window/size/test_height", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_height",
-			PropertyInfo(Variant::INT,
-					"display/window/size/test_height",
-					PROPERTY_HINT_RANGE,
-					"0,4320,or_greater")); // 8K resolution
-
-	if (use_custom_res) {
-		if (!force_res) {
-			window_size.width = GLOBAL_GET("display/window/size/width");
-			window_size.height = GLOBAL_GET("display/window/size/height");
-
-			if (globals->has_setting("display/window/size/test_width") &&
-					globals->has_setting("display/window/size/test_height")) {
-				int tw = globals->get("display/window/size/test_width");
-				if (tw > 0) {
-					window_size.width = tw;
-				}
-				int th = globals->get("display/window/size/test_height");
-				if (th > 0) {
-					window_size.height = th;
-				}
-			}
-		}
-
-		if (!bool(GLOBAL_GET("display/window/size/resizable"))) {
-			window_flags |= DisplayServer::WINDOW_FLAG_RESIZE_DISABLED_BIT;
-		}
-		if (bool(GLOBAL_GET("display/window/size/borderless"))) {
-			window_flags |= DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
-		}
-		if (bool(GLOBAL_GET("display/window/size/fullscreen"))) {
-			window_mode = DisplayServer::WINDOW_MODE_FULLSCREEN;
-		}
-
-		if (bool(GLOBAL_GET("display/window/size/always_on_top"))) {
-			window_flags |= DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP_BIT;
-		}
-	}
-
-	GLOBAL_DEF("internationalization/rendering/force_right_to_left_layout_direction", false);
-	GLOBAL_DEF("internationalization/locale/include_text_server_data", false);
-
-	if (!force_lowdpi) {
-		OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", false);
-	}
-
-	use_vsync = GLOBAL_DEF_RST("display/window/vsync/use_vsync", true);
-	OS::get_singleton()->_use_vsync = use_vsync;
-
-	if (!saw_vsync_via_compositor_override) {
-		// If one of the command line options to enable/disable vsync via the
-		// window compositor ("--enable-vsync-via-compositor" or
-		// "--disable-vsync-via-compositor") was present then it overrides the
-		// project setting.
-		window_vsync_via_compositor = GLOBAL_DEF("display/window/vsync/vsync_via_compositor", false);
-	}
-
-	OS::get_singleton()->_vsync_via_compositor = window_vsync_via_compositor;
-
-	/* todo restore
-    OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);
-    video_mode.layered = GLOBAL_DEF("display/window/per_pixel_transparency/enabled", false);
-*/
-	if (editor || project_manager) {
-		// The editor and project manager always detect and use hiDPI if needed
-		OS::get_singleton()->_allow_hidpi = true;
-		OS::get_singleton()->_allow_layered = false;
-	}
-
-	OS::get_singleton()->_keep_screen_on = GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
-	if (rtm == -1) {
-		rtm = GLOBAL_DEF("rendering/driver/threads/thread_model", OS::RENDER_THREAD_SAFE);
-	}
-
-	if (rtm >= 0 && rtm < 3) {
-#ifdef NO_THREADS
-		rtm = OS::RENDER_THREAD_UNSAFE; // No threads available on this platform.
-#else
-		if (editor) {
-			rtm = OS::RENDER_THREAD_SAFE;
-		}
-#endif
-		OS::get_singleton()->_render_thread_mode = OS::RenderThreadMode(rtm);
-	}
-
-	/* Determine audio and video drivers */
-
-	for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
-		if (display_driver == DisplayServer::get_create_function_name(i)) {
-			display_driver_idx = i;
-			break;
-		}
-	}
-
-	if (display_driver_idx < 0) {
-		display_driver_idx = 0;
-	}
-
-	if (audio_driver == "") { // specified in project.godot
-		audio_driver = GLOBAL_DEF_RST_NOVAL("audio/driver/driver", AudioDriverManager::get_driver(0)->get_name());
-	}
-
-	for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
-		if (audio_driver == AudioDriverManager::get_driver(i)->get_name()) {
-			audio_driver_idx = i;
-			break;
-		}
-	}
-
-	if (audio_driver_idx < 0) {
-		audio_driver_idx = 0;
-	}
-
-	{
-		window_orientation = DisplayServer::ScreenOrientation(int(GLOBAL_DEF_BASIC("display/window/handheld/orientation", DisplayServer::ScreenOrientation::SCREEN_LANDSCAPE)));
-	}
-
-	Engine::get_singleton()->set_iterations_per_second(GLOBAL_DEF_BASIC("physics/common/physics_fps", 60));
-	ProjectSettings::get_singleton()->set_custom_property_info("physics/common/physics_fps",
-			PropertyInfo(Variant::INT, "physics/common/physics_fps",
-					PROPERTY_HINT_RANGE, "1,120,1,or_greater"));
-	Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_DEF("physics/common/physics_jitter_fix", 0.5));
-	Engine::get_singleton()->set_target_fps(GLOBAL_DEF("debug/settings/fps/force_fps", 0));
-	ProjectSettings::get_singleton()->set_custom_property_info("debug/settings/fps/force_fps",
-			PropertyInfo(Variant::INT,
-					"debug/settings/fps/force_fps",
-					PROPERTY_HINT_RANGE, "0,120,1,or_greater"));
-
-	GLOBAL_DEF("debug/settings/stdout/print_fps", false);
-	GLOBAL_DEF("debug/settings/stdout/verbose_stdout", false);
-
-	if (!OS::get_singleton()->_verbose_stdout) { // Not manually overridden.
-		OS::get_singleton()->_verbose_stdout = GLOBAL_GET("debug/settings/stdout/verbose_stdout");
-	}
-
-	if (frame_delay == 0) {
-		frame_delay = GLOBAL_DEF("application/run/frame_delay_msec", 0);
-		ProjectSettings::get_singleton()->set_custom_property_info("application/run/frame_delay_msec",
-				PropertyInfo(Variant::INT,
-						"application/run/frame_delay_msec",
-						PROPERTY_HINT_RANGE,
-						"0,100,1,or_greater")); // No negative numbers
-	}
-
-	OS::get_singleton()->set_low_processor_usage_mode(GLOBAL_DEF("application/run/low_processor_mode", false));
-	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(
-			GLOBAL_DEF("application/run/low_processor_mode_sleep_usec", 6900)); // Roughly 144 FPS
-	ProjectSettings::get_singleton()->set_custom_property_info("application/run/low_processor_mode_sleep_usec",
-			PropertyInfo(Variant::INT,
-					"application/run/low_processor_mode_sleep_usec",
-					PROPERTY_HINT_RANGE,
-					"0,33200,1,or_greater")); // No negative numbers
-
-	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
-	GLOBAL_DEF("input_devices/pointing/ios/touch_delay", 0.150);
-
-	Engine::get_singleton()->set_frame_delay(frame_delay);
-
-	message_queue = memnew(MessageQueue);
-
-	if (p_second_phase) {
-		return setup2();
+	if (p_finish_setup) {
+		return finish_setup();
 	}
 
 	return OK;
-
-error:
-
-	text_driver = "";
-	display_driver = "";
-	audio_driver = "";
-	tablet_driver = "";
-	project_path = "";
-
-	args.clear();
-	main_args.clear();
-
-	if (show_help) {
-		print_help(execpath);
-	}
-
-	EngineDebugger::deinitialize();
-
-	if (performance) {
-		memdelete(performance);
-	}
-	if (input_map) {
-		memdelete(input_map);
-	}
-	if (translation_server) {
-		memdelete(translation_server);
-	}
-	if (globals) {
-		memdelete(globals);
-	}
-	if (engine) {
-		memdelete(engine);
-	}
-	if (packed_data) {
-		memdelete(packed_data);
-	}
-	if (file_access_network_client) {
-		memdelete(file_access_network_client);
-	}
-
-	unregister_core_driver_types();
-	unregister_core_types();
-
-	OS::get_singleton()->_cmdline.clear();
-
-	if (message_queue) {
-		memdelete(message_queue);
-	}
-	OS::get_singleton()->finalize_core();
-	locale = String();
-
-	return ERR_INVALID_PARAMETER;
 }
-
-Error Main::setup2(Thread::ID p_main_tid_override) {
-	preregister_module_types();
-	preregister_server_types();
-
-	// Print engine name and version
-	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
-
-#if !defined(NO_THREADS)
-	if (p_main_tid_override) {
-		Thread::main_thread_id = p_main_tid_override;
-	}
-#endif
-
-#ifdef TOOLS_ENABLED
-	if (editor || project_manager) {
-		EditorNode::register_editor_paths(project_manager);
-	}
-#endif
-
-	/* Determine text driver */
-
-	if (text_driver == "") {
-		text_driver = GLOBAL_GET("internationalization/rendering/text_driver");
-	}
-
-	if (text_driver != "") {
-		/* Load user selected text server. */
-		for (int i = 0; i < TextServerManager::get_interface_count(); i++) {
-			if (text_driver == TextServerManager::get_interface_name(i)) {
-				text_driver_idx = i;
-				break;
-			}
-		}
-	}
-
-	if (text_driver_idx < 0) {
-		/* If not selected, use one with the most features available. */
-		int max_features = 0;
-		for (int i = 0; i < TextServerManager::get_interface_count(); i++) {
-			uint32_t ftrs = TextServerManager::get_interface_features(i);
-			int features = 0;
-			while (ftrs) {
-				features += ftrs & 1;
-				ftrs >>= 1;
-			}
-			if (features >= max_features) {
-				max_features = features;
-				text_driver_idx = i;
-			}
-		}
-	}
-	print_verbose("Using \"" + TextServerManager::get_interface_name(text_driver_idx) + "\" text server...");
-
-	/* Initialize Text Server */
-
-	{
-		tsman = memnew(TextServerManager);
-		Error err;
-		TextServer *text_server = TextServerManager::initialize(text_driver_idx, err);
-		if (err != OK || text_server == nullptr) {
-			for (int i = 0; i < TextServerManager::get_interface_count(); i++) {
-				if (i == text_driver_idx) {
-					continue; //don't try the same twice
-				}
-				text_server = TextServerManager::initialize(i, err);
-				if (err == OK && text_server != nullptr) {
-					break;
-				}
-			}
-		}
-
-		if (err != OK || text_server == nullptr) {
-			ERR_PRINT("Unable to create TextServer, all text drivers failed.");
-			return err;
-		}
-	}
-
-	/* Initialize Input */
-
-	input = memnew(Input);
-
-	/* Initialize Display Server */
-
-	{
-		String rendering_driver; // temp broken
-
-		Error err;
-		display_server = DisplayServer::create(display_driver_idx, rendering_driver, window_mode, window_flags, window_size, err);
-		if (err != OK || display_server == nullptr) {
-			//ok i guess we can't use this display server, try other ones
-			for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
-				if (i == display_driver_idx) {
-					continue; //don't try the same twice
-				}
-				display_server = DisplayServer::create(i, rendering_driver, window_mode, window_flags, window_size, err);
-				if (err == OK && display_server != nullptr) {
-					break;
-				}
-			}
-		}
-
-		if (err != OK || display_server == nullptr) {
-			ERR_PRINT("Unable to create DisplayServer, all display drivers failed.");
-			return err;
-		}
-	}
-
-	if (display_server->has_feature(DisplayServer::FEATURE_ORIENTATION)) {
-		display_server->screen_set_orientation(window_orientation);
-	}
-
-	/* Initialize Pen Tablet Driver */
-
-	{
-		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver", "");
-		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver.Windows", "");
-		ProjectSettings::get_singleton()->set_custom_property_info("input_devices/pen_tablet/driver.Windows", PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.Windows", PROPERTY_HINT_ENUM, "wintab,winink"));
-	}
-
-	if (tablet_driver == "") { // specified in project.godot
-		tablet_driver = GLOBAL_GET("input_devices/pen_tablet/driver");
-		if (tablet_driver == "") {
-			tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(0);
-		}
-	}
-
-	for (int i = 0; i < DisplayServer::get_singleton()->tablet_get_driver_count(); i++) {
-		if (tablet_driver == DisplayServer::get_singleton()->tablet_get_driver_name(i)) {
-			DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(i));
-			break;
-		}
-	}
-
-	if (DisplayServer::get_singleton()->tablet_get_current_driver() == "") {
-		DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(0));
-	}
-
-	print_verbose("Using \"" + tablet_driver + "\" pen tablet driver...");
-
-	/* Initialize Visual Server */
-
-	rendering_server = memnew(RenderingServerDefault(OS::get_singleton()->get_render_thread_mode() == OS::RENDER_SEPARATE_THREAD));
-
-	rendering_server->init();
-	rendering_server->set_render_loop_enabled(!disable_render_loop);
-
-	if (profile_gpu) {
-		rendering_server->set_print_gpu_profile(true);
-	}
-
-	OS::get_singleton()->initialize_joypads();
-
-	/* Initialize Audio Driver */
-
-	AudioDriverManager::initialize(audio_driver_idx);
-
-	print_line(" "); //add a blank line for readability
-
-	if (init_use_custom_pos) {
-		display_server->window_set_position(init_custom_pos);
-	}
-
-	// right moment to create and initialize the audio server
-
-	audio_server = memnew(AudioServer);
-	audio_server->init();
-
-	// also init our xr_server from here
-	xr_server = memnew(XRServer);
-
-	register_core_singletons();
-
-	MAIN_PRINT("Main: Setup Logo");
-
-#if defined(JAVASCRIPT_ENABLED) || defined(ANDROID_ENABLED)
-	bool show_logo = false;
-#else
-	bool show_logo = true;
-#endif
-
-	if (init_screen != -1) {
-		DisplayServer::get_singleton()->window_set_current_screen(init_screen);
-	}
-	if (init_windowed) {
-		//do none..
-	} else if (init_maximized) {
-		DisplayServer::get_singleton()->window_set_mode(DisplayServer::WINDOW_MODE_MAXIMIZED);
-	} else if (init_fullscreen) {
-		DisplayServer::get_singleton()->window_set_mode(DisplayServer::WINDOW_MODE_FULLSCREEN);
-	}
-	if (init_always_on_top) {
-		DisplayServer::get_singleton()->window_set_flag(DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP, true);
-	}
-
-	if (allow_focus_steal_pid) {
-		DisplayServer::get_singleton()->enable_for_stealing_focus(allow_focus_steal_pid);
-	}
-
-	register_server_types();
-
-	MAIN_PRINT("Main: Load Boot Image");
-
-	Color clear = GLOBAL_DEF("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3));
-	RenderingServer::get_singleton()->set_default_clear_color(clear);
-
-	if (show_logo) { //boot logo!
-		String boot_logo_path = GLOBAL_DEF("application/boot_splash/image", String());
-		bool boot_logo_scale = GLOBAL_DEF("application/boot_splash/fullsize", true);
-		bool boot_logo_filter = GLOBAL_DEF("application/boot_splash/use_filter", true);
-		ProjectSettings::get_singleton()->set_custom_property_info("application/boot_splash/image",
-				PropertyInfo(Variant::STRING,
-						"application/boot_splash/image",
-						PROPERTY_HINT_FILE, "*.png"));
-
-		Ref<Image> boot_logo;
-
-		boot_logo_path = boot_logo_path.strip_edges();
-
-		if (boot_logo_path != String()) {
-			boot_logo.instance();
-			Error load_err = ImageLoader::load_image(boot_logo_path, boot_logo);
-			if (load_err) {
-				ERR_PRINT("Non-existing or invalid boot splash at '" + boot_logo_path + "'. Loading default splash.");
-			}
-		}
-
-#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
-		const Color boot_bg_color =
-				GLOBAL_DEF("application/boot_splash/bg_color",
-						(editor || project_manager) ? boot_splash_editor_bg_color : boot_splash_bg_color);
-#else
-		const Color boot_bg_color = GLOBAL_DEF("application/boot_splash/bg_color", boot_splash_bg_color);
-#endif
-		if (boot_logo.is_valid()) {
-			RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color, boot_logo_scale,
-					boot_logo_filter);
-
-		} else {
-#ifndef NO_DEFAULT_BOOT_LOGO
-			MAIN_PRINT("Main: Create bootsplash");
-#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
-			Ref<Image> splash = (editor || project_manager) ? memnew(Image(boot_splash_editor_png)) : memnew(Image(boot_splash_png));
-#else
-			Ref<Image> splash = memnew(Image(boot_splash_png));
-#endif
-
-			MAIN_PRINT("Main: ClearColor");
-			RenderingServer::get_singleton()->set_default_clear_color(boot_bg_color);
-			MAIN_PRINT("Main: Image");
-			RenderingServer::get_singleton()->set_boot_image(splash, boot_bg_color, false);
-#endif
-		}
-
-#ifdef TOOLS_ENABLED
-		Ref<Image> icon = memnew(Image(app_icon_png));
-		DisplayServer::get_singleton()->set_icon(icon);
-#endif
-	}
-
-	MAIN_PRINT("Main: DCC");
-	RenderingServer::get_singleton()->set_default_clear_color(
-			GLOBAL_DEF("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3)));
-
-	GLOBAL_DEF("application/config/icon", String());
-	ProjectSettings::get_singleton()->set_custom_property_info("application/config/icon",
-			PropertyInfo(Variant::STRING, "application/config/icon",
-					PROPERTY_HINT_FILE, "*.png,*.webp,*.svg,*.svgz"));
-
-	GLOBAL_DEF("application/config/macos_native_icon", String());
-	ProjectSettings::get_singleton()->set_custom_property_info("application/config/macos_native_icon",
-			PropertyInfo(Variant::STRING,
-					"application/config/macos_native_icon",
-					PROPERTY_HINT_FILE, "*.icns"));
-
-	GLOBAL_DEF("application/config/windows_native_icon", String());
-	ProjectSettings::get_singleton()->set_custom_property_info("application/config/windows_native_icon",
-			PropertyInfo(Variant::STRING,
-					"application/config/windows_native_icon",
-					PROPERTY_HINT_FILE, "*.ico"));
-
-	Input *id = Input::get_singleton();
-	if (id) {
-		if (bool(GLOBAL_DEF("input_devices/pointing/emulate_touch_from_mouse", false)) &&
-				!(editor || project_manager)) {
-			bool found_touchscreen = false;
-			for (int i = 0; i < DisplayServer::get_singleton()->get_screen_count(); i++) {
-				if (DisplayServer::get_singleton()->screen_is_touchscreen(i)) {
-					found_touchscreen = true;
-				}
-			}
-			if (!found_touchscreen) {
-				//only if no touchscreen ui hint, set emulation
-				id->set_emulate_touch_from_mouse(true);
-			}
-		}
-
-		id->set_emulate_mouse_from_touch(bool(GLOBAL_DEF("input_devices/pointing/emulate_mouse_from_touch", true)));
-	}
-
-	MAIN_PRINT("Main: Load Translations and Remaps");
-
-	translation_server->setup(); //register translations, load them, etc.
-	if (locale != "") {
-		translation_server->set_locale(locale);
-	}
-	translation_server->load_translations();
-	ResourceLoader::load_translation_remaps(); //load remaps for resources
-
-	ResourceLoader::load_path_remaps();
-
-	MAIN_PRINT("Main: Load Scene Types");
-
-	register_scene_types();
-
-#ifdef TOOLS_ENABLED
-	ClassDB::set_current_api(ClassDB::API_EDITOR);
-	EditorNode::register_editor_types();
-
-	ClassDB::set_current_api(ClassDB::API_CORE);
-
-#endif
-
-	MAIN_PRINT("Main: Load Modules, Physics, Drivers, Scripts");
-
-	register_platform_apis();
-	register_module_types();
-
-	GLOBAL_DEF("display/mouse_cursor/custom_image", String());
-	GLOBAL_DEF("display/mouse_cursor/custom_image_hotspot", Vector2());
-	GLOBAL_DEF("display/mouse_cursor/tooltip_position_offset", Point2(10, 10));
-	ProjectSettings::get_singleton()->set_custom_property_info("display/mouse_cursor/custom_image",
-			PropertyInfo(Variant::STRING,
-					"display/mouse_cursor/custom_image",
-					PROPERTY_HINT_FILE, "*.png,*.webp"));
-
-	if (String(ProjectSettings::get_singleton()->get("display/mouse_cursor/custom_image")) != String()) {
-		Ref<Texture2D> cursor = ResourceLoader::load(
-				ProjectSettings::get_singleton()->get("display/mouse_cursor/custom_image"));
-		if (cursor.is_valid()) {
-			Vector2 hotspot = ProjectSettings::get_singleton()->get("display/mouse_cursor/custom_image_hotspot");
-			Input::get_singleton()->set_custom_mouse_cursor(cursor, Input::CURSOR_ARROW, hotspot);
-		}
-	}
-
-	camera_server = CameraServer::create();
-
-	initialize_physics();
-	initialize_navigation_server();
-	register_server_singletons();
-
-	register_driver_types();
-
-	// This loads global classes, so it must happen before custom loaders and savers are registered
-	ScriptServer::init_languages();
-
-	audio_server->load_default_bus_layout();
-
-	if (use_debug_profiler && EngineDebugger::is_active()) {
-		// Start the "scripts" profiler, used in local debugging.
-		// We could add more, and make the CLI arg require a comma-separated list of profilers.
-		EngineDebugger::get_singleton()->profiler_enable("scripts", true);
-	}
-
-	if (!project_manager) {
-		// If not running the project manager, and now that the engine is
-		// able to load resources, load the global shader variables.
-		// If running on editor, don't load the textures because the editor
-		// may want to import them first. Editor will reload those later.
-		rendering_server->global_variables_load_settings(!editor);
-	}
-
-	_start_success = true;
-	locale = String();
-
-	ClassDB::set_current_api(ClassDB::API_NONE); //no more APIs are registered at this point
-
-	print_verbose("CORE API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_CORE)));
-	print_verbose("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
-	MAIN_PRINT("Main: Done");
-
-	return OK;
-}
-
-// everything the main loop needs to know about frame timings
-static MainTimerSync main_timer_sync;
 
 bool Main::start() {
-	ERR_FAIL_COND_V(!_start_success, false);
+	ERR_FAIL_COND_V(!_setup_completed, false);
 
-	bool hasicon = false;
-	String doc_tool_path;
-	String positional_arg;
-	String game_path;
-	String script;
-	bool check_only = false;
+	// If configured, run a tool and exit the application.
+	if (configuration.run_tool) {
+		switch (configuration.selected_tool) {
+			case StandaloneTool::VALIDATE_SCRIPT: {
+				Ref<Script> script_res = ResourceLoader::load(configuration.script_path);
+				ERR_FAIL_COND_V_MSG(script_res.is_null(), false, "Can't load script: " + configuration.script_path);
 
-#ifdef TOOLS_ENABLED
-	bool doc_base = true;
-	String _export_preset;
-	bool export_debug = false;
-	bool export_pack_only = false;
-#endif
-
-	main_timer_sync.init(OS::get_singleton()->get_ticks_usec());
-	List<String> args = OS::get_singleton()->get_cmdline_args();
-
-	// parameters that do not have an argument to the right
-	for (int i = 0; i < args.size(); i++) {
-		// Doctest Unit Testing Handler
-		// Designed to override and pass arguments to the unit test handler.
-		if (args[i] == "--check-only") {
-			check_only = true;
-#ifdef TOOLS_ENABLED
-		} else if (args[i] == "--no-docbase") {
-			doc_base = false;
-		} else if (args[i] == "-e" || args[i] == "--editor") {
-			editor = true;
-		} else if (args[i] == "-p" || args[i] == "--project-manager") {
-			project_manager = true;
-#endif
-		} else if (args[i].length() && args[i][0] != '-' && positional_arg == "") {
-			positional_arg = args[i];
-
-			if (args[i].ends_with(".scn") ||
-					args[i].ends_with(".tscn") ||
-					args[i].ends_with(".escn") ||
-					args[i].ends_with(".res") ||
-					args[i].ends_with(".tres")) {
-				// Only consider the positional argument to be a scene path if it ends with
-				// a file extension associated with Godot scenes. This makes it possible
-				// for projects to parse command-line arguments for custom CLI arguments
-				// or other file extensions without trouble. This can be used to implement
-				// "drag-and-drop onto executable" logic, which can prove helpful
-				// for non-game applications.
-				game_path = args[i];
-			}
-		}
-		//parameters that have an argument to the right
-		else if (i < (args.size() - 1)) {
-			bool parsed_pair = true;
-			if (args[i] == "-s" || args[i] == "--script") {
-				script = args[i + 1];
-#ifdef TOOLS_ENABLED
-			} else if (args[i] == "--doctool") {
-				doc_tool_path = args[i + 1];
-				if (doc_tool_path.begins_with("-")) {
-					// Assuming other command line arg, so default to cwd.
-					doc_tool_path = ".";
-					parsed_pair = false;
+				if (!script_res->is_valid()) {
+					OS::get_singleton()->set_exit_code(EXIT_FAILURE);
 				}
-			} else if (args[i] == "--export") {
-				editor = true; //needs editor
-				_export_preset = args[i + 1];
-			} else if (args[i] == "--export-debug") {
-				editor = true; //needs editor
-				_export_preset = args[i + 1];
-				export_debug = true;
-			} else if (args[i] == "--export-pack") {
-				editor = true;
-				_export_preset = args[i + 1];
-				export_pack_only = true;
-#endif
-			} else {
-				// The parameter does not match anything known, don't skip the next argument
-				parsed_pair = false;
-			}
-			if (parsed_pair) {
-				i++;
-			}
-		} else if (args[i] == "--doctool") {
-			// Handle case where no path is given to --doctool.
-			doc_tool_path = ".";
-		}
-	}
-
+			} break;
 #ifdef TOOLS_ENABLED
-	if (doc_tool_path != "") {
-		Engine::get_singleton()->set_editor_hint(
-				true); // Needed to instance editor-only classes for their default values
-
-		{
-			DirAccessRef da = DirAccess::open(doc_tool_path);
-			ERR_FAIL_COND_V_MSG(!da, false, "Argument supplied to --doctool must be a valid directory path.");
-		}
-
-#ifndef MODULE_MONO_ENABLED
-		// Hack to define Mono-specific project settings even on non-Mono builds,
-		// so that we don't lose their descriptions and default values in DocData.
-		// Default values should be synced with mono_gd/gd_mono.cpp.
-		GLOBAL_DEF("mono/debugger_agent/port", 23685);
-		GLOBAL_DEF("mono/debugger_agent/wait_for_debugger", false);
-		GLOBAL_DEF("mono/debugger_agent/wait_timeout", 3000);
-		GLOBAL_DEF("mono/profiler/args", "log:calls,alloc,sample,output=output.mlpd");
-		GLOBAL_DEF("mono/profiler/enabled", false);
-		GLOBAL_DEF("mono/unhandled_exception_policy", 0);
-		// From editor/csharp_project.cpp.
-		GLOBAL_DEF("mono/project/auto_update_project", true);
+			case StandaloneTool::DOC_TOOL: {
+				run_doc_tool(configuration.doc_tool_path, configuration.doc_base_types);
+			} break;
 #endif
-
-		DocTools doc;
-		doc.generate(doc_base);
-
-		DocTools docsrc;
-		Map<String, String> doc_data_classes;
-		Set<String> checked_paths;
-		print_line("Loading docs...");
-
-		for (int i = 0; i < _doc_data_class_path_count; i++) {
-			// Custom modules are always located by absolute path.
-			String path = _doc_data_class_paths[i].path;
-			if (path.is_rel_path()) {
-				path = doc_tool_path.plus_file(path);
-			}
-			String name = _doc_data_class_paths[i].name;
-			doc_data_classes[name] = path;
-			if (!checked_paths.has(path)) {
-				checked_paths.insert(path);
-
-				// Create the module documentation directory if it doesn't exist
-				DirAccess *da = DirAccess::create_for_path(path);
-				da->make_dir_recursive(path);
-				memdelete(da);
-
-				docsrc.load_classes(path);
-				print_line("Loading docs from: " + path);
-			}
+			default:
+				break;
 		}
-
-		String index_path = doc_tool_path.plus_file("doc/classes");
-		// Create the main documentation directory if it doesn't exist
-		DirAccess *da = DirAccess::create_for_path(index_path);
-		da->make_dir_recursive(index_path);
-		memdelete(da);
-
-		docsrc.load_classes(index_path);
-		checked_paths.insert(index_path);
-		print_line("Loading docs from: " + index_path);
-
-		print_line("Merging docs...");
-		doc.merge_from(docsrc);
-		for (Set<String>::Element *E = checked_paths.front(); E; E = E->next()) {
-			print_line("Erasing old docs at: " + E->get());
-			DocTools::erase_classes(E->get());
-		}
-
-		print_line("Generating new docs...");
-		doc.save_classes(index_path, doc_data_classes);
 
 		return false;
 	}
 
-#endif
+	// Create a MainLoop
+	// Usually main loop will be a a SceneTree. However, scripts and project settings
+	// can overwrite this. If nothing is configured we default to SceneTree.
+	String main_loop_type = GLOBAL_GET("application/run/main_loop_type");
 
-	if (script == "" && game_path == "" && String(GLOBAL_GET("application/run/main_scene")) != "") {
-		game_path = GLOBAL_GET("application/run/main_scene");
-	}
+	const bool is_scene_tree = configuration.application_type != ApplicationType::SCRIPT && (main_loop_type == "SceneTree" || main_loop_type == "");
+	MainLoop *main_loop = is_scene_tree ? memnew(SceneTree) : create_main_loop(main_loop_type);
+	ERR_FAIL_COND_V_MSG(!main_loop, false, "Main loop could not be created.");
 
-	MainLoop *main_loop = nullptr;
-	if (editor) {
-		main_loop = memnew(SceneTree);
-	};
-	String main_loop_type = GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
+	if (is_scene_tree || main_loop->is_class("SceneTree")) {
+		SceneTree *scene_tree = create_scene_tree(main_loop);
 
-	if (script != "") {
-		Ref<Script> script_res = ResourceLoader::load(script);
-		ERR_FAIL_COND_V_MSG(script_res.is_null(), false, "Can't load script: " + script);
-
-		if (check_only) {
-			if (!script_res->is_valid()) {
-				OS::get_singleton()->set_exit_code(EXIT_FAILURE);
-			}
-			return false;
-		}
-
-		if (script_res->can_instance()) {
-			StringName instance_type = script_res->get_instance_base_type();
-			Object *obj = ClassDB::instance(instance_type);
-			MainLoop *script_loop = Object::cast_to<MainLoop>(obj);
-			if (!script_loop) {
-				if (obj) {
-					memdelete(obj);
-				}
-				ERR_FAIL_V_MSG(false,
-						vformat("Can't load the script \"%s\" as it doesn't inherit from SceneTree or MainLoop.",
-								script));
-			}
-
-			script_loop->set_initialize_script(script_res);
-			main_loop = script_loop;
-		} else {
-			return false;
-		}
-	} else { // Not based on script path.
-		if (!editor && !ClassDB::class_exists(main_loop_type) && ScriptServer::is_global_class(main_loop_type)) {
-			String script_path = ScriptServer::get_global_class_path(main_loop_type);
-			Ref<Script> script_res = ResourceLoader::load(script_path);
-			StringName script_base = ScriptServer::get_global_class_native_base(main_loop_type);
-			Object *obj = ClassDB::instance(script_base);
-			MainLoop *script_loop = Object::cast_to<MainLoop>(obj);
-			if (!script_loop) {
-				if (obj) {
-					memdelete(obj);
-				}
-				DisplayServer::get_singleton()->alert("Error: Invalid MainLoop script base type: " + script_base);
-				ERR_FAIL_V_MSG(false, vformat("The global class %s does not inherit from SceneTree or MainLoop.", main_loop_type));
-			}
-			script_loop->set_initialize_script(script_res);
-			main_loop = script_loop;
-		}
-	}
-
-	if (!main_loop && main_loop_type == "") {
-		main_loop_type = "SceneTree";
-	}
-
-	if (!main_loop) {
-		if (!ClassDB::class_exists(main_loop_type)) {
-			DisplayServer::get_singleton()->alert("Error: MainLoop type doesn't exist: " + main_loop_type);
-			return false;
-		} else {
-			Object *ml = ClassDB::instance(main_loop_type);
-			ERR_FAIL_COND_V_MSG(!ml, false, "Can't instance MainLoop type.");
-
-			main_loop = Object::cast_to<MainLoop>(ml);
-			if (!main_loop) {
-				memdelete(ml);
-				ERR_FAIL_V_MSG(false, "Invalid MainLoop type.");
-			}
-		}
-	}
-
-	if (main_loop->is_class("SceneTree")) {
-		SceneTree *sml = Object::cast_to<SceneTree>(main_loop);
-
-#ifdef DEBUG_ENABLED
-		if (debug_collisions) {
-			sml->set_debug_collisions_hint(true);
-		}
-		if (debug_navigation) {
-			sml->set_debug_navigation_hint(true);
-		}
-#endif
-
-		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", false);
-
-		if (single_window || (!project_manager && !editor && embed_subwindows)) {
-			sml->get_root()->set_embed_subwindows_hint(true);
-		}
-		ResourceLoader::add_custom_loaders();
-		ResourceSaver::add_custom_savers();
-
-		if (!project_manager && !editor) { // game
-			if (game_path != "" || script != "") {
-				//autoload
-				Map<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
-
-				//first pass, add the constants so they exist before any script is loaded
-				for (Map<StringName, ProjectSettings::AutoloadInfo>::Element *E = autoloads.front(); E; E = E->next()) {
-					const ProjectSettings::AutoloadInfo &info = E->get();
-
-					if (info.is_singleton) {
-						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-							ScriptServer::get_language(i)->add_global_constant(info.name, Variant());
-						}
-					}
-				}
-
-				//second pass, load into global constants
-				List<Node *> to_add;
-				for (Map<StringName, ProjectSettings::AutoloadInfo>::Element *E = autoloads.front(); E; E = E->next()) {
-					const ProjectSettings::AutoloadInfo &info = E->get();
-
-					RES res = ResourceLoader::load(info.path);
-					ERR_CONTINUE_MSG(res.is_null(), "Can't autoload: " + info.path);
-					Node *n = nullptr;
-					if (res->is_class("PackedScene")) {
-						Ref<PackedScene> ps = res;
-						n = ps->instance();
-					} else if (res->is_class("Script")) {
-						Ref<Script> script_res = res;
-						StringName ibt = script_res->get_instance_base_type();
-						bool valid_type = ClassDB::is_parent_class(ibt, "Node");
-						ERR_CONTINUE_MSG(!valid_type, "Script does not inherit a Node: " + info.path);
-
-						Object *obj = ClassDB::instance(ibt);
-
-						ERR_CONTINUE_MSG(obj == nullptr,
-								"Cannot instance script for autoload, expected 'Node' inheritance, got: " +
-										String(ibt));
-
-						n = Object::cast_to<Node>(obj);
-						n->set_script(script_res);
-					}
-
-					ERR_CONTINUE_MSG(!n, "Path in autoload not a node or script: " + info.path);
-					n->set_name(info.name);
-
-					//defer so references are all valid on _ready()
-					to_add.push_back(n);
-
-					if (info.is_singleton) {
-						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-							ScriptServer::get_language(i)->add_global_constant(info.name, n);
-						}
-					}
-				}
-
-				for (List<Node *>::Element *E = to_add.front(); E; E = E->next()) {
-					sml->get_root()->add_child(E->get());
-				}
-			}
-		}
-
+		// Set the root node.
+		switch (configuration.application_type) {
 #ifdef TOOLS_ENABLED
-		EditorNode *editor_node = nullptr;
-		if (editor) {
-			editor_node = memnew(EditorNode);
-			sml->get_root()->add_child(editor_node);
-
-			if (_export_preset != "") {
-				editor_node->export_preset(_export_preset, positional_arg, export_debug, export_pack_only);
-				game_path = ""; // Do not load anything.
-			}
-		}
-#endif
-
-		if (!editor && !project_manager) {
-			//standard helpers that can be changed from main config
-
-			String stretch_mode = GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
-			String stretch_aspect = GLOBAL_DEF_BASIC("display/window/stretch/aspect", "ignore");
-			Size2i stretch_size = Size2i(GLOBAL_DEF_BASIC("display/window/size/width", 0),
-					GLOBAL_DEF_BASIC("display/window/size/height", 0));
-
-			Window::ContentScaleMode cs_sm = Window::CONTENT_SCALE_MODE_DISABLED;
-			if (stretch_mode == "canvas_items") {
-				cs_sm = Window::CONTENT_SCALE_MODE_CANVAS_ITEMS;
-			} else if (stretch_mode == "viewport") {
-				cs_sm = Window::CONTENT_SCALE_MODE_VIEWPORT;
-			}
-
-			Window::ContentScaleAspect cs_aspect = Window::CONTENT_SCALE_ASPECT_IGNORE;
-			if (stretch_aspect == "keep") {
-				cs_aspect = Window::CONTENT_SCALE_ASPECT_KEEP;
-			} else if (stretch_aspect == "keep_width") {
-				cs_aspect = Window::CONTENT_SCALE_ASPECT_KEEP_WIDTH;
-			} else if (stretch_aspect == "keep_height") {
-				cs_aspect = Window::CONTENT_SCALE_ASPECT_KEEP_HEIGHT;
-			} else if (stretch_aspect == "expand") {
-				cs_aspect = Window::CONTENT_SCALE_ASPECT_EXPAND;
-			}
-
-			sml->get_root()->set_content_scale_mode(cs_sm);
-			sml->get_root()->set_content_scale_aspect(cs_aspect);
-			sml->get_root()->set_content_scale_size(stretch_size);
-
-			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
-			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
-			String appname = ProjectSettings::get_singleton()->get("application/config/name");
-			appname = TranslationServer::get_singleton()->translate(appname);
-#ifdef DEBUG_ENABLED
-			// Append a suffix to the window title to denote that the project is running
-			// from a debug build (including the editor). Since this results in lower performance,
-			// this should be clearly presented to the user.
-			DisplayServer::get_singleton()->window_set_title(vformat("%s (DEBUG)", appname));
-#else
-			DisplayServer::get_singleton()->window_set_title(appname);
-#endif
-
-			bool snap_controls = GLOBAL_DEF("gui/common/snap_controls_to_pixels", true);
-			sml->get_root()->set_snap_controls_to_pixels(snap_controls);
-
-			bool font_oversampling = GLOBAL_DEF("gui/fonts/dynamic_fonts/use_oversampling", true);
-			sml->get_root()->set_use_font_oversampling(font_oversampling);
-
-			int texture_filter = GLOBAL_DEF("rendering/textures/canvas_textures/default_texture_filter", 1);
-			int texture_repeat = GLOBAL_DEF("rendering/textures/canvas_textures/default_texture_repeat", 0);
-			sml->get_root()->set_default_canvas_item_texture_filter(
-					Viewport::DefaultCanvasItemTextureFilter(texture_filter));
-			sml->get_root()->set_default_canvas_item_texture_repeat(
-					Viewport::DefaultCanvasItemTextureRepeat(texture_repeat));
-
-		} else {
-			GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
-			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/mode",
-					PropertyInfo(Variant::STRING,
-							"display/window/stretch/mode",
-							PROPERTY_HINT_ENUM,
-							"disabled,canvas_items,viewport"));
-			GLOBAL_DEF_BASIC("display/window/stretch/aspect", "ignore");
-			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/aspect",
-					PropertyInfo(Variant::STRING,
-							"display/window/stretch/aspect",
-							PROPERTY_HINT_ENUM,
-							"ignore,keep,keep_width,keep_height,expand"));
-			GLOBAL_DEF_BASIC("display/window/stretch/shrink", 1.0);
-			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/shrink",
-					PropertyInfo(Variant::FLOAT,
-							"display/window/stretch/shrink",
-							PROPERTY_HINT_RANGE,
-							"1.0,8.0,0.1"));
-			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
-			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
-			GLOBAL_DEF_BASIC("gui/common/snap_controls_to_pixels", true);
-			GLOBAL_DEF_BASIC("gui/fonts/dynamic_fonts/use_oversampling", true);
-
-			GLOBAL_DEF_BASIC("rendering/textures/canvas_textures/default_texture_filter", 1);
-			ProjectSettings::get_singleton()->set_custom_property_info(
-					"rendering/textures/canvas_textures/default_texture_filter",
-					PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_filter", PROPERTY_HINT_ENUM,
-							"Nearest,Linear,Linear Mipmap,Nearest Mipmap"));
-			GLOBAL_DEF_BASIC("rendering/textures/canvas_textures/default_texture_repeat", 0);
-			ProjectSettings::get_singleton()->set_custom_property_info(
-					"rendering/textures/canvas_textures/default_texture_repeat",
-					PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_repeat", PROPERTY_HINT_ENUM,
-							"Disable,Enable,Mirror"));
-		}
-
-#ifdef TOOLS_ENABLED
-		if (editor) {
-			bool editor_embed_subwindows = EditorSettings::get_singleton()->get_setting(
-					"interface/editor/single_window_mode");
-
-			if (editor_embed_subwindows) {
-				sml->get_root()->set_embed_subwindows_hint(true);
-			}
-		}
-#endif
-
-		String local_game_path;
-		if (game_path != "" && !project_manager) {
-			local_game_path = game_path.replace("\\", "/");
-
-			if (!local_game_path.begins_with("res://")) {
-				bool absolute =
-						(local_game_path.size() > 1) && (local_game_path[0] == '/' || local_game_path[1] == ':');
-
-				if (!absolute) {
-					if (ProjectSettings::get_singleton()->is_using_datapack()) {
-						local_game_path = "res://" + local_game_path;
-
-					} else {
-						int sep = local_game_path.rfind("/");
-
-						if (sep == -1) {
-							DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-							local_game_path = da->get_current_dir().plus_file(local_game_path);
-							memdelete(da);
-						} else {
-							DirAccess *da = DirAccess::open(local_game_path.substr(0, sep));
-							if (da) {
-								local_game_path = da->get_current_dir().plus_file(
-										local_game_path.substr(sep + 1, local_game_path.length()));
-								memdelete(da);
-							}
-						}
-					}
-				}
-			}
-
-			local_game_path = ProjectSettings::get_singleton()->localize_path(local_game_path);
-
-#ifdef TOOLS_ENABLED
-			if (editor) {
-				if (game_path != String(GLOBAL_GET("application/run/main_scene")) || !editor_node->has_scenes_in_session()) {
-					Error serr = editor_node->load_scene(local_game_path);
-					if (serr != OK) {
-						ERR_PRINT("Failed to load scene");
-					}
-				}
+			case ApplicationType::EDITOR: {
 				DisplayServer::get_singleton()->set_context(DisplayServer::CONTEXT_EDITOR);
-			}
-#endif
-			if (!editor) {
-				DisplayServer::get_singleton()->set_context(DisplayServer::CONTEXT_ENGINE);
-			}
-		}
 
-		if (!project_manager && !editor) { // game
+				EditorNode *editor_node = memnew(EditorNode);
+				scene_tree->get_root()->add_child(editor_node);
 
-			// Load SSL Certificates from Project Settings (or builtin).
-			Crypto::load_default_certificates(GLOBAL_DEF("network/ssl/certificate_bundle_override", ""));
-
-			if (game_path != "") {
-				Node *scene = nullptr;
-				Ref<PackedScene> scenedata = ResourceLoader::load(local_game_path);
-				if (scenedata.is_valid()) {
-					scene = scenedata->instance();
+				if (configuration.selected_tool == StandaloneTool::EXPORT) {
+					editor_node->export_preset(configuration.export_config.preset, configuration.export_config.path, configuration.export_config.debug_build, configuration.export_config.pack_only);
 				}
 
-				ERR_FAIL_COND_V_MSG(!scene, false, "Failed loading scene: " + local_game_path);
-				sml->add_current_scene(scene);
-
-#ifdef OSX_ENABLED
-				String mac_iconpath = GLOBAL_DEF("application/config/macos_native_icon", "Variant()");
-				if (mac_iconpath != "") {
-					DisplayServer::get_singleton()->set_native_icon(mac_iconpath);
-					hasicon = true;
-				}
-#endif
-
-#ifdef WINDOWS_ENABLED
-				String win_iconpath = GLOBAL_DEF("application/config/windows_native_icon", "Variant()");
-				if (win_iconpath != "") {
-					DisplayServer::get_singleton()->set_native_icon(win_iconpath);
-					hasicon = true;
-				}
-#endif
-
-				String iconpath = GLOBAL_DEF("application/config/icon", "Variant()");
-				if ((iconpath != "") && (!hasicon)) {
-					Ref<Image> icon;
-					icon.instance();
-					if (ImageLoader::load_image(iconpath, icon) == OK) {
-						DisplayServer::get_singleton()->set_icon(icon);
-						hasicon = true;
+				if (configuration.scene_path != String(GLOBAL_GET("application/run/main_scene")) || !editor_node->has_scenes_in_session()) {
+					Error serr = editor_node->load_scene(localize_scene_path(configuration.scene_path));
+					if (serr != OK) {
+						ERR_PRINT("Failed to load scene.");
 					}
 				}
-			}
-		}
-
-#ifdef TOOLS_ENABLED
-		if (project_manager || (script == "" && game_path == "" && !editor)) {
-			Engine::get_singleton()->set_editor_hint(true);
-			ProjectManager *pmanager = memnew(ProjectManager);
-			ProgressDialog *progress_dialog = memnew(ProgressDialog);
-			pmanager->add_child(progress_dialog);
-			sml->get_root()->add_child(pmanager);
-			DisplayServer::get_singleton()->set_context(DisplayServer::CONTEXT_PROJECTMAN);
-			project_manager = true;
-		}
-
-		if (project_manager || editor) {
-			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CONSOLE_WINDOW)) {
-				// Hide console window if requested (Windows-only).
-				bool hide_console = EditorSettings::get_singleton()->get_setting(
-						"interface/editor/hide_console_window");
-				DisplayServer::get_singleton()->console_set_visible(!hide_console);
-			}
-
-			// Load SSL Certificates from Editor Settings (or builtin)
-			Crypto::load_default_certificates(EditorSettings::get_singleton()->get_setting(
-																					 "network/ssl/editor_ssl_certificates")
-													  .
-													  operator String());
-		}
+			} break;
+			case ApplicationType::PROJECT_MANAGER: {
+				DisplayServer::get_singleton()->set_context(DisplayServer::CONTEXT_PROJECTMAN);
+				scene_tree->get_root()->add_child(memnew(ProjectManager));
+			} break;
 #endif
-	}
+			case ApplicationType::PROJECT: {
+				DisplayServer::get_singleton()->set_context(DisplayServer::CONTEXT_ENGINE);
 
-	if (!hasicon) {
-		Ref<Image> icon = memnew(Image(app_icon_png));
-		DisplayServer::get_singleton()->set_icon(icon);
+				String localized_scene_path = localize_scene_path(configuration.scene_path);
+				Node *scene = nullptr;
+				Ref<PackedScene> packed_scene = ResourceLoader::load(localized_scene_path);
+				if (packed_scene.is_valid()) {
+					scene = packed_scene->instance();
+				}
+				ERR_FAIL_COND_V_MSG(!scene, false, "Failed loading scene: " + localized_scene_path);
+
+				scene_tree->add_current_scene(scene);
+			} break;
+			case ApplicationType::SCRIPT: {
+				DisplayServer::get_singleton()->set_context(DisplayServer::CONTEXT_ENGINE);
+			} break;
+			default:
+				break;
+		}
 	}
 
 	OS::get_singleton()->set_main_loop(main_loop);
-
+	main_timer_sync.init(OS::get_singleton()->get_ticks_usec());
 	return true;
 }
 
 /* Main iteration
  *
- * This is the iteration of the engine's game loop, advancing the state of physics,
- * rendering and audio.
- * It's called directly by the platform's OS::run method, where the loop is created
- * and monitored.
+ * Advances the state of physics, rendering and audio. It's called directly
+ * by the platform's OS::run method, where the loop is created and monitored.
  *
  * The OS implementation can impact its draw step with the Main::force_redraw() method.
  */
-
-uint64_t Main::last_ticks = 0;
-uint32_t Main::frames = 0;
-uint32_t Main::frame = 0;
-bool Main::force_redraw_requested = false;
-int Main::iterating = 0;
-
-bool Main::is_iterating() {
-	return iterating > 0;
-}
-
-// For performance metrics.
-static uint64_t physics_process_max = 0;
-static uint64_t process_max = 0;
-
 bool Main::iteration() {
 	//for now do not error on this
 	//ERR_FAIL_COND_V(iterating, false);
@@ -2424,7 +329,7 @@ bool Main::iteration() {
 	uint64_t ticks = OS::get_singleton()->get_ticks_usec();
 	Engine::get_singleton()->_frame_ticks = ticks;
 	main_timer_sync.set_cpu_ticks_usec(ticks);
-	main_timer_sync.set_fixed_fps(fixed_fps);
+	main_timer_sync.set_fixed_fps(configuration.fixed_fps);
 
 	uint64_t ticks_elapsed = ticks - last_ticks;
 
@@ -2448,7 +353,7 @@ bool Main::iteration() {
 	last_ticks = ticks;
 
 	static const int max_physics_steps = 8;
-	if (fixed_fps == -1 && advance.physics_steps > max_physics_steps) {
+	if (configuration.fixed_fps == -1 && advance.physics_steps > max_physics_steps) {
 		process_step -= (advance.physics_steps - max_physics_steps) * physics_step;
 		advance.physics_steps = max_physics_steps;
 	}
@@ -2501,7 +406,7 @@ bool Main::iteration() {
 
 	if (DisplayServer::get_singleton()->can_any_window_draw() &&
 			RenderingServer::get_singleton()->is_render_loop_enabled()) {
-		if ((!force_redraw_requested) && OS::get_singleton()->is_in_low_processor_usage_mode()) {
+		if (!force_redraw_requested && OS::get_singleton()->is_in_low_processor_usage_mode()) {
 			if (RenderingServer::get_singleton()->has_changed()) {
 				RenderingServer::get_singleton()->draw(true, scaled_step); // flush visual commands
 				Engine::get_singleton()->frames_drawn++;
@@ -2531,17 +436,19 @@ bool Main::iteration() {
 	Engine::get_singleton()->_process_frames++;
 
 	if (frame > 1000000) {
-		if (editor || project_manager) {
-			if (print_fps) {
+		if (is_tool_application) {
+#ifdef TOOLS_ENABLED
+			if (configuration.print_fps) {
 				print_line(vformat("Editor FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(1)));
 			}
-		} else if (GLOBAL_GET("debug/settings/stdout/print_fps") || print_fps) {
+#endif
+		} else if (GLOBAL_GET("debug/settings/stdout/print_fps") || configuration.print_fps) {
 			print_line(vformat("Project FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(1)));
 		}
 
 		Engine::get_singleton()->_fps = frames;
-		performance->set_process_time(USEC_TO_SEC(process_max));
-		performance->set_physics_process_time(USEC_TO_SEC(physics_process_max));
+		Performance::get_singleton()->set_process_time(USEC_TO_SEC(process_max));
+		Performance::get_singleton()->set_physics_process_time(USEC_TO_SEC(physics_process_max));
 		process_max = 0;
 		physics_process_max = 0;
 
@@ -2551,32 +458,47 @@ bool Main::iteration() {
 
 	iterating--;
 
-	if (fixed_fps != -1) {
+	if (configuration.fixed_fps != -1) {
 		return exit;
 	}
 
 	OS::get_singleton()->add_frame_delay(DisplayServer::get_singleton()->window_can_draw());
 
 #ifdef TOOLS_ENABLED
-	if (auto_build_solutions) {
-		auto_build_solutions = false;
+	if (configuration.auto_build_solutions) {
+		configuration.auto_build_solutions = false;
 		// Only relevant when running the editor.
-		if (!editor) {
-			ERR_FAIL_V_MSG(true,
-					"Command line option --build-solutions was passed, but no project is being edited. Aborting.");
-		}
-		if (!EditorNode::get_singleton()->call_build()) {
-			ERR_FAIL_V_MSG(true,
-					"Command line option --build-solutions was passed, but the build callback failed. Aborting.");
-		}
+		ERR_FAIL_V_MSG((configuration.application_type != ApplicationType::EDITOR), "Command line option --build-solutions was passed, but no project is being edited. Aborting.");
+		ERR_FAIL_V_MSG(!EditorNode::get_singleton()->call_build(), "Command line option --build-solutions was passed, but the build callback failed. Aborting.");
 	}
 #endif
 
-	return exit || auto_quit;
+	return exit || configuration.auto_quit;
 }
 
-void Main::force_redraw() {
-	force_redraw_requested = true;
+void Main::deinitialize_early(bool p_unregister_core) {
+	if (p_unregister_core) {
+		unregister_core();
+	}
+
+	if (file_access_network_client) {
+		memdelete(file_access_network_client);
+	}
+	if (packed_data) {
+		memdelete(packed_data);
+	}
+	if (project_settings) {
+		memdelete(project_settings);
+	}
+	if (engine) {
+		memdelete(engine);
+	}
+
+	configuration.user_args.clear();
+	configuration.main_args.clear();
+	OS::get_singleton()->_cmdline.clear();
+
+	OS::get_singleton()->finalize_core();
 }
 
 /* Engine deinitialization
@@ -2587,8 +509,10 @@ void Main::force_redraw() {
  */
 void Main::cleanup(bool p_force) {
 	if (!p_force) {
-		ERR_FAIL_COND(!_start_success);
+		ERR_FAIL_COND(!_setup_completed);
 	}
+
+	// The order of deallocating matters as some of these steps are linked with each other.
 
 	EngineDebugger::deinitialize();
 
@@ -2626,7 +550,6 @@ void Main::cleanup(bool p_force) {
 
 	ImageLoader::cleanup();
 
-	unregister_driver_types();
 	unregister_module_types();
 	unregister_platform_apis();
 	unregister_scene_types();
@@ -2643,12 +566,29 @@ void Main::cleanup(bool p_force) {
 
 	OS::get_singleton()->finalize();
 
-	finalize_physics();
-	finalize_navigation_server();
-	finalize_display();
+	{
+		physics_server_3d->finish();
+		memdelete(physics_server_3d);
 
-	if (tsman) {
-		memdelete(tsman);
+		physics_server_2d->finish();
+		memdelete(physics_server_2d);
+	}
+	{
+		memdelete(navigation_server);
+		navigation_server = nullptr;
+
+		memdelete(navigation_2d_server);
+		navigation_2d_server = nullptr;
+	}
+	{
+		rendering_server->finish();
+		memdelete(rendering_server);
+
+		memdelete(display_server);
+	}
+
+	if (text_server_manager) {
+		memdelete(text_server_manager);
 	}
 
 	if (input) {
@@ -2670,8 +610,8 @@ void Main::cleanup(bool p_force) {
 	if (translation_server) {
 		memdelete(translation_server);
 	}
-	if (globals) {
-		memdelete(globals);
+	if (project_settings) {
+		memdelete(project_settings);
 	}
 	if (engine) {
 		memdelete(engine);
@@ -2691,6 +631,1089 @@ void Main::cleanup(bool p_force) {
 
 	unregister_core_driver_types();
 	unregister_core_types();
+	unregister_core();
 
 	OS::get_singleton()->finalize_core();
 }
+
+bool Main::is_iterating() {
+	return iterating > 0;
+}
+
+void Main::force_redraw() {
+	force_redraw_requested = true;
+}
+
+// Used by Mono module, should likely be registered in Engine singleton instead
+bool Main::is_project_manager() {
+	return configuration.application_type == ApplicationType::PROJECT_MANAGER;
+};
+
+Error Main::load_project_settings() {
+	// Try to load project settings.
+	if (configuration.application_type == ApplicationType::PROJECT || configuration.application_type == ApplicationType::EDITOR) {
+		bool failed = false;
+
+		// Network file system needs to be configured before project settings, since project settings are based on the
+		// 'project.godot' file which will only be available through the network if this is enabled
+		FileAccessNetwork::configure();
+		if (configuration.remote_filesystem_address != "") {
+			file_access_network_client = memnew(FileAccessNetworkClient);
+
+			Error err = file_access_network_client->connect(configuration.remote_filesystem_address, configuration.remote_filesystem_port, configuration.remote_filesystem_password);
+			if (err) {
+				OS::get_singleton()->printerr("Could not connect to remote filesystem: %s:%i.\n", configuration.remote_filesystem_address.utf8().get_data(), configuration.remote_filesystem_port);
+				failed = true;
+			}
+
+			FileAccess::make_default<FileAccessNetwork>(FileAccess::ACCESS_RESOURCES);
+		}
+
+		if (project_settings->setup(configuration.project_path, configuration.main_pack, configuration.scan_folders_upwards) != OK) {
+			failed = true;
+#ifndef TOOLS_ENABLED
+			const String error_message = vformat("Error: Couldn't load project data at '%s'. Is the .pck file missing?\nIf you've renamed the executable, the associated .pck file should also be renamed to match the executable's name (without the extension).\n", configuration.project_path.utf8().get_data());
+			DisplayServer::get_singleton()->alert(error_message);
+			OS::get_singleton()->print("%s", error_message.utf8().get_data());
+#endif
+		}
+
+		if (failed) {
+#ifdef TOOLS_ENABLED
+			configuration.application_type = ApplicationType::PROJECT_MANAGER;
+#else
+			ERR_FAIL_COND_V(failed, ERR_INVALID_PARAMETER);
+#endif
+		}
+	}
+
+	// Now that program type won't change anymore, load default project settings for the remaining settings.
+	is_tool_application = configuration.application_type == ApplicationType::PROJECT_MANAGER || configuration.application_type == ApplicationType::EDITOR;
+	load_default_project_settings();
+
+	// Needs to be done before initializing anything.
+	if (configuration.output_verbosity == OutputVerbosity::QUIET || bool(GLOBAL_GET("application/run/disable_stdout"))) {
+		_print_line_enabled = false;
+	}
+	if (bool(GLOBAL_GET("application/run/disable_stderr"))) {
+		_print_error_enabled = false;
+	};
+
+	return OK;
+}
+
+void Main::load_default_project_settings() {
+	GLOBAL_DEF_BASIC("display/window/size/width", 1024);
+	GLOBAL_DEF_BASIC("display/window/size/height", 600);
+
+	if (!is_tool_application) {
+		GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
+		GLOBAL_DEF_BASIC("display/window/stretch/aspect", "ignore");
+
+		GLOBAL_DEF("application/config/auto_accept_quit", true);
+		GLOBAL_DEF("application/config/quit_on_go_back", true);
+
+		GLOBAL_DEF("gui/common/snap_controls_to_pixels", true);
+		GLOBAL_DEF("gui/fonts/dynamic_fonts/use_oversampling", true);
+
+		GLOBAL_DEF("rendering/textures/canvas_textures/default_texture_filter", 1);
+		GLOBAL_DEF("rendering/textures/canvas_textures/default_texture_repeat", 0);
+	} else {
+#ifdef TOOLS_ENABLED
+		GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
+		GLOBAL_DEF_BASIC("display/window/stretch/aspect", "ignore");
+		GLOBAL_DEF_BASIC("display/window/stretch/shrink", 1.0);
+		GLOBAL_DEF("application/config/auto_accept_quit", true);
+		GLOBAL_DEF("application/config/quit_on_go_back", true);
+		GLOBAL_DEF_BASIC("gui/common/snap_controls_to_pixels", true);
+		GLOBAL_DEF_BASIC("gui/fonts/dynamic_fonts/use_oversampling", true);
+		GLOBAL_DEF_BASIC("rendering/textures/canvas_textures/default_texture_filter", 1);
+		GLOBAL_DEF_BASIC("rendering/textures/canvas_textures/default_texture_repeat", 0);
+
+		ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/mode",
+				PropertyInfo(Variant::STRING, "display/window/stretch/mode", PROPERTY_HINT_ENUM, "disabled,canvas_items,viewport"));
+
+		ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/aspect",
+				PropertyInfo(Variant::STRING, "display/window/stretch/aspect", PROPERTY_HINT_ENUM, "ignore,keep,keep_width,keep_height,expand"));
+
+		ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/shrink",
+				PropertyInfo(Variant::FLOAT, "display/window/stretch/shrink", PROPERTY_HINT_RANGE, "1.0,8.0,0.1"));
+
+		ProjectSettings::get_singleton()->set_custom_property_info("rendering/textures/canvas_textures/default_texture_filter",
+				PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Linear Mipmap,Nearest Mipmap"));
+
+		ProjectSettings::get_singleton()->set_custom_property_info("rendering/textures/canvas_textures/default_texture_repeat",
+				PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_repeat", PROPERTY_HINT_ENUM, "Disable,Enable,Mirror"));
+#endif // TOOLS_ENABLED
+	}
+
+// Boot splash
+#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
+	GLOBAL_DEF("application/boot_splash/bg_color", is_tool_application ? boot_splash_editor_bg_color : boot_splash_bg_color);
+#else
+	GLOBAL_DEF("application/boot_splash/bg_color", boot_splash_bg_color);
+#endif
+
+	// Display
+	GLOBAL_DEF_BASIC("display/window/size/resizable", true);
+	GLOBAL_DEF_BASIC("display/window/size/borderless", false);
+	GLOBAL_DEF_BASIC("display/window/size/fullscreen", false);
+	GLOBAL_DEF("display/window/size/always_on_top", false);
+	GLOBAL_DEF("display/window/size/test_width", 0);
+	GLOBAL_DEF("display/window/size/test_height", 0);
+
+	GLOBAL_DEF_BASIC("display/window/handheld/orientation", DisplayServer::ScreenOrientation::SCREEN_LANDSCAPE);
+	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
+	GLOBAL_DEF("display/window/dpi/allow_hidpi", false);
+	GLOBAL_DEF_RST("display/window/vsync/use_vsync", true);
+	GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
+	GLOBAL_DEF("display/window/vsync/vsync_via_compositor", false);
+	GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);
+	GLOBAL_DEF("display/window/per_pixel_transparency/enabled", false);
+	GLOBAL_DEF("display/window/subwindows/embed_subwindows", false);
+
+	GLOBAL_DEF("display/mouse_cursor/custom_image", String());
+	GLOBAL_DEF("display/mouse_cursor/custom_image_hotspot", Vector2());
+	GLOBAL_DEF("display/mouse_cursor/tooltip_position_offset", Point2(10, 10));
+
+	// Application
+	GLOBAL_DEF("application/run/frame_delay_msec", 0);
+	GLOBAL_DEF("application/run/low_processor_mode", false);
+	GLOBAL_DEF("application/run/low_processor_mode_sleep_usec", 6900); // Roughly 144 FPS
+	// Only flush stdout in debug builds by default, as spamming `print()` will
+	// decrease performance if this is enabled.
+	GLOBAL_DEF_RST("application/run/flush_stdout_on_print", false);
+	GLOBAL_DEF_RST("application/run/flush_stdout_on_print.debug", true);
+	GLOBAL_DEF("application/config/icon", String());
+	GLOBAL_DEF("application/config/windows_native_icon", String());
+	GLOBAL_DEF("application/config/macos_native_icon", String());
+	GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
+	GLOBAL_DEF("application/boot_splash/image", String());
+	GLOBAL_DEF("application/boot_splash/fullsize", true);
+	GLOBAL_DEF("application/boot_splash/use_filter", true);
+
+	// Debug
+	GLOBAL_DEF("debug/settings/stdout/print_fps", false);
+	GLOBAL_DEF("debug/settings/stdout/verbose_stdout", false);
+	GLOBAL_DEF("debug/settings/fps/force_fps", 0);
+	GLOBAL_DEF("debug/settings/crash_handler/message",
+			String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
+	GLOBAL_DEF("debug/file_logging/enable_file_logging", false);
+	GLOBAL_DEF("debug/file_logging/log_path", "user://logs/godot.log");
+	GLOBAL_DEF("debug/file_logging/max_log_files", 5);
+
+	// Only enable file logging by default on desktop platforms as logs can't be
+	// accessed easily on mobile/Web platforms (if at all).
+	// This also prevents logs from being created for the editor instance, as feature tags
+	// are disabled while in the editor (even if they should logically apply).
+	GLOBAL_DEF("debug/file_logging/enable_file_logging.pc", true);
+
+	// Input
+	GLOBAL_DEF("input_devices/pointing/ios/touch_delay", 0.150);
+	GLOBAL_DEF("input_devices/pointing/emulate_mouse_from_touch", true);
+	GLOBAL_DEF("input_devices/pointing/emulate_touch_from_mouse", false);
+	GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver", "");
+	GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver.Windows", "");
+
+	// Network
+	GLOBAL_DEF("network/ssl/certificate_bundle_override", "");
+	GLOBAL_DEF("network/limits/debugger/max_chars_per_second", 32768);
+	GLOBAL_DEF("network/limits/debugger/max_queued_messages", 2048);
+	GLOBAL_DEF("network/limits/debugger/max_errors_per_second", 400);
+	GLOBAL_DEF("network/limits/debugger/max_warnings_per_second", 400);
+	GLOBAL_DEF("network/limits/tcp/connect_timeout_seconds", (30));
+	GLOBAL_DEF_RST("network/limits/packet_peer_stream/max_buffer_po2", (16));
+	GLOBAL_DEF("network/ssl/certificate_bundle_override", "");
+
+	// Other
+	GLOBAL_DEF_BASIC("physics/common/physics_fps", 60);
+	GLOBAL_DEF("physics/common/physics_jitter_fix", 0.5);
+
+	GLOBAL_DEF("memory/limits/multithreaded_server/rid_pool_prealloc", 60);
+
+	GLOBAL_DEF("internationalization/rendering/force_right_to_left_layout_direction", false);
+	GLOBAL_DEF("internationalization/locale/include_text_server_data", false);
+
+	GLOBAL_DEF("rendering/driver/driver_name", "Vulkan");
+	GLOBAL_DEF("rendering/driver/threads/thread_model", OS::RENDER_THREAD_SAFE);
+	GLOBAL_DEF("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3));
+
+#ifdef TOOLS_ENABLED
+	// Application
+	ProjectSettings::get_singleton()->set_custom_property_info("application/boot_splash/image",
+			PropertyInfo(Variant::STRING, "application/boot_splash/image", PROPERTY_HINT_FILE, "*.png"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("application/config/icon",
+			PropertyInfo(Variant::STRING, "application/config/icon", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg,*.svgz"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("application/config/windows_native_icon",
+			PropertyInfo(Variant::STRING, "application/config/windows_native_icon", PROPERTY_HINT_FILE, "*.ico"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("application/config/macos_native_icon",
+			PropertyInfo(Variant::STRING, "application/config/macos_native_icon", PROPERTY_HINT_FILE, "*.icns"));
+
+	// Display
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/width",
+			PropertyInfo(Variant::INT, "display/window/size/width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
+
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/height",
+			PropertyInfo(Variant::INT, "display/window/size/height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
+
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_width",
+			PropertyInfo(Variant::INT, "display/window/size/test_width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
+
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_height",
+			PropertyInfo(Variant::INT, "display/window/size/test_height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
+
+	ProjectSettings::get_singleton()->set_custom_property_info("display/mouse_cursor/custom_image",
+			PropertyInfo(Variant::STRING, "display/mouse_cursor/custom_image", PROPERTY_HINT_FILE, "*.png,*.webp"));
+
+	// Debug
+	ProjectSettings::get_singleton()->set_custom_property_info("debug/settings/fps/force_fps",
+			PropertyInfo(Variant::INT, "debug/settings/fps/force_fps", PROPERTY_HINT_RANGE, "0,120,1,or_greater"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("debug/file_logging/max_log_files",
+			PropertyInfo(Variant::INT, "debug/file_logging/max_log_files", PROPERTY_HINT_RANGE, "0,20,1,or_greater")); //no negative numbers
+
+	ProjectSettings::get_singleton()->set_custom_property_info("application/run/frame_delay_msec",
+			PropertyInfo(Variant::INT, "application/run/frame_delay_msec", PROPERTY_HINT_RANGE, "0,100,1,or_greater")); // No negative numbers
+
+	ProjectSettings::get_singleton()->set_custom_property_info("application/run/low_processor_mode_sleep_usec",
+			PropertyInfo(Variant::INT, "application/run/low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "0,33200,1,or_greater")); // No negative numbers
+
+	ProjectSettings::get_singleton()->set_custom_property_info("memory/limits/multithreaded_server/rid_pool_prealloc",
+			PropertyInfo(Variant::INT, "memory/limits/multithreaded_server/rid_pool_prealloc", PROPERTY_HINT_RANGE, "0,500,1")); // No negative and limit to 500 due to crashes
+
+	// Network
+	ProjectSettings::get_singleton()->set_custom_property_info("network/ssl/certificate_bundle_override",
+			PropertyInfo(Variant::STRING, "network/ssl/certificate_bundle_override", PROPERTY_HINT_FILE, "*.crt"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/tcp/connect_timeout_seconds",
+			PropertyInfo(Variant::INT, "network/limits/tcp/connect_timeout_seconds", PROPERTY_HINT_RANGE, "1,1800,1"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/packet_peer_stream/max_buffer_po2",
+			PropertyInfo(Variant::INT, "network/limits/packet_peer_stream/max_buffer_po2", PROPERTY_HINT_RANGE, "0,64,1,or_greater"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_chars_per_second",
+			PropertyInfo(Variant::INT, "network/limits/debugger/max_chars_per_second", PROPERTY_HINT_RANGE, "0, 4096, 1, or_greater"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_queued_messages",
+			PropertyInfo(Variant::INT, "network/limits/debugger/max_queued_messages", PROPERTY_HINT_RANGE, "0, 8192, 1, or_greater"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_errors_per_second",
+			PropertyInfo(Variant::INT, "network/limits/debugger/max_errors_per_second", PROPERTY_HINT_RANGE, "0, 200, 1, or_greater"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/debugger/max_warnings_per_second",
+			PropertyInfo(Variant::INT, "network/limits/debugger/max_warnings_per_second", PROPERTY_HINT_RANGE, "0, 200, 1, or_greater"));
+
+	// Other
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/driver/driver_name",
+			PropertyInfo(Variant::STRING, "rendering/driver/driver_name", PROPERTY_HINT_ENUM, "Vulkan"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("input_devices/pen_tablet/driver.Windows",
+			PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.Windows", PROPERTY_HINT_ENUM, "wintab,winink"));
+
+	ProjectSettings::get_singleton()->set_custom_property_info("physics/common/physics_fps",
+			PropertyInfo(Variant::INT, "physics/common/physics_fps", PROPERTY_HINT_RANGE, "1,120,1,or_greater"));
+#endif // TOOLS_ENABLED
+}
+
+void Main::initialize_core() {
+	// Initialize OS
+	{
+		OS::get_singleton()->set_cmdline(configuration.exec_path, configuration.main_args);
+		OS::get_singleton()->_use_vsync = GLOBAL_GET("display/window/vsync/use_vsync");
+		OS::get_singleton()->_vsync_via_compositor = configuration.window_vsync_via_compositor;
+		OS::get_singleton()->_render_thread_mode = OS::RenderThreadMode(configuration.render_thread_mode);
+		OS::get_singleton()->_keep_screen_on = GLOBAL_GET("display/window/energy_saving/keep_screen_on");
+		OS::get_singleton()->set_low_processor_usage_mode(GLOBAL_GET("application/run/low_processor_mode"));
+		OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(GLOBAL_GET("application/run/low_processor_mode_sleep_usec"));
+
+		/* todo restore
+		OS::get_singleton()->_allow_layered = GLOBAL_GET("display/window/per_pixel_transparency/allowed");
+		video_mode.layered = GLOBAL_GET("display/window/per_pixel_transparency/enabled");
+		*/
+
+		if (configuration.disable_crash_handler) {
+			OS::get_singleton()->disable_crash_handler();
+		}
+		if (configuration.debug_output) {
+			OS::get_singleton()->_debug_stdout = true;
+		}
+		if (configuration.no_window_mode) {
+			// Currently not used.
+			OS::get_singleton()->set_no_window_mode(true);
+		}
+		if (configuration.output_verbosity == OutputVerbosity::VERBOSE) {
+			OS::get_singleton()->_verbose_stdout = true;
+		}
+		if (configuration.allow_hidpi) {
+			OS::get_singleton()->_allow_hidpi = GLOBAL_GET("display/window/dpi/allow_hidpi");
+		}
+		if (!OS::get_singleton()->_verbose_stdout) { // Not manually overridden.
+			OS::get_singleton()->_verbose_stdout = GLOBAL_GET("debug/settings/stdout/verbose_stdout");
+		}
+#ifdef TOOLS_ENABLED
+		if (is_tool_application) {
+			// The editor and project manager always detect and use hiDPI if needed
+			OS::get_singleton()->_allow_hidpi = true;
+			OS::get_singleton()->_allow_layered = false;
+		}
+#endif // TOOLS_ENABLED
+
+		OS::get_singleton()->ensure_user_data_dir();
+
+		if (!is_tool_application && GLOBAL_GET("debug/file_logging/enable_file_logging") && FileAccess::get_create_func(FileAccess::ACCESS_USERDATA)) {
+			String base_path = GLOBAL_GET("debug/file_logging/log_path");
+			int max_files = GLOBAL_GET("debug/file_logging/max_log_files");
+			OS::get_singleton()->add_logger(memnew(RotatedFileLogger(base_path, max_files)));
+		}
+	}
+
+	// Initalize Engine
+	{
+		Engine::get_singleton()->set_iterations_per_second(GLOBAL_GET("physics/common/physics_fps"));
+		Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_GET("physics/common/physics_jitter_fix"));
+		Engine::get_singleton()->set_target_fps(GLOBAL_GET("debug/settings/fps/force_fps"));
+		Engine::get_singleton()->set_frame_delay(configuration.frame_delay);
+		Engine::get_singleton()->abort_on_gpu_errors = configuration.abort_on_gpu_errors;
+		Engine::get_singleton()->use_validation_layers = configuration.use_validation_layers;
+		Engine::get_singleton()->set_time_scale(configuration.time_scale);
+#ifdef TOOLS_ENABLED
+		Engine::get_singleton()->set_editor_hint(is_tool_application);
+#endif // TOOLS_ENABLED
+	}
+
+	if (is_tool_application || configuration.run_tool) {
+		input_map->load_default();
+	} else {
+		input_map->load_from_project_settings();
+	}
+
+	translation_server = memnew(TranslationServer);
+	performance = memnew(Performance);
+	engine->add_singleton(Engine::Singleton("Performance", performance));
+
+#ifdef MINIZIP_ENABLED
+	//XXX: always get_singleton() == 0x0
+	zip_packed_data = ZipArchive::get_singleton();
+	//TODO: remove this temporary fix
+	if (!zip_packed_data) {
+		zip_packed_data = memnew(ZipArchive);
+	}
+
+	packed_data->add_pack_source(zip_packed_data);
+#endif // MINIZIP_ENABLED
+#ifdef TOOLS_ENABLED
+	if (configuration.application_type == ApplicationType::EDITOR) {
+		packed_data->set_disabled(true);
+		project_settings->set_disable_feature_overrides(true);
+	}
+#endif // TOOLS_ENABLED
+
+	EngineDebugger::initialize(configuration.debug_uri, configuration.skip_breakpoints, configuration.breakpoints);
+	Logger::set_flush_stdout_on_print(GLOBAL_GET("application/run/flush_stdout_on_print"));
+
+	message_queue = memnew(MessageQueue);
+}
+
+Error Main::finish_setup(Thread::ID p_main_tid_override) {
+	preregister_module_types();
+	preregister_server_types();
+
+#if !defined(NO_THREADS)
+	if (p_main_tid_override) {
+		Thread::main_thread_id = p_main_tid_override;
+	}
+#endif
+
+#ifdef TOOLS_ENABLED
+	if (is_tool_application) {
+		EditorNode::register_editor_paths(configuration.application_type == ApplicationType::PROJECT_MANAGER);
+	}
+#endif
+
+	input = memnew(Input);
+	OS::get_singleton()->initialize_joypads();
+
+	Error error = initialize_servers();
+	ERR_FAIL_COND_V(error != OK, error);
+
+	register_core_types();
+	register_core_singletons();
+	register_core_driver_types();
+	register_server_types();
+
+	MAIN_PRINT("Main: Load Boot Image");
+	load_boot_graphics();
+
+	const String img_path = ProjectSettings::get_singleton()->get("display/mouse_cursor/custom_image");
+	if (img_path != String()) {
+		Ref<Texture2D> cursor = ResourceLoader::load(img_path);
+		if (cursor.is_valid()) {
+			Vector2 hotspot = ProjectSettings::get_singleton()->get("display/mouse_cursor/custom_image_hotspot");
+			Input::get_singleton()->set_custom_mouse_cursor(cursor, Input::CURSOR_ARROW, hotspot);
+		}
+	}
+
+	// Input
+	{
+		if (!is_tool_application && bool(GLOBAL_GET("input_devices/pointing/emulate_touch_from_mouse"))) {
+			bool found_touchscreen = false;
+			for (int i = 0; i < DisplayServer::get_singleton()->get_screen_count(); i++) {
+				if (DisplayServer::get_singleton()->screen_is_touchscreen(i)) {
+					found_touchscreen = true;
+				}
+			}
+			if (!found_touchscreen) {
+				//only if no touchscreen ui hint, set emulation
+				Input::get_singleton()->set_emulate_touch_from_mouse(true);
+			}
+		}
+
+		Input::get_singleton()->set_emulate_mouse_from_touch(bool(GLOBAL_GET("input_devices/pointing/emulate_mouse_from_touch")));
+	}
+
+	MAIN_PRINT("Main: Load Translations and Remaps");
+	{
+		translation_server->setup();
+		if (configuration.locale != "" && translation_server->is_locale_valid(configuration.locale)) {
+			translation_server->set_locale(configuration.locale);
+		}
+		translation_server->load_translations();
+
+		ResourceLoader::load_translation_remaps(); //load remaps for resources
+		ResourceLoader::load_path_remaps();
+	}
+
+	// Register types
+	{
+		MAIN_PRINT("Main: Load Scene Types");
+		register_scene_types();
+
+#ifdef TOOLS_ENABLED
+		ClassDB::set_current_api(ClassDB::API_EDITOR);
+		EditorNode::register_editor_types();
+		ClassDB::set_current_api(ClassDB::API_CORE);
+#endif
+
+		MAIN_PRINT("Main: Load Modules, Physics, Drivers, Scripts");
+		register_platform_apis();
+		register_module_types();
+	}
+
+	if (is_tool_application) {
+#ifdef TOOLS_ENABLED
+		EditorSettings::create();
+
+		// Load SSL Certificates from Editor Settings (or builtin)
+		Crypto::load_default_certificates(EditorSettings::get_singleton()->get_setting("network/ssl/editor_ssl_certificates").operator String());
+
+		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CONSOLE_WINDOW)) {
+			// Hide console window if requested (Windows-only).
+			bool hide_console = EditorSettings::get_singleton()->get_setting("interface/editor/hide_console_window");
+			DisplayServer::get_singleton()->console_set_visible(!hide_console);
+		}
+#endif
+	} else {
+		// Load SSL Certificates from Project Settings (or builtin).
+		Crypto::load_default_certificates(GLOBAL_GET("network/ssl/certificate_bundle_override"));
+
+		String app_name = TranslationServer::get_singleton()->translate(GLOBAL_GET("application/config/name"));
+#ifdef DEBUG_ENABLED
+		// Append a suffix to the window title to denote that the project is running
+		// from a debug build (including the editor). Since this results in lower performance,
+		// this should be clearly presented to the user.
+		DisplayServer::get_singleton()->window_set_title(vformat("%s (DEBUG)", app_name));
+#else
+		DisplayServer::get_singleton()->window_set_title(app_name);
+#endif
+	}
+
+	camera_server = CameraServer::create();
+
+	// FIXME: Could maybe be moved to PhysicsServer3DManager and PhysicsServer2DManager directly
+	// to have less code in main.cpp.
+	{
+		physics_server_3d = PhysicsServer3DManager::new_server(GLOBAL_GET("physics/3d/physics_engine"));
+		if (!physics_server_3d) {
+			physics_server_3d = PhysicsServer3DManager::new_default_server();
+		}
+		if (physics_server_3d) {
+			physics_server_3d->init();
+		}
+
+		physics_server_2d = PhysicsServer2DManager::new_server(GLOBAL_GET("physics/3d/physics_engine"));
+		if (!physics_server_2d) {
+			physics_server_2d = PhysicsServer2DManager::new_default_server();
+		}
+		if (physics_server_2d) {
+			physics_server_2d->init();
+		}
+
+		navigation_server = NavigationServer3DManager::new_default_server();
+		navigation_2d_server = memnew(NavigationServer2D);
+	}
+
+	register_server_singletons();
+
+	// This loads global classes, so it must happen before custom loaders and savers are registered
+	ScriptServer::init_languages();
+
+	ResourceLoader::add_custom_loaders();
+	ResourceSaver::add_custom_savers();
+
+	audio_server->load_default_bus_layout();
+
+	if (configuration.enable_debug_profiler && EngineDebugger::is_active()) {
+		// Start the "scripts" profiler, used in local debugging.
+		// We could add more, and make the CLI arg require a comma-separated list of profilers.
+		EngineDebugger::get_singleton()->profiler_enable("scripts", true);
+	}
+
+	if (configuration.application_type != ApplicationType::PROJECT_MANAGER) {
+		// If not running the project manager, and now that the engine is
+		// able to load resources, load the global shader variables.
+		// If running on editor, don't load the textures because the editor
+		// may want to import them first. Editor will reload those later.
+		rendering_server->global_variables_load_settings(configuration.application_type != ApplicationType::EDITOR);
+	}
+
+	ClassDB::set_current_api(ClassDB::API_NONE); //no more APIs are registered at this point
+	print_verbose("CORE API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_CORE)));
+	print_verbose("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
+
+	MAIN_PRINT("Main: Done");
+	_setup_completed = true;
+
+	return OK;
+}
+
+Error Main::initialize_servers() {
+	// Audio
+	{
+		if (configuration.audio_driver_index < 0) {
+			configuration.audio_driver_index = 0; // Default to first audio driver if not specified.
+		}
+
+		GLOBAL_DEF_RST_NOVAL("audio/driver/driver", AudioDriverManager::get_driver(configuration.audio_driver_index)->get_name());
+		AudioDriverManager::initialize(configuration.audio_driver_index);
+		audio_server = memnew(AudioServer);
+		audio_server->init();
+	}
+
+	// Display
+	{
+		if (configuration.display_driver_index < 0) {
+			String driver_name = GLOBAL_GET("rendering/driver/driver_name");
+			const int display_driver_count = DisplayServer::get_create_function_count();
+
+			for (int i = 0; i < display_driver_count; i++) {
+				if (driver_name == DisplayServer::get_create_function_name(i)) {
+					configuration.display_driver_index = i;
+					break;
+				}
+			}
+		}
+
+		if (configuration.display_driver_index < 0) {
+			configuration.display_driver_index = 0;
+		}
+
+		Error err;
+		String rendering_driver; // temp broken
+		display_server = DisplayServer::create(configuration.display_driver_index, rendering_driver, configuration.window_mode, configuration.window_flags, configuration.window_size, err);
+		if (err != OK || display_server == nullptr) {
+			//ok i guess we can't use this display server, try other ones
+			const int display_driver_count = DisplayServer::get_create_function_count();
+
+			for (int i = 0; i < display_driver_count; i++) {
+				if (i == configuration.display_driver_index) {
+					continue; //don't try the same twice
+				}
+
+				display_server = DisplayServer::create(i, rendering_driver, configuration.window_mode, configuration.window_flags, configuration.window_size, err);
+				if (err == OK && display_server != nullptr) {
+					break;
+				}
+			}
+		}
+		ERR_FAIL_COND_V_MSG((err != OK || display_server == nullptr), ERR_INVALID_PARAMETER, "Unable to create DisplayServer, all display drivers failed.");
+
+		if (configuration.allow_focus_steal_pid > 0) {
+			DisplayServer::get_singleton()->enable_for_stealing_focus(configuration.allow_focus_steal_pid);
+		}
+		if (display_server->has_feature(DisplayServer::FEATURE_ORIENTATION)) {
+			display_server->screen_set_orientation(DisplayServer::ScreenOrientation(int(GLOBAL_GET("display/window/handheld/orientation"))));
+		}
+		if (configuration.window_position != Point2()) {
+			display_server->window_set_position(configuration.window_position);
+		}
+
+		// TODO: Already in DisplayServer::create()?
+		if (configuration.init_always_on_top) {
+			DisplayServer::get_singleton()->window_set_flag(DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP, true);
+		}
+
+		// TODO: Already in DisplayServer::create()?
+		if (configuration.window_mode != DisplayServer::WINDOW_MODE_WINDOWED) {
+			DisplayServer::get_singleton()->window_set_mode(configuration.window_mode);
+		}
+
+		// Tablet driver
+		{
+			bool driver_found = false;
+			if (configuration.tablet_driver_name != "") {
+				const int tablet_driver_count = DisplayServer::get_singleton()->tablet_get_driver_count();
+				for (int i = 0; i < tablet_driver_count; i++) {
+					if (configuration.tablet_driver_name == DisplayServer::get_singleton()->tablet_get_driver_name(i)) {
+						driver_found = true;
+						break;
+					}
+				}
+			}
+
+			if (!driver_found) {
+				configuration.tablet_driver_name = GLOBAL_GET("input_devices/pen_tablet/driver");
+				if (configuration.tablet_driver_name == "") {
+					configuration.tablet_driver_name = DisplayServer::get_singleton()->tablet_get_driver_name(0);
+				}
+			}
+
+			print_verbose("Using \"" + configuration.tablet_driver_name + "\" pen tablet driver...");
+			DisplayServer::get_singleton()->tablet_set_current_driver(configuration.tablet_driver_name);
+		}
+	}
+
+	// Text
+	{
+		// Determine text driver.
+		{
+			if (configuration.text_driver_index < 0) {
+				String text_driver_name = GLOBAL_GET("internationalization/rendering/text_driver");
+				for (int i = 0; i < TextServerManager::get_interface_count(); i++) {
+					if (text_driver_name == TextServerManager::get_interface_name(i)) {
+						configuration.text_driver_index = i;
+						break;
+					}
+				}
+
+				if (configuration.text_driver_index < 0) {
+					/* If not selected, use one with the most features available. */
+					int max_features = 0;
+					for (int i = 0; i < TextServerManager::get_interface_count(); i++) {
+						uint32_t ftrs = TextServerManager::get_interface_features(i);
+						int features = 0;
+						while (ftrs) {
+							features += ftrs & 1;
+							ftrs >>= 1;
+						}
+						if (features >= max_features) {
+							max_features = features;
+							configuration.text_driver_index = i;
+						}
+					}
+				}
+			}
+			print_verbose("Using \"" + TextServerManager::get_interface_name(configuration.text_driver_index) + "\" text server...");
+		}
+
+		text_server_manager = memnew(TextServerManager);
+		Error err;
+		TextServer *text_server = TextServerManager::initialize(configuration.text_driver_index, err);
+		if (err != OK || text_server == nullptr) {
+			for (int i = 0; i < TextServerManager::get_interface_count(); i++) {
+				if (i == configuration.text_driver_index) {
+					continue; //don't try the same twice
+				}
+				text_server = TextServerManager::initialize(i, err);
+				if (err == OK && text_server != nullptr) {
+					break;
+				}
+			}
+		}
+
+		if (err != OK || text_server == nullptr) {
+			ERR_PRINT("Unable to create TextServer, all text drivers failed.");
+			return err;
+		}
+	}
+
+	// Rendering
+	{
+		rendering_server = memnew(RenderingServerDefault(OS::get_singleton()->get_render_thread_mode() == OS::RENDER_SEPARATE_THREAD));
+		rendering_server->init();
+		rendering_server->set_render_loop_enabled(!configuration.disable_render_loop);
+		if (configuration.enable_gpu_profiler) {
+			rendering_server->set_print_gpu_profile(true);
+		}
+	}
+
+	xr_server = memnew(XRServer);
+
+	return OK;
+}
+
+void Main::load_boot_graphics() {
+#if !defined(JAVASCRIPT_ENABLED) && !defined(ANDROID_ENABLED)
+	if (configuration.application_type != ApplicationType::PROJECT_MANAGER) {
+		String boot_logo_path = GLOBAL_GET("application/boot_splash/image");
+		bool boot_logo_scale = GLOBAL_GET("application/boot_splash/fullsize");
+		bool boot_logo_filter = GLOBAL_GET("application/boot_splash/use_filter");
+		const Color boot_bg_color = GLOBAL_GET("application/boot_splash/bg_color");
+
+		boot_logo_path = boot_logo_path.strip_edges();
+		Ref<Image> boot_logo;
+		if (boot_logo_path != String()) {
+			boot_logo.instance();
+			Error load_err = ImageLoader::load_image(boot_logo_path, boot_logo);
+			if (load_err) {
+				ERR_PRINT("Non-existing or invalid boot splash at '" + boot_logo_path + "'. Loading default splash.");
+			}
+		}
+
+		if (boot_logo.is_valid()) {
+			RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color, boot_logo_scale, boot_logo_filter);
+		} else {
+#ifndef NO_DEFAULT_BOOT_LOGO
+			MAIN_PRINT("Main: Create bootsplash");
+			MAIN_PRINT("Main: ClearColor");
+			RenderingServer::get_singleton()->set_default_clear_color(boot_bg_color);
+
+			MAIN_PRINT("Main: Image");
+#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
+			const Ref<Image> splash = is_tool_application ? memnew(Image(boot_splash_editor_png)) : memnew(Image(boot_splash_png));
+#else
+			const Ref<Image> splash = memnew(Image(boot_splash_png));
+#endif
+			RenderingServer::get_singleton()->set_boot_image(splash, boot_bg_color, false);
+#endif // NO_DEFAULT_BOOT_LOGO
+		}
+	}
+#endif
+
+	//Configure icon
+	bool icon_configured = false;
+	if (configuration.application_type == ApplicationType::PROJECT) {
+		String icon_path;
+#ifdef WINDOWS_ENABLED
+		icon_path = GLOBAL_GET("application/config/windows_native_icon");
+#elif OSX_ENABLED
+		icon_path = GLOBAL_GET("application/config/macos_native_icon");
+#endif
+		if (icon_path != "") {
+			DisplayServer::get_singleton()->set_native_icon(icon_path);
+			icon_configured = true;
+		} else {
+			icon_path = GLOBAL_GET("application/config/icon");
+			if (icon_path != "") {
+				Ref<Image> icon;
+				icon.instance();
+				if (ImageLoader::load_image(icon_path, icon) == OK) {
+					DisplayServer::get_singleton()->set_icon(icon);
+					icon_configured = true;
+				}
+			}
+		}
+	}
+
+	if (!icon_configured) {
+		DisplayServer::get_singleton()->set_icon(memnew(Image(app_icon_png)));
+	}
+}
+
+MainLoop *create_main_loop(const String &p_main_loop_type) {
+	MainLoop *main_loop = nullptr;
+
+	if (configuration.script_path != "") {
+		// Load from script.
+		Ref<Script> script_res = ResourceLoader::load(configuration.script_path);
+		ERR_FAIL_COND_V_MSG(script_res.is_null(), main_loop, "Can't load script: " + configuration.script_path);
+		ERR_FAIL_COND_V_MSG(!script_res->can_instance(), main_loop, "Can't instance script: " + configuration.script_path);
+
+		Object *obj = ClassDB::instance(script_res->get_instance_base_type());
+		main_loop = Object::cast_to<MainLoop>(obj);
+		if (!main_loop) {
+			if (obj) {
+				memdelete(obj);
+			}
+			ERR_FAIL_V_MSG(main_loop, vformat("Can't load the script \"%s\" as it doesn't inherit from SceneTree or MainLoop.",
+											  configuration.script_path));
+		}
+
+		main_loop->set_initialize_script(script_res);
+	} else if (!ClassDB::class_exists(p_main_loop_type)) {
+		if (!ScriptServer::is_global_class(p_main_loop_type)) {
+			DisplayServer::get_singleton()->alert("Error: MainLoop type doesn't exist: " + p_main_loop_type);
+			return main_loop;
+		}
+
+		// Load global class
+		String script_path = ScriptServer::get_global_class_path(p_main_loop_type);
+		StringName script_base = ScriptServer::get_global_class_native_base(p_main_loop_type);
+
+		Ref<Script> script_res = ResourceLoader::load(script_path);
+		Object *obj = ClassDB::instance(script_base);
+		main_loop = Object::cast_to<MainLoop>(obj);
+		if (!main_loop) {
+			if (obj) {
+				memdelete(obj);
+			}
+			ERR_FAIL_V_MSG(main_loop, vformat("The class %s does not inherit from SceneTree or MainLoop.", p_main_loop_type));
+		}
+		main_loop->set_initialize_script(script_res);
+	}
+
+	return main_loop;
+}
+
+SceneTree *create_scene_tree(MainLoop *p_main_loop) {
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(p_main_loop);
+
+	if (is_tool_application) {
+#ifdef TOOLS_ENABLED
+		scene_tree->set_auto_accept_quit(GLOBAL_GET("application/config/auto_accept_quit"));
+		scene_tree->set_quit_on_go_back(GLOBAL_GET("application/config/quit_on_go_back"));
+#endif // TOOLS_ENABLED
+	} else {
+		String stretch_mode = GLOBAL_GET("display/window/stretch/mode");
+		Window::ContentScaleMode scale_mode = Window::CONTENT_SCALE_MODE_DISABLED;
+		if (stretch_mode == "canvas_items") {
+			scale_mode = Window::CONTENT_SCALE_MODE_CANVAS_ITEMS;
+		} else if (stretch_mode == "viewport") {
+			scale_mode = Window::CONTENT_SCALE_MODE_VIEWPORT;
+		}
+		scene_tree->get_root()->set_content_scale_mode(scale_mode);
+
+		String stretch_aspect = GLOBAL_GET("display/window/stretch/aspect");
+		Window::ContentScaleAspect scale_aspect = Window::CONTENT_SCALE_ASPECT_IGNORE;
+		if (stretch_aspect == "keep") {
+			scale_aspect = Window::CONTENT_SCALE_ASPECT_KEEP;
+		} else if (stretch_aspect == "keep_width") {
+			scale_aspect = Window::CONTENT_SCALE_ASPECT_KEEP_WIDTH;
+		} else if (stretch_aspect == "keep_height") {
+			scale_aspect = Window::CONTENT_SCALE_ASPECT_KEEP_HEIGHT;
+		} else if (stretch_aspect == "expand") {
+			scale_aspect = Window::CONTENT_SCALE_ASPECT_EXPAND;
+		}
+		scene_tree->get_root()->set_content_scale_aspect(scale_aspect);
+
+		const Size2i scale_size = Size2i(GLOBAL_GET("display/window/size/width"), GLOBAL_GET("display/window/size/height"));
+		scene_tree->get_root()->set_content_scale_size(scale_size);
+
+		scene_tree->set_auto_accept_quit(GLOBAL_GET("application/config/auto_accept_quit"));
+		scene_tree->set_quit_on_go_back(GLOBAL_GET("application/config/quit_on_go_back"));
+
+		scene_tree->get_root()->set_snap_controls_to_pixels(GLOBAL_GET("gui/common/snap_controls_to_pixels"));
+		scene_tree->get_root()->set_use_font_oversampling(GLOBAL_GET("gui/fonts/dynamic_fonts/use_oversampling"));
+
+		int texture_filter = GLOBAL_GET("rendering/textures/canvas_textures/default_texture_filter");
+		int texture_repeat = GLOBAL_GET("rendering/textures/canvas_textures/default_texture_repeat");
+		scene_tree->get_root()->set_default_canvas_item_texture_filter(
+				Viewport::DefaultCanvasItemTextureFilter(texture_filter));
+		scene_tree->get_root()->set_default_canvas_item_texture_repeat(
+				Viewport::DefaultCanvasItemTextureRepeat(texture_repeat));
+
+		// Add autoload nodes.
+		{
+			Map<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
+
+			//first pass, add the constants so they exist before any script is loaded
+			for (Map<StringName, ProjectSettings::AutoloadInfo>::Element *E = autoloads.front(); E; E = E->next()) {
+				const ProjectSettings::AutoloadInfo &info = E->get();
+
+				if (info.is_singleton) {
+					for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+						ScriptServer::get_language(i)->add_global_constant(info.name, Variant());
+					}
+				}
+			}
+
+			//second pass, load into global constants
+			List<Node *> to_add;
+			for (Map<StringName, ProjectSettings::AutoloadInfo>::Element *E = autoloads.front(); E; E = E->next()) {
+				const ProjectSettings::AutoloadInfo &info = E->get();
+
+				RES res = ResourceLoader::load(info.path);
+				ERR_CONTINUE_MSG(res.is_null(), "Can't autoload: " + info.path);
+				Node *n = nullptr;
+				if (res->is_class("PackedScene")) {
+					Ref<PackedScene> ps = res;
+					n = ps->instance();
+				} else if (res->is_class("Script")) {
+					Ref<Script> script_res = res;
+					StringName ibt = script_res->get_instance_base_type();
+					bool valid_type = ClassDB::is_parent_class(ibt, "Node");
+					ERR_CONTINUE_MSG(!valid_type, "Script does not inherit a Node: " + info.path);
+
+					Object *obj = ClassDB::instance(ibt);
+
+					ERR_CONTINUE_MSG(obj == nullptr,
+							"Cannot instance script for autoload, expected 'Node' inheritance, got: " +
+									String(ibt));
+
+					n = Object::cast_to<Node>(obj);
+					n->set_script(script_res);
+				}
+
+				ERR_CONTINUE_MSG(!n, "Path in autoload not a node or script: " + info.path);
+				n->set_name(info.name);
+
+				//defer so references are all valid on _ready()
+				to_add.push_back(n);
+
+				if (info.is_singleton) {
+					for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+						ScriptServer::get_language(i)->add_global_constant(info.name, n);
+					}
+				}
+			}
+
+			for (List<Node *>::Element *E = to_add.front(); E; E = E->next()) {
+				scene_tree->get_root()->add_child(E->get());
+			}
+		}
+	}
+
+#ifdef DEBUG_ENABLED
+	scene_tree->set_debug_collisions_hint(configuration.enable_debug_collisions);
+	scene_tree->set_debug_navigation_hint(configuration.enable_debug_navigation);
+#endif
+
+	bool embed_subwindows = false;
+	if (configuration.application_type == ApplicationType::EDITOR) {
+#ifdef TOOLS_ENABLED
+		embed_subwindows = EditorSettings::get_singleton()->get_setting("interface/editor/single_window_mode");
+#endif
+	} else {
+		embed_subwindows = configuration.single_window || GLOBAL_GET("display/window/subwindows/embed_subwindows");
+	}
+
+	if (embed_subwindows) {
+		scene_tree->get_root()->set_embed_subwindows_hint(true);
+	}
+
+	return scene_tree;
+}
+
+String Main::localize_scene_path(const String &p_scene_path) {
+	String path = p_scene_path.replace("\\", "/");
+
+	if (!path.begins_with("res://")) {
+		bool absolute =
+				(path.size() > 1) && (path[0] == '/' || path[1] == ':');
+
+		if (!absolute) {
+			if (ProjectSettings::get_singleton()->is_using_datapack()) {
+				path = "res://" + path;
+			} else {
+				int sep = path.rfind("/");
+
+				if (sep == -1) {
+					DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+					path = da->get_current_dir().plus_file(path);
+					memdelete(da);
+				} else {
+					DirAccess *da = DirAccess::open(path.substr(0, sep));
+					if (da) {
+						path = da->get_current_dir().plus_file(
+								path.substr(sep + 1, path.length()));
+						memdelete(da);
+					}
+				}
+			}
+		}
+	}
+
+	return ProjectSettings::get_singleton()->localize_path(path);
+}
+
+#ifdef TESTS_ENABLED
+// The order is the same as in `Main::setup()`, only core and some editor types
+// are initialized here. This also combines `Main::complete_setup()` initialization.
+Error Main::test_setup() {
+	OS::get_singleton()->initialize();
+
+	engine = memnew(Engine);
+
+	register_core();
+	register_core_types();
+	register_core_driver_types();
+
+	packed_data = memnew(PackedData);
+
+	project_settings = memnew(ProjectSettings);
+
+	GLOBAL_DEF("debug/settings/crash_handler/message",
+			String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
+
+	translation_server = memnew(TranslationServer);
+
+	// From `Main::complete_setup()`.
+	preregister_module_types();
+	preregister_server_types();
+
+	register_core_singletons();
+
+	register_server_types();
+
+	translation_server->setup(); //register translations, load them, etc.
+	translation_server->load_translations();
+	ResourceLoader::load_translation_remaps(); //load remaps for resources
+
+	ResourceLoader::load_path_remaps();
+
+	register_scene_types();
+
+#ifdef TOOLS_ENABLED
+	ClassDB::set_current_api(ClassDB::API_EDITOR);
+	EditorNode::register_editor_types();
+
+	ClassDB::set_current_api(ClassDB::API_CORE);
+#endif
+	register_platform_apis();
+
+	register_module_types();
+
+	ClassDB::set_current_api(ClassDB::API_NONE);
+
+	return OK;
+}
+
+// The order is the same as in `Main::cleanup()`.
+void Main::test_cleanup() {
+	EngineDebugger::deinitialize();
+
+	ResourceLoader::remove_custom_loaders();
+	ResourceSaver::remove_custom_savers();
+
+#ifdef TOOLS_ENABLED
+	EditorNode::unregister_editor_types();
+#endif
+	unregister_module_types();
+	unregister_platform_apis();
+	unregister_scene_types();
+	unregister_server_types();
+
+	OS::get_singleton()->finalize();
+
+	if (translation_server) {
+		memdelete(translation_server);
+	}
+	if (project_settings) {
+		memdelete(project_settings);
+	}
+	if (packed_data) {
+		memdelete(packed_data);
+	}
+	if (engine) {
+		memdelete(engine);
+	}
+
+	unregister_core_driver_types();
+	unregister_core_types();
+	unregister_core();
+
+	OS::get_singleton()->finalize_core();
+}
+#endif // TESTS_ENABLED

--- a/main/main.h
+++ b/main/main.h
@@ -36,44 +36,48 @@
 #include "core/typedefs.h"
 
 class Main {
-	static void print_help(const char *p_binary);
-	static uint64_t last_ticks;
-	static uint32_t frames;
-	static uint32_t frame;
-	static bool force_redraw_requested;
-	static int iterating;
+	static Error load_project_settings();
+	static void load_default_project_settings();
+
+	static void initialize_core();
+	static Error initialize_servers();
+
+	static void load_boot_graphics();
+	static String localize_scene_path(const String &p_scene_path);
+	static void deinitialize_early(bool p_unregister_core = true);
 
 public:
+	static Error setup(const char *exec_path, int argc, char *argv[], bool p_finish_setup = true);
+	static Error finish_setup(Thread::ID p_main_tid_override = 0);
+	static bool start();
+
+	static bool iteration();
+
+	static void force_redraw();
+
+	static void cleanup(bool p_force = false);
+
+	static bool is_iterating();
 	static bool is_project_manager();
-	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
-	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
-	static Error setup2(Thread::ID p_main_tid_override = 0);
+
+	static int test_entrypoint(int argc, char *argv[], bool &finished);
 #ifdef TESTS_ENABLED
 	static Error test_setup();
 	static void test_cleanup();
 #endif
-	static bool start();
-
-	static bool iteration();
-	static void force_redraw();
-
-	static bool is_iterating();
-
-	static void cleanup(bool p_force = false);
 };
 
-// Test main override is for the testing behaviour.
 #define TEST_MAIN_OVERRIDE                                         \
-	bool run_test = false;                                         \
-	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
+	bool finished = false;                                         \
+	int return_code = Main::test_entrypoint(argc, argv, finished); \
+	if (finished) {                                                \
 		return return_code;                                        \
 	}
 
 #define TEST_MAIN_PARAM_OVERRIDE(argc, argv)                       \
-	bool run_test = false;                                         \
-	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
+	bool finished = false;                                         \
+	int return_code = Main::test_entrypoint(argc, argv, finished); \
+	if (finished) {                                                \
 		return return_code;                                        \
 	}
 

--- a/main/standalone_tools.cpp
+++ b/main/standalone_tools.cpp
@@ -1,0 +1,108 @@
+/*************************************************************************/
+/*  standalone_tools.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "standalone_tools.h"
+
+#ifdef TOOLS_ENABLED
+#include "core/config/engine.h"
+#include "core/config/project_settings.h"
+#include "core/os/dir_access.h"
+
+#include "editor/doc_data_class_path.gen.h"
+#include "editor/doc_tools.h"
+
+void run_doc_tool(const String &p_doc_tool_path, bool p_doc_base_types) {
+	// Needed to instance editor-only classes for their default values
+	Engine::get_singleton()->set_editor_hint(true);
+
+#ifndef MODULE_MONO_ENABLED
+	// Hack to define Mono-specific project settings even on non-Mono builds,
+	// so that we don't lose their descriptions and default values in DocData.
+	// Default values should be synced with mono_gd/gd_mono.cpp.
+	GLOBAL_DEF("mono/debugger_agent/port", 23685);
+	GLOBAL_DEF("mono/debugger_agent/wait_for_debugger", false);
+	GLOBAL_DEF("mono/debugger_agent/wait_timeout", 3000);
+	GLOBAL_DEF("mono/profiler/args", "log:calls,alloc,sample,output=output.mlpd");
+	GLOBAL_DEF("mono/profiler/enabled", false);
+	GLOBAL_DEF("mono/unhandled_exception_policy", 0);
+	// From editor/csharp_project.cpp.
+	GLOBAL_DEF("mono/project/auto_update_project", true);
+#endif
+
+	DocTools doc;
+	doc.generate(p_doc_base_types);
+
+	DocTools docsrc;
+	Map<String, String> doc_data_classes;
+	Set<String> checked_paths;
+
+	print_line("Loading docs...");
+	for (int i = 0; i < _doc_data_class_path_count; i++) {
+		// Custom modules are always located by absolute path.
+		String path = _doc_data_class_paths[i].path;
+		if (path.is_rel_path()) {
+			path = p_doc_tool_path.plus_file(path);
+		}
+		String name = _doc_data_class_paths[i].name;
+		doc_data_classes[name] = path;
+		if (!checked_paths.has(path)) {
+			checked_paths.insert(path);
+
+			// Create the module documentation directory if it doesn't exist
+			DirAccess *da = DirAccess::create_for_path(path);
+			da->make_dir_recursive(path);
+			memdelete(da);
+
+			docsrc.load_classes(path);
+			print_line("Loading docs from: " + path);
+		}
+	}
+
+	String index_path = p_doc_tool_path.plus_file("doc/classes");
+	// Create the main documentation directory if it doesn't exist
+	DirAccess *da = DirAccess::create_for_path(index_path);
+	da->make_dir_recursive(index_path);
+	memdelete(da);
+
+	docsrc.load_classes(index_path);
+	checked_paths.insert(index_path);
+	print_line("Loading docs from: " + index_path);
+
+	print_line("Merging docs...");
+	doc.merge_from(docsrc);
+	for (Set<String>::Element *E = checked_paths.front(); E; E = E->next()) {
+		print_line("Erasing old docs at: " + E->get());
+		DocTools::erase_classes(E->get());
+	}
+
+	print_line("Generating new docs...");
+	doc.save_classes(index_path, doc_data_classes);
+}
+#endif // TOOLS_ENABLED

--- a/main/standalone_tools.h
+++ b/main/standalone_tools.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  godot_view_renderer.mm                                               */
+/*  standalone_tools.h                                                   */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,90 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#import "godot_view_renderer.h"
-#include "core/config/project_settings.h"
-#include "core/os/keyboard.h"
-#import "display_server_iphone.h"
-#include "main/main.h"
-#include "os_iphone.h"
-#include "servers/audio_server.h"
+#ifndef STANDALONE_TOOLS_H
+#define STANDALONE_TOOLS_H
 
-#import <AudioToolbox/AudioServices.h>
-#import <CoreMotion/CoreMotion.h>
-#import <GameController/GameController.h>
-#import <QuartzCore/QuartzCore.h>
-#import <UIKit/UIKit.h>
+#include "core/string/ustring.h"
 
-@interface GodotViewRenderer ()
+#ifdef TOOLS_ENABLED
+void run_doc_tool(const String &p_doc_tool_path, bool p_doc_base_types);
+#endif // TOOLS_ENABLED
 
-@property(assign, nonatomic) BOOL hasFinishedProjectDataSetup;
-@property(assign, nonatomic) BOOL hasStartedMain;
-@property(assign, nonatomic) BOOL hasFinishedSetup;
-
-@end
-
-@implementation GodotViewRenderer
-
-- (BOOL)setupView:(UIView *)view {
-	if (self.hasFinishedSetup) {
-		return NO;
-	}
-
-	if (!OS::get_singleton()) {
-		exit(0);
-	}
-
-	if (!self.hasFinishedProjectDataSetup) {
-		[self setupProjectData];
-		return YES;
-	}
-
-	if (!self.hasStartedMain) {
-		self.hasStartedMain = YES;
-		OSIPhone::get_singleton()->start();
-		return YES;
-	}
-
-	self.hasFinishedSetup = YES;
-
-	return NO;
-}
-
-- (void)setupProjectData {
-	self.hasFinishedProjectDataSetup = YES;
-
-	Main::finish_setup();
-
-	// this might be necessary before here
-	NSDictionary *dict = [[NSBundle mainBundle] infoDictionary];
-	for (NSString *key in dict) {
-		NSObject *value = [dict objectForKey:key];
-		String ukey = String::utf8([key UTF8String]);
-
-		// we need a NSObject to Variant conversor
-
-		if ([value isKindOfClass:[NSString class]]) {
-			NSString *str = (NSString *)value;
-			String uval = String::utf8([str UTF8String]);
-
-			ProjectSettings::get_singleton()->set("Info.plist/" + ukey, uval);
-
-		} else if ([value isKindOfClass:[NSNumber class]]) {
-			NSNumber *n = (NSNumber *)value;
-			double dval = [n doubleValue];
-
-			ProjectSettings::get_singleton()->set("Info.plist/" + ukey, dval);
-		};
-		// do stuff
-	}
-}
-
-- (void)renderOnView:(UIView *)view {
-	if (!OSIPhone::get_singleton()) {
-		return;
-	}
-
-	OSIPhone::get_singleton()->iterate();
-}
-
-@end
+#endif // STANDALONE_TOOLS_H

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -211,7 +211,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jcl
 	if (step == 0) {
 		// Since Godot is initialized on the UI thread, main_thread_id was set to that thread's id,
 		// but for Godot purposes, the main thread is the one running the game loop
-		Main::setup2(Thread::get_caller_id());
+		Main::finish_setup(Thread::get_caller_id());
 		++step;
 		return;
 	}

--- a/platform/uwp/app.cpp
+++ b/platform/uwp/app.cpp
@@ -142,7 +142,7 @@ void App::SetWindow(CoreWindow ^ p_window) {
 
 	UpdateWindowSize(Size(window->Bounds.Width, window->Bounds.Height));
 
-	Main::setup2();
+	Main::finish_setup();
 }
 
 static int _get_button(Windows::UI::Input::PointerPoint ^ pt) {

--- a/tests/test_application_configuration.h
+++ b/tests/test_application_configuration.h
@@ -1,0 +1,884 @@
+/*************************************************************************/
+/*  test_application_configuration.h                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_APPLICATION_CONFIGURATION_H
+#define TEST_APPLICATION_CONFIGURATION_H
+
+#include "core/config/project_settings.h"
+#include "core/error/error_list.h"
+#include "main/application_configuration.h"
+
+#include "tests/test_macros.h"
+#include "thirdparty/doctest/doctest.h"
+
+namespace TestApplicationConfiguration {
+
+// Converts arguments to char ** and parses the arguments.
+#define PARSE_CONFIG()                                             \
+	char **argv = new char *[args.size()];                         \
+	const int n = args.size();                                     \
+                                                                   \
+	for (int i = 0; i < n; i++) {                                  \
+		const char *str = args[i].utf8().get_data();               \
+		argv[i] = new char[strlen(str) + 1];                       \
+		memcpy(argv[i], str, strlen(str) + 1);                     \
+	}                                                              \
+                                                                   \
+	ApplicationConfiguration configuration;                        \
+	Error error = parse_configuration("", n, argv, configuration); \
+                                                                   \
+	for (int i = 0; i < n; i++) {                                  \
+		delete[] argv[i];                                          \
+	}                                                              \
+	delete[] argv;
+
+TEST_SUITE("[ApplicationConfiguration] Parsing") {
+	TEST_CASE("[ApplicationConfiguration] project.godot or scene file." * doctest::description("Test desc.")) {
+		SUBCASE("Empty argv should return OK.") {
+			ApplicationConfiguration configuration;
+			Error error = parse_configuration("", 0, {}, configuration);
+
+			CHECK(error == OK);
+			CHECK(configuration.project_path == ".");
+			CHECK(configuration.application_type == ApplicationType::PROJECT);
+		}
+
+		SUBCASE("Project file should open editor.") {
+			Vector<String> args;
+			args.push_back("./project.godot");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.application_type == ApplicationType::EDITOR);
+		}
+
+		SUBCASE(".scn should be recognized as a scene file.") {
+			Vector<String> args;
+			args.push_back("path/to/scene.scn");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.scene_path == "path/to/scene.scn");
+			CHECK(configuration.application_type == ApplicationType::PROJECT);
+		}
+
+		SUBCASE(".tscn should be recognized as a scene file.") {
+			Vector<String> args;
+			args.push_back("path/to/scene.tscn");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.scene_path == "path/to/scene.tscn");
+			CHECK(configuration.application_type == ApplicationType::PROJECT);
+		}
+
+		SUBCASE(".escn should be recognized as a scene file.") {
+			Vector<String> args;
+			args.push_back("path/to/scene.escn");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.scene_path == "path/to/scene.escn");
+			CHECK(configuration.application_type == ApplicationType::PROJECT);
+		}
+
+		SUBCASE(".res should be recognized as a scene file.") {
+			Vector<String> args;
+			args.push_back("path/to/scene.res");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.scene_path == "path/to/scene.res");
+			CHECK(configuration.application_type == ApplicationType::PROJECT);
+		}
+
+		SUBCASE(".tres should be recognized as a scene file.") {
+			Vector<String> args;
+			args.push_back("path/to/scene.tres");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.scene_path == "path/to/scene.tres");
+			CHECK(configuration.application_type == ApplicationType::PROJECT);
+		}
+	}
+
+	TEST_CASE("[ApplicationConfiguration] Export") {
+		ERR_PRINT_OFF;
+
+		SUBCASE("Regular export") {
+			Vector<String> args;
+			args.push_back("--export");
+			args.push_back("W");
+			args.push_back("builds/project.exe");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.export_config.preset == args[1]);
+			CHECK(configuration.export_config.path == args[2]);
+			CHECK(configuration.export_config.debug_build == false);
+			CHECK(configuration.export_config.pack_only == false);
+		}
+
+		SUBCASE("Debug export set correct config.") {
+			Vector<String> args;
+			args.push_back("--export");
+			args.push_back("W");
+			args.push_back("builds/project.exe");
+			args.push_back("--export-debug");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.export_config.preset == args[1]);
+			CHECK(configuration.export_config.path == args[2]);
+			CHECK(configuration.export_config.debug_build == true);
+			CHECK(configuration.export_config.pack_only == false);
+		}
+
+		SUBCASE("Pack export should set correct config.") {
+			Vector<String> args;
+			args.push_back("--export");
+			args.push_back("W");
+			args.push_back("builds/project.pck");
+			args.push_back("--export-pack");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.export_config.preset == args[1]);
+			CHECK(configuration.export_config.path == args[2]);
+			CHECK(configuration.export_config.debug_build == false);
+			CHECK(configuration.export_config.pack_only == true);
+		}
+
+		SUBCASE("Combined export options should set correct config.") {
+			Vector<String> args;
+			args.push_back("--export");
+			args.push_back("W");
+			args.push_back("builds/project.exe");
+			args.push_back("--export-debug");
+			args.push_back("--export-pack");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.export_config.preset == args[1]);
+			CHECK(configuration.export_config.path == args[2]);
+			CHECK(configuration.export_config.debug_build == true);
+			CHECK(configuration.export_config.pack_only == true);
+		}
+
+		SUBCASE("Combined export options should set correct config, independent of order.") {
+			Vector<String> args;
+			args.push_back("--export");
+			args.push_back("W");
+			args.push_back("builds/project.exe");
+			args.push_back("--export-pack");
+			args.push_back("--export-debug");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.export_config.preset == args[1]);
+			CHECK(configuration.export_config.path == args[2]);
+			CHECK(configuration.export_config.debug_build == true);
+			CHECK(configuration.export_config.pack_only == true);
+		}
+
+		SUBCASE("Export without path should fail.") {
+			Vector<String> args;
+			args.push_back("--export");
+			args.push_back("W");
+
+			PARSE_CONFIG();
+
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+
+		SUBCASE("Export without preset or path should fail.") {
+			Vector<String> args;
+			args.push_back("--export");
+
+			PARSE_CONFIG();
+
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+
+		SUBCASE("Export should not treat next argument as parameters.") {
+			Vector<String> args;
+			args.push_back("--export");
+			args.push_back("--verbose");
+			args.push_back("-q");
+
+			PARSE_CONFIG();
+
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+
+		ERR_PRINT_ON;
+	}
+
+	TEST_CASE("[ApplicationConfiguration] Script") {
+		ERR_PRINT_OFF;
+
+		SUBCASE("Script with regular argument.") {
+			Vector<String> args;
+			args.push_back("--script");
+			args.push_back("path/to/script.gd");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.application_type == ApplicationType::SCRIPT);
+			CHECK(configuration.script_path == args[1]);
+			CHECK(configuration.run_tool == false);
+		}
+
+		SUBCASE("Script shortcut argument.") {
+			Vector<String> args;
+			args.push_back("-s");
+			args.push_back("path/to/script.gd");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.application_type == ApplicationType::SCRIPT);
+			CHECK(configuration.script_path == args[1]);
+			CHECK(configuration.run_tool == false);
+		}
+
+		SUBCASE("Script with check-only.") {
+			Vector<String> args;
+			args.push_back("--script");
+			args.push_back("path/to/script.gd");
+			args.push_back("--check-only");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.run_tool == true);
+			CHECK(configuration.selected_tool == StandaloneTool::VALIDATE_SCRIPT);
+			CHECK(configuration.script_path == args[1]);
+		}
+
+		ERR_PRINT_ON;
+	}
+
+	TEST_CASE("[ApplicationConfiguration] DocTool.") {
+		SUBCASE("Doctool without parameters.") {
+			Vector<String> args;
+			args.push_back("--doctool");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.doc_tool_path == ".");
+			CHECK(configuration.doc_base_types == true);
+		}
+
+		SUBCASE("Doctool with regular parameters.") {
+			Vector<String> args;
+			args.push_back("--doctool");
+			args.push_back("path/to/somewhere");
+			args.push_back("--no-docbase");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.doc_tool_path == args[1]);
+			CHECK(configuration.doc_base_types == false);
+		}
+
+		SUBCASE("Doctool without path.") {
+			Vector<String> args;
+			args.push_back("--doctool");
+			args.push_back("--no-docbase");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.doc_tool_path == ".");
+			CHECK(configuration.doc_base_types == false);
+		}
+
+		SUBCASE("Doctool without options.") {
+			Vector<String> args;
+			args.push_back("--doctool");
+			args.push_back(".");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.doc_tool_path == args[1]);
+			CHECK(configuration.doc_base_types == true);
+		}
+	}
+
+	TEST_CASE("[ApplicationConfiguration] Remote file system.") {
+		SUBCASE("Remote file sytem with port should extract address and port.") {
+			Vector<String> args;
+			args.push_back("--remote-fs");
+			args.push_back("localhost:8000");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.remote_filesystem_address == "localhost");
+			CHECK(configuration.remote_filesystem_port == 8000);
+		}
+
+		SUBCASE("Remote file sytem without port should assign default port.") {
+			Vector<String> args;
+			args.push_back("--remote-fs");
+			args.push_back("localhost");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.remote_filesystem_address == "localhost");
+			CHECK(configuration.remote_filesystem_port == 6010);
+		}
+
+		SUBCASE("Remote file sytem password.") {
+			Vector<String> args;
+			args.push_back("--remote-fs-password");
+			args.push_back("secret");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.remote_filesystem_password == args[1]);
+		}
+	}
+
+	TEST_CASE("[ApplicationConfiguration] Position") {
+		SUBCASE("Should set valid window position.") {
+			Vector<String> args;
+			args.push_back("--position");
+			args.push_back("199,188");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.window_position == Point2i(199, 188));
+		}
+
+		SUBCASE("Should fail with invalid window position format.") {
+			Vector<String> args;
+			args.push_back("--position");
+			args.push_back("199x188");
+
+			ERR_PRINT_OFF;
+			PARSE_CONFIG();
+			ERR_PRINT_ON;
+
+			// Assert
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+
+		SUBCASE("Should fail with invalid window position format.") {
+			Vector<String> args;
+			args.push_back("--position");
+			args.push_back("199");
+
+			ERR_PRINT_OFF;
+			PARSE_CONFIG();
+			ERR_PRINT_ON;
+
+			// Assert
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+	}
+
+	TEST_CASE("[ApplicationConfiguration] Resolution") {
+		SUBCASE("Should set valid window size.") {
+			Vector<String> args;
+			args.push_back("--resolution");
+			args.push_back("188x188");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.window_size == Size2i(188, 188));
+		}
+
+		SUBCASE("Should fail with invalid window position format.") {
+			Vector<String> args;
+			args.push_back("--resolution");
+			args.push_back("188,188");
+
+			ERR_PRINT_OFF;
+			PARSE_CONFIG();
+			ERR_PRINT_ON;
+
+			// Assert
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+
+		SUBCASE("Should fail with invalid window height.") {
+			Vector<String> args;
+			args.push_back("--resolution");
+			args.push_back("188,-188");
+
+			ERR_PRINT_OFF;
+			PARSE_CONFIG();
+			ERR_PRINT_ON;
+
+			// Assert
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+
+		SUBCASE("Should fail with invalid window width.") {
+			Vector<String> args;
+			args.push_back("--resolution");
+			args.push_back("0,188");
+
+			ERR_PRINT_OFF;
+			PARSE_CONFIG();
+			ERR_PRINT_ON;
+
+			// Assert
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+	}
+
+	TEST_CASE("[ApplicationConfiguration] Render thread.") {
+		SUBCASE("No parameter") {
+			Vector<String> args;
+			args.push_back("--render-thread");
+
+			ERR_PRINT_OFF;
+			PARSE_CONFIG();
+			ERR_PRINT_ON;
+
+			// Assert
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+
+		SUBCASE("Safe") {
+			Vector<String> args;
+			args.push_back("--render-thread");
+			args.push_back("safe");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.render_thread_mode == OS::RENDER_THREAD_SAFE);
+		}
+
+		SUBCASE("Unsafe") {
+			Vector<String> args;
+			args.push_back("--render-thread");
+			args.push_back("unsafe");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.render_thread_mode == OS::RENDER_THREAD_UNSAFE);
+		}
+
+		SUBCASE("Separate") {
+			Vector<String> args;
+			args.push_back("--render-thread");
+			args.push_back("separate");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.render_thread_mode == OS::RENDER_SEPARATE_THREAD);
+		}
+
+		SUBCASE("Incorrect parameter") {
+			Vector<String> args;
+			args.push_back("--render-thread");
+			args.push_back("somethingelse");
+
+			ERR_PRINT_OFF;
+			PARSE_CONFIG();
+			ERR_PRINT_ON;
+
+			CHECK(error == ERR_INVALID_PARAMETER);
+		}
+	}
+
+	TEST_CASE("[ApplicationConfiguration] Individual flags.") {
+		SUBCASE("Start project manager.") {
+			Vector<String> args;
+			args.push_back("--project-manager");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.application_type == ApplicationType::PROJECT_MANAGER);
+		}
+
+		SUBCASE("Start project manager. (shorthand)") {
+			Vector<String> args;
+			args.push_back("-p");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.application_type == ApplicationType::PROJECT_MANAGER);
+		}
+
+		SUBCASE("Start editor.") {
+			Vector<String> args;
+			args.push_back("--editor");
+
+			PARSE_CONFIG();
+
+			// Assert
+			CHECK(error == OK);
+			CHECK(configuration.application_type == ApplicationType::EDITOR);
+		}
+
+		SUBCASE("Start editor. (shorthand)") {
+			Vector<String> args;
+			args.push_back("-e");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.application_type == ApplicationType::EDITOR);
+		}
+
+		SUBCASE("Enable verbose printing.") {
+			Vector<String> args;
+			args.push_back("--verbose");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.output_verbosity == OutputVerbosity::VERBOSE);
+		}
+
+		SUBCASE("Enable verbose printing. (shorthand)") {
+			Vector<String> args;
+			args.push_back("-v");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.output_verbosity == OutputVerbosity::VERBOSE);
+		}
+
+		SUBCASE("Disable printing.") {
+			Vector<String> args;
+			args.push_back("--quiet");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.output_verbosity == OutputVerbosity::QUIET);
+		}
+
+		SUBCASE("Enable scanning folders upwards.") {
+			Vector<String> args;
+			args.push_back("--upwards");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.scan_folders_upwards);
+		}
+
+		SUBCASE("Enable profiler.") {
+			Vector<String> args;
+			args.push_back("--profiling");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.enable_debug_profiler);
+		}
+
+		SUBCASE("Enable GPU profiler.") {
+			Vector<String> args;
+			args.push_back("--profile-gpu");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.enable_gpu_profiler);
+		}
+
+		SUBCASE("Enable Vulkan validation layers.") {
+			Vector<String> args;
+			args.push_back("--vk-layers");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.use_validation_layers);
+		}
+
+		SUBCASE("Disable crash handler.") {
+			Vector<String> args;
+			args.push_back("--disable-crash-handler");
+
+			PARSE_CONFIG();
+
+			CHECK(error == OK);
+			CHECK(configuration.disable_crash_handler);
+		}
+	}
+}
+
+TEST_SUITE("[ApplicationConfiguration] Finalize") {
+	TEST_CASE("[ApplicationConfiguration] Finalize Project") {
+		ERR_PRINT_OFF;
+
+		ApplicationConfiguration configuration;
+		configuration.application_type = ApplicationType::PROJECT;
+
+		SUBCASE("Window size") {
+			ProjectSettings::get_singleton()->set("display/window/size/test_width", 700);
+			ProjectSettings::get_singleton()->set("display/window/size/test_height", 700);
+			ProjectSettings::get_singleton()->set("display/window/size/width", 900);
+			ProjectSettings::get_singleton()->set("display/window/size/height", 900);
+			ProjectSettings::get_singleton()->set("application/run/main_scene", "prevent_fail.scn");
+
+			SUBCASE("Requested window size should not be overridden.") {
+				// Arrange
+				const Size2i requested_size = Size2i(100, 100);
+				configuration.window_size = requested_size;
+				configuration.forced_window_size = true;
+
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.window_size == requested_size);
+			}
+
+			SUBCASE("Window size should be set to test size if possible.") {
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.window_size == Size2i(700, 700));
+			}
+
+			SUBCASE("Window size should be set to regular size if test size is unavailable.") {
+				// Arrange
+				ProjectSettings::get_singleton()->set("display/window/size/test_width", 0);
+				ProjectSettings::get_singleton()->set("display/window/size/test_height", 0);
+
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.window_size == Size2i(900, 900));
+			}
+		}
+
+		SUBCASE("Window flags") {
+			ProjectSettings::get_singleton()->set("display/window/size/resizable", true);
+			ProjectSettings::get_singleton()->set("display/window/size/borderless", false);
+			ProjectSettings::get_singleton()->set("display/window/size/always_on_top", false);
+			ProjectSettings::get_singleton()->set("display/window/size/fullscreen", false);
+
+			SUBCASE("Should not set any window flags if not configured.") {
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.window_flags == 0);
+				CHECK(configuration.window_mode == DisplayServer::WINDOW_MODE_WINDOWED);
+			}
+
+			SUBCASE("Should set resizable window flag.") {
+				// Arrange
+				ProjectSettings::get_singleton()->set("display/window/size/resizable", false);
+
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.window_flags == DisplayServer::WINDOW_FLAG_RESIZE_DISABLED_BIT);
+			}
+
+			SUBCASE("Should set borderless window flag.") {
+				// Arrange
+				ProjectSettings::get_singleton()->set("display/window/size/borderless", true);
+
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.window_flags == DisplayServer::WINDOW_FLAG_BORDERLESS_BIT);
+			}
+
+			SUBCASE("Should set always_on_top window flag.") {
+				// Arrange
+				ProjectSettings::get_singleton()->set("display/window/size/always_on_top", true);
+
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.window_flags == DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP_BIT);
+			}
+
+			SUBCASE("Should set fullscreen window flag.") {
+				// Arrange
+				ProjectSettings::get_singleton()->set("display/window/size/fullscreen", true);
+
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.window_mode == DisplayServer::WINDOW_MODE_FULLSCREEN);
+			}
+		}
+
+		SUBCASE("Scene") {
+			ProjectSettings::get_singleton()->set("application/run/main_scene", "the_scene.scn");
+
+			SUBCASE("Should load requested scene.") {
+				// Arrange
+				const String the_other_scene = "the_other_scene.tscn";
+				configuration.scene_path = the_other_scene;
+
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.scene_path == the_other_scene);
+			}
+
+			SUBCASE("Should load project main scene if no scene requested.") {
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == OK);
+				CHECK(configuration.scene_path == "the_scene.scn");
+			}
+
+			SUBCASE("Should load project main scene if no scene requested.") {
+				// Arrange
+				ProjectSettings::get_singleton()->set("application/run/main_scene", "");
+
+				// Act
+				Error error = finalize_configuration(configuration);
+
+				// Assert
+				CHECK(error == ERR_INVALID_PARAMETER);
+			}
+		}
+
+		ERR_PRINT_ON;
+	}
+
+	TEST_CASE("[ApplicationConfiguration] Finalize Project Manager") {
+		ERR_PRINT_OFF;
+
+		ApplicationConfiguration configuration;
+		configuration.application_type = ApplicationType::PROJECT_MANAGER;
+
+		SUBCASE("Window size should be set to requested size.") {
+			// Arrange
+			const Size2i requested_size = Size2i(1000, 1000);
+			configuration.window_size = requested_size;
+
+			// Act
+			Error error = finalize_configuration(configuration);
+
+			// Assert
+			CHECK(error == OK);
+			CHECK(configuration.window_size == requested_size);
+		}
+
+		SUBCASE("Window size should be set to default if not requested.") {
+			// Act
+			Error error = finalize_configuration(configuration);
+
+			// Assert
+			CHECK(error == OK);
+			CHECK(configuration.window_size == Size2i(1024, 600));
+		}
+
+		ERR_PRINT_ON;
+	}
+
+	TEST_CASE("[ApplicationConfiguration] Finalize Editor") {
+		ERR_PRINT_OFF;
+
+		ApplicationConfiguration configuration;
+		configuration.application_type = ApplicationType::EDITOR;
+
+		SUBCASE("Should not set window mode to maximized if requested.") {
+			// Arrange
+			configuration.window_mode = DisplayServer::WINDOW_MODE_FULLSCREEN;
+			configuration.forced_window_mode = true;
+
+			// Act
+			Error error = finalize_configuration(configuration);
+
+			// Assert
+			CHECK(error == OK);
+			CHECK(configuration.window_mode == DisplayServer::WINDOW_MODE_FULLSCREEN);
+		}
+
+		SUBCASE("Should set window mode to maximized by default.") {
+			// Act
+			Error error = finalize_configuration(configuration);
+
+			// Assert
+			CHECK(error == OK);
+			CHECK(configuration.window_mode == DisplayServer::WINDOW_MODE_MAXIMIZED);
+		}
+
+		ERR_PRINT_ON;
+	}
+}
+
+} // namespace TestApplicationConfiguration
+
+#endif // TEST_APPLICATION_CONFIGURATION_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -33,6 +33,7 @@
 #include "core/templates/list.h"
 
 #include "test_aabb.h"
+#include "test_application_configuration.h"
 #include "test_array.h"
 #include "test_astar.h"
 #include "test_basis.h"


### PR DESCRIPTION
This PR refactors the setup code in main.cpp. When looking to contribute to a project, I always start with the program entrypoint. I think main.cpp being a bit of a mess sets off a lot of new contributors. It's easy to get lost in chunks of code with overlapping logic and the dependencies between various singletons isn't conveyed very well. I hope this makes it easier for new users to understand the engine.

Because things were so tangled up, it wasn't easy to isolate a specific part and just refactor that. So in the end, most of the setup code has been refactored, but only a few intentional changes have been introduced. That increases the chance of a regression, so it should obviously be tested in as many ways as possible.

## Main goals

The PR mostly restructures and groups code in a way that makes it easier to understand program flow and dependencies between certain classes. I think the code should speak for itself, but a short explanation might help with reviewing, and if we at least agree on these principles, it makes it easier to discuss the implementation.

### Separating distinct phases.
While the interface of main was easy to understand, under the hood all kinds of things were blended together. I have tried to separate the code in Main into the following stages:

1. Parsing command line
2. Loading project settings
3. Finalizing the configuration
4. Initialization
5. Starting (running tool or creating main loop)
6. Iteration (no changes)

### Clear setup based on application type.
To me, I felt that it's important to understand what kind of application we want to run (project, script, editor, project manager, a tool) to understandi the whole initialization process. Currently, it's not clear until the very last moment. It also seems like most code assumes that we are running the editor or project manager, while running a project is somewhat of an afterthought. I have made the application type explicit and it is specified as early as possible.

Important here is the ApplicationConfiguration, which holds most of the variables for initializing singletons. It first gets initialized in step 1. Then, after loading project settings, it is manually adjusted in step 3, after which it doesn't have to change anymore. That leaves us with an invariant configuration for the rest of the program, which makes the code much simpler to understand. Not much has fundamentally changed to step 4 (initialization), because I don't have enough knowledge of this part. Step 6 has not changed at all.

#### Intentional changes
In the CLI, there were a few arguments that only had meaning in combination with other arguments. They have been changed so that they are optional parameters to those arguments.
- `--export-debug`, `--export-pack` are no longer separate commands. Instead you use `--export <preset> <path> [option]`, where option can be `--export-debug` or `--export-pack`. Options can be combined in any order.
- `--no-docbase` is no longer a separate command. Instead you use `--doc-tool <path> --no-docbase`.
- `--check-only` is no longer a separate command. Instead you use `--script <path> --check-only`.

EditorSettings is now created in main.cpp instead of duplicated in Editor and PM.

#### A few open questions
- Default project settings are now grouped in a method, but maybe they should be moved to corresponding singletons/servers.
- Personally, I don't like the conditional automatic chaining between setup and  finish_setup(setup2). I think it would be better to force every platform to call both methods, but I don't know if that is a good solution.
- Display driver project setting defaults to Vulkan, but isn't that supposed to be the rendering driver? It currently always fails and defaults to something else.

#### Things that are not in this PR, but could be looked into in the future:
- Tools each require a different amount of initialisation. At the moment the engine is fully initialised regardless of which tool you run. This also means a window is created by default. We could set no-window flag, but that seems to be broken on master at the moment. Maybe it should default to headless?
- Exporting through CLI still requires the editor node. Just like other tools, it should run without creating a main loop.
- There are some leftover methods (e.g. is_project_manager) that could be refactored/relocated.
- Currently, physics, navigation etc. is initialized and running when running the Project Manager.