### PR TITLE
Fix crash with FindReplaceBar

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -105,6 +105,11 @@ void FindReplaceBar::_notification(int p_what) {
 		hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
 		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color("font_color", "Label") : get_theme_color("error_color", "Editor"));
+	} else if (p_what == NOTIFICATION_PREDELETE) {
+		if (base_text_editor) {
+			base_text_editor->remove_find_replace_bar();
+			base_text_editor = nullptr;
+		}
 	}
 }
 
@@ -593,6 +598,10 @@ void FindReplaceBar::set_text_edit(CodeTextEditor *p_text_editor) {
 		base_text_editor = nullptr;
 		text_editor->disconnect("text_changed", callable_mp(this, &FindReplaceBar::_editor_text_changed));
 		text_editor = nullptr;
+	}
+
+	if (!p_text_editor) {
+		return;
 	}
 
 	results_count = -1;
@@ -1660,6 +1669,11 @@ void CodeTextEditor::_notification(int p_what) {
 				update_toggle_scripts_button();
 			}
 			set_process_input(is_visible_in_tree());
+		} break;
+		case NOTIFICATION_PREDELETE: {
+			if (find_replace_bar) {
+				find_replace_bar->set_text_edit(nullptr);
+			}
 		} break;
 		default:
 			break;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -760,6 +760,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save, bool p_history_back) {
 	_update_members_overview_visibility();
 	_update_help_overview_visibility();
 	_save_layout();
+	_update_find_replace_bar();
 }
 
 void ScriptEditor::_close_current_tab(bool p_save) {
@@ -829,6 +830,7 @@ void ScriptEditor::_close_all_tabs() {
 
 		_close_current_tab(false);
 	}
+	_update_find_replace_bar();
 }
 
 void ScriptEditor::_ask_close_current_unsaved_tab(ScriptEditorBase *current) {
@@ -1640,15 +1642,13 @@ void ScriptEditor::ensure_select_current() {
 		ScriptEditorBase *se = _get_current_editor();
 		if (se) {
 			se->enable_editor();
-			se->set_find_replace_bar(find_replace_bar);
 
 			if (!grab_focus_block && is_visible_in_tree()) {
 				se->ensure_focus();
 			}
-		} else {
-			find_replace_bar->hide();
 		}
 	}
+	_update_find_replace_bar();
 
 	_update_selected_editor_menu();
 }
@@ -2517,6 +2517,16 @@ void ScriptEditor::_file_removed(const String &p_removed_file) {
 			// The script is deleted with no undo, so just close the tab.
 			_close_tab(i, false, false);
 		}
