### PR TITLE
Remove unused `shadow_color` property from Light3D

### DIFF
--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -86,9 +86,6 @@
 		<member name="shadow_blur" type="float" setter="set_param" getter="get_param" default="1.0">
 			Blurs the edges of the shadow. Can be used to hide pixel artifacts in low-resolution shadow maps. A high value can impact performance, make shadows appear grainy and can cause other unwanted artifacts. Try to keep as near default as possible.
 		</member>
-		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color(0, 0, 0, 1)">
-			The color of shadows cast by this light.
-		</member>
 		<member name="shadow_enabled" type="bool" setter="set_shadow" getter="has_shadow" default="false">
 			If [code]true[/code], the light will cast real-time shadows. This has a significant performance cost. Only enable shadow rendering when it makes a noticeable difference in the scene's appearance, and consider using [member distance_fade_enabled] to hide the light when far away from the [Camera3D].
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1709,14 +1709,6 @@
 				If [code]true[/code], light will cast shadows. Equivalent to [member Light3D.shadow_enabled].
 			</description>
 		</method>
-		<method name="light_set_shadow_color">
-			<return type="void" />
-			<argument index="0" name="light" type="RID" />
-			<argument index="1" name="color" type="Color" />
-			<description>
-				Sets the color of the shadow cast by the light. Equivalent to [member Light3D.shadow_color].
-			</description>
-		</method>
 		<method name="lightmap_create">
 			<return type="RID" />
 			<description>

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2255,9 +2255,6 @@ void RasterizerStorageGLES3::light_set_param(RID p_light, RS::LightParam p_param
 void RasterizerStorageGLES3::light_set_shadow(RID p_light, bool p_enabled) {
 }
 
-void RasterizerStorageGLES3::light_set_shadow_color(RID p_light, const Color &p_color) {
-}
-
 void RasterizerStorageGLES3::light_set_projector(RID p_light, RID p_texture) {
 }
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -898,7 +898,6 @@ public:
 	void light_set_color(RID p_light, const Color &p_color) override;
 	void light_set_param(RID p_light, RS::LightParam p_param, float p_value) override;
 	void light_set_shadow(RID p_light, bool p_enabled) override;
-	void light_set_shadow_color(RID p_light, const Color &p_color) override;
 	void light_set_projector(RID p_light, RID p_texture) override;
 	void light_set_negative(RID p_light, bool p_enable) override;
 	void light_set_cull_mask(RID p_light, uint32_t p_mask) override;

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -131,15 +131,6 @@ Color Light3D::get_color() const {
 	return color;
 }
 
-void Light3D::set_shadow_color(const Color &p_shadow_color) {
-	shadow_color = p_shadow_color;
-	RS::get_singleton()->light_set_shadow_color(light, p_shadow_color);
-}
-
-Color Light3D::get_shadow_color() const {
-	return shadow_color;
-}
-
 void Light3D::set_shadow_reverse_cull_face(bool p_enable) {
 	reverse_cull = p_enable;
 	RS::get_singleton()->light_set_reverse_cull_face_mode(light, reverse_cull);
@@ -232,7 +223,7 @@ bool Light3D::is_editor_only() const {
 }
 
 void Light3D::_validate_property(PropertyInfo &property) const {
-	if (!shadow && (property.name == "shadow_color" || property.name == "shadow_bias" || property.name == "shadow_normal_bias" || property.name == "shadow_reverse_cull_face" || property.name == "shadow_transmittance_bias" || property.name == "shadow_fog_fade" || property.name == "shadow_blur" || property.name == "distance_fade_shadow")) {
+	if (!shadow && (property.name == "shadow_bias" || property.name == "shadow_normal_bias" || property.name == "shadow_reverse_cull_face" || property.name == "shadow_transmittance_bias" || property.name == "shadow_fog_fade" || property.name == "shadow_blur" || property.name == "distance_fade_shadow")) {
 		property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
@@ -282,9 +273,6 @@ void Light3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shadow_reverse_cull_face", "enable"), &Light3D::set_shadow_reverse_cull_face);
 	ClassDB::bind_method(D_METHOD("get_shadow_reverse_cull_face"), &Light3D::get_shadow_reverse_cull_face);
 
-	ClassDB::bind_method(D_METHOD("set_shadow_color", "shadow_color"), &Light3D::set_shadow_color);
-	ClassDB::bind_method(D_METHOD("get_shadow_color"), &Light3D::get_shadow_color);
-
 	ClassDB::bind_method(D_METHOD("set_bake_mode", "bake_mode"), &Light3D::set_bake_mode);
 	ClassDB::bind_method(D_METHOD("get_bake_mode"), &Light3D::get_bake_mode);
 
@@ -304,7 +292,6 @@ void Light3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_cull_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_cull_mask", "get_cull_mask");
 	ADD_GROUP("Shadow", "shadow_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shadow_enabled"), "set_shadow", "has_shadow");
-	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "shadow_color", PROPERTY_HINT_COLOR_NO_ALPHA), "set_shadow_color", "get_shadow_color");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "shadow_bias", PROPERTY_HINT_RANGE, "0,10,0.001"), "set_param", "get_param", PARAM_SHADOW_BIAS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "shadow_normal_bias", PROPERTY_HINT_RANGE, "0,10,0.001"), "set_param", "get_param", PARAM_SHADOW_NORMAL_BIAS);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shadow_reverse_cull_face"), "set_shadow_reverse_cull_face", "get_shadow_reverse_cull_face");

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -70,7 +70,6 @@ public:
 private:
 	Color color;
 	real_t param[PARAM_MAX] = {};
