### PR TITLE
Move indentation into CodeEdit

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -143,6 +143,20 @@
 				Inserts the selected entry into the text. If [code]replace[/code] is true, any existing text is replaced rather then merged.
 			</description>
 		</method>
+		<method name="do_indent">
+			<return type="void">
+			</return>
+			<description>
+				Perform an indent as if the user activated the "ui_text_indent" action.
+			</description>
+		</method>
+		<method name="do_unindent">
+			<return type="void">
+			</return>
+			<description>
+				Perform an unindent as if the user activated the "ui_text_unindent" action.
+			</description>
+		</method>
 		<method name="fold_all_lines">
 			<return type="void">
 			</return>
@@ -276,6 +290,13 @@
 			</argument>
 			<description>
 				Returns [code]true[/code] if string [code]start_key[/code] exists.
+			</description>
+		</method>
+		<method name="indent_lines">
+			<return type="void">
+			</return>
+			<description>
+				Indents selected lines, or in the case of no selection the caret line by one.
 			</description>
 		</method>
 		<method name="is_in_comment" qualifiers="const">
@@ -441,6 +462,13 @@
 				Unfolds all lines that were previously folded.
 			</description>
 		</method>
+		<method name="unindent_lines">
+			<return type="void">
+			</return>
+			<description>
+				Unindents selected lines, or in the case of no selection the caret line by one.
+			</description>
+		</method>
 		<method name="update_code_completion_options">
 			<return type="void">
 			</return>
@@ -474,6 +502,18 @@
 		<member name="draw_fold_gutter" type="bool" setter="set_draw_fold_gutter" getter="is_drawing_fold_gutter" default="false">
 		</member>
 		<member name="draw_line_numbers" type="bool" setter="set_draw_line_numbers" getter="is_draw_line_numbers_enabled" default="false">
+		</member>
+		<member name="indent_automatic" type="bool" setter="set_auto_indent_enabled" getter="is_auto_indent_enabled" default="false">
+			Sets whether automatic indent are enabled, this will add an extra indent if a prefix or brace is found.
+		</member>
+		<member name="indent_automatic_prefixes" type="String[]" setter="set_auto_indent_prefixes" getter="get_auto_indent_prefixes" default="[&quot;(&quot;, &quot;:&quot;, &quot;[&quot;, &quot;{&quot;]">
+			Prefixes to trigger an automatic indent.
+		</member>
+		<member name="indent_size" type="int" setter="set_indent_size" getter="get_indent_size" default="4">
+			Size of tabs, if [code]indent_use_spaces[/code] is enabled the amount of spaces to use.
+		</member>
+		<member name="indent_use_spaces" type="bool" setter="set_indent_using_spaces" getter="is_indent_using_spaces" default="false">
+			Use spaces instead of tabs for indentation.
 		</member>
 		<member name="layout_direction" type="int" setter="set_layout_direction" getter="get_layout_direction" override="true" enum="Control.LayoutDirection" default="2" />
 		<member name="line_folding" type="bool" setter="set_line_folding_enabled" getter="is_line_folding_enabled" default="true">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -10,11 +10,23 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_backspace" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="add_gutter">
 			<return type="void">
 			</return>
 			<argument index="0" name="at" type="int" default="-1">
 			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="backspace">
+			<return type="void">
+			</return>
 			<description>
 			</description>
 		</method>
@@ -96,6 +108,12 @@
 				Cut's the current selection.
 			</description>
 		</method>
+		<method name="delete_selection">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="deselect">
 			<return type="void">
 			</return>
@@ -108,6 +126,14 @@
 			</return>
 			<description>
 				Gets the caret pixel draw poistion.
+			</description>
+		</method>
+		<method name="get_first_non_whitespace_column" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="get_gutter_count" qualifiers="const">
@@ -136,6 +162,14 @@
 			<return type="int">
 			</return>
 			<argument index="0" name="gutter" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_indent_level" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="line" type="int">
 			</argument>
 			<description>
 			</description>
@@ -274,6 +308,12 @@
 				Returns the selection end line.
 			</description>
 		</method>
+		<method name="get_tab_size" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_visible_line_count" qualifiers="const">
 			<return type="int">
 			</return>
@@ -352,6 +392,16 @@
 			</argument>
 			<description>
 				Triggers a right-click menu action by the specified index. See [enum MenuItems] for a list of available indexes.
+			</description>
+		</method>
+		<method name="merge_gutters">
+			<return type="void">
+			</return>
+			<argument index="0" name="from_line" type="int">
+			</argument>
+			<argument index="1" name="to_line" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="paste">
@@ -607,6 +657,14 @@
 			<argument index="1" name="line" type="int" default="-1">
 			</argument>
 			<argument index="2" name="column" type="int" default="-1">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_tab_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="size" type="int">
 			</argument>
 			<description>
 			</description>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -930,7 +930,7 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_highlight_current_line(EditorSettings::get_singleton()->get("text_editor/highlighting/highlight_current_line"));
 	text_editor->set_indent_using_spaces(EditorSettings::get_singleton()->get("text_editor/indent/type"));
 	text_editor->set_indent_size(EditorSettings::get_singleton()->get("text_editor/indent/size"));
