### PR TITLE
Fix equal operation for typed enums

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1779,10 +1779,10 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 	} else {
 		if (p_binary_op->variant_op < Variant::OP_MAX) {
 			bool valid = false;
-			result = get_operation_type(p_binary_op->variant_op, p_binary_op->left_operand->get_datatype(), right_type, valid, p_binary_op);
+			result = get_operation_type(p_binary_op->variant_op, left_type, right_type, valid, p_binary_op);
 
 			if (!valid) {
-				push_error(vformat(R"(Invalid operands "%s" and "%s" for "%s" operator.)", p_binary_op->left_operand->get_datatype().to_string(), right_type.to_string(), Variant::get_operator_name(p_binary_op->variant_op)), p_binary_op);
+				push_error(vformat(R"(Invalid operands "%s" and "%s" for "%s" operator.)", left_type.to_string(), right_type.to_string(), Variant::get_operator_name(p_binary_op->variant_op)), p_binary_op);
 			}
 		} else {
 			if (p_binary_op->operation == GDScriptParser::BinaryOpNode::OP_TYPE_TEST) {
@@ -2349,6 +2349,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 				GDScriptParser::DataType result;
 				result.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
 				result.kind = GDScriptParser::DataType::ENUM_VALUE;
+				result.builtin_type = base.builtin_type;
 				result.native_type = base.native_type;
 				result.enum_type = name;
 				p_identifier->set_datatype(result);


### PR DESCRIPTION
# Summary

Fix #49278

Screen proof: 
<img width="1305" alt="image" src="https://user-images.githubusercontent.com/6003467/121273105-2554cf80-c8d0-11eb-8936-30226bd1a6da.png">

## How I Fix it

`op_binary` can't compare two `builtin_type`. **ENUM_VALUE** returns `Variant::NIL` and **ENUM** returns `Variant::DICTIONARY`. Problem was in default value for `builtin_type`, because for **ENUM_VALUE** we don't set builtin_type and using default `Variant::NIL`
<img width="776" alt="image" src="https://user-images.githubusercontent.com/6003467/121273374-d0fe1f80-c8d0-11eb-9317-372a3899378e.png">
