### PR TITLE
[3.x] Backport exposing `EditorResourcePicker` and using it in the Inspector

### DIFF
--- a/doc/classes/EditorResourcePicker.xml
+++ b/doc/classes/EditorResourcePicker.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorResourcePicker" inherits="HBoxContainer" version="3.4">
+	<brief_description>
+		Godot editor's control for selecting [Resource] type properties.
+	</brief_description>
+	<description>
+		This [Control] node is used in the editor's Inspector dock to allow editing of [Resource] type properties. It provides options for creating, loading, saving and converting resources. Can be used with [EditorInspectorPlugin] to recreate the same behavior.
+		[b]Note:[/b] This [Control] does not include any editor for the resource, as editing is controlled by the Inspector dock itself or sub-Inspectors.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="can_drop_data_fw" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<argument index="1" name="data" type="Variant">
+			</argument>
+			<argument index="2" name="from" type="Control">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="drop_data_fw">
+			<return type="void">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<argument index="1" name="data" type="Variant">
+			</argument>
+			<argument index="2" name="from" type="Control">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_allowed_types" qualifiers="const">
+			<return type="PoolStringArray">
+			</return>
+			<description>
+				Returns a list of all allowed types and subtypes corresponding to the [member base_type]. If the [member base_type] is empty, an empty list is returned.
+			</description>
+		</method>
+		<method name="get_drag_data_fw">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<argument index="1" name="from" type="Control">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="handle_menu_selected" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+				This virtual method can be implemented to handle context menu items not handled by default. See [method set_create_options].
+			</description>
+		</method>
+		<method name="set_create_options" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="menu_node" type="Object">
+			</argument>
+			<description>
+				This virtual method is called when updating the context menu of [EditorResourcePicker]. Implement this method to override the "New ..." items with your own options. [code]menu_node[/code] is a reference to the [PopupMenu] node.
+				[b]Note:[/b] Implement [method handle_menu_selected] to handle these custom items.
+			</description>
+		</method>
+		<method name="set_toggle_pressed">
+			<return type="void">
+			</return>
+			<argument index="0" name="pressed" type="bool">
+			</argument>
+			<description>
+				Sets the toggle mode state for the main button. Works only if [member toggle_mode] is set to [code]true[/code].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="base_type" type="String" setter="set_base_type" getter="get_base_type" default="&quot;&quot;">
+			The base type of allowed resource types. Can be a comma-separated list of several options.
+		</member>
+		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
+			If [code]true[/code], the value can be selected and edited.
+		</member>
+		<member name="edited_resource" type="Resource" setter="set_edited_resource" getter="get_edited_resource">
+			The edited resource value.
+		</member>
+		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" default="false">
+			If [code]true[/code], the main button with the resource preview works in the toggle mode. Use [method set_toggle_pressed] to manually set the state.
+		</member>
+	</members>
+	<signals>
+		<signal name="resource_changed">
+			<argument index="0" name="resource" type="Resource">
+			</argument>
+			<description>
+				Emitted when the value of the edited resource was changed.
+			</description>
+		</signal>
+		<signal name="resource_selected">
+			<argument index="0" name="resource" type="Resource">
+			</argument>
+			<description>
+				Emitted when the resource value was set and user clicked to edit it.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/EditorScriptPicker.xml
+++ b/doc/classes/EditorScriptPicker.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorScriptPicker" inherits="EditorResourcePicker" version="3.4">
+	<brief_description>
+		Godot editor's control for selecting the [code]script[/code] property of a [Node].
+	</brief_description>
+	<description>
+		Similar to [EditorResourcePicker] this [Control] node is used in the editor's Inspector dock, but only to edit the [code]script[/code] property of a [Node]. Default options for creating new resources of all possible subtypes are replaced with dedicated buttons that open the "Attach Node Script" dialog. Can be used with [EditorInspectorPlugin] to recreate the same behavior.
+		[b]Note:[/b] You must set the [member script_owner] for the custom context menu items to work.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="script_owner" type="Node" setter="set_script_owner" getter="get_script_owner">
+			The owner [Node] of the script property that holds the edited resource.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EditorSpinSlider" inherits="Range" version="3.4">
 	<brief_description>
+		Godot editor's control for editing numeric values.
 	</brief_description>
 	<description>
+		This [Control] node is used in the editor's Inspector dock to allow editing of numeric values. Can be used with [EditorInspectorPlugin] to recreate the same behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -79,6 +79,7 @@
 #include "editor/editor_log.h"
 #include "editor/editor_plugin.h"
 #include "editor/editor_properties.h"
+#include "editor/editor_resource_picker.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_run_native.h"
 #include "editor/editor_run_script.h"
@@ -3799,6 +3800,8 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<ScriptCreateDialog>();
 	ClassDB::register_class<EditorFeatureProfile>();
 	ClassDB::register_class<EditorSpinSlider>();
