### PR TITLE
EditorSettings: Ensure `create()` makes a valid singleton

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2373,10 +2373,8 @@ bool Main::start() {
 			}
 
 			// Load SSL Certificates from Editor Settings (or builtin)
-			Crypto::load_default_certificates(EditorSettings::get_singleton()->get_setting(
-																					 "network/ssl/editor_ssl_certificates")
-													  .
-													  operator String());
+			Crypto::load_default_certificates(
+					EditorSettings::get_singleton()->get_setting("network/ssl/editor_ssl_certificates").operator String());
 		}
 #endif
 	}


### PR DESCRIPTION
If `singleton` is not initialized, we can easily get a crash in various code
paths which assume that a call to `EditorSettings::create()` will create a
valid singleton.

Fixes #49179, fixes #49450.
Supersedes #47882.

---

It doesn't fix the fact that we still try to create a `.godot` folder even when not editing project and not having write permissions, but that's a separate issue and I find the workaround in #47882 unsatisfactory. I'll work on this in a follow-up PR.