-	Color shadow_color;
 	bool shadow = false;
 	bool negative = false;
 	bool reverse_cull = false;
@@ -128,9 +127,6 @@ public:
 
 	void set_color(const Color &p_color);
 	Color get_color() const;
-
-	void set_shadow_color(const Color &p_shadow_color);
-	Color get_shadow_color() const;
 
 	void set_shadow_reverse_cull_face(bool p_enable);
 	bool get_shadow_reverse_cull_face() const;

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -408,7 +408,6 @@ public:
 	void light_set_color(RID p_light, const Color &p_color) override {}
 	void light_set_param(RID p_light, RS::LightParam p_param, float p_value) override {}
 	void light_set_shadow(RID p_light, bool p_enabled) override {}
-	void light_set_shadow_color(RID p_light, const Color &p_color) override {}
 	void light_set_projector(RID p_light, RID p_texture) override {}
 	void light_set_negative(RID p_light, bool p_enable) override {}
 	void light_set_cull_mask(RID p_light, uint32_t p_mask) override {}

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.h
@@ -250,8 +250,6 @@ private:
 			float cos_spot_angle;
 			float inv_spot_attenuation;
 			float radius;
-
-			float shadow_color[4];
 		};
 
 		struct DirectLightPushConstant {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3316,43 +3316,8 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 
 				light_data.size = 1.0 - Math::cos(Math::deg2rad(size)); //angle to cosine offset
 
-				Color shadow_col = storage->light_get_shadow_color(base).to_linear();
-
 				if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_PSSM_SPLITS) {
-					light_data.shadow_color1[0] = 1.0;
-					light_data.shadow_color1[1] = 0.0;
-					light_data.shadow_color1[2] = 0.0;
-					light_data.shadow_color1[3] = 1.0;
-					light_data.shadow_color2[0] = 0.0;
-					light_data.shadow_color2[1] = 1.0;
-					light_data.shadow_color2[2] = 0.0;
-					light_data.shadow_color2[3] = 1.0;
-					light_data.shadow_color3[0] = 0.0;
-					light_data.shadow_color3[1] = 0.0;
-					light_data.shadow_color3[2] = 1.0;
-					light_data.shadow_color3[3] = 1.0;
-					light_data.shadow_color4[0] = 1.0;
-					light_data.shadow_color4[1] = 1.0;
-					light_data.shadow_color4[2] = 0.0;
-					light_data.shadow_color4[3] = 1.0;
-
-				} else {
-					light_data.shadow_color1[0] = shadow_col.r;
-					light_data.shadow_color1[1] = shadow_col.g;
-					light_data.shadow_color1[2] = shadow_col.b;
-					light_data.shadow_color1[3] = 1.0;
-					light_data.shadow_color2[0] = shadow_col.r;
-					light_data.shadow_color2[1] = shadow_col.g;
-					light_data.shadow_color2[2] = shadow_col.b;
-					light_data.shadow_color2[3] = 1.0;
-					light_data.shadow_color3[0] = shadow_col.r;
-					light_data.shadow_color3[1] = shadow_col.g;
-					light_data.shadow_color3[2] = shadow_col.b;
-					light_data.shadow_color3[3] = 1.0;
-					light_data.shadow_color4[0] = shadow_col.r;
-					light_data.shadow_color4[1] = shadow_col.g;
-					light_data.shadow_color4[2] = shadow_col.b;
-					light_data.shadow_color4[3] = 1.0;
+					WARN_PRINT_ONCE("The DirectionalLight3D PSSM splits debug draw mode is not reimplemented yet.");
 				}
 
 				light_data.shadow_enabled = p_using_shadows && storage->light_has_shadow(base);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -678,10 +678,6 @@ private:
 			float shadow_range_begin[4];
 			float shadow_split_offsets[4];
 			float shadow_matrices[4][16];
