### PR TITLE
Update editor description property flag

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -228,11 +228,6 @@
 				If [code]include_internal[/code] is [code]false[/code], the returned array won't include internal children (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>
-		<method name="get_editor_description" qualifiers="const">
-			<return type="String" />
-			<description>
-			</description>
-		</method>
 		<method name="get_groups" qualifiers="const">
 			<return type="Array" />
 			<description>
@@ -618,12 +613,6 @@
 				Sets the editable children state of [code]node[/code] relative to this node. This method is only intended for use with editor tooling.
 			</description>
 		</method>
-		<method name="set_editor_description">
-			<return type="void" />
-			<argument index="0" name="editor_description" type="String" />
-			<description>
-			</description>
-		</method>
 		<method name="set_multiplayer_authority">
 			<return type="void" />
 			<argument index="0" name="id" type="int" />
@@ -701,6 +690,9 @@
 	<members>
 		<member name="custom_multiplayer" type="MultiplayerAPI" setter="set_custom_multiplayer" getter="get_custom_multiplayer">
 			The override to the default [MultiplayerAPI]. Set to [code]null[/code] to use the default [SceneTree] one.
+		</member>
+		<member name="editor_description" type="String" setter="set_editor_description" getter="get_editor_description" default="&quot;&quot;">
+			Add a custom description to a node.
 		</member>
 		<member name="multiplayer" type="MultiplayerAPI" setter="" getter="get_multiplayer">
 			The [MultiplayerAPI] instance associated with this node. Either the [member custom_multiplayer], or the default SceneTree one (if inside tree).

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2889,7 +2889,7 @@ void Node::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_priority"), "set_process_priority", "get_process_priority");
 
 	ADD_GROUP("Editor Description", "editor_");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_INTERNAL), "set_editor_description", "get_editor_description");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT), "set_editor_description", "get_editor_description");
 
 	GDVIRTUAL_BIND(_process, "delta");
 	GDVIRTUAL_BIND(_physics_process, "delta");


### PR DESCRIPTION
Fixes #49648

I updated the property flag for `editor_description` to be the same as `text` from `Label`. It fixed the problem, but maybe it's not a valid flag to use? 



<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
