### PR TITLE
Fix gdscript language server auto completion compatibility with external text editors.

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -255,18 +255,6 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 		item.documentation = symbol->render();
 	}
 
-	if ((item.kind == lsp::CompletionItemKind::Method || item.kind == lsp::CompletionItemKind::Function) && !item.label.ends_with("):")) {
-		item.insertText = item.label + "(";
-		if (symbol && symbol->children.is_empty()) {
-			item.insertText += ")";
-		}
-	} else if (item.kind == lsp::CompletionItemKind::Event) {
-		if (params.context.triggerKind == lsp::CompletionTriggerKind::TriggerCharacter && (params.context.triggerCharacter == "(")) {
-			const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", false) ? "'" : "\"";
-			item.insertText = quote_style + item.label + quote_style;
-		}
-	}
-
 	return item.to_json(true);
 }
 


### PR DESCRIPTION
The gdscript language server changes the content of `insertText` during resolve.
But, by the [lsp specs](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion), that should not happen, as pointed out https://github.com/godotengine/godot-vscode-plugin/issues/142#issuecomment-699625127 (his emphasis):

>    The request can only delay the computation of the detail and documentation properties. Other properties like sortText, filterText, **insertText**, textEdit and additionalTextEdits must be provided in the textDocument/completion response and **must not be changed during resolve**.


Because of this, bugs in external text editors regarding auto completion happen.
By removing the changes to `insertText` in the language server, this commit ensures better compatibility with external editors.

This commit removes the parenthesis addition to functions in auto complete. This feature should exist in the text editor and **not** in the language server.

*Bugsquad edit:*
- Fixes #48436
- Fixes godotengine/godot-vscode-plugin#184
- Fixes godotengine/godot-vscode-plugin#142
- Fixes godotengine/godot-vscode-plugin#323