### PR TITLE
Single 3D pass optimisation for mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
@@ -275,7 +275,9 @@ public:
 
 	void setup(RendererSceneEnvironmentRD *p_env, RID p_render_buffers, const CameraMatrix &p_projection, const Transform3D &p_transform, const Size2i p_screen_size, RendererSceneRenderRD *p_scene_render);
 	void update(RendererSceneEnvironmentRD *p_env, const CameraMatrix &p_projection, const Transform3D &p_transform, double p_time);
+	void draw(RD::DrawListID p_draw_list, RendererSceneEnvironmentRD *p_env, RID p_fb, uint32_t p_view_count, const CameraMatrix *p_projections, const Transform3D &p_transform, double p_time);
 	void draw(RendererSceneEnvironmentRD *p_env, bool p_can_continue_color, bool p_can_continue_depth, RID p_fb, uint32_t p_view_count, const CameraMatrix *p_projections, const Transform3D &p_transform, double p_time);
+	void draw_res(RendererSceneEnvironmentRD *p_env, uint32_t p_view_count, const CameraMatrix *p_projections, const Transform3D &p_transform, double p_time);
 
 	void invalidate_sky(Sky *p_sky);
 	void update_dirty_skys();


### PR DESCRIPTION
The 3D rendering logic performs 3 passes:
- Opaque
- Sky
- Transparent
Then copies the end result into the Viewport buffer applying post effects.

On mobile devices having these 3 steps split is causing bottlenecks. This PR attempts to merge them into a single pass when possible. 
