### PR TITLE
[3.x] Fix uninitialized members in physics query results

### DIFF
--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -160,9 +160,9 @@ public:
 		Vector2 position;
 		Vector2 normal;
 		RID rid;
-		ObjectID collider_id;
-		Object *collider;
-		int shape;
+		ObjectID collider_id = 0;
+		Object *collider = nullptr;
+		int shape = 0;
 		Variant metadata;
 	};
 
@@ -170,9 +170,9 @@ public:
 
 	struct ShapeResult {
 		RID rid;
-		ObjectID collider_id;
-		Object *collider;
-		int shape;
+		ObjectID collider_id = 0;
+		Object *collider = nullptr;
+		int shape = 0;
 		Variant metadata;
 	};
 
@@ -189,8 +189,8 @@ public:
 		Vector2 point;
 		Vector2 normal;
 		RID rid;
-		ObjectID collider_id;
-		int shape;
+		ObjectID collider_id = 0;
+		int shape = 0;
 		Vector2 linear_velocity; //velocity at contact point
 		Variant metadata;
 	};

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -154,9 +154,9 @@ protected:
 public:
 	struct ShapeResult {
 		RID rid;
-		ObjectID collider_id;
-		Object *collider;
-		int shape;
+		ObjectID collider_id = 0;
+		Object *collider = nullptr;
+		int shape = 0;
 	};
 
 	virtual int intersect_point(const Vector3 &p_point, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_areas = false) = 0;
@@ -165,9 +165,9 @@ public:
 		Vector3 position;
 		Vector3 normal;
 		RID rid;
-		ObjectID collider_id;
-		Object *collider;
-		int shape;
+		ObjectID collider_id = 0;
+		Object *collider = nullptr;
+		int shape = 0;
 	};
 
 	virtual bool intersect_ray(const Vector3 &p_from, const Vector3 &p_to, RayResult &r_result, const Set<RID> &p_exclude = Set<RID>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_areas = false, bool p_pick_ray = false) = 0;
@@ -178,8 +178,8 @@ public:
 		Vector3 point;
 		Vector3 normal;
 		RID rid;
-		ObjectID collider_id;
-		int shape;
+		ObjectID collider_id = 0;
+		int shape = 0;
 		Vector3 linear_velocity; //velocity at contact point
 	};
 


### PR DESCRIPTION
Fixes #48425 on 3.x branch.

Note: `ObjectID` is a class on master so it's already initialized with a default value, but not on the 3.x branch.