### PR TITLE
Fix 8 bone weights in glTF2

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2653,10 +2653,10 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> state) {
 				//must generate mikktspace tangents.. ergh..
 				Ref<SurfaceTool> st;
 				st.instance();
+				st->create_from_triangle_arrays(array);
 				if (a.has("JOINTS_0") && a.has("JOINTS_1")) {
 					st->set_skin_weight_count(SurfaceTool::SKIN_8_WEIGHTS);
 				}
-				st->create_from_triangle_arrays(array);
 				st->generate_tangents();
 				array = st->commit_to_arrays();
 			}
@@ -2772,10 +2772,10 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> state) {
 					if (generate_tangents) {
 						Ref<SurfaceTool> st;
 						st.instance();
+						st->create_from_triangle_arrays(array_copy);
 						if (a.has("JOINTS_0") && a.has("JOINTS_1")) {
 							st->set_skin_weight_count(SurfaceTool::SKIN_8_WEIGHTS);
 						}
-						st->create_from_triangle_arrays(array_copy);
 						st->deindex();
 						st->generate_tangents();
 						array_copy = st->commit_to_arrays();

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -537,12 +537,16 @@ Array SurfaceTool::commit_to_arrays() {
 				int count = skin_weights == SKIN_8_WEIGHTS ? 8 : 4;
 				Vector<int> array;
 				array.resize(varr_len * count);
+				array.fill(0);
 				int *w = array.ptrw();
 
 				for (uint32_t idx = 0; idx < vertex_array.size(); idx++) {
 					const Vertex &v = vertex_array[idx];
 
-					ERR_CONTINUE(v.bones.size() != count);
+					if (v.bones.size() > count) {
+						ERR_PRINT_ONCE(vformat("Invalid bones size %d vs count %d", v.bones.size(), count));
+						continue;
+					}
 
 					for (int j = 0; j < count; j++) {
 						w[idx * count + j] = v.bones[j];
@@ -557,12 +561,16 @@ Array SurfaceTool::commit_to_arrays() {
 				int count = skin_weights == SKIN_8_WEIGHTS ? 8 : 4;
 
 				array.resize(varr_len * count);
+				array.fill(0.0f);
 				float *w = array.ptrw();
 
 				for (uint32_t idx = 0; idx < vertex_array.size(); idx++) {
 					const Vertex &v = vertex_array[idx];
 
-					ERR_CONTINUE(v.weights.size() != count);
+					if (v.weights.size() > count) {
+						ERR_PRINT_ONCE(vformat("Invalid weight size %d vs count %d", v.weights.size(), count));
+						continue;
+					}
 
 					for (int j = 0; j < count; j++) {
 						w[idx * count + j] = v.weights[j];


### PR DESCRIPTION
Don't spam in glTF2 import either.

Clear() in SurfaceTool does not keep 8 weights.

Fixes: https://github.com/godotengine/godot/issues/49399