### PR TITLE
[3.x] Use SpinLock instead of Mutex for X11 events thread safety

### DIFF
--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -34,6 +34,7 @@
 #include "context_gl_x11.h"
 #include "core/local_vector.h"
 #include "core/os/input.h"
+#include "core/os/spin_lock.h"
 #include "crash_handler_x11.h"
 #include "drivers/alsa/audio_driver_alsa.h"
 #include "drivers/alsamidi/midi_driver_alsamidi.h"
@@ -164,7 +165,7 @@ class OS_X11 : public OS_Unix {
 	String _get_clipboard(Atom p_source, Window x11_window) const;
 	void _clipboard_transfer_ownership(Atom p_source, Window x11_window) const;
 
-	mutable Mutex events_mutex;
+	mutable SpinLock events_lock;
 	Thread events_thread;
 	bool events_thread_done = false;
 	LocalVector<XEvent> polled_events;


### PR DESCRIPTION
Draft PR to test a potential fix for #48369.

Uses `SpinLock` instead of `Mutex` to lock events processing, to see if that could prevent long stalls to happen. I haven't reproduced the issue so far so I'm not sure if that's the actual cause.

If it helps, a separate PR will be needed to do the same change on master.