### PR TITLE
Tweak the "Changes may be lost!" text color to match the icon's color (3.x)

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -340,6 +340,7 @@ void InspectorDock::_notification(int p_what) {
 			history_menu->set_icon(get_icon("History", "EditorIcons"));
 			object_menu->set_icon(get_icon("Tools", "EditorIcons"));
 			warning->set_icon(get_icon("NodeWarning", "EditorIcons"));
+			warning->add_color_override("font_color", get_color("warning_color", "Editor"));
 		} break;
 	}
 }
@@ -581,6 +582,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	add_child(warning);
 	warning->set_text(TTR("Changes may be lost!"));
 	warning->set_icon(get_icon("NodeWarning", "EditorIcons"));
+	warning->add_color_override("font_color", get_color("warning_color", "Editor"));
 	warning->set_clip_text(true);
 	warning->hide();
 	warning->connect("pressed", this, "_warning_pressed");


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/36061.

## Preview (`3.x` branch)

![image](https://user-images.githubusercontent.com/180032/122158879-a5011200-ce6d-11eb-9452-2352d3143b0f.png)