### PR TITLE
Translate file path to URI on LSP symbol requests

### DIFF
--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -188,7 +188,9 @@ Array GDScriptWorkspace::symbol(const Dictionary &p_params) {
 			E->get()->get_symbols().symbol_tree_as_list(E->key(), script_symbols);
 			for (int i = 0; i < script_symbols.size(); ++i) {
 				if (query.is_subsequence_ofi(script_symbols[i].name)) {
-					arr.push_back(script_symbols[i].to_json());
+					lsp::DocumentedSymbolInformation symbol = script_symbols[i];
+					symbol.location.uri = get_file_uri(symbol.location.uri);
+					arr.push_back(symbol.to_json());
 				}
 			}
 		}


### PR DESCRIPTION
When an external client sends a symbols request, the LSP currently responds with a filepath that starts `res://`, which external editors have no idea how to handle. This PR fixes this issue by translating the filepath into a URI.

Fixes #49686 . Cherry-pickable for 3.x.