+	ClassDB::register_class<EditorResourcePicker>();
+	ClassDB::register_class<EditorScriptPicker>();
 	ClassDB::register_virtual_class<FileSystemDock>();
 
 	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2083,424 +2083,62 @@ EditorPropertyRID::EditorPropertyRID() {
 
 ////////////// RESOURCE //////////////////////
 
-void EditorPropertyResource::_file_selected(const String &p_path) {
-	RES res = ResourceLoader::load(p_path);
-
-	ERR_FAIL_COND_MSG(res.is_null(), "Cannot load resource from path '" + p_path + "'.");
-
-	List<PropertyInfo> prop_list;
-	get_edited_object()->get_property_list(&prop_list);
-	String property_types;
-
-	for (List<PropertyInfo>::Element *E = prop_list.front(); E; E = E->next()) {
-		if (E->get().name == get_edited_property() && (E->get().hint & PROPERTY_HINT_RESOURCE_TYPE)) {
-			property_types = E->get().hint_string;
-		}
+void EditorPropertyResource::_resource_selected(const RES &p_resource) {
+	if (use_sub_inspector) {
+		bool unfold = !get_edited_object()->editor_is_section_unfolded(get_edited_property());
+		get_edited_object()->editor_set_section_unfold(get_edited_property(), unfold);
+		update_property();
+	} else {
+		emit_signal("resource_selected", get_edited_property(), p_resource);
 	}
-	if (!property_types.empty()) {
-		bool any_type_matches = false;
-		const Vector<String> split_property_types = property_types.split(",");
-		for (int i = 0; i < split_property_types.size(); ++i) {
-			if (res->is_class(split_property_types[i])) {
-				any_type_matches = true;
-				break;
-			}
-		}
-
-		if (!any_type_matches) {
-			EditorNode::get_singleton()->show_warning(vformat(TTR("The selected resource (%s) does not match any type expected for this property (%s)."), res->get_class(), property_types));
-		}
-	}
-
-	emit_changed(get_edited_property(), res);
-	update_property();
 }
 
-void EditorPropertyResource::_menu_option(int p_which) {
-	//	scene_tree->popup_centered_ratio();
-	switch (p_which) {
-		case OBJ_MENU_LOAD: {
-			if (!file) {
-				file = memnew(EditorFileDialog);
-				file->connect("file_selected", this, "_file_selected");
-				add_child(file);
-			}
-			file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-			String type = base_type;
+void EditorPropertyResource::_resource_changed(const RES &p_resource) {
+	// Make visual script the correct type.
+	Ref<Script> s = p_resource;
+	if (get_edited_object() && s.is_valid()) {
+		s->call("set_instance_base_type", get_edited_object()->get_class());
+	}
 
-			List<String> extensions;
-			for (int i = 0; i < type.get_slice_count(","); i++) {
-				ResourceLoader::get_recognized_extensions_for_type(type.get_slice(",", i), &extensions);
-			}
-
-			Set<String> valid_extensions;
-			for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
-				valid_extensions.insert(E->get());
-			}
-
-			file->clear_filters();
-			for (Set<String>::Element *E = valid_extensions.front(); E; E = E->next()) {
-				file->add_filter("*." + E->get() + " ; " + E->get().to_upper());
-			}
-
-			file->popup_centered_ratio();
-		} break;
-
-		case OBJ_MENU_EDIT: {
-			RES res = get_edited_object()->get(get_edited_property());
-
-			if (!res.is_null()) {
-				emit_signal("resource_selected", get_edited_property(), res);
-			}
-		} break;
-		case OBJ_MENU_CLEAR: {
+	// Prevent the creation of invalid ViewportTextures when possible.
+	Ref<ViewportTexture> vpt = p_resource;
+	if (vpt.is_valid()) {
+		Resource *r = Object::cast_to<Resource>(get_edited_object());
+		if (r && r->get_path().is_resource_file()) {
+			EditorNode::get_singleton()->show_warning(TTR("Can't create a ViewportTexture on resources saved as a file.\nResource needs to belong to a scene."));
 			emit_changed(get_edited_property(), RES());
 			update_property();
-
-		} break;
-
-		case OBJ_MENU_MAKE_UNIQUE: {
-			RES res_orig = get_edited_object()->get(get_edited_property());
-			if (res_orig.is_null()) {
-				return;
-			}
-
-			List<PropertyInfo> property_list;
-			res_orig->get_property_list(&property_list);
-			List<Pair<String, Variant>> propvalues;
-
-			for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
-				Pair<String, Variant> p;
-				PropertyInfo &pi = E->get();
-				if (pi.usage & PROPERTY_USAGE_STORAGE) {
-					p.first = pi.name;
-					p.second = res_orig->get(pi.name);
-				}
-
-				propvalues.push_back(p);
-			}
-
-			String orig_type = res_orig->get_class();
-
-			Object *inst = ClassDB::instance(orig_type);
-
-			Ref<Resource> res = Ref<Resource>(Object::cast_to<Resource>(inst));
-
-			ERR_FAIL_COND(res.is_null());
-
-			for (List<Pair<String, Variant>>::Element *E = propvalues.front(); E; E = E->next()) {
-				Pair<String, Variant> &p = E->get();
-				res->set(p.first, p.second);
-			}
-
-			emit_changed(get_edited_property(), res);
-			update_property();
-
-		} break;
-
-		case OBJ_MENU_SAVE: {
-			RES res = get_edited_object()->get(get_edited_property());
-			if (res.is_null()) {
-				return;
-			}
-			EditorNode::get_singleton()->save_resource(res);
-		} break;
-
-		case OBJ_MENU_COPY: {
-			RES res = get_edited_object()->get(get_edited_property());
-
-			EditorSettings::get_singleton()->set_resource_clipboard(res);
-
-		} break;
-		case OBJ_MENU_PASTE: {
-			RES res = EditorSettings::get_singleton()->get_resource_clipboard();
-			emit_changed(get_edited_property(), res);
-			update_property();
-
-		} break;
-		case OBJ_MENU_NEW_SCRIPT: {
-			if (Object::cast_to<Node>(get_edited_object())) {
-				EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(get_edited_object()), false);
-			}
-
-		} break;
-		case OBJ_MENU_EXTEND_SCRIPT: {
-			if (Object::cast_to<Node>(get_edited_object())) {
-				EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(get_edited_object()), true);
-			}
-
-		} break;
-		case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {
-			RES res = get_edited_object()->get(get_edited_property());
-
-			FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
-			file_system_dock->navigate_to_path(res->get_path());
-			// Ensure that the FileSystem dock is visible.
-			TabContainer *tab_container = (TabContainer *)file_system_dock->get_parent_control();
-			tab_container->set_current_tab(file_system_dock->get_position_in_parent());
-		} break;
-		default: {
-			RES res = get_edited_object()->get(get_edited_property());
-
-			if (p_which >= CONVERT_BASE_ID) {
-				int to_type = p_which - CONVERT_BASE_ID;
-
-				Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(res);
-
-				ERR_FAIL_INDEX(to_type, conversions.size());
-
-				Ref<Resource> new_res = conversions[to_type]->convert(res);
-
-				emit_changed(get_edited_property(), new_res);
-				update_property();
-				break;
-			}
-			ERR_FAIL_COND(inheritors_array.empty());
-
-			String intype = inheritors_array[p_which - TYPE_BASE_ID];
-
-			if (intype == "ViewportTexture") {
-				Resource *r = Object::cast_to<Resource>(get_edited_object());
-				if (r && r->get_path().is_resource_file()) {
-					EditorNode::get_singleton()->show_warning(TTR("Can't create a ViewportTexture on resources saved as a file.\nResource needs to belong to a scene."));
-					return;
-				}
-
-				if (r && !r->is_local_to_scene()) {
-					EditorNode::get_singleton()->show_warning(TTR("Can't create a ViewportTexture on this resource because it's not set as local to scene.\nPlease switch on the 'local to scene' property on it (and all resources containing it up to a node)."));
-					return;
-				}
-
-				if (!scene_tree) {
-					scene_tree = memnew(SceneTreeDialog);
-					Vector<StringName> valid_types;
-					valid_types.push_back("Viewport");
-					scene_tree->get_scene_tree()->set_valid_types(valid_types);
-					scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
-					add_child(scene_tree);
-					scene_tree->connect("selected", this, "_viewport_selected");
-					scene_tree->set_title(TTR("Pick a Viewport"));
-				}
-				scene_tree->popup_centered_ratio();
-
-				return;
-			}
-
-			Variant obj;
-
-			if (ScriptServer::is_global_class(intype)) {
-				obj = ClassDB::instance(ScriptServer::get_global_class_native_base(intype));
-				if (obj) {
-					Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(intype));
-					if (script.is_valid()) {
-						((Object *)obj)->set_script(script.get_ref_ptr());
-					}
-				}
-			} else {
-				obj = ClassDB::instance(intype);
-			}
-
-			if (!obj) {
-				obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
-			}
-
-			Resource *resp = Object::cast_to<Resource>(obj);
-			ERR_BREAK(!resp);
-			if (get_edited_object() && base_type != String() && base_type == "Script") {
-				//make visual script the right type
-				resp->call("set_instance_base_type", get_edited_object()->get_class());
-			}
-
-			res = RES(resp);
-			emit_changed(get_edited_property(), res);
-			update_property();
-
-		} break;
-	}
-}
-
-void EditorPropertyResource::_resource_preview(const String &p_path, const Ref<Texture> &p_preview, const Ref<Texture> &p_small_preview, ObjectID p_obj) {
-	RES p = get_edited_object()->get(get_edited_property());
-	if (p.is_valid() && p->get_instance_id() == p_obj) {
-		String type = p->get_class_name();
-
-		if (ClassDB::is_parent_class(type, "Script")) {
-			assign->set_text(p->get_path().get_file());
 			return;
 		}
 
-		if (p_preview.is_valid()) {
-			preview->set_margin(MARGIN_LEFT, assign->get_icon()->get_width() + assign->get_stylebox("normal")->get_default_margin(MARGIN_LEFT) + get_constant("hseparation", "Button"));
-			if (type == "GradientTexture") {
-				preview->set_stretch_mode(TextureRect::STRETCH_SCALE);
-				assign->set_custom_minimum_size(Size2(1, 1));
-			} else {
-				preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-				int thumbnail_size = EditorSettings::get_singleton()->get("filesystem/file_dialog/thumbnail_size");
-				thumbnail_size *= EDSCALE;
-				assign->set_custom_minimum_size(Size2(1, thumbnail_size));
-			}
-			preview->set_texture(p_preview);
-			assign->set_text("");
-		}
-	}
-}
-
-void EditorPropertyResource::_update_menu_items() {
-	//////////////////// UPDATE MENU //////////////////////////
-	RES res = get_edited_object()->get(get_edited_property());
-
-	menu->clear();
-
-	if (get_edited_property() == "script" && base_type == "Script" && Object::cast_to<Node>(get_edited_object())) {
-		menu->add_icon_item(get_icon("ScriptCreate", "EditorIcons"), TTR("New Script"), OBJ_MENU_NEW_SCRIPT);
-		menu->add_icon_item(get_icon("ScriptExtend", "EditorIcons"), TTR("Extend Script"), OBJ_MENU_EXTEND_SCRIPT);
-		menu->add_separator();
-	} else if (base_type != "") {
-		int idx = 0;
-
-		Vector<EditorData::CustomType> custom_resources;
-
-		if (EditorNode::get_editor_data().get_custom_types().has("Resource")) {
-			custom_resources = EditorNode::get_editor_data().get_custom_types()["Resource"];
-		}
-
-		for (int i = 0; i < base_type.get_slice_count(","); i++) {
-			String base = base_type.get_slice(",", i);
-
-			Set<String> valid_inheritors;
-			valid_inheritors.insert(base);
-			List<StringName> inheritors;
-			ClassDB::get_inheriters_from_class(base.strip_edges(), &inheritors);
-
-			for (int j = 0; j < custom_resources.size(); j++) {
-				inheritors.push_back(custom_resources[j].name);
-			}
-
-			List<StringName>::Element *E = inheritors.front();
-			while (E) {
-				valid_inheritors.insert(E->get());
-				E = E->next();
-			}
-
-			List<StringName> global_classes;
-			ScriptServer::get_global_class_list(&global_classes);
-			E = global_classes.front();
-			while (E) {
-				if (EditorNode::get_editor_data().script_class_is_parent(E->get(), base_type)) {
-					valid_inheritors.insert(E->get());
-				}
-				E = E->next();
-			}
-
-			for (Set<String>::Element *F = valid_inheritors.front(); F; F = F->next()) {
-				const String &t = F->get();
-
-				bool is_custom_resource = false;
-				Ref<Texture> icon;
-				if (!custom_resources.empty()) {
-					for (int j = 0; j < custom_resources.size(); j++) {
-						if (custom_resources[j].name == t) {
-							is_custom_resource = true;
-							if (custom_resources[j].icon.is_valid()) {
-								icon = custom_resources[j].icon;
-							}
-							break;
-						}
-					}
-				}
-
-				if (!is_custom_resource && !(ScriptServer::is_global_class(t) || ClassDB::can_instance(t))) {
-					continue;
-				}
-
-				inheritors_array.push_back(t);
-
-				if (!icon.is_valid()) {
-					icon = get_icon(has_icon(t, "EditorIcons") ? t : "Object", "EditorIcons");
-				}
-
-				int id = TYPE_BASE_ID + idx;
-				menu->add_icon_item(icon, vformat(TTR("New %s"), t), id);
-
-				idx++;
-			}
-		}
-
-		if (menu->get_item_count()) {
-			menu->add_separator();
+		if (r && !r->is_local_to_scene()) {
+			EditorNode::get_singleton()->show_warning(TTR("Can't create a ViewportTexture on this resource because it's not set as local to scene.\nPlease switch on the 'local to scene' property on it (and all resources containing it up to a node)."));
+			emit_changed(get_edited_property(), RES());
+			update_property();
+			return;
 		}
 	}
 
-	menu->add_icon_item(get_icon("Load", "EditorIcons"), TTR("Load"), OBJ_MENU_LOAD);
+	emit_changed(get_edited_property(), p_resource);
+	update_property();
 
-	if (!res.is_null()) {
-		menu->add_icon_item(get_icon("Edit", "EditorIcons"), TTR("Edit"), OBJ_MENU_EDIT);
-		menu->add_icon_item(get_icon("Clear", "EditorIcons"), TTR("Clear"), OBJ_MENU_CLEAR);
-		menu->add_icon_item(get_icon("Duplicate", "EditorIcons"), TTR("Make Unique"), OBJ_MENU_MAKE_UNIQUE);
-		menu->add_icon_item(get_icon("Save", "EditorIcons"), TTR("Save"), OBJ_MENU_SAVE);
-		RES r = res;
-		if (r.is_valid() && r->get_path().is_resource_file()) {
-			menu->add_separator();
-			menu->add_item(TTR("Show in FileSystem"), OBJ_MENU_SHOW_IN_FILE_SYSTEM);
+	// Automatically suggest setting up the path for a ViewportTexture.
+	if (vpt.is_valid() && vpt->get_viewport_path_in_scene().is_empty()) {
+		if (!scene_tree) {
+			scene_tree = memnew(SceneTreeDialog);
+			scene_tree->set_title(TTR("Pick a Viewport"));
+
+			Vector<StringName> valid_types;
+			valid_types.push_back("Viewport");
+			scene_tree->get_scene_tree()->set_valid_types(valid_types);
+			scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
+
+			add_child(scene_tree);
+			scene_tree->connect("selected", this, "_viewport_selected");
 		}
+
+		scene_tree->popup_centered_ratio();
 	}
-
-	RES cb = EditorSettings::get_singleton()->get_resource_clipboard();
-	bool paste_valid = false;
-	if (cb.is_valid()) {
-		if (base_type == "") {
-			paste_valid = true;
-		} else {
-			for (int i = 0; i < base_type.get_slice_count(","); i++) {
-				if (ClassDB::is_parent_class(cb->get_class(), base_type.get_slice(",", i))) {
-					paste_valid = true;
-					break;
-				}
-			}
-		}
-	}
-
-	if (!res.is_null() || paste_valid) {
-		menu->add_separator();
-
-		if (!res.is_null()) {
-			menu->add_item(TTR("Copy"), OBJ_MENU_COPY);
-		}
-
-		if (paste_valid) {
-			menu->add_item(TTR("Paste"), OBJ_MENU_PASTE);
-		}
-	}
-
-	if (!res.is_null()) {
-		Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(res);
-		if (conversions.size()) {
-			menu->add_separator();
-		}
-		for (int i = 0; i < conversions.size(); i++) {
-			String what = conversions[i]->converts_to();
-			Ref<Texture> icon;
-			if (has_icon(what, "EditorIcons")) {
-				icon = get_icon(what, "EditorIcons");
-			} else {
-				icon = get_icon(what, "Resource");
-			}
-
-			menu->add_icon_item(icon, vformat(TTR("Convert To %s"), what), CONVERT_BASE_ID + i);
-		}
-	}
-}
-
-void EditorPropertyResource::_update_menu() {
-	_update_menu_items();
-
-	Rect2 gt = edit->get_global_rect();
-	menu->set_as_minsize();
-	int ms = menu->get_combined_minimum_size().width;
-	Vector2 popup_pos = gt.position + gt.size - Vector2(ms, 0);
-	menu->set_global_position(popup_pos);
-	menu->popup();
 }
 
 void EditorPropertyResource::_sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool) {
@@ -2515,24 +2153,11 @@ void EditorPropertyResource::_sub_inspector_object_id_selected(int p_id) {
 	emit_signal("object_id_selected", get_edited_property(), p_id);
 }
 
-void EditorPropertyResource::_button_input(const Ref<InputEvent> &p_event) {
-	Ref<InputEventMouseButton> mb = p_event;
-	if (mb.is_valid()) {
-		if (mb->is_pressed() && mb->get_button_index() == BUTTON_RIGHT) {
-			_update_menu_items();
-			Vector2 pos = mb->get_global_position();
-			//pos = assign->get_global_transform().xform(pos);
-			menu->set_as_minsize();
-			menu->set_global_position(pos);
-			menu->popup();
-		}
-	}
-}
-
 void EditorPropertyResource::_open_editor_pressed() {
 	RES res = get_edited_object()->get(get_edited_property());
 	if (res.is_valid()) {
-		EditorNode::get_singleton()->call_deferred("edit_item_resource", res); //may clear the editor so do it deferred
+		// May clear the editor so do it deferred.
+		EditorNode::get_singleton()->call_deferred("edit_item_resource", res);
 	}
 }
 
@@ -2542,10 +2167,10 @@ void EditorPropertyResource::_fold_other_editors(Object *p_self) {
 	}
 
 	RES res = get_edited_object()->get(get_edited_property());
-
 	if (!res.is_valid()) {
 		return;
 	}
+
 	bool use_editor = false;
 	for (int i = 0; i < EditorNode::get_editor_data().get_editor_plugin_count(); i++) {
 		EditorPlugin *ep = EditorNode::get_editor_data().get_editor_plugin(i);
@@ -2553,17 +2178,16 @@ void EditorPropertyResource::_fold_other_editors(Object *p_self) {
 			use_editor = true;
 		}
 	}
-
 	if (!use_editor) {
 		return;
 	}
-	bool unfolded = get_edited_object()->editor_is_section_unfolded(get_edited_property());
 
 	opened_editor = false;
 
+	bool unfolded = get_edited_object()->editor_is_section_unfolded(get_edited_property());
 	if (unfolded) {
-		//refold
-		assign->set_pressed(false);
+		// Refold.
+		resource_picker->set_toggle_pressed(false);
 		get_edited_object()->editor_set_section_unfold(get_edited_property(), false);
 		update_property();
 	}
@@ -2575,6 +2199,7 @@ void EditorPropertyResource::_update_property_bg() {
 	}
 
 	updating_theme = true;
+
 	if (sub_inspector != nullptr) {
 		int count_subinspectors = 0;
 		Node *n = get_parent();
@@ -2604,12 +2229,60 @@ void EditorPropertyResource::_update_property_bg() {
 	updating_theme = false;
 	update();
 }
+
+void EditorPropertyResource::_viewport_selected(const NodePath &p_path) {
+	Node *to_node = get_node(p_path);
+	if (!Object::cast_to<Viewport>(to_node)) {
+		EditorNode::get_singleton()->show_warning(TTR("Selected node is not a Viewport!"));
+		return;
+	}
+
+	Ref<ViewportTexture> vt;
+	vt.instance();
+	vt->set_viewport_path_in_scene(get_tree()->get_edited_scene_root()->get_path_to(to_node));
+	vt->setup_local_to_scene();
+
+	emit_changed(get_edited_property(), vt);
+	update_property();
+}
+
+void EditorPropertyResource::setup(Object *p_object, const String &p_path, const String &p_base_type) {
+	if (resource_picker) {
+		resource_picker->disconnect("resource_selected", this, "_resource_selected");
+		resource_picker->disconnect("resource_changed", this, "_resource_changed");
+		memdelete(resource_picker);
+	}
+
+	if (p_path == "script" && p_base_type == "Script" && Object::cast_to<Node>(p_object)) {
+		EditorScriptPicker *script_picker = memnew(EditorScriptPicker);
+		script_picker->set_script_owner(Object::cast_to<Node>(p_object));
+		resource_picker = script_picker;
+	} else {
+		resource_picker = memnew(EditorResourcePicker);
+	}
+
+	resource_picker->set_base_type(p_base_type);
+	resource_picker->set_editable(true);
+	resource_picker->set_h_size_flags(SIZE_EXPAND_FILL);
+	add_child(resource_picker);
+
+	resource_picker->connect("resource_selected", this, "_resource_selected");
+	resource_picker->connect("resource_changed", this, "_resource_changed");
+
+	for (int i = 0; i < resource_picker->get_child_count(); i++) {
+		Button *b = Object::cast_to<Button>(resource_picker->get_child(i));
+		if (b) {
+			add_focusable(b);
+		}
+	}
+}
+
 void EditorPropertyResource::update_property() {
 	RES res = get_edited_object()->get(get_edited_property());
 
 	if (use_sub_inspector) {
-		if (res.is_valid() != assign->is_toggle_mode()) {
-			assign->set_toggle_mode(res.is_valid());
+		if (res.is_valid() != resource_picker->is_toggle_mode()) {
+			resource_picker->set_toggle_mode(res.is_valid());
 		}
 
 		if (res.is_valid() && get_edited_object()->editor_is_section_unfolded(get_edited_property())) {
@@ -2634,7 +2307,7 @@ void EditorPropertyResource::update_property() {
 				set_bottom_editor(sub_inspector_vbox);
 
 				sub_inspector_vbox->add_child(sub_inspector);
-				assign->set_pressed(true);
+				resource_picker->set_toggle_pressed(true);
 
 				bool use_editor = false;
 				for (int i = 0; i < EditorNode::get_editor_data().get_editor_plugin_count(); i++) {
@@ -2645,7 +2318,7 @@ void EditorPropertyResource::update_property() {
 				}
 
 				if (use_editor) {
-					//open editor directly and hide other open of these
+					// Open editor directly and hide other such editors which are currently open.
 					_open_editor_pressed();
 					if (is_inside_tree()) {
 						get_tree()->call_deferred("call_group", "_editor_resource_properties", "_fold_other_editors", this);
@@ -2667,104 +2340,18 @@ void EditorPropertyResource::update_property() {
 				memdelete(sub_inspector_vbox);
 				sub_inspector = nullptr;
 				sub_inspector_vbox = nullptr;
+
 				if (opened_editor) {
 					EditorNode::get_singleton()->hide_top_editors();
 					opened_editor = false;
 				}
+
 				_update_property_bg();
 			}
 		}
 	}
 
-	preview->set_texture(Ref<Texture>());
-	if (res == RES()) {
-		assign->set_icon(Ref<Texture>());
-		assign->set_text(TTR("[empty]"));
-		assign->set_custom_minimum_size(Size2(1, 1));
-	} else {
-		assign->set_icon(EditorNode::get_singleton()->get_object_icon(res.operator->(), "Object"));
-
-		if (res->get_name() != String()) {
-			assign->set_text(res->get_name());
-		} else if (res->get_path().is_resource_file()) {
-			assign->set_text(res->get_path().get_file());
-			assign->set_tooltip(res->get_path());
-		} else {
-			assign->set_text(res->get_class());
-		}
-
-		if (res->get_path().is_resource_file()) {
-			assign->set_tooltip(res->get_path());
-		}
-
-		//preview will override the above, so called at the end
-		EditorResourcePreview::get_singleton()->queue_edited_resource_preview(res, this, "_resource_preview", res->get_instance_id());
-	}
-}
-
-void EditorPropertyResource::_resource_selected() {
-	RES res = get_edited_object()->get(get_edited_property());
-
-	if (res.is_null()) {
-		edit->set_pressed(true);
-		_update_menu();
-		return;
-	}
-
-	if (use_sub_inspector) {
-		bool unfold = !get_edited_object()->editor_is_section_unfolded(get_edited_property());
-		get_edited_object()->editor_set_section_unfold(get_edited_property(), unfold);
-		update_property();
-	} else {
-		emit_signal("resource_selected", get_edited_property(), res);
-	}
-}
-
-void EditorPropertyResource::setup(const String &p_base_type) {
-	base_type = p_base_type;
-}
-
-void EditorPropertyResource::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		if (updating_theme) {
-			return;
-		}
-		Ref<Texture> t = get_icon("select_arrow", "Tree");
-		edit->set_icon(t);
-		_update_property_bg();
-	}
-
-	if (p_what == NOTIFICATION_DRAG_BEGIN) {
-		if (is_visible_in_tree()) {
-			if (_is_drop_valid(get_viewport()->gui_get_drag_data())) {
-				dropping = true;
-				assign->update();
-			}
-		}
-	}
-
-	if (p_what == NOTIFICATION_DRAG_END) {
-		if (dropping) {
-			dropping = false;
-			assign->update();
-		}
-	}
-}
-
-void EditorPropertyResource::_viewport_selected(const NodePath &p_path) {
-	Node *to_node = get_node(p_path);
-	if (!Object::cast_to<Viewport>(to_node)) {
-		EditorNode::get_singleton()->show_warning(TTR("Selected node is not a Viewport!"));
-		return;
-	}
-
-	Ref<ViewportTexture> vt;
-	vt.instance();
-	vt->set_viewport_path_in_scene(get_tree()->get_edited_scene_root()->get_path_to(to_node));
-	vt->setup_local_to_scene();
-
-	emit_changed(get_edited_property(), vt);
-	update_property();
+	resource_picker->set_edited_resource(res);
 }
 
 void EditorPropertyResource::collapse_all_folding() {
@@ -2779,169 +2366,35 @@ void EditorPropertyResource::expand_all_folding() {
 	}
 }
 
-void EditorPropertyResource::_button_draw() {
-	if (dropping) {
-		Color color = get_color("accent_color", "Editor");
-		assign->draw_rect(Rect2(Point2(), assign->get_size()), color, false);
-	}
-}
-
-Variant EditorPropertyResource::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	RES res = get_edited_object()->get(get_edited_property());
-	if (res.is_valid()) {
-		return EditorNode::get_singleton()->drag_resource(res, p_from);
-	}
-
-	return Variant();
-}
-
-bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const {
-	String allowed_type = base_type;
-
-	Dictionary drag_data = p_drag_data;
-
-	Ref<Resource> res;
-	if (drag_data.has("type") && String(drag_data["type"]) == "script_list_element") {
-		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(drag_data["script_list_element"]);
-		res = se->get_edited_resource();
-	} else if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
-		res = drag_data["resource"];
-	}
-
-	if (res.is_valid()) {
-		for (int i = 0; i < allowed_type.get_slice_count(","); i++) {
-			String at = allowed_type.get_slice(",", i).strip_edges();
-			if (res.is_valid() && ClassDB::is_parent_class(res->get_class(), at)) {
-				return true;
-			}
-		}
-	}
-
-	if (drag_data.has("type") && String(drag_data["type"]) == "files") {
-		Vector<String> files = drag_data["files"];
-
-		if (files.size() == 1) {
-			String file = files[0];
-			String ftype = EditorFileSystem::get_singleton()->get_file_type(file);
-
-			if (ftype != "") {
-				for (int i = 0; i < allowed_type.get_slice_count(","); i++) {
-					String at = allowed_type.get_slice(",", i).strip_edges();
-					if (ClassDB::is_parent_class(ftype, at)) {
-						return true;
-					}
-				}
-			}
-		}
-	}
-
-	return false;
-}
-
-bool EditorPropertyResource::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-	return _is_drop_valid(p_data);
-}
-void EditorPropertyResource::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	ERR_FAIL_COND(!_is_drop_valid(p_data));
-
-	Dictionary drag_data = p_data;
-
-	Ref<Resource> res;
-	if (drag_data.has("type") && String(drag_data["type"]) == "script_list_element") {
-		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(drag_data["script_list_element"]);
-		res = se->get_edited_resource();
-	} else if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
-		res = drag_data["resource"];
-	}
-
-	if (res.is_valid()) {
-		emit_changed(get_edited_property(), res);
-		update_property();
-		return;
-	}
-
-	if (drag_data.has("type") && String(drag_data["type"]) == "files") {
-		Vector<String> files = drag_data["files"];
-
-		if (files.size() == 1) {
-			String file = files[0];
-			RES file_res = ResourceLoader::load(file);
-			if (file_res.is_valid()) {
-				emit_changed(get_edited_property(), file_res);
-				update_property();
-				return;
-			}
-		}
-	}
-}
-
 void EditorPropertyResource::set_use_sub_inspector(bool p_enable) {
 	use_sub_inspector = p_enable;
 }
 
+void EditorPropertyResource::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			if (!updating_theme) {
+				_update_property_bg();
+			}
+		} break;
+	}
+}
+
 void EditorPropertyResource::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_file_selected"), &EditorPropertyResource::_file_selected);
