### PR TITLE
Main: Fixup bogus fallback to project manager with more bolognese

### DIFF
--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -186,7 +186,7 @@ EditorPaths::EditorPaths() {
 	// Validate or create project-specific editor data dir (`res://.godot`),
 	// including shader cache subdir.
 
-	if (Main::is_project_manager()) {
+	if (Main::is_project_manager() || Main::is_cmdline_tool()) {
 		// Nothing to create, use shared editor data dir for shader cache.
 		Engine::get_singleton()->set_shader_cache_path(data_dir);
 	} else {
@@ -209,6 +209,4 @@ EditorPaths::EditorPaths() {
 			dir_res->make_dir(ProjectSettings::IMPORTED_FILES_PATH);
 		}
 	}
-
-	print_line("paths valid: " + itos((int)paths_valid));
 }

--- a/main/main.h
+++ b/main/main.h
@@ -45,6 +45,7 @@ class Main {
 
 public:
 	static bool is_project_manager();
+	static bool is_cmdline_tool();
 	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
 	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
 	static Error setup2(Thread::ID p_main_tid_override = 0);


### PR DESCRIPTION
WARNING: Hacks everywhere!

The logic in `main.cpp` is due a full rewrite as it's extremely hacky,
splitting argument parsing over several functions, with a mess of global state
and assumptions about what combinations of arguments or lack thereof should
mean in terms of what we want to read: game, editor, project manager, or
command line tools such as `--doctool`, `--export` or `--script`.

Until this is fully rewritten, this patch hacks things some more to ensure
that we don't fall back to the project manager in cases where it's not
warranted, and especially not *too late*, as it can mean that we haven't
properly initialized stuff like `EditorPaths` needed by the PM (which in turn
impacts what kind of path will be used for logs and the shader cache, etc...
the rabbit hole goes deep).

Fixes #41435.
Fixes #49392.
Fixes #49658.
Fixes https://github.com/godotengine/godot/issues/38202#issuecomment-773158477.

![xkcd: Data Pipeline](https://imgs.xkcd.com/comics/data_pipeline.png)

----

This has a lot of potential for regressions as this code is really brittle, and my preferred approach to making things better (and fixing potential regressions) would be to rewrite the whole thing from scratch, which I might do soon, after reviewing some pending PRs which tried to poke at this mess.