### PR TITLE
Tweak the editor environment defaults and its interface

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -293,7 +293,7 @@
 		<member name="tonemap_mode" type="int" setter="set_tonemapper" getter="get_tonemapper" enum="Environment.ToneMapper" default="0">
 			The tonemapping mode to use. Tonemapping is the process that "converts" HDR values to be suitable for rendering on a LDR display. (Godot doesn't support rendering on HDR displays yet.)
 		</member>
-		<member name="tonemap_white" type="float" setter="set_tonemap_white" getter="get_tonemap_white" default="1.0">
+		<member name="tonemap_white" type="float" setter="set_tonemap_white" getter="get_tonemap_white" default="6.0">
 			The white reference value for tonemapping (also called "whitepoint"). Higher values can make highlights look less blown out, and will also slightly darken the whole scene as a result. Only effective if the [member tonemap_mode] isn't set to [constant TONE_MAPPER_LINEAR]. See also [member tonemap_exposure].
 		</member>
 		<member name="volumetric_fog_albedo" type="Color" setter="set_volumetric_fog_albedo" getter="get_volumetric_fog_albedo" default="Color(1, 1, 1, 1)">

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7582,7 +7582,7 @@ void Node3DEditor::_preview_settings_changed() {
 		environment->set_ssao_enabled(environ_ao_button->is_pressed());
 		environment->set_glow_enabled(environ_glow_button->is_pressed());
 		environment->set_sdfgi_enabled(environ_gi_button->is_pressed());
-		environment->set_tonemapper(environ_tonemap_button->is_pressed() ? Environment::TONE_MAPPER_FILMIC : Environment::TONE_MAPPER_LINEAR);
+		environment->set_tonemapper(environ_tonemap_button->is_pressed() ? Environment::TONE_MAPPER_ACES : Environment::TONE_MAPPER_LINEAR);
 	}
 }
 
@@ -7603,8 +7603,8 @@ void Node3DEditor::_load_default_preview_settings() {
 	environ_sky_color->set_pick_color(Color(0.385, 0.454, 0.55));
 	environ_ground_color->set_pick_color(Color(0.2, 0.169, 0.133));
 	environ_energy->set_value(1.0);
-	environ_glow_button->set_pressed(true);
 	environ_tonemap_button->set_pressed(true);
+	environ_glow_button->set_pressed(true);
 	environ_ao_button->set_pressed(false);
 	environ_gi_button->set_pressed(false);
 	sun_max_distance->set_value(250);
@@ -8251,23 +8251,27 @@ void fragment() {
 		HBoxContainer *fx_vb = memnew(HBoxContainer);
 		fx_vb->set_h_size_flags(SIZE_EXPAND_FILL);
 
-		environ_ao_button = memnew(Button);
-		environ_ao_button->set_text(TTR("AO"));
-		environ_ao_button->set_toggle_mode(true);
-		environ_ao_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), CONNECT_DEFERRED);
-		fx_vb->add_child(environ_ao_button);
-		environ_glow_button = memnew(Button);
-		environ_glow_button->set_text(TTR("Glow"));
-		environ_glow_button->set_toggle_mode(true);
-		environ_glow_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), CONNECT_DEFERRED);
-		fx_vb->add_child(environ_glow_button);
 		environ_tonemap_button = memnew(Button);
-		environ_tonemap_button->set_text(TTR("Tonemap"));
+		environ_tonemap_button->set_text(TTR("ACES Tonemap"));
+		environ_tonemap_button->set_tooltip(TTR("Uses ACES tonemapping instead of linear tonemapping. This adjusts colors to avoid blowing out highlights.\nLow performance cost."));
 		environ_tonemap_button->set_toggle_mode(true);
 		environ_tonemap_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), CONNECT_DEFERRED);
 		fx_vb->add_child(environ_tonemap_button);
+		environ_glow_button = memnew(Button);
+		environ_glow_button->set_text(TTR("Glow"));
+		environ_glow_button->set_tooltip(TTR("Makes bright pixels \"bleed\" out, simulating real world vision.\nModerate performance cost."));
+		environ_glow_button->set_toggle_mode(true);
+		environ_glow_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), CONNECT_DEFERRED);
+		fx_vb->add_child(environ_glow_button);
+		environ_ao_button = memnew(Button);
+		environ_ao_button->set_text(TTR("SSAO"));
+		environ_ao_button->set_tooltip(TTR("Enables screen-space ambient occlusion, which helps objects stand out from each other.\nModerate performance cost."));
+		environ_ao_button->set_toggle_mode(true);
+		environ_ao_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), CONNECT_DEFERRED);
+		fx_vb->add_child(environ_ao_button);
 		environ_gi_button = memnew(Button);
-		environ_gi_button->set_text(TTR("GI"));
+		environ_gi_button->set_text(TTR("SDFGI"));
+		environ_gi_button->set_tooltip(TTR("Provides semi-real-time global illumination for the scene using signed distance field global illumination.\nMeshes must have their GI Mode set to Static for them to contribute to SDFGI.\nHigh performance cost."));
 		environ_gi_button->set_toggle_mode(true);
 		environ_gi_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), CONNECT_DEFERRED);
 		fx_vb->add_child(environ_gi_button);

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -107,7 +107,7 @@ private:
 	// Tonemap
 	ToneMapper tone_mapper = TONE_MAPPER_LINEAR;
 	float tonemap_exposure = 1.0;
-	float tonemap_white = 1.0;
+	float tonemap_white = 6.0;
 	bool tonemap_auto_exposure_enabled = false;
 	float tonemap_auto_exposure_min = 0.05;
 	float tonemap_auto_exposure_max = 8.0;


### PR DESCRIPTION
- Use ACES tonemapping instead of filmic tonemapping to provide a better appearance for bright lights.
- Set the default tonemap whitepoint to 6 to make filmic tonemapping less bright and blown out. Linear tonemapping is unaffected.
- Add tooltips to post-process buttons to explain what they do and how they work.
- Rename Tonemap button to ACES Tonemap to better explain its effect when enabled.
- Reorder post-process buttons from least to most expensive.
- ~~Decrease the maximum shadow distance for the default sun to improve shadow texel density. It's now the same as the DirectionalLight3D node's default value (100).~~
  - Split to another PR: https://github.com/godotengine/godot/pull/64587

This closes https://github.com/godotengine/godot-proposals/issues/3274 ~~and addresses https://github.com/godotengine/godot/issues/54717~~ (will be split into a separate PR).

## Preview

*SSAO is now disabled by default (not shown on the preview).*

![image](https://user-images.githubusercontent.com/180032/122638165-ef46f500-d0f2-11eb-8c08-c4dd1ad82924.png)
