### PR TITLE
Fix roughness limiter derivative

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -850,7 +850,7 @@ void main() {
 	if (scene_data.roughness_limiter_enabled) {
 		//http://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
 		float roughness2 = roughness * roughness;
-		vec3 dndu = dFdx(normal), dndv = dFdx(normal);
+		vec2 dndu = dFdx(normal), dndv = dFdy(normal);
 		float variance = scene_data.roughness_limiter_amount * (dot(dndu, dndu) + dot(dndv, dndv));
 		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit); //limit effect
 		float filteredRoughness2 = min(1.0, roughness2 + kernelRoughness2);

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -761,7 +761,7 @@ void main() {
 	if (scene_data.roughness_limiter_enabled) {
 		//http://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
 		float roughness2 = roughness * roughness;
-		vec3 dndu = dFdx(normal), dndv = dFdx(normal);
+		vec3 dndu = dFdx(normal), dndv = dFdy(normal);
 		float variance = scene_data.roughness_limiter_amount * (dot(dndu, dndu) + dot(dndv, dndv));
 		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit); //limit effect
 		float filteredRoughness2 = min(1.0, roughness2 + kernelRoughness2);


### PR DESCRIPTION
This is just a small typo in the roughness limiter code that resulted in the roughness limiter not considering changes in the normal across the screen y-axis. 

This small change significantly improves the roughness limiter visual appearance

A further improvement to the roughness limiter can be to use the same general approach except using the light's half vector instead of the normal. http://jcgt.org/published/0010/02/02/ However, this approach would require us to a) save a copy of the original normal and b) recompute roughness for each light source (IBL, SDFGI, Probes, all lights).
