### PR TITLE
Remove an unreachable string from the "Open Scene" popup.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2367,7 +2367,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			if (scene) {
 				file->set_current_path(scene->get_filename());
 			};
-			file->set_title(p_option == FILE_OPEN_SCENE ? TTR("Open Scene") : TTR("Open Base Scene"));
+			file->set_title(TTR("Open Scene"));
 			file->popup_file_dialog();
 
 		} break;


### PR DESCRIPTION
Apparently there was a ternary operator which never returned its "else" part ("Open Base Scene"):
https://github.com/godotengine/godot/blob/master/editor/editor_node.cpp#L2370

This PR just removes it. If it was actually needed feel free to close it.