### PR TITLE
Fix "super" call when having at least one argument

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1989,7 +1989,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				ip += instr_arg_count;
 
-				int self_fun = _code_ptr[ip + 1];
+				int argc = _code_ptr[ip + 1];
+				GD_ERR_BREAK(argc < 0);
+
+				int self_fun = _code_ptr[ip + 2];
 #ifdef DEBUG_ENABLED
 				if (self_fun < 0 || self_fun >= _global_names_count) {
 					err_text = "compiler bug, function name not found";
@@ -1997,9 +2000,6 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				}
 #endif
 				const StringName *methodname = &_global_names_ptr[self_fun];
-
-				int argc = _code_ptr[ip + 2];
-				GD_ERR_BREAK(argc < 0);
 
 				Variant **argptrs = instruction_args;
 


### PR DESCRIPTION
Fixes #49573

Looks like arguments count and method_name are switched.

In the codegen, args size in **first**, then function name is **second**:

https://github.com/godotengine/godot/blob/12e0f10c74e9619262f1edcfdc1840432ada0565/modules/gdscript/gdscript_byte_codegen.cpp#L907-L915

However, in gdscript_vm, self_fun is **first**, and argc is **second**:
https://github.com/godotengine/godot/blob/12e0f10c74e9619262f1edcfdc1840432ada0565/modules/gdscript/gdscript_vm.cpp#L1987-L2004
