### PR TITLE
Remove unused `caret_background_color` theme item from TextEdit

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -466,8 +466,6 @@
 		</theme_item>
 		<theme_item name="can_fold" type="Texture2D">
 		</theme_item>
-		<theme_item name="caret_background_color" type="Color" default="Color( 0, 0, 0, 1 )">
-		</theme_item>
 		<theme_item name="caret_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 		</theme_item>
 		<theme_item name="code_folding_color" type="Color" default="Color( 0.8, 0.8, 0.8, 0.8 )">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -968,8 +968,6 @@
 		</theme_item>
 		<theme_item name="brace_mismatch_color" type="Color" default="Color( 1, 0.2, 0.2, 1 )">
 		</theme_item>
-		<theme_item name="caret_background_color" type="Color" default="Color( 0, 0, 0, 1 )">
-		</theme_item>
 		<theme_item name="caret_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 		</theme_item>
 		<theme_item name="code_folding_color" type="Color" default="Color( 0.8, 0.8, 0.8, 0.8 )">

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1518,7 +1518,6 @@ void CodeTextEditor::_update_text_editor_theme() {
 	text_editor->add_theme_color_override("font_color", EDITOR_GET("text_editor/highlighting/text_color"));
 	text_editor->add_theme_color_override("line_number_color", EDITOR_GET("text_editor/highlighting/line_number_color"));
 	text_editor->add_theme_color_override("caret_color", EDITOR_GET("text_editor/highlighting/caret_color"));
-	text_editor->add_theme_color_override("caret_background_color", EDITOR_GET("text_editor/highlighting/caret_background_color"));
 	text_editor->add_theme_color_override("font_selected_color", EDITOR_GET("text_editor/highlighting/text_selected_color"));
 	text_editor->add_theme_color_override("selection_color", EDITOR_GET("text_editor/highlighting/selection_color"));
 	text_editor->add_theme_color_override("brace_mismatch_color", EDITOR_GET("text_editor/highlighting/brace_mismatch_color"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -804,7 +804,6 @@ void EditorSettings::_load_godot2_text_editor_theme() {
 	_initial_set("text_editor/highlighting/line_number_color", Color(0.67, 0.67, 0.67, 0.4));
 	_initial_set("text_editor/highlighting/safe_line_number_color", Color(0.67, 0.78, 0.67, 0.6));
 	_initial_set("text_editor/highlighting/caret_color", Color(0.67, 0.67, 0.67));
-	_initial_set("text_editor/highlighting/caret_background_color", Color(0, 0, 0));
 	_initial_set("text_editor/highlighting/text_selected_color", Color(0, 0, 0));
 	_initial_set("text_editor/highlighting/selection_color", Color(0.41, 0.61, 0.91, 0.35));
 	_initial_set("text_editor/highlighting/brace_mismatch_color", Color(1, 0.2, 0.2));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1416,7 +1416,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		setting->set_initial_value("text_editor/highlighting/line_number_color", line_number_color, true);
 		setting->set_initial_value("text_editor/highlighting/safe_line_number_color", safe_line_number_color, true);
 		setting->set_initial_value("text_editor/highlighting/caret_color", caret_color, true);
-		setting->set_initial_value("text_editor/highlighting/caret_background_color", caret_background_color, true);
 		setting->set_initial_value("text_editor/highlighting/text_selected_color", text_selected_color, true);
 		setting->set_initial_value("text_editor/highlighting/selection_color", selection_color, true);
 		setting->set_initial_value("text_editor/highlighting/brace_mismatch_color", brace_mismatch_color, true);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4397,7 +4397,6 @@ void TextEdit::_update_caches() {
 	cache.outline_color = get_theme_color("font_outline_color");
 	cache.outline_size = get_theme_constant("outline_size");
 	cache.caret_color = get_theme_color("caret_color");
-	cache.caret_background_color = get_theme_color("caret_background_color");
 	cache.font_color = get_theme_color("font_color");
 	cache.font_selected_color = get_theme_color("font_selected_color");
 	cache.font_readonly_color = get_theme_color("font_readonly_color");

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -448,7 +448,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("code_folding_color", "TextEdit", Color(0.8, 0.8, 0.8, 0.8));
 	theme->set_color("current_line_color", "TextEdit", Color(0.25, 0.25, 0.26, 0.8));
 	theme->set_color("caret_color", "TextEdit", control_font_color);
-	theme->set_color("caret_background_color", "TextEdit", Color(0, 0, 0));
 	theme->set_color("brace_mismatch_color", "TextEdit", Color(1, 0.2, 0.2));
 	theme->set_color("word_highlighted_color", "TextEdit", Color(0.8, 0.9, 0.9, 0.15));
 
@@ -490,7 +489,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("code_folding_color", "CodeEdit", Color(0.8, 0.8, 0.8, 0.8));
 	theme->set_color("current_line_color", "CodeEdit", Color(0.25, 0.25, 0.26, 0.8));
 	theme->set_color("caret_color", "CodeEdit", control_font_color);
-	theme->set_color("caret_background_color", "CodeEdit", Color(0, 0, 0));
 	theme->set_color("brace_mismatch_color", "CodeEdit", Color(1, 0.2, 0.2));
 	theme->set_color("line_number_color", "CodeEdit", Color(0.67, 0.67, 0.67, 0.4));
 	theme->set_color("safe_line_number_color", "CodeEdit", Color(0.67, 0.78, 0.67, 0.6));


### PR DESCRIPTION
This color wasn't used anywhere.

Since this is a theme item (and not a property), removing it shouldn't break existing any projects, so we can probably cherry-pick this for `3.4`. This would also be useful to remove the associated editor setting which does nothing.

I found this out while working on https://github.com/godotengine/godot/pull/48548.