### PR TITLE
Separate version hash from version number in editor and project manager

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -141,7 +141,7 @@ EditorAbout::EditorAbout() {
 	version_btn = memnew(LinkButton);
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0) {
-		hash = "." + hash.left(9);
+		hash = " " + vformat("[%s]", hash.left(9));
 	}
 	version_btn->set_text(VERSION_FULL_NAME + hash);
 	// Set the text to copy in metadata as it slightly differs from the button's text.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6632,7 +6632,7 @@ EditorNode::EditorNode() {
 	version_btn->set_text(VERSION_FULL_CONFIG);
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0) {
-		hash = "." + hash.left(9);
+		hash = " " + vformat("[%s]", hash.left(9));
 	}
 	// Set the text to copy in metadata as it slightly differs from the button's text.
 	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2621,7 +2621,7 @@ ProjectManager::ProjectManager() {
 		version_btn = memnew(LinkButton);
 		String hash = String(VERSION_HASH);
 		if (hash.length() != 0) {
-			hash = "." + hash.left(9);
+			hash = " " + vformat("[%s]", hash.left(9));
 		}
 		version_btn->set_text("v" VERSION_FULL_BUILD + hash);
 		// Fade the version label to be less prominent, but still readable.


### PR DESCRIPTION
When copy-pasting the version from About dialog to bug reports at GitHub, this makes the version hash linkable to commits at GitHub (users might not be aware of this feature):

![image](https://user-images.githubusercontent.com/17108460/121092755-bce4f000-c7f4-11eb-86da-246b4ea49dbd.png)

v4.0.dev.Xrayez a2b6336b1.




