### PR TITLE
Add extents get/set override to BoxShape3D and RectangleShape2D for compatibility

### DIFF
--- a/scene/resources/box_shape_3d.cpp
+++ b/scene/resources/box_shape_3d.cpp
@@ -56,6 +56,26 @@ void BoxShape3D::_update_shape() {
 	Shape3D::_update_shape();
 }
 
+#ifndef DISABLE_DEPRECATED
+bool BoxShape3D::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "extents") { // Compatibility with Godot 3.x.
+		// Convert to `size`, twice as big.
+		set_size((Vector3)p_value * 2);
+		return true;
+	}
+	return false;
+}
+
+bool BoxShape3D::_get(const StringName &p_name, Variant &r_property) const {
+	if (p_name == "extents") { // Compatibility with Godot 3.x.
+		// Convert to `extents`, half as big.
+		r_property = size / 2;
+		return true;
+	}
+	return false;
+}
+#endif // DISABLE_DEPRECATED
+
 void BoxShape3D::set_size(const Vector3 &p_size) {
 	size = p_size;
 	_update_shape();

--- a/scene/resources/box_shape_3d.h
+++ b/scene/resources/box_shape_3d.h
@@ -39,6 +39,10 @@ class BoxShape3D : public Shape3D {
 
 protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_property) const;
+#endif // DISABLE_DEPRECATED
 
 	virtual void _update_shape() override;
 

--- a/scene/resources/rectangle_shape_2d.cpp
+++ b/scene/resources/rectangle_shape_2d.cpp
@@ -37,6 +37,26 @@ void RectangleShape2D::_update_shape() {
 	emit_changed();
 }
 
+#ifndef DISABLE_DEPRECATED
+bool RectangleShape2D::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "extents") { // Compatibility with Godot 3.x.
+		// Convert to `size`, twice as big.
+		set_size((Vector2)p_value * 2);
+		return true;
+	}
+	return false;
+}
+
+bool RectangleShape2D::_get(const StringName &p_name, Variant &r_property) const {
+	if (p_name == "extents") { // Compatibility with Godot 3.x.
+		// Convert to `extents`, half as big.
+		r_property = size / 2;
+		return true;
+	}
+	return false;
+}
+#endif // DISABLE_DEPRECATED
+
 void RectangleShape2D::set_size(const Vector2 &p_size) {
 	size = p_size;
 	_update_shape();

--- a/scene/resources/rectangle_shape_2d.h
+++ b/scene/resources/rectangle_shape_2d.h
@@ -41,6 +41,10 @@ class RectangleShape2D : public Shape2D {
 
 protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_property) const;
+#endif // DISABLE_DEPRECATED
 
 public:
 	void set_size(const Vector2 &p_size);


### PR DESCRIPTION
PR #44183 replaced `extents` with `size`. However, when upgrading 3.x projects, this change is one of the biggest compatibility breakages. Across the demos there are many hundreds of BoxShape3Ds and RectangleShape2Ds which all have `extents`.

This PR re-adds `extents` as a deprecated wrapper for `size`. With this PR Godot can read the `extents` property from scenes, and then it's written back as `size` the next time it's saved. Users can also use the `extents` property from script, but it shows deprecated warnings.