### PR TITLE
[CTL] Improve font fallback order selection.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2352,24 +2352,22 @@ bool TextServerAdvanced::shaped_text_shape(RID p_shaped) {
 							sd->glyphs.push_back(gl);
 						} else {
 							Vector<RID> fonts;
-							// Push fonts with the language and script support first.
-							for (int l = 0; l < span.fonts.size(); l++) {
-								if ((font_is_language_supported(span.fonts[l], span.language)) && (font_is_script_supported(span.fonts[l], script))) {
-									fonts.push_back(sd->spans[k].fonts[l]);
+							Vector<RID> fonts_scr_only;
+							Vector<RID> fonts_no_match;
+							int font_count = span.fonts.size();
+							for (int l = 0; l < font_count; l++) {
+								if (font_is_script_supported(span.fonts[l], script)) {
+									if (font_is_language_supported(span.fonts[l], span.language)) {
+										fonts.push_back(sd->spans[k].fonts[l]);
+									} else {
+										fonts_scr_only.push_back(sd->spans[k].fonts[l]);
+									}
+								} else {
+									fonts_no_match.push_back(sd->spans[k].fonts[l]);
 								}
 							}
-							// Push fonts with the script support.
-							for (int l = 0; l < sd->spans[k].fonts.size(); l++) {
-								if (!(font_is_language_supported(span.fonts[l], span.language)) && (font_is_script_supported(span.fonts[l], script))) {
-									fonts.push_back(sd->spans[k].fonts[l]);
-								}
-							}
-							// Push the rest valid fonts.
-							for (int l = 0; l < sd->spans[k].fonts.size(); l++) {
-								if (!(font_is_language_supported(span.fonts[l], span.language)) && !(font_is_script_supported(span.fonts[l], script))) {
-									fonts.push_back(sd->spans[k].fonts[l]);
-								}
-							}
+							fonts.append_array(fonts_scr_only);
+							fonts.append_array(fonts_no_match);
 							_shape_run(sd, MAX(sd->spans[k].start, script_run_start), MIN(sd->spans[k].end, script_run_end), sd->script_iter->script_ranges[j].script, bidi_run_direction, fonts, k, 0);
 						}
 					}

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -634,17 +634,17 @@ bool TextServerFallback::shaped_text_add_string(RID p_shaped, const String &p_te
 	span.start = sd->text.length();
 	span.end = span.start + p_text.length();
 	// Pre-sort fonts, push fonts with the language support first.
-	for (int i = 0; i < p_fonts.size(); i++) {
+	Vector<RID> fonts_no_match;
+	int font_count = p_fonts.size();
+	for (int i = 0; i < font_count; i++) {
 		if (font_is_language_supported(p_fonts[i], p_language)) {
 			span.fonts.push_back(p_fonts[i]);
+		} else {
+			fonts_no_match.push_back(p_fonts[i]);
 		}
 	}
-	// Push the rest valid fonts.
-	for (int i = 0; i < p_fonts.size(); i++) {
-		if (!font_is_language_supported(p_fonts[i], p_language)) {
-			span.fonts.push_back(p_fonts[i]);
-		}
-	}
+	span.fonts.append_array(fonts_no_match);
+
 	ERR_FAIL_COND_V(span.fonts.is_empty(), false);
 	span.font_size = p_size;
 	span.language = p_language;


### PR DESCRIPTION
Fix loosing fallback fonts in some cases, and decrease overall number of `is_language_supported`/`is_script_supported` checks.