### PR TITLE
Document editor export presets in the class reference

### DIFF
--- a/doc/classes/EditorExportPlatformPC.xml
+++ b/doc/classes/EditorExportPlatformPC.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformPC" inherits="EditorExportPlatform" version="4.0">
+	<brief_description>
+		Exporter for desktop platforms (Windows, macOS, Linux).
+	</brief_description>
+	<description>
+		This exporter supports the following OS/architecture combinations:
+		[codeblock]
+		- Windows x86, Windows x86_64
+		- macOS x86_64, macOS ARMv8 (Apple Silicon)
+		    - Can be packed into an universal .app bundle.
+		    - x86 support is not available as Apple no longer supports 32-bit x86.
+		- Linux x86, x86_64
+		[/codeblock]
+		Support for other OS/architecture combinations (such as Linux + ARM) is possible by using custom export templates.
+	</description>
+	<tutorials>
+		<link title="Exporting for PC">https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_pc.html</link>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="binary_format/64_bits" type="bool" setter="" getter="">
+			If [code]true[/code], exports a 64-bit binary instead of a 32-bit binary.
+		</member>
+		<member name="binary_format/embed_pck" type="bool" setter="" getter="">
+			If [code]true[/code], embeds the PCK file inside the binary. This allows for single-file distribution without having to worry about the PCK file being disassociated from its binary. However, enabling PCK embedding has some bugs, is not compatible with using [code]rcedit[/code] at the same time, and can cause false positives in antivirus programs.
+			If [code]false[/code], a PCK file is placed besides the binary and must be moved along with the binary to keep the exported project in working state. If the binary is renamed, the PCK file must also be renamed to match (except the file extension).
+		</member>
+		<member name="custom_template/debug" type="String" setter="" getter="">
+			The custom export template binary to use when exporting with debugging enabled.
+		</member>
+		<member name="custom_template/release" type="String" setter="" getter="">
+			The custom export template binary to use when exporting with debugging disabled.
+		</member>
+		<member name="texture_format/bptc" type="bool" setter="" getter="">
+		</member>
+		<member name="texture_format/etc" type="bool" setter="" getter="">
+		</member>
+		<member name="texture_format/etc2" type="bool" setter="" getter="">
+		</member>
+		<member name="texture_format/no_bptc_fallbacks" type="bool" setter="" getter="">
+		</member>
+		<member name="texture_format/s3tc" type="bool" setter="" getter="">
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -38,6 +38,7 @@
 #include "core/io/marshalls.h"
 #include "core/object/script_language.h"
 #include "core/version.h"
+#include "editor/editor_export.h"
 #include "scene/resources/theme.h"
 
 // Used for a hack preserving Mono properties on non-Mono builds.
@@ -260,6 +261,11 @@ void DocTools::generate(bool p_basic_types) {
 			//special case for project settings, so settings can be documented
 			ProjectSettings::get_singleton()->get_property_list(&properties);
 			own_properties = properties;
+		} else if (name == "EditorExportPlatformPC") {
+			EditorExportPlatformPC *editor_export_platform = memnew(EditorExportPlatformPC);
+			Ref<EditorExportPreset> export_preset = editor_export_platform->create_preset();
+			export_preset->get_property_list(&properties);
+			own_properties = properties;
 		} else {
 			ClassDB::get_property_list(name, &properties);
 			ClassDB::get_property_list(name, &own_properties, true);
@@ -285,6 +291,13 @@ void DocTools::generate(bool p_basic_types) {
 
 			bool default_value_valid = false;
 			Variant default_value;
+
+			if (name == "EditorExportPlatformPC") {
+				if (E->get().name == "script") {
+					// Prevent spurious property from being added to the generated XML.
+					continue;
+				}
+			}
 
 			if (name == "ProjectSettings") {
 				// Special case for project settings, so that settings are not taken from the current project's settings

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3755,6 +3755,15 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<EditorSyntaxHighlighter>();
 	ClassDB::register_virtual_class<EditorInterface>();
 	ClassDB::register_class<EditorExportPlugin>();
+
+	// Required to document export preset properties in the class reference.
+	// ClassDB::register_class<EditorExportPlatformAndroid>();
+	// ClassDB::register_class<EditorExportPlatformIOS>();
+	// ClassDB::register_class<EditorExportPlatformJavaScript>();
+	// ClassDB::register_class<EditorExportPlatformOSX>();
+	ClassDB::register_class<EditorExportPlatformPC>();
+	// ClassDB::register_class<EditorExportPlatformUWP>();
+
 	ClassDB::register_class<EditorResourceConversionPlugin>();
 	ClassDB::register_class<EditorSceneImporter>();
 	ClassDB::register_class<EditorInspector>();

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -229,6 +229,9 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	export_path->update_property();
 	runnable->set_disabled(false);
 	runnable->set_pressed(current->is_runnable());
+	// Set the importer class to fetch the correct class in the XML class reference.
+	// This allows tooltips to display when hovering properties.
+	parameters->set_object_class(current->get_platform()->get_class_name());
 	parameters->edit(current.ptr());
 
 	export_filter->select(current->get_export_filter());
@@ -1069,6 +1072,9 @@ ProjectExportDialog::ProjectExportDialog() {
 	sections->add_child(parameters);
 	parameters->set_name(TTR("Options"));
 	parameters->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	// Make it possible to display tooltips stored in the XML class reference.
+	// The object name is set when the importer changes in `_update_options()`.
+	parameters->set_use_doc_hints(true);
 	parameters->connect("property_edited", callable_mp(this, &ProjectExportDialog::_update_parameters));
 	EditorExport::get_singleton()->connect("export_presets_updated", callable_mp(this, &ProjectExportDialog::_force_update_current_preset_parameters));
 


### PR DESCRIPTION
The documentation appears as tooltips when hovering options in export presets.

This PR can be remade for the `3.x` branch once we reach an agreement on its design.

This closes https://github.com/godotengine/godot-proposals/issues/1955. See also https://github.com/godotengine/godot/pull/48548 and https://github.com/godotengine/godot/pull/49524 (can be merged independently).

## Preview

*Disregard the black text – it's not a bug related to this PR.*

![Tooltip](https://user-images.githubusercontent.com/180032/121763733-9e595e80-cb3e-11eb-8c03-8598626d6e2a.png)

## TODO

- [ ] Only one export platform is present in the documentation right now. Generate the XML for all other export platforms.
- [ ] Write documentation for all export platforms.