### PR TITLE
Fix sub-resource storing the wrong index in cache

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -575,6 +575,7 @@ Error ResourceLoaderText::load() {
 		int_resources[id] = res; //always assign int resources
 		if (do_assign && cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 			res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
+			res->set_subindex(id);
 		}
 
 		if (progress && resources_total > 0) {


### PR DESCRIPTION
Fixes #49622

The subindex within Resource wasn't synchronized with the path stored in cache when saving a packed scene. It could cause sub-resources to be swapped when loading the same packed scene in the same session.

Now the subindex in Resource reflects the sub-resource path in cache, making saving and loading sub-resources consistent.

Credits to @latorril for finding the issue and investigating the cause.
