### PR TITLE
Tweak CSG shape defaults for consistency with primitive meshes

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1090,8 +1090,9 @@ Ref<Material> CSGSphere3D::get_material() const {
 CSGSphere3D::CSGSphere3D() {
 	// defaults
 	radius = 1.0;
-	radial_segments = 12;
-	rings = 6;
+	// Use lower level of detail than MeshInstance3D's SphereMesh since CSG is expensive to update.
+	radial_segments = 16;
+	rings = 8;
 	smooth_faces = true;
 }
 
@@ -1451,8 +1452,10 @@ Ref<Material> CSGCylinder3D::get_material() const {
 CSGCylinder3D::CSGCylinder3D() {
 	// defaults
 	radius = 1.0;
-	height = 1.0;
-	sides = 8;
+	// Use the same height as a MeshInstance3D's CylinderMesh.
+	height = 2.0;
+	// Use lower level of detail than MeshInstance3D's SphereMesh since CSG is expensive to update.
+	sides = 16;
 	cone = false;
 	smooth_faces = true;
 }
@@ -1670,10 +1673,12 @@ Ref<Material> CSGTorus3D::get_material() const {
 
 CSGTorus3D::CSGTorus3D() {
 	// defaults
-	inner_radius = 2.0;
-	outer_radius = 3.0;
-	sides = 8;
-	ring_sides = 6;
+	// Match the size of a CSGSphere3D or CSGCylinder3D.
+	inner_radius = 0.5;
+	outer_radius = 1.0;
+	// Use lower level of detail than MeshInstance3D's SphereMesh since CSG is expensive to update.
+	sides = 16;
+	ring_sides = 8;
 	smooth_faces = true;
 }
 
@@ -2227,7 +2232,7 @@ CSGPolygon3D::CSGPolygon3D() {
 	polygon.push_back(Vector2(1, 0));
 	depth = 1.0;
 	spin_degrees = 360;
-	spin_sides = 8;
+	spin_sides = 16;
 	smooth_faces = false;
 	path_interval = 1.0;
 	path_rotation = PATH_ROTATION_PATH_FOLLOW;

--- a/modules/csg/doc_classes/CSGCylinder3D.xml
+++ b/modules/csg/doc_classes/CSGCylinder3D.xml
@@ -14,7 +14,7 @@
 		<member name="cone" type="bool" setter="set_cone" getter="is_cone" default="false">
 			If [code]true[/code] a cone is created, the [member radius] will only apply to one side.
 		</member>
-		<member name="height" type="float" setter="set_height" getter="get_height" default="1.0">
+		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
 			The height of the cylinder.
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
@@ -23,11 +23,11 @@
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
 			The radius of the cylinder.
 		</member>
-		<member name="sides" type="int" setter="set_sides" getter="get_sides" default="8">
-			The number of sides of the cylinder, the higher this number the more detail there will be in the cylinder.
+		<member name="sides" type="int" setter="set_sides" getter="get_sides" default="16">
+			The number of sides of the cylinder, the higher this number the more detail there will be in the cylinder. Higher values result in a smoother-looking shape, but are more demanding to render and update.
 		</member>
 		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces" default="true">
-			If [code]true[/code] the normals of the cylinder are set to give a smooth effect making the cylinder seem rounded. If [code]false[/code] the cylinder will have a flat shaded look.
+			If [code]true[/code], the normals of the cylinder are set to give a smooth effect making the cylinder seem rounded. If [code]false[/code], the cylinder will have a flat shaded look.
 		</member>
 	</members>
 	<constants>

--- a/modules/csg/doc_classes/CSGPolygon3D.xml
+++ b/modules/csg/doc_classes/CSGPolygon3D.xml
@@ -42,13 +42,13 @@
 			The point array that defines the 2D polygon that is extruded.
 		</member>
 		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces" default="false">
-			If [code]true[/code], applies smooth shading to the extrusions.
+			If [code]true[/code], applies smooth shading to the extrusions. If [code]false[/code], the polygon will have a flat shaded look.
 		</member>
 		<member name="spin_degrees" type="float" setter="set_spin_degrees" getter="get_spin_degrees">
 			When [member mode] is [constant MODE_SPIN], the total number of degrees the [member polygon] is rotated when extruding.
 		</member>
 		<member name="spin_sides" type="int" setter="set_spin_sides" getter="get_spin_sides">
-			When [member mode] is [constant MODE_SPIN], the number of extrusions made.
+			When [member mode] is [constant MODE_SPIN], the number of extrusions made. Higher values result in a smoother-looking shape, but are more demanding to render and update.
 		</member>
 	</members>
 	<constants>

--- a/modules/csg/doc_classes/CSGSphere3D.xml
+++ b/modules/csg/doc_classes/CSGSphere3D.xml
@@ -14,17 +14,17 @@
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The material used to render the sphere.
 		</member>
-		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="12">
-			Number of vertical slices for the sphere.
+		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="16">
+			Number of vertical slices for the sphere. Higher values result in a smoother-looking shape, but are more demanding to render and update.
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
 			Radius of the sphere.
 		</member>
-		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="6">
-			Number of horizontal slices for the sphere.
+		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="8">
+			Number of horizontal slices for the sphere. Higher values result in a smoother-looking shape, but are more demanding to render and update.
 		</member>
 		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces" default="true">
-			If [code]true[/code] the normals of the sphere are set to give a smooth effect making the sphere seem rounded. If [code]false[/code] the sphere will have a flat shaded look.
+			If [code]true[/code], the normals of the sphere are set to give a smooth effect making the sphere seem rounded. If [code]false[/code], the sphere will have a flat shaded look.
 		</member>
 	</members>
 	<constants>

--- a/modules/csg/doc_classes/CSGTorus3D.xml
+++ b/modules/csg/doc_classes/CSGTorus3D.xml
@@ -11,23 +11,23 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="inner_radius" type="float" setter="set_inner_radius" getter="get_inner_radius" default="2.0">
+		<member name="inner_radius" type="float" setter="set_inner_radius" getter="get_inner_radius" default="0.5">
 			The inner radius of the torus.
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The material used to render the torus.
 		</member>
-		<member name="outer_radius" type="float" setter="set_outer_radius" getter="get_outer_radius" default="3.0">
+		<member name="outer_radius" type="float" setter="set_outer_radius" getter="get_outer_radius" default="1.0">
 			The outer radius of the torus.
 		</member>
-		<member name="ring_sides" type="int" setter="set_ring_sides" getter="get_ring_sides" default="6">
-			The number of edges each ring of the torus is constructed of.
+		<member name="ring_sides" type="int" setter="set_ring_sides" getter="get_ring_sides" default="8">
+			The number of edges each ring of the torus is constructed of. Higher values result in a smoother-looking shape, but are more demanding to render and update.
 		</member>
-		<member name="sides" type="int" setter="set_sides" getter="get_sides" default="8">
-			The number of slices the torus is constructed of.
+		<member name="sides" type="int" setter="set_sides" getter="get_sides" default="16">
+			The number of slices the torus is constructed of. Higher values result in a smoother-looking shape, but are more demanding to render and update.
 		</member>
 		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces" default="true">
-			If [code]true[/code] the normals of the torus are set to give a smooth effect making the torus seem rounded. If [code]false[/code] the torus will have a flat shaded look.
+			If [code]true[/code], the normals of the torus are set to give a smooth effect making the torus seem rounded. If [code]false[/code], the torus will have a flat shaded look.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
- Increase the default level of detail (but not too much since updating CSG is expensive).

## Preview

*MeshInstances on the front, CSG nodes on the back.*

![image](https://user-images.githubusercontent.com/180032/122633579-9f0f6900-d0d9-11eb-884c-7ca0679e4ac1.png)