### PR TITLE
Added InputMap entry for backspacing using Shift+Backspace

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -511,6 +511,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	// Text Backspace and Delete
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_BACKSPACE));
+	inputs.push_back(InputEventKey::create_reference(KEY_BACKSPACE | KEY_MASK_SHIFT));
 	default_builtin_cache.insert("ui_text_backspace", inputs);
 
 	inputs = List<Ref<InputEvent>>();


### PR DESCRIPTION
In response to #49517 

*Bugsquad edit:* fixes #49517.

It used to be possible to backspace using shift+backspace by default, so I added an Input_Map entry in order to bring that functionality back. 
This is my first pull request, sorry if I made any mistakes!