### PR TITLE
Fix sub-optimal uses of is_equal_approx 

### DIFF
--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1544,7 +1544,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 			}
 
 			Vector3 s = xform.basis.get_scale();
-			bool singular_matrix = Math::is_equal_approx(s.x, 0.0f) || Math::is_equal_approx(s.y, 0.0f) || Math::is_equal_approx(s.z, 0.0f);
+			bool singular_matrix = Math::is_zero_approx(s.x) || Math::is_zero_approx(s.y) || Math::is_zero_approx(s.z);
 			Quaternion q = singular_matrix ? Quaternion() : xform.basis.get_rotation_quaternion();
 			Vector3 l = xform.origin;
 
@@ -1595,7 +1595,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 			xform = sk->get_bone_rest(nm.bone).affine_inverse() * xform;
 
 			Vector3 s = xform.basis.get_scale();
-			bool singular_matrix = Math::is_equal_approx(s.x, 0.0f) || Math::is_equal_approx(s.y, 0.0f) || Math::is_equal_approx(s.z, 0.0f);
+			bool singular_matrix = Math::is_zero_approx(s.x) || Math::is_zero_approx(s.y) || Math::is_zero_approx(s.z);
 			Quaternion q = singular_matrix ? Quaternion() : xform.basis.get_rotation_quaternion();
 			Vector3 l = xform.origin;
 

--- a/editor/import/scene_importer_mesh.cpp
+++ b/editor/import/scene_importer_mesh.cpp
@@ -224,7 +224,7 @@ void EditorSceneImporterMesh::generate_lods() {
 			}
 			Surface::LOD lod;
 			lod.distance = mesh_error;
