### PR TITLE
Enable Camera2D smoothing on limit change

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -161,6 +161,8 @@
 		</member>
 		<member name="limit_smoothed" type="bool" setter="set_limit_smoothing_enabled" getter="is_limit_smoothing_enabled" default="false">
 			If [code]true[/code], the camera smoothly stops when reaches its limits.
+			This has no effect if smoothing is disabled.
+			[b]Note:[/b] To immediately update the camera's position to be within limits without smoothing, even with this setting enabled, invoke [method reset_smoothing].
 		</member>
 		<member name="limit_top" type="int" setter="set_limit" getter="get_limit" default="-10000000">
 			Top scroll limit in pixels. The camera stops moving when reaching this value.

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -178,20 +178,23 @@ Transform2D Camera2D::get_camera_transform() {
 	}
 
 	Rect2 screen_rect(-screen_offset + ret_camera_pos, screen_size * zoom);
-	if (screen_rect.position.x < limit[SIDE_LEFT]) {
-		screen_rect.position.x = limit[SIDE_LEFT];
-	}
 
-	if (screen_rect.position.x + screen_rect.size.x > limit[SIDE_RIGHT]) {
-		screen_rect.position.x = limit[SIDE_RIGHT] - screen_rect.size.x;
-	}
+	if (!limit_smoothing_enabled) {
+		if (screen_rect.position.x < limit[SIDE_LEFT]) {
+			screen_rect.position.x = limit[SIDE_LEFT];
+		}
 
-	if (screen_rect.position.y + screen_rect.size.y > limit[SIDE_BOTTOM]) {
-		screen_rect.position.y = limit[SIDE_BOTTOM] - screen_rect.size.y;
-	}
+		if (screen_rect.position.x + screen_rect.size.x > limit[SIDE_RIGHT]) {
+			screen_rect.position.x = limit[SIDE_RIGHT] - screen_rect.size.x;
+		}
 
-	if (screen_rect.position.y < limit[SIDE_TOP]) {
-		screen_rect.position.y = limit[SIDE_TOP];
+		if (screen_rect.position.y + screen_rect.size.y > limit[SIDE_BOTTOM]) {
+			screen_rect.position.y = limit[SIDE_BOTTOM] - screen_rect.size.y;
+		}
+
+		if (screen_rect.position.y < limit[SIDE_TOP]) {
+			screen_rect.position.y = limit[SIDE_TOP];
+		}
 	}
 
 	if (offset != Vector2()) {


### PR DESCRIPTION
This change resolves #32596.

Currently, if the limiting bounds for a `Camera2D` are changed such that the camera is no longer in the bounds, the camera will jump (immediately) to the new bounds, even if `Smoothed` is checked for the `Camera2D` object. This change alters that behavior, allowing the camera to smoothly move to the new position when adjusting to new limits.

For scenarios where `Smoothed` is enabled but the "jump" behavior is desired, one should invoke `reset_smoothing()` after updating the limits.

*Bugsquad edit:* fixes #32596.