### PR TITLE
Use double-sided material for RayCast (3.x)

### DIFF
--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -415,6 +415,8 @@ void RayCast::_update_debug_shape_material(bool p_check_collision) {
 
 		material->set_flag(SpatialMaterial::FLAG_UNSHADED, true);
 		material->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, true);
+		// Use double-sided rendering so that the RayCast can be seen if the camera is inside.
+		material->set_cull_mode(SpatialMaterial::CULL_DISABLED);
 	}
 
 	Color color = debug_shape_custom_color;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/49724. Follow-up to https://github.com/godotengine/godot/pull/49726.

This makes RayCasts visible if the camera is fully inside one (e.g. a RayCast parented to the current Camera).