-			if (Math::is_equal_approx(mesh_error, 0.0f)) {
+			if (Math::is_zero_approx(mesh_error)) {
 				break;
 			}
 			if (new_len <= 0) {

--- a/modules/fbx/data/fbx_material.cpp
+++ b/modules/fbx/data/fbx_material.cpp
@@ -420,7 +420,7 @@ Ref<StandardMaterial3D> FBXMaterial::import_material(ImportState &state) {
 			} break;
 			case PROPERTY_DESC_COAT_ROUGHNESS: {
 				// meaning is that approx equal to zero is disabled not actually zero. ;)
-				if (real_value && Math::is_equal_approx(real_value->Value(), 0.0f)) {
+				if (real_value && Math::is_zero_approx(real_value->Value())) {
 					print_verbose("clearcoat real value: " + rtos(real_value->Value()));
 					spatial_material->set_clearcoat_gloss(1.0 - real_value->Value());
 				} else {
@@ -428,7 +428,7 @@ Ref<StandardMaterial3D> FBXMaterial::import_material(ImportState &state) {
 				}
 			} break;
 			case PROPERTY_DESC_EMISSIVE: {
-				if (real_value && Math::is_equal_approx(real_value->Value(), 0.0f)) {
+				if (real_value && Math::is_zero_approx(real_value->Value())) {
 					print_verbose("Emissive real value: " + rtos(real_value->Value()));
 					spatial_material->set_emission_energy(real_value->Value());
 				} else if (vector_value && !vector_value->Value().is_equal_approx(Vector3(0, 0, 0))) {

--- a/modules/fbx/fbx_parser/FBXParser.cpp
+++ b/modules/fbx/fbx_parser/FBXParser.cpp
@@ -1167,7 +1167,7 @@ Transform3D ReadMatrix(const ElementPtr element) {
 
 	// clean values to prevent any IBM damage on inverse() / affine_inverse()
 	for (float &value : values) {
-		if (::Math::is_equal_approx(0, value)) {
+		if (::Math::is_zero_approx(value)) {
 			value = 0;
 		}
 	}

--- a/modules/fbx/tools/import_utils.h
+++ b/modules/fbx/tools/import_utils.h
@@ -137,15 +137,15 @@ public:
 
 	static Vector3 safe_import_vector3(const Vector3 &p_vec) {
 		Vector3 vector = p_vec;
-		if (Math::is_equal_approx(0, vector.x)) {
+		if (Math::is_zero_approx(vector.x)) {
 			vector.x = 0;
 		}
 
-		if (Math::is_equal_approx(0, vector.y)) {
+		if (Math::is_zero_approx(vector.y)) {
 			vector.y = 0;
 		}
 
-		if (Math::is_equal_approx(0, vector.z)) {
+		if (Math::is_zero_approx(vector.z)) {
 			vector.z = 0;
 		}
 		return vector;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3596,7 +3596,7 @@ void GLTFDocument::spec_gloss_to_rough_metal(Ref<GLTFSpecGloss> r_spec_gloss, Re
 			if (!Math::is_equal_approx(mr.g, 1.0f)) {
 				has_roughness = true;
 			}
-			if (!Math::is_equal_approx(mr.b, 0.0f)) {
+			if (!Math::is_zero_approx(mr.b)) {
 				has_metal = true;
 			}
 			mr.g *= r_spec_gloss->gloss_factor;

--- a/tests/test_aabb.h
+++ b/tests/test_aabb.h
@@ -278,24 +278,24 @@ TEST_CASE("[AABB] Get endpoints") {
 TEST_CASE("[AABB] Get longest/shortest axis") {
 	const AABB aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6));
 	CHECK_MESSAGE(
-			aabb.get_longest_axis().is_equal_approx(Vector3(0, 0, 1)),
+			aabb.get_longest_axis() == Vector3(0, 0, 1),
 			"get_longest_axis() should return the expected value.");
 	CHECK_MESSAGE(
 			aabb.get_longest_axis_index() == Vector3::AXIS_Z,
-			"get_longest_axis() should return the expected value.");
+			"get_longest_axis_index() should return the expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(aabb.get_longest_axis_size(), 6),
-			"get_longest_axis() should return the expected value.");
+			aabb.get_longest_axis_size() == 6,
+			"get_longest_axis_size() should return the expected value.");
 
 	CHECK_MESSAGE(
-			aabb.get_shortest_axis().is_equal_approx(Vector3(1, 0, 0)),
+			aabb.get_shortest_axis() == Vector3(1, 0, 0),
 			"get_shortest_axis() should return the expected value.");
 	CHECK_MESSAGE(
 			aabb.get_shortest_axis_index() == Vector3::AXIS_X,
-			"get_shortest_axis() should return the expected value.");
+			"get_shortest_axis_index() should return the expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(aabb.get_shortest_axis_size(), 4),
-			"get_shortest_axis() should return the expected value.");
+			aabb.get_shortest_axis_size() == 4,
+			"get_shortest_axis_size() should return the expected value.");
 }
 
 #ifndef _MSC_VER

--- a/tests/test_curve.h
+++ b/tests/test_curve.h
@@ -80,7 +80,7 @@ TEST_CASE("[Curve] Custom curve with free tangents") {
 			"Custom free curve should contain the expected number of points.");
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->interpolate(-0.1), 0),
+			Math::is_zero_approx(curve->interpolate(-0.1)),
 			"Custom free curve should return the expected value at offset 0.1.");
 	CHECK_MESSAGE(
 			Math::is_equal_approx(curve->interpolate(0.1), (real_t)0.352),
@@ -99,7 +99,7 @@ TEST_CASE("[Curve] Custom curve with free tangents") {
 			"Custom free curve should return the expected value at offset 0.1.");
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->interpolate_baked(-0.1), 0),
+			Math::is_zero_approx(curve->interpolate_baked(-0.1)),
 			"Custom free curve should return the expected baked value at offset 0.1.");
 	CHECK_MESSAGE(
 			Math::is_equal_approx(curve->interpolate_baked(0.1), (real_t)0.352),
@@ -169,7 +169,7 @@ TEST_CASE("[Curve] Custom curve with linear tangents") {
 			"Custom linear curve should contain the expected number of points.");
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->interpolate(-0.1), 0),
+			Math::is_zero_approx(curve->interpolate(-0.1)),
 			"Custom linear curve should return the expected value at offset -0.1.");
 	CHECK_MESSAGE(
 			Math::is_equal_approx(curve->interpolate(0.1), (real_t)0.4),
@@ -188,7 +188,7 @@ TEST_CASE("[Curve] Custom curve with linear tangents") {
 			"Custom linear curve should return the expected value at offset 2.0.");
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->interpolate_baked(-0.1), 0),
+			Math::is_zero_approx(curve->interpolate_baked(-0.1)),
 			"Custom linear curve should return the expected baked value at offset -0.1.");
 	CHECK_MESSAGE(
 			Math::is_equal_approx(curve->interpolate_baked(0.1), (real_t)0.4),

--- a/tests/test_json.h
+++ b/tests/test_json.h
@@ -83,7 +83,7 @@ TEST_CASE("[JSON] Parsing single data types") {
 			json.get_error_line() == 0,
 			"Parsing a floating-point number as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(json.get_data(), 0.123456),
+			Math::is_equal_approx(double(json.get_data()), 0.123456),
 			"Parsing a floating-point number as JSON should return the expected value.");
 
 	json.parse("\"hello\"");


### PR DESCRIPTION
Most of this is replacing `is_equal_approx` comparison with zero with `is_zero_approx`, which is faster and simpler.

In AABB tests, change some uses of `is_equal_approx` to exact equality, as in this case it's expected to be exact.

In JSON tests, add an explicit cast from Variant to double.