### PR TITLE
Fix typo in CodeEdit methods

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -184,7 +184,7 @@
 				Gets the end key for a string or comment region index.
 			</description>
 		</method>
-		<method name="get_delimiter_end_postion" qualifiers="const">
+		<method name="get_delimiter_end_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="line" type="int">
@@ -204,7 +204,7 @@
 				Gets the start key for a string or comment region index.
 			</description>
 		</method>
-		<method name="get_delimiter_start_postion" qualifiers="const">
+		<method name="get_delimiter_start_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="line" type="int">

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1121,8 +1121,8 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_delimiter_start_key", "delimiter_index"), &CodeEdit::get_delimiter_start_key);
 	ClassDB::bind_method(D_METHOD("get_delimiter_end_key", "delimiter_index"), &CodeEdit::get_delimiter_end_key);
 
-	ClassDB::bind_method(D_METHOD("get_delimiter_start_postion", "line", "column"), &CodeEdit::get_delimiter_start_position);
-	ClassDB::bind_method(D_METHOD("get_delimiter_end_postion", "line", "column"), &CodeEdit::get_delimiter_end_position);
+	ClassDB::bind_method(D_METHOD("get_delimiter_start_position", "line", "column"), &CodeEdit::get_delimiter_start_position);
+	ClassDB::bind_method(D_METHOD("get_delimiter_end_position", "line", "column"), &CodeEdit::get_delimiter_end_position);
 
 	/* Code hint */
 	ClassDB::bind_method(D_METHOD("set_code_hint", "code_hint"), &CodeEdit::set_code_hint);


### PR DESCRIPTION
Came across these typos when I was inspecting #49568... and they were quickly forgotten 🤣 

p.s. I did a search and other code that have the same typo are all third-party ones.