### PR TITLE
Hide unsupported features in the web editor

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5816,6 +5816,10 @@ void Node3DEditor::_menu_gizmo_toggled(int p_option) {
 void Node3DEditor::_update_camera_override_button(bool p_game_running) {
 	Button *const button = tool_option_button[TOOL_OPT_OVERRIDE_CAMERA];
 
+#ifdef WEB_ENABLED
+	button->set_disabled(true);
+	button->set_tooltip(TTR("Game Camera Override is not available in the web editor due to missing debugger protocol support."));
+#else
 	if (p_game_running) {
 		button->set_disabled(false);
 		button->set_tooltip_text(TTR("Project Camera Override\nOverrides the running project's camera with the editor viewport camera."));
@@ -5824,6 +5828,7 @@ void Node3DEditor::_update_camera_override_button(bool p_game_running) {
 		button->set_pressed(false);
 		button->set_tooltip_text(TTR("Project Camera Override\nNo project instance running. Run the project from the editor to use this feature."));
 	}
+#endif
 }
 
 void Node3DEditor::_update_camera_override_viewport(Object *p_viewport) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2704,6 +2704,11 @@ ProjectManager::ProjectManager() {
 		scan_btn->set_shortcut(ED_SHORTCUT("project_manager/scan_projects", TTR("Scan Projects"), KeyModifierMask::CMD_OR_CTRL | Key::S));
 		scan_btn->connect("pressed", callable_mp(this, &ProjectManager::_scan_projects));
 		tree_vb->add_child(scan_btn);
+#ifdef WEB_ENABLED
+		// Scan function is not relevant on the web editor, as there is no way
+		// to import multiple projects at once into the virtual HTML5 filesystem.
+		scan_btn->hide();
+#endif
 
 		tree_vb->add_child(memnew(HSeparator));
 


### PR DESCRIPTION
The game camera override button is disabled with a tooltip explaining why, but other menu options are hidden entirely to prevent them from being listed in the list of available editor shortcuts.

The Scan button is hidden as it serves no purpose in the web project manager. There is no way to import multiple project folders at once to the virtual HTML5 filesystem.

This pull request can be remade on the `3.x` branch once we agree on its design.