### PR TITLE
WIP: Fix wrong editor hint for string values in visual script editor

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -549,8 +549,8 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 				action_buttons[0]->set_anchor(SIDE_LEFT, Control::ANCHOR_END);
 				action_buttons[0]->set_anchor(SIDE_TOP, Control::ANCHOR_END);
-				action_buttons[0]->set_anchor(SIDE_RIGHT, Control::ANCHOR_END);
-				action_buttons[0]->set_anchor(SIDE_BOTTOM, Control::ANCHOR_END);
+				action_buttons[0]->set_anchor(SIDE_RIGHT, Control::ANCHOR_BEGIN);
+				action_buttons[0]->set_anchor(SIDE_BOTTOM, Control::ANCHOR_BEGIN);
 				action_buttons[0]->set_begin(Point2(-70 * EDSCALE, -button_margin + 5 * EDSCALE));
 				action_buttons[0]->set_end(Point2(-margin, -margin));
 				action_buttons[0]->set_text(TTR("Close"));

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -1000,7 +1000,7 @@ PropertyInfo VisualScriptPropertySet::get_input_value_port_info(int p_idx) const
 	ClassDB::get_property_list(_get_base_type(), &props, false);
 	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 		if (E->get().name == property) {
-			PropertyInfo pinfo = PropertyInfo(E->get().type, "value", PROPERTY_HINT_TYPE_STRING, E->get().hint_string);
+			PropertyInfo pinfo = PropertyInfo(E->get().type, "value", E->get().hint, E->get().hint_string);
 			_adjust_input_index(pinfo);
 			return pinfo;
 		}


### PR DESCRIPTION
Fixes #49231

---

Still work in progress as the PropertyEditor for Multi Line Text in master is currently not displayed correctly.