-	ClassDB::bind_method(D_METHOD("_menu_option"), &EditorPropertyResource::_menu_option);
-	ClassDB::bind_method(D_METHOD("_update_menu"), &EditorPropertyResource::_update_menu);
-	ClassDB::bind_method(D_METHOD("_resource_preview"), &EditorPropertyResource::_resource_preview);
 	ClassDB::bind_method(D_METHOD("_resource_selected"), &EditorPropertyResource::_resource_selected);
+	ClassDB::bind_method(D_METHOD("_resource_changed"), &EditorPropertyResource::_resource_changed);
 	ClassDB::bind_method(D_METHOD("_viewport_selected"), &EditorPropertyResource::_viewport_selected);
 	ClassDB::bind_method(D_METHOD("_sub_inspector_property_keyed"), &EditorPropertyResource::_sub_inspector_property_keyed);
 	ClassDB::bind_method(D_METHOD("_sub_inspector_resource_selected"), &EditorPropertyResource::_sub_inspector_resource_selected);
 	ClassDB::bind_method(D_METHOD("_sub_inspector_object_id_selected"), &EditorPropertyResource::_sub_inspector_object_id_selected);
-	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &EditorPropertyResource::get_drag_data_fw);
-	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &EditorPropertyResource::can_drop_data_fw);
-	ClassDB::bind_method(D_METHOD("drop_data_fw"), &EditorPropertyResource::drop_data_fw);
-	ClassDB::bind_method(D_METHOD("_button_draw"), &EditorPropertyResource::_button_draw);
+
 	ClassDB::bind_method(D_METHOD("_open_editor_pressed"), &EditorPropertyResource::_open_editor_pressed);
