### PR TITLE
Automatic `GraphEdit` node connection hot zone height 2

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -351,6 +351,9 @@
 		</theme_item>
 		<theme_item name="layout" data_type="icon" type="Texture2D">
 		</theme_item>
+		<theme_item name="reset" type="Texture2D">
+			The icon for the zoom reset button.
+		</theme_item>
 		<theme_item name="minimap" data_type="icon" type="Texture2D">
 		</theme_item>
 		<theme_item name="minus" data_type="icon" type="Texture2D">

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -120,7 +120,6 @@ private:
 	VScrollBar *v_scroll;
 
 	float port_grab_distance_horizontal = 0.0;
-	float port_grab_distance_vertical;
 
 	bool connecting = false;
 	String connecting_from;
@@ -183,9 +182,7 @@ private:
 	GraphEditMinimap *minimap;
 	void _top_layer_input(const Ref<InputEvent> &p_ev);
 
-	bool is_in_input_hotzone(GraphNode *p_graph_node, int p_slot_index, const Vector2 &p_mouse_pos, const Vector2i &p_port_size);
-	bool is_in_output_hotzone(GraphNode *p_graph_node, int p_slot_index, const Vector2 &p_mouse_pos, const Vector2i &p_port_size);
-	bool is_in_port_hotzone(const Vector2 &pos, const Vector2 &p_mouse_pos, const Vector2i &p_port_size, bool p_left);
+	bool is_in_hot_zone(const Vector2 &pos, int hot_zone_height, const Vector2 &p_mouse_pos);
 
 	void _top_layer_draw();
 	void _connections_layer_draw();

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -790,6 +790,7 @@ void GraphNode::_connpos_update() {
 			if (slot_info[idx].enable_left) {
 				ConnCache cc;
 				cc.pos = Point2i(edgeofs, y + h / 2);
+				cc.height = h;
 				cc.type = slot_info[idx].type_left;
 				cc.color = slot_info[idx].color_left;
 				conn_input_cache.push_back(cc);
@@ -797,6 +798,7 @@ void GraphNode::_connpos_update() {
 			if (slot_info[idx].enable_right) {
 				ConnCache cc;
 				cc.pos = Point2i(get_size().width - edgeofs, y + h / 2);
+				cc.height = h;
 				cc.type = slot_info[idx].type_right;
 				cc.color = slot_info[idx].color_right;
 				conn_output_cache.push_back(cc);
@@ -839,6 +841,15 @@ Vector2 GraphNode::get_connection_input_position(int p_idx) {
 	return pos;
 }
 
+int GraphNode::get_connection_input_height(int p_idx) {
+	if (connpos_dirty) {
+		_connpos_update();
+	}
+
+	ERR_FAIL_INDEX_V(p_idx, conn_input_cache.size(), 0);
+	return conn_input_cache[p_idx].height;
+}
+
 int GraphNode::get_connection_input_type(int p_idx) {
 	if (connpos_dirty) {
 		_connpos_update();
@@ -867,6 +878,15 @@ Vector2 GraphNode::get_connection_output_position(int p_idx) {
 	pos.x *= get_scale().x;
 	pos.y *= get_scale().y;
 	return pos;
+}
+
+int GraphNode::get_connection_output_height(int p_idx) {
+	if (connpos_dirty) {
+		_connpos_update();
+	}
+
+	ERR_FAIL_INDEX_V(p_idx, conn_output_cache.size(), 0);
+	return conn_output_cache[p_idx].height;
 }
 
 int GraphNode::get_connection_output_type(int p_idx) {

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -78,6 +78,7 @@ private:
 
 	struct ConnCache {
 		Vector2 pos;
+		int height;
 		int type = 0;
 		Color color;
 	};
@@ -165,9 +166,11 @@ public:
 	int get_connection_input_count();
 	int get_connection_output_count();
 	Vector2 get_connection_input_position(int p_idx);
+	int get_connection_input_height(int p_idx);
 	int get_connection_input_type(int p_idx);
 	Color get_connection_input_color(int p_idx);
 	Vector2 get_connection_output_position(int p_idx);
+	int get_connection_output_height(int p_idx);
 	int get_connection_output_type(int p_idx);
 	Color get_connection_output_color(int p_idx);
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -993,8 +993,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// Visual Node Ports
 
-	theme->set_constant("port_grab_distance_horizontal", "GraphEdit", 24 * scale);
-	theme->set_constant("port_grab_distance_vertical", "GraphEdit", 6 * scale);
+	theme->set_constant("port_grab_distance_horizontal", "GraphEdit", 48 * scale);
 
 	theme->set_stylebox("bg", "GraphEditMinimap", make_flat_stylebox(Color(0.24, 0.24, 0.24), 0, 0, 0, 0));
 	Ref<StyleBoxFlat> style_minimap_camera = make_flat_stylebox(Color(0.65, 0.65, 0.65, 0.2), 0, 0, 0, 0);


### PR DESCRIPTION
The graph editor in 4.0 has a too-small hot zone for connecting graph nodes, which can make snapping unintuitive. This PR changes how hot zones are calculated and now automatically sets their height based on the accompanying UI elements instead of using a constant.

red is what we currently have, green is what I am proposing:
![image](https://user-images.githubusercontent.com/6329420/122623745-9a2cc400-d09d-11eb-90c3-ddcecab70642.png)

However, this PR exacerbates another problem with the `GraphEditor`: When the input is filtered it doesn't take child nodes into consideration, which means that hot zones can block the user from editing fields below them. To fix this we would need to pass the mouse down event to the children first before the GraphEditor handles it, and I have no clue how to properly do that.
Would appreciate it if someone could help me with this. Perhaps I am missing something obvious.

This PR superseeds #49705, for more information please see godotengine/godot-proposals#2790.


## TODO

- [ ] figure out how to handle overlapping hot zones and input field ui elements
	- if impossible just use differents hot zones for drag and drop.
- [ ] add highlights to connections on hover