-			float shadow_color1[4];
-			float shadow_color2[4];
-			float shadow_color3[4];
-			float shadow_color4[4];
 			float uv_scale1[2];
 			float uv_scale2[2];
 			float uv_scale3[2];

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -6555,12 +6555,6 @@ void RendererStorageRD::light_set_shadow(RID p_light, bool p_enabled) {
 	light->dependency.changed_notify(DEPENDENCY_CHANGED_LIGHT);
 }
 
-void RendererStorageRD::light_set_shadow_color(RID p_light, const Color &p_color) {
-	Light *light = light_owner.get_or_null(p_light);
-	ERR_FAIL_COND(!light);
-	light->shadow_color = p_color;
-}
-
 void RendererStorageRD::light_set_projector(RID p_light, RID p_texture) {
 	Light *light = light_owner.get_or_null(p_light);
 	ERR_FAIL_COND(!light);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -1025,7 +1025,6 @@ private:
 		RS::LightType type;
 		float param[RS::LIGHT_PARAM_MAX];
 		Color color = Color(1, 1, 1, 1);
-		Color shadow_color;
 		RID projector;
 		bool shadow = false;
 		bool negative = false;
@@ -1841,7 +1840,6 @@ public:
 	void light_set_color(RID p_light, const Color &p_color);
 	void light_set_param(RID p_light, RS::LightParam p_param, float p_value);
 	void light_set_shadow(RID p_light, bool p_enabled);
-	void light_set_shadow_color(RID p_light, const Color &p_color);
 	void light_set_projector(RID p_light, RID p_texture);
 	void light_set_negative(RID p_light, bool p_enable);
 	void light_set_cull_mask(RID p_light, uint32_t p_mask);
@@ -1888,13 +1886,6 @@ public:
 		ERR_FAIL_COND_V(!light, Color());
 
 		return light->color;
-	}
-
-	_FORCE_INLINE_ Color light_get_shadow_color(RID p_light) {
-		const Light *light = light_owner.get_or_null(p_light);
-		ERR_FAIL_COND_V(!light, Color());
-
-		return light->shadow_color;
 	}
 
 	_FORCE_INLINE_ uint32_t light_get_cull_mask(RID p_light) {

--- a/servers/rendering/renderer_rd/shaders/light_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/light_data_inc.glsl
@@ -76,10 +76,6 @@ struct DirectionalLightData {
 	highp mat4 shadow_matrix2;
 	highp mat4 shadow_matrix3;
 	highp mat4 shadow_matrix4;
-	mediump vec4 shadow_color1;
-	mediump vec4 shadow_color2;
-	mediump vec4 shadow_color3;
-	mediump vec4 shadow_color4;
 	highp vec2 uv_scale1;
 	highp vec2 uv_scale2;
 	highp vec2 uv_scale3;

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -1124,7 +1124,6 @@ void main() {
 				float depth_z = -vertex.z;
 
 				vec4 pssm_coord;
-				vec3 shadow_color = vec3(0.0);
 				vec3 light_dir = directional_lights.data[i].direction;
 
 #define BIAS_FUNC(m_var, m_idx)                                                                                                                                       \
@@ -1150,9 +1149,6 @@ void main() {
 					} else {
 						shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
 					}
-
-					shadow_color = directional_lights.data[i].shadow_color1.rgb;
-
 				} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
 					vec4 v = vec4(vertex, 1.0);
 
@@ -1170,8 +1166,6 @@ void main() {
 					} else {
 						shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
 					}
-
-					shadow_color = directional_lights.data[i].shadow_color2.rgb;
 				} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
 					vec4 v = vec4(vertex, 1.0);
 
@@ -1189,9 +1183,6 @@ void main() {
 					} else {
 						shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
 					}
-
-					shadow_color = directional_lights.data[i].shadow_color3.rgb;
-
 				} else {
 					vec4 v = vec4(vertex, 1.0);
 
@@ -1209,12 +1200,9 @@ void main() {
 					} else {
 						shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
 					}
-
-					shadow_color = directional_lights.data[i].shadow_color4.rgb;
 				}
 
 				if (directional_lights.data[i].blend_splits) {
-					vec3 shadow_color_blend = vec3(0.0);
 					float pssm_blend;
 					float shadow2;
 
@@ -1235,7 +1223,6 @@ void main() {
 						}
 
 						pssm_blend = smoothstep(0.0, directional_lights.data[i].shadow_split_offsets.x, depth_z);
-						shadow_color_blend = directional_lights.data[i].shadow_color2.rgb;
 					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
 						vec4 v = vec4(vertex, 1.0);
 						BIAS_FUNC(v, 2)
@@ -1253,8 +1240,6 @@ void main() {
 						}
 
 						pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x, directional_lights.data[i].shadow_split_offsets.y, depth_z);
