### PR TITLE
Allow higher and lower maximum zoom values in GraphEdit

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -42,8 +42,13 @@
 
 #define ZOOM_SCALE 1.2
 
-#define MIN_ZOOM (((1 / ZOOM_SCALE) / ZOOM_SCALE) / ZOOM_SCALE)
-#define MAX_ZOOM (1 * ZOOM_SCALE * ZOOM_SCALE * ZOOM_SCALE)
+// Allow dezooming 8 times from the default zoom level.
+// At low zoom levels, text is unreadable due to its small size and poor filtering,
+// but this is still useful for previewing purposes.
+#define MIN_ZOOM (1 / Math::pow(ZOOM_SCALE, 8))
+
+// Allow zooming 4 times from the default zoom level.
+#define MAX_ZOOM (1 * Math::pow(ZOOM_SCALE, 4))
 
 #define MINIMAP_OFFSET 12
 #define MINIMAP_PADDING 5


### PR DESCRIPTION
Low zoom values result in unreadable text, but it can still be useful for previewing purposes.

Eventually, characters could be replaced by rectangles at very low zoom levels to improve the visual appearance.