### PR TITLE
Fixed a bunch of connection errors in TextureRegionEditor

### DIFF
--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -39,6 +39,11 @@
 				Emitted when the [member frame] changes.
 			</description>
 		</signal>
+		<signal name="texture_changed">
+			<description>
+				Emitted when the [member texture] changes.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 	</constants>

--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -127,13 +127,6 @@
 			The texture to use when drawing this style box.
 		</member>
 	</members>
-	<signals>
-		<signal name="texture_changed">
-			<description>
-				Emitted when the stylebox's texture is changed.
-			</description>
-		</signal>
-	</signals>
 	<constants>
 		<constant name="AXIS_STRETCH_MODE_STRETCH" value="0" enum="AxisStretchMode">
 			Stretch the stylebox's texture. This results in visible distortion unless the texture size matches the stylebox's size perfectly.

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -863,13 +863,13 @@ Sprite2D *TextureRegionEditor::get_sprite() {
 
 void TextureRegionEditor::edit(Object *p_obj) {
 	if (node_sprite) {
-		node_sprite->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+		node_sprite->disconnect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (node_sprite_3d) {
-		node_sprite_3d->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+		node_sprite_3d->disconnect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (node_ninepatch) {
-		node_ninepatch->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+		node_ninepatch->disconnect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (obj_styleBox.is_valid()) {
 		obj_styleBox->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
@@ -881,13 +881,22 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		node_sprite = Object::cast_to<Sprite2D>(p_obj);
 		node_sprite_3d = Object::cast_to<Sprite3D>(p_obj);
 		node_ninepatch = Object::cast_to<NinePatchRect>(p_obj);
+
+		bool is_resource = false;
 		if (Object::cast_to<StyleBoxTexture>(p_obj)) {
 			obj_styleBox = Ref<StyleBoxTexture>(Object::cast_to<StyleBoxTexture>(p_obj));
+			is_resource = true;
 		}
 		if (Object::cast_to<AtlasTexture>(p_obj)) {
 			atlas_tex = Ref<AtlasTexture>(Object::cast_to<AtlasTexture>(p_obj));
+			is_resource = true;
 		}
-		p_obj->connect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+
+		if (is_resource) {
+			p_obj->connect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+		} else {
+			p_obj->connect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+		}
 		_edit_region();
 	} else {
 		node_sprite = nullptr;

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "mesh_instance_2d.h"
+#include "scene/scene_string_names.h"
 
 void MeshInstance2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
@@ -70,7 +71,7 @@ void MeshInstance2D::set_texture(const Ref<Texture2D> &p_texture) {
 	}
 	texture = p_texture;
 	update();
-	emit_signal("texture_changed");
+	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 }
 
 void MeshInstance2D::set_normal_map(const Ref<Texture2D> &p_texture) {

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "multimesh_instance_2d.h"
+#include "scene/scene_string_names.h"
 
 void MultiMeshInstance2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
@@ -70,7 +71,7 @@ void MultiMeshInstance2D::set_texture(const Ref<Texture2D> &p_texture) {
 	}
 	texture = p_texture;
 	update();
-	emit_signal("texture_changed");
+	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 }
 
 Ref<Texture2D> MultiMeshInstance2D::get_texture() const {

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -153,7 +153,7 @@ void Sprite2D::set_texture(const Ref<Texture2D> &p_texture) {
 	}
 
 	update();
-	emit_signal("texture_changed");
+	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 	item_rect_changed();
 }
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -505,6 +505,7 @@ void Sprite3D::set_texture(const Ref<Texture2D> &p_texture) {
 		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Sprite3D::_texture_changed));
 	}
 	_queue_update();
+	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 }
 
 Ref<Texture2D> Sprite3D::get_texture() const {
@@ -663,6 +664,7 @@ void Sprite3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "region_rect"), "set_region_rect", "get_region_rect");
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
+	ADD_SIGNAL(MethodInfo("texture_changed"));
 }
 
 Sprite3D::Sprite3D() {

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -30,6 +30,7 @@
 
 #include "nine_patch_rect.h"
 
+#include "scene/scene_string_names.h"
 #include "servers/rendering_server.h"
 
 void NinePatchRect::_notification(int p_what) {
@@ -97,7 +98,7 @@ void NinePatchRect::set_texture(const Ref<Texture2D> &p_tex) {
 		texture->set_flags(texture->get_flags()&(~Texture::FLAG_REPEAT)); //remove repeat from texture, it looks bad in sprites
 	*/
 	minimum_size_changed();
-	emit_signal("texture_changed");
+	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 }
 
 Ref<Texture2D> NinePatchRect::get_texture() const {

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -121,7 +121,6 @@ void StyleBoxTexture::set_texture(Ref<Texture2D> p_texture) {
 	} else {
 		region_rect = Rect2(Point2(), texture->get_size());
 	}
-	emit_signal("texture_changed");
 	emit_changed();
 }
 
@@ -284,8 +283,6 @@ void StyleBoxTexture::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_v_axis_stretch_mode", "mode"), &StyleBoxTexture::set_v_axis_stretch_mode);
 	ClassDB::bind_method(D_METHOD("get_v_axis_stretch_mode"), &StyleBoxTexture::get_v_axis_stretch_mode);
-
-	ADD_SIGNAL(MethodInfo("texture_changed"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "region_rect"), "set_region_rect", "get_region_rect");

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -175,6 +175,7 @@ SceneStringNames::SceneStringNames() {
 	_toggled = StaticCString::create("_toggled");
 
 	frame_changed = StaticCString::create("frame_changed");
+	texture_changed = StaticCString::create("texture_changed");
 
 	playback_speed = StaticCString::create("playback/speed");
 	playback_active = StaticCString::create("playback/active");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -184,6 +184,7 @@ public:
 	StringName _mouse_exit;
 
 	StringName frame_changed;
+	StringName texture_changed;
 
 	StringName playback_speed;
 	StringName playback_active;


### PR DESCRIPTION
Fix error spam on selection of `Sprite2D`, `Sprite3D`, `NinePatchRect`, `StyleboxTexture` or `AtlasTexture`:

![image](https://user-images.githubusercontent.com/3036176/121765252-4593c100-cb52-11eb-9f9d-50dbce9d1099.png)

Restored correct links to `texture_changed`, Added `texture_changed` signal to `Sprite3D`, Removed `texture_changed` from `StyleBoxTexture` (it's just a duplicate of already existed `changed` signal from `Resource`).

Fix #47477