### PR TITLE
Fixed error spam when XR mode is not enabled and a missed setting rename

### DIFF
--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -520,9 +520,9 @@ TypedArray<String> XROrigin3D::get_configuration_warnings() const {
 		}
 	}
 
-	bool vr_enabled = GLOBAL_GET("rendering/vr/enabled");
-	if (!vr_enabled) {
-		warnings.push_back(TTR("VR is not enabled in rendering project settings. Stereoscopic output is not supported unless this is enabled."));
+	bool xr_enabled = GLOBAL_GET("rendering/xr/enabled");
+	if (!xr_enabled) {
+		warnings.push_back(TTR("XR is not enabled in rendering project settings. Stereoscopic output is not supported unless this is enabled."));
 	}
 
 	return warnings;

--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -1580,7 +1580,11 @@ EffectsRD::EffectsRD() {
 		tonemap.shader_version = tonemap.shader.version_create();
 
 		for (int i = 0; i < TONEMAP_MODE_MAX; i++) {
-			tonemap.pipelines[i].setup(tonemap.shader.version_get_shader(tonemap.shader_version, i), RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), RD::PipelineDepthStencilState(), RD::PipelineColorBlendState::create_disabled(), 0);
+			if (tonemap.shader.is_variant_enabled(i)) {
+				tonemap.pipelines[i].setup(tonemap.shader.version_get_shader(tonemap.shader_version, i), RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), RD::PipelineDepthStencilState(), RD::PipelineColorBlendState::create_disabled(), 0);
+			} else {
+				tonemap.pipelines[i].clear();
+			}
 		}
 	}
 

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -127,8 +127,12 @@ void RendererSceneSkyRD::SkyShaderData::set_code(const String &p_code) {
 		depth_stencil_state.enable_depth_test = true;
 		depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_LESS_OR_EQUAL;
 
-		RID shader_variant = scene_singleton->sky.sky_shader.shader.version_get_shader(version, i);
-		pipelines[i].setup(shader_variant, RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), depth_stencil_state, RD::PipelineColorBlendState::create_disabled(), 0);
+		if (scene_singleton->sky.sky_shader.shader.is_variant_enabled(i)) {
+			RID shader_variant = scene_singleton->sky.sky_shader.shader.version_get_shader(version, i);
+			pipelines[i].setup(shader_variant, RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), depth_stencil_state, RD::PipelineColorBlendState::create_disabled(), 0);
+		} else {
+			pipelines[i].clear();
+		}
 	}
 
 	valid = true;


### PR DESCRIPTION
Added some missing checks that resulted in error spam when XR mode wasn't enabled and the initialization attempted to create pipelines for the shaders we do not initialise in this condition. 

Also renamed a setting I had forgot to rename. 