### PR TITLE
[HTML5] Fix build without eval, library functions signatures.

### DIFF
--- a/platform/javascript/api/javascript_tools_editor_plugin.cpp
+++ b/platform/javascript/api/javascript_tools_editor_plugin.cpp
@@ -41,7 +41,7 @@
 
 // JavaScript functions defined in library_godot_editor_tools.js
 extern "C" {
-extern int godot_js_os_download_buffer(const uint8_t *p_buf, int p_buf_size, const char *p_name, const char *p_mime);
+extern void godot_js_os_download_buffer(const uint8_t *p_buf, int p_buf_size, const char *p_name, const char *p_mime);
 }
 
 static void _javascript_editor_init_callback() {

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -84,7 +84,7 @@ extern void godot_js_display_cursor_set_custom_shape(const char *p_shape, const 
 extern void godot_js_display_cursor_set_visible(int p_visible);
 
 // Display gamepad
-extern char *godot_js_display_gamepad_cb(void (*p_on_change)(int p_index, int p_connected, const char *p_id, const char *p_guid));
+extern void godot_js_display_gamepad_cb(void (*p_on_change)(int p_index, int p_connected, const char *p_id, const char *p_guid));
 extern int godot_js_display_gamepad_sample();
 extern int godot_js_display_gamepad_sample_count();
 extern int godot_js_display_gamepad_sample_get(int p_idx, float r_btns[16], int32_t *r_btns_num, float r_axes[10], int32_t *r_axes_num, int32_t *r_standard);

--- a/platform/javascript/javascript_singleton.cpp
+++ b/platform/javascript/javascript_singleton.cpp
@@ -28,10 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef JAVASCRIPT_EVAL_ENABLED
-
 #include "api/javascript_singleton.h"
 #include "emscripten.h"
+
+extern "C" {
+extern void godot_js_os_download_buffer(const uint8_t *p_buf, int p_buf_size, const char *p_name, const char *p_mime);
+}
+
+#ifdef JAVASCRIPT_EVAL_ENABLED
 
 extern "C" {
 typedef union {
@@ -301,7 +305,6 @@ union js_eval_ret {
 };
 
 extern int godot_js_eval(const char *p_js, int p_use_global_ctx, union js_eval_ret *p_union_ptr, void *p_byte_arr, void *p_byte_arr_write, void *(*p_callback)(void *p_ptr, void *p_ptr2, int p_len));
-extern int godot_js_os_download_buffer(const uint8_t *p_buf, int p_buf_size, const char *p_name, const char *p_mime);
 }
 
 void *resize_PackedByteArray_and_open_write(void *p_arr, void *r_write, int p_len) {

--- a/platform/javascript/js/libs/library_godot_display.js
+++ b/platform/javascript/js/libs/library_godot_display.js
@@ -683,7 +683,7 @@ const GodotDisplay = {
 		return GodotDisplayScreen.exitFullscreen();
 	},
 
-	godot_js_display_desired_size_set__sig: 'v',
+	godot_js_display_desired_size_set__sig: 'vii',
 	godot_js_display_desired_size_set: function (width, height) {
 		GodotDisplayScreen.desired_size = [width, height];
 		GodotDisplayScreen.updateSize();

--- a/platform/javascript/js/libs/library_godot_fetch.js
+++ b/platform/javascript/js/libs/library_godot_fetch.js
@@ -126,7 +126,7 @@ const GodotFetch = {
 		},
 	},
 
-	godot_js_fetch_create__sig: 'iii',
+	godot_js_fetch_create__sig: 'iiiiiii',
 	godot_js_fetch_create: function (p_method, p_url, p_headers, p_headers_size, p_body, p_body_size) {
 		const method = GodotRuntime.parseString(p_method);
 		const url = GodotRuntime.parseString(p_url);
@@ -176,7 +176,7 @@ const GodotFetch = {
 		return obj.status;
 	},
 
-	godot_js_fetch_read_headers__sig: 'iii',
+	godot_js_fetch_read_headers__sig: 'iiii',
 	godot_js_fetch_read_headers: function (p_id, p_parse_cb, p_ref) {
 		const obj = IDHandler.get(p_id);
 		if (!obj || !obj.response) {
@@ -193,7 +193,7 @@ const GodotFetch = {
 		return 0;
 	},
 
-	godot_js_fetch_read_chunk__sig: 'ii',
+	godot_js_fetch_read_chunk__sig: 'iiii',
 	godot_js_fetch_read_chunk: function (p_id, p_buf, p_buf_size) {
 		const obj = IDHandler.get(p_id);
 		if (!obj || !obj.response) {

--- a/platform/javascript/js/libs/library_godot_javascript_singleton.js
+++ b/platform/javascript/js/libs/library_godot_javascript_singleton.js
@@ -196,7 +196,7 @@ const GodotJSWrapper = {
 		}
 	},
 
-	godot_js_wrapper_create_cb__sig: 'vii',
+	godot_js_wrapper_create_cb__sig: 'iii',
 	godot_js_wrapper_create_cb: function (p_ref, p_func) {
 		const func = GodotRuntime.get_func(p_func);
 		let id = 0;


### PR DESCRIPTION
In this PR:

- Fix a bunch of spotted mismatching signatures between JavaScript and C++
- Fix build with `javascript_eval=no`.