### PR TITLE
Update File.store_var description to mention which properties of an object are included.

### DIFF
--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -486,6 +486,7 @@
 			</argument>
 			<description>
 				Stores any Variant value in the file. If [code]full_objects[/code] is [code]true[/code], encoding objects is allowed (and can potentially include code).
+				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object._get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
This update is in response to discussion at https://github.com/godotengine/godot/issues/49430.