### PR TITLE
Add OS.get_external_data_dir() to get Android external directory

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -643,6 +643,10 @@ String _OS::get_user_data_dir() const {
 	return OS::get_singleton()->get_user_data_dir();
 }
 
+String _OS::get_external_data_dir() const {
+	return OS::get_singleton()->get_external_data_dir();
+}
+
 bool _OS::is_debug_build() const {
 #ifdef DEBUG_ENABLED
 	return true;
@@ -743,6 +747,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_static_memory_peak_usage"), &_OS::get_static_memory_peak_usage);
 
 	ClassDB::bind_method(D_METHOD("get_user_data_dir"), &_OS::get_user_data_dir);
+	ClassDB::bind_method(D_METHOD("get_external_data_dir"), &_OS::get_external_data_dir);
 	ClassDB::bind_method(D_METHOD("get_system_dir", "dir"), &_OS::get_system_dir);
 	ClassDB::bind_method(D_METHOD("get_unique_id"), &_OS::get_unique_id);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -237,6 +237,7 @@ public:
 	String get_system_dir(SystemDir p_dir) const;
 
 	String get_user_data_dir() const;
+	String get_external_data_dir() const;
 
 	Error set_thread_name(const String &p_name);
 	Thread::ID get_thread_caller_id() const;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -310,6 +310,11 @@ String OS::get_user_data_dir() const {
 	return ".";
 }
 
+// Android OS path to app's external data storage
+String OS::get_external_data_dir() const {
+	return get_user_data_dir();
+};
+
 // Absolute path to res://
 String OS::get_resource_dir() const {
 	return ProjectSettings::get_singleton()->get_resource_path();

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -252,6 +252,7 @@ public:
 	virtual String get_bundle_resource_dir() const;
 
 	virtual String get_user_data_dir() const;
+	virtual String get_external_data_dir() const;
 	virtual String get_resource_dir() const;
 
 	enum SystemDir {

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -221,6 +221,13 @@
 				Returns the path to the current engine executable.
 			</description>
 		</method>
+		<method name="get_external_data_dir" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				On Android, returns the absolute directory path where user data can be written to external storage if available. On all other platforms, this will return the same location as [method get_user_data_dir].
+			</description>
+		</method>
 		<method name="get_granted_permissions" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -452,6 +452,10 @@ public class GodotIO {
 		return activity.getFilesDir().getAbsolutePath();
 	}
 
+	public String getExternalDataDir() {
+		return activity.getExternalFilesDir(null).getAbsolutePath();
+	}
+
 	public String getLocale() {
 		return Locale.getDefault().toString();
 	}

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -49,6 +49,7 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 
 		_open_URI = p_env->GetMethodID(cls, "openURI", "(Ljava/lang/String;)I");
 		_get_data_dir = p_env->GetMethodID(cls, "getDataDir", "()Ljava/lang/String;");
+		_get_external_data_dir = p_env->GetMethodID(cls, "getExternalDataDir", "()Ljava/lang/String;");
 		_get_locale = p_env->GetMethodID(cls, "getLocale", "()Ljava/lang/String;");
 		_get_model = p_env->GetMethodID(cls, "getModel", "()Ljava/lang/String;");
 		_get_screen_DPI = p_env->GetMethodID(cls, "getScreenDPI", "()I");
@@ -86,6 +87,17 @@ String GodotIOJavaWrapper::get_user_data_dir() {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_COND_V(env == nullptr, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_data_dir);
+		return jstring_to_string(s, env);
+	} else {
+		return String();
+	}
+}
+
+String GodotIOJavaWrapper::get_external_data_dir() {
+	if (_get_external_data_dir) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, String());
+		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_external_data_dir);
 		return jstring_to_string(s, env);
 	} else {
 		return String();

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -47,6 +47,7 @@ private:
 
 	jmethodID _open_URI = 0;
 	jmethodID _get_data_dir = 0;
+	jmethodID _get_external_data_dir = 0;
 	jmethodID _get_locale = 0;
 	jmethodID _get_model = 0;
 	jmethodID _get_screen_DPI = 0;
@@ -66,6 +67,7 @@ public:
 
 	Error open_uri(const String &p_uri);
 	String get_user_data_dir();
+	String get_external_data_dir();
 	String get_locale();
 	String get_model();
 	int get_screen_dpi();

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -111,6 +111,7 @@ public:
 
 	virtual Error shell_open(String p_uri) override;
 	virtual String get_user_data_dir() const override;
+	virtual String get_external_data_dir() const override;
 	virtual String get_resource_dir() const override;
 	virtual String get_locale() const override;
 	virtual String get_model_name() const override;


### PR DESCRIPTION
Android provides each app with a dedicated location for external storage. However, this was often ignored because any external storage location could be accessed with the `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions. With Android 10+, with [scoped storage](https://developer.android.com/training/data-storage#scoped-storage), the dedicated external storage location is the only external location that the app is allowed to access (without using the `MediaStore` API or requesting the `MANAGE_EXTERNAL_STORAGE` permission). On Android 10, this could be worked around with `android:requestLegacyExternalStorage="true"` (see #39103), however this workaround is disabled with Android 11 (see #47954).

This PR provides users with an easy way to locate the dedicated external storage location e.g.:
```
func _on_Save_Button_pressed():
	var dir = OS.get_external_data_dir()
	var image = $TextureRect.get_texture().get_data()
	image.save_png(dir + "/test.png")
```
To provide compatibility, on other OSs, this will return the same location as `OS.get_user_data_dir()`.

Fixes #39414.
Should help with #38913 and #48636.
