### PR TITLE
Fixed mistake in binding of Skeleton2D::execute_modifications

### DIFF
--- a/doc/classes/Skeleton2D.xml
+++ b/doc/classes/Skeleton2D.xml
@@ -13,7 +13,7 @@
 		<method name="execute_modifications">
 			<return type="void">
 			</return>
-			<argument index="0" name="execution_mode" type="float">
+			<argument index="0" name="delta" type="float">
 			</argument>
 			<argument index="1" name="execution_mode" type="int">
 			</argument>

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -787,7 +787,7 @@ void Skeleton2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_modification_stack", "modification_stack"), &Skeleton2D::set_modification_stack);
 	ClassDB::bind_method(D_METHOD("get_modification_stack"), &Skeleton2D::get_modification_stack);
-	ClassDB::bind_method(D_METHOD("execute_modifications", "execution_mode", "execution_mode"), &Skeleton2D::execute_modifications);
+	ClassDB::bind_method(D_METHOD("execute_modifications", "delta", "execution_mode"), &Skeleton2D::execute_modifications);
 
 	ClassDB::bind_method(D_METHOD("set_bone_local_pose_override", "bone_idx", "override_pose", "strength", "persistent"), &Skeleton2D::set_bone_local_pose_override);
 	ClassDB::bind_method(D_METHOD("get_bone_local_pose_override", "bone_idx"), &Skeleton2D::get_bone_local_pose_override);


### PR DESCRIPTION
Found this when testing stuff with GDNative and it not wanting to compile :)

Simple mistake in the binding of parameters