### PR TITLE
Expose RenderingServer directional shadow quality setters

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1532,41 +1532,61 @@
 			Lower-end override for [member rendering/shading/overrides/force_vertex_shading] on mobile devices, due to performance concerns or driver support.
 		</member>
 		<member name="rendering/shadows/directional_shadow/16_bits" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], use faster 16-bit precision for directional shadow rendering. If [code]false[/code], use more accurate 24-bit precision for directional shadow rendering. See also [member rendering/shadows/shadow_atlas/16_bits].
+			Most of the time, this value should be set [code]true[/code] to improve performance. However, in particularly large scenes, 16-bit precision may not be sufficient. In this case, setting this value to [code]false[/code] will decrease the amount of visible shadow artifacts at the cost of performance.
+			[b]Note:[/b] This property is only read when the project starts. To change the directional shadow precision at runtime, use the following code sample:
+			[codeblock]
+			# Example with 8192x8192 shadows and 24-bit precision:
+			RenderingServer.directional_shadow_atlas_set_size(8192, false)
+			[/codeblock]
 		</member>
 		<member name="rendering/shadows/directional_shadow/size" type="int" setter="" getter="" default="4096">
 			The directional shadow's size in pixels. Higher values will result in sharper shadows, at the cost of performance. The value will be rounded up to the nearest power of 2.
+			[b]Note:[/b] This property is only read when the project starts. To change the directional shadow size at runtime, use the following code sample:
+			[codeblock]
+			# Example with 8192x8192 shadows and 24-bit precision:
+			RenderingServer.directional_shadow_atlas_set_size(8192, false)
+			[/codeblock]
 		</member>
 		<member name="rendering/shadows/directional_shadow/size.mobile" type="int" setter="" getter="" default="2048">
 			Lower-end override for [member rendering/shadows/directional_shadow/size] on mobile devices, due to performance concerns or driver support.
 		</member>
 		<member name="rendering/shadows/directional_shadow/soft_shadow_quality" type="int" setter="" getter="" default="2">
-			Quality setting for shadows cast by [DirectionalLight3D]s. Higher quality settings use more samples when reading from shadow maps and are thus slower. Low quality settings may result in shadows looking grainy.
+			Quality setting for shadows cast by [DirectionalLight3D]s. Higher quality settings use more samples when reading from shadow maps and are thus slower. Low quality settings may result in shadows looking grainy. See also [member rendering/shadows/shadows/soft_shadow_quality].
+			[b]Note:[/b] This property is only read when the project starts. To change the directional shadow quality at runtime, use the following code sample:
+			[codeblock]
+			# Example with Ultra shadow quality:
+			RenderingServer.directional_shadow_quality_set(RenderingServer.SHADOW_QUALITY_SOFT_ULTRA)
+			[/codeblock]
 		</member>
 		<member name="rendering/shadows/directional_shadow/soft_shadow_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/shadows/directional_shadow/soft_shadow_quality] on mobile devices, due to performance concerns or driver support.
 		</member>
 		<member name="rendering/shadows/shadow_atlas/16_bits" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], use faster 16-bit precision for [OmniLight3D] and [SpotLight3D] shadow rendering. If [code]false[/code], use more accurate 24-bit precision for [OmniLight3D] and [SpotLight3D] shadow rendering. See also [member rendering/shadows/directional_shadow/16_bits].
+			Most of the time, this value should be set [code]true[/code] to improve performance. However, in particularly large scenes, 16-bit precision may not be sufficient. In this case, setting this value to [code]false[/code] will decrease the amount of visible shadow artifacts at the cost of performance.
 		</member>
 		<member name="rendering/shadows/shadow_atlas/quadrant_0_subdiv" type="int" setter="" getter="" default="2">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+			Subdivision quadrant size for [OmniLight3D] and [SpotLight3D] shadow mapping. See shadow mapping documentation.
 		</member>
 		<member name="rendering/shadows/shadow_atlas/quadrant_1_subdiv" type="int" setter="" getter="" default="2">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+			Subdivision quadrant size for [OmniLight3D] and [SpotLight3D] shadow mapping. See shadow mapping documentation.
 		</member>
 		<member name="rendering/shadows/shadow_atlas/quadrant_2_subdiv" type="int" setter="" getter="" default="3">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+			Subdivision quadrant size for [OmniLight3D] and [SpotLight3D] shadow mapping. See shadow mapping documentation.
 		</member>
 		<member name="rendering/shadows/shadow_atlas/quadrant_3_subdiv" type="int" setter="" getter="" default="4">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+			Subdivision quadrant size for [OmniLight3D] and [SpotLight3D] shadow mapping. See shadow mapping documentation.
 		</member>
 		<member name="rendering/shadows/shadow_atlas/size" type="int" setter="" getter="" default="4096">
