### PR TITLE
TextureButton Update min size on any texture change

### DIFF
--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -295,11 +295,13 @@ void TextureButton::set_normal_texture(const Ref<Texture2D> &p_normal) {
 void TextureButton::set_pressed_texture(const Ref<Texture2D> &p_pressed) {
 	pressed = p_pressed;
 	update();
+	minimum_size_changed();
 }
 
 void TextureButton::set_hover_texture(const Ref<Texture2D> &p_hover) {
 	hover = p_hover;
 	update();
+	minimum_size_changed();
 }
 
 void TextureButton::set_disabled_texture(const Ref<Texture2D> &p_disabled) {
@@ -310,6 +312,7 @@ void TextureButton::set_disabled_texture(const Ref<Texture2D> &p_disabled) {
 void TextureButton::set_click_mask(const Ref<BitMap> &p_click_mask) {
 	click_mask = p_click_mask;
 	update();
+	minimum_size_changed();
 }
 
 Ref<Texture2D> TextureButton::get_normal_texture() const {


### PR DESCRIPTION
Ensures minimum size of `TextureButton` is being updated when [any of its textures being involved into min size calculations](https://github.com/godotengine/godot/blob/9aedc020c37ed383c1829222d4b83a9a2cb66b59/scene/gui/texture_button.cpp#L37-L62) is being set.

Fixes #42256.
Cherry-pickable.
