### PR TITLE
Update Gradle archiveName and destinationDir properties

### DIFF
--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -118,8 +118,8 @@ task zipCustomBuild(type: Zip) {
     }
     from(fileTree(dir: 'app', excludes: ['**/build/**', '**/.gradle/**', '**/*.iml']), fileTree(dir: '.', includes: ['gradle.properties', 'gradlew', 'gradlew.bat', 'gradle/**']))
     include '**/*'
-    archiveName 'android_source.zip'
-    destinationDir(file(binDir))
+    archiveFileName = 'android_source.zip'
+    destinationDirectory = file(binDir)
 }
 
 def templateExcludedBuildTask() {


### PR DESCRIPTION
Currently, when building Android templates, we're getting the following warnings:
```
The AbstractArchiveTask.archiveName property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveFileName property instead. See https://docs.gradle.org/6.5/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archiveName for more details.
	at build_cp9pwwzqebywqdu09u4k30tds$_run_closure9.doCall(/home/runner/work/godot/godot/platform/android/java/build.gradle:121)
	(Run with --stacktrace to get the full stack trace of this deprecation warning.)
The AbstractArchiveTask.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the destinationDirectory property instead. See https://docs.gradle.org/6.5/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:destinationDir for more details.
	at build_cp9pwwzqebywqdu09u4k30tds$_run_closure9.doCall(/home/runner/work/godot/godot/platform/android/java/build.gradle:122)
	(Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

This PR updates the properties as suggested.