### PR TITLE
AnimationMultiTrackKeyEdit Allow editing easing if it's possible for all edited tracks

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1168,31 +1168,29 @@ public:
 					p_list->push_back(PropertyInfo(Variant::VECTOR3, "scale"));
 				} break;
 				case Animation::TYPE_VALUE: {
-					if (!same_key_type) {
-						break;
-					}
+					if (same_key_type) {
+						Variant v = animation->track_get_key_value(first_track, first_key);
 
-					Variant v = animation->track_get_key_value(first_track, first_key);
+						if (hint.type != Variant::NIL) {
+							PropertyInfo pi = hint;
+							pi.name = "value";
+							p_list->push_back(pi);
+						} else {
+							PropertyHint hint = PROPERTY_HINT_NONE;
+							String hint_string;
 
-					if (hint.type != Variant::NIL) {
-						PropertyInfo pi = hint;
-						pi.name = "value";
-						p_list->push_back(pi);
-					} else {
-						PropertyHint hint = PROPERTY_HINT_NONE;
-						String hint_string;
-
-						if (v.get_type() == Variant::OBJECT) {
-							//could actually check the object property if exists..? yes i will!
-							Ref<Resource> res = v;
-							if (res.is_valid()) {
-								hint = PROPERTY_HINT_RESOURCE_TYPE;
-								hint_string = res->get_class();
+							if (v.get_type() == Variant::OBJECT) {
+								//could actually check the object property if exists..? yes i will!
+								Ref<Resource> res = v;
+								if (res.is_valid()) {
+									hint = PROPERTY_HINT_RESOURCE_TYPE;
+									hint_string = res->get_class();
+								}
 							}
-						}
 
-						if (v.get_type() != Variant::NIL) {
-							p_list->push_back(PropertyInfo(v.get_type(), "value", hint, hint_string));
+							if (v.get_type() != Variant::NIL) {
+								p_list->push_back(PropertyInfo(v.get_type(), "value", hint, hint_string));
+							}
 						}
 					}
 


### PR DESCRIPTION
This PR allows editing `easing` in the inspector if every edited track's type is `Animation::TYPE_VALUE`, whether track key values are of the same type or not.

Fixes #49689.
Cherry-pickable `3.x`, `3.3`.

---

Implementation-wise it's simply changing:
```
if (!same_key_type) {
	break;
}
many_lines_of_code();
p_list->push_back(PropertyInfo(Variant::FLOAT, "easing", PROPERTY_HINT_EXP_EASING));
```
to:
```
if (same_key_type) {
	many_lines_of_code();
}
p_list->push_back(PropertyInfo(Variant::FLOAT, "easing", PROPERTY_HINT_EXP_EASING));
```
so the most changes are indentation-only.