### PR TITLE
[3.x] Fix sub-resource storing the wrong index in cache

### DIFF
--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -60,6 +60,7 @@ class ResourceInteractiveLoaderText : public ResourceInteractiveLoader {
 	//Map<String,String> remaps;
 
 	Map<int, ExtResource> ext_resources;
+	Map<int, RES> int_resources;
 
 	int resources_total;
 	int resource_current;
@@ -100,7 +101,6 @@ class ResourceInteractiveLoaderText : public ResourceInteractiveLoader {
 
 	friend class ResourceFormatLoaderText;
 
-	List<RES> resource_cache;
 	Error error;
 
 	RES resource;


### PR DESCRIPTION
Fixes #49622 on 3.x branch.

1. Backport sub-resource cache fixes from master.

Partial backport of #45903 (just the sub-resource cache fix, not additional cache modes).
Uses a cache by index to keep sub resource indices consistent.

2. Backport of #49624

The subindex within Resource wasn't synchronized with the path stored in cache when saving a packed scene. It could cause sub-resources to be swapped when loading the same packed scene in the same session.

Now the subindex in Resource reflects the sub-resource path in cache, making saving and loading sub-resources consistent.

Credits to @latorril for finding the issue and investigating the cause.