### PR TITLE
Allow multiplying Transforms and Basis by numbers

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -158,8 +158,8 @@ public:
 	_FORCE_INLINE_ Basis operator+(const Basis &p_matrix) const;
 	_FORCE_INLINE_ void operator-=(const Basis &p_matrix);
 	_FORCE_INLINE_ Basis operator-(const Basis &p_matrix) const;
-	_FORCE_INLINE_ void operator*=(real_t p_val);
-	_FORCE_INLINE_ Basis operator*(real_t p_val) const;
+	_FORCE_INLINE_ void operator*=(const real_t p_val);
+	_FORCE_INLINE_ Basis operator*(const real_t p_val) const;
 
 	int get_orthogonal_index() const;
 	void set_orthogonal_index(int p_index);
@@ -298,13 +298,13 @@ _FORCE_INLINE_ Basis Basis::operator-(const Basis &p_matrix) const {
 	return ret;
 }
 
-_FORCE_INLINE_ void Basis::operator*=(real_t p_val) {
+_FORCE_INLINE_ void Basis::operator*=(const real_t p_val) {
 	elements[0] *= p_val;
 	elements[1] *= p_val;
 	elements[2] *= p_val;
 }
 
-_FORCE_INLINE_ Basis Basis::operator*(real_t p_val) const {
+_FORCE_INLINE_ Basis Basis::operator*(const real_t p_val) const {
 	Basis ret(*this);
 	ret *= p_val;
 	return ret;

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -276,6 +276,18 @@ Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, real_t
 	return res;
 }
 
+void Transform2D::operator*=(const real_t p_val) {
+	elements[0] *= p_val;
+	elements[1] *= p_val;
+	elements[2] *= p_val;
+}
+
+Transform2D Transform2D::operator*(const real_t p_val) const {
+	Transform2D ret(*this);
+	ret *= p_val;
+	return ret;
+}
+
 Transform2D::operator String() const {
 	return "[X: " + elements[0].operator String() +
 		   ", Y: " + elements[1].operator String() +

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -107,6 +107,8 @@ struct Transform2D {
 
 	void operator*=(const Transform2D &p_transform);
 	Transform2D operator*(const Transform2D &p_transform) const;
+	void operator*=(const real_t p_val);
+	Transform2D operator*(const real_t p_val) const;
 
 	Transform2D interpolate_with(const Transform2D &p_transform, real_t p_c) const;
 

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -190,6 +190,17 @@ Transform3D Transform3D::operator*(const Transform3D &p_transform) const {
 	return t;
 }
 
+void Transform3D::operator*=(const real_t p_val) {
+	origin *= p_val;
+	basis *= p_val;
+}
+
+Transform3D Transform3D::operator*(const real_t p_val) const {
+	Transform3D ret(*this);
+	ret *= p_val;
+	return ret;
+}
+
 Transform3D::operator String() const {
 	return "[X: " + basis.get_axis(0).operator String() +
 		   ", Y: " + basis.get_axis(1).operator String() +

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -88,6 +88,8 @@ public:
 
 	void operator*=(const Transform3D &p_transform);
 	Transform3D operator*(const Transform3D &p_transform) const;
+	void operator*=(const real_t p_val);
+	Transform3D operator*(const real_t p_val) const;
 
 	Transform3D interpolate_with(const Transform3D &p_transform, real_t p_c) const;
 

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -1458,6 +1458,8 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorMul<Color, Color, double>>(Variant::OP_MULTIPLY, Variant::COLOR, Variant::FLOAT);
 
 	register_op<OperatorEvaluatorMul<Transform2D, Transform2D, Transform2D>>(Variant::OP_MULTIPLY, Variant::TRANSFORM2D, Variant::TRANSFORM2D);
+	register_op<OperatorEvaluatorMul<Transform2D, Transform2D, int64_t>>(Variant::OP_MULTIPLY, Variant::TRANSFORM2D, Variant::INT);
+	register_op<OperatorEvaluatorMul<Transform2D, Transform2D, double>>(Variant::OP_MULTIPLY, Variant::TRANSFORM2D, Variant::FLOAT);
 	register_op<OperatorEvaluatorXForm<Vector2, Transform2D, Vector2>>(Variant::OP_MULTIPLY, Variant::TRANSFORM2D, Variant::VECTOR2);
 	register_op<OperatorEvaluatorXFormInv<Vector2, Vector2, Transform2D>>(Variant::OP_MULTIPLY, Variant::VECTOR2, Variant::TRANSFORM2D);
 	register_op<OperatorEvaluatorXForm<Rect2, Transform2D, Rect2>>(Variant::OP_MULTIPLY, Variant::TRANSFORM2D, Variant::RECT2);
@@ -1466,6 +1468,8 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorXFormInv<Vector<Vector2>, Vector<Vector2>, Transform2D>>(Variant::OP_MULTIPLY, Variant::PACKED_VECTOR2_ARRAY, Variant::TRANSFORM2D);
 
 	register_op<OperatorEvaluatorMul<Transform3D, Transform3D, Transform3D>>(Variant::OP_MULTIPLY, Variant::TRANSFORM3D, Variant::TRANSFORM3D);
+	register_op<OperatorEvaluatorMul<Transform3D, Transform3D, int64_t>>(Variant::OP_MULTIPLY, Variant::TRANSFORM3D, Variant::INT);
+	register_op<OperatorEvaluatorMul<Transform3D, Transform3D, double>>(Variant::OP_MULTIPLY, Variant::TRANSFORM3D, Variant::FLOAT);
 	register_op<OperatorEvaluatorXForm<Vector3, Transform3D, Vector3>>(Variant::OP_MULTIPLY, Variant::TRANSFORM3D, Variant::VECTOR3);
 	register_op<OperatorEvaluatorXFormInv<Vector3, Vector3, Transform3D>>(Variant::OP_MULTIPLY, Variant::VECTOR3, Variant::TRANSFORM3D);
 	register_op<OperatorEvaluatorXForm<::AABB, Transform3D, ::AABB>>(Variant::OP_MULTIPLY, Variant::TRANSFORM3D, Variant::AABB);
@@ -1474,6 +1478,8 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorXFormInv<Vector<Vector3>, Vector<Vector3>, Transform3D>>(Variant::OP_MULTIPLY, Variant::PACKED_VECTOR3_ARRAY, Variant::TRANSFORM3D);
 
 	register_op<OperatorEvaluatorMul<Basis, Basis, Basis>>(Variant::OP_MULTIPLY, Variant::BASIS, Variant::BASIS);
+	register_op<OperatorEvaluatorMul<Basis, Basis, int64_t>>(Variant::OP_MULTIPLY, Variant::BASIS, Variant::INT);
+	register_op<OperatorEvaluatorMul<Basis, Basis, double>>(Variant::OP_MULTIPLY, Variant::BASIS, Variant::FLOAT);
 	register_op<OperatorEvaluatorXForm<Vector3, Basis, Vector3>>(Variant::OP_MULTIPLY, Variant::BASIS, Variant::VECTOR3);
 	register_op<OperatorEvaluatorXFormInv<Vector3, Vector3, Basis>>(Variant::OP_MULTIPLY, Variant::VECTOR3, Variant::BASIS);
 

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -155,6 +155,24 @@
 			<description>
 			</description>
 		</method>
+		<method name="operator *" qualifiers="operator">
+			<return type="Basis">
+			</return>
+			<argument index="0" name="right" type="float">
+			</argument>
+			<description>
+				This operator multiplies all components of the [Basis], which scales it uniformly.
+			</description>
+		</method>
+		<method name="operator *" qualifiers="operator">
+			<return type="Basis">
+			</return>
+			<argument index="0" name="right" type="int">
+			</argument>
+			<description>
+				This operator multiplies all components of the [Basis], which scales it uniformly.
+			</description>
+		</method>
 		<method name="operator ==" qualifiers="operator">
 			<return type="bool">
 			</return>

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -148,17 +148,9 @@
 			</description>
 		</method>
 		<method name="operator *" qualifiers="operator">
-			<return type="PackedVector2Array">
+			<return type="Vector2">
 			</return>
-			<argument index="0" name="right" type="PackedVector2Array">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="operator *" qualifiers="operator">
-			<return type="Transform2D">
-			</return>
-			<argument index="0" name="right" type="Transform2D">
+			<argument index="0" name="right" type="Vector2">
 			</argument>
 			<description>
 			</description>
@@ -172,11 +164,37 @@
 			</description>
 		</method>
 		<method name="operator *" qualifiers="operator">
-			<return type="Vector2">
+			<return type="Transform2D">
 			</return>
-			<argument index="0" name="right" type="Vector2">
+			<argument index="0" name="right" type="Transform2D">
 			</argument>
 			<description>
+			</description>
+		</method>
+		<method name="operator *" qualifiers="operator">
+			<return type="PackedVector2Array">
+			</return>
+			<argument index="0" name="right" type="PackedVector2Array">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="operator *" qualifiers="operator">
+			<return type="Transform2D">
+			</return>
+			<argument index="0" name="right" type="float">
+			</argument>
+			<description>
+				This operator multiplies all components of the [Transform2D], including the origin vector, which scales it uniformly.
+			</description>
+		</method>
+		<method name="operator *" qualifiers="operator">
+			<return type="Transform2D">
+			</return>
+			<argument index="0" name="right" type="int">
+			</argument>
+			<description>
+				This operator multiplies all components of the [Transform2D], including the origin vector, which scales it uniformly.
 			</description>
 		</method>
 		<method name="operator ==" qualifiers="operator">

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -145,6 +145,24 @@
 			<description>
 			</description>
 		</method>
+		<method name="operator *" qualifiers="operator">
+			<return type="Transform3D">
+			</return>
+			<argument index="0" name="right" type="float">
+			</argument>
+			<description>
+				This operator multiplies all components of the [Transform3D], including the origin vector, which scales it uniformly.
+			</description>
+		</method>
+		<method name="operator *" qualifiers="operator">
+			<return type="Transform3D">
+			</return>
+			<argument index="0" name="right" type="int">
+			</argument>
+			<description>
+				This operator multiplies all components of the [Transform3D], including the origin vector, which scales it uniformly.
+			</description>
+		</method>
 		<method name="operator ==" qualifiers="operator">
 			<return type="bool">
 			</return>

--- a/modules/gdnavigation/navigation_mesh_generator.cpp
+++ b/modules/gdnavigation/navigation_mesh_generator.cpp
@@ -255,7 +255,7 @@ void NavigationMeshGenerator::_parse_geometry(Transform3D p_accumulated_transfor
 		for (int i = 0; i < meshes.size(); i += 2) {
 			Ref<Mesh> mesh = meshes[i + 1];
 			if (mesh.is_valid()) {
-				_add_mesh(mesh, p_accumulated_transform * xform * meshes[i], p_verticies, p_indices);
+				_add_mesh(mesh, p_accumulated_transform * xform * (Transform3D)meshes[i], p_verticies, p_indices);
 			}
 		}
 	}


### PR DESCRIPTION
This operator multiplies all components of the transform/basis. It's a helpful shortcut for uniformly scaling a transform (including its origin vector) or basis. With this PR, `Transform2D() * 0.375` creates a `Transform2D` with a scale of (0.375, 0.375).

`Basis` can already do this internally in C++, but the behavior isn't exposed.

Test code:

```gdscript
print("Transform2D")
print(Transform2D() * 0.375)
print("Basis")
print(Basis() * 0.375)
print("Transform3D")
print(Transform3D() * 0.375)
```

Output:

```
Transform2D
[X: (0.375, 0), Y: (0, 0.375), O: (0, 0)]
Basis
[X: (0.375, 0, 0), Y: (0, 0.375, 0), Z: (0, 0, 0.375)]
Transform3D
[X: (0.375, 0, 0), Y: (0, 0.375, 0), Z: (0, 0, 0.375), O: (0, 0, 0)]
```

The test code is identical to this code that works in the current master:

```gdscript
print("Transform2D")
print(Transform2D().scaled(Vector2(0.375, 0.375)))
print("Basis")
print(Basis().scaled(Vector3(0.375, 0.375, 0.375)))
print("Transform3D")
print(Transform3D().scaled(Vector3(0.375, 0.375, 0.375)))
```