### PR TITLE
Make sure Variant is not implicitely cast when using operator[]

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -346,6 +346,10 @@ public:
 	bool is_one() const;
 	bool is_null() const;
 
+	// Make sure Variant is not implicitly cast when accessing it with bracket notation (GH-49469).
+	Variant &operator[](const Variant &p_key) = delete;
+	const Variant &operator[](const Variant &p_key) const = delete;
+
 	operator bool() const;
 	operator signed int() const;
 	operator unsigned int() const; // this is the real one


### PR DESCRIPTION
Without this change, doing something like:
```
Variant test;
print_line(test["test"]);
```
could compile fine in C++. 

In this case, `test` Variant would be implicitly cast to `int64_t`, which would fail, and thus lead to an int64_t of value 0. This means that print_line would print `0["test"]`, which is equivalent to `"test"[0]`, which itself is equivalent to the character 't'.
Consequently, those two lines would compile fine and print 116, the decimal ASCII value of the 't' character.

As you can imagine, I spent some time trying to understand what was happening... (thanks @JFonS for the explanation).
To avoid the compiler to accept such lines of code, @hpvb suggested these changes. They seem to fix the problem as my compiler now throws this error:
![2021-06-09-212212_996x46_scrot](https://user-images.githubusercontent.com/6093119/121416177-ca22eb80-c968-11eb-9fb9-9f49b78dc177.png)

And even if the operator is not ambiguous (with `test[Variant("test")]`) it still fails at compile time:
![2021-06-09-212337_865x36_scrot](https://user-images.githubusercontent.com/6093119/121416338-fccce400-c968-11eb-9bc8-a4e43cfa45db.png)

So yeah, it solves the issue pretty well.

Of course, @hpvb, I added you as co-author.