### PR TITLE
Fix export var override in PackedScene at runtime

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -471,7 +471,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 	StringName type = p_node->get_class();
 
 	Ref<Script> script = p_node->get_script();
-	if (script.is_valid()) {
+	if (Engine::get_singleton()->is_editor_hint() && script.is_valid()) {
+		// Should be called in the editor only and not at runtime,
+		// otherwise it can cause problems because of missing instance state support.
 		script->update_exports();
 	}
 


### PR DESCRIPTION
Fixes #49712 (regression from #38565).

`update_exports()` code is tool only and should be used only in the editor, otherwise it can cause export variable overrides from instances to be discarded in favor of the parent's value.

The original issue can't be reproduced on master, but in any case it makes more sense to prevent `update_exports()` to be used for packed scenes at runtime since it's meant to be editor-only and could cause other issues, as well as discrepancies between tool-runtime and export-runtime.
