### PR TITLE
Fix slow load/save of scenes with many instances of the same script

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -148,7 +148,7 @@ class GDScript : public Script {
 
 #endif
 
-	bool _update_exports(bool *r_err = nullptr, bool p_recursive_call = false);
+	bool _update_exports(bool *r_err = nullptr, bool p_recursive_call = false, PlaceHolderScriptInstance *p_instance_to_update = nullptr);
 
 	void _save_orphaned_subclasses();
 	void _init_rpc_methods_properties();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2370,7 +2370,7 @@ void CSharpScript::_update_member_info_no_exports() {
 }
 #endif
 
-bool CSharpScript::_update_exports() {
+bool CSharpScript::_update_exports(PlaceHolderScriptInstance *p_instance_to_update) {
 #ifdef TOOLS_ENABLED
 	bool is_editor = Engine::get_singleton()->is_editor_hint();
 	if (is_editor) {
@@ -2542,14 +2542,18 @@ bool CSharpScript::_update_exports() {
 	if (is_editor) {
 		placeholder_fallback_enabled = false;
 
-		if (placeholders.size()) {
+		if ((changed || p_instance_to_update) && placeholders.size()) {
 			// Update placeholders if any
 			Map<StringName, Variant> values;
 			List<PropertyInfo> propnames;
 			_update_exports_values(values, propnames);
 
-			for (Set<PlaceHolderScriptInstance *>::Element *E = placeholders.front(); E; E = E->next()) {
-				E->get()->update(propnames, values);
+			if (changed) {
+				for (Set<PlaceHolderScriptInstance *>::Element *E = placeholders.front(); E; E = E->next()) {
+					E->get()->update(propnames, values);
+				}
+			} else {
+				p_instance_to_update->update(propnames, values);
 			}
 		}
 	}
@@ -3230,7 +3234,7 @@ PlaceHolderScriptInstance *CSharpScript::placeholder_instance_create(Object *p_t
 #ifdef TOOLS_ENABLED
 	PlaceHolderScriptInstance *si = memnew(PlaceHolderScriptInstance(CSharpLanguage::get_singleton(), Ref<Script>(this), p_this));
 	placeholders.insert(si);
-	_update_exports();
+	_update_exports(si);
 	return si;
 #else
 	return nullptr;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -163,7 +163,7 @@ private:
 	void load_script_signals(GDMonoClass *p_class, GDMonoClass *p_native_class);
 	bool _get_signal(GDMonoClass *p_class, GDMonoMethod *p_delegate_invoke, Vector<SignalParameter> &params);
 
-	bool _update_exports();
+	bool _update_exports(PlaceHolderScriptInstance *p_instance_to_update = nullptr);
 
 	bool _get_member_export(IMonoClassMember *p_member, bool p_inspect_export, PropertyInfo &r_prop_info, bool &r_exported);
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
This is my hypothesis and approach to fix #43156.

@reduz did c79be979d47daae613d1b1bbc732a30a74f56543 quite a long time ago to fix one of these: #756, #859, #914

There, some `changed` condition was removed so `_update_exports()` would update every script placeholder instance regardless the script had changed or not. One effect I can confirm if the condition is re-added is that the property inspector won't show the exported variables anymore (however, I'm not sure if the removal fixes something else in addition, and that's why I've listed all the three potential issues that may be addressed by the change).

However, that change also introduced the behavior that when the scene edit state is generated –which happens when saving or loading a scene–, _every placeholder instance of a given script_ triggers the update of the exports of all the others that have been found so far, which may even happen several times because the same code is run for the whole inheritance chain.

This PR fixes that by making such updates conditional again, this way:
- If the update happens because of a script change (so the check  for `changed` is back), all the instances are updated, which is what was happening unconditionally and causing the slowness.
- But, in order to avoid resurrecting a bug, now there's the option to ask explicitly for the update of a single placeholder instance, so the code that creates a instance can ask to update its, and only its, exports, instead of doing that on every instance.

Lastly, I think that C# was added when `change` had already been removed from the condition a long time ago, so it would be affected by the same bug. For that reason, I've applied the patch there as well.

**Disclaimer:**
As I said above, this is based on my hypothesis about the bug, but it's hard to be sure. Also, testing to ensure all the aforementioned bugs (or any other, for that matter) aren't resurrected would be very difficult,

@akien-mga, being that the case, I'm not sure if this should get the _Needs testing_ tag or, considering that specific testing for regressions is impractical or nearly impossible, just let users do it via alphas/betas.

Supersedes #47828.

Fixes #43156.