### PR TITLE
Improve the console error logging appearance (3.x)

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -65,19 +65,19 @@ void Logger::log_error(const char *p_function, const char *p_file, int p_line, c
 		return;
 	}
 
-	const char *err_type = "**ERROR**";
+	const char *err_type = "ERROR";
 	switch (p_type) {
 		case ERR_ERROR:
-			err_type = "**ERROR**";
+			err_type = "ERROR";
 			break;
 		case ERR_WARNING:
-			err_type = "**WARNING**";
+			err_type = "WARNING";
 			break;
 		case ERR_SCRIPT:
-			err_type = "**SCRIPT ERROR**";
+			err_type = "SCRIPT ERROR";
 			break;
 		case ERR_SHADER:
-			err_type = "**SHADER ERROR**";
+			err_type = "SHADER ERROR";
 			break;
 		default:
 			ERR_PRINT("Unknown error type");
@@ -92,7 +92,7 @@ void Logger::log_error(const char *p_function, const char *p_file, int p_line, c
 	}
 
 	logf_error("%s: %s\n", err_type, err_details);
-	logf_error("   At: %s:%i:%s() - %s\n", p_file, p_line, p_function, p_code);
+	logf_error("   at: %s (%s:%i) - %s\n", p_function, p_file, p_line, p_code);
 }
 
 void Logger::logf(const char *p_format, ...) {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -535,34 +535,34 @@ void UnixTerminalLogger::log_error(const char *p_function, const char *p_file, i
 	// This prevents Godot from writing ANSI escape codes when redirecting
 	// stdout and stderr to a file.
 	const bool tty = isatty(fileno(stdout));
-	const char *red = tty ? "\E[0;31m" : "";
+	const char *gray = tty ? "\E[0;90m" : "";
+	const char *red = tty ? "\E[0;91m" : "";
 	const char *red_bold = tty ? "\E[1;31m" : "";
-	const char *yellow = tty ? "\E[0;33m" : "";
+	const char *yellow = tty ? "\E[0;93m" : "";
 	const char *yellow_bold = tty ? "\E[1;33m" : "";
-	const char *magenta = tty ? "\E[0;35m" : "";
+	const char *magenta = tty ? "\E[0;95m" : "";
 	const char *magenta_bold = tty ? "\E[1;35m" : "";
-	const char *cyan = tty ? "\E[0;36m" : "";
+	const char *cyan = tty ? "\E[0;96m" : "";
 	const char *cyan_bold = tty ? "\E[1;36m" : "";
 	const char *reset = tty ? "\E[0m" : "";
-	const char *bold = tty ? "\E[1m" : "";
 
 	switch (p_type) {
 		case ERR_WARNING:
-			logf_error("%sWARNING: %s: %s%s%s\n", yellow_bold, p_function, reset, bold, err_details);
-			logf_error("%s   At: %s:%i.%s\n", yellow, p_file, p_line, reset);
+			logf_error("%sWARNING:%s %s\n", yellow_bold, yellow, err_details);
+			logf_error("%s     at: %s (%s:%i)%s\n", gray, p_function, p_file, p_line, reset);
 			break;
 		case ERR_SCRIPT:
-			logf_error("%sSCRIPT ERROR: %s: %s%s%s\n", magenta_bold, p_function, reset, bold, err_details);
-			logf_error("%s   At: %s:%i.%s\n", magenta, p_file, p_line, reset);
+			logf_error("%sSCRIPT ERROR:%s %s\n", magenta_bold, magenta, err_details);
+			logf_error("%s          at: %s (%s:%i)%s\n", gray, p_function, p_file, p_line, reset);
 			break;
 		case ERR_SHADER:
-			logf_error("%sSHADER ERROR: %s: %s%s%s\n", cyan_bold, p_function, reset, bold, err_details);
-			logf_error("%s   At: %s:%i.%s\n", cyan, p_file, p_line, reset);
+			logf_error("%sSHADER ERROR:%s %s\n", cyan_bold, cyan, err_details);
+			logf_error("%s          at: %s (%s:%i)%s\n", gray, p_function, p_file, p_line, reset);
 			break;
 		case ERR_ERROR:
 		default:
-			logf_error("%sERROR: %s: %s%s%s\n", red_bold, p_function, reset, bold, err_details);
-			logf_error("%s   At: %s:%i.%s\n", red, p_file, p_line, reset);
+			logf_error("%sERROR:%s %s\n", red_bold, red, err_details);
+			logf_error("%s   at: %s (%s:%i)%s\n", gray, p_function, p_file, p_line, reset);
 			break;
 	}
 }

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1826,42 +1826,39 @@ public:
 			case ERR_WARNING:
 				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
 					os_log_info(OS_LOG_DEFAULT,
-							"WARNING: %{public}s: %{public}s\nAt: %{public}s:%i.",
-							p_function, err_details, p_file, p_line);
+							"WARNING: %{public}s\nat: %{public}s (%{public}s:%i)",
+							err_details, p_function, p_file, p_line);
 				}
