### PR TITLE
Fix font preview text for CJKV ideographs

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -832,7 +832,7 @@ struct FSample {
 };
 
 static FSample _samples[] = {
-	{ "hani", U"漢語" },
+	{ "hani", U"漢字" },
 	{ "armn", U"Աբ" },
 	{ "copt", U"Αα" },
 	{ "cyrl", U"Аб" },

--- a/editor/plugins/font_editor_plugin.cpp
+++ b/editor/plugins/font_editor_plugin.cpp
@@ -56,7 +56,7 @@ struct FSample {
 };
 
 static FSample _samples[] = {
-	{ "hani", U"漢語" },
+	{ "hani", U"漢字" },
 	{ "armn", U"Աբ" },
 	{ "copt", U"Αα" },
 	{ "cyrl", U"Аб" },


### PR DESCRIPTION
Use 漢字 instead of 漢語.

漢語 means the Chinese language, while 漢字 means Chinese characters which is shared across CJKV.

Before:
![截屏2021-06-08 下午9 35 46](https://user-images.githubusercontent.com/372476/121195445-2d961600-c8a2-11eb-9ce8-6aa5246e6ab7.png)

After:
![截屏2021-06-08 下午9 39 02](https://user-images.githubusercontent.com/372476/121195447-2ec74300-c8a2-11eb-8715-aacb02c6ceca.png)
