### PR TITLE
GDNative: Use VariantWriter for the API JSON generator

### DIFF
--- a/modules/visual_script/doc_classes/VisualScriptFunctionState.xml
+++ b/modules/visual_script/doc_classes/VisualScriptFunctionState.xml
@@ -28,7 +28,7 @@
 		<method name="resume">
 			<return type="Variant">
 			</return>
-			<argument index="0" name="args" type="Array" default="null">
+			<argument index="0" name="args" type="Array" default="[  ]">
 			</argument>
 			<description>
 			</description>

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2204,7 +2204,7 @@ Variant VisualScriptFunctionState::resume(Array p_args) {
 
 void VisualScriptFunctionState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("connect_to_signal", "obj", "signals", "args"), &VisualScriptFunctionState::connect_to_signal);
-	ClassDB::bind_method(D_METHOD("resume", "args"), &VisualScriptFunctionState::resume, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("resume", "args"), &VisualScriptFunctionState::resume, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("is_valid"), &VisualScriptFunctionState::is_valid);
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "_signal_callback", &VisualScriptFunctionState::_signal_callback, MethodInfo("_signal_callback"));
 }


### PR DESCRIPTION
Instead of the String representation, which can be finicky to work with.
VariantWriter is more robust since changes to it affects the whole
system thus it's changed less often and it's never ambiguous.

This will break the existing bindings that depend on this, but it'll be easier to parse in general (and the String representation changed anyway, so it's broken even before this change). 