### PR TITLE
Rename CollisionObject3D input_event signal position and normal parameters

### DIFF
--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -16,14 +16,14 @@
 			</argument>
 			<argument index="1" name="event" type="InputEvent">
 			</argument>
-			<argument index="2" name="click_position" type="Vector3">
+			<argument index="2" name="position" type="Vector3">
 			</argument>
-			<argument index="3" name="click_normal" type="Vector3">
+			<argument index="3" name="normal" type="Vector3">
 			</argument>
 			<argument index="4" name="shape_idx" type="int">
 			</argument>
 			<description>
-				Accepts unhandled [InputEvent]s. [code]click_position[/code] is the clicked location in world space and [code]click_normal[/code] is the normal vector extending from the clicked surface of the [Shape3D] at [code]shape_idx[/code]. Connect to the [code]input_event[/code] signal to easily pick up these events.
+				Receives unhandled [InputEvent]s. [code]position[/code] is the location in world space of the mouse pointer on the surface of the shape with index [code]shape_idx[/code] and [code]normal[/code] is the normal vector of the surface at that point. Connect to the [signal input_event] signal to easily pick up these events.
 			</description>
 		</method>
 		<method name="create_shape_owner">
@@ -243,14 +243,14 @@
 			</argument>
 			<argument index="1" name="event" type="InputEvent">
 			</argument>
-			<argument index="2" name="click_position" type="Vector3">
+			<argument index="2" name="position" type="Vector3">
 			</argument>
-			<argument index="3" name="click_normal" type="Vector3">
+			<argument index="3" name="normal" type="Vector3">
 			</argument>
 			<argument index="4" name="shape_idx" type="int">
 			</argument>
 			<description>
-				Emitted when [method _input_event] receives an event. See its description for details.
+				Emitted when the object receives an unhandled [InputEvent]. [code]position[/code] is the location in world space of the mouse pointer on the surface of the shape with index [code]shape_idx[/code] and [code]normal[/code] is the normal vector of the surface at that point.
 			</description>
 		</signal>
 		<signal name="mouse_entered">

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -326,9 +326,9 @@ void CollisionObject3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shape_owner_clear_shapes", "owner_id"), &CollisionObject3D::shape_owner_clear_shapes);
 	ClassDB::bind_method(D_METHOD("shape_find_owner", "shape_index"), &CollisionObject3D::shape_find_owner);
 
-	BIND_VMETHOD(MethodInfo("_input_event", PropertyInfo(Variant::OBJECT, "camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "click_position"), PropertyInfo(Variant::VECTOR3, "click_normal"), PropertyInfo(Variant::INT, "shape_idx")));
+	BIND_VMETHOD(MethodInfo("_input_event", PropertyInfo(Variant::OBJECT, "camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "position"), PropertyInfo(Variant::VECTOR3, "normal"), PropertyInfo(Variant::INT, "shape_idx")));
 
-	ADD_SIGNAL(MethodInfo("input_event", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "click_position"), PropertyInfo(Variant::VECTOR3, "click_normal"), PropertyInfo(Variant::INT, "shape_idx")));
+	ADD_SIGNAL(MethodInfo("input_event", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "position"), PropertyInfo(Variant::VECTOR3, "normal"), PropertyInfo(Variant::INT, "shape_idx")));
 	ADD_SIGNAL(MethodInfo("mouse_entered"));
 	ADD_SIGNAL(MethodInfo("mouse_exited"));
 


### PR DESCRIPTION
As originally identified by @rcorre in #37019, `CollisionObject3D` `_input_event()` has the arguments `click_position` and `click_normal`, which suggests that they are only valid for click events. However, they are valid for all `InputEvent`s.

This PR renames those parameters `position` and `normal`, which is consistent with other `CollisionObject`s' naming.

Closes #37019.
Part of #16863.