### PR TITLE
Fix Control::get_screen_position() not considering viewport scale

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1504,7 +1504,7 @@ Point2 Control::get_global_position() const {
 
 Point2 Control::get_screen_position() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), Point2());
-	Point2 global_pos = get_global_position();
+	Point2 global_pos = get_viewport()->get_canvas_transform().xform(get_global_position());
 	Window *w = Object::cast_to<Window>(get_viewport());
 	if (w && !w->is_embedding_subwindows()) {
 		global_pos += w->get_position();


### PR DESCRIPTION
If active camera has non-default zoom, `Control:get_screen_position()` does not return correct screen position. This PR fixes it.

Discovered while working on #49376