### PR TITLE
[3.x] Ignore disabled shapes for mass property calculations

### DIFF
--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -59,6 +59,10 @@ void BodySW::update_inertias() {
 			real_t total_area = 0;
 
 			for (int i = 0; i < get_shape_count(); i++) {
+				if (is_shape_disabled(i)) {
+					continue;
+				}
+
 				total_area += get_shape_area(i);
 			}
 
@@ -67,6 +71,10 @@ void BodySW::update_inertias() {
 
 			if (total_area != 0.0) {
 				for (int i = 0; i < get_shape_count(); i++) {
+					if (is_shape_disabled(i)) {
+						continue;
+					}
+
 					real_t area = get_shape_area(i);
 
 					real_t mass = area * this->mass / total_area;

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -52,6 +52,10 @@ void Body2DSW::update_inertias() {
 			real_t total_area = 0;
 
 			for (int i = 0; i < get_shape_count(); i++) {
+				if (is_shape_disabled(i)) {
+					continue;
+				}
+
 				total_area += get_shape_aabb(i).get_area();
 			}
 


### PR DESCRIPTION
Addresses issue from https://github.com/godotengine/godot/pull/49185#pullrequestreview-671757775 on the 3.x branch.
Already part of #49610 on master.