### PR TITLE
Readd support for kerning in DynamicFont (3.x)

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -236,6 +236,18 @@ const Pair<const DynamicFontAtSize::Character *, DynamicFontAtSize *> DynamicFon
 	return Pair<const Character *, DynamicFontAtSize *>(chr, const_cast<DynamicFontAtSize *>(this));
 }
 
+float DynamicFontAtSize::_get_kerning_advance(const DynamicFontAtSize *font, CharType p_char, CharType p_next) const {
+	float advance = 0.0;
+
+	if (p_next) {
+		FT_Vector delta;
+		FT_Get_Kerning(font->face, FT_Get_Char_Index(font->face, p_char), FT_Get_Char_Index(font->face, p_next), FT_KERNING_DEFAULT, &delta);
+		advance = (delta.x / 64.0) / oversampling;
+	}
+
+	return advance;
+}
+
 Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks) const {
 	if (!valid) {
 		return Size2(1, 1);
@@ -244,6 +256,7 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 
 	Pair<const Character *, DynamicFontAtSize *> char_pair_with_font = _find_char_with_font(p_char, p_fallbacks);
 	const Character *ch = char_pair_with_font.first;
+	DynamicFontAtSize *font = char_pair_with_font.second;
 	ERR_FAIL_COND_V(!ch, Size2());
 
 	Size2 ret(0, get_height());
@@ -251,6 +264,7 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 	if (ch->found) {
 		ret.x = ch->advance;
 	}
+	ret.x += _get_kerning_advance(font, p_char, p_next);
 
 	return ret;
 }
@@ -331,6 +345,8 @@ float DynamicFontAtSize::draw_char(RID p_canvas_item, const Point2 &p_pos, CharT
 
 		advance = ch->advance;
 	}
+
+	advance += _get_kerning_advance(font, p_char, p_next);
 
 	return advance;
 }

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -162,6 +162,7 @@ class DynamicFontAtSize : public Reference {
 
 	const Pair<const Character *, DynamicFontAtSize *> _find_char_with_font(CharType p_char, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks) const;
 	Character _make_outline_char(CharType p_char);
+	float _get_kerning_advance(const DynamicFontAtSize *font, CharType p_char, CharType p_next) const;
 	TexturePosition _find_texture_pos_for_glyph(int p_color_size, Image::Format p_image_format, int p_width, int p_height);
 	Character _bitmap_to_character(FT_Bitmap bitmap, int yofs, int xofs, float advance);
 


### PR DESCRIPTION
DynamicFont kerning was removed in a9b7843dca3ea3eda9f9f890a3e2c78542ca7561.

This readds kerning support and fixes it at the same time. I haven't tested thit yet, so give it a try with your own fonts :slightly_smiling_face:

This pull request targets the `3.x` branch since drawing code has changed in `master`, and kerning is likely fixed there as part of the TextServer work.

This closes https://github.com/godotengine/godot/issues/38731. cc @follower 