### PR TITLE
fix String::get_slice_count

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1022,7 +1022,7 @@ int String::get_slice_count(String p_splitter) const {
 	}
 
 	int pos = 0;
-	int slices = 1;
+	int slices = 0;
 
 	while ((pos = find(p_splitter, pos)) >= 0) {
 		slices++;


### PR DESCRIPTION
from what I undestand the current behaviour would always return the actual count +1. get_slice_count should return 0 if no slice was found and not 1. This changes fixes my use case where I tried to parse an URL with a port number ```127.0.0.1:8000/test``` and getting invalid parameter.