-
-						shadow_color_blend = directional_lights.data[i].shadow_color3.rgb;
 					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
 						vec4 v = vec4(vertex, 1.0);
 						BIAS_FUNC(v, 3)
@@ -1271,7 +1256,6 @@ void main() {
 						}
 
 						pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y, directional_lights.data[i].shadow_split_offsets.z, depth_z);
-						shadow_color_blend = directional_lights.data[i].shadow_color4.rgb;
 					} else {
 						pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
 					}
@@ -1279,7 +1263,6 @@ void main() {
 					pssm_blend = sqrt(pssm_blend);
 
 					shadow = mix(shadow, shadow2, pssm_blend);
-					shadow_color = mix(shadow_color, shadow_color_blend, pssm_blend);
 				}
 
 				shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance

--- a/servers/rendering/renderer_rd/shaders/sdfgi_direct_light.glsl
+++ b/servers/rendering/renderer_rd/shaders/sdfgi_direct_light.glsl
@@ -70,8 +70,6 @@ struct Light {
 	float cos_spot_angle;
 	float inv_spot_attenuation;
 	float radius;
-
-	vec4 shadow_color;
 };
 
 layout(set = 0, binding = 9, std140) buffer restrict readonly Lights {

--- a/servers/rendering/renderer_rd/shaders/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/volumetric_fog_process.glsl
@@ -382,7 +382,6 @@ void main() {
 				float depth_z = -view_pos.z;
 
 				vec4 pssm_coord;
-				vec3 shadow_color = directional_lights.data[i].shadow_color1.rgb;
 				vec3 light_dir = directional_lights.data[i].direction;
 				vec4 v = vec4(view_pos, 1.0);
 				float z_range;
@@ -413,7 +412,7 @@ void main() {
 
 				shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, view_pos.z)); //done with negative values for performance
 
-				shadow_attenuation = mix(shadow_color, vec3(1.0), shadow);
+				shadow_attenuation = mix(vec3(0.0), vec3(1.0), shadow);
 			}
 
 			total_light += shadow_attenuation * directional_lights.data[i].color * directional_lights.data[i].energy * henyey_greenstein(dot(normalize(view_pos), normalize(directional_lights.data[i].direction)), params.phase_g);

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -317,7 +317,6 @@ public:
 	virtual void light_set_color(RID p_light, const Color &p_color) = 0;
 	virtual void light_set_param(RID p_light, RS::LightParam p_param, float p_value) = 0;
 	virtual void light_set_shadow(RID p_light, bool p_enabled) = 0;
