### PR TITLE
Fix Viewport crashes when not in tree

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2547,6 +2547,8 @@ void Viewport::_gui_remove_control(Control *p_control) {
 }
 
 Window *Viewport::get_base_window() const {
+	ERR_FAIL_COND_V(!is_inside_tree(), nullptr);
+
 	Viewport *v = const_cast<Viewport *>(this);
 	Window *w = Object::cast_to<Window>(v);
 	while (!w) {
@@ -3336,6 +3338,7 @@ bool Viewport::is_input_handled() const {
 		return local_input_handled;
 	} else {
 		const Viewport *vp = this;
+		ERR_FAIL_COND_V(!is_inside_tree(), false);
 		while (true) {
 			if (Object::cast_to<Window>(vp)) {
 				break;


### PR DESCRIPTION
Added `is_inside_tree` checks.

* For `Viewport::is_input_handled`, this is what `Viewport::set_input_as_handled` does.
* For `Viewport::get_base_window`, this could be replaced by null-checking `v` in the loop. But since `Viewport::get_parent_viewport` always return `nullptr` when not in tree, null-checking `v` won't bring anything useful but two "not inside tree" error outputs in the console.

Fixes #49533.
Fixes #49530.