### PR TITLE
Decrease the default number of rings in CylinderMesh to 0

### DIFF
--- a/doc/classes/CylinderMesh.xml
+++ b/doc/classes/CylinderMesh.xml
@@ -20,7 +20,7 @@
 		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="64">
 			Number of radial segments on the cylinder. Higher values result in a more detailed cylinder/cone at the cost of performance.
 		</member>
-		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="4">
+		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="0">
 			Number of edge rings along the height of the cylinder. Changing [member rings] does not have any visual impact unless a shader or procedural mesh tool is used to alter the vertex data. Higher values result in more subdivisions, which can be used to create smoother-looking effects with shaders or procedural mesh tools (at the cost of performance). When not altering the vertex data using a shader or procedural mesh tool, [member rings] should be kept to its default value.
 		</member>
 		<member name="top_radius" type="float" setter="set_top_radius" getter="get_top_radius" default="1.0">

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -876,7 +876,7 @@ void CylinderMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bottom_radius", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), "set_bottom_radius", "get_bottom_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), "set_height", "get_height");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radial_segments", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_radial_segments", "get_radial_segments");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_rings", "get_rings");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), "set_rings", "get_rings");
 }
 
 void CylinderMesh::set_top_radius(const float p_radius) {

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -176,7 +176,7 @@ private:
 	float bottom_radius = 1.0;
 	float height = 2.0;
 	int radial_segments = 64;
-	int rings = 4;
+	int rings = 0;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/49729.

Subdividing a CylinderMesh is only needed when deforming it in a shader. The new default rings value decreases the triangle count for a CylinderMesh by a factor of 5.

The property hint was also tweaked to allow setting the number of rings to 0, which is a valid value.

## Preview

### Before

![Subdivided cylinder](https://user-images.githubusercontent.com/180032/122633979-bea79100-d0db-11eb-98e2-7b746f1d8071.png)

### After

![Non-subdivided cylinder](https://user-images.githubusercontent.com/180032/122633978-be0efa80-d0db-11eb-97ad-90a3ef09e7cd.png)
