### PR TITLE
Fixed crash on calling set_editor_draw without properly setup

### DIFF
--- a/scene/resources/skeleton_modification_2d.cpp
+++ b/scene/resources/skeleton_modification_2d.cpp
@@ -216,7 +216,9 @@ void SkeletonModification2D::set_editor_draw_gizmo(bool p_draw_gizmo) {
 	editor_draw_gizmo = p_draw_gizmo;
 #ifdef TOOLS_ENABLED
 	if (is_setup) {
-		stack->set_editor_gizmos_dirty(true);
+		if (stack) {
+			stack->set_editor_gizmos_dirty(true);
+		}
 	}
 #endif // TOOLS_ENABLED
 }


### PR DESCRIPTION
Should fix #49531

It seems like there was a missing check for the validity of SkeletonModificationStack2D. No longer crashes on my end.