### PR TITLE
Style: Cleanup uses of double spaces between words

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -889,7 +889,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			// Test for potential wrong values sent by the debugger when it breaks.
 			Object *obj = p_variant.get_validated_object();
 			if (!obj) {
-				// Object is invalid, send a nullptr  instead.
+				// Object is invalid, send a nullptr instead.
 				if (buf) {
 					encode_uint32(Variant::NIL, buf);
 				}

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -354,7 +354,7 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 
 	ThreadLoadTask &load_task = thread_load_tasks[local_path];
 
-	if (load_task.resource.is_null()) { //needs  to be loaded in thread
+	if (load_task.resource.is_null()) { //needs to be loaded in thread
 
 		load_task.semaphore = memnew(Semaphore);
 		if (thread_loading_count < thread_load_max) {

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -80,7 +80,6 @@ private:
 
 	Vector<Attribute> attributes;
 
-	String _replace_special_characters(const String &origstr);
 	bool _set_text(char *start, char *end);
 	void _parse_closing_xml_element();
 	void _ignore_definition();

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -112,7 +112,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 		}
 	}
 
-	//fourth vertex is the one  most further away from the plane
+	//fourth vertex is the one most further away from the plane
 
 	{
 		real_t maxd = 0;

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -291,7 +291,7 @@ public:
 	}
 
 	/**
-	 * Same as get, except it can return nullptr  when item was not found.
+	 * Same as get, except it can return nullptr when item was not found.
 	 * This is mainly used for speed purposes.
 	 */
 
@@ -324,7 +324,7 @@ public:
 	}
 
 	/**
-	 * Same as get, except it can return nullptr  when item was not found.
+	 * Same as get, except it can return nullptr when item was not found.
 	 * This version is custom, will take a hash and a custom key (that should support operator==()
 	 */
 
@@ -443,7 +443,7 @@ public:
 
 	/**
 	 * Get the next key to p_key, and the first key if p_key is null.
-	 * Returns a pointer to the next key if found, nullptr  otherwise.
+	 * Returns a pointer to the next key if found, nullptr otherwise.
 	 * Adding/Removing elements while iterating will, of course, have unexpected results, don't do it.
 	 *
 	 * Example:

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -231,7 +231,7 @@ public:
 	/**
 	 * returns true if the value was found, false otherwise.
 	 *
-	 * if r_data is not nullptr  then the value will be written to the object
+	 * if r_data is not nullptr then the value will be written to the object
 	 * it points to.
 	 */
 	bool lookup(const TKey &p_key, TValue &r_data) const {
@@ -249,7 +249,7 @@ public:
 	/**
 	 * returns true if the value was found, false otherwise.
 	 *
-	 * if r_data is not nullptr  then the value will be written to the object
+	 * if r_data is not nullptr then the value will be written to the object
 	 * it points to.
 	 */
 	TValue *lookup_ptr(const TKey &p_key) const {

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1055,7 +1055,7 @@
 			Anchors the right edge of the node to the origin, the center or the end of its parent control. It changes how the right offset updates when the node moves or changes size. You can use one of the [enum Anchor] constants for convenience.
 		</member>
 		<member name="anchor_top" type="float" setter="_set_anchor" getter="get_anchor" default="0.0">
-			Anchors the top edge of the node to the origin, the center or the end of its parent control. It changes how the top offset updates when the node moves or changes size. You can use  one of the [enum Anchor] constants for convenience.
+			Anchors the top edge of the node to the origin, the center or the end of its parent control. It changes how the top offset updates when the node moves or changes size. You can use one of the [enum Anchor] constants for convenience.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" enum="Control.FocusMode" default="0">
 			The focus access mode for the control (None, Click or All). Only one Control can be focused at the same time, and it will receive keyboard signals.
@@ -1067,7 +1067,7 @@
 			Tells Godot which node it should give keyboard focus to if the user presses the left arrow on the keyboard or left on a gamepad by default. You can change the key by editing the [code]ui_left[/code] input action. The node must be a [Control]. If this property is not set, Godot will give focus to the closest [Control] to the left of this one.
 		</member>
 		<member name="focus_neighbor_right" type="NodePath" setter="set_focus_neighbor" getter="get_focus_neighbor" default="NodePath(&quot;&quot;)">
-			Tells Godot which node it should give keyboard focus to if the user presses the right arrow on the keyboard or right on a gamepad  by default. You can change the key by editing the [code]ui_right[/code] input action. The node must be a [Control]. If this property is not set, Godot will give focus to the closest [Control] to the bottom of this one.
+			Tells Godot which node it should give keyboard focus to if the user presses the right arrow on the keyboard or right on a gamepad by default. You can change the key by editing the [code]ui_right[/code] input action. The node must be a [Control]. If this property is not set, Godot will give focus to the closest [Control] to the bottom of this one.
 		</member>
 		<member name="focus_neighbor_top" type="NodePath" setter="set_focus_neighbor" getter="get_focus_neighbor" default="NodePath(&quot;&quot;)">
 			Tells Godot which node it should give keyboard focus to if the user presses the top arrow on the keyboard or top on a gamepad by default. You can change the key by editing the [code]ui_top[/code] input action. The node must be a [Control]. If this property is not set, Godot will give focus to the closest [Control] to the bottom of this one.

--- a/doc/classes/EditorDebuggerPlugin.xml
+++ b/doc/classes/EditorDebuggerPlugin.xml
@@ -38,7 +38,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if there is an instance of  the game running with the attached debugger otherwise [code]false[/code].
+				Returns [code]true[/code] if there is an instance of the game running with the attached debugger otherwise [code]false[/code].
 			</description>
 		</method>
 		<method name="register_message_capture">

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -92,7 +92,7 @@
 		        return new Godot.Collections.Array{new Godot.Collections.Dictionary{{"name", "myOption"}, {"defaultValue", false}}};
 		    }
 
-		    public override int Import(String sourceFile, String savePath, Godot.Collections.Dictionary options, Godot.Collections.Array platformVariants, Godot.Collections.Array  genFiles)
+		    public override int Import(String sourceFile, String savePath, Godot.Collections.Dictionary options, Godot.Collections.Array platformVariants, Godot.Collections.Array genFiles)
 		    {
 		        var file = new File();
 		        if (file.Open(sourceFile, File.ModeFlags.Read) != Error.Ok)

--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -31,7 +31,7 @@
 	</methods>
 	<members>
 		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB( 0, 0, 0, 0, 0, 0 )">
-			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when  using a shader to offset vertices.
+			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
 		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
 			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -976,7 +976,7 @@
 			</argument>
 			<description>
 				Returns [code]true[/code] if text buffer is configured to display hexadecimal codes in place of invalid characters.
-				Note: If set to [code]false[/code], nothing is displayed  in place of invalid characters.
+				Note: If set to [code]false[/code], nothing is displayed in place of invalid characters.
 			</description>
 		</method>
 		<method name="shaped_text_get_range" qualifiers="const">

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -466,7 +466,7 @@ Error NetSocketPosix::poll(PollType p_type, int p_timeout) const {
 	FD_ZERO(&ex);
 	FD_SET(_sock, &ex);
 	struct timeval timeout = { p_timeout / 1000, (p_timeout % 1000) * 1000 };
-	// For blocking operation, pass nullptr  timeout pointer to select.
+	// For blocking operation, pass nullptr timeout pointer to select.
 	struct timeval *tp = nullptr;
 	if (p_timeout >= 0) {
 		//  If timeout is non-negative, we want to specify the timeout instead.

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -3280,7 +3280,7 @@ VkRenderPass RenderingDeviceVulkan::_render_pass_create(const Vector<AttachmentF
 
 		// For each UNDEFINED, assume the prior use was a *read*, as we'd be discarding the output of a write
 		// Also, each UNDEFINED will do an immediate layout transition (write), s.t. we must ensure execution synchronization vs.
-		// the read.  If this is a performance issue, one could track the actual last accessor of each resource, adding only that
+		// the read. If this is a performance issue, one could track the actual last accessor of each resource, adding only that
 		// stage
 		switch (is_depth_stencil ? p_initial_depth_action : p_initial_color_action) {
 			case INITIAL_ACTION_CLEAR_REGION:

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -1731,59 +1731,10 @@ void Skeleton3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 				surface_tool->set_color(bonecolor);
 				surface_tool->add_vertex(points[(j + 1) % 4]);
 			}
-
-			/*
-			bones[0]=parent;
-			surface_tool->add_bones(bones);
-			surface_tool->add_weights(weights);
-			surface_tool->add_color(Color(0.4,1,0.4,0.4));
-			surface_tool->add_vertex(v0);
-			bones[0]=i;
-			surface_tool->add_bones(bones);
-			surface_tool->add_weights(weights);
-			surface_tool->add_color(Color(0.4,1,0.4,0.4));
-			surface_tool->add_vertex(v1);
-*/
 		} else {
 			grests.write[i] = skel->get_bone_rest(i);
 			bones.write[0] = i;
 		}
-		/*
-		Transform3D  t = grests[i];
-		t.orthonormalize();
-
-		for (int i=0;i<6;i++) {
-
-
-			Vector3 face_points[4];
-
-			for (int j=0;j<4;j++) {
-				float v[3];
-				v[0]=1.0;
-				v[1]=1-2*((j>>1)&1);
-				v[2]=v[1]*(1-2*(j&1));
-
-				for (int k=0;k<3;k++) {
-					if (i<3)
-						face_points[j][(i+k)%3]=v[k]*(i>=3?-1:1);
-					else
-						face_points[3-j][(i+k)%3]=v[k]*(i>=3?-1:1);
-				}
-			}
-
-			for(int j=0;j<4;j++) {
-				surface_tool->add_bones(bones);
-				surface_tool->add_weights(weights);
-				surface_tool->add_color(Color(1.0,0.4,0.4,0.4));
-				surface_tool->add_vertex(t.xform(face_points[j]*0.04));
-				surface_tool->add_bones(bones);
-				surface_tool->add_weights(weights);
-				surface_tool->add_color(Color(1.0,0.4,0.4,0.4));
-				surface_tool->add_vertex(t.xform(face_points[(j+1)%4]*0.04));
-			}
-
-		}
-		*/
 	}
 
 	Ref<ArrayMesh> m = surface_tool->commit();

--- a/misc/hooks/canonicalize_filename.sh
+++ b/misc/hooks/canonicalize_filename.sh
@@ -13,7 +13,7 @@
 # There should be no need to change anything below this line.
 
 # Canonicalize by recursively following every symlink in every component of the
-# specified filename.  This should reproduce the results of the GNU version of
+# specified filename. This should reproduce the results of the GNU version of
 # readlink with the -f option.
 #
 # Reference: http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -445,7 +445,7 @@ real_t SpaceBullet::get_param(PhysicsServer3D::SpaceParameter p_param) {
 		case PhysicsServer3D::SPACE_PARAM_BODY_ANGULAR_VELOCITY_DAMP_RATIO:
 		case PhysicsServer3D::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS:
 		default:
-			WARN_PRINT("The SpaceBullet  doesn't support this get parameter (" + itos(p_param) + "), 0 is returned.");
+			WARN_PRINT("The SpaceBullet doesn't support this get parameter (" + itos(p_param) + "), 0 is returned.");
 			return 0.f;
 	}
 }

--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -1126,8 +1126,8 @@ HashMap<int, R> FBXMeshData::extract_per_vertex_data(
 					}
 					const int vertex_index = get_vertex_from_polygon_vertex(p_mesh_indices, polygon_vertex_index);
 					ERR_FAIL_COND_V_MSG(vertex_index < 0, (HashMap<int, R>()), "FBX file corrupted: #ERR8");
-					ERR_FAIL_COND_V_MSG(vertex_index >= p_vertex_count, (HashMap<int, R>()), "FBX file seems  corrupted: #ERR9.");
-					ERR_FAIL_COND_V_MSG(p_mapping_data.index[polygon_vertex_index] < 0, (HashMap<int, R>()), "FBX file seems  corrupted: #ERR10.");
+					ERR_FAIL_COND_V_MSG(vertex_index >= p_vertex_count, (HashMap<int, R>()), "FBX file seems corrupted: #ERR9.");
+					ERR_FAIL_COND_V_MSG(p_mapping_data.index[polygon_vertex_index] < 0, (HashMap<int, R>()), "FBX file seems corrupted: #ERR10.");
 					ERR_FAIL_COND_V_MSG(p_mapping_data.index[polygon_vertex_index] >= (int)p_mapping_data.data.size(), (HashMap<int, R>()), "FBX file seems corrupted: #ERR11.");
 					aggregate_vertex_data[vertex_index].push_back({ polygon_id, p_mapping_data.data[p_mapping_data.index[polygon_vertex_index]] });
 				}

--- a/modules/gdnative/include/pluginscript/godot_pluginscript.h
+++ b/modules/gdnative/include/pluginscript/godot_pluginscript.h
@@ -61,7 +61,7 @@ typedef struct {
 	//this is used by script languages that keep a reference counter of their own
 	//you can make make Ref<> not die when it reaches zero, so deleting the reference
 	//depends entirely from the script.
-	// Note: You can set those function pointer to nullptr  if not needed.
+	// Note: You can set those function pointer to nullptr if not needed.
 	void (*refcount_incremented)(godot_pluginscript_instance_data *p_data);
 	bool (*refcount_decremented)(godot_pluginscript_instance_data *p_data); // return true if it can die
 } godot_pluginscript_instance_desc;
@@ -121,12 +121,12 @@ typedef struct {
 	const char *name;
 	const char *type;
 	const char *extension;
-	const char **recognized_extensions; // nullptr  terminated array
+	const char **recognized_extensions; // nullptr terminated array
 	godot_pluginscript_language_data *(*init)();
 	void (*finish)(godot_pluginscript_language_data *p_data);
-	const char **reserved_words; // nullptr  terminated array
-	const char **comment_delimiters; // nullptr  terminated array
-	const char **string_delimiters; // nullptr  terminated array
+	const char **reserved_words; // nullptr terminated array
+	const char **comment_delimiters; // nullptr terminated array
+	const char **string_delimiters; // nullptr terminated array
 	godot_bool has_named_classes;
 	godot_bool supports_builtin_mode;
 	godot_bool can_inherit_from_file;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -442,7 +442,7 @@ namespace Godot
 #if DEBUG
             if (!normal.IsNormalized())
             {
-                throw new ArgumentException("Argument  is not normalized", nameof(normal));
+                throw new ArgumentException("Argument is not normalized", nameof(normal));
             }
 #endif
             return 2 * Dot(normal) * normal - this;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -456,7 +456,7 @@ namespace Godot
 #if DEBUG
             if (!normal.IsNormalized())
             {
-                throw new ArgumentException("Argument  is not normalized", nameof(normal));
+                throw new ArgumentException("Argument is not normalized", nameof(normal));
             }
 #endif
             return 2.0f * Dot(normal) * normal - this;
@@ -474,7 +474,7 @@ namespace Godot
 #if DEBUG
             if (!axis.IsNormalized())
             {
-                throw new ArgumentException("Argument  is not normalized", nameof(axis));
+                throw new ArgumentException("Argument is not normalized", nameof(axis));
             }
 #endif
             return new Basis(axis, phi).Xform(this);

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -302,7 +302,7 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 		}
 	}
 
