### PR TITLE
Use 32bit instead of 64bit 3D render buffer on mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -151,6 +151,8 @@ protected:
 		}
 	};
 
+	virtual RD::DataFormat _render_buffers_get_color_format() override;
+
 	RID _setup_render_pass_uniform_set(RenderListType p_render_list, const RenderDataRD *p_render_data, RID p_radiance_texture, bool p_use_directional_shadow_atlas = false, int p_index = 0);
 	virtual void _render_scene(RenderDataRD *p_render_data, const Color &p_default_bg_color) override;
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -654,7 +654,7 @@ bool RendererSceneRenderRD::reflection_probe_instance_begin_render(RID p_instanc
 			//reflection atlas was unused, create:
 			RD::TextureFormat tf;
 			tf.array_layers = 6 * atlas->count;
-			tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+			tf.format = _render_buffers_get_color_format();
 			tf.texture_type = RD::TEXTURE_TYPE_CUBE_ARRAY;
 			tf.mipmaps = mipmaps;
 			tf.width = atlas->size;
@@ -2118,6 +2118,10 @@ float RendererSceneRenderRD::render_buffers_get_volumetric_fog_detail_spread(RID
 	return rb->volumetric_fog->spread;
 }
 
+RD::DataFormat RendererSceneRenderRD::_render_buffers_get_color_format() {
+	return RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+}
+
 void RendererSceneRenderRD::render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RenderingServer::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding, uint32_t p_view_count) {
 	ERR_FAIL_COND_MSG(p_view_count == 0, "Must have atleast 1 view");
 
@@ -2144,7 +2148,7 @@ void RendererSceneRenderRD::render_buffers_configure(RID p_render_buffers, RID p
 		if (rb->view_count > 1) {
 			tf.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
 		}
-		tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+		tf.format = _render_buffers_get_color_format();
 		tf.width = rb->width;
 		tf.height = rb->height;
 		tf.array_layers = rb->view_count; // create a layer for every view

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -1129,6 +1129,7 @@ public:
 
 	/* render buffers */
 
+	virtual RD::DataFormat _render_buffers_get_color_format();
 	virtual RID render_buffers_create() override;
 	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding, uint32_t p_view_count) override;
 	virtual void gi_set_use_half_resolution(bool p_enable) override;


### PR DESCRIPTION
One of the suggestions made by ARM is to render into a 32bit buffer instead of a 64bit buffer when running on a mobile GPU using a 10/11 bpp for the color channels. This halves memory usage and on MALI GPUs allows for hardware compression when data is read from/written to the tiles being rendered. 

The missing bit at this point in time is that we lose the ability to support viewports with transparent background when rendering 3D. The suggestion here is to add an additional 8bit RT and write alpha into that. We may do that in a separate PR.