-				logf_error("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n", p_function,
-						err_details);
-				logf_error("\E[0;33m   At: %s:%i.\E[0m\n", p_file, p_line);
+				logf_error("\E[1;33mWARNING:\E[0;93m %s\n", err_details);
+				logf_error("\E[0;90m     at: %s (%s:%i)\E[0m\n", p_function, p_file, p_line);
 				break;
 			case ERR_SCRIPT:
 				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
 					os_log_error(OS_LOG_DEFAULT,
-							"SCRIPT ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
-							p_function, err_details, p_file, p_line);
+							"SCRIPT ERROR: %{public}s\nat: %{public}s (%{public}s:%i)",
+							err_details, p_function, p_file, p_line);
 				}
-				logf_error("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m%s\n", p_function,
-						err_details);
-				logf_error("\E[0;35m   At: %s:%i.\E[0m\n", p_file, p_line);
+				logf_error("\E[1;35mSCRIPT ERROR:\E[0;95m %s\n", err_details);
+				logf_error("\E[0;90m          at: %s (%s:%i)\E[0m\n", p_function, p_file, p_line);
 				break;
 			case ERR_SHADER:
 				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
 					os_log_error(OS_LOG_DEFAULT,
-							"SHADER ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
-							p_function, err_details, p_file, p_line);
+							"SHADER ERROR: %{public}s\nat: %{public}s (%{public}s:%i)",
+							err_details, p_function, p_file, p_line);
 				}
-				logf_error("\E[1;36mSHADER ERROR: %s: \E[0m\E[1m%s\n", p_function,
-						err_details);
-				logf_error("\E[0;36m   At: %s:%i.\E[0m\n", p_file, p_line);
+				logf_error("\E[1;36mSHADER ERROR:\E[0;96m %s\n", err_details);
+				logf_error("\E[0;90m          at: %s (%s:%i)\E[0m\n", p_function, p_file, p_line);
 				break;
 			case ERR_ERROR:
 			default:
 				if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_12) {
 					os_log_error(OS_LOG_DEFAULT,
-							"ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
-							p_function, err_details, p_file, p_line);
+							"ERROR: %{public}s\nat: %{public}s (%{public}s:%i)",
+							err_details, p_function, p_file, p_line);
 				}
-				logf_error("\E[1;31mERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
-				logf_error("\E[0;31m   At: %s:%i.\E[0m\n", p_file, p_line);
+				logf_error("\E[1;31mERROR:\E[0;91m %s\n", err_details);
+				logf_error("\E[0;90m   at: %s (%s:%i)\E[0m\n", p_function, p_file, p_line);
 				break;
 		}
 	}

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -85,7 +85,6 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 		CONSOLE_SCREEN_BUFFER_INFO sbi; //original
 		GetConsoleScreenBufferInfo(hCon, &sbi);
 
