### PR TITLE
Fix vertical centering of images in `RichTextLabel`

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1468,7 +1468,7 @@ RID TextServerAdvanced::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 							E->get().rect.position.y = -new_sd->ascent;
 						} break;
 						case VALIGN_CENTER: {
-							E->get().rect.position.y = -(E->get().rect.size.y / 2);
+							E->get().rect.position.y = -E->get().rect.size.y;
 						} break;
 						case VALIGN_BOTTOM: {
 							E->get().rect.position.y = new_sd->descent - E->get().rect.size.y;
@@ -1480,7 +1480,7 @@ RID TextServerAdvanced::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 							E->get().rect.position.x = -new_sd->ascent;
 						} break;
 						case VALIGN_CENTER: {
-							E->get().rect.position.x = -(E->get().rect.size.x / 2);
+							E->get().rect.position.x = -E->get().rect.size.x;
 						} break;
 						case VALIGN_BOTTOM: {
 							E->get().rect.position.x = new_sd->descent - E->get().rect.size.x;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -919,6 +919,7 @@ RID TextServerFallback::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 			}
 		}
 
+		// Align embedded objects to baseline.
 		for (Map<Variant, ShapedTextData::EmbeddedObject>::Element *E = new_sd->objects.front(); E; E = E->next()) {
 			if ((E->get().pos >= new_sd->start) && (E->get().pos < new_sd->end)) {
 				if (sd->orientation == ORIENTATION_HORIZONTAL) {
@@ -927,7 +928,7 @@ RID TextServerFallback::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 							E->get().rect.position.y = -new_sd->ascent;
 						} break;
 						case VALIGN_CENTER: {
-							E->get().rect.position.y = -(E->get().rect.size.y / 2);
+							E->get().rect.position.y = -E->get().rect.size.y;
 						} break;
 						case VALIGN_BOTTOM: {
 							E->get().rect.position.y = new_sd->descent - E->get().rect.size.y;
@@ -939,7 +940,7 @@ RID TextServerFallback::shaped_text_substr(RID p_shaped, int p_start, int p_leng
 							E->get().rect.position.x = -new_sd->ascent;
 						} break;
 						case VALIGN_CENTER: {
-							E->get().rect.position.x = -(E->get().rect.size.x / 2);
+							E->get().rect.position.x = -E->get().rect.size.x;
 						} break;
 						case VALIGN_BOTTOM: {
 							E->get().rect.position.x = new_sd->descent - E->get().rect.size.x;


### PR DESCRIPTION
While fixing another bug, I bumped into this one.

**Before:**
![Screenshot at 2021-06-12 20-41-56](https://user-images.githubusercontent.com/30739239/121791280-d2cd2900-cbd7-11eb-85b2-070469b8d1d2.png)

**After:**
![Screenshot at 2021-06-12 20-14-34](https://user-images.githubusercontent.com/30739239/121791282-d52f8300-cbd7-11eb-89d7-265aab87d6f6.png)