### PR TITLE
Update cache after clearing delimiters in CodeEdit

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1526,6 +1526,9 @@ void CodeEdit::_clear_delimiters(DelimiterType p_type) {
 		}
 	}
 	delimiter_cache.clear();
+	if (!setting_delimiters) {
+		_update_delimiter_cache();
+	}
 }
 
 TypedArray<String> CodeEdit::_get_delimiters(DelimiterType p_type) const {


### PR DESCRIPTION
Fixes #49568.

It crashed because the cache is out of sync with the real world :(