### PR TITLE
fix url parsing with port numbers

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -275,7 +275,7 @@ Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r
 		base = base.substr(pos + 1, base.length() - pos - 1);
 	} else {
 		// Anything else
-		if (base.get_slice_count(":") > 1) {
+		if (base.get_slice_count(":") > 2) {
 			return ERR_INVALID_PARAMETER;
 		}
 		pos = base.rfind(":");


### PR DESCRIPTION
String.get_slice_count is always at least 1 or 2 for bases with a port number.
Before this change the following URL would return ERR_INVALID_PARAMETER ```ws://127.0.0.1:8000/test```

*Bugsquad edit:* Fixup to #48205. Fixes #49652.