### PR TITLE
Inverse XR camera offset for stereoscopic rendering

### DIFF
--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -175,7 +175,7 @@ void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count
 	/////////////////////////////////////////////////////////////////////////////
 	// 3. Copy our view data
 	for (uint32_t v = 0; v < view_count; v++) {
-		view_offset[v] = p_transforms[v] * main_transform_inv;
-		view_projection[v] = p_projections[v] * CameraMatrix(view_offset[v]);
+		view_offset[v] = main_transform_inv * p_transforms[v];
+		view_projection[v] = p_projections[v] * CameraMatrix(view_offset[v].inverse());
 	}
 }


### PR DESCRIPTION
While testing the new stereoscopic renderer with OpenVR I noticed I was seeing crossed eyed :)
The calculated offset is the offset from the headcenter to the eye. For viewspace translation we need to apply the inverse of this.