### PR TITLE
[3.x] AnimatedSprite Fix updating inspector when SpriteFrames is modified

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1448,8 +1448,7 @@ void EditorInspector::update_tree() {
 	String group_base;
 	VBoxContainer *category_vbox = nullptr;
 
-	List<PropertyInfo>
-			plist;
+	List<PropertyInfo> plist;
 	object->get_property_list(&plist, true);
 
 	HashMap<String, VBoxContainer *> item_path;

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -744,15 +744,19 @@ void SpriteFramesEditor::_animation_name_edited() {
 	undo_redo->add_undo_method(frames, "rename_animation", name, edited_anim);
 
 	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
-		String current = E->get()->call("get_animation");
+		StringName current = E->get()->call("get_animation");
+		if (current != edited_anim) {
+			continue;
+		}
+
 		undo_redo->add_do_method(E->get(), "set_animation", name);
-		undo_redo->add_undo_method(E->get(), "set_animation", edited_anim);
+		undo_redo->add_undo_method(E->get(), "set_animation", current);
 	}
 
 	undo_redo->add_do_method(this, "_update_library");
 	undo_redo->add_undo_method(this, "_update_library");
 
-	edited_anim = new_name;
+	edited_anim = name;
 
 	undo_redo->commit_action();
 }
@@ -774,8 +778,14 @@ void SpriteFramesEditor::_animation_add() {
 	undo_redo->add_do_method(this, "_update_library");
 	undo_redo->add_undo_method(this, "_update_library");
 
+	// Assign the newly added animation to the edited anim sprite and to all other anim sprites having invalid animation.
+	Object *edited_anim_sprite = EditorNode::get_singleton()->get_inspector()->get_edited_object();
 	for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
-		String current = E->get()->call("get_animation");
+		StringName current = E->get()->call("get_animation");
+		if (frames->has_animation(current) && E->get() != edited_anim_sprite) {
+			continue;
+		}
+
 		undo_redo->add_do_method(E->get(), "set_animation", name);
 		undo_redo->add_undo_method(E->get(), "set_animation", current);
 	}
@@ -810,10 +820,35 @@ void SpriteFramesEditor::_animation_remove_confirmed() {
 		Ref<Texture> frame = frames->get_frame(edited_anim, i);
 		undo_redo->add_undo_method(frames, "add_frame", edited_anim, frame);
 	}
+
+	StringName new_edited_anim = StringName();
+
+	List<StringName> anim_names;
+	frames->get_animation_list(&anim_names);
+	anim_names.sort_custom<StringName::AlphCompare>();
+
+	// If removing not the last animation, make the first animation left the new edited one.
+	if (anim_names.size() > 1) {
+		new_edited_anim = edited_anim != anim_names.front()->get() ? anim_names.front()->get() : anim_names.front()->next()->get();
+
+		List<Node *> nodes;
+		_find_anim_sprites(EditorNode::get_singleton()->get_edited_scene(), &nodes, Ref<SpriteFrames>(frames));
+
+		for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
+			StringName current = E->get()->call("get_animation");
+			if (current != edited_anim) {
+				continue;
+			}
+
+			undo_redo->add_do_method(E->get(), "set_animation", new_edited_anim);
+			undo_redo->add_undo_method(E->get(), "set_animation", current);
+		}
+	}
+
 	undo_redo->add_do_method(this, "_update_library");
 	undo_redo->add_undo_method(this, "_update_library");
 
-	edited_anim = StringName();
+	edited_anim = new_edited_anim;
 
 	undo_redo->commit_action();
 }

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -147,7 +147,7 @@ void SpriteFrames::clear(const StringName &p_anim) {
 
 void SpriteFrames::clear_all() {
 	animations.clear();
-	add_animation("default");
+	add_animation("default"); // Also emits changed.
 }
 
 void SpriteFrames::add_animation(const StringName &p_anim) {
@@ -155,13 +155,16 @@ void SpriteFrames::add_animation(const StringName &p_anim) {
 
 	animations[p_anim] = Anim();
 	animations[p_anim].normal_name = String(p_anim) + NORMAL_SUFFIX;
+	emit_changed();
 }
 
 bool SpriteFrames::has_animation(const StringName &p_anim) const {
 	return animations.has(p_anim);
 }
 void SpriteFrames::remove_animation(const StringName &p_anim) {
-	animations.erase(p_anim);
+	if (animations.erase(p_anim)) {
+		emit_changed();
+	}
 }
 
 void SpriteFrames::rename_animation(const StringName &p_prev, const StringName &p_next) {
@@ -172,17 +175,7 @@ void SpriteFrames::rename_animation(const StringName &p_prev, const StringName &
 	animations.erase(p_prev);
 	animations[p_next] = anim;
 	animations[p_next].normal_name = String(p_next) + NORMAL_SUFFIX;
-}
-
-Vector<String> SpriteFrames::_get_animation_list() const {
-	Vector<String> ret;
-	List<StringName> al;
-	get_animation_list(&al);
-	for (List<StringName>::Element *E = al.front(); E; E = E->next()) {
-		ret.push_back(E->get());
-	}
-
-	return ret;
+	emit_changed();
 }
 
 void SpriteFrames::get_animation_list(List<StringName> *r_animations) const {
@@ -571,8 +564,12 @@ bool AnimatedSprite::is_flipped_v() const {
 
 void AnimatedSprite::_res_changed() {
 	set_frame(frame);
-	_change_notify("frame");
-	_change_notify("animation");
+
+	// Calling _change_notify("frame") and _change_notify("animation") instead wouldn't
+	// make EditorInspector trigger calls to _validate_property(property) which would
+	// lead to not updating valid values for "frame" and "animation" properties.
+	_change_notify();
+
 	update();
 }
 

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -58,8 +58,6 @@ class SpriteFrames : public Resource {
 	Array _get_animations() const;
 	void _set_animations(const Array &p_animations);
 
-	Vector<String> _get_animation_list() const;
-
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION



(needs a separate `master` version due to #45879; for the same reason some issues fixed here might already be non-existent in the `master`; haven't checked none of these)

Makes creating / renaming / deleting animations in the `SpriteFramesEditorPlugin` properly update properties of the `AnimatedSprite` in the inspector (mainly options in the animation dropdown). Removing current animation of the `AnimatedSprite` will make the first (after removal) animation left be selected as the new current animation (if no animation would be left then nothing will be done from the inspector point of view). 


Reverts #27254 but keeps #26381 being fixed.
Fixes #44438.
Fixes #46741.
Fixes #28658, fixes #40263 (these look like duplicates).

Removes unused `SpriteFrames::_get_animation_list()` method.

~~After reverting #27254 newly created animation is no longer automatically set as the current animation of the `AnimatedSprite`/`AnimatedSprite3D` being edited. Should the current behavior be preserved (assigning it automatically)?~~
I've changed it so currently the newly created animation is automatically set as the current animation of the anim sprite being edited (same as before), and the same for all other anim sprites having currently invalid animation set (same as before). But valid animations of other anim sprites will no longer be automatically changed (as they used to be).


