### PR TITLE
Improve & fix Mono build

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1444,7 +1444,7 @@ bool CSharpLanguage::setup_csharp_script_binding(CSharpScriptBinding &r_script_b
 		// Unsafe refcount increment. The managed instance also counts as a reference.
 		// This way if the unmanaged world has no references to our owner
 		// but the managed instance is alive, the refcount will be 1 instead of 0.
-		// See: godot_icall_Reference_Dtor(MonoObject *p_obj, Object *p_ptr)
+		// See: godot_icall_RefCounted_Dtor(MonoObject *p_obj, Object *p_ptr)
 
 		rc->reference();
 		CSharpLanguage::get_singleton()->post_unsafe_reference(rc);

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -371,7 +371,7 @@ namespace GodotTools
             return (ExternalEditorId)editorSettings.GetSetting("mono/editor/external_editor") != ExternalEditorId.None;
         }
 
-        public override bool Build()
+        public override bool _Build()
         {
             return BuildManager.EditorBuildCallback();
         }
@@ -413,9 +413,9 @@ namespace GodotTools
                 bottomPanelBtn.Icon = MSBuildPanel.BuildOutputView.BuildStateIcon;
         }
 
-        public override void EnablePlugin()
+        public override void _EnablePlugin()
         {
-            base.EnablePlugin();
+            base._EnablePlugin();
 
             if (Instance != null)
                 throw new InvalidOperationException();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
@@ -66,7 +66,7 @@ namespace Godot
                 if (memoryOwn)
                 {
                     memoryOwn = false;
-                    godot_icall_Reference_Disposed(this, ptr, !disposing);
+                    godot_icall_RefCounted_Disposed(this, ptr, !disposing);
                 }
                 else
                 {
@@ -129,7 +129,7 @@ namespace Godot
         internal static extern void godot_icall_Object_Disposed(Object obj, IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern void godot_icall_Reference_Disposed(Object obj, IntPtr ptr, bool isFinalizer);
+        internal static extern void godot_icall_RefCounted_Disposed(Object obj, IntPtr ptr, bool isFinalizer);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern void godot_icall_Object_ConnectEventSignals(IntPtr obj);

--- a/modules/mono/glue/base_object_glue.cpp
+++ b/modules/mono/glue/base_object_glue.cpp
@@ -78,7 +78,7 @@ void godot_icall_Object_Disposed(MonoObject *p_obj, Object *p_ptr) {
 	}
 }
 
-void godot_icall_Reference_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoolean p_is_finalizer) {
+void godot_icall_RefCounted_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoolean p_is_finalizer) {
 #ifdef DEBUG_ENABLED
 	CRASH_COND(p_ptr == nullptr);
 	// This is only called with RefCounted derived classes
@@ -88,7 +88,7 @@ void godot_icall_Reference_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoolea
 	RefCounted *rc = static_cast<RefCounted *>(p_ptr);
 
 	if (rc->get_script_instance()) {
-		CSharpInstance *cs_instance = CAST_CSHARP_INSTANCE(ref->get_script_instance());
+		CSharpInstance *cs_instance = CAST_CSHARP_INSTANCE(rc->get_script_instance());
 		if (cs_instance) {
 			if (!cs_instance->is_destructing_script_instance()) {
 				bool delete_owner;
@@ -108,11 +108,11 @@ void godot_icall_Reference_Disposed(MonoObject *p_obj, Object *p_ptr, MonoBoolea
 
 	// Unsafe refcount decrement. The managed instance also counts as a reference.
 	// See: CSharpLanguage::alloc_instance_binding_data(Object *p_object)
-	CSharpLanguage::get_singleton()->pre_unsafe_unreference(ref);
-	if (ref->unreference()) {
-		memdelete(ref);
+	CSharpLanguage::get_singleton()->pre_unsafe_unreference(rc);
+	if (rc->unreference()) {
+		memdelete(rc);
 	} else {
-		void *data = ref->get_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index());
+		void *data = rc->get_script_instance_binding(CSharpLanguage::get_singleton()->get_language_index());
 
 		if (data) {
 			CSharpScriptBinding &script_binding = ((Map<Object *, CSharpScriptBinding>::Element *)data)->get();
@@ -242,7 +242,7 @@ MonoString *godot_icall_Object_ToString(Object *p_ptr) {
 void godot_register_object_icalls() {
 	GDMonoUtils::add_internal_call("Godot.Object::godot_icall_Object_Ctor", godot_icall_Object_Ctor);
 	GDMonoUtils::add_internal_call("Godot.Object::godot_icall_Object_Disposed", godot_icall_Object_Disposed);
-	GDMonoUtils::add_internal_call("Godot.Object::godot_icall_Reference_Disposed", godot_icall_Reference_Disposed);
+	GDMonoUtils::add_internal_call("Godot.Object::godot_icall_RefCounted_Disposed", godot_icall_RefCounted_Disposed);
 	GDMonoUtils::add_internal_call("Godot.Object::godot_icall_Object_ConnectEventSignals", godot_icall_Object_ConnectEventSignals);
 	GDMonoUtils::add_internal_call("Godot.Object::godot_icall_Object_ClassDB_get_method", godot_icall_Object_ClassDB_get_method);
 	GDMonoUtils::add_internal_call("Godot.Object::godot_icall_Object_ToString", godot_icall_Object_ToString);

--- a/modules/mono/mono_gd/gd_mono_internals.cpp
+++ b/modules/mono/mono_gd/gd_mono_internals.cpp
@@ -80,7 +80,7 @@ void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 			// Unsafe refcount increment. The managed instance also counts as a reference.
 			// This way if the unmanaged world has no references to our owner
 			// but the managed instance is alive, the refcount will be 1 instead of 0.
-			// See: godot_icall_Reference_Dtor(MonoObject *p_obj, Object *p_ptr)
+			// See: godot_icall_RefCounted_Dtor(MonoObject *p_obj, Object *p_ptr)
 
 			// May not me referenced yet, so we must use init_ref() instead of reference()
 			if (rc->init_ref()) {

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -114,7 +114,7 @@ MonoObject *unmanaged_get_managed(Object *unmanaged) {
 		// Unsafe refcount increment. The managed instance also counts as a reference.
 		// This way if the unmanaged world has no references to our owner
 		// but the managed instance is alive, the refcount will be 1 instead of 0.
-		// See: godot_icall_Reference_Dtor(MonoObject *p_obj, Object *p_ptr)
+		// See: godot_icall_RefCounted_Dtor(MonoObject *p_obj, Object *p_ptr)
 		rc->reference();
 		CSharpLanguage::get_singleton()->post_unsafe_reference(rc);
 	}


### PR DESCRIPTION
- Fix C++ compile errors about pending variable renames after the `Reference` to `RefCount` change.
- Fix C# compile errors due to the recent rename of `EnablePlugin()` and `Build()`, which are now underscore-prefixed in bindings.
- Additional rename: `godot_icall_Reference_Dtor` to  `godot_icall_RefCounted_Dtor`.