-	virtual void light_set_shadow_color(RID p_light, const Color &p_color) = 0;
 	virtual void light_set_projector(RID p_light, RID p_texture) = 0;
 	virtual void light_set_negative(RID p_light, bool p_enable) = 0;
 	virtual void light_set_cull_mask(RID p_light, uint32_t p_mask) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -342,7 +342,6 @@ public:
 	FUNC2(light_set_color, RID, const Color &)
 	FUNC3(light_set_param, RID, LightParam, float)
 	FUNC2(light_set_shadow, RID, bool)
-	FUNC2(light_set_shadow_color, RID, const Color &)
 	FUNC2(light_set_projector, RID, RID)
 	FUNC2(light_set_negative, RID, bool)
 	FUNC2(light_set_cull_mask, RID, uint32_t)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1879,7 +1879,6 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("light_set_color", "light", "color"), &RenderingServer::light_set_color);
 	ClassDB::bind_method(D_METHOD("light_set_param", "light", "param", "value"), &RenderingServer::light_set_param);
 	ClassDB::bind_method(D_METHOD("light_set_shadow", "light", "enabled"), &RenderingServer::light_set_shadow);
-	ClassDB::bind_method(D_METHOD("light_set_shadow_color", "light", "color"), &RenderingServer::light_set_shadow_color);
 	ClassDB::bind_method(D_METHOD("light_set_projector", "light", "texture"), &RenderingServer::light_set_projector);
 	ClassDB::bind_method(D_METHOD("light_set_negative", "light", "enable"), &RenderingServer::light_set_negative);
 	ClassDB::bind_method(D_METHOD("light_set_cull_mask", "light", "mask"), &RenderingServer::light_set_cull_mask);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -439,7 +439,6 @@ public:
 	virtual void light_set_color(RID p_light, const Color &p_color) = 0;
 	virtual void light_set_param(RID p_light, LightParam p_param, float p_value) = 0;
 	virtual void light_set_shadow(RID p_light, bool p_enabled) = 0;
-	virtual void light_set_shadow_color(RID p_light, const Color &p_color) = 0;
 	virtual void light_set_projector(RID p_light, RID p_texture) = 0;
 	virtual void light_set_negative(RID p_light, bool p_enable) = 0;
 	virtual void light_set_cull_mask(RID p_light, uint32_t p_mask) = 0;


### PR DESCRIPTION
This shadow color property was no longer effective since the [shaders were optimized to improve occupancy](https://github.com/godotengine/godot/pull/45023). Note that this doesn't affect its Light2D counterpart which still supports per-light shadow colors.

It could technically be supported in the lightmapper (for fully baked lights), but I can't find any references to the per-light shadow color in the GPU lightmapper in `master`.

**Note:** Not cherry-pickable to the `3.x` branch as per-light shadow color is still functional there.