### PR TITLE
[3.x] Backport non-breaking changes in the `Theme` resource from `master`

### DIFF
--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -109,6 +109,13 @@
 				Returns all the [Color]s as a [PoolStringArray] filled with each [Color]'s name, for use in [method get_color], if the theme has [code]node_type[/code].
 			</description>
 		</method>
+		<method name="get_color_types" qualifiers="const">
+			<return type="PoolStringArray">
+			</return>
+			<description>
+				Returns all the [Color] types as a [PoolStringArray] filled with unique type names, for use in [method get_color] and/or [method get_color_list].
+			</description>
+		</method>
 		<method name="get_constant" qualifiers="const">
 			<return type="int">
 			</return>
@@ -127,6 +134,13 @@
 			</argument>
 			<description>
 				Returns all the constants as a [PoolStringArray] filled with each constant's name, for use in [method get_constant], if the theme has [code]node_type[/code].
+			</description>
+		</method>
+		<method name="get_constant_types" qualifiers="const">
+			<return type="PoolStringArray">
+			</return>
+			<description>
+				Returns all the constant types as a [PoolStringArray] filled with unique type names, for use in [method get_constant] and/or [method get_constant_list].
 			</description>
 		</method>
 		<method name="get_font" qualifiers="const">
@@ -149,6 +163,13 @@
 				Returns all the [Font]s as a [PoolStringArray] filled with each [Font]'s name, for use in [method get_font], if the theme has [code]node_type[/code].
 			</description>
 		</method>
+		<method name="get_font_types" qualifiers="const">
+			<return type="PoolStringArray">
+			</return>
+			<description>
+				Returns all the [Font] types as a [PoolStringArray] filled with unique type names, for use in [method get_font] and/or [method get_font_list].
+			</description>
+		</method>
 		<method name="get_icon" qualifiers="const">
 			<return type="Texture">
 			</return>
@@ -167,6 +188,13 @@
 			</argument>
 			<description>
 				Returns all the icons as a [PoolStringArray] filled with each [Texture]'s name, for use in [method get_icon], if the theme has [code]node_type[/code].
+			</description>
+		</method>
+		<method name="get_icon_types" qualifiers="const">
+			<return type="PoolStringArray">
+			</return>
+			<description>
+				Returns all the icon types as a [PoolStringArray] filled with unique type names, for use in [method get_icon] and/or [method get_icon_list].
 			</description>
 		</method>
 		<method name="get_stylebox" qualifiers="const">
@@ -195,7 +223,7 @@
 			<return type="PoolStringArray">
 			</return>
 			<description>
-				Returns all the [StyleBox] types as a [PoolStringArray] filled with each [StyleBox]'s type, for use in [method get_stylebox] and/or [method get_stylebox_list], if the theme has [code]node_type[/code].
+				Returns all the [StyleBox] types as a [PoolStringArray] filled with unique type names, for use in [method get_stylebox] and/or [method get_stylebox_list].
 			</description>
 		</method>
 		<method name="get_type_list" qualifiers="const">
@@ -204,7 +232,8 @@
 			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the types in [code]node_type[/code] as a [PoolStringArray] for use in any of the [code]get_*[/code] functions, if the theme has [code]node_type[/code].
+				Returns all the theme types as a [PoolStringArray] filled with unique type names, for use in other [code]get_*[/code] functions of this theme.
+				[b]Note:[/b] [code]node_type[/code] has no effect and will be removed in future version.
 			</description>
 		</method>
 		<method name="has_color" qualifiers="const">

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -73,6 +73,19 @@
 				Clears [StyleBox] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
+		<method name="clear_theme_item">
+			<return type="void">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<argument index="2" name="node_type" type="String">
+			</argument>
+			<description>
+				Clears the theme item of [code]data_type[/code] at [code]name[/code] if the theme has [code]node_type[/code].
+			</description>
+		</method>
 		<method name="copy_default_theme">
 			<return type="void">
 			</return>
@@ -226,6 +239,41 @@
 				Returns all the [StyleBox] types as a [PoolStringArray] filled with unique type names, for use in [method get_stylebox] and/or [method get_stylebox_list].
 			</description>
 		</method>
+		<method name="get_theme_item" qualifiers="const">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<argument index="2" name="node_type" type="String">
+			</argument>
+			<description>
+				Returns the theme item of [code]data_type[/code] at [code]name[/code] if the theme has [code]node_type[/code].
+				Valid [code]name[/code]s may be found using [method get_theme_item_list] or a data type specific method. Valid [code]node_type[/code]s may be found using [method get_theme_item_types] or a data type specific method.
+			</description>
+		</method>
+		<method name="get_theme_item_list" qualifiers="const">
+			<return type="PoolStringArray">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="node_type" type="String">
+			</argument>
+			<description>
+				Returns all the theme items of [code]data_type[/code] as a [PoolStringArray] filled with each theme items's name, for use in [method get_theme_item] or a data type specific method, if the theme has [code]node_type[/code].
+				Valid [code]node_type[/code]s may be found using [method get_theme_item_types] or a data type specific method.
+			</description>
+		</method>
+		<method name="get_theme_item_types" qualifiers="const">
+			<return type="PoolStringArray">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<description>
+				Returns all the theme items of [code]data_type[/code] types as a [PoolStringArray] filled with unique type names, for use in [method get_theme_item], [method get_theme_item_list] or data type specific methods.
+			</description>
+		</method>
 		<method name="get_type_list" qualifiers="const">
 			<return type="PoolStringArray">
 			</return>