+	}
+}
+
+void ScriptEditor::_update_find_replace_bar() {
+	ScriptEditorBase *se = _get_current_editor();
+	if (se) {
+		se->set_find_replace_bar(find_replace_bar);
+	} else {
+		find_replace_bar->set_text_edit(nullptr);
+		find_replace_bar->hide();
 	}
 }
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -328,6 +328,7 @@ class ScriptEditor : public PanelContainer {
 	void _show_error_dialog(String p_path);
 
 	void _close_tab(int p_idx, bool p_save = true, bool p_history_back = true);
+	void _update_find_replace_bar();
 
 	void _close_current_tab(bool p_save = true);
 	void _close_discard_current_tab(const String &p_str);


### PR DESCRIPTION
Fixes regression from #49265

The editor was crashing with this backtrace, randomly when closing/opening scripts:
```
[0] Object::get_instance_id (C:\godot_source\core\object\object.h:627)
[1] CallableCustomMethodPointer<Label,String const &>::CallableCustomMethodPointer<Label,String const &> (C:\godot_source\core\object\callable_method_pointer.h:103)    
[2] create_custom_callable_function_pointer<Label,String const &> (C:\godot_source\core\object\callable_method_pointer.h:117)
[3] CodeTextEditor::remove_find_replace_bar (C:\godot_source\editor\code_editor.cpp:971)
[4] FindReplaceBar::set_text_edit (C:\godot_source\editor\code_editor.cpp:593)
[5] CodeTextEditor::set_find_replace_bar (C:\godot_source\editor\code_editor.cpp:963)
[6] ScriptTextEditor::set_find_replace_bar (C:\godot_source\editor\plugins\script_text_editor.cpp:1363)
[7] ScriptEditor::ensure_select_current (C:\godot_source\editor\plugins\script_editor_plugin.cpp:1645)
[8] ScriptEditor::_tab_changed (C:\godot_source\editor\plugins\script_editor_plugin.cpp:1465)
[9] call_with_variant_args_helper<ScriptEditor,int,0> (C:\godot_source\core\variant\binder_common.h:214)
[10] call_with_variant_args<ScriptEditor,int> (C:\godot_source\core\variant\binder_common.h:324)
[11] CallableCustomMethodPointer<ScriptEditor,int>::call (C:\godot_source\core\object\callable_method_pointer.h:97)
[12] Callable::call (C:\godot_source\core\variant\callable.cpp:51)
[13] Object::emit_signal (C:\godot_source\core\object\object.cpp:1084)
[14] Object::emit_signal (C:\godot_source\core\object\object.cpp:1139)
[15] TabContainer::add_child_notify (C:\godot_source\scene\gui\tab_container.cpp:735)
[16] Node::_add_child_nocheck (C:\godot_source\scene\main\node.cpp:1036)
[17] Node::add_child (C:\godot_source\scene\main\node.cpp:1051)
[18] ScriptEditor::edit (C:\godot_source\editor\plugins\script_editor_plugin.cpp:2246)
[19] ScriptEditor::edit (C:\godot_source\editor\plugins\script_editor_plugin.h:465)
[20] ScriptEditorPlugin::edit (C:\godot_source\editor\plugins\script_editor_plugin.cpp:3626)
[21] EditorNode::_edit_current (C:\godot_source\editor\editor_node.cpp:2193)
[22] EditorNode::push_item (C:\godot_source\editor\editor_node.cpp:1997)
[23] InspectorDock::_resource_selected (C:\godot_source\editor\inspector_dock.cpp:289)
[24] InspectorDock::edit_resource (C:\godot_source\editor\inspector_dock.cpp:380)
[25] EditorNode::load_resource (C:\godot_source\editor\editor_node.cpp:1074)
[26] FileSystemDock::_select_file (C:\godot_source\editor\filesystem_dock.cpp:985)
[27] FileSystemDock::_tree_activate_file (C:\godot_source\editor\filesystem_dock.cpp:999)
[28] call_with_variant_args_helper<FileSystemDock> (C:\godot_source\core\variant\binder_common.h:214)
[29] call_with_variant_args<FileSystemDock> (C:\godot_source\core\variant\binder_common.h:324)
[30] CallableCustomMethodPointer<FileSystemDock>::call (C:\godot_source\core\object\callable_method_pointer.h:97)
[31] Callable::call (C:\godot_source\core\variant\callable.cpp:51)
[32] Object::emit_signal (C:\godot_source\core\object\object.cpp:1084)
[33] Object::emit_signal (C:\godot_source\core\object\object.cpp:1139)
[34] Tree::_gui_input (C:\godot_source\scene\gui\tree.cpp:3143)
[35] call_with_variant_args_helper<Tree,Ref<InputEvent>,0> (C:\godot_source\core\variant\binder_common.h:214)
[36] call_with_variant_args_dv<Tree,Ref<InputEvent> > (C:\godot_source\core\variant\binder_common.h:357)
[37] MethodBindT<Tree,Ref<InputEvent> >::call (C:\godot_source\core\object\method_bind.h:285)
[38] Viewport::_gui_call_input (C:\godot_source\scene\main\viewport.cpp:1667)
[39] Viewport::_gui_input_event (C:\godot_source\scene\main\viewport.cpp:1923)
[40] Viewport::input (C:\godot_source\scene\main\viewport.cpp:3076)
[41] Window::_window_input (C:\godot_source\scene\main\window.cpp:916)
[42] call_with_variant_args_helper<Window,Ref<InputEvent> const &,0> (C:\godot_source\core\variant\binder_common.h:209)
[43] call_with_variant_args<Window,Ref<InputEvent> const &> (C:\godot_source\core\variant\binder_common.h:324)
[44] CallableCustomMethodPointer<Window,Ref<InputEvent> const &>::call (C:\godot_source\core\object\callable_method_pointer.h:97)
[45] Callable::call (C:\godot_source\core\variant\callable.cpp:51)
[46] DisplayServerWindows::_dispatch_input_event (C:\godot_source\platform\windows\display_server_windows.cpp:1798)
[47] DisplayServerWindows::_dispatch_input_events (C:\godot_source\platform\windows\display_server_windows.cpp:1772)
[48] Input::_parse_input_event_impl (C:\godot_source\core\input\input.cpp:643)
[49] Input::parse_input_event (C:\godot_source\core\input\input.cpp:466)
[51] DisplayServerWindows::process_events (C:\godot_source\platform\windows\display_server_windows.cpp:1534)
[52] OS_Windows::run (C:\godot_source\platform\windows\os_windows.cpp:622)
[53] widechar_main (C:\godot_source\platform\windows\godot_windows.cpp:163)
[54] _main (C:\godot_source\platform\windows\godot_windows.cpp:185)
[55] main (C:\godot_source\platform\windows\godot_windows.cpp:199)
[56] __scrt_common_main_seh (D:\a01\_work\26\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[57] BaseThreadInitThunk
```

Fixes #49785