### PR TITLE
[3.x] Set Environment's Ao Channel Affect to 1.0 by default

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -249,7 +249,7 @@
 		<member name="ss_reflections_roughness" type="bool" setter="set_ssr_rough" getter="is_ssr_rough" default="true">
 			If [code]true[/code], screen-space reflections will take the material roughness into account.
 		</member>
-		<member name="ssao_ao_channel_affect" type="float" setter="set_ssao_ao_channel_affect" getter="get_ssao_ao_channel_affect" default="0.0">
+		<member name="ssao_ao_channel_affect" type="float" setter="set_ssao_ao_channel_affect" getter="get_ssao_ao_channel_affect" default="1.0">
 			The screen-space ambient occlusion intensity on materials that have an AO texture defined. Values higher than [code]0[/code] will make the SSAO effect visible in areas darkened by AO textures.
 		</member>
 		<member name="ssao_bias" type="float" setter="set_ssao_bias" getter="get_ssao_bias" default="0.01">

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -473,7 +473,7 @@ public:
 				ssao_radius2(0.0),
 				ssao_bias(0.01),
 				ssao_light_affect(0),
-				ssao_ao_channel_affect(0),
+				ssao_ao_channel_affect(1.0),
 				ssao_quality(VS::ENV_SSAO_QUALITY_LOW),
 				ssao_bilateral_sharpness(4),
 				ssao_filter(VS::ENV_SSAO_BLUR_3x3),

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1205,7 +1205,7 @@ Environment::Environment() :
 	ssao_intensity2 = 1;
 	ssao_bias = 0.01;
 	ssao_direct_light_affect = 0.0;
-	ssao_ao_channel_affect = 0.0;
+	ssao_ao_channel_affect = 1.0;
 	ssao_blur = SSAO_BLUR_3x3;
 	set_ssao_edge_sharpness(4);
 	set_ssao_quality(SSAO_QUALITY_MEDIUM);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/43960 (no longer useful in `master`).

"Ao Channel Affect" was defaulting to 0, giving unexpected results. This meant that as soon as you set an AO texture on a material, there will no longer be SSAO on that material.

This led many users to think that Godot didn't support using SSAO and AO textures at the same time.

This is technically a breaking change, but since the default behavior felt broken for a lot of people, I think it makes sense to switch to a more logical behavior.

This closes https://github.com/godotengine/godot/issues/43957 for `3.x` (already solved in `master`).