### PR TITLE
Fix typo in `CUSTOM_IRRADIANCE` calculations

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -904,7 +904,7 @@ void main() {
 	}
 #endif // USE_LIGHTMAP
 #if defined(CUSTOM_IRRADIANCE_USED)
-	ambient_light = mix(specular_light, custom_irradiance.rgb, custom_irradiance.a);
+	ambient_light = mix(ambient_light, custom_irradiance.rgb, custom_irradiance.a);
 #endif
 #endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/49626

I did exactly what the issue said. I fixed the type-o.
