### PR TITLE
Compute SSAO at half resolution by default

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1643,11 +1643,8 @@
 		<member name="rendering/environment/ssao/fadeout_to" type="float" setter="" getter="" default="300.0">
 			Distance at which the screen-space ambient occlusion is fully faded out. Use this hide ambient occlusion at great distances.
 		</member>
-		<member name="rendering/environment/ssao/half_size" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], screen-space ambient occlusion will be rendered at half size and then upscaled before being added to the scene. This is significantly faster but may miss small details.
-		</member>
-		<member name="rendering/environment/ssao/half_size.mobile" type="bool" setter="" getter="" default="true">
-			Lower-end override for [member rendering/environment/ssao/half_size] on mobile devices, due to performance concerns.
+		<member name="rendering/environment/ssao/half_size" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], screen-space ambient occlusion will be rendered at half size and then upscaled before being added to the scene. This is significantly faster but may miss small details. If [code]false[/code], screen-space ambient occlusion will be rendered at full size.
 		</member>
 		<member name="rendering/environment/ssao/quality" type="int" setter="" getter="" default="2">
 			Sets the quality of the screen-space ambient occlusion effect. Higher values take more samples and so will result in better quality, at the cost of performance. Setting to [code]ULTRA[/code] will use the [member rendering/environment/ssao/adaptive_target] setting.

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2896,8 +2896,7 @@ RenderingServer::RenderingServer() {
 
 	GLOBAL_DEF("rendering/environment/ssao/quality", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/ssao/quality", PropertyInfo(Variant::INT, "rendering/environment/ssao/quality", PROPERTY_HINT_ENUM, "Very Low (Fast),Low (Fast),Medium (Average),High (Slow),Ultra (Custom)"));
-	GLOBAL_DEF("rendering/environment/ssao/half_size", false);
-	GLOBAL_DEF("rendering/environment/ssao/half_size.mobile", true);
+	GLOBAL_DEF("rendering/environment/ssao/half_size", true);
 	GLOBAL_DEF("rendering/environment/ssao/adaptive_target", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/ssao/adaptive_target", PropertyInfo(Variant::FLOAT, "rendering/environment/ssao/adaptive_target", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"));
 	GLOBAL_DEF("rendering/environment/ssao/blur_passes", 2);


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/49736 (can be merged independently).

This provides a significant speedup for a small quality loss.

The quality loss is generally more noticeable during a project's early stages of development (e.g. in level blockouts) than it is in a finished project.

Some added rationale:

- People with low-end or even mid-range GPUs may not know *why* an effect is slow, so it's better to default to a lower quality version that can reasonably run on such GPUs.
- People with high-end GPUs will generally figure out how to increase graphics settings.
  - Eventually, [automatic graphics quality adjustment](https://github.com/godotengine/godot-proposals/issues/2183) could be used, but I think it's better to err on the side of caution from now.
- With the current GPU shortages, most people will not be able to upgrade their GPU until after Godot 4.0 is released. Some people will also have to "downgrade" their GPU due to their current GPU calling it quits and having to replace it with a much slower option (integrated graphics or low-end dedicated GPU).