### PR TITLE
Fix loading RLE compressed TGAs and invalid memory reads.

### DIFF
--- a/modules/tga/image_loader_tga.h
+++ b/modules/tga/image_loader_tga.h
@@ -72,8 +72,8 @@ class ImageLoaderTGA : public ImageFormatLoader {
 		uint8_t pixel_depth = 0;
 		uint8_t image_descriptor = 0;
 	};
-	static Error decode_tga_rle(const uint8_t *p_compressed_buffer, size_t p_pixel_size, uint8_t *p_uncompressed_buffer, size_t p_output_size);
-	static Error convert_to_image(Ref<Image> p_image, const uint8_t *p_buffer, const tga_header_s &p_header, const uint8_t *p_palette, const bool p_is_monochrome, size_t p_output_size);
+	static Error decode_tga_rle(const uint8_t *p_compressed_buffer, size_t p_pixel_size, uint8_t *p_uncompressed_buffer, size_t p_output_size, size_t p_input_size);
+	static Error convert_to_image(Ref<Image> p_image, const uint8_t *p_buffer, const tga_header_s &p_header, const uint8_t *p_palette, const bool p_is_monochrome, size_t p_input_size);
 
 public:
 	virtual Error load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale);


### PR DESCRIPTION
- Fix loading RLE compressed TGA files
- Fix memory reads outside of input buffer when loading invalid TGA files.

Fixes #48592
Fixes #46549

Tested with a bunch of images saved by GIMP, and test files from #45702 and #46549.