### PR TITLE
fix AnimationBlendTree graph update on input count change

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -869,7 +869,6 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 	} else {
 		blend_tree->connect("removed_from_graph", callable_mp(this, &AnimationNodeBlendTreeEditor::_removed_from_graph));
 		blend_tree->connect("tree_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_update_graph));
-		
 		_update_graph();
 	}
 }

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -868,7 +868,8 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 		hide();
 	} else {
 		blend_tree->connect("removed_from_graph", callable_mp(this, &AnimationNodeBlendTreeEditor::_removed_from_graph));
-
+		blend_tree->connect("tree_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_update_graph));
+		
 		_update_graph();
 	}
 }

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -34,6 +34,7 @@
 
 void AnimationNodeAnimation::set_animation(const StringName &p_name) {
 	animation = p_name;
+	emit_signal("tree_changed");
 }
 
 StringName AnimationNodeAnimation::get_animation() const {
@@ -641,6 +642,8 @@ void AnimationNodeTransition::set_enabled_inputs(int p_inputs) {
 	ERR_FAIL_INDEX(p_inputs, MAX_INPUTS);
 	enabled_inputs = p_inputs;
 	_update_inputs();
+
+	emit_signal("tree_changed");
 }
 
 int AnimationNodeTransition::get_enabled_inputs() {
@@ -661,6 +664,8 @@ void AnimationNodeTransition::set_input_caption(int p_input, const String &p_nam
 	ERR_FAIL_INDEX(p_input, MAX_INPUTS);
 	inputs[p_input].name = p_name;
 	set_input_name(p_input, p_name);
+
+	emit_signal("tree_changed");
 }
 
 String AnimationNodeTransition::get_input_caption(int p_input) const {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/45437

Connects blend tree plugin to the `tree_changed` signal which is emited when set_input is updated. The signal then calls update_graph.