@@ -296,6 +344,100 @@
 				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
+		<method name="has_theme_item" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<argument index="2" name="node_type" type="String">
+			</argument>
+			<description>
+				Returns [code]true[/code] if a theme item of [code]data_type[/code] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
+			</description>
+		</method>
+		<method name="rename_color">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="String">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<argument index="2" name="node_type" type="String">
+			</argument>
+			<description>
+				Renames the [Color] at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_constant">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="String">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<argument index="2" name="node_type" type="String">
+			</argument>
+			<description>
+				Renames the constant at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_font">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="String">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<argument index="2" name="node_type" type="String">
+			</argument>
+			<description>
+				Renames the [Font] at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_icon">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="String">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<argument index="2" name="node_type" type="String">
+			</argument>
+			<description>
+				Renames the icon at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_stylebox">
+			<return type="void">
+			</return>
+			<argument index="0" name="old_name" type="String">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<argument index="2" name="node_type" type="String">
+			</argument>
+			<description>
+				Renames [StyleBox] at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
+		<method name="rename_theme_item">
+			<return type="void">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="old_name" type="String">
+			</argument>
+			<argument index="2" name="name" type="String">
+			</argument>
+			<argument index="3" name="node_type" type="String">
+			</argument>
+			<description>
+				Renames the theme item of [code]data_type[/code] at [code]old_name[/code] to [code]name[/code] if the theme has [code]node_type[/code]. If [code]name[/code] is already taken, this method fails.
+			</description>
+		</method>
 		<method name="set_color">
 			<return type="void">
 			</return>
@@ -307,7 +449,7 @@
 			</argument>
 			<description>
 				Sets the theme's [Color] to [code]color[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 		<method name="set_constant">
@@ -321,7 +463,7 @@
 			</argument>
 			<description>
 				Sets the theme's constant to [code]constant[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 		<method name="set_font">
@@ -335,7 +477,7 @@
 			</argument>
 			<description>
 				Sets the theme's [Font] to [code]font[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 		<method name="set_icon">
@@ -349,7 +491,7 @@
 			</argument>
 			<description>
 				Sets the theme's icon [Texture] to [code]texture[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 		<method name="set_stylebox">
@@ -363,7 +505,24 @@
 			</argument>
 			<description>
 				Sets theme's [StyleBox] to [code]stylebox[/code] at [code]name[/code] in [code]node_type[/code].
-				Does nothing if the theme does not have [code]node_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
+			</description>
+		</method>
+		<method name="set_theme_item">
+			<return type="void">
+			</return>
+			<argument index="0" name="data_type" type="int" enum="Theme.DataType">
+			</argument>
+			<argument index="1" name="name" type="String">
+			</argument>
+			<argument index="2" name="node_type" type="String">
+			</argument>
+			<argument index="3" name="value" type="Variant">
+			</argument>
+			<description>
+				Sets the theme item of [code]data_type[/code] to [code]value[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the [code]value[/code] type does not match [code]data_type[/code].
+				Creates [code]node_type[/code] if the theme does not have it.
 			</description>
 		</method>
 	</methods>
@@ -373,5 +532,23 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="DATA_TYPE_COLOR" value="0" enum="DataType">
+			Theme's [Color] item type.
+		</constant>
+		<constant name="DATA_TYPE_CONSTANT" value="1" enum="DataType">
+			Theme's constant item type.
+		</constant>
+		<constant name="DATA_TYPE_FONT" value="2" enum="DataType">
+			Theme's [Font] item type.
+		</constant>
+		<constant name="DATA_TYPE_ICON" value="3" enum="DataType">
+			Theme's icon [Texture] item type.
+		</constant>
+		<constant name="DATA_TYPE_STYLEBOX" value="4" enum="DataType">
+			Theme's [StyleBox] item type.
+		</constant>
+		<constant name="DATA_TYPE_MAX" value="5" enum="DataType">
+			Maximum value for the DataType enum.
+		</constant>
 	</constants>
 </class>

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -965,6 +965,7 @@ Color Control::get_color(const StringName &p_name, const StringName &p_node_type
 	}
 
 	StringName type = p_node_type ? p_node_type : get_class_name();
+
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
 
@@ -1005,6 +1006,7 @@ int Control::get_constant(const StringName &p_name, const StringName &p_node_typ
 	}
 
 	StringName type = p_node_type ? p_node_type : get_class_name();
+
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
 
@@ -1098,7 +1100,7 @@ bool Control::has_icon(const StringName &p_name, const StringName &p_node_type) 
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_color(p_name, type)) {
+		if (Theme::get_project_default()->has_icon(p_name, type)) {
 			return true;
 		}
 	}

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -186,6 +186,44 @@ PoolVector<String> Theme::_get_constant_types() const {
 	return ilret;
 }
 
