### PR TITLE
[HTML5] Fix builds with emcc >= 2.0.17 on Chrome for Android.

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -130,7 +130,6 @@ def configure(env):
         env.Append(CCFLAGS=["-fsanitize=leak"])
         env.Append(LINKFLAGS=["-fsanitize=leak"])
     if env["use_safe_heap"]:
-        env.Append(CCFLAGS=["-s", "SAFE_HEAP=1"])
         env.Append(LINKFLAGS=["-s", "SAFE_HEAP=1"])
 
     # Closure compiler
@@ -212,6 +211,9 @@ def configure(env):
 
     # Reduce code size by generating less support code (e.g. skip NodeJS support).
     env.Append(LINKFLAGS=["-s", "ENVIRONMENT=web,worker"])
+
+    # Break Chrome for android? Need to report upstream.
+    env.Append(LINKFLAGS=["-s", "BINARYEN_EXTRA_PASSES=--one-caller-inline-max-function-size=1"])
 
     # Wrap the JavaScript support code around a closure named Godot.
     env.Append(LINKFLAGS=["-s", "MODULARIZE=1", "-s", "EXPORT_NAME='Godot'"])


### PR DESCRIPTION
Disables a new default behaviour in emscripten that always inlines functions with only one caller.

This has been reported to cause performance issued on some browsers (https://github.com/emscripten-core/emscripten/issues/13899), but more importantly, breaks Godot builds on Chrome for Android (not Firefox for Android, not Chrome for Desktop).

Also fix a warning about SAFE_HEAP being a linker only flag.