### PR TITLE
Ensure inherited default parameter is not redefined

### DIFF
--- a/servers/physics_2d/physics_server_2d_sw.h
+++ b/servers/physics_2d/physics_server_2d_sw.h
@@ -247,8 +247,8 @@ public:
 
 	virtual void body_set_pickable(RID p_body, bool p_pickable) override;
 
-	virtual bool body_test_motion(RID p_body, const Transform2D &p_from, const Vector2 &p_motion, bool p_infinite_inertia, real_t p_margin = 0.08, MotionResult *r_result = nullptr, bool p_exclude_raycast_shapes = true) override;
-	virtual int body_test_ray_separation(RID p_body, const Transform2D &p_transform, bool p_infinite_inertia, Vector2 &r_recover_motion, SeparationResult *r_results, int p_result_max, real_t p_margin = 0.08) override;
+	virtual bool body_test_motion(RID p_body, const Transform2D &p_from, const Vector2 &p_motion, bool p_infinite_inertia, real_t p_margin = 0.001, MotionResult *r_result = nullptr, bool p_exclude_raycast_shapes = true) override;
+	virtual int body_test_ray_separation(RID p_body, const Transform2D &p_transform, bool p_infinite_inertia, Vector2 &r_recover_motion, SeparationResult *r_results, int p_result_max, real_t p_margin = 0.001) override;
 
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectBodyState2D *body_get_direct_state(RID p_body) override;


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/?mode=tree&ruleFocus=2153510663), #48908 changed the default values for the inherited functions `body_test_motion()` and `body_test_ray_separation()`'s `p_margin` values in `physics_server_2d_sw.h` to be different from the parent default values in `physics_server_2d.h`:
https://github.com/godotengine/godot/blob/f178e7abd7d0af21d326f2e818bcd07a487b19fe/servers/physics_server_2d.h#L503
https://github.com/godotengine/godot/blob/f178e7abd7d0af21d326f2e818bcd07a487b19fe/servers/physics_server_2d.h#L517
"Inherited default parameters should not be redefined because this obscures the behavior of the code. Default values are statically bound and when they are redefined in dynamically bound function calls this reduces readability of the code, increasing the risk of introducing defects."[[1](https://lgtm.com/rules/2153510663/)]

This PR reverts that change so the inherited default values are once again the same as the parent's default values.

Note: The confusion comes from the fact that this function is called by `_body_test_motion()` (with an underscore) that passes a defined (non-default) value into `body_test_motion()`:
https://github.com/godotengine/godot/blob/f178e7abd7d0af21d326f2e818bcd07a487b19fe/servers/physics_server_2d.cpp#L514-L520
`_body_test_motion()` `p_margin`'s default value is 0.08:
https://github.com/godotengine/godot/blob/f178e7abd7d0af21d326f2e818bcd07a487b19fe/servers/physics_server_2d.h#L233
And it's `_body_test_motion()` that is exposed as `body_test_motion()`:
https://github.com/godotengine/godot/blob/f178e7abd7d0af21d326f2e818bcd07a487b19fe/servers/physics_server_2d.cpp#L646

I've have previously suggested fixing this, so the values are all 0.001 by default as is the case in 3D physics: #45361 (and it's 3.x version: #45362). Perhaps we should reopen those PRs.