### PR TITLE
[WIP] Fix RID get_ptr_by_index access to freed objects

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3522,11 +3522,15 @@ void RendererSceneCull::update_dirty_instances() {
 
 void RendererSceneCull::update() {
 	//optimize bvhs
-	for (uint32_t i = 0; i < scenario_owner.get_rid_count(); i++) {
-		Scenario *s = scenario_owner.get_ptr_by_index(i);
-		s->indexers[Scenario::INDEXER_GEOMETRY].optimize_incremental(indexer_update_iterations);
-		s->indexers[Scenario::INDEXER_VOLUMES].optimize_incremental(indexer_update_iterations);
+	uint32_t i = UINT32_MAX;
+	while (scenario_owner.find_next_valid_alloc_id(i)) {
+		Scenario *s = scenario_owner.get_ptr_by_alloc_id(i);
+		if (s) {
+			s->indexers[Scenario::INDEXER_GEOMETRY].optimize_incremental(indexer_update_iterations);
+			s->indexers[Scenario::INDEXER_VOLUMES].optimize_incremental(indexer_update_iterations);
+		}
 	}
+
 	scene_render->update();
 	update_dirty_instances();
 	render_particle_colliders();


### PR DESCRIPTION
RID_Alloc get_ptr_by_index was allowing access to objects that had previously been freed, causing crashes in the BVH.

This PR changes the function to iterate by allocation id rather than index, and provides protection against access to freed allocations.

Fixes #44973

## Notes
* Thanks to extensive debugging by @pouleyKetchoupp the issue was tracked down to access to freed memory
* This is a rough PR for discussion as I need to check it with pouley and reduz, and reduz may want to make / decide on the final PR. In particular I'm unsure whether the `validator_chunks` index used should be `p_index` or `idx`, I'm just guessing by reverse engineering the existing code.
* There are probably multiple ways of fixing this.
* Let me know of preferences for different names for functions etc.

## Update
This version is changed to iterate through the list by allocation ID rather than `index` .. it doesn't matter the order for the BVH, and I suspect the `index` is semi random anyway, and iterating by `alloc_id` is more efficient and simpler.

While we could just check for nullptr and access up to `max_alloc` sequentially, it is inefficient if there are a lot of invalid allocations in the list, because of the spinlock .. so I'm trying a single function to move an iterator on to the next valid `alloc_id`.

* We can alternatively iterate by `index` if desired, it isn't hugely different.
* The other alternative is to maintain a separate list of used elements, similar to the free list, but this may be overkill for the use case (although we should consider whether this would be generally useful functionality for RID_PtrOwners).
* Note that this implementation does a fair amount of naive silliness compared to having a `used_list`, like if there are 512 members in the scenario minimum chunk size, it will iterate through all 512, even if only 1 is active.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
