### PR TITLE
Fix crash when freeing GradientTexture and NoiseTexture

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -351,6 +351,9 @@ public:
 
 			for (size_t i = 0; i < max_alloc; i++) {
 				uint64_t validator = validator_chunks[i / elements_in_chunk][i % elements_in_chunk];
+				if (validator & 0x80000000) {
+					continue; //uninitialized
+				}
 				if (validator != 0xFFFFFFFF) {
 					chunks[i / elements_in_chunk][i % elements_in_chunk].~T();
 				}

--- a/modules/opensimplex/noise_texture.cpp
+++ b/modules/opensimplex/noise_texture.cpp
@@ -187,6 +187,7 @@ Ref<OpenSimplexNoise> NoiseTexture::get_noise() {
 }
 
 void NoiseTexture::set_width(int p_width) {
+	ERR_FAIL_COND(p_width <= 0);
 	if (p_width == size.x) {
 		return;
 	}
@@ -195,6 +196,7 @@ void NoiseTexture::set_width(int p_width) {
 }
 
 void NoiseTexture::set_height(int p_height) {
+	ERR_FAIL_COND(p_height <= 0);
 	if (p_height == size.y) {
 		return;
 	}

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1595,6 +1595,7 @@ void GradientTexture::_update() {
 }
 
 void GradientTexture::set_width(int p_width) {
+	ERR_FAIL_COND(p_width <= 0);
 	width = p_width;
 	_queue_update();
 }


### PR DESCRIPTION
* The crash was directly caused by `RID_Alloc` calling destructor for uninitialized elements.
    * The backtrace of original issues show godot crashed at a different place for a different reason, that was covered by #49520.
* No range validation are performed when setting texture size, thus the uninitialized element, resulting in leaked RID allocations at exit.

Fixes #49569.
Fixes #49563.