### PR TITLE
Make LineShape2D normal point upwards by default

### DIFF
--- a/doc/classes/LineShape2D.xml
+++ b/doc/classes/LineShape2D.xml
@@ -14,8 +14,8 @@
 		<member name="distance" type="float" setter="set_distance" getter="get_distance" default="0.0">
 			The line's distance from the origin.
 		</member>
-		<member name="normal" type="Vector2" setter="set_normal" getter="get_normal" default="Vector2(0, 1)">
-			The line's normal.
+		<member name="normal" type="Vector2" setter="set_normal" getter="get_normal" default="Vector2(0, -1)">
+			The line's normal. Defaults to [code]Vector2.UP[/code].
 		</member>
 	</members>
 	<constants>

--- a/scene/resources/line_shape_2d.h
+++ b/scene/resources/line_shape_2d.h
@@ -36,7 +36,8 @@
 class LineShape2D : public Shape2D {
 	GDCLASS(LineShape2D, Shape2D);
 
-	Vector2 normal = Vector2(0, 1);
+	// LineShape2D is often used for one-way platforms, where the normal pointing up makes sense.
+	Vector2 normal = Vector2(0, -1);
 	real_t distance = 0.0;
 
 	void _update_shape();


### PR DESCRIPTION
Allows line shapes to collide with bodies falling from the top by default (otherwise they fall through), which makes more sense for the most common cases.

This PR doesn't break compatibility as it just reverts a change from #33613 (cc @aaronfranke).