### PR TITLE
Move the Android "clear previous install" setting to Editor Settings

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -48,6 +48,8 @@ void register_android_exporter() {
 
 	EDITOR_DEF("export/android/shutdown_adb_on_exit", true);
 
+	EDITOR_DEF("export/android/one_click_deploy_clear_previous_install", false);
+
 	Ref<EditorExportPlatformAndroid> exporter = Ref<EditorExportPlatformAndroid>(memnew(EditorExportPlatformAndroid));
 	EditorExport::get_singleton()->add_export_platform(exporter);
 }

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1632,8 +1632,6 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "keystore/release_user"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "keystore/release_password"), ""));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "one_click_deploy/clear_previous_install"), false));
-
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "version/code", PROPERTY_HINT_RANGE, "1,4096,1,or_greater"), 1));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "version/name"), "1.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/unique_name", PROPERTY_HINT_PLACEHOLDER_TEXT, "ext.domain.name"), "org.godotengine.$genname"));
@@ -1780,7 +1778,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 	int rv;
 	String output;
 
-	bool remove_prev = p_preset->get("one_click_deploy/clear_previous_install");
+	bool remove_prev = EDITOR_GET("export/android/one_click_deploy_clear_previous_install");
 	String version_name = p_preset->get("version/name");
 	String package_name = p_preset->get("package/unique_name");
 


### PR DESCRIPTION
This means the setting now applies to every project deployed from the editor, rather than being per-export preset.

This closes https://github.com/godotengine/godot-proposals/issues/2892.