### PR TITLE
FileAccess: Don't err in `store_buffer` with buffer of size 0

### DIFF
--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -257,6 +257,7 @@ Error FileAccessEncrypted::get_error() const {
 
 void FileAccessEncrypted::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND_MSG(!writing, "File has not been opened in write mode.");
+	ERR_FAIL_COND(!p_src && p_length > 0);
 
 	if (pos < get_length()) {
 		for (uint64_t i = 0; i < p_length; i++) {

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -168,6 +168,7 @@ void FileAccessMemory::store_8(uint8_t p_byte) {
 }
 
 void FileAccessMemory::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	ERR_FAIL_COND(!p_src && p_length > 0);
 	uint64_t left = length - pos;
 	uint64_t write = MIN(p_length, left);
 	if (write < p_length) {

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -551,6 +551,7 @@ void FileAccess::store_csv_line(const Vector<String> &p_values, const String &p_
 }
 
 void FileAccess::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	ERR_FAIL_COND(!p_src && p_length > 0);
 	for (uint64_t i = 0; i < p_length; i++) {
 		store_8(p_src[i]);
 	}

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -264,7 +264,7 @@ void FileAccessUnix::store_8(uint8_t p_dest) {
 
 void FileAccessUnix::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
-	ERR_FAIL_COND(!p_src);
+	ERR_FAIL_COND(!p_src && p_length > 0);
 	ERR_FAIL_COND(fwrite(p_src, 1, p_length, f) != p_length);
 }
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -294,6 +294,7 @@ void FileAccessWindows::store_8(uint8_t p_dest) {
 
 void FileAccessWindows::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND(!p_src && p_length > 0);
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == READ) {
 			if (last_error != ERR_FILE_EOF) {


### PR DESCRIPTION
The error check was added for `FileAccessUnix` but it's not an error when both
`p_src` and `p_length` are zero.

Added correct error checks to all implementations to prevent the actual
erroneous case: `p_src` is nullptr but `p_length > 0` (risk of null pointer
indexing).

Fixes #33564.

(Congrats @qarmin for reporting a bug you created :P 9ddb3265e1a)