### PR TITLE
Document editor import options in the class reference

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -394,6 +394,15 @@ Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_name(const String 
 	return Ref<ResourceImporter>();
 }
 
+void ResourceFormatImporter::add_importer(const Ref<ResourceImporter> &p_importer, bool p_first_priority) {
+	ERR_FAIL_COND(p_importer.is_null());
+	if (p_first_priority) {
+		importers.insert(0, p_importer);
+	} else {
+		importers.push_back(p_importer);
+	}
+}
+
 void ResourceFormatImporter::get_importers_for_extension(const String &p_extension, List<Ref<ResourceImporter>> *r_importers) {
 	for (int i = 0; i < importers.size(); i++) {
 		List<String> local_exts;
@@ -472,18 +481,11 @@ ResourceFormatImporter::ResourceFormatImporter() {
 	singleton = this;
 }
 
+//////////////
+
 void ResourceImporter::_bind_methods() {
 	BIND_ENUM_CONSTANT(IMPORT_ORDER_DEFAULT);
 	BIND_ENUM_CONSTANT(IMPORT_ORDER_SCENE);
-}
-
-void ResourceFormatImporter::add_importer(const Ref<ResourceImporter> &p_importer, bool p_first_priority) {
-	ERR_FAIL_COND(p_importer.is_null());
-	if (p_first_priority) {
-		importers.insert(0, p_importer);
-	} else {
-		importers.push_back(p_importer);
-	}
 }
 
 /////

--- a/doc/classes/ResourceImporterBMFont.xml
+++ b/doc/classes/ResourceImporterBMFont.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterBMFont" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="compress" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="fallbacks" type="Array" setter="" getter="" default="[]">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterBitMap.xml
+++ b/doc/classes/ResourceImporterBitMap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterBitMap" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="create_from" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="threshold" type="float" setter="" getter="" default="0.5">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterCSVTranslation.xml
+++ b/doc/classes/ResourceImporterCSVTranslation.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterCSVTranslation" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="compress" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="delimiter" type="int" setter="" getter="" default="0">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterDynamicFont.xml
+++ b/doc/classes/ResourceImporterDynamicFont.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterDynamicFont" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="allow_system_fallback" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="antialiasing" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="compress" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="fallbacks" type="Array" setter="" getter="" default="[]">
+		</member>
+		<member name="force_autohinter" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="generate_mipmaps" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="hinting" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="language_support" type="Dictionary" setter="" getter="" default="{}">
+		</member>
+		<member name="msdf_pixel_range" type="int" setter="" getter="" default="8">
+		</member>
+		<member name="msdf_size" type="int" setter="" getter="" default="48">
+		</member>
+		<member name="multichannel_signed_distance_field" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="opentype_features" type="Dictionary" setter="" getter="" default="{}">
+		</member>
+		<member name="oversampling" type="float" setter="" getter="" default="0.0">
+		</member>
+		<member name="preload" type="Array" setter="" getter="" default="[]">
+		</member>
+		<member name="script_support" type="Dictionary" setter="" getter="" default="{}">
+		</member>
+		<member name="subpixel_positioning" type="int" setter="" getter="" default="1">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterImage.xml
+++ b/doc/classes/ResourceImporterImage.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterImage" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/ResourceImporterImageFont.xml
+++ b/doc/classes/ResourceImporterImageFont.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterImageFont" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="character_margin" type="Rect2i" setter="" getter="" default="Rect2i(0, 0, 0, 0)">
+		</member>
+		<member name="character_ranges" type="PackedStringArray" setter="" getter="" default="PackedStringArray()">
+		</member>
+		<member name="columns" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="compress" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="fallbacks" type="Array" setter="" getter="" default="[]">
+		</member>
+		<member name="image_margin" type="Rect2i" setter="" getter="" default="Rect2i(0, 0, 0, 0)">
+		</member>
+		<member name="rows" type="int" setter="" getter="" default="1">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterLayeredTexture.xml
+++ b/doc/classes/ResourceImporterLayeredTexture.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterLayeredTexture" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="compress/channel_pack" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="compress/hdr_compression" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="compress/high_quality" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="compress/lossy_quality" type="float" setter="" getter="" default="0.7">
+		</member>
+		<member name="compress/mode" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="mipmaps/generate" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
+		</member>
+		<member name="slices/arrangement" type="int" setter="" getter="" default="1">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterOBJ.xml
+++ b/doc/classes/ResourceImporterOBJ.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterOBJ" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="generate_tangents" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="offset_mesh" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
+		</member>
+		<member name="optimize_mesh" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="scale_mesh" type="Vector3" setter="" getter="" default="Vector3(1, 1, 1)">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterScene" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="_subresources" type="Dictionary" setter="" getter="" default="{}">
+		</member>
+		<member name="animation/fps" type="float" setter="" getter="" default="30">
+		</member>
+		<member name="animation/import" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="animation/remove_immutable_tracks" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="animation/trimming" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="import_script/path" type="String" setter="" getter="" default="&quot;&quot;">
+		</member>
+		<member name="meshes/create_shadow_meshes" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="meshes/ensure_tangents" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="meshes/generate_lods" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="meshes/light_baking" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="meshes/lightmap_texel_size" type="float" setter="" getter="" default="0.2">
+		</member>
+		<member name="nodes/apply_root_scale" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="nodes/root_name" type="String" setter="" getter="" default="&quot;Scene Root&quot;">
+		</member>
+		<member name="nodes/root_scale" type="float" setter="" getter="" default="1.0">
+		</member>
+		<member name="nodes/root_type" type="String" setter="" getter="" default="&quot;Node3D&quot;">
+		</member>
+		<member name="skins/use_named_skins" type="bool" setter="" getter="" default="true">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterShaderFile.xml
+++ b/doc/classes/ResourceImporterShaderFile.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterShaderFile" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterTexture" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="compress/channel_pack" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="compress/hdr_compression" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="compress/high_quality" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="compress/lossy_quality" type="float" setter="" getter="" default="0.7">
+		</member>
+		<member name="compress/mode" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="compress/normal_map" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="detect_3d/compress_to" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="editor/convert_colors_with_editor_theme" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="editor/scale_with_editor_scale" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="mipmaps/generate" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
+		</member>
+		<member name="process/fix_alpha_border" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="process/hdr_as_srgb" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="process/hdr_clamp_exposure" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="process/normal_map_invert_y" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="process/premult_alpha" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="process/size_limit" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="roughness/mode" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="roughness/src_normal" type="String" setter="" getter="" default="&quot;&quot;">
+		</member>
+		<member name="svg/scale" type="float" setter="" getter="" default="1.0">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterTextureAtlas.xml
+++ b/doc/classes/ResourceImporterTextureAtlas.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterTextureAtlas" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="atlas_file" type="String" setter="" getter="" default="&quot;&quot;">
+		</member>
+		<member name="crop_to_region" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="import_mode" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="trim_alpha_border_from_region" type="bool" setter="" getter="" default="true">
+		</member>
+	</members>
+</class>

--- a/doc/classes/ResourceImporterWAV.xml
+++ b/doc/classes/ResourceImporterWAV.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterWAV" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="compress/mode" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="edit/loop_begin" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="edit/loop_end" type="int" setter="" getter="" default="-1">
+		</member>
+		<member name="edit/loop_mode" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="edit/normalize" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="edit/trim" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="force/8_bit" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="force/max_rate" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="force/max_rate_hz" type="float" setter="" getter="" default="44100">
+		</member>
+		<member name="force/mono" type="bool" setter="" getter="" default="false">
+		</member>
+	</members>
+</class>

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -36,6 +36,7 @@
 #include "core/io/compression.h"
 #include "core/io/dir_access.h"
 #include "core/io/marshalls.h"
+#include "core/io/resource_importer.h"
 #include "core/object/script_language.h"
 #include "core/string/translation.h"
 #include "core/version.h"
@@ -392,7 +393,13 @@ void DocTools::generate(bool p_basic_types) {
 			List<PropertyInfo> properties;
 			List<PropertyInfo> own_properties;
 
-			// Special case for editor and project settings, so they can be documented.
+			// Special cases for editor/project settings, and ResourceImporter classes,
+			// we have to rely on Object's property list to get settings and import options.
+			// Otherwise we just use ClassDB's property list (pure registered properties).
+
+			bool properties_from_instance = true; // To skip `script`, etc.
+			bool import_option = false; // Special case for default value.
+			HashMap<StringName, Variant> import_options_default;
 			if (name == "EditorSettings") {
 				// We don't create the full blown EditorSettings (+ config file) with `create()`,
 				// instead we just make a local instance to get default values.
@@ -402,7 +409,20 @@ void DocTools::generate(bool p_basic_types) {
 			} else if (name == "ProjectSettings") {
 				ProjectSettings::get_singleton()->get_property_list(&properties);
 				own_properties = properties;
+			} else if (ClassDB::is_parent_class(name, "ResourceImporter") && name != "EditorImportPlugin" && ClassDB::can_instantiate(name)) {
+				import_option = true;
+				ResourceImporter *resimp = Object::cast_to<ResourceImporter>(ClassDB::instantiate(name));
+				List<ResourceImporter::ImportOption> options;
+				resimp->get_import_options("", &options);
+				for (int i = 0; i < options.size(); i++) {
+					const PropertyInfo &prop = options[i].option;
+					properties.push_back(prop);
+					import_options_default[prop.name] = options[i].default_value;
+				}
+				own_properties = properties;
+				memdelete(resimp);
 			} else if (name.begins_with("EditorExportPlatform") && ClassDB::can_instantiate(name)) {
+				properties_from_instance = false;
 				Ref<EditorExportPlatform> platform = Object::cast_to<EditorExportPlatform>(ClassDB::instantiate(name));
 				if (platform.is_valid()) {
 					List<EditorExportPlatform::ExportOption> options;
@@ -413,6 +433,7 @@ void DocTools::generate(bool p_basic_types) {
 					own_properties = properties;
 				}
 			} else {
+				properties_from_instance = false;
 				ClassDB::get_property_list(name, &properties);
 				ClassDB::get_property_list(name, &own_properties, true);
 			}
@@ -427,6 +448,13 @@ void DocTools::generate(bool p_basic_types) {
 				if (EO && EO->get() == E) {
 					inherited = false;
 					EO = EO->next();
+				}
+
+				if (properties_from_instance) {
+					if (E.name == "resource_local_to_scene" || E.name == "resource_name" || E.name == "resource_path" || E.name == "script") {
+						// Don't include spurious properties from Object property list.
+						continue;
+					}
 				}
 
 				if (E.usage & PROPERTY_USAGE_GROUP || E.usage & PROPERTY_USAGE_SUBGROUP || E.usage & PROPERTY_USAGE_CATEGORY || E.usage & PROPERTY_USAGE_INTERNAL || (E.type == Variant::NIL && E.usage & PROPERTY_USAGE_ARRAY)) {
@@ -448,22 +476,9 @@ void DocTools::generate(bool p_basic_types) {
 				bool default_value_valid = false;
 				Variant default_value;
 
-				if (name == "EditorSettings") {
-					if (E.name == "resource_local_to_scene" || E.name == "resource_name" || E.name == "resource_path" || E.name == "script") {
-						// Don't include spurious properties in the generated EditorSettings class reference.
-						continue;
-					}
-				}
-
-				if (name.begins_with("EditorExportPlatform")) {
-					if (E.name == "script") {
-						continue;
-					}
-				}
-
 				if (name == "ProjectSettings") {
 					// Special case for project settings, so that settings are not taken from the current project's settings
-					if (E.name == "script" || !ProjectSettings::get_singleton()->is_builtin_setting(E.name)) {
+					if (!ProjectSettings::get_singleton()->is_builtin_setting(E.name)) {
 						continue;
 					}
 					if (E.usage & PROPERTY_USAGE_EDITOR) {
@@ -472,6 +487,9 @@ void DocTools::generate(bool p_basic_types) {
 							default_value_valid = true;
 						}
 					}
+				} else if (import_option) {
+					default_value = import_options_default[E.name];
+					default_value_valid = true;
 				} else {
 					default_value = get_documentation_default_value(name, E.name, default_value_valid);
 					if (inherited) {

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -157,6 +157,9 @@ void ImportDefaultsEditor::_update_importer() {
 
 	settings->notify_property_list_changed();
 
+	// Set the importer class to fetch the correct class in the XML class reference.
+	// This allows tooltips to display when hovering properties.
+	inspector->set_object_class(importer->get_class_name());
 	inspector->edit(settings);
 }
 
@@ -210,9 +213,14 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 	reset_defaults->connect("pressed", callable_mp(this, &ImportDefaultsEditor::_reset));
 	hb->add_child(reset_defaults);
 	add_child(hb);
+
 	inspector = memnew(EditorInspector);
 	add_child(inspector);
 	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
+	// Make it possible to display tooltips stored in the XML class reference.
+	// The object name is set when the importer changes in `_update_importer()`.
+	inspector->set_use_doc_hints(true);
+
 	CenterContainer *cc = memnew(CenterContainer);
 	save_defaults = memnew(Button);
 	save_defaults->set_text(TTR("Save"));

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -157,6 +157,13 @@ void ImportDock::_add_keep_import_option(const String &p_importer_name) {
 }
 
 void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_config) {
+	// Set the importer class to fetch the correct class in the XML class reference.
+	// This allows tooltips to display when hovering properties.
+	if (params->importer != nullptr) {
+		// Null check to avoid crashing if the "Keep File (No Import)" mode is selected.
+		import_opts->set_object_class(params->importer->get_class_name());
+	}
+
 	List<ResourceImporter::ImportOption> options;
 
 	if (params->importer.is_valid()) {
@@ -644,6 +651,9 @@ ImportDock::ImportDock() {
 	import_opts->set_v_size_flags(SIZE_EXPAND_FILL);
 	import_opts->connect("property_edited", callable_mp(this, &ImportDock::_property_edited));
 	import_opts->connect("property_toggled", callable_mp(this, &ImportDock::_property_toggled));
+	// Make it possible to display tooltips stored in the XML class reference.
+	// The object name is set when the importer changes in `_update_options()`.
+	import_opts->set_use_doc_hints(true);
 
 	hb = memnew(HBoxContainer);
 	content->add_child(hb);

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -50,7 +50,19 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_spin_slider.h"
 #include "editor/import/editor_import_plugin.h"
+#include "editor/import/resource_importer_bitmask.h"
+#include "editor/import/resource_importer_bmfont.h"
+#include "editor/import/resource_importer_csv_translation.h"
+#include "editor/import/resource_importer_dynamic_font.h"
+#include "editor/import/resource_importer_image.h"
+#include "editor/import/resource_importer_imagefont.h"
+#include "editor/import/resource_importer_layered_texture.h"
+#include "editor/import/resource_importer_obj.h"
 #include "editor/import/resource_importer_scene.h"
+#include "editor/import/resource_importer_shader_file.h"
+#include "editor/import/resource_importer_texture.h"
+#include "editor/import/resource_importer_texture_atlas.h"
+#include "editor/import/resource_importer_wav.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "editor/plugins/audio_stream_editor_plugin.h"
 #include "editor/plugins/audio_stream_randomizer_editor_plugin.h"
@@ -167,6 +179,21 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorCommandPalette);
 	GDREGISTER_CLASS(EditorDebuggerPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorDebuggerSession);
+
+	// Required to document import options in the class reference.
+	GDREGISTER_CLASS(ResourceImporterBitMap);
+	GDREGISTER_CLASS(ResourceImporterBMFont);
+	GDREGISTER_CLASS(ResourceImporterCSVTranslation);
+	GDREGISTER_CLASS(ResourceImporterDynamicFont);
+	GDREGISTER_CLASS(ResourceImporterImage);
+	GDREGISTER_CLASS(ResourceImporterImageFont);
+	GDREGISTER_CLASS(ResourceImporterLayeredTexture);
+	GDREGISTER_CLASS(ResourceImporterOBJ);
+	GDREGISTER_CLASS(ResourceImporterScene);
+	GDREGISTER_CLASS(ResourceImporterShaderFile);
+	GDREGISTER_CLASS(ResourceImporterTexture);
+	GDREGISTER_CLASS(ResourceImporterTextureAtlas);
+	GDREGISTER_CLASS(ResourceImporterWAV);
 
 	// This list is alphabetized, and plugins that depend on Node2D are in their own section below.
 	EditorPlugins::add_by_type<AnimationTreeEditorPlugin>();

--- a/modules/minimp3/config.py
+++ b/modules/minimp3/config.py
@@ -9,6 +9,7 @@ def configure(env):
 def get_doc_classes():
     return [
         "AudioStreamMP3",
+        "ResourceImporterMP3",
     ]
 
 

--- a/modules/minimp3/doc_classes/ResourceImporterMP3.xml
+++ b/modules/minimp3/doc_classes/ResourceImporterMP3.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterMP3" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="bar_beats" type="int" setter="" getter="" default="4">
+		</member>
+		<member name="beat_count" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="bpm" type="float" setter="" getter="" default="0">
+		</member>
+		<member name="loop" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the audio will play again from the specified [member loop_offset] once it is done playing. Useful for ambient sounds and background music.
+		</member>
+		<member name="loop_offset" type="float" setter="" getter="" default="0">
+		</member>
+	</members>
+</class>

--- a/modules/minimp3/register_types.cpp
+++ b/modules/minimp3/register_types.cpp
@@ -48,7 +48,11 @@ void initialize_minimp3_module(ModuleInitializationLevel p_level) {
 		mp3_import.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(mp3_import);
 	}
+
+	// Required to document import options in the class reference.
+	GDREGISTER_CLASS(ResourceImporterMP3);
 #endif
+
 	GDREGISTER_CLASS(AudioStreamMP3);
 }
 

--- a/modules/vorbis/config.py
+++ b/modules/vorbis/config.py
@@ -11,6 +11,7 @@ def get_doc_classes():
     return [
         "AudioStreamOggVorbis",
         "AudioStreamPlaybackOggVorbis",
+        "ResourceImporterOggVorbis",
     ]
 
 

--- a/modules/vorbis/doc_classes/AudioStreamOggVorbis.xml
+++ b/modules/vorbis/doc_classes/AudioStreamOggVorbis.xml
@@ -14,7 +14,7 @@
 		<member name="bpm" type="float" setter="set_bpm" getter="get_bpm" default="0.0">
 		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="false">
-			If [code]true[/code], the stream will automatically loop when it reaches the end.
+			If [code]true[/code], the audio will play again from the specified [member loop_offset] once it is done playing. Useful for ambient sounds and background music.
 		</member>
 		<member name="loop_offset" type="float" setter="set_loop_offset" getter="get_loop_offset" default="0.0">
 			Time in seconds at which the stream starts after being looped.

--- a/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
+++ b/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterOggVorbis" inherits="ResourceImporter" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="bar_beats" type="int" setter="" getter="" default="4">
+		</member>
+		<member name="beat_count" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="bpm" type="float" setter="" getter="" default="0">
+		</member>
+		<member name="loop" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the audio will play again from the specified [member loop_offset] once it is done playing. Useful for ambient sounds and background music.
+		</member>
+		<member name="loop_offset" type="float" setter="" getter="" default="0">
+		</member>
+	</members>
+</class>

--- a/modules/vorbis/register_types.cpp
+++ b/modules/vorbis/register_types.cpp
@@ -44,7 +44,11 @@ void initialize_vorbis_module(ModuleInitializationLevel p_level) {
 		ogg_vorbis_importer.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(ogg_vorbis_importer);
 	}
+
+	// Required to document import options in the class reference.
+	GDREGISTER_CLASS(ResourceImporterOggVorbis);
 #endif
+
 	GDREGISTER_CLASS(AudioStreamOggVorbis);
 	GDREGISTER_CLASS(AudioStreamPlaybackOggVorbis);
 }


### PR DESCRIPTION
Tooltips are displayed when hovering import options, both in the Import dock and in the import defaults editor (which is in the Project Settings).

This closes https://github.com/godotengine/godot-proposals/issues/2041. See also https://github.com/godotengine/godot/pull/48548 and #49525 (can be merged independently).

## Preview

*Disregard the black text – it's not a bug related to this PR.*

### Import dock

![Import dock](https://user-images.githubusercontent.com/180032/121763242-c2b33c00-cb3a-11eb-8d27-df3f5075abd2.png)

### Import defaults editor

![Import defaults editor](https://user-images.githubusercontent.com/180032/121763241-c21aa580-cb3a-11eb-8315-90ef9e028821.png)

## TODO

- [x] Only one importer is present in the documentation right now. Add the rest of the importers.
- [ ] Write documentation for all importers.