### PR TITLE
VariantParser: Fix reading StringNames with '&'.

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -190,10 +190,13 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 				r_token.type = TK_COLOR;
 				return OK;
 			}
-			case '@': {
+#ifndef DISABLE_DEPRECATED
+			case '@': // Compatibility with 3.x StringNames.
+#endif
+			case '&': { // StringName.
 				cchar = p_stream->get_char();
 				if (cchar != '"') {
-					r_err_str = "Expected '\"' after '@'";
+					r_err_str = "Expected '\"' after '&'";
 					r_token.type = TK_ERROR;
 					return ERR_PARSE_ERROR;
 				}


### PR DESCRIPTION
Keep support for '@' for now for compatibility.

Fixes #49535.
Fixes #49542.

Was a regression after #49499 which changed writing and not reading.

---

Note: In a test project using `class_name` and no class icons defined I noticed these errors on editor start:
```
ERROR: Error opening file 'Null'.
   at: load_image (core/io/image_loader.cpp:55)
ERROR: Error opening file 'Null'.
   at: load_image (core/io/image_loader.cpp:55)
```

But these don't seem to be related to #49499 or my fix, I can reproduce the issue before them. The issue seems to be that the global classes code in `EditorData` converts the StringName to String and then can't properly read from the dictionary. *Edit*: More context from the quick investigation I made, the errors are raised when trying to load script class icons as read from `project.godot`. The `class_name` key is a StringName, but the `_global_script_class_icons` is indexed with a `String` so it doesn't find the key.