-	text_editor->set_auto_indent(EditorSettings::get_singleton()->get("text_editor/indent/auto_indent"));
+	text_editor->set_auto_indent_enabled(EditorSettings::get_singleton()->get("text_editor/indent/auto_indent"));
 	text_editor->set_draw_tabs(EditorSettings::get_singleton()->get("text_editor/indent/draw_tabs"));
 	text_editor->set_draw_spaces(EditorSettings::get_singleton()->get("text_editor/indent/draw_spaces"));
 	text_editor->set_smooth_scroll_enabled(EditorSettings::get_singleton()->get("text_editor/navigation/smooth_scrolling"));
@@ -1255,7 +1255,7 @@ void CodeTextEditor::_delete_line(int p_line) {
 		text_editor->cursor_set_line(1);
 		text_editor->cursor_set_column(0);
 	}
-	text_editor->backspace_at_cursor();
+	text_editor->backspace();
 	text_editor->unfold_line(p_line);
 	text_editor->cursor_set_line(p_line);
 }
@@ -1809,7 +1809,7 @@ CodeTextEditor::CodeTextEditor() {
 
 	text_editor->set_draw_line_numbers(true);
 	text_editor->set_brace_matching(true);
-	text_editor->set_auto_indent(true);
+	text_editor->set_auto_indent_enabled(true);
 
 	status_bar = memnew(HBoxContainer);
 	add_child(status_bar);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -524,7 +524,7 @@ void ScriptTextEditor::_validate_script() {
 			if (safe_lines.has(i + 1)) {
 				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 				last_is_safe = true;
-			} else if (last_is_safe && (te->is_line_comment(i) || te->get_line(i).strip_edges().is_empty())) {
+			} else if (last_is_safe && (te->is_in_comment(i) != -1 || te->get_line(i).strip_edges().is_empty())) {
 				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 			} else {
 				te->set_line_gutter_item_color(i, line_number_gutter, default_line_number_color);
@@ -1038,7 +1038,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
-			tx->indent_selected_lines_left();
+			tx->unindent_lines();
 		} break;
 		case EDIT_INDENT_RIGHT: {
 			Ref<Script> scr = script;
@@ -1046,7 +1046,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
-			tx->indent_selected_lines_right();
+			tx->indent_lines();
 		} break;
 		case EDIT_DELETE_LINE: {
 			code_editor->delete_lines();

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -323,19 +323,13 @@ void ShaderEditor::_menu_option(int p_option) {
 			if (shader.is_null()) {
 				return;
 			}
-
-			CodeEdit *tx = shader_editor->get_text_editor();
-			tx->indent_selected_lines_left();
-
+			shader_editor->get_text_editor()->unindent_lines();
 		} break;
 		case EDIT_INDENT_RIGHT: {
 			if (shader.is_null()) {
 				return;
 			}
-
-			CodeEdit *tx = shader_editor->get_text_editor();
-			tx->indent_selected_lines_right();
-
+			shader_editor->get_text_editor()->indent_lines();
 		} break;
 		case EDIT_DELETE_LINE: {
 			shader_editor->delete_lines();

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -320,10 +320,10 @@ void TextEditor::_edit_option(int p_op) {
 			code_editor->move_lines_down();
 		} break;
 		case EDIT_INDENT_LEFT: {
-			tx->indent_selected_lines_left();
+			tx->unindent_lines();
 		} break;
 		case EDIT_INDENT_RIGHT: {
-			tx->indent_selected_lines_right();
+			tx->indent_lines();
 		} break;
 		case EDIT_DELETE_LINE: {
 			code_editor->delete_lines();

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -53,6 +53,19 @@ public:
 	};
 
 private:
+	/* Indent management */
+	int indent_size = 4;
+	String indent_text = "\t";
+
+	bool auto_indent = false;
+	Set<char32_t> auto_indent_prefixes;
+
+	bool indent_using_spaces = false;
+	int _calculate_spaces_till_next_left_indent(int p_column) const;
+	int _calculate_spaces_till_next_right_indent(int p_column) const;
+
+	void _new_line(bool p_split_current_line = true, bool p_above = false);
+
 	/* Main Gutter */
 	enum MainGutterType {
 		MAIN_GUTTER_BREAKPOINT = 0x01,
@@ -205,6 +218,27 @@ protected:
 
 public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
+
+	/* Indent management */
+	void set_indent_size(const int p_size);
+	int get_indent_size() const;
+
+	void set_indent_using_spaces(const bool p_use_spaces);
+	bool is_indent_using_spaces() const;
+
+	void set_auto_indent_enabled(bool p_enabled);
+	bool is_auto_indent_enabled() const;
+
+	void set_auto_indent_prefixes(const TypedArray<String> &p_prefixes);
+	TypedArray<String> get_auto_indent_prefixes() const;
+
+	void do_indent();
+	void do_unindent();
+
+	void indent_lines();
+	void unindent_lines();
+
+	virtual void backspace() override;
 
 	/* Main Gutter */
 	void set_draw_breakpoints_gutter(bool p_draw);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -112,11 +112,12 @@ private:
 
 		int width = -1;
 
-		int indent_size = 4;
+		int tab_size = 4;
 		int gutter_count = 0;
 
 	public:
-		void set_indent_size(int p_indent_size);
+		void set_tab_size(int p_tab_size);
+		int get_tab_size() const;
 		void set_font(const Ref<Font> &p_font);
 		void set_font_size(int p_font_size);
 		void set_font_features(const Dictionary &p_features);
@@ -259,9 +260,6 @@ private:
 
 	int max_chars = 0;
 	bool readonly = true; // Initialise to opposite first, so we get past the early-out in set_readonly.
-	bool indent_using_spaces = false;
-	int indent_size = 4;
-	String space_indent = "    ";
 
 	Timer *caret_blink_timer;
 	bool caret_blink_enabled = false;
@@ -296,7 +294,6 @@ private:
 	bool scroll_past_end_of_file_enabled = false;
 	bool brace_matching_enabled = false;
 	bool highlight_current_line = false;
-	bool auto_indent = false;
 
 	String cut_copy_line;
 	bool insert_mode = false;
@@ -420,14 +417,9 @@ private:
 
 	void _clear();
 
-	int _calculate_spaces_till_next_left_indent(int column);
-	int _calculate_spaces_till_next_right_indent(int column);
-
 	// Methods used in shortcuts
 	void _swap_current_input_direction();
 	void _new_line(bool p_split_current = true, bool p_above = false);
-	void _indent_right();
-	void _indent_left();
 	void _move_cursor_left(bool p_select, bool p_move_by_word = false);
 	void _move_cursor_right(bool p_select, bool p_move_by_word = false);
 	void _move_cursor_up(bool p_select);
@@ -436,9 +428,8 @@ private:
 	void _move_cursor_to_line_end(bool p_select);
 	void _move_cursor_page_up(bool p_select);
 	void _move_cursor_page_down(bool p_select);
-	void _backspace(bool p_word = false, bool p_all_to_left = false);
+	void _do_backspace(bool p_word = false, bool p_all_to_left = false);
 	void _delete(bool p_word = false, bool p_all_to_right = false);
-	void _delete_selection();
 	void _move_cursor_document_start(bool p_select);
 	void _move_cursor_document_end(bool p_select);
 	void _handle_unicode_character(uint32_t unicode, bool p_had_selection);
@@ -521,6 +512,8 @@ public:
 
 	void set_gutter_overwritable(int p_gutter, bool p_overwritable);
 	bool is_gutter_overwritable(int p_gutter) const;
+
+	void merge_gutters(int p_from_line, int p_to_line);
 
 	void set_gutter_custom_draw(int p_gutter, Object *p_object, const StringName &p_callback);
 
@@ -635,12 +628,9 @@ public:
 	bool has_ime_text() const;
 	void set_line(int line, String new_text);
 	int get_row_height() const;
-	void backspace_at_cursor();
 
-	void indent_selected_lines_left();
-	void indent_selected_lines_right();
 	int get_indent_level(int p_line) const;
-	bool is_line_comment(int p_line) const;
+	int get_first_non_whitespace_column(int p_line) const;
 
 	inline void set_scroll_pass_end_of_file(bool p_enabled) {
 		scroll_past_end_of_file_enabled = p_enabled;
@@ -653,7 +643,6 @@ public:
 		brace_matching_enabled = p_enabled;
 		update();
 	}
-	void set_auto_indent(bool p_auto_indent);
 
 	void center_viewport_to_cursor();
 
@@ -699,6 +688,9 @@ public:
 
 	void clear();
 
+	void delete_selection();
+
+	virtual void backspace();
 	void cut();
 	void copy();
 	void paste();
@@ -730,10 +722,8 @@ public:
 	void redo();
 	void clear_undo_history();
 
-	void set_indent_using_spaces(const bool p_use_spaces);
-	bool is_indent_using_spaces() const;
-	void set_indent_size(const int p_size);
-	int get_indent_size();
+	void set_tab_size(const int p_size);
+	int get_tab_size() const;
 	void set_draw_tabs(bool p_draw);
 	bool is_drawing_tabs() const;
 	void set_draw_spaces(bool p_draw);


### PR DESCRIPTION
Continuation of #31739

Builds on top of #49238

---

The main aim of this PR is abstracting out indentation into CodeEdit. It's now entirely exposed to the API. 

As part of the refactor `backspace_at_cursor` has become `backspace`. It has been exposed and made overridable. This will be the way forward for other such actions like cut, copy and paste.

Indent size in `TextEdit` is now called tab size as it no longer relates to spaces.

A couple extra utility methods have also be made pubic for use.

Will start to move more functionality in, such as indent type conversion that currently sits within `code_editor` when the `TextEdit ` split is complete.

