### PR TITLE
[3.x] Clarify docs of Transform.xform_inv, Transform2D.xform_inv

### DIFF
--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -168,7 +168,7 @@
 			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
-				Inverse-transforms the given [Vector3], [Plane], [AABB], or [PoolVector3Array] by this transform.
+				Inverse-transforms the given [Vector3], [Plane], [AABB], or [PoolVector3Array] by this transform, under the assumption that the transformation is composed of rotation and translation (no scaling). Equivalent to calling [code]inverse().xform(v)[/code] on this transform. For affine transformations (e.g. with scaling) see [method affine_inverse] method.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -172,7 +172,7 @@
 			<argument index="0" name="v" type="Variant">
 			</argument>
 			<description>
-				Inverse-transforms the given [Vector2], [Rect2], or [PoolVector2Array] by this transform.
+				Inverse-transforms the given [Vector2], [Rect2], or [PoolVector2Array] by this transform, under the assumption that the transformation is composed of rotation and translation (no scaling). Equivalent to calling [code]inverse().xform(v)[/code] on this transform. For affine transformations (e.g. with scaling) see [method affine_inverse] method.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Related issue: #39433.
`3.x` only since `xform_inv()` is no longer documented (and binded/exposed?) in the `master` (probably because of favoring multiplying operators).
Cherry-pickable for `3.3`.