### PR TITLE
Fix some virtual methods

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -334,6 +334,15 @@
 				Restore the state saved by [method _get_state].
 			</description>
 		</method>
+		<method name="_set_window_layout" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="layout" type="ConfigFile">
+			</argument>
+			<description>
+				Restore the plugin GUI layout saved by [method _get_window_layout].
+			</description>
+		</method>
 		<method name="add_autoload_singleton">
 			<return type="void">
 			</return>
@@ -695,15 +704,6 @@
 			</return>
 			<description>
 				Use this method if you always want to receive inputs from 3D view screen inside [method _forward_spatial_gui_input]. It might be especially usable if your plugin will want to use raycast in the scene.
-			</description>
-		</method>
-		<method name="set_window_layout" qualifiers="virtual">
-			<return type="void">
-			</return>
-			<argument index="0" name="layout" type="ConfigFile">
-			</argument>
-			<description>
-				Restore the plugin GUI layout saved by [method _get_window_layout].
 			</description>
 		</method>
 		<method name="update_overlays" qualifiers="const">

--- a/doc/classes/EditorResourcePicker.xml
+++ b/doc/classes/EditorResourcePicker.xml
@@ -10,30 +10,30 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_allowed_types" qualifiers="const">
-			<return type="PackedStringArray">
-			</return>
-			<description>
-				Returns a list of all allowed types and subtypes corresponding to the [member base_type]. If the [member base_type] is empty, an empty list is returned.
-			</description>
-		</method>
-		<method name="handle_menu_selected" qualifiers="virtual">
+		<method name="_handle_menu_selected" qualifiers="virtual">
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				This virtual method can be implemented to handle context menu items not handled by default. See [method set_create_options].
+				This virtual method can be implemented to handle context menu items not handled by default. See [method _set_create_options].
 			</description>
 		</method>
-		<method name="set_create_options" qualifiers="virtual">
+		<method name="_set_create_options" qualifiers="virtual">
 			<return type="void">
 			</return>
 			<argument index="0" name="menu_node" type="Object">
 			</argument>
 			<description>
 				This virtual method is called when updating the context menu of [EditorResourcePicker]. Implement this method to override the "New ..." items with your own options. [code]menu_node[/code] is a reference to the [PopupMenu] node.
-				[b]Note:[/b] Implement [method handle_menu_selected] to handle these custom items.
+				[b]Note:[/b] Implement [method _handle_menu_selected] to handle these custom items.
+			</description>
+		</method>
+		<method name="get_allowed_types" qualifiers="const">
+			<return type="PackedStringArray">
+			</return>
+			<description>
+				Returns a list of all allowed types and subtypes corresponding to the [member base_type]. If the [member base_type] is empty, an empty list is returned.
 			</description>
 		</method>
 		<method name="set_toggle_pressed">

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -916,7 +916,7 @@ void EditorPlugin::_bind_methods() {
 	BIND_VMETHOD(MethodInfo("_save_external_data"));
 	BIND_VMETHOD(MethodInfo("_apply_changes"));
 	BIND_VMETHOD(MethodInfo(Variant::PACKED_STRING_ARRAY, "_get_breakpoints"));
-	BIND_VMETHOD(MethodInfo("set_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
+	BIND_VMETHOD(MethodInfo("_set_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
 	BIND_VMETHOD(MethodInfo("_get_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_build"));
 	BIND_VMETHOD(MethodInfo("_enable_plugin"));

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -361,8 +361,8 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 
 void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 	// If a subclass implements this method, use it to replace all create items.
-	if (get_script_instance() && get_script_instance()->has_method("set_create_options")) {
-		get_script_instance()->call("set_create_options", p_menu_node);
+	if (get_script_instance() && get_script_instance()->has_method("_set_create_options")) {
+		get_script_instance()->call("_set_create_options", p_menu_node);
 		return;
 	}
 
@@ -418,8 +418,8 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 }
 
 bool EditorResourcePicker::handle_menu_selected(int p_which) {
-	if (get_script_instance() && get_script_instance()->has_method("handle_menu_selected")) {
-		return get_script_instance()->call("handle_menu_selected", p_which);
+	if (get_script_instance() && get_script_instance()->has_method("_handle_menu_selected")) {
+		return get_script_instance()->call("_handle_menu_selected", p_which);
 	}
 
 	return false;
@@ -640,8 +640,8 @@ void EditorResourcePicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_editable", "enable"), &EditorResourcePicker::set_editable);
 	ClassDB::bind_method(D_METHOD("is_editable"), &EditorResourcePicker::is_editable);
 
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("set_create_options", PropertyInfo(Variant::OBJECT, "menu_node")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("handle_menu_selected", PropertyInfo(Variant::INT, "id")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_set_create_options", PropertyInfo(Variant::OBJECT, "menu_node")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_handle_menu_selected", PropertyInfo(Variant::INT, "id")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "base_type"), "set_base_type", "get_base_type");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "edited_resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource", 0), "set_edited_resource", "get_edited_resource");


### PR DESCRIPTION
Follow-up to #48746 as some mistakes were made :/

btw we should probably enforce that all virtual methods start with underscore. Should be easy to do by parsing XML files.