### PR TITLE
Rename get_parent_spatial() to get_parent_node_3d()

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -20,7 +20,7 @@
 				Forces the transform to update. Transform changes in physics are not instant for performance reasons. Transforms are accumulated and then set. Use this if you need an up-to-date transform when doing physics operations.
 			</description>
 		</method>
-		<method name="get_parent_spatial" qualifiers="const">
+		<method name="get_parent_node_3d" qualifiers="const">
 			<return type="Node3D">
 			</return>
 			<description>

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1213,7 +1213,7 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 					Node3D *n = src_mesh_node;
 					while (n) {
 						xf = n->get_transform() * xf;
-						n = n->get_parent_spatial();
+						n = n->get_parent_node_3d();
 					}
 
 					Vector<uint8_t> lightmap_cache;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -282,8 +282,12 @@ Transform3D Node3D::get_local_gizmo_transform() const {
 }
 #endif
 
-Node3D *Node3D::get_parent_spatial() const {
-	return data.parent;
+Node3D *Node3D::get_parent_node_3d() const {
+	if (data.top_level) {
+		return nullptr;
+	}
+
+	return Object::cast_to<Node3D>(get_parent());
 }
 
 Transform3D Node3D::get_relative_transform(const Node *p_parent) const {
@@ -703,7 +707,7 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_scale"), &Node3D::get_scale);
 	ClassDB::bind_method(D_METHOD("set_global_transform", "global"), &Node3D::set_global_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &Node3D::get_global_transform);
-	ClassDB::bind_method(D_METHOD("get_parent_spatial"), &Node3D::get_parent_spatial);
+	ClassDB::bind_method(D_METHOD("get_parent_node_3d"), &Node3D::get_parent_node_3d);
 	ClassDB::bind_method(D_METHOD("set_ignore_transform_notification", "enabled"), &Node3D::set_ignore_transform_notification);
 	ClassDB::bind_method(D_METHOD("set_as_top_level", "enable"), &Node3D::set_as_top_level);
 	ClassDB::bind_method(D_METHOD("is_set_as_top_level"), &Node3D::is_set_as_top_level);

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -118,7 +118,7 @@ public:
 		NOTIFICATION_LOCAL_TRANSFORM_CHANGED = 44,
 	};
 
-	Node3D *get_parent_spatial() const;
+	Node3D *get_parent_node_3d() const;
 
 	Ref<World3D> get_world_3d() const;
 


### PR DESCRIPTION
Renames `get_parent_spatial()` to `get_parent_node_3d()` and changes its implementation. Before it was not returning a correct pointer if the node wasn't added to a SceneTree. Now it uses the same implementation as CanvasItem, which will be correct even for nodes outside a SceneTree.

Fixes #49414.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
