### PR TITLE
Remove side effects of scene save

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1625,15 +1625,6 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		return;
 	}
 
-	// force creation of node path cache
-	// (hacky but needed for the tree to update properly)
-	Node *dummy_scene = sdata->instance(PackedScene::GEN_EDIT_STATE_INSTANCE);
-	if (!dummy_scene) {
-		show_accept(TTR("Couldn't save scene. Likely dependencies (instances or inheritance) couldn't be satisfied."), TTR("OK"));
-		return;
-	}
-	memdelete(dummy_scene);
-
 	int flg = 0;
 	if (EditorSettings::get_singleton()->get("filesystem/on_save/compress_binary_resources")) {
 		flg |= ResourceSaver::FLAG_COMPRESS;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -893,6 +893,13 @@ Error SceneState::pack(Node *p_scene) {
 		node_paths.write[E->get()] = scene->get_path_to(E->key());
 	}
 
+	if (Engine::get_singleton()->is_editor_hint()) {
+		// Build node path cache
+		for (Map<Node *, int>::Element *E = node_map.front(); E; E = E->next()) {
+			node_path_cache[scene->get_path_to(E->key())] = E->get();
+		}
+	}
+
 	return OK;
 }
 
@@ -927,10 +934,12 @@ Ref<SceneState> SceneState::_get_base_scene_state() const {
 }
 
 int SceneState::find_node_by_path(const NodePath &p_node) const {
+	ERR_FAIL_COND_V_MSG(node_path_cache.size() == 0, -1, "This operation requires the node cache to have been built.");
+
 	if (!node_path_cache.has(p_node)) {
 		if (_get_base_scene_state().is_valid()) {
 			int idx = _get_base_scene_state()->find_node_by_path(p_node);
-			if (idx >= 0) {
+			if (idx != -1) {
 				int rkey = _find_base_scene_node_remap_key(idx);
 				if (rkey == -1) {
 					rkey = nodes.size() + base_scene_node_remap.size();


### PR DESCRIPTION
Here we finally get rid of the dummy instantiation of the scene being saved,, which was a way of recreating the node path cache, needed for the editing state to be consistent and avoid bugs like #7979.

In this PR, in addition to removing the generation of the dummy scene (like #47828 tentatively did), a new way of having a good node path cache is added: namely, when a scene is packed in the editor, the data already collected for packing is leveraged to create such cache.

Benefits:
- Tool scripts are not unexpectedly run anymore when saving a scene (so it fixes #17681).
- The goal of #49570 may be reinforced (even better scene saving speed).

Testing-wise, I've
- ensured that #7976 is not reintroduced;
- noticed that #7984 still happens;
- checked that #47828 alone (just removing the dummy scene thing) would indeed reintroduce #7976.

Therefore, I'd say this PR is _pretty likely_ not to cause any observable change of behavior, either for bad or for good in addition to its purpose. As always in this kind of PR, testing every case is difficult, so user testing on alphas/betas would be a good thing to have.

As a final note, it may be better to add the possibility of user control about generating or not the node cache –pretty much like in `PackedScene::instance()` you can choose to generate editor data or not–. However, this already improves the state of things and something like that can be done as a future refinement.

**UPDATE:** I forgot to add that, since `SceneState::find_node_by_path()` is unreliable without a node path cache, I've added a check so we can detect easily if there's some other flow that needs it. That's not because of this PR; it would have been a good idea before it as well.