-	ClassDB::bind_method(D_METHOD("_button_input"), &EditorPropertyResource::_button_input);
 	ClassDB::bind_method(D_METHOD("_fold_other_editors"), &EditorPropertyResource::_fold_other_editors);
 }
 
 EditorPropertyResource::EditorPropertyResource() {
-	opened_editor = false;
-	sub_inspector = nullptr;
-	sub_inspector_vbox = nullptr;
 	use_sub_inspector = bool(EDITOR_GET("interface/inspector/open_resources_in_current_inspector"));
-
-	HBoxContainer *hbc = memnew(HBoxContainer);
-	add_child(hbc);
-	assign = memnew(Button);
-	assign->set_flat(true);
-	assign->set_h_size_flags(SIZE_EXPAND_FILL);
-	assign->set_clip_text(true);
-	assign->connect("pressed", this, "_resource_selected");
-	assign->set_drag_forwarding(this);
-	assign->connect("draw", this, "_button_draw");
-	hbc->add_child(assign);
-	add_focusable(assign);
-
-	preview = memnew(TextureRect);
-	preview->set_expand(true);
-	preview->set_anchors_and_margins_preset(PRESET_WIDE);
-	preview->set_margin(MARGIN_TOP, 1);
-	preview->set_margin(MARGIN_BOTTOM, -1);
-	preview->set_margin(MARGIN_RIGHT, -1);
-	// This is required to draw the focus outline in front of the preview, rather than behind.
-	preview->set_draw_behind_parent(true);
-	assign->add_child(preview);
-	assign->connect("gui_input", this, "_button_input");
-
-	menu = memnew(PopupMenu);
-	add_child(menu);
-	edit = memnew(Button);
-	edit->set_flat(true);
-	edit->set_toggle_mode(true);
-	menu->connect("id_pressed", this, "_menu_option");
-	menu->connect("popup_hide", edit, "set_pressed", varray(false));
-	edit->connect("pressed", this, "_update_menu");
-	hbc->add_child(edit);
-	edit->connect("gui_input", this, "_button_input");
-	add_focusable(edit);
-
-	file = nullptr;
-	scene_tree = nullptr;
-	dropping = false;
 
 	add_to_group("_editor_resource_properties");
 }