+PoolVector<String> Theme::_get_theme_item_list(DataType p_data_type, const String &p_node_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return _get_color_list(p_node_type);
+		case DATA_TYPE_CONSTANT:
+			return _get_constant_list(p_node_type);
+		case DATA_TYPE_FONT:
+			return _get_font_list(p_node_type);
+		case DATA_TYPE_ICON:
+			return _get_icon_list(p_node_type);
+		case DATA_TYPE_STYLEBOX:
+			return _get_stylebox_list(p_node_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return PoolVector<String>();
+}
+
+PoolVector<String> Theme::_get_theme_item_types(DataType p_data_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return _get_color_types();
+		case DATA_TYPE_CONSTANT:
+			return _get_constant_types();
+		case DATA_TYPE_FONT:
+			return _get_font_types();
+		case DATA_TYPE_ICON:
+			return _get_icon_types();
+		case DATA_TYPE_STYLEBOX:
+			return _get_stylebox_types();
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return PoolVector<String>();
+}
+
 PoolVector<String> Theme::_get_type_list(const String &p_node_type) const {
 	PoolVector<String> ilret;
 	List<StringName> il;
@@ -386,8 +424,6 @@ void Theme::set_default_font(const Ref<Font> &p_font) {
 }
 
 void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture> &p_icon) {
-	//ERR_FAIL_COND(p_icon.is_null());
-
 	bool new_value = !icon_map.has(p_node_type) || !icon_map[p_node_type].has(p_name);
 
 	if (icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
@@ -418,9 +454,21 @@ bool Theme::has_icon(const StringName &p_name, const StringName &p_node_type) co
 	return (icon_map.has(p_node_type) && icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid());
 }
 
+void Theme::rename_icon(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!icon_map.has(p_node_type), "Cannot rename the icon '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(icon_map[p_node_type].has(p_name), "Cannot rename the icon '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!icon_map[p_node_type].has(p_old_name), "Cannot rename the icon '" + String(p_old_name) + "' because it does not exist.");
+
+	icon_map[p_node_type][p_name] = icon_map[p_node_type][p_old_name];
+	icon_map[p_node_type].erase(p_old_name);
+
+	_change_notify();
+	emit_changed();
+}
+
 void Theme::clear_icon(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!icon_map.has(p_node_type));
-	ERR_FAIL_COND(!icon_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!icon_map.has(p_node_type), "Cannot clear the icon '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!icon_map[p_node_type].has(p_name), "Cannot clear the icon '" + String(p_name) + "' because it does not exist.");
 
 	if (icon_map[p_node_type][p_name].is_valid()) {
 		icon_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
@@ -444,6 +492,13 @@ void Theme::get_icon_list(StringName p_node_type, List<StringName> *p_list) cons
 	while ((key = icon_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
+}
+
+void Theme::add_icon_type(const StringName &p_node_type) {
+	if (icon_map.has(p_node_type)) {
+		return;
+	}
+	icon_map[p_node_type] = HashMap<StringName, Ref<Texture>>();
 }
 
 void Theme::get_icon_types(List<StringName> *p_list) const {
@@ -502,8 +557,6 @@ void Theme::get_shader_list(const StringName &p_node_type, List<StringName> *p_l
 }
 
 void Theme::set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style) {
-	//ERR_FAIL_COND(p_style.is_null());
-
 	bool new_value = !style_map.has(p_node_type) || !style_map[p_node_type].has(p_name);
 
 	if (style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid()) {
@@ -534,9 +587,21 @@ bool Theme::has_stylebox(const StringName &p_name, const StringName &p_node_type
 	return (style_map.has(p_node_type) && style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid());
 }
 
+void Theme::rename_stylebox(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!style_map.has(p_node_type), "Cannot rename the stylebox '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(style_map[p_node_type].has(p_name), "Cannot rename the stylebox '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!style_map[p_node_type].has(p_old_name), "Cannot rename the stylebox '" + String(p_old_name) + "' because it does not exist.");
+
+	style_map[p_node_type][p_name] = style_map[p_node_type][p_old_name];
+	style_map[p_node_type].erase(p_old_name);
+
+	_change_notify();
+	emit_changed();
+}
+
 void Theme::clear_stylebox(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!style_map.has(p_node_type));
-	ERR_FAIL_COND(!style_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!style_map.has(p_node_type), "Cannot clear the stylebox '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!style_map[p_node_type].has(p_name), "Cannot clear the stylebox '" + String(p_name) + "' because it does not exist.");
 
 	if (style_map[p_node_type][p_name].is_valid()) {
 		style_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
@@ -562,6 +627,13 @@ void Theme::get_stylebox_list(StringName p_node_type, List<StringName> *p_list) 
 	}
 }
 
+void Theme::add_stylebox_type(const StringName &p_node_type) {
+	if (style_map.has(p_node_type)) {
+		return;
+	}
+	style_map[p_node_type] = HashMap<StringName, Ref<StyleBox>>();
+}
+
 void Theme::get_stylebox_types(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
@@ -572,8 +644,6 @@ void Theme::get_stylebox_types(List<StringName> *p_list) const {
 }
 
 void Theme::set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font) {
-	//ERR_FAIL_COND(p_font.is_null());
-
 	bool new_value = !font_map.has(p_node_type) || !font_map[p_node_type].has(p_name);
 
 	if (font_map[p_node_type][p_name].is_valid()) {
@@ -606,9 +676,21 @@ bool Theme::has_font(const StringName &p_name, const StringName &p_node_type) co
 	return (font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid());
 }
 
+void Theme::rename_font(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!font_map.has(p_node_type), "Cannot rename the font '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(font_map[p_node_type].has(p_name), "Cannot rename the font '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!font_map[p_node_type].has(p_old_name), "Cannot rename the font '" + String(p_old_name) + "' because it does not exist.");
+
+	font_map[p_node_type][p_name] = font_map[p_node_type][p_old_name];
+	font_map[p_node_type].erase(p_old_name);
+
+	_change_notify();
+	emit_changed();
+}
+
 void Theme::clear_font(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!font_map.has(p_node_type));
-	ERR_FAIL_COND(!font_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!font_map.has(p_node_type), "Cannot clear the font '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!font_map[p_node_type].has(p_name), "Cannot clear the font '" + String(p_name) + "' because it does not exist.");
 
 	if (font_map[p_node_type][p_name].is_valid()) {
 		font_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
@@ -631,6 +713,13 @@ void Theme::get_font_list(StringName p_node_type, List<StringName> *p_list) cons
 	while ((key = font_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
+}
+
+void Theme::add_font_type(const StringName &p_node_type) {
+	if (font_map.has(p_node_type)) {
+		return;
+	}
+	font_map[p_node_type] = HashMap<StringName, Ref<Font>>();
 }
 
 void Theme::get_font_types(List<StringName> *p_list) const {
@@ -665,9 +754,21 @@ bool Theme::has_color(const StringName &p_name, const StringName &p_node_type) c
 	return (color_map.has(p_node_type) && color_map[p_node_type].has(p_name));
 }
 
+void Theme::rename_color(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!color_map.has(p_node_type), "Cannot rename the color '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(color_map[p_node_type].has(p_name), "Cannot rename the color '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!color_map[p_node_type].has(p_old_name), "Cannot rename the color '" + String(p_old_name) + "' because it does not exist.");
+
+	color_map[p_node_type][p_name] = color_map[p_node_type][p_old_name];
+	color_map[p_node_type].erase(p_old_name);
+
+	_change_notify();
+	emit_changed();
+}
+
 void Theme::clear_color(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!color_map.has(p_node_type));
-	ERR_FAIL_COND(!color_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!color_map.has(p_node_type), "Cannot clear the color '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!color_map[p_node_type].has(p_name), "Cannot clear the color '" + String(p_name) + "' because it does not exist.");
 
 	color_map[p_node_type].erase(p_name);
 	_change_notify();
@@ -686,6 +787,13 @@ void Theme::get_color_list(StringName p_node_type, List<StringName> *p_list) con
 	while ((key = color_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
+}
+
+void Theme::add_color_type(const StringName &p_node_type) {
+	if (color_map.has(p_node_type)) {
+		return;
+	}
+	color_map[p_node_type] = HashMap<StringName, Color>();
 }
 
 void Theme::get_color_types(List<StringName> *p_list) const {
@@ -719,9 +827,21 @@ bool Theme::has_constant(const StringName &p_name, const StringName &p_node_type
 	return (constant_map.has(p_node_type) && constant_map[p_node_type].has(p_name));
 }
 
+void Theme::rename_constant(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND_MSG(!constant_map.has(p_node_type), "Cannot rename the constant '" + String(p_old_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(constant_map[p_node_type].has(p_name), "Cannot rename the constant '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!constant_map[p_node_type].has(p_old_name), "Cannot rename the constant '" + String(p_old_name) + "' because it does not exist.");
+
+	constant_map[p_node_type][p_name] = constant_map[p_node_type][p_old_name];
+	constant_map[p_node_type].erase(p_old_name);
+
+	_change_notify();
+	emit_changed();
+}
+
 void Theme::clear_constant(const StringName &p_name, const StringName &p_node_type) {
-	ERR_FAIL_COND(!constant_map.has(p_node_type));
-	ERR_FAIL_COND(!constant_map[p_node_type].has(p_name));
+	ERR_FAIL_COND_MSG(!constant_map.has(p_node_type), "Cannot clear the constant '" + String(p_name) + "' because the node type '" + String(p_node_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!constant_map[p_node_type].has(p_name), "Cannot clear the constant '" + String(p_name) + "' because it does not exist.");
 
 	constant_map[p_node_type].erase(p_name);
 	_change_notify();
@@ -742,12 +862,204 @@ void Theme::get_constant_list(StringName p_node_type, List<StringName> *p_list) 
 	}
 }
 
+void Theme::add_constant_type(const StringName &p_node_type) {
+	if (constant_map.has(p_node_type)) {
+		return;
+	}
+	constant_map[p_node_type] = HashMap<StringName, int>();
+}
+
 void Theme::get_constant_types(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
 	const StringName *key = nullptr;
 	while ((key = constant_map.next(key))) {
 		p_list->push_back(*key);
+	}
+}
+
+void Theme::set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type, const Variant &p_value) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::COLOR, "Theme item's data type (Color) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Color color_value = p_value;
+			set_color(p_name, p_node_type, color_value);
+		} break;
+		case DATA_TYPE_CONSTANT: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::INT, "Theme item's data type (int) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			int constant_value = p_value;
+			set_constant(p_name, p_node_type, constant_value);
+		} break;
+		case DATA_TYPE_FONT: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<Font> font_value = Object::cast_to<Font>(p_value);
+			set_font(p_name, p_node_type, font_value);
+		} break;
+		case DATA_TYPE_ICON: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<Texture> icon_value = Object::cast_to<Texture>(p_value);
+			set_icon(p_name, p_node_type, icon_value);
+		} break;
+		case DATA_TYPE_STYLEBOX: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<StyleBox> stylebox_value = Object::cast_to<StyleBox>(p_value);
+			set_stylebox(p_name, p_node_type, stylebox_value);
+		} break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+Variant Theme::get_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return get_color(p_name, p_node_type);
+		case DATA_TYPE_CONSTANT:
+			return get_constant(p_name, p_node_type);
+		case DATA_TYPE_FONT:
+			return get_font(p_name, p_node_type);
+		case DATA_TYPE_ICON:
+			return get_icon(p_name, p_node_type);
+		case DATA_TYPE_STYLEBOX:
+			return get_stylebox(p_name, p_node_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return Variant();
+}
+
+bool Theme::has_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			return has_color(p_name, p_node_type);
+		case DATA_TYPE_CONSTANT:
+			return has_constant(p_name, p_node_type);
+		case DATA_TYPE_FONT:
+			return has_font(p_name, p_node_type);
+		case DATA_TYPE_ICON:
+			return has_icon(p_name, p_node_type);
+		case DATA_TYPE_STYLEBOX:
+			return has_stylebox(p_name, p_node_type);
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+
+	return false;
+}
+
+void Theme::rename_theme_item(DataType p_data_type, const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			rename_color(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			rename_constant(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_FONT:
+			rename_font(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_ICON:
+			rename_icon(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			rename_stylebox(p_old_name, p_name, p_node_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::clear_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			clear_color(p_name, p_node_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			clear_constant(p_name, p_node_type);
+			break;
+		case DATA_TYPE_FONT:
+			clear_font(p_name, p_node_type);
+			break;
+		case DATA_TYPE_ICON:
+			clear_icon(p_name, p_node_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			clear_stylebox(p_name, p_node_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::get_theme_item_list(DataType p_data_type, StringName p_node_type, List<StringName> *p_list) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			get_color_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_CONSTANT:
+			get_constant_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_FONT:
+			get_font_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_ICON:
+			get_icon_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			get_stylebox_list(p_node_type, p_list);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::add_theme_item_type(DataType p_data_type, const StringName &p_node_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			add_color_type(p_node_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			add_constant_type(p_node_type);
+			break;
+		case DATA_TYPE_FONT:
+			add_font_type(p_node_type);
+			break;
+		case DATA_TYPE_ICON:
+			add_icon_type(p_node_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			add_stylebox_type(p_node_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
+void Theme::get_theme_item_types(DataType p_data_type, List<StringName> *p_list) const {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			get_color_types(p_list);
+			break;
+		case DATA_TYPE_CONSTANT:
+			get_constant_types(p_list);
+			break;
+		case DATA_TYPE_FONT:
+			get_font_types(p_list);
+			break;
+		case DATA_TYPE_ICON:
+			get_icon_types(p_list);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			get_stylebox_types(p_list);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
 	}
 }
 
@@ -811,11 +1123,10 @@ void Theme::copy_default_theme() {
 void Theme::copy_theme(const Ref<Theme> &p_other) {
 	if (p_other.is_null()) {
 		clear();
-
 		return;
 	}
 
-	//these need reconnecting, so add normally
+	// These items need reconnecting, so add them normally.
 	{
 		const StringName *K = nullptr;
 		while ((K = p_other->icon_map.next(K))) {
@@ -846,8 +1157,7 @@ void Theme::copy_theme(const Ref<Theme> &p_other) {
 		}
 	}
 
-	//these are ok to just copy
-
+	// These items can be simply copied.
 	color_map = p_other->color_map;
 	constant_map = p_other->constant_map;
 	shader_map = p_other->shader_map;
@@ -899,6 +1209,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_icon", "name", "node_type", "texture"), &Theme::set_icon);
 	ClassDB::bind_method(D_METHOD("get_icon", "name", "node_type"), &Theme::get_icon);
 	ClassDB::bind_method(D_METHOD("has_icon", "name", "node_type"), &Theme::has_icon);
+	ClassDB::bind_method(D_METHOD("rename_icon", "old_name", "name", "node_type"), &Theme::rename_icon);
 	ClassDB::bind_method(D_METHOD("clear_icon", "name", "node_type"), &Theme::clear_icon);
 	ClassDB::bind_method(D_METHOD("get_icon_list", "node_type"), &Theme::_get_icon_list);
 	ClassDB::bind_method(D_METHOD("get_icon_types"), &Theme::_get_icon_types);
@@ -906,6 +1217,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stylebox", "name", "node_type", "texture"), &Theme::set_stylebox);
 	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "node_type"), &Theme::get_stylebox);
 	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "node_type"), &Theme::has_stylebox);
+	ClassDB::bind_method(D_METHOD("rename_stylebox", "old_name", "name", "node_type"), &Theme::rename_stylebox);
 	ClassDB::bind_method(D_METHOD("clear_stylebox", "name", "node_type"), &Theme::clear_stylebox);
 	ClassDB::bind_method(D_METHOD("get_stylebox_list", "node_type"), &Theme::_get_stylebox_list);
 	ClassDB::bind_method(D_METHOD("get_stylebox_types"), &Theme::_get_stylebox_types);
@@ -913,6 +1225,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_font", "name", "node_type", "font"), &Theme::set_font);
 	ClassDB::bind_method(D_METHOD("get_font", "name", "node_type"), &Theme::get_font);
 	ClassDB::bind_method(D_METHOD("has_font", "name", "node_type"), &Theme::has_font);
+	ClassDB::bind_method(D_METHOD("rename_font", "old_name", "name", "node_type"), &Theme::rename_font);
 	ClassDB::bind_method(D_METHOD("clear_font", "name", "node_type"), &Theme::clear_font);
 	ClassDB::bind_method(D_METHOD("get_font_list", "node_type"), &Theme::_get_font_list);
 	ClassDB::bind_method(D_METHOD("get_font_types"), &Theme::_get_font_types);
@@ -920,6 +1233,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_color", "name", "node_type", "color"), &Theme::set_color);
 	ClassDB::bind_method(D_METHOD("get_color", "name", "node_type"), &Theme::get_color);
 	ClassDB::bind_method(D_METHOD("has_color", "name", "node_type"), &Theme::has_color);
+	ClassDB::bind_method(D_METHOD("rename_color", "old_name", "name", "node_type"), &Theme::rename_color);
 	ClassDB::bind_method(D_METHOD("clear_color", "name", "node_type"), &Theme::clear_color);
 	ClassDB::bind_method(D_METHOD("get_color_list", "node_type"), &Theme::_get_color_list);
 	ClassDB::bind_method(D_METHOD("get_color_types"), &Theme::_get_color_types);
@@ -927,6 +1241,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_constant", "name", "node_type", "constant"), &Theme::set_constant);
 	ClassDB::bind_method(D_METHOD("get_constant", "name", "node_type"), &Theme::get_constant);
 	ClassDB::bind_method(D_METHOD("has_constant", "name", "node_type"), &Theme::has_constant);
+	ClassDB::bind_method(D_METHOD("rename_constant", "old_name", "name", "node_type"), &Theme::rename_constant);
 	ClassDB::bind_method(D_METHOD("clear_constant", "name", "node_type"), &Theme::clear_constant);
 	ClassDB::bind_method(D_METHOD("get_constant_list", "node_type"), &Theme::_get_constant_list);
 	ClassDB::bind_method(D_METHOD("get_constant_types"), &Theme::_get_constant_types);
@@ -936,6 +1251,14 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_default_font", "font"), &Theme::set_default_theme_font);
 	ClassDB::bind_method(D_METHOD("get_default_font"), &Theme::get_default_theme_font);
 
+	ClassDB::bind_method(D_METHOD("set_theme_item", "data_type", "name", "node_type", "value"), &Theme::set_theme_item);
+	ClassDB::bind_method(D_METHOD("get_theme_item", "data_type", "name", "node_type"), &Theme::get_theme_item);
+	ClassDB::bind_method(D_METHOD("has_theme_item", "data_type", "name", "node_type"), &Theme::has_theme_item);
+	ClassDB::bind_method(D_METHOD("rename_theme_item", "data_type", "old_name", "name", "node_type"), &Theme::rename_theme_item);
+	ClassDB::bind_method(D_METHOD("clear_theme_item", "data_type", "name", "node_type"), &Theme::clear_theme_item);
+	ClassDB::bind_method(D_METHOD("get_theme_item_list", "data_type", "node_type"), &Theme::_get_theme_item_list);
+	ClassDB::bind_method(D_METHOD("get_theme_item_types", "data_type"), &Theme::_get_theme_item_types);
+
 	ClassDB::bind_method(D_METHOD("get_type_list", "node_type"), &Theme::_get_type_list);
 
 	ClassDB::bind_method(D_METHOD("_emit_theme_changed"), &Theme::_emit_theme_changed);
@@ -944,6 +1267,13 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("copy_theme", "other"), &Theme::copy_theme);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "default_font", PROPERTY_HINT_RESOURCE_TYPE, "Font"), "set_default_font", "get_default_font");
+
+	BIND_ENUM_CONSTANT(DATA_TYPE_COLOR);
+	BIND_ENUM_CONSTANT(DATA_TYPE_CONSTANT);
+	BIND_ENUM_CONSTANT(DATA_TYPE_FONT);
+	BIND_ENUM_CONSTANT(DATA_TYPE_ICON);
+	BIND_ENUM_CONSTANT(DATA_TYPE_STYLEBOX);
+	BIND_ENUM_CONSTANT(DATA_TYPE_MAX);
 }
 
 Theme::Theme() {

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -51,6 +51,21 @@ PoolVector<String> Theme::_get_icon_list(const String &p_node_type) const {
 	return ilret;
 }
 
+PoolVector<String> Theme::_get_icon_types() const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_icon_types(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
 PoolVector<String> Theme::_get_stylebox_list(const String &p_node_type) const {
 	PoolVector<String> ilret;
 	List<StringName> il;
@@ -96,6 +111,21 @@ PoolVector<String> Theme::_get_font_list(const String &p_node_type) const {
 	return ilret;
 }
 
+PoolVector<String> Theme::_get_font_types() const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_font_types(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
 PoolVector<String> Theme::_get_color_list(const String &p_node_type) const {
 	PoolVector<String> ilret;
 	List<StringName> il;
@@ -111,11 +141,41 @@ PoolVector<String> Theme::_get_color_list(const String &p_node_type) const {
 	return ilret;
 }
 
+PoolVector<String> Theme::_get_color_types() const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_color_types(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
 PoolVector<String> Theme::_get_constant_list(const String &p_node_type) const {
 	PoolVector<String> ilret;
 	List<StringName> il;
 
 	get_constant_list(p_node_type, &il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	PoolVector<String>::Write w = ilret.write();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+PoolVector<String> Theme::_get_constant_types() const {
+	PoolVector<String> ilret;
+	List<StringName> il;
+
+	get_constant_types(&il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -316,9 +376,11 @@ void Theme::set_project_default(const Ref<Theme> &p_project_default) {
 void Theme::set_default_icon(const Ref<Texture> &p_icon) {
 	default_icon = p_icon;
 }
+
 void Theme::set_default_style(const Ref<StyleBox> &p_style) {
 	default_style = p_style;
 }
+
 void Theme::set_default_font(const Ref<Font> &p_font) {
 	default_font = p_font;
 }
@@ -343,6 +405,7 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, co
 		emit_changed();
 	}
 }
+
 Ref<Texture> Theme::get_icon(const StringName &p_name, const StringName &p_node_type) const {
 	if (icon_map.has(p_node_type) && icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
 		return icon_map[p_node_type][p_name];
@@ -379,6 +442,15 @@ void Theme::get_icon_list(StringName p_node_type, List<StringName> *p_list) cons
 	const StringName *key = nullptr;
 
 	while ((key = icon_map[p_node_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::get_icon_types(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = icon_map.next(key))) {
 		p_list->push_back(*key);
 	}
 }
@@ -519,6 +591,7 @@ void Theme::set_font(const StringName &p_name, const StringName &p_node_type, co
 		emit_changed();
 	}
 }
+
 Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_node_type) const {
 	if (font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid()) {
 		return font_map[p_node_type][p_name];
@@ -556,6 +629,15 @@ void Theme::get_font_list(StringName p_node_type, List<StringName> *p_list) cons
 	const StringName *key = nullptr;
 
 	while ((key = font_map[p_node_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::get_font_types(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = font_map.next(key))) {
 		p_list->push_back(*key);
 	}
 }
@@ -606,6 +688,15 @@ void Theme::get_color_list(StringName p_node_type, List<StringName> *p_list) con
 	}
 }
 
+void Theme::get_color_types(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = color_map.next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
 void Theme::set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant) {
 	bool new_value = !constant_map.has(p_node_type) || !constant_map[p_node_type].has(p_name);
 	constant_map[p_node_type][p_name] = p_constant;
@@ -647,6 +738,15 @@ void Theme::get_constant_list(StringName p_node_type, List<StringName> *p_list) 
 	const StringName *key = nullptr;
 
 	while ((key = constant_map[p_node_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::get_constant_types(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = constant_map.next(key))) {
 		p_list->push_back(*key);
 	}
 }
@@ -801,6 +901,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_icon", "name", "node_type"), &Theme::has_icon);
 	ClassDB::bind_method(D_METHOD("clear_icon", "name", "node_type"), &Theme::clear_icon);
 	ClassDB::bind_method(D_METHOD("get_icon_list", "node_type"), &Theme::_get_icon_list);
+	ClassDB::bind_method(D_METHOD("get_icon_types"), &Theme::_get_icon_types);
 
 	ClassDB::bind_method(D_METHOD("set_stylebox", "name", "node_type", "texture"), &Theme::set_stylebox);
 	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "node_type"), &Theme::get_stylebox);
@@ -814,18 +915,21 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_font", "name", "node_type"), &Theme::has_font);
 	ClassDB::bind_method(D_METHOD("clear_font", "name", "node_type"), &Theme::clear_font);
 	ClassDB::bind_method(D_METHOD("get_font_list", "node_type"), &Theme::_get_font_list);
+	ClassDB::bind_method(D_METHOD("get_font_types"), &Theme::_get_font_types);
 
 	ClassDB::bind_method(D_METHOD("set_color", "name", "node_type", "color"), &Theme::set_color);
 	ClassDB::bind_method(D_METHOD("get_color", "name", "node_type"), &Theme::get_color);
 	ClassDB::bind_method(D_METHOD("has_color", "name", "node_type"), &Theme::has_color);
 	ClassDB::bind_method(D_METHOD("clear_color", "name", "node_type"), &Theme::clear_color);
 	ClassDB::bind_method(D_METHOD("get_color_list", "node_type"), &Theme::_get_color_list);
+	ClassDB::bind_method(D_METHOD("get_color_types"), &Theme::_get_color_types);
 
 	ClassDB::bind_method(D_METHOD("set_constant", "name", "node_type", "constant"), &Theme::set_constant);
 	ClassDB::bind_method(D_METHOD("get_constant", "name", "node_type"), &Theme::get_constant);
 	ClassDB::bind_method(D_METHOD("has_constant", "name", "node_type"), &Theme::has_constant);
 	ClassDB::bind_method(D_METHOD("clear_constant", "name", "node_type"), &Theme::clear_constant);
 	ClassDB::bind_method(D_METHOD("get_constant_list", "node_type"), &Theme::_get_constant_list);
+	ClassDB::bind_method(D_METHOD("get_constant_types"), &Theme::_get_constant_types);
 
 	ClassDB::bind_method(D_METHOD("clear"), &Theme::clear);
 

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -52,11 +52,15 @@ class Theme : public Resource {
 	HashMap<StringName, HashMap<StringName, int>> constant_map;
 
 	PoolVector<String> _get_icon_list(const String &p_node_type) const;
+	PoolVector<String> _get_icon_types() const;
 	PoolVector<String> _get_stylebox_list(const String &p_node_type) const;
 	PoolVector<String> _get_stylebox_types() const;
 	PoolVector<String> _get_font_list(const String &p_node_type) const;
+	PoolVector<String> _get_font_types() const;
 	PoolVector<String> _get_color_list(const String &p_node_type) const;
+	PoolVector<String> _get_color_types() const;
 	PoolVector<String> _get_constant_list(const String &p_node_type) const;
+	PoolVector<String> _get_constant_types() const;
 	PoolVector<String> _get_type_list(const String &p_node_type) const;
 
 protected:
@@ -93,6 +97,7 @@ public:
 	bool has_icon(const StringName &p_name, const StringName &p_node_type) const;
 	void clear_icon(const StringName &p_name, const StringName &p_node_type);
 	void get_icon_list(StringName p_node_type, List<StringName> *p_list) const;
+	void get_icon_types(List<StringName> *p_list) const;
 
 	void set_shader(const StringName &p_name, const StringName &p_node_type, const Ref<Shader> &p_shader);
 	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_node_type) const;
@@ -112,18 +117,21 @@ public:
 	bool has_font(const StringName &p_name, const StringName &p_node_type) const;
 	void clear_font(const StringName &p_name, const StringName &p_node_type);
 	void get_font_list(StringName p_node_type, List<StringName> *p_list) const;
+	void get_font_types(List<StringName> *p_list) const;
 
 	void set_color(const StringName &p_name, const StringName &p_node_type, const Color &p_color);
 	Color get_color(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_color(const StringName &p_name, const StringName &p_node_type) const;
 	void clear_color(const StringName &p_name, const StringName &p_node_type);
 	void get_color_list(StringName p_node_type, List<StringName> *p_list) const;
+	void get_color_types(List<StringName> *p_list) const;
 
 	void set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant);
 	int get_constant(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_constant(const StringName &p_name, const StringName &p_node_type) const;
 	void clear_constant(const StringName &p_name, const StringName &p_node_type);
 	void get_constant_list(StringName p_node_type, List<StringName> *p_list) const;
+	void get_constant_types(List<StringName> *p_list) const;
 
 	void get_type_list(List<StringName> *p_list) const;
 

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -42,6 +42,17 @@ class Theme : public Resource {
 	GDCLASS(Theme, Resource);
 	RES_BASE_EXTENSION("theme");
 
+public:
+	enum DataType {
+		DATA_TYPE_COLOR,
+		DATA_TYPE_CONSTANT,
+		DATA_TYPE_FONT,
+		DATA_TYPE_ICON,
+		DATA_TYPE_STYLEBOX,
+		DATA_TYPE_MAX
+	};
+
+private:
 	void _emit_theme_changed();
 
 	HashMap<StringName, HashMap<StringName, Ref<Texture>>> icon_map;
@@ -61,6 +72,9 @@ class Theme : public Resource {
 	PoolVector<String> _get_color_types() const;
 	PoolVector<String> _get_constant_list(const String &p_node_type) const;
 	PoolVector<String> _get_constant_types() const;
+
+	PoolVector<String> _get_theme_item_list(DataType p_data_type, const String &p_node_type) const;
+	PoolVector<String> _get_theme_item_types(DataType p_data_type) const;
 	PoolVector<String> _get_type_list(const String &p_node_type) const;
 
 protected:
@@ -95,8 +109,10 @@ public:
 	void set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture> &p_icon);
 	Ref<Texture> get_icon(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_icon(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_icon(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_icon(const StringName &p_name, const StringName &p_node_type);
 	void get_icon_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_icon_type(const StringName &p_node_type);
 	void get_icon_types(List<StringName> *p_list) const;
 
 	void set_shader(const StringName &p_name, const StringName &p_node_type, const Ref<Shader> &p_shader);
@@ -108,30 +124,47 @@ public:
 	void set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style);
 	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_stylebox(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_stylebox(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_stylebox(const StringName &p_name, const StringName &p_node_type);
 	void get_stylebox_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_stylebox_type(const StringName &p_node_type);
 	void get_stylebox_types(List<StringName> *p_list) const;
 
 	void set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font);
 	Ref<Font> get_font(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_font(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_font(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_font(const StringName &p_name, const StringName &p_node_type);
 	void get_font_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_font_type(const StringName &p_node_type);
 	void get_font_types(List<StringName> *p_list) const;
 
 	void set_color(const StringName &p_name, const StringName &p_node_type, const Color &p_color);
 	Color get_color(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_color(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_color(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_color(const StringName &p_name, const StringName &p_node_type);
 	void get_color_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_color_type(const StringName &p_node_type);
 	void get_color_types(List<StringName> *p_list) const;
 
 	void set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant);
 	int get_constant(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_constant(const StringName &p_name, const StringName &p_node_type) const;
+	void rename_constant(const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
 	void clear_constant(const StringName &p_name, const StringName &p_node_type);
 	void get_constant_list(StringName p_node_type, List<StringName> *p_list) const;
+	void add_constant_type(const StringName &p_node_type);
 	void get_constant_types(List<StringName> *p_list) const;
+
+	void set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type, const Variant &p_value);
+	Variant get_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) const;
+	bool has_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type) const;
+	void rename_theme_item(DataType p_data_type, const StringName &p_old_name, const StringName &p_name, const StringName &p_node_type);
+	void clear_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_node_type);
+	void get_theme_item_list(DataType p_data_type, StringName p_node_type, List<StringName> *p_list) const;
+	void add_theme_item_type(DataType p_data_type, const StringName &p_node_type);
+	void get_theme_item_types(DataType p_data_type, List<StringName> *p_list) const;
 
 	void get_type_list(List<StringName> *p_list) const;
 
@@ -142,5 +175,7 @@ public:
 	Theme();
 	~Theme();
 };
+
+VARIANT_ENUM_CAST(Theme::DataType);
 
 #endif


### PR DESCRIPTION
Following changes has been ported:

1. Add missing type list methods (#37759) (named `*_types` to follow `get_stylebox_types`, renamed in `master`):
    - `Theme.get_color_types()` (`get_color_type_list` in `master`)
    - `Theme.get_constant_types()` (`get_constant_type_list` in `master`)
    - `Theme.get_font_types()` (`get_font_type_list` in `master`)
    - `Theme.get_icon_types()` (`get_icon_type_list` in `master`)

2. Add utility methods with all fixes applied (#47251, #49308):
    - All as described in #47251, except for font size related methods as it doesn't exist in `3.x`

3. While #47544 is not portable due to compatibility breaking fixes, one fix can be ported as it is just a typo.

All changes are split into individual commits related to each backported changeset/PR.