### PR TITLE
Implement animation slice drawing in CanvasItem

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -24,6 +24,21 @@
 				Overridable function called by the engine (if defined) to draw the canvas item.
 			</description>
 		</method>
+		<method name="draw_animation_slice">
+			<return type="void">
+			</return>
+			<argument index="0" name="animation_length" type="float">
+			</argument>
+			<argument index="1" name="slice_begin" type="float">
+			</argument>
+			<argument index="2" name="slice_end" type="float">
+			</argument>
+			<argument index="3" name="offset" type="float" default="0.0">
+			</argument>
+			<description>
+				Subsequent drawing commands will be ignored unless they fall within the specified animation slice. This is a faster way to implement animations that loop on background rather than redrawing constantly.
+			</description>
+		</method>
 		<method name="draw_arc">
 			<return type="void">
 			</return>
@@ -96,6 +111,13 @@
 			</argument>
 			<description>
 				Draws a colored polygon of any amount of points, convex or concave.
+			</description>
+		</method>
+		<method name="draw_end_animation">
+			<return type="void">
+			</return>
+			<description>
+				After submitting all animations slices via [method draw_animation_slice], this function can be used to revert drawing to its default state (all subsequent drawing commands will be visible). If you don't care about this particular use case, usage of this function after submitting the slices is not required.
 			</description>
 		</method>
 		<method name="draw_line">

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -876,6 +876,17 @@ void CanvasItem::draw_set_transform_matrix(const Transform2D &p_matrix) {
 
 	RenderingServer::get_singleton()->canvas_item_add_set_transform(canvas_item, p_matrix);
 }
+void CanvasItem::draw_animation_slice(double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset) {
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
+
+	RenderingServer::get_singleton()->canvas_item_add_animation_slice(canvas_item, p_animation_length, p_slice_begin, p_slice_end, p_offset);
+}
+
+void CanvasItem::draw_end_animation() {
+	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
+
+	RenderingServer::get_singleton()->canvas_item_add_animation_slice(canvas_item, 1, 0, 2, 0);
+}
 
 void CanvasItem::draw_polygon(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture2D> p_texture) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
@@ -1159,6 +1170,8 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_multimesh", "multimesh", "texture"), &CanvasItem::draw_multimesh);
 	ClassDB::bind_method(D_METHOD("draw_set_transform", "position", "rotation", "scale"), &CanvasItem::draw_set_transform, DEFVAL(0.0), DEFVAL(Size2(1.0, 1.0)));
 	ClassDB::bind_method(D_METHOD("draw_set_transform_matrix", "xform"), &CanvasItem::draw_set_transform_matrix);
+	ClassDB::bind_method(D_METHOD("draw_animation_slice", "animation_length", "slice_begin", "slice_end", "offset"), &CanvasItem::draw_animation_slice, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("draw_end_animation"), &CanvasItem::draw_end_animation);
 	ClassDB::bind_method(D_METHOD("get_transform"), &CanvasItem::get_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &CanvasItem::get_global_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform_with_canvas"), &CanvasItem::get_global_transform_with_canvas);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -356,6 +356,8 @@ public:
 
 	void draw_set_transform(const Point2 &p_offset, real_t p_rot = 0.0, const Size2 &p_scale = Size2(1.0, 1.0));
 	void draw_set_transform_matrix(const Transform2D &p_matrix);
+	void draw_animation_slice(double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset = 0);
+	void draw_end_animation();
 
 	static CanvasItem *get_current_item_drawn();
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1003,6 +1003,18 @@ void RendererCanvasCull::canvas_item_add_clip_ignore(RID p_item, bool p_ignore) 
 	ci->ignore = p_ignore;
 }
 
+void RendererCanvasCull::canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset) {
+	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	ERR_FAIL_COND(!canvas_item);
+
+	Item::CommandAnimationSlice *as = canvas_item->alloc_command<Item::CommandAnimationSlice>();
+	ERR_FAIL_COND(!as);
+	as->animation_length = p_animation_length;
+	as->slice_begin = p_slice_begin;
+	as->slice_end = p_slice_end;
+	as->offset = p_offset;
+}
+
 void RendererCanvasCull::canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -231,6 +231,8 @@ public:
 	void canvas_item_add_particles(RID p_item, RID p_particles, RID p_texture);
 	void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_add_clip_ignore(RID p_item, bool p_ignore);
+	void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset);
+
 	void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable);
 	void canvas_item_set_z_index(RID p_item, int p_z);
 	void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable);

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -180,6 +180,7 @@ public:
 				TYPE_PARTICLES,
 				TYPE_TRANSFORM,
 				TYPE_CLIP_IGNORE,
+				TYPE_ANIMATION_SLICE,
 			};
 
 			Command *next;
@@ -283,6 +284,17 @@ public:
 			CommandClipIgnore() {
 				type = TYPE_CLIP_IGNORE;
 				ignore = false;
+			}
+		};
+
+		struct CommandAnimationSlice : public Command {
+			double animation_length = 0;
+			double slice_begin = 0;
+			double slice_end = 0;
+			double offset = 0;
+
+			CommandAnimationSlice() {
+				type = TYPE_ANIMATION_SLICE;
 			}
 		};
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -813,6 +813,8 @@ public:
 	FUNC3(canvas_item_add_particles, RID, RID, RID)
 	FUNC2(canvas_item_add_set_transform, RID, const Transform2D &)
 	FUNC2(canvas_item_add_clip_ignore, RID, bool)
+	FUNC5(canvas_item_add_animation_slice, RID, double, double, double, double)
+
 	FUNC2(canvas_item_set_sort_children_by_y, RID, bool)
 	FUNC2(canvas_item_set_z_index, RID, int)
 	FUNC2(canvas_item_set_z_as_relative_to_parent, RID, bool)

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1294,6 +1294,7 @@ public:
 	virtual void canvas_item_add_particles(RID p_item, RID p_particles, RID p_texture) = 0;
 	virtual void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform) = 0;
 	virtual void canvas_item_add_clip_ignore(RID p_item, bool p_ignore) = 0;
+	virtual void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset) = 0;
 	virtual void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_z_index(RID p_item, int p_z) = 0;
 	virtual void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable) = 0;


### PR DESCRIPTION
* Added a function to ignore subsequent commands if they don't fall within a time slice.
* It works for any kind of rendering command, so you can loop-animate anything you want, any way you want.
* This will be used by the new TileMap to properly provide animated tiles.

Usage:

```GDScript

func _draw():
   draw_animation_slice( 2.0, 0.0 ,1.0 ) # anim length 2 secs, from 0 to 1
   draw_texture( frame1_tex, Vector2() )
   draw_animation_slice( 2.0, 1.0 ,2.0 ) # anim length 2 secs, from 1 to 2
   draw_texture( frame2_tex, Vector2() )
   # optional if you want subsequent draw calls to be always visible again:
   draw_end_animation()
```
