### PR TITLE
Fix crash when using invalid index in Color.get_named_color

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -368,7 +368,7 @@ Color Color::named(const String &p_name) {
 		ERR_FAIL_V_MSG(Color(), "Invalid color name: " + p_name + ".");
 		return Color();
 	}
-	return get_named_color(idx);
+	return named_colors[idx].color;
 }
 
 Color Color::named(const String &p_name, const Color &p_default) {
@@ -376,7 +376,7 @@ Color Color::named(const String &p_name, const Color &p_default) {
 	if (idx == -1) {
 		return p_default;
 	}
-	return get_named_color(idx);
+	return named_colors[idx].color;
 }
 
 int Color::find_named_color(const String &p_name) {
@@ -409,10 +409,12 @@ int Color::get_named_color_count() {
 }
 
 String Color::get_named_color_name(int p_idx) {
+	ERR_FAIL_INDEX_V(p_idx, get_named_color_count(), "");
 	return named_colors[p_idx].name;
 }
 
 Color Color::get_named_color(int p_idx) {
+	ERR_FAIL_INDEX_V(p_idx, get_named_color_count(), Color());
 	return named_colors[p_idx].color;
 }
 


### PR DESCRIPTION
Adds index range check for `Color::get_named_color_name` and `Color::get_named_color`.

The internal use of `Color::get_named_color` in `Color::named` is replaced by indexing the `named_colors` array directly. This is because the invalid index is already handled in that function, and the range check uses `Color::get_named_color_count` which has to loop through each entry of the array to get the total size.

Fixes #49532.