### PR TITLE
Make nodes with popups consider camera

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1308,6 +1308,8 @@ void ColorPickerButton::_modal_closed() {
 void ColorPickerButton::pressed() {
 	_update_picker();
 
+	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
+
 	popup->set_as_minsize();
 	picker->_update_presets();
 
@@ -1319,13 +1321,13 @@ void ColorPickerButton::pressed() {
 		if (i > 1) {
 			cp_rect.position.y = get_screen_position().y - cp_rect.size.y;
 		} else {
-			cp_rect.position.y = get_screen_position().y + get_size().height;
+			cp_rect.position.y = get_screen_position().y + size.height;
 		}
 
 		if (i & 1) {
 			cp_rect.position.x = get_screen_position().x;
 		} else {
-			cp_rect.position.x = get_screen_position().x - MAX(0, (cp_rect.size.x - get_size().x));
+			cp_rect.position.x = get_screen_position().x - MAX(0, (cp_rect.size.x - size.x));
 		}
 
 		if (usable_rect.encloses(cp_rect)) {

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -87,15 +87,15 @@ void MenuButton::_popup_visibility_changed(bool p_visible) {
 
 void MenuButton::pressed() {
 	emit_signal(SNAME("about_to_popup"));
-	Size2 size = get_size();
+	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
 
 	Point2 gp = get_screen_position();
-	gp.y += get_size().y;
+	gp.y += size.y;
 
 	popup->set_position(gp);
 
 	popup->set_size(Size2(size.width, 0));
-	popup->set_parent_rect(Rect2(Point2(gp - popup->get_position()), get_size()));
+	popup->set_parent_rect(Rect2(Point2(gp - popup->get_position()), size));
 	popup->take_mouse_focus();
 	popup->popup();
 }

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -115,7 +115,7 @@ void OptionButton::_selected(int p_which) {
 }
 
 void OptionButton::pressed() {
-	Size2 size = get_size();
+	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
 	popup->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
 	popup->set_size(Size2(size.width, 0));
 	popup->popup();


### PR DESCRIPTION
Fixes #48016.

The affected nodes I discovered: ColorPicker, MenuButton, OptionButton. 
If there are others, let me know I will update PR.

Project tested with: [FixTest.zip](https://github.com/godotengine/godot/files/6605192/FixTest.zip)

---
Pushed formatting changes to make CI happy
Pushed to update commit email
