### PR TITLE
Add rotation ability to material editor preview.

### DIFF
--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -40,6 +40,19 @@
 #include "scene/resources/particle_process_material.h"
 #include "scene/resources/sky_material.h"
 
+void MaterialEditor::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid() && (mm->get_button_mask() & MouseButton::MASK_LEFT) != MouseButton::NONE) {
+		rot.x -= mm->get_relative().y * 0.01;
+		rot.y -= mm->get_relative().x * 0.01;
+
+		rot.x = CLAMP(rot.x, -Math_PI / 2, Math_PI / 2);
+		_update_rotation();
+	}
+}
+
 void MaterialEditor::_update_theme_item_cache() {
 	Control::_update_theme_item_cache();
 
@@ -77,6 +90,13 @@ void MaterialEditor::_notification(int p_what) {
 	}
 }
 
+void MaterialEditor::_update_rotation() {
+	Transform3D t;
+	t.basis.rotate(Vector3(0, 1, 0), -rot.y);
+	t.basis.rotate(Vector3(1, 0, 0), -rot.x);
+	rotation->set_transform(t);
+}
+
 void MaterialEditor::edit(Ref<Material> p_material, const Ref<Environment> &p_env) {
 	material = p_material;
 	camera->set_environment(p_env);
@@ -102,6 +122,10 @@ void MaterialEditor::edit(Ref<Material> p_material, const Ref<Environment> &p_en
 	} else {
 		hide();
 	}
+
+	rot.x = Math::deg_to_rad(-15.0);
+	rot.y = Math::deg_to_rad(30.0);
+	_update_rotation();
 }
 
 void MaterialEditor::_button_pressed(Node *p_button) {
@@ -128,9 +152,6 @@ void MaterialEditor::_button_pressed(Node *p_button) {
 		sphere_switch->set_pressed(true);
 		EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_on_sphere", true);
 	}
-}
-
-void MaterialEditor::_bind_methods() {
 }
 
 MaterialEditor::MaterialEditor() {
@@ -163,7 +184,7 @@ MaterialEditor::MaterialEditor() {
 	viewport->set_msaa_3d(Viewport::MSAA_4X);
 
 	camera = memnew(Camera3D);
-	camera->set_transform(Transform3D(Basis(), Vector3(0, 0, 3)));
+	camera->set_transform(Transform3D(Basis(), Vector3(0, 0, 1.1)));
 	// Use low field of view so the sphere/box is fully encompassed within the preview,
 	// without much distortion.
 	camera->set_perspective(20, 0.1, 10);
@@ -183,18 +204,17 @@ MaterialEditor::MaterialEditor() {
 	light2->set_color(Color(0.7, 0.7, 0.7));
 	viewport->add_child(light2);
 
+	rotation = memnew(Node3D);
+	viewport->add_child(rotation);
+
 	sphere_instance = memnew(MeshInstance3D);
-	viewport->add_child(sphere_instance);
+	rotation->add_child(sphere_instance);
 
 	box_instance = memnew(MeshInstance3D);
-	viewport->add_child(box_instance);
+	rotation->add_child(box_instance);
 
-	Transform3D box_xform;
-	box_xform.basis.rotate(Vector3(1, 0, 0), Math::deg_to_rad(25.0));
-	box_xform.basis = box_xform.basis * Basis().rotated(Vector3(0, 1, 0), Math::deg_to_rad(-25.0));
-	box_xform.basis.scale(Vector3(0.7, 0.7, 0.7));
-	box_xform.origin.y = 0.05;
-	box_instance->set_transform(box_xform);
+	box_instance->set_transform(Transform3D() * 0.25);
+	sphere_instance->set_transform(Transform3D() * 0.375);
 
 	sphere_mesh.instantiate();
 	sphere_instance->set_mesh(sphere_mesh);

--- a/editor/plugins/material_editor_plugin.h
+++ b/editor/plugins/material_editor_plugin.h
@@ -45,11 +45,14 @@ class SubViewportContainer;
 class MaterialEditor : public Control {
 	GDCLASS(MaterialEditor, Control);
 
+	Vector2 rot = Vector2();
+
 	HBoxContainer *layout_2d = nullptr;
 	ColorRect *rect_instance = nullptr;
 
 	SubViewportContainer *vc = nullptr;
 	SubViewport *viewport = nullptr;
+	Node3D *rotation = nullptr;
 	MeshInstance3D *sphere_instance = nullptr;
 	MeshInstance3D *box_instance = nullptr;
 	DirectionalLight3D *light1 = nullptr;
@@ -87,7 +90,8 @@ class MaterialEditor : public Control {
 protected:
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
-	static void _bind_methods();
+	void gui_input(const Ref<InputEvent> &p_event) override;
+	void _update_rotation();
 
 public:
 	void edit(Ref<Material> p_material, const Ref<Environment> &p_env);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Mesh editor(Inspector while selecting MeshInstance3D) already  had the ability to rotate the preview of currently edited mesh.

That feature is added to material editor.Just  a copy paste from mesh_editor class.


Normal Preview:

https://user-images.githubusercontent.com/17506575/121393295-ef672800-c96f-11eb-9e21-1c28b7acffc1.mp4


Shader Preview:

https://user-images.githubusercontent.com/17506575/121393318-f3934580-c96f-11eb-8ac5-b6017b814c0e.mp4



Useful especially while shader editor is zoomed. If more primitives are added along with the built in sphere and cube then, it low key would act like that scrapped dedicated shader editor PR.
![shader editor full screen](https://user-images.githubusercontent.com/17506575/121393153-cd6da580-c96f-11eb-821d-ec2be68ce37b.png)
