### PR TITLE
Fix game camera override tooltips being swapped

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5056,11 +5056,11 @@ void Node3DEditor::_update_camera_override_button(bool p_game_running) {
 
 	if (p_game_running) {
 		button->set_disabled(false);
-		button->set_tooltip(TTR("Game Camera Override\nNo game instance running."));
+		button->set_tooltip(TTR("Project Camera Override\nOverrides the running project's camera with the editor viewport camera."));
 	} else {
 		button->set_disabled(true);
 		button->set_pressed(false);
-		button->set_tooltip(TTR("Game Camera Override\nOverrides game camera with editor viewport camera."));
+		button->set_tooltip(TTR("Project Camera Override\nNo project instance running. Run the project from the editor to use this feature."));
 	}
 }
 


### PR DESCRIPTION
Previously, the wrong tooltip was shown (tested on `master` Git fe7559f75). I found this out while working on https://github.com/godotengine/godot/pull/49540 :slightly_smiling_face: 

This also tweaks the tooltips' texts to be clearer and remove references to "game" (since Godot is used for more than just games).