### PR TITLE
Consider a thread done if current_work is null

### DIFF
--- a/core/templates/thread_work_pool.h
+++ b/core/templates/thread_work_pool.h
@@ -105,7 +105,7 @@ public:
 	}
 
 	bool is_done_dispatching() const {
-		ERR_FAIL_COND_V(current_work == nullptr, false);
+		ERR_FAIL_COND_V(current_work == nullptr, true);
 		return index.load(std::memory_order_acquire) >= current_work->max_elements;
 	}
 


### PR DESCRIPTION
Fixes #48257
Addresses one of the causes of #49324

I forgot to make a PR for this fix, so here it is finally. I was hoping someone with more knowledge of the threaded importer would make a comment, but it seems to work well for me so far.

Read #48257 for more detail