### PR TITLE
Correcting path recording in the recent directory list

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -294,7 +294,10 @@ void EditorFileDialog::_post_popup() {
 			if (res && name == "res://") {
 				name = "/";
 			} else {
-				name = name.get_file() + "/";
+			  if(name[name.length()-1] == '/'){
+			    name.erase(name.length()-1, 1);
+			  }
+			  name = name.get_file() + "/";		  
 			}
 			bool exists = dir_access->dir_exists(recentd[i]);
 			if (!exists) {

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -294,10 +294,10 @@ void EditorFileDialog::_post_popup() {
 			if (res && name == "res://") {
 				name = "/";
 			} else {
-			  if(name[name.length()-1] == '/'){
-			    name.erase(name.length()-1, 1);
-			  }
-			  name = name.get_file() + "/";		  
+				if(name.ends_with("/")){
+					name.erase(name.length() - 1, 1);
+				}
+				name = name.get_file() + "/";		  
 			}
 			bool exists = dir_access->dir_exists(recentd[i]);
 			if (!exists) {


### PR DESCRIPTION
Fixes Issue #49453. Paths ending in slashes should now be treated the same as paths not ending in a slash in editor pop-up windows.

The bug arises from string's get_file() function only getting the path ending when the file name is after the final slash(/). Thus, I've added an if statement and a string::erase to revise the string in the event that a user enters a path ending in a slash.

<I>Bugsquad edit</i>: Fix #49453