### PR TITLE
[3.x] Fix external resource cache regression

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -422,6 +422,7 @@ Error ResourceInteractiveLoaderText::poll() {
 		}
 
 		ExtResource er;
+		er.cache = res;
 		er.path = path;
 		er.type = type;
 		ext_resources[index] = er;

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -48,6 +48,7 @@ class ResourceInteractiveLoaderText : public ResourceInteractiveLoader {
 	VariantParser::StreamFile stream;
 
 	struct ExtResource {
+		RES cache;
 		String path;
 		String type;
 	};


### PR DESCRIPTION
Fixes #49663 (regression from #49625).

#49625 changed the way cache is handled for sub-resources by partially backporting #45903, but removing `resource_cache` (used in common for sub-resources and external resources) without making the proper changes for external resources prevented the latter to be cached.

This PR integrates extra changes from #45903 that allow external resources to be cached again.