### PR TITLE
Improve undo log messages throughout the editor for additional context

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -283,7 +283,7 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 	UndoRedo *ur = EditorNode::get_undo_redo();
 
 	StringName current = AudioServer::get_singleton()->get_bus_name(get_index());
-	ur->create_action(TTR("Rename Audio Bus"));
+	ur->create_action(vformat(TTR("Rename Audio Bus from \"%s\" to \"%s\""), current, attempt));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_name", get_index(), attempt);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_name", get_index(), current);
 
@@ -322,7 +322,8 @@ void EditorAudioBus::_volume_changed(float p_normalized) {
 	}
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Change Audio Bus Volume"), UndoRedo::MERGE_ENDS);
+	ur->create_action(
+			vformat(TTR("Change Audio Bus Volume for \"%s\""), AudioServer::get_singleton()->get_bus_name(get_index())), UndoRedo::MERGE_ENDS);
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", get_index(), p_db);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", get_index(), AudioServer::get_singleton()->get_bus_volume_db(get_index()));
 	ur->add_do_method(buses, "_update_bus", get_index());
@@ -416,7 +417,7 @@ void EditorAudioBus::_solo_toggled() {
 	updating_bus = true;
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Toggle Audio Bus Solo"));
+	ur->create_action(vformat(TTR("Toggle Audio Bus Solo for \"%s\""), AudioServer::get_singleton()->get_bus_name(get_index())));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_solo", get_index(), solo->is_pressed());
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_solo", get_index(), AudioServer::get_singleton()->is_bus_solo(get_index()));
 	ur->add_do_method(buses, "_update_bus", get_index());
@@ -430,7 +431,7 @@ void EditorAudioBus::_mute_toggled() {
 	updating_bus = true;
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Toggle Audio Bus Mute"));
+	ur->create_action(vformat(TTR("Toggle Audio Bus Mute for \"%s\""), AudioServer::get_singleton()->get_bus_name(get_index())));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_mute", get_index(), mute->is_pressed());
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_mute", get_index(), AudioServer::get_singleton()->is_bus_mute(get_index()));
 	ur->add_do_method(buses, "_update_bus", get_index());
@@ -444,7 +445,7 @@ void EditorAudioBus::_bypass_toggled() {
 	updating_bus = true;
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Toggle Audio Bus Bypass Effects"));
+	ur->create_action(vformat(TTR("Toggle Audio Bus Bypass Effects for \"%s\""), AudioServer::get_singleton()->get_bus_name(get_index())));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_bypass_effects", get_index(), bypass->is_pressed());
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_bypass_effects", get_index(), AudioServer::get_singleton()->is_bus_bypassing_effects(get_index()));
 	ur->add_do_method(buses, "_update_bus", get_index());
@@ -458,7 +459,7 @@ void EditorAudioBus::_send_selected(int p_which) {
 	updating_bus = true;
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Select Audio Bus Send"));
+	ur->create_action(vformat(TTR("Select Audio Bus Send for \"%s\""), AudioServer::get_singleton()->get_bus_name(get_index())));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_send", get_index(), send->get_item_text(p_which));
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_send", get_index(), AudioServer::get_singleton()->get_bus_send(get_index()));
 	ur->add_do_method(buses, "_update_bus", get_index());
@@ -507,7 +508,7 @@ void EditorAudioBus::_effect_edited() {
 		updating_bus = true;
 
 		UndoRedo *ur = EditorNode::get_undo_redo();
-		ur->create_action(TTR("Select Audio Bus Send"));
+		ur->create_action(vformat(TTR("Select Audio Bus Send for \"%s\""), AudioServer::get_singleton()->get_bus_name(get_index())));
 		ur->add_do_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, effect->is_checked(0));
 		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, AudioServer::get_singleton()->is_bus_effect_enabled(get_index(), index));
 		ur->add_do_method(buses, "_update_bus", get_index());
@@ -534,7 +535,7 @@ void EditorAudioBus::_effect_add(int p_which) {
 	afxr->set_name(effect_options->get_item_text(p_which));
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Add Audio Bus Effect"));
+	ur->create_action(vformat(TTR("Add Audio Bus Effect \"%s\" to \"%s\""), afxr->get_class_name(), AudioServer::get_singleton()->get_bus_name(get_index())));
 	ur->add_do_method(AudioServer::get_singleton(), "add_bus_effect", get_index(), afxr, -1);
 	ur->add_undo_method(AudioServer::get_singleton(), "remove_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect_count(get_index()));
 	ur->add_do_method(buses, "_update_bus", get_index());
@@ -688,7 +689,11 @@ void EditorAudioBus::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 	bool enabled = AudioServer::get_singleton()->is_bus_effect_enabled(bus, effect);
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Move Bus Effect"));
+	ur->create_action(
+			vformat(TTR("Move Bus Effect \"%s\" from \"%s\" to \"%s\""),
+					AudioServer::get_singleton()->get_bus_effect(bus, effect)->get_class_name(),
+					AudioServer::get_singleton()->get_bus_name(bus),
+					AudioServer::get_singleton()->get_bus_name(get_index())));
 	ur->add_do_method(AudioServer::get_singleton(), "remove_bus_effect", bus, effect);
 	ur->add_do_method(AudioServer::get_singleton(), "add_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect(bus, effect), paste_at);
 
@@ -730,7 +735,8 @@ void EditorAudioBus::_delete_effect_pressed(int p_option) {
 	int index = item->get_metadata(0);
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Delete Bus Effect"));
+	ur->create_action(
+			vformat(TTR("Remove Bus Effect \"%s\" from \"%s\""), AudioServer::get_singleton()->get_bus_effect(get_index(), index)->get_class_name(), AudioServer::get_singleton()->get_bus_name(get_index())));
 	ur->add_do_method(AudioServer::get_singleton(), "remove_bus_effect", get_index(), index);
 	ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect(get_index(), index), index);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, AudioServer::get_singleton()->is_bus_effect_enabled(get_index(), index));
@@ -1094,7 +1100,7 @@ void EditorAudioBuses::_delete_bus(Object *p_which) {
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 
-	ur->create_action(TTR("Delete Audio Bus"));
+	ur->create_action(vformat(TTR("Delete Audio Bus \"%s\""), AudioServer::get_singleton()->get_bus_name(index)));
 	ur->add_do_method(AudioServer::get_singleton(), "remove_bus", index);
 	ur->add_undo_method(AudioServer::get_singleton(), "add_bus", index);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_name", index, AudioServer::get_singleton()->get_bus_name(index));
@@ -1115,7 +1121,7 @@ void EditorAudioBuses::_delete_bus(Object *p_which) {
 void EditorAudioBuses::_duplicate_bus(int p_which) {
 	int add_at_pos = p_which + 1;
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Duplicate Audio Bus"));
+	ur->create_action(vformat(TTR("Duplicate Audio Bus \"%s\""), AudioServer::get_singleton()->get_bus_name(p_which)));
 	ur->add_do_method(AudioServer::get_singleton(), "add_bus", add_at_pos);
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_name", add_at_pos, AudioServer::get_singleton()->get_bus_name(p_which) + " Copy");
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", add_at_pos, AudioServer::get_singleton()->get_bus_volume_db(p_which));
@@ -1138,7 +1144,7 @@ void EditorAudioBuses::_reset_bus_volume(Object *p_which) {
 	int index = bus->get_index();
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Reset Bus Volume"));
+	ur->create_action(vformat(TTR("Reset Volume of Bus \"%s\""), AudioServer::get_singleton()->get_bus_name(index)));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", index, 0.f);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", index, AudioServer::get_singleton()->get_bus_volume_db(index));
 	ur->add_do_method(this, "_update_buses");
@@ -1158,7 +1164,7 @@ void EditorAudioBuses::_request_drop_end() {
 
 void EditorAudioBuses::_drop_at_index(int p_bus, int p_index) {
 	UndoRedo *ur = EditorNode::get_undo_redo();
-	ur->create_action(TTR("Move Audio Bus"));
+	ur->create_action(vformat(TTR("Move Audio Bus \"%s\""), AudioServer::get_singleton()->get_bus_name(p_bus)));
 
 	ur->add_do_method(AudioServer::get_singleton(), "move_bus", p_bus, p_index);
 	int real_bus = p_index > p_bus ? p_bus : p_bus + 1;

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -173,7 +173,7 @@ void EditorAutoloadSettings::_autoload_edited() {
 		int order = ProjectSettings::get_singleton()->get_order(selected_autoload);
 		String path = ProjectSettings::get_singleton()->get(selected_autoload);
 
-		undo_redo->create_action(TTR("Rename Autoload"));
+		undo_redo->create_action(vformat(TTR("Rename AutoLoad from \"%s\" to \"%s\""), old_name, name));
 
 		undo_redo->add_do_property(ProjectSettings::get_singleton(), name, path);
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", name, order);
@@ -260,7 +260,7 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 			int order = ProjectSettings::get_singleton()->get_order(name);
 			int swap_order = ProjectSettings::get_singleton()->get_order(swap_name);
 
-			undo_redo->create_action(TTR("Move Autoload"));
+			undo_redo->create_action(vformat(TTR("Move AutoLoad \"%s\""), name));
 
 			undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", name, swap_order);
 			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", name, order);
@@ -279,7 +279,7 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 		case BUTTON_DELETE: {
 			int order = ProjectSettings::get_singleton()->get_order(name);
 
-			undo_redo->create_action(TTR("Remove Autoload"));
+			undo_redo->create_action(vformat(TTR("Remove AutoLoad \"%s\""), name));
 
 			undo_redo->add_do_property(ProjectSettings::get_singleton(), name, Variant());
 
@@ -657,7 +657,7 @@ void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &
 
 	UndoRedo *undo_redo = EditorNode::get_undo_redo();
 
-	undo_redo->create_action(TTR("Rearrange Autoloads"));
+	undo_redo->create_action(TTR("Rearrange AutoLoads"));
 
 	i = 0;
 
@@ -701,7 +701,7 @@ bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_
 
 	UndoRedo *undo_redo = EditorNode::get_undo_redo();
 
-	undo_redo->create_action(TTR("Add AutoLoad"));
+	undo_redo->create_action(vformat(TTR("Add AutoLoad \"%s\""), name));
 	// Singleton autoloads are represented with a leading "*" in their path.
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, "*" + path);
 
@@ -729,7 +729,7 @@ void EditorAutoloadSettings::autoload_remove(const String &p_name) {
 
 	int order = ProjectSettings::get_singleton()->get_order(name);
 
-	undo_redo->create_action(TTR("Remove Autoload"));
+	undo_redo->create_action(vformat(TTR("Remove AutoLoad \"%s\""), name));
 
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, Variant());
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2257,7 +2257,7 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		_edit_request_change(object, p_name);
 		emit_signal(_prop_edited, p_name);
 	} else {
-		undo_redo->create_action(TTR("Set") + " " + p_name, UndoRedo::MERGE_ENDS);
+		undo_redo->create_action(vformat(TTR("Set Property \"%s\""), p_name), UndoRedo::MERGE_ENDS);
 		undo_redo->add_do_property(object, p_name, p_value);
 		undo_redo->add_undo_property(object, p_name, object->get(p_name));
 
@@ -2338,11 +2338,11 @@ void EditorInspector::_multiple_properties_changed(Vector<String> p_paths, Array
 	String names;
 	for (int i = 0; i < p_paths.size(); i++) {
 		if (i > 0) {
-			names += ",";
+			names += ", ";
 		}
-		names += p_paths[i];
+		names += vformat("\"%s\"", p_paths[i]);
 	}
-	undo_redo->create_action(TTR("Set Multiple:") + " " + names, UndoRedo::MERGE_ENDS);
+	undo_redo->create_action(TTR("Set Multiple Properties:") + " " + names, UndoRedo::MERGE_ENDS);
 	for (int i = 0; i < p_paths.size(); i++) {
 		_edit_set(p_paths[i], p_values[i], false, "");
 		if (restart_request_props.has(p_paths[i])) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4925,7 +4925,7 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 
 	uint64_t next_scene_version = editor_data.get_scene_version(p_tab);
 
-	editor_data.get_undo_redo().create_action(TTR("Switch Scene Tab"));
+	editor_data.get_undo_redo().create_action(vformat(TTR("Switch Scene Tab to \"%s\""), editor_data.get_scene_title(p_tab, true)));
 	editor_data.get_undo_redo().add_do_method(this, "set_current_version", unsaved ? saved_version : 0);
 	editor_data.get_undo_redo().add_do_method(this, "set_current_scene", p_tab);
 	editor_data.get_undo_redo().add_do_method(this, "set_current_version", next_scene_version == 0 ? editor_data.get_undo_redo().get_version() + 1 : next_scene_version);

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -128,7 +128,7 @@ void GroupDialog::_add_pressed() {
 		return;
 	}
 
-	undo_redo->create_action(TTR("Add to Group"));
+	undo_redo->create_action(vformat(TTR("Add Node(s) to Group \"%s\""), selected_group));
 
 	while (selected) {
 		Node *node = scene_tree->get_edited_scene_root()->get_node(selected->get_metadata(0));
@@ -157,7 +157,7 @@ void GroupDialog::_removed_pressed() {
 		return;
 	}
 
-	undo_redo->create_action(TTR("Remove from Group"));
+	undo_redo->create_action(vformat(TTR("Remove Node(s) from Group \"%s\""), selected_group));
 
 	while (selected) {
 		Node *node = scene_tree->get_edited_scene_root()->get_node(selected->get_metadata(0));
@@ -235,7 +235,7 @@ void GroupDialog::_group_renamed() {
 
 	renamed_group->set_text(0, name); // Spaces trimmed.
 
-	undo_redo->create_action(TTR("Rename Group"));
+	undo_redo->create_action(vformat(TTR("Rename Group \"%s\" to \"%s\""), selected_group, name));
 
 	List<Node *> nodes;
 	scene_tree->get_nodes_in_group(selected_group, &nodes);
@@ -306,7 +306,7 @@ void GroupDialog::_delete_group_pressed(Object *p_item, int p_column, int p_id) 
 
 	String name = ti->get_text(0);
 
-	undo_redo->create_action(TTR("Delete Group"));
+	undo_redo->create_action(vformat(TTR("Delete Group \"%s\""), name));
 
 	List<Node *> nodes;
 	scene_tree->get_nodes_in_group(name, &nodes);
@@ -559,7 +559,7 @@ void GroupsEditor::_add_group(const String &p_group) {
 		return;
 	}
 
-	undo_redo->create_action(TTR("Add to Group"));
+	undo_redo->create_action(vformat(TTR("Add Node \"%s\" to Group \"%s\""), node->get_name(), name));
 
 	undo_redo->add_do_method(node, "add_to_group", name, true);
 	undo_redo->add_undo_method(node, "remove_from_group", name);
@@ -587,7 +587,7 @@ void GroupsEditor::_remove_group(Object *p_item, int p_column, int p_id) {
 
 	String name = ti->get_text(0);
 
-	undo_redo->create_action(TTR("Remove from Group"));
+	undo_redo->create_action(vformat(TTR("Remove Node \"%s\" from Group \"%s\""), node->get_name(), name));
 
 	undo_redo->add_do_method(node, "remove_from_group", name);
 	undo_redo->add_undo_method(node, "add_to_group", name, true);

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -327,7 +327,7 @@ void LocalizationEditor::_translation_filter_option_changed() {
 
 	f_locales.sort();
 
-	undo_redo->create_action(TTR("Changed Locale Filter"));
+	undo_redo->create_action(TTR("Change Locale Filter"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/locale_filter", f_locales_all);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/locale_filter", prev);
 	undo_redo->add_do_method(this, "update_translations");
@@ -359,7 +359,7 @@ void LocalizationEditor::_translation_filter_mode_changed(int p_mode) {
 		f_locales_all.append(Array());
 	}
 
-	undo_redo->create_action(TTR("Changed Locale Filter Mode"));
+	undo_redo->create_action(TTR("Change Locale Filter Mode"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/locale_filter", f_locales_all);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/locale_filter", prev);
 	undo_redo->add_do_method(this, "update_translations");
@@ -382,7 +382,7 @@ void LocalizationEditor::_pot_add(const PackedStringArray &p_paths) {
 		pot_translations.push_back(p_paths[i]);
 	}
 
-	undo_redo->create_action(vformat(TTR("Add %d file(s) for POT generation"), p_paths.size()));
+	undo_redo->create_action(vformat(TTR("Add %d File(s) for POT Generation"), p_paths.size()));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translations_pot_files", pot_translations);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translations_pot_files", ProjectSettings::get_singleton()->get("internationalization/locale/translations_pot_files"));
 	undo_redo->add_do_method(this, "update_translations");
@@ -404,7 +404,7 @@ void LocalizationEditor::_pot_delete(Object *p_item, int p_column, int p_button)
 
 	pot_translations.remove(idx);
 
-	undo_redo->create_action(TTR("Remove file from POT generation"));
+	undo_redo->create_action(TTR("Remove File from POT Generation"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translations_pot_files", pot_translations);
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translations_pot_files", ProjectSettings::get_singleton()->get("internationalization/locale/translations_pot_files"));
 	undo_redo->add_do_method(this, "update_translations");

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -51,7 +51,7 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 
-	ur->create_action(TTR("MultiNode Set") + " " + String(name), UndoRedo::MERGE_ENDS);
+	ur->create_action(vformat(TTR("Set Property \"%s\" on %d Nodes"), name, nodes.size()), UndoRedo::MERGE_ENDS);
 	for (const List<NodePath>::Element *E = nodes.front(); E; E = E->next()) {
 		if (!es->has_node(E->get())) {
 			continue;

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -904,13 +904,21 @@ void Light3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, co
 
 	} else if (p_idx == 0) {
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Light Radius"));
+		ur->create_action(
+				vformat(TTR("Change Light \"%s\" Range from %.2f to %.2f"),
+						light->get_name(),
+						p_restore,
+						light->get_param(Light3D::PARAM_RANGE)));
 		ur->add_do_method(light, "set_param", Light3D::PARAM_RANGE, light->get_param(Light3D::PARAM_RANGE));
 		ur->add_undo_method(light, "set_param", Light3D::PARAM_RANGE, p_restore);
 		ur->commit_action();
 	} else if (p_idx == 1) {
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Light Radius"));
+		ur->create_action(
+				vformat(TTR("Change Light \"%s\" Spot Angle from %.2f to %.2f"),
+						light->get_name(),
+						p_restore,
+						light->get_param(Light3D::PARAM_RANGE)));
 		ur->add_do_method(light, "set_param", Light3D::PARAM_SPOT_ANGLE, light->get_param(Light3D::PARAM_SPOT_ANGLE));
 		ur->add_undo_method(light, "set_param", Light3D::PARAM_SPOT_ANGLE, p_restore);
 		ur->commit_action();
@@ -1126,7 +1134,7 @@ void AudioStreamPlayer3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, i
 
 	} else {
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change AudioStreamPlayer3D Emission Angle"));
+		ur->create_action(vformat(TTR("Change AudioStreamPlayer3D \"%s\" Emission Angle from %.2f to %.2f"), player->get_name(), p_restore, player->get_emission_angle()));
 		ur->add_do_method(player, "set_emission_angle", player->get_emission_angle());
 		ur->add_undo_method(player, "set_emission_angle", p_restore);
 		ur->commit_action();
@@ -1264,7 +1272,7 @@ void Camera3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, c
 			camera->set("fov", p_restore);
 		} else {
 			UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-			ur->create_action(TTR("Change Camera FOV"));
+			ur->create_action(vformat(TTR("Change Camera \"%s\" FOV from %.2f to %.2f"), camera->get_name(), p_restore, camera->get_fov()));
 			ur->add_do_property(camera, "fov", camera->get_fov());
 			ur->add_undo_property(camera, "fov", p_restore);
 			ur->commit_action();
@@ -1275,7 +1283,7 @@ void Camera3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, c
 			camera->set("size", p_restore);
 		} else {
 			UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-			ur->create_action(TTR("Change Camera Size"));
+			ur->create_action(vformat(TTR("Change Camera \"%s\" Size from %.2f to %.2f"), camera->get_name(), p_restore, camera->get_size()));
 			ur->add_do_property(camera, "size", camera->get_size());
 			ur->add_undo_property(camera, "size", p_restore);
 			ur->commit_action();
@@ -2232,7 +2240,7 @@ void VisibleOnScreenNotifier3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gi
 	}
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-	ur->create_action(TTR("Change Notifier AABB"));
+	ur->create_action(vformat(TTR("Change Notifier \"%s\" AABB"), notifier->get_name()));
 	ur->add_do_method(notifier, "set_aabb", notifier->get_aabb());
 	ur->add_undo_method(notifier, "set_aabb", p_restore);
 	ur->commit_action();
@@ -2423,7 +2431,7 @@ void GPUParticles3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_
 	}
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-	ur->create_action(TTR("Change Particles AABB"));
+	ur->create_action(vformat(TTR("Change Particles \"%s\" AABB"), particles->get_name()));
 	ur->add_do_method(particles, "set_visibility_aabb", particles->get_visibility_aabb());
 	ur->add_undo_method(particles, "set_visibility_aabb", p_restore);
 	ur->commit_action();
@@ -2586,7 +2594,7 @@ void GPUParticlesCollision3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizm
 		}
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Radius"));
+		ur->create_action(vformat(TTR("Change GPUParticlesCollisionSphere \"%s\" Radius from %.2f to %.2f"), sn->get_name(), p_restore, sn->call("get_radius")));
 		ur->add_do_method(sn, "set_radius", sn->call("get_radius"));
 		ur->add_undo_method(sn, "set_radius", p_restore);
 		ur->commit_action();
@@ -2599,7 +2607,7 @@ void GPUParticlesCollision3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizm
 		}
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Box Shape Extents"));
+		ur->create_action(vformat(TTR("Change GPUParticlesCollisionBox \"%s\" Extents"), sn->get_name()));
 		ur->add_do_method(sn, "set_extents", sn->call("get_extents"));
 		ur->add_undo_method(sn, "set_extents", p_restore);
 		ur->commit_action();
@@ -2859,7 +2867,7 @@ void ReflectionProbeGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p
 	}
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-	ur->create_action(TTR("Change Probe Extents"));
+	ur->create_action(vformat(TTR("Change ReflectionProbe \"%s\" Extents"), probe->get_name()));
 	ur->add_do_method(probe, "set_extents", probe->get_extents());
 	ur->add_do_method(probe, "set_origin_offset", probe->get_origin_offset());
 	ur->add_undo_method(probe, "set_extents", restore.position);
@@ -3011,7 +3019,7 @@ void DecalGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, cons
 	}
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-	ur->create_action(TTR("Change Decal Extents"));
+	ur->create_action(vformat(TTR("Change Decal \"%s\" Extents"), decal->get_name()));
 	ur->add_do_method(decal, "set_extents", decal->get_extents());
 	ur->add_undo_method(decal, "set_extents", restore);
 	ur->commit_action();
@@ -3152,7 +3160,7 @@ void VoxelGIGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx, co
 	}
 
 	UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-	ur->create_action(TTR("Change Probe Extents"));
+	ur->create_action(vformat(TTR("Change VoxelGI \"%s\" Extents"), probe->get_name()));
 	ur->add_do_method(probe, "set_extents", probe->get_extents());
 	ur->add_undo_method(probe, "set_extents", restore);
 	ur->commit_action();
@@ -3804,7 +3812,7 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 		}
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Sphere Shape Radius"));
+		ur->create_action(vformat(TTR("Change SphereShape3D \"%s\" Radius from %.2f to %.2f"), ss->get_name(), p_restore, ss->get_radius()));
 		ur->add_do_method(ss.ptr(), "set_radius", ss->get_radius());
 		ur->add_undo_method(ss.ptr(), "set_radius", p_restore);
 		ur->commit_action();
@@ -3818,7 +3826,7 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 		}
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Box Shape Size"));
+		ur->create_action(vformat(TTR("Change BoxShape3D \"%s\" Size from %s to %s"), ss->get_name(), p_restore, ss->get_size()));
 		ur->add_do_method(ss.ptr(), "set_size", ss->get_size());
 		ur->add_undo_method(ss.ptr(), "set_size", p_restore);
 		ur->commit_action();
@@ -3837,11 +3845,11 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		if (p_idx == 0) {
-			ur->create_action(TTR("Change Capsule Shape Radius"));
+			ur->create_action(vformat(TTR("Change CapsuleShape3D \"%s\" Radius from %.2f to %.2f"), ss->get_name(), p_restore, ss->get_radius()));
 			ur->add_do_method(ss.ptr(), "set_radius", ss->get_radius());
 			ur->add_undo_method(ss.ptr(), "set_radius", p_restore);
 		} else {
-			ur->create_action(TTR("Change Capsule Shape Height"));
+			ur->create_action(vformat(TTR("Change CapsuleShape3D \"%s\" Height from %.2f to %.2f"), ss->get_name(), p_restore, ss->get_height()));
 			ur->add_do_method(ss.ptr(), "set_height", ss->get_height());
 			ur->add_undo_method(ss.ptr(), "set_height", p_restore);
 		}
@@ -3862,15 +3870,11 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		if (p_idx == 0) {
-			ur->create_action(TTR("Change Cylinder Shape Radius"));
+			ur->create_action(vformat(TTR("Change CylinderShape3D \"%s\" Radius from %.2f to %.2f"), ss->get_name(), p_restore, ss->get_radius()));
 			ur->add_do_method(ss.ptr(), "set_radius", ss->get_radius());
 			ur->add_undo_method(ss.ptr(), "set_radius", p_restore);
 		} else {
-			ur->create_action(
-					///
-
-					////////
-					TTR("Change Cylinder Shape Height"));
+			ur->create_action(vformat(TTR("Change CylinderShape3D \"%s\" Shape Height from %.2f to %.2f"), ss->get_name(), p_restore, ss->get_height()));
 			ur->add_do_method(ss.ptr(), "set_height", ss->get_height());
 			ur->add_undo_method(ss.ptr(), "set_height", p_restore);
 		}
@@ -3886,7 +3890,7 @@ void CollisionShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int 
 		}
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Ray Shape Length"));
+		ur->create_action(vformat(TTR("Change RayShape3D \"%s\" Length from %.2f to %.2f"), ss->get_name(), p_restore, ss->get_length()));
 		ur->add_do_method(ss.ptr(), "set_length", ss->get_length());
 		ur->add_undo_method(ss.ptr(), "set_length", p_restore);
 		ur->commit_action();

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -164,7 +164,7 @@ void AnimationPlayerEditor::_autoplay_pressed() {
 	String current = animation->get_item_text(animation->get_selected());
 	if (player->get_autoplay() == current) {
 		//unset
-		undo_redo->create_action(TTR("Toggle Autoplay"));
+		undo_redo->create_action(vformat(TTR("Disable Autoplay for Animation \"%s\" on AnimationPlayer \"%s\""), current, player->get_name()));
 		undo_redo->add_do_method(player, "set_autoplay", "");
 		undo_redo->add_undo_method(player, "set_autoplay", player->get_autoplay());
 		undo_redo->add_do_method(this, "_animation_player_changed", player);
@@ -173,7 +173,7 @@ void AnimationPlayerEditor::_autoplay_pressed() {
 
 	} else {
 		//set
-		undo_redo->create_action(TTR("Toggle Autoplay"));
+		undo_redo->create_action(vformat(TTR("Enable Autoplay for Animation \"%s\" on AnimationPlayer \"%s\""), current, player->get_name()));
 		undo_redo->add_do_method(player, "set_autoplay", current);
 		undo_redo->add_undo_method(player, "set_autoplay", player->get_autoplay());
 		undo_redo->add_do_method(this, "_animation_player_changed", player);
@@ -433,7 +433,7 @@ void AnimationPlayerEditor::_animation_remove_confirmed() {
 	String current = animation->get_item_text(animation->get_selected());
 	Ref<Animation> anim = player->get_animation(current);
 
-	undo_redo->create_action(TTR("Remove Animation"));
+	undo_redo->create_action(vformat(TTR("Remove Animation \"%s\" from AnimationPlayer \"%s\""), current, player->get_name()));
 	if (player->get_autoplay() == current) {
 		undo_redo->add_do_method(player, "set_autoplay", "");
 		undo_redo->add_undo_method(player, "set_autoplay", current);
@@ -506,7 +506,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 		String current = animation->get_item_text(animation->get_selected());
 		Ref<Animation> anim = player->get_animation(current);
 
-		undo_redo->create_action(TTR("Rename Animation"));
+		undo_redo->create_action(vformat(TTR("Rename Animation from \"%s\" to \"%s\" on AnimationPlayer \"%s\""), current, new_name, player->get_name()));
 		undo_redo->add_do_method(player, "rename_animation", current, new_name);
 		undo_redo->add_do_method(anim.ptr(), "set_name", new_name);
 		undo_redo->add_undo_method(player, "rename_animation", new_name, current);
@@ -521,7 +521,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 		Ref<Animation> new_anim = Ref<Animation>(memnew(Animation));
 		new_anim->set_name(new_name);
 
-		undo_redo->create_action(TTR("Add Animation"));
+		undo_redo->create_action(vformat(TTR("Add Animation \"%s\" to AnimationPlayer \"%s\""), new_name, player->get_name()));
 		undo_redo->add_do_method(player, "add_animation", new_name, new_anim);
 		undo_redo->add_undo_method(player, "remove_animation", new_name);
 		undo_redo->add_do_method(this, "_animation_player_changed", player);
@@ -731,7 +731,7 @@ void AnimationPlayerEditor::_dialog_action(String p_path) {
 				anim_name = anim_name.substr(0, ext_pos);
 			}
 
-			undo_redo->create_action(TTR("Load Animation"));
+			undo_redo->create_action(vformat(TTR("Load Animation \"%s\" on AnimationPlayer \"%s\""), anim_name, player->get_name()));
 			undo_redo->add_do_method(player, "add_animation", anim_name, res);
 			undo_redo->add_undo_method(player, "remove_animation", anim_name);
 			if (player->has_animation(anim_name)) {
@@ -977,7 +977,7 @@ void AnimationPlayerEditor::_animation_duplicate() {
 	}
 	new_anim->set_name(new_name);
 
-	undo_redo->create_action(TTR("Duplicate Animation"));
+	undo_redo->create_action(vformat(TTR("Duplicate Animation \"%s\" on AnimationPlayer \"%s\""), current, player->get_name()));
 	undo_redo->add_do_method(player, "add_animation", new_name, new_anim);
 	undo_redo->add_undo_method(player, "remove_animation", new_name);
 	undo_redo->add_do_method(player, "animation_set_next", new_name, player->animation_get_next(current));
@@ -1146,7 +1146,7 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 				name = base + " " + itos(idx);
 			}
 
-			undo_redo->create_action(TTR("Paste Animation"));
+			undo_redo->create_action(vformat(TTR("Paste Animation \"%s\" on AnimationPlayer \"%s\""), name, player->get_name()));
 			undo_redo->add_do_method(player, "add_animation", name, anim2);
 			undo_redo->add_undo_method(player, "remove_animation", name);
 			undo_redo->add_do_method(this, "_animation_player_changed", player);

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -211,7 +211,7 @@ void CollisionShape2DEditor::set_handle(int idx, Point2 &p_point) {
 }
 
 void CollisionShape2DEditor::commit_handle(int idx, Variant &p_org) {
-	undo_redo->create_action(TTR("Set Handle"));
+	undo_redo->create_action(TTR("Set Handle on CollisionShape2D"));
 
 	switch (shape_type) {
 		case CAPSULE_SHAPE: {

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -85,7 +85,7 @@ void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 			cpu_particles->set_z_index(particles->get_z_index());
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-			ur->create_action(TTR("Convert to CPUParticles2D"));
+			ur->create_action(vformat(TTR("Convert GPUParticles2D \"%s\" to CPUParticles2D"), particles->get_name()));
 			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", particles, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
 			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, particles, false, false);
@@ -132,7 +132,7 @@ void GPUParticles2DEditorPlugin::_generate_visibility_rect() {
 		particles->set_emitting(false);
 	}
 
-	undo_redo->create_action(TTR("Generate Visibility Rect"));
+	undo_redo->create_action(vformat(TTR("Generate GPUParticles2D Visibility Rect for \"%s\""), particles->get_name()));
 	undo_redo->add_do_method(particles, "set_visibility_rect", rect);
 	undo_redo->add_undo_method(particles, "set_visibility_rect", particles->get_visibility_rect());
 	undo_redo->commit_action();

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -266,7 +266,7 @@ void GPUParticles3DEditor::_menu_option(int p_option) {
 			cpu_particles->set_process_mode(node->get_process_mode());
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-			ur->create_action(TTR("Convert to CPUParticles3D"));
+			ur->create_action(vformat(TTR("Convert GPUParticles3D \"%s\" to CPUParticles3D"), node->get_name()));
 			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
 			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, node, false, false);
@@ -316,7 +316,7 @@ void GPUParticles3DEditor::_generate_aabb() {
 	}
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-	ur->create_action(TTR("Generate Visibility AABB"));
+	ur->create_action(vformat(TTR("Generate GPUParticles3D Visibility AABB for \"%s\""), node->get_name()));
 	ur->add_do_method(node, "set_visibility_aabb", rect);
 	ur->add_undo_method(node, "set_visibility_aabb", node->get_visibility_aabb());
 	ur->commit_action();

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -52,7 +52,7 @@ void GradientEditor::_gradient_changed() {
 void GradientEditor::_ramp_changed() {
 	editing = true;
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
-	undo_redo->create_action(TTR("Gradient Edited"));
+	undo_redo->create_action(TTR("Edit Gradient"));
 	undo_redo->add_do_method(gradient.ptr(), "set_offsets", get_offsets());
 	undo_redo->add_do_method(gradient.ptr(), "set_colors", get_colors());
 	undo_redo->add_undo_method(gradient.ptr(), "set_offsets", gradient->get_offsets());

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -94,7 +94,7 @@ void LightOccluder2DEditor::_create_resource() {
 		return;
 	}
 
-	undo_redo->create_action(TTR("Create Occluder Polygon"));
+	undo_redo->create_action(TTR("Create LightOccluder2D Polygon"));
 	undo_redo->add_do_method(node, "set_occluder_polygon", Ref<OccluderPolygon2D>(memnew(OccluderPolygon2D)));
 	undo_redo->add_undo_method(node, "set_occluder_polygon", Variant(REF()));
 	undo_redo->commit_action();

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -78,7 +78,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 				Node *owner = node == get_tree()->get_edited_scene_root() ? node : node->get_owner();
 
-				ur->create_action(TTR("Create Static Trimesh Body"));
+				ur->create_action(vformat(TTR("Create Static Trimesh Body for MeshInstance3D \"%s\""), node->get_name()));
 				ur->add_do_method(node, "add_child", body);
 				ur->add_do_method(body, "set_owner", owner);
 				ur->add_do_method(cshape, "set_owner", owner);
@@ -88,7 +88,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				return;
 			}
 
-			ur->create_action(TTR("Create Static Trimesh Body"));
+			ur->create_action(vformat(TTR("Create Static Trimesh Body for MeshInstance3D \"%s\""), node->get_name()));
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 				MeshInstance3D *instance = Object::cast_to<MeshInstance3D>(E->get());
@@ -144,7 +144,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 
-			ur->create_action(TTR("Create Trimesh Static Shape"));
+			ur->create_action(vformat(TTR("Create Trimesh Static Shape for MeshInstance3D \"%s\""), node->get_name()));
 
 			ur->add_do_method(node->get_parent(), "add_child", cshape);
 			ur->add_do_method(node->get_parent(), "move_child", cshape, node->get_index() + 1);
@@ -169,7 +169,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 			}
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 
-			ur->create_action(TTR("Create Single Convex Shape"));
+			ur->create_action(vformat(TTR("Create Single Convex Shape for MeshInstance3D \"%s\""), node->get_name()));
 
 			CollisionShape3D *cshape = memnew(CollisionShape3D);
 			cshape->set_shape(shape);
@@ -202,7 +202,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 			}
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 
-			ur->create_action(TTR("Create Multiple Convex Shapes"));
+			ur->create_action(vformat(TTR("Create Multiple Convex Shapes for MeshInstance3D \"%s\""), node->get_name()));
 
 			for (int i = 0; i < shapes.size(); i++) {
 				CollisionShape3D *cshape = memnew(CollisionShape3D);
@@ -235,7 +235,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 			Node *owner = node == get_tree()->get_edited_scene_root() ? node : node->get_owner();
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-			ur->create_action(TTR("Create Navigation Mesh"));
+			ur->create_action(vformat(TTR("Create Navigation Mesh for MeshInstance3D \"%s\""), node->get_name()));
 
 			ur->add_do_method(node, "add_child", nmi);
 			ur->add_do_method(nmi, "set_owner", owner);
@@ -413,7 +413,7 @@ void MeshInstance3DEditor::_create_outline_mesh() {
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 
-	ur->create_action(TTR("Create Outline"));
+	ur->create_action(vformat(TTR("Create MeshInstance3D Outline for MeshInstance3D \"%s\""), node->get_name()));
 
 	ur->add_do_method(node, "add_child", mi);
 	ur->add_do_method(mi, "set_owner", owner);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4974,7 +4974,7 @@ void Node3DEditor::_xform_dialog_action() {
 	t.basis.rotate(rotate);
 	t.origin = translate;
 
-	undo_redo->create_action(TTR("XForm Dialog"));
+	undo_redo->create_action(TTR("Apply 3D Transform Dialog"));
 
 	List<Node *> &selection = editor_selection->get_selected_node_list();
 
@@ -5211,7 +5211,7 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			snap_selected_nodes_to_floor();
 		} break;
 		case MENU_LOCK_SELECTED: {
-			undo_redo->create_action(TTR("Lock Selected"));
+			undo_redo->create_action(TTR("Lock Selected Node(s)"));
 
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
@@ -5236,7 +5236,7 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			undo_redo->commit_action();
 		} break;
 		case MENU_UNLOCK_SELECTED: {
-			undo_redo->create_action(TTR("Unlock Selected"));
+			undo_redo->create_action(TTR("Unlock Selected Node(s)"));
 
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
@@ -5261,7 +5261,7 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			undo_redo->commit_action();
 		} break;
 		case MENU_GROUP_SELECTED: {
-			undo_redo->create_action(TTR("Group Selected"));
+			undo_redo->create_action(TTR("Group Selected Node(s)"));
 
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
@@ -5286,7 +5286,7 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			undo_redo->commit_action();
 		} break;
 		case MENU_UNGROUP_SELECTED: {
-			undo_redo->create_action(TTR("Ungroup Selected"));
+			undo_redo->create_action(TTR("Ungroup Selected Node(s)"));
 			List<Node *> &selection = editor_selection->get_selected_node_list();
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
@@ -6170,7 +6170,7 @@ void Node3DEditor::snap_selected_nodes_to_floor() {
 		}
 
 		if (snapped_to_floor) {
-			undo_redo->create_action(TTR("Snap Nodes To Floor"));
+			undo_redo->create_action(TTR("Snap Node(s) To Floor"));
 
 			// Perform snapping if at least one node can be snapped
 			for (int i = 0; i < keys.size(); i++) {

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -75,7 +75,7 @@ void ResourcePreloaderEditor::_files_load_request(const Vector<String> &p_paths)
 			name = basename + " " + itos(counter);
 		}
 
-		undo_redo->create_action(TTR("Add Resource"));
+		undo_redo->create_action(vformat(TTR("Add Resource \"%s\" to ResourcePreloader \"%s\""), name, preloader->get_name()));
 		undo_redo->add_do_method(preloader, "add_resource", name, resource);
 		undo_redo->add_undo_method(preloader, "remove_resource", name);
 		undo_redo->add_do_method(this, "_update_library");
@@ -119,7 +119,7 @@ void ResourcePreloaderEditor::_item_edited() {
 		}
 
 		RES samp = preloader->get_resource(old_name);
-		undo_redo->create_action(TTR("Rename Resource"));
+		undo_redo->create_action(vformat(TTR("Rename Resource from \"%s\" to \"%s\" in ResourcePreloader \"%s\""), old_name, new_name, preloader->get_name()));
 		undo_redo->add_do_method(preloader, "remove_resource", old_name);
 		undo_redo->add_do_method(preloader, "add_resource", new_name, samp);
 		undo_redo->add_undo_method(preloader, "remove_resource", new_name);
@@ -131,7 +131,7 @@ void ResourcePreloaderEditor::_item_edited() {
 }
 
 void ResourcePreloaderEditor::_remove_resource(const String &p_to_remove) {
-	undo_redo->create_action(TTR("Delete Resource"));
+	undo_redo->create_action(vformat(TTR("Delete Resource \"%s\" from ResourcePreloader \"%s\""), p_to_remove, preloader->get_name()));
 	undo_redo->add_do_method(preloader, "remove_resource", p_to_remove);
 	undo_redo->add_undo_method(preloader, "add_resource", p_to_remove, preloader->get_resource(p_to_remove));
 	undo_redo->add_do_method(this, "_update_library");
@@ -164,7 +164,7 @@ void ResourcePreloaderEditor::_paste_pressed() {
 		name = basename + " " + itos(counter);
 	}
 
-	undo_redo->create_action(TTR("Paste Resource"));
+	undo_redo->create_action(vformat(TTR("Paste Resource \"%s\" in ResourcePreloader \"%s\""), name, preloader->get_name()));
 	undo_redo->add_do_method(preloader, "add_resource", name, r);
 	undo_redo->add_undo_method(preloader, "remove_resource", name);
 	undo_redo->add_do_method(this, "_update_library");
@@ -318,7 +318,7 @@ void ResourcePreloaderEditor::drop_data_fw(const Point2 &p_point, const Variant 
 				name = basename + "_" + itos(counter);
 			}
 
-			undo_redo->create_action(TTR("Add Resource"));
+			undo_redo->create_action(vformat(TTR("Add Resource \"%s\" to ResourcePreloader \"%s\""), name, preloader->get_name()));
 			undo_redo->add_do_method(preloader, "add_resource", name, r);
 			undo_redo->add_undo_method(preloader, "remove_resource", name);
 			undo_redo->add_do_method(this, "_update_library");

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -336,7 +336,7 @@ void Sprite2DEditor::_convert_to_mesh_2d_node() {
 	mesh_instance->set_mesh(mesh);
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-	ur->create_action(TTR("Convert to Mesh2D"));
+	ur->create_action(vformat(TTR("Convert Sprite2D \"%s\" to MeshInstance2D"), node->get_name()));
 	ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, mesh_instance, true, false);
 	ur->add_do_reference(mesh_instance);
 	ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", mesh_instance, node, false, false);
@@ -394,7 +394,7 @@ void Sprite2DEditor::_convert_to_polygon_2d_node() {
 	polygon_2d_instance->set_polygons(polys);
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-	ur->create_action(TTR("Convert to Polygon2D"));
+	ur->create_action(vformat(TTR("Convert Sprite2D \"%s\" to Polygon2D"), node->get_name()));
 	ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, polygon_2d_instance, true, false);
 	ur->add_do_reference(polygon_2d_instance);
 	ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", polygon_2d_instance, node, false, false);
@@ -416,7 +416,7 @@ void Sprite2DEditor::_create_collision_polygon_2d_node() {
 		collision_polygon_2d_instance->set_polygon(outline);
 
 		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Create CollisionPolygon2D Sibling"));
+		ur->create_action(vformat(TTR("Create CollisionPolygon2D Sibling for Sprite2D \"%s\""), node->get_name()));
 		ur->add_do_method(this, "_add_as_sibling_or_child", node, collision_polygon_2d_instance);
 		ur->add_do_reference(collision_polygon_2d_instance);
 		ur->add_undo_method(node != this->get_tree()->get_edited_scene_root() ? node->get_parent() : this->get_tree()->get_edited_scene_root(), "remove_child", collision_polygon_2d_instance);
@@ -449,7 +449,7 @@ void Sprite2DEditor::_create_light_occluder_2d_node() {
 		light_occluder_2d_instance->set_occluder_polygon(polygon);
 
 		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Create LightOccluder2D Sibling"));
+		ur->create_action(vformat(TTR("Create LightOccluder2D Sibling for Sprite2D \"%s\""), node->get_name()));
 		ur->add_do_method(this, "_add_as_sibling_or_child", node, light_occluder_2d_instance);
 		ur->add_do_reference(light_occluder_2d_instance);
 		ur->add_undo_method(node != this->get_tree()->get_edited_scene_root() ? node->get_parent() : this->get_tree()->get_edited_scene_root(), "remove_child", light_occluder_2d_instance);

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -622,7 +622,7 @@ void SpriteFramesEditor::_animation_name_edited() {
 	List<Node *> nodes;
 	_find_anim_sprites(EditorNode::get_singleton()->get_edited_scene(), &nodes, Ref<SpriteFrames>(frames));
 
-	undo_redo->create_action(TTR("Rename Animation"));
+	undo_redo->create_action(vformat(TTR("Rename SpriteFrames Animation from \"%s\" to \"%s\""), edited_anim, name));
 	undo_redo->add_do_method(frames, "rename_animation", edited_anim, name);
 	undo_redo->add_undo_method(frames, "rename_animation", name, edited_anim);
 
@@ -651,7 +651,7 @@ void SpriteFramesEditor::_animation_add() {
 	List<Node *> nodes;
 	_find_anim_sprites(EditorNode::get_singleton()->get_edited_scene(), &nodes, Ref<SpriteFrames>(frames));
 
-	undo_redo->create_action(TTR("Add Animation"));
+	undo_redo->create_action(vformat(TTR("Add SpriteFrames Animation \"%s\""), name));
 	undo_redo->add_do_method(frames, "add_animation", name);
 	undo_redo->add_undo_method(frames, "remove_animation", name);
 	undo_redo->add_do_method(this, "_update_library");
@@ -683,7 +683,7 @@ void SpriteFramesEditor::_animation_remove() {
 }
 
 void SpriteFramesEditor::_animation_remove_confirmed() {
-	undo_redo->create_action(TTR("Remove Animation"));
+	undo_redo->create_action(vformat(TTR("Remove SpriteFrames Animation \"%s\""), edited_anim));
 	undo_redo->add_do_method(frames, "remove_animation", edited_anim);
 	undo_redo->add_undo_method(frames, "add_animation", edited_anim);
 	undo_redo->add_undo_method(frames, "set_animation_speed", edited_anim, frames->get_animation_speed(edited_anim));
@@ -706,7 +706,11 @@ void SpriteFramesEditor::_animation_loop_changed() {
 		return;
 	}
 
-	undo_redo->create_action(TTR("Change Animation Loop"));
+	if (anim_loop->is_pressed()) {
+		undo_redo->create_action(vformat(TTR("Enable SpriteFrames Animation \"%s\" Loop"), edited_anim));
+	} else {
+		undo_redo->create_action(vformat(TTR("Disable SpriteFrames Animation \"%s\" Loop"), edited_anim));
+	}
 	undo_redo->add_do_method(frames, "set_animation_loop", edited_anim, anim_loop->is_pressed());
 	undo_redo->add_undo_method(frames, "set_animation_loop", edited_anim, frames->get_animation_loop(edited_anim));
 	undo_redo->add_do_method(this, "_update_library", true);
@@ -719,7 +723,12 @@ void SpriteFramesEditor::_animation_fps_changed(double p_value) {
 		return;
 	}
 
-	undo_redo->create_action(TTR("Change Animation FPS"), UndoRedo::MERGE_ENDS);
+	undo_redo->create_action(
+			vformat(TTR("Change SpriteFrames Animation \"%s\" FPS from %.2f to %.2f"),
+					edited_anim,
+					frames->get_animation_speed(edited_anim),
+					p_value),
+			UndoRedo::MERGE_ENDS);
 	undo_redo->add_do_method(frames, "set_animation_speed", edited_anim, p_value);
 	undo_redo->add_undo_method(frames, "set_animation_speed", edited_anim, frames->get_animation_speed(edited_anim));
 	undo_redo->add_do_method(this, "_update_library", true);
@@ -970,7 +979,7 @@ void SpriteFramesEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 					from_frame = d["frame"];
 				}
 
-				undo_redo->create_action(TTR("Move Frame"));
+				undo_redo->create_action(vformat(TTR("Move Frame in SpriteFrames Animation \"%s\""), edited_anim));
 				undo_redo->add_do_method(frames, "remove_frame", edited_anim, from_frame == -1 ? frames->get_frame_count(edited_anim) : from_frame);
 				undo_redo->add_do_method(frames, "add_frame", edited_anim, texture, at_pos == -1 ? -1 : at_pos);
 				undo_redo->add_undo_method(frames, "remove_frame", edited_anim, at_pos == -1 ? frames->get_frame_count(edited_anim) - 1 : at_pos);
@@ -979,7 +988,7 @@ void SpriteFramesEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				undo_redo->add_undo_method(this, "_update_library");
 				undo_redo->commit_action();
 			} else {
-				undo_redo->create_action(TTR("Add Frame"));
+				undo_redo->create_action(vformat(TTR("Add Frame to SpriteFrames Animation \"%s\""), edited_anim));
 				undo_redo->add_do_method(frames, "add_frame", edited_anim, texture, at_pos == -1 ? -1 : at_pos);
 				undo_redo->add_undo_method(frames, "remove_frame", edited_anim, at_pos == -1 ? frames->get_frame_count(edited_anim) : at_pos);
 				undo_redo->add_do_method(this, "_update_library");

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -347,7 +347,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 								rect.expand_to(r.position);
 								rect.expand_to(r.position + r.size);
 							}
-							undo_redo->create_action(TTR("Set Region Rect"));
+							undo_redo->create_action(TTR("Set TextureRegion Rect"));
 							if (node_sprite) {
 								undo_redo->add_do_method(node_sprite, "set_region_rect", rect);
 								undo_redo->add_undo_method(node_sprite, "set_region_rect", node_sprite->get_region_rect());
@@ -407,7 +407,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 
 			} else if (drag) {
 				if (edited_margin >= 0) {
-					undo_redo->create_action(TTR("Set Margin"));
+					undo_redo->create_action(TTR("Set TextureRegion Margin"));
 					static Side side[4] = { SIDE_TOP, SIDE_BOTTOM, SIDE_LEFT, SIDE_RIGHT };
 					if (node_ninepatch) {
 						undo_redo->add_do_method(node_ninepatch, "set_patch_margin", side[edited_margin], node_ninepatch->get_patch_margin(side[edited_margin]));
@@ -419,7 +419,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					}
 					edited_margin = -1;
 				} else {
-					undo_redo->create_action(TTR("Set Region Rect"));
+					undo_redo->create_action(TTR("Set TextureRegion Rect"));
 					if (node_sprite) {
 						undo_redo->add_do_method(node_sprite, "set_region_rect", node_sprite->get_region_rect());
 						undo_redo->add_undo_method(node_sprite, "set_region_rect", rect_prev);

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -408,7 +408,7 @@ bool TileMapEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p
 		if (ED_IS_SHORTCUT("tiles_editor/cut", p_event)) {
 			// Delete selected tiles.
 			if (!tile_map_selection.is_empty()) {
-				undo_redo->create_action(TTR("Delete tiles"));
+				undo_redo->create_action(TTR("Delete Tiles"));
 				for (Set<Vector2i>::Element *E = tile_map_selection.front(); E; E = E->next()) {
 					undo_redo->add_do_method(tile_map, "set_cell", E->get(), -1, TileSetSource::INVALID_ATLAS_COORDS, TileSetSource::INVALID_TILE_ALTERNATIVE);
 					undo_redo->add_undo_method(tile_map, "set_cell", E->get(), tile_map->get_cell_source_id(E->get()), tile_map->get_cell_atlas_coords(E->get()), tile_map->get_cell_alternative_tile(E->get()));
@@ -439,7 +439,7 @@ bool TileMapEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p
 	if (ED_IS_SHORTCUT("tiles_editor/delete", p_event)) {
 		// Delete selected tiles.
 		if (!tile_map_selection.is_empty()) {
-			undo_redo->create_action(TTR("Delete tiles"));
+			undo_redo->create_action(TTR("Delete Tiles"));
 			for (Set<Vector2i>::Element *E = tile_map_selection.front(); E; E = E->next()) {
 				undo_redo->add_do_method(tile_map, "set_cell", E->get(), -1, TileSetSource::INVALID_ATLAS_COORDS, TileSetSource::INVALID_TILE_ALTERNATIVE);
 				undo_redo->add_undo_method(tile_map, "set_cell", E->get(), tile_map->get_cell_source_id(E->get()), tile_map->get_cell_atlas_coords(E->get()), tile_map->get_cell_alternative_tile(E->get()));
@@ -1087,7 +1087,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 
 	switch (drag_type) {
 		case DRAG_TYPE_SELECT: {
-			undo_redo->create_action(TTR("Change selection"));
+			undo_redo->create_action(TTR("Change Selection"));
 			undo_redo->add_undo_method(this, "_set_tile_map_selection", _get_tile_map_selection());
 
 			if (!Input::get_singleton()->is_key_pressed(KEY_SHIFT) && !Input::get_singleton()->is_key_pressed(KEY_CTRL)) {
@@ -1146,7 +1146,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 				coords = tile_map->map_pattern(top_left + offset, selection_used_cells[i], selection_pattern);
 				cells_do[coords] = TileMapCell(selection_pattern->get_cell_source_id(selection_used_cells[i]), selection_pattern->get_cell_atlas_coords(selection_used_cells[i]), selection_pattern->get_cell_alternative_tile(selection_used_cells[i]));
 			}
-			undo_redo->create_action(TTR("Move tiles"));
+			undo_redo->create_action(TTR("Move Tiles"));
 			// Move the tiles.
 			for (Map<Vector2i, TileMapCell>::Element *E = cells_do.front(); E; E = E->next()) {
 				undo_redo->add_do_method(tile_map, "set_cell", E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
@@ -1187,7 +1187,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 			picker_button->set_pressed(false);
 		} break;
 		case DRAG_TYPE_PAINT: {
-			undo_redo->create_action(TTR("Paint tiles"));
+			undo_redo->create_action(TTR("Paint Tiles"));
 			for (Map<Vector2i, TileMapCell>::Element *E = drag_modified.front(); E; E = E->next()) {
 				undo_redo->add_do_method(tile_map, "set_cell", E->key(), tile_map->get_cell_source_id(E->key()), tile_map->get_cell_atlas_coords(E->key()), tile_map->get_cell_alternative_tile(E->key()));
 				undo_redo->add_undo_method(tile_map, "set_cell", E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);
@@ -1196,7 +1196,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 		} break;
 		case DRAG_TYPE_LINE: {
 			Map<Vector2i, TileMapCell> to_draw = _draw_line(drag_start_mouse_pos, drag_start_mouse_pos, mpos);
-			undo_redo->create_action(TTR("Paint tiles"));
+			undo_redo->create_action(TTR("Paint Tiles"));
 			for (Map<Vector2i, TileMapCell>::Element *E = to_draw.front(); E; E = E->next()) {
 				if (!erase_button->is_pressed() && E->get().source_id == -1) {
 					continue;
@@ -1208,7 +1208,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 		} break;
 		case DRAG_TYPE_RECT: {
 			Map<Vector2i, TileMapCell> to_draw = _draw_rect(tile_map->world_to_map(drag_start_mouse_pos), tile_map->world_to_map(mpos));
-			undo_redo->create_action(TTR("Paint tiles"));
+			undo_redo->create_action(TTR("Paint Tiles"));
 			for (Map<Vector2i, TileMapCell>::Element *E = to_draw.front(); E; E = E->next()) {
 				if (!erase_button->is_pressed() && E->get().source_id == -1) {
 					continue;
@@ -1219,7 +1219,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 			undo_redo->commit_action();
 		} break;
 		case DRAG_TYPE_BUCKET: {
-			undo_redo->create_action(TTR("Paint tiles"));
+			undo_redo->create_action(TTR("Paint Tiles"));
 			for (Map<Vector2i, TileMapCell>::Element *E = drag_modified.front(); E; E = E->next()) {
 				if (!erase_button->is_pressed() && E->get().source_id == -1) {
 					continue;
@@ -1231,7 +1231,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 		} break;
 		case DRAG_TYPE_CLIPBOARD_PASTE: {
 			Vector2 mouse_offset = (Vector2(tile_map_clipboard->get_size()) / 2.0 - Vector2(0.5, 0.5)) * tile_set->get_tile_size();
-			undo_redo->create_action(TTR("Paste tiles"));
+			undo_redo->create_action(TTR("Paste Tiles"));
 			TypedArray<Vector2i> used_cells = tile_map_clipboard->get_used_cells();
 			for (int i = 0; i < used_cells.size(); i++) {
 				Vector2i coords = tile_map->map_pattern(tile_map->world_to_map(mpos - mouse_offset), used_cells[i], tile_map_clipboard);
@@ -2823,7 +2823,7 @@ bool TileMapEditorTerrainsPlugin::forward_canvas_gui_input(const Ref<InputEvent>
 						picker_button->set_pressed(false);
 					} break;
 					case DRAG_TYPE_PAINT: {
-						undo_redo->create_action(TTR("Paint terrain"));
+						undo_redo->create_action(TTR("Paint Terrain"));
 						for (Map<Vector2i, TileMapCell>::Element *E = drag_modified.front(); E; E = E->next()) {
 							undo_redo->add_do_method(tile_map, "set_cell", E->key(), tile_map->get_cell_source_id(E->key()), tile_map->get_cell_atlas_coords(E->key()), tile_map->get_cell_alternative_tile(E->key()));
 							undo_redo->add_undo_method(tile_map, "set_cell", E->key(), E->get().source_id, E->get().get_atlas_coords(), E->get().alternative_tile);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -817,7 +817,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 				// Set the selection if needed.
 				if (selection.size() <= 1) {
 					if (selected.tile != TileSetSource::INVALID_ATLAS_COORDS) {
-						undo_redo->create_action(TTR("Select tiles"));
+						undo_redo->create_action(TTR("Select Tiles"));
 						undo_redo->add_undo_method(this, "_set_selection_from_array", _get_selection_as_array());
 						selection.clear();
 						selection.insert(selected);
@@ -857,7 +857,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 void TileSetAtlasSourceEditor::_end_dragging() {
 	switch (drag_type) {
 		case DRAG_TYPE_CREATE_TILES:
-			undo_redo->create_action(TTR("Create tiles"));
+			undo_redo->create_action(TTR("Create Tiles"));
 			for (Set<Vector2i>::Element *E = drag_modified_tiles.front(); E; E = E->next()) {
 				undo_redo->add_do_method(tile_set_atlas_source, "create_tile", E->get());
 				undo_redo->add_undo_method(tile_set_atlas_source, "remove_tile", E->get());
@@ -865,7 +865,7 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 			undo_redo->commit_action(false);
 			break;
 		case DRAG_TYPE_CREATE_BIG_TILE:
-			undo_redo->create_action(TTR("Create a tile"));
+			undo_redo->create_action(TTR("Create Big Tile"));
 			undo_redo->add_do_method(tile_set_atlas_source, "create_tile", drag_current_tile, tile_set_atlas_source->get_tile_size_in_atlas(drag_current_tile));
 			undo_redo->add_undo_method(tile_set_atlas_source, "remove_tile", drag_current_tile);
 			undo_redo->commit_action(false);
@@ -874,7 +874,7 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 			List<PropertyInfo> list;
 			tile_set_atlas_source->get_property_list(&list);
 			Map<Vector2i, List<const PropertyInfo *>> per_tile = _group_properties_per_tiles(list, tile_set_atlas_source);
-			undo_redo->create_action(TTR("Remove tiles"));
+			undo_redo->create_action(TTR("Remove Tiles"));
 			for (Set<Vector2i>::Element *E = drag_modified_tiles.front(); E; E = E->next()) {
 				Vector2i coords = E->get();
 				undo_redo->add_do_method(tile_set_atlas_source, "remove_tile", coords);
@@ -896,7 +896,7 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 			Vector2i new_base_tiles_coords = tile_atlas_view->get_atlas_tile_coords_at_pos(tile_atlas_control->get_local_mouse_position());
 			Rect2i area = Rect2i(start_base_tiles_coords, new_base_tiles_coords - start_base_tiles_coords).abs();
 			area.set_end((area.get_end() + Vector2i(1, 1)).min(tile_set_atlas_source->get_atlas_grid_size()));
-			undo_redo->create_action(TTR("Create tiles"));
+			undo_redo->create_action(TTR("Create Tiles"));
 			for (int x = area.get_position().x; x < area.get_end().x; x++) {
 				for (int y = area.get_position().y; y < area.get_end().y; y++) {
 					Vector2i coords = Vector2i(x, y);
@@ -927,7 +927,7 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 				}
 			}
 
-			undo_redo->create_action(TTR("Remove tiles"));
+			undo_redo->create_action(TTR("Remove Tiles"));
 			undo_redo->add_do_method(this, "_set_selection_from_array", Array());
 			for (Set<Vector2i>::Element *E = to_delete.front(); E; E = E->next()) {
 				Vector2i coords = E->get();
@@ -948,7 +948,7 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 		} break;
 		case DRAG_TYPE_MOVE_TILE:
 			if (drag_current_tile != drag_start_tile_shape.position) {
-				undo_redo->create_action(TTR("Move a tile"));
+				undo_redo->create_action(TTR("Move Tile"));
 				undo_redo->add_do_method(tile_set_atlas_source, "move_tile_in_atlas", drag_start_tile_shape.position, drag_current_tile, tile_set_atlas_source->get_tile_size_in_atlas(drag_current_tile));
 				undo_redo->add_do_method(this, "_set_selection_from_array", _get_selection_as_array());
 				undo_redo->add_undo_method(tile_set_atlas_source, "move_tile_in_atlas", drag_current_tile, drag_start_tile_shape.position, drag_start_tile_shape.size);
@@ -968,7 +968,7 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 			Rect2i region = Rect2i(start_base_tiles_coords, new_base_tiles_coords - start_base_tiles_coords).abs();
 			region.size += Vector2i(1, 1);
 
-			undo_redo->create_action(TTR("Select tiles"));
+			undo_redo->create_action(TTR("Select Tiles"));
 			undo_redo->add_undo_method(this, "_set_selection_from_array", _get_selection_as_array());
 
 			// Determine if we clear, then add or remove to the selection.
@@ -1013,7 +1013,7 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 		case DRAG_TYPE_RESIZE_BOTTOM_LEFT:
 		case DRAG_TYPE_RESIZE_LEFT:
 			if (drag_start_tile_shape != Rect2i(drag_current_tile, tile_set_atlas_source->get_tile_size_in_atlas(drag_current_tile))) {
-				undo_redo->create_action(TTR("Resize a tile"));
+				undo_redo->create_action(TTR("Resize Tile"));
 				undo_redo->add_do_method(tile_set_atlas_source, "move_tile_in_atlas", drag_start_tile_shape.position, drag_current_tile, tile_set_atlas_source->get_tile_size_in_atlas(drag_current_tile));
 				undo_redo->add_do_method(this, "_set_selection_from_array", _get_selection_as_array());
 				undo_redo->add_undo_method(tile_set_atlas_source, "move_tile_in_atlas", drag_current_tile, drag_start_tile_shape.position, drag_start_tile_shape.size);
@@ -1055,7 +1055,7 @@ void TileSetAtlasSourceEditor::_menu_option(int p_option) {
 			List<PropertyInfo> list;
 			tile_set_atlas_source->get_property_list(&list);
 			Map<Vector2i, List<const PropertyInfo *>> per_tile = _group_properties_per_tiles(list, tile_set_atlas_source);
-			undo_redo->create_action(TTR("Remove tile"));
+			undo_redo->create_action(TTR("Remove Tile"));
 
 			// Remove tiles
 			Set<Vector2i> removed;
@@ -1104,7 +1104,7 @@ void TileSetAtlasSourceEditor::_menu_option(int p_option) {
 			_update_tile_id_label();
 		} break;
 		case TILE_CREATE: {
-			undo_redo->create_action(TTR("Create a tile"));
+			undo_redo->create_action(TTR("Create Tile"));
 			undo_redo->add_do_method(tile_set_atlas_source, "create_tile", menu_option_coords);
 			Array array;
 			array.push_back(menu_option_coords);
@@ -1116,7 +1116,7 @@ void TileSetAtlasSourceEditor::_menu_option(int p_option) {
 			_update_tile_id_label();
 		} break;
 		case TILE_CREATE_ALTERNATIVE: {
-			undo_redo->create_action(TTR("Create tile alternatives"));
+			undo_redo->create_action(TTR("Create Tile Alternatives"));
 			Array array;
 			for (Set<TileSelection>::Element *E = selection.front(); E; E = E->next()) {
 				if (E->get().alternative == 0) {
@@ -1518,7 +1518,7 @@ void TileSetAtlasSourceEditor::_auto_create_tiles() {
 		Vector2i separation = tile_set_atlas_source->get_separation();
 		Vector2i texture_region_size = tile_set_atlas_source->get_texture_region_size();
 		Size2i grid_size = tile_set_atlas_source->get_atlas_grid_size();
-		undo_redo->create_action(TTR("Create tiles in non-transparent texture regions"));
+		undo_redo->create_action(TTR("Create Tiles in Non-Transparent Texture Regions"));
 		for (int y = 0; y < grid_size.y; y++) {
 			for (int x = 0; x < grid_size.x; x++) {
 				// Check if we have a tile at the coord
@@ -1563,7 +1563,7 @@ void TileSetAtlasSourceEditor::_auto_remove_tiles() {
 		Vector2i texture_region_size = tile_set_atlas_source->get_texture_region_size();
 		Vector2i grid_size = tile_set_atlas_source->get_atlas_grid_size();
 
-		undo_redo->create_action(TTR("Remove tiles in fully transparent texture regions"));
+		undo_redo->create_action(TTR("Remove Tiles in Fully Transparent Texture Regions"));
 
 		List<PropertyInfo> list;
 		tile_set_atlas_source->get_property_list(&list);

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -63,7 +63,7 @@ void TileSetEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 				// Actually create the new source.
 				Ref<TileSetAtlasSource> atlas_source = memnew(TileSetAtlasSource);
 				atlas_source->set_texture(resource);
-				undo_redo->create_action(TTR("Add a new atlas source"));
+				undo_redo->create_action(TTR("Add New TileSet Atlas Source"));
 				undo_redo->add_do_method(*tile_set, "add_source", atlas_source, source_id);
 				undo_redo->add_do_method(*atlas_source, "set_texture_region_size", tile_set->get_tile_size());
 				undo_redo->add_undo_method(*tile_set, "remove_source", source_id);
@@ -245,7 +245,7 @@ void TileSetEditor::_source_add_id_pressed(int p_id_pressed) {
 			Ref<TileSetAtlasSource> atlas_source = memnew(TileSetAtlasSource);
 
 			// Add a new source.
-			undo_redo->create_action(TTR("Add atlas source"));
+			undo_redo->create_action(TTR("Add TileSet Atlas Source"));
 			undo_redo->add_do_method(*tile_set, "add_source", atlas_source, source_id);
 			undo_redo->add_do_method(*atlas_source, "set_texture_region_size", tile_set->get_tile_size());
 			undo_redo->add_undo_method(*tile_set, "remove_source", source_id);
@@ -259,7 +259,7 @@ void TileSetEditor::_source_add_id_pressed(int p_id_pressed) {
 			Ref<TileSetScenesCollectionSource> scene_collection_source = memnew(TileSetScenesCollectionSource);
 
 			// Add a new source.
-			undo_redo->create_action(TTR("Add atlas source"));
+			undo_redo->create_action(TTR("Add TileSet Atlas Source"));
 			undo_redo->add_do_method(*tile_set, "add_source", scene_collection_source, source_id);
 			undo_redo->add_undo_method(*tile_set, "remove_source", source_id);
 			undo_redo->commit_action();
@@ -280,7 +280,7 @@ void TileSetEditor::_source_delete_pressed() {
 	Ref<TileSetSource> source = tile_set->get_source(to_delete);
 
 	// Remove the source.
-	undo_redo->create_action(TTR("Remove source"));
+	undo_redo->create_action(TTR("Remove TileSet Source"));
 	undo_redo->add_do_method(*tile_set, "remove_source", to_delete);
 	undo_redo->add_undo_method(*tile_set, "add_source", source, to_delete);
 	undo_redo->commit_action();

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -211,7 +211,7 @@ void TileSetScenesCollectionSourceEditor::_scenes_list_item_activated(int p_inde
 
 void TileSetScenesCollectionSourceEditor::_source_add_pressed() {
 	int scene_id = tile_set_scenes_collection_source->get_next_scene_tile_id();
-	undo_redo->create_action(TTR("Add a Scene Tile"));
+	undo_redo->create_action(TTR("Add Scene Tile"));
 	undo_redo->add_do_method(tile_set_scenes_collection_source, "create_scene_tile", Ref<PackedScene>(), scene_id);
 	undo_redo->add_undo_method(tile_set_scenes_collection_source, "remove_scene_tile", scene_id);
 	undo_redo->commit_action();
@@ -225,7 +225,7 @@ void TileSetScenesCollectionSourceEditor::_source_delete_pressed() {
 	ERR_FAIL_COND(selected_indices.size() <= 0);
 	int scene_id = scene_tiles_list->get_item_metadata(selected_indices[0]);
 
-	undo_redo->create_action(TTR("Remove a Scene Tile"));
+	undo_redo->create_action(TTR("Remove Scene Tile"));
 	undo_redo->add_do_method(tile_set_scenes_collection_source, "remove_scene_tile", scene_id);
 	undo_redo->add_undo_method(tile_set_scenes_collection_source, "create_scene_tile", tile_set_scenes_collection_source->get_scene_tile_scene(scene_id), scene_id);
 	undo_redo->commit_action();
@@ -377,7 +377,7 @@ void TileSetScenesCollectionSourceEditor::drop_data_fw(const Point2 &p_point, co
 			Ref<PackedScene> resource = ResourceLoader::load(files[i]);
 			if (resource.is_valid()) {
 				scene_id = tile_set_scenes_collection_source->get_next_scene_tile_id();
-				undo_redo->create_action(TTR("Add a Scene Tile"));
+				undo_redo->create_action(TTR("Add Scene Tile"));
 				undo_redo->add_do_method(tile_set_scenes_collection_source, "create_scene_tile", resource, scene_id);
 				undo_redo->add_undo_method(tile_set_scenes_collection_source, "remove_scene_tile", scene_id);
 				undo_redo->commit_action();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -95,7 +95,7 @@ void ProjectSettingsEditor::_add_setting() {
 	Variant value;
 	Variant::construct(Variant::Type(type_box->get_selected_id()), value, nullptr, 0, ce);
 
-	undo_redo->create_action(TTR("Add Project Setting"));
+	undo_redo->create_action(vformat(TTR("Add Project Setting \"%s\""), setting));
 	undo_redo->add_do_property(ps, setting, value);
 	undo_redo->add_undo_property(ps, setting, ps->has_setting(setting) ? ps->get(setting) : Variant());
 
@@ -114,7 +114,7 @@ void ProjectSettingsEditor::_delete_setting() {
 	Variant value = ps->get(setting);
 	int order = ps->get_order(setting);
 
-	undo_redo->create_action(TTR("Delete Item"));
+	undo_redo->create_action(vformat(TTR("Delete Project Setting \"%s\""), setting));
 
 	undo_redo->add_do_method(ps, "clear", setting);
 	undo_redo->add_undo_method(ps, "set", setting, value);
@@ -285,7 +285,7 @@ void ProjectSettingsEditor::_action_added(const String &p_name) {
 	action["events"] = Array();
 	action["deadzone"] = 0.5f;
 
-	undo_redo->create_action(TTR("Add Input Action"));
+	undo_redo->create_action(vformat(TTR("Add Input Action \"%s\""), p_name));
 	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
 	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", name);
 
@@ -302,7 +302,7 @@ void ProjectSettingsEditor::_action_edited(const String &p_name, const Dictionar
 
 	if (old_val["deadzone"] != p_action["deadzone"]) {
 		// Deadzone Changed
-		undo_redo->create_action(TTR("Change Action deadzone"));
+		undo_redo->create_action(vformat(TTR("Change Action \"%s\" Deadzone from %.2f to %.2f"), p_name, old_val["deadzone"], p_action["deadzone"]));
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", property_name, p_action);
 		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", property_name, old_val);
 
@@ -312,11 +312,11 @@ void ProjectSettingsEditor::_action_edited(const String &p_name, const Dictionar
 		int old_event_count = ((Array)old_val["events"]).size();
 
 		if (event_count == old_event_count) {
-			undo_redo->create_action(TTR("Edit Input Action Event"));
+			undo_redo->create_action(vformat(TTR("Edit Input Action Event in \"%s\""), p_name));
 		} else if (event_count > old_event_count) {
-			undo_redo->create_action(TTR("Add Input Action Event"));
+			undo_redo->create_action(vformat(TTR("Add Input Action Event to \"%s\""), p_name));
 		} else if (event_count < old_event_count) {
-			undo_redo->create_action(TTR("Remove Input Action Event"));
+			undo_redo->create_action(vformat(TTR("Remove Input Action Event from \"%s\""), p_name));
 		}
 
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", property_name, p_action);
@@ -336,7 +336,7 @@ void ProjectSettingsEditor::_action_removed(const String &p_name) {
 	Dictionary old_val = ProjectSettings::get_singleton()->get(property_name);
 	int order = ProjectSettings::get_singleton()->get_order(property_name);
 
-	undo_redo->create_action(TTR("Erase Input Action"));
+	undo_redo->create_action(TTR(vformat("Remove Input Action \"%s\""), p_name));
 	undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", property_name);
 	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", property_name, old_val);
 	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", property_name, order);
@@ -360,7 +360,7 @@ void ProjectSettingsEditor::_action_renamed(const String &p_old_name, const Stri
 	int order = ProjectSettings::get_singleton()->get_order(old_property_name);
 	Dictionary action = ProjectSettings::get_singleton()->get(old_property_name);
 
-	undo_redo->create_action(TTR("Rename Input Action Event"));
+	undo_redo->create_action(vformat(TTR("Rename Input Action from \"%s\" to \"%s\""), p_old_name, p_new_name));
 	// Do: clear old, set new
 	undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", old_property_name);
 	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", new_property_name, action);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2141,7 +2141,11 @@ void SceneTreeDock::_create() {
 		ERR_FAIL_COND(selection.size() <= 0);
 
 		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change type of node(s)"));
+		if (selection.size() != 1) {
+			ur->create_action(vformat(TTR("Change Type of %d Nodes"), selection.size()));
+		} else {
+			ur->create_action(vformat(TTR("Change Type of Node \"%s\""), selection[0]->get_name()));
+		}
 
 		for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 			Node *n = E->get();
@@ -2467,7 +2471,7 @@ void SceneTreeDock::_script_dropped(String p_file, NodePath p_to) {
 	ERR_FAIL_COND(!scr.is_valid());
 	Node *n = get_node(p_to);
 	if (n) {
-		editor_data->get_undo_redo().create_action(TTR("Attach Script"));
+		editor_data->get_undo_redo().create_action(vformat(TTR("Attach Script \"%s\" to Node \"%s\""), scr->get_path(), n->get_name()));
 		editor_data->get_undo_redo().add_do_method(n, "set_script", scr);
 		editor_data->get_undo_redo().add_undo_method(n, "set_script", n->get_script());
 		editor_data->get_undo_redo().add_do_method(this, "_update_script_button");

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -108,7 +108,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		}
 
 	} else if (p_id == BUTTON_GROUP) {
-		undo_redo->create_action(TTR("Button Group"));
+		undo_redo->create_action(TTR("Group Node"));
 
 		if (n->is_class("CanvasItem") || n->is_class("Node3D")) {
 			undo_redo->add_do_method(n, "remove_meta", "_edit_group_");
@@ -807,7 +807,7 @@ void SceneTreeEditor::_renamed() {
 		which->set_metadata(0, n->get_path());
 		emit_signal("node_renamed");
 	} else {
-		undo_redo->create_action(TTR("Rename Node"));
+		undo_redo->create_action(vformat(TTR("Rename Node from \"%s\" to \"%s\""), n->get_name(), new_name));
 		emit_signal("node_prerename", n, new_name);
 		undo_redo->add_do_method(this, "_rename_node", n->get_instance_id(), new_name);
 		undo_redo->add_undo_method(this, "_rename_node", n->get_instance_id(), n->get_name());

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -221,7 +221,7 @@ void EditorSettingsDialog::_event_config_confirmed() {
 void EditorSettingsDialog::_update_builtin_action(const String &p_name, const Array &p_events) {
 	Array old_input_array = EditorSettings::get_singleton()->get_builtin_action_overrides(current_action);
 
-	undo_redo->create_action(TTR("Edit Built-in Action"));
+	undo_redo->create_action(vformat(TTR("Edit Built-in Action \"%s\""), p_name));
 	undo_redo->add_do_method(EditorSettings::get_singleton(), "set_builtin_action_override", p_name, p_events);
 	undo_redo->add_undo_method(EditorSettings::get_singleton(), "set_builtin_action_override", p_name, old_input_array);
 	undo_redo->add_do_method(this, "_settings_changed");

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -84,7 +84,7 @@ protected:
 
 		UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
-		undo_redo->create_action("Set Shader Global Variable");
+		undo_redo->create_action(vformat(TTR("Set Shader Global Variable \"%s\""), p_name));
 		undo_redo->add_do_method(RS::get_singleton(), "global_variable_set", p_name, p_value);
 		undo_redo->add_undo_method(RS::get_singleton(), "global_variable_set", p_name, existing);
 		RS::GlobalVariableType type = RS::get_singleton()->global_variable_get_type(p_name);
@@ -395,7 +395,7 @@ void ShaderGlobalsEditor::_variable_added() {
 
 	Variant value = create_var(RS::GlobalVariableType(variable_type->get_selected()));
 
-	undo_redo->create_action("Add Shader Global Variable");
+	undo_redo->create_action(TTR("Add Shader Global Variable"));
 	undo_redo->add_do_method(RS::get_singleton(), "global_variable_add", var, RS::GlobalVariableType(variable_type->get_selected()), value);
 	undo_redo->add_undo_method(RS::get_singleton(), "global_variable_remove", var);
 	Dictionary gv;
@@ -413,7 +413,7 @@ void ShaderGlobalsEditor::_variable_deleted(const String &p_variable) {
 	print_line("deleted " + p_variable);
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
-	undo_redo->create_action("Add Shader Global Variable");
+	undo_redo->create_action(TTR("Add Shader Global Variable"));
 	undo_redo->add_do_method(RS::get_singleton(), "global_variable_remove", p_variable);
 	undo_redo->add_undo_method(RS::get_singleton(), "global_variable_add", p_variable, RS::get_singleton()->global_variable_get_type(p_variable), RS::get_singleton()->global_variable_get(p_variable));
 

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -204,7 +204,7 @@ void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx,
 		}
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Sphere Shape Radius"));
+		ur->create_action(vformat(TTR("Change CSGSphere3D \"%s\" Shape Radius from %.2f to %.2f"), s->get_name(), p_restore, s->get_radius()));
 		ur->add_do_method(s, "set_radius", s->get_radius());
 		ur->add_undo_method(s, "set_radius", p_restore);
 		ur->commit_action();
@@ -218,7 +218,7 @@ void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx,
 		}
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Change Box Shape Size"));
+		ur->create_action(vformat(TTR("Change CSGBox3D \"%s\" Shape Size from %s to %s"), s->get_name(), p_restore, s->get_size()));
 		ur->add_do_method(s, "set_size", s->get_size());
 		ur->add_undo_method(s, "set_size", p_restore);
 		ur->commit_action();
@@ -237,11 +237,11 @@ void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx,
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		if (p_idx == 0) {
-			ur->create_action(TTR("Change Cylinder Radius"));
+			ur->create_action(vformat(TTR("Change CSGCylinder3D \"%s\" Radius from %.2f to %.2f"), s->get_name(), p_restore, s->get_radius()));
 			ur->add_do_method(s, "set_radius", s->get_radius());
 			ur->add_undo_method(s, "set_radius", p_restore);
 		} else {
-			ur->create_action(TTR("Change Cylinder Height"));
+			ur->create_action(vformat(TTR("Change CSGCylinder3D \"%s\" Height from %.2f to %.2f"), s->get_name(), p_restore, s->get_height()));
 			ur->add_do_method(s, "set_height", s->get_height());
 			ur->add_undo_method(s, "set_height", p_restore);
 		}
@@ -262,11 +262,11 @@ void CSGShape3DGizmoPlugin::commit_handle(EditorNode3DGizmo *p_gizmo, int p_idx,
 
 		UndoRedo *ur = Node3DEditor::get_singleton()->get_undo_redo();
 		if (p_idx == 0) {
-			ur->create_action(TTR("Change Torus Inner Radius"));
+			ur->create_action(vformat(TTR("Change CSGTorus3D \"%s\" Inner Radius from %.2f to %.2f"), s->get_name(), p_restore, s->get_inner_radius()));
 			ur->add_do_method(s, "set_inner_radius", s->get_inner_radius());
 			ur->add_undo_method(s, "set_inner_radius", p_restore);
 		} else {
-			ur->create_action(TTR("Change Torus Outer Radius"));
+			ur->create_action(vformat(TTR("Change CSGTorus3D \"%s\" Outer Radius from %.2f to %.2f"), s->get_name(), p_restore, s->get_outer_radius()));
 			ur->add_do_method(s, "set_outer_radius", s->get_outer_radius());
 			ur->add_undo_method(s, "set_outer_radius", p_restore);
 		}

--- a/modules/gdnative/gdnative_library_singleton_editor.cpp
+++ b/modules/gdnative/gdnative_library_singleton_editor.cpp
@@ -173,7 +173,7 @@ void GDNativeLibrarySingletonEditor::_item_edited() {
 		}
 	}
 
-	undo_redo->create_action(enabled ? TTR("Enabled GDNative Singleton") : TTR("Disabled GDNative Singleton"));
+	undo_redo->create_action(enabled ? TTR("Enable GDNative Singleton") : TTR("Disable GDNative Singleton"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "gdnative/singletons_disabled", disabled_paths);
 	undo_redo->add_do_method(this, "_update_libraries");
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "gdnative/singletons_disabled", undo_paths);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1579,7 +1579,7 @@ Ref<AnimatedValuesBackup> AnimationPlayer::apply_reset(bool p_user_initiated) {
 		old_values->restore();
 
 		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-		ur->create_action(TTR("Anim Apply Reset"));
+		ur->create_action(vformat(TTR("Apply Reset in AnimationPlayer \"%s\""), get_name()));
 		ur->add_do_method(new_values.ptr(), "restore");
 		ur->add_undo_method(old_values.ptr(), "restore");
 		ur->commit_action();


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/42229.

Note that unlike https://github.com/godotengine/godot/pull/42229, many of these messages also display the *old* values (e.g. `Rename Animation from "run" to "running"`). While this gives even more context in the undo log, it can look a bit verbose at times, so I'm not sure if it's a good idea. Feel free to chime in on this :slightly_smiling_face:

I've done some testing to make sure this doesn't break anything. Most notably, I had to back away from improving the array editor/dictionary editor/inspector undo messages because merging relies on the string being constant.

Since this PR modifies a lot of messages, it would have to be remade manually for the `3.x` branch once we reach an agreement on this one.