### PR TITLE
Move render tree BVH frame update to occur in viewport draw

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -3474,18 +3474,8 @@ void VisualServerScene::_update_dirty_instance(Instance *p_instance) {
 void VisualServerScene::update_dirty_instances() {
 	VSG::storage->update_dirty_resources();
 
-	// this is just to get access to scenario so we can update the spatial partitioning scheme
-	Scenario *scenario = nullptr;
-	if (_instance_update_list.first()) {
-		scenario = _instance_update_list.first()->self()->scenario;
-	}
-
 	while (_instance_update_list.first()) {
 		_update_dirty_instance(_instance_update_list.first()->self());
-	}
-
-	if (scenario) {
-		scenario->sps->update();
 	}
 }
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -291,6 +291,12 @@ void VisualServerViewport::draw_viewports() {
 			continue;
 		}
 
+		// do once per frame spatial partitioning scene here because the scenario should be valid at this point
+		VisualServerScene::Scenario *scenario = VSG::scene->scenario_owner.getornull(vp->scenario);
+		if (scenario) {
+			scenario->sps->update();
+		}
+
 		VSG::storage->render_target_clear_used(vp->render_target);
 
 		if (vp->use_arvr && arvr_interface.is_valid()) {


### PR DESCRIPTION
Moves the render tree bvh update from `VisualServerScene::update_dirty_instances` to `VisualServerViewport::draw_viewports`. It is more clear that the scenario should be valid at this point (as the scenario is stored on the viewport), and this ensures update is called once per viewport draw, rather than possibly several times per frame in update_dirty_instances.

May help with #48749, #48790

I wouldn't suggest necessarily merging this straight away, but it will be good to have available for the artefacts for testing if we get anyone else who can replicate the above bugs.

## Notes
* I had been meaning to change the location of the render tree bvh update for a while, I tried it in #45311, but had to revert it in #45335 because that method was not sound
* The scenarios are usually created in Worlds, and even if not, they seem tightly bound to Viewports, so it seems to make sense to access the scenario for the update from Viewport (there is no other obvious list, the `scenario_owner` does not provide facilities for iterating the scenarios in Godot 3.x)
* There is a possibility that some of the bugs seen above are similar in nature to #44973 in Godot 4, which we tracked down to a problem of using scenarios after they had been freed. The same thing is theoretically possible in Godot 3, although perhaps less likely. The previous method of getting the scenario from instances assumes that the scenario is valid - however instances linked to the scenario do seem to get deleted with the scenario, so it may not be a problem in practice.
* This will probably result in less calls to update (which is good), it does however move the point in the code where collision callbacks can occur, which may or may not be a good thing, so this would need to be extensively tested in betas. If there are problems having the collision check here, another possibility is to separate the update call into two - the trickle optimization of the tree, and the collision check.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
