### PR TITLE
Revert "[3.x] Fix SceneTreeDock::_selection_changed"

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2045,8 +2045,6 @@ void SceneTreeDock::_selection_changed() {
 		_tool_selected(TOOL_MULTI_EDIT);
 	} else if (selection_size == 0) {
 		editor->push_item(nullptr);
-	} else {
-		editor->push_item(EditorNode::get_singleton()->get_editor_selection()->get_selection().front()->value());
 	}
 
 	_update_script_button();


### PR DESCRIPTION
Reverts godotengine/godot#49486

Fixes #49627 in `3.x`.