### PR TITLE
Remove thread-unsafe and unused late_added_files.

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1475,8 +1475,6 @@ void EditorFileSystem::update_file(const String &p_file) {
 
 	if (cpos == -1) {
 		// The file did not exist, it was added.
-
-		late_added_files.insert(p_file); // Remember that it was added. This mean it will be scanned and imported on editor restart.
 		int idx = 0;
 		String file_name = p_file.get_file();
 
@@ -1723,9 +1721,6 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 				}
 			}
 		}
-
-	} else {
-		late_added_files.insert(p_file); //imported files do not call update_file(), but just in case..
 	}
 
 	if (importer_name == "keep") {

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -148,7 +148,6 @@ class EditorFileSystem : public Node {
 
 	void _scan_filesystem();
 
-	Set<String> late_added_files; //keep track of files that were added, these will be re-scanned
 	Set<String> late_update_files;
 
 	void _save_late_updated_files();


### PR DESCRIPTION
_reimport_file is called from multiple threads as part of the threaded importer.
Inserting to this set from a thread could hit a race condition leading to memory corruption or hangs.
It seems to be unused, intentionally or unintentionally

Addresses one of the causes of https://github.com/godotengine/godot/issues/49324#issuecomment-854994094

See also here: https://github.com/godotengine/godot/pull/47343#issuecomment-863062947

The unused set that caused the crash was added in bd282ff43f23fe845f29a3e25c8efc01bd65ffb0
CC @reduz 