### PR TITLE
Prefer discrete GPU over integrated one

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -379,8 +379,25 @@ Error VulkanContext::_create_physical_device() {
 		free(physical_devices);
 		ERR_FAIL_V(ERR_CANT_CREATE);
 	}
-	/* for now, just grab the first physical device */
+
+	// TODO: At least on Linux Laptops integrated GPUs fail with Vulkan in many instances.
+	//   The device should really be a preference, but for now choosing a discrete GPU over the
+	//   integrated one is better than the default.
+
+	// Default to first device
 	uint32_t device_index = 0;
+
+	for (uint32_t i = 0; i < gpu_count; ++i) {
+		VkPhysicalDeviceProperties props;
+		vkGetPhysicalDeviceProperties(physical_devices[i], &props);
+
+		if (props.deviceType == VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+			// Prefer discrete GPU.
+			device_index = i;
+			break;
+		}
+	}
+
 	gpu = physical_devices[device_index];
 	free(physical_devices);
 


### PR DESCRIPTION
This unblocks launching on Linux laptops that default to the integrated
GPU which can not handle Vulkan in many instances.
Ideally a manual device selection, or an option for the optimal selection
strategy should be provided via CLI or config, but for the time being
this will unblock the Linux devs.

Partially addresses #42348 and #43714

Supersedes #46070.