### PR TITLE
Fixed missed IDHandler dependency in GodotFetch

### DIFF
--- a/platform/javascript/js/libs/library_godot_fetch.js
+++ b/platform/javascript/js/libs/library_godot_fetch.js
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 const GodotFetch = {
-	$GodotFetch__deps: ['$GodotRuntime'],
+	$GodotFetch__deps: ['$IDHandler', '$GodotRuntime'],
 	$GodotFetch: {
 
 		onread: function (id, result) {


### PR DESCRIPTION
Disabling webrtc and websocket  without this dependency break HttpRequest for HTML5