-			Size for shadow atlas (used for OmniLights and SpotLights). See documentation.
+			The size for shadow atlas in the default [Viewport] (used for [OmniLight3D]s and [SpotLight3D]s). If set to [code]0[/code], [OmniLight3D]s and [SpotLight3D]s will not be able to cast any shadows, which improves performance. See also [member rendering/shadows/directional_shadow/size].
+			[b]Note:[/b] When using custom [Viewport]s, this value must be set on a per-[Viewport] basis.
 		</member>
 		<member name="rendering/shadows/shadow_atlas/size.mobile" type="int" setter="" getter="" default="2048">
 			Lower-end override for [member rendering/shadows/shadow_atlas/size] on mobile devices, due to performance concerns or driver support.
 		</member>
 		<member name="rendering/shadows/shadows/soft_shadow_quality" type="int" setter="" getter="" default="2">
-			Quality setting for shadows cast by [OmniLight3D]s and [SpotLight3D]s. Higher quality settings use more samples when reading from shadow maps and are thus slower. Low quality settings may result in shadows looking grainy.
+			Quality setting for shadows cast by [OmniLight3D]s and [SpotLight3D]s. Higher quality settings use more samples when reading from shadow maps and are thus slower. Low quality settings may result in shadows looking grainy. See also [member rendering/shadows/directional_shadow/soft_shadow_quality].
 		</member>
 		<member name="rendering/shadows/shadows/soft_shadow_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/shadows/shadows/soft_shadow_quality] on mobile devices, due to performance concerns or driver support.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -576,6 +576,28 @@
 				To place in a scene, attach this directional light to an instance using [method instance_set_base] using the returned RID.
 			</description>
 		</method>
+		<method name="directional_shadow_atlas_set_size">
+			<return type="void">
+			</return>
+			<argument index="0" name="size" type="int">
+			</argument>
+			<argument index="1" name="use_16_bits" type="bool">
+			</argument>
+			<description>
+				The directional shadow's size in pixels. Higher values will result in sharper shadows, at the cost of performance. The value will be rounded up to the nearest power of 2.
+				See also [member ProjectSettings.rendering/shadows/directional_shadow/size].
+			</description>
+		</method>
+		<method name="directional_shadow_quality_set">
+			<return type="void">
+			</return>
+			<argument index="0" name="quality" type="int" enum="RenderingServer.ShadowQuality">
+			</argument>
+			<description>
+				Quality setting for shadows cast by [DirectionalLight3D]s. Higher quality settings use more samples when reading from shadow maps and are thus slower. Low quality settings may result in shadows looking grainy.
+				See also [member ProjectSettings.rendering/shadows/directional_shadow/soft_shadow_quality].
+			</description>
+		</method>
 		<method name="environment_create">
 			<return type="RID">
 			</return>

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1556,6 +1556,9 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("light_directional_set_sky_only", "light", "enable"), &RenderingServer::light_directional_set_sky_only);
 	ClassDB::bind_method(D_METHOD("light_directional_set_shadow_depth_range_mode", "light", "range_mode"), &RenderingServer::light_directional_set_shadow_depth_range_mode);
 
+	ClassDB::bind_method(D_METHOD("directional_shadow_atlas_set_size", "size", "use_16_bits"), &RenderingServer::directional_shadow_atlas_set_size);
+	ClassDB::bind_method(D_METHOD("directional_shadow_quality_set", "quality"), &RenderingServer::directional_shadow_quality_set);
+
 	ClassDB::bind_method(D_METHOD("reflection_probe_create"), &RenderingServer::reflection_probe_create);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_update_mode", "probe", "mode"), &RenderingServer::reflection_probe_set_update_mode);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_intensity", "probe", "intensity"), &RenderingServer::reflection_probe_set_intensity);


### PR DESCRIPTION
This allows configuring directional shadow quality and size at run-time.

I've also included a bunch of documentation improvements along the way.

This closes https://github.com/godotengine/godot/issues/18621.

**Note:** Not cherry-pickable to the `3.x` branch as it only sets the shadow quality once at startup. It would require significant refactoring to have a similar feature in `3.x`.

## Example code

```gdscript
RenderingServer.directional_shadow_quality_set(RenderingServer.SHADOW_QUALITY_SOFT_ULTRA)
RenderingServer.directional_shadow_atlas_set_size(8192, false)
```