### PR TITLE
Fixes for multi-node editing interactions.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -467,21 +467,30 @@ void Node3DEditorViewport::_select_clicked(bool p_append, bool p_single, bool p_
 }
 
 void Node3DEditorViewport::_select(Node *p_node, bool p_append, bool p_single) {
-	if (!p_append) {
-		editor_selection->clear();
-	}
-
-	if (editor_selection->is_selected(p_node)) {
-		//erase
-		editor_selection->remove_node(p_node);
-	} else {
+	// Add or remove a single node from the selection
+	if (p_append && p_single) {
+		if (editor_selection->is_selected(p_node)) {
+			// Already in the selection, remove it from the selected nodes
+			editor_selection->remove_node(p_node);
+		} else {
+			// Add the item to the selection
+			editor_selection->add_node(p_node);
+		}
+	} else if (p_append && !p_single) {
+		// Add the item to the selection
 		editor_selection->add_node(p_node);
-	}
-
-	if (p_single) {
+	} else {
+		// No append; single select
+		editor_selection->clear();
+		editor_selection->add_node(p_node);
+		// Reselect
 		if (Engine::get_singleton()->is_editor_hint()) {
 			editor->call("edit_node", p_node);
 		}
+	}
+
+	if (editor_selection->get_selected_node_list().size() == 1) {
+		editor->push_item(editor_selection->get_selected_node_list()[0]);
 	}
 }
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1202,9 +1202,6 @@ void SceneTreeDock::_notification(int p_what) {
 			filter->set_right_icon(get_theme_icon("Search", "EditorIcons"));
 			filter->set_clear_button_enabled(true);
 
-			EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", callable_mp(this, &SceneTreeDock::_selection_changed));
-			scene_tree->get_scene_tree()->connect("item_collapsed", callable_mp(this, &SceneTreeDock::_node_collapsed));
-
 			// create_root_dialog
 			HBoxContainer *top_row = memnew(HBoxContainer);
 			top_row->set_name("NodeShortcutsTopRow");
@@ -3157,6 +3154,9 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	scene_tree->connect("nodes_dragged", callable_mp(this, &SceneTreeDock::_nodes_drag_begin));
 
 	scene_tree->get_scene_tree()->connect("item_double_clicked", callable_mp(this, &SceneTreeDock::_focus_node));
+	scene_tree->get_scene_tree()->connect("item_collapsed", callable_mp(this, &SceneTreeDock::_node_collapsed));
+
+	editor_selection->connect("selection_changed", callable_mp(this, &SceneTreeDock::_selection_changed));
 
 	scene_tree->set_undo_redo(&editor_data->get_undo_redo());
 	scene_tree->set_editor_selection(editor_selection);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -659,7 +659,14 @@ void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_
 	} else {
 		editor_selection->remove_node(n);
 	}
-	emit_signal("node_changed");
+
+	// Selection changed to be single node, so emit "selected" (for single node) rather than "changed" (for multiple nodes)
+	if (editor_selection->get_selected_nodes().size() == 1) {
+		selected = editor_selection->get_selected_node_list()[0];
+		emit_signal("node_selected");
+	} else {
+		emit_signal("node_changed");
+	}
 }
 
 void SceneTreeEditor::_notification(int p_what) {


### PR DESCRIPTION
1. When having 2 nodes selected, deselecting one in the SceneTreeDock would keep the inspector in MultiNodeEdit rather than editing the one remaining node directly. This is now fixed. Closes #49451

<details><summary>AFTER Video</summary>

https://user-images.githubusercontent.com/41730826/122629304-608ca500-d0ff-11eb-8a40-f461f8dc49d6.mp4

</details>

2. In the Node3D editor, Shift-Selecting a region (drag selecting) would *deselect* nodes which were already selected, and select ones which were not, essentially inverting the selection. This is now fixed - shift-drag-selecting will only add nodes to the selection. To deselect, individual nodes can be clicked on. I am not sure if there is an issue open for this - it was a bug I found 
while testing other changes.

<details><summary>BEFORE Video</summary>

https://user-images.githubusercontent.com/41730826/122629356-acd7e500-d0ff-11eb-8021-cb0fe00d9723.mp4

</details>

<details><summary>AFTER Video</summary>

https://user-images.githubusercontent.com/41730826/122629317-700bee00-d0ff-11eb-80eb-a5b6d56b435c.mp4

</details>

3. Other minor code cleanup.

Supersedes/closes #49676
