### PR TITLE
Initialize PhysicalBone2D::parent_skeleton

### DIFF
--- a/scene/2d/physical_bone_2d.h
+++ b/scene/2d/physical_bone_2d.h
@@ -44,7 +44,7 @@ protected:
 	static void _bind_methods();
 
 private:
-	Skeleton2D *parent_skeleton;
+	Skeleton2D *parent_skeleton = nullptr;
 	int bone2d_index = -1;
 	NodePath bone2d_nodepath;
 	bool follow_bone_when_simulating = false;


### PR DESCRIPTION
Fixes #49529.

The member was left uninitialized until the ready notification, so the `if (parent_skeleton)` check did not work.