### PR TITLE
Use double-sided material for RayCast3D

### DIFF
--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -419,6 +419,8 @@ void RayCast3D::_update_debug_shape_material(bool p_check_collision) {
 		debug_material = material;
 
 		material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+		// Use double-sided rendering so that the RayCast can be seen if the camera is inside.
+		material->set_cull_mode(BaseMaterial3D::CULL_DISABLED);
 		material->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
 	}
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/49733.

This makes [the new RayCast3Ds](https://github.com/godotengine/godot/pull/46529) visible if the camera is fully inside one (e.g. a RayCast3d parented to the current Camera3D).

## Preview

*Previously, this RayCast3D would have been completely invisible.*

![2021-06-19_05 05 45](https://user-images.githubusercontent.com/180032/122629307-55645580-d0bc-11eb-8030-c1301f44e33a.png)