### PR TITLE
Fix alignment of indicators in the "Output" tab

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -245,14 +245,14 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		case MSG_TYPE_ERROR: {
 			log->push_color(get_theme_color("error_color", "Editor"));
 			Ref<Texture2D> icon = get_theme_icon("Error", "EditorIcons");
-			log->add_image(icon);
+			log->add_image(icon, 0, 0, Color(1, 1, 1), VALIGN_CENTER);
 			log->add_text(" ");
 			tool_button->set_icon(icon);
 		} break;
 		case MSG_TYPE_WARNING: {
 			log->push_color(get_theme_color("warning_color", "Editor"));
 			Ref<Texture2D> icon = get_theme_icon("Warning", "EditorIcons");
-			log->add_image(icon);
+			log->add_image(icon, 0, 0, Color(1, 1, 1), VALIGN_CENTER);
 			log->add_text(" ");
 			tool_button->set_icon(icon);
 		} break;


### PR DESCRIPTION
A noticeable bug when the editor's font size is bigger than the default.

**Before:**
![Screenshot at 2021-06-12 15-04-51](https://user-images.githubusercontent.com/30739239/121791928-98b35580-cbde-11eb-984a-763832e46d31.png)

**After:**
![Screenshot at 2021-06-12 21-23-02](https://user-images.githubusercontent.com/30739239/121791926-96e99200-cbde-11eb-9692-21650623de6d.png)

Depends on #49548.