### PR TITLE
Remove GridMap's "Lock View" option and a related method.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7245,10 +7245,6 @@ void Node3DEditorPlugin::set_state(const Dictionary &p_state) {
 	spatial_editor->set_state(p_state);
 }
 
-void Node3DEditor::snap_cursor_to_plane(const Plane &p_plane) {
-	//cursor.pos=p_plane.project(cursor.pos);
-}
-
 Vector3 Node3DEditor::snap_point(Vector3 p_target, Vector3 p_start) const {
 	if (is_snap_enabled()) {
 		p_target.x = Math::snap_scalar(0.0, get_translate_snap(), p_target.x);
@@ -7289,14 +7285,6 @@ float Node3DEditor::get_scale_snap() const {
 	}
 
 	return snap_value;
-}
-
-void Node3DEditorPlugin::_bind_methods() {
-	ClassDB::bind_method("snap_cursor_to_plane", &Node3DEditorPlugin::snap_cursor_to_plane);
-}
-
-void Node3DEditorPlugin::snap_cursor_to_plane(const Plane &p_plane) {
-	spatial_editor->snap_cursor_to_plane(p_plane);
 }
 
 struct _GizmoPluginPriorityComparator {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -817,7 +817,6 @@ protected:
 
 public:
 	static Node3DEditor *get_singleton() { return singleton; }
-	void snap_cursor_to_plane(const Plane &p_plane);
 
 	Vector3 snap_point(Vector3 p_target, Vector3 p_start = Vector3(0, 0, 0)) const;
 
@@ -890,12 +889,7 @@ class Node3DEditorPlugin : public EditorPlugin {
 	Node3DEditor *spatial_editor;
 	EditorNode *editor;
 
-protected:
-	static void _bind_methods();
-
 public:
-	void snap_cursor_to_plane(const Plane &p_plane);
-
 	Node3DEditor *get_spatial_editor() { return spatial_editor; }
 	virtual String get_name() const override { return "3D"; }
 	bool has_main_screen() const override { return true; }

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -62,12 +62,6 @@ void GridMapEditor::_menu_option(int p_option) {
 			floor->set_value(floor->get_value() + 1);
 		} break;
 
-		case MENU_OPTION_LOCK_VIEW: {
-			int index = options->get_popup()->get_item_index(MENU_OPTION_LOCK_VIEW);
-			lock_view = !options->get_popup()->is_item_checked(index);
-
-			options->get_popup()->set_item_checked(index, lock_view);
-		} break;
 		case MENU_OPTION_CLIP_DISABLED:
 		case MENU_OPTION_CLIP_ABOVE:
 		case MENU_OPTION_CLIP_BELOW: {
@@ -1080,20 +1074,6 @@ void GridMapEditor::_notification(int p_what) {
 			if (cgmt.operator->() != last_mesh_library) {
 				update_palette();
 			}
-
-			if (lock_view) {
-				EditorNode *editor = Object::cast_to<EditorNode>(get_tree()->get_root()->get_child(0));
-
-				Plane p;
-				p.normal[edit_axis] = 1.0;
-				p.d = edit_floor[edit_axis] * node->get_cell_size()[edit_axis];
-				p = node->get_transform().xform(p); // plane to snap
-
-				Node3DEditorPlugin *sep = Object::cast_to<Node3DEditorPlugin>(editor->get_editor_plugin_screen());
-				if (sep) {
-					sep->snap_cursor_to_plane(p);
-				}
-			}
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -1187,8 +1167,6 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	spatial_editor_hb->hide();
 
 	options->set_text(TTR("Grid Map"));
-	options->get_popup()->add_check_item(TTR("Snap View"), MENU_OPTION_LOCK_VIEW);
-	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Previous Floor"), MENU_OPTION_PREV_LEVEL, KEY_Q);
 	options->get_popup()->add_item(TTR("Next Floor"), MENU_OPTION_NEXT_LEVEL, KEY_E);
 	options->get_popup()->add_separator();

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -94,7 +94,6 @@ class GridMapEditor : public VBoxContainer {
 	MeshLibrary *last_mesh_library;
 	ClipMode clip_mode = CLIP_DISABLED;
 
-	bool lock_view = false;
 	Transform3D grid_xform;
 	Transform3D edit_grid_xform;
 	Vector3::Axis edit_axis;


### PR DESCRIPTION
While translating the engine I usually test what I'm translating to make sure I'm writing the right thing, but this one checkbox did aboslutely nothing. So I found out that it never worked, and as such I figured out it would make more sense to remove it, since it has been designed for (AFAICT) a single viewport editor.

If I missed anything, let me know.
