### PR TITLE
Don't install Android NDK in CI

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -6,7 +6,6 @@ env:
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: platform=android verbose=yes warnings=extra werror=yes debug_symbols=no --jobs=2 module_text_server_fb_enabled=yes
   SCONS_CACHE_LIMIT: 4096
-  ANDROID_NDK_VERSION: 21.4.7075529
 
 jobs:
   android-template:
@@ -28,10 +27,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-
-      - name: Install Android NDK
-        run: |
-          sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install 'ndk;${{env.ANDROID_NDK_VERSION}}'
 
       # Upload cache on completion and check it out now
       - name: Load .scons_cache directory
@@ -64,7 +59,6 @@ jobs:
       - name: Compilation
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
-          ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk/${{env.ANDROID_NDK_VERSION}}/
         run: |
           scons target=release tools=no android_arch=armv7
           scons target=release tools=no android_arch=arm64v8


### PR DESCRIPTION
Android CI is unnecessarily installing a version of the Android NDK. If it's not there, it is installed by `detect.py` `configure(env)`:
https://github.com/godotengine/godot/blob/afbabd12f3a5b83c6a9ddc4e8e43be4041b290bf/platform/android/detect.py#L72-L93

The only actual dependencies are the installation of the Android SDK, and the setting of the environmental variable `ANDROID_SDK_ROOT`, which it (correctly) assumes to already be done.

Furthermore, it is installing it in a non-default location:
```
Warning: Observed package id 'ndk;21.4.7075529' in inconsistent location '/usr/local/lib/android/sdk/ndk-bundle' (Expected '/usr/local/lib/android/sdk/ndk/21.4.7075529')
```

It is also doing this using the deprecated environmental variable `ANDROID_HOME`:
https://github.com/godotengine/godot/blob/afbabd12f3a5b83c6a9ddc4e8e43be4041b290bf/.github/workflows/android_builds.yml#L34

It is creating another hard-coded dependency on the version:
https://github.com/godotengine/godot/blob/afbabd12f3a5b83c6a9ddc4e8e43be4041b290bf/.github/workflows/android_builds.yml#L9

And, it's unnecessarily setting the deprecated environmental variable `ANDROID_NDK_ROOT` (the version is now specified in the `build.gradle` file):
https://github.com/godotengine/godot/blob/afbabd12f3a5b83c6a9ddc4e8e43be4041b290bf/.github/workflows/android_builds.yml#L67

This PR removes the unnecessary installation of the Android NDK and the unnecessary setting of environmental variables `ANDROID_NDK_VERSION` and `ANDROID_NDK_ROOT`.