-	/* and now we have it all.  initialize decoders */
+	/* And now we have it all. Initialize decoders. */
 	if (theora_p) {
 		td = th_decode_alloc(&ti, ts);
 		px_fmt = ti.pixel_fmt;
@@ -484,10 +484,10 @@ void VideoStreamPlaybackTheora::update(float p_delta) {
 
 					//printf("frame time %f, play time %f, ready %i\n", (float)videobuf_time, get_time(), videobuf_ready);
 
-					/* is it already too old to be useful?  This is only actually
-					 useful cosmetically after a SIGSTOP.  Note that we have to
+					/* is it already too old to be useful? This is only actually
+					 useful cosmetically after a SIGSTOP. Note that we have to
 					 decode the frame even if we don't show it (for now) due to
-					 keyframing.  Soon enough libtheora will be able to deal
+					 keyframing. Soon enough libtheora will be able to deal
 					 with non-keyframe seeks.  */
 
 					if (videobuf_time >= get_time()) {

--- a/modules/visual_script/doc_classes/VisualScript.xml
+++ b/modules/visual_script/doc_classes/VisualScript.xml
@@ -4,7 +4,7 @@
 		A script implemented in the Visual Script programming environment.
 	</brief_description>
 	<description>
-		A script implemented in the  Visual Script programming environment. The script extends the functionality of all objects that instance it.
+		A script implemented in the Visual Script programming environment. The script extends the functionality of all objects that instance it.
 		[method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
 		You are most likely to use this class via the Visual Script editor or when writing plugins for it.
 	</description>

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -81,7 +81,7 @@ private:
 		1004, //CURSOR_BUSY
 		1021, //CURSOR_DRAG
 		1021, //CURSOR_CAN_DRO
-		1000, //CURSOR_FORBIDD (no corresponding icon in Android's icon  so fallback to default)
+		1000, //CURSOR_FORBIDD (no corresponding icon in Android's icon so fallback to default)
 		1015, //CURSOR_VSIZE
 		1014, //CURSOR_HSIZE
 		1017, //CURSOR_BDIAGSI

--- a/platform/android/java/gradlew.bat
+++ b/platform/android/java/gradlew.bat
@@ -1,7 +1,7 @@
 @if "%DEBUG%" == "" @echo off
 @rem ##########################################################################
 @rem
-@rem  Gradle startup script for Windows
+@rem Gradle startup script for Windows
 @rem
 @rem ##########################################################################
 
@@ -75,7 +75,7 @@ if "%ERRORLEVEL%"=="0" goto mainEnd
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+if not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
 exit /b 1
 
 :mainEnd

--- a/platform/android/java/lib/res/values/strings.xml
+++ b/platform/android/java/lib/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="text_button_resume_cellular">Resume download</string>
     <string name="text_button_wifi_settings">Wi-Fi settings</string>
     <string name="text_verifying_download">Verifying Download</string>
-    <string name="text_validation_complete">XAPK File Validation Complete.  Select OK to exit.</string>
+    <string name="text_validation_complete">XAPK File Validation Complete. Select OK to exit.</string>
     <string name="text_validation_failed">XAPK File Validation Failed.</string>
     <string name="text_button_pause">Pause Download</string>
     <string name="text_button_resume">Resume Download</string>

--- a/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkSurfaceView.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkSurfaceView.kt
@@ -115,7 +115,7 @@ open internal class VkSurfaceView(context: Context) : SurfaceView(context), Surf
 	/**
 	 * Tear down the rendering thread.
 	 *
-	 * Must not be called  before a [VkRenderer] has been set.
+	 * Must not be called before a [VkRenderer] has been set.
 	 */
 	fun onDestroy() {
 		vkThread.blockingExit()

--- a/platform/android/plugin/godot_plugin_config.h
+++ b/platform/android/plugin/godot_plugin_config.h
@@ -37,8 +37,8 @@
 
 /*
  The `config` section and fields are required and defined as follow:
-- **name**: name of the plugin
-- **binary_type**: can be either `local` or `remote`.  The type affects the **binary** field
+- **name**: name of the plugin.
+- **binary_type**: can be either `local` or `remote`. The type affects the **binary** field.
 - **binary**:
   - if **binary_type** is `local`, then this should be the filename of the plugin `aar` file in the `res://android/plugins` directory (e.g: `MyPlugin.aar`).
   - if **binary_type** is `remote`, then this should be a declaration for a remote gradle binary (e.g: "org.godot.example:my-plugin:0.0.0").

--- a/platform/windows/context_gl_windows.cpp
+++ b/platform/windows/context_gl_windows.cpp
@@ -94,7 +94,7 @@ void ContextGL_Windows::swap_buffers() {
 
 		if (vsync_via_compositor_now != vsync_via_compositor) {
 			// The previous frame had a different operating mode than this
-			// frame.  Set the 'vsync_via_compositor' member variable and the
+			// frame. Set the 'vsync_via_compositor' member variable and the
 			// OpenGL swap interval to their proper values.
 			set_use_vsync(true);
 		}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1891,7 +1891,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				// Run a timer to prevent event catching warning if the focused window is closing.
 				windows[window_id].focus_timer_id = SetTimer(windows[window_id].hWnd, 2, USER_TIMER_MINIMUM, (TIMERPROC) nullptr);
 			}
-			return 0; // Return  To The Message Loop
+			return 0; // Return To The Message Loop
 		}
 		case WM_GETMINMAXINFO: {
 			if (windows[window_id].resizable && !windows[window_id].fullscreen) {

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -33,7 +33,7 @@
 void GridContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
-			Map<int, int> col_minw; // Max of min_width  of all controls in each col (indexed by col).
+			Map<int, int> col_minw; // Max of min_width of all controls in each col (indexed by col).
 			Map<int, int> row_minh; // Max of min_height of all controls in each row (indexed by row).
 			Set<int> col_expanded; // Columns which have the SIZE_EXPAND flag set.
 			Set<int> row_expanded; // Rows which have the SIZE_EXPAND flag set.

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -891,7 +891,7 @@ void BaseMaterial3D::_update_shader() {
 			code += "\t\tfloat current_layer_depth = 0.0;\n";
 			code += "\t\tvec2 P = view_dir.xy * heightmap_scale;\n";
 			code += "\t\tvec2 delta = P / num_layers;\n";
-			code += "\t\tvec2  ofs = base_uv;\n";
+			code += "\t\tvec2 ofs = base_uv;\n";
 			if (flags[FLAG_INVERT_HEIGHTMAP]) {
 				code += "\t\tfloat depth = texture(texture_heightmap, ofs).r;\n";
 			} else {

--- a/servers/audio/effects/reverb.cpp
+++ b/servers/audio/effects/reverb.cpp
@@ -290,7 +290,7 @@ void Reverb::update_parameters() {
 			c.feedback = (room_offset + room_scale);
 		}
 
-		float auxdmp = params.damp / 2.0 + 0.5; //only half the range (0.5 .. 1.0  is enough)
+		float auxdmp = params.damp / 2.0 + 0.5; //only half the range (0.5 .. 1.0 is enough)
 		auxdmp *= auxdmp;
 
 		c.damp = expf(-Math_TAU * auxdmp * 10000 / params.mix_rate); // 0 .. 10khz

--- a/servers/physics_3d/joints/generic_6dof_joint_3d_sw.h
+++ b/servers/physics_3d/joints/generic_6dof_joint_3d_sw.h
@@ -81,7 +81,7 @@ public:
 
 	//! temp_variables
 	//!@{
-	real_t m_currentLimitError; //!  How much is violated this limit
+	real_t m_currentLimitError; //!< How much is violated this limit
 	int m_currentLimit; //!< 0=free, 1=at lo limit, 2=at hi limit
 	real_t m_accumulatedImpulse;
 	//!@}
@@ -113,7 +113,7 @@ public:
 		return (m_enableMotor || m_currentLimit != 0);
 	}
 
-	//! calculates  error
+	//! calculates error
 	/*!
 	calculates m_currentLimit and m_currentLimitError.
 	*/
@@ -327,7 +327,7 @@ public:
 		return &m_angularLimits[index];
 	}
 
-	//! Retrieves the  limit informacion
+	//! Retrieves the limit informacion
 	G6DOFTranslationalLimitMotor3DSW *getTranslationalLimitMotor() {
 		return &m_linearLimits;
 	}

--- a/servers/physics_3d/soft_body_3d_sw.cpp
+++ b/servers/physics_3d/soft_body_3d_sw.cpp
@@ -684,7 +684,7 @@ void SoftBody3DSW::generate_bending_constraints(int p_distance) {
 //
 // This function takes in a list of interdependent Links and tries
 // to maximize the distance between calculation
-// of dependent links.  This increases the amount of parallelism that can
+// of dependent links. This increases the amount of parallelism that can
 // be exploited by out-of-order instruction processors with large but
 // (inevitably) finite instruction windows.
 //


### PR DESCRIPTION
Or after punctuation. Tried to leave third-party stuff alone, unless it has
been heavily modified for Godot.

Improved some comment formatting along the way.