-		WORD current_fg = sbi.wAttributes & (FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
 		WORD current_bg = sbi.wAttributes & (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
 
 		uint32_t basecol = 0;
@@ -106,83 +105,50 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 
 		basecol |= current_bg;
 
+		SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
+		switch (p_type) {
+			case ERR_ERROR:
+				logf("ERROR:");
+				break;
+			case ERR_WARNING:
+				logf("WARNING:");
+				break;
+			case ERR_SCRIPT:
+				logf("SCRIPT ERROR:");
+				break;
+			case ERR_SHADER:
+				logf("SHADER ERROR:");
+				break;
+		}
+
+		SetConsoleTextAttribute(hCon, basecol);
 		if (p_rationale && p_rationale[0]) {
-			SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
-			switch (p_type) {
-				case ERR_ERROR:
-					logf("ERROR: ");
-					break;
-				case ERR_WARNING:
-					logf("WARNING: ");
-					break;
-				case ERR_SCRIPT:
-					logf("SCRIPT ERROR: ");
-					break;
-				case ERR_SHADER:
-					logf("SHADER ERROR: ");
-					break;
-			}
-
-			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
-			logf("%s\n", p_rationale);
-
-			SetConsoleTextAttribute(hCon, basecol);
-			switch (p_type) {
-				case ERR_ERROR:
-					logf("   At: ");
-					break;
-				case ERR_WARNING:
-					logf("     At: ");
-					break;
-				case ERR_SCRIPT:
-					logf("          At: ");
-					break;
-				case ERR_SHADER:
-					logf("          At: ");
-					break;
-			}
-
-			SetConsoleTextAttribute(hCon, current_fg | current_bg);
-			logf("%s:%i\n", p_file, p_line);
-
+			logf(" %s\n", p_rationale);
 		} else {
-			SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
-			switch (p_type) {
-				case ERR_ERROR:
-					logf("ERROR: %s: ", p_function);
-					break;
-				case ERR_WARNING:
-					logf("WARNING: %s: ", p_function);
-					break;
-				case ERR_SCRIPT:
-					logf("SCRIPT ERROR: %s: ", p_function);
-					break;
-				case ERR_SHADER:
-					logf("SCRIPT ERROR: %s: ", p_function);
-					break;
-			}
+			logf(" %s\n", p_code);
+		}
 
-			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
-			logf("%s\n", p_code);
+		// `FOREGROUND_INTENSITY` alone results in gray text.
+		SetConsoleTextAttribute(hCon, FOREGROUND_INTENSITY);
+		switch (p_type) {
+			case ERR_ERROR:
+				logf("   at: ");
+				break;
+			case ERR_WARNING:
+				logf("     at: ");
+				break;
+			case ERR_SCRIPT:
+				logf("          at: ");
+				break;
+			case ERR_SHADER:
+				logf("          at: ");
+				break;
+		}
 
-			SetConsoleTextAttribute(hCon, basecol);
-			switch (p_type) {
-				case ERR_ERROR:
-					logf("   At: ");
-					break;
-				case ERR_WARNING:
-					logf("     At: ");
-					break;
-				case ERR_SCRIPT:
-					logf("          At: ");
-					break;
-				case ERR_SHADER:
-					logf("          At: ");
-					break;
-			}
-
-			SetConsoleTextAttribute(hCon, current_fg | current_bg);
-			logf("%s:%i\n", p_file, p_line);
+		if (p_rationale && p_rationale[0]) {
+			logf("(%s:%i)\n", p_file, p_line);
+		} else {
+			logf("%s (%s:%i)\n", p_function, p_file, p_line);
 		}
 
 		SetConsoleTextAttribute(hCon, sbi.wAttributes);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/35301.

This makes secondary information less visually prominent to improve overall readability.

Various loggers were also tweaked for consistency.

## Preview

*The terminal font is [Recursive Mono Duotone](http://recursive.design/), if you're interested* :slightly_smiling_face:

![image](https://user-images.githubusercontent.com/180032/121818236-357cfe00-cc86-11eb-89cb-6d5c2f4e33b6.png)