@@ -3348,7 +2801,7 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 		} break;
 		case Variant::OBJECT: {
 			EditorPropertyResource *editor = memnew(EditorPropertyResource);
-			editor->setup(p_hint == PROPERTY_HINT_RESOURCE_TYPE ? p_hint_text : "Resource");
+			editor->setup(p_object, p_path, p_hint == PROPERTY_HINT_RESOURCE_TYPE ? p_hint_text : "Resource");
 
 			if (p_hint == PROPERTY_HINT_RESOURCE_TYPE) {
 				String open_in_new = EDITOR_GET("interface/inspector/resources_to_open_in_new_inspector");

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -33,6 +33,7 @@
 
 #include "editor/create_dialog.h"
 #include "editor/editor_inspector.h"
+#include "editor/editor_resource_picker.h"
 #include "editor/editor_spin_slider.h"
 #include "editor/property_selector.h"
 #include "editor/scene_tree_editor.h"
@@ -543,65 +544,26 @@ public:
 class EditorPropertyResource : public EditorProperty {
 	GDCLASS(EditorPropertyResource, EditorProperty);
 
-	enum MenuOption {
+	EditorResourcePicker *resource_picker = nullptr;
+	SceneTreeDialog *scene_tree = nullptr;
 
-		OBJ_MENU_LOAD = 0,
-		OBJ_MENU_EDIT = 1,
-		OBJ_MENU_CLEAR = 2,
-		OBJ_MENU_MAKE_UNIQUE = 3,
-		OBJ_MENU_SAVE = 4,
-		OBJ_MENU_COPY = 5,
-		OBJ_MENU_PASTE = 6,
-		OBJ_MENU_NEW_SCRIPT = 7,
-		OBJ_MENU_EXTEND_SCRIPT = 8,
-		OBJ_MENU_SHOW_IN_FILE_SYSTEM = 9,
-		TYPE_BASE_ID = 100,
-		CONVERT_BASE_ID = 1000
+	bool use_sub_inspector = false;
+	EditorInspector *sub_inspector = nullptr;
+	VBoxContainer *sub_inspector_vbox = nullptr;
+	bool updating_theme = false;
+	bool opened_editor = false;
 
-	};
+	void _resource_selected(const RES &p_resource);
+	void _resource_changed(const RES &p_resource);
 
-	Button *assign;
-	TextureRect *preview;
-	Button *edit;
-	PopupMenu *menu;
-	EditorFileDialog *file;
-	Vector<String> inheritors_array;
-	EditorInspector *sub_inspector;
-	VBoxContainer *sub_inspector_vbox;
-
-	bool use_sub_inspector;
-	bool dropping;
-	String base_type;
-
-	SceneTreeDialog *scene_tree;
-
-	void _file_selected(const String &p_path);
-	void _menu_option(int p_which);
-	void _resource_preview(const String &p_path, const Ref<Texture> &p_preview, const Ref<Texture> &p_small_preview, ObjectID p_obj);
-	void _resource_selected();
 	void _viewport_selected(const NodePath &p_path);
-
-	void _update_menu_items();
-
-	void _update_menu();
 
 	void _sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool);
 	void _sub_inspector_resource_selected(const RES &p_resource, const String &p_property);
 	void _sub_inspector_object_id_selected(int p_id);
 
-	void _button_draw();
-	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
-	bool _is_drop_valid(const Dictionary &p_drag_data) const;
-	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
-	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
-
-	void _button_input(const Ref<InputEvent> &p_event);
 	void _open_editor_pressed();
 	void _fold_other_editors(Object *p_self);
-
-	bool opened_editor;
-
-	bool updating_theme = false;
 	void _update_property_bg();
 
 protected:
@@ -610,7 +572,7 @@ protected:
 
 public:
 	virtual void update_property();
-	void setup(const String &p_base_type);
+	void setup(Object *p_object, const String &p_path, const String &p_base_type);
 
 	void collapse_all_folding();
 	void expand_all_folding();

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -783,7 +783,7 @@ void EditorPropertyDictionary::update_property() {
 
 					} else {
 						EditorPropertyResource *editor = memnew(EditorPropertyResource);
-						editor->setup("Resource");
+						editor->setup(object.ptr(), prop_name, "Resource");
 						prop = editor;
 					}
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -1,0 +1,869 @@
+/*************************************************************************/
+/*  editor_resource_picker.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor_resource_picker.h"
+
+#include "editor/editor_resource_preview.h"
+#include "editor_node.h"
+#include "editor_scale.h"
+#include "editor_settings.h"
+#include "filesystem_dock.h"
+#include "scene/main/viewport.h"
+#include "scene/resources/dynamic_font.h"
+
+void EditorResourcePicker::_update_resource() {
+	preview_rect->set_texture(Ref<Texture>());
+	assign_button->set_custom_minimum_size(Size2(1, 1));
+
+	if (edited_resource == RES()) {
+		assign_button->set_icon(Ref<Texture>());
+		assign_button->set_text(TTR("[empty]"));
+	} else {
+		assign_button->set_icon(EditorNode::get_singleton()->get_object_icon(edited_resource.operator->(), "Object"));
+
+		if (edited_resource->get_name() != String()) {
+			assign_button->set_text(edited_resource->get_name());
+		} else if (edited_resource->get_path().is_resource_file()) {
+			assign_button->set_text(edited_resource->get_path().get_file());
+			assign_button->set_tooltip(edited_resource->get_path());
+		} else {
+			assign_button->set_text(edited_resource->get_class());
+		}
+
+		if (edited_resource->get_path().is_resource_file()) {
+			assign_button->set_tooltip(edited_resource->get_path());
+		}
+
+		// Preview will override the above, so called at the end.
+		EditorResourcePreview::get_singleton()->queue_edited_resource_preview(edited_resource, this, "_update_resource_preview", edited_resource->get_instance_id());
+	}
+}
+
+void EditorResourcePicker::_update_resource_preview(const String &p_path, const Ref<Texture> &p_preview, const Ref<Texture> &p_small_preview, ObjectID p_obj) {
+	if (!edited_resource.is_valid() || edited_resource->get_instance_id() != p_obj) {
+		return;
+	}
+
+	String type = edited_resource->get_class_name();
+	if (ClassDB::class_exists(type) && ClassDB::is_parent_class(type, "Script")) {
+		assign_button->set_text(edited_resource->get_path().get_file());
+		return;
+	}
+
+	if (p_preview.is_valid()) {
+		preview_rect->set_margin(MARGIN_LEFT, assign_button->get_icon()->get_width() + assign_button->get_stylebox("normal")->get_default_margin(MARGIN_LEFT) + get_constant("hseparation", "Button"));
+
+		if (type == "GradientTexture") {
+			preview_rect->set_stretch_mode(TextureRect::STRETCH_SCALE);
+			assign_button->set_custom_minimum_size(Size2(1, 1));
+		} else {
+			preview_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+			int thumbnail_size = EditorSettings::get_singleton()->get("filesystem/file_dialog/thumbnail_size");
+			thumbnail_size *= EDSCALE;
+			assign_button->set_custom_minimum_size(Size2(1, thumbnail_size));
+		}
+
+		preview_rect->set_texture(p_preview);
+		assign_button->set_text("");
+	}
+}
+
+void EditorResourcePicker::_resource_selected() {
+	if (edited_resource.is_null()) {
+		edit_button->set_pressed(true);
+		_update_menu();
+		return;
+	}
+
+	emit_signal("resource_selected", edited_resource);
+}
+
+void EditorResourcePicker::_file_selected(const String &p_path) {
+	RES loaded_resource = ResourceLoader::load(p_path);
+	ERR_FAIL_COND_MSG(loaded_resource.is_null(), "Cannot load resource from path '" + p_path + "'.");
+
+	if (base_type != "") {
+		bool any_type_matches = false;
+
+		for (int i = 0; i < base_type.get_slice_count(","); i++) {
+			String base = base_type.get_slice(",", i);
+			if (loaded_resource->is_class(base)) {
+				any_type_matches = true;
+				break;
+			}
+		}
+
+		if (!any_type_matches) {
+			EditorNode::get_singleton()->show_warning(vformat(TTR("The selected resource (%s) does not match any type expected for this property (%s)."), loaded_resource->get_class(), base_type));
+			return;
+		}
+	}
+
+	edited_resource = loaded_resource;
+	emit_signal("resource_changed", edited_resource);
+	_update_resource();
+}
+
+void EditorResourcePicker::_update_menu() {
+	_update_menu_items();
+
+	Rect2 gt = edit_button->get_global_rect();
+	edit_menu->set_as_minsize();
+	int ms = edit_menu->get_combined_minimum_size().width;
+	Vector2 popup_pos = gt.position + gt.size - Vector2(ms, 0);
+	edit_menu->set_global_position(popup_pos);
+	edit_menu->popup();
+}
+
+void EditorResourcePicker::_update_menu_items() {
+	edit_menu->clear();
+
+	// Add options for creating specific subtypes of the base resource type.
+	set_create_options(edit_menu);
+
+	// Add an option to load a resource from a file.
+	edit_menu->add_icon_item(get_icon("Load", "EditorIcons"), TTR("Load"), OBJ_MENU_LOAD);
+
+	// Add options for changing existing value of the resource.
+	if (edited_resource.is_valid()) {
+		edit_menu->add_icon_item(get_icon("Edit", "EditorIcons"), TTR("Edit"), OBJ_MENU_EDIT);
+		edit_menu->add_icon_item(get_icon("Clear", "EditorIcons"), TTR("Clear"), OBJ_MENU_CLEAR);
+		edit_menu->add_icon_item(get_icon("Duplicate", "EditorIcons"), TTR("Make Unique"), OBJ_MENU_MAKE_UNIQUE);
+		edit_menu->add_icon_item(get_icon("Save", "EditorIcons"), TTR("Save"), OBJ_MENU_SAVE);
+
+		if (edited_resource->get_path().is_resource_file()) {
+			edit_menu->add_separator();
+			edit_menu->add_item(TTR("Show in FileSystem"), OBJ_MENU_SHOW_IN_FILE_SYSTEM);
+		}
+	}
+
+	// Add options to copy/paste resource.
+	RES cb = EditorSettings::get_singleton()->get_resource_clipboard();
+	bool paste_valid = false;
+	if (cb.is_valid()) {
+		if (base_type == "") {
+			paste_valid = true;
+		} else {
+			for (int i = 0; i < base_type.get_slice_count(","); i++) {
+				if (ClassDB::class_exists(cb->get_class()) && ClassDB::is_parent_class(cb->get_class(), base_type.get_slice(",", i))) {
+					paste_valid = true;
+					break;
+				}
+			}
+		}
+	}
+
+	if (edited_resource.is_valid() || paste_valid) {
+		edit_menu->add_separator();
+
+		if (edited_resource.is_valid()) {
+			edit_menu->add_item(TTR("Copy"), OBJ_MENU_COPY);
+		}
+
+		if (paste_valid) {
+			edit_menu->add_item(TTR("Paste"), OBJ_MENU_PASTE);
+		}
+	}
+
+	// Add options to convert existing resource to another type of resource.
+	if (edited_resource.is_valid()) {
+		Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(edited_resource);
+		if (conversions.size()) {
+			edit_menu->add_separator();
+		}
+		for (int i = 0; i < conversions.size(); i++) {
+			String what = conversions[i]->converts_to();
+			Ref<Texture> icon;
+			if (has_icon(what, "EditorIcons")) {
+				icon = get_icon(what, "EditorIcons");
+			} else {
+				icon = get_icon(what, "Resource");
+			}
+
+			edit_menu->add_icon_item(icon, vformat(TTR("Convert To %s"), what), CONVERT_BASE_ID + i);
+		}
+	}
+}
+
+void EditorResourcePicker::_edit_menu_cbk(int p_which) {
+	switch (p_which) {
+		case OBJ_MENU_LOAD: {
+			List<String> extensions;
+			for (int i = 0; i < base_type.get_slice_count(","); i++) {
+				String base = base_type.get_slice(",", i);
+				ResourceLoader::get_recognized_extensions_for_type(base, &extensions);
+			}
+
+			Set<String> valid_extensions;
+			for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
+				valid_extensions.insert(E->get());
+			}
+
+			if (!file_dialog) {
+				file_dialog = memnew(EditorFileDialog);
+				file_dialog->set_mode(EditorFileDialog::MODE_OPEN_FILE);
+				add_child(file_dialog);
+				file_dialog->connect("file_selected", this, "_file_selected");
+			}
+
+			file_dialog->clear_filters();
+			for (Set<String>::Element *E = valid_extensions.front(); E; E = E->next()) {
+				file_dialog->add_filter("*." + E->get() + " ; " + E->get().to_upper());
+			}
+
+			file_dialog->popup_centered_ratio();
+		} break;
+
+		case OBJ_MENU_EDIT: {
+			if (edited_resource.is_valid()) {
+				emit_signal("resource_selected", edited_resource);
+			}
+		} break;
+
+		case OBJ_MENU_CLEAR: {
+			edited_resource = RES();
+			emit_signal("resource_changed", edited_resource);
+			_update_resource();
+		} break;
+
+		case OBJ_MENU_MAKE_UNIQUE: {
+			if (edited_resource.is_null()) {
+				return;
+			}
+
+			List<PropertyInfo> property_list;
+			edited_resource->get_property_list(&property_list);
+			List<Pair<String, Variant>> propvalues;
+			for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
+				Pair<String, Variant> p;
+				PropertyInfo &pi = E->get();
+				if (pi.usage & PROPERTY_USAGE_STORAGE) {
+					p.first = pi.name;
+					p.second = edited_resource->get(pi.name);
+				}
+
+				propvalues.push_back(p);
+			}
+
+			String orig_type = edited_resource->get_class();
+			Object *inst = ClassDB::instance(orig_type);
+			Ref<Resource> unique_resource = Ref<Resource>(Object::cast_to<Resource>(inst));
+			ERR_FAIL_COND(unique_resource.is_null());
+
+			for (List<Pair<String, Variant>>::Element *E = propvalues.front(); E; E = E->next()) {
+				Pair<String, Variant> &p = E->get();
+				unique_resource->set(p.first, p.second);
+			}
+
+			edited_resource = unique_resource;
+			emit_signal("resource_changed", edited_resource);
+			_update_resource();
+		} break;
+
+		case OBJ_MENU_SAVE: {
+			if (edited_resource.is_null()) {
+				return;
+			}
+			EditorNode::get_singleton()->save_resource(edited_resource);
+		} break;
+
+		case OBJ_MENU_COPY: {
+			EditorSettings::get_singleton()->set_resource_clipboard(edited_resource);
+		} break;
+
+		case OBJ_MENU_PASTE: {
+			edited_resource = EditorSettings::get_singleton()->get_resource_clipboard();
+			emit_signal("resource_changed", edited_resource);
+			_update_resource();
+		} break;
+
+		case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {
+			FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
+			file_system_dock->navigate_to_path(edited_resource->get_path());
+
+			// Ensure that the FileSystem dock is visible.
+			TabContainer *tab_container = (TabContainer *)file_system_dock->get_parent_control();
+			tab_container->set_current_tab(file_system_dock->get_index());
+		} break;
+
+		default: {
+			// Allow subclasses to handle their own options first, only then fallback on the default branch logic.
+			if (handle_menu_selected(p_which)) {
+				break;
+			}
+
+			if (p_which >= CONVERT_BASE_ID) {
+				int to_type = p_which - CONVERT_BASE_ID;
+				Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(edited_resource);
+				ERR_FAIL_INDEX(to_type, conversions.size());
+
+				edited_resource = conversions[to_type]->convert(edited_resource);
+				emit_signal("resource_changed", edited_resource);
+				_update_resource();
+				break;
+			}
+
+			ERR_FAIL_COND(inheritors_array.empty());
+
+			String intype = inheritors_array[p_which - TYPE_BASE_ID];
+			Variant obj;
+
+			if (ScriptServer::is_global_class(intype)) {
+				obj = ClassDB::instance(ScriptServer::get_global_class_native_base(intype));
+				if (obj) {
+					Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(intype));
+					if (script.is_valid()) {
+						((Object *)obj)->set_script(script.get_ref_ptr());
+					}
+				}
+			} else {
+				obj = ClassDB::instance(intype);
+			}
+
+			if (!obj) {
+				obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+			}
+
+			Resource *resp = Object::cast_to<Resource>(obj);
+			ERR_BREAK(!resp);
+
+			edited_resource = RES(resp);
+			emit_signal("resource_changed", edited_resource);
+			_update_resource();
+		} break;
+	}
+}
+
+void EditorResourcePicker::set_create_options(Object *p_menu_node) {
+	// If a subclass implements this method, use it to replace all create items.
+	if (get_script_instance() && get_script_instance()->has_method("set_create_options")) {
+		get_script_instance()->call("set_create_options", p_menu_node);
+		return;
+	}
+
+	// By default provide generic "New ..." options.
+	if (base_type != "") {
+		int idx = 0;
+
+		Set<String> allowed_types;
+		_get_allowed_types(false, &allowed_types);
+
+		Vector<EditorData::CustomType> custom_resources;
+		if (EditorNode::get_editor_data().get_custom_types().has("Resource")) {
+			custom_resources = EditorNode::get_editor_data().get_custom_types()["Resource"];
+		}
+
+		for (Set<String>::Element *E = allowed_types.front(); E; E = E->next()) {
+			const String &t = E->get();
+
+			bool is_custom_resource = false;
+			Ref<Texture> icon;
+			if (!custom_resources.empty()) {
+				for (int j = 0; j < custom_resources.size(); j++) {
+					if (custom_resources[j].name == t) {
+						is_custom_resource = true;
+						if (custom_resources[j].icon.is_valid()) {
+							icon = custom_resources[j].icon;
+						}
+						break;
+					}
+				}
+			}
+
+			if (!is_custom_resource && !(ScriptServer::is_global_class(t) || ClassDB::can_instance(t))) {
+				continue;
+			}
+
+			inheritors_array.push_back(t);
+
+			if (!icon.is_valid()) {
+				icon = get_icon(has_icon(t, "EditorIcons") ? t : "Object", "EditorIcons");
+			}
+
+			int id = TYPE_BASE_ID + idx;
+			edit_menu->add_icon_item(icon, vformat(TTR("New %s"), t), id);
+
+			idx++;
+		}
+
+		if (edit_menu->get_item_count()) {
+			edit_menu->add_separator();
+		}
+	}
+}
+
+bool EditorResourcePicker::handle_menu_selected(int p_which) {
+	if (get_script_instance() && get_script_instance()->has_method("handle_menu_selected")) {
+		return get_script_instance()->call("handle_menu_selected", p_which);
+	}
+
+	return false;
+}
+
+void EditorResourcePicker::_button_draw() {
+	if (dropping) {
+		Color color = get_color("accent_color", "Editor");
+		assign_button->draw_rect(Rect2(Point2(), assign_button->get_size()), color, false);
+	}
+}
+
+void EditorResourcePicker::_button_input(const Ref<InputEvent> &p_event) {
+	if (!editable) {
+		return;
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+
+	if (mb.is_valid()) {
+		if (mb->is_pressed() && mb->get_button_index() == BUTTON_RIGHT) {
+			_update_menu_items();
+
+			Vector2 pos = get_global_position() + mb->get_position();
+			edit_menu->set_as_minsize();
+			edit_menu->set_global_position(pos);
+			edit_menu->popup();
+		}
+	}
+}
+
+void EditorResourcePicker::_get_allowed_types(bool p_with_convert, Set<String> *p_vector) const {
+	Vector<String> allowed_types = base_type.split(",");
+	int size = allowed_types.size();
+
+	List<StringName> global_classes;
+	ScriptServer::get_global_class_list(&global_classes);
+
+	for (int i = 0; i < size; i++) {
+		String base = allowed_types[i].strip_edges();
+		p_vector->insert(base);
+
+		List<StringName> inheriters;
+
+		ClassDB::get_inheriters_from_class(base, &inheriters);
+		for (List<StringName>::Element *E = inheriters.front(); E; E = E->next()) {
+			p_vector->insert(E->get());
+		}
+
+		for (List<StringName>::Element *E = global_classes.front(); E; E = E->next()) {
+			if (EditorNode::get_editor_data().script_class_is_parent(E->get(), base)) {
+				p_vector->insert(E->get());
+			}
+		}
+
+		if (p_with_convert) {
+			if (base == "SpatialMaterial") {
+				p_vector->insert("Texture");
+			} else if (base == "ShaderMaterial") {
+				p_vector->insert("Shader");
+			}
+		}
+	}
+
+	if (EditorNode::get_editor_data().get_custom_types().has("Resource")) {
+		Vector<EditorData::CustomType> custom_resources = EditorNode::get_editor_data().get_custom_types()["Resource"];
+
+		for (int i = 0; i < custom_resources.size(); i++) {
+			p_vector->insert(custom_resources[i].name);
+		}
+	}
+}
+
+bool EditorResourcePicker::_is_drop_valid(const Dictionary &p_drag_data) const {
+	if (base_type.empty()) {
+		return true;
+	}
+
+	Dictionary drag_data = p_drag_data;
+
+	Ref<Resource> res;
+	if (drag_data.has("type") && String(drag_data["type"]) == "script_list_element") {
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(drag_data["script_list_element"]);
+		res = se->get_edited_resource();
+	} else if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+		res = drag_data["resource"];
+	}
+
+	Set<String> allowed_types;
+	_get_allowed_types(true, &allowed_types);
+
+	if (res.is_valid() && _is_type_valid(res->get_class(), allowed_types)) {
+		return true;
+	}
+
+	if (res.is_valid() && !res->get_script().is_null()) {
+		Ref<Script> res_script = res->get_script();
+		StringName custom_class = EditorNode::get_singleton()->get_object_custom_type_name(res_script.ptr());
+		if (_is_type_valid(custom_class, allowed_types)) {
+			return true;
+		}
+	}
+
+	if (drag_data.has("type") && String(drag_data["type"]) == "files") {
+		Vector<String> files = drag_data["files"];
+
+		if (files.size() == 1) {
+			String file = files[0];
+
+			String file_type = EditorFileSystem::get_singleton()->get_file_type(file);
+			if (file_type != "" && _is_type_valid(file_type, allowed_types)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+bool EditorResourcePicker::_is_type_valid(const String p_type_name, Set<String> p_allowed_types) const {
+	for (Set<String>::Element *E = p_allowed_types.front(); E; E = E->next()) {
+		String at = E->get().strip_edges();
+		if (p_type_name == at || (ClassDB::class_exists(p_type_name) && ClassDB::is_parent_class(p_type_name, at)) || EditorNode::get_editor_data().script_class_is_parent(p_type_name, at)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+Variant EditorResourcePicker::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
+	if (edited_resource.is_valid()) {
+		return EditorNode::get_singleton()->drag_resource(edited_resource, p_from);
+	}
+
+	return Variant();
+}
+
+bool EditorResourcePicker::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
+	return editable && _is_drop_valid(p_data);
+}
+
+void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
+	ERR_FAIL_COND(!_is_drop_valid(p_data));
+
+	Dictionary drag_data = p_data;
+
+	Ref<Resource> dropped_resource;
+	if (drag_data.has("type") && String(drag_data["type"]) == "script_list_element") {
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(drag_data["script_list_element"]);
+		dropped_resource = se->get_edited_resource();
+	} else if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+		dropped_resource = drag_data["resource"];
+	}
+
+	if (!dropped_resource.is_valid() && drag_data.has("type") && String(drag_data["type"]) == "files") {
+		Vector<String> files = drag_data["files"];
+
+		if (files.size() == 1) {
+			String file = files[0];
+			dropped_resource = ResourceLoader::load(file);
+		}
+	}
+
+	if (dropped_resource.is_valid()) {
+		Set<String> allowed_types;
+		_get_allowed_types(false, &allowed_types);
+
+		// If the accepted dropped resource is from the extended list, it requires conversion.
+		if (!_is_type_valid(dropped_resource->get_class(), allowed_types)) {
+			for (Set<String>::Element *E = allowed_types.front(); E; E = E->next()) {
+				String at = E->get().strip_edges();
+
+				if (at == "SpatialMaterial" && ClassDB::is_parent_class(dropped_resource->get_class(), "Texture")) {
+					Ref<SpatialMaterial> mat = memnew(SpatialMaterial);
+					mat->set_texture(SpatialMaterial::TextureParam::TEXTURE_ALBEDO, dropped_resource);
+					dropped_resource = mat;
+					break;
+				}
+
+				if (at == "ShaderMaterial" && ClassDB::is_parent_class(dropped_resource->get_class(), "Shader")) {
+					Ref<ShaderMaterial> mat = memnew(ShaderMaterial);
+					mat->set_shader(dropped_resource);
+					dropped_resource = mat;
+					break;
+				}
+			}
+		}
+
+		edited_resource = dropped_resource;
+		emit_signal("resource_changed", edited_resource);
+		_update_resource();
+	}
+}
+
+void EditorResourcePicker::_bind_methods() {
+	// Internal binds.
+	ClassDB::bind_method(D_METHOD("_file_selected"), &EditorResourcePicker::_file_selected);
+	ClassDB::bind_method(D_METHOD("_resource_selected"), &EditorResourcePicker::_resource_selected);
+	ClassDB::bind_method(D_METHOD("_button_draw"), &EditorResourcePicker::_button_draw);
+	ClassDB::bind_method(D_METHOD("_button_input"), &EditorResourcePicker::_button_input);
+	ClassDB::bind_method(D_METHOD("_update_menu"), &EditorResourcePicker::_update_menu);
+	ClassDB::bind_method(D_METHOD("_edit_menu_cbk"), &EditorResourcePicker::_edit_menu_cbk);
+
+	// Public binds.
+	ClassDB::bind_method(D_METHOD("_update_resource_preview"), &EditorResourcePicker::_update_resource_preview);
+	ClassDB::bind_method(D_METHOD("get_drag_data_fw", "position", "from"), &EditorResourcePicker::get_drag_data_fw);
+	ClassDB::bind_method(D_METHOD("can_drop_data_fw", "position", "data", "from"), &EditorResourcePicker::can_drop_data_fw);
+	ClassDB::bind_method(D_METHOD("drop_data_fw", "position", "data", "from"), &EditorResourcePicker::drop_data_fw);
+
+	ClassDB::bind_method(D_METHOD("set_base_type", "base_type"), &EditorResourcePicker::set_base_type);
+	ClassDB::bind_method(D_METHOD("get_base_type"), &EditorResourcePicker::get_base_type);
+	ClassDB::bind_method(D_METHOD("get_allowed_types"), &EditorResourcePicker::get_allowed_types);
+	ClassDB::bind_method(D_METHOD("set_edited_resource", "resource"), &EditorResourcePicker::set_edited_resource);
+	ClassDB::bind_method(D_METHOD("get_edited_resource"), &EditorResourcePicker::get_edited_resource);
+	ClassDB::bind_method(D_METHOD("set_toggle_mode", "enable"), &EditorResourcePicker::set_toggle_mode);
+	ClassDB::bind_method(D_METHOD("is_toggle_mode"), &EditorResourcePicker::is_toggle_mode);
+	ClassDB::bind_method(D_METHOD("set_toggle_pressed", "pressed"), &EditorResourcePicker::set_toggle_pressed);
+	ClassDB::bind_method(D_METHOD("set_editable", "enable"), &EditorResourcePicker::set_editable);
+	ClassDB::bind_method(D_METHOD("is_editable"), &EditorResourcePicker::is_editable);
+
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("set_create_options", PropertyInfo(Variant::OBJECT, "menu_node")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("handle_menu_selected", PropertyInfo(Variant::INT, "id")));
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "base_type"), "set_base_type", "get_base_type");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "edited_resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource", 0), "set_edited_resource", "get_edited_resource");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
+
+	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
+	ADD_SIGNAL(MethodInfo("resource_changed", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
+}
+
+void EditorResourcePicker::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			_update_resource();
+			FALLTHROUGH;
+		}
+		case NOTIFICATION_THEME_CHANGED: {
+			edit_button->set_icon(get_icon("select_arrow", "Tree"));
+		} break;
+
+		case NOTIFICATION_DRAW: {
+			draw_style_box(get_stylebox("bg", "Tree"), Rect2(Point2(), get_size()));
+		} break;
+
+		case NOTIFICATION_DRAG_BEGIN: {
+			if (editable && _is_drop_valid(get_viewport()->gui_get_drag_data())) {
+				dropping = true;
+				assign_button->update();
+			}
+		} break;
+
+		case NOTIFICATION_DRAG_END: {
+			if (dropping) {
+				dropping = false;
+				assign_button->update();
+			}
+		} break;
+	}
+}
+
+void EditorResourcePicker::set_base_type(const String &p_base_type) {
+	base_type = p_base_type;
+
+	// There is a possibility that the new base type is conflicting with the existing value.
+	// Keep the value, but warn the user that there is a potential mistake.
+	if (!base_type.empty() && edited_resource.is_valid()) {
+		Set<String> allowed_types;
+		_get_allowed_types(true, &allowed_types);
+
+		StringName custom_class;
+		bool is_custom = false;
+		if (!edited_resource->get_script().is_null()) {
+			Ref<Script> res_script = edited_resource->get_script();
+			custom_class = EditorNode::get_singleton()->get_object_custom_type_name(res_script.ptr());
+			is_custom = _is_type_valid(custom_class, allowed_types);
+		}
+
+		if (!is_custom && !_is_type_valid(edited_resource->get_class(), allowed_types)) {
+			String class_str = (custom_class == StringName() ? edited_resource->get_class() : vformat("%s (%s)", custom_class, edited_resource->get_class()));
+			WARN_PRINT(vformat("Value mismatch between the new base type of this EditorResourcePicker, '%s', and the type of the value it already has, '%s'.", base_type, class_str));
+		}
+	}
+}
+
+String EditorResourcePicker::get_base_type() const {
+	return base_type;
+}
+
+Vector<String> EditorResourcePicker::get_allowed_types() const {
+	Set<String> allowed_types;
+	_get_allowed_types(false, &allowed_types);
+
+	Vector<String> types;
+	types.resize(allowed_types.size());
+
+	int i = 0;
+	String *w = types.ptrw();
+	for (Set<String>::Element *E = allowed_types.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+
+	return types;
+}
+
+void EditorResourcePicker::set_edited_resource(RES p_resource) {
+	if (!p_resource.is_valid()) {
+		edited_resource = RES();
+		_update_resource();
+		return;
+	}
+
+	if (!base_type.empty()) {
+		Set<String> allowed_types;
+		_get_allowed_types(true, &allowed_types);
+
+		StringName custom_class;
+		bool is_custom = false;
+		if (!p_resource->get_script().is_null()) {
+			Ref<Script> res_script = p_resource->get_script();
+			custom_class = EditorNode::get_singleton()->get_object_custom_type_name(res_script.ptr());
+			is_custom = _is_type_valid(custom_class, allowed_types);
+		}
+
+		if (!is_custom && !_is_type_valid(p_resource->get_class(), allowed_types)) {
+			String class_str = (custom_class == StringName() ? p_resource->get_class() : vformat("%s (%s)", custom_class, p_resource->get_class()));
+			ERR_FAIL_MSG(vformat("Failed to set a resource of the type '%s' because this EditorResourcePicker only accepts '%s' and its derivatives.", class_str, base_type));
+		}
+	}
+
+	edited_resource = p_resource;
+	_update_resource();
+}
+
+RES EditorResourcePicker::get_edited_resource() {
+	return edited_resource;
+}
+
+void EditorResourcePicker::set_toggle_mode(bool p_enable) {
+	assign_button->set_toggle_mode(p_enable);
+}
+
+bool EditorResourcePicker::is_toggle_mode() const {
+	return assign_button->is_toggle_mode();
+}
+
+void EditorResourcePicker::set_toggle_pressed(bool p_pressed) {
+	if (!is_toggle_mode()) {
+		return;
+	}
+
+	assign_button->set_pressed(p_pressed);
+}
+
+void EditorResourcePicker::set_editable(bool p_editable) {
+	editable = p_editable;
+	assign_button->set_disabled(!editable);
+	edit_button->set_visible(editable);
+}
+
+bool EditorResourcePicker::is_editable() const {
+	return editable;
+}
+
+EditorResourcePicker::EditorResourcePicker() {
+	assign_button = memnew(Button);
+	assign_button->set_flat(true);
+	assign_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	assign_button->set_clip_text(true);
+	assign_button->set_drag_forwarding(this);
+	add_child(assign_button);
+	assign_button->connect("pressed", this, "_resource_selected");
+	assign_button->connect("draw", this, "_button_draw");
+	assign_button->connect("gui_input", this, "_button_input");
+
+	preview_rect = memnew(TextureRect);
+	preview_rect->set_expand(true);
+	preview_rect->set_anchors_and_margins_preset(PRESET_WIDE);
+	preview_rect->set_margin(MARGIN_TOP, 1);
+	preview_rect->set_margin(MARGIN_BOTTOM, -1);
+	preview_rect->set_margin(MARGIN_RIGHT, -1);
+	assign_button->add_child(preview_rect);
+
+	edit_button = memnew(Button);
+	edit_button->set_flat(true);
+	edit_button->set_toggle_mode(true);
+	edit_button->connect("pressed", this, "_update_menu");
+	add_child(edit_button);
+	edit_button->connect("gui_input", this, "_button_input");
+	edit_menu = memnew(PopupMenu);
+	add_child(edit_menu);
+	edit_menu->connect("id_pressed", this, "_edit_menu_cbk");
+	edit_menu->connect("popup_hide", edit_button, "set_pressed", varray(false));
+}
+
+void EditorScriptPicker::set_create_options(Object *p_menu_node) {
+	PopupMenu *menu_node = Object::cast_to<PopupMenu>(p_menu_node);
+	if (!menu_node) {
+		return;
+	}
+
+	menu_node->add_icon_item(get_icon("ScriptCreate", "EditorIcons"), TTR("New Script"), OBJ_MENU_NEW_SCRIPT);
+	menu_node->add_icon_item(get_icon("ScriptExtend", "EditorIcons"), TTR("Extend Script"), OBJ_MENU_EXTEND_SCRIPT);
+	menu_node->add_separator();
+}
+
+bool EditorScriptPicker::handle_menu_selected(int p_which) {
+	switch (p_which) {
+		case OBJ_MENU_NEW_SCRIPT: {
+			if (script_owner) {
+				EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(script_owner, false);
+			}
+			return true;
+		}
+
+		case OBJ_MENU_EXTEND_SCRIPT: {
+			if (script_owner) {
+				EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(script_owner, true);
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void EditorScriptPicker::set_script_owner(Node *p_owner) {
+	script_owner = p_owner;
+}
+
+Node *EditorScriptPicker::get_script_owner() const {
+	return script_owner;
+}
+
+void EditorScriptPicker::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_script_owner", "owner_node"), &EditorScriptPicker::set_script_owner);
+	ClassDB::bind_method(D_METHOD("get_script_owner"), &EditorScriptPicker::get_script_owner);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "script_owner", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0), "set_script_owner", "get_script_owner");
+}
+
+EditorScriptPicker::EditorScriptPicker() {
+}

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -1,0 +1,141 @@
+/*************************************************************************/
+/*  editor_resource_picker.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef EDITOR_RESOURCE_PICKER_H
+#define EDITOR_RESOURCE_PICKER_H
+
+#include "editor_file_dialog.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/popup_menu.h"
+#include "scene/gui/texture_rect.h"
+
+class EditorResourcePicker : public HBoxContainer {
+	GDCLASS(EditorResourcePicker, HBoxContainer);
+
+	String base_type;
+	RES edited_resource;
+
+	bool editable = true;
+	bool dropping = false;
+
+	Vector<String> inheritors_array;
+
+	Button *assign_button;
+	TextureRect *preview_rect;
+	Button *edit_button;
+	EditorFileDialog *file_dialog = nullptr;
+
+	enum MenuOption {
+		OBJ_MENU_LOAD,
+		OBJ_MENU_EDIT,
+		OBJ_MENU_CLEAR,
+		OBJ_MENU_MAKE_UNIQUE,
+		OBJ_MENU_SAVE,
+		OBJ_MENU_COPY,
+		OBJ_MENU_PASTE,
+		OBJ_MENU_SHOW_IN_FILE_SYSTEM,
+
+		TYPE_BASE_ID = 100,
+		CONVERT_BASE_ID = 1000,
+	};
+
+	PopupMenu *edit_menu;
+
+	void _update_resource();
+	void _update_resource_preview(const String &p_path, const Ref<Texture> &p_preview, const Ref<Texture> &p_small_preview, ObjectID p_obj);
+
+	void _resource_selected();
+	void _file_selected(const String &p_path);
+
+	void _update_menu();
+	void _update_menu_items();
+	void _edit_menu_cbk(int p_which);
+
+	void _button_draw();
+	void _button_input(const Ref<InputEvent> &p_event);
+
+	void _get_allowed_types(bool p_with_convert, Set<String> *p_vector) const;
+	bool _is_drop_valid(const Dictionary &p_drag_data) const;
+	bool _is_type_valid(const String p_type_name, Set<String> p_allowed_types) const;
+
+	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
+	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
+	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	void set_base_type(const String &p_base_type);
+	String get_base_type() const;
+	Vector<String> get_allowed_types() const;
+
+	void set_edited_resource(RES p_resource);
+	RES get_edited_resource();
+
+	void set_toggle_mode(bool p_enable);
+	bool is_toggle_mode() const;
+	void set_toggle_pressed(bool p_pressed);
+
+	void set_editable(bool p_editable);
+	bool is_editable() const;
+
+	virtual void set_create_options(Object *p_menu_node);
+	virtual bool handle_menu_selected(int p_which);
+
+	EditorResourcePicker();
+};
+
+class EditorScriptPicker : public EditorResourcePicker {
+	GDCLASS(EditorScriptPicker, EditorResourcePicker);
+
+	enum ExtraMenuOption {
+		OBJ_MENU_NEW_SCRIPT = 10,
+		OBJ_MENU_EXTEND_SCRIPT = 11
+	};
+
+	Node *script_owner = nullptr;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual void set_create_options(Object *p_menu_node);
+	virtual bool handle_menu_selected(int p_which);
+
+	void set_script_owner(Node *p_owner);
+	Node *get_script_owner() const;
+
+	EditorScriptPicker();
+};
+
+#endif // EDITOR_RESOURCE_PICKER_H


### PR DESCRIPTION
This backport includes:

1. Exposing `EditorResourcePicker` and `EditorScriptPicker` (#47260, with #49068 bugfix).
2. Use new controls in the editor's Inspector dock (#48854).

Should be more or less the same as the `master` version. I've also noticed that there is no code for auto-converting some data types into their appropriate resources, the code is present in `master`. I saw no downside from including it, though I had to omit `FontType` -> `Font` conversion due to fonts being very different in `3.x`.

All changes are split into individual commits related to each backported PR.