### PR TITLE
Highlight "namespace" as a GDScript keyword in the syntax highlighter

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2022,8 +2022,6 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		"preload",
 		"signal",
 		"super",
-		"trait",
-		"yield",
 		// var
 		"const",
 		"enum",
@@ -2040,6 +2038,11 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		"return",
 		"match",
 		"while",
+		// These keywords are not implemented currently, but reserved for (potential) future use.
+		// We highlight them as keywords to make errors easier to understand.
+		"trait",
+		"namespace",
+		"yield",
 		nullptr
 	};
 


### PR DESCRIPTION
Like "trait" and "yield", "namespace" is currently not implemented but is still reserved for future use.

See https://github.com/godotengine/godot/issues/41865.

**Note:** Not cherry-pickable to the `3.x` branch as the "namespace" keyword is not reserved there.