### PR TITLE
Fix assignment with operator on type member

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -951,7 +951,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 				// Perform operator if any.
 				if (assignment->operation != GDScriptParser::AssignmentNode::OP_NONE) {
-					GDScriptCodeGenerator::Address value = codegen.add_temporary();
+					GDScriptCodeGenerator::Address value = codegen.add_temporary(_gdtype_from_datatype(subscript->get_datatype()));
 					if (subscript->is_attribute) {
 						gen->write_get_named(value, name, prev_base);
 					} else {


### PR DESCRIPTION
Fixes #49748 

When assigning on the type member for instance transform.x += 1.0, the destination type is not guessed and the binary operation fails.
This change is made to guess the type before the binary operation, but I don't know if it could have some side effect.

Tested with the following script:


```
func _ready():
	var vec2: Vector2 = Vector2()
	vec2.x = vec2.x + 1.0
	vec2.x -= 10.0
	print(vec2.x)  # ----> print -9 OK
	
	var a = 3
	a += 3
	print(a)  # -----> print 6 OK

```