### PR TITLE
Fix `length()` array function usage in shader

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -447,7 +447,7 @@ public:
 
 		virtual DataType get_datatype() const override { return datatype_cache; }
 		virtual String get_datatype_name() const override { return String(struct_name); }
-		virtual int get_array_size() const override { return array_size; }
+		virtual int get_array_size() const override { return (index_expression || call_expression) ? 0 : array_size; }
 		virtual bool is_indexed() const override { return index_expression != nullptr; }
 
 		ArrayNode() :


### PR DESCRIPTION
I think I broke it in https://github.com/godotengine/godot/pull/48933:

![image](https://user-images.githubusercontent.com/3036176/121349005-b5773100-c931-11eb-8e9b-b3c0dae9ddad.png)

Update:
Also fixes incorrect array element size returning from the arrays:

![image](https://user-images.githubusercontent.com/3036176/121480278-8fa26880-c9d3-11eb-84f2-e0af6360fea3.png)
