### PR TITLE
Fixed color for node headers in visual scripts

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -739,6 +739,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			}
 
 			Color c = sbf->get_border_color();
+			c = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0, 0.85) : Color(0.0, 0.0, 0.0, 0.85);
 			Color ic = c;
 			gnode->add_theme_color_override("title_color", c);
 			c.a = 1;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3036176/120935150-0b699000-c70a-11eb-916e-c282e87b0b7c.png)

After:
![image](https://user-images.githubusercontent.com/3036176/120935155-115f7100-c70a-11eb-85b8-fe5d4fabe666.png)

Fix #49103