### PR TITLE
UWP: Keep upstream names for capabilities preset settings to avoid mismatch

### DIFF
--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1049,19 +1049,19 @@ public:
 		// Capabilities
 		const char **basic = uwp_capabilities;
 		while (*basic) {
-			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/" + String(*basic).camelcase_to_underscore(false)), false));
+			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/" + String(*basic)), false));
 			basic++;
 		}
 
 		const char **uap = uwp_uap_capabilities;
 		while (*uap) {
-			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/" + String(*uap).camelcase_to_underscore(false)), false));
+			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/" + String(*uap)), false));
 			uap++;
 		}
 
 		const char **device = uwp_device_capabilities;
 		while (*device) {
-			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/" + String(*device).camelcase_to_underscore(false)), false));
+			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "capabilities/" + String(*device)), false));
 			device++;
 		}
 	}


### PR DESCRIPTION
The previous code used `camelcase_to_underscore` to prettify the names for
display in the export preset, but it leads to inconsistencies if we don't make
sure to do the reverse operation when writing to the `AppxManifest.xml`.

It's simpler to keep the same names as in the manifest, which is also what
users will see referenced in MS documentation.

Fixes #47900.
Supersedes #47902.

---

Also, this doesn't seem to impact what gets shown to users in the Export Preset configuration dialog, where the property editor does apply `capitalize` anyway:

![Screenshot_20210617_130850](https://user-images.githubusercontent.com/4701338/122385483-2a1f2080-cf6d-11eb-99d3-9a592d3d1848.png)